### PR TITLE
REF: re-use sequence_to_datetimes in try_datetime

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1905,13 +1905,16 @@ default 'raise'
 
 
 def sequence_to_datetimes(
-    data, allow_object: bool = False
+    data, allow_object: bool = False, require_iso8601: bool = False
 ) -> Union[np.ndarray, DatetimeArray]:
     """
     Parse/convert the passed data to either DatetimeArray or np.ndarray[object].
     """
     result, tz, freq = sequence_to_dt64ns(
-        data, allow_object=allow_object, allow_mixed=True
+        data,
+        allow_object=allow_object,
+        allow_mixed=True,
+        require_iso8601=require_iso8601,
     )
     if result.dtype == object:
         return result
@@ -1932,6 +1935,7 @@ def sequence_to_dt64ns(
     *,
     allow_object: bool = False,
     allow_mixed: bool = False,
+    require_iso8601: bool = False,
 ):
     """
     Parameters
@@ -1949,6 +1953,8 @@ def sequence_to_dt64ns(
         data contains more than one timezone.
     allow_mixed : bool, default False
         Interpret integers as timestamps when datetime objects are also present.
+    require_iso8601 : bool, default False
+        Only consider ISO-8601 formats when parsing strings.
 
     Returns
     -------
@@ -2017,6 +2023,7 @@ def sequence_to_dt64ns(
                 yearfirst=yearfirst,
                 allow_object=allow_object,
                 allow_mixed=allow_mixed,
+                require_iso8601=require_iso8601,
             )
             if tz and inferred_tz:
                 #  two timezones: convert to intended from base UTC repr
@@ -2083,8 +2090,8 @@ def objects_to_datetime64ns(
     yearfirst,
     utc=False,
     errors="raise",
-    require_iso8601=False,
-    allow_object=False,
+    require_iso8601: bool = False,
+    allow_object: bool = False,
     allow_mixed: bool = False,
 ):
     """


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

if it weren't for the [expletive deleted] 1D/2D kludges, try_datetime would be down to 3 lines.