### PR TITLE
TST: add test for Index.where when needing to cast to object dtype

### DIFF
--- a/pandas/tests/indexes/numeric/test_indexing.py
+++ b/pandas/tests/indexes/numeric/test_indexing.py
@@ -376,6 +376,18 @@ class TestWhere:
         result = index.where(klass(cond))
         tm.assert_index_equal(result, expected)
 
+    def test_maybe_cast_with_dtype(self):
+        # https://github.com/pandas-dev/pandas/issues/32413
+        index = Index([1, np.nan])
+
+        cond = index.notna()
+        other = "a" + Index(range(2)).astype(str)
+
+        fixed_index = index.where(cond, other)
+
+        tm.assert_index_equal(other, Index(["a0", "a1"]))
+        tm.assert_index_equal(fixed_index, Index([1.0, "a1"]))
+
 
 class TestTake:
     @pytest.mark.parametrize("klass", [Float64Index, Int64Index, UInt64Index])

--- a/pandas/tests/indexes/test_indexing.py
+++ b/pandas/tests/indexes/test_indexing.py
@@ -248,20 +248,6 @@ class TestPutmask:
             index.putmask("foo", fill)
 
 
-class TestCasting:
-    def test_maybe_cast_with_dtype(self):
-        # https://github.com/pandas-dev/pandas/issues/32413
-        index = Index([1, np.nan])
-
-        cond = index.notna()
-        other = "a" + Index(range(2)).astype(str)
-
-        fixed_index = index.where(cond, other)
-
-        tm.assert_index_equal(other, Index(["a0", "a1"]))
-        tm.assert_index_equal(fixed_index, Index([1.0, "a1"]))
-
-
 @pytest.mark.parametrize(
     "idx", [Index([1, 2, 3]), Index([0.1, 0.2, 0.3]), Index(["a", "b", "c"])]
 )

--- a/pandas/tests/indexes/test_indexing.py
+++ b/pandas/tests/indexes/test_indexing.py
@@ -19,7 +19,6 @@ import pytest
 from pandas.errors import InvalidIndexError
 
 from pandas import (
-    DataFrame,
     DatetimeIndex,
     Float64Index,
     Index,
@@ -252,15 +251,15 @@ class TestPutmask:
 class TestCasting:
     def test_maybe_cast_with_dtype(self):
         # https://github.com/pandas-dev/pandas/issues/32413
-        frame = DataFrame(index=Index([1, np.nan]))
+        index = Index([1, np.nan])
 
-        cond = frame.index.notna()
-        other = "a" + frame.reset_index().index.astype(str)
+        cond = index.notna()
+        other = "a" + Index(range(2)).astype(str)
 
-        fixed_index = frame.index.where(cond, other)
+        fixed_index = index.where(cond, other)
 
-        assert (other == Index(["a0", "a1"])).all()
-        assert (fixed_index == Index([1.0, "a1"])).all()
+        tm.assert_index_equal(other, Index(["a0", "a1"]))
+        tm.assert_index_equal(fixed_index, Index([1.0, "a1"]))
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/indexes/test_indexing.py
+++ b/pandas/tests/indexes/test_indexing.py
@@ -19,6 +19,7 @@ import pytest
 from pandas.errors import InvalidIndexError
 
 from pandas import (
+    DataFrame,
     DatetimeIndex,
     Float64Index,
     Index,
@@ -246,6 +247,20 @@ class TestPutmask:
 
         with pytest.raises(ValueError, match=msg):
             index.putmask("foo", fill)
+
+
+class TestCasting:
+    def test_maybe_cast_with_dtype(self):
+        # https://github.com/pandas-dev/pandas/issues/32413
+        frame = DataFrame(index=Index([1, np.nan]))
+
+        cond = frame.index.notna()
+        other = "a" + frame.reset_index().index.astype(str)
+
+        fixed_index = frame.index.where(cond, other)
+
+        assert (other == Index(["a0", "a1"])).all()
+        assert (fixed_index == Index([1.0, "a1"])).all()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] closes #32413
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry: Adds a basic test for #32413.

Hey! This is my first PR with actual code: added a very basic test to validate #32413. 

Questions:
* What is the best place for this test? (currently put it in `pandas/tests/indexes/test_indexing.py`)
* Should I try to create another test that uses the `index` input argument? 