### PR TITLE
TST: Add test for missing fillvalue in categorical dtype

### DIFF
--- a/pandas/tests/indexes/categorical/test_reindex.py
+++ b/pandas/tests/indexes/categorical/test_reindex.py
@@ -1,6 +1,7 @@
 import numpy as np
+import pytest
 
-from pandas import Categorical, CategoricalIndex, Index
+from pandas import Categorical, CategoricalIndex, Index, Series
 import pandas._testing as tm
 
 
@@ -51,3 +52,10 @@ class TestReindex:
         res, indexer = c.reindex(["a", "b"])
         tm.assert_index_equal(res, Index(["a", "b"]), exact=True)
         tm.assert_numpy_array_equal(indexer, np.array([-1, -1], dtype=np.intp))
+
+    def test_reindex_missing_category(self):
+        # GH: 18185
+        ser = Series([1, 2, 3, 1], dtype="category")
+        msg = "'fill_value=-1' is not present in this Categorical's categories"
+        with pytest.raises(ValueError, match=msg):
+            ser.reindex([1, 2, 3, 4, 5], fill_value=-1)


### PR DESCRIPTION
- [x] closes #18185
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

cc @jreback Could not find a test for something similar with reindex.