### PR TITLE
TST: GH30999 add match=msg to pytest.raises in modules with one simple instance each

### DIFF
--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -131,7 +131,7 @@ def test_is_list_like_recursion():
         inference.is_list_like([])
         foo()
 
-    with pytest.raises(RecursionError):
+    with tm.external_error_raised(RecursionError):
         foo()
 
 

--- a/pandas/tests/libs/test_hashtable.py
+++ b/pandas/tests/libs/test_hashtable.py
@@ -69,9 +69,8 @@ class TestHashTable:
         assert table.get_item(index + 1) == 41
         assert index + 2 not in table
 
-        with pytest.raises(KeyError) as excinfo:
+        with pytest.raises(KeyError, match=str(index + 2)):
             table.get_item(index + 2)
-        assert str(index + 2) in str(excinfo.value)
 
     def test_map(self, table_type, dtype):
         # PyObjectHashTable has no map-method

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -151,7 +151,7 @@ def test_groupby_with_origin():
     count_ts = ts.groupby(simple_grouper).agg("count")
     count_ts = count_ts[middle:end]
     count_ts2 = ts2.groupby(simple_grouper).agg("count")
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError, match="Index are different"):
         tm.assert_index_equal(count_ts.index, count_ts2.index)
 
     # test origin on 1970-01-01 00:00:00


### PR DESCRIPTION
This pull request partially addresses xref #30999 to remove bare pytest.raises by adding match=msg. It doesn't close that issue as I have only addressed the following three modules:

pandas/tests/dtypes/test_inference.py
pandas/tests/libs/test_hashtable.py
pandas/tests/resample/test_resampler_grouper.py

They are scattered around the test directory but each of them only had one instance of a bare pytest.raises which could be fixed with a simple addition of match=msg or change to tm.external_error_raised

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
