### PR TITLE
PERF: Styler render improvement by limiting .join()

### DIFF
--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -466,7 +466,7 @@ class Styler:
                     }
                     colspan = col_lengths.get((r, c), 0)
                     if colspan > 1:
-                        es["attributes"] = [f'colspan="{colspan}"']
+                        es["attributes"] = f'colspan="{colspan}"'
                     row_es.append(es)
                 head.append(row_es)
 
@@ -517,7 +517,7 @@ class Styler:
                 }
                 rowspan = idx_lengths.get((c, r), 0)
                 if rowspan > 1:
-                    es["attributes"] = [f'rowspan="{rowspan}"']
+                    es["attributes"] = f'rowspan="{rowspan}"'
                 row_es.append(es)
 
             for c, col in enumerate(self.data.columns):
@@ -529,6 +529,7 @@ class Styler:
                     "value": value,
                     "display_value": formatter(value),
                     "is_visible": (c not in hidden_columns),
+                    "attributes": "",
                 }
 
                 # only add an id if the cell has a style

--- a/pandas/io/formats/templates/html.tpl
+++ b/pandas/io/formats/templates/html.tpl
@@ -56,7 +56,11 @@
     <tr>
 {% for c in r %}
 {% if c.is_visible != False %}
-      <{{c.type}} {% if c.id is defined -%} id="T_{{uuid}}{{c.id}}" {%- endif %} class="{{c.class}}" {{c.attributes|join(" ")}}>{{c.display_value}}</{{c.type}}>
+{% if c.type == 'th' %}
+      <th {% if c.id is defined -%} id="T_{{uuid}}{{c.id}}" {%- endif %} class="{{c.class}}" {{c.attributes|join(" ")}}>{{c.display_value}}</th>
+{% else %}
+      <td {% if c.id is defined -%} id="T_{{uuid}}{{c.id}}" {%- endif %} class="{{c.class}}" >{{c.display_value}}</td>
+{% endif %}
 {% endif %}
 {% endfor %}
     </tr>

--- a/pandas/io/formats/templates/html.tpl
+++ b/pandas/io/formats/templates/html.tpl
@@ -39,7 +39,7 @@
     <tr>
 {% for c in r %}
 {% if c.is_visible != False %}
-      <{{c.type}} class="{{c.class}}" {{c.attributes|join(" ")}}>{{c.value}}</{{c.type}}>
+      <{{c.type}} class="{{c.class}}" {{c.attributes}}>{{c.value}}</{{c.type}}>
 {% endif %}
 {% endfor %}
     </tr>
@@ -56,11 +56,7 @@
     <tr>
 {% for c in r %}
 {% if c.is_visible != False %}
-{% if c.type == 'th' %}
-      <th {% if c.id is defined -%} id="T_{{uuid}}{{c.id}}" {%- endif %} class="{{c.class}}" {{c.attributes|join(" ")}}>{{c.display_value}}</th>
-{% else %}
-      <td {% if c.id is defined -%} id="T_{{uuid}}{{c.id}}" {%- endif %} class="{{c.class}}" >{{c.display_value}}</td>
-{% endif %}
+      <{{c.type}} {% if c.id is defined -%} id="T_{{uuid}}{{c.id}}" {%- endif %} class="{{c.class}}" {{c.attributes}}>{{c.display_value}}</{{c.type}}>
 {% endif %}
 {% endfor %}
     </tr>

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1323,7 +1323,7 @@ class TestStyler:
             "display_value": "a",
             "is_visible": True,
             "type": "th",
-            "attributes": ['rowspan="2"'],
+            "attributes": 'rowspan="2"',
             "class": "row_heading level0 row0",
             "id": "level0_row0",
         }


### PR DESCRIPTION
Currently 
`<th>` only have attributes when there is a row or column span.
`<td>` never have attributes currently.
So there is no need for repititive `join()` operations, especially inside the jinja2 template. Could be preconfigured outside.

We can get around 10-15% better render times.

```
[ 75.00%] ··· io.style.RenderApply.time_render                                                                                                           ok
[ 75.00%] ··· ====== ============ ============
              --                rows          
              ------ -------------------------
               cols       12          120     
              ====== ============ ============
                12    11.6±0.5ms   77.0±0.5ms 
                24    29.2±0.5ms    144±1ms   
                36    43.7±0.9ms    209±2ms   
              ====== ============ ============

```
versus master
```
[100.00%] ··· io.style.RenderApply.time_render                                                                                                           ok
[100.00%] ··· ====== ============ ==========
              --               rows         
              ------ -----------------------
               cols       12         120    
              ====== ============ ==========
                12    12.9±0.4ms   89.8±4ms 
                24    31.4±0.9ms   166±2ms  
                36     46.5±2ms    250±40ms 
              ====== ============ ==========
```