### PR TITLE
DOC: Document how encoding errors are handled

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -270,6 +270,11 @@ encoding : str, optional
     Encoding to use for UTF when reading/writing (ex. 'utf-8'). `List of Python
     standard encodings
     <https://docs.python.org/3/library/codecs.html#standard-encodings>`_ .
+    .. versionchanged:: 1.2
+
+       When ``encoding`` is ``None``, ``errors="replace"`` is passed to
+       ``open()``. Otherwise, ``errors="strict"`` is passed to ``open()``.
+       This behavior was previously only the case for ``engine="python"``.
 dialect : str or csv.Dialect, optional
     If provided, this parameter will override values (default or not) for the
     following parameters: `delimiter`, `doublequote`, `escapechar`,


### PR DESCRIPTION
xref #39450

This should probably go in 1.2.2.

<1.2.0: `engine=c` and `engine=python` handled encoding errors differently when `encoding=None` (python: "replace", c: "strict"). The `engine=c` further supported to ignore lines (`skiprows`) with encoding errors iff `encoding=None`.

1.2.0 (shared file opening code between `engine=c` and `engine=python`): both engine mistakenly used "strict" when `encoding=None`. `engine=c`+`encoding=None` can no longer skip encoding errors.

1.2.1: both engine use "replace" when `encoding=None`. Both engines can ignore encoding errors in skipped rows iff `encoding=None`.

Option for 1.3: default to "strict" but expose `errors` in `read_csv` (and other read calls that might need it)?
