### PR TITLE
BUG: clean the figure windows created by tests

### DIFF
--- a/pandas/tests/plotting/test_converter.py
+++ b/pandas/tests/plotting/test_converter.py
@@ -70,15 +70,17 @@ class TestRegistration:
         # Set to the "warn" state, in case this isn't the first test run
         register_matplotlib_converters()
         ax.plot(s.index, s.values)
+        plt.close()
 
     def test_pandas_plots_register(self):
-        pytest.importorskip("matplotlib.pyplot")
+        plt = pytest.importorskip("matplotlib.pyplot")
         s = Series(range(12), index=date_range("2017", periods=12))
         # Set to the "warn" state, in case this isn't the first test run
         with tm.assert_produces_warning(None) as w:
             s.plot()
 
         assert len(w) == 0
+        plt.close()
 
     def test_matplotlib_formatters(self):
         units = pytest.importorskip("matplotlib.units")
@@ -108,6 +110,7 @@ class TestRegistration:
         register_matplotlib_converters()
         with ctx:
             ax.plot(s.index, s.values)
+        plt.close()
 
     def test_registry_resets(self):
         units = pytest.importorskip("matplotlib.units")

--- a/pandas/tests/plotting/test_converter.py
+++ b/pandas/tests/plotting/test_converter.py
@@ -70,17 +70,15 @@ class TestRegistration:
         # Set to the "warn" state, in case this isn't the first test run
         register_matplotlib_converters()
         ax.plot(s.index, s.values)
-        plt.close()
 
     def test_pandas_plots_register(self):
-        plt = pytest.importorskip("matplotlib.pyplot")
+        pytest.importorskip("matplotlib.pyplot")
         s = Series(range(12), index=date_range("2017", periods=12))
         # Set to the "warn" state, in case this isn't the first test run
         with tm.assert_produces_warning(None) as w:
             s.plot()
 
         assert len(w) == 0
-        plt.close()
 
     def test_matplotlib_formatters(self):
         units = pytest.importorskip("matplotlib.units")
@@ -110,7 +108,6 @@ class TestRegistration:
         register_matplotlib_converters()
         with ctx:
             ax.plot(s.index, s.values)
-        plt.close()
 
     def test_registry_resets(self):
         units = pytest.importorskip("matplotlib.units")


### PR DESCRIPTION
- [x] closes #35080
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

fixed: FAILED pandas/tests/plotting/test_datetimelike.py::TestTSPlot::test_ts_plot_with_tz['UTC']
reference:
- https://github.com/pandas-dev/pandas/issues/35080#issuecomment-652988132 @StefRe as co-author (have already marked as  the co-author in my forked repo, however, I'm not sure whether as well as right here)
- https://stackoverflow.com/a/8228808/7069618
- https://stackoverflow.com/a/33343289/7069618