### PR TITLE
[BUG]: Fix bug in MultiIndex.drop dropped nan when non existing key was given

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -483,6 +483,7 @@ MultiIndex
 - Bug in :meth:`DataFrame.xs` when used with :class:`IndexSlice` raises ``TypeError`` with message ``"Expected label or tuple of labels"`` (:issue:`35301`)
 - Bug in :meth:`DataFrame.reset_index` with ``NaT`` values in index raises ``ValueError`` with message ``"cannot convert float NaN to integer"`` (:issue:`36541`)
 - Bug in :meth:`DataFrame.combine_first` when used with :class:`MultiIndex` containing string and ``NaN`` values raises ``TypeError`` (:issue:`36562`)
+- Bug in :meth:`MultiIndex.drop` dropped ``NaN`` values when non existing key was given as input (:issue:`18853`)
 
 I/O
 ^^^

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2157,7 +2157,7 @@ class MultiIndex(Index):
         index = self.levels[i]
         values = index.get_indexer(codes)
         nan_codes = isna(codes)
-        values[(nan_codes == False) & (values == -1)] = -2
+        values[(not nan_codes) & (values == -1)] = -2
 
         mask = ~algos.isin(self.codes[i], values)
         if mask.all() and errors != "ignore":

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2156,6 +2156,8 @@ class MultiIndex(Index):
         i = self._get_level_number(level)
         index = self.levels[i]
         values = index.get_indexer(codes)
+        # If nan should be dropped it will equal -1 here. We have to check which values
+        # are not nan and equal -1, this means they are missing in the index
         nan_codes = isna(codes)
         values[(np.equal(nan_codes, False)) & (values == -1)] = -2
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2156,6 +2156,8 @@ class MultiIndex(Index):
         i = self._get_level_number(level)
         index = self.levels[i]
         values = index.get_indexer(codes)
+        nan_codes = isna(codes)
+        values[(nan_codes == False) & (values == -1)] = -2
 
         mask = ~algos.isin(self.codes[i], values)
         if mask.all() and errors != "ignore":

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2157,7 +2157,7 @@ class MultiIndex(Index):
         index = self.levels[i]
         values = index.get_indexer(codes)
         nan_codes = isna(codes)
-        values[(not nan_codes) & (values == -1)] = -2
+        values[(np.equal(nan_codes, False)) & (values == -1)] = -2
 
         mask = ~algos.isin(self.codes[i], values)
         if mask.all() and errors != "ignore":

--- a/pandas/tests/indexes/multi/test_drop.py
+++ b/pandas/tests/indexes/multi/test_drop.py
@@ -139,3 +139,11 @@ def test_drop_not_lexsorted():
     tm.assert_index_equal(lexsorted_mi, not_lexsorted_mi)
     with tm.assert_produces_warning(PerformanceWarning):
         tm.assert_index_equal(lexsorted_mi.drop("a"), not_lexsorted_mi.drop("a"))
+
+
+def test_drop_with_nan_in_index(nulls_fixture):
+    # GH#18853
+    mi = MultiIndex.from_tuples([("blah", nulls_fixture)], names=["name", "date"])
+    msg = r"labels \[Timestamp\('2001-01-01 00:00:00'\)\] not found in level"
+    with pytest.raises(KeyError, match=msg):
+        mi.drop(pd.Timestamp("2001"), level="date")


### PR DESCRIPTION
- [x] closes #18853
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Additional question:
The doc says (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Index.drop.html) that ``drop`` raises when not all labels are found, but
```
pd.DataFrame(index=pd.MultiIndex.from_product([range(3), range(3)])).drop([1, 5], level=0)
```
does not raise, because ``1`` is found. Should we implement, that it raises every time when at least one of the keys is not found?