### PR TITLE
Revert "TST: Bare pytest raises" in base extension tests

### DIFF
--- a/pandas/tests/arrays/boolean/test_arithmetic.py
+++ b/pandas/tests/arrays/boolean/test_arithmetic.py
@@ -46,7 +46,7 @@ def test_add_mul(left_array, right_array, opname, exp):
 
 
 def test_sub(left_array, right_array):
-    with tm.external_error_raised(TypeError):
+    with pytest.raises(TypeError):
         # numpy points to ^ operator or logical_xor function instead
         left_array - right_array
 
@@ -92,29 +92,13 @@ def test_error_invalid_values(data, all_arithmetic_operators):
     ops = getattr(s, op)
 
     # invalid scalars
-    msg = (
-        "ufunc '\\w+' did not contain a loop with signature matching types|"
-        "ufunc '\\w+' not supported for the input types, and the inputs could "
-        "not be safely coerced to any supported types|"
-        "\\w+ cannot perform the operation \\w+"
-    )
-    with pytest.raises(TypeError, match=msg):
+    with pytest.raises(TypeError):
         ops("foo")
-
-    msg = (
-        "unsupported operand type\\(s\\) for|"
-        "Concatenation operation is not implemented for NumPy arrays"
-    )
-    with pytest.raises(TypeError, match=msg):
+    with pytest.raises(TypeError):
         ops(pd.Timestamp("20180101"))
 
     # invalid array-likes
     if op not in ("__mul__", "__rmul__"):
         # TODO(extension) numpy's mul with object array sees booleans as numbers
-        msg = (
-            "unsupported operand type\\(s\\) for|"
-            'can only concatenate str \\(not "bool"\\) to str|'
-            "not all arguments converted during string formatting"
-        )
-        with pytest.raises(TypeError, match=msg):
+        with pytest.raises(TypeError):
             ops(pd.Series("foo", index=s.index))

--- a/pandas/tests/extension/base/ops.py
+++ b/pandas/tests/extension/base/ops.py
@@ -30,17 +30,7 @@ class BaseOpsUtil(BaseExtensionTests):
                 expected = s.combine(other, op)
                 self.assert_series_equal(result, expected)
         else:
-            msg = (
-                "unsupported operand type\\(s\\) for|"
-                "cannot perform [\\w_]+ with this index type: [\\w_]+|"
-                "Object with dtype category cannot perform the numpy op [\\w_]+|"
-                "cannot add [\\w_]+ and [\\w_]+|"
-                "can't multiply sequence by non-int of type '[\\w_]+'|"
-                'can only concatenate str \\(not "[\\w_]+"\\) to str|'
-                "Object with dtype category cannot perform the numpy op [\\w_]+|"
-                "Concatenation operation is not implemented for NumPy arrays"
-            )
-            with pytest.raises(exc, match=msg):
+            with pytest.raises(exc):
                 op(s, other)
 
     def _check_divmod_op(self, s, op, other, exc=Exception):
@@ -54,12 +44,7 @@ class BaseOpsUtil(BaseExtensionTests):
             self.assert_series_equal(result_div, expected_div)
             self.assert_series_equal(result_mod, expected_mod)
         else:
-            msg = (
-                "'tuple' object has no attribute 'dtype'|"
-                "cannot perform __r?divmod__ with this index type|"
-                "unsupported operand type\\(s\\) for divmod\\(\\)"
-            )
-            with pytest.raises(exc, match=msg):
+            with pytest.raises(exc):
                 divmod(s, other)
 
 
@@ -126,8 +111,7 @@ class BaseArithmeticOpsTests(BaseOpsUtil):
     def test_error(self, data, all_arithmetic_operators):
         # invalid ops
         op_name = all_arithmetic_operators
-        msg = "'[\\w_]+' object has no attribute '[\\w_]+'"
-        with pytest.raises(AttributeError, match=msg):
+        with pytest.raises(AttributeError):
             getattr(data, op_name)
 
     @pytest.mark.parametrize("box", [pd.Series, pd.DataFrame])
@@ -161,8 +145,7 @@ class BaseComparisonOpsTests(BaseOpsUtil):
 
             # series
             s = pd.Series(data)
-            msg = "not supported between instances of '[\\w._]+' and '[\\w._]+'"
-            with pytest.raises(TypeError, match=msg):
+            with pytest.raises(TypeError):
                 op(s, other)
 
     def test_compare_scalar(self, data, all_compare_operators):

--- a/pandas/tests/extension/base/setitem.py
+++ b/pandas/tests/extension/base/setitem.py
@@ -282,25 +282,8 @@ class BaseSetitemTests(BaseExtensionTests):
         self.assert_equal(result, expected)
 
     def test_setitem_slice_mismatch_length_raises(self, data):
-        # This class is a test mixin class, based on which test class it's mixed
-        # with the expected error messages can vary. This regular expression
-        # catches all the variants of those messages. It's formatted as a big OR
-        # statement: /m1|m2|m3|m4/
-
-        msg = (
-            # pandas.core.arrays.period.PeriodArray
-            # pandas.core.arrays.datetimes.DatetimeArray
-            "cannot set using a slice indexer with a different length than the value|"
-            # string_arrow.ArrowStringArray
-            "Length of indexer and values mismatch|"
-            # pandas.tests.extension.decimal.array.DecimalArray
-            "cannot copy sequence with size \\d to array axis with dimension \\d|"
-            # All the rest
-            "could not broadcast input array from "
-            "shape \\(\\d,?\\) into shape \\(\\d,?\\)"
-        )
         arr = data[:5]
-        with pytest.raises(ValueError, match=msg):
+        with pytest.raises(ValueError):
             arr[:1] = arr[:2]
 
     def test_setitem_slice_array(self, data):
@@ -309,17 +292,8 @@ class BaseSetitemTests(BaseExtensionTests):
         self.assert_extension_array_equal(arr, data[-5:])
 
     def test_setitem_scalar_key_sequence_raise(self, data):
-        # Check the comment on test_setitem_slice_mismatch_length_raises for more info.
-        msg = (
-            # pandas.core.arrays.string_arrow.ArrowStringArray
-            "Must pass scalars with scalar indexer|"
-            # pandas.core.arrays.datetimes.DatetimeArray
-            "Could not convert object to NumPy datetime|"
-            # All the rest
-            "setting an array element with a sequence"
-        )
         arr = data[:5].copy()
-        with pytest.raises(ValueError, match=msg):
+        with pytest.raises(ValueError):
             arr[0] = arr[[0, 1]]
 
     def test_setitem_preserves_views(self, data):

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -292,22 +292,9 @@ def test_series_equal_exact_for_nonnumeric():
     tm.assert_series_equal(s1, s2, check_exact=True)
     tm.assert_series_equal(s2, s1, check_exact=True)
 
-    msg = """Series are different
-
-Series values are different \\(100\\.0 %\\)
-\\[index\\]: \\[0, 1\\]
-\\[left\\]:  \\[a, b\\]
-\\[right\\]: \\[b, a\\]"""
-    with pytest.raises(AssertionError, match=msg):
+    with pytest.raises(AssertionError):
         tm.assert_series_equal(s1, s3, check_exact=True)
-
-    msg = """Series are different
-
-Series values are different \\(100\\.0 %\\)
-\\[index\\]: \\[0, 1\\]
-\\[left\\]:  \\[b, a\\]
-\\[right\\]: \\[a, b\\]"""
-    with pytest.raises(AssertionError, match=msg):
+    with pytest.raises(AssertionError):
         tm.assert_series_equal(s3, s1, check_exact=True)
 
 

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -293,6 +293,7 @@ def test_series_equal_exact_for_nonnumeric():
     tm.assert_series_equal(s2, s1, check_exact=True)
 
     msg = """Series are different
+
 Series values are different \\(100\\.0 %\\)
 \\[index\\]: \\[0, 1\\]
 \\[left\\]:  \\[a, b\\]
@@ -301,6 +302,7 @@ Series values are different \\(100\\.0 %\\)
         tm.assert_series_equal(s1, s3, check_exact=True)
 
     msg = """Series are different
+
 Series values are different \\(100\\.0 %\\)
 \\[index\\]: \\[0, 1\\]
 \\[left\\]:  \\[b, a\\]

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -292,9 +292,20 @@ def test_series_equal_exact_for_nonnumeric():
     tm.assert_series_equal(s1, s2, check_exact=True)
     tm.assert_series_equal(s2, s1, check_exact=True)
 
-    with pytest.raises(AssertionError):
+    msg = """Series are different
+Series values are different \\(100\\.0 %\\)
+\\[index\\]: \\[0, 1\\]
+\\[left\\]:  \\[a, b\\]
+\\[right\\]: \\[b, a\\]"""
+    with pytest.raises(AssertionError, match=msg):
         tm.assert_series_equal(s1, s3, check_exact=True)
-    with pytest.raises(AssertionError):
+
+    msg = """Series are different
+Series values are different \\(100\\.0 %\\)
+\\[index\\]: \\[0, 1\\]
+\\[left\\]:  \\[b, a\\]
+\\[right\\]: \\[a, b\\]"""
+    with pytest.raises(AssertionError, match=msg):
         tm.assert_series_equal(s3, s1, check_exact=True)
 
 


### PR DESCRIPTION
Reverts pandas-dev/pandas#38576, see discussion there. We should not add detailed error message asserts, as those tests are also used by external packages, that might have different error messages.