### PR TITLE
C408 fix

### DIFF
--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -521,13 +521,13 @@ class TestJSONNormalize:
 
 class TestNestedToRecord:
     def test_flat_stays_flat(self):
-        recs = [dict(flat1=1, flat2=2), dict(flat1=3, flat2=4)]
+        recs = [{"flat1": 1, "flat2": 2}, {"flat3": 3, "flat2": 4}]
         result = nested_to_record(recs)
         expected = recs
         assert result == expected
 
     def test_one_level_deep_flattens(self):
-        data = dict(flat1=1, dict1=dict(c=1, d=2))
+        data = {"flat1": 1, "dict1": {"c": 1, "d": 2}}
 
         result = nested_to_record(data)
         expected = {"dict1.c": 1, "dict1.d": 2, "flat1": 1}
@@ -535,7 +535,10 @@ class TestNestedToRecord:
         assert result == expected
 
     def test_nested_flattens(self):
-        data = dict(flat1=1, dict1=dict(c=1, d=2), nested=dict(e=dict(c=1, d=2), d=2))
+        data = {
+            "flat1": 1, "dict1": {"c": 1, "d": 2},
+            "nested": {"e": {"c": 1, "d": 2}, "d": 2}
+        }
 
         result = nested_to_record(data)
         expected = {

--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -538,7 +538,7 @@ class TestNestedToRecord:
         data = {
             "flat1": 1,
             "dict1": {"c": 1, "d": 2},
-            "nested": {"e": {"c": 1, "d": 2}, "d": 2}
+            "nested": {"e": {"c": 1, "d": 2}, "d": 2},
         }
 
         result = nested_to_record(data)

--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -536,7 +536,8 @@ class TestNestedToRecord:
 
     def test_nested_flattens(self):
         data = {
-            "flat1": 1, "dict1": {"c": 1, "d": 2},
+            "flat1": 1,
+            "dict1": {"c": 1, "d": 2},
             "nested": {"e": {"c": 1, "d": 2}, "d": 2}
         }
 

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -797,9 +797,9 @@ class TestNumpyJSONTests:
             ([42, {}, "a"], TypeError, {}),
             ([42, ["a"], 42], ValueError, {}),
             (["a", "b", [], "c"], ValueError, {}),
-            ([{"a": "b"}], ValueError, dict(labelled=True)),
-            ({"a": {"b": {"c": 42}}}, ValueError, dict(labelled=True)),
-            ([{"a": 42, "b": 23}, {"c": 17}], ValueError, dict(labelled=True)),
+            ([{"a": "b"}], ValueError, {"labelled": True}),
+            ({"a": {"b": {"c": 42}}}, ValueError, {"labelled": True}),
+            ([{"a": 42, "b": 23}, {"c": 17}], ValueError, {"labelled": True}),
         ],
     )
     def test_array_numpy_except(self, bad_input, exc_type, kwargs):
@@ -852,7 +852,7 @@ class TestPandasJSONTests:
             columns=["x", "y", "z"],
             dtype=dtype,
         )
-        encode_kwargs = {} if orient is None else dict(orient=orient)
+        encode_kwargs = {} if orient is None else {"orient": orient}
         decode_kwargs = {} if numpy is None else dict(numpy=numpy)
         assert (df.dtypes == dtype).all()
 
@@ -884,7 +884,7 @@ class TestPandasJSONTests:
         )
 
         nested = {"df1": df, "df2": df.copy()}
-        kwargs = {} if orient is None else dict(orient=orient)
+        kwargs = {} if orient is None else {"orient": orient}
 
         exp = {
             "df1": ujson.decode(ujson.encode(df, **kwargs)),
@@ -902,7 +902,7 @@ class TestPandasJSONTests:
             columns=["x", "y", "z"],
             dtype=int,
         )
-        kwargs = {} if orient is None else dict(orient=orient)
+        kwargs = {} if orient is None else {"orient": orient}
 
         output = DataFrame(
             *ujson.decode(ujson.encode(df, **kwargs), numpy=True, labelled=True)
@@ -925,7 +925,7 @@ class TestPandasJSONTests:
         ).sort_values()
         assert s.dtype == dtype
 
-        encode_kwargs = {} if orient is None else dict(orient=orient)
+        encode_kwargs = {} if orient is None else {"orient": orient}
         decode_kwargs = {} if numpy is None else dict(numpy=numpy)
 
         output = ujson.decode(ujson.encode(s, **encode_kwargs), **decode_kwargs)
@@ -953,7 +953,7 @@ class TestPandasJSONTests:
             [10, 20, 30, 40, 50, 60], name="series", index=[6, 7, 8, 9, 10, 15]
         ).sort_values()
         nested = {"s1": s, "s2": s.copy()}
-        kwargs = {} if orient is None else dict(orient=orient)
+        kwargs = {} if orient is None else {"orient": orient}
 
         exp = {
             "s1": ujson.decode(ujson.encode(s, **kwargs)),

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -757,10 +757,10 @@ class TestNumpyJSONTests:
     def test_array_list(self):
         arr_list = [
             "a",
-            list(),
-            dict(),
-            dict(),
-            list(),
+            [],
+            {},
+            {},
+            [],
             42,
             97.8,
             ["a", "b"],
@@ -853,7 +853,7 @@ class TestPandasJSONTests:
             dtype=dtype,
         )
         encode_kwargs = {} if orient is None else {"orient": orient}
-        decode_kwargs = {} if numpy is None else dict(numpy=numpy)
+        decode_kwargs = {} if numpy is None else {"numpy": numpy}
         assert (df.dtypes == dtype).all()
 
         output = ujson.decode(ujson.encode(df, **encode_kwargs), **decode_kwargs)
@@ -926,7 +926,7 @@ class TestPandasJSONTests:
         assert s.dtype == dtype
 
         encode_kwargs = {} if orient is None else {"orient": orient}
-        decode_kwargs = {} if numpy is None else dict(numpy=numpy)
+        decode_kwargs = {} if numpy is None else {"numpy": numpy}
 
         output = ujson.decode(ujson.encode(s, **encode_kwargs), **decode_kwargs)
         assert s.dtype == dtype


### PR DESCRIPTION
- [x] xref #38138 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Rewrote dict calls to dict literals in the following files
./pandas/tests/io/json/test_ujson.py
./pandas/tests/io/json/test_normalize.py

Also changed list calls to literals in line 730 of the following file
pandas/tests/io/json/test_ujson.py