### PR TITLE
REGR: replace with multivalued regex raising

### DIFF
--- a/doc/source/whatsnew/v1.2.4.rst
+++ b/doc/source/whatsnew/v1.2.4.rst
@@ -18,6 +18,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.sum` when ``min_count`` greater than the :class:`DataFrame` shape was passed resulted in a ``ValueError`` (:issue:`39738`)
 - Fixed regression in :meth:`DataFrame.to_json` raising ``AttributeError`` when run on PyPy (:issue:`39837`)
 - Fixed regression in :meth:`DataFrame.where` not returning a copy in the case of an all True condition (:issue:`39595`)
+- Fixed regression in :meth:`DataFrame.replace` raising ``IndexError`` with ``regex`` was a multi-key dictionary (:issue:`39338`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.2.4.rst
+++ b/doc/source/whatsnew/v1.2.4.rst
@@ -18,7 +18,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.sum` when ``min_count`` greater than the :class:`DataFrame` shape was passed resulted in a ``ValueError`` (:issue:`39738`)
 - Fixed regression in :meth:`DataFrame.to_json` raising ``AttributeError`` when run on PyPy (:issue:`39837`)
 - Fixed regression in :meth:`DataFrame.where` not returning a copy in the case of an all True condition (:issue:`39595`)
-- Fixed regression in :meth:`DataFrame.replace` raising ``IndexError`` with ``regex`` was a multi-key dictionary (:issue:`39338`)
+- Fixed regression in :meth:`DataFrame.replace` raising ``IndexError`` when ``regex`` was a multi-key dictionary (:issue:`39338`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -810,7 +810,10 @@ class Block(libinternals.Block, PandasObject):
                 else:
                     # GH-39338: _replace_coerce can split a block, so we
                     # need to keep track of where to index into the mask
-                    m = masks[i][mask_pos : mask_pos + blk.shape[0]]
+                    assert not isinstance(masks[i], bool)
+                    # error: Value of type "Union[ExtensionArray, ndarray, bool]"
+                    # is not indexable
+                    m = masks[i][mask_pos : mask_pos + blk.shape[0]]  # type: ignore[index]
                     mask_pos += blk.shape[0]
 
                 result = blk._replace_coerce(

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -813,7 +813,9 @@ class Block(libinternals.Block, PandasObject):
                     assert not isinstance(masks[i], bool)
                     # error: Value of type "Union[ExtensionArray, ndarray, bool]"
                     # is not indexable
-                    m = masks[i][mask_pos : mask_pos + blk.shape[0]]  # type: ignore[index]
+                    m = masks[i][
+                        mask_pos : mask_pos + blk.shape[0]
+                    ]  # type: ignore[index]
                     mask_pos += blk.shape[0]
 
                 result = blk._replace_coerce(

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -808,14 +808,11 @@ class Block(libinternals.Block, PandasObject):
                 if blk.ndim == 1:
                     m = masks[i]
                 else:
+                    mib = masks[i]
                     # GH-39338: _replace_coerce can split a block, so we
                     # need to keep track of where to index into the mask
-                    assert not isinstance(masks[i], bool)
-                    # error: Value of type "Union[ExtensionArray, ndarray, bool]"
-                    # is not indexable
-                    m = masks[i][
-                        mask_pos : mask_pos + blk.shape[0]
-                    ]  # type: ignore[index]
+                    assert not isinstance(mib, bool)
+                    m = mib[mask_pos : mask_pos + blk.shape[0]]
                     mask_pos += blk.shape[0]
 
                 result = blk._replace_coerce(

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -801,10 +801,18 @@ class Block(libinternals.Block, PandasObject):
 
         rb = [self if inplace else self.copy()]
         for i, (src, dest) in enumerate(pairs):
+            convert = i == src_len  # only convert once at the end
             new_rb: List[Block] = []
+            mask_pos = 0
             for blk in rb:
-                m = masks[i]
-                convert = i == src_len  # only convert once at the end
+                if blk.ndim == 1:
+                    m = masks[i]
+                else:
+                    # GH-39338: _replace_coerce can split a block, so we
+                    # need to keep track of where to index into the mask
+                    m = masks[i][mask_pos : mask_pos + blk.shape[0]]
+                    mask_pos += blk.shape[0]
+
                 result = blk._replace_coerce(
                     to_replace=src,
                     value=dest,

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -803,17 +803,17 @@ class Block(libinternals.Block, PandasObject):
         for i, (src, dest) in enumerate(pairs):
             convert = i == src_len  # only convert once at the end
             new_rb: List[Block] = []
-            mask_pos = 0
-            for blk in rb:
-                if blk.ndim == 1:
+
+            # GH-39338: _replace_coerce can split a block into
+            # single-column blocks, so track the index so we know
+            # where to index into the mask
+            for blk_num, blk in enumerate(rb):
+                if len(rb) == 1:
                     m = masks[i]
                 else:
                     mib = masks[i]
-                    # GH-39338: _replace_coerce can split a block, so we
-                    # need to keep track of where to index into the mask
                     assert not isinstance(mib, bool)
-                    m = mib[mask_pos : mask_pos + blk.shape[0]]
-                    mask_pos += blk.shape[0]
+                    m = mib[blk_num : blk_num + 1]
 
                 result = blk._replace_coerce(
                     to_replace=src,

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -659,11 +659,9 @@ class TestDataFrameReplace:
     )
     def test_joint_simple_replace_and_regex_replace(self, to_replace):
         # GH-39338
-        df = pd.DataFrame({"col1": ["1,000", "a", "3"], "col2": ["a", "", "b"]})
+        df = DataFrame({"col1": ["1,000", "a", "3"], "col2": ["a", "", "b"]})
         result = df.replace(regex=to_replace)
-        expected = pd.DataFrame(
-            {"col1": ["1000", "a", "3"], "col2": ["a", np.nan, "b"]}
-        )
+        expected = DataFrame({"col1": ["1000", "a", "3"], "col2": ["a", np.nan, "b"]})
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize("metachar", ["[]", "()", r"\d", r"\w", r"\s"])

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -654,6 +654,13 @@ class TestDataFrameReplace:
         tm.assert_frame_equal(res, expec)
         assert res.a.dtype == np.object_
 
+    def test_regex_replace_after_splitting_replace(self):
+        df =  pd.DataFrame({ 'a_str' : ['A1','A2','A3'],
+#                            'b_int' : ['1,000','200','3'],
+#                            'c_str' : ['C1','C2','C3'],
+#                            'd_date' : ['2021-01-01', '', '2021-03-03']})
+
+
     @pytest.mark.parametrize("metachar", ["[]", "()", r"\d", r"\w", r"\s"])
     def test_replace_regex_metachar(self, metachar):
         df = DataFrame({"a": [metachar, "else"]})

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -659,9 +659,21 @@ class TestDataFrameReplace:
     )
     def test_joint_simple_replace_and_regex_replace(self, to_replace):
         # GH-39338
-        df = DataFrame({"col1": ["1,000", "a", "3"], "col2": ["a", "", "b"]})
+        df = DataFrame(
+            {
+                "col1": ["1,000", "a", "3"],
+                "col2": ["a", "", "b"],
+                "col3": ["a", "b", "c"],
+            }
+        )
         result = df.replace(regex=to_replace)
-        expected = DataFrame({"col1": ["1000", "a", "3"], "col2": ["a", np.nan, "b"]})
+        expected = DataFrame(
+            {
+                "col1": ["1000", "a", "3"],
+                "col2": ["a", np.nan, "b"],
+                "col3": ["a", "b", "c"],
+            }
+        )
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize("metachar", ["[]", "()", r"\d", r"\w", r"\s"])

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -654,12 +654,17 @@ class TestDataFrameReplace:
         tm.assert_frame_equal(res, expec)
         assert res.a.dtype == np.object_
 
-    def test_regex_replace_after_splitting_replace(self):
-        df =  pd.DataFrame({ 'a_str' : ['A1','A2','A3'],
-#                            'b_int' : ['1,000','200','3'],
-#                            'c_str' : ['C1','C2','C3'],
-#                            'd_date' : ['2021-01-01', '', '2021-03-03']})
-
+    @pytest.mark.parametrize(
+        "to_replace", [{"": np.nan, ",": ""}, {",": "", "": np.nan}]
+    )
+    def test_joint_simple_replace_and_regex_replace(self, to_replace):
+        # GH-39338
+        df = pd.DataFrame({"col1": ["1,000", "a", "3"], "col2": ["a", "", "b"]})
+        result = df.replace(regex=to_replace)
+        expected = pd.DataFrame(
+            {"col1": ["1000", "a", "3"], "col2": ["a", np.nan, "b"]}
+        )
+        tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize("metachar", ["[]", "()", r"\d", r"\w", r"\s"])
     def test_replace_regex_metachar(self, metachar):


### PR DESCRIPTION
- [x] closes #39338
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

Issue comes from the first pair in the `regex` arg hitting the simple replace path, which causes the `ObjectBlock` to be split. From here, the mask indexing will be wrong, but that will not cause an error unless a later  pair hits `_replace_regex`, which actually uses the mask.