### PR TITLE
REF: move mixed-int handling from maybe_cast_to_datetime

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1904,6 +1904,23 @@ default 'raise'
 # Constructor Helpers
 
 
+def sequence_to_datetimes(
+    data, allow_object: bool = False
+) -> Union[np.ndarray, DatetimeArray]:
+    """
+    Parse/convert the passed data to either DatetimeArray or np.ndarray[object].
+    """
+    result, tz, freq = sequence_to_dt64ns(
+        data, allow_object=allow_object, allow_mixed=True
+    )
+    if result.dtype == object:
+        return result
+
+    dtype = tz_to_dtype(tz)
+    dta = DatetimeArray._simple_new(result, freq=freq, dtype=dtype)
+    return dta
+
+
 def sequence_to_dt64ns(
     data,
     dtype=None,
@@ -1912,6 +1929,9 @@ def sequence_to_dt64ns(
     dayfirst=False,
     yearfirst=False,
     ambiguous="raise",
+    *,
+    allow_object: bool = False,
+    allow_mixed: bool = False,
 ):
     """
     Parameters
@@ -1924,6 +1944,11 @@ def sequence_to_dt64ns(
     yearfirst : bool, default False
     ambiguous : str, bool, or arraylike, default 'raise'
         See pandas._libs.tslibs.tzconversion.tz_localize_to_utc.
+    allow_object : bool, default False
+        Whether to return an object-dtype ndarray instead of raising if the
+        data contains more than one timezone.
+    allow_mixed : bool, default False
+        Interpret integers as timestamps when datetime objects are also present.
 
     Returns
     -------
@@ -1987,7 +2012,11 @@ def sequence_to_dt64ns(
             # data comes back here as either i8 to denote UTC timestamps
             #  or M8[ns] to denote wall times
             data, inferred_tz = objects_to_datetime64ns(
-                data, dayfirst=dayfirst, yearfirst=yearfirst
+                data,
+                dayfirst=dayfirst,
+                yearfirst=yearfirst,
+                allow_object=allow_object,
+                allow_mixed=allow_mixed,
             )
             if tz and inferred_tz:
                 #  two timezones: convert to intended from base UTC repr
@@ -1995,6 +2024,9 @@ def sequence_to_dt64ns(
                 data = data.view(DT64NS_DTYPE)
             elif inferred_tz:
                 tz = inferred_tz
+            elif allow_object and data.dtype == object:
+                # We encountered mixed-timezones.
+                return data, None, None
 
         data_dtype = data.dtype
 
@@ -2053,6 +2085,7 @@ def objects_to_datetime64ns(
     errors="raise",
     require_iso8601=False,
     allow_object=False,
+    allow_mixed: bool = False,
 ):
     """
     Convert data to array of timestamps.
@@ -2069,6 +2102,8 @@ def objects_to_datetime64ns(
     allow_object : bool
         Whether to return an object-dtype ndarray instead of raising if the
         data contains more than one timezone.
+    allow_mixed : bool, default False
+        Interpret integers as timestamps when datetime objects are also present.
 
     Returns
     -------
@@ -2097,6 +2132,7 @@ def objects_to_datetime64ns(
             dayfirst=dayfirst,
             yearfirst=yearfirst,
             require_iso8601=require_iso8601,
+            allow_mixed=allow_mixed,
         )
         result = result.reshape(data.shape, order=order)
     except ValueError as err:
@@ -2133,7 +2169,7 @@ def objects_to_datetime64ns(
         raise TypeError(result)
 
 
-def maybe_convert_dtype(data, copy):
+def maybe_convert_dtype(data, copy: bool):
     """
     Convert data based on dtype conventions, issuing deprecation warnings
     or errors where appropriate.


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

ideally we'll end up with only one place in the non-cython code calling into the array_to_datetime/datetime_to_datetime64