### PR TITLE
Fix libpthread not found during local installation

### DIFF
--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -299,6 +299,11 @@ We'll now kick off a three-step process:
    python setup.py build_ext -j 4
    python -m pip install -e . --no-build-isolation --no-use-pep517
 
+.. note::
+    If the ``python setup.py build_ext -j 4`` command fails on a linux distribution you might
+    be able to fix it by adding ``"-L/usr/lib/x86_64-linux-gnu/"`` to the
+    ``extra_link_args`` list.
+
 At this point you should be able to import pandas from your locally built version::
 
    $ python  # start an interpreter

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,10 @@ def is_platform_mac():
     return sys.platform == "darwin"
 
 
+def is_platform_linux():
+    return sys.platform == "linux"
+
+
 min_cython_ver = "0.29.21"  # note: sync with pyproject.toml
 
 try:
@@ -327,6 +331,10 @@ else:
 
 extra_compile_args = []
 extra_link_args = []
+
+if is_platform_linux():
+    extra_link_args.append("-L/usr/lib/x86_64-linux-gnu/")
+
 if is_platform_windows():
     if debugging_symbols_requested:
         extra_compile_args.append("/Z7")

--- a/setup.py
+++ b/setup.py
@@ -327,8 +327,6 @@ else:
 
 extra_compile_args = []
 extra_link_args = []
-
-
 if is_platform_windows():
     if debugging_symbols_requested:
         extra_compile_args.append("/Z7")

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,6 @@ def is_platform_mac():
     return sys.platform == "darwin"
 
 
-def is_platform_linux():
-    return sys.platform == "linux"
-
-
 min_cython_ver = "0.29.21"  # note: sync with pyproject.toml
 
 try:
@@ -332,8 +328,6 @@ else:
 extra_compile_args = []
 extra_link_args = []
 
-if is_platform_linux():
-    extra_link_args.append("-L/usr/lib/x86_64-linux-gnu/")
 
 if is_platform_windows():
     if debugging_symbols_requested:


### PR DESCRIPTION
Hey! This is my first PR, I am getting to know the code base and found this as I was doing the local setup.

- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

I was installing the development environment and it was failing due to:
> /home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a

This also happens in the Docker container under some conditions (creating a new env).

Steps followed:
```bash
mamba env create -f environment.yml  
conda activate pandas-dev

python setup.py build_ext -j 4 # <-- ERROR HERE
python -m pip install -e . --no-build-isolation --no-use-pep517
```

Adding a `extra_link_args.append("-L/usr/lib/x86_64-linux-gnu/")` fixed the issue on Ubuntu 20.04. 

<details>
<summary>Logs</summary>

```
❯ python setup.py build_ext -j 4                                                                                                                                              (pandas-dev) 
Compiling pandas/_libs/algos.pyx because it changed.
Compiling pandas/_libs/groupby.pyx because it changed.
Compiling pandas/_libs/hashing.pyx because it changed.
Compiling pandas/_libs/hashtable.pyx because it changed.
Compiling pandas/_libs/index.pyx because it changed.
Compiling pandas/_libs/indexing.pyx because it changed.
Compiling pandas/_libs/internals.pyx because it changed.
Compiling pandas/_libs/interval.pyx because it changed.
Compiling pandas/_libs/join.pyx because it changed.
Compiling pandas/_libs/lib.pyx because it changed.
Compiling pandas/_libs/missing.pyx because it changed.
Compiling pandas/_libs/parsers.pyx because it changed.
Compiling pandas/_libs/reduction.pyx because it changed.
Compiling pandas/_libs/ops.pyx because it changed.
Compiling pandas/_libs/ops_dispatch.pyx because it changed.
Compiling pandas/_libs/properties.pyx because it changed.
Compiling pandas/_libs/reshape.pyx because it changed.
Compiling pandas/_libs/sparse.pyx because it changed.
Compiling pandas/_libs/tslib.pyx because it changed.
Compiling pandas/_libs/tslibs/base.pyx because it changed.
Compiling pandas/_libs/tslibs/ccalendar.pyx because it changed.
Compiling pandas/_libs/tslibs/dtypes.pyx because it changed.
Compiling pandas/_libs/tslibs/conversion.pyx because it changed.
Compiling pandas/_libs/tslibs/fields.pyx because it changed.
Compiling pandas/_libs/tslibs/nattype.pyx because it changed.
Compiling pandas/_libs/tslibs/np_datetime.pyx because it changed.
Compiling pandas/_libs/tslibs/offsets.pyx because it changed.
Compiling pandas/_libs/tslibs/parsing.pyx because it changed.
Compiling pandas/_libs/tslibs/period.pyx because it changed.
Compiling pandas/_libs/tslibs/strptime.pyx because it changed.
Compiling pandas/_libs/tslibs/timedeltas.pyx because it changed.
Compiling pandas/_libs/tslibs/timestamps.pyx because it changed.
Compiling pandas/_libs/tslibs/timezones.pyx because it changed.
Compiling pandas/_libs/tslibs/tzconversion.pyx because it changed.
Compiling pandas/_libs/tslibs/vectorized.pyx because it changed.
Compiling pandas/_libs/testing.pyx because it changed.
Compiling pandas/_libs/window/aggregations.pyx because it changed.
Compiling pandas/_libs/window/indexers.pyx because it changed.
Compiling pandas/_libs/writers.pyx because it changed.
Compiling pandas/io/sas/sas.pyx because it changed.
[ 1/40] Cythonizing pandas/_libs/algos.pyx
[ 2/40] Cythonizing pandas/_libs/groupby.pyx
[ 4/40] Cythonizing pandas/_libs/hashtable.pyx
[ 3/40] Cythonizing pandas/_libs/hashing.pyx
[ 5/40] Cythonizing pandas/_libs/index.pyx
[ 6/40] Cythonizing pandas/_libs/indexing.pyx
[ 7/40] Cythonizing pandas/_libs/internals.pyx
[ 8/40] Cythonizing pandas/_libs/interval.pyx
[ 9/40] Cythonizing pandas/_libs/join.pyx
[10/40] Cythonizing pandas/_libs/lib.pyx
[11/40] Cythonizing pandas/_libs/missing.pyx
[12/40] Cythonizing pandas/_libs/ops.pyx
[13/40] Cythonizing pandas/_libs/ops_dispatch.pyx
[14/40] Cythonizing pandas/_libs/parsers.pyx
[15/40] Cythonizing pandas/_libs/properties.pyx
[16/40] Cythonizing pandas/_libs/reduction.pyx
[17/40] Cythonizing pandas/_libs/reshape.pyx
[18/40] Cythonizing pandas/_libs/sparse.pyx
[19/40] Cythonizing pandas/_libs/testing.pyx
[20/40] Cythonizing pandas/_libs/tslib.pyx
[21/40] Cythonizing pandas/_libs/tslibs/base.pyx
[22/40] Cythonizing pandas/_libs/tslibs/ccalendar.pyx
[23/40] Cythonizing pandas/_libs/tslibs/conversion.pyx
[24/40] Cythonizing pandas/_libs/tslibs/dtypes.pyx
[25/40] Cythonizing pandas/_libs/tslibs/fields.pyx
[26/40] Cythonizing pandas/_libs/tslibs/nattype.pyx
[27/40] Cythonizing pandas/_libs/tslibs/np_datetime.pyx
[28/40] Cythonizing pandas/_libs/tslibs/offsets.pyx
[29/40] Cythonizing pandas/_libs/tslibs/parsing.pyx
[30/40] Cythonizing pandas/_libs/tslibs/period.pyx
[31/40] Cythonizing pandas/_libs/tslibs/strptime.pyx
[32/40] Cythonizing pandas/_libs/tslibs/timedeltas.pyx
[33/40] Cythonizing pandas/_libs/tslibs/timestamps.pyx
[34/40] Cythonizing pandas/_libs/tslibs/timezones.pyx
[35/40] Cythonizing pandas/_libs/tslibs/tzconversion.pyx
[36/40] Cythonizing pandas/_libs/tslibs/vectorized.pyx
[37/40] Cythonizing pandas/_libs/window/aggregations.pyx
[38/40] Cythonizing pandas/_libs/window/indexers.pyx
[39/40] Cythonizing pandas/_libs/writers.pyx
[40/40] Cythonizing pandas/io/sas/sas.pyx
running build_ext
building 'pandas._libs.algos' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs -Ipandas/_libs/src/klib -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/algos.c -o build/temp.linux-x86_64-3.8/pandas/_libs/algos.o
building 'pandas._libs.groupby' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/groupby.c -o build/temp.linux-x86_64-3.8/pandas/_libs/groupby.o
building 'pandas._libs.hashtable' extension
building 'pandas._libs.hashing' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/hashing.c -o build/temp.linux-x86_64-3.8/pandas/_libs/hashing.o
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -Ipandas/_libs/src/klib -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/hashtable.c -o build/temp.linux-x86_64-3.8/pandas/_libs/hashtable.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/hashing.o -o build/lib.linux-x86_64-3.8/pandas/_libs/hashing.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.index' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs/tslibs -I./pandas/_libs -Ipandas/_libs/src/klib -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/index.c -o build/temp.linux-x86_64-3.8/pandas/_libs/index.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/index.o -o build/lib.linux-x86_64-3.8/pandas/_libs/index.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.indexing' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/indexing.c -o build/temp.linux-x86_64-3.8/pandas/_libs/indexing.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/indexing.o -o build/lib.linux-x86_64-3.8/pandas/_libs/indexing.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.internals' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/internals.c -o build/temp.linux-x86_64-3.8/pandas/_libs/internals.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/internals.o -o build/lib.linux-x86_64-3.8/pandas/_libs/internals.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.interval' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs/tslibs -Ipandas/_libs/src/klib -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/interval.c -o build/temp.linux-x86_64-3.8/pandas/_libs/interval.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/groupby.o -o build/lib.linux-x86_64-3.8/pandas/_libs/groupby.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.join' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -Ipandas/_libs/src/klib -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/join.c -o build/temp.linux-x86_64-3.8/pandas/_libs/join.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/hashtable.o -o build/lib.linux-x86_64-3.8/pandas/_libs/hashtable.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.lib' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -Ipandas/_libs -I./pandas/_libs/tslibs -I./pandas/_libs -Ipandas/_libs/src/klib -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/lib.c -o build/temp.linux-x86_64-3.8/pandas/_libs/lib.o
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -Ipandas/_libs -I./pandas/_libs/tslibs -I./pandas/_libs -Ipandas/_libs/src/klib -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/src/parser/tokenizer.c -o build/temp.linux-x86_64-3.8/pandas/_libs/src/parser/tokenizer.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/lib.o build/temp.linux-x86_64-3.8/pandas/_libs/src/parser/tokenizer.o -o build/lib.linux-x86_64-3.8/pandas/_libs/lib.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.missing' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs/tslibs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/missing.c -o build/temp.linux-x86_64-3.8/pandas/_libs/missing.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/missing.o -o build/lib.linux-x86_64-3.8/pandas/_libs/missing.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.parsers' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs -Ipandas/_libs/src/klib -Ipandas/_libs/src -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/parsers.c -o build/temp.linux-x86_64-3.8/pandas/_libs/parsers.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/algos.o -o build/lib.linux-x86_64-3.8/pandas/_libs/algos.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.reduction' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/reduction.c -o build/temp.linux-x86_64-3.8/pandas/_libs/reduction.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/reduction.o -o build/lib.linux-x86_64-3.8/pandas/_libs/reduction.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.ops' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/ops.c -o build/temp.linux-x86_64-3.8/pandas/_libs/ops.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/interval.o -o build/lib.linux-x86_64-3.8/pandas/_libs/interval.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.ops_dispatch' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/ops_dispatch.c -o build/temp.linux-x86_64-3.8/pandas/_libs/ops_dispatch.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/ops_dispatch.o -o build/lib.linux-x86_64-3.8/pandas/_libs/ops_dispatch.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.properties' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/properties.c -o build/temp.linux-x86_64-3.8/pandas/_libs/properties.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/properties.o -o build/lib.linux-x86_64-3.8/pandas/_libs/properties.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.reshape' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/reshape.c -o build/temp.linux-x86_64-3.8/pandas/_libs/reshape.o
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs -Ipandas/_libs/src/klib -Ipandas/_libs/src -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/src/parser/tokenizer.c -o build/temp.linux-x86_64-3.8/pandas/_libs/src/parser/tokenizer.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/ops.o -o build/lib.linux-x86_64-3.8/pandas/_libs/ops.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.sparse' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/sparse.c -o build/temp.linux-x86_64-3.8/pandas/_libs/sparse.o
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs -Ipandas/_libs/src/klib -Ipandas/_libs/src -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/src/parser/io.c -o build/temp.linux-x86_64-3.8/pandas/_libs/src/parser/io.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/parsers.o build/temp.linux-x86_64-3.8/pandas/_libs/src/parser/tokenizer.o build/temp.linux-x86_64-3.8/pandas/_libs/src/parser/io.o -o build/lib.linux-x86_64-3.8/pandas/_libs/parsers.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.tslib' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs/tslibs -I./pandas/_libs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslib.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslib.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/reshape.o -o build/lib.linux-x86_64-3.8/pandas/_libs/reshape.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.tslibs.base' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslibs/base.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/base.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/base.o -o build/lib.linux-x86_64-3.8/pandas/_libs/tslibs/base.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.tslibs.ccalendar' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslibs/ccalendar.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/ccalendar.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/ccalendar.o -o build/lib.linux-x86_64-3.8/pandas/_libs/tslibs/ccalendar.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.tslibs.dtypes' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslibs/dtypes.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/dtypes.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/tslib.o -o build/lib.linux-x86_64-3.8/pandas/_libs/tslib.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.tslibs.conversion' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs/tslibs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslibs/conversion.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/conversion.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/dtypes.o -o build/lib.linux-x86_64-3.8/pandas/_libs/tslibs/dtypes.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.tslibs.fields' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs/tslibs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslibs/fields.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/fields.o
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs/tslibs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslibs/src/datetime/np_datetime.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/src/datetime/np_datetime.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/conversion.o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/src/datetime/np_datetime.o -o build/lib.linux-x86_64-3.8/pandas/_libs/tslibs/conversion.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.tslibs.nattype' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs/tslibs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslibs/nattype.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/nattype.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/fields.o -o build/lib.linux-x86_64-3.8/pandas/_libs/tslibs/fields.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.tslibs.np_datetime' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -Ipandas/_libs/tslibs -I./pandas/_libs/tslibs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslibs/np_datetime.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/np_datetime.o
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -Ipandas/_libs/tslibs -I./pandas/_libs/tslibs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslibs/src/datetime/np_datetime.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/src/datetime/np_datetime.o
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -Ipandas/_libs/tslibs -I./pandas/_libs/tslibs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslibs/src/datetime/np_datetime_strings.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/src/datetime/np_datetime_strings.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/np_datetime.o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/src/datetime/np_datetime.o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/src/datetime/np_datetime_strings.o -o build/lib.linux-x86_64-3.8/pandas/_libs/tslibs/np_datetime.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.tslibs.offsets' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs/tslibs -Ipandas/_libs/tslibs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslibs/offsets.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/offsets.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/nattype.o -o build/lib.linux-x86_64-3.8/pandas/_libs/tslibs/nattype.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.tslibs.parsing' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -Ipandas/_libs/tslibs -Ipandas/_libs/src/klib -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslibs/parsing.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/parsing.o
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -Ipandas/_libs/tslibs -Ipandas/_libs/src/klib -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/src/parser/tokenizer.c -o build/temp.linux-x86_64-3.8/pandas/_libs/src/parser/tokenizer.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/parsing.o build/temp.linux-x86_64-3.8/pandas/_libs/src/parser/tokenizer.o -o build/lib.linux-x86_64-3.8/pandas/_libs/tslibs/parsing.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.tslibs.period' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -Ipandas/_libs/tslibs -I./pandas/_libs/tslibs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslibs/period.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/period.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/sparse.o -o build/lib.linux-x86_64-3.8/pandas/_libs/sparse.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.tslibs.strptime' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs/tslibs -Ipandas/_libs/tslibs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslibs/strptime.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/strptime.o
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -Ipandas/_libs/tslibs -I./pandas/_libs/tslibs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslibs/src/datetime/np_datetime.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/src/datetime/np_datetime.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/period.o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/src/datetime/np_datetime.o -o build/lib.linux-x86_64-3.8/pandas/_libs/tslibs/period.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.tslibs.timedeltas' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs/tslibs -Ipandas/_libs/tslibs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslibs/timedeltas.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/timedeltas.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/offsets.o -o build/lib.linux-x86_64-3.8/pandas/_libs/tslibs/offsets.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.tslibs.timestamps' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs/tslibs -Ipandas/_libs/tslibs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslibs/timestamps.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/timestamps.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/strptime.o -o build/lib.linux-x86_64-3.8/pandas/_libs/tslibs/strptime.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.tslibs.timezones' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslibs/timezones.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/timezones.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/timedeltas.o -o build/lib.linux-x86_64-3.8/pandas/_libs/tslibs/timedeltas.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.tslibs.tzconversion' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs/tslibs -Ipandas/_libs/tslibs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslibs/tzconversion.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/tzconversion.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/timezones.o -o build/lib.linux-x86_64-3.8/pandas/_libs/tslibs/timezones.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.tslibs.vectorized' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs/tslibs -Ipandas/_libs/tslibs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/tslibs/vectorized.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/vectorized.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/timestamps.o -o build/lib.linux-x86_64-3.8/pandas/_libs/tslibs/timestamps.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.testing' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I./pandas/_libs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/testing.c -o build/temp.linux-x86_64-3.8/pandas/_libs/testing.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/vectorized.o -o build/lib.linux-x86_64-3.8/pandas/_libs/tslibs/vectorized.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.window.aggregations' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -Ipandas/_libs/window -I./pandas/_libs -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/window/aggregations.cpp -o build/temp.linux-x86_64-3.8/pandas/_libs/window/aggregations.o
cc1plus: warning: command line option '-Wstrict-prototypes' is valid for C/ObjC but not for C++
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/testing.o -o build/lib.linux-x86_64-3.8/pandas/_libs/testing.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.window.indexers' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/window/indexers.c -o build/temp.linux-x86_64-3.8/pandas/_libs/window/indexers.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/tzconversion.o -o build/lib.linux-x86_64-3.8/pandas/_libs/tslibs/tzconversion.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas._libs.writers' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/_libs/writers.c -o build/temp.linux-x86_64-3.8/pandas/_libs/writers.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/window/indexers.o -o build/lib.linux-x86_64-3.8/pandas/_libs/window/indexers.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
building 'pandas.io.sas._sas' extension
gcc -pthread -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DNPY_NO_DEPRECATED_API=0 -I/home/cristian/miniforge3/envs/pandas-dev/lib/python3.8/site-packages/numpy/core/include -I/home/cristian/miniforge3/envs/pandas-dev/include/python3.8 -c pandas/io/sas/sas.c -o build/temp.linux-x86_64-3.8/pandas/io/sas/sas.o
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/writers.o -o build/lib.linux-x86_64-3.8/pandas/_libs/writers.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
g++ -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/window/aggregations.o -o build/lib.linux-x86_64-3.8/pandas/_libs/window/aggregations.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/io/sas/sas.o -o build/lib.linux-x86_64-3.8/pandas/io/sas/_sas.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
gcc -pthread -shared -B /home/cristian/miniforge3/envs/pandas-dev/compiler_compat -L/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,-rpath=/home/cristian/miniforge3/envs/pandas-dev/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.8/pandas/_libs/join.o -o build/lib.linux-x86_64-3.8/pandas/_libs/join.cpython-38-x86_64-linux-gnu.so
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /lib64/libpthread.so.0
/home/cristian/miniforge3/envs/pandas-dev/compiler_compat/ld: cannot find /usr/lib64/libpthread_nonshared.a
collect2: error: ld returned 1 exit status
error: command 'gcc' failed with exit status 1
```
</details>