### PR TITLE
REF: Remove Apply.get_result

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -40,7 +40,6 @@ ResType = Dict[int, Any]
 
 def frame_apply(
     obj: DataFrame,
-    how: str,
     func: AggFuncType,
     axis: Axis = 0,
     raw: bool = False,
@@ -58,7 +57,6 @@ def frame_apply(
 
     return klass(
         obj,
-        how,
         func,
         raw=raw,
         result_type=result_type,
@@ -69,7 +67,6 @@ def frame_apply(
 
 def series_apply(
     obj: Series,
-    how: str,
     func: AggFuncType,
     convert_dtype: bool = True,
     args=None,
@@ -77,7 +74,6 @@ def series_apply(
 ) -> SeriesApply:
     return SeriesApply(
         obj,
-        how,
         func,
         convert_dtype,
         args,
@@ -91,16 +87,13 @@ class Apply(metaclass=abc.ABCMeta):
     def __init__(
         self,
         obj: FrameOrSeriesUnion,
-        how: str,
         func,
         raw: bool,
         result_type: Optional[str],
         args,
         kwds,
     ):
-        assert how in ("apply", "agg")
         self.obj = obj
-        self.how = how
         self.raw = raw
         self.args = args or ()
         self.kwds = kwds or {}
@@ -131,12 +124,6 @@ class Apply(metaclass=abc.ABCMeta):
     @property
     def index(self) -> Index:
         return self.obj.index
-
-    def get_result(self):
-        if self.how == "apply":
-            return self.apply()
-        else:
-            return self.agg()
 
     @abc.abstractmethod
     def apply(self) -> FrameOrSeriesUnion:
@@ -233,12 +220,6 @@ class FrameApply(Apply):
     @property
     def agg_axis(self) -> Index:
         return self.obj._get_agg_axis(self.axis)
-
-    def get_result(self):
-        if self.how == "apply":
-            return self.apply()
-        else:
-            return self.agg()
 
     def apply(self) -> FrameOrSeriesUnion:
         """ compute the results """
@@ -570,7 +551,6 @@ class SeriesApply(Apply):
     def __init__(
         self,
         obj: Series,
-        how: str,
         func: AggFuncType,
         convert_dtype: bool,
         args,
@@ -580,7 +560,6 @@ class SeriesApply(Apply):
 
         super().__init__(
             obj,
-            how,
             func,
             raw=False,
             result_type=None,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7646,13 +7646,12 @@ NaN 12.3   33.0
 
         op = frame_apply(
             self if axis == 0 else self.T,
-            how="agg",
             func=arg,
             axis=0,
             args=args,
             kwds=kwargs,
         )
-        result, how = op.get_result()
+        result, how = op.agg()
 
         if axis == 1:
             # NDFrame.aggregate returns a tuple, and we need to transpose
@@ -7819,7 +7818,6 @@ NaN 12.3   33.0
 
         op = frame_apply(
             self,
-            how="apply",
             func=func,
             axis=axis,
             raw=raw,
@@ -7827,7 +7825,7 @@ NaN 12.3   33.0
             args=args,
             kwds=kwds,
         )
-        return op.get_result()
+        return op.apply()
 
     def applymap(
         self, func: PythonFuncType, na_action: Optional[str] = None

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3944,8 +3944,8 @@ Keep all original rows and also all original values
         if func is None:
             func = dict(kwargs.items())
 
-        op = series_apply(self, "agg", func, args=args, kwds=kwargs)
-        result, how = op.get_result()
+        op = series_apply(self, func, args=args, kwds=kwargs)
+        result, how = op.agg()
         if result is None:
 
             # we can be called from an inner function which
@@ -4077,8 +4077,8 @@ Keep all original rows and also all original values
         Helsinki    2.484907
         dtype: float64
         """
-        op = series_apply(self, "apply", func, convert_dtype, args, kwds)
-        return op.get_result()
+        op = series_apply(self, func, convert_dtype, args, kwds)
+        return op.apply()
 
     def _reduce(
         self,


### PR DESCRIPTION
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

Slightly simpler and allows typing of the result that we get out of Apply. Having both apply and agg go through get_result would mean typing the result as `Union[FrameOrSeriesUnion, Tuple[bool, Optional[FrameOrSeriesUnion]]]`