### PR TITLE
DOC: Fix incorrect doc string for infer_dtype (#38375)

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -1313,7 +1313,7 @@ def infer_dtype(value: object, skipna: bool = True) -> str:
     'boolean'
 
     >>> infer_dtype([True, False, np.nan])
-    'mixed'
+    'boolean'
 
     >>> infer_dtype([pd.Timestamp('20130101')])
     'datetime'


### PR DESCRIPTION
- [x] closes #38375
- ~~tests added / passed~~
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- ~~whatsnew entry~~

A minor fix to https://github.com/pandas-dev/pandas/issues/38375 correcting the output of an example in `infer_dtype` doc string
