### PR TITLE
[WIP] Test (and more fixes) for duplicate indices with concat

### DIFF
--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -89,6 +89,19 @@ def get_objs_combined_axis(
     Index
     """
     obs_idxes = [obj._get_axis(axis) for obj in objs]
+    if all_indexes_same(obs_idxes):
+        idx = obs_idxes[0]
+        if sort:
+            try:
+                idx = idx.sort_values()
+                copy = False
+            except TypeError:
+                pass
+        if copy:
+            idx = idx.copy()
+        return idx
+    elif not all(idx.is_unique for idx in obs_idxes):
+        raise InvalidIndexError()
     return _get_combined_index(obs_idxes, intersect=intersect, sort=sort, copy=copy)
 
 

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -138,10 +138,13 @@ def _get_combined_index(
     elif len(indexes) == 1 or all_indexes_same(indexes):
         index = indexes[0]
     elif intersect:
+        duplicates = union_indexes(
+            [index[index.duplicated(keep="first")] for index in indexes]
+        )
         index = indexes[0]
         for other in indexes[1:]:
             index = index.intersection(other)
-        if not index.is_unique:
+        if len(duplicates.intersection(index)) > 0:
             raise InvalidIndexError("Duplicated values in intersection of indices.")
     else:
         if not all(idx.is_unique for idx in indexes):

--- a/pandas/tests/reshape/concat/test_concat.py
+++ b/pandas/tests/reshape/concat/test_concat.py
@@ -454,16 +454,14 @@ def test_concat_duplicates_error(index_maker, join):
     # pytest.skip()
     index_unique = index_maker(k=4)
     index_non_unique = index_unique[[0, 0, 1, 2, 3]]
+
+    df_non_unique = pd.DataFrame(
+        np.ones((1, len(index_non_unique))), columns=index_non_unique
+    )
+    df_unique = pd.DataFrame(np.ones((1, len(index_unique))), columns=index_unique)
+
     with pytest.raises(InvalidIndexError):
-        _ = pd.concat(
-            [
-                pd.DataFrame(
-                    np.ones((1, len(index_non_unique))), columns=index_non_unique
-                ),
-                pd.DataFrame(np.ones((1, len(index_unique))), columns=index_unique),
-            ],
-            join=join,
-        )
+        _ = pd.concat([df_non_unique, df_unique], join=join)
 
 
 @pytest.mark.parametrize("pdt", [Series, pd.DataFrame])

--- a/pandas/tests/reshape/concat/test_concat.py
+++ b/pandas/tests/reshape/concat/test_concat.py
@@ -1,6 +1,5 @@
 from collections import abc, deque
 from decimal import Decimal
-from pandas.errors import InvalidIndexError
 from warnings import catch_warnings
 
 import numpy as np
@@ -11,6 +10,7 @@ from pandas import DataFrame, Index, MultiIndex, Series, concat, date_range
 import pandas._testing as tm
 from pandas.core.arrays import SparseArray
 from pandas.core.construction import create_series_with_explicit_dtype
+from pandas.errors import InvalidIndexError
 from pandas.tests.extension.decimal import to_decimal
 
 


### PR DESCRIPTION
- [ ] closes #31308, #36263
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Follow up to #38654, currently WIP.

It's a work in progress because it turns out union and intersection act differently for different index types. `intersection` seems mostly normal, except for `IntervalIndex` #38743), while `union` is sometimes a set union (for `Index`) and sometimes keeps duplicates (for many `Index` subclasses, though order matters sometimes).

This effects `concat` in `get_objs_combined_axis`. Once I figured out where the problems were coming from, I figured I could maybe side step this by adding checks to `get_objs_combined_axis` for equality and uniqueness. All checks pass `reshape` on my machine, but I'm done working on this for the day, so I'll rely on CI to do the checks on the rest of the codebase.

------------------------

This test could be expanded with:

* More types of indexes (there is no `object` index currently)
* Checks for commutativity, i.e. results should have set-equal columns regardless of order
* Interactions with other arguments (`sort`, `axis`?)

TODO:

- [ ] Move test for `concat` where duplicates don't error
- [ ] Decide whether error should be `DuplicateLabelErrors`
- [ ] Have error report which duplicates are used
- [ ] Check that error reports which duplicates are used