### PR TITLE
TYP only set default for one overloaded function in reset_index

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5098,9 +5098,7 @@ class DataFrame(NDFrame, OpsMixin):
             return frame
 
     @overload
-    # https://github.com/python/mypy/issues/6580
-    # Overloaded function signatures 1 and 2 overlap with incompatible return types
-    def reset_index(  # type: ignore[misc]
+    def reset_index(
         self,
         level: Optional[Union[Hashable, Sequence[Hashable]]] = ...,
         drop: bool = ...,
@@ -5113,11 +5111,11 @@ class DataFrame(NDFrame, OpsMixin):
     @overload
     def reset_index(
         self,
-        level: Optional[Union[Hashable, Sequence[Hashable]]] = ...,
-        drop: bool = ...,
-        inplace: Literal[True] = ...,
-        col_level: Hashable = ...,
-        col_fill: Hashable = ...,
+        level: Optional[Union[Hashable, Sequence[Hashable]]],
+        drop: bool,
+        inplace: Literal[True],
+        col_level: Hashable,
+        col_fill: Hashable,
     ) -> None:
         ...
 


### PR DESCRIPTION
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

@simonjayhawkins I think we only need `=...` in one of the two overloads, then the error goes away and all passes:
```console
$ mypy pandas
Success: no issues found in 1244 source files
```