### PR TITLE
TST: Fix pandas.io.stata imports in test_stata.py

### DIFF
--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -31,6 +31,7 @@ from pandas.io.stata import (
     StataMissingValue,
     StataReader,
     StataWriterUTF8,
+    ValueLabelTypeMismatch,
     read_stata,
 )
 
@@ -435,7 +436,7 @@ class TestStata:
         formatted = formatted.astype(np.int32)
 
         with tm.ensure_clean() as path:
-            with tm.assert_produces_warning(io.stata.InvalidColumnName):
+            with tm.assert_produces_warning(InvalidColumnName):
                 original.to_stata(path, None)
 
             written_and_read_again = self.read_dta(path)
@@ -1022,7 +1023,7 @@ class TestStata:
             [original[col].astype("category") for col in original], axis=1
         )
 
-        with tm.assert_produces_warning(io.stata.ValueLabelTypeMismatch):
+        with tm.assert_produces_warning(ValueLabelTypeMismatch):
             original.to_stata(path)
             # should get a warning for mixed content
 
@@ -1652,7 +1653,7 @@ The repeated labels are:\n-+\nwolof
         )
         original.index.name = "index"
 
-        with tm.assert_produces_warning(io.stata.InvalidColumnName):
+        with tm.assert_produces_warning(InvalidColumnName):
             with tm.ensure_clean() as path:
                 original.to_stata(path, convert_strl=["long", 1], version=117)
                 reread = self.read_dta(path)


### PR DESCRIPTION
- [x] Fixes test failures introduced in #40069
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

