### PR TITLE
REGR: missing vals not replaceable in categorical

### DIFF
--- a/doc/source/whatsnew/v1.2.4.rst
+++ b/doc/source/whatsnew/v1.2.4.rst
@@ -19,6 +19,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.to_json` raising ``AttributeError`` when run on PyPy (:issue:`39837`)
 - Fixed regression in :meth:`DataFrame.where` not returning a copy in the case of an all True condition (:issue:`39595`)
 - Fixed regression in :meth:`DataFrame.replace` raising ``IndexError`` when ``regex`` was a multi-key dictionary (:issue:`39338`)
+- Fixed regression in :meth:`Series.replace` and :meth:`DataFrame.replace` not replacing missing values for :class:`CategoricalDtype` (:issue:`40472`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2365,6 +2365,17 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
                 else:
                     categories[index] = new_value
                     cat.rename_categories(categories, inplace=True)
+            elif isna(replace_value) and (cat._codes == -1).any():
+                if new_value in cat.categories:
+                    categories = cat.categories.tolist()
+                    value_index = categories.index(new_value)
+                    cat._codes[cat._codes == -1] = value_index
+                else:
+                    cat.add_categories(new_value, inplace=True)
+                    new_value = len(cat.categories) - 1
+
+                cat._codes[cat._codes == -1] = new_value
+
         if not inplace:
             return cat
 

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1654,7 +1654,9 @@ class TestDataFrameReplace:
 
     # Replace with an existing category and one which will add a new category
     @pytest.mark.parametrize("new_value", ["c", "b"])
-    def test_replace_categorical_missing_vals(self, frame_or_series, unique_nulls_fixture, new_value):
+    def test_replace_categorical_missing_vals(
+        self, frame_or_series, unique_nulls_fixture, new_value
+    ):
         # GH-40472
         obj = frame_or_series([unique_nulls_fixture, "b"], dtype="category")
 

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1652,6 +1652,17 @@ class TestDataFrameReplace:
 
         tm.assert_frame_equal(result, expected)
 
+    # Replace with an existing category and one which will add a new category
+    @pytest.mark.parametrize("new_value", ["c", "b"])
+    def test_replace_categorical_missing_vals(self, frame_or_series, unique_nulls_fixture, new_value):
+        # GH-40472
+        obj = frame_or_series([unique_nulls_fixture, "b"], dtype="category")
+
+        result = obj.replace({unique_nulls_fixture: new_value})
+        expected = frame_or_series([new_value, "b"], dtype="category")
+
+        tm.assert_equal(result, expected)
+
     def test_replace_with_compiled_regex(self):
         # https://github.com/pandas-dev/pandas/issues/35680
         df = DataFrame(["a", "b", "c"])


### PR DESCRIPTION
- [x] closes #40472
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

This restores behavior to before the regression, but I think also deprecating this behavior while patching might be reasonable. Since categoricals represent all missing values the same way, this allows unintuitive behavior like
```
ser = pd.Series([None, "b"]).astype('category')
ser = ser.replace({np.nan: 'c'})
print(ser)
```

replacing the missing value even though `None` and `np.nan` are different missing values. Forcing usage of the more explicit `fillna` seems more reasonable in this case.