### PR TITLE
BUG: name retention in Index.difference corner cases

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -825,6 +825,7 @@ Other
 - Fixed metadata propagation when selecting columns with ``DataFrame.__getitem__`` (:issue:`28283`)
 - Bug in :meth:`Index.intersection` with non-:class:`Index` failing to set the correct name on the returned :class:`Index` (:issue:`38111`)
 - Bug in :meth:`RangeIndex.intersection` failing to set the correct name on the returned :class:`Index` in some corner cases (:issue:`38197`)
+- Bug in :meth:`Index.difference` failing to set the correct name on the returned :class:`Index` in some corner cases (:issue:`38268`)
 - Bug in :meth:`Index.union` behaving differently depending on whether operand is an :class:`Index` or other list-like (:issue:`36384`)
 - Bug in :meth:`Index.intersection` with non-matching numeric dtypes casting to ``object`` dtype instead of minimal common dtype (:issue:`38122`)
 - Passing an array with 2 or more dimensions to the :class:`Series` constructor now raises the more specific ``ValueError`` rather than a bare ``Exception`` (:issue:`35744`)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2914,12 +2914,15 @@ class Index(IndexOpsMixin, PandasObject):
         """
         self._validate_sort_keyword(sort)
         self._assert_can_do_setop(other)
+        other, result_name = self._convert_can_do_setop(other)
 
         if self.equals(other):
-            # pass an empty np.ndarray with the appropriate dtype
-            return self._shallow_copy(self._data[:0])
+            return self[:0].rename(result_name)
 
-        other, result_name = self._convert_can_do_setop(other)
+        result = self._difference(other, sort=sort)
+        return self._wrap_setop_result(other, result)
+
+    def _difference(self, other, sort):
 
         this = self._get_unique_index()
 
@@ -2934,7 +2937,7 @@ class Index(IndexOpsMixin, PandasObject):
             except TypeError:
                 pass
 
-        return this._shallow_copy(the_diff, name=result_name)
+        return the_diff
 
     def symmetric_difference(self, other, result_name=None, sort=None):
         """

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Any, cast
+from typing import Any
 import warnings
 
 import numpy as np
@@ -660,14 +660,14 @@ class PeriodIndex(DatetimeIndexOpsMixin):
     def difference(self, other, sort=None):
         self._validate_sort_keyword(sort)
         self._assert_can_do_setop(other)
-        other = ensure_index(other)
+        other, result_name = self._convert_can_do_setop(other)
 
         if self.equals(other):
-            # pass an empty PeriodArray with the appropriate dtype
+            return self[:0].rename(result_name)
 
-            # TODO: overload DatetimeLikeArrayMixin.__getitem__
-            values = cast(PeriodArray, self._data[:0])
-            return type(self)._simple_new(values, name=self.name)
+        return self._difference(other, sort=sort)
+
+    def _difference(self, other, sort):
 
         if is_object_dtype(other):
             return self.astype(object).difference(other).astype(self.dtype)

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -666,6 +666,8 @@ class RangeIndex(Int64Index):
     def difference(self, other, sort=None):
         # optimized set operation if we have another RangeIndex
         self._validate_sort_keyword(sort)
+        self._assert_can_do_setop(other)
+        other, result_name = self._convert_can_do_setop(other)
 
         if not isinstance(other, RangeIndex):
             return super().difference(other, sort=sort)

--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -424,6 +424,18 @@ class TestSetOps:
         expected = index[:0]
         tm.assert_index_equal(result, expected, exact=True)
 
+    def test_difference_name_retention_equals(self, index, sort, names):
+        if isinstance(index, MultiIndex):
+            names = [[x] * index.nlevels for x in names]
+        index = index.rename(names[0])
+        other = index.rename(names[1])
+
+        assert index.equals(other)
+
+        result = index.difference(other)
+        expected = index[:0].rename(names[2])
+        tm.assert_index_equal(result, expected)
+
     def test_intersection_difference_match_empty(self, index, sort):
         # GH#20040
         # Test that the intersection of an index with an


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
