### PR TITLE
BUG: read_csv does not close file during an error in _make_reader

### DIFF
--- a/doc/source/whatsnew/v1.2.1.rst
+++ b/doc/source/whatsnew/v1.2.1.rst
@@ -40,7 +40,7 @@ Bug fixes
 ~~~~~~~~~
 
 - Bug in :meth:`read_csv` with ``float_precision="high"`` caused segfault or wrong parsing of long exponent strings. This resulted in a regression in some cases as the default for ``float_precision`` was changed in pandas 1.2.0 (:issue:`38753`)
--
+- Bug in :func:`read_csv` not closing an opened file handle when a ``csv.Error`` or ``UnicodeDecodeError`` occurred while initializing (:issue:`39024`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2297,7 +2297,11 @@ class PythonParser(ParserBase):
             self._open_handles(f, kwds)
             assert self.handles is not None
             assert hasattr(self.handles.handle, "readline")
-            self._make_reader(self.handles.handle)
+            try:
+                self._make_reader(self.handles.handle)
+            except (csv.Error, UnicodeDecodeError):
+                self.close()
+                raise
 
         # Get columns in two steps: infer from data, then
         # infer column indices from self.usecols if it is specified.


### PR DESCRIPTION
- [x] closes #39024
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

I don't understand why `td.check_file_leaks` doesn't complain about the left opened file (at least for me locally). I commented the close call on purpose to see whether the test fails at least for the CI.

@jbrockmendel I think you have debugged ResourceWarnings in the past. Do you know why the test doesn't fail? Even putting a `open("foo", mode="w")` in the test doesn't make it fail.

[The test case is different from  #39024 but the symptoms are the same. Unless the except clause is narrowed down to specific exceptions, this PR will fix #39024]