### PR TITLE
CI autofix_prs: false for pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,7 @@
 minimum_pre_commit_version: 2.9.2
 exclude: ^LICENSES/|\.(html|csv|svg)$
+ci:
+    autofix_prs: false
 repos:
 -   repo: https://github.com/MarcoGorelli/absolufy-imports
     rev: v0.3.0


### PR DESCRIPTION
Somehow, this autoupdate job doesn't trigger all the workflows. I don't know why, because [the same workflow in PyMC3](https://github.com/pymc-devs/pymc3/pull/4466) works just fine.

From [this action's README](https://github.com/technote-space/create-pr-action), all the actions have commit email and commit name set - setting them is all I can think to try at the moment. @afeld any ideas? Maybe there's a different workflow that should be used instead?