### PR TITLE
CLN: rank_1d

### DIFF
--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -946,7 +946,7 @@ def rank_1d(
     cdef:
         TiebreakEnumType tiebreak
         Py_ssize_t i, j, N, grp_start=0, dups=0, sum_ranks=0
-        Py_ssize_t grp_vals_seen=1, grp_na_count=0, grp_tie_count=0
+        Py_ssize_t grp_vals_seen=1, grp_na_count=0
         ndarray[int64_t, ndim=1] lexsort_indexer
         ndarray[float64_t, ndim=1] grp_sizes, out
         ndarray[rank_t, ndim=1] masked_vals

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -988,9 +988,12 @@ def rank_1d(
     else:
         mask = np.zeros(shape=len(masked_vals), dtype=np.uint8)
 
-    # If ascending and na_option == 'bottom' or descending and
-    # na_option == 'top' -> we want to rank NaN as the highest
-    # so fill with the maximum value for the type
+    # If `na_option == 'top'`, we want to assign the lowest rank
+    # to NaN regardless of ascending/descending. So if ascending,
+    # fill with lowest value of type to end up with lowest rank.
+    # If descending, fill with highest value since descending
+    # will flip the ordering to still end up with lowest rank.
+    # Symmetric logic applies to `na_option == 'bottom'`
     if ascending ^ (na_option == 'top'):
         if rank_t is object:
             nan_fill_val = Infinity()
@@ -1001,8 +1004,6 @@ def rank_1d(
         else:
             nan_fill_val = np.inf
         order = (masked_vals, mask, labels)
-
-    # Otherwise, fill with the lowest value of the type
     else:
         if rank_t is object:
             nan_fill_val = NegInfinity()

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -1166,11 +1166,11 @@ def rank_1d(
                         for j in range(i - dups + 1, i + 1):
                             out[lexsort_indexer[j]] = grp_vals_seen
 
-                    # Look forward to the next value (using the sorting in lexsort_indexer)
-                    # if the value does not equal the current value then we need to
-                    # reset the dups and sum_ranks, knowing that a new value is
-                    # coming up. The conditional also needs to handle nan equality
-                    # and the end of iteration
+                    # Look forward to the next value (using the sorting in
+                    # lexsort_indexer) if the value does not equal the current
+                    # value then we need to reset the dups and sum_ranks, knowing
+                    # that a new value is coming up. The conditional also needs
+                    # to handle nan equality and the end of iteration
                     if next_val_diff or (mask[lexsort_indexer[i]]
                                          ^ mask[lexsort_indexer[i+1]]):
                         dups = sum_ranks = 0

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -953,7 +953,7 @@ def rank_1d(
         ndarray[uint8_t, ndim=1] mask
         bint keep_na, at_end, next_val_diff, check_labels, set_as_na, group_changed
         rank_t nan_fill_val
-        float computed_rank
+        float64_t computed_rank = 0
 
     tiebreak = tiebreakers[ties_method]
     keep_na = na_option == 'keep'

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -1075,9 +1075,17 @@ def rank_1d(
                 elif tiebreak == TIEBREAK_MAX:
                     for j in range(i - dups + 1, i + 1):
                         out[lexsort_indexer[j]] = i - grp_start + 1
+
+                # With n as the previous rank in the group and m as the number
+                # of duplicates in this stretch, if TIEBREAK_FIRST and ascending,
+                # then rankings should be n+1, n+2...n+m
                 elif tiebreak == TIEBREAK_FIRST:
                     for j in range(i - dups + 1, i + 1):
                         out[lexsort_indexer[j]] = j + 1 - grp_start
+
+                # If TIEBREAK_FIRST and descending, the ranking should be
+                # n+m, n+(m-1)...n+1. This is equivalent to
+                # (i - dups + 1) + (i - j + 1) - grp_start
                 elif tiebreak == TIEBREAK_FIRST_DESCENDING:
                     for j in range(i - dups + 1, i + 1):
                         out[lexsort_indexer[j]] = 2 * i - j - dups + 2 - grp_start
@@ -1157,9 +1165,17 @@ def rank_1d(
                     elif tiebreak == TIEBREAK_MAX:
                         for j in range(i - dups + 1, i + 1):
                             out[lexsort_indexer[j]] = i - grp_start + 1
+
+                    # With n as the previous rank in the group and m as the number
+                    # of duplicates in this stretch, if TIEBREAK_FIRST and ascending,
+                    # then rankings should be n + 1, n + 2 ... n + m
                     elif tiebreak == TIEBREAK_FIRST:
                         for j in range(i - dups + 1, i + 1):
                             out[lexsort_indexer[j]] = j + 1 - grp_start
+
+                    # If TIEBREAK_FIRST and descending, the ranking should be
+                    # n + m, n + (m - 1) ... n + 1. This is equivalent to
+                    # (i - dups + 1) + (i - j + 1) - grp_start
                     elif tiebreak == TIEBREAK_FIRST_DESCENDING:
                         for j in range(i - dups + 1, i + 1):
                             out[lexsort_indexer[j]] = 2 * i - j - dups + 2 - grp_start

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -985,8 +985,9 @@ def rank_1d(
     else:
         mask = np.zeros(shape=len(masked_vals), dtype=np.uint8)
 
-    # If ascending is true and na_option == 'bottom',
-    # fill with the largest so NaN
+    # If ascending and na_option == 'bottom' or descending and
+    # na_option == 'top' -> we want to rank NaN as the highest
+    # so fill with the maximum value for the type
     if ascending ^ (na_option == 'top'):
         if rank_t is object:
             nan_fill_val = Infinity()
@@ -997,6 +998,8 @@ def rank_1d(
         else:
             nan_fill_val = np.inf
         order = (masked_vals, mask, labels)
+
+    # Otherwise, fill with the lowest value of the type
     else:
         if rank_t is object:
             nan_fill_val = NegInfinity()
@@ -1036,8 +1039,8 @@ def rank_1d(
             dups += 1
             sum_ranks += i - grp_start + 1
 
-            next_val_diff = at_end or (masked_vals[lexsort_indexer[i]] !=
-                                       masked_vals[lexsort_indexer[i+1]])
+            next_val_diff = at_end or are_diff(masked_vals[lexsort_indexer[i]],
+                                               masked_vals[lexsort_indexer[i+1]])
 
             # We'll need this check later anyway to determine group size, so just
             # compute it here since shortcircuiting won't help
@@ -1058,7 +1061,7 @@ def rank_1d(
                 set_as_na = keep_na and mask[lexsort_indexer[i]]
 
                 # For all cases except TIEBREAK_FIRST when not setting
-                # nulls, we set the same value at each index
+                # nulls, we can set the same value at each index
                 if set_as_na:
                     computed_rank = NaN
                     grp_na_count = dups

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -1078,13 +1078,13 @@ def rank_1d(
 
                 # With n as the previous rank in the group and m as the number
                 # of duplicates in this stretch, if TIEBREAK_FIRST and ascending,
-                # then rankings should be n+1, n+2...n+m
+                # then rankings should be n + 1, n + 2 ... n + m
                 elif tiebreak == TIEBREAK_FIRST:
                     for j in range(i - dups + 1, i + 1):
                         out[lexsort_indexer[j]] = j + 1 - grp_start
 
                 # If TIEBREAK_FIRST and descending, the ranking should be
-                # n+m, n+(m-1)...n+1. This is equivalent to
+                # n + m, n + (m - 1) ... n + 1. This is equivalent to
                 # (i - dups + 1) + (i - j + 1) - grp_start
                 elif tiebreak == TIEBREAK_FIRST_DESCENDING:
                     for j in range(i - dups + 1, i + 1):


### PR DESCRIPTION
Long overdue followup to #38744. Only half the diff is relevant since the changes are duplicated over the if rank_t is object... else with no_gil... structure.