### PR TITLE
BUG: Do not attempt to cache unhashable values in to_datetime (#39756)

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -592,6 +592,7 @@ Reshaping
 - Bug in :meth:`DataFrame.pivot_table` returning a ``MultiIndex`` for a single value when operating on and empty ``DataFrame`` (:issue:`13483`)
 - Allow :class:`Index` to be passed to the :func:`numpy.all` function (:issue:`40180`)
 - Bug in :meth:`DataFrame.stack` not preserving ``CategoricalDtype`` in a ``MultiIndex`` (:issue:`36991`)
+- Bug in :func:`to_datetime` raising error when input sequence contains unhashable items (:issue:`39756`)
 
 Sparse
 ^^^^^^

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -147,7 +147,11 @@ def should_cache(
 
     assert 0 < unique_share < 1, "unique_share must be in next bounds: (0; 1)"
 
-    unique_elements = set(islice(arg, check_count))
+    try:
+        # We can't cache if the items are not hashable.
+        unique_elements = set(islice(arg, check_count))
+    except TypeError:
+        return False
     if len(unique_elements) > check_count * unique_share:
         do_caching = False
     return do_caching

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -1653,8 +1653,8 @@ class TestToDatetimeMisc:
 
     @pytest.mark.parametrize("cache", [True, False])
     def test_to_datetime_unhashable_input(self, cache):
-        series = Series([['a']] * 100)
-        result = to_datetime(series, errors='ignore', cache=cache)
+        series = Series([["a"]] * 100)
+        result = to_datetime(series, errors="ignore", cache=cache)
         tm.assert_series_equal(series, result)
 
     def test_to_datetime_other_datetime64_units(self):

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -1653,7 +1653,7 @@ class TestToDatetimeMisc:
 
     @pytest.mark.parametrize("cache", [True, False])
     def test_to_datetime_unhashable_input(self, cache):
-        series = Series([['a']]*100)
+        series = Series([['a']] * 100)
         result = to_datetime(series, errors='ignore', cache=cache)
         tm.assert_series_equal(series, result)
 

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -1651,6 +1651,12 @@ class TestToDatetimeMisc:
         with pytest.raises(TypeError, match=msg):
             to_datetime([1, "1"], errors="raise", cache=cache)
 
+    @pytest.mark.parametrize("cache", [True, False])
+    def test_to_datetime_unhashable_input(self, cache):
+        series = Series([['a']]*100)
+        result = to_datetime(series, errors='ignore', cache=cache)
+        tm.assert_series_equal(series, result)
+
     def test_to_datetime_other_datetime64_units(self):
         # 5/25/2012
         scalar = np.int64(1337904000000000).view("M8[us]")


### PR DESCRIPTION
- [x] closes #39756
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
