### PR TITLE
CLN: MultiIndex.union align with Index.union()

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3566,17 +3566,18 @@ class MultiIndex(Index):
         """
         self._validate_sort_keyword(sort)
         self._assert_can_do_setop(other)
-        other, result_names = self._convert_can_do_setop(other)
+        other, _ = self._convert_can_do_setop(other)
 
-        if len(other) == 0 or self.equals(other):
-            return self.rename(result_names)
+        if not len(other) or self.equals(other):
+            return self._get_reconciled_name_object(other)
+
+        if not len(self):
+            return other._get_reconciled_name_object(self)
 
         return self._union(other, sort=sort)
 
     def _union(self, other, sort):
         other, result_names = self._convert_can_do_setop(other)
-
-        # TODO: Index.union returns other when `len(self)` is 0.
 
         if not is_object_dtype(other.dtype):
             raise NotImplementedError(
@@ -3608,10 +3609,10 @@ class MultiIndex(Index):
         """
         Try to find common names to attach to the result of an operation between
         a and b.  Return a consensus list of names if they match at least partly
-        or None if they have completely different names.
+        or list of None if they have completely different names.
         """
         if len(self.names) != len(other.names):
-            return None
+            return [None] * len(self.names)
         names = []
         for a_name, b_name in zip(self.names, other.names):
             if a_name == b_name:

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -387,6 +387,15 @@ def test_union_non_object_dtype_raises():
         mi.union(idx)
 
 
+def test_union_empty_self_different_names():
+    # GH#38423
+    mi = MultiIndex.from_arrays([[]])
+    mi2 = MultiIndex.from_arrays([[1, 2], [3, 4]], names=["a", "b"])
+    result = mi.union(mi2)
+    expected = MultiIndex.from_arrays([[1, 2], [3, 4]])
+    tm.assert_index_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     "method", ["union", "intersection", "difference", "symmetric_difference"]
 )
@@ -460,12 +469,3 @@ def test_intersection_different_names():
     mi2 = MultiIndex.from_arrays([[1], [3]])
     result = mi.intersection(mi2)
     tm.assert_index_equal(result, mi2)
-
-
-def test_union_empty_self_different_names():
-    # GH#
-    mi = MultiIndex.from_arrays([[]])
-    mi2 = MultiIndex.from_arrays([[1, 2], [3, 4]], names=["a", "b"])
-    result = mi.union(mi2)
-    expected = MultiIndex.from_arrays([[1, 2], [3, 4]])
-    tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -424,12 +424,12 @@ def test_intersect_with_duplicates(tuples, exp_tuples):
 @pytest.mark.parametrize(
     "data, names, expected",
     [
-        ((1,), None, None),
-        ((1,), ["a"], None),
-        ((1,), ["b"], None),
+        ((1,), None, [None, None]),
+        ((1,), ["a"], [None, None]),
+        ((1,), ["b"], [None, None]),
         ((1, 2), ["c", "d"], [None, None]),
         ((1, 2), ["b", "a"], [None, None]),
-        ((1, 2, 3), ["a", "b", "c"], None),
+        ((1, 2, 3), ["a", "b", "c"], [None, None]),
         ((1, 2), ["a", "c"], ["a", None]),
         ((1, 2), ["c", "b"], [None, "b"]),
         ((1, 2), ["a", "b"], ["a", "b"]),

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -460,3 +460,12 @@ def test_intersection_different_names():
     mi2 = MultiIndex.from_arrays([[1], [3]])
     result = mi.intersection(mi2)
     tm.assert_index_equal(result, mi2)
+
+
+def test_union_empty_self_different_names():
+    # GH#
+    mi = MultiIndex.from_arrays([[]])
+    mi2 = MultiIndex.from_arrays([[1, 2], [3, 4]], names=["a", "b"])
+    result = mi.union(mi2)
+    expected = MultiIndex.from_arrays([[1, 2], [3, 4]])
+    tm.assert_index_equal(result, expected)


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Similar to MultiIndex.intersection()

Stumbled over a issue in the maybe_match_names function. Can not return plain None, because MultiIndex.rename can not handle this.

cc @jbrockmendel 