### PR TITLE
Fixed #38419 - BUG: set_index screws up the dtypes on empty DataFrames

### DIFF
--- a/pandas/tests/frame/methods/test_set_index.py
+++ b/pandas/tests/frame/methods/test_set_index.py
@@ -47,6 +47,17 @@ class TestSetIndex:
         expected.index = MultiIndex.from_arrays([df["a"], df["x"]], names=["a", "x"])
         tm.assert_frame_equal(result, expected)
 
+    def test_set_index_empty_dataframe(self):
+        # GH#38419
+        df1 = DataFrame(
+            {"a": Series(dtype="datetime64[ns]"), "b": Series(dtype="int64"), "c": []}
+        )
+
+        df2 = df1.set_index(["a", "b"])
+        result = df2.index.to_frame().dtypes
+        expected = df1[["a", "b"]].dtypes
+        tm.assert_series_equal(result, expected)
+
     def test_set_index_multiindexcolumns(self):
         columns = MultiIndex.from_tuples([("foo", 1), ("foo", 2), ("bar", 1)])
         df = DataFrame(np.random.randn(3, 3), columns=columns)


### PR DESCRIPTION

Fixes #38419 - BUG: set_index screws up the dtypes on empty DataFrames
- [ test_set_index_empty_dataframe] tests added / passed

