### PR TITLE
CI: update tests for numpy 1.20 change to floordiv

### DIFF
--- a/pandas/tests/arrays/integer/test_arithmetic.py
+++ b/pandas/tests/arrays/integer/test_arithmetic.py
@@ -3,6 +3,8 @@ import operator
 import numpy as np
 import pytest
 
+from pandas.compat.numpy import _np_version_under1p20
+
 import pandas as pd
 import pandas._testing as tm
 from pandas.core.arrays import integer_array
@@ -197,7 +199,9 @@ def test_arith_coerce_scalar(data, all_arithmetic_operators):
     result = op(s, other)
     expected = op(s.astype(float), other)
     # rfloordiv results in nan instead of inf
-    if all_arithmetic_operators == "__rfloordiv__":
+    if all_arithmetic_operators == "__rfloordiv__" and _np_version_under1p20:
+        # for numpy 1.20 https://github.com/numpy/numpy/pull/16161
+        #  updated floordiv, now matches our behavior defined in core.ops
         expected[(expected == np.inf) | (expected == -np.inf)] = np.nan
 
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/arrays/sparse/test_arithmetics.py
+++ b/pandas/tests/arrays/sparse/test_arithmetics.py
@@ -150,7 +150,22 @@ class TestSparseArrayArithmetics:
         self._check_comparison_ops(a, 0, values, 0)
         self._check_comparison_ops(a, 3, values, 3)
 
-    def test_float_same_index(self, kind, mix, all_arithmetic_functions, request):
+    def test_float_same_index_without_nans(
+        self, kind, mix, all_arithmetic_functions, request
+    ):
+        # when sp_index are the same
+        op = all_arithmetic_functions
+
+        values = self._base([0.0, 1.0, 2.0, 6.0, 0.0, 0.0, 1.0, 2.0, 1.0, 0.0])
+        rvalues = self._base([0.0, 2.0, 3.0, 4.0, 0.0, 0.0, 1.0, 3.0, 2.0, 0.0])
+
+        a = self._klass(values, kind=kind, fill_value=0)
+        b = self._klass(rvalues, kind=kind, fill_value=0)
+        self._check_numeric_ops(a, b, values, rvalues, mix, op)
+
+    def test_float_same_index_with_nans(
+        self, kind, mix, all_arithmetic_functions, request
+    ):
         # when sp_index are the same
         op = all_arithmetic_functions
 
@@ -164,13 +179,6 @@ class TestSparseArrayArithmetics:
 
         a = self._klass(values, kind=kind)
         b = self._klass(rvalues, kind=kind)
-        self._check_numeric_ops(a, b, values, rvalues, mix, op)
-
-        values = self._base([0.0, 1.0, 2.0, 6.0, 0.0, 0.0, 1.0, 2.0, 1.0, 0.0])
-        rvalues = self._base([0.0, 2.0, 3.0, 4.0, 0.0, 0.0, 1.0, 3.0, 2.0, 0.0])
-
-        a = self._klass(values, kind=kind, fill_value=0)
-        b = self._klass(rvalues, kind=kind, fill_value=0)
         self._check_numeric_ops(a, b, values, rvalues, mix, op)
 
     def test_float_same_index_comparison(self, kind):
@@ -342,8 +350,8 @@ class TestSparseArrayArithmetics:
         op = all_arithmetic_functions
 
         if not _np_version_under1p20:
-            if op in [operator.floordiv, ops.rfloordiv]:
-                mark = pytest.mark.xfail(strict=False, reason="GH#38172")
+            if op in [operator.floordiv, ops.rfloordiv] and mix:
+                mark = pytest.mark.xfail(strict=True, reason="GH#38172")
                 request.node.add_marker(mark)
 
         rdtype = "int64"

--- a/pandas/tests/arrays/sparse/test_arithmetics.py
+++ b/pandas/tests/arrays/sparse/test_arithmetics.py
@@ -31,7 +31,7 @@ class TestSparseArrayArithmetics:
     def _assert(self, a, b):
         tm.assert_numpy_array_equal(a, b)
 
-    def _check_numeric_ops(self, a, b, a_dense, b_dense, mix, op, flag=False):
+    def _check_numeric_ops(self, a, b, a_dense, b_dense, mix, op):
         with np.errstate(invalid="ignore", divide="ignore"):
             if mix:
                 result = op(a, b_dense).to_dense()

--- a/pandas/tests/arrays/sparse/test_arithmetics.py
+++ b/pandas/tests/arrays/sparse/test_arithmetics.py
@@ -3,6 +3,8 @@ import operator
 import numpy as np
 import pytest
 
+from pandas.compat.numpy import _np_version_under1p20
+
 import pandas as pd
 import pandas._testing as tm
 from pandas.core import ops
@@ -44,9 +46,12 @@ class TestSparseArrayArithmetics:
 
             if op in [operator.floordiv, ops.rfloordiv]:
                 # Series sets 1//0 to np.inf, which SparseArray does not do (yet)
-                mask = np.isinf(expected)
-                if mask.any():
-                    expected[mask] = np.nan
+                if _np_version_under1p20:
+                    # numpy 1.20 updated floordiv, matching the behavior
+                    #  in core.ops.  See https://github.com/numpy/numpy/pull/16161
+                    mask = np.isinf(expected)
+                    if mask.any():
+                        expected[mask] = np.nan
 
             self._assert(result, expected)
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Looks like https://github.com/numpy/numpy/pull/16161 changed numpy's floordiv behavior