### PR TITLE
BUG: additional keys in groupby indices when NAs are present

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -283,7 +283,7 @@ Plotting
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
--
+- Bug in :meth:`.GroupBy.indices` would contain non-existent indices when null values were present in the groupby keys (:issue:`9304`)
 -
 
 Reshaping

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -891,9 +891,16 @@ def indices_fast(ndarray index, const int64_t[:] labels, list keys,
     if n == 0:
         return result
 
-    start = 0
-    cur = labels[0]
-    for i in range(1, n):
+    # Start at the first non-null entry
+    j = 0
+    for j in range(0, n):
+        if labels[j] != -1:
+            break
+    assert j != n
+    cur = labels[j]
+    start = j
+
+    for i in range(j+1, n):
         lab = labels[i]
 
         if lab != cur:

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -896,7 +896,8 @@ def indices_fast(ndarray index, const int64_t[:] labels, list keys,
     for j in range(0, n):
         if labels[j] != -1:
             break
-    assert j != n
+    else:
+        raise ValueError("cannot handle all null values")
     cur = labels[j]
     start = j
 

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -888,9 +888,6 @@ def indices_fast(ndarray index, const int64_t[:] labels, list keys,
 
     k = len(keys)
 
-    if n == 0:
-        return result
-
     # Start at the first non-null entry
     j = 0
     for j in range(0, n):

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -897,7 +897,7 @@ def indices_fast(ndarray index, const int64_t[:] labels, list keys,
         if labels[j] != -1:
             break
     else:
-        raise ValueError("cannot handle all null values")
+        return result
     cur = labels[j]
     start = j
 

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -542,8 +542,7 @@ def get_indexer_dict(
 
     group_index = get_group_index(label_list, shape, sort=True, xnull=True)
     if np.all(group_index == -1):
-        # When all keys are nan and dropna=True, indices_fast can't handle this
-        # and the return is empty anyway
+        # Short-circuit, lib.indices_fast will return the same
         return {}
     ngroups = (
         ((group_index.size and group_index.max()) + 1)

--- a/pandas/tests/groupby/test_missing.py
+++ b/pandas/tests/groupby/test_missing.py
@@ -126,3 +126,12 @@ def test_min_count(func, min_count, value):
     result = getattr(df.groupby("a"), func)(min_count=min_count)
     expected = DataFrame({"b": [value], "c": [np.nan]}, index=Index([1], name="a"))
     tm.assert_frame_equal(result, expected)
+
+
+def test_indicies_with_missing():
+    # GH 9304
+    df = pd.DataFrame({"a": [1, 1, np.nan], "b": [2, 3, 4], "c": [5, 6, 7]})
+    g = df.groupby(["a", "b"])
+    result = g.indices
+    expected = {(1.0, 2): np.array([0]), (1.0, 3): np.array([1])}
+    assert result == expected

--- a/pandas/tests/groupby/test_missing.py
+++ b/pandas/tests/groupby/test_missing.py
@@ -130,7 +130,7 @@ def test_min_count(func, min_count, value):
 
 def test_indicies_with_missing():
     # GH 9304
-    df = pd.DataFrame({"a": [1, 1, np.nan], "b": [2, 3, 4], "c": [5, 6, 7]})
+    df = DataFrame({"a": [1, 1, np.nan], "b": [2, 3, 4], "c": [5, 6, 7]})
     g = df.groupby(["a", "b"])
     result = g.indices
     expected = {(1.0, 2): np.array([0]), (1.0, 3): np.array([1])}


### PR DESCRIPTION
- [x] closes #9304
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

`lib.indices_fast` included logic to skip over null values (-1's), but did not include the case where the first index is null. Currently this function is only used in `sorting.get_indexer_dict` where the case of all null group_index is handled separately.