### PR TITLE
BUG: isin numeric vs string

### DIFF
--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -1044,7 +1044,6 @@ class TestIsin:
         expected = np.array([True, True])
         tm.assert_numpy_array_equal(result, expected)
 
-    @pytest.mark.xfail(reason="problem related with issue #34125")
     def test_isin_int_df_string_search(self):
         """Comparing df with int`s (1,2) with a string at isin() ("1")
         -> should not match values because int 1 is not equal str 1"""
@@ -1053,7 +1052,6 @@ class TestIsin:
         expected_false = DataFrame({"values": [False, False]})
         tm.assert_frame_equal(result, expected_false)
 
-    @pytest.mark.xfail(reason="problem related with issue #34125")
     def test_isin_nan_df_string_search(self):
         """Comparing df with nan value (np.nan,2) with a string at isin() ("NaN")
         -> should not match values because np.nan is not equal str NaN"""
@@ -1062,7 +1060,6 @@ class TestIsin:
         expected_false = DataFrame({"values": [False, False]})
         tm.assert_frame_equal(result, expected_false)
 
-    @pytest.mark.xfail(reason="problem related with issue #34125")
     def test_isin_float_df_string_search(self):
         """Comparing df with floats (1.4245,2.32441) with a string at isin() ("1.4245")
         -> should not match values because float 1.4245 is not equal str 1.4245"""


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Using the new hashtables!

```
In [3]: arr = np.arange(10**7).astype(np.int32)

In [4]: %timeit isin(arr, arr[:10])
88.8 ms ± 497 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)   # <-- master
42.7 ms ± 385 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)   # <-- PR
```