### PR TITLE
BUG: Resample.aggregate raising TypeError instead of SpecificationError with missing keys dtypes

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -306,7 +306,7 @@ Groupby/resample/rolling
 - Bug in :meth:`.GroupBy.indices` would contain non-existent indices when null values were present in the groupby keys (:issue:`9304`)
 - Fixed bug in :meth:`DataFrameGroupBy.sum` and :meth:`SeriesGroupBy.sum` causing loss of precision through using Kahan summation (:issue:`38778`)
 - Fixed bug in :meth:`DataFrameGroupBy.cumsum`, :meth:`SeriesGroupBy.cumsum`, :meth:`DataFrameGroupBy.mean` and :meth:`SeriesGroupBy.mean` causing loss of precision through using Kahan summation (:issue:`38934`)
-- Bug in :meth:`.Resampler.aggregate` raising ``TypeError`` instead of ``SpecificationError`` when missing keys having mixed dtypes (:issue:`39025`)
+- Bug in :meth:`.Resampler.aggregate` and :meth:`DataFrame.transform` raising ``TypeError`` instead of ``SpecificationError`` when missing keys having mixed dtypes (:issue:`39025`)
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -306,6 +306,7 @@ Groupby/resample/rolling
 - Bug in :meth:`.GroupBy.indices` would contain non-existent indices when null values were present in the groupby keys (:issue:`9304`)
 - Fixed bug in :meth:`DataFrameGroupBy.sum` and :meth:`SeriesGroupBy.sum` causing loss of precision through using Kahan summation (:issue:`38778`)
 - Fixed bug in :meth:`DataFrameGroupBy.cumsum`, :meth:`SeriesGroupBy.cumsum`, :meth:`DataFrameGroupBy.mean` and :meth:`SeriesGroupBy.mean` causing loss of precision through using Kahan summation (:issue:`38934`)
+- Bug in :meth:`.Resampler.aggregate` raising ``TypeError`` instead of ``SpecificationError`` when columns and missing keys had mixed dtypes (:issue:`39025`)
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -306,7 +306,7 @@ Groupby/resample/rolling
 - Bug in :meth:`.GroupBy.indices` would contain non-existent indices when null values were present in the groupby keys (:issue:`9304`)
 - Fixed bug in :meth:`DataFrameGroupBy.sum` and :meth:`SeriesGroupBy.sum` causing loss of precision through using Kahan summation (:issue:`38778`)
 - Fixed bug in :meth:`DataFrameGroupBy.cumsum`, :meth:`SeriesGroupBy.cumsum`, :meth:`DataFrameGroupBy.mean` and :meth:`SeriesGroupBy.mean` causing loss of precision through using Kahan summation (:issue:`38934`)
-- Bug in :meth:`.Resampler.aggregate` raising ``TypeError`` instead of ``SpecificationError`` when columns and missing keys had mixed dtypes (:issue:`39025`)
+- Bug in :meth:`.Resampler.aggregate` raising ``TypeError`` instead of ``SpecificationError`` when missing keys having mixed dtypes (:issue:`39025`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -739,8 +739,10 @@ def agg_dict_like(
         if isinstance(selected_obj, ABCDataFrame) and len(
             selected_obj.columns.intersection(keys)
         ) != len(keys):
-            cols = safe_sort(
-                set(keys) - set(selected_obj.columns.intersection(keys)),
+            cols = list(
+                safe_sort(
+                    list(set(keys) - set(selected_obj.columns.intersection(keys))),
+                )
             )
             raise SpecificationError(f"Column(s) {cols} do not exist")
 

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -483,8 +483,9 @@ def transform_dict_like(
 
     if obj.ndim != 1:
         # Check for missing columns on a frame
-        cols = sorted(set(func.keys()) - set(obj.columns))
+        cols = set(func.keys()) - set(obj.columns)
         if len(cols) > 0:
+            cols = list(safe_sort(list(cols)))
             raise SpecificationError(f"Column(s) {cols} do not exist")
 
     # Can't use func.values(); wouldn't work for a Series

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -35,6 +35,7 @@ from pandas.core.dtypes.cast import is_nested_object
 from pandas.core.dtypes.common import is_dict_like, is_list_like
 from pandas.core.dtypes.generic import ABCDataFrame, ABCNDFrame, ABCSeries
 
+from pandas.core.algorithms import safe_sort
 from pandas.core.base import DataError, SpecificationError
 import pandas.core.common as com
 from pandas.core.indexes.api import Index
@@ -738,9 +739,8 @@ def agg_dict_like(
         if isinstance(selected_obj, ABCDataFrame) and len(
             selected_obj.columns.intersection(keys)
         ) != len(keys):
-            cols = sorted(
+            cols = safe_sort(
                 set(keys) - set(selected_obj.columns.intersection(keys)),
-                key=lambda col: (isinstance(col, str), col),
             )
             raise SpecificationError(f"Column(s) {cols} do not exist")
 

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -735,10 +735,12 @@ def agg_dict_like(
         # deprecation of renaming keys
         # GH 15931
         keys = list(arg.keys())
-        if isinstance(selected_obj, ABCDataFrame) and len(
-            selected_obj.columns.intersection(keys)
-        ) != len(keys):
-            cols = sorted(set(keys) - set(selected_obj.columns.intersection(keys)))
+        common_keys = selected_obj.columns.intersection(keys)
+        if isinstance(selected_obj, ABCDataFrame) and len(common_keys) != len(keys):
+            cols = sorted(
+                set(keys) - set(common_keys),
+                key=lambda col: (isinstance(col, str), col),
+            )
             raise SpecificationError(f"Column(s) {cols} do not exist")
 
     from pandas.core.reshape.concat import concat

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -735,10 +735,11 @@ def agg_dict_like(
         # deprecation of renaming keys
         # GH 15931
         keys = list(arg.keys())
-        common_keys = selected_obj.columns.intersection(keys)
-        if isinstance(selected_obj, ABCDataFrame) and len(common_keys) != len(keys):
+        if isinstance(selected_obj, ABCDataFrame) and len(
+            selected_obj.columns.intersection(keys)
+        ) != len(keys):
             cols = sorted(
-                set(keys) - set(common_keys),
+                set(keys) - set(selected_obj.columns.intersection(keys)),
                 key=lambda col: (isinstance(col, str), col),
             )
             raise SpecificationError(f"Column(s) {cols} do not exist")

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -485,8 +485,8 @@ def transform_dict_like(
         # Check for missing columns on a frame
         cols = set(func.keys()) - set(obj.columns)
         if len(cols) > 0:
-            cols = list(safe_sort(list(cols)))
-            raise SpecificationError(f"Column(s) {cols} do not exist")
+            cols_sorted = list(safe_sort(list(cols)))
+            raise SpecificationError(f"Column(s) {cols_sorted} do not exist")
 
     # Can't use func.values(); wouldn't work for a Series
     if any(is_dict_like(v) for _, v in func.items()):

--- a/pandas/tests/frame/apply/test_frame_transform.py
+++ b/pandas/tests/frame/apply/test_frame_transform.py
@@ -253,7 +253,7 @@ def test_transform_passes_args(use_apply, frame_or_series):
 
 
 def test_transform_missing_columns(axis):
-    # GH 35964
+    # GH#35964
     df = DataFrame({"A": [1, 2], "B": [3, 4]})
     match = re.escape("Column(s) ['C'] do not exist")
     with pytest.raises(SpecificationError, match=match):
@@ -261,7 +261,7 @@ def test_transform_missing_columns(axis):
 
 
 def test_transform_none_to_type():
-    # GH34377
+    # GH#34377
     df = DataFrame({"a": [None]})
     msg = "Transform function failed"
     with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/frame/apply/test_frame_transform.py
+++ b/pandas/tests/frame/apply/test_frame_transform.py
@@ -258,3 +258,19 @@ def test_transform_missing_columns(axis):
     match = re.escape("Column(s) ['C'] do not exist")
     with pytest.raises(SpecificationError, match=match):
         df.transform({"C": "cumsum"})
+
+
+def test_transform_none_to_type():
+    # GH34377
+    df = DataFrame({"a": [None]})
+    msg = "Transform function failed"
+    with pytest.raises(ValueError, match=msg):
+        df.transform({"a": int})
+
+
+def test_transform_mixed_column_name_dtypes():
+    # GH39025
+    df = DataFrame({"a": ["1"]})
+    msg = r"Column\(s\) \[1, 'b'\] do not exist"
+    with pytest.raises(SpecificationError, match=msg):
+        df.transform({"a": int, 1: str, "b": int})

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -297,6 +297,21 @@ def test_agg_consistency():
         r.agg({"r1": "mean", "r2": "sum"})
 
 
+def test_agg_consistency_int_str_column_mix():
+    # GH#39025
+    df = DataFrame(
+        np.random.randn(1000, 2),
+        index=pd.date_range("1/1/2012", freq="S", periods=1000),
+        columns=[1, "a"],
+    )
+
+    r = df.resample("3T")
+
+    msg = r"Column\(s\) \[2, 'b'\] do not exist"
+    with pytest.raises(pd.core.base.SpecificationError, match=msg):
+        r.agg({2: "mean", "b": "sum"})
+
+
 # TODO: once GH 14008 is fixed, move these tests into
 # `Base` test class
 

--- a/pandas/tests/series/apply/test_series_transform.py
+++ b/pandas/tests/series/apply/test_series_transform.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas import DataFrame, Series, concat
+from pandas import Series, concat
 import pandas._testing as tm
 from pandas.core.base import SpecificationError
 from pandas.core.groupby.base import transformation_kernels
@@ -63,22 +63,6 @@ def test_transform_wont_agg(string_series):
     with pytest.raises(ValueError, match=msg):
         with np.errstate(all="ignore"):
             string_series.transform(["sqrt", "max"])
-
-
-def test_transform_none_to_type():
-    # GH34377
-    df = DataFrame({"a": [None]})
-    msg = "Transform function failed"
-    with pytest.raises(ValueError, match=msg):
-        df.transform({"a": int})
-
-
-def test_transform_mixed_column_name_dtypes():
-    # GH39025
-    df = DataFrame({"a": ["1"]})
-    msg = r"Column\(s\) \[1, 'b'\] do not exist"
-    with pytest.raises(SpecificationError, match=msg):
-        df.transform({"a": int, 1: str, "b": int})
 
 
 def test_transform_axis_1_raises():

--- a/pandas/tests/series/apply/test_series_transform.py
+++ b/pandas/tests/series/apply/test_series_transform.py
@@ -73,6 +73,14 @@ def test_transform_none_to_type():
         df.transform({"a": int})
 
 
+def test_transform_mixed_column_name_dtypes():
+    # GH39025
+    df = DataFrame({"a": ["1"]})
+    msg = r"Column\(s\) \[1, 'b'\] do not exist"
+    with pytest.raises(SpecificationError, match=msg):
+        df.transform({"a": int, 1: str, "b": int})
+
+
 def test_transform_axis_1_raises():
     # GH 35964
     msg = "No axis named 1 for object type Series"


### PR DESCRIPTION
- [x] closes #39025
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
