### PR TITLE
BUG: fix sharey overwrite on area plots

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -664,6 +664,7 @@ Plotting
 - Bug in :meth:`Series.plot` and :meth:`DataFrame.plot` was throwing :exc:`ValueError` with a :class:`Series` or :class:`DataFrame`
   indexed by a :class:`TimedeltaIndex` with a fixed frequency when x-axis lower limit was greater than upper limit (:issue:`37454`)
 - Bug in :meth:`DataFrameGroupBy.boxplot` when ``subplots=False``, a KeyError would raise (:issue:`16748`)
+- Bug in :meth:`DataFrame.plot` was overwriting matplotlib's shared y axes behaviour when no sharey parameter was passed (:issue:`37942`)
 
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -664,7 +664,7 @@ Plotting
 - Bug in :meth:`Series.plot` and :meth:`DataFrame.plot` was throwing :exc:`ValueError` with a :class:`Series` or :class:`DataFrame`
   indexed by a :class:`TimedeltaIndex` with a fixed frequency when x-axis lower limit was greater than upper limit (:issue:`37454`)
 - Bug in :meth:`DataFrameGroupBy.boxplot` when ``subplots=False``, a KeyError would raise (:issue:`16748`)
-- Bug in :meth:`DataFrame.plot` was overwriting matplotlib's shared y axes behaviour when no sharey parameter was passed (:issue:`37942`)
+- Bug in :meth:`DataFrame.plot` and :meth:`Series.plot` was overwriting matplotlib's shared y axes behaviour when no sharey parameter was passed (:issue:`37942`)
 
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -1340,7 +1340,7 @@ class AreaPlot(LinePlot):
 
         is_shared_y = len(list(ax.get_shared_y_axes())) > 0
         # do not override the default axis behaviour in case of shared y axes
-        if self.ylim is None and not is_shared_y: 
+        if self.ylim is None and not is_shared_y:
             if (data >= 0).all().all():
                 ax.set_ylim(0, None)
             elif (data <= 0).all().all():

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -1338,7 +1338,9 @@ class AreaPlot(LinePlot):
     def _post_plot_logic(self, ax: "Axes", data):
         LinePlot._post_plot_logic(self, ax, data)
 
-        if self.ylim is None:
+        is_shared_y = len(list(ax.get_shared_y_axes())) > 0
+        # do not override the default axis behaviour in case of shared y axes
+        if self.ylim is None and not is_shared_y: 
             if (data >= 0).all().all():
                 ax.set_ylim(0, None)
             elif (data <= 0).all().all():

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -477,6 +477,18 @@ class TestDataFramePlots(TestPlotBase):
             ymin, ymax = ax.get_ylim()
             assert ymax == 0
 
+    def test_area_sharey_dont_overwrite(self):
+        # GH37942
+        df1 = DataFrame(np.random.rand(4, 2), columns=["x", "y"])
+        df2 = DataFrame(np.random.rand(4, 2), columns=["x", "y"])
+        fig, (ax1, ax2) = self.plt.subplots(1, 2, sharey=True)
+
+        df1.plot(ax=ax1, kind="area")
+        df2.plot(ax=ax2, kind="area")
+
+        assert ax1._shared_y_axes.joined(ax1, ax2)
+        assert ax2._shared_y_axes.joined(ax1, ax2)
+
     @pytest.mark.slow
     def test_bar_linewidth(self):
         df = DataFrame(np.random.randn(5, 5))

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -479,12 +479,11 @@ class TestDataFramePlots(TestPlotBase):
 
     def test_area_sharey_dont_overwrite(self):
         # GH37942
-        df1 = DataFrame(np.random.rand(4, 2), columns=["x", "y"])
-        df2 = DataFrame(np.random.rand(4, 2), columns=["x", "y"])
+        df = DataFrame(np.random.rand(4, 2), columns=["x", "y"])
         fig, (ax1, ax2) = self.plt.subplots(1, 2, sharey=True)
 
-        df1.plot(ax=ax1, kind="area")
-        df2.plot(ax=ax2, kind="area")
+        df.plot(ax=ax1, kind="area")
+        df.plot(ax=ax2, kind="area")
 
         assert ax1._shared_y_axes.joined(ax1, ax2)
         assert ax2._shared_y_axes.joined(ax1, ax2)

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -140,6 +140,16 @@ class TestSeriesPlots(TestPlotBase):
         assert xmax >= line[-1]
         self._check_ticks_props(ax, xrot=0)
 
+    def test_area_sharey_dont_overwrite(self):
+        # GH37942
+        fig, (ax1, ax2) = self.plt.subplots(1, 2, sharey=True)
+
+        self.ts.plot(ax=ax1, kind="area")
+        self.ts.plot(ax=ax2, kind="area")
+
+        assert ax1._shared_y_axes.joined(ax1, ax2)
+        assert ax2._shared_y_axes.joined(ax1, ax2)
+
     def test_label(self):
         s = Series([1, 2])
         _, ax = self.plt.subplots()

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -144,8 +144,8 @@ class TestSeriesPlots(TestPlotBase):
         # GH37942
         fig, (ax1, ax2) = self.plt.subplots(1, 2, sharey=True)
 
-        self.ts.plot(ax=ax1, kind="area")
-        self.ts.plot(ax=ax2, kind="area")
+        abs(self.ts).plot(ax=ax1, kind="area")
+        abs(self.ts).plot(ax=ax2, kind="area")
 
         assert ax1._shared_y_axes.joined(ax1, ax2)
         assert ax2._shared_y_axes.joined(ax1, ax2)


### PR DESCRIPTION
- [x] closes #37942
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
