### PR TITLE
CLN: Unify number recognition tests for all parsers

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2349,12 +2349,12 @@ class PythonParser(ParserBase):
 
         decimal = re.escape(self.decimal)
         if self.thousands is None:
-            regex = fr"^\-?[0-9]*({decimal}[0-9]*)?([0-9](E|e)\-?[0-9]*)?$"
+            regex = fr"^[\-|\+]?[0-9]*({decimal}[0-9]*)?([0-9]?(E|e)\-?[0-9]+)?$"
         else:
             thousands = re.escape(self.thousands)
             regex = (
-                fr"^\-?([0-9]+{thousands}|[0-9])*({decimal}[0-9]*)?"
-                fr"([0-9](E|e)\-?[0-9]*)?$"
+                fr"^[\-|\+]?([0-9]+{thousands}|[0-9])*({decimal}[0-9]*)?"
+                fr"([0-9]?(E|e)\-?[0-9]+)?$"
             )
         self.num = re.compile(regex)
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2349,11 +2349,11 @@ class PythonParser(ParserBase):
 
         decimal = re.escape(self.decimal)
         if self.thousands is None:
-            regex = fr"^[\-|\+]?[0-9]*({decimal}[0-9]*)?([0-9]?(E|e)\-?[0-9]+)?$"
+            regex = fr"^[\-\+]?[0-9]*({decimal}[0-9]*)?([0-9]?(E|e)\-?[0-9]+)?$"
         else:
             thousands = re.escape(self.thousands)
             regex = (
-                fr"^[\-|\+]?([0-9]+{thousands}|[0-9])*({decimal}[0-9]*)?"
+                fr"^[\-\+]?([0-9]+{thousands}|[0-9])*({decimal}[0-9]*)?"
                 fr"([0-9]?(E|e)\-?[0-9]+)?$"
             )
         self.num = re.compile(regex)

--- a/pandas/tests/io/parser/common/test_decimal.py
+++ b/pandas/tests/io/parser/common/test_decimal.py
@@ -58,3 +58,21 @@ def test_euro_decimal_format(all_parsers):
         columns=["Id", "Number1", "Number2", "Text1", "Text2", "Number3"],
     )
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("thousands", [None, "."])
+@pytest.mark.parametrize(
+    "value",
+    ["e11,2", "1e11,2", "1,2,2", "1,2.1", "1,2e-10e1", "--1,2", "1a.2,1", "1..2,3"],
+)
+def test_decimal_and_exponential_erroneous(all_parsers, thousands, value):
+    # GH#31920
+    data = StringIO(
+        f"""a	b
+    1,1	{value}
+    """
+    )
+    parser = all_parsers
+    result = parser.read_csv(data, "\t", decimal=",", thousands=thousands)
+    expected = DataFrame({"a": [1.1], "b": [value]})
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/parser/common/test_decimal.py
+++ b/pandas/tests/io/parser/common/test_decimal.py
@@ -58,21 +58,3 @@ def test_euro_decimal_format(all_parsers):
         columns=["Id", "Number1", "Number2", "Text1", "Text2", "Number3"],
     )
     tm.assert_frame_equal(result, expected)
-
-
-@pytest.mark.parametrize("thousands", [None, "."])
-@pytest.mark.parametrize(
-    "value",
-    ["e11,2", "1e11,2", "1,2,2", "1,2.1", "1,2e-10e1", "--1,2", "1a.2,1", "1..2,3"],
-)
-def test_decimal_and_exponential_erroneous(all_parsers, thousands, value):
-    # GH#31920
-    data = StringIO(
-        f"""a	b
-    1,1	{value}
-    """
-    )
-    parser = all_parsers
-    result = parser.read_csv(data, "\t", decimal=",", thousands=thousands)
-    expected = DataFrame({"a": [1.1], "b": [value]})
-    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/parser/conftest.py
+++ b/pandas/tests/io/parser/conftest.py
@@ -148,3 +148,48 @@ def encoding_fmt(request):
     Fixture for all possible string formats of a UTF encoding.
     """
     return request.param
+
+
+@pytest.fixture(params=[
+        ("-1,0", -1.0),
+        ("-1,2e0", -1.2),
+        ("-1e0", -1.0),
+        ("+1e0", 1.0),
+        ("+1e+0", 1.0),
+        ("+1e-1", 0.1),
+        ("+,1e1", 1.0),
+        ("+1,e0", 1.0),
+        ("-,1e1", -1.0),
+        ("-1,e0", -1.0),
+        ("0,1", 0.1),
+        ("1,", 1.0),
+        (",1", 0.1),
+        ("-,1", -0.1),
+        ("1_,", 1.0),
+        ("1_234,56", 1234.56),
+        ("1_234,56e0", 1234.56),
+        # negative cases; must not parse as float
+        ("_", "_"),
+        ("-_", "-_"),
+        ("-_1", "-_1"),
+        ("-_1e0", "-_1e0"),
+        ("_1", "_1"),
+        ("_1,", "_1,"),
+        ("_1,_", "_1,_"),
+        ("_1e0", "_1e0"),
+        ("1,2e_1", "1,2e_1"),
+        ("1,2e1_0", "1,2e1_0"),
+        ("1,_2", "1,_2"),
+        (",1__2", ",1__2"),
+        (",1e", ",1e"),
+        ("-,1e", "-,1e"),
+        ("1_000,000_000", "1_000,000_000"),
+        ("1,e1_2", "1,e1_2"),
+    ])
+def numeric_decimal_thousands(request):
+    """
+    Fixture for all numeric formats which should get recognized
+    """
+    return request.param
+
+

--- a/pandas/tests/io/parser/conftest.py
+++ b/pandas/tests/io/parser/conftest.py
@@ -197,7 +197,7 @@ def encoding_fmt(request):
         ("1,2E1", 12.0),
     ]
 )
-def numeric_decimal_thousands(request):
+def numeric_decimal(request):
     """
     Fixture for all numeric formats which should get recognized
     """

--- a/pandas/tests/io/parser/conftest.py
+++ b/pandas/tests/io/parser/conftest.py
@@ -150,7 +150,8 @@ def encoding_fmt(request):
     return request.param
 
 
-@pytest.fixture(params=[
+@pytest.fixture(
+    params=[
         ("-1,0", -1.0),
         ("-1,2e0", -1.2),
         ("-1e0", -1.0),
@@ -185,11 +186,19 @@ def encoding_fmt(request):
         ("-,1e", "-,1e"),
         ("1_000,000_000", "1_000,000_000"),
         ("1,e1_2", "1,e1_2"),
-    ])
+        ("e11,2", "e11,2"),
+        ("1e11,2", "1e11,2"),
+        ("1,2,2", "1,2,2"),
+        ("1,2_1", "1,2_1"),
+        ("1,2e-10e1", "1,2e-10e1"),
+        ("--1,2", "--1,2"),
+        ("1a_2,1", "1a_2,1"),
+        ("1,2E-1", 0.12),
+        ("1,2E1", 12.0),
+    ]
+)
 def numeric_decimal_thousands(request):
     """
     Fixture for all numeric formats which should get recognized
     """
     return request.param
-
-

--- a/pandas/tests/io/parser/conftest.py
+++ b/pandas/tests/io/parser/conftest.py
@@ -199,6 +199,7 @@ def encoding_fmt(request):
 )
 def numeric_decimal(request):
     """
-    Fixture for all numeric formats which should get recognized
+    Fixture for all numeric formats which should get recognized. The first entry
+    represents the value to read while the second represents the expected result.
     """
     return request.param

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -653,25 +653,6 @@ def test_1000_sep_with_decimal(
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.parametrize("float_precision", [None, "legacy", "high", "round_trip"])
-def test_1000_sep_decimal_float_precision(
-    c_parser_only, numeric_decimal_thousands, float_precision
-):
-    # test decimal and thousand sep handling in across 'float_precision'
-    # parsers
-    parser = c_parser_only
-    df = parser.read_csv(
-        StringIO(numeric_decimal_thousands[0]),
-        sep="|",
-        thousands="_",
-        decimal=",",
-        header=None,
-        float_precision=float_precision,
-    )
-    val = df.iloc[0, 0]
-    assert val == numeric_decimal_thousands[1]
-
-
 def test_float_precision_options(c_parser_only):
     # GH 17154, 36228
     parser = c_parser_only

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -654,53 +654,14 @@ def test_1000_sep_with_decimal(
 
 
 @pytest.mark.parametrize("float_precision", [None, "legacy", "high", "round_trip"])
-@pytest.mark.parametrize(
-    "value,expected",
-    [
-        ("-1,0", -1.0),
-        ("-1,2e0", -1.2),
-        ("-1e0", -1.0),
-        ("+1e0", 1.0),
-        ("+1e+0", 1.0),
-        ("+1e-1", 0.1),
-        ("+,1e1", 1.0),
-        ("+1,e0", 1.0),
-        ("-,1e1", -1.0),
-        ("-1,e0", -1.0),
-        ("0,1", 0.1),
-        ("1,", 1.0),
-        (",1", 0.1),
-        ("-,1", -0.1),
-        ("1_,", 1.0),
-        ("1_234,56", 1234.56),
-        ("1_234,56e0", 1234.56),
-        # negative cases; must not parse as float
-        ("_", "_"),
-        ("-_", "-_"),
-        ("-_1", "-_1"),
-        ("-_1e0", "-_1e0"),
-        ("_1", "_1"),
-        ("_1,", "_1,"),
-        ("_1,_", "_1,_"),
-        ("_1e0", "_1e0"),
-        ("1,2e_1", "1,2e_1"),
-        ("1,2e1_0", "1,2e1_0"),
-        ("1,_2", "1,_2"),
-        (",1__2", ",1__2"),
-        (",1e", ",1e"),
-        ("-,1e", "-,1e"),
-        ("1_000,000_000", "1_000,000_000"),
-        ("1,e1_2", "1,e1_2"),
-    ],
-)
 def test_1000_sep_decimal_float_precision(
-    c_parser_only, value, expected, float_precision
+    c_parser_only, numeric_decimal_thousands, float_precision
 ):
     # test decimal and thousand sep handling in across 'float_precision'
     # parsers
     parser = c_parser_only
     df = parser.read_csv(
-        StringIO(value),
+        StringIO(numeric_decimal_thousands[0]),
         sep="|",
         thousands="_",
         decimal=",",
@@ -708,7 +669,7 @@ def test_1000_sep_decimal_float_precision(
         float_precision=float_precision,
     )
     val = df.iloc[0, 0]
-    assert val == expected
+    assert val == numeric_decimal_thousands[1]
 
 
 def test_float_precision_options(c_parser_only):

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -305,23 +305,3 @@ footer
     msg = "Expected 3 fields in line 4, saw 5"
     with pytest.raises(ParserError, match=msg):
         parser.read_csv(StringIO(data), header=1, comment="#", skipfooter=1)
-
-
-@pytest.mark.parametrize("thousands", ["_", None])
-def test_decimal_and_exponential(
-    python_parser_only, numeric_decimal_thousands, thousands
-):
-    # GH#31920
-    parser = python_parser_only
-    value = numeric_decimal_thousands[0]
-    if thousands is None and "_" in value:
-        pytest.skip("Skip test if no thousands sep is defined and sep is in value")
-    df = parser.read_csv(
-        StringIO(value),
-        sep="|",
-        thousands=thousands,
-        decimal=",",
-        header=None,
-    )
-    val = df.iloc[0, 0]
-    assert val == numeric_decimal_thousands[1]

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -307,47 +307,19 @@ footer
         parser.read_csv(StringIO(data), header=1, comment="#", skipfooter=1)
 
 
-@pytest.mark.parametrize("thousands", [None, "."])
-@pytest.mark.parametrize(
-    "value, result_value",
-    [
-        ("1,2", 1.2),
-        ("1,2e-1", 0.12),
-        ("1,2E-1", 0.12),
-        ("1,2e-10", 0.0000000012),
-        ("1,2e1", 12.0),
-        ("1,2E1", 12.0),
-        ("-1,2e-1", -0.12),
-        ("0,2", 0.2),
-        (",2", 0.2),
-    ],
-)
-def test_decimal_and_exponential(python_parser_only, thousands, value, result_value):
+@pytest.mark.parametrize("thousands", ["_", None])
+def test_decimal_and_exponential(python_parser_only, numeric_decimal_thousands, thousands):
     # GH#31920
-    data = StringIO(
-        f"""a	b
-    1,1	{value}
-    """
+    parser = python_parser_only
+    value = numeric_decimal_thousands[0]
+    if thousands is None and "_" in value:
+        pytest.skip("Skip test if no thousands sep is defined and sep is in value")
+    df = parser.read_csv(
+        StringIO(value),
+        sep="|",
+        thousands=thousands,
+        decimal=",",
+        header=None,
     )
-    result = python_parser_only.read_csv(
-        data, "\t", decimal=",", engine="python", thousands=thousands
-    )
-    expected = DataFrame({"a": [1.1], "b": [result_value]})
-    tm.assert_frame_equal(result, expected)
-
-
-@pytest.mark.parametrize("thousands", [None, "."])
-@pytest.mark.parametrize(
-    "value",
-    ["e11,2", "1e11,2", "1,2,2", "1,2.1", "1,2e-10e1", "--1,2", "1a.2,1", "1..2,3"],
-)
-def test_decimal_and_exponential_erroneous(python_parser_only, thousands, value):
-    # GH#31920
-    data = StringIO(
-        f"""a	b
-    1,1	{value}
-    """
-    )
-    result = python_parser_only.read_csv(data, "\t", decimal=",", thousands=thousands)
-    expected = DataFrame({"a": [1.1], "b": [value]})
-    tm.assert_frame_equal(result, expected)
+    val = df.iloc[0, 0]
+    assert val == numeric_decimal_thousands[1]

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -308,7 +308,9 @@ footer
 
 
 @pytest.mark.parametrize("thousands", ["_", None])
-def test_decimal_and_exponential(python_parser_only, numeric_decimal_thousands, thousands):
+def test_decimal_and_exponential(
+    python_parser_only, numeric_decimal_thousands, thousands
+):
     # GH#31920
     parser = python_parser_only
     value = numeric_decimal_thousands[0]


### PR DESCRIPTION
- [x] closes #38926
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

Minor regex improvements.
Is a fixture the right thing to do here? 
