### PR TITLE
BUG: IntervalArray.astype(categorical_dtype) losing ordered

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -589,6 +589,7 @@ Interval
 - Bug in :meth:`DataFrame.replace` and :meth:`Series.replace` where :class:`Interval` dtypes would be converted to object dtypes (:issue:`34871`)
 - Bug in :meth:`IntervalIndex.take` with negative indices and ``fill_value=None`` (:issue:`37330`)
 - Bug in :meth:`IntervalIndex.putmask` with datetime-like dtype incorrectly casting to object dtype (:issue:`37968`)
+- Bug in :meth:`IntervalArray.astype` incorrectly dropping dtype information with a :class:`CategoricalDtype` object (:issue:`37984`)
 -
 
 Indexing

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -702,7 +702,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             combined = _get_combined_data(new_left, new_right)
             return type(self)._simple_new(combined, closed=self.closed)
         elif is_categorical_dtype(dtype):
-            return Categorical(np.asarray(self))
+            return Categorical(np.asarray(self), dtype=dtype)
         elif isinstance(dtype, StringDtype):
             return dtype.construct_array_type()._from_sequence(self, copy=False)
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -373,9 +373,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
     def astype(self, dtype, copy: bool = True):
         with rewrite_exception("IntervalArray", type(self).__name__):
             new_values = self._values.astype(dtype, copy=copy)
-        if is_interval_dtype(new_values.dtype):
-            return self._shallow_copy(new_values)
-        return Index.astype(self, dtype, copy=copy)
+        return Index(new_values, dtype=new_values.dtype, name=self.name)
 
     @property
     def inferred_type(self) -> str:

--- a/pandas/tests/arrays/interval/test_astype.py
+++ b/pandas/tests/arrays/interval/test_astype.py
@@ -1,0 +1,23 @@
+import pytest
+
+from pandas import Categorical, CategoricalDtype, Index, IntervalIndex
+import pandas._testing as tm
+
+
+class TestAstype:
+    @pytest.mark.parametrize("ordered", [True, False])
+    def test_astype_categorical_retains_ordered(self, ordered):
+        index = IntervalIndex.from_breaks(range(5))
+        arr = index._data
+
+        dtype = CategoricalDtype(None, ordered=ordered)
+
+        expected = Categorical(list(arr), ordered=ordered)
+        result = arr.astype(dtype)
+        assert result.ordered is ordered
+        tm.assert_categorical_equal(result, expected)
+
+        # test IntervalIndex.astype while we're at it.
+        result = index.astype(dtype)
+        expected = Index(expected)
+        tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/interval/test_astype.py
+++ b/pandas/tests/indexes/interval/test_astype.py
@@ -114,7 +114,13 @@ class TestIntSubtype(Base):
         # int64 -> uint64 fails with negative values
         index = interval_range(-10, 10)
         dtype = IntervalDtype("uint64")
-        with pytest.raises(ValueError):
+
+        # Until we decide what the exception message _should_ be, we
+        #  assert something that it should _not_ be.
+        #  We should _not_ be getting a message suggesting that the -10
+        #  has been wrapped around to a large-positive integer
+        msg = "^(?!(left side of interval must be <= right side))"
+        with pytest.raises(ValueError, match=msg):
             index.astype(dtype)
 
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
