### PR TITLE
[BUG] Concat duplicates errors (or lack there of)

### DIFF
--- a/asv_bench/benchmarks/algorithms.py
+++ b/asv_bench/benchmarks/algorithms.py
@@ -5,7 +5,6 @@ import numpy as np
 from pandas._libs import lib
 
 import pandas as pd
-from pandas.core.algorithms import make_duplicates_of_left_unique_in_right
 
 from .pandas_vb_common import tm
 
@@ -173,17 +172,6 @@ class SortIntegerArray:
 
     def time_argsort(self, N):
         self.array.argsort()
-
-
-class RemoveDuplicates:
-    def setup(self):
-        N = 10 ** 5
-        na = np.arange(int(N / 2))
-        self.left = np.concatenate([na[: int(N / 4)], na[: int(N / 4)]])
-        self.right = np.concatenate([na, na])
-
-    def time_make_duplicates_of_left_unique_in_right(self):
-        make_duplicates_of_left_unique_in_right(self.left, self.right)
 
 
 from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -821,7 +821,6 @@ Reshaping
 - Bug in :meth:`DataFrame.combine_first` caused wrong alignment with dtype ``string`` and one level of ``MultiIndex`` containing only ``NA`` (:issue:`37591`)
 - Fixed regression in :func:`merge` on merging :class:`.DatetimeIndex` with empty DataFrame (:issue:`36895`)
 - Bug in :meth:`DataFrame.apply` not setting index of return value when ``func`` return type is ``dict`` (:issue:`37544`)
-- Bug in :func:`concat` resulting in a ``ValueError`` when at least one of both inputs had a non-unique index (:issue:`36263`)
 - Bug in :meth:`DataFrame.merge` and :meth:`pandas.merge` returning inconsistent ordering in result for ``how=right`` and ``how=left`` (:issue:`35382`)
 - Bug in :func:`merge_ordered` couldn't handle list-like ``left_by`` or ``right_by`` (:issue:`35269`)
 - Bug in :func:`merge_ordered` returned wrong join result when length of ``left_by`` or ``right_by`` equals to the rows of ``left`` or ``right`` (:issue:`38166`)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -2199,24 +2199,3 @@ def _sort_tuples(values: np.ndarray[tuple]):
     arrays, _ = to_arrays(values, None)
     indexer = lexsort_indexer(arrays, orders=True)
     return values[indexer]
-
-
-def make_duplicates_of_left_unique_in_right(
-    left: np.ndarray, right: np.ndarray
-) -> np.ndarray:
-    """
-    If left has duplicates, which are also duplicated in right, this duplicated values
-    are dropped from right, meaning that every duplicate value from left exists only
-    once in right.
-
-    Parameters
-    ----------
-    left: ndarray
-    right: ndarray
-
-    Returns
-    -------
-    Duplicates of left are unique in right
-    """
-    left_duplicates = unique(left[duplicated(left)])
-    return right[~(duplicated(right) & isin(right, left_duplicates))]

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -24,7 +24,6 @@ from pandas.core.dtypes.concat import concat_compat
 from pandas.core.dtypes.generic import ABCDataFrame, ABCSeries
 from pandas.core.dtypes.missing import isna
 
-import pandas.core.algorithms as algos
 from pandas.core.arrays.categorical import (
     factorize_from_iterable,
     factorize_from_iterables,
@@ -513,13 +512,6 @@ class _Concatenator:
                     # 1-ax to convert BlockManager axis to DataFrame axis
                     obj_labels = obj.axes[1 - ax]
                     if not new_labels.equals(obj_labels):
-                        # We have to remove the duplicates from obj_labels
-                        # in new labels to make them unique, otherwise we would
-                        # duplicate or duplicates again
-                        if not obj_labels.is_unique:
-                            new_labels = algos.make_duplicates_of_left_unique_in_right(
-                                np.asarray(obj_labels), np.asarray(new_labels)
-                            )
                         indexers[ax] = obj_labels.reindex(new_labels)[1]
 
                 mgrs_indexers.append((obj._mgr, indexers))

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -512,7 +512,7 @@ class _Concatenator:
                     # 1-ax to convert BlockManager axis to DataFrame axis
                     obj_labels = obj.axes[1 - ax]
                     if not new_labels.equals(obj_labels):
-                        indexers[ax] = obj_labels.reindex(new_labels)[1]
+                        indexers[ax] = obj_labels.get_indexer(new_labels)
 
                 mgrs_indexers.append((obj._mgr, indexers))
 

--- a/pandas/tests/reshape/concat/test_dataframe.py
+++ b/pandas/tests/reshape/concat/test_dataframe.py
@@ -167,14 +167,3 @@ class TestDataFrameConcat:
         # it works
         result = concat([t1, t2], axis=1, keys=["t1", "t2"], sort=sort)
         assert list(result.columns) == [("t1", "value"), ("t2", "value")]
-
-    def test_concat_duplicate_indexes(self):
-        # GH#36263 ValueError with non unique indexes
-        df1 = DataFrame([1, 2, 3, 4], index=[0, 1, 1, 4], columns=["a"])
-        df2 = DataFrame([6, 7, 8, 9], index=[0, 0, 1, 3], columns=["b"])
-        result = concat([df1, df2], axis=1)
-        expected = DataFrame(
-            {"a": [1, 1, 2, 3, np.nan, 4], "b": [6, 7, 8, 8, 9, np.nan]},
-            index=Index([0, 0, 1, 1, 3, 4]),
-        )
-        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -2409,15 +2409,3 @@ class TestDiff:
         msg = "cannot diff DatetimeArray on axis=1"
         with pytest.raises(ValueError, match=msg):
             algos.diff(dta, 1, axis=1)
-
-
-@pytest.mark.parametrize(
-    "left_values", [[0, 1, 1, 4], [0, 1, 1, 4, 4], [0, 1, 1, 1, 4]]
-)
-def test_make_duplicates_of_left_unique_in_right(left_values):
-    # GH#36263
-    left = np.array(left_values)
-    right = np.array([0, 0, 1, 1, 4])
-    result = algos.make_duplicates_of_left_unique_in_right(left, right)
-    expected = np.array([0, 0, 1, 4])
-    tm.assert_numpy_array_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #6963
- [ ]  xref #36263, #36290
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

@jreback

So here is a basic proposal for making `concat` throw a more useful error when there are duplicate values on the index not being concatenated along. Below are some examples of how this error message is improved. I'm including a comparison to 1.2.0rc1, since it includes a pr which was supposed to change some of these errors to working cases, but those cases are extremely limited. That's why the first commit of this PR reverts that change.

I haven't gone too far with this since it a) reverts a merged PR and b) affects the release candidate, so should be conservative. I would like to get feedback on whether I should proceed with this approach.

My thinking right now is that a better error and revert should go into 1.2 – no behaviour change from 1.1, just better errors. A question of whether `pd.concat(..., join="inner")` means an intersection of indices (the current [and documented](https://pandas.pydata.org/docs/user_guide/merging.html#concatenating-objects) behaviour) or an actual inner join seems like something that could benefit from more discussion.

If they are set operations, it should probably error on duplicates. If they are relational algebra operations, they should work with duplicates. It would probably also be useful to then add more arguments to `concat`, like `merge`s `validate`.

# One dataframe has repeated column names (str)

```python
pd.concat([
    pd.DataFrame(np.ones((4, 4)), columns=list("aabc")),
    pd.DataFrame(np.ones((4, 3)), columns=list("abc")),
])
```

This PR

```pytb
InvalidIndexError: Reindexing only valid with uniquely valued Index objects
```

Pandas v1.1.5

```pytb
ValueError: Plan shapes are not aligned
```

pandas 1.2.0rc1

```pytb
ValueError: Plan shapes are not aligned
```

-------------------------

# One dataframe has repeated column names (int)

```python
pd.concat([  # One dataframe has repeated column names
    pd.DataFrame(np.ones((4, 4)), columns=[1, 1, 2, 3]),
    pd.DataFrame(np.ones((4, 3)), columns=[1, 2, 3]),
)
```

This PR

```pytb
InvalidIndexError: Reindexing only valid with uniquely valued Index objects
```

Pandas v1.1.5

```pytb
ValueError: Plan shapes are not aligned
```

pandas 1.2.0rc1

```pytb
ValueError: Plan shapes are not aligned
```


--------------------------

# Repeated columns (same amount) different column ordering

```python
pd.concat([
    pd.DataFrame(np.ones((2, 4)), columns=list("aabc")),
    pd.DataFrame(np.ones((2, 4)), columns=list("abca")),
])
``` 

This PR:

```pytb
InvalidIndexError: Reindexing only valid with uniquely valued Index objects
```

In pandas v1.15

```pytb
AssertionError: Number of manager items must equal union of block items
# manager items: 3, # tot_items: 4
```

In pandas v1.2.0rc1

```pytb
AssertionError: Number of manager items must equal union of block items
# manager items: 3, # tot_items: 4
```

----------------------------

# Repeated columns of different values in each

This point is what the reverted PR was trying to fix. This demonstrates that it didn't seem to fix what it set out to, and that the intended fix introduced strange behaviour anyways. To do this, I'll use the reverted test case.

```python
# Test case from previous PR
a_int = pd.DataFrame([1, 2, 3, 4], index=[0, 1, 1, 4], columns=["a"])
b_int = pd.DataFrame([6, 7, 8, 9], index=[0, 0, 1, 3], columns=["b"])

# Same, but with string indexes
a_str = a_int.set_index(letters[a_int.index])
b_str = b_int.set_index(letters[b_int.index])
```

## Int index

```python
pd.concat([a_int, b_int], axis=1)
```

This PR

```pytb
InvalidIndexError: Reindexing only valid with uniquely valued Index objects
```

Pandas v1.1.5

```pytb
ValueError: Shape of passed values is (8, 2), indices imply (6, 2)
```

pandas 1.2.0rc1

```pytb
     a    b
0  1.0  6.0
0  1.0  7.0
1  2.0  8.0
1  3.0  8.0
3  NaN  9.0
4  4.0  NaN
```

<details>
<summary> This behaviour is a bit strange </summary>

First, the `concat` documentation [defines the options here as set operations, like intersect and union](https://pandas.pydata.org/docs/user_guide/merging.html#concatenating-objects). Is this a union, or is this an outer join?

If these are joins, then inner joins only seem to work when they are equivalent to intersections:

```python
>>> pd.concat([a_int, b_int], axis=1, join="inner")
...
ValueError: Shape of passed values is (3, 2), indices imply (2, 2)

>>> pd.merge(a_int, b_int, how="inner", left_index=True, right_index=True)
   a  b
0  1  6
0  1  7
1  2  8
1  3  8
```

</details>


## str index

This is mostly just to show the behaviour in 1.2.0rc1 is different for string and int indices

```python
pd.concat([a_str, b_str], axis=1)
```

This PR

```pytb
InvalidIndexError: Reindexing only valid with uniquely valued Index objects
```

Pandas v1.1.5

```pytb
ValueError: Shape of passed values is (5, 2), indices imply (4, 2)
```

pandas 1.2.0rc1

```pytb
ValueError: Shape of passed values is (5, 2), indices imply (4, 2)
```
