### PR TITLE
BUG: Fix typo in melt value_name futurewarning

### DIFF
--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -42,7 +42,7 @@ def melt(
     if value_name in frame.columns:
         warnings.warn(
             "This dataframe has a column name that matches the 'value_name' column "
-            "name of the resultiing Dataframe. "
+            "name of the resulting Dataframe. "
             "In the future this will raise an error, please set the 'value_name' "
             "parameter of DataFrame.melt to a unique name.",
             FutureWarning,


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Just removing the duplicated 'i' in "resultiing" of the futurewarning in melt about using `value_name` with the same name as a column the in the original dataframe.  Filing an issue or a whatsnew entry for such a minor change seemed excessive.