### PR TITLE
TYP: ALL_NUMPY_DTYPES mypy errors with numpy-1.20

### DIFF
--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -108,9 +108,9 @@ STRING_DTYPES: List[Dtype] = [str, "str", "U"]
 DATETIME64_DTYPES: List[Dtype] = ["datetime64[ns]", "M8[ns]"]
 TIMEDELTA64_DTYPES: List[Dtype] = ["timedelta64[ns]", "m8[ns]"]
 
-BOOL_DTYPES = [bool, "bool"]
-BYTES_DTYPES = [bytes, "bytes"]
-OBJECT_DTYPES = [object, "object"]
+BOOL_DTYPES: List[Dtype] = [bool, "bool"]
+BYTES_DTYPES: List[Dtype] = [bytes, "bytes"]
+OBJECT_DTYPES: List[Dtype] = [object, "object"]
 
 ALL_REAL_DTYPES = FLOAT_DTYPES + ALL_INT_DTYPES
 ALL_NUMPY_DTYPES = (


### PR DESCRIPTION
prevents mypy errors

pandas/_testing/__init__.py:122: error: Unsupported operand types for + ("List[Union[ExtensionDtype, Union[str, dtype[Any]], Type[str], Type[float], Type[int], Type[complex], Type[bool], Type[object]]]" and "List[object]")  [operator]
pandas/_testing/__init__.py:123: error: Unsupported operand types for + ("List[Union[ExtensionDtype, Union[str, dtype[Any]], Type[str], Type[float], Type[int], Type[complex], Type[bool], Type[object]]]" and "List[object]")  [operator]
pandas/_testing/__init__.py:124: error: Unsupported operand types for + ("List[Union[ExtensionDtype, Union[str, dtype[Any]], Type[str], Type[float], Type[int], Type[complex], Type[bool], Type[object]]]" and "List[object]")  [operator]