### PR TITLE
BUG: construct_1d_ndarray_preserving_na with dt64/td64 and object dtype

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1839,7 +1839,16 @@ def construct_1d_ndarray_preserving_na(
     else:
         if dtype is not None:
             _disallow_mismatched_datetimelike(values, dtype)
-        subarr = np.array(values, dtype=dtype, copy=copy)
+
+        if (
+            dtype == object
+            and isinstance(values, np.ndarray)
+            and values.dtype.kind in ["m", "M"]
+        ):
+            # TODO(numpy#12550): special-case can be removed
+            subarr = construct_1d_object_array_from_listlike(list(values))
+        else:
+            subarr = np.array(values, dtype=dtype, copy=copy)
 
     return subarr
 

--- a/pandas/tests/dtypes/cast/test_construct_ndarray.py
+++ b/pandas/tests/dtypes/cast/test_construct_ndarray.py
@@ -19,3 +19,13 @@ import pandas._testing as tm
 def test_construct_1d_ndarray_preserving_na(values, dtype, expected):
     result = construct_1d_ndarray_preserving_na(values, dtype=dtype)
     tm.assert_numpy_array_equal(result, expected)
+
+
+@pytest.mark.parametrize("dtype", ["m8[ns]", "M8[ns]"])
+def test_construct_1d_ndarray_preserving_na_datetimelike(dtype):
+    arr = np.arange(5).view(dtype)
+    expected = np.array(list(arr), dtype=object)
+    assert all(isinstance(x, type(arr[0])) for x in expected)
+
+    result = construct_1d_ndarray_preserving_na(arr, np.dtype(object))
+    tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/dtypes/cast/test_construct_ndarray.py
+++ b/pandas/tests/dtypes/cast/test_construct_ndarray.py
@@ -23,7 +23,7 @@ def test_construct_1d_ndarray_preserving_na(values, dtype, expected):
 
 @pytest.mark.parametrize("dtype", ["m8[ns]", "M8[ns]"])
 def test_construct_1d_ndarray_preserving_na_datetimelike(dtype):
-    arr = np.arange(5).view(dtype)
+    arr = np.arange(5, dtype=np.int64).view(dtype)
     expected = np.array(list(arr), dtype=object)
     assert all(isinstance(x, type(arr[0])) for x in expected)
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
