### PR TITLE
'lower' method causing problems when individual values are being read as 'int'

### DIFF
--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -890,6 +890,7 @@ def _assemble_from_unit_mappings(arg, errors, tz):
 
     # replace passed unit with _unit_map
     def f(value):
+        value = float(value) #some values being read as int raising error with lower method used below
         if value in _unit_map:
             return _unit_map[value]
 


### PR DESCRIPTION
- couldn't run tests as using company locked system

