### PR TITLE
[ArrayManager] TST: activate a bunch of (passing) tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,3 +176,19 @@ jobs:
         pytest pandas/tests/frame/indexing/test_setitem.py::TestDataFrameSetItem::test_setitem_listlike_indexer_duplicate_columns
         pytest pandas/tests/indexing/multiindex/test_setitem.py::TestMultiIndexSetItem::test_astype_assignment_with_dups
         pytest pandas/tests/indexing/multiindex/test_setitem.py::TestMultiIndexSetItem::test_frame_setitem_multi_column
+
+        pytest pandas/tests/api/
+        pytest pandas/tests/base/
+        pytest pandas/tests/computation/
+        pytest pandas/tests/config/
+        pytest pandas/tests/dtypes/
+        pytest pandas/tests/generic/
+        pytest pandas/tests/indexes/
+        pytest pandas/tests/libs/
+        pytest pandas/tests/plotting/
+        pytest pandas/tests/scalar/
+        pytest pandas/tests/strings/
+        pytest pandas/tests/tools/
+        pytest pandas/tests/tseries/
+        pytest pandas/tests/tslibs/
+        pytest pandas/tests/util/

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -85,7 +85,7 @@ class Generic:
 
         # multiple axes at once
 
-    def test_get_numeric_data(self):
+    def test_get_numeric_data(self, using_array_manager):
 
         n = 4
         kwargs = {
@@ -100,6 +100,9 @@ class Generic:
         # non-inclusion
         result = o._get_bool_data()
         expected = self._construct(n, value="empty", **kwargs)
+        if using_array_manager and isinstance(o, DataFrame):
+            # INFO(ArrayManager) preserve the dtype of the columns Index
+            expected.columns = expected.columns.astype("int64")
         self._compare(result, expected)
 
         # get the bool data


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/39146/

This is on top of #40152, so only the second commit is relevant: https://github.com/pandas-dev/pandas/pull/40217/commits/e7209aaa7b85c206d3efcd446eaa54b34851cb98

But this basically adds the following to CI for ArrayManager:

```
        pytest pandas/tests/api/ --array-manager
        pytest pandas/tests/base/ --array-manager
        pytest pandas/tests/computation/ --array-manager
        pytest pandas/tests/config/ --array-manager
        pytest pandas/tests/dtypes/ --array-manager
        pytest pandas/tests/generic/ --array-manager
        pytest pandas/tests/indexes/ --array-manager
        pytest pandas/tests/libs/ --array-manager
        pytest pandas/tests/plotting/ --array-manager
        pytest pandas/tests/scalar/ --array-manager
        pytest pandas/tests/strings/ --array-manager
        pytest pandas/tests/tools/ --array-manager
        pytest pandas/tests/tseries/ --array-manager
        pytest pandas/tests/tslibs/ --array-manager
        pytest pandas/tests/util/ --array-manager
```