### PR TITLE
Updated read_html to add option

### DIFF
--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -73,7 +73,7 @@ def _importers():
 _RE_WHITESPACE = re.compile(r"[\r\n]+|\s{2,}")
 
 
-def _remove_whitespace(s: str, regex=_RE_WHITESPACE, remove_whitespace=True) -> str:
+def _remove_whitespace(s: str, regex=_RE_WHITESPACE) -> str:
     """
     Replace extra whitespace inside of a string with a single space.
 
@@ -83,18 +83,13 @@ def _remove_whitespace(s: str, regex=_RE_WHITESPACE, remove_whitespace=True) -> 
         The string from which to remove extra whitespace.
     regex : re.Pattern
         The regular expression to use to remove extra whitespace.
-    remove_whitespace : bool, default True
-        Whether to replace whitespace, or skip replacement.
 
     Returns
     -------
     subd : str or unicode
         `s` with all extra whitespace replaced with a single space.
     """
-    if remove_whitespace:
-        return regex.sub(" ", s.strip())
-    else:
-        return s
+    return regex.sub(" ", s.strip())
 
 
 def _get_skiprows(skiprows):
@@ -478,7 +473,10 @@ class _HtmlFrameParser:
                     index += 1
 
                 # Append the text from this <td>, colspan times
-                text = _remove_whitespace(self._text_getter(td), remove_whitespace=self.remove_whitespace)
+                if self.remove_whitespace:
+                    text = _remove_whitespace(self._text_getter(td))
+                else:
+                    text = self._text_getter(td)
                 rowspan = int(self._attr_getter(td, "rowspan") or 1)
                 colspan = int(self._attr_getter(td, "colspan") or 1)
 

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -175,6 +175,7 @@ class _HtmlFrameParser:
     
     remove_whitespace : bool
         Whether table row values should have all whitespace replaced with a space.
+        .. versionadded:: 1.3.0
 
     Attributes
     ----------
@@ -196,6 +197,7 @@ class _HtmlFrameParser:
     
     remove_whitespace : bool
         Whether table row values should have all whitespace replaced with a space
+        .. versionadded:: 1.3.0
 
     Notes
     -----
@@ -1059,6 +1061,7 @@ def read_html(
     
     remove_whitespace : bool, default True
         Whether table row values should have all whitespace replaced with a space.
+        .. versionadded:: 1.3.0
 
     Returns
     -------


### PR DESCRIPTION
Adds optional boolean parameter "remove_whitespace" to skip the remove_whitespace functionality. Defaults to true to support backwards compatibility. See https://github.com/pandas-dev/pandas/issues/24766

- [ x ] closes #24766 
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
