### PR TITLE
REF: de-duplicate code for pad/backfill

### DIFF
--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -597,43 +597,12 @@ def pad(ndarray[algos_t] old, ndarray[algos_t] new, limit=None):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def pad_inplace(algos_t[:] values, uint8_t[:] mask, limit=None):
-    cdef:
-        Py_ssize_t i, N
-        algos_t val
-        uint8_t prev_mask
-        int lim, fill_count = 0
-
-    N = len(values)
-
-    # GH#2778
-    if N == 0:
-        return
-
-    lim = validate_limit(N, limit)
-
-    val = values[0]
-    prev_mask = mask[0]
-    for i in range(N):
-        if mask[i]:
-            if fill_count >= lim:
-                continue
-            fill_count += 1
-            values[i] = val
-            mask[i] = prev_mask
-        else:
-            fill_count = 0
-            val = values[i]
-            prev_mask = mask[i]
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-def pad_2d_inplace(algos_t[:, :] values, const uint8_t[:, :] mask, limit=None):
+def pad_2d_inplace(algos_t[:, :] values, uint8_t[:, :] mask, limit=None):
     cdef:
         Py_ssize_t i, j, N, K
         algos_t val
         int lim, fill_count = 0
+        uint8_t prev_mask
 
     K, N = (<object>values).shape
 
@@ -646,15 +615,18 @@ def pad_2d_inplace(algos_t[:, :] values, const uint8_t[:, :] mask, limit=None):
     for j in range(K):
         fill_count = 0
         val = values[j, 0]
+        prev_mask = mask[j, 0]
         for i in range(N):
             if mask[j, i]:
                 if fill_count >= lim:
                     continue
                 fill_count += 1
                 values[j, i] = val
+                mask[j, i] = prev_mask
             else:
                 fill_count = 0
                 val = values[j, i]
+                prev_mask = mask[j, i]
 
 
 """
@@ -739,70 +711,6 @@ def backfill(ndarray[algos_t] old, ndarray[algos_t] new, limit=None) -> ndarray:
         cur = prev
 
     return indexer
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-def backfill_inplace(algos_t[:] values, uint8_t[:] mask, limit=None):
-    cdef:
-        Py_ssize_t i, N
-        algos_t val
-        uint8_t prev_mask
-        int lim, fill_count = 0
-
-    N = len(values)
-
-    # GH#2778
-    if N == 0:
-        return
-
-    lim = validate_limit(N, limit)
-
-    val = values[N - 1]
-    prev_mask = mask[N - 1]
-    for i in range(N - 1, -1, -1):
-        if mask[i]:
-            if fill_count >= lim:
-                continue
-            fill_count += 1
-            values[i] = val
-            mask[i] = prev_mask
-        else:
-            fill_count = 0
-            val = values[i]
-            prev_mask = mask[i]
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-def backfill_2d_inplace(algos_t[:, :] values,
-                        const uint8_t[:, :] mask,
-                        limit=None):
-    cdef:
-        Py_ssize_t i, j, N, K
-        algos_t val
-        int lim, fill_count = 0
-
-    K, N = (<object>values).shape
-
-    # GH#2778
-    if N == 0:
-        return
-
-    lim = validate_limit(N, limit)
-
-    for j in range(K):
-        fill_count = 0
-        val = values[j, N - 1]
-        for i in range(N - 1, -1, -1):
-            if mask[j, i]:
-                if fill_count >= lim:
-                    continue
-                fill_count += 1
-                values[j, i] = val
-            else:
-                fill_count = 0
-                val = values[j, i]
 
 
 @cython.boundscheck(False)

--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -278,8 +278,9 @@ class NDArrayBackedExtensionArray(ExtensionArray):
 
         if mask.any():
             if method is not None:
-                func = missing.get_fill_func(method)
-                new_values, _ = func(self._ndarray.copy(), limit=limit, mask=mask)
+                new_values, _ = missing.interpolate_2d(
+                    self._ndarray.copy(), method=method, limit=limit, mask=mask
+                )
                 # TODO: PandasArray didn't used to copy, need tests for this
                 new_values = self._from_backing_data(new_values)
             else:

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -701,8 +701,9 @@ class ExtensionArray:
 
         if mask.any():
             if method is not None:
-                func = missing.get_fill_func(method)
-                new_values, _ = func(self.astype(object), limit=limit, mask=mask)
+                new_values, _ = missing.interpolate_2d(
+                    self.astype(object), method=method, limit=limit, mask=mask
+                )
                 new_values = self._from_sequence(new_values, dtype=self.dtype)
             else:
                 # fill with value

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1774,10 +1774,8 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
             # pad / bfill
 
             # TODO: dispatch when self.categories is EA-dtype
-            values = np.asarray(self).reshape(-1, len(self))
-            values = interpolate_2d(values, method, 0, None).astype(
-                self.categories.dtype
-            )[0]
+            values, _ = interpolate_2d(np.asarray(self), method=method)
+            values = values.astype(self.categories.dtype)
             codes = _get_codes_for_values(values, self.categories)
 
         else:

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -670,7 +670,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         elif method is not None:
             msg = "fillna with 'method' requires high memory usage."
             warnings.warn(msg, PerformanceWarning)
-            filled = interpolate_2d(np.asarray(self), method=method, limit=limit)
+            filled, _ = interpolate_2d(np.asarray(self), method=method, limit=limit)
             return type(self)(filled, fill_value=self.fill_value)
 
         else:

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -399,8 +399,9 @@ class ArrowStringArray(OpsMixin, ExtensionArray):
 
         if mask.any():
             if method is not None:
-                func = missing.get_fill_func(method)
-                new_values, _ = func(self.to_numpy(object), limit=limit, mask=mask)
+                new_values, _ = missing.interpolate_2d(
+                    self.to_numpy(object), method=method, limit=limit, mask=mask
+                )
                 new_values = self._from_sequence(new_values)
             else:
                 # fill with value

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1208,7 +1208,7 @@ class Block(PandasObject):
 
         values = self.values if inplace else self.values.copy()
 
-        values = missing.interpolate_2d(
+        values, _ = missing.interpolate_2d(
             values,
             method=method,
             axis=axis,

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -650,22 +650,21 @@ def interpolate_2d(
         return values
 
     orig_values = values
+    mask = isna(values)
 
     if axis == 1:
-        values = values.T
+        values, mask = values.T, mask.T
 
     # reshape a 1 dim if needed
     if values.ndim == 1:
         if axis != 0:
             raise AssertionError("cannot interpolate on a ndim == 1 with axis != 0")
-        values = values[np.newaxis, :]
+        values, mask = values[np.newaxis, :], mask[np.newaxis, :]
 
     # reverse stride for backfill
     method = clean_fill_method(method)
     if method == "backfill":
-        values = values[:, ::-1]
-
-    mask = isna(values)
+        values, mask = values[:, ::-1], mask[:, ::-1]
 
     if needs_i8_conversion(values.dtype):
         values = values.view("i8")

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -660,15 +660,15 @@ def interpolate_2d(
             raise AssertionError("cannot interpolate on a ndim == 1 with axis != 0")
         values = values[np.newaxis, :]
 
-    mask = isna(values)
-
-    if needs_i8_conversion(values.dtype):
-        values = values.view("i8")
-
     # reverse stride for backfill
     method = clean_fill_method(method)
     if method == "backfill":
         values = values[:, ::-1]
+
+    mask = isna(values)
+
+    if needs_i8_conversion(values.dtype):
+        values = values.view("i8")
 
     algos.pad_2d_inplace(values, mask.view(np.uint8), limit=limit)
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4529,10 +4529,11 @@ Keep all original rows and also all original values
 
         orig_dtype = self.dtype
         result = self if inplace else self.copy()
-        fill_f = missing.get_fill_func(method)
 
         mask = missing.mask_missing(result.values, to_replace)
-        values, _ = fill_f(result.values, limit=limit, mask=mask)
+        values, _ = missing.interpolate_2d(
+            result.values, method=method, limit=limit, mask=mask
+        )
 
         if values.dtype == orig_dtype and inplace:
             return


### PR DESCRIPTION
```
       before           after         ratio
     [5ef41593]       [6a7ac9e4]
     <master>         <interpolate_2d>
+     3.44±0.04ms       5.14±0.4ms     1.50  frame_methods.Fillna.time_frame_fillna(True, 'pad', 'Float64')
+      3.48±0.1ms       5.06±0.3ms     1.45  frame_methods.Fillna.time_frame_fillna(True, 'pad', 'Int64')
+     3.32±0.05ms      4.59±0.05ms     1.38  frame_methods.Fillna.time_frame_fillna(False, 'bfill', 'Int64')
+     3.30±0.05ms       4.42±0.1ms     1.34  frame_methods.Fillna.time_frame_fillna(False, 'bfill', 'Float64')
+     3.37±0.03ms       4.43±0.1ms     1.32  frame_methods.Fillna.time_frame_fillna(False, 'pad', 'Int64')
+     3.34±0.05ms      4.30±0.08ms     1.29  frame_methods.Fillna.time_frame_fillna(False, 'pad', 'Float64')
+     2.15±0.04ms       2.48±0.2ms     1.15  frame_methods.Fillna.time_frame_fillna(True, 'bfill', 'Float64')

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE DECREASED.
```

if the general idea of this PR is acceptable, could try to improve these but these were already significantly improved in #39953. 

with the cython functions reduced from 4 to 1, it is feasible to add 1 dedicated function for no limit (my numba branch is quicker than cython with that change) instead of 4 extra functions.

also may pave the way to add limit area and limit direction support to EAs

and maybe also for 2D masked arrays? cc @jbrockmendel 

also having 1 cython function, I think also paves the way for a cython version for the limit area to remove the python set logic could be investigated.