### PR TITLE
Change in astype leads to no longer casting to numpy string dtypes

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -234,7 +234,7 @@ Other API changes
 ^^^^^^^^^^^^^^^^^
 - Partially initialized :class:`CategoricalDtype` (i.e. those with ``categories=None`` objects will no longer compare as equal to fully initialized dtype objects.
 - Accessing ``_constructor_expanddim`` on a :class:`DataFrame` and ``_constructor_sliced`` on a :class:`Series` now raise an ``AttributeError``. Previously a ``NotImplementedError`` was raised (:issue:`38782`)
--
+- :meth:`DataFrame.astype` and :meth:`Series.astype` for ``bytes`` no longer casting to numpy string dtypes but instead casting to ``object`` dtype (:issue:`39566`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1268,7 +1268,7 @@ def soft_convert_objects(
             values = lib.maybe_convert_objects(
                 values, convert_datetime=datetime, convert_timedelta=timedelta
             )
-        except (OutOfBoundsDatetime, ValueError):
+        except OutOfBoundsDatetime:
             return values
 
     if numeric and is_object_dtype(values.dtype):

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -287,7 +287,9 @@ class ArrayManager(DataManager):
                 if not ignore_failures:
                     raise
                 continue
-            # if not isinstance(applied, ExtensionArray):
+            if not isinstance(applied, ExtensionArray):
+                if issubclass(applied.dtype.type, (str, bytes)):
+                    applied = np.array(applied, dtype=object)
             #     # TODO not all EA operations return new EAs (eg astype)
             #     applied = array(applied)
             result_arrays.append(applied)
@@ -413,7 +415,10 @@ class ArrayManager(DataManager):
         return self.apply_with_block("downcast")
 
     def astype(self, dtype, copy: bool = False, errors: str = "raise") -> ArrayManager:
-        return self.apply("astype", dtype=dtype, copy=copy)  # , errors=errors)
+        # if issubclass(dtype, (str, bytes)):
+        #     dtype = "object"
+        y = self.apply("astype", dtype=dtype, copy=copy)  # , errors=errors)
+        return y
 
     def convert(
         self,

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2219,7 +2219,7 @@ class ObjectBlock(Block):
 
     @classmethod
     def _maybe_coerce_values(cls, values):
-        if issubclass(values.dtype.type, str):
+        if issubclass(values.dtype.type, (str, bytes)):
             values = np.array(values, dtype=object)
         return values
 

--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -644,7 +644,8 @@ class TestAstype:
         alt = obj.astype(str)
         assert np.all(alt.iloc[1:] == result.iloc[1:])
 
-    def test_astype_bytes(self):
-        # GH#39474
-        result = DataFrame(["foo", "bar", "baz"]).astype(bytes)
-        assert result.dtypes[0] == np.dtype("S3")
+    @pytest.mark.parametrize("dtype", [bytes, np.string_, np.bytes_])
+    def test_astype_bytes(self, dtype):
+        # GH#39566
+        result = DataFrame(["foo", "bar", "baz"]).astype(dtype)
+        assert result.dtypes[0] == "object"

--- a/pandas/tests/series/methods/test_astype.py
+++ b/pandas/tests/series/methods/test_astype.py
@@ -344,10 +344,11 @@ class TestAstype:
             reload(sys)
             sys.setdefaultencoding(former_encoding)
 
-    def test_astype_bytes(self):
+    @pytest.mark.parametrize("dtype", [bytes, np.string_, np.bytes_])
+    def test_astype_bytes(self, dtype):
         # GH#39474
-        result = Series(["foo", "bar", "baz"]).astype(bytes)
-        assert result.dtypes == np.dtype("S3")
+        result = Series(["foo", "bar", "baz"]).astype(dtype)
+        assert result.dtypes == "object"
 
 
 class TestAstypeCategorical:


### PR DESCRIPTION
- [x] closes #39566
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

@jreback as discussed we no longer cast to numpy string dtypes after this