### PR TITLE
BUG/CLN: Minimize number of ResourceWarnings

### DIFF
--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -553,6 +553,9 @@ class ExcelWriter(metaclass=abc.ABCMeta):
     Default is to use xlwt for xls, openpyxl for xlsx, odf for ods.
     See DataFrame.to_excel for typical usage.
 
+    The writer should be used as a context manager. Otherwise, call `close()` to save
+    and close any opened file handles.
+
     Parameters
     ----------
     path : str or typing.BinaryIO

--- a/pandas/io/excel/_xlwt.py
+++ b/pandas/io/excel/_xlwt.py
@@ -45,7 +45,9 @@ class XlwtWriter(ExcelWriter):
         """
         Save workbook to disk.
         """
-        self.book.save(self.handles.handle)
+        if self.sheets:
+            # fails when the ExcelWriter is just opened and then closed
+            self.book.save(self.handles.handle)
 
     def write_cells(
         self, cells, sheet_name=None, startrow=0, startcol=0, freeze_panes=None

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1881,7 +1881,11 @@ class CParserWrapper(ParserBase):
             # no attribute "mmap"  [union-attr]
             self.handles.handle = self.handles.handle.mmap  # type: ignore[union-attr]
 
-        self._reader = parsers.TextReader(self.handles.handle, **kwds)
+        try:
+            self._reader = parsers.TextReader(self.handles.handle, **kwds)
+        except Exception:
+            self.handles.close()
+            raise
         self.unnamed_cols = self._reader.unnamed_cols
 
         passed_names = self.names is None

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Optional, Union, overload
 
 from pandas._typing import FilePathOrBuffer, Label
 
-from pandas.io.common import stringify_path
+from pandas.io.common import IOHandles, stringify_path
 
 if TYPE_CHECKING:
     from pandas import DataFrame
@@ -17,6 +17,8 @@ class ReaderBase(metaclass=ABCMeta):
     """
     Protocol for XportReader and SAS7BDATReader classes.
     """
+
+    handles: IOHandles
 
     @abstractmethod
     def read(self, nrows=None):
@@ -134,4 +136,5 @@ def read_sas(
     if iterator or chunksize:
         return reader
 
-    return reader.read()
+    with reader.handles:
+        return reader.read()

--- a/pandas/tests/io/excel/test_openpyxl.py
+++ b/pandas/tests/io/excel/test_openpyxl.py
@@ -68,11 +68,11 @@ def test_write_cells_merge_styled(ext):
     ]
 
     with tm.ensure_clean(ext) as path:
-        writer = _OpenpyxlWriter(path)
-        writer.write_cells(initial_cells, sheet_name=sheet_name)
-        writer.write_cells(merge_cells, sheet_name=sheet_name)
+        with _OpenpyxlWriter(path) as writer:
+            writer.write_cells(initial_cells, sheet_name=sheet_name)
+            writer.write_cells(merge_cells, sheet_name=sheet_name)
 
-        wks = writer.sheets[sheet_name]
+            wks = writer.sheets[sheet_name]
         xcell_b1 = wks["B1"]
         xcell_a2 = wks["A2"]
         assert xcell_b1.font == openpyxl_sty_merged
@@ -93,9 +93,8 @@ def test_write_append_mode(ext, mode, expected):
         wb.worksheets[1]["A1"].value = "bar"
         wb.save(f)
 
-        writer = ExcelWriter(f, engine="openpyxl", mode=mode)
-        df.to_excel(writer, sheet_name="baz", index=False)
-        writer.save()
+        with ExcelWriter(f, engine="openpyxl", mode=mode) as writer:
+            df.to_excel(writer, sheet_name="baz", index=False)
 
         wb2 = openpyxl.load_workbook(f)
         result = [sheet.title for sheet in wb2.worksheets]

--- a/pandas/tests/io/excel/test_style.py
+++ b/pandas/tests/io/excel/test_style.py
@@ -68,15 +68,14 @@ def test_styler_to_excel(engine):
 
     df = DataFrame(np.random.randn(11, 3))
     with tm.ensure_clean(".xlsx" if engine != "xlwt" else ".xls") as path:
-        writer = ExcelWriter(path, engine=engine)
-        df.to_excel(writer, sheet_name="frame")
-        df.style.to_excel(writer, sheet_name="unstyled")
-        styled = df.style.apply(style, axis=None)
-        styled.to_excel(writer, sheet_name="styled")
-        ExcelFormatter(styled, style_converter=custom_converter).write(
-            writer, sheet_name="custom"
-        )
-        writer.save()
+        with ExcelWriter(path, engine=engine) as writer:
+            df.to_excel(writer, sheet_name="frame")
+            df.style.to_excel(writer, sheet_name="unstyled")
+            styled = df.style.apply(style, axis=None)
+            styled.to_excel(writer, sheet_name="styled")
+            ExcelFormatter(styled, style_converter=custom_converter).write(
+                writer, sheet_name="custom"
+            )
 
         if engine not in ("openpyxl", "xlsxwriter"):
             # For other engines, we only smoke test

--- a/pandas/tests/io/excel/test_xlsxwriter.py
+++ b/pandas/tests/io/excel/test_xlsxwriter.py
@@ -23,16 +23,15 @@ def test_column_format(ext):
     with tm.ensure_clean(ext) as path:
         frame = DataFrame({"A": [123456, 123456], "B": [123456, 123456]})
 
-        writer = ExcelWriter(path)
-        frame.to_excel(writer)
+        with ExcelWriter(path) as writer:
+            frame.to_excel(writer)
 
-        # Add a number format to col B and ensure it is applied to cells.
-        num_format = "#,##0"
-        write_workbook = writer.book
-        write_worksheet = write_workbook.worksheets()[0]
-        col_format = write_workbook.add_format({"num_format": num_format})
-        write_worksheet.set_column("B:B", None, col_format)
-        writer.save()
+            # Add a number format to col B and ensure it is applied to cells.
+            num_format = "#,##0"
+            write_workbook = writer.book
+            write_worksheet = write_workbook.worksheets()[0]
+            col_format = write_workbook.add_format({"num_format": num_format})
+            write_worksheet.set_column("B:B", None, col_format)
 
         read_workbook = openpyxl.load_workbook(path)
         try:

--- a/pandas/tests/io/parser/test_multi_thread.py
+++ b/pandas/tests/io/parser/test_multi_thread.py
@@ -2,6 +2,7 @@
 Tests multithreading behaviour for reading and
 parsing files for each parser defined in parsers.py
 """
+from contextlib import ExitStack
 from io import BytesIO
 from multiprocessing.pool import ThreadPool
 
@@ -46,16 +47,18 @@ def test_multi_thread_string_io_read_csv(all_parsers):
         "\n".join([f"{i:d},{i:d},{i:d}" for i in range(max_row_range)]).encode()
         for _ in range(num_files)
     ]
-    files = [BytesIO(b) for b in bytes_to_df]
 
     # Read all files in many threads.
-    pool = ThreadPool(8)
+    with ExitStack() as stack:
+        files = [stack.enter_context(BytesIO(b)) for b in bytes_to_df]
 
-    results = pool.map(parser.read_csv, files)
-    first_result = results[0]
+        pool = stack.enter_context(ThreadPool(8))
 
-    for result in results:
-        tm.assert_frame_equal(first_result, result)
+        results = pool.map(parser.read_csv, files)
+        first_result = results[0]
+
+        for result in results:
+            tm.assert_frame_equal(first_result, result)
 
 
 def _generate_multi_thread_dataframe(parser, path, num_rows, num_tasks):
@@ -116,8 +119,8 @@ def _generate_multi_thread_dataframe(parser, path, num_rows, num_tasks):
         (num_rows * i // num_tasks, num_rows // num_tasks) for i in range(num_tasks)
     ]
 
-    pool = ThreadPool(processes=num_tasks)
-    results = pool.map(reader, tasks)
+    with ThreadPool(processes=num_tasks) as pool:
+        results = pool.map(reader, tasks)
 
     header = results[0].columns
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

I think I got all `ResourceWarning`s when running:
`PYTHONWARNINGS=default pytest pandas/tests/io`