### PR TITLE
TST: strict xfail

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -473,7 +473,7 @@ def index_with_missing(request):
     Fixture for indices with missing values
     """
     if request.param in ["int", "uint", "range", "empty", "repeats"]:
-        pytest.xfail("missing values not supported")
+        pytest.skip("missing values not supported")
     # GH 35538. Use deep copy to avoid illusive bug on np-dev
     # Azure pipeline that writes into indices_dict despite copy
     ind = indices_dict[request.param].copy(deep=True)

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -436,7 +436,20 @@ class TestInsertIndexCoercion(CoercionBase):
         ],
         ids=["datetime64", "datetime64tz"],
     )
-    def test_insert_index_datetimes(self, fill_val, exp_dtype):
+    @pytest.mark.parametrize(
+        "insert_value",
+        [pd.Timestamp("2012-01-01"), pd.Timestamp("2012-01-01", tz="Asia/Tokyo"), 1],
+    )
+    def test_insert_index_datetimes(self, request, fill_val, exp_dtype, insert_value):
+        if not hasattr(insert_value, "tz"):
+            request.node.add_marker(
+                pytest.mark.xfail(reason="ToDo: must coerce to object")
+            )
+        elif fill_val.tz != insert_value.tz:
+            request.node.add_marker(
+                pytest.mark.xfail(reason="GH 37605 - require tz equality?")
+            )
+
         obj = pd.DatetimeIndex(
             ["2011-01-01", "2011-01-02", "2011-01-03", "2011-01-04"], tz=fill_val.tz
         )
@@ -448,23 +461,7 @@ class TestInsertIndexCoercion(CoercionBase):
         )
         self._assert_insert_conversion(obj, fill_val, exp, exp_dtype)
 
-        if fill_val.tz:
-            msg = "Cannot compare tz-naive and tz-aware"
-            with pytest.raises(TypeError, match=msg):
-                obj.insert(1, pd.Timestamp("2012-01-01"))
-
-            msg = "Timezones don't match"
-            with pytest.raises(ValueError, match=msg):
-                obj.insert(1, pd.Timestamp("2012-01-01", tz="Asia/Tokyo"))
-
-        else:
-            msg = "Cannot compare tz-naive and tz-aware"
-            with pytest.raises(TypeError, match=msg):
-                obj.insert(1, pd.Timestamp("2012-01-01", tz="Asia/Tokyo"))
-
-        msg = "value should be a 'Timestamp' or 'NaT'. Got 'int' instead."
-        with pytest.raises(TypeError, match=msg):
-            obj.insert(1, 1)
+        obj.insert(1, insert_value)
 
     def test_insert_index_timedelta64(self):
         obj = pd.TimedeltaIndex(["1 day", "2 day", "3 day", "4 day"])

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -466,8 +466,6 @@ class TestInsertIndexCoercion(CoercionBase):
         with pytest.raises(TypeError, match=msg):
             obj.insert(1, 1)
 
-        pytest.xfail("ToDo: must coerce to object")
-
     def test_insert_index_timedelta64(self):
         obj = pd.TimedeltaIndex(["1 day", "2 day", "3 day", "4 day"])
         assert obj.dtype == "timedelta64[ns]"

--- a/pandas/tests/tseries/offsets/common.py
+++ b/pandas/tests/tseries/offsets/common.py
@@ -98,14 +98,15 @@ class Base:
             klass = klass(value, normalize=normalize)
         return klass
 
-    def test_apply_out_of_range(self, request, tz_naive_fixture):
+    def test_apply_out_of_range(self, tz_naive_fixture):
         tz = tz_naive_fixture
         if self._offset is None:
             return
         if isinstance(tz, tzlocal) and not IS64:
-            request.node.add_marker(
-                pytest.mark.xfail(reason="OverflowError inside tzlocal past 2038")
-            )
+            # request.node.add_marker(
+            #     pytest.mark.xfail(reason="OverflowError inside tzlocal past 2038")
+            # )
+            pass
 
         # try to create an out-of-bounds result timestamp; if we can't create
         # the offset skip
@@ -127,6 +128,8 @@ class Base:
             assert isinstance(result, datetime)
             assert t.tzinfo == result.tzinfo
 
+        except OutOfBoundsDatetime:
+            pass
         except (ValueError, KeyError):
             # we are creating an invalid offset
             # so ignore

--- a/pandas/tests/tseries/offsets/common.py
+++ b/pandas/tests/tseries/offsets/common.py
@@ -98,15 +98,14 @@ class Base:
             klass = klass(value, normalize=normalize)
         return klass
 
-    def test_apply_out_of_range(self, tz_naive_fixture):
+    def test_apply_out_of_range(self, request, tz_naive_fixture):
         tz = tz_naive_fixture
         if self._offset is None:
             return
         if isinstance(tz, tzlocal) and not IS64:
-            # request.node.add_marker(
-            #     pytest.mark.xfail(reason="OverflowError inside tzlocal past 2038")
-            # )
-            pass
+            request.node.add_marker(
+                pytest.mark.xfail(reason="OverflowError inside tzlocal past 2038")
+            )
 
         # try to create an out-of-bounds result timestamp; if we can't create
         # the offset skip
@@ -116,7 +115,7 @@ class Base:
                 # difference
                 offset = self._get_offset(self._offset, value=100000)
             else:
-                offset = self._get_offset(self._offset, value=10000)
+                offset = self._get_offset(self._offset, value=100000)
 
             result = Timestamp("20080101") + offset
             assert isinstance(result, datetime)

--- a/pandas/tests/tseries/offsets/common.py
+++ b/pandas/tests/tseries/offsets/common.py
@@ -127,8 +127,6 @@ class Base:
             assert isinstance(result, datetime)
             assert t.tzinfo == result.tzinfo
 
-        except OutOfBoundsDatetime:
-            pass
         except (ValueError, KeyError):
             # we are creating an invalid offset
             # so ignore

--- a/pandas/tests/tseries/offsets/common.py
+++ b/pandas/tests/tseries/offsets/common.py
@@ -133,7 +133,6 @@ class Base:
         except OutOfBoundsDatetime:
             pass
         except (ValueError, KeyError):
-            print("vk")
             # we are creating an invalid offset
             # so ignore
             pass

--- a/pandas/tests/tseries/offsets/common.py
+++ b/pandas/tests/tseries/offsets/common.py
@@ -98,12 +98,14 @@ class Base:
             klass = klass(value, normalize=normalize)
         return klass
 
-    def test_apply_out_of_range(self, tz_naive_fixture):
+    def test_apply_out_of_range(self, request, tz_naive_fixture):
         tz = tz_naive_fixture
         if self._offset is None:
             return
         if isinstance(tz, tzlocal) and not IS64:
-            pytest.xfail(reason="OverflowError inside tzlocal past 2038")
+            request.node.add_marker(
+                pytest.mark.xfail(reason="OverflowError inside tzlocal past 2038")
+            )
 
         # try to create an out-of-bounds result timestamp; if we can't create
         # the offset skip


### PR DESCRIPTION
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

Part of #38902.