### PR TITLE
TST: Remove broken test for deprecated functionality

### DIFF
--- a/pandas/tests/plotting/test_converter.py
+++ b/pandas/tests/plotting/test_converter.py
@@ -54,6 +54,17 @@ def test_timtetonum_accepts_unicode():
 
 
 class TestRegistration:
+    def test_dont_register_by_default(self):
+        # Run in subprocess to ensure a clean state
+        code = (
+            "import matplotlib.units; "
+            "import pandas as pd; "
+            "units = dict(matplotlib.units.registry); "
+            "assert pd.Timestamp not in units"
+        )
+        call = [sys.executable, "-c", code]
+        assert subprocess.check_call(call) == 0
+
     @td.skip_if_no("matplotlib", min_version="3.1.3")
     def test_registering_no_warning(self):
         plt = pytest.importorskip("matplotlib.pyplot")

--- a/pandas/tests/plotting/test_converter.py
+++ b/pandas/tests/plotting/test_converter.py
@@ -54,17 +54,6 @@ def test_timtetonum_accepts_unicode():
 
 
 class TestRegistration:
-    def test_register_by_default(self):
-        # Run in subprocess to ensure a clean state
-        code = (
-            "'import matplotlib.units; "
-            "import pandas as pd; "
-            "units = dict(matplotlib.units.registry); "
-            "assert pd.Timestamp in units)'"
-        )
-        call = [sys.executable, "-c", code]
-        assert subprocess.check_call(call) == 0
-
     @td.skip_if_no("matplotlib", min_version="3.1.3")
     def test_registering_no_warning(self):
         plt = pytest.importorskip("matplotlib.pyplot")


### PR DESCRIPTION
Registering converters by default on import is deprecated since #28722.

The test did not fail as the subprocess call contains errors in the python code. Specifically, the code is in double and single quotes. This means that the python code passed to the subprocess call is never actually excecuted. Python in the subprocess is called to "excecute" a string. This is will simply finish with exit code 0 as there is nothing to do basically.
Additonally, the test code contains a stray closing bracket at the end which would make the code fail if it was excecuted. 

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
