### PR TITLE
STYLE: inconsistent namespace (io, reshape)

### DIFF
--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -275,7 +275,7 @@ class TestRoundTrip:
 
     def test_multiindex_interval_datetimes(self, ext):
         # GH 30986
-        midx = pd.MultiIndex.from_arrays(
+        midx = MultiIndex.from_arrays(
             [
                 range(4),
                 pd.interval_range(
@@ -289,7 +289,7 @@ class TestRoundTrip:
             result = pd.read_excel(pth, index_col=[0, 1])
         expected = DataFrame(
             range(4),
-            pd.MultiIndex.from_arrays(
+            MultiIndex.from_arrays(
                 [
                     range(4),
                     [

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -249,7 +249,7 @@ class TestDataFrameFormatting:
 
     def test_repr_chop_threshold(self):
         df = DataFrame([[0.1, 0.5], [0.5, -0.1]])
-        pd.reset_option("display.chop_threshold")  # default None
+        reset_option("display.chop_threshold")  # default None
         assert repr(df) == "     0    1\n0  0.1  0.5\n1  0.5 -0.1"
 
         with option_context("display.chop_threshold", 0.2):
@@ -382,7 +382,7 @@ class TestDataFrameFormatting:
         )
 
         index = range(5)
-        columns = pd.MultiIndex.from_tuples(
+        columns = MultiIndex.from_tuples(
             [
                 ("This is a long title with > 37 chars.", "cat"),
                 ("This is a loooooonger title with > 43 chars.", "dog"),
@@ -689,7 +689,7 @@ class TestDataFrameFormatting:
         assert repr(df) == expected
 
         # MultiIndex
-        idx = pd.MultiIndex.from_tuples(
+        idx = MultiIndex.from_tuples(
             [("あ", "いい"), ("う", "え"), ("おおお", "かかかか"), ("き", "くく")]
         )
         df = DataFrame(
@@ -833,7 +833,7 @@ class TestDataFrameFormatting:
             assert repr(df) == expected
 
             # MultiIndex
-            idx = pd.MultiIndex.from_tuples(
+            idx = MultiIndex.from_tuples(
                 [("あ", "いい"), ("う", "え"), ("おおお", "かかかか"), ("き", "くく")]
             )
             df = DataFrame(
@@ -1002,14 +1002,14 @@ class TestDataFrameFormatting:
             + [datetime.datetime(2012, 1, 3)] * 10
         )
 
-        with pd.option_context("display.max_rows", 8):
+        with option_context("display.max_rows", 8):
             result = str(s)
             assert "object" in result
 
         # 12045
         df = DataFrame({"text": ["some words"] + [None] * 9})
 
-        with pd.option_context("display.max_rows", 8, "display.max_columns", 3):
+        with option_context("display.max_rows", 8, "display.max_columns", 3):
             result = str(df)
             assert "None" in result
             assert "NaN" not in result
@@ -1026,9 +1026,7 @@ class TestDataFrameFormatting:
     def test_datetimelike_frame(self):
 
         # GH 12211
-        df = DataFrame(
-            {"date": [Timestamp("20130101").tz_localize("UTC")] + [pd.NaT] * 5}
-        )
+        df = DataFrame({"date": [Timestamp("20130101").tz_localize("UTC")] + [NaT] * 5})
 
         with option_context("display.max_rows", 5):
             result = str(df)
@@ -1037,7 +1035,7 @@ class TestDataFrameFormatting:
             assert "..." in result
             assert "[6 rows x 1 columns]" in result
 
-        dts = [Timestamp("2011-01-01", tz="US/Eastern")] * 5 + [pd.NaT] * 5
+        dts = [Timestamp("2011-01-01", tz="US/Eastern")] * 5 + [NaT] * 5
         df = DataFrame({"dt": dts, "x": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]})
         with option_context("display.max_rows", 5):
             expected = (
@@ -1051,7 +1049,7 @@ class TestDataFrameFormatting:
             )
             assert repr(df) == expected
 
-        dts = [pd.NaT] * 5 + [Timestamp("2011-01-01", tz="US/Eastern")] * 5
+        dts = [NaT] * 5 + [Timestamp("2011-01-01", tz="US/Eastern")] * 5
         df = DataFrame({"dt": dts, "x": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]})
         with option_context("display.max_rows", 5):
             expected = (
@@ -1117,7 +1115,7 @@ class TestDataFrameFormatting:
 
     def test_string_repr_encoding(self, datapath):
         filepath = datapath("io", "parser", "data", "unicode_series.csv")
-        df = pd.read_csv(filepath, header=None, encoding="latin1")
+        df = read_csv(filepath, header=None, encoding="latin1")
         repr(df)
         repr(df[1])
 
@@ -1548,7 +1546,7 @@ class TestDataFrameFormatting:
 
     def test_to_string_complex_float_formatting(self):
         # GH #25514, 25745
-        with pd.option_context("display.precision", 5):
+        with option_context("display.precision", 5):
             df = DataFrame(
                 {
                     "x": [
@@ -1785,7 +1783,7 @@ c  10  11  12  13  14\
         df = DataFrame([[1, 2], [3, 4]])
         assert "tex2jax_ignore" not in df._repr_html_()
 
-        with pd.option_context("display.html.use_mathjax", False):
+        with option_context("display.html.use_mathjax", False):
             assert "tex2jax_ignore" in df._repr_html_()
 
     def test_repr_html_wide(self):
@@ -2229,7 +2227,7 @@ class TestSeriesFormatting:
         assert repr(s) == expected
 
         # MultiIndex
-        idx = pd.MultiIndex.from_tuples(
+        idx = MultiIndex.from_tuples(
             [("あ", "いい"), ("う", "え"), ("おおお", "かかかか"), ("き", "くく")]
         )
         s = Series([1, 22, 3333, 44444], index=idx)
@@ -2324,7 +2322,7 @@ class TestSeriesFormatting:
             assert repr(s) == expected
 
             # MultiIndex
-            idx = pd.MultiIndex.from_tuples(
+            idx = MultiIndex.from_tuples(
                 [("あ", "いい"), ("う", "え"), ("おおお", "かかかか"), ("き", "くく")]
             )
             s = Series([1, 22, 3333, 44444], index=idx)
@@ -2853,7 +2851,7 @@ class TestFloatArrayFormatter:
         # Issue #20359: trimming zeros while there is no decimal point
 
         # Happens when display precision is set to zero
-        with pd.option_context("display.precision", 0):
+        with option_context("display.precision", 0):
             s = Series([840.0, 4200.0])
             expected_output = "0     840\n1    4200\ndtype: float64"
             assert str(s) == expected_output
@@ -2862,7 +2860,7 @@ class TestFloatArrayFormatter:
         # Issue #9764
 
         # In case default display precision changes:
-        with pd.option_context("display.precision", 6):
+        with option_context("display.precision", 6):
             # DataFrame example from issue #9764
             d = DataFrame(
                 {
@@ -2933,7 +2931,7 @@ class TestFloatArrayFormatter:
 
     def test_too_long(self):
         # GH 10451
-        with pd.option_context("display.precision", 4):
+        with option_context("display.precision", 4):
             # need both a number > 1e6 and something that normally formats to
             # having length > display.precision + 6
             df = DataFrame({"x": [12345.6789]})
@@ -3011,7 +3009,7 @@ class TestRepr_timedelta64:
 
 class TestTimedelta64Formatter:
     def test_days(self):
-        x = pd.to_timedelta(list(range(5)) + [pd.NaT], unit="D")
+        x = pd.to_timedelta(list(range(5)) + [NaT], unit="D")
         result = fmt.Timedelta64Formatter(x, box=True).get_result()
         assert result[0].strip() == "'0 days'"
         assert result[1].strip() == "'1 days'"
@@ -3027,25 +3025,25 @@ class TestTimedelta64Formatter:
         assert result[0].strip() == "1 days"
 
     def test_days_neg(self):
-        x = pd.to_timedelta(list(range(5)) + [pd.NaT], unit="D")
+        x = pd.to_timedelta(list(range(5)) + [NaT], unit="D")
         result = fmt.Timedelta64Formatter(-x, box=True).get_result()
         assert result[0].strip() == "'0 days'"
         assert result[1].strip() == "'-1 days'"
 
     def test_subdays(self):
-        y = pd.to_timedelta(list(range(5)) + [pd.NaT], unit="s")
+        y = pd.to_timedelta(list(range(5)) + [NaT], unit="s")
         result = fmt.Timedelta64Formatter(y, box=True).get_result()
         assert result[0].strip() == "'0 days 00:00:00'"
         assert result[1].strip() == "'0 days 00:00:01'"
 
     def test_subdays_neg(self):
-        y = pd.to_timedelta(list(range(5)) + [pd.NaT], unit="s")
+        y = pd.to_timedelta(list(range(5)) + [NaT], unit="s")
         result = fmt.Timedelta64Formatter(-y, box=True).get_result()
         assert result[0].strip() == "'0 days 00:00:00'"
         assert result[1].strip() == "'-1 days +23:59:59'"
 
     def test_zero(self):
-        x = pd.to_timedelta(list(range(1)) + [pd.NaT], unit="D")
+        x = pd.to_timedelta(list(range(1)) + [NaT], unit="D")
         result = fmt.Timedelta64Formatter(x, box=True).get_result()
         assert result[0].strip() == "'0 days'"
 
@@ -3056,13 +3054,13 @@ class TestTimedelta64Formatter:
 
 class TestDatetime64Formatter:
     def test_mixed(self):
-        x = Series([datetime(2013, 1, 1), datetime(2013, 1, 1, 12), pd.NaT])
+        x = Series([datetime(2013, 1, 1), datetime(2013, 1, 1, 12), NaT])
         result = fmt.Datetime64Formatter(x).get_result()
         assert result[0].strip() == "2013-01-01 00:00:00"
         assert result[1].strip() == "2013-01-01 12:00:00"
 
     def test_dates(self):
-        x = Series([datetime(2013, 1, 1), datetime(2013, 1, 2), pd.NaT])
+        x = Series([datetime(2013, 1, 1), datetime(2013, 1, 2), NaT])
         result = fmt.Datetime64Formatter(x).get_result()
         assert result[0].strip() == "2013-01-01"
         assert result[1].strip() == "2013-01-02"
@@ -3137,20 +3135,20 @@ class TestDatetime64Formatter:
 
 class TestNaTFormatting:
     def test_repr(self):
-        assert repr(pd.NaT) == "NaT"
+        assert repr(NaT) == "NaT"
 
     def test_str(self):
-        assert str(pd.NaT) == "NaT"
+        assert str(NaT) == "NaT"
 
 
 class TestDatetimeIndexFormat:
     def test_datetime(self):
-        formatted = pd.to_datetime([datetime(2003, 1, 1, 12), pd.NaT]).format()
+        formatted = pd.to_datetime([datetime(2003, 1, 1, 12), NaT]).format()
         assert formatted[0] == "2003-01-01 12:00:00"
         assert formatted[1] == "NaT"
 
     def test_date(self):
-        formatted = pd.to_datetime([datetime(2003, 1, 1), pd.NaT]).format()
+        formatted = pd.to_datetime([datetime(2003, 1, 1), NaT]).format()
         assert formatted[0] == "2003-01-01"
         assert formatted[1] == "NaT"
 
@@ -3158,11 +3156,11 @@ class TestDatetimeIndexFormat:
         formatted = pd.to_datetime([datetime(2013, 1, 1)], utc=True).format()
         assert formatted[0] == "2013-01-01 00:00:00+00:00"
 
-        formatted = pd.to_datetime([datetime(2013, 1, 1), pd.NaT], utc=True).format()
+        formatted = pd.to_datetime([datetime(2013, 1, 1), NaT], utc=True).format()
         assert formatted[0] == "2013-01-01 00:00:00+00:00"
 
     def test_date_explicit_date_format(self):
-        formatted = pd.to_datetime([datetime(2003, 2, 1), pd.NaT]).format(
+        formatted = pd.to_datetime([datetime(2003, 2, 1), NaT]).format(
             date_format="%m-%d-%Y", na_rep="UT"
         )
         assert formatted[0] == "02-01-2003"
@@ -3226,7 +3224,7 @@ class TestStringRepTimestamp:
 
     def test_nat_representations(self):
         for f in (str, repr, methodcaller("isoformat")):
-            assert f(pd.NaT) == "NaT"
+            assert f(NaT) == "NaT"
 
 
 def test_format_percentiles():

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -326,7 +326,7 @@ $1$,$2$
             ),
         ],
     )
-    @pytest.mark.parametrize("klass", [pd.DataFrame, pd.Series])
+    @pytest.mark.parametrize("klass", [DataFrame, pd.Series])
     def test_to_csv_single_level_multi_index(self, ind, expected, klass):
         # see gh-19589
         result = klass(pd.Series([1], ind, name="data")).to_csv(

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -763,7 +763,7 @@ def test_to_html_render_links(render_links, expected, datapath):
 def test_ignore_display_max_colwidth(method, expected, max_colwidth):
     # see gh-17004
     df = DataFrame([lorem_ipsum])
-    with pd.option_context("display.max_colwidth", max_colwidth):
+    with option_context("display.max_colwidth", max_colwidth):
         result = getattr(df, method)()
     expected = expected(max_colwidth)
     assert expected in result
@@ -782,7 +782,7 @@ def test_to_html_invalid_classes_type(classes):
 def test_to_html_round_column_headers():
     # GH 17280
     df = DataFrame([1], columns=[0.55555])
-    with pd.option_context("display.precision", 3):
+    with option_context("display.precision", 3):
         html = df.to_html(notebook=False)
         notebook = df.to_html(notebook=True)
     assert "0.55555" in html

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -149,7 +149,7 @@ class TestPandasContainer:
     @pytest.mark.parametrize("numpy", [True, False])
     def test_roundtrip_simple(self, orient, convert_axes, numpy, dtype, float_frame):
         data = float_frame.to_json(orient=orient)
-        result = pd.read_json(
+        result = read_json(
             data, orient=orient, convert_axes=convert_axes, numpy=numpy, dtype=dtype
         )
 
@@ -162,7 +162,7 @@ class TestPandasContainer:
     @pytest.mark.parametrize("numpy", [True, False])
     def test_roundtrip_intframe(self, orient, convert_axes, numpy, dtype, int_frame):
         data = int_frame.to_json(orient=orient)
-        result = pd.read_json(
+        result = read_json(
             data, orient=orient, convert_axes=convert_axes, numpy=numpy, dtype=dtype
         )
         expected = int_frame
@@ -195,7 +195,7 @@ class TestPandasContainer:
             )
 
         data = df.to_json(orient=orient)
-        result = pd.read_json(
+        result = read_json(
             data, orient=orient, convert_axes=convert_axes, numpy=numpy, dtype=dtype
         )
 
@@ -235,9 +235,7 @@ class TestPandasContainer:
                 pytest.mark.xfail(reason=f"Orient {orient} is broken with numpy=True")
             )
 
-        result = pd.read_json(
-            data, orient=orient, convert_axes=convert_axes, numpy=numpy
-        )
+        result = read_json(data, orient=orient, convert_axes=convert_axes, numpy=numpy)
 
         expected = self.categorical.copy()
         expected.index = expected.index.astype(str)  # Categorical not preserved
@@ -252,9 +250,7 @@ class TestPandasContainer:
     @pytest.mark.parametrize("numpy", [True, False])
     def test_roundtrip_empty(self, orient, convert_axes, numpy, empty_frame):
         data = empty_frame.to_json(orient=orient)
-        result = pd.read_json(
-            data, orient=orient, convert_axes=convert_axes, numpy=numpy
-        )
+        result = read_json(data, orient=orient, convert_axes=convert_axes, numpy=numpy)
         expected = empty_frame.copy()
 
         # TODO: both conditions below are probably bugs
@@ -271,9 +267,7 @@ class TestPandasContainer:
     def test_roundtrip_timestamp(self, orient, convert_axes, numpy, datetime_frame):
         # TODO: improve coverage with date_format parameter
         data = datetime_frame.to_json(orient=orient)
-        result = pd.read_json(
-            data, orient=orient, convert_axes=convert_axes, numpy=numpy
-        )
+        result = read_json(data, orient=orient, convert_axes=convert_axes, numpy=numpy)
         expected = datetime_frame.copy()
 
         if not convert_axes:  # one off for ts handling
@@ -305,9 +299,7 @@ class TestPandasContainer:
         df = DataFrame(data=values, index=index)
 
         data = df.to_json(orient=orient)
-        result = pd.read_json(
-            data, orient=orient, convert_axes=convert_axes, numpy=numpy
-        )
+        result = read_json(data, orient=orient, convert_axes=convert_axes, numpy=numpy)
 
         expected = df.copy()
         expected = expected.assign(**expected.select_dtypes("number").astype(np.int64))
@@ -487,12 +479,12 @@ class TestPandasContainer:
 
         dirpath = datapath("io", "json", "data")
         v12_json = os.path.join(dirpath, "tsframe_v012.json")
-        df_unser = pd.read_json(v12_json)
+        df_unser = read_json(v12_json)
         tm.assert_frame_equal(df, df_unser)
 
         df_iso = df.drop(["modified"], axis=1)
         v12_iso_json = os.path.join(dirpath, "tsframe_iso_v012.json")
-        df_unser_iso = pd.read_json(v12_iso_json)
+        df_unser_iso = read_json(v12_iso_json)
         tm.assert_frame_equal(df_iso, df_unser_iso)
 
     def test_blocks_compat_GH9037(self):
@@ -581,7 +573,7 @@ class TestPandasContainer:
         # JSON deserialisation always creates unicode strings
         df_mixed.columns = df_mixed.columns.astype("unicode")
 
-        df_roundtrip = pd.read_json(df_mixed.to_json(orient="split"), orient="split")
+        df_roundtrip = read_json(df_mixed.to_json(orient="split"), orient="split")
         tm.assert_frame_equal(
             df_mixed,
             df_roundtrip,
@@ -654,7 +646,7 @@ class TestPandasContainer:
     @pytest.mark.parametrize("numpy", [True, False])
     def test_series_roundtrip_simple(self, orient, numpy, string_series):
         data = string_series.to_json(orient=orient)
-        result = pd.read_json(data, typ="series", orient=orient, numpy=numpy)
+        result = read_json(data, typ="series", orient=orient, numpy=numpy)
 
         expected = string_series
         if orient in ("values", "records"):
@@ -668,9 +660,7 @@ class TestPandasContainer:
     @pytest.mark.parametrize("numpy", [True, False])
     def test_series_roundtrip_object(self, orient, numpy, dtype, object_series):
         data = object_series.to_json(orient=orient)
-        result = pd.read_json(
-            data, typ="series", orient=orient, numpy=numpy, dtype=dtype
-        )
+        result = read_json(data, typ="series", orient=orient, numpy=numpy, dtype=dtype)
 
         expected = object_series
         if orient in ("values", "records"):
@@ -683,7 +673,7 @@ class TestPandasContainer:
     @pytest.mark.parametrize("numpy", [True, False])
     def test_series_roundtrip_empty(self, orient, numpy, empty_series):
         data = empty_series.to_json(orient=orient)
-        result = pd.read_json(data, typ="series", orient=orient, numpy=numpy)
+        result = read_json(data, typ="series", orient=orient, numpy=numpy)
 
         expected = empty_series
         if orient in ("values", "records"):
@@ -696,7 +686,7 @@ class TestPandasContainer:
     @pytest.mark.parametrize("numpy", [True, False])
     def test_series_roundtrip_timeseries(self, orient, numpy, datetime_series):
         data = datetime_series.to_json(orient=orient)
-        result = pd.read_json(data, typ="series", orient=orient, numpy=numpy)
+        result = read_json(data, typ="series", orient=orient, numpy=numpy)
 
         expected = datetime_series
         if orient in ("values", "records"):
@@ -711,7 +701,7 @@ class TestPandasContainer:
     def test_series_roundtrip_numeric(self, orient, numpy, dtype):
         s = Series(range(6), index=["a", "b", "c", "d", "e", "f"])
         data = s.to_json(orient=orient)
-        result = pd.read_json(data, typ="series", orient=orient, numpy=numpy)
+        result = read_json(data, typ="series", orient=orient, numpy=numpy)
 
         expected = s.copy()
         if orient in ("values", "records"):
@@ -747,7 +737,7 @@ class TestPandasContainer:
     def test_series_with_dtype_datetime(self, dtype, expected):
         s = Series(["2000-01-01"], dtype="datetime64[ns]")
         data = s.to_json()
-        result = pd.read_json(data, typ="series", dtype=dtype)
+        result = read_json(data, typ="series", dtype=dtype)
         tm.assert_series_equal(result, expected)
 
     def test_frame_from_json_precise_float(self):
@@ -1001,7 +991,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         csv = "https://raw.github.com/hayd/lahman2012/master/csvs/Teams.csv"
         df = pd.read_csv(csv)
         s = df.to_json()
-        result = pd.read_json(s)
+        result = read_json(s)
         tm.assert_frame_equal(result.reindex(index=df.index, columns=df.columns), df)
 
     @tm.network
@@ -1025,17 +1015,17 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         s = Series([timedelta(23), timedelta(seconds=5)])
         assert s.dtype == "timedelta64[ns]"
 
-        result = pd.read_json(s.to_json(), typ="series").apply(converter)
+        result = read_json(s.to_json(), typ="series").apply(converter)
         tm.assert_series_equal(result, s)
 
         s = Series([timedelta(23), timedelta(seconds=5)], index=pd.Index([0, 1]))
         assert s.dtype == "timedelta64[ns]"
-        result = pd.read_json(s.to_json(), typ="series").apply(converter)
+        result = read_json(s.to_json(), typ="series").apply(converter)
         tm.assert_series_equal(result, s)
 
         frame = DataFrame([timedelta(23), timedelta(seconds=5)])
         assert frame[0].dtype == "timedelta64[ns]"
-        tm.assert_frame_equal(frame, pd.read_json(frame.to_json()).apply(converter))
+        tm.assert_frame_equal(frame, read_json(frame.to_json()).apply(converter))
 
         frame = DataFrame(
             {
@@ -1045,7 +1035,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
             }
         )
 
-        result = pd.read_json(frame.to_json(date_unit="ns"))
+        result = read_json(frame.to_json(date_unit="ns"))
         result["a"] = pd.to_timedelta(result.a, unit="ns")
         result["c"] = pd.to_datetime(result.c)
         tm.assert_frame_equal(frame, result)
@@ -1056,7 +1046,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         expected = DataFrame(
             {"a": [pd.Timedelta(frame.a[0]).value, Timestamp(frame.a[1]).value]}
         )
-        result = pd.read_json(frame.to_json(date_unit="ns"), dtype={"a": "int64"})
+        result = read_json(frame.to_json(date_unit="ns"), dtype={"a": "int64"})
         tm.assert_frame_equal(result, expected, check_index_type=False)
 
     @pytest.mark.parametrize("as_object", [True, False])
@@ -1086,7 +1076,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         value = object()
         frame = DataFrame({"a": [7, value]})
         expected = DataFrame({"a": [7, str(value)]})
-        result = pd.read_json(frame.to_json(default_handler=str))
+        result = read_json(frame.to_json(default_handler=str))
         tm.assert_frame_equal(expected, result, check_index_type=False)
 
     def test_default_handler_indirect(self):
@@ -1319,14 +1309,14 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         result = df.to_json(orient="records", lines=True)
         expected = '{"a":"foo}","b":"bar"}\n{"a":"foo\\"","b":"bar"}\n'
         assert result == expected
-        tm.assert_frame_equal(pd.read_json(result, lines=True), df)
+        tm.assert_frame_equal(read_json(result, lines=True), df)
 
         # GH15096: escaped characters in columns and data
         df = DataFrame([["foo\\", "bar"], ['foo"', "bar"]], columns=["a\\", "b"])
         result = df.to_json(orient="records", lines=True)
         expected = '{"a\\\\":"foo\\\\","b":"bar"}\n{"a\\\\":"foo\\"","b":"bar"}\n'
         assert result == expected
-        tm.assert_frame_equal(pd.read_json(result, lines=True), df)
+        tm.assert_frame_equal(read_json(result, lines=True), df)
 
     # TODO: there is a near-identical test for pytables; can we share?
     def test_latin_encoding(self):
@@ -1382,14 +1372,14 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         # GH25433 GH25435
         expected = DataFrame([[1, 2], [3, 4]], index=index, columns=columns)
         dfjson = expected.to_json(orient="table")
-        result = pd.read_json(dfjson, orient="table")
+        result = read_json(dfjson, orient="table")
         tm.assert_frame_equal(result, expected)
 
     def test_from_json_to_json_table_dtypes(self):
         # GH21345
         expected = DataFrame({"a": [1, 2], "b": [3.0, 4.0], "c": ["5", "6"]})
         dfjson = expected.to_json(orient="table")
-        result = pd.read_json(dfjson, orient="table")
+        result = read_json(dfjson, orient="table")
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize("dtype", [True, {"b": int, "c": int}])
@@ -1399,7 +1389,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         dfjson = df.to_json(orient="table")
         msg = "cannot pass both dtype and orient='table'"
         with pytest.raises(ValueError, match=msg):
-            pd.read_json(dfjson, orient="table", dtype=dtype)
+            read_json(dfjson, orient="table", dtype=dtype)
 
     def test_read_json_table_convert_axes_raises(self):
         # GH25433 GH25435
@@ -1407,7 +1397,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         dfjson = df.to_json(orient="table")
         msg = "cannot pass both convert_axes and orient='table'"
         with pytest.raises(ValueError, match=msg):
-            pd.read_json(dfjson, orient="table", convert_axes=True)
+            read_json(dfjson, orient="table", convert_axes=True)
 
     @pytest.mark.parametrize(
         "data, expected",
@@ -1681,7 +1671,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
     def test_emca_262_nan_inf_support(self):
         # GH 12213
         data = '["a", NaN, "NaN", Infinity, "Infinity", -Infinity, "-Infinity"]'
-        result = pd.read_json(data)
+        result = read_json(data)
         expected = DataFrame(
             ["a", np.nan, "NaN", np.inf, "Infinity", -np.inf, "-Infinity"]
         )

--- a/pandas/tests/io/json/test_readlines.py
+++ b/pandas/tests/io/json/test_readlines.py
@@ -93,7 +93,7 @@ def test_readjson_chunks(lines_json_df, chunksize):
 def test_readjson_chunksize_requires_lines(lines_json_df):
     msg = "chunksize can only be passed if lines=True"
     with pytest.raises(ValueError, match=msg):
-        with pd.read_json(StringIO(lines_json_df), lines=False, chunksize=2) as _:
+        with read_json(StringIO(lines_json_df), lines=False, chunksize=2) as _:
             pass
 
 
@@ -102,10 +102,10 @@ def test_readjson_chunks_series():
     s = pd.Series({"A": 1, "B": 2})
 
     strio = StringIO(s.to_json(lines=True, orient="records"))
-    unchunked = pd.read_json(strio, lines=True, typ="Series")
+    unchunked = read_json(strio, lines=True, typ="Series")
 
     strio = StringIO(s.to_json(lines=True, orient="records"))
-    with pd.read_json(strio, lines=True, typ="Series", chunksize=1) as reader:
+    with read_json(strio, lines=True, typ="Series", chunksize=1) as reader:
         chunked = pd.concat(reader)
 
     tm.assert_series_equal(chunked, unchunked)
@@ -114,7 +114,7 @@ def test_readjson_chunks_series():
 def test_readjson_each_chunk(lines_json_df):
     # Other tests check that the final result of read_json(chunksize=True)
     # is correct. This checks the intermediate chunks.
-    with pd.read_json(StringIO(lines_json_df), lines=True, chunksize=2) as reader:
+    with read_json(StringIO(lines_json_df), lines=True, chunksize=2) as reader:
         chunks = list(reader)
     assert chunks[0].shape == (2, 2)
     assert chunks[1].shape == (1, 2)
@@ -124,9 +124,9 @@ def test_readjson_chunks_from_file():
     with tm.ensure_clean("test.json") as path:
         df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
         df.to_json(path, lines=True, orient="records")
-        with pd.read_json(path, lines=True, chunksize=1) as reader:
+        with read_json(path, lines=True, chunksize=1) as reader:
             chunked = pd.concat(reader)
-        unchunked = pd.read_json(path, lines=True)
+        unchunked = read_json(path, lines=True)
         tm.assert_frame_equal(unchunked, chunked)
 
 
@@ -164,9 +164,7 @@ def test_readjson_invalid_chunksize(lines_json_df, chunksize):
     msg = r"'chunksize' must be an integer >=1"
 
     with pytest.raises(ValueError, match=msg):
-        with pd.read_json(
-            StringIO(lines_json_df), lines=True, chunksize=chunksize
-        ) as _:
+        with read_json(StringIO(lines_json_df), lines=True, chunksize=chunksize) as _:
             pass
 
 
@@ -189,7 +187,7 @@ def test_readjson_chunks_multiple_empty_lines(chunksize):
     {"A":3,"B":6}
     """
     orig = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-    test = pd.read_json(j, lines=True, chunksize=chunksize)
+    test = read_json(j, lines=True, chunksize=chunksize)
     if chunksize is not None:
         with test:
             test = pd.concat(test)
@@ -215,7 +213,7 @@ def test_readjson_nrows(nrows):
         {"a": 3, "b": 4}
         {"a": 5, "b": 6}
         {"a": 7, "b": 8}"""
-    result = pd.read_json(jsonl, lines=True, nrows=nrows)
+    result = read_json(jsonl, lines=True, nrows=nrows)
     expected = DataFrame({"a": [1, 3, 5, 7], "b": [2, 4, 6, 8]}).iloc[:nrows]
     tm.assert_frame_equal(result, expected)
 
@@ -243,7 +241,7 @@ def test_readjson_nrows_requires_lines():
         {"a": 7, "b": 8}"""
     msg = "nrows can only be passed if lines=True"
     with pytest.raises(ValueError, match=msg):
-        pd.read_json(jsonl, lines=False, nrows=2)
+        read_json(jsonl, lines=False, nrows=2)
 
 
 def test_readjson_lines_chunks_fileurl(datapath):
@@ -256,7 +254,7 @@ def test_readjson_lines_chunks_fileurl(datapath):
     ]
     os_path = datapath("io", "json", "data", "line_delimited.json")
     file_url = Path(os_path).as_uri()
-    with pd.read_json(file_url, lines=True, chunksize=1) as url_reader:
+    with read_json(file_url, lines=True, chunksize=1) as url_reader:
         for index, chuck in enumerate(url_reader):
             tm.assert_frame_equal(chuck, df_list_expected[index])
 
@@ -285,5 +283,5 @@ def test_chunksize_is_incremental():
             return iter(self.stringio)
 
     reader = MyReader(jsonl)
-    assert len(list(pd.read_json(reader, lines=True, chunksize=100))) > 1
+    assert len(list(read_json(reader, lines=True, chunksize=100))) > 1
     assert reader.read_count > 10

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -1526,7 +1526,7 @@ def test_parse_timezone(all_parsers):
 
     dti = DatetimeIndex(
         list(
-            pd.date_range(
+            date_range(
                 start="2018-01-04 09:01:00",
                 end="2018-01-04 09:05:00",
                 freq="1min",

--- a/pandas/tests/io/parser/test_read_fwf.py
+++ b/pandas/tests/io/parser/test_read_fwf.py
@@ -16,7 +16,6 @@ import pytest
 
 from pandas.errors import EmptyDataError
 
-import pandas as pd
 from pandas import (
     DataFrame,
     DatetimeIndex,
@@ -687,7 +686,7 @@ bba bab b a"""
     with tm.ensure_clean() as path:
         Path(path).write_text(data)
         with open(path, "rb") as file:
-            df = pd.read_fwf(file)
+            df = read_fwf(file)
             file.seek(0)
             tm.assert_frame_equal(df, df_reference)
 
@@ -701,7 +700,7 @@ def test_encoding_mmap(memory_map):
     """
     encoding = "iso8859_1"
     data = BytesIO(" 1 A Ä 2\n".encode(encoding))
-    df = pd.read_fwf(
+    df = read_fwf(
         data,
         header=None,
         widths=[2, 2, 2, 2],

--- a/pandas/tests/io/pytables/test_append.py
+++ b/pandas/tests/io/pytables/test_append.py
@@ -415,12 +415,12 @@ def test_append_with_strings(setup_path):
             # just make sure there is a longer string:
             df2 = df.copy().reset_index().assign(C="longer").set_index("C")
             store.append("ss3", df2)
-            tm.assert_frame_equal(store.select("ss3"), pd.concat([df, df2]))
+            tm.assert_frame_equal(store.select("ss3"), concat([df, df2]))
 
             # same as above, with a Series
             store.put("ss4", df["B"], format="table", min_itemsize={"index": 6})
             store.append("ss4", df2["B"])
-            tm.assert_series_equal(store.select("ss4"), pd.concat([df["B"], df2["B"]]))
+            tm.assert_series_equal(store.select("ss4"), concat([df["B"], df2["B"]]))
 
             # with nans
             _maybe_remove(store, "df")

--- a/pandas/tests/io/pytables/test_errors.py
+++ b/pandas/tests/io/pytables/test_errors.py
@@ -6,7 +6,6 @@ from warnings import catch_warnings
 import numpy as np
 import pytest
 
-import pandas as pd
 from pandas import (
     CategoricalIndex,
     DataFrame,
@@ -207,7 +206,7 @@ def test_unsuppored_hdf_file_error(datapath):
     )
 
     with pytest.raises(ValueError, match=message):
-        pd.read_hdf(data_path)
+        read_hdf(data_path)
 
 
 def test_read_hdf_errors(setup_path):

--- a/pandas/tests/io/pytables/test_file_handling.py
+++ b/pandas/tests/io/pytables/test_file_handling.py
@@ -5,7 +5,6 @@ import pytest
 
 from pandas.compat import is_platform_little_endian
 
-import pandas as pd
 from pandas import (
     DataFrame,
     HDFStore,
@@ -188,7 +187,7 @@ def test_complibs_default_settings(setup_path):
     # default value
     with ensure_clean_path(setup_path) as tmpfile:
         df.to_hdf(tmpfile, "df", complevel=9)
-        result = pd.read_hdf(tmpfile, "df")
+        result = read_hdf(tmpfile, "df")
         tm.assert_frame_equal(result, df)
 
         with tables.open_file(tmpfile, mode="r") as h5file:
@@ -199,7 +198,7 @@ def test_complibs_default_settings(setup_path):
     # Set complib and check to see if compression is disabled
     with ensure_clean_path(setup_path) as tmpfile:
         df.to_hdf(tmpfile, "df", complib="zlib")
-        result = pd.read_hdf(tmpfile, "df")
+        result = read_hdf(tmpfile, "df")
         tm.assert_frame_equal(result, df)
 
         with tables.open_file(tmpfile, mode="r") as h5file:
@@ -210,7 +209,7 @@ def test_complibs_default_settings(setup_path):
     # Check if not setting complib or complevel results in no compression
     with ensure_clean_path(setup_path) as tmpfile:
         df.to_hdf(tmpfile, "df")
-        result = pd.read_hdf(tmpfile, "df")
+        result = read_hdf(tmpfile, "df")
         tm.assert_frame_equal(result, df)
 
         with tables.open_file(tmpfile, mode="r") as h5file:
@@ -256,7 +255,7 @@ def test_complibs(setup_path):
 
             # Write and read file to see if data is consistent
             df.to_hdf(tmpfile, gname, complib=lib, complevel=lvl)
-            result = pd.read_hdf(tmpfile, gname)
+            result = read_hdf(tmpfile, gname)
             tm.assert_frame_equal(result, df)
 
             # Open file and check metadata

--- a/pandas/tests/io/pytables/test_read.py
+++ b/pandas/tests/io/pytables/test_read.py
@@ -35,7 +35,7 @@ def test_read_missing_key_close_store(setup_path):
         df.to_hdf(path, "k1")
 
         with pytest.raises(KeyError, match="'No object named k2 in the file'"):
-            pd.read_hdf(path, "k2")
+            read_hdf(path, "k2")
 
         # smoke test to test that file is properly closed after
         # read with KeyError before another write
@@ -51,11 +51,11 @@ def test_read_missing_key_opened_store(setup_path):
         with HDFStore(path, "r") as store:
 
             with pytest.raises(KeyError, match="'No object named k2 in the file'"):
-                pd.read_hdf(store, "k2")
+                read_hdf(store, "k2")
 
             # Test that the file is still open after a KeyError and that we can
             # still read from it.
-            pd.read_hdf(store, "k1")
+            read_hdf(store, "k1")
 
 
 def test_read_column(setup_path):
@@ -315,7 +315,7 @@ def test_read_hdf_series_mode_r(format, setup_path):
     series = tm.makeFloatSeries()
     with ensure_clean_path(setup_path) as path:
         series.to_hdf(path, key="data", format=format)
-        result = pd.read_hdf(path, key="data", mode="r")
+        result = read_hdf(path, key="data", mode="r")
     tm.assert_series_equal(result, series)
 
 

--- a/pandas/tests/io/pytables/test_select.py
+++ b/pandas/tests/io/pytables/test_select.py
@@ -978,5 +978,5 @@ def test_select_empty_where(where):
     with ensure_clean_path("empty_where.h5") as path:
         with HDFStore(path) as store:
             store.put("df", df, "t")
-            result = pd.read_hdf(store, "df", where=where)
+            result = read_hdf(store, "df", where=where)
             tm.assert_frame_equal(result, df)

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -335,12 +335,12 @@ def test_to_hdf_with_min_itemsize(setup_path):
         # just make sure there is a longer string:
         df2 = df.copy().reset_index().assign(C="longer").set_index("C")
         df2.to_hdf(path, "ss3", append=True, format="table")
-        tm.assert_frame_equal(pd.read_hdf(path, "ss3"), pd.concat([df, df2]))
+        tm.assert_frame_equal(read_hdf(path, "ss3"), concat([df, df2]))
 
         # same as above, with a Series
         df["B"].to_hdf(path, "ss4", format="table", min_itemsize={"index": 6})
         df2["B"].to_hdf(path, "ss4", append=True, format="table")
-        tm.assert_series_equal(pd.read_hdf(path, "ss4"), pd.concat([df["B"], df2["B"]]))
+        tm.assert_series_equal(read_hdf(path, "ss4"), concat([df["B"], df2["B"]]))
 
 
 @pytest.mark.parametrize("format", ["fixed", "table"])
@@ -352,7 +352,7 @@ def test_to_hdf_errors(format, setup_path):
         # GH 20835
         ser.to_hdf(path, "table", format=format, errors="surrogatepass")
 
-        result = pd.read_hdf(path, "table", errors="surrogatepass")
+        result = read_hdf(path, "table", errors="surrogatepass")
         tm.assert_series_equal(result, ser)
 
 
@@ -532,11 +532,7 @@ def test_same_name_scoping(setup_path):
 
     with ensure_clean_store(setup_path) as store:
 
-        import pandas as pd
-
-        df = DataFrame(
-            np.random.randn(20, 2), index=pd.date_range("20130101", periods=20)
-        )
+        df = DataFrame(np.random.randn(20, 2), index=date_range("20130101", periods=20))
         store.put("df", df, format="table")
         expected = df[df.index > Timestamp("20130105")]
 
@@ -762,7 +758,7 @@ def test_start_stop_fixed(setup_path):
         # fixed, GH 8287
         df = DataFrame(
             {"A": np.random.rand(20), "B": np.random.rand(20)},
-            index=pd.date_range("20130101", periods=20),
+            index=date_range("20130101", periods=20),
         )
         store.put("df", df)
 
@@ -818,7 +814,7 @@ def test_path_pathlib(setup_path):
     df = tm.makeDataFrame()
 
     result = tm.round_trip_pathlib(
-        lambda p: df.to_hdf(p, "df"), lambda p: pd.read_hdf(p, "df")
+        lambda p: df.to_hdf(p, "df"), lambda p: read_hdf(p, "df")
     )
     tm.assert_frame_equal(df, result)
 
@@ -849,7 +845,7 @@ def test_path_pathlib_hdfstore(setup_path):
 
     def reader(path):
         with HDFStore(path) as store:
-            return pd.read_hdf(store, "df")
+            return read_hdf(store, "df")
 
     result = tm.round_trip_pathlib(writer, reader)
     tm.assert_frame_equal(df, result)
@@ -858,7 +854,7 @@ def test_path_pathlib_hdfstore(setup_path):
 def test_pickle_path_localpath(setup_path):
     df = tm.makeDataFrame()
     result = tm.round_trip_pathlib(
-        lambda p: df.to_hdf(p, "df"), lambda p: pd.read_hdf(p, "df")
+        lambda p: df.to_hdf(p, "df"), lambda p: read_hdf(p, "df")
     )
     tm.assert_frame_equal(df, result)
 
@@ -872,7 +868,7 @@ def test_path_localpath_hdfstore(setup_path):
 
     def reader(path):
         with HDFStore(path) as store:
-            return pd.read_hdf(store, "df")
+            return read_hdf(store, "df")
 
     result = tm.round_trip_localpath(writer, reader)
     tm.assert_frame_equal(df, result)
@@ -1013,5 +1009,5 @@ def test_to_hdf_with_object_column_names(setup_path):
         with ensure_clean_path(setup_path) as path:
             with catch_warnings(record=True):
                 df.to_hdf(path, "df", format="table", data_columns=True)
-                result = pd.read_hdf(path, "df", where=f"index = [{df.index[0]}]")
+                result = read_hdf(path, "df", where=f"index = [{df.index[0]}]")
                 assert len(result)

--- a/pandas/tests/io/pytables/test_timezones.py
+++ b/pandas/tests/io/pytables/test_timezones.py
@@ -327,7 +327,7 @@ def test_legacy_datetimetz_object(datapath, setup_path):
 def test_dst_transitions(setup_path):
     # make sure we are not failing on transitions
     with ensure_clean_store(setup_path) as store:
-        times = pd.date_range(
+        times = date_range(
             "2013-10-26 23:00",
             "2013-10-27 01:00",
             tz="Europe/London",
@@ -347,7 +347,7 @@ def test_dst_transitions(setup_path):
 def test_read_with_where_tz_aware_index(setup_path):
     # GH 11926
     periods = 10
-    dts = pd.date_range("20151201", periods=periods, freq="D", tz="UTC")
+    dts = date_range("20151201", periods=periods, freq="D", tz="UTC")
     mi = pd.MultiIndex.from_arrays([dts, range(periods)], names=["DATE", "NO"])
     expected = DataFrame({"MYCOL": 0}, index=mi)
 

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -3,7 +3,6 @@ from textwrap import dedent
 import numpy as np
 import pytest
 
-import pandas as pd
 from pandas import (
     DataFrame,
     get_option,
@@ -216,7 +215,7 @@ class TestClipboard:
             """.strip()
         )
         mock_clipboard[request.node.name] = text
-        df = pd.read_clipboard(**clip_kwargs)
+        df = read_clipboard(**clip_kwargs)
 
         # excel data is parsed correctly
         assert df.iloc[1][1] == "Harry Carney"
@@ -230,7 +229,7 @@ class TestClipboard:
             """.strip()
         )
         mock_clipboard[request.node.name] = text
-        res = pd.read_clipboard(**clip_kwargs)
+        res = read_clipboard(**clip_kwargs)
 
         text = dedent(
             """
@@ -240,7 +239,7 @@ class TestClipboard:
             """.strip()
         )
         mock_clipboard[request.node.name] = text
-        exp = pd.read_clipboard(**clip_kwargs)
+        exp = read_clipboard(**clip_kwargs)
 
         tm.assert_frame_equal(res, exp)
 
@@ -250,7 +249,7 @@ class TestClipboard:
         with pytest.raises(ValueError, match=msg):
             df.to_clipboard(encoding="ascii")
         with pytest.raises(NotImplementedError, match=msg):
-            pd.read_clipboard(encoding="ascii")
+            read_clipboard(encoding="ascii")
 
     @pytest.mark.parametrize("enc", ["UTF-8", "utf-8", "utf8"])
     def test_round_trip_valid_encodings(self, enc, df):

--- a/pandas/tests/io/test_feather.py
+++ b/pandas/tests/io/test_feather.py
@@ -177,12 +177,12 @@ class TestFeather:
 
     def test_path_pathlib(self):
         df = tm.makeDataFrame().reset_index()
-        result = tm.round_trip_pathlib(df.to_feather, pd.read_feather)
+        result = tm.round_trip_pathlib(df.to_feather, read_feather)
         tm.assert_frame_equal(df, result)
 
     def test_path_localpath(self):
         df = tm.makeDataFrame().reset_index()
-        result = tm.round_trip_localpath(df.to_feather, pd.read_feather)
+        result = tm.round_trip_localpath(df.to_feather, read_feather)
         tm.assert_frame_equal(df, result)
 
     @td.skip_if_no("pyarrow", min_version="0.16.1.dev")
@@ -198,6 +198,6 @@ class TestFeather:
             "https://raw.githubusercontent.com/pandas-dev/pandas/master/"
             "pandas/tests/io/data/feather/feather-0_3_1.feather"
         )
-        expected = pd.read_feather(feather_file)
-        res = pd.read_feather(url)
+        expected = read_feather(feather_file)
+        res = read_feather(url)
         tm.assert_frame_equal(expected, res)

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -359,7 +359,7 @@ class Base:
             "https://raw.githubusercontent.com/pandas-dev/pandas/"
             "master/pandas/tests/io/data/parquet/simple.parquet"
         )
-        df = pd.read_parquet(url)
+        df = read_parquet(url)
         tm.assert_frame_equal(df, df_compat)
 
 
@@ -605,7 +605,7 @@ class TestParquetPyArrow(Base):
         assert isinstance(buf_bytes, bytes)
 
         buf_stream = BytesIO(buf_bytes)
-        res = pd.read_parquet(buf_stream)
+        res = read_parquet(buf_stream)
 
         tm.assert_frame_equal(df_full, res)
 
@@ -740,7 +740,7 @@ class TestParquetPyArrow(Base):
     def test_read_file_like_obj_support(self, df_compat):
         buffer = BytesIO()
         df_compat.to_parquet(buffer)
-        df_from_buf = pd.read_parquet(buffer)
+        df_from_buf = read_parquet(buffer)
         tm.assert_frame_equal(df_compat, df_from_buf)
 
     @td.skip_if_no("pyarrow")
@@ -748,7 +748,7 @@ class TestParquetPyArrow(Base):
         monkeypatch.setenv("HOME", "TestingUser")
         monkeypatch.setenv("USERPROFILE", "TestingUser")
         with pytest.raises(OSError, match=r".*TestingUser.*"):
-            pd.read_parquet("~/file.parquet")
+            read_parquet("~/file.parquet")
         with pytest.raises(OSError, match=r".*TestingUser.*"):
             df_compat.to_parquet("~/file.parquet")
 

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -428,7 +428,7 @@ class TestProtocol:
 @pytest.mark.parametrize(
     ["pickle_file", "excols"],
     [
-        ("test_py27.pkl", pd.Index(["a", "b", "c"])),
+        ("test_py27.pkl", Index(["a", "b", "c"])),
         (
             "test_mi_py27.pkl",
             pd.MultiIndex.from_arrays([["a", "b", "c"], ["A", "B", "C"]]),

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -675,7 +675,7 @@ class _TestSQLApi(PandasSQLTest):
         query = "SELECT * FROM iris_view WHERE SepalLength < 0.0"
         with_batch = sql.read_sql_query(query, self.conn, chunksize=5)
         without_batch = sql.read_sql_query(query, self.conn)
-        tm.assert_frame_equal(pd.concat(with_batch), without_batch)
+        tm.assert_frame_equal(concat(with_batch), without_batch)
 
     def test_to_sql(self):
         sql.to_sql(self.test_frame1, "test_frame1", self.conn)
@@ -1592,7 +1592,7 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
                 )
 
         # GH11216
-        df = pd.read_sql_query("select * from types_test_data", self.conn)
+        df = read_sql_query("select * from types_test_data", self.conn)
         if not hasattr(df, "DateColWithTz"):
             pytest.skip("no column with datetime with time zone")
 
@@ -1602,7 +1602,7 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
         col = df.DateColWithTz
         assert is_datetime64tz_dtype(col.dtype)
 
-        df = pd.read_sql_query(
+        df = read_sql_query(
             "select * from types_test_data", self.conn, parse_dates=["DateColWithTz"]
         )
         if not hasattr(df, "DateColWithTz"):
@@ -1612,11 +1612,9 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
         assert str(col.dt.tz) == "UTC"
         check(df.DateColWithTz)
 
-        df = pd.concat(
+        df = concat(
             list(
-                pd.read_sql_query(
-                    "select * from types_test_data", self.conn, chunksize=1
-                )
+                read_sql_query("select * from types_test_data", self.conn, chunksize=1)
             ),
             ignore_index=True,
         )
@@ -2851,7 +2849,7 @@ class TestXMySQL(MySQLMixIn):
         sql.to_sql(frame, name="test", con=self.conn)
         query = "select * from test"
         chunksize = 5
-        chunk_gen = pd.read_sql_query(
+        chunk_gen = read_sql_query(
             sql=query, con=self.conn, chunksize=chunksize, index_col="index"
         )
         chunk_df = next(chunk_gen)

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -435,7 +435,7 @@ class TestStata:
         formatted = formatted.astype(np.int32)
 
         with tm.ensure_clean() as path:
-            with tm.assert_produces_warning(pd.io.stata.InvalidColumnName):
+            with tm.assert_produces_warning(io.stata.InvalidColumnName):
                 original.to_stata(path, None)
 
             written_and_read_again = self.read_dta(path)
@@ -643,7 +643,7 @@ class TestStata:
         # Data obtained from:
         # http://go.worldbank.org/ZXY29PVJ21
         dpath = os.path.join(self.dirpath, "S4_EDUC1.dta")
-        df = pd.read_stata(dpath)
+        df = read_stata(dpath)
         df0 = [[1, 1, 3, -2], [2, 1, 2, -2], [4, 1, 1, -2]]
         df0 = DataFrame(df0)
         df0.columns = ["clustnum", "pri_schl", "psch_num", "psch_dis"]
@@ -1022,7 +1022,7 @@ class TestStata:
             [original[col].astype("category") for col in original], axis=1
         )
 
-        with tm.assert_produces_warning(pd.io.stata.ValueLabelTypeMismatch):
+        with tm.assert_produces_warning(io.stata.ValueLabelTypeMismatch):
             original.to_stata(path)
             # should get a warning for mixed content
 
@@ -1541,7 +1541,7 @@ The repeated labels are:\n-+\nwolof
         with tm.ensure_clean() as path:
             df.to_stata(path, write_index=write_index)
 
-            with pd.read_stata(path, iterator=True) as dta_iter:
+            with read_stata(path, iterator=True) as dta_iter:
                 value_labels = dta_iter.value_labels()
         assert value_labels == {"A": {0: "A", 1: "B", 2: "C", 3: "E"}}
 
@@ -1551,7 +1551,7 @@ The repeated labels are:\n-+\nwolof
         df.index.name = "index"
         with tm.ensure_clean() as path:
             df.to_stata(path)
-            reread = pd.read_stata(path, index_col="index")
+            reread = read_stata(path, index_col="index")
         tm.assert_frame_equal(df, reread)
 
     @pytest.mark.parametrize(
@@ -1652,7 +1652,7 @@ The repeated labels are:\n-+\nwolof
         )
         original.index.name = "index"
 
-        with tm.assert_produces_warning(pd.io.stata.InvalidColumnName):
+        with tm.assert_produces_warning(io.stata.InvalidColumnName):
             with tm.ensure_clean() as path:
                 original.to_stata(path, convert_strl=["long", 1], version=117)
                 reread = self.read_dta(path)
@@ -1691,7 +1691,7 @@ The repeated labels are:\n-+\nwolof
             bio.seek(0)
             with open(path, "wb") as dta:
                 dta.write(bio.read())
-            reread = pd.read_stata(path, index_col="index")
+            reread = read_stata(path, index_col="index")
         tm.assert_frame_equal(df, reread)
 
     def test_gzip_writing(self):
@@ -1702,7 +1702,7 @@ The repeated labels are:\n-+\nwolof
             with gzip.GzipFile(path, "wb") as gz:
                 df.to_stata(gz, version=114)
             with gzip.GzipFile(path, "rb") as gz:
-                reread = pd.read_stata(gz, index_col="index")
+                reread = read_stata(gz, index_col="index")
         tm.assert_frame_equal(df, reread)
 
     def test_unicode_dta_118(self):
@@ -1873,8 +1873,8 @@ def test_backward_compat(version, datapath):
     data_base = datapath("io", "data", "stata")
     ref = os.path.join(data_base, "stata-compat-118.dta")
     old = os.path.join(data_base, f"stata-compat-{version}.dta")
-    expected = pd.read_stata(ref)
-    old_dta = pd.read_stata(old)
+    expected = read_stata(ref)
+    old_dta = read_stata(old)
     tm.assert_frame_equal(old_dta, expected, check_dtype=False)
 
 
@@ -1984,7 +1984,7 @@ def test_iterator_value_labels():
     with tm.ensure_clean() as path:
         df.to_stata(path, write_index=False)
         expected = pd.Index(["a_label", "b_label", "c_label"], dtype="object")
-        with pd.read_stata(path, chunksize=100) as reader:
+        with read_stata(path, chunksize=100) as reader:
             for j, chunk in enumerate(reader):
                 for i in range(2):
                     tm.assert_index_equal(chunk.dtypes[i].categories, expected)
@@ -2025,7 +2025,7 @@ def test_compression_roundtrip(compression):
         # explicitly ensure file was compressed.
         with tm.decompress_file(path, compression) as fh:
             contents = io.BytesIO(fh.read())
-        reread = pd.read_stata(contents, index_col="index")
+        reread = read_stata(contents, index_col="index")
         tm.assert_frame_equal(df, reread)
 
 
@@ -2049,5 +2049,5 @@ def test_stata_compression(compression_only, read_infer, to_infer):
 
     with tm.ensure_clean(filename) as path:
         df.to_stata(path, compression=to_compression)
-        result = pd.read_stata(path, compression=read_compression, index_col="index")
+        result = read_stata(path, compression=read_compression, index_col="index")
         tm.assert_frame_equal(result, df)


### PR DESCRIPTION
- [x] xref #39992
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
