### PR TITLE
BUG: Bug in setitem raising ValueError when setting more than one column via array

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -668,6 +668,7 @@ class _LocationIndexer(NDFrameIndexerBase):
                     if value is None:
                         self.obj[k] = np.nan
                     elif is_array_like(value) and value.ndim == 2:
+                        # GH#37964 have to select columnwise in case of array
                         self.obj[k] = value[:, i]
                     elif is_list_like(value):
                         self.obj[k] = value[i]

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -667,6 +667,8 @@ class _LocationIndexer(NDFrameIndexerBase):
                 if k not in self.obj:
                     if value is None:
                         self.obj[k] = np.nan
+                    elif is_array_like(value) and value.ndim == 2:
+                        self.obj[k] = value[:, i]
                     elif is_list_like(value):
                         self.obj[k] = value[i]
                     else:

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -289,6 +289,21 @@ class TestDataFrameSetItem:
         assert isinstance(rs.index, PeriodIndex)
         tm.assert_index_equal(rs.index, rng)
 
+    def test_setitem_complete_column_with_array(self):
+        # GH#37954
+        df = DataFrame({"a": ["one", "two", "three"], "b": [1, 2, 3]})
+        arr = np.array([[1, 1], [3, 1], [5, 1]])
+        df[["c", "d"]] = arr
+        expected = DataFrame(
+            {
+                "a": ["one", "two", "three"],
+                "b": [1, 2, 3],
+                "c": [1, 3, 5],
+                "d": [1, 1, 1],
+            }
+        )
+        tm.assert_frame_equal(df, expected)
+
 
 class TestDataFrameSetItemSlicing:
     def test_setitem_slice_position(self):


### PR DESCRIPTION
- [x] xref #37954
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Did not add whatsnew, cause works on 1.1.4

Array to set has to have more or less rows than columns, otherwise bug won't occur. Wrong values would be set silently here.

This is only a regression on master, not related to any release

cc @jbrockmendel 
