### PR TITLE
DOC: reference the visualization page from the ecosystem one

### DIFF
--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -90,6 +90,9 @@ Compose is a machine learning tool for labeling data and prediction engineering.
 Visualization
 -------------
 
+While :ref:`pandas has built-in support for data visualization with matplotlib <visualization>`,
+there are a number of other pandas-compatible libraries.
+
 `Altair <https://altair-viz.github.io/>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The link already exists in the other direction, so want to make sure readers who come across the latter understand the built-in option.

- [ ] ~~closes #xxxx~~
- [ ] ~~tests added / passed~~
- [ ] ~~passes `black pandas`~~
- [ ] ~~passes `git diff upstream/master -u -- "*.py" | flake8 --diff`~~
- [ ] ~~whatsnew entry~~
