### PR TITLE
Move docstring of NDFrame.replace in preparation of #32542

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4528,10 +4528,7 @@ class DataFrame(NDFrame, OpsMixin):
         """
         return super().pop(item=item)
 
-    @doc(
-        NDFrame.replace,
-        **_shared_doc_kwargs,
-    )
+    @doc(NDFrame.replace, **_shared_doc_kwargs)
     def replace(
         self,
         to_replace=None,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -156,6 +156,7 @@ from pandas.core.internals.construction import (
 )
 from pandas.core.reshape.melt import melt
 from pandas.core.series import Series
+from pandas.core.shared_docs import _shared_doc_kwargs as core_shared_doc_kwargs
 from pandas.core.sorting import get_group_index, lexsort_indexer, nargsort
 
 from pandas.io.common import get_handle
@@ -4522,7 +4523,12 @@ class DataFrame(NDFrame, OpsMixin):
         """
         return super().pop(item=item)
 
-    @doc(NDFrame.replace, **_shared_doc_kwargs)
+    @doc(
+        NDFrame.replace,
+        inplace=core_shared_doc_kwargs["inplace"],
+        replace_iloc=core_shared_doc_kwargs["replace_iloc"],
+        **_shared_doc_kwargs,
+    )
     def replace(
         self,
         to_replace=None,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -156,7 +156,6 @@ from pandas.core.internals.construction import (
 )
 from pandas.core.reshape.melt import melt
 from pandas.core.series import Series
-from pandas.core.shared_docs import _shared_doc_kwargs as core_shared_doc_kwargs
 from pandas.core.sorting import get_group_index, lexsort_indexer, nargsort
 
 from pandas.io.common import get_handle
@@ -181,6 +180,9 @@ _shared_doc_kwargs = {
     "axis": """axis : {0 or 'index', 1 or 'columns'}, default 0
         If 0 or 'index': apply function to each column.
         If 1 or 'columns': apply function to each row.""",
+    "inplace": """
+    inplace : boolean, default False
+        If True, performs operation inplace and returns None.""",
     "optional_by": """
         by : str or list of str
             Name or list of names to sort by.
@@ -194,6 +196,9 @@ _shared_doc_kwargs = {
     "optional_axis": """axis : int or str, optional
             Axis to target. Can be either the axis name ('index', 'columns')
             or number (0, 1).""",
+    "replace_iloc": """
+    This differs from updating with ``.loc`` or ``.iloc``, which require
+    you to specify a location to update with some value.""",
 }
 
 _numeric_only_doc = """numeric_only : boolean, default None
@@ -4525,8 +4530,6 @@ class DataFrame(NDFrame, OpsMixin):
 
     @doc(
         NDFrame.replace,
-        inplace=core_shared_doc_kwargs["inplace"],
-        replace_iloc=core_shared_doc_kwargs["replace_iloc"],
         **_shared_doc_kwargs,
     )
     def replace(

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -105,7 +105,7 @@ from pandas.core.indexes.api import (
 from pandas.core.internals import BlockManager
 from pandas.core.missing import find_valid_index
 from pandas.core.ops import align_method_FRAME
-from pandas.core.shared_docs import _shared_docs
+from pandas.core.shared_docs import _shared_doc_kwargs, _shared_docs
 from pandas.core.sorting import get_indexer_indexer
 from pandas.core.window import Expanding, ExponentialMovingWindow, Rolling, Window
 
@@ -128,15 +128,17 @@ if TYPE_CHECKING:
 # goal is to be able to define the docs close to function, while still being
 # able to share
 _shared_docs = {**_shared_docs}
-_shared_doc_kwargs = {
-    "axes": "keywords for axes",
-    "klass": "Series/DataFrame",
-    "axes_single_arg": "int or labels for object",
-    "args_transpose": "axes to permute (int or label for object)",
-    "optional_by": """
-        by : str or list of str
-            Name or list of names to sort by""",
-}
+_shared_doc_kwargs.update(
+    {
+        "axes": "keywords for axes",
+        "klass": "Series/DataFrame",
+        "axes_single_arg": "int or labels for object",
+        "args_transpose": "axes to permute (int or label for object)",
+        "optional_by": """
+            by : str or list of str
+                Name or list of names to sort by""",
+    }
+)
 
 
 bool_t = bool  # Need alias because NDFrame has def bool:
@@ -6469,7 +6471,12 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
     backfill = bfill
 
-    @doc(klass=_shared_doc_kwargs["klass"])
+    @doc(
+        _shared_docs["replace"],
+        klass=_shared_doc_kwargs["klass"],
+        inplace=_shared_doc_kwargs["inplace"],
+        replace_iloc=_shared_doc_kwargs["replace_iloc"],
+    )
     def replace(
         self,
         to_replace=None,
@@ -6479,282 +6486,6 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         regex=False,
         method="pad",
     ):
-        """
-        Replace values given in `to_replace` with `value`.
-
-        Values of the {klass} are replaced with other values dynamically.
-        This differs from updating with ``.loc`` or ``.iloc``, which require
-        you to specify a location to update with some value.
-
-        Parameters
-        ----------
-        to_replace : str, regex, list, dict, Series, int, float, or None
-            How to find the values that will be replaced.
-
-            * numeric, str or regex:
-
-                - numeric: numeric values equal to `to_replace` will be
-                  replaced with `value`
-                - str: string exactly matching `to_replace` will be replaced
-                  with `value`
-                - regex: regexs matching `to_replace` will be replaced with
-                  `value`
-
-            * list of str, regex, or numeric:
-
-                - First, if `to_replace` and `value` are both lists, they
-                  **must** be the same length.
-                - Second, if ``regex=True`` then all of the strings in **both**
-                  lists will be interpreted as regexs otherwise they will match
-                  directly. This doesn't matter much for `value` since there
-                  are only a few possible substitution regexes you can use.
-                - str, regex and numeric rules apply as above.
-
-            * dict:
-
-                - Dicts can be used to specify different replacement values
-                  for different existing values. For example,
-                  ``{{'a': 'b', 'y': 'z'}}`` replaces the value 'a' with 'b' and
-                  'y' with 'z'. To use a dict in this way the `value`
-                  parameter should be `None`.
-                - For a DataFrame a dict can specify that different values
-                  should be replaced in different columns. For example,
-                  ``{{'a': 1, 'b': 'z'}}`` looks for the value 1 in column 'a'
-                  and the value 'z' in column 'b' and replaces these values
-                  with whatever is specified in `value`. The `value` parameter
-                  should not be ``None`` in this case. You can treat this as a
-                  special case of passing two lists except that you are
-                  specifying the column to search in.
-                - For a DataFrame nested dictionaries, e.g.,
-                  ``{{'a': {{'b': np.nan}}}}``, are read as follows: look in column
-                  'a' for the value 'b' and replace it with NaN. The `value`
-                  parameter should be ``None`` to use a nested dict in this
-                  way. You can nest regular expressions as well. Note that
-                  column names (the top-level dictionary keys in a nested
-                  dictionary) **cannot** be regular expressions.
-
-            * None:
-
-                - This means that the `regex` argument must be a string,
-                  compiled regular expression, or list, dict, ndarray or
-                  Series of such elements. If `value` is also ``None`` then
-                  this **must** be a nested dictionary or Series.
-
-            See the examples section for examples of each of these.
-        value : scalar, dict, list, str, regex, default None
-            Value to replace any values matching `to_replace` with.
-            For a DataFrame a dict of values can be used to specify which
-            value to use for each column (columns not in the dict will not be
-            filled). Regular expressions, strings and lists or dicts of such
-            objects are also allowed.
-        inplace : bool, default False
-            If True, in place. Note: this will modify any
-            other views on this object (e.g. a column from a DataFrame).
-            Returns the caller if this is True.
-        limit : int or None, default None
-            Maximum size gap to forward or backward fill.
-        regex : bool or same types as `to_replace`, default False
-            Whether to interpret `to_replace` and/or `value` as regular
-            expressions. If this is ``True`` then `to_replace` *must* be a
-            string. Alternatively, this could be a regular expression or a
-            list, dict, or array of regular expressions in which case
-            `to_replace` must be ``None``.
-        method : {{'pad', 'ffill', 'bfill', `None`}}
-            The method to use when for replacement, when `to_replace` is a
-            scalar, list or tuple and `value` is ``None``.
-
-        Returns
-        -------
-        {klass} or None
-            Object after replacement or None if ``inplace=True``.
-
-        Raises
-        ------
-        AssertionError
-            * If `regex` is not a ``bool`` and `to_replace` is not
-              ``None``.
-
-        TypeError
-            * If `to_replace` is not a scalar, array-like, ``dict``, or ``None``
-            * If `to_replace` is a ``dict`` and `value` is not a ``list``,
-              ``dict``, ``ndarray``, or ``Series``
-            * If `to_replace` is ``None`` and `regex` is not compilable
-              into a regular expression or is a list, dict, ndarray, or
-              Series.
-            * When replacing multiple ``bool`` or ``datetime64`` objects and
-              the arguments to `to_replace` does not match the type of the
-              value being replaced
-
-        ValueError
-            * If a ``list`` or an ``ndarray`` is passed to `to_replace` and
-              `value` but they are not the same length.
-
-        See Also
-        --------
-        {klass}.fillna : Fill NA values.
-        {klass}.where : Replace values based on boolean condition.
-        Series.str.replace : Simple string replacement.
-
-        Notes
-        -----
-        * Regex substitution is performed under the hood with ``re.sub``. The
-          rules for substitution for ``re.sub`` are the same.
-        * Regular expressions will only substitute on strings, meaning you
-          cannot provide, for example, a regular expression matching floating
-          point numbers and expect the columns in your frame that have a
-          numeric dtype to be matched. However, if those floating point
-          numbers *are* strings, then you can do this.
-        * This method has *a lot* of options. You are encouraged to experiment
-          and play with this method to gain intuition about how it works.
-        * When dict is used as the `to_replace` value, it is like
-          key(s) in the dict are the to_replace part and
-          value(s) in the dict are the value parameter.
-
-        Examples
-        --------
-
-        **Scalar `to_replace` and `value`**
-
-        >>> s = pd.Series([0, 1, 2, 3, 4])
-        >>> s.replace(0, 5)
-        0    5
-        1    1
-        2    2
-        3    3
-        4    4
-        dtype: int64
-
-        >>> df = pd.DataFrame({{'A': [0, 1, 2, 3, 4],
-        ...                    'B': [5, 6, 7, 8, 9],
-        ...                    'C': ['a', 'b', 'c', 'd', 'e']}})
-        >>> df.replace(0, 5)
-           A  B  C
-        0  5  5  a
-        1  1  6  b
-        2  2  7  c
-        3  3  8  d
-        4  4  9  e
-
-        **List-like `to_replace`**
-
-        >>> df.replace([0, 1, 2, 3], 4)
-           A  B  C
-        0  4  5  a
-        1  4  6  b
-        2  4  7  c
-        3  4  8  d
-        4  4  9  e
-
-        >>> df.replace([0, 1, 2, 3], [4, 3, 2, 1])
-           A  B  C
-        0  4  5  a
-        1  3  6  b
-        2  2  7  c
-        3  1  8  d
-        4  4  9  e
-
-        >>> s.replace([1, 2], method='bfill')
-        0    0
-        1    3
-        2    3
-        3    3
-        4    4
-        dtype: int64
-
-        **dict-like `to_replace`**
-
-        >>> df.replace({{0: 10, 1: 100}})
-             A  B  C
-        0   10  5  a
-        1  100  6  b
-        2    2  7  c
-        3    3  8  d
-        4    4  9  e
-
-        >>> df.replace({{'A': 0, 'B': 5}}, 100)
-             A    B  C
-        0  100  100  a
-        1    1    6  b
-        2    2    7  c
-        3    3    8  d
-        4    4    9  e
-
-        >>> df.replace({{'A': {{0: 100, 4: 400}}}})
-             A  B  C
-        0  100  5  a
-        1    1  6  b
-        2    2  7  c
-        3    3  8  d
-        4  400  9  e
-
-        **Regular expression `to_replace`**
-
-        >>> df = pd.DataFrame({{'A': ['bat', 'foo', 'bait'],
-        ...                    'B': ['abc', 'bar', 'xyz']}})
-        >>> df.replace(to_replace=r'^ba.$', value='new', regex=True)
-              A    B
-        0   new  abc
-        1   foo  new
-        2  bait  xyz
-
-        >>> df.replace({{'A': r'^ba.$'}}, {{'A': 'new'}}, regex=True)
-              A    B
-        0   new  abc
-        1   foo  bar
-        2  bait  xyz
-
-        >>> df.replace(regex=r'^ba.$', value='new')
-              A    B
-        0   new  abc
-        1   foo  new
-        2  bait  xyz
-
-        >>> df.replace(regex={{r'^ba.$': 'new', 'foo': 'xyz'}})
-              A    B
-        0   new  abc
-        1   xyz  new
-        2  bait  xyz
-
-        >>> df.replace(regex=[r'^ba.$', 'foo'], value='new')
-              A    B
-        0   new  abc
-        1   new  new
-        2  bait  xyz
-
-        Compare the behavior of ``s.replace({{'a': None}})`` and
-        ``s.replace('a', None)`` to understand the peculiarities
-        of the `to_replace` parameter:
-
-        >>> s = pd.Series([10, 'a', 'a', 'b', 'a'])
-
-        When one uses a dict as the `to_replace` value, it is like the
-        value(s) in the dict are equal to the `value` parameter.
-        ``s.replace({{'a': None}})`` is equivalent to
-        ``s.replace(to_replace={{'a': None}}, value=None, method=None)``:
-
-        >>> s.replace({{'a': None}})
-        0      10
-        1    None
-        2    None
-        3       b
-        4    None
-        dtype: object
-
-        When ``value=None`` and `to_replace` is a scalar, list or
-        tuple, `replace` uses the method parameter (default 'pad') to do the
-        replacement. So this is why the 'a' values are being replaced by 10
-        in rows 1 and 2 and 'b' in row 4 in this case.
-        The command ``s.replace('a', None)`` is actually equivalent to
-        ``s.replace(to_replace='a', value=None, method='pad')``:
-
-        >>> s.replace('a', None)
-        0    10
-        1    10
-        2    10
-        3     b
-        4     b
-        dtype: object
-        """
         if not (
             is_scalar(to_replace)
             or is_re_compilable(to_replace)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -105,7 +105,7 @@ from pandas.core.indexes.api import (
 from pandas.core.internals import BlockManager
 from pandas.core.missing import find_valid_index
 from pandas.core.ops import align_method_FRAME
-from pandas.core.shared_docs import _shared_doc_kwargs, _shared_docs
+from pandas.core.shared_docs import _shared_docs
 from pandas.core.sorting import get_indexer_indexer
 from pandas.core.window import Expanding, ExponentialMovingWindow, Rolling, Window
 
@@ -128,17 +128,21 @@ if TYPE_CHECKING:
 # goal is to be able to define the docs close to function, while still being
 # able to share
 _shared_docs = {**_shared_docs}
-_shared_doc_kwargs.update(
-    {
-        "axes": "keywords for axes",
-        "klass": "Series/DataFrame",
-        "axes_single_arg": "int or labels for object",
-        "args_transpose": "axes to permute (int or label for object)",
-        "optional_by": """
-            by : str or list of str
-                Name or list of names to sort by""",
-    }
-)
+_shared_doc_kwargs = {
+    "axes": "keywords for axes",
+    "klass": "Series/DataFrame",
+    "axes_single_arg": "int or labels for object",
+    "args_transpose": "axes to permute (int or label for object)",
+    "inplace": """
+    inplace : boolean, default False
+        If True, performs operation inplace and returns None.""",
+    "optional_by": """
+        by : str or list of str
+            Name or list of names to sort by""",
+    "replace_iloc": """
+    This differs from updating with ``.loc`` or ``.iloc``, which require
+    you to specify a location to update with some value.""",
+}
 
 
 bool_t = bool  # Need alias because NDFrame has def bool:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -97,7 +97,7 @@ from pandas.core.indexes.period import PeriodIndex
 from pandas.core.indexes.timedeltas import TimedeltaIndex
 from pandas.core.indexing import check_bool_indexer
 from pandas.core.internals import SingleBlockManager
-from pandas.core.shared_docs import _shared_doc_kwargs, _shared_docs
+from pandas.core.shared_docs import _shared_docs
 from pandas.core.sorting import ensure_key_mapped, nargsort
 from pandas.core.strings import StringMethods
 from pandas.core.tools.datetimes import to_datetime
@@ -111,23 +111,24 @@ if TYPE_CHECKING:
 
 __all__ = ["Series"]
 
-_shared_doc_kwargs.update(
-    {
-        "axes": "index",
-        "klass": "Series",
-        "axes_single_arg": "{0 or 'index'}",
-        "axis": """axis : {0 or 'index'}
-            Parameter needed for compatibility with DataFrame.""",
-        "inplace": """inplace : boolean, default False
-            If True, performs operation inplace and returns None.""",
-        "unique": "np.ndarray",
-        "duplicated": "Series",
-        "optional_by": "",
-        "optional_mapper": "",
-        "optional_labels": "",
-        "optional_axis": "",
-    }
-)
+_shared_doc_kwargs = {
+    "axes": "index",
+    "klass": "Series",
+    "axes_single_arg": "{0 or 'index'}",
+    "axis": """axis : {0 or 'index'}
+        Parameter needed for compatibility with DataFrame.""",
+    "inplace": """inplace : boolean, default False
+        If True, performs operation inplace and returns None.""",
+    "unique": "np.ndarray",
+    "duplicated": "Series",
+    "optional_by": "",
+    "optional_mapper": "",
+    "optional_labels": "",
+    "optional_axis": "",
+    "replace_iloc": """
+    This differs from updating with ``.loc`` or ``.iloc``, which require
+    you to specify a location to update with some value.""",
+}
 
 
 def _coerce_method(converter):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -97,7 +97,7 @@ from pandas.core.indexes.period import PeriodIndex
 from pandas.core.indexes.timedeltas import TimedeltaIndex
 from pandas.core.indexing import check_bool_indexer
 from pandas.core.internals import SingleBlockManager
-from pandas.core.shared_docs import _shared_docs
+from pandas.core.shared_docs import _shared_doc_kwargs, _shared_docs
 from pandas.core.sorting import ensure_key_mapped, nargsort
 from pandas.core.strings import StringMethods
 from pandas.core.tools.datetimes import to_datetime
@@ -111,21 +111,23 @@ if TYPE_CHECKING:
 
 __all__ = ["Series"]
 
-_shared_doc_kwargs = {
-    "axes": "index",
-    "klass": "Series",
-    "axes_single_arg": "{0 or 'index'}",
-    "axis": """axis : {0 or 'index'}
-        Parameter needed for compatibility with DataFrame.""",
-    "inplace": """inplace : boolean, default False
-        If True, performs operation inplace and returns None.""",
-    "unique": "np.ndarray",
-    "duplicated": "Series",
-    "optional_by": "",
-    "optional_mapper": "",
-    "optional_labels": "",
-    "optional_axis": "",
-}
+_shared_doc_kwargs.update(
+    {
+        "axes": "index",
+        "klass": "Series",
+        "axes_single_arg": "{0 or 'index'}",
+        "axis": """axis : {0 or 'index'}
+            Parameter needed for compatibility with DataFrame.""",
+        "inplace": """inplace : boolean, default False
+            If True, performs operation inplace and returns None.""",
+        "unique": "np.ndarray",
+        "duplicated": "Series",
+        "optional_by": "",
+        "optional_mapper": "",
+        "optional_labels": "",
+        "optional_axis": "",
+    }
+)
 
 
 def _coerce_method(converter):
@@ -4473,7 +4475,12 @@ Keep all original rows and also all original values
         """
         return super().pop(item=item)
 
-    @doc(NDFrame.replace, klass=_shared_doc_kwargs["klass"])
+    @doc(
+        NDFrame.replace,
+        klass=_shared_doc_kwargs["klass"],
+        inplace=_shared_doc_kwargs["inplace"],
+        replace_iloc=_shared_doc_kwargs["replace_iloc"],
+    )
     def replace(
         self,
         to_replace=None,

--- a/pandas/core/shared_docs.py
+++ b/pandas/core/shared_docs.py
@@ -665,12 +665,3 @@ _shared_docs[
     4     b
     dtype: object
 """
-
-_shared_doc_kwargs: Dict[str, str] = {
-    "inplace": """
-    inplace : boolean, default False
-        If True, performs operation inplace and returns None.""",
-    "replace_iloc": """
-    This differs from updating with ``.loc`` or ``.iloc``, which require
-    you to specify a location to update with some value.""",
-}

--- a/pandas/core/shared_docs.py
+++ b/pandas/core/shared_docs.py
@@ -387,3 +387,290 @@ _shared_docs[
     are forwarded to ``urllib`` as header options. For other URLs (e.g.
     starting with "s3://", and "gcs://") the key-value pairs are forwarded to
     ``fsspec``. Please see ``fsspec`` and ``urllib`` for more details."""
+
+_shared_docs[
+    "replace"
+] = """
+    Replace values given in `to_replace` with `value`.
+
+    Values of the {klass} are replaced with other values dynamically.
+    {replace_iloc}
+
+    Parameters
+    ----------
+    to_replace : str, regex, list, dict, Series, int, float, or None
+        How to find the values that will be replaced.
+
+        * numeric, str or regex:
+
+            - numeric: numeric values equal to `to_replace` will be
+                replaced with `value`
+            - str: string exactly matching `to_replace` will be replaced
+                with `value`
+            - regex: regexs matching `to_replace` will be replaced with
+                `value`
+
+        * list of str, regex, or numeric:
+
+            - First, if `to_replace` and `value` are both lists, they
+                **must** be the same length.
+            - Second, if ``regex=True`` then all of the strings in **both**
+                lists will be interpreted as regexs otherwise they will match
+                directly. This doesn't matter much for `value` since there
+                are only a few possible substitution regexes you can use.
+            - str, regex and numeric rules apply as above.
+
+        * dict:
+
+            - Dicts can be used to specify different replacement values
+                for different existing values. For example,
+                ``{{'a': 'b', 'y': 'z'}}`` replaces the value 'a' with 'b' and
+                'y' with 'z'. To use a dict in this way the `value`
+                parameter should be `None`.
+            - For a DataFrame a dict can specify that different values
+                should be replaced in different columns. For example,
+                ``{{'a': 1, 'b': 'z'}}`` looks for the value 1 in column 'a'
+                and the value 'z' in column 'b' and replaces these values
+                with whatever is specified in `value`. The `value` parameter
+                should not be ``None`` in this case. You can treat this as a
+                special case of passing two lists except that you are
+                specifying the column to search in.
+            - For a DataFrame nested dictionaries, e.g.,
+                ``{{'a': {{'b': np.nan}}}}``, are read as follows: look in column
+                'a' for the value 'b' and replace it with NaN. The `value`
+                parameter should be ``None`` to use a nested dict in this
+                way. You can nest regular expressions as well. Note that
+                column names (the top-level dictionary keys in a nested
+                dictionary) **cannot** be regular expressions.
+
+        * None:
+
+            - This means that the `regex` argument must be a string,
+                compiled regular expression, or list, dict, ndarray or
+                Series of such elements. If `value` is also ``None`` then
+                this **must** be a nested dictionary or Series.
+
+        See the examples section for examples of each of these.
+    value : scalar, dict, list, str, regex, default None
+        Value to replace any values matching `to_replace` with.
+        For a DataFrame a dict of values can be used to specify which
+        value to use for each column (columns not in the dict will not be
+        filled). Regular expressions, strings and lists or dicts of such
+        objects are also allowed.
+    {inplace}
+    limit : int, default None
+        Maximum size gap to forward or backward fill.
+    regex : bool or same types as `to_replace`, default False
+        Whether to interpret `to_replace` and/or `value` as regular
+        expressions. If this is ``True`` then `to_replace` *must* be a
+        string. Alternatively, this could be a regular expression or a
+        list, dict, or array of regular expressions in which case
+        `to_replace` must be ``None``.
+    method : {{'pad', 'ffill', 'bfill', `None`}}
+        The method to use when for replacement, when `to_replace` is a
+        scalar, list or tuple and `value` is ``None``.
+
+        .. versionchanged:: 0.23.0
+            Added to DataFrame.
+
+    Returns
+    -------
+    {klass}
+        Object after replacement.
+
+    Raises
+    ------
+    AssertionError
+        * If `regex` is not a ``bool`` and `to_replace` is not
+            ``None``.
+
+    TypeError
+        * If `to_replace` is not a scalar, array-like, ``dict``, or ``None``
+        * If `to_replace` is a ``dict`` and `value` is not a ``list``,
+            ``dict``, ``ndarray``, or ``Series``
+        * If `to_replace` is ``None`` and `regex` is not compilable
+            into a regular expression or is a list, dict, ndarray, or
+            Series.
+        * When replacing multiple ``bool`` or ``datetime64`` objects and
+            the arguments to `to_replace` does not match the type of the
+            value being replaced
+
+    ValueError
+        * If a ``list`` or an ``ndarray`` is passed to `to_replace` and
+            `value` but they are not the same length.
+
+    See Also
+    --------
+    {klass}.fillna : Fill NA values.
+    {klass}.where : Replace values based on boolean condition.
+    Series.str.replace : Simple string replacement.
+
+    Notes
+    -----
+    * Regex substitution is performed under the hood with ``re.sub``. The
+        rules for substitution for ``re.sub`` are the same.
+    * Regular expressions will only substitute on strings, meaning you
+        cannot provide, for example, a regular expression matching floating
+        point numbers and expect the columns in your frame that have a
+        numeric dtype to be matched. However, if those floating point
+        numbers *are* strings, then you can do this.
+    * This method has *a lot* of options. You are encouraged to experiment
+        and play with this method to gain intuition about how it works.
+    * When dict is used as the `to_replace` value, it is like
+        key(s) in the dict are the to_replace part and
+        value(s) in the dict are the value parameter.
+
+    Examples
+    --------
+
+    **Scalar `to_replace` and `value`**
+
+    >>> s = pd.Series([0, 1, 2, 3, 4])
+    >>> s.replace(0, 5)
+    0    5
+    1    1
+    2    2
+    3    3
+    4    4
+    dtype: int64
+
+    >>> df = pd.DataFrame({{'A': [0, 1, 2, 3, 4],
+    ...                    'B': [5, 6, 7, 8, 9],
+    ...                    'C': ['a', 'b', 'c', 'd', 'e']}})
+    >>> df.replace(0, 5)
+        A  B  C
+    0  5  5  a
+    1  1  6  b
+    2  2  7  c
+    3  3  8  d
+    4  4  9  e
+
+    **List-like `to_replace`**
+
+    >>> df.replace([0, 1, 2, 3], 4)
+        A  B  C
+    0  4  5  a
+    1  4  6  b
+    2  4  7  c
+    3  4  8  d
+    4  4  9  e
+
+    >>> df.replace([0, 1, 2, 3], [4, 3, 2, 1])
+        A  B  C
+    0  4  5  a
+    1  3  6  b
+    2  2  7  c
+    3  1  8  d
+    4  4  9  e
+
+    >>> s.replace([1, 2], method='bfill')
+    0    0
+    1    3
+    2    3
+    3    3
+    4    4
+    dtype: int64
+
+    **dict-like `to_replace`**
+
+    >>> df.replace({{0: 10, 1: 100}})
+            A  B  C
+    0   10  5  a
+    1  100  6  b
+    2    2  7  c
+    3    3  8  d
+    4    4  9  e
+
+    >>> df.replace({{'A': 0, 'B': 5}}, 100)
+            A    B  C
+    0  100  100  a
+    1    1    6  b
+    2    2    7  c
+    3    3    8  d
+    4    4    9  e
+
+    >>> df.replace({{'A': {{0: 100, 4: 400}}}})
+            A  B  C
+    0  100  5  a
+    1    1  6  b
+    2    2  7  c
+    3    3  8  d
+    4  400  9  e
+
+    **Regular expression `to_replace`**
+
+    >>> df = pd.DataFrame({{'A': ['bat', 'foo', 'bait'],
+    ...                    'B': ['abc', 'bar', 'xyz']}})
+    >>> df.replace(to_replace=r'^ba.$', value='new', regex=True)
+            A    B
+    0   new  abc
+    1   foo  new
+    2  bait  xyz
+
+    >>> df.replace({{'A': r'^ba.$'}}, {{'A': 'new'}}, regex=True)
+            A    B
+    0   new  abc
+    1   foo  bar
+    2  bait  xyz
+
+    >>> df.replace(regex=r'^ba.$', value='new')
+            A    B
+    0   new  abc
+    1   foo  new
+    2  bait  xyz
+
+    >>> df.replace(regex={{r'^ba.$': 'new', 'foo': 'xyz'}})
+            A    B
+    0   new  abc
+    1   xyz  new
+    2  bait  xyz
+
+    >>> df.replace(regex=[r'^ba.$', 'foo'], value='new')
+            A    B
+    0   new  abc
+    1   new  new
+    2  bait  xyz
+
+    Compare the behavior of ``s.replace({{'a': None}})`` and
+    ``s.replace('a', None)`` to understand the peculiarities
+    of the `to_replace` parameter:
+
+    >>> s = pd.Series([10, 'a', 'a', 'b', 'a'])
+
+    When one uses a dict as the `to_replace` value, it is like the
+    value(s) in the dict are equal to the `value` parameter.
+    ``s.replace({{'a': None}})`` is equivalent to
+    ``s.replace(to_replace={{'a': None}}, value=None, method=None)``:
+
+    >>> s.replace({{'a': None}})
+    0      10
+    1    None
+    2    None
+    3       b
+    4    None
+    dtype: object
+
+    When ``value=None`` and `to_replace` is a scalar, list or
+    tuple, `replace` uses the method parameter (default 'pad') to do the
+    replacement. So this is why the 'a' values are being replaced by 10
+    in rows 1 and 2 and 'b' in row 4 in this case.
+    The command ``s.replace('a', None)`` is actually equivalent to
+    ``s.replace(to_replace='a', value=None, method='pad')``:
+
+    >>> s.replace('a', None)
+    0    10
+    1    10
+    2    10
+    3     b
+    4     b
+    dtype: object
+"""
+
+_shared_doc_kwargs: Dict[str, str] = {
+    "inplace": """
+    inplace : boolean, default False
+        If True, performs operation inplace and returns None.""",
+    "replace_iloc": """
+    This differs from updating with ``.loc`` or ``.iloc``, which require
+    you to specify a location to update with some value.""",
+}

--- a/scripts/validate_unwanted_patterns.py
+++ b/scripts/validate_unwanted_patterns.py
@@ -23,6 +23,7 @@ PRIVATE_IMPORTS_TO_IGNORE: Set[str] = {
     "_interval_shared_docs",
     "_merge_doc",
     "_shared_docs",
+    "_shared_doc_kwargs",
     "_apply_docs",
     "_new_Index",
     "_new_PeriodIndex",

--- a/scripts/validate_unwanted_patterns.py
+++ b/scripts/validate_unwanted_patterns.py
@@ -23,7 +23,6 @@ PRIVATE_IMPORTS_TO_IGNORE: Set[str] = {
     "_interval_shared_docs",
     "_merge_doc",
     "_shared_docs",
-    "_shared_doc_kwargs",
     "_apply_docs",
     "_new_Index",
     "_new_PeriodIndex",


### PR DESCRIPTION
This is a pre-cursor PR for #32542 as requested by @jreback [here](https://github.com/pandas-dev/pandas/pull/32542#issuecomment-744043100).

It moves the docstring of `replace()` method(s) to `pandas.core.shared_docs` so that we can reuse most of it for index classes.