### PR TITLE
ENH: Added support for `AsyncEngine` and `AsyncConnection` when using pandas SQL functions/methods

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -128,24 +128,23 @@ Example Usage:
    engine = create_async_engine('postgresql+asyncpg://anakin:skywalker@localhost/test')
 
    async def sql_operations():
+    # Accessing a table with the AsyncEngine
+    umbara = await pd.read_sql('umbara', engine)
+    # Can alternatively be written as: await pd.read_sql_table('umbara', engine)
 
-      # Accessing a table with the AsyncEngine
-      umbara = await pd.read_sql('umbara', engine)
-      # Can alternatively be written as: await pd.read_sql_table('umbara', engine)
+    # Using an SQL query with the AsyncConnection
+    async with engine.connect() as conn:
+        seasons = await pd.read_sql_query('SELECT season6, season5, season7 FROM clonewars', conn)
 
-      # Using an SQL query with the AsyncConnection
-      async with engine.connect() as conn:
-         seasons = await pd.read_sql_query('SELECT season6, season5, season7 FROM clonewars', conn)
+    favs = pd.DataFrame({
+        'FirstName': ['Mace', 'Obi-Wan', 'Ahsoka'],
+        'LastName': ['Windu', 'Kenobi', 'Tano']
+    })
 
-      favs = pd.DataFrame({
-         'FirstName': ['Mace', 'Obi-Wan', 'Ahsoka'],
-         'LastName': ['Windu', 'Kenobi', 'Tano']
-      })
+    # Writing data with the AsyncEngine
+    await favs.to_sql('jedi', engine)
 
-      # Writing data with the AsyncEngine
-      await favs.to_sql('jedi', engine)
-
-   asyncio.run(sql_operations())
+    asyncio.run(sql_operations())
 
 .. |AsyncEngine| replace:: ``AsyncEngine``
 .. _AsyncEngine: https://docs.sqlalchemy.org/en/latest/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.AsyncEngine

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -126,8 +126,9 @@ Example Usage:
    from sqlalchemy.ext.asyncio import create_async_engine
 
    engine = create_async_engine('postgresql+asyncpg://anakin:skywalker@localhost/test')
-   
+
    async def sql_operations():
+
       # Accessing a table with the AsyncEngine
       umbara = await pd.read_sql('umbara', engine)
       # Can alternatively be written as: await pd.read_sql_table('umbara', engine)
@@ -135,15 +136,15 @@ Example Usage:
       # Using an SQL query with the AsyncConnection
       async with engine.connect() as conn:
          seasons = await pd.read_sql_query('SELECT season6, season5, season7 FROM clonewars', conn)
-      
+
       favs = pd.DataFrame({
          'FirstName': ['Mace', 'Obi-Wan', 'Ahsoka'],
          'LastName': ['Windu', 'Kenobi', 'Tano']
       })
-      
+
       # Writing data with the AsyncEngine
       await favs.to_sql('jedi', engine)
-   
+
    asyncio.run(sql_operations())
 
 .. |AsyncEngine| replace:: ``AsyncEngine``

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -110,6 +110,47 @@ both XPath 1.0 and XSLT 1.0 is available. (:issue:`27554`)
 
 For more, see :ref:`io.xml` in the user guide on IO tools.
 
+|AsyncEngine|_ and |AsyncConnection|_ now supported in Pandas SQL Functions/Methods
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:meth:`pandas.read_sql`, :meth:`pandas.read_sql_query`, :meth:`pandas.read_sql_table`, :meth:`DataFrame.to_sql`, and :meth:`Series.to_sql`
+can now accept an |AsyncEngine|_ or an |AsyncConnection|_ as a valid argument to ``con``. (:issue:`40654`)
+
+.. note::
+   Just as a friendly reminder, you **must** ``await`` the function/method when using an |AsyncEngine|_ or |AsyncConnection|_
+
+Example Usage:
+
+.. code-block:: python
+
+   import asyncio
+   from sqlalchemy.ext.asyncio import create_async_engine
+
+   engine = create_async_engine('postgresql+asyncpg://anakin:skywalker@localhost/test')
+   
+   async def sql_operations():
+      # Accessing a table with the AsyncEngine
+      umbara = await pd.read_sql('umbara', engine)
+      # Can alternatively be written as: await pd.read_sql_table('umbara', engine)
+
+      # Using an SQL query with the AsyncConnection
+      async with engine.connect() as conn:
+         seasons = await pd.read_sql_query('SELECT season6, season5, season7 FROM clonewars', conn)
+      
+      favs = pd.DataFrame({
+         'FirstName': ['Mace', 'Obi-Wan', 'Ahsoka'],
+         'LastName': ['Windu', 'Kenobi', 'Tano']
+      })
+      
+      # Writing data with the AsyncEngine
+      await favs.to_sql('jedi', engine)
+   
+   asyncio.run(sql_operations())
+
+.. |AsyncEngine| replace:: ``AsyncEngine``
+.. _AsyncEngine: https://docs.sqlalchemy.org/en/latest/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.AsyncEngine
+.. |AsyncConnection| replace:: ``AsyncConnection``
+.. _AsyncConnection: https://docs.sqlalchemy.org/en/latest/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.AsyncConnection
+
 .. _whatsnew_130.enhancements.other:
 
 Other enhancements

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -154,6 +154,55 @@ Example Usage:
 .. |AsyncConnection| replace:: ``AsyncConnection``
 .. _AsyncConnection: https://docs.sqlalchemy.org/en/latest/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.AsyncConnection
 
+Styler Upgrades
+^^^^^^^^^^^^^^^
+
+We provided some focused development on :class:`.Styler`, including altering methods
+to accept more universal CSS language for arguments, such as ``'color:red;'`` instead of
+``[('color', 'red')]`` (:issue:`39564`). This is also added to the built-in methods
+to allow custom CSS highlighting instead of default background coloring (:issue:`40242`).
+
+The :meth:`.Styler.apply` now consistently allows functions with ``ndarray`` output to
+allow more flexible development of UDFs when ``axis`` is ``None`` ``0`` or ``1`` (:issue:`39393`).
+
+:meth:`.Styler.set_tooltips` is a new method that allows adding on hover tooltips to
+enhance interactive displays (:issue:`35643`). :meth:`.Styler.set_td_classes`, which was recently
+introduced in v1.2.0 (:issue:`36159`) to allow adding specific CSS classes to data cells, has
+been made as performant as :meth:`.Styler.apply` and :meth:`.Styler.applymap` (:issue:`40453`),
+if not more performant in some cases. The overall performance of HTML
+render times has been considerably improved to
+match :meth:`DataFrame.to_html` (:issue:`39952` :issue:`37792` :issue:`40425`).
+
+The :meth:`.Styler.format` has had upgrades to easily format missing data,
+precision, and perform HTML escaping (:issue:`40437` :issue:`40134`). There have been numerous other bug fixes to
+properly format HTML and eliminate some inconsistencies (:issue:`39942` :issue:`40356` :issue:`39807` :issue:`39889` :issue:`39627`)
+
+Documentation has also seen major revisions in light of new features (:issue:`39720` :issue:`39317` :issue:`40493`)
+
+.. _whatsnew_130.dataframe_honors_copy_with_dict:
+
+DataFrame constructor honors ``copy=False`` with dict
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When passing a dictionary to :class:`DataFrame` with ``copy=False``,
+a copy will no longer be made (:issue:`32960`)
+
+.. ipython:: python
+
+    arr = np.array([1, 2, 3])
+    df = pd.DataFrame({"A": arr, "B": arr.copy()}, copy=False)
+    df
+
+``df["A"]`` remains a view on ``arr``:
+
+.. ipython:: python
+
+    arr[0] = 0
+    assert df.iloc[0, 0] == 0
+
+The default behavior when not passing ``copy`` will remain unchanged, i.e.
+a copy will be made.
+
 .. _whatsnew_130.enhancements.other:
 
 Other enhancements
@@ -181,6 +230,7 @@ Other enhancements
 - :meth:`.Styler.apply` now more consistently accepts ndarray function returns, i.e. in all cases for ``axis`` is ``0, 1 or None`` (:issue:`39359`)
 - :meth:`.Styler.apply` and :meth:`.Styler.applymap` now raise errors if wrong format CSS is passed on render (:issue:`39660`)
 - :meth:`.Styler.format` adds keyword argument ``escape`` for optional HTML escaping (:issue:`40437`)
+- :meth:`.Styler.clear` now clears :attr:`Styler.hidden_index` and :attr:`Styler.hidden_columns` as well (:issue:`40484`)
 - Builtin highlighting methods in :class:`Styler` have a more consistent signature and css customisability (:issue:`40242`)
 - :meth:`Series.loc.__getitem__` and :meth:`Series.loc.__setitem__` with :class:`MultiIndex` now raising helpful error message when indexer has too many dimensions (:issue:`35349`)
 - :meth:`pandas.read_stata` and :class:`StataReader` support reading data from compressed files.
@@ -346,6 +396,38 @@ cast to ``dtype=object`` (:issue:`38709`)
    ser2
 
 
+.. _whatsnew_130.notable_bug_fixes.rolling_groupby_column:
+
+GroupBy.rolling no longer returns grouped-by column in values
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The group-by column will now be dropped from the result of a
+``groupby.rolling`` operation (:issue:`32262`)
+
+.. ipython:: python
+
+    df = pd.DataFrame({"A": [1, 1, 2, 3], "B": [0, 1, 2, 3]})
+    df
+
+*Previous behavior*:
+
+.. code-block:: ipython
+
+    In [1]: df.groupby("A").rolling(2).sum()
+    Out[1]:
+           A    B
+    A
+    1 0  NaN  NaN
+    1    2.0  1.0
+    2 2  NaN  NaN
+    3 3  NaN  NaN
+
+*New behavior*:
+
+.. ipython:: python
+
+    df.groupby("A").rolling(2).sum()
+
 .. _whatsnew_130.notable_bug_fixes.rolling_var_precision:
 
 Removed artificial truncation in rolling variance and standard deviation
@@ -467,7 +549,7 @@ Deprecations
 - Using ``.astype`` to convert between ``datetime64[ns]`` dtype and :class:`DatetimeTZDtype` is deprecated and will raise in a future version, use ``obj.tz_localize`` or ``obj.dt.tz_localize`` instead (:issue:`38622`)
 - Deprecated casting ``datetime.date`` objects to ``datetime64`` when used as ``fill_value`` in :meth:`DataFrame.unstack`, :meth:`DataFrame.shift`, :meth:`Series.shift`, and :meth:`DataFrame.reindex`, pass ``pd.Timestamp(dateobj)`` instead (:issue:`39767`)
 - Deprecated :meth:`.Styler.set_na_rep` and :meth:`.Styler.set_precision` in favour of :meth:`.Styler.format` with ``na_rep`` and ``precision`` as existing and new input arguments respectively (:issue:`40134`, :issue:`40425`)
-- Deprecated allowing partial failure in :meth:`Series.transform` and :meth:`DataFrame.transform` when ``func`` is list-like or dict-like; will raise if any function fails on a column in a future version (:issue:`40211`)
+- Deprecated allowing partial failure in :meth:`Series.transform` and :meth:`DataFrame.transform` when ``func`` is list-like or dict-like and raises anything but ``TypeError``; ``func`` raising anything but a ``TypeError`` will raise in a future version (:issue:`40211`)
 - Deprecated support for ``np.ma.mrecords.MaskedRecords`` in the :class:`DataFrame` constructor, pass ``{name: data[name] for name in data.dtype.names}`` instead (:issue:`40363`)
 - Deprecated the use of ``**kwargs`` in :class:`.ExcelWriter`; use the keyword argument ``engine_kwargs`` instead (:issue:`40430`)
 
@@ -545,9 +627,11 @@ Numeric
 - Bug in :meth:`DataFrame.mode` and :meth:`Series.mode` not keeping consistent integer :class:`Index` for empty input (:issue:`33321`)
 - Bug in :meth:`DataFrame.rank` with ``np.inf`` and mixture of ``np.nan`` and ``np.inf`` (:issue:`32593`)
 - Bug in :meth:`DataFrame.rank` with ``axis=0`` and columns holding incomparable types raising ``IndexError`` (:issue:`38932`)
+- Bug in ``rank`` method for :class:`Series`, :class:`DataFrame`, :class:`DataFrameGroupBy`, and :class:`SeriesGroupBy` treating the most negative ``int64`` value as missing (:issue:`32859`)
 - Bug in :func:`select_dtypes` different behavior between Windows and Linux with ``include="int"`` (:issue:`36569`)
 - Bug in :meth:`DataFrame.apply` and :meth:`DataFrame.agg` when passed argument ``func="size"`` would operate on the entire ``DataFrame`` instead of rows or columns (:issue:`39934`)
 - Bug in :meth:`DataFrame.transform` would raise ``SpecificationError`` when passed a dictionary and columns were missing; will now raise a ``KeyError`` instead (:issue:`40004`)
+- Bug in :meth:`DataFrameGroupBy.rank` giving incorrect results with ``pct=True`` and equal values between consecutive groups (:issue:`40518`)
 -
 
 Conversion
@@ -557,6 +641,9 @@ Conversion
 - Bug in creating a :class:`DataFrame` from an empty ``np.recarray`` not retaining the original dtypes (:issue:`40121`)
 - Bug in :class:`DataFrame` failing to raise ``TypeError`` when constructing from a ``frozenset`` (:issue:`40163`)
 - Bug in :class:`Index` construction silently ignoring a passed ``dtype`` when the data cannot be cast to that dtype (:issue:`21311`)
+- Bug in :meth:`StringArray.astype` falling back to numpy and raising when converting to ``dtype='categorical'`` (:issue:`40450`)
+- Bug in :class:`DataFrame` construction with a dictionary containing an arraylike with ``ExtensionDtype`` and ``copy=True`` failing to make a copy (:issue:`38939`)
+-
 
 Strings
 ^^^^^^^
@@ -695,6 +782,7 @@ Reshaping
 - Allow :class:`Index` to be passed to the :func:`numpy.all` function (:issue:`40180`)
 - Bug in :meth:`DataFrame.stack` not preserving ``CategoricalDtype`` in a ``MultiIndex`` (:issue:`36991`)
 - Bug in :func:`to_datetime` raising error when input sequence contains unhashable items (:issue:`39756`)
+- Bug in :meth:`Series.explode` preserving index when ``ignore_index`` was ``True`` and values were scalars (:issue:`40487`)
 
 Sparse
 ^^^^^^

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -122,27 +122,30 @@ Example Usage:
 
 .. code-block:: python
 
-   import asyncio
-   from sqlalchemy.ext.asyncio import create_async_engine
+    import asyncio
+    from sqlalchemy.ext.asyncio import create_async_engine
 
-   engine = create_async_engine('postgresql+asyncpg://anakin:skywalker@localhost/test')
+    engine = create_async_engine('postgresql+asyncpg://anakin:skywalker@localhost/test')
 
-   async def sql_operations():
-    # Accessing a table with the AsyncEngine
-    umbara = await pd.read_sql('umbara', engine)
-    # Can alternatively be written as: await pd.read_sql_table('umbara', engine)
+    async def sql_operations():
+        # Accessing a table with the AsyncEngine
+        umbara = await pd.read_sql('umbara', engine)
+        # Can alternatively be written as: await pd.read_sql_table('umbara', engine)
 
-    # Using an SQL query with the AsyncConnection
-    async with engine.connect() as conn:
-        seasons = await pd.read_sql_query('SELECT season6, season5, season7 FROM clonewars', conn)
+        # Using an SQL query with the AsyncConnection
+        async with engine.connect() as conn:
+            seasons = await pd.read_sql_query(
+                'SELECT season6, season5, season7 FROM clonewars',
+                conn
+            )
 
-    favs = pd.DataFrame({
-        'FirstName': ['Mace', 'Obi-Wan', 'Ahsoka'],
-        'LastName': ['Windu', 'Kenobi', 'Tano']
-    })
+        favs = pd.DataFrame({
+            'FirstName': ['Mace', 'Obi-Wan', 'Ahsoka'],
+            'LastName': ['Windu', 'Kenobi', 'Tano']
+        })
 
-    # Writing data with the AsyncEngine
-    await favs.to_sql('jedi', engine)
+        # Writing data with the AsyncEngine
+        await favs.to_sql('jedi', engine)
 
     asyncio.run(sql_operations())
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2889,7 +2889,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         """
         from pandas.io import sql
 
-        sql.to_sql(
+        return sql.to_sql(
             self,
             name,
             con,

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1378,12 +1378,10 @@ class AsyncSQLTable(SQLTable):
     async def _execute_create(self):
         metadata = await self.pd_sql.metadata
         self.table = self.table.to_metadata(metadata)
-        print(metadata.tables)
         async with self.pd_sql.engine.begin() as conn:
             await conn.run_sync(self.table.create)
 
     async def create(self):
-        print('create is being called!')
         if await self.exists():
             if self.if_exists == "fail":
                 raise ValueError(f"Table '{self.name}' already exists.")
@@ -1395,7 +1393,6 @@ class AsyncSQLTable(SQLTable):
             else:
                 raise ValueError(f"'{self.if_exists}' is not valid for if_exists")
         else:
-            print('table not detected!')
             await self._execute_create()
 
     async def _execute_insert(self, conn, keys: List[str], data_iter):

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1914,13 +1914,13 @@ class AsyncSQLDatabase(SQLDatabase):
         else:
             self.engine = connectable.engine
 
+        self.schema = schema
+
         self._tables_added = False
 
         if meta:
             self._metadata = meta
             self._tables_added = True
-
-        self.schema = schema or (await self.metadata).schema
 
     async def execute(self, *args, **kwargs):
         async with self.engine.connect() as conn:
@@ -1940,18 +1940,18 @@ class AsyncSQLDatabase(SQLDatabase):
         return self._metadata
 
     async def has_table(self, table_name: str, schema: Optional[str] = None):
-        schema = schema or self.schema
+        # TODO: Change schema to schema or self.schema
         async with self.engine.connect() as conn:
             return await conn.run_sync(conn.dialect.has_table, table_name, schema)
 
     async def get_table(self, table_name: str, schema: Optional[str] = None):
-        schema = schema or self.schema
+        # TODO: Change schema to schema or self.schema
         return (await self.metadata).tables.get(
             ".".join([schema, table_name]) if schema else table_name
         )
 
     async def drop_table(self, table_name: str, schema: Optional[str] = None):
-        schema = schema or self.schema
+        schema = schema or self.meta.schema
         if await self.has_table(table_name, schema):
             table = self.get_table(table_name, schema)
             (await self.metadata).remove(table)

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -997,8 +997,7 @@ class SQLTable(PandasObject):
 
                 yield self.frame
 
-    def read(self, coerce_float=True, parse_dates=None, columns=None, chunksize=None):
-
+    def _selector_from_columns(self, columns):
         if columns is not None and len(columns) > 0:
             from sqlalchemy import select
 
@@ -1009,7 +1008,11 @@ class SQLTable(PandasObject):
             sql_select = select(cols)
         else:
             sql_select = self.table.select()
+        
+        return sql_select
 
+    def read(self, coerce_float=True, parse_dates=None, columns=None, chunksize=None):
+        sql_select = self._selector_from_columns(columns)
         result = self.pd_sql.execute(sql_select)
         column_names = result.keys()
 

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1787,6 +1787,22 @@ class AsyncSQLDatabase(SQLDatabase):
     async def get_table(self, table_name: str, schema: Optional[str] = None):
         return (await self.metadata).tables.get(".".join([schema, table_name]) \
                                                 if schema else table_name)
+    
+    async def read_table(self,
+                         table_name: str,
+                         index_col: Optional[Union[str, Sequence[str]]] = None,
+                         coerce_float: bool = True,
+                         parse_dates=None,
+                         columns=None,
+                         schema: Optional[str] = None,
+                         chunksize: Optional[int] = None):
+        table = await AsyncSQLTable(table_name, self, index=index_col, schema=schema)
+        return await table.read(
+            coerce_float=coerce_float,
+            parse_dates=parse_dates,
+            columns=columns,
+            chunksize=chunksize,
+        )
 
 
 # ---- SQL without SQLAlchemy ---

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1804,6 +1804,26 @@ class AsyncSQLDatabase(SQLDatabase):
             chunksize=chunksize,
         )
 
+    async def read_query(self,
+                         sql: str,
+                         index_col: Optional[str] = None,
+                         coerce_float: bool = True,
+                         parse_dates=None,
+                         params=None,
+                         chunksize: Optional[int] = None,
+                         dtype: Optional[DtypeArg] = None):
+        from sqlalchemy import text
+
+        result = await self.execute(text(sql), parameters=params)
+
+        return self._convert_result_to_df(result,
+                                          index_col=index_col,
+                                          coerce_float=coerce_float,
+                                          parse_dates=parse_dates,
+                                          params=params,
+                                          chunksize=chunksize,
+                                          dtype=dtype)
+
 
 # ---- SQL without SQLAlchemy ---
 # sqlite-specific sql strings and handler class

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -87,7 +87,7 @@ def _is_async_sqlalchemy_connectable(con):
         try:
             from sqlalchemy.ext.asyncio import (
                 AsyncEngine,
-                AsyncConnection
+                AsyncConnection,
             )
 
             return isinstance(con, (AsyncEngine, AsyncConnection))
@@ -362,7 +362,7 @@ def read_sql_table(
                 coerce_float=coerce_float,
                 parse_dates=parse_dates,
                 columns=columns,
-                chunksize=chunksize
+                chunksize=chunksize,
             )
 
             if table is not None:
@@ -1115,7 +1115,7 @@ class SQLTable(PandasObject):
             result,
             coerce_float=coerce_float,
             parse_dates=parse_dates,
-            chunksize=chunksize
+            chunksize=chunksize,
         )
 
     def _index_name(self, index, index_label):
@@ -1377,7 +1377,7 @@ class AsyncSQLTable(SQLTable):
             result,
             coerce_float=coerce_float,
             parse_dates=parse_dates,
-            chunksize=chunksize
+            chunksize=chunksize,
         )
 
     async def exists(self):
@@ -1412,9 +1412,7 @@ class AsyncSQLTable(SQLTable):
         await conn.execute(self.table.insert().values(data))
 
     async def insert(
-        self,
-        chunksize: Optional[int] = None,
-        method: Optional[str] = None
+        self, chunksize: Optional[int] = None, method: Optional[str] = None
     ):
         exec_insert = self._get_insertion_method(method)
 
@@ -1605,7 +1603,7 @@ class SQLDatabase(PandasSQL):
         parse_dates=None,
         params=None,
         chunksize: Optional[int] = None,
-        dtype: Optional[DtypeArg] = None
+        dtype: Optional[DtypeArg] = None,
     ):
         columns = result.keys()
 
@@ -1696,7 +1694,7 @@ class SQLDatabase(PandasSQL):
             parse_dates=parse_dates,
             params=params,
             chunksize=chunksize,
-            dtype=dtype
+            dtype=dtype,
         )
 
     read_sql = read_query
@@ -1902,8 +1900,8 @@ class SQLDatabase(PandasSQL):
 class AsyncSQLDatabase(SQLDatabase):
     def __init__(self, connectable, schema: Optional[str] = None, meta=None):
         from sqlalchemy.ext.asyncio import (
+            AsyncConnection,
             AsyncEngine,
-            AsyncConnection
         )
 
         if not isinstance(connectable, (AsyncEngine, AsyncConnection)):
@@ -1968,7 +1966,7 @@ class AsyncSQLDatabase(SQLDatabase):
         parse_dates=None,
         columns=None,
         schema: Optional[str] = None,
-        chunksize: Optional[int] = None
+        chunksize: Optional[int] = None,
     ):
         table = await AsyncSQLTable(table_name, self, index=index_col, schema=schema)
         return await table.read(
@@ -1986,7 +1984,7 @@ class AsyncSQLDatabase(SQLDatabase):
         parse_dates=None,
         params=None,
         chunksize: Optional[int] = None,
-        dtype: Optional[DtypeArg] = None
+        dtype: Optional[DtypeArg] = None,
     ):
         from sqlalchemy import text
 
@@ -1999,7 +1997,7 @@ class AsyncSQLDatabase(SQLDatabase):
             parse_dates=parse_dates,
             params=params,
             chunksize=chunksize,
-            dtype=dtype
+            dtype=dtype,
         )
 
     async def to_sql(
@@ -2012,7 +2010,7 @@ class AsyncSQLDatabase(SQLDatabase):
         schema=None,
         chunksize=None,
         dtype: Optional[DtypeArg] = None,
-        method=None
+        method=None,
     ):
         dtype = self._check_dtype(frame, dtype)
 
@@ -2024,7 +2022,7 @@ class AsyncSQLDatabase(SQLDatabase):
             if_exists=if_exists,
             index_label=index_label,
             schema=schema,
-            dtype=dtype
+            dtype=dtype,
         )
         await table.create()
 

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1281,6 +1281,25 @@ class SQLTable(PandasObject):
         return object
 
 
+class AsyncSQLTable(SQLTable):
+    async def __async_init__(self):
+        self.table = await self.table
+        return self
+    
+    def __await__(self):
+        return self.__async_init__().__await__()
+    
+    async def read(self, coerce_float=True, parse_dates=None, columns=None, chunksize=None):
+        sql_select = self._selector_from_columns(columns)
+
+        result = await self.pd_sql.execute(sql_select)
+
+        return self._create_df_from_result(result,
+                                           coerce_float=coerce_float,
+                                           parse_dates=parse_dates,
+                                           chunksize=chunksize)
+
+
 class PandasSQL(PandasObject):
     """
     Subclasses Should define read_sql and to_sql.

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1998,7 +1998,6 @@ class AsyncSQLDatabase(SQLDatabase):
         if not name.isdigit() and not name.islower():
             if await self.has_table(name):
                 self._warn_table_name_mismatch()
-        
 
 
 # ---- SQL without SQLAlchemy ---

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1732,7 +1732,7 @@ class SQLDatabase(PandasSQL):
                 raise err
 
     @staticmethod
-    def _warn_table_name_mismatch():
+    def _warn_table_name_mismatch(name):
         msg = (
             f"The provided table name '{name}' is not found exactly as "
             "such in the database after writing the table, possibly "
@@ -1828,7 +1828,7 @@ class SQLDatabase(PandasSQL):
                         schema=schema or self.meta.schema, connection=conn
                     )
             if name not in table_names:
-                self._warn_table_name_mismatch()
+                self._warn_table_name_mismatch(name)
 
     @property
     def tables(self):
@@ -2006,7 +2006,7 @@ class AsyncSQLDatabase(SQLDatabase):
 
         if not name.isdigit() and not name.islower():
             if await self.has_table(name):
-                self._warn_table_name_mismatch()
+                self._warn_table_name_mismatch(name)
 
 
 # ---- SQL without SQLAlchemy ---

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -85,7 +85,11 @@ def _is_async_sqlalchemy_connectable(con):
     _is_sqlalchemy_connectable(con)
     if _SQLALCHEMY_INSTALLED:
         try:
-            from sqlalchemy.ext.asyncio import AsyncEngine, AsyncConnection
+            from sqlalchemy.ext.asyncio import (
+                AsyncEngine,
+                AsyncConnection
+            )
+
             return isinstance(con, (AsyncEngine, AsyncConnection))
         except ModuleNotFoundError:
             return False
@@ -352,12 +356,15 @@ def read_sql_table(
             async with pandas_sql.engine.connect() as conn:
                 await conn.run_sync(metadata.reflect, views=True, only=[table_name])
             pandas_sql._metadata = metadata
-            table = await pandas_sql.read_table(table_name,
-                                                index_col=index_col,
-                                                coerce_float=coerce_float,
-                                                parse_dates=parse_dates,
-                                                columns=columns,
-                                                chunksize=chunksize)
+            table = await pandas_sql.read_table(
+                table_name,
+                index_col=index_col,
+                coerce_float=coerce_float,
+                parse_dates=parse_dates,
+                columns=columns,
+                chunksize=chunksize
+            )
+
             if table is not None:
                 return table
             else:
@@ -1075,11 +1082,9 @@ class SQLTable(PandasObject):
 
         return sql_select
 
-    def _create_df_from_result(self,
-                               result,
-                               coerce_float=True,
-                               parse_dates=None,
-                               chunksize=None):
+    def _create_df_from_result(
+        self, result, coerce_float=True, parse_dates=None, chunksize=None
+    ):
         column_names = result.keys()
 
         if chunksize is not None:
@@ -1106,10 +1111,12 @@ class SQLTable(PandasObject):
     def read(self, coerce_float=True, parse_dates=None, columns=None, chunksize=None):
         sql_select = self._selector_from_columns(columns)
         result = self.pd_sql.execute(sql_select)
-        return self._create_df_from_result(result,
-                                           coerce_float=coerce_float,
-                                           parse_dates=parse_dates,
-                                           chunksize=chunksize)
+        return self._create_df_from_result(
+            result,
+            coerce_float=coerce_float,
+            parse_dates=parse_dates,
+            chunksize=chunksize
+        )
 
     def _index_name(self, index, index_label):
         # for writing: index=True to include index in sql table
@@ -1189,7 +1196,7 @@ class SQLTable(PandasObject):
             schema = self.schema or self.pd_sql.meta.schema
         else:
             # This should never be triggered
-            raise TypeError('self is somehow not a SQLTable or AsyncSQLTable')
+            raise TypeError("self is somehow not a SQLTable or AsyncSQLTable")
 
         # At this point, attach to new metadata, only attach to self.meta
         # once table is created.
@@ -1359,18 +1366,19 @@ class AsyncSQLTable(SQLTable):
     def __await__(self):
         return self.__async_init__().__await__()
 
-    async def read(self, coerce_float=True,
-                   parse_dates=None,
-                   columns=None,
-                   chunksize=None):
+    async def read(
+        self, coerce_float=True, parse_dates=None, columns=None, chunksize=None
+    ):
         sql_select = self._selector_from_columns(columns)
 
         result = await self.pd_sql.execute(sql_select)
 
-        return self._create_df_from_result(result,
-                                           coerce_float=coerce_float,
-                                           parse_dates=parse_dates,
-                                           chunksize=chunksize)
+        return self._create_df_from_result(
+            result,
+            coerce_float=coerce_float,
+            parse_dates=parse_dates,
+            chunksize=chunksize
+        )
 
     async def exists(self):
         return await self.pd_sql.has_table(self.name, self.schema)
@@ -1403,9 +1411,11 @@ class AsyncSQLTable(SQLTable):
         data = [dict(zip(keys, row)) for row in data_iter]
         await conn.execute(self.table.insert().values(data))
 
-    async def insert(self,
-                     chunksize: Optional[int] = None,
-                     method: Optional[str] = None):
+    async def insert(
+        self,
+        chunksize: Optional[int] = None,
+        method: Optional[str] = None
+    ):
         exec_insert = self._get_insertion_method(method)
 
         keys, data_list = self.insert_data()
@@ -1587,14 +1597,16 @@ class SQLDatabase(PandasSQL):
                     dtype=dtype,
                 )
 
-    def _convert_result_to_df(self,
-                              result,
-                              index_col: Optional[str] = None,
-                              coerce_float: bool = True,
-                              parse_dates=None,
-                              params=None,
-                              chunksize: Optional[int] = None,
-                              dtype: Optional[DtypeArg] = None):
+    def _convert_result_to_df(
+        self,
+        result,
+        index_col: Optional[str] = None,
+        coerce_float: bool = True,
+        parse_dates=None,
+        params=None,
+        chunksize: Optional[int] = None,
+        dtype: Optional[DtypeArg] = None
+    ):
         columns = result.keys()
 
         if chunksize is not None:
@@ -1677,13 +1689,15 @@ class SQLDatabase(PandasSQL):
         """
         args = _convert_params(sql, params)
         result = self.execute(*args)
-        return self._convert_result_to_df(result,
-                                          index_col=index_col,
-                                          coerce_float=coerce_float,
-                                          parse_dates=parse_dates,
-                                          params=params,
-                                          chunksize=chunksize,
-                                          dtype=dtype)
+        return self._convert_result_to_df(
+            result,
+            index_col=index_col,
+            coerce_float=coerce_float,
+            parse_dates=parse_dates,
+            params=params,
+            chunksize=chunksize,
+            dtype=dtype
+        )
 
     read_sql = read_query
 
@@ -1887,11 +1901,16 @@ class SQLDatabase(PandasSQL):
 
 class AsyncSQLDatabase(SQLDatabase):
     def __init__(self, connectable, schema: Optional[str] = None, meta=None):
-        from sqlalchemy.ext.asyncio import AsyncEngine, AsyncConnection
+        from sqlalchemy.ext.asyncio import (
+            AsyncEngine,
+            AsyncConnection
+        )
 
         if not isinstance(connectable, (AsyncEngine, AsyncConnection)):
-            raise TypeError(('connectable argument must be an AsyncEngine '
-                            f'or an AsyncConnection, not {type(connectable)!r}'))
+            raise TypeError(
+                "connectable argument must be an AsyncEngine "
+                f"or an AsyncConnection, not {type(connectable)!r}"
+            )
         if isinstance(connectable, AsyncEngine):
             self.engine = connectable
         else:
@@ -1911,7 +1930,7 @@ class AsyncSQLDatabase(SQLDatabase):
 
     @property
     async def metadata(self):
-        if not hasattr(self, '_metadata'):
+        if not hasattr(self, "_metadata"):
             from sqlalchemy.schema import MetaData
             self._metadata = MetaData()
 
@@ -1929,8 +1948,9 @@ class AsyncSQLDatabase(SQLDatabase):
 
     async def get_table(self, table_name: str, schema: Optional[str] = None):
         # TODO: Change schema to schema or self.schema
-        return (await self.metadata).tables.get(".".join([schema, table_name])
-                                                if schema else table_name)
+        return (await self.metadata).tables.get(
+            ".".join([schema, table_name]) if schema else table_name
+        )
 
     async def drop_table(self, table_name: str, schema: Optional[str] = None):
         schema = schema or self.meta.schema
@@ -1940,14 +1960,16 @@ class AsyncSQLDatabase(SQLDatabase):
             async with self.engine.connect() as conn:
                 await conn.run_sync(table.drop, conn)
 
-    async def read_table(self,
-                         table_name: str,
-                         index_col: Optional[Union[str, Sequence[str]]] = None,
-                         coerce_float: bool = True,
-                         parse_dates=None,
-                         columns=None,
-                         schema: Optional[str] = None,
-                         chunksize: Optional[int] = None):
+    async def read_table(
+        self,
+        table_name: str,
+        index_col: Optional[Union[str, Sequence[str]]] = None,
+        coerce_float: bool = True,
+        parse_dates=None,
+        columns=None,
+        schema: Optional[str] = None,
+        chunksize: Optional[int] = None
+    ):
         table = await AsyncSQLTable(table_name, self, index=index_col, schema=schema)
         return await table.read(
             coerce_float=coerce_float,
@@ -1956,46 +1978,54 @@ class AsyncSQLDatabase(SQLDatabase):
             chunksize=chunksize,
         )
 
-    async def read_query(self,
-                         sql: str,
-                         index_col: Optional[str] = None,
-                         coerce_float: bool = True,
-                         parse_dates=None,
-                         params=None,
-                         chunksize: Optional[int] = None,
-                         dtype: Optional[DtypeArg] = None):
+    async def read_query(
+        self,
+        sql: str,
+        index_col: Optional[str] = None,
+        coerce_float: bool = True,
+        parse_dates=None,
+        params=None,
+        chunksize: Optional[int] = None,
+        dtype: Optional[DtypeArg] = None
+    ):
         from sqlalchemy import text
 
         result = await self.execute(text(sql), parameters=params)
 
-        return self._convert_result_to_df(result,
-                                          index_col=index_col,
-                                          coerce_float=coerce_float,
-                                          parse_dates=parse_dates,
-                                          params=params,
-                                          chunksize=chunksize,
-                                          dtype=dtype)
+        return self._convert_result_to_df(
+            result,
+            index_col=index_col,
+            coerce_float=coerce_float,
+            parse_dates=parse_dates,
+            params=params,
+           chunksize=chunksize,
+           dtype=dtype
+        )
 
-    async def to_sql(self,
-                     frame,
-                     name,
-                     if_exists="fail",
-                     index=True,
-                     index_label=None,
-                     schema=None,
-                     chunksize=None,
-                     dtype: Optional[DtypeArg] = None,
-                     method=None):
+    async def to_sql(
+        self,
+        frame,
+        name,
+        if_exists="fail",
+        index=True,
+        index_label=None,
+        schema=None,
+        chunksize=None,
+        dtype: Optional[DtypeArg] = None,
+        method=None
+    ):
         dtype = self._check_dtype(frame, dtype)
 
-        table = AsyncSQLTable(name,
-                              self,
-                              frame=frame,
-                              index=index,
-                              if_exists=if_exists,
-                              index_label=index_label,
-                              schema=schema,
-                              dtype=dtype)
+        table = AsyncSQLTable(
+            name,
+            self,
+            frame=frame,
+            index=index,
+            if_exists=if_exists,
+            index_label=index_label,
+            schema=schema,
+            dtype=dtype
+        )
         await table.create()
 
         with self._my_sql_error():

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -77,6 +77,18 @@ def _is_sqlalchemy_connectable(con):
     else:
         return False
 
+def _is_async_sqlalchemy_connectable(con):
+    # NOTE: Call to _is_sqlalchemy_connectable
+    # is to initialize _SQLALCHEMY_INSTALLED
+    # global variable
+    _is_sqlalchemy_connectable(con)
+    if _SQLALCHEMY_INSTALLED:
+        try:
+            from sqlalchemy.ext.asyncio import AsyncEngine, AsyncConnection
+            return isinstance(con, (AsyncEngine, AsyncConnection))
+        except ModuleNotFoundError:
+            return False 
+    return False
 
 def _gt14() -> bool:
     """

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -618,6 +618,29 @@ def read_sql(
             parse_dates=parse_dates,
             chunksize=chunksize,
         )
+    
+    if isinstance(pandas_sql, AsyncSQLDatabase):
+        async def read_sql():
+            if await pandas_sql.has_table(sql):
+                return await pandas_sql.read_table(
+                    sql,
+                    index_col=index_col,
+                    coerce_float=coerce_float,
+                    parse_dates=parse_dates,
+                    columns=columns,
+                    chunksize=chunksize,
+                )
+            else:
+                return await pandas_sql.read_query(
+                    sql,
+                    index_col=index_col,
+                    params=params,
+                    coerce_float=coerce_float,
+                    parse_dates=parse_dates,
+                    chunksize=chunksize,
+                )
+        
+        return read_sql()
 
     try:
         _is_table_name = pandas_sql.has_table(sql)

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1916,13 +1916,13 @@ class AsyncSQLDatabase(SQLDatabase):
         else:
             self.engine = connectable.engine
 
-        self.schema = schema
-
         self._tables_added = False
 
         if meta:
             self._metadata = meta
             self._tables_added = True
+
+        self.schema = schema or (await self.metadata).schema
 
     async def execute(self, *args, **kwargs):
         async with self.engine.connect() as conn:
@@ -1942,18 +1942,18 @@ class AsyncSQLDatabase(SQLDatabase):
         return self._metadata
 
     async def has_table(self, table_name: str, schema: Optional[str] = None):
-        # TODO: Change schema to schema or self.schema
+        schema = schema or self.schema
         async with self.engine.connect() as conn:
             return await conn.run_sync(conn.dialect.has_table, table_name, schema)
 
     async def get_table(self, table_name: str, schema: Optional[str] = None):
-        # TODO: Change schema to schema or self.schema
+        schema = schema or self.schema
         return (await self.metadata).tables.get(
             ".".join([schema, table_name]) if schema else table_name
         )
 
     async def drop_table(self, table_name: str, schema: Optional[str] = None):
-        schema = schema or self.meta.schema
+        schema = schema or self.schema
         if await self.has_table(table_name, schema):
             table = self.get_table(table_name, schema)
             (await self.metadata).remove(table)

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1951,9 +1951,9 @@ class AsyncSQLDatabase(SQLDatabase):
         )
 
     async def drop_table(self, table_name: str, schema: Optional[str] = None):
-        schema = schema or self.meta.schema
+        schema = schema or self.schema
         if await self.has_table(table_name, schema):
-            table = self.get_table(table_name, schema)
+            table = await self.get_table(table_name, schema)
             (await self.metadata).remove(table)
             async with self.engine.connect() as conn:
                 await conn.run_sync(table.drop, conn)

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1998,8 +1998,8 @@ class AsyncSQLDatabase(SQLDatabase):
             coerce_float=coerce_float,
             parse_dates=parse_dates,
             params=params,
-           chunksize=chunksize,
-           dtype=dtype
+            chunksize=chunksize,
+            dtype=dtype
         )
 
     async def to_sql(

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -86,14 +86,15 @@ def _is_async_sqlalchemy_connectable(con):
     if _SQLALCHEMY_INSTALLED:
         try:
             from sqlalchemy.ext.asyncio import (
-                AsyncEngine,
                 AsyncConnection,
+                AsyncEngine,
             )
 
             return isinstance(con, (AsyncEngine, AsyncConnection))
         except ModuleNotFoundError:
             return False
     return False
+
 
 def _gt14() -> bool:
     """
@@ -350,6 +351,7 @@ def read_sql_table(
         else:
             raise ValueError(f"Table {table_name} not found", con)
     elif _is_async_sqlalchemy_connectable(con):
+
         async def read_table():
             metadata = MetaData()
             pandas_sql = AsyncSQLDatabase(con)
@@ -369,6 +371,7 @@ def read_sql_table(
                 return table
             else:
                 raise ValueError(f"Table {table_name} not found", con)
+
         return read_table()
     else:
         raise NotImplementedError(
@@ -1930,6 +1933,7 @@ class AsyncSQLDatabase(SQLDatabase):
     async def metadata(self):
         if not hasattr(self, "_metadata"):
             from sqlalchemy.schema import MetaData
+
             self._metadata = MetaData()
 
         if not self._tables_added:

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -788,6 +788,8 @@ def pandasSQL_builder(
         return SQLDatabase(con, schema=schema, meta=meta)
     elif isinstance(con, str):
         raise ImportError("Using URI string without sqlalchemy installed.")
+    elif _is_async_sqlalchemy_connectable(con):
+        return AsyncSQLDatabase(con, schema=schema, meta=meta)
     else:
         return SQLiteDatabase(con, is_cursor=is_cursor)
 

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1010,10 +1010,12 @@ class SQLTable(PandasObject):
             sql_select = self.table.select()
         
         return sql_select
-
-    def read(self, coerce_float=True, parse_dates=None, columns=None, chunksize=None):
-        sql_select = self._selector_from_columns(columns)
-        result = self.pd_sql.execute(sql_select)
+    
+    def _create_df_from_result(self,
+                               result,
+                               coerce_float=True,
+                               parse_dates=None,
+                               chunksize=None):
         column_names = result.keys()
 
         if chunksize is not None:
@@ -1036,6 +1038,14 @@ class SQLTable(PandasObject):
                 self.frame.set_index(self.index, inplace=True)
 
             return self.frame
+
+    def read(self, coerce_float=True, parse_dates=None, columns=None, chunksize=None):
+        sql_select = self._selector_from_columns(columns)
+        result = self.pd_sql.execute(sql_select)
+        return self._create_df_from_result(result,
+                                           coerce_float=coerce_float,
+                                           parse_dates=parse_dates,
+                                           chunksize=chunksize)
 
     def _index_name(self, index, index_label):
         # for writing: index=True to include index in sql table

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -651,6 +651,7 @@ def read_sql(
         )
 
     if isinstance(pandas_sql, AsyncSQLDatabase):
+
         async def read_sql():
             if await pandas_sql.has_table(sql):
                 return await pandas_sql.read_table(

--- a/pandas/tests/io/conftest.py
+++ b/pandas/tests/io/conftest.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import shlex
@@ -10,6 +11,9 @@ import pandas._testing as tm
 
 from pandas.io.parsers import read_csv
 
+@pytest.fixture(scope="class")
+def event_loop():
+    return asyncio.get_event_loop()
 
 @pytest.fixture
 def tips_file(datapath):

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -2814,7 +2814,7 @@ class TestAsyncSQLiteAlchemy(_TestSQLiteAlchemy, _TestAsyncSQLAlchemy, metaclass
     unique_tests_for_conversion = ("test_bigint_warning",)
 
     @pytest.fixture(scope="class")
-    async def engine(cls):
+    def engine(cls):
         return create_async_engine(f"sqlite+{cls.driver}:///")
 
     @pytest.fixture(scope="class")


### PR DESCRIPTION
[`pandas.read_sql`](https://pandas.pydata.org/pandas-docs/dev/reference/api/pandas.read_sql.html#pandas.read_sql), [`pandas.read_sql_query`](https://pandas.pydata.org/pandas-docs/dev/reference/api/pandas.read_sql_query.html#pandas.read_sql_query), [`pandas.read_sql_table`](https://pandas.pydata.org/pandas-docs/dev/reference/api/pandas.read_sql_table.html#pandas.read_sql_table), [`DataFrame.to_sql`](https://pandas.pydata.org/pandas-docs/dev/reference/api/pandas.DataFrame.to_sql.html#pandas.DataFrame.to_sql), and [`Series.to_sql`](https://pandas.pydata.org/pandas-docs/dev/reference/api/pandas.Series.to_sql.html#pandas.Series.to_sql) can now accept an [`AsyncEngine`](https://docs.sqlalchemy.org/en/latest/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.AsyncEngine) or an [`AsyncConnection`](https://docs.sqlalchemy.org/en/latest/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.AsyncConnection) as a valid argument to `con`.

Example Usage:

```py
import asyncio
from sqlalchemy.ext.asyncio import create_async_engine

engine = create_async_engine('postgresql+asyncpg://anakin:skywalker@localhost/test')

async def sql_operations():
  # Accessing a table with the AsyncEngine
  umbara = await pd.read_sql('umbara', engine)
  # Can alternatively be written as: await pd.read_sql_table('umbara', engine)

  # Using an SQL query with the AsyncConnection
  async with engine.connect() as conn:
     seasons = await pd.read_sql_query('SELECT season6, season5, season7 FROM clonewars', conn)
  
  favs = pd.DataFrame({
     'FirstName': ['Mace', 'Obi-Wan', 'Ahsoka'],
     'LastName': ['Windu', 'Kenobi', 'Tano']
  })
  
  # Writing data with the AsyncEngine
  await favs.to_sql('jedi', engine)

asyncio.run(sql_operations())
```

# Check list
- [x] tests added / passed (found a way to do this efficiently and relatively easily, will be pushing soon!)
- [X] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [X] whatsnew entry

# Issue with unit tests
So unfortunately, as far as I can tell, creating unit tests will require that all the current unit tests for the SQL functions/methods will need to be rewritten, since every time the SQL functions/methods are invoked they need to be awaited.  One kind of unique idea I have is to read the source code of the existing test functions and add the word `await` whenever one of the SQL functions/methods is called and the use `exec` function to create the new `asyncio` version of the function.  Or perhaps there is a better approach I am not familiar with to avoid having to completely rewrite the unit tests for these new use cases.  I'm open to any ideas!

Thank you for considering my proposal! ♥