### PR TITLE
TST Add test for loc on sparse dataframes

### DIFF
--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1182,17 +1182,6 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         )
         tm.assert_frame_equal(result, expected)
 
-        ser = df[0]
-        ser.name = None
-
-        result = ser.loc[range(2)]
-        expected = Series([1.0, 0.0], dtype=SparseDtype("float64", 0.0))
-        tm.assert_series_equal(result, expected)
-
-        result = ser.loc[range(3)].loc[range(2)]
-        expected = Series([1.0, 0.0], dtype=SparseDtype("float64", 0.0))
-        tm.assert_series_equal(result, expected)
-
     @pytest.mark.parametrize("key_type", [iter, np.array, Series, Index])
     def test_loc_getitem_iterable(self, float_frame, key_type):
         idx = key_type(["A", "B", "C"])

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1164,7 +1164,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         tm.assert_frame_equal(result, df)
 
     @td.skip_if_no_scipy
-    def test_loc_sparse_frame(self):
+    def test_loc_getitem_sparse_frame(self):
         # GH34687
         from scipy.sparse import eye
 
@@ -1181,6 +1181,17 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
             [[1.0, 0.0, 0.0, 0.0, 0.0]], dtype=SparseDtype("float64", 0.0)
         )
         tm.assert_frame_equal(result, expected)
+
+        ser = df[0]
+        ser.name = None
+
+        result = ser.loc[range(2)]
+        expected = Series([1.0, 0.0], dtype=SparseDtype("float64", 0.0))
+        tm.assert_series_equal(result, expected)
+
+        result = ser.loc[range(3)].loc[range(2)]
+        expected = Series([1.0, 0.0], dtype=SparseDtype("float64", 0.0))
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("key_type", [iter, np.array, Series, Index])
     def test_loc_getitem_iterable(self, float_frame, key_type):

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1163,6 +1163,25 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         result = df.loc[[0, 1]]
         tm.assert_frame_equal(result, df)
 
+    @td.skip_if_no_scipy
+    def test_loc_sparse_frame(self):
+        # GH34687
+        from scipy.sparse import eye
+
+        df = DataFrame.sparse.from_spmatrix(eye(5))
+        result = df.loc[range(2)]
+        expected = DataFrame(
+            [[1.0, 0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0, 0.0]],
+            dtype=SparseDtype("float64", 0.0),
+        )
+        tm.assert_frame_equal(result, expected)
+
+        result = df.loc[range(2)].loc[range(1)]
+        expected = DataFrame(
+            [[1.0, 0.0, 0.0, 0.0, 0.0]], dtype=SparseDtype("float64", 0.0)
+        )
+        tm.assert_frame_equal(result, expected)
+
     @pytest.mark.parametrize("key_type", [iter, np.array, Series, Index])
     def test_loc_getitem_iterable(self, float_frame, key_type):
         idx = key_type(["A", "B", "C"])

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1182,6 +1182,18 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         )
         tm.assert_frame_equal(result, expected)
 
+    def test_loc_getitem_sparse_series(self):
+        # GH34687
+        s = Series([1.0, 0.0, 0.0, 0.0, 0.0], dtype=SparseDtype("float64", 0.0))
+
+        result = s.loc[range(2)]
+        expected = Series([1.0, 0.0], dtype=SparseDtype("float64", 0.0))
+        tm.assert_series_equal(result, expected)
+
+        result = s.loc[range(3)].loc[range(2)]
+        expected = Series([1.0, 0.0], dtype=SparseDtype("float64", 0.0))
+        tm.assert_series_equal(result, expected)
+
     @pytest.mark.parametrize("key_type", [iter, np.array, Series, Index])
     def test_loc_getitem_iterable(self, float_frame, key_type):
         idx = key_type(["A", "B", "C"])

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -10,12 +10,12 @@ from pandas import (
     IndexSlice,
     MultiIndex,
     Series,
+    SparseDtype,
     Timedelta,
     Timestamp,
     date_range,
     period_range,
     timedelta_range,
-    SparseDtype,
 )
 import pandas._testing as tm
 

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -15,6 +15,7 @@ from pandas import (
     date_range,
     period_range,
     timedelta_range,
+    SparseDtype,
 )
 import pandas._testing as tm
 
@@ -377,3 +378,17 @@ def test_frozenset_index():
     assert s[idx1] == 2
     s[idx1] = 3
     assert s[idx1] == 3
+
+
+def test_loc_getitem_sparse_series():
+    # GH34687
+
+    s = Series([1.0, 0.0, 0.0, 0.0, 0.0], dtype=SparseDtype("float64", 0.0))
+
+    result = s.loc[range(2)]
+    expected = Series([1.0, 0.0], dtype=SparseDtype("float64", 0.0))
+    tm.assert_series_equal(result, expected)
+
+    result = s.loc[range(3)].loc[range(2)]
+    expected = Series([1.0, 0.0], dtype=SparseDtype("float64", 0.0))
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -10,7 +10,6 @@ from pandas import (
     IndexSlice,
     MultiIndex,
     Series,
-    SparseDtype,
     Timedelta,
     Timestamp,
     date_range,
@@ -378,17 +377,3 @@ def test_frozenset_index():
     assert s[idx1] == 2
     s[idx1] = 3
     assert s[idx1] == 3
-
-
-def test_loc_getitem_sparse_series():
-    # GH34687
-
-    s = Series([1.0, 0.0, 0.0, 0.0, 0.0], dtype=SparseDtype("float64", 0.0))
-
-    result = s.loc[range(2)]
-    expected = Series([1.0, 0.0], dtype=SparseDtype("float64", 0.0))
-    tm.assert_series_equal(result, expected)
-
-    result = s.loc[range(3)].loc[range(2)]
-    expected = Series([1.0, 0.0], dtype=SparseDtype("float64", 0.0))
-    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
Adds a test for loc on sparse dataframes.

- [x] closes #34687
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
