### PR TITLE
TST: GH30999 add match=msg to all pytest.raises in pandas/tests/window

### DIFF
--- a/pandas/tests/window/moments/test_moments_ewm.py
+++ b/pandas/tests/window/moments/test_moments_ewm.py
@@ -218,11 +218,12 @@ def test_ewma_halflife_arg(series):
     msg = "comass, span, halflife, and alpha are mutually exclusive"
     with pytest.raises(ValueError, match=msg):
         series.ewm(span=20, halflife=50)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=msg):
         series.ewm(com=9.5, halflife=50)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=msg):
         series.ewm(com=9.5, span=20, halflife=50)
-    with pytest.raises(ValueError):
+    msg = "Must pass one of comass, span, halflife, or alpha"
+    with pytest.raises(ValueError, match=msg):
         series.ewm()
 
 

--- a/pandas/tests/window/test_apply.py
+++ b/pandas/tests/window/test_apply.py
@@ -44,7 +44,7 @@ def test_rolling_apply_with_pandas_objects(window):
     expected = df.iloc[2:].reindex_like(df)
     tm.assert_frame_equal(result, expected)
 
-    with pytest.raises(AttributeError):
+    with tm.external_error_raised(AttributeError):
         df.rolling(window).apply(f, raw=True)
 
 


### PR DESCRIPTION
This pull request partially addresses xref #30999 to remove bare `pytest.raises` by adding `match=msg`. It doesn't close that issue as I have only addressed test modules in the pandas/tests/window/ directory.

I have added `match=msg` to 3 instances of `pytest.raises` and converted another to a `tm.external_error_raised`. Nothing complicated or controversial, imo.

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
