### PR TITLE
Backport PR #39204:  BUG: assert_frame_equal raising TypeError with check_like and mixed dtype in Index or columns

### DIFF
--- a/doc/source/whatsnew/v1.2.1.rst
+++ b/doc/source/whatsnew/v1.2.1.rst
@@ -29,6 +29,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrameGroupBy.diff` raising for ``int8`` and ``int16`` columns (:issue:`39050`)
 - Fixed regression in :meth:`Series.fillna` that raised ``RecursionError`` with ``datetime64[ns, UTC]`` dtype (:issue:`38851`)
 - Fixed regression that raised ``AttributeError`` with PyArrow versions [0.16.0, 1.0.0) (:issue:`38801`)
+- Fixed regression in :func:`pandas.testing.assert_frame_equal` raising ``TypeError`` with ``check_like=True`` when :class:`Index` or columns have mixed dtype (:issue:`39168`)
 - Fixed regression in :meth:`DataFrame.groupby` when aggregating an :class:`ExtensionDType` that could fail for non-numeric values (:issue:`38980`)
 - Fixed regression in :meth:`DataFrame.loc.__setitem__` raising ``KeyError`` with :class:`MultiIndex` and list-like columns indexer enlarging :class:`DataFrame` (:issue:`39147`)
 - Fixed regression in comparisons between ``NaT`` and ``datetime.date`` objects incorrectly returning ``True`` (:issue:`39151`)
@@ -42,7 +43,7 @@ Bug fixes
 
 - Bug in :meth:`read_csv` with ``float_precision="high"`` caused segfault or wrong parsing of long exponent strings. This resulted in a regression in some cases as the default for ``float_precision`` was changed in pandas 1.2.0 (:issue:`38753`)
 - Bug in :func:`read_csv` not closing an opened file handle when a ``csv.Error`` or ``UnicodeDecodeError`` occurred while initializing (:issue:`39024`)
--
+- Bug in :func:`pandas.testing.assert_index_equal` raising ``TypeError`` with ``check_order=False`` when :class:`Index` has mixed dtype (:issue:`39168`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -57,7 +57,7 @@ from pandas import (
     Series,
     bdate_range,
 )
-from pandas.core.algorithms import take_1d
+from pandas.core.algorithms import safe_sort, take_1d
 from pandas.core.arrays import (
     DatetimeArray,
     ExtensionArray,
@@ -804,8 +804,8 @@ def assert_index_equal(
 
     # If order doesn't matter then sort the index entries
     if not check_order:
-        left = left.sort_values()
-        right = right.sort_values()
+        left = Index(safe_sort(left))
+        right = Index(safe_sort(right))
 
     # MultiIndex special comparison for little-friendly error messages
     if left.nlevels > 1:

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -299,3 +299,9 @@ def test_allows_duplicate_labels():
 
     with pytest.raises(AssertionError, match="<Flags"):
         tm.assert_frame_equal(left, right)
+
+
+def test_assert_frame_equal_columns_mixed_dtype():
+    # GH#39168
+    df = DataFrame([[0, 1, 2]], columns=["foo", "bar", 42], index=[1, "test", 2])
+    tm.assert_frame_equal(df, df, check_like=True)

--- a/pandas/tests/util/test_assert_index_equal.py
+++ b/pandas/tests/util/test_assert_index_equal.py
@@ -192,3 +192,9 @@ ordered=False\\)"""
             tm.assert_index_equal(idx1, idx2, check_categorical=check_categorical)
     else:
         tm.assert_index_equal(idx1, idx2, check_categorical=check_categorical)
+
+
+def test_assert_index_equal_mixed_dtype():
+    # GH#39168
+    idx = Index(["foo", "bar", 42])
+    tm.assert_index_equal(idx, idx, check_order=False)


### PR DESCRIPTION

Backport PR #39204