### PR TITLE
DOC: fix includes

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -68,7 +68,12 @@ extensions = [
     "contributors",  # custom pandas extension
 ]
 
-exclude_patterns = ["**.ipynb_checkpoints"]
+exclude_patterns = [
+    "**.ipynb_checkpoints",
+    # to ensure that include files (partial pages) aren't built, exclude them
+    # https://github.com/sphinx-doc/sphinx/issues/1965#issuecomment-124732907
+    "**/includes/**",
+]
 try:
     import nbconvert
 except ImportError:

--- a/doc/source/getting_started/intro_tutorials/02_read_write.rst
+++ b/doc/source/getting_started/intro_tutorials/02_read_write.rst
@@ -17,7 +17,7 @@
         <ul class="list-group list-group-flush">
             <li class="list-group-item">
 
-.. include:: titanic.rst
+.. include:: includes/titanic.rst
 
 .. raw:: html
 

--- a/doc/source/getting_started/intro_tutorials/03_subset_data.rst
+++ b/doc/source/getting_started/intro_tutorials/03_subset_data.rst
@@ -17,7 +17,7 @@
         <ul class="list-group list-group-flush">
             <li class="list-group-item">
 
-.. include:: titanic.rst
+.. include:: includes/titanic.rst
 
 .. ipython:: python
 

--- a/doc/source/getting_started/intro_tutorials/04_plotting.rst
+++ b/doc/source/getting_started/intro_tutorials/04_plotting.rst
@@ -18,7 +18,7 @@
         <ul class="list-group list-group-flush">
             <li class="list-group-item">
 
-. include:: air_quality_no2.rst
+.. include:: includes/air_quality_no2.rst
 
 .. ipython:: python
 

--- a/doc/source/getting_started/intro_tutorials/05_add_columns.rst
+++ b/doc/source/getting_started/intro_tutorials/05_add_columns.rst
@@ -17,7 +17,7 @@
         <ul class="list-group list-group-flush">
             <li class="list-group-item">
 
-. include:: air_quality_no2.rst
+.. include:: includes/air_quality_no2.rst
 
 .. ipython:: python
 

--- a/doc/source/getting_started/intro_tutorials/06_calculate_statistics.rst
+++ b/doc/source/getting_started/intro_tutorials/06_calculate_statistics.rst
@@ -17,7 +17,7 @@
         <ul class="list-group list-group-flush">
             <li class="list-group-item">
 
-.. include:: titanic.rst
+.. include:: includes/titanic.rst
 
 .. ipython:: python
 

--- a/doc/source/getting_started/intro_tutorials/07_reshape_table_layout.rst
+++ b/doc/source/getting_started/intro_tutorials/07_reshape_table_layout.rst
@@ -17,7 +17,7 @@
         <ul class="list-group list-group-flush">
             <li class="list-group-item">
 
-.. include:: titanic.rst
+.. include:: includes/titanic.rst
 
 .. ipython:: python
 

--- a/doc/source/getting_started/intro_tutorials/10_text_data.rst
+++ b/doc/source/getting_started/intro_tutorials/10_text_data.rst
@@ -16,7 +16,7 @@
         </div>
         <ul class="list-group list-group-flush">
             <li class="list-group-item">
-.. include:: titanic.rst
+.. include:: includes/titanic.rst
 
 .. ipython:: python
 

--- a/doc/source/getting_started/intro_tutorials/includes/air_quality_no2.rst
+++ b/doc/source/getting_started/intro_tutorials/includes/air_quality_no2.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. raw:: html
 
     <div data-toggle="collapse" href="#collapsedata" role="button" aria-expanded="false" aria-controls="collapsedata">

--- a/doc/source/getting_started/intro_tutorials/includes/titanic.rst
+++ b/doc/source/getting_started/intro_tutorials/includes/titanic.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. raw:: html
 
     <div data-toggle="collapse" href="#collapsedata" role="button" aria-expanded="false" aria-controls="collapsedata">


### PR DESCRIPTION
- Added missing `.` to the `.. include`s
- Put the includes in a folder to exclude from Sphinx, to avoid `:orphan:` being written to the HTML

Before:

<img width="1156" alt="Screen_Shot_2020-12-30_at_7_08_52_PM" src="https://user-images.githubusercontent.com/86842/103387595-99de4380-4ad2-11eb-85bf-8ac8da85676a.png">

After:

<img width="1186" alt="Screen Shot 2020-12-30 at 7 07 41 PM" src="https://user-images.githubusercontent.com/86842/103387540-5f74a680-4ad2-11eb-992c-44de074462ff.png">

---

- [ ] ~~closes #xxxx~~
- [ ] tests added / passed
- [ ] ~~passes `black pandas`~~
- [ ] ~~passes `git diff upstream/master -u -- "*.py" | flake8 --diff`~~
- [ ] ~~whatsnew entry~~
