### PR TITLE
STYLE: Inconsistent namespace - dtypes (pandas-dev#39992)

### DIFF
--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -821,7 +821,7 @@ class TestCategoricalDtypeParametrized:
             np.arange(1000),
             ["a", "b", 10, 2, 1.3, True],
             [True, False],
-            pd.date_range("2017", periods=4),
+            date_range("2017", periods=4),
         ],
     )
     def test_basic(self, categories, ordered):

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -808,7 +808,7 @@ class TestTypeInference:
             (object, None, True, "empty"),
         ],
     )
-    @pytest.mark.parametrize("box", [pd.Series, np.array])
+    @pytest.mark.parametrize("box", [Series, np.array])
     def test_object_empty(self, box, missing, dtype, skipna, expected):
         # GH 23421
         arr = box([missing, missing], dtype=dtype)
@@ -915,7 +915,7 @@ class TestTypeInference:
         arr = np.array([Period("2011-01", freq="D"), Period("2011-02", freq="M")])
         assert lib.infer_dtype(arr, skipna=True) == "period"
 
-    @pytest.mark.parametrize("klass", [pd.array, pd.Series, pd.Index])
+    @pytest.mark.parametrize("klass", [pd.array, Series, Index])
     @pytest.mark.parametrize("skipna", [True, False])
     def test_infer_dtype_period_array(self, klass, skipna):
         # https://github.com/pandas-dev/pandas/issues/23553
@@ -1264,7 +1264,7 @@ class TestTypeInference:
         inferred = lib.infer_dtype(Series(idx), skipna=False)
         assert inferred == "interval"
 
-    @pytest.mark.parametrize("klass", [pd.array, pd.Series])
+    @pytest.mark.parametrize("klass", [pd.array, Series])
     @pytest.mark.parametrize("skipna", [True, False])
     @pytest.mark.parametrize("data", [["a", "b", "c"], ["a", "b", pd.NA]])
     def test_string_dtype(self, data, skipna, klass):
@@ -1273,7 +1273,7 @@ class TestTypeInference:
         inferred = lib.infer_dtype(val, skipna=skipna)
         assert inferred == "string"
 
-    @pytest.mark.parametrize("klass", [pd.array, pd.Series])
+    @pytest.mark.parametrize("klass", [pd.array, Series])
     @pytest.mark.parametrize("skipna", [True, False])
     @pytest.mark.parametrize("data", [[True, False, True], [True, False, pd.NA]])
     def test_boolean_dtype(self, data, skipna, klass):

--- a/pandas/tests/dtypes/test_missing.py
+++ b/pandas/tests/dtypes/test_missing.py
@@ -205,16 +205,16 @@ class TestIsNA:
 
     def test_isna_old_datetimelike(self):
         # isna_old should work for dt64tz, td64, and period, not just tznaive
-        dti = pd.date_range("2016-01-01", periods=3)
+        dti = date_range("2016-01-01", periods=3)
         dta = dti._data
-        dta[-1] = pd.NaT
+        dta[-1] = NaT
         expected = np.array([False, False, True], dtype=bool)
 
         objs = [dta, dta.tz_localize("US/Eastern"), dta - dta, dta.to_period("D")]
 
         for obj in objs:
             with cf.option_context("mode.use_inf_as_na", True):
-                result = pd.isna(obj)
+                result = isna(obj)
 
             tm.assert_numpy_array_equal(result, expected)
 
@@ -320,38 +320,38 @@ class TestIsNA:
     def test_decimal(self):
         # scalars GH#23530
         a = Decimal(1.0)
-        assert pd.isna(a) is False
-        assert pd.notna(a) is True
+        assert isna(a) is False
+        assert notna(a) is True
 
         b = Decimal("NaN")
-        assert pd.isna(b) is True
-        assert pd.notna(b) is False
+        assert isna(b) is True
+        assert notna(b) is False
 
         # array
         arr = np.array([a, b])
         expected = np.array([False, True])
-        result = pd.isna(arr)
+        result = isna(arr)
         tm.assert_numpy_array_equal(result, expected)
 
-        result = pd.notna(arr)
+        result = notna(arr)
         tm.assert_numpy_array_equal(result, ~expected)
 
         # series
         ser = Series(arr)
         expected = Series(expected)
-        result = pd.isna(ser)
+        result = isna(ser)
         tm.assert_series_equal(result, expected)
 
-        result = pd.notna(ser)
+        result = notna(ser)
         tm.assert_series_equal(result, ~expected)
 
         # index
         idx = pd.Index(arr)
         expected = np.array([False, True])
-        result = pd.isna(idx)
+        result = isna(idx)
         tm.assert_numpy_array_equal(result, expected)
 
-        result = pd.notna(idx)
+        result = notna(idx)
         tm.assert_numpy_array_equal(result, ~expected)
 
 
@@ -578,7 +578,7 @@ class TestNAObj:
             tm.assert_numpy_array_equal(result, expected)
 
     def test_basic(self):
-        arr = np.array([1, None, "foo", -5.1, pd.NaT, np.nan])
+        arr = np.array([1, None, "foo", -5.1, NaT, np.nan])
         expected = np.array([False, True, False, False, True, True])
 
         self._check_behavior(arr, expected)


### PR DESCRIPTION
- [x] xref #39992 
- [ ] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
