### PR TITLE
Added an example for infer_freq

### DIFF
--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -145,6 +145,13 @@ def infer_freq(index, warn: bool = True) -> Optional[str]:
         If the index is not datetime-like.
     ValueError
         If there are fewer than three values.
+        
+    Examples
+    --------
+    >>> idx = pd.date_range(start = '2020/12/01', end = '2020/12/30', periods = 30)
+    >>> pd.infer_freq(idx)
+    'D'
+            
     """
     import pandas as pd
 

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -145,13 +145,12 @@ def infer_freq(index, warn: bool = True) -> Optional[str]:
         If the index is not datetime-like.
     ValueError
         If there are fewer than three values.
-        
+
     Examples
     --------
     >>> idx = pd.date_range(start = '2020/12/01', end = '2020/12/30', periods = 30)
     >>> pd.infer_freq(idx)
     'D'
-            
     """
     import pandas as pd
 

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -148,7 +148,7 @@ def infer_freq(index, warn: bool = True) -> Optional[str]:
 
     Examples
     --------
-    >>> idx = pd.date_range(start = '2020/12/01', end = '2020/12/30', periods = 30)
+    >>> idx = pd.date_range(start='2020/12/01', end='2020/12/30', periods=30)
     >>> pd.infer_freq(idx)
     'D'
     """


### PR DESCRIPTION
Added an example for infer_freq function. The initial index is built using a fixed number of periods to avoid encoding frequency in this index explicitly.
