### PR TITLE
TYP: implement typing.Manager2D

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -187,6 +187,9 @@ ColspaceArgType = Union[
 # internals
 Manager = Union["ArrayManager", "BlockManager", "SingleBlockManager"]
 SingleManager = Union["SingleArrayManager", "SingleBlockManager"]
+Manager2D = Union["ArrayManager", "BlockManager"]
+# TODO: Manager2d excludes SingleBlockManager, but does not exclude
+#  SingleArrayManager
 
 # indexing
 # PositionalIndexer -> valid 1D positional indexer, e.g. can pass

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -178,7 +178,7 @@ class SeriesGroupBy(GroupBy[Series]):
     _apply_allowlist = base.series_apply_allowlist
 
     # Defined as a cache_readonly in SelectionMixin
-    _obj_with_exclusions: DataFrame
+    _obj_with_exclusions: Series
 
     def _iterate_slices(self) -> Iterable[Series]:
         yield self._selected_obj

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -36,7 +36,7 @@ from pandas._typing import (
     ArrayLike,
     FrameOrSeries,
     FrameOrSeriesUnion,
-    Manager,
+    Manager2D,
 )
 from pandas.util._decorators import (
     Appender,
@@ -176,6 +176,9 @@ def pin_allowlisted_properties(klass: type[FrameOrSeries], allowlist: frozenset[
 @pin_allowlisted_properties(Series, base.series_apply_allowlist)
 class SeriesGroupBy(GroupBy[Series]):
     _apply_allowlist = base.series_apply_allowlist
+
+    # Defined as a cache_readonly in SelectionMixin
+    _obj_with_exclusions: DataFrame
 
     def _iterate_slices(self) -> Iterable[Series]:
         yield self._selected_obj
@@ -927,6 +930,9 @@ class SeriesGroupBy(GroupBy[Series]):
 @pin_allowlisted_properties(DataFrame, base.dataframe_apply_allowlist)
 class DataFrameGroupBy(GroupBy[DataFrame]):
 
+    # Defined as a cache_readonly in SelectionMixin
+    _obj_with_exclusions: DataFrame
+
     _apply_allowlist = base.dataframe_apply_allowlist
 
     _agg_examples_doc = dedent(
@@ -1095,9 +1101,9 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
     def _cython_agg_manager(
         self, how: str, alt=None, numeric_only: bool = True, min_count: int = -1
-    ) -> Manager:
+    ) -> Manager2D:
 
-        data: Manager = self._get_data_to_aggregate()
+        data: Manager2D = self._get_data_to_aggregate()
 
         if numeric_only:
             data = data.get_numeric_data(copy=False)
@@ -1691,7 +1697,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         else:
             return self.obj._constructor(result, index=obj.index, columns=result_index)
 
-    def _get_data_to_aggregate(self) -> Manager:
+    def _get_data_to_aggregate(self) -> Manager2D:
         obj = self._obj_with_exclusions
         if self.axis == 1:
             return obj.T._mgr
@@ -1776,7 +1782,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
         return result
 
-    def _wrap_agged_manager(self, mgr: Manager) -> DataFrame:
+    def _wrap_agged_manager(self, mgr: Manager2D) -> DataFrame:
         if not self.as_index:
             index = np.arange(mgr.shape[1])
             mgr.set_axis(1, ibase.Index(index), verify_integrity=False)


### PR DESCRIPTION
Makes it feasible to annotate a Manager as specifically-2D, which I find makes it easier to reason about some of the groupby code.

@jorisvandenbossche any objection to a refactor of ArrayManager to make SingleArrayManager share a parent class with ArrayManager, but not subclass it?  See https://github.com/pandas-dev/pandas/compare/master...jbrockmendel:typ-mgr-2d?expand=1#diff-80af4c7d6ece8cfeec6401a5f5babe27f19a7fc7476ad9148dca02f58a07a8dcR191

@simonjayhawkins the annotation for obj_with_exclusions https://github.com/pandas-dev/pandas/compare/master...jbrockmendel:typ-mgr-2d?expand=1#diff-f1ec980d06b0b54c8263f663f767636c3f5921f04f8a7ee91dfc71a2100b05cdR934 is a bit sketchy since it is a cache_readonly, not an attribute.  Thoughts on how best to handle this?  (Also, annotating it incorrectly as DataFrame in SeriesGroupBy doesn't get mypy to complain, which seems like it should?)