### PR TITLE
TST: skips in extension.test_categorical

### DIFF
--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -394,7 +394,6 @@ class BaseMethodsTests(BaseExtensionTests):
 
     def test_searchsorted(self, data_for_sorting, as_series):
         b, c, a = data_for_sorting
-        # Pass dtype so sorting order is not lost for Categorical
         arr = data_for_sorting.take([2, 0, 1])  # to get [a, b, c]
 
         if as_series:

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -395,9 +395,7 @@ class BaseMethodsTests(BaseExtensionTests):
     def test_searchsorted(self, data_for_sorting, as_series):
         b, c, a = data_for_sorting
         # Pass dtype so sorting order is not lost for Categorical
-        arr = type(data_for_sorting)._from_sequence(
-            [a, b, c], dtype=data_for_sorting.dtype
-        )
+        arr = data_for_sorting.take([2, 0, 1])  # to get [a, b, c]
 
         if as_series:
             arr = pd.Series(arr)

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -394,7 +394,10 @@ class BaseMethodsTests(BaseExtensionTests):
 
     def test_searchsorted(self, data_for_sorting, as_series):
         b, c, a = data_for_sorting
-        arr = type(data_for_sorting)._from_sequence([a, b, c])
+        # Pass dtype so sorting order is not lost for Categorical
+        arr = type(data_for_sorting)._from_sequence(
+            [a, b, c], dtype=data_for_sorting.dtype
+        )
 
         if as_series:
             arr = pd.Series(arr)

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -175,9 +175,8 @@ class TestMethods(base.BaseMethodsTests):
     def test_fillna_length_mismatch(self, data_missing):
         super().test_fillna_length_mismatch(data_missing)
 
-    def test_searchsorted(self, data_for_sorting):
-        if not data_for_sorting.ordered:
-            raise pytest.skip(reason="searchsorted requires ordered data.")
+    def test_searchsorted(self, data_for_sorting, as_series):
+        super().test_searchsorted(data_for_sorting, as_series)
 
 
 class TestCasting(base.BaseCastingTests):
@@ -229,21 +228,26 @@ class TestCasting(base.BaseCastingTests):
 
 
 class TestArithmeticOps(base.BaseArithmeticOpsTests):
-    def test_arith_frame_with_scalar(self, data, all_arithmetic_operators):
+    def test_arith_frame_with_scalar(self, data, all_arithmetic_operators, request):
         # frame & scalar
         op_name = all_arithmetic_operators
-        if op_name != "__rmod__":
-            super().test_arith_frame_with_scalar(data, all_arithmetic_operators)
-        else:
-            pytest.skip("rmod never called when string is first argument")
+        if op_name == "__rmod__":
+            request.node.add_marker(
+                pytest.mark.xfail(
+                    reason="rmod never called when string is first argument"
+                )
+            )
+        super().test_arith_frame_with_scalar(data, op_name)
 
-    def test_arith_series_with_scalar(self, data, all_arithmetic_operators):
-
+    def test_arith_series_with_scalar(self, data, all_arithmetic_operators, request):
         op_name = all_arithmetic_operators
-        if op_name != "__rmod__":
-            super().test_arith_series_with_scalar(data, op_name)
-        else:
-            pytest.skip("rmod never called when string is first argument")
+        if op_name == "__rmod__":
+            request.node.add_marker(
+                pytest.mark.xfail(
+                    reason="rmod never called when string is first argument"
+                )
+            )
+        super().test_arith_series_with_scalar(data, op_name)
 
     def test_add_series_with_extension_array(self, data):
         ser = pd.Series(data)

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -175,9 +175,6 @@ class TestMethods(base.BaseMethodsTests):
     def test_fillna_length_mismatch(self, data_missing):
         super().test_fillna_length_mismatch(data_missing)
 
-    def test_searchsorted(self, data_for_sorting, as_series):
-        super().test_searchsorted(data_for_sorting, as_series)
-
 
 class TestCasting(base.BaseCastingTests):
     @pytest.mark.parametrize("cls", [Categorical, CategoricalIndex])


### PR DESCRIPTION
- [x] closes #38904  
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

cc @simonjayhawkins 

For the searchsorted test, the categorical data starts off ordered as "C" < "A" < "B" but then gets reordered in the test by these lines:

> b, c, a = data_for_sorting
        arr = type(data_for_sorting)._from_sequence([a, b, c])

so the ordering becomes "A" < "B" < "C". This causes failure when "C" is said to be inserted at index 3 (new order) to preserve order rather than the expected 0 (original order).

