### PR TITLE
sort_index not sorting when multi-index made by different categorical types

### DIFF
--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -257,7 +257,7 @@ def test_sorting_with_different_categoricals():
     index = Categorical(index, categories=["low", "med", "high"], ordered=True)
     index = [["A", "A", "A", "B", "B", "B"], CategoricalIndex(index)]
     index = MultiIndex.from_arrays(index, names=["group", "dose"])
-    expected = Series([2] * 6, index=index, name="dose")
+    expected = Series([2] * 6, index=index)
     tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -256,7 +256,7 @@ def test_sorting_with_different_categoricals():
     index = ["low", "med", "high", "low", "med", "high"]
     index = Categorical(index, categories=["low", "med", "high"], ordered=True)
     index = [["A", "A", "A", "B", "B", "B"], CategoricalIndex(index)]
-    index = MultiIndex.from_arrays(index)
+    index = MultiIndex.from_arrays(index, names=["group"])
     expected = Series([2] * 6, index=index)
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -256,7 +256,7 @@ def test_sorting_with_different_categoricals():
     index = ["low", "med", "high", "low", "med", "high"]
     index = Categorical(index, categories=["low", "med", "high"], ordered=True)
     index = [["A", "A", "A", "B", "B", "B"], CategoricalIndex(index)]
-    index = MultiIndex.from_arrays(index, names=["group", "dose"])
+    index = MultiIndex.from_arrays(index)
     expected = Series([2] * 6, index=index)
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -256,7 +256,7 @@ def test_sorting_with_different_categoricals():
     index = ["low", "med", "high", "low", "med", "high"]
     index = Categorical(index, categories=["low", "med", "high"], ordered=True)
     index = [["A", "A", "A", "B", "B", "B"], CategoricalIndex(index)]
-    index = MultiIndex.from_arrays(index, names="group")
+    index = MultiIndex.from_arrays(index, names=["group", None])
     expected = Series([2] * 6, index=index)
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -256,7 +256,7 @@ def test_sorting_with_different_categoricals():
     index = ["low", "med", "high", "low", "med", "high"]
     index = Categorical(index, categories=["low", "med", "high"], ordered=True)
     index = [["A", "A", "A", "B", "B", "B"], CategoricalIndex(index)]
-    index = MultiIndex.from_arrays(index, names=["group"])
+    index = MultiIndex.from_arrays(index, names="group")
     expected = Series([2] * 6, index=index)
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -255,7 +255,7 @@ def test_sorting_with_different_categoricals():
     result = result.sort_index(level=0, sort_remaining=True)
     index = ["low", "med", "high", "low", "med", "high"]
     index = pd.Categorical(index, categories=["low", "med", "high"], ordered=True)
-    index = [["A", "A", "A", "B", "B", "B"], pd.CategoricalIndex(index)]
+    index = [["A", "A", "A", "B", "B", "B"], CategoricalIndex(index)]
     index = MultiIndex.from_arrays(index, names=["group", "dose"])
     expected = Series([2] * 6, index=index, name="dose")
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -249,12 +249,12 @@ def test_sorting_with_different_categoricals():
         }
     )
 
-    df.dose = pd.Categorical(df.dose, categories=["low", "med", "high"], ordered=True)
+    df.dose = Categorical(df.dose, categories=["low", "med", "high"], ordered=True)
 
     result = df.groupby("group")["dose"].value_counts()
     result = result.sort_index(level=0, sort_remaining=True)
     index = ["low", "med", "high", "low", "med", "high"]
-    index = pd.Categorical(index, categories=["low", "med", "high"], ordered=True)
+    index = Categorical(index, categories=["low", "med", "high"], ordered=True)
     index = [["A", "A", "A", "B", "B", "B"], CategoricalIndex(index)]
     index = MultiIndex.from_arrays(index, names=["group", "dose"])
     expected = Series([2] * 6, index=index, name="dose")

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -239,6 +239,33 @@ def test_level_get_group(observed):
     tm.assert_frame_equal(result, expected)
 
 
+def test_sorting_with_different_categoricals():
+    # GH 24271
+    df = DataFrame(
+        {
+            "group": ["A"] * 6 + ["B"] * 6,
+            "dose": ["high", "med", "low"] * 4,
+            "outcomes": np.arange(12.0),
+        }
+    )
+
+    df.dose = pd.Categorical(df.dose, categories=["low", "med", "high"], ordered=True)
+
+    result = df.groupby("group")["dose"].value_counts()
+    result = result.sort_index(level=0, sort_remaining=True)
+    index = [
+        ("A", "low"),
+        ("A", "med"),
+        ("A", "high"),
+        ("B", "low"),
+        ("B", "med"),
+        ("B", "high"),
+    ]
+    index = MultiIndex.from_tuples(index, names=["group", "dose"])
+    expected = Series([2] * 6, index=index, name="dose")
+    tm.assert_series_equal(result, expected)
+
+
 @pytest.mark.parametrize("ordered", [True, False])
 def test_apply(ordered):
     # GH 10138

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -253,15 +253,10 @@ def test_sorting_with_different_categoricals():
 
     result = df.groupby("group")["dose"].value_counts()
     result = result.sort_index(level=0, sort_remaining=True)
-    index = [
-        ("A", "low"),
-        ("A", "med"),
-        ("A", "high"),
-        ("B", "low"),
-        ("B", "med"),
-        ("B", "high"),
-    ]
-    index = MultiIndex.from_tuples(index, names=["group", "dose"])
+    index = ["low", "med", "high", "low", "med", "high"]
+    index = pd.Categorical(index, categories=["low", "med", "high"], ordered=True)
+    index = [["A", "A", "A", "B", "B", "B"], pd.CategoricalIndex(index)]
+    index = MultiIndex.from_arrays(index, names=["group", "dose"])
     expected = Series([2] * 6, index=index, name="dose")
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -257,7 +257,7 @@ def test_sorting_with_different_categoricals():
     index = Categorical(index, categories=["low", "med", "high"], ordered=True)
     index = [["A", "A", "A", "B", "B", "B"], CategoricalIndex(index)]
     index = MultiIndex.from_arrays(index, names=["group", None])
-    expected = Series([2] * 6, index=index)
+    expected = Series([2] * 6, index=index, name="dose")
     tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -146,33 +146,6 @@ def test_groupby_return_type():
     assert isinstance(result, DataFrame)
 
 
-def test_multi_index_sort():
-    # GH 24271
-    df = DataFrame(
-        {
-            "group": ["A"] * 6 + ["B"] * 6,
-            "dose": ["high", "med", "low"] * 4,
-            "outcomes": np.arange(12.0),
-        }
-    )
-
-    df.dose = pd.Categorical(df.dose, categories=["low", "med", "high"], ordered=True)
-
-    result = df.groupby("group")["dose"].value_counts()
-    result = result.sort_index(level=0, sort_remaining=True)
-    index = [
-        ("A", "low"),
-        ("A", "med"),
-        ("A", "high"),
-        ("B", "low"),
-        ("B", "med"),
-        ("B", "high"),
-    ]
-    index = MultiIndex.from_tuples(index, names=["group", "dose"])
-    expected = Series([2] * 6, index=index, name="dose")
-    tm.assert_series_equal(result, expected)
-
-
 def test_inconsistent_return_type():
     # GH5592
     # inconsistent return type

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -148,25 +148,29 @@ def test_groupby_return_type():
 
 def test_multi_index_sort():
     # GH 24271
-    df = DataFrame({'group':['A']*6 + ['B']*6,
-                   'dose':['high', 'med', 'low']*4,
-                   'outcomes':np.arange(12.0)})
+    df = DataFrame(
+        {
+            "group": ["A"] * 6 + ["B"] * 6,
+            "dose": ["high", "med", "low"] * 4,
+            "outcomes": np.arange(12.0),
+        }
+    )
 
-    df.dose = pd.Categorical(df.dose,
-                             categories=['low', 'med', 'high'],
-                             ordered=True)
+    df.dose = pd.Categorical(df.dose, categories=["low", "med", "high"], ordered=True)
 
-    result = df.groupby('group')['dose'].value_counts().sort_index(level=0,
-                                                       sort_remaining=True)
-    index = [('A','low'),
-             ('A','med'),
-             ('A','high'),
-             ('B','low'),
-             ('B','med'),
-             ('B','high')]
-    index = MultiIndex.from_tuples(index,names=['group','dose'])
-    expected = Series([2]*6,index=index)
-    tm.assert_series_equal(result,expected)
+    result = df.groupby("group")["dose"].value_counts()
+    result = result.sort_index(level=0, sort_remaining=True)
+    index = [
+        ("A", "low"),
+        ("A", "med"),
+        ("A", "high"),
+        ("B", "low"),
+        ("B", "med"),
+        ("B", "high"),
+    ]
+    index = MultiIndex.from_tuples(index, names=["group", "dose"])
+    expected = Series([2] * 6, index=index, name="dose")
+    tm.assert_series_equal(result, expected)
 
 
 def test_inconsistent_return_type():

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -146,6 +146,29 @@ def test_groupby_return_type():
     assert isinstance(result, DataFrame)
 
 
+def test_multi_index_sort():
+    # GH 24271
+    df = DataFrame({'group':['A']*6 + ['B']*6,
+                   'dose':['high', 'med', 'low']*4,
+                   'outcomes':np.arange(12.0)})
+
+    df.dose = pd.Categorical(df.dose,
+                             categories=['low', 'med', 'high'],
+                             ordered=True)
+
+    result = df.groupby('group')['dose'].value_counts().sort_index(level=0,
+                                                       sort_remaining=True)
+    index = [('A','low'),
+             ('A','med'),
+             ('A','high'),
+             ('B','low'),
+             ('B','med'),
+             ('B','high')]
+    index = MultiIndex.from_tuples(index,names=['group','dose'])
+    expected = Series([2]*6,index=index)
+    tm.assert_series_equal(result,expected)
+
+
 def test_inconsistent_return_type():
     # GH5592
     # inconsistent return type


### PR DESCRIPTION
- [ ] closes #24271
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
