### PR TITLE
[ArrayManager] Add libreduction frame Slider for ArrayManager

### DIFF
--- a/pandas/_libs/reduction.pyx
+++ b/pandas/_libs/reduction.pyx
@@ -527,7 +527,6 @@ cdef class ArraySlider(FrameSlider):
 
         # GH#35417 attributes we need to restore at each step in case
         #  the function modified them.
-        mgr = self.dummy._mgrs
         self.orig_arrays = self.dummy._mgr.arrays
         self.arrays = list(self.dummy._mgr.arrays)
 

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -71,6 +71,7 @@ from pandas.core.dtypes.missing import (
 )
 
 import pandas.core.algorithms as algorithms
+from pandas.core.arrays import ExtensionArray
 from pandas.core.base import SelectionMixin
 import pandas.core.common as com
 from pandas.core.frame import DataFrame
@@ -214,11 +215,15 @@ class BaseGrouper:
             #  if we pass EA instead of ndarray
             #  TODO: can we have a workaround for EAs backed by ndarray?
             pass
-
-        elif isinstance(sdata._mgr, ArrayManager):
-            # TODO(ArrayManager) don't use fast_apply / libreduction.apply_frame_axis0
-            # for now -> relies on BlockManager internals
+        elif (
+            sdata.ndim == 2
+            and isinstance(sdata._mgr, ArrayManager)
+            and any(isinstance(arr, ExtensionArray) for arr in sdata._mgr.arrays)
+        ):
+            # For ArrayManager, we also store datetime-like data as EAs, although
+            # their dtype is not an extension array dtype (so the above check passes)
             pass
+
         elif (
             com.get_callable_name(f) not in base.plotting_methods
             and isinstance(splitter, FrameSplitter)


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/39146 and follow-up on https://github.com/pandas-dev/pandas/pull/40050#discussion_r583042707

While getting groupby working for ArrayManager in https://github.com/pandas-dev/pandas/pull/40050, I didn't yet use `fast_apply` / `libreduction.apply_frame_axis0` because that relies on BlockManager internals. But, `libreduction` is faster than the python fallback (luckily, otherwise we would have it for nothing ;)).

So this PR is adding a version of the `BlockSlider` but then for a frame backed by an ArrayManager. 

I didn't combine `BlockSlider` / `ArraySlider` in a single class for now (first wanted to get it working). I assume it would be "possible" with some gymnastics (there are several details that are different, such as different strides/shape index being used to move, access to `blklocs`/`blklocs`, etc). 
So personally I would prefer keeping it as a separate class (certainly given that we don't intend to keep both long term, I think)

For benchmarks, we have `groupby.Apply.time_scalar_function_single/multi_col` that exercises this fast path, and this PR brings the ArrayManager code path back on par with the BlockManager version (before this PR, that benchmark saw a 3x slowdown because of using the python fallback).



