### PR TITLE
Iloc truncates single-column dataframe with extension arrays

### DIFF
--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -874,6 +874,13 @@ class TestiLoc2:
         df.iloc[1] = rhs
         expected = DataFrame({"x": [1, 9], "y": [2.0, 99.0]})
         tm.assert_frame_equal(df, expected)
+    
+    def test_iloc_truncate_data_wrong_axis_single_column(self):
+        # GH30263
+        df = DataFrame({"A": array([1] * 10, dtype="Int64")})
+        df = df.iloc[:, :5]
+        expected = (10, 1)
+        tm.assert_equal(df.shape, expected)
 
 
 class TestILocErrors:

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -877,10 +877,10 @@ class TestiLoc2:
     
     def test_iloc_truncate_data_wrong_axis_single_column(self):
         # GH30263
-        df = DataFrame({"A": array([1] * 10, dtype="Int64")})
+        df = DataFrame({"A": np.array([1] * 10, dtype="Int64")})
         df = df.iloc[:, :5]
-        expected = (10, 1)
-        tm.assert_equal(df.shape, expected)
+        expected = np.array([10, 1])
+        tm.assert_equal(np.array(df.shape), expected)
 
 
 class TestILocErrors:

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -874,10 +874,10 @@ class TestiLoc2:
         df.iloc[1] = rhs
         expected = DataFrame({"x": [1, 9], "y": [2.0, 99.0]})
         tm.assert_frame_equal(df, expected)
-    
+
     def test_iloc_truncate_data_wrong_axis_single_column(self):
         # GH30263
-        df = DataFrame({"A": np.array([1] * 10, dtype="Int64")})
+        df = DataFrame({"A": [1] * 10})
         df = df.iloc[:, :5]
         expected = np.array([10, 1])
         tm.assert_equal(np.array(df.shape), expected)


### PR DESCRIPTION
Added a test to ensure .iloc does not truncate data for a single-column dataframe with an extension array, as discussed in GH30263.

- [ ] closes #30263
- [x ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
