### PR TITLE
REF: de-duplicate intersection methods

### DIFF
--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -706,10 +706,6 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
 
         if not isinstance(other, type(self)):
             result = Index.intersection(self, other, sort=sort)
-            if isinstance(result, type(self)):
-                if result.freq is None:
-                    # TODO: no tests rely on this; needed?
-                    result = result._with_freq("infer")
             return result
 
         elif not self._can_fast_intersect(other):

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -126,10 +126,6 @@ def setop_check(method):
         self._assert_can_do_setop(other)
         other, _ = self._convert_can_do_setop(other)
 
-        if op_name == "intersection":
-            if self.equals(other):
-                return self._get_reconciled_name_object(other)
-
         if not isinstance(other, IntervalIndex):
             result = getattr(self.astype(object), op_name)(other)
             if op_name in ("difference",):
@@ -965,7 +961,6 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
             )
 
     @Appender(Index.intersection.__doc__)
-    @setop_check
     def intersection(self, other, sort=False) -> Index:
         self._validate_sort_keyword(sort)
         self._assert_can_do_setop(other)

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -15,7 +15,6 @@ from pandas.util._decorators import Appender, cache_readonly, doc
 from pandas.core.dtypes.common import (
     ensure_platform_int,
     ensure_python_int,
-    is_dtype_equal,
     is_float,
     is_integer,
     is_list_like,
@@ -482,42 +481,6 @@ class RangeIndex(Int64Index):
 
     # --------------------------------------------------------------------
     # Set Operations
-
-    def intersection(self, other, sort=False):
-        """
-        Form the intersection of two Index objects.
-
-        Parameters
-        ----------
-        other : Index or array-like
-        sort : False or None, default False
-            Sort the resulting index if possible
-
-            .. versionadded:: 0.24.0
-
-            .. versionchanged:: 0.24.1
-
-               Changed the default to ``False`` to match the behaviour
-               from before 0.24.0.
-
-        Returns
-        -------
-        intersection : Index
-        """
-        self._validate_sort_keyword(sort)
-        self._assert_can_do_setop(other)
-        other, _ = self._convert_can_do_setop(other)
-
-        if self.equals(other) and not self.has_duplicates:
-            # has_duplicates check is unnecessary for RangeIndex, but
-            #  used to match other subclasses.
-            return self._get_reconciled_name_object(other)
-
-        if not is_dtype_equal(self.dtype, other.dtype):
-            return super().intersection(other, sort=sort)
-
-        result = self._intersection(other, sort=sort)
-        return self._wrap_setop_result(other, result)
 
     def _intersection(self, other, sort=False):
 


### PR DESCRIPTION
De-duplicating the PeriodIndex, IntervalIndex, and MultiIndex methods is blocked by #38251