### PR TITLE
DOC: keep color for note admonitions in sphinx theme

### DIFF
--- a/doc/source/_static/css/pandas.css
+++ b/doc/source/_static/css/pandas.css
@@ -1,3 +1,10 @@
+/* Override some aspects of the pydata-sphinx-theme */
+
+:root {
+  /* Use softer blue from bootstrap's default info color */
+  --color-info: 23, 162, 184;
+}
+
 /* Getting started index page */
 
 .intro-card {


### PR DESCRIPTION
This doesn't change anything about the appearance in the docs, but is meant to keep the current look anticipating a change in the default color in the theme upstream (https://github.com/pandas-dev/pydata-sphinx-theme/pull/281)