### PR TITLE
TST: don't use global fixture in the base extension tests

### DIFF
--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -108,6 +108,8 @@ ALL_NUMPY_DTYPES = (
     + BYTES_DTYPES
 )
 
+NULL_OBJECTS = [None, np.nan, pd.NaT, float("nan"), pd.NA]
+
 
 # set testing_mode
 _testing_mode_warnings = (DeprecationWarning, ResourceWarning)

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -266,7 +266,7 @@ def nselect_method(request):
 # ----------------------------------------------------------------
 # Missing values & co.
 # ----------------------------------------------------------------
-@pytest.fixture(params=[None, np.nan, pd.NaT, float("nan"), pd.NA], ids=str)
+@pytest.fixture(params=tm.NULL_OBJECTS, ids=str)
 def nulls_fixture(request):
     """
     Fixture for each null type in pandas.

--- a/pandas/tests/extension/arrow/test_bool.py
+++ b/pandas/tests/extension/arrow/test_bool.py
@@ -51,8 +51,8 @@ class TestInterface(BaseArrowTests, base.BaseInterfaceTests):
         data.view()
 
     @pytest.mark.xfail(raises=AssertionError, reason="Not implemented yet")
-    def test_contains(self, data, data_missing, nulls_fixture):
-        super().test_contains(data, data_missing, nulls_fixture)
+    def test_contains(self, data, data_missing):
+        super().test_contains(data, data_missing)
 
 
 class TestConstructors(BaseArrowTests, base.BaseConstructorsTests):

--- a/pandas/tests/extension/base/interface.py
+++ b/pandas/tests/extension/base/interface.py
@@ -29,7 +29,7 @@ class BaseInterfaceTests(BaseExtensionTests):
         # GH-20761
         assert data._can_hold_na is True
 
-    def test_contains(self, data, data_missing, nulls_fixture):
+    def test_contains(self, data, data_missing):
         # GH-37867
         # Tests for membership checks. Membership checks for nan-likes is tricky and
         # the settled on rule is: `nan_like in arr` is True if nan_like is
@@ -47,10 +47,12 @@ class BaseInterfaceTests(BaseExtensionTests):
         assert na_value in data_missing
         assert na_value not in data
 
-        if nulls_fixture is not na_value:
-            # the data can never contain other nan-likes than na_value
-            assert nulls_fixture not in data
-            assert nulls_fixture not in data_missing
+        # the data can never contain other nan-likes than na_value
+        for na_value_obj in tm.NULL_OBJECTS:
+            if na_value_obj is na_value:
+                continue
+            assert na_value_obj not in data
+            assert na_value_obj not in data_missing
 
     def test_memory_usage(self, data):
         s = pd.Series(data)

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -87,7 +87,7 @@ class TestInterface(base.BaseInterfaceTests):
         # Is this deliberate?
         super().test_memory_usage(data)
 
-    def test_contains(self, data, data_missing, nulls_fixture):
+    def test_contains(self, data, data_missing):
         # GH-37867
         # na value handling in Categorical.__contains__ is deprecated.
         # See base.BaseInterFaceTests.test_contains for more details.
@@ -105,9 +105,11 @@ class TestInterface(base.BaseInterfaceTests):
         assert na_value not in data
 
         # Categoricals can contain other nan-likes than na_value
-        if nulls_fixture is not na_value:
-            assert nulls_fixture not in data
-            assert nulls_fixture in data_missing  # this line differs from super method
+        for na_value_obj in tm.NULL_OBJECTS:
+            if na_value_obj is na_value:
+                continue
+            assert na_value_obj not in data
+            assert na_value_obj in data_missing  # this line differs from super method
 
 
 class TestConstructors(base.BaseConstructorsTests):


### PR DESCRIPTION
Follow-up on https://github.com/pandas-dev/pandas/pull/37867. In the discussion about using this fixture, I forgot that we should not use global pandas fixtures in those tests, but only the ones that are defined in the local /pandas/tests/extension/conftest.py, otherwise this doesn't work for downstream projects (eg https://github.com/geopandas/geopandas/issues/1735). For this case it's easier to simply not use a fixture, I think (but still share the common definition of the list)