### PR TITLE
CI: upload coverage report to Codecov

### DIFF
--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -176,7 +176,5 @@ jobs:
       with:
         files: /tmp/test_coverage.xml
         flags: unittests
-        env_vars: OS,PYTHON
         name: codecov-pandas
         fail_ci_if_error: true
-        verbose: true

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -170,3 +170,13 @@ jobs:
 
     - name: Print skipped tests
       run: python ci/print_skipped.py
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        files: /tmp/test_coverage.xml
+        flags: unittests
+        env_vars: OS,PYTHON
+        name: codecov-pandas
+        fail_ci_if_error: true
+        verbose: true


### PR DESCRIPTION
After moving the coverage build from Travis to GitHub Actions #38344, coverage upload was stopped. 

Trying to add it back using action provided by codecov. https://github.com/codecov/codecov-action
