### PR TITLE
ENH: support 2D in DatetimeArray._from_sequence

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2065,20 +2065,24 @@ def objects_to_datetime64ns(
     # if str-dtype, convert
     data = np.array(data, copy=False, dtype=np.object_)
 
+    flags = data.flags
+    order = "F" if flags.f_contiguous else "C"
     try:
         result, tz_parsed = tslib.array_to_datetime(
-            data,
+            data.ravel("K"),
             errors=errors,
             utc=utc,
             dayfirst=dayfirst,
             yearfirst=yearfirst,
             require_iso8601=require_iso8601,
         )
+        result = result.reshape(data.shape, order=order)
     except ValueError as e:
         try:
-            values, tz_parsed = conversion.datetime_to_datetime64(data)
+            values, tz_parsed = conversion.datetime_to_datetime64(data.ravel("K"))
             # If tzaware, these values represent unix timestamps, so we
             #  return them as i8 to distinguish from wall times
+            values = values.reshape(data.shape, order=order)
             return values.view("i8"), tz_parsed
         except (ValueError, TypeError):
             raise e

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -465,6 +465,24 @@ class TestSequenceToDT64NS:
         result, _, _ = sequence_to_dt64ns(arr, dtype=DatetimeTZDtype(tz="US/Central"))
         tm.assert_numpy_array_equal(arr._data, result)
 
+    @pytest.mark.parametrize("order", ["F", "C"])
+    def test_2d(self, order):
+        dti = pd.date_range("2016-01-01", periods=6, tz="US/Pacific")
+        arr = np.array(dti, dtype=object).reshape(3, 2)
+        if order == "F":
+            arr = arr.T
+
+        res = sequence_to_dt64ns(arr)
+        expected = sequence_to_dt64ns(arr.ravel())
+
+        tm.assert_numpy_array_equal(res[0].ravel(), expected[0])
+        assert res[1] == expected[1]
+        assert res[2] == expected[2]
+
+        res = DatetimeArray._from_sequence(arr)
+        expected = DatetimeArray._from_sequence(arr.ravel()).reshape(arr.shape)
+        tm.assert_datetime_array_equal(res, expected)
+
 
 class TestReductions:
     @pytest.fixture


### PR DESCRIPTION
Broken off from a branch that fixes #37682, the constraint on which is that _validate_setitem_value needs to handle 2D.