### PR TITLE
TYP: make typing DatetimeLikeScalar a Union instead of TypeVar

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -80,7 +80,7 @@ AnyArrayLike = Union[ArrayLike, "Index", "Series"]
 # scalars
 
 PythonScalar = Union[str, int, float, bool]
-DatetimeLikeScalar = TypeVar("DatetimeLikeScalar", "Period", "Timestamp", "Timedelta")
+DatetimeLikeScalar = Union["Period", "Timestamp", "Timedelta"]
 PandasScalar = Union["Period", "Timestamp", "Timedelta", "Interval"]
 Scalar = Union[PythonScalar, PandasScalar]
 

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -563,8 +563,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
                 raise InvalidComparison(other)
 
         if isinstance(other, self._recognized_scalars) or other is NaT:
-            # error: Too many arguments for "object"
-            other = self._scalar_type(other)  # type: ignore[call-arg]
+            other = self._scalar_type(other)
             try:
                 self._check_compatible_with(other)
             except (TypeError, IncompatibleFrequency) as err:
@@ -614,16 +613,14 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         if is_valid_na_for_dtype(fill_value, self.dtype):
             fill_value = NaT
         elif isinstance(fill_value, self._recognized_scalars):
-            # error: Too many arguments for "object"
-            fill_value = self._scalar_type(fill_value)  # type: ignore[call-arg]
+            fill_value = self._scalar_type(fill_value)
         else:
             # only warn if we're not going to raise
             if self._scalar_type is Period and lib.is_integer(fill_value):
                 # kludge for #31971 since Period(integer) tries to cast to str
                 new_fill = Period._from_ordinal(fill_value, freq=self.freq)
             else:
-                # error: Too many arguments for "object"
-                new_fill = self._scalar_type(fill_value)  # type: ignore[call-arg]
+                new_fill = self._scalar_type(fill_value)
 
             # stacklevel here is chosen to be correct when called from
             #  DataFrame.shift or Series.shift
@@ -684,8 +681,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
             raise TypeError(msg)
 
         elif isinstance(value, self._recognized_scalars):
-            # error: Too many arguments for "object"
-            value = self._scalar_type(value)  # type: ignore[call-arg]
+            value = self._scalar_type(value)
 
         else:
             msg = self._validation_error_message(value, allow_listlike)


### PR DESCRIPTION
In `_typing.py` change `DatetimeLikeScalar` from `TypeVar` to `Union`

Allows removal of 4 `#type: ignore` lines

Per split out from #39501 