### PR TITLE
BUG: Assert_frame_equal always raising AssertionError when comparing extension dtypes

### DIFF
--- a/doc/source/whatsnew/v1.2.2.rst
+++ b/doc/source/whatsnew/v1.2.2.rst
@@ -14,7 +14,7 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
--
+- Fixed regression in :func:`pandas.testing.assert_series_equal` and :func:`pandas.testing.assert_frame_equal` always raising ``AssertionError`` when comparing extension dtypes (:issue:`39410`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -968,14 +968,24 @@ def assert_series_equal(
             assert_attr_equal("dtype", left, right, obj=f"Attributes of {obj}")
 
     if check_exact and is_numeric_dtype(left.dtype) and is_numeric_dtype(right.dtype):
+        left_values = left._values
+        right_values = right._values
         # Only check exact if dtype is numeric
-        assert_numpy_array_equal(
-            left._values,
-            right._values,
-            check_dtype=check_dtype,
-            obj=str(obj),
-            index_values=np.asarray(left.index),
-        )
+        if is_extension_array_dtype(left_values):
+            assert_extension_array_equal(
+                left_values,
+                right_values,
+                check_dtype=check_dtype,
+                index_values=np.asarray(left.index),
+            )
+        else:
+            assert_numpy_array_equal(
+                left_values,
+                right_values,
+                check_dtype=check_dtype,
+                obj=str(obj),
+                index_values=np.asarray(left.index),
+            )
     elif check_datetimelike_compat and (
         needs_i8_conversion(left.dtype) or needs_i8_conversion(right.dtype)
     ):

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -971,7 +971,9 @@ def assert_series_equal(
         left_values = left._values
         right_values = right._values
         # Only check exact if dtype is numeric
-        if is_extension_array_dtype(left_values):
+        if is_extension_array_dtype(left_values) and is_extension_array_dtype(
+            right_values
+        ):
             assert_extension_array_equal(
                 left_values,
                 right_values,

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -305,3 +305,19 @@ def test_assert_frame_equal_columns_mixed_dtype():
     # GH#39168
     df = DataFrame([[0, 1, 2]], columns=["foo", "bar", 42], index=[1, "test", 2])
     tm.assert_frame_equal(df, df, check_like=True)
+
+
+def test_frame_equal_extension_dtype(frame_or_series, any_nullable_numeric_dtype):
+    # GH#39410
+    obj = frame_or_series([1, 2], dtype=any_nullable_numeric_dtype)
+    tm.assert_equal(obj, obj, check_exact=True)
+
+
+@pytest.mark.parametrize("indexer", [(0, 1), (1, 0)])
+def test_frame_equal_mixed_dtypes(frame_or_series, any_nullable_numeric_dtype, indexer):
+    dtypes = (any_nullable_numeric_dtype, "int64")
+    obj1 = frame_or_series([1, 2], dtype=dtypes[indexer[0]])
+    obj2 = frame_or_series([1, 2], dtype=dtypes[indexer[1]])
+    msg = r'(Series|DataFrame.iloc\[:, 0\] \(column name="0"\) classes) are different'
+    with pytest.raises(AssertionError, match=msg):
+        tm.assert_equal(obj1, obj2, check_exact=True, check_dtype=False)


### PR DESCRIPTION
- [x] closes #39410
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

