### PR TITLE
Fixed comment for pandas.unique

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -321,7 +321,8 @@ def unique(values):
     Hash table-based unique. Uniques are returned in order
     of appearance. This does NOT sort.
 
-    Significantly faster than numpy.unique. Includes NA values.
+    Significantly faster than numpy.unique for long enough sequences.
+    Includes NA values.
 
     Parameters
     ----------


### PR DESCRIPTION
Timed pd.unique vs np.unique with 1_000 and 100_000 sequences lengths. In first case np.unique was faster, whereas in the second case pd.unique won.
Hence, I propose to make the doc a bit more accurate.

![image](https://user-images.githubusercontent.com/1339818/106612351-519ac100-6569-11eb-9388-1acfc39ef3a1.png)
