### PR TITLE
BUG: more specific .drop() message when keys not found

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5866,7 +5866,7 @@ class Index(IndexOpsMixin, PandasObject):
         mask = indexer == -1
         if mask.any():
             if errors != "ignore":
-                raise KeyError(f"{labels[mask]} not found in axis")
+                raise KeyError(f"{labels[mask]} not found in columns")
             indexer = indexer[~mask]
         return self.delete(indexer)
 


### PR DESCRIPTION
Changed "not found in axis" to "not found in columns"

- [x] closes #40160 
