### PR TITLE
PERF: numexpr doesn't support floordiv, so don't try 

### DIFF
--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -128,8 +128,9 @@ _op_str_mapping = {
     roperator.rsub: "-",
     operator.truediv: "/",
     roperator.rtruediv: "/",
-    operator.floordiv: "//",
-    roperator.rfloordiv: "//",
+    # floordiv not supported by numexpr 2.x
+    operator.floordiv: None,
+    roperator.rfloordiv: None,
     # we require Python semantics for mod of negative for backwards compatibility
     # see https://github.com/pydata/numexpr/issues/365
     # so sticking with unaccelerated for now


### PR DESCRIPTION
See overview of supported operators: https://numexpr.readthedocs.io/projects/NumExpr3/en/latest/user_guide.html#supported-operators. By trying to use it, we were falling back to the (slower) `_masked_arith_op`

Discovered by investigating the arithmetic benchmarks at https://github.com/pandas-dev/pandas/issues/39146#issuecomment-799482699

For example using the `arithmetic.IntFrameWithScalar.time_frame_op_with_scalar(<class 'numpy.float64'>, 3.0, <built-in function floordiv>)` benchmark:

```python
import operator

dtype = np.float64
arr = np.random.randn(20000, 100)
df = pd.DataFrame(arr.astype(dtype))
scalar = 3.0
op = operator.floordiv
```

```
In [2]: %timeit op(df, scalar)
56.4 ms ± 723 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)  <-- master
24.3 ms ± 236 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)  <-- PR
```
