### PR TITLE
PERF: non-cython groupby.apply

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -276,6 +276,22 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
                 mgr = mgr.astype(dtype=dtype)
         return mgr
 
+    @classmethod
+    def _from_mgr(cls, mgr: Manager):
+        """
+        Fastpath to create a new DataFrame/Series from just a BlockManager/ArrayManager.
+
+        Notes
+        -----
+        Skips setting `_flags` attribute; caller is responsible for doing so.
+        """
+        obj = cls.__new__(cls)
+        object.__setattr__(obj, "_is_copy", None)
+        object.__setattr__(obj, "_mgr", mgr)
+        object.__setattr__(obj, "_item_cache", {})
+        object.__setattr__(obj, "_attrs", {})
+        return obj
+
     # ----------------------------------------------------------------------
     # attrs and flags
 

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -1013,7 +1013,13 @@ class SeriesSplitter(DataSplitter):
         # fastpath equivalent to `sdata.iloc[slice_obj]`
         mgr = sdata._mgr.get_slice(slice_obj)
         # __finalize__ not called here, must be applied by caller if applicable
-        return sdata._constructor(mgr, name=sdata.name, fastpath=True)
+
+        # fastpath equivalent to:
+        # `return sdata._constructor(mgr, name=sdata.name, fastpath=True)`
+        obj = type(sdata)._from_mgr(mgr)
+        object.__setattr__(obj, "_flags", sdata._flags)
+        object.__setattr__(obj, "_name", sdata._name)
+        return obj
 
 
 class FrameSplitter(DataSplitter):
@@ -1030,7 +1036,11 @@ class FrameSplitter(DataSplitter):
         #     return sdata.iloc[:, slice_obj]
         mgr = sdata._mgr.get_slice(slice_obj, axis=1 - self.axis)
         # __finalize__ not called here, must be applied by caller if applicable
-        return sdata._constructor(mgr)
+
+        # fastpath equivalent to `return sdata._constructor(mgr)`
+        obj = type(sdata)._from_mgr(mgr)
+        object.__setattr__(obj, "_flags", sdata._flags)
+        return obj
 
 
 def get_splitter(


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/40171#issuecomment-790219422 when disabling fast_apply, this cuts the linked benchmark by 13-15%

xref #40227 which also gets 13%

Potential pitfall if _constructor is particularly wonky.