### PR TITLE
CI: parallelize the documentation build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,9 +114,11 @@ jobs:
         source activate pandas-dev
         python web/pandas_web.py web/pandas --target-path=web/build
     - name: Build documentation
+      # num-jobs corresponds to number of CPUs in runner
+      # https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources
       run: |
         source activate pandas-dev
-        doc/make.py --warnings-are-errors | tee sphinx.log ; exit ${PIPESTATUS[0]}
+        doc/make.py --warnings-are-errors --num-jobs 2 | tee sphinx.log ; exit ${PIPESTATUS[0]}
 
     # This can be removed when the ipython directive fails when there are errors,
     # including the `tee sphinx.log` in te previous step (https://github.com/ipython/ipython/issues/11547)


### PR DESCRIPTION
Testing if this makes a difference in the build time, relative to `auto` (https://github.com/pandas-dev/pandas/pull/39364). 

- [ ] ~~closes #xxxx~~
- [ ] tests ~~added /~~ passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] ~~whatsnew entry~~
