### PR TITLE
COMPAT: make Categorical._codes settable again

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1756,6 +1756,10 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
     def _codes(self) -> np.ndarray:
         return self._ndarray
 
+    @_codes.setter
+    def _codes(self, value: np.ndarray):
+        self._ndarray = value
+
     def _from_backing_data(self, arr: np.ndarray) -> Categorical:
         assert isinstance(arr, np.ndarray)
         assert arr.dtype == self._ndarray.dtype


### PR DESCRIPTION
This is a follow-up on https://github.com/pandas-dev/pandas/pull/40033, which changes the `_code` attribute of a Categorical into a property without a setter.

This broke dask / fastparquet, so this PR is making it settable again. We could deprecate the setter, though, at the same time.