### PR TITLE
Using os.PathLike instead of pathlib.Path (#37979)

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, tzinfo
 from io import BufferedIOBase, RawIOBase, TextIOBase, TextIOWrapper
 from mmap import mmap
-from pathlib import Path
+from os import PathLike
 from typing import (
     IO,
     TYPE_CHECKING,
@@ -135,7 +135,7 @@ AggObjType = Union[
 # filenames and file-like-objects
 Buffer = Union[IO[AnyStr], RawIOBase, BufferedIOBase, TextIOBase, TextIOWrapper, mmap]
 FileOrBuffer = Union[str, Buffer[T]]
-FilePathOrBuffer = Union[Path, FileOrBuffer[T]]
+FilePathOrBuffer = Union["PathLike[str]", FileOrBuffer[T]]
 
 # for arbitrary kwargs passed during reading/writing files
 StorageOptions = Optional[Dict[str, Any]]

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -7,7 +7,6 @@ import gzip
 from io import BufferedIOBase, BytesIO, RawIOBase, TextIOWrapper
 import mmap
 import os
-from os import PathLike
 from typing import IO, Any, AnyStr, Dict, List, Mapping, Optional, Tuple, cast
 from urllib.parse import (
     urljoin,
@@ -176,19 +175,8 @@ def stringify_path(
     Any other object is passed through unchanged, which includes bytes,
     strings, buffers, or anything else that's not even path-like.
     """
-    if hasattr(filepath_or_buffer, "__fspath__"):
-        # https://github.com/python/mypy/issues/1424
-        # error: Item "str" of "Union[str, Path, IO[str]]" has no attribute
-        # "__fspath__"  [union-attr]
-        # error: Item "IO[str]" of "Union[str, Path, IO[str]]" has no attribute
-        # "__fspath__"  [union-attr]
-        # error: Item "str" of "Union[str, Path, IO[bytes]]" has no attribute
-        # "__fspath__"  [union-attr]
-        # error: Item "IO[bytes]" of "Union[str, Path, IO[bytes]]" has no
-        # attribute "__fspath__"  [union-attr]
-        filepath_or_buffer = filepath_or_buffer.__fspath__()  # type: ignore[union-attr]
-    elif isinstance(filepath_or_buffer, PathLike):
-        filepath_or_buffer = str(filepath_or_buffer)
+    if isinstance(filepath_or_buffer, os.PathLike):
+        filepath_or_buffer = filepath_or_buffer.__fspath__()
     return _expand_user(filepath_or_buffer)
 
 

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -7,7 +7,7 @@ import gzip
 from io import BufferedIOBase, BytesIO, RawIOBase, TextIOWrapper
 import mmap
 import os
-import pathlib
+from os import PathLike
 from typing import IO, Any, AnyStr, Dict, List, Mapping, Optional, Tuple, cast
 from urllib.parse import (
     urljoin,
@@ -187,7 +187,7 @@ def stringify_path(
         # error: Item "IO[bytes]" of "Union[str, Path, IO[bytes]]" has no
         # attribute "__fspath__"  [union-attr]
         filepath_or_buffer = filepath_or_buffer.__fspath__()  # type: ignore[union-attr]
-    elif isinstance(filepath_or_buffer, pathlib.Path):
+    elif isinstance(filepath_or_buffer, PathLike):
         filepath_or_buffer = str(filepath_or_buffer)
     return _expand_user(filepath_or_buffer)
 


### PR DESCRIPTION
- [x] closes #37979 
- [x] tests passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Replaces `pathlib.Path` with `os.PathLike` to bring behaviour further in-line with the [documentation](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html)