### PR TITLE
REF/PERF: deduplicate kth_smallest

### DIFF
--- a/pandas/_libs/algos.pxd
+++ b/pandas/_libs/algos.pxd
@@ -44,7 +44,7 @@ cdef inline numeric kth_smallest_c(numeric* arr, Py_ssize_t k, Py_ssize_t n) nog
             while arr[i] < x: i += 1
             while x < arr[j]: j -= 1
             if i <= j:
-                swap(&arr[i], &arr[j])
+                swap(arr + i, arr + j)
                 i += 1; j -= 1
 
             if i > j: break

--- a/pandas/_libs/algos.pxd
+++ b/pandas/_libs/algos.pxd
@@ -12,10 +12,43 @@ cdef inline Py_ssize_t swap(numeric *a, numeric *b) nogil:
     return 0
 
 
-cdef enum TiebreakEnumType:
-    TIEBREAK_AVERAGE
-    TIEBREAK_MIN,
-    TIEBREAK_MAX
-    TIEBREAK_FIRST
-    TIEBREAK_FIRST_DESCENDING
-    TIEBREAK_DENSE
+cdef inline numeric kth_smallest_c(numeric* arr, Py_ssize_t k, Py_ssize_t n) nogil:
+    """
+    Compute the kth smallest value in an array
+
+    Parameters
+    ----------
+    arr: numeric* arr
+        Pointer to the start of the array
+    k: Py_ssize_t
+
+    Returns
+    -------
+    numeric
+        The kth smallest value in arr
+    """
+    cdef:
+        Py_ssize_t i, j, l, m
+        numeric x
+
+    l = 0
+    m = n - 1
+
+    while l < m:
+        x = arr[k]
+        i = l
+        j = m
+
+        while 1:
+            while arr[i] < x: i += 1
+            while x < arr[j]: j -= 1
+            if i <= j:
+                swap(&arr[i], &arr[j])
+                i += 1; j -= 1
+
+            if i > j: break
+
+        if j < k: l = i
+        if k < i: m = j
+    return arr[k]
+

--- a/pandas/_libs/algos.pxd
+++ b/pandas/_libs/algos.pxd
@@ -53,3 +53,12 @@ cdef inline numeric kth_smallest_c(numeric* arr, Py_ssize_t k, Py_ssize_t n) nog
         if k < i: m = j
     return arr[k]
 
+
+cdef enum TiebreakEnumType:
+    TIEBREAK_AVERAGE
+    TIEBREAK_MIN,
+    TIEBREAK_MAX
+    TIEBREAK_FIRST
+    TIEBREAK_FIRST_DESCENDING
+    TIEBREAK_DENSE
+

--- a/pandas/_libs/algos.pxd
+++ b/pandas/_libs/algos.pxd
@@ -1,23 +1,4 @@
 from pandas._libs.util cimport numeric
 
 
-cdef inline Py_ssize_t swap(numeric *a, numeric *b) nogil:
-    cdef:
-        numeric t
-
-    # cython doesn't allow pointer dereference so use array syntax
-    t = a[0]
-    a[0] = b[0]
-    b[0] = t
-    return 0
-
-
 cdef numeric kth_smallest_c(numeric* arr, Py_ssize_t k, Py_ssize_t n) nogil
-
-cdef enum TiebreakEnumType:
-    TIEBREAK_AVERAGE
-    TIEBREAK_MIN,
-    TIEBREAK_MAX
-    TIEBREAK_FIRST
-    TIEBREAK_FIRST_DESCENDING
-    TIEBREAK_DENSE

--- a/pandas/_libs/algos.pxd
+++ b/pandas/_libs/algos.pxd
@@ -44,7 +44,7 @@ cdef inline numeric kth_smallest_c(numeric* arr, Py_ssize_t k, Py_ssize_t n) nog
             while arr[i] < x: i += 1
             while x < arr[j]: j -= 1
             if i <= j:
-                swap(arr + i, arr + j)
+                swap(&arr[i], &arr[j])
                 i += 1; j -= 1
 
             if i > j: break

--- a/pandas/_libs/algos.pxd
+++ b/pandas/_libs/algos.pxd
@@ -61,4 +61,3 @@ cdef enum TiebreakEnumType:
     TIEBREAK_FIRST
     TIEBREAK_FIRST_DESCENDING
     TIEBREAK_DENSE
-

--- a/pandas/_libs/algos.pxd
+++ b/pandas/_libs/algos.pxd
@@ -12,47 +12,7 @@ cdef inline Py_ssize_t swap(numeric *a, numeric *b) nogil:
     return 0
 
 
-cdef inline numeric kth_smallest_c(numeric* arr, Py_ssize_t k, Py_ssize_t n) nogil:
-    """
-    Compute the kth smallest value in an array
-
-    Parameters
-    ----------
-    arr: numeric* arr
-        Pointer to the start of the array
-    k: Py_ssize_t
-    n: Number of values in arr to consider (no more than len(arr))
-
-    Returns
-    -------
-    numeric
-        The kth smallest value in arr
-    """
-    cdef:
-        Py_ssize_t i, j, l, m
-        numeric x
-
-    l = 0
-    m = n - 1
-
-    while l < m:
-        x = arr[k]
-        i = l
-        j = m
-
-        while 1:
-            while arr[i] < x: i += 1
-            while x < arr[j]: j -= 1
-            if i <= j:
-                swap(&arr[i], &arr[j])
-                i += 1; j -= 1
-
-            if i > j: break
-
-        if j < k: l = i
-        if k < i: m = j
-    return arr[k]
-
+cdef numeric kth_smallest_c(numeric* arr, Py_ssize_t k, Py_ssize_t n) nogil
 
 cdef enum TiebreakEnumType:
     TIEBREAK_AVERAGE

--- a/pandas/_libs/algos.pxd
+++ b/pandas/_libs/algos.pxd
@@ -21,6 +21,7 @@ cdef inline numeric kth_smallest_c(numeric* arr, Py_ssize_t k, Py_ssize_t n) nog
     arr: numeric* arr
         Pointer to the start of the array
     k: Py_ssize_t
+    n: Number of values in arr to consider (no more than len(arr))
 
     Returns
     -------

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -64,6 +64,15 @@ cdef:
     float64_t NaN = <float64_t>np.NaN
     int64_t NPY_NAT = get_nat()
 
+
+cdef enum TiebreakEnumType:
+    TIEBREAK_AVERAGE
+    TIEBREAK_MIN,
+    TIEBREAK_MAX
+    TIEBREAK_FIRST
+    TIEBREAK_FIRST_DESCENDING
+    TIEBREAK_DENSE
+
 tiebreakers = {
     "average": TIEBREAK_AVERAGE,
     "min": TIEBREAK_MIN,
@@ -239,32 +248,23 @@ def groupsort_indexer(const int64_t[:] index, Py_ssize_t ngroups):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def kth_smallest(numeric[:] a, Py_ssize_t k) -> numeric:
-    cdef:
-        Py_ssize_t i, j, l, m, n = a.shape[0]
-        numeric x
+def kth_smallest(numeric[::1] arr, Py_ssize_t k) -> numeric:
+    """
+    Compute the kth smallest value in arr
 
-    with nogil:
-        l = 0
-        m = n - 1
+    Parameters
+    ----------
+    arr: numeric[::1]
+        Array to compute the kth smallest value for, must be
+        contiguous
+    k: Py_ssize_t
 
-        while l < m:
-            x = a[k]
-            i = l
-            j = m
-
-            while 1:
-                while a[i] < x: i += 1
-                while x < a[j]: j -= 1
-                if i <= j:
-                    swap(&a[i], &a[j])
-                    i += 1; j -= 1
-
-                if i > j: break
-
-            if j < k: l = i
-            if k < i: m = j
-    return a[k]
+    Returns
+    -------
+    numeric
+        The kth smallest value in arr
+    """
+    return kth_smallest_c(&a[0], k, a.shape[0])
 
 
 # ----------------------------------------------------------------------

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -64,15 +64,6 @@ cdef:
     float64_t NaN = <float64_t>np.NaN
     int64_t NPY_NAT = get_nat()
 
-
-cdef enum TiebreakEnumType:
-    TIEBREAK_AVERAGE
-    TIEBREAK_MIN,
-    TIEBREAK_MAX
-    TIEBREAK_FIRST
-    TIEBREAK_FIRST_DESCENDING
-    TIEBREAK_DENSE
-
 tiebreakers = {
     "average": TIEBREAK_AVERAGE,
     "min": TIEBREAK_MIN,
@@ -266,7 +257,7 @@ def kth_smallest(numeric[::1] arr, Py_ssize_t k) -> numeric:
     """
     cdef:
         numeric result
-        
+
     with nogil:
         result = kth_smallest_c(&arr[0], k, arr.shape[0])
 

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -258,19 +258,9 @@ cdef inline Py_ssize_t swap(numeric *a, numeric *b) nogil:
 
 cdef inline numeric kth_smallest_c(numeric* arr, Py_ssize_t k, Py_ssize_t n) nogil:
     """
-    Compute the kth smallest value in an array
-
-    Parameters
-    ----------
-    arr: numeric* arr
-        Pointer to the start of the array
-    k: Py_ssize_t
-    n: Number of values in arr to consider (no more than len(arr))
-
-    Returns
-    -------
-    numeric
-        The kth smallest value in arr
+    See kth_smallest.__doc__. The additional parameter n specifies the maximum
+    number of elements considered in arr, needed for compatibility with usage
+    in groupby.pyx
     """
     cdef:
         Py_ssize_t i, j, l, m
@@ -302,14 +292,15 @@ cdef inline numeric kth_smallest_c(numeric* arr, Py_ssize_t k, Py_ssize_t n) nog
 @cython.wraparound(False)
 def kth_smallest(numeric[::1] arr, Py_ssize_t k) -> numeric:
     """
-    Compute the kth smallest value in arr
+    Compute the kth smallest value in arr. Note that the input
+    array will be modified.
 
     Parameters
     ----------
-    arr: numeric[::1]
+    arr : numeric[::1]
         Array to compute the kth smallest value for, must be
         contiguous
-    k: Py_ssize_t
+    k : Py_ssize_t
 
     Returns
     -------

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -264,7 +264,7 @@ def kth_smallest(numeric[::1] arr, Py_ssize_t k) -> numeric:
     numeric
         The kth smallest value in arr
     """
-    return kth_smallest_c(&a[0], k, a.shape[0])
+    return kth_smallest_c(&arr[0], k, arr.shape[0])
 
 
 # ----------------------------------------------------------------------

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -64,6 +64,14 @@ cdef:
     float64_t NaN = <float64_t>np.NaN
     int64_t NPY_NAT = get_nat()
 
+cdef enum TiebreakEnumType:
+    TIEBREAK_AVERAGE
+    TIEBREAK_MIN,
+    TIEBREAK_MAX
+    TIEBREAK_FIRST
+    TIEBREAK_FIRST_DESCENDING
+    TIEBREAK_DENSE
+
 tiebreakers = {
     "average": TIEBREAK_AVERAGE,
     "min": TIEBREAK_MIN,
@@ -235,6 +243,17 @@ def groupsort_indexer(const int64_t[:] index, Py_ssize_t ngroups):
             where[label] += 1
 
     return indexer, counts
+
+
+cdef inline Py_ssize_t swap(numeric *a, numeric *b) nogil:
+    cdef:
+        numeric t
+
+    # cython doesn't allow pointer dereference so use array syntax
+    t = a[0]
+    a[0] = b[0]
+    b[0] = t
+    return 0
 
 
 cdef inline numeric kth_smallest_c(numeric* arr, Py_ssize_t k, Py_ssize_t n) nogil:

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -264,7 +264,8 @@ def kth_smallest(numeric[::1] arr, Py_ssize_t k) -> numeric:
     numeric
         The kth smallest value in arr
     """
-    return kth_smallest_c(&arr[0], k, arr.shape[0])
+    with nogil:
+        return kth_smallest_c(&arr[0], k, arr.shape[0])
 
 
 # ----------------------------------------------------------------------

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -237,6 +237,48 @@ def groupsort_indexer(const int64_t[:] index, Py_ssize_t ngroups):
     return indexer, counts
 
 
+cdef inline numeric kth_smallest_c(numeric* arr, Py_ssize_t k, Py_ssize_t n) nogil:
+    """
+    Compute the kth smallest value in an array
+
+    Parameters
+    ----------
+    arr: numeric* arr
+        Pointer to the start of the array
+    k: Py_ssize_t
+    n: Number of values in arr to consider (no more than len(arr))
+
+    Returns
+    -------
+    numeric
+        The kth smallest value in arr
+    """
+    cdef:
+        Py_ssize_t i, j, l, m
+        numeric x
+
+    l = 0
+    m = n - 1
+
+    while l < m:
+        x = arr[k]
+        i = l
+        j = m
+
+        while 1:
+            while arr[i] < x: i += 1
+            while x < arr[j]: j -= 1
+            if i <= j:
+                swap(&arr[i], &arr[j])
+                i += 1; j -= 1
+
+            if i > j: break
+
+        if j < k: l = i
+        if k < i: m = j
+    return arr[k]
+
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def kth_smallest(numeric[::1] arr, Py_ssize_t k) -> numeric:

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -264,8 +264,13 @@ def kth_smallest(numeric[::1] arr, Py_ssize_t k) -> numeric:
     numeric
         The kth smallest value in arr
     """
+    cdef:
+        numeric result
+        
     with nogil:
-        return kth_smallest_c(&arr[0], k, arr.shape[0])
+        result = kth_smallest_c(&arr[0], k, arr.shape[0])
+
+    return result
 
 
 # ----------------------------------------------------------------------

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -30,7 +30,7 @@ from numpy.math cimport NAN
 
 cnp.import_array()
 
-from pandas._libs.algos cimport swap
+from pandas._libs.algos cimport kth_smallest_c
 from pandas._libs.util cimport (
     get_nat,
     numeric,
@@ -88,7 +88,7 @@ cdef inline float64_t median_linear(float64_t* a, int n) nogil:
         n -= na_count
 
     if n % 2:
-        result = kth_smallest_c( a, n // 2, n)
+        result = kth_smallest_c(a, n // 2, n)
     else:
         result = (kth_smallest_c(a, n // 2, n) +
                   kth_smallest_c(a, n // 2 - 1, n)) / 2
@@ -97,35 +97,6 @@ cdef inline float64_t median_linear(float64_t* a, int n) nogil:
         free(a)
 
     return result
-
-
-# TODO: Is this redundant with algos.kth_smallest
-cdef inline float64_t kth_smallest_c(float64_t* a,
-                                     Py_ssize_t k,
-                                     Py_ssize_t n) nogil:
-    cdef:
-        Py_ssize_t i, j, l, m
-        float64_t x, t
-
-    l = 0
-    m = n - 1
-    while l < m:
-        x = a[k]
-        i = l
-        j = m
-
-        while 1:
-            while a[i] < x: i += 1
-            while x < a[j]: j -= 1
-            if i <= j:
-                swap(&a[i], &a[j])
-                i += 1; j -= 1
-
-            if i > j: break
-
-        if j < k: l = i
-        if k < i: m = j
-    return a[k]
 
 
 @cython.boundscheck(False)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1305,7 +1305,8 @@ class SelectNSeries(SelectN):
         narr = len(arr)
         n = min(n, narr)
 
-        # arr passed into kth_smallest must be contiguous
+        # arr passed into kth_smallest must be contiguous. We copy
+        # here because kth_smallest will modify its input
         kth_val = algos.kth_smallest(arr.copy(order="C"), n - 1)
         (ns,) = np.nonzero(arr <= kth_val)
         inds = ns[arr[ns].argsort(kind="mergesort")]

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1305,9 +1305,8 @@ class SelectNSeries(SelectN):
         narr = len(arr)
         n = min(n, narr)
 
-        # arr passed into kth_smallest must be contiguous, which
-        # should be assured by the copy
-        kth_val = algos.kth_smallest(arr.copy(), n - 1)
+        # arr passed into kth_smallest must be contiguous
+        kth_val = algos.kth_smallest(arr.copy(order="C"), n - 1)
         (ns,) = np.nonzero(arr <= kth_val)
         inds = ns[arr[ns].argsort(kind="mergesort")]
 

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1305,6 +1305,8 @@ class SelectNSeries(SelectN):
         narr = len(arr)
         n = min(n, narr)
 
+        # arr passed into kth_smallest must be contiguous, which
+        # should be assured by the copy
         kth_val = algos.kth_smallest(arr.copy(), n - 1)
         (ns,) = np.nonzero(arr <= kth_val)
         inds = ns[arr[ns].argsort(kind="mergesort")]


### PR DESCRIPTION
Ensuring a contiguous input seems to give about a 5-10% performance improvement on the existing benchmark `gil.ParallelKth`