### PR TITLE
BUG: Support numpy.random.Generator as random_state input

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -425,6 +425,8 @@ def random_state(state=None):
         or (not np_version_under1p18 and isinstance(state, np.random.BitGenerator))
     ):
         return np.random.RandomState(state)
+    elif not np_version_under1p18 and isinstance(state, np.random.Generator):
+        return np.random.RandomState(state.bit_generator)
     elif isinstance(state, np.random.RandomState):
         return state
     elif state is None:

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -91,8 +91,8 @@ def test_random_state():
             com.random_state(rng1).uniform()
             == npr.RandomState(rng2.bit_generator).uniform()
         )
+        # Check base RNGs have advanced correctly
         assert rng1.uniform() == rng2.uniform()
-        assert com.random_state(rng1).uniform() != rng2.uniform()
 
     # Error for floats or strings
     msg = (

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -82,6 +82,18 @@ def test_random_state():
             == npr.RandomState(npr.PCG64(11)).uniform()
         )
 
+    # Check Generators
+    # GH38100
+    if not np_version_under1p17:
+        rng1 = npr.default_rng(4)
+        rng2 = npr.default_rng(4)
+        assert (
+            com.random_state(rng1).uniform()
+            == npr.RandomState(rng2.bit_generator).uniform()
+        )
+        assert rng1.uniform() == rng2.uniform()
+        assert com.random_state(rng1).uniform() != rng2.uniform()
+
     # Error for floats or strings
     msg = (
         "random_state must be an integer, array-like, a BitGenerator, "


### PR DESCRIPTION
- [x] workaround for #38100
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
