### PR TITLE
ENH: Add support to import optional submodule and specify different min_version than default

### DIFF
--- a/pandas/compat/_optional.py
+++ b/pandas/compat/_optional.py
@@ -13,7 +13,7 @@ VERSIONS = {
     "fsspec": "0.7.4",
     "fastparquet": "0.3.2",
     "gcsfs": "0.6.0",
-    "lxml": "4.3.0",
+    "lxml.etree": "4.3.0",
     "matplotlib": "2.2.3",
     "numexpr": "2.6.8",
     "odfpy": "1.3.0",
@@ -40,6 +40,7 @@ VERSIONS = {
 INSTALL_MAPPING = {
     "bs4": "beautifulsoup4",
     "bottleneck": "Bottleneck",
+    "lxml.etree": "lxml",
     "odf": "odfpy",
     "pandas_gbq": "pandas-gbq",
     "sqlalchemy": "SQLAlchemy",
@@ -89,7 +90,7 @@ def import_optional_dependency(
         * ignore: Return the module, even if the version is too old.
           It's expected that users validate the version locally when
           using ``on_version="ignore"`` (see. ``io/html.py``)
-    min_version : Optional[str]
+    min_version : str, default None
         Specify a minimum version that is different from the global pandas
         minimum version required.
     Returns

--- a/pandas/tests/test_optional_dependency.py
+++ b/pandas/tests/test_optional_dependency.py
@@ -33,6 +33,10 @@ def test_bad_version(monkeypatch):
     with pytest.raises(ImportError, match=match):
         import_optional_dependency("fakemodule")
 
+    # Test min_version parameter
+    result = import_optional_dependency("fakemodule", min_version="0.8")
+    assert result is module
+
     with tm.assert_produces_warning(UserWarning):
         result = import_optional_dependency("fakemodule", on_version="warn")
     assert result is None
@@ -40,6 +44,31 @@ def test_bad_version(monkeypatch):
     module.__version__ = "1.0.0"  # exact match is OK
     result = import_optional_dependency("fakemodule")
     assert result is module
+
+
+def test_submodule(monkeypatch):
+    # Create a fake module with a submodule
+    name = "fakemodule"
+    module = types.ModuleType(name)
+    module.__version__ = "0.9.0"
+    sys.modules[name] = module
+    sub_name = "submodule"
+    submodule = types.ModuleType(sub_name)
+    setattr(module, sub_name, submodule)
+    sys.modules[f"{name}.{sub_name}"] = submodule
+    monkeypatch.setitem(VERSIONS, name, "1.0.0")
+
+    match = "Pandas requires .*1.0.0.* of .fakemodule.*'0.9.0'"
+    with pytest.raises(ImportError, match=match):
+        print(import_optional_dependency("fakemodule.submodule"))
+
+    with tm.assert_produces_warning(UserWarning):
+        result = import_optional_dependency("fakemodule.submodule", on_version="warn")
+    assert result is None
+
+    module.__version__ = "1.0.0"  # exact match is OK
+    result = import_optional_dependency("fakemodule.submodule")
+    assert result is submodule
 
 
 def test_no_version_raises(monkeypatch):

--- a/pandas/tests/test_optional_dependency.py
+++ b/pandas/tests/test_optional_dependency.py
@@ -60,7 +60,7 @@ def test_submodule(monkeypatch):
 
     match = "Pandas requires .*1.0.0.* of .fakemodule.*'0.9.0'"
     with pytest.raises(ImportError, match=match):
-        print(import_optional_dependency("fakemodule.submodule"))
+        import_optional_dependency("fakemodule.submodule")
 
     with tm.assert_produces_warning(UserWarning):
         result = import_optional_dependency("fakemodule.submodule", on_version="warn")


### PR DESCRIPTION
- [ ] closes #38888
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

cc @jreback, @arw2019 