### PR TITLE
BUG: DataFrame.idxmin/idxmax with mixed dtypes

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -619,6 +619,7 @@ Numeric
 - Bug in :class:`DataFrame` allowing arithmetic operations with list of array-likes with undefined results. Behavior changed to raising ``ValueError`` (:issue:`36702`)
 - Bug in :meth:`DataFrame.std` with ``timedelta64`` dtype and ``skipna=False`` (:issue:`37392`)
 - Bug in :meth:`DataFrame.min` and :meth:`DataFrame.max` with ``datetime64`` dtype and ``skipna=False`` (:issue:`36907`)
+- Bug in :meth:`DataFrame.idxmax` and :meth:`DataFrame.idxmin` with mixed dtypes incorrectly raising ``TypeError`` (:issue:`38195`)
 
 Conversion
 ^^^^^^^^^^

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9002,17 +9002,10 @@ NaN 12.3   33.0
         """
         axis = self._get_axis_number(axis)
 
-        if self._can_fast_transpose or axis == 1:
-            # i.e. self.values call is cheap and non-casting (or unavoidable)
-            indices = nanops.nanargmin(self.values, axis=axis, skipna=skipna)
-        else:
-            bm_axis = 1 - axis
-
-            def blk_func(bvalues):
-                return nanops.nanargmin(bvalues, axis=bm_axis, skipna=skipna)
-
-            mgr, _ = self._mgr.reduce(blk_func)
-            indices = mgr.as_array().ravel()
+        res = self._reduce(
+            nanops.nanargmin, "argmin", axis=axis, skipna=skipna, numeric_only=False
+        )
+        indices = res._values
 
         # indices will always be np.ndarray since axis is not None and
         # values is a 2d array for DataFrame
@@ -9086,17 +9079,10 @@ NaN 12.3   33.0
         """
         axis = self._get_axis_number(axis)
 
-        if self._can_fast_transpose or axis == 1:
-            # i.e. self.values call is cheap and non-casting (or unavoidable)
-            indices = nanops.nanargmax(self.values, axis=axis, skipna=skipna)
-        else:
-            bm_axis = 1 - axis
-
-            def blk_func(bvalues):
-                return nanops.nanargmax(bvalues, axis=bm_axis, skipna=skipna)
-
-            mgr, _ = self._mgr.reduce(blk_func)
-            indices = mgr.as_array().ravel()
+        res = self._reduce(
+            nanops.nanargmax, "argmax", axis=axis, skipna=skipna, numeric_only=False
+        )
+        indices = res._values
 
         # indices will always be np.ndarray since axis is not None and
         # values is a 2d array for DataFrame

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9001,7 +9001,18 @@ NaN 12.3   33.0
         dtype: object
         """
         axis = self._get_axis_number(axis)
-        indices = nanops.nanargmin(self.values, axis=axis, skipna=skipna)
+
+        if self._can_fast_transpose or axis == 1:
+            # i.e. self.values call is cheap and non-casting (or unavoidable)
+            indices = nanops.nanargmin(self.values, axis=axis, skipna=skipna)
+        else:
+            bm_axis = 1 - axis
+
+            def blk_func(bvalues):
+                return nanops.nanargmin(bvalues, axis=bm_axis, skipna=skipna)
+
+            mgr, _ = self._mgr.reduce(blk_func)
+            indices = mgr.as_array().ravel()
 
         # indices will always be np.ndarray since axis is not None and
         # values is a 2d array for DataFrame
@@ -9074,7 +9085,18 @@ NaN 12.3   33.0
         dtype: object
         """
         axis = self._get_axis_number(axis)
-        indices = nanops.nanargmax(self.values, axis=axis, skipna=skipna)
+
+        if self._can_fast_transpose or axis == 1:
+            # i.e. self.values call is cheap and non-casting (or unavoidable)
+            indices = nanops.nanargmax(self.values, axis=axis, skipna=skipna)
+        else:
+            bm_axis = 1 - axis
+
+            def blk_func(bvalues):
+                return nanops.nanargmax(bvalues, axis=bm_axis, skipna=skipna)
+
+            mgr, _ = self._mgr.reduce(blk_func)
+            indices = mgr.as_array().ravel()
 
         # indices will always be np.ndarray since axis is not None and
         # values is a 2d array for DataFrame

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -969,6 +969,20 @@ class TestDataFrameAnalytics:
         with pytest.raises(ValueError, match=msg):
             frame.idxmax(axis=2)
 
+    def test_idxmax_mixed_dtype(self):
+        # don't cast to object, which would raise in nanops
+        dti = pd.date_range("2016-01-01", periods=3)
+
+        df = DataFrame({1: [0, 2, 1], 2: range(3)[::-1], 3: dti})
+
+        result = df.idxmax()
+        expected = Series([1, 0, 2], index=[1, 2, 3])
+        tm.assert_series_equal(result, expected)
+
+        result = df.idxmin()
+        expected = Series([0, 2, 0], index=[1, 2, 3])
+        tm.assert_series_equal(result, expected)
+
     # ----------------------------------------------------------------------
     # Logical reductions
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
