### PR TITLE
BUG: accepting ndarray[object] of dt64(nat) in TimedeltaIndex

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -284,7 +284,7 @@ Datetimelike
 Timedelta
 ^^^^^^^^^
 - Bug in constructing :class:`Timedelta` from ``np.timedelta64`` objects with non-nanosecond units that are out of bounds for ``timedelta64[ns]`` (:issue:`38965`)
--
+- Bug in constructing a :class:`TimedeltaIndex` incorrectly accepting ``np.datetime64("NaT")`` objects (:issue:`39462`)
 -
 
 Timezones

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -257,10 +257,6 @@ cdef convert_to_timedelta64(object ts, str unit):
     elif isinstance(ts, _Timedelta):
         # already in the proper format
         ts = np.timedelta64(ts.value, "ns")
-    elif is_datetime64_object(ts):
-        # only accept a NaT here
-        if ts.astype('int64') == NPY_NAT:
-            return np.timedelta64(NPY_NAT)
     elif is_timedelta64_object(ts):
         ts = ensure_td64ns(ts)
     elif is_integer_object(ts):

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -48,6 +48,17 @@ MIXED_INT_DTYPES = [
 
 
 class TestDataFrameConstructors:
+    def test_array_of_dt64_nat_with_td64dtype_raises(self, frame_or_series):
+        # GH#39462
+        nat = np.datetime64("NaT", "ns")
+        arr = np.array([nat], dtype=object)
+        if frame_or_series is DataFrame:
+            arr = arr.reshape(1, 1)
+
+        msg = "Could not convert object to NumPy timedelta"
+        with pytest.raises(ValueError, match=msg):
+            frame_or_series(arr, dtype="m8[ns]")
+
     def test_series_with_name_not_matching_column(self):
         # GH#9232
         x = Series(range(5), name=1)

--- a/pandas/tests/indexes/timedeltas/test_constructors.py
+++ b/pandas/tests/indexes/timedeltas/test_constructors.py
@@ -11,6 +11,7 @@ from pandas.core.arrays.timedeltas import TimedeltaArray, sequence_to_td64ns
 
 class TestTimedeltaIndex:
     def test_array_of_dt64_nat_raises(self):
+        # GH#39462
         nat = np.datetime64("NaT", "ns")
         arr = np.array([nat], dtype=object)
 

--- a/pandas/tests/indexes/timedeltas/test_constructors.py
+++ b/pandas/tests/indexes/timedeltas/test_constructors.py
@@ -6,10 +6,25 @@ import pytest
 import pandas as pd
 from pandas import Timedelta, TimedeltaIndex, timedelta_range, to_timedelta
 import pandas._testing as tm
-from pandas.core.arrays import TimedeltaArray
+from pandas.core.arrays.timedeltas import TimedeltaArray, sequence_to_td64ns
 
 
 class TestTimedeltaIndex:
+    def test_array_of_dt64_nat_raises(self):
+        nat = np.datetime64("NaT", "ns")
+        arr = np.array([nat], dtype=object)
+
+        # TODO: should be TypeError?
+        msg = "Invalid type for timedelta scalar"
+        with pytest.raises(ValueError, match=msg):
+            TimedeltaIndex(arr)
+
+        with pytest.raises(ValueError, match=msg):
+            TimedeltaArray._from_sequence(arr)
+
+        with pytest.raises(ValueError, match=msg):
+            sequence_to_td64ns(arr)
+
     @pytest.mark.parametrize("unit", ["Y", "y", "M"])
     def test_unit_m_y_raises(self, unit):
         msg = "Units 'M', 'Y', and 'y' are no longer supported"


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
