### PR TITLE
CI: save site+docs builds as artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,15 @@ jobs:
       run: rsync -az --delete doc/build/html/ docs@${{ secrets.server_ip }}:/usr/share/nginx/pandas/pandas-docs/dev
       if: github.event_name == 'push'
 
+    - name: Move docs into site directory
+      run: mv doc/build/html web/build/docs
+    - name: Save website as an artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: website
+        path: web/build
+        retention-days: 14
+
   data_manager:
     name: Test experimental data manager
     runs-on: ubuntu-latest

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -629,6 +629,17 @@ the documentation are also built by Travis-CI. These docs are then hosted `here
 <https://pandas.pydata.org/docs/dev/>`__, see also
 the :ref:`Continuous Integration <contributing.ci>` section.
 
+Previewing changes
+------------------
+
+Once, the pull request is submitted, GitHub Actions will automatically build the
+documentation. To view the built site:
+
+#. Wait for the ``CI / Web and docs`` check to complete.
+#. Click ``Details`` next to it.
+#. From the ``Artifacts`` drop-down, click ``docs`` or ``website`` to download
+   the site as a ZIP file.
+
 .. _contributing.code:
 
 Contributing to the code base


### PR DESCRIPTION
 Makes the downloadable for previewing locally. Not as good as having a URL to preview it, but better than nothing.

- [x] closes https://github.com/pandas-dev/pandas/issues/17921
- [ ] tests ~~added /~~ passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] ~~whatsnew entry~~