### PR TITLE
REF: Move aggregation into apply

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -129,7 +129,7 @@ class FrameApply(metaclass=abc.ABCMeta):
         else:
             f = func
 
-        self.f = f
+        self.f: Any = f
 
     @property
     def res_columns(self) -> "Index":


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This is a step toward #35725. We can't simply ban agg from not aggregating because it's used by apply for series, dataframe, groupby, resampler, and rolling. There are two other related issues. First, apply, agg, and transform are all doing similar things but with different implementations leading to unintended inconsistencies. Second, we would also like to ban mutation in apply (and presumably agg and transform for the same reasons).

It seems best to me to handle all of these by first combining the implementation into apply, cleaning up and sharing code between the implementations, and then we would be in a good place to ban agg from not aggregating.

This starts the process by moving aggregation.aggregate into apply, but it is only utilized for frames. Once this is done for the remaining objects (series, groupby, resampler, rolling), the rest of the functions in aggregation can be moved into apply as well.