### PR TITLE
PERF: avoid validating indices repeatedly in ArrayManager.reindex_indexer

### DIFF
--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -73,7 +73,10 @@ from pandas.core.construction import (
     extract_array,
     sanitize_array,
 )
-from pandas.core.indexers import maybe_convert_indices
+from pandas.core.indexers import (
+    maybe_convert_indices,
+    validate_indices,
+)
 from pandas.core.indexes.api import (
     Index,
     ensure_index,
@@ -965,8 +968,9 @@ class ArrayManager(DataManager):
                 new_arrays.append(arr)
 
         else:
+            validate_indices(indexer, len(self._axes[0]))
             new_arrays = [
-                algos.take(
+                take_nd(
                     arr,
                     indexer,
                     allow_fill=True,


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/39146

In `ArrayManager.reindex_indexer`, we are currently using `take`, which validates the indices each time. Since we know we have the same indices for each column, we can validate them once, and use the lower level `take_nd`.

From the `frame_methods.py::Reindex` ASV benchmark:

```python
N = 10 ** 3
df = DataFrame(np.random.randn(N * 10, N))
idx = np.arange(4 * N, 7 * N)
df_am = df._as_manager("array")
```

```
In [4]: %timeit df_am.reindex(idx)
21 ms ± 189 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)  <-- master
12.6 ms ± 1.5 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)  <-- PR
```