### PR TITLE
PERF: specialized 1D take version

### DIFF
--- a/pandas/core/array_algos/take.py
+++ b/pandas/core/array_algos/take.py
@@ -126,7 +126,7 @@ def take_1d(
     indexer: np.ndarray,
     fill_value=None,
     allow_fill: bool = True,
-):
+) -> ArrayLike:
     """
     Specialized version for 1D arrays. Differences compared to take_nd:
 

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -58,7 +58,7 @@ from pandas.core.dtypes.missing import (
 
 import pandas.core.algorithms as algos
 from pandas.core.array_algos.quantile import quantile_compat
-from pandas.core.array_algos.take import take_nd
+from pandas.core.array_algos.take import take_1d
 from pandas.core.arrays import (
     DatetimeArray,
     ExtensionArray,
@@ -1048,7 +1048,7 @@ class ArrayManager(DataManager):
         new_arrays = []
         for arr in self.arrays:
             for i in range(unstacker.full_shape[1]):
-                new_arr = take_nd(
+                new_arr = take_1d(
                     arr, new_indexer2D[:, i], allow_fill=True, fill_value=fill_value
                 )
                 new_arrays.append(new_arr)

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -991,7 +991,7 @@ class ArrayManager(DataManager):
         else:
             validate_indices(indexer, len(self._axes[0]))
             new_arrays = [
-                take_nd(
+                take_1d(
                     arr,
                     indexer,
                     allow_fill=True,


### PR DESCRIPTION
A part that I took out of https://github.com/pandas-dev/pandas/pull/39692, doing it separately here. 

This gives a bit of code duplication (but all large parts of the function were already factored out into shared helper functions before, like `_take_preprocess_indexer_and_fill_value`), but having a 1D version gives less overhead compared to `take_nd`. 

Using the same benchmark case (unstack ASV case) as in https://github.com/pandas-dev/pandas/pull/39692, this gives:

```python
arrays = [np.arange(100).repeat(100), np.roll(np.tile(np.arange(100), 100), 25)]
index = pd.MultiIndex.from_arrays(arrays)
df = pd.DataFrame(np.random.randn(10000, 4), index=index)
df_am = df._as_manager("array")
```

```
In [3]:  %timeit df_am.unstack()
3.31 ms ± 60.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  <-- master
2.95 ms ± 57.2 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  <-- PR
```

It's a small difference (around 10% improvement), but I repeated the timings above multiple times it was quite consistently a bit faster.