### PR TITLE
BUG: pd.to_numeric does not copy _mask for ExtensionArrays 

### DIFF
--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -221,7 +221,7 @@ def to_numeric(arg, errors="raise", downcast=None):
         from pandas.core.arrays import FloatingArray, IntegerArray
 
         klass = IntegerArray if is_integer_dtype(data.dtype) else FloatingArray
-        values = klass(data, mask)
+        values = klass(data, mask.copy())
 
     if is_series:
         return arg._constructor(values, index=arg.index, name=arg.name)

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -764,3 +764,16 @@ def test_downcast_nullable_numeric(data, input_dtype, downcast, expected_dtype):
     result = pd.to_numeric(arr, downcast=downcast)
     expected = pd.array(data, dtype=expected_dtype)
     tm.assert_extension_array_equal(result, expected)
+
+
+def test_downcast_nullable_mask_is_copied():
+    # GH38974
+
+    arr = pd.array([1, 2, pd.NA], dtype="Int64")
+
+    result = pd.to_numeric(arr, downcast="integer")
+    expected = pd.array([1, 2, pd.NA], dtype="Int8")
+    tm.assert_extension_array_equal(result, expected)
+
+    arr[1] = pd.NA  # should not modify result
+    tm.assert_extension_array_equal(result, expected)


### PR DESCRIPTION
- [x] closes #38974 
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry (not needed as bug on master only)

Fixing a bug I introduced in  #38746