### PR TITLE
BUG: merge_ordered fails with list-like left_by or right_by

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -737,6 +737,7 @@ Reshaping
 - Bug in :meth:`DataFrame.apply` not setting index of return value when ``func`` return type is ``dict`` (:issue:`37544`)
 - Bug in :func:`concat` resulting in a ``ValueError`` when at least one of both inputs had a non-unique index (:issue:`36263`)
 - Bug in :meth:`DataFrame.merge` and :meth:`pandas.merge` returning inconsistent ordering in result for ``how=right`` and ``how=left`` (:issue:`35382`)
+- Bug in :func:`merge_ordered` wasn't able to handle list-like ``left_by`` or ``right_by`` (:issue:`35269`)
 
 Sparse
 ^^^^^^

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -737,7 +737,7 @@ Reshaping
 - Bug in :meth:`DataFrame.apply` not setting index of return value when ``func`` return type is ``dict`` (:issue:`37544`)
 - Bug in :func:`concat` resulting in a ``ValueError`` when at least one of both inputs had a non-unique index (:issue:`36263`)
 - Bug in :meth:`DataFrame.merge` and :meth:`pandas.merge` returning inconsistent ordering in result for ``how=right`` and ``how=left`` (:issue:`35382`)
-- Bug in :func:`merge_ordered` wasn't able to handle list-like ``left_by`` or ``right_by`` (:issue:`35269`)
+- Bug in :func:`merge_ordered` couldn't handle list-like ``left_by`` or ``right_by`` (:issue:`35269`)
 
 Sparse
 ^^^^^^

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -737,7 +737,7 @@ Reshaping
 - Bug in :meth:`DataFrame.apply` not setting index of return value when ``func`` return type is ``dict`` (:issue:`37544`)
 - Bug in :func:`concat` resulting in a ``ValueError`` when at least one of both inputs had a non-unique index (:issue:`36263`)
 - Bug in :meth:`DataFrame.merge` and :meth:`pandas.merge` returning inconsistent ordering in result for ``how=right`` and ``how=left`` (:issue:`35382`)
-- Bug in :func:`merge_ordered` couldn't handle list-like ``left_by`` or ``right_by`` (:issue:`35269`)
+- Bug in :func:`merge_ordered` wasn't able to handle list-like ``left_by`` or ``right_by`` (:issue:`35269`)
 
 Sparse
 ^^^^^^

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -140,9 +140,7 @@ def _groupby_and_merge(by, on, left: "DataFrame", right: "DataFrame", merge_piec
 
         # make sure join keys are in the merged
         # TODO, should merge_pieces do this?
-        for k in by:
-            if k in merged:
-                merged[k] = key
+        merged[by] = key
 
         pieces.append(merged)
 

--- a/pandas/tests/reshape/merge/test_merge_ordered.py
+++ b/pandas/tests/reshape/merge/test_merge_ordered.py
@@ -124,13 +124,13 @@ class TestMergeOrdered:
         result2 = pd.merge_ordered(left, right, on="T", left_by=["G", "H"])
 
         expected = pd.DataFrame(
-                    {
-                        "G": ["g"] * 3,
-                        "H": ["h"] * 3,
-                        "T": [1, 2, 3],
-                        "E": [np.nan, 1.0, np.nan],
-                    }
-                )
+            {
+                "G": ["g"] * 3,
+                "H": ["h"] * 3,
+                "T": [1, 2, 3],
+                "E": [np.nan, 1.0, np.nan],
+            }
+        )
 
         tm.assert_frame_equal(result1, expected)
         tm.assert_frame_equal(result2, expected)
@@ -138,12 +138,12 @@ class TestMergeOrdered:
         result3 = pd.merge_ordered(right, left, on=["T"], right_by=["G", "H"])
 
         expected = pd.DataFrame(
-                    {
-                        "T": [1, 2, 3],
-                        "E": [np.nan, 1.0, np.nan],
-                        "G": ["g"] * 3,
-                        "H": ["h"] * 3,
-                    }
-                )
+            {
+                "T": [1, 2, 3],
+                "E": [np.nan, 1.0, np.nan],
+                "G": ["g"] * 3,
+                "H": ["h"] * 3,
+            }
+        )
 
         tm.assert_frame_equal(result3, expected)

--- a/pandas/tests/reshape/merge/test_merge_ordered.py
+++ b/pandas/tests/reshape/merge/test_merge_ordered.py
@@ -116,34 +116,64 @@ class TestMergeOrdered:
 
         tm.assert_frame_equal(result, expected)
 
-    def test_list_type_by(self):
+    @pytest.mark.parametrize(
+        "left, right, on, left_by, right_by, expected",
+        [
+            (
+                DataFrame({"G": ["g", "g"], "H": ["h", "h"], "T": [1, 3]}),
+                DataFrame({"T": [2], "E": [1]}),
+                ["T"],
+                ["G", "H"],
+                None,
+                DataFrame(
+                    {
+                        "G": ["g"] * 3,
+                        "H": ["h"] * 3,
+                        "T": [1, 2, 3],
+                        "E": [np.nan, 1.0, np.nan],
+                    }
+                ),
+            ),
+            (
+                DataFrame({"G": ["g", "g"], "H": ["h", "h"], "T": [1, 3]}),
+                DataFrame({"T": [2], "E": [1]}),
+                "T",
+                ["G", "H"],
+                None,
+                DataFrame(
+                    {
+                        "G": ["g"] * 3,
+                        "H": ["h"] * 3,
+                        "T": [1, 2, 3],
+                        "E": [np.nan, 1.0, np.nan],
+                    }
+                ),
+            ),
+            (
+                DataFrame({"T": [2], "E": [1]}),
+                DataFrame({"G": ["g", "g"], "H": ["h", "h"], "T": [1, 3]}),
+                ["T"],
+                None,
+                ["G", "H"],
+                DataFrame(
+                    {
+                        "T": [1, 2, 3],
+                        "E": [np.nan, 1.0, np.nan],
+                        "G": ["g"] * 3,
+                        "H": ["h"] * 3,
+                    }
+                ),
+            ),
+        ],
+    )
+    def test_list_type_by(self, left, right, on, left_by, right_by, expected):
         # GH 35269
-        left = DataFrame({"G": ["g", "g"], "H": ["h", "h"], "T": [1, 3]})
-        right = DataFrame({"T": [2], "E": [1]})
-        result1 = merge_ordered(left, right, on=["T"], left_by=["G", "H"])
-        result2 = merge_ordered(left, right, on="T", left_by=["G", "H"])
-
-        expected = DataFrame(
-            {
-                "G": ["g"] * 3,
-                "H": ["h"] * 3,
-                "T": [1, 2, 3],
-                "E": [np.nan, 1.0, np.nan],
-            }
+        result = merge_ordered(
+            left=left,
+            right=right,
+            on=on,
+            left_by=left_by,
+            right_by=right_by,
         )
 
-        tm.assert_frame_equal(result1, expected)
-        tm.assert_frame_equal(result2, expected)
-
-        result3 = merge_ordered(right, left, on=["T"], right_by=["G", "H"])
-
-        expected = DataFrame(
-            {
-                "T": [1, 2, 3],
-                "E": [np.nan, 1.0, np.nan],
-                "G": ["g"] * 3,
-                "H": ["h"] * 3,
-            }
-        )
-
-        tm.assert_frame_equal(result3, expected)
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/reshape/merge/test_merge_ordered.py
+++ b/pandas/tests/reshape/merge/test_merge_ordered.py
@@ -115,3 +115,33 @@ class TestMergeOrdered:
         )
 
         tm.assert_frame_equal(result, expected)
+
+    def test_list_type_by(self):
+        # GH 35269
+        left = DataFrame(
+            {
+                "G": ["g", "g"],
+                "H": ["h", "h"],
+                "T": [1, 3]
+            }
+        )
+
+        right = DataFrame(
+            {
+                "T": [2],
+                "E": [1]
+            }
+        )
+
+        result = merge_ordered(left, right, on=["T"], left_by=["G", "H"])
+
+        expected = DataFrame(
+            {
+                "G": ["g", "g", "g"],
+                "H": ["h", "h", "h"],
+                "T": [1, 2, 3],
+                "E": [np.nan, 1.0, np.nan]
+            }
+        )
+
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/reshape/merge/test_merge_ordered.py
+++ b/pandas/tests/reshape/merge/test_merge_ordered.py
@@ -118,16 +118,32 @@ class TestMergeOrdered:
 
     def test_list_type_by(self):
         # GH 35269
-        left = DataFrame({"G": ["g", "g"], "H": ["h", "h"], "T": [1, 3]})
-        right = DataFrame({"T": [2], "E": [1]})
-        result = merge_ordered(left, right, on=["T"], left_by=["G", "H"])
-        expected = DataFrame(
-            {
-                "G": ["g"] * 3,
-                "H": ["h"] * 3,
-                "T": [1, 2, 3],
-                "E": [np.nan, 1.0, np.nan],
-            }
-        )
+        left = pd.DataFrame({"G": ["g", "g"], "H": ["h", "h"], "T": [1, 3]})
+        right = pd.DataFrame({"T": [2], "E": [1]})
+        result1 = pd.merge_ordered(left, right, on=["T"], left_by=["G", "H"])
+        result2 = pd.merge_ordered(left, right, on="T", left_by=["G", "H"])
 
-        tm.assert_frame_equal(result, expected)
+        expected = pd.DataFrame(
+                    {
+                        "G": ["g"] * 3,
+                        "H": ["h"] * 3,
+                        "T": [1, 2, 3],
+                        "E": [np.nan, 1.0, np.nan],
+                    }
+                )
+
+        tm.assert_frame_equal(result1, expected)
+        tm.assert_frame_equal(result2, expected)
+
+        result3 = pd.merge_ordered(right, left, on=["T"], right_by=["G", "H"])
+
+        expected = pd.DataFrame(
+                    {
+                        "T": [1, 2, 3],
+                        "E": [np.nan, 1.0, np.nan],
+                        "G": ["g"] * 3,
+                        "H": ["h"] * 3,
+                    }
+                )
+
+        tm.assert_frame_equal(result3, expected)

--- a/pandas/tests/reshape/merge/test_merge_ordered.py
+++ b/pandas/tests/reshape/merge/test_merge_ordered.py
@@ -118,12 +118,12 @@ class TestMergeOrdered:
 
     def test_list_type_by(self):
         # GH 35269
-        left = pd.DataFrame({"G": ["g", "g"], "H": ["h", "h"], "T": [1, 3]})
-        right = pd.DataFrame({"T": [2], "E": [1]})
-        result1 = pd.merge_ordered(left, right, on=["T"], left_by=["G", "H"])
-        result2 = pd.merge_ordered(left, right, on="T", left_by=["G", "H"])
+        left = DataFrame({"G": ["g", "g"], "H": ["h", "h"], "T": [1, 3]})
+        right = DataFrame({"T": [2], "E": [1]})
+        result1 = merge_ordered(left, right, on=["T"], left_by=["G", "H"])
+        result2 = merge_ordered(left, right, on="T", left_by=["G", "H"])
 
-        expected = pd.DataFrame(
+        expected = DataFrame(
             {
                 "G": ["g"] * 3,
                 "H": ["h"] * 3,
@@ -135,9 +135,9 @@ class TestMergeOrdered:
         tm.assert_frame_equal(result1, expected)
         tm.assert_frame_equal(result2, expected)
 
-        result3 = pd.merge_ordered(right, left, on=["T"], right_by=["G", "H"])
+        result3 = merge_ordered(right, left, on=["T"], right_by=["G", "H"])
 
-        expected = pd.DataFrame(
+        expected = DataFrame(
             {
                 "T": [1, 2, 3],
                 "E": [np.nan, 1.0, np.nan],

--- a/pandas/tests/reshape/merge/test_merge_ordered.py
+++ b/pandas/tests/reshape/merge/test_merge_ordered.py
@@ -118,29 +118,15 @@ class TestMergeOrdered:
 
     def test_list_type_by(self):
         # GH 35269
-        left = DataFrame(
-            {
-                "G": ["g", "g"],
-                "H": ["h", "h"],
-                "T": [1, 3]
-            }
-        )
-
-        right = DataFrame(
-            {
-                "T": [2],
-                "E": [1]
-            }
-        )
-
+        left = DataFrame({"G": ["g", "g"], "H": ["h", "h"], "T": [1, 3]})
+        right = DataFrame({"T": [2], "E": [1]})
         result = merge_ordered(left, right, on=["T"], left_by=["G", "H"])
-
         expected = DataFrame(
             {
-                "G": ["g", "g", "g"],
-                "H": ["h", "h", "h"],
+                "G": ["g"] * 3,
+                "H": ["h"] * 3,
                 "T": [1, 2, 3],
-                "E": [np.nan, 1.0, np.nan]
+                "E": [np.nan, 1.0, np.nan],
             }
         )
 


### PR DESCRIPTION
- [x] closes #35269
- [x] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
