### PR TITLE
CI: pin numpy for CI / Checks github action

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   # required
-  - numpy>=1.16.5
+  - numpy>=1.16.5, <1.20 # gh-39513
   - python=3
   - python-dateutil>=2.7.3
   - pytz

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # This file is auto-generated from environment.yml, do not modify.
 # See that file for comments about the need/usage of each dependency.
 
-numpy>=1.16.5
+numpy>=1.16.5, <1.20
 python-dateutil>=2.7.3
 pytz
 asv


### PR DESCRIPTION
failures with numpy 1.20

https://github.com/pandas-dev/pandas/pull/39517/checks?check_run_id=1803471267

xref #39513 and https://github.com/pandas-dev/pandas/pull/38379#discussion_r567753143

conda-forge should pick up 1.19.5 with these changes.