### PR TITLE
CI: Renable window tests on Windows

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -25,7 +25,7 @@ PYTEST_CMD="${XVFB}pytest -m \"$PATTERN\" -n $PYTEST_WORKERS --dist=loadfile -s 
 if [[ $(uname) != "Linux"  && $(uname) != "Darwin" ]]; then
     # GH#37455 windows py38 build appears to be running out of memory
     #  skip collection of window tests
-    PYTEST_CMD="$PYTEST_CMD --ignore=pandas/tests/window/ --ignore=pandas/tests/plotting/"
+    PYTEST_CMD="$PYTEST_CMD --ignore=pandas/tests/plotting/"
 fi
 
 echo $PYTEST_CMD


### PR DESCRIPTION
- [x] closes #37535
- [ ] tests added / passed

Checking if the recent cleanup of the `tests/window` directory had any impact.
