### PR TITLE
TST: update pre-commit config to only exclude extension from bare pytest.raises check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -126,7 +126,7 @@ repos:
         entry: python scripts/validate_unwanted_patterns.py --validation-type="bare_pytest_raises"
         types: [python]
         files: ^pandas/tests/
-        exclude: ^pandas/tests/extension
+        exclude: ^pandas/tests/extension/
     -   id: inconsistent-namespace-usage
         name: 'Check for inconsistent use of pandas namespace in tests'
         entry: python scripts/check_for_inconsistent_pandas_namespace.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -126,7 +126,7 @@ repos:
         entry: python scripts/validate_unwanted_patterns.py --validation-type="bare_pytest_raises"
         types: [python]
         files: ^pandas/tests/
-        exclude: ^pandas/tests/(computation|extension|io)/
+        exclude: ^pandas/tests/extension
     -   id: inconsistent-namespace-usage
         name: 'Check for inconsistent use of pandas namespace in tests'
         entry: python scripts/check_for_inconsistent_pandas_namespace.py


### PR DESCRIPTION
With #38920 I eliminated all instances of `pytest.raise` without `match=msg` in pandas/tests/computation and pandas/tests/io. #38799 was happening around the same time and missed that they were fixed. So this closes the loop and now only pandas/tests/extension needs to be excluded from the linting check.

I don't think the bare `pytest.raise`s in pandas/tests/extensions will be removed. They are in a pretty complex inheritance hierarchy and reused for many different types of errors and error messages. So I propose that this PR closes #30999.

- [x] closes #30999 
- [ ] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
