### PR TITLE
TYP: make EA registry private

### DIFF
--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -33,7 +33,7 @@ from pandas._typing import (
 
 from pandas.core.dtypes.base import (
     ExtensionDtype,
-    registry,
+    _registry as registry,
 )
 from pandas.core.dtypes.cast import (
     construct_1d_arraylike_from_scalar,

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -388,7 +388,7 @@ def register_extension_dtype(cls: Type[ExtensionDtype]) -> Type[ExtensionDtype]:
     ... class MyExtensionDtype(ExtensionDtype):
     ...     name = "myextension"
     """
-    registry.register(cls)
+    _registry.register(cls)
     return cls
 
 
@@ -452,4 +452,4 @@ class Registry:
         return None
 
 
-registry = Registry()
+_registry = Registry()

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -23,7 +23,7 @@ from pandas._typing import (
     Optional,
 )
 
-from pandas.core.dtypes.base import registry
+from pandas.core.dtypes.base import _registry as registry
 from pandas.core.dtypes.dtypes import (
     CategoricalDtype,
     DatetimeTZDtype,

--- a/pandas/tests/arrays/test_array.py
+++ b/pandas/tests/arrays/test_array.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 import pytz
 
-from pandas.core.dtypes.base import registry
+from pandas.core.dtypes.base import _registry as registry
 
 import pandas as pd
 import pandas._testing as tm

--- a/pandas/tests/arrays/test_period.py
+++ b/pandas/tests/arrays/test_period.py
@@ -4,7 +4,7 @@ import pytest
 from pandas._libs.tslibs import iNaT
 from pandas._libs.tslibs.period import IncompatibleFrequency
 
-from pandas.core.dtypes.base import registry
+from pandas.core.dtypes.base import _registry as registry
 from pandas.core.dtypes.dtypes import PeriodDtype
 
 import pandas as pd

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 import pytz
 
-from pandas.core.dtypes.base import registry
+from pandas.core.dtypes.base import _registry as registry
 from pandas.core.dtypes.common import (
     is_bool_dtype,
     is_categorical,

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -5,7 +5,7 @@ import pytest
 
 import pandas.util._test_decorators as td
 
-from pandas.core.dtypes.base import registry as ea_registry
+from pandas.core.dtypes.base import _registry as ea_registry
 from pandas.core.dtypes.common import (
     is_categorical_dtype,
     is_interval_dtype,


### PR DESCRIPTION
From #39501 splitting out the part to make the EA `registry` private.  This will make it so that `pyright --verifytypes` accepts pandas public API.


