### PR TITLE
REF: move PandasDtype to dtypes.dtypes

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -47,6 +47,7 @@ from pandas.core.dtypes.common import (
     needs_i8_conversion,
     pandas_dtype,
 )
+from pandas.core.dtypes.dtypes import PandasDtype
 from pandas.core.dtypes.generic import (
     ABCDatetimeArray,
     ABCExtensionArray,
@@ -1929,7 +1930,6 @@ def diff(arr, n: int, axis: int = 0, stacklevel=3):
     -------
     shifted
     """
-    from pandas.core.arrays import PandasDtype
 
     n = int(n)
     na = np.nan
@@ -1942,7 +1942,7 @@ def diff(arr, n: int, axis: int = 0, stacklevel=3):
 
     if isinstance(dtype, PandasDtype):
         # PandasArray cannot necessarily hold shifted versions of itself.
-        arr = np.asarray(arr)
+        arr = arr.to_numpy()
         dtype = arr.dtype
 
     if is_extension_array_dtype(dtype):

--- a/pandas/core/arrays/__init__.py
+++ b/pandas/core/arrays/__init__.py
@@ -10,7 +10,7 @@ from pandas.core.arrays.floating import FloatingArray
 from pandas.core.arrays.integer import IntegerArray
 from pandas.core.arrays.interval import IntervalArray
 from pandas.core.arrays.masked import BaseMaskedArray
-from pandas.core.arrays.numpy_ import PandasArray, PandasDtype
+from pandas.core.arrays.numpy_ import PandasArray
 from pandas.core.arrays.period import PeriodArray, period_array
 from pandas.core.arrays.sparse import SparseArray
 from pandas.core.arrays.string_ import StringArray
@@ -28,7 +28,6 @@ __all__ = [
     "IntegerArray",
     "IntervalArray",
     "PandasArray",
-    "PandasDtype",
     "PeriodArray",
     "period_array",
     "SparseArray",

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import numbers
-from typing import Optional, Tuple, Type, Union
+from typing import Optional, Tuple, Union
 
 import numpy as np
 from numpy.lib.mixins import NDArrayOperatorsMixin
@@ -10,108 +10,13 @@ from pandas._libs import lib
 from pandas._typing import Dtype, NpDtype, Scalar
 from pandas.compat.numpy import function as nv
 
-from pandas.core.dtypes.dtypes import ExtensionDtype
+from pandas.core.dtypes.dtypes import PandasDtype
 from pandas.core.dtypes.missing import isna
 
 from pandas.core import nanops, ops
 from pandas.core.arraylike import OpsMixin
 from pandas.core.arrays._mixins import NDArrayBackedExtensionArray
 from pandas.core.strings.object_array import ObjectStringArrayMixin
-
-
-class PandasDtype(ExtensionDtype):
-    """
-    A Pandas ExtensionDtype for NumPy dtypes.
-
-    .. versionadded:: 0.24.0
-
-    This is mostly for internal compatibility, and is not especially
-    useful on its own.
-
-    Parameters
-    ----------
-    dtype : object
-        Object to be converted to a NumPy data type object.
-
-    See Also
-    --------
-    numpy.dtype
-    """
-
-    _metadata = ("_dtype",)
-
-    def __init__(self, dtype: Optional[NpDtype]):
-        self._dtype = np.dtype(dtype)
-
-    def __repr__(self) -> str:
-        return f"PandasDtype({repr(self.name)})"
-
-    @property
-    def numpy_dtype(self) -> np.dtype:
-        """
-        The NumPy dtype this PandasDtype wraps.
-        """
-        return self._dtype
-
-    @property
-    def name(self) -> str:
-        """
-        A bit-width name for this data-type.
-        """
-        return self._dtype.name
-
-    @property
-    def type(self) -> Type[np.generic]:
-        """
-        The type object used to instantiate a scalar of this NumPy data-type.
-        """
-        return self._dtype.type
-
-    @property
-    def _is_numeric(self) -> bool:
-        # exclude object, str, unicode, void.
-        return self.kind in set("biufc")
-
-    @property
-    def _is_boolean(self) -> bool:
-        return self.kind == "b"
-
-    @classmethod
-    def construct_from_string(cls, string: str) -> PandasDtype:
-        try:
-            dtype = np.dtype(string)
-        except TypeError as err:
-            if not isinstance(string, str):
-                msg = f"'construct_from_string' expects a string, got {type(string)}"
-            else:
-                msg = f"Cannot construct a 'PandasDtype' from '{string}'"
-            raise TypeError(msg) from err
-        return cls(dtype)
-
-    @classmethod
-    def construct_array_type(cls) -> Type[PandasArray]:
-        """
-        Return the array type associated with this dtype.
-
-        Returns
-        -------
-        type
-        """
-        return PandasArray
-
-    @property
-    def kind(self) -> str:
-        """
-        A character code (one of 'biufcmMOSUV') identifying the general kind of data.
-        """
-        return self._dtype.kind
-
-    @property
-    def itemsize(self) -> int:
-        """
-        The element size of this data-type object.
-        """
-        return self._dtype.itemsize
 
 
 class PandasArray(

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -18,12 +18,12 @@ from pandas.core.dtypes.common import (
     is_extension_array_dtype,
     is_numeric_dtype,
 )
-from pandas.core.dtypes.dtypes import ExtensionDtype
+from pandas.core.dtypes.dtypes import ExtensionDtype, PandasDtype
 from pandas.core.dtypes.generic import ABCDataFrame, ABCSeries
 from pandas.core.dtypes.missing import isna
 
 import pandas.core.algorithms as algos
-from pandas.core.arrays import ExtensionArray, PandasDtype
+from pandas.core.arrays import ExtensionArray
 from pandas.core.arrays.sparse import SparseDtype
 from pandas.core.construction import extract_array
 from pandas.core.indexers import maybe_convert_indices

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -50,7 +50,7 @@ from pandas.core.dtypes.common import (
     is_sparse,
     pandas_dtype,
 )
-from pandas.core.dtypes.dtypes import CategoricalDtype, ExtensionDtype
+from pandas.core.dtypes.dtypes import CategoricalDtype, ExtensionDtype, PandasDtype
 from pandas.core.dtypes.generic import ABCDataFrame, ABCIndex, ABCPandasArray, ABCSeries
 from pandas.core.dtypes.missing import isna
 
@@ -67,7 +67,6 @@ from pandas.core.arrays import (
     DatetimeArray,
     ExtensionArray,
     PandasArray,
-    PandasDtype,
     TimedeltaArray,
 )
 from pandas.core.base import PandasObject

--- a/pandas/tests/arrays/test_numpy.py
+++ b/pandas/tests/arrays/test_numpy.py
@@ -5,10 +5,11 @@ the interface tests.
 import numpy as np
 import pytest
 
+from pandas.core.dtypes.dtypes import PandasDtype
+
 import pandas as pd
 import pandas._testing as tm
 from pandas.arrays import PandasArray
-from pandas.core.arrays.numpy_ import PandasDtype
 
 
 @pytest.fixture(
@@ -84,6 +85,13 @@ def test_constructor_from_string():
     result = PandasDtype.construct_from_string("int64")
     expected = PandasDtype(np.dtype("int64"))
     assert result == expected
+
+
+def test_dtype_univalent(any_numpy_dtype):
+    dtype = PandasDtype(any_numpy_dtype)
+
+    result = PandasDtype(dtype)
+    assert result == dtype
 
 
 # ----------------------------------------------------------------------------

--- a/pandas/tests/extension/test_numpy.py
+++ b/pandas/tests/extension/test_numpy.py
@@ -313,6 +313,10 @@ class TestArithmetics(BaseNumPyTests, base.BaseArithmeticOpsTests):
     def test_arith_series_with_array(self, data, all_arithmetic_operators):
         super().test_arith_series_with_array(data, all_arithmetic_operators)
 
+    @skip_nested
+    def test_arith_frame_with_scalar(self, data, all_arithmetic_operators):
+        super().test_arith_frame_with_scalar(data, all_arithmetic_operators)
+
 
 class TestPrinting(BaseNumPyTests, base.BasePrintingTests):
     pass

--- a/pandas/tests/extension/test_numpy.py
+++ b/pandas/tests/extension/test_numpy.py
@@ -16,11 +16,11 @@ be added to the array-specific tests in `pandas/tests/arrays/`.
 import numpy as np
 import pytest
 
-from pandas.core.dtypes.dtypes import ExtensionDtype
+from pandas.core.dtypes.dtypes import ExtensionDtype, PandasDtype
 
 import pandas as pd
 import pandas._testing as tm
-from pandas.core.arrays.numpy_ import PandasArray, PandasDtype
+from pandas.core.arrays.numpy_ import PandasArray
 
 from . import base
 


### PR DESCRIPTION
This will allow us to import it in e.g. core.construction without a circular import