### PR TITLE
CLN: Remove _axis from apply

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -166,19 +166,15 @@ class Apply(metaclass=abc.ABCMeta):
         args = self.args
         kwargs = self.kwargs
 
-        _axis = kwargs.pop("_axis", None)
-        if _axis is None:
-            _axis = getattr(obj, "axis", 0)
-
         result = self.maybe_apply_str()
         if result is not None:
             return result
 
         if is_dict_like(arg):
-            return self.agg_dict_like(_axis)
+            return self.agg_dict_like()
         elif is_list_like(arg):
             # we require a list, but not a 'str'
-            return self.agg_list_like(_axis=_axis)
+            return self.agg_list_like()
 
         if callable(arg):
             f = obj._get_cython_func(arg)
@@ -317,14 +313,9 @@ class Apply(metaclass=abc.ABCMeta):
         except Exception:
             return func(obj, *args, **kwargs)
 
-    def agg_list_like(self, _axis: int) -> FrameOrSeriesUnion:
+    def agg_list_like(self) -> FrameOrSeriesUnion:
         """
         Compute aggregation in the case of a list-like argument.
-
-        Parameters
-        ----------
-        _axis : int, 0 or 1
-            Axis to compute aggregation on.
 
         Returns
         -------
@@ -334,9 +325,6 @@ class Apply(metaclass=abc.ABCMeta):
 
         obj = self.obj
         arg = cast(List[AggFuncTypeBase], self.f)
-
-        if _axis != 0:
-            raise NotImplementedError("axis other than 0 is not supported")
 
         if obj._selected_obj.ndim == 1:
             selected_obj = obj._selected_obj
@@ -404,14 +392,9 @@ class Apply(metaclass=abc.ABCMeta):
                 ) from err
             return result
 
-    def agg_dict_like(self, _axis: int) -> FrameOrSeriesUnion:
+    def agg_dict_like(self) -> FrameOrSeriesUnion:
         """
         Compute aggregation in the case of a dict-like argument.
-
-        Parameters
-        ----------
-        _axis : int, 0 or 1
-            Axis to compute aggregation on.
 
         Returns
         -------
@@ -421,9 +404,6 @@ class Apply(metaclass=abc.ABCMeta):
 
         obj = self.obj
         arg = cast(AggFuncTypeDict, self.f)
-
-        if _axis != 0:  # pragma: no cover
-            raise ValueError("Can only pass dict with axis=0")
 
         selected_obj = obj._selected_obj
 
@@ -1007,7 +987,6 @@ class SeriesApply(Apply):
 
             # we can be called from an inner function which
             # passes this meta-data
-            kwargs.pop("_axis", None)
             kwargs.pop("_level", None)
 
             # try a regular apply, this evaluates lambdas

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1023,9 +1023,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
                 # try to treat as if we are passing a list
                 try:
-                    result = GroupByApply(
-                        self, [func], args=(), kwargs={"_axis": self.axis}
-                    ).agg()
+                    result = GroupByApply(self, [func], args=(), kwargs={}).agg()
 
                     # select everything except for the last level, which is the one
                     # containing the name of the function(s), see GH 32040


### PR DESCRIPTION
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

The regex `[\W]_axis` is showing this removes the only occurances of the variable `_axis` throughout all of `pandas.core`. It is only set in groupby in a branch where is must be 0, and is only used to check that it is 0.