### PR TITLE
TYP: typing refactor mypy fix

### DIFF
--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -158,13 +158,12 @@ class Styler:
         uuid_len: int = 5,
     ):
         # validate ordered args
-        if not isinstance(data, (pd.Series, pd.DataFrame)):
-            raise TypeError("``data`` must be a Series or DataFrame")
-        if data.ndim == 1:
+        if isinstance(data, pd.Series):
             data = data.to_frame()
+        if not isinstance(data, DataFrame):
+            raise TypeError("``data`` must be a Series or DataFrame")
         if not data.index.is_unique or not data.columns.is_unique:
             raise ValueError("style is not supported for non-unique indices.")
-        assert isinstance(data, DataFrame)
         self.data: DataFrame = data
         self.index: pd.Index = data.index
         self.columns: pd.Index = data.columns


### PR DESCRIPTION
`pandas/io/formats/style.py:168: error: Incompatible types in assignment (expression has type "Union[DataFrame, Series]", variable has type "DataFrame")  [assignment]`

refactor to remove the `assert` statement otherwise needed to solve the above `mypy` error.