### PR TITLE
BUG: DataFrame.__setitem__ raising ValueError when setting multiple values to dup columns

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -275,6 +275,7 @@ Indexing
 ^^^^^^^^
 - Bug in :meth:`CategoricalIndex.get_indexer` failing to raise ``InvalidIndexError`` when non-unique (:issue:`38372`)
 - Bug in inserting many new columns into a :class:`DataFrame` causing incorrect subsequent indexing behavior (:issue:`38380`)
+- Bug in :meth:`DataFrame.__setitem__` raising ``ValueError`` when setting multiple values to duplicate columns (:issue:`15695`)
 - Bug in :meth:`DataFrame.loc`, :meth:`Series.loc`, :meth:`DataFrame.__getitem__` and :meth:`Series.__getitem__` returning incorrect elements for non-monotonic :class:`DatetimeIndex` for string slices (:issue:`33146`)
 - Bug in :meth:`DataFrame.reindex` and :meth:`Series.reindex` with timezone aware indexes raising ``TypeError`` for ``method="ffill"`` and ``method="bfill"`` and specified ``tolerance`` (:issue:`38566`)
 - Bug in :meth:`DataFrame.__setitem__` raising ``ValueError`` with empty :class:`DataFrame` and specified columns for string indexer and non empty :class:`DataFrame` to set (:issue:`38831`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3195,9 +3195,11 @@ class DataFrame(NDFrame, OpsMixin):
             self._setitem_array(key, value)
         elif isinstance(value, DataFrame):
             self._set_item_frame_value(key, value)
-        elif len(self.columns.get_indexer_for([key])) > 1:
+        elif is_list_like(value) and 1 < len(
+            self.columns.get_indexer_for([key])
+        ) == len(value):
             # Column to set is duplicated
-            self._setitem_array(key, value)
+            self._setitem_array([key], value)
         else:
             # set column
             self._set_item(key, value)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3195,6 +3195,9 @@ class DataFrame(NDFrame, OpsMixin):
             self._setitem_array(key, value)
         elif isinstance(value, DataFrame):
             self._set_item_frame_value(key, value)
+        elif len(self.columns.get_indexer_for([key])) > 1:
+            # Column to set is duplicated
+            self._setitem_array(key, value)
         else:
             # set column
             self._set_item(key, value)

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -348,6 +348,24 @@ class TestDataFrameSetItem:
         expected["A"] = expected["A"].astype("object")
         tm.assert_frame_equal(df, expected)
 
+    def test_setitem_frame_duplicate_columns(self):
+        # GH#15695
+        cols = ["A", "B", "C"] * 2
+        df = DataFrame(index=range(3), columns=cols)
+        df.loc[0, "A"] = (0, 3)
+        df.loc[:, "B"] = (1, 4)
+        df["C"] = (2, 5)
+        expected = DataFrame(
+            [
+                [0, 1, 2, 3, 4, 5],
+                [np.nan, 1, 2, np.nan, 4, 5],
+                [np.nan, 1, 2, np.nan, 4, 5],
+            ],
+            columns=cols,
+            dtype="object",
+        )
+        tm.assert_frame_equal(df, expected)
+
 
 class TestDataFrameSetItemWithExpansion:
     def test_setitem_listlike_views(self):


### PR DESCRIPTION
- [x] closes #15695
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

Setting with a scalar key which is duplicated in columns should be the same as using a listlike key