### PR TITLE
CLN, TYP use from __future__ import annotations

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3220,7 +3220,7 @@ class DataFrame(NDFrame, OpsMixin):
         self._check_setitem_copy()
         self._where(-key, value, inplace=True)
 
-    def _set_item_frame_value(self, key, value: "DataFrame") -> None:
+    def _set_item_frame_value(self, key, value: DataFrame) -> None:
         self._ensure_valid_index(value)
 
         # align right-hand-side columns if self.columns

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Hashable, List, Sequence, Tuple, Union
 import warnings
@@ -1742,7 +1744,7 @@ class _iLocIndexer(_LocationIndexer):
             # setting with a list, re-coerces
             self._setitem_single_column(loc, value[:, i].tolist(), pi)
 
-    def _setitem_with_indexer_frame_value(self, indexer, value: "DataFrame", name: str):
+    def _setitem_with_indexer_frame_value(self, indexer, value: DataFrame, name: str):
         ilocs = self._ensure_iterable_column_indexer(indexer[1])
 
         sub_indexer = list(indexer)
@@ -2032,7 +2034,7 @@ class _iLocIndexer(_LocationIndexer):
 
         raise ValueError("Incompatible indexer with Series")
 
-    def _align_frame(self, indexer, df: "DataFrame"):
+    def _align_frame(self, indexer, df: DataFrame):
         is_frame = self.ndim == 2
 
         if isinstance(indexer, tuple):
@@ -2204,7 +2206,7 @@ def _tuplify(ndim: int, loc: Hashable) -> Tuple[Union[Hashable, slice], ...]:
     return tuple(_tup)
 
 
-def convert_to_index_sliceable(obj: "DataFrame", key):
+def convert_to_index_sliceable(obj: DataFrame, key):
     """
     If we are index sliceable, then return my slicer, otherwise return None.
     """

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -3,6 +3,8 @@ Arithmetic operations for PandasObjects
 
 This is not a public API.
 """
+from __future__ import annotations
+
 import operator
 from typing import TYPE_CHECKING, Optional, Set
 import warnings
@@ -293,7 +295,7 @@ def align_method_FRAME(
 
 
 def should_reindex_frame_op(
-    left: "DataFrame", right, op, axis, default_axis, fill_value, level
+    left: DataFrame, right, op, axis, default_axis, fill_value, level
 ) -> bool:
     """
     Check if this is an operation between DataFrames that will need to reindex.
@@ -322,7 +324,7 @@ def should_reindex_frame_op(
 
 
 def frame_arith_method_with_reindex(
-    left: "DataFrame", right: "DataFrame", op
+    left: DataFrame, right: DataFrame, op
 ) -> "DataFrame":
     """
     For DataFrame-with-DataFrame operations that require reindexing,
@@ -367,7 +369,7 @@ def frame_arith_method_with_reindex(
     return result
 
 
-def _maybe_align_series_as_frame(frame: "DataFrame", series: "Series", axis: int):
+def _maybe_align_series_as_frame(frame: DataFrame, series: "Series", axis: int):
     """
     If the Series operand is not EA-dtype, we can broadcast to 2D and operate
     blockwise.

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from typing import TYPE_CHECKING, List, cast
 import warnings
@@ -24,7 +26,7 @@ if TYPE_CHECKING:
 
 @Appender(_shared_docs["melt"] % {"caller": "pd.melt(df, ", "other": "DataFrame.melt"})
 def melt(
-    frame: "DataFrame",
+    frame: DataFrame,
     id_vars=None,
     value_vars=None,
     var_name=None,
@@ -139,7 +141,7 @@ def melt(
 
 
 @deprecate_kwarg(old_arg_name="label", new_arg_name=None)
-def lreshape(data: "DataFrame", groups, dropna: bool = True, label=None) -> "DataFrame":
+def lreshape(data: DataFrame, groups, dropna: bool = True, label=None) -> "DataFrame":
     """
     Reshape wide-format data to long. Generalized inverse of DataFrame.pivot.
 
@@ -234,7 +236,7 @@ def lreshape(data: "DataFrame", groups, dropna: bool = True, label=None) -> "Dat
 
 
 def wide_to_long(
-    df: "DataFrame", stubnames, i, j, sep: str = "", suffix: str = r"\d+"
+    df: DataFrame, stubnames, i, j, sep: str = "", suffix: str = r"\d+"
 ) -> "DataFrame":
     r"""
     Wide panel to long format. Less flexible but more user-friendly than melt.

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1,6 +1,7 @@
 """
 SQL-style merge routines
 """
+from __future__ import annotations
 
 import copy
 import datetime
@@ -99,7 +100,7 @@ if __debug__:
     merge.__doc__ = _merge_doc % "\nleft : DataFrame"
 
 
-def _groupby_and_merge(by, on, left: "DataFrame", right: "DataFrame", merge_pieces):
+def _groupby_and_merge(by, on, left: DataFrame, right: DataFrame, merge_pieces):
     """
     groupby & merge; we are always performing a left-by type operation
 
@@ -157,8 +158,8 @@ def _groupby_and_merge(by, on, left: "DataFrame", right: "DataFrame", merge_piec
 
 
 def merge_ordered(
-    left: "DataFrame",
-    right: "DataFrame",
+    left: DataFrame,
+    right: DataFrame,
     on: Optional[IndexLabel] = None,
     left_on: Optional[IndexLabel] = None,
     right_on: Optional[IndexLabel] = None,
@@ -300,8 +301,8 @@ def merge_ordered(
 
 
 def merge_asof(
-    left: "DataFrame",
-    right: "DataFrame",
+    left: DataFrame,
+    right: DataFrame,
     on: Optional[IndexLabel] = None,
     left_on: Optional[IndexLabel] = None,
     right_on: Optional[IndexLabel] = None,
@@ -717,12 +718,12 @@ class _MergeOperation:
 
         return result.__finalize__(self, method="merge")
 
-    def _maybe_drop_cross_column(self, result: "DataFrame", cross_col: Optional[str]):
+    def _maybe_drop_cross_column(self, result: DataFrame, cross_col: Optional[str]):
         if cross_col is not None:
             result.drop(columns=cross_col, inplace=True)
 
     def _indicator_pre_merge(
-        self, left: "DataFrame", right: "DataFrame"
+        self, left: DataFrame, right: DataFrame
     ) -> Tuple["DataFrame", "DataFrame"]:
 
         columns = left.columns.union(right.columns)
@@ -1230,7 +1231,7 @@ class _MergeOperation:
                 self.right = self.right.assign(**{name: self.right[name].astype(typ)})
 
     def _create_cross_configuration(
-        self, left: "DataFrame", right: "DataFrame"
+        self, left: DataFrame, right: DataFrame
     ) -> Tuple["DataFrame", "DataFrame", str, str]:
         """
         Creates the configuration to dispatch the cross operation to inner join,
@@ -1546,8 +1547,8 @@ class _OrderedMerge(_MergeOperation):
 
     def __init__(
         self,
-        left: "DataFrame",
-        right: "DataFrame",
+        left: DataFrame,
+        right: DataFrame,
         on: Optional[IndexLabel] = None,
         left_on: Optional[IndexLabel] = None,
         right_on: Optional[IndexLabel] = None,
@@ -1640,8 +1641,8 @@ class _AsOfMerge(_OrderedMerge):
 
     def __init__(
         self,
-        left: "DataFrame",
-        right: "DataFrame",
+        left: DataFrame,
+        right: DataFrame,
         on: Optional[IndexLabel] = None,
         left_on: Optional[IndexLabel] = None,
         right_on: Optional[IndexLabel] = None,

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -367,7 +369,7 @@ def _generate_marginal_results(
 
 
 def _generate_marginal_results_without_values(
-    table: "DataFrame", data, rows, cols, aggfunc, observed, margins_name: str = "All"
+    table: DataFrame, data, rows, cols, aggfunc, observed, margins_name: str = "All"
 ):
     if len(cols) > 0:
         # need to "interleave" the margins
@@ -421,7 +423,7 @@ def _convert_by(by):
 @Substitution("\ndata : DataFrame")
 @Appender(_shared_docs["pivot"], indents=1)
 def pivot(
-    data: "DataFrame",
+    data: DataFrame,
     index: Optional[Union[Label, Sequence[Label]]] = None,
     columns: Optional[Union[Label, Sequence[Label]]] = None,
     values: Optional[Union[Label, Sequence[Label]]] = None,

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -2,6 +2,8 @@
 Provide a generic structure to support window functions,
 similar to how we have a Groupby object.
 """
+from __future__ import annotations
+
 from datetime import timedelta
 from functools import partial
 import inspect
@@ -314,7 +316,7 @@ class BaseWindow(ShallowMixin, SelectionMixin):
 
         return values
 
-    def _insert_on_column(self, result: "DataFrame", obj: "DataFrame"):
+    def _insert_on_column(self, result: DataFrame, obj: DataFrame):
         # if we have an 'on' column we want to put it back into
         # the results in the same location
         from pandas import Series

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -2,6 +2,7 @@
 Internal module for formatting output data in csv, html,
 and latex files. This module also applies to display formatting.
 """
+from __future__ import annotations
 
 from contextlib import contextmanager
 from csv import QUOTE_NONE, QUOTE_NONNUMERIC
@@ -462,7 +463,7 @@ class DataFrameFormatter:
 
     def __init__(
         self,
-        frame: "DataFrame",
+        frame: DataFrame,
         columns: Optional[Sequence[str]] = None,
         col_space: Optional[ColspaceArgType] = None,
         header: Union[bool, Sequence[str]] = True,
@@ -813,7 +814,7 @@ class DataFrameFormatter:
                 i = self.columns[i]
             return self.formatters.get(i, None)
 
-    def _get_formatted_column_labels(self, frame: "DataFrame") -> List[List[str]]:
+    def _get_formatted_column_labels(self, frame: DataFrame) -> List[List[str]]:
         from pandas.core.indexes.multi import sparsify_labels
 
         columns = frame.columns
@@ -854,7 +855,7 @@ class DataFrameFormatter:
         # self.str_columns = str_columns
         return str_columns
 
-    def _get_formatted_index(self, frame: "DataFrame") -> List[str]:
+    def _get_formatted_index(self, frame: DataFrame) -> List[str]:
         # Note: this is only used by to_string() and to_latex(), not by
         # to_html(). so safe to cast col_space here.
         col_space = {k: cast(int, v) for k, v in self.col_space.items()}

--- a/pandas/io/formats/info.py
+++ b/pandas/io/formats/info.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 import sys
 from typing import (
@@ -227,10 +229,10 @@ class DataFrameInfo(BaseInfo):
 
     def __init__(
         self,
-        data: "DataFrame",
+        data: DataFrame,
         memory_usage: Optional[Union[bool, str]] = None,
     ):
-        self.data: "DataFrame" = data
+        self.data: DataFrame = data
         self.memory_usage = _initialize_memory_usage(memory_usage)
 
     @property
@@ -679,7 +681,7 @@ class DataFrameTableBuilderVerbose(DataFrameTableBuilder, TableBuilderVerboseMix
             yield pprint_thing(col)
 
 
-def _get_dataframe_dtype_counts(df: "DataFrame") -> Mapping[str, int]:
+def _get_dataframe_dtype_counts(df: DataFrame) -> Mapping[str, int]:
     """
     Create mapping between datatypes and their number of occurences.
     """

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -1,4 +1,6 @@
 """ Google BigQuery support """
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from pandas.compat._optional import import_optional_dependency
@@ -195,7 +197,7 @@ def read_gbq(
 
 
 def to_gbq(
-    dataframe: "DataFrame",
+    dataframe: DataFrame,
     destination_table: str,
     project_id: Optional[str] = None,
     chunksize: Optional[int] = None,

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 from typing import TYPE_CHECKING, Optional, Sequence, Tuple, Union
 
@@ -99,7 +101,7 @@ def hist_series(
 
 
 def hist_frame(
-    data: "DataFrame",
+    data: DataFrame,
     column: Union[Label, Sequence[Label]] = None,
     by=None,
     grid: bool = True,

--- a/pandas/plotting/_matplotlib/misc.py
+++ b/pandas/plotting/_matplotlib/misc.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 from typing import TYPE_CHECKING, Dict, List, Optional, Set
 
@@ -21,7 +23,7 @@ if TYPE_CHECKING:
 
 
 def scatter_matrix(
-    frame: "DataFrame",
+    frame: DataFrame,
     alpha=0.5,
     figsize=None,
     ax=None,
@@ -124,7 +126,7 @@ def _get_marker_compat(marker):
 
 
 def radviz(
-    frame: "DataFrame",
+    frame: DataFrame,
     class_column,
     ax: Optional["Axes"] = None,
     color=None,
@@ -212,7 +214,7 @@ def radviz(
 
 
 def andrews_curves(
-    frame: "DataFrame",
+    frame: DataFrame,
     class_column,
     ax: Optional["Axes"] = None,
     samples: int = 200,
@@ -334,7 +336,7 @@ def bootstrap_plot(
 
 
 def parallel_coordinates(
-    frame: "DataFrame",
+    frame: DataFrame,
     class_column,
     cols=None,
     ax: Optional["Axes"] = None,


### PR DESCRIPTION
Seeing as pandas is Python3.7+ we can clean up some annotations. Not yet figured out how to write a good automated check for this, but here's a start