### PR TITLE
ENH: include conversion to nullable float in convert_dtypes()

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1255,6 +1255,7 @@ def convert_dtypes(
     convert_string: bool = True,
     convert_integer: bool = True,
     convert_boolean: bool = True,
+    convert_floating: bool = True,
 ) -> Dtype:
     """
     Convert objects to best possible type, and optionally,
@@ -1269,6 +1270,7 @@ def convert_dtypes(
         Whether, if possible, conversion can be done to integer extension types.
     convert_boolean : bool, defaults True
         Whether object dtypes should be converted to ``BooleanDtypes()``.
+    convert_floating : bool, defaults True
 
     Returns
     -------
@@ -1303,6 +1305,16 @@ def convert_dtypes(
         else:
             if is_integer_dtype(inferred_dtype):
                 inferred_dtype = input_array.dtype
+
+        if convert_floating:
+            if not is_integer_dtype(input_array.dtype) and is_numeric_dtype(
+                input_array.dtype
+            ):
+                arr = input_array[notna(input_array)]
+                if (arr.astype(int) == arr).all():
+                    inferred_dtype = "Int64"
+                else:
+                    inferred_dtype = "Float64"
 
         if convert_boolean:
             if is_bool_dtype(input_array.dtype):

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1271,6 +1271,9 @@ def convert_dtypes(
     convert_boolean : bool, defaults True
         Whether object dtypes should be converted to ``BooleanDtypes()``.
     convert_floating : bool, defaults True
+        Whether, if possible, conversion can be done to floating extension types.
+        If `convert_integer` is also True, preference will be give to integer
+        dtypes if the floats can be faithfully casted to integers.
 
     Returns
     -------

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1278,7 +1278,9 @@ def convert_dtypes(
         new dtype
     """
     is_extension = is_extension_array_dtype(input_array.dtype)
-    if (convert_string or convert_integer or convert_boolean) and not is_extension:
+    if (
+        convert_string or convert_integer or convert_boolean or convert_floating
+    ) and not is_extension:
         try:
             inferred_dtype = lib.infer_dtype(input_array)
         except ValueError:
@@ -1310,9 +1312,14 @@ def convert_dtypes(
             if not is_integer_dtype(input_array.dtype) and is_numeric_dtype(
                 input_array.dtype
             ):
-                arr = input_array[notna(input_array)]
-                if (arr.astype(int) == arr).all():
-                    inferred_dtype = "Int64"
+                # if we could also convert to integer, check if all floats
+                # are actually integers
+                if convert_integer:
+                    arr = input_array[notna(input_array)]
+                    if (arr.astype(int) == arr).all():
+                        inferred_dtype = "Int64"
+                    else:
+                        inferred_dtype = "Float64"
                 else:
                     inferred_dtype = "Float64"
         else:

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1315,6 +1315,9 @@ def convert_dtypes(
                     inferred_dtype = "Int64"
                 else:
                     inferred_dtype = "Float64"
+        else:
+            if is_float_dtype(inferred_dtype):
+                inferred_dtype = input_array.dtype
 
         if convert_boolean:
             if is_bool_dtype(input_array.dtype):

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1315,6 +1315,11 @@ def convert_dtypes(
             if not is_integer_dtype(input_array.dtype) and is_numeric_dtype(
                 input_array.dtype
             ):
+                from pandas.core.arrays.floating import FLOAT_STR_TO_DTYPE
+
+                inferred_float_dtype = FLOAT_STR_TO_DTYPE.get(
+                    input_array.dtype.name, "Float64"
+                )
                 # if we could also convert to integer, check if all floats
                 # are actually integers
                 if convert_integer:
@@ -1322,9 +1327,9 @@ def convert_dtypes(
                     if (arr.astype(int) == arr).all():
                         inferred_dtype = "Int64"
                     else:
-                        inferred_dtype = "Float64"
+                        inferred_dtype = inferred_float_dtype
                 else:
-                    inferred_dtype = "Float64"
+                    inferred_dtype = inferred_float_dtype
         else:
             if is_float_dtype(inferred_dtype):
                 inferred_dtype = input_array.dtype

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6105,6 +6105,12 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
             Whether, if possible, conversion can be done to integer extension types.
         convert_boolean : bool, defaults True
             Whether object dtypes should be converted to ``BooleanDtypes()``.
+        convert_floating : bool, defaults True
+            Whether, if possible, conversion can be done to floating extension types.
+            If `convert_integer` is also True, preference will be give to integer
+            dtypes if the floats can be faithfully casted to integers.
+
+            .. versionadded:: 1.2.0
 
         Returns
         -------
@@ -6122,19 +6128,21 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         -----
         By default, ``convert_dtypes`` will attempt to convert a Series (or each
         Series in a DataFrame) to dtypes that support ``pd.NA``. By using the options
-        ``convert_string``, ``convert_integer``, and ``convert_boolean``, it is
-        possible to turn off individual conversions to ``StringDtype``, the integer
-        extension types or ``BooleanDtype``, respectively.
+        ``convert_string``, ``convert_integer``, ``convert_boolean`` and
+        ``convert_boolean``, it is possible to turn off individual conversions
+        to ``StringDtype``, the integer extension types, ``BooleanDtype``
+        or floating extension types, respectively.
 
         For object-dtyped columns, if ``infer_objects`` is ``True``, use the inference
         rules as during normal Series/DataFrame construction.  Then, if possible,
-        convert to ``StringDtype``, ``BooleanDtype`` or an appropriate integer extension
-        type, otherwise leave as ``object``.
+        convert to ``StringDtype``, ``BooleanDtype`` or an appropriate integer
+        or floating extension type, otherwise leave as ``object``.
 
         If the dtype is integer, convert to an appropriate integer extension type.
 
         If the dtype is numeric, and consists of all integers, convert to an
-        appropriate integer extension type.
+        appropriate integer extension type. Otherwise, convert to an
+        appropriate floating extension type.
 
         In the future, as new dtypes are added that support ``pd.NA``, the results
         of this method will change to support those new dtypes.
@@ -6174,7 +6182,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         >>> dfn = df.convert_dtypes()
         >>> dfn
            a  b      c     d     e      f
-        0  1  x   True     h    10    NaN
+        0  1  x   True     h    10   <NA>
         1  2  y  False     i  <NA>  100.5
         2  3  z   <NA>  <NA>    20  200.0
 
@@ -6184,7 +6192,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         c    boolean
         d     string
         e      Int64
-        f    float64
+        f    Float64
         dtype: object
 
         Start with a Series of strings and missing data represented by ``np.nan``.

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6088,6 +6088,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         convert_string: bool_t = True,
         convert_integer: bool_t = True,
         convert_boolean: bool_t = True,
+        convert_floating: bool_t = True,
     ) -> FrameOrSeries:
         """
         Convert columns to best possible dtypes using dtypes supporting ``pd.NA``.
@@ -6205,12 +6206,20 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         """
         if self.ndim == 1:
             return self._convert_dtypes(
-                infer_objects, convert_string, convert_integer, convert_boolean
+                infer_objects,
+                convert_string,
+                convert_integer,
+                convert_boolean,
+                convert_floating,
             )
         else:
             results = [
                 col._convert_dtypes(
-                    infer_objects, convert_string, convert_integer, convert_boolean
+                    infer_objects,
+                    convert_string,
+                    convert_integer,
+                    convert_boolean,
+                    convert_floating,
                 )
                 for col_name, col in self.items()
             ]

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6144,6 +6144,10 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         appropriate integer extension type. Otherwise, convert to an
         appropriate floating extension type.
 
+        .. versionchanged:: 1.2
+            Starting with pandas 1.2, this method also converts float columns
+            to the nullable floating extension type.
+
         In the future, as new dtypes are added that support ``pd.NA``, the results
         of this method will change to support those new dtypes.
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4706,6 +4706,7 @@ Keep all original rows and also all original values
         convert_string: bool = True,
         convert_integer: bool = True,
         convert_boolean: bool = True,
+        convert_floating: bool = True,
     ) -> "Series":
         input_series = self
         if infer_objects:
@@ -4713,9 +4714,13 @@ Keep all original rows and also all original values
             if is_object_dtype(input_series):
                 input_series = input_series.copy()
 
-        if convert_string or convert_integer or convert_boolean:
+        if convert_string or convert_integer or convert_boolean or convert_floating:
             inferred_dtype = convert_dtypes(
-                input_series._values, convert_string, convert_integer, convert_boolean
+                input_series._values,
+                convert_string,
+                convert_integer,
+                convert_boolean,
+                convert_floating,
             )
             try:
                 result = input_series.astype(inferred_dtype)

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -145,21 +145,17 @@ class TestSeriesConvertDtypes:
 
         result = series.convert_dtypes(*params)
 
-        params = dict(
-            zip(
-                [
-                    "infer_objects",
-                    "convert_string",
-                    "convert_integer",
-                    "convert_boolean",
-                ],
-                params,
-            )
-        )
+        param_names = [
+            "infer_objects",
+            "convert_string",
+            "convert_integer",
+            "convert_boolean",
+        ]
+        params_dict = dict(zip(param_names, params))
 
         expected_dtype = expected_default
         for (key, val), dtype in expected_other.items():
-            if params[key] is val:
+            if params_dict[key] is val:
                 expected_dtype = dtype
 
         expected = pd.Series(data, dtype=expected_dtype)

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -59,7 +59,7 @@ test_cases = [
         np.dtype("float"),
         "Int64",
         {
-            ("convert_integer", False): "Float64",
+            ("convert_integer", False, "convert_floating", True): "Float64",
             ("convert_integer", False, "convert_floating", False): np.dtype("float"),
         },
     ),

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -8,272 +8,171 @@ from pandas.core.dtypes.common import is_interval_dtype
 import pandas as pd
 import pandas._testing as tm
 
+# Each test case consists of a tuple with the data and dtype to create the
+# test Series, the default dtype for the expected result (which is valid
+# for most cases), and the specific cases where the result deviates from
+# this default. Those overrides are defined as a dict with (keyword, val) as
+# dictionary key. In case of multiple items, the last override takes precendence.
+test_cases = [
+    (
+        # data
+        [1, 2, 3],
+        # original dtype
+        np.dtype("int32"),
+        # default expected dtype
+        "Int32",
+        # exceptions on expected dtype
+        {("convert_integer", False): np.dtype("int32")},
+    ),
+    (
+        [1, 2, 3],
+        np.dtype("int64"),
+        "Int64",
+        {("convert_integer", False): np.dtype("int64")},
+    ),
+    (
+        ["x", "y", "z"],
+        np.dtype("O"),
+        pd.StringDtype(),
+        {("convert_string", False): np.dtype("O")},
+    ),
+    (
+        [True, False, np.nan],
+        np.dtype("O"),
+        pd.BooleanDtype(),
+        {("convert_boolean", False): np.dtype("O")},
+    ),
+    (
+        ["h", "i", np.nan],
+        np.dtype("O"),
+        pd.StringDtype(),
+        {("convert_string", False): np.dtype("O")},
+    ),
+    (  # GH32117
+        ["h", "i", 1],
+        np.dtype("O"),
+        np.dtype("O"),
+        {},
+    ),
+    (
+        [10, np.nan, 20],
+        np.dtype("float"),
+        "Int64",
+        {("convert_integer", False): np.dtype("float")},
+    ),
+    ([np.nan, 100.5, 200], np.dtype("float"), np.dtype("float"), {}),
+    (
+        [3, 4, 5],
+        "Int8",
+        "Int8",
+        {},
+    ),
+    (
+        [[1, 2], [3, 4], [5]],
+        None,
+        np.dtype("O"),
+        {},
+    ),
+    (
+        [4, 5, 6],
+        np.dtype("uint32"),
+        "UInt32",
+        {("convert_integer", False): np.dtype("uint32")},
+    ),
+    (
+        [-10, 12, 13],
+        np.dtype("i1"),
+        "Int8",
+        {("convert_integer", False): np.dtype("i1")},
+    ),
+    (
+        [1, 2.0],
+        object,
+        "Int64",
+        {
+            ("convert_integer", False): np.dtype("float"),
+            ("infer_objects", False): np.dtype("object"),
+        },
+    ),
+    (
+        [1, 2.5],
+        object,
+        np.dtype("float"),
+        {("infer_objects", False): np.dtype("object")},
+    ),
+    (["a", "b"], pd.CategoricalDtype(), pd.CategoricalDtype(), {}),
+    (
+        pd.to_datetime(["2020-01-14 10:00", "2020-01-15 11:11"]),
+        pd.DatetimeTZDtype(tz="UTC"),
+        pd.DatetimeTZDtype(tz="UTC"),
+        {},
+    ),
+    (
+        pd.to_datetime(["2020-01-14 10:00", "2020-01-15 11:11"]),
+        "datetime64[ns]",
+        np.dtype("datetime64[ns]"),
+        {},
+    ),
+    (
+        pd.to_datetime(["2020-01-14 10:00", "2020-01-15 11:11"]),
+        object,
+        np.dtype("datetime64[ns]"),
+        {("infer_objects", False): np.dtype("object")},
+    ),
+    (pd.period_range("1/1/2011", freq="M", periods=3), None, pd.PeriodDtype("M"), {}),
+    (
+        pd.arrays.IntervalArray([pd.Interval(0, 1), pd.Interval(1, 5)]),
+        None,
+        pd.IntervalDtype("int64"),
+        {},
+    ),
+]
+
 
 class TestSeriesConvertDtypes:
-    # The answerdict has keys that have 4 tuples, corresponding to the arguments
-    # infer_objects, convert_string, convert_integer, convert_boolean
-    # This allows all 16 possible combinations to be tested.  Since common
-    # combinations expect the same answer, this provides an easy way to list
-    # all the possibilities
     @pytest.mark.parametrize(
-        "data, maindtype, answerdict",
-        [
-            (
-                [1, 2, 3],
-                np.dtype("int32"),
-                {
-                    ((True, False), (True, False), (True,), (True, False)): "Int32",
-                    ((True, False), (True, False), (False,), (True, False)): np.dtype(
-                        "int32"
-                    ),
-                },
-            ),
-            (
-                [1, 2, 3],
-                np.dtype("int64"),
-                {
-                    ((True, False), (True, False), (True,), (True, False)): "Int64",
-                    ((True, False), (True, False), (False,), (True, False)): np.dtype(
-                        "int64"
-                    ),
-                },
-            ),
-            (
-                ["x", "y", "z"],
-                np.dtype("O"),
-                {
-                    (
-                        (True, False),
-                        (True,),
-                        (True, False),
-                        (True, False),
-                    ): pd.StringDtype(),
-                    ((True, False), (False,), (True, False), (True, False)): np.dtype(
-                        "O"
-                    ),
-                },
-            ),
-            (
-                [True, False, np.nan],
-                np.dtype("O"),
-                {
-                    (
-                        (True, False),
-                        (True, False),
-                        (True, False),
-                        (True,),
-                    ): pd.BooleanDtype(),
-                    ((True, False), (True, False), (True, False), (False,)): np.dtype(
-                        "O"
-                    ),
-                },
-            ),
-            (
-                ["h", "i", np.nan],
-                np.dtype("O"),
-                {
-                    (
-                        (True, False),
-                        (True,),
-                        (True, False),
-                        (True, False),
-                    ): pd.StringDtype(),
-                    ((True, False), (False,), (True, False), (True, False)): np.dtype(
-                        "O"
-                    ),
-                },
-            ),
-            (  # GH32117
-                ["h", "i", 1],
-                np.dtype("O"),
-                {
-                    (
-                        (True, False),
-                        (True, False),
-                        (True, False),
-                        (True, False),
-                    ): np.dtype("O"),
-                },
-            ),
-            (
-                [10, np.nan, 20],
-                np.dtype("float"),
-                {
-                    ((True, False), (True, False), (True,), (True, False)): "Int64",
-                    ((True, False), (True, False), (False,), (True, False)): np.dtype(
-                        "float"
-                    ),
-                },
-            ),
-            (
-                [np.nan, 100.5, 200],
-                np.dtype("float"),
-                {
-                    (
-                        (True, False),
-                        (True, False),
-                        (True, False),
-                        (True, False),
-                    ): np.dtype("float"),
-                },
-            ),
-            (
-                [3, 4, 5],
-                "Int8",
-                {((True, False), (True, False), (True, False), (True, False)): "Int8"},
-            ),
-            (
-                [[1, 2], [3, 4], [5]],
-                None,
-                {
-                    (
-                        (True, False),
-                        (True, False),
-                        (True, False),
-                        (True, False),
-                    ): np.dtype("O"),
-                },
-            ),
-            (
-                [4, 5, 6],
-                np.dtype("uint32"),
-                {
-                    ((True, False), (True, False), (True,), (True, False)): "UInt32",
-                    ((True, False), (True, False), (False,), (True, False)): np.dtype(
-                        "uint32"
-                    ),
-                },
-            ),
-            (
-                [-10, 12, 13],
-                np.dtype("i1"),
-                {
-                    ((True, False), (True, False), (True,), (True, False)): "Int8",
-                    ((True, False), (True, False), (False,), (True, False)): np.dtype(
-                        "i1"
-                    ),
-                },
-            ),
-            (
-                [1, 2.0],
-                object,
-                {
-                    ((True,), (True, False), (True,), (True, False)): "Int64",
-                    ((True,), (True, False), (False,), (True, False)): np.dtype(
-                        "float"
-                    ),
-                    ((False,), (True, False), (True, False), (True, False)): np.dtype(
-                        "object"
-                    ),
-                },
-            ),
-            (
-                [1, 2.5],
-                object,
-                {
-                    ((True,), (True, False), (True, False), (True, False)): np.dtype(
-                        "float"
-                    ),
-                    ((False,), (True, False), (True, False), (True, False)): np.dtype(
-                        "object"
-                    ),
-                },
-            ),
-            (
-                ["a", "b"],
-                pd.CategoricalDtype(),
-                {
-                    (
-                        (True, False),
-                        (True, False),
-                        (True, False),
-                        (True, False),
-                    ): pd.CategoricalDtype(),
-                },
-            ),
-            (
-                pd.to_datetime(["2020-01-14 10:00", "2020-01-15 11:11"]),
-                pd.DatetimeTZDtype(tz="UTC"),
-                {
-                    (
-                        (True, False),
-                        (True, False),
-                        (True, False),
-                        (True, False),
-                    ): pd.DatetimeTZDtype(tz="UTC"),
-                },
-            ),
-            (
-                pd.to_datetime(["2020-01-14 10:00", "2020-01-15 11:11"]),
-                "datetime64[ns]",
-                {
-                    (
-                        (True, False),
-                        (True, False),
-                        (True, False),
-                        (True, False),
-                    ): np.dtype("datetime64[ns]"),
-                },
-            ),
-            (
-                pd.to_datetime(["2020-01-14 10:00", "2020-01-15 11:11"]),
-                object,
-                {
-                    ((True,), (True, False), (True, False), (True, False)): np.dtype(
-                        "datetime64[ns]"
-                    ),
-                    ((False,), (True, False), (True, False), (True, False)): np.dtype(
-                        "O"
-                    ),
-                },
-            ),
-            (
-                pd.period_range("1/1/2011", freq="M", periods=3),
-                None,
-                {
-                    (
-                        (True, False),
-                        (True, False),
-                        (True, False),
-                        (True, False),
-                    ): pd.PeriodDtype("M"),
-                },
-            ),
-            (
-                pd.arrays.IntervalArray([pd.Interval(0, 1), pd.Interval(1, 5)]),
-                None,
-                {
-                    (
-                        (True, False),
-                        (True, False),
-                        (True, False),
-                        (True, False),
-                    ): pd.IntervalDtype("int64"),
-                },
-            ),
-        ],
+        "data, maindtype, expected_default, expected_other",
+        test_cases,
     )
     @pytest.mark.parametrize("params", product(*[(True, False)] * 4))
-    def test_convert_dtypes(self, data, maindtype, params, answerdict):
+    def test_convert_dtypes(
+        self, data, maindtype, params, expected_default, expected_other
+    ):
         if maindtype is not None:
             series = pd.Series(data, dtype=maindtype)
         else:
             series = pd.Series(data)
-        answers = {k: a for (kk, a) in answerdict.items() for k in product(*kk)}
 
-        ns = series.convert_dtypes(*params)
-        expected_dtype = answers[tuple(params)]
-        expected = pd.Series(series.values, dtype=expected_dtype)
-        tm.assert_series_equal(ns, expected)
+        result = series.convert_dtypes(*params)
+
+        params = dict(
+            zip(
+                [
+                    "infer_objects",
+                    "convert_string",
+                    "convert_integer",
+                    "convert_boolean",
+                ],
+                params,
+            )
+        )
+
+        expected_dtype = expected_default
+        for (key, val), dtype in expected_other.items():
+            if params[key] is val:
+                expected_dtype = dtype
+
+        expected = pd.Series(data, dtype=expected_dtype)
+        tm.assert_series_equal(result, expected)
 
         # Test that it is a copy
         copy = series.copy(deep=True)
-        if is_interval_dtype(ns.dtype) and ns.dtype.subtype.kind in ["i", "u"]:
+        if is_interval_dtype(result.dtype) and result.dtype.subtype.kind in ["i", "u"]:
             msg = "Cannot set float NaN to integer-backed IntervalArray"
             with pytest.raises(ValueError, match=msg):
-                ns[ns.notna()] = np.nan
+                result[result.notna()] = np.nan
         else:
-            ns[ns.notna()] = np.nan
+            result[result.notna()] = np.nan
 
         # Make sure original not changed
         tm.assert_series_equal(series, copy)

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -94,6 +94,12 @@ test_cases = [
         {("convert_integer", False): np.dtype("i1")},
     ),
     (
+        [1.2, 1.3],
+        np.dtype("float32"),
+        "Float32",
+        {("convert_floating", False): np.dtype("float32")},
+    ),
+    (
         [1, 2.0],
         object,
         "Int64",


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/38110

There is one potentially corner case: what with floats that are all "integer"-like? I think we want to keep returning nullable int for that, at least by default, and that is what I did now in this PR But we might want to add a parameter controlling that behaviour? (but that can also be added later on if there is demand for it)