### PR TITLE
small typing fixes

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -91,7 +91,7 @@ Shape = Tuple[int, ...]
 Suffixes = Tuple[str, str]
 Ordered = Optional[bool]
 JSONSerializable = Optional[Union[PythonScalar, List, Dict]]
-Axes = Collection
+Axes = Collection[Any]
 
 # dtypes
 NpDtype = Union[str, np.dtype]

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -139,7 +139,7 @@ class ExtensionDtype:
         return np.nan
 
     @property
-    def type(self) -> Type:
+    def type(self) -> Type[Any]:
         """
         The scalar type for the array, e.g. ``int``
 


### PR DESCRIPTION
Some very small fixes to typing declarations to fix some errors found by `pyright`

Should not affect running code at all.  mypy tests passed locally.

