### PR TITLE
REF: ensure_arraylike in algos.isin

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -218,7 +218,8 @@ def _ensure_arraylike(values):
     """
     if not is_array_like(values):
         inferred = lib.infer_dtype(values, skipna=False)
-        if inferred in ["mixed", "string"]:
+        if inferred in ["mixed", "string", "mixed-integer"]:
+            # "mixed-integer" to ensure we do not cast ["ss", 42] to str GH#22160
             if isinstance(values, tuple):
                 values = list(values)
             values = construct_1d_object_array_from_listlike(values)
@@ -424,6 +425,7 @@ def isin(comps: AnyArrayLike, values: AnyArrayLike) -> np.ndarray:
         values = construct_1d_object_array_from_listlike(list(values))
         # TODO: could use ensure_arraylike here
 
+    comps = _ensure_arraylike(comps)
     comps = extract_array(comps, extract_numpy=True)
     if is_categorical_dtype(comps):
         # TODO(extension)


### PR DESCRIPTION
This is one of two places where we do not explicitly call ensure_arraylike before ensure_data.  Once I get the other one sorted out, we can annotate _ensure_data and others.