### PR TITLE
BUG: Fix nanvar for large float16 arrays

### DIFF
--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -909,10 +909,7 @@ def nanvar(values, *, axis=None, skipna=True, ddof=1, mask=None):
         if mask is not None:
             values[mask] = np.nan
 
-    if is_float_dtype(values.dtype):
-        count, d = _get_counts_nanvar(values.shape, mask, axis, ddof, values.dtype)
-    else:
-        count, d = _get_counts_nanvar(values.shape, mask, axis, ddof)
+    count, d = _get_counts_nanvar(values.shape, mask, axis, ddof)
 
     if skipna and mask is not None:
         values = values.copy()


### PR DESCRIPTION
Summary of bug:

Above a certain length, calling `.std()` and `.var()` on a Series or DataFrame fails for float types. The is easily shown with float16 in the following example:

```python
>>> import pandas as pd
>>> import numpy as np

>>> zeros = 32760
>>> ones = 32759
>>> pd.Series([0] * zeros + [1] * ones).astype("float16").var()
0.25

>>> zeros = 32760
>>> ones = 32760
>>> pd.Series([0] * zeros + [1] * ones).astype("float16").var()
0.0
```

What is happening here is that both `count` and `d` overflow to `inf` as 65519 is the largest integer float16 can represent. Example:

```python
>>> import numpy as np
>>> np.float16(65519)
65500.0
>>> np.float16(65520)
inf
```

This makes the variance go to 0.0. Since the `avg` calculation on line 927 of this file casts to float64 anyway, it seems like there is no downside to not casting `count` and `d`. It will also improve accuracy in cases where the overflow does not happen.






INSTALLED VERSIONS
------------------
commit           : f2c8480af2f25efdbd803218b9d87980f416563e
python           : 3.8.2.final.0
python-bits      : 64
OS               : Darwin
OS-release       : 20.3.0
Version          : Darwin Kernel Version 20.3.0: Thu Jan 21 00:07:06 PST 2021; root:xnu-7195.81.3~1/RELEASE_X86_64
machine          : x86_64
processor        : i386
byteorder        : little
LC_ALL           : None
LANG             : en_GB.UTF-8
LOCALE           : en_GB.UTF-8

pandas           : 1.2.3
numpy            : 1.20.1

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
