### PR TITLE
REF: remove take_1d alias of take_nd

### DIFF
--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -29,7 +29,7 @@ from pandas import (
     Series,
     TimedeltaIndex,
 )
-from pandas.core.algorithms import safe_sort, take_1d
+from pandas.core.algorithms import safe_sort, take_nd
 from pandas.core.arrays import (
     DatetimeArray,
     ExtensionArray,
@@ -309,7 +309,7 @@ def assert_index_equal(
         # accept level number only
         unique = index.levels[level]
         level_codes = index.codes[level]
-        filled = take_1d(unique._values, level_codes, fill_value=unique._na_value)
+        filled = take_nd(unique._values, level_codes, fill_value=unique._na_value)
         return unique._shallow_copy(filled, name=index.names[level])
 
     if check_less_precise is not no_default:

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1652,7 +1652,7 @@ def take(arr, indices, axis: int = 0, allow_fill: bool = False, fill_value=None)
     if allow_fill:
         # Pandas style, -1 means NA
         validate_indices(indices, arr.shape[axis])
-        result = take_1d(
+        result = take_nd(
             arr, indices, axis=axis, allow_fill=True, fill_value=fill_value
         )
     else:
@@ -1771,9 +1771,6 @@ def take_nd(
     if flip_order:
         out = out.T
     return out
-
-
-take_1d = take_nd
 
 
 def take_2d_multi(arr, indexer, fill_value=np.nan):
@@ -2159,9 +2156,9 @@ def safe_sort(
         sorter = ensure_platform_int(t.lookup(ordered))
 
     if na_sentinel == -1:
-        # take_1d is faster, but only works for na_sentinels of -1
+        # take_nd is faster, but only works for na_sentinels of -1
         order2 = sorter.argsort()
-        new_codes = take_1d(order2, codes, fill_value=-1)
+        new_codes = take_nd(order2, codes, fill_value=-1)
         if verify:
             mask = (codes < -len(values)) | (codes >= len(values))
         else:

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -59,7 +59,7 @@ from pandas.core.dtypes.missing import is_valid_na_for_dtype, isna, notna
 from pandas.core import ops
 from pandas.core.accessor import PandasDelegate, delegate_names
 import pandas.core.algorithms as algorithms
-from pandas.core.algorithms import factorize, get_data_algo, take_1d, unique1d
+from pandas.core.algorithms import factorize, get_data_algo, take_nd, unique1d
 from pandas.core.arrays._mixins import NDArrayBackedExtensionArray
 from pandas.core.base import ExtensionArray, NoNewAttributesMixin, PandasObject
 import pandas.core.common as com
@@ -475,7 +475,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
                 msg = f"Cannot cast {self.categories.dtype} dtype to {dtype}"
                 raise ValueError(msg)
 
-            result = take_1d(new_cats, libalgos.ensure_platform_int(self._codes))
+            result = take_nd(new_cats, libalgos.ensure_platform_int(self._codes))
 
         return result
 
@@ -1310,7 +1310,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
             if dtype==None (default), the same dtype as
             categorical.categories.dtype.
         """
-        ret = take_1d(self.categories._values, self._codes)
+        ret = take_nd(self.categories._values, self._codes)
         if dtype and not is_dtype_equal(dtype, self.categories.dtype):
             return np.asarray(ret, dtype)
         # When we're a Categorical[ExtensionArray], like Interval,
@@ -2349,7 +2349,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         categories = self.categories
         codes = self.codes
         result = PandasArray(categories.to_numpy())._str_map(f, na_value, dtype)
-        return take_1d(result, codes, fill_value=na_value)
+        return take_nd(result, codes, fill_value=na_value)
 
     def _str_get_dummies(self, sep="|"):
         # sep may not be in categories. Just bail on this.
@@ -2600,7 +2600,7 @@ def recode_for_categories(
     indexer = coerce_indexer_dtype(
         new_categories.get_indexer(old_categories), new_categories
     )
-    new_codes = take_1d(indexer, codes, fill_value=-1)
+    new_codes = take_nd(indexer, codes, fill_value=-1)
     return new_codes
 
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -926,7 +926,7 @@ class IndexOpsMixin(OpsMixin):
             values = self._values
 
             indexer = mapper.index.get_indexer(values)
-            new_values = algorithms.take_1d(mapper._values, indexer)
+            new_values = algorithms.take_nd(mapper._values, indexer)
 
             return new_values
 

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -272,9 +272,9 @@ def union_categoricals(
             categories = categories.sort_values()
             indexer = categories.get_indexer(first.categories)
 
-            from pandas.core.algorithms import take_1d
+            from pandas.core.algorithms import take_nd
 
-            new_codes = take_1d(indexer, new_codes, fill_value=-1)
+            new_codes = take_nd(indexer, new_codes, fill_value=-1)
     elif ignore_order or all(not c.ordered for c in to_union):
         # different categories - union and recode
         cats = first.categories.append([c.categories for c in to_union[1:]])

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -565,7 +565,7 @@ class SeriesGroupBy(GroupBy[Series]):
         """
         ids, _, ngroup = self.grouper.group_info
         result = result.reindex(self.grouper.result_index, copy=False)
-        out = algorithms.take_1d(result._values, ids)
+        out = algorithms.take_nd(result._values, ids)
         return self.obj._constructor(out, index=self.obj.index, name=self.obj.name)
 
     def filter(self, func, dropna=True, *args, **kwargs):
@@ -1413,7 +1413,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         ids, _, ngroup = self.grouper.group_info
         result = result.reindex(self.grouper.result_index, copy=False)
         output = [
-            algorithms.take_1d(result.iloc[:, i].values, ids)
+            algorithms.take_nd(result.iloc[:, i].values, ids)
             for i, _ in enumerate(result.columns)
         ]
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -42,7 +42,7 @@ from pandas.core.dtypes.common import (
 )
 from pandas.core.dtypes.dtypes import IntervalDtype
 
-from pandas.core.algorithms import take_1d, unique
+from pandas.core.algorithms import take_nd, unique
 from pandas.core.arrays.interval import IntervalArray, _interval_shared_docs
 import pandas.core.common as com
 from pandas.core.indexers import is_valid_positional_slice
@@ -673,7 +673,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
             target = cast("CategoricalIndex", target)
             # get an indexer for unique categories then propagate to codes via take_1d
             categories_indexer = self.get_indexer(target.categories)
-            indexer = take_1d(categories_indexer, target.codes, fill_value=-1)
+            indexer = take_nd(categories_indexer, target.codes, fill_value=-1)
         elif not is_object_dtype(target):
             # homogeneous scalar index: use IntervalTree
             target = self._maybe_convert_i8(target)

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -671,7 +671,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
             indexer = np.where(left_indexer == right_indexer, left_indexer, -1)
         elif is_categorical_dtype(target.dtype):
             target = cast("CategoricalIndex", target)
-            # get an indexer for unique categories then propagate to codes via take_1d
+            # get an indexer for unique categories then propagate to codes via take_nd
             categories_indexer = self.get_indexer(target.categories)
             indexer = take_nd(categories_indexer, target.codes, fill_value=-1)
         elif not is_object_dtype(target):

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1343,7 +1343,7 @@ class MultiIndex(Index):
                 # weird all NA case
                 formatted = [
                     pprint_thing(na if isna(x) else x, escape_chars=("\t", "\r", "\n"))
-                    for x in algos.take_1d(lev._values, level_codes)
+                    for x in algos.take_nd(lev._values, level_codes)
                 ]
             stringified_levels.append(formatted)
 
@@ -1632,7 +1632,7 @@ class MultiIndex(Index):
         name = self._names[level]
         if unique:
             level_codes = algos.unique(level_codes)
-        filled = algos.take_1d(lev._values, level_codes, fill_value=lev._na_value)
+        filled = algos.take_nd(lev._values, level_codes, fill_value=lev._na_value)
         return lev._shallow_copy(filled, name=name)
 
     def get_level_values(self, level):
@@ -1916,7 +1916,7 @@ class MultiIndex(Index):
                     # indexer to reorder the level codes
                     indexer = ensure_int64(indexer)
                     ri = lib.get_reverse_indexer(indexer, len(indexer))
-                    level_codes = algos.take_1d(ri, level_codes)
+                    level_codes = algos.take_nd(ri, level_codes)
 
             new_levels.append(lev)
             new_codes.append(level_codes)

--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -139,8 +139,8 @@ def _get_mgr_concatenation_plan(mgr: BlockManager, indexers: Dict[int, np.ndarra
 
     if 0 in indexers:
         ax0_indexer = indexers.pop(0)
-        blknos = algos.take_1d(mgr.blknos, ax0_indexer, fill_value=-1)
-        blklocs = algos.take_1d(mgr.blklocs, ax0_indexer, fill_value=-1)
+        blknos = algos.take_nd(mgr.blknos, ax0_indexer, fill_value=-1)
+        blklocs = algos.take_nd(mgr.blklocs, ax0_indexer, fill_value=-1)
     else:
 
         if mgr.is_single_block:

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -645,7 +645,7 @@ def _list_of_series_to_arrays(
             indexer = indexer_cache[id(index)] = index.get_indexer(columns)
 
         values = extract_array(s, extract_numpy=True)
-        aligned_values.append(algorithms.take_1d(values, indexer))
+        aligned_values.append(algorithms.take_nd(values, indexer))
 
     content = np.vstack(aligned_values)
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -255,7 +255,7 @@ class BlockManager(DataManager):
 
     def get_dtypes(self):
         dtypes = np.array([blk.dtype for blk in self.blocks])
-        return algos.take_1d(dtypes, self.blknos, allow_fill=False)
+        return algos.take_nd(dtypes, self.blknos, allow_fill=False)
 
     def __getstate__(self):
         block_values = [b.values for b in self.blocks]
@@ -1308,10 +1308,10 @@ class BlockManager(DataManager):
             blknos = self.blknos[slobj]
             blklocs = self.blklocs[slobj]
         else:
-            blknos = algos.take_1d(
+            blknos = algos.take_nd(
                 self.blknos, slobj, fill_value=-1, allow_fill=allow_fill
             )
-            blklocs = algos.take_1d(
+            blklocs = algos.take_nd(
                 self.blklocs, slobj, fill_value=-1, allow_fill=allow_fill
             )
 

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1713,7 +1713,7 @@ class TimeGrouper(Grouper):
 def _take_new_index(obj, indexer, new_index, axis=0):
 
     if isinstance(obj, ABCSeries):
-        new_values = algos.take_1d(obj._values, indexer)
+        new_values = algos.take_nd(obj._values, indexer)
         return obj._constructor(new_values, index=new_index, name=obj.name)
     elif isinstance(obj, ABCDataFrame):
         if axis == 1:

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -852,13 +852,13 @@ class _MergeOperation:
                     lvals = result[name]._values
                 else:
                     lfill = na_value_for_dtype(take_left.dtype)
-                    lvals = algos.take_1d(take_left, left_indexer, fill_value=lfill)
+                    lvals = algos.take_nd(take_left, left_indexer, fill_value=lfill)
 
                 if take_right is None:
                     rvals = result[name]._values
                 else:
                     rfill = na_value_for_dtype(take_right.dtype)
-                    rvals = algos.take_1d(take_right, right_indexer, fill_value=rfill)
+                    rvals = algos.take_nd(take_right, right_indexer, fill_value=rfill)
 
                 # if we have an all missing left_indexer
                 # make sure to just use the right values or vice-versa

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4155,7 +4155,7 @@ Keep all original rows and also all original values
                 return self.copy()
             return self
 
-        new_values = algorithms.take_1d(
+        new_values = algorithms.take_nd(
             self._values, indexer, allow_fill=True, fill_value=None
         )
         return self._constructor(new_values, index=new_index)

--- a/pandas/tests/test_take.py
+++ b/pandas/tests/test_take.py
@@ -80,7 +80,7 @@ class TestTake:
 
         indexer = [2, 1, 0, 1]
         out = np.empty(4, dtype=dtype)
-        algos.take_1d(data, indexer, out=out)
+        algos.take_nd(data, indexer, out=out)
 
         expected = data.take(indexer)
         tm.assert_almost_equal(out, expected)
@@ -89,13 +89,13 @@ class TestTake:
         out = np.empty(4, dtype=dtype)
 
         if can_hold_na:
-            algos.take_1d(data, indexer, out=out)
+            algos.take_nd(data, indexer, out=out)
             expected = data.take(indexer)
             expected[3] = np.nan
             tm.assert_almost_equal(out, expected)
         else:
             with pytest.raises(TypeError, match=self.fill_error):
-                algos.take_1d(data, indexer, out=out)
+                algos.take_nd(data, indexer, out=out)
 
             # No Exception otherwise.
             data.take(indexer, out=out)
@@ -105,14 +105,14 @@ class TestTake:
         data = np.random.randint(0, 2, 4).astype(dtype)
         indexer = [2, 1, 0, -1]
 
-        result = algos.take_1d(data, indexer, fill_value=fill_value)
+        result = algos.take_nd(data, indexer, fill_value=fill_value)
         assert (result[[0, 1, 2]] == data[[2, 1, 0]]).all()
         assert result[3] == fill_value
         assert result.dtype == out_dtype
 
         indexer = [2, 1, 0, 1]
 
-        result = algos.take_1d(data, indexer, fill_value=fill_value)
+        result = algos.take_nd(data, indexer, fill_value=fill_value)
         assert (result[[0, 1, 2, 3]] == data[indexer]).all()
         assert result.dtype == dtype
 
@@ -269,7 +269,7 @@ class TestTake:
         arr = np.random.randn(10).astype(np.float32)
 
         indexer = [1, 2, 3, -1]
-        result = algos.take_1d(arr, indexer)
+        result = algos.take_nd(arr, indexer)
         expected = arr.take(indexer)
         expected[-1] = np.nan
         tm.assert_almost_equal(result, expected)
@@ -294,11 +294,11 @@ class TestTake:
     def test_1d_bool(self):
         arr = np.array([0, 1, 0], dtype=bool)
 
-        result = algos.take_1d(arr, [0, 2, 2, 1])
+        result = algos.take_nd(arr, [0, 2, 2, 1])
         expected = arr.take([0, 2, 2, 1])
         tm.assert_numpy_array_equal(result, expected)
 
-        result = algos.take_1d(arr, [0, 2, -1])
+        result = algos.take_nd(arr, [0, 2, -1])
         assert result.dtype == np.object_
 
     def test_2d_bool(self):


### PR DESCRIPTION
@jreback as discussed in https://github.com/pandas-dev/pandas/pull/39692

Since this is just an alias, this is certainly fine in theory. Although now doing it, I think there is still *some* value of the alias to signal that it is taking a 1D array which can provide useful context when *reading* code that uses this.