### PR TITLE
REF: Block._astype defer to astype_nansafe in more cases

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -346,7 +346,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         elif is_string_dtype(dtype) and not is_categorical_dtype(dtype):
             if is_extension_array_dtype(dtype):
                 arr_cls = dtype.construct_array_type()
-                return arr_cls._from_sequence(self, dtype=dtype)
+                return arr_cls._from_sequence(self, dtype=dtype, copy=copy)
             else:
                 return self._format_native_types()
         elif is_integer_dtype(dtype):

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -589,10 +589,15 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
 
         if is_datetime64_ns_dtype(dtype) and not is_dtype_equal(dtype, self.dtype):
             # GH#18951: datetime64_ns dtype but not equal means different tz
+            # FIXME: this doesn't match DatetimeBlock.astype, xref GH#33401
             new_tz = getattr(dtype, "tz", None)
-            if getattr(self.dtype, "tz", None) is None:
+            if self.tz is None:
                 return self.tz_localize(new_tz)
-            result = self.tz_convert(new_tz)
+            elif new_tz is None:
+                result = self.tz_convert("UTC").tz_localize(None)
+            else:
+                result = self.tz_convert(new_tz)
+
             if copy:
                 result = result.copy()
             if new_tz is None:

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -30,7 +30,6 @@ from pandas._libs.tslibs import (
     conversion,
     iNaT,
     ints_to_pydatetime,
-    ints_to_pytimedelta,
 )
 from pandas._libs.tslibs.timezones import tz_compare
 from pandas._typing import AnyArrayLike, ArrayLike, Dtype, DtypeObj, Scalar
@@ -994,9 +993,7 @@ def astype_nansafe(
         ).reshape(arr.shape)
 
     elif is_datetime64_dtype(arr):
-        if is_object_dtype(dtype):
-            return ints_to_pydatetime(arr.view(np.int64))
-        elif dtype == np.int64:
+        if dtype == np.int64:
             if isna(arr).any():
                 raise ValueError("Cannot convert NaT values to integer")
             return arr.view(dtype)
@@ -1008,9 +1005,7 @@ def astype_nansafe(
         raise TypeError(f"cannot astype a datetimelike from [{arr.dtype}] to [{dtype}]")
 
     elif is_timedelta64_dtype(arr):
-        if is_object_dtype(dtype):
-            return ints_to_pytimedelta(arr.view(np.int64))
-        elif dtype == np.int64:
+        if dtype == np.int64:
             if isna(arr).any():
                 raise ValueError("Cannot convert NaT values to integer")
             return arr.view(dtype)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -980,6 +980,14 @@ def astype_nansafe(
     elif not isinstance(dtype, np.dtype):
         raise ValueError("dtype must be np.dtype or ExtensionDtype")
 
+    if arr.dtype.kind in ["m", "M"] and (
+        issubclass(dtype.type, str) or dtype == object
+    ):
+        from pandas.core.construction import ensure_wrapped_if_datetimelike
+
+        arr = ensure_wrapped_if_datetimelike(arr)
+        return arr.astype(dtype, copy=copy)
+
     if issubclass(dtype.type, str):
         return lib.ensure_string_array(
             arr.ravel(), skipna=skipna, convert_na_value=False

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5852,6 +5852,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         elif is_extension_array_dtype(dtype) and self.ndim > 1:
             # GH 18099/22869: columnwise conversion to extension dtype
             # GH 24704: use iloc to handle duplicate column names
+            # TODO(EA2D): special case not needed with 2D EAs
             results = [
                 self.iloc[:, i].astype(dtype, copy=copy)
                 for i in range(len(self.columns))

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -68,7 +68,7 @@ from pandas.core.arrays import (
 )
 from pandas.core.base import PandasObject
 import pandas.core.common as com
-from pandas.core.construction import array as pd_array, extract_array
+from pandas.core.construction import extract_array
 from pandas.core.indexers import (
     check_setitem_lengths,
     is_empty_indexer,
@@ -654,7 +654,7 @@ class Block(PandasObject):
 
             return Categorical(values, dtype=dtype)
 
-        if is_datetime64tz_dtype(dtype) and is_datetime64_dtype(values.dtype):
+        elif is_datetime64tz_dtype(dtype) and is_datetime64_dtype(values.dtype):
             # if we are passed a datetime64[ns, tz]
             if copy:
                 # this should be the only copy
@@ -672,27 +672,7 @@ class Block(PandasObject):
         if isinstance(values, ExtensionArray):
             values = values.astype(dtype, copy=copy)
 
-        elif isinstance(dtype, ExtensionDtype):
-            # same thing we do in astype_nansafe
-            cls = dtype.construct_array_type()
-            return cls._from_sequence(values, dtype=dtype, copy=copy)
-
         else:
-            if issubclass(dtype.type, str):
-                if values.dtype.kind in ["m", "M"]:
-                    # use native type formatting for datetime/tz/timedelta
-                    arr = pd_array(values)
-                    return arr.astype(dtype)
-
-            elif is_object_dtype(dtype):
-                if values.dtype.kind in ["m", "M"]:
-                    # Wrap in Timedelta/Timestamp
-                    arr = pd_array(values)
-                    values = arr.astype(object)
-                else:
-                    values = values.astype(object)
-                return values
-
             # astype_nansafe works with 1-d only
             vals1d = values.ravel()
             values = astype_nansafe(vals1d, dtype, copy=True)

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -654,7 +654,7 @@ class Block(PandasObject):
 
             return Categorical(values, dtype=dtype)
 
-        elif is_datetime64tz_dtype(dtype) and is_datetime64_dtype(values.dtype):
+        if is_datetime64tz_dtype(dtype) and is_datetime64_dtype(values.dtype):
             # if we are passed a datetime64[ns, tz]
             if copy:
                 # this should be the only copy

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -126,7 +126,12 @@ def test_string_methods(input, method, dtype, request):
 def test_astype_roundtrip(dtype, request):
     if dtype == "arrow_string":
         reason = "ValueError: Could not convert object to NumPy datetime"
-        mark = pytest.mark.xfail(reason=reason)
+        mark = pytest.mark.xfail(reason=reason, raises=ValueError)
+        request.node.add_marker(mark)
+    else:
+        mark = pytest.mark.xfail(
+            reason="GH#36153 casting from StringArray to dt64 fails", raises=ValueError
+        )
         request.node.add_marker(mark)
 
     ser = pd.Series(pd.date_range("2000", periods=12))


### PR DESCRIPTION
Makes astype_nansafe for (td64|dt64) -> (object|str|string) match DTA/TDA/Series behavior.

Medium-term (weeks) the goal is to get rid of Block._astype altogether and just use astype_nansafe, which among other things will be helpful for ArrayManager.

This changes `Series[dt64].astype("string")` behavior in a way that causes a new xfail in test_astype_roundtrip, but as discussed in #36153 that test is already wrong for other reasons.

This also has a side-effect of changing Series(dt64, dtype="Sparse[object]") behavior, discussed in #38508 as possibly not-desirable.