### PR TITLE
Fix broken link in docs of DataFrame.to_hdf

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2576,7 +2576,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
         See Also
         --------
-        DataFrame.read_hdf : Read from HDF file.
+        read_hdf : Read from HDF file.
         DataFrame.to_parquet : Write a DataFrame to the binary parquet format.
         DataFrame.to_sql : Write to a sql table.
         DataFrame.to_feather : Write out feather-format for DataFrames.


### PR DESCRIPTION
The link in https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_hdf.html in "See also" seems to be broken. This should fix it.

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
