### PR TITLE
CI: Use --strict-markers for pytest 6.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Testing docstring validation script
       run: |
         source activate pandas-dev
-        pytest --capture=no --strict scripts
+        pytest --capture=no --strict-markers scripts
       if: always()
 
     - name: Running benchmarks

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -20,7 +20,7 @@ if [[ $(uname) == "Linux" && -z $DISPLAY ]]; then
     XVFB="xvfb-run "
 fi
 
-PYTEST_CMD="${XVFB}pytest -m \"$PATTERN\" -n $PYTEST_WORKERS --dist=loadfile -s --strict --durations=30 --junitxml=test-data.xml $TEST_ARGS $COVERAGE pandas"
+PYTEST_CMD="${XVFB}pytest -m \"$PATTERN\" -n $PYTEST_WORKERS --dist=loadfile -s --strict-markers --durations=30 --junitxml=test-data.xml $TEST_ARGS $COVERAGE pandas"
 
 if [[ $(uname) != "Linux"  && $(uname) != "Darwin" ]]; then
     # GH#37455 windows py38 build appears to be running out of memory

--- a/test_fast.bat
+++ b/test_fast.bat
@@ -1,3 +1,3 @@
 :: test on windows
 set PYTHONHASHSEED=314159265
-pytest --skip-slow --skip-network --skip-db -m "not single" -n 4 -r sXX --strict pandas
+pytest --skip-slow --skip-network --skip-db -m "not single" -n 4 -r sXX --strict-markers pandas

--- a/test_fast.sh
+++ b/test_fast.sh
@@ -5,4 +5,4 @@
 # https://github.com/pytest-dev/pytest/issues/1075
 export PYTHONHASHSEED=$(python -c 'import random; print(random.randint(1, 4294967295))')
 
-pytest pandas --skip-slow --skip-network --skip-db -m "not single" -n 4 -r sxX --strict "$@"
+pytest pandas --skip-slow --skip-network --skip-db -m "not single" -n 4 -r sxX --strict-markers "$@"


### PR DESCRIPTION
closes #38483 

Found in the npdev build.

Noted in pytest changlog: https://docs.pytest.org/en/stable/changelog.html#deprecations
