### PR TITLE
DOC: Start v1.2.3 release notes

### DIFF
--- a/doc/source/whatsnew/index.rst
+++ b/doc/source/whatsnew/index.rst
@@ -24,6 +24,7 @@ Version 1.2
 .. toctree::
    :maxdepth: 2
 
+   v1.2.3
    v1.2.2
    v1.2.1
    v1.2.0

--- a/doc/source/whatsnew/v1.2.2.rst
+++ b/doc/source/whatsnew/v1.2.2.rst
@@ -55,4 +55,4 @@ Other
 Contributors
 ~~~~~~~~~~~~
 
-.. contributors:: v1.2.1..v1.2.2|HEAD
+.. contributors:: v1.2.1..v1.2.2

--- a/doc/source/whatsnew/v1.2.3.rst
+++ b/doc/source/whatsnew/v1.2.3.rst
@@ -1,0 +1,48 @@
+.. _whatsnew_123:
+
+What's new in 1.2.3 (March ??, 2021)
+---------------------------------------
+
+These are the changes in pandas 1.2.3. See :ref:`release` for a full changelog
+including other versions of pandas.
+
+{{ header }}
+
+.. ---------------------------------------------------------------------------
+
+.. _whatsnew_123.regressions:
+
+Fixed regressions
+~~~~~~~~~~~~~~~~~
+
+-
+-
+
+.. ---------------------------------------------------------------------------
+
+.. _whatsnew_123.bug_fixes:
+
+Bug fixes
+~~~~~~~~~
+
+-
+-
+
+.. ---------------------------------------------------------------------------
+
+.. _whatsnew_123.other:
+
+Other
+~~~~~
+
+-
+-
+
+.. ---------------------------------------------------------------------------
+
+.. _whatsnew_123.contributors:
+
+Contributors
+~~~~~~~~~~~~
+
+.. contributors:: v1.2.2..v1.2.3|HEAD

--- a/doc/source/whatsnew/v1.2.3.rst
+++ b/doc/source/whatsnew/v1.2.3.rst
@@ -1,7 +1,7 @@
 .. _whatsnew_123:
 
 What's new in 1.2.3 (March ??, 2021)
----------------------------------------
+------------------------------------
 
 These are the changes in pandas 1.2.3. See :ref:`release` for a full changelog
 including other versions of pandas.


### PR DESCRIPTION
web and docs will fail until 1.2.2 tag exists (can restart just that job after release)

