### PR TITLE
DOC: Remove repeated column assignment in visualization doc

### DIFF
--- a/doc/source/user_guide/visualization.rst
+++ b/doc/source/user_guide/visualization.rst
@@ -665,7 +665,7 @@ given by column ``z``. The bins are aggregated with NumPy's ``max`` function.
 .. ipython:: python
 
    df = pd.DataFrame(np.random.randn(1000, 2), columns=["a", "b"])
-   df["b"] = df["b"] = df["b"] + np.arange(1000)
+   df["b"] = df["b"] + np.arange(1000)
    df["z"] = np.random.uniform(0, 3, 1000)
 
    @savefig hexbin_plot_agg.png


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

The visualization doc had an example where a column in a DataFrame is repeatedly assigned.

```python
df["b"] = df["b"] = df["b"] + np.arange(1000)
```

The expression has been simplified.

---

Thanks for helping to maintain the library!
