### PR TITLE
BUG: fix convert_dtypes to handle empty df

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -625,7 +625,7 @@ Other
 - Bug in :class:`Styler` where multiple elements in CSS-selectors were not correctly added to ``table_styles`` (:issue:`39942`)
 - Bug in :meth:`DataFrame.equals`, :meth:`Series.equals`, :meth:`Index.equals` with object-dtype containing ``np.datetime64("NaT")`` or ``np.timedelta64("NaT")`` (:issue:`39650`)
 - Bug in :func:`pandas.util.show_versions` where console JSON output was not proper JSON (:issue:`39701`)
-- Bug in :meth:`generic.convert_dtypes` when called on an empty DataFrame (:issue:`40393`)
+- Bug in :meth:`DataFrame.convert_dtypes` when called on an empty DataFrame (:issue:`40393`)
 
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -625,7 +625,7 @@ Other
 - Bug in :class:`Styler` where multiple elements in CSS-selectors were not correctly added to ``table_styles`` (:issue:`39942`)
 - Bug in :meth:`DataFrame.equals`, :meth:`Series.equals`, :meth:`Index.equals` with object-dtype containing ``np.datetime64("NaT")`` or ``np.timedelta64("NaT")`` (:issue:`39650`)
 - Bug in :func:`pandas.util.show_versions` where console JSON output was not proper JSON (:issue:`39701`)
-- Bug in :meth:`DataFrame.convert_dtypes` when called on an empty DataFrame (:issue:`40393`)
+- Bug in :meth:`DataFrame.convert_dtypes` incorrectly raised ValueError when called on an empty DataFrame (:issue:`40393`)
 
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -625,6 +625,7 @@ Other
 - Bug in :class:`Styler` where multiple elements in CSS-selectors were not correctly added to ``table_styles`` (:issue:`39942`)
 - Bug in :meth:`DataFrame.equals`, :meth:`Series.equals`, :meth:`Index.equals` with object-dtype containing ``np.datetime64("NaT")`` or ``np.timedelta64("NaT")`` (:issue:`39650`)
 - Bug in :func:`pandas.util.show_versions` where console JSON output was not proper JSON (:issue:`39701`)
+- Bug in :meth:`generic.convert_dtypes` when called on an empty DataFrame (:issue:`40393`)
 
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6325,7 +6325,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
             if len(results) > 0:
                 return concat(results, axis=1, copy=False)
             else:
-                return self
+                return self.copy()
 
     # ----------------------------------------------------------------------
     # Filling NA's

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6322,7 +6322,10 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
                 )
                 for col_name, col in self.items()
             ]
-            return concat(results, axis=1, copy=False)
+            if len(results) > 0:
+                return concat(results, axis=1, copy=False)
+            else:
+                return self
 
     # ----------------------------------------------------------------------
     # Filling NA's

--- a/pandas/tests/frame/methods/test_convert_dtypes.py
+++ b/pandas/tests/frame/methods/test_convert_dtypes.py
@@ -26,3 +26,8 @@ class TestConvertDtypes:
             }
         )
         tm.assert_frame_equal(result, expected)
+
+    def test_convert_empty(self):
+        # Empty DataFrame can pass convert_dtypes, see GH#40393
+        df = pd.DataFrame().convert_dtypes()
+        assert df.empty

--- a/pandas/tests/frame/methods/test_convert_dtypes.py
+++ b/pandas/tests/frame/methods/test_convert_dtypes.py
@@ -30,4 +30,4 @@ class TestConvertDtypes:
     def test_convert_empty(self):
         # Empty DataFrame can pass convert_dtypes, see GH#40393
         empty_df = pd.DataFrame()
-        tm.assert_equal(empty_df, empty_df.convert_dtypes())
+        tm.assert_frame_equal(empty_df, empty_df.convert_dtypes())

--- a/pandas/tests/frame/methods/test_convert_dtypes.py
+++ b/pandas/tests/frame/methods/test_convert_dtypes.py
@@ -29,5 +29,5 @@ class TestConvertDtypes:
 
     def test_convert_empty(self):
         # Empty DataFrame can pass convert_dtypes, see GH#40393
-        df = pd.DataFrame().convert_dtypes()
-        assert df.empty
+        empty_df = pd.DataFrame()
+        tm.assert_equal(empty_df, empty_df.convert_dtypes())

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -225,3 +225,10 @@ class TestSeriesConvertDtypes:
         # GH32287
         df = pd.DataFrame({"A": pd.array([True])})
         tm.assert_frame_equal(df, df.convert_dtypes())
+
+
+class TestDataFrameConvertDtypes:
+    def test_convert_empty(self):
+        # Empty DataFrame can pass convert_dtypes, see GH#40393
+        df = pd.DataFrame().convert_dtypes()
+        assert df.empty

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -225,10 +225,3 @@ class TestSeriesConvertDtypes:
         # GH32287
         df = pd.DataFrame({"A": pd.array([True])})
         tm.assert_frame_equal(df, df.convert_dtypes())
-
-
-class TestDataFrameConvertDtypes:
-    def test_convert_empty(self):
-        # Empty DataFrame can pass convert_dtypes, see GH#40393
-        df = pd.DataFrame().convert_dtypes()
-        assert df.empty


### PR DESCRIPTION
Added a conditional to check a DataFrame had at least one column and if not return the original (empty) DataFrame if so.

- [x] closes #40393
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
