### PR TITLE
DEPR: EWM.vol

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -191,7 +191,7 @@ Deprecations
 - Deprecated comparison of :class:`Timestamp` object with ``datetime.date`` objects.  Instead of e.g. ``ts <= mydate`` use ``ts <= pd.Timestamp(mydate)`` or ``ts.date() <= mydate`` (:issue:`36131`)
 - Deprecated :attr:`Rolling.win_type` returning ``"freq"`` (:issue:`38963`)
 - Deprecated :attr:`Rolling.is_datetimelike` (:issue:`38963`)
-- Deprecated :meth:`core.window.ewm.ExponentialMovingWindow.vol` (:issue:``)
+- Deprecated :meth:`core.window.ewm.ExponentialMovingWindow.vol` (:issue:`39220`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -191,6 +191,7 @@ Deprecations
 - Deprecated comparison of :class:`Timestamp` object with ``datetime.date`` objects.  Instead of e.g. ``ts <= mydate`` use ``ts <= pd.Timestamp(mydate)`` or ``ts.date() <= mydate`` (:issue:`36131`)
 - Deprecated :attr:`Rolling.win_type` returning ``"freq"`` (:issue:`38963`)
 - Deprecated :attr:`Rolling.is_datetimelike` (:issue:`38963`)
+- Deprecated :meth:`core.window.ewm.ExponentialMovingWindow.vol` (:issue:``)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -4,6 +4,7 @@ import datetime
 from functools import partial
 from textwrap import dedent
 from typing import TYPE_CHECKING, Optional, Union
+import warnings
 
 import numpy as np
 
@@ -360,7 +361,16 @@ class ExponentialMovingWindow(BaseWindow):
         nv.validate_window_func("std", args, kwargs)
         return zsqrt(self.var(bias=bias, **kwargs))
 
-    vol = std
+    def vol(self, bias: bool = False, *args, **kwargs):
+        warnings.warn(
+            (
+                "vol is deprecated will be removed in a future version. "
+                "Use std instead."
+            ),
+            FutureWarning,
+            stacklevel=2,
+        )
+        return self.std(bias, *args, **kwargs)
 
     @Substitution(name="ewm", func_name="var")
     @Appender(_doc_template)

--- a/pandas/tests/window/moments/test_moments_ewm.py
+++ b/pandas/tests/window/moments/test_moments_ewm.py
@@ -5,13 +5,13 @@ from pandas import DataFrame, Series
 import pandas._testing as tm
 
 
-@pytest.mark.parametrize("name", ["var", "vol", "mean"])
+@pytest.mark.parametrize("name", ["var", "std", "mean"])
 def test_ewma_series(series, name):
     series_result = getattr(series.ewm(com=10), name)()
     assert isinstance(series_result, Series)
 
 
-@pytest.mark.parametrize("name", ["var", "vol", "mean"])
+@pytest.mark.parametrize("name", ["var", "std", "mean"])
 def test_ewma_frame(frame, name):
     frame_result = getattr(frame.ewm(com=10), name)()
     assert isinstance(frame_result, DataFrame)

--- a/pandas/tests/window/moments/test_moments_ewm.py
+++ b/pandas/tests/window/moments/test_moments_ewm.py
@@ -300,7 +300,7 @@ def test_ewm_domain_checks():
         s.ewm(alpha=1.1)
 
 
-@pytest.mark.parametrize("method", ["mean", "vol", "var"])
+@pytest.mark.parametrize("method", ["mean", "std", "var"])
 def test_ew_empty_series(method):
     vals = Series([], dtype=np.float64)
 

--- a/pandas/tests/window/moments/test_moments_ewm.py
+++ b/pandas/tests/window/moments/test_moments_ewm.py
@@ -310,7 +310,7 @@ def test_ew_empty_series(method):
 
 
 @pytest.mark.parametrize("min_periods", [0, 1])
-@pytest.mark.parametrize("name", ["mean", "var", "vol"])
+@pytest.mark.parametrize("name", ["mean", "var", "std"])
 def test_ew_min_periods(min_periods, name):
     # excluding NaNs correctly
     arr = np.random.randn(50)
@@ -329,7 +329,7 @@ def test_ew_min_periods(min_periods, name):
         assert result[:10].isna().all()
         assert not result[10:].isna().any()
     else:
-        # ewm.std, ewm.vol, ewm.var (with bias=False) require at least
+        # ewm.std, ewm.var (with bias=False) require at least
         # two values
         assert result[:11].isna().all()
         assert not result[11:].isna().any()
@@ -343,7 +343,7 @@ def test_ew_min_periods(min_periods, name):
     if name == "mean":
         tm.assert_series_equal(result, Series([1.0]))
     else:
-        # ewm.std, ewm.vol, ewm.var with bias=False require at least
+        # ewm.std, ewm.var with bias=False require at least
         # two values
         tm.assert_series_equal(result, Series([np.NaN]))
 

--- a/pandas/tests/window/test_ewm.py
+++ b/pandas/tests/window/test_ewm.py
@@ -135,3 +135,11 @@ def test_ewm_with_nat_raises(halflife_with_times):
     times = DatetimeIndex(["NaT"])
     with pytest.raises(ValueError, match="Cannot convert NaT values to integer"):
         ser.ewm(com=0.1, halflife=halflife_with_times, times=times)
+
+
+def test_ewm_vol_deprecated():
+    ser = Series(range(1))
+    with tm.assert_produces_warning(FutureWarning):
+        result = ser.ewm(com=0.1).vol()
+    expected = ser.ewm(com=0.1).std()
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

`vol` is undocumented and was just `std` which is more standard in our API