### PR TITLE
Backport PR #39604: REGR: Rolling.count setting min_periods after call

### DIFF
--- a/doc/source/whatsnew/v1.2.2.rst
+++ b/doc/source/whatsnew/v1.2.2.rst
@@ -21,6 +21,7 @@ Fixed regressions
 - Fixed regression in :meth:`~DataFrame.to_pickle` failing to create bz2/xz compressed pickle files with ``protocol=5`` (:issue:`39002`)
 - Fixed regression in :func:`pandas.testing.assert_series_equal` and :func:`pandas.testing.assert_frame_equal` always raising ``AssertionError`` when comparing extension dtypes (:issue:`39410`)
 - Fixed regression in :meth:`~DataFrame.to_csv` opening ``codecs.StreamWriter`` in binary mode instead of in text mode and ignoring user-provided ``mode`` (:issue:`39247`)
+- Fixed regression in :meth:`core.window.rolling.Rolling.count` where the ``min_periods`` argument would be set to ``0`` after the operation (:issue:`39554`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -2016,7 +2016,11 @@ class Rolling(RollingAndExpandingMixin):
                 FutureWarning,
             )
             self.min_periods = 0
-        return super().count()
+            result = super().count()
+            self.min_periods = None
+        else:
+            result = super().count()
+        return result
 
     @Substitution(name="rolling")
     @Appender(_shared_docs["apply"])

--- a/pandas/tests/window/test_api.py
+++ b/pandas/tests/window/test_api.py
@@ -319,3 +319,17 @@ def test_multiple_agg_funcs(func, window_size, expected_vals):
     result = window.agg({"low": ["mean", "max"], "high": ["mean", "min"]})
 
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.filterwarnings("ignore:min_periods:FutureWarning")
+def test_dont_modify_attributes_after_methods(
+    arithmetic_win_operators, closed, center, min_periods
+):
+    # GH 39554
+    roll_obj = Series(range(1)).rolling(
+        1, center=center, closed=closed, min_periods=min_periods
+    )
+    expected = {attr: getattr(roll_obj, attr) for attr in roll_obj._attributes}
+    getattr(roll_obj, arithmetic_win_operators)()
+    result = {attr: getattr(roll_obj, attr) for attr in roll_obj._attributes}
+    assert result == expected

--- a/pandas/tests/window/test_base_indexer.py
+++ b/pandas/tests/window/test_base_indexer.py
@@ -170,7 +170,10 @@ def test_rolling_forward_window(constructor, func, np_func, expected, np_kwargs)
 
     # Check that the function output matches applying an alternative function
     # if min_periods isn't specified
-    rolling3 = constructor(values).rolling(window=indexer)
+    # GH 39604: After count-min_periods deprecation, apply(lambda x: len(x))
+    # is equivalent to count after setting min_periods=0
+    min_periods = 0 if func == "count" else None
+    rolling3 = constructor(values).rolling(window=indexer, min_periods=min_periods)
     result3 = getattr(rolling3, func)()
     expected3 = constructor(rolling3.apply(lambda x: np_func(x, **np_kwargs)))
     tm.assert_equal(result3, expected3)


### PR DESCRIPTION
Backport PR #39604