### PR TITLE
DOC: clarify in which version the excel engine default changed

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -2853,7 +2853,7 @@ See the :ref:`cookbook<cookbook.excel>` for some advanced strategies.
    The `xlrd <https://xlrd.readthedocs.io/en/latest/>`__ package is now only for reading
    old-style ``.xls`` files.
 
-   Previously, the default argument ``engine=None`` to :func:`~pandas.read_excel`
+   Before pandas 1.2.0, the default argument ``engine=None`` to :func:`~pandas.read_excel`
    would result in using the ``xlrd`` engine in many cases, including new
    Excel 2007+ (``.xlsx``) files.
    If `openpyxl <https://openpyxl.readthedocs.io/en/stable/>`__  is installed,


### PR DESCRIPTION
Small clarification, because "previously" only made sense in the actual v1.2.0 release notes, and not in the main docs