### PR TITLE
BENCH: add DataFrame.reindex(columns=..) benchmark that selects existing columns

### DIFF
--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -52,6 +52,7 @@ class Reindex:
         N = 10 ** 3
         self.df = DataFrame(np.random.randn(N * 10, N))
         self.idx = np.arange(4 * N, 7 * N)
+        self.idx_cols = np.random.randint(0, N, N)
         self.df2 = DataFrame(
             {
                 c: {
@@ -68,6 +69,9 @@ class Reindex:
         self.df.reindex(self.idx)
 
     def time_reindex_axis1(self):
+        self.df.reindex(columns=self.idx_cols)
+
+    def time_reindex_axis1_missing(self):
         self.df.reindex(columns=self.idx)
 
     def time_reindex_both_axes(self):


### PR DESCRIPTION
I noticed that the current `df.reindex(columns=idx)` benchmark uses an indexer with all-non-existing indices (it uses `range(4000, 7000)` as indexer, but there are only 1000 columns), so basically it is benchmarking to create empty (all-NaN) columns. Therefore added a case of reindexing with an indexer consisting of existing column labels.

For reindexing the rows, it's already using existing row labels.