### PR TITLE
Move cpplint check to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,16 @@ repos:
     -   id: end-of-file-fixer
         exclude: \.txt$
     -   id: trailing-whitespace
+-   repo: https://github.com/cpplint/cpplint
+    rev: f7061b1 # the latest tag does not have the hook
+    hooks:
+    -   id: cpplint
+        # We don't lint all C files because we don't want to lint any that are built
+        # from Cython files nor do we want to lint C files that we didn't modify for
+        # this particular codebase (e.g. src/headers, src/klib). However,
+        # we can lint all header files since they aren't "generated" like C files are.
+        exclude: ^pandas/_libs/src/(klib|headers)/
+        args: [--quiet, '--extensions=c,h', '--headers=h', --recursive, '--filter=-readability/casting,-runtime/int,-build/include_subdir']
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.4
     hooks:

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -59,14 +59,6 @@ if [[ -z "$CHECK" || "$CHECK" == "lint" ]]; then
     # runtime/int: Warnings about using C number types instead of C++ ones
     # build/include_subdir: Warnings about prefacing included header files with directory
 
-    # We don't lint all C files because we don't want to lint any that are built
-    # from Cython files nor do we want to lint C files that we didn't modify for
-    # this particular codebase (e.g. src/headers, src/klib). However,
-    # we can lint all header files since they aren't "generated" like C files are.
-    MSG='Linting .c and .h' ; echo $MSG
-    cpplint --quiet --extensions=c,h --headers=h --recursive --filter=-readability/casting,-runtime/int,-build/include_subdir pandas/_libs/src/*.h pandas/_libs/src/parser pandas/_libs/src/ujson pandas/_libs/tslibs/src/datetime pandas/_libs/*.cpp
-    RET=$(($RET + $?)) ; echo $MSG "DONE"
-
 fi
 
 ### PATTERNS ###


### PR DESCRIPTION
Currently, cpplint runs from https://github.com/pandas-dev/pandas/blob/master/ci/code_checks.sh
However, cpplint have a pre-commit hook which can be used.

- [x] closes https://github.com/MarcoGorelli/pyladies-sprint-March-2021/issues/2
- [ ] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
