### PR TITLE
Rewrite dict literal for files in tests/plotting/test_boxplot_method.py

### DIFF
--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -171,11 +171,11 @@ class TestDataFramePlots(TestPlotBase):
         "colors_kwd, expected",
         [
             (
-                dict(boxes="r", whiskers="b", medians="g", caps="c"),
-                dict(boxes="r", whiskers="b", medians="g", caps="c"),
+                {"boxes": "r", "whiskers": "b", "medians": "g", "caps": "c"},
+                {"boxes": "r", "whiskers": "b", "medians": "g", "caps": "c"},
             ),
-            (dict(boxes="r"), dict(boxes="r")),
-            ("r", dict(boxes="r", whiskers="r", medians="r", caps="r")),
+            ({"boxes": "r"}, {"boxes": "r"}),
+            ("r", {"boxes": "r", "whiskers": "r", "medians": "r", "caps": "r"}),
         ],
     )
     def test_color_kwd(self, colors_kwd, expected):
@@ -187,7 +187,7 @@ class TestDataFramePlots(TestPlotBase):
 
     @pytest.mark.parametrize(
         "dict_colors, msg",
-        [(dict(boxes="r", invalid_key="r"), "invalid key 'invalid_key'")],
+        [({"boxes": "r", "invalid_key": "r"}, "invalid key 'invalid_key'")],
     )
     def test_color_kwd_errors(self, dict_colors, msg):
         # GH: 26214
@@ -207,7 +207,7 @@ class TestDataFramePlots(TestPlotBase):
     def test_specified_props_kwd(self, props, expected):
         # GH 30346
         df = DataFrame({k: np.random.random(100) for k in "ABC"})
-        kwd = {props: dict(color="C1")}
+        kwd = {props: {"color": "C1"}}
         result = df.boxplot(return_type="dict", **kwd)
 
         assert result[expected][0].get_color() == "C1"


### PR DESCRIPTION
- [ ] xref #38138
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Rewrites as dictionary literals for the following files:
- pandas/tests/plotting/test_boxplot_method.py
