### PR TITLE
ENH: try to preserve the dtype on combine_first for the case where the two DataFrame objects have the same columns

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -73,44 +73,27 @@ Preserve dtypes in  :meth:`~pandas.DataFrame.combine_first`
 .. ipython:: python
 
    df1 = pd.DataFrame({"A": [1, 2, 3], "B": [1, 2, 3]}, index=[0, 1, 2])
+   df1
    df2 = pd.DataFrame({"B": [4, 5, 6], "C": [1, 2, 3]}, index=[2, 3, 4])
+   df2
    combined = df1.combine_first(df2)
 
 *pandas 1.2.x*
 
 .. code-block:: ipython
 
-   In [1]: (combined, "---------------", combined.dtypes)
+   In [1]: combined.dtypes
    Out[2]:
-   (     A    B    C
-   0  1.0  1.0  NaN
-   1  2.0  2.0  NaN
-   2  3.0  3.0  1.0
-   3  NaN  5.0  2.0
-   4  NaN  6.0  3.0,
-   '---------------',
    A    float64
    B    float64
    C    float64
-   dtype: object)
+   dtype: object
 
 *pandas 1.3.0*
 
 .. ipython:: python
 
-   In [1]: (combined, "---------------", combined.dtypes)
-   Out[2]:
-   (     A  B    C
-   0  1.0  1  NaN
-   1  2.0  2  NaN
-   2  3.0  3  1.0
-   3  NaN  5  2.0
-   4  NaN  6  3.0, 
-   '---------------', 
-   A    float64
-   B      int64
-   C    float64
-   dtype: object)
+   combined.dtypes
 
 
 .. _whatsnew_130.api_breaking.deps:

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -65,6 +65,41 @@ Notable bug fixes
 These are bug fixes that might have notable behavior changes.
 
 
+Preserve dtypes in  :meth:`~pandas.DataFrame.combine_first`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:meth:`~pandas.DataFrame.combine_first` will now preserve dtypes (:issue:`7509`)
+
+*pandas 1.2.x*
+
+.. code-block:: ipython
+
+   In [1]: df1 = pd.DataFrame({"A": [1, 2, 3], "B": [1, 2, 3]}, index=[0, 1, 2])
+   df2 = pd.DataFrame({"B": [4, 5, 6], "C": [1, 2, 3]}, index=[2, 3, 4])
+   combined = df1.combine_first(df2)
+   (combined, "---------------", combined.dtypes)
+   Out[2]:
+   (     A    B    C
+   0  1.0  1.0  NaN
+   1  2.0  2.0  NaN
+   2  3.0  3.0  1.0
+   3  NaN  5.0  2.0
+   4  NaN  6.0  3.0,
+   '---------------',
+   A    float64
+   B    float64
+   C    float64
+   dtype: object)
+
+*pandas 1.3.0*
+
+.. ipython:: python
+
+   df1 = pd.DataFrame({"A": [1, 2, 3], "B": [1, 2, 3]}, index=[0, 1, 2])
+   df2 = pd.DataFrame({"B": [4, 5, 6], "C": [1, 2, 3]}, index=[2, 3, 4])
+   combined = df1.combine_first(df2)
+   (combined, "---------------", combined.dtypes)
+
 
 .. _whatsnew_130.api_breaking.deps:
 

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -70,14 +70,17 @@ Preserve dtypes in  :meth:`~pandas.DataFrame.combine_first`
 
 :meth:`~pandas.DataFrame.combine_first` will now preserve dtypes (:issue:`7509`)
 
+.. ipython:: python
+
+   df1 = pd.DataFrame({"A": [1, 2, 3], "B": [1, 2, 3]}, index=[0, 1, 2])
+   df2 = pd.DataFrame({"B": [4, 5, 6], "C": [1, 2, 3]}, index=[2, 3, 4])
+   combined = df1.combine_first(df2)
+
 *pandas 1.2.x*
 
 .. code-block:: ipython
 
-   In [1]: df1 = pd.DataFrame({"A": [1, 2, 3], "B": [1, 2, 3]}, index=[0, 1, 2])
-   df2 = pd.DataFrame({"B": [4, 5, 6], "C": [1, 2, 3]}, index=[2, 3, 4])
-   combined = df1.combine_first(df2)
-   (combined, "---------------", combined.dtypes)
+   In [1]: (combined, "---------------", combined.dtypes)
    Out[2]:
    (     A    B    C
    0  1.0  1.0  NaN
@@ -95,10 +98,19 @@ Preserve dtypes in  :meth:`~pandas.DataFrame.combine_first`
 
 .. ipython:: python
 
-   df1 = pd.DataFrame({"A": [1, 2, 3], "B": [1, 2, 3]}, index=[0, 1, 2])
-   df2 = pd.DataFrame({"B": [4, 5, 6], "C": [1, 2, 3]}, index=[2, 3, 4])
-   combined = df1.combine_first(df2)
-   (combined, "---------------", combined.dtypes)
+   In [1]: (combined, "---------------", combined.dtypes)
+   Out[2]:
+   (     A  B    C
+   0  1.0  1  NaN
+   1  2.0  2  NaN
+   2  3.0  3  1.0
+   3  NaN  5  2.0
+   4  NaN  6  3.0, 
+   '---------------', 
+   A    float64
+   B      int64
+   C    float64
+   dtype: object)
 
 
 .. _whatsnew_130.api_breaking.deps:

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -66,7 +66,7 @@ These are bug fixes that might have notable behavior changes.
 
 
 Preserve dtypes in  :meth:`~pandas.DataFrame.combine_first`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :meth:`~pandas.DataFrame.combine_first` will now preserve dtypes (:issue:`7509`)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6425,7 +6425,7 @@ Keep all original rows and columns and also all original values
         # convert_objects just in case
         return self._constructor(result, index=new_index, columns=new_columns)
 
-    def combine_first(self, other: DataFrame) -> DataFrame:
+    def combine_first(self, other: DataFrame, preserve_dtypes: bool = False) -> DataFrame:
         """
         Update null elements with value in the same location in `other`.
 
@@ -6437,6 +6437,11 @@ Keep all original rows and columns and also all original values
         ----------
         other : DataFrame
             Provided DataFrame to use to fill null values.
+
+        preserve_dtypes : bool, default False
+            try to preserve the column dtypes afetr combining
+
+            .. versionadded:: 1.2.1
 
         Returns
         -------
@@ -6482,7 +6487,18 @@ Keep all original rows and columns and also all original values
 
             return expressions.where(mask, y_values, x_values)
 
-        return self.combine(other, combiner, overwrite=False)
+        combined = self.combine(other, combiner, overwrite=False)
+
+        if preserve_dtypes:
+            dtypes = {
+                col: find_common_type([self.dtypes[col], other.dtypes[col]])
+                for col in self.columns.intersection(other.columns)
+            }
+
+            if dtypes:
+                combined = combined.astype(dtypes)
+
+        return combined
 
     def update(
         self,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6488,10 +6488,6 @@ Keep all original rows and columns and also all original values
             col: find_common_type([self.dtypes[col], other.dtypes[col]])
             for col in self.columns.intersection(other.columns)
             if not is_dtype_equal(combined.dtypes[col], self.dtypes[col])
-            and not is_dtype_equal(
-                combined.dtypes[col],
-                find_common_type([self.dtypes[col], other.dtypes[col]]),
-            )
         }
 
         if dtypes:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6488,7 +6488,10 @@ Keep all original rows and columns and also all original values
             col: find_common_type([self.dtypes[col], other.dtypes[col]])
             for col in self.columns.intersection(other.columns)
             if not is_dtype_equal(combined.dtypes[col], self.dtypes[col])
-            and not is_dtype_equal(combined.dtypes[col], find_common_type([self.dtypes[col], other.dtypes[col]]))
+            and not is_dtype_equal(
+                combined.dtypes[col],
+                find_common_type([self.dtypes[col], other.dtypes[col]]),
+            )
         }
 
         if dtypes:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6484,25 +6484,12 @@ Keep all original rows and columns and also all original values
 
         combined = self.combine(other, combiner, overwrite=False)
 
-        dtypes = {}
-
-        for col in self.columns.intersection(other.columns):
-            try:
-                # if the column has different dtype in the
-                # DataFrame objects then add the common dtype
-                # to the columns dtype conversion dict
-                if combined.dtypes[col] != self.dtypes[col]:
-                    dtypes[col] = find_common_type(
-                        [self.dtypes[col], other.dtypes[col]]
-                    )
-            except TypeError:
-                # numpy dtype was compared with pandas dtype
-                try:
-                    # just try to apply the initial column dtype
-                    combined[col] = combined[col].astype(self.dtypes[col])
-                except ValueError:
-                    # could not apply the initial dtype, so skip
-                    pass
+        dtypes = {
+            col: find_common_type([self.dtypes[col], other.dtypes[col]])
+            for col in self.columns.intersection(other.columns)
+            if not is_dtype_equal(combined.dtypes[col], self.dtypes[col])
+            and not is_dtype_equal(combined.dtypes[col], find_common_type([self.dtypes[col], other.dtypes[col]]))
+        }
 
         if dtypes:
             combined = combined.astype(dtypes)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6488,14 +6488,20 @@ Keep all original rows and columns and also all original values
 
         for col in self.columns.intersection(other.columns):
             try:
+                # if the column has different dtype in the
+                # DataFrame objects then add the common dtype
+                # to the columns dtype conversion dict
                 if combined.dtypes[col] != self.dtypes[col]:
                     dtypes[col] = find_common_type(
                         [self.dtypes[col], other.dtypes[col]]
                     )
             except TypeError:
+                # numpy dtype was compared with pandas dtype
                 try:
+                    # just try to apply the initial column dtype
                     combined[col] = combined[col].astype(self.dtypes[col])
-                except:
+                except ValueError:
+                    # could not apply the initial dtype, so skip
                     pass
 
         if dtypes:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6441,7 +6441,7 @@ Keep all original rows and columns and also all original values
             Provided DataFrame to use to fill null values.
 
         preserve_dtypes : bool, default False
-            try to preserve the column dtypes afetr combining
+            try to preserve the column dtypes after combining
 
             .. versionadded:: 1.2.1
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6425,7 +6425,9 @@ Keep all original rows and columns and also all original values
         # convert_objects just in case
         return self._constructor(result, index=new_index, columns=new_columns)
 
-    def combine_first(self, other: DataFrame, preserve_dtypes: bool = False) -> DataFrame:
+    def combine_first(
+        self, other: DataFrame, preserve_dtypes: bool = False
+    ) -> DataFrame:
         """
         Update null elements with value in the same location in `other`.
 

--- a/pandas/tests/frame/methods/test_combine_first.py
+++ b/pandas/tests/frame/methods/test_combine_first.py
@@ -6,6 +6,7 @@ import pytest
 import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, Series
 import pandas._testing as tm
+from pandas.core.dtypes.cast import find_common_type
 
 
 class TestDataFrameCombineFirst:
@@ -18,14 +19,8 @@ class TestDataFrameCombineFirst:
         b = Series(range(2), index=range(5, 7))
         g = DataFrame({"A": a, "B": b})
 
-        exp = DataFrame(
-            {"A": list("abab"), "B": [0.0, 1.0, 0.0, 1.0]}, index=[0, 1, 5, 6]
-        )
-        combined = f.combine_first(g)
-        tm.assert_frame_equal(combined, exp)
-
         exp = DataFrame({"A": list("abab"), "B": [0, 1, 0, 1]}, index=[0, 1, 5, 6])
-        combined = f.combine_first(g, preserve_dtypes=True)
+        combined = f.combine_first(g)
         tm.assert_frame_equal(combined, exp)
 
     def test_combine_first(self, float_frame):
@@ -148,7 +143,7 @@ class TestDataFrameCombineFirst:
         )
         df2 = DataFrame([[-42.6, np.nan, True], [-5.0, 1.6, False]], index=[1, 2])
 
-        expected = Series([True, True, False], name=2, dtype=object)
+        expected = Series([True, True, False], name=2, dtype=bool)
 
         result_12 = df1.combine_first(df2)[2]
         tm.assert_series_equal(result_12, expected)
@@ -161,22 +156,22 @@ class TestDataFrameCombineFirst:
         (
             (
                 [datetime(2000, 1, 1), datetime(2000, 1, 2), datetime(2000, 1, 3)],
-                [None, None, None],
+                [pd.NaT, pd.NaT, pd.NaT],
                 [datetime(2000, 1, 1), datetime(2000, 1, 2), datetime(2000, 1, 3)],
             ),
             (
-                [None, None, None],
+                [pd.NaT, pd.NaT, pd.NaT],
                 [datetime(2000, 1, 1), datetime(2000, 1, 2), datetime(2000, 1, 3)],
                 [datetime(2000, 1, 1), datetime(2000, 1, 2), datetime(2000, 1, 3)],
             ),
             (
-                [datetime(2000, 1, 2), None, None],
+                [datetime(2000, 1, 2), pd.NaT, pd.NaT],
                 [datetime(2000, 1, 1), datetime(2000, 1, 2), datetime(2000, 1, 3)],
                 [datetime(2000, 1, 2), datetime(2000, 1, 2), datetime(2000, 1, 3)],
             ),
             (
                 [datetime(2000, 1, 1), datetime(2000, 1, 2), datetime(2000, 1, 3)],
-                [datetime(2000, 1, 2), None, None],
+                [datetime(2000, 1, 2), pd.NaT, pd.NaT],
                 [datetime(2000, 1, 1), datetime(2000, 1, 2), datetime(2000, 1, 3)],
             ),
         ),
@@ -200,13 +195,13 @@ class TestDataFrameCombineFirst:
 
         res = dfa.combine_first(dfb)
         exp = DataFrame(
-            {"a": [pd.Timestamp("2011-01-01"), pd.NaT], "b": [2.0, 5.0]},
+            {"a": [pd.Timestamp("2011-01-01"), pd.NaT], "b": [2, 5]},
             columns=["a", "b"],
         )
         tm.assert_frame_equal(res, exp)
         assert res["a"].dtype == "datetime64[ns]"
         # ToDo: this must be int64
-        assert res["b"].dtype == "float64"
+        assert res["b"].dtype == "int64"
 
         res = dfa.iloc[:0].combine_first(dfb)
         exp = DataFrame({"a": [np.nan, np.nan], "b": [4, 5]}, columns=["a", "b"])
@@ -223,14 +218,12 @@ class TestDataFrameCombineFirst:
             columns=["UTCdatetime", "abc"],
             data=data1,
             index=pd.date_range("20140627", periods=1),
-            dtype="object",
         )
         data2 = pd.to_datetime("20121212 12:12").tz_localize("UTC")
         df2 = DataFrame(
             columns=["UTCdatetime", "xyz"],
             data=data2,
             index=pd.date_range("20140628", periods=1),
-            dtype="object",
         )
         res = df2[["UTCdatetime"]].combine_first(df1)
         exp = DataFrame(
@@ -243,13 +236,10 @@ class TestDataFrameCombineFirst:
             },
             columns=["UTCdatetime", "abc"],
             index=pd.date_range("20140627", periods=2, freq="D"),
-            dtype="object",
         )
         assert res["UTCdatetime"].dtype == "datetime64[ns, UTC]"
         assert res["abc"].dtype == "datetime64[ns, UTC]"
-        # Need to cast all to "obejct" because combine_first does not retain dtypes:
-        # GH Issue 7509
-        res = res.astype("object")
+
         tm.assert_frame_equal(res, exp)
 
         # see gh-10567
@@ -364,18 +354,10 @@ class TestDataFrameCombineFirst:
         df2 = DataFrame({"a": [1, 4]}, dtype="int64")
 
         result_12 = df1.combine_first(df2)
-        expected_12 = DataFrame({"a": [0, 1, 3, 5]}, dtype="float64")
-        tm.assert_frame_equal(result_12, expected_12)
-
-        result_12 = df1.combine_first(df2, preserve_dtypes=True)
         expected_12 = DataFrame({"a": [0, 1, 3, 5]})
         tm.assert_frame_equal(result_12, expected_12)
 
         result_21 = df2.combine_first(df1)
-        expected_21 = DataFrame({"a": [1, 4, 3, 5]}, dtype="float64")
-        tm.assert_frame_equal(result_21, expected_21)
-
-        result_21 = df2.combine_first(df1, preserve_dtypes=True)
         expected_21 = DataFrame({"a": [1, 4, 3, 5]})
         tm.assert_frame_equal(result_21, expected_21)
 
@@ -415,11 +397,41 @@ class TestDataFrameCombineFirst:
 def test_combine_first_timestamp_bug(scalar1, scalar2, nulls_fixture):
     # GH28481
     na_value = nulls_fixture
+
     frame = DataFrame([[na_value, na_value]], columns=["a", "b"])
     other = DataFrame([[scalar1, scalar2]], columns=["b", "c"])
 
+    try:
+        common_dtype = find_common_type([frame.dtypes["b"], other.dtypes["b"]])
+    except TypeError:
+        common_dtype = "object"
+
+    if common_dtype == "object" or frame.dtypes["b"] == other.dtypes["b"]:
+        val = scalar1
+    else:
+        val = na_value
+
     result = frame.combine_first(other)
-    expected = DataFrame([[na_value, scalar1, scalar2]], columns=["a", "b", "c"])
+
+    expected = DataFrame([[na_value, val, scalar2]], columns=["a", "b", "c"])
+
+    expected["b"] = expected["b"].astype(common_dtype)
+
+    tm.assert_frame_equal(result, expected)
+
+
+def test_combine_first_timestamp_bug_NaT():
+    # GH28481
+    frame = DataFrame([[pd.NaT, pd.NaT]], columns=["a", "b"])
+    other = DataFrame(
+        [[datetime(2020, 1, 1), datetime(2020, 1, 2)]], columns=["b", "c"]
+    )
+
+    result = frame.combine_first(other)
+    expected = DataFrame(
+        [[pd.NaT, datetime(2020, 1, 1), datetime(2020, 1, 2)]], columns=["a", "b", "c"]
+    )
+
     tm.assert_frame_equal(result, expected)
 
 
@@ -464,21 +476,10 @@ def test_combine_preserve_dtypes():
     exp = DataFrame(
         {
             "A": ["a", "b", np.nan, np.nan],
-            "B": [0.0, 1.0, -1.0, 0.0],
-            "C": [np.nan, np.nan, "a", "b"],
-        },
-        index=[0, 1, 5, 6],
-    )
-    combined = f.combine_first(g)
-    tm.assert_frame_equal(combined, exp)
-
-    exp = DataFrame(
-        {
-            "A": ["a", "b", np.nan, np.nan],
             "B": [0, 1, -1, 0],
             "C": [np.nan, np.nan, "a", "b"],
         },
         index=[0, 1, 5, 6],
     )
-    combined = f.combine_first(g, preserve_dtypes=True)
+    combined = f.combine_first(g)
     tm.assert_frame_equal(combined, exp)

--- a/pandas/tests/frame/methods/test_combine_first.py
+++ b/pandas/tests/frame/methods/test_combine_first.py
@@ -3,10 +3,11 @@ from datetime import datetime
 import numpy as np
 import pytest
 
+from pandas.core.dtypes.cast import find_common_type
+
 import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, Series
 import pandas._testing as tm
-from pandas.core.dtypes.cast import find_common_type
 
 
 class TestDataFrameCombineFirst:

--- a/pandas/tests/frame/methods/test_combine_first.py
+++ b/pandas/tests/frame/methods/test_combine_first.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import numpy as np
 import pytest
 
-from pandas.core.dtypes.cast import find_common_type
+from pandas.core.dtypes.cast import find_common_type, is_dtype_equal
 
 import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, Series
@@ -402,12 +402,9 @@ def test_combine_first_timestamp_bug(scalar1, scalar2, nulls_fixture):
     frame = DataFrame([[na_value, na_value]], columns=["a", "b"])
     other = DataFrame([[scalar1, scalar2]], columns=["b", "c"])
 
-    try:
-        common_dtype = find_common_type([frame.dtypes["b"], other.dtypes["b"]])
-    except TypeError:
-        common_dtype = "object"
+    common_dtype = find_common_type([frame.dtypes["b"], other.dtypes["b"]])
 
-    if common_dtype == "object" or frame.dtypes["b"] == other.dtypes["b"]:
+    if is_dtype_equal(common_dtype, "object") or frame.dtypes["b"] == other.dtypes["b"]:
         val = scalar1
     else:
         val = na_value
@@ -466,6 +463,7 @@ def test_combine_first_with_nan_multiindex():
 
 
 def test_combine_preserve_dtypes():
+    # GH7509
     a = Series(["a", "b"], index=range(2))
     b = Series(range(2), index=range(2))
     f = DataFrame({"A": a, "B": b})

--- a/pandas/tests/frame/methods/test_combine_first.py
+++ b/pandas/tests/frame/methods/test_combine_first.py
@@ -24,9 +24,7 @@ class TestDataFrameCombineFirst:
         combined = f.combine_first(g)
         tm.assert_frame_equal(combined, exp)
 
-        exp = DataFrame(
-            {"A": list("abab"), "B": [0, 1, 0, 1]}, index=[0, 1, 5, 6]
-        )
+        exp = DataFrame({"A": list("abab"), "B": [0, 1, 0, 1]}, index=[0, 1, 5, 6])
         combined = f.combine_first(g, preserve_dtypes=True)
         tm.assert_frame_equal(combined, exp)
 
@@ -453,6 +451,7 @@ def test_combine_first_with_nan_multiindex():
     )
     tm.assert_frame_equal(res, expected)
 
+
 def test_combine_preserve_dtypes():
     a = Series(["a", "b"], index=range(2))
     b = Series(range(2), index=range(2))
@@ -466,9 +465,9 @@ def test_combine_preserve_dtypes():
         {
             "A": ["a", "b", np.nan, np.nan],
             "B": [0.0, 1.0, -1.0, 0.0],
-            "C": [np.nan, np.nan, "a", "b"]
+            "C": [np.nan, np.nan, "a", "b"],
         },
-        index=[0, 1, 5, 6]
+        index=[0, 1, 5, 6],
     )
     combined = f.combine_first(g)
     tm.assert_frame_equal(combined, exp)
@@ -477,9 +476,9 @@ def test_combine_preserve_dtypes():
         {
             "A": ["a", "b", np.nan, np.nan],
             "B": [0, 1, -1, 0],
-            "C": [np.nan, np.nan, "a", "b"]
+            "C": [np.nan, np.nan, "a", "b"],
         },
-        index=[0, 1, 5, 6]
+        index=[0, 1, 5, 6],
     )
     combined = f.combine_first(g, preserve_dtypes=True)
     tm.assert_frame_equal(combined, exp)

--- a/pandas/tests/frame/methods/test_combine_first.py
+++ b/pandas/tests/frame/methods/test_combine_first.py
@@ -464,15 +464,15 @@ def test_combine_first_with_nan_multiindex():
 
 def test_combine_preserve_dtypes():
     # GH7509
-    a = Series(["a", "b"], index=range(2))
-    b = Series(range(2), index=range(2))
-    f = DataFrame({"A": a, "B": b})
+    a_column = Series(["a", "b"], index=range(2))
+    b_column = Series(range(2), index=range(2))
+    df1 = DataFrame({"A": a_column, "B": b_column})
 
-    c = Series(["a", "b"], index=range(5, 7))
-    b = Series(range(-1, 1), index=range(5, 7))
-    g = DataFrame({"B": b, "C": c})
+    c_column = Series(["a", "b"], index=range(5, 7))
+    b_column = Series(range(-1, 1), index=range(5, 7))
+    df2 = DataFrame({"B": b_column, "C": c_column})
 
-    exp = DataFrame(
+    expected = DataFrame(
         {
             "A": ["a", "b", np.nan, np.nan],
             "B": [0, 1, -1, 0],
@@ -480,5 +480,5 @@ def test_combine_preserve_dtypes():
         },
         index=[0, 1, 5, 6],
     )
-    combined = f.combine_first(g)
-    tm.assert_frame_equal(combined, exp)
+    combined = df1.combine_first(df2)
+    tm.assert_frame_equal(combined, expected)


### PR DESCRIPTION
…e two DataFrame objects have the same columns

- [ ] closes #7509 
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
