### PR TITLE
REGR: ufunc with DataFrame input not passing all kwargs

### DIFF
--- a/doc/source/whatsnew/v1.2.4.rst
+++ b/doc/source/whatsnew/v1.2.4.rst
@@ -21,6 +21,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.where` not returning a copy in the case of an all True condition (:issue:`39595`)
 - Fixed regression in :meth:`DataFrame.replace` raising ``IndexError`` when ``regex`` was a multi-key dictionary (:issue:`39338`)
 - Fixed regression in repr of floats in an ``object`` column not respecting ``float_format`` when printed in the console or outputted through :meth:`DataFrame.to_string`, :meth:`DataFrame.to_html`, and :meth:`DataFrame.to_latex` (:issue:`40024`)
+- Fixed regression in ``numpy`` ufunc such as ``np.add`` not passing through all arguments for 2-dimensional input (:issue:`40662`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.2.4.rst
+++ b/doc/source/whatsnew/v1.2.4.rst
@@ -21,7 +21,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.where` not returning a copy in the case of an all True condition (:issue:`39595`)
 - Fixed regression in :meth:`DataFrame.replace` raising ``IndexError`` when ``regex`` was a multi-key dictionary (:issue:`39338`)
 - Fixed regression in repr of floats in an ``object`` column not respecting ``float_format`` when printed in the console or outputted through :meth:`DataFrame.to_string`, :meth:`DataFrame.to_html`, and :meth:`DataFrame.to_latex` (:issue:`40024`)
-- Fixed regression in ``numpy`` ufunc such as ``np.add`` not passing through all arguments for 2-dimensional input (:issue:`40662`)
+- Fixed regression in ``numpy`` ufuncs such as ``np.add`` not passing through all arguments for 2-dimensional input (:issue:`40662`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.2.4.rst
+++ b/doc/source/whatsnew/v1.2.4.rst
@@ -21,7 +21,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.where` not returning a copy in the case of an all True condition (:issue:`39595`)
 - Fixed regression in :meth:`DataFrame.replace` raising ``IndexError`` when ``regex`` was a multi-key dictionary (:issue:`39338`)
 - Fixed regression in repr of floats in an ``object`` column not respecting ``float_format`` when printed in the console or outputted through :meth:`DataFrame.to_string`, :meth:`DataFrame.to_html`, and :meth:`DataFrame.to_latex` (:issue:`40024`)
-- Fixed regression in NumPy ufuncs such as ``np.add`` not passing through all arguments for 2-dimensional input (:issue:`40662`)
+- Fixed regression in NumPy ufuncs such as ``np.add`` not passing through all arguments for :class:`DataFrame` (:issue:`40662`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.2.4.rst
+++ b/doc/source/whatsnew/v1.2.4.rst
@@ -21,7 +21,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.where` not returning a copy in the case of an all True condition (:issue:`39595`)
 - Fixed regression in :meth:`DataFrame.replace` raising ``IndexError`` when ``regex`` was a multi-key dictionary (:issue:`39338`)
 - Fixed regression in repr of floats in an ``object`` column not respecting ``float_format`` when printed in the console or outputted through :meth:`DataFrame.to_string`, :meth:`DataFrame.to_html`, and :meth:`DataFrame.to_latex` (:issue:`40024`)
-- Fixed regression in ``numpy`` ufuncs such as ``np.add`` not passing through all arguments for 2-dimensional input (:issue:`40662`)
+- Fixed regression in NumPy ufuncs such as ``np.add`` not passing through all arguments for 2-dimensional input (:issue:`40662`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/arraylike.py
+++ b/pandas/core/arraylike.py
@@ -364,10 +364,12 @@ def array_ufunc(self, ufunc: np.ufunc, method: str, *inputs: Any, **kwargs: Any)
         result = getattr(ufunc, method)(*inputs, **kwargs)
     else:
         # ufunc(dataframe)
-        if method == "__call__":
+        if method == "__call__" and not kwargs:
             # for np.<ufunc>(..) calls
+            # kwargs cannot necessarily be handled block-by-block, so only
+            # take this path if there are no kwargs
             mgr = inputs[0]._mgr
-            result = mgr.apply(getattr(ufunc, method), **kwargs)
+            result = mgr.apply(getattr(ufunc, method))
         else:
             # otherwise specific ufunc methods (eg np.<ufunc>.accumulate(..))
             # Those can have an axis keyword and thus can't be called block-by-block

--- a/pandas/core/arraylike.py
+++ b/pandas/core/arraylike.py
@@ -357,7 +357,7 @@ def array_ufunc(self, ufunc: np.ufunc, method: str, *inputs: Any, **kwargs: Any)
         # * len(inputs) > 1 is doable when we know that we have
         #   aligned blocks / dtypes.
         inputs = tuple(np.asarray(x) for x in inputs)
-        result = getattr(ufunc, method)(*inputs)
+        result = getattr(ufunc, method)(*inputs, **kwargs)
     elif self.ndim == 1:
         # ufunc(series, ...)
         inputs = tuple(extract_array(x, extract_numpy=True) for x in inputs)

--- a/pandas/core/arraylike.py
+++ b/pandas/core/arraylike.py
@@ -367,7 +367,7 @@ def array_ufunc(self, ufunc: np.ufunc, method: str, *inputs: Any, **kwargs: Any)
         if method == "__call__":
             # for np.<ufunc>(..) calls
             mgr = inputs[0]._mgr
-            result = mgr.apply(getattr(ufunc, method))
+            result = mgr.apply(getattr(ufunc, method), **kwargs)
         else:
             # otherwise specific ufunc methods (eg np.<ufunc>.accumulate(..))
             # Those can have an axis keyword and thus can't be called block-by-block

--- a/pandas/tests/frame/test_ufunc.py
+++ b/pandas/tests/frame/test_ufunc.py
@@ -68,6 +68,7 @@ def test_binary_input_dispatch_binop(dtype):
         (np.add, [2, 3, 4, 5]),
         (partial(np.add, where=[[False, True], [True, False]]), [0, 3, 4, 0]),
         (np.power, [1, 2, 3, 4]),
+        (np.subtract, [0, 1, 2, 3]),
     ],
 )
 def test_ufunc_passes_args(func, expected):

--- a/pandas/tests/frame/test_ufunc.py
+++ b/pandas/tests/frame/test_ufunc.py
@@ -62,7 +62,7 @@ def test_binary_input_dispatch_binop(dtype):
 
 def test_ufunc_passes_args():
     # GH#40662
-    arr = np.array([[1, 2], [3, 4]])
+    arr = np.array([[1, 2, 3, 4]])
     df = pd.DataFrame(arr)
     result = np.zeros_like(df)
     np.add(df, 1, out=result)
@@ -71,8 +71,8 @@ def test_ufunc_passes_args():
     tm.assert_numpy_array_equal(result, expected)
 
     result = np.zeros_like(df)
-    np.add(df, 1, out=result, where=[[False, True], [True, False]])
-    expected = np.array([[0, 3], [4, 0]])
+    np.add(df, 1, out=result, where=[[False, True, True, False]])
+    expected = np.array([[0, 3, 4, 0]])
     tm.assert_numpy_array_equal(result, expected)
 
 

--- a/pandas/tests/frame/test_ufunc.py
+++ b/pandas/tests/frame/test_ufunc.py
@@ -70,7 +70,7 @@ def test_binary_input_dispatch_binop(dtype):
         (np.power, [1, 2, 3, 4]),
     ],
 )
-def test_ufunc_passes_args(frame_or_series, func, expected):
+def test_ufunc_passes_args(func, expected):
     # GH#40662
     arr = np.array([[1, 2], [3, 4]])
     df = pd.DataFrame(arr)

--- a/pandas/tests/frame/test_ufunc.py
+++ b/pandas/tests/frame/test_ufunc.py
@@ -87,10 +87,6 @@ def test_ufunc_passes_args(func, arg, expected, request):
     result_inplace = np.zeros_like(arr)
     # 1-argument ufunc
     if arg is None:
-        mark = pytest.mark.xfail(
-            reason="Result becomes transposed with block-wise apply of ufunc, #40878"
-        )
-        request.node.add_marker(mark)
         result = func(df, out=result_inplace)
     else:
         result = func(df, arg, out=result_inplace)

--- a/pandas/tests/frame/test_ufunc.py
+++ b/pandas/tests/frame/test_ufunc.py
@@ -74,11 +74,14 @@ def test_ufunc_passes_args(func, expected):
     # GH#40662
     arr = np.array([[1, 2], [3, 4]])
     df = pd.DataFrame(arr)
-    result = np.zeros_like(df)
-    func(df, 1, out=result)
+    result_inplace = np.zeros_like(df)
+    result = func(df, 1, out=result_inplace)
 
     expected = np.array(expected).reshape(2, 2)
-    tm.assert_numpy_array_equal(result, expected)
+    tm.assert_numpy_array_equal(result_inplace, expected)
+
+    expected = pd.DataFrame(expected)
+    tm.assert_frame_equal(result, expected)
 
 
 @pytest.mark.parametrize("dtype_a", dtypes)

--- a/pandas/tests/frame/test_ufunc.py
+++ b/pandas/tests/frame/test_ufunc.py
@@ -64,10 +64,16 @@ def test_ufunc_passes_args():
     # GH#40662
     arr = np.array([[1, 2], [3, 4]])
     df = pd.DataFrame(arr)
-    arr_to_modify = np.zeros_like(df)
-    np.add(df, 1, out=arr_to_modify)
+    result = np.zeros_like(df)
+    np.add(df, 1, out=result)
 
-    tm.assert_numpy_array_equal(arr + 1, arr_to_modify)
+    expected = arr + 1
+    tm.assert_numpy_array_equal(result, expected)
+
+    result = np.zeros_like(df)
+    np.add(df, 1, out=result, where=[[False, True], [True, False]])
+    expected = np.array([[0, 3], [4, 0]])
+    tm.assert_numpy_array_equal(result, expected)
 
 
 @pytest.mark.parametrize("dtype_a", dtypes)

--- a/pandas/tests/frame/test_ufunc.py
+++ b/pandas/tests/frame/test_ufunc.py
@@ -60,6 +60,16 @@ def test_binary_input_dispatch_binop(dtype):
     tm.assert_frame_equal(result, expected)
 
 
+def test_ufunc_passes_args():
+    # GH#40662
+    arr = np.array([[1, 2], [3, 4]])
+    df = pd.DataFrame(arr)
+    arr_to_modify = np.zeros_like(df)
+    np.add(df, 1, out=arr_to_modify)
+
+    tm.assert_numpy_array_equal(arr + 1, arr_to_modify)
+
+
 @pytest.mark.parametrize("dtype_a", dtypes)
 @pytest.mark.parametrize("dtype_b", dtypes)
 def test_binary_input_aligns_columns(request, dtype_a, dtype_b):


### PR DESCRIPTION
- [x] closes #40662
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

Credit to @attack68 for the fix, just figured we should try to get this is in for 1.2.4 if possible since we know the fix.