### PR TITLE
REF: Index._intersection

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2798,6 +2798,13 @@ class Index(IndexOpsMixin, PandasObject):
             other = other.astype("O")
             return this.intersection(other, sort=sort)
 
+        result = self._intersection(other, sort=sort)
+        return self._wrap_setop_result(other, result)
+
+    def _intersection(self, other, sort=False):
+        """
+        intersection specialized to the case with matching dtypes.
+        """
         # TODO(EA): setops-refactor, clean all this up
         lvals = self._values
         rvals = other._values
@@ -2808,7 +2815,7 @@ class Index(IndexOpsMixin, PandasObject):
             except TypeError:
                 pass
             else:
-                return self._wrap_setop_result(other, result)
+                return result
 
         try:
             indexer = Index(rvals).get_indexer(lvals)
@@ -2824,7 +2831,7 @@ class Index(IndexOpsMixin, PandasObject):
         if sort is None:
             result = algos.safe_sort(result)
 
-        return self._wrap_setop_result(other, result)
+        return result
 
     def difference(self, other, sort=None):
         """


### PR DESCRIPTION
Follow the same pattern as Index._union.  Motivated by trying to get stricter typing in CategoricalIndex._shallow_copy, which is blocked by pinning down return types for set ops.