### PR TITLE
DOC: fixed a minor mistake worksheet -> workbook

### DIFF
--- a/doc/source/getting_started/comparison/comparison_with_spreadsheets.rst
+++ b/doc/source/getting_started/comparison/comparison_with_spreadsheets.rst
@@ -35,7 +35,7 @@ General terminology translation
 ``DataFrame``
 ~~~~~~~~~~~~~
 
-A ``DataFrame`` in pandas is analogous to an Excel worksheet. While an Excel worksheet can contain
+A ``DataFrame`` in pandas is analogous to an Excel worksheet. While an Excel workbook can contain
 multiple worksheets, pandas ``DataFrame``\s exist independently.
 
 ``Series``


### PR DESCRIPTION
A small typo related to #38990
A worksheet can't have multiple worksheets, but a workbook can. Minor fix but may confuse the newcomers

- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
