### PR TITLE
[#38390] Bug fix for Datetime64Formatter with values of ndim > 1

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -747,7 +747,6 @@ I/O
 - :meth:`DataFrame.to_html` was ignoring ``formatters`` argument for ``ExtensionDtype`` columns (:issue:`36525`)
 - Bumped minimum xarray version to 0.12.3 to avoid reference to the removed ``Panel`` class (:issue:`27101`)
 - :meth:`DataFrame.to_csv` was re-opening file-like handles that also implement ``os.PathLike`` (:issue:`38125`)
-- Bug in :class:`Datetime64Formatter` that caused error on string representation with extension types of datetime64 values and ndim > 1 (:issue:`38390`)
 
 Period
 ^^^^^^

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -747,6 +747,7 @@ I/O
 - :meth:`DataFrame.to_html` was ignoring ``formatters`` argument for ``ExtensionDtype`` columns (:issue:`36525`)
 - Bumped minimum xarray version to 0.12.3 to avoid reference to the removed ``Panel`` class (:issue:`27101`)
 - :meth:`DataFrame.to_csv` was re-opening file-like handles that also implement ``os.PathLike`` (:issue:`38125`)
+- Bug in :class:`Datetime64Formatter` that caused error on string representation with extension types of datetime64 values and ndim > 1 (:issue:`38390`)
 
 Period
 ^^^^^^

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -242,6 +242,7 @@ I/O
 - Bug in :func:`read_csv` not accepting ``usecols`` with different length than ``names`` for ``engine="python"`` (:issue:`16469`)
 - Bug in :func:`read_csv` raising ``TypeError`` when ``names`` and ``parse_dates`` is specified for ``engine="c"`` (:issue:`33699`)
 - Allow custom error values for parse_dates argument of :func:`read_sql`, :func:`read_sql_query` and :func:`read_sql_table` (:issue:`35185`)
+- Bug in :class:`Datetime64Formatter` that caused error on string representation with extension types of datetime64 values and ndim > 1 (:issue:`38390`)
 -
 
 Period

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1521,18 +1521,17 @@ class Datetime64Formatter(GenericArrayFormatter):
             flat_values = DatetimeIndex(flat_values)
 
         if self.formatter is not None and callable(self.formatter):
-            flat_str_values = np.array([self.formatter(x) for x in flat_values])
-            fmt_values = flat_str_values
+            fmt_values = [self.formatter(x) for x in flat_values]
         else:
             fmt_values = flat_values._data._format_native_types(
                 na_rep=self.nat_rep, date_format=self.date_format
             )
-        fmt_values = fmt_values.reshape(values.shape)
 
-        if len(fmt_values.shape) > 1:
-            nested_string_formatter = GenericArrayFormatter(fmt_values)
-            fmt_values = nested_string_formatter.get_result()
-        else:
+        if len(values.shape) > 1:
+            fmt_values = np.asarray(fmt_values).reshape(values.shape)
+            nested_formatter = GenericArrayFormatter(fmt_values)
+            fmt_values = nested_formatter.get_result()
+        elif isinstance(fmt_values, np.ndarray):
             fmt_values = fmt_values.tolist()
 
         return fmt_values
@@ -1713,18 +1712,16 @@ class Datetime64TZFormatter(Datetime64Formatter):
         flat_values = values.ravel()
 
         ido = is_dates_only(flat_values)
-
         formatter = self.formatter or get_format_datetime64(
             ido, date_format=self.date_format
         )
 
-        fmt_values = np.array([formatter(x) for x in flat_values]).reshape(values.shape)
+        fmt_values = [formatter(x) for x in flat_values]
 
-        if len(fmt_values.shape) > 1:
-            nested_string_formatter = GenericArrayFormatter(fmt_values)
-            fmt_values = nested_string_formatter.get_result()
-        else:
-            fmt_values = fmt_values.tolist()
+        if len(values.shape) > 1:
+            fmt_values = np.asarray(fmt_values).reshape(values.shape)
+            nested_formatter = GenericArrayFormatter(fmt_values)
+            fmt_values = nested_formatter.get_result()
 
         return fmt_values
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1514,11 +1514,8 @@ class Datetime64Formatter(GenericArrayFormatter):
 
     def _format_strings(self) -> List[str]:
         """ we by definition have DO NOT have a TZ """
-        values = self.values
-        flat_values = values.ravel()
-
-        if not isinstance(flat_values, DatetimeArray):
-            flat_values = DatetimeArray(flat_values)
+        values = np.asarray(self.values)
+        flat_values = DatetimeArray(values.ravel())
 
         if self.formatter is not None and callable(self.formatter):
             fmt_values = [self.formatter(x) for x in flat_values]

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1515,7 +1515,8 @@ class Datetime64Formatter(GenericArrayFormatter):
     def _format_strings(self) -> List[str]:
         """ we by definition have DO NOT have a TZ """
         values = np.asarray(self.values)
-        flat_values = DatetimeArray(values.ravel())
+        flat_values = values.ravel() if len(values.shape) > 1 else values
+        flat_values = DatetimeArray(flat_values)
 
         if self.formatter is not None and callable(self.formatter):
             fmt_values = [self.formatter(x) for x in flat_values]
@@ -1706,7 +1707,7 @@ class Datetime64TZFormatter(Datetime64Formatter):
     def _format_strings(self) -> List[str]:
         """ we by definition have a TZ """
         values = self.values.astype(object)
-        flat_values = values.ravel()
+        flat_values = values.ravel() if len(values.shape) > 1 else values
 
         ido = is_dates_only(flat_values)
         formatter = self.formatter or get_format_datetime64(

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1515,7 +1515,7 @@ class Datetime64Formatter(GenericArrayFormatter):
     def _format_strings(self) -> List[str]:
         """ we by definition have DO NOT have a TZ """
         values = np.asarray(self.values)
-        flat_values = values.ravel() if len(values.shape) > 1 else values
+        flat_values = values.ravel() if values.ndim > 1 else values
         flat_values = DatetimeArray(flat_values)
 
         if self.formatter is not None and callable(self.formatter):
@@ -1525,7 +1525,7 @@ class Datetime64Formatter(GenericArrayFormatter):
                 na_rep=self.nat_rep, date_format=self.date_format
             )
 
-        if len(values.shape) > 1:
+        if values.ndim > 1:
             fmt_values = np.asarray(fmt_values).reshape(values.shape)
             nested_formatter = GenericArrayFormatter(fmt_values)
             fmt_values = nested_formatter.get_result()
@@ -1707,7 +1707,7 @@ class Datetime64TZFormatter(Datetime64Formatter):
     def _format_strings(self) -> List[str]:
         """ we by definition have a TZ """
         values = self.values.astype(object)
-        flat_values = values.ravel() if len(values.shape) > 1 else values
+        flat_values = values.ravel() if values.ndim > 1 else values
 
         ido = is_dates_only(flat_values)
         formatter = self.formatter or get_format_datetime64(
@@ -1716,7 +1716,7 @@ class Datetime64TZFormatter(Datetime64Formatter):
 
         fmt_values = [formatter(x) for x in flat_values]
 
-        if len(values.shape) > 1:
+        if values.ndim > 1:
             fmt_values = np.asarray(fmt_values).reshape(values.shape)
             nested_formatter = GenericArrayFormatter(fmt_values)
             fmt_values = nested_formatter.get_result()

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1517,13 +1517,13 @@ class Datetime64Formatter(GenericArrayFormatter):
         values = self.values
         flat_values = values.ravel()
 
-        if not isinstance(flat_values, DatetimeIndex):
-            flat_values = DatetimeIndex(flat_values)
+        if not isinstance(flat_values, DatetimeArray):
+            flat_values = DatetimeArray(flat_values)
 
         if self.formatter is not None and callable(self.formatter):
             fmt_values = [self.formatter(x) for x in flat_values]
         else:
-            fmt_values = flat_values._data._format_native_types(
+            fmt_values = flat_values._format_native_types(
                 na_rep=self.nat_rep, date_format=self.date_format
             )
 

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -3106,6 +3106,43 @@ class TestDatetime64Formatter:
         result = formatter.get_result()
         assert result == ["10:10", "12:12"]
 
+    def test_datetime64formatter_2d_array(self):
+        x = pd.date_range('2018-01-01', periods=10, freq='H').to_numpy()
+
+        formatter = fmt.Datetime64Formatter(x.reshape((5, 2)))
+        result = formatter.get_result()
+        assert len(result) == 5
+        assert result[0].strip() == "[2018-01-01 00:00:00, 2018-01-01 01:00:00]"
+        assert result[4].strip() == "[2018-01-01 08:00:00, 2018-01-01 09:00:00]"
+
+        formatter = fmt.Datetime64Formatter(x.reshape((2, 5)))
+        result = formatter.get_result()
+        assert len(result) == 2
+        assert result[0].strip() == "[2018-01-01 00:00:00, 2018-01-01 01:00:00, 201..."
+        assert result[1].strip() == "[2018-01-01 05:00:00, 2018-01-01 06:00:00, 201..."
+
+    def test_datetime64formatter_3d_array(self):
+        x = pd.date_range('2018-01-01', periods=10, freq='H').to_numpy()
+
+        formatter = fmt.Datetime64Formatter(x.reshape((10, 1, 1)))
+        result = formatter.get_result()
+        assert len(result) == 10
+        assert result[0].strip() == "[[2018-01-01 00:00:00]]"
+        assert result[9].strip() == "[[2018-01-01 09:00:00]]"
+
+    def test_datetime64formatter_2d_array_format_func(self):
+        x = pd.date_range('2018-01-01', periods=24, freq='H').to_numpy()
+
+        def format_func(t):
+            return t.strftime("%H-%m")
+
+        formatter = fmt.Datetime64Formatter(x.reshape((4, 2, 3)),
+                                            formatter=format_func)
+        result = formatter.get_result()
+        assert len(result) == 4
+        assert result[0].strip() == "[[00-01, 01-01, 02-01], [03-01, 04-01, 05-01]]"
+        assert result[3].strip() == "[[18-01, 19-01, 20-01], [21-01, 22-01, 23-01]]"
+
 
 class TestNaTFormatting:
     def test_repr(self):

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -3146,7 +3146,13 @@ class TestDatetime64Formatter:
 class TestDatetime64TZFormatter:
     def test_mixed(self):
         utc = dateutil.tz.tzutc()
-        x = Series([datetime(2013, 1, 1, tzinfo=utc), datetime(2013, 1, 1, 12, tzinfo=utc), pd.NaT])
+        x = Series(
+            [
+                datetime(2013, 1, 1, tzinfo=utc),
+                datetime(2013, 1, 1, 12, tzinfo=utc),
+                pd.NaT,
+            ]
+        )
         result = fmt.Datetime64TZFormatter(x).get_result()
         assert len(result) == 3
         assert result[0].strip() == "2013-01-01 00:00:00+00:00"
@@ -3163,7 +3169,9 @@ class TestDatetime64TZFormatter:
         assert result[2].strip() == "2018-01-01 02:00:00-08:00"
 
     def test_datetime64formatter_2d_array(self):
-        x = pd.date_range("2018-01-01", periods=10, freq="H", tz="US/Pacific").to_numpy()
+        x = pd.date_range(
+            "2018-01-01", periods=10, freq="H", tz="US/Pacific"
+        ).to_numpy()
         formatter = fmt.Datetime64TZFormatter(x.reshape((5, 2)))
         result = formatter.get_result()
         assert len(result) == 5
@@ -3171,12 +3179,16 @@ class TestDatetime64TZFormatter:
         assert result[4].strip() == "[2018-01-01 08:00:00-08:00, 2018-01-01 09:00:0..."
 
     def test_datetime64formatter_2d_array_format_func(self):
-        x = pd.date_range("2018-01-01", periods=16, freq="H", tz="US/Pacific").to_numpy()
+        x = pd.date_range(
+            "2018-01-01", periods=16, freq="H", tz="US/Pacific"
+        ).to_numpy()
 
         def format_func(t):
             return t.strftime("%H-%m %Z")
 
-        formatter = fmt.Datetime64TZFormatter(x.reshape((4, 2, 2)), formatter=format_func)
+        formatter = fmt.Datetime64TZFormatter(
+            x.reshape((4, 2, 2)), formatter=format_func
+        )
         result = formatter.get_result()
         assert len(result) == 4
         assert result[0].strip() == "[[00-01 PST, 01-01 PST], [02-01 PST, 03-01 PST]]"

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -3167,8 +3167,8 @@ class TestDatetime64TZFormatter:
         formatter = fmt.Datetime64TZFormatter(x.reshape((5, 2)))
         result = formatter.get_result()
         assert len(result) == 5
-        assert result[0].strip() == "[2018-01-01 00:00:00-08:00, 2018-01-01 01:00:00-08:00]"
-        assert result[4].strip() == "[2018-01-01 08:00:00-08:00, 2018-01-01 09:00:00-08:00]"
+        assert result[0].strip() == "[2018-01-01 00:00:00-08:00, 2018-01-01 01:00:0..."
+        assert result[4].strip() == "[2018-01-01 08:00:00-08:00, 2018-01-01 09:00:0..."
 
     def test_datetime64formatter_2d_array_format_func(self):
         x = pd.date_range("2018-01-01", periods=16, freq="H", tz="US/Pacific").to_numpy()
@@ -3179,8 +3179,8 @@ class TestDatetime64TZFormatter:
         formatter = fmt.Datetime64TZFormatter(x.reshape((4, 2, 2)), formatter=format_func)
         result = formatter.get_result()
         assert len(result) == 4
-        assert result[0].strip() == "[[00-01, 01-01, 02-01], [03-01, 04-01, 05-01]]"
-        assert result[3].strip() == "[[18-01, 19-01, 20-01], [21-01, 22-01, 23-01]]"
+        assert result[0].strip() == "[[00-01 PST, 01-01 PST], [02-01 PST, 03-01 PST]]"
+        assert result[3].strip() == "[[12-01 PST, 13-01 PST], [14-01 PST, 15-01 PST]]"
 
 
 class TestNaTFormatting:

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -3107,7 +3107,7 @@ class TestDatetime64Formatter:
         assert result == ["10:10", "12:12"]
 
     def test_datetime64formatter_2d_array(self):
-        x = pd.date_range('2018-01-01', periods=10, freq='H').to_numpy()
+        x = pd.date_range("2018-01-01", periods=10, freq="H").to_numpy()
 
         formatter = fmt.Datetime64Formatter(x.reshape((5, 2)))
         result = formatter.get_result()
@@ -3122,7 +3122,7 @@ class TestDatetime64Formatter:
         assert result[1].strip() == "[2018-01-01 05:00:00, 2018-01-01 06:00:00, 201..."
 
     def test_datetime64formatter_3d_array(self):
-        x = pd.date_range('2018-01-01', periods=10, freq='H').to_numpy()
+        x = pd.date_range("2018-01-01", periods=10, freq="H").to_numpy()
 
         formatter = fmt.Datetime64Formatter(x.reshape((10, 1, 1)))
         result = formatter.get_result()
@@ -3131,13 +3131,12 @@ class TestDatetime64Formatter:
         assert result[9].strip() == "[[2018-01-01 09:00:00]]"
 
     def test_datetime64formatter_2d_array_format_func(self):
-        x = pd.date_range('2018-01-01', periods=24, freq='H').to_numpy()
+        x = pd.date_range("2018-01-01", periods=24, freq="H").to_numpy()
 
         def format_func(t):
             return t.strftime("%H-%m")
 
-        formatter = fmt.Datetime64Formatter(x.reshape((4, 2, 3)),
-                                            formatter=format_func)
+        formatter = fmt.Datetime64Formatter(x.reshape((4, 2, 3)), formatter=format_func)
         result = formatter.get_result()
         assert len(result) == 4
         assert result[0].strip() == "[[00-01, 01-01, 02-01], [03-01, 04-01, 05-01]]"


### PR DESCRIPTION
- [x] closes #38390
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This change fixes a bug in `Datetime64Formatter` that errors with values of ndim > 1. This was discovered when using an ExtensionArray with 2D values of datetime64 and attempting to format/display. The formatter currently allows for 2D values, but will end up returning nested strings instead of a flat list of string. The same error occurs when using the `Datetime64Formatter` directly on 2D values.

The fix is to flatten the values to get a flat list of formatted datetime64 strings, then reshape, and then format a second time over the outer dimension to produce the properly nested list format and the final flat list of strings.