### PR TITLE
CI: split benchmarks from other checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
+
     - name: Checkout
       uses: actions/checkout@v1
 
@@ -67,6 +68,34 @@ jobs:
     - name: Testing docstring validation script
       run: pytest --capture=no --strict-markers scripts
       if: always()
+
+  benchmarks:
+    name: Benchmarks
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Cache conda
+      uses: actions/cache@v2
+      with:
+        path: ~/conda_pkgs_dir
+        key: ${{ runner.os }}-conda-${{ hashFiles('${{ env.ENV_FILE }}') }}
+
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        activate-environment: pandas-dev
+        channel-priority: strict
+        environment-file: ${{ env.ENV_FILE }}
+        use-only-tar-bz2: true
+
+    - name: Build Pandas
+      uses: ./.github/actions/build_pandas
 
     - name: Running benchmarks
       run: |


### PR DESCRIPTION
That job was the longest-running, so this should parallelize the various code checks with the benchmarks to get done in less wall clock time.

This pull request builds on https://github.com/pandas-dev/pandas/pull/39745.

cc @fangchenli

- [ ] ~~closes #xxxx~~
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] ~~whatsnew entry~~
