### PR TITLE
BUG: IntervalArray.insert cast on failure

### DIFF
--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -1483,6 +1483,28 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             self._left.putmask(mask, value_left)
             self._right.putmask(mask, value_right)
 
+    def insert(self: IntervalArrayT, loc: int, item: Interval) -> IntervalArrayT:
+        """
+        Return a new IntervalArray inserting new item at location. Follows
+        Python list.append semantics for negative values.  Only Interval
+        objects and NA can be inserted into an IntervalIndex
+
+        Parameters
+        ----------
+        loc : int
+        item : Interval
+
+        Returns
+        -------
+        IntervalArray
+        """
+        left_insert, right_insert = self._validate_scalar(item)
+
+        new_left = self.left.insert(loc, left_insert)
+        new_right = self.right.insert(loc, right_insert)
+
+        return self._shallow_copy(new_left, new_right)
+
     def delete(self: IntervalArrayT, loc) -> IntervalArrayT:
         if isinstance(self._left, np.ndarray):
             new_left = np.delete(self._left, loc)

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -873,11 +873,14 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
         -------
         IntervalIndex
         """
-        left_insert, right_insert = self._data._validate_scalar(item)
+        try:
+            result = self._data.insert(loc, item)
+        except (ValueError, TypeError):
+            # e.g trying to insert a string
+            dtype, _ = infer_dtype_from_scalar(item, pandas_dtype=True)
+            dtype = find_common_type([self.dtype, dtype])
+            return self.astype(dtype).insert(loc, item)
 
-        new_left = self.left.insert(loc, left_insert)
-        new_right = self.right.insert(loc, right_insert)
-        result = self._data._shallow_copy(new_left, new_right)
         return type(self)._simple_new(result, name=self.name)
 
     # --------------------------------------------------------------------

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -23,7 +23,6 @@ from pandas import (
     DatetimeIndex,
     Index,
     IndexSlice,
-    IntervalIndex,
     MultiIndex,
     Period,
     Series,
@@ -1680,9 +1679,6 @@ class TestLocSetitemWithExpansion:
         # GH#40096
         if not len(index):
             return
-        if isinstance(index, IntervalIndex):
-            mark = pytest.mark.xfail(reason="IntervalIndex raises")
-            request.node.add_marker(mark)
 
         index = index.repeat(2)  # ensure non-unique
         N = len(index)


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

We fixed this for DTI/TDI/PI in #39068.  Also did CategoricalIndex recently, not sure where off the top.