### PR TITLE
CI: remove stale assignments

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,3 +1,4 @@
+# deprecated in favor of /assign
 name: Assign
 on:
   issue_comment:

--- a/.github/workflows/slash_assign.yml
+++ b/.github/workflows/slash_assign.yml
@@ -1,0 +1,32 @@
+# https://github.com/JasonEtco/slash-assign-action#usage
+name: Slash assign
+
+on:
+  schedule:
+    - cron: 0 0 * * *
+  issue_comment:
+    types: [created]
+
+jobs:
+  slash_assign:
+    if: >
+      (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/assign')) ||
+      github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      # not yet published
+      # https://github.com/JasonEtco/slash-assign-action/issues/1
+      - name: Check out GitHub Action
+        uses: actions/checkout@v2
+        with:
+          repository: JasonEtco/slash-assign-action
+          ref: 842404647dfd10109c8c4feb3e776807eb5e2071
+          path: .github/actions/slash-assign-action
+      - name: Compile the Action
+        run: |
+          npm install
+          npm run build
+        working-directory: .github/actions/slash-assign-action
+
+      - name: Assign the user or unassign stale assignments
+        uses: ./.github/actions/slash-assign-action

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -31,13 +31,13 @@ comment letting others know they are working on an issue. While this is ok, you 
 check each issue individually, and it's not possible to find the unassigned ones.
 
 For this reason, we implemented a workaround consisting of adding a comment with the exact
-text ``take``. When you do it, a GitHub action will automatically assign you the issue
+text ``/assign``. When you do it, a GitHub action will automatically assign you the issue
 (this will take seconds, and may require refreshing the page to see it).
 By doing this, it's possible to filter the list of issues and find only the unassigned ones.
 
 So, a good way to find an issue to start contributing to pandas is to check the list of
 `unassigned good first issues <https://github.com/pandas-dev/pandas/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+no%3Aassignee>`_
-and assign yourself one you like by writing a comment with the exact text ``take``.
+and assign yourself one you like by writing a comment with the exact text ``/assign``.
 
 If for whatever reason you are not able to continue working with the issue, please try to
 unassign it, so other people know it's available again. You can check the list of


### PR DESCRIPTION
Use a third-party GitHub Action to handle the claiming of issues. [See it in action.](https://github.com/afeld/pandas/issues/2#issuecomment-779635007)

It also handles automatically unassigning them after a period of inactivity, which is the more interesting part. The motivation here is that I bet there are a lot of issues where someone has used `take`, but the issue remains open without movement. [By default](https://github.com/JasonEtco/slash-assign-action#options), this Action will remove the assignment after 21 days. Open to suggestions about whether that should be longer or shorter.

- [ ] ~~closes #xxxx~~
- [ ] ~~tests added / passed~~
- [ ] ~~Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them~~
- [ ] ~~whatsnew entry~~
