### PR TITLE
BUG: avoid attribute error with pyarrow >=0.16.0 and <1.0.0

### DIFF
--- a/ci/deps/actions-37-locale.yaml
+++ b/ci/deps/actions-37-locale.yaml
@@ -30,7 +30,7 @@ dependencies:
   - openpyxl
   - pandas-gbq
   - google-cloud-bigquery>=1.27.2 # GH 36436
-  - pyarrow>=0.17
+  - pyarrow=0.17 # GH 38803
   - pytables>=3.5.1
   - scipy
   - xarray=0.12.3

--- a/doc/source/whatsnew/v1.2.1.rst
+++ b/doc/source/whatsnew/v1.2.1.rst
@@ -32,6 +32,7 @@ I/O
 
 - Bumped minimum fastparquet version to 0.4.0 to avoid ``AttributeError`` from numba (:issue:`38344`)
 - Bumped minimum pymysql version to 0.8.1 to avoid test failures (:issue:`38344`)
+- Fixed ``AttributeError`` with PyArrow versions [0.16.0, 1.0.0) (:issue:`38801`)
 
 -
 -

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -29,13 +29,12 @@ try:
 except ImportError:
     pa = None
 else:
-    # our min supported version of pyarrow, 0.15.1, does not have a compute
-    # module
-    try:
+    # PyArrow backed StringArrays are available starting at 1.0.0, but this
+    # file is imported from even if pyarrow is < 1.0.0, before pyarrow.compute
+    # and its compute functions existed. GH38801
+    if LooseVersion(pa.__version__) >= "1.0.0":
         import pyarrow.compute as pc
-    except ImportError:
-        pass
-    else:
+
         ARROW_CMP_FUNCS = {
             "eq": pc.equal,
             "ne": pc.not_equal,

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -896,7 +896,7 @@ class TestParquetPyArrow(Base):
         # this use-case sets the resolution to 1 minute
         check_round_trip(df, pa, check_dtype=False)
 
-    @td.skip_if_no("pyarrow", min_version="0.17")
+    @td.skip_if_no("pyarrow", min_version="1.0.0")
     def test_filter_row_groups(self, pa):
         # https://github.com/pandas-dev/pandas/issues/26551
         df = pd.DataFrame({"a": list(range(0, 3))})


### PR DESCRIPTION
Problem: The minimum pyarrow [listed](https://pandas.pydata.org/docs/dev/whatsnew/v1.2.0.html#increased-minimum-versions-for-dependencies) as an optional dependency is 0.15.1.  Pyarrow added the compute module that is imported in the change here with pyarrow [0.16.0](https://github.com/apache/arrow/commit/27dded680e84f1a628de1bddff1f4eb62fbc5887#diff-3d08757408024228c4443730cc3536ab39c9436cd2e4cb63e5da34c69c18962f) but attributes imported by pandas are not available in that module until [1.0.0](https://github.com/apache/arrow/commit/dcd17bf36e0f7b18e8b8f466ed2cb3eb396955d8#diff-3d08757408024228c4443730cc3536ab39c9436cd2e4cb63e5da34c69c18962f) thus anyone using pyarrow [0.16.0, 1.0.0) will get an Attribute error.

This PR adds as try/expect around accessing the attributes such that they are only accessed if available (i.e. pyarrow >=1.0.0)

- [X] closes #38801
- [X] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry
