### PR TITLE
REGR: fix numpy accumulate ufuncs for DataFrame

### DIFF
--- a/doc/source/whatsnew/v1.2.1.rst
+++ b/doc/source/whatsnew/v1.2.1.rst
@@ -31,6 +31,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.replace` raising ``ValueError`` when :class:`DataFrame` has dtype ``bytes`` (:issue:`38900`)
 - Fixed regression in :meth:`Series.fillna` that raised ``RecursionError`` with ``datetime64[ns, UTC]`` dtype (:issue:`38851`)
 - Fixed regression in comparisons between ``NaT`` and ``datetime.date`` objects incorrectly returning ``True`` (:issue:`39151`)
+- Fixed regression in calling NumPy ``accumulate`` ufuncs on DataFrames (:issue:`39259`)
 - Fixed regression in repr of float-like strings of an ``object`` dtype having trailing 0's truncated after the decimal (:issue:`38708`)
 - Fixed regression that raised ``AttributeError`` with PyArrow versions [0.16.0, 1.0.0) (:issue:`38801`)
 - Fixed regression in :func:`pandas.testing.assert_frame_equal` raising ``TypeError`` with ``check_like=True`` when :class:`Index` or columns have mixed dtype (:issue:`39168`)

--- a/doc/source/whatsnew/v1.2.1.rst
+++ b/doc/source/whatsnew/v1.2.1.rst
@@ -31,7 +31,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.replace` raising ``ValueError`` when :class:`DataFrame` has dtype ``bytes`` (:issue:`38900`)
 - Fixed regression in :meth:`Series.fillna` that raised ``RecursionError`` with ``datetime64[ns, UTC]`` dtype (:issue:`38851`)
 - Fixed regression in comparisons between ``NaT`` and ``datetime.date`` objects incorrectly returning ``True`` (:issue:`39151`)
-- Fixed regression in calling NumPy ``accumulate`` ufuncs on DataFrames (:issue:`39259`)
+- Fixed regression in calling NumPy ``accumulate`` ufuncs on DataFrames, e.g. ``np.maximum.accumulate(df)`` (:issue:`39259`)
 - Fixed regression in repr of float-like strings of an ``object`` dtype having trailing 0's truncated after the decimal (:issue:`38708`)
 - Fixed regression that raised ``AttributeError`` with PyArrow versions [0.16.0, 1.0.0) (:issue:`38801`)
 - Fixed regression in :func:`pandas.testing.assert_frame_equal` raising ``TypeError`` with ``check_like=True`` when :class:`Index` or columns have mixed dtype (:issue:`39168`)

--- a/doc/source/whatsnew/v1.2.1.rst
+++ b/doc/source/whatsnew/v1.2.1.rst
@@ -32,7 +32,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.replace` raising ``ValueError`` when :class:`DataFrame` has dtype ``bytes`` (:issue:`38900`)
 - Fixed regression in :meth:`Series.fillna` that raised ``RecursionError`` with ``datetime64[ns, UTC]`` dtype (:issue:`38851`)
 - Fixed regression in comparisons between ``NaT`` and ``datetime.date`` objects incorrectly returning ``True`` (:issue:`39151`)
-- Fixed regression in calling NumPy ``accumulate`` ufuncs on DataFrames, e.g. ``np.maximum.accumulate(df)`` (:issue:`39259`)
+- Fixed regression in calling NumPy :func:`~numpy.ufunc.accumulate` ufuncs on DataFrames, e.g. ``np.maximum.accumulate(df)`` (:issue:`39259`)
 - Fixed regression in repr of float-like strings of an ``object`` dtype having trailing 0's truncated after the decimal (:issue:`38708`)
 - Fixed regression that raised ``AttributeError`` with PyArrow versions [0.16.0, 1.0.0) (:issue:`38801`)
 - Fixed regression in :func:`pandas.testing.assert_frame_equal` raising ``TypeError`` with ``check_like=True`` when :class:`Index` or columns have mixed dtype (:issue:`39168`)

--- a/pandas/core/arraylike.py
+++ b/pandas/core/arraylike.py
@@ -275,11 +275,12 @@ def array_ufunc(self, ufunc: Callable, method: str, *inputs: Any, **kwargs: Any)
     else:
         # ufunc(dataframe)
         if method == "__call__":
+            # for np.<ufunc>(..) calls
             mgr = inputs[0]._mgr
             result = mgr.apply(getattr(ufunc, method))
         else:
-            # specific ufunc methods (eg accumulate) have an axis keyword
-            # and thus can't be called block-by-block
+            # otherwise specific ufunc methods (eg np.<ufunc>.accumulate(..))
+            # Those can have an axis keyword and thus can't be called block-by-block
             result = getattr(ufunc, method)(np.asarray(inputs[0]), **kwargs)
 
     if ufunc.nout > 1:  # type: ignore[attr-defined]

--- a/pandas/tests/frame/test_ufunc.py
+++ b/pandas/tests/frame/test_ufunc.py
@@ -117,6 +117,27 @@ def test_binary_frame_series_raises():
         np.logaddexp(df["A"], df)
 
 
+def test_unary_accumulate_axis():
+    # https://github.com/pandas-dev/pandas/issues/39259
+    df = pd.DataFrame({"a": [1, 3, 2, 4]})
+    result = np.maximum.accumulate(df)
+    expected = pd.DataFrame({"a": [1, 3, 3, 4]})
+    tm.assert_frame_equal(result, expected)
+
+    df = pd.DataFrame({"a": [1, 3, 2, 4], "b": [0.1, 4.0, 3.0, 2.0]})
+    result = np.maximum.accumulate(df)
+    # in theory could preserve int dtype for default axis=0
+    expected = pd.DataFrame({"a": [1.0, 3.0, 3.0, 4.0], "b": [0.1, 4.0, 4.0, 4.0]})
+    tm.assert_frame_equal(result, expected)
+
+    result = np.maximum.accumulate(df, axis=0)
+    tm.assert_frame_equal(result, expected)
+
+    result = np.maximum.accumulate(df, axis=1)
+    expected = pd.DataFrame({"a": [1.0, 3.0, 2.0, 4.0], "b": [1.0, 4.0, 3.0, 4.0]})
+    tm.assert_frame_equal(result, expected)
+
+
 def test_frame_outer_deprecated():
     df = pd.DataFrame({"A": [1, 2]})
     with tm.assert_produces_warning(FutureWarning):


### PR DESCRIPTION
Closes #39259

So we shouldn't call non-`__call__` ufuncs block-by-block, since they can work along a certain axis, like `accumulate`. In this case there were 2 problems: 1) we were applying the ufunc on the Block values, which is 2D but transposed compared to the DataFrame (so the accumulation was done in the wrong direction) and 2) the `axis` keyword was also not passed through in case the user specified it.