### PR TITLE
PERF: optimize is_numeric_v_string_like

### DIFF
--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1303,37 +1303,6 @@ def is_numeric_dtype(arr_or_dtype) -> bool:
     )
 
 
-def is_string_like_dtype(arr_or_dtype) -> bool:
-    """
-    Check whether the provided array or dtype is of a string-like dtype.
-
-    Unlike `is_string_dtype`, the object dtype is excluded because it
-    is a mixed dtype.
-
-    Parameters
-    ----------
-    arr_or_dtype : array-like
-        The array or dtype to check.
-
-    Returns
-    -------
-    boolean
-        Whether or not the array or dtype is of the string dtype.
-
-    Examples
-    --------
-    >>> is_string_like_dtype(str)
-    True
-    >>> is_string_like_dtype(object)
-    False
-    >>> is_string_like_dtype(np.array(['a', 'b']))
-    True
-    >>> is_string_like_dtype(pd.Series([1, 2]))
-    False
-    """
-    return _is_dtype(arr_or_dtype, lambda dtype: dtype.kind in ("S", "U"))
-
-
 def is_float_dtype(arr_or_dtype) -> bool:
     """
     Check whether the provided array or dtype is of a float dtype.

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1100,7 +1100,7 @@ def is_datetime_or_timedelta_dtype(arr_or_dtype) -> bool:
 
 
 # This exists to silence numpy deprecation warnings, see GH#29553
-def is_numeric_v_string_like(a, b):
+def is_numeric_v_string_like(a: ArrayLike, b):
     """
     Check if we are comparing a string-like object to a numeric ndarray.
     NumPy doesn't like to compare such objects, especially numeric arrays
@@ -1108,7 +1108,7 @@ def is_numeric_v_string_like(a, b):
 
     Parameters
     ----------
-    a : array-like, scalar
+    a : array-like
         The first object to check.
     b : array-like, scalar
         The second object to check.
@@ -1142,17 +1142,15 @@ def is_numeric_v_string_like(a, b):
     is_a_array = isinstance(a, np.ndarray)
     is_b_array = isinstance(b, np.ndarray)
 
-    is_a_numeric_array = is_a_array and is_numeric_dtype(a)
-    is_b_numeric_array = is_b_array and is_numeric_dtype(b)
-    is_a_string_array = is_a_array and is_string_like_dtype(a)
-    is_b_string_array = is_b_array and is_string_like_dtype(b)
+    is_a_numeric_array = is_a_array and a.dtype.kind in ("u", "i", "f", "c", "b")
+    is_b_numeric_array = is_b_array and b.dtype.kind in ("u", "i", "f", "c", "b")
+    is_a_string_array = is_a_array and a.dtype.kind in ("S", "U")
+    is_b_string_array = is_b_array and b.dtype.kind in ("S", "U")
 
-    is_a_scalar_string_like = not is_a_array and isinstance(a, str)
     is_b_scalar_string_like = not is_b_array and isinstance(b, str)
 
     return (
         (is_a_numeric_array and is_b_scalar_string_like)
-        or (is_b_numeric_array and is_a_scalar_string_like)
         or (is_a_numeric_array and is_b_string_array)
         or (is_b_numeric_array and is_a_string_array)
     )

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1120,15 +1120,7 @@ def is_numeric_v_string_like(a: ArrayLike, b):
 
     Examples
     --------
-    >>> is_numeric_v_string_like(1, 1)
-    False
-    >>> is_numeric_v_string_like("foo", "foo")
-    False
-    >>> is_numeric_v_string_like(1, "foo")  # non-array numeric
-    False
     >>> is_numeric_v_string_like(np.array([1]), "foo")
-    True
-    >>> is_numeric_v_string_like("foo", np.array([1]))  # symmetric check
     True
     >>> is_numeric_v_string_like(np.array([1, 2]), np.array(["foo"]))
     True

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -35,7 +35,6 @@ from pandas.core.dtypes.common import (
     is_object_dtype,
     is_scalar,
     is_string_dtype,
-    is_string_like_dtype,
     needs_i8_conversion,
 )
 from pandas.core.dtypes.dtypes import ExtensionDtype
@@ -258,7 +257,7 @@ def _isna_string_dtype(values: np.ndarray, inf_as_na: bool) -> np.ndarray:
     dtype = values.dtype
     shape = values.shape
 
-    if is_string_like_dtype(dtype):
+    if dtype.kind in ("S", "U"):
         result = np.zeros(values.shape, dtype=bool)
     else:
         result = np.empty(shape, dtype=bool)

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -469,14 +469,11 @@ def test_is_datetime_or_timedelta_dtype():
 
 
 def test_is_numeric_v_string_like():
-    assert not com.is_numeric_v_string_like(1, 1)
-    assert not com.is_numeric_v_string_like(1, "foo")
-    assert not com.is_numeric_v_string_like("foo", "foo")
+    assert not com.is_numeric_v_string_like(np.array([1]), 1)
     assert not com.is_numeric_v_string_like(np.array([1]), np.array([2]))
     assert not com.is_numeric_v_string_like(np.array(["foo"]), np.array(["foo"]))
 
     assert com.is_numeric_v_string_like(np.array([1]), "foo")
-    assert com.is_numeric_v_string_like("foo", np.array([1]))
     assert com.is_numeric_v_string_like(np.array([1, 2]), np.array(["foo"]))
     assert com.is_numeric_v_string_like(np.array(["foo"]), np.array([1, 2]))
 

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -518,14 +518,6 @@ def test_is_numeric_dtype():
     assert com.is_numeric_dtype(pd.Index([1, 2.0]))
 
 
-def test_is_string_like_dtype():
-    assert not com.is_string_like_dtype(object)
-    assert not com.is_string_like_dtype(pd.Series([1, 2]))
-
-    assert com.is_string_like_dtype(str)
-    assert com.is_string_like_dtype(np.array(["a", "b"]))
-
-
 def test_is_float_dtype():
     assert not com.is_float_dtype(str)
     assert not com.is_float_dtype(int)


### PR DESCRIPTION
In some of the arithmetic benchmarks (xref https://github.com/pandas-dev/pandas/issues/39146#issuecomment-799482699), just this `is_numeric_v_string_like` check takes up 15-35% of the overall time. 

This improves the performance of this check by using some ndarray-specialized dtype checks (checking the kind instead of the generic functions):

```
In [1]: from pandas.core.dtypes.common import is_numeric_v_string_like

In [2]: arr = np.array([1, 2, 3])

In [3]: %timeit is_numeric_v_string_like(arr, 2.0)
2.3 µs ± 46.9 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <-- master
482 ns ± 41.8 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  # <-- PR
```