### PR TITLE
DOC: Change warning for sort behavior in concat

### DIFF
--- a/doc/source/user_guide/merging.rst
+++ b/doc/source/user_guide/merging.rst
@@ -204,12 +204,6 @@ behavior:
    p.plot([df1, df4], result, labels=["df1", "df4"], vertical=False);
    plt.close("all");
 
-.. warning::
-
-    .. versionchanged:::::: 1.0.0
-
-    The default behavior with ``join='outer'`` changed to not sort.
-
 Here is the same thing with ``join='inner'``:
 
 .. ipython:: python

--- a/doc/source/user_guide/merging.rst
+++ b/doc/source/user_guide/merging.rst
@@ -208,7 +208,7 @@ behavior:
 
     .. versionchanged:::::: 1.0.0
 
-    The default behavior with ``join='outer` changed to not sort.
+    The default behavior with ``join='outer'`` changed to not sort.
 
 Here is the same thing with ``join='inner'``:
 

--- a/doc/source/user_guide/merging.rst
+++ b/doc/source/user_guide/merging.rst
@@ -194,7 +194,7 @@ behavior:
        },
        index=[2, 3, 6, 7],
    )
-   result = pd.concat([df1, df4], axis=1, sort=False)
+   result = pd.concat([df1, df4], axis=1)
 
 
 .. ipython:: python
@@ -206,10 +206,9 @@ behavior:
 
 .. warning::
 
-   The default behavior with ``join='outer'`` is to sort the other axis
-   (columns in this case). In a future version of pandas, the default will
-   be to not sort. We specified ``sort=False`` to opt in to the new
-   behavior now.
+    .. versionchanged:::::: 1.0.0
+
+    The default behavior with ``join='outer` changed to not sort.
 
 Here is the same thing with ``join='inner'``:
 


### PR DESCRIPTION
We should either add a ``versionchanged`` attribute, for when this behavior changed or remove the warning completly. Additionally I removed the ``sort=False`` input for the function, because this is no longer necessary.