### PR TITLE
CI: pin pip to 20.2 on numpy-dev build

### DIFF
--- a/ci/deps/azure-38-numpydev.yaml
+++ b/ci/deps/azure-38-numpydev.yaml
@@ -12,7 +12,7 @@ dependencies:
 
   # pandas dependencies
   - pytz
-  - pip
+  - pip=20.2
   - pip:
     - cython==0.29.21 # GH#34014
     - "git+git://github.com/dateutil/dateutil.git"


### PR DESCRIPTION
See https://github.com/pandas-dev/pandas/issues/38221