### PR TITLE
DOC: Clarify that DataFrame.sort_values is stable for sorting by multiple columns or labels

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4367,9 +4367,9 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
              If True, perform operation in-place.
         kind : {'quicksort', 'mergesort', 'heapsort'}, default 'quicksort'
              Choice of sorting algorithm. See also ndarray.np.sort for more
-             information.  `mergesort` is the only stable algorithm. For
-             DataFrames, this option is only applied when sorting on a single
-             column or label.
+             information. `mergesort` is the only stable algorithm. For
+             DataFrames, if sorting by multiple columns or labels, this
+             argument is ignored, defaulting to a stable sorting algorithm.
         na_position : {'first', 'last'}, default 'last'
              Puts NaNs at the beginning if `first`; `last` puts NaNs at the
              end.

--- a/pandas/tests/frame/methods/test_sort_values.py
+++ b/pandas/tests/frame/methods/test_sort_values.py
@@ -219,25 +219,30 @@ class TestDataFrameSortValues:
 
     def test_sort_values_stable_descending_multicolumn_sort(self):
         df = DataFrame(
-            {"A": [1, 2, np.nan, 1, 6, 8, 4], "B": [9, np.nan, 5, 2, 5, 4, 5]}
+            {
+                "A": [1, 2, np.nan, 1, 1, 1, 6, 8, 4, 8, 8, np.nan, np.nan, 8, 8],
+                "B": [9, np.nan, 5, 2, 2, 2, 5, 4, 5, 3, 4, np.nan, np.nan, 4, 4],
+            }
         )
-        # test stable mergesort
+        # test sorting is stable
         expected = DataFrame(
-            {"A": [np.nan, 8, 6, 4, 2, 1, 1], "B": [5, 4, 5, 5, np.nan, 2, 9]},
-            index=[2, 5, 4, 6, 1, 3, 0],
+            {
+                "A": [np.nan, np.nan, np.nan, 8, 8, 8, 8, 8, 6, 4, 2, 1, 1, 1, 1],
+                "B": [np.nan, np.nan, 5, 3, 4, 4, 4, 4, 5, 5, np.nan, 2, 2, 2, 9],
+            },
+            index=[11, 12, 2, 9, 7, 10, 13, 14, 6, 8, 1, 3, 4, 5, 0],
         )
-        sorted_df = df.sort_values(
-            ["A", "B"], ascending=[0, 1], na_position="first", kind="mergesort"
-        )
+        sorted_df = df.sort_values(["A", "B"], ascending=[0, 1], na_position="first")
         tm.assert_frame_equal(sorted_df, expected)
 
         expected = DataFrame(
-            {"A": [np.nan, 8, 6, 4, 2, 1, 1], "B": [5, 4, 5, 5, np.nan, 9, 2]},
-            index=[2, 5, 4, 6, 1, 0, 3],
+            {
+                "A": [8, 8, 8, 8, 8, 6, 4, 2, 1, 1, 1, 1, np.nan, np.nan, np.nan],
+                "B": [4, 4, 4, 4, 3, 5, 5, np.nan, 9, 2, 2, 2, 5, np.nan, np.nan],
+            },
+            index=[7, 10, 13, 14, 9, 6, 8, 1, 0, 3, 4, 5, 2, 11, 12],
         )
-        sorted_df = df.sort_values(
-            ["A", "B"], ascending=[0, 0], na_position="first", kind="mergesort"
-        )
+        sorted_df = df.sort_values(["A", "B"], ascending=[0, 0], na_position="last")
         tm.assert_frame_equal(sorted_df, expected)
 
     def test_sort_values_stable_categorial(self):

--- a/pandas/tests/frame/methods/test_sort_values.py
+++ b/pandas/tests/frame/methods/test_sort_values.py
@@ -242,13 +242,14 @@ class TestDataFrameSortValues:
     def test_sort_values_stable_multicolumn_sort(
         self, expected_idx_non_na, ascending, na_position
     ):
+        # GH#38426 Clarify sort_values with mult. columns / labels is stable
         df = DataFrame(
             {
                 "A": [1, 2, np.nan, 1, 1, 1, 6, 8, 4, 8, 8, np.nan, np.nan, 8, 8],
                 "B": [9, np.nan, 5, 2, 2, 2, 5, 4, 5, 3, 4, np.nan, np.nan, 4, 4],
             }
         )
-        # All rows with NaN in col "B" only have unique value in "A", therefore,
+        # All rows with NaN in col "B" only have unique values in "A", therefore,
         # only the rows with NaNs in "A" have to be treated individually:
         expected_idx = (
             [11, 12, 2] + expected_idx_non_na

--- a/pandas/tests/frame/methods/test_sort_values.py
+++ b/pandas/tests/frame/methods/test_sort_values.py
@@ -218,66 +218,52 @@ class TestDataFrameSortValues:
         tm.assert_frame_equal(df, sorted_df)
 
     @pytest.mark.parametrize(
-        "expected_idx, ascending, na_position",
+        "expected_idx_non_na, ascending",
         [
             pytest.param(
-                [11, 12, 2, 3, 4, 5, 0, 1, 8, 6, 9, 7, 10, 13, 14],
+                [3, 4, 5, 0, 1, 8, 6, 9, 7, 10, 13, 14],
                 [True, True],
-                "first",
-                id="both_ascending_na_first",
+                id="both_ascending",
             ),
             pytest.param(
-                [11, 12, 2, 0, 3, 4, 5, 1, 8, 6, 7, 10, 13, 14, 9],
+                [0, 3, 4, 5, 1, 8, 6, 7, 10, 13, 14, 9],
                 [True, False],
-                "first",
-                id="first_ascending_na_first",
+                id="first_ascending",
             ),
             pytest.param(
-                [11, 12, 2, 9, 7, 10, 13, 14, 6, 8, 1, 3, 4, 5, 0],
+                [9, 7, 10, 13, 14, 6, 8, 1, 3, 4, 5, 0],
                 [False, True],
-                "first",
-                id="second_ascending_na_first",
+                id="second_ascending",
             ),
             pytest.param(
-                [11, 12, 2, 7, 10, 13, 14, 9, 6, 8, 1, 0, 3, 4, 5],
+                [7, 10, 13, 14, 9, 6, 8, 1, 0, 3, 4, 5],
                 [False, False],
-                "first",
-                id="both_descending_na_first",
-            ),
-            pytest.param(
-                [3, 4, 5, 0, 1, 8, 6, 9, 7, 10, 13, 14, 2, 11, 12],
-                [True, True],
-                "last",
-                id="both_ascending_na_last",
-            ),
-            pytest.param(
-                [0, 3, 4, 5, 1, 8, 6, 7, 10, 13, 14, 9, 2, 11, 12],
-                [True, False],
-                "last",
-                id="first_ascending_na_last",
-            ),
-            pytest.param(
-                [9, 7, 10, 13, 14, 6, 8, 1, 3, 4, 5, 0, 2, 11, 12],
-                [False, True],
-                "last",
-                id="second_ascending_na_last",
-            ),
-            pytest.param(
-                [7, 10, 13, 14, 9, 6, 8, 1, 0, 3, 4, 5, 2, 11, 12],
-                [False, False],
-                "last",
-                id="both_descending_na_last",
+                id="both_descending",
             ),
         ],
     )
+    @pytest.mark.parametrize(
+        "na_position",
+        [
+            pytest.param("first", id="na_first"),
+            pytest.param("last", id="na_last"),
+        ],
+    )
     def test_sort_values_stable_multicolumn_sort(
-        self, expected_idx, ascending, na_position
+        self, expected_idx_non_na, ascending, na_position
     ):
         df = DataFrame(
             {
                 "A": [1, 2, np.nan, 1, 1, 1, 6, 8, 4, 8, 8, np.nan, np.nan, 8, 8],
                 "B": [9, np.nan, 5, 2, 2, 2, 5, 4, 5, 3, 4, np.nan, np.nan, 4, 4],
             }
+        )
+        # All rows with NaN in col "B" only have unique value in "A", therefore,
+        # only the rows with NaNs in "A" have to be treated individually:
+        expected_idx = (
+            [11, 12, 2] + expected_idx_non_na
+            if na_position == "first"
+            else expected_idx_non_na + [2, 11, 12]
         )
         expected = df.take(expected_idx)
         sorted_df = df.sort_values(

--- a/pandas/tests/frame/methods/test_sort_values.py
+++ b/pandas/tests/frame/methods/test_sort_values.py
@@ -220,35 +220,25 @@ class TestDataFrameSortValues:
     @pytest.mark.parametrize(
         "expected_idx_non_na, ascending",
         [
-            pytest.param(
+            [
                 [3, 4, 5, 0, 1, 8, 6, 9, 7, 10, 13, 14],
                 [True, True],
-                id="both_ascending",
-            ),
-            pytest.param(
+            ],
+            [
                 [0, 3, 4, 5, 1, 8, 6, 7, 10, 13, 14, 9],
                 [True, False],
-                id="first_ascending",
-            ),
-            pytest.param(
+            ],
+            [
                 [9, 7, 10, 13, 14, 6, 8, 1, 3, 4, 5, 0],
                 [False, True],
-                id="second_ascending",
-            ),
-            pytest.param(
+            ],
+            [
                 [7, 10, 13, 14, 9, 6, 8, 1, 0, 3, 4, 5],
                 [False, False],
-                id="both_descending",
-            ),
+            ],
         ],
     )
-    @pytest.mark.parametrize(
-        "na_position",
-        [
-            pytest.param("first", id="na_first"),
-            pytest.param("last", id="na_last"),
-        ],
-    )
+    @pytest.mark.parametrize("na_position", ["first", "last"])
     def test_sort_values_stable_multicolumn_sort(
         self, expected_idx_non_na, ascending, na_position
     ):


### PR DESCRIPTION
- [x] closes #38357
- ~~tests added / passed~~
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- ~~whatsnew entry~~

From what I understand from the code, for `by` containing more than one entry, `pandas.DataFrame.sort_values` uses `pandas.core.sorting.lexsort_indexer`, which converts the columns to ordered `Categorical`s, gets grouped lexicographic group indices via `get_group_index`, compressed these via `compress_group_index` and then sorts using counting sort or mergesort via `get_group_index_sorter`. Both of these are stable, as explained in `get_group_index_sorter`'s docstring. Therefore, the sorting should be stable if `sort_values` is called with `len(by)>1`.