### PR TITLE
DOC: Add reference to Text Extensions for Pandas project

### DIFF
--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -480,8 +480,8 @@ use pint's extension array are then units aware.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``Text Extensions for Pandas <https://ibm.biz/text-extensions-for-pandas>``
-provides extension types to cover common data structures for representing natural language 
-data, plus library integrations that convert the outputs of popular natural language 
+provides extension types to cover common data structures for representing natural language
+data, plus library integrations that convert the outputs of popular natural language
 processing libraries into Pandas DataFrames.
 
 .. _ecosystem.accessors:

--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -476,6 +476,14 @@ storing numeric arrays with units. These arrays can be stored inside pandas'
 Series and DataFrame. Operations between Series and DataFrame columns which
 use pint's extension array are then units aware.
 
+`Text Extensions for Pandas`_
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``Text Extensions for Pandas <https://ibm.biz/text-extensions-for-pandas>``
+provides extension types to cover common data structures for representing natural language 
+data, plus library integrations that convert the outputs of popular natural language 
+processing libraries into Pandas DataFrames.
+
 .. _ecosystem.accessors:
 
 Accessors


### PR DESCRIPTION
This PR adds a reference to our Text Extensions for Pandas library, which adds extension types for representing natural language processing data in Pandas DataFrames, to the "Pandas ecosystem" section of the documentation.

Main web page for our project: https://ibm.biz/text-extensions-for-pandas
Source code: https://github.com/CODAIT/text-extensions-for-pandas
API docs: https://text-extensions-for-pandas.readthedocs.io/
