### PR TITLE
CI: delete unused import in groupby/groupby.py

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -50,7 +50,7 @@ from pandas.compat.numpy import function as nv
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import Appender, Substitution, cache_readonly, doc
 
-from pandas.core.dtypes.cast import maybe_cast_result, maybe_downcast_to_dtype
+from pandas.core.dtypes.cast import maybe_downcast_to_dtype
 from pandas.core.dtypes.common import (
     ensure_float,
     is_bool_dtype,


### PR DESCRIPTION
Fixes a `flake8` bug on current master:
```
(pandas-dev) andrewwieteska@Andrews-MacBook-Pro pandas % flake8 pandas/core/groupby/groupby.py
pandas/core/groupby/groupby.py:53:1: F401 'pandas.core.dtypes.cast.maybe_cast_result' imported but unused
```