### PR TITLE
TST: GH30999 add match=msg to 2 pytest.raises in pandas/tests/io/json/test_normalize.py

### DIFF
--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -1,4 +1,3 @@
-from contextlib import nullcontext as does_not_raise
 import json
 
 import numpy as np
@@ -170,27 +169,21 @@ class TestJSONNormalize:
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize(
-        "data, record_path, error",
+        "data, record_path, exception_type",
         [
-            ([{"a": 0}, {"a": 1}], None, does_not_raise()),
-            ({"a": [{"a": 0}, {"a": 1}]}, "a", does_not_raise()),
-            (
-                '{"a": [{"a": 0}, {"a": 1}]}',
-                None,
-                pytest.raises(NotImplementedError, match=tm.EMPTY_STRING_PATTERN),
-            ),
-            (
-                None,
-                None,
-                pytest.raises(NotImplementedError, match=tm.EMPTY_STRING_PATTERN),
-            ),
+            ([{"a": 0}, {"a": 1}], None, None),
+            ({"a": [{"a": 0}, {"a": 1}]}, "a", None),
+            ('{"a": [{"a": 0}, {"a": 1}]}', None, NotImplementedError),
+            (None, None, NotImplementedError),
         ],
     )
-    def test_accepted_input(self, data, record_path, error):
-        with error:
+    def test_accepted_input(self, data, record_path, exception_type):
+        if exception_type is not None:
+            with pytest.raises(exception_type, match=tm.EMPTY_STRING_PATTERN):
+                json_normalize(data, record_path=record_path)
+        else:
             result = json_normalize(data, record_path=record_path)
             expected = DataFrame([0, 1], columns=["a"])
-
             tm.assert_frame_equal(result, expected)
 
     def test_simple_normalize_with_separator(self, deep_nested):

--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -174,8 +174,16 @@ class TestJSONNormalize:
         [
             ([{"a": 0}, {"a": 1}], None, does_not_raise()),
             ({"a": [{"a": 0}, {"a": 1}]}, "a", does_not_raise()),
-            ('{"a": [{"a": 0}, {"a": 1}]}', None, pytest.raises(NotImplementedError)),
-            (None, None, pytest.raises(NotImplementedError)),
+            (
+                '{"a": [{"a": 0}, {"a": 1}]}',
+                None,
+                pytest.raises(NotImplementedError, match=tm.EMPTY_STRING_PATTERN),
+            ),
+            (
+                None,
+                None,
+                pytest.raises(NotImplementedError, match=tm.EMPTY_STRING_PATTERN),
+            ),
         ],
     )
     def test_accepted_input(self, data, record_path, error):


### PR DESCRIPTION
xref #30999 for pandas/tests/io/json/test_normalize.py

And with this my work on #30999 is done. Will head over to the issue to explain why I am not fixing the remaining 15 instances of `pytest.raise`

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
