### PR TITLE
TST: Inconsistent behavior of .replace() in Int64 series with NA 

### DIFF
--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -208,11 +208,15 @@ class TestSeriesReplace:
         expected = pd.Series(["yes", False, "yes"])
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.parametrize("dtype", ["Int8", "Int16", "Int32", "Int64"])
-    def test_replace_Int_with_na(self, dtype):
+    def test_replace_Int_with_na(self):
         # GH 38267
-        result = pd.Series([0, None], dtype=dtype).replace(0, pd.NA)
-        expected = pd.Series([pd.NA, pd.NA], dtype=dtype)
+        from pandas.conftest import any_nullable_int_dtype
+        result = pd.Series([0, None], dtype=any_nullable_int_dtype).replace(0, pd.NA)
+        expected = pd.Series([pd.NA, pd.NA], dtype=any_nullable_int_dtype)
+        tm.assert_series_equal(result, expected)
+        
+        result = pd.Series([0, 1], dtype=any_nullable_int_dtype).replace(0, pd.NA)
+        expected = pd.Series([pd.NA, 1], dtype=any_nullable_int_dtype)
         tm.assert_series_equal(result, expected)
 
     def test_replace2(self):

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -210,10 +210,9 @@ class TestSeriesReplace:
 
     @pytest.mark.parametrize('dtype', ['int8', 'int16', 'int32', 'int64'])
     def test_replace_int_with_na(self, dtype):
-        result = pd.Series([0, None]).astype(dtype)
-        result.replace(0, pd.NA)
-        expected = pd.Series([0, None]).astype(dtype)
-        expected.fillna(0).replace(0, pd.NA)
+        # GH 38267
+        result = pd.Series([0, None]).astype(dtype).replace(0, pd.NA)
+        expected = pd.Series([0, None]).astype(dtype).fillna(0).replace(0, pd.NA)
         tm.assert_series_equal(result, expected)
 
     def test_replace2(self):

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -209,10 +209,10 @@ class TestSeriesReplace:
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("dtype", ["Int8", "Int16", "Int32", "Int64"])
-    def test_replace_int_with_na(self, dtype):
+    def test_replace_Int_with_na(self, dtype):
         # GH 38267
-        result = pd.Series([0, None]).astype(dtype).replace(0, pd.NA)
-        expected = pd.Series([pd.NA, pd.NA])
+        result = pd.Series([0, None], dtype=dtype).replace(0, pd.NA)
+        expected = pd.Series([pd.NA, pd.NA], dtype=dtype)
         tm.assert_series_equal(result, expected)
 
     def test_replace2(self):

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -208,12 +208,12 @@ class TestSeriesReplace:
         expected = pd.Series(["yes", False, "yes"])
         tm.assert_series_equal(result, expected)
 
-    def test_replace_Int_with_na(self):
+    def test_replace_Int_with_na(self, any_nullable_int_dtype):
         # GH 38267
-        result = pd.Series([0, None], dtype=pd.conftest.any_nullable_int_dtype).replace(0, pd.NA)
-        expected = pd.Series([pd.NA, pd.NA], dtype=pd.conftest.any_nullable_int_dtype)
+        result = pd.Series([0, None], dtype=any_nullable_int_dtype).replace(0, pd.NA)
+        expected = pd.Series([pd.NA, pd.NA], dtype=any_nullable_int_dtype)
         tm.assert_series_equal(result, expected)
-        result = pd.Series([0, 1], dtype=pd.conftest.any_nullable_int_dtype).replace(0, pd.NA).replace(1, pd.NA)
+        result = pd.Series([0, 1], dtype=any_nullable_int_dtype).replace(0, pd.NA).replace(1, pd.NA)
         tm.assert_series_equal(result, expected)
 
     def test_replace2(self):

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -211,8 +211,9 @@ class TestSeriesReplace:
     @pytest.mark.parametrize("dtype", ["int8", "int16", "int32", "int64"])
     def test_replace_int_with_na(self, dtype):
         # GH 38267
-        result = pd.Series([0, None]).astype(dtype).replace(0, pd.NA)
-        expected = pd.Series([0, None]).astype(dtype).fillna(0).replace(0, pd.NA)
+        s = pd.Series([0, None]).astype(dtype)
+        result = s.replace(0, pd.NA)
+        expected = s.fillna(0).replace(0, pd.NA)
         tm.assert_series_equal(result, expected)
 
     def test_replace2(self):

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -210,13 +210,10 @@ class TestSeriesReplace:
 
     def test_replace_Int_with_na(self):
         # GH 38267
-        from pandas.conftest import any_nullable_int_dtype
-        result = pd.Series([0, None], dtype=any_nullable_int_dtype).replace(0, pd.NA)
-        expected = pd.Series([pd.NA, pd.NA], dtype=any_nullable_int_dtype)
+        result = pd.Series([0, None], dtype=pd.conftest.any_nullable_int_dtype).replace(0, pd.NA)
+        expected = pd.Series([pd.NA, pd.NA], dtype=pd.conftest.any_nullable_int_dtype)
         tm.assert_series_equal(result, expected)
-        
-        result = pd.Series([0, 1], dtype=any_nullable_int_dtype).replace(0, pd.NA)
-        expected = pd.Series([pd.NA, 1], dtype=any_nullable_int_dtype)
+        result = pd.Series([0, 1], dtype=pd.conftest.any_nullable_int_dtype).replace(0, pd.NA).replace(1, pd.NA)
         tm.assert_series_equal(result, expected)
 
     def test_replace2(self):

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -208,7 +208,7 @@ class TestSeriesReplace:
         expected = pd.Series(["yes", False, "yes"])
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.parametrize('dtype', ['int8', 'int16', 'int32', 'int64'])
+    @pytest.mark.parametrize("dtype", ["int8", "int16", "int32", "int64"])
     def test_replace_int_with_na(self, dtype):
         # GH 38267
         result = pd.Series([0, None]).astype(dtype).replace(0, pd.NA)

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -211,9 +211,8 @@ class TestSeriesReplace:
     @pytest.mark.parametrize("dtype", ["int8", "int16", "int32", "int64"])
     def test_replace_int_with_na(self, dtype):
         # GH 38267
-        s = pd.Series([0, None]).astype(dtype)
-        result = s.replace(0, pd.NA)
-        expected = s.fillna(0).replace(0, pd.NA)
+        result = pd.Series([0, None]).astype(dtype).replace(0, pd.NA)
+        expected = pd.Series([pd.NA, pd.NA])
         tm.assert_series_equal(result, expected)
 
     def test_replace2(self):

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -208,7 +208,7 @@ class TestSeriesReplace:
         expected = pd.Series(["yes", False, "yes"])
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.parametrize("dtype", ["int8", "int16", "int32", "int64"])
+    @pytest.mark.parametrize("dtype", ["Int8", "Int16", "Int32", "Int64"])
     def test_replace_int_with_na(self, dtype):
         # GH 38267
         result = pd.Series([0, None]).astype(dtype).replace(0, pd.NA)

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -213,7 +213,11 @@ class TestSeriesReplace:
         result = pd.Series([0, None], dtype=any_nullable_int_dtype).replace(0, pd.NA)
         expected = pd.Series([pd.NA, pd.NA], dtype=any_nullable_int_dtype)
         tm.assert_series_equal(result, expected)
-        result = pd.Series([0, 1], dtype=any_nullable_int_dtype).replace(0, pd.NA).replace(1, pd.NA)
+        result = (
++            pd.Series([0, 1], dtype=any_nullable_int_dtype)
++            .replace(0, pd.NA)
++            .replace(1, pd.NA)
++        )
         tm.assert_series_equal(result, expected)
 
     def test_replace2(self):

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -213,11 +213,8 @@ class TestSeriesReplace:
         result = pd.Series([0, None], dtype=any_nullable_int_dtype).replace(0, pd.NA)
         expected = pd.Series([pd.NA, pd.NA], dtype=any_nullable_int_dtype)
         tm.assert_series_equal(result, expected)
-        result = (
-+            pd.Series([0, 1], dtype=any_nullable_int_dtype)
-+            .replace(0, pd.NA)
-+            .replace(1, pd.NA)
-+        )
+        result = pd.Series([0, 1], dtype=any_nullable_int_dtype).replace(0, pd.NA)
+        result.replace(1, pd.NA, inplace=True)
         tm.assert_series_equal(result, expected)
 
     def test_replace2(self):

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -210,7 +210,7 @@ class TestSeriesReplace:
 
     @pytest.mark.parametrize('dtype', ['int8', 'int16', 'int32', 'int64'])
     def test_replace_int_with_na(self, dtype):
-        result = pd.Series([0, 1]).astype(dtype)
+        result = pd.Series([0, None]).astype(dtype)
         result.replace(0, pd.NA)
         expected = pd.Series([0, None]).astype(dtype)
         expected.fillna(0).replace(0, pd.NA)

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -208,6 +208,14 @@ class TestSeriesReplace:
         expected = pd.Series(["yes", False, "yes"])
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize('dtype', ['int8', 'int16', 'int32', 'int64'])
+    def test_replace_int_with_na(self, dtype):
+        result = pd.Series([0, 1]).astype(dtype)
+        result.replace(0, pd.NA)
+        expected = pd.Series([0, None]).astype(dtype)
+        expected.fillna(0).replace(0, pd.NA)
+        tm.assert_series_equal(result, expected)
+
     def test_replace2(self):
         N = 100
         ser = pd.Series(np.fabs(np.random.randn(N)), tm.makeDateIndex(N), dtype=object)


### PR DESCRIPTION
- [ ] closes #38267
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
