### PR TITLE
The error message for unsupported index on shift() could be more explicit

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4735,8 +4735,10 @@ class Index(IndexOpsMixin, PandasObject):
                        '2012-03-01'],
                       dtype='datetime64[ns]', freq='MS')
         """
-        raise NotImplementedError(f"This method is only implemented for DatetimeIndex," 
-                                  "PeriodIndex and TimedeltaIndex; Got type {type(self).__name__}")
+        raise NotImplementedError(
+            f"This method is only implemented for DatetimeIndex,"
+            "PeriodIndex and TimedeltaIndex; Got type {type(self).__name__}"
+        )
 
     def argsort(self, *args, **kwargs) -> np.ndarray:
         """

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4735,7 +4735,8 @@ class Index(IndexOpsMixin, PandasObject):
                        '2012-03-01'],
                       dtype='datetime64[ns]', freq='MS')
         """
-        raise NotImplementedError(f"This method is only implemented for DatetimeIndex, PeriodIndex and TimedeltaIndex; Got type {type(self).__name__}")
+        raise NotImplementedError(f"This method is only implemented for DatetimeIndex," 
+                                  "PeriodIndex and TimedeltaIndex; Got type {type(self).__name__}")
 
     def argsort(self, *args, **kwargs) -> np.ndarray:
         """

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4735,7 +4735,7 @@ class Index(IndexOpsMixin, PandasObject):
                        '2012-03-01'],
                       dtype='datetime64[ns]', freq='MS')
         """
-        raise NotImplementedError(f"Not supported for type {type(self).__name__}")
+        raise NotImplementedError(f"This method is only implemented for DatetimeIndex, PeriodIndex and TimedeltaIndex; Got type {type(self).__name__}")
 
     def argsort(self, *args, **kwargs) -> np.ndarray:
         """

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4736,7 +4736,7 @@ class Index(IndexOpsMixin, PandasObject):
                       dtype='datetime64[ns]', freq='MS')
         """
         raise NotImplementedError(
-            f"This method is only implemented for DatetimeIndex,"
+            f"This method is only implemented for DatetimeIndex, "
             "PeriodIndex and TimedeltaIndex; Got type {type(self).__name__}"
         )
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4735,9 +4735,8 @@ class Index(IndexOpsMixin, PandasObject):
                        '2012-03-01'],
                       dtype='datetime64[ns]', freq='MS')
         """
-        raise NotImplementedError(
-            f"This method is only implemented for DatetimeIndex, PeriodIndex and "
-            f"TimedeltaIndex; Got type {type(self).__name__}")
+        raise NotImplementedError(f"This method is only implemented for DatetimeIndex, PeriodIndex and "
+                                  f"TimedeltaIndex; Got type {type(self).__name__}")
 
     def argsort(self, *args, **kwargs) -> np.ndarray:
         """

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4736,9 +4736,8 @@ class Index(IndexOpsMixin, PandasObject):
                       dtype='datetime64[ns]', freq='MS')
         """
         raise NotImplementedError(
-            f"This method is only implemented for DatetimeIndex, "
-            "PeriodIndex and TimedeltaIndex; Got type {type(self).__name__}"
-        )
+            f"This method is only implemented for DatetimeIndex, PeriodIndex and "
+            f"TimedeltaIndex; Got type {type(self).__name__}")
 
     def argsort(self, *args, **kwargs) -> np.ndarray:
         """

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4735,8 +4735,10 @@ class Index(IndexOpsMixin, PandasObject):
                        '2012-03-01'],
                       dtype='datetime64[ns]', freq='MS')
         """
-        raise NotImplementedError(f"This method is only implemented for DatetimeIndex, PeriodIndex and "
-                                  f"TimedeltaIndex; Got type {type(self).__name__}")
+        raise NotImplementedError(
+            f"This method is only implemented for DatetimeIndex, PeriodIndex and "
+            f"TimedeltaIndex; Got type {type(self).__name__}"
+        )
 
     def argsort(self, *args, **kwargs) -> np.ndarray:
         """

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -73,7 +73,8 @@ class Base:
 
         # GH8083 test the base class for shift
         idx = self.create_index()
-        msg = f"Not supported for type {type(idx).__name__}"
+        msg = f"This method is only implemented for DatetimeIndex, "
+            "PeriodIndex and TimedeltaIndex; Got type {type(idx).__name__}"
         with pytest.raises(NotImplementedError, match=msg):
             idx.shift(1)
         with pytest.raises(NotImplementedError, match=msg):

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -74,7 +74,7 @@ class Base:
         # GH8083 test the base class for shift
         idx = self.create_index()
         msg = f"This method is only implemented for DatetimeIndex, "
-            "PeriodIndex and TimedeltaIndex; Got type {type(idx).__name__}"
+              "PeriodIndex and TimedeltaIndex; Got type {type(idx).__name__}"
         with pytest.raises(NotImplementedError, match=msg):
             idx.shift(1)
         with pytest.raises(NotImplementedError, match=msg):

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -74,7 +74,7 @@ class Base:
         # GH8083 test the base class for shift
         idx = self.create_index()
         msg = f"This method is only implemented for DatetimeIndex, "
-              "PeriodIndex and TimedeltaIndex; Got type {type(idx).__name__}"
+        "PeriodIndex and TimedeltaIndex; Got type {type(idx).__name__}"
         with pytest.raises(NotImplementedError, match=msg):
             idx.shift(1)
         with pytest.raises(NotImplementedError, match=msg):

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -74,7 +74,7 @@ class Base:
         # GH8083 test the base class for shift
         idx = self.create_index()
         msg = f"This method is only implemented for DatetimeIndex, PeriodIndex and "
-              f"TimedeltaIndex; Got type {type(idx).__name__}"
+        f"TimedeltaIndex; Got type {type(idx).__name__}"
         with pytest.raises(NotImplementedError, match=msg):
             idx.shift(1)
         with pytest.raises(NotImplementedError, match=msg):

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -73,8 +73,8 @@ class Base:
 
         # GH8083 test the base class for shift
         idx = self.create_index()
-        msg = f"This method is only implemented for DatetimeIndex, "
-        "PeriodIndex and TimedeltaIndex; Got type {type(idx).__name__}"
+        msg = f"This method is only implemented for DatetimeIndex, PeriodIndex and "
+              f"TimedeltaIndex; Got type {type(idx).__name__}"
         with pytest.raises(NotImplementedError, match=msg):
             idx.shift(1)
         with pytest.raises(NotImplementedError, match=msg):

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -73,8 +73,10 @@ class Base:
 
         # GH8083 test the base class for shift
         idx = self.create_index()
-        msg = f"This method is only implemented for DatetimeIndex, PeriodIndex and "\
-        f"TimedeltaIndex; Got type {type(idx).__name__}"
+        msg = (
+            f"This method is only implemented for DatetimeIndex, PeriodIndex and "
+            f"TimedeltaIndex; Got type {type(idx).__name__}"
+        )
         with pytest.raises(NotImplementedError, match=msg):
             idx.shift(1)
         with pytest.raises(NotImplementedError, match=msg):

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -73,7 +73,7 @@ class Base:
 
         # GH8083 test the base class for shift
         idx = self.create_index()
-        msg = f"This method is only implemented for DatetimeIndex, PeriodIndex and "
+        msg = f"This method is only implemented for DatetimeIndex, PeriodIndex and "\
         f"TimedeltaIndex; Got type {type(idx).__name__}"
         with pytest.raises(NotImplementedError, match=msg):
             idx.shift(1)

--- a/pandas/tests/indexes/multi/test_analytics.py
+++ b/pandas/tests/indexes/multi/test_analytics.py
@@ -11,7 +11,8 @@ import pandas._testing as tm
 def test_shift(idx):
 
     # GH8083 test the base class for shift
-    msg = "Not supported for type MultiIndex"
+    msg = "This method is only implemented for DatetimeIndex, "
+    "PeriodIndex and TimedeltaIndex; Got type MultiIndex"
     with pytest.raises(NotImplementedError, match=msg):
         idx.shift(1)
     with pytest.raises(NotImplementedError, match=msg):

--- a/pandas/tests/indexes/multi/test_analytics.py
+++ b/pandas/tests/indexes/multi/test_analytics.py
@@ -11,8 +11,8 @@ import pandas._testing as tm
 def test_shift(idx):
 
     # GH8083 test the base class for shift
-    msg = "This method is only implemented for DatetimeIndex, "
-    "PeriodIndex and TimedeltaIndex; Got type MultiIndex"
+    msg = "This method is only implemented for DatetimeIndex, PeriodIndex and "
+    "TimedeltaIndex; Got type MultiIndex"
     with pytest.raises(NotImplementedError, match=msg):
         idx.shift(1)
     with pytest.raises(NotImplementedError, match=msg):


### PR DESCRIPTION
When the type of data index is not datetime-like, the following error message will raise:
`NotImplementedError: Not supported for type Index`
 
The error message could be more useful by explicitly stating which types of data that `shift` supports.
 
Expected error message:
` f"This method is only implemented for DatetimeIndex, PeriodIndex and TimedeltaIndex; Got type {type(self).__name__}."`
