### PR TITLE
TST: GH30999 Add match=msg to test_nat_comparisons_invalid

### DIFF
--- a/pandas/tests/scalar/test_nat.py
+++ b/pandas/tests/scalar/test_nat.py
@@ -558,20 +558,28 @@ def test_nat_comparisons_numpy(other):
     assert not NaT >= other
 
 
-@pytest.mark.parametrize("other", ["foo", 2, 2.0])
-@pytest.mark.parametrize("op", [operator.le, operator.lt, operator.ge, operator.gt])
-def test_nat_comparisons_invalid(other, op):
+@pytest.mark.parametrize("other_and_type", [("foo", "str"), (2, "int"), (2.0, "float")])
+@pytest.mark.parametrize(
+    "symbol_and_op",
+    [("<=", operator.le), ("<", operator.lt), (">=", operator.ge), (">", operator.gt)],
+)
+def test_nat_comparisons_invalid(other_and_type, symbol_and_op):
     # GH#35585
+    other, other_type = other_and_type
+    symbol, op = symbol_and_op
+
     assert not NaT == other
     assert not other == NaT
 
     assert NaT != other
     assert other != NaT
 
-    with pytest.raises(TypeError):
+    msg = f"'{symbol}' not supported between instances of 'NaTType' and '{other_type}'"
+    with pytest.raises(TypeError, match=msg):
         op(NaT, other)
 
-    with pytest.raises(TypeError):
+    msg = f"'{symbol}' not supported between instances of '{other_type}' and 'NaTType'"
+    with pytest.raises(TypeError, match=msg):
         op(other, NaT)
 
 


### PR DESCRIPTION
This pull request xref #30999 to remove bare pytest.raises. It doesn't close that issue as I have only addressed one file: pandas/tests/scalar/test_nat.py . In that file there was only one test that had a bare pytest.raises and I added a message to the two instances of pytest.raises in that test. It required modifications to the test parameters in order to populate the message.

I did not add a whatsnew entry since it's only a tiny change to one test. Let me know if I should add one (and I am a bit unclear on how, i.e. what version this would end up in).

This is my first ever pull request to an open source project. I am expecting that I will have to make changes before it's accepted; thanks for your patience.

- [ ] xref #30999
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
