### PR TITLE
BUG: inspect.getmembers(Series)

### DIFF
--- a/doc/source/development/extending.rst
+++ b/doc/source/development/extending.rst
@@ -329,21 +329,11 @@ Each data structure has several *constructor properties* for returning a new
 data structure as the result of an operation. By overriding these properties,
 you can retain subclasses through ``pandas`` data manipulations.
 
-There are 3 constructor properties to be defined:
+There are 3 possible constructor properties to be defined on a subclass:
 
-* ``_constructor``: Used when a manipulation result has the same dimensions as the original.
-* ``_constructor_sliced``: Used when a manipulation result has one lower dimension(s) as the original, such as ``DataFrame`` single columns slicing.
-* ``_constructor_expanddim``: Used when a manipulation result has one higher dimension as the original, such as ``Series.to_frame()``.
-
-Following table shows how ``pandas`` data structures define constructor properties by default.
-
-===========================  ======================= =============
-Property Attributes          ``Series``              ``DataFrame``
-===========================  ======================= =============
-``_constructor``             ``Series``              ``DataFrame``
-``_constructor_sliced``      ``NotImplementedError`` ``Series``
-``_constructor_expanddim``   ``DataFrame``           ``NotImplementedError``
-===========================  ======================= =============
+* ``DataFrame/Series._constructor``: Used when a manipulation result has the same (sub-)class as the original.
+* ``DataFrame._constructor_sliced``: Used when a ``DataFrame`` (sub-)class manipulation result should be a ``Series`` (sub-)class.
+* ``Series._constructor_expanddim``: Used when a ``Series`` (sub-)class manipulation result should be a ``DataFrame`` (sub-)class, e.g. ``Series.to_frame()``.
 
 Below example shows how to define ``SubclassedSeries`` and ``SubclassedDataFrame`` overriding constructor properties.
 

--- a/doc/source/development/extending.rst
+++ b/doc/source/development/extending.rst
@@ -331,7 +331,7 @@ you can retain subclasses through ``pandas`` data manipulations.
 
 There are 3 possible constructor properties to be defined on a subclass:
 
-* ``DataFrame/Series._constructor``: Used when a manipulation result has the same (sub-)class as the original.
+* ``DataFrame/Series._constructor``: Used when a manipulation result has the same dimension as the original.
 * ``DataFrame._constructor_sliced``: Used when a ``DataFrame`` (sub-)class manipulation result should be a ``Series`` (sub-)class.
 * ``Series._constructor_expanddim``: Used when a ``Series`` (sub-)class manipulation result should be a ``DataFrame`` (sub-)class, e.g. ``Series.to_frame()``.
 

--- a/doc/source/whatsnew/v1.2.1.rst
+++ b/doc/source/whatsnew/v1.2.1.rst
@@ -135,7 +135,6 @@ Other
 - Bumped minimum fastparquet version to 0.4.0 to avoid ``AttributeError`` from numba (:issue:`38344`)
 - Bumped minimum pymysql version to 0.8.1 to avoid test failures (:issue:`38344`)
 - Fixed build failure on MacOS 11 in Python 3.9.1 (:issue:`38766`)
-- ``inspect.getmembers(Series)`` no longer raises an ``AbstractMethodError`` (:issue:`38782`).
 - Added reference to backwards incompatible ``check_freq`` arg of :func:`testing.assert_frame_equal` and :func:`testing.assert_series_equal` in :ref:`pandas 1.1.0 whats new <whatsnew_110.api_breaking.testing.check_freq>` (:issue:`34050`)
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.2.1.rst
+++ b/doc/source/whatsnew/v1.2.1.rst
@@ -135,6 +135,7 @@ Other
 - Bumped minimum fastparquet version to 0.4.0 to avoid ``AttributeError`` from numba (:issue:`38344`)
 - Bumped minimum pymysql version to 0.8.1 to avoid test failures (:issue:`38344`)
 - Fixed build failure on MacOS 11 in Python 3.9.1 (:issue:`38766`)
+- ``inspect.getmembers(Series)`` no longer raises an ``AbstractMethodError`` (:issue:`38782`).
 - Added reference to backwards incompatible ``check_freq`` arg of :func:`testing.assert_frame_equal` and :func:`testing.assert_series_equal` in :ref:`pandas 1.1.0 whats new <whatsnew_110.api_breaking.testing.check_freq>` (:issue:`34050`)
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -219,7 +219,7 @@ See :ref:`install.dependencies` and :ref:`install.optional_dependencies` for mor
 Other API changes
 ^^^^^^^^^^^^^^^^^
 - Partially initialized :class:`CategoricalDtype` (i.e. those with ``categories=None`` objects will no longer compare as equal to fully initialized dtype objects.
-- Accessing ``_constructor_expanddim`` on a :class:`DataFrame` and ``_constructor_sliced`` on a :class:`Series` now raise an ``AttributeError``. Previously a ``NotImplementedError`` was raised (:issue:`38782`)
+-
 -
 
 .. ---------------------------------------------------------------------------
@@ -449,6 +449,7 @@ Other
 - :meth:`Index.where` behavior now mirrors :meth:`Index.putmask` behavior, i.e. ``index.where(mask, other)`` matches ``index.putmask(~mask, other)`` (:issue:`39412`)
 - Bug in :func:`pandas.testing.assert_series_equal`, :func:`pandas.testing.assert_frame_equal`, :func:`pandas.testing.assert_index_equal` and :func:`pandas.testing.assert_extension_array_equal` incorrectly raising when an attribute has an unrecognized NA type (:issue:`39461`)
 - Bug in :class:`Styler` where ``subset`` arg in methods raised an error for some valid multiindex slices (:issue:`33562`)
+-
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -219,7 +219,7 @@ See :ref:`install.dependencies` and :ref:`install.optional_dependencies` for mor
 Other API changes
 ^^^^^^^^^^^^^^^^^
 - Partially initialized :class:`CategoricalDtype` (i.e. those with ``categories=None`` objects will no longer compare as equal to fully initialized dtype objects.
--
+- Accessing ``_constructor_expanddim`` on a :class:`DataFrame` and ``_constructor_sliced`` on a :class:`Series` now raise an ``AttributeError``. Previously a ``NotImplementedError`` was raised (:issue:`38782`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -445,10 +445,10 @@ Other
 - Bug in :class:`Index` constructor sometimes silently ignorning a specified ``dtype`` (:issue:`38879`)
 - Bug in constructing a :class:`Series` from a list and a :class:`PandasDtype` (:issue:`39357`)
 - Bug in :class:`Styler` which caused CSS to duplicate on multiple renders. (:issue:`39395`)
+- ``inspect.getmembers(Series)`` no longer raises an ``AbstractMethodError`` (:issue:`38782`)
 - :meth:`Index.where` behavior now mirrors :meth:`Index.putmask` behavior, i.e. ``index.where(mask, other)`` matches ``index.putmask(~mask, other)`` (:issue:`39412`)
 - Bug in :func:`pandas.testing.assert_series_equal`, :func:`pandas.testing.assert_frame_equal`, :func:`pandas.testing.assert_index_equal` and :func:`pandas.testing.assert_extension_array_equal` incorrectly raising when an attribute has an unrecognized NA type (:issue:`39461`)
 - Bug in :class:`Styler` where ``subset`` arg in methods raised an error for some valid multiindex slices (:issue:`33562`)
--
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -490,14 +490,13 @@ class DataFrame(NDFrame, OpsMixin):
     _internal_names_set = {"columns", "index"} | NDFrame._internal_names_set
     _typ = "dataframe"
     _HANDLED_TYPES = (Series, Index, ExtensionArray, np.ndarray)
+    _accessors: Set[str] = {"sparse"}
+    _hidden_attrs: FrozenSet[str] = NDFrame._hidden_attrs | frozenset([])
+    _constructor_sliced: Type[Series] = Series
 
     @property
     def _constructor(self) -> Type[DataFrame]:
         return DataFrame
-
-    _constructor_sliced: Type[Series] = Series
-    _hidden_attrs: FrozenSet[str] = NDFrame._hidden_attrs | frozenset([])
-    _accessors: Set[str] = {"sparse"}
 
     @property
     def _constructor_expanddim(self):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -492,20 +492,12 @@ class DataFrame(NDFrame, OpsMixin):
     _HANDLED_TYPES = (Series, Index, ExtensionArray, np.ndarray)
     _accessors: Set[str] = {"sparse"}
     _hidden_attrs: FrozenSet[str] = NDFrame._hidden_attrs | frozenset([])
-    _constructor_sliced: Type[Series] = Series
 
     @property
     def _constructor(self) -> Type[DataFrame]:
         return DataFrame
 
-    @property
-    def _constructor_expanddim(self):
-        # GH#31549 raising NotImplementedError on a property causes trouble
-        #  for `inspect`
-        def constructor(*args, **kwargs):
-            raise NotImplementedError("Not supported for DataFrames!")
-
-        return constructor
+    _constructor_sliced: Type[Series] = Series
 
     # ----------------------------------------------------------------------
     # Constructors

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -375,14 +375,6 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         """
         raise AbstractMethodError(self)
 
-    @property
-    def _constructor_expanddim(self):
-        """
-        Used when a manipulation result has one higher dimension as the
-        original, such as Series.to_frame()
-        """
-        raise NotImplementedError
-
     # ----------------------------------------------------------------------
     # Internals
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -376,14 +376,6 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         raise AbstractMethodError(self)
 
     @property
-    def _constructor_sliced(self):
-        """
-        Used when a manipulation result has one lower dimension(s) as the
-        original, such as DataFrame single columns slicing.
-        """
-        raise AbstractMethodError(self)
-
-    @property
     def _constructor_expanddim(self):
         """
         Used when a manipulation result has one higher dimension as the

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -403,6 +403,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     @property
     def _constructor_expanddim(self) -> Type[DataFrame]:
+        """
+        Used when a manipulation result has one higher dimension as the
+        original, such as Series.to_frame()
+        """
         from pandas.core.frame import DataFrame
 
         return DataFrame

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -321,9 +321,9 @@ class TestDataFrameMisc:
         result.iloc[key] = 10
         assert obj.iloc[key] == 0
 
-    def test_constructor_expanddim_lookup(self):
+    def test_constructor_expanddim(self):
         # GH#33628 accessing _constructor_expanddim should not raise NotImplementedError
-        # GH38782 pandas has no container higher than DatafFame (two-dim), so
+        # GH38782 pandas has no container higher than DataFrame (two-dim), so
         # DataFrame._constructor_expand_dim, doesn't make sense, so is removed.
         df = DataFrame()
 

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -322,11 +322,13 @@ class TestDataFrameMisc:
         assert obj.iloc[key] == 0
 
     def test_constructor_expanddim_lookup(self):
-        # GH#33628 accessing _constructor_expanddim should not
-        #  raise NotImplementedError
+        # GH#33628 accessing _constructor_expanddim should not raise NotImplementedError
+        # GH38782 pandas has no container higher than DatafFame (two-dim), so
+        # DataFrame._constructor_expand_dim, doesn't make sense, so is removed.
         df = DataFrame()
 
-        with pytest.raises(NotImplementedError, match="Not supported for DataFrames!"):
+        msg = "'DataFrame' object has no attribute '_constructor_expanddim'"
+        with pytest.raises(AttributeError, match=msg):
             df._constructor_expanddim(np.arange(27).reshape(3, 3, 3))
 
     @skip_if_no("jinja2")

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -1,11 +1,12 @@
-import pydoc
 import inspect
+import pydoc
 
 import numpy as np
 import pytest
 
-import pandas as pd
 from pandas.util._test_decorators import skip_if_no
+
+import pandas as pd
 from pandas import DataFrame, Index, Series, date_range
 import pandas._testing as tm
 

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -172,7 +172,7 @@ class TestSeriesMisc:
 
     @skip_if_no("jinja2")
     def test_inspect_getmembers(self):
-        # GH38740
+        # GH38782
         ser = Series()
         with tm.assert_produces_warning(None):
             inspect.getmembers(ser)

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -1,9 +1,11 @@
 import pydoc
+import inspect
 
 import numpy as np
 import pytest
 
 import pandas as pd
+from pandas.util._test_decorators import skip_if_no
 from pandas import DataFrame, Index, Series, date_range
 import pandas._testing as tm
 
@@ -167,3 +169,10 @@ class TestSeriesMisc:
         s.attrs["version"] = 1
         result = s + 1
         assert result.attrs == {"version": 1}
+
+    @skip_if_no("jinja2")
+    def test_inspect_getmembers(self):
+        # GH38740
+        ser = Series()
+        with tm.assert_produces_warning(None):
+            inspect.getmembers(ser)


### PR DESCRIPTION
Make `inspect.getmembers(Series)` work, previously raised an `AbstractMethodError`.

xref: #38740

