### PR TITLE
REF: consolidate result-casting in _cython_operation

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1000,9 +1000,6 @@ b  2""",
             except NotImplementedError:
                 continue
 
-            if self._transform_should_cast(how):
-                result = maybe_cast_result(result, obj, how=how)
-
             key = base.OutputKey(label=name, position=idx)
             output[key] = result
 
@@ -1081,12 +1078,12 @@ b  2""",
                 assert len(agg_names) == result.shape[1]
                 for result_column, result_name in zip(result.T, agg_names):
                     key = base.OutputKey(label=result_name, position=idx)
-                    output[key] = maybe_cast_result(result_column, obj, how=how)
+                    output[key] = result_column
                     idx += 1
             else:
                 assert result.ndim == 1
                 key = base.OutputKey(label=name, position=idx)
-                output[key] = maybe_cast_result(result, obj, how=how)
+                output[key] = result
                 idx += 1
 
         if not output:

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -627,12 +627,8 @@ class BaseGrouper:
         if is_datetimelike and kind == "aggregate":
             result = result.astype(orig_values.dtype)
 
-        if kind == "transform":
-            filled_series = self.size().fillna(0)
-            if filled_series.gt(0).any() and how not in base.cython_cast_blocklist:
-                dtype = maybe_cast_result_dtype(orig_values.dtype, how)
-                result = maybe_downcast_to_dtype(result, dtype)
-        else:
+        if how not in base.cython_cast_blocklist:
+            # "rank" is the only member of cython_cast_blocklist we get here
             dtype = maybe_cast_result_dtype(orig_values.dtype, how)
             result = maybe_downcast_to_dtype(result, dtype)
 

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -625,6 +625,7 @@ class BaseGrouper:
             result = result.swapaxes(0, axis)
 
         if how not in base.cython_cast_blocklist:
+            # e.g. if we are int64 and need to restore to datetime64/timedelta64
             # "rank" is the only member of cython_cast_blocklist we get here
             dtype = maybe_cast_result_dtype(orig_values.dtype, how)
             result = maybe_downcast_to_dtype(result, dtype)

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -624,9 +624,6 @@ class BaseGrouper:
         if swapped:
             result = result.swapaxes(0, axis)
 
-        if is_datetimelike and kind == "aggregate":
-            result = result.astype(orig_values.dtype)
-
         if how not in base.cython_cast_blocklist:
             # "rank" is the only member of cython_cast_blocklist we get here
             dtype = maybe_cast_result_dtype(orig_values.dtype, how)


### PR DESCRIPTION
Orthogonal to #38235.  After this and 38235, we'll be down to only two usages of maybe_cast_result, only one of which is sketchy.