### PR TITLE
REF: more distinctive names for BaseGrouper.aggregate, transform

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1063,8 +1063,8 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         def blk_func(bvalues: ArrayLike) -> ArrayLike:
 
             try:
-                result, _ = self.grouper.aggregate(
-                    bvalues, how, axis=1, min_count=min_count
+                result, _ = self.grouper._cython_operation(
+                    "aggregate", bvalues, how, axis=1, min_count=min_count
                 )
             except NotImplementedError:
                 # generally if we have numeric_only=False

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -982,8 +982,11 @@ b  2""",
         assert filled_series is not None
         return filled_series.gt(0).any() and func_nm not in base.cython_cast_blocklist
 
-    def _cython_transform(self, how: str, numeric_only: bool = True, **kwargs):
+    def _cython_transform(
+        self, how: str, numeric_only: bool = True, axis: int = 0, **kwargs
+    ):
         output: Dict[base.OutputKey, np.ndarray] = {}
+
         for idx, obj in enumerate(self._iterate_slices()):
             name = obj.name
             is_numeric = is_numeric_dtype(obj.dtype)
@@ -991,7 +994,9 @@ b  2""",
                 continue
 
             try:
-                result, _ = self.grouper.transform(obj.values, how, **kwargs)
+                result, _ = self.grouper._cython_operation(
+                    "transform", obj.values, how, axis, **kwargs
+                )
             except NotImplementedError:
                 continue
 
@@ -1067,8 +1072,8 @@ b  2""",
             if numeric_only and not is_numeric:
                 continue
 
-            result, agg_names = self.grouper.aggregate(
-                obj._values, how, min_count=min_count
+            result, agg_names = self.grouper._cython_operation(
+                "aggregate", obj._values, how, axis=0, min_count=min_count
             )
 
             if agg_names:

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -588,16 +588,6 @@ class BaseGrouper:
 
         return result, names
 
-    def aggregate(
-        self, values, how: str, axis: int = 0, min_count: int = -1
-    ) -> Tuple[np.ndarray, Optional[List[str]]]:
-        return self._cython_operation(
-            "aggregate", values, how, axis, min_count=min_count
-        )
-
-    def transform(self, values, how: str, axis: int = 0, **kwargs):
-        return self._cython_operation("transform", values, how, axis, **kwargs)
-
     def _aggregate(
         self, result, counts, values, comp_ids, agg_func, min_count: int = -1
     ):


### PR DESCRIPTION
ATM it is way too difficult to reason about where BaseGrouper.transform/aggregate is being called from.  This removes two one-liners to make it this easy.