### PR TITLE
PERF: make Styler default formatter arguments statics instead of repeated dynamic

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -367,7 +367,7 @@ Deprecations
 - Deprecated :meth:`core.window.ewm.ExponentialMovingWindow.vol` (:issue:`39220`)
 - Using ``.astype`` to convert between ``datetime64[ns]`` dtype and :class:`DatetimeTZDtype` is deprecated and will raise in a future version, use ``obj.tz_localize`` or ``obj.dt.tz_localize`` instead (:issue:`38622`)
 - Deprecated casting ``datetime.date`` objects to ``datetime64`` when used as ``fill_value`` in :meth:`DataFrame.unstack`, :meth:`DataFrame.shift`, :meth:`Series.shift`, and :meth:`DataFrame.reindex`, pass ``pd.Timestamp(dateobj)`` instead (:issue:`39767`)
-- Deprecated :meth:`.Styler.set_na_rep` and :meth:`.Styler.set_precision` in favour of :meth:`.Styler.format` with ``na_rep`` and ``precision`` as existing and new input arguments respectively (:issue:`40134`)
+- Deprecated :meth:`.Styler.set_na_rep` and :meth:`.Styler.set_precision` in favour of :meth:`.Styler.format` with ``na_rep`` and ``precision`` as existing and new input arguments respectively (:issue:`40134`, :issue:`40425`)
 - Deprecated allowing partial failure in :meth:`Series.transform` and :meth:`DataFrame.transform` when ``func`` is list-like or dict-like; will raise if any function fails on a column in a future version (:issue:`40211`)
 
 .. ---------------------------------------------------------------------------

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -198,7 +198,11 @@ class Styler:
         self.tooltips: Optional[_Tooltips] = None
         self._display_funcs: DefaultDict[  # maps (row, col) -> formatting function
             Tuple[int, int], Callable[[Any], str]
-        ] = defaultdict(lambda: partial(_default_formatter, precision=None))
+        ] = defaultdict(
+            lambda: partial(
+                _default_formatter, precision=get_option("display.precision")
+            )
+        )
         self.precision = precision  # can be removed on set_precision depr cycle
         self.na_rep = na_rep  # can be removed on set_na_rep depr cycle
         self.format(formatter=None, precision=precision, na_rep=na_rep)
@@ -2127,7 +2131,7 @@ def _get_level_lengths(index, hidden_elements=None):
     return non_zero_lengths
 
 
-def _default_formatter(x: Any, precision: Optional[int] = None) -> Any:
+def _default_formatter(x: Any, precision: int) -> Any:
     """
     Format the display of a value
 
@@ -2143,8 +2147,6 @@ def _default_formatter(x: Any, precision: Optional[int] = None) -> Any:
     value : Any
         Matches input type, or string if input is float or complex.
     """
-    if precision is None:
-        precision = get_option("display.precision")
     if isinstance(x, (float, complex)):
         return f"{x:.{precision}f}"
     return x
@@ -2165,6 +2167,7 @@ def _maybe_wrap_formatter(
     elif callable(formatter):
         formatter_func = formatter
     elif formatter is None:
+        precision = get_option("display.precision") if precision is None else precision
         formatter_func = partial(_default_formatter, precision=precision)
     else:
         raise TypeError(f"'formatter' expected str or callable, got {type(formatter)}")

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -2136,7 +2136,7 @@ def _default_formatter(x: Any, precision: int) -> Any:
     ----------
     x : Any
         Input variable to be formatted
-    precision : Int, optional
+    precision : Int
         Floating point precision used if ``x`` is float or complex.
 
     Returns

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -196,13 +196,10 @@ class Styler:
         self.cell_context: Dict[str, Any] = {}
         self._todo: List[Tuple[Callable, Tuple, Dict]] = []
         self.tooltips: Optional[_Tooltips] = None
+        def_precision = get_option("display.precision")
         self._display_funcs: DefaultDict[  # maps (row, col) -> formatting function
             Tuple[int, int], Callable[[Any], str]
-        ] = defaultdict(
-            lambda: partial(
-                _default_formatter, precision=get_option("display.precision")
-            )
-        )
+        ] = defaultdict(lambda: partial(_default_formatter, precision=def_precision))
         self.precision = precision  # can be removed on set_precision depr cycle
         self.na_rep = na_rep  # can be removed on set_na_rep depr cycle
         self.format(formatter=None, precision=precision, na_rep=na_rep)


### PR DESCRIPTION
This PR is a minor fix/improvement to a recent PR which deprecated `set_na_rep` and `set_precision`. #40134

For a dataframe with 100,000 floats the current Styler default formatter will make 100,000 `get_option` lookups for the pandas precision.

Doing this calculation once prevents all these lookups and saves just over 10% render time for larger tables.

```
rows                       THIS PR   
------ -------------------------
 cols       12          120     
====== ============ ============
  12    11.8±0.2ms   40.8±0.8ms 
  24    22.5±0.3ms    69.2±2ms  
  36    32.3±0.6ms    96.9±1ms  
====== ============ ============
```

```
rows                        MASTER         
------ -------------------------
 cols       12          120     
====== ============ ============
  12    12.9±0.4ms    43.4±1ms  
  24    22.3±0.1ms   75.2±0.7ms 
  36    32.3±0.3ms   105±0.5ms  
====== ============ ============
```

