### PR TITLE
DEPR: use DeprecationWarning instead of FutureWarning for CategoricalBlock

### DIFF
--- a/pandas/core/internals/__init__.py
+++ b/pandas/core/internals/__init__.py
@@ -53,7 +53,7 @@ def __getattr__(name: str):
         warnings.warn(
             "CategoricalBlock is deprecated and will be removed in a future version. "
             "Use ExtensionBlock instead.",
-            FutureWarning,
+            DeprecationWarning,
             stacklevel=2,
         )
         return ExtensionBlock

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -258,7 +258,9 @@ bar2,12,13,14,15
             ),
         ],
     )
-    @pytest.mark.filterwarnings("ignore:CategoricalBlock is deprecated:FutureWarning")
+    @pytest.mark.filterwarnings(
+        "ignore:CategoricalBlock is deprecated:DeprecationWarning"
+    )
     def test_read_fspath_all(self, reader, module, path, datapath):
         pytest.importorskip(module)
         path = datapath(*path)

--- a/pandas/tests/io/test_feather.py
+++ b/pandas/tests/io/test_feather.py
@@ -20,7 +20,7 @@ filter_sparse = pytest.mark.filterwarnings("ignore:The Sparse")
 
 @filter_sparse
 @pytest.mark.single
-@pytest.mark.filterwarnings("ignore:CategoricalBlock is deprecated:FutureWarning")
+@pytest.mark.filterwarnings("ignore:CategoricalBlock is deprecated:DeprecationWarning")
 class TestFeather:
     def check_error_on_write(self, df, exc, err_msg):
         # check that we are raising the exception

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -573,7 +573,7 @@ class TestBasic(Base):
         self.check_error_on_write(df, engine, ValueError, msg)
 
 
-@pytest.mark.filterwarnings("ignore:CategoricalBlock is deprecated:FutureWarning")
+@pytest.mark.filterwarnings("ignore:CategoricalBlock is deprecated:DeprecationWarning")
 class TestParquetPyArrow(Base):
     def test_basic(self, pa, df_full):
 


### PR DESCRIPTION
Follow-up on https://github.com/pandas-dev/pandas/pull/40527

There is no need for end-users to see this warning if an underlying library they use generates this, so using a DeprecationWarning instead of FutureWarning (as we did before with potentially noisy or internal warnings). At a later point we can change to FutureWarning.