### PR TITLE
PERF: use arr.size instead of np.prod(arr.shape) in _can_use_numexpr

### DIFF
--- a/pandas/core/array_algos/transforms.py
+++ b/pandas/core/array_algos/transforms.py
@@ -19,7 +19,7 @@ def shift(values: np.ndarray, periods: int, axis: int, fill_value) -> np.ndarray
         new_values = new_values.T
         axis = new_values.ndim - axis - 1
 
-    if np.prod(new_values.shape):
+    if new_values.size:
         new_values = np.roll(new_values, ensure_platform_int(periods), axis=axis)
 
     axis_indexer = [slice(None)] * values.ndim

--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -76,7 +76,7 @@ def _can_use_numexpr(op, op_str, a, b, dtype_check):
     if op_str is not None:
 
         # required min elements (otherwise we are adding overhead)
-        if np.prod(a.shape) > _MIN_ELEMENTS:
+        if a.size > _MIN_ELEMENTS:
             # check for dtype compatibility
             dtypes: Set[str] = set()
             for o in [a, b]:

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1497,7 +1497,7 @@ def maybe_cast_to_datetime(value, dtype: Optional[DtypeObj]):
                     value = iNaT
 
                 # we have an array of datetime or timedeltas & nulls
-                elif np.prod(value.shape) or not is_dtype_equal(value.dtype, dtype):
+                elif value.size or not is_dtype_equal(value.dtype, dtype):
                     _disallow_mismatched_datetimelike(value, dtype)
 
                     try:

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -429,7 +429,7 @@ def array_equivalent(
 
     # NaNs can occur in float and complex arrays.
     if is_float_dtype(left.dtype) or is_complex_dtype(left.dtype):
-        if not (np.prod(left.shape) and np.prod(right.shape)):
+        if not (left.size and right.size):
             return True
         return ((left == right) | (isna(left) & isna(right))).all()
 


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/39772

Using `np.prod` gives quite some overhead, and I *think* it's always equivalent to `.size` ?

```
In [1]: arr = np.random.randn(3, 2)

In [2]: %timeit arr.size
42.8 ns ± 0.628 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [3]: %timeit np.prod(arr.shape)
6.63 µs ± 344 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```