### PR TITLE
ASV: add frame ops benchmarks for varying n_rows/n_columns ratios

### DIFF
--- a/asv_bench/benchmarks/arithmetic.py
+++ b/asv_bench/benchmarks/arithmetic.py
@@ -127,6 +127,10 @@ class FrameWithFrameWide:
         #  b) appreciably bigger than single columns
         n_rows, n_cols = shape
 
+        if op is operator.floordiv:
+            # floordiv is much slower as the other operations -> use less data
+            n_rows = n_rows // 10
+
         # construct dataframe with 2 blocks
         arr1 = np.random.randn(n_rows, n_cols // 2).astype("f8")
         arr2 = np.random.randn(n_rows, n_cols // 2).astype("f4")

--- a/asv_bench/benchmarks/arithmetic.py
+++ b/asv_bench/benchmarks/arithmetic.py
@@ -128,7 +128,7 @@ class FrameWithFrameWide:
         n_rows, n_cols = shape
 
         if op is operator.floordiv:
-            # floordiv is much slower as the other operations -> use less data
+            # floordiv is much slower than the other operations -> use less data
             n_rows = n_rows // 10
 
         # construct dataframe with 2 blocks

--- a/asv_bench/benchmarks/arithmetic.py
+++ b/asv_bench/benchmarks/arithmetic.py
@@ -110,16 +110,22 @@ class FrameWithFrameWide:
             operator.add,
             operator.floordiv,
             operator.gt,
-        ]
+        ],
+        [
+            # (n_rows, n_columns)
+            (1_000_000, 10),
+            (100_000, 100),
+            (10_000, 1000),
+            (1000, 10_000),
+        ],
     ]
-    param_names = ["op"]
+    param_names = ["op", "shape"]
 
-    def setup(self, op):
+    def setup(self, op, shape):
         # we choose dtypes so as to make the blocks
         #  a) not perfectly match between right and left
         #  b) appreciably bigger than single columns
-        n_cols = 2000
-        n_rows = 500
+        n_rows, n_cols = shape
 
         # construct dataframe with 2 blocks
         arr1 = np.random.randn(n_rows, n_cols // 2).astype("f8")
@@ -131,7 +137,7 @@ class FrameWithFrameWide:
         df._consolidate_inplace()
 
         # TODO: GH#33198 the setting here shoudlnt need two steps
-        arr1 = np.random.randn(n_rows, n_cols // 4).astype("f8")
+        arr1 = np.random.randn(n_rows, max(n_cols // 4, 3)).astype("f8")
         arr2 = np.random.randn(n_rows, n_cols // 2).astype("i8")
         arr3 = np.random.randn(n_rows, n_cols // 4).astype("f8")
         df2 = pd.concat(
@@ -145,11 +151,11 @@ class FrameWithFrameWide:
         self.left = df
         self.right = df2
 
-    def time_op_different_blocks(self, op):
+    def time_op_different_blocks(self, op, shape):
         # blocks (and dtypes) are not aligned
         op(self.left, self.right)
 
-    def time_op_same_blocks(self, op):
+    def time_op_same_blocks(self, op, shape):
         # blocks (and dtypes) are aligned
         op(self.left, self.left)
 


### PR DESCRIPTION
Currently, we have a benchmark for frame/frame ops with a wide dataframe (originating from previous (long) PR / discussion about this, xref https://github.com/pandas-dev/pandas/pull/32779)

To get a better idea of the trade-offs for future changes to the ops code (eg ArrayManager related), I think it is useful to have this benchmark for a varying rows/columns ratio (it is mostly this ratio that determines how much overhead we have when performing ops column-wise). 

So I changed the benchmark to be parametrized over 4 different ratios, from a long to a wide dataframe, and with each case having the same number of total elements in the dataframe. 

The shape in the original benchmark was `(500, 2000)`, which is somewhere in between two new cases of  `(10_000, 1000)` and `(1000, 10_000)`, so that should preserve the original intent of the benchmark (the last case of `(1000, 10_000)` even has a lower row/column ratio, so should even be a "worse" case for the column-wise ops perspective).

cc @jbrockmendel 