### PR TITLE
BUG: read_html - file path cannot be pathlib.Path type

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -507,7 +507,7 @@ I/O
 - Bug in :class:`HDFStore` was dropping timezone information when exporting :class:`Series` with ``datetime64[ns, tz]`` dtypes with a fixed HDF5 store (:issue:`20594`)
 - :func:`read_csv` was closing user-provided binary file handles when ``engine="c"`` and an ``encoding`` was requested (:issue:`36980`)
 - Bug in :meth:`DataFrame.to_hdf` was not dropping missing rows with ``dropna=True`` (:issue:`35719`)
-- Bug in :func:`read_html` caused a ``TypeError`` when parsing ``pathlib.Path`` as html path since it was not converted to string  (:issue:`37705`)
+- Bug in :func:`read_html` was raising a ``TypeError`` when supplying a ``pathlib.Path`` argument to the ``io`` parameter (:issue:`37705`)
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -507,6 +507,7 @@ I/O
 - Bug in :class:`HDFStore` was dropping timezone information when exporting :class:`Series` with ``datetime64[ns, tz]`` dtypes with a fixed HDF5 store (:issue:`20594`)
 - :func:`read_csv` was closing user-provided binary file handles when ``engine="c"`` and an ``encoding`` was requested (:issue:`36980`)
 - Bug in :meth:`DataFrame.to_hdf` was not dropping missing rows with ``dropna=True`` (:issue:`35719`)
+- Bug in :func:`read_html` when parsing ``pathlib.Path`` object as html path (:issue:`37705`)
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -507,7 +507,7 @@ I/O
 - Bug in :class:`HDFStore` was dropping timezone information when exporting :class:`Series` with ``datetime64[ns, tz]`` dtypes with a fixed HDF5 store (:issue:`20594`)
 - :func:`read_csv` was closing user-provided binary file handles when ``engine="c"`` and an ``encoding`` was requested (:issue:`36980`)
 - Bug in :meth:`DataFrame.to_hdf` was not dropping missing rows with ``dropna=True`` (:issue:`35719`)
-- Bug in :func:`read_html` when parsing ``pathlib.Path`` object as html path (:issue:`37705`)
+- Bug in :func:`read_html` caused a ``TypeError`` when parsing ``pathlib.Path`` as html path since it was not converted to string  (:issue:`37705`)
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -507,7 +507,7 @@ I/O
 - Bug in :class:`HDFStore` was dropping timezone information when exporting :class:`Series` with ``datetime64[ns, tz]`` dtypes with a fixed HDF5 store (:issue:`20594`)
 - :func:`read_csv` was closing user-provided binary file handles when ``engine="c"`` and an ``encoding`` was requested (:issue:`36980`)
 - Bug in :meth:`DataFrame.to_hdf` was not dropping missing rows with ``dropna=True`` (:issue:`35719`)
-- Bug in :func:`read_html` caused a ``TypeError`` when parsing ``pathlib.Path`` as html path since it was not converted to string  (:issue:`37705`)
+- Bug in :func:`read_html` was raising a ``TypeError`` when supplying a ``pathlib.Path`` argument to the ``io`` parameter  (:issue:`37705`)
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -507,11 +507,7 @@ I/O
 - Bug in :class:`HDFStore` was dropping timezone information when exporting :class:`Series` with ``datetime64[ns, tz]`` dtypes with a fixed HDF5 store (:issue:`20594`)
 - :func:`read_csv` was closing user-provided binary file handles when ``engine="c"`` and an ``encoding`` was requested (:issue:`36980`)
 - Bug in :meth:`DataFrame.to_hdf` was not dropping missing rows with ``dropna=True`` (:issue:`35719`)
-<<<<<<< HEAD
-- Bug in :func:`read_html` was raising a ``TypeError`` when supplying a ``pathlib.Path`` argument to the ``io`` parameter  (:issue:`37705`)
-=======
 - Bug in :func:`read_html` was raising a ``TypeError`` when supplying a ``pathlib.Path`` argument to the ``io`` parameter (:issue:`37705`)
->>>>>>> 88bc2ee492633ab6a94be78384c5ac7524043322
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -9,6 +9,7 @@ import numbers
 import os
 import re
 from typing import Dict, List, Optional, Pattern, Sequence, Tuple, Union
+from pathlib import Path
 
 from pandas._typing import FilePathOrBuffer
 from pandas.compat._optional import import_optional_dependency
@@ -20,7 +21,7 @@ from pandas.core.dtypes.common import is_list_like
 from pandas.core.construction import create_series_with_explicit_dtype
 from pandas.core.frame import DataFrame
 
-from pandas.io.common import is_url, urlopen, validate_header_arg
+from pandas.io.common import is_url, urlopen, validate_header_arg, stringify_path
 from pandas.io.formats.printing import pprint_thing
 from pandas.io.parsers import TextParser
 
@@ -1080,6 +1081,10 @@ def read_html(
             "data (you passed a negative value)"
         )
     validate_header_arg(header)
+
+    if isinstance(io, Path):
+        io = stringify_path(io)
+
     return _parse(
         flavor=flavor,
         io=io,

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -9,7 +9,6 @@ import numbers
 import os
 import re
 from typing import Dict, List, Optional, Pattern, Sequence, Tuple, Union
-from pathlib import Path
 
 from pandas._typing import FilePathOrBuffer
 from pandas.compat._optional import import_optional_dependency
@@ -21,7 +20,7 @@ from pandas.core.dtypes.common import is_list_like
 from pandas.core.construction import create_series_with_explicit_dtype
 from pandas.core.frame import DataFrame
 
-from pandas.io.common import is_url, urlopen, validate_header_arg, stringify_path
+from pandas.io.common import is_url, stringify_path, urlopen, validate_header_arg
 from pandas.io.formats.printing import pprint_thing
 from pandas.io.parsers import TextParser
 
@@ -1082,8 +1081,7 @@ def read_html(
         )
     validate_header_arg(header)
 
-    if isinstance(io, Path):
-        io = stringify_path(io)
+    io = stringify_path(io)
 
     return _parse(
         flavor=flavor,

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -1236,6 +1236,11 @@ class TestReadHtml:
         assert None is helper_thread1.err is helper_thread2.err
 
     def test_parse_Path_object(self):
+        """
+        read_html should be able to cope with Path
+
+        GH 37705
+        """
         file_path_string = r"pandas/tests/io/data/html/spam.html"
         file_path = Path(file_path_string)
         df1 = self.read_html(file_path_string)[0]

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -1236,8 +1236,8 @@ class TestReadHtml:
         assert None is helper_thread1.err is helper_thread2.err
 
     def test_parse_Path_object(self):
-        file_path_string = r'pandas/tests/io/data/html/spam.html'
+        file_path_string = r"pandas/tests/io/data/html/spam.html"
         file_path = Path(file_path_string)
-        df1 = pd.read_html(file_path_string)[0]
-        df2 = pd.read_html(file_path)[0]
+        df1 = self.read_html(file_path_string)[0]
+        df2 = self.read_html(file_path)[0]
         tm.assert_frame_equal(df1, df2)

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -1235,13 +1235,9 @@ class TestReadHtml:
             pass
         assert None is helper_thread1.err is helper_thread2.err
 
-    def test_parse_Path_object(self):
-        """
-        read_html should be able to cope with Path
-
-        GH 37705
-        """
-        file_path_string = r"pandas/tests/io/data/html/spam.html"
+    def test_parse_path_object(self, datapath):
+        # GH 37705
+        file_path_string = datapath("io", "data", "html", "spam.html")
         file_path = Path(file_path_string)
         df1 = self.read_html(file_path_string)[0]
         df2 = self.read_html(file_path)[0]

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -1235,7 +1235,7 @@ class TestReadHtml:
             pass
         assert None is helper_thread1.err is helper_thread2.err
 
-    def test_parse_Path_object(self):
+    def test_parse_path_object(self):
         """
         read_html should be able to cope with Path
 

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -2,6 +2,7 @@ from functools import partial
 from importlib import reload
 from io import BytesIO, StringIO
 import os
+from pathlib import Path
 import re
 import threading
 from urllib.error import URLError
@@ -1233,3 +1234,11 @@ class TestReadHtml:
         while helper_thread1.is_alive() or helper_thread2.is_alive():
             pass
         assert None is helper_thread1.err is helper_thread2.err
+
+    def test_parse_Path_object(self):
+        file_path_string = r'pandas/tests/io/data/html/spam.html'
+        file_path = Path(file_path_string)
+        df1 = pd.read_html(file_path_string)[0]  
+        df2 = pd.read_html(file_path)[0]
+        tm.assert_frame_equal(df1, df2)
+

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -1238,7 +1238,6 @@ class TestReadHtml:
     def test_parse_Path_object(self):
         file_path_string = r'pandas/tests/io/data/html/spam.html'
         file_path = Path(file_path_string)
-        df1 = pd.read_html(file_path_string)[0]  
+        df1 = pd.read_html(file_path_string)[0]
         df2 = pd.read_html(file_path)[0]
         tm.assert_frame_equal(df1, df2)
-


### PR DESCRIPTION
Fix `read_html` TypeError when parsing `pathlib.Path` object.
