### PR TITLE
Backport PR #37787 on branch 1.1.x (Fix regression for loc and __setitem__ when one-dimensional tuple was given for MultiIndex)

### DIFF
--- a/doc/source/whatsnew/v1.1.5.rst
+++ b/doc/source/whatsnew/v1.1.5.rst
@@ -16,6 +16,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Regression in addition of a timedelta-like scalar to a :class:`DatetimeIndex` raising incorrectly (:issue:`37295`)
 - Fixed regression in :meth:`Series.groupby` raising when the :class:`Index` of the :class:`Series` had a tuple as its name (:issue:`37755`)
+- Fixed regression in :meth:`DataFrame.loc` and :meth:`Series.loc` for ``__setitem__`` when one-dimensional tuple was given to select from :class:`MultiIndex` (:issue:`37711`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -641,9 +641,9 @@ class _LocationIndexer(_NDFrameIndexerBase):
         if self.ndim != 2:
             return
 
-        if isinstance(key, tuple):
+        if isinstance(key, tuple) and not isinstance(self.obj.index, ABCMultiIndex):
             # key may be a tuple if we are .loc
-            # in that case, set key to the column part of key
+            # if index is not a MultiIndex, set key to column part
             key = key[column_axis]
             axis = column_axis
 

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -288,6 +288,23 @@ class TestMultiIndexLoc:
 
         tm.assert_series_equal(result, expected)
 
+    def test_multiindex_loc_one_dimensional_tuple(self, frame_or_series):
+        # GH#37711
+        mi = MultiIndex.from_tuples([("a", "A"), ("b", "A")])
+        obj = frame_or_series([1, 2], index=mi)
+        obj.loc[("a",)] = 0
+        expected = frame_or_series([0, 2], index=mi)
+        tm.assert_equal(obj, expected)
+
+    @pytest.mark.parametrize("indexer", [("a",), ("a")])
+    def test_multiindex_one_dimensional_tuple_columns(self, indexer):
+        # GH#37711
+        mi = MultiIndex.from_tuples([("a", "A"), ("b", "A")])
+        obj = DataFrame([1, 2], index=mi)
+        obj.loc[indexer, :] = 0
+        expected = DataFrame([0, 2], index=mi)
+        tm.assert_frame_equal(obj, expected)
+
 
 @pytest.mark.parametrize(
     "indexer, pos",

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -288,12 +288,13 @@ class TestMultiIndexLoc:
 
         tm.assert_series_equal(result, expected)
 
-    def test_multiindex_loc_one_dimensional_tuple(self, frame_or_series):
+    @pytest.mark.parametrize("klass", [Series, DataFrame])
+    def test_multiindex_loc_one_dimensional_tuple(self, klass):
         # GH#37711
         mi = MultiIndex.from_tuples([("a", "A"), ("b", "A")])
-        obj = frame_or_series([1, 2], index=mi)
+        obj = klass([1, 2], index=mi)
         obj.loc[("a",)] = 0
-        expected = frame_or_series([0, 2], index=mi)
+        expected = klass([0, 2], index=mi)
         tm.assert_equal(obj, expected)
 
     @pytest.mark.parametrize("indexer", [("a",), ("a")])


### PR DESCRIPTION
Backport #37787

``frame_or_series`` not know here.

cc @simonjayhawkins 