### PR TITLE
CI, STYLE Consolidate pygrep checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,11 +90,6 @@ repos:
         entry: python scripts/check_for_inconsistent_pandas_namespace.py
         language: python
         types: [python]
-    -   id: incorrect-code-directives
-        name: Check for incorrect code block or IPython directives
-        language: pygrep
-        entry: (\.\. code-block ::|\.\. ipython ::)
-        types_or: [python, cython, rst]
     -   id: no-os-remove
         name: Check code for instances of os.remove
         entry: os\.remove
@@ -106,49 +101,60 @@ repos:
             pandas/tests/io/excel/test_writers\.py
             |pandas/tests/io/pytables/common\.py
             |pandas/tests/io/pytables/test_store\.py$
-    -   id: non-standard-imports
-        name: Check for non-standard imports
+    -   id: unwanted-patterns
+        name: Unwanted patterns
         language: pygrep
         entry: |
             (?x)
-            # Check for imports from pandas.core.common instead of `import pandas.core.common as com`
-            from\ pandas\.core\.common\ import
+            # outdated annotation syntax, missing error codes
+            \#\ type:\ (?!ignore)
+            |\#\ type:\s?ignore(?!\[)
+
+            # foo._class__ instead of type(foo)
+            |\.__class__
+
+            # np.bool/np.object instead of np.bool_/np.object_
+            |np\.bool[^_8]
+            |np\.object[^_8]
+
+            # imports from pandas.core.common instead of `import pandas.core.common as com`
+            |from\ pandas\.core\.common\ import
             |from\ pandas\.core\ import\ common
 
-            # Check for imports from collections.abc instead of `from collections import abc`
+            # imports from collections.abc instead of `from collections import abc`
             |from\ collections\.abc\ import
 
             # Numpy
             |from\ numpy\ import\ random
             |from\ numpy\.random\ import
-        types: [python]
-    -   id: non-standard-imports-in-tests
-        name: Check for non-standard imports in test suite
+
+            # Incorrect code-block / IPython directives
+            |\.\.\ code-block\ ::
+            |\.\.\ ipython\ ::
+        types_or: [python, cython, rst]
+        exclude: ^doc/source/development/code_style\.rst  # contains examples of patterns to avoid
+    -   id: unwanted-patterns-in-tests
+        name: Unwanted patterns in tests
         language: pygrep
         entry: |
             (?x)
-            # Check for imports from pandas._testing instead of `import pandas._testing as tm`
-            from\ pandas\._testing\ import
+            # pytest.xfail instead of pytest.mark.xfail
+            pytest\.xfail
+
+            # imports from pandas._testing instead of `import pandas._testing as tm`
+            |from\ pandas\._testing\ import
             |from\ pandas\ import\ _testing\ as\ tm
 
             # No direct imports from conftest
             |conftest\ import
             |import\ conftest
 
-            # Check for use of pandas.testing instead of tm
+            # pandas.testing instead of tm
             |pd\.testing\.
 
-            # Check for pd.api.types instead of from pandas.api.types import ...
+            # pd.api.types instead of from pandas.api.types import ...
             |(pd|pandas)\.api\.types\.
-        types: [python]
         files: ^pandas/tests/
-    -   id: np-bool-and-np-object
-        name: Check for use of np.bool/np.object instead of np.bool_/np.object_
-        entry: |
-            (?x)
-            np\.bool[^_8]
-            |np\.object[^_8]
-        language: pygrep
         types_or: [python, cython, rst]
     -   id: pip-to-conda
         name: Generate pip dependency from conda
@@ -164,11 +170,6 @@ repos:
         language: python
         types: [rst]
         files: ^doc/source/(development|reference)/
-    -   id: type-not-class
-        name: Check for use of foo.__class__ instead of type(foo)
-        entry: \.__class__
-        language: pygrep
-        types_or: [python, cython]
     -   id: unwanted-patterns-bare-pytest-raises
         name: Check for use of bare pytest raises
         language: python
@@ -188,12 +189,6 @@ repos:
         entry: python scripts/validate_unwanted_patterns.py --validation-type="private_import_across_module"
         types: [python]
         exclude: ^(asv_bench|pandas/tests|doc)/
-    -   id: unwanted-patterns-pytest-xfail
-        name: Check for use of pytest.xfail
-        entry: pytest\.xfail
-        language: pygrep
-        types: [python]
-        files: ^pandas/tests/
     -   id: unwanted-patterns-strings-to-concatenate
         name: Check for use of not concatenated strings
         language: python
@@ -204,14 +199,6 @@ repos:
         language: python
         entry: python scripts/validate_unwanted_patterns.py --validation-type="strings_with_wrong_placed_whitespace"
         types_or: [python, cython]
-    -   id: unwanted-typing
-        name: Check for outdated annotation syntax and missing error codes
-        entry: |
-            (?x)
-            \#\ type:\ (?!ignore)
-            |\#\ type:\s?ignore(?!\[)
-        language: pygrep
-        types: [python]
     -   id: use-pd_array-in-core
         name: Import pandas.array as pd_array in core
         language: python


### PR DESCRIPTION
These checks can be consolidated using multi-line expressions and verbose regex

I think this should make it easier to extend them, so it should be straightforward to port over the remaining ones in code_checks.sh without having to keep increasing the number of hooks

It also reduces the total number of distinct checks (26 now, down from 31 on master), leading to less visual clutter every time we make a commit

The output will still be clear, as it'll just show the line in which an offending pattern was found. E.g. inserting `import conftest` into `pandas/tests/io/formats/test_info.py` results in:
```console
$ pre-commit run unwanted-patterns-in-tests -a
Unwanted patterns in tests...............................................Failed
- hook id: unwanted-patterns-in-tests
- exit code: 1

pandas/tests/io/formats/test_info.py:2:import conftest
```