### PR TITLE
CLN: remove something.xlsx

### DIFF
--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -1353,12 +1353,15 @@ class TestExcelWriterEngineTests:
             del called_write_cells[:]
 
         with pd.option_context("io.excel.xlsx.writer", "dummy"):
-            register_writer(DummyClass)
-            writer = ExcelWriter("something.xlsx")
-            assert isinstance(writer, DummyClass)
-            df = tm.makeCustomDataframe(1, 1)
-            check_called(lambda: df.to_excel("something.xlsx"))
-            check_called(lambda: df.to_excel("something.xls", engine="dummy"))
+            path = "something.xlsx"
+            with tm.ensure_clean(path) as filepath:
+                register_writer(DummyClass)
+                writer = ExcelWriter(filepath)
+                assert isinstance(writer, DummyClass)
+                df = tm.makeCustomDataframe(1, 1)
+                check_called(lambda: df.to_excel(filepath))
+            with tm.ensure_clean("something.xls") as filepath:
+                check_called(lambda: df.to_excel(filepath, engine="dummy"))
 
 
 @td.skip_if_no("xlrd")


### PR DESCRIPTION
`test_register_writer` in `pandas/tests/io/excel/test_writers.py` wasn't expecting that `something.xls` and `something.xlsx` will ever be created.

Since #37639, `ExcelWriter` opens the file which will create it.