### PR TITLE
CLN: Optional[Hashable] in dict type hints

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -231,7 +231,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
     _metadata: List[str] = []
     _is_copy: Optional[weakref.ReferenceType[NDFrame]] = None
     _mgr: Manager
-    _attrs: Dict[Optional[Hashable], Any]
+    _attrs: Dict[Hashable, Any]
     _typ: str
 
     # ----------------------------------------------------------------------
@@ -241,7 +241,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         self,
         data: Manager,
         copy: bool = False,
-        attrs: Optional[Mapping[Optional[Hashable], Any]] = None,
+        attrs: Optional[Mapping[Hashable, Any]] = None,
     ):
         # copy kwarg is retained for mypy compat, is not used
 
@@ -320,7 +320,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
     # attrs and flags
 
     @property
-    def attrs(self) -> Dict[Optional[Hashable], Any]:
+    def attrs(self) -> Dict[Hashable, Any]:
         """
         Dictionary of global attributes of this dataset.
 
@@ -337,7 +337,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         return self._attrs
 
     @attrs.setter
-    def attrs(self, value: Mapping[Optional[Hashable], Any]) -> None:
+    def attrs(self, value: Mapping[Hashable, Any]) -> None:
         self._attrs = dict(value)
 
     @final
@@ -803,7 +803,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
             # error: Argument 2 to "NDFrame" has incompatible type "*Generator[Index,
             # None, None]"; expected "bool" [arg-type]
             # error: Argument 2 to "NDFrame" has incompatible type "*Generator[Index,
-            # None, None]"; expected "Optional[Mapping[Optional[Hashable], Any]]"
+            # None, None]"; expected "Optional[Mapping[Hashable, Any]]"
             new_values,  # type: ignore[arg-type]
             *new_axes,  # type: ignore[arg-type]
         ).__finalize__(self, method="swapaxes")
@@ -11180,7 +11180,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
     @final
     @doc(first_valid_index, position="last", klass=_shared_doc_kwargs["klass"])
-    def last_valid_index(self):
+    def last_valid_index(self) -> Optional[Scalar]:
         return self._find_valid_index("last")
 
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11180,7 +11180,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
     @final
     @doc(first_valid_index, position="last", klass=_shared_doc_kwargs["klass"])
-    def last_valid_index(self) -> Optional[Scalar]:
+    def last_valid_index(self):
         return self._find_valid_index("last")
 
 

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -572,7 +572,7 @@ def read_json(
     if dtype is None and orient != "table":
         # error: Incompatible types in assignment (expression has type "bool", variable
         # has type "Union[ExtensionDtype, str, dtype[Any], Type[str], Type[float],
-        # Type[int], Type[complex], Type[bool], Type[object], Dict[Optional[Hashable],
+        # Type[int], Type[complex], Type[bool], Type[object], Dict[Hashable,
         # Union[ExtensionDtype, Union[str, dtype[Any]], Type[str], Type[float],
         # Type[int], Type[complex], Type[bool], Type[object]]], None]")
         dtype = True  # type: ignore[assignment]
@@ -921,7 +921,7 @@ class Parser:
 
             # error: Non-overlapping identity check (left operand type:
             # "Union[ExtensionDtype, str, dtype[Any], Type[object],
-            # Dict[Optional[Hashable], Union[ExtensionDtype, Union[str, dtype[Any]],
+            # Dict[Hashable, Union[ExtensionDtype, Union[str, dtype[Any]],
             # Type[str], Type[float], Type[int], Type[complex], Type[bool],
             # Type[object]]]]", right operand type: "Literal[True]")
             elif self.dtype is True:  # type: ignore[comparison-overlap]

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1563,7 +1563,7 @@ class SQLDatabase(PandasSQL):
             if not is_dict_like(dtype):
                 # error: Value expression in dictionary comprehension has incompatible
                 # type "Union[ExtensionDtype, str, dtype[Any], Type[object],
-                # Dict[Optional[Hashable], Union[ExtensionDtype, Union[str, dtype[Any]],
+                # Dict[Hashable, Union[ExtensionDtype, Union[str, dtype[Any]],
                 # Type[str], Type[float], Type[int], Type[complex], Type[bool],
                 # Type[object]]]]"; expected type "Union[ExtensionDtype, str,
                 # dtype[Any], Type[object]]"
@@ -2060,7 +2060,7 @@ class SQLiteDatabase(PandasSQL):
             if not is_dict_like(dtype):
                 # error: Value expression in dictionary comprehension has incompatible
                 # type "Union[ExtensionDtype, str, dtype[Any], Type[object],
-                # Dict[Optional[Hashable], Union[ExtensionDtype, Union[str, dtype[Any]],
+                # Dict[Hashable, Union[ExtensionDtype, Union[str, dtype[Any]],
                 # Type[str], Type[float], Type[int], Type[complex], Type[bool],
                 # Type[object]]]]"; expected type "Union[ExtensionDtype, str,
                 # dtype[Any], Type[object]]"

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -609,8 +609,8 @@ class MPLPlot:
                         self.legend_handles
                     )
                     # error: Incompatible types in assignment (expression has type
-                    # "Iterator[Optional[Hashable]]", variable has type
-                    # "List[Optional[Hashable]]")
+                    # "Iterator[Hashable]", variable has type
+                    # "List[Hashable]")
                     self.legend_labels = reversed(  # type: ignore[assignment]
                         self.legend_labels
                     )


### PR DESCRIPTION
Minor clean-up.

```python
>>> from typing import Hashable
>>> isinstance(None, Hashable)
True
```

In old versions of mypy, mypy had a bug and didn't see this, but is has been fixed now.

There are many instances of `Optional[Hashable]` instead of just `Hashable` in the code base, other than in these dicts. I've assumed those should be left as-is for readability and not because it's strictly needed.
