### PR TITLE
DOC: Change user guide style notebook to reST

### DIFF
--- a/doc/source/user_guide/style.ipynb
+++ b/doc/source/user_guide/style.ipynb
@@ -1,21 +1,24 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
    "source": [
-    "# Styling\n",
+    "Styling\n",
+    "=======\n",
     "\n",
     "This document is written as a Jupyter Notebook, and can be viewed or downloaded [here](https://nbviewer.ipython.org/github/pandas-dev/pandas/blob/master/doc/source/user_guide/style.ipynb).\n",
     "\n",
     "You can apply **conditional formatting**, the visual styling of a DataFrame\n",
-    "depending on the data within, by using the ``DataFrame.style`` property.\n",
-    "This is a property that returns a ``Styler`` object, which has\n",
+    "depending on the data within, by using the :attr:`pandas.DataFrame.style` property.\n",
+    "This is a property that returns a :class:`~pandas.io.formats.style.Styler` object, which has\n",
     "useful methods for formatting and displaying DataFrames.\n",
     "\n",
     "The styling is accomplished using CSS.\n",
-    "You write \"style functions\" that take scalars, `DataFrame`s or `Series`, and return *like-indexed* DataFrames or Series with CSS `\"attribute: value\"` pairs for the values.\n",
-    "These functions can be incrementally passed to the `Styler` which collects the styles before rendering.\n",
+    "You write \"style functions\" that take scalars, :attr:`~pandas.DataFrame`\\ s or :attr:`~pandas.Series`, and return *like-indexed* DataFrames or Series with CSS `\"attribute: value\"` pairs for the values.\n",
+    "These functions can be incrementally passed to the :class:`~pandas.io.formats.style.Styler` which collects the styles before rendering.\n",
     "\n",
     "CSS is a flexible language and as such there may be multiple ways of achieving the same result, with potential\n",
     "advantages or disadvantages, which we try to illustrate."
@@ -1421,6 +1424,7 @@
   }
  ],
  "metadata": {
+  "celltoolbar": "Raw Cell Format",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -1436,7 +1440,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This way, the content is parsed by Sphinx so that links to the documentation can be automatically inserted.

The downside is, that the downloadable notebook is not as pretty as before (because it contains raw cells with reST code).

Is this something worth the effort?

- [ ] closes #40645
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
