### PR TITLE
CLN: remove unused arg from Index._get_unique_index

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2620,36 +2620,15 @@ class Index(IndexOpsMixin, PandasObject):
             return np.zeros(len(self), dtype=bool)
         return super().duplicated(keep=keep)
 
-    def _get_unique_index(self, dropna: bool = False):
+    def _get_unique_index(self: _IndexT) -> _IndexT:
         """
         Returns an index containing unique values.
 
-        Parameters
-        ----------
-        dropna : bool, default False
-            If True, NaN values are dropped.
-
         Returns
         -------
-        uniques : index
+        Index
         """
-        if self.is_unique and not dropna:
-            return self
-
-        if not self.is_unique:
-            values = self.unique()
-            if not isinstance(self, ABCMultiIndex):
-                # extract an array to pass to _shallow_copy
-                values = values._data
-        else:
-            values = self._values
-
-        if dropna and not isinstance(self, ABCMultiIndex):
-            # isna not defined for MultiIndex
-            if self.hasnans:
-                values = values[~isna(values)]
-
-        return self._shallow_copy(values)
+        return self.unique()
 
     # --------------------------------------------------------------------
     # Arithmetic & Logical Methods

--- a/pandas/core/indexes/extension.py
+++ b/pandas/core/indexes/extension.py
@@ -263,13 +263,11 @@ class ExtensionIndex(Index):
         # ExtensionIndex subclasses must override Index.insert
         raise AbstractMethodError(self)
 
-    def _get_unique_index(self, dropna=False):
-        if self.is_unique and not dropna:
+    def _get_unique_index(self):
+        if self.is_unique:
             return self
 
         result = self._data.unique()
-        if dropna and self.hasnans:
-            result = result[~result.isna()]
         return self._shallow_copy(result)
 
     @doc(Index.map)

--- a/pandas/tests/indexes/multi/test_duplicates.py
+++ b/pandas/tests/indexes/multi/test_duplicates.py
@@ -71,12 +71,11 @@ def test_unique_level(idx, level):
     tm.assert_index_equal(result, expected)
 
 
-@pytest.mark.parametrize("dropna", [True, False])
-def test_get_unique_index(idx, dropna):
+def test_get_unique_index(idx):
     mi = idx[[0, 1, 0, 1, 1, 0, 0]]
     expected = mi._shallow_copy(mi[[0, 1]])
 
-    result = mi._get_unique_index(dropna=dropna)
+    result = mi._get_unique_index()
     assert result.unique
     tm.assert_index_equal(result, expected)
 

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -158,9 +158,8 @@ class TestCommon:
         except NotImplementedError:
             pass
 
-        for dropna in [False, True]:
-            result = idx._get_unique_index(dropna=dropna)
-            tm.assert_index_equal(result, idx_unique)
+        result = idx._get_unique_index()
+        tm.assert_index_equal(result, idx_unique)
 
         # nans:
         if not index._can_hold_na:
@@ -188,10 +187,10 @@ class TestCommon:
         assert idx_nan.dtype == index.dtype
         assert idx_unique_nan.dtype == index.dtype
 
-        for dropna, expected in zip([False, True], [idx_unique_nan, idx_unique]):
-            for i in [idx_nan, idx_unique_nan]:
-                result = i._get_unique_index(dropna=dropna)
-                tm.assert_index_equal(result, expected)
+        expected = idx_unique_nan
+        for i in [idx_nan, idx_unique_nan]:
+            result = i._get_unique_index()
+            tm.assert_index_equal(result, expected)
 
     def test_searchsorted_monotonic(self, index_flat):
         # GH17271


### PR DESCRIPTION
we'll be able to get rid of get_unique_index altogether following #38140