### PR TITLE
BUG: Clean intersection and fix resulting names when MultiIndex are equal

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2826,7 +2826,9 @@ class Index(IndexOpsMixin, PandasObject):
         self._assert_can_do_setop(other)
         other, _ = self._convert_can_do_setop(other)
 
-        if self.equals(other) and not self.has_duplicates:
+        if self.equals(other):
+            if self.has_duplicates:
+                return self.unique()._get_reconciled_name_object(other)
             return self._get_reconciled_name_object(other)
 
         if not is_dtype_equal(self.dtype, other.dtype):

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -980,7 +980,9 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
         self._assert_can_do_setop(other)
         other, _ = self._convert_can_do_setop(other)
 
-        if self.equals(other) and not self.has_duplicates:
+        if self.equals(other):
+            if self.has_duplicates:
+                return self.unique()._get_reconciled_name_object(other)
             return self._get_reconciled_name_object(other)
 
         if not isinstance(other, IntervalIndex):

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3614,7 +3614,7 @@ class MultiIndex(Index):
         if self.equals(other):
             if self.has_duplicates:
                 return self.unique().rename(result_names)
-            return self._get_reconciled_name_object(other)
+            return self.rename(result_names)
 
         return self._intersection(other, sort=sort)
 

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -639,6 +639,8 @@ class PeriodIndex(DatetimeIndexOpsMixin):
         other, _ = self._convert_can_do_setop(other)
 
         if self.equals(other):
+            if self.has_duplicates:
+                return self.unique()._get_reconciled_name_object(other)
             return self._get_reconciled_name_object(other)
 
         return self._intersection(other, sort=sort)

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -419,3 +419,12 @@ def test_intersect_with_duplicates(tuples, exp_tuples):
     result = left.intersection(right)
     expected = MultiIndex.from_tuples(exp_tuples, names=["first", "second"])
     tm.assert_index_equal(result, expected)
+
+
+def test_intersection_equal_different_names():
+    mi1 = MultiIndex.from_arrays([[1, 2], [3, 4]], names=["c", "b"])
+    mi2 = MultiIndex.from_arrays([[1, 2], [3, 4]], names=["a", "b"])
+
+    result = mi1.intersection(mi2)
+    expected = MultiIndex.from_arrays([[1, 2], [3, 4]], names=[None, "b"])
+    tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -422,6 +422,7 @@ def test_intersect_with_duplicates(tuples, exp_tuples):
 
 
 def test_intersection_equal_different_names():
+    # GH#30302
     mi1 = MultiIndex.from_arrays([[1, 2], [3, 4]], names=["c", "b"])
     mi2 = MultiIndex.from_arrays([[1, 2], [3, 4]], names=["a", "b"])
 

--- a/pandas/tests/indexes/period/test_setops.py
+++ b/pandas/tests/indexes/period/test_setops.py
@@ -339,3 +339,10 @@ class TestPeriodIndex:
         expected = PeriodIndex(["20160920", "20160921"], freq="D")
         tm.assert_index_equal(idx_diff, expected)
         tm.assert_attr_equal("freq", idx_diff, expected)
+
+    def test_intersection_equal_duplicates(self):
+        # GH#38302
+        idx = pd.period_range("2011-01-01", periods=2)
+        idx_dup = idx.append(idx)
+        result = idx_dup.intersection(idx_dup)
+        tm.assert_index_equal(result, idx)


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Names were wrong when MultiIndexes where equal and unique with different names. Additional cleanups

cc @jbrockmendel 