### PR TITLE
BUG: CategoricalIndex.reindex fails when Index passed with labels all in category

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -170,7 +170,7 @@ Bug fixes
 Categorical
 ^^^^^^^^^^^
 
--
+- Bug in ``CategoricalIndex.reindex`` failed when ``Index`` passed with elements all in category (:issue:`28690`)
 -
 
 Datetimelike

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -170,7 +170,7 @@ Bug fixes
 Categorical
 ^^^^^^^^^^^
 
-- Bug in ``CategoricalIndex.reindex`` failed when ``Index`` passed with elements all in the category (:issue:`28690`)
+- Bug in ``CategoricalIndex.reindex`` failed when ``Index`` passed with elements all in category (:issue:`28690`)
 -
 
 Datetimelike

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -170,7 +170,7 @@ Bug fixes
 Categorical
 ^^^^^^^^^^^
 
-- Bug in ``CategoricalIndex.reindex`` failed when ``Index`` passed with elements all in category (:issue:`28690`)
+- Bug in ``CategoricalIndex.reindex`` failed when ``Index`` passed with elements all in the category (:issue:`28690`)
 -
 
 Datetimelike

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -441,7 +441,7 @@ class CategoricalIndex(NDArrayBackedExtensionIndex, accessor.PandasDelegate):
         if len(missing):
             cats = self.categories.get_indexer(target)
 
-            if (cats == -1).any():
+            if not isinstance(cats, CategoricalIndex) or (cats == -1).any():
                 # coerce to a regular index here!
                 result = Index(np.array(self), name=self.name)
                 new_target, indexer, _ = result._reindex_non_unique(np.array(target))

--- a/pandas/tests/indexes/categorical/test_reindex.py
+++ b/pandas/tests/indexes/categorical/test_reindex.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas import Categorical, CategoricalIndex, Index, Series
+from pandas import Categorical, CategoricalIndex, Index, Series, DataFrame
 import pandas._testing as tm
 
 
@@ -59,3 +59,12 @@ class TestReindex:
         msg = "'fill_value=-1' is not present in this Categorical's categories"
         with pytest.raises(TypeError, match=msg):
             ser.reindex([1, 2, 3, 4, 5], fill_value=-1)
+
+    def test_reindex_not_category(self):
+        # GH: 28690
+        df = DataFrame(
+            index=CategoricalIndex([], categories=["A"])
+        )
+        result = df.reindex(index=Index(["A"]))
+        expected = DataFrame(index=Index(["A"]))
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/indexes/categorical/test_reindex.py
+++ b/pandas/tests/indexes/categorical/test_reindex.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas import Categorical, CategoricalIndex, Index, Series, DataFrame
+from pandas import Categorical, CategoricalIndex, DataFrame, Index, Series
 import pandas._testing as tm
 
 
@@ -62,9 +62,7 @@ class TestReindex:
 
     def test_reindex_not_category(self):
         # GH: 28690
-        df = DataFrame(
-            index=CategoricalIndex([], categories=["A"])
-        )
+        df = DataFrame(index=CategoricalIndex([], categories=["A"]))
         result = df.reindex(index=Index(["A"]))
         expected = DataFrame(index=Index(["A"]))
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/indexes/categorical/test_reindex.py
+++ b/pandas/tests/indexes/categorical/test_reindex.py
@@ -60,9 +60,34 @@ class TestReindex:
         with pytest.raises(TypeError, match=msg):
             ser.reindex([1, 2, 3, 4, 5], fill_value=-1)
 
-    def test_reindex_not_category(self):
+    @pytest.mark.parametrize(
+        "index_df,index_res,index_exp",
+        [
+            (
+                CategoricalIndex([], categories=["A"]),
+                Index(["A"]),
+                Index(["A"]),
+            ),
+            (
+                CategoricalIndex([], categories=["A"]),
+                Index(["B"]),
+                Index(["B"]),
+            ),
+            (
+                CategoricalIndex([], categories=["A"]),
+                CategoricalIndex(["A"]),
+                CategoricalIndex(["A"]),
+            ),
+            (
+                CategoricalIndex([], categories=["A"]),
+                CategoricalIndex(["B"]),
+                CategoricalIndex(["B"]),
+            ),
+        ],
+    )
+    def test_reindex_not_category(self, index_df, index_res, index_exp):
         # GH: 28690
-        df = DataFrame(index=CategoricalIndex([], categories=["A"]))
-        result = df.reindex(index=Index(["A"]))
-        expected = DataFrame(index=Index(["A"]))
+        df = DataFrame(index=index_df)
+        result = df.reindex(index=index_res)
+        expected = DataFrame(index=index_exp)
         tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #28690
- [x] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
