### PR TITLE
ENH: allow start=range_object in RangeIndex constructor

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -139,6 +139,7 @@ Other enhancements
 - :meth:`pandas.read_stata` and :class:`StataReader` support reading data from compressed files.
 - Add support for parsing ``ISO 8601``-like timestamps with negative signs to :meth:`pandas.Timedelta` (:issue:`37172`)
 - Add support for unary operators in :class:`FloatingArray` (:issue:`38749`)
+- :class:`RangeIndex` can now be constructed by passing a ``range`` object directly e.g. ``pd.RangeIndex(range(3))`` (:issue:`12067`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -366,13 +366,8 @@ class Index(IndexOpsMixin, PandasObject):
         data_dtype = getattr(data, "dtype", None)
 
         # range
-        if isinstance(data, RangeIndex):
+        if isinstance(data, (range, RangeIndex)):
             result = RangeIndex(start=data, copy=copy, name=name)
-            if dtype is not None:
-                return result.astype(dtype, copy=False)
-            return result
-        elif isinstance(data, range):
-            result = RangeIndex.from_range(data, name=name)
             if dtype is not None:
                 return result.astype(dtype, copy=False)
             return result

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -116,8 +116,7 @@ class RangeIndex(Int64Index):
 
         # RangeIndex
         if isinstance(start, RangeIndex):
-            start = start._range
-            return cls._simple_new(start, name=name)
+            return start.copy(name=name)
         elif isinstance(start, range):
             return cls._simple_new(start, name=name)
 

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -118,6 +118,8 @@ class RangeIndex(Int64Index):
         if isinstance(start, RangeIndex):
             start = start._range
             return cls._simple_new(start, name=name)
+        elif isinstance(start, range):
+            return cls._simple_new(start, name=name)
 
         # validate the arguments
         if com.all_none(start, stop, step):

--- a/pandas/tests/indexes/ranges/test_constructors.py
+++ b/pandas/tests/indexes/ranges/test_constructors.py
@@ -91,11 +91,12 @@ class TestRangeIndexConstructors:
         ):
             RangeIndex(index, dtype="float64")
 
-    def test_constructor_range(self):
+    def test_constructor_range_object(self):
+        result = RangeIndex(range(1, 5, 2))
+        expected = RangeIndex(1, 5, 2)
+        tm.assert_index_equal(result, expected, exact=True)
 
-        msg = "Value needs to be a scalar value, was type range"
-        with pytest.raises(TypeError, match=msg):
-            result = RangeIndex(range(1, 5, 2))
+    def test_constructor_range(self):
 
         result = RangeIndex.from_range(range(1, 5, 2))
         expected = RangeIndex(1, 5, 2)


### PR DESCRIPTION
- [x] closes #12067
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

simplifies `Index.__new__` a bit