### PR TITLE
Revert "PERF: numexpr doesn't support floordiv, so don't try (#40727)"

### DIFF
--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -128,9 +128,8 @@ _op_str_mapping = {
     roperator.rsub: "-",
     operator.truediv: "/",
     roperator.rtruediv: "/",
-    # floordiv not supported by numexpr 2.x
-    operator.floordiv: None,
-    roperator.rfloordiv: None,
+    operator.floordiv: "//",
+    roperator.rfloordiv: "//",
     # we require Python semantics for mod of negative for backwards compatibility
     # see https://github.com/pydata/numexpr/issues/365
     # so sticking with unaccelerated for now


### PR DESCRIPTION
This reverts commit e6f7e7b20ebb1512d6debee5e8592b0b5351ac49.
