### PR TITLE
CLN: strip whitespaces on `set_td_classes`

### DIFF
--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -683,7 +683,9 @@ class Styler:
         '  </tbody>'
         '</table>'
         """
-        classes = classes.reindex_like(self.data)
+        classes = classes.reindex_like(self.data).applymap(
+            lambda v: v.strip() if isinstance(v, str) else v
+        )  # perf: stripping cost ~2-3ms/5000 elements, maybe improves below
 
         mask = (classes.isna()) | (classes.eq(""))
         self.cell_context["data"] = {

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1749,8 +1749,10 @@ class TestStyler:
                 columns=["A", "B"],
                 index=["a", "b"],
             ),
-            DataFrame(data=[["test-class"]], columns=["B"], index=["a"]),
-            DataFrame(data=[["test-class", "unused"]], columns=["B", "C"], index=["a"]),
+            DataFrame(data=[[" test-class "]], columns=["B"], index=["a"]),
+            DataFrame(
+                data=[["test-class ", "unused"]], columns=["B", "C"], index=["a"]
+            ),
         ],
     )
     def test_set_data_classes(self, classes):

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1756,14 +1756,14 @@ class TestStyler:
         ],
     )
     def test_set_data_classes(self, classes):
-        # GH 36159
+        # GH 36159 / GH 39718
         df = DataFrame(data=[[0, 1], [2, 3]], columns=["A", "B"], index=["a", "b"])
         s = Styler(df, uuid_len=0, cell_ids=False).set_td_classes(classes).render()
         assert '<td  class="data row0 col0" >0</td>' in s
         assert '<td  class="data row0 col1 test-class" >1</td>' in s
         assert '<td  class="data row1 col0" >2</td>' in s
         assert '<td  class="data row1 col1" >3</td>' in s
-        # GH 39317
+        # GH 39317 / GH 39718
         s = Styler(df, uuid_len=0, cell_ids=True).set_td_classes(classes).render()
         assert '<td id="T__row0_col0" class="data row0 col0" >0</td>' in s
         assert '<td id="T__row0_col1" class="data row0 col1 test-class" >1</td>' in s


### PR DESCRIPTION
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

A use case with string DataFrames is to construct multiple and add them, needing space separators:

```
cls1 = pd.DataFrame([['', 'cls1 ']])
cls2 = pd.DataFrame([['cls2 ', '']])
cls3 = pd.DataFrame([['cls3 ', 'cls3 ']])
Styler.set_td_classes(cls1 + cls2 + cls3)
```

Stripping cleans up the output for HTML, and might be helpful in other ways..
