### PR TITLE
CI: pin jedi version<0.18.0

### DIFF
--- a/ci/deps/azure-38-locale.yaml
+++ b/ci/deps/azure-38-locale.yaml
@@ -18,6 +18,7 @@ dependencies:
   - html5lib
   - ipython
   - jinja2
+  - jedi<0.18.0
   - lxml
   - matplotlib <3.3.0
   - moto


### PR DESCRIPTION
... so CI jobs pass.

xref #38703. OP should be kept open until upstream fix comes through.