### PR TITLE
STYLE: Extending codespell to pandas/tests Part 2

### DIFF
--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -439,8 +439,8 @@ class TestDataFrameIndexing:
         dm["foo"] = "bar"
         assert dm["foo"].dtype == np.object_
 
-        dm["coercable"] = ["1", "2", "3"]
-        assert dm["coercable"].dtype == np.object_
+        dm["coercible"] = ["1", "2", "3"]
+        assert dm["coercible"].dtype == np.object_
 
     def test_setitem_corner2(self):
         data = {

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -433,7 +433,7 @@ class TestDataFrameSetItem:
         assert is_categorical_dtype(df["D"].dtype)
         assert is_interval_dtype(df["D"].cat.categories)
 
-        # These goes through the Series constructor and so get inferred back
+        # These go through the Series constructor and so get inferred back
         #  to IntervalDtype
         assert is_interval_dtype(df["C"])
         assert is_interval_dtype(df["E"])

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -420,7 +420,7 @@ class TestDataFrameSetItem:
         assert isinstance(ser.cat.categories, IntervalIndex)
 
         # B & D end up as Categoricals
-        # the remainer are converted to in-line objects
+        # the remainder are converted to in-line objects
         # containing an IntervalIndex.values
         df["B"] = ser
         df["C"] = np.array(ser)
@@ -433,13 +433,13 @@ class TestDataFrameSetItem:
         assert is_categorical_dtype(df["D"].dtype)
         assert is_interval_dtype(df["D"].cat.categories)
 
-        # Thes goes through the Series constructor and so get inferred back
+        # These goes through the Series constructor and so get inferred back
         #  to IntervalDtype
         assert is_interval_dtype(df["C"])
         assert is_interval_dtype(df["E"])
 
         # But the Series constructor doesn't do inference on Series objects,
-        #  so setting df["F"] doesnt get cast back to IntervalDtype
+        #  so setting df["F"] doesn't get cast back to IntervalDtype
         assert is_object_dtype(df["F"])
 
         # they compare equal as Index

--- a/pandas/tests/frame/methods/test_cov_corr.py
+++ b/pandas/tests/frame/methods/test_cov_corr.py
@@ -207,7 +207,7 @@ class TestDataFrameCorr:
 
         _ = df.corr()
 
-        # Check that the corr didnt break link between ser and df
+        # Check that the corr didn't break link between ser and df
         ser.values[0] = 99
         assert df.loc[0, "A"] == 99
         assert df["A"] is ser

--- a/pandas/tests/frame/methods/test_quantile.py
+++ b/pandas/tests/frame/methods/test_quantile.py
@@ -550,11 +550,11 @@ class TestQuantileExtensionDtype:
             pd.date_range("2016-01-01", periods=9, tz="US/Pacific"),
             pytest.param(
                 pd.array(np.arange(9), dtype="Int64"),
-                marks=pytest.mark.xfail(reason="doesnt implement from_factorized"),
+                marks=pytest.mark.xfail(reason="doesn't implement from_factorized"),
             ),
             pytest.param(
                 pd.array(np.arange(9), dtype="Float64"),
-                marks=pytest.mark.xfail(reason="doesnt implement from_factorized"),
+                marks=pytest.mark.xfail(reason="doesn't implement from_factorized"),
             ),
         ],
         ids=lambda x: str(x.dtype),

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1439,8 +1439,8 @@ class TestDataFrameReplace:
 
         a = pd.Categorical(final_data[:, 0], categories=[3, 2])
 
-        excat = [3, 2] if replace_dict["b"] == 1 else [1, 3]
-        b = pd.Categorical(final_data[:, 1], categories=excat)
+        ex_cat = [3, 2] if replace_dict["b"] == 1 else [1, 3]
+        b = pd.Categorical(final_data[:, 1], categories=ex_cat)
 
         expected = DataFrame({"a": a, "b": b})
         result = df.replace(replace_dict, 3)

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -137,8 +137,8 @@ class TestResetIndex:
 
         # preserve column names
         float_frame.columns.name = "columns"
-        resetted = float_frame.reset_index()
-        assert resetted.columns.name == "columns"
+        reset = float_frame.reset_index()
+        assert reset.columns.name == "columns"
 
         # only remove certain columns
         df = float_frame.reset_index().set_index(["index", "A", "B"])
@@ -159,10 +159,10 @@ class TestResetIndex:
 
         # test resetting in place
         df = float_frame.copy()
-        resetted = float_frame.reset_index()
+        reset = float_frame.reset_index()
         return_value = df.reset_index(inplace=True)
         assert return_value is None
-        tm.assert_frame_equal(df, resetted, check_names=False)
+        tm.assert_frame_equal(df, reset, check_names=False)
 
         df = float_frame.reset_index().set_index(["index", "A", "B"])
         rs = df.reset_index("A", drop=True)
@@ -224,11 +224,11 @@ class TestResetIndex:
         )
         df = DataFrame(s1)
 
-        resetted = s1.reset_index()
-        assert resetted["time"].dtype == np.float64
+        reset = s1.reset_index()
+        assert reset["time"].dtype == np.float64
 
-        resetted = df.reset_index()
-        assert resetted["time"].dtype == np.float64
+        reset = df.reset_index()
+        assert reset["time"].dtype == np.float64
 
     def test_reset_index_multiindex_col(self):
         vals = np.random.randn(3, 3).astype(object)

--- a/pandas/tests/frame/methods/test_to_dict_of_blocks.py
+++ b/pandas/tests/frame/methods/test_to_dict_of_blocks.py
@@ -53,7 +53,7 @@ def test_to_dict_of_blocks_item_cache():
 
     df._to_dict_of_blocks()
 
-    # Check that the to_dict_of_blocks didnt break link between ser and df
+    # Check that the to_dict_of_blocks didn't break link between ser and df
     ser.values[0] = "foo"
     assert df.loc[0, "b"] == "foo"
 

--- a/pandas/tests/frame/methods/test_values.py
+++ b/pandas/tests/frame/methods/test_values.py
@@ -91,7 +91,7 @@ class TestDataFrameValues:
         )
         tm.assert_numpy_array_equal(result, expected)
 
-        # two columns, homogenous
+        # two columns, homogeneous
 
         df["B"] = df["A"]
         result = df.values

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -519,7 +519,7 @@ class TestDataFrameSubclassing:
         def check_row_subclass(row):
             assert isinstance(row, tm.SubclassedSeries)
 
-        def strech(row):
+        def stretch(row):
             if row["variable"] == "height":
                 row["value"] += 0.5
             return row
@@ -547,7 +547,7 @@ class TestDataFrameSubclassing:
             columns=["first", "last", "variable", "value"],
         )
 
-        result = df.apply(lambda x: strech(x), axis=1)
+        result = df.apply(lambda x: stretch(x), axis=1)
         assert isinstance(result, tm.SubclassedDataFrame)
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -758,7 +758,7 @@ def test_agg_relabel_multiindex_column(
 
 
 def test_agg_relabel_multiindex_raises_not_exist():
-    # GH 29422, add test for raises senario when aggregate column does not exist
+    # GH 29422, add test for raises scenario when aggregate column does not exist
     df = DataFrame(
         {"group": ["a", "a", "b", "b"], "A": [0, 1, 2, 3], "B": [5, 6, 7, 8]}
     )
@@ -769,7 +769,7 @@ def test_agg_relabel_multiindex_raises_not_exist():
 
 
 def test_agg_relabel_multiindex_duplicates():
-    # GH29422, add test for raises senario when getting duplicates
+    # GH29422, add test for raises scenario when getting duplicates
     # GH28426, after this change, duplicates should also work if the relabelling is
     # different
     df = DataFrame(

--- a/pandas/tests/groupby/test_libgroupby.py
+++ b/pandas/tests/groupby/test_libgroupby.py
@@ -176,13 +176,13 @@ def _check_cython_group_transform_cumulative(pd_op, np_op, dtype):
     is_datetimelike = False
 
     data = np.array([[1], [2], [3], [4]], dtype=dtype)
-    ans = np.zeros_like(data)
+    answer = np.zeros_like(data)
 
     labels = np.array([0, 0, 0, 0], dtype=np.int64)
     ngroups = 1
-    pd_op(ans, data, labels, ngroups, is_datetimelike)
+    pd_op(answer, data, labels, ngroups, is_datetimelike)
 
-    tm.assert_numpy_array_equal(np_op(data), ans[:, 0], check_dtype=False)
+    tm.assert_numpy_array_equal(np_op(data), answer[:, 0], check_dtype=False)
 
 
 def test_cython_group_transform_cumsum(any_real_dtype):

--- a/pandas/tests/indexes/categorical/test_formats.py
+++ b/pandas/tests/indexes/categorical/test_formats.py
@@ -76,7 +76,7 @@ class TestCategoricalIndexRepr:
 
         assert repr(idx) == expected
 
-        # Emable Unicode option -----------------------------------------
+        # Enable Unicode option -----------------------------------------
         with cf.option_context("display.unicode.east_asian_width", True):
 
             # short

--- a/pandas/tests/indexes/datetimelike_/test_sort_values.py
+++ b/pandas/tests/indexes/datetimelike_/test_sort_values.py
@@ -295,7 +295,7 @@ class TestSortValues:
         self.check_sort_values_without_freq(idx, expected)
 
     def test_sort_values_without_freq_periodindex_nat(self):
-        # doesnt quite fit into check_sort_values_without_freq
+        # doesn't quite fit into check_sort_values_without_freq
         idx = PeriodIndex(["2011", "2013", "NaT", "2011"], name="pidx", freq="D")
         expected = PeriodIndex(["NaT", "2011", "2011", "2013"], name="pidx", freq="D")
 

--- a/pandas/tests/indexes/datetimes/methods/test_insert.py
+++ b/pandas/tests/indexes/datetimes/methods/test_insert.py
@@ -47,7 +47,7 @@ class TestInsert:
         result = dti.insert(0, item)
         assert result.freq == dti.freq
 
-        # But not when we insert an item that doesnt conform to freq
+        # But not when we insert an item that doesn't conform to freq
         dti = DatetimeIndex([], tz=tz, freq="W-THU")
         result = dti.insert(0, item)
         assert result.freq is None

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -465,7 +465,7 @@ class TestDatetimeIndexTimezones:
         idx = date_range(start="2014-06-01", end="2014-08-30", freq="15T")
         tz = tz_aware_fixture
         localized = idx.tz_localize(tz)
-        # cant localize a tz-aware object
+        # can't localize a tz-aware object
         with pytest.raises(
             TypeError, match="Already tz-aware, use tz_convert to convert"
         ):

--- a/pandas/tests/indexes/multi/test_constructors.py
+++ b/pandas/tests/indexes/multi/test_constructors.py
@@ -108,7 +108,7 @@ def test_constructor_mismatched_codes_levels(idx):
 def test_na_levels():
     # GH26408
     # test if codes are re-assigned value -1 for levels
-    # with mising values (NaN, NaT, None)
+    # with missing values (NaN, NaT, None)
     result = MultiIndex(
         levels=[[np.nan, None, pd.NaT, 128, 2]], codes=[[0, -1, 1, 2, 3, 4]]
     )

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -464,7 +464,7 @@ class TestGetIndexer:
         tm.assert_numpy_array_equal(result, expected)
 
     def test_get_indexer_mismatched_dtype_different_length(self, non_comparable_idx):
-        # without method we arent checking inequalities, so get all-missing
+        # without method we aren't checking inequalities, so get all-missing
         #  but do not raise
         dti = date_range("2016-01-01", periods=3)
         pi = dti.to_period("D")

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -386,7 +386,7 @@ class TestIndex(Base):
     @pytest.mark.parametrize("klass", [Index, TimedeltaIndex])
     def test_constructor_dtypes_timedelta(self, attr, klass):
         index = pd.timedelta_range("1 days", periods=5)
-        index = index._with_freq(None)  # wont be preserved by constructors
+        index = index._with_freq(None)  # won't be preserved by constructors
         dtype = index.dtype
 
         values = getattr(index, attr)

--- a/pandas/tests/indexes/timedeltas/methods/test_insert.py
+++ b/pandas/tests/indexes/timedeltas/methods/test_insert.py
@@ -128,7 +128,7 @@ class TestTimedeltaIndexInsert:
         tm.assert_index_equal(result, expected)
 
     def test_insert_empty(self):
-        # Corner case inserting with length zero doesnt raise IndexError
+        # Corner case inserting with length zero doesn't raise IndexError
         # GH#33573 for freq preservation
         idx = timedelta_range("1 Day", periods=3)
         td = idx[0]

--- a/pandas/tests/indexes/timedeltas/test_setops.py
+++ b/pandas/tests/indexes/timedeltas/test_setops.py
@@ -116,7 +116,7 @@ class TestTimedeltaIndex:
 
     def test_intersection_equal(self, sort):
         # GH 24471 Test intersection outcome given the sort keyword
-        # for equal indicies intersection should return the original index
+        # for equal indices intersection should return the original index
         first = timedelta_range("1 day", periods=4, freq="h")
         second = timedelta_range("1 day", periods=4, freq="h")
         intersect = first.intersection(second, sort=sort)

--- a/pandas/tests/indexing/common.py
+++ b/pandas/tests/indexing/common.py
@@ -136,9 +136,9 @@ class Base:
         if f is None:
             return
         axes = f.axes
-        indicies = itertools.product(*axes)
+        indices = itertools.product(*axes)
 
-        for i in indicies:
+        for i in indices:
             result = getattr(f, func)[i]
 
             # check against values

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -443,7 +443,7 @@ class TestInsertIndexCoercion(CoercionBase):
             assert expected.dtype == object
             tm.assert_index_equal(result, expected)
 
-            # mismatched tz --> cast to object (could reasonably cast to commom tz)
+            # mismatched tz --> cast to object (could reasonably cast to common tz)
             ts = pd.Timestamp("2012-01-01", tz="Asia/Tokyo")
             result = obj.insert(1, ts)
             expected = obj.astype(object).insert(1, ts)

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -112,7 +112,7 @@ class TestiLocBaseIndependent:
             assert obj.values.base is values.base and values.base is not None
 
     def test_is_scalar_access(self):
-        # GH#32085 index with duplicates doesnt matter for _is_scalar_access
+        # GH#32085 index with duplicates doesn't matter for _is_scalar_access
         index = Index([1, 2, 1])
         ser = Series(range(3), index=index)
 
@@ -739,18 +739,18 @@ class TestiLocBaseIndependent:
                             accessor = getattr(df, method[1:])
                         else:
                             accessor = df
-                        ans = str(bin(accessor[mask]["nums"].sum()))
+                        answer = str(bin(accessor[mask]["nums"].sum()))
                     except (ValueError, IndexingError, NotImplementedError) as e:
-                        ans = str(e)
+                        answer = str(e)
 
                     key = (
                         idx,
                         method,
                     )
                     r = expected.get(key)
-                    if r != ans:
+                    if r != answer:
                         raise AssertionError(
-                            f"[{key}] does not match [{ans}], received [{r}]"
+                            f"[{key}] does not match [{answer}], received [{r}]"
                         )
 
     def test_iloc_non_unique_indexing(self):


### PR DESCRIPTION
- [X] xref #38802 
- [X] tests added / passed
- [X] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
