### PR TITLE
TYP: prep _generate_range_overflow_safe for numpy 1.20

### DIFF
--- a/pandas/core/arrays/_ranges.py
+++ b/pandas/core/arrays/_ranges.py
@@ -69,8 +69,11 @@ def generate_regular_range(
 
 
 def _generate_range_overflow_safe(
-    endpoint: int, periods: int, stride: int, side: str = "start"
-) -> int:
+    endpoint: Union[int, np.integer],
+    periods: Union[int, np.integer],
+    stride: int,
+    side: str = "start",
+) -> np.integer:
     """
     Calculate the second endpoint for passing to np.arange, checking
     to avoid an integer overflow.  Catch OverflowError and re-raise
@@ -89,7 +92,7 @@ def _generate_range_overflow_safe(
 
     Returns
     -------
-    other_end : int
+    np.integer
 
     Raises
     ------
@@ -136,8 +139,11 @@ def _generate_range_overflow_safe(
 
 
 def _generate_range_overflow_safe_signed(
-    endpoint: int, periods: int, stride: int, side: str
-) -> int:
+    endpoint: Union[int, np.integer],
+    periods: Union[int, np.integer],
+    stride: int,
+    side: str,
+) -> np.integer:
     """
     A special case for _generate_range_overflow_safe where `periods * stride`
     can be calculated without overflowing int64 bounds.

--- a/pandas/core/arrays/_ranges.py
+++ b/pandas/core/arrays/_ranges.py
@@ -69,11 +69,8 @@ def generate_regular_range(
 
 
 def _generate_range_overflow_safe(
-    endpoint: Union[int, np.integer],
-    periods: Union[int, np.integer],
-    stride: int,
-    side: str = "start",
-) -> np.integer:
+    endpoint: int, periods: int, stride: int, side: str = "start"
+):
     """
     Calculate the second endpoint for passing to np.arange, checking
     to avoid an integer overflow.  Catch OverflowError and re-raise
@@ -139,11 +136,8 @@ def _generate_range_overflow_safe(
 
 
 def _generate_range_overflow_safe_signed(
-    endpoint: Union[int, np.integer],
-    periods: Union[int, np.integer],
-    stride: int,
-    side: str,
-) -> np.integer:
+    endpoint: int, periods: int, stride: int, side: str
+):
     """
     A special case for _generate_range_overflow_safe where `periods * stride`
     can be calculated without overflowing int64 bounds.


### PR DESCRIPTION
difficult call, will replace

pandas/core/arrays/_ranges.py:153: error: Incompatible return value type (got "signedinteger[_64Bit]", expected "int")  [return-value]
pandas/core/arrays/_ranges.py:171: error: Incompatible return value type (got "unsignedinteger[_64Bit]", expected "int")  [return-value]

with

pandas/core/arrays/_ranges.py:129: error: Argument 1 to "_generate_range_overflow_safe" has incompatible type "Union[int, number[Any]]"; expected "Union[int, integer[Any]]"  [arg-type]
pandas/core/arrays/_ranges.py:129: error: Argument 2 to "_generate_range_overflow_safe" has incompatible type "Union[int, number[Any]]"; expected "Union[int, integer[Any]]"  [arg-type]
pandas/core/arrays/_ranges.py:137: error: Argument 2 to "_generate_range_overflow_safe" has incompatible type "Union[int, number[Any]]"; expected "Union[int, integer[Any]]"  [arg-type]
pandas/core/arrays/_ranges.py:138: error: Argument 2 to "_generate_range_overflow_safe" has incompatible type "Union[int, number[Any]]"; expected "Union[int, integer[Any]]"  [arg-type]

these are from arithmetic operations on np.integer (including floordiv) which AFAICT should return np.integer and not np.number

can't add the ignores yet, since we will get unused ignore mypy messages - active branch with fixes https://github.com/pandas-dev/pandas/compare/master...simonjayhawkins:numpy-fixes?expand=1