### PR TITLE
REF: implement ensure_can_hold_na

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -87,12 +87,7 @@ from pandas.core.dtypes.generic import (
     ABCSeries,
 )
 from pandas.core.dtypes.inference import is_list_like
-from pandas.core.dtypes.missing import (
-    is_valid_nat_for_dtype,
-    isna,
-    na_value_for_dtype,
-    notna,
-)
+from pandas.core.dtypes.missing import is_valid_nat_for_dtype, isna, notna
 
 if TYPE_CHECKING:
     from pandas import Series
@@ -548,18 +543,6 @@ def maybe_promote(dtype: DtypeObj, fill_value=np.nan):
             fill_value = np.nan
             dtype = np.dtype(np.object_)
 
-    if is_valid_nat_for_dtype(fill_value, dtype) and dtype.kind in [
-        "i",
-        "u",
-        "f",
-        "c",
-        "m",
-        "M",
-    ]:
-        dtype = ensure_dtype_can_hold_na(dtype)
-        fv = na_value_for_dtype(dtype)
-        return dtype, fv
-
     # returns tuple of (dtype, fill_value)
     if issubclass(dtype.type, np.datetime64):
         if isinstance(fill_value, datetime) and fill_value.tzinfo is not None:
@@ -608,9 +591,7 @@ def maybe_promote(dtype: DtypeObj, fill_value=np.nan):
             # TODO: sure we want to cast here?
             dtype = np.dtype(np.object_)
 
-    elif is_extension_array_dtype(dtype) and isna(
-        fill_value
-    ):  # TODO: is_valid_nat_for_dtype
+    elif is_extension_array_dtype(dtype) and isna(fill_value):
         fill_value = dtype.na_value
 
     elif is_float(fill_value):

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -580,7 +580,7 @@ def maybe_promote(dtype: DtypeObj, fill_value=np.nan):
                     fill_value = np.timedelta64("NaT", "ns")
                 else:
                     fill_value = fv.to_timedelta64()
-    elif is_datetime64tz_dtype(dtype):
+    elif isinstance(dtype, DatetimeTZDtype):
         if isna(fill_value):
             fill_value = NaT
         elif not isinstance(fill_value, datetime):

--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -11,9 +11,8 @@ from pandas._libs import internals as libinternals
 from pandas._typing import ArrayLike, DtypeObj, Manager, Shape
 from pandas.util._decorators import cache_readonly
 
-from pandas.core.dtypes.cast import find_common_type, maybe_promote
+from pandas.core.dtypes.cast import ensure_dtype_can_hold_na, find_common_type
 from pandas.core.dtypes.common import (
-    get_dtype,
     is_categorical_dtype,
     is_datetime64_dtype,
     is_datetime64tz_dtype,
@@ -225,13 +224,13 @@ class JoinUnit:
 
     @cache_readonly
     def dtype(self):
-        if self.block is None:
+        blk = self.block
+        if blk is None:
             raise AssertionError("Block is None, no dtype")
 
         if not self.needs_filling:
-            return self.block.dtype
-        else:
-            return get_dtype(maybe_promote(self.block.dtype, self.block.fill_value)[0])
+            return blk.dtype
+        return ensure_dtype_can_hold_na(blk.dtype)
 
     @cache_readonly
     def is_na(self) -> bool:


### PR DESCRIPTION
Much simpler than maybe_promote, which for the most part id like to replace with something like

```
def maybe_promote(dtype, fill_value):
    inferred, fv = infer_dtype_from(fill_value)
    new_dtype = find_common_type([dtype, inferred])
    return inferred, fv
```