### PR TITLE
BUG+DOC: Recent Styler Enhancements

### DIFF
--- a/doc/source/user_guide/style.ipynb
+++ b/doc/source/user_guide/style.ipynb
@@ -15,30 +15,19 @@
     "\n",
     "The styling is accomplished using CSS.\n",
     "You write \"style functions\" that take scalars, `DataFrame`s or `Series`, and return *like-indexed* DataFrames or Series with CSS `\"attribute: value\"` pairs for the values.\n",
-    "These functions can be incrementally passed to the `Styler` which collects the styles before rendering."
+    "These functions can be incrementally passed to the `Styler` which collects the styles before rendering.\n",
+    "\n",
+    "CSS is a flexible language and as such there may be multiple ways of achieving the same result, with potential\n",
+    "advantages or disadvantages, which we try to illustrate."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Building styles\n",
+    "## Styler Object\n",
     "\n",
-    "Pass your style functions into one of the following methods:\n",
-    "\n",
-    "- ``Styler.applymap``: elementwise\n",
-    "- ``Styler.apply``: column-/row-/table-wise\n",
-    "\n",
-    "Both of those methods take a function (and some other keyword arguments) and applies your function to the DataFrame in a certain way.\n",
-    "`Styler.applymap` works through the DataFrame elementwise.\n",
-    "`Styler.apply` passes each column or row into your DataFrame one-at-a-time or the entire table at once, depending on the `axis` keyword argument.\n",
-    "For columnwise use `axis=0`, rowwise use `axis=1`, and for the entire table at once use `axis=None`.\n",
-    "\n",
-    "For `Styler.applymap` your function should take a scalar and return a single string with the CSS attribute-value pair.\n",
-    "\n",
-    "For `Styler.apply` your function should take a Series or DataFrame (depending on the axis parameter), and return a Series or DataFrame with an identical shape where each value is a string with a CSS attribute-value pair.\n",
-    "\n",
-    "Let's see some examples."
+    "The `DataFrame.style` attribute is a property that returns a `Styler` object. `Styler` has a `_repr_html_` method defined on it so they are rendered automatically. If you want the actual HTML back for further processing or for writing to file call the `.render()` method which returns a string."
    ]
   },
   {
@@ -61,6 +50,7 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
+    "from pandas.io.formats.style import Styler\n",
     "import numpy as np\n",
     "\n",
     "np.random.seed(24)\n",
@@ -68,22 +58,7 @@
     "df = pd.concat([df, pd.DataFrame(np.random.randn(10, 4), columns=list('BCDE'))],\n",
     "               axis=1)\n",
     "df.iloc[3, 3] = np.nan\n",
-    "df.iloc[0, 2] = np.nan"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Here's a boring example of rendering a DataFrame, without any (visible) styles:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "df.iloc[0, 2] = np.nan\n",
     "df.style"
    ]
   },
@@ -91,8 +66,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*Note*: The `DataFrame.style` attribute is a property that returns a `Styler` object. `Styler` has a `_repr_html_` method defined on it so they are rendered automatically. If you want the actual HTML back for further processing or for writing to file call the `.render()` method which returns a string.\n",
-    "\n",
     "The above output looks very similar to the standard DataFrame HTML representation. But we've done some work behind the scenes to attach CSS classes to each cell. We can view these by calling the `.render` method."
    ]
   },
@@ -102,16 +75,152 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.style.highlight_null().render().split('\\n')[:10]"
+    "df.style.render().split('\\n')[:10]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `row0_col2` is the identifier for that particular cell. We've also prepended each row/column identifier with a UUID unique to each DataFrame so that the style from one doesn't collide with the styling from another within the same notebook or page (you can set the `uuid` if you'd like to tie together the styling of two DataFrames).\n",
+    "The `row0_col2` is the identifier for that particular cell. We've also prepended each row/column identifier with a UUID unique to each DataFrame so that the style from one doesn't collide with the styling from another within the same notebook or page (you can set the `uuid` if you'd like to tie together the styling of two DataFrames, or remove it if you want to optimise HTML transfer for larger tables)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Building styles\n",
     "\n",
-    "When writing style functions, you take care of producing the CSS attribute / value pairs you want. Pandas matches those up with the CSS classes that identify each cell."
+    "There are 3 primary methods of adding custom styles to DataFrames using CSS and matching it to cells:\n",
+    "\n",
+    "- Directly linking external CSS classes to your individual cells using `Styler.set_td_classes`.\n",
+    "- Using `table_styles` to control broader areas of the DataFrame with internal CSS.\n",
+    "- Using the `Styler.apply` and `Styler.applymap` functions for more specific control with internal CSS. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Linking External CSS\n",
+    "\n",
+    "*New in version 1.2.0*\n",
+    "\n",
+    "If you have designed a website then it is likely you will already have an external CSS file that controls the styling of table and cell objects within your website.\n",
+    "\n",
+    "For example, suppose we have an external CSS which controls table properties and has some additional classes to style individual elements (here we manually add one to this notebook):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import HTML\n",
+    "style = \\\n",
+    "\"<style>\"\\\n",
+    "\".table-cls {color: grey;}\"\\\n",
+    "\".cls1 {background-color: red; color: white;}\"\\\n",
+    "\".cls2 {background-color: blue; color: white;}\"\\\n",
+    "\".cls3 {font-weight: bold; font-style: italic; font-size:1.8em}\"\\\n",
+    "\"</style>\"\n",
+    "HTML(style)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can manually link these to our DataFrame using the `Styler.set_table_attributes` and `Styler.set_td_classes` methods (note that table level 'table-cls' is overwritten here by Jupyters own CSS, but in HTML the default text color will be grey)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s = df.style.set_table_attributes('class=\"table-cls\"')\n",
+    "cls = pd.DataFrame(data=[['cls1', None], ['cls3', 'cls2 cls3']], index=[0,2], columns=['A', 'C'])\n",
+    "s.set_td_classes(cls)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The **advantage** of linking to external CSS is that it can be applied very easily. One can build a DataFrame of (multiple) CSS classes to add to each cell dynamically using traditional `DataFrame.apply` and `DataFrame.applymap` methods, or otherwise, and then add those to the Styler. It will integrate with your website's existing CSS styling.\n",
+    "\n",
+    "The **disadvantage** of this approach is that it is not easy to transmit files standalone. For example the external CSS must be included or the styling will simply be lost. It is also, as this example shows, not well suited (at a table level) for Jupyter Notebooks. Also this method cannot be used for exporting to Excel, for example, since the external CSS cannot be referenced either by the exporters or by Excel itself."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Using Table Styles\n",
+    "\n",
+    "Table styles allow you to control broader areas of the DataFrame styling with minimal HTML transfer. Much of the functionality of `Styler` uses individual HTML id tags to manipulate the output, which may be inefficient for very large tables. Using `table_styles` and otherwise avoiding using id tags can greatly reduce the rendered HTML.\n",
+    "\n",
+    "Table styles are also used to control features which can apply to the whole table at once such as greating a generic hover functionality:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s = Styler(df, cell_ids=False, uuid_len=1)\n",
+    "s.set_table_styles([{'selector': 'tr:hover',\n",
+    "                     'props': [('background-color', 'yellow')]}])\n",
+    "s.set_table_styles({\n",
+    "    'A': [{'selector': '',\n",
+    "           'props': [('color', 'red')]}],\n",
+    "    'B': [{'selector': 'td',\n",
+    "           'props': [('color', 'blue')]}]\n",
+    "}, axis=0, overwrite=False)\n",
+    "s.set_table_styles({\n",
+    "    3: [{'selector': 'td',\n",
+    "           'props': [('color', 'green')]}]\n",
+    "}, axis=1, overwrite=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The **advantage** of table styles is obviously the reduced HTML that it can create and the relative ease with which more general parts of the table can be quickly styled, e.g. by applying a generic hover, rather than having to apply a hover to each cell individually. Rows and columns as individual objects can only be styled in this way.\n",
+    "\n",
+    "The **disadvantage** of being restricted solely to table styles is that you have very limited ability to target and style individual cells based on dynamic criteria. For this one must use either of the other two methods. Also table level styles cannot be exported to Excel: to format cells for Excel output you must use the Styler Functions method below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Styler Functions\n",
+    "\n",
+    "Thirdly we can use the method to pass your style functions into one of the following methods:\n",
+    "\n",
+    "- ``Styler.applymap``: elementwise\n",
+    "- ``Styler.apply``: column-/row-/table-wise\n",
+    "\n",
+    "Both of those methods take a function (and some other keyword arguments) and applies your function to the DataFrame in a certain way.\n",
+    "`Styler.applymap` works through the DataFrame elementwise.\n",
+    "`Styler.apply` passes each column or row into your DataFrame one-at-a-time or the entire table at once, depending on the `axis` keyword argument.\n",
+    "For columnwise use `axis=0`, rowwise use `axis=1`, and for the entire table at once use `axis=None`.\n",
+    "\n",
+    "For `Styler.applymap` your function should take a scalar and return a single string with the CSS attribute-value pair.\n",
+    "\n",
+    "For `Styler.apply` your function should take a Series or DataFrame (depending on the axis parameter), and return a Series or DataFrame with an identical shape where each value is a string with a CSS attribute-value pair.\n",
+    "\n",
+    "The **advantage** of this method is that there is full granular control and the output is isolated and easily transferrable, especially in Jupyter Notebooks.\n",
+    "\n",
+    "The **disadvantage** is that the HTML/CSS required to produce this needs to be directly generated from the Python code and it can lead to inefficient data transfer for large tables.\n",
+    "\n",
+    "Let's see some examples."
    ]
   },
   {
@@ -210,7 +319,34 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We encourage you to use method chains to build up a style piecewise, before finally rending at the end of the chain."
+    "A common use case is also to highlight values based on comparison between columns. Suppose we wish to highlight those cells in columns 'B' and 'C' which are lower than respective values in 'E' then we can write a comparator function. (You can read a little more below in 'Finer Control: Slicing')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compare_col(s, comparator=None):\n",
+    "    attr = 'background-color: #00BFFF;'\n",
+    "    return np.where(s < comparator, attr, '')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.style.apply(compare_col, subset=['B', 'C'], comparator=df['E'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We encourage you to use method chains to build up a style piecewise, before finally rending at the end of the chain. Note the ordering of application will affect styles that overlap."
    ]
   },
   {
@@ -220,6 +356,7 @@
    "outputs": [],
    "source": [
     "df.style.\\\n",
+    "    apply(compare_col, subset=['B', 'C'], comparator=df['E']).\\\n",
     "    applymap(color_negative_red).\\\n",
     "    apply(highlight_max)"
    ]
@@ -271,7 +408,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.style.apply(highlight_max, color='darkorange', axis=None)"
+    "s = df.style.apply(highlight_max, color='darkorange', axis=None)\n",
+    "s"
    ]
   },
   {
@@ -288,6 +426,62 @@
     "- `Styler.apply(func, axis=None)` for tablewise styles\n",
     "\n",
     "And crucially the input and output shapes of `func` must match. If `x` is the input then ``func(x).shape == x.shape``."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tooltips\n",
+    "\n",
+    "*New in version 1.3.0*\n",
+    "\n",
+    "You can now add tooltips in the same way you can add external CSS classes to datacells by providing a string based DataFrame with intersecting indices and columns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tt = pd.DataFrame(data=[[None, 'No Data', None], \n",
+    "                     [None, None, 'Missing Data'], \n",
+    "                     ['Maximum value across entire DataFrame', None, None]], \n",
+    "                  index=[0, 3, 9], \n",
+    "                  columns=['A', 'C', 'D'])\n",
+    "s.set_tooltips(tt)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The tooltips are added with a default CSS styling, however, you have full control of the tooltips in the following way. The name of the class can be integrated with your existing website's CSS so you do not need to set any properties within Python if you have the external CSS files. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "s.set_tooltips_class(name='pd-tt', properties=[\n",
+    "    ('visibility', 'hidden'),\n",
+    "    ('position', 'absolute'),\n",
+    "    ('z-index', '1'),\n",
+    "    ('background-color', 'blue'),\n",
+    "    ('color', 'white'),\n",
+    "    ('font-size', '1.5em'),\n",
+    "    ('transform', 'translate(3px, -11px)'),\n",
+    "    ('padding', '0.5em'),\n",
+    "    ('border', '1px solid red'),\n",
+    "    ('border-radius', '0.5em')\n",
+    "])"
    ]
   },
   {
@@ -843,6 +1037,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "html = html.set_table_styles({\n",
@@ -850,13 +1049,7 @@
     "    'C': [dict(selector='td', props=[('color', 'red')])], \n",
     "    }, overwrite=False)\n",
     "html"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1053,7 +1246,9 @@
     "\n",
     "- Only CSS2 named colors and hex colors of the form `#rgb` or `#rrggbb` are currently supported.\n",
     "- The following pseudo CSS properties are also available to set excel specific style properties:\n",
-    "    - `number-format`\n"
+    "    - `number-format`\n",
+    "\n",
+    "Table level styles are not included in the export to Excel: individual cells must have their properties mapped by the `Styler.apply` and/or `Styler.applymap` methods."
    ]
   },
   {
@@ -1262,7 +1457,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/doc/source/user_guide/style.ipynb
+++ b/doc/source/user_guide/style.ipynb
@@ -50,7 +50,6 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "from pandas.io.formats.style import Styler\n",
     "import numpy as np\n",
     "\n",
     "np.random.seed(24)\n",
@@ -161,9 +160,12 @@
    "source": [
     "### Using Table Styles\n",
     "\n",
-    "Table styles allow you to control broader areas of the DataFrame styling with minimal HTML transfer. Much of the functionality of `Styler` uses individual HTML id tags to manipulate the output, which may be inefficient for very large tables. Using `table_styles` and otherwise avoiding using id tags can greatly reduce the rendered HTML.\n",
+    "Table styles allow you to control broader areas of the DataFrame, i.e. the whole table or specific columns or rows, with minimal HTML transfer. Much of the functionality of `Styler` uses individual HTML id tags to manipulate the output, which may be inefficient for very large tables. Using `table_styles` and otherwise avoiding using id tags in data cells can greatly reduce the rendered HTML.\n",
     "\n",
-    "Table styles are also used to control features which can apply to the whole table at once such as greating a generic hover functionality:"
+    "Table styles are also used to control features which can apply to the whole table at once such as greating a generic hover functionality. This `:hover` pseudo-selectors, as well as others, can only be used this way.\n",
+    "\n",
+    "`table_styles` are extremely flexible, but not as fun to type out by hand.\n",
+    "We hope to collect some useful ones either in pandas, or preferable in a new package that [builds on top](#Extensibility) the tools here."
    ]
   },
   {
@@ -172,19 +174,95 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s = Styler(df, cell_ids=False, uuid_len=1)\n",
-    "s.set_table_styles([{'selector': 'tr:hover',\n",
-    "                     'props': [('background-color', 'yellow')]}])\n",
-    "s.set_table_styles({\n",
+    "def hover(hover_color=\"#ffff99\"):\n",
+    "    return {'selector': \"tr:hover\",\n",
+    "            'props': [(\"background-color\", \"%s\" % hover_color)]}\n",
+    "\n",
+    "styles = [\n",
+    "    hover(),\n",
+    "    {'selector': \"th\", 'props': [(\"font-size\", \"150%\"),\n",
+    "                                 (\"text-align\", \"center\")]}\n",
+    "]\n",
+    "\n",
+    "df.style.set_table_styles(styles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If `table_styles` is given as a dictionary each key should be a specified column or index value and this will map to specific class CSS selectors of the given column or row."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.style.set_table_styles({\n",
     "    'A': [{'selector': '',\n",
     "           'props': [('color', 'red')]}],\n",
     "    'B': [{'selector': 'td',\n",
     "           'props': [('color', 'blue')]}]\n",
-    "}, axis=0, overwrite=False)\n",
-    "s.set_table_styles({\n",
+    "}, axis=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.style.set_table_styles({\n",
     "    3: [{'selector': 'td',\n",
     "           'props': [('color', 'green')]}]\n",
-    "}, axis=1, overwrite=False)"
+    "}, axis=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also chain all of the above by setting the `overwrite` argument to `False` so that it preserves previous settings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pandas.io.formats.style import Styler\n",
+    "s = Styler(df, cell_ids=False, uuid_len=0).\\\n",
+    "    set_table_styles(styles).\\\n",
+    "    set_table_styles({\n",
+    "        'A': [{'selector': '',\n",
+    "               'props': [('color', 'red')]}],\n",
+    "        'B': [{'selector': 'td',\n",
+    "               'props': [('color', 'blue')]}]\n",
+    "    }, axis=0, overwrite=False).\\\n",
+    "    set_table_styles({\n",
+    "        3: [{'selector': 'td',\n",
+    "             'props': [('color', 'green')]}]\n",
+    "    }, axis=1, overwrite=False)\n",
+    "s"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By using these `table_styles` and the additional `Styler` arguments to optimize the HTML we have compressed these styles to only a few lines withing the \\<style\\> tags and none of the \\<td\\> cells require any `id` attributes.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s.render().split('\\n')[:16]"
    ]
   },
   {
@@ -193,7 +271,7 @@
    "source": [
     "The **advantage** of table styles is obviously the reduced HTML that it can create and the relative ease with which more general parts of the table can be quickly styled, e.g. by applying a generic hover, rather than having to apply a hover to each cell individually. Rows and columns as individual objects can only be styled in this way.\n",
     "\n",
-    "The **disadvantage** of being restricted solely to table styles is that you have very limited ability to target and style individual cells based on dynamic criteria. For this one must use either of the other two methods. Also table level styles cannot be exported to Excel: to format cells for Excel output you must use the Styler Functions method below."
+    "The **disadvantage** of being restricted solely to table styles is that you have very limited ability to target and style individual cells based on dynamic criteria. For this, one must use either of the other two methods. Also table level styles cannot be exported to Excel: to format cells for Excel output you must use the Styler Functions method below."
    ]
   },
   {
@@ -961,7 +1039,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Regular table captions can be added in a few ways."
+    "Regular table captions can be added and, if necessary, controlled with CSS."
    ]
   },
   {
@@ -971,84 +1049,10 @@
    "outputs": [],
    "source": [
     "df.style.set_caption('Colormaps, with a caption.')\\\n",
+    "    .set_table_styles([{\n",
+    "        'selector': \"caption\", 'props': [(\"caption-side\", \"bottom\")]\n",
+    "    }])\\\n",
     "    .background_gradient(cmap=cm)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Table styles"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The next option you have are \"table styles\".\n",
-    "These are styles that apply to the table as a whole, but don't look at the data.\n",
-    "Certain stylings, including pseudo-selectors like `:hover` can only be used this way.\n",
-    "These can also be used to set specific row or column based class selectors, as will be shown."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from IPython.display import HTML\n",
-    "\n",
-    "def hover(hover_color=\"#ffff99\"):\n",
-    "    return dict(selector=\"tr:hover\",\n",
-    "                props=[(\"background-color\", \"%s\" % hover_color)])\n",
-    "\n",
-    "styles = [\n",
-    "    hover(),\n",
-    "    dict(selector=\"th\", props=[(\"font-size\", \"150%\"),\n",
-    "                               (\"text-align\", \"center\")]),\n",
-    "    dict(selector=\"caption\", props=[(\"caption-side\", \"bottom\")])\n",
-    "]\n",
-    "html = (df.style.set_table_styles(styles)\n",
-    "          .set_caption(\"Hover to highlight.\"))\n",
-    "html"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`table_styles` should be a list of dictionaries.\n",
-    "Each dictionary should have the `selector` and `props` keys.\n",
-    "The value for `selector` should be a valid CSS selector.\n",
-    "Recall that all the styles are already attached to an `id`, unique to\n",
-    "each `Styler`. This selector is in addition to that `id`.\n",
-    "The value for `props` should be a list of tuples of `('attribute', 'value')`.\n",
-    "\n",
-    "`table_styles` are extremely flexible, but not as fun to type out by hand.\n",
-    "We hope to collect some useful ones either in pandas, or preferable in a new package that [builds on top](#Extensibility) the tools here.\n",
-    "\n",
-    "`table_styles` can be used to add column and row based class descriptors. For large tables this can increase performance by avoiding repetitive individual css for each cell, and it can also simplify style construction in some cases.\n",
-    "If `table_styles` is given as a dictionary each key should be a specified column or index value and this will map to specific class CSS selectors of the given column or row.\n",
-    "\n",
-    "Note that `Styler.set_table_styles` will overwrite existing styles but can be chained by setting the `overwrite` argument to `False`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "html = html.set_table_styles({\n",
-    "    'B': [dict(selector='', props=[('color', 'green')])],\n",
-    "    'C': [dict(selector='td', props=[('color', 'red')])], \n",
-    "    }, overwrite=False)\n",
-    "html"
    ]
   },
   {

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -511,16 +511,15 @@ class Styler:
 
             for c, col in enumerate(self.data.columns):
                 cs = [DATA_CLASS, f"row{r}", f"col{c}"]
-                cs.extend(cell_context.get("data", {}).get(r, {}).get(c, []))
                 formatter = self._display_funcs[(r, c)]
                 value = self.data.iloc[r, c]
                 row_dict = {
                     "type": "td",
                     "value": value,
-                    "class": " ".join(cs),
                     "display_value": formatter(value),
                     "is_visible": (c not in hidden_columns),
                 }
+
                 # only add an id if the cell has a style
                 props = []
                 if self.cell_ids or (r, c) in ctx:
@@ -531,6 +530,11 @@ class Styler:
                             props.append(tuple(x.split(":")))
                         else:
                             props.append(("", ""))
+
+                # add custom classes from cell context
+                cs.extend(cell_context.get("data", {}).get(r, {}).get(c, []))
+                row_dict["class"] = " ".join(cs)
+
                 row_es.append(row_dict)
                 cellstyle_map[tuple(props)].append(f"row{r}_col{c}")
             body.append(row_es)
@@ -690,10 +694,12 @@ class Styler:
 
         mask = (classes.isna()) | (classes.eq(""))
         self.cell_context["data"] = {
-            r: {c: [str(classes.iloc[r, c])]}
+            r: {
+                c: [str(classes.iloc[r, c])]
+                for c, cn in enumerate(classes.columns)
+                if not mask.iloc[r, c]
+            }
             for r, rn in enumerate(classes.index)
-            for c, cn in enumerate(classes.columns)
-            if not mask.iloc[r, c]
         }
 
         return self
@@ -1914,11 +1920,8 @@ class _Tooltips:
         -------
         render_dict : Dict
         """
-        self.tt_data = (
-            self.tt_data.reindex_like(styler_data)
-            .dropna(how="all", axis=0)
-            .dropna(how="all", axis=1)
-        )
+        self.tt_data = self.tt_data.reindex_like(styler_data)
+
         if self.tt_data.empty:
             return d
 

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1706,11 +1706,34 @@ class TestStyler:
     def test_set_data_classes(self, classes):
         # GH 36159
         df = DataFrame(data=[[0, 1], [2, 3]], columns=["A", "B"], index=["a", "b"])
-        s = Styler(df, uuid="_", cell_ids=False).set_td_classes(classes).render()
+        s = Styler(df, uuid_len=0, cell_ids=False).set_td_classes(classes).render()
         assert '<td  class="data row0 col0" >0</td>' in s
         assert '<td  class="data row0 col1 test-class" >1</td>' in s
         assert '<td  class="data row1 col0" >2</td>' in s
         assert '<td  class="data row1 col1" >3</td>' in s
+        # GH 39317
+        s = Styler(df, uuid_len=0, cell_ids=True).set_td_classes(classes).render()
+        assert '<td id="T__row0_col0" class="data row0 col0" >0</td>' in s
+        assert '<td id="T__row0_col1" class="data row0 col1 test-class" >1</td>' in s
+        assert '<td id="T__row1_col0" class="data row1 col0" >2</td>' in s
+        assert '<td id="T__row1_col1" class="data row1 col1" >3</td>' in s
+
+    def test_set_data_classes_reindex(self):
+        # GH 39317
+        df = DataFrame(
+            data=[[0, 1, 2], [3, 4, 5], [6, 7, 8]], columns=[0, 1, 2], index=[0, 1, 2]
+        )
+        classes = DataFrame(
+            data=[["mi", "ma"], ["mu", "mo"]],
+            columns=[0, 2],
+            index=[0, 2],
+        )
+        s = Styler(df, uuid_len=0).set_td_classes(classes).render()
+        assert '<td id="T__row0_col0" class="data row0 col0 mi" >0</td>' in s
+        assert '<td id="T__row0_col2" class="data row0 col2 ma" >2</td>' in s
+        assert '<td id="T__row1_col1" class="data row1 col1" >4</td>' in s
+        assert '<td id="T__row2_col0" class="data row2 col0 mu" >6</td>' in s
+        assert '<td id="T__row2_col2" class="data row2 col2 mo" >8</td>' in s
 
     def test_chaining_table_styles(self):
         # GH 35607
@@ -1814,6 +1837,22 @@ class TestStyler:
             + "</span></td>"
             in s
         )
+
+    def test_tooltip_reindex(self):
+        # GH 39317
+        df = DataFrame(
+            data=[[0, 1, 2], [3, 4, 5], [6, 7, 8]], columns=[0, 1, 2], index=[0, 1, 2]
+        )
+        ttips = DataFrame(
+            data=[["Mi", "Ma"], ["Mu", "Mo"]],
+            columns=[0, 2],
+            index=[0, 2],
+        )
+        s = Styler(df, uuid_len=0).set_tooltips(DataFrame(ttips)).render()
+        assert '#T__ #T__row0_col0 .pd-t::after {\n          content: "Mi";\n    }' in s
+        assert '#T__ #T__row0_col2 .pd-t::after {\n          content: "Ma";\n    }' in s
+        assert '#T__ #T__row2_col0 .pd-t::after {\n          content: "Mu";\n    }' in s
+        assert '#T__ #T__row2_col2 .pd-t::after {\n          content: "Mo";\n    }' in s
 
     def test_tooltip_ignored(self):
         # GH 21266


### PR DESCRIPTION
**DOC**: this edits the `style.ipynb` file to include examples of the 3 recent enhancements to `Styler`:

 - Tooltips
 - External CSS classes to datacells
 - Row and Column styling via table styles

It also addresses 3 minor bugs that I detected when wirting the documentation:

**BUG1** (lines 696-703): `set_td_classes` only attached classes to 'diagonal elements' of the DataFrame due a misaligned comprehension loop:

```
{
r: {
   c: [str(classes.iloc[r, c])] 
   for c, cn in enumerate(classes.columns) if not mask.iloc[r, c]
   }
for r, rn in enumerate(classes.index)
}
```
replaces:
```
{
r: {
    c: [str(classes.iloc[r, c])]
    }
for r, rn in enumerate(classes.index)
for c, cn in enumerate(classes.columns)
if not mask.iloc[r, c]
}
```

**BUG2** (lines 513 to 537): external css class names from the set_td_classes were appended to the HTML id tag, as well as the HTML class tag, due to a premature variable update relating to the `row_dict`. The solution was to re-order so that 'id' tags were generated first and then 'class' was updated with information from the new methods.

**BUG3** (lines 1920-1925): Tooltips were generated for the wrong indexes/columns, since the null rows/columns were dropped and then the interger locations of rows/columns was mapped. The solution was to avoid dropping null rows/columns.


