### PR TITLE
Backport PR #40877 on branch 1.2.x (Skipt failing tests for numpy dev)

### DIFF
--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -12,6 +12,7 @@ import sys
 import warnings
 
 from pandas._typing import F
+from pandas.compat.numpy import is_numpy_dev
 
 PY38 = sys.version_info >= (3, 8)
 PY39 = sys.version_info >= (3, 9)
@@ -118,3 +119,8 @@ def get_lzma_file(lzma):
             "might be required to solve this issue."
         )
     return lzma.LZMAFile
+
+
+__all__ = [
+    "is_numpy_dev",
+]

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -12,7 +12,6 @@ import sys
 import warnings
 
 from pandas._typing import F
-from pandas.compat.numpy import is_numpy_dev
 
 PY38 = sys.version_info >= (3, 8)
 PY39 = sys.version_info >= (3, 9)
@@ -119,8 +118,3 @@ def get_lzma_file(lzma):
             "might be required to solve this issue."
         )
     return lzma.LZMAFile
-
-
-__all__ = [
-    "is_numpy_dev",
-]

--- a/pandas/tests/arrays/boolean/test_arithmetic.py
+++ b/pandas/tests/arrays/boolean/test_arithmetic.py
@@ -66,7 +66,10 @@ def test_div(left_array, right_array):
 @pytest.mark.parametrize(
     "opname",
     [
-        "floordiv",
+        pytest.param(
+            "floordiv",
+            marks=pytest.mark.xfail(reason="NumpyDev GH#40874", strict=False),
+        ),
         "mod",
         pytest.param(
             "pow", marks=pytest.mark.xfail(reason="TODO follow int8 behaviour? GH34686")

--- a/pandas/tests/arrays/masked/test_arithmetic.py
+++ b/pandas/tests/arrays/masked/test_arithmetic.py
@@ -3,6 +3,8 @@ from typing import Any, List
 import numpy as np
 import pytest
 
+from pandas.compat import is_numpy_dev
+
 import pandas as pd
 import pandas._testing as tm
 from pandas.core.arrays import ExtensionArray
@@ -49,6 +51,8 @@ def test_array_scalar_like_equivalence(data, all_arithmetic_operators):
 def test_array_NA(data, all_arithmetic_operators):
     if "truediv" in all_arithmetic_operators:
         pytest.skip("division with pd.NA raises")
+    if "floordiv" in all_arithmetic_operators and is_numpy_dev:
+        pytest.skip("NumpyDev behavior GH#40874")
     data, _ = data
     op = tm.get_op_from_name(all_arithmetic_operators)
     check_skip(data, all_arithmetic_operators)

--- a/pandas/tests/arrays/masked/test_arithmetic.py
+++ b/pandas/tests/arrays/masked/test_arithmetic.py
@@ -3,7 +3,7 @@ from typing import Any, List
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
+from pandas.compat.numpy import is_numpy_dev
 
 import pandas as pd
 import pandas._testing as tm

--- a/pandas/tests/extension/test_boolean.py
+++ b/pandas/tests/extension/test_boolean.py
@@ -16,6 +16,8 @@ be added to the array-specific tests in `pandas/tests/arrays/`.
 import numpy as np
 import pytest
 
+from pandas.compat import is_numpy_dev
+
 import pandas as pd
 import pandas._testing as tm
 from pandas.core.arrays.boolean import BooleanDtype
@@ -138,6 +140,26 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
         else:
             with pytest.raises(exc):
                 op(s, other)
+
+    def test_arith_series_with_scalar(self, data, all_arithmetic_operators):
+        if "floordiv" in all_arithmetic_operators and is_numpy_dev:
+            pytest.skip("NumpyDev behavior GH#40874")
+        super().test_arith_series_with_scalar(data, all_arithmetic_operators)
+
+    def test_arith_frame_with_scalar(self, data, all_arithmetic_operators):
+        if "floordiv" in all_arithmetic_operators and is_numpy_dev:
+            pytest.skip("NumpyDev behavior GH#40874")
+        super().test_arith_frame_with_scalar(data, all_arithmetic_operators)
+
+    def test_arith_series_with_array(self, data, all_arithmetic_operators):
+        if "floordiv" in all_arithmetic_operators and is_numpy_dev:
+            pytest.skip("NumpyDev behavior GH#40874")
+        super().test_arith_series_with_scalar(data, all_arithmetic_operators)
+
+    def test_divmod_series_array(self, data, data_for_twos):
+        if is_numpy_dev:
+            pytest.skip("NumpyDev behavior GH#40874")
+        super().test_divmod_series_array(data, data_for_twos)
 
     def _check_divmod_op(self, s, op, other, exc=None):
         # override to not raise an error

--- a/pandas/tests/extension/test_boolean.py
+++ b/pandas/tests/extension/test_boolean.py
@@ -16,7 +16,7 @@ be added to the array-specific tests in `pandas/tests/arrays/`.
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
+from pandas.compat.numpy import is_numpy_dev
 
 import pandas as pd
 import pandas._testing as tm

--- a/pandas/tests/extension/test_boolean.py
+++ b/pandas/tests/extension/test_boolean.py
@@ -146,11 +146,6 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
             pytest.skip("NumpyDev behavior GH#40874")
         super().test_arith_series_with_scalar(data, all_arithmetic_operators)
 
-    def test_arith_frame_with_scalar(self, data, all_arithmetic_operators):
-        if "floordiv" in all_arithmetic_operators and is_numpy_dev:
-            pytest.skip("NumpyDev behavior GH#40874")
-        super().test_arith_frame_with_scalar(data, all_arithmetic_operators)
-
     def test_arith_series_with_array(self, data, all_arithmetic_operators):
         if "floordiv" in all_arithmetic_operators and is_numpy_dev:
             pytest.skip("NumpyDev behavior GH#40874")


### PR DESCRIPTION
Backport PR #40877

Had to add the is_numpy_dev import, we could otherwise import from other directory if this would be preferrable