### PR TITLE
CLN, TYP Remove string type hints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -149,8 +149,7 @@ repos:
         entry: |
             (?x)
             \#\ type:\ (?!ignore)|
-            \#\ type:\s?ignore(?!\[)|
-            \)\ ->\ \"
+            \#\ type:\s?ignore(?!\[)
         language: pygrep
         types: [python]
     -   id: np-bool
@@ -185,3 +184,7 @@ repos:
     -   id: codespell
         types_or: [python, rst, markdown]
         files: ^pandas/core/
+-   repo: https://github.com/MarcoGorelli/no-string-hints
+    rev: v0.1.5
+    hooks:
+    -   id: no-string-hints

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -3,6 +3,8 @@ aggregation.py contains utility functions to handle multiple named and lambda
 kwarg aggregations in groupby and DataFrame/Series aggregation
 """
 
+from __future__ import annotations
+
 from collections import defaultdict
 from functools import partial
 from typing import (
@@ -296,7 +298,7 @@ def relabel_result(
     func: Dict[str, List[Union[Callable, str]]],
     columns: Iterable[Hashable],
     order: Iterable[int],
-) -> Dict[Hashable, "Series"]:
+) -> Dict[Hashable, Series]:
     """
     Internal function to reorder result if relabelling is True for
     dataframe.agg, and return the reordered result in dict.
@@ -323,7 +325,7 @@ def relabel_result(
     reordered_indexes = [
         pair[0] for pair in sorted(zip(columns, order), key=lambda t: t[1])
     ]
-    reordered_result_in_dict: Dict[Hashable, "Series"] = {}
+    reordered_result_in_dict: Dict[Hashable, Series] = {}
     idx = 0
 
     reorder_mask = not isinstance(result, ABCSeries) and len(result.columns) > 1

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -559,7 +559,7 @@ def factorize(
     sort: bool = False,
     na_sentinel: Optional[int] = -1,
     size_hint: Optional[int] = None,
-) -> Tuple[np.ndarray, Union[np.ndarray, "Index"]]:
+) -> Tuple[np.ndarray, Union[np.ndarray, Index]]:
     """
     Encode the object as an enumerated type or categorical variable.
 

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -72,7 +72,7 @@ class BooleanDtype(BaseMaskedDtype):
         return np.dtype("bool")
 
     @classmethod
-    def construct_array_type(cls) -> Type["BooleanArray"]:
+    def construct_array_type(cls) -> Type[BooleanArray]:
         """
         Return the array type associated with this dtype.
 
@@ -94,7 +94,7 @@ class BooleanDtype(BaseMaskedDtype):
         return True
 
     def __from_arrow__(
-        self, array: Union["pyarrow.Array", "pyarrow.ChunkedArray"]
+        self, array: Union[pyarrow.Array, pyarrow.ChunkedArray]
     ) -> BooleanArray:
         """
         Construct BooleanArray from pyarrow Array/ChunkedArray.

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -422,7 +422,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         return self._dtype
 
     @property
-    def _constructor(self) -> Type["Categorical"]:
+    def _constructor(self) -> Type[Categorical]:
         return Categorical
 
     @classmethod
@@ -2162,7 +2162,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
     # ------------------------------------------------------------------
 
-    def _encode_with_my_categories(self, other: "Categorical") -> Categorical:
+    def _encode_with_my_categories(self, other: Categorical) -> Categorical:
         """
         Re-encode another categorical using this Categorical's categories.
 
@@ -2179,7 +2179,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         )
         return self._from_backing_data(codes)
 
-    def _categories_match_up_to_permutation(self, other: "Categorical") -> bool:
+    def _categories_match_up_to_permutation(self, other: Categorical) -> bool:
         """
         Returns True if categoricals are the same dtype
           same categories, and same ordered
@@ -2527,7 +2527,7 @@ class CategoricalAccessor(PandasDelegate, PandasObject, NoNewAttributesMixin):
 # utility routines
 
 
-def _get_codes_for_values(values, categories: "Index") -> np.ndarray:
+def _get_codes_for_values(values, categories: Index) -> np.ndarray:
     """
     utility routine to turn values into codes given the specified categories
 

--- a/pandas/core/arrays/floating.py
+++ b/pandas/core/arrays/floating.py
@@ -47,7 +47,7 @@ class FloatingDtype(NumericDtype):
         return True
 
     @classmethod
-    def construct_array_type(cls) -> Type["FloatingArray"]:
+    def construct_array_type(cls) -> Type[FloatingArray]:
         """
         Return the array type associated with this dtype.
 

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -57,7 +57,7 @@ class _IntegerDtype(NumericDtype):
         return True
 
     @classmethod
-    def construct_array_type(cls) -> Type["IntegerArray"]:
+    def construct_array_type(cls) -> Type[IntegerArray]:
         """
         Return the array type associated with this dtype.
 

--- a/pandas/core/arrays/numeric.py
+++ b/pandas/core/arrays/numeric.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import numbers
 from typing import TYPE_CHECKING, Any, List, Union
@@ -25,7 +27,7 @@ if TYPE_CHECKING:
 
 class NumericDtype(BaseMaskedDtype):
     def __from_arrow__(
-        self, array: Union["pyarrow.Array", "pyarrow.ChunkedArray"]
+        self, array: Union[pyarrow.Array, pyarrow.ChunkedArray]
     ) -> BaseMaskedArray:
         """
         Construct IntegerArray/FloatingArray from pyarrow Array/ChunkedArray.

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -89,7 +89,7 @@ class PandasDtype(ExtensionDtype):
         return cls(dtype)
 
     @classmethod
-    def construct_array_type(cls) -> Type["PandasArray"]:
+    def construct_array_type(cls) -> Type[PandasArray]:
         """
         Return the array type associated with this dtype.
 
@@ -155,7 +155,7 @@ class PandasArray(
     # ------------------------------------------------------------------------
     # Constructors
 
-    def __init__(self, values: Union[np.ndarray, "PandasArray"], copy: bool = False):
+    def __init__(self, values: Union[np.ndarray, PandasArray], copy: bool = False):
         if isinstance(values, type(self)):
             values = values._ndarray
         if not isinstance(values, np.ndarray):

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -201,7 +201,7 @@ class PeriodArray(PeriodMixin, dtl.DatelikeOps):
 
     @classmethod
     def _from_sequence(
-        cls: Type["PeriodArray"],
+        cls: Type[PeriodArray],
         scalars: Union[Sequence[Optional[Period]], AnyArrayLike],
         *,
         dtype: Optional[Dtype] = None,

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -62,7 +62,7 @@ SparseArrayT = TypeVar("SparseArrayT", bound="SparseArray")
 _sparray_doc_kwargs = {"klass": "SparseArray"}
 
 
-def _get_fill(arr: "SparseArray") -> np.ndarray:
+def _get_fill(arr: SparseArray) -> np.ndarray:
     """
     Create a 0-dim ndarray containing the fill value
 
@@ -87,7 +87,7 @@ def _get_fill(arr: "SparseArray") -> np.ndarray:
 
 
 def _sparse_array_op(
-    left: "SparseArray", right: "SparseArray", op: Callable, name: str
+    left: SparseArray, right: SparseArray, op: Callable, name: str
 ) -> Any:
     """
     Perform a binary operation between two arrays.
@@ -896,7 +896,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
         return taken
 
-    def _take_without_fill(self, indices) -> Union[np.ndarray, "SparseArray"]:
+    def _take_without_fill(self, indices) -> Union[np.ndarray, SparseArray]:
         to_shift = indices < 0
         indices = indices.copy()
 

--- a/pandas/core/arrays/sparse/dtype.py
+++ b/pandas/core/arrays/sparse/dtype.py
@@ -173,7 +173,7 @@ class SparseDtype(ExtensionDtype):
         return self.name
 
     @classmethod
-    def construct_array_type(cls) -> Type["SparseArray"]:
+    def construct_array_type(cls) -> Type[SparseArray]:
         """
         Return the array type associated with this dtype.
 

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -71,7 +71,7 @@ class StringDtype(ExtensionDtype):
         return str
 
     @classmethod
-    def construct_array_type(cls) -> Type["StringArray"]:
+    def construct_array_type(cls) -> Type[StringArray]:
         """
         Return the array type associated with this dtype.
 
@@ -85,7 +85,7 @@ class StringDtype(ExtensionDtype):
         return "StringDtype"
 
     def __from_arrow__(
-        self, array: Union["pyarrow.Array", "pyarrow.ChunkedArray"]
+        self, array: Union[pyarrow.Array, pyarrow.ChunkedArray]
     ) -> StringArray:
         """
         Construct StringArray from pyarrow Array/ChunkedArray.

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -87,7 +87,7 @@ class ArrowStringDtype(ExtensionDtype):
         return str
 
     @classmethod
-    def construct_array_type(cls) -> Type["ArrowStringArray"]:
+    def construct_array_type(cls) -> Type[ArrowStringArray]:
         """
         Return the array type associated with this dtype.
 
@@ -104,7 +104,7 @@ class ArrowStringDtype(ExtensionDtype):
         return "ArrowStringDtype"
 
     def __from_arrow__(
-        self, array: Union["pa.Array", "pa.ChunkedArray"]
+        self, array: Union[pa.Array, pa.ChunkedArray]
     ) -> ArrowStringArray:
         """
         Construct StringArray from pyarrow Array/ChunkedArray.

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -2,6 +2,8 @@
 Operator classes for eval.
 """
 
+from __future__ import annotations
+
 from datetime import datetime
 from distutils.version import LooseVersion
 from functools import partial
@@ -203,7 +205,7 @@ class Op:
 
     op: str
 
-    def __init__(self, op: str, operands: Iterable[Union[Term, "Op"]], encoding=None):
+    def __init__(self, op: str, operands: Iterable[Union[Term, Op]], encoding=None):
         self.op = _bool_op_map.get(op, op)
         self.operands = operands
         self.encoding = encoding

--- a/pandas/core/describe.py
+++ b/pandas/core/describe.py
@@ -92,7 +92,7 @@ class NDFrameDescriberAbstract(ABC):
         Whether to treat datetime dtypes as numeric.
     """
 
-    def __init__(self, obj: "FrameOrSeriesUnion", datetime_is_numeric: bool):
+    def __init__(self, obj: FrameOrSeriesUnion, datetime_is_numeric: bool):
         self.obj = obj
         self.datetime_is_numeric = datetime_is_numeric
 
@@ -110,7 +110,7 @@ class NDFrameDescriberAbstract(ABC):
 class SeriesDescriber(NDFrameDescriberAbstract):
     """Class responsible for creating series description."""
 
-    obj: "Series"
+    obj: Series
 
     def describe(self, percentiles: Sequence[float]) -> Series:
         describe_func = select_describe_func(
@@ -137,7 +137,7 @@ class DataFrameDescriber(NDFrameDescriberAbstract):
 
     def __init__(
         self,
-        obj: "DataFrame",
+        obj: DataFrame,
         *,
         include: Optional[Union[str, Sequence[str]]],
         exclude: Optional[Union[str, Sequence[str]]],
@@ -154,7 +154,7 @@ class DataFrameDescriber(NDFrameDescriberAbstract):
     def describe(self, percentiles: Sequence[float]) -> DataFrame:
         data = self._select_data()
 
-        ldesc: List["Series"] = []
+        ldesc: List[Series] = []
         for _, series in data.items():
             describe_func = select_describe_func(series, self.datetime_is_numeric)
             ldesc.append(describe_func(series, percentiles))
@@ -191,7 +191,7 @@ class DataFrameDescriber(NDFrameDescriberAbstract):
         return data
 
 
-def reorder_columns(ldesc: Sequence["Series"]) -> List[Hashable]:
+def reorder_columns(ldesc: Sequence[Series]) -> List[Hashable]:
     """Set a convenient order for rows for display."""
     names: List[Hashable] = []
     ldesc_indexes = sorted((x.index for x in ldesc), key=len)
@@ -202,7 +202,7 @@ def reorder_columns(ldesc: Sequence["Series"]) -> List[Hashable]:
     return names
 
 
-def describe_numeric_1d(series: "Series", percentiles: Sequence[float]) -> Series:
+def describe_numeric_1d(series: Series, percentiles: Sequence[float]) -> Series:
     """Describe series containing numerical data.
 
     Parameters
@@ -226,7 +226,7 @@ def describe_numeric_1d(series: "Series", percentiles: Sequence[float]) -> Serie
 
 
 def describe_categorical_1d(
-    data: "Series",
+    data: Series,
     percentiles_ignored: Sequence[float],
 ) -> Series:
     """Describe series containing categorical data.
@@ -258,7 +258,7 @@ def describe_categorical_1d(
 
 
 def describe_timestamp_as_categorical_1d(
-    data: "Series",
+    data: Series,
     percentiles_ignored: Sequence[float],
 ) -> Series:
     """Describe series containing timestamp data treated as categorical.
@@ -305,7 +305,7 @@ def describe_timestamp_as_categorical_1d(
     return Series(result, index=names, name=data.name, dtype=dtype)
 
 
-def describe_timestamp_1d(data: "Series", percentiles: Sequence[float]) -> Series:
+def describe_timestamp_1d(data: Series, percentiles: Sequence[float]) -> Series:
     """Describe series containing datetime64 dtype.
 
     Parameters
@@ -330,7 +330,7 @@ def describe_timestamp_1d(data: "Series", percentiles: Sequence[float]) -> Serie
 
 
 def select_describe_func(
-    data: "Series",
+    data: Series,
     datetime_is_numeric: bool,
 ) -> Callable:
     """Select proper function for describing series based on data type.

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -2,6 +2,8 @@
 Extend pandas with custom array types.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Type, Union
 
 import numpy as np
@@ -186,7 +188,7 @@ class ExtensionDtype:
         return None
 
     @classmethod
-    def construct_array_type(cls) -> Type["ExtensionArray"]:
+    def construct_array_type(cls) -> Type[ExtensionArray]:
         """
         Return the array type associated with this dtype.
 

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -321,7 +321,7 @@ def maybe_downcast_numeric(result, dtype: DtypeObj, do_round: bool = False):
 
 
 def maybe_cast_result(
-    result: ArrayLike, obj: "Series", numeric_only: bool = False, how: str = ""
+    result: ArrayLike, obj: Series, numeric_only: bool = False, how: str = ""
 ) -> ArrayLike:
     """
     Try casting result to a different type if appropriate
@@ -397,7 +397,7 @@ def maybe_cast_result_dtype(dtype: DtypeObj, how: str) -> DtypeObj:
 
 
 def maybe_cast_to_extension_array(
-    cls: Type["ExtensionArray"], obj: ArrayLike, dtype: Optional[ExtensionDtype] = None
+    cls: Type[ExtensionArray], obj: ArrayLike, dtype: Optional[ExtensionDtype] = None
 ) -> ArrayLike:
     """
     Call to `_from_sequence` that returns the object unchanged on Exception.

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -67,7 +67,7 @@ class PandasExtensionDtype(ExtensionDtype):
     base = None
     isbuiltin = 0
     isnative = 0
-    _cache: Dict[str_type, "PandasExtensionDtype"] = {}
+    _cache: Dict[str_type, PandasExtensionDtype] = {}
 
     def __str__(self) -> str_type:
         """
@@ -178,7 +178,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
 
     @classmethod
     def _from_categorical_dtype(
-        cls, dtype: "CategoricalDtype", categories=None, ordered: Ordered = None
+        cls, dtype: CategoricalDtype, categories=None, ordered: Ordered = None
     ) -> CategoricalDtype:
         if categories is ordered is None:
             return dtype
@@ -453,7 +453,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
         return np.bitwise_xor.reduce(hashed)
 
     @classmethod
-    def construct_array_type(cls) -> Type["Categorical"]:
+    def construct_array_type(cls) -> Type[Categorical]:
         """
         Return the array type associated with this dtype.
 
@@ -522,7 +522,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
         return categories
 
     def update_dtype(
-        self, dtype: Union[str_type, "CategoricalDtype"]
+        self, dtype: Union[str_type, CategoricalDtype]
     ) -> CategoricalDtype:
         """
         Returns a CategoricalDtype with categories and ordered taken from dtype
@@ -655,7 +655,7 @@ class DatetimeTZDtype(PandasExtensionDtype):
     _match = re.compile(r"(datetime64|M8)\[(?P<unit>.+), (?P<tz>.+)\]")
     _cache: Dict[str_type, PandasExtensionDtype] = {}
 
-    def __init__(self, unit: Union[str_type, "DatetimeTZDtype"] = "ns", tz=None):
+    def __init__(self, unit: Union[str_type, DatetimeTZDtype] = "ns", tz=None):
         if isinstance(unit, DatetimeTZDtype):
             # error: "str" has no attribute "tz"
             unit, tz = unit.unit, unit.tz  # type: ignore[attr-defined]
@@ -702,7 +702,7 @@ class DatetimeTZDtype(PandasExtensionDtype):
         return self._tz
 
     @classmethod
-    def construct_array_type(cls) -> Type["DatetimeArray"]:
+    def construct_array_type(cls) -> Type[DatetimeArray]:
         """
         Return the array type associated with this dtype.
 
@@ -948,7 +948,7 @@ class PeriodDtype(dtypes.PeriodDtypeBase, PandasExtensionDtype):
         return super().is_dtype(dtype)
 
     @classmethod
-    def construct_array_type(cls) -> Type["PeriodArray"]:
+    def construct_array_type(cls) -> Type[PeriodArray]:
         """
         Return the array type associated with this dtype.
 
@@ -961,7 +961,7 @@ class PeriodDtype(dtypes.PeriodDtypeBase, PandasExtensionDtype):
         return PeriodArray
 
     def __from_arrow__(
-        self, array: Union["pyarrow.Array", "pyarrow.ChunkedArray"]
+        self, array: Union[pyarrow.Array, pyarrow.ChunkedArray]
     ) -> PeriodArray:
         """
         Construct PeriodArray from pyarrow Array/ChunkedArray.
@@ -1098,7 +1098,7 @@ class IntervalDtype(PandasExtensionDtype):
         return self._subtype
 
     @classmethod
-    def construct_array_type(cls) -> Type["IntervalArray"]:
+    def construct_array_type(cls) -> Type[IntervalArray]:
         """
         Return the array type associated with this dtype.
 
@@ -1192,7 +1192,7 @@ class IntervalDtype(PandasExtensionDtype):
         return super().is_dtype(dtype)
 
     def __from_arrow__(
-        self, array: Union["pyarrow.Array", "pyarrow.ChunkedArray"]
+        self, array: Union[pyarrow.Array, pyarrow.ChunkedArray]
     ) -> IntervalArray:
         """
         Construct IntervalArray from pyarrow Array/ChunkedArray.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9440,8 +9440,8 @@ NaN 12.3   33.0
         base: Optional[int] = None,
         on=None,
         level=None,
-        origin: Union[str, "TimestampConvertibleTypes"] = "start_day",
-        offset: Optional["TimedeltaConvertibleTypes"] = None,
+        origin: Union[str, TimestampConvertibleTypes] = "start_day",
+        offset: Optional[TimedeltaConvertibleTypes] = None,
     ) -> Resampler:
         return super().resample(
             rule=rule,

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1690,7 +1690,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
         return result
 
-    def _wrap_agged_blocks(self, blocks: Sequence["Block"], items: Index) -> DataFrame:
+    def _wrap_agged_blocks(self, blocks: Sequence[Block], items: Index) -> DataFrame:
         if not self.as_index:
             index = np.arange(blocks[0].values.shape[-1])
             mgr = BlockManager(blocks, axes=[items, index])

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -522,7 +522,7 @@ class BaseGroupBy(PandasObject, SelectionMixin, Generic[FrameOrSeries]):
         keys: Optional[_KeysArgType] = None,
         axis: int = 0,
         level: Optional[IndexLabel] = None,
-        grouper: Optional["ops.BaseGrouper"] = None,
+        grouper: Optional[ops.BaseGrouper] = None,
         exclusions: Optional[Set[Hashable]] = None,
         selection: Optional[IndexLabel] = None,
         as_index: bool = True,
@@ -1371,7 +1371,7 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
 
     @final
     @property
-    def _obj_1d_constructor(self) -> Type["Series"]:
+    def _obj_1d_constructor(self) -> Type[Series]:
         # GH28330 preserve subclassed Series/DataFrames
         if isinstance(self.obj, DataFrame):
             return self.obj._constructor_sliced

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -2,6 +2,8 @@
 Provide user facing operators for doing the split part of the
 split-apply-combine paradigm.
 """
+from __future__ import annotations
+
 from typing import Dict, Hashable, List, Optional, Set, Tuple
 import warnings
 
@@ -616,7 +618,7 @@ def get_grouper(
     mutated: bool = False,
     validate: bool = True,
     dropna: bool = True,
-) -> Tuple["ops.BaseGrouper", Set[Hashable], FrameOrSeries]:
+) -> Tuple[ops.BaseGrouper, Set[Hashable], FrameOrSeries]:
     """
     Create and return a BaseGrouper, which is an internal
     mapping of how to create the grouper indexers.

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -100,7 +100,7 @@ class BaseGrouper:
     def __init__(
         self,
         axis: Index,
-        groupings: Sequence["grouper.Grouping"],
+        groupings: Sequence[grouper.Grouping],
         sort: bool = True,
         group_keys: bool = True,
         mutated: bool = False,
@@ -119,7 +119,7 @@ class BaseGrouper:
         self.dropna = dropna
 
     @property
-    def groupings(self) -> List["grouper.Grouping"]:
+    def groupings(self) -> List[grouper.Grouping]:
         return self._groupings
 
     @property

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -1,6 +1,8 @@
 """
 datetimelike delegation
 """
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 import warnings
 
@@ -33,7 +35,7 @@ class Properties(PandasDelegate, PandasObject, NoNewAttributesMixin):
         "name",
     }
 
-    def __init__(self, data: "Series", orig):
+    def __init__(self, data: Series, orig):
         if not isinstance(data, ABCSeries):
             raise TypeError(
                 f"cannot convert an object of type {type(data)} to a datetimelike index"
@@ -462,7 +464,7 @@ class PeriodProperties(Properties):
 class CombinedDatetimelikeProperties(
     DatetimeProperties, TimedeltaProperties, PeriodProperties
 ):
-    def __new__(cls, data: "Series"):
+    def __new__(cls, data: Series):
         # CombinedDatetimelikeProperties isn't really instantiated. Instead
         # we need to choose which parent (datetime or timedelta) is
         # appropriate. Since we're checking the dtypes anyway, we'll just

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3313,7 +3313,7 @@ class Index(IndexOpsMixin, PandasObject):
         return self._get_indexer(target, method, limit, tolerance)
 
     def _get_indexer(
-        self, target: "Index", method=None, limit=None, tolerance=None
+        self, target: Index, method=None, limit=None, tolerance=None
     ) -> np.ndarray:
         if tolerance is not None:
             tolerance = self._convert_tolerance(tolerance, target)
@@ -3372,7 +3372,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     @final
     def _get_fill_indexer(
-        self, target: "Index", method: str_t, limit=None, tolerance=None
+        self, target: Index, method: str_t, limit=None, tolerance=None
     ) -> np.ndarray:
 
         target_values = target._get_engine_target()
@@ -3392,7 +3392,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     @final
     def _get_fill_indexer_searchsorted(
-        self, target: "Index", method: str_t, limit=None
+        self, target: Index, method: str_t, limit=None
     ) -> np.ndarray:
         """
         Fallback pad/backfill get_indexer that works for monotonic decreasing
@@ -3425,7 +3425,7 @@ class Index(IndexOpsMixin, PandasObject):
         return indexer
 
     @final
-    def _get_nearest_indexer(self, target: "Index", limit, tolerance) -> np.ndarray:
+    def _get_nearest_indexer(self, target: Index, limit, tolerance) -> np.ndarray:
         """
         Get the indexer for the nearest index labels; requires an index with
         values that can be subtracted from each other (e.g., not strings or
@@ -3460,7 +3460,7 @@ class Index(IndexOpsMixin, PandasObject):
     @final
     def _filter_indexer_tolerance(
         self,
-        target: Union["Index", np.ndarray, ExtensionArray],
+        target: Union[Index, np.ndarray, ExtensionArray],
         indexer: np.ndarray,
         tolerance,
     ) -> np.ndarray:
@@ -4524,7 +4524,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         return self._concat(to_concat, name)
 
-    def _concat(self, to_concat: List["Index"], name: Hashable) -> Index:
+    def _concat(self, to_concat: List[Index], name: Hashable) -> Index:
         """
         Concatenate multiple Index objects.
         """
@@ -4724,7 +4724,7 @@ class Index(IndexOpsMixin, PandasObject):
                 loc = loc.indices(len(self))[-1]
             return self[loc]
 
-    def asof_locs(self, where: "Index", mask) -> np.ndarray:
+    def asof_locs(self, where: Index, mask) -> np.ndarray:
         """
         Return the locations (indices) of labels in the index.
 
@@ -4955,7 +4955,7 @@ class Index(IndexOpsMixin, PandasObject):
         return self._data.argsort(*args, **kwargs)
 
     @final
-    def get_value(self, series: "Series", key):
+    def get_value(self, series: Series, key):
         """
         Fast lookup of value from 1-dimensional ndarray.
 
@@ -5005,7 +5005,7 @@ class Index(IndexOpsMixin, PandasObject):
         """
         return not self.holds_integer() and not self.is_boolean()
 
-    def _get_values_for_loc(self, series: "Series", loc, key):
+    def _get_values_for_loc(self, series: Series, loc, key):
         """
         Do a positional lookup on the given Series, returning either a scalar
         or a Series.
@@ -5121,7 +5121,7 @@ class Index(IndexOpsMixin, PandasObject):
         indexer, _ = self.get_indexer_non_unique(target)
         return indexer
 
-    def _get_indexer_non_comparable(self, target: "Index", method, unique: bool = True):
+    def _get_indexer_non_comparable(self, target: Index, method, unique: bool = True):
         """
         Called from get_indexer or get_indexer_non_unique when the target
         is of a non-comparable dtype.
@@ -5171,7 +5171,7 @@ class Index(IndexOpsMixin, PandasObject):
     _requires_unique_msg = "Reindexing only valid with uniquely valued Index objects"
 
     @final
-    def _maybe_promote(self, other: "Index"):
+    def _maybe_promote(self, other: Index):
         """
         When dealing with an object-dtype Index and a non-object Index, see
         if we can upcast the object-dtype one to improve performance.
@@ -5195,7 +5195,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         return self, other
 
-    def _should_compare(self, other: "Index") -> bool:
+    def _should_compare(self, other: Index) -> bool:
         """
         Check if `self == other` can ever have non-False entries.
         """

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -468,7 +468,7 @@ class CategoricalIndex(NDArrayBackedExtensionIndex, accessor.PandasDelegate):
         return self._data._unbox_scalar(key)
 
     def _get_indexer(
-        self, target: "Index", method=None, limit=None, tolerance=None
+        self, target: Index, method=None, limit=None, tolerance=None
     ) -> np.ndarray:
 
         if self.equals(target):
@@ -605,7 +605,7 @@ class CategoricalIndex(NDArrayBackedExtensionIndex, accessor.PandasDelegate):
         mapped = self._values.map(mapper)
         return Index(mapped, name=self.name)
 
-    def _concat(self, to_concat: List["Index"], name: Hashable) -> Index:
+    def _concat(self, to_concat: List[Index], name: Hashable) -> Index:
         # if calling index is category, don't check dtype of others
         try:
             codes = np.concatenate([self._is_dtype_compat(c).codes for c in to_concat])

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -404,7 +404,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
             return this.rename(res_name)
         return this
 
-    def _maybe_utc_convert(self, other: Index) -> Tuple["DatetimeIndex", Index]:
+    def _maybe_utc_convert(self, other: Index) -> Tuple[DatetimeIndex, Index]:
         this = self
 
         if isinstance(other, DatetimeIndex):

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -936,7 +936,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
 
         return taken
 
-    def _intersection_unique(self, other: "IntervalIndex") -> IntervalIndex:
+    def _intersection_unique(self, other: IntervalIndex) -> IntervalIndex:
         """
         Used when the IntervalIndex does not have any common endpoint,
         no matter left or right.
@@ -959,7 +959,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
 
         return self.take(indexer)
 
-    def _intersection_non_unique(self, other: "IntervalIndex") -> IntervalIndex:
+    def _intersection_non_unique(self, other: IntervalIndex) -> IntervalIndex:
         """
         Used when the IntervalIndex does have some common endpoints,
         on either sides.

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2548,7 +2548,7 @@ class MultiIndex(Index):
         # GH#33355
         return self.levels[0]._should_fallback_to_positional()
 
-    def _get_values_for_loc(self, series: "Series", loc, key):
+    def _get_values_for_loc(self, series: Series, loc, key):
         """
         Do a positional lookup on the given Series, returning either a scalar
         or a Series.

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -472,7 +472,7 @@ class RangeIndex(Int64Index):
 
     def factorize(
         self, sort: bool = False, na_sentinel: Optional[int] = -1
-    ) -> Tuple[np.ndarray, "RangeIndex"]:
+    ) -> Tuple[np.ndarray, RangeIndex]:
         codes = np.arange(len(self), dtype=np.intp)
         uniques = self
         if sort and self.step < 0:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1941,7 +1941,7 @@ class _iLocIndexer(_LocationIndexer):
             ilocs = column_indexer
         return ilocs
 
-    def _align_series(self, indexer, ser: "Series", multiindex_indexer: bool = False):
+    def _align_series(self, indexer, ser: Series, multiindex_indexer: bool = False):
         """
         Parameters
         ----------

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -187,7 +187,7 @@ class ArrayManager(DataManager):
         indexer = np.arange(self.shape[0])
         return new_mgr, indexer
 
-    def operate_blockwise(self, other: "ArrayManager", array_op) -> ArrayManager:
+    def operate_blockwise(self, other: ArrayManager, array_op) -> ArrayManager:
         """
         Apply array_op blockwise with another (aligned) BlockManager.
         """

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -368,7 +368,7 @@ class Block(PandasObject):
         self.values = np.delete(self.values, loc, 0)
         self.mgr_locs = self.mgr_locs.delete(loc)
 
-    def apply(self, func, **kwargs) -> List["Block"]:
+    def apply(self, func, **kwargs) -> List[Block]:
         """
         apply the function to my values; return a block if we are not
         one
@@ -378,7 +378,7 @@ class Block(PandasObject):
 
         return self._split_op_result(result)
 
-    def reduce(self, func, ignore_failures: bool = False) -> List["Block"]:
+    def reduce(self, func, ignore_failures: bool = False) -> List[Block]:
         # We will apply the function and reshape the result into a single-row
         #  Block with the same mgr_locs; squeezing will be done at a higher level
         assert self.ndim == 2
@@ -399,7 +399,7 @@ class Block(PandasObject):
         nb = self.make_block(res_values)
         return [nb]
 
-    def _split_op_result(self, result) -> List["Block"]:
+    def _split_op_result(self, result) -> List[Block]:
         # See also: split_and_operate
         if is_extension_array_dtype(result) and result.ndim > 1:
             # TODO(EA2D): unnecessary with 2D EAs
@@ -418,7 +418,7 @@ class Block(PandasObject):
 
     def fillna(
         self, value, limit=None, inplace: bool = False, downcast=None
-    ) -> List["Block"]:
+    ) -> List[Block]:
         """
         fillna on the block with the value. If we fail, then convert to
         ObjectBlock and try again
@@ -459,7 +459,7 @@ class Block(PandasObject):
 
         return self.split_and_operate(None, f, inplace)
 
-    def _split(self) -> List["Block"]:
+    def _split(self) -> List[Block]:
         """
         Split a block into a list of single-column blocks.
         """
@@ -475,7 +475,7 @@ class Block(PandasObject):
 
     def split_and_operate(
         self, mask, f, inplace: bool, ignore_failures: bool = False
-    ) -> List["Block"]:
+    ) -> List[Block]:
         """
         split the block per-column, and apply the callable f
         per-column, return a new block for each. Handle
@@ -543,7 +543,7 @@ class Block(PandasObject):
 
         return new_blocks
 
-    def _maybe_downcast(self, blocks: List["Block"], downcast=None) -> List["Block"]:
+    def _maybe_downcast(self, blocks: List[Block], downcast=None) -> List[Block]:
 
         # no need to downcast our float
         # unless indicated
@@ -552,7 +552,7 @@ class Block(PandasObject):
 
         return extend_blocks([b.downcast(downcast) for b in blocks])
 
-    def downcast(self, dtypes=None) -> List["Block"]:
+    def downcast(self, dtypes=None) -> List[Block]:
         """ try to downcast each item to the dict of dtypes if present """
         # turn it off completely
         if dtypes is False:
@@ -668,7 +668,7 @@ class Block(PandasObject):
         datetime: bool = True,
         numeric: bool = True,
         timedelta: bool = True,
-    ) -> List["Block"]:
+    ) -> List[Block]:
         """
         attempt to coerce any object types to better types return a copy
         of the block (if copy = True) by definition we are not an ObjectBlock
@@ -726,7 +726,7 @@ class Block(PandasObject):
         value,
         inplace: bool = False,
         regex: bool = False,
-    ) -> List["Block"]:
+    ) -> List[Block]:
         """
         replace the to_replace value with value, possible to create new
         blocks here this is just a call to putmask. regex is not used here.
@@ -771,7 +771,7 @@ class Block(PandasObject):
         inplace: bool = False,
         convert: bool = True,
         mask=None,
-    ) -> List["Block"]:
+    ) -> List[Block]:
         """
         Replace elements by the given value.
 
@@ -815,7 +815,7 @@ class Block(PandasObject):
         dest_list: List[Any],
         inplace: bool = False,
         regex: bool = False,
-    ) -> List["Block"]:
+    ) -> List[Block]:
         """
         See BlockManager._replace_list docstring.
         """
@@ -996,7 +996,7 @@ class Block(PandasObject):
         block = self.make_block(values)
         return block
 
-    def putmask(self, mask, new) -> List["Block"]:
+    def putmask(self, mask, new) -> List[Block]:
         """
         putmask the data to the block; it is possible that we may create a
         new dtype of block
@@ -1091,7 +1091,7 @@ class Block(PandasObject):
         self,
         method: str = "pad",
         axis: int = 0,
-        index: Optional["Index"] = None,
+        index: Optional[Index] = None,
         inplace: bool = False,
         limit: Optional[int] = None,
         limit_direction: str = "forward",
@@ -1153,7 +1153,7 @@ class Block(PandasObject):
         limit: Optional[int] = None,
         limit_area: Optional[str] = None,
         downcast: Optional[str] = None,
-    ) -> List["Block"]:
+    ) -> List[Block]:
         """ fillna but using the interpolate machinery """
         inplace = validate_bool_kwarg(inplace, "inplace")
 
@@ -1175,7 +1175,7 @@ class Block(PandasObject):
     def _interpolate(
         self,
         method: str,
-        index: "Index",
+        index: Index,
         fill_value: Optional[Any] = None,
         axis: int = 0,
         limit: Optional[int] = None,
@@ -1184,7 +1184,7 @@ class Block(PandasObject):
         inplace: bool = False,
         downcast: Optional[str] = None,
         **kwargs,
-    ) -> List["Block"]:
+    ) -> List[Block]:
         """ interpolate using scipy wrappers """
         inplace = validate_bool_kwarg(inplace, "inplace")
         data = self.values if inplace else self.values.copy()
@@ -1260,7 +1260,7 @@ class Block(PandasObject):
         else:
             return self.make_block_same_class(new_values, new_mgr_locs)
 
-    def diff(self, n: int, axis: int = 1) -> List["Block"]:
+    def diff(self, n: int, axis: int = 1) -> List[Block]:
         """ return block for the diff of the values """
         new_values = algos.diff(self.values, n, axis=axis, stacklevel=7)
         return [self.make_block(values=new_values)]
@@ -1275,7 +1275,7 @@ class Block(PandasObject):
 
         return [self.make_block(new_values)]
 
-    def where(self, other, cond, errors="raise", axis: int = 0) -> List["Block"]:
+    def where(self, other, cond, errors="raise", axis: int = 0) -> List[Block]:
         """
         evaluate the block; return result block(s) from the result
 
@@ -1351,7 +1351,7 @@ class Block(PandasObject):
         cond = cond.swapaxes(axis, 0)
         mask = np.array([cond[i].all() for i in range(cond.shape[0])], dtype=bool)
 
-        result_blocks: List["Block"] = []
+        result_blocks: List[Block] = []
         for m in [mask, ~mask]:
             if m.any():
                 result = cast(np.ndarray, result)  # EABlock overrides where
@@ -1455,7 +1455,7 @@ class Block(PandasObject):
         mask: np.ndarray,
         inplace: bool = True,
         regex: bool = False,
-    ) -> List["Block"]:
+    ) -> List[Block]:
         """
         Replace value corresponding to the given boolean array with another
         value.
@@ -1573,7 +1573,7 @@ class ExtensionBlock(Block):
         assert locs.tolist() == [0]
         self.values = values
 
-    def putmask(self, mask, new) -> List["Block"]:
+    def putmask(self, mask, new) -> List[Block]:
         """
         See Block.putmask.__doc__
         """
@@ -1775,7 +1775,7 @@ class ExtensionBlock(Block):
             placement=self.mgr_locs,
         )
 
-    def diff(self, n: int, axis: int = 1) -> List["Block"]:
+    def diff(self, n: int, axis: int = 1) -> List[Block]:
         if axis == 0 and n != 0:
             # n==0 case will be a no-op so let is fall through
             # Since we only have one column, the result will be all-NA.
@@ -1790,7 +1790,7 @@ class ExtensionBlock(Block):
 
     def shift(
         self, periods: int, axis: int = 0, fill_value: Any = None
-    ) -> List["ExtensionBlock"]:
+    ) -> List[ExtensionBlock]:
         """
         Shift the block by `periods`.
 
@@ -1805,7 +1805,7 @@ class ExtensionBlock(Block):
             )
         ]
 
-    def where(self, other, cond, errors="raise", axis: int = 0) -> List["Block"]:
+    def where(self, other, cond, errors="raise", axis: int = 0) -> List[Block]:
 
         cond = _extract_bool_array(cond)
         assert not isinstance(other, (ABCIndex, ABCSeries, ABCDataFrame))
@@ -1991,7 +1991,7 @@ class DatetimeLikeBlockMixin(HybridMixin, Block):
         # TODO(EA2D): this can be removed if we ever have 2D EA
         return self.array_values().reshape(self.shape)[key]
 
-    def diff(self, n: int, axis: int = 0) -> List["Block"]:
+    def diff(self, n: int, axis: int = 0) -> List[Block]:
         """
         1st discrete difference.
 
@@ -2032,7 +2032,7 @@ class DatetimeLikeBlockMixin(HybridMixin, Block):
         result = arr._format_native_types(na_rep=na_rep, **kwargs)
         return self.make_block(result)
 
-    def where(self, other, cond, errors="raise", axis: int = 0) -> List["Block"]:
+    def where(self, other, cond, errors="raise", axis: int = 0) -> List[Block]:
         # TODO(EA2D): reshape unnecessary with 2D EAs
         arr = self.array_values().reshape(self.shape)
 
@@ -2315,7 +2315,7 @@ class ObjectBlock(Block):
         datetime: bool = True,
         numeric: bool = True,
         timedelta: bool = True,
-    ) -> List["Block"]:
+    ) -> List[Block]:
         """
         attempt to cast any object types to better types return a copy of
         the block (if copy = True) by definition we ARE an ObjectBlock!!!!!
@@ -2345,7 +2345,7 @@ class ObjectBlock(Block):
 
         return blocks
 
-    def _maybe_downcast(self, blocks: List["Block"], downcast=None) -> List["Block"]:
+    def _maybe_downcast(self, blocks: List[Block], downcast=None) -> List[Block]:
 
         if downcast is not None:
             return blocks
@@ -2362,7 +2362,7 @@ class ObjectBlock(Block):
         value,
         inplace: bool = False,
         regex: bool = False,
-    ) -> List["Block"]:
+    ) -> List[Block]:
         # Note: the checks we do in NDFrame.replace ensure we never get
         #  here with listlike to_replace or value, as those cases
         #  go through _replace_list
@@ -2398,7 +2398,7 @@ class CategoricalBlock(ExtensionBlock):
         dest_list: List[Any],
         inplace: bool = False,
         regex: bool = False,
-    ) -> List["Block"]:
+    ) -> List[Block]:
         if len(algos.unique(dest_list)) == 1:
             # We likely got here by tiling value inside NDFrame.replace,
             #  so un-tile here
@@ -2411,7 +2411,7 @@ class CategoricalBlock(ExtensionBlock):
         value,
         inplace: bool = False,
         regex: bool = False,
-    ) -> List["Block"]:
+    ) -> List[Block]:
         inplace = validate_bool_kwarg(inplace, "inplace")
         result = self if inplace else self.copy()
 

--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 import copy
 import itertools
@@ -36,7 +38,7 @@ if TYPE_CHECKING:
 
 
 def concatenate_block_managers(
-    mgrs_indexers, axes: List["Index"], concat_axis: int, copy: bool
+    mgrs_indexers, axes: List[Index], concat_axis: int, copy: bool
 ) -> Manager:
     """
     Concatenate block managers into one.

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -2,6 +2,8 @@
 Functions for preparing various inputs passed to the DataFrame or Series
 constructors before passing them to a BlockManager.
 """
+from __future__ import annotations
+
 from collections import abc
 from typing import (
     TYPE_CHECKING,
@@ -65,8 +67,6 @@ from pandas.core.internals.managers import (
 if TYPE_CHECKING:
     from numpy.ma.mrecords import MaskedRecords
 
-    from pandas import Series
-
 # ---------------------------------------------------------------------
 # BlockManager Interface
 
@@ -108,7 +108,7 @@ def arrays_to_mgr(
 
 
 def masked_rec_array_to_mgr(
-    data: "MaskedRecords", index, columns, dtype: Optional[DtypeObj], copy: bool
+    data: MaskedRecords, index, columns, dtype: Optional[DtypeObj], copy: bool
 ):
     """
     Extract from a masked rec array and create the manager.
@@ -267,7 +267,7 @@ def init_dict(data: Dict, index, columns, dtype: Optional[DtypeObj] = None):
     Segregate Series based on type and coerce into matrices.
     Needs to handle a lot of exceptional cases.
     """
-    arrays: Union[Sequence[Any], "Series"]
+    arrays: Union[Sequence[Any], Series]
 
     if columns is not None:
         from pandas.core.series import Series

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -371,7 +371,7 @@ class BlockManager(DataManager):
             new_mgr = type(self).from_blocks(res_blocks, [self.items, index])
         return new_mgr, indexer
 
-    def operate_blockwise(self, other: "BlockManager", array_op) -> BlockManager:
+    def operate_blockwise(self, other: BlockManager, array_op) -> BlockManager:
         """
         Apply array_op blockwise with another (aligned) BlockManager.
         """

--- a/pandas/core/internals/ops.py
+++ b/pandas/core/internals/ops.py
@@ -18,7 +18,7 @@ BlockPairInfo = namedtuple(
 
 
 def _iter_block_pairs(
-    left: "BlockManager", right: "BlockManager"
+    left: BlockManager, right: BlockManager
 ) -> Iterator[BlockPairInfo]:
     # At this point we have already checked the parent DataFrames for
     #  assert rframe._indexed_same(lframe)
@@ -46,12 +46,12 @@ def _iter_block_pairs(
 
 
 def operate_blockwise(
-    left: "BlockManager", right: "BlockManager", array_op
+    left: BlockManager, right: BlockManager, array_op
 ) -> BlockManager:
     # At this point we have already checked the parent DataFrames for
     #  assert rframe._indexed_same(lframe)
 
-    res_blks: List["Block"] = []
+    res_blks: List[Block] = []
     for lvals, rvals, locs, left_ea, right_ea, rblk in _iter_block_pairs(left, right):
         res_values = array_op(lvals, rvals)
         if left_ea and not right_ea and hasattr(res_values, "reshape"):
@@ -79,7 +79,7 @@ def operate_blockwise(
     return new_mgr
 
 
-def _reset_block_mgr_locs(nbs: List["Block"], locs):
+def _reset_block_mgr_locs(nbs: List[Block], locs):
     """
     Reset mgr_locs to correspond to our original DataFrame.
     """
@@ -92,7 +92,7 @@ def _reset_block_mgr_locs(nbs: List["Block"], locs):
 
 
 def _get_same_shape_values(
-    lblk: "Block", rblk: "Block", left_ea: bool, right_ea: bool
+    lblk: Block, rblk: Block, left_ea: bool, right_ea: bool
 ) -> Tuple[ArrayLike, ArrayLike]:
     """
     Slice lblk.values to align with rblk.  Squeeze if we have EAs.
@@ -122,7 +122,7 @@ def _get_same_shape_values(
     return lvals, rvals
 
 
-def blockwise_all(left: "BlockManager", right: "BlockManager", op) -> bool:
+def blockwise_all(left: BlockManager, right: BlockManager, op) -> bool:
     """
     Blockwise `all` reduction.
     """

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -1,6 +1,8 @@
 """
 Routines for filling missing data.
 """
+from __future__ import annotations
+
 from functools import partial
 from typing import TYPE_CHECKING, Any, List, Optional, Set, Union
 
@@ -158,7 +160,7 @@ def find_valid_index(values, how: str):
 
 
 def interpolate_1d(
-    xvalues: "Index",
+    xvalues: Index,
     yvalues: np.ndarray,
     method: Optional[str] = "linear",
     limit: Optional[int] = None,

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -131,7 +131,7 @@ def fill_binop(left, right, fill_value):
 # Series
 
 
-def align_method_SERIES(left: "Series", right, align_asobject: bool = False):
+def align_method_SERIES(left: Series, right, align_asobject: bool = False):
     """ align lhs and rhs Series """
     # ToDo: Different from align_method_FRAME, list, tuple and ndarray
     # are not coerced here
@@ -367,7 +367,7 @@ def frame_arith_method_with_reindex(left: DataFrame, right: DataFrame, op) -> Da
     return result
 
 
-def _maybe_align_series_as_frame(frame: DataFrame, series: "Series", axis: int):
+def _maybe_align_series_as_frame(frame: DataFrame, series: Series, axis: int):
     """
     If the Series operand is not EA-dtype, we can broadcast to 2D and operate
     blockwise.

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
 
 @overload
 def concat(
-    objs: Union[Iterable["DataFrame"], Mapping[Hashable, "DataFrame"]],
+    objs: Union[Iterable[DataFrame], Mapping[Hashable, DataFrame]],
     axis=0,
     join: str = "outer",
     ignore_index: bool = False,
@@ -68,7 +68,7 @@ def concat(
 
 @overload
 def concat(
-    objs: Union[Iterable["NDFrame"], Mapping[Hashable, "NDFrame"]],
+    objs: Union[Iterable[NDFrame], Mapping[Hashable, NDFrame]],
     axis=0,
     join: str = "outer",
     ignore_index: bool = False,
@@ -83,7 +83,7 @@ def concat(
 
 
 def concat(
-    objs: Union[Iterable["NDFrame"], Mapping[Hashable, "NDFrame"]],
+    objs: Union[Iterable[NDFrame], Mapping[Hashable, NDFrame]],
     axis=0,
     join="outer",
     ignore_index: bool = False,
@@ -308,7 +308,7 @@ class _Concatenator:
 
     def __init__(
         self,
-        objs: Union[Iterable["NDFrame"], Mapping[Hashable, "NDFrame"]],
+        objs: Union[Iterable[NDFrame], Mapping[Hashable, NDFrame]],
         axis=0,
         join: str = "outer",
         keys=None,
@@ -377,7 +377,7 @@ class _Concatenator:
         # get the sample
         # want the highest ndim that we have, and must be non-empty
         # unless all objs are empty
-        sample: Optional["NDFrame"] = None
+        sample: Optional[NDFrame] = None
         if len(ndims) > 1:
             max_ndim = max(ndims)
             for obj in objs:

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -724,7 +724,7 @@ class _MergeOperation:
 
     def _indicator_pre_merge(
         self, left: DataFrame, right: DataFrame
-    ) -> Tuple["DataFrame", "DataFrame"]:
+    ) -> Tuple[DataFrame, DataFrame]:
 
         columns = left.columns.union(right.columns)
 
@@ -1232,7 +1232,7 @@ class _MergeOperation:
 
     def _create_cross_configuration(
         self, left: DataFrame, right: DataFrame
-    ) -> Tuple["DataFrame", "DataFrame", str, str]:
+    ) -> Tuple[DataFrame, DataFrame, str, str]:
         """
         Creates the configuration to dispatch the cross operation to inner join,
         e.g. adding a join column and resetting parameters. Join column is added

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -211,8 +211,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     )
     __hash__ = generic.NDFrame.__hash__
     _mgr: SingleBlockManager
-    div: Callable[["Series", Any], "Series"]
-    rdiv: Callable[["Series", Any], "Series"]
+    div: Callable[[Series, Any], Series]
+    rdiv: Callable[[Series, Any], Series]
 
     # ----------------------------------------------------------------------
     # Constructors
@@ -398,11 +398,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     # ----------------------------------------------------------------------
 
     @property
-    def _constructor(self) -> Type["Series"]:
+    def _constructor(self) -> Type[Series]:
         return Series
 
     @property
-    def _constructor_expanddim(self) -> Type["DataFrame"]:
+    def _constructor_expanddim(self) -> Type[DataFrame]:
         from pandas.core.frame import DataFrame
 
         return DataFrame
@@ -1847,7 +1847,7 @@ Name: Max Speed, dtype: float64
         """
         return super().unique()
 
-    def drop_duplicates(self, keep="first", inplace=False) -> Optional["Series"]:
+    def drop_duplicates(self, keep="first", inplace=False) -> Optional[Series]:
         """
         Return Series with duplicate values removed.
 
@@ -2309,7 +2309,7 @@ Name: Max Speed, dtype: float64
 
     def cov(
         self,
-        other: "Series",
+        other: Series,
         min_periods: Optional[int] = None,
         ddof: Optional[int] = 1,
     ) -> float:
@@ -2705,7 +2705,7 @@ Name: Max Speed, dtype: float64
 
     def _construct_result(
         self, result: Union[ArrayLike, Tuple[ArrayLike, ArrayLike]], name: Hashable
-    ) -> Union["Series", Tuple["Series", "Series"]]:
+    ) -> Union[Series, Tuple[Series, Series]]:
         """
         Construct an appropriately-labelled Series from the result of an op.
 
@@ -2806,7 +2806,7 @@ Keep all original rows and also all original values
     )
     def compare(
         self,
-        other: "Series",
+        other: Series,
         align_axis: Axis = 1,
         keep_shape: bool = False,
         keep_equal: bool = False,
@@ -4395,7 +4395,7 @@ Keep all original rows and also all original values
         inplace=False,
         limit=None,
         downcast=None,
-    ) -> Optional["Series"]:
+    ) -> Optional[Series]:
         return super().fillna(
             value=value,
             method=method,
@@ -4853,8 +4853,8 @@ Keep all original rows and also all original values
         base: Optional[int] = None,
         on=None,
         level=None,
-        origin: Union[str, "TimestampConvertibleTypes"] = "start_day",
-        offset: Optional["TimedeltaConvertibleTypes"] = None,
+        origin: Union[str, TimestampConvertibleTypes] = "start_day",
+        offset: Optional[TimedeltaConvertibleTypes] = None,
     ) -> Resampler:
         return super().resample(
             rule=rule,
@@ -4935,7 +4935,7 @@ Keep all original rows and also all original values
     _info_axis_number = 0
     _info_axis_name = "index"
 
-    index: "Index" = properties.AxisProperty(
+    index: Index = properties.AxisProperty(
         axis=0, doc="The index (axis labels) of the Series."
     )
 

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -39,7 +39,7 @@ _INT64_MAX = np.iinfo(np.int64).max
 
 
 def get_indexer_indexer(
-    target: "Index",
+    target: Index,
     level: Union[str, int, List[str], List[int]],
     ascending: bool,
     kind: str,
@@ -420,7 +420,7 @@ def nargminmax(values, method: str):
 
 
 def _ensure_key_mapped_multiindex(
-    index: "MultiIndex", key: Callable, level=None
+    index: MultiIndex, key: Callable, level=None
 ) -> MultiIndex:
     """
     Returns a new MultiIndex in which key has been applied
@@ -515,7 +515,7 @@ def ensure_key_mapped(values, key: Optional[Callable], levels=None):
 def get_flattened_list(
     comp_ids: np.ndarray,
     ngroups: int,
-    levels: Iterable["Index"],
+    levels: Iterable[Index],
     labels: Iterable[np.ndarray],
 ) -> List[Tuple]:
     """Map compressed group id -> key tuple."""
@@ -530,7 +530,7 @@ def get_flattened_list(
 
 
 def get_indexer_dict(
-    label_list: List[np.ndarray], keys: List["Index"]
+    label_list: List[np.ndarray], keys: List[Index]
 ) -> Dict[Union[str, Tuple], np.ndarray]:
     """
     Returns

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -214,7 +214,7 @@ def _box_as_indexlike(
 
 def _convert_and_box_cache(
     arg: DatetimeScalarOrArrayConvertible,
-    cache_array: "Series",
+    cache_array: Series,
     name: Optional[str] = None,
 ) -> Index:
     """
@@ -571,13 +571,13 @@ def to_datetime(
     infer_datetime_format: bool = ...,
     origin=...,
     cache: bool = ...,
-) -> Union[DatetimeScalar, "NaTType"]:
+) -> Union[DatetimeScalar, NaTType]:
     ...
 
 
 @overload
 def to_datetime(
-    arg: "Series",
+    arg: Series,
     errors: str = ...,
     dayfirst: bool = ...,
     yearfirst: bool = ...,
@@ -621,7 +621,7 @@ def to_datetime(
     infer_datetime_format: bool = False,
     origin="unix",
     cache: bool = True,
-) -> Union[DatetimeIndex, "Series", DatetimeScalar, "NaTType"]:
+) -> Union[DatetimeIndex, Series, DatetimeScalar, NaTType]:
     """
     Convert argument to datetime.
 

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -80,7 +80,7 @@ def get_center_of_mass(
     return float(comass)
 
 
-def wrap_result(obj: "Series", result: np.ndarray) -> Series:
+def wrap_result(obj: Series, result: np.ndarray) -> Series:
     """
     Wrap a single 1D result.
     """

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import abc
 import datetime
 from distutils.version import LooseVersion
@@ -789,7 +791,7 @@ class ExcelWriter(metaclass=abc.ABCMeta):
 
     def __init__(
         self,
-        path: Union[FilePathOrBuffer, "ExcelWriter"],
+        path: Union[FilePathOrBuffer, ExcelWriter],
         engine=None,
         date_format=None,
         datetime_format=None,

--- a/pandas/io/excel/_openpyxl.py
+++ b/pandas/io/excel/_openpyxl.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 import numpy as np
@@ -51,7 +53,7 @@ class OpenpyxlWriter(ExcelWriter):
         self.book.save(self.handles.handle)
 
     @classmethod
-    def _convert_to_style_kwargs(cls, style_dict: dict) -> Dict[str, "Serialisable"]:
+    def _convert_to_style_kwargs(cls, style_dict: dict) -> Dict[str, Serialisable]:
         """
         Convert a style_dict to a set of kwargs suitable for initializing
         or updating-on-copy an openpyxl v2 style object.

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -2,6 +2,8 @@
 Module for formatting output data into CSV files.
 """
 
+from __future__ import annotations
+
 import csv as csvlib
 import os
 from typing import (
@@ -46,7 +48,7 @@ if TYPE_CHECKING:
 class CSVFormatter:
     def __init__(
         self,
-        formatter: "DataFrameFormatter",
+        formatter: DataFrameFormatter,
         path_or_buf: FilePathOrBuffer[str] = "",
         sep: str = ",",
         cols: Optional[Sequence[Hashable]] = None,
@@ -91,7 +93,7 @@ class CSVFormatter:
         return self.fmt.na_rep
 
     @property
-    def float_format(self) -> Optional["FloatFormatType"]:
+    def float_format(self) -> Optional[FloatFormatType]:
         return self.fmt.float_format
 
     @property

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -173,7 +173,7 @@ return_docstring = """
 class CategoricalFormatter:
     def __init__(
         self,
-        categorical: "Categorical",
+        categorical: Categorical,
         buf: Optional[IO[str]] = None,
         length: bool = True,
         na_rep: str = "NaN",
@@ -237,7 +237,7 @@ class CategoricalFormatter:
 class SeriesFormatter:
     def __init__(
         self,
-        series: "Series",
+        series: Series,
         buf: Optional[IO[str]] = None,
         length: Union[bool, str] = True,
         header: bool = True,
@@ -1502,7 +1502,7 @@ class IntArrayFormatter(GenericArrayFormatter):
 class Datetime64Formatter(GenericArrayFormatter):
     def __init__(
         self,
-        values: Union[np.ndarray, "Series", DatetimeIndex, DatetimeArray],
+        values: Union[np.ndarray, Series, DatetimeIndex, DatetimeArray],
         nat_rep: str = "NaT",
         date_format: None = None,
         **kwargs,

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -828,7 +828,7 @@ class Styler:
 
     def _apply(
         self,
-        func: Callable[..., "Styler"],
+        func: Callable[..., Styler],
         axis: Optional[Axis] = 0,
         subset=None,
         **kwargs,
@@ -867,7 +867,7 @@ class Styler:
 
     def apply(
         self,
-        func: Callable[..., "Styler"],
+        func: Callable[..., Styler],
         axis: Optional[Axis] = 0,
         subset=None,
         **kwargs,

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -74,7 +74,7 @@ def to_json(
     if orient == "table" and isinstance(obj, Series):
         obj = obj.to_frame(name=obj.name or "values")
 
-    writer: Type["Writer"]
+    writer: Type[Writer]
     if orient == "table" and isinstance(obj, DataFrame):
         writer = JSONTableWriter
     elif isinstance(obj, Series):

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -1,6 +1,8 @@
 """
 Read SAS sas7bdat or xport files.
 """
+from __future__ import annotations
+
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Hashable, Optional, Union, overload
 
@@ -53,7 +55,7 @@ def read_sas(
     encoding: Optional[str] = ...,
     chunksize: None = ...,
     iterator: bool = ...,
-) -> Union["DataFrame", ReaderBase]:
+) -> Union[DataFrame, ReaderBase]:
     ...
 
 
@@ -64,7 +66,7 @@ def read_sas(
     encoding: Optional[str] = None,
     chunksize: Optional[int] = None,
     iterator: bool = False,
-) -> Union["DataFrame", ReaderBase]:
+) -> Union[DataFrame, ReaderBase]:
     """
     Read SAS files stored as either XPORT or SAS7BDAT format files.
 

--- a/pandas/plotting/_matplotlib/__init__.py
+++ b/pandas/plotting/_matplotlib/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Dict, Type
 
 from pandas.plotting._matplotlib.boxplot import (
@@ -31,7 +33,7 @@ from pandas.plotting._matplotlib.tools import table
 if TYPE_CHECKING:
     from pandas.plotting._matplotlib.core import MPLPlot
 
-PLOT_CLASSES: Dict[str, Type["MPLPlot"]] = {
+PLOT_CLASSES: Dict[str, Type[MPLPlot]] = {
     "line": LinePlot,
     "bar": BarPlot,
     "barh": BarhPlot,

--- a/pandas/plotting/_matplotlib/boxplot.py
+++ b/pandas/plotting/_matplotlib/boxplot.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import namedtuple
 from typing import TYPE_CHECKING
 import warnings
@@ -155,7 +157,7 @@ class BoxPlot(LinePlot):
                 labels = [pprint_thing(key) for key in range(len(labels))]
             self._set_ticklabels(ax, labels)
 
-    def _set_ticklabels(self, ax: "Axes", labels):
+    def _set_ticklabels(self, ax: Axes, labels):
         if self.orientation == "vertical":
             ax.set_xticklabels(labels)
         else:
@@ -297,7 +299,7 @@ def boxplot(
         if not kwds.get("capprops"):
             setp(bp["caps"], color=colors[3], alpha=1)
 
-    def plot_group(keys, values, ax: "Axes"):
+    def plot_group(keys, values, ax: Axes):
         keys = [pprint_thing(x) for x in keys]
         values = [np.asarray(remove_na_arraylike(v), dtype=object) for v in values]
         bp = ax.boxplot(values, **kwds)

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Hashable, List, Optional, Tuple
 import warnings
 
@@ -288,11 +290,11 @@ class MPLPlot:
     def _args_adjust(self):
         pass
 
-    def _has_plotted_object(self, ax: "Axes") -> bool:
+    def _has_plotted_object(self, ax: Axes) -> bool:
         """check whether ax has data"""
         return len(ax.lines) != 0 or len(ax.artists) != 0 or len(ax.containers) != 0
 
-    def _maybe_right_yaxis(self, ax: "Axes", axes_num):
+    def _maybe_right_yaxis(self, ax: Axes, axes_num):
         if not self.on_right(axes_num):
             # secondary axes may be passed via ax kw
             return self._get_ax_layer(ax)
@@ -536,7 +538,7 @@ class MPLPlot:
                     raise ValueError(msg)
                 self.axes[0].set_title(self.title)
 
-    def _apply_axis_properties(self, axis: "Axis", rot=None, fontsize=None):
+    def _apply_axis_properties(self, axis: Axis, rot=None, fontsize=None):
         """
         Tick creation within matplotlib is reasonably expensive and is
         internally deferred until accessed as Ticks are created/destroyed
@@ -616,7 +618,7 @@ class MPLPlot:
                 if ax.get_visible():
                     ax.legend(loc="best")
 
-    def _get_ax_legend_handle(self, ax: "Axes"):
+    def _get_ax_legend_handle(self, ax: Axes):
         """
         Take in axes and return ax, legend and handle under different scenarios
         """
@@ -671,7 +673,7 @@ class MPLPlot:
 
     @classmethod
     @register_pandas_matplotlib_converters
-    def _plot(cls, ax: "Axes", x, y, style=None, is_errorbar: bool = False, **kwds):
+    def _plot(cls, ax: Axes, x, y, style=None, is_errorbar: bool = False, **kwds):
         mask = isna(y)
         if mask.any():
             y = np.ma.array(y)
@@ -944,14 +946,14 @@ class PlanePlot(MPLPlot):
     def nseries(self) -> int:
         return 1
 
-    def _post_plot_logic(self, ax: "Axes", data):
+    def _post_plot_logic(self, ax: Axes, data):
         x, y = self.x, self.y
         xlabel = self.xlabel if self.xlabel is not None else pprint_thing(x)
         ylabel = self.ylabel if self.ylabel is not None else pprint_thing(y)
         ax.set_xlabel(xlabel)
         ax.set_ylabel(ylabel)
 
-    def _plot_colorbar(self, ax: "Axes", **kwds):
+    def _plot_colorbar(self, ax: Axes, **kwds):
         # Addresses issues #10611 and #10678:
         # When plotting scatterplots and hexbinplots in IPython
         # inline backend the colorbar axis height tends not to
@@ -1167,7 +1169,7 @@ class LinePlot(MPLPlot):
 
     @classmethod
     def _plot(
-        cls, ax: "Axes", x, y, style=None, column_num=None, stacking_id=None, **kwds
+        cls, ax: Axes, x, y, style=None, column_num=None, stacking_id=None, **kwds
     ):
         # column_num is used to get the target column from plotf in line and
         # area plots
@@ -1179,7 +1181,7 @@ class LinePlot(MPLPlot):
         return lines
 
     @classmethod
-    def _ts_plot(cls, ax: "Axes", x, data, style=None, **kwds):
+    def _ts_plot(cls, ax: Axes, x, data, style=None, **kwds):
         # accept x to be consistent with normal plot func,
         # x is not passed to tsplot as it uses data.index as x coordinate
         # column_num must be in kwds for stacking purpose
@@ -1206,7 +1208,7 @@ class LinePlot(MPLPlot):
             return None
 
     @classmethod
-    def _initialize_stacker(cls, ax: "Axes", stacking_id, n: int):
+    def _initialize_stacker(cls, ax: Axes, stacking_id, n: int):
         if stacking_id is None:
             return
         if not hasattr(ax, "_stacker_pos_prior"):
@@ -1217,7 +1219,7 @@ class LinePlot(MPLPlot):
         ax._stacker_neg_prior[stacking_id] = np.zeros(n)
 
     @classmethod
-    def _get_stacked_values(cls, ax: "Axes", stacking_id, values, label):
+    def _get_stacked_values(cls, ax: Axes, stacking_id, values, label):
         if stacking_id is None:
             return values
         if not hasattr(ax, "_stacker_pos_prior"):
@@ -1236,7 +1238,7 @@ class LinePlot(MPLPlot):
         )
 
     @classmethod
-    def _update_stacker(cls, ax: "Axes", stacking_id, values):
+    def _update_stacker(cls, ax: Axes, stacking_id, values):
         if stacking_id is None:
             return
         if (values >= 0).all():
@@ -1244,7 +1246,7 @@ class LinePlot(MPLPlot):
         elif (values <= 0).all():
             ax._stacker_neg_prior[stacking_id] += values
 
-    def _post_plot_logic(self, ax: "Axes", data):
+    def _post_plot_logic(self, ax: Axes, data):
         from matplotlib.ticker import FixedLocator
 
         def get_label(i):
@@ -1303,7 +1305,7 @@ class AreaPlot(LinePlot):
     @classmethod
     def _plot(
         cls,
-        ax: "Axes",
+        ax: Axes,
         x,
         y,
         style=None,
@@ -1345,7 +1347,7 @@ class AreaPlot(LinePlot):
         res = [rect]
         return res
 
-    def _post_plot_logic(self, ax: "Axes", data):
+    def _post_plot_logic(self, ax: Axes, data):
         LinePlot._post_plot_logic(self, ax, data)
 
         is_shared_y = len(list(ax.get_shared_y_axes())) > 0
@@ -1401,7 +1403,7 @@ class BarPlot(MPLPlot):
             self.left = np.array(self.left)
 
     @classmethod
-    def _plot(cls, ax: "Axes", x, y, w, start=0, log=False, **kwds):
+    def _plot(cls, ax: Axes, x, y, w, start=0, log=False, **kwds):
         return ax.bar(x, y, w, bottom=start, log=log, **kwds)
 
     @property
@@ -1483,7 +1485,7 @@ class BarPlot(MPLPlot):
                 )
             self._add_legend_handle(rect, label, index=i)
 
-    def _post_plot_logic(self, ax: "Axes", data):
+    def _post_plot_logic(self, ax: Axes, data):
         if self.use_index:
             str_index = [pprint_thing(key) for key in data.index]
         else:
@@ -1495,7 +1497,7 @@ class BarPlot(MPLPlot):
 
         self._decorate_ticks(ax, name, str_index, s_edge, e_edge)
 
-    def _decorate_ticks(self, ax: "Axes", name, ticklabels, start_edge, end_edge):
+    def _decorate_ticks(self, ax: Axes, name, ticklabels, start_edge, end_edge):
         ax.set_xlim((start_edge, end_edge))
 
         if self.xticks is not None:
@@ -1518,10 +1520,10 @@ class BarhPlot(BarPlot):
         return self.left
 
     @classmethod
-    def _plot(cls, ax: "Axes", x, y, w, start=0, log=False, **kwds):
+    def _plot(cls, ax: Axes, x, y, w, start=0, log=False, **kwds):
         return ax.barh(x, y, w, left=start, log=log, **kwds)
 
-    def _decorate_ticks(self, ax: "Axes", name, ticklabels, start_edge, end_edge):
+    def _decorate_ticks(self, ax: Axes, name, ticklabels, start_edge, end_edge):
         # horizontal bars
         ax.set_ylim((start_edge, end_edge))
         ax.set_yticks(self.tick_pos)

--- a/pandas/plotting/_matplotlib/hist.py
+++ b/pandas/plotting/_matplotlib/hist.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -99,7 +101,7 @@ class HistPlot(LinePlot):
         kwds["bins"] = self.bins
         return kwds
 
-    def _post_plot_logic(self, ax: "Axes", data):
+    def _post_plot_logic(self, ax: Axes, data):
         if self.orientation == "horizontal":
             ax.set_xlabel("Frequency")
         else:

--- a/pandas/plotting/_matplotlib/misc.py
+++ b/pandas/plotting/_matplotlib/misc.py
@@ -126,7 +126,7 @@ def _get_marker_compat(marker):
 def radviz(
     frame: DataFrame,
     class_column,
-    ax: Optional["Axes"] = None,
+    ax: Optional[Axes] = None,
     color=None,
     colormap=None,
     **kwds,
@@ -214,7 +214,7 @@ def radviz(
 def andrews_curves(
     frame: DataFrame,
     class_column,
-    ax: Optional["Axes"] = None,
+    ax: Optional[Axes] = None,
     samples: int = 200,
     color=None,
     colormap=None,
@@ -279,8 +279,8 @@ def andrews_curves(
 
 
 def bootstrap_plot(
-    series: "Series",
-    fig: Optional["Figure"] = None,
+    series: Series,
+    fig: Optional[Figure] = None,
     size: int = 50,
     samples: int = 500,
     **kwds,
@@ -337,7 +337,7 @@ def parallel_coordinates(
     frame: DataFrame,
     class_column,
     cols=None,
-    ax: Optional["Axes"] = None,
+    ax: Optional[Axes] = None,
     color=None,
     use_columns=False,
     xticks=None,
@@ -413,9 +413,7 @@ def parallel_coordinates(
     return ax
 
 
-def lag_plot(
-    series: "Series", lag: int = 1, ax: Optional["Axes"] = None, **kwds
-) -> Axes:
+def lag_plot(series: Series, lag: int = 1, ax: Optional[Axes] = None, **kwds) -> Axes:
     # workaround because `c='b'` is hardcoded in matplotlib's scatter method
     import matplotlib.pyplot as plt
 
@@ -432,7 +430,7 @@ def lag_plot(
     return ax
 
 
-def autocorrelation_plot(series: "Series", ax: Optional["Axes"] = None, **kwds) -> Axes:
+def autocorrelation_plot(series: Series, ax: Optional[Axes] = None, **kwds) -> Axes:
     import matplotlib.pyplot as plt
 
     n = len(series)

--- a/pandas/plotting/_matplotlib/style.py
+++ b/pandas/plotting/_matplotlib/style.py
@@ -31,7 +31,7 @@ Color = Union[str, Sequence[float]]
 
 def get_standard_colors(
     num_colors: int,
-    colormap: Optional["Colormap"] = None,
+    colormap: Optional[Colormap] = None,
     color_type: str = "default",
     color: Optional[Union[Dict[str, Color], Color, Collection[Color]]] = None,
 ):
@@ -83,7 +83,7 @@ def get_standard_colors(
 def _derive_colors(
     *,
     color: Optional[Union[Color, Collection[Color]]],
-    colormap: Optional[Union[str, "Colormap"]],
+    colormap: Optional[Union[str, Colormap]],
     color_type: str,
     num_colors: int,
 ) -> List[Color]:
@@ -142,7 +142,7 @@ def _cycle_colors(colors: List[Color], num_colors: int) -> Iterator[Color]:
 
 
 def _get_colors_from_colormap(
-    colormap: Union[str, "Colormap"],
+    colormap: Union[str, Colormap],
     num_colors: int,
 ) -> List[Color]:
     """Get colors from colormap."""
@@ -150,7 +150,7 @@ def _get_colors_from_colormap(
     return [colormap(num) for num in np.linspace(0, 1, num=num_colors)]
 
 
-def _get_cmap_instance(colormap: Union[str, "Colormap"]) -> Colormap:
+def _get_cmap_instance(colormap: Union[str, Colormap]) -> Colormap:
     """Get instance of matplotlib colormap."""
     if isinstance(colormap, str):
         cmap = colormap

--- a/pandas/plotting/_matplotlib/timeseries.py
+++ b/pandas/plotting/_matplotlib/timeseries.py
@@ -1,5 +1,7 @@
 # TODO: Use the fact that axis can have units to simplify the process
 
+from __future__ import annotations
+
 import functools
 from typing import TYPE_CHECKING, Optional, cast
 
@@ -32,7 +34,7 @@ if TYPE_CHECKING:
 # Plotting functions and monkey patches
 
 
-def maybe_resample(series: "Series", ax: "Axes", kwargs):
+def maybe_resample(series: Series, ax: Axes, kwargs):
     # resample against axes freq if necessary
     freq, ax_freq = _get_freq(ax, series)
 
@@ -75,7 +77,7 @@ def _is_sup(f1: str, f2: str) -> bool:
     )
 
 
-def _upsample_others(ax: "Axes", freq, kwargs):
+def _upsample_others(ax: Axes, freq, kwargs):
     legend = ax.get_legend()
     lines, labels = _replot_ax(ax, freq, kwargs)
     _replot_ax(ax, freq, kwargs)
@@ -98,7 +100,7 @@ def _upsample_others(ax: "Axes", freq, kwargs):
         ax.legend(lines, labels, loc="best", title=title)
 
 
-def _replot_ax(ax: "Axes", freq, kwargs):
+def _replot_ax(ax: Axes, freq, kwargs):
     data = getattr(ax, "_plot_data", None)
 
     # clear current axes and data
@@ -128,7 +130,7 @@ def _replot_ax(ax: "Axes", freq, kwargs):
     return lines, labels
 
 
-def decorate_axes(ax: "Axes", freq, kwargs):
+def decorate_axes(ax: Axes, freq, kwargs):
     """Initialize axes for time-series plotting"""
     if not hasattr(ax, "_plot_data"):
         ax._plot_data = []
@@ -144,7 +146,7 @@ def decorate_axes(ax: "Axes", freq, kwargs):
     ax.date_axis_info = None
 
 
-def _get_ax_freq(ax: "Axes"):
+def _get_ax_freq(ax: Axes):
     """
     Get the freq attribute of the ax object if set.
     Also checks shared axes (eg when using secondary yaxis, sharex=True
@@ -175,7 +177,7 @@ def _get_period_alias(freq) -> Optional[str]:
     return freq
 
 
-def _get_freq(ax: "Axes", series: "Series"):
+def _get_freq(ax: Axes, series: Series):
     # get frequency from data
     freq = getattr(series.index, "freq", None)
     if freq is None:
@@ -193,7 +195,7 @@ def _get_freq(ax: "Axes", series: "Series"):
     return freq, ax_freq
 
 
-def use_dynamic_x(ax: "Axes", data: FrameOrSeriesUnion) -> bool:
+def use_dynamic_x(ax: Axes, data: FrameOrSeriesUnion) -> bool:
     freq = _get_index_freq(data.index)
     ax_freq = _get_ax_freq(ax)
 
@@ -221,7 +223,7 @@ def use_dynamic_x(ax: "Axes", data: FrameOrSeriesUnion) -> bool:
     return True
 
 
-def _get_index_freq(index: "Index") -> Optional[BaseOffset]:
+def _get_index_freq(index: Index) -> Optional[BaseOffset]:
     freq = getattr(index, "freq", None)
     if freq is None:
         freq = getattr(index, "inferred_freq", None)
@@ -235,7 +237,7 @@ def _get_index_freq(index: "Index") -> Optional[BaseOffset]:
     return freq
 
 
-def maybe_convert_index(ax: "Axes", data):
+def maybe_convert_index(ax: Axes, data):
     # tsplot converts automatically, but don't want to convert index
     # over and over for DataFrames
     if isinstance(data.index, (ABCDatetimeIndex, ABCPeriodIndex)):

--- a/pandas/plotting/_matplotlib/tools.py
+++ b/pandas/plotting/_matplotlib/tools.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from matplotlib.table import Table
 
 
-def format_date_labels(ax: "Axes", rot):
+def format_date_labels(ax: Axes, rot):
     # mini version of autofmt_xdate
     for label in ax.get_xticklabels():
         label.set_ha("right")
@@ -284,7 +284,7 @@ def create_subplots(
     return fig, axes
 
 
-def _remove_labels_from_axis(axis: "Axis"):
+def _remove_labels_from_axis(axis: Axis):
     for t in axis.get_majorticklabels():
         t.set_visible(False)
 
@@ -300,7 +300,7 @@ def _remove_labels_from_axis(axis: "Axis"):
     axis.get_label().set_visible(False)
 
 
-def _has_externally_shared_axis(ax1: "matplotlib.axes", compare_axis: "str") -> bool:
+def _has_externally_shared_axis(ax1: matplotlib.axes, compare_axis: str) -> bool:
     """
     Return whether an axis is externally shared.
 
@@ -351,7 +351,7 @@ def _has_externally_shared_axis(ax1: "matplotlib.axes", compare_axis: "str") -> 
 
 
 def handle_shared_axes(
-    axarr: Iterable["Axes"],
+    axarr: Iterable[Axes],
     nplots: int,
     naxes: int,
     nrows: int,
@@ -404,7 +404,7 @@ def handle_shared_axes(
                     _remove_labels_from_axis(ax.yaxis)
 
 
-def flatten_axes(axes: Union["Axes", Sequence["Axes"]]) -> np.ndarray:
+def flatten_axes(axes: Union[Axes, Sequence[Axes]]) -> np.ndarray:
     if not is_list_like(axes):
         return np.array([axes])
     elif isinstance(axes, (np.ndarray, ABCIndex)):
@@ -413,7 +413,7 @@ def flatten_axes(axes: Union["Axes", Sequence["Axes"]]) -> np.ndarray:
 
 
 def set_ticks_props(
-    axes: Union["Axes", Sequence["Axes"]],
+    axes: Union[Axes, Sequence[Axes]],
     xlabelsize=None,
     xrot=None,
     ylabelsize=None,
@@ -433,7 +433,7 @@ def set_ticks_props(
     return axes
 
 
-def get_all_lines(ax: "Axes") -> List["Line2D"]:
+def get_all_lines(ax: Axes) -> List[Line2D]:
     lines = ax.get_lines()
 
     if hasattr(ax, "right_ax"):
@@ -445,7 +445,7 @@ def get_all_lines(ax: "Axes") -> List["Line2D"]:
     return lines
 
 
-def get_xlim(lines: Iterable["Line2D"]) -> Tuple[float, float]:
+def get_xlim(lines: Iterable[Line2D]) -> Tuple[float, float]:
     left, right = np.inf, -np.inf
     for line in lines:
         x = line.get_xdata(orig=False)

--- a/pandas/tests/extension/arrow/arrays.py
+++ b/pandas/tests/extension/arrow/arrays.py
@@ -6,6 +6,8 @@ Eventually, we'll want to parametrize the type and support
 multiple dtypes. Not all methods are implemented yet, and the
 current implementation is not efficient.
 """
+from __future__ import annotations
+
 import copy
 import itertools
 import operator
@@ -33,7 +35,7 @@ class ArrowBoolDtype(ExtensionDtype):
     na_value = pa.NULL
 
     @classmethod
-    def construct_array_type(cls) -> Type["ArrowBoolArray"]:
+    def construct_array_type(cls) -> Type[ArrowBoolArray]:
         """
         Return the array type associated with this dtype.
 
@@ -57,7 +59,7 @@ class ArrowStringDtype(ExtensionDtype):
     na_value = pa.NULL
 
     @classmethod
-    def construct_array_type(cls) -> Type["ArrowStringArray"]:
+    def construct_array_type(cls) -> Type[ArrowStringArray]:
         """
         Return the array type associated with this dtype.
 

--- a/pandas/tests/extension/arrow/test_timestamp.py
+++ b/pandas/tests/extension/arrow/test_timestamp.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from typing import Type
 
@@ -22,7 +24,7 @@ class ArrowTimestampUSDtype(ExtensionDtype):
     na_value = pa.NULL
 
     @classmethod
-    def construct_array_type(cls) -> Type["ArrowTimestampUSArray"]:
+    def construct_array_type(cls) -> Type[ArrowTimestampUSArray]:
         """
         Return the array type associated with this dtype.
 

--- a/pandas/tests/extension/decimal/array.py
+++ b/pandas/tests/extension/decimal/array.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import decimal
 import numbers
 import random
@@ -30,7 +32,7 @@ class DecimalDtype(ExtensionDtype):
         return f"DecimalDtype(context={self.context})"
 
     @classmethod
-    def construct_array_type(cls) -> Type["DecimalArray"]:
+    def construct_array_type(cls) -> Type[DecimalArray]:
         """
         Return the array type associated with this dtype.
 

--- a/pandas/tests/extension/json/array.py
+++ b/pandas/tests/extension/json/array.py
@@ -11,6 +11,8 @@ internally that specifically check for dicts, and does non-scalar things
 in that case. We *want* the dictionaries to be treated as scalars, so we
 hack around pandas by using UserDicts.
 """
+from __future__ import annotations
+
 from collections import UserDict, abc
 import itertools
 import numbers
@@ -33,7 +35,7 @@ class JSONDtype(ExtensionDtype):
     na_value: Mapping[str, Any] = UserDict()
 
     @classmethod
-    def construct_array_type(cls) -> Type["JSONArray"]:
+    def construct_array_type(cls) -> Type[JSONArray]:
         """
         Return the array type associated with this dtype.
 

--- a/pandas/tests/extension/list/array.py
+++ b/pandas/tests/extension/list/array.py
@@ -3,6 +3,8 @@ Test extension array for storing nested data in a pandas container.
 
 The ListArray stores an ndarray of lists.
 """
+from __future__ import annotations
+
 import numbers
 import random
 import string
@@ -22,7 +24,7 @@ class ListDtype(ExtensionDtype):
     na_value = np.nan
 
     @classmethod
-    def construct_array_type(cls) -> Type["ListArray"]:
+    def construct_array_type(cls) -> Type[ListArray]:
         """
         Return the array type associated with this dtype.
 

--- a/pandas/tests/plotting/common.py
+++ b/pandas/tests/plotting/common.py
@@ -5,6 +5,8 @@ Currently all plotting tests are marked as slow via
 ``pytestmark = pytest.mark.slow`` at the module level.
 """
 
+from __future__ import annotations
+
 import os
 from typing import TYPE_CHECKING, Sequence, Union
 import warnings
@@ -184,7 +186,7 @@ class TestPlotBase:
             assert patch.get_visible() == visible
 
     def _check_patches_all_filled(
-        self, axes: Union["Axes", Sequence["Axes"]], filled: bool = True
+        self, axes: Union[Axes, Sequence[Axes]], filled: bool = True
     ) -> None:
         """
         Check for each artist whether it is filled or not


### PR DESCRIPTION
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

For some background: there was some consensus on doing this [here](https://github.com/pandas-dev/pandas/pull/36034#issuecomment-685186742)

Then [here](https://github.com/pandas-dev/pandas/pull/39270#pullrequestreview-571190631) there was the suggestion to use `ast.parse`, rather than regular expressions. I had a go at that, and made this into its own package: https://github.com/MarcoGorelli/no-string-hints , which I've included here as a pre-commit hook

The changes here are just a result of running `pre-commit run no-string-hints -a`, and then adding `from __future__ import annotations` to some files.