### PR TITLE
BUG: first("2M") returning incorrect results

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -607,7 +607,6 @@ Datetimelike
 - Bug in :meth:`Series.isin` with ``datetime64[ns]`` dtype and :meth:`.DatetimeIndex.isin` failing to consider timezone-aware and timezone-naive datetimes as always different (:issue:`35728`)
 - Bug in :meth:`Series.isin` with ``PeriodDtype`` dtype and :meth:`PeriodIndex.isin` failing to consider arguments with different ``PeriodDtype`` as always different (:issue:`37528`)
 - Bug in :class:`Period` constructor now correctly handles nanoseconds in the ``value`` argument (:issue:`34621` and :issue:`17053`)
-- Bug in :meth:`DataFrame.first` and :meth:`Series.first` returning two months for offset one month when first day is last calendar day (:issue:`29623`)
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -607,6 +607,7 @@ Datetimelike
 - Bug in :meth:`Series.isin` with ``datetime64[ns]`` dtype and :meth:`.DatetimeIndex.isin` failing to consider timezone-aware and timezone-naive datetimes as always different (:issue:`35728`)
 - Bug in :meth:`Series.isin` with ``PeriodDtype`` dtype and :meth:`PeriodIndex.isin` failing to consider arguments with different ``PeriodDtype`` as always different (:issue:`37528`)
 - Bug in :class:`Period` constructor now correctly handles nanoseconds in the ``value`` argument (:issue:`34621` and :issue:`17053`)
+- Bug in :meth:`DataFrame.first` and :meth:`Series.first` returning two months for offset one month when first day is last calendar day (:issue:`29623`)
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -156,7 +156,7 @@ Categorical
 Datetimelike
 ^^^^^^^^^^^^
 - Bug in :class:`DataFrame` and :class:`Series` constructors sometimes dropping nanoseconds from :class:`Timestamp` (resp. :class:`Timedelta`) ``data``, with ``dtype=datetime64[ns]`` (resp. ``timedelta64[ns]``) (:issue:`38032`)
--
+- Bug in :meth:`DataFrame.first` and :meth:`Series.first` returning two months for offset one month when first day is last calendar day (:issue:`29623`)
 -
 
 Timedelta

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8421,8 +8421,9 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
         offset = to_offset(offset)
         if not isinstance(offset, Tick) and offset.is_on_offset(self.index[0]):
-            # GH#29623 if first value is end of period
-            end_date = end = self.index[0]
+            # GH#29623 if first value is end of period, remove offset with n = 1
+            #  before adding the real offset
+            end_date = end = self.index[0] - to_offset(offset.name) + offset
         else:
             end_date = end = self.index[0] + offset
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8423,7 +8423,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         if not isinstance(offset, Tick) and offset.is_on_offset(self.index[0]):
             # GH#29623 if first value is end of period, remove offset with n = 1
             #  before adding the real offset
-            end_date = end = self.index[0] - to_offset(offset.name) + offset
+            end_date = end = self.index[0] - offset.base + offset
         else:
             end_date = end = self.index[0] + offset
 

--- a/pandas/tests/frame/methods/test_first_and_last.py
+++ b/pandas/tests/frame/methods/test_first_and_last.py
@@ -79,3 +79,12 @@ class TestFirst:
             [1] * periods, index=bdate_range(start, periods=periods)
         )
         tm.assert_equal(result, expected)
+
+    def test_first_with_first_day_end_of_frq_n_greater_one(self, frame_or_series):
+        # GH#29623
+        x = frame_or_series([1] * 100, index=bdate_range("2010-03-31", periods=100))
+        result = x.first("2M")
+        expected = frame_or_series(
+            [1] * 23, index=bdate_range("2010-03-31", "2010-04-30")
+        )
+        tm.assert_equal(result, expected)


### PR DESCRIPTION
- [x] closes #29623
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
 
This would fix #29623 for offsets with n > 1
cc @simonjayhawkins 