### PR TITLE
CI: pin build to use pyarrow==1.0

### DIFF
--- a/ci/deps/azure-38-locale.yaml
+++ b/ci/deps/azure-38-locale.yaml
@@ -34,7 +34,7 @@ dependencies:
   - xlsxwriter
   - xlwt
   - moto
-  - pyarrow>=0.15
+  - pyarrow=1.0.0
   - pip
   - pip:
     - pyxlsb


### PR DESCRIPTION
closes #37306

@jorisvandenbossche picked build at random. we can discuss here what the preferences are? cc @jreback 