### PR TITLE
ENH: `escape` html argument in Styler.format

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -135,6 +135,7 @@ Other enhancements
 - :meth:`.Styler.set_table_styles` amended to optionally allow certain css-string input arguments (:issue:`39564`)
 - :meth:`.Styler.apply` now more consistently accepts ndarray function returns, i.e. in all cases for ``axis`` is ``0, 1 or None`` (:issue:`39359`)
 - :meth:`.Styler.apply` and :meth:`.Styler.applymap` now raise errors if wrong format CSS is passed on render (:issue:`39660`)
+- :meth:`.Styler.format` adds keyword argument ``escape`` for optional HTML escaping (:issue:`40437`)
 - Builtin highlighting methods in :class:`Styler` have a more consistent signature and css customisability (:issue:`40242`)
 - :meth:`Series.loc.__getitem__` and :meth:`Series.loc.__setitem__` with :class:`MultiIndex` now raising helpful error message when indexer has too many dimensions (:issue:`35349`)
 - :meth:`pandas.read_stata` and :class:`StataReader` support reading data from compressed files.

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -2205,17 +2205,19 @@ def _maybe_wrap_formatter(
     else:
         raise TypeError(f"'formatter' expected str or callable, got {type(formatter)}")
 
-    def _str_escape(x):
-        """only use escape_func on str, else return input"""
-        return escape_func(x) if isinstance(x, str) else x
+    def _str_escape(x, escape: bool):
+        """if escaping: only use on str, else return input"""
+        if escape and isinstance(x, str):
+            return escape_func(x)
+        else:
+            return x
+
+    display_func = lambda x: formatter_func(partial(_str_escape, escape=escape)(x))
 
     if na_rep is None:
-        return (lambda x: formatter_func(_str_escape(x))) if escape else formatter_func
+        return display_func
     else:
-        if escape:
-            return lambda x: na_rep if pd.isna(x) else formatter_func(_str_escape(x))
-        else:
-            return lambda x: na_rep if pd.isna(x) else formatter_func(x)
+        return lambda x: na_rep if pd.isna(x) else display_func(x)
 
 
 def _maybe_convert_css_to_tuples(style: CSSProperties) -> CSSList:

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -2207,7 +2207,7 @@ def _maybe_wrap_formatter(
     else:
         na_func = lambda x: na_rep if pd.isna(x) else formatter_func(x)
 
-    return lambda x: na_func(escape_func(x)) if escape else na_func
+    return (lambda x: na_func(escape_func(x))) if escape else na_func
 
 
 def _maybe_convert_css_to_tuples(style: CSSProperties) -> CSSList:

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -652,6 +652,17 @@ class Styler:
                 0        1        2
         0    MISS   1.0000   STRING
         1     2.0     MISS    FLOAT
+
+        Using a formatter with HTML ``escape``.
+
+        >>> df = pd.DataFrame([['<div></div>', '"A&B"']])
+        >>> s = df.style.format('<a href="a.com/{0}">{0}</a>', escape=True)
+        >>> s.render()
+        ...
+        <td .. ><a href="a.com/&lt;div&gt;&lt;/div&gt;">&lt;div&gt;&lt;/div&gt;</a></td>
+        <td .. ><a href="a.com/&#34;A&amp;B&#34;">&#34;A&amp;B&#34;</a></td>
+        ...
+
         """
         if all(
             (

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -2205,11 +2205,15 @@ def _maybe_wrap_formatter(
     else:
         raise TypeError(f"'formatter' expected str or callable, got {type(formatter)}")
 
+    def _str_escape(x):
+        """only use escape_func on str, else return input"""
+        return escape_func(x) if isinstance(x, str) else x
+
     if na_rep is None:
-        return (lambda x: formatter_func(escape_func(x))) if escape else formatter_func
+        return (lambda x: formatter_func(_str_escape(x))) if escape else formatter_func
     else:
         if escape:
-            return lambda x: na_rep if pd.isna(x) else formatter_func(escape_func(x))
+            return lambda x: na_rep if pd.isna(x) else formatter_func(_str_escape(x))
         else:
             return lambda x: na_rep if pd.isna(x) else formatter_func(x)
 

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -118,6 +118,8 @@ class Styler:
         Replace the characters ``&``, ``<``, ``>``, ``'``, and ``"`` in cell display
         strings with HTML-safe sequences.
 
+        ... versionadded:: 1.3.0
+
     Attributes
     ----------
     env : Jinja2 jinja2.Environment

--- a/pandas/tests/io/formats/style/test_style.py
+++ b/pandas/tests/io/formats/style/test_style.py
@@ -647,6 +647,17 @@ class TestStyler:
         self.styler.format()
         assert (0, 0) not in self.styler._display_funcs  # formatter cleared to default
 
+    def test_format_escape(self):
+        df = DataFrame([['<>&"']])
+        s = Styler(df, uuid_len=0).format("X&{0}>X", escape=False)
+        ex = '<td id="T__row0_col0" class="data row0 col0" >X&<>&">X</td>'
+        assert ex in s.render()
+
+        # only the value should be escaped before passing to the formatter
+        s = Styler(df, uuid_len=0).format("X&{0}>X", escape=True)
+        ex = '<td id="T__row0_col0" class="data row0 col0" >X&&lt;&gt;&amp;&#34;>X</td>'
+        assert ex in s.render()
+
     def test_nonunique_raises(self):
         df = DataFrame([[1, 2]], columns=["A", "A"])
         msg = "style is not supported for non-unique indices."

--- a/pandas/tests/io/formats/style/test_style.py
+++ b/pandas/tests/io/formats/style/test_style.py
@@ -650,13 +650,22 @@ class TestStyler:
     def test_format_escape(self):
         df = DataFrame([['<>&"']])
         s = Styler(df, uuid_len=0).format("X&{0}>X", escape=False)
-        ex = '<td id="T__row0_col0" class="data row0 col0" >X&<>&">X</td>'
-        assert ex in s.render()
+        expected = '<td id="T__row0_col0" class="data row0 col0" >X&<>&">X</td>'
+        assert expected in s.render()
 
         # only the value should be escaped before passing to the formatter
         s = Styler(df, uuid_len=0).format("X&{0}>X", escape=True)
         ex = '<td id="T__row0_col0" class="data row0 col0" >X&&lt;&gt;&amp;&#34;>X</td>'
         assert ex in s.render()
+
+    def test_format_escape_na_rep(self):
+        # tests the na_rep is not escaped
+        df = DataFrame([['<>&"', None]])
+        s = Styler(df, uuid_len=0).format("X&{0}>X", escape=True, na_rep="&")
+        ex = '<td id="T__row0_col0" class="data row0 col0" >X&&lt;&gt;&amp;&#34;>X</td>'
+        expected2 = '<td id="T__row0_col1" class="data row0 col1" >&</td>'
+        assert ex in s.render()
+        assert expected2 in s.render()
 
     def test_nonunique_raises(self):
         df = DataFrame([[1, 2]], columns=["A", "A"])

--- a/pandas/tests/io/formats/style/test_style.py
+++ b/pandas/tests/io/formats/style/test_style.py
@@ -667,6 +667,16 @@ class TestStyler:
         assert ex in s.render()
         assert expected2 in s.render()
 
+    def test_format_escape_floats(self):
+        # test given formatter for number format is not impacted by escape
+        s = self.df.style.format("{:.1f}", escape=True)
+        for expected in [">0.0<", ">1.0<", ">-1.2<", ">-0.6<"]:
+            assert expected in s.render()
+        # tests precision of floats is not impacted by escape
+        s = self.df.style.format(precision=1, escape=True)
+        for expected in [">0<", ">1<", ">-1.2<", ">-0.6<"]:
+            assert expected in s.render()
+
     def test_nonunique_raises(self):
         df = DataFrame([[1, 2]], columns=["A", "A"])
         msg = "style is not supported for non-unique indices."


### PR DESCRIPTION
- [x] closes #40388 

Adds an HTML `escape` parameter to `Styler.format`, which acts to escape the data value **before** it is passed to a formatter.

For example, `Styler.format('<a href="a.com/{0}">{0}</a>', escape=True)` will not escape the HTML as part of the formatting function, it will only escape the value `{0}` going into the formatter.