### PR TITLE
BUG: Post-merge fixup, raise on dimension-expanding

### DIFF
--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1659,6 +1659,9 @@ class SingleBlockManager(BlockManager, SingleDataManager):
         # similar to get_slice, but not restricted to slice indexer
         blk = self._block
         array = blk._slice(indexer)
+        if array.ndim > blk.values.ndim:
+            # This will be caught by Series._get_values
+            raise ValueError("dimension-expanding indexing not allowed")
         block = blk.make_block_same_class(array, placement=slice(0, len(array)))
         return type(self)(block, self.index[indexer])
 


### PR DESCRIPTION
Looks like a couple of individually-correct things got merged that together are causing failures on master.  This should fix it.