### PR TITLE
BUG: adding Timedelta to DatetimeIndex raising incorrectly

### DIFF
--- a/doc/source/whatsnew/v1.1.5.rst
+++ b/doc/source/whatsnew/v1.1.5.rst
@@ -14,7 +14,7 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
--
+- Regression in addition of a timedelta-like scalar to a :class:`DatetimeIndex` raising incorrectly (:issue:`37295`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -964,7 +964,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
             # adding a scalar preserves freq
             new_freq = self.freq
 
-        return type(self)(new_values, dtype=self.dtype, freq=new_freq)
+        return type(self)._simple_new(new_values, dtype=self.dtype, freq=new_freq)
 
     def _add_timedelta_arraylike(self, other):
         """

--- a/pandas/tests/indexes/datetimes/test_misc.py
+++ b/pandas/tests/indexes/datetimes/test_misc.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas import DatetimeIndex, Index, Timestamp, date_range, offsets
+from pandas import DatetimeIndex, Index, Timedelta, Timestamp, date_range, offsets
 import pandas._testing as tm
 
 
@@ -408,3 +408,15 @@ def test_isocalendar_returns_correct_values_close_to_new_year_with_tz():
         dtype="UInt32",
     )
     tm.assert_frame_equal(result, expected_data_frame)
+
+
+def test_add_timedelta_preserves_freq():
+    # GH#37295 should hold for any DTI with freq=None or Tick freq
+    tz = "Canada/Eastern"
+    dti = date_range(
+        start=Timestamp("2019-03-26 00:00:00-0400", tz=tz),
+        end=Timestamp("2020-10-17 00:00:00-0400", tz=tz),
+        freq="D",
+    )
+    result = dti + Timedelta(days=1)
+    assert result.freq == dti.freq


### PR DESCRIPTION
- [x] closes #37295
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
