### PR TITLE
Backport PR #37986 on branch 1.1.x: REGR: fix inplace operations for EAs with non-EA arg

### DIFF
--- a/doc/source/whatsnew/v1.1.5.rst
+++ b/doc/source/whatsnew/v1.1.5.rst
@@ -17,7 +17,7 @@ Fixed regressions
 - Regression in addition of a timedelta-like scalar to a :class:`DatetimeIndex` raising incorrectly (:issue:`37295`)
 - Fixed regression in :meth:`Series.groupby` raising when the :class:`Index` of the :class:`Series` had a tuple as its name (:issue:`37755`)
 - Fixed regression in :meth:`DataFrame.loc` and :meth:`Series.loc` for ``__setitem__`` when one-dimensional tuple was given to select from :class:`MultiIndex` (:issue:`37711`)
--
+- Fixed regression in inplace operations on :class:`Series` with ``ExtensionDtype`` with NumPy dtyped operand (:issue:`37910`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/ops/methods.py
+++ b/pandas/core/ops/methods.py
@@ -3,6 +3,7 @@ Functions to generate methods and pin them to the appropriate classes.
 """
 import operator
 
+from pandas.core.dtypes.common import is_dtype_equal
 from pandas.core.dtypes.generic import ABCDataFrame, ABCSeries
 
 from pandas.core.ops.roperator import (
@@ -97,7 +98,7 @@ def add_special_arithmetic_methods(cls):
             if (
                 self.ndim == 1
                 and result._indexed_same(self)
-                and result.dtype == self.dtype
+                and is_dtype_equal(result.dtype, self.dtype)
             ):
                 # GH#36498 this inplace op can _actually_ be inplace.
                 self._values[:] = result._values

--- a/pandas/tests/scalar/timedelta/test_arithmetic.py
+++ b/pandas/tests/scalar/timedelta/test_arithmetic.py
@@ -429,6 +429,7 @@ class TestTimedeltaMultiplicationDivision:
                     _is_numpy_dev and not compat.PY39,
                     raises=RuntimeWarning,
                     reason="https://github.com/pandas-dev/pandas/issues/31992",
+                    strict=False,
                 ),
             ),
             float("nan"),

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -687,3 +687,30 @@ class TestTimeSeriesArithmetic:
         result = series - offset
         expected = pd.Series(pd.to_datetime(["2011-12-26", "2011-12-27", "2011-12-28"]))
         tm.assert_series_equal(result, expected)
+
+
+class TestInplaceOperations:
+    @pytest.mark.parametrize(
+        "dtype1, dtype2, dtype_expected, dtype_mul",
+        (
+            ("Int64", "Int64", "Int64", "Int64"),
+            ("float", "float", "float", "float"),
+            ("Int64", "float", "float", "float"),
+        ),
+    )
+    def test_series_inplace_ops(self, dtype1, dtype2, dtype_expected, dtype_mul):
+        # GH 37910
+
+        ser1 = Series([1], dtype=dtype1)
+        ser2 = Series([2], dtype=dtype2)
+        ser1 += ser2
+        expected = Series([3], dtype=dtype_expected)
+        tm.assert_series_equal(ser1, expected)
+
+        ser1 -= ser2
+        expected = Series([1], dtype=dtype_expected)
+        tm.assert_series_equal(ser1, expected)
+
+        ser1 *= ser2
+        expected = Series([2], dtype=dtype_mul)
+        tm.assert_series_equal(ser1, expected)


### PR DESCRIPTION
Backport PR #37986