### PR TITLE
TST: GH30999 address all bare pytest.raises in pandas/tests/series and add EMPTY_STRING_PATTERN to tm

### DIFF
--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -130,6 +130,7 @@ ALL_NUMPY_DTYPES = (
 
 NULL_OBJECTS = [None, np.nan, pd.NaT, float("nan"), pd.NA]
 
+EMPTY_STRING_PATTERN = re.compile("^$")
 
 # set testing_mode
 _testing_mode_warnings = (DeprecationWarning, ResourceWarning)

--- a/pandas/tests/series/apply/test_series_apply.py
+++ b/pandas/tests/series/apply/test_series_apply.py
@@ -454,7 +454,8 @@ class TestSeriesAggregate:
     )
     def test_agg_cython_table_raises(self, series, func, expected):
         # GH21224
-        with pytest.raises(expected):
+        msg = r"[Cc]ould not convert|can't multiply sequence by non-int of type"
+        with pytest.raises(expected, match=msg):
             # e.g. Series('a b'.split()).cumprod() will raise
             series.agg(func)
 
@@ -714,7 +715,7 @@ class TestSeriesMap:
         tm.assert_series_equal(result, exp)
         assert result.dtype == object
 
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(NotImplementedError, match=tm.EMPTY_STRING_PATTERN):
             s.map(lambda x: x, na_action="ignore")
 
     def test_map_datetimetz(self):
@@ -737,7 +738,7 @@ class TestSeriesMap:
         exp = Series(list(range(24)) + [0], name="XX", dtype=np.int64)
         tm.assert_series_equal(result, exp)
 
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(NotImplementedError, match=tm.EMPTY_STRING_PATTERN):
             s.map(lambda x: x, na_action="ignore")
 
         # not vectorized

--- a/pandas/tests/series/test_ufunc.py
+++ b/pandas/tests/series/test_ufunc.py
@@ -300,5 +300,5 @@ def test_outer():
     s = pd.Series([1, 2, 3])
     o = np.array([1, 2, 3])
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match=tm.EMPTY_STRING_PATTERN):
         np.subtract.outer(s, o)


### PR DESCRIPTION
This PR is to address xref #30999 in pandas/tests/series

Three of the four errors raised within `pytest.raises` were for `NotImplementedError` with the empty string as the error message. Rather than individually making a regular expression for the empty string, I added one as a constant to `pandas/_testing/__init__.py` . There are two more similar cases in other modules so I wanted to put it somewhere that all the testing modules import. But if you don't like it I can revert it and instead use an individual empty string pattern in each case.

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
