### PR TITLE
REF: ensure CategoricalIndex._shallow_copy only ever gets Categorical

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2734,7 +2734,7 @@ class Index(IndexOpsMixin, PandasObject):
                         stacklevel=3,
                     )
 
-        return self._shallow_copy(result)
+        return result
 
     @final
     def _wrap_setop_result(self, other, result):
@@ -2742,6 +2742,8 @@ class Index(IndexOpsMixin, PandasObject):
             result, np.ndarray
         ):
             result = type(self._data)._simple_new(result, dtype=self.dtype)
+        elif is_categorical_dtype(self.dtype) and isinstance(result, np.ndarray):
+            result = Categorical(result, dtype=self.dtype)
 
         name = get_op_result_name(self, other)
         if isinstance(result, Index):

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any, List, Optional
 import warnings
 
 import numpy as np
@@ -227,10 +227,15 @@ class CategoricalIndex(NDArrayBackedExtensionIndex, accessor.PandasDelegate):
     # --------------------------------------------------------------------
 
     @doc(Index._shallow_copy)
-    def _shallow_copy(self, values=None, name: Label = no_default):
+    def _shallow_copy(
+        self, values: Optional[Categorical] = None, name: Label = no_default
+    ):
         name = self.name if name is no_default else name
 
         if values is not None:
+            # In tests we only get here with Categorical objects that
+            #  have matching .ordered, and values.categories a subset of
+            #  our own.  However we do _not_ have a dtype match in general.
             values = Categorical(values, dtype=self.dtype)
 
         return super()._shallow_copy(values=values, name=name)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -765,11 +765,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
         start = right[0]
 
         if end < start:
-            # pandas\core\indexes\datetimelike.py:758: error: Unexpected
-            # keyword argument "freq" for "DatetimeTimedeltaMixin"  [call-arg]
-            result = type(self)(
-                data=[], dtype=self.dtype, freq=self.freq  # type: ignore[call-arg]
-            )
+            result = self[:0]
         else:
             lslice = slice(*left.slice_locs(start, end))
             left_chunk = left._values[lslice]

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -29,7 +29,7 @@ import pandas.core.common as com
 from pandas.core.construction import extract_array
 import pandas.core.indexes.base as ibase
 from pandas.core.indexes.base import _index_shared_docs, maybe_extract_name
-from pandas.core.indexes.numeric import Int64Index
+from pandas.core.indexes.numeric import Float64Index, Int64Index
 from pandas.core.ops.common import unpack_zerodim_and_defer
 
 _empty_range = range(0)
@@ -397,6 +397,8 @@ class RangeIndex(Int64Index):
         name = self.name if name is no_default else name
 
         if values is not None:
+            if values.dtype.kind == "f":
+                return Float64Index(values, name=name)
             return Int64Index._simple_new(values, name=name)
 
         result = self._simple_new(self._range, name=name)

--- a/pandas/tests/indexes/base_class/test_setops.py
+++ b/pandas/tests/indexes/base_class/test_setops.py
@@ -31,7 +31,7 @@ class TestIndexSetOps:
 
         result = idx._union(idx[1:], sort=None)
         expected = idx
-        tm.assert_index_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected.values)
 
         result = idx.union(idx[1:], sort=None)
         tm.assert_index_equal(result, expected)
@@ -39,7 +39,7 @@ class TestIndexSetOps:
         # if other is not monotonic increasing, _union goes through
         #  a different route
         result = idx._union(idx[1:][::-1], sort=None)
-        tm.assert_index_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected.values)
 
         result = idx.union(idx[1:][::-1], sort=None)
         tm.assert_index_equal(result, expected)


### PR DESCRIPTION
still not as tightly restricted as id like, but a step in the right direction.