### PR TITLE
PERF: fix regression in tz_convert_from_utc

### DIFF
--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -426,7 +426,7 @@ def tz_convert_from_utc(const int64_t[:] vals, tzinfo tz):
     int64 ndarray of converted
     """
     cdef:
-        int64_t[:] converted
+        const int64_t[:] converted
 
     if len(vals) == 0:
         return np.array([], dtype=np.int64)
@@ -437,7 +437,7 @@ def tz_convert_from_utc(const int64_t[:] vals, tzinfo tz):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef int64_t[:] _tz_convert_from_utc(const int64_t[:] vals, tzinfo tz):
+cdef const int64_t[:] _tz_convert_from_utc(const int64_t[:] vals, tzinfo tz):
     """
     Convert the given values (in i8) either to UTC or from UTC.
 
@@ -459,7 +459,7 @@ cdef int64_t[:] _tz_convert_from_utc(const int64_t[:] vals, tzinfo tz):
         str typ
 
     if is_utc(tz):
-        converted = vals.copy()
+        return vals
     elif is_tzlocal(tz):
         converted = np.empty(n, dtype=np.int64)
         for i in range(n):


### PR DESCRIPTION
- [x] closes #35803 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry - N/A I believe

Get rid of an unnecessary copy.