### PR TITLE
PERF: increase the minimum number of elements to use numexpr for ops from 1e4 to 1e6

### DIFF
--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -38,7 +38,7 @@ _ALLOWED_DTYPES = {
 }
 
 # the minimum prod shape that we will use numexpr
-_MIN_ELEMENTS = 10000
+_MIN_ELEMENTS = 1_000_000
 
 
 def set_use_numexpr(v=True):

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -48,9 +48,7 @@ class TestExpressions:
     def setup_method(self, method):
 
         self.frame = _frame.copy()
-        self.array = _array.copy()
         self.frame2 = _frame2.copy()
-        self.array2 = _array2.copy()
         self.mixed = _mixed.copy()
         self.mixed2 = _mixed2.copy()
         self._MIN_ELEMENTS = expr._MIN_ELEMENTS
@@ -138,23 +136,19 @@ class TestExpressions:
         self.run_frame(df, df, flex)
 
     def test_invalid(self):
+        array = np.random.randn(1_000_001)
+        array2 = np.random.randn(100)
 
         # no op
-        result = expr._can_use_numexpr(
-            operator.add, None, self.array, self.array, "evaluate"
-        )
+        result = expr._can_use_numexpr(operator.add, None, array, array, "evaluate")
         assert not result
 
         # min elements
-        result = expr._can_use_numexpr(
-            operator.add, "+", self.array2, self.array2, "evaluate"
-        )
+        result = expr._can_use_numexpr(operator.add, "+", array2, array2, "evaluate")
         assert not result
 
         # ok, we only check on first part of expression
-        result = expr._can_use_numexpr(
-            operator.add, "+", self.array, self.array2, "evaluate"
-        )
+        result = expr._can_use_numexpr(operator.add, "+", array, array2, "evaluate")
         assert result
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #40500, see that issue for the analysis of speedup vs size.

Another take of https://github.com/pandas-dev/pandas/pull/40502, but hopefully now without crashing the tests because of increased memory use.