### PR TITLE
BUG: DataFrame.from_records doesn't raise proper error message when Series passed

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1970,6 +1970,15 @@ class DataFrame(NDFrame, OpsMixin):
         2      1     c
         3      0     d
         """
+        if not (
+            (isinstance(data, np.ndarray) and data.dtype.names is not None)
+            or isinstance(data, DataFrame)
+            or (is_list_like(data) and not isinstance(data, Series))
+        ):
+            raise TypeError(
+                "data must be structured ndarray, sequence of tuples or dicts, "
+                "or DataFrame"
+            )
         # Make a copy of the input columns so we can modify it
         if columns is not None:
             columns = ensure_index(columns)


### PR DESCRIPTION
- [x] closes #40429 
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
