### PR TITLE
BUG: loc raising KeyError for string slices in list-like indexer and DatetimeIndex

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -634,6 +634,7 @@ Indexing
 - Bug in :meth:`DataFrame.loc` returning and assigning elements in wrong order when indexer is differently ordered than the :class:`MultiIndex` to filter (:issue:`31330`, :issue:`34603`)
 - Bug in :meth:`DataFrame.loc` and :meth:`DataFrame.__getitem__`  raising ``KeyError`` when columns were :class:`MultiIndex` with only one level (:issue:`29749`)
 - Bug in :meth:`Series.__getitem__` and :meth:`DataFrame.__getitem__` raising blank ``KeyError`` without missing keys for :class:`IntervalIndex` (:issue:`27365`)
+- Bug in :meth:`DataFrame.loc` raising ``KeyError`` for list-like indexers with string slices for :class:`DatetimeIndex` (:issue:`27180`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -820,14 +820,15 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
 
     def _convert_listlike_indexer(self, key):
         if not isinstance(key, list):
-            # There are no slices for arrays or indexes, so we can dispatch back
+            # There are no slices, so we can dispatch back
             return super()._convert_listlike_indexer(key)
 
         new_indexer = []
-        indexes = list(range(len(self)))
+        positions = list(range(len(self)))
         try:
             for k in key:
-                indexer = indexes[self.get_loc(k)]
+                # Convert slices to list of integers
+                indexer = positions[self.get_loc(k)]
                 if not isinstance(indexer, list):
                     indexer = [indexer]
                 new_indexer.extend(indexer)

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -818,6 +818,24 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
 
     # --------------------------------------------------------------------
 
+    def _convert_listlike_indexer(self, key):
+        if not isinstance(key, list):
+            # There are no slices for arrays or indexes, so we can dispatch back
+            return super()._convert_listlike_indexer(key)
+
+        new_indexer = []
+        indexes = list(range(len(self)))
+        try:
+            for k in key:
+                indexer = indexes[self.get_loc(k)]
+                if not isinstance(indexer, list):
+                    indexer = [indexer]
+                new_indexer.extend(indexer)
+        except KeyError:
+            # Dispatch to base method for handling of KeyErrors
+            return super()._convert_listlike_indexer(key)
+        return np.array(new_indexer), key
+
     @property
     def inferred_type(self) -> str:
         # b/c datetime is represented as microseconds since the epoch, make

--- a/pandas/tests/indexing/test_datetime.py
+++ b/pandas/tests/indexing/test_datetime.py
@@ -232,10 +232,20 @@ class TestDatetimeIndex:
         )
         tm.assert_frame_equal(result, expected)
 
-    @pytest.mark.parametrize("indexer", ["2001-01", ["2001-01"]])
+    @pytest.mark.parametrize(
+        "indexer", [["2001-01", "2001-01-30"], ["2001-01", Timestamp("2001-01-30")]]
+    )
     def test_loc_getitem_partial_strings_in_list(self, indexer):
         # GH#27180
-        ser = Series(1, index=date_range('2001-01-01', periods=60))
+        ser = Series(1, index=date_range("2001-01-29", periods=60))
         result = ser.loc[indexer]
-        expected = Series(1, index=date_range('2001-01-01', periods=31))
+        expected = Series(
+            1,
+            index=[
+                Timestamp("2001-01-29"),
+                Timestamp("2001-01-30"),
+                Timestamp("2001-01-31"),
+                Timestamp("2001-01-30"),
+            ],
+        )
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/indexing/test_datetime.py
+++ b/pandas/tests/indexing/test_datetime.py
@@ -231,3 +231,11 @@ class TestDatetimeIndex:
             dtype=object,
         )
         tm.assert_frame_equal(result, expected)
+
+    @pytest.mark.parametrize("indexer", ["2001-01", ["2001-01"]])
+    def test_loc_getitem_partial_strings_in_list(self, indexer):
+        # GH#27180
+        ser = Series(1, index=date_range('2001-01-01', periods=60))
+        result = ser.loc[indexer]
+        expected = Series(1, index=date_range('2001-01-01', periods=31))
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #27180
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

I looked into this and added an implementation for list-like indexers containing slices and DatetimeIndexes. If we want to support this we probably have to do something like this.