### PR TITLE
PERF: increase the minimum number of elements to use numexpr for ops from 1e4 to 1e6

### DIFF
--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -40,7 +40,7 @@ _ALLOWED_DTYPES = {
 }
 
 # the minimum prod shape that we will use numexpr
-_MIN_ELEMENTS = 100000
+_MIN_ELEMENTS = 1000000
 
 
 def set_use_numexpr(v=True):

--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -40,7 +40,7 @@ _ALLOWED_DTYPES = {
 }
 
 # the minimum prod shape that we will use numexpr
-_MIN_ELEMENTS = 10000
+_MIN_ELEMENTS = 100000
 
 
 def set_use_numexpr(v=True):

--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -40,7 +40,7 @@ _ALLOWED_DTYPES = {
 }
 
 # the minimum prod shape that we will use numexpr
-_MIN_ELEMENTS = 1000000
+_MIN_ELEMENTS = 1_000_000
 
 
 def set_use_numexpr(v=True):

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -12,7 +12,7 @@ from pandas.core.api import (
 )
 from pandas.core.computation import expressions as expr
 
-_frame = DataFrame(np.random.randn(10000, 4), columns=list("ABCD"), dtype="float64")
+_frame = DataFrame(np.random.randn(1000000, 4), columns=list("ABCD"), dtype="float64")
 _frame2 = DataFrame(np.random.randn(100, 4), columns=list("ABCD"), dtype="float64")
 _mixed = DataFrame(
     {


### PR DESCRIPTION
See https://github.com/pandas-dev/pandas/issues/40500 for the analysis.