### PR TITLE
update link to config.py in options user guide

### DIFF
--- a/doc/source/user_guide/options.rst
+++ b/doc/source/user_guide/options.rst
@@ -31,7 +31,7 @@ namespace:
 * :func:`~pandas.option_context` - execute a codeblock with a set of options
   that revert to prior settings after execution.
 
-**Note:** Developers can check out `pandas/core/config.py <https://github.com/pandas-dev/pandas/blob/master/pandas/core/config_init.py>`_ for more information.
+**Note:** Developers can check out `pandas/core/config_init.py <https://github.com/pandas-dev/pandas/blob/master/pandas/core/config_init.py>`_ for more information.
 
 All of the functions above accept a regexp pattern (``re.search`` style) as an argument,
 and so passing in a substring will work - as long as it is unambiguous:

--- a/doc/source/user_guide/options.rst
+++ b/doc/source/user_guide/options.rst
@@ -31,7 +31,7 @@ namespace:
 * :func:`~pandas.option_context` - execute a codeblock with a set of options
   that revert to prior settings after execution.
 
-**Note:** Developers can check out `pandas/core/config.py <https://github.com/pandas-dev/pandas/blob/master/pandas/core/config.py>`_ for more information.
+**Note:** Developers can check out `pandas/core/config.py <https://github.com/pandas-dev/pandas/blob/master/pandas/core/config_init.py>`_ for more information.
 
 All of the functions above accept a regexp pattern (``re.search`` style) as an argument,
 and so passing in a substring will work - as long as it is unambiguous:


### PR DESCRIPTION
- `config.py` now `config_core.py` ?!
- maybe also [pandas/_config/config.py](https://github.com/pandas-dev/pandas/blob/master/pandas/_config/config.py)

- link in [`user_guide/options` ](https://pandas.pydata.org/pandas-docs/stable/user_guide/options.html) changed. 