### PR TITLE
Revert "CI: Skip numpy dev failing tests (#39090)"

### DIFF
--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -12,7 +12,6 @@ import sys
 import warnings
 
 from pandas._typing import F
-from pandas.compat.numpy import is_numpy_dev
 
 PY38 = sys.version_info >= (3, 8)
 PY39 = sys.version_info >= (3, 9)
@@ -119,8 +118,3 @@ def get_lzma_file(lzma):
             "might be required to solve this issue."
         )
     return lzma.LZMAFile
-
-
-__all__ = [
-    "is_numpy_dev",
-]

--- a/pandas/tests/arithmetic/test_interval.py
+++ b/pandas/tests/arithmetic/test_interval.py
@@ -3,8 +3,6 @@ import operator
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
-
 from pandas.core.dtypes.common import is_list_like
 
 import pandas as pd
@@ -254,7 +252,6 @@ class TestComparison:
         with pytest.raises(ValueError, match="Lengths must match to compare"):
             op(array, other)
 
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     @pytest.mark.parametrize(
         "constructor, expected_type, assert_func",
         [

--- a/pandas/tests/base/test_misc.py
+++ b/pandas/tests/base/test_misc.py
@@ -3,7 +3,7 @@ import sys
 import numpy as np
 import pytest
 
-from pandas.compat import IS64, PYPY, is_numpy_dev
+from pandas.compat import IS64, PYPY
 
 from pandas.core.dtypes.common import is_categorical_dtype, is_object_dtype
 
@@ -115,9 +115,6 @@ def test_searchsorted(index_or_series_obj):
     if isinstance(obj, pd.MultiIndex):
         # See gh-14833
         pytest.skip("np.searchsorted doesn't work on pd.MultiIndex")
-
-    if is_object_dtype(obj) and is_numpy_dev:
-        pytest.skip("GH#39089 Numpy changed dtype inference")
 
     max_obj = max(obj, default=0)
     index = np.searchsorted(obj, max_obj)

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -3,8 +3,6 @@ import operator
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
-
 from pandas.core.dtypes.common import is_bool_dtype
 
 import pandas as pd
@@ -394,9 +392,6 @@ class BaseMethodsTests(BaseExtensionTests):
         b = pd.util.hash_pandas_object(data)
         self.assert_equal(a, b)
 
-    @pytest.mark.xfail(
-        is_numpy_dev, reason="GH#39089 Numpy changed dtype inference", strict=False
-    )
     def test_searchsorted(self, data_for_sorting, as_series):
         b, c, a = data_for_sorting
         arr = data_for_sorting.take([2, 0, 1])  # to get [a, b, c]

--- a/pandas/tests/frame/apply/test_frame_apply.py
+++ b/pandas/tests/frame/apply/test_frame_apply.py
@@ -5,8 +5,6 @@ import warnings
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
-
 from pandas.core.dtypes.dtypes import CategoricalDtype
 
 import pandas as pd
@@ -592,7 +590,6 @@ class TestDataFrameApply:
             tm.assert_frame_equal(reduce_false, df)
             tm.assert_series_equal(reduce_none, dicts)
 
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     def test_applymap(self, float_frame):
         applied = float_frame.applymap(lambda x: x * 2)
         tm.assert_frame_equal(applied, float_frame * 2)

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -5,7 +5,6 @@ import numpy as np
 import pytest
 
 from pandas._libs import iNaT
-from pandas.compat import is_numpy_dev
 
 from pandas.core.dtypes.common import is_integer
 
@@ -255,8 +254,6 @@ class TestDataFrameIndexing:
     )
     def test_setitem_same_column(self, cols, values, expected):
         # GH 23239
-        if cols == ["C", "D", "D", "a"] and is_numpy_dev:
-            pytest.skip("GH#39089 Numpy changed dtype inference")
         df = DataFrame([values], columns=cols)
         df["a"] = df["a"]
         result = df["a"].values[0]

--- a/pandas/tests/frame/methods/test_drop.py
+++ b/pandas/tests/frame/methods/test_drop.py
@@ -3,7 +3,6 @@ import re
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
 from pandas.errors import PerformanceWarning
 import pandas.util._test_decorators as td
 
@@ -109,7 +108,6 @@ class TestDataFrameDrop:
         expected = Index(["a", "b", "c"], name="first")
         tm.assert_index_equal(dropped.index, expected)
 
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     def test_drop(self):
         simple = DataFrame({"A": [1, 2, 3, 4], "B": [0, 1, 2, 3]})
         tm.assert_frame_equal(simple.drop("A", axis=1), simple[["B"]])

--- a/pandas/tests/frame/methods/test_isin.py
+++ b/pandas/tests/frame/methods/test_isin.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
-
 import pandas as pd
 from pandas import DataFrame, MultiIndex, Series
 import pandas._testing as tm
@@ -34,7 +32,6 @@ class TestDataFrameIsIn:
         result = df.isin(empty)
         tm.assert_frame_equal(result, expected)
 
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     def test_isin_dict(self):
         df = DataFrame({"A": ["a", "b", "c"], "B": ["a", "e", "f"]})
         d = {"A": ["a"]}

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -6,8 +6,6 @@ from typing import Dict, List, Union
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
-
 import pandas as pd
 from pandas import DataFrame, Index, Series, Timestamp, date_range
 import pandas._testing as tm
@@ -1510,7 +1508,6 @@ class TestDataFrameReplace:
         result = df.replace(to_replace=[None, -np.inf, np.inf], value=value)
         tm.assert_frame_equal(result, df)
 
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     @pytest.mark.parametrize("replacement", [np.nan, 5])
     def test_replace_with_duplicate_columns(self, replacement):
         # GH 24798

--- a/pandas/tests/frame/methods/test_to_csv.py
+++ b/pandas/tests/frame/methods/test_to_csv.py
@@ -5,7 +5,6 @@ import os
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
 from pandas.errors import ParserError
 
 import pandas as pd
@@ -182,7 +181,6 @@ class TestDataFrameToCSV:
 
         tm.assert_frame_equal(df[cols], rs_c, check_names=False)
 
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     def test_to_csv_new_dupe_cols(self):
         import pandas as pd
 

--- a/pandas/tests/frame/test_nonunique_indexes.py
+++ b/pandas/tests/frame/test_nonunique_indexes.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
-
 import pandas as pd
 from pandas import DataFrame, MultiIndex, Series, date_range
 import pandas._testing as tm
@@ -16,7 +14,6 @@ def check(result, expected=None):
 
 
 class TestDataFrameNonuniqueIndexes:
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     def test_column_dups_operations(self):
 
         # assignment
@@ -313,7 +310,6 @@ class TestDataFrameNonuniqueIndexes:
         result = df.dropna(subset=["A", "C"], how="all")
         tm.assert_frame_equal(result, expected)
 
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     def test_getitem_boolean_series_with_duplicate_columns(self):
         # boolean indexing
         # GH 4879
@@ -341,7 +337,6 @@ class TestDataFrameNonuniqueIndexes:
         result = df[df > 6]
         check(result, expected)
 
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     def test_getitem_boolean_frame_unaligned_with_duplicate_columns(self):
         # `df.A > 6` is a DataFrame with a different shape from df
         dups = ["A", "A", "C", "D"]

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -4,7 +4,6 @@ from io import StringIO
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
 from pandas.errors import UnsupportedFunctionCall
 
 import pandas as pd
@@ -1005,7 +1004,6 @@ def test_frame_describe_unstacked_format():
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
 @pytest.mark.filterwarnings(
     "ignore:"
     "indexing past lexsort depth may impact performance:"

--- a/pandas/tests/groupby/test_quantile.py
+++ b/pandas/tests/groupby/test_quantile.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
-
 import pandas as pd
 from pandas import DataFrame, Index
 import pandas._testing as tm
@@ -73,7 +71,6 @@ def test_quantile_array():
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
 def test_quantile_array2():
     # https://github.com/pandas-dev/pandas/pull/28085#issuecomment-524066959
     df = DataFrame(
@@ -109,7 +106,6 @@ def test_quantile_array_no_sort():
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
 def test_quantile_array_multiple_levels():
     df = DataFrame(
         {"A": [0, 1, 2], "B": [3, 4, 5], "c": ["a", "a", "a"], "d": ["a", "a", "b"]}
@@ -220,8 +216,6 @@ def test_quantile_missing_group_values_correct_results(
 @pytest.mark.parametrize("q", [0.5, [0.0, 0.5, 1.0]])
 def test_groupby_quantile_nullable_array(values, q):
     # https://github.com/pandas-dev/pandas/issues/33136
-    if isinstance(q, list):
-        pytest.skip("GH#39089 Numpy changed dtype inference")
     df = DataFrame({"a": ["x"] * 3 + ["y"] * 3, "b": values})
     result = df.groupby("a")["b"].quantile(q)
 
@@ -262,7 +256,6 @@ def test_groupby_timedelta_quantile():
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
 def test_columns_groupby_quantile():
     # GH 33795
     df = DataFrame(

--- a/pandas/tests/indexes/base_class/test_indexing.py
+++ b/pandas/tests/indexes/base_class/test_indexing.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
-
 from pandas import Index
 import pandas._testing as tm
 
@@ -15,7 +13,6 @@ class TestGetSliceBounds:
         result = index.get_slice_bound("e", kind=kind, side=side)
         assert result == expected
 
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     @pytest.mark.parametrize("kind", ["getitem", "loc", None])
     @pytest.mark.parametrize("side", ["left", "right"])
     @pytest.mark.parametrize(

--- a/pandas/tests/indexes/base_class/test_where.py
+++ b/pandas/tests/indexes/base_class/test_where.py
@@ -1,14 +1,10 @@
 import numpy as np
-import pytest
-
-from pandas.compat import is_numpy_dev
 
 from pandas import Index
 import pandas._testing as tm
 
 
 class TestWhere:
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     def test_where_intlike_str_doesnt_cast_ints(self):
         idx = Index(range(3))
         mask = np.array([True, False, True])

--- a/pandas/tests/indexes/categorical/test_indexing.py
+++ b/pandas/tests/indexes/categorical/test_indexing.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
 from pandas.errors import InvalidIndexError
 
 import pandas as pd
@@ -130,7 +129,6 @@ class TestTake:
 
 
 class TestGetLoc:
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     def test_get_loc(self):
         # GH 12531
         cidx1 = CategoricalIndex(list("abcde"), categories=list("edabc"))

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -4,7 +4,6 @@ import re
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
 from pandas.errors import InvalidIndexError
 
 import pandas as pd
@@ -917,9 +916,6 @@ def test_searchsorted_different_argument_classes(klass):
     tm.assert_numpy_array_equal(result, expected)
 
 
-@pytest.mark.xfail(
-    is_numpy_dev, reason="GH#39089 Numpy changed dtype inference", strict=False
-)
 @pytest.mark.parametrize(
     "arg", [[1, 2], ["a", "b"], [Timestamp("2020-01-01", tz="Europe/London")] * 2]
 )

--- a/pandas/tests/indexes/period/test_constructors.py
+++ b/pandas/tests/indexes/period/test_constructors.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs.period import IncompatibleFrequency
-from pandas.compat import is_numpy_dev
 
 from pandas.core.dtypes.dtypes import PeriodDtype
 
@@ -305,7 +304,6 @@ class TestPeriodIndex:
                 )
             )
 
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     def test_constructor_mixed(self):
         idx = PeriodIndex(["2011-01", NaT, Period("2011-01", freq="M")])
         exp = PeriodIndex(["2011-01", "NaT", "2011-01"], freq="M")

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslib import Timestamp
-from pandas.compat import IS64, is_numpy_dev
+from pandas.compat import IS64
 from pandas.compat.numpy import np_datetime64_compat
 from pandas.util._test_decorators import async_mark
 
@@ -1358,7 +1358,6 @@ class TestIndex(Base):
         assert index2.slice_locs(8.5, 1.5) == (2, 6)
         assert index2.slice_locs(10.5, -1) == (0, n)
 
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     def test_slice_locs_dup(self):
         index = Index(["a", "a", "b", "c", "d", "d"])
         assert index.slice_locs("a", "d") == (0, 6)
@@ -1398,9 +1397,6 @@ class TestIndex(Base):
         with pytest.raises(KeyError, match=""):
             index.slice_locs(end=1.5)
 
-    @pytest.mark.xfail(
-        is_numpy_dev, reason="GH#39089 Numpy changed dtype inference", strict=False
-    )
     @pytest.mark.parametrize(
         "in_slice,expected",
         [

--- a/pandas/tests/indexes/test_engines.py
+++ b/pandas/tests/indexes/test_engines.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 
 from pandas._libs import algos as libalgos, index as libindex
-from pandas.compat import is_numpy_dev
 
 import pandas as pd
 import pandas._testing as tm
@@ -199,7 +198,6 @@ class TestObjectEngine:
         engine = self.engine_type(lambda: arr, len(arr))
         assert engine.is_unique is False
 
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     def test_get_loc(self):
         # unique
         arr = np.array(self.values, dtype=self.dtype)

--- a/pandas/tests/indexes/timedeltas/test_delete.py
+++ b/pandas/tests/indexes/timedeltas/test_delete.py
@@ -1,7 +1,3 @@
-import pytest
-
-from pandas.compat import is_numpy_dev
-
 from pandas import TimedeltaIndex, timedelta_range
 import pandas._testing as tm
 
@@ -64,7 +60,6 @@ class TestTimedeltaIndexDelete:
             assert result.name == expected.name
             assert result.freq == expected.freq
 
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     def test_delete_doesnt_infer_freq(self):
         # GH#30655 behavior matches DatetimeIndex
 

--- a/pandas/tests/indexing/multiindex/test_getitem.py
+++ b/pandas/tests/indexing/multiindex/test_getitem.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
-
 from pandas import DataFrame, Index, MultiIndex, Series
 import pandas._testing as tm
 from pandas.core.indexing import IndexingError
@@ -263,7 +261,6 @@ def test_frame_mi_access(dataframe_with_duplicate_index, indexer):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
 def test_frame_mi_access_returns_series(dataframe_with_duplicate_index):
     # GH 4146, not returning a block manager when selecting a unique index
     # from a duplicate index
@@ -275,7 +272,6 @@ def test_frame_mi_access_returns_series(dataframe_with_duplicate_index):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
 def test_frame_mi_access_returns_frame(dataframe_with_duplicate_index):
     # selecting a non_unique from the 2nd level
     df = dataframe_with_duplicate_index

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
-
 import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, Series
 import pandas._testing as tm
@@ -146,7 +144,6 @@ class TestMultiIndexLoc:
         with pytest.raises(KeyError, match="not in index"):
             df.loc[key]
 
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     def test_loc_multiindex_too_many_dims_raises(self):
         # GH 14885
         s = Series(

--- a/pandas/tests/indexing/multiindex/test_partial.py
+++ b/pandas/tests/indexing/multiindex/test_partial.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
-
 from pandas import (
     DataFrame,
     Float64Index,
@@ -98,7 +96,6 @@ class TestMultiIndexPartial:
         expected = ymd[(lev >= 1) & (lev <= 3)]
         tm.assert_frame_equal(result, expected)
 
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     def test_getitem_partial_column_select(self):
         idx = MultiIndex(
             codes=[[0, 0, 0], [0, 1, 1], [1, 0, 1]],

--- a/pandas/tests/indexing/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/test_chaining_and_caching.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
-
 import pandas as pd
 from pandas import DataFrame, Series, Timestamp, date_range, option_context
 import pandas._testing as tm
@@ -349,7 +347,6 @@ class TestChaining:
             with pytest.raises(com.SettingWithCopyError, match=msg):
                 df.loc[0]["A"] = 111
 
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     def test_detect_chained_assignment_warnings_filter_and_dupe_cols(self):
         # xref gh-13017.
         with option_context("chained_assignment", "warn"):

--- a/pandas/tests/indexing/test_scalar.py
+++ b/pandas/tests/indexing/test_scalar.py
@@ -4,8 +4,6 @@ from datetime import datetime, timedelta
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
-
 from pandas import DataFrame, Series, Timedelta, Timestamp, date_range
 import pandas._testing as tm
 from pandas.tests.indexing.common import Base
@@ -130,7 +128,6 @@ class TestScalar2:
         result = df.iat[2, 0]
         assert result == 2
 
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     def test_frame_at_with_duplicate_axes(self):
         # GH#33041
         arr = np.random.randn(6).reshape(3, 2)

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -5,8 +5,6 @@ import re
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
-
 from pandas.core.dtypes.common import is_categorical_dtype, is_object_dtype
 from pandas.core.dtypes.dtypes import CategoricalDtype
 
@@ -2039,7 +2037,6 @@ def test_merge_suffix(col1, col2, kwargs, expected_cols):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
 @pytest.mark.parametrize(
     "how,expected",
     [

--- a/pandas/tests/scalar/test_nat.py
+++ b/pandas/tests/scalar/test_nat.py
@@ -6,7 +6,7 @@ import pytest
 import pytz
 
 from pandas._libs.tslibs import iNaT
-from pandas.compat import PY38, is_numpy_dev
+import pandas.compat as compat
 
 from pandas.core.dtypes.common import is_datetime64_any_dtype
 
@@ -59,7 +59,6 @@ def test_nat_fields(nat, idx):
         assert result is False
 
 
-@pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
 def test_nat_vector_field_access():
     idx = DatetimeIndex(["1/1/2000", None, None, "1/4/2000"])
 
@@ -135,7 +134,7 @@ def test_round_nat(klass, method, freq):
         pytest.param(
             "fromisocalendar",
             marks=pytest.mark.skipif(
-                not PY38,
+                not compat.PY38,
                 reason="'fromisocalendar' was added in stdlib datetime in python 3.8",
             ),
         ),
@@ -311,7 +310,7 @@ def test_overlap_public_nat_methods(klass, expected):
     # is considered to be with Timestamp and NaT, not Timedelta.
 
     # "fromisocalendar" was introduced in 3.8
-    if klass is Timestamp and not PY38:
+    if klass is Timestamp and not compat.PY38:
         expected.remove("fromisocalendar")
 
     assert _get_overlap_public_nat_methods(klass) == expected

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -5,8 +5,6 @@ from datetime import timedelta
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
-
 from pandas.core.dtypes.common import is_scalar
 
 import pandas as pd
@@ -227,7 +225,6 @@ def test_getitem_dups_with_missing():
         s[["foo", "bar", "bah", "bam"]]
 
 
-@pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
 def test_getitem_dups():
     s = Series(range(5), index=["A", "A", "B", "C", "C"], dtype=np.int64)
     expected = Series([3, 4], index=["C", "C"], dtype=np.int64)

--- a/pandas/tests/series/indexing/test_where.py
+++ b/pandas/tests/series/indexing/test_where.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
-
 from pandas.core.dtypes.common import is_integer
 
 import pandas as pd
@@ -349,7 +347,6 @@ def test_where_dups():
     tm.assert_series_equal(comb, expected)
 
 
-@pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
 def test_where_numeric_with_string():
     # GH 9280
     s = Series([1, 2, 3])

--- a/pandas/tests/series/methods/test_clip.py
+++ b/pandas/tests/series/methods/test_clip.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
-
 import pandas as pd
 from pandas import Series, Timestamp, isna, notna
 import pandas._testing as tm
@@ -20,7 +18,6 @@ class TestSeriesClip:
         tm.assert_series_equal(result, expected)
         assert isinstance(expected, Series)
 
-    @pytest.mark.xfail(is_numpy_dev, reason="GH#39089 Numpy changed dtype inference")
     def test_clip_types_and_nulls(self):
 
         sers = [


### PR DESCRIPTION
This reverts commit 3bd3d1ec

- [x] xref #39205 can close this now probably
- [x] closes #39089 
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

