### PR TITLE
BUG: calling at[] on a Series with a single-level MultiIndex returns a Series, not a scalar

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -82,7 +82,11 @@ from pandas.core.construction import (
     sanitize_array,
 )
 from pandas.core.generic import NDFrame
-from pandas.core.indexers import deprecate_ndim_indexing, unpack_1tuple
+from pandas.core.indexers import (
+    deprecate_ndim_indexing,
+    is_list_like_indexer,
+    unpack_1tuple,
+)
 from pandas.core.indexes.accessors import CombinedDatetimelikeProperties
 from pandas.core.indexes.api import Float64Index, Index, MultiIndex, ensure_index
 import pandas.core.indexes.base as ibase
@@ -922,6 +926,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         if takeable:
             return self._values[label]
 
+        if isinstance(self.index, MultiIndex) and not is_list_like_indexer(label):
+            label = (label,)
         # Similar to Index.get_value, but we do not fall back to positional
         loc = self.index.get_loc(label)
         return self.index._get_values_for_loc(self, loc, label)


### PR DESCRIPTION
- [ ] closes #GH38053
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
