### PR TITLE
ENH: Make to_csv('filename.csv.zip') compress the output

### DIFF
--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -776,6 +776,11 @@ class _BytesZipFile(zipfile.ZipFile, BytesIO):  # type: ignore[misc]
         self.archive_name = archive_name
         self.multiple_write_buffer: Optional[Union[StringIO, BytesIO]] = None
 
+        if archive_name is None and isinstance(file, (os.PathLike, str)):
+            archive_name = os.path.basename(file)
+            if archive_name.endswith(".zip"):
+                self.archive_name = archive_name[:-4]
+
         kwargs_zip: Dict[str, Any] = {"compression": zipfile.ZIP_DEFLATED}
         kwargs_zip.update(kwargs)
 

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -644,7 +644,31 @@ z
                 handle.seek(0)
                 assert handle.read().startswith(b'\xef\xbb\xbf""')
 
+    @pytest.mark.parametrize(
+        "df,csv_name",
+        [
+            (
+                    DataFrame({"a": [1, 2, 3, 4, 5], "b": [4, 5, 6, 7, 8]}),
+                    "test_to_csv_zipped_content_name.csv",
+            )
+        ],
+    )
+    def test_to_csv_content_name_in_zipped_file(self, df, csv_name):
+        from zipfile import ZipFile
+        from pathlib import Path
 
+        suffix_zip_name = csv_name + ".zip"
+        with tm.ensure_clean(suffix_zip_name) as pth:
+            # ensure_clean will add random str before suffix_zip_name,
+            # need Path.stem to get real file name
+            df.to_csv(pth)
+            zf = ZipFile(pth)
+            pp = Path(pth)
+            result = zf.filelist[0].filename
+            expected = pp.stem
+            zf.close()
+            assert result == expected
+            
 def test_to_csv_iterative_compression_name(compression):
     # GH 38714
     df = tm.makeDataFrame()

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -543,9 +543,6 @@ z
     )
     def test_to_csv_zip_arguments(self, compression, archive_name):
         # GH 26023
-        from pathlib import Path
-        from zipfile import ZipFile
-
         df = DataFrame({"ABC": [1]})
         with tm.ensure_clean("to_csv_archive_name.zip") as path:
             df.to_csv(

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -541,8 +541,8 @@ z
     )
     def test_to_csv_zip_arguments(self, compression, archive_name):
         # GH 26023
-        from zipfile import ZipFile
         from pathlib import Path
+        from zipfile import ZipFile
 
         df = DataFrame({"ABC": [1]})
         with tm.ensure_clean("to_csv_archive_name.zip") as path:
@@ -551,7 +551,7 @@ z
             )
             with ZipFile(path) as zp:
                 if archive_name is None:
-                    pth=Path(path)
+                    pth = Path(path)
                     expected_arcname = pth.stem
                 else:
                     expected_arcname = archive_name

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -648,14 +648,14 @@ z
         "df,csv_name",
         [
             (
-                    DataFrame({"a": [1, 2, 3, 4, 5], "b": [4, 5, 6, 7, 8]}),
-                    "test_to_csv_zipped_content_name.csv",
+                DataFrame({"a": [1, 2, 3, 4, 5], "b": [4, 5, 6, 7, 8]}),
+                "test_to_csv_zipped_content_name.csv",
             )
         ],
     )
     def test_to_csv_content_name_in_zipped_file(self, df, csv_name):
-        from zipfile import ZipFile
         from pathlib import Path
+        from zipfile import ZipFile
 
         suffix_zip_name = csv_name + ".zip"
         with tm.ensure_clean(suffix_zip_name) as pth:
@@ -668,7 +668,8 @@ z
             expected = pp.stem
             zf.close()
             assert result == expected
-            
+
+
 def test_to_csv_iterative_compression_name(compression):
     # GH 38714
     df = tm.makeDataFrame()

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -1,6 +1,8 @@
 import io
 import os
+from pathlib import Path
 import sys
+from zipfile import ZipFile
 
 import numpy as np
 import pytest
@@ -659,20 +661,16 @@ z
         ],
     )
     def test_to_csv_content_name_in_zipped_file(self, df, csv_name):
-        from pathlib import Path
-        from zipfile import ZipFile
-
         suffix_zip_name = csv_name + ".zip"
         with tm.ensure_clean(suffix_zip_name) as pth:
             # ensure_clean will add random str before suffix_zip_name,
             # need Path.stem to get real file name
             df.to_csv(pth)
-            zf = ZipFile(pth)
             pp = Path(pth)
-            result = zf.filelist[0].filename
-            expected = pp.stem
-            zf.close()
-            assert result == expected
+            with ZipFile(pth) as zf:
+                result = zf.filelist[0].filename
+                expected = pp.stem
+                assert result == expected
 
 
 def test_to_csv_iterative_compression_name(compression):

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -542,6 +542,7 @@ z
     def test_to_csv_zip_arguments(self, compression, archive_name):
         # GH 26023
         from zipfile import ZipFile
+        from pathlib import Path
 
         df = DataFrame({"ABC": [1]})
         with tm.ensure_clean("to_csv_archive_name.zip") as path:
@@ -549,7 +550,11 @@ z
                 path, compression={"method": compression, "archive_name": archive_name}
             )
             with ZipFile(path) as zp:
-                expected_arcname = path if archive_name is None else archive_name
+                if archive_name is None:
+                    pth=Path(path)
+                    expected_arcname = pth.stem
+                else:
+                    expected_arcname = archive_name
                 expected_arcname = os.path.basename(expected_arcname)
                 assert len(zp.filelist) == 1
                 archived_file = os.path.basename(zp.filelist[0].filename)


### PR DESCRIPTION
- [x] closes #39465 #26023
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] dataframe.to_csv  with zip compression now works like gzip/xz, when use 'infer' and destination path 'xxxx.csv.zip' which endwith '.zip', to_csv will create a zip file with archive_name=xxxx.csv

close old PR,do some work after read pre commit guidelines