### PR TITLE
TYP: NDFrame.pipe, GroupBy.pipe etc.

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -8,7 +8,19 @@ from collections import abc, defaultdict
 import contextlib
 from functools import partial
 import inspect
-from typing import Any, Collection, Iterable, Iterator, List, Optional, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Collection,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 import warnings
 
 import numpy as np
@@ -27,6 +39,9 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.generic import ABCExtensionArray, ABCIndex, ABCSeries
 from pandas.core.dtypes.inference import iterable_not_string
 from pandas.core.dtypes.missing import isna, isnull, notnull  # noqa
+
+if TYPE_CHECKING:
+    from pandas._typing import T
 
 
 class SettingWithCopyError(ValueError):
@@ -405,7 +420,9 @@ def random_state(state=None):
         )
 
 
-def pipe(obj, func, *args, **kwargs):
+def pipe(
+    obj, func: Union[Callable[..., T], Tuple[Callable[..., T], str]], *args, **kwargs
+) -> T:
     """
     Apply a function ``func`` to object ``obj`` either by passing obj as the
     first argument to the function or, in the case that the func is a tuple,

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -40,9 +40,6 @@ from pandas.core.dtypes.generic import ABCExtensionArray, ABCIndex, ABCSeries
 from pandas.core.dtypes.inference import iterable_not_string
 from pandas.core.dtypes.missing import isna, isnull, notnull  # noqa
 
-if TYPE_CHECKING:
-    from pandas._typing import T
-
 
 class SettingWithCopyError(ValueError):
     pass

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -9,7 +9,6 @@ import contextlib
 from functools import partial
 import inspect
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Collection,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -123,6 +123,7 @@ from pandas.io.formats.printing import pprint_thing
 
 if TYPE_CHECKING:
     from pandas._libs.tslibs import BaseOffset
+    from pandas._typing import T
 
     from pandas.core.frame import DataFrame
     from pandas.core.resample import Resampler
@@ -5356,7 +5357,12 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
     @final
     @doc(klass=_shared_doc_kwargs["klass"])
-    def pipe(self, func, *args, **kwargs):
+    def pipe(
+        self,
+        func: Union[Callable[..., T], Tuple[Callable[..., T], str]],
+        *args,
+        **kwargs,
+    ) -> T:
         r"""
         Apply func(self, \*args, \*\*kwargs).
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -49,6 +49,7 @@ from pandas._typing import (
     NpDtype,
     Renamer,
     StorageOptions,
+    T,
     TimedeltaConvertibleTypes,
     TimestampConvertibleTypes,
     ValueKeyFunc,
@@ -123,7 +124,6 @@ from pandas.io.formats.printing import pprint_thing
 
 if TYPE_CHECKING:
     from pandas._libs.tslibs import BaseOffset
-    from pandas._typing import T
 
     from pandas.core.frame import DataFrame
     from pandas.core.resample import Resampler

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -47,6 +47,7 @@ from pandas._typing import (
     IndexLabel,
     Label,
     Scalar,
+    T,
     final,
 )
 from pandas.compat.numpy import function as nv
@@ -79,10 +80,6 @@ from pandas.core.indexes.api import CategoricalIndex, Index, MultiIndex
 from pandas.core.series import Series
 from pandas.core.sorting import get_group_index_sorter
 from pandas.core.util.numba_ import NUMBA_FUNC_CACHE
-
-if TYPE_CHECKING:
-    from pandas._typing import T
-
 
 _common_see_also = """
         See Also

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -6,6 +6,7 @@ The SeriesGroupBy and DataFrameGroupBy sub-class
 (defined in pandas.core.groupby.generic)
 expose these user-facing objects to provide specific functionality.
 """
+from __future__ import annotations
 
 from contextlib import contextmanager
 import datetime
@@ -14,6 +15,7 @@ import inspect
 from textwrap import dedent
 import types
 from typing import (
+    TYPE_CHECKING,
     Callable,
     Dict,
     FrozenSet,
@@ -77,6 +79,10 @@ from pandas.core.indexes.api import CategoricalIndex, Index, MultiIndex
 from pandas.core.series import Series
 from pandas.core.sorting import get_group_index_sorter
 from pandas.core.util.numba_ import NUMBA_FUNC_CACHE
+
+if TYPE_CHECKING:
+    from pandas._typing import T
+
 
 _common_see_also = """
         See Also
@@ -476,7 +482,7 @@ class GroupByPlot(PandasObject):
 
 
 @contextmanager
-def group_selection_context(groupby: "BaseGroupBy") -> Iterator["BaseGroupBy"]:
+def group_selection_context(groupby: BaseGroupBy) -> Iterator[BaseGroupBy]:
     """
     Set / reset the group_selection_context.
     """
@@ -724,8 +730,8 @@ class BaseGroupBy(PandasObject, SelectionMixin, Generic[FrameOrSeries]):
 
     @final
     def _set_result_index_ordered(
-        self, result: "OutputFrameOrSeries"
-    ) -> "OutputFrameOrSeries":
+        self, result: OutputFrameOrSeries
+    ) -> OutputFrameOrSeries:
         # set the result index on the passed values object and
         # return the new object, xref 8046
 
@@ -790,7 +796,12 @@ class BaseGroupBy(PandasObject, SelectionMixin, Generic[FrameOrSeries]):
         ),
     )
     @Appender(_pipe_template)
-    def pipe(self, func, *args, **kwargs):
+    def pipe(
+        self,
+        func: Union[Callable[..., T], Tuple[Callable[..., T], str]],
+        *args,
+        **kwargs,
+    ) -> T:
         return com.pipe(self, func, *args, **kwargs)
 
     plot = property(GroupByPlot)
@@ -3058,7 +3069,7 @@ def get_groupby(
     by: Optional[_KeysArgType] = None,
     axis: int = 0,
     level=None,
-    grouper: "Optional[ops.BaseGrouper]" = None,
+    grouper: Optional[ops.BaseGrouper] = None,
     exclusions=None,
     selection=None,
     as_index: bool = True,

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -15,7 +15,6 @@ import inspect
 from textwrap import dedent
 import types
 from typing import (
-    TYPE_CHECKING,
     Callable,
     Dict,
     FrozenSet,

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -16,7 +16,7 @@ from pandas._libs.tslibs import (
     Timestamp,
     to_offset,
 )
-from pandas._typing import TimedeltaConvertibleTypes, TimestampConvertibleTypes
+from pandas._typing import T, TimedeltaConvertibleTypes, TimestampConvertibleTypes
 from pandas.compat.numpy import function as nv
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import Appender, Substitution, doc
@@ -44,9 +44,6 @@ from pandas.core.indexes.timedeltas import TimedeltaIndex, timedelta_range
 
 from pandas.tseries.frequencies import is_subperiod, is_superperiod
 from pandas.tseries.offsets import DateOffset, Day, Nano, Tick
-
-if TYPE_CHECKING:
-    from pandas._typing import T
 
 _shared_docs_kwargs: Dict[str, str] = {}
 

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 from datetime import timedelta
 from textwrap import dedent

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1,7 +1,7 @@
 import copy
 from datetime import timedelta
 from textwrap import dedent
-from typing import Dict, Optional, Union, no_type_check
+from typing import TYPE_CHECKING, Callable, Dict, Optional, Tuple, Union, no_type_check
 
 import numpy as np
 
@@ -42,6 +42,9 @@ from pandas.core.indexes.timedeltas import TimedeltaIndex, timedelta_range
 
 from pandas.tseries.frequencies import is_subperiod, is_superperiod
 from pandas.tseries.offsets import DateOffset, Day, Nano, Tick
+
+if TYPE_CHECKING:
+    from pandas._typing import T
 
 _shared_docs_kwargs: Dict[str, str] = {}
 
@@ -231,7 +234,12 @@ class Resampler(BaseGroupBy, ShallowMixin):
     2012-08-04  1""",
     )
     @Appender(_pipe_template)
-    def pipe(self, func, *args, **kwargs):
+    def pipe(
+        self,
+        func: Union[Callable[..., T], Tuple[Callable[..., T], str]],
+        *args,
+        **kwargs,
+    ) -> T:
         return super().pipe(func, *args, **kwargs)
 
     _agg_see_also_doc = dedent(

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 from datetime import timedelta
 from textwrap import dedent
-from typing import TYPE_CHECKING, Callable, Dict, Optional, Tuple, Union, no_type_check
+from typing import Callable, Dict, Optional, Tuple, Union, no_type_check
 
 import numpy as np
 


### PR DESCRIPTION
Type up `pipe` function and methods. This allows type checkers to understand the return value type from pipes, which is nice.
