### PR TITLE
DOC fix misspelling of countries

### DIFF
--- a/pandas/io/json/_normalize.py
+++ b/pandas/io/json/_normalize.py
@@ -327,15 +327,15 @@ def _json_normalize(
     >>> data = [{'state': 'Florida',
     ...          'shortname': 'FL',
     ...          'info': {'governor': 'Rick Scott'},
-    ...          'counties': [{'name': 'Dade', 'population': 12345},
+    ...          'countries': [{'name': 'Dade', 'population': 12345},
     ...                       {'name': 'Broward', 'population': 40000},
     ...                       {'name': 'Palm Beach', 'population': 60000}]},
     ...         {'state': 'Ohio',
     ...          'shortname': 'OH',
     ...          'info': {'governor': 'John Kasich'},
-    ...          'counties': [{'name': 'Summit', 'population': 1234},
+    ...          'countries': [{'name': 'Summit', 'population': 1234},
     ...                       {'name': 'Cuyahoga', 'population': 1337}]}]
-    >>> result = pd.json_normalize(data, 'counties', ['state', 'shortname',
+    >>> result = pd.json_normalize(data, 'countries', ['state', 'shortname',
     ...                                            ['info', 'governor']])
     >>> result
              name  population    state shortname info.governor


### PR DESCRIPTION
simple misspelling fix. From "counties" to "countries"
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
