### PR TITLE
DOC/CI: temp pin of decorator (IPython dependency)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -78,7 +78,7 @@ dependencies:
   - bottleneck>=1.2.1
   - ipykernel
   - ipython>=7.11.1
-  - decorator=4  # temporary pin (dependency of IPython)
+  - decorator=4  # temporary pin (dependency of IPython), see GH-40768
   - jinja2  # pandas.Styler
   - matplotlib>=2.2.2  # pandas.plotting, Series.plot, DataFrame.plot
   - numexpr>=2.6.8

--- a/environment.yml
+++ b/environment.yml
@@ -78,6 +78,7 @@ dependencies:
   - bottleneck>=1.2.1
   - ipykernel
   - ipython>=7.11.1
+  - decorator=4  # temporary pin (dependency of IPython)
   - jinja2  # pandas.Styler
   - matplotlib>=2.2.2  # pandas.plotting, Series.plot, DataFrame.plot
   - numexpr>=2.6.8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -50,6 +50,7 @@ blosc
 bottleneck>=1.2.1
 ipykernel
 ipython>=7.11.1
+decorator==4
 jinja2
 matplotlib>=2.2.2
 numexpr>=2.6.8


### PR DESCRIPTION
The doc builds are failing since yesterday (in enhancingperf.rst, where using the cython ipython magic). By comparing the env from the last working / first failing build on master, one of the differences is a version bump of the `decorator` package, which is a dependency of IPython.

So checking if pinning this package fixes the issue. 