### PR TITLE
TST: add message matches to pytest.raises in various tests GH30999

### DIFF
--- a/pandas/tests/io/pytables/test_complex.py
+++ b/pandas/tests/io/pytables/test_complex.py
@@ -149,8 +149,11 @@ def test_complex_indexing_error(setup_path):
         {"A": [1, 2, 3, 4], "B": ["a", "b", "c", "d"], "C": complex128},
         index=list("abcd"),
     )
+
+    msg = "indexing error with complex numbers"
+
     with ensure_clean_store(setup_path) as store:
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match=msg):
             store.append("df", df, data_columns=["C"])
 
 
@@ -158,8 +161,10 @@ def test_complex_series_error(setup_path):
     complex128 = np.array([1.0 + 1.0j, 1.0 + 1.0j, 1.0 + 1.0j, 1.0 + 1.0j])
     s = Series(complex128, index=list("abcd"))
 
+    msg = "type error in series of complex"
+
     with ensure_clean_path(setup_path) as path:
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match=msg):
             s.to_hdf(path, "obj", format="t")
 
     with ensure_clean_path(setup_path) as path:

--- a/pandas/tests/io/pytables/test_complex.py
+++ b/pandas/tests/io/pytables/test_complex.py
@@ -150,7 +150,13 @@ def test_complex_indexing_error(setup_path):
         index=list("abcd"),
     )
 
-    msg = "indexing error with complex numbers"
+    msg = (
+        "Columns containing complex values can be stored "
+        "but cannot be indexed when using table format. "
+        "Either use fixed format, set index=False, "
+        "or do not include the columns containing complex "
+        "values to data_columns when initializing the table."
+    )
 
     with ensure_clean_store(setup_path) as store:
         with pytest.raises(TypeError, match=msg):
@@ -161,7 +167,13 @@ def test_complex_series_error(setup_path):
     complex128 = np.array([1.0 + 1.0j, 1.0 + 1.0j, 1.0 + 1.0j, 1.0 + 1.0j])
     s = Series(complex128, index=list("abcd"))
 
-    msg = "type error in series of complex"
+    msg = (
+        "Columns containing complex values can be stored "
+        "but cannot be indexed when using table format. "
+        "Either use fixed format, set index=False, "
+        "or do not include the columns containing complex "
+        "values to data_columns when initializing the table."
+    )
 
     with ensure_clean_path(setup_path) as path:
         with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -238,7 +238,7 @@ class TestClipboard:
         tm.assert_frame_equal(res, exp)
 
     def test_invalid_encoding(self, df):
-        msg = "invalid coding, encoding must be ascii"
+        msg = "clipboard only supports utf-8 encoding"
         # test case for testing invalid encoding
         with pytest.raises(ValueError, match=msg):
             df.to_clipboard(encoding="ascii")

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -238,10 +238,11 @@ class TestClipboard:
         tm.assert_frame_equal(res, exp)
 
     def test_invalid_encoding(self, df):
+        msg = "invalid coding, encoding must be ascii"
         # test case for testing invalid encoding
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=msg):
             df.to_clipboard(encoding="ascii")
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(NotImplementedError, match=msg):
             pd.read_clipboard(encoding="ascii")
 
     @pytest.mark.parametrize("enc", ["UTF-8", "utf-8", "utf8"])

--- a/pandas/tests/plotting/frame/test_frame_subplots.py
+++ b/pandas/tests/plotting/frame/test_frame_subplots.py
@@ -218,9 +218,11 @@ class TestDataFramePlotsSubplots(TestPlotBase):
         self._check_axes_shape(axes, axes_num=3, layout=(4, 1))
         assert axes.shape == (4, 1)
 
-        with pytest.raises(ValueError):
+        msg = "can't create subplots with layout (1,1) or (-1,-1)"
+
+        with pytest.raises(ValueError, match=msg):
             df.plot(subplots=True, layout=(1, 1))
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=msg):
             df.plot(subplots=True, layout=(-1, -1))
 
     @pytest.mark.parametrize(
@@ -272,7 +274,9 @@ class TestDataFramePlotsSubplots(TestPlotBase):
         self._check_axes_shape(axes, axes_num=6, layout=(2, 3))
         tm.close()
 
-        with pytest.raises(ValueError):
+        msg = "number of axes passed is different than the ones required"
+
+        with pytest.raises(ValueError, match=msg):
             fig, axes = self.plt.subplots(2, 3)
             # pass different number of axes from required
             df.plot(subplots=True, ax=axes)

--- a/pandas/tests/plotting/frame/test_frame_subplots.py
+++ b/pandas/tests/plotting/frame/test_frame_subplots.py
@@ -218,7 +218,7 @@ class TestDataFramePlotsSubplots(TestPlotBase):
         self._check_axes_shape(axes, axes_num=3, layout=(4, 1))
         assert axes.shape == (4, 1)
 
-        msg = "can't create subplots with layout (1,1) or (-1,-1)"
+        msg = "Layout of 1x1 must be larger than required size 3"
 
         with pytest.raises(ValueError, match=msg):
             df.plot(subplots=True, layout=(1, 1))
@@ -274,7 +274,7 @@ class TestDataFramePlotsSubplots(TestPlotBase):
         self._check_axes_shape(axes, axes_num=6, layout=(2, 3))
         tm.close()
 
-        msg = "number of axes passed is different than the ones required"
+        msg = "The number of passed axes must be 3, the same as the output plot"
 
         with pytest.raises(ValueError, match=msg):
             fig, axes = self.plt.subplots(2, 3)

--- a/pandas/tests/plotting/frame/test_frame_subplots.py
+++ b/pandas/tests/plotting/frame/test_frame_subplots.py
@@ -222,6 +222,8 @@ class TestDataFramePlotsSubplots(TestPlotBase):
 
         with pytest.raises(ValueError, match=msg):
             df.plot(subplots=True, layout=(1, 1))
+
+        msg = "At least one dimension of layout must be positive"
         with pytest.raises(ValueError, match=msg):
             df.plot(subplots=True, layout=(-1, -1))
 


### PR DESCRIPTION
- [x] ref [#30999 ](https://github.com/pandas-dev/pandas/issues/30999)
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Files changed: 
pandas/tests/io/pytables/test_complex.py
pandas/tests/io/test_clipboard.py
pandas/tests/plotting/frame/test_frame_subplots.py