### PR TITLE
TYP: Add cast to ABC classes.

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -60,7 +60,7 @@ from pandas.core.construction import array, extract_array
 from pandas.core.indexers import validate_indices
 
 if TYPE_CHECKING:
-    from pandas import Categorical, DataFrame, Series
+    from pandas import Categorical, DataFrame, Index, Series
 
 _shared_docs: Dict[str, str] = {}
 
@@ -533,7 +533,7 @@ def factorize(
     sort: bool = False,
     na_sentinel: Optional[int] = -1,
     size_hint: Optional[int] = None,
-) -> Tuple[np.ndarray, Union[np.ndarray, ABCIndex]]:
+) -> Tuple[np.ndarray, Union[np.ndarray, "Index"]]:
     """
     Encode the object as an enumerated type or categorical variable.
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -269,12 +269,14 @@ class SelectionMixin:
             return self._gotitem(list(key), ndim=2)
 
         elif not getattr(self, "as_index", False):
-            if key not in self.obj.columns:
+            # error: "SelectionMixin" has no attribute "obj"  [attr-defined]
+            if key not in self.obj.columns:  # type: ignore[attr-defined]
                 raise KeyError(f"Column not found: {key}")
             return self._gotitem(key, ndim=2)
 
         else:
-            if key not in self.obj:
+            # error: "SelectionMixin" has no attribute "obj"  [attr-defined]
+            if key not in self.obj:  # type: ignore[attr-defined]
                 raise KeyError(f"Column not found: {key}")
             return self._gotitem(key, ndim=1)
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -921,10 +921,9 @@ class IndexOpsMixin(OpsMixin):
             # "astype"  [attr-defined]
             values = self.astype(object)._values  # type: ignore[attr-defined]
             if na_action == "ignore":
-
-                def map_f(values, f):
-                    return lib.map_infer_mask(values, f, isna(values).view(np.uint8))
-
+                map_f = lambda values, f: lib.map_infer_mask(
+                    values, f, isna(values).view(np.uint8)
+                )
             elif na_action is None:
                 map_f = lib.map_infer
             else:

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -469,7 +469,8 @@ def convert_to_list_like(
     inputs are returned unmodified whereas others are converted to list.
     """
     if isinstance(values, (list, np.ndarray, ABCIndex, ABCSeries, ABCExtensionArray)):
-        return values
+        # np.ndarray resolving as Any gives a false positive
+        return values  # type: ignore[return-value]
     elif isinstance(values, abc.Iterable) and not isinstance(values, str):
         return list(values)
 

--- a/pandas/core/computation/align.py
+++ b/pandas/core/computation/align.py
@@ -3,7 +3,7 @@ Core eval alignment algorithms.
 """
 
 from functools import partial, wraps
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Dict, Optional, Sequence, Tuple, Type, Union
 import warnings
 
 import numpy as np
@@ -39,7 +39,7 @@ def _align_core_single_unary_op(
 
 
 def _zip_axes_from_type(
-    typ: Type[FrameOrSeries], new_axes: List["Index"]
+    typ: Type[FrameOrSeries], new_axes: Sequence["Index"]
 ) -> Dict[str, "Index"]:
     return {name: new_axes[i] for i, name in enumerate(typ._AXIS_ORDERS)}
 

--- a/pandas/core/computation/align.py
+++ b/pandas/core/computation/align.py
@@ -1,6 +1,7 @@
 """
 Core eval alignment algorithms.
 """
+from __future__ import annotations
 
 from functools import partial, wraps
 from typing import TYPE_CHECKING, Dict, Optional, Sequence, Tuple, Type, Union
@@ -23,10 +24,10 @@ if TYPE_CHECKING:
 
 def _align_core_single_unary_op(
     term,
-) -> Tuple[Union[partial, Type[FrameOrSeries]], Optional[Dict[str, "Index"]]]:
+) -> Tuple[Union[partial, Type[FrameOrSeries]], Optional[Dict[str, Index]]]:
 
     typ: Union[partial, Type[FrameOrSeries]]
-    axes: Optional[Dict[str, "Index"]] = None
+    axes: Optional[Dict[str, Index]] = None
 
     if isinstance(term.value, np.ndarray):
         typ = partial(np.asanyarray, dtype=term.value.dtype)
@@ -39,8 +40,8 @@ def _align_core_single_unary_op(
 
 
 def _zip_axes_from_type(
-    typ: Type[FrameOrSeries], new_axes: Sequence["Index"]
-) -> Dict[str, "Index"]:
+    typ: Type[FrameOrSeries], new_axes: Sequence[Index]
+) -> Dict[str, Index]:
     return {name: new_axes[i] for i, name in enumerate(typ._AXIS_ORDERS)}
 
 

--- a/pandas/core/computation/align.py
+++ b/pandas/core/computation/align.py
@@ -3,7 +3,7 @@ Core eval alignment algorithms.
 """
 
 from functools import partial, wraps
-from typing import Dict, Optional, Sequence, Tuple, Type, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type, Union
 import warnings
 
 import numpy as np
@@ -17,13 +17,16 @@ from pandas.core.base import PandasObject
 import pandas.core.common as com
 from pandas.core.computation.common import result_type_many
 
+if TYPE_CHECKING:
+    from pandas.core.indexes.api import Index
+
 
 def _align_core_single_unary_op(
     term,
-) -> Tuple[Union[partial, Type[FrameOrSeries]], Optional[Dict[str, int]]]:
+) -> Tuple[Union[partial, Type[FrameOrSeries]], Optional[Dict[str, "Index"]]]:
 
     typ: Union[partial, Type[FrameOrSeries]]
-    axes: Optional[Dict[str, int]] = None
+    axes: Optional[Dict[str, "Index"]] = None
 
     if isinstance(term.value, np.ndarray):
         typ = partial(np.asanyarray, dtype=term.value.dtype)
@@ -36,8 +39,8 @@ def _align_core_single_unary_op(
 
 
 def _zip_axes_from_type(
-    typ: Type[FrameOrSeries], new_axes: Sequence[int]
-) -> Dict[str, int]:
+    typ: Type[FrameOrSeries], new_axes: List["Index"]
+) -> Dict[str, "Index"]:
     return {name: new_axes[i] for i, name in enumerate(typ._AXIS_ORDERS)}
 
 

--- a/pandas/core/computation/parsing.py
+++ b/pandas/core/computation/parsing.py
@@ -6,10 +6,13 @@ from io import StringIO
 from keyword import iskeyword
 import token
 import tokenize
-from typing import Iterator, Tuple
+from typing import TYPE_CHECKING, Iterator, Tuple
 
 # A token value Python's tokenizer probably will never use.
 BACKTICK_QUOTED_STRING = 100
+
+if TYPE_CHECKING:
+    from pandas._typing import Label
 
 
 def create_valid_python_identifier(name: str) -> str:
@@ -91,7 +94,7 @@ def clean_backtick_quoted_toks(tok: Tuple[int, str]) -> Tuple[int, str]:
     return toknum, tokval
 
 
-def clean_column_name(name: str) -> str:
+def clean_column_name(name: "Label") -> "Label":
     """
     Function to emulate the cleaning of a backtick quoted name.
 

--- a/pandas/core/computation/parsing.py
+++ b/pandas/core/computation/parsing.py
@@ -104,12 +104,12 @@ def clean_column_name(name: "Label") -> "Label":
 
     Parameters
     ----------
-    name : Label
+    name : hashable
         Name to be cleaned.
 
     Returns
     -------
-    name : Label
+    name : hashable
         Returns the name after tokenizing and cleaning.
 
     Notes

--- a/pandas/core/computation/parsing.py
+++ b/pandas/core/computation/parsing.py
@@ -6,13 +6,12 @@ from io import StringIO
 from keyword import iskeyword
 import token
 import tokenize
-from typing import TYPE_CHECKING, Iterator, Tuple
+from typing import Iterator, Tuple
+
+from pandas._typing import Label
 
 # A token value Python's tokenizer probably will never use.
 BACKTICK_QUOTED_STRING = 100
-
-if TYPE_CHECKING:
-    from pandas._typing import Label
 
 
 def create_valid_python_identifier(name: str) -> str:
@@ -105,12 +104,12 @@ def clean_column_name(name: "Label") -> "Label":
 
     Parameters
     ----------
-    name : str
+    name : Label
         Name to be cleaned.
 
     Returns
     -------
-    name : str
+    name : Label
         Returns the name after tokenizing and cleaning.
 
     Notes

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -351,7 +351,9 @@ def array(
     return result
 
 
-def extract_array(obj: AnyArrayLike, extract_numpy: bool = False) -> ArrayLike:
+def extract_array(
+    obj: AnyArrayLike, extract_numpy: bool = False
+) -> Union[AnyArrayLike, ExtensionArray, np.ndarray]:
     """
     Extract the ndarray or ExtensionArray from a Series or Index.
 
@@ -394,14 +396,14 @@ def extract_array(obj: AnyArrayLike, extract_numpy: bool = False) -> ArrayLike:
     array([1, 2, 3])
     """
     if isinstance(obj, (ABCIndexClass, ABCSeries)):
-        obj = obj.array
+        result = obj.array
+    else:
+        result = obj
 
-    if extract_numpy and isinstance(obj, ABCPandasArray):
-        obj = obj.to_numpy()
+    if extract_numpy and isinstance(result, ABCPandasArray):
+        result = result.to_numpy()
 
-    # error: Incompatible return value type (got "Index", expected "ExtensionArray")
-    # error: Incompatible return value type (got "Series", expected "ExtensionArray")
-    return obj  # type: ignore[return-value]
+    return result
 
 
 def sanitize_array(

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -351,9 +351,7 @@ def array(
     return result
 
 
-def extract_array(
-    obj: AnyArrayLike, extract_numpy: bool = False
-) -> Union[ExtensionArray, np.ndarray]:
+def extract_array(obj: object, extract_numpy: bool = False) -> Union[Any, ArrayLike]:
     """
     Extract the ndarray or ExtensionArray from a Series or Index.
 
@@ -396,7 +394,7 @@ def extract_array(
     array([1, 2, 3])
     """
     if isinstance(obj, (ABCIndexClass, ABCSeries)):
-        obj = obj.array  # type: ignore[assignment]
+        obj = obj.array
 
     if extract_numpy and isinstance(obj, ABCPandasArray):
         obj = obj.to_numpy()

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -396,14 +396,12 @@ def extract_array(
     array([1, 2, 3])
     """
     if isinstance(obj, (ABCIndexClass, ABCSeries)):
-        result = obj.array
-    else:
-        result = obj
+        obj = obj.array  # type: ignore[assignment]
 
-    if extract_numpy and isinstance(result, ABCPandasArray):
-        result = result.to_numpy()
+    if extract_numpy and isinstance(obj, ABCPandasArray):
+        obj = obj.to_numpy()
 
-    return result
+    return obj
 
 
 def sanitize_array(

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -353,7 +353,7 @@ def array(
 
 def extract_array(
     obj: AnyArrayLike, extract_numpy: bool = False
-) -> Union[AnyArrayLike, ExtensionArray, np.ndarray]:
+) -> Union[ExtensionArray, np.ndarray]:
     """
     Extract the ndarray or ExtensionArray from a Series or Index.
 

--- a/pandas/core/dtypes/generic.py
+++ b/pandas/core/dtypes/generic.py
@@ -1,4 +1,5 @@
 """ define generic base classes for pandas objects """
+from __future__ import annotations
 
 from typing import TYPE_CHECKING, Type, cast
 
@@ -59,15 +60,15 @@ ABCIndexClass = create_pandas_abc_type(
 )
 
 ABCNDFrame = cast(
-    "Type[NDFrame]",
+    Type[NDFrame],
     create_pandas_abc_type("ABCNDFrame", "_typ", ("series", "dataframe")),
 )
 ABCSeries = cast(
-    "Type[Series]",
+    Type[Series],
     create_pandas_abc_type("ABCSeries", "_typ", ("series",)),
 )
 ABCDataFrame = cast(
-    "Type[DataFrame]", create_pandas_abc_type("ABCDataFrame", "_typ", ("dataframe",))
+    Type[DataFrame], create_pandas_abc_type("ABCDataFrame", "_typ", ("dataframe",))
 )
 
 ABCCategorical = create_pandas_abc_type("ABCCategorical", "_typ", ("categorical"))

--- a/pandas/core/dtypes/generic.py
+++ b/pandas/core/dtypes/generic.py
@@ -1,5 +1,12 @@
 """ define generic base classes for pandas objects """
 
+from typing import TYPE_CHECKING, Type, cast
+
+if TYPE_CHECKING:
+    from pandas.core.frame import DataFrame
+    from pandas.core.generic import NDFrame
+    from pandas.core.series import Series
+
 
 # define abstract base classes to enable isinstance type checking on our
 # objects
@@ -53,9 +60,17 @@ ABCIndexClass = create_pandas_abc_type(
     },
 )
 
-ABCNDFrame = create_pandas_abc_type("ABCNDFrame", "_typ", ("series", "dataframe"))
-ABCSeries = create_pandas_abc_type("ABCSeries", "_typ", ("series",))
-ABCDataFrame = create_pandas_abc_type("ABCDataFrame", "_typ", ("dataframe",))
+ABCNDFrame = cast(
+    "Type[NDFrame]",
+    create_pandas_abc_type("ABCNDFrame", "_typ", ("series", "dataframe")),
+)
+ABCSeries = cast(
+    "Type[Series]",
+    create_pandas_abc_type("ABCSeries", "_typ", ("series",)),
+)
+ABCDataFrame = cast(
+    "Type[DataFrame]", create_pandas_abc_type("ABCDataFrame", "_typ", ("dataframe",))
+)
 
 ABCCategorical = create_pandas_abc_type("ABCCategorical", "_typ", ("categorical"))
 ABCDatetimeArray = create_pandas_abc_type("ABCDatetimeArray", "_typ", ("datetimearray"))

--- a/pandas/core/dtypes/generic.py
+++ b/pandas/core/dtypes/generic.py
@@ -3,9 +3,7 @@
 from typing import TYPE_CHECKING, Type, cast
 
 if TYPE_CHECKING:
-    from pandas.core.frame import DataFrame
-    from pandas.core.generic import NDFrame
-    from pandas.core.series import Series
+    from pandas import DataFrame, NDFrame, Series
 
 
 # define abstract base classes to enable isinstance type checking on our

--- a/pandas/core/dtypes/generic.py
+++ b/pandas/core/dtypes/generic.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Type, cast
 
 if TYPE_CHECKING:
-    from pandas import DataFrame, NDFrame, Series
+    from pandas import DataFrame, Series
+    from pandas.core.generic import NDFrame
 
 
 # define abstract base classes to enable isinstance type checking on our
@@ -60,15 +61,15 @@ ABCIndexClass = create_pandas_abc_type(
 )
 
 ABCNDFrame = cast(
-    Type[NDFrame],
+    "Type[NDFrame]",
     create_pandas_abc_type("ABCNDFrame", "_typ", ("series", "dataframe")),
 )
 ABCSeries = cast(
-    Type[Series],
+    "Type[Series]",
     create_pandas_abc_type("ABCSeries", "_typ", ("series",)),
 )
 ABCDataFrame = cast(
-    Type[DataFrame], create_pandas_abc_type("ABCDataFrame", "_typ", ("dataframe",))
+    "Type[DataFrame]", create_pandas_abc_type("ABCDataFrame", "_typ", ("dataframe",))
 )
 
 ABCCategorical = create_pandas_abc_type("ABCCategorical", "_typ", ("categorical"))

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -511,7 +511,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         return d
 
     @final
-    def _get_index_resolvers(self) -> Dict[str, Union[Series, MultiIndex]]:
+    def _get_index_resolvers(self) -> Dict[Label, Union[Series, MultiIndex]]:
         from pandas.core.computation.parsing import clean_column_name
 
         d: Dict[str, Union[Series, MultiIndex]] = {}
@@ -521,7 +521,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         return {clean_column_name(k): v for k, v in d.items() if not isinstance(k, int)}
 
     @final
-    def _get_cleaned_column_resolvers(self) -> Dict[str, ABCSeries]:
+    def _get_cleaned_column_resolvers(self) -> Dict[Label, Series]:
         """
         Return the special character free column resolvers of a dataframe.
 
@@ -532,7 +532,6 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         from pandas.core.computation.parsing import clean_column_name
 
         if isinstance(self, ABCSeries):
-            self = cast("Series", self)
             return {clean_column_name(self.name): self}
 
         return {

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2016,7 +2016,7 @@ class _iLocIndexer(_LocationIndexer):
 
         raise ValueError("Incompatible indexer with Series")
 
-    def _align_frame(self, indexer, df: ABCDataFrame):
+    def _align_frame(self, indexer, df: "DataFrame"):
         is_frame = self.ndim == 2
 
         if isinstance(indexer, tuple):

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -369,7 +369,7 @@ def extract_index(data) -> Index:
         index = Index([])
     elif len(data) > 0:
         raw_lengths = []
-        indexes: List[Any] = []
+        indexes: List[Union[List[Label], Index]] = []
 
         have_raw_arrays = False
         have_series = False

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -369,7 +369,7 @@ def extract_index(data) -> Index:
         index = Index([])
     elif len(data) > 0:
         raw_lengths = []
-        indexes = []
+        indexes: List[Any] = []
 
         have_raw_arrays = False
         have_series = False

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -447,7 +447,7 @@ class _Concatenator:
                     if self._is_frame and axis == 1:
                         name = 0
                     # mypy needs to know sample is not an NDFrame
-                    assert isinstance(sample, (ABCSeries, ABCDataFrame))
+                    sample = cast("FrameOrSeriesUnion", sample)
                     obj = sample._constructor({name: obj})
 
                 self.objs.append(obj)

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -3,11 +3,21 @@ Concat routines.
 """
 
 from collections import abc
-from typing import TYPE_CHECKING, Iterable, List, Mapping, Type, Union, cast, overload
+from typing import (
+    TYPE_CHECKING,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Type,
+    Union,
+    cast,
+    overload,
+)
 
 import numpy as np
 
-from pandas._typing import FrameOrSeries, FrameOrSeriesUnion, Label
+from pandas._typing import FrameOrSeriesUnion, Label
 
 from pandas.core.dtypes.concat import concat_compat
 from pandas.core.dtypes.generic import ABCDataFrame, ABCSeries
@@ -295,7 +305,7 @@ class _Concatenator:
 
     def __init__(
         self,
-        objs: Union[Iterable[FrameOrSeries], Mapping[Label, FrameOrSeries]],
+        objs: Union[Iterable["NDFrame"], Mapping[Label, "NDFrame"]],
         axis=0,
         join: str = "outer",
         keys=None,
@@ -366,7 +376,7 @@ class _Concatenator:
         # get the sample
         # want the highest ndim that we have, and must be non-empty
         # unless all objs are empty
-        sample = None
+        sample: Optional["NDFrame"] = None
         if len(ndims) > 1:
             max_ndim = max(ndims)
             for obj in objs:
@@ -436,6 +446,8 @@ class _Concatenator:
                     # to line up
                     if self._is_frame and axis == 1:
                         name = 0
+                    # mypy needs to know sample is not an NDFrame
+                    assert isinstance(sample, (ABCSeries, ABCDataFrame))
                     obj = sample._constructor({name: obj})
 
                 self.objs.append(obj)

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -157,11 +157,10 @@ class StringMethods(NoNewAttributesMixin):
         array = data.array
         self._array = array
 
+        self._index = self._name = None
         if isinstance(data, ABCSeries):
             self._index = data.index
             self._name = data.name
-        else:
-            self._index = self._name = None
 
         # ._values.categories works for both Series/Index
         self._parent = data._values.categories if self._is_categorical else data

--- a/pandas/core/window/common.py
+++ b/pandas/core/window/common.py
@@ -1,5 +1,6 @@
 """Common utility functions for rolling operations"""
 from collections import defaultdict
+from typing import cast
 import warnings
 
 import numpy as np
@@ -111,7 +112,7 @@ def flex_binary_moment(arg1, arg2, f, pairwise=False):
                     if arg2.columns.nlevels > 1:
                         # mypy needs to know columns is a MultiIndex, Index doesn't
                         # have levels attribute
-                        assert isinstance(arg2.columns, MultiIndex)
+                        arg2.columns = cast(MultiIndex, arg2.columns)
                         result.index = MultiIndex.from_product(
                             arg2.columns.levels + [result_index]
                         )

--- a/pandas/core/window/common.py
+++ b/pandas/core/window/common.py
@@ -109,6 +109,9 @@ def flex_binary_moment(arg1, arg2, f, pairwise=False):
 
                     # set the index and reorder
                     if arg2.columns.nlevels > 1:
+                        # mypy needs to know columns is a MultiIndex, Index doesn't
+                        # have levels attribute
+                        assert isinstance(arg2.columns, MultiIndex)
                         result.index = MultiIndex.from_product(
                             arg2.columns.levels + [result_index]
                         )

--- a/pandas/plotting/_matplotlib/tools.py
+++ b/pandas/plotting/_matplotlib/tools.py
@@ -7,7 +7,7 @@ import matplotlib.table
 import matplotlib.ticker as ticker
 import numpy as np
 
-from pandas._typing import FrameOrSeries
+from pandas._typing import FrameOrSeriesUnion
 
 from pandas.core.dtypes.common import is_list_like
 from pandas.core.dtypes.generic import ABCDataFrame, ABCIndexClass, ABCSeries
@@ -30,21 +30,23 @@ def format_date_labels(ax: "Axes", rot):
     fig.subplots_adjust(bottom=0.2)
 
 
-def table(ax, data: FrameOrSeries, rowLabels=None, colLabels=None, **kwargs) -> "Table":
+def table(
+    ax, data: FrameOrSeriesUnion, rowLabels=None, colLabels=None, **kwargs
+) -> "Table":
     if isinstance(data, ABCSeries):
-        frame = data.to_frame()
+        data = data.to_frame()
     elif isinstance(data, ABCDataFrame):
-        frame = data
+        pass
     else:
         raise ValueError("Input data must be DataFrame or Series")
 
     if rowLabels is None:
-        rowLabels = frame.index
+        rowLabels = data.index
 
     if colLabels is None:
-        colLabels = frame.columns
+        colLabels = data.columns
 
-    cellText = frame.values
+    cellText = data.values
 
     table = matplotlib.table.table(
         ax, cellText=cellText, rowLabels=rowLabels, colLabels=colLabels, **kwargs

--- a/pandas/plotting/_matplotlib/tools.py
+++ b/pandas/plotting/_matplotlib/tools.py
@@ -32,19 +32,19 @@ def format_date_labels(ax: "Axes", rot):
 
 def table(ax, data: FrameOrSeries, rowLabels=None, colLabels=None, **kwargs) -> "Table":
     if isinstance(data, ABCSeries):
-        data = data.to_frame()
+        frame = data.to_frame()
     elif isinstance(data, ABCDataFrame):
-        pass
+        frame = data
     else:
         raise ValueError("Input data must be DataFrame or Series")
 
     if rowLabels is None:
-        rowLabels = data.index
+        rowLabels = frame.index
 
     if colLabels is None:
-        colLabels = data.columns
+        colLabels = frame.columns
 
-    cellText = data.values
+    cellText = frame.values
 
     table = matplotlib.table.table(
         ax, cellText=cellText, rowLabels=rowLabels, colLabels=colLabels, **kwargs


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Implements the idea of @simonjayhawkins from https://github.com/pandas-dev/pandas/issues/27353#issuecomment-526391462 to use cast on ABC classes. Currently only implements ABCDataFrame, ABCNDFrame, and ABCSeries. Previously, mypy would resolve e.g. ABCSeries as any, now it gets resolved as Series.

One issue remains: I don't understand why the code below generates this complaint.

> pandas/core/common.py:472: error: Incompatible return value type (got "Union[Any, List[Any], Series]", expected "Union[List[Any], ExtensionArray]")  [return-value]

```
def convert_to_list_like(
    values: Union[Scalar, Iterable, AnyArrayLike]
) -> Union[List, AnyArrayLike]:
    if isinstance(values, (list, np.ndarray, ABCIndex, ABCSeries, ABCExtensionArray)):
        return values
    ...
```

One can add Series to the return Union to resolve this, but it doesn't seem like that should be necessary.

I'm also getting:

> pandas/core/base.py:923: note: Internal mypy error checking function redefinition

on the lines

```
def map_f(values, f):
    return lib.map_infer_mask(values, f, isna(values).view(np.uint8))
```

where `map_f` is defined in various ways in if-else blocks. I'm not sure if this is a mypy bug.