### PR TITLE
STYLE: Inconsistent namespace - apply (pandas-dev#39992)

### DIFF
--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -748,13 +748,13 @@ def test_frame_apply_dont_convert_datetime64():
 
 def test_apply_non_numpy_dtype():
     # GH 12244
-    df = DataFrame({"dt": pd.date_range("2015-01-01", periods=3, tz="Europe/Brussels")})
+    df = DataFrame({"dt": date_range("2015-01-01", periods=3, tz="Europe/Brussels")})
     result = df.apply(lambda x: x)
     tm.assert_frame_equal(result, df)
 
     result = df.apply(lambda x: x + pd.Timedelta("1day"))
     expected = DataFrame(
-        {"dt": pd.date_range("2015-01-02", periods=3, tz="Europe/Brussels")}
+        {"dt": date_range("2015-01-02", periods=3, tz="Europe/Brussels")}
     )
     tm.assert_frame_equal(result, expected)
 
@@ -1149,11 +1149,9 @@ def test_agg_transform(axis, float_frame):
         result = float_frame.apply([np.sqrt], axis=axis)
         expected = f_sqrt.copy()
         if axis in {0, "index"}:
-            expected.columns = pd.MultiIndex.from_product(
-                [float_frame.columns, ["sqrt"]]
-            )
+            expected.columns = MultiIndex.from_product([float_frame.columns, ["sqrt"]])
         else:
-            expected.index = pd.MultiIndex.from_product([float_frame.index, ["sqrt"]])
+            expected.index = MultiIndex.from_product([float_frame.index, ["sqrt"]])
         tm.assert_frame_equal(result, expected)
 
         # multiple items in list
@@ -1162,11 +1160,11 @@ def test_agg_transform(axis, float_frame):
         result = float_frame.apply([np.abs, np.sqrt], axis=axis)
         expected = zip_frames([f_abs, f_sqrt], axis=other_axis)
         if axis in {0, "index"}:
-            expected.columns = pd.MultiIndex.from_product(
+            expected.columns = MultiIndex.from_product(
                 [float_frame.columns, ["absolute", "sqrt"]]
             )
         else:
-            expected.index = pd.MultiIndex.from_product(
+            expected.index = MultiIndex.from_product(
                 [float_frame.index, ["absolute", "sqrt"]]
             )
         tm.assert_frame_equal(result, expected)
@@ -1228,7 +1226,7 @@ def test_agg_multiple_mixed_no_warning():
             "A": [1, 2, 3],
             "B": [1.0, 2.0, 3.0],
             "C": ["foo", "bar", "baz"],
-            "D": pd.date_range("20130101", periods=3),
+            "D": date_range("20130101", periods=3),
         }
     )
     expected = DataFrame(
@@ -1343,7 +1341,7 @@ def test_nuiscance_columns():
             "A": [1, 2, 3],
             "B": [1.0, 2.0, 3.0],
             "C": ["foo", "bar", "baz"],
-            "D": pd.date_range("20130101", periods=3),
+            "D": date_range("20130101", periods=3),
         }
     )
 

--- a/pandas/tests/apply/test_series_apply.py
+++ b/pandas/tests/apply/test_series_apply.py
@@ -255,13 +255,13 @@ def test_transform(string_series):
         # multiple items in list
         # these are in the order as if we are applying both functions per
         # series and then concatting
-        expected = pd.concat([f_sqrt, f_abs], axis=1)
+        expected = concat([f_sqrt, f_abs], axis=1)
         expected.columns = ["sqrt", "absolute"]
         result = string_series.apply([np.sqrt, np.abs])
         tm.assert_frame_equal(result, expected)
 
         # dict, provide renaming
-        expected = pd.concat([f_sqrt, f_abs], axis=1)
+        expected = concat([f_sqrt, f_abs], axis=1)
         expected.columns = ["foo", "bar"]
         expected = expected.unstack().rename("series")
 


### PR DESCRIPTION
Fix inconsistent namespace in apply directory.

- [x] xref #39992
- [ ] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
