### PR TITLE
REF: Move part of groupby.agg to apply

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -135,7 +135,7 @@ repos:
         files: ^pandas/tests/
     -   id: FrameOrSeriesUnion
         name: Check for use of Union[Series, DataFrame] instead of FrameOrSeriesUnion alias
-        entry: Union\[.*(Series.*DataFrame|DataFrame.*Series).*\]
+        entry: Union\[.*(Series,.*DataFrame|DataFrame,.*Series).*\]
         language: pygrep
         types: [python]
         exclude: ^pandas/_typing\.py$

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -57,11 +57,11 @@ from pandas.core.dtypes.missing import isna, notna
 from pandas.core import algorithms, nanops
 from pandas.core.aggregation import (
     agg_list_like,
-    aggregate,
     maybe_mangle_lambdas,
     reconstruct_func,
     validate_func_kwargs,
 )
+from pandas.core.apply import GroupByApply
 from pandas.core.arrays import Categorical, ExtensionArray
 from pandas.core.base import DataError, SpecificationError
 import pandas.core.common as com
@@ -952,7 +952,8 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         relabeling, func, columns, order = reconstruct_func(func, **kwargs)
         func = maybe_mangle_lambdas(func)
 
-        result, how = aggregate(self, func, *args, **kwargs)
+        op = GroupByApply(self, func, args, kwargs)
+        result, how = op.agg()
         if how is None:
             return result
 

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -203,6 +203,18 @@ def test_aggregate_str_func(tsframe, groupbyfunc):
     tm.assert_frame_equal(result, expected)
 
 
+def test_agg_str_with_kwarg_axis_1_raises(df, reduction_func):
+    gb = df.groupby(level=0)
+    if reduction_func in ("idxmax", "idxmin"):
+        error = TypeError
+        msg = "reduction operation '.*' not allowed for this dtype"
+    else:
+        error = ValueError
+        msg = f"Operation {reduction_func} does not support axis=1"
+    with pytest.raises(error, match=msg):
+        gb.agg(reduction_func, axis=1)
+
+
 def test_aggregate_item_by_item(df):
     grouped = df.groupby("A")
 


### PR DESCRIPTION
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

pre-commit adjusted to account for the false positive on `Union[SeriesGroupBy, DataFrameGroupBy]`.

Moves part of groupby.agg implementation from `pandas.core.aggregation` to `pandas.core.apply`. The only difference in the code is that in `apply`, the error message raised is different when the argument is a string (e.g. "sum") and the kwarg axis=1 is provided. Added a test to check for error message.

After this will be resample and rolling, then much of the implementation code in core.aggregation code can be moved into apply.