### PR TITLE
Two missing spaces in argmax, argmin docs

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10843,7 +10843,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         @doc(
             _num_doc,
             desc="Return the maximum of the values over the requested axis.\n\n"
-            "If you want the *index* of the maximum, use ``idxmax``. This is"
+            "If you want the *index* of the maximum, use ``idxmax``. This is "
             "the equivalent of the ``numpy.ndarray`` method ``argmax``.",
             name1=name1,
             name2=name2,
@@ -10860,7 +10860,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         @doc(
             _num_doc,
             desc="Return the minimum of the values over the requested axis.\n\n"
-            "If you want the *index* of the minimum, use ``idxmin``. This is"
+            "If you want the *index* of the minimum, use ``idxmin``. This is "
             "the equivalent of the ``numpy.ndarray`` method ``argmin``.",
             name1=name1,
             name2=name2,


### PR DESCRIPTION
I fixed the missing space that made the documentation render "isthe" instead of "is the".

Before the change:
- This **isthe** equivalent of the numpy.ndarray method argmax.
- This **isthe** equivalent of the numpy.ndarray method argmin.

After the change:
- This **is the** equivalent of the numpy.ndarray method argmax.
- This **is the** equivalent of the numpy.ndarray method argmin.


- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry