### PR TITLE
TST: Suppress http logs in tests

### DIFF
--- a/pandas/tests/io/conftest.py
+++ b/pandas/tests/io/conftest.py
@@ -50,8 +50,8 @@ def s3_base(worker_id):
     pytest.importorskip("s3fs")
     pytest.importorskip("boto3")
     requests = pytest.importorskip("requests")
-    # GH 38090: Suppress http logs in tests
-    logging.getLogger("botocore").propagate = False
+    # GH 38090: Suppress http logs in tests by moto_server
+    logging.getLogger("werkzeug").disabled = True
 
     with tm.ensure_safe_environment_variables():
         # temporary workaround as moto fails for botocore >= 1.11 otherwise,

--- a/pandas/tests/io/conftest.py
+++ b/pandas/tests/io/conftest.py
@@ -51,7 +51,7 @@ def s3_base(worker_id):
     pytest.importorskip("boto3")
     requests = pytest.importorskip("requests")
     # GH 38090: Suppress http logs in tests
-    logging.getLogger("urllib3").propagate = False
+    logging.getLogger("botocore").propagate = False
 
     with tm.ensure_safe_environment_variables():
         # temporary workaround as moto fails for botocore >= 1.11 otherwise,

--- a/pandas/tests/io/conftest.py
+++ b/pandas/tests/io/conftest.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shlex
 import subprocess
@@ -49,6 +50,8 @@ def s3_base(worker_id):
     pytest.importorskip("s3fs")
     pytest.importorskip("boto3")
     requests = pytest.importorskip("requests")
+    # GH 38090: Suppress http logs in tests
+    logging.getLogger("urllib3").propagate = False
 
     with tm.ensure_safe_environment_variables():
         # temporary workaround as moto fails for botocore >= 1.11 otherwise,


### PR DESCRIPTION
- [x] closes #38090
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Confirming that this does the trick.