### PR TITLE
PERF: Introducing hash tables for complex64 and complex128

### DIFF
--- a/pandas/_libs/hashtable.pxd
+++ b/pandas/_libs/hashtable.pxd
@@ -1,12 +1,16 @@
 from numpy cimport intp_t, ndarray
 
 from pandas._libs.khash cimport (
+    complex64_t,
+    complex128_t,
     float32_t,
     float64_t,
     int8_t,
     int16_t,
     int32_t,
     int64_t,
+    kh_complex64_t,
+    kh_complex128_t,
     kh_float32_t,
     kh_float64_t,
     kh_int8_t,
@@ -19,6 +23,8 @@ from pandas._libs.khash cimport (
     kh_uint16_t,
     kh_uint32_t,
     kh_uint64_t,
+    khcomplex64_t,
+    khcomplex128_t,
     uint8_t,
     uint16_t,
     uint32_t,
@@ -89,6 +95,18 @@ cdef class Float32HashTable(HashTable):
 
     cpdef get_item(self, float32_t val)
     cpdef set_item(self, float32_t key, Py_ssize_t val)
+
+cdef class Complex64HashTable(HashTable):
+    cdef kh_complex64_t *table
+
+    cpdef get_item(self, complex64_t val)
+    cpdef set_item(self, complex64_t key, Py_ssize_t val)
+
+cdef class Complex128HashTable(HashTable):
+    cdef kh_complex128_t *table
+
+    cpdef get_item(self, complex128_t val)
+    cpdef set_item(self, complex128_t key, Py_ssize_t val)
 
 cdef class PyObjectHashTable(HashTable):
     cdef kh_pymap_t *table

--- a/pandas/_libs/hashtable.pyx
+++ b/pandas/_libs/hashtable.pyx
@@ -15,8 +15,10 @@ cnp.import_array()
 from pandas._libs cimport util
 from pandas._libs.khash cimport (
     KHASH_TRACE_DOMAIN,
-    are_equal_khcomplex64_t,
-    are_equal_khcomplex128_t,
+    are_equivalent_float32_t,
+    are_equivalent_float64_t,
+    are_equivalent_khcomplex64_t,
+    are_equivalent_khcomplex128_t,
     kh_str_t,
     khcomplex64_t,
     khcomplex128_t,

--- a/pandas/_libs/hashtable.pyx
+++ b/pandas/_libs/hashtable.pyx
@@ -13,7 +13,15 @@ cnp.import_array()
 
 
 from pandas._libs cimport util
-from pandas._libs.khash cimport KHASH_TRACE_DOMAIN, kh_str_t, khiter_t
+from pandas._libs.khash cimport (
+    KHASH_TRACE_DOMAIN,
+    are_equal_khcomplex64_t,
+    are_equal_khcomplex128_t,
+    kh_str_t,
+    khcomplex64_t,
+    khcomplex128_t,
+    khiter_t,
+)
 from pandas._libs.missing cimport checknull
 
 

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -19,52 +19,53 @@ cdef kh{{name}}_t to_kh{{name}}_t({{name}}_t val) nogil:
     res.imag = val.imag
     return res
 
+
 cdef {{name}}_t to_{{name}}(kh{{name}}_t val) nogil:
     cdef {{name}}_t res
     res.real = val.real
     res.imag = val.imag
     return res
 
-cdef bint is_nan_kh{{name}}_t(kh{{name}}_t val) nogil:
+{{endfor}}
+
+
+{{py:
+
+
+# name
+c_types = ['khcomplex128_t',
+           'khcomplex64_t',
+           'float64_t',
+           'float32_t',
+           'int64_t',
+           'int32_t',
+           'int16_t',
+           'int8_t',
+           'uint64_t',
+           'uint32_t',
+           'uint16_t',
+           'uint8_t']
+}}
+
+{{for c_type in c_types}}
+
+cdef bint is_nan_{{c_type}}({{c_type}} val) nogil:
+    {{if c_type in {'khcomplex128_t', 'khcomplex64_t'} }}
     return val.real != val.real or val.imag != val.imag
-{{endfor}}
-
-
-{{py:
-
-# name
-float_types = ['float64_t',
-               'float32_t']
-}}
-
-{{for c_type in float_types}}
-
-cdef bint is_nan_{{c_type}}({{c_type}} val) nogil:
+    {{elif c_type in {'float64_t', 'float32_t'} }}
     return val != val
-{{endfor}}
-
-
-{{py:
-
-
-# name
-int_types = ['int64_t',
-             'int32_t',
-             'int16_t',
-             'int8_t',
-             'uint64_t',
-             'uint32_t',
-             'uint16_t',
-             'uint8_t']
-}}
-
-{{for c_type in int_types}}
-
-cdef bint is_nan_{{c_type}}({{c_type}} val) nogil:
+    {{else}}
     return False
+    {{endif}}
 
+
+{{if c_type in {'khcomplex128_t', 'khcomplex64_t', 'float64_t', 'float32_t'} }}
+# are_equivalent_{{c_type}} is cimported via khash.pxd
+{{else}}
 cdef bint are_equivalent_{{c_type}}({{c_type}} val1, {{c_type}} val2) nogil:
     return val1 == val2
+{{endif}}
+
 {{endfor}}
 
 
@@ -97,6 +98,7 @@ from pandas._libs.khash cimport (
     kh_put_{{name}},
     kh_resize_{{name}},
 )
+
 {{endfor}}
 
 # ----------------------------------------------------------------------

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -8,7 +8,34 @@ WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
 {{py:
 
 # name
-cimported_types = ['float32',
+complex_types = ['complex64',
+                 'complex128']
+}}
+
+{{for name in complex_types}}
+cdef kh{{name}}_t to_kh{{name}}_t({{name}}_t val) nogil:
+    cdef kh{{name}}_t res
+    res.real = val.real
+    res.imag = val.imag
+    return res
+
+cdef {{name}}_t to_{{name}}(kh{{name}}_t val) nogil:
+    cdef {{name}}_t res
+    res.real = val.real
+    res.imag = val.imag
+    return res
+
+cdef bint is_nan_kh{{name}}_t(kh{{name}}_t val) nogil:
+    return val.real != val.real or val.imag != val.imag
+{{endfor}}
+
+
+{{py:
+
+# name
+cimported_types = ['complex64',
+                   'complex128',
+                   'float32',
                    'float64',
                    'int8',
                    'int16',
@@ -48,7 +75,9 @@ from pandas._libs.missing cimport C_NA
 # but is included for completeness (rather ObjectVector is used
 # for uniques in hashtables)
 
-dtypes = [('Float64', 'float64', 'float64_t'),
+dtypes = [('Complex128', 'complex128', 'khcomplex128_t'),
+          ('Complex64', 'complex64', 'khcomplex64_t'),
+          ('Float64', 'float64', 'float64_t'),
           ('Float32', 'float32', 'float32_t'),
           ('Int64', 'int64', 'int64_t'),
           ('Int32', 'int32', 'int32_t'),
@@ -94,6 +123,8 @@ ctypedef fused vector_data:
     UInt8VectorData
     Float64VectorData
     Float32VectorData
+    Complex128VectorData
+    Complex64VectorData
     StringVectorData
 
 cdef inline bint needs_resize(vector_data *data) nogil:
@@ -106,7 +137,9 @@ cdef inline bint needs_resize(vector_data *data) nogil:
 {{py:
 
 # name, dtype, c_type
-dtypes = [('Float64', 'float64', 'float64_t'),
+dtypes = [('Complex128', 'complex128', 'khcomplex128_t'),
+          ('Complex64', 'complex64', 'khcomplex64_t'),
+          ('Float64', 'float64', 'float64_t'),
           ('UInt64', 'uint64', 'uint64_t'),
           ('Int64', 'int64', 'int64_t'),
           ('Float32', 'float32', 'float32_t'),
@@ -303,22 +336,24 @@ cdef class HashTable:
 
 {{py:
 
-# name, dtype, c_type, float_group
-dtypes = [('Float64', 'float64', 'float64_t', True),
-          ('UInt64', 'uint64', 'uint64_t', False),
-          ('Int64', 'int64', 'int64_t', False),
-          ('Float32', 'float32', 'float32_t', True),
-          ('UInt32', 'uint32', 'uint32_t', False),
-          ('Int32', 'int32', 'int32_t', False),
-          ('UInt16', 'uint16', 'uint16_t', False),
-          ('Int16', 'int16', 'int16_t', False),
-          ('UInt8', 'uint8', 'uint8_t', False),
-          ('Int8', 'int8', 'int8_t', False)]
+# name, dtype, c_type, float_group, complex_group
+dtypes = [('Complex128', 'complex128', 'khcomplex128_t', True, True),
+          ('Float64', 'float64', 'float64_t', True, False),
+          ('UInt64', 'uint64', 'uint64_t', False, False),
+          ('Int64', 'int64', 'int64_t', False, False),
+          ('Complex64', 'complex64', 'khcomplex64_t', True, True),
+          ('Float32', 'float32', 'float32_t', True, False),
+          ('UInt32', 'uint32', 'uint32_t', False, False),
+          ('Int32', 'int32', 'int32_t', False, False),
+          ('UInt16', 'uint16', 'uint16_t', False, False),
+          ('Int16', 'int16', 'int16_t', False, False),
+          ('UInt8', 'uint8', 'uint8_t', False, False),
+          ('Int8', 'int8', 'int8_t', False, False)]
 
 }}
 
 
-{{for name, dtype, c_type, float_group in dtypes}}
+{{for name, dtype, c_type, float_group, complex_group in dtypes}}
 
 cdef class {{name}}HashTable(HashTable):
 
@@ -339,7 +374,13 @@ cdef class {{name}}HashTable(HashTable):
     def __contains__(self, object key):
         cdef:
             khiter_t k
-        k = kh_get_{{dtype}}(self.table, key)
+            {{c_type}} ckey
+        {{if complex_group}}
+        ckey = to_{{c_type}}(key)
+        {{else}}
+        ckey = key
+        {{endif}}
+        k = kh_get_{{dtype}}(self.table, ckey)
         return k != self.table.n_buckets
 
     def sizeof(self, deep=False):
@@ -353,7 +394,13 @@ cdef class {{name}}HashTable(HashTable):
     cpdef get_item(self, {{dtype}}_t val):
         cdef:
             khiter_t k
-        k = kh_get_{{dtype}}(self.table, val)
+            {{c_type}} cval
+        {{if complex_group}}
+        cval = to_{{c_type}}(val)
+        {{else}}
+        cval = val
+        {{endif}}
+        k = kh_get_{{dtype}}(self.table, cval)
         if k != self.table.n_buckets:
             return self.table.vals[k]
         else:
@@ -363,8 +410,13 @@ cdef class {{name}}HashTable(HashTable):
         cdef:
             khiter_t k
             int ret = 0
-
-        k = kh_put_{{dtype}}(self.table, key, &ret)
+            {{c_type}} ckey
+        {{if complex_group}}
+        ckey = to_{{c_type}}(key)
+        {{else}}
+        ckey = key
+        {{endif}}
+        k = kh_put_{{dtype}}(self.table, ckey, &ret)
         if kh_exist_{{dtype}}(self.table, k):
             self.table.vals[k] = val
         else:
@@ -486,9 +538,17 @@ cdef class {{name}}HashTable(HashTable):
             # We use None, to make it optional, which requires `object` type
             # for the parameter. To please the compiler, we use na_value2,
             # which is only used if it's *specified*.
-            na_value2 = <{{dtype}}_t>na_value
+            {{if complex_group}}
+            na_value2 = to_{{c_type}}(na_value)
+            {{else}}
+            na_value2 = na_value
+            {{endif}}       
         else:
+            {{if complex_group}}
+            na_value2 = to_{{c_type}}(0)
+            {{else}}
             na_value2 = 0
+            {{endif}}   
 
         with nogil:
             for i in range(n):
@@ -499,10 +559,14 @@ cdef class {{name}}HashTable(HashTable):
                         labels[i] = na_sentinel
                         continue
                 elif ignore_na and (
-                {{if not name.lower().startswith(("uint", "int"))}}
-                val != val or
-                {{endif}}
+                {{if complex_group}}
+                not is_nan_{{c_type}}(val) or 
+                (use_na_value and are_equal_{{c_type}}(val,na_value2))
+                {{elif float_group}}
+                val != val or (use_na_value and val == na_value2)
+                {{else}}
                 (use_na_value and val == na_value2)
+                {{endif}}             
                 ):
                     # if missing values do not count as unique values (i.e. if
                     # ignore_na is True), skip the hashtable entry for them,
@@ -625,7 +689,12 @@ cdef class {{name}}HashTable(HashTable):
                 val = values[i]
 
                 # specific for groupby
-                {{if dtype != 'uint64'}}
+                {{if dtype == 'complex64' or dtype== 'complex128'}}
+                # TODO: what should be done here?
+                if val.real < 0:
+                    labels[i] = -1
+                    continue
+                {{elif dtype != 'uint64'}}
                 if val < 0:
                     labels[i] = -1
                     continue

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -33,6 +33,44 @@ cdef bint is_nan_kh{{name}}_t(kh{{name}}_t val) nogil:
 {{py:
 
 # name
+float_types = ['float64_t',
+               'float32_t']
+}}
+
+{{for c_type in float_types}}
+
+cdef bint is_nan_{{c_type}}({{c_type}} val) nogil:
+    return val != val
+{{endfor}}
+
+
+{{py:
+
+
+# name
+int_types = ['int64_t',
+             'int32_t',
+             'int16_t',
+             'int8_t',
+             'uint64_t',
+             'uint32_t',
+             'uint16_t',
+             'uint8_t',]
+}}
+
+{{for c_type in int_types}}
+
+cdef bint is_nan_{{c_type}}({{c_type}} val) nogil:
+    return False
+
+cdef bint are_equivalent_{{c_type}}({{c_type}} val1, {{c_type}} val2) nogil:
+    return val1 == val2
+{{endfor}}
+
+
+{{py:
+
+# name
 cimported_types = ['complex64',
                    'complex128',
                    'float32',
@@ -336,24 +374,24 @@ cdef class HashTable:
 
 {{py:
 
-# name, dtype, c_type, float_group, complex_group, to_c_type
-dtypes = [('Complex128', 'complex128', 'khcomplex128_t', True, True, "to_khcomplex128_t"),
-          ('Float64', 'float64', 'float64_t', True, False, ""),
-          ('UInt64', 'uint64', 'uint64_t', False, False, ""),
-          ('Int64', 'int64', 'int64_t', False, False, ""),
-          ('Complex64', 'complex64', 'khcomplex64_t', True, True, "to_khcomplex64_t"),
-          ('Float32', 'float32', 'float32_t', True, False, ""),
-          ('UInt32', 'uint32', 'uint32_t', False, False, ""),
-          ('Int32', 'int32', 'int32_t', False, False, ""),
-          ('UInt16', 'uint16', 'uint16_t', False, False, ""),
-          ('Int16', 'int16', 'int16_t', False, False, ""),
-          ('UInt8', 'uint8', 'uint8_t', False, False, ""),
-          ('Int8', 'int8', 'int8_t', False, False, "")]
+# name, dtype, c_type, to_c_type
+dtypes = [('Complex128', 'complex128', 'khcomplex128_t', "to_khcomplex128_t"),
+          ('Float64', 'float64', 'float64_t', ""),
+          ('UInt64', 'uint64', 'uint64_t', ""),
+          ('Int64', 'int64', 'int64_t', ""),
+          ('Complex64', 'complex64', 'khcomplex64_t', "to_khcomplex64_t"),
+          ('Float32', 'float32', 'float32_t', ""),
+          ('UInt32', 'uint32', 'uint32_t', ""),
+          ('Int32', 'int32', 'int32_t', ""),
+          ('UInt16', 'uint16', 'uint16_t', ""),
+          ('Int16', 'int16', 'int16_t', ""),
+          ('UInt8', 'uint8', 'uint8_t', ""),
+          ('Int8', 'int8', 'int8_t', "")]
 
 }}
 
 
-{{for name, dtype, c_type, float_group, complex_group, to_c_type in dtypes}}
+{{for name, dtype, c_type, to_c_type in dtypes}}
 
 cdef class {{name}}HashTable(HashTable):
 
@@ -539,14 +577,8 @@ cdef class {{name}}HashTable(HashTable):
                         labels[i] = na_sentinel
                         continue
                 elif ignore_na and (
-                {{if complex_group}}
-                not is_nan_{{c_type}}(val) or 
-                (use_na_value and are_equal_{{c_type}}(val,na_value2))
-                {{elif float_group}}
-                val != val or (use_na_value and val == na_value2)
-                {{else}}
-                (use_na_value and val == na_value2)
-                {{endif}}             
+                    is_nan_{{c_type}}(val) or 
+                    (use_na_value and are_equivalent_{{c_type}}(val,na_value2))               
                 ):
                     # if missing values do not count as unique values (i.e. if
                     # ignore_na is True), skip the hashtable entry for them,

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -55,7 +55,7 @@ int_types = ['int64_t',
              'uint64_t',
              'uint32_t',
              'uint16_t',
-             'uint8_t',]
+             'uint8_t']
 }}
 
 {{for c_type in int_types}}
@@ -564,9 +564,9 @@ cdef class {{name}}HashTable(HashTable):
             # We use None, to make it optional, which requires `object` type
             # for the parameter. To please the compiler, we use na_value2,
             # which is only used if it's *specified*.
-            na_value2 = {{to_c_type}}(na_value)      
+            na_value2 = {{to_c_type}}(na_value)
         else:
-            na_value2 = {{to_c_type}}(0)  
+            na_value2 = {{to_c_type}}(0)
 
         with nogil:
             for i in range(n):
@@ -577,8 +577,8 @@ cdef class {{name}}HashTable(HashTable):
                         labels[i] = na_sentinel
                         continue
                 elif ignore_na and (
-                    is_nan_{{c_type}}(val) or 
-                    (use_na_value and are_equivalent_{{c_type}}(val,na_value2))               
+                   is_nan_{{c_type}}(val) or
+                   (use_na_value and are_equivalent_{{c_type}}(val, na_value2))
                 ):
                     # if missing values do not count as unique values (i.e. if
                     # ignore_na is True), skip the hashtable entry for them,

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -681,6 +681,7 @@ cdef class {{name}}HashTable(HashTable):
                                  ignore_na=True, return_inverse=True)
         return labels
 
+    {{if dtype == 'int64'}}
     @cython.boundscheck(False)
     def get_labels_groupby(self, const {{dtype}}_t[:] values):
         cdef:
@@ -701,16 +702,9 @@ cdef class {{name}}HashTable(HashTable):
                 val = {{to_c_type}}(values[i])
 
                 # specific for groupby
-                {{if dtype == 'complex64' or dtype== 'complex128'}}
-                # TODO: what should be done here?
-                if val.real < 0:
-                    labels[i] = -1
-                    continue
-                {{elif dtype != 'uint64'}}
                 if val < 0:
                     labels[i] = -1
                     continue
-                {{endif}}
 
                 k = kh_get_{{dtype}}(self.table, val)
                 if k != self.table.n_buckets:
@@ -730,6 +724,7 @@ cdef class {{name}}HashTable(HashTable):
         arr_uniques = uniques.to_array()
 
         return np.asarray(labels), arr_uniques
+    {{endif}}
 
 {{endfor}}
 

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -423,7 +423,7 @@ cdef class {{name}}HashTable(HashTable):
             raise KeyError(key)
 
     @cython.boundscheck(False)
-    def map(self, const {{c_type}}[:] keys, const int64_t[:] values):
+    def map(self, const {{dtype}}_t[:] keys, const int64_t[:] values):
         cdef:
             Py_ssize_t i, n = len(values)
             int ret = 0
@@ -432,12 +432,16 @@ cdef class {{name}}HashTable(HashTable):
 
         with nogil:
             for i in range(n):
+                {{if complex_group}}
+                key = to_{{c_type}}(keys[i])
+                {{else}}
                 key = keys[i]
+                {{endif}}
                 k = kh_put_{{dtype}}(self.table, key, &ret)
                 self.table.vals[k] = <Py_ssize_t>values[i]
 
     @cython.boundscheck(False)
-    def map_locations(self, const {{c_type}}[:] values):
+    def map_locations(self, const {{dtype}}_t[:] values):
         cdef:
             Py_ssize_t i, n = len(values)
             int ret = 0
@@ -446,12 +450,16 @@ cdef class {{name}}HashTable(HashTable):
 
         with nogil:
             for i in range(n):
+                {{if complex_group}}
+                val= to_{{c_type}}(values[i])
+                {{else}}
                 val = values[i]
+                {{endif}}
                 k = kh_put_{{dtype}}(self.table, val, &ret)
                 self.table.vals[k] = i
 
     @cython.boundscheck(False)
-    def lookup(self, const {{c_type}}[:] values):
+    def lookup(self, const {{dtype}}_t[:] values):
         cdef:
             Py_ssize_t i, n = len(values)
             int ret = 0
@@ -461,7 +469,11 @@ cdef class {{name}}HashTable(HashTable):
 
         with nogil:
             for i in range(n):
+                {{if complex_group}}
+                val = to_{{c_type}}(values[i])
+                {{else}}
                 val = values[i]
+                {{endif}}
                 k = kh_get_{{dtype}}(self.table, val)
                 if k != self.table.n_buckets:
                     locs[i] = self.table.vals[k]
@@ -472,7 +484,7 @@ cdef class {{name}}HashTable(HashTable):
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    def _unique(self, const {{c_type}}[:] values, {{name}}Vector uniques,
+    def _unique(self, const {{dtype}}_t[:] values, {{name}}Vector uniques,
                 Py_ssize_t count_prior=0, Py_ssize_t na_sentinel=-1,
                 object na_value=None, bint ignore_na=False,
                 object mask=None, bint return_inverse=False):
@@ -552,7 +564,11 @@ cdef class {{name}}HashTable(HashTable):
 
         with nogil:
             for i in range(n):
+                {{if complex_group}}
+                val = to_{{c_type}}(values[i])
+                {{else}}
                 val = values[i]
+                {{endif}}
 
                 if ignore_na and use_mask:
                     if mask_values[i]:
@@ -602,7 +618,7 @@ cdef class {{name}}HashTable(HashTable):
             return uniques.to_array(), np.asarray(labels)
         return uniques.to_array()
 
-    def unique(self, const {{c_type}}[:] values, bint return_inverse=False):
+    def unique(self, const {{dtype}}_t[:] values, bint return_inverse=False):
         """
         Calculate unique values and labels (no sorting!)
 
@@ -625,7 +641,7 @@ cdef class {{name}}HashTable(HashTable):
         return self._unique(values, uniques, ignore_na=False,
                             return_inverse=return_inverse)
 
-    def factorize(self, const {{c_type}}[:] values, Py_ssize_t na_sentinel=-1,
+    def factorize(self, const {{dtype}}_t[:] values, Py_ssize_t na_sentinel=-1,
                   object na_value=None, object mask=None):
         """
         Calculate unique values and labels (no sorting!)
@@ -670,7 +686,7 @@ cdef class {{name}}HashTable(HashTable):
         return labels
 
     @cython.boundscheck(False)
-    def get_labels_groupby(self, const {{c_type}}[:] values):
+    def get_labels_groupby(self, const {{dtype}}_t[:] values):
         cdef:
             Py_ssize_t i, n = len(values)
             intp_t[:] labels
@@ -686,7 +702,11 @@ cdef class {{name}}HashTable(HashTable):
 
         with nogil:
             for i in range(n):
+                {{if complex_group}}
+                val = to_{{c_type}}(values[i])
+                {{else}}
                 val = values[i]
+                {{endif}}
 
                 # specific for groupby
                 {{if dtype == 'complex64' or dtype== 'complex128'}}

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -375,18 +375,18 @@ cdef class HashTable:
 {{py:
 
 # name, dtype, c_type, to_c_type
-dtypes = [('Complex128', 'complex128', 'khcomplex128_t', "to_khcomplex128_t"),
-          ('Float64', 'float64', 'float64_t', ""),
-          ('UInt64', 'uint64', 'uint64_t', ""),
-          ('Int64', 'int64', 'int64_t', ""),
-          ('Complex64', 'complex64', 'khcomplex64_t', "to_khcomplex64_t"),
-          ('Float32', 'float32', 'float32_t', ""),
-          ('UInt32', 'uint32', 'uint32_t', ""),
-          ('Int32', 'int32', 'int32_t', ""),
-          ('UInt16', 'uint16', 'uint16_t', ""),
-          ('Int16', 'int16', 'int16_t', ""),
-          ('UInt8', 'uint8', 'uint8_t', ""),
-          ('Int8', 'int8', 'int8_t', "")]
+dtypes = [('Complex128', 'complex128', 'khcomplex128_t', 'to_khcomplex128_t'),
+          ('Float64', 'float64', 'float64_t', ''),
+          ('UInt64', 'uint64', 'uint64_t', ''),
+          ('Int64', 'int64', 'int64_t', ''),
+          ('Complex64', 'complex64', 'khcomplex64_t', 'to_khcomplex64_t'),
+          ('Float32', 'float32', 'float32_t', ''),
+          ('UInt32', 'uint32', 'uint32_t', ''),
+          ('Int32', 'int32', 'int32_t', ''),
+          ('UInt16', 'uint16', 'uint16_t', ''),
+          ('Int16', 'int16', 'int16_t', ''),
+          ('UInt8', 'uint8', 'uint8_t', ''),
+          ('Int8', 'int8', 'int8_t', '')]
 
 }}
 

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -303,22 +303,22 @@ cdef class HashTable:
 
 {{py:
 
-# name, dtype, float_group
-dtypes = [('Float64', 'float64', True),
-          ('UInt64', 'uint64', False),
-          ('Int64', 'int64', False),
-          ('Float32', 'float32', True),
-          ('UInt32', 'uint32', False),
-          ('Int32', 'int32', False),
-          ('UInt16', 'uint16', False),
-          ('Int16', 'int16', False),
-          ('UInt8', 'uint8', False),
-          ('Int8', 'int8', False)]
+# name, dtype, c_type, float_group
+dtypes = [('Float64', 'float64', 'float64_t', True),
+          ('UInt64', 'uint64', 'uint64_t', False),
+          ('Int64', 'int64', 'int64_t', False),
+          ('Float32', 'float32', 'float32_t', True),
+          ('UInt32', 'uint32', 'uint32_t', False),
+          ('Int32', 'int32', 'int32_t', False),
+          ('UInt16', 'uint16', 'uint16_t', False),
+          ('Int16', 'int16', 'int16_t', False),
+          ('UInt8', 'uint8', 'uint8_t', False),
+          ('Int8', 'int8', 'int8_t', False)]
 
 }}
 
 
-{{for name, dtype, float_group in dtypes}}
+{{for name, dtype, c_type, float_group in dtypes}}
 
 cdef class {{name}}HashTable(HashTable):
 
@@ -371,11 +371,11 @@ cdef class {{name}}HashTable(HashTable):
             raise KeyError(key)
 
     @cython.boundscheck(False)
-    def map(self, const {{dtype}}_t[:] keys, const int64_t[:] values):
+    def map(self, const {{c_type}}[:] keys, const int64_t[:] values):
         cdef:
             Py_ssize_t i, n = len(values)
             int ret = 0
-            {{dtype}}_t key
+            {{c_type}} key
             khiter_t k
 
         with nogil:
@@ -385,11 +385,11 @@ cdef class {{name}}HashTable(HashTable):
                 self.table.vals[k] = <Py_ssize_t>values[i]
 
     @cython.boundscheck(False)
-    def map_locations(self, const {{dtype}}_t[:] values):
+    def map_locations(self, const {{c_type}}[:] values):
         cdef:
             Py_ssize_t i, n = len(values)
             int ret = 0
-            {{dtype}}_t val
+            {{c_type}} val
             khiter_t k
 
         with nogil:
@@ -399,11 +399,11 @@ cdef class {{name}}HashTable(HashTable):
                 self.table.vals[k] = i
 
     @cython.boundscheck(False)
-    def lookup(self, const {{dtype}}_t[:] values):
+    def lookup(self, const {{c_type}}[:] values):
         cdef:
             Py_ssize_t i, n = len(values)
             int ret = 0
-            {{dtype}}_t val
+            {{c_type}} val
             khiter_t k
             intp_t[:] locs = np.empty(n, dtype=np.intp)
 
@@ -420,7 +420,7 @@ cdef class {{name}}HashTable(HashTable):
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    def _unique(self, const {{dtype}}_t[:] values, {{name}}Vector uniques,
+    def _unique(self, const {{c_type}}[:] values, {{name}}Vector uniques,
                 Py_ssize_t count_prior=0, Py_ssize_t na_sentinel=-1,
                 object na_value=None, bint ignore_na=False,
                 object mask=None, bint return_inverse=False):
@@ -465,7 +465,7 @@ cdef class {{name}}HashTable(HashTable):
             Py_ssize_t i, idx, count = count_prior, n = len(values)
             int64_t[:] labels
             int ret = 0
-            {{dtype}}_t val, na_value2
+            {{c_type}} val, na_value2
             khiter_t k
             {{name}}VectorData *ud
             bint use_na_value, use_mask
@@ -538,7 +538,7 @@ cdef class {{name}}HashTable(HashTable):
             return uniques.to_array(), np.asarray(labels)
         return uniques.to_array()
 
-    def unique(self, const {{dtype}}_t[:] values, bint return_inverse=False):
+    def unique(self, const {{c_type}}[:] values, bint return_inverse=False):
         """
         Calculate unique values and labels (no sorting!)
 
@@ -561,7 +561,7 @@ cdef class {{name}}HashTable(HashTable):
         return self._unique(values, uniques, ignore_na=False,
                             return_inverse=return_inverse)
 
-    def factorize(self, const {{dtype}}_t[:] values, Py_ssize_t na_sentinel=-1,
+    def factorize(self, const {{c_type}}[:] values, Py_ssize_t na_sentinel=-1,
                   object na_value=None, object mask=None):
         """
         Calculate unique values and labels (no sorting!)
@@ -606,13 +606,13 @@ cdef class {{name}}HashTable(HashTable):
         return labels
 
     @cython.boundscheck(False)
-    def get_labels_groupby(self, const {{dtype}}_t[:] values):
+    def get_labels_groupby(self, const {{c_type}}[:] values):
         cdef:
             Py_ssize_t i, n = len(values)
             intp_t[:] labels
             Py_ssize_t idx, count = 0
             int ret = 0
-            {{dtype}}_t val
+            {{c_type}} val
             khiter_t k
             {{name}}Vector uniques = {{name}}Vector()
             {{name}}VectorData *ud

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -365,7 +365,6 @@ cdef class {{name}}HashTable(HashTable):
             int ret = 0
 
         k = kh_put_{{dtype}}(self.table, key, &ret)
-        self.table.keys[k] = key
         if kh_exist_{{dtype}}(self.table, k):
             self.table.vals[k] = val
         else:
@@ -698,7 +697,6 @@ cdef class StringHashTable(HashTable):
         v = get_c_string(key)
 
         k = kh_put_str(self.table, v, &ret)
-        self.table.keys[k] = v
         if kh_exist_str(self.table, k):
             self.table.vals[k] = val
         else:
@@ -1022,7 +1020,6 @@ cdef class PyObjectHashTable(HashTable):
         hash(key)
 
         k = kh_put_pymap(self.table, <PyObject*>key, &ret)
-        # self.table.keys[k] = key
         if kh_exist_pymap(self.table, k):
             self.table.vals[k] = val
         else:

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -336,24 +336,24 @@ cdef class HashTable:
 
 {{py:
 
-# name, dtype, c_type, float_group, complex_group
-dtypes = [('Complex128', 'complex128', 'khcomplex128_t', True, True),
-          ('Float64', 'float64', 'float64_t', True, False),
-          ('UInt64', 'uint64', 'uint64_t', False, False),
-          ('Int64', 'int64', 'int64_t', False, False),
-          ('Complex64', 'complex64', 'khcomplex64_t', True, True),
-          ('Float32', 'float32', 'float32_t', True, False),
-          ('UInt32', 'uint32', 'uint32_t', False, False),
-          ('Int32', 'int32', 'int32_t', False, False),
-          ('UInt16', 'uint16', 'uint16_t', False, False),
-          ('Int16', 'int16', 'int16_t', False, False),
-          ('UInt8', 'uint8', 'uint8_t', False, False),
-          ('Int8', 'int8', 'int8_t', False, False)]
+# name, dtype, c_type, float_group, complex_group, to_c_type
+dtypes = [('Complex128', 'complex128', 'khcomplex128_t', True, True, "to_khcomplex128_t"),
+          ('Float64', 'float64', 'float64_t', True, False, ""),
+          ('UInt64', 'uint64', 'uint64_t', False, False, ""),
+          ('Int64', 'int64', 'int64_t', False, False, ""),
+          ('Complex64', 'complex64', 'khcomplex64_t', True, True, "to_khcomplex64_t"),
+          ('Float32', 'float32', 'float32_t', True, False, ""),
+          ('UInt32', 'uint32', 'uint32_t', False, False, ""),
+          ('Int32', 'int32', 'int32_t', False, False, ""),
+          ('UInt16', 'uint16', 'uint16_t', False, False, ""),
+          ('Int16', 'int16', 'int16_t', False, False, ""),
+          ('UInt8', 'uint8', 'uint8_t', False, False, ""),
+          ('Int8', 'int8', 'int8_t', False, False, "")]
 
 }}
 
 
-{{for name, dtype, c_type, float_group, complex_group in dtypes}}
+{{for name, dtype, c_type, float_group, complex_group, to_c_type in dtypes}}
 
 cdef class {{name}}HashTable(HashTable):
 
@@ -375,11 +375,7 @@ cdef class {{name}}HashTable(HashTable):
         cdef:
             khiter_t k
             {{c_type}} ckey
-        {{if complex_group}}
-        ckey = to_{{c_type}}(key)
-        {{else}}
-        ckey = key
-        {{endif}}
+        ckey = {{to_c_type}}(key)
         k = kh_get_{{dtype}}(self.table, ckey)
         return k != self.table.n_buckets
 
@@ -395,11 +391,7 @@ cdef class {{name}}HashTable(HashTable):
         cdef:
             khiter_t k
             {{c_type}} cval
-        {{if complex_group}}
-        cval = to_{{c_type}}(val)
-        {{else}}
-        cval = val
-        {{endif}}
+        cval = {{to_c_type}}(val)
         k = kh_get_{{dtype}}(self.table, cval)
         if k != self.table.n_buckets:
             return self.table.vals[k]
@@ -411,11 +403,7 @@ cdef class {{name}}HashTable(HashTable):
             khiter_t k
             int ret = 0
             {{c_type}} ckey
-        {{if complex_group}}
-        ckey = to_{{c_type}}(key)
-        {{else}}
-        ckey = key
-        {{endif}}
+        ckey = {{to_c_type}}(key)
         k = kh_put_{{dtype}}(self.table, ckey, &ret)
         if kh_exist_{{dtype}}(self.table, k):
             self.table.vals[k] = val
@@ -432,11 +420,7 @@ cdef class {{name}}HashTable(HashTable):
 
         with nogil:
             for i in range(n):
-                {{if complex_group}}
-                key = to_{{c_type}}(keys[i])
-                {{else}}
-                key = keys[i]
-                {{endif}}
+                key = {{to_c_type}}(keys[i])
                 k = kh_put_{{dtype}}(self.table, key, &ret)
                 self.table.vals[k] = <Py_ssize_t>values[i]
 
@@ -450,11 +434,7 @@ cdef class {{name}}HashTable(HashTable):
 
         with nogil:
             for i in range(n):
-                {{if complex_group}}
-                val= to_{{c_type}}(values[i])
-                {{else}}
-                val = values[i]
-                {{endif}}
+                val= {{to_c_type}}(values[i])
                 k = kh_put_{{dtype}}(self.table, val, &ret)
                 self.table.vals[k] = i
 
@@ -469,11 +449,7 @@ cdef class {{name}}HashTable(HashTable):
 
         with nogil:
             for i in range(n):
-                {{if complex_group}}
-                val = to_{{c_type}}(values[i])
-                {{else}}
-                val = values[i]
-                {{endif}}
+                val = {{to_c_type}}(values[i])
                 k = kh_get_{{dtype}}(self.table, val)
                 if k != self.table.n_buckets:
                     locs[i] = self.table.vals[k]
@@ -550,25 +526,13 @@ cdef class {{name}}HashTable(HashTable):
             # We use None, to make it optional, which requires `object` type
             # for the parameter. To please the compiler, we use na_value2,
             # which is only used if it's *specified*.
-            {{if complex_group}}
-            na_value2 = to_{{c_type}}(na_value)
-            {{else}}
-            na_value2 = na_value
-            {{endif}}       
+            na_value2 = {{to_c_type}}(na_value)      
         else:
-            {{if complex_group}}
-            na_value2 = to_{{c_type}}(0)
-            {{else}}
-            na_value2 = 0
-            {{endif}}   
+            na_value2 = {{to_c_type}}(0)  
 
         with nogil:
             for i in range(n):
-                {{if complex_group}}
-                val = to_{{c_type}}(values[i])
-                {{else}}
-                val = values[i]
-                {{endif}}
+                val = {{to_c_type}}(values[i])
 
                 if ignore_na and use_mask:
                     if mask_values[i]:
@@ -702,11 +666,7 @@ cdef class {{name}}HashTable(HashTable):
 
         with nogil:
             for i in range(n):
-                {{if complex_group}}
-                val = to_{{c_type}}(values[i])
-                {{else}}
-                val = values[i]
-                {{endif}}
+                val = {{to_c_type}}(values[i])
 
                 # specific for groupby
                 {{if dtype == 'complex64' or dtype== 'complex128'}}

--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -6,24 +6,24 @@ WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
 
 {{py:
 
-# dtype, ttype, c_type, complex_group, to_c_type
-dtypes = [('complex128', 'complex128', 'khcomplex128_t', True, "to_khcomplex128_t"),
-          ('complex64', 'complex64', 'khcomplex64_t', True, "to_khcomplex64_t"),
-          ('float64', 'float64', 'float64_t', False, ""),
-          ('float32', 'float32', 'float32_t', False, ""),
-          ('uint64', 'uint64', 'uint64_t', False, ""),
-          ('uint32', 'uint32', 'uint32_t', False, ""),
-          ('uint16', 'uint16', 'uint16_t', False, ""),
-          ('uint8', 'uint8', 'uint8_t', False, ""),
-          ('object', 'pymap', 'object', False, ""),
-          ('int64', 'int64', 'int64_t', False, ""),
-          ('int32', 'int32', 'int32_t', False, ""),
-          ('int16', 'int16', 'int16_t', False, ""),
-          ('int8', 'int8', 'int8_t', False, "")]
+# dtype, ttype, c_type, to_c_type, to_dtype
+dtypes = [('complex128', 'complex128', 'khcomplex128_t', "to_khcomplex128_t", "to_complex128"),
+          ('complex64', 'complex64', 'khcomplex64_t', "to_khcomplex64_t", "to_complex64"),
+          ('float64', 'float64', 'float64_t', "", ""),
+          ('float32', 'float32', 'float32_t', "", ""),
+          ('uint64', 'uint64', 'uint64_t', "", ""),
+          ('uint32', 'uint32', 'uint32_t', "", ""),
+          ('uint16', 'uint16', 'uint16_t', "", ""),
+          ('uint8', 'uint8', 'uint8_t', "", ""),
+          ('object', 'pymap', 'object', "", ""),
+          ('int64', 'int64', 'int64_t', "", ""),
+          ('int32', 'int32', 'int32_t', "", ""),
+          ('int16', 'int16', 'int16_t', "", ""),
+          ('int8', 'int8', 'int8_t', "", "")]
 
 }}
 
-{{for dtype, ttype, c_type, complex_group, to_c_type in dtypes}}
+{{for dtype, ttype, c_type, to_c_type, to_dtype in dtypes}}
 
 
 @cython.wraparound(False)
@@ -62,13 +62,7 @@ cdef build_count_table_{{dtype}}(const {{dtype}}_t[:] values,
         for i in range(n):
             val = {{to_c_type}}(values[i])
 
-            {{if dtype == 'float64' or dtype == 'float32'}}
-            if val == val or not dropna:
-            {{elif complex_group}}
             if not is_nan_{{c_type}}(val) or not dropna:
-            {{else}}
-            if True:
-            {{endif}}
                 k = kh_get_{{ttype}}(table, val)
                 if k != table.n_buckets:
                     table.vals[k] += 1
@@ -117,11 +111,7 @@ cpdef value_count_{{dtype}}(const {{dtype}}_t[:] values, bint dropna):
     with nogil:
         for k in range(table.n_buckets):
             if kh_exist_{{ttype}}(table, k):
-                {{if complex_group}}
-                result_keys[i] = to_{{dtype}}(table.keys[k])
-                {{else}}
-                result_keys[i] = table.keys[k]
-                {{endif}}         
+                result_keys[i] = {{to_dtype}}(table.keys[k])     
                 result_counts[i] = table.vals[k]
                 i += 1
     {{endif}}

--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -7,8 +7,10 @@ WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
 {{py:
 
 # dtype, ttype, c_type, to_c_type, to_dtype
-dtypes = [('complex128', 'complex128', 'khcomplex128_t', "to_khcomplex128_t", "to_complex128"),
-          ('complex64', 'complex64', 'khcomplex64_t', "to_khcomplex64_t", "to_complex64"),
+dtypes = [('complex128', 'complex128', 'khcomplex128_t', \
+                         "to_khcomplex128_t", "to_complex128"),
+          ('complex64', 'complex64', 'khcomplex64_t', \
+                         "to_khcomplex64_t", "to_complex64"),
           ('float64', 'float64', 'float64_t', "", ""),
           ('float32', 'float32', 'float32_t', "", ""),
           ('uint64', 'uint64', 'uint64_t', "", ""),
@@ -111,7 +113,7 @@ cpdef value_count_{{dtype}}(const {{dtype}}_t[:] values, bint dropna):
     with nogil:
         for k in range(table.n_buckets):
             if kh_exist_{{ttype}}(table, k):
-                result_keys[i] = {{to_dtype}}(table.keys[k])     
+                result_keys[i] = {{to_dtype}}(table.keys[k])
                 result_counts[i] = table.vals[k]
                 i += 1
     {{endif}}

--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -141,7 +141,7 @@ cpdef value_count_{{dtype}}({{c_type}}[:] values, bint dropna):
 {{if dtype == 'object'}}
 def duplicated_{{dtype}}(ndarray[{{dtype}}] values, object keep='first'):
 {{else}}
-def duplicated_{{dtype}}(const {{c_type}}[:] values, object keep='first'):
+def duplicated_{{dtype}}(const {{dtype}}_t[:] values, object keep='first'):
 {{endif}}
     cdef:
         int ret = 0
@@ -168,7 +168,12 @@ def duplicated_{{dtype}}(const {{c_type}}[:] values, object keep='first'):
         with nogil:
             for i in range(n - 1, -1, -1):
                 # equivalent: range(n)[::-1], which cython doesn't like in nogil
-                kh_put_{{ttype}}(table, values[i], &ret)
+                {{if complex_group}}
+                value = to_{{c_type}}(values[i])
+                {{else}}
+                value = values[i]
+                {{endif}}
+                kh_put_{{ttype}}(table, value, &ret)
                 out[i] = ret == 0
         {{endif}}
     elif keep == 'first':
@@ -179,7 +184,12 @@ def duplicated_{{dtype}}(const {{c_type}}[:] values, object keep='first'):
         {{else}}
         with nogil:
             for i in range(n):
-                kh_put_{{ttype}}(table, values[i], &ret)
+                {{if complex_group}}
+                value = to_{{c_type}}(values[i])
+                {{else}}
+                value = values[i]
+                {{endif}}
+                kh_put_{{ttype}}(table, value, &ret)
                 out[i] = ret == 0
         {{endif}}
     else:
@@ -197,7 +207,11 @@ def duplicated_{{dtype}}(const {{c_type}}[:] values, object keep='first'):
         {{else}}
         with nogil:
             for i in range(n):
+                {{if complex_group}}
+                value = to_{{c_type}}(values[i])
+                {{else}}
                 value = values[i]
+                {{endif}}
                 k = kh_get_{{ttype}}(table, value)
                 if k != table.n_buckets:
                     out[table.vals[k]] = 1
@@ -221,7 +235,7 @@ def duplicated_{{dtype}}(const {{c_type}}[:] values, object keep='first'):
 {{if dtype == 'object'}}
 def ismember_{{dtype}}(ndarray[{{c_type}}] arr, ndarray[{{c_type}}] values):
 {{else}}
-def ismember_{{dtype}}(const {{c_type}}[:] arr, const {{c_type}}[:] values):
+def ismember_{{dtype}}(const {{dtype}}_t[:] arr, const {{dtype}}_t[:] values):
 {{endif}}
     """
     Return boolean of values in arr on an
@@ -254,7 +268,12 @@ def ismember_{{dtype}}(const {{c_type}}[:] arr, const {{c_type}}[:] values):
     {{else}}
     with nogil:
         for i in range(n):
-            kh_put_{{ttype}}(table, values[i], &ret)
+            {{if complex_group}}
+            val = to_{{c_type}}(values[i])
+            {{else}}
+            val = values[i]
+            {{endif}}
+            kh_put_{{ttype}}(table, val, &ret)
     {{endif}}
 
     # test membership
@@ -269,7 +288,11 @@ def ismember_{{dtype}}(const {{c_type}}[:] arr, const {{c_type}}[:] values):
     {{else}}
     with nogil:
         for i in range(n):
+            {{if complex_group}}
+            val = to_{{c_type}}(arr[i])
+            {{else}}
             val = arr[i]
+            {{endif}}
             k = kh_get_{{ttype}}(table, val)
             result[i] = (k != table.n_buckets)
     {{endif}}

--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -30,7 +30,7 @@ dtypes = [('float64', 'float64', 'float64_t'),
 cdef build_count_table_{{dtype}}(ndarray[{{dtype}}] values,
                                  kh_{{ttype}}_t *table, bint dropna):
 {{else}}
-cdef build_count_table_{{dtype}}({{dtype}}_t[:] values,
+cdef build_count_table_{{dtype}}({{c_type}}[:] values,
                                  kh_{{ttype}}_t *table, bint dropna):
 {{endif}}
     cdef:
@@ -138,7 +138,7 @@ def duplicated_{{dtype}}(const {{c_type}}[:] values, object keep='first'):
     cdef:
         int ret = 0
         {{if dtype != 'object'}}
-        {{dtype}}_t value
+        {{c_type}} value
         {{endif}}
         Py_ssize_t i, n = len(values)
         khiter_t k

--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -6,22 +6,24 @@ WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
 
 {{py:
 
-# dtype, ttype, c_type
-dtypes = [('float64', 'float64', 'float64_t'),
-          ('float32', 'float32', 'float32_t'),
-          ('uint64', 'uint64', 'uint64_t'),
-          ('uint32', 'uint32', 'uint32_t'),
-          ('uint16', 'uint16', 'uint16_t'),
-          ('uint8', 'uint8', 'uint8_t'),
-          ('object', 'pymap', 'object'),
-          ('int64', 'int64', 'int64_t'),
-          ('int32', 'int32', 'int32_t'),
-          ('int16', 'int16', 'int16_t'),
-          ('int8', 'int8', 'int8_t')]
+# dtype, ttype, c_type, complex_group
+dtypes = [('complex128', 'complex128', 'khcomplex128_t', True),
+          ('complex64', 'complex64', 'khcomplex64_t', True),
+          ('float64', 'float64', 'float64_t', False),
+          ('float32', 'float32', 'float32_t', False),
+          ('uint64', 'uint64', 'uint64_t', False),
+          ('uint32', 'uint32', 'uint32_t', False),
+          ('uint16', 'uint16', 'uint16_t', False),
+          ('uint8', 'uint8', 'uint8_t', False),
+          ('object', 'pymap', 'object', False),
+          ('int64', 'int64', 'int64_t', False),
+          ('int32', 'int32', 'int32_t', False),
+          ('int16', 'int16', 'int16_t', False),
+          ('int8', 'int8', 'int8_t', False)]
 
 }}
 
-{{for dtype, ttype, c_type in dtypes}}
+{{for dtype, ttype, c_type, complex_group in dtypes}}
 
 
 @cython.wraparound(False)
@@ -63,6 +65,8 @@ cdef build_count_table_{{dtype}}({{c_type}}[:] values,
 
             {{if dtype == 'float64' or dtype == 'float32'}}
             if val == val or not dropna:
+            {{elif complex_group}}
+            if not is_nan_{{c_type}}(val) or not dropna:
             {{else}}
             if True:
             {{endif}}
@@ -114,7 +118,11 @@ cpdef value_count_{{dtype}}({{c_type}}[:] values, bint dropna):
     with nogil:
         for k in range(table.n_buckets):
             if kh_exist_{{ttype}}(table, k):
+                {{if complex_group}}
+                result_keys[i] = to_{{dtype}}(table.keys[k])
+                {{else}}
                 result_keys[i] = table.keys[k]
+                {{endif}}         
                 result_counts[i] = table.vals[k]
                 i += 1
     {{endif}}
@@ -279,7 +287,9 @@ def ismember_{{dtype}}(const {{c_type}}[:] arr, const {{c_type}}[:] values):
 {{py:
 
 # dtype, ctype, table_type, npy_dtype
-dtypes = [('float64', 'float64_t', 'float64', 'float64'),
+dtypes = [('complex128', 'khcomplex128_t', 'complex128', 'complex128'),
+          ('complex64', 'khcomplex64_t', 'complex64', 'complex64'),
+          ('float64', 'float64_t', 'float64', 'float64'),
           ('float32', 'float32_t', 'float32', 'float32'),
           ('int64', 'int64_t', 'int64', 'int64'),
           ('int32', 'int32_t', 'int32', 'int32'),

--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -7,21 +7,21 @@ WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
 {{py:
 
 # dtype, ttype, c_type, to_c_type, to_dtype
-dtypes = [('complex128', 'complex128', 'khcomplex128_t', \
-                         "to_khcomplex128_t", "to_complex128"),
-          ('complex64', 'complex64', 'khcomplex64_t', \
-                         "to_khcomplex64_t", "to_complex64"),
-          ('float64', 'float64', 'float64_t', "", ""),
-          ('float32', 'float32', 'float32_t', "", ""),
-          ('uint64', 'uint64', 'uint64_t', "", ""),
-          ('uint32', 'uint32', 'uint32_t', "", ""),
-          ('uint16', 'uint16', 'uint16_t', "", ""),
-          ('uint8', 'uint8', 'uint8_t', "", ""),
-          ('object', 'pymap', 'object', "", ""),
-          ('int64', 'int64', 'int64_t', "", ""),
-          ('int32', 'int32', 'int32_t', "", ""),
-          ('int16', 'int16', 'int16_t', "", ""),
-          ('int8', 'int8', 'int8_t', "", "")]
+dtypes = [('complex128', 'complex128', 'khcomplex128_t',
+                         'to_khcomplex128_t', 'to_complex128'),
+          ('complex64', 'complex64', 'khcomplex64_t',
+                        'to_khcomplex64_t', 'to_complex64'),
+          ('float64', 'float64', 'float64_t', '', ''),
+          ('float32', 'float32', 'float32_t', '', ''),
+          ('uint64', 'uint64', 'uint64_t', '', ''),
+          ('uint32', 'uint32', 'uint32_t', '', ''),
+          ('uint16', 'uint16', 'uint16_t', '', ''),
+          ('uint8', 'uint8', 'uint8_t', '', ''),
+          ('object', 'pymap', 'object', '', ''),
+          ('int64', 'int64', 'int64_t', '', ''),
+          ('int32', 'int32', 'int32_t', '', ''),
+          ('int16', 'int16', 'int16_t', '', ''),
+          ('int8', 'int8', 'int8_t', '', '')]
 
 }}
 

--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -184,7 +184,6 @@ def duplicated_{{dtype}}(const {{c_type}}[:] values, object keep='first'):
                 out[i] = 1
             else:
                 k = kh_put_{{ttype}}(table, <PyObject*>value, &ret)
-                table.keys[k] = <PyObject*>value
                 table.vals[k] = i
                 out[i] = 0
         {{else}}
@@ -197,7 +196,6 @@ def duplicated_{{dtype}}(const {{c_type}}[:] values, object keep='first'):
                     out[i] = 1
                 else:
                     k = kh_put_{{ttype}}(table, value, &ret)
-                    table.keys[k] = value
                     table.vals[k] = i
                     out[i] = 0
         {{endif}}

--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -6,24 +6,24 @@ WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
 
 {{py:
 
-# dtype, ttype, c_type, complex_group
-dtypes = [('complex128', 'complex128', 'khcomplex128_t', True),
-          ('complex64', 'complex64', 'khcomplex64_t', True),
-          ('float64', 'float64', 'float64_t', False),
-          ('float32', 'float32', 'float32_t', False),
-          ('uint64', 'uint64', 'uint64_t', False),
-          ('uint32', 'uint32', 'uint32_t', False),
-          ('uint16', 'uint16', 'uint16_t', False),
-          ('uint8', 'uint8', 'uint8_t', False),
-          ('object', 'pymap', 'object', False),
-          ('int64', 'int64', 'int64_t', False),
-          ('int32', 'int32', 'int32_t', False),
-          ('int16', 'int16', 'int16_t', False),
-          ('int8', 'int8', 'int8_t', False)]
+# dtype, ttype, c_type, complex_group, to_c_type
+dtypes = [('complex128', 'complex128', 'khcomplex128_t', True, "to_khcomplex128_t"),
+          ('complex64', 'complex64', 'khcomplex64_t', True, "to_khcomplex64_t"),
+          ('float64', 'float64', 'float64_t', False, ""),
+          ('float32', 'float32', 'float32_t', False, ""),
+          ('uint64', 'uint64', 'uint64_t', False, ""),
+          ('uint32', 'uint32', 'uint32_t', False, ""),
+          ('uint16', 'uint16', 'uint16_t', False, ""),
+          ('uint8', 'uint8', 'uint8_t', False, ""),
+          ('object', 'pymap', 'object', False, ""),
+          ('int64', 'int64', 'int64_t', False, ""),
+          ('int32', 'int32', 'int32_t', False, ""),
+          ('int16', 'int16', 'int16_t', False, ""),
+          ('int8', 'int8', 'int8_t', False, "")]
 
 }}
 
-{{for dtype, ttype, c_type, complex_group in dtypes}}
+{{for dtype, ttype, c_type, complex_group, to_c_type in dtypes}}
 
 
 @cython.wraparound(False)
@@ -47,11 +47,7 @@ cdef build_count_table_{{dtype}}(const {{dtype}}_t[:] values,
     kh_resize_{{ttype}}(table, n // 10)
 
     for i in range(n):
-        {{if complex_group}}
-        val = to_{{c_type}}(values[i])
-        {{else}}
         val = values[i]
-        {{endif}}
         if not checknull(val) or not dropna:
             k = kh_get_{{ttype}}(table, <PyObject*>val)
             if k != table.n_buckets:
@@ -64,11 +60,7 @@ cdef build_count_table_{{dtype}}(const {{dtype}}_t[:] values,
         kh_resize_{{ttype}}(table, n)
 
         for i in range(n):
-            {{if complex_group}}
-            val = to_{{c_type}}(values[i])
-            {{else}}
-            val = values[i]
-            {{endif}}
+            val = {{to_c_type}}(values[i])
 
             {{if dtype == 'float64' or dtype == 'float32'}}
             if val == val or not dropna:
@@ -175,11 +167,7 @@ def duplicated_{{dtype}}(const {{dtype}}_t[:] values, object keep='first'):
         with nogil:
             for i in range(n - 1, -1, -1):
                 # equivalent: range(n)[::-1], which cython doesn't like in nogil
-                {{if complex_group}}
-                value = to_{{c_type}}(values[i])
-                {{else}}
-                value = values[i]
-                {{endif}}
+                value = {{to_c_type}}(values[i])
                 kh_put_{{ttype}}(table, value, &ret)
                 out[i] = ret == 0
         {{endif}}
@@ -191,11 +179,7 @@ def duplicated_{{dtype}}(const {{dtype}}_t[:] values, object keep='first'):
         {{else}}
         with nogil:
             for i in range(n):
-                {{if complex_group}}
-                value = to_{{c_type}}(values[i])
-                {{else}}
-                value = values[i]
-                {{endif}}
+                value = {{to_c_type}}(values[i])
                 kh_put_{{ttype}}(table, value, &ret)
                 out[i] = ret == 0
         {{endif}}
@@ -214,11 +198,7 @@ def duplicated_{{dtype}}(const {{dtype}}_t[:] values, object keep='first'):
         {{else}}
         with nogil:
             for i in range(n):
-                {{if complex_group}}
-                value = to_{{c_type}}(values[i])
-                {{else}}
-                value = values[i]
-                {{endif}}
+                value = {{to_c_type}}(values[i])
                 k = kh_get_{{ttype}}(table, value)
                 if k != table.n_buckets:
                     out[table.vals[k]] = 1
@@ -275,11 +255,7 @@ def ismember_{{dtype}}(const {{dtype}}_t[:] arr, const {{dtype}}_t[:] values):
     {{else}}
     with nogil:
         for i in range(n):
-            {{if complex_group}}
-            val = to_{{c_type}}(values[i])
-            {{else}}
-            val = values[i]
-            {{endif}}
+            val = {{to_c_type}}(values[i])
             kh_put_{{ttype}}(table, val, &ret)
     {{endif}}
 
@@ -295,11 +271,7 @@ def ismember_{{dtype}}(const {{dtype}}_t[:] arr, const {{dtype}}_t[:] values):
     {{else}}
     with nogil:
         for i in range(n):
-            {{if complex_group}}
-            val = to_{{c_type}}(arr[i])
-            {{else}}
-            val = arr[i]
-            {{endif}}
+            val = {{to_c_type}}(arr[i])
             k = kh_get_{{ttype}}(table, val)
             result[i] = (k != table.n_buckets)
     {{endif}}

--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -32,7 +32,7 @@ dtypes = [('complex128', 'complex128', 'khcomplex128_t', True),
 cdef build_count_table_{{dtype}}(ndarray[{{dtype}}] values,
                                  kh_{{ttype}}_t *table, bint dropna):
 {{else}}
-cdef build_count_table_{{dtype}}({{c_type}}[:] values,
+cdef build_count_table_{{dtype}}(const {{dtype}}_t[:] values,
                                  kh_{{ttype}}_t *table, bint dropna):
 {{endif}}
     cdef:
@@ -47,8 +47,11 @@ cdef build_count_table_{{dtype}}({{c_type}}[:] values,
     kh_resize_{{ttype}}(table, n // 10)
 
     for i in range(n):
+        {{if complex_group}}
+        val = to_{{c_type}}(values[i])
+        {{else}}
         val = values[i]
-
+        {{endif}}
         if not checknull(val) or not dropna:
             k = kh_get_{{ttype}}(table, <PyObject*>val)
             if k != table.n_buckets:
@@ -61,7 +64,11 @@ cdef build_count_table_{{dtype}}({{c_type}}[:] values,
         kh_resize_{{ttype}}(table, n)
 
         for i in range(n):
+            {{if complex_group}}
+            val = to_{{c_type}}(values[i])
+            {{else}}
             val = values[i]
+            {{endif}}
 
             {{if dtype == 'float64' or dtype == 'float32'}}
             if val == val or not dropna:
@@ -84,7 +91,7 @@ cdef build_count_table_{{dtype}}({{c_type}}[:] values,
 {{if dtype == 'object'}}
 cpdef value_count_{{dtype}}(ndarray[{{dtype}}] values, bint dropna):
 {{else}}
-cpdef value_count_{{dtype}}({{c_type}}[:] values, bint dropna):
+cpdef value_count_{{dtype}}(const {{dtype}}_t[:] values, bint dropna):
 {{endif}}
     cdef:
         Py_ssize_t i = 0
@@ -338,7 +345,7 @@ def mode_{{dtype}}(ndarray[{{ctype}}] values, bint dropna):
 {{else}}
 
 
-def mode_{{dtype}}({{ctype}}[:] values, bint dropna):
+def mode_{{dtype}}(const {{dtype}}_t[:] values, bint dropna):
 {{endif}}
     cdef:
         int count, max_count = 1

--- a/pandas/_libs/khash.pxd
+++ b/pandas/_libs/khash.pxd
@@ -25,13 +25,16 @@ cdef extern from "khash_python.h":
         double real
         double imag
 
-    bint are_equal_khcomplex128_t "kh_complex_hash_equal" (khcomplex128_t a, khcomplex128_t b) nogil
+    bint are_equivalent_khcomplex128_t "kh_complex_hash_equal" (khcomplex128_t a, khcomplex128_t b) nogil
 
     ctypedef struct khcomplex64_t:
         float real
         float imag
 
-    bint are_equal_khcomplex64_t "kh_complex_hash_equal" (khcomplex64_t a, khcomplex64_t b) nogil
+    bint are_equivalent_khcomplex64_t "kh_complex_hash_equal" (khcomplex64_t a, khcomplex64_t b) nogil
+
+    bint are_equivalent_float64_t "kh_floats_hash_equal" (float64_t a, float64_t b) nogil
+    bint are_equivalent_float32_t "kh_floats_hash_equal" (float32_t a, float32_t b) nogil
 
     ctypedef struct kh_pymap_t:
         khint_t n_buckets, size, n_occupied, upper_bound

--- a/pandas/_libs/khash.pxd
+++ b/pandas/_libs/khash.pxd
@@ -25,16 +25,21 @@ cdef extern from "khash_python.h":
         double real
         double imag
 
-    bint are_equivalent_khcomplex128_t "kh_complex_hash_equal" (khcomplex128_t a, khcomplex128_t b) nogil
+    bint are_equivalent_khcomplex128_t \
+    "kh_complex_hash_equal" (khcomplex128_t a, khcomplex128_t b) nogil
 
     ctypedef struct khcomplex64_t:
         float real
         float imag
 
-    bint are_equivalent_khcomplex64_t "kh_complex_hash_equal" (khcomplex64_t a, khcomplex64_t b) nogil
+    bint are_equivalent_khcomplex64_t \
+    "kh_complex_hash_equal" (khcomplex64_t a, khcomplex64_t b) nogil
 
-    bint are_equivalent_float64_t "kh_floats_hash_equal" (float64_t a, float64_t b) nogil
-    bint are_equivalent_float32_t "kh_floats_hash_equal" (float32_t a, float32_t b) nogil
+    bint are_equivalent_float64_t \
+    "kh_floats_hash_equal" (float64_t a, float64_t b) nogil
+
+    bint are_equivalent_float32_t \
+    "kh_floats_hash_equal" (float32_t a, float32_t b) nogil
 
     ctypedef struct kh_pymap_t:
         khint_t n_buckets, size, n_occupied, upper_bound

--- a/pandas/_libs/khash.pxd
+++ b/pandas/_libs/khash.pxd
@@ -1,5 +1,7 @@
 from cpython.object cimport PyObject
 from numpy cimport (
+    complex64_t,
+    complex128_t,
     float32_t,
     float64_t,
     int8_t,
@@ -18,6 +20,18 @@ cdef extern from "khash_python.h":
 
     ctypedef uint32_t khint_t
     ctypedef khint_t khiter_t
+
+    ctypedef struct khcomplex128_t:
+        double real
+        double imag
+
+    bint are_equal_khcomplex128_t "kh_complex_hash_equal" (khcomplex128_t a, khcomplex128_t b) nogil
+
+    ctypedef struct khcomplex64_t:
+        float real
+        float imag
+
+    bint are_equal_khcomplex64_t "kh_complex_hash_equal" (khcomplex64_t a, khcomplex64_t b) nogil
 
     ctypedef struct kh_pymap_t:
         khint_t n_buckets, size, n_occupied, upper_bound

--- a/pandas/_libs/khash_for_primitive_helper.pxi.in
+++ b/pandas/_libs/khash_for_primitive_helper.pxi.in
@@ -17,6 +17,8 @@ primitive_types = [('int64', 'int64_t'),
                    ('uint16', 'uint16_t'),
                    ('int8', 'int8_t'),
                    ('uint8', 'uint8_t'),
+                   ('complex64', 'khcomplex64_t'),
+                   ('complex128', 'khcomplex128_t'),
                   ]
 }}
 

--- a/pandas/_libs/src/klib/khash_python.h
+++ b/pandas/_libs/src/klib/khash_python.h
@@ -1,14 +1,9 @@
 #include <string.h>
 #include <Python.h>
 
+
+// use numpy's definitions for complex
 #include <numpy/arrayobject.h>
-
-//typedef struct { double real, imag; } khcomplex128_t;
-//typedef struct { float  real, imag; } khcomplex64_t;
-//typedef __pyx_t_float_complex khcomplex64_t;
-//typedef __pyx_t_double_complex khcomplex128_t;
-
-
 typedef npy_complex64 khcomplex64_t;
 typedef npy_complex128 khcomplex128_t;
 

--- a/pandas/_libs/src/klib/khash_python.h
+++ b/pandas/_libs/src/klib/khash_python.h
@@ -1,6 +1,19 @@
 #include <string.h>
 #include <Python.h>
 
+#include <numpy/arrayobject.h>
+
+//typedef struct { double real, imag; } khcomplex128_t;
+//typedef struct { float  real, imag; } khcomplex64_t;
+//typedef __pyx_t_float_complex khcomplex64_t;
+//typedef __pyx_t_double_complex khcomplex128_t;
+
+
+typedef npy_complex64 khcomplex64_t;
+typedef npy_complex128 khcomplex128_t;
+
+
+
 // khash should report usage to tracemalloc
 #if PY_VERSION_HEX >= 0x03060000
 #include <pymem.h>
@@ -127,6 +140,32 @@ KHASH_MAP_INIT_FLOAT64(float64, size_t)
 	KHASH_INIT(name, khfloat32_t, khval_t, 1, kh_float32_hash_func, kh_floats_hash_equal)
 
 KHASH_MAP_INIT_FLOAT32(float32, size_t)
+
+khint32_t PANDAS_INLINE kh_complex128_hash_func(khcomplex128_t val){
+    return kh_float64_hash_func(val.real)^kh_float64_hash_func(val.imag);
+}
+khint32_t PANDAS_INLINE kh_complex64_hash_func(khcomplex64_t val){
+    return kh_float32_hash_func(val.real)^kh_float32_hash_func(val.imag);
+}
+
+#define kh_complex_hash_equal(a, b) \
+  (kh_floats_hash_equal(a.real, b.real) && kh_floats_hash_equal(a.imag, b.imag))
+
+
+#define KHASH_MAP_INIT_COMPLEX64(name, khval_t)								\
+	KHASH_INIT(name, khcomplex64_t, khval_t, 1, kh_complex64_hash_func, kh_complex_hash_equal)
+
+KHASH_MAP_INIT_COMPLEX64(complex64, size_t)
+
+
+#define KHASH_MAP_INIT_COMPLEX128(name, khval_t)								\
+	KHASH_INIT(name, khcomplex128_t, khval_t, 1, kh_complex128_hash_func, kh_complex_hash_equal)
+
+KHASH_MAP_INIT_COMPLEX128(complex128, size_t)
+
+
+#define kh_exist_complex64(h, k) (kh_exist(h, k))
+#define kh_exist_complex128(h, k) (kh_exist(h, k))
 
 
 int PANDAS_INLINE pyobject_cmp(PyObject* a, PyObject* b) {

--- a/pandas/tests/libs/test_hashtable.py
+++ b/pandas/tests/libs/test_hashtable.py
@@ -162,7 +162,7 @@ def test_get_labels_groupby_for_Int64():
     arr, unique = table.get_labels_groupby(vals)
     expected_arr = np.array([0, 1, -1, 1, 0, -1], dtype=np.int64)
     expected_unique = np.array([1, 2], dtype=np.int64)
-    tm.assert_numpy_array_equal(arr, expected_arr)
+    tm.assert_numpy_array_equal(arr.astype(np.int64), expected_arr)
     tm.assert_numpy_array_equal(unique, expected_unique)
 
 

--- a/pandas/tests/libs/test_hashtable.py
+++ b/pandas/tests/libs/test_hashtable.py
@@ -80,6 +80,8 @@ class TestHashTable:
             table = table_type()
             keys = np.arange(N).astype(dtype)
             vals = np.arange(N).astype(np.int64) + N
+            keys.flags.writeable = False
+            vals.flags.writeable = False
             table.map(keys, vals)
             for i in range(N):
                 assert table.get_item(keys[i]) == i + N
@@ -88,6 +90,7 @@ class TestHashTable:
         N = 8
         table = table_type()
         keys = (np.arange(N) + N).astype(dtype)
+        keys.flags.writeable = False
         table.map_locations(keys)
         for i in range(N):
             assert table.get_item(keys[i]) == i
@@ -96,6 +99,7 @@ class TestHashTable:
         N = 3
         table = table_type()
         keys = (np.arange(N) + N).astype(dtype)
+        keys.flags.writeable = False
         table.map_locations(keys)
         result = table.lookup(keys)
         expected = np.arange(N)
@@ -121,6 +125,7 @@ class TestHashTable:
         table = table_type()
         expected = (np.arange(N) + N).astype(dtype)
         keys = np.repeat(expected, 5)
+        keys.flags.writeable = False
         unique = table.unique(keys)
         tm.assert_numpy_array_equal(unique, expected)
 
@@ -254,6 +259,7 @@ class TestHelpFunctions:
         N = 100
         duplicated = get_ht_function("duplicated", type_suffix)
         values = np.repeat(np.arange(N).astype(dtype), 5)
+        values.flags.writeable = False
         result = duplicated(values)
         expected = np.ones_like(values, dtype=np.bool_)
         expected[::5] = False
@@ -264,6 +270,8 @@ class TestHelpFunctions:
         ismember = get_ht_function("ismember", type_suffix)
         arr = np.arange(N).astype(dtype)
         values = np.arange(N).astype(dtype)
+        arr.flags.writeable = False
+        values.flags.writeable = False
         result = ismember(arr, values)
         expected = np.ones_like(values, dtype=np.bool_)
         tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/libs/test_hashtable.py
+++ b/pandas/tests/libs/test_hashtable.py
@@ -251,6 +251,7 @@ class TestHelpFunctions:
         value_count = get_ht_function("value_count", type_suffix)
         expected = (np.arange(N) + N).astype(dtype)
         values = np.repeat(expected, 5)
+        values.flags.writeable = False
         keys, counts = value_count(values, False)
         tm.assert_numpy_array_equal(np.sort(keys), expected)
         assert np.all(counts == 5)
@@ -293,6 +294,7 @@ class TestHelpFunctions:
         mode = get_ht_function("mode", type_suffix)
         values = np.repeat(np.arange(N).astype(dtype), 5)
         values[0] = 42
+        values.flags.writeable = False
         result = mode(values, False)
         assert result == 42
 

--- a/pandas/tests/libs/test_hashtable.py
+++ b/pandas/tests/libs/test_hashtable.py
@@ -30,9 +30,11 @@ def get_allocated_khash_memory():
     "table_type, dtype",
     [
         (ht.PyObjectHashTable, np.object_),
+        (ht.Complex128HashTable, np.complex128),
         (ht.Int64HashTable, np.int64),
         (ht.UInt64HashTable, np.uint64),
         (ht.Float64HashTable, np.float64),
+        (ht.Complex64HashTable, np.complex64),
         (ht.Int32HashTable, np.int32),
         (ht.UInt32HashTable, np.uint32),
         (ht.Float32HashTable, np.float32),
@@ -182,6 +184,8 @@ def test_tracemalloc_for_empty_StringHashTable():
     [
         (ht.Float64HashTable, np.float64),
         (ht.Float32HashTable, np.float32),
+        (ht.Complex128HashTable, np.complex128),
+        (ht.Complex64HashTable, np.complex64),
     ],
 )
 class TestHashTableWithNans:
@@ -233,9 +237,11 @@ def get_ht_function(fun_name, type_suffix):
     "dtype, type_suffix",
     [
         (np.object_, "object"),
+        (np.complex128, "complex128"),
         (np.int64, "int64"),
         (np.uint64, "uint64"),
         (np.float64, "float64"),
+        (np.complex64, "complex64"),
         (np.int32, "int32"),
         (np.uint32, "uint32"),
         (np.float32, "float32"),
@@ -304,6 +310,8 @@ class TestHelpFunctions:
     [
         (np.float64, "float64"),
         (np.float32, "float32"),
+        (np.complex128, "complex128"),
+        (np.complex64, "complex64"),
     ],
 )
 class TestHelpFunctionsWithNans:

--- a/pandas/tests/libs/test_hashtable.py
+++ b/pandas/tests/libs/test_hashtable.py
@@ -75,33 +75,33 @@ class TestHashTable:
             table.get_item(index + 2)
         assert str(index + 2) in str(excinfo.value)
 
-    def test_map(self, table_type, dtype):
+    def test_map(self, table_type, dtype, writable):
         # PyObjectHashTable has no map-method
         if table_type != ht.PyObjectHashTable:
             N = 77
             table = table_type()
             keys = np.arange(N).astype(dtype)
             vals = np.arange(N).astype(np.int64) + N
-            keys.flags.writeable = False
-            vals.flags.writeable = False
+            keys.flags.writeable = writable
+            vals.flags.writeable = writable
             table.map(keys, vals)
             for i in range(N):
                 assert table.get_item(keys[i]) == i + N
 
-    def test_map_locations(self, table_type, dtype):
+    def test_map_locations(self, table_type, dtype, writable):
         N = 8
         table = table_type()
         keys = (np.arange(N) + N).astype(dtype)
-        keys.flags.writeable = False
+        keys.flags.writeable = writable
         table.map_locations(keys)
         for i in range(N):
             assert table.get_item(keys[i]) == i
 
-    def test_lookup(self, table_type, dtype):
+    def test_lookup(self, table_type, dtype, writable):
         N = 3
         table = table_type()
         keys = (np.arange(N) + N).astype(dtype)
-        keys.flags.writeable = False
+        keys.flags.writeable = writable
         table.map_locations(keys)
         result = table.lookup(keys)
         expected = np.arange(N)
@@ -119,7 +119,7 @@ class TestHashTable:
         result = table.lookup(wrong_keys)
         assert np.all(result == -1)
 
-    def test_unique(self, table_type, dtype):
+    def test_unique(self, table_type, dtype, writable):
         if dtype in (np.int8, np.uint8):
             N = 88
         else:
@@ -127,7 +127,7 @@ class TestHashTable:
         table = table_type()
         expected = (np.arange(N) + N).astype(dtype)
         keys = np.repeat(expected, 5)
-        keys.flags.writeable = False
+        keys.flags.writeable = writable
         unique = table.unique(keys)
         tm.assert_numpy_array_equal(unique, expected)
 
@@ -156,9 +156,10 @@ class TestHashTable:
             assert get_allocated_khash_memory() == 0
 
 
-def test_get_labels_groupby_for_Int64():
+def test_get_labels_groupby_for_Int64(writable):
     table = ht.Int64HashTable()
     vals = np.array([1, 2, -1, 2, 1, -1], dtype=np.int64)
+    vals.flags.writeable = writable
     arr, unique = table.get_labels_groupby(vals)
     expected_arr = np.array([0, 1, -1, 1, 0, -1], dtype=np.int64)
     expected_unique = np.array([1, 2], dtype=np.int64)
@@ -262,33 +263,33 @@ def get_ht_function(fun_name, type_suffix):
     ],
 )
 class TestHelpFunctions:
-    def test_value_count(self, dtype, type_suffix):
+    def test_value_count(self, dtype, type_suffix, writable):
         N = 43
         value_count = get_ht_function("value_count", type_suffix)
         expected = (np.arange(N) + N).astype(dtype)
         values = np.repeat(expected, 5)
-        values.flags.writeable = False
+        values.flags.writeable = writable
         keys, counts = value_count(values, False)
         tm.assert_numpy_array_equal(np.sort(keys), expected)
         assert np.all(counts == 5)
 
-    def test_duplicated_first(self, dtype, type_suffix):
+    def test_duplicated_first(self, dtype, type_suffix, writable):
         N = 100
         duplicated = get_ht_function("duplicated", type_suffix)
         values = np.repeat(np.arange(N).astype(dtype), 5)
-        values.flags.writeable = False
+        values.flags.writeable = writable
         result = duplicated(values)
         expected = np.ones_like(values, dtype=np.bool_)
         expected[::5] = False
         tm.assert_numpy_array_equal(result, expected)
 
-    def test_ismember_yes(self, dtype, type_suffix):
+    def test_ismember_yes(self, dtype, type_suffix, writable):
         N = 127
         ismember = get_ht_function("ismember", type_suffix)
         arr = np.arange(N).astype(dtype)
         values = np.arange(N).astype(dtype)
-        arr.flags.writeable = False
-        values.flags.writeable = False
+        arr.flags.writeable = writable
+        values.flags.writeable = writable
         result = ismember(arr, values)
         expected = np.ones_like(values, dtype=np.bool_)
         tm.assert_numpy_array_equal(result, expected)
@@ -302,7 +303,7 @@ class TestHelpFunctions:
         expected = np.zeros_like(values, dtype=np.bool_)
         tm.assert_numpy_array_equal(result, expected)
 
-    def test_mode(self, dtype, type_suffix):
+    def test_mode(self, dtype, type_suffix, writable):
         if dtype in (np.int8, np.uint8):
             N = 53
         else:
@@ -310,7 +311,7 @@ class TestHelpFunctions:
         mode = get_ht_function("mode", type_suffix)
         values = np.repeat(np.arange(N).astype(dtype), 5)
         values[0] = 42
-        values.flags.writeable = False
+        values.flags.writeable = writable
         result = mode(values, False)
         assert result == 42
 

--- a/pandas/tests/libs/test_hashtable.py
+++ b/pandas/tests/libs/test_hashtable.py
@@ -156,6 +156,16 @@ class TestHashTable:
             assert get_allocated_khash_memory() == 0
 
 
+def test_get_labels_groupby_for_Int64():
+    table = ht.Int64HashTable()
+    vals = np.array([1, 2, -1, 2, 1, -1], dtype=np.int64)
+    arr, unique = table.get_labels_groupby(vals)
+    expected_arr = np.array([0, 1, -1, 1, 0, -1], dtype=np.int64)
+    expected_unique = np.array([1, 2], dtype=np.int64)
+    tm.assert_numpy_array_equal(arr, expected_arr)
+    tm.assert_numpy_array_equal(unique, expected_unique)
+
+
 def test_tracemalloc_works_for_StringHashTable():
     N = 1000
     keys = np.arange(N).astype(np.compat.unicode).astype(np.object_)


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Next step for #33287

The complex case is somewhat less straight forward, because Cython [defines](https://github.com/cython/cython/blob/master/Cython/Includes/numpy/__init__.pxd#L755) `complex128`/`complex64` as:

```
ctypedef float complex  complex64_t
ctypedef double complex complex128_t
```

where `double complex` actually means a Cython-datatype defined here https://github.com/cython/cython/blob/master/Cython/Utility/Complex.c#L56

Thus a conversion between numpy's complex and Cython's complex must happens somewhere.



