### PR TITLE
CLN: always pass ndim to make_block

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -125,6 +125,15 @@ class Block(PandasObject):
         return obj
 
     def __init__(self, values, placement, ndim: int):
+        """
+        Parameters
+        ----------
+        values : np.ndarray or ExtensionArray
+        placement : BlockPlacement (or castable)
+        ndim : int
+            1 for SingleBlockManager/Series, 2 for BlockManager/DataFrame
+        """
+        # TODO(EA2D): ndim will be unnecessary with 2D EAs
         self.ndim = self._check_ndim(values, ndim)
         self.mgr_locs = placement
         self.values = self._maybe_coerce_values(values)

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -124,7 +124,7 @@ class Block(PandasObject):
         obj._mgr_locs = placement
         return obj
 
-    def __init__(self, values, placement, ndim=None):
+    def __init__(self, values, placement, ndim: int):
         self.ndim = self._check_ndim(values, ndim)
         self.mgr_locs = placement
         self.values = self._maybe_coerce_values(values)
@@ -1646,7 +1646,7 @@ class ExtensionBlock(Block):
 
     values: ExtensionArray
 
-    def __init__(self, values, placement, ndim=None):
+    def __init__(self, values, placement, ndim: int):
         """
         Initialize a non-consolidatable block.
 
@@ -2172,7 +2172,9 @@ class DatetimeLikeBlockMixin(Block):
         values = self.array_values().reshape(self.shape)
 
         new_values = values - values.shift(n, axis=axis)
-        return [TimeDeltaBlock(new_values, placement=self.mgr_locs.indexer)]
+        return [
+            TimeDeltaBlock(new_values, placement=self.mgr_locs.indexer, ndim=self.ndim)
+        ]
 
     def shift(self, periods, axis=0, fill_value=None):
         # TODO(EA2D) this is unnecessary if these blocks are backed by 2D EAs
@@ -2623,6 +2625,7 @@ def get_block_type(values, dtype=None):
     elif is_interval_dtype(dtype) or is_period_dtype(dtype):
         cls = ObjectValuesExtensionBlock
     elif is_extension_array_dtype(values.dtype):
+        # Note: need to be sure PandasArray is unwrapped before we get here
         cls = ExtensionBlock
     elif issubclass(vtype, np.floating):
         cls = FloatBlock

--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -82,6 +82,7 @@ def concatenate_block_managers(
             b = make_block(
                 _concatenate_join_units(join_units, concat_axis, copy=copy),
                 placement=placement,
+                ndim=len(axes),
             )
         blocks.append(b)
 

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -225,7 +225,8 @@ def init_ndarray(values, index, columns, dtype: Optional[DtypeObj], copy: bool):
 
             # TODO: What about re-joining object columns?
             block_values = [
-                make_block(dvals_list[n], placement=[n]) for n in range(len(dvals_list))
+                make_block(dvals_list[n], placement=[n], ndim=2)
+                for n in range(len(dvals_list))
             ]
 
         else:

--- a/pandas/tests/extension/test_external_block.py
+++ b/pandas/tests/extension/test_external_block.py
@@ -17,7 +17,7 @@ def df():
     df1 = pd.DataFrame({"a": [1, 2, 3]})
     blocks = df1._mgr.blocks
     values = np.arange(3, dtype="int64")
-    custom_block = CustomBlock(values, placement=slice(1, 2))
+    custom_block = CustomBlock(values, placement=slice(1, 2), ndim=2)
     blocks = blocks + (custom_block,)
     block_manager = BlockManager(blocks, [pd.Index(["a", "b"]), df1.index])
     return pd.DataFrame(block_manager)

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -267,7 +267,7 @@ class TestBlock:
     def test_split(self):
         # GH#37799
         values = np.random.randn(3, 4)
-        blk = make_block(values, placement=[3, 1, 6])
+        blk = make_block(values, placement=[3, 1, 6], ndim=2)
         result = blk._split()
 
         # check that we get views, not copies
@@ -276,9 +276,9 @@ class TestBlock:
 
         assert len(result) == 3
         expected = [
-            make_block(values[[0]], placement=[3]),
-            make_block(values[[1]], placement=[1]),
-            make_block(values[[2]], placement=[6]),
+            make_block(values[[0]], placement=[3], ndim=2),
+            make_block(values[[1]], placement=[1], ndim=2),
+            make_block(values[[2]], placement=[6], ndim=2),
         ]
         for res, exp in zip(result, expected):
             assert_block_equal(res, exp)
@@ -342,7 +342,9 @@ class TestBlockManager:
     def test_iget(self):
         cols = Index(list("abc"))
         values = np.random.rand(3, 3)
-        block = make_block(values=values.copy(), placement=np.arange(3))
+        block = make_block(
+            values=values.copy(), placement=np.arange(3), ndim=values.ndim
+        )
         mgr = BlockManager(blocks=[block], axes=[cols, np.arange(3)])
 
         tm.assert_almost_equal(mgr.iget(0).internal_values(), values[0])
@@ -1150,17 +1152,17 @@ def test_make_block_no_pandas_array():
     arr = pd.arrays.PandasArray(np.array([1, 2]))
 
     # PandasArray, no dtype
-    result = make_block(arr, slice(len(arr)))
+    result = make_block(arr, slice(len(arr)), ndim=arr.ndim)
     assert result.is_integer is True
     assert result.is_extension is False
 
     # PandasArray, PandasDtype
-    result = make_block(arr, slice(len(arr)), dtype=arr.dtype)
+    result = make_block(arr, slice(len(arr)), dtype=arr.dtype, ndim=arr.ndim)
     assert result.is_integer is True
     assert result.is_extension is False
 
     # ndarray, PandasDtype
-    result = make_block(arr.to_numpy(), slice(len(arr)), dtype=arr.dtype)
+    result = make_block(arr.to_numpy(), slice(len(arr)), dtype=arr.dtype, ndim=arr.ndim)
     assert result.is_integer is True
     assert result.is_extension is False
 


### PR DESCRIPTION
Found along the way that we can incorrectly put an ndarray[object] into an ExtensionBlock if we're not careful.  This will fix some of those, will make another branch that fixes the rest (with tests)