### PR TITLE
WIP: CI: Supress urllib3 tests in pytest

### DIFF
--- a/pandas/tests/io/conftest.py
+++ b/pandas/tests/io/conftest.py
@@ -50,8 +50,7 @@ def s3_base(worker_id):
     pytest.importorskip("s3fs")
     pytest.importorskip("boto3")
     requests = pytest.importorskip("requests")
-    logging.getLogger("urllib3").propagate = False
-    logger = logging.getLogger()
+
     with tm.ensure_safe_environment_variables():
         # temporary workaround as moto fails for botocore >= 1.11 otherwise,
         # see https://github.com/spulec/moto/issues/1924 & 1952
@@ -74,8 +73,6 @@ def s3_base(worker_id):
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
-        for key in logging.Logger.manager.loggerDict:
-            logger.critical(key)
 
         timeout = 5
         while timeout > 0:
@@ -112,6 +109,8 @@ def s3_resource(s3_base, tips_file, jsonl_file, feather_file):
     """
     import boto3
     import s3fs
+
+    logging.getLogger("botocore.vendored.requests.packages.urllib3").disabled = True
 
     test_s3_files = [
         ("tips#1.csv", tips_file),

--- a/pandas/tests/io/conftest.py
+++ b/pandas/tests/io/conftest.py
@@ -50,7 +50,7 @@ def s3_base(worker_id):
     pytest.importorskip("s3fs")
     pytest.importorskip("boto3")
     requests = pytest.importorskip("requests")
-    logging.getLogger("requests").disabled = True
+    logging.getLogger("urllib3").propagate = False
 
     with tm.ensure_safe_environment_variables():
         # temporary workaround as moto fails for botocore >= 1.11 otherwise,

--- a/pandas/tests/io/conftest.py
+++ b/pandas/tests/io/conftest.py
@@ -74,6 +74,8 @@ def s3_base(worker_id):
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
+        for key in logging.Logger.manager.loggerDict:
+            print(key)
 
         timeout = 5
         while timeout > 0:

--- a/pandas/tests/io/conftest.py
+++ b/pandas/tests/io/conftest.py
@@ -110,7 +110,8 @@ def s3_resource(s3_base, tips_file, jsonl_file, feather_file):
     import boto3
     import s3fs
 
-    logging.getLogger("botocore.vendored.requests.packages.urllib3").disabled = True
+    for logging_key in logging.Logger.manager.loggerDict:
+        logging.getLogger(logging_key).disabled = True
 
     test_s3_files = [
         ("tips#1.csv", tips_file),

--- a/pandas/tests/io/conftest.py
+++ b/pandas/tests/io/conftest.py
@@ -51,7 +51,7 @@ def s3_base(worker_id):
     pytest.importorskip("boto3")
     requests = pytest.importorskip("requests")
     logging.getLogger("urllib3").propagate = False
-
+    logger = logging.getLogger()
     with tm.ensure_safe_environment_variables():
         # temporary workaround as moto fails for botocore >= 1.11 otherwise,
         # see https://github.com/spulec/moto/issues/1924 & 1952
@@ -75,7 +75,7 @@ def s3_base(worker_id):
             stderr=subprocess.DEVNULL,
         )
         for key in logging.Logger.manager.loggerDict:
-            print(key)
+            logger.critical(key)
 
         timeout = 5
         while timeout > 0:


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

xref https://github.com/pandas-dev/pandas/pull/38480, there are some remaining urllib3 logs coming from somewhere. Testing if this gets rid of those.