### PR TITLE
Remove numpy pin from environment.yml on 1.2.x

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   # required
-  - numpy>=1.16.5, <1.20 # gh-39513
+  - numpy>=1.16.5
   - python=3
   - python-dateutil>=2.7.3
   - pytz

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -14,13 +14,8 @@ skip_if_no_pyarrow = td.skip_if_no("pyarrow", min_version="1.0.0")
 
 @pytest.fixture(
     params=[
-        # pandas\tests\arrays\string_\test_string.py:16: error: List item 1 has
-        # incompatible type "ParameterSet"; expected
-        # "Sequence[Collection[object]]"  [list-item]
         "string",
-        pytest.param(
-            "arrow_string", marks=skip_if_no_pyarrow
-        ),  # type:ignore[list-item]
+        pytest.param("arrow_string", marks=skip_if_no_pyarrow),
     ]
 )
 def dtype(request):

--- a/pandas/tests/window/conftest.py
+++ b/pandas/tests/window/conftest.py
@@ -100,9 +100,7 @@ def ignore_na(request):
 
 @pytest.fixture(
     params=[
-        pytest.param(
-            "numba", marks=td.skip_if_no("numba", "0.46.0")
-        ),  # type: ignore[list-item]
+        pytest.param("numba", marks=td.skip_if_no("numba", "0.46.0")),
         "cython",
     ]
 )
@@ -318,7 +316,7 @@ def halflife_with_times(request):
         "float64",
         "m8[ns]",
         "M8[ns]",
-        pytest.param(  # type: ignore[list-item]
+        pytest.param(
             "datetime64[ns, UTC]",
             marks=pytest.mark.skip(
                 "direct creation of extension dtype datetime64[ns, UTC] "

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # This file is auto-generated from environment.yml, do not modify.
 # See that file for comments about the need/usage of each dependency.
 
-numpy>=1.16.5, <1.20
+numpy>=1.16.5
 python-dateutil>=2.7.3
 pytz
 asv

--- a/setup.cfg
+++ b/setup.cfg
@@ -122,6 +122,7 @@ strict_equality = True
 warn_redundant_casts = True
 warn_unused_ignores = True
 show_error_codes = True
+no_site_packages = True
 
 [mypy-pandas.tests.*]
 check_untyped_defs=False


### PR DESCRIPTION
xref #39513, expected to fail until #39994 backported

This PR is directly against 1.2.x and ignores site packages for mypy checks.