### PR TITLE
BUG: Avoid duplicates in DatetimeIndex.intersection

### DIFF
--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -687,7 +687,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
         self._validate_sort_keyword(sort)
         self._assert_can_do_setop(other)
 
-        if self.equals(other):
+        if self.equals(other) and not self.has_duplicates:
             return self._get_reconciled_name_object(other)
 
         if len(self) == 0:

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -686,8 +686,11 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
         """
         self._validate_sort_keyword(sort)
         self._assert_can_do_setop(other)
+        other, _ = self._convert_can_do_setop(other)
 
-        if self.equals(other) and not self.has_duplicates:
+        if self.equals(other):
+            if self.has_duplicates:
+                return self.unique()._get_reconciled_name_object(other)
             return self._get_reconciled_name_object(other)
 
         if len(self) == 0:

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -509,17 +509,18 @@ class TestBusinessDatetimeIndex:
 
         early_dr.union(late_dr, sort=sort)
 
-    def test_intersection_duplicates(self):
-        # GH#
+    @pytest.mark.parametrize("sort", [False, None])
+    def test_intersection_duplicates(self, sort):
+        # GH#38196
         idx1 = Index(
             [
-                pd.Timestamp("2019-12-12"),
                 pd.Timestamp("2019-12-13"),
+                pd.Timestamp("2019-12-12"),
                 pd.Timestamp("2019-12-12"),
             ]
         )
-        result = idx1.intersection(idx1)
-        expected = Index([pd.Timestamp("2019-12-12"), pd.Timestamp("2019-12-13")])
+        result = idx1.intersection(idx1, sort=sort)
+        expected = Index([pd.Timestamp("2019-12-13"), pd.Timestamp("2019-12-12")])
         tm.assert_index_equal(result, expected)
 
 

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -474,7 +474,7 @@ class TestBusinessDatetimeIndex:
         values = [pd.Timestamp("2020-01-01"), pd.Timestamp("2020-02-01")]
         idx = DatetimeIndex(values, name="a")
         res = idx.intersection(values)
-        tm.assert_index_equal(res, idx.rename(None))
+        tm.assert_index_equal(res, idx)
 
     def test_month_range_union_tz_pytz(self, sort):
         from pytz import timezone

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -509,6 +509,19 @@ class TestBusinessDatetimeIndex:
 
         early_dr.union(late_dr, sort=sort)
 
+    def test_intersection_duplicates(self):
+        # GH#
+        idx1 = Index(
+            [
+                pd.Timestamp("2019-12-12"),
+                pd.Timestamp("2019-12-13"),
+                pd.Timestamp("2019-12-12"),
+            ]
+        )
+        result = idx1.intersection(idx1)
+        expected = Index([pd.Timestamp("2019-12-12"), pd.Timestamp("2019-12-13")])
+        tm.assert_index_equal(result, expected)
+
 
 class TestCustomDatetimeIndex:
     def setup_method(self, method):


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

@jbrockmendel I think we should call ``_convert_can_do_setop`` here too, but https://github.com/pandas-dev/pandas/blob/56b9a80e1e47e123eb7a7c01448d1506400f8a5b/pandas/tests/indexes/datetimes/test_setops.py#L472 tests the opposite
