### PR TITLE
TST: strictly xfail mid-test

### DIFF
--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -158,10 +158,12 @@ def test_transform_broadcast(tsframe, ts):
             assert_fp_equal(res.xs(idx), agged[idx])
 
 
-def test_transform_axis_1(transformation_func):
+def test_transform_axis_1(request, transformation_func):
     # GH 36308
     if transformation_func == "tshift":
-        pytest.xfail("tshift is deprecated")
+        request.applymarker(pytest.mark.xfail(reason="tshift is deprecated"))
+    if transformation_func == "fillna":
+        request.applymarker(pytest.mark.xfail(reason="whoops, this works"))
     args = ("ffill",) if transformation_func == "fillna" else ()
 
     df = DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]}, index=["x", "y"])


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Using `pytest.xfail` when a test is running will immediately stop the test and will not xpass if test would otherwise succeed. It doesn't seem to be documented anywhere, but an alternative would be to use the request fixture. In this demo, I've added an xfail that runs successfully, making the test fail (xpass).

If this looks like a good idea, I can make a tracking issue to replace `pytest.xfail` with the method used here.
