### PR TITLE
BUG: unstack with missing levels results in incorrect index names

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -697,8 +697,6 @@ Indexing
 - Bug in setting a new label on a :class:`DataFrame` or :class:`Series` with a :class:`CategoricalIndex` incorrectly raising ``TypeError`` when the new label is not among the index's categories (:issue:`38098`)
 - Bug in :meth:`Series.loc` and :meth:`Series.iloc` raising ``ValueError`` when inserting a listlike ``np.array``, ``list`` or ``tuple`` in an ``object`` Series of equal length (:issue:`37748`, :issue:`37486`)
 - Bug in :meth:`Series.loc` and :meth:`Series.iloc` setting all the values of an ``object`` Series with those of a listlike ``ExtensionArray`` instead of inserting it (:issue:`38271`)
-- Bug in :meth:`MultiIndex.remove_unused_levels` drops NaN when level contains NaN (:issue:`37510`)
-- Bug in :meth:`MultiIndex.remove_unused_levels` was dropping missing values when levels contain ``NaN`` which set by ``set_levels`` (:issue:`37510`)
 
 Missing
 ^^^^^^^

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -689,6 +689,7 @@ Indexing
 - Bug in :meth:`DataFrame.iloc` and :meth:`Series.iloc` aligning objects in ``__setitem__`` (:issue:`22046`)
 - Bug in :meth:`MultiIndex.drop` does not raise if labels are partially found (:issue:`37820`)
 - Bug in :meth:`DataFrame.loc` did not raise ``KeyError`` when missing combination was given with ``slice(None)`` for remaining levels (:issue:`19556`)
+- Bug in :meth:`MultiIndex.remove_unused_levels` was dropping missing values when levels contain ``NaN`` set by ``set_levels`` (:issue:`37510`)
 - Bug in :meth:`DataFrame.loc` raising ``TypeError`` when non-integer slice was given to select values from :class:`MultiIndex` (:issue:`25165`, :issue:`24263`)
 - Bug in :meth:`Series.at` returning :class:`Series` with one element instead of scalar when index is a :class:`MultiIndex` with one level (:issue:`38053`)
 - Bug in :meth:`DataFrame.loc` returning and assigning elements in wrong order when indexer is differently ordered than the :class:`MultiIndex` to filter (:issue:`31330`, :issue:`34603`)

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -829,7 +829,6 @@ Reshaping
 - Bug in :func:`merge_ordered` returned wrong join result when length of ``left_by`` or ``right_by`` equals to the rows of ``left`` or ``right`` (:issue:`38166`)
 - Bug in :func:`merge_ordered` didn't raise when elements in ``left_by`` or ``right_by`` not exist in ``left`` columns or ``right`` columns (:issue:`38167`)
 - Bug in :func:`DataFrame.drop_duplicates` not validating bool dtype for ``ignore_index`` keyword (:issue:`38274`)
-- Bug in :meth:`DataFrame.unstack` with missing levels led to incorrect index names (:issue:`37510`)
 
 Sparse
 ^^^^^^

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -697,6 +697,7 @@ Indexing
 - Bug in setting a new label on a :class:`DataFrame` or :class:`Series` with a :class:`CategoricalIndex` incorrectly raising ``TypeError`` when the new label is not among the index's categories (:issue:`38098`)
 - Bug in :meth:`Series.loc` and :meth:`Series.iloc` raising ``ValueError`` when inserting a listlike ``np.array``, ``list`` or ``tuple`` in an ``object`` Series of equal length (:issue:`37748`, :issue:`37486`)
 - Bug in :meth:`Series.loc` and :meth:`Series.iloc` setting all the values of an ``object`` Series with those of a listlike ``ExtensionArray`` instead of inserting it (:issue:`38271`)
+- Bug in :meth:`MultiIndex.remove_unused_levels` drops NaN when level contains NaN (:issue:`37510`)
 
 Missing
 ^^^^^^^

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -698,6 +698,7 @@ Indexing
 - Bug in :meth:`Series.loc` and :meth:`Series.iloc` raising ``ValueError`` when inserting a listlike ``np.array``, ``list`` or ``tuple`` in an ``object`` Series of equal length (:issue:`37748`, :issue:`37486`)
 - Bug in :meth:`Series.loc` and :meth:`Series.iloc` setting all the values of an ``object`` Series with those of a listlike ``ExtensionArray`` instead of inserting it (:issue:`38271`)
 - Bug in :meth:`MultiIndex.remove_unused_levels` drops NaN when level contains NaN (:issue:`37510`)
+- Bug in :meth:`MultiIndex.remove_unused_levels` was dropping missing values when levels contain ``NaN`` which set by ``set_levels`` (:issue:`37510`)
 
 Missing
 ^^^^^^^

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -689,7 +689,6 @@ Indexing
 - Bug in :meth:`DataFrame.iloc` and :meth:`Series.iloc` aligning objects in ``__setitem__`` (:issue:`22046`)
 - Bug in :meth:`MultiIndex.drop` does not raise if labels are partially found (:issue:`37820`)
 - Bug in :meth:`DataFrame.loc` did not raise ``KeyError`` when missing combination was given with ``slice(None)`` for remaining levels (:issue:`19556`)
-- Bug in :meth:`MultiIndex.remove_unused_levels` was dropping missing values when levels contain ``NaN`` set by ``set_levels`` (:issue:`37510`)
 - Bug in :meth:`DataFrame.loc` raising ``TypeError`` when non-integer slice was given to select values from :class:`MultiIndex` (:issue:`25165`, :issue:`24263`)
 - Bug in :meth:`Series.at` returning :class:`Series` with one element instead of scalar when index is a :class:`MultiIndex` with one level (:issue:`38053`)
 - Bug in :meth:`DataFrame.loc` returning and assigning elements in wrong order when indexer is differently ordered than the :class:`MultiIndex` to filter (:issue:`31330`, :issue:`34603`)
@@ -830,6 +829,7 @@ Reshaping
 - Bug in :func:`merge_ordered` returned wrong join result when length of ``left_by`` or ``right_by`` equals to the rows of ``left`` or ``right`` (:issue:`38166`)
 - Bug in :func:`merge_ordered` didn't raise when elements in ``left_by`` or ``right_by`` not exist in ``left`` columns or ``right`` columns (:issue:`38167`)
 - Bug in :func:`DataFrame.drop_duplicates` not validating bool dtype for ``ignore_index`` keyword (:issue:`38274`)
+- Bug in :meth:`DataFrame.unstack` with missing levels led to incorrect index names (:issue:`37510`)
 
 Sparse
 ^^^^^^

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -267,7 +267,7 @@ Groupby/resample/rolling
 Reshaping
 ^^^^^^^^^
 
--
+- Bug in :meth:`DataFrame.unstack` with missing levels led to incorrect index names (:issue:`37510`)
 -
 
 Sparse

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1980,7 +1980,7 @@ class MultiIndex(Index):
 
             if len(uniques) != len(lev) + has_na:
 
-                if -1 in level_codes and len(uniques) == len(lev):
+                if lev.isna().any() and len(uniques) == len(lev):
                     break
                 # We have unused levels
                 changed = True

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1979,6 +1979,9 @@ class MultiIndex(Index):
             has_na = int(len(uniques) and (uniques[0] == -1))
 
             if len(uniques) != len(lev) + has_na:
+
+                if None in lev and len(uniques) == len(lev):
+                    break
                 # We have unused levels
                 changed = True
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1980,7 +1980,7 @@ class MultiIndex(Index):
 
             if len(uniques) != len(lev) + has_na:
 
-                if None in lev and len(uniques) == len(lev):
+                if -1 in level_codes and len(uniques) == len(lev):
                     break
                 # We have unused levels
                 changed = True

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -1907,3 +1907,27 @@ Thur,Lunch,Yes,51.51,17"""
             ),
         )
         tm.assert_frame_equal(result, expected)
+
+    def test_unstack_with_level_has_nan(self):
+        # GH 37510
+        df1 = DataFrame(
+            {
+                "L1": [1, 2, 3, 4],
+                "L2": [3, 4, 1, 2],
+                "L3": [1, 1, 1, 1],
+                "x": [1, 2, 3, 4],
+            }
+        )
+        df1 = df1.set_index(["L1", "L2", "L3"])
+        new_levels = ["n1", "n2", "n3", None]
+        df1.index = df1.index.set_levels(levels=new_levels, level="L1")
+        df1.index = df1.index.set_levels(levels=new_levels, level="L2")
+
+        result = df1.unstack("L3")[("x", 1)].sort_index().index
+        expected = MultiIndex(
+            levels=[["n1", "n2", "n3", None], ["n1", "n2", "n3", None]],
+            codes=[[0, 1, 2, 3], [2, 3, 0, 1]],
+            names=["L1", "L2"],
+        )
+
+        tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -292,7 +292,7 @@ def test_remove_unused_levels_with_missing():
     expected = MultiIndex(
         levels=[["n1", "n2", "n3", None], ["n1", "n2", "n3", None]],
         codes=[[0, 1, 2, 3], [2, 3, 0, 1]],
-        names=["L1", "L2"]
+        names=["L1", "L2"],
     )
 
     tm.assert_index_equal(result.index, expected)

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -271,3 +271,21 @@ def test_argsort(idx):
     result = idx.argsort()
     expected = idx.values.argsort()
     tm.assert_numpy_array_equal(result, expected)
+
+
+def test_not_remove_nan():
+    # GH 37510
+    df1 = DataFrame({"id1": [1, 2, 3, 4],
+                     "id2": [3, 4, 1, 2],
+                     "id3": [1, 1, 1, 1],
+                     "x": [1, 2, 3, 4]})
+    df1.set_index(["id1", "id2", "id3"], inplace=True)
+
+    new_levels = ["n1", "n2", "n3", None]
+    df1.index = df1.index.set_levels(levels=new_levels, level="id1", inplace=True)
+    df1.index = df1.index.set_levels(levels=new_levels, level="id2", inplace=True)
+
+    result = df1.unstack("id3")[("x", 1)].sort_index().index
+    expected = df1.droplevel(2, 0).sort_index().index
+
+    assert result.equals(expected)

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -295,4 +295,4 @@ def test_remove_unused_levels_with_missing():
         names=["L1", "L2"],
     )
 
-    tm.assert_index_equal(result.index, expected)
+    tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -276,7 +276,7 @@ def test_argsort(idx):
 
 def test_remove_unused_levels_with_nan():
     # GH 37510
-    idx = Index([(1, np.nan), (3, 4)], names=["id1", "id2"])
+    idx = Index([(1, np.nan), (3, 4)]).rename(["id1", "id2"])
     idx = idx.set_levels(["a", np.nan], level="id1")
     idx = idx.remove_unused_levels()
     result = idx.levels

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -290,10 +290,7 @@ def test_remove_unused_levels_with_missing():
 
     result = df1.unstack("L3")[("x", 1)].sort_index().index
     expected_index = Index(
-        [
-            ("n1", "n3"), ("n2", np.nan), ("n3", "n1"), ( np.nan, "n2")
-        ],
-        names=["L1", "L2"]
+        [("n1", "n3"), ("n2", np.nan), ("n3", "n1"), (np.nan, "n2")], names=["L1", "L2"]
     )
 
     tm.assert_index_equal(result.index, expected_index)

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -5,9 +5,9 @@ import pytest
 
 from pandas.errors import PerformanceWarning, UnsortedIndexError
 
-from pandas.core.indexes.frozen import FrozenList
 from pandas import CategoricalIndex, DataFrame, Index, MultiIndex, RangeIndex
 import pandas._testing as tm
+from pandas.core.indexes.frozen import FrozenList
 
 
 def test_sortlevel(idx):
@@ -280,5 +280,5 @@ def test_remove_unused_levels_with_nan():
     idx = idx.set_levels(["a", np.nan], level="id1")
     idx = idx.remove_unused_levels()
     result = idx.levels
-    expected = FrozenList([['a', np.nan], [4]])
+    expected = FrozenList([["a", np.nan], [4]])
     assert str(result) == str(expected)

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -288,7 +288,7 @@ def test_remove_unused_levels_with_missing():
     df1.index = df1.index.set_levels(levels=new_levels, level="L1")
     df1.index = df1.index.set_levels(levels=new_levels, level="L2")
 
-    result = df1.unstack("L3")[("x", 1)].sort_index().index
+    result = df1.unstack("L3")[("x", 1)].sort_index()
     expected_index = Index(
         [("n1", "n3"), ("n2", np.nan), ("n3", "n1"), (np.nan, "n2")], names=["L1", "L2"]
     )

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -291,4 +291,4 @@ def test_remove_unused_levels_with_missing():
     result = df1.unstack("L3")[("x", 1)].sort_index().index
     expected = df1.droplevel(2, 0).sort_index().index
 
-    assert tm.assert_index_equal(result, expected)
+    tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -275,15 +275,18 @@ def test_argsort(idx):
 
 def test_not_remove_nan():
     # GH 37510
-    df1 = DataFrame({"id1": [1, 2, 3, 4],
-                     "id2": [3, 4, 1, 2],
-                     "id3": [1, 1, 1, 1],
-                     "x": [1, 2, 3, 4]})
-    df1.set_index(["id1", "id2", "id3"], inplace=True)
-
+    df1 = DataFrame(
+        {
+            "id1": [1, 2, 3, 4],
+            "id2": [3, 4, 1, 2],
+            "id3": [1, 1, 1, 1],
+            "x": [1, 2, 3, 4],
+        }
+    )
+    df1 = df1.set_index(["id1", "id2", "id3"])
     new_levels = ["n1", "n2", "n3", None]
-    df1.index = df1.index.set_levels(levels=new_levels, level="id1", inplace=True)
-    df1.index = df1.index.set_levels(levels=new_levels, level="id2", inplace=True)
+    df1.index = df1.index.set_levels(levels=new_levels, level="id1")
+    df1.index = df1.index.set_levels(levels=new_levels, level="id2")
 
     result = df1.unstack("id3")[("x", 1)].sort_index().index
     expected = df1.droplevel(2, 0).sort_index().index

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -289,12 +289,13 @@ def test_remove_unused_levels_with_missing():
     df1.index = df1.index.set_levels(levels=new_levels, level="L2")
 
     result = df1.unstack("L3")[("x", 1)].sort_index()
-    expected_index = Index(
-        [("n1", "n3"), ("n2", np.nan), ("n3", "n1"), (np.nan, "n2")], names=["L1", "L2"]
-    ).set_levels(
-        levels=new_levels, level="L1"
-    ).set_levels(
-        levels=new_levels, level="L2"
+    expected_index = (
+        Index(
+            [("n1", "n3"), ("n2", np.nan), ("n3", "n1"), (np.nan, "n2")],
+            names=["L1", "L2"],
+        )
+        .set_levels(levels=new_levels, level="L1")
+        .set_levels(levels=new_levels, level="L2")
     )
 
     tm.assert_index_equal(result.index, expected_index)

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -291,6 +291,10 @@ def test_remove_unused_levels_with_missing():
     result = df1.unstack("L3")[("x", 1)].sort_index()
     expected_index = Index(
         [("n1", "n3"), ("n2", np.nan), ("n3", "n1"), (np.nan, "n2")], names=["L1", "L2"]
+    ).set_levels(
+        levels=new_levels, level="L1"
+    ).set_levels(
+        levels=new_levels, level="L2"
     )
 
     tm.assert_index_equal(result.index, expected_index)

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -288,14 +288,11 @@ def test_remove_unused_levels_with_missing():
     df1.index = df1.index.set_levels(levels=new_levels, level="L1")
     df1.index = df1.index.set_levels(levels=new_levels, level="L2")
 
-    result = df1.unstack("L3")[("x", 1)].sort_index()
-    expected_index = (
-        Index(
-            [("n1", "n3"), ("n2", np.nan), ("n3", "n1"), (np.nan, "n2")],
-            names=["L1", "L2"],
-        )
-        .set_levels(levels=new_levels, level="L1")
-        .set_levels(levels=new_levels, level="L2")
+    result = df1.unstack("L3")[("x", 1)].sort_index().index
+    expected = MultiIndex(
+        levels=[["n1", "n2", "n3", None], ["n1", "n2", "n3", None]],
+        codes=[[0, 1, 2, 3], [2, 3, 0, 1]],
+        names=["L1", "L2"]
     )
 
-    tm.assert_index_equal(result.index, expected_index)
+    tm.assert_index_equal(result.index, expected)

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -273,22 +273,22 @@ def test_argsort(idx):
     tm.assert_numpy_array_equal(result, expected)
 
 
-def test_not_remove_nan():
+def test_remove_unused_levels_with_missing():
     # GH 37510
     df1 = DataFrame(
         {
-            "id1": [1, 2, 3, 4],
-            "id2": [3, 4, 1, 2],
-            "id3": [1, 1, 1, 1],
+            "L1": [1, 2, 3, 4],
+            "L2": [3, 4, 1, 2],
+            "L3": [1, 1, 1, 1],
             "x": [1, 2, 3, 4],
         }
     )
-    df1 = df1.set_index(["id1", "id2", "id3"])
+    df1 = df1.set_index(["L1", "L2", "L3"])
     new_levels = ["n1", "n2", "n3", None]
-    df1.index = df1.index.set_levels(levels=new_levels, level="id1")
-    df1.index = df1.index.set_levels(levels=new_levels, level="id2")
+    df1.index = df1.index.set_levels(levels=new_levels, level="L1")
+    df1.index = df1.index.set_levels(levels=new_levels, level="L2")
 
-    result = df1.unstack("id3")[("x", 1)].sort_index().index
+    result = df1.unstack("L3")[("x", 1)].sort_index().index
     expected = df1.droplevel(2, 0).sort_index().index
 
-    assert result.equals(expected)
+    assert tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -289,6 +289,11 @@ def test_remove_unused_levels_with_missing():
     df1.index = df1.index.set_levels(levels=new_levels, level="L2")
 
     result = df1.unstack("L3")[("x", 1)].sort_index().index
-    expected = df1.droplevel(2, 0).sort_index().index
+    expected_index = Index(
+        [
+            ("n1", "n3"), ("n2", np.nan), ("n3", "n1"), ( np.nan, "n2")
+        ],
+        names=["L1", "L2"]
+    )
 
-    tm.assert_index_equal(result, expected)
+    tm.assert_index_equal(result.index, expected_index)


### PR DESCRIPTION
- [x] closes #37510
- [x] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
