### PR TITLE
CLN: improve is_unique check in Index.intersection

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2861,12 +2861,14 @@ class Index(IndexOpsMixin, PandasObject):
         result = Index(other.take(indexer))
         if not result.is_unique:
             result = result.unique()._values
+        else:
+            result = result._values
 
         if sort is None:
             result = algos.safe_sort(result)
 
         # Intersection has to be unique
-        assert Index(other.take(indexer)).is_unique
+        assert Index(result).is_unique
 
         return result
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2381,7 +2381,7 @@ class Index(IndexOpsMixin, PandasObject):
             self._validate_index_level(level)
 
         if self.is_unique:
-            return self
+            return self._shallow_copy()
 
         result = super().unique()
         return self._shallow_copy(result)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2379,6 +2379,10 @@ class Index(IndexOpsMixin, PandasObject):
         """
         if level is not None:
             self._validate_index_level(level)
+
+        if self.is_unique:
+            return self
+
         result = super().unique()
         return self._shallow_copy(result)
 
@@ -2858,11 +2862,7 @@ class Index(IndexOpsMixin, PandasObject):
             indexer = algos.unique1d(Index(rvals).get_indexer_non_unique(lvals)[0])
             indexer = indexer[indexer != -1]
 
-        result = other.take(indexer)
-        if not result.is_unique:
-            result = result.unique()._values
-        else:
-            result = result._values
+        result = other.take(indexer).unique()._values
 
         if sort is None:
             result = algos.safe_sort(result)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2858,7 +2858,7 @@ class Index(IndexOpsMixin, PandasObject):
             indexer = algos.unique1d(Index(rvals).get_indexer_non_unique(lvals)[0])
             indexer = indexer[indexer != -1]
 
-        result = Index(other.take(indexer))
+        result = other.take(indexer)
         if not result.is_unique:
             result = result.unique()._values
         else:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2858,13 +2858,15 @@ class Index(IndexOpsMixin, PandasObject):
             indexer = algos.unique1d(Index(rvals).get_indexer_non_unique(lvals)[0])
             indexer = indexer[indexer != -1]
 
-        result = other.take(indexer).unique()._values
+        result = Index(other.take(indexer))
+        if not result.is_unique:
+            result = result.unique()._values
 
         if sort is None:
             result = algos.safe_sort(result)
 
         # Intersection has to be unique
-        assert algos.unique(result).shape == result.shape
+        assert Index(other.take(indexer)).is_unique
 
         return result
 


### PR DESCRIPTION
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

```
       before           after         ratio
     [e99e5ab3]       [79d6a50f]
     <cln_intersection~1>       <cln_intersection>
-        918±20ns          819±2ns     0.89  index_object.Range.time_min_trivial
-         465±7ns          414±7ns     0.89  index_object.Range.time_get_loc_dec
-         464±6ns          411±7ns     0.89  index_object.Range.time_get_loc_inc
-      16.6±0.7ms      12.6±0.03ms     0.76  index_object.SetOperations.time_operation('date_string', 'union')
```

Seems to have no impact.

cc @jreback
