### PR TITLE
TST/REF: Consolidate tests in apply.test_invalid_arg

### DIFF
--- a/pandas/tests/apply/conftest.py
+++ b/pandas/tests/apply/conftest.py
@@ -1,0 +1,18 @@
+import numpy as np
+import pytest
+
+from pandas import DataFrame
+
+
+@pytest.fixture
+def int_frame_const_col():
+    """
+    Fixture for DataFrame of ints which are constant per column
+
+    Columns are ['A', 'B', 'C'], with values (per column): [1, 2, 3]
+    """
+    df = DataFrame(
+        np.tile(np.arange(3, dtype="int64"), 6).reshape(6, -1) + 1,
+        columns=["A", "B", "C"],
+    )
+    return df

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -14,25 +14,9 @@ from pandas import (
     Series,
     Timestamp,
     date_range,
-    notna,
 )
 import pandas._testing as tm
-from pandas.core.base import SpecificationError
 from pandas.tests.frame.common import zip_frames
-
-
-@pytest.fixture
-def int_frame_const_col():
-    """
-    Fixture for DataFrame of ints which are constant per column
-
-    Columns are ['A', 'B', 'C'], with values (per column): [1, 2, 3]
-    """
-    df = DataFrame(
-        np.tile(np.arange(3, dtype="int64"), 6).reshape(6, -1) + 1,
-        columns=["A", "B", "C"],
-    )
-    return df
 
 
 def test_apply(float_frame):
@@ -192,17 +176,6 @@ def test_apply_with_string_funcs(request, float_frame, func, args, kwds, how):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    "how, args", [("pct_change", ()), ("nsmallest", (1, ["a", "b"])), ("tail", 1)]
-)
-def test_apply_str_axis_1_raises(how, args):
-    # GH 39211 - some ops don't support axis=1
-    df = DataFrame({"a": [1, 2], "b": [3, 4]})
-    msg = f"Operation {how} does not support axis=1"
-    with pytest.raises(ValueError, match=msg):
-        df.apply(how, axis=1, args=args)
-
-
 def test_apply_broadcast(float_frame, int_frame_const_col):
 
     # scalars
@@ -254,27 +227,6 @@ def test_apply_broadcast(float_frame, int_frame_const_col):
     )
     expected = df.copy()
     tm.assert_frame_equal(result, expected)
-
-
-def test_apply_broadcast_error(int_frame_const_col):
-    df = int_frame_const_col
-
-    # > 1 ndim
-    msg = "too many dims to broadcast"
-    with pytest.raises(ValueError, match=msg):
-        df.apply(
-            lambda x: np.array([1, 2]).reshape(-1, 2),
-            axis=1,
-            result_type="broadcast",
-        )
-
-    # cannot broadcast
-    msg = "cannot broadcast result"
-    with pytest.raises(ValueError, match=msg):
-        df.apply(lambda x: [1, 2], axis=1, result_type="broadcast")
-
-    with pytest.raises(ValueError, match=msg):
-        df.apply(lambda x: Series([1, 2]), axis=1, result_type="broadcast")
 
 
 def test_apply_raw(float_frame, mixed_type_frame):
@@ -422,71 +374,6 @@ def test_apply_differently_indexed():
         {i: v.describe() for i, v in df.T.items()}, columns=df.index
     ).T
     tm.assert_frame_equal(result1, expected1)
-
-
-def test_apply_modify_traceback():
-    data = DataFrame(
-        {
-            "A": [
-                "foo",
-                "foo",
-                "foo",
-                "foo",
-                "bar",
-                "bar",
-                "bar",
-                "bar",
-                "foo",
-                "foo",
-                "foo",
-            ],
-            "B": [
-                "one",
-                "one",
-                "one",
-                "two",
-                "one",
-                "one",
-                "one",
-                "two",
-                "two",
-                "two",
-                "one",
-            ],
-            "C": [
-                "dull",
-                "dull",
-                "shiny",
-                "dull",
-                "dull",
-                "shiny",
-                "shiny",
-                "dull",
-                "shiny",
-                "shiny",
-                "shiny",
-            ],
-            "D": np.random.randn(11),
-            "E": np.random.randn(11),
-            "F": np.random.randn(11),
-        }
-    )
-
-    data.loc[4, "C"] = np.nan
-
-    def transform(row):
-        if row["C"].startswith("shin") and row["A"] == "foo":
-            row["D"] = 7
-        return row
-
-    def transform2(row):
-        if notna(row["C"]) and row["C"].startswith("shin") and row["A"] == "foo":
-            row["D"] = 7
-        return row
-
-    msg = "'float' object has no attribute 'startswith'"
-    with pytest.raises(AttributeError, match=msg):
-        data.apply(transform, axis=1)
 
 
 def test_apply_bug():
@@ -1101,19 +988,6 @@ def test_result_type(int_frame_const_col):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.parametrize("result_type", ["foo", 1])
-def test_result_type_error(result_type, int_frame_const_col):
-    # allowed result_type
-    df = int_frame_const_col
-
-    msg = (
-        "invalid value for result_type, must be one of "
-        "{None, 'reduce', 'broadcast', 'expand'}"
-    )
-    with pytest.raises(ValueError, match=msg):
-        df.apply(lambda x: [1, 2, 3], axis=1, result_type=result_type)
-
-
 @pytest.mark.parametrize(
     "box",
     [lambda x: list(x), lambda x: tuple(x), lambda x: np.array(x, dtype="int64")],
@@ -1168,20 +1042,6 @@ def test_agg_transform(axis, float_frame):
                 [float_frame.index, ["absolute", "sqrt"]]
             )
         tm.assert_frame_equal(result, expected)
-
-
-def test_transform_and_agg_err(axis, float_frame):
-    # cannot both transform and agg
-    msg = "cannot combine transform and aggregation operations"
-    with pytest.raises(ValueError, match=msg):
-        with np.errstate(all="ignore"):
-            float_frame.agg(["max", "sqrt"], axis=axis)
-
-    df = DataFrame({"A": range(5), "B": 5})
-
-    def f():
-        with np.errstate(all="ignore"):
-            df.agg({"A": ["abs", "sum"], "B": ["mean", "max"]}, axis=axis)
 
 
 def test_demo():
@@ -1252,16 +1112,6 @@ def test_agg_multiple_mixed_no_warning():
     # not ['sum', 'min'].
     expected = expected[["D", "C", "B", "A"]]
     tm.assert_frame_equal(result, expected)
-
-
-def test_agg_dict_nested_renaming_depr():
-
-    df = DataFrame({"A": range(5), "B": 5})
-
-    # nested renaming
-    msg = r"nested renamer is not supported"
-    with pytest.raises(SpecificationError, match=msg):
-        df.agg({"A": {"foo": "min"}, "B": {"bar": "max"}})
 
 
 def test_agg_reduce(axis, float_frame):
@@ -1514,19 +1364,6 @@ def test_agg_cython_table_transform(df, func, expected, axis):
 
     result = df.agg(func, axis=axis)
     tm.assert_frame_equal(result, expected)
-
-
-@pytest.mark.parametrize(
-    "df, func, expected",
-    tm.get_cython_table_params(
-        DataFrame([["a", "b"], ["b", "a"]]), [["cumprod", TypeError]]
-    ),
-)
-def test_agg_cython_table_raises(df, func, expected, axis):
-    # GH 21224
-    msg = "can't multiply sequence by non-int of type 'str'"
-    with pytest.raises(expected, match=msg):
-        df.agg(func, axis=axis)
 
 
 @pytest.mark.parametrize("axis", [0, 1])

--- a/pandas/tests/apply/test_frame_apply_relabeling.py
+++ b/pandas/tests/apply/test_frame_apply_relabeling.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 import pandas as pd
 import pandas._testing as tm
@@ -96,12 +95,3 @@ def test_agg_namedtuple():
         index=pd.Index(["foo", "bar", "cat"]),
     )
     tm.assert_frame_equal(result, expected)
-
-
-def test_agg_raises():
-    # GH 26513
-    df = pd.DataFrame({"A": [0, 1], "B": [1, 2]})
-    msg = "Must provide"
-
-    with pytest.raises(TypeError, match=msg):
-        df.agg()

--- a/pandas/tests/apply/test_frame_transform.py
+++ b/pandas/tests/apply/test_frame_transform.py
@@ -1,5 +1,4 @@
 import operator
-import re
 
 import numpy as np
 import pytest
@@ -10,7 +9,6 @@ from pandas import (
     Series,
 )
 import pandas._testing as tm
-from pandas.core.base import SpecificationError
 from pandas.core.groupby.base import transformation_kernels
 from pandas.tests.frame.common import zip_frames
 
@@ -148,47 +146,6 @@ def test_transform_method_name(method):
     tm.assert_frame_equal(result, expected)
 
 
-def test_transform_and_agg_err(axis, float_frame):
-    # GH 35964
-    # cannot both transform and agg
-    msg = "Function did not transform"
-    with pytest.raises(ValueError, match=msg):
-        float_frame.transform(["max", "min"], axis=axis)
-
-    msg = "Function did not transform"
-    with pytest.raises(ValueError, match=msg):
-        float_frame.transform(["max", "sqrt"], axis=axis)
-
-
-def test_agg_dict_nested_renaming_depr():
-    df = DataFrame({"A": range(5), "B": 5})
-
-    # nested renaming
-    msg = r"nested renamer is not supported"
-    with pytest.raises(SpecificationError, match=msg):
-        # mypy identifies the argument as an invalid type
-        df.transform({"A": {"foo": "min"}, "B": {"bar": "max"}})
-
-
-def test_transform_reducer_raises(all_reductions, frame_or_series):
-    # GH 35964
-    op = all_reductions
-
-    obj = DataFrame({"A": [1, 2, 3]})
-    if frame_or_series is not DataFrame:
-        obj = obj["A"]
-
-    msg = "Function did not transform"
-    with pytest.raises(ValueError, match=msg):
-        obj.transform(op)
-    with pytest.raises(ValueError, match=msg):
-        obj.transform([op])
-    with pytest.raises(ValueError, match=msg):
-        obj.transform({"A": op})
-    with pytest.raises(ValueError, match=msg):
-        obj.transform({"A": [op]})
-
-
 wont_fail = ["ffill", "bfill", "fillna", "pad", "backfill", "shift"]
 frame_kernels_raise = [x for x in frame_kernels if x not in wont_fail]
 
@@ -254,30 +211,6 @@ def test_transform_passes_args(use_apply, frame_or_series):
         return x
 
     frame_or_series([1]).transform(f, 0, *expected_args, **expected_kwargs)
-
-
-def test_transform_missing_columns(axis):
-    # GH#35964
-    df = DataFrame({"A": [1, 2], "B": [3, 4]})
-    match = re.escape("Column(s) ['C'] do not exist")
-    with pytest.raises(KeyError, match=match):
-        df.transform({"C": "cumsum"})
-
-
-def test_transform_none_to_type():
-    # GH#34377
-    df = DataFrame({"a": [None]})
-    msg = "Transform function failed"
-    with pytest.raises(ValueError, match=msg):
-        df.transform({"a": int})
-
-
-def test_transform_mixed_column_name_dtypes():
-    # GH39025
-    df = DataFrame({"a": ["1"]})
-    msg = r"Column\(s\) \[1, 'b'\] do not exist"
-    with pytest.raises(KeyError, match=msg):
-        df.transform({"a": int, 1: str, "b": int})
 
 
 def test_transform_empty_dataframe():

--- a/pandas/tests/apply/test_invalid_arg.py
+++ b/pandas/tests/apply/test_invalid_arg.py
@@ -1,13 +1,46 @@
 # Tests specifically aimed at detecting bad arguments.
+# This file is organized by reason for exception.
+#     1. always invalid argument values
+#     2. missing column(s)
+#     3. incompatible ops/dtype/args/kwargs
+#     4. invalid result shape/type
+# If your test does not fit into one of these categories, add to this list.
+
 import re
 
+import numpy as np
 import pytest
 
 from pandas import (
     DataFrame,
     Series,
+    date_range,
+    notna,
 )
+import pandas._testing as tm
 from pandas.core.base import SpecificationError
+
+
+@pytest.mark.parametrize("result_type", ["foo", 1])
+def test_result_type_error(result_type, int_frame_const_col):
+    # allowed result_type
+    df = int_frame_const_col
+
+    msg = (
+        "invalid value for result_type, must be one of "
+        "{None, 'reduce', 'broadcast', 'expand'}"
+    )
+    with pytest.raises(ValueError, match=msg):
+        df.apply(lambda x: [1, 2, 3], axis=1, result_type=result_type)
+
+
+def test_agg_raises():
+    # GH 26513
+    df = DataFrame({"A": [0, 1], "B": [1, 2]})
+    msg = "Must provide"
+
+    with pytest.raises(TypeError, match=msg):
+        df.agg()
 
 
 @pytest.mark.parametrize("box", [DataFrame, Series])
@@ -21,6 +54,45 @@ def test_nested_renamer(box, method, func):
         getattr(obj, method)(func)
 
 
+def test_transform_nested_renamer():
+    # GH 35964
+    match = "nested renamer is not supported"
+    with pytest.raises(SpecificationError, match=match):
+        Series([1]).transform({"A": {"B": ["sum"]}})
+
+
+def test_agg_dict_nested_renaming_depr_agg():
+
+    df = DataFrame({"A": range(5), "B": 5})
+
+    # nested renaming
+    msg = r"nested renamer is not supported"
+    with pytest.raises(SpecificationError, match=msg):
+        df.agg({"A": {"foo": "min"}, "B": {"bar": "max"}})
+
+
+def test_agg_dict_nested_renaming_depr_transform():
+    df = DataFrame({"A": range(5), "B": 5})
+
+    # nested renaming
+    msg = r"nested renamer is not supported"
+    with pytest.raises(SpecificationError, match=msg):
+        # mypy identifies the argument as an invalid type
+        df.transform({"A": {"foo": "min"}, "B": {"bar": "max"}})
+
+
+def test_apply_dict_depr():
+
+    tsdf = DataFrame(
+        np.random.randn(10, 3),
+        columns=["A", "B", "C"],
+        index=date_range("1/1/2000", periods=10),
+    )
+    msg = "nested renamer is not supported"
+    with pytest.raises(SpecificationError, match=msg):
+        tsdf.A.agg({"foo": ["sum", "mean"]})
+
+
 @pytest.mark.parametrize("method", ["apply", "agg", "transform"])
 @pytest.mark.parametrize("func", [{"B": "sum"}, {"B": ["sum"]}])
 def test_missing_column(method, func):
@@ -29,3 +101,215 @@ def test_missing_column(method, func):
     match = re.escape("Column(s) ['B'] do not exist")
     with pytest.raises(KeyError, match=match):
         getattr(obj, method)(func)
+
+
+def test_transform_missing_columns(axis):
+    # GH#35964
+    df = DataFrame({"A": [1, 2], "B": [3, 4]})
+    match = re.escape("Column(s) ['C'] do not exist")
+    with pytest.raises(KeyError, match=match):
+        df.transform({"C": "cumsum"})
+
+
+def test_transform_mixed_column_name_dtypes():
+    # GH39025
+    df = DataFrame({"a": ["1"]})
+    msg = r"Column\(s\) \[1, 'b'\] do not exist"
+    with pytest.raises(KeyError, match=msg):
+        df.transform({"a": int, 1: str, "b": int})
+
+
+@pytest.mark.parametrize(
+    "how, args", [("pct_change", ()), ("nsmallest", (1, ["a", "b"])), ("tail", 1)]
+)
+def test_apply_str_axis_1_raises(how, args):
+    # GH 39211 - some ops don't support axis=1
+    df = DataFrame({"a": [1, 2], "b": [3, 4]})
+    msg = f"Operation {how} does not support axis=1"
+    with pytest.raises(ValueError, match=msg):
+        df.apply(how, axis=1, args=args)
+
+
+def test_transform_axis_1_raises():
+    # GH 35964
+    msg = "No axis named 1 for object type Series"
+    with pytest.raises(ValueError, match=msg):
+        Series([1]).transform("sum", axis=1)
+
+
+def test_apply_modify_traceback():
+    data = DataFrame(
+        {
+            "A": [
+                "foo",
+                "foo",
+                "foo",
+                "foo",
+                "bar",
+                "bar",
+                "bar",
+                "bar",
+                "foo",
+                "foo",
+                "foo",
+            ],
+            "B": [
+                "one",
+                "one",
+                "one",
+                "two",
+                "one",
+                "one",
+                "one",
+                "two",
+                "two",
+                "two",
+                "one",
+            ],
+            "C": [
+                "dull",
+                "dull",
+                "shiny",
+                "dull",
+                "dull",
+                "shiny",
+                "shiny",
+                "dull",
+                "shiny",
+                "shiny",
+                "shiny",
+            ],
+            "D": np.random.randn(11),
+            "E": np.random.randn(11),
+            "F": np.random.randn(11),
+        }
+    )
+
+    data.loc[4, "C"] = np.nan
+
+    def transform(row):
+        if row["C"].startswith("shin") and row["A"] == "foo":
+            row["D"] = 7
+        return row
+
+    def transform2(row):
+        if notna(row["C"]) and row["C"].startswith("shin") and row["A"] == "foo":
+            row["D"] = 7
+        return row
+
+    msg = "'float' object has no attribute 'startswith'"
+    with pytest.raises(AttributeError, match=msg):
+        data.apply(transform, axis=1)
+
+
+@pytest.mark.parametrize(
+    "df, func, expected",
+    tm.get_cython_table_params(
+        DataFrame([["a", "b"], ["b", "a"]]), [["cumprod", TypeError]]
+    ),
+)
+def test_agg_cython_table_raises(df, func, expected, axis):
+    # GH 21224
+    msg = "can't multiply sequence by non-int of type 'str'"
+    with pytest.raises(expected, match=msg):
+        df.agg(func, axis=axis)
+
+
+def test_transform_none_to_type():
+    # GH#34377
+    df = DataFrame({"a": [None]})
+    msg = "Transform function failed"
+    with pytest.raises(ValueError, match=msg):
+        df.transform({"a": int})
+
+
+def test_apply_broadcast_error(int_frame_const_col):
+    df = int_frame_const_col
+
+    # > 1 ndim
+    msg = "too many dims to broadcast"
+    with pytest.raises(ValueError, match=msg):
+        df.apply(
+            lambda x: np.array([1, 2]).reshape(-1, 2),
+            axis=1,
+            result_type="broadcast",
+        )
+
+    # cannot broadcast
+    msg = "cannot broadcast result"
+    with pytest.raises(ValueError, match=msg):
+        df.apply(lambda x: [1, 2], axis=1, result_type="broadcast")
+
+    with pytest.raises(ValueError, match=msg):
+        df.apply(lambda x: Series([1, 2]), axis=1, result_type="broadcast")
+
+
+def test_transform_and_agg_err_agg(axis, float_frame):
+    # cannot both transform and agg
+    msg = "cannot combine transform and aggregation operations"
+    with pytest.raises(ValueError, match=msg):
+        with np.errstate(all="ignore"):
+            float_frame.agg(["max", "sqrt"], axis=axis)
+
+    df = DataFrame({"A": range(5), "B": 5})
+
+    def f():
+        with np.errstate(all="ignore"):
+            df.agg({"A": ["abs", "sum"], "B": ["mean", "max"]}, axis=axis)
+
+
+def test_transform_and_agg_error_agg(string_series):
+    # we are trying to transform with an aggregator
+    msg = "cannot combine transform and aggregation"
+    with pytest.raises(ValueError, match=msg):
+        with np.errstate(all="ignore"):
+            string_series.agg(["sqrt", "max"])
+
+    msg = "cannot perform both aggregation and transformation"
+    with pytest.raises(ValueError, match=msg):
+        with np.errstate(all="ignore"):
+            string_series.agg({"foo": np.sqrt, "bar": "sum"})
+
+
+def test_transform_and_agg_err_transform(axis, float_frame):
+    # GH 35964
+    # cannot both transform and agg
+    msg = "Function did not transform"
+    with pytest.raises(ValueError, match=msg):
+        float_frame.transform(["max", "min"], axis=axis)
+
+    msg = "Function did not transform"
+    with pytest.raises(ValueError, match=msg):
+        float_frame.transform(["max", "sqrt"], axis=axis)
+
+
+def test_transform_reducer_raises(all_reductions, frame_or_series):
+    # GH 35964
+    op = all_reductions
+
+    obj = DataFrame({"A": [1, 2, 3]})
+    if frame_or_series is not DataFrame:
+        obj = obj["A"]
+
+    msg = "Function did not transform"
+    with pytest.raises(ValueError, match=msg):
+        obj.transform(op)
+    with pytest.raises(ValueError, match=msg):
+        obj.transform([op])
+    with pytest.raises(ValueError, match=msg):
+        obj.transform({"A": op})
+    with pytest.raises(ValueError, match=msg):
+        obj.transform({"A": [op]})
+
+
+def test_transform_wont_agg(string_series):
+    # GH 35964
+    # we are trying to transform with an aggregator
+    msg = "Function did not transform"
+    with pytest.raises(ValueError, match=msg):
+        string_series.transform(["min", "max"])
+
+    msg = "Function did not transform"
+    with pytest.raises(ValueError, match=msg):
+        with np.errstate(all="ignore"):
+            string_series.transform(["sqrt", "max"])

--- a/pandas/tests/apply/test_series_apply.py
+++ b/pandas/tests/apply/test_series_apply.py
@@ -182,18 +182,6 @@ def test_apply_datetimetz():
     tm.assert_series_equal(result, exp)
 
 
-def test_apply_dict_depr():
-
-    tsdf = DataFrame(
-        np.random.randn(10, 3),
-        columns=["A", "B", "C"],
-        index=pd.date_range("1/1/2000", periods=10),
-    )
-    msg = "nested renamer is not supported"
-    with pytest.raises(SpecificationError, match=msg):
-        tsdf.A.agg({"foo": ["sum", "mean"]})
-
-
 def test_apply_categorical():
     values = pd.Categorical(list("ABBABCD"), categories=list("DCBA"), ordered=True)
     ser = Series(values, name="XX", index=list("abcdefg"))
@@ -267,19 +255,6 @@ def test_transform(string_series):
 
         result = string_series.apply({"foo": np.sqrt, "bar": np.abs})
         tm.assert_series_equal(result.reindex_like(expected), expected)
-
-
-def test_transform_and_agg_error(string_series):
-    # we are trying to transform with an aggregator
-    msg = "cannot combine transform and aggregation"
-    with pytest.raises(ValueError, match=msg):
-        with np.errstate(all="ignore"):
-            string_series.agg(["sqrt", "max"])
-
-    msg = "cannot perform both aggregation and transformation"
-    with pytest.raises(ValueError, match=msg):
-        with np.errstate(all="ignore"):
-            string_series.agg({"foo": np.sqrt, "bar": "sum"})
 
 
 def test_demo():

--- a/pandas/tests/apply/test_series_transform.py
+++ b/pandas/tests/apply/test_series_transform.py
@@ -8,7 +8,6 @@ from pandas import (
     concat,
 )
 import pandas._testing as tm
-from pandas.core.base import SpecificationError
 from pandas.core.groupby.base import transformation_kernels
 
 # tshift only works on time index and is deprecated
@@ -66,30 +65,3 @@ def test_transform_dictlike_mixed():
         columns=MultiIndex([("b", "c"), ("sqrt", "abs")], [(0, 0, 1), (0, 1, 0)]),
     )
     tm.assert_frame_equal(result, expected)
-
-
-def test_transform_wont_agg(string_series):
-    # GH 35964
-    # we are trying to transform with an aggregator
-    msg = "Function did not transform"
-    with pytest.raises(ValueError, match=msg):
-        string_series.transform(["min", "max"])
-
-    msg = "Function did not transform"
-    with pytest.raises(ValueError, match=msg):
-        with np.errstate(all="ignore"):
-            string_series.transform(["sqrt", "max"])
-
-
-def test_transform_axis_1_raises():
-    # GH 35964
-    msg = "No axis named 1 for object type Series"
-    with pytest.raises(ValueError, match=msg):
-        Series([1]).transform("sum", axis=1)
-
-
-def test_transform_nested_renamer():
-    # GH 35964
-    match = "nested renamer is not supported"
-    with pytest.raises(SpecificationError, match=match):
-        Series([1]).transform({"A": {"B": ["sum"]}})

--- a/pandas/tests/apply/test_series_transform.py
+++ b/pandas/tests/apply/test_series_transform.py
@@ -6,7 +6,6 @@ from pandas import (
     concat,
 )
 import pandas._testing as tm
-from pandas.core.base import SpecificationError
 from pandas.core.groupby.base import transformation_kernels
 
 # tshift only works on time index and is deprecated
@@ -53,30 +52,3 @@ def test_transform_dictlike(string_series, box):
     expected.columns = ["foo", "bar"]
     result = string_series.transform(box({"foo": np.sqrt, "bar": np.abs}))
     tm.assert_frame_equal(result, expected)
-
-
-def test_transform_wont_agg(string_series):
-    # GH 35964
-    # we are trying to transform with an aggregator
-    msg = "Function did not transform"
-    with pytest.raises(ValueError, match=msg):
-        string_series.transform(["min", "max"])
-
-    msg = "Function did not transform"
-    with pytest.raises(ValueError, match=msg):
-        with np.errstate(all="ignore"):
-            string_series.transform(["sqrt", "max"])
-
-
-def test_transform_axis_1_raises():
-    # GH 35964
-    msg = "No axis named 1 for object type Series"
-    with pytest.raises(ValueError, match=msg):
-        Series([1]).transform("sum", axis=1)
-
-
-def test_transform_nested_renamer():
-    # GH 35964
-    match = "nested renamer is not supported"
-    with pytest.raises(SpecificationError, match=match):
-        Series([1]).transform({"A": {"B": ["sum"]}})


### PR DESCRIPTION
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

Moves relevant tests into test_invalid_arg. Had to rename two tests because they were of the same name, but no other changes. I organized the file by the reason for the exception, and indicated this at the top of the file. Certainly open to any other ways of organizing.