### PR TITLE
REF: dont pass fill_value to algos.take_nd from internals.concat

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1658,8 +1658,25 @@ def take(arr, indices, axis: int = 0, allow_fill: bool = False, fill_value=None)
     return result
 
 
+# TODO: can we de-duplicate with something in dtypes.missing?
+def _get_default_fill_value(dtype, fill_value):
+    if fill_value is lib.no_default:
+        if is_extension_array_dtype(dtype):
+            fill_value = dtype.na_value
+        elif dtype.kind in ["m", "M"]:
+            fill_value = dtype.type("NaT")
+        else:
+            fill_value = np.nan
+    return fill_value
+
+
 def take_nd(
-    arr, indexer, axis: int = 0, out=None, fill_value=np.nan, allow_fill: bool = True
+    arr,
+    indexer,
+    axis: int = 0,
+    out=None,
+    fill_value=lib.no_default,
+    allow_fill: bool = True,
 ):
     """
     Specialized Cython take which sets NaN values in one pass
@@ -1693,6 +1710,8 @@ def take_nd(
         May be the same type as the input, or cast to an ndarray.
     """
     mask_info = None
+
+    fill_value = _get_default_fill_value(arr.dtype, fill_value)
 
     if isinstance(arr, ABCExtensionArray):
         # Check for EA to catch DatetimeArray, TimedeltaArray

--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -322,7 +322,7 @@ class JoinUnit:
 
         else:
             for ax, indexer in self.indexers.items():
-                values = algos.take_nd(values, indexer, axis=ax, fill_value=fill_value)
+                values = algos.take_nd(values, indexer, axis=ax)
 
         return values
 


### PR DESCRIPTION
The dtype-finding code in internals.concat is something else.  Tried untangling it, but now I think we can make it unnecessary altogether.  This is the first step in that process.