### PR TITLE
DOC/MAINT: Clean up docs build warnings

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -305,7 +305,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
     Notes
     -----
     See the `user guide
-    <https://pandas.pydata.org/pandas-docs/stable/user_guide/categorical.html>`_
+    <https://pandas.pydata.org/pandas-docs/stable/user_guide/categorical.html>`__
     for more.
 
     Examples

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -154,7 +154,7 @@ qcut : Bin values into equal-sized Intervals based on rank or sample quantiles.
 Notes
 -----
 See the `user guide
-<https://pandas.pydata.org/pandas-docs/stable/user_guide/advanced.html#intervalindex>`_
+<https://pandas.pydata.org/pandas-docs/stable/user_guide/advanced.html#intervalindex>`__
 for more.
 
 %(examples)s\

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7958,7 +7958,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         Notes
         -----
         See the `user guide
-        <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#resampling>`_
+        <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#resampling>`__
         for more.
 
         To learn more about the offset strings, please see `this link

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -150,7 +150,7 @@ class CategoricalIndex(NDArrayBackedExtensionIndex, accessor.PandasDelegate):
     Notes
     -----
     See the `user guide
-    <https://pandas.pydata.org/pandas-docs/stable/user_guide/advanced.html#categoricalindex>`_
+    <https://pandas.pydata.org/pandas-docs/stable/user_guide/advanced.html#categoricalindex>`__
     for more.
 
     Examples

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -267,7 +267,7 @@ class MultiIndex(Index):
     Notes
     -----
     See the `user guide
-    <https://pandas.pydata.org/pandas-docs/stable/user_guide/advanced.html>`_
+    <https://pandas.pydata.org/pandas-docs/stable/user_guide/advanced.html>`__
     for more.
 
     Examples

--- a/pandas/core/shared_docs.py
+++ b/pandas/core/shared_docs.py
@@ -143,7 +143,7 @@ resample : Convenience method for frequency conversion and resampling
 Notes
 -----
 See the `user guide
-<https://pandas.pydata.org/pandas-docs/stable/groupby.html>`_ for more.
+<https://pandas.pydata.org/pandas-docs/stable/groupby.html>`__ for more.
 """
 
 _shared_docs[


### PR DESCRIPTION
For example: `Duplicate explicit target name: "user guide"`

I was seeing these warnings in the dask docs build because dask pulls docstrings from pandas. I think using anonomous links like this should fix it based on https://github.com/sphinx-doc/sphinx/issues/3921
