### PR TITLE
TST: GH30999 address all bare pytest.raises in pandas/tests/arrays/boolean/test_arithmetic.py

### DIFF
--- a/pandas/tests/arrays/boolean/test_arithmetic.py
+++ b/pandas/tests/arrays/boolean/test_arithmetic.py
@@ -1,5 +1,4 @@
 import operator
-import re
 
 import numpy as np
 import pytest
@@ -101,7 +100,10 @@ def test_error_invalid_values(data, all_arithmetic_operators):
     )
     with pytest.raises(TypeError, match=msg):
         ops("foo")
-    msg = re.escape("unsupported operand type(s) for")
+    msg = (
+        r"unsupported operand type\(s\) for|"
+        "Concatenation operation is not implemented for NumPy arrays"
+    )
     with pytest.raises(TypeError, match=msg):
         ops(pd.Timestamp("20180101"))
 
@@ -110,7 +112,7 @@ def test_error_invalid_values(data, all_arithmetic_operators):
         # TODO(extension) numpy's mul with object array sees booleans as numbers
         msg = (
             r"unsupported operand type\(s\) for|can only concatenate str|"
-            "not all arguments converted during string formatting"
+            "not all arguments converted during string formatting|"
         )
         with pytest.raises(TypeError, match=msg):
             ops(pd.Series("foo", index=s.index))

--- a/pandas/tests/arrays/boolean/test_arithmetic.py
+++ b/pandas/tests/arrays/boolean/test_arithmetic.py
@@ -116,7 +116,7 @@ def test_error_invalid_values(data, all_arithmetic_operators):
         # TODO(extension) numpy's mul with object array sees booleans as numbers
         msg = (
             r"unsupported operand type\(s\) for|can only concatenate str|"
-            "not all arguments converted during string formatting|"
+            "not all arguments converted during string formatting"
         )
         with pytest.raises(TypeError, match=msg):
             ops(pd.Series("foo", index=s.index))

--- a/pandas/tests/arrays/boolean/test_arithmetic.py
+++ b/pandas/tests/arrays/boolean/test_arithmetic.py
@@ -1,5 +1,4 @@
 import operator
-import re
 
 import numpy as np
 import pytest
@@ -47,9 +46,9 @@ def test_add_mul(left_array, right_array, opname, exp):
 
 
 def test_sub(left_array, right_array):
-    msg = re.escape(
-        "numpy boolean subtract, the `-` operator, is not supported, "
-        "use the bitwise_xor, the `^` operator, or the logical_xor function instead."
+    msg = (
+        r"numpy boolean subtract, the `-` operator, is (?:deprecated|not supported), "
+        r"use the bitwise_xor, the `\^` operator, or the logical_xor function instead\."
     )
     with pytest.raises(TypeError, match=msg):
         left_array - right_array

--- a/pandas/tests/arrays/boolean/test_arithmetic.py
+++ b/pandas/tests/arrays/boolean/test_arithmetic.py
@@ -1,4 +1,5 @@
 import operator
+import re
 
 import numpy as np
 import pytest
@@ -46,8 +47,11 @@ def test_add_mul(left_array, right_array, opname, exp):
 
 
 def test_sub(left_array, right_array):
-    with tm.external_error_raised(TypeError):
-        # numpy points to ^ operator or logical_xor function instead
+    msg = re.escape(
+        "numpy boolean subtract, the `-` operator, is not supported, "
+        "use the bitwise_xor, the `^` operator, or the logical_xor function instead."
+    )
+    with pytest.raises(TypeError, match=msg):
         left_array - right_array
 
 


### PR DESCRIPTION
xref #30999 I thought I was done with the simple bare `pytest.raise` instances but I somehow missed this test module. Four instances, three fixed by adding `match` and one by using `tm.external_error_raised` because I believe the error comes from numpy.

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
