### PR TITLE
Revert "BUG: first("1M") returning two months when first day is last day of month"

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -607,7 +607,6 @@ Datetimelike
 - Bug in :meth:`Series.isin` with ``datetime64[ns]`` dtype and :meth:`.DatetimeIndex.isin` failing to consider timezone-aware and timezone-naive datetimes as always different (:issue:`35728`)
 - Bug in :meth:`Series.isin` with ``PeriodDtype`` dtype and :meth:`PeriodIndex.isin` failing to consider arguments with different ``PeriodDtype`` as always different (:issue:`37528`)
 - Bug in :class:`Period` constructor now correctly handles nanoseconds in the ``value`` argument (:issue:`34621` and :issue:`17053`)
-- Bug in :meth:`DataFrame.first` and :meth:`Series.first` returning two months for offset one month when first day is last calendar day (:issue:`29623`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8420,11 +8420,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
             return self
 
         offset = to_offset(offset)
-        if not isinstance(offset, Tick) and offset.is_on_offset(self.index[0]):
-            # GH#29623 if first value is end of period
-            end_date = end = self.index[0]
-        else:
-            end_date = end = self.index[0] + offset
+        end_date = end = self.index[0] + offset
 
         # Tick-like, e.g. 3 weeks
         if isinstance(offset, Tick):

--- a/pandas/tests/frame/methods/test_first_and_last.py
+++ b/pandas/tests/frame/methods/test_first_and_last.py
@@ -3,7 +3,7 @@ Note: includes tests for `last`
 """
 import pytest
 
-from pandas import DataFrame, bdate_range
+from pandas import DataFrame
 import pandas._testing as tm
 
 
@@ -69,13 +69,3 @@ class TestFirst:
 
         result = ts[:0].last("3M")
         tm.assert_equal(result, ts[:0])
-
-    @pytest.mark.parametrize("start, periods", [("2010-03-31", 1), ("2010-03-30", 2)])
-    def test_first_with_first_day_last_of_month(self, frame_or_series, start, periods):
-        # GH#29623
-        x = frame_or_series([1] * 100, index=bdate_range(start, periods=100))
-        result = x.first("1M")
-        expected = frame_or_series(
-            [1] * periods, index=bdate_range(start, periods=periods)
-        )
-        tm.assert_equal(result, expected)


### PR DESCRIPTION
Reverts pandas-dev/pandas#38331