### PR TITLE
CLN: rename init_dict/ndarray to dict/ndarray_to_mgr for consistency

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -177,10 +177,10 @@ from pandas.core.internals import (
 from pandas.core.internals.construction import (
     arrays_to_mgr,
     dataclasses_to_dicts,
-    init_dict,
-    init_ndarray,
+    dict_to_mgr,
     masked_rec_array_to_mgr,
     mgr_to_mgr,
+    ndarray_to_mgr,
     nested_data_to_arrays,
     reorder_arrays,
     sanitize_index,
@@ -575,7 +575,7 @@ class DataFrame(NDFrame, OpsMixin):
             )
 
         elif isinstance(data, dict):
-            mgr = init_dict(data, index, columns, dtype=dtype)
+            mgr = dict_to_mgr(data, index, columns, dtype=dtype)
         elif isinstance(data, ma.MaskedArray):
             import numpy.ma.mrecords as mrecords
 
@@ -586,7 +586,7 @@ class DataFrame(NDFrame, OpsMixin):
             # a masked array
             else:
                 data = sanitize_masked_array(data)
-                mgr = init_ndarray(data, index, columns, dtype=dtype, copy=copy)
+                mgr = ndarray_to_mgr(data, index, columns, dtype=dtype, copy=copy)
 
         elif isinstance(data, (np.ndarray, Series, Index)):
             if data.dtype.names:
@@ -594,11 +594,11 @@ class DataFrame(NDFrame, OpsMixin):
                 data = {k: data[k] for k in data_columns}
                 if columns is None:
                     columns = data_columns
-                mgr = init_dict(data, index, columns, dtype=dtype)
+                mgr = dict_to_mgr(data, index, columns, dtype=dtype)
             elif getattr(data, "name", None) is not None:
-                mgr = init_dict({data.name: data}, index, columns, dtype=dtype)
+                mgr = dict_to_mgr({data.name: data}, index, columns, dtype=dtype)
             else:
-                mgr = init_ndarray(data, index, columns, dtype=dtype, copy=copy)
+                mgr = ndarray_to_mgr(data, index, columns, dtype=dtype, copy=copy)
 
         # For data is list-like, or Iterable (will consume into list)
         elif is_list_like(data):
@@ -613,9 +613,9 @@ class DataFrame(NDFrame, OpsMixin):
                     )
                     mgr = arrays_to_mgr(arrays, columns, index, columns, dtype=dtype)
                 else:
-                    mgr = init_ndarray(data, index, columns, dtype=dtype, copy=copy)
+                    mgr = ndarray_to_mgr(data, index, columns, dtype=dtype, copy=copy)
             else:
-                mgr = init_dict({}, index, columns, dtype=dtype)
+                mgr = dict_to_mgr({}, index, columns, dtype=dtype)
         # For data is scalar
         else:
             if index is None or columns is None:
@@ -638,7 +638,7 @@ class DataFrame(NDFrame, OpsMixin):
                     data, len(index), len(columns), dtype, copy
                 )
 
-                mgr = init_ndarray(
+                mgr = ndarray_to_mgr(
                     values, index, columns, dtype=values.dtype, copy=False
                 )
 

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -195,7 +195,8 @@ def mgr_to_mgr(mgr, typ: str):
 # DataFrame Constructor Interface
 
 
-def init_ndarray(values, index, columns, dtype: Optional[DtypeObj], copy: bool):
+def ndarray_to_mgr(values, index, columns, dtype: Optional[DtypeObj], copy: bool):
+    # used in DataFrame.__init__
     # input must be a ndarray, list, Series, index
 
     if isinstance(values, ABCSeries):
@@ -277,10 +278,12 @@ def init_ndarray(values, index, columns, dtype: Optional[DtypeObj], copy: bool):
     return create_block_manager_from_blocks(block_values, [columns, index])
 
 
-def init_dict(data: Dict, index, columns, dtype: Optional[DtypeObj] = None):
+def dict_to_mgr(data: Dict, index, columns, dtype: Optional[DtypeObj] = None):
     """
     Segregate Series based on type and coerce into matrices.
     Needs to handle a lot of exceptional cases.
+
+    Used in DataFrame.__init__
     """
     arrays: Union[Sequence[Any], Series]
 


### PR DESCRIPTION
See https://github.com/pandas-dev/pandas/pull/39991#discussion_r582632186, in case this is preferred for consistency with `arrays_to_mgr` (I don't have a strong preference myself, since they are only used in `__init__` the current name is also nice)