### PR TITLE
TST: add cases for nearest_workday and before_nearest_workday

### DIFF
--- a/pandas/tests/tseries/holiday/test_observance.py
+++ b/pandas/tests/tseries/holiday/test_observance.py
@@ -22,6 +22,7 @@ _SATURDAY = datetime(2014, 4, 12)
 _SUNDAY = datetime(2014, 4, 13)
 _MONDAY = datetime(2014, 4, 14)
 _TUESDAY = datetime(2014, 4, 15)
+_NEXT_WEDNESDAY = datetime(2014, 4, 16)
 
 
 @pytest.mark.parametrize("day", [_SATURDAY, _SUNDAY])
@@ -60,7 +61,15 @@ def test_weekend_to_monday(day, expected):
 
 
 @pytest.mark.parametrize(
-    "day,expected", [(_SATURDAY, _MONDAY), (_SUNDAY, _MONDAY), (_MONDAY, _TUESDAY)]
+    "day,expected",
+    [
+        (_WEDNESDAY, _THURSDAY),
+        (_THURSDAY, _FRIDAY),
+        (_SATURDAY, _MONDAY),
+        (_SUNDAY, _MONDAY),
+        (_MONDAY, _TUESDAY),
+        (_TUESDAY, _NEXT_WEDNESDAY),  # WED is same week as TUE
+    ],
 )
 def test_next_workday(day, expected):
     assert next_workday(day) == expected
@@ -74,7 +83,16 @@ def test_previous_workday(day, expected):
 
 
 @pytest.mark.parametrize(
-    "day,expected", [(_SATURDAY, _THURSDAY), (_SUNDAY, _FRIDAY), (_TUESDAY, _MONDAY)]
+    "day,expected",
+    [
+        (_THURSDAY, _WEDNESDAY),
+        (_FRIDAY, _THURSDAY),
+        (_SATURDAY, _THURSDAY),
+        (_SUNDAY, _FRIDAY),
+        (_MONDAY, _FRIDAY),  # last week Friday
+        (_TUESDAY, _MONDAY),
+        (_NEXT_WEDNESDAY, _TUESDAY),  # WED is same week as TUE
+    ],
 )
 def test_before_nearest_workday(day, expected):
     assert before_nearest_workday(day) == expected


### PR DESCRIPTION
- [ ] xref #38139
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Add cases for testing observance rules ``nearest_workday`` and ``before_nearest_workday`` for their full coverage.