### PR TITLE
Revert "BUG/REG: RollingGroupby MultiIndex levels dropped (#38737)"

### DIFF
--- a/doc/source/whatsnew/v1.2.1.rst
+++ b/doc/source/whatsnew/v1.2.1.rst
@@ -15,7 +15,6 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Fixed regression in :meth:`to_csv` that created corrupted zip files when there were more rows than ``chunksize`` (:issue:`38714`)
-- Fixed regression in ``groupby().rolling()`` where :class:`MultiIndex` levels were dropped (:issue:`38523`)
 - Fixed regression in repr of float-like strings of an ``object`` dtype having trailing 0's truncated after the decimal (:issue:`38708`)
 - Fixed regression in :meth:`DataFrame.groupby()` with :class:`Categorical` grouping column not showing unused categories for ``grouped.indices`` (:issue:`38642`)
 - Fixed regression in :meth:`DataFrame.any` and :meth:`DataFrame.all` not returning a result for tz-aware ``datetime64`` columns (:issue:`38723`)

--- a/pandas/core/shared_docs.py
+++ b/pandas/core/shared_docs.py
@@ -108,7 +108,7 @@ sort : bool, default True
     Note this does not influence the order of observations within each
     group. Groupby preserves the order of rows within each group.
 group_keys : bool, default True
-    When calling ``groupby().apply()``, add group keys to index to identify pieces.
+    When calling apply, add group keys to index to identify pieces.
 squeeze : bool, default False
     Reduce the dimensionality of the return type if possible,
     otherwise return a consistent type.

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -794,22 +794,28 @@ class BaseWindowGroupby(GotItemMixin, BaseWindow):
             numba_cache_key,
             **kwargs,
         )
-        # Reconstruct the resulting MultiIndex
+        # Reconstruct the resulting MultiIndex from tuples
         # 1st set of levels = group by labels
-        # 2nd set of levels = original DataFrame/Series index
-        grouped_object_index = self.obj.index
-        grouped_index_name = [*grouped_object_index.names]
-        groupby_keys = [grouping.name for grouping in self._groupby.grouper._groupings]
-        result_index_names = groupby_keys + grouped_index_name
+        # 2nd set of levels = original index
+        # Ignore 2nd set of levels if a group by label include an index level
+        result_index_names = [
+            grouping.name for grouping in self._groupby.grouper._groupings
+        ]
+        grouped_object_index = None
 
-        drop_columns = [
+        column_keys = [
             key
-            for key in groupby_keys
+            for key in result_index_names
             if key not in self.obj.index.names or key is None
         ]
-        if len(drop_columns) != len(groupby_keys):
-            # Our result will have kept groupby columns which should be dropped
-            result = result.drop(columns=drop_columns, errors="ignore")
+
+        if len(column_keys) == len(result_index_names):
+            grouped_object_index = self.obj.index
+            grouped_index_name = [*grouped_object_index.names]
+            result_index_names += grouped_index_name
+        else:
+            # Our result will have still kept the column in the result
+            result = result.drop(columns=column_keys, errors="ignore")
 
         codes = self._groupby.grouper.codes
         levels = self._groupby.grouper.levels


### PR DESCRIPTION
This reverts commit a37f1a45e83d7f803d7fcab7d384da28e9c1e714.

reverts PR #38737

I think we ended up deciding to revert on master and backport to keep master and 1.2.x in sync and not release this change in 1.2.1 to allow for further discussion.

once this revert PR merged:
- [x] backport
- [x] the blocker tag can then be removed from #38787
- [x] #38523 will be reopen temporarily
- [ ] @mroeschke will open a new PR with these changes (in draft? milestoned 1.2.2?)

if not these changes, the mutliindex with a single level may still need resolution (and backport) to close #38523

cc @mroeschke @jorisvandenbossche 

add 1.2.1 milestone for this revert for backport.

