### PR TITLE
Revert "DOC/CI: temp pin of decorator (IPython dependency) (#40768)"

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -78,7 +78,6 @@ dependencies:
   - bottleneck>=1.2.1
   - ipykernel
   - ipython>=7.11.1
-  - decorator=4  # temporary pin (dependency of IPython), see GH-40768
   - jinja2  # pandas.Styler
   - matplotlib>=2.2.2  # pandas.plotting, Series.plot, DataFrame.plot
   - numexpr>=2.6.8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -50,7 +50,6 @@ blosc
 bottleneck>=1.2.1
 ipykernel
 ipython>=7.11.1
-decorator==4
 jinja2
 matplotlib>=2.2.2
 numexpr>=2.6.8


### PR DESCRIPTION
This reverts commit 64f08445ae76bc7d3318d1e46c24254087ed5186.

Reverts #40768, as it is now fixed upstream