### PR TITLE
REF: casting in _python_agg_general

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -50,7 +50,7 @@ from pandas.compat.numpy import function as nv
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import Appender, Substitution, cache_readonly, doc
 
-from pandas.core.dtypes.cast import maybe_cast_result
+from pandas.core.dtypes.cast import maybe_cast_result, maybe_downcast_to_dtype
 from pandas.core.dtypes.common import (
     ensure_float,
     is_bool_dtype,
@@ -1195,7 +1195,7 @@ b  2""",
                 if is_numeric_dtype(values.dtype):
                     values = ensure_float(values)
 
-                result = maybe_cast_result(values[mask], result)
+                result = maybe_downcast_to_dtype(values[mask], result.dtype)
 
             output[key] = result
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1185,22 +1185,22 @@ b  2""",
 
             assert result is not None
             key = base.OutputKey(label=name, position=idx)
-            output[key] = maybe_cast_result(result, obj, numeric_only=True)
+            result = maybe_cast_result(result, obj, numeric_only=True)
 
-        if not output:
-            return self._python_apply_general(f, self._selected_obj)
-
-        if self.grouper._filter_empty_groups:
-
-            mask = counts.ravel() > 0
-            for key, result in output.items():
+            if self.grouper._filter_empty_groups:
+                mask = counts.ravel() > 0
 
                 # since we are masking, make sure that we have a float object
                 values = result
                 if is_numeric_dtype(values.dtype):
                     values = ensure_float(values)
 
-                output[key] = maybe_cast_result(values[mask], result)
+                result = maybe_cast_result(values[mask], result)
+
+            output[key] = result
+
+        if not output:
+            return self._python_apply_general(f, self._selected_obj)
 
         return self._wrap_aggregated_output(output, index=self.grouper.result_index)
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1185,7 +1185,9 @@ b  2""",
 
             assert result is not None
             key = base.OutputKey(label=name, position=idx)
-            result = maybe_cast_result(result, obj, numeric_only=True)
+
+            if is_numeric_dtype(obj.dtype):
+                result = maybe_downcast_to_dtype(result, obj.dtype)
 
             if self.grouper._filter_empty_groups:
                 mask = counts.ravel() > 0

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -718,7 +718,7 @@ class BaseGrouper:
             result[label] = res
 
         result = lib.maybe_convert_objects(result, try_float=0)
-        # TODO: maybe_cast_to_extension_array?
+        result = maybe_cast_result(result, obj, numeric_only=True)
 
         return result, counts
 


### PR DESCRIPTION
Consolidate two for-loops into one.

Instead of using maybe_cast_result in two places, use it only once, immediately after the function call being wrapped.  Replace those two usages with the less-invasive `maybe_downcast_to_dtype`