### PR TITLE
CI: Supress moto server logs in tests

### DIFF
--- a/pandas/tests/io/conftest.py
+++ b/pandas/tests/io/conftest.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import shlex
 import subprocess
@@ -50,8 +49,6 @@ def s3_base(worker_id):
     pytest.importorskip("s3fs")
     pytest.importorskip("boto3")
     requests = pytest.importorskip("requests")
-    # GH 38090: Suppress http logs in tests by moto_server
-    logging.getLogger("werkzeug").disabled = True
 
     with tm.ensure_safe_environment_variables():
         # temporary workaround as moto fails for botocore >= 1.11 otherwise,
@@ -71,7 +68,9 @@ def s3_base(worker_id):
 
         # pipe to null to avoid logging in terminal
         proc = subprocess.Popen(
-            shlex.split(f"moto_server s3 -p {endpoint_port}"), stdout=subprocess.DEVNULL
+            shlex.split(f"moto_server s3 -p {endpoint_port}"),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
         )
 
         timeout = 5

--- a/pandas/tests/io/conftest.py
+++ b/pandas/tests/io/conftest.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shlex
 import subprocess
@@ -49,6 +50,7 @@ def s3_base(worker_id):
     pytest.importorskip("s3fs")
     pytest.importorskip("boto3")
     requests = pytest.importorskip("requests")
+    logging.getLogger("requests").disabled = True
 
     with tm.ensure_safe_environment_variables():
         # temporary workaround as moto fails for botocore >= 1.11 otherwise,


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

https://github.com/pandas-dev/pandas/pull/38096 originally did not do the trick. This change worked for me locally.