### PR TITLE
BUG: Fix regression in pandas merge

### DIFF
--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -865,7 +865,7 @@ class _MergeOperation:
                 mask_right = right_indexer == -1
                 if mask_left.all():
                     key_col = rvals
-                elif mask_right.all():
+                elif right_indexer is not None and mask_right.all():
                     key_col = lvals
                 else:
                     key_col = Index(lvals).where(~mask_left, rvals)

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2349,3 +2349,20 @@ def test_merge_join_cols_error_reporting_on_and_index(func, kwargs):
     )
     with pytest.raises(MergeError, match=msg):
         getattr(pd, func)(left, right, on="a", **kwargs)
+
+
+def test_merge_right_left_index():
+    # GH#38616
+    left = DataFrame({"x": [1, 1], "z": ["foo", "foo"]})
+    right = DataFrame({"x": [1, 1], "z": ["foo", "foo"]})
+    result = pd.merge(left, right, how="right", left_index=True, right_on="x")
+    expected = DataFrame(
+        {
+            "x": [1, 1],
+            "x_x": [1, 1],
+            "z_x": ["foo", "foo"],
+            "x_y": [1, 1],
+            "z_y": ["foo", "foo"],
+        }
+    )
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #38616
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Since this is a regression on master I think a whatsnew is not necessary?
