### PR TITLE
STYLE: Inconsistent namespace - plotting

### DIFF
--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -271,7 +271,6 @@ class TestDataFramePlots(TestPlotBase):
             df.plot(**{input_param: "sm"})
 
     def test_xcompat(self):
-        import pandas as pd
 
         df = self.tdf
         ax = df.plot(x_compat=True)
@@ -280,14 +279,14 @@ class TestDataFramePlots(TestPlotBase):
         self._check_ticks_props(ax, xrot=30)
 
         tm.close()
-        pd.plotting.plot_params["xaxis.compat"] = True
+        plotting.plot_params["xaxis.compat"] = True
         ax = df.plot()
         lines = ax.get_lines()
         assert not isinstance(lines[0].get_xdata(), PeriodIndex)
         self._check_ticks_props(ax, xrot=30)
 
         tm.close()
-        pd.plotting.plot_params["x_compat"] = False
+        plotting.plot_params["x_compat"] = False
 
         ax = df.plot()
         lines = ax.get_lines()
@@ -296,7 +295,7 @@ class TestDataFramePlots(TestPlotBase):
 
         tm.close()
         # useful if you're plotting a bunch together
-        with pd.plotting.plot_params.use("x_compat", True):
+        with plotting.plot_params.use("x_compat", True):
             ax = df.plot()
             lines = ax.get_lines()
             assert not isinstance(lines[0].get_xdata(), PeriodIndex)
@@ -682,7 +681,7 @@ class TestDataFramePlots(TestPlotBase):
     def test_raise_error_on_datetime_time_data(self):
         # GH 8113, datetime.time type is not supported by matplotlib in scatter
         df = DataFrame(np.random.randn(10), columns=["a"])
-        df["dtime"] = pd.date_range(start="2014-01-01", freq="h", periods=10).time
+        df["dtime"] = date_range(start="2014-01-01", freq="h", periods=10).time
         msg = "must be a string or a number, not 'datetime.time'"
 
         with pytest.raises(TypeError, match=msg):
@@ -690,7 +689,7 @@ class TestDataFramePlots(TestPlotBase):
 
     def test_scatterplot_datetime_data(self):
         # GH 30391
-        dates = pd.date_range(start=date(2019, 1, 1), periods=12, freq="W")
+        dates = date_range(start=date(2019, 1, 1), periods=12, freq="W")
         vals = np.random.normal(0, 1, len(dates))
         df = DataFrame({"dates": dates, "vals": vals})
 
@@ -2095,7 +2094,7 @@ class TestDataFramePlots(TestPlotBase):
     def test_x_multiindex_values_ticks(self):
         # Test if multiindex plot index have a fixed xtick position
         # GH: 15912
-        index = pd.MultiIndex.from_product([[2012, 2013], [1, 2]])
+        index = MultiIndex.from_product([[2012, 2013], [1, 2]])
         df = DataFrame(np.random.randn(4, 2), columns=["A", "B"], index=index)
         ax = df.plot()
         ax.set_xlim(-1, 4)


### PR DESCRIPTION
- [x] xref #39992
- [x] tests added / passed - plotting
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
