### PR TITLE
TYP: PeriodArray._unbox_scalar

### DIFF
--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -272,7 +272,7 @@ class PeriodArray(PeriodMixin, dtl.DatelikeOps):
 
     def _unbox_scalar(
         self, value: Union[Period, NaTType], setitem: bool = False
-    ) -> int:
+    ) -> np.int64:
         if value is NaT:
             return np.int64(value.value)
         elif isinstance(value, self._scalar_type):


### PR DESCRIPTION
mypy errors with numpy 1.20

pandas/core/arrays/period.py:273: error: Return type "int" of "_unbox_scalar" incompatible with return type "Union[signedinteger[_64Bit], datetime64, timedelta64]" in supertype "DatetimeLikeArrayMixin"  [override]
pandas/core/arrays/period.py:277: error: Incompatible return value type (got "signedinteger[_64Bit]", expected "int")  [return-value]
pandas/core/arrays/period.py:280: error: Incompatible return value type (got "signedinteger[_64Bit]", expected "int")  [return-value]