### PR TITLE
TYP: change ArrayLike/AnyArrayLike alias to Union

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
     from pandas.core.dtypes.dtypes import ExtensionDtype
 
     from pandas import Interval
-    from pandas.core.arrays.base import ExtensionArray  # noqa: F401
+    from pandas.core.arrays.base import ExtensionArray
     from pandas.core.frame import DataFrame
     from pandas.core.generic import NDFrame  # noqa: F401
     from pandas.core.groupby.generic import (
@@ -74,8 +74,8 @@ else:
 
 # array-like
 
-AnyArrayLike = TypeVar("AnyArrayLike", "ExtensionArray", "Index", "Series", np.ndarray)
-ArrayLike = TypeVar("ArrayLike", "ExtensionArray", np.ndarray)
+ArrayLike = Union["ExtensionArray", np.ndarray]
+AnyArrayLike = Union[ArrayLike, "Index", "Series"]
 
 # scalars
 

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -176,9 +176,7 @@ def _ensure_data(values: ArrayLike) -> Tuple[np.ndarray, DtypeObj]:
         elif is_timedelta64_dtype(values.dtype):
             from pandas import TimedeltaIndex
 
-            # error: Incompatible types in assignment (expression has type
-            # "TimedeltaArray", variable has type "ndarray")
-            values = TimedeltaIndex(values)._data  # type: ignore[assignment]
+            values = TimedeltaIndex(values)._data
         else:
             # Datetime
             if values.ndim > 1 and is_datetime64_ns_dtype(values.dtype):
@@ -194,22 +192,13 @@ def _ensure_data(values: ArrayLike) -> Tuple[np.ndarray, DtypeObj]:
 
             from pandas import DatetimeIndex
 
-            # Incompatible types in assignment (expression has type "DatetimeArray",
-            # variable has type "ndarray")
-            values = DatetimeIndex(values)._data  # type: ignore[assignment]
+            values = DatetimeIndex(values)._data
         dtype = values.dtype
-        # error: Item "ndarray" of "Union[PeriodArray, Any, ndarray]" has no attribute
-        # "asi8"
-        return values.asi8, dtype  # type: ignore[union-attr]
+        return values.asi8, dtype
 
     elif is_categorical_dtype(values.dtype):
-        # error: Incompatible types in assignment (expression has type "Categorical",
-        # variable has type "ndarray")
-        values = cast("Categorical", values)  # type: ignore[assignment]
-        # error: Incompatible types in assignment (expression has type "ndarray",
-        # variable has type "ExtensionArray")
-        # error: Item "ndarray" of "Union[Any, ndarray]" has no attribute "codes"
-        values = values.codes  # type: ignore[assignment,union-attr]
+        values = cast("Categorical", values)
+        values = values.codes
         dtype = pandas_dtype("category")
 
         # we are actually coercing to int64
@@ -222,10 +211,7 @@ def _ensure_data(values: ArrayLike) -> Tuple[np.ndarray, DtypeObj]:
         return values, dtype  # type: ignore[return-value]
 
     # we have failed, return object
-
-    # error: Incompatible types in assignment (expression has type "ndarray", variable
-    # has type "ExtensionArray")
-    values = np.asarray(values, dtype=object)  # type: ignore[assignment]
+    values = np.asarray(values, dtype=object)
     return ensure_object(values), np.dtype("object")
 
 
@@ -335,9 +321,7 @@ def _get_values_for_rank(values: ArrayLike):
     if is_categorical_dtype(values):
         values = cast("Categorical", values)._values_for_rank()
 
-    # error: Incompatible types in assignment (expression has type "ndarray", variable
-    # has type "ExtensionArray")
-    values, _ = _ensure_data(values)  # type: ignore[assignment]
+    values, _ = _ensure_data(values)
     return values
 
 
@@ -503,42 +487,15 @@ def isin(comps: AnyArrayLike, values: AnyArrayLike) -> np.ndarray:
         )
 
     if not isinstance(values, (ABCIndex, ABCSeries, ABCExtensionArray, np.ndarray)):
-        # error: Incompatible types in assignment (expression has type "ExtensionArray",
-        # variable has type "Index")
-        # error: Incompatible types in assignment (expression has type "ExtensionArray",
-        # variable has type "Series")
-        # error: Incompatible types in assignment (expression has type "ExtensionArray",
-        # variable has type "ndarray")
-        values = _ensure_arraylike(list(values))  # type: ignore[assignment]
+        values = _ensure_arraylike(list(values))
     elif isinstance(values, ABCMultiIndex):
         # Avoid raising in extract_array
-
-        # error: Incompatible types in assignment (expression has type "ndarray",
-        # variable has type "ExtensionArray")
-        # error: Incompatible types in assignment (expression has type "ndarray",
-        # variable has type "Index")
-        # error: Incompatible types in assignment (expression has type "ndarray",
-        # variable has type "Series")
-        values = np.array(values)  # type: ignore[assignment]
+        values = np.array(values)
     else:
-        # error: Incompatible types in assignment (expression has type "Union[Any,
-        # ExtensionArray]", variable has type "Index")
-        # error: Incompatible types in assignment (expression has type "Union[Any,
-        # ExtensionArray]", variable has type "Series")
-        values = extract_array(values, extract_numpy=True)  # type: ignore[assignment]
+        values = extract_array(values, extract_numpy=True)
 
-    # error: Incompatible types in assignment (expression has type "ExtensionArray",
-    # variable has type "Index")
-    # error: Incompatible types in assignment (expression has type "ExtensionArray",
-    # variable has type "Series")
-    # error: Incompatible types in assignment (expression has type "ExtensionArray",
-    # variable has type "ndarray")
-    comps = _ensure_arraylike(comps)  # type: ignore[assignment]
-    # error: Incompatible types in assignment (expression has type "Union[Any,
-    # ExtensionArray]", variable has type "Index")
-    # error: Incompatible types in assignment (expression has type "Union[Any,
-    # ExtensionArray]", variable has type "Series")
-    comps = extract_array(comps, extract_numpy=True)  # type: ignore[assignment]
+    comps = _ensure_arraylike(comps)
+    comps = extract_array(comps, extract_numpy=True)
     if is_extension_array_dtype(comps.dtype):
         # error: Incompatible return value type (got "Series", expected "ndarray")
         # error: Item "ndarray" of "Union[Any, ndarray]" has no attribute "isin"
@@ -1000,9 +957,7 @@ def duplicated(values: ArrayLike, keep: Union[str, bool] = "first") -> np.ndarra
     -------
     duplicated : ndarray
     """
-    # error: Incompatible types in assignment (expression has type "ndarray", variable
-    # has type "ExtensionArray")
-    values, _ = _ensure_data(values)  # type: ignore[assignment]
+    values, _ = _ensure_data(values)
     ndtype = values.dtype.name
     f = getattr(htable, f"duplicated_{ndtype}")
     return f(values, keep=keep)

--- a/pandas/core/array_algos/putmask.py
+++ b/pandas/core/array_algos/putmask.py
@@ -191,16 +191,10 @@ def extract_bool_array(mask: ArrayLike) -> np.ndarray:
         # We could have BooleanArray, Sparse[bool], ...
         #  Except for BooleanArray, this is equivalent to just
         #  np.asarray(mask, dtype=bool)
+        mask = mask.to_numpy(dtype=bool, na_value=False)
 
-        # error: Incompatible types in assignment (expression has type "ndarray",
-        # variable has type "ExtensionArray")
-        mask = mask.to_numpy(dtype=bool, na_value=False)  # type: ignore[assignment]
-
-    # error: Incompatible types in assignment (expression has type "ndarray", variable
-    # has type "ExtensionArray")
-    mask = np.asarray(mask, dtype=bool)  # type: ignore[assignment]
-    # error: Incompatible return value type (got "ExtensionArray", expected "ndarray")
-    return mask  # type: ignore[return-value]
+    mask = np.asarray(mask, dtype=bool)
+    return mask
 
 
 def setitem_datetimelike_compat(values: np.ndarray, num_set: int, other):

--- a/pandas/core/array_algos/quantile.py
+++ b/pandas/core/array_algos/quantile.py
@@ -40,14 +40,9 @@ def quantile_compat(values: ArrayLike, qs, interpolation: str, axis: int) -> Arr
     if isinstance(values, np.ndarray):
         fill_value = na_value_for_dtype(values.dtype, compat=False)
         mask = isna(values)
-        result = quantile_with_mask(values, mask, fill_value, qs, interpolation, axis)
+        return quantile_with_mask(values, mask, fill_value, qs, interpolation, axis)
     else:
-        # error: Incompatible types in assignment (expression has type "ExtensionArray",
-        # variable has type "ndarray")
-        result = quantile_ea_compat(  # type: ignore[assignment]
-            values, qs, interpolation, axis
-        )
-    return result
+        return quantile_ea_compat(values, qs, interpolation, axis)
 
 
 def quantile_with_mask(

--- a/pandas/core/array_algos/quantile.py
+++ b/pandas/core/array_algos/quantile.py
@@ -42,7 +42,11 @@ def quantile_compat(values: ArrayLike, qs, interpolation: str, axis: int) -> Arr
         mask = isna(values)
         result = quantile_with_mask(values, mask, fill_value, qs, interpolation, axis)
     else:
-        result = quantile_ea_compat(values, qs, interpolation, axis)
+        # error: Incompatible types in assignment (expression has type "ExtensionArray",
+        # variable has type "ndarray")
+        result = quantile_ea_compat(  # type: ignore[assignment]
+            values, qs, interpolation, axis
+        )
     return result
 
 

--- a/pandas/core/array_algos/replace.py
+++ b/pandas/core/array_algos/replace.py
@@ -95,9 +95,7 @@ def compare_or_regex_search(
 
     if is_numeric_v_string_like(a, b):
         # GH#29553 avoid deprecation warnings from numpy
-        # error: Incompatible return value type (got "ndarray", expected
-        # "Union[ExtensionArray, bool]")
-        return np.zeros(a.shape, dtype=bool)  # type: ignore[return-value]
+        return np.zeros(a.shape, dtype=bool)
 
     elif is_datetimelike_v_numeric(a, b):
         # GH#29553 avoid deprecation warnings from numpy

--- a/pandas/core/array_algos/take.py
+++ b/pandas/core/array_algos/take.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import functools
-from typing import Optional
+from typing import (
+    TYPE_CHECKING,
+    Optional,
+    overload,
+)
 
 import numpy as np
 
@@ -19,6 +23,33 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.missing import na_value_for_dtype
 
 from pandas.core.construction import ensure_wrapped_if_datetimelike
+
+if TYPE_CHECKING:
+    from pandas.core.arrays.base import ExtensionArray
+
+
+@overload
+def take_nd(
+    arr: np.ndarray,
+    indexer,
+    axis: int = ...,
+    out: Optional[np.ndarray] = ...,
+    fill_value=...,
+    allow_fill: bool = ...,
+) -> np.ndarray:
+    ...
+
+
+@overload
+def take_nd(
+    arr: ExtensionArray,
+    indexer,
+    axis: int = ...,
+    out: Optional[np.ndarray] = ...,
+    fill_value=...,
+    allow_fill: bool = ...,
+) -> ArrayLike:
+    ...
 
 
 def take_nd(

--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -291,8 +291,9 @@ class NDArrayBackedExtensionArray(ExtensionArray):
             value, mask, len(self)  # type: ignore[arg-type]
         )
 
-        # error: "ExtensionArray" has no attribute "any"
-        if mask.any():  # type: ignore[attr-defined]
+        # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
+        # attribute "any"
+        if mask.any():  # type: ignore[union-attr]
             if method is not None:
                 # TODO: check value is None
                 # (for now) when self.ndim == 2, we assume axis=0

--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -291,9 +291,7 @@ class NDArrayBackedExtensionArray(ExtensionArray):
             value, mask, len(self)  # type: ignore[arg-type]
         )
 
-        # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
-        # attribute "any"
-        if mask.any():  # type: ignore[union-attr]
+        if mask.any():
             if method is not None:
                 # TODO: check value is None
                 # (for now) when self.ndim == 2, we assume axis=0

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -391,8 +391,11 @@ class ExtensionArray:
             if not self._can_hold_na:
                 return False
             elif item is self.dtype.na_value or isinstance(item, self.dtype.type):
-                # error: "ExtensionArray" has no attribute "any"
-                return self.isna().any()  # type: ignore[attr-defined]
+                # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has
+                # no attribute "any"
+                # error: Incompatible return value type (got "Union[Any, bool_]",
+                # expected "bool")
+                return self.isna().any()  # type: ignore[union-attr, return-value]
             else:
                 return False
         else:
@@ -648,8 +651,9 @@ class ExtensionArray:
         ExtensionArray.argmax
         """
         validate_bool_kwarg(skipna, "skipna")
-        # error: "ExtensionArray" has no attribute "any"
-        if not skipna and self.isna().any():  # type: ignore[attr-defined]
+        # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
+        # attribute "any"
+        if not skipna and self.isna().any():  # type: ignore[union-attr]
             raise NotImplementedError
         return nargminmax(self, "argmin")
 
@@ -673,8 +677,9 @@ class ExtensionArray:
         ExtensionArray.argmin
         """
         validate_bool_kwarg(skipna, "skipna")
-        # error: "ExtensionArray" has no attribute "any"
-        if not skipna and self.isna().any():  # type: ignore[attr-defined]
+        # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
+        # attribute "any"
+        if not skipna and self.isna().any():  # type: ignore[union-attr]
             raise NotImplementedError
         return nargminmax(self, "argmax")
 
@@ -714,8 +719,9 @@ class ExtensionArray:
             value, mask, len(self)  # type: ignore[arg-type]
         )
 
-        # error: "ExtensionArray" has no attribute "any"
-        if mask.any():  # type: ignore[attr-defined]
+        # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
+        # attribute "any"
+        if mask.any():  # type: ignore[union-attr]
             if method is not None:
                 func = missing.get_fill_func(method)
                 new_values, _ = func(self.astype(object), limit=limit, mask=mask)
@@ -1156,9 +1162,7 @@ class ExtensionArray:
         #   giving a view with the same dtype as self.
         if dtype is not None:
             raise NotImplementedError(dtype)
-        # error: Incompatible return value type (got "Union[ExtensionArray, Any]",
-        # expected "ndarray")
-        return self[:]  # type: ignore[return-value]
+        return self[:]
 
     # ------------------------------------------------------------------------
     # Printing

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import operator
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -70,6 +71,16 @@ from pandas.core.sorting import (
     nargminmax,
     nargsort,
 )
+
+if TYPE_CHECKING:
+
+    class ExtensionArraySupportsAnyAll("ExtensionArray"):
+        def any(self, *, skipna: bool = True):
+            pass
+
+        def all(self, *, skipna: bool = True):
+            pass
+
 
 _extension_array_shared_docs: Dict[str, str] = {}
 
@@ -546,7 +557,7 @@ class ExtensionArray:
 
         return np.array(self, dtype=dtype, copy=copy)
 
-    def isna(self) -> ArrayLike:
+    def isna(self) -> Union[np.ndarray, ExtensionArraySupportsAnyAll]:
         """
         A 1-D array indicating if each value is missing.
 
@@ -651,9 +662,7 @@ class ExtensionArray:
         ExtensionArray.argmax
         """
         validate_bool_kwarg(skipna, "skipna")
-        # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
-        # attribute "any"
-        if not skipna and self.isna().any():  # type: ignore[union-attr]
+        if not skipna and self.isna().any():
             raise NotImplementedError
         return nargminmax(self, "argmin")
 
@@ -677,9 +686,7 @@ class ExtensionArray:
         ExtensionArray.argmin
         """
         validate_bool_kwarg(skipna, "skipna")
-        # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
-        # attribute "any"
-        if not skipna and self.isna().any():  # type: ignore[union-attr]
+        if not skipna and self.isna().any():
             raise NotImplementedError
         return nargminmax(self, "argmax")
 
@@ -719,9 +726,7 @@ class ExtensionArray:
             value, mask, len(self)  # type: ignore[arg-type]
         )
 
-        # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
-        # attribute "any"
-        if mask.any():  # type: ignore[union-attr]
+        if mask.any():
             if method is not None:
                 func = missing.get_fill_func(method)
                 new_values, _ = func(self.astype(object), limit=limit, mask=mask)

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -75,10 +75,10 @@ from pandas.core.sorting import (
 if TYPE_CHECKING:
 
     class ExtensionArraySupportsAnyAll("ExtensionArray"):
-        def any(self, *, skipna: bool = True):
+        def any(self, *, skipna: bool = True) -> bool:
             pass
 
-        def all(self, *, skipna: bool = True):
+        def all(self, *, skipna: bool = True) -> bool:
             pass
 
 
@@ -391,7 +391,7 @@ class ExtensionArray:
         for i in range(len(self)):
             yield self[i]
 
-    def __contains__(self, item) -> bool:
+    def __contains__(self, item) -> Union[bool, np.bool_]:
         """
         Return for `item in self`.
         """
@@ -402,11 +402,7 @@ class ExtensionArray:
             if not self._can_hold_na:
                 return False
             elif item is self.dtype.na_value or isinstance(item, self.dtype.type):
-                # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has
-                # no attribute "any"
-                # error: Incompatible return value type (got "Union[Any, bool_]",
-                # expected "bool")
-                return self.isna().any()  # type: ignore[union-attr, return-value]
+                return self.isna().any()
             else:
                 return False
         else:

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -406,18 +406,14 @@ class BooleanArray(BaseMaskedArray):
         dtype = pandas_dtype(dtype)
 
         if isinstance(dtype, ExtensionDtype):
-            # error: Incompatible return value type (got "ExtensionArray", expected
-            # "ndarray")
-            return super().astype(dtype, copy)  # type: ignore[return-value]
+            return super().astype(dtype, copy)
 
         if is_bool_dtype(dtype):
             # astype_nansafe converts np.nan to True
             if self._hasna:
                 raise ValueError("cannot convert float NaN to bool")
             else:
-                # error: Incompatible return value type (got "ndarray", expected
-                # "ExtensionArray")
-                return self._data.astype(dtype, copy=copy)  # type: ignore[return-value]
+                return self._data.astype(dtype, copy=copy)
 
         # for integer, error if there are missing values
         if is_integer_dtype(dtype) and self._hasna:
@@ -429,12 +425,7 @@ class BooleanArray(BaseMaskedArray):
         if is_float_dtype(dtype):
             na_value = np.nan
         # coerce
-
-        # error: Incompatible return value type (got "ndarray", expected
-        # "ExtensionArray")
-        return self.to_numpy(  # type: ignore[return-value]
-            dtype=dtype, na_value=na_value, copy=False
-        )
+        return self.to_numpy(dtype=dtype, na_value=na_value, copy=False)
 
     def _values_for_argsort(self) -> np.ndarray:
         """

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2706,9 +2706,7 @@ def recode_for_categories(
         new_categories.get_indexer(old_categories), new_categories
     )
     new_codes = take_nd(indexer, codes, fill_value=-1)
-    # error: Incompatible return value type (got "Union[ExtensionArray, ndarray]",
-    # expected "ndarray")
-    return new_codes  # type: ignore[return-value]
+    return new_codes
 
 
 def factorize_from_iterable(values):

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -550,8 +550,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
                 new_cats, libalgos.ensure_platform_int(self._codes)
             )
 
-        # error: Incompatible return value type (got "Categorical", expected "ndarray")
-        return result  # type: ignore[return-value]
+        return result
 
     @cache_readonly
     def itemsize(self) -> int:
@@ -2659,8 +2658,9 @@ def _get_codes_for_values(values, categories: Index) -> np.ndarray:
     # Only hit here when we've already coerced to object dtypee.
 
     hash_klass, vals = get_data_algo(values)
-    # error: Value of type variable "ArrayLike" of "get_data_algo" cannot be "Index"
-    _, cats = get_data_algo(categories)  # type: ignore[type-var]
+    # pandas/core/arrays/categorical.py:2661: error: Argument 1 to "get_data_algo" has
+    # incompatible type "Index"; expected "Union[ExtensionArray, ndarray]"  [arg-type]
+    _, cats = get_data_algo(categories)  # type: ignore[arg-type]
     t = hash_klass(len(cats))
     t.map_locations(cats)
     return coerce_indexer_dtype(t.lookup(vals), cats)
@@ -2706,7 +2706,9 @@ def recode_for_categories(
         new_categories.get_indexer(old_categories), new_categories
     )
     new_codes = take_nd(indexer, codes, fill_value=-1)
-    return new_codes
+    # error: Incompatible return value type (got "Union[ExtensionArray, ndarray]",
+    # expected "ndarray")
+    return new_codes  # type: ignore[return-value]
 
 
 def factorize_from_iterable(values):

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -16,6 +16,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    overload,
 )
 import warnings
 
@@ -452,6 +453,14 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
             return arr_cls(self, dtype=dtype)
         else:
             return np.asarray(self, dtype=dtype)
+
+    @overload
+    def view(self: DatetimeLikeArrayT) -> DatetimeLikeArrayT:
+        ...
+
+    @overload
+    def view(self, dtype: Optional[Dtype] = ...) -> ArrayLike:
+        ...
 
     def view(self, dtype: Optional[Dtype] = None) -> ArrayLike:
         # We handle datetime64, datetime64tz, timedelta64, and period
@@ -1774,11 +1783,7 @@ class TimelikeOps(DatetimeLikeArrayMixin):
             freq = to_offset(self.inferred_freq)
 
         arr = self.view()
-        # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
-        # attribute "_freq"
-        # error: Item "ndarray" of "Union[ExtensionArray, ndarray]" has no attribute
-        # "_freq"
-        arr._freq = freq  # type: ignore[union-attr]
+        arr._freq = freq
         return arr
 
     # --------------------------------------------------------------

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -458,38 +458,25 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         #  dtypes here. Everything else we pass through to the underlying
         #  ndarray.
         if dtype is None or dtype is self.dtype:
-            # error: Incompatible return value type (got "DatetimeLikeArrayMixin",
-            # expected "ndarray")
-            return type(self)(  # type: ignore[return-value]
-                self._ndarray, dtype=self.dtype
-            )
+            return type(self)(self._ndarray, dtype=self.dtype)
 
         if isinstance(dtype, type):
             # we sometimes pass non-dtype objects, e.g np.ndarray;
             #  pass those through to the underlying ndarray
-
-            # error: Incompatible return value type (got "ndarray", expected
-            # "ExtensionArray")
-            return self._ndarray.view(dtype)  # type: ignore[return-value]
+            return self._ndarray.view(dtype)
 
         dtype = pandas_dtype(dtype)
         if isinstance(dtype, (PeriodDtype, DatetimeTZDtype)):
             cls = dtype.construct_array_type()
-            # error: Incompatible return value type (got "Union[PeriodArray,
-            # DatetimeArray]", expected "ndarray")
-            return cls(self.asi8, dtype=dtype)  # type: ignore[return-value]
+            return cls(self.asi8, dtype=dtype)
         elif dtype == "M8[ns]":
             from pandas.core.arrays import DatetimeArray
 
-            # error: Incompatible return value type (got "DatetimeArray", expected
-            # "ndarray")
-            return DatetimeArray(self.asi8, dtype=dtype)  # type: ignore[return-value]
+            return DatetimeArray(self.asi8, dtype=dtype)
         elif dtype == "m8[ns]":
             from pandas.core.arrays import TimedeltaArray
 
-            # error: Incompatible return value type (got "TimedeltaArray", expected
-            # "ndarray")
-            return TimedeltaArray(self.asi8, dtype=dtype)  # type: ignore[return-value]
+            return TimedeltaArray(self.asi8, dtype=dtype)
         # error: Incompatible return value type (got "ndarray", expected
         # "ExtensionArray")
         # error: Argument "dtype" to "view" of "_ArrayOrScalarCommon" has incompatible
@@ -871,9 +858,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
     # ------------------------------------------------------------------
     # Null Handling
 
-    # error: Return type "ndarray" of "isna" incompatible with return type "ArrayLike"
-    # in supertype "ExtensionArray"
-    def isna(self) -> np.ndarray:  # type: ignore[override]
+    def isna(self) -> np.ndarray:
         return self._isnan
 
     @property  # NB: override with cache_readonly in immutable subclasses
@@ -1789,8 +1774,11 @@ class TimelikeOps(DatetimeLikeArrayMixin):
             freq = to_offset(self.inferred_freq)
 
         arr = self.view()
-        # error: "ExtensionArray" has no attribute "_freq"
-        arr._freq = freq  # type: ignore[attr-defined]
+        # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
+        # attribute "_freq"
+        # error: Item "ndarray" of "Union[ExtensionArray, ndarray]" has no attribute
+        # "_freq"
+        arr._freq = freq  # type: ignore[union-attr]
         return arr
 
     # --------------------------------------------------------------

--- a/pandas/core/arrays/floating.py
+++ b/pandas/core/arrays/floating.py
@@ -305,9 +305,7 @@ class FloatingArray(NumericArray):
         dtype = pandas_dtype(dtype)
 
         if isinstance(dtype, ExtensionDtype):
-            # error: Incompatible return value type (got "ExtensionArray", expected
-            # "ndarray")
-            return super().astype(dtype, copy=copy)  # type: ignore[return-value]
+            return super().astype(dtype, copy=copy)
 
         # coerce
         if is_float_dtype(dtype):
@@ -323,9 +321,7 @@ class FloatingArray(NumericArray):
         # error: Argument 2 to "to_numpy" of "BaseMaskedArray" has incompatible
         # type "**Dict[str, float]"; expected "bool"
         data = self.to_numpy(dtype=dtype, **kwargs)  # type: ignore[arg-type]
-        # error: Incompatible return value type (got "ExtensionArray", expected
-        # "ndarray")
-        return astype_nansafe(data, dtype, copy=False)  # type: ignore[return-value]
+        return astype_nansafe(data, dtype, copy=False)
 
     def _values_for_argsort(self) -> np.ndarray:
         return self._data

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -369,9 +369,7 @@ class IntegerArray(NumericArray):
         dtype = pandas_dtype(dtype)
 
         if isinstance(dtype, ExtensionDtype):
-            # error: Incompatible return value type (got "ExtensionArray", expected
-            # "ndarray")
-            return super().astype(dtype, copy=copy)  # type: ignore[return-value]
+            return super().astype(dtype, copy=copy)
 
         # coerce
         if is_float_dtype(dtype):
@@ -384,11 +382,7 @@ class IntegerArray(NumericArray):
         else:
             na_value = lib.no_default
 
-        # error: Incompatible return value type (got "ndarray", expected
-        # "ExtensionArray")
-        return self.to_numpy(  # type: ignore[return-value]
-            dtype=dtype, na_value=na_value, copy=False
-        )
+        return self.to_numpy(dtype=dtype, na_value=na_value, copy=False)
 
     def _values_for_argsort(self) -> np.ndarray:
         """

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -911,9 +911,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         # TODO: Could skip verify_integrity here.
         return type(self).from_arrays(left, right, closed=closed)
 
-    # error: Return type "ndarray" of "isna" incompatible with return type
-    # "ArrayLike" in supertype "ExtensionArray"
-    def isna(self) -> np.ndarray:  # type: ignore[override]
+    def isna(self) -> np.ndarray:
         return isna(self._left)
 
     def shift(
@@ -1573,9 +1571,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             if is_dtype_equal(self.dtype, values.dtype):
                 # GH#38353 instead of casting to object, operating on a
                 #  complex128 ndarray is much more performant.
-
-                # error: "ArrayLike" has no attribute "view"
-                left = self._combined.view("complex128")  # type:ignore[attr-defined]
+                left = self._combined.view("complex128")
                 right = values._combined.view("complex128")
                 return np.in1d(left, right)
 
@@ -1618,10 +1614,7 @@ def _maybe_convert_platform_interval(values) -> ArrayLike:
         # GH 19016
         # empty lists/tuples get object dtype by default, but this is
         # prohibited for IntervalArray, so coerce to integer instead
-
-        # error: Incompatible return value type (got "ndarray", expected
-        # "ExtensionArray")
-        return np.array([], dtype=np.int64)  # type: ignore[return-value]
+        return np.array([], dtype=np.int64)
     elif not is_list_like(values) or isinstance(values, ABCDataFrame):
         # This will raise later, but we avoid passing to maybe_convert_platform
         return values
@@ -1633,5 +1626,4 @@ def _maybe_convert_platform_interval(values) -> ArrayLike:
     else:
         values = extract_array(values, extract_numpy=True)
 
-    # error: Incompatible return value type (got "ExtensionArray", expected "ndarray")
-    return maybe_convert_platform(values)  # type: ignore[return-value]
+    return maybe_convert_platform(values)

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -310,12 +310,8 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
 
         if is_dtype_equal(dtype, self.dtype):
             if copy:
-                # error: Incompatible return value type (got "BaseMaskedArray", expected
-                # "ndarray")
-                return self.copy()  # type: ignore[return-value]
-            # error: Incompatible return value type (got "BaseMaskedArray", expected
-            # "ndarray")
-            return self  # type: ignore[return-value]
+                return self.copy()
+            return self
 
         # if we are astyping to another nullable masked dtype, we can fastpath
         if isinstance(dtype, BaseMaskedDtype):
@@ -325,9 +321,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
             # not directly depending on the `copy` keyword
             mask = self._mask if data is self._data else self._mask.copy()
             cls = dtype.construct_array_type()
-            # error: Incompatible return value type (got "BaseMaskedArray", expected
-            # "ndarray")
-            return cls(data, mask, copy=False)  # type: ignore[return-value]
+            return cls(data, mask, copy=False)
 
         if isinstance(dtype, ExtensionDtype):
             eacls = dtype.construct_array_type()
@@ -361,9 +355,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
         # error: Incompatible return value type (got "bool_", expected "bool")
         return self._mask.any()  # type: ignore[return-value]
 
-    # error: Return type "ndarray" of "isna" incompatible with return type
-    # "ArrayLike" in supertype "ExtensionArray"
-    def isna(self) -> np.ndarray:  # type: ignore[override]
+    def isna(self) -> np.ndarray:
         return self._mask
 
     @property

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -190,9 +190,7 @@ class PandasArray(
     # ------------------------------------------------------------------------
     # Pandas ExtensionArray Interface
 
-    # error: Return type "ndarray" of "isna" incompatible with return type
-    # "ArrayLike" in supertype "ExtensionArray"
-    def isna(self) -> np.ndarray:  # type: ignore[override]
+    def isna(self) -> np.ndarray:
         return isna(self._ndarray)
 
     def _validate_fill_value(self, fill_value):

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -643,7 +643,11 @@ class PeriodArray(PeriodMixin, dtl.DatelikeOps):
         if method is not None:
             # view as dt64 so we get treated as timelike in core.missing
             dta = self.view("M8[ns]")
-            result = dta.fillna(value=value, method=method, limit=limit)
+            # error: Item "ndarray" of "Union[ExtensionArray, ndarray]" has no attribute
+            # "fillna"
+            result = dta.fillna(  # type: ignore[union-attr]
+                value=value, method=method, limit=limit
+            )
             return result.view(self.dtype)
         return super().fillna(value=value, method=method, limit=limit)
 

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1145,9 +1145,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         # TODO copy=False is broken for astype_nansafe with int -> float, so cannot
         # passthrough copy keyword: https://github.com/pandas-dev/pandas/issues/34456
         sp_values = astype_nansafe(self.sp_values, subtype, copy=True)
-        # error: Non-overlapping identity check (left operand type: "ExtensionArray",
-        # right operand t...ype: "ndarray")
-        if sp_values is self.sp_values and copy:  # type: ignore[comparison-overlap]
+        if sp_values is self.sp_values and copy:
             sp_values = sp_values.copy()
 
         # error: Argument 1 to "_simple_new" of "SparseArray" has incompatible type

--- a/pandas/core/arrays/sparse/dtype.py
+++ b/pandas/core/arrays/sparse/dtype.py
@@ -342,10 +342,11 @@ class SparseDtype(ExtensionDtype):
             if is_extension_array_dtype(dtype):
                 raise TypeError("sparse arrays of extension dtypes not supported")
 
-            # error: "ExtensionArray" has no attribute "item"
-            fill_value = astype_nansafe(
+            # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
+            # attribute "item"
+            fill_value = astype_nansafe(  # type: ignore[union-attr]
                 np.array(self.fill_value), dtype
-            ).item()  # type: ignore[attr-defined]
+            ).item()
             dtype = cls(dtype, fill_value=fill_value)
 
         return dtype

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -434,9 +434,7 @@ class ArrowStringArray(OpsMixin, ExtensionArray):
         """
         return self._data.nbytes
 
-    # error: Return type "ndarray" of "isna" incompatible with return type "ArrayLike"
-    # in supertype "ExtensionArray"
-    def isna(self) -> np.ndarray:  # type: ignore[override]
+    def isna(self) -> np.ndarray:
         """
         Boolean NumPy array indicating if each value is missing.
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -735,9 +735,7 @@ class IndexOpsMixin(OpsMixin):
         skipna = nv.validate_argmax_with_skipna(skipna, args, kwargs)
 
         if isinstance(delegate, ExtensionArray):
-            # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
-            # attribute "any"
-            if not skipna and delegate.isna().any():  # type: ignore[union-attr]
+            if not skipna and delegate.isna().any():
                 return -1
             else:
                 return delegate.argmax()
@@ -799,9 +797,7 @@ class IndexOpsMixin(OpsMixin):
         skipna = nv.validate_argmin_with_skipna(skipna, args, kwargs)
 
         if isinstance(delegate, ExtensionArray):
-            # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
-            # attribute "any"
-            if not skipna and delegate.isna().any():  # type: ignore[union-attr]
+            if not skipna and delegate.isna().any():
                 return -1
             else:
                 return delegate.argmin()

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -735,8 +735,9 @@ class IndexOpsMixin(OpsMixin):
         skipna = nv.validate_argmax_with_skipna(skipna, args, kwargs)
 
         if isinstance(delegate, ExtensionArray):
-            # error: "ExtensionArray" has no attribute "any"
-            if not skipna and delegate.isna().any():  # type: ignore[attr-defined]
+            # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
+            # attribute "any"
+            if not skipna and delegate.isna().any():  # type: ignore[union-attr]
                 return -1
             else:
                 return delegate.argmax()
@@ -798,8 +799,9 @@ class IndexOpsMixin(OpsMixin):
         skipna = nv.validate_argmin_with_skipna(skipna, args, kwargs)
 
         if isinstance(delegate, ExtensionArray):
-            # error: "ExtensionArray" has no attribute "any"
-            if not skipna and delegate.isna().any():  # type: ignore[attr-defined]
+            # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
+            # attribute "any"
+            if not skipna and delegate.isna().any():  # type: ignore[union-attr]
                 return -1
             else:
                 return delegate.argmin()
@@ -1333,6 +1335,4 @@ class IndexOpsMixin(OpsMixin):
         return self[~duplicated]  # type: ignore[index]
 
     def duplicated(self, keep: Union[str, bool] = "first") -> np.ndarray:
-        # error: Value of type variable "ArrayLike" of "duplicated" cannot be
-        # "Union[ExtensionArray, ndarray]"
-        return duplicated(self._values, keep=keep)  # type: ignore[type-var]
+        return duplicated(self._values, keep=keep)

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -500,13 +500,7 @@ def convert_to_list_like(
     inputs are returned unmodified whereas others are converted to list.
     """
     if isinstance(values, (list, np.ndarray, ABCIndex, ABCSeries, ABCExtensionArray)):
-        # error: Incompatible return value type (got "Union[Any, List[Any], Index,
-        # Series, ExtensionArray]", expected "Union[List[Any], ExtensionArray]")
-        # error: Incompatible return value type (got "Union[Any, List[Any], Index,
-        # Series, ExtensionArray]", expected "Union[List[Any], Index]")
-        # error: Incompatible return value type (got "Union[Any, List[Any], Index,
-        # Series, ExtensionArray]", expected "Union[List[Any], Series]")
-        return values  # type: ignore[return-value]
+        return values
     elif isinstance(values, abc.Iterable) and not isinstance(values, str):
         return list(values)
 

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -231,7 +231,11 @@ class BinOp(ops.BinOp):
             if v not in metadata:
                 result = -1
             else:
-                result = metadata.searchsorted(v, side="left")
+                # error: Incompatible types in assignment (expression has type
+                # "Union[Any, ndarray]", variable has type "int")
+                result = metadata.searchsorted(  # type: ignore[assignment]
+                    v, side="left"
+                )
             return TermValue(result, result, "integer")
         elif kind == "integer":
             v = int(float(v))

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -306,17 +306,7 @@ def array(
         # Note: we exclude np.ndarray here, will do type inference on it
         dtype = data.dtype
 
-    # error: Value of type variable "AnyArrayLike" of "extract_array" cannot be
-    # "Union[Sequence[object], ExtensionArray]"
-    # error: Value of type variable "AnyArrayLike" of "extract_array" cannot be
-    # "Union[Sequence[object], Index]"
-    # error: Incompatible types in assignment (expression has type "ExtensionArray",
-    # variable has type "Union[Sequence[object], Index]")
-    # error: Incompatible types in assignment (expression has type "ExtensionArray",
-    # variable has type "Union[Sequence[object], Series]")
-    # error: Incompatible types in assignment (expression has type "ExtensionArray",
-    # variable has type "Union[Sequence[object], ndarray]")
-    data = extract_array(data, extract_numpy=True)  # type: ignore[type-var,assignment]
+    data = extract_array(data, extract_numpy=True)
 
     # this returns None for not-found dtypes.
     if isinstance(dtype, str):
@@ -510,9 +500,7 @@ def sanitize_array(
             try:
                 subarr = _try_cast(data, dtype, copy, True)
             except ValueError:
-                # error: Incompatible types in assignment (expression has type
-                # "ndarray", variable has type "ExtensionArray")
-                subarr = np.array(data, copy=copy)  # type: ignore[assignment]
+                subarr = np.array(data, copy=copy)
         else:
             # we will try to copy by-definition here
             subarr = _try_cast(data, dtype, copy, raise_cast_failure)
@@ -525,9 +513,7 @@ def sanitize_array(
             subarr = subarr.astype(dtype, copy=copy)
         elif copy:
             subarr = subarr.copy()
-        # error: Incompatible return value type (got "ExtensionArray", expected
-        # "ndarray")
-        return subarr  # type: ignore[return-value]
+        return subarr
 
     elif isinstance(data, (list, tuple, abc.Set, abc.ValuesView)) and len(data) > 0:
         # TODO: deque, array.array
@@ -564,11 +550,9 @@ def sanitize_array(
     subarr = _sanitize_ndim(subarr, data, dtype, index)
 
     if not (is_extension_array_dtype(subarr.dtype) or is_extension_array_dtype(dtype)):
-        # error: Incompatible types in assignment (expression has type "ndarray",
-        # variable has type "ExtensionArray")
         # error: Argument 1 to "_sanitize_str_dtypes" has incompatible type
         # "ExtensionArray"; expected "ndarray"
-        subarr = _sanitize_str_dtypes(  # type: ignore[assignment]
+        subarr = _sanitize_str_dtypes(
             subarr, data, dtype, copy  # type: ignore[arg-type]
         )
 
@@ -579,8 +563,7 @@ def sanitize_array(
                 subarr = array(subarr)
                 subarr = extract_array(subarr, extract_numpy=True)
 
-    # error: Incompatible return value type (got "ExtensionArray", expected "ndarray")
-    return subarr  # type: ignore[return-value]
+    return subarr
 
 
 def _sanitize_ndim(
@@ -602,24 +585,16 @@ def _sanitize_ndim(
         if is_object_dtype(dtype) and isinstance(dtype, ExtensionDtype):
             # i.e. PandasDtype("O")
 
-            # error: Incompatible types in assignment (expression has type "ndarray",
-            # variable has type "ExtensionArray")
             # error: Argument "dtype" to "asarray_tuplesafe" has incompatible type
             # "Type[object]"; expected "Union[str, dtype[Any], None]"
-            result = com.asarray_tuplesafe(  # type: ignore[assignment]
-                data, dtype=object  # type: ignore[arg-type]
-            )
+            result = com.asarray_tuplesafe(data, dtype=object)  # type: ignore[arg-type]
             cls = dtype.construct_array_type()
             result = cls._from_sequence(result, dtype=dtype)
         else:
-            # error: Incompatible types in assignment (expression has type "ndarray",
-            # variable has type "ExtensionArray")
             # error: Argument "dtype" to "asarray_tuplesafe" has incompatible type
             # "Union[dtype[Any], ExtensionDtype, None]"; expected "Union[str,
             # dtype[Any], None]"
-            result = com.asarray_tuplesafe(  # type: ignore[assignment]
-                data, dtype=dtype  # type: ignore[arg-type]
-            )
+            result = com.asarray_tuplesafe(data, dtype=dtype)  # type: ignore[arg-type]
     return result
 
 
@@ -689,9 +664,7 @@ def _try_cast(
         and not copy
         and dtype is None
     ):
-        # error: Incompatible return value type (got "ndarray", expected
-        # "ExtensionArray")
-        return arr  # type: ignore[return-value]
+        return arr
 
     if isinstance(dtype, ExtensionDtype) and (dtype.kind != "M" or is_sparse(dtype)):
         # create an extension array from its dtype

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -165,8 +165,9 @@ def ensure_int_or_float(arr: ArrayLike, copy: bool = False) -> np.ndarray:
         return arr.astype("uint64", copy=copy, casting="safe")  # type: ignore[call-arg]
     except TypeError:
         if is_extension_array_dtype(arr.dtype):
-            # error: "ndarray" has no attribute "to_numpy"
-            return arr.to_numpy(  # type: ignore[attr-defined]
+            # pandas/core/dtypes/common.py:168: error: Item "ndarray" of
+            # "Union[ExtensionArray, ndarray]" has no attribute "to_numpy"  [union-attr]
+            return arr.to_numpy(  # type: ignore[union-attr]
                 dtype="float64", na_value=np.nan
             )
         return arr.astype("float64", copy=copy)

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -51,12 +51,8 @@ def _cast_to_common_type(arr: ArrayLike, dtype: DtypeObj) -> ArrayLike:
         # problem case: SparseArray.astype(dtype) doesn't follow the specified
         # dtype exactly, but converts this to Sparse[dtype] -> first manually
         # convert to dense array
-
-        # error: Incompatible types in assignment (expression has type
-        # "SparseArray", variable has type "ndarray")
-        arr = cast(SparseArray, arr)  # type: ignore[assignment]
-        # error: "ndarray" has no attribute "to_dense"
-        return arr.to_dense().astype(dtype, copy=False)  # type: ignore[attr-defined]
+        arr = cast(SparseArray, arr)
+        return arr.to_dense().astype(dtype, copy=False)
 
     if (
         isinstance(arr, np.ndarray)

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -164,13 +164,9 @@ def _isna(obj, inf_as_na: bool = False):
     elif isinstance(obj, type):
         return False
     elif isinstance(obj, (np.ndarray, ABCExtensionArray)):
-        # error: Value of type variable "ArrayLike" of "_isna_array" cannot be
-        # "Union[ndarray, ExtensionArray]"
-        return _isna_array(obj, inf_as_na=inf_as_na)  # type: ignore[type-var]
+        return _isna_array(obj, inf_as_na=inf_as_na)
     elif isinstance(obj, (ABCSeries, ABCIndex)):
-        # error: Value of type variable "ArrayLike" of "_isna_array" cannot be
-        # "Union[Any, ExtensionArray, ndarray]"
-        result = _isna_array(obj._values, inf_as_na=inf_as_na)  # type: ignore[type-var]
+        result = _isna_array(obj._values, inf_as_na=inf_as_na)
         # box
         if isinstance(obj, ABCSeries):
             result = obj._constructor(
@@ -238,13 +234,15 @@ def _isna_array(values: ArrayLike, inf_as_na: bool = False):
 
     if is_extension_array_dtype(dtype):
         if inf_as_na and is_categorical_dtype(dtype):
-            # error: "ndarray" has no attribute "to_numpy"
+            # error: Item "ndarray" of "Union[ExtensionArray, ndarray]" has no attribute
+            # "to_numpy"
             result = libmissing.isnaobj_old(
-                values.to_numpy()  # type: ignore[attr-defined]
+                values.to_numpy()  # type: ignore[union-attr]
             )
         else:
-            # error: "ndarray" has no attribute "isna"
-            result = values.isna()  # type: ignore[attr-defined]
+            # error: Item "ndarray" of "Union[ExtensionArray, ndarray]" has no attribute
+            # "isna"
+            result = values.isna()  # type: ignore[union-attr]
     elif is_string_dtype(dtype):
         # error: Argument 1 to "_isna_string_dtype" has incompatible type
         # "ExtensionArray"; expected "ndarray"

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -673,9 +673,10 @@ class DataFrame(NDFrame, OpsMixin):
                     data = dataclasses_to_dicts(data)
                 if treat_as_nested(data):
                     if columns is not None:
-                        # error: Value of type variable "AnyArrayLike" of "ensure_index"
-                        # cannot be "Collection[Any]"
-                        columns = ensure_index(columns)  # type: ignore[type-var]
+                        # error: Argument 1 to "ensure_index" has incompatible type
+                        # "Collection[Any]"; expected "Union[Union[Union[ExtensionArray,
+                        # ndarray], Index, Series], Sequence[Any]]"
+                        columns = ensure_index(columns)  # type: ignore[arg-type]
                     arrays, columns, index = nested_data_to_arrays(
                         # error: Argument 3 to "nested_data_to_arrays" has incompatible
                         # type "Optional[Collection[Any]]"; expected "Optional[Index]"
@@ -1344,11 +1345,7 @@ class DataFrame(NDFrame, OpsMixin):
     def dot(self, other: Union[DataFrame, Index, ArrayLike]) -> DataFrame:
         ...
 
-    # error: Overloaded function implementation cannot satisfy signature 2 due to
-    # inconsistencies in how they use type variables
-    def dot(  # type: ignore[misc]
-        self, other: Union[AnyArrayLike, FrameOrSeriesUnion]
-    ) -> FrameOrSeriesUnion:
+    def dot(self, other: Union[AnyArrayLike, FrameOrSeriesUnion]) -> FrameOrSeriesUnion:
         """
         Compute the matrix multiplication between the DataFrame and other.
 
@@ -3390,9 +3387,7 @@ class DataFrame(NDFrame, OpsMixin):
         Get the values of the i'th column (ndarray or ExtensionArray, as stored
         in the Block)
         """
-        # error: Incompatible return value type (got "ExtensionArray", expected
-        # "ndarray")
-        return self._mgr.iget_values(i)  # type: ignore[return-value]
+        return self._mgr.iget_values(i)
 
     def _iter_column_arrays(self) -> Iterator[ArrayLike]:
         """
@@ -3400,9 +3395,7 @@ class DataFrame(NDFrame, OpsMixin):
         This returns the values as stored in the Block (ndarray or ExtensionArray).
         """
         for i in range(len(self.columns)):
-            # error: Incompatible types in "yield" (actual type
-            # "ExtensionArray", expected type "ndarray")
-            yield self._get_column_array(i)  # type: ignore[misc]
+            yield self._get_column_array(i)
 
     def __getitem__(self, key):
         key = lib.item_from_zerodim(key)
@@ -10168,9 +10161,7 @@ def _reindex_for_setitem(value: FrameOrSeriesUnion, index: Index) -> ArrayLike:
     # reindex if necessary
 
     if value.index.equals(index) or not len(index):
-        # error: Incompatible return value type (got "Union[ndarray, Any]", expected
-        # "ExtensionArray")
-        return value._values.copy()  # type: ignore[return-value]
+        return value._values.copy()
 
     # GH#4107
     try:

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1174,20 +1174,11 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                 # We've split an object block! Everything we've assumed
                 # about a single block input returning a single block output
                 # is a lie. See eg GH-39329
-
-                # error: Incompatible return value type (got "ndarray", expected
-                # "ExtensionArray")
-                return mgr.as_array()  # type: ignore[return-value]
+                return mgr.as_array()
             else:
                 # We are a single block from a BlockManager
                 # or one array from SingleArrayManager
-
-                # error: Incompatible return value type (got "Union[ndarray,
-                # ExtensionArray, ArrayLike]", expected "ExtensionArray")
-                # error: Incompatible return value type (got "Union[ndarray,
-                # ExtensionArray, ArrayLike]", expected
-                # "ndarray")
-                return arrays[0]  # type: ignore[return-value]
+                return arrays[0]
 
         def array_func(values: ArrayLike) -> ArrayLike:
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2753,9 +2753,7 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
                 result = result.reshape(-1)
 
             if result_is_index:
-                # error: Incompatible types in assignment (expression has type
-                # "Union[ExtensionArray, ndarray]", variable has type "ndarray")
-                result = algorithms.take_nd(values, result)  # type: ignore[assignment]
+                result = algorithms.take_nd(values, result)
 
             if post_processing:
                 result = post_processing(result, inferences)

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2753,7 +2753,9 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
                 result = result.reshape(-1)
 
             if result_is_index:
-                result = algorithms.take_nd(values, result)
+                # error: Incompatible types in assignment (expression has type
+                # "Union[ExtensionArray, ndarray]", variable has type "ndarray")
+                result = algorithms.take_nd(values, result)  # type: ignore[assignment]
 
             if post_processing:
                 result = post_processing(result, inferences)

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -791,7 +791,11 @@ class BaseGrouper:
             result[label] = res
 
         result = lib.maybe_convert_objects(result, try_float=False)
-        result = maybe_cast_result(result, obj, numeric_only=True)
+        # error: Incompatible types in assignment (expression has type
+        # "Union[ExtensionArray, ndarray]", variable has type "ndarray")
+        result = maybe_cast_result(  # type: ignore[assignment]
+            result, obj, numeric_only=True
+        )
 
         return result, counts
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2993,11 +2993,7 @@ class Index(IndexOpsMixin, PandasObject):
             missing = algos.unique1d(self.get_indexer_non_unique(other)[1])
 
         if len(missing) > 0:
-            # error: Value of type variable "ArrayLike" of "take_nd" cannot be
-            # "Union[ExtensionArray, ndarray]"
-            other_diff = algos.take_nd(
-                rvals, missing, allow_fill=False  # type: ignore[type-var]
-            )
+            other_diff = algos.take_nd(rvals, missing, allow_fill=False)
             result = concat_compat((lvals, other_diff))
         else:
             # error: Incompatible types in assignment (expression has type
@@ -4211,13 +4207,17 @@ class Index(IndexOpsMixin, PandasObject):
             if keep_order:  # just drop missing values. o.w. keep order
                 left_indexer = np.arange(len(left), dtype=np.intp)
                 mask = new_lev_codes != -1
-                if not mask.all():
+                # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray, Any]"
+                # has no attribute "all"
+                if not mask.all():  # type: ignore[union-attr]
                     new_codes = [lab[mask] for lab in new_codes]
                     left_indexer = left_indexer[mask]
 
             else:  # tie out the order with other
                 if level == 0:  # outer most level, take the fast route
-                    ngroups = 1 + new_lev_codes.max()
+                    # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]"
+                    # has no attribute "max"
+                    ngroups = 1 + new_lev_codes.max()  # type: ignore[union-attr]
                     left_indexer, counts = libalgos.groupsort_indexer(
                         new_lev_codes, ngroups
                     )
@@ -4228,7 +4228,9 @@ class Index(IndexOpsMixin, PandasObject):
 
                 else:  # sort the leaves
                     mask = new_lev_codes != -1
-                    mask_all = mask.all()
+                    # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray,
+                    # Any]" has no attribute "all"
+                    mask_all = mask.all()  # type: ignore[union-attr]
                     if not mask_all:
                         new_codes = [lab[mask] for lab in new_codes]
 
@@ -4238,7 +4240,11 @@ class Index(IndexOpsMixin, PandasObject):
                     # left_indexers are w.r.t masked frame.
                     # reverse to original frame!
                     if not mask_all:
-                        left_indexer = mask.nonzero()[0][left_indexer]
+                        # error: Item "ExtensionArray" of "Union[ExtensionArray,
+                        # ndarray, Any]" has no attribute "nonzero"
+                        left_indexer = mask.nonzero()[0][  # type: ignore[union-attr]
+                            left_indexer
+                        ]
 
             join_index = MultiIndex(
                 levels=new_levels,
@@ -4389,11 +4395,7 @@ class Index(IndexOpsMixin, PandasObject):
         Index.array : Reference to the underlying data.
         Index.to_numpy : A NumPy array representing the underlying data.
         """
-        # error: Incompatible return value type (got "Union[ExtensionArray, ndarray]",
-        # expected "ExtensionArray")
-        # error: Incompatible return value type (got "Union[ExtensionArray, ndarray]",
-        # expected "ndarray")
-        return self._data  # type: ignore[return-value]
+        return self._data
 
     @cache_readonly
     @doc(IndexOpsMixin.array)
@@ -4714,9 +4716,7 @@ class Index(IndexOpsMixin, PandasObject):
         numpy.ndarray.putmask : Changes elements of an array
             based on conditional and input values.
         """
-        # error: Value of type variable "ArrayLike" of "validate_putmask" cannot be
-        # "Union[ExtensionArray, ndarray]"
-        mask, noop = validate_putmask(self._values, mask)  # type: ignore[type-var]
+        mask, noop = validate_putmask(self._values, mask)
         if noop:
             return self.copy()
 
@@ -5600,9 +5600,7 @@ class Index(IndexOpsMixin, PandasObject):
         """
         if level is not None:
             self._validate_index_level(level)
-        # error: Value of type variable "AnyArrayLike" of "isin" cannot be
-        # "Union[ExtensionArray, ndarray]"
-        return algos.isin(self._values, values)  # type: ignore[type-var]
+        return algos.isin(self._values, values)
 
     def _get_string_slice(self, key: str_t):
         # this is for partial string indexing,
@@ -6023,11 +6021,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         else:
             with np.errstate(all="ignore"):
-                # error: Value of type variable "ArrayLike" of "comparison_op" cannot be
-                # "Union[ExtensionArray, ndarray]"
-                result = ops.comparison_op(
-                    self._values, other, op  # type: ignore[type-var]
-                )
+                result = ops.comparison_op(self._values, other, op)
 
         return result
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4207,17 +4207,13 @@ class Index(IndexOpsMixin, PandasObject):
             if keep_order:  # just drop missing values. o.w. keep order
                 left_indexer = np.arange(len(left), dtype=np.intp)
                 mask = new_lev_codes != -1
-                # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray, Any]"
-                # has no attribute "all"
-                if not mask.all():  # type: ignore[union-attr]
+                if not mask.all():
                     new_codes = [lab[mask] for lab in new_codes]
                     left_indexer = left_indexer[mask]
 
             else:  # tie out the order with other
                 if level == 0:  # outer most level, take the fast route
-                    # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]"
-                    # has no attribute "max"
-                    ngroups = 1 + new_lev_codes.max()  # type: ignore[union-attr]
+                    ngroups = 1 + new_lev_codes.max()
                     left_indexer, counts = libalgos.groupsort_indexer(
                         new_lev_codes, ngroups
                     )
@@ -4228,9 +4224,7 @@ class Index(IndexOpsMixin, PandasObject):
 
                 else:  # sort the leaves
                     mask = new_lev_codes != -1
-                    # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray,
-                    # Any]" has no attribute "all"
-                    mask_all = mask.all()  # type: ignore[union-attr]
+                    mask_all = mask.all()
                     if not mask_all:
                         new_codes = [lab[mask] for lab in new_codes]
 
@@ -4240,11 +4234,7 @@ class Index(IndexOpsMixin, PandasObject):
                     # left_indexers are w.r.t masked frame.
                     # reverse to original frame!
                     if not mask_all:
-                        # error: Item "ExtensionArray" of "Union[ExtensionArray,
-                        # ndarray, Any]" has no attribute "nonzero"
-                        left_indexer = mask.nonzero()[0][  # type: ignore[union-attr]
-                            left_indexer
-                        ]
+                        left_indexer = mask.nonzero()[0][left_indexer]
 
             join_index = MultiIndex(
                 levels=new_levels,

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -489,9 +489,7 @@ class CategoricalIndex(NDArrayBackedExtensionIndex, accessor.PandasDelegate):
         if self.equals(target):
             return np.arange(len(self), dtype="intp")
 
-        # error: Value of type variable "ArrayLike" of "_get_indexer_non_unique" of
-        # "CategoricalIndex" cannot be "Union[ExtensionArray, ndarray]"
-        return self._get_indexer_non_unique(target._values)[0]  # type: ignore[type-var]
+        return self._get_indexer_non_unique(target._values)[0]
 
     @Appender(_index_shared_docs["get_indexer_non_unique"] % _index_doc_kwargs)
     def get_indexer_non_unique(self, target):

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -528,16 +528,8 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex):
         PeriodIndex.shift : Shift values of PeriodIndex.
         """
         arr = self._data.view()
-        # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
-        # attribute "_freq"
-        # error: Item "ndarray" of "Union[ExtensionArray, ndarray]" has no attribute
-        # "_freq"
-        arr._freq = self.freq  # type: ignore[union-attr]
-        # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
-        # attribute "_time_shift"
-        # error: Item "ndarray" of "Union[ExtensionArray, ndarray]" has no attribute
-        # "_time_shift"
-        result = arr._time_shift(periods, freq=freq)  # type: ignore[union-attr]
+        arr._freq = self.freq
+        result = arr._time_shift(periods, freq=freq)
         return type(self)(result, name=self.name)
 
     # --------------------------------------------------------------------

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -136,9 +136,7 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex):
     # Abstract data attributes
 
     @property
-    # error: Return type "ndarray" of "values" incompatible with return type "ArrayLike"
-    # in supertype "Index"
-    def values(self) -> np.ndarray:  # type: ignore[override]
+    def values(self) -> np.ndarray:
         # Note: PeriodArray overrides this to return an ndarray of objects.
         return self._data._ndarray
 
@@ -530,10 +528,16 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex):
         PeriodIndex.shift : Shift values of PeriodIndex.
         """
         arr = self._data.view()
-        # error: "ExtensionArray" has no attribute "_freq"
-        arr._freq = self.freq  # type: ignore[attr-defined]
-        # error: "ExtensionArray" has no attribute "_time_shift"
-        result = arr._time_shift(periods, freq=freq)  # type: ignore[attr-defined]
+        # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
+        # attribute "_freq"
+        # error: Item "ndarray" of "Union[ExtensionArray, ndarray]" has no attribute
+        # "_freq"
+        arr._freq = self.freq  # type: ignore[union-attr]
+        # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
+        # attribute "_time_shift"
+        # error: Item "ndarray" of "Union[ExtensionArray, ndarray]" has no attribute
+        # "_time_shift"
+        result = arr._time_shift(periods, freq=freq)  # type: ignore[union-attr]
         return type(self)(result, name=self.name)
 
     # --------------------------------------------------------------------

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1223,7 +1223,12 @@ def interval_range(
         breaks = np.linspace(start, end, periods)
         if all(is_integer(x) for x in com.not_none(start, end, freq)):
             # np.linspace always produces float output
-            breaks = maybe_downcast_numeric(breaks, np.dtype("int64"))
+
+            # error: Incompatible types in assignment (expression has type
+            # "Union[ExtensionArray, ndarray]", variable has type "ndarray")
+            breaks = maybe_downcast_numeric(  # type: ignore[assignment]
+                breaks, np.dtype("int64")
+            )
     else:
         # delegate to the appropriate range function
         if isinstance(endpoint, Timestamp):

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -720,9 +720,7 @@ class MultiIndex(Index):
         return arr
 
     @property
-    # error: Return type "ndarray" of "values" incompatible with return type "ArrayLike"
-    # in supertype "Index"
-    def values(self) -> np.ndarray:  # type: ignore[override]
+    def values(self) -> np.ndarray:
         return self._values
 
     @property

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -275,9 +275,7 @@ class PeriodIndex(DatetimeIndexOpsMixin):
     # Data
 
     @property
-    # error: Return type "ndarray" of "values" incompatible with return type "ArrayLike"
-    # in supertype "Index"
-    def values(self) -> np.ndarray:  # type: ignore[override]
+    def values(self) -> np.ndarray:
         return np.asarray(self, dtype=object)
 
     def _maybe_convert_timedelta(self, other):

--- a/pandas/core/internals/api.py
+++ b/pandas/core/internals/api.py
@@ -39,7 +39,11 @@ def make_block(
     - Block.make_block_same_class
     - Block.__init__
     """
-    values, dtype = extract_pandas_array(values, dtype, ndim)
+    # error: Argument 2 to "extract_pandas_array" has incompatible type
+    # "Union[ExtensionDtype, str, dtype[Any], Type[str], Type[float], Type[int],
+    # Type[complex], Type[bool], Type[object], None]"; expected "Union[dtype[Any],
+    # ExtensionDtype, None]"
+    values, dtype = extract_pandas_array(values, dtype, ndim)  # type: ignore[arg-type]
 
     if klass is None:
         dtype = dtype or values.dtype

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -503,16 +503,9 @@ class ArrayManager(DataManager):
         interpolation="linear",
     ) -> ArrayManager:
 
-        # error: Value of type variable "ArrayLike" of "ensure_block_shape" cannot be
-        # "Union[ndarray, ExtensionArray]"
-        arrs = [ensure_block_shape(x, 2) for x in self.arrays]  # type: ignore[type-var]
+        arrs = [ensure_block_shape(x, 2) for x in self.arrays]
         assert axis == 1
-        # error: Value of type variable "ArrayLike" of "quantile_compat" cannot be
-        # "object"
-        new_arrs = [
-            quantile_compat(x, qs, interpolation, axis=axis)  # type: ignore[type-var]
-            for x in arrs
-        ]
+        new_arrs = [quantile_compat(x, qs, interpolation, axis=axis) for x in arrs]
         for i, arr in enumerate(new_arrs):
             if arr.ndim == 2:
                 assert arr.shape[0] == 1, arr.shape
@@ -836,11 +829,7 @@ class ArrayManager(DataManager):
         """
         Return the data for column i as the values (ndarray or ExtensionArray).
         """
-        # error: Incompatible return value type (got "Union[ndarray, ExtensionArray]",
-        # expected "ExtensionArray")
-        # error: Incompatible return value type (got "Union[ndarray, ExtensionArray]",
-        # expected "ndarray")
-        return self.arrays[i]  # type: ignore[return-value]
+        return self.arrays[i]
 
     def idelete(self, indexer):
         """
@@ -1019,9 +1008,7 @@ class ArrayManager(DataManager):
         else:
             validate_indices(indexer, len(self._axes[0]))
             new_arrays = [
-                # error: Value of type variable "ArrayLike" of "take_1d" cannot be
-                # "Union[ndarray, ExtensionArray]"  [type-var]
-                take_1d(  # type: ignore[type-var]
+                take_1d(
                     arr,
                     indexer,
                     allow_fill=True,
@@ -1080,9 +1067,7 @@ class ArrayManager(DataManager):
         assuming shape and indexes have already been checked.
         """
         for left, right in zip(self.arrays, other.arrays):
-            # error: Value of type variable "ArrayLike" of "array_equals" cannot be
-            # "Union[Any, ndarray, ExtensionArray]"
-            if not array_equals(left, right):  # type: ignore[type-var]
+            if not array_equals(left, right):
                 return False
         else:
             return True
@@ -1109,9 +1094,7 @@ class ArrayManager(DataManager):
         new_arrays = []
         for arr in self.arrays:
             for i in range(unstacker.full_shape[1]):
-                # error: Value of type variable "ArrayLike" of "take_1d" cannot be
-                # "Union[ndarray, ExtensionArray]"  [type-var]
-                new_arr = take_1d(  # type: ignore[type-var]
+                new_arr = take_1d(
                     arr, new_indexer2D[:, i], allow_fill=True, fill_value=fill_value
                 )
                 new_arrays.append(new_arr)

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2316,15 +2316,10 @@ def extract_pandas_array(
     """
     # For now, blocks should be backed by ndarrays when possible.
     if isinstance(values, ABCPandasArray):
-        # error: Incompatible types in assignment (expression has type "ndarray",
-        # variable has type "ExtensionArray")
-        values = values.to_numpy()  # type: ignore[assignment]
+        values = values.to_numpy()
         if ndim and ndim > 1:
             # TODO(EA2D): special case not needed with 2D EAs
-
-            # error: No overload variant of "atleast_2d" matches argument type
-            # "PandasArray"
-            values = np.atleast_2d(values)  # type: ignore[call-overload]
+            values = np.atleast_2d(values)
 
     if isinstance(dtype, PandasDtype):
         dtype = dtype.numpy_dtype

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -432,9 +432,7 @@ class Block(PandasObject):
         inplace = validate_bool_kwarg(inplace, "inplace")
 
         mask = isna(self.values)
-        # error: Value of type variable "ArrayLike" of "validate_putmask" cannot be
-        # "Union[ndarray, ExtensionArray]"
-        mask, noop = validate_putmask(self.values, mask)  # type: ignore[type-var]
+        mask, noop = validate_putmask(self.values, mask)
 
         if limit is not None:
             limit = libalgos.validate_limit(None, limit=limit)
@@ -577,9 +575,7 @@ class Block(PandasObject):
             if dtypes is None:
                 dtypes = "infer"
 
-            # error: Value of type variable "ArrayLike" of "maybe_downcast_to_dtype"
-            # cannot be "Union[ndarray, ExtensionArray]"
-            nv = maybe_downcast_to_dtype(values, dtypes)  # type: ignore[type-var]
+            nv = maybe_downcast_to_dtype(values, dtypes)
             return [self.make_block(nv)]
 
         # ndim > 1
@@ -623,11 +619,7 @@ class Block(PandasObject):
         if values.dtype.kind in ["m", "M"]:
             values = self.array_values()
 
-        # error: Value of type variable "ArrayLike" of "astype_array_safe" cannot be
-        # "Union[ndarray, ExtensionArray]"
-        new_values = astype_array_safe(
-            values, dtype, copy=copy, errors=errors  # type: ignore[type-var]
-        )
+        new_values = astype_array_safe(values, dtype, copy=copy, errors=errors)
 
         newb = self.make_block(new_values)
         if newb.shape != self.shape:
@@ -724,9 +716,7 @@ class Block(PandasObject):
 
         values = self.values
 
-        # error: Value of type variable "ArrayLike" of "mask_missing" cannot be
-        # "Union[ndarray, ExtensionArray]"
-        mask = missing.mask_missing(values, to_replace)  # type: ignore[type-var]
+        mask = missing.mask_missing(values, to_replace)
         if not mask.any():
             # Note: we get here with test_replace_extension_other incorrectly
             #  bc _can_hold_element is incorrect.
@@ -753,9 +743,7 @@ class Block(PandasObject):
             )
 
         blk = self if inplace else self.copy()
-        # error: Value of type variable "ArrayLike" of "putmask_inplace" cannot be
-        # "Union[ndarray, ExtensionArray]"
-        putmask_inplace(blk.values, mask, value)  # type: ignore[type-var]
+        putmask_inplace(blk.values, mask, value)
         blocks = blk.convert(numeric=False, copy=False)
         return blocks
 
@@ -796,9 +784,7 @@ class Block(PandasObject):
         rx = re.compile(to_replace)
 
         new_values = self.values if inplace else self.values.copy()
-        # error: Value of type variable "ArrayLike" of "replace_regex" cannot be
-        # "Union[ndarray, ExtensionArray]"
-        replace_regex(new_values, rx, value, mask)  # type: ignore[type-var]
+        replace_regex(new_values, rx, value, mask)
 
         block = self.make_block(new_values)
         return [block]
@@ -835,26 +821,17 @@ class Block(PandasObject):
             # in order to avoid repeating the same computations
             mask = ~isna(self.values)
             masks = [
-                # error: Value of type variable "ArrayLike" of "compare_or_regex_search"
-                # cannot be "Union[ndarray, ExtensionArray]"
-                compare_or_regex_search(  # type: ignore[type-var]
-                    self.values, s[0], regex=regex, mask=mask
-                )
+                compare_or_regex_search(self.values, s[0], regex=regex, mask=mask)
                 for s in pairs
             ]
         else:
             # GH#38086 faster if we know we dont need to check for regex
+            masks = [missing.mask_missing(self.values, s[0]) for s in pairs]
 
-            # error: Value of type variable "ArrayLike" of "mask_missing" cannot be
-            # "Union[ndarray, ExtensionArray]"
-            masks = [
-                missing.mask_missing(self.values, s[0])  # type: ignore[type-var]
-                for s in pairs
-            ]
-
-        # error: Value of type variable "ArrayLike" of "extract_bool_array" cannot be
-        # "Union[ndarray, ExtensionArray, bool]"
-        masks = [extract_bool_array(x) for x in masks]  # type: ignore[type-var]
+        # error: Argument 1 to "extract_bool_array" has incompatible type
+        # "Union[ExtensionArray, ndarray, bool]"; expected "Union[ExtensionArray,
+        # ndarray]"
+        masks = [extract_bool_array(x) for x in masks]  # type: ignore[arg-type]
 
         rb = [self if inplace else self.copy()]
         for i, (src, dest) in enumerate(pairs):
@@ -912,9 +889,7 @@ class Block(PandasObject):
                 nb = self.coerce_to_target_dtype(value)
                 if nb is self and not inplace:
                     nb = nb.copy()
-                # error: Value of type variable "ArrayLike" of "putmask_inplace" cannot
-                # be "Union[ndarray, ExtensionArray]"
-                putmask_inplace(nb.values, mask, value)  # type: ignore[type-var]
+                putmask_inplace(nb.values, mask, value)
                 return [nb]
             else:
                 regex = should_use_regex(regex, to_replace)
@@ -987,9 +962,7 @@ class Block(PandasObject):
 
         # length checking
         check_setitem_lengths(indexer, value, values)
-        # error: Value of type variable "ArrayLike" of "is_exact_shape_match" cannot be
-        # "Union[Any, ndarray, ExtensionArray]"
-        exact_match = is_exact_shape_match(values, arr_value)  # type: ignore[type-var]
+        exact_match = is_exact_shape_match(values, arr_value)
 
         if is_empty_indexer(indexer, arr_value):
             # GH#8669 empty indexers
@@ -1057,9 +1030,7 @@ class Block(PandasObject):
         List[Block]
         """
         orig_mask = mask
-        # error: Value of type variable "ArrayLike" of "validate_putmask" cannot be
-        # "Union[ndarray, ExtensionArray]"
-        mask, noop = validate_putmask(self.values.T, mask)  # type: ignore[type-var]
+        mask, noop = validate_putmask(self.values.T, mask)
         assert not isinstance(new, (ABCIndex, ABCSeries, ABCDataFrame))
 
         # if we are passed a scalar None, convert it here
@@ -1284,9 +1255,7 @@ class Block(PandasObject):
         else:
             allow_fill = True
 
-        # error: Value of type variable "ArrayLike" of "take_nd" cannot be
-        # "Union[ndarray, ExtensionArray]"
-        new_values = algos.take_nd(  # type: ignore[type-var]
+        new_values = algos.take_nd(
             values, indexer, axis=axis, allow_fill=allow_fill, fill_value=fill_value
         )
 
@@ -1350,9 +1319,7 @@ class Block(PandasObject):
         if transpose:
             values = values.T
 
-        # error: Value of type variable "ArrayLike" of "validate_putmask" cannot be
-        # "Union[ndarray, ExtensionArray]"
-        icond, noop = validate_putmask(values, ~cond)  # type: ignore[type-var]
+        icond, noop = validate_putmask(values, ~cond)
 
         if is_valid_na_for_dtype(other, self.dtype) and not self.is_object:
             other = self.fill_value
@@ -1463,11 +1430,7 @@ class Block(PandasObject):
         assert axis == 1  # only ever called this way
         assert is_list_like(qs)  # caller is responsible for this
 
-        # error: Value of type variable "ArrayLike" of "quantile_compat" cannot be
-        # "Union[ndarray, ExtensionArray]"
-        result = quantile_compat(  # type: ignore[type-var]
-            self.values, qs, interpolation, axis
-        )
+        result = quantile_compat(self.values, qs, interpolation, axis)
 
         return new_block(result, placement=self.mgr_locs, ndim=2)
 
@@ -2392,8 +2355,5 @@ def ensure_block_shape(values: ArrayLike, ndim: int = 1) -> ArrayLike:
             # TODO(EA2D): https://github.com/pandas-dev/pandas/issues/23023
             # block.shape is incorrect for "2D" ExtensionArrays
             # We can't, and don't need to, reshape.
-
-            # error: Incompatible types in assignment (expression has type "ndarray",
-            # variable has type "ExtensionArray")
-            values = np.asarray(values).reshape(1, -1)  # type: ignore[assignment]
+            values = np.asarray(values).reshape(1, -1)
     return values

--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -235,7 +235,9 @@ def _get_mgr_concatenation_plan(mgr: BlockManager, indexers: Dict[int, np.ndarra
             if unit_no_ax0_reindexing:
                 join_unit_indexers.pop(0, None)
             else:
-                join_unit_indexers[0] = ax0_blk_indexer
+                # error: Incompatible types in assignment (expression has type
+                # "Union[ExtensionArray, Any]", target has type "ndarray")
+                join_unit_indexers[0] = ax0_blk_indexer  # type: ignore[assignment]
 
             unit = JoinUnit(blk, shape, join_unit_indexers)
 
@@ -344,11 +346,7 @@ class JoinUnit:
                 if is_datetime64tz_dtype(empty_dtype):
                     # TODO(EA2D): special case unneeded with 2D EAs
                     i8values = np.full(self.shape[1], fill_value.value)
-                    # error: Incompatible return value type (got "DatetimeArray",
-                    # expected "ndarray")
-                    return DatetimeArray(  # type: ignore[return-value]
-                        i8values, dtype=empty_dtype
-                    )
+                    return DatetimeArray(i8values, dtype=empty_dtype)
                 elif is_extension_array_dtype(blk_dtype):
                     pass
                 elif is_extension_array_dtype(empty_dtype):
@@ -439,21 +437,14 @@ def _concatenate_join_units(
     elif any(isinstance(t, ExtensionArray) for t in to_concat):
         # concatting with at least one EA means we are concatting a single column
         # the non-EA values are 2D arrays with shape (1, n)
-
-        # error: Invalid index type "Tuple[int, slice]" for "ExtensionArray"; expected
-        # type "Union[int, slice, ndarray]"
-        to_concat = [
-            t if isinstance(t, ExtensionArray) else t[0, :]  # type: ignore[index]
-            for t in to_concat
-        ]
+        to_concat = [t if isinstance(t, ExtensionArray) else t[0, :] for t in to_concat]
         concat_values = concat_compat(to_concat, axis=0, ea_compat_axis=True)
         concat_values = ensure_block_shape(concat_values, 2)
 
     else:
         concat_values = concat_compat(to_concat, axis=concat_axis)
 
-    # error: Incompatible return value type (got "ExtensionArray", expected "ndarray")
-    return concat_values  # type: ignore[return-value]
+    return concat_values
 
 
 def _dtype_to_na_value(dtype: DtypeObj, has_none_blocks: bool):

--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -235,9 +235,7 @@ def _get_mgr_concatenation_plan(mgr: BlockManager, indexers: Dict[int, np.ndarra
             if unit_no_ax0_reindexing:
                 join_unit_indexers.pop(0, None)
             else:
-                # error: Incompatible types in assignment (expression has type
-                # "Union[ExtensionArray, Any]", target has type "ndarray")
-                join_unit_indexers[0] = ax0_blk_indexer  # type: ignore[assignment]
+                join_unit_indexers[0] = ax0_blk_indexer
 
             unit = JoinUnit(blk, shape, join_unit_indexers)
 

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -319,7 +319,9 @@ def ndarray_to_mgr(
             datelike_vals = maybe_squeeze_dt64tz(datelike_vals)
             block_values = [datelike_vals]
     else:
-        block_values = [maybe_squeeze_dt64tz(values)]
+        # error: List item 0 has incompatible type "Union[ExtensionArray, ndarray]";
+        # expected "Block"
+        block_values = [maybe_squeeze_dt64tz(values)]  # type: ignore[list-item]
 
     return create_block_manager_from_blocks(block_values, [columns, index])
 
@@ -574,9 +576,10 @@ def extract_index(data) -> Index:
             else:
                 index = ibase.default_index(lengths[0])
 
-    # error: Value of type variable "AnyArrayLike" of "ensure_index" cannot be
-    # "Optional[Index]"
-    return ensure_index(index)  # type: ignore[type-var]
+    # error: Argument 1 to "ensure_index" has incompatible type "Optional[Index]";
+    # expected "Union[Union[Union[ExtensionArray, ndarray], Index, Series],
+    # Sequence[Any]]"
+    return ensure_index(index)  # type: ignore[arg-type]
 
 
 def reorder_arrays(

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -314,11 +314,7 @@ class BlockManager(DataManager):
         Not to be used in actual code, and return value is not the same as the
         ArrayManager method (list of 1D arrays vs iterator of 2D ndarrays / 1D EAs).
         """
-        # error: List comprehension has incompatible type List[Union[ndarray,
-        # ExtensionArray]]; expected List[ExtensionArray]
-        # error: List comprehension has incompatible type List[Union[ndarray,
-        # ExtensionArray]]; expected List[ndarray]
-        return [blk.values for blk in self.blocks]  # type: ignore[misc]
+        return [blk.values for blk in self.blocks]
 
     def __getstate__(self):
         block_values = [b.values for b in self.blocks]
@@ -1022,9 +1018,7 @@ class BlockManager(DataManager):
         if isinstance(dtype, ExtensionDtype):
             result = dtype.construct_array_type()._from_sequence(result, dtype=dtype)
 
-        # error: Incompatible return value type (got "ndarray", expected
-        # "ExtensionArray")
-        return result  # type: ignore[return-value]
+        return result
 
     def consolidate(self) -> BlockManager:
         """
@@ -1535,9 +1529,7 @@ class BlockManager(DataManager):
                 return False
             left = self.blocks[0].values
             right = other.blocks[0].values
-            # error: Value of type variable "ArrayLike" of "array_equals" cannot be
-            # "Union[ndarray, ExtensionArray]"
-            return array_equals(left, right)  # type: ignore[type-var]
+            return array_equals(left, right)
 
         return blockwise_all(self, other, array_equals)
 

--- a/pandas/core/internals/ops.py
+++ b/pandas/core/internals/ops.py
@@ -131,12 +131,7 @@ def _get_same_shape_values(
         # ExtensionArray]"; expected type "Union[int, slice, ndarray]"
         rvals = rvals[0, :]  # type: ignore[index]
 
-    # error: Incompatible return value type (got "Tuple[Union[ndarray, ExtensionArray],
-    # Union[ndarray, ExtensionArray]]", expected "Tuple[ExtensionArray,
-    # ExtensionArray]")
-    # error: Incompatible return value type (got "Tuple[Union[ndarray, ExtensionArray],
-    # Union[ndarray, ExtensionArray]]", expected "Tuple[ndarray, ndarray]")
-    return lvals, rvals  # type: ignore[return-value]
+    return lvals, rvals
 
 
 def blockwise_all(left: BlockManager, right: BlockManager, op) -> bool:

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -302,7 +302,9 @@ def _get_values(
     #  with scalar fill_value.  This guarantee is important for the
     #  np.where call below
     assert is_scalar(fill_value)
-    values = extract_array(values, extract_numpy=True)
+    # error: Incompatible types in assignment (expression has type "Union[Any,
+    # Union[ExtensionArray, ndarray]]", variable has type "ndarray")
+    values = extract_array(values, extract_numpy=True)  # type: ignore[assignment]
 
     mask = _maybe_get_mask(values, skipna, mask)
 
@@ -1161,7 +1163,9 @@ def nanskew(
     >>> nanops.nanskew(s)
     1.7320508075688787
     """
-    values = extract_array(values, extract_numpy=True)
+    # error: Incompatible types in assignment (expression has type "Union[Any,
+    # Union[ExtensionArray, ndarray]]", variable has type "ndarray")
+    values = extract_array(values, extract_numpy=True)  # type: ignore[assignment]
     mask = _maybe_get_mask(values, skipna, mask)
     if not is_float_dtype(values.dtype):
         values = values.astype("f8")
@@ -1246,7 +1250,9 @@ def nankurt(
     >>> nanops.nankurt(s)
     -1.2892561983471076
     """
-    values = extract_array(values, extract_numpy=True)
+    # error: Incompatible types in assignment (expression has type "Union[Any,
+    # Union[ExtensionArray, ndarray]]", variable has type "ndarray")
+    values = extract_array(values, extract_numpy=True)  # type: ignore[assignment]
     mask = _maybe_get_mask(values, skipna, mask)
     if not is_float_dtype(values.dtype):
         values = values.astype("f8")

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1847,10 +1847,12 @@ class _AsOfMerge(_OrderedMerge):
 
         def flip(xs) -> np.ndarray:
             """ unlike np.transpose, this returns an array of tuples """
+            # error: Item "ndarray" of "Union[Any, Union[ExtensionArray, ndarray]]" has
+            # no attribute "_values_for_argsort"
             xs = [
                 x
                 if not is_extension_array_dtype(x)
-                else extract_array(x)._values_for_argsort()
+                else extract_array(x)._values_for_argsort()  # type: ignore[union-attr]
                 for x in xs
             ]
             labels = list(string.ascii_lowercase[: len(xs)])
@@ -2064,13 +2066,8 @@ def _factorize_keys(
     if is_datetime64tz_dtype(lk.dtype) and is_datetime64tz_dtype(rk.dtype):
         # Extract the ndarray (UTC-localized) values
         # Note: we dont need the dtypes to match, as these can still be compared
-
-        # error: Incompatible types in assignment (expression has type "ndarray",
-        # variable has type "ExtensionArray")
-        lk = cast("DatetimeArray", lk)._ndarray  # type: ignore[assignment]
-        # error: Incompatible types in assignment (expression has type "ndarray",
-        # variable has type "ExtensionArray")
-        rk = cast("DatetimeArray", rk)._ndarray  # type: ignore[assignment]
+        lk = cast("DatetimeArray", lk)._ndarray
+        rk = cast("DatetimeArray", rk)._ndarray
 
     elif (
         is_categorical_dtype(lk.dtype)
@@ -2081,13 +2078,10 @@ def _factorize_keys(
         assert isinstance(rk, Categorical)
         # Cast rk to encoding so we can compare codes with lk
 
-        # error: <nothing> has no attribute "_encode_with_my_categories"
-        rk = lk._encode_with_my_categories(rk)  # type: ignore[attr-defined]
+        rk = lk._encode_with_my_categories(rk)
 
-        # error: <nothing> has no attribute "codes"
-        lk = ensure_int64(lk.codes)  # type: ignore[attr-defined]
-        # error: "ndarray" has no attribute "codes"
-        rk = ensure_int64(rk.codes)  # type: ignore[attr-defined]
+        lk = ensure_int64(lk.codes)
+        rk = ensure_int64(rk.codes)
 
     elif is_extension_array_dtype(lk.dtype) and is_dtype_equal(lk.dtype, rk.dtype):
         # error: Incompatible types in assignment (expression has type "ndarray",

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -152,7 +152,9 @@ class _Unstacker:
         indexer, _ = self._indexer_and_to_sort
 
         sorted_values = algos.take_nd(values, indexer, axis=0)
-        return sorted_values
+        # error: Incompatible return value type (got "Union[ExtensionArray, ndarray]",
+        # expected "ndarray")
+        return sorted_values  # type: ignore[return-value]
 
     def _make_selectors(self):
         new_levels = self.new_index_levels

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -152,9 +152,7 @@ class _Unstacker:
         indexer, _ = self._indexer_and_to_sort
 
         sorted_values = algos.take_nd(values, indexer, axis=0)
-        # error: Incompatible return value type (got "Union[ExtensionArray, ndarray]",
-        # expected "ndarray")
-        return sorted_values  # type: ignore[return-value]
+        return sorted_values
 
     def _make_selectors(self):
         new_levels = self.new_index_levels

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -460,11 +460,14 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         # Input is now list-like, so rely on "standard" construction:
 
         # TODO: passing np.float64 to not break anything yet. See GH-17261
-
-        # error: Value of type variable "ArrayLike" of
-        # "create_series_with_explicit_dtype" cannot be "Tuple[Any, ...]"
-        s = create_series_with_explicit_dtype(  # type: ignore[type-var]
-            values, index=keys, dtype=dtype, dtype_if_empty=np.float64
+        s = create_series_with_explicit_dtype(
+            # error: Argument "index" to "create_series_with_explicit_dtype" has
+            # incompatible type "Tuple[Any, ...]"; expected "Union[ExtensionArray,
+            # ndarray, Index, None]"
+            values,
+            index=keys,  # type: ignore[arg-type]
+            dtype=dtype,
+            dtype_if_empty=np.float64,
         )
 
         # Now we just make sure the order is respected, if any
@@ -3003,10 +3006,13 @@ Keep all original rows and also all original values
             # The function can return something of any type, so check
             # if the type is compatible with the calling EA.
 
-            # error: Value of type variable "ArrayLike" of
-            # "maybe_cast_to_extension_array" cannot be "List[Any]"
-            new_values = maybe_cast_to_extension_array(
-                type(self._values), new_values  # type: ignore[type-var]
+            # error: Incompatible types in assignment (expression has type
+            # "Union[ExtensionArray, ndarray]", variable has type "List[Any]")
+            new_values = maybe_cast_to_extension_array(  # type: ignore[assignment]
+                # error: Argument 2 to "maybe_cast_to_extension_array" has incompatible
+                # type "List[Any]"; expected "Union[ExtensionArray, ndarray]"
+                type(self._values),
+                new_values,  # type: ignore[arg-type]
             )
         return self._constructor(new_values, index=new_index, name=new_name)
 

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -245,9 +245,9 @@ def _convert_and_box_cache(
     from pandas import Series
 
     result = Series(arg).map(cache_array)
-    # error: Value of type variable "ArrayLike" of "_box_as_indexlike" cannot
-    # be "Series"
-    return _box_as_indexlike(result, utc=None, name=name)  # type: ignore[type-var]
+    # error: Argument 1 to "_box_as_indexlike" has incompatible type "Series"; expected
+    # "Union[ExtensionArray, ndarray]"
+    return _box_as_indexlike(result, utc=None, name=name)  # type: ignore[arg-type]
 
 
 def _return_parsed_timezone_results(result: np.ndarray, timezones, tz, name) -> Index:
@@ -1081,9 +1081,9 @@ def _attempt_YYYYMMDD(arg: np.ndarray, errors: Optional[str]) -> Optional[np.nda
 
     # string with NaN-like
     try:
-        # error: Value of type variable "AnyArrayLike" of "isin" cannot be
-        # "Iterable[Any]"
-        mask = ~algorithms.isin(arg, list(nat_strings))  # type: ignore[type-var]
+        # error: Argument 2 to "isin" has incompatible type "List[Any]"; expected
+        # "Union[Union[ExtensionArray, ndarray], Index, Series]"
+        mask = ~algorithms.isin(arg, list(nat_strings))  # type: ignore[arg-type]
         return calc_with_mask(arg, mask)
     except (ValueError, OverflowError, TypeError):
         pass

--- a/pandas/core/util/hashing.py
+++ b/pandas/core/util/hashing.py
@@ -116,11 +116,9 @@ def hash_pandas_object(
         return Series(hash_tuples(obj, encoding, hash_key), dtype="uint64", copy=False)
 
     elif isinstance(obj, ABCIndex):
-        # error: Value of type variable "ArrayLike" of "hash_array" cannot be
-        # "Union[ExtensionArray, ndarray]"
-        h = hash_array(  # type: ignore[type-var]
-            obj._values, encoding, hash_key, categorize
-        ).astype("uint64", copy=False)
+        h = hash_array(obj._values, encoding, hash_key, categorize).astype(
+            "uint64", copy=False
+        )
         # error: Incompatible types in assignment (expression has type "Series",
         # variable has type "ndarray")
         h = Series(h, index=obj, dtype="uint64", copy=False)  # type: ignore[assignment]
@@ -297,17 +295,13 @@ def hash_array(
     # hash values. (This check is above the complex check so that we don't ask
     # numpy if categorical is a subdtype of complex, as it will choke).
     if is_categorical_dtype(dtype):
-        # error: Incompatible types in assignment (expression has type "Categorical",
-        # variable has type "ndarray")
-        vals = cast("Categorical", vals)  # type: ignore[assignment]
-        # error: Argument 1 to "_hash_categorical" has incompatible type "ndarray";
-        # expected "Categorical"
-        return _hash_categorical(vals, encoding, hash_key)  # type: ignore[arg-type]
+        vals = cast("Categorical", vals)
+        return _hash_categorical(vals, encoding, hash_key)
     elif is_extension_array_dtype(dtype):
-        # error: Incompatible types in assignment (expression has type "ndarray",
-        # variable has type "ExtensionArray")
-        # error: "ndarray" has no attribute "_values_for_factorize"
-        vals, _ = vals._values_for_factorize()  # type: ignore[assignment,attr-defined]
+        # pandas/core/util/hashing.py:301: error: Item "ndarray" of
+        # "Union[ExtensionArray, ndarray]" has no attribute "_values_for_factorize"
+        # [union-attr]
+        vals, _ = vals._values_for_factorize()  # type: ignore[union-attr]
 
     # error: Argument 1 to "_hash_ndarray" has incompatible type "ExtensionArray";
     # expected "ndarray"

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -424,11 +424,7 @@ class BaseWindow(SelectionMixin):
             return getattr(res_values, "T", res_values)
 
         def hfunc2d(values: ArrayLike) -> ArrayLike:
-            # error: Incompatible types in assignment (expression has type "ndarray",
-            # variable has type "ExtensionArray")
-            # error: Argument 1 to "_prep_values" of "BaseWindow" has incompatible type
-            # "ExtensionArray"; expected "Optional[ndarray]"
-            values = self._prep_values(values)  # type: ignore[assignment,arg-type]
+            values = self._prep_values(values)
             return homogeneous_func(values)
 
         if isinstance(mgr, ArrayManager) and self.axis == 1:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1561,7 +1561,9 @@ class ExtensionArrayFormatter(GenericArrayFormatter):
 
         formatter = self.formatter
         if formatter is None:
-            formatter = values._formatter(boxed=True)
+            # error: Item "ndarray" of "Union[Any, Union[ExtensionArray, ndarray]]" has
+            # no attribute "_formatter"
+            formatter = values._formatter(boxed=True)  # type: ignore[union-attr]
 
         if is_categorical_dtype(values.dtype):
             # Categorical is special for now, so that we can preserve tzinfo

--- a/pandas/io/parsers/base_parser.py
+++ b/pandas/io/parsers/base_parser.py
@@ -531,7 +531,11 @@ class ParserBase:
                 try:
                     values = lib.map_infer(values, conv_f)
                 except ValueError:
-                    mask = algorithms.isin(values, list(na_values)).view(np.uint8)
+                    # error: Argument 2 to "isin" has incompatible type "List[Any]";
+                    # expected "Union[Union[ExtensionArray, ndarray], Index, Series]"
+                    mask = algorithms.isin(
+                        values, list(na_values)  # type: ignore[arg-type]
+                    ).view(np.uint8)
                     values = lib.map_infer_mask(values, conv_f, mask)
 
                 cvals, na_count = self._infer_types(
@@ -657,7 +661,9 @@ class ParserBase:
         """
         na_count = 0
         if issubclass(values.dtype.type, (np.number, np.bool_)):
-            mask = algorithms.isin(values, list(na_values))
+            # error: Argument 2 to "isin" has incompatible type "List[Any]"; expected
+            # "Union[Union[ExtensionArray, ndarray], Index, Series]"
+            mask = algorithms.isin(values, list(na_values))  # type: ignore[arg-type]
             # error: Incompatible types in assignment (expression has type
             # "number[Any]", variable has type "int")
             na_count = mask.sum()  # type: ignore[assignment]

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2362,8 +2362,9 @@ class DataCol(IndexCol):
         Get an appropriately typed and shaped pytables.Col object for values.
         """
         dtype = values.dtype
-        # error: "ExtensionDtype" has no attribute "itemsize"
-        itemsize = dtype.itemsize  # type: ignore[attr-defined]
+        # error: Item "ExtensionDtype" of "Union[ExtensionDtype, dtype[Any]]" has no
+        # attribute "itemsize"
+        itemsize = dtype.itemsize  # type: ignore[union-attr]
 
         shape = values.shape
         if values.ndim == 1:
@@ -4845,9 +4846,9 @@ def _convert_index(name: str, index: Index, encoding: str, errors: str) -> Index
     assert isinstance(name, str)
 
     index_name = index.name
-    # error: Value of type variable "ArrayLike" of "_get_data_and_dtype_name"
-    # cannot be "Index"
-    converted, dtype_name = _get_data_and_dtype_name(index)  # type: ignore[type-var]
+    # error: Argument 1 to "_get_data_and_dtype_name" has incompatible type "Index";
+    # expected "Union[ExtensionArray, ndarray]"
+    converted, dtype_name = _get_data_and_dtype_name(index)  # type: ignore[arg-type]
     kind = _dtype_to_kind(dtype_name)
     atom = DataIndexableCol._get_atom(converted)
 
@@ -5169,26 +5170,20 @@ def _get_data_and_dtype_name(data: ArrayLike):
     Convert the passed data into a storable form and a dtype string.
     """
     if isinstance(data, Categorical):
-        # error: Incompatible types in assignment (expression has type
-        # "ndarray", variable has type "ExtensionArray")
-        data = data.codes  # type: ignore[assignment]
+        data = data.codes
 
     # For datetime64tz we need to drop the TZ in tests TODO: why?
     dtype_name = data.dtype.name.split("[")[0]
 
     if data.dtype.kind in ["m", "M"]:
-        # error: Incompatible types in assignment (expression has type "ndarray",
-        # variable has type "ExtensionArray")
-        data = np.asarray(data.view("i8"))  # type: ignore[assignment]
+        data = np.asarray(data.view("i8"))
         # TODO: we used to reshape for the dt64tz case, but no longer
         #  doing that doesn't seem to break anything.  why?
 
     elif isinstance(data, PeriodIndex):
         data = data.asi8
 
-    # error: Incompatible types in assignment (expression has type "ndarray", variable
-    # has type "ExtensionArray")
-    data = np.asarray(data)  # type: ignore[assignment]
+    data = np.asarray(data)
     return data, dtype_name
 
 

--- a/pandas/tests/extension/decimal/array.py
+++ b/pandas/tests/extension/decimal/array.py
@@ -4,7 +4,10 @@ import decimal
 import numbers
 import random
 import sys
-from typing import Type
+from typing import (
+    Type,
+    Union,
+)
 
 import numpy as np
 
@@ -173,7 +176,7 @@ class DecimalArray(OpsMixin, ExtensionScalarOpsMixin, ExtensionArray):
     def __len__(self) -> int:
         return len(self._data)
 
-    def __contains__(self, item) -> bool:
+    def __contains__(self, item) -> Union[bool, np.bool_]:
         if not isinstance(item, decimal.Decimal):
             return False
         elif item.is_nan():


### PR DESCRIPTION
follow-on from #36092

The first commit is the change in the alias.

Although this does get rid of many of the false positives, as well as removing ignores this also results is some changes in the mypy error codes and some new errors where we might need a typevar (or more likely an overload)

The subsequent commits were an attempt to ensure that this PR only removed ignores.

The PR is starting to get a bit difficult to review imo. so I have stopped for now.

I could break off the first commit and then submit the subsequent commits as separate PRs if it makes review easier.