### PR TITLE
CI: Set xfail to strict=False for network tests

### DIFF
--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -209,7 +209,7 @@ class TestS3:
         with pytest.raises(IOError, match=msg):
             read_csv("s3://cant_get_it/file.csv")
 
-    @pytest.mark.xfail(reason="GH#39155 s3fs upgrade")
+    @pytest.mark.xfail(reason="GH#39155 s3fs upgrade", strict=False)
     def test_write_s3_csv_fails(self, tips_df, s3so):
         # GH 32486
         # Attempting to write to an invalid S3 path should raise
@@ -225,7 +225,7 @@ class TestS3:
                 "s3://an_s3_bucket_data_doesnt_exit/not_real.csv", storage_options=s3so
             )
 
-    @pytest.mark.xfail(reason="GH#39155 s3fs upgrade")
+    @pytest.mark.xfail(reason="GH#39155 s3fs upgrade", strict=False)
     @td.skip_if_no("pyarrow")
     def test_write_s3_parquet_fails(self, tips_df, s3so):
         # GH 27679


### PR DESCRIPTION
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

This one is ugly. Botocore and boto3 were upgraded tonight to 1.19.55 and 1.16.55. Since aiobotocore requires them to be .52 this is no longer installed, but aiobotocore is an required dependency from s3fs 0.5.*. So this get's downgraded to 0.4.2 were only botocore was a required dependency (no version specification). As soon as the requirements of aiobotocore are updated again this will switch back to s3fs=0.5.2 which will cause the tests to fail again. Hence setting them to strict=False

sorry for the long explanation :)