### PR TITLE
Slicing columns with mixed types <str>,<int> fails with ValueError #20975

### DIFF
--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1645,10 +1645,10 @@ class TestLabelSlicing:
         tm.assert_equal(result, expected)
 
     def test_loc_getitem_slice_columns_mixed_dtype(self):
-        df1 = pd.DataFrame({'test':1, 1:2, 2:3}, index=[0])
-        df2 = pd.DataFrame({1:2, 2:3}, index=[0])
-        breakpoint()
-        tm.assert_equal(df1.loc[:, 1:], df2)
+        # GH: 20975
+        df = pd.DataFrame({'test':1, 1:2, 2:3}, index=[0])
+        expected = pd.DataFrame(data=[[2, 3]], index=[0], columns=Index([1, 2], dtype=object))
+        tm.assert_equal(df.loc[:, 1:], expected)
 
 
 class TestLocBooleanMask:

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1646,8 +1646,8 @@ class TestLabelSlicing:
 
     def test_loc_getitem_slice_columns_mixed_dtype(self):
         # GH: 20975
-        df = pd.DataFrame({'test': 1, 1: 2, 2: 3}, index=[0])
-        expected = pd.DataFrame(data=[[2, 3]], index=[0], columns=Index([1, 2],
+        df = DataFrame({'test': 1, 1: 2, 2: 3}, index=[0])
+        expected = DataFrame(data=[[2, 3]], index=[0], columns=Index([1, 2],
                                 dtype=object))
         tm.assert_equal(df.loc[:, 1:], expected)
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1646,9 +1646,10 @@ class TestLabelSlicing:
 
     def test_loc_getitem_slice_columns_mixed_dtype(self):
         # GH: 20975
-        df = DataFrame({'test': 1, 1: 2, 2: 3}, index=[0])
-        expected = DataFrame(data=[[2, 3]], index=[0], columns=pd.Index([1, 2],
-                                dtype=object))
+        df = DataFrame({"test": 1, 1: 2, 2: 3}, index=[0])
+        expected = DataFrame(
+            data=[[2, 3]], index=[0], columns=pd.Index([1, 2], dtype=object)
+        )
         tm.assert_equal(df.loc[:, 1:], expected)
 
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1647,7 +1647,7 @@ class TestLabelSlicing:
     def test_loc_getitem_slice_columns_mixed_dtype(self):
         # GH: 20975
         df = DataFrame({'test': 1, 1: 2, 2: 3}, index=[0])
-        expected = DataFrame(data=[[2, 3]], index=[0], columns=Index([1, 2],
+        expected = DataFrame(data=[[2, 3]], index=[0], columns=pd.Index([1, 2],
                                 dtype=object))
         tm.assert_equal(df.loc[:, 1:], expected)
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1650,7 +1650,7 @@ class TestLabelSlicing:
         expected = DataFrame(
             data=[[2, 3]], index=[0], columns=pd.Index([1, 2], dtype=object)
         )
-        tm.assert_equal(df.loc[:, 1:], expected)
+        tm.assert_frame_equal(df.loc[:, 1:], expected)
 
 
 class TestLocBooleanMask:

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1644,6 +1644,12 @@ class TestLabelSlicing:
         expected = frame_or_series(range(4), index=[value, "first", 2, "third"])
         tm.assert_equal(result, expected)
 
+    def test_loc_getitem_slice_columns_mixed_dtype(self):
+        df1 = pd.DataFrame({'test':1, 1:2, 2:3}, index=[0])
+        df2 = pd.DataFrame({1:2, 2:3}, index=[0])
+        breakpoint()
+        tm.assert_equal(df1.loc[:, 1:], df2)
+
 
 class TestLocBooleanMask:
     def test_loc_setitem_bool_mask_timedeltaindex(self):

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1648,7 +1648,7 @@ class TestLabelSlicing:
         # GH: 20975
         df = pd.DataFrame({'test': 1, 1: 2, 2: 3}, index=[0])
         expected = pd.DataFrame(data=[[2, 3]], index=[0], columns=Index([1, 2],
-            dtype=object))
+                                dtype=object))
         tm.assert_equal(df.loc[:, 1:], expected)
 
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1646,8 +1646,9 @@ class TestLabelSlicing:
 
     def test_loc_getitem_slice_columns_mixed_dtype(self):
         # GH: 20975
-        df = pd.DataFrame({'test':1, 1:2, 2:3}, index=[0])
-        expected = pd.DataFrame(data=[[2, 3]], index=[0], columns=Index([1, 2], dtype=object))
+        df = pd.DataFrame({'test': 1, 1: 2, 2: 3}, index=[0])
+        expected = pd.DataFrame(data=[[2, 3]], index=[0], columns=Index([1, 2],
+            dtype=object))
         tm.assert_equal(df.loc[:, 1:], expected)
 
 


### PR DESCRIPTION
- [ ] closes #20975 
- [x] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
