### PR TITLE
TST: GH30999 Add match=msg to all pytest.raises in tests/reductions and add an error message to nanmedian

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10351,15 +10351,22 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
                 name, func, axis=0, bool_only=bool_only, skipna=skipna, **kwargs
             )
             return res._logical_func(name, func, skipna=skipna, **kwargs)
-
-        return self._reduce(
-            func,
-            name=name,
-            axis=axis,
-            skipna=skipna,
-            numeric_only=bool_only,
-            filter_type="bool",
-        )
+        try:
+            return self._reduce(
+                func,
+                name=name,
+                axis=axis,
+                skipna=skipna,
+                numeric_only=bool_only,
+                filter_type="bool",
+            )
+        except NotImplementedError as exc:
+            err_msg = str(exc)
+            if err_msg.endswith("does not implement numeric_only."):
+                raise NotImplementedError(
+                    err_msg.replace("numeric_only", "bool_only")
+                ) from exc
+            raise
 
     def any(self, axis=0, bool_only=None, skipna=True, level=None, **kwargs):
         return self._logical_func(

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10351,22 +10351,14 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
                 name, func, axis=0, bool_only=bool_only, skipna=skipna, **kwargs
             )
             return res._logical_func(name, func, skipna=skipna, **kwargs)
-        try:
-            return self._reduce(
-                func,
-                name=name,
-                axis=axis,
-                skipna=skipna,
-                numeric_only=bool_only,
-                filter_type="bool",
-            )
-        except NotImplementedError as exc:
-            err_msg = str(exc)
-            if err_msg.endswith("does not implement numeric_only."):
-                raise NotImplementedError(
-                    err_msg.replace("numeric_only", "bool_only")
-                ) from exc
-            raise
+        return self._reduce(
+            func,
+            name=name,
+            axis=axis,
+            skipna=skipna,
+            numeric_only=bool_only,
+            filter_type="bool",
+        )
 
     def any(self, axis=0, bool_only=None, skipna=True, level=None, **kwargs):
         return self._logical_func(

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10351,6 +10351,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
                 name, func, axis=0, bool_only=bool_only, skipna=skipna, **kwargs
             )
             return res._logical_func(name, func, skipna=skipna, **kwargs)
+
         return self._reduce(
             func,
             name=name,

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -685,7 +685,7 @@ def nanmedian(values, *, axis=None, skipna=True, mask=None):
             values = values.astype("f8")
         except ValueError as err:
             # e.g. "could not convert string to float: 'a'"
-            raise TypeError from err
+            raise TypeError(str(err)) from err
         if mask is not None:
             values[mask] = np.nan
 

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -526,9 +526,17 @@ class TestIndexReductions:
     def test_min_max_categorical(self):
 
         ci = pd.CategoricalIndex(list("aabbca"), categories=list("cab"), ordered=False)
-        with pytest.raises(TypeError):
+        msg = (
+            r"Categorical is not ordered for operation min\n"
+            r"you can use .as_ordered\(\) to change the Categorical to an ordered one\n"
+        )
+        with pytest.raises(TypeError, match=msg):
             ci.min()
-        with pytest.raises(TypeError):
+        msg = (
+            r"Categorical is not ordered for operation max\n"
+            r"you can use .as_ordered\(\) to change the Categorical to an ordered one\n"
+        )
+        with pytest.raises(TypeError, match=msg):
             ci.max()
 
         ci = pd.CategoricalIndex(list("aabbca"), categories=list("cab"), ordered=True)
@@ -880,16 +888,18 @@ class TestSeriesReductions:
         tm.assert_series_equal(s.all(level=0), Series([False, True, False]))
         tm.assert_series_equal(s.any(level=0), Series([False, True, True]))
 
-        # bool_only is not implemented with level option.
-        with pytest.raises(NotImplementedError):
+        msg = "Option bool_only is not implemented with option level"
+        with pytest.raises(NotImplementedError, match=msg):
             s.any(bool_only=True, level=0)
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(NotImplementedError, match=msg):
             s.all(bool_only=True, level=0)
 
         # bool_only is not implemented alone.
-        with pytest.raises(NotImplementedError):
+        msg = "Series.any does not implement numeric_only"
+        with pytest.raises(NotImplementedError, match=msg):
             s.any(bool_only=True)
-        with pytest.raises(NotImplementedError):
+        msg = "Series.all does not implement numeric_only."
+        with pytest.raises(NotImplementedError, match=msg):
             s.all(bool_only=True)
 
     def test_all_any_boolean(self):
@@ -980,13 +990,21 @@ class TestSeriesReductions:
         """
         Cases where ``Series.argmax`` and related should raise an exception
         """
-        with pytest.raises(error_type):
+        msg = (
+            "reduction operation 'argmin' not allowed for this dtype|"
+            "attempt to get argmin of an empty sequence"
+        )
+        with pytest.raises(error_type, match=msg):
             test_input.idxmin()
-        with pytest.raises(error_type):
+        with pytest.raises(error_type, match=msg):
             test_input.idxmin(skipna=False)
-        with pytest.raises(error_type):
+        msg = (
+            "reduction operation 'argmax' not allowed for this dtype|"
+            "attempt to get argmax of an empty sequence"
+        )
+        with pytest.raises(error_type, match=msg):
             test_input.idxmax()
-        with pytest.raises(error_type):
+        with pytest.raises(error_type, match=msg):
             test_input.idxmax(skipna=False)
 
     def test_idxminmax_with_inf(self):

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -895,10 +895,10 @@ class TestSeriesReductions:
             s.all(bool_only=True, level=0)
 
         # bool_only is not implemented alone.
-        msg = "Series.any does not implement numeric_only"
+        msg = "Series.any does not implement bool_only"
         with pytest.raises(NotImplementedError, match=msg):
             s.any(bool_only=True)
-        msg = "Series.all does not implement numeric_only."
+        msg = "Series.all does not implement bool_only."
         with pytest.raises(NotImplementedError, match=msg):
             s.all(bool_only=True)
 

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -895,10 +895,12 @@ class TestSeriesReductions:
             s.all(bool_only=True, level=0)
 
         # bool_only is not implemented alone.
-        msg = "Series.any does not implement bool_only"
+        # TODO GH38810 change this error message to:
+        # "Series.any does not implement bool_only"
+        msg = "Series.any does not implement numeric_only"
         with pytest.raises(NotImplementedError, match=msg):
             s.any(bool_only=True)
-        msg = "Series.all does not implement bool_only."
+        msg = "Series.all does not implement numeric_only."
         with pytest.raises(NotImplementedError, match=msg):
             s.all(bool_only=True)
 

--- a/pandas/tests/reductions/test_stat_reductions.py
+++ b/pandas/tests/reductions/test_stat_reductions.py
@@ -133,18 +133,9 @@ class TestSeriesStatReductions:
                 exp = alternate(s)
                 assert res == exp
 
-            # Series.median(Series('abc'))
             # check on string data
-
-            if name == "prod":
-                with tm.external_error_raised(TypeError):
-                    f(Series(list("abc")))
-            elif name not in ["sum", "min", "max"]:
-                if name == "mean":
-                    msg = "Could not convert abc to numeric"
-                else:
-                    msg = "could not convert string to float"
-                with pytest.raises(TypeError, match=msg):
+            if name not in ["sum", "min", "max"]:
+                with pytest.raises(TypeError, match=None):
                     f(Series(list("abc")))
 
             # Invalid axis.

--- a/pandas/tests/reductions/test_stat_reductions.py
+++ b/pandas/tests/reductions/test_stat_reductions.py
@@ -98,7 +98,8 @@ class TestSeriesStatReductions:
             # mean, idxmax, idxmin, min, and max are valid for dates
             if name not in ["max", "min", "mean", "median", "std"]:
                 ds = Series(pd.date_range("1/1/2001", periods=10))
-                with pytest.raises(TypeError):
+                msg = f"'DatetimeArray' does not implement reduction '{name}'"
+                with pytest.raises(TypeError, match=msg):
                     f(ds)
 
             # skipna or no
@@ -132,13 +133,21 @@ class TestSeriesStatReductions:
                 exp = alternate(s)
                 assert res == exp
 
+            # Series.median(Series('abc'))
             # check on string data
+            msg = (
+                "could not convert string to float|"
+                r"complex\(\) arg is a malformed string|"
+                "can't multiply sequence by non-int of type 'str'|"
+                "Could not convert abc to numeric"
+            )
             if name not in ["sum", "min", "max"]:
-                with pytest.raises(TypeError):
+                with pytest.raises(TypeError, match=msg):
                     f(Series(list("abc")))
 
             # Invalid axis.
-            with pytest.raises(ValueError):
+            msg = "No axis named 1 for object type Series"
+            with pytest.raises(ValueError, match=msg):
                 f(string_series_, axis=1)
 
             # Unimplemented numeric_only parameter.

--- a/pandas/tests/reductions/test_stat_reductions.py
+++ b/pandas/tests/reductions/test_stat_reductions.py
@@ -135,13 +135,15 @@ class TestSeriesStatReductions:
 
             # Series.median(Series('abc'))
             # check on string data
-            msg = (
-                "could not convert string to float|"
-                r"complex\(\) arg is a malformed string|"
-                "can't multiply sequence by non-int of type 'str'|"
-                "Could not convert abc to numeric"
-            )
-            if name not in ["sum", "min", "max"]:
+
+            if name == "prod":
+                with tm.external_error_raised(TypeError):
+                    f(Series(list("abc")))
+            elif name not in ["sum", "min", "max"]:
+                if name == "mean":
+                    msg = "Could not convert abc to numeric"
+                else:
+                    msg = "could not convert string to float"
                 with pytest.raises(TypeError, match=msg):
                     f(Series(list("abc")))
 


### PR DESCRIPTION
This pull request partially addresses xref #30999 to remove bare `pytest.raises` by adding `match=msg`. It doesn't close that issue as I have only addressed test modules in the pandas/tests/reductions directory.

When going through the tests I found one case where the error message was the empty string. I decided that wasn't correct so I modified the `TypeError` to inherit the error message from the `ValueError` it was raising from. This made the error message similar to other messages in the same test.

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
