### PR TITLE
BUG: update should try harder to preserve dtypes #4094

### DIFF
--- a/doc/source/whatsnew/v1.2.4.rst
+++ b/doc/source/whatsnew/v1.2.4.rst
@@ -25,7 +25,7 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 
--
+- Bug in :meth:`~DataFrame.update` unnecessarily changing the dtype of a column (:issue:`4094`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.2.4.rst
+++ b/doc/source/whatsnew/v1.2.4.rst
@@ -25,7 +25,7 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 
-- Bug in :meth:`~DataFrame.update` unnecessarily changing the dtype of a column (:issue:`4094`)
+-
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -406,7 +406,7 @@ Conversion
 - Bug in :meth:`Series.view` and :meth:`Index.view` when converting between datetime-like (``datetime64[ns]``, ``datetime64[ns, tz]``, ``timedelta64``, ``period``) dtypes (:issue:`39788`)
 - Bug in creating a :class:`DataFrame` from an empty ``np.recarray`` not retaining the original dtypes (:issue:`40121`)
 - Bug in :class:`DataFrame` failing to raise ``TypeError`` when constructing from a ``frozenset`` (:issue:`40163`)
--
+- Bug in :meth:`~DataFrame.update` unnecessarily changing the dtype of a column (:issue:`4094`)
 
 Strings
 ^^^^^^^

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6939,6 +6939,7 @@ Keep all original rows and columns and also all original values
         if not isinstance(other, DataFrame):
             other = DataFrame(other)
 
+        other_dtypes = other.dtypes  # dtype might change during reindexing
         other = other.reindex_like(self)
 
         for col in self.columns:
@@ -6963,7 +6964,11 @@ Keep all original rows and columns and also all original values
             if mask.all():
                 continue
 
-            self[col] = expressions.where(mask, this, that)
+            col_array = expressions.where(mask, this, that)
+            if self[col].dtype == other_dtypes[col] != col_array.dtype:
+                self[col] = Series(col_array, index=self.index, dtype=self[col].dtype)
+            else:
+                self[col] = col_array
 
     # ----------------------------------------------------------------------
     # Data reshaping

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6939,7 +6939,7 @@ Keep all original rows and columns and also all original values
         if not isinstance(other, DataFrame):
             other = DataFrame(other)
 
-        other_dtypes = other.dtypes  # dtype might change during reindexing
+        other_dtypes = other.dtypes
         other = other.reindex_like(self)
 
         for col in self.columns:

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -1,5 +1,3 @@
-from hypothesis import given
-from hypothesis.extra import numpy as np_st
 import numpy as np
 import pytest
 
@@ -149,25 +147,24 @@ class TestDataFrameUpdate:
         expected = DataFrame({"a": [1, 3], "b": [np.nan, 2], "c": ["foo", np.nan]})
         tm.assert_frame_equal(df, expected)
 
-    @given(dtype=np_st.integer_dtypes())
-    def test_update_with_subset_and_same_integer_dtype(self, dtype):
+    def test_update_with_subset_and_same_not_nullable_dtype(self, any_real_dtype):
         # GH4094
-        df = DataFrame({"a": Series([1, 2, 3], dtype=dtype)})
+        df = DataFrame({"a": Series([1, 2, 3], dtype=any_real_dtype)})
         update = df.copy()[:-1]
         df.update(update)
-        assert df.a.dtype == dtype
+        assert df.a.dtype == any_real_dtype
 
-    def test_update_str_dtype(self):
+    def test_update_str_dtype(self, string_dtype):
         # GH4094
-        df = DataFrame({"a": ["a", "b", "c"]}, dtype="string")
+        df = DataFrame({"a": ["a", "b", "c"]}, dtype=string_dtype)
         update = df.copy()
         expected = df.copy()
         df.update(update)
         assert df.a.dtype == expected.a.dtype
 
-    def test_update_with_subset_str_dtype(self):
+    def test_update_with_subset_str_dtype(self, string_dtype):
         # GH4094
-        df = DataFrame({"a": ["a", "b", "c"]}, dtype="string")
+        df = DataFrame({"a": ["a", "b", "c"]}, dtype=string_dtype)
         update = df.copy()[:-1]
         expected = df.copy()
         df.update(update)

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -152,14 +152,14 @@ class TestDataFrameUpdate:
     @given(dtype=np_st.integer_dtypes(endianness="="))
     def test_update_with_subset_and_same_integer_dtype(self, dtype):
         # GH4094
-        df = pd.DataFrame({"a": pd.Series([1, 2, 3], dtype=dtype)})
+        df = DataFrame({"a": Series([1, 2, 3], dtype=dtype)})
         update = df.copy()[:-1]
         df.update(update)
         assert df.a.dtype == dtype
 
     def test_update_str_dtype(self):
         # GH4094
-        df = pd.DataFrame({"a": ["a", "b", "c"]}, dtype="string")
+        df = DataFrame({"a": ["a", "b", "c"]}, dtype="string")
         update = df.copy()
         expected = df.copy()
         df.update(update)
@@ -167,7 +167,7 @@ class TestDataFrameUpdate:
 
     def test_update_with_subset_str_dtype(self):
         # GH4094
-        df = pd.DataFrame({"a": ["a", "b", "c"]}, dtype="string")
+        df = DataFrame({"a": ["a", "b", "c"]}, dtype="string")
         update = df.copy()[:-1]
         expected = df.copy()
         df.update(update)
@@ -175,7 +175,7 @@ class TestDataFrameUpdate:
 
     def test_update_bool_dtype(self):
         # GH4094
-        df = pd.DataFrame({"a": [True, False, True]}, dtype=bool)
+        df = DataFrame({"a": [True, False, True]}, dtype=bool)
         update = df.copy()
         expected = df.copy()
         df.update(update)
@@ -183,8 +183,8 @@ class TestDataFrameUpdate:
 
     def test_update_with_subset_bool_dtype(self):
         # GH4094
-        df = pd.DataFrame({"a": [True, False]}, dtype=bool)
-        update = pd.DataFrame({"a": [False]}, dtype=bool)
+        df = DataFrame({"a": [True, False]}, dtype=bool)
+        update = DataFrame({"a": [False]}, dtype=bool)
         expected = df.copy()
         df.update(update)
         assert df.a.dtype == expected.a.dtype

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -1,3 +1,5 @@
+from hypothesis import given
+from hypothesis.extra import numpy as np_st
 import numpy as np
 import pytest
 
@@ -146,3 +148,43 @@ class TestDataFrameUpdate:
 
         expected = DataFrame({"a": [1, 3], "b": [np.nan, 2], "c": ["foo", np.nan]})
         tm.assert_frame_equal(df, expected)
+
+    @given(dtype=np_st.integer_dtypes(endianness="="))
+    def test_update_with_subset_and_same_integer_dtype(self, dtype):
+        # GH4094
+        df = pd.DataFrame({"a": pd.Series([1, 2, 3], dtype=dtype)})
+        update = df.copy()[:-1]
+        df.update(update)
+        assert df.a.dtype == dtype
+
+    def test_update_str_dtype(self):
+        # GH4094
+        df = pd.DataFrame({"a": ["a", "b", "c"]}, dtype="string")
+        update = df.copy()
+        expected = df.copy()
+        df.update(update)
+        assert df.a.dtype == expected.a.dtype
+
+    def test_update_with_subset_str_dtype(self):
+        # GH4094
+        df = pd.DataFrame({"a": ["a", "b", "c"]}, dtype="string")
+        update = df.copy()[:-1]
+        expected = df.copy()
+        df.update(update)
+        assert df.a.dtype == expected.a.dtype
+
+    def test_update_bool_dtype(self):
+        # GH4094
+        df = pd.DataFrame({"a": [True, False, True]}, dtype=bool)
+        update = df.copy()
+        expected = df.copy()
+        df.update(update)
+        assert df.a.dtype == expected.a.dtype
+
+    def test_update_with_subset_bool_dtype(self):
+        # GH4094
+        df = pd.DataFrame({"a": [True, False]}, dtype=bool)
+        update = pd.DataFrame({"a": [False]}, dtype=bool)
+        expected = df.copy()
+        df.update(update)
+        assert df.a.dtype == expected.a.dtype

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -149,7 +149,7 @@ class TestDataFrameUpdate:
         expected = DataFrame({"a": [1, 3], "b": [np.nan, 2], "c": ["foo", np.nan]})
         tm.assert_frame_equal(df, expected)
 
-    @given(dtype=np_st.integer_dtypes(endianness="="))
+    @given(dtype=np_st.integer_dtypes())
     def test_update_with_subset_and_same_integer_dtype(self, dtype):
         # GH4094
         df = DataFrame({"a": Series([1, 2, 3], dtype=dtype)})


### PR DESCRIPTION
- [ ] closes #4094
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

I have to admit, I am not quite sure about the code in the [initial example](https://github.com/pandas-dev/pandas/issues/4094#issue-16212879). But the rest of the given examples ([1](https://github.com/pandas-dev/pandas/issues/4094#issuecomment-297671925), [2](https://github.com/pandas-dev/pandas/issues/4094#issuecomment-583174514)) are converted to tests and they do pass.

I would have loved to make better use of hypothesis in the tests, but currently [column](https://hypothesis.readthedocs.io/en/latest/numpy.html#hypothesis.extra.pandas.columns) does not support dtype strategies and neither does [from_dtype](https://hypothesis.readthedocs.io/en/latest/numpy.html#hypothesis.extra.numpy.from_dtype) (if I would define the elements of the column and infere the dtype).