### PR TITLE
Fix line_terminator escaping in python doc

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3426,7 +3426,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         line_terminator : str, optional
             The newline character or character sequence to use in the output
             file. Defaults to `os.linesep`, which depends on the OS in which
-            this method is called ('\n' for linux, '\r\n' for Windows, i.e.).
+            this method is called ('\\n' for linux, '\\r\\n' for Windows, i.e.).
 
             .. versionchanged:: 0.24.0
         chunksize : int or None


### PR DESCRIPTION
The line terminators are not escaped so we don't see the backslash here:

![image](https://user-images.githubusercontent.com/9317502/113784381-9ee80a00-9735-11eb-8e5e-6d4b84da7527.png)

Source : https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_csv.html