### PR TITLE
CLN: minor changes to `_translate` to simplify and setup for other chgs.

### DIFF
--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -375,11 +375,15 @@ class Styler:
         cellstyle_map: DefaultDict[Tuple[CSSPair, ...], List[str]] = defaultdict(list)
 
         # copied attributes
-        table_styles = self.table_styles or []
-        caption = self.caption
         hidden_index = self.hidden_index
         hidden_columns = self.hidden_columns
-        uuid = self.uuid
+
+        # construct render dict
+        d = {
+            "uuid": self.uuid,
+            "table_styles": _format_table_styles(self.table_styles or []),
+            "caption": self.caption,
+        }
 
         # for sparsifying a MultiIndex
         idx_lengths = _get_level_lengths(self.index)
@@ -468,6 +472,7 @@ class Styler:
             )
 
             head.append(index_header_row)
+        d.update({"head": head})
 
         body = []
         for r, row_tup in enumerate(self.data.itertuples()):
@@ -517,11 +522,13 @@ class Styler:
                 if props:  # (), [] won't be in cellstyle_map, cellstyle respectively
                     cellstyle_map[tuple(props)].append(f"row{r}_col{c}")
             body.append(row_es)
+        d.update({"body": body})
 
         cellstyle: List[Dict[str, Union[CSSList, List[str]]]] = [
             {"props": list(props), "selectors": selectors}
             for props, selectors in cellstyle_map.items()
         ]
+        d.update({"cellstyle": cellstyle})
 
         table_attr = self.table_attributes
         use_mathjax = get_option("display.html.use_mathjax")
@@ -531,16 +538,8 @@ class Styler:
                 table_attr = table_attr.replace('class="', 'class="tex2jax_ignore ')
             else:
                 table_attr += ' class="tex2jax_ignore"'
+        d.update({"table_attributes": table_attr})
 
-        d = {
-            "head": head,
-            "cellstyle": cellstyle,
-            "body": body,
-            "uuid": uuid,
-            "table_styles": _format_table_styles(table_styles),
-            "caption": caption,
-            "table_attributes": table_attr,
-        }
         if self.tooltips:
             d = self.tooltips._translate(self.data, self.uuid, d)
 


### PR DESCRIPTION
minor changes here to decouple the render dict `d` into sections for code readability.

this is also first part of other changes to improve readability of this method. 
