### PR TITLE
Return view for xs when droplevel=False with regular Index

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3751,7 +3751,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
                 dtype=new_values.dtype,
             )
         elif is_scalar(loc):
-            result = self.iloc[:, [loc]]
+            result = self.iloc[:, slice(loc, loc + 1)]
         elif axis == 1:
             result = self.iloc[:, loc]
         else:

--- a/pandas/tests/frame/indexing/test_xs.py
+++ b/pandas/tests/frame/indexing/test_xs.py
@@ -324,6 +324,6 @@ class TestXSWithMultiIndex:
         # GH#37832
         df = DataFrame([[1, 2, 3]], columns=Index(["a", "b", "c"]))
         result = df.xs("a", axis=1, drop_level=False)
-        df["a"] = 2
+        df.values[0, 0] = 2
         expected = DataFrame({"a": [2]})
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/indexing/test_xs.py
+++ b/pandas/tests/frame/indexing/test_xs.py
@@ -321,6 +321,7 @@ class TestXSWithMultiIndex:
         tm.assert_frame_equal(result, expected)
 
     def test_xs_droplevel_false_view(self):
+        # GH#37832
         df = DataFrame([[1, 2, 3]], columns=Index(["a", "b", "c"]))
         result = df.xs("a", axis=1, drop_level=False)
         df["a"] = 2

--- a/pandas/tests/frame/indexing/test_xs.py
+++ b/pandas/tests/frame/indexing/test_xs.py
@@ -319,3 +319,10 @@ class TestXSWithMultiIndex:
         result = df.xs("a", axis=1, drop_level=False)
         expected = DataFrame({"a": [1]})
         tm.assert_frame_equal(result, expected)
+
+    def test_xs_droplevel_false_view(self):
+        df = DataFrame([[1, 2, 3]], columns=Index(["a", "b", "c"]))
+        result = df.xs("a", axis=1, drop_level=False)
+        df["a"] = 2
+        expected = DataFrame({"a": [2]})
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] xref #37776
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Is there a better way to test, if the object is a view?

cc @jbrockmendel 
