### PR TITLE
CLN: Remove some duplicated tests and parametrize

### DIFF
--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -507,30 +507,22 @@ class TestFloatIndexers:
         # label based slicing
         result1 = s[1.0:3.0]
         result2 = s.loc[1.0:3.0]
-        result3 = s.loc[1.0:3.0]
         tm.assert_series_equal(result1, result2)
-        tm.assert_series_equal(result1, result3)
 
         # exact indexing when found
         result1 = s[5.0]
         result2 = s.loc[5.0]
-        result3 = s.loc[5.0]
         assert result1 == result2
-        assert result1 == result3
 
         result1 = s[5]
         result2 = s.loc[5]
-        result3 = s.loc[5]
         assert result1 == result2
-        assert result1 == result3
 
         assert s[5.0] == s[5]
 
         # value not found (and no fallbacking at all)
 
         # scalar integers
-        with pytest.raises(KeyError, match=r"^4$"):
-            s.loc[4]
         with pytest.raises(KeyError, match=r"^4$"):
             s.loc[4]
         with pytest.raises(KeyError, match=r"^4$"):
@@ -542,12 +534,10 @@ class TestFloatIndexers:
         for fancy_idx in [[5.0, 0.0], np.array([5.0, 0.0])]:  # float
             tm.assert_series_equal(s[fancy_idx], expected)
             tm.assert_series_equal(s.loc[fancy_idx], expected)
-            tm.assert_series_equal(s.loc[fancy_idx], expected)
 
         expected = Series([2, 0], index=Index([5, 0], dtype="int64"))
         for fancy_idx in [[5, 0], np.array([5, 0])]:  # int
             tm.assert_series_equal(s[fancy_idx], expected)
-            tm.assert_series_equal(s.loc[fancy_idx], expected)
             tm.assert_series_equal(s.loc[fancy_idx], expected)
 
         # all should return the same as we are slicing 'the same'
@@ -568,30 +558,18 @@ class TestFloatIndexers:
         tm.assert_series_equal(result1, result3)
         tm.assert_series_equal(result1, result4)
 
-        result1 = s.loc[2:5]
-        result2 = s.loc[2.0:5.0]
-        result3 = s.loc[2.0:5]
-        result4 = s.loc[2.1:5]
-        tm.assert_series_equal(result1, result2)
-        tm.assert_series_equal(result1, result3)
-        tm.assert_series_equal(result1, result4)
-
         # combined test
         result1 = s.loc[2:5]
-        result2 = s.loc[2:5]
-        result3 = s[2:5]
+        result2 = s[2:5]
 
         tm.assert_series_equal(result1, result2)
-        tm.assert_series_equal(result1, result3)
 
         # list selection
         result1 = s[[0.0, 5, 10]]
         result2 = s.loc[[0.0, 5, 10]]
-        result3 = s.loc[[0.0, 5, 10]]
-        result4 = s.iloc[[0, 2, 4]]
+        result3 = s.iloc[[0, 2, 4]]
         tm.assert_series_equal(result1, result2)
         tm.assert_series_equal(result1, result3)
-        tm.assert_series_equal(result1, result4)
 
         with pytest.raises(KeyError, match="with any missing labels"):
             s[[1.6, 5, 10]]
@@ -604,15 +582,11 @@ class TestFloatIndexers:
             s.loc[[0, 1, 2]]
 
         result1 = s.loc[[2.5, 5]]
-        result2 = s.loc[[2.5, 5]]
-        tm.assert_series_equal(result1, result2)
         tm.assert_series_equal(result1, Series([1, 2], index=[2.5, 5.0]))
 
         result1 = s[[2.5]]
         result2 = s.loc[[2.5]]
-        result3 = s.loc[[2.5]]
         tm.assert_series_equal(result1, result2)
-        tm.assert_series_equal(result1, result3)
         tm.assert_series_equal(result1, Series([1], index=[2.5]))
 
     def test_floating_tuples(self):

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -498,96 +498,72 @@ class TestFloatIndexers:
         assert s.loc[3] == 2
         assert s.iloc[3] == 3
 
-    def test_floating_misc(self):
+    @pytest.mark.parametrize("indexer_sl", [tm.getitem, tm.loc])
+    def test_floating_misc(self, indexer_sl):
 
         # related 236
         # scalar/slicing of a float index
         s = Series(np.arange(5), index=np.arange(5) * 2.5, dtype=np.int64)
 
         # label based slicing
-        result1 = s[1.0:3.0]
-        result2 = s.loc[1.0:3.0]
-        tm.assert_series_equal(result1, result2)
+        result = indexer_sl(s)[1.0:3.0]
+        expected = Series(1, index=[2.5])
+        tm.assert_series_equal(result, expected)
 
         # exact indexing when found
-        result1 = s[5.0]
-        result2 = s.loc[5.0]
-        assert result1 == result2
 
-        result1 = s[5]
-        result2 = s.loc[5]
-        assert result1 == result2
+        result = indexer_sl(s)[5.0]
+        assert result == 2
 
-        assert s[5.0] == s[5]
+        result = indexer_sl(s)[5]
+        assert result == 2
 
         # value not found (and no fallbacking at all)
 
         # scalar integers
         with pytest.raises(KeyError, match=r"^4$"):
-            s.loc[4]
-        with pytest.raises(KeyError, match=r"^4$"):
-            s[4]
+            indexer_sl(s)[4]
 
         # fancy floats/integers create the correct entry (as nan)
         # fancy tests
         expected = Series([2, 0], index=Float64Index([5.0, 0.0]))
         for fancy_idx in [[5.0, 0.0], np.array([5.0, 0.0])]:  # float
-            tm.assert_series_equal(s[fancy_idx], expected)
-            tm.assert_series_equal(s.loc[fancy_idx], expected)
+            tm.assert_series_equal(indexer_sl(s)[fancy_idx], expected)
 
         expected = Series([2, 0], index=Index([5, 0], dtype="int64"))
         for fancy_idx in [[5, 0], np.array([5, 0])]:  # int
-            tm.assert_series_equal(s[fancy_idx], expected)
-            tm.assert_series_equal(s.loc[fancy_idx], expected)
+            tm.assert_series_equal(indexer_sl(s)[fancy_idx], expected)
 
         # all should return the same as we are slicing 'the same'
-        result1 = s.loc[2:5]
-        result2 = s.loc[2.0:5.0]
-        result3 = s.loc[2.0:5]
-        result4 = s.loc[2.1:5]
+        result1 = indexer_sl(s)[2:5]
+        result2 = indexer_sl(s)[2.0:5.0]
+        result3 = indexer_sl(s)[2.0:5]
+        result4 = indexer_sl(s)[2.1:5]
         tm.assert_series_equal(result1, result2)
         tm.assert_series_equal(result1, result3)
         tm.assert_series_equal(result1, result4)
 
-        # previously this did fallback indexing
-        result1 = s[2:5]
-        result2 = s[2.0:5.0]
-        result3 = s[2.0:5]
-        result4 = s[2.1:5]
-        tm.assert_series_equal(result1, result2)
-        tm.assert_series_equal(result1, result3)
-        tm.assert_series_equal(result1, result4)
+        expected = Series([1, 2], index=[2.5, 5.0])
+        result = indexer_sl(s)[2:5]
 
-        # combined test
-        result1 = s.loc[2:5]
-        result2 = s[2:5]
-
-        tm.assert_series_equal(result1, result2)
+        tm.assert_series_equal(result, expected)
 
         # list selection
-        result1 = s[[0.0, 5, 10]]
-        result2 = s.loc[[0.0, 5, 10]]
-        result3 = s.iloc[[0, 2, 4]]
+        result1 = indexer_sl(s)[[0.0, 5, 10]]
+        result2 = s.iloc[[0, 2, 4]]
         tm.assert_series_equal(result1, result2)
-        tm.assert_series_equal(result1, result3)
 
         with pytest.raises(KeyError, match="with any missing labels"):
-            s[[1.6, 5, 10]]
-        with pytest.raises(KeyError, match="with any missing labels"):
-            s.loc[[1.6, 5, 10]]
+            indexer_sl(s)[[1.6, 5, 10]]
 
         with pytest.raises(KeyError, match="with any missing labels"):
-            s[[0, 1, 2]]
-        with pytest.raises(KeyError, match="with any missing labels"):
-            s.loc[[0, 1, 2]]
+            indexer_sl(s)[[0, 1, 2]]
 
-        result1 = s.loc[[2.5, 5]]
-        tm.assert_series_equal(result1, Series([1, 2], index=[2.5, 5.0]))
+        result = indexer_sl(s)[[2.5, 5]]
+        tm.assert_series_equal(result, Series([1, 2], index=[2.5, 5.0]))
 
-        result1 = s[[2.5]]
-        result2 = s.loc[[2.5]]
-        tm.assert_series_equal(result1, result2)
-        tm.assert_series_equal(result1, Series([1], index=[2.5]))
+        result = indexer_sl(s)[[2.5]]
+        tm.assert_series_equal(result, Series([1], index=[2.5]))
 
     def test_floating_tuples(self):
         # see gh-13509

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -498,7 +498,6 @@ class TestFloatIndexers:
         assert s.loc[3] == 2
         assert s.iloc[3] == 3
 
-    @pytest.mark.parametrize("indexer_sl", [tm.getitem, tm.loc])
     def test_floating_misc(self, indexer_sl):
 
         # related 236

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -36,8 +36,7 @@ _slice_iloc_msg = re.escape(
 
 class TestiLoc(Base):
     @pytest.mark.parametrize("key", [2, -1, [0, 1, 2]])
-    def test_iloc_getitem_int(self, key):
-        # integer
+    def test_iloc_getitem_int_and_list_int(self, key):
         self.check_result(
             "iloc",
             key,

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -35,28 +35,12 @@ _slice_iloc_msg = re.escape(
 
 
 class TestiLoc(Base):
-    def test_iloc_getitem_int(self):
+    @pytest.mark.parametrize("key", [2, -1, [0, 1, 2]])
+    def test_iloc_getitem_int(self, key):
         # integer
         self.check_result(
             "iloc",
-            2,
-            typs=["labels", "mixed", "ts", "floats", "empty"],
-            fails=IndexError,
-        )
-
-    def test_iloc_getitem_neg_int(self):
-        # neg integer
-        self.check_result(
-            "iloc",
-            -1,
-            typs=["labels", "mixed", "ts", "floats", "empty"],
-            fails=IndexError,
-        )
-
-    def test_iloc_getitem_list_int(self):
-        self.check_result(
-            "iloc",
-            [0, 1, 2],
+            key,
             typs=["labels", "mixed", "ts", "floats", "empty"],
             fails=IndexError,
         )
@@ -371,7 +355,7 @@ class TestiLocBaseIndependent:
         s = Series([1, 2, 3])
         msg = f"Boolean index has wrong length: {len(index)} instead of {len(s)}"
         with pytest.raises(IndexError, match=msg):
-            _ = s.iloc[index]
+            s.iloc[index]
 
     def test_iloc_getitem_slice(self):
         df = DataFrame(

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -266,14 +266,11 @@ class TestFancy:
 
         # ToDo: check_index_type can be True after GH 11497
 
-    def test_dups_fancy_indexing_missing_label(self):
+    @pytest.mark.parametrize("vals", [[0, 1, 2], list("abc")])
+    def test_dups_fancy_indexing_missing_label(self, vals):
 
         # GH 4619; duplicate indexer with missing label
-        df = DataFrame({"A": [0, 1, 2]})
-        with pytest.raises(KeyError, match="with any missing labels"):
-            df.loc[[0, 8, 0]]
-
-        df = DataFrame({"A": list("abc")})
+        df = DataFrame({"A": vals})
         with pytest.raises(KeyError, match="with any missing labels"):
             df.loc[[0, 8, 0]]
 
@@ -455,9 +452,6 @@ class TestFancy:
         df2.loc[mask, cols] = dft.loc[mask, cols]
         tm.assert_frame_equal(df2, expected)
 
-        df2.loc[mask, cols] = dft.loc[mask, cols]
-        tm.assert_frame_equal(df2, expected)
-
         # with an ndarray on rhs
         # coerces to float64 because values has float64 dtype
         # GH 14001
@@ -470,8 +464,6 @@ class TestFancy:
             }
         )
         df2 = df.copy()
-        df2.loc[mask, cols] = dft.loc[mask, cols].values
-        tm.assert_frame_equal(df2, expected)
         df2.loc[mask, cols] = dft.loc[mask, cols].values
         tm.assert_frame_equal(df2, expected)
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -756,7 +756,6 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         result = df.iloc[3:]
         tm.assert_series_equal(result.dtypes, expected)
 
-    @pytest.mark.parametrize("indexer_sl", [tm.setitem, tm.loc])
     def test_setitem_new_key_tz(self, indexer_sl):
         # GH#12862 should not raise on assigning the second value
         vals = [

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -756,8 +756,8 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         result = df.iloc[3:]
         tm.assert_series_equal(result.dtypes, expected)
 
-    @pytest.mark.parametrize("indexer", [tm.setitem, tm.loc])
-    def test_setitem_new_key_tz(self, indexer):
+    @pytest.mark.parametrize("indexer_sl", [tm.setitem, tm.loc])
+    def test_setitem_new_key_tz(self, indexer_sl):
         # GH#12862 should not raise on assigning the second value
         vals = [
             pd.to_datetime(42).tz_localize("UTC"),
@@ -766,8 +766,8 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         expected = Series(vals, index=["foo", "bar"])
 
         ser = Series(dtype=object)
-        indexer(ser)["foo"] = vals[0]
-        indexer(ser)["bar"] = vals[1]
+        indexer_sl(ser)["foo"] = vals[0]
+        indexer_sl(ser)["bar"] = vals[1]
 
         tm.assert_series_equal(ser, expected)
 
@@ -1562,15 +1562,15 @@ class TestLabelSlicing:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "ix",
+        "index",
         [
             pd.period_range(start="2017-01-01", end="2018-01-01", freq="M"),
             timedelta_range(start="1 day", end="2 days", freq="1H"),
         ],
     )
-    def test_loc_getitem_label_slice_period(self, ix):
-        ser = ix.to_series()
-        result = ser.loc[: ix[-2]]
+    def test_loc_getitem_label_slice_period_timedelta(self, index):
+        ser = index.to_series()
+        result = ser.loc[: index[-2]]
         expected = ser.iloc[:-1]
 
         tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them


There were a few duplicates from the ix removal