### PR TITLE
PERF: IntervalArray.argsort

### DIFF
--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -619,6 +619,21 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     def __le__(self, other):
         return self._cmp_method(other, operator.le)
 
+    def argsort(
+        self,
+        ascending: bool = True,
+        kind: str = "quicksort",
+        na_position: str = "last",
+        *args,
+        **kwargs,
+    ) -> np.ndarray:
+        if ascending and kind == "quicksort" and na_position == "last":
+            return np.lexsort((self.right, self.left))
+        # TODO: other cases we can use lexsort for?  much more performant.
+        return super().argsort(
+            *args, ascending=ascending, kind=kind, na_position=na_position, **kwargs
+        )
+
     def fillna(self, value=None, method=None, limit=None):
         """
         Fill NA/NaN values using the specified method.

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -627,11 +627,14 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         *args,
         **kwargs,
     ) -> np.ndarray:
+        ascending = nv.validate_argsort_with_ascending(ascending, args, kwargs)
+
         if ascending and kind == "quicksort" and na_position == "last":
             return np.lexsort((self.right, self.left))
+
         # TODO: other cases we can use lexsort for?  much more performant.
         return super().argsort(
-            *args, ascending=ascending, kind=kind, na_position=na_position, **kwargs
+            ascending=ascending, kind=kind, na_position=na_position, **kwargs
         )
 
     def fillna(self, value=None, method=None, limit=None):

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -958,11 +958,6 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
         return f"\n{space}"
 
     # --------------------------------------------------------------------
-
-    def argsort(self, *args, **kwargs) -> np.ndarray:
-        return np.lexsort((self.right, self.left))
-
-    # --------------------------------------------------------------------
     # Set Operations
 
     @Appender(Index.intersection.__doc__)


### PR DESCRIPTION
IntervalIndex.argsort has a more performant implementation (at least for default kwargs).  This just moves that up to IntervalArray.

```
In [2]: idx = pd.IntervalIndex.from_breaks(range(10**4))

In [3]: arr = idx._data

In [4]: %timeit arr.argsort()
24.5 ms ± 458 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)     # <-- master
79 µs ± 1.64 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)   # <-- PR
```