### PR TITLE
Fix regression in setitem when expanding DataFrame with specific column name format

### DIFF
--- a/doc/source/whatsnew/v1.2.1.rst
+++ b/doc/source/whatsnew/v1.2.1.rst
@@ -20,6 +20,7 @@ Fixed regressions
 - Fixed regression in repr of float-like strings of an ``object`` dtype having trailing 0's truncated after the decimal (:issue:`38708`)
 - Fixed regression in :meth:`DataFrame.groupby()` with :class:`Categorical` grouping column not showing unused categories for ``grouped.indices`` (:issue:`38642`)
 - Fixed regression in :meth:`DataFrame.any` and :meth:`DataFrame.all` not returning a result for tz-aware ``datetime64`` columns (:issue:`38723`)
+- Fixed regression in :meth:`DataFrame.__setitem__` raising ``ValueError`` when expanding :class:`DataFrame` and new column is from type ``"0 - name"`` (:issue:`39010`)
 - Fixed regression in :meth:`.GroupBy.sem` where the presence of non-numeric columns would cause an error instead of being dropped (:issue:`38774`)
 - Fixed regression in :func:`read_excel` with non-rawbyte file handles (:issue:`38788`)
 - Bug in :meth:`read_csv` with ``float_precision="high"`` caused segfault or wrong parsing of long exponent strings. This resulted in a regression in some cases as the default for ``float_precision`` was changed in pandas 1.2.0 (:issue:`38753`)

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1395,7 +1395,7 @@ def is_bool_dtype(arr_or_dtype) -> bool:
         return False
     try:
         dtype = get_dtype(arr_or_dtype)
-    except TypeError:
+    except (TypeError, ValueError):
         return False
 
     if isinstance(arr_or_dtype, CategoricalDtype):

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -124,7 +124,9 @@ class NumericIndex(Index):
 
     @doc(Index._validate_fill_value)
     def _validate_fill_value(self, value):
-        if is_bool(value) or is_bool_dtype(value):
+        if isinstance(value, str):
+            raise TypeError
+        elif is_bool(value) or is_bool_dtype(value):
             # force conversion to object
             # so we don't lose the bools
             raise TypeError

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -124,9 +124,7 @@ class NumericIndex(Index):
 
     @doc(Index._validate_fill_value)
     def _validate_fill_value(self, value):
-        if isinstance(value, str):
-            raise TypeError
-        elif is_bool(value) or is_bool_dtype(value):
+        if is_bool(value) or is_bool_dtype(value):
             # force conversion to object
             # so we don't lose the bools
             raise TypeError

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -557,6 +557,11 @@ def test_is_bool_dtype():
     assert com.is_bool_dtype("boolean")
 
 
+def test_is_bool_dtype_numpy_error():
+    # GH39010
+    assert not com.is_bool_dtype("0 - Name")
+
+
 @pytest.mark.filterwarnings("ignore:'is_extension_type' is deprecated:FutureWarning")
 @pytest.mark.parametrize(
     "check_scipy", [False, pytest.param(True, marks=td.skip_if_no_scipy)]

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -366,6 +366,13 @@ class TestDataFrameSetItemWithExpansion:
         expected = Series([100, 2, 3], name="a")
         tm.assert_series_equal(ser, expected)
 
+    def test_setitem_string_column_numpy_dtype_raising(self):
+        # GH#39010
+        df = DataFrame([[1, 2], [3, 4]])
+        df["0 - Name"] = [5, 6]
+        expected = DataFrame([[1, 2, 5], [3, 4, 6]], columns=[0, 1, "0 - Name"])
+        tm.assert_frame_equal(df, expected)
+
 
 class TestDataFrameSetItemSlicing:
     def test_setitem_slice_position(self):


### PR DESCRIPTION
- [x] closes #39010
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

We obviously want cast to object if value is string.