### PR TITLE
DOC: remove is_lexsorted from MultiIndex docstring

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -216,7 +216,6 @@ class MultiIndex(Index):
     set_codes
     to_frame
     to_flat_index
-    is_lexsorted
     sortlevel
     droplevel
     swaplevel


### PR DESCRIPTION
`is_lexsorted` has been deprecated (https://github.com/pandas-dev/pandas/pull/38701)

- [x] closes https://github.com/pandas-dev/pandas/issues/38953
- [ ] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
