### PR TITLE
STYLE keep local imports relative

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -208,7 +208,8 @@ repos:
     hooks:
     -   id: no-string-hints
 -   repo: https://github.com/MarcoGorelli/abs-imports
-    rev: v0.1.2
+    rev: c434798
     hooks:
     -   id: abs-imports
         files: ^pandas/
+        args: [--keep-local-imports-relative]

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -19,14 +19,14 @@ if missing_dependencies:
 del hard_dependencies, dependency, missing_dependencies
 
 # numpy compat
-from pandas.compat import (
+from .compat import (
     np_version_under1p17 as _np_version_under1p17,
     np_version_under1p18 as _np_version_under1p18,
     is_numpy_dev as _is_numpy_dev,
 )
 
 try:
-    from pandas._libs import hashtable as _hashtable, lib as _lib, tslib as _tslib
+    from ._libs import hashtable as _hashtable, lib as _lib, tslib as _tslib
 except ImportError as e:  # pragma: no cover
     # hack but overkill to use re
     module = str(e).replace("cannot import name ", "")
@@ -36,7 +36,7 @@ except ImportError as e:  # pragma: no cover
         "'python setup.py build_ext --force' to build the C extensions first."
     ) from e
 
-from pandas._config import (
+from ._config import (
     get_option,
     set_option,
     reset_option,
@@ -48,7 +48,7 @@ from pandas._config import (
 # let init-time option registration happen
 import pandas.core.config_init
 
-from pandas.core.api import (
+from .core.api import (
     # dtype
     Int8Dtype,
     Int16Dtype,
@@ -115,14 +115,14 @@ from pandas.core.api import (
     DataFrame,
 )
 
-from pandas.core.arrays.sparse import SparseDtype
+from .core.arrays.sparse import SparseDtype
 
-from pandas.tseries.api import infer_freq
-from pandas.tseries import offsets
+from .tseries.api import infer_freq
+from .tseries import offsets
 
-from pandas.core.computation.api import eval
+from .core.computation.api import eval
 
-from pandas.core.reshape.api import (
+from .core.reshape.api import (
     concat,
     lreshape,
     melt,
@@ -139,9 +139,9 @@ from pandas.core.reshape.api import (
 )
 
 import pandas.api
-from pandas.util._print_versions import show_versions
+from .util._print_versions import show_versions
 
-from pandas.io.api import (
+from .io.api import (
     # excel
     ExcelFile,
     ExcelWriter,
@@ -173,14 +173,14 @@ from pandas.io.api import (
     read_spss,
 )
 
-from pandas.io.json import _json_normalize as json_normalize
+from .io.json import _json_normalize as json_normalize
 
-from pandas.util._tester import test
+from .util._tester import test
 import pandas.testing
 import pandas.arrays
 
 # use the closest tagged version if possible
-from pandas._version import get_versions
+from ._version import get_versions
 
 v = get_versions()
 __version__ = v.get("closest-tag", v["version"])
@@ -237,7 +237,7 @@ def __getattr__(name):
             FutureWarning,
             stacklevel=2,
         )
-        from pandas.core.arrays.sparse import SparseArray as _SparseArray
+        from .core.arrays.sparse import SparseArray as _SparseArray
 
         return _SparseArray
 

--- a/pandas/_config/__init__.py
+++ b/pandas/_config/__init__.py
@@ -15,9 +15,9 @@ __all__ = [
     "option_context",
     "options",
 ]
-from pandas._config import config
-from pandas._config import dates  # noqa:F401
-from pandas._config.config import (
+from . import config
+from . import dates  # noqa:F401
+from .config import (
     describe_option,
     get_option,
     option_context,
@@ -25,4 +25,4 @@ from pandas._config.config import (
     reset_option,
     set_option,
 )
-from pandas._config.display import detect_console_encoding
+from .display import detect_console_encoding

--- a/pandas/_config/dates.py
+++ b/pandas/_config/dates.py
@@ -1,7 +1,7 @@
 """
 config for datetime formatting
 """
-from pandas._config import config as cf
+from . import config as cf
 
 pc_date_dayfirst_doc = """
 : boolean

--- a/pandas/_config/display.py
+++ b/pandas/_config/display.py
@@ -6,7 +6,7 @@ import locale
 import sys
 from typing import Optional
 
-from pandas._config import config as cf
+from . import config as cf
 
 # -----------------------------------------------------------------------------
 # Global formatting options

--- a/pandas/_config/localization.py
+++ b/pandas/_config/localization.py
@@ -8,7 +8,7 @@ import locale
 import re
 import subprocess
 
-from pandas._config.config import options
+from .config import options
 
 
 @contextmanager

--- a/pandas/_libs/__init__.py
+++ b/pandas/_libs/__init__.py
@@ -10,8 +10,8 @@ __all__ = [
 ]
 
 
-from pandas._libs.interval import Interval
-from pandas._libs.tslibs import (
+from .interval import Interval
+from .tslibs import (
     NaT,
     NaTType,
     OutOfBoundsDatetime,

--- a/pandas/_libs/tslibs/__init__.py
+++ b/pandas/_libs/tslibs/__init__.py
@@ -27,38 +27,38 @@ __all__ = [
     "tz_compare",
 ]
 
-from pandas._libs.tslibs import dtypes
-from pandas._libs.tslibs.conversion import (
+from . import dtypes
+from .conversion import (
     OutOfBoundsTimedelta,
     localize_pydatetime,
 )
-from pandas._libs.tslibs.dtypes import Resolution
-from pandas._libs.tslibs.nattype import (
+from .dtypes import Resolution
+from .nattype import (
     NaT,
     NaTType,
     iNaT,
     is_null_datetimelike,
     nat_strings,
 )
-from pandas._libs.tslibs.np_datetime import OutOfBoundsDatetime
-from pandas._libs.tslibs.offsets import (
+from .np_datetime import OutOfBoundsDatetime
+from .offsets import (
     BaseOffset,
     Tick,
     to_offset,
 )
-from pandas._libs.tslibs.period import (
+from .period import (
     IncompatibleFrequency,
     Period,
 )
-from pandas._libs.tslibs.timedeltas import (
+from .timedeltas import (
     Timedelta,
     delta_to_nanoseconds,
     ints_to_pytimedelta,
 )
-from pandas._libs.tslibs.timestamps import Timestamp
-from pandas._libs.tslibs.timezones import tz_compare
-from pandas._libs.tslibs.tzconversion import tz_convert_from_utc_single
-from pandas._libs.tslibs.vectorized import (
+from .timestamps import Timestamp
+from .timezones import tz_compare
+from .tzconversion import tz_convert_from_utc_single
+from .vectorized import (
     dt64arr_to_periodarr,
     get_resolution,
     ints_to_pydatetime,

--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -49,7 +49,14 @@ from pandas import (
     Series,
     bdate_range,
 )
-from pandas._testing._io import (  # noqa:F401
+from pandas.core.arrays import (
+    DatetimeArray,
+    PeriodArray,
+    TimedeltaArray,
+    period_array,
+)
+
+from ._io import (  # noqa:F401
     close,
     network,
     round_trip_localpath,
@@ -58,14 +65,14 @@ from pandas._testing._io import (  # noqa:F401
     with_connectivity_check,
     write_to_compressed,
 )
-from pandas._testing._random import (  # noqa:F401
+from ._random import (  # noqa:F401
     randbool,
     rands,
     rands_array,
     randu_array,
 )
-from pandas._testing._warnings import assert_produces_warning  # noqa:F401
-from pandas._testing.asserters import (  # noqa:F401
+from ._warnings import assert_produces_warning  # noqa:F401
+from .asserters import (  # noqa:F401
     assert_almost_equal,
     assert_attr_equal,
     assert_categorical_equal,
@@ -88,8 +95,8 @@ from pandas._testing.asserters import (  # noqa:F401
     assert_timedelta_array_equal,
     raise_assert_detail,
 )
-from pandas._testing.compat import get_dtype  # noqa:F401
-from pandas._testing.contexts import (  # noqa:F401
+from .compat import get_dtype  # noqa:F401
+from .contexts import (  # noqa:F401
     RNGContext,
     decompress_file,
     ensure_clean,
@@ -98,12 +105,6 @@ from pandas._testing.contexts import (  # noqa:F401
     set_timezone,
     use_numexpr,
     with_csv_dialect,
-)
-from pandas.core.arrays import (
-    DatetimeArray,
-    PeriodArray,
-    TimedeltaArray,
-    period_array,
 )
 
 if TYPE_CHECKING:

--- a/pandas/_testing/_io.py
+++ b/pandas/_testing/_io.py
@@ -19,10 +19,11 @@ from pandas.compat import (
 )
 
 import pandas as pd
-from pandas._testing._random import rands
-from pandas._testing.contexts import ensure_clean
 
 from pandas.io.common import urlopen
+
+from ._random import rands
+from .contexts import ensure_clean
 
 _RAISE_NETWORK_ERROR_DEFAULT = False
 

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -38,32 +38,29 @@ import numpy as np
 if TYPE_CHECKING:
     from typing import final
 
-    from pandas._libs import (
+    from . import Interval
+    from ._libs import (
         Period,
         Timedelta,
         Timestamp,
     )
-
-    from pandas.core.dtypes.dtypes import ExtensionDtype
-
-    from pandas import Interval
-    from pandas.core.arrays.base import ExtensionArray  # noqa: F401
-    from pandas.core.frame import DataFrame
-    from pandas.core.generic import NDFrame  # noqa: F401
-    from pandas.core.groupby.generic import (
+    from .core.arrays.base import ExtensionArray  # noqa: F401
+    from .core.dtypes.dtypes import ExtensionDtype
+    from .core.frame import DataFrame
+    from .core.generic import NDFrame  # noqa: F401
+    from .core.groupby.generic import (
         DataFrameGroupBy,
         SeriesGroupBy,
     )
-    from pandas.core.indexes.base import Index
-    from pandas.core.internals import (
+    from .core.indexes.base import Index
+    from .core.internals import (
         ArrayManager,
         BlockManager,
     )
-    from pandas.core.resample import Resampler
-    from pandas.core.series import Series
-    from pandas.core.window.rolling import BaseWindow
-
-    from pandas.io.formats.format import EngFormatter
+    from .core.resample import Resampler
+    from .core.series import Series
+    from .core.window.rolling import BaseWindow
+    from .io.formats.format import EngFormatter
 else:
     # typing.final does not exist until py38
     final = lambda x: x

--- a/pandas/api/__init__.py
+++ b/pandas/api/__init__.py
@@ -1,5 +1,5 @@
 """ public toolkit API """
-from pandas.api import (  # noqa
+from . import (  # noqa
     extensions,
     indexers,
     types,

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -12,7 +12,8 @@ import sys
 import warnings
 
 from pandas._typing import F
-from pandas.compat.numpy import (
+
+from .numpy import (
     is_numpy_dev,
     np_array_datetime64_compat,
     np_datetime64_compat,

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -45,13 +45,10 @@ from pytz import (
 
 import pandas.util._test_decorators as td
 
-from pandas.core.dtypes.dtypes import (
-    DatetimeTZDtype,
-    IntervalDtype,
-)
-
 import pandas as pd
-from pandas import (
+import pandas._testing as tm
+
+from . import (
     DataFrame,
     Interval,
     Period,
@@ -59,9 +56,12 @@ from pandas import (
     Timedelta,
     Timestamp,
 )
-import pandas._testing as tm
-from pandas.core import ops
-from pandas.core.indexes.api import (
+from .core import ops
+from .core.dtypes.dtypes import (
+    DatetimeTZDtype,
+    IntervalDtype,
+)
+from .core.indexes.api import (
     Index,
     MultiIndex,
 )

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -32,22 +32,22 @@ from pandas._typing import (
     FrameOrSeriesUnion,
 )
 
-from pandas.core.dtypes.common import (
+import pandas.core.common as com
+
+from .algorithms import safe_sort
+from .base import SpecificationError
+from .dtypes.common import (
     is_dict_like,
     is_list_like,
 )
-from pandas.core.dtypes.generic import (
+from .dtypes.generic import (
     ABCDataFrame,
     ABCSeries,
 )
-
-from pandas.core.algorithms import safe_sort
-from pandas.core.base import SpecificationError
-import pandas.core.common as com
-from pandas.core.indexes.api import Index
+from .indexes.api import Index
 
 if TYPE_CHECKING:
-    from pandas.core.series import Series
+    from .series import Series
 
 
 def reconstruct_func(
@@ -482,7 +482,7 @@ def transform_dict_like(
     """
     Compute transform in the case of a dict-like func
     """
-    from pandas.core.reshape.concat import concat
+    from .reshape.concat import concat
 
     if len(func) == 0:
         raise ValueError("No transform functions were provided")

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -36,12 +36,17 @@ from pandas._typing import (
 )
 from pandas.util._decorators import doc
 
-from pandas.core.dtypes.cast import (
+from .construction import (
+    array,
+    ensure_wrapped_if_datetimelike,
+    extract_array,
+)
+from .dtypes.cast import (
     construct_1d_object_array_from_listlike,
     infer_dtype_from_array,
     maybe_promote,
 )
-from pandas.core.dtypes.common import (
+from .dtypes.common import (
     ensure_float64,
     ensure_int64,
     ensure_object,
@@ -68,8 +73,8 @@ from pandas.core.dtypes.common import (
     needs_i8_conversion,
     pandas_dtype,
 )
-from pandas.core.dtypes.dtypes import PandasDtype
-from pandas.core.dtypes.generic import (
+from .dtypes.dtypes import PandasDtype
+from .dtypes.generic import (
     ABCDatetimeArray,
     ABCExtensionArray,
     ABCIndex,
@@ -78,17 +83,11 @@ from pandas.core.dtypes.generic import (
     ABCSeries,
     ABCTimedeltaArray,
 )
-from pandas.core.dtypes.missing import (
+from .dtypes.missing import (
     isna,
     na_value_for_dtype,
 )
-
-from pandas.core.construction import (
-    array,
-    ensure_wrapped_if_datetimelike,
-    extract_array,
-)
-from pandas.core.indexers import validate_indices
+from .indexers import validate_indices
 
 if TYPE_CHECKING:
     from pandas import (
@@ -97,7 +96,8 @@ if TYPE_CHECKING:
         Index,
         Series,
     )
-    from pandas.core.arrays import (
+
+    from .arrays import (
         DatetimeArray,
         TimedeltaArray,
     )
@@ -819,12 +819,12 @@ def value_counts(
     -------
     Series
     """
-    from pandas.core.series import Series
+    from .series import Series
 
     name = getattr(values, "name", None)
 
     if bins is not None:
-        from pandas.core.reshape.tile import cut
+        from .reshape.tile import cut
 
         values = Series(values)
         try:
@@ -2247,8 +2247,8 @@ def _sort_tuples(values: np.ndarray):
     nans (can't use `np.sort` as it may fail when str and nan are mixed in a
     column as types cannot be compared).
     """
-    from pandas.core.internals.construction import to_arrays
-    from pandas.core.sorting import lexsort_indexer
+    from .internals.construction import to_arrays
+    from .sorting import lexsort_indexer
 
     arrays, _ = to_arrays(values, None)
     indexer = lexsort_indexer(arrays, orders=True)

--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -8,31 +8,21 @@ from pandas._libs import (
 )
 from pandas._libs.missing import NA
 
-from pandas.core.dtypes.dtypes import (
-    CategoricalDtype,
-    DatetimeTZDtype,
-    IntervalDtype,
-    PeriodDtype,
-)
-from pandas.core.dtypes.missing import (
-    isna,
-    isnull,
-    notna,
-    notnull,
-)
+from pandas.io.formats.format import set_eng_float_format
+from pandas.tseries.offsets import DateOffset
 
-from pandas.core.algorithms import (
+from .algorithms import (
     factorize,
     unique,
     value_counts,
 )
-from pandas.core.arrays import Categorical
-from pandas.core.arrays.boolean import BooleanDtype
-from pandas.core.arrays.floating import (
+from .arrays import Categorical
+from .arrays.boolean import BooleanDtype
+from .arrays.floating import (
     Float32Dtype,
     Float64Dtype,
 )
-from pandas.core.arrays.integer import (
+from .arrays.integer import (
     Int8Dtype,
     Int16Dtype,
     Int32Dtype,
@@ -42,14 +32,26 @@ from pandas.core.arrays.integer import (
     UInt32Dtype,
     UInt64Dtype,
 )
-from pandas.core.arrays.string_ import StringDtype
-from pandas.core.construction import array
-from pandas.core.flags import Flags
-from pandas.core.groupby import (
+from .arrays.string_ import StringDtype
+from .construction import array
+from .dtypes.dtypes import (
+    CategoricalDtype,
+    DatetimeTZDtype,
+    IntervalDtype,
+    PeriodDtype,
+)
+from .dtypes.missing import (
+    isna,
+    isnull,
+    notna,
+    notnull,
+)
+from .flags import Flags
+from .groupby import (
     Grouper,
     NamedAgg,
 )
-from pandas.core.indexes.api import (
+from .indexes.api import (
     CategoricalIndex,
     DatetimeIndex,
     Float64Index,
@@ -62,24 +64,21 @@ from pandas.core.indexes.api import (
     TimedeltaIndex,
     UInt64Index,
 )
-from pandas.core.indexes.datetimes import (
+from .indexes.datetimes import (
     bdate_range,
     date_range,
 )
-from pandas.core.indexes.interval import (
+from .indexes.interval import (
     Interval,
     interval_range,
 )
-from pandas.core.indexes.period import period_range
-from pandas.core.indexes.timedeltas import timedelta_range
-from pandas.core.indexing import IndexSlice
-from pandas.core.series import Series
-from pandas.core.tools.datetimes import to_datetime
-from pandas.core.tools.numeric import to_numeric
-from pandas.core.tools.timedeltas import to_timedelta
-
-from pandas.io.formats.format import set_eng_float_format
-from pandas.tseries.offsets import DateOffset
+from .indexes.period import period_range
+from .indexes.timedeltas import timedelta_range
+from .indexing import IndexSlice
+from .series import Series
+from .tools.datetimes import to_datetime
+from .tools.numeric import to_numeric
+from .tools.timedeltas import to_timedelta
 
 # DataFrame needs to be imported after NamedAgg to avoid a circular import
-from pandas.core.frame import DataFrame  # isort:skip
+from .frame import DataFrame  # isort:skip

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -30,28 +30,28 @@ from pandas._typing import (
 )
 from pandas.util._decorators import cache_readonly
 
-from pandas.core.dtypes.cast import is_nested_object
-from pandas.core.dtypes.common import (
+import pandas.core.common as com
+
+from .algorithms import safe_sort
+from .base import (
+    DataError,
+    SpecificationError,
+)
+from .construction import (
+    array as pd_array,
+    create_series_with_explicit_dtype,
+)
+from .dtypes.cast import is_nested_object
+from .dtypes.common import (
     is_dict_like,
     is_extension_array_dtype,
     is_list_like,
     is_sequence,
 )
-from pandas.core.dtypes.generic import (
+from .dtypes.generic import (
     ABCDataFrame,
     ABCNDFrame,
     ABCSeries,
-)
-
-from pandas.core.algorithms import safe_sort
-from pandas.core.base import (
-    DataError,
-    SpecificationError,
-)
-import pandas.core.common as com
-from pandas.core.construction import (
-    array as pd_array,
-    create_series_with_explicit_dtype,
 )
 
 if TYPE_CHECKING:
@@ -60,12 +60,13 @@ if TYPE_CHECKING:
         Index,
         Series,
     )
-    from pandas.core.groupby import (
+
+    from .groupby import (
         DataFrameGroupBy,
         SeriesGroupBy,
     )
-    from pandas.core.resample import Resampler
-    from pandas.core.window.rolling import BaseWindow
+    from .resample import Resampler
+    from .window.rolling import BaseWindow
 
 ResType = Dict[int, Any]
 
@@ -210,7 +211,7 @@ class Apply(metaclass=abc.ABCMeta):
         -------
         Result of aggregation.
         """
-        from pandas.core.reshape.concat import concat
+        from .reshape.concat import concat
 
         obj = self.obj
         arg = cast(List[AggFuncTypeBase], self.f)
@@ -355,7 +356,7 @@ class Apply(metaclass=abc.ABCMeta):
                 )
                 raise SpecificationError(f"Column(s) {cols} do not exist")
 
-        from pandas.core.reshape.concat import concat
+        from .reshape.concat import concat
 
         if selected_obj.ndim == 1:
             # key only used for output

--- a/pandas/core/arraylike.py
+++ b/pandas/core/arraylike.py
@@ -15,12 +15,12 @@ import numpy as np
 
 from pandas._libs import lib
 
-from pandas.core.construction import extract_array
-from pandas.core.ops import (
+from .construction import extract_array
+from .ops import (
     maybe_dispatch_ufunc_to_dunder_op,
     roperator,
 )
-from pandas.core.ops.common import unpack_zerodim_and_defer
+from .ops.common import unpack_zerodim_and_defer
 
 
 class OpsMixin:
@@ -183,7 +183,8 @@ def _maybe_fallback(ufunc: Callable, method: str, *inputs: Any, **kwargs: Any):
     See https://github.com/pandas-dev/pandas/pull/39239
     """
     from pandas import DataFrame
-    from pandas.core.generic import NDFrame
+
+    from .generic import NDFrame
 
     n_alignable = sum(isinstance(x, NDFrame) for x in inputs)
     n_frames = sum(isinstance(x, DataFrame) for x in inputs)
@@ -242,8 +243,8 @@ def array_ufunc(self, ufunc: np.ufunc, method: str, *inputs: Any, **kwargs: Any)
     --------
     numpy.org/doc/stable/reference/arrays.classes.html#numpy.class.__array_ufunc__
     """
-    from pandas.core.generic import NDFrame
-    from pandas.core.internals import BlockManager
+    from .generic import NDFrame
+    from .internals import BlockManager
 
     cls = type(self)
 

--- a/pandas/core/arrays/__init__.py
+++ b/pandas/core/arrays/__init__.py
@@ -1,23 +1,23 @@
-from pandas.core.arrays.base import (
+from .base import (
     ExtensionArray,
     ExtensionOpsMixin,
     ExtensionScalarOpsMixin,
 )
-from pandas.core.arrays.boolean import BooleanArray
-from pandas.core.arrays.categorical import Categorical
-from pandas.core.arrays.datetimes import DatetimeArray
-from pandas.core.arrays.floating import FloatingArray
-from pandas.core.arrays.integer import IntegerArray
-from pandas.core.arrays.interval import IntervalArray
-from pandas.core.arrays.masked import BaseMaskedArray
-from pandas.core.arrays.numpy_ import PandasArray
-from pandas.core.arrays.period import (
+from .boolean import BooleanArray
+from .categorical import Categorical
+from .datetimes import DatetimeArray
+from .floating import FloatingArray
+from .integer import IntegerArray
+from .interval import IntervalArray
+from .masked import BaseMaskedArray
+from .numpy_ import PandasArray
+from .period import (
     PeriodArray,
     period_array,
 )
-from pandas.core.arrays.sparse import SparseArray
-from pandas.core.arrays.string_ import StringArray
-from pandas.core.arrays.timedeltas import TimedeltaArray
+from .sparse import SparseArray
+from .string_ import StringArray
+from .timedeltas import TimedeltaArray
 
 __all__ = [
     "ExtensionArray",

--- a/pandas/core/arrays/_arrow_utils.py
+++ b/pandas/core/arrays/_arrow_utils.py
@@ -4,7 +4,7 @@ import json
 import numpy as np
 import pyarrow
 
-from pandas.core.arrays.interval import VALID_CLOSED
+from .interval import VALID_CLOSED
 
 _pyarrow_version_ge_015 = LooseVersion(pyarrow.__version__) >= LooseVersion("0.15")
 

--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -33,9 +33,10 @@ from pandas.core.algorithms import (
     value_counts,
 )
 from pandas.core.array_algos.transforms import shift
-from pandas.core.arrays.base import ExtensionArray
 from pandas.core.construction import extract_array
 from pandas.core.indexers import check_array_indexer
+
+from .base import ExtensionArray
 
 NDArrayBackedExtensionArrayT = TypeVar(
     "NDArrayBackedExtensionArrayT", bound="NDArrayBackedExtensionArray"

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -515,8 +515,8 @@ class ExtensionArray:
         array : ndarray
             NumPy ndarray with 'dtype' for its dtype.
         """
-        from pandas.core.arrays.string_ import StringDtype
-        from pandas.core.arrays.string_arrow import ArrowStringDtype
+        from .string_ import StringDtype
+        from .string_arrow import ArrowStringDtype
 
         dtype = pandas_dtype(dtype)
         if is_dtype_equal(dtype, self.dtype):

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -39,7 +39,8 @@ from pandas.core.dtypes.dtypes import (
 from pandas.core.dtypes.missing import isna
 
 from pandas.core import ops
-from pandas.core.arrays.masked import (
+
+from .masked import (
     BaseMaskedArray,
     BaseMaskedDtype,
 )
@@ -727,7 +728,7 @@ class BooleanArray(BaseMaskedArray):
         if (is_float_dtype(other) or is_float(other)) or (
             op_name in ["rtruediv", "truediv"]
         ):
-            from pandas.core.arrays import FloatingArray
+            from . import FloatingArray
 
             return FloatingArray(result, mask, copy=False)
 
@@ -735,7 +736,7 @@ class BooleanArray(BaseMaskedArray):
             return BooleanArray(result, mask, copy=False)
 
         elif is_integer_dtype(result):
-            from pandas.core.arrays import IntegerArray
+            from . import IntegerArray
 
             return IntegerArray(result, mask, copy=False)
         else:

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -91,7 +91,6 @@ from pandas.core.algorithms import (
     take_nd,
     unique1d,
 )
-from pandas.core.arrays._mixins import NDArrayBackedExtensionArray
 from pandas.core.base import (
     ExtensionArray,
     NoNewAttributesMixin,
@@ -110,6 +109,8 @@ from pandas.core.sorting import nargsort
 from pandas.core.strings.object_array import ObjectStringArrayMixin
 
 from pandas.io.formats import console
+
+from ._mixins import NDArrayBackedExtensionArray
 
 if TYPE_CHECKING:
     from pandas import Index
@@ -2391,7 +2392,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         # Optimization to apply the callable `f` to the categories once
         # and rebuild the result by `take`ing from the result with the codes.
         # Returns the same type as the object-dtype implementation though.
-        from pandas.core.arrays import PandasArray
+        from . import PandasArray
 
         categories = self.categories
         codes = self.codes
@@ -2400,7 +2401,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
     def _str_get_dummies(self, sep="|"):
         # sep may not be in categories. Just bail on this.
-        from pandas.core.arrays import PandasArray
+        from . import PandasArray
 
         return PandasArray(self.astype(str))._str_get_dummies(sep)
 

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -94,10 +94,6 @@ from pandas.core.algorithms import (
     unique1d,
 )
 from pandas.core.arraylike import OpsMixin
-from pandas.core.arrays._mixins import (
-    NDArrayBackedExtensionArray,
-    ravel_compat,
-)
 import pandas.core.common as com
 from pandas.core.construction import (
     array,
@@ -115,8 +111,13 @@ from pandas.core.ops.invalid import (
 
 from pandas.tseries import frequencies
 
+from ._mixins import (
+    NDArrayBackedExtensionArray,
+    ravel_compat,
+)
+
 if TYPE_CHECKING:
-    from pandas.core.arrays import (
+    from . import (
         DatetimeArray,
         TimedeltaArray,
     )
@@ -1086,7 +1087,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
 
         if isinstance(other, np.ndarray):
             # ndarray[timedelta64]; wrap in TimedeltaIndex for op
-            from pandas.core.arrays import TimedeltaArray
+            from . import TimedeltaArray
 
             other = TimedeltaArray._from_sequence(other)
 
@@ -1250,7 +1251,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
             return NotImplemented
 
         if isinstance(result, np.ndarray) and is_timedelta64_dtype(result.dtype):
-            from pandas.core.arrays import TimedeltaArray
+            from . import TimedeltaArray
 
             return TimedeltaArray(result)
         return result
@@ -1306,7 +1307,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
             return NotImplemented
 
         if isinstance(result, np.ndarray) and is_timedelta64_dtype(result.dtype):
-            from pandas.core.arrays import TimedeltaArray
+            from . import TimedeltaArray
 
             return TimedeltaArray(result)
         return result
@@ -1322,7 +1323,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
                 return Timestamp(other) - self
             if not isinstance(other, DatetimeLikeArrayMixin):
                 # Avoid down-casting DatetimeIndex
-                from pandas.core.arrays import DatetimeArray
+                from . import DatetimeArray
 
                 other = DatetimeArray(other)
             return other - self

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -67,8 +67,6 @@ from pandas.core.dtypes.generic import (
 from pandas.core.dtypes.missing import isna
 
 from pandas.core.algorithms import checked_add_with_arr
-from pandas.core.arrays import datetimelike as dtl
-from pandas.core.arrays._ranges import generate_regular_range
 import pandas.core.common as com
 
 from pandas.tseries.frequencies import get_period_alias
@@ -77,6 +75,9 @@ from pandas.tseries.offsets import (
     Day,
     Tick,
 )
+
+from . import datetimelike as dtl
+from ._ranges import generate_regular_range
 
 _midnight = time(0, 0)
 
@@ -1109,7 +1110,7 @@ default 'raise'
         PeriodIndex(['2017-01-01', '2017-01-02'],
                     dtype='period[D]', freq='D')
         """
-        from pandas.core.arrays import PeriodArray
+        from . import PeriodArray
 
         if self.tz is not None:
             warnings.warn(
@@ -1158,7 +1159,7 @@ default 'raise'
             FutureWarning,
             stacklevel=3,
         )
-        from pandas.core.arrays.timedeltas import TimedeltaArray
+        from .timedeltas import TimedeltaArray
 
         i8delta = self.asi8 - self.to_period(freq).to_timestamp().asi8
         m8delta = i8delta.view("m8[ns]")
@@ -1890,7 +1891,7 @@ default 'raise'
         # Because std is translation-invariant, we can get self.std
         #  by calculating (self - Timestamp(0)).std, and we can do it
         #  without creating a copy by using a view on self._ndarray
-        from pandas.core.arrays import TimedeltaArray
+        from . import TimedeltaArray
 
         tda = TimedeltaArray(self._ndarray.view("i8"))
         return tda.std(

--- a/pandas/core/arrays/floating.py
+++ b/pandas/core/arrays/floating.py
@@ -37,12 +37,13 @@ from pandas.core.dtypes.dtypes import (
 )
 from pandas.core.dtypes.missing import isna
 
-from pandas.core.arrays.numeric import (
+from pandas.core.ops import invalid_comparison
+from pandas.core.tools.numeric import to_numeric
+
+from .numeric import (
     NumericArray,
     NumericDtype,
 )
-from pandas.core.ops import invalid_comparison
-from pandas.core.tools.numeric import to_numeric
 
 
 class FloatingDtype(NumericDtype):

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -40,16 +40,17 @@ from pandas.core.dtypes.common import (
 )
 from pandas.core.dtypes.missing import isna
 
-from pandas.core.arrays.masked import (
+from pandas.core.ops import invalid_comparison
+from pandas.core.tools.numeric import to_numeric
+
+from .masked import (
     BaseMaskedArray,
     BaseMaskedDtype,
 )
-from pandas.core.arrays.numeric import (
+from .numeric import (
     NumericArray,
     NumericDtype,
 )
-from pandas.core.ops import invalid_comparison
-from pandas.core.tools.numeric import to_numeric
 
 
 class _IntegerDtype(NumericDtype):
@@ -106,7 +107,7 @@ class _IntegerDtype(NumericDtype):
         if np.issubdtype(np_dtype, np.integer):
             return INT_STR_TO_DTYPE[str(np_dtype)]
         elif np.issubdtype(np_dtype, np.floating):
-            from pandas.core.arrays.floating import FLOAT_STR_TO_DTYPE
+            from .floating import FLOAT_STR_TO_DTYPE
 
             return FLOAT_STR_TO_DTYPE[str(np_dtype)]
         return None
@@ -401,7 +402,7 @@ class IntegerArray(NumericArray):
         return data
 
     def _cmp_method(self, other, op):
-        from pandas.core.arrays import BooleanArray
+        from . import BooleanArray
 
         mask = None
 
@@ -476,12 +477,12 @@ class IntegerArray(NumericArray):
         if (is_float_dtype(other) or is_float(other)) or (
             op_name in ["rtruediv", "truediv"]
         ):
-            from pandas.core.arrays import FloatingArray
+            from . import FloatingArray
 
             return FloatingArray(result, mask, copy=False)
 
         if result.dtype == "timedelta64[ns]":
-            from pandas.core.arrays import TimedeltaArray
+            from . import TimedeltaArray
 
             result[mask] = iNaT
             return TimedeltaArray._simple_new(result)

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -69,11 +69,6 @@ from pandas.core.algorithms import (
     take,
     value_counts,
 )
-from pandas.core.arrays.base import (
-    ExtensionArray,
-    _extension_array_shared_docs,
-)
-from pandas.core.arrays.categorical import Categorical
 import pandas.core.common as com
 from pandas.core.construction import (
     array,
@@ -86,6 +81,12 @@ from pandas.core.ops import (
     invalid_comparison,
     unpack_zerodim_and_defer,
 )
+
+from .base import (
+    ExtensionArray,
+    _extension_array_shared_docs,
+)
+from .categorical import Categorical
 
 IntervalArrayT = TypeVar("IntervalArrayT", bound="IntervalArray")
 
@@ -808,7 +809,8 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             ExtensionArray or NumPy ndarray with 'dtype' for its dtype.
         """
         from pandas import Index
-        from pandas.core.arrays.string_ import StringDtype
+
+        from .string_ import StringDtype
 
         if dtype is not None:
             dtype = pandas_dtype(dtype)
@@ -1370,7 +1372,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         """
         import pyarrow
 
-        from pandas.core.arrays._arrow_utils import ArrowIntervalType
+        from ._arrow_utils import ArrowIntervalType
 
         try:
             subtype = pyarrow.from_numpy_dtype(self.dtype.subtype)

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -51,12 +51,14 @@ from pandas.core.algorithms import (
 )
 from pandas.core.array_algos import masked_reductions
 from pandas.core.arraylike import OpsMixin
-from pandas.core.arrays import ExtensionArray
 from pandas.core.indexers import check_array_indexer
+
+from . import ExtensionArray
 
 if TYPE_CHECKING:
     from pandas import Series
-    from pandas.core.arrays import BooleanArray
+
+    from . import BooleanArray
 
 
 BaseMaskedArrayT = TypeVar("BaseMaskedArrayT", bound="BaseMaskedArray")
@@ -358,7 +360,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
 
     def isin(self, values) -> BooleanArray:
 
-        from pandas.core.arrays import BooleanArray
+        from . import BooleanArray
 
         result = isin(self._data, values)
         if self._hasna:

--- a/pandas/core/arrays/numeric.py
+++ b/pandas/core/arrays/numeric.py
@@ -26,7 +26,8 @@ from pandas.core.dtypes.common import (
 )
 
 from pandas.core import ops
-from pandas.core.arrays.masked import (
+
+from .masked import (
     BaseMaskedArray,
     BaseMaskedDtype,
 )
@@ -44,7 +45,7 @@ class NumericDtype(BaseMaskedDtype):
         """
         import pyarrow
 
-        from pandas.core.arrays._arrow_utils import pyarrow_array_to_numpy_and_mask
+        from ._arrow_utils import pyarrow_array_to_numpy_and_mask
 
         array_class = self.construct_array_type()
 
@@ -181,12 +182,12 @@ class NumericArray(BaseMaskedArray):
             # raise for reduce up above.
 
             if is_integer_dtype(x.dtype):
-                from pandas.core.arrays import IntegerArray
+                from . import IntegerArray
 
                 m = mask.copy()
                 return IntegerArray(x, m)
             elif is_float_dtype(x.dtype):
-                from pandas.core.arrays import FloatingArray
+                from . import FloatingArray
 
                 m = mask.copy()
                 return FloatingArray(x, m)

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -27,8 +27,9 @@ from pandas.core import (
     ops,
 )
 from pandas.core.arraylike import OpsMixin
-from pandas.core.arrays._mixins import NDArrayBackedExtensionArray
 from pandas.core.strings.object_array import ObjectStringArrayMixin
+
+from ._mixins import NDArrayBackedExtensionArray
 
 
 class PandasArray(
@@ -390,7 +391,7 @@ class PandasArray(
         # If we have timedelta64[ns] result, return a TimedeltaArray instead
         #  of a PandasArray
         if result.dtype == "timedelta64[ns]":
-            from pandas.core.arrays import TimedeltaArray
+            from . import TimedeltaArray
 
             return TimedeltaArray._simple_new(result)
         return type(self)(result)

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -73,8 +73,9 @@ from pandas.core.dtypes.missing import (
 )
 
 import pandas.core.algorithms as algos
-from pandas.core.arrays import datetimelike as dtl
 import pandas.core.common as com
+
+from . import datetimelike as dtl
 
 _shared_doc_kwargs = {
     "klass": "PeriodArray",
@@ -343,7 +344,7 @@ class PeriodArray(PeriodMixin, dtl.DatelikeOps):
         """
         import pyarrow
 
-        from pandas.core.arrays._arrow_utils import ArrowPeriodType
+        from ._arrow_utils import ArrowPeriodType
 
         if type is not None:
             if pyarrow.types.is_integer(type):
@@ -462,7 +463,7 @@ class PeriodArray(PeriodMixin, dtl.DatelikeOps):
         -------
         DatetimeArray/Index
         """
-        from pandas.core.arrays import DatetimeArray
+        from . import DatetimeArray
 
         how = libperiod.validate_end_alias(how)
 

--- a/pandas/core/arrays/sparse/__init__.py
+++ b/pandas/core/arrays/sparse/__init__.py
@@ -1,13 +1,13 @@
 # flake8: noqa: F401
 
-from pandas.core.arrays.sparse.accessor import (
+from .accessor import (
     SparseAccessor,
     SparseFrameAccessor,
 )
-from pandas.core.arrays.sparse.array import (
+from .array import (
     BlockIndex,
     IntIndex,
     SparseArray,
     make_sparse_index,
 )
-from pandas.core.arrays.sparse.dtype import SparseDtype
+from .dtype import SparseDtype

--- a/pandas/core/arrays/sparse/accessor.py
+++ b/pandas/core/arrays/sparse/accessor.py
@@ -10,8 +10,9 @@ from pandas.core.accessor import (
     PandasDelegate,
     delegate_names,
 )
-from pandas.core.arrays.sparse.array import SparseArray
-from pandas.core.arrays.sparse.dtype import SparseDtype
+
+from .array import SparseArray
+from .dtype import SparseDtype
 
 
 class BaseAccessor:
@@ -91,7 +92,8 @@ class SparseAccessor(BaseAccessor, PandasDelegate):
         dtype: Sparse[float64, nan]
         """
         from pandas import Series
-        from pandas.core.arrays.sparse.scipy_sparse import coo_to_sparse_series
+
+        from .scipy_sparse import coo_to_sparse_series
 
         result = coo_to_sparse_series(A, dense_index=dense_index)
         result = Series(result.array, index=result.index, copy=False)
@@ -171,7 +173,7 @@ class SparseAccessor(BaseAccessor, PandasDelegate):
         >>> columns
         [('a', 0), ('a', 1), ('b', 0), ('b', 1)]
         """
-        from pandas.core.arrays.sparse.scipy_sparse import sparse_series_to_coo
+        from .scipy_sparse import sparse_series_to_coo
 
         A, rows, columns = sparse_series_to_coo(
             self._parent, row_levels, column_levels, sort_labels=sort_labels

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -66,7 +66,6 @@ from pandas.core.dtypes.missing import (
 import pandas.core.algorithms as algos
 from pandas.core.arraylike import OpsMixin
 from pandas.core.arrays import ExtensionArray
-from pandas.core.arrays.sparse.dtype import SparseDtype
 from pandas.core.base import PandasObject
 import pandas.core.common as com
 from pandas.core.construction import (
@@ -79,6 +78,8 @@ from pandas.core.nanops import check_below_min_count
 import pandas.core.ops as ops
 
 import pandas.io.formats.printing as printing
+
+from .dtype import SparseDtype
 
 # ----------------------------------------------------------------------------
 # Array

--- a/pandas/core/arrays/sparse/dtype.py
+++ b/pandas/core/arrays/sparse/dtype.py
@@ -39,7 +39,7 @@ from pandas.core.dtypes.missing import (
 )
 
 if TYPE_CHECKING:
-    from pandas.core.arrays.sparse.array import SparseArray
+    from .array import SparseArray
 
 
 @register_extension_dtype
@@ -197,7 +197,7 @@ class SparseDtype(ExtensionDtype):
         -------
         type
         """
-        from pandas.core.arrays.sparse.array import SparseArray
+        from .array import SparseArray
 
         return SparseArray
 

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -35,16 +35,17 @@ from pandas.core.dtypes.common import (
 
 from pandas.core import ops
 from pandas.core.array_algos import masked_reductions
-from pandas.core.arrays import (
+from pandas.core.construction import extract_array
+from pandas.core.indexers import check_array_indexer
+from pandas.core.missing import isna
+
+from . import (
     FloatingArray,
     IntegerArray,
     PandasArray,
 )
-from pandas.core.arrays.floating import FloatingDtype
-from pandas.core.arrays.integer import _IntegerDtype
-from pandas.core.construction import extract_array
-from pandas.core.indexers import check_array_indexer
-from pandas.core.missing import isna
+from .floating import FloatingDtype
+from .integer import _IntegerDtype
 
 if TYPE_CHECKING:
     import pyarrow
@@ -229,7 +230,7 @@ class StringArray(PandasArray):
         if dtype:
             assert dtype == "string"
 
-        from pandas.core.arrays.masked import BaseMaskedArray
+        from .masked import BaseMaskedArray
 
         if isinstance(scalars, BaseMaskedArray):
             # avoid costly conversion to object dtype
@@ -408,7 +409,8 @@ class StringArray(PandasArray):
             IntegerArray,
             StringArray,
         )
-        from pandas.core.arrays.string_ import StringDtype
+
+        from .string_ import StringDtype
 
         if dtype is None:
             dtype = StringDtype()

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -34,12 +34,13 @@ from pandas.api.types import (
     is_scalar,
 )
 from pandas.core.arraylike import OpsMixin
-from pandas.core.arrays.base import ExtensionArray
 from pandas.core.indexers import (
     check_array_indexer,
     validate_indices,
 )
 from pandas.core.missing import get_fill_func
+
+from .base import ExtensionArray
 
 try:
     import pyarrow as pa

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -57,14 +57,15 @@ from pandas.core.dtypes.missing import isna
 
 from pandas.core import nanops
 from pandas.core.algorithms import checked_add_with_arr
-from pandas.core.arrays import (
-    IntegerArray,
-    datetimelike as dtl,
-)
-from pandas.core.arrays._ranges import generate_regular_range
 import pandas.core.common as com
 from pandas.core.construction import extract_array
 from pandas.core.ops.common import unpack_zerodim_and_defer
+
+from . import (
+    IntegerArray,
+    datetimelike as dtl,
+)
+from ._ranges import generate_regular_range
 
 
 def _field_accessor(name: str, alias: str, docstring: str):
@@ -432,7 +433,7 @@ class TimedeltaArray(dtl.TimelikeOps):
         Add a Period object.
         """
         # We will wrap in a PeriodArray and defer to the reversed operation
-        from pandas.core.arrays.period import PeriodArray
+        from .period import PeriodArray
 
         i8vals = np.broadcast_to(other.ordinal, self.shape)
         oth = PeriodArray(i8vals, freq=other.freq)
@@ -444,7 +445,7 @@ class TimedeltaArray(dtl.TimelikeOps):
         """
         if isinstance(other, np.ndarray):
             # At this point we have already checked that dtype is datetime64
-            from pandas.core.arrays import DatetimeArray
+            from . import DatetimeArray
 
             other = DatetimeArray(other)
 
@@ -453,7 +454,7 @@ class TimedeltaArray(dtl.TimelikeOps):
 
     def _add_datetimelike_scalar(self, other):
         # adding a timedeltaindex to a datetimelike
-        from pandas.core.arrays import DatetimeArray
+        from . import DatetimeArray
 
         assert other is not NaT
         other = Timestamp(other)

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -32,34 +32,34 @@ from pandas.util._decorators import (
     doc,
 )
 
-from pandas.core.dtypes.common import (
+import pandas.core.nanops as nanops
+
+from . import algorithms
+from .accessor import DirNamesMixin
+from .algorithms import (
+    duplicated,
+    unique1d,
+    value_counts,
+)
+from .arraylike import OpsMixin
+from .arrays import ExtensionArray
+from .construction import create_series_with_explicit_dtype
+from .dtypes.common import (
     is_categorical_dtype,
     is_dict_like,
     is_extension_array_dtype,
     is_object_dtype,
     is_scalar,
 )
-from pandas.core.dtypes.generic import (
+from .dtypes.generic import (
     ABCDataFrame,
     ABCIndex,
     ABCSeries,
 )
-from pandas.core.dtypes.missing import (
+from .dtypes.missing import (
     isna,
     remove_na_arraylike,
 )
-
-from pandas.core import algorithms
-from pandas.core.accessor import DirNamesMixin
-from pandas.core.algorithms import (
-    duplicated,
-    unique1d,
-    value_counts,
-)
-from pandas.core.arraylike import OpsMixin
-from pandas.core.arrays import ExtensionArray
-from pandas.core.construction import create_series_with_explicit_dtype
-import pandas.core.nanops as nanops
 
 if TYPE_CHECKING:
     from pandas import Categorical

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -36,20 +36,20 @@ from pandas._typing import (
 )
 from pandas.compat import np_version_under1p18
 
-from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
-from pandas.core.dtypes.common import (
+from .dtypes.cast import construct_1d_object_array_from_listlike
+from .dtypes.common import (
     is_array_like,
     is_bool_dtype,
     is_extension_array_dtype,
     is_integer,
 )
-from pandas.core.dtypes.generic import (
+from .dtypes.generic import (
     ABCExtensionArray,
     ABCIndex,
     ABCSeries,
 )
-from pandas.core.dtypes.inference import iterable_not_string
-from pandas.core.dtypes.missing import (  # noqa
+from .dtypes.inference import iterable_not_string
+from .dtypes.missing import (  # noqa
     isna,
     isnull,
     notnull,

--- a/pandas/core/computation/align.py
+++ b/pandas/core/computation/align.py
@@ -30,7 +30,8 @@ from pandas.core.dtypes.generic import (
 
 from pandas.core.base import PandasObject
 import pandas.core.common as com
-from pandas.core.computation.common import result_type_many
+
+from .common import result_type_many
 
 if TYPE_CHECKING:
     from pandas.core.indexes.api import Index

--- a/pandas/core/computation/api.py
+++ b/pandas/core/computation/api.py
@@ -1,3 +1,3 @@
 # flake8: noqa
 
-from pandas.core.computation.eval import eval
+from .eval import eval

--- a/pandas/core/computation/engines.py
+++ b/pandas/core/computation/engines.py
@@ -8,16 +8,16 @@ from typing import (
     Type,
 )
 
-from pandas.core.computation.align import (
+import pandas.io.formats.printing as printing
+
+from .align import (
     align_terms,
     reconstruct_object,
 )
-from pandas.core.computation.ops import (
+from .ops import (
     MATHOPS,
     REDUCTIONS,
 )
-
-import pandas.io.formats.printing as printing
 
 _ne_builtins = frozenset(MATHOPS + REDUCTIONS)
 

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -9,15 +9,15 @@ import warnings
 from pandas._libs.lib import no_default
 from pandas.util._validators import validate_bool_kwarg
 
-from pandas.core.computation.engines import ENGINES
-from pandas.core.computation.expr import (
+from pandas.io.formats.printing import pprint_thing
+
+from .engines import ENGINES
+from .expr import (
     PARSERS,
     Expr,
 )
-from pandas.core.computation.parsing import tokenize_string
-from pandas.core.computation.scope import ensure_scope
-
-from pandas.io.formats.printing import pprint_thing
+from .parsing import tokenize_string
+from .scope import ensure_scope
 
 
 def _check_engine(engine: Optional[str]) -> str:
@@ -41,7 +41,7 @@ def _check_engine(engine: Optional[str]) -> str:
     str
         Engine name.
     """
-    from pandas.core.computation.check import NUMEXPR_INSTALLED
+    from .check import NUMEXPR_INSTALLED
 
     if engine is None:
         engine = "numexpr" if NUMEXPR_INSTALLED else "python"

--- a/pandas/core/computation/expr.py
+++ b/pandas/core/computation/expr.py
@@ -23,7 +23,10 @@ import numpy as np
 from pandas.compat import PY39
 
 import pandas.core.common as com
-from pandas.core.computation.ops import (
+
+import pandas.io.formats.printing as printing
+
+from .ops import (
     ARITH_OPS_SYMS,
     BOOL_OPS_SYMS,
     CMP_OPS_SYMS,
@@ -41,13 +44,11 @@ from pandas.core.computation.ops import (
     UndefinedVariableError,
     is_term,
 )
-from pandas.core.computation.parsing import (
+from .parsing import (
     clean_backtick_quoted_toks,
     tokenize_string,
 )
-from pandas.core.computation.scope import Scope
-
-import pandas.io.formats.printing as printing
+from .scope import Scope
 
 
 def _rewrite_assign(tok: Tuple[int, str]) -> Tuple[int, str]:

--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -21,8 +21,9 @@ from pandas._typing import FuncType
 
 from pandas.core.dtypes.generic import ABCDataFrame
 
-from pandas.core.computation.check import NUMEXPR_INSTALLED
 from pandas.core.ops import roperator
+
+from .check import NUMEXPR_INSTALLED
 
 if NUMEXPR_INSTALLED:
     import numexpr as ne

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -25,16 +25,17 @@ from pandas.core.dtypes.common import (
 )
 
 import pandas.core.common as com
-from pandas.core.computation.common import (
-    ensure_decoded,
-    result_type_many,
-)
-from pandas.core.computation.scope import DEFAULT_GLOBALS
 
 from pandas.io.formats.printing import (
     pprint_thing,
     pprint_thing_encoded,
 )
+
+from .common import (
+    ensure_decoded,
+    result_type_many,
+)
+from .scope import DEFAULT_GLOBALS
 
 REDUCTIONS = ("sum", "prod")
 
@@ -457,7 +458,7 @@ class BinOp(Op):
             if self.op in eval_in_python:
                 res = self.func(left.value, right.value)
             else:
-                from pandas.core.computation.eval import eval
+                from .eval import eval
 
                 res = eval(self, local_dict=env, engine=engine, parser=parser)
 
@@ -618,7 +619,7 @@ class MathCall(Op):
 
 class FuncNode:
     def __init__(self, name: str):
-        from pandas.core.computation.check import (
+        from .check import (
             NUMEXPR_INSTALLED,
             NUMEXPR_VERSION,
         )

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -21,23 +21,24 @@ from pandas.compat.chainmap import DeepChainMap
 from pandas.core.dtypes.common import is_list_like
 
 import pandas.core.common as com
-from pandas.core.computation import (
-    expr,
-    ops,
-    scope as _scope,
-)
-from pandas.core.computation.common import ensure_decoded
-from pandas.core.computation.expr import BaseExprVisitor
-from pandas.core.computation.ops import (
-    UndefinedVariableError,
-    is_term,
-)
 from pandas.core.construction import extract_array
 from pandas.core.indexes.base import Index
 
 from pandas.io.formats.printing import (
     pprint_thing,
     pprint_thing_encoded,
+)
+
+from . import (
+    expr,
+    ops,
+    scope as _scope,
+)
+from .common import ensure_decoded
+from .expr import BaseExprVisitor
+from .ops import (
+    UndefinedVariableError,
+    is_term,
 )
 
 

--- a/pandas/core/computation/scope.py
+++ b/pandas/core/computation/scope.py
@@ -209,7 +209,7 @@ class Scope:
                 return self.temps[key]
             except KeyError as err:
                 # runtime import because ops imports from scope
-                from pandas.core.computation.ops import UndefinedVariableError
+                from .ops import UndefinedVariableError
 
                 raise UndefinedVariableError(key, is_local) from err
 

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -33,7 +33,7 @@ use_bottleneck_doc = """
 
 
 def use_bottleneck_cb(key):
-    from pandas.core import nanops
+    from . import nanops
 
     nanops.set_use_bottleneck(cf.get_option(key))
 
@@ -47,7 +47,7 @@ use_numexpr_doc = """
 
 
 def use_numexpr_cb(key):
-    from pandas.core.computation import expressions
+    from .computation import expressions
 
     expressions.set_use_numexpr(cf.get_option(key))
 
@@ -61,7 +61,7 @@ use_numba_doc = """
 
 
 def use_numba_cb(key):
-    from pandas.core.util import numba_
+    from .util import numba_
 
     numba_.set_use_numba(cf.get_option(key))
 
@@ -473,7 +473,7 @@ use_inf_as_na_doc = """
 
 
 def use_inf_as_na_cb(key):
-    from pandas.core.dtypes.missing import _use_inf_as_na
+    from .dtypes.missing import _use_inf_as_na
 
     _use_inf_as_na(key)
 

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -31,11 +31,13 @@ from pandas._typing import (
     DtypeObj,
 )
 
-from pandas.core.dtypes.base import (
+import pandas.core.common as com
+
+from .dtypes.base import (
     ExtensionDtype,
     registry,
 )
-from pandas.core.dtypes.cast import (
+from .dtypes.cast import (
     construct_1d_arraylike_from_scalar,
     construct_1d_ndarray_preserving_na,
     construct_1d_object_array_from_listlike,
@@ -45,7 +47,7 @@ from pandas.core.dtypes.cast import (
     maybe_convert_platform,
     maybe_upcast,
 )
-from pandas.core.dtypes.common import (
+from .dtypes.common import (
     is_datetime64_ns_dtype,
     is_extension_array_dtype,
     is_float_dtype,
@@ -56,15 +58,13 @@ from pandas.core.dtypes.common import (
     is_string_dtype,
     is_timedelta64_ns_dtype,
 )
-from pandas.core.dtypes.generic import (
+from .dtypes.generic import (
     ABCExtensionArray,
     ABCIndex,
     ABCPandasArray,
     ABCSeries,
 )
-from pandas.core.dtypes.missing import isna
-
-import pandas.core.common as com
+from .dtypes.missing import isna
 
 if TYPE_CHECKING:
     from pandas import (
@@ -286,7 +286,7 @@ def array(
       ...
     ValueError: Cannot pass scalar '1' to 'pandas.array'.
     """
-    from pandas.core.arrays import (
+    from .arrays import (
         BooleanArray,
         DatetimeArray,
         FloatingArray,
@@ -425,12 +425,12 @@ def ensure_wrapped_if_datetimelike(arr):
     """
     if isinstance(arr, np.ndarray):
         if arr.dtype.kind == "M":
-            from pandas.core.arrays import DatetimeArray
+            from .arrays import DatetimeArray
 
             return DatetimeArray._from_sequence(arr)
 
         elif arr.dtype.kind == "m":
-            from pandas.core.arrays import TimedeltaArray
+            from .arrays import TimedeltaArray
 
             return TimedeltaArray._from_sequence(arr)
 
@@ -706,7 +706,7 @@ def create_series_with_explicit_dtype(
     -------
     Series
     """
-    from pandas.core.series import Series
+    from .series import Series
 
     if is_empty_data(data) and dtype is None:
         dtype = dtype_if_empty

--- a/pandas/core/describe.py
+++ b/pandas/core/describe.py
@@ -30,16 +30,15 @@ from pandas._typing import (
 )
 from pandas.util._validators import validate_percentile
 
-from pandas.core.dtypes.common import (
+from pandas.io.formats.format import format_percentiles
+
+from .dtypes.common import (
     is_bool_dtype,
     is_datetime64_any_dtype,
     is_numeric_dtype,
     is_timedelta64_dtype,
 )
-
-from pandas.core.reshape.concat import concat
-
-from pandas.io.formats.format import format_percentiles
+from .reshape.concat import concat
 
 if TYPE_CHECKING:
     from pandas import (

--- a/pandas/core/dtypes/api.py
+++ b/pandas/core/dtypes/api.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 
-from pandas.core.dtypes.common import (
+from .common import (
     is_array_like,
     is_bool,
     is_bool_dtype,

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -19,7 +19,7 @@ import numpy as np
 from pandas._typing import DtypeObj
 from pandas.errors import AbstractMethodError
 
-from pandas.core.dtypes.generic import (
+from .generic import (
     ABCDataFrame,
     ABCIndex,
     ABCSeries,

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -53,7 +53,7 @@ from pandas._typing import (
 from pandas.util._exceptions import find_stack_level
 from pandas.util._validators import validate_bool_kwarg
 
-from pandas.core.dtypes.common import (
+from .common import (
     DT64NS_DTYPE,
     POSSIBLY_CAST_DTYPES,
     TD64NS_DTYPE,
@@ -87,20 +87,20 @@ from pandas.core.dtypes.common import (
     is_timedelta64_ns_dtype,
     is_unsigned_integer_dtype,
 )
-from pandas.core.dtypes.dtypes import (
+from .dtypes import (
     DatetimeTZDtype,
     ExtensionDtype,
     IntervalDtype,
     PeriodDtype,
 )
-from pandas.core.dtypes.generic import (
+from .generic import (
     ABCDataFrame,
     ABCExtensionArray,
     ABCIndex,
     ABCSeries,
 )
-from pandas.core.dtypes.inference import is_list_like
-from pandas.core.dtypes.missing import (
+from .inference import is_list_like
+from .missing import (
     is_valid_na_for_dtype,
     isna,
     na_value_for_dtype,

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -23,19 +23,19 @@ from pandas._typing import (
     Optional,
 )
 
-from pandas.core.dtypes.base import registry
-from pandas.core.dtypes.dtypes import (
+from .base import registry
+from .dtypes import (
     CategoricalDtype,
     DatetimeTZDtype,
     ExtensionDtype,
     IntervalDtype,
     PeriodDtype,
 )
-from pandas.core.dtypes.generic import (
+from .generic import (
     ABCCategorical,
     ABCIndex,
 )
-from pandas.core.dtypes.inference import (  # noqa:F401
+from .inference import (  # noqa:F401
     is_array_like,
     is_bool,
     is_complex,

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -10,23 +10,23 @@ from pandas._typing import (
     DtypeObj,
 )
 
-from pandas.core.dtypes.cast import find_common_type
-from pandas.core.dtypes.common import (
-    is_categorical_dtype,
-    is_dtype_equal,
-    is_extension_array_dtype,
-    is_sparse,
-)
-from pandas.core.dtypes.generic import (
-    ABCCategoricalIndex,
-    ABCSeries,
-)
-
 from pandas.core.arrays import ExtensionArray
 from pandas.core.arrays.sparse import SparseArray
 from pandas.core.construction import (
     array,
     ensure_wrapped_if_datetimelike,
+)
+
+from .cast import find_common_type
+from .common import (
+    is_categorical_dtype,
+    is_dtype_equal,
+    is_extension_array_dtype,
+    is_sparse,
+)
+from .generic import (
+    ABCCategoricalIndex,
+    ABCSeries,
 )
 
 

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -38,15 +38,15 @@ from pandas._typing import (
     Ordered,
 )
 
-from pandas.core.dtypes.base import (
+from .base import (
     ExtensionDtype,
     register_extension_dtype,
 )
-from pandas.core.dtypes.generic import (
+from .generic import (
     ABCCategoricalIndex,
     ABCIndex,
 )
-from pandas.core.dtypes.inference import (
+from .inference import (
     is_bool,
     is_list_like,
 )
@@ -591,7 +591,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
 
     @property
     def _is_boolean(self) -> bool:
-        from pandas.core.dtypes.common import is_bool_dtype
+        from .common import is_bool_dtype
 
         return is_bool_dtype(self.categories)
 
@@ -621,7 +621,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
             x.categories.dtype if isinstance(x, CategoricalDtype) else x for x in dtypes
         ]
         # TODO should categorical always give an answer?
-        from pandas.core.dtypes.cast import find_common_type
+        from .cast import find_common_type
 
         return find_common_type(non_cat_dtypes)
 
@@ -1046,7 +1046,7 @@ class IntervalDtype(PandasExtensionDtype):
     _cache: Dict[str_type, PandasExtensionDtype] = {}
 
     def __new__(cls, subtype=None, closed: Optional[str_type] = None):
-        from pandas.core.dtypes.common import (
+        from .common import (
             is_string_dtype,
             pandas_dtype,
         )
@@ -1181,7 +1181,7 @@ class IntervalDtype(PandasExtensionDtype):
         elif self.closed != other.closed:
             return False
         else:
-            from pandas.core.dtypes.common import is_dtype_equal
+            from .common import is_dtype_equal
 
             return is_dtype_equal(self.subtype, other.subtype)
 
@@ -1246,7 +1246,7 @@ class IntervalDtype(PandasExtensionDtype):
         if not all(cast("IntervalDtype", x).closed == closed for x in dtypes):
             return np.dtype(object)
 
-        from pandas.core.dtypes.cast import find_common_type
+        from .cast import find_common_type
 
         common = find_common_type([cast("IntervalDtype", x).subtype for x in dtypes])
         if common == object:

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -19,7 +19,7 @@ from pandas._typing import (
     DtypeObj,
 )
 
-from pandas.core.dtypes.common import (
+from .common import (
     DT64NS_DTYPE,
     TD64NS_DTYPE,
     ensure_object,
@@ -37,14 +37,14 @@ from pandas.core.dtypes.common import (
     is_string_like_dtype,
     needs_i8_conversion,
 )
-from pandas.core.dtypes.generic import (
+from .generic import (
     ABCDataFrame,
     ABCExtensionArray,
     ABCIndex,
     ABCMultiIndex,
     ABCSeries,
 )
-from pandas.core.dtypes.inference import is_list_like
+from .inference import is_list_like
 
 isposinf_scalar = libmissing.isposinf_scalar
 isneginf_scalar = libmissing.isneginf_scalar

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -75,7 +75,33 @@ from pandas.util._validators import (
     validate_fillna_kwargs,
 )
 
-from pandas.core.dtypes.common import (
+import pandas.core.algorithms as algos
+import pandas.core.common as com
+
+from pandas.io.formats import format as fmt
+from pandas.io.formats.format import (
+    DataFrameFormatter,
+    DataFrameRenderer,
+)
+from pandas.io.formats.printing import pprint_thing
+
+from . import (
+    arraylike,
+    indexing,
+    missing,
+    nanops,
+)
+from .arrays import ExtensionArray
+from .base import (
+    PandasObject,
+    SelectionMixin,
+)
+from .construction import (
+    create_series_with_explicit_dtype,
+    extract_array,
+)
+from .describe import describe_ndframe
+from .dtypes.common import (
     ensure_int64,
     ensure_object,
     ensure_str,
@@ -96,37 +122,18 @@ from pandas.core.dtypes.common import (
     is_timedelta64_dtype,
     pandas_dtype,
 )
-from pandas.core.dtypes.generic import (
+from .dtypes.generic import (
     ABCDataFrame,
     ABCSeries,
 )
-from pandas.core.dtypes.inference import is_hashable
-from pandas.core.dtypes.missing import (
+from .dtypes.inference import is_hashable
+from .dtypes.missing import (
     isna,
     notna,
 )
-
-from pandas.core import (
-    arraylike,
-    indexing,
-    missing,
-    nanops,
-)
-import pandas.core.algorithms as algos
-from pandas.core.arrays import ExtensionArray
-from pandas.core.base import (
-    PandasObject,
-    SelectionMixin,
-)
-import pandas.core.common as com
-from pandas.core.construction import (
-    create_series_with_explicit_dtype,
-    extract_array,
-)
-from pandas.core.describe import describe_ndframe
-from pandas.core.flags import Flags
-from pandas.core.indexes import base as ibase
-from pandas.core.indexes.api import (
+from .flags import Flags
+from .indexes import base as ibase
+from .indexes.api import (
     DatetimeIndex,
     Index,
     MultiIndex,
@@ -134,36 +141,29 @@ from pandas.core.indexes.api import (
     RangeIndex,
     ensure_index,
 )
-from pandas.core.internals import (
+from .internals import (
     ArrayManager,
     BlockManager,
 )
-from pandas.core.missing import find_valid_index
-from pandas.core.ops import align_method_FRAME
-from pandas.core.reshape.concat import concat
-from pandas.core.shared_docs import _shared_docs
-from pandas.core.sorting import get_indexer_indexer
-from pandas.core.window import (
+from .missing import find_valid_index
+from .ops import align_method_FRAME
+from .reshape.concat import concat
+from .shared_docs import _shared_docs
+from .sorting import get_indexer_indexer
+from .window import (
     Expanding,
     ExponentialMovingWindow,
     Rolling,
     Window,
 )
 
-from pandas.io.formats import format as fmt
-from pandas.io.formats.format import (
-    DataFrameFormatter,
-    DataFrameRenderer,
-)
-from pandas.io.formats.printing import pprint_thing
-
 if TYPE_CHECKING:
     from pandas._libs.tslibs import BaseOffset
 
-    from pandas.core.frame import DataFrame
-    from pandas.core.resample import Resampler
-    from pandas.core.series import Series
-    from pandas.core.window.indexers import BaseIndexer
+    from .frame import DataFrame
+    from .resample import Resampler
+    from .series import Series
+    from .window.indexers import BaseIndexer
 
 # goal is to be able to define the docs close to function, while still being
 # able to share
@@ -552,7 +552,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
     @final
     def _get_index_resolvers(self) -> Dict[Hashable, Union[Series, MultiIndex]]:
-        from pandas.core.computation.parsing import clean_column_name
+        from .computation.parsing import clean_column_name
 
         d: Dict[str, Union[Series, MultiIndex]] = {}
         for axis_name in self._AXIS_ORDERS:
@@ -569,7 +569,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         be referred to by backtick quoting.
         Used in :meth:`DataFrame.eval`.
         """
-        from pandas.core.computation.parsing import clean_column_name
+        from .computation.parsing import clean_column_name
 
         if isinstance(self, ABCSeries):
             return {clean_column_name(self.name): self}
@@ -7615,7 +7615,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         2000-01-01 00:02:30    3.0
         2000-01-01 00:03:00    3.0
         """
-        from pandas.core.resample import asfreq
+        from .resample import asfreq
 
         return asfreq(
             self,
@@ -8182,7 +8182,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         2000-10-02 00:41:00    24
         Freq: 17T, dtype: int64
         """
-        from pandas.core.resample import get_resampler
+        from .resample import get_resampler
 
         axis = self._get_axis_number(axis)
         return get_resampler(
@@ -8470,7 +8470,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         keep_shape: bool_t = False,
         keep_equal: bool_t = False,
     ):
-        from pandas.core.reshape.concat import concat
+        from .reshape.concat import concat
 
         if type(self) is not type(other):
             cls_self, cls_other = type(self).__name__, type(other).__name__
@@ -9533,7 +9533,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         # if we have a date index, convert to dates, otherwise
         # treat like a slice
         if ax._is_all_dates:
-            from pandas.core.tools.datetimes import to_datetime
+            from .tools.datetimes import to_datetime
 
             before = to_datetime(before)
             after = to_datetime(after)

--- a/pandas/core/groupby/__init__.py
+++ b/pandas/core/groupby/__init__.py
@@ -1,10 +1,10 @@
-from pandas.core.groupby.generic import (
+from .generic import (
     DataFrameGroupBy,
     NamedAgg,
     SeriesGroupBy,
 )
-from pandas.core.groupby.groupby import GroupBy
-from pandas.core.groupby.grouper import Grouper
+from .groupby import GroupBy
+from .grouper import Grouper
 
 __all__ = [
     "DataFrameGroupBy",

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -94,15 +94,6 @@ import pandas.core.common as com
 from pandas.core.construction import create_series_with_explicit_dtype
 from pandas.core.frame import DataFrame
 from pandas.core.generic import NDFrame
-from pandas.core.groupby import base
-from pandas.core.groupby.groupby import (
-    GroupBy,
-    _agg_template,
-    _apply_docs,
-    _transform_template,
-    get_groupby,
-    group_selection_context,
-)
 from pandas.core.indexes.api import (
     Index,
     MultiIndex,
@@ -114,6 +105,16 @@ from pandas.core.series import Series
 from pandas.core.util.numba_ import maybe_use_numba
 
 from pandas.plotting import boxplot_frame_groupby
+
+from . import base
+from .groupby import (
+    GroupBy,
+    _agg_template,
+    _apply_docs,
+    _transform_template,
+    get_groupby,
+    group_selection_context,
+)
 
 if TYPE_CHECKING:
     from pandas.core.internals import Block

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -94,11 +94,6 @@ from pandas.core.base import (
 import pandas.core.common as com
 from pandas.core.frame import DataFrame
 from pandas.core.generic import NDFrame
-from pandas.core.groupby import (
-    base,
-    numba_,
-    ops,
-)
 from pandas.core.indexes.api import (
     CategoricalIndex,
     Index,
@@ -107,6 +102,12 @@ from pandas.core.indexes.api import (
 from pandas.core.series import Series
 from pandas.core.sorting import get_group_index_sorter
 from pandas.core.util.numba_ import NUMBA_FUNC_CACHE
+
+from . import (
+    base,
+    numba_,
+    ops,
+)
 
 _common_see_also = """
         See Also
@@ -589,7 +590,7 @@ class BaseGroupBy(PandasObject, SelectionMixin, Generic[FrameOrSeries]):
         self.dropna = dropna
 
         if grouper is None:
-            from pandas.core.groupby.grouper import get_grouper
+            from .grouper import get_grouper
 
             grouper, exclusions, obj = get_grouper(
                 obj,
@@ -2179,7 +2180,7 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
 
             # create a grouper with the original parameters, but on dropped
             # object
-            from pandas.core.groupby.grouper import get_grouper
+            from .grouper import get_grouper
 
             grouper, _, _ = get_grouper(
                 dropped,
@@ -3111,11 +3112,11 @@ def get_groupby(
 
     klass: Type[GroupBy]
     if isinstance(obj, Series):
-        from pandas.core.groupby.generic import SeriesGroupBy
+        from .generic import SeriesGroupBy
 
         klass = SeriesGroupBy
     elif isinstance(obj, DataFrame):
-        from pandas.core.groupby.generic import DataFrameGroupBy
+        from .generic import DataFrameGroupBy
 
         klass = DataFrameGroupBy
     else:

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -38,11 +38,6 @@ from pandas.core.arrays import (
 )
 import pandas.core.common as com
 from pandas.core.frame import DataFrame
-from pandas.core.groupby import ops
-from pandas.core.groupby.categorical import (
-    recode_for_groupby,
-    recode_from_groupby,
-)
 from pandas.core.indexes.api import (
     CategoricalIndex,
     Index,
@@ -51,6 +46,12 @@ from pandas.core.indexes.api import (
 from pandas.core.series import Series
 
 from pandas.io.formats.printing import pprint_thing
+
+from . import ops
+from .categorical import (
+    recode_for_groupby,
+    recode_from_groupby,
+)
 
 
 class Grouper:

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -75,10 +75,6 @@ from pandas.core.base import SelectionMixin
 import pandas.core.common as com
 from pandas.core.frame import DataFrame
 from pandas.core.generic import NDFrame
-from pandas.core.groupby import (
-    base,
-    grouper,
-)
 from pandas.core.indexes.api import (
     Index,
     MultiIndex,
@@ -92,6 +88,11 @@ from pandas.core.sorting import (
     get_group_index,
     get_group_index_sorter,
     get_indexer_dict,
+)
+
+from . import (
+    base,
+    grouper,
 )
 
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1,6 +1,6 @@
 import warnings
 
-from pandas.core.indexes.api import (  # noqa:F401
+from .indexes.api import (  # noqa:F401
     CategoricalIndex,
     DatetimeIndex,
     Float64Index,
@@ -19,7 +19,7 @@ from pandas.core.indexes.api import (  # noqa:F401
     ensure_index_from_sequences,
     get_objs_combined_axis,
 )
-from pandas.core.indexes.multi import sparsify_labels  # noqa:F401
+from .indexes.multi import sparsify_labels  # noqa:F401
 
 # GH#30193
 warnings.warn(

--- a/pandas/core/indexers.py
+++ b/pandas/core/indexers.py
@@ -14,7 +14,7 @@ from pandas._typing import (
     ArrayLike,
 )
 
-from pandas.core.dtypes.common import (
+from .dtypes.common import (
     is_array_like,
     is_bool_dtype,
     is_extension_array_dtype,
@@ -22,14 +22,14 @@ from pandas.core.dtypes.common import (
     is_integer_dtype,
     is_list_like,
 )
-from pandas.core.dtypes.generic import (
+from .dtypes.generic import (
     ABCIndex,
     ABCSeries,
 )
 
 if TYPE_CHECKING:
-    from pandas.core.frame import DataFrame
-    from pandas.core.indexes.base import Index
+    from .frame import DataFrame
+    from .indexes.base import Index
 
 # -----------------------------------------------------------
 # Indexer Identification
@@ -514,7 +514,7 @@ def check_array_indexer(array: AnyArrayLike, indexer: Any) -> Any:
     ...
     IndexError: arrays used as indices must be of integer or boolean type
     """
-    from pandas.core.construction import array as pd_array
+    from .construction import array as pd_array
 
     # whatever is not an array-like is returned as-is (possible valid array
     # indexers that are not array-like: integer, slice, Ellipsis, None)

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -32,8 +32,9 @@ from pandas.core.base import (
     NoNewAttributesMixin,
     PandasObject,
 )
-from pandas.core.indexes.datetimes import DatetimeIndex
-from pandas.core.indexes.timedeltas import TimedeltaIndex
+
+from .datetimes import DatetimeIndex
+from .timedeltas import TimedeltaIndex
 
 if TYPE_CHECKING:
     from pandas import Series

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -10,26 +10,26 @@ from pandas._libs import (
 )
 from pandas.errors import InvalidIndexError
 
-from pandas.core.indexes.base import (
+from .base import (
     Index,
     _new_Index,
     ensure_index,
     ensure_index_from_sequences,
     get_unanimous_names,
 )
-from pandas.core.indexes.category import CategoricalIndex
-from pandas.core.indexes.datetimes import DatetimeIndex
-from pandas.core.indexes.interval import IntervalIndex
-from pandas.core.indexes.multi import MultiIndex
-from pandas.core.indexes.numeric import (
+from .category import CategoricalIndex
+from .datetimes import DatetimeIndex
+from .interval import IntervalIndex
+from .multi import MultiIndex
+from .numeric import (
     Float64Index,
     Int64Index,
     NumericIndex,
     UInt64Index,
 )
-from pandas.core.indexes.period import PeriodIndex
-from pandas.core.indexes.range import RangeIndex
-from pandas.core.indexes.timedeltas import TimedeltaIndex
+from .period import PeriodIndex
+from .range import RangeIndex
+from .timedeltas import TimedeltaIndex
 
 _sort_msg = textwrap.dedent(
     """\

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -141,7 +141,6 @@ from pandas.core.base import (
 import pandas.core.common as com
 from pandas.core.construction import extract_array
 from pandas.core.indexers import deprecate_ndim_indexing
-from pandas.core.indexes.frozen import FrozenList
 from pandas.core.ops import get_op_result_name
 from pandas.core.ops.invalid import make_invalid_op
 from pandas.core.sorting import (
@@ -158,6 +157,8 @@ from pandas.io.formats.printing import (
     pprint_thing,
 )
 
+from .frozen import FrozenList
+
 if TYPE_CHECKING:
     from pandas import (
         CategoricalIndex,
@@ -166,7 +167,8 @@ if TYPE_CHECKING:
         RangeIndex,
         Series,
     )
-    from pandas.core.indexes.datetimelike import DatetimeIndexOpsMixin
+
+    from .datetimelike import DatetimeIndexOpsMixin
 
 
 __all__ = ["Index"]
@@ -204,7 +206,7 @@ def _new_Index(cls, d):
     # required for backward compat, because PI can't be instantiated with
     # ordinals through __new__ GH #13277
     if issubclass(cls, ABCPeriodIndex):
-        from pandas.core.indexes.period import _new_PeriodIndex
+        from .period import _new_PeriodIndex
 
         return _new_PeriodIndex(cls, **d)
 
@@ -333,7 +335,8 @@ class Index(IndexOpsMixin, PandasObject):
             )
 
         from pandas.core.arrays import PandasArray
-        from pandas.core.indexes.range import RangeIndex
+
+        from .range import RangeIndex
 
         name = maybe_extract_name(name, data, cls)
 
@@ -432,7 +435,7 @@ class Index(IndexOpsMixin, PandasObject):
                 if data and all(isinstance(e, tuple) for e in data):
                     # we must be all tuples, otherwise don't construct
                     # 10697
-                    from pandas.core.indexes.multi import MultiIndex
+                    from .multi import MultiIndex
 
                     return MultiIndex.from_tuples(
                         data, names=name or kwargs.get("names")
@@ -831,7 +834,7 @@ class Index(IndexOpsMixin, PandasObject):
             return self.copy() if copy else self
 
         elif is_categorical_dtype(dtype):
-            from pandas.core.indexes.category import CategoricalIndex
+            from .category import CategoricalIndex
 
             return CategoricalIndex(
                 self._values, name=self.name, dtype=dtype, copy=copy
@@ -1821,7 +1824,7 @@ class Index(IndexOpsMixin, PandasObject):
             result._name = new_names[0]
             return result
         else:
-            from pandas.core.indexes.multi import MultiIndex
+            from .multi import MultiIndex
 
             return MultiIndex(
                 levels=new_levels,
@@ -3940,8 +3943,9 @@ class Index(IndexOpsMixin, PandasObject):
 
     @final
     def _join_multi(self, other, how, return_indexers=True):
-        from pandas.core.indexes.multi import MultiIndex
         from pandas.core.reshape.merge import restore_dropped_levels_multijoin
+
+        from .multi import MultiIndex
 
         # figure out join names
         self_names_list = list(com.not_none(*self.names))
@@ -4058,7 +4062,7 @@ class Index(IndexOpsMixin, PandasObject):
         MultiIndex will not be changed; otherwise, it will tie out
         with `other`.
         """
-        from pandas.core.indexes.multi import MultiIndex
+        from .multi import MultiIndex
 
         def _get_leaf_sorter(labels):
             """
@@ -5329,7 +5333,7 @@ class Index(IndexOpsMixin, PandasObject):
             If the function returns a tuple with more than one element
             a MultiIndex will be returned.
         """
-        from pandas.core.indexes.multi import MultiIndex
+        from .multi import MultiIndex
 
         new_values = super()._map_values(mapper, na_action=na_action)
 
@@ -6067,7 +6071,7 @@ def ensure_index_from_sequences(sequences, names=None):
     --------
     ensure_index
     """
-    from pandas.core.indexes.multi import MultiIndex
+    from .multi import MultiIndex
 
     if len(sequences) == 1:
         if names is not None:
@@ -6140,7 +6144,7 @@ def ensure_index(
         converted, all_arrays = lib.clean_index_list(index_like)
 
         if len(converted) > 0 and all_arrays:
-            from pandas.core.indexes.multi import MultiIndex
+            from .multi import MultiIndex
 
             return MultiIndex.from_arrays(converted)
         else:
@@ -6198,7 +6202,7 @@ def _validate_join_method(method: str):
 
 
 def default_index(n: int) -> RangeIndex:
-    from pandas.core.indexes.range import RangeIndex
+    from .range import RangeIndex
 
     return RangeIndex(0, n, name=None)
 

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -39,12 +39,13 @@ from pandas.core.arrays.categorical import (
 )
 from pandas.core.construction import extract_array
 import pandas.core.indexes.base as ibase
-from pandas.core.indexes.base import (
+
+from .base import (
     Index,
     _index_shared_docs,
     maybe_extract_name,
 )
-from pandas.core.indexes.extension import (
+from .extension import (
     NDArrayBackedExtensionIndex,
     inherit_names,
 )

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -57,17 +57,18 @@ from pandas.core.arrays import (
 from pandas.core.arrays.datetimelike import DatetimeLikeArrayMixin
 import pandas.core.common as com
 import pandas.core.indexes.base as ibase
-from pandas.core.indexes.base import (
+from pandas.core.tools.timedeltas import to_timedelta
+
+from .base import (
     Index,
     _index_shared_docs,
 )
-from pandas.core.indexes.extension import (
+from .extension import (
     NDArrayBackedExtensionIndex,
     inherit_names,
     make_wrapped_arith_op,
 )
-from pandas.core.indexes.numeric import Int64Index
-from pandas.core.tools.timedeltas import to_timedelta
+from .numeric import Int64Index
 
 if TYPE_CHECKING:
     from pandas import CategoricalIndex

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -55,14 +55,15 @@ from pandas.core.arrays.datetimes import (
     tz_to_dtype,
 )
 import pandas.core.common as com
-from pandas.core.indexes.base import (
+from pandas.core.tools.times import to_time
+
+from .base import (
     Index,
     get_unanimous_names,
     maybe_extract_name,
 )
-from pandas.core.indexes.datetimelike import DatetimeTimedeltaMixin
-from pandas.core.indexes.extension import inherit_names
-from pandas.core.tools.times import to_time
+from .datetimelike import DatetimeTimedeltaMixin
+from .extension import inherit_names
 
 if TYPE_CHECKING:
     from pandas import (
@@ -286,21 +287,21 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
 
     @doc(DatetimeArray.to_period)
     def to_period(self, freq=None) -> PeriodIndex:
-        from pandas.core.indexes.api import PeriodIndex
+        from .api import PeriodIndex
 
         arr = self._data.to_period(freq)
         return PeriodIndex._simple_new(arr, name=self.name)
 
     @doc(DatetimeArray.to_perioddelta)
     def to_perioddelta(self, freq) -> TimedeltaIndex:
-        from pandas.core.indexes.api import TimedeltaIndex
+        from .api import TimedeltaIndex
 
         arr = self._data.to_perioddelta(freq)
         return TimedeltaIndex._simple_new(arr, name=self.name)
 
     @doc(DatetimeArray.to_julian_date)
     def to_julian_date(self) -> Float64Index:
-        from pandas.core.indexes.api import Float64Index
+        from .api import Float64Index
 
         arr = self._data.to_julian_date()
         return Float64Index._simple_new(arr, name=self.name)

--- a/pandas/core/indexes/extension.py
+++ b/pandas/core/indexes/extension.py
@@ -28,8 +28,9 @@ from pandas.core.dtypes.generic import (
 from pandas.core.arrays import ExtensionArray
 from pandas.core.arrays._mixins import NDArrayBackedExtensionArray
 from pandas.core.indexers import deprecate_ndim_indexing
-from pandas.core.indexes.base import Index
 from pandas.core.ops import get_op_result_name
+
+from .base import Index
 
 _T = TypeVar("_T", bound="NDArrayBackedExtensionIndex")
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -81,27 +81,28 @@ from pandas.core.arrays.interval import (
 import pandas.core.common as com
 from pandas.core.indexers import is_valid_positional_slice
 import pandas.core.indexes.base as ibase
-from pandas.core.indexes.base import (
+from pandas.core.ops import get_op_result_name
+
+from .base import (
     Index,
     _index_shared_docs,
     default_pprint,
     ensure_index,
     maybe_extract_name,
 )
-from pandas.core.indexes.datetimes import (
+from .datetimes import (
     DatetimeIndex,
     date_range,
 )
-from pandas.core.indexes.extension import (
+from .extension import (
     ExtensionIndex,
     inherit_names,
 )
-from pandas.core.indexes.multi import MultiIndex
-from pandas.core.indexes.timedeltas import (
+from .multi import MultiIndex
+from .timedeltas import (
     TimedeltaIndex,
     timedelta_range,
 )
-from pandas.core.ops import get_op_result_name
 
 if TYPE_CHECKING:
     from pandas import CategoricalIndex

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -74,14 +74,6 @@ from pandas.core.arrays import Categorical
 from pandas.core.arrays.categorical import factorize_from_iterables
 import pandas.core.common as com
 import pandas.core.indexes.base as ibase
-from pandas.core.indexes.base import (
-    Index,
-    _index_shared_docs,
-    ensure_index,
-    get_unanimous_names,
-)
-from pandas.core.indexes.frozen import FrozenList
-from pandas.core.indexes.numeric import Int64Index
 from pandas.core.ops.invalid import make_invalid_op
 from pandas.core.sorting import (
     get_group_index,
@@ -94,6 +86,15 @@ from pandas.io.formats.printing import (
     format_object_summary,
     pprint_thing,
 )
+
+from .base import (
+    Index,
+    _index_shared_docs,
+    ensure_index,
+    get_unanimous_names,
+)
+from .frozen import FrozenList
+from .numeric import Int64Index
 
 if TYPE_CHECKING:
     from pandas import (

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -33,7 +33,8 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.generic import ABCSeries
 
 import pandas.core.common as com
-from pandas.core.indexes.base import (
+
+from .base import (
     Index,
     maybe_extract_name,
 )

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -51,14 +51,15 @@ from pandas.core.arrays.period import (
 )
 import pandas.core.common as com
 import pandas.core.indexes.base as ibase
-from pandas.core.indexes.base import maybe_extract_name
-from pandas.core.indexes.datetimelike import DatetimeIndexOpsMixin
-from pandas.core.indexes.datetimes import (
+
+from .base import maybe_extract_name
+from .datetimelike import DatetimeIndexOpsMixin
+from .datetimes import (
     DatetimeIndex,
     Index,
 )
-from pandas.core.indexes.extension import inherit_names
-from pandas.core.indexes.numeric import Int64Index
+from .extension import inherit_names
+from .numeric import Int64Index
 
 _index_doc_kwargs = dict(ibase._index_doc_kwargs)
 _index_doc_kwargs.update({"target_klass": "PeriodIndex or list of Periods"})

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -40,12 +40,13 @@ from pandas.core import ops
 import pandas.core.common as com
 from pandas.core.construction import extract_array
 import pandas.core.indexes.base as ibase
-from pandas.core.indexes.base import maybe_extract_name
-from pandas.core.indexes.numeric import (
+from pandas.core.ops.common import unpack_zerodim_and_defer
+
+from .base import maybe_extract_name
+from .numeric import (
     Float64Index,
     Int64Index,
 )
-from pandas.core.ops.common import unpack_zerodim_and_defer
 
 if TYPE_CHECKING:
     from pandas import Index

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -23,12 +23,13 @@ from pandas.core.dtypes.common import (
 from pandas.core.arrays import datetimelike as dtl
 from pandas.core.arrays.timedeltas import TimedeltaArray
 import pandas.core.common as com
-from pandas.core.indexes.base import (
+
+from .base import (
     Index,
     maybe_extract_name,
 )
-from pandas.core.indexes.datetimelike import DatetimeTimedeltaMixin
-from pandas.core.indexes.extension import inherit_names
+from .datetimelike import DatetimeTimedeltaMixin
+from .extension import inherit_names
 
 
 @inherit_names(

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -24,7 +24,10 @@ from pandas.errors import (
 )
 from pandas.util._decorators import doc
 
-from pandas.core.dtypes.common import (
+import pandas.core.common as com
+
+from .construction import array as pd_array
+from .dtypes.common import (
     is_array_like,
     is_bool_dtype,
     is_hashable,
@@ -36,26 +39,23 @@ from pandas.core.dtypes.common import (
     is_scalar,
     is_sequence,
 )
-from pandas.core.dtypes.concat import concat_compat
-from pandas.core.dtypes.generic import (
+from .dtypes.concat import concat_compat
+from .dtypes.generic import (
     ABCDataFrame,
     ABCMultiIndex,
     ABCSeries,
 )
-from pandas.core.dtypes.missing import (
+from .dtypes.missing import (
     infer_fill_value,
     isna,
 )
-
-import pandas.core.common as com
-from pandas.core.construction import array as pd_array
-from pandas.core.indexers import (
+from .indexers import (
     check_array_indexer,
     is_exact_shape_match,
     is_list_like_indexer,
     length_of_indexer,
 )
-from pandas.core.indexes.api import Index
+from .indexes.api import Index
 
 if TYPE_CHECKING:
     from pandas import (

--- a/pandas/core/internals/__init__.py
+++ b/pandas/core/internals/__init__.py
@@ -1,6 +1,6 @@
-from pandas.core.internals.array_manager import ArrayManager
-from pandas.core.internals.base import DataManager
-from pandas.core.internals.blocks import (  # io.pytables, io.packers
+from .array_manager import ArrayManager
+from .base import DataManager
+from .blocks import (  # io.pytables, io.packers
     Block,
     CategoricalBlock,
     DatetimeBlock,
@@ -12,8 +12,8 @@ from pandas.core.internals.blocks import (  # io.pytables, io.packers
     TimeDeltaBlock,
     make_block,
 )
-from pandas.core.internals.concat import concatenate_block_managers
-from pandas.core.internals.managers import (
+from .concat import concatenate_block_managers
+from .managers import (
     BlockManager,
     SingleBlockManager,
     create_block_manager_from_arrays,

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -56,11 +56,12 @@ from pandas.core.indexes.api import (
     Index,
     ensure_index,
 )
-from pandas.core.internals.base import DataManager
-from pandas.core.internals.blocks import make_block
+
+from .base import DataManager
+from .blocks import make_block
 
 if TYPE_CHECKING:
-    from pandas.core.internals.managers import SingleBlockManager
+    from .managers import SingleBlockManager
 
 
 T = TypeVar("T", bound="ArrayManager")
@@ -643,7 +644,7 @@ class ArrayManager(DataManager):
         """
         Return the data as a SingleBlockManager.
         """
-        from pandas.core.internals.managers import SingleBlockManager
+        from .managers import SingleBlockManager
 
         values = self.arrays[i]
         block = make_block(values, placement=slice(0, len(values)), ndim=1)

--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -41,9 +41,10 @@ from pandas.core.arrays import (
     DatetimeArray,
     ExtensionArray,
 )
-from pandas.core.internals.array_manager import ArrayManager
-from pandas.core.internals.blocks import make_block
-from pandas.core.internals.managers import BlockManager
+
+from .array_manager import ArrayManager
+from .blocks import make_block
+from .managers import BlockManager
 
 if TYPE_CHECKING:
     from pandas import Index

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -70,7 +70,8 @@ from pandas.core.indexes.api import (
     get_objs_combined_axis,
     union_indexes,
 )
-from pandas.core.internals.managers import (
+
+from .managers import (
     create_block_manager_from_arrays,
     create_block_manager_from_blocks,
 )
@@ -165,7 +166,7 @@ def mgr_to_mgr(mgr, typ: str):
     Convert to specific type of Manager. Does not copy if the type is already
     correct. Does not guarantee a copy otherwise.
     """
-    from pandas.core.internals import (
+    from . import (
         ArrayManager,
         BlockManager,
     )
@@ -259,7 +260,7 @@ def init_ndarray(values, index, columns, dtype: Optional[DtypeObj], copy: bool):
                 if isinstance(dvals_list[n], np.ndarray):
                     dvals_list[n] = dvals_list[n].reshape(1, -1)
 
-            from pandas.core.internals.blocks import make_block
+            from .blocks import make_block
 
             # TODO: What about re-joining object columns?
             block_values = [

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -62,8 +62,9 @@ from pandas.core.indexes.api import (
     Index,
     ensure_index,
 )
-from pandas.core.internals.base import DataManager
-from pandas.core.internals.blocks import (
+
+from .base import DataManager
+from .blocks import (
     Block,
     CategoricalBlock,
     DatetimeTZBlock,
@@ -74,7 +75,7 @@ from pandas.core.internals.blocks import (
     get_block_type,
     make_block,
 )
-from pandas.core.internals.ops import (
+from .ops import (
     blockwise_all,
     operate_blockwise,
 )

--- a/pandas/core/internals/ops.py
+++ b/pandas/core/internals/ops.py
@@ -13,8 +13,8 @@ import numpy as np
 from pandas._typing import ArrayLike
 
 if TYPE_CHECKING:
-    from pandas.core.internals.blocks import Block
-    from pandas.core.internals.managers import BlockManager
+    from .blocks import Block
+    from .managers import BlockManager
 
 
 BlockPairInfo = namedtuple(

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -26,14 +26,14 @@ from pandas._typing import (
 )
 from pandas.compat._optional import import_optional_dependency
 
-from pandas.core.dtypes.cast import infer_dtype_from
-from pandas.core.dtypes.common import (
+from .dtypes.cast import infer_dtype_from
+from .dtypes.common import (
     ensure_float64,
     is_integer_dtype,
     is_numeric_v_string_like,
     needs_i8_conversion,
 )
-from pandas.core.dtypes.missing import isna
+from .dtypes.missing import isna
 
 if TYPE_CHECKING:
     from pandas import Index

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -29,7 +29,8 @@ from pandas._typing import (
 )
 from pandas.compat._optional import import_optional_dependency
 
-from pandas.core.dtypes.common import (
+from .construction import extract_array
+from .dtypes.common import (
     get_dtype,
     is_any_int_dtype,
     is_bool_dtype,
@@ -46,14 +47,12 @@ from pandas.core.dtypes.common import (
     needs_i8_conversion,
     pandas_dtype,
 )
-from pandas.core.dtypes.dtypes import PeriodDtype
-from pandas.core.dtypes.missing import (
+from .dtypes.dtypes import PeriodDtype
+from .dtypes.missing import (
     isna,
     na_value_for_dtype,
     notna,
 )
-
-from pandas.core.construction import extract_array
 
 bn = import_optional_dependency("bottleneck", errors="warn")
 _BOTTLENECK_INSTALLED = bn is not None

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -30,30 +30,31 @@ from pandas.core.dtypes.generic import (
 from pandas.core.dtypes.missing import isna
 
 from pandas.core import algorithms
-from pandas.core.ops.array_ops import (  # noqa:F401
+
+from .array_ops import (  # noqa:F401
     arithmetic_op,
     comp_method_OBJECT_ARRAY,
     comparison_op,
     get_array_op,
     logical_op,
 )
-from pandas.core.ops.common import (  # noqa:F401
+from .common import (  # noqa:F401
     get_op_result_name,
     unpack_zerodim_and_defer,
 )
-from pandas.core.ops.docstrings import (
+from .docstrings import (
     _flex_comp_doc_FRAME,
     _op_descriptions,
     make_flex_doc,
 )
-from pandas.core.ops.invalid import invalid_comparison  # noqa:F401
-from pandas.core.ops.mask_ops import (  # noqa: F401
+from .invalid import invalid_comparison  # noqa:F401
+from .mask_ops import (  # noqa: F401
     kleene_and,
     kleene_or,
     kleene_xor,
 )
-from pandas.core.ops.methods import add_flex_arithmetic_methods  # noqa:F401
-from pandas.core.ops.roperator import (  # noqa:F401
+from .methods import add_flex_arithmetic_methods  # noqa:F401
+from .roperator import (  # noqa:F401
     radd,
     rand_,
     rdiv,

--- a/pandas/core/ops/array_ops.py
+++ b/pandas/core/ops/array_ops.py
@@ -46,10 +46,11 @@ from pandas.core.dtypes.missing import (
 )
 
 from pandas.core.construction import ensure_wrapped_if_datetimelike
-from pandas.core.ops import missing
-from pandas.core.ops.dispatch import should_extension_dispatch
-from pandas.core.ops.invalid import invalid_comparison
-from pandas.core.ops.roperator import rpow
+
+from . import missing
+from .dispatch import should_extension_dispatch
+from .invalid import invalid_comparison
+from .roperator import rpow
 
 
 def comp_method_OBJECT_ARRAY(op, x, y):

--- a/pandas/core/ops/methods.py
+++ b/pandas/core/ops/methods.py
@@ -8,7 +8,7 @@ from pandas.core.dtypes.generic import (
     ABCSeries,
 )
 
-from pandas.core.ops.roperator import (
+from .roperator import (
     radd,
     rdivmod,
     rfloordiv,
@@ -36,7 +36,7 @@ def _get_method_wrappers(cls):
     """
     # TODO: make these non-runtime imports once the relevant functions
     #  are no longer in __init__
-    from pandas.core.ops import (
+    from . import (
         flex_arith_method_FRAME,
         flex_comp_method_FRAME,
         flex_method_SERIES,

--- a/pandas/core/ops/missing.py
+++ b/pandas/core/ops/missing.py
@@ -31,7 +31,7 @@ from pandas.core.dtypes.common import (
     is_scalar,
 )
 
-from pandas.core.ops.roperator import (
+from .roperator import (
     rdivmod,
     rfloordiv,
     rmod,

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -36,44 +36,7 @@ from pandas.util._decorators import (
     doc,
 )
 
-from pandas.core.dtypes.generic import (
-    ABCDataFrame,
-    ABCSeries,
-)
-
 import pandas.core.algorithms as algos
-from pandas.core.apply import ResamplerWindowApply
-from pandas.core.base import DataError
-from pandas.core.generic import (
-    NDFrame,
-    _shared_docs,
-)
-from pandas.core.groupby.base import (
-    GotItemMixin,
-    ShallowMixin,
-)
-from pandas.core.groupby.generic import SeriesGroupBy
-from pandas.core.groupby.groupby import (
-    BaseGroupBy,
-    GroupBy,
-    _pipe_template,
-    get_groupby,
-)
-from pandas.core.groupby.grouper import Grouper
-from pandas.core.groupby.ops import BinGrouper
-from pandas.core.indexes.api import Index
-from pandas.core.indexes.datetimes import (
-    DatetimeIndex,
-    date_range,
-)
-from pandas.core.indexes.period import (
-    PeriodIndex,
-    period_range,
-)
-from pandas.core.indexes.timedeltas import (
-    TimedeltaIndex,
-    timedelta_range,
-)
 
 from pandas.tseries.frequencies import (
     is_subperiod,
@@ -84,6 +47,43 @@ from pandas.tseries.offsets import (
     Day,
     Nano,
     Tick,
+)
+
+from .apply import ResamplerWindowApply
+from .base import DataError
+from .dtypes.generic import (
+    ABCDataFrame,
+    ABCSeries,
+)
+from .generic import (
+    NDFrame,
+    _shared_docs,
+)
+from .groupby.base import (
+    GotItemMixin,
+    ShallowMixin,
+)
+from .groupby.generic import SeriesGroupBy
+from .groupby.groupby import (
+    BaseGroupBy,
+    GroupBy,
+    _pipe_template,
+    get_groupby,
+)
+from .groupby.grouper import Grouper
+from .groupby.ops import BinGrouper
+from .indexes.api import Index
+from .indexes.datetimes import (
+    DatetimeIndex,
+    date_range,
+)
+from .indexes.period import (
+    PeriodIndex,
+    period_range,
+)
+from .indexes.timedeltas import (
+    TimedeltaIndex,
+    timedelta_range,
 )
 
 _shared_docs_kwargs: Dict[str, str] = {}

--- a/pandas/core/reshape/api.py
+++ b/pandas/core/reshape/api.py
@@ -1,23 +1,23 @@
 # flake8: noqa
 
-from pandas.core.reshape.concat import concat
-from pandas.core.reshape.melt import (
+from .concat import concat
+from .melt import (
     lreshape,
     melt,
     wide_to_long,
 )
-from pandas.core.reshape.merge import (
+from .merge import (
     merge,
     merge_asof,
     merge_ordered,
 )
-from pandas.core.reshape.pivot import (
+from .pivot import (
     crosstab,
     pivot,
     pivot_table,
 )
-from pandas.core.reshape.reshape import get_dummies
-from pandas.core.reshape.tile import (
+from .reshape import get_dummies
+from .tile import (
     cut,
     qcut,
 )

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -28,10 +28,11 @@ from pandas.core.indexes.api import (
     Index,
     MultiIndex,
 )
-from pandas.core.reshape.concat import concat
-from pandas.core.reshape.util import tile_compat
 from pandas.core.shared_docs import _shared_docs
 from pandas.core.tools.numeric import to_numeric
+
+from .concat import concat
+from .util import tile_compat
 
 if TYPE_CHECKING:
     from pandas import (

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -173,7 +173,7 @@ def _groupby_and_merge(by, on, left: DataFrame, right: DataFrame, merge_pieces):
 
     # preserve the original order
     # if we have a missing piece this can be reset
-    from pandas.core.reshape.concat import concat
+    from .concat import concat
 
     result = concat(pieces, ignore_index=True)
     result = result.reindex(columns=pieces[0].columns, copy=False)

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -44,9 +44,10 @@ from pandas.core.indexes.api import (
     MultiIndex,
     get_objs_combined_axis,
 )
-from pandas.core.reshape.concat import concat
-from pandas.core.reshape.util import cartesian_product
 from pandas.core.series import Series
+
+from .concat import concat
+from .util import cartesian_product
 
 if TYPE_CHECKING:
     from pandas import DataFrame

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -841,7 +841,7 @@ def get_dummies(
     1  0.0  1.0  0.0
     2  0.0  0.0  1.0
     """
-    from pandas.core.reshape.concat import concat
+    from .concat import concat
 
     dtypes_to_encode = ["object", "category"]
 
@@ -931,7 +931,7 @@ def _get_dummies_1d(
     drop_first=False,
     dtype: Optional[Dtype] = None,
 ):
-    from pandas.core.reshape.concat import concat
+    from .concat import concat
 
     # Series avoids inconsistent NaN handling
     codes, levels = factorize_from_iterable(Series(data))

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -56,13 +56,39 @@ from pandas.util._validators import (
     validate_percentile,
 )
 
-from pandas.core.dtypes.cast import (
+import pandas.core.common as com
+import pandas.core.indexes.base as ibase
+
+import pandas.io.formats.format as fmt
+import pandas.plotting
+
+from . import (
+    algorithms,
+    base,
+    generic,
+    missing,
+    nanops,
+    ops,
+)
+from .accessor import CachedAccessor
+from .aggregation import transform
+from .apply import series_apply
+from .arrays import ExtensionArray
+from .arrays.categorical import CategoricalAccessor
+from .arrays.sparse import SparseAccessor
+from .construction import (
+    create_series_with_explicit_dtype,
+    extract_array,
+    is_empty_data,
+    sanitize_array,
+)
+from .dtypes.cast import (
     convert_dtypes,
     maybe_box_native,
     maybe_cast_to_extension_array,
     validate_numeric_casting,
 )
-from pandas.core.dtypes.common import (
+from .dtypes.common import (
     ensure_platform_int,
     is_bool,
     is_categorical_dtype,
@@ -76,66 +102,40 @@ from pandas.core.dtypes.common import (
     pandas_dtype,
     validate_all_hashable,
 )
-from pandas.core.dtypes.generic import ABCDataFrame
-from pandas.core.dtypes.inference import is_hashable
-from pandas.core.dtypes.missing import (
+from .dtypes.generic import ABCDataFrame
+from .dtypes.inference import is_hashable
+from .dtypes.missing import (
     isna,
     na_value_for_dtype,
     notna,
     remove_na_arraylike,
 )
-
-from pandas.core import (
-    algorithms,
-    base,
-    generic,
-    missing,
-    nanops,
-    ops,
-)
-from pandas.core.accessor import CachedAccessor
-from pandas.core.aggregation import transform
-from pandas.core.apply import series_apply
-from pandas.core.arrays import ExtensionArray
-from pandas.core.arrays.categorical import CategoricalAccessor
-from pandas.core.arrays.sparse import SparseAccessor
-import pandas.core.common as com
-from pandas.core.construction import (
-    create_series_with_explicit_dtype,
-    extract_array,
-    is_empty_data,
-    sanitize_array,
-)
-from pandas.core.generic import NDFrame
-from pandas.core.indexers import (
+from .generic import NDFrame
+from .indexers import (
     deprecate_ndim_indexing,
     unpack_1tuple,
 )
-from pandas.core.indexes.accessors import CombinedDatetimelikeProperties
-from pandas.core.indexes.api import (
+from .indexes.accessors import CombinedDatetimelikeProperties
+from .indexes.api import (
     CategoricalIndex,
     Float64Index,
     Index,
     MultiIndex,
     ensure_index,
 )
-import pandas.core.indexes.base as ibase
-from pandas.core.indexes.datetimes import DatetimeIndex
-from pandas.core.indexes.period import PeriodIndex
-from pandas.core.indexes.timedeltas import TimedeltaIndex
-from pandas.core.indexing import check_bool_indexer
-from pandas.core.internals import SingleBlockManager
-from pandas.core.internals.construction import sanitize_index
-from pandas.core.shared_docs import _shared_docs
-from pandas.core.sorting import (
+from .indexes.datetimes import DatetimeIndex
+from .indexes.period import PeriodIndex
+from .indexes.timedeltas import TimedeltaIndex
+from .indexing import check_bool_indexer
+from .internals import SingleBlockManager
+from .internals.construction import sanitize_index
+from .shared_docs import _shared_docs
+from .sorting import (
     ensure_key_mapped,
     nargsort,
 )
-from pandas.core.strings import StringMethods
-from pandas.core.tools.datetimes import to_datetime
-
-import pandas.io.formats.format as fmt
-import pandas.plotting
+from .strings import StringMethods
+from .tools.datetimes import to_datetime
 
 if TYPE_CHECKING:
     from pandas._typing import (
@@ -143,9 +143,9 @@ if TYPE_CHECKING:
         TimestampConvertibleTypes,
     )
 
-    from pandas.core.frame import DataFrame
-    from pandas.core.groupby.generic import SeriesGroupBy
-    from pandas.core.resample import Resampler
+    from .frame import DataFrame
+    from .groupby.generic import SeriesGroupBy
+    from .resample import Resampler
 
 __all__ = ["Series"]
 
@@ -464,7 +464,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         Used when a manipulation result has one higher dimension as the
         original, such as Series.to_frame()
         """
-        from pandas.core.frame import DataFrame
+        from .frame import DataFrame
 
         return DataFrame
 
@@ -1736,7 +1736,7 @@ Name: Max Speed, dtype: float64
         observed: bool = False,
         dropna: bool = True,
     ) -> SeriesGroupBy:
-        from pandas.core.groupby.generic import SeriesGroupBy
+        from .groupby.generic import SeriesGroupBy
 
         if squeeze is not no_default:
             warnings.warn(
@@ -2715,7 +2715,7 @@ Name: Max Speed, dtype: float64
         ...
         ValueError: Indexes have overlapping values: [0, 1, 2]
         """
-        from pandas.core.reshape.concat import concat
+        from .reshape.concat import concat
 
         if isinstance(to_append, (list, tuple)):
             to_concat = [self]
@@ -3854,7 +3854,7 @@ Keep all original rows and also all original values
         a    1    3
         b    2    4
         """
-        from pandas.core.reshape.reshape import unstack
+        from .reshape.reshape import unstack
 
         return unstack(self, level, fill_value)
 

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -24,20 +24,21 @@ from pandas._libs import (
 from pandas._libs.hashtable import unique_label_indices
 from pandas._typing import IndexKeyFunc
 
-from pandas.core.dtypes.common import (
+import pandas.core.algorithms as algorithms
+
+from .construction import extract_array
+from .dtypes.common import (
     ensure_int64,
     ensure_platform_int,
     is_extension_array_dtype,
 )
-from pandas.core.dtypes.generic import ABCMultiIndex
-from pandas.core.dtypes.missing import isna
-
-import pandas.core.algorithms as algorithms
-from pandas.core.construction import extract_array
+from .dtypes.generic import ABCMultiIndex
+from .dtypes.missing import isna
 
 if TYPE_CHECKING:
     from pandas import MultiIndex
-    from pandas.core.indexes.base import Index
+
+    from .indexes.base import Index
 
 _INT64_MAX = np.iinfo(np.int64).max
 
@@ -289,7 +290,7 @@ def lexsort_indexer(
 
         .. versionadded:: 1.0.0
     """
-    from pandas.core.arrays import Categorical
+    from .arrays import Categorical
 
     labels = []
     shape = []
@@ -485,7 +486,7 @@ def ensure_key_mapped(values, key: Optional[Callable], levels=None):
     levels : Optional[List], if values is a MultiIndex, list of levels to
     apply the key to.
     """
-    from pandas.core.indexes.api import Index
+    from .indexes.api import Index
 
     if not key:
         return values

--- a/pandas/core/strings/__init__.py
+++ b/pandas/core/strings/__init__.py
@@ -26,7 +26,7 @@ to other string extension arrays.
 #     - PandasArray
 #     - Categorical
 
-from pandas.core.strings.accessor import StringMethods
-from pandas.core.strings.base import BaseStringArrayMethods
+from .accessor import StringMethods
+from .base import BaseStringArrayMethods
 
 __all__ = ["StringMethods", "BaseStringArrayMethods"]

--- a/pandas/core/strings/object_array.py
+++ b/pandas/core/strings/object_array.py
@@ -26,7 +26,7 @@ from pandas.core.dtypes.common import (
 )
 from pandas.core.dtypes.missing import isna
 
-from pandas.core.strings.base import BaseStringArrayMethods
+from .base import BaseStringArrayMethods
 
 
 class ObjectStringArrayMixin(BaseStringArrayMethods):

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -1025,6 +1025,6 @@ def to_time(arg, format=None, infer_time_format=False, errors="raise"):
         FutureWarning,
         stacklevel=2,
     )
-    from pandas.core.tools.times import to_time
+    from .times import to_time
 
     return to_time(arg, format, infer_time_format, errors)

--- a/pandas/core/window/__init__.py
+++ b/pandas/core/window/__init__.py
@@ -1,12 +1,12 @@
-from pandas.core.window.ewm import (  # noqa:F401
+from .ewm import (  # noqa:F401
     ExponentialMovingWindow,
     ExponentialMovingWindowGroupby,
 )
-from pandas.core.window.expanding import (  # noqa:F401
+from .expanding import (  # noqa:F401
     Expanding,
     ExpandingGroupby,
 )
-from pandas.core.window.rolling import (  # noqa:F401
+from .rolling import (  # noqa:F401
     Rolling,
     RollingGroupby,
     Window,

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -26,8 +26,9 @@ from pandas.core.dtypes.missing import isna
 
 import pandas.core.common as common
 from pandas.core.util.numba_ import maybe_use_numba
-from pandas.core.window.common import zsqrt
-from pandas.core.window.doc import (
+
+from .common import zsqrt
+from .doc import (
     _shared_docs,
     args_compat,
     create_section_header,
@@ -36,13 +37,13 @@ from pandas.core.window.doc import (
     template_returns,
     template_see_also,
 )
-from pandas.core.window.indexers import (
+from .indexers import (
     BaseIndexer,
     ExponentialMovingWindowIndexer,
     GroupbyIndexer,
 )
-from pandas.core.window.numba_ import generate_numba_groupby_ewma_func
-from pandas.core.window.rolling import (
+from .numba_ import generate_numba_groupby_ewma_func
+from .rolling import (
     BaseWindow,
     BaseWindowGroupby,
 )

--- a/pandas/core/window/expanding.py
+++ b/pandas/core/window/expanding.py
@@ -14,7 +14,7 @@ from pandas._typing import FrameOrSeries
 from pandas.compat.numpy import function as nv
 from pandas.util._decorators import doc
 
-from pandas.core.window.doc import (
+from .doc import (
     _shared_docs,
     args_compat,
     create_section_header,
@@ -26,12 +26,12 @@ from pandas.core.window.doc import (
     window_agg_numba_parameters,
     window_apply_parameters,
 )
-from pandas.core.window.indexers import (
+from .indexers import (
     BaseIndexer,
     ExpandingIndexer,
     GroupbyIndexer,
 )
-from pandas.core.window.rolling import (
+from .rolling import (
     BaseWindowGroupby,
     RollingAndExpandingMixin,
 )

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -77,11 +77,12 @@ from pandas.core.util.numba_ import (
     NUMBA_FUNC_CACHE,
     maybe_use_numba,
 )
-from pandas.core.window.common import (
+
+from .common import (
     flex_binary_moment,
     zsqrt,
 )
-from pandas.core.window.doc import (
+from .doc import (
     _shared_docs,
     args_compat,
     create_section_header,
@@ -94,13 +95,13 @@ from pandas.core.window.doc import (
     window_agg_numba_parameters,
     window_apply_parameters,
 )
-from pandas.core.window.indexers import (
+from .indexers import (
     BaseIndexer,
     FixedWindowIndexer,
     GroupbyIndexer,
     VariableWindowIndexer,
 )
-from pandas.core.window.numba_ import (
+from .numba_ import (
     generate_manual_numpy_nan_agg_with_axis,
     generate_numba_apply_func,
     generate_numba_table_func,

--- a/pandas/io/api.py
+++ b/pandas/io/api.py
@@ -4,36 +4,36 @@ Data IO api
 
 # flake8: noqa
 
-from pandas.io.clipboards import read_clipboard
-from pandas.io.excel import (
+from .clipboards import read_clipboard
+from .excel import (
     ExcelFile,
     ExcelWriter,
     read_excel,
 )
-from pandas.io.feather_format import read_feather
-from pandas.io.gbq import read_gbq
-from pandas.io.html import read_html
-from pandas.io.json import read_json
-from pandas.io.orc import read_orc
-from pandas.io.parquet import read_parquet
-from pandas.io.parsers import (
+from .feather_format import read_feather
+from .gbq import read_gbq
+from .html import read_html
+from .json import read_json
+from .orc import read_orc
+from .parquet import read_parquet
+from .parsers import (
     read_csv,
     read_fwf,
     read_table,
 )
-from pandas.io.pickle import (
+from .pickle import (
     read_pickle,
     to_pickle,
 )
-from pandas.io.pytables import (
+from .pytables import (
     HDFStore,
     read_hdf,
 )
-from pandas.io.sas import read_sas
-from pandas.io.spss import read_spss
-from pandas.io.sql import (
+from .sas import read_sas
+from .spss import read_spss
+from .sql import (
     read_sql,
     read_sql_query,
     read_sql_table,
 )
-from pandas.io.stata import read_stata
+from .stata import read_stata

--- a/pandas/io/clipboards.py
+++ b/pandas/io/clipboards.py
@@ -35,8 +35,8 @@ def read_clipboard(sep=r"\s+", **kwargs):  # pragma: no cover
     if encoding is not None and encoding.lower().replace("-", "") != "utf8":
         raise NotImplementedError("reading from clipboard only supports utf-8 encoding")
 
-    from pandas.io.clipboard import clipboard_get
-    from pandas.io.parsers import read_csv
+    from .clipboard import clipboard_get
+    from .parsers import read_csv
 
     text = clipboard_get()
 
@@ -107,7 +107,7 @@ def to_clipboard(obj, excel=True, sep=None, **kwargs):  # pragma: no cover
     if encoding is not None and encoding.lower().replace("-", "") != "utf8":
         raise ValueError("clipboard only supports utf-8 encoding")
 
-    from pandas.io.clipboard import clipboard_set
+    from .clipboard import clipboard_set
 
     if excel is None:
         excel = True

--- a/pandas/io/excel/__init__.py
+++ b/pandas/io/excel/__init__.py
@@ -1,13 +1,13 @@
-from pandas.io.excel._base import (
+from ._base import (
     ExcelFile,
     ExcelWriter,
     read_excel,
 )
-from pandas.io.excel._odswriter import ODSWriter as _ODSWriter
-from pandas.io.excel._openpyxl import OpenpyxlWriter as _OpenpyxlWriter
-from pandas.io.excel._util import register_writer
-from pandas.io.excel._xlsxwriter import XlsxWriter as _XlsxWriter
-from pandas.io.excel._xlwt import XlwtWriter as _XlwtWriter
+from ._odswriter import ODSWriter as _ODSWriter
+from ._openpyxl import OpenpyxlWriter as _OpenpyxlWriter
+from ._util import register_writer
+from ._xlsxwriter import XlsxWriter as _XlsxWriter
+from ._xlwt import XlwtWriter as _XlwtWriter
 
 __all__ = ["read_excel", "ExcelWriter", "ExcelFile"]
 

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -54,14 +54,15 @@ from pandas.io.common import (
     stringify_path,
     validate_header_arg,
 )
-from pandas.io.excel._util import (
+from pandas.io.parsers import TextParser
+
+from ._util import (
     fill_mi_header,
     get_default_engine,
     get_writer,
     maybe_convert_usecols,
     pop_header_name,
 )
-from pandas.io.parsers import TextParser
 
 _read_excel_doc = (
     """
@@ -1064,10 +1065,10 @@ class ExcelFile:
             This is not supported, switch to using ``openpyxl`` instead.
     """
 
-    from pandas.io.excel._odfreader import ODFReader
-    from pandas.io.excel._openpyxl import OpenpyxlReader
-    from pandas.io.excel._pyxlsb import PyxlsbReader
-    from pandas.io.excel._xlrd import XlrdReader
+    from ._odfreader import ODFReader
+    from ._openpyxl import OpenpyxlReader
+    from ._pyxlsb import PyxlsbReader
+    from ._xlrd import XlrdReader
 
     _engines: Mapping[str, Any] = {
         "xlrd": XlrdReader,

--- a/pandas/io/excel/_odfreader.py
+++ b/pandas/io/excel/_odfreader.py
@@ -14,7 +14,7 @@ from pandas.compat._optional import import_optional_dependency
 
 import pandas as pd
 
-from pandas.io.excel._base import BaseExcelReader
+from ._base import BaseExcelReader
 
 
 class ODFReader(BaseExcelReader):

--- a/pandas/io/excel/_odswriter.py
+++ b/pandas/io/excel/_odswriter.py
@@ -13,9 +13,10 @@ from typing import (
 import pandas._libs.json as json
 from pandas._typing import StorageOptions
 
-from pandas.io.excel._base import ExcelWriter
-from pandas.io.excel._util import validate_freeze_panes
 from pandas.io.formats.excel import ExcelCell
+
+from ._base import ExcelWriter
+from ._util import validate_freeze_panes
 
 
 class ODSWriter(ExcelWriter):

--- a/pandas/io/excel/_openpyxl.py
+++ b/pandas/io/excel/_openpyxl.py
@@ -17,11 +17,11 @@ from pandas._typing import (
 )
 from pandas.compat._optional import import_optional_dependency
 
-from pandas.io.excel._base import (
+from ._base import (
     BaseExcelReader,
     ExcelWriter,
 )
-from pandas.io.excel._util import validate_freeze_panes
+from ._util import validate_freeze_panes
 
 if TYPE_CHECKING:
     from openpyxl.descriptors.serialisable import Serialisable

--- a/pandas/io/excel/_pyxlsb.py
+++ b/pandas/io/excel/_pyxlsb.py
@@ -7,7 +7,7 @@ from pandas._typing import (
 )
 from pandas.compat._optional import import_optional_dependency
 
-from pandas.io.excel._base import BaseExcelReader
+from ._base import BaseExcelReader
 
 
 class PyxlsbReader(BaseExcelReader):

--- a/pandas/io/excel/_xlrd.py
+++ b/pandas/io/excel/_xlrd.py
@@ -5,7 +5,7 @@ import numpy as np
 from pandas._typing import StorageOptions
 from pandas.compat._optional import import_optional_dependency
 
-from pandas.io.excel._base import BaseExcelReader
+from ._base import BaseExcelReader
 
 
 class XlrdReader(BaseExcelReader):

--- a/pandas/io/excel/_xlsxwriter.py
+++ b/pandas/io/excel/_xlsxwriter.py
@@ -7,8 +7,8 @@ from typing import (
 import pandas._libs.json as json
 from pandas._typing import StorageOptions
 
-from pandas.io.excel._base import ExcelWriter
-from pandas.io.excel._util import validate_freeze_panes
+from ._base import ExcelWriter
+from ._util import validate_freeze_panes
 
 
 class _XlsxStyler:

--- a/pandas/io/excel/_xlwt.py
+++ b/pandas/io/excel/_xlwt.py
@@ -6,8 +6,8 @@ from typing import (
 import pandas._libs.json as json
 from pandas._typing import StorageOptions
 
-from pandas.io.excel._base import ExcelWriter
-from pandas.io.excel._util import validate_freeze_panes
+from ._base import ExcelWriter
+from ._util import validate_freeze_panes
 
 if TYPE_CHECKING:
     from xlwt import XFStyle

--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -16,7 +16,7 @@ from pandas import (
 )
 from pandas.core import generic
 
-from pandas.io.common import get_handle
+from .common import get_handle
 
 
 @doc(storage_options=generic._shared_docs["storage_options"])

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -42,7 +42,7 @@ from pandas.core.indexes.api import Index
 from pandas.io.common import get_handle
 
 if TYPE_CHECKING:
-    from pandas.io.formats.format import DataFrameFormatter
+    from .format import DataFrameFormatter
 
 
 class CSVFormatter:

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -42,13 +42,13 @@ from pandas import (
 from pandas.core import generic
 import pandas.core.common as com
 
-from pandas.io.formats._color_data import CSS4_COLORS
-from pandas.io.formats.css import (
+from ._color_data import CSS4_COLORS
+from .css import (
     CSSResolver,
     CSSWarning,
 )
-from pandas.io.formats.format import get_level_lengths
-from pandas.io.formats.printing import pprint_thing
+from .format import get_level_lengths
+from .printing import pprint_thing
 
 
 class ExcelCell:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -98,7 +98,8 @@ from pandas.core.indexes.timedeltas import TimedeltaIndex
 from pandas.core.reshape.concat import concat
 
 from pandas.io.common import stringify_path
-from pandas.io.formats.printing import (
+
+from .printing import (
     adjoin,
     justify,
     pprint_thing,
@@ -968,7 +969,7 @@ class DataFrameRenderer:
         """
         Render a DataFrame to a LaTeX tabular/longtable environment output.
         """
-        from pandas.io.formats.latex import LatexFormatter
+        from .latex import LatexFormatter
 
         latex_formatter = LatexFormatter(
             self.fmt,
@@ -1016,7 +1017,7 @@ class DataFrameRenderer:
         render_links : bool, default False
             Convert URLs to HTML links.
         """
-        from pandas.io.formats.html import (
+        from .html import (
             HTMLFormatter,
             NotebookFormatter,
         )
@@ -1051,7 +1052,7 @@ class DataFrameRenderer:
         line_width : int, optional
             Width to wrap a line in characters.
         """
-        from pandas.io.formats.string import StringFormatter
+        from .string import StringFormatter
 
         string_formatter = StringFormatter(self.fmt, line_width=line_width)
         string = string_formatter.to_string()
@@ -1079,7 +1080,7 @@ class DataFrameRenderer:
         """
         Render dataframe as comma-separated file.
         """
-        from pandas.io.formats.csvs import CSVFormatter
+        from .csvs import CSVFormatter
 
         if path_or_buf is None:
             created_buffer = True

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -25,11 +25,12 @@ from pandas import (
 )
 
 from pandas.io.common import is_url
-from pandas.io.formats.format import (
+
+from .format import (
     DataFrameFormatter,
     get_level_lengths,
 )
-from pandas.io.formats.printing import pprint_thing
+from .printing import pprint_thing
 
 
 class HTMLFormatter:

--- a/pandas/io/formats/info.py
+++ b/pandas/io/formats/info.py
@@ -26,8 +26,8 @@ from pandas._typing import (
 
 from pandas.core.indexes.api import Index
 
-from pandas.io.formats import format as fmt
-from pandas.io.formats.printing import pprint_thing
+from . import format as fmt
+from .printing import pprint_thing
 
 if TYPE_CHECKING:
     from pandas.core.frame import DataFrame

--- a/pandas/io/formats/latex.py
+++ b/pandas/io/formats/latex.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from pandas.core.dtypes.generic import ABCMultiIndex
 
-from pandas.io.formats.format import DataFrameFormatter
+from .format import DataFrameFormatter
 
 
 def _split_into_full_short_caption(

--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -321,8 +321,8 @@ def format_object_summary(
     -------
     summary string
     """
-    from pandas.io.formats.console import get_console_size
-    from pandas.io.formats.format import get_adjustment
+    from .console import get_console_size
+    from .format import get_adjustment
 
     display_width, _ = get_console_size()
     if display_width is None:

--- a/pandas/io/formats/string.py
+++ b/pandas/io/formats/string.py
@@ -10,8 +10,8 @@ from typing import (
 
 import numpy as np
 
-from pandas.io.formats.format import DataFrameFormatter
-from pandas.io.formats.printing import pprint_thing
+from .format import DataFrameFormatter
+from .printing import pprint_thing
 
 
 class StringFormatter:

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -355,7 +355,7 @@ class Styler:
         freeze_panes: Optional[Tuple[int, int]] = None,
     ) -> None:
 
-        from pandas.io.formats.excel import ExcelFormatter
+        from .excel import ExcelFormatter
 
         formatter = ExcelFormatter(
             self,

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -31,14 +31,14 @@ from pandas.core.dtypes.common import is_list_like
 from pandas.core.construction import create_series_with_explicit_dtype
 from pandas.core.frame import DataFrame
 
-from pandas.io.common import (
+from .common import (
     is_url,
     stringify_path,
     urlopen,
     validate_header_arg,
 )
-from pandas.io.formats.printing import pprint_thing
-from pandas.io.parsers import TextParser
+from .formats.printing import pprint_thing
+from .parsers import TextParser
 
 _IMPORTS = False
 _HAS_BS4 = False

--- a/pandas/io/json/__init__.py
+++ b/pandas/io/json/__init__.py
@@ -1,14 +1,14 @@
-from pandas.io.json._json import (
+from ._json import (
     dumps,
     loads,
     read_json,
     to_json,
 )
-from pandas.io.json._normalize import (
+from ._normalize import (
     _json_normalize,
     json_normalize,
 )
-from pandas.io.json._table_schema import build_table_schema
+from ._table_schema import build_table_schema
 
 __all__ = [
     "dumps",

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -61,12 +61,13 @@ from pandas.io.common import (
     is_url,
     stringify_path,
 )
-from pandas.io.json._normalize import convert_to_line_delimits
-from pandas.io.json._table_schema import (
+from pandas.io.parsers.readers import validate_integer
+
+from ._normalize import convert_to_line_delimits
+from ._table_schema import (
     build_table_schema,
     parse_table_schema,
 )
-from pandas.io.parsers.readers import validate_integer
 
 loads = json.loads
 dumps = json.dumps

--- a/pandas/io/orc.py
+++ b/pandas/io/orc.py
@@ -10,7 +10,7 @@ from typing import (
 
 from pandas._typing import FilePathOrBuffer
 
-from pandas.io.common import get_handle
+from .common import get_handle
 
 if TYPE_CHECKING:
     from pandas import DataFrame

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -29,7 +29,7 @@ from pandas import (
 )
 from pandas.core import generic
 
-from pandas.io.common import (
+from .common import (
     IOHandles,
     get_handle,
     is_fsspec_url,

--- a/pandas/io/parsers/__init__.py
+++ b/pandas/io/parsers/__init__.py
@@ -1,4 +1,4 @@
-from pandas.io.parsers.readers import (
+from .readers import (
     TextFileReader,
     TextParser,
     read_csv,

--- a/pandas/io/parsers/c_parser_wrapper.py
+++ b/pandas/io/parsers/c_parser_wrapper.py
@@ -3,7 +3,7 @@ from pandas._typing import FilePathOrBuffer
 
 from pandas.core.indexes.api import ensure_index_from_sequences
 
-from pandas.io.parsers.base_parser import (
+from .base_parser import (
     ParserBase,
     is_index_col,
 )

--- a/pandas/io/parsers/python_parser.py
+++ b/pandas/io/parsers/python_parser.py
@@ -30,7 +30,7 @@ from pandas.errors import (
 
 from pandas.core.dtypes.common import is_integer
 
-from pandas.io.parsers.base_parser import (
+from .base_parser import (
     ParserBase,
     parser_defaults,
 )

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -43,13 +43,14 @@ from pandas.core.frame import DataFrame
 from pandas.core.indexes.api import RangeIndex
 
 from pandas.io.common import validate_header_arg
-from pandas.io.parsers.base_parser import (
+
+from .base_parser import (
     ParserBase,
     is_index_col,
     parser_defaults,
 )
-from pandas.io.parsers.c_parser_wrapper import CParserWrapper
-from pandas.io.parsers.python_parser import (
+from .c_parser_wrapper import CParserWrapper
+from .python_parser import (
     FixedWidthFieldParser,
     PythonParser,
 )

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -13,7 +13,7 @@ from pandas.util._decorators import doc
 
 from pandas.core import generic
 
-from pandas.io.common import get_handle
+from .common import get_handle
 
 
 @doc(storage_options=generic._shared_docs["storage_options"])

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -94,8 +94,8 @@ from pandas.core.construction import extract_array
 from pandas.core.indexes.api import ensure_index
 from pandas.core.internals import BlockManager
 
-from pandas.io.common import stringify_path
-from pandas.io.formats.printing import (
+from .common import stringify_path
+from .formats.printing import (
     adjoin,
     pprint_thing,
 )

--- a/pandas/io/sas/__init__.py
+++ b/pandas/io/sas/__init__.py
@@ -1,1 +1,1 @@
-from pandas.io.sas.sasreader import read_sas  # noqa
+from .sasreader import read_sas  # noqa

--- a/pandas/io/sas/sas7bdat.py
+++ b/pandas/io/sas/sas7bdat.py
@@ -37,9 +37,10 @@ import pandas as pd
 from pandas import isna
 
 from pandas.io.common import get_handle
-from pandas.io.sas._sas import Parser
 import pandas.io.sas.sas_constants as const
-from pandas.io.sas.sasreader import ReaderBase
+
+from ._sas import Parser
+from .sasreader import ReaderBase
 
 
 def _parse_datetime(sas_datetime: float, unit: str):

--- a/pandas/io/sas/sas_xport.py
+++ b/pandas/io/sas/sas_xport.py
@@ -23,7 +23,8 @@ from pandas.util._decorators import Appender
 import pandas as pd
 
 from pandas.io.common import get_handle
-from pandas.io.sas.sasreader import ReaderBase
+
+from .sasreader import ReaderBase
 
 _correct_line1 = (
     "HEADER RECORD*******LIBRARY HEADER RECORD!!!!!!!"

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -136,7 +136,7 @@ def read_sas(
 
     reader: ReaderBase
     if format.lower() == "xport":
-        from pandas.io.sas.sas_xport import XportReader
+        from .sas_xport import XportReader
 
         reader = XportReader(
             filepath_or_buffer,
@@ -145,7 +145,7 @@ def read_sas(
             chunksize=chunksize,
         )
     elif format.lower() == "sas7bdat":
-        from pandas.io.sas.sas7bdat import SAS7BDATReader
+        from .sas7bdat import SAS7BDATReader
 
         reader = SAS7BDATReader(
             filepath_or_buffer,

--- a/pandas/io/spss.py
+++ b/pandas/io/spss.py
@@ -11,7 +11,7 @@ from pandas.core.dtypes.inference import is_list_like
 
 from pandas.core.api import DataFrame
 
-from pandas.io.common import stringify_path
+from .common import stringify_path
 
 
 def read_spss(

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -68,7 +68,7 @@ from pandas.core.frame import DataFrame
 from pandas.core.indexes.base import Index
 from pandas.core.series import Series
 
-from pandas.io.common import get_handle
+from .common import get_handle
 
 _version_error = (
     "Version of given Stata file is {version}. pandas supports importing "

--- a/pandas/plotting/__init__.py
+++ b/pandas/plotting/__init__.py
@@ -55,7 +55,7 @@ https://github.com/pyviz/hvplot as a reference on how to write a backend.
 For the discussion about the API see
 https://github.com/pandas-dev/pandas/issues/26747.
 """
-from pandas.plotting._core import (
+from ._core import (
     PlotAccessor,
     boxplot,
     boxplot_frame,
@@ -63,7 +63,7 @@ from pandas.plotting._core import (
     hist_frame,
     hist_series,
 )
-from pandas.plotting._misc import (
+from ._misc import (
     andrews_curves,
     autocorrelation_plot,
     bootstrap_plot,

--- a/pandas/plotting/_matplotlib/__init__.py
+++ b/pandas/plotting/_matplotlib/__init__.py
@@ -6,17 +6,17 @@ from typing import (
     Type,
 )
 
-from pandas.plotting._matplotlib.boxplot import (
+from .boxplot import (
     BoxPlot,
     boxplot,
     boxplot_frame,
     boxplot_frame_groupby,
 )
-from pandas.plotting._matplotlib.converter import (
+from .converter import (
     deregister,
     register,
 )
-from pandas.plotting._matplotlib.core import (
+from .core import (
     AreaPlot,
     BarhPlot,
     BarPlot,
@@ -25,13 +25,13 @@ from pandas.plotting._matplotlib.core import (
     PiePlot,
     ScatterPlot,
 )
-from pandas.plotting._matplotlib.hist import (
+from .hist import (
     HistPlot,
     KdePlot,
     hist_frame,
     hist_series,
 )
-from pandas.plotting._matplotlib.misc import (
+from .misc import (
     andrews_curves,
     autocorrelation_plot,
     bootstrap_plot,
@@ -40,10 +40,10 @@ from pandas.plotting._matplotlib.misc import (
     radviz,
     scatter_matrix,
 )
-from pandas.plotting._matplotlib.tools import table
+from .tools import table
 
 if TYPE_CHECKING:
-    from pandas.plotting._matplotlib.core import MPLPlot
+    from .core import MPLPlot
 
 PLOT_CLASSES: Dict[str, Type[MPLPlot]] = {
     "line": LinePlot,

--- a/pandas/plotting/_matplotlib/boxplot.py
+++ b/pandas/plotting/_matplotlib/boxplot.py
@@ -14,12 +14,13 @@ import pandas as pd
 import pandas.core.common as com
 
 from pandas.io.formats.printing import pprint_thing
-from pandas.plotting._matplotlib.core import (
+
+from .core import (
     LinePlot,
     MPLPlot,
 )
-from pandas.plotting._matplotlib.style import get_standard_colors
-from pandas.plotting._matplotlib.tools import (
+from .style import get_standard_colors
+from .tools import (
     create_subplots,
     flatten_axes,
     maybe_adjust_figure,

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -43,17 +43,18 @@ from pandas.core.dtypes.missing import (
 import pandas.core.common as com
 
 from pandas.io.formats.printing import pprint_thing
-from pandas.plotting._matplotlib.compat import mpl_ge_3_0_0
-from pandas.plotting._matplotlib.converter import register_pandas_matplotlib_converters
-from pandas.plotting._matplotlib.style import get_standard_colors
-from pandas.plotting._matplotlib.timeseries import (
+
+from .compat import mpl_ge_3_0_0
+from .converter import register_pandas_matplotlib_converters
+from .style import get_standard_colors
+from .timeseries import (
     decorate_axes,
     format_dateaxis,
     maybe_convert_index,
     maybe_resample,
     use_dynamic_x,
 )
-from pandas.plotting._matplotlib.tools import (
+from .tools import (
     create_subplots,
     flatten_axes,
     format_date_labels,

--- a/pandas/plotting/_matplotlib/hist.py
+++ b/pandas/plotting/_matplotlib/hist.py
@@ -18,11 +18,12 @@ from pandas.core.dtypes.missing import (
 )
 
 from pandas.io.formats.printing import pprint_thing
-from pandas.plotting._matplotlib.core import (
+
+from .core import (
     LinePlot,
     MPLPlot,
 )
-from pandas.plotting._matplotlib.tools import (
+from .tools import (
     create_subplots,
     flatten_axes,
     maybe_adjust_figure,

--- a/pandas/plotting/_matplotlib/misc.py
+++ b/pandas/plotting/_matplotlib/misc.py
@@ -17,8 +17,9 @@ import numpy as np
 from pandas.core.dtypes.missing import notna
 
 from pandas.io.formats.printing import pprint_thing
-from pandas.plotting._matplotlib.style import get_standard_colors
-from pandas.plotting._matplotlib.tools import (
+
+from .style import get_standard_colors
+from .tools import (
     create_subplots,
     do_adjust_figure,
     maybe_adjust_figure,

--- a/pandas/plotting/_matplotlib/timeseries.py
+++ b/pandas/plotting/_matplotlib/timeseries.py
@@ -26,15 +26,16 @@ from pandas.core.dtypes.generic import (
 )
 
 from pandas.io.formats.printing import pprint_thing
-from pandas.plotting._matplotlib.converter import (
-    TimeSeries_DateFormatter,
-    TimeSeries_DateLocator,
-    TimeSeries_TimedeltaFormatter,
-)
 from pandas.tseries.frequencies import (
     get_period_alias,
     is_subperiod,
     is_superperiod,
+)
+
+from .converter import (
+    TimeSeries_DateFormatter,
+    TimeSeries_DateLocator,
+    TimeSeries_TimedeltaFormatter,
 )
 
 if TYPE_CHECKING:
@@ -136,7 +137,7 @@ def _replot_ax(ax: Axes, freq, kwargs):
 
             # for tsplot
             if isinstance(plotf, str):
-                from pandas.plotting._matplotlib import PLOT_CLASSES
+                from . import PLOT_CLASSES
 
                 plotf = PLOT_CLASSES[plotf]._plot
 

--- a/pandas/plotting/_matplotlib/tools.py
+++ b/pandas/plotting/_matplotlib/tools.py
@@ -25,7 +25,7 @@ from pandas.core.dtypes.generic import (
     ABCSeries,
 )
 
-from pandas.plotting._matplotlib import compat
+from . import compat
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 
-from pandas.plotting._core import _get_plot_backend
+from ._core import _get_plot_backend
 
 
 def table(ax, data, rowLabels=None, colLabels=None, **kwargs):

--- a/pandas/testing.py
+++ b/pandas/testing.py
@@ -3,7 +3,7 @@ Public testing utility functions.
 """
 
 
-from pandas._testing import (
+from ._testing import (
     assert_extension_array_equal,
     assert_frame_equal,
     assert_index_equal,

--- a/pandas/tests/api/test_types.py
+++ b/pandas/tests/api/test_types.py
@@ -1,6 +1,7 @@
 import pandas._testing as tm
 from pandas.api import types
-from pandas.tests.api.test_api import Base
+
+from .test_api import Base
 
 
 class TestTypes(Base):

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -40,7 +40,8 @@ from pandas.core.arrays import (
     TimedeltaArray,
 )
 from pandas.core.ops import roperator
-from pandas.tests.arithmetic.common import (
+
+from .common import (
     assert_invalid_addsub_type,
     assert_invalid_comparison,
     get_upcast_box,

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -25,7 +25,8 @@ from pandas import (
 import pandas._testing as tm
 from pandas.core import ops
 from pandas.core.arrays import TimedeltaArray
-from pandas.tests.arithmetic.common import assert_invalid_comparison
+
+from .common import assert_invalid_comparison
 
 # ------------------------------------------------------------------
 # Comparisons

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -26,7 +26,8 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.tests.arithmetic.common import (
+
+from .common import (
     assert_invalid_addsub_type,
     assert_invalid_comparison,
     get_upcast_box,

--- a/pandas/tests/arrays/categorical/test_api.py
+++ b/pandas/tests/arrays/categorical/test_api.py
@@ -12,7 +12,8 @@ from pandas import (
 )
 import pandas._testing as tm
 from pandas.core.arrays.categorical import recode_for_categories
-from pandas.tests.arrays.categorical.common import TestCategorical
+
+from .common import TestCategorical
 
 
 class TestCategoricalAPI:

--- a/pandas/tests/arrays/categorical/test_indexing.py
+++ b/pandas/tests/arrays/categorical/test_indexing.py
@@ -14,7 +14,8 @@ from pandas import (
 )
 import pandas._testing as tm
 import pandas.core.common as com
-from pandas.tests.arrays.categorical.common import TestCategorical
+
+from .common import TestCategorical
 
 
 class TestCategoricalIndexingWithFactor(TestCategorical):

--- a/pandas/tests/arrays/categorical/test_operators.py
+++ b/pandas/tests/arrays/categorical/test_operators.py
@@ -12,7 +12,8 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
-from pandas.tests.arrays.categorical.common import TestCategorical
+
+from .common import TestCategorical
 
 
 class TestCategoricalOpsWithFactor(TestCategorical):

--- a/pandas/tests/arrays/categorical/test_repr.py
+++ b/pandas/tests/arrays/categorical/test_repr.py
@@ -9,7 +9,8 @@ from pandas import (
     period_range,
     timedelta_range,
 )
-from pandas.tests.arrays.categorical.common import TestCategorical
+
+from .common import TestCategorical
 
 
 class TestCategoricalReprWithFactor(TestCategorical):

--- a/pandas/tests/base/test_fillna.py
+++ b/pandas/tests/base/test_fillna.py
@@ -13,7 +13,8 @@ from pandas.core.dtypes.generic import ABCMultiIndex
 
 from pandas import Index
 import pandas._testing as tm
-from pandas.tests.base.common import allow_na_ops
+
+from .common import allow_na_ops
 
 
 def test_fillna(index_or_series_obj):

--- a/pandas/tests/base/test_unique.py
+++ b/pandas/tests/base/test_unique.py
@@ -10,7 +10,8 @@ from pandas.core.dtypes.common import (
 
 import pandas as pd
 import pandas._testing as tm
-from pandas.tests.base.common import allow_na_ops
+
+from .common import allow_na_ops
 
 
 def test_unique(index_or_series_obj):

--- a/pandas/tests/base/test_value_counts.py
+++ b/pandas/tests/base/test_value_counts.py
@@ -21,7 +21,8 @@ from pandas import (
     TimedeltaIndex,
 )
 import pandas._testing as tm
-from pandas.tests.base.common import allow_na_ops
+
+from .common import allow_na_ops
 
 
 def test_value_counts(index_or_series_obj):

--- a/pandas/tests/extension/arrow/test_bool.py
+++ b/pandas/tests/extension/arrow/test_bool.py
@@ -8,7 +8,7 @@ from pandas.tests.extension import base
 
 pytest.importorskip("pyarrow", minversion="0.13.0")
 
-from pandas.tests.extension.arrow.arrays import (  # isort:skip
+from .arrays import (  # isort:skip
     ArrowBoolArray,
     ArrowBoolDtype,
 )

--- a/pandas/tests/extension/arrow/test_string.py
+++ b/pandas/tests/extension/arrow/test_string.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 pytest.importorskip("pyarrow", minversion="0.13.0")
 
-from pandas.tests.extension.arrow.arrays import ArrowStringDtype  # isort:skip
+from .arrays import ArrowStringDtype  # isort:skip
 
 
 def test_constructor_from_list():

--- a/pandas/tests/extension/arrow/test_timestamp.py
+++ b/pandas/tests/extension/arrow/test_timestamp.py
@@ -15,7 +15,7 @@ pytest.importorskip("pyarrow", minversion="0.13.0")
 
 import pyarrow as pa  # isort:skip
 
-from pandas.tests.extension.arrow.arrays import ArrowExtensionArray  # isort:skip
+from .arrays import ArrowExtensionArray  # isort:skip
 
 
 @register_extension_dtype

--- a/pandas/tests/extension/base/__init__.py
+++ b/pandas/tests/extension/base/__init__.py
@@ -41,26 +41,26 @@ by defining the staticmethods ``assert_frame_equal`` and
 ``assert_series_equal`` on your base test class.
 
 """
-from pandas.tests.extension.base.casting import BaseCastingTests  # noqa
-from pandas.tests.extension.base.constructors import BaseConstructorsTests  # noqa
-from pandas.tests.extension.base.dtype import BaseDtypeTests  # noqa
-from pandas.tests.extension.base.getitem import BaseGetitemTests  # noqa
-from pandas.tests.extension.base.groupby import BaseGroupbyTests  # noqa
-from pandas.tests.extension.base.interface import BaseInterfaceTests  # noqa
-from pandas.tests.extension.base.io import BaseParsingTests  # noqa
-from pandas.tests.extension.base.methods import BaseMethodsTests  # noqa
-from pandas.tests.extension.base.missing import BaseMissingTests  # noqa
-from pandas.tests.extension.base.ops import (  # noqa
+from .casting import BaseCastingTests  # noqa
+from .constructors import BaseConstructorsTests  # noqa
+from .dtype import BaseDtypeTests  # noqa
+from .getitem import BaseGetitemTests  # noqa
+from .groupby import BaseGroupbyTests  # noqa
+from .interface import BaseInterfaceTests  # noqa
+from .io import BaseParsingTests  # noqa
+from .methods import BaseMethodsTests  # noqa
+from .missing import BaseMissingTests  # noqa
+from .ops import (  # noqa
     BaseArithmeticOpsTests,
     BaseComparisonOpsTests,
     BaseOpsUtil,
     BaseUnaryOpsTests,
 )
-from pandas.tests.extension.base.printing import BasePrintingTests  # noqa
-from pandas.tests.extension.base.reduce import (  # noqa
+from .printing import BasePrintingTests  # noqa
+from .reduce import (  # noqa
     BaseBooleanReduceTests,
     BaseNoReduceTests,
     BaseNumericReduceTests,
 )
-from pandas.tests.extension.base.reshaping import BaseReshapingTests  # noqa
-from pandas.tests.extension.base.setitem import BaseSetitemTests  # noqa
+from .reshaping import BaseReshapingTests  # noqa
+from .setitem import BaseSetitemTests  # noqa

--- a/pandas/tests/extension/base/casting.py
+++ b/pandas/tests/extension/base/casting.py
@@ -3,7 +3,8 @@ import pytest
 
 import pandas as pd
 from pandas.core.internals import ObjectBlock
-from pandas.tests.extension.base.base import BaseExtensionTests
+
+from .base import BaseExtensionTests
 
 
 class BaseCastingTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/constructors.py
+++ b/pandas/tests/extension/base/constructors.py
@@ -3,7 +3,8 @@ import pytest
 
 import pandas as pd
 from pandas.core.internals import ExtensionBlock
-from pandas.tests.extension.base.base import BaseExtensionTests
+
+from .base import BaseExtensionTests
 
 
 class BaseConstructorsTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/dtype.py
+++ b/pandas/tests/extension/base/dtype.py
@@ -9,7 +9,8 @@ from pandas.api.types import (
     is_object_dtype,
     is_string_dtype,
 )
-from pandas.tests.extension.base.base import BaseExtensionTests
+
+from .base import BaseExtensionTests
 
 
 class BaseDtypeTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/getitem.py
+++ b/pandas/tests/extension/base/getitem.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas.tests.extension.base.base import BaseExtensionTests
+
+from .base import BaseExtensionTests
 
 
 class BaseGetitemTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/groupby.py
+++ b/pandas/tests/extension/base/groupby.py
@@ -2,7 +2,8 @@ import pytest
 
 import pandas as pd
 import pandas._testing as tm
-from pandas.tests.extension.base.base import BaseExtensionTests
+
+from .base import BaseExtensionTests
 
 
 class BaseGroupbyTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/interface.py
+++ b/pandas/tests/extension/base/interface.py
@@ -5,7 +5,8 @@ from pandas.core.dtypes.dtypes import ExtensionDtype
 
 import pandas as pd
 import pandas._testing as tm
-from pandas.tests.extension.base.base import BaseExtensionTests
+
+from .base import BaseExtensionTests
 
 
 class BaseInterfaceTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/io.py
+++ b/pandas/tests/extension/base/io.py
@@ -4,7 +4,8 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas.tests.extension.base.base import BaseExtensionTests
+
+from .base import BaseExtensionTests
 
 
 class BaseParsingTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -9,7 +9,8 @@ from pandas.core.dtypes.common import is_bool_dtype
 import pandas as pd
 import pandas._testing as tm
 from pandas.core.sorting import nargsort
-from pandas.tests.extension.base.base import BaseExtensionTests
+
+from .base import BaseExtensionTests
 
 
 class BaseMethodsTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/missing.py
+++ b/pandas/tests/extension/base/missing.py
@@ -2,7 +2,8 @@ import numpy as np
 
 import pandas as pd
 import pandas._testing as tm
-from pandas.tests.extension.base.base import BaseExtensionTests
+
+from .base import BaseExtensionTests
 
 
 class BaseMissingTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/ops.py
+++ b/pandas/tests/extension/base/ops.py
@@ -8,7 +8,8 @@ import pytest
 import pandas as pd
 import pandas._testing as tm
 from pandas.core import ops
-from pandas.tests.extension.base.base import BaseExtensionTests
+
+from .base import BaseExtensionTests
 
 
 class BaseOpsUtil(BaseExtensionTests):

--- a/pandas/tests/extension/base/printing.py
+++ b/pandas/tests/extension/base/printing.py
@@ -3,7 +3,8 @@ import io
 import pytest
 
 import pandas as pd
-from pandas.tests.extension.base.base import BaseExtensionTests
+
+from .base import BaseExtensionTests
 
 
 class BasePrintingTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/reduce.py
+++ b/pandas/tests/extension/base/reduce.py
@@ -4,7 +4,8 @@ import pytest
 
 import pandas as pd
 import pandas._testing as tm
-from pandas.tests.extension.base.base import BaseExtensionTests
+
+from .base import BaseExtensionTests
 
 
 class BaseReduceTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/reshaping.py
+++ b/pandas/tests/extension/base/reshaping.py
@@ -5,7 +5,8 @@ import pytest
 
 import pandas as pd
 from pandas.core.internals import ExtensionBlock
-from pandas.tests.extension.base.base import BaseExtensionTests
+
+from .base import BaseExtensionTests
 
 
 class BaseReshapingTests(BaseExtensionTests):

--- a/pandas/tests/extension/base/setitem.py
+++ b/pandas/tests/extension/base/setitem.py
@@ -3,7 +3,8 @@ import pytest
 
 import pandas as pd
 import pandas._testing as tm
-from pandas.tests.extension.base.base import BaseExtensionTests
+
+from .base import BaseExtensionTests
 
 
 class BaseSetitemTests(BaseExtensionTests):

--- a/pandas/tests/extension/decimal/__init__.py
+++ b/pandas/tests/extension/decimal/__init__.py
@@ -1,4 +1,4 @@
-from pandas.tests.extension.decimal.array import (
+from .array import (
     DecimalArray,
     DecimalDtype,
     make_data,

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -9,7 +9,8 @@ import pandas as pd
 import pandas._testing as tm
 from pandas.api.types import infer_dtype
 from pandas.tests.extension import base
-from pandas.tests.extension.decimal.array import (
+
+from .array import (
     DecimalArray,
     DecimalDtype,
     make_data,

--- a/pandas/tests/extension/json/__init__.py
+++ b/pandas/tests/extension/json/__init__.py
@@ -1,4 +1,4 @@
-from pandas.tests.extension.json.array import (
+from .array import (
     JSONArray,
     JSONDtype,
     make_data,

--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -6,7 +6,8 @@ import pytest
 import pandas as pd
 import pandas._testing as tm
 from pandas.tests.extension import base
-from pandas.tests.extension.json.array import (
+
+from .array import (
     JSONArray,
     JSONDtype,
     make_data,

--- a/pandas/tests/extension/list/__init__.py
+++ b/pandas/tests/extension/list/__init__.py
@@ -1,4 +1,4 @@
-from pandas.tests.extension.list.array import (
+from .array import (
     ListArray,
     ListDtype,
     make_data,

--- a/pandas/tests/extension/list/test_list.py
+++ b/pandas/tests/extension/list/test_list.py
@@ -1,7 +1,8 @@
 import pytest
 
 import pandas as pd
-from pandas.tests.extension.list.array import (
+
+from .array import (
     ListArray,
     ListDtype,
     make_data,

--- a/pandas/tests/extension/test_boolean.py
+++ b/pandas/tests/extension/test_boolean.py
@@ -19,7 +19,8 @@ import pytest
 import pandas as pd
 import pandas._testing as tm
 from pandas.core.arrays.boolean import BooleanDtype
-from pandas.tests.extension import base
+
+from . import base
 
 
 def make_data():

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -26,7 +26,8 @@ from pandas import (
 )
 import pandas._testing as tm
 from pandas.api.types import CategoricalDtype
-from pandas.tests.extension import base
+
+from . import base
 
 
 def make_data():

--- a/pandas/tests/extension/test_datetime.py
+++ b/pandas/tests/extension/test_datetime.py
@@ -20,7 +20,8 @@ from pandas.core.dtypes.dtypes import DatetimeTZDtype
 
 import pandas as pd
 from pandas.core.arrays import DatetimeArray
-from pandas.tests.extension import base
+
+from . import base
 
 
 @pytest.fixture(params=["US/Central"])

--- a/pandas/tests/extension/test_floating.py
+++ b/pandas/tests/extension/test_floating.py
@@ -25,7 +25,8 @@ from pandas.core.arrays.floating import (
     Float32Dtype,
     Float64Dtype,
 )
-from pandas.tests.extension import base
+
+from . import base
 
 
 def make_data():

--- a/pandas/tests/extension/test_integer.py
+++ b/pandas/tests/extension/test_integer.py
@@ -32,7 +32,8 @@ from pandas.core.arrays.integer import (
     UInt32Dtype,
     UInt64Dtype,
 )
-from pandas.tests.extension import base
+
+from . import base
 
 
 def make_data():

--- a/pandas/tests/extension/test_interval.py
+++ b/pandas/tests/extension/test_interval.py
@@ -20,7 +20,8 @@ from pandas.core.dtypes.dtypes import IntervalDtype
 
 from pandas import Interval
 from pandas.core.arrays import IntervalArray
-from pandas.tests.extension import base
+
+from . import base
 
 
 def make_data():

--- a/pandas/tests/extension/test_numpy.py
+++ b/pandas/tests/extension/test_numpy.py
@@ -24,7 +24,8 @@ from pandas.core.dtypes.dtypes import (
 import pandas as pd
 import pandas._testing as tm
 from pandas.core.arrays.numpy_ import PandasArray
-from pandas.tests.extension import base
+
+from . import base
 
 
 @pytest.fixture(params=["float", "object"])

--- a/pandas/tests/extension/test_period.py
+++ b/pandas/tests/extension/test_period.py
@@ -22,7 +22,8 @@ from pandas.core.dtypes.dtypes import PeriodDtype
 
 import pandas as pd
 from pandas.core.arrays import PeriodArray
-from pandas.tests.extension import base
+
+from . import base
 
 
 @pytest.fixture

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -28,7 +28,8 @@ import pandas as pd
 from pandas import SparseDtype
 import pandas._testing as tm
 from pandas.arrays import SparseArray
-from pandas.tests.extension import base
+
+from . import base
 
 
 def make_data(fill_value):

--- a/pandas/tests/extension/test_string.py
+++ b/pandas/tests/extension/test_string.py
@@ -23,7 +23,8 @@ import pandas.util._test_decorators as td
 import pandas as pd
 from pandas.core.arrays.string_ import StringDtype
 from pandas.core.arrays.string_arrow import ArrowStringDtype
-from pandas.tests.extension import base
+
+from . import base
 
 
 @pytest.fixture(

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -19,7 +19,8 @@ from pandas.core.computation.expressions import (
     _MIN_ELEMENTS,
     NUMEXPR_INSTALLED,
 )
-from pandas.tests.frame.common import (
+
+from .common import (
     _check_mixed_float,
     _check_mixed_int,
 )

--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -12,7 +12,8 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
-from pandas.tests.generic.test_generic import Generic
+
+from .test_generic import Generic
 
 
 class TestDataFrame(Generic):

--- a/pandas/tests/generic/test_series.py
+++ b/pandas/tests/generic/test_series.py
@@ -10,7 +10,8 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
-from pandas.tests.generic.test_generic import Generic
+
+from .test_generic import Generic
 
 
 class TestSeries(Generic):

--- a/pandas/tests/indexes/datetimelike.py
+++ b/pandas/tests/indexes/datetimelike.py
@@ -5,7 +5,8 @@ import pytest
 
 import pandas as pd
 import pandas._testing as tm
-from pandas.tests.indexes.common import Base
+
+from .common import Base
 
 
 class DatetimeLike(Base):

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -714,7 +714,7 @@ class TestDateRangeTZ:
         tm.assert_index_equal(result, expected)
 
     def test_date_range_with_fixedoffset_noname(self):
-        from pandas.tests.indexes.datetimes.test_timezones import fixed_off_no_name
+        from .test_timezones import fixed_off_no_name
 
         off = fixed_off_no_name
         start = datetime(2012, 3, 11, 5, 0, 0, tzinfo=off)

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -43,7 +43,8 @@ from pandas.core.indexes.api import (
     ensure_index,
     ensure_index_from_sequences,
 )
-from pandas.tests.indexes.common import Base
+
+from .common import Base
 
 
 class TestIndex(Base):

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -15,7 +15,8 @@ from pandas import (
     UInt64Index,
 )
 import pandas._testing as tm
-from pandas.tests.indexes.common import Base
+
+from .common import Base
 
 
 class TestArithmetic:

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -25,7 +25,8 @@ from pandas import (
 import pandas._testing as tm
 from pandas.api.types import is_scalar
 from pandas.core.indexing import IndexingError
-from pandas.tests.indexing.common import Base
+
+from .common import Base
 
 # We pass through the error message from numpy
 _slice_iloc_msg = re.escape(

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -23,8 +23,9 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.tests.indexing.common import _mklbl
-from pandas.tests.indexing.test_floats import gen_obj
+
+from .common import _mklbl
+from .test_floats import gen_obj
 
 # ------------------------------------------------------------------------
 # Indexing test cases

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -33,7 +33,8 @@ from pandas import (
 )
 import pandas._testing as tm
 from pandas.api.types import is_scalar
-from pandas.tests.indexing.common import Base
+
+from .common import Base
 
 
 class TestLoc(Base):

--- a/pandas/tests/indexing/test_scalar.py
+++ b/pandas/tests/indexing/test_scalar.py
@@ -15,7 +15,8 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
-from pandas.tests.indexing.common import Base
+
+from .common import Base
 
 
 class TestScalar(Base):

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -20,7 +20,8 @@ from pandas import (
     Series,
 )
 import pandas._testing as tm
-from pandas.tests.io.excel import xlrd_version
+
+from . import xlrd_version
 
 read_ext_params = [".xls", ".xlsx", ".xlsm", ".xlsb", ".ods"]
 engine_params = [

--- a/pandas/tests/io/excel/test_xlrd.py
+++ b/pandas/tests/io/excel/test_xlrd.py
@@ -4,9 +4,10 @@ from pandas.compat._optional import import_optional_dependency
 
 import pandas as pd
 import pandas._testing as tm
-from pandas.tests.io.excel import xlrd_version
 
 from pandas.io.excel import ExcelFile
+
+from . import xlrd_version
 
 xlrd = pytest.importorskip("xlrd")
 xlwt = pytest.importorskip("xlwt")

--- a/pandas/tests/io/pytables/test_append.py
+++ b/pandas/tests/io/pytables/test_append.py
@@ -18,7 +18,8 @@ from pandas import (
     date_range,
     read_hdf,
 )
-from pandas.tests.io.pytables.common import (
+
+from .common import (
     _maybe_remove,
     ensure_clean_path,
     ensure_clean_store,

--- a/pandas/tests/io/pytables/test_categorical.py
+++ b/pandas/tests/io/pytables/test_categorical.py
@@ -9,7 +9,8 @@ from pandas import (
     concat,
     read_hdf,
 )
-from pandas.tests.io.pytables.common import (
+
+from .common import (
     _maybe_remove,
     ensure_clean_path,
     ensure_clean_store,

--- a/pandas/tests/io/pytables/test_compat.py
+++ b/pandas/tests/io/pytables/test_compat.py
@@ -2,7 +2,8 @@ import pytest
 
 import pandas as pd
 import pandas._testing as tm
-from pandas.tests.io.pytables.common import ensure_clean_path
+
+from .common import ensure_clean_path
 
 tables = pytest.importorskip("tables")
 

--- a/pandas/tests/io/pytables/test_complex.py
+++ b/pandas/tests/io/pytables/test_complex.py
@@ -11,12 +11,13 @@ from pandas import (
     Series,
 )
 import pandas._testing as tm
-from pandas.tests.io.pytables.common import (
+
+from pandas.io.pytables import read_hdf
+
+from .common import (
     ensure_clean_path,
     ensure_clean_store,
 )
-
-from pandas.io.pytables import read_hdf
 
 # TODO(ArrayManager) HDFStore relies on accessing the blocks
 pytestmark = td.skip_array_manager_not_yet_implemented

--- a/pandas/tests/io/pytables/test_errors.py
+++ b/pandas/tests/io/pytables/test_errors.py
@@ -16,14 +16,15 @@ from pandas import (
     date_range,
     read_hdf,
 )
-from pandas.tests.io.pytables.common import (
-    ensure_clean_path,
-    ensure_clean_store,
-)
 
 from pandas.io.pytables import (
     Term,
     _maybe_adjust_name,
+)
+
+from .common import (
+    ensure_clean_path,
+    ensure_clean_store,
 )
 
 pytestmark = pytest.mark.single

--- a/pandas/tests/io/pytables/test_file_handling.py
+++ b/pandas/tests/io/pytables/test_file_handling.py
@@ -13,18 +13,19 @@ from pandas import (
     _testing as tm,
     read_hdf,
 )
-from pandas.tests.io.pytables.common import (
-    _maybe_remove,
-    ensure_clean_path,
-    ensure_clean_store,
-    tables,
-)
 
 from pandas.io import pytables as pytables
 from pandas.io.pytables import (
     ClosedFileError,
     PossibleDataLossError,
     Term,
+)
+
+from .common import (
+    _maybe_remove,
+    ensure_clean_path,
+    ensure_clean_store,
+    tables,
 )
 
 pytestmark = pytest.mark.single

--- a/pandas/tests/io/pytables/test_keys.py
+++ b/pandas/tests/io/pytables/test_keys.py
@@ -5,7 +5,8 @@ from pandas import (
     HDFStore,
     _testing as tm,
 )
-from pandas.tests.io.pytables.common import (
+
+from .common import (
     ensure_clean_path,
     ensure_clean_store,
     tables,

--- a/pandas/tests/io/pytables/test_put.py
+++ b/pandas/tests/io/pytables/test_put.py
@@ -22,12 +22,13 @@ from pandas import (
     _testing as tm,
     concat,
 )
-from pandas.tests.io.pytables.common import (
+from pandas.util import _test_decorators as td
+
+from .common import (
     _maybe_remove,
     ensure_clean_path,
     ensure_clean_store,
 )
-from pandas.util import _test_decorators as td
 
 pytestmark = pytest.mark.single
 

--- a/pandas/tests/io/pytables/test_read.py
+++ b/pandas/tests/io/pytables/test_read.py
@@ -16,14 +16,15 @@ from pandas import (
     _testing as tm,
     read_hdf,
 )
-from pandas.tests.io.pytables.common import (
+from pandas.util import _test_decorators as td
+
+from pandas.io.pytables import TableIterator
+
+from .common import (
     _maybe_remove,
     ensure_clean_path,
     ensure_clean_store,
 )
-from pandas.util import _test_decorators as td
-
-from pandas.io.pytables import TableIterator
 
 pytestmark = pytest.mark.single
 

--- a/pandas/tests/io/pytables/test_retain_attributes.py
+++ b/pandas/tests/io/pytables/test_retain_attributes.py
@@ -11,7 +11,8 @@ from pandas import (
     date_range,
     read_hdf,
 )
-from pandas.tests.io.pytables.common import (
+
+from .common import (
     _maybe_remove,
     ensure_clean_path,
     ensure_clean_store,

--- a/pandas/tests/io/pytables/test_round_trip.py
+++ b/pandas/tests/io/pytables/test_round_trip.py
@@ -20,12 +20,13 @@ from pandas import (
     bdate_range,
     read_hdf,
 )
-from pandas.tests.io.pytables.common import (
+from pandas.util import _test_decorators as td
+
+from .common import (
     _maybe_remove,
     ensure_clean_path,
     ensure_clean_store,
 )
-from pandas.util import _test_decorators as td
 
 _default_compressor = "blosc"
 

--- a/pandas/tests/io/pytables/test_select.py
+++ b/pandas/tests/io/pytables/test_select.py
@@ -20,14 +20,15 @@ from pandas import (
     isna,
     read_hdf,
 )
-from pandas.tests.io.pytables.common import (
+
+from pandas.io.pytables import Term
+
+from .common import (
     _maybe_remove,
     ensure_clean_path,
     ensure_clean_store,
     tables,
 )
-
-from pandas.io.pytables import Term
 
 pytestmark = pytest.mark.single
 

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -25,7 +25,8 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.tests.io.pytables.common import (
+
+from .common import (
     _maybe_remove,
     ensure_clean_path,
     ensure_clean_store,

--- a/pandas/tests/io/pytables/test_subclass.py
+++ b/pandas/tests/io/pytables/test_subclass.py
@@ -5,12 +5,13 @@ from pandas import (
     Series,
 )
 import pandas._testing as tm
-from pandas.tests.io.pytables.common import ensure_clean_path
 
 from pandas.io.pytables import (
     HDFStore,
     read_hdf,
 )
+
+from .common import ensure_clean_path
 
 
 class TestHDFStoreSubclass:

--- a/pandas/tests/io/pytables/test_time_series.py
+++ b/pandas/tests/io/pytables/test_time_series.py
@@ -8,7 +8,8 @@ from pandas import (
     Series,
     _testing as tm,
 )
-from pandas.tests.io.pytables.common import ensure_clean_store
+
+from .common import ensure_clean_store
 
 pytestmark = pytest.mark.single
 

--- a/pandas/tests/io/pytables/test_timezones.py
+++ b/pandas/tests/io/pytables/test_timezones.py
@@ -18,7 +18,8 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
-from pandas.tests.io.pytables.common import (
+
+from .common import (
     _maybe_remove,
     ensure_clean_path,
     ensure_clean_store,

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -57,7 +57,7 @@ lzma = import_lzma()
 @pytest.fixture(scope="module")
 def current_pickle_data():
     # our current version pickle data
-    from pandas.tests.io.generate_legacy_storage_files import create_pickle_data
+    from .generate_legacy_storage_files import create_pickle_data
 
     return create_pickle_data()
 

--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -16,12 +16,13 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.tests.plotting.common import (
+
+import pandas.plotting as plotting
+
+from .common import (
     TestPlotBase,
     _check_plot_works,
 )
-
-import pandas.plotting as plotting
 
 pytestmark = pytest.mark.slow
 

--- a/pandas/tests/plotting/test_common.py
+++ b/pandas/tests/plotting/test_common.py
@@ -3,7 +3,8 @@ import pytest
 import pandas.util._test_decorators as td
 
 from pandas import DataFrame
-from pandas.tests.plotting.common import (
+
+from .common import (
     TestPlotBase,
     _check_plot_works,
     _gen_two_subplots,

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -37,9 +37,10 @@ from pandas.core.indexes.period import (
     period_range,
 )
 from pandas.core.indexes.timedeltas import timedelta_range
-from pandas.tests.plotting.common import TestPlotBase
 
 from pandas.tseries.offsets import WeekOfMonth
+
+from .common import TestPlotBase
 
 pytestmark = pytest.mark.slow
 

--- a/pandas/tests/plotting/test_groupby.py
+++ b/pandas/tests/plotting/test_groupby.py
@@ -13,7 +13,8 @@ from pandas import (
     Series,
 )
 import pandas._testing as tm
-from pandas.tests.plotting.common import TestPlotBase
+
+from .common import TestPlotBase
 
 pytestmark = pytest.mark.slow
 

--- a/pandas/tests/plotting/test_hist_method.py
+++ b/pandas/tests/plotting/test_hist_method.py
@@ -13,7 +13,8 @@ from pandas import (
     to_datetime,
 )
 import pandas._testing as tm
-from pandas.tests.plotting.common import (
+
+from .common import (
     TestPlotBase,
     _check_plot_works,
 )

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -10,12 +10,13 @@ from pandas import (
     Series,
 )
 import pandas._testing as tm
-from pandas.tests.plotting.common import (
+
+import pandas.plotting as plotting
+
+from .common import (
     TestPlotBase,
     _check_plot_works,
 )
-
-import pandas.plotting as plotting
 
 pytestmark = pytest.mark.slow
 

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -16,12 +16,13 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
-from pandas.tests.plotting.common import (
+
+import pandas.plotting as plotting
+
+from .common import (
     TestPlotBase,
     _check_plot_works,
 )
-
-import pandas.plotting as plotting
 
 pytestmark = pytest.mark.slow
 

--- a/pandas/tests/reshape/merge/test_join.py
+++ b/pandas/tests/reshape/merge/test_join.py
@@ -13,7 +13,8 @@ from pandas import (
     merge,
 )
 import pandas._testing as tm
-from pandas.tests.reshape.merge.test_merge import (
+
+from .test_merge import (
     NGROUPS,
     N,
     get_test_data,

--- a/pandas/tests/strings/test_cat.py
+++ b/pandas/tests/strings/test_cat.py
@@ -10,7 +10,8 @@ from pandas import (
     _testing as tm,
     concat,
 )
-from pandas.tests.strings.test_strings import assert_series_or_index_equal
+
+from .test_strings import assert_series_or_index_equal
 
 
 @pytest.mark.parametrize("other", [None, Series, Index])

--- a/pandas/tests/tseries/offsets/test_business_day.py
+++ b/pandas/tests/tseries/offsets/test_business_day.py
@@ -23,15 +23,16 @@ from pandas import (
     _testing as tm,
     read_pickle,
 )
-from pandas.tests.tseries.offsets.common import (
+
+from pandas.tseries import offsets as offsets
+from pandas.tseries.holiday import USFederalHolidayCalendar
+
+from .common import (
     Base,
     assert_is_on_offset,
     assert_offset_equal,
 )
-from pandas.tests.tseries.offsets.test_offsets import _ApplyCases
-
-from pandas.tseries import offsets as offsets
-from pandas.tseries.holiday import USFederalHolidayCalendar
+from .test_offsets import _ApplyCases
 
 
 class TestBusinessDay(Base):

--- a/pandas/tests/tseries/offsets/test_business_hour.py
+++ b/pandas/tests/tseries/offsets/test_business_hour.py
@@ -23,7 +23,8 @@ from pandas import (
     _testing as tm,
     date_range,
 )
-from pandas.tests.tseries.offsets.common import (
+
+from .common import (
     Base,
     assert_offset_equal,
 )

--- a/pandas/tests/tseries/offsets/test_custom_business_hour.py
+++ b/pandas/tests/tseries/offsets/test_custom_business_hour.py
@@ -14,7 +14,8 @@ from pandas._libs.tslibs.offsets import (
 )
 
 import pandas._testing as tm
-from pandas.tests.tseries.offsets.common import (
+
+from .common import (
     Base,
     assert_offset_equal,
 )

--- a/pandas/tests/tseries/offsets/test_dst.py
+++ b/pandas/tests/tseries/offsets/test_dst.py
@@ -28,7 +28,7 @@ from pandas._libs.tslibs.offsets import (
     YearEnd,
 )
 
-from pandas.tests.tseries.offsets.test_offsets import get_utc_offset_hours
+from .test_offsets import get_utc_offset_hours
 
 
 class TestDST:

--- a/pandas/tests/tseries/offsets/test_fiscal.py
+++ b/pandas/tests/tseries/offsets/test_fiscal.py
@@ -10,17 +10,18 @@ from pandas._libs.tslibs.period import INVALID_FREQ_ERR_MSG
 
 from pandas import Timestamp
 import pandas._testing as tm
-from pandas.tests.tseries.offsets.common import (
-    Base,
-    WeekDay,
-    assert_is_on_offset,
-    assert_offset_equal,
-)
 
 from pandas.tseries.frequencies import get_offset
 from pandas.tseries.offsets import (
     FY5253,
     FY5253Quarter,
+)
+
+from .common import (
+    Base,
+    WeekDay,
+    assert_is_on_offset,
+    assert_offset_equal,
 )
 
 

--- a/pandas/tests/tseries/offsets/test_month.py
+++ b/pandas/tests/tseries/offsets/test_month.py
@@ -24,15 +24,16 @@ from pandas import (
     _testing as tm,
     date_range,
 )
-from pandas.tests.tseries.offsets.common import (
+
+from pandas.tseries import offsets as offsets
+from pandas.tseries.holiday import USFederalHolidayCalendar
+
+from .common import (
     Base,
     assert_is_on_offset,
     assert_offset_equal,
 )
-from pandas.tests.tseries.offsets.test_offsets import _ApplyCases
-
-from pandas.tseries import offsets as offsets
-from pandas.tseries.holiday import USFederalHolidayCalendar
+from .test_offsets import _ApplyCases
 
 
 class CustomBusinessMonthBase:

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -31,11 +31,6 @@ from pandas.errors import PerformanceWarning
 
 from pandas import DatetimeIndex
 import pandas._testing as tm
-from pandas.tests.tseries.offsets.common import (
-    Base,
-    WeekDay,
-    assert_offset_equal,
-)
 
 import pandas.tseries.offsets as offsets
 from pandas.tseries.offsets import (
@@ -58,6 +53,12 @@ from pandas.tseries.offsets import (
     Tick,
     Week,
     WeekOfMonth,
+)
+
+from .common import (
+    Base,
+    WeekDay,
+    assert_offset_equal,
 )
 
 _ApplyCases = List[Tuple[BaseOffset, Dict[datetime, datetime]]]

--- a/pandas/tests/tseries/offsets/test_ticks.py
+++ b/pandas/tests/tseries/offsets/test_ticks.py
@@ -23,7 +23,6 @@ from pandas import (
     Timestamp,
 )
 import pandas._testing as tm
-from pandas.tests.tseries.offsets.common import assert_offset_equal
 
 from pandas.tseries import offsets
 from pandas.tseries.offsets import (
@@ -34,6 +33,8 @@ from pandas.tseries.offsets import (
     Nano,
     Second,
 )
+
+from .common import assert_offset_equal
 
 # ---------------------------------------------------------------------
 # Test Helpers

--- a/pandas/tests/tseries/offsets/test_week.py
+++ b/pandas/tests/tseries/offsets/test_week.py
@@ -15,7 +15,7 @@ from pandas._libs.tslibs.offsets import (
     WeekOfMonth,
 )
 
-from pandas.tests.tseries.offsets.common import (
+from .common import (
     Base,
     WeekDay,
     assert_is_on_offset,

--- a/pandas/tests/tseries/offsets/test_yqm_offsets.py
+++ b/pandas/tests/tseries/offsets/test_yqm_offsets.py
@@ -7,11 +7,6 @@ import pytest
 
 import pandas as pd
 from pandas import Timestamp
-from pandas.tests.tseries.offsets.common import (
-    Base,
-    assert_is_on_offset,
-    assert_offset_equal,
-)
 
 from pandas.tseries.offsets import (
     BMonthBegin,
@@ -26,6 +21,12 @@ from pandas.tseries.offsets import (
     QuarterEnd,
     YearBegin,
     YearEnd,
+)
+
+from .common import (
+    Base,
+    assert_is_on_offset,
+    assert_offset_equal,
 )
 
 # --------------------------------------------------------------------

--- a/pandas/tseries/api.py
+++ b/pandas/tseries/api.py
@@ -4,5 +4,6 @@ Timeseries API
 
 # flake8: noqa
 
-from pandas.tseries.frequencies import infer_freq
 import pandas.tseries.offsets as offsets
+
+from .frequencies import infer_freq

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -27,7 +27,7 @@ from pandas import (
     date_range,
 )
 
-from pandas.tseries.offsets import (
+from .offsets import (
     Day,
     Easter,
 )

--- a/pandas/util/__init__.py
+++ b/pandas/util/__init__.py
@@ -1,12 +1,12 @@
-from pandas.util._decorators import (  # noqa
-    Appender,
-    Substitution,
-    cache_readonly,
-)
-
 from pandas.core.util.hashing import (  # noqa
     hash_array,
     hash_pandas_object,
+)
+
+from ._decorators import (  # noqa
+    Appender,
+    Substitution,
+    cache_readonly,
 )
 
 


### PR DESCRIPTION
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

xref [this comment](https://github.com/pandas-dev/pandas/pull/39561#discussion_r575644482):

> > more generally, i like relative imports for same-directory as it clarified dependency structure
> 
> +1, I also find this helpful. I think it should certainly be doable to have a check that relative imports are never outside the local directory

@jorisvandenbossche @jbrockmendel is this what you had in mind?

Like this, imports in the same folder are relative, and those outside are absolute.

So, for example, in `pandas/_testing/_io.py`:
- `from pandas.io.common import urlopen` stays absolute
- `from pandas._testing.contexts import ensure_clean` becomes `from .contexts import ensure_clean`