### PR TITLE
DEPR: Hide deprecated attrs _AXIS_NAMES & _AXIS_NUMBERS

### DIFF
--- a/doc/source/whatsnew/v1.2.1.rst
+++ b/doc/source/whatsnew/v1.2.1.rst
@@ -14,7 +14,7 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
--
+- The deprecated attributes ``_AXIS_NAMES`` and ``_AXIS_NUMBERS`` of :class:`DataFrame` and :class:`Series` will no longer show up in ``dir`` or ``inspect.getmembers`` calls (:issue:`38740`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -178,7 +178,9 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
     ]
     _internal_names_set: Set[str] = set(_internal_names)
     _accessors: Set[str] = set()
-    _hidden_attrs: FrozenSet[str] = frozenset(["get_values", "tshift"])
+    _hidden_attrs: FrozenSet[str] = frozenset(
+        ["_AXIS_NAMES", "_AXIS_NUMBERS", "get_values", "tshift"]
+    )
     _metadata: List[str] = []
     _is_copy = None
     _mgr: BlockManager

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -336,11 +336,14 @@ class TestDataFrameMisc:
         #  raise NotImplementedError
         df = DataFrame()
 
+        with pytest.raises(NotImplementedError, match="Not supported for DataFrames!"):
+            df._constructor_expanddim(np.arange(27).reshape(3, 3, 3))
+
+    def test_inspect_getmembers(self):
+        # GH38740
+        df = DataFrame()
+
         with warnings.catch_warnings(record=True) as wrn:
             inspect.getmembers(df)
 
-        # some versions may give FutureWarning, others DeprecationWarning
         assert not len(wrn)
-
-        with pytest.raises(NotImplementedError, match="Not supported for DataFrames!"):
-            df._constructor_expanddim(np.arange(27).reshape(3, 3, 3))

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -337,12 +337,10 @@ class TestDataFrameMisc:
         df = DataFrame()
 
         with warnings.catch_warnings(record=True) as wrn:
-            # _AXIS_NUMBERS, _AXIS_NAMES lookups
             inspect.getmembers(df)
 
-        # some versions give FutureWarning, others DeprecationWarning
-        assert len(wrn)
-        assert any(x.category in [FutureWarning, DeprecationWarning] for x in wrn)
+        # some versions may give FutureWarning, others DeprecationWarning
+        assert not len(wrn)
 
         with pytest.raises(NotImplementedError, match="Not supported for DataFrames!"):
             df._constructor_expanddim(np.arange(27).reshape(3, 3, 3))

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 import inspect
 import pydoc
-import warnings
 
 import numpy as np
 import pytest
@@ -342,8 +341,5 @@ class TestDataFrameMisc:
     def test_inspect_getmembers(self):
         # GH38740
         df = DataFrame()
-
-        with warnings.catch_warnings(record=True) as wrn:
+        with tm.assert_produces_warning(None):
             inspect.getmembers(df)
-
-        assert not len(wrn)

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -330,7 +330,6 @@ class TestDataFrameMisc:
         result.iloc[key] = 10
         assert obj.iloc[key] == 0
 
-    @skip_if_no("jinja2")
     def test_constructor_expanddim_lookup(self):
         # GH#33628 accessing _constructor_expanddim should not
         #  raise NotImplementedError
@@ -339,6 +338,7 @@ class TestDataFrameMisc:
         with pytest.raises(NotImplementedError, match="Not supported for DataFrames!"):
             df._constructor_expanddim(np.arange(27).reshape(3, 3, 3))
 
+    @skip_if_no("jinja2")
     def test_inspect_getmembers(self):
         # GH38740
         df = DataFrame()


### PR DESCRIPTION
- [x] closes #38722
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Users that do e.g. `[getattr(pd.DataFrame, x) for x in dir(pd.DataFrame())]` or `inspect.getmembers(pd.DataFrame())` currently get an unfriendly deprecation warning. This fixes that by adding `_AXIS_NAMES` & `_AXIS_NUMBERS` to `_hidden_attrs`.

@JSunRae, is it possible for you to add this to your pandas source code and see if this fixes your problem?

xref: #33637