### PR TITLE
STYLE: Fix incorrect path to ujson directory

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -64,7 +64,7 @@ if [[ -z "$CHECK" || "$CHECK" == "lint" ]]; then
     # this particular codebase (e.g. src/headers, src/klib). However,
     # we can lint all header files since they aren't "generated" like C files are.
     MSG='Linting .c and .h' ; echo $MSG
-    cpplint --quiet --extensions=c,h --headers=h --recursive --filter=-readability/casting,-runtime/int,-build/include_subdir pandas/_libs/src/*.h pandas/_libs/src/parser pandas/_libs/ujson pandas/_libs/tslibs/src/datetime pandas/_libs/*.cpp
+    cpplint --quiet --extensions=c,h --headers=h --recursive --filter=-readability/casting,-runtime/int,-build/include_subdir pandas/_libs/src/*.h pandas/_libs/src/parser pandas/_libs/src/ujson pandas/_libs/tslibs/src/datetime pandas/_libs/*.cpp
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
 fi

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -58,14 +58,13 @@ if [[ -z "$CHECK" || "$CHECK" == "lint" ]]; then
     # readability/casting: Warnings about C casting instead of C++ casting
     # runtime/int: Warnings about using C number types instead of C++ ones
     # build/include_subdir: Warnings about prefacing included header files with directory
-    # runtime/printf: Warnings about using sprintf instead of snprintf
 
     # We don't lint all C files because we don't want to lint any that are built
     # from Cython files nor do we want to lint C files that we didn't modify for
     # this particular codebase (e.g. src/headers, src/klib). However,
     # we can lint all header files since they aren't "generated" like C files are.
     MSG='Linting .c and .h' ; echo $MSG
-    cpplint --quiet --extensions=c,h --headers=h --recursive --filter=-readability/casting,-runtime/int,-build/include_subdir,-runtime/printf pandas/_libs/src/*.h pandas/_libs/src/parser pandas/_libs/src/ujson pandas/_libs/tslibs/src/datetime pandas/_libs/*.cpp
+    cpplint --quiet --extensions=c,h --headers=h --recursive --filter=-readability/casting,-runtime/int,-build/include_subdir pandas/_libs/src/*.h pandas/_libs/src/parser pandas/_libs/src/ujson pandas/_libs/tslibs/src/datetime pandas/_libs/*.cpp
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
 fi

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -58,13 +58,14 @@ if [[ -z "$CHECK" || "$CHECK" == "lint" ]]; then
     # readability/casting: Warnings about C casting instead of C++ casting
     # runtime/int: Warnings about using C number types instead of C++ ones
     # build/include_subdir: Warnings about prefacing included header files with directory
+    # runtime/printf: Warnings about using sprintf instead of snprintf
 
     # We don't lint all C files because we don't want to lint any that are built
     # from Cython files nor do we want to lint C files that we didn't modify for
     # this particular codebase (e.g. src/headers, src/klib). However,
     # we can lint all header files since they aren't "generated" like C files are.
     MSG='Linting .c and .h' ; echo $MSG
-    cpplint --quiet --extensions=c,h --headers=h --recursive --filter=-readability/casting,-runtime/int,-build/include_subdir pandas/_libs/src/*.h pandas/_libs/src/parser pandas/_libs/src/ujson pandas/_libs/tslibs/src/datetime pandas/_libs/*.cpp
+    cpplint --quiet --extensions=c,h --headers=h --recursive --filter=-readability/casting,-runtime/int,-build/include_subdir,-runtime/printf pandas/_libs/src/*.h pandas/_libs/src/parser pandas/_libs/src/ujson pandas/_libs/tslibs/src/datetime pandas/_libs/*.cpp
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
 fi

--- a/pandas/_libs/src/ujson/lib/ultrajsonenc.c
+++ b/pandas/_libs/src/ujson/lib/ultrajsonenc.c
@@ -728,20 +728,19 @@ INLINE_PREFIX void FASTCALL_MSVC strreverse(char *begin,
     while (end > begin) aux = *end, *end-- = *begin, *begin++ = aux;
 }
 
-void Buffer_AppendIndentNewlineUnchecked(JSONObjectEncoder *enc)
-{
+void Buffer_AppendIndentNewlineUnchecked(JSONObjectEncoder *enc) {
   if (enc->indent > 0) Buffer_AppendCharUnchecked(enc, '\n');
 }
 
 // This function could be refactored to only accept enc as an argument,
 // but this is a straight vendor from ujson source
-void Buffer_AppendIndentUnchecked(JSONObjectEncoder *enc, JSINT32 value)
-{
+void Buffer_AppendIndentUnchecked(JSONObjectEncoder *enc, JSINT32 value) {
   int i;
-  if (enc->indent > 0)
+  if (enc->indent > 0) {
     while (value-- > 0)
       for (i = 0; i < enc->indent; i++)
         Buffer_AppendCharUnchecked(enc, ' ');
+  }
 }
 
 void Buffer_AppendIntUnchecked(JSONObjectEncoder *enc, JSINT32 value) {
@@ -976,7 +975,7 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name,
             enc->iterBegin(obj, &tc);
 
             Buffer_AppendCharUnchecked(enc, '[');
-            Buffer_AppendIndentNewlineUnchecked (enc);
+            Buffer_AppendIndentNewlineUnchecked(enc);
 
             while (enc->iterNext(obj, &tc)) {
                 if (count > 0) {
@@ -984,20 +983,20 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name,
 #ifndef JSON_NO_EXTRA_WHITESPACE
                     Buffer_AppendCharUnchecked(buffer, ' ');
 #endif
-                    Buffer_AppendIndentNewlineUnchecked (enc);
+                    Buffer_AppendIndentNewlineUnchecked(enc);
                 }
 
                 iterObj = enc->iterGetValue(obj, &tc);
 
                 enc->level++;
-                Buffer_AppendIndentUnchecked (enc, enc->level);
+                Buffer_AppendIndentUnchecked(enc, enc->level);
                 encode(iterObj, enc, NULL, 0);
                 count++;
             }
 
             enc->iterEnd(obj, &tc);
-            Buffer_AppendIndentNewlineUnchecked (enc);
-            Buffer_AppendIndentUnchecked (enc, enc->level);
+            Buffer_AppendIndentNewlineUnchecked(enc);
+            Buffer_AppendIndentUnchecked(enc, enc->level);
             Buffer_AppendCharUnchecked(enc, ']');
             break;
         }
@@ -1007,7 +1006,7 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name,
             enc->iterBegin(obj, &tc);
 
             Buffer_AppendCharUnchecked(enc, '{');
-            Buffer_AppendIndentNewlineUnchecked (enc);
+            Buffer_AppendIndentNewlineUnchecked(enc);
 
             while (enc->iterNext(obj, &tc)) {
                 if (count > 0) {
@@ -1015,21 +1014,21 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name,
 #ifndef JSON_NO_EXTRA_WHITESPACE
                     Buffer_AppendCharUnchecked(enc, ' ');
 #endif
-                    Buffer_AppendIndentNewlineUnchecked (enc);
+                    Buffer_AppendIndentNewlineUnchecked(enc);
                 }
 
                 iterObj = enc->iterGetValue(obj, &tc);
                 objName = enc->iterGetName(obj, &tc, &szlen);
 
                 enc->level++;
-                Buffer_AppendIndentUnchecked (enc, enc->level);
+                Buffer_AppendIndentUnchecked(enc, enc->level);
                 encode(iterObj, enc, objName, szlen);
                 count++;
             }
 
             enc->iterEnd(obj, &tc);
-            Buffer_AppendIndentNewlineUnchecked (enc);
-            Buffer_AppendIndentUnchecked (enc, enc->level);
+            Buffer_AppendIndentNewlineUnchecked(enc);
+            Buffer_AppendIndentUnchecked(enc, enc->level);
             Buffer_AppendCharUnchecked(enc, '}');
             break;
         }
@@ -1134,7 +1133,6 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name,
             }
 
             break;
-
         }
     }
 

--- a/pandas/_libs/src/ujson/python/date_conversions.c
+++ b/pandas/_libs/src/ujson/python/date_conversions.c
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2020, PyData Development Team
+All rights reserved.
+Distributed under the terms of the BSD Simplified License.
+The full license is in the LICENSE file, distributed with this software.
+*/
+
 // Conversion routines that are useful for serialization,
 // but which don't interact with JSON objects directly
 
@@ -108,7 +115,7 @@ npy_datetime PyDateTimeToEpoch(PyObject *dt, NPY_DATETIMEUNIT base) {
             PyErr_SetString(PyExc_ValueError,
                             "Could not convert PyDateTime to numpy datetime");
         }
-        // TODO: is setting errMsg required?
+        // TODO(username): is setting errMsg required?
         // ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
         // return NULL;
     }

--- a/pandas/_libs/src/ujson/python/date_conversions.c
+++ b/pandas/_libs/src/ujson/python/date_conversions.c
@@ -109,7 +109,7 @@ npy_datetime PyDateTimeToEpoch(PyObject *dt, NPY_DATETIMEUNIT base) {
                             "Could not convert PyDateTime to numpy datetime");
         }
         // TODO: is setting errMsg required?
-        //((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
+        // ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
         // return NULL;
     }
 

--- a/pandas/_libs/src/ujson/python/date_conversions.h
+++ b/pandas/_libs/src/ujson/python/date_conversions.h
@@ -1,5 +1,5 @@
-#ifndef PANDAS__LIBS_SRC_UJSON_DATE_CONVERSIONS
-#define PANDAS__LIBS_SRC_UJSON_DATE_CONVERSIONS
+#ifndef PANDAS__LIBS_SRC_UJSON_PYTHON_DATE_CONVERSIONS_H_
+#define PANDAS__LIBS_SRC_UJSON_PYTHON_DATE_CONVERSIONS_H_
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
@@ -29,4 +29,4 @@ npy_datetime PyDateTimeToEpoch(PyObject *dt, NPY_DATETIMEUNIT base);
 
 char *int64ToIsoDuration(int64_t value, size_t *len);
 
-#endif
+#endif  // PANDAS__LIBS_SRC_UJSON_PYTHON_DATE_CONVERSIONS_H_

--- a/pandas/_libs/src/ujson/python/date_conversions.h
+++ b/pandas/_libs/src/ujson/python/date_conversions.h
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2020, PyData Development Team
+All rights reserved.
+Distributed under the terms of the BSD Simplified License.
+The full license is in the LICENSE file, distributed with this software.
+*/
+
 #ifndef PANDAS__LIBS_SRC_UJSON_PYTHON_DATE_CONVERSIONS_H_
 #define PANDAS__LIBS_SRC_UJSON_PYTHON_DATE_CONVERSIONS_H_
 
@@ -14,8 +21,8 @@ int scaleNanosecToUnit(npy_int64 *value, NPY_DATETIMEUNIT unit);
 // len is mutated to save the length of the returned string
 char *int64ToIso(int64_t value, NPY_DATETIMEUNIT base, size_t *len);
 
-// TODO: this function doesn't do a lot; should augment or replace with
-// scaleNanosecToUnit
+// TODO(username): this function doesn't do a lot; should augment or
+// replace with scaleNanosecToUnit
 npy_datetime NpyDateTimeToEpoch(npy_datetime dt, NPY_DATETIMEUNIT base);
 
 // Converts a Python object representing a Date / Datetime to ISO format

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -64,9 +64,9 @@ typedef char *(*PFN_PyTypeToUTF8)(JSOBJ obj, JSONTypeContext *ti,
 typedef struct __NpyArrContext {
     PyObject *array;
     char *dataptr;
-    int curdim;    // current dimension in array's order
-    int stridedim; // dimension we are striding over
-    int inc;       // stride dimension increment (+/- 1)
+    int curdim;     // current dimension in array's order
+    int stridedim;  // dimension we are striding over
+    int inc;        // stride dimension increment (+/- 1)
     npy_intp dim;
     npy_intp stride;
     npy_intp ndim;
@@ -83,8 +83,8 @@ typedef struct __PdBlockContext {
     int ncols;
     int transpose;
 
-    int *cindices;            // frame column -> block column map
-    NpyArrContext **npyCtxts; // NpyArrContext for each column
+    int *cindices;             // frame column -> block column map
+    NpyArrContext **npyCtxts;  // NpyArrContext for each column
 } PdBlockContext;
 
 typedef struct __TypeContext {
@@ -346,7 +346,6 @@ static char *NpyTimeDeltaToIsoCallback(JSOBJ Py_UNUSED(unused),
 /* JSON callback */
 static char *PyDateTimeToIsoCallback(JSOBJ obj, JSONTypeContext *tc,
                                      size_t *len) {
-
     if (!PyDate_Check(obj)) {
         PyErr_SetString(PyExc_TypeError, "Expected date object");
         return NULL;
@@ -1108,7 +1107,7 @@ void Series_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     PyObjectEncoder *enc = (PyObjectEncoder *)tc->encoder;
     GET_TC(tc)->index = 0;
     GET_TC(tc)->cStr = PyObject_Malloc(20 * sizeof(char));
-    enc->outputFormat = VALUES; // for contained series
+    enc->outputFormat = VALUES;  // for contained series
     if (!GET_TC(tc)->cStr) {
         PyErr_NoMemory();
     }
@@ -1164,7 +1163,7 @@ void DataFrame_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     PyObjectEncoder *enc = (PyObjectEncoder *)tc->encoder;
     GET_TC(tc)->index = 0;
     GET_TC(tc)->cStr = PyObject_Malloc(20 * sizeof(char));
-    enc->outputFormat = VALUES; // for contained series & index
+    enc->outputFormat = VALUES;  // for contained series & index
     if (!GET_TC(tc)->cStr) {
         PyErr_NoMemory();
     }
@@ -1364,7 +1363,7 @@ char **NpyArr_encodeLabels(PyArrayObject *labels, PyObjectEncoder *enc,
             } else {
                 if (PyDelta_Check(item)) {
                     nanosecVal = total_seconds(item) *
-                                 1000000000LL; // nanoseconds per second
+                                 1000000000LL;  // nanoseconds per second
                 } else {
                     // datetime.* objects don't follow above rules
                     nanosecVal = PyDateTimeToEpoch(item, NPY_FR_ns);
@@ -1395,13 +1394,13 @@ char **NpyArr_encodeLabels(PyArrayObject *labels, PyObjectEncoder *enc,
                         break;
                     }
                 } else {
-                    cLabel = PyObject_Malloc(21); // 21 chars for int64
+                    cLabel = PyObject_Malloc(21);  // 21 chars for int64
                     sprintf(cLabel, "%" NPY_DATETIME_FMT,
                             NpyDateTimeToEpoch(nanosecVal, base));
                     len = strlen(cLabel);
                 }
             }
-        } else { // Fallback to string representation
+        } else {  // Fallback to string representation
             // Replace item with the string to keep it alive.
             Py_SETREF(item, PyObject_Str(item));
             if (item == NULL) {
@@ -1502,7 +1501,6 @@ void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
         if (longVal == get_nat()) {
             tc->type = JT_NULL;
         } else {
-
             if (enc->datetimeIso) {
                 if (enc->npyType == NPY_TIMEDELTA) {
                     pc->PyTypeToUTF8 = NpyTimeDeltaToIsoCallback;
@@ -2039,7 +2037,7 @@ PyObject *objToJSON(PyObject *Py_UNUSED(self), PyObject *args,
     PyObject *newobj;
     PyObject *oinput = NULL;
     PyObject *oensureAscii = NULL;
-    int idoublePrecision = 10; // default double precision setting
+    int idoublePrecision = 10;  // default double precision setting
     PyObject *oencodeHTMLChars = NULL;
     char *sOrient = NULL;
     char *sdateFormat = NULL;
@@ -2052,7 +2050,7 @@ PyObject *objToJSON(PyObject *Py_UNUSED(self), PyObject *args,
         Object_endTypeContext,
         Object_getStringValue,
         Object_getLongValue,
-        NULL, // getIntValue is unused
+        NULL,  // getIntValue is unused
         Object_getDoubleValue,
         Object_getBigNumStringValue,
         Object_iterBegin,
@@ -2064,11 +2062,11 @@ PyObject *objToJSON(PyObject *Py_UNUSED(self), PyObject *args,
         PyObject_Malloc,
         PyObject_Realloc,
         PyObject_Free,
-        -1, // recursionMax
+        -1,  // recursionMax
         idoublePrecision,
-        1, // forceAscii
-        0, // encodeHTMLChars
-        0, // indent
+        1,  // forceAscii
+        0,  // encodeHTMLChars
+        0,  // indent
     }};
     JSONObjectEncoder *encoder = (JSONObjectEncoder *)&pyEncoder;
 

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -1395,7 +1395,7 @@ char **NpyArr_encodeLabels(PyArrayObject *labels, PyObjectEncoder *enc,
                     }
                 } else {
                     cLabel = PyObject_Malloc(21);  // 21 chars for int64
-                    sprintf(cLabel, "%" NPY_DATETIME_FMT,
+                    snprintf(cLabel, "%" NPY_DATETIME_FMT,
                             NpyDateTimeToEpoch(nanosecVal, base));
                     len = strlen(cLabel);
                 }

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -1394,8 +1394,9 @@ char **NpyArr_encodeLabels(PyArrayObject *labels, PyObjectEncoder *enc,
                         break;
                     }
                 } else {
-                    cLabel = PyObject_Malloc(21);  // 21 chars for int64
-                    sprintf(cLabel, "%" NPY_DATETIME_FMT,
+                    int size_of_cLabel = 21;  // 21 chars for int 64
+                    cLabel = PyObject_Malloc(size_of_cLabel);
+                    snprintf(cLabel, size_of_cLabel, "%" NPY_DATETIME_FMT,
                             NpyDateTimeToEpoch(nanosecVal, base));
                     len = strlen(cLabel);
                 }

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -1395,7 +1395,7 @@ char **NpyArr_encodeLabels(PyArrayObject *labels, PyObjectEncoder *enc,
                     }
                 } else {
                     cLabel = PyObject_Malloc(21);  // 21 chars for int64
-                    snprintf(cLabel, "%" NPY_DATETIME_FMT,
+                    sprintf(cLabel, "%" NPY_DATETIME_FMT,
                             NpyDateTimeToEpoch(nanosecVal, base));
                     len = strlen(cLabel);
                 }

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -1519,7 +1519,8 @@ void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
             }
         }
 
-        // TODO: this prevents infinite loop with mixed-type DataFrames;
+        // TODO(username): this prevents infinite loop with
+        // mixed-type DataFrames;
         // refactor
         enc->npyCtxtPassthru = NULL;
         enc->npyType = -1;
@@ -1618,7 +1619,7 @@ void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
         } else {
             unit = ((PyObjectEncoder *)tc->encoder)->datetimeUnit;
             if (scaleNanosecToUnit(&value, unit) != 0) {
-                // TODO: Add some kind of error handling here
+                // TODO(username): Add some kind of error handling here
             }
 
             exc = PyErr_Occurred();

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -1606,7 +1606,7 @@ void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
         if (PyObject_HasAttrString(obj, "value")) {
             value = get_long_attr(obj, "value");
         } else {
-            value = total_seconds(obj) * 1000000000LL; // nanoseconds per second
+            value = total_seconds(obj) * 1000000000LL;  // nanoseconds per sec
         }
 
         if (value == get_nat()) {

--- a/pandas/_libs/src/ujson/python/ujson.c
+++ b/pandas/_libs/src/ujson/python/ujson.c
@@ -73,6 +73,6 @@ static PyModuleDef moduledef = {
 
 
 PyMODINIT_FUNC PyInit_json(void) {
-  initObjToJSON();  // TODO: clean up, maybe via tp_free?
+  initObjToJSON();  // TODO(username): clean up, maybe via tp_free?
   return PyModuleDef_Init(&moduledef);
 }

--- a/pandas/_libs/src/ujson/python/ujson.c
+++ b/pandas/_libs/src/ujson/python/ujson.c
@@ -75,5 +75,4 @@ static PyModuleDef moduledef = {
 PyMODINIT_FUNC PyInit_json(void) {
   initObjToJSON();  // TODO: clean up, maybe via tp_free?
   return PyModuleDef_Init(&moduledef);
-
 }


### PR DESCRIPTION
- [x] closes #39347 

I fixed the path to `ujson` directory so `cpplint` will run on `pandas/_libs/src/ujson/` instead of `pandas/_libs/ujson`, which doesn't exist.

But the title of the issue says `cpplint (unintentionally?) skips pandas/_libs/src/ujson/`, so I understand there's a chance the `pandas/_libs/src/ujson/` is getting *intentionally* skipped.

Assuming this was **unintentional**, I believe this small fix solves the issue.