### PR TITLE
REGR: Assigning label with registered EA dtype raises

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -856,7 +856,7 @@ Other
 - Bug in :meth:`Index.drop` raising ``InvalidIndexError`` when index has duplicates (:issue:`38051`)
 - Bug in :meth:`RangeIndex.difference` returning :class:`Int64Index` in some cases where it should return :class:`RangeIndex` (:issue:`38028`)
 - Fixed bug in :func:`assert_series_equal` when comparing a datetime-like array with an equivalent non extension dtype array (:issue:`37609`)
-- Bug in :func:`.is_bool_dtype` would raise when passed a valid string such as ``"boolean"`` (:issue:`38386`).
+- Bug in :func:`.is_bool_dtype` would raise when passed a valid string such as ``"boolean"`` (:issue:`38386`)
 
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -856,7 +856,7 @@ Other
 - Bug in :meth:`Index.drop` raising ``InvalidIndexError`` when index has duplicates (:issue:`38051`)
 - Bug in :meth:`RangeIndex.difference` returning :class:`Int64Index` in some cases where it should return :class:`RangeIndex` (:issue:`38028`)
 - Fixed bug in :func:`assert_series_equal` when comparing a datetime-like array with an equivalent non extension dtype array (:issue:`37609`)
-
+- Bug in :func:`.is_bool_dtype` would raise when passed a valid string such as ``"boolean"`` (:issue:`38386`).
 
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1397,7 +1397,7 @@ def is_bool_dtype(arr_or_dtype) -> bool:
         # guess this
         return arr_or_dtype.is_object and arr_or_dtype.inferred_type == "boolean"
     elif is_extension_array_dtype(arr_or_dtype):
-        return getattr(arr_or_dtype, "dtype", arr_or_dtype)._is_boolean
+        return getattr(dtype, "_is_boolean", False)
 
     return issubclass(dtype.type, np.bool_)
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1689,9 +1689,8 @@ class ParserBase:
                     values, set(col_na_values) | col_na_fvalues, try_num_bool=False
                 )
             else:
-                is_str_or_ea_dtype = is_string_dtype(
-                    cast_type
-                ) or is_extension_array_dtype(cast_type)
+                is_ea = is_extension_array_dtype(cast_type)
+                is_str_or_ea_dtype = is_string_dtype(cast_type) or is_ea
                 # skip inference if specified dtype is object
                 # or casting to an EA
                 try_num_bool = not (cast_type and is_str_or_ea_dtype)
@@ -1707,11 +1706,7 @@ class ParserBase:
                     or is_extension_array_dtype(cast_type)
                 ):
                     try:
-                        if (
-                            is_bool_dtype(cast_type)
-                            and not is_categorical_dtype(cast_type)
-                            and na_count > 0
-                        ):
+                        if not is_ea and na_count > 0 and is_bool_dtype(cast_type):
                             raise ValueError(f"Bool column has NA values in column {c}")
                     except (AttributeError, TypeError):
                         # invalid input to is_bool_dtype

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1690,7 +1690,7 @@ class ParserBase:
                 )
             else:
                 is_ea = is_extension_array_dtype(cast_type)
-                is_str_or_ea_dtype = is_string_dtype(cast_type) or is_ea
+                is_str_or_ea_dtype = is_ea or is_string_dtype(cast_type)
                 # skip inference if specified dtype is object
                 # or casting to an EA
                 try_num_bool = not (cast_type and is_str_or_ea_dtype)
@@ -1705,12 +1705,15 @@ class ParserBase:
                     not is_dtype_equal(cvals, cast_type)
                     or is_extension_array_dtype(cast_type)
                 ):
-                    try:
-                        if not is_ea and na_count > 0 and is_bool_dtype(cast_type):
-                            raise ValueError(f"Bool column has NA values in column {c}")
-                    except (AttributeError, TypeError):
-                        # invalid input to is_bool_dtype
-                        pass
+                    if not is_ea and na_count > 0:
+                        try:
+                            if is_bool_dtype(cast_type):
+                                raise ValueError(
+                                    f"Bool column has NA values in column {c}"
+                                )
+                        except (AttributeError, TypeError):
+                            # invalid input to is_bool_dtype
+                            pass
                     cvals = self._cast_types(cvals, cast_type, c)
 
             result[c] = cvals

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -545,6 +545,7 @@ def test_is_bool_dtype():
     assert not com.is_bool_dtype(pd.Series([1, 2]))
     assert not com.is_bool_dtype(np.array(["a", "b"]))
     assert not com.is_bool_dtype(pd.Index(["a", "b"]))
+    assert not com.is_bool_dtype("Int64")
 
     assert com.is_bool_dtype(bool)
     assert com.is_bool_dtype(np.bool_)
@@ -553,6 +554,7 @@ def test_is_bool_dtype():
 
     assert com.is_bool_dtype(pd.BooleanDtype())
     assert com.is_bool_dtype(pd.array([True, False, None], dtype="boolean"))
+    assert com.is_bool_dtype("boolean")
 
 
 @pytest.mark.filterwarnings("ignore:'is_extension_type' is deprecated:FutureWarning")

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from pandas.core.dtypes.base import registry as ea_registry
 from pandas.core.dtypes.dtypes import DatetimeTZDtype, IntervalDtype, PeriodDtype
 
 from pandas import (
@@ -196,6 +197,18 @@ class TestDataFrameSetItem:
         df["obj"] = obj
 
         tm.assert_frame_equal(df, expected)
+
+    @pytest.mark.parametrize(
+        "ea_name",
+        # Don't test if name is a property
+        [dtype.name for dtype in ea_registry.dtypes if isinstance(dtype.name, str)],
+    )
+    def test_setitem_with_ea_name(self, ea_name):
+        # GH 38386
+        result = DataFrame([0])
+        result[ea_name] = [1]
+        expected = DataFrame({0: [0], ea_name: [1]})
+        tm.assert_frame_equal(result, expected)
 
     def test_setitem_dt64_ndarray_with_NaT_and_diff_time_units(self):
         # GH#7492

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -200,8 +200,12 @@ class TestDataFrameSetItem:
 
     @pytest.mark.parametrize(
         "ea_name",
-        # Don't test if name is a property
-        [dtype.name for dtype in ea_registry.dtypes if isinstance(dtype.name, str)],
+        # property would require instantiation
+        [
+            dtype.name
+            for dtype in ea_registry.dtypes
+            if not isinstance(dtype.name, property)
+        ],
     )
     def test_setitem_with_ea_name(self, ea_name):
         # GH 38386

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -200,13 +200,17 @@ class TestDataFrameSetItem:
 
     @pytest.mark.parametrize(
         "ea_name",
-        # property would require instantiation
+        # mypy doesn't allow adding lists of different types
+        # https://github.com/python/mypy/issues/5492
         [
-            dtype.name
-            for dtype in ea_registry.dtypes
-            if not isinstance(dtype.name, property)
-        ]
-        + ["datetime64[ns, UTC]", "period[D]"],
+            *[
+                dtype.name
+                for dtype in ea_registry.dtypes
+                # property would require instantiation
+                if not isinstance(dtype.name, property)
+            ],
+            *["datetime64[ns, UTC]", "period[D]"],
+        ],
     )
     def test_setitem_with_ea_name(self, ea_name):
         # GH 38386

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -205,7 +205,8 @@ class TestDataFrameSetItem:
             dtype.name
             for dtype in ea_registry.dtypes
             if not isinstance(dtype.name, property)
-        ],
+        ]
+        + ["datetime64[ns, UTC]", "period[D]"],
     )
     def test_setitem_with_ea_name(self, ea_name):
         # GH 38386

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -200,17 +200,15 @@ class TestDataFrameSetItem:
 
     @pytest.mark.parametrize(
         "ea_name",
+        [
+            dtype.name
+            for dtype in ea_registry.dtypes
+            # property would require instantiation
+            if not isinstance(dtype.name, property)
+        ]
         # mypy doesn't allow adding lists of different types
         # https://github.com/python/mypy/issues/5492
-        [
-            *[
-                dtype.name
-                for dtype in ea_registry.dtypes
-                # property would require instantiation
-                if not isinstance(dtype.name, property)
-            ],
-            *["datetime64[ns, UTC]", "period[D]"],
-        ],
+        + ["datetime64[ns, UTC]", "period[D]"],  # type: ignore[list-item]
     )
     def test_setitem_with_ea_name(self, ea_name):
         # GH 38386


### PR DESCRIPTION
- [x] closes #38386
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Previous behavior in `io.parsers` depended on `is_bool_dtype("boolean")` erroneously raising `AttributeError`.

Test currently iterates over the names:

> ['category', 'interval', 'boolean', 'Float32', 'Float64', 'Int8', 'Int16', 'Int32', 'Int64', 'UInt8', 'UInt16', 'UInt32', 'UInt64', 'string']

It skips any EA where the name is a property; I don't see a good way to iterate over these in the test.

I only added a note about `is_bool_dtype` in the whatsnew as the `DataFrame.__setitem__` issue does not occur on 1.1.x. It didn't seem appropriate for any section besides other.