### PR TITLE
DOC: add option for skipping execution of code blocks

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -41,6 +41,7 @@ class DocBuilder:
         self,
         num_jobs=0,
         include_api=True,
+        no_ipython=False,
         single_doc=None,
         verbosity=0,
         warnings_are_errors=False,
@@ -56,6 +57,9 @@ class DocBuilder:
             os.environ["SPHINX_PATTERN"] = single_doc
         elif not include_api:
             os.environ["SPHINX_PATTERN"] = "-api"
+
+        if no_ipython:
+            os.environ["SPHINX_SKIP_IPYTHON"] = "TRUE"
 
         self.single_doc_html = None
         if single_doc and single_doc.endswith(".rst"):
@@ -303,6 +307,12 @@ def main():
         "--no-api", default=False, help="omit api and autosummary", action="store_true"
     )
     argparser.add_argument(
+        "--no-ipython",
+        default=False,
+        help="skip execution of code blocks",
+        action="store_true",
+    )
+    argparser.add_argument(
         "--single",
         metavar="FILENAME",
         type=str,
@@ -353,6 +363,7 @@ def main():
     builder = DocBuilder(
         args.num_jobs,
         not args.no_api,
+        args.no_ipython,
         args.single,
         args.verbosity,
         args.warnings_are_errors,

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -17,6 +17,7 @@ import logging
 import os
 import sys
 
+from IPython.sphinxext.ipython_directive import IPythonDirective
 import jinja2
 from numpydoc.docscrape import NumpyDocString
 from sphinx.ext.autosummary import _import_by_name
@@ -744,6 +745,16 @@ def rstjinja(app, docname, source):
     source[0] = rendered
 
 
+class SkipIPython(IPythonDirective):
+    """
+    Treats all ipython directives as :verbatim:, to speed up build time.
+    """
+
+    def run(self):
+        self.options["verbatim"] = True
+        return super().run()
+
+
 def setup(app):
     app.connect("source-read", rstjinja)
     app.connect("autodoc-process-docstring", remove_flags_docstring)
@@ -754,3 +765,7 @@ def setup(app):
     app.add_autodocumenter(AccessorMethodDocumenter)
     app.add_autodocumenter(AccessorCallableDocumenter)
     app.add_directive("autosummary", PandasAutosummary)
+
+    if os.environ.get("SPHINX_SKIP_IPYTHON"):
+        # override the directive
+        app.add_directive("ipython", SkipIPython)

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -595,6 +595,9 @@ reducing the turn-around time for checking your changes.
     python make.py clean
     python make.py --no-api
 
+    # skip executing the code blocks
+    python make.py --no-ipython
+
     # compile the docs with only a single section, relative to the "source" folder.
     # For example, compiling only this guide (doc/source/development/contributing.rst)
     python make.py clean


### PR DESCRIPTION
Came up as an idea at the documentation meeting (https://github.com/pandas-dev/pandas/issues/39183). This should make documentation builds faster for people who aren't working on the code samples.

```
$ time python make.py --single getting_started/comparison/comparison_with_spreadsheets.rst
…
real    0m22.119s
user    0m13.745s
sys     0m1.700s
$ time python make.py --no-ipython --single getting_started/comparison/comparison_with_spreadsheets.rst
…
real    0m17.481s
user    0m11.750s
sys     0m1.521s
```

Very open to alternatives names to `--no-ipython`.

- [ ] ~~closes #xxxx~~
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] ~~whatsnew entry~~
