### PR TITLE
REF: share IntervalIndex.intersection with Index.intersection

### DIFF
--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -1171,3 +1171,15 @@ class IntervalDtype(PandasExtensionDtype):
             results.append(iarr)
 
         return IntervalArray._concat_same_type(results)
+
+    def _get_common_dtype(self, dtypes: List[DtypeObj]) -> Optional[DtypeObj]:
+        # NB: this doesn't handle checking for closed match
+        if not all(isinstance(x, IntervalDtype) for x in dtypes):
+            return np.dtype(object)
+
+        from pandas.core.dtypes.cast import find_common_type
+
+        common = find_common_type([x.subtype for x in dtypes])
+        if common == object:
+            return np.dtype(object)
+        return IntervalDtype(common)

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -1179,7 +1179,7 @@ class IntervalDtype(PandasExtensionDtype):
 
         from pandas.core.dtypes.cast import find_common_type
 
-        common = find_common_type([x.subtype for x in dtypes])
+        common = find_common_type([cast("IntervalDtype", x).subtype for x in dtypes])
         if common == object:
             return np.dtype(object)
         return IntervalDtype(common)

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -810,9 +810,11 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
         return not is_object_dtype(common_subtype)
 
     def _should_compare(self, other) -> bool:
-        if not super()._should_compare(other):
-            return False
         other = unpack_nested_dtype(other)
+        if is_object_dtype(other.dtype):
+            return True
+        if not self._is_comparable_dtype(other.dtype):
+            return False
         return other.closed == self.closed
 
     # TODO: use should_compare and get rid of _is_non_comparable_own_type
@@ -971,23 +973,6 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
                 "objects that are closed on the same side "
                 "and have compatible dtypes"
             )
-
-    @Appender(Index.intersection.__doc__)
-    def intersection(self, other, sort=False) -> Index:
-        self._validate_sort_keyword(sort)
-        self._assert_can_do_setop(other)
-        other, _ = self._convert_can_do_setop(other)
-
-        if self.equals(other):
-            if self.has_duplicates:
-                return self.unique()._get_reconciled_name_object(other)
-            return self._get_reconciled_name_object(other)
-
-        if not isinstance(other, IntervalIndex):
-            return self.astype(object).intersection(other)
-
-        result = self._intersection(other, sort=sort)
-        return self._wrap_setop_result(other, result)
 
     def _intersection(self, other, sort):
         """

--- a/pandas/tests/indexes/interval/test_setops.py
+++ b/pandas/tests/indexes/interval/test_setops.py
@@ -61,17 +61,6 @@ class TestIntervalIndex:
 
         tm.assert_index_equal(index.intersection(index, sort=sort), index)
 
-        # GH 19101: empty result, same dtype
-        other = monotonic_index(300, 314, closed=closed)
-        expected = empty_index(dtype="int64", closed=closed)
-        result = index.intersection(other, sort=sort)
-        tm.assert_index_equal(result, expected)
-
-        # GH 19101: empty result, different dtypes
-        other = monotonic_index(300, 314, dtype="float64", closed=closed)
-        result = index.intersection(other, sort=sort)
-        tm.assert_index_equal(result, expected)
-
         # GH 26225: nested intervals
         index = IntervalIndex.from_tuples([(1, 2), (1, 3), (1, 4), (0, 2)])
         other = IntervalIndex.from_tuples([(1, 2), (1, 3)])
@@ -98,6 +87,25 @@ class TestIntervalIndex:
         other = IntervalIndex([np.nan])
         expected = IntervalIndex([np.nan])
         result = index.intersection(other)
+        tm.assert_index_equal(result, expected)
+
+    def test_intersection_empty_result(self, closed, sort):
+        index = monotonic_index(0, 11, closed=closed)
+
+        # GH 19101: empty result, same dtype
+        other = monotonic_index(300, 314, closed=closed)
+        expected = empty_index(dtype="int64", closed=closed)
+        result = index.intersection(other, sort=sort)
+        tm.assert_index_equal(result, expected)
+
+        # GH 19101: empty result, different numeric dtypes -> common dtype is float64
+        other = monotonic_index(300, 314, dtype="float64", closed=closed)
+        result = index.intersection(other, sort=sort)
+        expected = other[:0]
+        tm.assert_index_equal(result, expected)
+
+        other = monotonic_index(300, 314, dtype="uint64", closed=closed)
+        result = index.intersection(other, sort=sort)
         tm.assert_index_equal(result, expected)
 
     def test_difference(self, closed, sort):


### PR DESCRIPTION
- [x] closes #38299
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This changes the return dtype of IntervalIndex.intersection when that intersection is empty. 