### PR TITLE
DOC: pin sphinx theme to avoid mobile dropdown bug

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -113,5 +113,5 @@ dependencies:
   - tabulate>=0.8.3  # DataFrame.to_markdown
   - natsort  # DataFrame.sort_values
   - pip:
-    - git+https://github.com/pandas-dev/pydata-sphinx-theme.git@master
+    - git+https://github.com/pandas-dev/pydata-sphinx-theme.git@2488b7defbd3d753dd5fcfc890fc4a7e79d25103
     - git+https://github.com/numpy/numpydoc

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -76,5 +76,5 @@ cftime
 pyreadstat
 tabulate>=0.8.3
 natsort
-git+https://github.com/pandas-dev/pydata-sphinx-theme.git@master
+git+https://github.com/pandas-dev/pydata-sphinx-theme.git@2488b7defbd3d753dd5fcfc890fc4a7e79d25103
 git+https://github.com/numpy/numpydoc


### PR DESCRIPTION
In the latest master version of the pydata-sphinx-theme, there is a bug in the menu dropdown on mobile mode (https://github.com/pydata/pydata-sphinx-theme/issues/304), and since this will probably not be fixed by tomorrow when releasing 1.2.2, I am pinning it here to a few commits earlier to avoid this specific bug (but still using the latest version to have the same looks as the current docs, since we are using a few features that are not yet in the latest stable release).