### PR TITLE
ENH: MatplotlibDeprecationWarning: is_first_col function was deprecated

### DIFF
--- a/pandas/plotting/_matplotlib/tools.py
+++ b/pandas/plotting/_matplotlib/tools.py
@@ -423,7 +423,7 @@ def handle_shared_axes(
                 # only the first column should get y labels -> set all other to
                 # off as we only have labels in the first column and we always
                 # have a subplot there, we can skip the layout test
-                if ax.is_first_col():
+                if ax.get_subplotspec().is_first_col():
                     continue
                 if sharey or _has_externally_shared_axis(ax, "y"):
                     _remove_labels_from_axis(ax.yaxis)


### PR DESCRIPTION
Fix for [#40714](https://github.com/pandas-dev/pandas/issues/40714)

The is_first_col function was deprecated in Matplotlib 3.4 and will be removed two minor releases later. Used ax.get_subplotspec().is_first_col() instead.


