### PR TITLE
BUG: EWM.__getitem__ raised error with times

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -516,8 +516,8 @@ Groupby/resample/rolling
 - Bug in :meth:`DataFrameGroupBy.sample` where error was raised when ``weights`` was specified and the index was an :class:`Int64Index` (:issue:`39927`)
 - Bug in :meth:`DataFrameGroupBy.aggregate` and :meth:`.Resampler.aggregate` would sometimes raise ``SpecificationError`` when passed a dictionary and columns were missing; will now always raise a ``KeyError`` instead (:issue:`40004`)
 - Bug in :meth:`DataFrameGroupBy.sample` where column selection was not applied to sample result (:issue:`39928`)
-- Bug in :class:`core.window.ewm.ExponentialMovingWindow` when calling ``__getitem__`` would incorrectly raise a ``ValueError`` when providing ``times`` (:issue:``)
-- Bug in :class:`core.window.ewm.ExponentialMovingWindow` when calling ``__getitem__`` would not retain ``com``, ``span``, ``alpha`` or ``halflife`` attributes  (:issue:``)
+- Bug in :class:`core.window.ewm.ExponentialMovingWindow` when calling ``__getitem__`` would incorrectly raise a ``ValueError`` when providing ``times`` (:issue:`40164`)
+- Bug in :class:`core.window.ewm.ExponentialMovingWindow` when calling ``__getitem__`` would not retain ``com``, ``span``, ``alpha`` or ``halflife`` attributes  (:issue:`40164`)
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -516,7 +516,8 @@ Groupby/resample/rolling
 - Bug in :meth:`DataFrameGroupBy.sample` where error was raised when ``weights`` was specified and the index was an :class:`Int64Index` (:issue:`39927`)
 - Bug in :meth:`DataFrameGroupBy.aggregate` and :meth:`.Resampler.aggregate` would sometimes raise ``SpecificationError`` when passed a dictionary and columns were missing; will now always raise a ``KeyError`` instead (:issue:`40004`)
 - Bug in :meth:`DataFrameGroupBy.sample` where column selection was not applied to sample result (:issue:`39928`)
--
+- Bug in :class:`core.window.ewm.ExponentialMovingWindow` when calling ``__getitem__`` would incorrectly raise a ``ValueError`` when providing ``times`` (:issue:``)
+- Bug in :class:`core.window.ewm.ExponentialMovingWindow` when calling ``__getitem__`` would not retain ``com``, ``span``, ``alpha`` or ``halflife`` attributes  (:issue:``)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -1476,7 +1476,7 @@ def roll_weighted_var(const float64_t[:] values, const float64_t[:] weights,
 
 def ewma(const float64_t[:] vals, const int64_t[:] start, const int64_t[:] end,
          int minp, float64_t com, bint adjust, bint ignore_na,
-         const float64_t[:] times, float64_t halflife):
+         const float64_t[:] deltas):
     """
     Compute exponentially-weighted moving average using center-of-mass.
 
@@ -1501,7 +1501,7 @@ def ewma(const float64_t[:] vals, const int64_t[:] start, const int64_t[:] end,
         Py_ssize_t i, j, s, e, nobs, win_size, N = len(vals), M = len(start)
         const float64_t[:] sub_vals
         ndarray[float64_t] sub_output, output = np.empty(N, dtype=float)
-        float64_t alpha, old_wt_factor, new_wt, weighted_avg, old_wt, cur, delta
+        float64_t alpha, old_wt_factor, new_wt, weighted_avg, old_wt, cur
         bint is_observation
 
     if N == 0:
@@ -1532,8 +1532,7 @@ def ewma(const float64_t[:] vals, const int64_t[:] start, const int64_t[:] end,
                 if weighted_avg == weighted_avg:
 
                     if is_observation or not ignore_na:
-                        delta = times[i] - times[i - 1]
-                        old_wt *= old_wt_factor ** (delta / halflife)
+                        old_wt *= old_wt_factor ** deltas[i - 1]
                         if is_observation:
 
                             # avoid numerical errors on constant series

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -285,7 +285,7 @@ class ExponentialMovingWindow(BaseWindow):
                     "times is not None."
                 )
             # Without times, points are equally spaced
-            self._deltas = np.ones(len(self.obj) - 1, dtype=np.float64)
+            self._deltas = np.ones(max(len(self.obj) - 1, 0), dtype=np.float64)
             self._com = get_center_of_mass(
                 self.com, self.span, self.halflife, self.alpha
             )

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -215,11 +215,13 @@ class ExponentialMovingWindow(BaseWindow):
 
     _attributes = [
         "com",
+        "span",
+        "halflife",
+        "alpha",
         "min_periods",
         "adjust",
         "ignore_na",
         "axis",
-        "halflife",
         "times",
     ]
 
@@ -245,10 +247,13 @@ class ExponentialMovingWindow(BaseWindow):
             method="single",
             axis=axis,
         )
+        self.com = com
+        self.span = span
+        self.halflife = halflife
+        self.alpha = alpha
         self.adjust = adjust
         self.ignore_na = ignore_na
         self.times = times
-        self.halflife = halflife
         if self.times is not None:
             if isinstance(times, str):
                 self.times = self._selected_obj[times]
@@ -267,19 +272,23 @@ class ExponentialMovingWindow(BaseWindow):
             self._deltas = np.diff(_times) / _halflife
             # Halflife is no longer applicable when calculating COM
             # But allow COM to still be calculated if the user passes other decay args
-            if common.count_not_none(com, span, alpha) > 0:
-                self.com = get_center_of_mass(com, span, None, alpha)
+            if common.count_not_none(self.com, self.span, self.alpha) > 0:
+                self._com = get_center_of_mass(self.com, self.span, None, self.alpha)
             else:
-                self.com = 0.0
+                self._com = 1.0
         else:
-            if halflife is not None and isinstance(halflife, (str, datetime.timedelta)):
+            if self.halflife is not None and isinstance(
+                self.halflife, (str, datetime.timedelta)
+            ):
                 raise ValueError(
                     "halflife can only be a timedelta convertible argument if "
                     "times is not None."
                 )
             # Without times, points are equally spaced
             self._deltas = np.ones(len(self.obj) - 1, dtype=np.float64)
-            self.com = get_center_of_mass(com, span, halflife, alpha)
+            self._com = get_center_of_mass(
+                self.com, self.span, self.halflife, self.alpha
+            )
 
     def _get_window_indexer(self) -> BaseIndexer:
         """
@@ -337,14 +346,10 @@ class ExponentialMovingWindow(BaseWindow):
     )
     def mean(self, *args, **kwargs):
         nv.validate_window_func("mean", args, kwargs)
-        if self.times is not None:
-            com = 1.0
-        else:
-            com = self.com
         window_func = window_aggregations.ewma
         window_func = partial(
             window_func,
-            com=com,
+            com=self._com,
             adjust=self.adjust,
             ignore_na=self.ignore_na,
             deltas=self._deltas,
@@ -409,7 +414,7 @@ class ExponentialMovingWindow(BaseWindow):
         window_func = window_aggregations.ewmcov
         window_func = partial(
             window_func,
-            com=self.com,
+            com=self._com,
             adjust=self.adjust,
             ignore_na=self.ignore_na,
             bias=bias,
@@ -478,7 +483,7 @@ class ExponentialMovingWindow(BaseWindow):
                 end,
                 self.min_periods,
                 y_array,
-                self.com,
+                self._com,
                 self.adjust,
                 self.ignore_na,
                 bias,
@@ -544,7 +549,7 @@ class ExponentialMovingWindow(BaseWindow):
                     end,
                     self.min_periods,
                     Y,
-                    self.com,
+                    self._com,
                     self.adjust,
                     self.ignore_na,
                     1,
@@ -611,7 +616,7 @@ class ExponentialMovingWindowGroupby(BaseWindowGroupby, ExponentialMovingWindow)
         if maybe_use_numba(engine):
             groupby_ewma_func = generate_numba_groupby_ewma_func(
                 engine_kwargs,
-                self.com,
+                self._com,
                 self.adjust,
                 self.ignore_na,
             )

--- a/pandas/tests/window/test_ewm.py
+++ b/pandas/tests/window/test_ewm.py
@@ -143,6 +143,7 @@ def test_ewm_with_nat_raises(halflife_with_times):
 
 
 def test_ewm_with_times_getitem(halflife_with_times):
+    # GH 40164
     halflife = halflife_with_times
     data = np.arange(10.0)
     data[::2] = np.nan
@@ -155,6 +156,7 @@ def test_ewm_with_times_getitem(halflife_with_times):
 
 @pytest.mark.parametrize("arg", ["com", "halflife", "span", "alpha"])
 def test_ewm_getitem_attributes_retained(arg, adjust, ignore_na):
+    # GH 40164
     kwargs = {arg: 1, "adjust": adjust, "ignore_na": ignore_na}
     ewm = DataFrame({"A": range(1), "B": range(1)}).ewm(**kwargs)
     expected = {attr: getattr(ewm, attr) for attr in ewm._attributes}

--- a/pandas/tests/window/test_ewm.py
+++ b/pandas/tests/window/test_ewm.py
@@ -142,6 +142,27 @@ def test_ewm_with_nat_raises(halflife_with_times):
         ser.ewm(com=0.1, halflife=halflife_with_times, times=times)
 
 
+def test_ewm_with_times_getitem(halflife_with_times):
+    halflife = halflife_with_times
+    data = np.arange(10.0)
+    data[::2] = np.nan
+    times = date_range("2000", freq="D", periods=10)
+    df = DataFrame({"A": data, "B": data})
+    result = df.ewm(halflife=halflife, times=times)["A"].mean()
+    expected = df.ewm(halflife=1.0)["A"].mean()
+    tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("arg", ["com", "halflife", "span", "alpha"])
+def test_ewm_getitem_attributes_retained(arg, adjust, ignore_na):
+    kwargs = {arg: 1, "adjust": adjust, "ignore_na": ignore_na}
+    ewm = DataFrame({"A": range(1), "B": range(1)}).ewm(**kwargs)
+    expected = {attr: getattr(ewm, attr) for attr in ewm._attributes}
+    ewm_slice = ewm["A"]
+    result = {attr: getattr(ewm, attr) for attr in ewm_slice._attributes}
+    assert result == expected
+
+
 def test_ewm_vol_deprecated():
     ser = Series(range(1))
     with tm.assert_produces_warning(FutureWarning):


### PR DESCRIPTION
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry


Also somewhat ameliorates the performance hit in https://github.com/pandas-dev/pandas/pull/40072#issuecomment-787456038

```
dtype="float"
window=1000
N = 10 ** 5
arr = (100 * np.random.random(N)).astype(dtype)
ewm = pd.Series(arr).ewm(halflife=window)

%timeit ewm.mean()
# Master
2.59 ms ± 25.5 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# PR
2.5 ms ± 31.5 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```