### PR TITLE
REGR: groupby.sem with nuisance columns

### DIFF
--- a/doc/source/whatsnew/v1.2.1.rst
+++ b/doc/source/whatsnew/v1.2.1.rst
@@ -20,6 +20,7 @@ Fixed regressions
 - Bug in repr of float-like strings of an ``object`` dtype having trailing 0's truncated after the decimal (:issue:`38708`)
 - Fixed regression in :meth:`DataFrame.groupby()` with :class:`Categorical` grouping column not showing unused categories for ``grouped.indices`` (:issue:`38642`)
 - Fixed regression in :meth:`DataFrame.any` and :meth:`DataFrame.all` not returning a result for tz-aware ``datetime64`` columns (:issue:`38723`)
+- Fixed regression in :meth:`.GroupBy.sem` where non-numeric columns would raise an error instead of being dropped (:issue:`38774`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.2.1.rst
+++ b/doc/source/whatsnew/v1.2.1.rst
@@ -20,7 +20,7 @@ Fixed regressions
 - Bug in repr of float-like strings of an ``object`` dtype having trailing 0's truncated after the decimal (:issue:`38708`)
 - Fixed regression in :meth:`DataFrame.groupby()` with :class:`Categorical` grouping column not showing unused categories for ``grouped.indices`` (:issue:`38642`)
 - Fixed regression in :meth:`DataFrame.any` and :meth:`DataFrame.all` not returning a result for tz-aware ``datetime64`` columns (:issue:`38723`)
-- Fixed regression in :meth:`.GroupBy.sem` where non-numeric columns would raise an error instead of being dropped (:issue:`38774`)
+- Fixed regression in :meth:`.GroupBy.sem` where the presence of non-numeric columns would cause an error instead of being dropped (:issue:`38774`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1620,12 +1620,11 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
         if result.ndim == 1:
             result /= np.sqrt(self.count())
         else:
-            cols = result.columns.get_indexer_for(
-                result.columns.difference(self.exclusions).unique()
-            )
-            result.iloc[:, cols] = result.iloc[:, cols] / np.sqrt(
-                self.count().iloc[:, cols]
-            )
+            cols = result.columns.difference(self.exclusions).unique()
+            counts = self.count()
+            result_ilocs = result.columns.get_indexer_for(cols)
+            count_ilocs = counts.columns.get_indexer_for(cols)
+            result.iloc[:, result_ilocs] /= np.sqrt(counts.iloc[:, count_ilocs])
         return result
 
     @final

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -842,6 +842,14 @@ def test_omit_nuisance(df):
         grouped.agg(lambda x: x.sum(0, numeric_only=False))
 
 
+def test_omit_nuisance_sem(df):
+    # GH 38774 - sem should work with nuisance columns
+    grouped = df.groupby("A")
+    result = grouped.sem()
+    expected = df.loc[:, ["A", "C", "D"]].groupby("A").sem()
+    tm.assert_frame_equal(result, expected)
+
+
 def test_omit_nuisance_python_multiple(three_group):
     grouped = three_group.groupby(["A", "B"])
 


### PR DESCRIPTION
- [x] closes #38774
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

We were using the same integer locs in the result of `std` and `count` when computing the quotient for `sem`. However, `std` will drop nuisance columns and `count` will not.

I could only find two tests involving nuisance columns, and these only test sum/mean. Created #38815 for a followup.