### PR TITLE
STY: remove --keep-runtime-typing from pyupgrade Part-2

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -25,7 +25,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
-    Type,
+    Type as type_t,
     TypeVar,
     Union,
 )
@@ -119,7 +119,7 @@ Axes = Collection[Any]
 # dtypes
 NpDtype = Union[str, np.dtype]
 Dtype = Union[
-    "ExtensionDtype", NpDtype, Type[Union[str, float, int, complex, bool, object]]
+    "ExtensionDtype", NpDtype, type_t[Union[str, float, int, complex, bool, object]]
 ]
 # DtypeArg specifies all allowable dtypes in a functions its dtype argument
 DtypeArg = Union[Dtype, Dict[Hashable, Dtype]]

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -6,13 +6,8 @@ import operator
 from shutil import get_terminal_size
 from typing import (
     TYPE_CHECKING,
-    Dict,
     Hashable,
-    List,
-    Optional,
     Sequence,
-    Tuple,
-    Type,
     TypeVar,
     Union,
     cast,
@@ -359,7 +354,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         values,
         categories=None,
         ordered=None,
-        dtype: Optional[Dtype] = None,
+        dtype: Dtype | None = None,
         fastpath=False,
         copy: bool = True,
     ):
@@ -473,11 +468,11 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         return self._dtype
 
     @property
-    def _constructor(self) -> Type[Categorical]:
+    def _constructor(self) -> type[Categorical]:
         return Categorical
 
     @classmethod
-    def _from_sequence(cls, scalars, *, dtype: Optional[Dtype] = None, copy=False):
+    def _from_sequence(cls, scalars, *, dtype: Dtype | None = None, copy=False):
         return Categorical(scalars, dtype=dtype, copy=copy)
 
     def astype(self, dtype: Dtype, copy: bool = True) -> ArrayLike:
@@ -547,7 +542,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         """
         return self.categories.itemsize
 
-    def tolist(self) -> List[Scalar]:
+    def tolist(self) -> list[Scalar]:
         """
         Return a list of the values.
 
@@ -630,7 +625,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
     @classmethod
     def from_codes(
-        cls, codes, categories=None, ordered=None, dtype: Optional[Dtype] = None
+        cls, codes, categories=None, ordered=None, dtype: Dtype | None = None
     ):
         """
         Make a Categorical type from codes and categories or dtype.
@@ -1369,7 +1364,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
     # -------------------------------------------------------------
 
-    def __array__(self, dtype: Optional[NpDtype] = None) -> np.ndarray:
+    def __array__(self, dtype: NpDtype | None = None) -> np.ndarray:
         """
         The numpy array interface.
 
@@ -1960,7 +1955,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         codes = self.categories.get_indexer(rvalue)
         return codes.astype(self._ndarray.dtype, copy=False)
 
-    def _reverse_indexer(self) -> Dict[Hashable, np.ndarray]:
+    def _reverse_indexer(self) -> dict[Hashable, np.ndarray]:
         """
         Compute the inverse of a categorical, returning
         a dict of categories -> indexers.
@@ -2187,7 +2182,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
     @classmethod
     def _concat_same_type(
-        cls: Type[CategoricalT], to_concat: Sequence[CategoricalT], axis: int = 0
+        cls: type[CategoricalT], to_concat: Sequence[CategoricalT], axis: int = 0
     ) -> CategoricalT:
         from pandas.core.dtypes.concat import union_categoricals
 
@@ -2643,7 +2638,7 @@ def recode_for_categories(
     return new_codes
 
 
-def factorize_from_iterable(values) -> Tuple[np.ndarray, Index]:
+def factorize_from_iterable(values) -> tuple[np.ndarray, Index]:
     """
     Factorize an input `values` into `categories` and `codes`. Preserves
     categorical dtype in `categories`.
@@ -2682,7 +2677,7 @@ def factorize_from_iterable(values) -> Tuple[np.ndarray, Index]:
     return codes, categories
 
 
-def factorize_from_iterables(iterables) -> Tuple[List[np.ndarray], List[Index]]:
+def factorize_from_iterables(iterables) -> tuple[list[np.ndarray], list[Index]]:
     """
     A higher-level wrapper over `factorize_from_iterable`.
 

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -9,10 +9,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Optional,
     Sequence,
-    Tuple,
-    Type,
     TypeVar,
     Union,
     cast,
@@ -156,25 +153,25 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
     """
 
     # _infer_matches -> which infer_dtype strings are close enough to our own
-    _infer_matches: Tuple[str, ...]
+    _infer_matches: tuple[str, ...]
     _is_recognized_dtype: Callable[[DtypeObj], bool]
-    _recognized_scalars: Tuple[Type, ...]
+    _recognized_scalars: tuple[type, ...]
     _ndarray: np.ndarray
 
-    def __init__(self, data, dtype: Optional[Dtype] = None, freq=None, copy=False):
+    def __init__(self, data, dtype: Dtype | None = None, freq=None, copy=False):
         raise AbstractMethodError(self)
 
     @classmethod
     def _simple_new(
-        cls: Type[DatetimeLikeArrayT],
+        cls: type[DatetimeLikeArrayT],
         values: np.ndarray,
-        freq: Optional[BaseOffset] = None,
-        dtype: Optional[Dtype] = None,
+        freq: BaseOffset | None = None,
+        dtype: Dtype | None = None,
     ) -> DatetimeLikeArrayT:
         raise AbstractMethodError(cls)
 
     @property
-    def _scalar_type(self) -> Type[DatetimeLikeScalar]:
+    def _scalar_type(self) -> type[DatetimeLikeScalar]:
         """
         The scalar associated with this datelike
 
@@ -206,7 +203,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
 
     def _unbox_scalar(
         self, value: DTScalarOrNaT, setitem: bool = False
-    ) -> Union[np.int64, np.datetime64, np.timedelta64]:
+    ) -> np.int64 | np.datetime64 | np.timedelta64:
         """
         Unbox the integer value of a scalar `value`.
 
@@ -334,15 +331,15 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
     # ----------------------------------------------------------------
     # Array-Like / EA-Interface Methods
 
-    def __array__(self, dtype: Optional[NpDtype] = None) -> np.ndarray:
+    def __array__(self, dtype: NpDtype | None = None) -> np.ndarray:
         # used for Timedelta/DatetimeArray, overwritten by PeriodArray
         if is_object_dtype(dtype):
             return np.array(list(self), dtype=object)
         return self._ndarray
 
     def __getitem__(
-        self, key: Union[int, slice, np.ndarray]
-    ) -> Union[DatetimeLikeArrayMixin, DTScalarOrNaT]:
+        self, key: int | slice | np.ndarray
+    ) -> DatetimeLikeArrayMixin | DTScalarOrNaT:
         """
         This getitem defers to the underlying array, which by-definition can
         only handle list-likes, slices, and integer scalars
@@ -354,7 +351,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         result._freq = self._get_getitem_freq(key)
         return result
 
-    def _get_getitem_freq(self, key) -> Optional[BaseOffset]:
+    def _get_getitem_freq(self, key) -> BaseOffset | None:
         """
         Find the `freq` attribute to assign to the result of a __getitem__ lookup.
         """
@@ -386,8 +383,8 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
     # ndarray]"
     def __setitem__(  # type: ignore[override]
         self,
-        key: Union[int, Sequence[int], Sequence[bool], slice],
-        value: Union[NaTType, Any, Sequence[Any]],
+        key: int | Sequence[int] | Sequence[bool] | slice,
+        value: NaTType | Any | Sequence[Any],
     ) -> None:
         # I'm fudging the types a bit here. "Any" above really depends
         # on type(self). For PeriodArray, it's Period (or stuff coercible
@@ -469,10 +466,10 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         ...
 
     @overload
-    def view(self, dtype: Optional[Dtype] = ...) -> ArrayLike:
+    def view(self, dtype: Dtype | None = ...) -> ArrayLike:
         ...
 
-    def view(self, dtype: Optional[Dtype] = None) -> ArrayLike:
+    def view(self, dtype: Dtype | None = None) -> ArrayLike:
         # We handle datetime64, datetime64tz, timedelta64, and period
         #  dtypes here. Everything else we pass through to the underlying
         #  ndarray.
@@ -509,7 +506,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
 
     @classmethod
     def _concat_same_type(
-        cls: Type[DatetimeLikeArrayT],
+        cls: type[DatetimeLikeArrayT],
         to_concat: Sequence[DatetimeLikeArrayT],
         axis: int = 0,
     ) -> DatetimeLikeArrayT:
@@ -545,7 +542,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
 
     @classmethod
     def _from_factorized(
-        cls: Type[DatetimeLikeArrayT], values, original: DatetimeLikeArrayT
+        cls: type[DatetimeLikeArrayT], values, original: DatetimeLikeArrayT
     ) -> DatetimeLikeArrayT:
         return cls(values, dtype=original.dtype)
 
@@ -789,7 +786,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
 
     def _unbox(
         self, other, setitem: bool = False
-    ) -> Union[np.int64, np.datetime64, np.timedelta64, np.ndarray]:
+    ) -> np.int64 | np.datetime64 | np.timedelta64 | np.ndarray:
         """
         Unbox either a scalar with _unbox_scalar or an instance of our own type.
         """
@@ -939,7 +936,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         self._freq = value
 
     @property
-    def freqstr(self) -> Optional[str]:
+    def freqstr(self) -> str | None:
         """
         Return the frequency object as a string if its set, otherwise None.
         """
@@ -948,7 +945,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         return self.freq.freqstr
 
     @property  # NB: override with cache_readonly in immutable subclasses
-    def inferred_freq(self) -> Optional[str]:
+    def inferred_freq(self) -> str | None:
         """
         Tries to return a string representing a frequency guess,
         generated by infer_freq.  Returns None if it can't autodetect the
@@ -962,7 +959,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
             return None
 
     @property  # NB: override with cache_readonly in immutable subclasses
-    def _resolution_obj(self) -> Optional[Resolution]:
+    def _resolution_obj(self) -> Resolution | None:
         freqstr = self.freqstr
         if freqstr is None:
             return None
@@ -1020,7 +1017,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
 
     @classmethod
     def _generate_range(
-        cls: Type[DatetimeLikeArrayT], start, end, periods, freq, *args, **kwargs
+        cls: type[DatetimeLikeArrayT], start, end, periods, freq, *args, **kwargs
     ) -> DatetimeLikeArrayT:
         raise AbstractMethodError(cls)
 
@@ -1443,7 +1440,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
     # --------------------------------------------------------------
     # Reductions
 
-    def min(self, *, axis: Optional[int] = None, skipna: bool = True, **kwargs):
+    def min(self, *, axis: int | None = None, skipna: bool = True, **kwargs):
         """
         Return the minimum value of the Array or minimum along
         an axis.
@@ -1472,7 +1469,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         result = nanops.nanmin(self._ndarray, axis=axis, skipna=skipna)
         return self._wrap_reduction_result(axis, result)
 
-    def max(self, *, axis: Optional[int] = None, skipna: bool = True, **kwargs):
+    def max(self, *, axis: int | None = None, skipna: bool = True, **kwargs):
         """
         Return the maximum value of the Array or maximum along
         an axis.
@@ -1503,7 +1500,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         result = nanops.nanmax(self._ndarray, axis=axis, skipna=skipna)
         return self._wrap_reduction_result(axis, result)
 
-    def mean(self, *, skipna: bool = True, axis: Optional[int] = 0):
+    def mean(self, *, skipna: bool = True, axis: int | None = 0):
         """
         Return the mean value of the Array.
 
@@ -1542,7 +1539,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         )
         return self._wrap_reduction_result(axis, result)
 
-    def median(self, *, axis: Optional[int] = None, skipna: bool = True, **kwargs):
+    def median(self, *, axis: int | None = None, skipna: bool = True, **kwargs):
         nv.validate_median((), kwargs)
 
         if axis is not None and abs(axis) >= self.ndim:
@@ -1752,11 +1749,11 @@ class TimelikeOps(DatetimeLikeArrayMixin):
     # --------------------------------------------------------------
     # Reductions
 
-    def any(self, *, axis: Optional[int] = None, skipna: bool = True):
+    def any(self, *, axis: int | None = None, skipna: bool = True):
         # GH#34479 discussion of desired behavior long-term
         return nanops.nanany(self._ndarray, axis=axis, skipna=skipna, mask=self.isna())
 
-    def all(self, *, axis: Optional[int] = None, skipna: bool = True):
+    def all(self, *, axis: int | None = None, skipna: bool = True):
         # GH#34479 discussion of desired behavior long-term
         return nanops.nanall(self._ndarray, axis=axis, skipna=skipna, mask=self.isna())
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -8,8 +8,6 @@ from datetime import (
 )
 from typing import (
     TYPE_CHECKING,
-    Optional,
-    Union,
     cast,
     overload,
 )
@@ -246,7 +244,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
     # -----------------------------------------------------------------
     # Constructors
 
-    _dtype: Union[np.dtype, DatetimeTZDtype]
+    _dtype: np.dtype | DatetimeTZDtype
     _freq = None
 
     def __init__(self, values, dtype=DT64NS_DTYPE, freq=None, copy: bool = False):
@@ -324,7 +322,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
 
     @classmethod
     def _simple_new(
-        cls, values: np.ndarray, freq: Optional[BaseOffset] = None, dtype=DT64NS_DTYPE
+        cls, values: np.ndarray, freq: BaseOffset | None = None, dtype=DT64NS_DTYPE
     ) -> DatetimeArray:
         assert isinstance(values, np.ndarray)
         assert values.dtype == DT64NS_DTYPE
@@ -497,7 +495,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
         self._check_compatible_with(value, setitem=setitem)
         return value.asm8
 
-    def _scalar_from_string(self, value) -> Union[Timestamp, NaTType]:
+    def _scalar_from_string(self, value) -> Timestamp | NaTType:
         return Timestamp(value, tz=self.tz)
 
     def _check_compatible_with(self, other, setitem: bool = False):
@@ -512,14 +510,14 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
     # -----------------------------------------------------------------
     # Descriptive Properties
 
-    def _box_func(self, x) -> Union[Timestamp, NaTType]:
+    def _box_func(self, x) -> Timestamp | NaTType:
         return Timestamp(x, freq=self.freq, tz=self.tz)
 
     @property
     # error: Return type "Union[dtype, DatetimeTZDtype]" of "dtype"
     # incompatible with return type "ExtensionDtype" in supertype
     # "ExtensionArray"
-    def dtype(self) -> Union[np.dtype, DatetimeTZDtype]:  # type: ignore[override]
+    def dtype(self) -> np.dtype | DatetimeTZDtype:  # type: ignore[override]
         """
         The dtype for the DatetimeArray.
 
@@ -541,7 +539,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
         return self._dtype
 
     @property
-    def tz(self) -> Optional[tzinfo]:
+    def tz(self) -> tzinfo | None:
         """
         Return timezone, if any.
 
@@ -562,7 +560,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
         )
 
     @property
-    def tzinfo(self) -> Optional[tzinfo]:
+    def tzinfo(self) -> tzinfo | None:
         """
         Alias for tz attribute
         """
@@ -1931,13 +1929,13 @@ def sequence_to_datetimes(
 @overload
 def sequence_to_datetimes(
     data, allow_object: Literal[True] = ..., require_iso8601: bool = ...
-) -> Union[np.ndarray, DatetimeArray]:
+) -> np.ndarray | DatetimeArray:
     ...
 
 
 def sequence_to_datetimes(
     data, allow_object: bool = False, require_iso8601: bool = False
-) -> Union[np.ndarray, DatetimeArray]:
+) -> np.ndarray | DatetimeArray:
     """
     Parse/convert the passed data to either DatetimeArray or np.ndarray[object].
     """
@@ -2268,9 +2266,7 @@ def maybe_convert_dtype(data, copy: bool):
 # Validation and Inference
 
 
-def _maybe_infer_tz(
-    tz: Optional[tzinfo], inferred_tz: Optional[tzinfo]
-) -> Optional[tzinfo]:
+def _maybe_infer_tz(tz: tzinfo | None, inferred_tz: tzinfo | None) -> tzinfo | None:
     """
     If a timezone is inferred from data, check that it is compatible with
     the user-provided timezone, if any.
@@ -2342,7 +2338,7 @@ def _validate_dt64_dtype(dtype):
     return dtype
 
 
-def validate_tz_from_dtype(dtype, tz: Optional[tzinfo]) -> Optional[tzinfo]:
+def validate_tz_from_dtype(dtype, tz: tzinfo | None) -> tzinfo | None:
     """
     If the given dtype is a DatetimeTZDtype, extract the implied
     tzinfo object from it and check that it does not conflict with the given
@@ -2390,8 +2386,8 @@ def validate_tz_from_dtype(dtype, tz: Optional[tzinfo]) -> Optional[tzinfo]:
 
 
 def _infer_tz_from_endpoints(
-    start: Timestamp, end: Timestamp, tz: Optional[tzinfo]
-) -> Optional[tzinfo]:
+    start: Timestamp, end: Timestamp, tz: tzinfo | None
+) -> tzinfo | None:
     """
     If a timezone is not explicitly given via `tz`, see if one can
     be inferred from the `start` and `end` endpoints.  If more than one
@@ -2433,7 +2429,7 @@ def _infer_tz_from_endpoints(
 
 
 def _maybe_normalize_endpoints(
-    start: Optional[Timestamp], end: Optional[Timestamp], normalize: bool
+    start: Timestamp | None, end: Timestamp | None, normalize: bool
 ):
     _normalized = True
 

--- a/pandas/core/arrays/floating.py
+++ b/pandas/core/arrays/floating.py
@@ -1,11 +1,5 @@
 from __future__ import annotations
 
-from typing import (
-    List,
-    Optional,
-    Tuple,
-    Type,
-)
 import warnings
 
 import numpy as np
@@ -63,7 +57,7 @@ class FloatingDtype(NumericDtype):
         return True
 
     @classmethod
-    def construct_array_type(cls) -> Type[FloatingArray]:
+    def construct_array_type(cls) -> type[FloatingArray]:
         """
         Return the array type associated with this dtype.
 
@@ -73,7 +67,7 @@ class FloatingDtype(NumericDtype):
         """
         return FloatingArray
 
-    def _get_common_dtype(self, dtypes: List[DtypeObj]) -> Optional[DtypeObj]:
+    def _get_common_dtype(self, dtypes: list[DtypeObj]) -> DtypeObj | None:
         # for now only handle other floating types
         if not all(isinstance(t, FloatingDtype) for t in dtypes):
             return None
@@ -90,7 +84,7 @@ class FloatingDtype(NumericDtype):
 
 def coerce_to_array(
     values, dtype=None, mask=None, copy: bool = False
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Coerce the input values array to numpy arrays with a mask.
 
@@ -274,7 +268,7 @@ class FloatingArray(NumericArray):
         scalars = to_numeric(strings, errors="raise")
         return cls._from_sequence(scalars, dtype=dtype, copy=copy)
 
-    def _coerce_to_array(self, value) -> Tuple[np.ndarray, np.ndarray]:
+    def _coerce_to_array(self, value) -> tuple[np.ndarray, np.ndarray]:
         return coerce_to_array(value, dtype=self.dtype)
 
     def astype(self, dtype, copy: bool = True) -> ArrayLike:

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -1,12 +1,5 @@
 from __future__ import annotations
 
-from typing import (
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Type,
-)
 import warnings
 
 import numpy as np
@@ -79,7 +72,7 @@ class _IntegerDtype(NumericDtype):
         return True
 
     @classmethod
-    def construct_array_type(cls) -> Type[IntegerArray]:
+    def construct_array_type(cls) -> type[IntegerArray]:
         """
         Return the array type associated with this dtype.
 
@@ -89,7 +82,7 @@ class _IntegerDtype(NumericDtype):
         """
         return IntegerArray
 
-    def _get_common_dtype(self, dtypes: List[DtypeObj]) -> Optional[DtypeObj]:
+    def _get_common_dtype(self, dtypes: list[DtypeObj]) -> DtypeObj | None:
         # we only handle nullable EA dtypes and numeric numpy dtypes
         if not all(
             isinstance(t, BaseMaskedDtype)
@@ -144,7 +137,7 @@ def safe_cast(values, dtype, copy: bool):
 
 def coerce_to_array(
     values, dtype, mask=None, copy: bool = False
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Coerce the input values array to numpy arrays with a mask
 
@@ -327,19 +320,19 @@ class IntegerArray(NumericArray):
 
     @classmethod
     def _from_sequence(
-        cls, scalars, *, dtype: Optional[Dtype] = None, copy: bool = False
+        cls, scalars, *, dtype: Dtype | None = None, copy: bool = False
     ) -> IntegerArray:
         values, mask = coerce_to_array(scalars, dtype=dtype, copy=copy)
         return IntegerArray(values, mask)
 
     @classmethod
     def _from_sequence_of_strings(
-        cls, strings, *, dtype: Optional[Dtype] = None, copy: bool = False
+        cls, strings, *, dtype: Dtype | None = None, copy: bool = False
     ) -> IntegerArray:
         scalars = to_numeric(strings, errors="raise")
         return cls._from_sequence(scalars, dtype=dtype, copy=copy)
 
-    def _coerce_to_array(self, value) -> Tuple[np.ndarray, np.ndarray]:
+    def _coerce_to_array(self, value) -> tuple[np.ndarray, np.ndarray]:
         return coerce_to_array(value, dtype=self.dtype)
 
     def astype(self, dtype, copy: bool = True) -> ArrayLike:
@@ -568,7 +561,7 @@ class UInt64Dtype(_IntegerDtype):
     __doc__ = _dtype_docstring.format(dtype="uint64")
 
 
-INT_STR_TO_DTYPE: Dict[str, _IntegerDtype] = {
+INT_STR_TO_DTYPE: dict[str, _IntegerDtype] = {
     "int8": Int8Dtype(),
     "int16": Int16Dtype(),
     "int32": Int32Dtype(),

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -7,9 +7,7 @@ from operator import (
 )
 import textwrap
 from typing import (
-    Optional,
     Sequence,
-    Type,
     TypeVar,
     cast,
 )
@@ -198,10 +196,10 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     # Constructors
 
     def __new__(
-        cls: Type[IntervalArrayT],
+        cls: type[IntervalArrayT],
         data,
         closed=None,
-        dtype: Optional[Dtype] = None,
+        dtype: Dtype | None = None,
         copy: bool = False,
         verify_integrity: bool = True,
     ):
@@ -240,12 +238,12 @@ class IntervalArray(IntervalMixin, ExtensionArray):
 
     @classmethod
     def _simple_new(
-        cls: Type[IntervalArrayT],
+        cls: type[IntervalArrayT],
         left,
         right,
         closed=None,
         copy: bool = False,
-        dtype: Optional[Dtype] = None,
+        dtype: Dtype | None = None,
         verify_integrity: bool = True,
     ) -> IntervalArrayT:
         result = IntervalMixin.__new__(cls)
@@ -327,17 +325,17 @@ class IntervalArray(IntervalMixin, ExtensionArray):
 
     @classmethod
     def _from_sequence(
-        cls: Type[IntervalArrayT],
+        cls: type[IntervalArrayT],
         scalars,
         *,
-        dtype: Optional[Dtype] = None,
+        dtype: Dtype | None = None,
         copy: bool = False,
     ) -> IntervalArrayT:
         return cls(scalars, dtype=dtype, copy=copy)
 
     @classmethod
     def _from_factorized(
-        cls: Type[IntervalArrayT], values: np.ndarray, original: IntervalArrayT
+        cls: type[IntervalArrayT], values: np.ndarray, original: IntervalArrayT
     ) -> IntervalArrayT:
         if len(values) == 0:
             # An empty array returns object-dtype here. We can't create
@@ -394,11 +392,11 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         }
     )
     def from_breaks(
-        cls: Type[IntervalArrayT],
+        cls: type[IntervalArrayT],
         breaks,
         closed="right",
         copy: bool = False,
-        dtype: Optional[Dtype] = None,
+        dtype: Dtype | None = None,
     ) -> IntervalArrayT:
         breaks = _maybe_convert_platform_interval(breaks)
 
@@ -469,12 +467,12 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         }
     )
     def from_arrays(
-        cls: Type[IntervalArrayT],
+        cls: type[IntervalArrayT],
         left,
         right,
         closed="right",
         copy: bool = False,
-        dtype: Optional[Dtype] = None,
+        dtype: Dtype | None = None,
     ) -> IntervalArrayT:
         left = _maybe_convert_platform_interval(left)
         right = _maybe_convert_platform_interval(right)
@@ -533,11 +531,11 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         }
     )
     def from_tuples(
-        cls: Type[IntervalArrayT],
+        cls: type[IntervalArrayT],
         data,
         closed="right",
         copy: bool = False,
-        dtype: Optional[Dtype] = None,
+        dtype: Dtype | None = None,
     ) -> IntervalArrayT:
         if len(data):
             left, right = [], []
@@ -875,7 +873,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
 
     @classmethod
     def _concat_same_type(
-        cls: Type[IntervalArrayT], to_concat: Sequence[IntervalArrayT]
+        cls: type[IntervalArrayT], to_concat: Sequence[IntervalArrayT]
     ) -> IntervalArrayT:
         """
         Concatenate multiple IntervalArray
@@ -1378,7 +1376,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     # ---------------------------------------------------------------------
     # Conversion
 
-    def __array__(self, dtype: Optional[NpDtype] = None) -> np.ndarray:
+    def __array__(self, dtype: NpDtype | None = None) -> np.ndarray:
         """
         Return the IntervalArray's data as a numpy array of Interval
         objects (with dtype='object')

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -3,12 +3,8 @@ from __future__ import annotations
 from typing import (
     TYPE_CHECKING,
     Any,
-    Optional,
     Sequence,
-    Tuple,
-    Type,
     TypeVar,
-    Union,
 )
 
 import numpy as np
@@ -22,6 +18,7 @@ from pandas._typing import (
     Dtype,
     NpDtype,
     Scalar,
+    type_t,
 )
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import (
@@ -74,7 +71,7 @@ class BaseMaskedDtype(ExtensionDtype):
 
     name: str
     base = None
-    type: Type
+    type: type
 
     na_value = libmissing.NA
 
@@ -93,7 +90,7 @@ class BaseMaskedDtype(ExtensionDtype):
         return self.numpy_dtype.itemsize
 
     @classmethod
-    def construct_array_type(cls) -> Type[BaseMaskedArray]:
+    def construct_array_type(cls) -> type_t[BaseMaskedArray]:
         """
         Return the array type associated with this dtype.
 
@@ -137,9 +134,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
     def dtype(self) -> BaseMaskedDtype:
         raise AbstractMethodError(self)
 
-    def __getitem__(
-        self, item: Union[int, slice, np.ndarray]
-    ) -> Union[BaseMaskedArray, Any]:
+    def __getitem__(self, item: int | slice | np.ndarray) -> BaseMaskedArray | Any:
         if is_integer(item):
             if self._mask[item]:
                 return self.dtype.na_value
@@ -182,7 +177,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
             new_values = self.copy()
         return new_values
 
-    def _coerce_to_array(self, values) -> Tuple[np.ndarray, np.ndarray]:
+    def _coerce_to_array(self, values) -> tuple[np.ndarray, np.ndarray]:
         raise AbstractMethodError(self)
 
     def __setitem__(self, key, value) -> None:
@@ -217,7 +212,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
     # Type[str], Type[float], Type[int], Type[complex], Type[bool], Type[object], None]"
     def to_numpy(  # type: ignore[override]
         self,
-        dtype: Optional[NpDtype] = None,
+        dtype: NpDtype | None = None,
         copy: bool = False,
         na_value: Scalar = lib.no_default,
     ) -> np.ndarray:
@@ -331,7 +326,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
 
     __array_priority__ = 1000  # higher than ndarray so ops dispatch to us
 
-    def __array__(self, dtype: Optional[NpDtype] = None) -> np.ndarray:
+    def __array__(self, dtype: NpDtype | None = None) -> np.ndarray:
         """
         the array interface, return my values
         We return an object array here to preserve our scalar values
@@ -368,7 +363,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
 
     @classmethod
     def _concat_same_type(
-        cls: Type[BaseMaskedArrayT], to_concat: Sequence[BaseMaskedArrayT]
+        cls: type[BaseMaskedArrayT], to_concat: Sequence[BaseMaskedArrayT]
     ) -> BaseMaskedArrayT:
         data = np.concatenate([x._data for x in to_concat])
         mask = np.concatenate([x._mask for x in to_concat])
@@ -379,7 +374,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
         indexer,
         *,
         allow_fill: bool = False,
-        fill_value: Optional[Scalar] = None,
+        fill_value: Scalar | None = None,
     ) -> BaseMaskedArrayT:
         # we always fill with 1 internally
         # to avoid upcasting
@@ -425,7 +420,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
         return type(self)(data, mask, copy=False)
 
     @doc(ExtensionArray.factorize)
-    def factorize(self, na_sentinel: int = -1) -> Tuple[np.ndarray, ExtensionArray]:
+    def factorize(self, na_sentinel: int = -1) -> tuple[np.ndarray, ExtensionArray]:
         arr = self._data
         mask = self._mask
 

--- a/pandas/core/arrays/numeric.py
+++ b/pandas/core/arrays/numeric.py
@@ -5,9 +5,7 @@ import numbers
 from typing import (
     TYPE_CHECKING,
     Any,
-    List,
     TypeVar,
-    Union,
 )
 
 import numpy as np
@@ -41,7 +39,7 @@ T = TypeVar("T", bound="NumericArray")
 
 class NumericDtype(BaseMaskedDtype):
     def __from_arrow__(
-        self, array: Union[pyarrow.Array, pyarrow.ChunkedArray]
+        self, array: pyarrow.Array | pyarrow.ChunkedArray
     ) -> BaseMaskedArray:
         """
         Construct IntegerArray/FloatingArray from pyarrow Array/ChunkedArray.
@@ -172,7 +170,7 @@ class NumericArray(BaseMaskedArray):
             return result
 
         mask = np.zeros(len(self), dtype=bool)
-        inputs2: List[Any] = []
+        inputs2: list[Any] = []
         for x in inputs:
             if isinstance(x, NumericArray):
                 mask |= x._mask

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 
 import numbers
-from typing import (
-    Optional,
-    Tuple,
-    Union,
-)
 
 import numpy as np
 from numpy.lib.mixins import NDArrayOperatorsMixin
@@ -72,7 +67,7 @@ class PandasArray(
     # ------------------------------------------------------------------------
     # Constructors
 
-    def __init__(self, values: Union[np.ndarray, PandasArray], copy: bool = False):
+    def __init__(self, values: np.ndarray | PandasArray, copy: bool = False):
         if isinstance(values, type(self)):
             values = values._ndarray
         if not isinstance(values, np.ndarray):
@@ -92,7 +87,7 @@ class PandasArray(
 
     @classmethod
     def _from_sequence(
-        cls, scalars, *, dtype: Optional[Dtype] = None, copy: bool = False
+        cls, scalars, *, dtype: Dtype | None = None, copy: bool = False
     ) -> PandasArray:
         if isinstance(dtype, PandasDtype):
             dtype = dtype._dtype
@@ -132,7 +127,7 @@ class PandasArray(
     # ------------------------------------------------------------------------
     # NumPy Array Interface
 
-    def __array__(self, dtype: Optional[NpDtype] = None) -> np.ndarray:
+    def __array__(self, dtype: NpDtype | None = None) -> np.ndarray:
         return np.asarray(self._ndarray, dtype=dtype)
 
     _HANDLED_TYPES = (np.ndarray, numbers.Number)
@@ -199,7 +194,7 @@ class PandasArray(
             fill_value = self.dtype.na_value
         return fill_value
 
-    def _values_for_factorize(self) -> Tuple[np.ndarray, int]:
+    def _values_for_factorize(self) -> tuple[np.ndarray, int]:
         return self._ndarray, -1
 
     # ------------------------------------------------------------------------
@@ -208,7 +203,7 @@ class PandasArray(
     def any(
         self,
         *,
-        axis: Optional[int] = None,
+        axis: int | None = None,
         out=None,
         keepdims: bool = False,
         skipna: bool = True,
@@ -220,7 +215,7 @@ class PandasArray(
     def all(
         self,
         *,
-        axis: Optional[int] = None,
+        axis: int | None = None,
         out=None,
         keepdims: bool = False,
         skipna: bool = True,
@@ -229,18 +224,14 @@ class PandasArray(
         result = nanops.nanall(self._ndarray, axis=axis, skipna=skipna)
         return self._wrap_reduction_result(axis, result)
 
-    def min(
-        self, *, axis: Optional[int] = None, skipna: bool = True, **kwargs
-    ) -> Scalar:
+    def min(self, *, axis: int | None = None, skipna: bool = True, **kwargs) -> Scalar:
         nv.validate_min((), kwargs)
         result = nanops.nanmin(
             values=self._ndarray, axis=axis, mask=self.isna(), skipna=skipna
         )
         return self._wrap_reduction_result(axis, result)
 
-    def max(
-        self, *, axis: Optional[int] = None, skipna: bool = True, **kwargs
-    ) -> Scalar:
+    def max(self, *, axis: int | None = None, skipna: bool = True, **kwargs) -> Scalar:
         nv.validate_max((), kwargs)
         result = nanops.nanmax(
             values=self._ndarray, axis=axis, mask=self.isna(), skipna=skipna
@@ -248,7 +239,7 @@ class PandasArray(
         return self._wrap_reduction_result(axis, result)
 
     def sum(
-        self, *, axis: Optional[int] = None, skipna: bool = True, min_count=0, **kwargs
+        self, *, axis: int | None = None, skipna: bool = True, min_count=0, **kwargs
     ) -> Scalar:
         nv.validate_sum((), kwargs)
         result = nanops.nansum(
@@ -257,7 +248,7 @@ class PandasArray(
         return self._wrap_reduction_result(axis, result)
 
     def prod(
-        self, *, axis: Optional[int] = None, skipna: bool = True, min_count=0, **kwargs
+        self, *, axis: int | None = None, skipna: bool = True, min_count=0, **kwargs
     ) -> Scalar:
         nv.validate_prod((), kwargs)
         result = nanops.nanprod(
@@ -268,8 +259,8 @@ class PandasArray(
     def mean(
         self,
         *,
-        axis: Optional[int] = None,
-        dtype: Optional[NpDtype] = None,
+        axis: int | None = None,
+        dtype: NpDtype | None = None,
         out=None,
         keepdims: bool = False,
         skipna: bool = True,
@@ -281,7 +272,7 @@ class PandasArray(
     def median(
         self,
         *,
-        axis: Optional[int] = None,
+        axis: int | None = None,
         out=None,
         overwrite_input: bool = False,
         keepdims: bool = False,
@@ -296,8 +287,8 @@ class PandasArray(
     def std(
         self,
         *,
-        axis: Optional[int] = None,
-        dtype: Optional[NpDtype] = None,
+        axis: int | None = None,
+        dtype: NpDtype | None = None,
         out=None,
         ddof=1,
         keepdims: bool = False,
@@ -312,8 +303,8 @@ class PandasArray(
     def var(
         self,
         *,
-        axis: Optional[int] = None,
-        dtype: Optional[NpDtype] = None,
+        axis: int | None = None,
+        dtype: NpDtype | None = None,
         out=None,
         ddof=1,
         keepdims: bool = False,
@@ -328,8 +319,8 @@ class PandasArray(
     def sem(
         self,
         *,
-        axis: Optional[int] = None,
-        dtype: Optional[NpDtype] = None,
+        axis: int | None = None,
+        dtype: NpDtype | None = None,
         out=None,
         ddof=1,
         keepdims: bool = False,
@@ -344,8 +335,8 @@ class PandasArray(
     def kurt(
         self,
         *,
-        axis: Optional[int] = None,
-        dtype: Optional[NpDtype] = None,
+        axis: int | None = None,
+        dtype: NpDtype | None = None,
         out=None,
         keepdims: bool = False,
         skipna: bool = True,
@@ -359,8 +350,8 @@ class PandasArray(
     def skew(
         self,
         *,
-        axis: Optional[int] = None,
-        dtype: Optional[NpDtype] = None,
+        axis: int | None = None,
+        dtype: NpDtype | None = None,
         out=None,
         keepdims: bool = False,
         skipna: bool = True,
@@ -379,7 +370,7 @@ class PandasArray(
     # Type[str], Type[float], Type[int], Type[complex], Type[bool], Type[object], None]"
     def to_numpy(  # type: ignore[override]
         self,
-        dtype: Optional[NpDtype] = None,
+        dtype: NpDtype | None = None,
         copy: bool = False,
         na_value=lib.no_default,
     ) -> np.ndarray:

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -6,11 +6,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    List,
-    Optional,
     Sequence,
-    Type,
-    Union,
 )
 
 import numpy as np
@@ -160,7 +156,7 @@ class PeriodArray(PeriodMixin, dtl.DatelikeOps):
     _infer_matches = ("period",)
 
     # Names others delegate to us
-    _other_ops: List[str] = []
+    _other_ops: list[str] = []
     _bool_ops = ["is_leap_year"]
     _object_ops = ["start_time", "end_time", "freq"]
     _field_ops = [
@@ -191,7 +187,7 @@ class PeriodArray(PeriodMixin, dtl.DatelikeOps):
     # Constructors
 
     def __init__(
-        self, values, dtype: Optional[Dtype] = None, freq=None, copy: bool = False
+        self, values, dtype: Dtype | None = None, freq=None, copy: bool = False
     ):
         freq = validate_dtype_freq(dtype, freq)
 
@@ -221,8 +217,8 @@ class PeriodArray(PeriodMixin, dtl.DatelikeOps):
     def _simple_new(
         cls,
         values: np.ndarray,
-        freq: Optional[BaseOffset] = None,
-        dtype: Optional[Dtype] = None,
+        freq: BaseOffset | None = None,
+        dtype: Dtype | None = None,
     ) -> PeriodArray:
         # alias for PeriodArray.__init__
         assertion_msg = "Should be numpy array of type i8"
@@ -231,10 +227,10 @@ class PeriodArray(PeriodMixin, dtl.DatelikeOps):
 
     @classmethod
     def _from_sequence(
-        cls: Type[PeriodArray],
-        scalars: Union[Sequence[Optional[Period]], AnyArrayLike],
+        cls: type[PeriodArray],
+        scalars: Sequence[Period | None] | AnyArrayLike,
         *,
-        dtype: Optional[Dtype] = None,
+        dtype: Dtype | None = None,
         copy: bool = False,
     ) -> PeriodArray:
         if dtype and isinstance(dtype, PeriodDtype):
@@ -256,7 +252,7 @@ class PeriodArray(PeriodMixin, dtl.DatelikeOps):
 
     @classmethod
     def _from_sequence_of_strings(
-        cls, strings, *, dtype: Optional[Dtype] = None, copy: bool = False
+        cls, strings, *, dtype: Dtype | None = None, copy: bool = False
     ) -> PeriodArray:
         return cls._from_sequence(strings, dtype=dtype, copy=copy)
 
@@ -302,9 +298,7 @@ class PeriodArray(PeriodMixin, dtl.DatelikeOps):
     # -----------------------------------------------------------------
     # DatetimeLike Interface
 
-    def _unbox_scalar(
-        self, value: Union[Period, NaTType], setitem: bool = False
-    ) -> np.int64:
+    def _unbox_scalar(self, value: Period | NaTType, setitem: bool = False) -> np.int64:
         if value is NaT:
             return np.int64(value.value)
         elif isinstance(value, self._scalar_type):
@@ -336,7 +330,7 @@ class PeriodArray(PeriodMixin, dtl.DatelikeOps):
         """
         return self.dtype.freq
 
-    def __array__(self, dtype: Optional[NpDtype] = None) -> np.ndarray:
+    def __array__(self, dtype: NpDtype | None = None) -> np.ndarray:
         if dtype == "i8":
             return self.asi8
         elif dtype == bool:
@@ -523,7 +517,7 @@ class PeriodArray(PeriodMixin, dtl.DatelikeOps):
             values[self._isnan] = iNaT
         return type(self)(values, freq=self.freq)
 
-    def _box_func(self, x) -> Union[Period, NaTType]:
+    def _box_func(self, x) -> Period | NaTType:
         return Period._from_ordinal(ordinal=x, freq=self.freq)
 
     @doc(**_shared_doc_kwargs, other="PeriodIndex", other_name="PeriodIndex")
@@ -869,8 +863,8 @@ def raise_on_incompatible(left, right):
 
 
 def period_array(
-    data: Union[Sequence[Optional[Period]], AnyArrayLike],
-    freq: Optional[Union[str, Tick]] = None,
+    data: Sequence[Period | None] | AnyArrayLike,
+    freq: str | Tick | None = None,
     copy: bool = False,
 ) -> PeriodArray:
     """
@@ -939,7 +933,7 @@ def period_array(
 
     arrdata = np.asarray(data)
 
-    dtype: Optional[PeriodDtype]
+    dtype: PeriodDtype | None
     if freq:
         dtype = PeriodDtype(freq)
     else:

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -9,11 +9,8 @@ import operator
 from typing import (
     Any,
     Callable,
-    Optional,
     Sequence,
-    Type,
     TypeVar,
-    Union,
 )
 import warnings
 
@@ -202,7 +199,7 @@ def _sparse_array_op(
     return _wrap_result(name, result, index, fill, dtype=result_dtype)
 
 
-def _wrap_result(name, data, sparse_index, fill_value, dtype: Optional[Dtype] = None):
+def _wrap_result(name, data, sparse_index, fill_value, dtype: Dtype | None = None):
     """
     wrap op result to have correct dtype
     """
@@ -309,7 +306,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         index=None,
         fill_value=None,
         kind="integer",
-        dtype: Optional[Dtype] = None,
+        dtype: Dtype | None = None,
         copy=False,
     ):
 
@@ -450,7 +447,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
     @classmethod
     def _simple_new(
-        cls: Type[SparseArrayT],
+        cls: type[SparseArrayT],
         sparse_array: np.ndarray,
         sparse_index: SparseIndex,
         dtype: SparseDtype,
@@ -507,7 +504,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
         return cls._simple_new(arr, index, dtype)
 
-    def __array__(self, dtype: Optional[NpDtype] = None) -> np.ndarray:
+    def __array__(self, dtype: NpDtype | None = None) -> np.ndarray:
         fill_value = self.fill_value
 
         if self.sp_index.ngaps == 0:
@@ -542,7 +539,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         raise TypeError(msg)
 
     @classmethod
-    def _from_sequence(cls, scalars, *, dtype: Optional[Dtype] = None, copy=False):
+    def _from_sequence(cls, scalars, *, dtype: Dtype | None = None, copy=False):
         return cls(scalars, dtype=dtype)
 
     @classmethod
@@ -961,7 +958,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
         return taken
 
-    def _take_without_fill(self, indices) -> Union[np.ndarray, SparseArray]:
+    def _take_without_fill(self, indices) -> np.ndarray | SparseArray:
         to_shift = indices < 0
         indices = indices.copy()
 
@@ -1013,7 +1010,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
     @classmethod
     def _concat_same_type(
-        cls: Type[SparseArrayT], to_concat: Sequence[SparseArrayT]
+        cls: type[SparseArrayT], to_concat: Sequence[SparseArrayT]
     ) -> SparseArrayT:
         fill_value = to_concat[0].fill_value
 
@@ -1065,7 +1062,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
         return cls(data, sparse_index=sp_index, fill_value=fill_value)
 
-    def astype(self, dtype: Optional[Dtype] = None, copy=True):
+    def astype(self, dtype: Dtype | None = None, copy=True):
         """
         Change the dtype of a SparseArray.
 
@@ -1555,7 +1552,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
 
 def make_sparse(
-    arr: np.ndarray, kind="block", fill_value=None, dtype: Optional[NpDtype] = None
+    arr: np.ndarray, kind="block", fill_value=None, dtype: NpDtype | None = None
 ):
     """
     Convert ndarray to sparse format

--- a/pandas/core/arrays/sparse/dtype.py
+++ b/pandas/core/arrays/sparse/dtype.py
@@ -5,10 +5,6 @@ import re
 from typing import (
     TYPE_CHECKING,
     Any,
-    List,
-    Optional,
-    Tuple,
-    Type,
 )
 import warnings
 
@@ -17,6 +13,7 @@ import numpy as np
 from pandas._typing import (
     Dtype,
     DtypeObj,
+    type_t,
 )
 from pandas.errors import PerformanceWarning
 
@@ -188,7 +185,7 @@ class SparseDtype(ExtensionDtype):
         return self.name
 
     @classmethod
-    def construct_array_type(cls) -> Type[SparseArray]:
+    def construct_array_type(cls) -> type_t[SparseArray]:
         """
         Return the array type associated with this dtype.
 
@@ -253,7 +250,7 @@ class SparseDtype(ExtensionDtype):
             raise TypeError(msg)
 
     @staticmethod
-    def _parse_subtype(dtype: str) -> Tuple[str, bool]:
+    def _parse_subtype(dtype: str) -> tuple[str, bool]:
         """
         Parse a string to get the subtype
 
@@ -374,7 +371,7 @@ class SparseDtype(ExtensionDtype):
             return type(self.fill_value)
         return self.subtype
 
-    def _get_common_dtype(self, dtypes: List[DtypeObj]) -> Optional[DtypeObj]:
+    def _get_common_dtype(self, dtypes: list[DtypeObj]) -> DtypeObj | None:
         # TODO for now only handle SparseDtypes and numpy dtypes => extend
         # with other compatibtle extension dtypes
         if any(

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 
-from typing import (
-    TYPE_CHECKING,
-    Optional,
-    Type,
-    Union,
-)
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -16,6 +11,7 @@ from pandas._libs import (
 from pandas._typing import (
     Dtype,
     Scalar,
+    type_t,
 )
 from pandas.compat.numpy import function as nv
 
@@ -85,11 +81,11 @@ class StringDtype(ExtensionDtype):
     na_value = libmissing.NA
 
     @property
-    def type(self) -> Type[str]:
+    def type(self) -> type[str]:
         return str
 
     @classmethod
-    def construct_array_type(cls) -> Type[StringArray]:
+    def construct_array_type(cls) -> type_t[StringArray]:
         """
         Return the array type associated with this dtype.
 
@@ -103,7 +99,7 @@ class StringDtype(ExtensionDtype):
         return "StringDtype"
 
     def __from_arrow__(
-        self, array: Union[pyarrow.Array, pyarrow.ChunkedArray]
+        self, array: pyarrow.Array | pyarrow.ChunkedArray
     ) -> StringArray:
         """
         Construct StringArray from pyarrow Array/ChunkedArray.
@@ -225,7 +221,7 @@ class StringArray(PandasArray):
             )
 
     @classmethod
-    def _from_sequence(cls, scalars, *, dtype: Optional[Dtype] = None, copy=False):
+    def _from_sequence(cls, scalars, *, dtype: Dtype | None = None, copy=False):
         if dtype:
             assert dtype == "string"
 
@@ -254,7 +250,7 @@ class StringArray(PandasArray):
 
     @classmethod
     def _from_sequence_of_strings(
-        cls, strings, *, dtype: Optional[Dtype] = None, copy=False
+        cls, strings, *, dtype: Dtype | None = None, copy=False
     ):
         return cls._from_sequence(strings, dtype=dtype, copy=copy)
 
@@ -407,7 +403,7 @@ class StringArray(PandasArray):
     # String methods interface
     _str_na_value = StringDtype.na_value
 
-    def _str_map(self, f, na_value=None, dtype: Optional[Dtype] = None):
+    def _str_map(self, f, na_value=None, dtype: Dtype | None = None):
         from pandas.arrays import BooleanArray
 
         if dtype is None:
@@ -419,7 +415,7 @@ class StringArray(PandasArray):
         arr = np.asarray(self)
 
         if is_integer_dtype(dtype) or is_bool_dtype(dtype):
-            constructor: Union[Type[IntegerArray], Type[BooleanArray]]
+            constructor: type[IntegerArray] | type[BooleanArray]
             if is_integer_dtype(dtype):
                 constructor = IntegerArray
             else:

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -4,11 +4,7 @@ from distutils.version import LooseVersion
 from typing import (
     TYPE_CHECKING,
     Any,
-    Optional,
     Sequence,
-    Tuple,
-    Type,
-    Union,
     cast,
 )
 
@@ -21,6 +17,7 @@ from pandas._libs import (
 from pandas._typing import (
     Dtype,
     NpDtype,
+    type_t,
 )
 from pandas.util._decorators import doc
 from pandas.util._validators import validate_fillna_kwargs
@@ -102,11 +99,11 @@ class ArrowStringDtype(ExtensionDtype):
     na_value = libmissing.NA
 
     @property
-    def type(self) -> Type[str]:
+    def type(self) -> type[str]:
         return str
 
     @classmethod
-    def construct_array_type(cls) -> Type[ArrowStringArray]:
+    def construct_array_type(cls) -> type_t[ArrowStringArray]:
         """
         Return the array type associated with this dtype.
 
@@ -122,9 +119,7 @@ class ArrowStringDtype(ExtensionDtype):
     def __repr__(self) -> str:
         return "ArrowStringDtype"
 
-    def __from_arrow__(
-        self, array: Union[pa.Array, pa.ChunkedArray]
-    ) -> ArrowStringArray:
+    def __from_arrow__(self, array: pa.Array | pa.ChunkedArray) -> ArrowStringArray:
         """
         Construct StringArray from pyarrow Array/ChunkedArray.
         """
@@ -222,7 +217,7 @@ class ArrowStringArray(OpsMixin, ExtensionArray):
             raise ImportError(msg)
 
     @classmethod
-    def _from_sequence(cls, scalars, dtype: Optional[Dtype] = None, copy: bool = False):
+    def _from_sequence(cls, scalars, dtype: Dtype | None = None, copy: bool = False):
         cls._chk_pyarrow_available()
         # convert non-na-likes to str, and nan-likes to ArrowStringDtype.na_value
         scalars = lib.ensure_string_array(scalars, copy=False)
@@ -230,7 +225,7 @@ class ArrowStringArray(OpsMixin, ExtensionArray):
 
     @classmethod
     def _from_sequence_of_strings(
-        cls, strings, dtype: Optional[Dtype] = None, copy: bool = False
+        cls, strings, dtype: Dtype | None = None, copy: bool = False
     ):
         return cls._from_sequence(strings, dtype=dtype, copy=copy)
 
@@ -241,7 +236,7 @@ class ArrowStringArray(OpsMixin, ExtensionArray):
         """
         return self._dtype
 
-    def __array__(self, dtype: Optional[NpDtype] = None) -> np.ndarray:
+    def __array__(self, dtype: NpDtype | None = None) -> np.ndarray:
         """Correctly construct numpy arrays when passed to `np.asarray()`."""
         return self.to_numpy(dtype=dtype)
 
@@ -254,7 +249,7 @@ class ArrowStringArray(OpsMixin, ExtensionArray):
     # Type[str], Type[float], Type[int], Type[complex], Type[bool], Type[object], None]"
     def to_numpy(  # type: ignore[override]
         self,
-        dtype: Optional[NpDtype] = None,
+        dtype: NpDtype | None = None,
         copy: bool = False,
         na_value=lib.no_default,
     ) -> np.ndarray:
@@ -280,7 +275,7 @@ class ArrowStringArray(OpsMixin, ExtensionArray):
         return len(self._data)
 
     @doc(ExtensionArray.factorize)
-    def factorize(self, na_sentinel: int = -1) -> Tuple[np.ndarray, ExtensionArray]:
+    def factorize(self, na_sentinel: int = -1) -> tuple[np.ndarray, ExtensionArray]:
         encoded = self._data.dictionary_encode()
         indices = pa.chunked_array(
             [c.indices for c in encoded.chunks], type=encoded.type.index_type
@@ -486,7 +481,7 @@ class ArrowStringArray(OpsMixin, ExtensionArray):
         # TODO(ARROW-9429): Add a .to_numpy() to ChunkedArray
         return BooleanArray._from_sequence(result.to_pandas().values)
 
-    def __setitem__(self, key: Union[int, slice, np.ndarray], value: Any) -> None:
+    def __setitem__(self, key: int | slice | np.ndarray, value: Any) -> None:
         """Set one or more values inplace.
 
         Parameters

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -1,13 +1,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import (
-    TYPE_CHECKING,
-    List,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -138,8 +132,8 @@ class TimedeltaArray(dtl.TimelikeOps):
 
     __array_priority__ = 1000
     # define my properties & methods for delegation
-    _other_ops: List[str] = []
-    _bool_ops: List[str] = []
+    _other_ops: list[str] = []
+    _bool_ops: list[str] = []
     _object_ops = ["freq"]
     _field_ops = ["days", "seconds", "microseconds", "nanoseconds"]
     _datetimelike_ops = _field_ops + _object_ops + _bool_ops
@@ -154,7 +148,7 @@ class TimedeltaArray(dtl.TimelikeOps):
     # Note: ndim must be defined to ensure NaT.__richcmp__(TimedeltaArray)
     #  operates pointwise.
 
-    def _box_func(self, x) -> Union[Timedelta, NaTType]:
+    def _box_func(self, x) -> Timedelta | NaTType:
         return Timedelta(x, unit="ns")
 
     @property
@@ -242,7 +236,7 @@ class TimedeltaArray(dtl.TimelikeOps):
 
     @classmethod
     def _simple_new(
-        cls, values: np.ndarray, freq: Optional[BaseOffset] = None, dtype=TD64NS_DTYPE
+        cls, values: np.ndarray, freq: BaseOffset | None = None, dtype=TD64NS_DTYPE
     ) -> TimedeltaArray:
         assert dtype == TD64NS_DTYPE, dtype
         assert isinstance(values, np.ndarray), type(values)
@@ -343,7 +337,7 @@ class TimedeltaArray(dtl.TimelikeOps):
         self._check_compatible_with(value, setitem=setitem)
         return np.timedelta64(value.value, "ns")
 
-    def _scalar_from_string(self, value) -> Union[Timedelta, NaTType]:
+    def _scalar_from_string(self, value) -> Timedelta | NaTType:
         return Timedelta(value)
 
     def _check_compatible_with(self, other, setitem: bool = False) -> None:
@@ -387,8 +381,8 @@ class TimedeltaArray(dtl.TimelikeOps):
     def sum(
         self,
         *,
-        axis: Optional[int] = None,
-        dtype: Optional[NpDtype] = None,
+        axis: int | None = None,
+        dtype: NpDtype | None = None,
         out=None,
         keepdims: bool = False,
         initial=None,
@@ -407,8 +401,8 @@ class TimedeltaArray(dtl.TimelikeOps):
     def std(
         self,
         *,
-        axis: Optional[int] = None,
-        dtype: Optional[NpDtype] = None,
+        axis: int | None = None,
+        dtype: NpDtype | None = None,
         out=None,
         ddof: int = 1,
         keepdims: bool = False,
@@ -934,7 +928,7 @@ class TimedeltaArray(dtl.TimelikeOps):
 
 def sequence_to_td64ns(
     data, copy: bool = False, unit=None, errors="raise"
-) -> Tuple[np.ndarray, Optional[Tick]]:
+) -> tuple[np.ndarray, Tick | None]:
     """
     Parameters
     ----------

--- a/pandas/core/computation/align.py
+++ b/pandas/core/computation/align.py
@@ -9,12 +9,7 @@ from functools import (
 )
 from typing import (
     TYPE_CHECKING,
-    Dict,
-    Optional,
     Sequence,
-    Tuple,
-    Type,
-    Union,
 )
 import warnings
 
@@ -38,10 +33,10 @@ if TYPE_CHECKING:
 
 def _align_core_single_unary_op(
     term,
-) -> Tuple[Union[partial, Type[FrameOrSeries]], Optional[Dict[str, Index]]]:
+) -> tuple[partial | type[FrameOrSeries], dict[str, Index] | None]:
 
-    typ: Union[partial, Type[FrameOrSeries]]
-    axes: Optional[Dict[str, Index]] = None
+    typ: partial | type[FrameOrSeries]
+    axes: dict[str, Index] | None = None
 
     if isinstance(term.value, np.ndarray):
         typ = partial(np.asanyarray, dtype=term.value.dtype)
@@ -54,8 +49,8 @@ def _align_core_single_unary_op(
 
 
 def _zip_axes_from_type(
-    typ: Type[FrameOrSeries], new_axes: Sequence[Index]
-) -> Dict[str, Index]:
+    typ: type[FrameOrSeries], new_axes: Sequence[Index]
+) -> dict[str, Index]:
     return {name: new_axes[i] for i, name in enumerate(typ._AXIS_ORDERS)}
 
 

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -11,8 +11,6 @@ import operator
 from typing import (
     Callable,
     Iterable,
-    Optional,
-    Union,
 )
 
 import numpy as np
@@ -73,7 +71,7 @@ class UndefinedVariableError(NameError):
     NameError subclass for local variables.
     """
 
-    def __init__(self, name: str, is_local: Optional[bool] = None):
+    def __init__(self, name: str, is_local: bool | None = None):
         base_msg = f"{repr(name)} is not defined"
         if is_local:
             msg = f"local variable {base_msg}"
@@ -218,7 +216,7 @@ class Op:
 
     op: str
 
-    def __init__(self, op: str, operands: Iterable[Union[Term, Op]], encoding=None):
+    def __init__(self, op: str, operands: Iterable[Term | Op], encoding=None):
         self.op = _bool_op_map.get(op, op)
         self.operands = operands
         self.encoding = encoding

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -3,12 +3,7 @@ from __future__ import annotations
 
 import ast
 from functools import partial
-from typing import (
-    Any,
-    Dict,
-    Optional,
-    Tuple,
-)
+from typing import Any
 
 import numpy as np
 
@@ -44,14 +39,14 @@ from pandas.io.formats.printing import (
 class PyTablesScope(_scope.Scope):
     __slots__ = ("queryables",)
 
-    queryables: Dict[str, Any]
+    queryables: dict[str, Any]
 
     def __init__(
         self,
         level: int,
         global_dict=None,
         local_dict=None,
-        queryables: Optional[Dict[str, Any]] = None,
+        queryables: dict[str, Any] | None = None,
     ):
         super().__init__(level + 1, global_dict=global_dict, local_dict=local_dict)
         self.queryables = queryables or {}
@@ -104,10 +99,10 @@ class BinOp(ops.BinOp):
     _max_selectors = 31
 
     op: str
-    queryables: Dict[str, Any]
-    condition: Optional[str]
+    queryables: dict[str, Any]
+    condition: str | None
 
-    def __init__(self, op: str, lhs, rhs, queryables: Dict[str, Any], encoding):
+    def __init__(self, op: str, lhs, rhs, queryables: dict[str, Any], encoding):
         super().__init__(op, lhs, rhs)
         self.queryables = queryables
         self.encoding = encoding
@@ -270,7 +265,7 @@ class BinOp(ops.BinOp):
 
 
 class FilterBinOp(BinOp):
-    filter: Optional[Tuple[Any, Any, Index]] = None
+    filter: tuple[Any, Any, Index] | None = None
 
     def __repr__(self) -> str:
         if self.filter is None:
@@ -549,13 +544,13 @@ class PyTablesExpr(expr.Expr):
     "major_axis>=20130101"
     """
 
-    _visitor: Optional[PyTablesExprVisitor]
+    _visitor: PyTablesExprVisitor | None
     env: PyTablesScope
 
     def __init__(
         self,
         where,
-        queryables: Optional[Dict[str, Any]] = None,
+        queryables: dict[str, Any] | None = None,
         encoding=None,
         scope_level: int = 0,
     ):

--- a/pandas/core/computation/scope.py
+++ b/pandas/core/computation/scope.py
@@ -10,7 +10,6 @@ import itertools
 import pprint
 import struct
 import sys
-from typing import List
 
 import numpy as np
 
@@ -239,7 +238,7 @@ class Scope:
                 mapping[new_key] = new_value  # type: ignore[index]
                 return
 
-    def _get_vars(self, stack, scopes: List[str]):
+    def _get_vars(self, stack, scopes: list[str]):
         """
         Get specifically scoped variables from a list of stack frames.
 


### PR DESCRIPTION
To fix issue #40759 :
Changes here are from PEP585 (e.g. List[str] -> list[str]) and from PEP604 (Optional[str] -> str | None), both of which are only applied in the presence of from __future__ import annotations. Some imports became unused after this so those have been removed.
As there were changes in many files (97) this has been split up into 5 smaller PRs.
This is part 2 of 5.

Refer the discussion here : #40773 

- [x] closes #40759 
- [] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
