### PR TITLE
CLN,TYP Remove string return annotations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -145,11 +145,12 @@ repos:
         language: pygrep
         types_or: [python, cython]
     -   id: unwanted-typing
-        name: Check for use of comment-based annotation syntax and missing error codes
+        name: Check for outdated annotation syntax and missing error codes
         entry: |
             (?x)
             \#\ type:\ (?!ignore)|
-            \#\ type:\s?ignore(?!\[)
+            \#\ type:\s?ignore(?!\[)|
+            \)\ ->\ \"
         language: pygrep
         types: [python]
     -   id: np-bool

--- a/pandas/compat/pickle_compat.py
+++ b/pandas/compat/pickle_compat.py
@@ -1,6 +1,7 @@
 """
 Support pre-0.12 series pickle compatibility.
 """
+from __future__ import annotations
 
 import contextlib
 import copy
@@ -64,7 +65,7 @@ class _LoadSparseSeries:
     # https://github.com/python/mypy/issues/1020
     # error: Incompatible return type for "__new__" (returns "Series", but must return
     # a subtype of "_LoadSparseSeries")
-    def __new__(cls) -> "Series":  # type: ignore[misc]
+    def __new__(cls) -> Series:  # type: ignore[misc]
         from pandas import Series
 
         warnings.warn(
@@ -82,7 +83,7 @@ class _LoadSparseFrame:
     # https://github.com/python/mypy/issues/1020
     # error: Incompatible return type for "__new__" (returns "DataFrame", but must
     # return a subtype of "_LoadSparseFrame")
-    def __new__(cls) -> "DataFrame":  # type: ignore[misc]
+    def __new__(cls) -> DataFrame:  # type: ignore[misc]
         from pandas import DataFrame
 
         warnings.warn(

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numbers
 from typing import TYPE_CHECKING, List, Optional, Tuple, Type, Union
 import warnings
@@ -93,7 +95,7 @@ class BooleanDtype(BaseMaskedDtype):
 
     def __from_arrow__(
         self, array: Union["pyarrow.Array", "pyarrow.ChunkedArray"]
-    ) -> "BooleanArray":
+    ) -> BooleanArray:
         """
         Construct BooleanArray from pyarrow Array/ChunkedArray.
         """
@@ -276,7 +278,7 @@ class BooleanArray(BaseMaskedArray):
     @classmethod
     def _from_sequence(
         cls, scalars, *, dtype: Optional[Dtype] = None, copy: bool = False
-    ) -> "BooleanArray":
+    ) -> BooleanArray:
         if dtype:
             assert dtype == "boolean"
         values, mask = coerce_to_array(scalars, copy=copy)
@@ -291,7 +293,7 @@ class BooleanArray(BaseMaskedArray):
         copy: bool = False,
         true_values: Optional[List[str]] = None,
         false_values: Optional[List[str]] = None,
-    ) -> "BooleanArray":
+    ) -> BooleanArray:
         true_values_union = cls._TRUE_VALUES.union(true_values or [])
         false_values_union = cls._FALSE_VALUES.union(false_values or [])
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from csv import QUOTE_NONNUMERIC
 from functools import partial
 import operator
@@ -740,7 +742,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
         self._dtype = new_dtype
 
-    def _set_dtype(self, dtype: CategoricalDtype) -> "Categorical":
+    def _set_dtype(self, dtype: CategoricalDtype) -> Categorical:
         """
         Internal method for directly updating the CategoricalDtype
 
@@ -1740,7 +1742,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
     def _ndarray(self) -> np.ndarray:
         return self._codes
 
-    def _from_backing_data(self, arr: np.ndarray) -> "Categorical":
+    def _from_backing_data(self, arr: np.ndarray) -> Categorical:
         return self._constructor(arr, dtype=self.dtype, fastpath=True)
 
     def _box_func(self, i: int):
@@ -2160,7 +2162,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
     # ------------------------------------------------------------------
 
-    def _encode_with_my_categories(self, other: "Categorical") -> "Categorical":
+    def _encode_with_my_categories(self, other: "Categorical") -> Categorical:
         """
         Re-encode another categorical using this Categorical's categories.
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime, time, timedelta, tzinfo
 from typing import Optional, Union, cast
 import warnings
@@ -291,7 +293,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
     @classmethod
     def _simple_new(
         cls, values, freq: Optional[BaseOffset] = None, dtype=DT64NS_DTYPE
-    ) -> "DatetimeArray":
+    ) -> DatetimeArray:
         assert isinstance(values, np.ndarray)
         if values.dtype != DT64NS_DTYPE:
             assert values.dtype == "i8"

--- a/pandas/core/arrays/floating.py
+++ b/pandas/core/arrays/floating.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Optional, Tuple, Type
 import warnings
 
@@ -242,14 +244,14 @@ class FloatingArray(NumericArray):
     @classmethod
     def _from_sequence(
         cls, scalars, *, dtype=None, copy: bool = False
-    ) -> "FloatingArray":
+    ) -> FloatingArray:
         values, mask = coerce_to_array(scalars, dtype=dtype, copy=copy)
         return FloatingArray(values, mask)
 
     @classmethod
     def _from_sequence_of_strings(
         cls, strings, *, dtype=None, copy: bool = False
-    ) -> "FloatingArray":
+    ) -> FloatingArray:
         scalars = to_numeric(strings, errors="raise")
         return cls._from_sequence(scalars, dtype=dtype, copy=copy)
 

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, List, Optional, Tuple, Type
 import warnings
 
@@ -303,14 +305,14 @@ class IntegerArray(NumericArray):
     @classmethod
     def _from_sequence(
         cls, scalars, *, dtype: Optional[Dtype] = None, copy: bool = False
-    ) -> "IntegerArray":
+    ) -> IntegerArray:
         values, mask = coerce_to_array(scalars, dtype=dtype, copy=copy)
         return IntegerArray(values, mask)
 
     @classmethod
     def _from_sequence_of_strings(
         cls, strings, *, dtype: Optional[Dtype] = None, copy: bool = False
-    ) -> "IntegerArray":
+    ) -> IntegerArray:
         scalars = to_numeric(strings, errors="raise")
         return cls._from_sequence(scalars, dtype=dtype, copy=copy)
 

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import operator
 from operator import le, lt
 import textwrap
@@ -861,7 +863,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     def isna(self) -> np.ndarray:
         return isna(self._left)
 
-    def shift(self, periods: int = 1, fill_value: object = None) -> "IntervalArray":
+    def shift(self, periods: int = 1, fill_value: object = None) -> IntervalArray:
         if not len(self) or periods == 0:
             return self.copy()
 

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -346,7 +346,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
         uniques = type(self)(uniques, np.zeros(len(uniques), dtype=bool))
         return codes, uniques
 
-    def value_counts(self, dropna: bool = True) -> "Series":
+    def value_counts(self, dropna: bool = True) -> Series:
         """
         Returns a Series containing counts of each unique value.
 

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numbers
 from typing import Optional, Tuple, Type, Union
 
@@ -75,7 +77,7 @@ class PandasDtype(ExtensionDtype):
         return self.kind == "b"
 
     @classmethod
-    def construct_from_string(cls, string: str) -> "PandasDtype":
+    def construct_from_string(cls, string: str) -> PandasDtype:
         try:
             dtype = np.dtype(string)
         except TypeError as err:
@@ -174,7 +176,7 @@ class PandasArray(
     @classmethod
     def _from_sequence(
         cls, scalars, *, dtype: Optional[Dtype] = None, copy: bool = False
-    ) -> "PandasArray":
+    ) -> PandasArray:
         if isinstance(dtype, PandasDtype):
             dtype = dtype._dtype
 
@@ -184,10 +186,10 @@ class PandasArray(
         return cls(result)
 
     @classmethod
-    def _from_factorized(cls, values, original) -> "PandasArray":
+    def _from_factorized(cls, values, original) -> PandasArray:
         return cls(values)
 
-    def _from_backing_data(self, arr: np.ndarray) -> "PandasArray":
+    def _from_backing_data(self, arr: np.ndarray) -> PandasArray:
         return type(self)(arr)
 
     # ------------------------------------------------------------------------

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import timedelta
 import operator
 from typing import Any, Callable, List, Optional, Sequence, Type, Union
@@ -191,7 +193,7 @@ class PeriodArray(PeriodMixin, dtl.DatelikeOps):
         values: np.ndarray,
         freq: Optional[BaseOffset] = None,
         dtype: Optional[Dtype] = None,
-    ) -> "PeriodArray":
+    ) -> PeriodArray:
         # alias for PeriodArray.__init__
         assertion_msg = "Should be numpy array of type i8"
         assert isinstance(values, np.ndarray) and values.dtype == "i8", assertion_msg
@@ -204,7 +206,7 @@ class PeriodArray(PeriodMixin, dtl.DatelikeOps):
         *,
         dtype: Optional[Dtype] = None,
         copy: bool = False,
-    ) -> "PeriodArray":
+    ) -> PeriodArray:
         if dtype and isinstance(dtype, PeriodDtype):
             freq = dtype.freq
         else:
@@ -225,11 +227,11 @@ class PeriodArray(PeriodMixin, dtl.DatelikeOps):
     @classmethod
     def _from_sequence_of_strings(
         cls, strings, *, dtype: Optional[Dtype] = None, copy=False
-    ) -> "PeriodArray":
+    ) -> PeriodArray:
         return cls._from_sequence(strings, dtype=dtype, copy=copy)
 
     @classmethod
-    def _from_datetime64(cls, data, freq, tz=None) -> "PeriodArray":
+    def _from_datetime64(cls, data, freq, tz=None) -> PeriodArray:
         """
         Construct a PeriodArray from a datetime64 array
 
@@ -504,7 +506,7 @@ class PeriodArray(PeriodMixin, dtl.DatelikeOps):
         return Period._from_ordinal(ordinal=x, freq=self.freq)
 
     @doc(**_shared_doc_kwargs, other="PeriodIndex", other_name="PeriodIndex")
-    def asfreq(self, freq=None, how: str = "E") -> "PeriodArray":
+    def asfreq(self, freq=None, how: str = "E") -> PeriodArray:
         """
         Convert the {klass} to the specified frequency `freq`.
 
@@ -675,7 +677,7 @@ class PeriodArray(PeriodMixin, dtl.DatelikeOps):
 
     def _addsub_int_array(
         self, other: np.ndarray, op: Callable[[Any, Any], Any]
-    ) -> "PeriodArray":
+    ) -> PeriodArray:
         """
         Add or subtract array of integers; equivalent to applying
         `_time_shift` pointwise.

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1,6 +1,8 @@
 """
 SparseArray data structure
 """
+from __future__ import annotations
+
 from collections import abc
 import numbers
 import operator
@@ -812,7 +814,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
             val = maybe_box_datetimelike(val, self.sp_values.dtype)
             return val
 
-    def take(self, indices, *, allow_fill=False, fill_value=None) -> "SparseArray":
+    def take(self, indices, *, allow_fill=False, fill_value=None) -> SparseArray:
         if is_scalar(indices):
             raise ValueError(f"'indices' must be an array, not a scalar '{indices}'.")
         indices = np.asarray(indices, dtype=np.int32)
@@ -1403,7 +1405,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
                     other = SparseArray(other, fill_value=self.fill_value, dtype=dtype)
                 return _sparse_array_op(self, other, op, op_name)
 
-    def _cmp_method(self, other, op) -> "SparseArray":
+    def _cmp_method(self, other, op) -> SparseArray:
         if not is_scalar(other) and not isinstance(other, type(self)):
             # convert list-like to ndarray
             other = np.asarray(other)
@@ -1431,19 +1433,19 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
     _logical_method = _cmp_method
 
-    def _unary_method(self, op) -> "SparseArray":
+    def _unary_method(self, op) -> SparseArray:
         fill_value = op(np.array(self.fill_value)).item()
         values = op(self.sp_values)
         dtype = SparseDtype(values.dtype, fill_value)
         return type(self)._simple_new(values, self.sp_index, dtype)
 
-    def __pos__(self) -> "SparseArray":
+    def __pos__(self) -> SparseArray:
         return self._unary_method(operator.pos)
 
-    def __neg__(self) -> "SparseArray":
+    def __neg__(self) -> SparseArray:
         return self._unary_method(operator.neg)
 
-    def __invert__(self) -> "SparseArray":
+    def __invert__(self) -> SparseArray:
         return self._unary_method(operator.invert)
 
     # ----------

--- a/pandas/core/arrays/sparse/dtype.py
+++ b/pandas/core/arrays/sparse/dtype.py
@@ -1,4 +1,5 @@
 """Sparse Dtype"""
+from __future__ import annotations
 
 import re
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Type
@@ -185,7 +186,7 @@ class SparseDtype(ExtensionDtype):
         return SparseArray
 
     @classmethod
-    def construct_from_string(cls, string: str) -> "SparseDtype":
+    def construct_from_string(cls, string: str) -> SparseDtype:
         """
         Construct a SparseDtype from a string form.
 

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Optional, Type, Union
 
 import numpy as np
@@ -84,7 +86,7 @@ class StringDtype(ExtensionDtype):
 
     def __from_arrow__(
         self, array: Union["pyarrow.Array", "pyarrow.ChunkedArray"]
-    ) -> "StringArray":
+    ) -> StringArray:
         """
         Construct StringArray from pyarrow Array/ChunkedArray.
         """

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -105,7 +105,7 @@ class ArrowStringDtype(ExtensionDtype):
 
     def __from_arrow__(
         self, array: Union["pa.Array", "pa.ChunkedArray"]
-    ) -> "ArrowStringArray":
+    ) -> ArrowStringArray:
         """
         Construct StringArray from pyarrow Array/ChunkedArray.
         """
@@ -507,7 +507,7 @@ class ArrowStringArray(OpsMixin, ExtensionArray):
 
     def take(
         self, indices: Sequence[int], allow_fill: bool = False, fill_value: Any = None
-    ) -> "ExtensionArray":
+    ) -> ExtensionArray:
         """
         Take elements from an array.
 

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import timedelta
 from typing import List, Optional, Union
 
@@ -206,7 +208,7 @@ class TimedeltaArray(dtl.TimelikeOps):
     @classmethod
     def _simple_new(
         cls, values, freq: Optional[BaseOffset] = None, dtype=TD64NS_DTYPE
-    ) -> "TimedeltaArray":
+    ) -> TimedeltaArray:
         assert dtype == TD64NS_DTYPE, dtype
         assert isinstance(values, np.ndarray), type(values)
         if values.dtype != TD64NS_DTYPE:
@@ -222,7 +224,7 @@ class TimedeltaArray(dtl.TimelikeOps):
     @classmethod
     def _from_sequence(
         cls, data, *, dtype=TD64NS_DTYPE, copy: bool = False
-    ) -> "TimedeltaArray":
+    ) -> TimedeltaArray:
         if dtype:
             _validate_td64_dtype(dtype)
 
@@ -239,7 +241,7 @@ class TimedeltaArray(dtl.TimelikeOps):
         copy: bool = False,
         freq=lib.no_default,
         unit=None,
-    ) -> "TimedeltaArray":
+    ) -> TimedeltaArray:
         if dtype:
             _validate_td64_dtype(dtype)
 
@@ -467,7 +469,7 @@ class TimedeltaArray(dtl.TimelikeOps):
             ) from err
 
     @unpack_zerodim_and_defer("__mul__")
-    def __mul__(self, other) -> "TimedeltaArray":
+    def __mul__(self, other) -> TimedeltaArray:
         if is_scalar(other):
             # numpy will accept float and int, raise TypeError for others
             result = self._data * other
@@ -743,15 +745,15 @@ class TimedeltaArray(dtl.TimelikeOps):
         res2 = other - res1 * self
         return res1, res2
 
-    def __neg__(self) -> "TimedeltaArray":
+    def __neg__(self) -> TimedeltaArray:
         if self.freq is not None:
             return type(self)(-self._data, freq=-self.freq)
         return type(self)(-self._data)
 
-    def __pos__(self) -> "TimedeltaArray":
+    def __pos__(self) -> TimedeltaArray:
         return type(self)(self._data, freq=self.freq)
 
-    def __abs__(self) -> "TimedeltaArray":
+    def __abs__(self) -> TimedeltaArray:
         # Note: freq is not preserved
         return type(self)(np.abs(self._data))
 

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -1,4 +1,5 @@
 """ manage PyTables query interface via Expressions """
+from __future__ import annotations
 
 import ast
 from functools import partial
@@ -180,7 +181,7 @@ class BinOp(ops.BinOp):
         val = v.tostring(self.encoding)
         return f"({self.lhs} {self.op} {val})"
 
-    def convert_value(self, v) -> "TermValue":
+    def convert_value(self, v) -> TermValue:
         """
         convert the expression that is in the term to something that is
         accepted by pytables

--- a/pandas/core/computation/scope.py
+++ b/pandas/core/computation/scope.py
@@ -1,6 +1,7 @@
 """
 Module for scope operations
 """
+from __future__ import annotations
 
 import datetime
 import inspect
@@ -19,7 +20,7 @@ from pandas.compat.chainmap import DeepChainMap
 
 def ensure_scope(
     level: int, global_dict=None, local_dict=None, resolvers=(), target=None, **kwargs
-) -> "Scope":
+) -> Scope:
     """Ensure that we are grabbing the correct scope."""
     return Scope(
         level + 1,

--- a/pandas/core/describe.py
+++ b/pandas/core/describe.py
@@ -89,7 +89,7 @@ def describe_series(
     series: "Series",
     percentiles: Sequence[float],
     datetime_is_numeric: bool,
-) -> "Series":
+) -> Series:
     """Describe series.
 
     The reason for the delegation to ``describe_1d`` only:
@@ -122,7 +122,7 @@ def describe_frame(
     exclude: Optional[Union[str, Sequence[str]]],
     percentiles: Sequence[float],
     datetime_is_numeric: bool,
-) -> "DataFrame":
+) -> DataFrame:
     """Describe DataFrame.
 
     Parameters
@@ -180,7 +180,7 @@ def select_columns(
     include: Optional[Union[str, Sequence[str]]],
     exclude: Optional[Union[str, Sequence[str]]],
     datetime_is_numeric: bool,
-) -> "DataFrame":
+) -> DataFrame:
     """Select columns to be described."""
     if (include is None) and (exclude is None):
         # when some numerics are found, keep only numerics

--- a/pandas/core/describe.py
+++ b/pandas/core/describe.py
@@ -3,6 +3,7 @@ Module responsible for execution of NDFrame.describe() method.
 
 Method NDFrame.describe() delegates actual execution to function describe_ndframe().
 """
+from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Sequence, Union, cast
 import warnings
@@ -107,7 +108,7 @@ def describe_ndframe(
     return d
 
 
-def describe_numeric_1d(series: "Series", percentiles: Sequence[float]) -> "Series":
+def describe_numeric_1d(series: "Series", percentiles: Sequence[float]) -> Series:
     """Describe series containing numerical data.
 
     Parameters
@@ -130,7 +131,7 @@ def describe_numeric_1d(series: "Series", percentiles: Sequence[float]) -> "Seri
     return Series(d, index=stat_index, name=series.name)
 
 
-def describe_categorical_1d(data: "Series", is_series: bool) -> "Series":
+def describe_categorical_1d(data: "Series", is_series: bool) -> Series:
     """Describe series containing categorical data.
 
     Parameters
@@ -192,7 +193,7 @@ def describe_categorical_1d(data: "Series", is_series: bool) -> "Series":
     return Series(result, index=names, name=data.name, dtype=dtype)
 
 
-def describe_timestamp_1d(data: "Series", percentiles: Sequence[float]) -> "Series":
+def describe_timestamp_1d(data: "Series", percentiles: Sequence[float]) -> Series:
     """Describe series containing datetime64 dtype.
 
     Parameters
@@ -222,7 +223,7 @@ def describe_1d(
     datetime_is_numeric: bool,
     *,
     is_series: bool,
-) -> "Series":
+) -> Series:
     """Describe series.
 
     Parameters

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -944,7 +944,7 @@ def coerce_indexer_dtype(indexer, categories):
 
 def astype_dt64_to_dt64tz(
     values: ArrayLike, dtype: DtypeObj, copy: bool, via_utc: bool = False
-) -> "DatetimeArray":
+) -> DatetimeArray:
     # GH#33401 we have inconsistent behaviors between
     #  Datetimeindex[naive].astype(tzaware)
     #  Series[dt64].astype(tzaware)

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -1,6 +1,7 @@
 """
 Define extension dtypes.
 """
+from __future__ import annotations
 
 import re
 from typing import (
@@ -162,7 +163,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
     @classmethod
     def _from_fastpath(
         cls, categories=None, ordered: Optional[bool] = None
-    ) -> "CategoricalDtype":
+    ) -> CategoricalDtype:
         self = cls.__new__(cls)
         self._finalize(categories, ordered, fastpath=True)
         return self
@@ -170,7 +171,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
     @classmethod
     def _from_categorical_dtype(
         cls, dtype: "CategoricalDtype", categories=None, ordered: Ordered = None
-    ) -> "CategoricalDtype":
+    ) -> CategoricalDtype:
         if categories is ordered is None:
             return dtype
         if categories is None:
@@ -186,7 +187,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
         categories=None,
         ordered: Optional[bool] = None,
         dtype: Optional[Dtype] = None,
-    ) -> "CategoricalDtype":
+    ) -> CategoricalDtype:
         """
         Construct dtype from the input parameters used in :class:`Categorical`.
 
@@ -275,7 +276,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
         return cast(CategoricalDtype, dtype)
 
     @classmethod
-    def construct_from_string(cls, string: str_type) -> "CategoricalDtype":
+    def construct_from_string(cls, string: str_type) -> CategoricalDtype:
         """
         Construct a CategoricalDtype from a string.
 
@@ -514,7 +515,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
 
     def update_dtype(
         self, dtype: Union[str_type, "CategoricalDtype"]
-    ) -> "CategoricalDtype":
+    ) -> CategoricalDtype:
         """
         Returns a CategoricalDtype with categories and ordered taken from dtype
         if specified, otherwise falling back to self if unspecified
@@ -706,7 +707,7 @@ class DatetimeTZDtype(PandasExtensionDtype):
         return DatetimeArray
 
     @classmethod
-    def construct_from_string(cls, string: str_type) -> "DatetimeTZDtype":
+    def construct_from_string(cls, string: str_type) -> DatetimeTZDtype:
         """
         Construct a DatetimeTZDtype from a string.
 
@@ -865,7 +866,7 @@ class PeriodDtype(dtypes.PeriodDtypeBase, PandasExtensionDtype):
         raise ValueError("could not construct PeriodDtype")
 
     @classmethod
-    def construct_from_string(cls, string: str_type) -> "PeriodDtype":
+    def construct_from_string(cls, string: str_type) -> PeriodDtype:
         """
         Strict construction from a string, raise a TypeError if not
         possible
@@ -953,7 +954,7 @@ class PeriodDtype(dtypes.PeriodDtypeBase, PandasExtensionDtype):
 
     def __from_arrow__(
         self, array: Union["pyarrow.Array", "pyarrow.ChunkedArray"]
-    ) -> "PeriodArray":
+    ) -> PeriodArray:
         """
         Construct PeriodArray from pyarrow Array/ChunkedArray.
         """
@@ -1184,7 +1185,7 @@ class IntervalDtype(PandasExtensionDtype):
 
     def __from_arrow__(
         self, array: Union["pyarrow.Array", "pyarrow.ChunkedArray"]
-    ) -> "IntervalArray":
+    ) -> IntervalArray:
         """
         Construct IntervalArray from pyarrow Array/ChunkedArray.
         """

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9407,7 +9407,7 @@ NaN 12.3   33.0
         how: Optional[str] = None,
         normalize: bool = False,
         fill_value=None,
-    ) -> "DataFrame":
+    ) -> DataFrame:
         return super().asfreq(
             freq=freq,
             method=method,
@@ -9431,7 +9431,7 @@ NaN 12.3   33.0
         level=None,
         origin: Union[str, "TimestampConvertibleTypes"] = "start_day",
         offset: Optional["TimedeltaConvertibleTypes"] = None,
-    ) -> "Resampler":
+    ) -> Resampler:
         return super().resample(
             rule=rule,
             axis=axis,

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -5,6 +5,8 @@ classes that hold the groupby interfaces (and some implementations).
 These are user facing as the result of the ``df.groupby(...)`` operations,
 which here returns a DataFrameGroupBy object.
 """
+from __future__ import annotations
+
 from collections import abc, namedtuple
 import copy
 from functools import partial

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -7,6 +7,8 @@ The SeriesGroupBy and DataFrameGroupBy sub-class
 expose these user-facing objects to provide specific functionality.
 """
 
+from __future__ import annotations
+
 from contextlib import contextmanager
 import datetime
 from functools import partial, wraps
@@ -724,7 +726,7 @@ class BaseGroupBy(PandasObject, SelectionMixin, Generic[FrameOrSeries]):
     @final
     def _set_result_index_ordered(
         self, result: "OutputFrameOrSeries"
-    ) -> "OutputFrameOrSeries":
+    ) -> OutputFrameOrSeries:
         # set the result index on the passed values object and
         # return the new object, xref 8046
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -8,8 +8,6 @@ expose these user-facing objects to provide specific functionality.
 """
 from __future__ import annotations
 
-from __future__ import annotations
-
 from contextlib import contextmanager
 import datetime
 from functools import partial, wraps

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -5,6 +5,7 @@ These are not exposed to the user and provide implementations of the grouping
 operations, primarily in cython. These classes (BaseGrouper and BinGrouper)
 are contained *in* the SeriesGroupBy and DataFrameGroupBy objects.
 """
+from __future__ import annotations
 
 import collections
 from typing import (
@@ -149,7 +150,7 @@ class BaseGrouper:
             yield key, group.__finalize__(data, method="groupby")
 
     @final
-    def _get_splitter(self, data: FrameOrSeries, axis: int = 0) -> "DataSplitter":
+    def _get_splitter(self, data: FrameOrSeries, axis: int = 0) -> DataSplitter:
         """
         Returns
         -------
@@ -909,7 +910,7 @@ class BinGrouper(BaseGrouper):
         return [self.binlabels.name]
 
     @property
-    def groupings(self) -> "List[grouper.Grouping]":
+    def groupings(self) -> List[grouper.Grouping]:
         return [
             grouper.Grouping(lvl, lvl, in_axis=False, level=None, name=name)
             for lvl, name in zip(self.levels, self.names)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from copy import copy as copy_func
 from datetime import datetime
 from itertools import zip_longest
@@ -263,7 +265,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     def __new__(
         cls, data=None, dtype=None, copy=False, name=None, tupleize_cols=True, **kwargs
-    ) -> "Index":
+    ) -> Index:
 
         if kwargs:
             warnings.warn(
@@ -4517,7 +4519,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         return self._concat(to_concat, name)
 
-    def _concat(self, to_concat: List["Index"], name: Hashable) -> "Index":
+    def _concat(self, to_concat: List["Index"], name: Hashable) -> Index:
         """
         Concatenate multiple Index objects.
         """
@@ -5273,7 +5275,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     # TODO: De-duplicate with map, xref GH#32349
     @final
-    def _transform_index(self, func, level=None) -> "Index":
+    def _transform_index(self, func, level=None) -> Index:
         """
         Apply function to all values found in index.
 
@@ -6119,7 +6121,7 @@ def _validate_join_method(method: str):
         raise ValueError(f"do not recognize join method {method}")
 
 
-def default_index(n: int) -> "RangeIndex":
+def default_index(n: int) -> RangeIndex:
     from pandas.core.indexes.range import RangeIndex
 
     return RangeIndex(0, n, name=None)

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import date, datetime, time, timedelta, tzinfo
 import operator
 from typing import TYPE_CHECKING, Optional, Tuple
@@ -239,40 +241,38 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         return Index(arr, name=self.name)
 
     @doc(DatetimeArray.tz_convert)
-    def tz_convert(self, tz) -> "DatetimeIndex":
+    def tz_convert(self, tz) -> DatetimeIndex:
         arr = self._data.tz_convert(tz)
         return type(self)._simple_new(arr, name=self.name)
 
     @doc(DatetimeArray.tz_localize)
-    def tz_localize(
-        self, tz, ambiguous="raise", nonexistent="raise"
-    ) -> "DatetimeIndex":
+    def tz_localize(self, tz, ambiguous="raise", nonexistent="raise") -> DatetimeIndex:
         arr = self._data.tz_localize(tz, ambiguous, nonexistent)
         return type(self)._simple_new(arr, name=self.name)
 
     @doc(DatetimeArray.to_period)
-    def to_period(self, freq=None) -> "PeriodIndex":
+    def to_period(self, freq=None) -> PeriodIndex:
         from pandas.core.indexes.api import PeriodIndex
 
         arr = self._data.to_period(freq)
         return PeriodIndex._simple_new(arr, name=self.name)
 
     @doc(DatetimeArray.to_perioddelta)
-    def to_perioddelta(self, freq) -> "TimedeltaIndex":
+    def to_perioddelta(self, freq) -> TimedeltaIndex:
         from pandas.core.indexes.api import TimedeltaIndex
 
         arr = self._data.to_perioddelta(freq)
         return TimedeltaIndex._simple_new(arr, name=self.name)
 
     @doc(DatetimeArray.to_julian_date)
-    def to_julian_date(self) -> "Float64Index":
+    def to_julian_date(self) -> Float64Index:
         from pandas.core.indexes.api import Float64Index
 
         arr = self._data.to_julian_date()
         return Float64Index._simple_new(arr, name=self.name)
 
     @doc(DatetimeArray.isocalendar)
-    def isocalendar(self) -> "DataFrame":
+    def isocalendar(self) -> DataFrame:
         df = self._data.isocalendar()
         return df.set_index(self)
 

--- a/pandas/core/indexes/frozen.py
+++ b/pandas/core/indexes/frozen.py
@@ -6,6 +6,7 @@ These are used for:
 - .names (FrozenList)
 
 """
+from __future__ import annotations
 
 from typing import Any
 
@@ -24,7 +25,7 @@ class FrozenList(PandasObject, list):
     # Side note: This has to be of type list. Otherwise,
     #            it messes up PyTables type checks.
 
-    def union(self, other) -> "FrozenList":
+    def union(self, other) -> FrozenList:
         """
         Returns a FrozenList with other concatenated to the end of self.
 
@@ -42,7 +43,7 @@ class FrozenList(PandasObject, list):
             other = list(other)
         return type(self)(super().__add__(other))
 
-    def difference(self, other) -> "FrozenList":
+    def difference(self, other) -> FrozenList:
         """
         Returns a FrozenList with elements from other removed from self.
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1,4 +1,6 @@
 """ define the IntervalIndex """
+from __future__ import annotations
+
 from functools import wraps
 from operator import le, lt
 import textwrap
@@ -941,7 +943,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
 
         return taken
 
-    def _intersection_unique(self, other: "IntervalIndex") -> "IntervalIndex":
+    def _intersection_unique(self, other: "IntervalIndex") -> IntervalIndex:
         """
         Used when the IntervalIndex does not have any common endpoint,
         no matter left or right.
@@ -964,7 +966,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
 
         return self.take(indexer)
 
-    def _intersection_non_unique(self, other: "IntervalIndex") -> "IntervalIndex":
+    def _intersection_non_unique(self, other: "IntervalIndex") -> IntervalIndex:
         """
         Used when the IntervalIndex does have some common endpoints,
         on either sides.

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import wraps
 from sys import getsizeof
 from typing import (
@@ -404,7 +406,7 @@ class MultiIndex(Index):
         return new_codes
 
     @classmethod
-    def from_arrays(cls, arrays, sortorder=None, names=lib.no_default) -> "MultiIndex":
+    def from_arrays(cls, arrays, sortorder=None, names=lib.no_default) -> MultiIndex:
         """
         Convert arrays to MultiIndex.
 
@@ -700,7 +702,7 @@ class MultiIndex(Index):
         )
 
     @cache_readonly
-    def dtypes(self) -> "Series":
+    def dtypes(self) -> Series:
         """
         Return the dtypes as a Series for the underlying MultiIndex
         """

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 from typing import Any, Optional
 import warnings
@@ -155,7 +157,7 @@ class PeriodIndex(DatetimeIndexOpsMixin):
         other_name="PeriodArray",
         **_shared_doc_kwargs,
     )
-    def asfreq(self, freq=None, how: str = "E") -> "PeriodIndex":
+    def asfreq(self, freq=None, how: str = "E") -> PeriodIndex:
         arr = self._data.asfreq(freq, how)
         return type(self)._simple_new(arr, name=self.name)
 

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import timedelta
 import operator
 from sys import getsizeof
@@ -121,7 +123,7 @@ class RangeIndex(Int64Index):
     @classmethod
     def from_range(
         cls, data: range, name=None, dtype: Optional[Dtype] = None
-    ) -> "RangeIndex":
+    ) -> RangeIndex:
         """
         Create RangeIndex from a range object.
 
@@ -139,7 +141,7 @@ class RangeIndex(Int64Index):
         return cls._simple_new(data, name=name)
 
     @classmethod
-    def _simple_new(cls, values: range, name: Hashable = None) -> "RangeIndex":
+    def _simple_new(cls, values: range, name: Hashable = None) -> RangeIndex:
         result = object.__new__(cls)
 
         assert isinstance(values, range)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -104,7 +104,7 @@ class IndexingMixin:
     """
 
     @property
-    def iloc(self) -> "_iLocIndexer":
+    def iloc(self) -> _iLocIndexer:
         """
         Purely integer-location based indexing for selection by position.
 
@@ -241,7 +241,7 @@ class IndexingMixin:
         return _iLocIndexer("iloc", self)
 
     @property
-    def loc(self) -> "_LocIndexer":
+    def loc(self) -> _LocIndexer:
         """
         Access a group of rows and columns by label(s) or a boolean array.
 
@@ -501,7 +501,7 @@ class IndexingMixin:
         return _LocIndexer("loc", self)
 
     @property
-    def at(self) -> "_AtIndexer":
+    def at(self) -> _AtIndexer:
         """
         Access a single value for a row/column label pair.
 
@@ -550,7 +550,7 @@ class IndexingMixin:
         return _AtIndexer("at", self)
 
     @property
-    def iat(self) -> "_iAtIndexer":
+    def iat(self) -> _iAtIndexer:
         """
         Access a single value for a row/column pair by integer position.
 

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -1,6 +1,8 @@
 """
 Experimental manager based on storing a collection of 1D arrays
 """
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, TypeVar, Union
 
 import numpy as np
@@ -126,7 +128,7 @@ class ArrayManager(DataManager):
 
         self._axes[axis] = new_labels
 
-    def consolidate(self) -> "ArrayManager":
+    def consolidate(self) -> ArrayManager:
         return self
 
     def is_consolidated(self) -> bool:
@@ -185,7 +187,7 @@ class ArrayManager(DataManager):
         indexer = np.arange(self.shape[0])
         return new_mgr, indexer
 
-    def operate_blockwise(self, other: "ArrayManager", array_op) -> "ArrayManager":
+    def operate_blockwise(self, other: "ArrayManager", array_op) -> ArrayManager:
         """
         Apply array_op blockwise with another (aligned) BlockManager.
         """
@@ -318,10 +320,10 @@ class ArrayManager(DataManager):
 
     # TODO quantile
 
-    def isna(self, func) -> "ArrayManager":
+    def isna(self, func) -> ArrayManager:
         return self.apply("apply", func=func)
 
-    def where(self, other, cond, align: bool, errors: str, axis: int) -> "ArrayManager":
+    def where(self, other, cond, align: bool, errors: str, axis: int) -> ArrayManager:
         if align:
             align_keys = ["other", "cond"]
         else:
@@ -338,7 +340,7 @@ class ArrayManager(DataManager):
         )
 
     # TODO what is this used for?
-    # def setitem(self, indexer, value) -> "ArrayManager":
+    # def setitem(self, indexer, value) -> ArrayManager:
     #     return self.apply_with_block("setitem", indexer=indexer, value=value)
 
     def putmask(self, mask, new, align: bool = True, axis: int = 0):
@@ -357,13 +359,13 @@ class ArrayManager(DataManager):
             axis=axis,
         )
 
-    def diff(self, n: int, axis: int) -> "ArrayManager":
+    def diff(self, n: int, axis: int) -> ArrayManager:
         return self.apply_with_block("diff", n=n, axis=axis)
 
-    def interpolate(self, **kwargs) -> "ArrayManager":
+    def interpolate(self, **kwargs) -> ArrayManager:
         return self.apply_with_block("interpolate", **kwargs)
 
-    def shift(self, periods: int, axis: int, fill_value) -> "ArrayManager":
+    def shift(self, periods: int, axis: int, fill_value) -> ArrayManager:
         if fill_value is lib.no_default:
             fill_value = None
 
@@ -375,7 +377,7 @@ class ArrayManager(DataManager):
             "shift", periods=periods, axis=axis, fill_value=fill_value
         )
 
-    def fillna(self, value, limit, inplace: bool, downcast) -> "ArrayManager":
+    def fillna(self, value, limit, inplace: bool, downcast) -> ArrayManager:
         # TODO implement downcast
         inplace = validate_bool_kwarg(inplace, "inplace")
 
@@ -399,12 +401,10 @@ class ArrayManager(DataManager):
 
         return self.apply(array_fillna, value=value, limit=limit, inplace=inplace)
 
-    def downcast(self) -> "ArrayManager":
+    def downcast(self) -> ArrayManager:
         return self.apply_with_block("downcast")
 
-    def astype(
-        self, dtype, copy: bool = False, errors: str = "raise"
-    ) -> "ArrayManager":
+    def astype(self, dtype, copy: bool = False, errors: str = "raise") -> ArrayManager:
         return self.apply("astype", dtype=dtype, copy=copy)  # , errors=errors)
 
     def convert(
@@ -413,7 +413,7 @@ class ArrayManager(DataManager):
         datetime: bool = True,
         numeric: bool = True,
         timedelta: bool = True,
-    ) -> "ArrayManager":
+    ) -> ArrayManager:
         return self.apply_with_block(
             "convert",
             copy=copy,
@@ -422,7 +422,7 @@ class ArrayManager(DataManager):
             timedelta=timedelta,
         )
 
-    def replace(self, value, **kwargs) -> "ArrayManager":
+    def replace(self, value, **kwargs) -> ArrayManager:
         assert np.ndim(value) == 0, value
         # TODO "replace" is right now implemented on the blocks, we should move
         # it to general array algos so it can be reused here
@@ -472,7 +472,7 @@ class ArrayManager(DataManager):
     def is_single_block(self) -> bool:
         return False
 
-    def get_bool_data(self, copy: bool = False) -> "ArrayManager":
+    def get_bool_data(self, copy: bool = False) -> ArrayManager:
         """
         Parameters
         ----------
@@ -485,7 +485,7 @@ class ArrayManager(DataManager):
         new_axes = [self._axes[0], self._axes[1][mask]]
         return type(self)(arrays, new_axes)
 
-    def get_numeric_data(self, copy: bool = False) -> "ArrayManager":
+    def get_numeric_data(self, copy: bool = False) -> ArrayManager:
         """
         Parameters
         ----------
@@ -588,7 +588,7 @@ class ArrayManager(DataManager):
         return result
         # return arr.transpose() if transpose else arr
 
-    def get_slice(self, slobj: slice, axis: int = 0) -> "ArrayManager":
+    def get_slice(self, slobj: slice, axis: int = 0) -> ArrayManager:
         axis = self._normalize_axis(axis)
 
         if axis == 0:
@@ -631,7 +631,7 @@ class ArrayManager(DataManager):
             result = dtype.construct_array_type()._from_sequence(result, dtype=dtype)
         return result
 
-    def iget(self, i: int) -> "SingleBlockManager":
+    def iget(self, i: int) -> SingleBlockManager:
         """
         Return the data as a SingleBlockManager.
         """
@@ -834,7 +834,7 @@ class ArrayManager(DataManager):
         # TODO
         raise NotImplementedError
 
-    def unstack(self, unstacker, fill_value) -> "ArrayManager":
+    def unstack(self, unstacker, fill_value) -> ArrayManager:
         """
         Return a BlockManager with all blocks unstacked..
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import re
 from typing import TYPE_CHECKING, Any, List, Optional, Type, Union, cast
@@ -114,7 +116,7 @@ class Block(PandasObject):
     @classmethod
     def _simple_new(
         cls, values: ArrayLike, placement: BlockPlacement, ndim: int
-    ) -> "Block":
+    ) -> Block:
         """
         Fastpath constructor, does *no* validation
         """
@@ -273,7 +275,7 @@ class Block(PandasObject):
 
         self._mgr_locs = new_mgr_locs
 
-    def make_block(self, values, placement=None) -> "Block":
+    def make_block(self, values, placement=None) -> Block:
         """
         Create a new block, with type inference propagate any values that are
         not specified

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 import itertools
 from typing import (
@@ -369,7 +371,7 @@ class BlockManager(DataManager):
             new_mgr = type(self).from_blocks(res_blocks, [self.items, index])
         return new_mgr, indexer
 
-    def operate_blockwise(self, other: "BlockManager", array_op) -> "BlockManager":
+    def operate_blockwise(self, other: "BlockManager", array_op) -> BlockManager:
         """
         Apply array_op blockwise with another (aligned) BlockManager.
         """
@@ -448,7 +450,7 @@ class BlockManager(DataManager):
         interpolation="linear",
         qs=None,
         numeric_only=None,
-    ) -> "BlockManager":
+    ) -> BlockManager:
         """
         Iterate over blocks applying quantile reduction.
         This routine is intended for reduction type operations and
@@ -540,10 +542,10 @@ class BlockManager(DataManager):
             make_block(values, ndim=1, placement=np.arange(len(values))), axes[0]
         )
 
-    def isna(self, func) -> "BlockManager":
+    def isna(self, func) -> BlockManager:
         return self.apply("apply", func=func)
 
-    def where(self, other, cond, align: bool, errors: str, axis: int) -> "BlockManager":
+    def where(self, other, cond, align: bool, errors: str, axis: int) -> BlockManager:
         if align:
             align_keys = ["other", "cond"]
         else:
@@ -559,7 +561,7 @@ class BlockManager(DataManager):
             axis=axis,
         )
 
-    def setitem(self, indexer, value) -> "BlockManager":
+    def setitem(self, indexer, value) -> BlockManager:
         return self.apply("setitem", indexer=indexer, value=value)
 
     def putmask(self, mask, new, align: bool = True, axis: int = 0):
@@ -578,13 +580,13 @@ class BlockManager(DataManager):
             axis=axis,
         )
 
-    def diff(self, n: int, axis: int) -> "BlockManager":
+    def diff(self, n: int, axis: int) -> BlockManager:
         return self.apply("diff", n=n, axis=axis)
 
-    def interpolate(self, **kwargs) -> "BlockManager":
+    def interpolate(self, **kwargs) -> BlockManager:
         return self.apply("interpolate", **kwargs)
 
-    def shift(self, periods: int, axis: int, fill_value) -> "BlockManager":
+    def shift(self, periods: int, axis: int, fill_value) -> BlockManager:
         if fill_value is lib.no_default:
             fill_value = None
 
@@ -609,17 +611,15 @@ class BlockManager(DataManager):
 
         return self.apply("shift", periods=periods, axis=axis, fill_value=fill_value)
 
-    def fillna(self, value, limit, inplace: bool, downcast) -> "BlockManager":
+    def fillna(self, value, limit, inplace: bool, downcast) -> BlockManager:
         return self.apply(
             "fillna", value=value, limit=limit, inplace=inplace, downcast=downcast
         )
 
-    def downcast(self) -> "BlockManager":
+    def downcast(self) -> BlockManager:
         return self.apply("downcast")
 
-    def astype(
-        self, dtype, copy: bool = False, errors: str = "raise"
-    ) -> "BlockManager":
+    def astype(self, dtype, copy: bool = False, errors: str = "raise") -> BlockManager:
         return self.apply("astype", dtype=dtype, copy=copy, errors=errors)
 
     def convert(
@@ -628,7 +628,7 @@ class BlockManager(DataManager):
         datetime: bool = True,
         numeric: bool = True,
         timedelta: bool = True,
-    ) -> "BlockManager":
+    ) -> BlockManager:
         return self.apply(
             "convert",
             copy=copy,
@@ -637,7 +637,7 @@ class BlockManager(DataManager):
             timedelta=timedelta,
         )
 
-    def replace(self, to_replace, value, inplace: bool, regex: bool) -> "BlockManager":
+    def replace(self, to_replace, value, inplace: bool, regex: bool) -> BlockManager:
         assert np.ndim(value) == 0, value
         return self.apply(
             "replace", to_replace=to_replace, value=value, inplace=inplace, regex=regex
@@ -663,7 +663,7 @@ class BlockManager(DataManager):
         bm._consolidate_inplace()
         return bm
 
-    def to_native_types(self, **kwargs) -> "BlockManager":
+    def to_native_types(self, **kwargs) -> BlockManager:
         """
         Convert values to native types (strings / python objects) that are used
         in formatting (repr / csv).
@@ -707,7 +707,7 @@ class BlockManager(DataManager):
 
         return False
 
-    def get_bool_data(self, copy: bool = False) -> "BlockManager":
+    def get_bool_data(self, copy: bool = False) -> BlockManager:
         """
         Select blocks that are bool-dtype and columns from object-dtype blocks
         that are all-bool.
@@ -732,7 +732,7 @@ class BlockManager(DataManager):
 
         return self._combine(new_blocks, copy)
 
-    def get_numeric_data(self, copy: bool = False) -> "BlockManager":
+    def get_numeric_data(self, copy: bool = False) -> BlockManager:
         """
         Parameters
         ----------
@@ -765,7 +765,7 @@ class BlockManager(DataManager):
 
         return type(self).from_blocks(new_blocks, axes)
 
-    def get_slice(self, slobj: slice, axis: int = 0) -> "BlockManager":
+    def get_slice(self, slobj: slice, axis: int = 0) -> BlockManager:
 
         if axis == 0:
             new_blocks = self._slice_take_blocks_ax0(slobj)
@@ -966,7 +966,7 @@ class BlockManager(DataManager):
 
         return result
 
-    def consolidate(self) -> "BlockManager":
+    def consolidate(self) -> BlockManager:
         """
         Join together blocks having same dtype
 
@@ -989,7 +989,7 @@ class BlockManager(DataManager):
             self._known_consolidated = True
             self._rebuild_blknos_and_blklocs()
 
-    def iget(self, i: int) -> "SingleBlockManager":
+    def iget(self, i: int) -> SingleBlockManager:
         """
         Return the data as a SingleBlockManager.
         """
@@ -1470,7 +1470,7 @@ class BlockManager(DataManager):
 
         return blockwise_all(self, other, array_equals)
 
-    def unstack(self, unstacker, fill_value) -> "BlockManager":
+    def unstack(self, unstacker, fill_value) -> BlockManager:
         """
         Return a BlockManager with all blocks unstacked..
 
@@ -1539,9 +1539,7 @@ class SingleBlockManager(BlockManager):
         self.blocks = (block,)
 
     @classmethod
-    def from_blocks(
-        cls, blocks: List[Block], axes: List[Index]
-    ) -> "SingleBlockManager":
+    def from_blocks(cls, blocks: List[Block], axes: List[Index]) -> SingleBlockManager:
         """
         Constructor for BlockManager and SingleBlockManager with same signature.
         """
@@ -1550,7 +1548,7 @@ class SingleBlockManager(BlockManager):
         return cls(blocks[0], axes[0], do_integrity_check=False)
 
     @classmethod
-    def from_array(cls, array: ArrayLike, index: Index) -> "SingleBlockManager":
+    def from_array(cls, array: ArrayLike, index: Index) -> SingleBlockManager:
         """
         Constructor for if we have an array that is not yet a Block.
         """
@@ -1574,7 +1572,7 @@ class SingleBlockManager(BlockManager):
         """ compat with BlockManager """
         return None
 
-    def get_slice(self, slobj: slice, axis: int = 0) -> "SingleBlockManager":
+    def get_slice(self, slobj: slice, axis: int = 0) -> SingleBlockManager:
         if axis >= self.ndim:
             raise IndexError("Requested axis not found in manager")
 

--- a/pandas/core/internals/ops.py
+++ b/pandas/core/internals/ops.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import namedtuple
 from typing import TYPE_CHECKING, Iterator, List, Tuple
 
@@ -45,7 +47,7 @@ def _iter_block_pairs(
 
 def operate_blockwise(
     left: "BlockManager", right: "BlockManager", array_op
-) -> "BlockManager":
+) -> BlockManager:
     # At this point we have already checked the parent DataFrames for
     #  assert rframe._indexed_same(lframe)
 

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -323,9 +323,7 @@ def should_reindex_frame_op(
     return False
 
 
-def frame_arith_method_with_reindex(
-    left: DataFrame, right: DataFrame, op
-) -> "DataFrame":
+def frame_arith_method_with_reindex(left: DataFrame, right: DataFrame, op) -> DataFrame:
     """
     For DataFrame-with-DataFrame operations that require reindexing,
     operate only on shared columns, then reindex.

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -1,6 +1,7 @@
 """
 Concat routines.
 """
+from __future__ import annotations
 
 from collections import abc
 from typing import (
@@ -61,7 +62,7 @@ def concat(
     verify_integrity: bool = False,
     sort: bool = False,
     copy: bool = True,
-) -> "DataFrame":
+) -> DataFrame:
     ...
 
 

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -33,7 +33,7 @@ def melt(
     value_name="value",
     col_level=None,
     ignore_index: bool = True,
-) -> "DataFrame":
+) -> DataFrame:
     # If multiindex, gather names of columns on all level for checking presence
     # of `id_vars` and `value_vars`
     if isinstance(frame.columns, MultiIndex):
@@ -141,7 +141,7 @@ def melt(
 
 
 @deprecate_kwarg(old_arg_name="label", new_arg_name=None)
-def lreshape(data: DataFrame, groups, dropna: bool = True, label=None) -> "DataFrame":
+def lreshape(data: DataFrame, groups, dropna: bool = True, label=None) -> DataFrame:
     """
     Reshape wide-format data to long. Generalized inverse of DataFrame.pivot.
 
@@ -237,7 +237,7 @@ def lreshape(data: DataFrame, groups, dropna: bool = True, label=None) -> "DataF
 
 def wide_to_long(
     df: DataFrame, stubnames, i, j, sep: str = "", suffix: str = r"\d+"
-) -> "DataFrame":
+) -> DataFrame:
     r"""
     Wide panel to long format. Less flexible but more user-friendly than melt.
 

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -77,7 +77,7 @@ def merge(
     copy: bool = True,
     indicator: bool = False,
     validate: Optional[str] = None,
-) -> "DataFrame":
+) -> DataFrame:
     op = _MergeOperation(
         left,
         right,
@@ -168,7 +168,7 @@ def merge_ordered(
     fill_method: Optional[str] = None,
     suffixes: Suffixes = ("_x", "_y"),
     how: str = "outer",
-) -> "DataFrame":
+) -> DataFrame:
     """
     Perform merge with optional filling/interpolation.
 
@@ -315,7 +315,7 @@ def merge_asof(
     tolerance=None,
     allow_exact_matches: bool = True,
     direction: str = "backward",
-) -> "DataFrame":
+) -> DataFrame:
     """
     Perform an asof merge.
 
@@ -2160,7 +2160,7 @@ def _any(x) -> bool:
     return x is not None and com.any_not_none(*x)
 
 
-def _validate_operand(obj: FrameOrSeries) -> "DataFrame":
+def _validate_operand(obj: FrameOrSeries) -> DataFrame:
     if isinstance(obj, ABCDataFrame):
         return obj
     elif isinstance(obj, ABCSeries):

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -50,7 +50,7 @@ def pivot_table(
     dropna=True,
     margins_name="All",
     observed=False,
-) -> "DataFrame":
+) -> DataFrame:
     index = _convert_by(index)
     columns = _convert_by(columns)
 
@@ -428,7 +428,7 @@ def pivot(
     index: Optional[IndexLabel] = None,
     columns: Optional[IndexLabel] = None,
     values: Optional[IndexLabel] = None,
-) -> "DataFrame":
+) -> DataFrame:
     if columns is None:
         raise TypeError("pivot() missing 1 required argument: 'columns'")
 
@@ -475,7 +475,7 @@ def crosstab(
     margins_name: str = "All",
     dropna: bool = True,
     normalize=False,
-) -> "DataFrame":
+) -> DataFrame:
     """
     Compute a simple cross tabulation of two (or more) factors. By default
     computes a frequency table of the factors unless an array of values and an

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 from typing import List, Optional, Union
 
@@ -738,7 +740,7 @@ def get_dummies(
     sparse: bool = False,
     drop_first: bool = False,
     dtype: Optional[Dtype] = None,
-) -> "DataFrame":
+) -> DataFrame:
     """
     Convert categorical variable into dummy/indicator variables.
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1,6 +1,8 @@
 """
 Data structure for 1-dimensional cross-sectional and time series data
 """
+from __future__ import annotations
+
 from io import StringIO
 from shutil import get_terminal_size
 from textwrap import dedent
@@ -620,7 +622,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         return len(self._mgr)
 
-    def view(self, dtype: Optional[Dtype] = None) -> "Series":
+    def view(self, dtype: Optional[Dtype] = None) -> Series:
         """
         Create a new view of the Series.
 
@@ -765,7 +767,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     # Indexing Methods
 
     @Appender(generic.NDFrame.take.__doc__)
-    def take(self, indices, axis=0, is_copy=None, **kwargs) -> "Series":
+    def take(self, indices, axis=0, is_copy=None, **kwargs) -> Series:
         if is_copy is not None:
             warnings.warn(
                 "is_copy is deprecated and will be removed in a future version. "
@@ -807,7 +809,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         return self._values[i]
 
-    def _slice(self, slobj: slice, axis: int = 0) -> "Series":
+    def _slice(self, slobj: slice, axis: int = 0) -> Series:
         # axis kwarg is retained for compat with NDFrame method
         #  _slice is *always* positional
         return self._get_values(slobj)
@@ -1060,7 +1062,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     def _is_mixed_type(self):
         return False
 
-    def repeat(self, repeats, axis=None) -> "Series":
+    def repeat(self, repeats, axis=None) -> Series:
         """
         Repeat elements of a Series.
 
@@ -1533,7 +1535,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         into_c = com.standardize_mapping(into)
         return into_c(self.items())
 
-    def to_frame(self, name=None) -> "DataFrame":
+    def to_frame(self, name=None) -> DataFrame:
         """
         Convert Series to DataFrame.
 
@@ -1565,7 +1567,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         return df
 
-    def _set_name(self, name, inplace=False) -> "Series":
+    def _set_name(self, name, inplace=False) -> Series:
         """
         Set the Series name.
 
@@ -1674,7 +1676,7 @@ Name: Max Speed, dtype: float64
         squeeze: bool = no_default,
         observed: bool = False,
         dropna: bool = True,
-    ) -> "SeriesGroupBy":
+    ) -> SeriesGroupBy:
         from pandas.core.groupby.generic import SeriesGroupBy
 
         if squeeze is not no_default:
@@ -1761,7 +1763,7 @@ Name: Max Speed, dtype: float64
             self, method="count"
         )
 
-    def mode(self, dropna=True) -> "Series":
+    def mode(self, dropna=True) -> Series:
         """
         Return the mode(s) of the Series.
 
@@ -1931,7 +1933,7 @@ Name: Max Speed, dtype: float64
         else:
             return result
 
-    def duplicated(self, keep="first") -> "Series":
+    def duplicated(self, keep="first") -> Series:
         """
         Indicate duplicate Series values.
 
@@ -2150,7 +2152,7 @@ Name: Max Speed, dtype: float64
             return np.nan
         return self.index[i]
 
-    def round(self, decimals=0, *args, **kwargs) -> "Series":
+    def round(self, decimals=0, *args, **kwargs) -> Series:
         """
         Round each value in a Series to the given number of decimals.
 
@@ -2402,7 +2404,7 @@ Name: Max Speed, dtype: float64
         dtype: float64"""
         ),
     )
-    def diff(self, periods: int = 1) -> "Series":
+    def diff(self, periods: int = 1) -> Series:
         """
         First discrete difference of element.
 
@@ -2820,7 +2822,7 @@ Keep all original rows and also all original values
             keep_equal=keep_equal,
         )
 
-    def combine(self, other, func, fill_value=None) -> "Series":
+    def combine(self, other, func, fill_value=None) -> Series:
         """
         Combine the Series with a Series or scalar according to `func`.
 
@@ -2918,7 +2920,7 @@ Keep all original rows and also all original values
             new_values = maybe_cast_to_extension_array(type(self._values), new_values)
         return self._constructor(new_values, index=new_index, name=new_name)
 
-    def combine_first(self, other) -> "Series":
+    def combine_first(self, other) -> Series:
         """
         Combine Series values, choosing the calling Series's values first.
 
@@ -3406,7 +3408,7 @@ Keep all original rows and also all original values
             key,
         )
 
-    def argsort(self, axis=0, kind="quicksort", order=None) -> "Series":
+    def argsort(self, axis=0, kind="quicksort", order=None) -> Series:
         """
         Return the integer indices that would sort the Series values.
 
@@ -3448,7 +3450,7 @@ Keep all original rows and also all original values
                 np.argsort(values, kind=kind), index=self.index, dtype="int64"
             ).__finalize__(self, method="argsort")
 
-    def nlargest(self, n=5, keep="first") -> "Series":
+    def nlargest(self, n=5, keep="first") -> Series:
         """
         Return the largest `n` elements.
 
@@ -3546,7 +3548,7 @@ Keep all original rows and also all original values
         """
         return algorithms.SelectNSeries(self, n=n, keep=keep).nlargest()
 
-    def nsmallest(self, n=5, keep="first") -> "Series":
+    def nsmallest(self, n=5, keep="first") -> Series:
         """
         Return the smallest `n` elements.
 
@@ -3643,7 +3645,7 @@ Keep all original rows and also all original values
         """
         return algorithms.SelectNSeries(self, n=n, keep=keep).nsmallest()
 
-    def swaplevel(self, i=-2, j=-1, copy=True) -> "Series":
+    def swaplevel(self, i=-2, j=-1, copy=True) -> Series:
         """
         Swap levels i and j in a :class:`MultiIndex`.
 
@@ -3667,7 +3669,7 @@ Keep all original rows and also all original values
             self, method="swaplevel"
         )
 
-    def reorder_levels(self, order) -> "Series":
+    def reorder_levels(self, order) -> Series:
         """
         Rearrange index levels using input order.
 
@@ -3690,7 +3692,7 @@ Keep all original rows and also all original values
         result.index = result.index.reorder_levels(order)
         return result
 
-    def explode(self, ignore_index: bool = False) -> "Series":
+    def explode(self, ignore_index: bool = False) -> Series:
         """
         Transform each element of a list-like to a row.
 
@@ -3804,7 +3806,7 @@ Keep all original rows and also all original values
     # ----------------------------------------------------------------------
     # function application
 
-    def map(self, arg, na_action=None) -> "Series":
+    def map(self, arg, na_action=None) -> Series:
         """
         Map values of Series according to input correspondence.
 
@@ -3884,7 +3886,7 @@ Keep all original rows and also all original values
             self, method="map"
         )
 
-    def _gotitem(self, key, ndim, subset=None) -> "Series":
+    def _gotitem(self, key, ndim, subset=None) -> Series:
         """
         Sub-classes to define. Return a sliced object.
 
@@ -4293,7 +4295,7 @@ Keep all original rows and also all original values
         level=None,
         inplace=False,
         errors="raise",
-    ) -> "Series":
+    ) -> Series:
         """
         Return Series with specified index labels removed.
 
@@ -4486,7 +4488,7 @@ Keep all original rows and also all original values
         return result
 
     @doc(NDFrame.shift, klass=_shared_doc_kwargs["klass"])
-    def shift(self, periods=1, freq=None, axis=0, fill_value=None) -> "Series":
+    def shift(self, periods=1, freq=None, axis=0, fill_value=None) -> Series:
         return super().shift(
             periods=periods, freq=freq, axis=axis, fill_value=fill_value
         )
@@ -4545,7 +4547,7 @@ Keep all original rows and also all original values
             v += self.index.memory_usage(deep=deep)
         return v
 
-    def isin(self, values) -> "Series":
+    def isin(self, values) -> Series:
         """
         Whether elements in Series are contained in `values`.
 
@@ -4603,7 +4605,7 @@ Keep all original rows and also all original values
             self, method="isin"
         )
 
-    def between(self, left, right, inclusive=True) -> "Series":
+    def between(self, left, right, inclusive=True) -> Series:
         """
         Return boolean Series equivalent to left <= series <= right.
 
@@ -4688,7 +4690,7 @@ Keep all original rows and also all original values
         convert_integer: bool = True,
         convert_boolean: bool = True,
         convert_floating: bool = True,
-    ) -> "Series":
+    ) -> Series:
         input_series = self
         if infer_objects:
             input_series = input_series.infer_objects()
@@ -4712,19 +4714,19 @@ Keep all original rows and also all original values
         return result
 
     @doc(NDFrame.isna, klass=_shared_doc_kwargs["klass"])
-    def isna(self) -> "Series":
+    def isna(self) -> Series:
         return generic.NDFrame.isna(self)
 
     @doc(NDFrame.isna, klass=_shared_doc_kwargs["klass"])
-    def isnull(self) -> "Series":
+    def isnull(self) -> Series:
         return super().isnull()
 
     @doc(NDFrame.notna, klass=_shared_doc_kwargs["klass"])
-    def notna(self) -> "Series":
+    def notna(self) -> Series:
         return super().notna()
 
     @doc(NDFrame.notna, klass=_shared_doc_kwargs["klass"])
-    def notnull(self) -> "Series":
+    def notnull(self) -> Series:
         return super().notnull()
 
     def dropna(self, axis=0, inplace=False, how=None):
@@ -4826,7 +4828,7 @@ Keep all original rows and also all original values
         how: Optional[str] = None,
         normalize: bool = False,
         fill_value=None,
-    ) -> "Series":
+    ) -> Series:
         return super().asfreq(
             freq=freq,
             method=method,
@@ -4850,7 +4852,7 @@ Keep all original rows and also all original values
         level=None,
         origin: Union[str, "TimestampConvertibleTypes"] = "start_day",
         offset: Optional["TimedeltaConvertibleTypes"] = None,
-    ) -> "Resampler":
+    ) -> Resampler:
         return super().resample(
             rule=rule,
             axis=axis,
@@ -4866,7 +4868,7 @@ Keep all original rows and also all original values
             offset=offset,
         )
 
-    def to_timestamp(self, freq=None, how="start", copy=True) -> "Series":
+    def to_timestamp(self, freq=None, how="start", copy=True) -> Series:
         """
         Cast to DatetimeIndex of Timestamps, at *beginning* of period.
 
@@ -4895,7 +4897,7 @@ Keep all original rows and also all original values
             self, method="to_timestamp"
         )
 
-    def to_period(self, freq=None, copy=True) -> "Series":
+    def to_period(self, freq=None, copy=True) -> Series:
         """
         Convert Series from DatetimeIndex to PeriodIndex.
 

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -1,4 +1,6 @@
 """ miscellaneous sorting / groupby utilities """
+from __future__ import annotations
+
 from collections import defaultdict
 from typing import (
     TYPE_CHECKING,
@@ -419,7 +421,7 @@ def nargminmax(values, method: str):
 
 def _ensure_key_mapped_multiindex(
     index: "MultiIndex", key: Callable, level=None
-) -> "MultiIndex":
+) -> MultiIndex:
     """
     Returns a new MultiIndex in which key has been applied
     to all levels specified in level (or all levels if level

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import abc
 from datetime import datetime
 from functools import partial
@@ -146,7 +148,7 @@ def _maybe_cache(
     format: Optional[str],
     cache: bool,
     convert_listlike: Callable,
-) -> "Series":
+) -> Series:
     """
     Create a cache of unique dates from an array of dates
 
@@ -214,7 +216,7 @@ def _convert_and_box_cache(
     arg: DatetimeScalarOrArrayConvertible,
     cache_array: "Series",
     name: Optional[str] = None,
-) -> "Index":
+) -> Index:
     """
     Convert array of dates with a cache and wrap the result in an Index.
 
@@ -586,7 +588,7 @@ def to_datetime(
     infer_datetime_format: bool = ...,
     origin=...,
     cache: bool = ...,
-) -> "Series":
+) -> Series:
     ...
 
 

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from functools import partial
 from textwrap import dedent
@@ -77,7 +79,7 @@ def get_center_of_mass(
     return float(comass)
 
 
-def wrap_result(obj: "Series", result: np.ndarray) -> "Series":
+def wrap_result(obj: "Series", result: np.ndarray) -> Series:
     """
     Wrap a single 1D result.
     """

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -362,7 +362,7 @@ class BaseWindow(ShallowMixin, SelectionMixin):
 
     def _apply_series(
         self, homogeneous_func: Callable[..., ArrayLike], name: Optional[str] = None
-    ) -> "Series":
+    ) -> Series:
         """
         Series version of _apply_blockwise
         """

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -1,4 +1,5 @@
 """Common IO api utilities"""
+from __future__ import annotations
 
 import bz2
 from collections import abc
@@ -97,7 +98,7 @@ class IOHandles:
         self.created_handles = []
         self.is_wrapped = False
 
-    def __enter__(self) -> "IOHandles":
+    def __enter__(self) -> IOHandles:
         return self
 
     def __exit__(self, *args: Any) -> None:
@@ -783,7 +784,7 @@ class _MMapWrapper(abc.Iterator):
             return lambda: self.attributes[name]
         return getattr(self.mmap, name)
 
-    def __iter__(self) -> "_MMapWrapper":
+    def __iter__(self) -> _MMapWrapper:
         return self
 
     def __next__(self) -> str:

--- a/pandas/io/formats/info.py
+++ b/pandas/io/formats/info.py
@@ -312,7 +312,7 @@ class InfoPrinterAbstract:
         fmt.buffer_put_lines(buf, lines)
 
     @abstractmethod
-    def _create_table_builder(self) -> "TableBuilderAbstract":
+    def _create_table_builder(self) -> TableBuilderAbstract:
         """Create instance of table builder."""
 
 
@@ -376,7 +376,7 @@ class DataFrameInfoPrinter(InfoPrinterAbstract):
         else:
             return show_counts
 
-    def _create_table_builder(self) -> "DataFrameTableBuilder":
+    def _create_table_builder(self) -> DataFrameTableBuilder:
         """
         Create instance of table builder based on verbosity and display settings.
         """
@@ -485,7 +485,7 @@ class DataFrameTableBuilder(TableBuilderAbstract):
         """Add lines to the info table, pertaining to non-empty dataframe."""
 
     @property
-    def data(self) -> "DataFrame":
+    def data(self) -> DataFrame:
         """DataFrame."""
         return self.info.data
 

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -1,6 +1,8 @@
 """
 Module for applying conditional formatting to DataFrames and Series.
 """
+from __future__ import annotations
+
 from collections import defaultdict
 from contextlib import contextmanager
 import copy
@@ -445,7 +447,7 @@ class Styler:
             "table_attributes": table_attr,
         }
 
-    def format(self, formatter, subset=None, na_rep: Optional[str] = None) -> "Styler":
+    def format(self, formatter, subset=None, na_rep: Optional[str] = None) -> Styler:
         """
         Format the text display value of cells.
 
@@ -516,7 +518,7 @@ class Styler:
                 self._display_funcs[(i, j)] = formatter
         return self
 
-    def set_td_classes(self, classes: DataFrame) -> "Styler":
+    def set_td_classes(self, classes: DataFrame) -> Styler:
         """
         Add string based CSS class names to data cells that will appear within the
         `Styler` HTML result. These classes are added within specified `<td>` elements.
@@ -656,7 +658,7 @@ class Styler:
                 for pair in c.split(";"):
                     self.ctx[(i, j)].append(pair)
 
-    def _copy(self, deepcopy: bool = False) -> "Styler":
+    def _copy(self, deepcopy: bool = False) -> Styler:
         styler = Styler(
             self.data,
             precision=self.precision,
@@ -673,13 +675,13 @@ class Styler:
             styler._todo = self._todo
         return styler
 
-    def __copy__(self) -> "Styler":
+    def __copy__(self) -> Styler:
         """
         Deep copy by default.
         """
         return self._copy(deepcopy=False)
 
-    def __deepcopy__(self, memo) -> "Styler":
+    def __deepcopy__(self, memo) -> Styler:
         return self._copy(deepcopy=True)
 
     def clear(self) -> None:
@@ -712,7 +714,7 @@ class Styler:
         axis: Optional[Axis] = 0,
         subset=None,
         **kwargs,
-    ) -> "Styler":
+    ) -> Styler:
         subset = slice(None) if subset is None else subset
         subset = non_reducing_slice(subset)
         data = self.data.loc[subset]
@@ -751,7 +753,7 @@ class Styler:
         axis: Optional[Axis] = 0,
         subset=None,
         **kwargs,
-    ) -> "Styler":
+    ) -> Styler:
         """
         Apply a function column-wise, row-wise, or table-wise.
 
@@ -802,7 +804,7 @@ class Styler:
         )
         return self
 
-    def _applymap(self, func: Callable, subset=None, **kwargs) -> "Styler":
+    def _applymap(self, func: Callable, subset=None, **kwargs) -> Styler:
         func = partial(func, **kwargs)  # applymap doesn't take kwargs?
         if subset is None:
             subset = pd.IndexSlice[:]
@@ -811,7 +813,7 @@ class Styler:
         self._update_ctx(result)
         return self
 
-    def applymap(self, func: Callable, subset=None, **kwargs) -> "Styler":
+    def applymap(self, func: Callable, subset=None, **kwargs) -> Styler:
         """
         Apply a function elementwise.
 
@@ -848,7 +850,7 @@ class Styler:
         other: Optional[str] = None,
         subset=None,
         **kwargs,
-    ) -> "Styler":
+    ) -> Styler:
         """
         Apply a function elementwise.
 
@@ -884,7 +886,7 @@ class Styler:
             lambda val: value if cond(val) else other, subset=subset, **kwargs
         )
 
-    def set_precision(self, precision: int) -> "Styler":
+    def set_precision(self, precision: int) -> Styler:
         """
         Set the precision used to render.
 
@@ -899,7 +901,7 @@ class Styler:
         self.precision = precision
         return self
 
-    def set_table_attributes(self, attributes: str) -> "Styler":
+    def set_table_attributes(self, attributes: str) -> Styler:
         """
         Set the table attributes.
 
@@ -939,7 +941,7 @@ class Styler:
         """
         return self._todo
 
-    def use(self, styles: List[Tuple[Callable, Tuple, Dict]]) -> "Styler":
+    def use(self, styles: List[Tuple[Callable, Tuple, Dict]]) -> Styler:
         """
         Set the styles on the current Styler.
 
@@ -961,7 +963,7 @@ class Styler:
         self._todo.extend(styles)
         return self
 
-    def set_uuid(self, uuid: str) -> "Styler":
+    def set_uuid(self, uuid: str) -> Styler:
         """
         Set the uuid for a Styler.
 
@@ -976,7 +978,7 @@ class Styler:
         self.uuid = uuid
         return self
 
-    def set_caption(self, caption: str) -> "Styler":
+    def set_caption(self, caption: str) -> Styler:
         """
         Set the caption on a Styler.
 
@@ -991,7 +993,7 @@ class Styler:
         self.caption = caption
         return self
 
-    def set_table_styles(self, table_styles, axis=0, overwrite=True) -> "Styler":
+    def set_table_styles(self, table_styles, axis=0, overwrite=True) -> Styler:
         """
         Set the table styles on a Styler.
 
@@ -1082,7 +1084,7 @@ class Styler:
             self.table_styles = table_styles
         return self
 
-    def set_na_rep(self, na_rep: str) -> "Styler":
+    def set_na_rep(self, na_rep: str) -> Styler:
         """
         Set the missing data representation on a Styler.
 
@@ -1099,7 +1101,7 @@ class Styler:
         self.na_rep = na_rep
         return self
 
-    def hide_index(self) -> "Styler":
+    def hide_index(self) -> Styler:
         """
         Hide any indices from rendering.
 
@@ -1110,7 +1112,7 @@ class Styler:
         self.hidden_index = True
         return self
 
-    def hide_columns(self, subset) -> "Styler":
+    def hide_columns(self, subset) -> Styler:
         """
         Hide columns from rendering.
 
@@ -1141,7 +1143,7 @@ class Styler:
         self,
         null_color: str = "red",
         subset: Optional[IndexLabel] = None,
-    ) -> "Styler":
+    ) -> Styler:
         """
         Shade the background ``null_color`` for missing values.
 
@@ -1170,7 +1172,7 @@ class Styler:
         text_color_threshold: float = 0.408,
         vmin: Optional[float] = None,
         vmax: Optional[float] = None,
-    ) -> "Styler":
+    ) -> Styler:
         """
         Color the background in a gradient style.
 
@@ -1307,7 +1309,7 @@ class Styler:
                     columns=s.columns,
                 )
 
-    def set_properties(self, subset=None, **kwargs) -> "Styler":
+    def set_properties(self, subset=None, **kwargs) -> Styler:
         """
         Method to set one or more non-data dependent properties or each cell.
 
@@ -1401,7 +1403,7 @@ class Styler:
         align: str = "left",
         vmin: Optional[float] = None,
         vmax: Optional[float] = None,
-    ) -> "Styler":
+    ) -> Styler:
         """
         Draw bar chart in the cell backgrounds.
 
@@ -1478,7 +1480,7 @@ class Styler:
 
     def highlight_max(
         self, subset=None, color: str = "yellow", axis: Optional[Axis] = 0
-    ) -> "Styler":
+    ) -> Styler:
         """
         Highlight the maximum by shading the background.
 
@@ -1500,7 +1502,7 @@ class Styler:
 
     def highlight_min(
         self, subset=None, color: str = "yellow", axis: Optional[Axis] = 0
-    ) -> "Styler":
+    ) -> Styler:
         """
         Highlight the minimum by shading the background.
 
@@ -1528,7 +1530,7 @@ class Styler:
         color: str = "yellow",
         axis: Optional[Axis] = None,
         max_: bool = True,
-    ) -> "Styler":
+    ) -> Styler:
         subset = non_reducing_slice(maybe_numeric_slice(self.data, subset))
         self.apply(
             self._highlight_extrema, color=color, axis=axis, subset=subset, max_=max_

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -34,7 +34,7 @@ def read_gbq(
     use_bqstorage_api: Optional[bool] = None,
     max_results: Optional[int] = None,
     progress_bar_type: Optional[str] = None,
-) -> "DataFrame":
+) -> DataFrame:
     """
     Load data from Google BigQuery.
 

--- a/pandas/io/json/_normalize.py
+++ b/pandas/io/json/_normalize.py
@@ -1,5 +1,6 @@
 # ---------------------------------------------------------------------
 # JSON normalization routines
+from __future__ import annotations
 
 from collections import abc, defaultdict
 import copy
@@ -118,7 +119,7 @@ def _json_normalize(
     errors: str = "raise",
     sep: str = ".",
     max_level: Optional[int] = None,
-) -> "DataFrame":
+) -> DataFrame:
     """
     Normalize semi-structured JSON data into a flat table.
 

--- a/pandas/io/orc.py
+++ b/pandas/io/orc.py
@@ -1,4 +1,5 @@
 """ orc compat """
+from __future__ import annotations
 
 import distutils
 from typing import TYPE_CHECKING, List, Optional
@@ -13,7 +14,7 @@ if TYPE_CHECKING:
 
 def read_orc(
     path: FilePathOrBuffer, columns: Optional[List[str]] = None, **kwargs
-) -> "DataFrame":
+) -> DataFrame:
     """
     Load an ORC object from the file path, returning a DataFrame.
 

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -1,4 +1,5 @@
 """ parquet compat """
+from __future__ import annotations
 
 from distutils.version import LooseVersion
 import io
@@ -23,7 +24,7 @@ from pandas.io.common import (
 )
 
 
-def get_engine(engine: str) -> "BaseImpl":
+def get_engine(engine: str) -> BaseImpl:
     """ return our implementation """
     if engine == "auto":
         engine = get_option("io.parquet.engine")

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2,6 +2,8 @@
 High level interface to PyTables for reading and writing pandas data structures
 to disk
 """
+from __future__ import annotations
+
 from contextlib import suppress
 import copy
 from datetime import date, tzinfo
@@ -1771,7 +1773,7 @@ class HDFStore:
         s.infer_axes()
         return s.read()
 
-    def _identify_group(self, key: str, append: bool) -> "Node":
+    def _identify_group(self, key: str, append: bool) -> Node:
         """Identify HDF5 group based on key, delete/create group if needed."""
         group = self.get_node(key)
 
@@ -1789,7 +1791,7 @@ class HDFStore:
 
         return group
 
-    def _create_nodes_and_group(self, key: str) -> "Node":
+    def _create_nodes_and_group(self, key: str) -> Node:
         """Create nodes from key and return group name."""
         # assertion for mypy
         assert self._handle is not None
@@ -2326,7 +2328,7 @@ class DataCol(IndexCol):
         return self.data
 
     @classmethod
-    def _get_atom(cls, values: ArrayLike) -> "Col":
+    def _get_atom(cls, values: ArrayLike) -> Col:
         """
         Get an appropriately typed and shaped pytables.Col object for values.
         """
@@ -2376,7 +2378,7 @@ class DataCol(IndexCol):
         return getattr(_tables(), col_name)
 
     @classmethod
-    def get_atom_data(cls, shape, kind: str) -> "Col":
+    def get_atom_data(cls, shape, kind: str) -> Col:
         return cls.get_atom_coltype(kind=kind)(shape=shape[0])
 
     @classmethod
@@ -2533,7 +2535,7 @@ class DataIndexableCol(DataCol):
         return _tables().StringCol(itemsize=itemsize)
 
     @classmethod
-    def get_atom_data(cls, shape, kind: str) -> "Col":
+    def get_atom_data(cls, shape, kind: str) -> Col:
         return cls.get_atom_coltype(kind=kind)()
 
     @classmethod

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -9,6 +9,8 @@ a once again improved version.
 You can find more information on http://presbrey.mit.edu/PyDTA and
 https://www.statsmodels.org/devel/
 """
+from __future__ import annotations
+
 from collections import abc
 import datetime
 from io import BytesIO
@@ -1072,7 +1074,7 @@ class StataReader(StataParser, abc.Iterator):
         self._read_header()
         self._setup_dtype()
 
-    def __enter__(self) -> "StataReader":
+    def __enter__(self) -> StataReader:
         """ enter context manager """
         return self
 

--- a/pandas/plotting/_matplotlib/misc.py
+++ b/pandas/plotting/_matplotlib/misc.py
@@ -130,7 +130,7 @@ def radviz(
     color=None,
     colormap=None,
     **kwds,
-) -> "Axes":
+) -> Axes:
     import matplotlib.pyplot as plt
 
     def normalize(series):
@@ -219,7 +219,7 @@ def andrews_curves(
     color=None,
     colormap=None,
     **kwds,
-) -> "Axes":
+) -> Axes:
     import matplotlib.pyplot as plt
 
     def function(amplitudes):
@@ -284,7 +284,7 @@ def bootstrap_plot(
     size: int = 50,
     samples: int = 500,
     **kwds,
-) -> "Figure":
+) -> Figure:
 
     import matplotlib.pyplot as plt
 
@@ -346,7 +346,7 @@ def parallel_coordinates(
     axvlines_kwds=None,
     sort_labels: bool = False,
     **kwds,
-) -> "Axes":
+) -> Axes:
     import matplotlib.pyplot as plt
 
     if axvlines_kwds is None:
@@ -415,7 +415,7 @@ def parallel_coordinates(
 
 def lag_plot(
     series: "Series", lag: int = 1, ax: Optional["Axes"] = None, **kwds
-) -> "Axes":
+) -> Axes:
     # workaround because `c='b'` is hardcoded in matplotlib's scatter method
     import matplotlib.pyplot as plt
 
@@ -432,9 +432,7 @@ def lag_plot(
     return ax
 
 
-def autocorrelation_plot(
-    series: "Series", ax: Optional["Axes"] = None, **kwds
-) -> "Axes":
+def autocorrelation_plot(series: "Series", ax: Optional["Axes"] = None, **kwds) -> Axes:
     import matplotlib.pyplot as plt
 
     n = len(series)

--- a/pandas/plotting/_matplotlib/style.py
+++ b/pandas/plotting/_matplotlib/style.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 from typing import (
     TYPE_CHECKING,
@@ -148,7 +150,7 @@ def _get_colors_from_colormap(
     return [colormap(num) for num in np.linspace(0, 1, num=num_colors)]
 
 
-def _get_cmap_instance(colormap: Union[str, "Colormap"]) -> "Colormap":
+def _get_cmap_instance(colormap: Union[str, "Colormap"]) -> Colormap:
     """Get instance of matplotlib colormap."""
     if isinstance(colormap, str):
         cmap = colormap

--- a/pandas/plotting/_matplotlib/tools.py
+++ b/pandas/plotting/_matplotlib/tools.py
@@ -1,4 +1,6 @@
 # being a bit too dynamic
+from __future__ import annotations
+
 from math import ceil
 from typing import TYPE_CHECKING, Iterable, List, Sequence, Tuple, Union
 import warnings
@@ -32,7 +34,7 @@ def format_date_labels(ax: "Axes", rot):
 
 def table(
     ax, data: FrameOrSeriesUnion, rowLabels=None, colLabels=None, **kwargs
-) -> "Table":
+) -> Table:
     if isinstance(data, ABCSeries):
         data = data.to_frame()
     elif isinstance(data, ABCDataFrame):


### PR DESCRIPTION

- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

this was just done with
```python
    parser = argparse.ArgumentParser()
    parser.add_argument('paths', nargs='*', type=Path)
    args = parser.parse_args()
    for path in args.paths:
        text = path.read_text()
        text = re.sub(r'-> "(\w+)"', '-> \\1', text)
        path.write_text(text)
```

There's other to do (which I'll get to in other PRs), but this already gets rid of a big load of them