### PR TITLE
TST: Add match=msg to all pytest.raises in pandas/tests/io/json

### DIFF
--- a/pandas/tests/io/json/test_json_table_schema.py
+++ b/pandas/tests/io/json/test_json_table_schema.py
@@ -439,7 +439,11 @@ class TestTableOrient:
         "ignore:an integer is required (got type float)*:DeprecationWarning"
     )
     def test_date_format_raises(self):
-        with pytest.raises(ValueError):
+        msg = (
+            "Trying to write with `orient='table'` and `date_format='epoch'`. Table "
+            "Schema requires dates to be formatted with `date_format='iso'`"
+        )
+        with pytest.raises(ValueError, match=msg):
             self.df.to_json(orient="table", date_format="epoch")
 
         # others work

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1264,6 +1264,10 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         with pytest.raises(ValueError, match=msg):
             read_json(json)
 
+        json = StringIO('{"0":{"articleId":' + str(bigNum) + "}}")
+        with pytest.raises(ValueError, match=msg):
+            read_json(json)
+
     def test_read_json_large_numbers2(self):
         # GH18842
         json = '{"articleId": "1404366058080022500245"}'

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -591,7 +591,7 @@ class TestPandasContainer:
 
         # the same with multiple columns threw segfaults
         df_mixed = DataFrame({"A": [binthing], "B": [1]}, columns=["A", "B"])
-        with pytest.raises(OverflowError):
+        with pytest.raises(OverflowError, match=msg):
             df_mixed.to_json()
 
         # default_handler should resolve exceptions for non-string types
@@ -1259,19 +1259,10 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
     def test_read_json_large_numbers(self, bigNum):
         # GH20599
 
-        series = Series(bigNum, dtype=object, index=["articleId"])
-        json = '{"articleId":' + str(bigNum) + "}"
-        with pytest.raises(ValueError):
-            json = StringIO(json)
-            result = read_json(json)
-            tm.assert_series_equal(series, result)
-
-        df = DataFrame(bigNum, dtype=object, index=["articleId"], columns=[0])
-        json = '{"0":{"articleId":' + str(bigNum) + "}}"
-        with pytest.raises(ValueError):
-            json = StringIO(json)
-            result = read_json(json)
-            tm.assert_frame_equal(df, result)
+        json = StringIO('{"articleId":' + str(bigNum) + "}")
+        msg = r"Value is too small|Value is too big"
+        with pytest.raises(ValueError, match=msg):
+            read_json(json)
 
     def test_read_json_large_numbers2(self):
         # GH18842

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -875,8 +875,8 @@ class TestNumpyJSONTests:
         ],
     )
     def test_array_numpy_except(self, bad_input, exc_type, err_msg, kwargs):
-        # with pytest.raises(exc_type, match=re.escape(err_msg)):
-        ujson.decode(ujson.dumps(bad_input), numpy=True, **kwargs)
+        with pytest.raises(exc_type, match=re.escape(err_msg)):
+            ujson.decode(ujson.dumps(bad_input), numpy=True, **kwargs)
 
     def test_array_numpy_labelled(self):
         labelled_input = {"a": []}

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -812,31 +812,71 @@ class TestNumpyJSONTests:
             ujson.encode(np.array(1))
 
     @pytest.mark.parametrize(
-        "bad_input,exc_type,kwargs",
+        "bad_input,exc_type,err_msg,kwargs",
         [
-            ([{}, []], ValueError, {}),
-            ([42, None], TypeError, {}),
-            ([["a"], 42], ValueError, {}),
-            ([42, {}, "a"], TypeError, {}),
-            ([42, ["a"], 42], ValueError, {}),
-            (["a", "b", [], "c"], ValueError, {}),
-            ([{"a": "b"}], ValueError, {"labelled": True}),
-            ({"a": {"b": {"c": 42}}}, ValueError, {"labelled": True}),
-            ([{"a": 42, "b": 23}, {"c": 17}], ValueError, {"labelled": True}),
+            (
+                [{}, []],
+                ValueError,
+                "nesting not supported for object or variable length dtypes",
+                {},
+            ),
+            (
+                [42, None],
+                TypeError,
+                "int() argument must be a string, a bytes-like object or a number, "
+                "not 'NoneType'",
+                {},
+            ),
+            (
+                [["a"], 42],
+                ValueError,
+                "Cannot decode multidimensional arrays with variable length elements "
+                "to numpy",
+                {},
+            ),
+            (
+                [42, {}, "a"],
+                TypeError,
+                "int() argument must be a string, a bytes-like object or a number, "
+                "not 'dict'",
+                {},
+            ),
+            (
+                [42, ["a"], 42],
+                ValueError,
+                "invalid literal for int() with base 10: 'a'",
+                {},
+            ),
+            (
+                ["a", "b", [], "c"],
+                ValueError,
+                "nesting not supported for object or variable length dtypes",
+                {},
+            ),
+            (
+                [{"a": "b"}],
+                ValueError,
+                "Cannot decode multidimensional arrays with variable length elements "
+                "to numpy",
+                {"labelled": True},
+            ),
+            (
+                {"a": {"b": {"c": 42}}},
+                ValueError,
+                "labels only supported up to 2 dimensions",
+                {"labelled": True},
+            ),
+            (
+                [{"a": 42, "b": 23}, {"c": 17}],
+                ValueError,
+                "cannot reshape array of size 3 into shape (2,1)",
+                {"labelled": True},
+            ),
         ],
     )
-    def test_array_numpy_except(self, bad_input, exc_type, kwargs):
-        msg = (
-            "Cannot decode multidimensional arrays with variable length elements to "
-            "numpy|"
-            "argument must be a string, a bytes-like object or a number, not|"
-            "nesting not supported for object or variable length dtypes|"
-            r"invalid literal for int\(\) with base 10|"
-            "labels only supported up to 2 dimensions|"
-            "cannot reshape array of size"
-        )
-        with pytest.raises(exc_type, match=msg):
-            ujson.decode(ujson.dumps(bad_input), numpy=True, **kwargs)
+    def test_array_numpy_except(self, bad_input, exc_type, err_msg, kwargs):
+        # with pytest.raises(exc_type, match=re.escape(err_msg)):
+        ujson.decode(ujson.dumps(bad_input), numpy=True, **kwargs)
 
     def test_array_numpy_labelled(self):
         labelled_input = {"a": []}


### PR DESCRIPTION
This pull request partially addresses xref #30999 to remove bare `pytest.raises` by adding `match=msg`. It doesn't close that issue as I have only addressed test modules in tje pandas/tests/io/json directory.

I also moved a couple of lines out of the `pytest.raises` context to make clear which pandas method was raising the error. And I deleted a couple of unreachable asserts in tests.

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
