### PR TITLE
TST: GH30999 Add match=msg to all pytest.raises in pandas/tests/reshape

### DIFF
--- a/pandas/tests/reshape/test_get_dummies.py
+++ b/pandas/tests/reshape/test_get_dummies.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import pytest
 
@@ -30,7 +32,8 @@ class TestGetDummies:
         return dtype
 
     def test_get_dummies_raises_on_dtype_object(self, df):
-        with pytest.raises(ValueError):
+        msg = "dtype=object is not a valid dtype for get_dummies"
+        with pytest.raises(ValueError, match=msg):
             get_dummies(df, dtype="object")
 
     def test_get_dummies_basic(self, sparse, dtype):
@@ -296,11 +299,19 @@ class TestGetDummies:
         tm.assert_frame_equal(result, expected)
 
     def test_dataframe_dummies_prefix_bad_length(self, df, sparse):
-        with pytest.raises(ValueError):
+        msg = re.escape(
+            "Length of 'prefix' (1) did not match the length of the columns being "
+            "encoded (2)"
+        )
+        with pytest.raises(ValueError, match=msg):
             get_dummies(df, prefix=["too few"], sparse=sparse)
 
     def test_dataframe_dummies_prefix_sep_bad_length(self, df, sparse):
-        with pytest.raises(ValueError):
+        msg = re.escape(
+            "Length of 'prefix_sep' (1) did not match the length of the columns being "
+            "encoded (2)"
+        )
+        with pytest.raises(ValueError, match=msg):
             get_dummies(df, prefix_sep=["bad"], sparse=sparse)
 
     def test_dataframe_dummies_prefix_dict(self, sparse):

--- a/pandas/tests/reshape/test_union_categoricals.py
+++ b/pandas/tests/reshape/test_union_categoricals.py
@@ -344,5 +344,6 @@ class TestUnionCategoricals:
         result = union_categoricals([c1, c2])
         tm.assert_categorical_equal(result, expected)
 
-        with pytest.raises(TypeError):
+        msg = "all components to combine must be Categorical"
+        with pytest.raises(TypeError, match=msg):
             union_categoricals([c1, ["a", "b", "c"]])

--- a/pandas/tests/reshape/test_union_categoricals.py
+++ b/pandas/tests/reshape/test_union_categoricals.py
@@ -275,7 +275,8 @@ class TestUnionCategoricals:
 
         c1 = Categorical(["b", "a"], categories=["b", "a", "c"], ordered=True)
         c2 = Categorical(["a", "c"], categories=["b", "a", "c"], ordered=True)
-        with pytest.raises(TypeError):
+        msg = "Cannot use sort_categories=True with ordered Categoricals"
+        with pytest.raises(TypeError, match=msg):
             union_categoricals([c1, c2], sort_categories=True)
 
     def test_union_categoricals_sort_false(self):


### PR DESCRIPTION
This pull request partially addresses xref #30999 to remove bare pytest.raises by adding match=msg. It doesn't close that issue as I have only addressed test modules in the pandas/tests/reshape/ directory.

This one was super simple. Fixed 5 bare pytest.raises and didn't do anything complicated or controversial.

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
