### PR TITLE
BUG: CategoricalDtype.__repr__ with RangeIndex categories

### DIFF
--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -404,7 +404,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
             data = self.categories._format_data(name=type(self).__name__)
             if data is None:
                 # self.categories is RangeIndex
-                data = self.categories._range
+                data = str(self.categories._range)
             data = data.rstrip(", ")
         return f"CategoricalDtype(categories={data}, ordered={self.ordered})"
 

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -399,10 +399,11 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
 
     def __repr__(self) -> str_type:
         if self.categories is None:
-            data = "None, "
+            data = "None"
         else:
             data = self.categories._format_data(name=type(self).__name__)
-        return f"CategoricalDtype(categories={data}ordered={self.ordered})"
+            data = data.rstrip(", ")
+        return f"CategoricalDtype(categories={data}, ordered={self.ordered})"
 
     @staticmethod
     def _hash_categories(categories, ordered: Ordered = True) -> int:

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -402,6 +402,9 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
             data = "None"
         else:
             data = self.categories._format_data(name=type(self).__name__)
+            if data is None:
+                # self.categories is RangeIndex
+                data = self.categories._range
             data = data.rstrip(", ")
         return f"CategoricalDtype(categories={data}, ordered={self.ordered})"
 

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -186,8 +186,9 @@ class RangeIndex(Int64Index):
         return attrs
 
     def _format_data(self, name=None):
-        # we are formatting thru the attributes
-        return None
+        # we are formatting thru the attributes; this is used for
+        #  CategoricalDtype.__repr__
+        return str(self._range)
 
     def _format_with_header(self, header: List[str], na_rep: str = "NaN") -> List[str]:
         if not len(self._range):

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -186,9 +186,8 @@ class RangeIndex(Int64Index):
         return attrs
 
     def _format_data(self, name=None):
-        # we are formatting thru the attributes; this is used for
-        #  CategoricalDtype.__repr__
-        return str(self._range)
+        # we are formatting thru the attributes
+        return None
 
     def _format_with_header(self, header: List[str], na_rep: str = "NaN") -> List[str]:
         if not len(self._range):

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -199,6 +199,14 @@ class TestCategoricalDtype(Base):
         # though CategoricalDtype has object kind, it cannot be string
         assert not is_string_dtype(CategoricalDtype())
 
+    def test_repr_range_categories(self):
+        rng = pd.Index(range(3))
+        dtype = CategoricalDtype(categories=rng, ordered=False)
+        result = repr(dtype)
+
+        expected = "CategoricalDtype(categories=range(0, 3), ordered=False)"
+        assert result == expected
+
 
 class TestDatetimeTZDtype(Base):
     @pytest.fixture


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

The problem was introduced a couple weeks ago, so shouldn't need a whatsnew.