### PR TITLE
Backport PR #38099: BUG: fix wrong error message in deprecated 2D indexing of Series with datetime values

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2295,6 +2295,28 @@ class DatetimeTZBlock(ExtensionBlock, DatetimeBlock):
         aware = self._holder(res_blk.values.ravel(), dtype=self.dtype)
         return self.make_block_same_class(aware, ndim=res_blk.ndim)
 
+    def _check_ndim(self, values, ndim):
+        """
+        ndim inference and validation.
+
+        This is overriden by the DatetimeTZBlock to check the case of 2D
+        data (values.ndim == 2), which should only be allowed if ndim is
+        also 2.
+        The case of 1D array is still allowed with both ndim of 1 or 2, as
+        if the case for other EAs. Therefore, we are only checking
+        `values.ndim > ndim` instead of `values.ndim != ndim` as for
+        consolidated blocks.
+        """
+        if ndim is None:
+            ndim = values.ndim
+
+        if values.ndim > ndim:
+            raise ValueError(
+                "Wrong number of dimensions. "
+                f"values.ndim != ndim [{values.ndim} != {ndim}]"
+            )
+        return ndim
+
 
 class TimeDeltaBlock(DatetimeLikeBlockMixin, IntBlock):
     __slots__ = ()

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -968,7 +968,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             # mpl compat if we look up e.g. ser[:, np.newaxis];
             #  see tests.series.timeseries.test_mpl_compat_hack
             # the asarray is needed to avoid returning a 2D DatetimeArray
-            return np.asarray(self._values[indexer])
+            return np.asarray(self._values)[indexer]
 
     def _get_value(self, label, takeable: bool = False):
         """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -967,7 +967,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         except ValueError:
             # mpl compat if we look up e.g. ser[:, np.newaxis];
             #  see tests.series.timeseries.test_mpl_compat_hack
-            return self._values[indexer]
+            # the asarray is needed to avoid returning a 2D DatetimeArray
+            return np.asarray(self._values[indexer])
 
     def _get_value(self, label, takeable: bool = False):
         """

--- a/pandas/tests/series/indexing/test_getitem.py
+++ b/pandas/tests/series/indexing/test_getitem.py
@@ -142,9 +142,7 @@ def test_getitem_generator(string_series):
     ],
 )
 def test_getitem_ndim_deprecated(series):
-    with tm.assert_produces_warning(
-        FutureWarning, match="Support for multi-dimensional indexing"
-    ):
+    with tm.assert_produces_warning(FutureWarning):
         result = series[:, None]
 
     expected = np.asarray(series)[:, None]

--- a/pandas/tests/series/indexing/test_getitem.py
+++ b/pandas/tests/series/indexing/test_getitem.py
@@ -133,10 +133,22 @@ def test_getitem_generator(string_series):
     tm.assert_series_equal(result2, expected)
 
 
-def test_getitem_ndim_deprecated():
-    s = pd.Series([0, 1])
-    with tm.assert_produces_warning(FutureWarning):
-        s[:, None]
+@pytest.mark.parametrize(
+    "series",
+    [
+        Series([0, 1]),
+        Series(date_range("2012-01-01", periods=2)),
+        Series(date_range("2012-01-01", periods=2, tz="CET")),
+    ],
+)
+def test_getitem_ndim_deprecated(series):
+    with tm.assert_produces_warning(
+        FutureWarning, match="Support for multi-dimensional indexing"
+    ):
+        result = series[:, None]
+
+    expected = np.asarray(series)[:, None]
+    tm.assert_numpy_array_equal(result, expected)
 
 
 def test_getitem_assignment_series_aligment():


### PR DESCRIPTION
Backport PR #38099 on branch 1.1.x