### PR TITLE
CLN: remove redundant openpyxl type conversions

### DIFF
--- a/pandas/io/excel/_openpyxl.py
+++ b/pandas/io/excel/_openpyxl.py
@@ -509,7 +509,7 @@ class OpenpyxlReader(BaseExcelReader):
 
     def _convert_cell(self, cell, convert_float: bool) -> Scalar:
 
-        from openpyxl.cell.cell import TYPE_BOOL, TYPE_ERROR, TYPE_NUMERIC
+        from openpyxl.cell.cell import TYPE_ERROR, TYPE_NUMERIC
 
         if cell.value is None:
             return ""  # compat with xlrd

--- a/pandas/io/excel/_openpyxl.py
+++ b/pandas/io/excel/_openpyxl.py
@@ -513,20 +513,10 @@ class OpenpyxlReader(BaseExcelReader):
 
         if cell.value is None:
             return ""  # compat with xlrd
-        elif cell.is_date:
-            return cell.value
         elif cell.data_type == TYPE_ERROR:
             return np.nan
-        elif cell.data_type == TYPE_BOOL:
-            return bool(cell.value)
-        elif cell.data_type == TYPE_NUMERIC:
-            # GH5394
-            if convert_float:
-                val = int(cell.value)
-                if val == cell.value:
-                    return val
-            else:
-                return float(cell.value)
+        elif not convert_float and cell.data_type == TYPE_NUMERIC:
+            return float(cell.value)
 
         return cell.value
 


### PR DESCRIPTION
openpyxl already converts cell values to Python types, preferring
integers where possible. For backwards-compatibility, we have to convert
integers back to float if not `convert_float`

- [ ] closes #xxxx
- [x] tests passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
