### PR TITLE
BUG: unexpected merge_ordered results caused by wrongly groupby

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -756,6 +756,8 @@ Reshaping
 - Bug in :func:`concat` resulting in a ``ValueError`` when at least one of both inputs had a non-unique index (:issue:`36263`)
 - Bug in :meth:`DataFrame.merge` and :meth:`pandas.merge` returning inconsistent ordering in result for ``how=right`` and ``how=left`` (:issue:`35382`)
 - Bug in :func:`merge_ordered` couldn't handle list-like ``left_by`` or ``right_by`` (:issue:`35269`)
+- Bug in :func:`merge_ordered` returned wrong join result when length of ``left_by`` or ``right_by`` equals to the rows of ``left`` or ``right`` (:issue:`38166`)
+- Bug in :func:`merge_ordered` didn't raise when elements in ``left_by`` or ``right_by`` not exist in ``left`` columns or ``right`` columns (:issue:`38167`)
 
 Sparse
 ^^^^^^

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -114,7 +114,7 @@ def _groupby_and_merge(by, on, left: "DataFrame", right: "DataFrame", merge_piec
 
     # if we can groupby the rhs
     # then we can get vastly better perf
-    if all([item in right.columns for item in by]):
+    if all(item in right.columns for item in by):
         rby = right.groupby(by, sort=False)
 
     for key, lhs in lby:
@@ -273,7 +273,7 @@ def merge_ordered(
     elif left_by is not None:
         if isinstance(left_by, str):
             left_by = [left_by]
-        check = list(filter(lambda i: i not in left.columns, left_by))
+        check = set(left_by).difference(left.columns)
         if len(check) != 0:
             raise KeyError(f"{check} not found in left columns")
         result, _ = _groupby_and_merge(
@@ -282,7 +282,7 @@ def merge_ordered(
     elif right_by is not None:
         if isinstance(right_by, str):
             right_by = [right_by]
-        check = list(filter(lambda i: i not in right.columns, right_by))
+        check = set(right_by).difference(right.columns)
         if len(check) != 0:
             raise KeyError(f"{check} not found in right columns")
         result, _ = _groupby_and_merge(

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -114,11 +114,8 @@ def _groupby_and_merge(by, on, left: "DataFrame", right: "DataFrame", merge_piec
 
     # if we can groupby the rhs
     # then we can get vastly better perf
-
-    try:
+    if all([item in right.columns for item in by]):
         rby = right.groupby(by, sort=False)
-    except KeyError:
-        pass
 
     for key, lhs in lby:
 
@@ -274,10 +271,20 @@ def merge_ordered(
     if left_by is not None and right_by is not None:
         raise ValueError("Can only group either left or right frames")
     elif left_by is not None:
+        if isinstance(left_by, str):
+            left_by = [left_by]
+        check = list(filter(lambda i: i not in left.columns, left_by))
+        if len(check) != 0:
+            raise KeyError(f"{check} not found in left columns")
         result, _ = _groupby_and_merge(
             left_by, on, left, right, lambda x, y: _merger(x, y)
         )
     elif right_by is not None:
+        if isinstance(right_by, str):
+            right_by = [right_by]
+        check = list(filter(lambda i: i not in right.columns, right_by))
+        if len(check) != 0:
+            raise KeyError(f"{check} not found in right columns")
         result, _ = _groupby_and_merge(
             right_by, on, right, left, lambda x, y: _merger(y, x)
         )

--- a/pandas/tests/reshape/merge/test_merge_ordered.py
+++ b/pandas/tests/reshape/merge/test_merge_ordered.py
@@ -193,6 +193,6 @@ class TestMergeOrdered:
         # GH 38167
         left = DataFrame([["g", "h", 1], ["g", "h", 3]], columns=list("GHT"))
         right = DataFrame([[2, 1]], columns=list("TE"))
-        msg = r"\['h'\] not found in left columns"
+        msg = r"\{'h'\} not found in left columns"
         with pytest.raises(KeyError, match=msg):
             merge_ordered(left, right, on="T", left_by=["G", "h"])

--- a/pandas/tests/reshape/merge/test_merge_ordered.py
+++ b/pandas/tests/reshape/merge/test_merge_ordered.py
@@ -177,3 +177,27 @@ class TestMergeOrdered:
         )
 
         tm.assert_frame_equal(result, expected)
+
+    def test_left_by_length_equals_to_right_shape0(self):
+        # GH 38166
+        l = DataFrame([["g", "h", 1], ["g", "h", 3]], columns=list("GHT"))
+        r = DataFrame([[2, 1]], columns=list("TE"))
+        result = merge_ordered(l, r, on="T", left_by=["G", "H"])
+        expected = DataFrame(
+            {
+                "G": ["g"] * 3,
+                "H": ["h"] * 3,
+                "T": [1, 2, 3],
+                "E": [np.nan, 1.0, np.nan]
+            }
+        )
+
+        tm.assert_frame_equal(result, expected)
+
+    def test_elements_not_in_by_but_in_df(self):
+        # GH 38167
+        l = DataFrame([["g", "h", 1], ["g", "h", 3]], columns=list("GHT"))
+        r = DataFrame([[2, 1]], columns=list("TE"))
+        msg = r"\['h'\] not found in left columns"
+        with pytest.raises(KeyError, match=msg):
+            merge_ordered(l, r, on="T", left_by=["G", "h"])

--- a/pandas/tests/reshape/merge/test_merge_ordered.py
+++ b/pandas/tests/reshape/merge/test_merge_ordered.py
@@ -180,9 +180,9 @@ class TestMergeOrdered:
 
     def test_left_by_length_equals_to_right_shape0(self):
         # GH 38166
-        l = DataFrame([["g", "h", 1], ["g", "h", 3]], columns=list("GHT"))
-        r = DataFrame([[2, 1]], columns=list("TE"))
-        result = merge_ordered(l, r, on="T", left_by=["G", "H"])
+        left = DataFrame([["g", "h", 1], ["g", "h", 3]], columns=list("GHT"))
+        right = DataFrame([[2, 1]], columns=list("TE"))
+        result = merge_ordered(left, right, on="T", left_by=["G", "H"])
         expected = DataFrame(
             {
                 "G": ["g"] * 3,
@@ -196,8 +196,8 @@ class TestMergeOrdered:
 
     def test_elements_not_in_by_but_in_df(self):
         # GH 38167
-        l = DataFrame([["g", "h", 1], ["g", "h", 3]], columns=list("GHT"))
-        r = DataFrame([[2, 1]], columns=list("TE"))
+        left = DataFrame([["g", "h", 1], ["g", "h", 3]], columns=list("GHT"))
+        right = DataFrame([[2, 1]], columns=list("TE"))
         msg = r"\['h'\] not found in left columns"
         with pytest.raises(KeyError, match=msg):
-            merge_ordered(l, r, on="T", left_by=["G", "h"])
+            merge_ordered(left, right, on="T", left_by=["G", "h"])

--- a/pandas/tests/reshape/merge/test_merge_ordered.py
+++ b/pandas/tests/reshape/merge/test_merge_ordered.py
@@ -185,10 +185,7 @@ class TestMergeOrdered:
         result = merge_ordered(left, right, on="T", left_by=["G", "H"])
         expected = DataFrame(
             {
-                "G": ["g"] * 3,
-                "H": ["h"] * 3,
-                "T": [1, 2, 3],
-                "E": [np.nan, 1.0, np.nan]
+                {"G": ["g"] * 3, "H": ["h"] * 3, "T": [1, 2, 3], "E": [np.nan, 1.0, np.nan]}
             }
         )
 

--- a/pandas/tests/reshape/merge/test_merge_ordered.py
+++ b/pandas/tests/reshape/merge/test_merge_ordered.py
@@ -184,9 +184,7 @@ class TestMergeOrdered:
         right = DataFrame([[2, 1]], columns=list("TE"))
         result = merge_ordered(left, right, on="T", left_by=["G", "H"])
         expected = DataFrame(
-            {
-                {"G": ["g"] * 3, "H": ["h"] * 3, "T": [1, 2, 3], "E": [np.nan, 1.0, np.nan]}
-            }
+            {"G": ["g"] * 3, "H": ["h"] * 3, "T": [1, 2, 3], "E": [np.nan, 1.0, np.nan]}
         )
 
         tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #38166
- [x] closes #38167
- [x] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
