### PR TITLE
CI: update pyupgrade to 2.7.4 in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
         name: isort (cython)
         types: [cython]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.3
+    rev: v2.7.4
     hooks:
     -   id: pyupgrade
         args: [--py37-plus]


### PR DESCRIPTION
Updating pyupgrade to 2.7.4 in pre-commit yaml. `pre-commit run pyupgrade --all-files` runs good :+1: 

- [x] closes #37891
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
- [x] passes `pre-commit run pyupgrade --all-files`
