### PR TITLE
VIS Wrong legend when combining multiple plots on the same axes , plotting with `legend=False` messes up legend 

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -425,7 +425,9 @@ Plotting
 
 - Bug in :func:`scatter_matrix` raising when 2d ``ax`` argument passed (:issue:`16253`)
 - Prevent warnings when matplotlib's ``constrained_layout`` is enabled (:issue:`25261`)
--
+- Bug in :func:`DataFrame.plot` was showing the wrong colors in the legend if the function was called repeatedly and some calls used ``yerr`` while others didn't (:issue:`39522`)
+- Bug in :func:`DataFrame.plot` was showing the wrong colors in the legend if the function was called repeatedly and some calls used ``secondary_y`` and others use ``legend=False`` (:issue:`40044`)
+
 
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -593,12 +593,11 @@ class MPLPlot:
         handles = []
         labels = []
         title = ""
-
         if not self.subplots:
             if leg is not None:
                 title = leg.get_title().get_text()
                 # Replace leg.LegendHandles because it misses marker info
-                handles.extend(handle)
+                handles.extend([i for i in handle if i not in self.legend_handles])
                 labels = [x.get_text() for x in leg.get_texts()]
 
             if self.legend:
@@ -641,6 +640,8 @@ class MPLPlot:
         other_leg = None
         if other_ax is not None:
             other_leg = other_ax.get_legend()
+            other_handle, _ = other_ax.get_legend_handles_labels()
+            handle.extend(other_handle)
         if leg is None and other_leg is not None:
             leg = other_leg
             ax = other_ax

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -593,6 +593,7 @@ class MPLPlot:
         handles = []
         labels = []
         title = ""
+
         if not self.subplots:
             if leg is not None:
                 title = leg.get_title().get_text()

--- a/pandas/tests/plotting/frame/test_frame_legend.py
+++ b/pandas/tests/plotting/frame/test_frame_legend.py
@@ -1,0 +1,73 @@
+from matplotlib.container import ErrorbarContainer
+from matplotlib.lines import Line2D
+
+from pandas import DataFrame
+
+
+def test_mixed_yerr():
+    # https://github.com/pandas-dev/pandas/issues/39522
+
+    df = DataFrame([{"x": 1, "a": 1, "b": 1}, {"x": 2, "a": 2, "b": 3}])
+
+    ax = df.plot("x", "a", c="orange", yerr=0.1, label="orange")
+    df.plot("x", "b", c="blue", yerr=None, ax=ax, label="blue")
+
+    result_handles, result_labels = ax.get_legend_handles_labels()
+
+    assert isinstance(result_handles[0], Line2D)
+    assert isinstance(result_handles[1], ErrorbarContainer)
+
+    expected_labels = ["blue", "orange"]
+    assert result_labels == expected_labels
+
+
+def test_all_have_yerr():
+    # https://github.com/pandas-dev/pandas/issues/39522
+
+    df = DataFrame([{"x": 1, "a": 1, "b": 1}, {"x": 2, "a": 2, "b": 3}])
+
+    ax = df.plot("x", "a", c="orange", yerr=0.1, label="orange")
+    df.plot("x", "b", c="blue", yerr=0.1, ax=ax, label="blue")
+
+    result_handles, result_labels = ax.get_legend_handles_labels()
+
+    assert isinstance(result_handles[0], ErrorbarContainer)
+    assert isinstance(result_handles[1], ErrorbarContainer)
+
+    expected_labels = ["orange", "blue"]
+    assert result_labels == expected_labels
+
+
+def test_none_have_yerr():
+    # https://github.com/pandas-dev/pandas/issues/39522
+
+    df = DataFrame([{"x": 1, "a": 1, "b": 1}, {"x": 2, "a": 2, "b": 3}])
+
+    ax = df.plot("x", "a", c="orange", label="orange")
+    df.plot("x", "b", c="blue", ax=ax, label="blue")
+
+    result_handles, result_labels = ax.get_legend_handles_labels()
+
+    assert isinstance(result_handles[0], Line2D)
+    assert isinstance(result_handles[1], Line2D)
+
+    expected_labels = ["orange", "blue"]
+    assert result_labels == expected_labels
+
+
+def test_legend_false():
+    # https://github.com/pandas-dev/pandas/issues/40044
+
+    df = DataFrame({"a": [1, 1], "b": [2, 2]})
+    df2 = DataFrame({"d": [2.5, 2.5]})
+
+    ax = df.plot(legend=True, color={"a": "blue", "b": "green"}, secondary_y="b")
+    df2.plot(legend=False, color="red", ax=ax)
+
+    handles, result_labels = ax.get_legend_handles_labels()
+    result_colors = [i.get_color() for i in handles]
+    expected_labels = ["a", "d"]
+    expected_colors = ["blue", "red"]
+
+    assert result_labels == expected_labels
+    assert result_colors == expected_colors


### PR DESCRIPTION
- [x] closes #39522
- [x] closes #40044
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

So, in #27808 , `leg.legendHandles` was replaced with `ax.get_legend_handles_labels()[0]` in order to preserve marker info.

However, `ax.get_legend_handles_labels()[0]` may contain extra elements which aren't (yet) visible, which means we may end up at 

https://github.com/pandas-dev/pandas/blob/272435073c70b4421f72184663837f4864601f11/pandas/plotting/_matplotlib/core.py#L625

with
```python
(Pdb) handles
[<matplotlib.lines.Line2D object at 0x7f0938a37430>, <ErrorbarContainer object of 3 artists>, <matplotlib.lines.Line2D object at 0x7f0938a37430>]
(Pdb) labels
['orange', 'blue']
```

This causes the permuting noted in #39522

Ideally, there would be a way to get `leg.legendHandles` in a way that preserves the marker info. However, I can't find a way to do that - have asked on the matplotlib discourse. Also, the current test doesn't quite work (as it passes on `master` too). I'm working on finding a satisfactory solution

---

On master:

![image](https://user-images.githubusercontent.com/33491632/109154213-e4440f80-7765-11eb-8c76-7d70ccddf447.png)

On this branch:

![image](https://user-images.githubusercontent.com/33491632/109154268-f8880c80-7765-11eb-839f-e239a909b8fe.png)

---

cc @charlesdong1991 in case you have comments / suggestions