### PR TITLE
REGR: Reading csv files with numbers with multiple leading zeros losses a lot of precision

### DIFF
--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -1616,7 +1616,7 @@ double precise_xstrtod(const char *str, char **endptr, char decimal,
     char *p = (char *)str;
     int num_digits;
     int num_decimals;
-    int max_digits = 17;
+    int max_digits = 309;
     int n;
 
     if (maybe_int != NULL) *maybe_int = 1;


### PR DESCRIPTION
- [x] closes #39514
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

Trying this change out to see what the tests say. It fixes the current issue I experienced.