### PR TITLE
Fix regression in loc setitem raising KeyError when enlarging df with multiindex

### DIFF
--- a/doc/source/whatsnew/v1.2.1.rst
+++ b/doc/source/whatsnew/v1.2.1.rst
@@ -29,7 +29,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrameGroupBy.diff` raising for ``int8`` and ``int16`` columns (:issue:`39050`)
 - Fixed regression that raised ``AttributeError`` with PyArrow versions [0.16.0, 1.0.0) (:issue:`38801`)
 - Fixed regression in :meth:`DataFrame.groupby` when aggregating an :class:`ExtensionDType` that could fail for non-numeric values (:issue:`38980`)
--
+- Fixed regression in :meth:`DataFrame.loc.__setitem__` raising ``KeyError`` with :class:`MultiIndex` and list-like columns indexer enlarging :class:`DataFrame` (:issue:`39147`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -663,10 +663,13 @@ class _LocationIndexer(NDFrameIndexerBase):
             return
 
         if isinstance(key, tuple) and (
-            isinstance(key[0], slice) or not isinstance(self.obj.index, ABCMultiIndex)
+            not isinstance(self.obj.index, ABCMultiIndex)
+            or len(key) == 2
+            and not isinstance(key[1], slice)
         ):
             # key may be a tuple if we are .loc
-            # if index is not a MultiIndex, set key to column part
+            # if index is not a MultiIndex or second element is not a slice,
+            # set key to column part
             key = key[column_axis]
             axis = column_axis
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -662,14 +662,9 @@ class _LocationIndexer(NDFrameIndexerBase):
         if self.ndim != 2:
             return
 
-        if isinstance(key, tuple) and (
-            not isinstance(self.obj.index, ABCMultiIndex)
-            or len(key) == 2
-            and not isinstance(key[1], slice)
-        ):
+        if isinstance(key, tuple) and len(key) > 1:
             # key may be a tuple if we are .loc
-            # if index is not a MultiIndex or second element is not a slice,
-            # set key to column part
+            # if length of key is > 1 set key to column part
             key = key[column_axis]
             axis = column_axis
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -662,7 +662,9 @@ class _LocationIndexer(NDFrameIndexerBase):
         if self.ndim != 2:
             return
 
-        if isinstance(key, tuple) and not isinstance(self.obj.index, ABCMultiIndex):
+        if isinstance(key, tuple) and (
+            isinstance(key[0], slice) or not isinstance(self.obj.index, ABCMultiIndex)
+        ):
             # key may be a tuple if we are .loc
             # if index is not a MultiIndex, set key to column part
             key = key[column_axis]

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -308,13 +308,16 @@ class TestMultiIndexLoc:
         expected = DataFrame([0, 2], index=mi)
         tm.assert_frame_equal(obj, expected)
 
-    def test_multiindex_setitem_columns_enlarging(self):
+    @pytest.mark.parametrize(
+        "indexer, exp_value", [(slice(None), 1.0), ((1, 2), np.nan)]
+    )
+    def test_multiindex_setitem_columns_enlarging(self, indexer, exp_value):
         # GH#39147
         mi = MultiIndex.from_tuples([(1, 2), (3, 4)])
         df = DataFrame([[1, 2], [3, 4]], index=mi, columns=["a", "b"])
-        df.loc[:, ["c", "d"]] = None
+        df.loc[indexer, ["c", "d"]] = 1.0
         expected = DataFrame(
-            [[1, 2, None, None], [3, 4, None, None]],
+            [[1, 2, 1.0, 1.0], [3, 4, exp_value, exp_value]],
             index=mi,
             columns=["a", "b", "c", "d"],
         )

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -308,6 +308,18 @@ class TestMultiIndexLoc:
         expected = DataFrame([0, 2], index=mi)
         tm.assert_frame_equal(obj, expected)
 
+    def test_multiindex_setitem_columns_enlarging(self):
+        # GH#39147
+        mi = MultiIndex.from_tuples([(1, 2), (3, 4)])
+        df = DataFrame([[1, 2], [3, 4]], index=mi, columns=["a", "b"])
+        df.loc[:, ["c", "d"]] = None
+        expected = DataFrame(
+            [[1, 2, None, None], [3, 4, None, None]],
+            index=mi,
+            columns=["a", "b", "c", "d"],
+        )
+        tm.assert_frame_equal(df, expected)
+
 
 @pytest.mark.parametrize(
     "indexer, pos",


### PR DESCRIPTION
- [x] closes #39147
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

The previous fix only viewed row indexers not column indexers