### PR TITLE
[ArrayManager] Implement .equals method

### DIFF
--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -20,7 +20,7 @@ from pandas.core.dtypes.common import (
 )
 from pandas.core.dtypes.dtypes import ExtensionDtype, PandasDtype
 from pandas.core.dtypes.generic import ABCDataFrame, ABCSeries
-from pandas.core.dtypes.missing import isna
+from pandas.core.dtypes.missing import array_equals, isna
 
 import pandas.core.algorithms as algos
 from pandas.core.arrays import ExtensionArray
@@ -829,9 +829,16 @@ class ArrayManager(DataManager):
         values.fill(fill_value)
         return values
 
-    def equals(self, other: object) -> bool:
-        # TODO
-        raise NotImplementedError
+    def _equal_values(self, other) -> bool:
+        """
+        Used in .equals defined in base class. Only check the column values
+        assuming shape and indexes have already been checked.
+        """
+        for left, right in zip(self.arrays, other.arrays):
+            if not array_equals(left, right):
+                return False
+        else:
+            return True
 
     def unstack(self, unstacker, fill_value) -> ArrayManager:
         """

--- a/pandas/core/internals/base.py
+++ b/pandas/core/internals/base.py
@@ -70,3 +70,25 @@ class DataManager(PandasObject):
             consolidate=consolidate,
             only_slice=only_slice,
         )
+
+    def _equal_values(self: T, other: T) -> bool:
+        """
+        To be implemented by the subclasses. Only check the column values
+        assuming shape and indexes have already been checked.
+        """
+        raise AbstractMethodError(self)
+
+    def equals(self, other: object) -> bool:
+        """
+        Implementation for DataFrame.equals
+        """
+        if not isinstance(other, DataManager):
+            return False
+
+        self_axes, other_axes = self.axes, other.axes
+        if len(self_axes) != len(other_axes):
+            return False
+        if not all(ax1.equals(ax2) for ax1, ax2 in zip(self_axes, other_axes)):
+            return False
+
+        return self._equal_values(other)

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1395,16 +1395,11 @@ class BlockManager(DataManager):
             consolidate=False,
         )
 
-    def equals(self, other: object) -> bool:
-        if not isinstance(other, BlockManager):
-            return False
-
-        self_axes, other_axes = self.axes, other.axes
-        if len(self_axes) != len(other_axes):
-            return False
-        if not all(ax1.equals(ax2) for ax1, ax2 in zip(self_axes, other_axes)):
-            return False
-
+    def _equal_values(self: T, other: T) -> bool:
+        """
+        Used in .equals defined in base class. Only check the column values
+        assuming shape and indexes have already been checked.
+        """
         if self.ndim == 1:
             # For SingleBlockManager (i.e.Series)
             if other.ndim != 1:

--- a/pandas/tests/frame/methods/test_equals.py
+++ b/pandas/tests/frame/methods/test_equals.py
@@ -1,12 +1,7 @@
 import numpy as np
 
-import pandas.util._test_decorators as td
-
 from pandas import DataFrame, date_range
 import pandas._testing as tm
-
-# TODO(ArrayManager) implement equals
-pytestmark = td.skip_array_manager_not_yet_implemented
 
 
 class TestEquals:
@@ -16,13 +11,14 @@ class TestEquals:
         df2 = DataFrame({"a": ["s", "d"], "b": [1, 2]})
         assert df1.equals(df2) is False
 
-    def test_equals_different_blocks(self):
+    def test_equals_different_blocks(self, using_array_manager):
         # GH#9330
         df0 = DataFrame({"A": ["x", "y"], "B": [1, 2], "C": ["w", "z"]})
         df1 = df0.reset_index()[["A", "B", "C"]]
-        # this assert verifies that the above operations have
-        # induced a block rearrangement
-        assert df0._mgr.blocks[0].dtype != df1._mgr.blocks[0].dtype
+        if not using_array_manager:
+            # this assert verifies that the above operations have
+            # induced a block rearrangement
+            assert df0._mgr.blocks[0].dtype != df1._mgr.blocks[0].dtype
 
         # do the real tests
         tm.assert_frame_equal(df0, df1)


### PR DESCRIPTION
xref #39146

Moved the common part (checking of dimension and indices) to the base class `equals` method so this can be shared, and the actual BlockManager/AraryManager then only need to check the column values.