### PR TITLE
ENH: Improve error message when names and usecols do not match for read_csv with engine=c

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -20,7 +20,7 @@ Other enhancements
 ^^^^^^^^^^^^^^^^^^
 
 - Added :meth:`MultiIndex.dtypes` (:issue:`37062`)
--
+- Improve error message when ``usecols`` and ``names`` do not match for :func:`read_csv` and ``engine="c"`` (:issue:`29042`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -738,8 +738,8 @@ cdef class TextReader:
                 elif self.names is None and nuse < passed_count:
                     self.leading_cols = field_count - passed_count
                 elif passed_count != field_count:
-                    raise ValueError('Passed header names '
-                                     'mismatches usecols')
+                    raise ValueError('Number of passed names did not match number of '
+                                     'header fields in the file')
             # oh boy, #2442, #2981
             elif self.allow_leading_cols and passed_count < field_count:
                 self.leading_cols = field_count - passed_count

--- a/pandas/tests/io/parser/test_usecols.py
+++ b/pandas/tests/io/parser/test_usecols.py
@@ -104,7 +104,7 @@ def test_usecols_name_length_conflict(all_parsers):
 7,8,9
 10,11,12"""
     parser = all_parsers
-    msg ="Number of passed names did not match number of header fields in the file"
+    msg = "Number of passed names did not match number of header fields in the file"
 
     with pytest.raises(ValueError, match=msg):
         parser.read_csv(StringIO(data), names=["a", "b"], header=None, usecols=[1])

--- a/pandas/tests/io/parser/test_usecols.py
+++ b/pandas/tests/io/parser/test_usecols.py
@@ -104,11 +104,7 @@ def test_usecols_name_length_conflict(all_parsers):
 7,8,9
 10,11,12"""
     parser = all_parsers
-    msg = (
-        "Number of passed names did not match number of header fields in the file"
-        if parser.engine == "python"
-        else "Passed header names mismatches usecols"
-    )
+    msg ="Number of passed names did not match number of header fields in the file"
 
     with pytest.raises(ValueError, match=msg):
         parser.read_csv(StringIO(data), names=["a", "b"], header=None, usecols=[1])


### PR DESCRIPTION
- [x] closes #29042
- [x] tests added / passed This case was already covered with differing error messages. I adjusted the message accordingly
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
