### PR TITLE
DEPR: Partial failure in Series.transform and DataFrame.transform

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -363,6 +363,7 @@ Deprecations
 - Deprecated :meth:`core.window.ewm.ExponentialMovingWindow.vol` (:issue:`39220`)
 - Using ``.astype`` to convert between ``datetime64[ns]`` dtype and :class:`DatetimeTZDtype` is deprecated and will raise in a future version, use ``obj.tz_localize`` or ``obj.dt.tz_localize`` instead (:issue:`38622`)
 - Deprecated casting ``datetime.date`` objects to ``datetime64`` when used as ``fill_value`` in :meth:`DataFrame.unstack`, :meth:`DataFrame.shift`, :meth:`Series.shift`, and :meth:`DataFrame.reindex`, pass ``pd.Timestamp(dateobj)`` instead (:issue:`39767`)
+- Deprecated allowing partial failure in :meth:`Series.transform` and :meth:`DataFrame.transform` when ``func`` is list-like or dict-like; will raise if any function fails on a column in a future version (:issue:`40211`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/tests/apply/common.py
+++ b/pandas/tests/apply/common.py
@@ -1,0 +1,10 @@
+from pandas.core.groupby.base import transformation_kernels
+
+# tshift only works on time index and is deprecated
+# There is no Series.cumcount or DataFrame.cumcount
+series_transform_kernels = [
+    x for x in sorted(transformation_kernels) if x not in ["tshift", "cumcount"]
+]
+frame_transform_kernels = [
+    x for x in sorted(transformation_kernels) if x not in ["tshift", "cumcount"]
+]


### PR DESCRIPTION
- [x] closes #40211
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

In test_frame_transform.test_transform_partial_failure, two of the tests did not actually test for partial failure as I had intended back in #35964. That is fixed here. Also added tests for Series.