### PR TITLE
DOC add note about how to skip tests during CI

### DIFF
--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -1479,6 +1479,13 @@ Now you can commit your changes in your local repository::
 
     git commit -m
 
+.. note::
+
+    If your pull request only makes changes to the documentation, then you can
+    choose to skip the tests by including ``[skip ci]`` in your commit message, e.g.::
+
+        git commit -m "Fix typo in docstring [skip ci]"
+
 .. _contributing.push-code:
 
 Pushing your changes


### PR DESCRIPTION
Tomorrow there will be a PyDataGlobal sprint, which'll probably involve many, many documentation-related pull requests, so this might help with not using up azure pipelines resources unnecessarily

EDIT
----
doesn't seem to be working :flushed: