### PR TITLE
CI: Pin pyarrow to 0.15.1 in 37 macos and linux

### DIFF
--- a/ci/deps/azure-37.yaml
+++ b/ci/deps/azure-37.yaml
@@ -18,7 +18,7 @@ dependencies:
   - numpy
   - python-dateutil
   - nomkl
-  - pyarrow
+  - pyarrow=0.15.1
   - pytz
   - s3fs>=0.4.0
   - moto>=1.3.14

--- a/ci/deps/azure-macos-37.yaml
+++ b/ci/deps/azure-macos-37.yaml
@@ -21,7 +21,7 @@ dependencies:
   - numexpr
   - numpy=1.16.5
   - openpyxl
-  - pyarrow>=0.15.0
+  - pyarrow=0.15.1
   - pytables
   - python-dateutil==2.7.3
   - pytz


### PR DESCRIPTION
Pyarrow 2.0.0 instead of 0.15.1 is fetched on these builds since today, which causes test failures