### PR TITLE
POC: aggregate always aggregates

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -674,7 +674,9 @@ class FrameApply(Apply):
             result = result.T if result is not None else result
 
         if result is None:
-            result = self.obj.apply(self.orig_f, axis, args=self.args, **self.kwargs)
+            results, res_index = self.apply_series_generator()
+            result = self.obj._constructor_sliced(results)
+            result.index = res_index
 
         return result
 
@@ -1018,10 +1020,7 @@ class SeriesApply(Apply):
             # we cannot FIRST try the vectorized evaluation, because
             # then .agg and .apply would have different semantics if the
             # operation is actually defined on the Series, e.g. str
-            try:
-                result = self.obj.apply(f, *args, **kwargs)
-            except (ValueError, AttributeError, TypeError):
-                result = f(self.obj, *args, **kwargs)
+            result = f(self.obj, *args, **kwargs)
 
         return result
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10285,9 +10285,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         grouped = self.groupby(level=level, axis=axis, sort=False)
         if hasattr(grouped, name) and skipna:
             return getattr(grouped, name)(**kwargs)
-        axis = self._get_axis_number(axis)
         method = getattr(type(self), name)
-        applyf = lambda x: method(x, axis=axis, skipna=skipna, **kwargs)
+        applyf = lambda x: method(x, skipna=skipna, **kwargs)
         return grouped.aggregate(applyf)
 
     @final

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1010,7 +1010,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         if result is None:
 
             # grouper specific aggregations
-            if self.grouper.nkeys > 1:
+            if not self._obj_with_exclusions.empty or self.grouper.nkeys > 1:
                 return self._python_agg_general(func, *args, **kwargs)
             elif args or kwargs:
                 result = self._aggregate_frame(func, *args, **kwargs)

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1092,7 +1092,7 @@ class BaseGroupBy(PandasObject, SelectionMixin, Generic[FrameOrSeries]):
 
             # apply a non-cython aggregation
             if result is None:
-                result = self.aggregate(lambda x: npfunc(x, axis=self.axis))
+                result = self.aggregate(lambda x: npfunc(x))
             return result.__finalize__(self.obj, method="groupby")
 
     def _cython_agg_general(

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -760,7 +760,6 @@ class BaseGrouper:
 
         counts = np.zeros(ngroups, dtype=int)
         result = np.empty(ngroups, dtype="O")
-        initialized = False
 
         splitter = get_splitter(obj, group_index, ngroups, axis=0)
 
@@ -768,16 +767,8 @@ class BaseGrouper:
 
             # Each step of this loop corresponds to
             #  libreduction._BaseGrouper._apply_to_group
-            res = func(group)
-            res = libreduction.extract_result(res)
-
-            if not initialized:
-                # We only do this validation on the first iteration
-                libreduction.check_result_array(res, 0)
-                initialized = True
-
             counts[label] = group.shape[0]
-            result[label] = res
+            result[label] = func(group)
 
         result = lib.maybe_convert_objects(result, try_float=False)
         result = maybe_cast_result(result, obj, numeric_only=True)

--- a/pandas/tests/apply/test_series_apply.py
+++ b/pandas/tests/apply/test_series_apply.py
@@ -298,16 +298,26 @@ def test_demo():
     tm.assert_series_equal(result, expected)
 
 
-def test_agg_apply_evaluate_lambdas_the_same(string_series):
+def test_agg_apply_evaluate_lambdas(string_series):
     # test that we are evaluating row-by-row first
     # before vectorized evaluation
+    expected = string_series.astype(str)
+
     result = string_series.apply(lambda x: str(x))
-    expected = string_series.agg(lambda x: str(x))
     tm.assert_series_equal(result, expected)
 
     result = string_series.apply(str)
-    expected = string_series.agg(str)
     tm.assert_series_equal(result, expected)
+
+    # GH 35725
+    # Agg always aggs - applies the function to the entire Series
+    expected = str(string_series)
+
+    result = string_series.agg(lambda x: str(x))
+    assert result == expected
+
+    result = string_series.agg(str)
+    assert result == expected
 
 
 def test_with_nested_series(datetime_series):
@@ -318,7 +328,8 @@ def test_with_nested_series(datetime_series):
     tm.assert_frame_equal(result, expected)
 
     result = datetime_series.agg(lambda x: Series([x, x ** 2], index=["x", "x^2"]))
-    tm.assert_frame_equal(result, expected)
+    expected = Series([datetime_series, datetime_series ** 2], index=["x", "x^2"])
+    tm.assert_series_equal(result, expected)
 
 
 def test_replicate_describe(string_series):

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -47,12 +47,10 @@ def test_agg_regression1(tsframe):
 
 def test_agg_must_agg(df):
     grouped = df.groupby("A")["C"]
-
-    msg = "Must produce aggregated value"
-    with pytest.raises(Exception, match=msg):
-        grouped.agg(lambda x: x.describe())
-    with pytest.raises(Exception, match=msg):
-        grouped.agg(lambda x: x.index[:2])
+    result = grouped.agg(lambda x: x.describe())
+    expected = Series({name: group.describe() for name, group in grouped}, name="C")
+    expected.index.name = "A"
+    tm.assert_series_equal(result, expected)
 
 
 def test_agg_ser_multi_key(df):
@@ -127,9 +125,8 @@ def test_groupby_aggregation_multi_level_column():
         data=lst,
         columns=MultiIndex.from_tuples([("A", 0), ("A", 1), ("B", 0), ("B", 1)]),
     )
-
     result = df.groupby(level=1, axis=1).sum()
-    expected = DataFrame({0: [2.0, 1, 1, 1], 1: [1, 0, 1, 1]})
+    expected = DataFrame({0: [2, 1, 1, 1], 1: [1, 0, 1, 1]})
 
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/groupby/aggregate/test_other.py
+++ b/pandas/tests/groupby/aggregate/test_other.py
@@ -605,9 +605,8 @@ def test_agg_lambda_with_timezone():
     )
     result = df.groupby("tag").agg({"date": lambda e: e.head(1)})
     expected = DataFrame(
-        [pd.Timestamp("2018-01-01", tz="UTC")],
+        {"date": [df["date"].iloc[:1]]},
         index=Index([1], name="tag"),
-        columns=["date"],
     )
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -75,11 +75,9 @@ def test_basic(dtype):
     agged = grouped.agg(lambda x: group_constants[x.name] + x.mean())
     assert agged[1] == 21
 
-    # corner cases
-    msg = "Must produce aggregated value"
-    # exception raised is type Exception
-    with pytest.raises(Exception, match=msg):
-        grouped.aggregate(lambda x: x * 2)
+    result = grouped.aggregate(lambda x: x * 2)
+    expected = Series({name: group * 2 for name, group in grouped})
+    tm.assert_series_equal(result, expected)
 
 
 def test_groupby_nonobject_dtype(mframe, df_mixed_floats):
@@ -1026,7 +1024,7 @@ def test_groupby_with_hier_columns():
     result = df.groupby(level=0).apply(lambda x: x.mean())
     tm.assert_index_equal(result.columns, columns)
 
-    result = df.groupby(level=0, axis=1).agg(lambda x: x.mean(1))
+    result = df.groupby(level=0, axis=1).agg(lambda x: x.mean())
     tm.assert_index_equal(result.columns, Index(["A", "B"]))
     tm.assert_index_equal(result.index, df.index)
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -214,7 +214,7 @@ class TestMultiLevel:
 
         def aggf(x):
             pieces.append(x)
-            return getattr(x, op)(skipna=skipna, axis=axis)
+            return getattr(x, op)(skipna=skipna)
 
         leftside = grouped.agg(aggf)
         rightside = getattr(frame, op)(level=level, axis=axis, skipna=skipna)


### PR DESCRIPTION
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

Proof of concept to show what it would take for #35725 (needs tests, docs, and some comments cleaned up). I wanted to make sure the desired behavior has a viable path before deprecating. I'm planning to put up a PR to deprecate for #35725 in the next week or so, but since this seems to be a somewhat substantial behavior change, I'm wondering if it should be behind an option so that users can opt-in earlier and restore previous behavior for at least 1 release after the deprecation takes effect.

This makes any call to `*.agg` aggregate. For example:

     pd.DataFrame({'a': [1, 1], 'b': [2, 2]}).agg(lambda x: x)

will return a Series with 2 rows whose entries are Series themselves. On master, this would be a no-op. Some notes:

 - GroupBy.aggregate is now almost entirely handled by either core.apply or _python_agg_general. The only case that isn't is where the result is empty; this should be able to be simplified.
 - Also closes #39169, #39436
 - Closes the agg portion of #38042
 - Series.agg no longer uses "try ser.apply(f), fallback to f(ser)"; it just does the latter now.