### PR TITLE
Addressing #40781 to raise ValueError as per discussion when a list with xlim or ylim is supplied, that contains elements in other format than integer or float type.

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -753,7 +753,7 @@ Plotting
 - Prevent warnings when matplotlib's ``constrained_layout`` is enabled (:issue:`25261`)
 - Bug in :func:`DataFrame.plot` was showing the wrong colors in the legend if the function was called repeatedly and some calls used ``yerr`` while others didn't (partial fix of :issue:`39522`)
 - Bug in :func:`DataFrame.plot` was showing the wrong colors in the legend if the function was called repeatedly and some calls used ``secondary_y`` and others use ``legend=False`` (:issue:`40044`)
-
+- Bug in :func:`DataFrame.plot.line` was taking ``xlim`` and ``ylim`` kwargs even if they had string elements, now ``ValueError`` is raised if elements are not ``int`` or ``float`` dtype.
 
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -505,6 +505,7 @@ class MPLPlot:
             )
 
         for ax in self.axes:
+
             if self.yticks is not None:
                 ax.set_yticks(self.yticks)
 
@@ -512,10 +513,22 @@ class MPLPlot:
                 ax.set_xticks(self.xticks)
 
             if self.ylim is not None:
-                ax.set_ylim(self.ylim)
+                    for elem in self.ylim: #Addressing issue #40781 raising ValueError if provided data type is not float or int.
+                        if not is_float(elem) and not is_integer(elem):
+                            raise ValueError(
+                                "`ylim` should contain y-Axis plot range in either float or integer datatype.\n"
+                               f"`ylim` had unsupported datatype of {type(elem)} with value {elem}. \n"
+                            )
+                    ax.set_ylim(self.ylim)
 
             if self.xlim is not None:
-                ax.set_xlim(self.xlim)
+                    for elem in self.xlim: #Addressing issue #40781 raising ValueError if provided data type is not float or int.
+                        if not is_float(elem) and not is_integer(elem):
+                            raise ValueError(
+                                "`xlim` should contain y-Axis plot range in either float or integer datatype.\n"
+                               f"`xlim` had unsupported datatype of {type(elem)} with value {elem}.\n"
+                            )
+                    ax.set_xlim(self.xlim)
 
             # GH9093, currently Pandas does not show ylabel, so if users provide
             # ylabel will set it as ylabel in the plot.


### PR DESCRIPTION
- [x] closes #40781 
- [x] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
