### PR TITLE
PERF: timeseries comparison ops

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -936,7 +936,8 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
             return result
 
         other_vals = self._unbox(other)
-        result = op(self._ndarray, other_vals)
+        # GH#37462 comparison on i8 values is almost 2x faster than M8/m8
+        result = op(self._ndarray.view("i8"), other_vals.view("i8"))
 
         o_mask = isna(other)
         if self._hasnans | np.any(o_mask):


### PR DESCRIPTION
- [x] closes #37462
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Locally this gets me to within 3-4% of 1.1.4 on the asv mentioned in #37462