### PR TITLE
DOC: remove pin for pydata-sphinx-theme + update for latest release

### DIFF
--- a/doc/source/_static/css/pandas.css
+++ b/doc/source/_static/css/pandas.css
@@ -2,7 +2,7 @@
 
 :root {
   /* Use softer blue from bootstrap's default info color */
-  --color-info: 23, 162, 184;
+  --pst-color-info: 23, 162, 184;
 }
 
 /* Getting started index page */

--- a/environment.yml
+++ b/environment.yml
@@ -113,5 +113,5 @@ dependencies:
   - tabulate>=0.8.3  # DataFrame.to_markdown
   - natsort  # DataFrame.sort_values
   - pip:
-    - git+https://github.com/pandas-dev/pydata-sphinx-theme.git@2488b7defbd3d753dd5fcfc890fc4a7e79d25103
+    - git+https://github.com/pydata/pydata-sphinx-theme.git@master
     - numpydoc < 1.2  # 2021-02-09 1.2dev breaking CI

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -76,5 +76,5 @@ cftime
 pyreadstat
 tabulate>=0.8.3
 natsort
-git+https://github.com/pandas-dev/pydata-sphinx-theme.git@2488b7defbd3d753dd5fcfc890fc4a7e79d25103
+git+https://github.com/pydata/pydata-sphinx-theme.git@master
 numpydoc < 1.2


### PR DESCRIPTION
No longer pinning since the bug with the mobile dropdown has been fixed + update the variable for changes in the last release.
