### PR TITLE
ENH: Categorical.unique can keep same dtype

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -254,6 +254,7 @@ Other enhancements
 - :func:`read_csv` supports memory-mapping for compressed files (:issue:`37621`)
 - Improve error reporting for :meth:`DataFrame.merge` when invalid merge column definitions were given (:issue:`16228`)
 - Improve numerical stability for :meth:`.Rolling.skew`, :meth:`.Rolling.kurt`, :meth:`Expanding.skew` and :meth:`Expanding.kurt` through implementation of Kahan summation (:issue:`6929`)
+- :meth:`Categorical.unique` has a new parameter ``remove_unused_categories``, which if set to ``False``, keeps the dtype of the original categorical (:issue:`xxxxx`)
 - Improved error reporting for subsetting columns of a :class:`.DataFrameGroupBy` with ``axis=1`` (:issue:`37725`)
 - Implement method ``cross`` for :meth:`DataFrame.merge` and :meth:`DataFrame.join` (:issue:`5401`)
 

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -254,7 +254,7 @@ Other enhancements
 - :func:`read_csv` supports memory-mapping for compressed files (:issue:`37621`)
 - Improve error reporting for :meth:`DataFrame.merge` when invalid merge column definitions were given (:issue:`16228`)
 - Improve numerical stability for :meth:`.Rolling.skew`, :meth:`.Rolling.kurt`, :meth:`Expanding.skew` and :meth:`Expanding.kurt` through implementation of Kahan summation (:issue:`6929`)
-- :meth:`Categorical.unique` has a new parameter ``remove_unused_categories``, which if set to ``False``, keeps the dtype of the original categorical (:issue:`xxxxx`)
+- :meth:`Categorical.unique` has a new parameter ``remove_unused_categories``, which if set to ``False``, keeps the dtype of the original categorical (:issue:`38135`)
 - Improved error reporting for subsetting columns of a :class:`.DataFrameGroupBy` with ``axis=1`` (:issue:`37725`)
 - Implement method ``cross`` for :meth:`DataFrame.merge` and :meth:`DataFrame.join` (:issue:`5401`)
 

--- a/pandas/tests/arrays/categorical/test_analytics.py
+++ b/pandas/tests/arrays/categorical/test_analytics.py
@@ -6,7 +6,7 @@ import pytest
 
 from pandas.compat import PYPY
 
-from pandas import Categorical, Index, NaT, Series, date_range
+from pandas import Categorical, CategoricalDtype, Index, NaT, Series, date_range
 import pandas._testing as tm
 from pandas.api.types import is_scalar
 
@@ -241,6 +241,25 @@ class TestCategoricalAnalytics:
         res = cat.unique()
         exp_cat = Categorical(["b", np.nan, "a"], categories=["a", "b"], ordered=True)
         tm.assert_categorical_equal(res, exp_cat)
+
+    @pytest.mark.parametrize("values, expected", [
+        [list("abc"), list("abc")],
+        [list("bac"), list("bac")],
+        [list("ab"), list("ab")],
+        [list("bc"), list("bc")],
+        [list("aabbcc"), list("abc")],
+        [list("aabb"), list("ab")],
+        [[np.nan, "a", "b"], [np.nan, "a", "b"]],
+        [["a", "b", np.nan], ["a", "b", np.nan]],
+        [["a", "b", "a", "b", np.nan], ["a", "b", np.nan]],
+    ])
+    def test_unique_keep_unused_categories(self, values, expected, ordered):
+        # GHxxxxx
+        dtype = CategoricalDtype(list("abc"), ordered=ordered)
+        result = Categorical(values, dtype=dtype).unique(remove_unused_categories=False)
+        expected = Categorical(expected, dtype=dtype)
+
+        tm.assert_categorical_equal(result, expected)
 
     def test_unique_index_series(self):
         c = Categorical([3, 1, 2, 2, 1], categories=[3, 2, 1])

--- a/pandas/tests/arrays/categorical/test_analytics.py
+++ b/pandas/tests/arrays/categorical/test_analytics.py
@@ -242,19 +242,22 @@ class TestCategoricalAnalytics:
         exp_cat = Categorical(["b", np.nan, "a"], categories=["a", "b"], ordered=True)
         tm.assert_categorical_equal(res, exp_cat)
 
-    @pytest.mark.parametrize("values, expected", [
-        [list("abc"), list("abc")],
-        [list("bac"), list("bac")],
-        [list("ab"), list("ab")],
-        [list("bc"), list("bc")],
-        [list("aabbcc"), list("abc")],
-        [list("aabb"), list("ab")],
-        [[np.nan, "a", "b"], [np.nan, "a", "b"]],
-        [["a", "b", np.nan], ["a", "b", np.nan]],
-        [["a", "b", "a", "b", np.nan], ["a", "b", np.nan]],
-    ])
+    @pytest.mark.parametrize(
+        "values, expected",
+        [
+            [list("abc"), list("abc")],
+            [list("bac"), list("bac")],
+            [list("ab"), list("ab")],
+            [list("bc"), list("bc")],
+            [list("aabbcc"), list("abc")],
+            [list("aabb"), list("ab")],
+            [[np.nan, "a", "b"], [np.nan, "a", "b"]],
+            [["a", "b", np.nan], ["a", "b", np.nan]],
+            [["a", "b", "a", "b", np.nan], ["a", "b", np.nan]],
+        ],
+    )
     def test_unique_keep_unused_categories(self, values, expected, ordered):
-        # GHxxxxx
+        # GH38135
         dtype = CategoricalDtype(list("abc"), ordered=ordered)
         result = Categorical(values, dtype=dtype).unique(remove_unused_categories=False)
         expected = Categorical(expected, dtype=dtype)


### PR DESCRIPTION
There are situations where we want to keep the same dtype as in the original after applying `unique` For example

```python
>>> dtype = pd.categoricalDtype(['very good', 'good', 'neutral', 'bad', 'very bad'], ordered=True)
>>> cat = pd.Categorical(['good','good', 'bad', 'bad'], dtype=dtype)
>>> cat
[good, good, bad, bad]
Categories (5, object): [very good < good < neutral < bad < very bad]
>>> cat.unique().dtype == cat.dtype
False  # this is a bug IMO, but others may not agree
```

Even if it's not a bug, there are situations where we want the comparison above to return True. To alleviate the above, I've added a new parameter, so we can do

```
>>> cat.unique(remove_unused_categories=False).dtype == cat.dtype
True
```

Helps #18291, but does not close the issue.
