### PR TITLE
REF: implement Index._view, Index._rename

### DIFF
--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -323,7 +323,7 @@ class Indexing:
         self.index.get_loc(self.category)
 
     def time_shallow_copy(self):
-        self.index._shallow_copy()
+        self.index._view()
 
     def time_align(self):
         pd.DataFrame({"a": self.series, "b": self.series[:500]})

--- a/asv_bench/benchmarks/period.py
+++ b/asv_bench/benchmarks/period.py
@@ -86,7 +86,7 @@ class Indexing:
         self.index.get_loc(self.period)
 
     def time_shallow_copy(self):
-        self.index._shallow_copy()
+        self.index._view()
 
     def time_series_loc(self):
         self.series.loc[self.period]

--- a/asv_bench/benchmarks/timedelta.py
+++ b/asv_bench/benchmarks/timedelta.py
@@ -74,7 +74,7 @@ class TimedeltaIndexing:
         self.index.get_loc(self.timedelta)
 
     def time_shallow_copy(self):
-        self.index._shallow_copy()
+        self.index._view()
 
     def time_series_loc(self):
         self.series.loc[self.timedelta]

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8917,7 +8917,7 @@ NaN 12.3   33.0
             level = count_axis._get_level_number(level)
 
         level_name = count_axis._names[level]
-        level_index = count_axis.levels[level]._shallow_copy(name=level_name)
+        level_index = count_axis.levels[level]._rename(name=level_name)
         level_codes = ensure_int64(count_axis.codes[level])
         counts = lib.count_level_2d(mask, level_codes, len(level_index), axis=axis)
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -607,6 +607,7 @@ class Index(IndexOpsMixin, PandasObject):
         result._cache = self._cache
         return result
 
+    @final
     def _rename(self: _IndexT, name: Hashable) -> _IndexT:
         """
         fastpath for rename if new name is already validated.

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -949,7 +949,8 @@ class Index(IndexOpsMixin, PandasObject):
         """
         name = self._validate_names(name=name, names=names, deep=deep)[0]
         if deep:
-            new_index = self._shallow_copy(self._data.copy(), name=name)
+            new_data = self._data.copy()
+            new_index = type(self)._simple_new(new_data, name=name)
         else:
             new_index = self._rename(name=name)
 

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -220,7 +220,7 @@ class CategoricalIndex(NDArrayBackedExtensionIndex, accessor.PandasDelegate):
     @doc(Index._shallow_copy)
     def _shallow_copy(  # type:ignore[override]
         self,
-        values: Optional[Categorical] = None,
+        values: Categorical,
         name: Hashable = no_default,
     ):
         name = self.name if name is no_default else name

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -214,11 +214,8 @@ class CategoricalIndex(NDArrayBackedExtensionIndex, accessor.PandasDelegate):
 
     # --------------------------------------------------------------------
 
-    # error: Argument 1 of "_shallow_copy" is incompatible with supertype
-    #  "ExtensionIndex"; supertype defines the argument type as
-    #  "Optional[ExtensionArray]"  [override]
     @doc(Index._shallow_copy)
-    def _shallow_copy(  # type:ignore[override]
+    def _shallow_copy(
         self,
         values: Categorical,
         name: Hashable = no_default,

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -797,7 +797,8 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin):
             dates = concat_compat((left._values, right_chunk))
             # With sort being False, we can't infer that result.freq == self.freq
             # TODO: no tests rely on the _with_freq("infer"); needed?
-            result = self._shallow_copy(dates)._with_freq("infer")
+            result = type(self)._simple_new(dates, name=self.name)
+            result = result._with_freq("infer")
             return result
         else:
             left, right = other, self

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -469,7 +469,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         from pandas import Series
 
         if index is None:
-            index = self._shallow_copy()
+            index = self._view()
         if name is None:
             name = self.name
 

--- a/pandas/core/indexes/extension.py
+++ b/pandas/core/indexes/extension.py
@@ -1,7 +1,7 @@
 """
 Shared methods for Index subclasses backed by ExtensionArray.
 """
-from typing import Hashable, List, Optional, TypeVar
+from typing import Hashable, List, TypeVar
 
 import numpy as np
 
@@ -214,17 +214,10 @@ class ExtensionIndex(Index):
     __ge__ = _make_wrapped_comparison_op("__ge__")
 
     @doc(Index._shallow_copy)
-    def _shallow_copy(
-        self, values: Optional[ExtensionArray] = None, name: Hashable = lib.no_default
-    ):
+    def _shallow_copy(self, values: ExtensionArray, name: Hashable = lib.no_default):
         name = self.name if name is lib.no_default else name
 
-        if values is not None:
-            return self._simple_new(values, name=name)
-
-        result = self._simple_new(self._data, name=name)
-        result._cache = self._cache
-        return result
+        return self._simple_new(values, name=name)
 
     @property
     def _has_complex_internals(self) -> bool:

--- a/pandas/core/indexes/extension.py
+++ b/pandas/core/indexes/extension.py
@@ -1,11 +1,10 @@
 """
 Shared methods for Index subclasses backed by ExtensionArray.
 """
-from typing import Hashable, List, TypeVar
+from typing import List, TypeVar
 
 import numpy as np
 
-from pandas._libs import lib
 from pandas.compat.numpy import function as nv
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import cache_readonly, doc
@@ -212,12 +211,6 @@ class ExtensionIndex(Index):
     __gt__ = _make_wrapped_comparison_op("__gt__")
     __le__ = _make_wrapped_comparison_op("__le__")
     __ge__ = _make_wrapped_comparison_op("__ge__")
-
-    @doc(Index._shallow_copy)
-    def _shallow_copy(self, values: ExtensionArray, name: Hashable = lib.no_default):
-        name = self.name if name is lib.no_default else name
-
-        return self._simple_new(values, name=name)
 
     @property
     def _has_complex_internals(self) -> bool:

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -111,8 +111,8 @@ class NumericIndex(Index):
     # ----------------------------------------------------------------
 
     @doc(Index._shallow_copy)
-    def _shallow_copy(self, values=None, name: Hashable = lib.no_default):
-        if values is not None and not self._can_hold_na and values.dtype.kind == "f":
+    def _shallow_copy(self, values, name: Hashable = lib.no_default):
+        if not self._can_hold_na and values.dtype.kind == "f":
             name = self.name if name is lib.no_default else name
             # Ensure we are not returning an Int64Index with float data:
             return Float64Index._simple_new(values, name=name)

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -422,22 +422,22 @@ class RangeIndex(Int64Index):
         yield from self._range
 
     @doc(Int64Index._shallow_copy)
-    def _shallow_copy(self, values=None, name: Hashable = no_default):
+    def _shallow_copy(self, values, name: Hashable = no_default):
         name = self.name if name is no_default else name
 
-        if values is not None:
-            if values.dtype.kind == "f":
-                return Float64Index(values, name=name)
-            return Int64Index._simple_new(values, name=name)
+        if values.dtype.kind == "f":
+            return Float64Index(values, name=name)
+        return Int64Index._simple_new(values, name=name)
 
-        result = self._simple_new(self._range, name=name)
+    def _view(self: RangeIndex) -> RangeIndex:
+        result = type(self)._simple_new(self._range, name=self.name)
         result._cache = self._cache
         return result
 
     @doc(Int64Index.copy)
     def copy(self, name=None, deep=False, dtype: Optional[Dtype] = None, names=None):
         name = self._validate_names(name=name, names=names, deep=deep)[0]
-        new_index = self._shallow_copy(name=name)
+        new_index = self._rename(name=name)
 
         if dtype:
             warnings.warn(

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -138,7 +138,7 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
             if copy:
                 return data.copy()
             else:
-                return data._shallow_copy()
+                return data._view()
 
         # - Cases checked above all return/raise before reaching here - #
 

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -261,7 +261,7 @@ class _Unstacker:
     def get_new_columns(self, value_columns):
         if value_columns is None:
             if self.lift == 0:
-                return self.removed_level._shallow_copy(name=self.removed_name)
+                return self.removed_level._rename(name=self.removed_name)
 
             lev = self.removed_level.insert(0, item=self.removed_level._na_value)
             return lev.rename(self.removed_name)
@@ -639,7 +639,7 @@ def _stack_multi_columns(frame, level_num=-1, dropna=True):
         new_names = this.columns.names[:-1]
         new_columns = MultiIndex.from_tuples(unique_groups, names=new_names)
     else:
-        new_columns = this.columns.levels[0]._shallow_copy(name=this.columns.names[0])
+        new_columns = this.columns.levels[0]._rename(name=this.columns.names[0])
         unique_groups = new_columns
 
     # time to ravel the values

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -733,7 +733,7 @@ class Base:
         # GH32669, GH36840
         idx = self.create_index()
         idx.get_loc(idx[0])  # populates the _cache.
-        shallow_copy = idx._shallow_copy()
+        shallow_copy = idx._view()
 
         assert shallow_copy._cache is idx._cache
 

--- a/pandas/tests/indexes/multi/test_copy.py
+++ b/pandas/tests/indexes/multi/test_copy.py
@@ -30,7 +30,7 @@ def test_copy(idx):
 
 
 def test_shallow_copy(idx):
-    i_copy = idx._shallow_copy()
+    i_copy = idx._view()
 
     assert_multiindex_copied(i_copy, idx)
 

--- a/pandas/tests/indexes/multi/test_names.py
+++ b/pandas/tests/indexes/multi/test_names.py
@@ -31,7 +31,7 @@ def test_changing_names(idx):
 
     view = idx.view()
     copy = idx.copy()
-    shallow_copy = idx._shallow_copy()
+    shallow_copy = idx._view()
 
     # changing names should not change level names on object
     new_names = [name + "a" for name in idx.names]

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -82,7 +82,7 @@ class TestPeriodIndex(DatetimeLike):
     def test_shallow_copy_empty(self):
         # GH13067
         idx = PeriodIndex([], freq="M")
-        result = idx._shallow_copy()
+        result = idx._view()
         expected = idx
 
         tm.assert_index_equal(result, expected)


### PR DESCRIPTION
take these 2 special cases out of _shallow_copy.  We can get rid of some more _shallow_copy usages following #38140