### PR TITLE
BUG: Datetimelike equality comparisons with Categorical 

### DIFF
--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -85,20 +85,8 @@ class SharedTests:
         with pytest.raises(ValueError, match="Lengths must match"):
             idx <= idx[[0]]
 
-    def test_compare_with_Categorical(self):
-        result = pd.date_range("2020", periods=3)
-        expected = pd.Categorical(result)
-        assert all(result == expected)
-        assert not any(result != expected)
-        result = pd.date_range("2020", periods=3, tz="UTC")
-        expected = pd.Categorical(result)
-        assert all(result == expected)
-        assert not any(result != expected)
-        result = pd.timedelta_range("0 days", periods=3)
-        expected = pd.Categorical(result)
-        assert all(result == expected)
-        assert not any(result != expected)
-        result = pd.period_range("2020Q1", periods=3, freq="Q")
+    @pytest.mark.parametrize("result",[pd.date_range("2020", periods=3), pd.date_range("2020", periods=3, tz="UTC"), pd.timedelta_range("0 days", periods=3), pd.period_range("2020Q1", periods=3, freq="Q")])
+    def test_compare_with_Categorical(self, result):
         expected = pd.Categorical(result)
         assert all(result == expected)
         assert not any(result != expected)

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -85,6 +85,24 @@ class SharedTests:
         with pytest.raises(ValueError, match="Lengths must match"):
             idx <= idx[[0]]
 
+    def test_compare_with_Categorical(self):
+        result = pd.date_range("2020", periods=3)
+        expected = pd.Categorical(result)
+        assert all(result == expected)
+        assert not any(result != expected)
+        result = pd.date_range("2020", periods=3, tz="UTC")
+        expected = pd.Categorical(result)
+        assert all(result == expected)
+        assert not any(result != expected)
+        result = pd.timedelta_range("0 days", periods=3)
+        expected = pd.Categorical(result)
+        assert all(result == expected)
+        assert not any(result != expected)
+        result = pd.period_range("2020Q1", periods=3, freq="Q")
+        expected = pd.Categorical(result)
+        assert all(result == expected)
+        assert not any(result != expected)
+
     @pytest.mark.parametrize("reverse", [True, False])
     @pytest.mark.parametrize("as_index", [True, False])
     def test_compare_categorical_dtype(self, arr1d, as_index, reverse, ordered):

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -91,7 +91,7 @@ class SharedTests:
             pd.date_range("2020", periods=3),
             pd.date_range("2020", periods=3, tz="UTC"),
             pd.timedelta_range("0 days", periods=3),
-            pd.period_range("2020Q1", periods=3, freq="Q")
+            pd.period_range("2020Q1", periods=3, freq="Q"),
         ],
     )
     def test_compare_with_Categorical(self, result):

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -92,7 +92,7 @@ class SharedTests:
             pd.date_range("2020", periods=3, tz="UTC"),
             pd.timedelta_range("0 days", periods=3),
             pd.period_range("2020Q1", periods=3, freq="Q")
-        ]
+        ],
     )
     def test_compare_with_Categorical(self, result):
         expected = pd.Categorical(result)

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -85,7 +85,15 @@ class SharedTests:
         with pytest.raises(ValueError, match="Lengths must match"):
             idx <= idx[[0]]
 
-    @pytest.mark.parametrize("result",[pd.date_range("2020", periods=3), pd.date_range("2020", periods=3, tz="UTC"), pd.timedelta_range("0 days", periods=3), pd.period_range("2020Q1", periods=3, freq="Q")])
+    @pytest.mark.parametrize(
+        "result",
+        [
+            pd.date_range("2020", periods=3),
+            pd.date_range("2020", periods=3, tz="UTC"),
+            pd.timedelta_range("0 days", periods=3),
+            pd.period_range("2020Q1", periods=3, freq="Q")
+        ]
+    )
     def test_compare_with_Categorical(self, result):
         expected = pd.Categorical(result)
         assert all(result == expected)

--- a/pandas/tests/extension/test_datetime.py
+++ b/pandas/tests/extension/test_datetime.py
@@ -165,16 +165,16 @@ class TestComparisonOps(BaseDatetimeTests, base.BaseComparisonOpsTests):
     def test_compare_with_Categorical(self):
         result = pd.date_range("2020", periods=3)
         expected = pd.Categorical(result)
-        assert (result == expected).all()
+        assert all(result == expected)
         result = pd.date_range("2020", periods=3, tz="UTC")
         expected = pd.Categorical(result)
-        assert (result == expected).all()
+        assert all(result == expected)
         result = pd.timedelta_range("0 days", periods=3)
         expected = pd.Categorical(result)
-        assert (result == expected).all()
+        assert all(result == expected)
         result = pd.period_range("2020Q1", periods=3, freq="Q")
         expected = pd.Categorical(result)
-        assert (result == expected).all()
+        assert all(result == expected)
 
 
 class TestMissing(BaseDatetimeTests, base.BaseMissingTests):

--- a/pandas/tests/extension/test_datetime.py
+++ b/pandas/tests/extension/test_datetime.py
@@ -162,20 +162,6 @@ class TestComparisonOps(BaseDatetimeTests, base.BaseComparisonOpsTests):
         # with (some) integers, depending on the value.
         pass
 
-    def test_compare_with_Categorical(self):
-        result = pd.date_range("2020", periods=3)
-        expected = pd.Categorical(result)
-        assert all(result == expected)
-        result = pd.date_range("2020", periods=3, tz="UTC")
-        expected = pd.Categorical(result)
-        assert all(result == expected)
-        result = pd.timedelta_range("0 days", periods=3)
-        expected = pd.Categorical(result)
-        assert all(result == expected)
-        result = pd.period_range("2020Q1", periods=3, freq="Q")
-        expected = pd.Categorical(result)
-        assert all(result == expected)
-
 
 class TestMissing(BaseDatetimeTests, base.BaseMissingTests):
     pass

--- a/pandas/tests/extension/test_datetime.py
+++ b/pandas/tests/extension/test_datetime.py
@@ -165,16 +165,16 @@ class TestComparisonOps(BaseDatetimeTests, base.BaseComparisonOpsTests):
     def test_compare_with_Categorical(self):
         result = pd.date_range("2020", periods=3)
         expected = pd.Categorical(result)
-        assert result == expected
+        assert (result == expected).all()
         result = pd.date_range("2020", periods=3, tz="UTC")
         expected = pd.Categorical(result)
-        assert result == expected
+        assert (result == expected).all()
         result = pd.timedelta_range("0 days", periods=3)
         expected = pd.Categorical(result)
-        assert result == expected
+        assert (result == expected).all()
         result = pd.period_range("2020Q1", periods=3, freq="Q")
         expected = pd.Categorical(result)
-        assert result == expected
+        assert (result == expected).all()
 
 
 class TestMissing(BaseDatetimeTests, base.BaseMissingTests):

--- a/pandas/tests/extension/test_datetime.py
+++ b/pandas/tests/extension/test_datetime.py
@@ -162,6 +162,20 @@ class TestComparisonOps(BaseDatetimeTests, base.BaseComparisonOpsTests):
         # with (some) integers, depending on the value.
         pass
 
+    def test_compare_with_Categorical(self):
+        result = pd.date_range("2020", periods=3)
+        expected = pd.Categorical(result)
+        assert result == expected
+        result = pd.date_range("2020", periods=3, tz="UTC")
+        expected = pd.Categorical(result)
+        assert result == expected
+        result = pd.timedelta_range("0 days", periods=3)
+        expected = pd.Categorical(result)
+        assert result == expected
+        result = pd.period_range("2020Q1", periods=3, freq="Q")
+        expected = pd.Categorical(result)
+        assert result == expected
+
 
 class TestMissing(BaseDatetimeTests, base.BaseMissingTests):
     pass


### PR DESCRIPTION
- [ ] closes #30699 
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
