### PR TITLE
TYP/CLN: factorize_from_iterable(s)

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2699,5 +2699,9 @@ def factorize_from_iterables(iterables) -> Tuple[List[np.ndarray], List[Index]]:
     -----
     See `factorize_from_iterable` for more info.
     """
+    if len(iterables) == 0:
+        # For consistency, it should return two empty lists.
+        return [], []
+
     codes, categories = zip(*(factorize_from_iterable(it) for it in iterables))
     return list(codes), list(categories)

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2699,9 +2699,5 @@ def factorize_from_iterables(iterables) -> Tuple[List[np.ndarray], List[Index]]:
     -----
     See `factorize_from_iterable` for more info.
     """
-    if len(iterables) == 0:
-        # For consistency, it should return two empty lists.
-        return [], []
-
     codes, categories = zip(*(factorize_from_iterable(it) for it in iterables))
     return list(codes), list(categories)

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -991,8 +991,7 @@ def _get_dummies_1d(
     if prefix is None:
         dummy_cols = levels
     else:
-        template = f"{prefix}{prefix_sep}" + "{label}"
-        dummy_cols = levels.map(template.format)
+        dummy_cols = Index([f"{prefix}{prefix_sep}{level}" for level in levels])
 
     index: Optional[Index]
     if isinstance(data, Series):

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -991,7 +991,8 @@ def _get_dummies_1d(
     if prefix is None:
         dummy_cols = levels
     else:
-        dummy_cols = [f"{prefix}{prefix_sep}{level}" for level in levels]
+        template = f"{prefix}{prefix_sep}" + "{label}"
+        dummy_cols = levels.map(template.format)
 
     index: Optional[Index]
     if isinstance(data, Series):


### PR DESCRIPTION
`factorize_from_iterable` didn't return an `CategoricalIndex`, if its input was a categorical-like. Instead it returned a plain `Categorical`.  This PR fixes that + adds return types.

Also makes the return value for `factorize_from_iterables` clearer and easier to read.
