### PR TITLE
Backport PR #39639: REGR: fix transform of empty DataFrame/Series

### DIFF
--- a/doc/source/whatsnew/v1.2.2.rst
+++ b/doc/source/whatsnew/v1.2.2.rst
@@ -21,6 +21,7 @@ Fixed regressions
 - Fixed regression in :meth:`~DataFrame.to_pickle` failing to create bz2/xz compressed pickle files with ``protocol=5`` (:issue:`39002`)
 - Fixed regression in :func:`pandas.testing.assert_series_equal` and :func:`pandas.testing.assert_frame_equal` always raising ``AssertionError`` when comparing extension dtypes (:issue:`39410`)
 - Fixed regression in :meth:`~DataFrame.to_csv` opening ``codecs.StreamWriter`` in binary mode instead of in text mode and ignoring user-provided ``mode`` (:issue:`39247`)
+- Fixed regression in :meth:`DataFrame.transform` failing in case of an empty DataFrame or Series (:issue:`39636`)
 - Fixed regression in :meth:`core.window.rolling.Rolling.count` where the ``min_periods`` argument would be set to ``0`` after the operation (:issue:`39554`)
 -
 

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -456,7 +456,7 @@ def transform(
 
     # Functions that transform may return empty Series/DataFrame
     # when the dtype is not appropriate
-    if isinstance(result, (ABCSeries, ABCDataFrame)) and result.empty:
+    if isinstance(result, (ABCSeries, ABCDataFrame)) and result.empty and not obj.empty:
         raise ValueError("Transform function failed")
     if not isinstance(result, (ABCSeries, ABCDataFrame)) or not result.index.equals(
         obj.index

--- a/pandas/tests/frame/apply/test_frame_transform.py
+++ b/pandas/tests/frame/apply/test_frame_transform.py
@@ -258,3 +258,13 @@ def test_transform_missing_columns(axis):
     match = re.escape("Column(s) ['C'] do not exist")
     with pytest.raises(SpecificationError, match=match):
         df.transform({"C": "cumsum"})
+
+
+def test_transform_empty_dataframe():
+    # https://github.com/pandas-dev/pandas/issues/39636
+    df = DataFrame([], columns=["col1", "col2"])
+    result = df.transform(lambda x: x + 10)
+    tm.assert_frame_equal(result, df)
+
+    result = df["col1"].transform(lambda x: x + 10)
+    tm.assert_series_equal(result, df["col1"])


### PR DESCRIPTION
Backport PR #39639