### PR TITLE
STYLE: Inconsistent namespace - base (pandas-dev#39992)

### DIFF
--- a/pandas/tests/base/test_conversion.py
+++ b/pandas/tests/base/test_conversion.py
@@ -327,7 +327,7 @@ def test_array_multiindex_raises():
         ),
         # GH#26406 tz is preserved in Categorical[dt64tz]
         (
-            pd.Categorical(pd.date_range("2016-01-01", periods=2, tz="US/Pacific")),
+            pd.Categorical(date_range("2016-01-01", periods=2, tz="US/Pacific")),
             np.array(
                 [
                     Timestamp("2016-01-01", tz="US/Pacific"),


### PR DESCRIPTION
- [x] xref #39992
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
