### PR TITLE
BUG: Close resources opened by pyxlsb

### DIFF
--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -292,13 +292,12 @@ def _get_filepath_or_buffer(
 
         # assuming storage_options is to be interpretted as headers
         req_info = urllib.request.Request(filepath_or_buffer, headers=storage_options)
-        req = urlopen(req_info)
-        content_encoding = req.headers.get("Content-Encoding", None)
-        if content_encoding == "gzip":
-            # Override compression based on Content-Encoding header
-            compression = {"method": "gzip"}
-        reader = BytesIO(req.read())
-        req.close()
+        with urlopen(req_info) as req:
+            content_encoding = req.headers.get("Content-Encoding", None)
+            if content_encoding == "gzip":
+                # Override compression based on Content-Encoding header
+                compression = {"method": "gzip"}
+            reader = BytesIO(req.read())
         return IOArgs(
             filepath_or_buffer=reader,
             encoding=encoding,

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -410,6 +410,9 @@ class BaseExcelReader(metaclass=abc.ABCMeta):
         pass
 
     def close(self):
+        if hasattr(self.book, "close"):
+            # pyxlsb opens a TemporaryFile
+            self.book.close()
         self.handles.close()
 
     @property
@@ -483,6 +486,9 @@ class BaseExcelReader(metaclass=abc.ABCMeta):
                 sheet = self.get_sheet_by_index(asheetname)
 
             data = self.get_sheet_data(sheet, convert_float)
+            if hasattr(sheet, "close"):
+                # pyxlsb opens two TemporaryFiles
+                sheet.close()
             usecols = maybe_convert_usecols(usecols)
 
             if not data:

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -465,6 +465,12 @@ def test_pickle_generalurl_read(monkeypatch, mockurl):
             else:
                 self.headers = {"Content-Encoding": None}
 
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            self.close()
+
         def read(self):
             return self.file.read()
 


### PR DESCRIPTION
Spin-off from #39047:
- Close resources opened by pyxlsb
- Use context manager when opening non-fsspec URLs (I'm not sure whether that reduced any `ResourceWarning`s but it can't hurt)
