### PR TITLE
Remove duplicate entry on series.rst

### DIFF
--- a/doc/source/reference/series.rst
+++ b/doc/source/reference/series.rst
@@ -252,7 +252,6 @@ Combining / comparing / joining / merging
 
    Series.append
    Series.compare
-   Series.replace
    Series.update
 
 Time Series-related


### PR DESCRIPTION
- [x] closes #38198 
- [ ] tests passed. Nothing new fails. Few tails already were failing on `master`
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry (Intentionally ignored as insignificant)

Removed the duplicate entry of `Series.replace` from doc