### PR TITLE
REF: implement Block._putmask_simple for non-casting putmask

### DIFF
--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -709,19 +709,25 @@ class TestDataFrameReplace:
         )
         tm.assert_frame_equal(res, expec)
 
-    def test_replace_with_empty_list(self):
+    def test_replace_with_empty_list(self, frame_or_series):
         # GH 21977
-        s = Series([["a", "b"], [], np.nan, [1]])
-        df = DataFrame({"col": s})
-        expected = df
-        result = df.replace([], np.nan)
-        tm.assert_frame_equal(result, expected)
+        ser = Series([["a", "b"], [], np.nan, [1]])
+        obj = DataFrame({"col": ser})
+        if frame_or_series is Series:
+            obj = ser
+        expected = obj
+        result = obj.replace([], np.nan)
+        tm.assert_equal(result, expected)
 
         # GH 19266
-        with pytest.raises(ValueError, match="cannot assign mismatch"):
-            df.replace({np.nan: []})
-        with pytest.raises(ValueError, match="cannot assign mismatch"):
-            df.replace({np.nan: ["dummy", "alt"]})
+        msg = (
+            "NumPy boolean array indexing assignment cannot assign {size} "
+            "input values to the 1 output values where the mask is true"
+        )
+        with pytest.raises(ValueError, match=msg.format(size=0)):
+            obj.replace({np.nan: []})
+        with pytest.raises(ValueError, match=msg.format(size=2)):
+            obj.replace({np.nan: ["dummy", "alt"]})
 
     def test_replace_series_dict(self):
         # from GH 3064

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -143,19 +143,6 @@ class TestSeriesReplace:
             assert return_value is None
         tm.assert_series_equal(s, ser)
 
-    def test_replace_with_empty_list(self):
-        # GH 21977
-        s = pd.Series([[1], [2, 3], [], np.nan, [4]])
-        expected = s
-        result = s.replace([], np.nan)
-        tm.assert_series_equal(result, expected)
-
-        # GH 19266
-        with pytest.raises(ValueError, match="cannot assign mismatch"):
-            s.replace({np.nan: []})
-        with pytest.raises(ValueError, match="cannot assign mismatch"):
-            s.replace({np.nan: ["dummy", "alt"]})
-
     def test_replace_mixed_types(self):
         s = pd.Series(np.arange(5), dtype="int64")
 


### PR DESCRIPTION
Much easier to reason about than Block.putmask.