### PR TITLE
TST: remove test_error

### DIFF
--- a/pandas/tests/extension/base/ops.py
+++ b/pandas/tests/extension/base/ops.py
@@ -111,12 +111,6 @@ class BaseArithmeticOpsTests(BaseOpsUtil):
         expected = pd.Series(data + data)
         self.assert_series_equal(result, expected)
 
-    def test_error(self, data, all_arithmetic_operators):
-        # invalid ops
-        op_name = all_arithmetic_operators
-        with pytest.raises(AttributeError):
-            getattr(data, op_name)
-
     @pytest.mark.parametrize("box", [pd.Series, pd.DataFrame])
     def test_direct_arith_with_ndframe_returns_not_implemented(self, data, box):
         # EAs should return NotImplemented for ops with Series/DataFrame

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -305,9 +305,6 @@ class TestArithmeticOps(BaseDecimal, base.BaseArithmeticOpsTests):
         # We implement divmod
         super()._check_divmod_op(s, op, other, exc=None)
 
-    def test_error(self):
-        pass
-
 
 class TestComparisonOps(BaseDecimal, base.BaseComparisonOpsTests):
     def check_opname(self, s, op_name, other, exc=None):

--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -319,9 +319,6 @@ class TestGroupby(BaseJSON, base.BaseGroupbyTests):
 
 
 class TestArithmeticOps(BaseJSON, base.BaseArithmeticOpsTests):
-    def test_error(self, data, all_arithmetic_operators):
-        pass
-
     def test_arith_frame_with_scalar(self, data, all_arithmetic_operators, request):
         if len(data[0]) != 1:
             mark = pytest.mark.xfail(reason="raises in coercing to Series")

--- a/pandas/tests/extension/test_boolean.py
+++ b/pandas/tests/extension/test_boolean.py
@@ -143,11 +143,6 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
         # override to not raise an error
         super()._check_divmod_op(s, op, other, None)
 
-    @pytest.mark.skip(reason="BooleanArray does not error on ops")
-    def test_error(self, data, all_arithmetic_operators):
-        # other specific errors tested in the boolean array specific tests
-        pass
-
     def test_arith_frame_with_scalar(self, data, all_arithmetic_operators, request):
         # frame & scalar
         op_name = all_arithmetic_operators

--- a/pandas/tests/extension/test_datetime.py
+++ b/pandas/tests/extension/test_datetime.py
@@ -158,9 +158,6 @@ class TestArithmeticOps(BaseDatetimeTests, base.BaseArithmeticOpsTests):
             # ... but not the rest.
             super().test_arith_series_with_scalar(data, all_arithmetic_operators)
 
-    def test_error(self, data, all_arithmetic_operators):
-        pass
-
     def test_divmod_series_array(self):
         # GH 23287
         # skipping because it is not implemented

--- a/pandas/tests/extension/test_extension.py
+++ b/pandas/tests/extension/test_extension.py
@@ -1,0 +1,26 @@
+"""
+Tests for behavior if an author does *not* implement EA methods.
+"""
+import numpy as np
+import pytest
+
+from pandas.core.arrays import ExtensionArray
+
+
+class MyEA(ExtensionArray):
+    def __init__(self, values):
+        self._values = values
+
+
+@pytest.fixture
+def data():
+    arr = np.arange(10)
+    return MyEA(arr)
+
+
+class TestExtensionArray:
+    def test_errors(self, data, all_arithmetic_operators):
+        # invalid ops
+        op_name = all_arithmetic_operators
+        with pytest.raises(AttributeError):
+            getattr(data, op_name)

--- a/pandas/tests/extension/test_floating.py
+++ b/pandas/tests/extension/test_floating.py
@@ -123,11 +123,6 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
     def _check_divmod_op(self, s, op, other, exc=None):
         super()._check_divmod_op(s, op, other, None)
 
-    @pytest.mark.skip(reason="intNA does not error on ops")
-    def test_error(self, data, all_arithmetic_operators):
-        # other specific errors tested in the float array specific tests
-        pass
-
 
 class TestComparisonOps(base.BaseComparisonOpsTests):
     def _check_op(self, s, op, other, op_name, exc=NotImplementedError):

--- a/pandas/tests/extension/test_integer.py
+++ b/pandas/tests/extension/test_integer.py
@@ -153,11 +153,6 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
     def _check_divmod_op(self, s, op, other, exc=None):
         super()._check_divmod_op(s, op, other, None)
 
-    @pytest.mark.skip(reason="intNA does not error on ops")
-    def test_error(self, data, all_arithmetic_operators):
-        # other specific errors tested in the integer array specific tests
-        pass
-
 
 class TestComparisonOps(base.BaseComparisonOpsTests):
     def _check_op(self, s, op, other, op_name, exc=NotImplementedError):

--- a/pandas/tests/extension/test_numpy.py
+++ b/pandas/tests/extension/test_numpy.py
@@ -313,6 +313,10 @@ class TestArithmetics(BaseNumPyTests, base.BaseArithmeticOpsTests):
     def test_arith_series_with_array(self, data, all_arithmetic_operators):
         super().test_arith_series_with_array(data, all_arithmetic_operators)
 
+    @skip_nested
+    def test_arith_frame_with_scalar(self, data, all_arithmetic_operators):
+        super().test_arith_frame_with_scalar(data, all_arithmetic_operators)
+
 
 class TestPrinting(BaseNumPyTests, base.BasePrintingTests):
     pass

--- a/pandas/tests/extension/test_numpy.py
+++ b/pandas/tests/extension/test_numpy.py
@@ -301,10 +301,6 @@ class TestArithmetics(BaseNumPyTests, base.BaseArithmeticOpsTests):
         ser = pd.Series(data)
         self._check_divmod_op(ser, divmod, data, exc=None)
 
-    @pytest.mark.skip("We implement ops")
-    def test_error(self, data, all_arithmetic_operators):
-        pass
-
     @skip_nested
     def test_arith_series_with_scalar(self, data, all_arithmetic_operators):
         super().test_arith_series_with_scalar(data, all_arithmetic_operators)

--- a/pandas/tests/extension/test_period.py
+++ b/pandas/tests/extension/test_period.py
@@ -138,9 +138,6 @@ class TestArithmeticOps(BasePeriodTests, base.BaseArithmeticOpsTests):
         with pytest.raises(TypeError, match=msg):
             s + data
 
-    def test_error(self):
-        pass
-
     @pytest.mark.parametrize("box", [pd.Series, pd.DataFrame])
     def test_direct_arith_with_ndframe_returns_not_implemented(self, data, box):
         # Override to use __sub__ instead of __add__

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -393,9 +393,6 @@ class TestArithmeticOps(BaseSparseTests, base.BaseArithmeticOpsTests):
             # general, so we can't make the expected. This is tested elsewhere
             raise pytest.skip("Incorrected expected from Series.combine")
 
-    def test_error(self, data, all_arithmetic_operators):
-        pass
-
     def test_arith_series_with_scalar(self, data, all_arithmetic_operators):
         self._skip_if_different_combine(data)
         super().test_arith_series_with_scalar(data, all_arithmetic_operators)


### PR DESCRIPTION
It makes no sense to me that we'd test unwanted behavior by default and then override it for working arrays.