### PR TITLE
CI: Skip test when no xlwt or openpyxl

### DIFF
--- a/pandas/tests/io/test_fsspec.py
+++ b/pandas/tests/io/test_fsspec.py
@@ -126,6 +126,11 @@ def test_csv_options(fsspectest):
 
 @pytest.mark.parametrize("extension", ["xlsx", "xls"])
 def test_excel_options(fsspectest, extension):
+    if extension == "xls":
+        pytest.importorskip("xlwt")
+    else:
+        pytest.importorskip("openpyxl")
+
     df = DataFrame({"a": [0]})
 
     path = f"testmem://test/test.{extension}"


### PR DESCRIPTION
Ref: https://github.com/pandas-dev/pandas/pull/37818

Seeing error in CI: https://dev.azure.com/pandas-dev/pandas/_build/results?buildId=47726&view=logs&j=acc1347f-8235-55b0-95c7-0e2189e61659&t=486f34f1-eda6-516a-fc5d-d8195128dacd

Skip logic same as `test_to_excel` in this file

cc @jreback 