### PR TITLE
Rewrite dict literal for files in ./pandas/tests/tools/ and  ./pandas/tests/resample/ 

### DIFF
--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -645,7 +645,7 @@ class TestParquetPyArrow(Base):
         if LooseVersion(pyarrow.__version__) <= LooseVersion("0.17.0"):
             pytest.skip()
         s3 = s3fs.S3FileSystem(**s3so)
-        kw = dict(filesystem=s3)
+        kw = {"filesystem": s3}
         check_round_trip(
             df_compat,
             pa,
@@ -658,7 +658,7 @@ class TestParquetPyArrow(Base):
         if LooseVersion(pyarrow.__version__) <= LooseVersion("0.17.0"):
             pytest.skip()
         # GH #19134
-        s3so = dict(storage_options=s3so)
+        s3so = {"storage_options": s3so}
         check_round_trip(
             df_compat,
             pa,
@@ -710,10 +710,11 @@ class TestParquetPyArrow(Base):
             pa,
             expected=expected_df,
             path="s3://pandas-test/parquet_dir",
-            read_kwargs=dict(storage_options=s3so),
-            write_kwargs=dict(
-                partition_cols=partition_col, compression=None, storage_options=s3so
-            ),
+            read_kwargs={"storage_options": s3so},
+            write_kwargs={
+                "partition_cols": partition_col, "compression": None,
+                "storage_options": s3so
+            },
             check_like=True,
             repeat=1,
         )
@@ -946,8 +947,8 @@ class TestParquetFastParquet(Base):
             df_compat,
             fp,
             path="s3://pandas-test/fastparquet.parquet",
-            read_kwargs=dict(storage_options=s3so),
-            write_kwargs=dict(compression=None, storage_options=s3so),
+            read_kwargs={"storage_options": s3so},
+            write_kwargs={"compression": None, "storage_options": s3so},
         )
 
     def test_partition_cols_supported(self, fp, df_full):

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -714,7 +714,7 @@ class TestParquetPyArrow(Base):
             write_kwargs={
                 "partition_cols": partition_col,
                 "compression": None,
-                "storage_options": s3so
+                "storage_options": s3so,
             },
             check_like=True,
             repeat=1,

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -712,7 +712,8 @@ class TestParquetPyArrow(Base):
             path="s3://pandas-test/parquet_dir",
             read_kwargs={"storage_options": s3so},
             write_kwargs={
-                "partition_cols": partition_col, "compression": None,
+                "partition_cols": partition_col,
+                "compression": None,
                 "storage_options": s3so
             },
             check_like=True,

--- a/pandas/tests/resample/test_time_grouper.py
+++ b/pandas/tests/resample/test_time_grouper.py
@@ -158,12 +158,12 @@ def test_aggregate_normal(resample_method):
 @pytest.mark.parametrize(
     "method, method_args, unit",
     [
-        ("sum", dict(), 0),
-        ("sum", dict(min_count=0), 0),
-        ("sum", dict(min_count=1), np.nan),
-        ("prod", dict(), 1),
-        ("prod", dict(min_count=0), 1),
-        ("prod", dict(min_count=1), np.nan),
+        ("sum", {}, 0),
+        ("sum", {"min_count": 0}, 0),
+        ("sum", {"min_count": 1}, np.nan),
+        ("prod", {}, 1),
+        ("prod", {"min_count": 0}, 1),
+        ("prod", {"min_count": 1}, np.nan),
     ],
 )
 def test_resample_entirely_nat_window(method, method_args, unit):
@@ -267,14 +267,14 @@ def test_repr():
 @pytest.mark.parametrize(
     "method, method_args, expected_values",
     [
-        ("sum", dict(), [1, 0, 1]),
-        ("sum", dict(min_count=0), [1, 0, 1]),
-        ("sum", dict(min_count=1), [1, np.nan, 1]),
-        ("sum", dict(min_count=2), [np.nan, np.nan, np.nan]),
-        ("prod", dict(), [1, 1, 1]),
-        ("prod", dict(min_count=0), [1, 1, 1]),
-        ("prod", dict(min_count=1), [1, np.nan, 1]),
-        ("prod", dict(min_count=2), [np.nan, np.nan, np.nan]),
+        ("sum", {}, [1, 0, 1]),
+        ("sum", {"min_count": 0}, [1, 0, 1]),
+        ("sum", {"min_count": 1}, [1, np.nan, 1]),
+        ("sum", {"min_count": 2}, [np.nan, np.nan, np.nan]),
+        ("prod", {}, [1, 1, 1]),
+        ("prod", {"min_count": 0}, [1, 1, 1]),
+        ("prod", {"min_count": 1}, [1, np.nan, 1]),
+        ("prod", {"min_count": 2}, [np.nan, np.nan, np.nan]),
     ],
 )
 def test_upsample_sum(method, method_args, expected_values):

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -48,8 +48,8 @@ def transform_assert_equal(request):
 @pytest.mark.parametrize(
     "input_kwargs,result_kwargs",
     [
-        (dict(), dict(dtype=np.int64)),
-        (dict(errors="coerce", downcast="integer"), dict(dtype=np.int8)),
+        ({}, {'dtype': np.int64}),
+        ({'errors': "coerce", 'downcast': "integer"}, {'dtype': np.int8}),
     ],
 )
 def test_empty(input_kwargs, result_kwargs):
@@ -147,10 +147,10 @@ def test_list():
 @pytest.mark.parametrize(
     "data,arr_kwargs",
     [
-        ([1, 3, 4, 5], dict(dtype=np.int64)),
-        ([1.0, 3.0, 4.0, 5.0], dict()),
+        ([1, 3, 4, 5], {'dtype': np.int64}),
+        ([1.0, 3.0, 4.0, 5.0], {}),
         # Boolean is regarded as numeric.
-        ([True, False, True, True], dict()),
+        ([True, False, True, True], {}),
     ],
 )
 def test_list_numeric(data, arr_kwargs):
@@ -159,7 +159,7 @@ def test_list_numeric(data, arr_kwargs):
     tm.assert_numpy_array_equal(result, expected)
 
 
-@pytest.mark.parametrize("kwargs", [dict(dtype="O"), dict()])
+@pytest.mark.parametrize("kwargs", [{'dtype' : "O"}, {}])
 def test_numeric(kwargs):
     data = [1, -3.14, 7]
 
@@ -182,13 +182,13 @@ def test_numeric(kwargs):
 def test_numeric_df_columns(columns):
     # see gh-14827
     df = DataFrame(
-        dict(
-            a=[1.2, decimal.Decimal(3.14), decimal.Decimal("infinity"), "0.1"],
-            b=[1.0, 2.0, 3.0, 4.0],
-        )
+        {
+            'a': [1.2, decimal.Decimal(3.14), decimal.Decimal("infinity"), "0.1"],
+            'b': [1.0, 2.0, 3.0, 4.0],
+        }
     )
 
-    expected = DataFrame(dict(a=[1.2, 3.14, np.inf, 0.1], b=[1.0, 2.0, 3.0, 4.0]))
+    expected = DataFrame({'a': [1.2, 3.14, np.inf, 0.1], 'b': [1.0, 2.0, 3.0, 4.0]})
 
     df_copy = df.copy()
     df_copy[columns] = df_copy[columns].apply(to_numeric)
@@ -208,10 +208,10 @@ def test_numeric_df_columns(columns):
 )
 def test_numeric_embedded_arr_likes(data, exp_data):
     # Test to_numeric with embedded lists and arrays
-    df = DataFrame(dict(a=data))
+    df = DataFrame({'a': data})
     df["a"] = df["a"].apply(to_numeric)
 
-    expected = DataFrame(dict(a=exp_data))
+    expected = DataFrame({'a': exp_data})
     tm.assert_frame_equal(df, expected)
 
 
@@ -226,7 +226,7 @@ def test_all_nan():
 def test_type_check(errors):
     # see gh-11776
     df = DataFrame({"a": [1, -3.14, 7], "b": ["4", "5", "6"]})
-    kwargs = dict(errors=errors) if errors is not None else dict()
+    kwargs = {'errors': errors} if errors is not None else {}
     error_ctx = pytest.raises(TypeError, match="1-d array")
 
     with error_ctx:
@@ -241,7 +241,7 @@ def test_scalar(val, signed, transform):
 
 def test_really_large_scalar(large_val, signed, transform, errors):
     # see gh-24910
-    kwargs = dict(errors=errors) if errors is not None else dict()
+    kwargs = {'errors': errors} if errors is not None else {}
     val = -large_val if signed else large_val
 
     val = transform(val)
@@ -258,7 +258,7 @@ def test_really_large_scalar(large_val, signed, transform, errors):
 
 def test_really_large_in_arr(large_val, signed, transform, multiple_elts, errors):
     # see gh-24910
-    kwargs = dict(errors=errors) if errors is not None else dict()
+    kwargs = {'errors': errors} if errors is not None else {}
     val = -large_val if signed else large_val
     val = transform(val)
 
@@ -300,7 +300,7 @@ def test_really_large_in_arr_consistent(large_val, signed, multiple_elts, errors
     #
     # Even if we discover that we have to hold float, does not mean
     # we should be lenient on subsequent elements that fail to be integer.
-    kwargs = dict(errors=errors) if errors is not None else dict()
+    kwargs = {'errors': errors} if errors is not None else {}
     arr = [str(-large_val if signed else large_val)]
 
     if multiple_elts:
@@ -452,12 +452,12 @@ def test_errors_invalid_value():
     "kwargs,exp_dtype",
     [
         # Basic function tests.
-        (dict(), np.int64),
-        (dict(downcast=None), np.int64),
+        ({}, np.int64),
+        ({'downcast': None}, np.int64),
         # Support below np.float32 is rare and far between.
-        (dict(downcast="float"), np.dtype(np.float32).char),
+        ({'downcast': "float"}, np.dtype(np.float32).char),
         # Basic dtype support.
-        (dict(downcast="unsigned"), np.dtype(np.typecodes["UnsignedInteger"][0])),
+        ({'downcast': "unsigned"}, np.dtype(np.typecodes["UnsignedInteger"][0])),
     ],
 )
 def test_downcast_basic(data, kwargs, exp_dtype):

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -48,8 +48,8 @@ def transform_assert_equal(request):
 @pytest.mark.parametrize(
     "input_kwargs,result_kwargs",
     [
-        ({}, {'dtype': np.int64}),
-        ({'errors': "coerce", 'downcast': "integer"}, {'dtype': np.int8}),
+        ({}, {"dtype": np.int64}),
+        ({"errors": "coerce", "downcast": "integer"}, {"dtype": np.int8}),
     ],
 )
 def test_empty(input_kwargs, result_kwargs):
@@ -147,7 +147,7 @@ def test_list():
 @pytest.mark.parametrize(
     "data,arr_kwargs",
     [
-        ([1, 3, 4, 5], {'dtype': np.int64}),
+        ([1, 3, 4, 5], {"dtype": np.int64}),
         ([1.0, 3.0, 4.0, 5.0], {}),
         # Boolean is regarded as numeric.
         ([True, False, True, True], {}),
@@ -159,7 +159,7 @@ def test_list_numeric(data, arr_kwargs):
     tm.assert_numpy_array_equal(result, expected)
 
 
-@pytest.mark.parametrize("kwargs", [{'dtype' : "O"}, {}])
+@pytest.mark.parametrize("kwargs", [{"dtype" : "O"}, {}])
 def test_numeric(kwargs):
     data = [1, -3.14, 7]
 
@@ -183,12 +183,12 @@ def test_numeric_df_columns(columns):
     # see gh-14827
     df = DataFrame(
         {
-            'a': [1.2, decimal.Decimal(3.14), decimal.Decimal("infinity"), "0.1"],
-            'b': [1.0, 2.0, 3.0, 4.0],
+            "a": [1.2, decimal.Decimal(3.14), decimal.Decimal("infinity"), "0.1"],
+            "b": [1.0, 2.0, 3.0, 4.0],
         }
     )
 
-    expected = DataFrame({'a': [1.2, 3.14, np.inf, 0.1], 'b': [1.0, 2.0, 3.0, 4.0]})
+    expected = DataFrame({"a": [1.2, 3.14, np.inf, 0.1], "b": [1.0, 2.0, 3.0, 4.0]})
 
     df_copy = df.copy()
     df_copy[columns] = df_copy[columns].apply(to_numeric)
@@ -208,10 +208,10 @@ def test_numeric_df_columns(columns):
 )
 def test_numeric_embedded_arr_likes(data, exp_data):
     # Test to_numeric with embedded lists and arrays
-    df = DataFrame({'a': data})
+    df = DataFrame({"a": data})
     df["a"] = df["a"].apply(to_numeric)
 
-    expected = DataFrame({'a': exp_data})
+    expected = DataFrame({"a": exp_data})
     tm.assert_frame_equal(df, expected)
 
 
@@ -226,7 +226,7 @@ def test_all_nan():
 def test_type_check(errors):
     # see gh-11776
     df = DataFrame({"a": [1, -3.14, 7], "b": ["4", "5", "6"]})
-    kwargs = {'errors': errors} if errors is not None else {}
+    kwargs = {"errors": errors} if errors is not None else {}
     error_ctx = pytest.raises(TypeError, match="1-d array")
 
     with error_ctx:
@@ -241,7 +241,7 @@ def test_scalar(val, signed, transform):
 
 def test_really_large_scalar(large_val, signed, transform, errors):
     # see gh-24910
-    kwargs = {'errors': errors} if errors is not None else {}
+    kwargs = {"errors": errors} if errors is not None else {}
     val = -large_val if signed else large_val
 
     val = transform(val)
@@ -258,7 +258,7 @@ def test_really_large_scalar(large_val, signed, transform, errors):
 
 def test_really_large_in_arr(large_val, signed, transform, multiple_elts, errors):
     # see gh-24910
-    kwargs = {'errors': errors} if errors is not None else {}
+    kwargs = {"errors": errors} if errors is not None else {}
     val = -large_val if signed else large_val
     val = transform(val)
 
@@ -300,7 +300,7 @@ def test_really_large_in_arr_consistent(large_val, signed, multiple_elts, errors
     #
     # Even if we discover that we have to hold float, does not mean
     # we should be lenient on subsequent elements that fail to be integer.
-    kwargs = {'errors': errors} if errors is not None else {}
+    kwargs = {"errors": errors} if errors is not None else {}
     arr = [str(-large_val if signed else large_val)]
 
     if multiple_elts:
@@ -453,11 +453,11 @@ def test_errors_invalid_value():
     [
         # Basic function tests.
         ({}, np.int64),
-        ({'downcast': None}, np.int64),
+        ({"downcast": None}, np.int64),
         # Support below np.float32 is rare and far between.
-        ({'downcast': "float"}, np.dtype(np.float32).char),
+        ({"downcast": "float"}, np.dtype(np.float32).char),
         # Basic dtype support.
-        ({'downcast': "unsigned"}, np.dtype(np.typecodes["UnsignedInteger"][0])),
+        ({"downcast": "unsigned"}, np.dtype(np.typecodes["UnsignedInteger"][0])),
     ],
 )
 def test_downcast_basic(data, kwargs, exp_dtype):

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -159,7 +159,7 @@ def test_list_numeric(data, arr_kwargs):
     tm.assert_numpy_array_equal(result, expected)
 
 
-@pytest.mark.parametrize("kwargs", [{"dtype" : "O"}, {}])
+@pytest.mark.parametrize("kwargs", [{"dtype": "O"}, {}])
 def test_numeric(kwargs):
     data = [1, -3.14, 7]
 

--- a/pandas/tests/util/test_assert_extension_array_equal.py
+++ b/pandas/tests/util/test_assert_extension_array_equal.py
@@ -9,9 +9,9 @@ from pandas.core.arrays.sparse import SparseArray
 @pytest.mark.parametrize(
     "kwargs",
     [
-        dict(),  # Default is check_exact=False
-        dict(check_exact=False),
-        dict(check_exact=True),
+        {},  # Default is check_exact=False
+        {"check_exact": False},
+        {"check_exact": True},
     ],
 )
 def test_assert_extension_array_equal_not_exact(kwargs):
@@ -55,7 +55,7 @@ ExtensionArray values are different \\(50\\.0 %\\)
 
 def test_assert_extension_array_equal_dtype_mismatch(check_dtype):
     end = 5
-    kwargs = dict(check_dtype=check_dtype)
+    kwargs = {"check_dtype": check_dtype}
 
     arr1 = SparseArray(np.arange(end, dtype="int64"))
     arr2 = SparseArray(np.arange(end, dtype="int32"))

--- a/pandas/tests/util/test_assert_index_equal.py
+++ b/pandas/tests/util/test_assert_index_equal.py
@@ -85,7 +85,7 @@ Index values are different \\(33\\.33333 %\\)
 def test_index_equal_values_less_close(check_exact, rtol):
     idx1 = Index([1, 2, 3.0])
     idx2 = Index([1, 2, 3.0001])
-    kwargs = dict(check_exact=check_exact, rtol=rtol)
+    kwargs = {"check_exact": check_exact, "rtol": rtol}
 
     if check_exact or rtol < 0.5e-3:
         msg = """Index are different
@@ -103,7 +103,7 @@ Index values are different \\(33\\.33333 %\\)
 def test_index_equal_values_too_far(check_exact, rtol):
     idx1 = Index([1, 2, 3])
     idx2 = Index([1, 2, 4])
-    kwargs = dict(check_exact=check_exact, rtol=rtol)
+    kwargs = {"check_exact": check_exact, "rtol": rtol}
 
     msg = """Index are different
 
@@ -140,7 +140,7 @@ Index values are different \\(66\\.66667 %\\)
 def test_index_equal_level_values_mismatch(check_exact, rtol):
     idx1 = MultiIndex.from_tuples([("A", 2), ("A", 2), ("B", 3), ("B", 4)])
     idx2 = MultiIndex.from_tuples([("A", 1), ("A", 2), ("B", 3), ("B", 4)])
-    kwargs = dict(check_exact=check_exact, rtol=rtol)
+    kwargs = {"check_exact": check_exact, "rtol": rtol}
 
     msg = """MultiIndex level \\[1\\] are different
 

--- a/pandas/tests/util/test_assert_interval_array_equal.py
+++ b/pandas/tests/util/test_assert_interval_array_equal.py
@@ -7,9 +7,9 @@ import pandas._testing as tm
 @pytest.mark.parametrize(
     "kwargs",
     [
-        dict(start=0, periods=4),
-        dict(start=1, periods=5),
-        dict(start=5, end=10, closed="left"),
+        {"start": 0, "periods": 4},
+        {"start": 1, "periods": 5},
+        {"start": 5, "end": 10, "closed": "left"},
     ],
 )
 def test_interval_array_equal(kwargs):
@@ -18,7 +18,7 @@ def test_interval_array_equal(kwargs):
 
 
 def test_interval_array_equal_closed_mismatch():
-    kwargs = dict(start=0, periods=5)
+    kwargs = {"start": 0, "periods": 5}
     arr1 = interval_range(closed="left", **kwargs).values
     arr2 = interval_range(closed="right", **kwargs).values
 
@@ -34,7 +34,7 @@ Attribute "closed" are different
 
 
 def test_interval_array_equal_periods_mismatch():
-    kwargs = dict(start=0)
+    kwargs = {"start": 0}
     arr1 = interval_range(periods=5, **kwargs).values
     arr2 = interval_range(periods=6, **kwargs).values
 
@@ -50,7 +50,7 @@ IntervalArray.left shapes are different
 
 
 def test_interval_array_equal_end_mismatch():
-    kwargs = dict(start=0, periods=5)
+    kwargs = {"start": 0, "periods": 5}
     arr1 = interval_range(end=10, **kwargs).values
     arr2 = interval_range(end=20, **kwargs).values
 
@@ -66,7 +66,7 @@ IntervalArray.left values are different \\(80.0 %\\)
 
 
 def test_interval_array_equal_start_mismatch():
-    kwargs = dict(periods=4)
+    kwargs = {"periods": 4}
     arr1 = interval_range(start=0, **kwargs).values
     arr2 = interval_range(start=1, **kwargs).values
 

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -87,9 +87,9 @@ def test_series_not_equal_value_mismatch(data1, data2):
 @pytest.mark.parametrize(
     "kwargs",
     [
-        dict(dtype="float64"),  # dtype mismatch
-        dict(index=[1, 2, 4]),  # index mismatch
-        dict(name="foo"),  # name mismatch
+        {"dtype": "float64"},  # dtype mismatch
+        {"index": [1, 2, 4]},  # index mismatch
+        {"name": "foo"},  # name mismatch
     ],
 )
 def test_series_not_equal_metadata_mismatch(kwargs):
@@ -140,7 +140,7 @@ def test_less_precise(data1, data2, dtype, decimals):
     ],
 )
 def test_series_equal_index_dtype(s1, s2, msg, check_index_type):
-    kwargs = dict(check_index_type=check_index_type)
+    kwargs = {"check_index_type": check_index_type}
 
     if check_index_type:
         with pytest.raises(AssertionError, match=msg):


### PR DESCRIPTION
- [ ] xref #38138
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Rewrote dict literal for the following files: 

 ./pandas/tests/tools/test_to_numeric.py
 ./pandas/tests/resample/test_time_grouper.py
 ./pandas/tests/util/test_assert_series_equal.py
 ./pandas/tests/util/test_assert_interval_array_equal.py
 ./pandas/tests/util/test_assert_index_equal.py
 ./pandas/tests/util/test_assert_extension_array_equal.py
 ./pandas/tests/io/test_parquet.py
