### PR TITLE
BUG: algos.rank with readonly values

### DIFF
--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -824,7 +824,7 @@ def rank_1d(
         if values.dtype != np.object_:
             values = values.astype('O')
     else:
-        values = np.asarray(in_arr)
+        values = np.asarray(in_arr).copy()
 
     keep_na = na_option == 'keep'
 

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -835,11 +835,6 @@ def rank_1d(
     elif rank_t is int64_t:
         mask = values == NPY_NAT
 
-        # create copy in case of NPY_NAT
-        # values are mutated inplace
-        if mask.any():
-            values = values.copy()
-
     # double sort first by mask and then by values to ensure nan values are
     # either at the beginning or the end. mask/(~mask) controls padding at
     # tail or the head

--- a/pandas/tests/util/test_show_versions.py
+++ b/pandas/tests/util/test_show_versions.py
@@ -39,7 +39,8 @@ def test_show_versions(capsys):
     assert re.search(r"commit\s*:\s[0-9a-f]{40}\n", result)
 
     # check required dependency
-    assert re.search(r"numpy\s*:\s([0-9\.\+a-f\_]|dev)+\n", result)
+    # 2020-12-09 npdev has "dirty" in the tag
+    assert re.search(r"numpy\s*:\s([0-9\.\+a-g\_]|dev)+(dirty)?\n", result)
 
     # check optional dependency
     assert re.search(r"pyarrow\s*:\s([0-9\.]+|None)\n", result)


### PR DESCRIPTION
One of the two current npdev failures is caused by https://github.com/numpy/numpy/pull/17884