### PR TITLE
Update conf.py to execute imports during pdf building

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -427,7 +427,7 @@ extlinks = {
 
 
 ipython_warning_is_error = False
-ipython_exec_lines = [
+ipython_execlines = [
     "import numpy as np",
     "import pandas as pd",
     # This ensures correct rendering on system with console encoding != utf8


### PR DESCRIPTION
closes #38451

According [https://ipython.readthedocs.io/en/stable/sphinxext.html](), it should be `ipython_execlines` not `ipython_exec_lines`. Should close issue #38451

