### PR TITLE
BUG: parsed datetime string resolution incorrect

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -565,10 +565,11 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
             "hour",
             "minute",
             "second",
-            "minute",
-            "second",
+            "millisecond",
             "microsecond",
+            "nanosecond"
         }
+        
         if reso.attrname not in valid_resos:
             raise KeyError
 


### PR DESCRIPTION
I was working today with datetime index, you have the reso (resolutions) defined from year to nanosecond, but then you had the lines 560-570 repeating 'minute' and 'second', and working with millisecond or nanosecond raises a KeyIndex error.


- [ ] closes #38121
- [ ] closes #38077 
- [ ]  tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
