### PR TITLE
Added Documentation to specify that DataFrame.last() needs the index to be sorted to deliver the expected results

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8441,8 +8441,9 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
         When having a DataFrame with dates as index, this function can
         select the last few rows based on a date offset.
-        
-        Note that for the last() method to work, the DatetimeIndex must be sorted otherwise it will not work as intended.
+
+        Note that for the last() method to work, the DatetimeIndex 
+        must be sorted otherwise it will not work as intended.
 
         Parameters
         ----------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8439,11 +8439,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         """
         Select final periods of time series data based on a date offset.
 
-        When having a DataFrame with dates as index, this function can
-        select the last few rows based on a date offset.
-
-        Note that for the last() method to work, the DatetimeIndex
-        must be sorted otherwise it will not work as intended.
+        For a DataFrame with a sorted DatetimeIndex, this function 
+        selects the last few rows based on a date offset.
 
         Parameters
         ----------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8442,7 +8442,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         When having a DataFrame with dates as index, this function can
         select the last few rows based on a date offset.
 
-        Note that for the last() method to work, the DatetimeIndex 
+        Note that for the last() method to work, the DatetimeIndex
         must be sorted otherwise it will not work as intended.
 
         Parameters

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8439,7 +8439,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         """
         Select final periods of time series data based on a date offset.
 
-        For a DataFrame with a sorted DatetimeIndex, this function 
+        For a DataFrame with a sorted DatetimeIndex, this function
         selects the last few rows based on a date offset.
 
         Parameters

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8441,6 +8441,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
         When having a DataFrame with dates as index, this function can
         select the last few rows based on a date offset.
+        
+        Note that for the last() method to work, the DatetimeIndex must be sorted otherwise it will not work as intended.
 
         Parameters
         ----------


### PR DESCRIPTION
Added Documentation mentioning that DataFrame.last() needs the index to be sorted to deliver the expected results

Haven't yet worked on raising an error will work as advised

- [ ] closes #38000
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
