### PR TITLE
Revert "Backport PR #39526 on branch 1.2.x (CI: pin numpy for CI / Checks github action)"

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   # required
-  - numpy>=1.16.5, <1.20 # gh-39513
+  - numpy>=1.16.5
   - python=3
   - python-dateutil>=2.7.3
   - pytz

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # This file is auto-generated from environment.yml, do not modify.
 # See that file for comments about the need/usage of each dependency.
 
-numpy>=1.16.5, <1.20
+numpy>=1.16.5
 python-dateutil>=2.7.3
 pytz
 asv


### PR DESCRIPTION
Reverts pandas-dev/pandas#39529

will be merging this just prior to tagging 1.2.2 see https://github.com/pandas-dev/pandas/issues/39513#issuecomment-771006563 and then re-appling after release so that ci on 12.x is green