### PR TITLE
Clean up DataFrame.setitem behavior for duplicate columns

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -128,6 +128,7 @@ from pandas.core.arrays import ExtensionArray
 from pandas.core.arrays.sparse import SparseFrameAccessor
 from pandas.core.construction import extract_array, sanitize_masked_array
 from pandas.core.generic import NDFrame, _shared_docs
+from pandas.core.indexers import check_key_length
 from pandas.core.indexes import base as ibase
 from pandas.core.indexes.api import (
     DatetimeIndex,
@@ -3211,14 +3212,6 @@ class DataFrame(NDFrame, OpsMixin):
         self._check_setitem_copy()
         self.iloc[key] = value
 
-    def _check_key_length(self, key, value: DataFrame):
-        if self.columns.is_unique:
-            if len(value.columns) != len(key):
-                raise ValueError("Columns must be same length as key")
-        else:
-            if len(self.columns.get_indexer_non_unique(key)[0]) != len(value.columns):
-                raise ValueError("Columns must be same length as key")
-
     def _setitem_array(self, key, value):
         # also raises Exception if object array with NA values
         if com.is_bool_indexer(key):
@@ -3232,7 +3225,7 @@ class DataFrame(NDFrame, OpsMixin):
             self.iloc[indexer] = value
         else:
             if isinstance(value, DataFrame):
-                self._check_key_length(key, value)
+                check_key_length(self.columns, key, value)
                 for k1, k2 in zip(key, value.columns):
                     self[k1] = value[k2]
             else:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3211,6 +3211,14 @@ class DataFrame(NDFrame, OpsMixin):
         self._check_setitem_copy()
         self.iloc[key] = value
 
+    def _check_key_length(self, key, value: DataFrame):
+        if self.columns.is_unique:
+            if len(value.columns) != len(key):
+                raise ValueError("Columns must be same length as key")
+        else:
+            if len(self.columns.get_indexer_non_unique(key)[0]) != len(value.columns):
+                raise ValueError("Columns must be same length as key")
+
     def _setitem_array(self, key, value):
         # also raises Exception if object array with NA values
         if com.is_bool_indexer(key):
@@ -3223,9 +3231,8 @@ class DataFrame(NDFrame, OpsMixin):
             self._check_setitem_copy()
             self.iloc[indexer] = value
         else:
-            if isinstance(value, DataFrame) and self.columns.is_unique:
-                if len(value.columns) != len(key):
-                    raise ValueError("Columns must be same length as key")
+            if isinstance(value, DataFrame):
+                self._check_key_length(key, value)
                 for k1, k2 in zip(key, value.columns):
                     self[k1] = value[k2]
             else:

--- a/pandas/core/indexers.py
+++ b/pandas/core/indexers.py
@@ -383,9 +383,9 @@ def check_key_length(columns, key, value):
 
     Parameters
     ----------
-    columns: Index The columns of the DataFrame to index.
-    key: A list-like of keys to index with.
-    value: The value to set for the keys.
+    columns : Index The columns of the DataFrame to index.
+    key : A list-like of keys to index with.
+    value : The value to set for the keys.
 
     """
     if columns.is_unique:

--- a/pandas/core/indexers.py
+++ b/pandas/core/indexers.py
@@ -1,6 +1,7 @@
 """
 Low-dependency indexing utilities.
 """
+from typing import TYPE_CHECKING
 import warnings
 
 import numpy as np
@@ -16,6 +17,9 @@ from pandas.core.dtypes.common import (
     is_list_like,
 )
 from pandas.core.dtypes.generic import ABCIndex, ABCSeries
+
+if TYPE_CHECKING:
+    from pandas.core.frame import DataFrame
 
 # -----------------------------------------------------------
 # Indexer Identification
@@ -374,6 +378,25 @@ def unpack_1tuple(tup):
 
         return tup[0]
     return tup
+
+
+def check_key_length(columns, key, value: DataFrame):
+    """Checks if a key used as indexer has the same length as the columns it is
+    associated with.
+
+    Parameters
+    ----------
+    columns: The columns of the DataFrame to index.
+    key: A list-like of keys to index with.
+    value: The value to set for the keys.
+
+    """
+    if columns.is_unique:
+        if len(value.columns) != len(key):
+            raise ValueError("Columns must be same length as key")
+    else:
+        if len(columns.get_indexer_non_unique(key)[0]) != len(value.columns):
+            raise ValueError("Columns must be same length as key")
 
 
 # -----------------------------------------------------------

--- a/pandas/core/indexers.py
+++ b/pandas/core/indexers.py
@@ -1,7 +1,6 @@
 """
 Low-dependency indexing utilities.
 """
-from typing import TYPE_CHECKING
 import warnings
 
 import numpy as np
@@ -17,9 +16,6 @@ from pandas.core.dtypes.common import (
     is_list_like,
 )
 from pandas.core.dtypes.generic import ABCIndex, ABCSeries
-
-if TYPE_CHECKING:
-    from pandas.core.frame import DataFrame
 
 # -----------------------------------------------------------
 # Indexer Identification
@@ -380,7 +376,7 @@ def unpack_1tuple(tup):
     return tup
 
 
-def check_key_length(columns, key, value: DataFrame):
+def check_key_length(columns, key, value):
     """Checks if a key used as indexer has the same length as the columns it is
     associated with.
 

--- a/pandas/core/indexers.py
+++ b/pandas/core/indexers.py
@@ -377,12 +377,13 @@ def unpack_1tuple(tup):
 
 
 def check_key_length(columns, key, value):
-    """Checks if a key used as indexer has the same length as the columns it is
+    """
+    Checks if a key used as indexer has the same length as the columns it is
     associated with.
 
     Parameters
     ----------
-    columns: The columns of the DataFrame to index.
+    columns: Index The columns of the DataFrame to index.
     key: A list-like of keys to index with.
     value: The value to set for the keys.
 
@@ -391,6 +392,7 @@ def check_key_length(columns, key, value):
         if len(value.columns) != len(key):
             raise ValueError("Columns must be same length as key")
     else:
+        # Missing keys in columns are represented as -1
         if len(columns.get_indexer_non_unique(key)[0]) != len(value.columns):
             raise ValueError("Columns must be same length as key")
 

--- a/pandas/core/indexers.py
+++ b/pandas/core/indexers.py
@@ -1,6 +1,9 @@
 """
 Low-dependency indexing utilities.
 """
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 import warnings
 
 import numpy as np
@@ -16,6 +19,10 @@ from pandas.core.dtypes.common import (
     is_list_like,
 )
 from pandas.core.dtypes.generic import ABCIndex, ABCSeries
+
+if TYPE_CHECKING:
+    from pandas.core.frame import DataFrame
+    from pandas.core.indexes.base import Index
 
 # -----------------------------------------------------------
 # Indexer Identification
@@ -376,7 +383,7 @@ def unpack_1tuple(tup):
     return tup
 
 
-def check_key_length(columns, key, value):
+def check_key_length(columns: Index, key, value: DataFrame):
     """
     Checks if a key used as indexer has the same length as the columns it is
     associated with.

--- a/pandas/core/indexers.py
+++ b/pandas/core/indexers.py
@@ -385,8 +385,13 @@ def check_key_length(columns, key, value):
     ----------
     columns : Index The columns of the DataFrame to index.
     key : A list-like of keys to index with.
-    value : The value to set for the keys.
+    value : DataFrame The value to set for the keys.
 
+    Raises
+    ------
+    ValueError: If the length of key is not equal to the number of columns in value
+                or if the number of columns referenced by key is not equal to number
+                of columns.
     """
     if columns.is_unique:
         if len(value.columns) != len(key):

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -384,7 +384,7 @@ class TestDataFrameSetItem:
         tm.assert_frame_equal(df, expected)
 
     def test_setitem_listlike_indexer_duplicate_columns_not_equal_length(self):
-        # GH#
+        # GH#39403
         df = DataFrame([[1, 2, 3]], columns=["a", "b", "b"])
         rhs = DataFrame([[10, 11]], columns=["a", "b"])
         msg = "Columns must be same length as key"

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -383,6 +383,10 @@ class TestDataFrameSetItem:
         expected = DataFrame([[10, 11, 12]], columns=["a", "b", "b"])
         tm.assert_frame_equal(df, expected)
 
+        df[["c", "b"]] = rhs
+        expected = DataFrame([[10, 11, 12, 10]], columns=["a", "b", "b", "c"])
+        tm.assert_frame_equal(df, expected)
+
     def test_setitem_listlike_indexer_duplicate_columns_not_equal_length(self):
         # GH#39403
         df = DataFrame([[1, 2, 3]], columns=["a", "b", "b"])

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -378,10 +378,18 @@ class TestDataFrameSetItem:
     def test_setitem_listlike_indexer_duplicate_columns(self):
         # GH#38604
         df = DataFrame([[1, 2, 3]], columns=["a", "b", "b"])
-        rhs = DataFrame([[10, 11, 12]], columns=["d", "e", "c"])
+        rhs = DataFrame([[10, 11, 12]], columns=["a", "b", "b"])
         df[["a", "b"]] = rhs
         expected = DataFrame([[10, 11, 12]], columns=["a", "b", "b"])
         tm.assert_frame_equal(df, expected)
+
+    def test_setitem_listlike_indexer_duplicate_columns_not_equal_length(self):
+        # GH#
+        df = DataFrame([[1, 2, 3]], columns=["a", "b", "b"])
+        rhs = DataFrame([[10, 11]], columns=["a", "b"])
+        msg = "Columns must be same length as key"
+        with pytest.raises(ValueError, match=msg):
+            df[["a", "b"]] = rhs
 
 
 class TestDataFrameSetItemWithExpansion:


### PR DESCRIPTION
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

cc  @jbrockmendel This cleans the edgy behavior up for duplicate columns.

Previous test was wrong.