### PR TITLE
CLN: Remove unnecessary code in docs/make.py

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -54,7 +54,6 @@ class DocBuilder:
 
         if single_doc:
             single_doc = self._process_single_doc(single_doc)
-            include_api = False
             os.environ["SPHINX_PATTERN"] = single_doc
         elif not include_api:
             os.environ["SPHINX_PATTERN"] = "-api"


### PR DESCRIPTION
Simple cleaning in docs/make.py.

`include_api = False`  in the if block doesn't have any effect.
