### PR TITLE
BLD: GH30873 Workaround parallel build failures

### DIFF
--- a/pandas/_libs/src/parser/tokenizer_lib.c
+++ b/pandas/_libs/src/parser/tokenizer_lib.c
@@ -1,0 +1,17 @@
+/*
+Copyright (c) 2021, PyData Development Team
+All rights reserved.
+
+Distributed under the terms of the BSD Simplified License.
+
+The full license is in the LICENSE file, distributed with this software.
+*/
+
+/*
+
+This file is used to workaround parallel compile bug,
+see https://github.com/pandas-dev/pandas/issues/30873
+
+*/
+
+#include "tokenizer.c"

--- a/pandas/_libs/src/parser/tokenizer_tslibs.c
+++ b/pandas/_libs/src/parser/tokenizer_tslibs.c
@@ -1,0 +1,17 @@
+/*
+Copyright (c) 2021, PyData Development Team
+All rights reserved.
+
+Distributed under the terms of the BSD Simplified License.
+
+The full license is in the LICENSE file, distributed with this software.
+*/
+
+/*
+
+This file is used to workaround parallel compile bug,
+see https://github.com/pandas-dev/pandas/issues/30873
+
+*/
+
+#include "tokenizer.c"

--- a/pandas/_libs/tslibs/src/datetime/np_datetime_conv.c
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime_conv.c
@@ -1,0 +1,17 @@
+/*
+Copyright (c) 2021, PyData Development Team
+All rights reserved.
+
+Distributed under the terms of the BSD Simplified License.
+
+The full license is in the LICENSE file, distributed with this software.
+*/
+
+/*
+
+This file is used to workaround parallel compile bug,
+see https://github.com/pandas-dev/pandas/issues/30873
+
+*/
+
+#include "np_datetime.c"

--- a/pandas/_libs/tslibs/src/datetime/np_datetime_period.c
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime_period.c
@@ -1,0 +1,17 @@
+/*
+Copyright (c) 2021, PyData Development Team
+All rights reserved.
+
+Distributed under the terms of the BSD Simplified License.
+
+The full license is in the LICENSE file, distributed with this software.
+*/
+
+/*
+
+This file is used to workaround parallel compile bug,
+see https://github.com/pandas-dev/pandas/issues/30873
+
+*/
+
+#include "np_datetime.c"

--- a/pandas/_libs/tslibs/src/datetime/np_datetime_strings_ujson.c
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime_strings_ujson.c
@@ -1,0 +1,17 @@
+/*
+Copyright (c) 2021, PyData Development Team
+All rights reserved.
+
+Distributed under the terms of the BSD Simplified License.
+
+The full license is in the LICENSE file, distributed with this software.
+*/
+
+/*
+
+This file is used to workaround parallel compile bug,
+see https://github.com/pandas-dev/pandas/issues/30873
+
+*/
+
+#include "np_datetime_strings.c"

--- a/pandas/_libs/tslibs/src/datetime/np_datetime_ujson.c
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime_ujson.c
@@ -1,0 +1,17 @@
+/*
+Copyright (c) 2021, PyData Development Team
+All rights reserved.
+
+Distributed under the terms of the BSD Simplified License.
+
+The full license is in the LICENSE file, distributed with this software.
+*/
+
+/*
+
+This file is used to workaround parallel compile bug,
+see https://github.com/pandas-dev/pandas/issues/30873
+
+*/
+
+#include "np_datetime.c"

--- a/setup.py
+++ b/setup.py
@@ -124,8 +124,15 @@ class CleanCommand(Command):
         ujson_lib = pjoin(base, "ujson", "lib")
         self._clean_exclude = [
             pjoin(dt, "np_datetime.c"),
+            pjoin(dt, "np_datetime_conv.c"),
+            pjoin(dt, "np_datetime_period.c"),
             pjoin(dt, "np_datetime_strings.c"),
+            pjoin(dt, "np_datetime_strings_ujson.c"),
+            pjoin(dt, "np_datetime_ujson.c"),
             pjoin(parser, "tokenizer.c"),
+            pjoin(parser, "tokenizer_lib.c"),
+            pjoin(parser, "tokenizer_tslibs.c"),
+            pjoin(parser, "tokenizer_ujson.c"),
             pjoin(parser, "io.c"),
             pjoin(ujson_python, "ujson.c"),
             pjoin(ujson_python, "objToJSON.c"),
@@ -467,7 +474,7 @@ ext_data = {
         "pyxfile": "_libs/lib",
         "depends": lib_depends + tseries_depends,
         "include": klib_include,  # due to tokenizer import
-        "sources": ["pandas/_libs/src/parser/tokenizer.c"],
+        "sources": ["pandas/_libs/src/parser/tokenizer_lib.c"],
     },
     "_libs.missing": {"pyxfile": "_libs/missing", "depends": tseries_depends},
     "_libs.parsers": {
@@ -495,7 +502,7 @@ ext_data = {
     "_libs.tslibs.conversion": {
         "pyxfile": "_libs/tslibs/conversion",
         "depends": tseries_depends,
-        "sources": ["pandas/_libs/tslibs/src/datetime/np_datetime.c"],
+        "sources": ["pandas/_libs/tslibs/src/datetime/np_datetime_conv.c"],
     },
     "_libs.tslibs.fields": {
         "pyxfile": "_libs/tslibs/fields",
@@ -518,12 +525,12 @@ ext_data = {
         "pyxfile": "_libs/tslibs/parsing",
         "include": klib_include,
         "depends": ["pandas/_libs/src/parser/tokenizer.h"],
-        "sources": ["pandas/_libs/src/parser/tokenizer.c"],
+        "sources": ["pandas/_libs/src/parser/tokenizer_tslibs.c"],
     },
     "_libs.tslibs.period": {
         "pyxfile": "_libs/tslibs/period",
         "depends": tseries_depends,
-        "sources": ["pandas/_libs/tslibs/src/datetime/np_datetime.c"],
+        "sources": ["pandas/_libs/tslibs/src/datetime/np_datetime_period.c"],
     },
     "_libs.tslibs.strptime": {
         "pyxfile": "_libs/tslibs/strptime",
@@ -606,8 +613,8 @@ ujson_ext = Extension(
             "pandas/_libs/src/ujson/lib/ultrajsondec.c",
         ]
         + [
-            "pandas/_libs/tslibs/src/datetime/np_datetime.c",
-            "pandas/_libs/tslibs/src/datetime/np_datetime_strings.c",
+            "pandas/_libs/tslibs/src/datetime/np_datetime_ujson.c",
+            "pandas/_libs/tslibs/src/datetime/np_datetime_strings_ujson.c",
         ]
     ),
     include_dirs=[


### PR DESCRIPTION
Fix parallel build race conditions due to the same source files being
used in multiple targets.  To workaround the distutils bug, create
unique .c files for each target that just #include the original file.

- [x] closes #30873 
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
