### PR TITLE
TYP: remove ignore from PandasObject.__sizeof__

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -113,9 +113,9 @@ class PandasObject(DirNamesMixin):
         Generates the total memory usage for an object that returns
         either a value or Series of values
         """
-        if hasattr(self, "memory_usage"):
-            # error: "PandasObject" has no attribute "memory_usage"
-            mem = self.memory_usage(deep=True)  # type: ignore[attr-defined]
+        memory_usage = getattr(self, "memory_usage", None)
+        if memory_usage:
+            mem = memory_usage(deep=True)
             return int(mem if is_scalar(mem) else mem.sum())
 
         # no memory_usage attribute, so fall back to object's 'sizeof'


### PR DESCRIPTION
xref #37715

we should probably have a base implementation (or make memory_usage an abstract method). without doing this we have no way of enforcing that the method has a `deep` parameter.

I am quite happy leaving the ignore in play to highlight this.