### PR TITLE
BUG: Timedelta input string with only symbols and no digits raises an error (GH39710)

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -292,7 +292,7 @@ Timedelta
 ^^^^^^^^^
 - Bug in constructing :class:`Timedelta` from ``np.timedelta64`` objects with non-nanosecond units that are out of bounds for ``timedelta64[ns]`` (:issue:`38965`)
 - Bug in constructing a :class:`TimedeltaIndex` incorrectly accepting ``np.datetime64("NaT")`` objects (:issue:`39462`)
--
+- Bug in constructing :class:`Timedelta` from input string with only symbols and no digits failed to raise an error (:issue:`39710`)
 
 Timezones
 ^^^^^^^^^

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -496,6 +496,10 @@ cdef inline int64_t parse_timedelta_string(str ts) except? -1:
         else:
             raise ValueError("unit abbreviation w/o a number")
 
+    # we only have symbols and no numbers
+    elif len(number) == 0:
+        raise ValueError("symbols w/o a number")
+
     # treat as nanoseconds
     # but only if we don't have anything else
     else:

--- a/pandas/tests/scalar/timedelta/test_constructors.py
+++ b/pandas/tests/scalar/timedelta/test_constructors.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from itertools import product
 
 import numpy as np
 import pytest
@@ -337,3 +338,22 @@ def test_string_with_unit(constructor, value, unit, expectation):
     exp, match = expectation
     with pytest.raises(exp, match=match):
         _ = constructor(value, unit=unit)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "".join(elements)
+        for repetition in (1, 2)
+        for elements in product("+-, ", repeat=repetition)
+    ],
+)
+def test_string_without_numbers(value):
+    # GH39710 Timedelta input string with only symbols and no digits raises an error
+    msg = (
+        "symbols w/o a number"
+        if value != "--"
+        else "only leading negative signs are allowed"
+    )
+    with pytest.raises(ValueError, match=msg):
+        Timedelta(value)


### PR DESCRIPTION
- [x] closes #39710
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
