### PR TITLE
BUG: assert_frame_equal exception for datetime #37609

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -784,6 +784,9 @@ Other
 - Passing an array with 2 or more dimensions to the :class:`Series` constructor now raises the more specific ``ValueError`` rather than a bare ``Exception`` (:issue:`35744`)
 - Bug in ``dir`` where ``dir(obj)`` wouldn't show attributes defined on the instance for pandas objects (:issue:`37173`)
 - Bug in :meth:`RangeIndex.difference` returning :class:`Int64Index` in some cases where it should return :class:`RangeIndex` (:issue:`38028`)
+- Fixed bug in :func:`assert_series_equal` when comparing a datetime-like array with an equivalent non extension dtype array (:issue:`37609`)
+
+
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -1876,7 +1876,9 @@ def assert_copy(iter1, iter2, **eql_kwargs):
 def is_ExtensionArrayDtype_and_needs_i8_conversion(left_dtype, right_dtype):
     """
     Checks that we have the combination of an ExtensionArraydtype and
-    a dtype that should be converted to int64.
+    a dtype that should be converted to int64
+
+    Related to issue #37609
     """
     return (
         is_extension_array_dtype(left_dtype) and needs_i8_conversion(right_dtype)

--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -1456,12 +1456,12 @@ def assert_series_equal(
             check_dtype=check_dtype,
             index_values=np.asarray(left.index),
         )
-    elif (is_extension_array_dtype(left.dtype) and needs_i8_conversion(right.dtype)) or (
-            is_extension_array_dtype(right.dtype) and needs_i8_conversion(left.dtype)
-    ):
-        #If we have an extension array and Datetimearray / TimedeltaArray, we still
-        #want to assert_extension_array_equal even though Datetimearray / TimedeltaArray
-        #dtypes are not an instance of ExtensionArraydtype subclass
+    elif (
+        is_extension_array_dtype(left.dtype) and needs_i8_conversion(right.dtype)
+    ) or (is_extension_array_dtype(right.dtype) and needs_i8_conversion(left.dtype)):
+        # If we have an extension array and Datetimearray / TimedeltaArray, we still
+        # want to assert_extension_array_equal even though Datetimearray and
+        # TimedeltaArray dtypes are not an instance of ExtensionArraydtype subclass
         assert_extension_array_equal(
             left._values,
             right._values,

--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -1456,7 +1456,9 @@ def assert_series_equal(
             check_dtype=check_dtype,
             index_values=np.asarray(left.index),
         )
-    elif is_ExtensionArrayDtype_and_needs_i8_conversion(left.dtype, right.dtype):
+    elif is_extension_array_dtype_and_needs_i8_conversion(
+        left.dtype, right.dtype
+    ) or is_extension_array_dtype_and_needs_i8_conversion(right.dtype, left.dtype):
         assert_extension_array_equal(
             left._values,
             right._values,
@@ -1873,16 +1875,18 @@ def assert_copy(iter1, iter2, **eql_kwargs):
         assert elem1 is not elem2, msg
 
 
-def is_ExtensionArrayDtype_and_needs_i8_conversion(left_dtype, right_dtype):
+def is_extension_array_dtype_and_needs_i8_conversion(left_dtype, right_dtype) -> bool:
     """
     Checks that we have the combination of an ExtensionArraydtype and
     a dtype that should be converted to int64
 
+    Returns
+    -------
+    bool
+
     Related to issue #37609
     """
-    return (
-        is_extension_array_dtype(left_dtype) and needs_i8_conversion(right_dtype)
-    ) or (is_extension_array_dtype(right_dtype) and needs_i8_conversion(left_dtype))
+    return is_extension_array_dtype(left_dtype) and needs_i8_conversion(right_dtype)
 
 
 def getCols(k):

--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -1456,7 +1456,19 @@ def assert_series_equal(
             check_dtype=check_dtype,
             index_values=np.asarray(left.index),
         )
-    elif needs_i8_conversion(left.dtype) or needs_i8_conversion(right.dtype):
+    elif (is_extension_array_dtype(left.dtype) and needs_i8_conversion(right.dtype)) or (
+            is_extension_array_dtype(right.dtype) and needs_i8_conversion(left.dtype)
+    ):
+        #If we have an extension array and Datetimearray / TimedeltaArray, we still
+        #want to assert_extension_array_equal even though Datetimearray / TimedeltaArray
+        #dtypes are not an instance of ExtensionArraydtype subclass
+        assert_extension_array_equal(
+            left._values,
+            right._values,
+            check_dtype=check_dtype,
+            index_values=np.asarray(left.index),
+        )
+    elif needs_i8_conversion(left.dtype) and needs_i8_conversion(right.dtype):
         # DatetimeArray or TimedeltaArray
         assert_extension_array_equal(
             left._values,

--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -1456,12 +1456,7 @@ def assert_series_equal(
             check_dtype=check_dtype,
             index_values=np.asarray(left.index),
         )
-    elif (
-        is_extension_array_dtype(left.dtype) and needs_i8_conversion(right.dtype)
-    ) or (is_extension_array_dtype(right.dtype) and needs_i8_conversion(left.dtype)):
-        # If we have an extension array and Datetimearray / TimedeltaArray, we still
-        # want to assert_extension_array_equal even though Datetimearray and
-        # TimedeltaArray dtypes are not an instance of ExtensionArraydtype subclass
+    elif is_ExtensionArrayDtype_and_needs_i8_conversion(left.dtype, right.dtype):
         assert_extension_array_equal(
             left._values,
             right._values,
@@ -1876,6 +1871,16 @@ def assert_copy(iter1, iter2, **eql_kwargs):
             "different objects, but they were the same object."
         )
         assert elem1 is not elem2, msg
+
+
+def is_ExtensionArrayDtype_and_needs_i8_conversion(left_dtype, right_dtype):
+    """
+    Checks that we have the combination of an ExtensionArraydtype and
+    a dtype that should be converted to int64.
+    """
+    return (
+        is_extension_array_dtype(left_dtype) and needs_i8_conversion(right_dtype)
+    ) or (is_extension_array_dtype(right_dtype) and needs_i8_conversion(left_dtype))
 
 
 def getCols(k):

--- a/pandas/tests/util/test_assert_extension_array_equal.py
+++ b/pandas/tests/util/test_assert_extension_array_equal.py
@@ -111,8 +111,3 @@ def test_assert_extension_array_equal_ignore_dtype_mismatch(right_dtype):
     left = array([1, 2, 3], dtype="Int64")
     right = array([1, 2, 3], dtype=right_dtype)
     tm.assert_extension_array_equal(left, right, check_dtype=False)
-
-def test_assert_frame_equal_datetime_dtype_mismatch():
-    df1 = DataFrame({'a': []}, dtype="datetime64[ns]")
-    df2 = DataFrame({'a': []})
-    tm.assert_frame_equal(df1, df2, check_dtype=False)

--- a/pandas/tests/util/test_assert_extension_array_equal.py
+++ b/pandas/tests/util/test_assert_extension_array_equal.py
@@ -111,3 +111,8 @@ def test_assert_extension_array_equal_ignore_dtype_mismatch(right_dtype):
     left = array([1, 2, 3], dtype="Int64")
     right = array([1, 2, 3], dtype=right_dtype)
     tm.assert_extension_array_equal(left, right, check_dtype=False)
+
+def test_assert_frame_equal_datetime_dtype_mismatch():
+    df1 = DataFrame({'a': []}, dtype="datetime64[ns]")
+    df2 = DataFrame({'a': []})
+    tm.assert_frame_equal(df1, df2, check_dtype=False)

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -271,6 +271,11 @@ def test_assert_frame_equal_ignore_extension_dtype_mismatch(right_dtype):
     right = DataFrame({"a": [1, 2, 3]}, dtype=right_dtype)
     tm.assert_frame_equal(left, right, check_dtype=False)
 
+def test_assert_frame_equal_datetime_dtype_mismatch():
+    df1 = DataFrame({'a': []}, dtype="datetime64[ns]")
+    df2 = DataFrame({'a': []})
+    tm.assert_frame_equal(df1, df2, check_dtype=False)
+
 
 def test_allows_duplicate_labels():
     left = DataFrame()

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -271,9 +271,10 @@ def test_assert_frame_equal_ignore_extension_dtype_mismatch(right_dtype):
     right = DataFrame({"a": [1, 2, 3]}, dtype=right_dtype)
     tm.assert_frame_equal(left, right, check_dtype=False)
 
+
 def test_assert_frame_equal_datetime_dtype_mismatch():
-    df1 = DataFrame({'a': []}, dtype="datetime64[ns]")
-    df2 = DataFrame({'a': []})
+    df1 = DataFrame({"a": []}, dtype="datetime64[ns]")
+    df2 = DataFrame({"a": []})
     tm.assert_frame_equal(df1, df2, check_dtype=False)
 
 

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -272,8 +272,16 @@ def test_assert_frame_equal_ignore_extension_dtype_mismatch(right_dtype):
     tm.assert_frame_equal(left, right, check_dtype=False)
 
 
-def test_assert_frame_equal_datetime_dtype_mismatch():
-    df1 = DataFrame({"a": []}, dtype="datetime64[ns]")
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ("timedelta64[ns]"),
+        ("datetime64[ns, UTC]"),
+        ("Period[D]"),
+    ],
+)
+def test_assert_frame_equal_datetime_like_dtype_mismatch(dtype):
+    df1 = DataFrame({"a": []}, dtype=dtype)
     df2 = DataFrame({"a": []})
     tm.assert_frame_equal(df1, df2, check_dtype=False)
 


### PR DESCRIPTION
closes #37609 

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Working with @richardwong8 on this issue.

This addresses issue #37609 where a check `needs_i8_conversion(left.dtype) or needs_i8_conversion(right.dtype)` in assert_series_equal caused an assert_extension_array on left._values and right._values when DatetimeArray or TimedeltaArray were used. This caused an exception to be raised when either the right or left was not an instance of ExtensionArray but was used with DatetimeArray or TimedeltaArray. 

This would have been covered in the earlier check `is_extension_array_dtype(left.dtype) and is_extension_array_dtype(right.dtype)`, however, DatetimeArray and TimedeltaArray are still experimental and their dtypes are not instances of ExtensionDtype subclass.