### PR TITLE
TYP: Arraylike alias change follow up

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -123,6 +123,8 @@ from pandas.core.ops.invalid import (
 from pandas.tseries import frequencies
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from pandas.core.arrays import (
         DatetimeArray,
         TimedeltaArray,
@@ -456,6 +458,14 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
 
     @overload
     def view(self: DatetimeLikeArrayT) -> DatetimeLikeArrayT:
+        ...
+
+    @overload
+    def view(self, dtype: Literal["M8[ns]"]) -> DatetimeArray:
+        ...
+
+    @overload
+    def view(self, dtype: Literal["m8[ns]"]) -> TimedeltaArray:
         ...
 
     @overload

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -643,11 +643,7 @@ class PeriodArray(PeriodMixin, dtl.DatelikeOps):
         if method is not None:
             # view as dt64 so we get treated as timelike in core.missing
             dta = self.view("M8[ns]")
-            # error: Item "ndarray" of "Union[ExtensionArray, ndarray]" has no attribute
-            # "fillna"
-            result = dta.fillna(  # type: ignore[union-attr]
-                value=value, method=method, limit=limit
-            )
+            result = dta.fillna(value=value, method=method, limit=limit)
             return result.view(self.dtype)
         return super().fillna(value=value, method=method, limit=limit)
 

--- a/pandas/core/arrays/sparse/dtype.py
+++ b/pandas/core/arrays/sparse/dtype.py
@@ -9,7 +9,6 @@ from typing import (
     Optional,
     Tuple,
     Type,
-    cast,
 )
 import warnings
 
@@ -28,7 +27,6 @@ from pandas.core.dtypes.base import (
 from pandas.core.dtypes.cast import astype_nansafe
 from pandas.core.dtypes.common import (
     is_bool_dtype,
-    is_extension_array_dtype,
     is_object_dtype,
     is_scalar,
     is_string_dtype,
@@ -340,10 +338,8 @@ class SparseDtype(ExtensionDtype):
         dtype = pandas_dtype(dtype)
 
         if not isinstance(dtype, cls):
-            if is_extension_array_dtype(dtype):
+            if not isinstance(dtype, np.dtype):
                 raise TypeError("sparse arrays of extension dtypes not supported")
-
-            dtype = cast(np.dtype, dtype)
 
             fill_value = astype_nansafe(np.array(self.fill_value), dtype).item()
             dtype = cls(dtype, fill_value=fill_value)

--- a/pandas/core/arrays/sparse/dtype.py
+++ b/pandas/core/arrays/sparse/dtype.py
@@ -9,6 +9,7 @@ from typing import (
     Optional,
     Tuple,
     Type,
+    cast,
 )
 import warnings
 
@@ -342,11 +343,9 @@ class SparseDtype(ExtensionDtype):
             if is_extension_array_dtype(dtype):
                 raise TypeError("sparse arrays of extension dtypes not supported")
 
-            # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
-            # attribute "item"
-            fill_value = astype_nansafe(  # type: ignore[union-attr]
-                np.array(self.fill_value), dtype
-            ).item()
+            dtype = cast(np.dtype, dtype)
+
+            fill_value = astype_nansafe(np.array(self.fill_value), dtype).item()
             dtype = cls(dtype, fill_value=fill_value)
 
         return dtype

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -25,6 +25,7 @@ from typing import (
     Type,
     Union,
     cast,
+    overload,
 )
 import warnings
 
@@ -1162,6 +1163,20 @@ def astype_td64_unit_conversion(
     mask = isna(values)
     np.putmask(result, mask, np.nan)
     return result
+
+
+@overload
+def astype_nansafe(
+    arr: np.ndarray, dtype: np.dtype, copy: bool = ..., skipna: bool = ...
+) -> np.ndarray:
+    ...
+
+
+@overload
+def astype_nansafe(
+    arr: np.ndarray, dtype: ExtensionDtype, copy: bool = ..., skipna: bool = ...
+) -> ExtensionArray:
+    ...
 
 
 def astype_nansafe(

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -108,6 +108,8 @@ from pandas.core.dtypes.missing import (
 )
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from pandas import Series
     from pandas.core.arrays import (
         DatetimeArray,
@@ -1205,14 +1207,10 @@ def astype_nansafe(
         flags = arr.flags
         flat = arr.ravel("K")
         result = astype_nansafe(flat, dtype, copy=copy, skipna=skipna)
-        order = "F" if flags.f_contiguous else "C"
+        order: Literal["C", "F"] = "F" if flags.f_contiguous else "C"
         # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
         # attribute "reshape"
-        # error: No overload variant of "reshape" of "_ArrayOrScalarCommon" matches
-        # argument types "Tuple[int, ...]", "str"
-        return result.reshape(  # type: ignore[union-attr,call-overload]
-            arr.shape, order=order
-        )
+        return result.reshape(arr.shape, order=order)  # type: ignore[union-attr]
 
     # We get here with 0-dim from sparse
     arr = np.atleast_1d(arr)

--- a/pandas/io/parsers/base_parser.py
+++ b/pandas/io/parsers/base_parser.py
@@ -724,6 +724,7 @@ class ParserBase:
                 # TODO: this is for consistency with
                 # c-parser which parses all categories
                 # as strings
+
                 values = astype_nansafe(values, np.dtype(str))
 
             cats = Index(values).unique().dropna()

--- a/pandas/io/parsers/base_parser.py
+++ b/pandas/io/parsers/base_parser.py
@@ -724,7 +724,7 @@ class ParserBase:
                 # TODO: this is for consistency with
                 # c-parser which parses all categories
                 # as strings
-                values = astype_nansafe(values, np.string_)
+                values = astype_nansafe(values, np.dtype(str))
 
             cats = Index(values).unique().dropna()
             values = Categorical._from_inferred_categories(

--- a/pandas/io/parsers/base_parser.py
+++ b/pandas/io/parsers/base_parser.py
@@ -724,10 +724,7 @@ class ParserBase:
                 # TODO: this is for consistency with
                 # c-parser which parses all categories
                 # as strings
-
-                # error: Argument 2 to "astype_nansafe" has incompatible type
-                # "Type[str]"; expected "Union[dtype[Any], ExtensionDtype]"
-                values = astype_nansafe(values, str)  # type: ignore[arg-type]
+                values = astype_nansafe(values, np.string_)
 
             cats = Index(values).unique().dropna()
             values = Categorical._from_inferred_categories(


### PR DESCRIPTION
follow-on from #40379 removing ignores that either changed or were added with the change of the ArrayLike alias to a Union
