### PR TITLE
REF: add skeleton for strategy pattern in describe

### DIFF
--- a/pandas/core/describe.py
+++ b/pandas/core/describe.py
@@ -92,35 +92,36 @@ class StrategyAbstract(ABC):
         self.data = data
         self.percentiles = percentiles
 
-    def describe(self) -> "Series":
+    @abstractmethod
+    def describe(self) -> Series:
         """Describe series."""
 
 
 class CategoricalStrategy(StrategyAbstract):
     """Strategy for series with categorical values."""
 
-    def describe(self) -> "Series":
+    def describe(self) -> Series:
         return describe_categorical_1d(self.data)
 
 
 class TimestampAsCategoricalStrategy(StrategyAbstract):
     """Strategy for series with timestamp values treated as categorical values."""
 
-    def describe(self) -> "Series":
+    def describe(self) -> Series:
         return describe_timestamp_as_categorical_1d(self.data)
 
 
 class TimestampStrategy(StrategyAbstract):
     """Strategy for series with timestamp values."""
 
-    def describe(self) -> "Series":
+    def describe(self) -> Series:
         return describe_timestamp_1d(self.data, percentiles=self.percentiles)
 
 
 class NumericStrategy(StrategyAbstract):
     """Strategy for series with numeric values."""
 
-    def describe(self) -> "Series":
+    def describe(self) -> Series:
         return describe_numeric_1d(self.data, percentiles=self.percentiles)
 
 


### PR DESCRIPTION
- [ ] xref #36833
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

Added a skeleton for the strategy pattern in ``pandas/core/describe.py``.
Currently the methods ``describe`` simply delegate to the corresponding ``describe_`` functions.
In the next steps I plan on moving the ``describe`` functions into each of the strategy classes.
Finally, these functions can be unified, since a lot there has a common pattern.