### PR TITLE
CI: fix reference to take_1d()

### DIFF
--- a/asv_bench/benchmarks/gil.py
+++ b/asv_bench/benchmarks/gil.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from pandas import DataFrame, Series, date_range, factorize, read_csv
-from pandas.core.algorithms import take_1d
+from pandas.core.algorithms import take_nd
 
 from .pandas_vb_common import tm
 
@@ -110,7 +110,7 @@ class ParallelTake1D:
 
         @test_parallel(num_threads=2)
         def parallel_take1d():
-            take_1d(df["col"].values, indexer)
+            take_nd(df["col"].values, indexer)
 
         self.parallel_take1d = parallel_take1d
 


### PR DESCRIPTION
Fix for issue noted by @lithomas1 in https://github.com/pandas-dev/pandas/pull/39731#issuecomment-777179836, which is causing the Benchmarks to fail.

- [ ] ~~closes #xxxx~~
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] ~~whatsnew entry~~
