### PR TITLE
BUG&TST: HTML formatting error in Styler.render() in rowspan attribute

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -769,7 +769,7 @@ Plotting
 Styler
 ^^^^^^
 
-- Bug in :meth:`Styler.render` HTML was generated incorrectly beacause of formatting error in rowspan attribute, it now matches with w3 syntax. 
+- Bug in :meth:`Styler.render` HTML was generated incorrectly beacause of formatting error in rowspan attribute, it now matches with w3 syntax. (:issue:`38234`)
 
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -766,6 +766,10 @@ Plotting
 - Bug in :meth:`DataFrame.plot` and :meth:`Series.plot` was overwriting matplotlib's shared y axes behaviour when no ``sharey`` parameter was passed (:issue:`37942`)
 - Bug in :meth:`DataFrame.plot` was raising a ``TypeError`` with ``ExtensionDtype`` columns (:issue:`32073`)
 
+Styler
+^^^^^^
+
+- Bug in :meth:`Styler.render` HTML was generated incorrectly beacause of formatting error in rowspan attribute, it now matches with w3 syntax. 
 
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -389,7 +389,7 @@ class Styler:
                 rowspan = idx_lengths.get((c, r), 0)
                 if rowspan > 1:
                     es["attributes"] = [
-                        format_attr({"key": "rowspan", "value": rowspan})
+                        format_attr({"key": "rowspan", "value": f'"{rowspan}"'})
                     ]
                 row_es.append(es)
 

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1745,8 +1745,8 @@ class TestStyler:
         df = DataFrame(data=[[1, 2]], index=[["l0", "l0"], ["l1a", "l1b"]])
         s = Styler(df, uuid="_", cell_ids=False)
         assert (
-            '<th id="T___level0_row0" class="row_heading'
-            ' level0 row0" rowspan="2">l0</th>' in s.render()
+            '<th id="T___level0_row0" class="row_heading '
+            'level0 row0" rowspan="2">l0</th>' in s.render()
         )
 
     @pytest.mark.parametrize("len_", [1, 5, 32, 33, 100])

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1740,6 +1740,11 @@ class TestStyler:
         s = Styler(df, uuid="_", cell_ids=False)
         assert '<th class="col_heading level0 col0" colspan="2">l0</th>' in s.render()
 
+    def test_rowspan_w3(self):
+        df = DataFrame(data=[[1, 2]], index=[["l0", "l0"], ["l1a", "l1b"]])
+        s = Styler(df, uuid="_", cell_ids=False)
+        assert '<th id="T___level0_row0" class="row_heading level0 row0" rowspan="2">l0</th>' in s.render()
+
     @pytest.mark.parametrize("len_", [1, 5, 32, 33, 100])
     def test_uuid_len(self, len_):
         # GH 36345

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1411,7 +1411,7 @@ class TestStyler:
             "display_value": "a",
             "is_visible": True,
             "type": "th",
-            "attributes": ["rowspan=2"],
+            "attributes": ['rowspan="2"'],
             "class": "row_heading level0 row0",
             "id": "level0_row0",
         }

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1741,10 +1741,12 @@ class TestStyler:
         assert '<th class="col_heading level0 col0" colspan="2">l0</th>' in s.render()
 
     def test_rowspan_w3(self):
+        # GH 38533
         df = DataFrame(data=[[1, 2]], index=[["l0", "l0"], ["l1a", "l1b"]])
         s = Styler(df, uuid="_", cell_ids=False)
         assert (
-            '<th id="T___level0_row0" class="row_heading level0 row0" rowspan="2">l0</th>' 
+            '<th id="T___level0_row0" class="row_heading'
+            ' level0 row0" rowspan="2">l0</th>'
             in s.render()
         )
 

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1743,7 +1743,10 @@ class TestStyler:
     def test_rowspan_w3(self):
         df = DataFrame(data=[[1, 2]], index=[["l0", "l0"], ["l1a", "l1b"]])
         s = Styler(df, uuid="_", cell_ids=False)
-        assert '<th id="T___level0_row0" class="row_heading level0 row0" rowspan="2">l0</th>' in s.render()
+        assert (
+            '<th id="T___level0_row0" class="row_heading level0 row0" rowspan="2">l0</th>' 
+            in s.render()
+        )
 
     @pytest.mark.parametrize("len_", [1, 5, 32, 33, 100])
     def test_uuid_len(self, len_):

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1746,8 +1746,7 @@ class TestStyler:
         s = Styler(df, uuid="_", cell_ids=False)
         assert (
             '<th id="T___level0_row0" class="row_heading'
-            ' level0 row0" rowspan="2">l0</th>'
-            in s.render()
+            ' level0 row0" rowspan="2">l0</th>' in s.render()
         )
 
     @pytest.mark.parametrize("len_", [1, 5, 32, 33, 100])


### PR DESCRIPTION
- [x] closes [#38234](https://github.com/pandas-dev/pandas/issues/38234)
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
