### PR TITLE
BUG: Slicing DatetimeIndex with strings containing microseconds raising KeyError

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -288,6 +288,7 @@ Indexing
 - Bug in :meth:`DataFrame.loc.__setitem__` raising ValueError when expanding unique column for :class:`DataFrame` with duplicate columns (:issue:`38521`)
 - Bug in :meth:`DataFrame.iloc.__setitem__` and :meth:`DataFrame.loc.__setitem__` with mixed dtypes when setting with a dictionary value (:issue:`38335`)
 - Bug in :meth:`DataFrame.loc` dropping levels of :class:`MultiIndex` when :class:`DataFrame` used as input has only one row (:issue:`10521`)
+- Bug in :meth:`DataFrame.__getitem__` and :meth:`Series.__getitem__` always raising ``KeyError`` when slicing with existing strings an :class:`Index` with milliseconds (:issue:`33589`)
 - Bug in setting ``timedelta64`` values into numeric :class:`Series` failing to cast to object dtype (:issue:`39086`)
 - Bug in setting :class:`Interval` values into a :class:`Series` or :class:`DataFrame` with mismatched :class:`IntervalDtype` incorrectly casting the new values to the existing dtype (:issue:`39120`)
 - Bug in incorrectly raising in :meth:`Index.insert`, when setting a new column that cannot be held in the existing ``frame.columns``, or in :meth:`Series.reset_index` or :meth:`DataFrame.reset_index` instead of casting to a compatible dtype (:issue:`39068`)

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -565,6 +565,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
             "second",
             "minute",
             "second",
+            "millisecond",
             "microsecond",
         }
         if reso.attrname not in valid_resos:

--- a/pandas/tests/indexing/test_datetime.py
+++ b/pandas/tests/indexing/test_datetime.py
@@ -231,3 +231,24 @@ class TestDatetimeIndex:
             dtype=object,
         )
         tm.assert_frame_equal(result, expected)
+
+    def test_getitem_millisecond_resolution(self, frame_or_series):
+        # GH#33589
+        obj = frame_or_series(
+            [1, 2, 3, 4],
+            index=[
+                Timestamp("2017-10-25T16:25:04.151"),
+                Timestamp("2017-10-25T16:25:04.252"),
+                Timestamp("2017-10-25T16:50:05.237"),
+                Timestamp("2017-10-25T16:50:05.238"),
+            ],
+        )
+        result = obj["2017-10-25T16:25:04.252":"2017-10-25T16:50:05.237"]
+        expected = frame_or_series(
+            [2, 3],
+            index=[
+                Timestamp("2017-10-25T16:25:04.252"),
+                Timestamp("2017-10-25T16:50:05.237"),
+            ],
+        )
+        tm.assert_equal(result, expected)


### PR DESCRIPTION
- [x] closes #33589
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

Is there a reason not supporting milliseconds resolution when supporting microseconds?