### PR TITLE
BUG: to_json failing on PyPy

### DIFF
--- a/doc/source/whatsnew/v1.2.4.rst
+++ b/doc/source/whatsnew/v1.2.4.rst
@@ -16,7 +16,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 
 - Fixed regression in :meth:`DataFrame.sum` when ``min_count`` greater than the :class:`DataFrame` shape was passed resulted in a ``ValueError`` (:issue:`39738`)
-- Fixed regression in :func:`pandas.to_json` raising ``AttributeError`` when run on PyPy (:issue:`39837`)
+- Fixed regression in :meth:`DataFrame.to_json` raising ``AttributeError`` when run on PyPy (:issue:`39837`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.2.4.rst
+++ b/doc/source/whatsnew/v1.2.4.rst
@@ -16,6 +16,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 
 - Fixed regression in :meth:`DataFrame.sum` when ``min_count`` greater than the :class:`DataFrame` shape was passed resulted in a ``ValueError`` (:issue:`39738`)
+- Fixed regression in :func:`pandas.to_json` raising ``AttributeError`` when run on PyPy (:issue:`39837`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -272,18 +272,6 @@ static PyObject *get_sub_attr(PyObject *obj, char *attr, char *subAttr) {
     return ret;
 }
 
-static int is_simple_frame(PyObject *obj) {
-    PyObject *check = get_sub_attr(obj, "_mgr", "is_mixed_type");
-    int ret = (check == Py_False);
-
-    if (!check) {
-        return 0;
-    }
-
-    Py_DECREF(check);
-    return ret;
-}
-
 static Py_ssize_t get_attr_length(PyObject *obj, char *attr) {
     PyObject *tmp = PyObject_GetAttrString(obj, attr);
     Py_ssize_t ret;
@@ -298,6 +286,17 @@ static Py_ssize_t get_attr_length(PyObject *obj, char *attr) {
         return 0;
     }
 
+    return ret;
+}
+
+static int is_simple_frame(PyObject *obj) {
+    PyObject *mgr = PyObject_GetAttrString(obj, "_mgr");
+    if (!mgr) {
+        return 0;
+    }
+    int ret = (get_attr_length(mgr, "blocks") <= 1);
+
+    Py_DECREF(mgr);
     return ret;
 }
 

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -144,6 +144,7 @@ typedef struct __PyObjectEncoder {
 enum PANDAS_FORMAT { SPLIT, RECORDS, INDEX, COLUMNS, VALUES };
 
 int PdBlock_iterNext(JSOBJ, JSONTypeContext *);
+static Py_ssize_t get_attr_length(PyObject *obj, char *attr);
 
 void *initObjToJSON(void) {
     PyObject *mod_pandas;
@@ -272,6 +273,17 @@ static PyObject *get_sub_attr(PyObject *obj, char *attr, char *subAttr) {
     return ret;
 }
 
+static int is_simple_frame(PyObject *obj) {
+    PyObject *mgr = PyObject_GetAttrString(obj, "_mgr");
+    if (!mgr) {
+        return 0;
+    }
+    int ret = (get_attr_length(mgr, "blocks") <= 1);
+
+    Py_DECREF(mgr);
+    return ret;
+}
+
 static Py_ssize_t get_attr_length(PyObject *obj, char *attr) {
     PyObject *tmp = PyObject_GetAttrString(obj, attr);
     Py_ssize_t ret;
@@ -286,17 +298,6 @@ static Py_ssize_t get_attr_length(PyObject *obj, char *attr) {
         return 0;
     }
 
-    return ret;
-}
-
-static int is_simple_frame(PyObject *obj) {
-    PyObject *mgr = PyObject_GetAttrString(obj, "_mgr");
-    if (!mgr) {
-        return 0;
-    }
-    int ret = (get_attr_length(mgr, "blocks") <= 1);
-
-    Py_DECREF(mgr);
     return ret;
 }
 

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -144,7 +144,6 @@ typedef struct __PyObjectEncoder {
 enum PANDAS_FORMAT { SPLIT, RECORDS, INDEX, COLUMNS, VALUES };
 
 int PdBlock_iterNext(JSOBJ, JSONTypeContext *);
-static Py_ssize_t get_attr_length(PyObject *obj, char *attr);
 
 void *initObjToJSON(void) {
     PyObject *mod_pandas;
@@ -273,17 +272,6 @@ static PyObject *get_sub_attr(PyObject *obj, char *attr, char *subAttr) {
     return ret;
 }
 
-static int is_simple_frame(PyObject *obj) {
-    PyObject *mgr = PyObject_GetAttrString(obj, "_mgr");
-    if (!mgr) {
-        return 0;
-    }
-    int ret = (get_attr_length(mgr, "blocks") <= 1);
-
-    Py_DECREF(mgr);
-    return ret;
-}
-
 static Py_ssize_t get_attr_length(PyObject *obj, char *attr) {
     PyObject *tmp = PyObject_GetAttrString(obj, attr);
     Py_ssize_t ret;
@@ -298,6 +286,17 @@ static Py_ssize_t get_attr_length(PyObject *obj, char *attr) {
         return 0;
     }
 
+    return ret;
+}
+
+static int is_simple_frame(PyObject *obj) {
+    PyObject *mgr = PyObject_GetAttrString(obj, "_mgr");
+    if (!mgr) {
+        return 0;
+    }
+    int ret = (get_attr_length(mgr, "blocks") <= 1);
+
+    Py_DECREF(mgr);
     return ret;
 }
 

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1744,6 +1744,22 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         result = DataFrame([[nulls_fixture]]).to_json()
         assert result == '{"0":{"0":null}}'
 
+    @pytest.mark.parametrize(
+        "data,expected",
+        [
+            ([pd.NA, pd.NA, pd.NA], '[{"0":null},{"0":null},{"0":null}]'),
+            ([1, pd.NA, 1], '[{"0":1},{"0":null},{"0":1}]'),
+        ],
+    )
+    def test_to_json_numeric_extension_backed(
+        self, any_nullable_numeric_dtype, data, expected
+    ):
+        dtype = any_nullable_numeric_dtype
+        result = DataFrame(data, dtype=dtype).to_json(orient="records")
+        if "Float" in dtype:
+            expected = expected.replace("1", "1.0")
+        assert result == expected
+
     def test_readjson_bool_series(self):
         # GH31464
         result = read_json("[true, true, false]", typ="series")

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1744,22 +1744,6 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         result = DataFrame([[nulls_fixture]]).to_json()
         assert result == '{"0":{"0":null}}'
 
-    @pytest.mark.parametrize(
-        "data,expected",
-        [
-            ([pd.NA, pd.NA, pd.NA], '[{"0":null},{"0":null},{"0":null}]'),
-            ([1, pd.NA, 1], '[{"0":1},{"0":null},{"0":1}]'),
-        ],
-    )
-    def test_to_json_numeric_extension_backed(
-        self, any_nullable_numeric_dtype, data, expected
-    ):
-        dtype = any_nullable_numeric_dtype
-        result = DataFrame(data, dtype=dtype).to_json(orient="records")
-        if "Float" in dtype:
-            expected = expected.replace("1", "1.0")
-        assert result == expected
-
     def test_readjson_bool_series(self):
         # GH31464
         result = read_json("[true, true, false]", typ="series")


### PR DESCRIPTION
- [x] closes #39837
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

Not sure how best to test this - confirmed this now works when run on PyPy, but since we don't test against PyPy the examples in the issue (or any other simple case) which fail on PyPy will still pass on master. 

Benchmarks look similar, might be minor performance improvement for the single block case:

```
before           after         ratio
     [b524462e]       [b1f4bcc8]
     <master>         <bug/is_mixed_type>
          194±5ms          190±2ms     0.98  io.json.ToJSONISO.time_iso_format('columns')
          208±5ms          198±6ms     0.95  io.json.ToJSONISO.time_iso_format('index')
          186±4ms          173±3ms     0.93  io.json.ToJSONISO.time_iso_format('records')
         193±10ms          187±3ms     0.97  io.json.ToJSONISO.time_iso_format('split')
          164±4ms          165±3ms     1.00  io.json.ToJSONISO.time_iso_format('values')
          115±4ms          114±3ms     0.99  io.json.ToJSONLines.time_delta_int_tstamp_lines
          142±4ms          132±6ms     0.93  io.json.ToJSONLines.time_float_int_lines
          140±4ms          142±4ms     1.02  io.json.ToJSONLines.time_float_int_str_lines
          152±2ms          153±3ms     1.01  io.json.ToJSONLines.time_float_longint_str_lines
          110±3ms          107±3ms     0.97  io.json.ToJSONLines.time_floats_with_dt_index_lines
          112±3ms          104±3ms     0.93  io.json.ToJSONLines.time_floats_with_int_idex_lines
          54.3M            55M         1.01  io.json.ToJSONMem.peakmem_float
          55.4M               55.2M    1.00  io.json.ToJSONMem.peakmem_int
          88.6±2ms         78.8±2ms    0.89  io.json.ToJSON.time_to_json('index', 'df')
          70.7±2ms         61.7±2ms    0.87  io.json.ToJSON.time_to_json('values', 'df')
          94.9±3ms         81.4±1ms    0.86  io.json.ToJSON.time_to_json('index', 'df_date_idx')
          76.3±0.9ms       65.1±1ms    0.85  io.json.ToJSON.time_to_json('records', 'df_date_idx')
```