### PR TITLE
BUG: rolling not calculating window bounds correctly with offset and desc dates

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -436,6 +436,7 @@ Groupby/resample/rolling
 - Bug in :meth:`core.window.rolling.RollingGroupby.corr` and :meth:`core.window.expanding.ExpandingGroupby.corr` where the groupby column would return 0 instead of ``np.nan`` when providing ``other`` that was longer than each group (:issue:`39591`)
 - Bug in :meth:`core.window.expanding.ExpandingGroupby.corr` and :meth:`core.window.expanding.ExpandingGroupby.cov` where 1 would be returned instead of ``np.nan`` when providing ``other`` that was longer than each group (:issue:`39591`)
 - Bug in :meth:`.GroupBy.mean`, :meth:`.GroupBy.median` and :meth:`DataFrame.pivot_table` not propagating metadata (:issue:`28283`)
+- Bug in :meth:`Series.rolling` and :meth:`DataFrame.rolling` not calculating window bounds correctly when window is an offset and dates are in descending order (:issue:`40002`)
 -
 
 Reshaping

--- a/pandas/_libs/window/indexers.pyx
+++ b/pandas/_libs/window/indexers.pyx
@@ -88,7 +88,7 @@ def calculate_variable_window_bounds(
 
             # left endpoint is closed
             if left_closed:
-                start_bound -= 1
+                start_bound -= 1 * index_growth_sign
 
             # advance the start bound until we are
             # within the constraint

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -1133,3 +1133,18 @@ def test_rolling_skew_kurt_large_value_range(method, values):
 def test_invalid_method():
     with pytest.raises(ValueError, match="method must be 'table' or 'single"):
         Series(range(1)).rolling(1, method="foo")
+
+
+@pytest.mark.parametrize("window", [1, "1d"])
+def test_rolling_descending_date_order_with_offset(window, frame_or_series):
+    # GH#40002
+    idx = date_range(start="2020-01-01", end="2020-01-03", freq="1d")
+    obj = frame_or_series(range(1, 4), index=idx)
+    result = obj.rolling("1d", closed="left").sum()
+    expected = frame_or_series([np.nan, 1, 2], index=idx)
+    tm.assert_equal(result, expected)
+
+    result = obj.iloc[::-1].rolling("1d", closed="left").sum()
+    idx = date_range(start="2020-01-03", end="2020-01-01", freq="-1d")
+    expected = frame_or_series([np.nan, 3, 2], index=idx)
+    tm.assert_equal(result, expected)


### PR DESCRIPTION
- [x] closes #40002
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
