### PR TITLE
REF: Block.putmask dont use split_and_operate

### DIFF
--- a/pandas/core/array_algos/putmask.py
+++ b/pandas/core/array_algos/putmask.py
@@ -81,7 +81,7 @@ def putmask_smart(values: np.ndarray, mask: np.ndarray, new) -> np.ndarray:
 
     # n should be the length of the mask or a scalar here
     if not is_list_like(new):
-        new = np.repeat(new, len(mask))
+        new = np.broadcast_to(new, mask.shape)
 
     # see if we are only masking values that if putted
     # will work in the current dtype

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1098,9 +1098,9 @@ class Block(PandasObject):
                 n = new
                 if is_array:
                     # we have a different value per-column
-                    n = new.T[[i]].T
+                    n = new[:, i : i + 1]
 
-                submask = orig_mask.T[[i]].T
+                submask = orig_mask[:, i : i + 1]
                 rbs = nb.putmask(submask, n)
                 res_blocks.extend(rbs)
             return res_blocks


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

I find this much clearer.  Along with #40256 we'll be able to get rid of split_and_operate altogether