### PR TITLE
PERF: avoid zeros_like in groupby.pyx

### DIFF
--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -556,7 +556,7 @@ def _group_prod(floating[:, :] out,
         raise ValueError("len(index) != len(labels)")
 
     nobs = np.zeros((<object>out).shape, dtype=np.int64)
-    prodx = np.ones_like(out)
+    prodx = np.ones((<object>out).shape, dtype=(<object>out).base.dtype)
 
     N, K = (<object>values).shape
 
@@ -609,7 +609,7 @@ def _group_var(floating[:, :] out,
         raise ValueError("len(index) != len(labels)")
 
     nobs = np.zeros((<object>out).shape, dtype=np.int64)
-    mean = np.zeros_like(out)
+    mean = np.zeros((<object>out).shape, dtype=(<object>out).base.dtype)
 
     N, K = (<object>values).shape
 

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -497,8 +497,9 @@ def _group_add(complexfloating_t[:, :] out,
         raise ValueError("len(index) != len(labels)")
 
     nobs = np.zeros((<object>out).shape, dtype=np.int64)
-    sumx = np.zeros_like(out)
-    compensation = np.zeros_like(out)
+    # the below is equivalent to `np.zeros_like(out)` but faster
+    sumx = np.zeros((<object>out).shape, dtype=(<object>out).base.dtype)
+    compensation = np.zeros((<object>out).shape, dtype=(<object>out).base.dtype)
 
     N, K = (<object>values).shape
 
@@ -665,8 +666,9 @@ def _group_mean(floating[:, :] out,
         raise ValueError("len(index) != len(labels)")
 
     nobs = np.zeros((<object>out).shape, dtype=np.int64)
-    sumx = np.zeros_like(out)
-    compensation = np.zeros_like(out)
+    # the below is equivalent to `np.zeros_like(out)` but faster
+    sumx = np.zeros((<object>out).shape, dtype=(<object>out).base.dtype)
+    compensation = np.zeros((<object>out).shape, dtype=(<object>out).base.dtype)
 
     N, K = (<object>values).shape
 


### PR DESCRIPTION
Apparently calling `np.zeros_like` has quite some overhead:

```
In [7]: arr = np.random.randn(1000)

In [8]: %timeit np.zeros_like(arr)
3.14 µs ± 44.2 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [9]: %timeit np.zeros(arr.shape, dtype=arr.dtype)
662 ns ± 41.9 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
``` 

So this PR replaces a few (recently added) occurences in groupby.pyx.

Using the same benchmarks case as in https://github.com/pandas-dev/pandas/pull/40178#issue-583301313, this gives:

```
In [2]: %timeit df_am.groupby(labels).sum()
66.5 ms ± 876 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)   <--- master
54.6 ms ± 958 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)   <--- PR
```

