### PR TITLE
add default  zip file name in dataframe to_csv when use 'infer' + 'zip' method

### DIFF
--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -118,11 +118,28 @@ class Concat:
         self.a = pd.Categorical(list("aabbcd") * N)
         self.b = pd.Categorical(list("bbcdjk") * N)
 
+        self.idx_a = pd.CategoricalIndex(range(N), range(N))
+        self.idx_b = pd.CategoricalIndex(range(N + 1), range(N + 1))
+        self.df_a = pd.DataFrame(range(N), columns=["a"], index=self.idx_a)
+        self.df_b = pd.DataFrame(range(N + 1), columns=["a"], index=self.idx_b)
+
     def time_concat(self):
         pd.concat([self.s, self.s])
 
     def time_union(self):
         union_categoricals([self.a, self.b])
+
+    def time_append_overlapping_index(self):
+        self.idx_a.append(self.idx_a)
+
+    def time_append_non_overlapping_index(self):
+        self.idx_a.append(self.idx_b)
+
+    def time_concat_overlapping_index(self):
+        pd.concat([self.df_a, self.df_a])
+
+    def time_concat_non_overlapping_index(self):
+        pd.concat([self.df_a, self.df_b])
 
 
 class ValueCounts:

--- a/asv_bench/benchmarks/hash_functions.py
+++ b/asv_bench/benchmarks/hash_functions.py
@@ -25,6 +25,15 @@ class IsinAlmostFullWithRandomInt:
         self.s.isin(self.values_outside)
 
 
+class UniqueForLargePyObjectInts:
+    def setup(self):
+        lst = [x << 32 for x in range(5000)]
+        self.arr = np.array(lst, dtype=np.object_)
+
+    def time_unique(self):
+        pd.unique(self.arr)
+
+
 class IsinWithRandomFloat:
     params = [
         [np.float64, np.object],

--- a/doc/source/development/extending.rst
+++ b/doc/source/development/extending.rst
@@ -329,21 +329,11 @@ Each data structure has several *constructor properties* for returning a new
 data structure as the result of an operation. By overriding these properties,
 you can retain subclasses through ``pandas`` data manipulations.
 
-There are 3 constructor properties to be defined:
+There are 3 possible constructor properties to be defined on a subclass:
 
-* ``_constructor``: Used when a manipulation result has the same dimensions as the original.
-* ``_constructor_sliced``: Used when a manipulation result has one lower dimension(s) as the original, such as ``DataFrame`` single columns slicing.
-* ``_constructor_expanddim``: Used when a manipulation result has one higher dimension as the original, such as ``Series.to_frame()``.
-
-Following table shows how ``pandas`` data structures define constructor properties by default.
-
-===========================  ======================= =============
-Property Attributes          ``Series``              ``DataFrame``
-===========================  ======================= =============
-``_constructor``             ``Series``              ``DataFrame``
-``_constructor_sliced``      ``NotImplementedError`` ``Series``
-``_constructor_expanddim``   ``DataFrame``           ``NotImplementedError``
-===========================  ======================= =============
+* ``DataFrame/Series._constructor``: Used when a manipulation result has the same dimension as the original.
+* ``DataFrame._constructor_sliced``: Used when a ``DataFrame`` (sub-)class manipulation result should be a ``Series`` (sub-)class.
+* ``Series._constructor_expanddim``: Used when a ``Series`` (sub-)class manipulation result should be a ``DataFrame`` (sub-)class, e.g. ``Series.to_frame()``.
 
 Below example shows how to define ``SubclassedSeries`` and ``SubclassedDataFrame`` overriding constructor properties.
 

--- a/doc/source/whatsnew/v1.2.2.rst
+++ b/doc/source/whatsnew/v1.2.2.rst
@@ -17,7 +17,7 @@ Fixed regressions
 
 - Fixed regression in :func:`read_excel` that caused it to raise ``AttributeError`` when checking version of older xlrd versions (:issue:`38955`)
 - Fixed regression in :class:`DataFrame` constructor reordering element when construction from datetime ndarray with dtype not ``"datetime64[ns]"`` (:issue:`39422`)
-- Fixed regression in :class:`DataFrame.astype` and :class:`Series.astype` not casting to bytes dtype (:issue:`39474`)
+- Fixed regression in :meth:`DataFrame.astype` and :meth:`Series.astype` not casting to bytes dtype (:issue:`39474`)
 - Fixed regression in :meth:`~DataFrame.to_pickle` failing to create bz2/xz compressed pickle files with ``protocol=5`` (:issue:`39002`)
 - Fixed regression in :func:`pandas.testing.assert_series_equal` and :func:`pandas.testing.assert_frame_equal` always raising ``AssertionError`` when comparing extension dtypes (:issue:`39410`)
 - Fixed regression in :meth:`~DataFrame.to_csv` opening ``codecs.StreamWriter`` in binary mode instead of in text mode and ignoring user-provided ``mode`` (:issue:`39247`)

--- a/doc/source/whatsnew/v1.2.2.rst
+++ b/doc/source/whatsnew/v1.2.2.rst
@@ -21,6 +21,7 @@ Fixed regressions
 - Fixed regression in :meth:`~DataFrame.to_pickle` failing to create bz2/xz compressed pickle files with ``protocol=5`` (:issue:`39002`)
 - Fixed regression in :func:`pandas.testing.assert_series_equal` and :func:`pandas.testing.assert_frame_equal` always raising ``AssertionError`` when comparing extension dtypes (:issue:`39410`)
 - Fixed regression in :meth:`~DataFrame.to_csv` opening ``codecs.StreamWriter`` in binary mode instead of in text mode and ignoring user-provided ``mode`` (:issue:`39247`)
+- Fixed regression in :meth:`DataFrame.transform` failing in case of an empty DataFrame or Series (:issue:`39636`)
 - Fixed regression in :meth:`core.window.rolling.Rolling.count` where the ``min_periods`` argument would be set to ``0`` after the operation (:issue:`39554`)
 -
 

--- a/doc/source/whatsnew/v1.2.2.rst
+++ b/doc/source/whatsnew/v1.2.2.rst
@@ -21,6 +21,7 @@ Fixed regressions
 - Fixed regression in :meth:`~DataFrame.to_pickle` failing to create bz2/xz compressed pickle files with ``protocol=5`` (:issue:`39002`)
 - Fixed regression in :func:`pandas.testing.assert_series_equal` and :func:`pandas.testing.assert_frame_equal` always raising ``AssertionError`` when comparing extension dtypes (:issue:`39410`)
 - Fixed regression in :meth:`~DataFrame.to_csv` opening ``codecs.StreamWriter`` in binary mode instead of in text mode and ignoring user-provided ``mode`` (:issue:`39247`)
+- Fixed regression in :meth:`~DataFrame.to_excel` creating corrupt files when appending (``mode="a"``) to an existing file (:issue:`39576`)
 - Fixed regression in :meth:`DataFrame.transform` failing in case of an empty DataFrame or Series (:issue:`39636`)
 - Fixed regression in :meth:`core.window.rolling.Rolling.count` where the ``min_periods`` argument would be set to ``0`` after the operation (:issue:`39554`)
 - Fixed regression in :func:`read_excel` that incorrectly raised when the argument ``io`` was a non-path and non-buffer and the ``engine`` argument was specified (:issue:`39528`)

--- a/doc/source/whatsnew/v1.2.2.rst
+++ b/doc/source/whatsnew/v1.2.2.rst
@@ -23,6 +23,7 @@ Fixed regressions
 - Fixed regression in :meth:`~DataFrame.to_csv` opening ``codecs.StreamWriter`` in binary mode instead of in text mode and ignoring user-provided ``mode`` (:issue:`39247`)
 - Fixed regression in :meth:`DataFrame.transform` failing in case of an empty DataFrame or Series (:issue:`39636`)
 - Fixed regression in :meth:`core.window.rolling.Rolling.count` where the ``min_periods`` argument would be set to ``0`` after the operation (:issue:`39554`)
+- Fixed regression in :func:`read_excel` that incorrectly raised when the argument ``io`` was a non-path and non-buffer and the ``engine`` argument was specified (:issue:`39528`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -305,6 +305,7 @@ Numeric
 - Bug in :meth:`DataFrame.mode` and :meth:`Series.mode` not keeping consistent integer :class:`Index` for empty input (:issue:`33321`)
 - Bug in :meth:`DataFrame.rank` with ``np.inf`` and mixture of ``np.nan`` and ``np.inf`` (:issue:`32593`)
 - Bug in :meth:`DataFrame.rank` with ``axis=0`` and columns holding incomparable types raising ``IndexError`` (:issue:`38932`)
+- Bug in :func:`select_dtypes` different behavior between Windows and Linux with ``include="int"`` (:issue:`36569`)
 -
 
 Conversion

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -219,7 +219,7 @@ See :ref:`install.dependencies` and :ref:`install.optional_dependencies` for mor
 Other API changes
 ^^^^^^^^^^^^^^^^^
 - Partially initialized :class:`CategoricalDtype` (i.e. those with ``categories=None`` objects will no longer compare as equal to fully initialized dtype objects.
--
+- Accessing ``_constructor_expanddim`` on a :class:`DataFrame` and ``_constructor_sliced`` on a :class:`Series` now raise an ``AttributeError``. Previously a ``NotImplementedError`` was raised (:issue:`38782`)
 -
 
 .. ---------------------------------------------------------------------------
@@ -446,6 +446,7 @@ Other
 - Bug in :class:`Index` constructor sometimes silently ignorning a specified ``dtype`` (:issue:`38879`)
 - Bug in constructing a :class:`Series` from a list and a :class:`PandasDtype` (:issue:`39357`)
 - Bug in :class:`Styler` which caused CSS to duplicate on multiple renders. (:issue:`39395`)
+- ``inspect.getmembers(Series)`` no longer raises an ``AbstractMethodError`` (:issue:`38782`)
 - :meth:`Index.where` behavior now mirrors :meth:`Index.putmask` behavior, i.e. ``index.where(mask, other)`` matches ``index.putmask(~mask, other)`` (:issue:`39412`)
 - Bug in :func:`pandas.testing.assert_series_equal`, :func:`pandas.testing.assert_frame_equal`, :func:`pandas.testing.assert_index_equal` and :func:`pandas.testing.assert_extension_array_equal` incorrectly raising when an attribute has an unrecognized NA type (:issue:`39461`)
 - Bug in :class:`Styler` where ``subset`` arg in methods raised an error for some valid multiindex slices (:issue:`33562`)

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -339,7 +339,7 @@ Indexing
 - Bug in :meth:`Series.__setitem__` raising ``ValueError`` when setting a :class:`Series` with a scalar indexer (:issue:`38303`)
 - Bug in :meth:`DataFrame.loc` dropping levels of :class:`MultiIndex` when :class:`DataFrame` used as input has only one row (:issue:`10521`)
 - Bug in :meth:`DataFrame.__getitem__` and :meth:`Series.__getitem__` always raising ``KeyError`` when slicing with existing strings an :class:`Index` with milliseconds (:issue:`33589`)
-- Bug in setting ``timedelta64`` values into numeric :class:`Series` failing to cast to object dtype (:issue:`39086`)
+- Bug in setting ``timedelta64`` or ``datetime64`` values into numeric :class:`Series` failing to cast to object dtype (:issue:`39086`, issue:`39619`)
 - Bug in setting :class:`Interval` values into a :class:`Series` or :class:`DataFrame` with mismatched :class:`IntervalDtype` incorrectly casting the new values to the existing dtype (:issue:`39120`)
 - Bug in setting ``datetime64`` values into a :class:`Series` with integer-dtype incorrect casting the datetime64 values to integers (:issue:`39266`)
 - Bug in :meth:`Index.get_loc` not raising ``KeyError`` when method is specified for ``NaN`` value when ``NaN`` is not in :class:`Index` (:issue:`39382`)

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -253,6 +253,7 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.corr` for method=kendall (:issue:`28329`)
 - Performance improvement in :meth:`core.window.rolling.Rolling.corr` and :meth:`core.window.rolling.Rolling.cov` (:issue:`39388`)
 - Performance improvement in :meth:`core.window.rolling.RollingGroupby.corr`, :meth:`core.window.expanding.ExpandingGroupby.corr`, :meth:`core.window.expanding.ExpandingGroupby.corr` and :meth:`core.window.expanding.ExpandingGroupby.cov` (:issue:`39591`)
+- Performance improvement in :func:`unique` for object data type (:issue:`37615`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -450,7 +450,7 @@ Other
 - :meth:`Index.where` behavior now mirrors :meth:`Index.putmask` behavior, i.e. ``index.where(mask, other)`` matches ``index.putmask(~mask, other)`` (:issue:`39412`)
 - Bug in :func:`pandas.testing.assert_series_equal`, :func:`pandas.testing.assert_frame_equal`, :func:`pandas.testing.assert_index_equal` and :func:`pandas.testing.assert_extension_array_equal` incorrectly raising when an attribute has an unrecognized NA type (:issue:`39461`)
 - Bug in :class:`Styler` where ``subset`` arg in methods raised an error for some valid multiindex slices (:issue:`33562`)
--
+- :class:`Styler` rendered HTML output minor alterations to support w3 good code standard (:issue:`39626`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/_libs/index_class_helper.pxi.in
+++ b/pandas/_libs/index_class_helper.pxi.in
@@ -34,9 +34,13 @@ cdef class {{name}}Engine(IndexEngine):
     cdef _make_hash_table(self, Py_ssize_t n):
         return _hash.{{name}}HashTable(n)
 
-    {{if name not in {'Float64', 'Float32'} }}
     cdef _check_type(self, object val):
+    {{if name not in {'Float64', 'Float32'} }}
         if not util.is_integer_object(val):
+            raise KeyError(val)
+    {{else}}
+        if util.is_bool_object(val):
+            # avoid casting to True -> 1.0
             raise KeyError(val)
     {{endif}}
 

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -457,7 +457,7 @@ def transform(
 
     # Functions that transform may return empty Series/DataFrame
     # when the dtype is not appropriate
-    if isinstance(result, (ABCSeries, ABCDataFrame)) and result.empty:
+    if isinstance(result, (ABCSeries, ABCDataFrame)) and result.empty and not obj.empty:
         raise ValueError("Transform function failed")
     if not isinstance(result, (ABCSeries, ABCDataFrame)) or not result.index.equals(
         obj.index

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -324,7 +324,8 @@ def unique(values):
     Hash table-based unique. Uniques are returned in order
     of appearance. This does NOT sort.
 
-    Significantly faster than numpy.unique. Includes NA values.
+    Significantly faster than numpy.unique for long enough sequences.
+    Includes NA values.
 
     Parameters
     ----------

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -588,9 +588,13 @@ def _try_cast(arr, dtype: Optional[DtypeObj], copy: bool, raise_cast_failure: bo
         Otherwise an object array is returned.
     """
     # perf shortcut as this is the most common case
-    if isinstance(arr, np.ndarray):
-        if maybe_castable(arr) and not copy and dtype is None:
-            return arr
+    if (
+        isinstance(arr, np.ndarray)
+        and maybe_castable(arr.dtype)
+        and not copy
+        and dtype is None
+    ):
+        return arr
 
     if isinstance(dtype, ExtensionDtype) and (dtype.kind != "M" or is_sparse(dtype)):
         # create an extension array from its dtype

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1331,20 +1331,18 @@ def convert_dtypes(
     return inferred_dtype
 
 
-def maybe_castable(arr: np.ndarray) -> bool:
+def maybe_castable(dtype: np.dtype) -> bool:
     # return False to force a non-fastpath
-
-    assert isinstance(arr, np.ndarray)  # GH 37024
 
     # check datetime64[ns]/timedelta64[ns] are valid
     # otherwise try to coerce
-    kind = arr.dtype.kind
+    kind = dtype.kind
     if kind == "M":
-        return is_datetime64_ns_dtype(arr.dtype)
+        return is_datetime64_ns_dtype(dtype)
     elif kind == "m":
-        return is_timedelta64_ns_dtype(arr.dtype)
+        return is_timedelta64_ns_dtype(dtype)
 
-    return arr.dtype.name not in POSSIBLY_CAST_DTYPES
+    return dtype.name not in POSSIBLY_CAST_DTYPES
 
 
 def maybe_infer_to_datetimelike(

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7718,7 +7718,7 @@ NaN 12.3   33.0
             func=arg,
             axis=0,
             args=args,
-            kwds=kwargs,
+            kwargs=kwargs,
         )
         result, how = op.agg()
 
@@ -7750,7 +7750,7 @@ NaN 12.3   33.0
         raw: bool = False,
         result_type=None,
         args=(),
-        **kwds,
+        **kwargs,
     ):
         """
         Apply a function along an axis of the DataFrame.
@@ -7798,7 +7798,7 @@ NaN 12.3   33.0
         args : tuple
             Positional arguments to pass to `func` in addition to the
             array/series.
-        **kwds
+        **kwargs
             Additional keyword arguments to pass as keywords arguments to
             `func`.
 
@@ -7892,7 +7892,7 @@ NaN 12.3   33.0
             raw=raw,
             result_type=result_type,
             args=args,
-            kwds=kwds,
+            kwargs=kwargs,
         )
         return op.apply()
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -490,23 +490,14 @@ class DataFrame(NDFrame, OpsMixin):
     _internal_names_set = {"columns", "index"} | NDFrame._internal_names_set
     _typ = "dataframe"
     _HANDLED_TYPES = (Series, Index, ExtensionArray, np.ndarray)
+    _accessors: Set[str] = {"sparse"}
+    _hidden_attrs: FrozenSet[str] = NDFrame._hidden_attrs | frozenset([])
 
     @property
     def _constructor(self) -> Type[DataFrame]:
         return DataFrame
 
     _constructor_sliced: Type[Series] = Series
-    _hidden_attrs: FrozenSet[str] = NDFrame._hidden_attrs | frozenset([])
-    _accessors: Set[str] = {"sparse"}
-
-    @property
-    def _constructor_expanddim(self):
-        # GH#31549 raising NotImplementedError on a property causes trouble
-        #  for `inspect`
-        def constructor(*args, **kwargs):
-            raise NotImplementedError("Not supported for DataFrames!")
-
-        return constructor
 
     # ----------------------------------------------------------------------
     # Constructors

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -375,22 +375,6 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         """
         raise AbstractMethodError(self)
 
-    @property
-    def _constructor_sliced(self):
-        """
-        Used when a manipulation result has one lower dimension(s) as the
-        original, such as DataFrame single columns slicing.
-        """
-        raise AbstractMethodError(self)
-
-    @property
-    def _constructor_expanddim(self):
-        """
-        Used when a manipulation result has one higher dimension as the
-        original, such as Series.to_frame()
-        """
-        raise NotImplementedError
-
     # ----------------------------------------------------------------------
     # Internals
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8875,32 +8875,11 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         if isinstance(other, (np.ndarray, ExtensionArray)):
 
             if other.shape != self.shape:
-
-                if self.ndim == 1:
-
-                    icond = cond._values
-
-                    # GH 2745 / GH 4192
-                    # treat like a scalar
-                    if len(other) == 1:
-                        other = other[0]
-
-                    # GH 3235
-                    # match True cond to other
-                    elif len(cond[icond]) == len(other):
-
-                        # try to not change dtype at first
-                        new_other = self._values
-                        new_other = new_other.copy()
-                        new_other[icond] = other
-                        other = new_other
-
-                    else:
-                        raise ValueError(
-                            "Length of replacements must equal series length"
-                        )
-
-                else:
+                if self.ndim != 1:
+                    # In the ndim == 1 case we may have
+                    #  other length 1, which we treat as scalar (GH#2745, GH#4192)
+                    #  or len(other) == icond.sum(), which we treat like
+                    #  __setitem__ (GH#3235)
                     raise ValueError(
                         "other must be the same shape as self when an ndarray"
                     )

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -983,7 +983,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                 # try to treat as if we are passing a list
                 try:
                     result, _ = GroupByApply(
-                        self, [func], args=(), kwds={"_axis": self.axis}
+                        self, [func], args=(), kwargs={"_axis": self.axis}
                     ).agg()
 
                     # select everything except for the last level, which is the one

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -1,4 +1,4 @@
-from typing import Any, Hashable, Optional
+from typing import Hashable, Optional
 import warnings
 
 import numpy as np
@@ -9,7 +9,6 @@ from pandas.util._decorators import doc
 
 from pandas.core.dtypes.cast import astype_nansafe
 from pandas.core.dtypes.common import (
-    is_bool,
     is_dtype_equal,
     is_extension_array_dtype,
     is_float,
@@ -336,13 +335,6 @@ class Float64Index(NumericIndex):
         # translate to locations
         return self.slice_indexer(key.start, key.stop, key.step, kind=kind)
 
-    @doc(Index.get_loc)
-    def get_loc(self, key, method=None, tolerance=None):
-        if is_bool(key):
-            # Catch this to avoid accidentally casting to 1.0
-            raise KeyError(key)
-        return super().get_loc(key, method=method, tolerance=tolerance)
-
     # ----------------------------------------------------------------
 
     def _format_native_types(
@@ -359,10 +351,3 @@ class Float64Index(NumericIndex):
             fixed_width=False,
         )
         return formatter.get_result_as_array()
-
-    def __contains__(self, other: Any) -> bool:
-        hash(other)
-        if super().__contains__(other):
-            return True
-
-        return is_float(other) and np.isnan(other) and self.hasnans

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1031,7 +1031,8 @@ class Block(PandasObject):
         elif not mask.any():
             return [self]
 
-        elif isinstance(new, np.timedelta64):
+        dtype, _ = infer_dtype_from(new)
+        if dtype.kind in ["m", "M"]:
             # using putmask with object dtype will incorrect cast to object
             # Having excluded self._can_hold_element, we know we cannot operate
             #  in-place, so we are safe using `where`
@@ -1317,10 +1318,15 @@ class Block(PandasObject):
                 blocks = block.where(orig_other, cond, errors=errors, axis=axis)
                 return self._maybe_downcast(blocks, "infer")
 
-            elif isinstance(other, np.timedelta64):
-                # expressions.where will cast np.timedelta64 to int
-                result = self.values.copy()
-                result[~cond] = [other] * (~cond).sum()
+            dtype, _ = infer_dtype_from(other, pandas_dtype=True)
+            if dtype.kind in ["m", "M"] and dtype.kind != values.dtype.kind:
+                # expressions.where would cast np.timedelta64 to int
+                if not is_list_like(other):
+                    other = [other] * (~cond).sum()
+                else:
+                    other = list(other)
+                result = values.copy()
+                np.putmask(result, ~cond, other)
 
             else:
                 # convert datetime to datetime64, timedelta to timedelta64

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -301,7 +301,7 @@ class Resampler(BaseGroupBy, ShallowMixin):
     def aggregate(self, func, *args, **kwargs):
 
         self._set_binner()
-        result, how = ResamplerWindowApply(self, func, args=args, kwds=kwargs).agg()
+        result, how = ResamplerWindowApply(self, func, args=args, kwargs=kwargs).agg()
         if result is None:
             how = func
             grouper = None

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -430,6 +430,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     @property
     def _constructor_expanddim(self) -> Type[DataFrame]:
+        """
+        Used when a manipulation result has one higher dimension as the
+        original, such as Series.to_frame()
+        """
         from pandas.core.frame import DataFrame
 
         return DataFrame

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -180,8 +180,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         Values must be hashable and have the same length as `data`.
         Non-unique index values are allowed. Will default to
         RangeIndex (0, 1, 2, ..., n) if not provided. If data is dict-like
-        and index is None, then the values in the index are used to
-        reindex the Series after it is created using the keys in the data.
+        and index is None, then the keys in the data are used as the index. If the
+        index is not None, the resulting Series is reindexed with the index values.
     dtype : str, numpy.dtype, or ExtensionDtype, optional
         Data type for the output Series. If not specified, this will be
         inferred from `data`.
@@ -190,6 +190,33 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         The name to give to the Series.
     copy : bool, default False
         Copy input data.
+
+    Examples
+    --------
+    Constructing Series from a dictionary with an Index specified
+
+    >>> d = {'a': 1, 'b': 2, 'c': 3}
+    >>> ser = pd.Series(data=d, index=['a', 'b', 'c'])
+    >>> ser
+    a   1
+    b   2
+    c   3
+    dtype: int64
+
+    The keys of the dictionary match with the Index values, hence the Index
+    values have no effect.
+
+    >>> d = {'a': 1, 'b': 2, 'c': 3}
+    >>> ser = pd.Series(data=d, index=['x', 'y', 'z'])
+    >>> ser
+    x   NaN
+    y   NaN
+    z   NaN
+    dtype: float64
+
+    Note that the Index is first build with the keys from the dictionary.
+    After this the Series is reindexed with the given Index values, hence we
+    get all NaN as a result.
     """
 
     _typ = "series"

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3967,7 +3967,7 @@ Keep all original rows and also all original values
         if func is None:
             func = dict(kwargs.items())
 
-        op = series_apply(self, func, args=args, kwds=kwargs)
+        op = series_apply(self, func, args=args, kwargs=kwargs)
         result, how = op.agg()
         if result is None:
 
@@ -4008,7 +4008,7 @@ Keep all original rows and also all original values
         func: AggFuncType,
         convert_dtype: bool = True,
         args: Tuple[Any, ...] = (),
-        **kwds,
+        **kwargs,
     ) -> FrameOrSeriesUnion:
         """
         Invoke function on values of Series.
@@ -4025,7 +4025,7 @@ Keep all original rows and also all original values
             False, leave as dtype=object.
         args : tuple
             Positional arguments passed to func after the series value.
-        **kwds
+        **kwargs
             Additional keyword arguments passed to func.
 
         Returns
@@ -4106,7 +4106,7 @@ Keep all original rows and also all original values
         Helsinki    2.484907
         dtype: float64
         """
-        op = series_apply(self, func, convert_dtype, args, kwds)
+        op = series_apply(self, func, convert_dtype, args, kwargs)
         return op.apply()
 
     def _reduce(

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -510,7 +510,7 @@ class BaseWindow(ShallowMixin, SelectionMixin):
             return self._apply_tablewise(homogeneous_func, name)
 
     def aggregate(self, func, *args, **kwargs):
-        result, how = ResamplerWindowApply(self, func, args=args, kwds=kwargs).agg()
+        result, how = ResamplerWindowApply(self, func, args=args, kwargs=kwargs).agg()
         if result is None:
             return self.apply(func, raw=False, args=args, kwargs=kwargs)
         return result
@@ -994,7 +994,7 @@ class Window(BaseWindow):
         axis="",
     )
     def aggregate(self, func, *args, **kwargs):
-        result, how = ResamplerWindowApply(self, func, args=args, kwds=kwargs).agg()
+        result, how = ResamplerWindowApply(self, func, args=args, kwargs=kwargs).agg()
         if result is None:
 
             # these must apply directly

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -726,6 +726,17 @@ class _BytesZipFile(zipfile.ZipFile, BytesIO):  # type: ignore[misc]
         self.archive_name = archive_name
         self.multiple_write_buffer: Optional[Union[StringIO, BytesIO]] = None
 
+        # add csv file name like gz or bz2
+        try:
+            fname = os.path.basename(file)
+            if not isinstance(fname, bytes):
+                fname = fname.encode('latin-1')
+            if fname.endswith(b'.zip'):
+                xname = fname[:-4].decode('latin-1')
+                self.archive_name=xname
+        except:
+            pass
+
         kwargs_zip: Dict[str, Any] = {"compression": zipfile.ZIP_DEFLATED}
         kwargs_zip.update(kwargs)
 

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -727,15 +727,10 @@ class _BytesZipFile(zipfile.ZipFile, BytesIO):  # type: ignore[misc]
         self.multiple_write_buffer: Optional[Union[StringIO, BytesIO]] = None
 
         # add csv file name like gz or bz2
-        try:
-            fname = os.path.basename(file)
-            if not isinstance(fname, bytes):
-                fname = fname.encode('latin-1')
-            if fname.endswith(b'.zip'):
-                xname = fname[:-4].decode('latin-1')
-                self.archive_name=xname
-        except:
-            pass
+        if archive_name is None and isinstance(file, (os.PathLike, str)):
+            archive_name = os.path.basename(file)
+            if archive_name.endswith('.zip'):
+                self.archive_name = archive_name[:-4]
 
         kwargs_zip: Dict[str, Any] = {"compression": zipfile.ZIP_DEFLATED}
         kwargs_zip.update(kwargs)

--- a/pandas/io/excel/_openpyxl.py
+++ b/pandas/io/excel/_openpyxl.py
@@ -533,7 +533,11 @@ class OpenpyxlReader(BaseExcelReader):
 
         version = LooseVersion(get_version(openpyxl))
 
-        if version >= "3.0.0":
+        # There is no good way of determining if a sheet is read-only
+        # https://foss.heptapod.net/openpyxl/openpyxl/-/issues/1605
+        is_readonly = hasattr(sheet, "reset_dimensions")
+
+        if version >= "3.0.0" and is_readonly:
             sheet.reset_dimensions()
 
         data: List[List[Scalar]] = []
@@ -541,7 +545,7 @@ class OpenpyxlReader(BaseExcelReader):
             converted_row = [self._convert_cell(cell, convert_float) for cell in row]
             data.append(converted_row)
 
-        if version >= "3.0.0" and len(data) > 0:
+        if version >= "3.0.0" and is_readonly and len(data) > 0:
             # With dimension reset, openpyxl no longer pads rows
             max_width = max(len(data_row) for data_row in data)
             if min(len(data_row) for data_row in data) < max_width:

--- a/pandas/io/excel/_openpyxl.py
+++ b/pandas/io/excel/_openpyxl.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from distutils.version import LooseVersion
+import mmap
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 import numpy as np
@@ -40,6 +41,7 @@ class OpenpyxlWriter(ExcelWriter):
             from openpyxl import load_workbook
 
             self.book = load_workbook(self.handles.handle)
+            self.handles.handle.seek(0)
         else:
             # Create workbook object with default optimized_write=True.
             self.book = Workbook()
@@ -52,6 +54,9 @@ class OpenpyxlWriter(ExcelWriter):
         Save workbook to disk.
         """
         self.book.save(self.handles.handle)
+        if "r+" in self.mode and not isinstance(self.handles.handle, mmap.mmap):
+            # truncate file to the written content
+            self.handles.handle.truncate()
 
     @classmethod
     def _convert_to_style_kwargs(cls, style_dict: dict) -> Dict[str, Serialisable]:

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -391,9 +391,6 @@ class Styler:
         BLANK_CLASS = "blank"
         BLANK_VALUE = ""
 
-        def format_attr(pair):
-            return f"{pair['key']}={pair['value']}"
-
         # for sparsifying a MultiIndex
         idx_lengths = _get_level_lengths(self.index)
         col_lengths = _get_level_lengths(self.columns, hidden_columns)
@@ -462,9 +459,7 @@ class Styler:
                     }
                     colspan = col_lengths.get((r, c), 0)
                     if colspan > 1:
-                        es["attributes"] = [
-                            format_attr({"key": "colspan", "value": f'"{colspan}"'})
-                        ]
+                        es["attributes"] = [f'colspan="{colspan}"']
                     row_es.append(es)
                 head.append(row_es)
 
@@ -508,9 +503,7 @@ class Styler:
                 }
                 rowspan = idx_lengths.get((c, r), 0)
                 if rowspan > 1:
-                    es["attributes"] = [
-                        format_attr({"key": "rowspan", "value": f'"{rowspan}"'})
-                    ]
+                    es["attributes"] = [f'rowspan="{rowspan}"']
                 row_es.append(es)
 
             for c, col in enumerate(self.data.columns):

--- a/pandas/io/formats/templates/html.tpl
+++ b/pandas/io/formats/templates/html.tpl
@@ -1,70 +1,70 @@
 {# Update the template_structure.html document too #}
 {%- block before_style -%}{%- endblock before_style -%}
 {% block style %}
-<style  type="text/css" >
+<style type="text/css">
 {% block table_styles %}
 {% for s in table_styles %}
-    #T_{{uuid}} {{s.selector}} {
-    {% for p,val in s.props %}
-      {{p}}: {{val}};
-    {% endfor -%}
-    }
-{%- endfor -%}
+#T_{{uuid}} {{s.selector}} {
+{% for p,val in s.props %}
+  {{p}}: {{val}};
+{% endfor %}
+}
+{% endfor %}
 {% endblock table_styles %}
 {% block before_cellstyle %}{% endblock before_cellstyle %}
 {% block cellstyle %}
-{%- for s in cellstyle %}
-    {%- for selector in s.selectors -%}{%- if not loop.first -%},{%- endif -%}#T_{{uuid}}{{selector}}{%- endfor -%} {
-    {% for p,val in s.props %}
-        {{p}}: {{val}};
-    {% endfor %}
-    }
-{%- endfor -%}
-{%- endblock cellstyle %}
+{% for s in cellstyle %}
+{% for selector in s.selectors %}{% if not loop.first %}, {% endif %}#T_{{uuid}}{{selector}}{% endfor %} {
+{% for p,val in s.props %}
+  {{p}}: {{val}};
+{% endfor %}
+}
+{% endfor %}
+{% endblock cellstyle %}
 </style>
-{%- endblock style %}
-{%- block before_table %}{% endblock before_table %}
-{%- block table %}
-<table id="T_{{uuid}}" {% if table_attributes %}{{ table_attributes }}{% endif %}>
-{%- block caption %}
-{%- if caption -%}
-    <caption>{{caption}}</caption>
-{%- endif -%}
-{%- endblock caption %}
-{%- block thead %}
-<thead>
-    {%- block before_head_rows %}{% endblock %}
-    {%- for r in head %}
-    {%- block head_tr scoped %}
+{% endblock style %}
+{% block before_table %}{% endblock before_table %}
+{% block table %}
+<table id="T_{{uuid}}"{% if table_attributes %} {{table_attributes}}{% endif %}>
+{% block caption %}
+{% if caption %}
+  <caption>{{caption}}</caption>
+{% endif %}
+{% endblock caption %}
+{% block thead %}
+  <thead>
+{% block before_head_rows %}{% endblock %}
+{% for r in head %}
+{% block head_tr scoped %}
     <tr>
-        {%- for c in r %}
-        {%- if c.is_visible != False %}
-        <{{ c.type }} class="{{c.class}}" {{ c.attributes|join(" ") }}>{{c.value}}</{{ c.type }}>
-        {%- endif %}
-        {%- endfor %}
+{% for c in r %}
+{% if c.is_visible != False %}
+      <{{c.type}} class="{{c.class}}" {{c.attributes|join(" ")}}>{{c.value}}</{{c.type}}>
+{% endif %}
+{% endfor %}
     </tr>
-    {%- endblock head_tr %}
-    {%- endfor %}
-    {%- block after_head_rows %}{% endblock %}
-</thead>
-{%- endblock thead %}
-{%- block tbody %}
-<tbody>
-    {% block before_rows %}{% endblock before_rows %}
-    {% for r in body %}
-    {% block tr scoped %}
+{% endblock head_tr %}
+{% endfor %}
+{% block after_head_rows %}{% endblock %}
+  </thead>
+{% endblock thead %}
+{% block tbody %}
+  <tbody>
+{% block before_rows %}{% endblock before_rows %}
+{% for r in body %}
+{% block tr scoped %}
     <tr>
-        {% for c in r %}
-        {% if c.is_visible != False %}
-        <{{ c.type }} {% if c.id is defined -%} id="T_{{ uuid }}{{ c.id }}" {%- endif %} class="{{ c.class }}" {{ c.attributes|join(" ") }}>{{ c.display_value }}</{{ c.type }}>
-        {% endif %}
-        {%- endfor %}
+{% for c in r %}
+{% if c.is_visible != False %}
+      <{{c.type}} {% if c.id is defined -%} id="T_{{uuid}}{{c.id}}" {%- endif %} class="{{c.class}}" {{c.attributes|join(" ")}}>{{c.display_value}}</{{c.type}}>
+{% endif %}
+{% endfor %}
     </tr>
-    {% endblock tr %}
-    {%- endfor %}
-    {%- block after_rows %}{%- endblock after_rows %}
-</tbody>
-{%- endblock tbody %}
+{% endblock tr %}
+{% endfor %}
+{% block after_rows %}{% endblock after_rows %}
+  </tbody>
+{% endblock tbody %}
 </table>
-{%- endblock table %}
-{%- block after_table %}{% endblock after_table %}
+{% endblock table %}
+{% block after_table %}{% endblock after_table %}

--- a/pandas/tests/apply/test_frame_transform.py
+++ b/pandas/tests/apply/test_frame_transform.py
@@ -274,3 +274,13 @@ def test_transform_mixed_column_name_dtypes():
     msg = r"Column\(s\) \[1, 'b'\] do not exist"
     with pytest.raises(SpecificationError, match=msg):
         df.transform({"a": int, 1: str, "b": int})
+
+
+def test_transform_empty_dataframe():
+    # https://github.com/pandas-dev/pandas/issues/39636
+    df = DataFrame([], columns=["col1", "col2"])
+    result = df.transform(lambda x: x + 10)
+    tm.assert_frame_equal(result, df)
+
+    result = df["col1"].transform(lambda x: x + 10)
+    tm.assert_series_equal(result, df["col1"])

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -110,7 +110,7 @@ class TestSelectDtypes:
             {
                 "a": list("abc"),
                 "b": list(range(1, 4)),
-                "c": np.arange(3, 6).astype("u1"),
+                "c": np.arange(3, 6, dtype="u1"),
                 "d": np.arange(4.0, 7.0, dtype="float64"),
                 "e": [True, False, True],
                 "f": pd.date_range("now", periods=3).values,
@@ -127,6 +127,26 @@ class TestSelectDtypes:
         r = df.select_dtypes(include=include, exclude=exclude)
         e = df[["b", "e"]]
         tm.assert_frame_equal(r, e)
+
+    @pytest.mark.parametrize(
+        "include", [(np.bool_, "int"), (np.bool_, "integer"), ("bool", int)]
+    )
+    def test_select_dtypes_exclude_include_int(self, include):
+        # Fix select_dtypes(include='int') for Windows, FYI #36596
+        df = DataFrame(
+            {
+                "a": list("abc"),
+                "b": list(range(1, 4)),
+                "c": np.arange(3, 6, dtype="int32"),
+                "d": np.arange(4.0, 7.0, dtype="float64"),
+                "e": [True, False, True],
+                "f": pd.date_range("now", periods=3).values,
+            }
+        )
+        exclude = (np.datetime64,)
+        result = df.select_dtypes(include=include, exclude=exclude)
+        expected = df[["b", "c", "e"]]
+        tm.assert_frame_equal(result, expected)
 
     def test_select_dtypes_include_using_scalars(self):
         df = DataFrame(

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -321,12 +321,14 @@ class TestDataFrameMisc:
         result.iloc[key] = 10
         assert obj.iloc[key] == 0
 
-    def test_constructor_expanddim_lookup(self):
-        # GH#33628 accessing _constructor_expanddim should not
-        #  raise NotImplementedError
+    def test_constructor_expanddim(self):
+        # GH#33628 accessing _constructor_expanddim should not raise NotImplementedError
+        # GH38782 pandas has no container higher than DataFrame (two-dim), so
+        # DataFrame._constructor_expand_dim, doesn't make sense, so is removed.
         df = DataFrame()
 
-        with pytest.raises(NotImplementedError, match="Not supported for DataFrames!"):
+        msg = "'DataFrame' object has no attribute '_constructor_expanddim'"
+        with pytest.raises(AttributeError, match=msg):
             df._constructor_expanddim(np.arange(27).reshape(3, 3, 3))
 
     @skip_if_no("jinja2")

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -2,6 +2,7 @@ from datetime import datetime, time
 from functools import partial
 import os
 from urllib.error import URLError
+from zipfile import BadZipFile
 
 import numpy as np
 import pytest
@@ -685,7 +686,13 @@ class TestReaders:
 
     def test_corrupt_bytes_raises(self, read_ext, engine):
         bad_stream = b"foo"
-        with pytest.raises(ValueError, match="File is not a recognized excel file"):
+        if engine is None or engine == "xlrd":
+            error = ValueError
+            msg = "File is not a recognized excel file"
+        else:
+            error = BadZipFile
+            msg = "File is not a zip file"
+        with pytest.raises(error, match=msg):
             pd.read_excel(bad_stream)
 
     @tm.network

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -140,8 +140,8 @@ class TestStyler:
         s = Styler(self.df, uuid_len=0).applymap(lambda x: "color: red;", subset=["A"])
         s.render()  # do 2 renders to ensure css styles not duplicated
         assert (
-            '<style  type="text/css" >\n#T__row0_col0,#T__row1_col0{\n            '
-            "color:  red;\n        }</style>" in s.render()
+            '<style type="text/css">\n#T__row0_col0, #T__row1_col0 {\n'
+            "  color:  red;\n}\n</style>" in s.render()
         )
 
     def test_render_empty_dfs(self):
@@ -1794,11 +1794,11 @@ class TestStyler:
         df = DataFrame(data=[[0, 1], [1, 2]], columns=["A", "B"])
         s = Styler(df, uuid_len=0)
         s = s.set_table_styles({"A": [{"selector": "", "props": [("color", "blue")]}]})
-        assert "#T__ .col0 {\n          color: blue;\n    }" in s.render()
+        assert "#T__ .col0 {\n  color: blue;\n}" in s.render()
         s = s.set_table_styles(
             {0: [{"selector": "", "props": [("color", "blue")]}]}, axis=1
         )
-        assert "#T__ .row0 {\n          color: blue;\n    }" in s.render()
+        assert "#T__ .row0 {\n  color: blue;\n}" in s.render()
 
     def test_colspan_w3(self):
         # GH 36223
@@ -1855,12 +1855,12 @@ class TestStyler:
         s = Styler(df, uuid_len=0).set_tooltips(ttips).render()
 
         # test tooltip table level class
-        assert "#T__ .pd-t {\n          visibility: hidden;\n" in s
+        assert "#T__ .pd-t {\n  visibility: hidden;\n" in s
 
         # test 'Min' tooltip added
         assert (
-            "#T__ #T__row0_col0:hover .pd-t {\n          visibility: visible;\n    }  "
-            + '  #T__ #T__row0_col0 .pd-t::after {\n          content: "Min";\n    }'
+            "#T__ #T__row0_col0:hover .pd-t {\n  visibility: visible;\n}\n"
+            + '#T__ #T__row0_col0 .pd-t::after {\n  content: "Min";\n}'
             in s
         )
         assert (
@@ -1871,8 +1871,8 @@ class TestStyler:
 
         # test 'Max' tooltip added
         assert (
-            "#T__ #T__row0_col1:hover .pd-t {\n          visibility: visible;\n    }  "
-            + '  #T__ #T__row0_col1 .pd-t::after {\n          content: "Max";\n    }'
+            "#T__ #T__row0_col1:hover .pd-t {\n  visibility: visible;\n}\n"
+            + '#T__ #T__row0_col1 .pd-t::after {\n  content: "Max";\n}'
             in s
         )
         assert (
@@ -1892,16 +1892,16 @@ class TestStyler:
             index=[0, 2],
         )
         s = Styler(df, uuid_len=0).set_tooltips(DataFrame(ttips)).render()
-        assert '#T__ #T__row0_col0 .pd-t::after {\n          content: "Mi";\n    }' in s
-        assert '#T__ #T__row0_col2 .pd-t::after {\n          content: "Ma";\n    }' in s
-        assert '#T__ #T__row2_col0 .pd-t::after {\n          content: "Mu";\n    }' in s
-        assert '#T__ #T__row2_col2 .pd-t::after {\n          content: "Mo";\n    }' in s
+        assert '#T__ #T__row0_col0 .pd-t::after {\n  content: "Mi";\n}' in s
+        assert '#T__ #T__row0_col2 .pd-t::after {\n  content: "Ma";\n}' in s
+        assert '#T__ #T__row2_col0 .pd-t::after {\n  content: "Mu";\n}' in s
+        assert '#T__ #T__row2_col2 .pd-t::after {\n  content: "Mo";\n}' in s
 
     def test_tooltip_ignored(self):
         # GH 21266
         df = DataFrame(data=[[0, 1], [2, 3]])
         s = Styler(df).set_tooltips_class("pd-t").render()  # no set_tooltips()
-        assert '<style  type="text/css" >\n</style>' in s
+        assert '<style type="text/css">\n</style>' in s
         assert '<span class="pd-t"></span>' not in s
 
     def test_tooltip_class(self):
@@ -1913,11 +1913,8 @@ class TestStyler:
             .set_tooltips_class(name="other-class", properties=[("color", "green")])
             .render()
         )
-        assert "#T__ .other-class {\n          color: green;\n" in s
-        assert (
-            '#T__ #T__row0_col0 .other-class::after {\n          content: "tooltip";\n'
-            in s
-        )
+        assert "#T__ .other-class {\n  color: green;\n" in s
+        assert '#T__ #T__row0_col0 .other-class::after {\n  content: "tooltip";\n' in s
 
         # GH 39563
         s = (
@@ -1926,10 +1923,50 @@ class TestStyler:
             .set_tooltips_class(name="other-class", properties="color:green;color:red;")
             .render()
         )
-        assert (
-            "#T__ .other-class {\n          color: green;\n          color: red;\n "
-            in s
+        assert "#T__ .other-class {\n  color: green;\n  color: red;\n}" in s
+
+    def test_w3_html_format(self):
+        s = (
+            Styler(
+                DataFrame([[2.61], [2.69]], index=["a", "b"], columns=["A"]),
+                uuid_len=0,
+            )
+            .set_table_styles([{"selector": "th", "props": "att2:v2;"}])
+            .applymap(lambda x: "att1:v1;")
+            .set_table_attributes('class="my-cls1" style="attr3:v3;"')
+            .set_td_classes(DataFrame(["my-cls2"], index=["a"], columns=["A"]))
+            .format("{:.1f}")
+            .set_caption("A comprehensive test")
         )
+        expected = """<style type="text/css">
+#T__ th {
+  att2: v2;
+}
+#T__row0_col0, #T__row1_col0 {
+  att1: v1;
+}
+</style>
+<table id="T__" class="my-cls1" style="attr3:v3;">
+  <caption>A comprehensive test</caption>
+  <thead>
+    <tr>
+      <th class="blank level0" ></th>
+      <th class="col_heading level0 col0" >A</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th id="T__level0_row0" class="row_heading level0 row0" >a</th>
+      <td id="T__row0_col0" class="data row0 col0 my-cls2" >2.6</td>
+    </tr>
+    <tr>
+      <th id="T__level0_row1" class="row_heading level0 row1" >b</th>
+      <td id="T__row1_col0" class="data row1 col0" >2.7</td>
+    </tr>
+  </tbody>
+</table>
+"""
+        assert expected == s.render()
 
 
 @td.skip_if_no_mpl

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -1,7 +1,10 @@
+import inspect
 import pydoc
 
 import numpy as np
 import pytest
+
+from pandas.util._test_decorators import skip_if_no
 
 import pandas as pd
 from pandas import DataFrame, Index, Series, date_range
@@ -167,3 +170,10 @@ class TestSeriesMisc:
         s.attrs["version"] = 1
         result = s + 1
         assert result.attrs == {"version": 1}
+
+    @skip_if_no("jinja2")
+    def test_inspect_getmembers(self):
+        # GH38782
+        ser = Series()
+        with tm.assert_produces_warning(None):
+            inspect.getmembers(ser)


### PR DESCRIPTION
fix #39465 

copy some code from gzip ,now df.to_csv('myfile.csv.zip') works like df.to_csv('myfile.csv.gz')


- [ ] closes #39465 
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
