### PR TITLE
TST: Add test to ensure DF describe does not throw an error (#32409)

### DIFF
--- a/pandas/tests/frame/methods/test_describe.py
+++ b/pandas/tests/frame/methods/test_describe.py
@@ -376,3 +376,14 @@ class TestDataFrameDescribe:
         msg = "exclude must be None when include is 'all'"
         with pytest.raises(ValueError, match=msg):
             df.describe(include="all", exclude=exclude)
+
+    def test_describe_does_not_raise_error(self):
+        # GH#32409
+        df = DataFrame([{"test": {"a": "1"}}, {"test": {"a": "2"}}])
+        expected = DataFrame(
+            {"test": [2, 2, {"a": "1"}, 1]}, index=["count", "unique", "top", "freq"]
+        )
+        result = df.describe()
+        tm.assert_frame_equal(result, expected)
+        exp_repr = " test\n" "count 2\n" "unique 2\n" "top {'a': '1'}\n" "freq 1"
+        assert repr(result) == exp_repr

--- a/pandas/tests/frame/methods/test_describe.py
+++ b/pandas/tests/frame/methods/test_describe.py
@@ -385,5 +385,11 @@ class TestDataFrameDescribe:
         )
         result = df.describe()
         tm.assert_frame_equal(result, expected)
-        exp_repr = " test\n" "count 2\n" "unique 2\n" "top {'a': '1'}\n" "freq 1"
+        exp_repr = (
+            "              test\n" 
+            "count            2\n" 
+            "unique           2\n" 
+            "top     {'a': '1'}\n" 
+            "freq               1"
+        )
         assert repr(result) == exp_repr

--- a/pandas/tests/frame/methods/test_describe.py
+++ b/pandas/tests/frame/methods/test_describe.py
@@ -367,6 +367,15 @@ class TestDataFrameDescribe:
         )
         tm.assert_frame_equal(result, expected)
 
+    def test_describe_does_not_raise_error_for_dictlike_elements(self):
+        # GH#32409
+        df = DataFrame([{"test": {"a": "1"}}, {"test": {"a": "2"}}])
+        expected = DataFrame(
+            {"test": [2, 2, {"a": "1"}, 1]}, index=["count", "unique", "top", "freq"]
+        )
+        result = df.describe()
+        tm.assert_frame_equal(result, expected)
+
     @pytest.mark.parametrize("exclude", ["x", "y", ["x", "y"], ["x", "z"]])
     def test_describe_when_include_all_exclude_not_allowed(self, exclude):
         """
@@ -376,20 +385,3 @@ class TestDataFrameDescribe:
         msg = "exclude must be None when include is 'all'"
         with pytest.raises(ValueError, match=msg):
             df.describe(include="all", exclude=exclude)
-
-    def test_describe_does_not_raise_error(self):
-        # GH#32409
-        df = DataFrame([{"test": {"a": "1"}}, {"test": {"a": "2"}}])
-        expected = DataFrame(
-            {"test": [2, 2, {"a": "1"}, 1]}, index=["count", "unique", "top", "freq"]
-        )
-        result = df.describe()
-        tm.assert_frame_equal(result, expected)
-        exp_repr = (
-            "              test\n"
-            "count            2\n"
-            "unique           2\n"
-            "top     {'a': '1'}\n"
-            "freq               1"
-        )
-        assert repr(result) == exp_repr

--- a/pandas/tests/frame/methods/test_describe.py
+++ b/pandas/tests/frame/methods/test_describe.py
@@ -386,10 +386,10 @@ class TestDataFrameDescribe:
         result = df.describe()
         tm.assert_frame_equal(result, expected)
         exp_repr = (
-            "              test\n" 
-            "count            2\n" 
-            "unique           2\n" 
-            "top     {'a': '1'}\n" 
+            "              test\n"
+            "count            2\n"
+            "unique           2\n"
+            "top     {'a': '1'}\n"
             "freq               1"
         )
         assert repr(result) == exp_repr

--- a/pandas/tests/frame/methods/test_describe.py
+++ b/pandas/tests/frame/methods/test_describe.py
@@ -371,7 +371,7 @@ class TestDataFrameDescribe:
         # GH#32409
         df = DataFrame([{"test": {"a": "1"}}, {"test": {"a": "2"}}])
         expected = DataFrame(
-            {"test": [2, 2, {"a": "1"}, 1]}, index=["count", "unique", "top", "freq"]
+            {"test": [2, 2, {"a": "2"}, 1]}, index=["count", "unique", "top", "freq"]
         )
         result = df.describe()
         tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #32409
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Notes:
- Tested using `pytest pandas/tests/frame/methods/test_describe.py::TestDataFrameDescribe::test_describe_does_not_raise_error` and tested error format by calling a raise error line in the try block `raise TypeError("Test message")`
- Re-created PR initial PR with rebase attempt in the following link: https://github.com/pandas-dev/pandas/pull/35270 -- but the diff didn't seem reasonable