### PR TITLE
TST: string representation of IntervalIndex

### DIFF
--- a/pandas/tests/indexes/interval/test_formats.py
+++ b/pandas/tests/indexes/interval/test_formats.py
@@ -1,7 +1,15 @@
 import numpy as np
 import pytest
 
-from pandas import DataFrame, IntervalIndex, Series, Timedelta, Timestamp
+from pandas import (
+    DataFrame,
+    Float64Index,
+    Interval,
+    IntervalIndex,
+    Series,
+    Timedelta,
+    Timestamp,
+)
 import pandas._testing as tm
 
 
@@ -35,6 +43,25 @@ class TestIntervalIndexRendering:
         index = IntervalIndex.from_tuples([(0, 1), np.nan, (2, 3)])
         obj = constructor(list("abc"), index=index)
         result = repr(obj)
+        assert result == expected
+
+    def test_repr_floats(self):
+        # GH 32553
+
+        markers = Series(
+            ["foo", "bar"],
+            index=IntervalIndex(
+                [
+                    Interval(left, right)
+                    for left, right in zip(
+                        Float64Index([329.973, 345.137], dtype="float64"),
+                        Float64Index([345.137, 360.191], dtype="float64"),
+                    )
+                ]
+            ),
+        )
+        result = str(markers)
+        expected = "(329.973, 345.137]    foo\n(345.137, 360.191]    bar\ndtype: object"
         assert result == expected
 
     @pytest.mark.parametrize(

--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -114,25 +114,6 @@ class TestIntervalIndex:
         with pytest.raises(KeyError, match=r"^\[10\]$"):
             df.loc[[10, 4]]
 
-    def test_string_representation(self):
-        # GH 32553
-
-        markers = Series(
-            ["foo", "bar"],
-            index=pd.IntervalIndex(
-                [
-                    pd.Interval(left, right)
-                    for left, right in zip(
-                        pd.Float64Index([329.973, 345.137], dtype="float64"),
-                        pd.Float64Index([345.137, 360.191], dtype="float64"),
-                    )
-                ]
-            ),
-        )
-        result = str(markers)
-        expected = "(329.973, 345.137]    foo\n(345.137, 360.191]    bar\ndtype: object"
-        assert result == expected
-
 
 class TestIntervalIndexInsideMultiIndex:
     def test_mi_intervalindex_slicing_with_scalar(self):

--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -114,6 +114,25 @@ class TestIntervalIndex:
         with pytest.raises(KeyError, match=r"^\[10\]$"):
             df.loc[[10, 4]]
 
+    def test_string_representation(self):
+        # GH 32553
+
+        markers = Series(
+            ["foo", "bar"],
+            index=pd.IntervalIndex(
+                [
+                    pd.Interval(left, right)
+                    for left, right in zip(
+                        pd.Float64Index([329.973, 345.137], dtype="float64"),
+                        pd.Float64Index([345.137, 360.191], dtype="float64"),
+                    )
+                ]
+            ),
+        )
+        result = str(markers)
+        expected = "(329.973, 345.137]    foo\n(345.137, 360.191]    bar\ndtype: object"
+        assert result == expected
+
 
 class TestIntervalIndexInsideMultiIndex:
     def test_mi_intervalindex_slicing_with_scalar(self):


### PR DESCRIPTION
- [x] closes #32553
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Picking up #36628