### PR TITLE
REGR: Groupby first/last/nth treats None as an observation

### DIFF
--- a/doc/source/whatsnew/v1.1.5.rst
+++ b/doc/source/whatsnew/v1.1.5.rst
@@ -27,7 +27,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.fillna` not filling ``NaN`` after other operations such as :meth:`DataFrame.pivot` (:issue:`36495`).
 - Fixed performance regression in ``df.groupby(..).rolling(..)`` (:issue:`38038`)
 - Fixed regression in :meth:`MultiIndex.intersection` returning duplicates when at least one of the indexes had duplicates (:issue:`36915`)
-- Fixed regression in :meth:`.DataFrameGroupBy.first`, :meth:`.DataFrameGroupBy.last`, :meth:`.DataFrameGroupBy.nth` where ``None`` was considered an observation (:issue:`38286`)
+- Fixed regression in :meth:`.GroupBy.first`, :meth:`.GroupBy.last`, and :meth:`.GroupBy.nth` where ``None`` was considered a non-NA value (:issue:`38286`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.1.5.rst
+++ b/doc/source/whatsnew/v1.1.5.rst
@@ -27,6 +27,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.fillna` not filling ``NaN`` after other operations such as :meth:`DataFrame.pivot` (:issue:`36495`).
 - Fixed performance regression in ``df.groupby(..).rolling(..)`` (:issue:`38038`)
 - Fixed regression in :meth:`MultiIndex.intersection` returning duplicates when at least one of the indexes had duplicates (:issue:`36915`)
+- Fixed regression in :meth:`.DataFrameGroupBy.first`, :meth:`.DataFrameGroupBy.last`, :meth:`.DataFrameGroupBy.nth` where ``None`` was considered an observation (:issue:`38286`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.1.5.rst
+++ b/doc/source/whatsnew/v1.1.5.rst
@@ -27,7 +27,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.fillna` not filling ``NaN`` after other operations such as :meth:`DataFrame.pivot` (:issue:`36495`).
 - Fixed performance regression in ``df.groupby(..).rolling(..)`` (:issue:`38038`)
 - Fixed regression in :meth:`MultiIndex.intersection` returning duplicates when at least one of the indexes had duplicates (:issue:`36915`)
-- Fixed regression in :meth:`.GroupBy.first`, :meth:`.GroupBy.last`, and :meth:`.GroupBy.nth` where ``None`` was considered a non-NA value (:issue:`38286`)
+- Fixed regression in :meth:`.GroupBy.first` and :meth:`.GroupBy.last` where ``None`` was considered a non-NA value (:issue:`38286`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -928,9 +928,7 @@ def group_last(rank_t[:, :] out,
             for j in range(K):
                 val = values[i, j]
 
-                # None should not be treated like other NA-like
-                # so that it won't be converted to nan
-                if not checknull(val) or val is None:
+                if not checknull(val):
                     # NB: use _treat_as_na here once
                     #  conditional-nogil is available.
                     nobs[lab, j] += 1
@@ -939,7 +937,7 @@ def group_last(rank_t[:, :] out,
         for i in range(ncounts):
             for j in range(K):
                 if nobs[i, j] < min_count:
-                    out[i, j] = NAN
+                    out[i, j] = None
                 else:
                     out[i, j] = resx[i, j]
     else:
@@ -1023,9 +1021,7 @@ def group_nth(rank_t[:, :] out,
             for j in range(K):
                 val = values[i, j]
 
-                # None should not be treated like other NA-like
-                # so that it won't be converted to nan
-                if not checknull(val) or val is None:
+                if not checknull(val):
                     # NB: use _treat_as_na here once
                     #  conditional-nogil is available.
                     nobs[lab, j] += 1
@@ -1035,7 +1031,7 @@ def group_nth(rank_t[:, :] out,
         for i in range(ncounts):
             for j in range(K):
                 if nobs[i, j] < min_count:
-                    out[i, j] = NAN
+                    out[i, j] = None
                 else:
                     out[i, j] = resx[i, j]
 

--- a/pandas/tests/groupby/test_nth.py
+++ b/pandas/tests/groupby/test_nth.py
@@ -91,13 +91,20 @@ def test_nth_with_na_object(index, nulls_fixture):
 
 
 @pytest.mark.parametrize("method", ["first", "last"])
+def test_first_last_with_None(method):
+    # https://github.com/pandas-dev/pandas/issues/32800
+    # None should be preserved as object dtype
+    df = DataFrame.from_dict({"id": ["a"], "value": [None]})
+    groups = df.groupby("id", as_index=False)
+    result = getattr(groups, method)()
+
+    tm.assert_frame_equal(result, df)
+
+
+@pytest.mark.parametrize("method", ["first", "last"])
 @pytest.mark.parametrize(
     "df, expected",
     [
-        (
-            DataFrame({"id": ["a"], "value": [None]}),
-            DataFrame({"value": [None]}, index=Index(["a"], name="id")),
-        ),
         (
             DataFrame({"id": "a", "value": [None, "foo", np.nan]}),
             DataFrame({"value": ["foo"]}, index=Index(["a"], name="id")),
@@ -108,7 +115,7 @@ def test_nth_with_na_object(index, nulls_fixture):
         ),
     ],
 )
-def test_first_last_with_none(method, df, expected):
+def test_first_last_with_None_expanded(method, df, expected):
     # GH 32800, 38286
     result = getattr(df.groupby("id"), method)()
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/test_nth.py
+++ b/pandas/tests/groupby/test_nth.py
@@ -91,14 +91,27 @@ def test_nth_with_na_object(index, nulls_fixture):
 
 
 @pytest.mark.parametrize("method", ["first", "last"])
-def test_first_last_with_None(method):
-    # https://github.com/pandas-dev/pandas/issues/32800
-    # None should be preserved as object dtype
-    df = DataFrame.from_dict({"id": ["a"], "value": [None]})
-    groups = df.groupby("id", as_index=False)
-    result = getattr(groups, method)()
-
-    tm.assert_frame_equal(result, df)
+@pytest.mark.parametrize(
+    "df, expected",
+    [
+        (
+            DataFrame({"id": ["a"], "value": [None]}),
+            DataFrame({"value": [None]}, index=Index(["a"], name="id")),
+        ),
+        (
+            DataFrame({"id": "a", "value": [None, "foo", np.nan]}),
+            DataFrame({"value": ["foo"]}, index=Index(["a"], name="id")),
+        ),
+        (
+            DataFrame({"id": "a", "value": [np.nan]}, dtype=object),
+            DataFrame({"value": [None]}, index=Index(["a"], name="id")),
+        ),
+    ],
+)
+def test_first_last_with_none(method, df, expected):
+    # GH 32800, 38286
+    result = getattr(df.groupby("id"), method)()
+    tm.assert_frame_equal(result, expected)
 
 
 def test_first_last_nth_dtypes(df_mixed_floats):


### PR DESCRIPTION
- [x] closes #38286
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This is a regression from 1.0.x to 1.1.x, introduced by #33462. Assuming it doesn't get into the 1.2 rc, not sure if it should go into 1.2 during the rc phase or wait until 1.3.

Had to decide on some edge-case behaviors in odd situations with missing values, see https://github.com/pandas-dev/pandas/issues/38286#issuecomment-739521117