### PR TITLE
DOC: capitalize NumPy as proper noun

### DIFF
--- a/doc/source/user_guide/10min.rst
+++ b/doc/source/user_guide/10min.rst
@@ -163,7 +163,7 @@ Selection
 
 .. note::
 
-   While standard Python / Numpy expressions for selecting and setting are
+   While standard Python / NumPy expressions for selecting and setting are
    intuitive and come in handy for interactive work, for production code, we
    recommend the optimized pandas data access methods, ``.at``, ``.iat``,
    ``.loc`` and ``.iloc``.
@@ -239,7 +239,7 @@ Select via the position of the passed integers:
 
    df.iloc[3]
 
-By integer slices, acting similar to numpy/Python:
+By integer slices, acting similar to NumPy/Python:
 
 .. ipython:: python
 

--- a/doc/source/user_guide/cookbook.rst
+++ b/doc/source/user_guide/cookbook.rst
@@ -15,7 +15,7 @@ Simplified, condensed, new-user friendly, in-line examples have been inserted wh
 augment the Stack-Overflow and GitHub links.  Many of the links contain expanded information,
 above what the in-line examples offer.
 
-pandas (pd) and Numpy (np) are the only two abbreviated imported modules. The rest are kept
+pandas (pd) and NumPy (np) are the only two abbreviated imported modules. The rest are kept
 explicitly imported for newer users.
 
 Idioms


### PR DESCRIPTION
In a similar vein to https://github.com/pandas-dev/pandas/pull/37808

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
