### PR TITLE
REF: unify casting logic in Categorical.__init__

### DIFF
--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -42,6 +42,12 @@ class TestCategoricalConstructors:
         with tm.assert_produces_warning(FutureWarning):
             Categorical("A", categories=["A", "B"])
 
+    def test_categorical_1d_only(self):
+        # ndim > 1
+        msg = "> 1 ndim Categorical are not supported at this time"
+        with pytest.raises(NotImplementedError, match=msg):
+            Categorical(np.array([list("abcd")]))
+
     def test_validate_ordered(self):
         # see gh-14058
         exp_msg = "'ordered' must either be 'True' or 'False'"

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2062,13 +2062,6 @@ class TestDataFrameConstructors:
         with pytest.raises(ValueError, match=msg):
             DataFrame([Categorical(list("abc")), Categorical(list("abdefg"))])
 
-    def test_categorical_1d_only(self):
-        # TODO: belongs in Categorical tests
-        # ndim > 1
-        msg = "> 1 ndim Categorical are not supported at this time"
-        with pytest.raises(NotImplementedError, match=msg):
-            Categorical(np.array([list("abcd")]))
-
     def test_constructor_categorical_series(self):
 
         items = [1, 2, 3, 1]


### PR DESCRIPTION
Big picture, trying to call maybe_infer_to_datetimelike in fewer places so we can simplify scattered datetimelike casting.
