### PR TITLE
TST: GH30999 Change all pytest.raises in pandas/tests/indexing to tm.external_error_raised

### DIFF
--- a/pandas/tests/indexing/multiindex/test_partial.py
+++ b/pandas/tests/indexing/multiindex/test_partial.py
@@ -178,9 +178,9 @@ class TestMultiIndexPartial:
         # assert (self.ymd.loc[2000]['A'] == 0).all()
 
         # Pretty sure the second (and maybe even the first) is already wrong.
-        with tm.external_error_raised(KeyError):
+        with pytest.raises(KeyError, match="6"):
             ymd.loc[(2000, 6)]
-        with tm.external_error_raised(KeyError):
+        with pytest.raises(KeyError, match="(2000, 6)"):
             ymd.loc[(2000, 6), 0]
 
     # ---------------------------------------------------------------------

--- a/pandas/tests/indexing/multiindex/test_partial.py
+++ b/pandas/tests/indexing/multiindex/test_partial.py
@@ -178,9 +178,9 @@ class TestMultiIndexPartial:
         # assert (self.ymd.loc[2000]['A'] == 0).all()
 
         # Pretty sure the second (and maybe even the first) is already wrong.
-        with pytest.raises(Exception):
+        with tm.external_error_raised(KeyError):
             ymd.loc[(2000, 6)]
-        with pytest.raises(Exception):
+        with tm.external_error_raised(KeyError):
             ymd.loc[(2000, 6), 0]
 
     # ---------------------------------------------------------------------

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -331,7 +331,8 @@ class TestSetitemCoercion(CoercionBase):
         if exp_dtype is IndexError:
             # float + int -> int
             temp = obj.copy()
-            with tm.external_error_raised(exp_dtype):
+            msg = "index 5 is out of bounds for axis 0 with size 4"
+            with pytest.raises(exp_dtype, match=msg):
                 temp[5] = 5
             mark = pytest.mark.xfail(reason="TODO_GH12747 The result must be float")
             request.node.add_marker(mark)

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -331,7 +331,7 @@ class TestSetitemCoercion(CoercionBase):
         if exp_dtype is IndexError:
             # float + int -> int
             temp = obj.copy()
-            with pytest.raises(exp_dtype):
+            with tm.external_error_raised(exp_dtype):
                 temp[5] = 5
             mark = pytest.mark.xfail(reason="TODO_GH12747 The result must be float")
             request.node.add_marker(mark)


### PR DESCRIPTION
Addresses xref #30999 for pandas/tests/indexing by changing three bare `pytest.raise` instances to `tm.external_error_raised`

This is the last of the simpler PRs for #30999 - after that it gets more complex.

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
