### PR TITLE
ENH: Allow numpy ops and DataFrame properties as str arguments to DataFrame.apply

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -54,6 +54,8 @@ Other enhancements
 - Add support for dict-like names in :class:`MultiIndex.set_names` and :class:`MultiIndex.rename` (:issue:`20421`)
 - :func:`pandas.read_excel` can now auto detect .xlsb files (:issue:`35416`)
 - :meth:`.Rolling.sum`, :meth:`.Expanding.sum`, :meth:`.Rolling.mean`, :meth:`.Expanding.mean`, :meth:`.Rolling.median`, :meth:`.Expanding.median`, :meth:`.Rolling.max`, :meth:`.Expanding.max`, :meth:`.Rolling.min`, and :meth:`.Expanding.min` now support ``Numba`` execution with the ``engine`` keyword (:issue:`38895`)
+- :meth:`DataFrame.apply` can now accept NumPy unary operators as strings, e.g. ``df.apply("sqrt")``, which was already the case for :meth:`Series.apply` (:issue:`39116`)
+- :meth:`DataFrame.apply` can now accept non-callable DataFrame properties as strings, e.g. ``df.apply("size")``, which was already the case for :meth:`Series.apply` (:issue:`39116`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/tests/series/apply/test_series_apply.py
+++ b/pandas/tests/series/apply/test_series_apply.py
@@ -338,19 +338,21 @@ class TestSeriesAggregate:
         )
         tm.assert_series_equal(result, expected)
 
-    def test_non_callable_aggregates(self):
+    @pytest.mark.parametrize("how", ["agg", "apply"])
+    def test_non_callable_aggregates(self, how):
         # test agg using non-callable series attributes
+        # GH 39116 - expand to apply
         s = Series([1, 2, None])
 
         # Calling agg w/ just a string arg same as calling s.arg
-        result = s.agg("size")
+        result = getattr(s, how)("size")
         expected = s.size
         assert result == expected
 
         # test when mixed w/ callable reducers
-        result = s.agg(["size", "count", "mean"])
+        result = getattr(s, how)(["size", "count", "mean"])
         expected = Series({"size": 3.0, "count": 2.0, "mean": 1.5})
-        tm.assert_series_equal(result[expected.index], expected)
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize(
         "series, func, expected",


### PR DESCRIPTION
- [x] closes #39116
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

