### PR TITLE
MAINT: regex char class improve

### DIFF
--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -1066,7 +1066,7 @@ class TestStringMethods:
         values = Series(["fooBAD__barBAD", np.nan])
 
         # test with compiled regex
-        pat = re.compile(r"BAD[_]*")
+        pat = re.compile(r"BAD_*")
         result = values.str.replace(pat, "", regex=True)
         exp = Series(["foobar", np.nan])
         tm.assert_series_equal(result, exp)
@@ -1095,7 +1095,7 @@ class TestStringMethods:
         # case and flags provided to str.replace will have no effect
         # and will produce warnings
         values = Series(["fooBAD__barBAD__bad", np.nan])
-        pat = re.compile(r"BAD[_]*")
+        pat = re.compile(r"BAD_*")
 
         with pytest.raises(ValueError, match="case and flags cannot be"):
             result = values.str.replace(pat, "", flags=re.IGNORECASE)


### PR DESCRIPTION
* remove superfluous regex character classes
from the codebase (those that contain a single
character incur the overhead of a class with
none of the advantages of a class)

* for more details, see similar change in NumPy:
https://github.com/numpy/numpy/pull/18083

* check performed with some simple [scraping code](https://github.com/tylerjereddy/regex-improve)