### PR TITLE
TST: mark all excel tests as slow

### DIFF
--- a/ci/deps/azure-37-locale_slow.yaml
+++ b/ci/deps/azure-37-locale_slow.yaml
@@ -15,9 +15,11 @@ dependencies:
   # pandas dependencies
   - beautifulsoup4=4.6.0
   - bottleneck=1.2.*
+  - jinja2
   - lxml
   - matplotlib=3.0.0
   - numpy=1.16.*
+  - odfpy
   - openpyxl=2.6.0
   - python-dateutil
   - python-blosc

--- a/ci/deps/azure-37-slow.yaml
+++ b/ci/deps/azure-37-slow.yaml
@@ -16,10 +16,12 @@ dependencies:
   - beautifulsoup4
   - fsspec>=0.7.4
   - html5lib
+  - jinja2
   - lxml
   - matplotlib
   - numexpr
   - numpy
+  - odfpy
   - openpyxl
   - patsy
   - psycopg2
@@ -36,3 +38,6 @@ dependencies:
   - xlwt
   - moto
   - flask
+  - pip
+  - pip:
+    - pyxlsb

--- a/ci/deps/travis-38-slow.yaml
+++ b/ci/deps/travis-38-slow.yaml
@@ -15,10 +15,12 @@ dependencies:
   - beautifulsoup4
   - fsspec>=0.7.4
   - html5lib
+  - jinja2
   - lxml
   - matplotlib
   - numexpr
   - numpy
+  - odfpy
   - openpyxl
   - patsy
   - psycopg2
@@ -35,3 +37,6 @@ dependencies:
   - xlwt
   - moto
   - flask
+  - pip
+  - pip:
+    - pyxlsb

--- a/pandas/tests/io/excel/__init__.py
+++ b/pandas/tests/io/excel/__init__.py
@@ -1,3 +1,10 @@
+"""
+Package for testing excel-related functionality.
+
+All tests are marked as slow via ``pytestmark = pytest.mark.slow``
+at the top of each test module.
+"""
+
 import pytest
 
 pytestmark = [

--- a/pandas/tests/io/excel/test_odf.py
+++ b/pandas/tests/io/excel/test_odf.py
@@ -6,6 +6,8 @@ import pytest
 import pandas as pd
 import pandas._testing as tm
 
+pytestmark = pytest.mark.slow
+
 pytest.importorskip("odf")
 
 

--- a/pandas/tests/io/excel/test_openpyxl.py
+++ b/pandas/tests/io/excel/test_openpyxl.py
@@ -7,6 +7,8 @@ import pandas._testing as tm
 
 from pandas.io.excel import ExcelWriter, _OpenpyxlWriter
 
+pytestmark = pytest.mark.slow
+
 openpyxl = pytest.importorskip("openpyxl")
 
 pytestmark = pytest.mark.parametrize("ext", [".xlsx"])

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -12,6 +12,8 @@ import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, Series
 import pandas._testing as tm
 
+pytestmark = pytest.mark.slow
+
 read_ext_params = [".xls", ".xlsx", ".xlsm", ".xlsb", ".ods"]
 engine_params = [
     # Add any engines to test here
@@ -636,9 +638,7 @@ class TestReaders:
         local_table = pd.read_excel("test1" + read_ext)
         tm.assert_frame_equal(url_table, local_table)
 
-    @pytest.mark.slow
     def test_read_from_file_url(self, read_ext, datapath):
-
         # FILE
         localtable = os.path.join(datapath("io", "data", "excel"), "test1" + read_ext)
         local_table = pd.read_excel(localtable)

--- a/pandas/tests/io/excel/test_style.py
+++ b/pandas/tests/io/excel/test_style.py
@@ -7,6 +7,8 @@ import pandas._testing as tm
 from pandas.io.excel import ExcelWriter
 from pandas.io.formats.excel import ExcelFormatter
 
+pytestmark = pytest.mark.slow
+
 
 @pytest.mark.parametrize(
     "engine",

--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -21,6 +21,8 @@ from pandas.io.excel import (
     register_writer,
 )
 
+pytestmark = pytest.mark.slow
+
 
 @pytest.fixture
 def path(ext):

--- a/pandas/tests/io/excel/test_xlrd.py
+++ b/pandas/tests/io/excel/test_xlrd.py
@@ -7,6 +7,8 @@ import pandas._testing as tm
 
 from pandas.io.excel import ExcelFile
 
+pytestmark = pytest.mark.slow
+
 xlrd = pytest.importorskip("xlrd")
 xlwt = pytest.importorskip("xlwt")
 

--- a/pandas/tests/io/excel/test_xlsxwriter.py
+++ b/pandas/tests/io/excel/test_xlsxwriter.py
@@ -7,6 +7,8 @@ import pandas._testing as tm
 
 from pandas.io.excel import ExcelWriter
 
+pytestmark = pytest.mark.slow
+
 xlsxwriter = pytest.importorskip("xlsxwriter")
 
 pytestmark = pytest.mark.parametrize("ext", [".xlsx"])

--- a/pandas/tests/io/excel/test_xlwt.py
+++ b/pandas/tests/io/excel/test_xlwt.py
@@ -6,6 +6,8 @@ import pandas._testing as tm
 
 from pandas.io.excel import ExcelWriter, _XlwtWriter
 
+pytestmark = pytest.mark.slow
+
 xlwt = pytest.importorskip("xlwt")
 
 pytestmark = pytest.mark.parametrize("ext,", [".xls"])


### PR DESCRIPTION
- [ ] xref #38091
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Marked all excel-related tests as slow.
There are a lot of time for setup and teardown for every test.
Overall, moving these tests to "slow" category may probably save about 5 minutes of test time for "not slow" pipelines.