### PR TITLE
TST: use frame_or_series for some tz_localize/tz_convert tests

### DIFF
--- a/pandas/tests/frame/methods/test_tz_convert.py
+++ b/pandas/tests/frame/methods/test_tz_convert.py
@@ -1,24 +1,47 @@
 import numpy as np
 import pytest
 
-from pandas import DataFrame, Index, MultiIndex, date_range
+from pandas import DataFrame, Index, MultiIndex, Series, date_range
 import pandas._testing as tm
 
 
 class TestTZConvert:
-    def test_frame_tz_convert(self):
+    def test_tz_convert(self, frame_or_series):
         rng = date_range("1/1/2011", periods=200, freq="D", tz="US/Eastern")
 
-        df = DataFrame({"a": 1}, index=rng)
-        result = df.tz_convert("Europe/Berlin")
-        expected = DataFrame({"a": 1}, rng.tz_convert("Europe/Berlin"))
-        assert result.index.tz.zone == "Europe/Berlin"
-        tm.assert_frame_equal(result, expected)
+        obj = DataFrame({"a": 1}, index=rng)
+        if frame_or_series is not DataFrame:
+            obj = obj["a"]
 
-        df = df.T
-        result = df.tz_convert("Europe/Berlin", axis=1)
+        result = obj.tz_convert("Europe/Berlin")
+        expected = DataFrame({"a": 1}, rng.tz_convert("Europe/Berlin"))
+        if frame_or_series is not DataFrame:
+            expected = expected["a"]
+
+        assert result.index.tz.zone == "Europe/Berlin"
+        tm.assert_equal(result, expected)
+
+    def test_tz_convert_axis1(self):
+        rng = date_range("1/1/2011", periods=200, freq="D", tz="US/Eastern")
+
+        obj = DataFrame({"a": 1}, index=rng)
+
+        obj = obj.T
+        result = obj.tz_convert("Europe/Berlin", axis=1)
         assert result.columns.tz.zone == "Europe/Berlin"
-        tm.assert_frame_equal(result, expected.T)
+
+        expected = DataFrame({"a": 1}, rng.tz_convert("Europe/Berlin"))
+
+        tm.assert_equal(result, expected.T)
+
+    def test_tz_convert_naive(self, frame_or_series):
+        # can't convert tz-naive
+        rng = date_range("1/1/2011", periods=200, freq="D")
+        ts = Series(1, index=rng)
+        ts = frame_or_series(ts)
+
+        with pytest.raises(TypeError, match="Cannot convert tz-naive"):
+            ts.tz_convert("US/Eastern")
 
     @pytest.mark.parametrize("fn", ["tz_localize", "tz_convert"])
     def test_tz_convert_and_localize(self, fn):

--- a/pandas/tests/frame/methods/test_tz_localize.py
+++ b/pandas/tests/frame/methods/test_tz_localize.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas import DataFrame, date_range
+from pandas import DataFrame, Series, date_range
 import pandas._testing as tm
 
 
@@ -9,19 +9,43 @@ class TestTZLocalize:
     # See also:
     # test_tz_convert_and_localize in test_tz_convert
 
-    def test_frame_tz_localize(self):
+    def test_tz_localize(self, frame_or_series):
+        rng = date_range("1/1/2011", periods=100, freq="H")
+
+        obj = DataFrame({"a": 1}, index=rng)
+        if frame_or_series is not DataFrame:
+            obj = obj["a"]
+
+        result = obj.tz_localize("utc")
+        expected = DataFrame({"a": 1}, rng.tz_localize("UTC"))
+        if frame_or_series is not DataFrame:
+            expected = expected["a"]
+
+        assert result.index.tz.zone == "UTC"
+        tm.assert_equal(result, expected)
+
+    def test_tz_localize_axis1(self):
         rng = date_range("1/1/2011", periods=100, freq="H")
 
         df = DataFrame({"a": 1}, index=rng)
-        result = df.tz_localize("utc")
-        expected = DataFrame({"a": 1}, rng.tz_localize("UTC"))
-        assert result.index.tz.zone == "UTC"
-        tm.assert_frame_equal(result, expected)
 
         df = df.T
         result = df.tz_localize("utc", axis=1)
         assert result.columns.tz.zone == "UTC"
+
+        expected = DataFrame({"a": 1}, rng.tz_localize("UTC"))
+
         tm.assert_frame_equal(result, expected.T)
+
+    def test_tz_localize_naive(self, frame_or_series):
+
+        # Can't localize if already tz-aware
+        rng = date_range("1/1/2011", periods=100, freq="H", tz="utc")
+        ts = Series(1, index=rng)
+        ts = frame_or_series(ts)
+
+        with pytest.raises(TypeError, match="Already tz-aware"):
+            ts.tz_localize("US/Eastern")
 
     @pytest.mark.parametrize("copy", [True, False])
     def test_tz_localize_copy_inplace_mutate(self, copy, frame_or_series):

--- a/pandas/tests/series/methods/test_tz_convert.py
+++ b/pandas/tests/series/methods/test_tz_convert.py
@@ -1,25 +1,10 @@
 import numpy as np
-import pytest
 
-from pandas import DatetimeIndex, Series, date_range
+from pandas import DatetimeIndex, Series
 import pandas._testing as tm
 
 
 class TestTZConvert:
-    def test_series_tz_convert(self):
-        rng = date_range("1/1/2011", periods=200, freq="D", tz="US/Eastern")
-        ts = Series(1, index=rng)
-
-        result = ts.tz_convert("Europe/Berlin")
-        assert result.index.tz.zone == "Europe/Berlin"
-
-        # can't convert tz-naive
-        rng = date_range("1/1/2011", periods=200, freq="D")
-        ts = Series(1, index=rng)
-
-        with pytest.raises(TypeError, match="Cannot convert tz-naive"):
-            ts.tz_convert("US/Eastern")
-
     def test_series_tz_convert_to_utc(self):
         base = DatetimeIndex(["2011-01-01", "2011-01-02", "2011-01-03"], tz="UTC")
         idx1 = base.tz_convert("Asia/Tokyo")[:2]

--- a/pandas/tests/series/methods/test_tz_localize.py
+++ b/pandas/tests/series/methods/test_tz_localize.py
@@ -8,21 +8,6 @@ import pandas._testing as tm
 
 
 class TestTZLocalize:
-    def test_series_tz_localize(self):
-
-        rng = date_range("1/1/2011", periods=100, freq="H")
-        ts = Series(1, index=rng)
-
-        result = ts.tz_localize("utc")
-        assert result.index.tz.zone == "UTC"
-
-        # Can't localize if already tz-aware
-        rng = date_range("1/1/2011", periods=100, freq="H", tz="utc")
-        ts = Series(1, index=rng)
-
-        with pytest.raises(TypeError, match="Already tz-aware"):
-            ts.tz_localize("US/Eastern")
-
     def test_series_tz_localize_ambiguous_bool(self):
         # make sure that we are correctly accepting bool values as ambiguous
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
