### PR TITLE
BUG: setting categorical values into object dtype DataFrame

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -195,6 +195,7 @@ Categorical
 - Bug where constructing a :class:`Categorical` from an object-dtype array of ``date`` objects did not round-trip correctly with ``astype`` (:issue:`38552`)
 - Bug in constructing a :class:`DataFrame` from an ``ndarray`` and a :class:`CategoricalDtype` (:issue:`38857`)
 - Bug in :meth:`DataFrame.reindex` was throwing ``IndexError`` when new index contained duplicates and old index was :class:`CategoricalIndex` (:issue:`38906`)
+- Bug in setting categorical values into an object-dtype column in a :class:`DataFrame` (:issue:`39136`)
 
 Datetimelike
 ^^^^^^^^^^^^

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -965,7 +965,12 @@ class Block(PandasObject):
             # GH25495 - If the current dtype is not categorical,
             # we need to create a new categorical block
             values[indexer] = value
-            return self.make_block(Categorical(self.values, dtype=arr_value.dtype))
+            if values.ndim == 2:
+                if values.shape[-1] != 1:
+                    # shouldn't get here (at least until 2D EAs)
+                    raise NotImplementedError
+                values = values[:, 0]
+            return self.make_block(Categorical(values, dtype=arr_value.dtype))
 
         elif exact_match and is_ea_value:
             # GH#32395 if we're going to replace the values entirely, just

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -966,6 +966,7 @@ class Block(PandasObject):
             # we need to create a new categorical block
             values[indexer] = value
             if values.ndim == 2:
+                # TODO(EA2D): special case not needed with 2D EAs
                 if values.shape[-1] != 1:
                     # shouldn't get here (at least until 2D EAs)
                     raise NotImplementedError


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

```
df = pd.DataFrame({"A": range(3)}, dtype=object)
cat = pd.Categorical(["alpha", "beta", "gamma"])

df.iloc[range(3), 0] = cat

>>> df
     A
0  NaN
1     
2     

```