### PR TITLE
CI/TST: Supply dtype to coo_matrix until scipy is fixed

### DIFF
--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -1185,7 +1185,9 @@ class TestAccessor:
         row = [0, 3, 1, 0]
         col = [0, 3, 1, 2]
         data = [4, 5, 7, 9]
-        sp_array = scipy.sparse.coo_matrix((data, (row, col)))
+        # TODO: Remove dtype when scipy is fixed
+        # https://github.com/scipy/scipy/issues/13585
+        sp_array = scipy.sparse.coo_matrix((data, (row, col)), dtype="int64")
         result = pd.Series.sparse.from_coo(sp_array)
 
         index = pd.MultiIndex.from_arrays([[0, 0, 1, 3], [0, 2, 1, 3]])

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -1187,7 +1187,7 @@ class TestAccessor:
         data = [4, 5, 7, 9]
         # TODO: Remove dtype when scipy is fixed
         # https://github.com/scipy/scipy/issues/13585
-        sp_array = scipy.sparse.coo_matrix((data, (row, col)), dtype="intp")
+        sp_array = scipy.sparse.coo_matrix((data, (row, col)), dtype="int")
         result = pd.Series.sparse.from_coo(sp_array)
 
         index = pd.MultiIndex.from_arrays([[0, 0, 1, 3], [0, 2, 1, 3]])

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -1187,7 +1187,7 @@ class TestAccessor:
         data = [4, 5, 7, 9]
         # TODO: Remove dtype when scipy is fixed
         # https://github.com/scipy/scipy/issues/13585
-        sp_array = scipy.sparse.coo_matrix((data, (row, col)), dtype="int64")
+        sp_array = scipy.sparse.coo_matrix((data, (row, col)), dtype="intp")
         result = pd.Series.sparse.from_coo(sp_array)
 
         index = pd.MultiIndex.from_arrays([[0, 0, 1, 3], [0, 2, 1, 3]])


### PR DESCRIPTION
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

Fixes CI for Windows 3.7 np1.6; regression in scipy 1.6.1 (https://github.com/scipy/scipy/issues/13585)

Alternative would be to pin build, wasn't sure which is prefered over the other. Will open tracking issue once the method is decided.