### PR TITLE
BUG: re-render CSS with `styler.apply` and `applymap` non-cleared ` _todo`

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -381,7 +381,7 @@ ExtensionArray
 Other
 ^^^^^
 - Bug in :class:`Index` constructor sometimes silently ignorning a specified ``dtype`` (:issue:`38879`)
--
+- Bug in :class:`Styler` which caused CSS to duplicate on multiple renders. (:issue:`39395`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -830,6 +830,7 @@ class Styler:
         r = self
         for func, args, kwargs in self._todo:
             r = func(self)(*args, **kwargs)
+        self._todo = []
         return r
 
     def _apply(
@@ -1454,9 +1455,8 @@ class Styler:
         >>> df.style.set_properties(color="white", align="right")
         >>> df.style.set_properties(**{'background-color': 'yellow'})
         """
-        values = ";".join(f"{p}: {v}" for p, v in kwargs.items())
-        f = lambda x: values
-        return self.applymap(f, subset=subset)
+        values = "".join(f"{p}: {v};" for p, v in kwargs.items())
+        return self.applymap(lambda x: values, subset=subset)
 
     @staticmethod
     def _bar(

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -102,6 +102,7 @@ class TestStyler:
         assert self.styler._todo != s2._todo
 
     def test_clear(self):
+        # updated in GH 39396
         tt = DataFrame({"A": [None, "tt"]})
         css = DataFrame({"A": [None, "cls-a"]})
         s = self.df.style.highlight_max().set_tooltips(tt).set_td_classes(css)
@@ -127,6 +128,15 @@ class TestStyler:
         s = Styler(df, uuid="AB").apply(style)
         s.render()
         # it worked?
+
+    def test_multiple_render(self):
+        # GH 39396
+        s = Styler(self.df, uuid_len=0).applymap(lambda x: "color: red;", subset=["A"])
+        s.render()  # do 2 renders to ensure css styles not duplicated
+        assert (
+            '<style  type="text/css" >\n#T__row0_col0,#T__row1_col0{\n            '
+            "color:  red;\n        }</style>" in s.render()
+        )
 
     def test_render_empty_dfs(self):
         empty_df = DataFrame()

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -105,14 +105,17 @@ class TestStyler:
         tt = DataFrame({"A": [None, "tt"]})
         css = DataFrame({"A": [None, "cls-a"]})
         s = self.df.style.highlight_max().set_tooltips(tt).set_td_classes(css)
+        # _todo, tooltips and cell_context items all affected..
         assert len(s._todo) > 0
         assert s.tooltips
         assert len(s.cell_context) > 0
         s = s._compute()
+        # ctx and _todo items affected
         assert len(s.ctx) > 0
-        assert len(s._todo) == 0
+        assert len(s._todo) == 0  # _todo is emptied after compute.
         s._todo = [1]
         s.clear()
+        # ctx, _todo, tooltips and cell_context items all revert to null state.
         assert len(s.ctx) == 0
         assert len(s._todo) == 0
         assert not s.tooltips

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -102,12 +102,21 @@ class TestStyler:
         assert self.styler._todo != s2._todo
 
     def test_clear(self):
-        s = self.df.style.highlight_max()._compute()
-        assert len(s.ctx) > 0
+        tt = DataFrame({"A": [None, "tt"]})
+        css = DataFrame({"A": [None, "cls-a"]})
+        s = self.df.style.highlight_max().set_tooltips(tt).set_td_classes(css)
         assert len(s._todo) > 0
+        assert s.tooltips
+        assert len(s.cell_context) > 0
+        s = s._compute()
+        assert len(s.ctx) > 0
+        assert len(s._todo) == 0
+        s._todo = [1]
         s.clear()
         assert len(s.ctx) == 0
         assert len(s._todo) == 0
+        assert not s.tooltips
+        assert len(s.cell_context) == 0
 
     def test_render(self):
         df = DataFrame({"A": [0, 1]})

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -106,14 +106,16 @@ class TestStyler:
         tt = DataFrame({"A": [None, "tt"]})
         css = DataFrame({"A": [None, "cls-a"]})
         s = self.df.style.highlight_max().set_tooltips(tt).set_td_classes(css)
-        # _todo, tooltips and cell_context items all affected..
+        # _todo, tooltips and cell_context items added to..
         assert len(s._todo) > 0
         assert s.tooltips
         assert len(s.cell_context) > 0
+
         s = s._compute()
-        # ctx and _todo items affected
+        # ctx and _todo items affected when a render takes place
         assert len(s.ctx) > 0
         assert len(s._todo) == 0  # _todo is emptied after compute.
+
         s._todo = [1]
         s.clear()
         # ctx, _todo, tooltips and cell_context items all revert to null state.


### PR DESCRIPTION
- [ x] closes #39395
- [ x] tests added / passed
- [ x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
