### PR TITLE
BUG: IntervalIndex.intersection returning duplicates

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -226,7 +226,7 @@ Strings
 Interval
 ^^^^^^^^
 - Bug in :meth:`IntervalIndex.intersection` and :meth:`IntervalIndex.symmetric_difference` always returning object-dtype when operating with :class:`CategoricalIndex` (:issue:`38653`, :issue:`38741`)
--
+- Bug in :meth:`IntervalIndex.intersection` returning duplicates when at least one of both Indexes has duplicates which are present in the other (:issue:`38743`)
 -
 
 Indexing

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -40,7 +40,7 @@ from pandas.core.dtypes.common import (
 )
 from pandas.core.dtypes.dtypes import IntervalDtype
 
-from pandas.core.algorithms import take_1d
+from pandas.core.algorithms import take_1d, unique
 from pandas.core.arrays.interval import IntervalArray, _interval_shared_docs
 import pandas.core.common as com
 from pandas.core.indexers import is_valid_positional_slice
@@ -964,6 +964,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
 
         match = (lindexer == rindexer) & (lindexer != -1)
         indexer = lindexer.take(match.nonzero()[0])
+        indexer = unique(indexer)
 
         return self.take(indexer)
 

--- a/pandas/tests/indexes/interval/test_setops.py
+++ b/pandas/tests/indexes/interval/test_setops.py
@@ -78,13 +78,6 @@ class TestIntervalIndex:
         result = index.intersection(other)
         tm.assert_index_equal(result, expected)
 
-        # GH 26225: duplicate element
-        index = IntervalIndex.from_tuples([(1, 2), (1, 2), (2, 3), (3, 4)])
-        other = IntervalIndex.from_tuples([(1, 2), (2, 3)])
-        expected = IntervalIndex.from_tuples([(1, 2), (1, 2), (2, 3)])
-        result = index.intersection(other)
-        tm.assert_index_equal(result, expected)
-
         # GH 26225
         index = IntervalIndex.from_tuples([(0, 3), (0, 2)])
         other = IntervalIndex.from_tuples([(0, 2), (1, 3)])
@@ -116,6 +109,14 @@ class TestIntervalIndex:
 
         other = monotonic_index(300, 314, dtype="uint64", closed=closed)
         result = index.intersection(other, sort=sort)
+        tm.assert_index_equal(result, expected)
+
+    def test_intersection_duplicates(self):
+        # GH#38743
+        index = IntervalIndex.from_tuples([(1, 2), (1, 2), (2, 3), (3, 4)])
+        other = IntervalIndex.from_tuples([(1, 2), (2, 3)])
+        expected = IntervalIndex.from_tuples([(1, 2), (2, 3)])
+        result = index.intersection(other)
         tm.assert_index_equal(result, expected)
 
     def test_difference(self, closed, sort):

--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -466,3 +466,19 @@ def test_setop_with_categorical(index, sort, method):
     result = getattr(index, method)(other[:5], sort=sort)
     expected = getattr(index, method)(index[:5], sort=sort)
     tm.assert_index_equal(result, expected)
+
+
+def test_intersection_duplicates_all_indexes(index):
+    # GH#38743
+    if index.empty:
+        # No duplicates in empty indexes
+        return
+
+    def check_intersection_commutative(left, right):
+        assert left.intersection(right).equals(right.intersection(left))
+
+    idx = index
+    idx_non_unique = idx[[0, 0, 1, 2]]
+
+    check_intersection_commutative(idx, idx_non_unique)
+    assert idx.intersection(idx_non_unique).is_unique


### PR DESCRIPTION
- [x] closes #38743
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Moved the wrong test code into a new test with adjusted behavior
