### PR TITLE
Rewrite dict literal for files in pandas/tests/frame

### DIFF
--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -714,7 +714,7 @@ class TestDataFrameIndexing:
         tm.assert_frame_equal(result, df)
 
     @pytest.mark.parametrize("dtype", ["float", "int64"])
-    @pytest.mark.parametrize("kwargs", [dict(), dict(index=[1]), dict(columns=["A"])])
+    @pytest.mark.parametrize("kwargs", [{}, {"index": [1]}, {"columns": ["A"]}])
     def test_setitem_empty_frame_with_boolean(self, dtype, kwargs):
         # see gh-10126
         kwargs["dtype"] = dtype
@@ -1238,7 +1238,7 @@ class TestDataFrameIndexing:
         assert is_integer(result)
 
         # GH 11617
-        df = DataFrame(dict(a=[1.23]))
+        df = DataFrame({"a": [1.23]})
         df["b"] = 666
 
         result = df.loc[0, "b"]

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -356,11 +356,11 @@ class TestDataFrameIndexingWhere:
 
         # GH 3311
         df = DataFrame(
-            dict(
-                A=date_range("20130102", periods=5),
-                B=date_range("20130104", periods=5),
-                C=np.random.randn(5),
-            )
+            {
+                "A": date_range("20130102", periods=5),
+                "B": date_range("20130104", periods=5),
+                "C": np.random.randn(5),
+            }
         )
 
         stamp = datetime(2013, 1, 3)
@@ -618,7 +618,7 @@ class TestDataFrameIndexingWhere:
 
         tm.assert_frame_equal(result, expected)
 
-    @pytest.mark.parametrize("kwargs", [dict(), dict(other=None)])
+    @pytest.mark.parametrize("kwargs", [{}, {"other": None}])
     def test_df_where_with_category(self, kwargs):
         # GH#16979
         df = DataFrame(np.arange(2 * 3).reshape(2, 3), columns=list("ABC"))

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -53,10 +53,10 @@ class TestFillNA:
         mf = mixed_float_frame.reindex(columns=["A", "B", "D"])
         mf.loc[mf.index[-10:], "A"] = np.nan
         result = mf.fillna(value=0)
-        _check_mixed_float(result, dtype=dict(C=None))
+        _check_mixed_float(result, dtype={"C": None})
 
         result = mf.fillna(method="pad")
-        _check_mixed_float(result, dtype=dict(C=None))
+        _check_mixed_float(result, dtype={"C": None})
 
     def test_fillna_empty(self):
         # empty frame (GH#2778)
@@ -262,7 +262,7 @@ class TestFillNA:
         tm.assert_frame_equal(result, expected)
 
         # equiv of replace
-        df = DataFrame(dict(A=[1, np.nan], B=[1.0, 2.0]))
+        df = DataFrame({"A": [1, np.nan], "B": [1.0, 2.0]})
         for v in ["", 1, np.nan, 1.0]:
             expected = df.replace(np.nan, v)
             result = df.fillna(v)

--- a/pandas/tests/frame/methods/test_sort_values.py
+++ b/pandas/tests/frame/methods/test_sort_values.py
@@ -305,11 +305,11 @@ class TestDataFrameSortValues:
         float_values = (2.0, -1.797693e308)
 
         df = DataFrame(
-            dict(int=int_values, float=float_values), columns=["int", "float"]
+            {"int": int_values, "float": float_values}, columns=["int", "float"]
         )
 
         df_reversed = DataFrame(
-            dict(int=int_values[::-1], float=float_values[::-1]),
+            {"int": int_values[::-1], "float": float_values[::-1]},
             columns=["int", "float"],
             index=[1, 0],
         )
@@ -329,12 +329,12 @@ class TestDataFrameSortValues:
         # and now check if NaT is still considered as "na" for datetime64
         # columns:
         df = DataFrame(
-            dict(datetime=[Timestamp("2016-01-01"), NaT], float=float_values),
+            {"datetime": [Timestamp("2016-01-01"), NaT], "float": float_values},
             columns=["datetime", "float"],
         )
 
         df_reversed = DataFrame(
-            dict(datetime=[NaT, Timestamp("2016-01-01")], float=float_values[::-1]),
+            {"datetime": [NaT, Timestamp("2016-01-01")], "float": float_values[::-1]},
             columns=["datetime", "float"],
             index=[1, 0],
         )

--- a/pandas/tests/frame/methods/test_to_csv.py
+++ b/pandas/tests/frame/methods/test_to_csv.py
@@ -38,7 +38,7 @@ MIXED_INT_DTYPES = [
 
 class TestDataFrameToCSV:
     def read_csv(self, path, **kwargs):
-        params = dict(index_col=0, parse_dates=True)
+        params = {"index_col": 0, "parse_dates": True}
         params.update(**kwargs)
 
         return pd.read_csv(path, **params)
@@ -248,7 +248,7 @@ class TestDataFrameToCSV:
 
         # s3=make_dtnjat_arr(chunksize+5,0)
         with tm.ensure_clean("1.csv") as pth:
-            df = DataFrame(dict(a=s1, b=s2))
+            df = DataFrame({"a": s1, "b": s2})
             df.to_csv(pth, chunksize=chunksize)
 
             recons = self.read_csv(pth).apply(to_datetime)
@@ -260,7 +260,7 @@ class TestDataFrameToCSV:
             df, r_dtype=None, c_dtype=None, rnlvl=None, cnlvl=None, dupe_col=False
         ):
 
-            kwargs = dict(parse_dates=False)
+            kwargs = {"parse_dates": False}
             if cnlvl:
                 if rnlvl is not None:
                     kwargs["index_col"] = list(range(rnlvl))
@@ -291,7 +291,7 @@ class TestDataFrameToCSV:
                 recons.index = ix
                 recons = recons.iloc[:, rnlvl - 1 :]
 
-            type_map = dict(i="i", f="f", s="O", u="O", dt="O", p="O")
+            type_map = {"i": "i", "f": "f", "s": "O", "u": "O", "dt": "O", "p": "O"}
             if r_dtype:
                 if r_dtype == "u":  # unicode
                     r_dtype = "O"
@@ -738,7 +738,7 @@ class TestDataFrameToCSV:
         df = pd.concat([df_float, df_int, df_bool, df_object, df_dt], axis=1)
 
         # dtype
-        dtypes = dict()
+        dtypes = {}
         for n, dtype in [
             ("float", np.float64),
             ("int", np.int64),

--- a/pandas/tests/frame/methods/test_to_records.py
+++ b/pandas/tests/frame/methods/test_to_records.py
@@ -131,7 +131,7 @@ class TestDataFrameToRecords:
         [
             # No dtypes --> default to array dtypes.
             (
-                dict(),
+                {},
                 np.rec.array(
                     [(0, 1, 0.2, "a"), (1, 2, 1.5, "bc")],
                     dtype=[("index", "<i8"), ("A", "<i8"), ("B", "<f8"), ("C", "O")],
@@ -139,7 +139,7 @@ class TestDataFrameToRecords:
             ),
             # Should have no effect in this case.
             (
-                dict(index=True),
+                {"index": True},
                 np.rec.array(
                     [(0, 1, 0.2, "a"), (1, 2, 1.5, "bc")],
                     dtype=[("index", "<i8"), ("A", "<i8"), ("B", "<f8"), ("C", "O")],
@@ -147,7 +147,7 @@ class TestDataFrameToRecords:
             ),
             # Column dtype applied across the board. Index unaffected.
             (
-                dict(column_dtypes="<U4"),
+                {"column_dtypes": "<U4"},
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
                     dtype=[("index", "<i8"), ("A", "<U4"), ("B", "<U4"), ("C", "<U4")],
@@ -155,7 +155,7 @@ class TestDataFrameToRecords:
             ),
             # Index dtype applied across the board. Columns unaffected.
             (
-                dict(index_dtypes="<U1"),
+                {"index_dtypes": "<U1"},
                 np.rec.array(
                     [("0", 1, 0.2, "a"), ("1", 2, 1.5, "bc")],
                     dtype=[("index", "<U1"), ("A", "<i8"), ("B", "<f8"), ("C", "O")],
@@ -163,7 +163,7 @@ class TestDataFrameToRecords:
             ),
             # Pass in a type instance.
             (
-                dict(column_dtypes=str),
+                {"column_dtypes": str},
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
                     dtype=[("index", "<i8"), ("A", "<U"), ("B", "<U"), ("C", "<U")],
@@ -171,7 +171,7 @@ class TestDataFrameToRecords:
             ),
             # Pass in a dtype instance.
             (
-                dict(column_dtypes=np.dtype("unicode")),
+                {"column_dtypes": np.dtype("unicode")},
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
                     dtype=[("index", "<i8"), ("A", "<U"), ("B", "<U"), ("C", "<U")],
@@ -179,7 +179,7 @@ class TestDataFrameToRecords:
             ),
             # Pass in a dictionary (name-only).
             (
-                dict(column_dtypes={"A": np.int8, "B": np.float32, "C": "<U2"}),
+                {"column_dtypes": {"A": np.int8, "B": np.float32, "C": "<U2"}},
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
                     dtype=[("index", "<i8"), ("A", "i1"), ("B", "<f4"), ("C", "<U2")],
@@ -187,7 +187,7 @@ class TestDataFrameToRecords:
             ),
             # Pass in a dictionary (indices-only).
             (
-                dict(index_dtypes={0: "int16"}),
+                {"index_dtypes": {0: "int16"}},
                 np.rec.array(
                     [(0, 1, 0.2, "a"), (1, 2, 1.5, "bc")],
                     dtype=[("index", "i2"), ("A", "<i8"), ("B", "<f8"), ("C", "O")],
@@ -195,7 +195,7 @@ class TestDataFrameToRecords:
             ),
             # Ignore index mappings if index is not True.
             (
-                dict(index=False, index_dtypes="<U2"),
+                {"index": False, "index_dtypes": "<U2"},
                 np.rec.array(
                     [(1, 0.2, "a"), (2, 1.5, "bc")],
                     dtype=[("A", "<i8"), ("B", "<f8"), ("C", "O")],
@@ -203,7 +203,7 @@ class TestDataFrameToRecords:
             ),
             # Non-existent names / indices in mapping should not error.
             (
-                dict(index_dtypes={0: "int16", "not-there": "float32"}),
+                {"index_dtypes": {0: "int16", "not-there": "float32"}},
                 np.rec.array(
                     [(0, 1, 0.2, "a"), (1, 2, 1.5, "bc")],
                     dtype=[("index", "i2"), ("A", "<i8"), ("B", "<f8"), ("C", "O")],
@@ -211,7 +211,7 @@ class TestDataFrameToRecords:
             ),
             # Names / indices not in mapping default to array dtype.
             (
-                dict(column_dtypes={"A": np.int8, "B": np.float32}),
+                {"column_dtypes": {"A": np.int8, "B": np.float32}},
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
                     dtype=[("index", "<i8"), ("A", "i1"), ("B", "<f4"), ("C", "O")],
@@ -219,7 +219,7 @@ class TestDataFrameToRecords:
             ),
             # Names / indices not in dtype mapping default to array dtype.
             (
-                dict(column_dtypes={"A": np.dtype("int8"), "B": np.dtype("float32")}),
+                {"column_dtypes": {"A": np.dtype("int8"), "B": np.dtype("float32")}},
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
                     dtype=[("index", "<i8"), ("A", "i1"), ("B", "<f4"), ("C", "O")],
@@ -227,7 +227,10 @@ class TestDataFrameToRecords:
             ),
             # Mixture of everything.
             (
-                dict(column_dtypes={"A": np.int8, "B": np.float32}, index_dtypes="<U2"),
+                {
+                    "column_dtypes": {"A": np.int8, "B": np.float32},
+                    "index_dtypes": "<U2",
+                },
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
                     dtype=[("index", "<U2"), ("A", "i1"), ("B", "<f4"), ("C", "O")],
@@ -235,24 +238,24 @@ class TestDataFrameToRecords:
             ),
             # Invalid dype values.
             (
-                dict(index=False, column_dtypes=list()),
+                {"index": False, "column_dtypes": list()},
                 (ValueError, "Invalid dtype \\[\\] specified for column A"),
             ),
             (
-                dict(index=False, column_dtypes={"A": "int32", "B": 5}),
+                {"index": False, "column_dtypes": {"A": "int32", "B": 5}},
                 (ValueError, "Invalid dtype 5 specified for column B"),
             ),
             # Numpy can't handle EA types, so check error is raised
             (
-                dict(
-                    index=False,
-                    column_dtypes={"A": "int32", "B": CategoricalDtype(["a", "b"])},
-                ),
+                {
+                    "index": False,
+                    "column_dtypes": {"A": "int32", "B": CategoricalDtype(["a", "b"])},
+                },
                 (ValueError, "Invalid dtype category specified for column B"),
             ),
             # Check that bad types raise
             (
-                dict(index=False, column_dtypes={"A": "int32", "B": "foo"}),
+                {"index": False, "column_dtypes": {"A": "int32", "B": "foo"}},
                 (TypeError, "data type [\"']foo[\"'] not understood"),
             ),
         ],
@@ -276,7 +279,7 @@ class TestDataFrameToRecords:
                 DataFrame(
                     [[1, 2, 3], [4, 5, 6], [7, 8, 9]], columns=list("abc")
                 ).set_index(["a", "b"]),
-                dict(column_dtypes="float64", index_dtypes={0: "int32", 1: "int8"}),
+                {"column_dtypes": "float64", "index_dtypes": {0: "int32", 1: "int8"}},
                 np.rec.array(
                     [(1, 2, 3.0), (4, 5, 6.0), (7, 8, 9.0)],
                     dtype=[("a", "<i4"), ("b", "i1"), ("c", "<f8")],
@@ -290,7 +293,7 @@ class TestDataFrameToRecords:
                         [("a", "d"), ("b", "e"), ("c", "f")]
                     ),
                 ),
-                dict(column_dtypes={0: "<U1", 2: "float32"}, index_dtypes="float32"),
+                {"column_dtypes": {0: "<U1", 2: "float32"}, "index_dtypes": "float32"},
                 np.rec.array(
                     [(0.0, "1", 2, 3.0), (1.0, "4", 5, 6.0), (2.0, "7", 8, 9.0)],
                     dtype=[
@@ -312,7 +315,7 @@ class TestDataFrameToRecords:
                         [("d", -4), ("d", -5), ("f", -6)], names=list("cd")
                     ),
                 ),
-                dict(column_dtypes="float64", index_dtypes={0: "<U2", 1: "int8"}),
+                {"column_dtypes": "float64", "index_dtypes": {0: "<U2", 1: "int8"}},
                 np.rec.array(
                     [
                         ("d", -4, 1.0, 2.0, 3.0),
@@ -352,10 +355,10 @@ class TestDataFrameToRecords:
 
         df = DataFrame({"A": [1, 2], "B": [0.2, 1.5], "C": ["a", "bc"]})
 
-        dtype_mappings = dict(
-            column_dtypes=DictLike(**{"A": np.int8, "B": np.float32}),
-            index_dtypes="<U2",
-        )
+        dtype_mappings = {
+            "column_dtypes": DictLike(**{"A": np.int8, "B": np.float32}),
+            "index_dtypes": "<U2",
+        }
 
         result = df.to_records(**dtype_mappings)
         expected = np.rec.array(

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -473,7 +473,7 @@ class TestFrameFlexArithmetic:
         result = getattr(mixed_float_frame, op)(2 * mixed_float_frame)
         expected = f(mixed_float_frame, 2 * mixed_float_frame)
         tm.assert_frame_equal(result, expected)
-        _check_mixed_float(result, dtype=dict(C=None))
+        _check_mixed_float(result, dtype={"C": None})
 
     @pytest.mark.parametrize("op", ["__add__", "__sub__", "__mul__"])
     def test_arith_flex_frame_mixed(
@@ -488,9 +488,9 @@ class TestFrameFlexArithmetic:
         # no overflow in the uint
         dtype = None
         if op in ["__sub__"]:
-            dtype = dict(B="uint64", C=None)
+            dtype = {"B": "uint64", "C": None}
         elif op in ["__add__", "__mul__"]:
-            dtype = dict(C=None)
+            dtype = {"C": None}
         tm.assert_frame_equal(result, expected)
         _check_mixed_int(result, dtype=dtype)
 
@@ -498,7 +498,7 @@ class TestFrameFlexArithmetic:
         result = getattr(mixed_float_frame, op)(2 * mixed_float_frame)
         expected = f(mixed_float_frame, 2 * mixed_float_frame)
         tm.assert_frame_equal(result, expected)
-        _check_mixed_float(result, dtype=dict(C=None))
+        _check_mixed_float(result, dtype={"C": None})
 
         # vs plain int
         result = getattr(int_frame, op)(2 * int_frame)
@@ -1126,7 +1126,7 @@ class TestFrameArithmeticUnsorted:
 
         # mix vs mix
         added = mixed_float_frame + mixed_float_frame
-        _check_mixed_float(added, dtype=dict(C=None))
+        _check_mixed_float(added, dtype={"C": None})
 
         # with int
         added = float_frame + mixed_int_frame
@@ -1160,20 +1160,20 @@ class TestFrameArithmeticUnsorted:
 
         # vs mix (upcast) as needed
         added = mixed_float_frame + series.astype("float32")
-        _check_mixed_float(added, dtype=dict(C=None))
+        _check_mixed_float(added, dtype={"C": None})
         added = mixed_float_frame + series.astype("float16")
-        _check_mixed_float(added, dtype=dict(C=None))
+        _check_mixed_float(added, dtype={"C": None})
 
         # FIXME: don't leave commented-out
         # these raise with numexpr.....as we are adding an int64 to an
         # uint64....weird vs int
 
         # added = mixed_int_frame + (100*series).astype('int64')
-        # _check_mixed_int(added, dtype = dict(A = 'int64', B = 'float64', C =
-        # 'int64', D = 'int64'))
+        # _check_mixed_int(added, dtype = {"A": 'int64', "B": 'float64', "C":
+        # 'int64', "D": 'int64'})
         # added = mixed_int_frame + (100*series).astype('int32')
-        # _check_mixed_int(added, dtype = dict(A = 'int32', B = 'float64', C =
-        # 'int32', D = 'int64'))
+        # _check_mixed_int(added, dtype = {"A": 'int32', "B": 'float64', "C":
+        # 'int32', "D": 'int64'})
 
         # TimeSeries
         ts = datetime_frame["A"]
@@ -1228,7 +1228,7 @@ class TestFrameArithmeticUnsorted:
         result = mixed_float_frame * 2
         for c, s in result.items():
             tm.assert_numpy_array_equal(s.values, mixed_float_frame[c].values * 2)
-        _check_mixed_float(result, dtype=dict(C=None))
+        _check_mixed_float(result, dtype={"C": None})
 
         result = DataFrame() * 2
         assert result.index.equals(DataFrame().index)

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -671,14 +671,14 @@ class TestDataFrameAnalytics:
 
     def test_operators_timedelta64(self):
         df = DataFrame(
-            dict(
-                A=date_range("2012-1-1", periods=3, freq="D"),
-                B=date_range("2012-1-2", periods=3, freq="D"),
-                C=Timestamp("20120101") - timedelta(minutes=5, seconds=5),
-            )
+            {
+                "A": date_range("2012-1-1", periods=3, freq="D"),
+                "B": date_range("2012-1-2", periods=3, freq="D"),
+                "C": Timestamp("20120101") - timedelta(minutes=5, seconds=5),
+            }
         )
 
-        diffs = DataFrame(dict(A=df["A"] - df["C"], B=df["A"] - df["B"]))
+        diffs = DataFrame({"A": df["A"] - df["C"], "B": df["A"] - df["B"]})
 
         # min
         result = diffs.min()
@@ -699,7 +699,7 @@ class TestDataFrameAnalytics:
         # abs
         result = diffs.abs()
         result2 = abs(diffs)
-        expected = DataFrame(dict(A=df["A"] - df["C"], B=df["B"] - df["A"]))
+        expected = DataFrame({"A": df["A"] - df["C"], "B": df["B"] - df["A"]})
         tm.assert_frame_equal(result, expected)
         tm.assert_frame_equal(result2, expected)
 
@@ -1241,7 +1241,7 @@ class TestDataFrameReductions:
         # returned NaT for series. These tests check that the API is consistent in
         # min/max calls on empty Series/DataFrames. See GH:33704 for more
         # information
-        df = DataFrame(dict(x=pd.to_datetime([])))
+        df = DataFrame({"x": pd.to_datetime([])})
         expected_dt_series = Series(pd.to_datetime([]))
         # check axis 0
         assert (df.min(axis=0).x is pd.NaT) == (expected_dt_series.min() is pd.NaT)
@@ -1254,7 +1254,7 @@ class TestDataFrameReductions:
     def test_min_max_dt64_api_consistency_empty_df(self):
         # check DataFrame/Series api consistency when calling min/max on an empty
         # DataFrame/Series.
-        df = DataFrame(dict(x=[]))
+        df = DataFrame({"x": []})
         expected_float_series = Series([], dtype=float)
         # check axis 0
         assert np.isnan(df.min(axis=0).x) == np.isnan(expected_float_series.min())


### PR DESCRIPTION
- [ ] xref #38138
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
identify unnecessary dict call - rewrite as a literal
Rewrites as dictionary literals for the following files:

	modified:   pandas/tests/frame/indexing/test_indexing.py
	modified:   pandas/tests/frame/indexing/test_where.py
	modified:   pandas/tests/frame/methods/test_fillna.py
	modified:   pandas/tests/frame/methods/test_sort_values.py
	modified:   pandas/tests/frame/methods/test_to_csv.py
	modified:   pandas/tests/frame/methods/test_to_records.py
	modified:   pandas/tests/frame/test_arithmetic.py
	modified:   pandas/tests/frame/test_reductions.py

However, I did not change it to literal in the following two places, as they seem like valid dict call:
1. pandas/tests/frame/indexing/test_indexing.py
```
lambda l: dict(zip(l, range(len(l)))),   # line 76
lambda l: dict(zip(l, range(len(l)))).keys(),  # line 77
```
2. pandas/tests/frame/indexing/test_where.py

```
return DataFrame(dict((c, s + 1) if is_ok(s) else (c, s) for c, s in df.items()))  # line 32
```