### PR TITLE
COMPAT: should an empty string match a format (or just be NaT)

### DIFF
--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2453,7 +2453,7 @@ def test_empty_string_datetime_coerce__format():
     # coerce empty string to pd.NaT
     result = pd.to_datetime(td, format=format, errors="coerce")
     expected = Series(["2016-03-24", "2016-03-25", pd.NaT], dtype="datetime64[ns]")
-    pd.testing.assert_series_equal(expected, result)
+    tm.assert_series_equal(expected, result)
 
     # raise an exception in case a format is given
     with pytest.raises(ValueError, match="does not match format"):
@@ -2461,7 +2461,7 @@ def test_empty_string_datetime_coerce__format():
 
     # don't raise an expection in case no format is given
     result = pd.to_datetime(td, errors="raise")
-    pd.testing.assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_empty_string_datetime_coerce__unit():
@@ -2469,8 +2469,8 @@ def test_empty_string_datetime_coerce__unit():
     # coerce empty string to pd.NaT
     result = pd.to_datetime([1, ""], unit="s", errors="coerce")
     expected = DatetimeIndex(["1970-01-01 00:00:01", "NaT"], dtype="datetime64[ns]")
-    pd.testing.assert_index_equal(expected, result)
+    tm.assert_index_equal(expected, result)
 
     # verify that no exception is raised even when errors='raise' is set
     result = pd.to_datetime([1, ""], unit="s", errors="raise")
-    pd.testing.assert_index_equal(expected, result)
+    tm.assert_index_equal(expected, result)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2447,12 +2447,12 @@ def test_na_to_datetime(nulls_fixture, klass):
 
 def test_empty_string_datetime_coerce():
     # GH13044
-    td = Series(["May 04", "Jun 02", ""])
-    format = "%b %y"
+    td = Series(["03/24/2016", "03/25/2016", ""])
+    format = "%m/%d/%Y"
 
     # coerce empty string to pd.NaT
     result = pd.to_datetime(td, format=format, errors="coerce")
-    expected = Series(["2004-05-01", "2002-06-01", pd.NaT], dtype="datetime64[ns]")
+    expected = Series(["2016-03-24", "2016-03-25", pd.NaT], dtype="datetime64[ns]")
     pd.testing.assert_series_equal(expected, result)
 
     # raise an exception in case a format is given
@@ -2460,6 +2460,5 @@ def test_empty_string_datetime_coerce():
         result = pd.to_datetime(td, format=format, errors="raise")
 
     # don't raise an expection in case no format is given
-    result = pd.to_datetime([1, ""], unit="s", errors="raise")
-    expected = DatetimeIndex(["1970-01-01 00:00:01", pd.NaT], dtype="datetime64[ns]")
-    pd.testing.assert_index_equal(result, expected)
+    result = pd.to_datetime(td, errors="raise")
+    pd.testing.assert_series_equal(result, expected)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2447,19 +2447,19 @@ def test_na_to_datetime(nulls_fixture, klass):
 
 def test_empty_string_datetime_coerce():
     # GH13044
-    td = pd.Series(['May 04', 'Jun 02', ''])
+    td = Series(["May 04", "Jun 02", ""])
     format = "%b %y"
 
     # coerce empty string to pd.NaT
     result = pd.to_datetime(td, format=format, errors="coerce")
-    expected = pd.Series(["2004-05-01", "2002-06-01", pd.NaT], dtype="datetime64[ns]")
+    expected = Series(["2004-05-01", "2002-06-01", pd.NaT], dtype="datetime64[ns]")
     pd.testing.assert_series_equal(expected, result)
 
     # raise an exception in case a format is given
     with pytest.raises(ValueError, match="does not match format"):
-        result = pd.to_datetime(td, format=format, errors='raise')
+        result = pd.to_datetime(td, format=format, errors="raise")
 
     # don't raise an expection in case no format is given
     result = pd.to_datetime([1, ""], unit="s", errors="raise")
-    expected = pd.DatetimeIndex(["1970-01-01 00:00:01", pd.NaT], dtype="datetime64[ns]")
+    expected = DatetimeIndex(["1970-01-01 00:00:01", pd.NaT], dtype="datetime64[ns]")
     pd.testing.assert_index_equal(result, expected)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2445,7 +2445,7 @@ def test_na_to_datetime(nulls_fixture, klass):
     assert result[0] is pd.NaT
 
 
-def test_empty_string_datetime_coerce():
+def test_empty_string_datetime_coerce__format():
     # GH13044
     td = Series(["03/24/2016", "03/25/2016", ""])
     format = "%m/%d/%Y"
@@ -2462,3 +2462,15 @@ def test_empty_string_datetime_coerce():
     # don't raise an expection in case no format is given
     result = pd.to_datetime(td, errors="raise")
     pd.testing.assert_series_equal(result, expected)
+
+
+def test_empty_string_datetime_coerce__unit():
+    # GH13044
+    # coerce empty string to pd.NaT
+    result = pd.to_datetime([1, ""], unit="s", errors="coerce")
+    expected = DatetimeIndex(["1970-01-01 00:00:01", "NaT"], dtype="datetime64[ns]")
+    pd.testing.assert_index_equal(expected, result)
+
+    # verify that no exception is raised even when errors='raise' is set
+    result = pd.to_datetime([1, ""], unit="s", errors="raise")
+    pd.testing.assert_index_equal(expected, result)


### PR DESCRIPTION
- [x] closes #13044
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry (not applicable)
