### PR TITLE
DOC: fix a warning using obsolete package

### DIFF
--- a/doc/source/user_guide/style.ipynb
+++ b/doc/source/user_guide/style.ipynb
@@ -1154,7 +1154,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from IPython.html import widgets\n",
+    "from ipywidgets import widgets\n",
     "@widgets.interact\n",
     "def f(h_neg=(0, 359, 1), h_pos=(0, 359), s=(0., 99.9), l=(0., 99.9)):\n",
     "    return df.style.background_gradient(\n",


### PR DESCRIPTION
currently there is a warning:
"/home/runner/miniconda3/envs/pandas-dev/lib/python3.8/site-packages/IPython/html.py:12: ShimWarning: The `IPython.html` package has been deprecated since IPython 4.0. You should import from `notebook` instead. `IPython.html.widgets` has moved to `ipywidgets`.
  warn("The `IPython.html` package has been deprecated since IPython 4.0. ""

this change fixes the warning.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
