### PR TITLE
TST: Remove duplicate invalid sheet tests from io.excel

### DIFF
--- a/pandas/tests/io/excel/test_odf.py
+++ b/pandas/tests/io/excel/test_odf.py
@@ -36,11 +36,3 @@ def test_read_writer_table():
     result = pd.read_excel("writertable.odt", sheet_name="Table1", index_col=0)
 
     tm.assert_frame_equal(result, expected)
-
-
-def test_nonexistent_sheetname_raises(read_ext):
-    # GH-27676
-    # Specifying a non-existent sheet_name parameter should throw an error
-    # with the sheet name.
-    with pytest.raises(ValueError, match="Worksheet named 'xyz' not found"):
-        pd.read_excel("blank.ods", sheet_name="xyz")

--- a/pandas/tests/io/excel/test_xlrd.py
+++ b/pandas/tests/io/excel/test_xlrd.py
@@ -40,15 +40,6 @@ def test_read_xlrd_book(read_ext, frame):
         tm.assert_frame_equal(df, result)
 
 
-# TODO: test for openpyxl as well
-def test_excel_table_sheet_by_index(datapath, read_ext):
-    path = datapath("io", "data", "excel", f"test1{read_ext}")
-    msg = "Worksheet named 'invalid_sheet_name' not found"
-    with ExcelFile(path, engine="xlrd") as excel:
-        with pytest.raises(ValueError, match=msg):
-            pd.read_excel(excel, sheet_name="invalid_sheet_name")
-
-
 def test_excel_file_warning_with_xlsx_file(datapath):
     # GH 29375
     path = datapath("io", "data", "excel", "test1.xlsx")


### PR DESCRIPTION
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

Followup from #39482 - removed tests are duplicates of `test_readers.test_bad_sheetname_raises`
