### PR TITLE
[WIP] ENH: Add only_unique group-by aggregation method

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1759,8 +1759,10 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
                 elif len(arr) == 1:
                     return next(iter(arr))
                 else:
-                    msg = f"Expected exactly one unique item in series, but got {len(arr)}."
-                    raise ValueError(msg)
+                    raise ValueError(
+                        "Expected exactly one unique item in series, "
+                        f"but got {len(arr)}."
+                    )
 
             if isinstance(obj, DataFrame):
                 return obj.apply(only_unique, axis=axis)

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1748,6 +1748,35 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
         )
 
     @final
+    @doc(_groupby_agg_method_template, fname="only unique", no=False, mc=-1)
+    def only_unique(self, numeric_only: bool = False, min_count: int = -1):
+        def only_unique_compat(obj: FrameOrSeries, axis: int = 0):
+            def only_unique(x: Series):
+                """Helper function for only unique item."""
+                arr = set(x)
+                if not arr:
+                    return np.nan
+                elif len(arr) == 1:
+                    return next(iter(arr))
+                else:
+                    msg = f"Expected exactly one unique item in series, but got {len(arr)}."
+                    raise ValueError(msg)
+
+            if isinstance(obj, DataFrame):
+                return obj.apply(only_unique, axis=axis)
+            elif isinstance(obj, Series):
+                return only_unique(obj)
+            else:
+                raise TypeError(type(obj))
+
+        return self._agg_general(
+            numeric_only=numeric_only,
+            min_count=min_count,
+            alias="only_unique",
+            npfunc=only_unique_compat,
+        )
+
+    @final
     @Substitution(name="groupby")
     @Appender(_common_see_also)
     def ohlc(self) -> DataFrame:

--- a/pandas/tests/groupby/test_only_unique.py
+++ b/pandas/tests/groupby/test_only_unique.py
@@ -1,0 +1,52 @@
+import pytest
+
+import pandas as pd
+import pandas._testing as tm
+
+
+def test_only_unique():
+    df = pd.DataFrame(
+        {"A": list("abbacc"), "B": list("122133"), "C": [1, 2, 2, 1, 3, 3]}
+    )
+
+    expected = pd.DataFrame({"A": list("abc"), "B": list("123"), "C": [1, 2, 3]})
+    result = df.groupby("A", as_index=False).only_unique()
+    tm.assert_frame_equal(result, expected)
+
+
+def test_only_unique_as_index():
+    df = pd.DataFrame({"A": list("abbacc"), "B": list("122133")})
+    expected = pd.DataFrame({"A": list("abc"), "B": list("123")})
+    result = df.groupby("A").only_unique()
+    tm.assert_frame_equal(result, expected.set_index("A"))
+
+
+def test_only_unique_aggregate():
+    df = pd.DataFrame({"A": list("abbacc"), "B": list("122133")})
+    expected = pd.DataFrame({"A": list("abc"), "B": list("123")})
+    result = df.groupby("A").aggregate("only_unique")
+    tm.assert_frame_equal(result, expected.set_index("A"))
+
+
+def test_not_only_unique():
+    df = pd.DataFrame({"A": list("abbacc"), "B": list("122333")})
+
+    with pytest.raises(ValueError):
+        df.groupby("A").only_unique()
+
+
+def test_with_missing():
+    df = pd.DataFrame({"A": list("abbcc"), "B": [None, 1, 1, 3, 3]})
+
+    expected = pd.DataFrame({"A": list("abc"), "B": [None, 1, 3]}).set_index("A")
+    result = df.groupby("A").only_unique()
+    tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.xfail(reason="missing values not yet handled properly")
+def test_with_multiple_missing():
+    df = pd.DataFrame({"A": list("abbcc"), "B": [None, 1, 1, None, 3, 3]})
+
+    expected = pd.DataFrame({"A": list("abc"), "B": [None, 1, 3]}).set_index("A")
+    result = df.groupby("A").only_unique()
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
I think it would be useful to have a "only unique value" aggregation method. I've implemented a straw-man version so far to get some feedback before I do any more.

- [x] closes #xxxx N/A
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

Idea is that you often get data-frames where some of the columns are constant across a group-by. Usually, this is collapsed using "first" when doing a group-by, but it would be good to have a version that verifies that the columns are constant as well.

For example:

```python
df = pd.DataFrame({"id": [0, 0, 1, 1], "name": ["Alice", "Alice", "Bob", "Bob"], "score": [0, 1, 2, 3]})
pd.concat([
    df.groupby("id")["name"].only_unique(),
    df.groupby("id")["score"].max(),
], axis=1)
```

```raw
     name  score
id              
0   Alice    0.5
1     Bob    2.5
```

```python
df = pd.DataFrame({"id": [0, 0, 1, 1], "name": ["Alice", "Alice", "Bob", "Charlie"], "score": [0, 1, 2, 3]})
pd.concat([
    df.groupby("id")["name"].only_unique(),
    df.groupby("id")["score"].max(),
], axis=1)
```

```raw
...
ValueError: Expected exactly one unique item in series, but got 2.
```

I've chosen not to drop NA values, so that the exact null value is maintained, but I'm definitely open to changing it.

```python
df = pd.DataFrame({"id": [0, 0, 1, 1], "name": ["Alice", "Alice", None, None], "score": [0, 1, 2, 3]})
pd.concat([
    df.groupby("id")["name"].only_unique(),
    df.groupby("id")["score"].max(),
], axis=1)
```

```raw
     name  score
id              
0   Alice    0.5
1    None    2.5
```
