### PR TITLE
TYP: Index.join, get_indexer, reindex

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3751,7 +3751,9 @@ class Index(IndexOpsMixin, PandasObject):
         if not self._index_as_unique and len(indexer):
             raise ValueError("cannot reindex from a duplicate axis")
 
-    def reindex(self, target, method=None, level=None, limit=None, tolerance=None):
+    def reindex(
+        self, target, method=None, level=None, limit=None, tolerance=None
+    ) -> Tuple[Index, Optional[np.ndarray[np.intp]]]:
         """
         Create index with target's values.
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3396,7 +3396,7 @@ class Index(IndexOpsMixin, PandasObject):
     @final
     def get_indexer(
         self, target, method=None, limit=None, tolerance=None
-    ) -> np.ndarray:
+    ) -> np.ndarray[np.intp]:
 
         method = missing.clean_reindex_fill_method(method)
         target = ensure_index(target)
@@ -3421,7 +3421,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     def _get_indexer(
         self, target: Index, method=None, limit=None, tolerance=None
-    ) -> np.ndarray:
+    ) -> np.ndarray[np.intp]:
         if tolerance is not None:
             tolerance = self._convert_tolerance(tolerance, target)
 
@@ -5383,6 +5383,18 @@ class Index(IndexOpsMixin, PandasObject):
             return self.get_indexer(target, **kwargs)
         indexer, _ = self.get_indexer_non_unique(target)
         return indexer
+
+    @overload
+    def _get_indexer_non_comparable(
+        self, target: Index, method, unique: Literal[True] = ...
+    ) -> np.ndarray[np.intp]:
+        ...
+
+    @overload
+    def _get_indexer_non_comparable(
+        self, target: Index, method, unique: Literal[False] = ...
+    ) -> Tuple[np.ndarray[np.intp], np.ndarray[np.intp]]:
+        ...
 
     @final
     def _get_indexer_non_comparable(self, target: Index, method, unique: bool = True):

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -3,6 +3,7 @@ from typing import (
     Hashable,
     List,
     Optional,
+    Tuple,
 )
 import warnings
 
@@ -484,7 +485,7 @@ class CategoricalIndex(NDArrayBackedExtensionIndex, accessor.PandasDelegate):
 
     def _get_indexer(
         self, target: Index, method=None, limit=None, tolerance=None
-    ) -> np.ndarray:
+    ) -> np.ndarray[np.intp]:
 
         if self.equals(target):
             return np.arange(len(self), dtype="intp")
@@ -492,11 +493,15 @@ class CategoricalIndex(NDArrayBackedExtensionIndex, accessor.PandasDelegate):
         return self._get_indexer_non_unique(target._values)[0]
 
     @Appender(_index_shared_docs["get_indexer_non_unique"] % _index_doc_kwargs)
-    def get_indexer_non_unique(self, target):
+    def get_indexer_non_unique(
+        self, target
+    ) -> Tuple[np.ndarray[np.intp], np.ndarray[np.intp]]:
         target = ibase.ensure_index(target)
         return self._get_indexer_non_unique(target._values)
 
-    def _get_indexer_non_unique(self, values: ArrayLike):
+    def _get_indexer_non_unique(
+        self, values: ArrayLike
+    ) -> Tuple[np.ndarray[np.intp], np.ndarray[np.intp]]:
         """
         get_indexer_non_unique but after unrapping the target Index object.
         """
@@ -515,7 +520,7 @@ class CategoricalIndex(NDArrayBackedExtensionIndex, accessor.PandasDelegate):
             codes = self.categories.get_indexer(values)
 
         indexer, missing = self._engine.get_indexer_non_unique(codes)
-        return ensure_platform_int(indexer), missing
+        return ensure_platform_int(indexer), ensure_platform_int(missing)
 
     @doc(Index._convert_list_indexer)
     def _convert_list_indexer(self, keyarr):

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -387,7 +387,9 @@ class CategoricalIndex(NDArrayBackedExtensionIndex, accessor.PandasDelegate):
         #  of result, not self.
         return type(self)._simple_new(result, name=self.name)
 
-    def reindex(self, target, method=None, level=None, limit=None, tolerance=None):
+    def reindex(
+        self, target, method=None, level=None, limit=None, tolerance=None
+    ) -> Tuple[Index, Optional[np.ndarray[np.intp]]]:
         """
         Create index with target's values (move/add/delete values as necessary)
 
@@ -395,7 +397,7 @@ class CategoricalIndex(NDArrayBackedExtensionIndex, accessor.PandasDelegate):
         -------
         new_index : pd.Index
             Resulting index
-        indexer : np.ndarray or None
+        indexer : np.ndarray[np.intp] or None
             Indices of output values in original index
 
         """

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -827,7 +827,12 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin):
     _join_precedence = 10
 
     def join(
-        self, other, how: str = "left", level=None, return_indexers=False, sort=False
+        self,
+        other: Index,
+        how: str = "left",
+        level=None,
+        return_indexers: bool = False,
+        sort: bool = False,
     ):
         """
         See Index.join

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -700,7 +700,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
         method: Optional[str] = None,
         limit: Optional[int] = None,
         tolerance: Optional[Any] = None,
-    ) -> np.ndarray:
+    ) -> np.ndarray[np.intp]:
 
         if isinstance(target, IntervalIndex):
             # equal indexes -> 1:1 positional match
@@ -732,7 +732,9 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
         return ensure_platform_int(indexer)
 
     @Appender(_index_shared_docs["get_indexer_non_unique"] % _index_doc_kwargs)
-    def get_indexer_non_unique(self, target: Index) -> Tuple[np.ndarray, np.ndarray]:
+    def get_indexer_non_unique(
+        self, target: Index
+    ) -> Tuple[np.ndarray[np.intp], np.ndarray[np.intp]]:
         target = ensure_index(target)
 
         if isinstance(target, IntervalIndex) and not self._should_compare(target):
@@ -751,7 +753,9 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
 
         return ensure_platform_int(indexer), ensure_platform_int(missing)
 
-    def _get_indexer_pointwise(self, target: Index) -> Tuple[np.ndarray, np.ndarray]:
+    def _get_indexer_pointwise(
+        self, target: Index
+    ) -> Tuple[np.ndarray[np.intp], np.ndarray[np.intp]]:
         """
         pointwise implementation for get_indexer and get_indexer_non_unique.
         """

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2672,7 +2672,7 @@ class MultiIndex(Index):
 
     def _get_indexer(
         self, target: Index, method=None, limit=None, tolerance=None
-    ) -> np.ndarray:
+    ) -> np.ndarray[np.intp]:
 
         # empty indexer
         if not len(target):

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2509,7 +2509,9 @@ class MultiIndex(Index):
 
         return new_index, indexer
 
-    def reindex(self, target, method=None, level=None, limit=None, tolerance=None):
+    def reindex(
+        self, target, method=None, level=None, limit=None, tolerance=None
+    ) -> Tuple[Index, Optional[np.ndarray[np.intp]]]:
         """
         Create index with target's values (move/add/delete values as necessary)
 
@@ -2517,7 +2519,7 @@ class MultiIndex(Index):
         -------
         new_index : pd.MultiIndex
             Resulting index
-        indexer : np.ndarray or None
+        indexer : np.ndarray[np.intp] or None
             Indices of output values in original index.
 
         """

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -395,7 +395,9 @@ class RangeIndex(Int64Index):
             raise KeyError(key)
         return super().get_loc(key, method=method, tolerance=tolerance)
 
-    def _get_indexer(self, target: Index, method=None, limit=None, tolerance=None):
+    def _get_indexer(
+        self, target: Index, method=None, limit=None, tolerance=None
+    ) -> np.ndarray[np.intp]:
         if com.any_not_none(method, tolerance, limit):
             return super()._get_indexer(
                 target, method=method, tolerance=tolerance, limit=limit

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4220,7 +4220,13 @@ Keep all original rows and also all original values
             with np.errstate(all="ignore"):
                 return op(delegate, skipna=skipna, **kwds)
 
-    def _reindex_indexer(self, new_index, indexer, copy):
+    def _reindex_indexer(
+        self,
+        new_index: Optional[Index],
+        indexer: Optional[np.ndarray[np.intp]],
+        copy: bool,
+    ) -> Series:
+        # Note: new_index is None iff indexer is None
         if indexer is None:
             if copy:
                 return self.copy()
@@ -4231,7 +4237,7 @@ Keep all original rows and also all original values
         )
         return self._constructor(new_values, index=new_index)
 
-    def _needs_reindex_multi(self, axes, method, level):
+    def _needs_reindex_multi(self, axes, method, level) -> bool:
         """
         Check if we do need a multi reindex; this is for compat with
         higher dims.


### PR DESCRIPTION
@simonjayhawkins this is technically incorrect bc im specifying returned dtypes as np.intp.  Is there a valid way to do this?  In working in core.internals trying to figure out whether we want int64 or intp I had to track all of these down to be sure.  Would prefer to avoid re-doing this in a few weeks when I forget.