### PR TITLE
ERR: Unify error message for bad excel sheetnames

### DIFF
--- a/doc/source/whatsnew/v1.2.2.rst
+++ b/doc/source/whatsnew/v1.2.2.rst
@@ -26,7 +26,7 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 
--
+- :func:`pandas.read_excel` error message when a specified ``sheetname`` does not exist is now uniform across engines (:issue:`39250`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -55,6 +55,7 @@ Other enhancements
 - :meth:`DataFrame.plot.scatter` can now accept a categorical column as the argument to ``c`` (:issue:`12380`, :issue:`31357`)
 - :meth:`.Styler.set_tooltips` allows on hover tooltips to be added to styled HTML dataframes.
 - :meth:`Series.loc.__getitem__` and :meth:`Series.loc.__setitem__` with :class:`MultiIndex` now raising helpful error message when indexer has too many dimensions (:issue:`35349`)
+- :func:`pandas.read_excel` error message when a specified ``sheetname`` does not exist is now uniform across engines (:issue:`39250`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -55,7 +55,6 @@ Other enhancements
 - :meth:`DataFrame.plot.scatter` can now accept a categorical column as the argument to ``c`` (:issue:`12380`, :issue:`31357`)
 - :meth:`.Styler.set_tooltips` allows on hover tooltips to be added to styled HTML dataframes.
 - :meth:`Series.loc.__getitem__` and :meth:`Series.loc.__setitem__` with :class:`MultiIndex` now raising helpful error message when indexer has too many dimensions (:issue:`35349`)
-- :func:`pandas.read_excel` error message when a specified ``sheetname`` does not exist is now uniform across engines (:issue:`39250`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -434,6 +434,17 @@ class BaseExcelReader(metaclass=abc.ABCMeta):
     def get_sheet_data(self, sheet, convert_float):
         pass
 
+    def raise_if_bad_sheet_by_index(self, index: int) -> None:
+        n_sheets = len(self.sheet_names)
+        if index >= n_sheets:
+            raise ValueError(
+                f"Worksheet index {index} is invalid, {n_sheets} worksheets found"
+            )
+
+    def raise_if_bad_sheet_by_name(self, name: str) -> None:
+        if name not in self.sheet_names:
+            raise ValueError(f"Worksheet named '{name}' not found")
+
     def parse(
         self,
         sheet_name=0,

--- a/pandas/io/excel/_odfreader.py
+++ b/pandas/io/excel/_odfreader.py
@@ -57,12 +57,14 @@ class ODFReader(BaseExcelReader):
     def get_sheet_by_index(self, index: int):
         from odf.table import Table
 
+        self.raise_if_bad_sheet_by_index(index)
         tables = self.book.getElementsByType(Table)
         return tables[index]
 
     def get_sheet_by_name(self, name: str):
         from odf.table import Table
 
+        self.raise_if_bad_sheet_by_name(name)
         tables = self.book.getElementsByType(Table)
 
         for table in tables:

--- a/pandas/io/excel/_openpyxl.py
+++ b/pandas/io/excel/_openpyxl.py
@@ -494,9 +494,11 @@ class OpenpyxlReader(BaseExcelReader):
         return self.book.sheetnames
 
     def get_sheet_by_name(self, name: str):
+        self.raise_if_bad_sheet_by_name(name)
         return self.book[name]
 
     def get_sheet_by_index(self, index: int):
+        self.raise_if_bad_sheet_by_index(index)
         return self.book.worksheets[index]
 
     def _convert_cell(self, cell, convert_float: bool) -> Scalar:

--- a/pandas/io/excel/_pyxlsb.py
+++ b/pandas/io/excel/_pyxlsb.py
@@ -47,9 +47,11 @@ class PyxlsbReader(BaseExcelReader):
         return self.book.sheets
 
     def get_sheet_by_name(self, name: str):
+        self.raise_if_bad_sheet_by_name(name)
         return self.book.get_sheet(name)
 
     def get_sheet_by_index(self, index: int):
+        self.raise_if_bad_sheet_by_index(index)
         # pyxlsb sheets are indexed from 1 onwards
         # There's a fix for this in the source, but the pypi package doesn't have it
         return self.book.get_sheet(index + 1)

--- a/pandas/io/excel/_xlrd.py
+++ b/pandas/io/excel/_xlrd.py
@@ -44,9 +44,11 @@ class XlrdReader(BaseExcelReader):
         return self.book.sheet_names()
 
     def get_sheet_by_name(self, name):
+        self.raise_if_bad_sheet_by_name(name)
         return self.book.sheet_by_name(name)
 
     def get_sheet_by_index(self, index):
+        self.raise_if_bad_sheet_by_index(index)
         return self.book.sheet_by_index(index)
 
     def get_sheet_data(self, sheet, convert_float):

--- a/pandas/tests/io/excel/test_odf.py
+++ b/pandas/tests/io/excel/test_odf.py
@@ -42,5 +42,5 @@ def test_nonexistent_sheetname_raises(read_ext):
     # GH-27676
     # Specifying a non-existent sheet_name parameter should throw an error
     # with the sheet name.
-    with pytest.raises(ValueError, match="sheet xyz not found"):
+    with pytest.raises(ValueError, match="Worksheet named 'xyz' not found"):
         pd.read_excel("blank.ods", sheet_name="xyz")

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -665,6 +665,16 @@ class TestReaders:
         with pytest.raises(ValueError, match="Unknown engine: foo"):
             pd.read_excel("", engine=bad_engine)
 
+    @pytest.mark.parametrize(
+        "sheet_name",
+        [3, [0, 3], [3, 0], "Sheet4", ["Sheet1", "Sheet4"], ["Sheet4", "Sheet1"]],
+    )
+    def test_bad_sheetname_raises(self, read_ext, sheet_name):
+        # GH 39250
+        msg = "Worksheet index 3 is invalid|Worksheet named 'Sheet4' not found"
+        with pytest.raises(ValueError, match=msg):
+            pd.read_excel("blank" + read_ext, sheet_name=sheet_name)
+
     def test_missing_file_raises(self, read_ext):
         bad_file = f"foo{read_ext}"
         # CI tests with zh_CN.utf8, translates to "No such file or directory"
@@ -1262,6 +1272,17 @@ class TestExcelFileRead:
 
         tm.assert_frame_equal(df1_parse, df_ref, check_names=False)
         tm.assert_frame_equal(df2_parse, df_ref, check_names=False)
+
+    @pytest.mark.parametrize(
+        "sheet_name",
+        [3, [0, 3], [3, 0], "Sheet4", ["Sheet1", "Sheet4"], ["Sheet4", "Sheet1"]],
+    )
+    def test_bad_sheetname_raises(self, read_ext, sheet_name):
+        # GH 39250
+        msg = "Worksheet index 3 is invalid|Worksheet named 'Sheet4' not found"
+        with pytest.raises(ValueError, match=msg):
+            with pd.ExcelFile("blank" + read_ext) as excel:
+                excel.parse(sheet_name=sheet_name)
 
     def test_excel_read_buffer(self, engine, read_ext):
         pth = "test1" + read_ext

--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -347,19 +347,9 @@ class TestExcelWriter:
 
         tm.assert_frame_equal(gt, df)
 
-        if engine == "odf":
-            msg = "sheet 0 not found"
-            with pytest.raises(ValueError, match=msg):
-                pd.read_excel(xl, "0")
-        elif engine == "xlwt":
-            import xlrd
-
-            msg = "No sheet named <'0'>"
-            with pytest.raises(xlrd.XLRDError, match=msg):
-                pd.read_excel(xl, sheet_name="0")
-        else:
-            with pytest.raises(KeyError, match="Worksheet 0 does not exist."):
-                pd.read_excel(xl, sheet_name="0")
+        msg = "Worksheet named '0' not found"
+        with pytest.raises(ValueError, match=msg):
+            pd.read_excel(xl, "0")
 
     def test_excel_writer_context_manager(self, frame, path):
         with ExcelWriter(path) as writer:

--- a/pandas/tests/io/excel/test_xlrd.py
+++ b/pandas/tests/io/excel/test_xlrd.py
@@ -43,9 +43,9 @@ def test_read_xlrd_book(read_ext, frame):
 # TODO: test for openpyxl as well
 def test_excel_table_sheet_by_index(datapath, read_ext):
     path = datapath("io", "data", "excel", f"test1{read_ext}")
-    msg = "No sheet named <'invalid_sheet_name'>"
+    msg = "Worksheet named 'invalid_sheet_name' not found"
     with ExcelFile(path, engine="xlrd") as excel:
-        with pytest.raises(xlrd.XLRDError, match=msg):
+        with pytest.raises(ValueError, match=msg):
             pd.read_excel(excel, sheet_name="invalid_sheet_name")
 
 


### PR DESCRIPTION
- [x] closes #39250
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

IMO the core issue in #39250 is upstream in openpyxl, providing a better error message is really tangential to it. Since the error message that openpyxl raises is not a regression, it seemed best to me to (a) target this for 1.3 and (b) unify all error messages across engines.

If, on the other hand, we really do want to improve the error message in 1.2.2 because of the switch from xlrd to openpyxl, then I will open a new PR for 1.2.2 that only impacts openpyxl.

Will do a followup to remove the duplicate tests.

cc @simonjayhawkins @jorisvandenbossche 