### PR TITLE
Rewrite dict literal for files in tests/groupby & ./pandas/tests/dtypes 

### DIFF
--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -68,7 +68,7 @@ ll_params = [
     ((1,), True, "tuple"),
     (tuple(), True, "tuple-empty"),
     ({"a": 1}, True, "dict"),
-    (dict(), True, "dict-empty"),
+    ({}, True, "dict-empty"),
     ({"a", 1}, "set", "set"),
     (set(), "set", "set-empty"),
     (frozenset({"a", 1}), "set", "frozenset"),
@@ -1489,7 +1489,7 @@ def test_datetimeindex_from_empty_datetime64_array():
 def test_nan_to_nat_conversions():
 
     df = DataFrame(
-        dict({"A": np.asarray(range(10), dtype="float64"), "B": Timestamp("20010101")})
+        {"A": np.asarray(range(10), dtype="float64"), "B": Timestamp("20010101")}
     )
     df.iloc[3:6, :] = np.nan
     result = df.loc[4, "B"]

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -692,14 +692,14 @@ def test_cummin(numpy_dtypes_for_minmax):
     tm.assert_frame_equal(result, expected)
 
     # GH 15561
-    df = DataFrame(dict(a=[1], b=pd.to_datetime(["2001"])))
+    df = DataFrame({"a": [1], "b": pd.to_datetime(["2001"])})
     expected = Series(pd.to_datetime("2001"), index=[0], name="b")
 
     result = df.groupby("a")["b"].cummin()
     tm.assert_series_equal(expected, result)
 
     # GH 15635
-    df = DataFrame(dict(a=[1, 2, 1], b=[1, 2, 2]))
+    df = DataFrame({"a": [1, 2, 1], "b": [1, 2, 2]})
     result = df.groupby("a").b.cummin()
     expected = Series([1, 2, 1], name="b")
     tm.assert_series_equal(result, expected)
@@ -748,14 +748,14 @@ def test_cummax(numpy_dtypes_for_minmax):
     tm.assert_frame_equal(result, expected)
 
     # GH 15561
-    df = DataFrame(dict(a=[1], b=pd.to_datetime(["2001"])))
+    df = DataFrame({"a": [1], "b": pd.to_datetime(["2001"])})
     expected = Series(pd.to_datetime("2001"), index=[0], name="b")
 
     result = df.groupby("a")["b"].cummax()
     tm.assert_series_equal(expected, result)
 
     # GH 15635
-    df = DataFrame(dict(a=[1, 2, 1], b=[2, 1, 1]))
+    df = DataFrame({"a": [1, 2, 1], "b": [2, 1, 1]})
     result = df.groupby("a").b.cummax()
     expected = Series([2, 1, 2], name="b")
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -228,7 +228,7 @@ def test_transform_dtype():
 def test_transform_bug():
     # GH 5712
     # transforming on a datetime column
-    df = DataFrame(dict(A=Timestamp("20130101"), B=np.arange(5)))
+    df = DataFrame({"A": Timestamp("20130101"), "B": np.arange(5)})
     result = df.groupby("A")["B"].transform(lambda x: x.rank(ascending=False))
     expected = Series(np.arange(5, 0, step=-1), name="B")
     tm.assert_series_equal(result, expected)
@@ -251,7 +251,7 @@ def test_transform_numeric_to_boolean():
 def test_transform_datetime_to_timedelta():
     # GH 15429
     # transforming a datetime to timedelta
-    df = DataFrame(dict(A=Timestamp("20130101"), B=np.arange(5)))
+    df = DataFrame({"A": Timestamp("20130101"), "B": np.arange(5)})
     expected = Series([Timestamp("20130101") - Timestamp("20130101")] * 5, name="A")
 
     # this does date math without changing result type in transform
@@ -442,7 +442,7 @@ def test_transform_coercion():
     # 14457
     # when we are transforming be sure to not coerce
     # via assignment
-    df = DataFrame(dict(A=["a", "a"], B=[0, 1]))
+    df = DataFrame({"A": ["a", "a"], "B": [0, 1]})
     g = df.groupby("A")
 
     expected = g.transform(np.mean)
@@ -456,30 +456,37 @@ def test_groupby_transform_with_int():
 
     # floats
     df = DataFrame(
-        dict(
-            A=[1, 1, 1, 2, 2, 2],
-            B=Series(1, dtype="float64"),
-            C=Series([1, 2, 3, 1, 2, 3], dtype="float64"),
-            D="foo",
-        )
+        {
+            "A": [1, 1, 1, 2, 2, 2],
+            "B": Series(1, dtype="float64"),
+            "C": Series([1, 2, 3, 1, 2, 3], dtype="float64"),
+            "D": "foo",
+        }
     )
     with np.errstate(all="ignore"):
         result = df.groupby("A").transform(lambda x: (x - x.mean()) / x.std())
     expected = DataFrame(
-        dict(B=np.nan, C=Series([-1, 0, 1, -1, 0, 1], dtype="float64"))
+        {"B": np.nan, "C": Series([-1, 0, 1, -1, 0, 1], dtype="float64")}
     )
     tm.assert_frame_equal(result, expected)
 
     # int case
-    df = DataFrame(dict(A=[1, 1, 1, 2, 2, 2], B=1, C=[1, 2, 3, 1, 2, 3], D="foo"))
+    df = DataFrame(
+        {
+            "A": [1, 1, 1, 2, 2, 2],
+            "B": 1,
+            "C": [1, 2, 3, 1, 2, 3],
+            "D": "foo",
+        }
+    )
     with np.errstate(all="ignore"):
         result = df.groupby("A").transform(lambda x: (x - x.mean()) / x.std())
-    expected = DataFrame(dict(B=np.nan, C=[-1, 0, 1, -1, 0, 1]))
+    expected = DataFrame({"B": np.nan, "C": [-1, 0, 1, -1, 0, 1]})
     tm.assert_frame_equal(result, expected)
 
     # int that needs float conversion
     s = Series([2, 3, 4, 10, 5, -1])
-    df = DataFrame(dict(A=[1, 1, 1, 2, 2, 2], B=1, C=s, D="foo"))
+    df = DataFrame({"A": [1, 1, 1, 2, 2, 2], "B": 1, "C": s, "D": "foo"})
     with np.errstate(all="ignore"):
         result = df.groupby("A").transform(lambda x: (x - x.mean()) / x.std())
 
@@ -487,12 +494,12 @@ def test_groupby_transform_with_int():
     s1 = (s1 - s1.mean()) / s1.std()
     s2 = s.iloc[3:6]
     s2 = (s2 - s2.mean()) / s2.std()
-    expected = DataFrame(dict(B=np.nan, C=concat([s1, s2])))
+    expected = DataFrame({"B": np.nan, "C": concat([s1, s2])})
     tm.assert_frame_equal(result, expected)
 
     # int downcasting
     result = df.groupby("A").transform(lambda x: x * 2 / 2)
-    expected = DataFrame(dict(B=1, C=[2, 3, 4, 10, 5, -1]))
+    expected = DataFrame({"B": 1, "C": [2, 3, 4, 10, 5, -1]})
     tm.assert_frame_equal(result, expected)
 
 
@@ -659,11 +666,11 @@ def test_cython_transform_frame(op, args, targop):
     # group by values, index level, columns
     for df in [df, df2]:
         for gb_target in [
-            dict(by=labels),
-            dict(level=0),
-            dict(by="string"),
-        ]:  # dict(by='string_missing')]:
-            # dict(by=['int','string'])]:
+            {"by": labels},
+            {"level": 0},
+            {"by": "string"},
+        ]:  # {"by": 'string_missing'}]:
+            # {"by": ['int','string']}]:
 
             gb = df.groupby(**gb_target)
             # allowlisted methods set the selection before applying
@@ -986,7 +993,7 @@ def test_transform_absent_categories(func):
     x_vals = [1]
     x_cats = range(2)
     y = [1]
-    df = DataFrame(dict(x=Categorical(x_vals, x_cats), y=y))
+    df = DataFrame({"x": Categorical(x_vals, x_cats), "y": y})
     result = getattr(df.y.groupby(df.x), func)()
     expected = df.y
     tm.assert_series_equal(result, expected)
@@ -1005,7 +1012,7 @@ def test_ffill_not_in_axis(func, key, val):
 
 def test_transform_invalid_name_raises():
     # GH#27486
-    df = DataFrame(dict(a=[0, 1, 1, 2]))
+    df = DataFrame({"a": [0, 1, 1, 2]})
     g = df.groupby(["a", "b", "b", "c"])
     with pytest.raises(ValueError, match="not a valid function name"):
         g.transform("some_arbitrary_name")
@@ -1025,7 +1032,7 @@ def test_transform_invalid_name_raises():
     "obj",
     [
         DataFrame(
-            dict(a=[0, 0, 0, 1, 1, 1], b=range(6)), index=["A", "B", "C", "D", "E", "F"]
+            {"a": [0, 0, 0, 1, 1, 1], "b": range(6)}, index=["A", "B", "C", "D", "E", "F"]
         ),
         Series([0, 0, 0, 1, 1, 1], index=["A", "B", "C", "D", "E", "F"]),
     ],

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -1033,7 +1033,7 @@ def test_transform_invalid_name_raises():
     [
         DataFrame(
             {"a": [0, 0, 0, 1, 1, 1], "b": range(6)},
-            index=["A", "B", "C", "D", "E", "F"]
+            index=["A", "B", "C", "D", "E", "F"],
         ),
         Series([0, 0, 0, 1, 1, 1], index=["A", "B", "C", "D", "E", "F"]),
     ],

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -1032,7 +1032,8 @@ def test_transform_invalid_name_raises():
     "obj",
     [
         DataFrame(
-            {"a": [0, 0, 0, 1, 1, 1], "b": range(6)}, index=["A", "B", "C", "D", "E", "F"]
+            {"a": [0, 0, 0, 1, 1, 1], "b": range(6)},
+            index=["A", "B", "C", "D", "E", "F"]
         ),
         Series([0, 0, 0, 1, 1, 1], index=["A", "B", "C", "D", "E", "F"]),
     ],


### PR DESCRIPTION
- [ ] xref #38138
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
identify unnecessary dict call - rewrite as a literal
Rewrites as dictionary literals for the following files:

 ./pandas/tests/dtypes/test_inference.py
./pandas/tests/groupby/test_function.py
./pandas/tests/groupby/transform/test_transform.py

