### PR TITLE
CLN: Use new hashtables in libindex to avoid casting

### DIFF
--- a/pandas/_libs/index_class_helper.pxi.in
+++ b/pandas/_libs/index_class_helper.pxi.in
@@ -10,21 +10,21 @@ WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
 
 {{py:
 
-# name, dtype, hashtable_name
-dtypes = [('Float64', 'float64', 'Float64'),
-          ('Float32', 'float32', 'Float64'),
-          ('Int64', 'int64', 'Int64'),
-          ('Int32', 'int32', 'Int64'),
-          ('Int16', 'int16', 'Int64'),
-          ('Int8', 'int8', 'Int64'),
-          ('UInt64', 'uint64', 'UInt64'),
-          ('UInt32', 'uint32', 'UInt64'),
-          ('UInt16', 'uint16', 'UInt64'),
-          ('UInt8', 'uint8', 'UInt64'),
+# name, dtype
+dtypes = [('Float64', 'float64'),
+          ('Float32', 'float32'),
+          ('Int64', 'int64'),
+          ('Int32', 'int32'),
+          ('Int16', 'int16'),
+          ('Int8', 'int8'),
+          ('UInt64', 'uint64'),
+          ('UInt32', 'uint32'),
+          ('UInt16', 'uint16'),
+          ('UInt8', 'uint8'),
           ]
 }}
 
-{{for name, dtype, hashtable_name in dtypes}}
+{{for name, dtype in dtypes}}
 
 
 cdef class {{name}}Engine(IndexEngine):
@@ -32,7 +32,7 @@ cdef class {{name}}Engine(IndexEngine):
     #  returns an ndarray with dtype {{dtype}}_t
 
     cdef _make_hash_table(self, Py_ssize_t n):
-        return _hash.{{hashtable_name}}HashTable(n)
+        return _hash.{{name}}HashTable(n)
 
     {{if name not in {'Float64', 'Float32'} }}
     cdef _check_type(self, object val):
@@ -41,9 +41,7 @@ cdef class {{name}}Engine(IndexEngine):
     {{endif}}
 
     cdef void _call_map_locations(self, values):
-        # self.mapping is of type {{hashtable_name}}HashTable,
-        # so convert dtype of values
-        self.mapping.map_locations(algos.ensure_{{hashtable_name.lower()}}(values))
+        self.mapping.map_locations(algos.ensure_{{name.lower()}}(values))
 
     cdef _maybe_get_bool_indexer(self, object val):
         cdef:


### PR DESCRIPTION
Small, hard-to-measure perf improvement, since it only makes a difference on the first lookup:

```
In [2]: rng = pd.Index(range(50)).repeat(20).astype("category")
In [14]: %timeit rng._engine.clear_mapping(); rng.get_loc(40)
24.8 µs ± 624 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)  # <-- master
21.3 µs ± 296 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)  # <-- PR

```