### PR TITLE
REF: remove internal Block usage from FrameColumnApply

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -883,9 +883,8 @@ class FrameColumnApply(FrameApply):
         #  of it.  Kids: don't do this at home.
         ser = self.obj._ixs(0, axis=0)
         mgr = ser._mgr
-        blk = mgr.blocks[0]
 
-        if is_extension_array_dtype(blk.dtype):
+        if is_extension_array_dtype(ser.dtype):
             # values will be incorrect for this block
             # TODO(EA2D): special case would be unnecessary with 2D EAs
             obj = self.obj
@@ -896,7 +895,7 @@ class FrameColumnApply(FrameApply):
             for (arr, name) in zip(values, self.index):
                 # GH#35462 re-pin mgr in case setitem changed it
                 ser._mgr = mgr
-                blk.values = arr
+                ser._mgr.set_values(arr)
                 ser.name = name
                 yield ser
 

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -895,7 +895,7 @@ class FrameColumnApply(FrameApply):
             for (arr, name) in zip(values, self.index):
                 # GH#35462 re-pin mgr in case setitem changed it
                 ser._mgr = mgr
-                ser._mgr.set_values(arr)
+                mgr.set_values(arr)
                 ser.name = name
                 yield ser
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1646,6 +1646,15 @@ class SingleBlockManager(BlockManager):
         """
         raise NotImplementedError("Use series._values[loc] instead")
 
+    def set_values(self, values):
+        """
+        Set the values of the single block in place.
+
+        Use at your own risk! This does not check if the passed values are
+        valid for the current Block/SingleBlockManager (length, dtype, etc).
+        """
+        self.blocks[0].values = values
+
 
 # --------------------------------------------------------------------
 # Constructor Helpers

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1646,7 +1646,7 @@ class SingleBlockManager(BlockManager):
         """
         raise NotImplementedError("Use series._values[loc] instead")
 
-    def set_values(self, values):
+    def set_values(self, values: ArrayLike):
         """
         Set the values of the single block in place.
 


### PR DESCRIPTION
In the `apply` code, there is still one case where we are directly using the internal blocks. This moves that to a method on the manager, so we don't have to interact directly with the blocks (which ideally we don't want outside of the internals, and let's ArrayManager cleanly support this as well). 

For the rest it still updates the Series' values in place, preserving the performance trick.

cc @jbrockmendel @rhshadrach 