### PR TITLE
CLN/PERF: remove catching of numpy deprecation warning in comparison_op

### DIFF
--- a/pandas/core/ops/array_ops.py
+++ b/pandas/core/ops/array_ops.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 from functools import partial
 import operator
 from typing import Any
-import warnings
 
 import numpy as np
 
@@ -267,10 +266,7 @@ def comparison_op(left: ArrayLike, right: Any, op) -> ArrayLike:
         res_values = comp_method_OBJECT_ARRAY(op, lvalues, rvalues)
 
     else:
-        with warnings.catch_warnings():
-            # suppress warnings from numpy about element-wise comparison
-            warnings.simplefilter("ignore", DeprecationWarning)
-            res_values = _na_arithmetic_op(lvalues, rvalues, op, is_cmp=True)
+        res_values = _na_arithmetic_op(lvalues, rvalues, op, is_cmp=True)
 
     return res_values
 

--- a/pandas/core/ops/array_ops.py
+++ b/pandas/core/ops/array_ops.py
@@ -231,7 +231,7 @@ def comparison_op(left: ArrayLike, right: Any, op) -> ArrayLike:
     """
     # NB: We assume extract_array has already been called on left and right
     lvalues = ensure_wrapped_if_datetimelike(left)
-    rvalues = right
+    rvalues = ensure_wrapped_if_datetimelike(right)
 
     rvalues = lib.item_from_zerodim(rvalues)
     if isinstance(rvalues, list):


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/39146

In some of the `FrameWithFrameWide` benchmarks, this takes up around 15% of the time. 

While I don't think this should be needed (but let's see if warnings appear in the CI builds).