### PR TITLE
Make Index.all compatible with numpy.all

### DIFF
--- a/doc/source/whatsnew/v1.2.4.rst
+++ b/doc/source/whatsnew/v1.2.4.rst
@@ -35,7 +35,7 @@ Bug fixes
 Other
 ~~~~~
 
-- Allow :class:`Index` to be passed to the numpy ``all`` function.
+-
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.2.4.rst
+++ b/doc/source/whatsnew/v1.2.4.rst
@@ -35,7 +35,7 @@ Bug fixes
 Other
 ~~~~~
 
--
+- Allow :class:`Index` to be passed to the numpy ``all`` function.
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -539,6 +539,8 @@ Reshaping
 - Bug in :meth:`DataFrame.append` returning incorrect dtypes with combinations of ``ExtensionDtype`` dtypes (:issue:`39454`)
 - Bug in :meth:`DataFrame.append` returning incorrect dtypes with combinations of ``datetime64`` and ``timedelta64`` dtypes (:issue:`39574`)
 - Bug in :meth:`DataFrame.pivot_table` returning a ``MultiIndex`` for a single value when operating on and empty ``DataFrame`` (:issue:`13483`)
+- Allow :class:`Index` to be passed to the :func:`numpy.all` function (:issue:`40180`)
+-
 
 Sparse
 ^^^^^^

--- a/pandas/compat/numpy/function.py
+++ b/pandas/compat/numpy/function.py
@@ -212,6 +212,7 @@ ALLANY_DEFAULTS: Dict[str, Optional[bool]] = {}
 ALLANY_DEFAULTS["dtype"] = None
 ALLANY_DEFAULTS["out"] = None
 ALLANY_DEFAULTS["keepdims"] = False
+ALLANY_DEFAULTS["axis"] = None
 validate_all = CompatValidator(
     ALLANY_DEFAULTS, fname="all", method="both", max_fname_arg_count=1
 )

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5994,10 +5994,11 @@ class Index(IndexOpsMixin, PandasObject):
         False
         """
         # FIXME: docstr inaccurate, args/kwargs not passed
+        nv.validate_any(args, kwargs)
         self._maybe_disable_logical_methods("any")
         return np.any(self.values)
 
-    def all(self):
+    def all(self, *args, **kwargs):
         """
         Return whether all elements are Truthy.
 
@@ -6052,6 +6053,7 @@ class Index(IndexOpsMixin, PandasObject):
         """
         # FIXME: docstr inaccurate, args/kwargs not passed
 
+        nv.validate_all(args, kwargs)
         self._maybe_disable_logical_methods("all")
         return np.all(self.values)
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5964,9 +5964,9 @@ class Index(IndexOpsMixin, PandasObject):
         Parameters
         ----------
         *args
-            These parameters will be passed to numpy.any.
+            Required for compatibility with numpy.
         **kwargs
-            These parameters will be passed to numpy.any.
+            Required for compatibility with numpy.
 
         Returns
         -------
@@ -5993,7 +5993,6 @@ class Index(IndexOpsMixin, PandasObject):
         >>> index.any()
         False
         """
-        # FIXME: docstr inaccurate, args/kwargs not passed
         nv.validate_any(args, kwargs)
         self._maybe_disable_logical_methods("any")
         return np.any(self.values)
@@ -6005,9 +6004,9 @@ class Index(IndexOpsMixin, PandasObject):
         Parameters
         ----------
         *args
-            These parameters will be passed to numpy.all.
+            Required for compatibility with numpy.
         **kwargs
-            These parameters will be passed to numpy.all.
+            Required for compatibility with numpy.
 
         Returns
         -------
@@ -6051,8 +6050,6 @@ class Index(IndexOpsMixin, PandasObject):
         >>> pd.Index([0, 0, 0]).any()
         False
         """
-        # FIXME: docstr inaccurate, args/kwargs not passed
-
         nv.validate_all(args, kwargs)
         self._maybe_disable_logical_methods("all")
         return np.all(self.values)

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -550,6 +550,14 @@ class TestIndexReductions:
         assert ci.min() == "c"
         assert ci.max() == "b"
 
+    @pytest.mark.parametrize("op", ["any", "all"])
+    def test_numpy_any_all(self, op):
+        idx = Index([0, 1, 2])
+        assert not np.all(idx)
+        assert np.any(idx)
+        idx = Index([1, 2, 3])
+        assert np.all(idx)
+
 
 class TestSeriesReductions:
     # Note: the name TestSeriesReductions indicates these tests

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -550,8 +550,7 @@ class TestIndexReductions:
         assert ci.min() == "c"
         assert ci.max() == "b"
 
-    @pytest.mark.parametrize("op", ["any", "all"])
-    def test_numpy_any_all(self, op):
+    def test_numpy_any_all(self):
         idx = Index([0, 1, 2])
         assert not np.all(idx)
         assert np.any(idx)

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -550,13 +550,6 @@ class TestIndexReductions:
         assert ci.min() == "c"
         assert ci.max() == "b"
 
-    def test_numpy_any_all(self):
-        idx = Index([0, 1, 2])
-        assert not np.all(idx)
-        assert np.any(idx)
-        idx = Index([1, 2, 3])
-        assert np.all(idx)
-
 
 class TestSeriesReductions:
     # Note: the name TestSeriesReductions indicates these tests
@@ -904,6 +897,15 @@ class TestSeriesReductions:
         # Alternative types, with implicit 'object' dtype.
         s = Series(["abc", True])
         assert "abc" == s.any()  # 'abc' || True => 'abc'
+
+    @pytest.mark.parametrize("klass", [Index, Series])
+    def test_numpy_all_any(self, klass):
+        # GH#40180
+        idx = klass([0, 1, 2])
+        assert not np.all(idx)
+        assert np.any(idx)
+        idx = Index([1, 2, 3])
+        assert np.all(idx)
 
     def test_all_any_params(self):
         # Check skipna, with implicit 'object' dtype.


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

Due to a bug in my own code, I discovered that `pandas.Index` objects cannot be passed to the `numpy.all` function:

```python
In [1]: import numpy as np

In [2]: import pandas as pd

In [3]: idx = pd.Int64Index([1,2,3,4,5])

In [4]: np.all(idx)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-597ac8c43e48> in <module>
----> 1 np.all(idx)

<__array_function__ internals> in all(*args, **kwargs)

~/venvs/funpack.venv/lib/python3.7/site-packages/numpy/core/fromnumeric.py in all(a, axis, out, keepdims, where)
   2437     """
   2438     return _wrapreduction(a, np.logical_and, 'all', axis, None, out,
-> 2439                           keepdims=keepdims, where=where)
   2440
   2441

~/venvs/funpack.venv/lib/python3.7/site-packages/numpy/core/fromnumeric.py in _wrapreduction(obj, ufunc, method, axis, dtype, out, **kwargs)
     83                 return reduction(axis=axis, dtype=dtype, out=out, **passkwargs)
     84             else:
---> 85                 return reduction(axis=axis, out=out, **passkwargs)
     86
     87     return ufunc.reduce(obj, axis, dtype, out, **passkwargs)

TypeError: all() got an unexpected keyword argument 'axis'
```

Using [this PR](https://github.com/pandas-dev/pandas/pull/26324/) as precedent, the fix is quite straightforward. 
