### PR TITLE
Fix cases of inconsistent namespacing in tests

### DIFF
--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -125,7 +125,7 @@ class TestPeriodArrayLikeComparisons:
 class TestPeriodIndexComparisons:
     # TODO: parameterize over boxes
 
-    @pytest.mark.parametrize("other", ["2017", pd.Period("2017", freq="D")])
+    @pytest.mark.parametrize("other", ["2017", Period("2017", freq="D")])
     def test_eq(self, other):
         idx = PeriodIndex(["2017", "2017", "2018"], freq="D")
         expected = np.array([True, True, False])
@@ -362,10 +362,8 @@ class TestPeriodIndexComparisons:
     # TODO: De-duplicate with test_pi_cmp_nat
     @pytest.mark.parametrize("dtype", [object, None])
     def test_comp_nat(self, dtype):
-        left = pd.PeriodIndex(
-            [pd.Period("2011-01-01"), pd.NaT, pd.Period("2011-01-03")]
-        )
-        right = pd.PeriodIndex([pd.NaT, pd.NaT, pd.Period("2011-01-03")])
+        left = PeriodIndex([Period("2011-01-01"), pd.NaT, Period("2011-01-03")])
+        right = PeriodIndex([pd.NaT, pd.NaT, Period("2011-01-03")])
 
         if dtype is not None:
             left = left.astype(dtype)
@@ -440,7 +438,7 @@ class TestPeriodIndexSeriesComparisonConsistency:
     def _check(self, values, func, expected):
         # Test PeriodIndex and Period Series Ops consistency
 
-        idx = pd.PeriodIndex(values)
+        idx = PeriodIndex(values)
         result = func(idx)
 
         # check that we don't pass an unwanted type to tm.assert_equal
@@ -458,27 +456,27 @@ class TestPeriodIndexSeriesComparisonConsistency:
             ["2011-01", "2011-02", "2011-03", "2011-04"], freq="M", name="idx"
         )
 
-        f = lambda x: x == pd.Period("2011-03", freq="M")
+        f = lambda x: x == Period("2011-03", freq="M")
         exp = np.array([False, False, True, False], dtype=np.bool_)
         self._check(idx, f, exp)
-        f = lambda x: pd.Period("2011-03", freq="M") == x
+        f = lambda x: Period("2011-03", freq="M") == x
         self._check(idx, f, exp)
 
-        f = lambda x: x != pd.Period("2011-03", freq="M")
+        f = lambda x: x != Period("2011-03", freq="M")
         exp = np.array([True, True, False, True], dtype=np.bool_)
         self._check(idx, f, exp)
-        f = lambda x: pd.Period("2011-03", freq="M") != x
+        f = lambda x: Period("2011-03", freq="M") != x
         self._check(idx, f, exp)
 
-        f = lambda x: pd.Period("2011-03", freq="M") >= x
+        f = lambda x: Period("2011-03", freq="M") >= x
         exp = np.array([True, True, True, False], dtype=np.bool_)
         self._check(idx, f, exp)
 
-        f = lambda x: x > pd.Period("2011-03", freq="M")
+        f = lambda x: x > Period("2011-03", freq="M")
         exp = np.array([False, False, False, True], dtype=np.bool_)
         self._check(idx, f, exp)
 
-        f = lambda x: pd.Period("2011-03", freq="M") >= x
+        f = lambda x: Period("2011-03", freq="M") >= x
         exp = np.array([True, True, True, False], dtype=np.bool_)
         self._check(idx, f, exp)
 
@@ -487,10 +485,10 @@ class TestPeriodIndexSeriesComparisonConsistency:
             ["2011-01", "NaT", "2011-03", "2011-04"], freq="M", name="idx"
         )
 
-        f = lambda x: x == pd.Period("2011-03", freq="M")
+        f = lambda x: x == Period("2011-03", freq="M")
         exp = np.array([False, False, True, False], dtype=np.bool_)
         self._check(idx, f, exp)
-        f = lambda x: pd.Period("2011-03", freq="M") == x
+        f = lambda x: Period("2011-03", freq="M") == x
         self._check(idx, f, exp)
 
         f = lambda x: x == pd.NaT
@@ -499,10 +497,10 @@ class TestPeriodIndexSeriesComparisonConsistency:
         f = lambda x: pd.NaT == x
         self._check(idx, f, exp)
 
-        f = lambda x: x != pd.Period("2011-03", freq="M")
+        f = lambda x: x != Period("2011-03", freq="M")
         exp = np.array([True, True, False, True], dtype=np.bool_)
         self._check(idx, f, exp)
-        f = lambda x: pd.Period("2011-03", freq="M") != x
+        f = lambda x: Period("2011-03", freq="M") != x
         self._check(idx, f, exp)
 
         f = lambda x: x != pd.NaT
@@ -511,11 +509,11 @@ class TestPeriodIndexSeriesComparisonConsistency:
         f = lambda x: pd.NaT != x
         self._check(idx, f, exp)
 
-        f = lambda x: pd.Period("2011-03", freq="M") >= x
+        f = lambda x: Period("2011-03", freq="M") >= x
         exp = np.array([True, False, True, False], dtype=np.bool_)
         self._check(idx, f, exp)
 
-        f = lambda x: x < pd.Period("2011-03", freq="M")
+        f = lambda x: x < Period("2011-03", freq="M")
         exp = np.array([True, False, False, False], dtype=np.bool_)
         self._check(idx, f, exp)
 
@@ -537,14 +535,14 @@ class TestPeriodFrameArithmetic:
         # GH#13043
         df = pd.DataFrame(
             {
-                "A": [pd.Period("2015-01", freq="M"), pd.Period("2015-02", freq="M")],
-                "B": [pd.Period("2014-01", freq="M"), pd.Period("2014-02", freq="M")],
+                "A": [Period("2015-01", freq="M"), Period("2015-02", freq="M")],
+                "B": [Period("2014-01", freq="M"), Period("2014-02", freq="M")],
             }
         )
         assert df["A"].dtype == "Period[M]"
         assert df["B"].dtype == "Period[M]"
 
-        p = pd.Period("2015-03", freq="M")
+        p = Period("2015-03", freq="M")
         off = p.freq
         # dtype will be object because of original dtype
         exp = pd.DataFrame(
@@ -558,8 +556,8 @@ class TestPeriodFrameArithmetic:
 
         df2 = pd.DataFrame(
             {
-                "A": [pd.Period("2015-05", freq="M"), pd.Period("2015-06", freq="M")],
-                "B": [pd.Period("2015-05", freq="M"), pd.Period("2015-06", freq="M")],
+                "A": [Period("2015-05", freq="M"), Period("2015-06", freq="M")],
+                "B": [Period("2015-05", freq="M"), Period("2015-06", freq="M")],
             }
         )
         assert df2["A"].dtype == "Period[M]"
@@ -640,10 +638,10 @@ class TestPeriodIndexArithmetic:
         # GH 23878
         p1_d = "19910905"
         p2_d = "19920406"
-        p1 = pd.PeriodIndex([p1_d], freq=tick_classes(n))
-        p2 = pd.PeriodIndex([p2_d], freq=tick_classes(n))
+        p1 = PeriodIndex([p1_d], freq=tick_classes(n))
+        p2 = PeriodIndex([p2_d], freq=tick_classes(n))
 
-        expected = pd.PeriodIndex([p2_d], freq=p2.freq.base) - pd.PeriodIndex(
+        expected = PeriodIndex([p2_d], freq=p2.freq.base) - PeriodIndex(
             [p1_d], freq=p1.freq.base
         )
 
@@ -665,11 +663,11 @@ class TestPeriodIndexArithmetic:
         p1_d = "19910905"
         p2_d = "19920406"
         freq = offset(n, normalize=False, **kwds)
-        p1 = pd.PeriodIndex([p1_d], freq=freq)
-        p2 = pd.PeriodIndex([p2_d], freq=freq)
+        p1 = PeriodIndex([p1_d], freq=freq)
+        p2 = PeriodIndex([p2_d], freq=freq)
 
         result = p2 - p1
-        expected = pd.PeriodIndex([p2_d], freq=freq.base) - pd.PeriodIndex(
+        expected = PeriodIndex([p2_d], freq=freq.base) - PeriodIndex(
             [p1_d], freq=freq.base
         )
 
@@ -825,14 +823,14 @@ class TestPeriodIndexArithmetic:
     @pytest.mark.parametrize("box", [np.array, pd.Index])
     def test_pi_add_offset_array(self, box):
         # GH#18849
-        pi = pd.PeriodIndex([pd.Period("2015Q1"), pd.Period("2016Q2")])
+        pi = PeriodIndex([Period("2015Q1"), Period("2016Q2")])
         offs = box(
             [
                 pd.offsets.QuarterEnd(n=1, startingMonth=12),
                 pd.offsets.QuarterEnd(n=-2, startingMonth=12),
             ]
         )
-        expected = pd.PeriodIndex([pd.Period("2015Q2"), pd.Period("2015Q4")])
+        expected = PeriodIndex([Period("2015Q2"), Period("2015Q4")])
 
         with tm.assert_produces_warning(PerformanceWarning):
             res = pi + offs
@@ -856,7 +854,7 @@ class TestPeriodIndexArithmetic:
     @pytest.mark.parametrize("box", [np.array, pd.Index])
     def test_pi_sub_offset_array(self, box):
         # GH#18824
-        pi = pd.PeriodIndex([pd.Period("2015Q1"), pd.Period("2016Q2")])
+        pi = PeriodIndex([Period("2015Q1"), Period("2016Q2")])
         other = box(
             [
                 pd.offsets.QuarterEnd(n=1, startingMonth=12),
@@ -934,10 +932,10 @@ class TestPeriodIndexArithmetic:
         # GH#23215
         # add offset to PeriodIndex with freq.n > 1
 
-        per = pd.Period("2016-01", freq="2M")
-        pi = pd.PeriodIndex([per])
+        per = Period("2016-01", freq="2M")
+        pi = PeriodIndex([per])
 
-        expected = pd.PeriodIndex(["2016-03"], freq="2M")
+        expected = PeriodIndex(["2016-03"], freq="2M")
 
         pi = tm.box_expected(pi, box_with_array, transpose=transpose)
         expected = tm.box_expected(expected, box_with_array, transpose=transpose)
@@ -951,8 +949,8 @@ class TestPeriodIndexArithmetic:
     def test_pi_add_offset_n_gt1_not_divisible(self, box_with_array):
         # GH#23215
         # PeriodIndex with freq.n > 1 add offset with offset.n % freq.n != 0
-        pi = pd.PeriodIndex(["2016-01"], freq="2M")
-        expected = pd.PeriodIndex(["2016-04"], freq="2M")
+        pi = PeriodIndex(["2016-01"], freq="2M")
+        expected = PeriodIndex(["2016-04"], freq="2M")
 
         pi = tm.box_expected(pi, box_with_array)
         expected = tm.box_expected(expected, box_with_array)
@@ -970,21 +968,21 @@ class TestPeriodIndexArithmetic:
     @pytest.mark.parametrize("op", [operator.add, ops.radd])
     def test_pi_add_intarray(self, int_holder, op):
         # GH#19959
-        pi = pd.PeriodIndex([pd.Period("2015Q1"), pd.Period("NaT")])
+        pi = PeriodIndex([Period("2015Q1"), Period("NaT")])
         other = int_holder([4, -1])
 
         result = op(pi, other)
-        expected = pd.PeriodIndex([pd.Period("2016Q1"), pd.Period("NaT")])
+        expected = PeriodIndex([Period("2016Q1"), Period("NaT")])
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("int_holder", [np.array, pd.Index])
     def test_pi_sub_intarray(self, int_holder):
         # GH#19959
-        pi = pd.PeriodIndex([pd.Period("2015Q1"), pd.Period("NaT")])
+        pi = PeriodIndex([Period("2015Q1"), Period("NaT")])
         other = int_holder([4, -1])
 
         result = pi - other
-        expected = pd.PeriodIndex([pd.Period("2014Q1"), pd.Period("NaT")])
+        expected = PeriodIndex([Period("2014Q1"), Period("NaT")])
         tm.assert_index_equal(result, expected)
 
         msg = r"bad operand type for unary -: 'PeriodArray'"
@@ -1003,7 +1001,7 @@ class TestPeriodIndexArithmetic:
         other = three_days
         rng = pd.period_range("2014-05-01", periods=3, freq="2D")
 
-        expected = pd.PeriodIndex(["2014-05-04", "2014-05-06", "2014-05-08"], freq="2D")
+        expected = PeriodIndex(["2014-05-04", "2014-05-06", "2014-05-08"], freq="2D")
 
         result = rng + other
         tm.assert_index_equal(result, expected)
@@ -1012,7 +1010,7 @@ class TestPeriodIndexArithmetic:
         tm.assert_index_equal(result, expected)
 
         # subtraction
-        expected = pd.PeriodIndex(["2014-04-28", "2014-04-30", "2014-05-02"], freq="2D")
+        expected = PeriodIndex(["2014-04-28", "2014-04-30", "2014-05-02"], freq="2D")
         result = rng - other
         tm.assert_index_equal(result, expected)
 
@@ -1170,7 +1168,7 @@ class TestPeriodIndexArithmetic:
         # GH#23320 special handling for timedelta64("NaT")
         pi = pd.period_range("1994-04-01", periods=9, freq="19D")
         other = np.timedelta64("NaT")
-        expected = pd.PeriodIndex(["NaT"] * 9, freq="19D")
+        expected = PeriodIndex(["NaT"] * 9, freq="19D")
 
         obj = tm.box_expected(pi, box_with_array, transpose=transpose)
         expected = tm.box_expected(expected, box_with_array, transpose=transpose)
@@ -1194,7 +1192,7 @@ class TestPeriodIndexArithmetic:
     )
     def test_parr_add_sub_tdt64_nat_array(self, box_with_array, other):
         pi = pd.period_range("1994-04-01", periods=9, freq="19D")
-        expected = pd.PeriodIndex(["NaT"] * 9, freq="19D")
+        expected = PeriodIndex(["NaT"] * 9, freq="19D")
 
         obj = tm.box_expected(pi, box_with_array)
         expected = tm.box_expected(expected, box_with_array)
@@ -1230,7 +1228,7 @@ class TestPeriodIndexArithmetic:
         with tm.assert_produces_warning(PerformanceWarning):
             result = parr + other
 
-        expected = pd.PeriodIndex(
+        expected = PeriodIndex(
             ["2001-01-01", "2001-01-03", "2001-01-05"], freq="D"
         ).array
         tm.assert_equal(result, expected)
@@ -1238,7 +1236,7 @@ class TestPeriodIndexArithmetic:
         with tm.assert_produces_warning(PerformanceWarning):
             result = parr - other
 
-        expected = pd.PeriodIndex(["2000-12-30"] * 3, freq="D").array
+        expected = PeriodIndex(["2000-12-30"] * 3, freq="D").array
         tm.assert_equal(result, expected)
 
 
@@ -1246,13 +1244,13 @@ class TestPeriodSeriesArithmetic:
     def test_ops_series_timedelta(self):
         # GH#13043
         ser = Series(
-            [pd.Period("2015-01-01", freq="D"), pd.Period("2015-01-02", freq="D")],
+            [Period("2015-01-01", freq="D"), Period("2015-01-02", freq="D")],
             name="xxx",
         )
         assert ser.dtype == "Period[D]"
 
         expected = Series(
-            [pd.Period("2015-01-02", freq="D"), pd.Period("2015-01-03", freq="D")],
+            [Period("2015-01-02", freq="D"), Period("2015-01-03", freq="D")],
             name="xxx",
         )
 
@@ -1271,12 +1269,12 @@ class TestPeriodSeriesArithmetic:
     def test_ops_series_period(self):
         # GH#13043
         ser = Series(
-            [pd.Period("2015-01-01", freq="D"), pd.Period("2015-01-02", freq="D")],
+            [Period("2015-01-01", freq="D"), Period("2015-01-02", freq="D")],
             name="xxx",
         )
         assert ser.dtype == "Period[D]"
 
-        per = pd.Period("2015-01-10", freq="D")
+        per = Period("2015-01-10", freq="D")
         off = per.freq
         # dtype will be object because of original dtype
         expected = Series([9 * off, 8 * off], name="xxx", dtype=object)
@@ -1284,7 +1282,7 @@ class TestPeriodSeriesArithmetic:
         tm.assert_series_equal(ser - per, -1 * expected)
 
         s2 = Series(
-            [pd.Period("2015-01-05", freq="D"), pd.Period("2015-01-04", freq="D")],
+            [Period("2015-01-05", freq="D"), Period("2015-01-04", freq="D")],
             name="xxx",
         )
         assert s2.dtype == "Period[D]"
@@ -1298,7 +1296,7 @@ class TestPeriodIndexSeriesMethods:
     """ Test PeriodIndex and Period Series Ops consistency """
 
     def _check(self, values, func, expected):
-        idx = pd.PeriodIndex(values)
+        idx = PeriodIndex(values)
         result = func(idx)
         tm.assert_equal(result, expected)
 
@@ -1475,27 +1473,27 @@ class TestPeriodIndexSeriesMethods:
             ["2011-01", "2011-02", "2011-03", "2011-04"], freq="M", name="idx"
         )
 
-        result = idx - pd.Period("2012-01", freq="M")
+        result = idx - Period("2012-01", freq="M")
         off = idx.freq
         exp = pd.Index([-12 * off, -11 * off, -10 * off, -9 * off], name="idx")
         tm.assert_index_equal(result, exp)
 
-        result = np.subtract(idx, pd.Period("2012-01", freq="M"))
+        result = np.subtract(idx, Period("2012-01", freq="M"))
         tm.assert_index_equal(result, exp)
 
-        result = pd.Period("2012-01", freq="M") - idx
+        result = Period("2012-01", freq="M") - idx
         exp = pd.Index([12 * off, 11 * off, 10 * off, 9 * off], name="idx")
         tm.assert_index_equal(result, exp)
 
-        result = np.subtract(pd.Period("2012-01", freq="M"), idx)
+        result = np.subtract(Period("2012-01", freq="M"), idx)
         tm.assert_index_equal(result, exp)
 
         exp = TimedeltaIndex([np.nan, np.nan, np.nan, np.nan], name="idx")
-        result = idx - pd.Period("NaT", freq="M")
+        result = idx - Period("NaT", freq="M")
         tm.assert_index_equal(result, exp)
         assert result.freq == exp.freq
 
-        result = pd.Period("NaT", freq="M") - idx
+        result = Period("NaT", freq="M") - idx
         tm.assert_index_equal(result, exp)
         assert result.freq == exp.freq
 
@@ -1514,23 +1512,23 @@ class TestPeriodIndexSeriesMethods:
             ["2011-01", "NaT", "2011-03", "2011-04"], freq="M", name="idx"
         )
 
-        result = idx - pd.Period("2012-01", freq="M")
+        result = idx - Period("2012-01", freq="M")
         off = idx.freq
         exp = pd.Index([-12 * off, pd.NaT, -10 * off, -9 * off], name="idx")
         tm.assert_index_equal(result, exp)
 
-        result = pd.Period("2012-01", freq="M") - idx
+        result = Period("2012-01", freq="M") - idx
         exp = pd.Index([12 * off, pd.NaT, 10 * off, 9 * off], name="idx")
         tm.assert_index_equal(result, exp)
 
         exp = TimedeltaIndex([np.nan, np.nan, np.nan, np.nan], name="idx")
-        tm.assert_index_equal(idx - pd.Period("NaT", freq="M"), exp)
-        tm.assert_index_equal(pd.Period("NaT", freq="M") - idx, exp)
+        tm.assert_index_equal(idx - Period("NaT", freq="M"), exp)
+        tm.assert_index_equal(Period("NaT", freq="M") - idx, exp)
 
     @pytest.mark.parametrize("scalars", ["a", False, 1, 1.0, None])
     def test_comparison_operations(self, scalars):
         # GH 28980
         expected = Series([False, False])
-        s = Series([pd.Period("2019"), pd.Period("2020")], dtype="period[A-DEC]")
+        s = Series([Period("2019"), Period("2020")], dtype="period[A-DEC]")
         result = s == scalars
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/arrays/floating/test_construction.py
+++ b/pandas/tests/arrays/floating/test_construction.py
@@ -8,7 +8,7 @@ from pandas.core.arrays.floating import Float32Dtype, Float64Dtype
 
 
 def test_uses_pandas_na():
-    a = pd.array([1, None], dtype=pd.Float64Dtype())
+    a = pd.array([1, None], dtype=Float64Dtype())
     assert a[1] is pd.NA
 
 

--- a/pandas/tests/arrays/sparse/test_dtype.py
+++ b/pandas/tests/arrays/sparse/test_dtype.py
@@ -200,10 +200,10 @@ def test_update_dtype_raises(original, dtype, expected_error_msg):
 
 def test_repr():
     # GH-34352
-    result = str(pd.SparseDtype("int64", fill_value=0))
+    result = str(SparseDtype("int64", fill_value=0))
     expected = "Sparse[int64, 0]"
     assert result == expected
 
-    result = str(pd.SparseDtype(object, fill_value="0"))
+    result = str(SparseDtype(object, fill_value="0"))
     expected = "Sparse[object, '0']"
     assert result == expected

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -31,7 +31,7 @@ def period_index(freqstr):
     the PeriodIndex behavior.
     """
     # TODO: non-monotone indexes; NaTs, different start dates
-    pi = pd.period_range(start=pd.Timestamp("2000-01-01"), periods=100, freq=freqstr)
+    pi = pd.period_range(start=Timestamp("2000-01-01"), periods=100, freq=freqstr)
     return pi
 
 
@@ -45,7 +45,7 @@ def datetime_index(freqstr):
     the DatetimeIndex behavior.
     """
     # TODO: non-monotone indexes; NaTs, different start dates, timezones
-    dti = pd.date_range(start=pd.Timestamp("2000-01-01"), periods=100, freq=freqstr)
+    dti = pd.date_range(start=Timestamp("2000-01-01"), periods=100, freq=freqstr)
     return dti
 
 
@@ -58,7 +58,7 @@ def timedelta_index():
     the TimedeltaIndex behavior.
     """
     # TODO: flesh this out
-    return pd.TimedeltaIndex(["1 Day", "3 Hours", "NaT"])
+    return TimedeltaIndex(["1 Day", "3 Hours", "NaT"])
 
 
 class SharedTests:
@@ -139,7 +139,7 @@ class SharedTests:
 
         tm.assert_index_equal(self.index_cls(result), expected)
 
-    @pytest.mark.parametrize("fill_value", [2, 2.0, pd.Timestamp.now().time])
+    @pytest.mark.parametrize("fill_value", [2, 2.0, Timestamp.now().time])
     def test_take_fill_raises(self, fill_value):
         data = np.arange(10, dtype="i8") * 24 * 3600 * 10 ** 9
 
@@ -539,7 +539,7 @@ class SharedTests:
 class TestDatetimeArray(SharedTests):
     index_cls = pd.DatetimeIndex
     array_cls = DatetimeArray
-    dtype = pd.Timestamp
+    dtype = Timestamp
 
     @pytest.fixture
     def arr1d(self, tz_naive_fixture, freqstr):
@@ -741,7 +741,7 @@ class TestDatetimeArray(SharedTests):
         arr = arr1d
         dti = self.index_cls(arr1d)
 
-        now = pd.Timestamp.now().tz_localize(dti.tz)
+        now = Timestamp.now().tz_localize(dti.tz)
         result = arr.take([-1, 1], allow_fill=True, fill_value=now)
         assert result[0] == now
 
@@ -752,10 +752,10 @@ class TestDatetimeArray(SharedTests):
 
         with pytest.raises(TypeError, match=msg):
             # fill_value Period invalid
-            arr.take([-1, 1], allow_fill=True, fill_value=pd.Period("2014Q1"))
+            arr.take([-1, 1], allow_fill=True, fill_value=Period("2014Q1"))
 
         tz = None if dti.tz is not None else "US/Eastern"
-        now = pd.Timestamp.now().tz_localize(tz)
+        now = Timestamp.now().tz_localize(tz)
         msg = "Cannot compare tz-naive and tz-aware datetime-like objects"
         with pytest.raises(TypeError, match=msg):
             # Timestamp with mismatched tz-awareness
@@ -828,22 +828,22 @@ class TestDatetimeArray(SharedTests):
 
 
 class TestTimedeltaArray(SharedTests):
-    index_cls = pd.TimedeltaIndex
+    index_cls = TimedeltaIndex
     array_cls = TimedeltaArray
     dtype = pd.Timedelta
 
     def test_from_tdi(self):
-        tdi = pd.TimedeltaIndex(["1 Day", "3 Hours"])
+        tdi = TimedeltaIndex(["1 Day", "3 Hours"])
         arr = TimedeltaArray(tdi)
         assert list(arr) == list(tdi)
 
         # Check that Index.__new__ knows what to do with TimedeltaArray
         tdi2 = pd.Index(arr)
-        assert isinstance(tdi2, pd.TimedeltaIndex)
+        assert isinstance(tdi2, TimedeltaIndex)
         assert list(tdi2) == list(arr)
 
     def test_astype_object(self):
-        tdi = pd.TimedeltaIndex(["1 Day", "3 Hours"])
+        tdi = TimedeltaIndex(["1 Day", "3 Hours"])
         arr = TimedeltaArray(tdi)
         asobj = arr.astype("O")
         assert isinstance(asobj, np.ndarray)
@@ -868,7 +868,7 @@ class TestTimedeltaArray(SharedTests):
 
         tm.assert_numpy_array_equal(result, expected.values)
 
-    @pytest.mark.parametrize("propname", pd.TimedeltaIndex._field_ops)
+    @pytest.mark.parametrize("propname", TimedeltaIndex._field_ops)
     def test_int_properties(self, timedelta_index, propname):
         tdi = timedelta_index
         arr = TimedeltaArray(tdi)
@@ -928,7 +928,7 @@ class TestTimedeltaArray(SharedTests):
         result = arr.take([-1, 1], allow_fill=True, fill_value=td1)
         assert result[0] == td1
 
-        now = pd.Timestamp.now()
+        now = Timestamp.now()
         value = now
         msg = f"value should be a '{arr._scalar_type.__name__}' or 'NaT'. Got"
         with pytest.raises(TypeError, match=msg):
@@ -947,9 +947,9 @@ class TestTimedeltaArray(SharedTests):
 
 
 class TestPeriodArray(SharedTests):
-    index_cls = pd.PeriodIndex
+    index_cls = PeriodIndex
     array_cls = PeriodArray
-    dtype = pd.Period
+    dtype = Period
 
     @pytest.fixture
     def arr1d(self, period_index):
@@ -962,7 +962,7 @@ class TestPeriodArray(SharedTests):
 
         # Check that Index.__new__ knows what to do with PeriodArray
         pi2 = pd.Index(arr)
-        assert isinstance(pi2, pd.PeriodIndex)
+        assert isinstance(pi2, PeriodIndex)
         assert list(pi2) == list(arr)
 
     def test_astype_object(self, arr1d):
@@ -1075,7 +1075,7 @@ class TestPeriodArray(SharedTests):
     "array,casting_nats",
     [
         (
-            pd.TimedeltaIndex(["1 Day", "3 Hours", "NaT"])._data,
+            TimedeltaIndex(["1 Day", "3 Hours", "NaT"])._data,
             (pd.NaT, np.timedelta64("NaT", "ns")),
         ),
         (
@@ -1099,7 +1099,7 @@ def test_casting_nat_setitem_array(array, casting_nats):
     "array,non_casting_nats",
     [
         (
-            pd.TimedeltaIndex(["1 Day", "3 Hours", "NaT"])._data,
+            TimedeltaIndex(["1 Day", "3 Hours", "NaT"])._data,
             (np.datetime64("NaT", "ns"), pd.NaT.value),
         ),
         (
@@ -1164,8 +1164,8 @@ def test_to_numpy_extra(array):
     "values",
     [
         pd.to_datetime(["2020-01-01", "2020-02-01"]),
-        pd.TimedeltaIndex([1, 2], unit="D"),
-        pd.PeriodIndex(["2020-01-01", "2020-02-01"], freq="D"),
+        TimedeltaIndex([1, 2], unit="D"),
+        PeriodIndex(["2020-01-01", "2020-02-01"], freq="D"),
     ],
 )
 @pytest.mark.parametrize(
@@ -1195,12 +1195,12 @@ def test_searchsorted_datetimelike_with_listlike(values, klass, as_index):
     "values",
     [
         pd.to_datetime(["2020-01-01", "2020-02-01"]),
-        pd.TimedeltaIndex([1, 2], unit="D"),
-        pd.PeriodIndex(["2020-01-01", "2020-02-01"], freq="D"),
+        TimedeltaIndex([1, 2], unit="D"),
+        PeriodIndex(["2020-01-01", "2020-02-01"], freq="D"),
     ],
 )
 @pytest.mark.parametrize(
-    "arg", [[1, 2], ["a", "b"], [pd.Timestamp("2020-01-01", tz="Europe/London")] * 2]
+    "arg", [[1, 2], ["a", "b"], [Timestamp("2020-01-01", tz="Europe/London")] * 2]
 )
 def test_searchsorted_datetimelike_with_listlike_invalid_dtype(values, arg):
     # https://github.com/pandas-dev/pandas/issues/32762

--- a/pandas/tests/indexes/categorical/test_formats.py
+++ b/pandas/tests/indexes/categorical/test_formats.py
@@ -3,18 +3,18 @@ Tests for CategoricalIndex.__repr__ and related methods.
 """
 import pandas._config.config as cf
 
-import pandas as pd
+from pandas import CategoricalIndex
 
 
 class TestCategoricalIndexRepr:
     def test_string_categorical_index_repr(self):
         # short
-        idx = pd.CategoricalIndex(["a", "bb", "ccc"])
+        idx = CategoricalIndex(["a", "bb", "ccc"])
         expected = """CategoricalIndex(['a', 'bb', 'ccc'], categories=['a', 'bb', 'ccc'], ordered=False, dtype='category')"""  # noqa
         assert repr(idx) == expected
 
         # multiple lines
-        idx = pd.CategoricalIndex(["a", "bb", "ccc"] * 10)
+        idx = CategoricalIndex(["a", "bb", "ccc"] * 10)
         expected = """CategoricalIndex(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a',
                   'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb',
                   'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc'],
@@ -23,7 +23,7 @@ class TestCategoricalIndexRepr:
         assert repr(idx) == expected
 
         # truncated
-        idx = pd.CategoricalIndex(["a", "bb", "ccc"] * 100)
+        idx = CategoricalIndex(["a", "bb", "ccc"] * 100)
         expected = """CategoricalIndex(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a',
                   ...
                   'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc'],
@@ -32,7 +32,7 @@ class TestCategoricalIndexRepr:
         assert repr(idx) == expected
 
         # larger categories
-        idx = pd.CategoricalIndex(list("abcdefghijklmmo"))
+        idx = CategoricalIndex(list("abcdefghijklmmo"))
         expected = """CategoricalIndex(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
                   'm', 'm', 'o'],
                  categories=['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', ...], ordered=False, dtype='category')"""  # noqa
@@ -40,12 +40,12 @@ class TestCategoricalIndexRepr:
         assert repr(idx) == expected
 
         # short
-        idx = pd.CategoricalIndex(["あ", "いい", "ううう"])
+        idx = CategoricalIndex(["あ", "いい", "ううう"])
         expected = """CategoricalIndex(['あ', 'いい', 'ううう'], categories=['あ', 'いい', 'ううう'], ordered=False, dtype='category')"""  # noqa
         assert repr(idx) == expected
 
         # multiple lines
-        idx = pd.CategoricalIndex(["あ", "いい", "ううう"] * 10)
+        idx = CategoricalIndex(["あ", "いい", "ううう"] * 10)
         expected = """CategoricalIndex(['あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ',
                   'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい',
                   'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう'],
@@ -54,7 +54,7 @@ class TestCategoricalIndexRepr:
         assert repr(idx) == expected
 
         # truncated
-        idx = pd.CategoricalIndex(["あ", "いい", "ううう"] * 100)
+        idx = CategoricalIndex(["あ", "いい", "ううう"] * 100)
         expected = """CategoricalIndex(['あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ',
                   ...
                   'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう'],
@@ -63,7 +63,7 @@ class TestCategoricalIndexRepr:
         assert repr(idx) == expected
 
         # larger categories
-        idx = pd.CategoricalIndex(list("あいうえおかきくけこさしすせそ"))
+        idx = CategoricalIndex(list("あいうえおかきくけこさしすせそ"))
         expected = """CategoricalIndex(['あ', 'い', 'う', 'え', 'お', 'か', 'き', 'く', 'け', 'こ', 'さ', 'し',
                   'す', 'せ', 'そ'],
                  categories=['あ', 'い', 'う', 'え', 'お', 'か', 'き', 'く', ...], ordered=False, dtype='category')"""  # noqa
@@ -74,12 +74,12 @@ class TestCategoricalIndexRepr:
         with cf.option_context("display.unicode.east_asian_width", True):
 
             # short
-            idx = pd.CategoricalIndex(["あ", "いい", "ううう"])
+            idx = CategoricalIndex(["あ", "いい", "ううう"])
             expected = """CategoricalIndex(['あ', 'いい', 'ううう'], categories=['あ', 'いい', 'ううう'], ordered=False, dtype='category')"""  # noqa
             assert repr(idx) == expected
 
             # multiple lines
-            idx = pd.CategoricalIndex(["あ", "いい", "ううう"] * 10)
+            idx = CategoricalIndex(["あ", "いい", "ううう"] * 10)
             expected = """CategoricalIndex(['あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい',
                   'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう',
                   'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい',
@@ -89,7 +89,7 @@ class TestCategoricalIndexRepr:
             assert repr(idx) == expected
 
             # truncated
-            idx = pd.CategoricalIndex(["あ", "いい", "ううう"] * 100)
+            idx = CategoricalIndex(["あ", "いい", "ううう"] * 100)
             expected = """CategoricalIndex(['あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい',
                   'ううう', 'あ',
                   ...
@@ -100,7 +100,7 @@ class TestCategoricalIndexRepr:
             assert repr(idx) == expected
 
             # larger categories
-            idx = pd.CategoricalIndex(list("あいうえおかきくけこさしすせそ"))
+            idx = CategoricalIndex(list("あいうえおかきくけこさしすせそ"))
             expected = """CategoricalIndex(['あ', 'い', 'う', 'え', 'お', 'か', 'き', 'く', 'け', 'こ',
                   'さ', 'し', 'す', 'せ', 'そ'],
                  categories=['あ', 'い', 'う', 'え', 'お', 'か', 'き', 'く', ...], ordered=False, dtype='category')"""  # noqa

--- a/pandas/tests/indexes/categorical/test_indexing.py
+++ b/pandas/tests/indexes/categorical/test_indexing.py
@@ -11,30 +11,30 @@ class TestTake:
         # GH 12631
 
         # numeric category
-        idx = pd.CategoricalIndex([1, 2, 3], name="xxx")
+        idx = CategoricalIndex([1, 2, 3], name="xxx")
         result = idx.take(np.array([1, 0, -1]))
-        expected = pd.CategoricalIndex([2, 1, 3], name="xxx")
+        expected = CategoricalIndex([2, 1, 3], name="xxx")
         tm.assert_index_equal(result, expected)
         tm.assert_categorical_equal(result.values, expected.values)
 
         # fill_value
         result = idx.take(np.array([1, 0, -1]), fill_value=True)
-        expected = pd.CategoricalIndex([2, 1, np.nan], categories=[1, 2, 3], name="xxx")
+        expected = CategoricalIndex([2, 1, np.nan], categories=[1, 2, 3], name="xxx")
         tm.assert_index_equal(result, expected)
         tm.assert_categorical_equal(result.values, expected.values)
 
         # allow_fill=False
         result = idx.take(np.array([1, 0, -1]), allow_fill=False, fill_value=True)
-        expected = pd.CategoricalIndex([2, 1, 3], name="xxx")
+        expected = CategoricalIndex([2, 1, 3], name="xxx")
         tm.assert_index_equal(result, expected)
         tm.assert_categorical_equal(result.values, expected.values)
 
         # object category
-        idx = pd.CategoricalIndex(
+        idx = CategoricalIndex(
             list("CBA"), categories=list("ABC"), ordered=True, name="xxx"
         )
         result = idx.take(np.array([1, 0, -1]))
-        expected = pd.CategoricalIndex(
+        expected = CategoricalIndex(
             list("BCA"), categories=list("ABC"), ordered=True, name="xxx"
         )
         tm.assert_index_equal(result, expected)
@@ -42,7 +42,7 @@ class TestTake:
 
         # fill_value
         result = idx.take(np.array([1, 0, -1]), fill_value=True)
-        expected = pd.CategoricalIndex(
+        expected = CategoricalIndex(
             ["B", "C", np.nan], categories=list("ABC"), ordered=True, name="xxx"
         )
         tm.assert_index_equal(result, expected)
@@ -50,7 +50,7 @@ class TestTake:
 
         # allow_fill=False
         result = idx.take(np.array([1, 0, -1]), allow_fill=False, fill_value=True)
-        expected = pd.CategoricalIndex(
+        expected = CategoricalIndex(
             list("BCA"), categories=list("ABC"), ordered=True, name="xxx"
         )
         tm.assert_index_equal(result, expected)
@@ -73,19 +73,19 @@ class TestTake:
 
         # datetime category
         idx = pd.DatetimeIndex(["2011-01-01", "2011-02-01", "2011-03-01"], name="xxx")
-        idx = pd.CategoricalIndex(idx)
+        idx = CategoricalIndex(idx)
         result = idx.take(np.array([1, 0, -1]))
         expected = pd.DatetimeIndex(
             ["2011-02-01", "2011-01-01", "2011-03-01"], name="xxx"
         )
-        expected = pd.CategoricalIndex(expected)
+        expected = CategoricalIndex(expected)
         tm.assert_index_equal(result, expected)
 
         # fill_value
         result = idx.take(np.array([1, 0, -1]), fill_value=True)
         expected = pd.DatetimeIndex(["2011-02-01", "2011-01-01", "NaT"], name="xxx")
         exp_cats = pd.DatetimeIndex(["2011-01-01", "2011-02-01", "2011-03-01"])
-        expected = pd.CategoricalIndex(expected, categories=exp_cats)
+        expected = CategoricalIndex(expected, categories=exp_cats)
         tm.assert_index_equal(result, expected)
 
         # allow_fill=False
@@ -93,7 +93,7 @@ class TestTake:
         expected = pd.DatetimeIndex(
             ["2011-02-01", "2011-01-01", "2011-03-01"], name="xxx"
         )
-        expected = pd.CategoricalIndex(expected)
+        expected = CategoricalIndex(expected)
         tm.assert_index_equal(result, expected)
 
         msg = (
@@ -110,7 +110,7 @@ class TestTake:
             idx.take(np.array([1, -5]))
 
     def test_take_invalid_kwargs(self):
-        idx = pd.CategoricalIndex([1, 2, 3], name="foo")
+        idx = CategoricalIndex([1, 2, 3], name="foo")
         indices = [1, 0, -1]
 
         msg = r"take\(\) got an unexpected keyword argument 'foo'"
@@ -175,18 +175,18 @@ class TestGetLoc:
                 i.get_loc("c")
 
     def test_get_loc_unique(self):
-        cidx = pd.CategoricalIndex(list("abc"))
+        cidx = CategoricalIndex(list("abc"))
         result = cidx.get_loc("b")
         assert result == 1
 
     def test_get_loc_monotonic_nonunique(self):
-        cidx = pd.CategoricalIndex(list("abbc"))
+        cidx = CategoricalIndex(list("abbc"))
         result = cidx.get_loc("b")
         expected = slice(1, 3, None)
         assert result == expected
 
     def test_get_loc_nonmonotonic_nonunique(self):
-        cidx = pd.CategoricalIndex(list("abcb"))
+        cidx = CategoricalIndex(list("abcb"))
         result = cidx.get_loc("b")
         expected = np.array([False, True, False, True], dtype=bool)
         tm.assert_numpy_array_equal(result, expected)
@@ -368,7 +368,7 @@ class TestContains:
 
     def test_contains_list(self):
         # GH#21729
-        idx = pd.CategoricalIndex([1, 2, 3])
+        idx = CategoricalIndex([1, 2, 3])
 
         assert "a" not in idx
 

--- a/pandas/tests/indexes/ranges/test_indexing.py
+++ b/pandas/tests/indexes/ranges/test_indexing.py
@@ -53,7 +53,7 @@ class TestTake:
 
     def test_take_fill_value(self):
         # GH#12631
-        idx = pd.RangeIndex(1, 4, name="xxx")
+        idx = RangeIndex(1, 4, name="xxx")
         result = idx.take(np.array([1, 0, -1]))
         expected = pd.Int64Index([2, 1, 3], name="xxx")
         tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -221,7 +221,7 @@ class TestIndex(Base):
     @pytest.mark.parametrize(
         "klass,dtype,na_val",
         [
-            (pd.Float64Index, np.float64, np.nan),
+            (Float64Index, np.float64, np.nan),
             (DatetimeIndex, "datetime64[ns]", pd.NaT),
         ],
     )
@@ -411,7 +411,7 @@ class TestIndex(Base):
             (PeriodIndex([], freq="B"), PeriodIndex),
             (PeriodIndex(iter([]), freq="B"), PeriodIndex),
             (PeriodIndex((_ for _ in []), freq="B"), PeriodIndex),
-            (RangeIndex(step=1), pd.RangeIndex),
+            (RangeIndex(step=1), RangeIndex),
             (MultiIndex(levels=[[1, 2], ["blue", "red"]], codes=[[], []]), MultiIndex),
         ],
     )
@@ -1982,7 +1982,7 @@ class TestIndex(Base):
         "labels,dtype",
         [
             (pd.Int64Index([]), np.int64),
-            (pd.Float64Index([]), np.float64),
+            (Float64Index([]), np.float64),
             (DatetimeIndex([]), np.datetime64),
         ],
     )
@@ -1994,7 +1994,7 @@ class TestIndex(Base):
     def test_reindex_no_type_preserve_target_empty_mi(self):
         index = Index(list("abc"))
         result = index.reindex(
-            MultiIndex([pd.Int64Index([]), pd.Float64Index([])], [[], []])
+            MultiIndex([pd.Int64Index([]), Float64Index([])], [[], []])
         )[0]
         assert result.levels[0].dtype.type == np.int64
         assert result.levels[1].dtype.type == np.float64
@@ -2342,12 +2342,12 @@ class TestMixedIntIndex(Base):
                 pd.TimedeltaIndex(["1 days", "2 days", "3 days"]),
             ),
             (
-                pd.PeriodIndex(["2012-02", "2012-04", "2012-05"], freq="M"),
-                pd.PeriodIndex(["2012-02", "2012-04", "2012-05"], freq="M"),
+                PeriodIndex(["2012-02", "2012-04", "2012-05"], freq="M"),
+                PeriodIndex(["2012-02", "2012-04", "2012-05"], freq="M"),
             ),
             (
-                pd.PeriodIndex(["2012-02", "2012-04", "NaT", "2012-05"], freq="M"),
-                pd.PeriodIndex(["2012-02", "2012-04", "2012-05"], freq="M"),
+                PeriodIndex(["2012-02", "2012-04", "NaT", "2012-05"], freq="M"),
+                PeriodIndex(["2012-02", "2012-04", "2012-05"], freq="M"),
             ),
         ],
     )
@@ -2517,7 +2517,7 @@ def test_deprecated_fastpath():
         pd.Int64Index(np.array([1, 2, 3], dtype="int64"), name="test", fastpath=True)
 
     with pytest.raises(TypeError, match=msg):
-        pd.RangeIndex(0, 5, 2, name="test", fastpath=True)
+        RangeIndex(0, 5, 2, name="test", fastpath=True)
 
     with pytest.raises(TypeError, match=msg):
         pd.CategoricalIndex(["a", "b", "c"], name="test", fastpath=True)
@@ -2544,7 +2544,7 @@ def test_validate_1d_input():
         Index(arr)
 
     with pytest.raises(ValueError, match=msg):
-        pd.Float64Index(arr.astype(np.float64))
+        Float64Index(arr.astype(np.float64))
 
     with pytest.raises(ValueError, match=msg):
         pd.Int64Index(arr.astype(np.int64))

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -302,7 +302,7 @@ class TestHDFStore:
             with ensure_clean_path(setup_path) as path:
                 df = DataFrame({"a": [1]})
 
-                with pd.HDFStore(path, mode="w") as hdf:
+                with HDFStore(path, mode="w") as hdf:
                     hdf.put(
                         "table",
                         df,
@@ -843,7 +843,7 @@ class TestHDFStore:
 
         # Check if file-defaults can be overridden on a per table basis
         with ensure_clean_path(setup_path) as tmpfile:
-            store = pd.HDFStore(tmpfile)
+            store = HDFStore(tmpfile)
             store.append("dfc", df, complevel=9, complib="blosc")
             store.append("df", df)
             store.close()
@@ -1298,7 +1298,7 @@ class TestHDFStore:
             df = DataFrame({"a": range(2), "b": range(2)})
             df.to_hdf(path, "k1")
 
-            with pd.HDFStore(path, "r") as store:
+            with HDFStore(path, "r") as store:
 
                 with pytest.raises(KeyError, match="'No object named k2 in the file'"):
                     pd.read_hdf(store, "k2")
@@ -3935,11 +3935,11 @@ class TestHDFStore:
         df = tm.makeDataFrame()
 
         def writer(path):
-            with pd.HDFStore(path) as store:
+            with HDFStore(path) as store:
                 df.to_hdf(store, "df")
 
         def reader(path):
-            with pd.HDFStore(path) as store:
+            with HDFStore(path) as store:
                 return pd.read_hdf(store, "df")
 
         result = tm.round_trip_pathlib(writer, reader)
@@ -3956,11 +3956,11 @@ class TestHDFStore:
         df = tm.makeDataFrame()
 
         def writer(path):
-            with pd.HDFStore(path) as store:
+            with HDFStore(path) as store:
                 df.to_hdf(store, "df")
 
         def reader(path):
-            with pd.HDFStore(path) as store:
+            with HDFStore(path) as store:
                 return pd.read_hdf(store, "df")
 
         result = tm.round_trip_localpath(writer, reader)
@@ -4829,7 +4829,7 @@ class TestHDFStore:
 
     def test_fspath(self):
         with tm.ensure_clean("foo.h5") as path:
-            with pd.HDFStore(path) as store:
+            with HDFStore(path) as store:
                 assert os.fspath(store) == str(path)
 
     def test_read_py2_hdf_file_in_py3(self, datapath):
@@ -4867,7 +4867,7 @@ class TestHDFStore:
 
         df = DataFrame([1, 2, 3])
         with ensure_clean_path("empty_where.h5") as path:
-            with pd.HDFStore(path) as store:
+            with HDFStore(path) as store:
                 store.put("df", df, "t")
                 result = pd.read_hdf(store, "df", where=where)
                 tm.assert_frame_equal(result, df)

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -491,7 +491,7 @@ class TestPeriodConstruction:
     def test_period_large_ordinal(self, hour):
         # Issue #36430
         # Integer overflow for Period over the maximum timestamp
-        p = pd.Period(ordinal=2562048 + hour, freq="1H")
+        p = Period(ordinal=2562048 + hour, freq="1H")
         assert p.hour == hour
 
 
@@ -652,7 +652,7 @@ class TestPeriodMethods:
         assert result == expected
 
     def test_to_timestamp_business_end(self):
-        per = pd.Period("1990-01-05", "B")  # Friday
+        per = Period("1990-01-05", "B")  # Friday
         result = per.to_timestamp("B", how="E")
 
         expected = Timestamp("1990-01-06") - Timedelta(nanoseconds=1)


### PR DESCRIPTION
Additional fixes for MarcoGorelli/PyDataGlobal2020-sprint#1.
Continues the work of lpkirwin in #37838.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
