### PR TITLE
STYLE use absolute imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -195,3 +195,8 @@ repos:
     rev: v0.1.6
     hooks:
     -   id: no-string-hints
+-   repo: https://github.com/MarcoGorelli/abs-imports
+    rev: v0.1.2
+    hooks:
+    -   id: abs-imports
+        files: ^pandas/

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -180,7 +180,7 @@ import pandas.testing
 import pandas.arrays
 
 # use the closest tagged version if possible
-from ._version import get_versions
+from pandas._version import get_versions
 
 v = get_versions()
 __version__ = v.get("closest-tag", v["version"])

--- a/pandas/_libs/tslibs/__init__.py
+++ b/pandas/_libs/tslibs/__init__.py
@@ -27,18 +27,28 @@ __all__ = [
     "tz_compare",
 ]
 
-from . import dtypes
-from .conversion import OutOfBoundsTimedelta, localize_pydatetime
-from .dtypes import Resolution
-from .nattype import NaT, NaTType, iNaT, is_null_datetimelike, nat_strings
-from .np_datetime import OutOfBoundsDatetime
-from .offsets import BaseOffset, Tick, to_offset
-from .period import IncompatibleFrequency, Period
-from .timedeltas import Timedelta, delta_to_nanoseconds, ints_to_pytimedelta
-from .timestamps import Timestamp
-from .timezones import tz_compare
-from .tzconversion import tz_convert_from_utc_single
-from .vectorized import (
+from pandas._libs.tslibs import dtypes
+from pandas._libs.tslibs.conversion import OutOfBoundsTimedelta, localize_pydatetime
+from pandas._libs.tslibs.dtypes import Resolution
+from pandas._libs.tslibs.nattype import (
+    NaT,
+    NaTType,
+    iNaT,
+    is_null_datetimelike,
+    nat_strings,
+)
+from pandas._libs.tslibs.np_datetime import OutOfBoundsDatetime
+from pandas._libs.tslibs.offsets import BaseOffset, Tick, to_offset
+from pandas._libs.tslibs.period import IncompatibleFrequency, Period
+from pandas._libs.tslibs.timedeltas import (
+    Timedelta,
+    delta_to_nanoseconds,
+    ints_to_pytimedelta,
+)
+from pandas._libs.tslibs.timestamps import Timestamp
+from pandas._libs.tslibs.timezones import tz_compare
+from pandas._libs.tslibs.tzconversion import tz_convert_from_utc_single
+from pandas._libs.tslibs.vectorized import (
     dt64arr_to_periodarr,
     get_resolution,
     ints_to_pydatetime,

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -23,8 +23,7 @@ from pandas.core.dtypes.dtypes import ExtensionDtype, register_extension_dtype
 from pandas.core.dtypes.missing import isna
 
 from pandas.core import ops
-
-from .masked import BaseMaskedArray, BaseMaskedDtype
+from pandas.core.arrays.masked import BaseMaskedArray, BaseMaskedDtype
 
 if TYPE_CHECKING:
     import pyarrow

--- a/pandas/core/arrays/floating.py
+++ b/pandas/core/arrays/floating.py
@@ -23,10 +23,9 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.dtypes import ExtensionDtype, register_extension_dtype
 from pandas.core.dtypes.missing import isna
 
+from pandas.core.arrays.numeric import NumericArray, NumericDtype
 from pandas.core.ops import invalid_comparison
 from pandas.core.tools.numeric import to_numeric
-
-from .numeric import NumericArray, NumericDtype
 
 
 class FloatingDtype(NumericDtype):

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -23,11 +23,10 @@ from pandas.core.dtypes.common import (
 )
 from pandas.core.dtypes.missing import isna
 
+from pandas.core.arrays.masked import BaseMaskedArray, BaseMaskedDtype
+from pandas.core.arrays.numeric import NumericArray, NumericDtype
 from pandas.core.ops import invalid_comparison
 from pandas.core.tools.numeric import to_numeric
-
-from .masked import BaseMaskedArray, BaseMaskedDtype
-from .numeric import NumericArray, NumericDtype
 
 
 class _IntegerDtype(NumericDtype):

--- a/pandas/core/arrays/numeric.py
+++ b/pandas/core/arrays/numeric.py
@@ -18,8 +18,7 @@ from pandas.core.dtypes.common import (
 )
 
 from pandas.core import ops
-
-from .masked import BaseMaskedArray, BaseMaskedDtype
+from pandas.core.arrays.masked import BaseMaskedArray, BaseMaskedDtype
 
 if TYPE_CHECKING:
     import pyarrow

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -419,7 +419,7 @@ class TimedeltaArray(dtl.TimelikeOps):
         Add a Period object.
         """
         # We will wrap in a PeriodArray and defer to the reversed operation
-        from .period import PeriodArray
+        from pandas.core.arrays.period import PeriodArray
 
         i8vals = np.broadcast_to(other.ordinal, self.shape)
         oth = PeriodArray(i8vals, freq=other.freq)

--- a/pandas/core/strings/__init__.py
+++ b/pandas/core/strings/__init__.py
@@ -26,7 +26,7 @@ to other string extension arrays.
 #     - PandasArray
 #     - Categorical
 
-from .accessor import StringMethods
-from .base import BaseStringArrayMethods
+from pandas.core.strings.accessor import StringMethods
+from pandas.core.strings.base import BaseStringArrayMethods
 
 __all__ = ["StringMethods", "BaseStringArrayMethods"]

--- a/pandas/tests/api/test_types.py
+++ b/pandas/tests/api/test_types.py
@@ -1,7 +1,6 @@
 import pandas._testing as tm
 from pandas.api import types
-
-from .test_api import Base
+from pandas.tests.api.test_api import Base
 
 
 class TestTypes(Base):

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -14,8 +14,7 @@ from pandas import PeriodIndex, Series, Timedelta, TimedeltaIndex, period_range
 import pandas._testing as tm
 from pandas.core import ops
 from pandas.core.arrays import TimedeltaArray
-
-from .common import assert_invalid_comparison
+from pandas.tests.arithmetic.common import assert_invalid_comparison
 
 # ------------------------------------------------------------------
 # Comparisons

--- a/pandas/tests/extension/arrow/test_bool.py
+++ b/pandas/tests/extension/arrow/test_bool.py
@@ -8,7 +8,10 @@ from pandas.tests.extension import base
 
 pytest.importorskip("pyarrow", minversion="0.13.0")
 
-from .arrays import ArrowBoolArray, ArrowBoolDtype  # isort:skip
+from pandas.tests.extension.arrow.arrays import (  # isort:skip
+    ArrowBoolArray,
+    ArrowBoolDtype,
+)
 
 
 @pytest.fixture

--- a/pandas/tests/extension/arrow/test_string.py
+++ b/pandas/tests/extension/arrow/test_string.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 pytest.importorskip("pyarrow", minversion="0.13.0")
 
-from .arrays import ArrowStringDtype  # isort:skip
+from pandas.tests.extension.arrow.arrays import ArrowStringDtype  # isort:skip
 
 
 def test_constructor_from_list():

--- a/pandas/tests/extension/arrow/test_timestamp.py
+++ b/pandas/tests/extension/arrow/test_timestamp.py
@@ -12,7 +12,7 @@ pytest.importorskip("pyarrow", minversion="0.13.0")
 
 import pyarrow as pa  # isort:skip
 
-from .arrays import ArrowExtensionArray  # isort:skip
+from pandas.tests.extension.arrow.arrays import ArrowExtensionArray  # isort:skip
 
 
 @register_extension_dtype

--- a/pandas/tests/extension/base/__init__.py
+++ b/pandas/tests/extension/base/__init__.py
@@ -41,26 +41,26 @@ by defining the staticmethods ``assert_frame_equal`` and
 ``assert_series_equal`` on your base test class.
 
 """
-from .casting import BaseCastingTests  # noqa
-from .constructors import BaseConstructorsTests  # noqa
-from .dtype import BaseDtypeTests  # noqa
-from .getitem import BaseGetitemTests  # noqa
-from .groupby import BaseGroupbyTests  # noqa
-from .interface import BaseInterfaceTests  # noqa
-from .io import BaseParsingTests  # noqa
-from .methods import BaseMethodsTests  # noqa
-from .missing import BaseMissingTests  # noqa
-from .ops import (  # noqa
+from pandas.tests.extension.base.casting import BaseCastingTests  # noqa
+from pandas.tests.extension.base.constructors import BaseConstructorsTests  # noqa
+from pandas.tests.extension.base.dtype import BaseDtypeTests  # noqa
+from pandas.tests.extension.base.getitem import BaseGetitemTests  # noqa
+from pandas.tests.extension.base.groupby import BaseGroupbyTests  # noqa
+from pandas.tests.extension.base.interface import BaseInterfaceTests  # noqa
+from pandas.tests.extension.base.io import BaseParsingTests  # noqa
+from pandas.tests.extension.base.methods import BaseMethodsTests  # noqa
+from pandas.tests.extension.base.missing import BaseMissingTests  # noqa
+from pandas.tests.extension.base.ops import (  # noqa
     BaseArithmeticOpsTests,
     BaseComparisonOpsTests,
     BaseOpsUtil,
     BaseUnaryOpsTests,
 )
-from .printing import BasePrintingTests  # noqa
-from .reduce import (  # noqa
+from pandas.tests.extension.base.printing import BasePrintingTests  # noqa
+from pandas.tests.extension.base.reduce import (  # noqa
     BaseBooleanReduceTests,
     BaseNoReduceTests,
     BaseNumericReduceTests,
 )
-from .reshaping import BaseReshapingTests  # noqa
-from .setitem import BaseSetitemTests  # noqa
+from pandas.tests.extension.base.reshaping import BaseReshapingTests  # noqa
+from pandas.tests.extension.base.setitem import BaseSetitemTests  # noqa

--- a/pandas/tests/extension/base/casting.py
+++ b/pandas/tests/extension/base/casting.py
@@ -3,8 +3,7 @@ import pytest
 
 import pandas as pd
 from pandas.core.internals import ObjectBlock
-
-from .base import BaseExtensionTests
+from pandas.tests.extension.base.base import BaseExtensionTests
 
 
 class BaseCastingTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/constructors.py
+++ b/pandas/tests/extension/base/constructors.py
@@ -3,8 +3,7 @@ import pytest
 
 import pandas as pd
 from pandas.core.internals import ExtensionBlock
-
-from .base import BaseExtensionTests
+from pandas.tests.extension.base.base import BaseExtensionTests
 
 
 class BaseConstructorsTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/dtype.py
+++ b/pandas/tests/extension/base/dtype.py
@@ -5,8 +5,7 @@ import pytest
 
 import pandas as pd
 from pandas.api.types import is_object_dtype, is_string_dtype
-
-from .base import BaseExtensionTests
+from pandas.tests.extension.base.base import BaseExtensionTests
 
 
 class BaseDtypeTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/getitem.py
+++ b/pandas/tests/extension/base/getitem.py
@@ -2,8 +2,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
-
-from .base import BaseExtensionTests
+from pandas.tests.extension.base.base import BaseExtensionTests
 
 
 class BaseGetitemTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/groupby.py
+++ b/pandas/tests/extension/base/groupby.py
@@ -2,8 +2,7 @@ import pytest
 
 import pandas as pd
 import pandas._testing as tm
-
-from .base import BaseExtensionTests
+from pandas.tests.extension.base.base import BaseExtensionTests
 
 
 class BaseGroupbyTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/interface.py
+++ b/pandas/tests/extension/base/interface.py
@@ -5,8 +5,7 @@ from pandas.core.dtypes.dtypes import ExtensionDtype
 
 import pandas as pd
 import pandas._testing as tm
-
-from .base import BaseExtensionTests
+from pandas.tests.extension.base.base import BaseExtensionTests
 
 
 class BaseInterfaceTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/io.py
+++ b/pandas/tests/extension/base/io.py
@@ -4,8 +4,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
-
-from .base import BaseExtensionTests
+from pandas.tests.extension.base.base import BaseExtensionTests
 
 
 class BaseParsingTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -8,8 +8,7 @@ from pandas.core.dtypes.common import is_bool_dtype
 import pandas as pd
 import pandas._testing as tm
 from pandas.core.sorting import nargsort
-
-from .base import BaseExtensionTests
+from pandas.tests.extension.base.base import BaseExtensionTests
 
 
 class BaseMethodsTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/missing.py
+++ b/pandas/tests/extension/base/missing.py
@@ -2,8 +2,7 @@ import numpy as np
 
 import pandas as pd
 import pandas._testing as tm
-
-from .base import BaseExtensionTests
+from pandas.tests.extension.base.base import BaseExtensionTests
 
 
 class BaseMissingTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/ops.py
+++ b/pandas/tests/extension/base/ops.py
@@ -5,8 +5,7 @@ import pytest
 import pandas as pd
 import pandas._testing as tm
 from pandas.core import ops
-
-from .base import BaseExtensionTests
+from pandas.tests.extension.base.base import BaseExtensionTests
 
 
 class BaseOpsUtil(BaseExtensionTests):

--- a/pandas/tests/extension/base/printing.py
+++ b/pandas/tests/extension/base/printing.py
@@ -3,8 +3,7 @@ import io
 import pytest
 
 import pandas as pd
-
-from .base import BaseExtensionTests
+from pandas.tests.extension.base.base import BaseExtensionTests
 
 
 class BasePrintingTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/reduce.py
+++ b/pandas/tests/extension/base/reduce.py
@@ -4,8 +4,7 @@ import pytest
 
 import pandas as pd
 import pandas._testing as tm
-
-from .base import BaseExtensionTests
+from pandas.tests.extension.base.base import BaseExtensionTests
 
 
 class BaseReduceTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/reshaping.py
+++ b/pandas/tests/extension/base/reshaping.py
@@ -5,8 +5,7 @@ import pytest
 
 import pandas as pd
 from pandas.core.internals import ExtensionBlock
-
-from .base import BaseExtensionTests
+from pandas.tests.extension.base.base import BaseExtensionTests
 
 
 class BaseReshapingTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/setitem.py
+++ b/pandas/tests/extension/base/setitem.py
@@ -3,8 +3,7 @@ import pytest
 
 import pandas as pd
 import pandas._testing as tm
-
-from .base import BaseExtensionTests
+from pandas.tests.extension.base.base import BaseExtensionTests
 
 
 class BaseSetitemTests(BaseExtensionTests):

--- a/pandas/tests/extension/decimal/__init__.py
+++ b/pandas/tests/extension/decimal/__init__.py
@@ -1,3 +1,8 @@
-from .array import DecimalArray, DecimalDtype, make_data, to_decimal
+from pandas.tests.extension.decimal.array import (
+    DecimalArray,
+    DecimalDtype,
+    make_data,
+    to_decimal,
+)
 
 __all__ = ["DecimalArray", "DecimalDtype", "to_decimal", "make_data"]

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -8,8 +8,12 @@ import pytest
 import pandas as pd
 import pandas._testing as tm
 from pandas.tests.extension import base
-
-from .array import DecimalArray, DecimalDtype, make_data, to_decimal
+from pandas.tests.extension.decimal.array import (
+    DecimalArray,
+    DecimalDtype,
+    make_data,
+    to_decimal,
+)
 
 
 @pytest.fixture

--- a/pandas/tests/extension/json/__init__.py
+++ b/pandas/tests/extension/json/__init__.py
@@ -1,3 +1,3 @@
-from .array import JSONArray, JSONDtype, make_data
+from pandas.tests.extension.json.array import JSONArray, JSONDtype, make_data
 
 __all__ = ["JSONArray", "JSONDtype", "make_data"]

--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -6,8 +6,7 @@ import pytest
 import pandas as pd
 import pandas._testing as tm
 from pandas.tests.extension import base
-
-from .array import JSONArray, JSONDtype, make_data
+from pandas.tests.extension.json.array import JSONArray, JSONDtype, make_data
 
 
 @pytest.fixture

--- a/pandas/tests/extension/list/__init__.py
+++ b/pandas/tests/extension/list/__init__.py
@@ -1,3 +1,3 @@
-from .array import ListArray, ListDtype, make_data
+from pandas.tests.extension.list.array import ListArray, ListDtype, make_data
 
 __all__ = ["ListArray", "ListDtype", "make_data"]

--- a/pandas/tests/extension/list/test_list.py
+++ b/pandas/tests/extension/list/test_list.py
@@ -1,8 +1,7 @@
 import pytest
 
 import pandas as pd
-
-from .array import ListArray, ListDtype, make_data
+from pandas.tests.extension.list.array import ListArray, ListDtype, make_data
 
 
 @pytest.fixture

--- a/pandas/tests/extension/test_numpy.py
+++ b/pandas/tests/extension/test_numpy.py
@@ -21,8 +21,7 @@ from pandas.core.dtypes.dtypes import ExtensionDtype, PandasDtype
 import pandas as pd
 import pandas._testing as tm
 from pandas.core.arrays.numpy_ import PandasArray
-
-from . import base
+from pandas.tests.extension import base
 
 
 @pytest.fixture(params=["float", "object"])

--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -7,8 +7,7 @@ import pytest
 import pandas as pd
 from pandas import DataFrame, MultiIndex, Series, date_range
 import pandas._testing as tm
-
-from .test_generic import Generic
+from pandas.tests.generic.test_generic import Generic
 
 
 class TestDataFrame(Generic):

--- a/pandas/tests/generic/test_series.py
+++ b/pandas/tests/generic/test_series.py
@@ -6,8 +6,7 @@ import pytest
 import pandas as pd
 from pandas import MultiIndex, Series, date_range
 import pandas._testing as tm
-
-from .test_generic import Generic
+from pandas.tests.generic.test_generic import Generic
 
 
 class TestSeries(Generic):

--- a/pandas/tests/indexes/categorical/test_category.py
+++ b/pandas/tests/indexes/categorical/test_category.py
@@ -7,8 +7,7 @@ import pandas as pd
 from pandas import Categorical
 import pandas._testing as tm
 from pandas.core.indexes.api import CategoricalIndex, Index
-
-from ..common import Base
+from pandas.tests.indexes.common import Base
 
 
 class TestCategoricalIndex(Base):

--- a/pandas/tests/indexes/datetimelike.py
+++ b/pandas/tests/indexes/datetimelike.py
@@ -5,8 +5,7 @@ import pytest
 
 import pandas as pd
 import pandas._testing as tm
-
-from .common import Base
+from pandas.tests.indexes.common import Base
 
 
 class DatetimeLike(Base):

--- a/pandas/tests/indexes/datetimes/test_datetimelike.py
+++ b/pandas/tests/indexes/datetimes/test_datetimelike.py
@@ -3,8 +3,7 @@ import pytest
 
 from pandas import DatetimeIndex, date_range
 import pandas._testing as tm
-
-from ..datetimelike import DatetimeLike
+from pandas.tests.indexes.datetimelike import DatetimeLike
 
 
 class TestDatetimeIndex(DatetimeLike):

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -17,8 +17,7 @@ from pandas import (
     period_range,
 )
 import pandas._testing as tm
-
-from ..datetimelike import DatetimeLike
+from pandas.tests.indexes.datetimelike import DatetimeLike
 
 
 class TestPeriodIndex(DatetimeLike):

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -6,8 +6,7 @@ from pandas.core.dtypes.common import ensure_platform_int
 import pandas as pd
 from pandas import Float64Index, Index, Int64Index, RangeIndex
 import pandas._testing as tm
-
-from ..test_numeric import Numeric
+from pandas.tests.indexes.test_numeric import Numeric
 
 # aliases to make some tests easier to read
 RI = RangeIndex

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -14,8 +14,7 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-
-from ..datetimelike import DatetimeLike
+from pandas.tests.indexes.datetimelike import DatetimeLike
 
 randn = np.random.randn
 

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -14,8 +14,7 @@ from pandas import DataFrame, Index, NaT, Series, date_range, offsets, timedelta
 import pandas._testing as tm
 from pandas.core.indexing import maybe_numeric_slice, non_reducing_slice
 from pandas.tests.indexing.common import _mklbl
-
-from .test_floats import gen_obj
+from pandas.tests.indexing.test_floats import gen_obj
 
 # ------------------------------------------------------------------------
 # Indexing test cases

--- a/pandas/tests/tseries/offsets/test_ticks.py
+++ b/pandas/tests/tseries/offsets/test_ticks.py
@@ -11,11 +11,10 @@ from pandas._libs.tslibs.offsets import delta_to_tick
 
 from pandas import Timedelta, Timestamp
 import pandas._testing as tm
+from pandas.tests.tseries.offsets.common import assert_offset_equal
 
 from pandas.tseries import offsets
 from pandas.tseries.offsets import Hour, Micro, Milli, Minute, Nano, Second
-
-from .common import assert_offset_equal
 
 # ---------------------------------------------------------------------
 # Test Helpers

--- a/versioneer.py
+++ b/versioneer.py
@@ -1776,7 +1776,7 @@ SAMPLE_CONFIG = """
 """
 
 INIT_PY_SNIPPET = """
-from ._version import get_versions
+from pandas._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 """


### PR DESCRIPTION
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

The code style guide reads

> 
> Imports (aim for absolute)
> ==========================
> 
> In Python 3, absolute imports are recommended. Using absolute imports, doing something
> like ``import string`` will import the string module rather than ``string.py``
> in the same directory. As much as possible, you should try to write out
> absolute imports that show the whole import chain from top-level pandas.
> 
> Explicit relative imports are also supported in Python 3 but it is not
> recommended to use them. Implicit relative imports should never be used
> and are removed in Python 3.
> 
> For example:
> 
> ::
> 
>     # preferred
>     import pandas.core.common as com
> 
>     # not preferred
>     from .common import test_base
> 
>     # wrong
>     from common import test_base

yet this isn't checked (nor followed).

So I've made a little package which does this - it's pretty simple and light ([link to source](https://github.com/MarcoGorelli/abs-imports/blob/main/abs_imports.py)), just standard Python libraries (`ast.parse`). Timing on my laptop:
```console
$ time pre-commit run abs-imports --all-files
abs-imports..............................................................Passed

real    0m1.102s
user    0m10.050s
sys     0m0.373s
```

I asked about doing this on the gitter channel and got the response

> in general we go for absolute imports, the exception being in places where that creates circular imports (generally init files)

I didn't find that this created any circular imports (at least, running `./test_fast.sh` worked fine), but `__init__` files can always be excluded if necessary (`exclude: __init__\.py$`)