### PR TITLE
CLN: remove now-unnecesary coerce_to_dtypes

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -987,36 +987,6 @@ def coerce_indexer_dtype(indexer, categories):
     return ensure_int64(indexer)
 
 
-def coerce_to_dtypes(result: Sequence[Scalar], dtypes: Sequence[Dtype]) -> List[Scalar]:
-    """
-    given a dtypes and a result set, coerce the result elements to the
-    dtypes
-    """
-    if len(result) != len(dtypes):
-        raise AssertionError("_coerce_to_dtypes requires equal len arrays")
-
-    def conv(r, dtype):
-        if np.any(isna(r)):
-            pass
-        elif dtype == DT64NS_DTYPE:
-            r = Timestamp(r)
-        elif dtype == TD64NS_DTYPE:
-            r = Timedelta(r)
-        elif dtype == np.bool_:
-            # messy. non 0/1 integers do not get converted.
-            if is_integer(r) and r not in [0, 1]:
-                return int(r)
-            r = bool(r)
-        elif dtype.kind == "f":
-            r = float(r)
-        elif dtype.kind == "i":
-            r = int(r)
-
-        return r
-
-    return [conv(r, dtype) for r, dtype in zip(result, dtypes)]
-
-
 def astype_nansafe(
     arr, dtype: DtypeObj, copy: bool = True, skipna: bool = False
 ) -> ArrayLike:


### PR DESCRIPTION
Made unnecessary bc we now operate blockwise, so coercion is handled at a lower level.