### PR TITLE
DOC: section in indexing user guide to show use of np.where

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -1167,8 +1167,9 @@ An alternative to :meth:`~pandas.DataFrame.where` is to use :func:`numpy.where`.
 Combined with setting a new column, you can use it to enlarge a dataframe where the
 values are determined conditionally.
 
-When you have two choices to choose from, say in the following dataframe, set the color
-to 'green' when the second column has 'Z'.  You can do the following:
+Consider you have two choices to choose from in the following dataframe. And you want to
+set a new column color to 'green' when the second column has 'Z'.  You can do the
+following:
 
 .. ipython:: python
 
@@ -1176,9 +1177,9 @@ to 'green' when the second column has 'Z'.  You can do the following:
    df['color'] = np.where(df['col2'] == 'Z', 'green', 'red')
    df
 
-If you have more than one conditions, you can use :func:`numpy.select` to achieve that.
-Say corresponding to three conditions there are three choice of colors, with a fourth
-color as a fallback, you can do the following.
+If you have multiple conditions, you can use :func:`numpy.select` to achieve that.  Say
+corresponding to three conditions there are three choice of colors, with a fourth color
+as a fallback, you can do the following.
 
 .. ipython:: python
 

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -1172,7 +1172,7 @@ to 'green' when the second column has 'Z'.  You can do the following:
 
 .. ipython:: python
 
-   df = pd.DataFrame({'col1':list('ABBC'), 'col2':list('ZZXY')})
+   df = pd.DataFrame({'col1': list('ABBC'), 'col2': list('ZZXY')})
    df['color'] = np.where(df['col2'] == 'Z', 'green', 'red')
    df
 

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -1158,6 +1158,39 @@ Mask
    s.mask(s >= 0)
    df.mask(df >= 0)
 
+.. _indexing.np_where:
+
+Setting with enlargement conditionally using :func:`numpy`
+----------------------------------------------------------
+
+An alternative to :meth:`~pandas.DataFrame.where` is to use :func:`numpy.where`.
+Combined with setting a new column, you can use it to enlarge a dataframe where the
+values are determined conditionally.
+
+When you have two choices to choose from, say in the following dataframe, set the color
+to 'green' when the second column has 'Z'.  You can do the following:
+
+.. ipython:: python
+
+   df = pd.DataFrame({'col1':list('ABBC'), 'col2':list('ZZXY')})
+   df['color'] = np.where(df['col2'] == 'Z', 'green', 'red')
+   df
+
+If you have more than one conditions, you can use :func:`numpy.select` to achieve that.
+Say corresponding to three conditions there are three choice of colors, with a fourth
+color as a fallback, you can do the following.
+
+.. ipython:: python
+
+   conditions = [
+       (df['col2'] == 'Z') & (df['col1'] == 'A'),
+       (df['col2'] == 'Z') & (df['col1'] == 'B'),
+       (df['col1'] == 'B')
+   ]
+   choices = ['yellow', 'blue', 'purple']
+   df['color'] = np.select(conditions, choices, default='black')
+   df
+
 .. _indexing.query:
 
 The :meth:`~pandas.DataFrame.query` Method


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Add a section in the user guide to illustrate the use of `np.where` and `np.select` to enlarge a dataframe conditionally.  The example is taken from SO, as mentioned in [this issue](https://github.com/MarcoGorelli/PyDataGlobal2020-sprint/issues/5#issuecomment-727241262).