### PR TITLE
BUG: pytables in py39

### DIFF
--- a/ci/deps/azure-39.yaml
+++ b/ci/deps/azure-39.yaml
@@ -18,3 +18,5 @@ dependencies:
 
   # optional dependencies
   - pytables
+  - scipy
+  - pyarrow=1.0

--- a/ci/deps/azure-39.yaml
+++ b/ci/deps/azure-39.yaml
@@ -15,3 +15,6 @@ dependencies:
   - numpy
   - python-dateutil
   - pytz
+
+  # optional dependencies
+  - pytables

--- a/doc/source/whatsnew/v1.1.5.rst
+++ b/doc/source/whatsnew/v1.1.5.rst
@@ -28,6 +28,7 @@ Bug fixes
 - Bug in metadata propagation for ``groupby`` iterator (:issue:`37343`)
 - Bug in indexing on a :class:`Series` with ``CategoricalDtype`` after unpickling (:issue:`37631`)
 - Bug in :class:`RollingGroupby` with the resulting :class:`MultiIndex` when grouping by a label that is in the index (:issue:`37641`)
+- Bug in pytables methods in python 3.9 (:issue:`38041`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -430,6 +430,10 @@ class PyTablesExprVisitor(BaseExprVisitor):
         except AttributeError:
             pass
 
+        if isinstance(slobj, Term):
+            # In py39 np.ndarray lookups with Term containing int raise
+            slobj = slobj.value
+
         try:
             return self.const_type(value[slobj], self.env)
         except TypeError as err:

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -4462,7 +4462,7 @@ class TestHDFStore:
 
             # Appending must have the same categories
             df3 = df.copy()
-            df3["s"].cat.remove_unused_categories(inplace=True)
+            df3["s"] = df3["s"].cat.remove_unused_categories()
 
             with pytest.raises(ValueError):
                 store.append("df3", df3)


### PR DESCRIPTION
There are failures I'm getting locally since homebrew bumped up to py39.  I'm not seeing them on the CI, but they _did_ appear around the same time as these [different](https://dev.azure.com/pandas-dev/pandas/_build/results?buildId=48423&view=logs&j=2d7fb38a-2053-50f3-a67c-09f6e91d3121&t=449937cc-3d50-56b5-5662-e489f41f1268) unexplained pytables failures started showing up.