### PR TITLE
Raising ValueError when xlim and ylim contain non-int and non-float dtype elements

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -753,7 +753,7 @@ Plotting
 - Prevent warnings when matplotlib's ``constrained_layout`` is enabled (:issue:`25261`)
 - Bug in :func:`DataFrame.plot` was showing the wrong colors in the legend if the function was called repeatedly and some calls used ``yerr`` while others didn't (partial fix of :issue:`39522`)
 - Bug in :func:`DataFrame.plot` was showing the wrong colors in the legend if the function was called repeatedly and some calls used ``secondary_y`` and others use ``legend=False`` (:issue:`40044`)
-
+- Bug in :func:`DataFrame.plot` was taking ``xlim`` and ``ylim`` kwargs even if they had string elements, now ``ValueError`` is raised if elements are not ``int`` or ``float`` dtype (:issue:`40781`)
 
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -753,7 +753,7 @@ Plotting
 - Prevent warnings when matplotlib's ``constrained_layout`` is enabled (:issue:`25261`)
 - Bug in :func:`DataFrame.plot` was showing the wrong colors in the legend if the function was called repeatedly and some calls used ``yerr`` while others didn't (partial fix of :issue:`39522`)
 - Bug in :func:`DataFrame.plot` was showing the wrong colors in the legend if the function was called repeatedly and some calls used ``secondary_y`` and others use ``legend=False`` (:issue:`40044`)
-- Bug in :func:`DataFrame.plot` was taking ``xlim`` and ``ylim`` kwargs even if they had string elements, now ``ValueError`` is raised if elements are not ``int`` or ``float`` dtype (:issue:`40781`)
+- Bug in :func:`DataFrame.plot` was not raising for invalid ``xlim`` and ``ylim`` dtypes (:issue:`40781`)
 
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -489,13 +489,17 @@ class MPLPlot:
         """Post process for each axes. Overridden in child classes"""
         pass
 
-    def has_iterable_only_float_or_int(self, list_iterable: list) -> bool:
-        """checks if an iterable has float or int datatype """
+    def _has_iterable_only_float_int_or_datetime(self, list_iterable: list) -> bool:
+        """checks if an iterable has float,int or datetime datatype """
         """targeting #GH40781"""
-        for item in list_iterable:
-            if not is_integer(item) and not is_float(item):
-                return False
-        return True
+        from datetime import datetime as dt
+        if (
+            all(([isinstance(x, dt) for x in list_iterable]))
+            or np.issubdtype(np.array(list_iterable).dtype, np.int)
+            or np.issubdtype(np.array(list_iterable).dtype, np.float)
+        ):
+            return True
+        return False
 
     def _adorn_subplots(self):
         """Common post process unrelated to data"""
@@ -522,19 +526,19 @@ class MPLPlot:
             # Addressing issue #40781 raising ValueError
             # if xlim or ylim contain non float or non int dtype
             if self.ylim is not None:
-                if not self.has_iterable_only_float_or_int(self.ylim):
+                if not self._has_iterable_only_float_int_or_datetime(self.ylim):
                     raise ValueError(
                         "`ylim` contains values"
-                        " which are not of float or int type"
+                        " which are not of float, int or datetime type"
                         f" in {self.ylim}"
                     )
                 ax.set_ylim(self.ylim)
 
             if self.xlim is not None:
-                if not self.has_iterable_only_float_or_int(self.xlim):
+                if not self._has_iterable_only_float_int_or_datetime(self.xlim):
                     raise ValueError(
                         "`xlim` contains values"
-                        " which are not of float or int type"
+                        " which are not of float, int or datetime type"
                         f" in {self.xlim}"
                     )
                 ax.set_xlim(self.xlim)

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -491,8 +491,8 @@ class MPLPlot:
         pass
 
     def _has_valid_lim_dtype(self, list_iterable: list) -> bool:
-        """checks if an iterable has float,int or datetime datatype """
-        """targeting #GH40781"""
+        """Check if an iterable has float, int or datetime datatype"""
+        # GH40781
         if (
             all([is_datetime64_any_dtype(lim) for lim in list_iterable])
             or np.issubdtype(np.array(list_iterable).dtype, np.int)

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -24,6 +24,7 @@ from pandas.core.dtypes.common import (
     is_list_like,
     is_number,
     is_numeric_dtype,
+    is_datetime64_any_dtype
 )
 from pandas.core.dtypes.generic import (
     ABCDataFrame,
@@ -489,12 +490,11 @@ class MPLPlot:
         """Post process for each axes. Overridden in child classes"""
         pass
 
-    def _has_iterable_only_float_int_or_datetime(self, list_iterable: list) -> bool:
+    def _has_valid_lim_dtype(self, list_iterable: list) -> bool:
         """checks if an iterable has float,int or datetime datatype """
         """targeting #GH40781"""
-        from datetime import datetime as dt
         if (
-            all(([isinstance(x, dt) for x in list_iterable]))
+            all([is_datetime64_any_dtype(lim) for lim in list_iterable])
             or np.issubdtype(np.array(list_iterable).dtype, np.int)
             or np.issubdtype(np.array(list_iterable).dtype, np.float)
         ):
@@ -523,22 +523,22 @@ class MPLPlot:
             if self.xticks is not None:
                 ax.set_xticks(self.xticks)
 
-            # Addressing issue #40781 raising ValueError
+            # Addressing issue #GH40781 raising ValueError
             # if xlim or ylim contain non float or non int dtype
             if self.ylim is not None:
-                if not self._has_iterable_only_float_int_or_datetime(self.ylim):
+                if not self._has_valid_lim_dtype(self.ylim):
                     raise ValueError(
                         "`ylim` contains values"
-                        " which are not of float, int or datetime type"
+                        " which are not of float, int or numpy.datetime64 dtype"
                         f" in {self.ylim}"
                     )
                 ax.set_ylim(self.ylim)
 
             if self.xlim is not None:
-                if not self._has_iterable_only_float_int_or_datetime(self.xlim):
+                if not self._has_valid_lim_dtype(self.xlim):
                     raise ValueError(
                         "`xlim` contains values"
-                        " which are not of float, int or datetime type"
+                        " which are not of float, int or numpy.datetime64 dtype"
                         f" in {self.xlim}"
                     )
                 ax.set_xlim(self.xlim)

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -489,6 +489,14 @@ class MPLPlot:
         """Post process for each axes. Overridden in child classes"""
         pass
 
+    def has_iterable_only_float_or_int(self, list_iterable: list) -> bool:
+        """checks if an iterable has float or int datatype """
+        """targeting #GH40781"""
+        for item in list_iterable:
+            if not is_integer(item) and not is_float(item):
+                return False
+        return True
+
     def _adorn_subplots(self):
         """Common post process unrelated to data"""
         if len(self.axes) > 0:
@@ -511,10 +519,24 @@ class MPLPlot:
             if self.xticks is not None:
                 ax.set_xticks(self.xticks)
 
+            # Addressing issue #40781 raising ValueError
+            # if xlim or ylim contain non float or non int dtype
             if self.ylim is not None:
+                if not self.has_iterable_only_float_or_int(self.ylim):
+                    raise ValueError(
+                        "`ylim` contains values"
+                        " which are not of float or int type"
+                        f" in {self.ylim}"
+                    )
                 ax.set_ylim(self.ylim)
 
             if self.xlim is not None:
+                if not self.has_iterable_only_float_or_int(self.xlim):
+                    raise ValueError(
+                        "`xlim` contains values"
+                        " which are not of float or int type"
+                        f" in {self.xlim}"
+                    )
                 ax.set_xlim(self.xlim)
 
             # GH9093, currently Pandas does not show ylabel, so if users provide

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -14,6 +14,7 @@ from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.common import (
     is_categorical_dtype,
+    is_datetime64_any_dtype,
     is_extension_array_dtype,
     is_float,
     is_float_dtype,
@@ -24,7 +25,6 @@ from pandas.core.dtypes.common import (
     is_list_like,
     is_number,
     is_numeric_dtype,
-    is_datetime64_any_dtype
 )
 from pandas.core.dtypes.generic import (
     ABCDataFrame,

--- a/pandas/tests/plotting/test_xlim_ylim_dtype.py
+++ b/pandas/tests/plotting/test_xlim_ylim_dtype.py
@@ -1,51 +1,51 @@
-import pytest
-import pandas as pd
 from datetime import datetime as dt
+
 import numpy as np
+import pytest
 
-"""targeting #GH40781"""
+from pandas import DataFrame
 
-# arbitrary df to test
-df = pd.DataFrame(
-    {
-        "A" : [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        "B": [dt.now() for i in range(0, 10)]
-    }
+
+@pytest.mark.parametrize("df, lim", [
+    (
+        DataFrame(
+            {
+                "A" : [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                "B": [dt.now() for i in range(0, 10)]
+            }
+        ),
+        [
+            ["1", "3"],
+            [dt.now(), dt.now()],
+            [1, "2"],
+            [0.1, "0.2"],
+            [np.datetime64(dt.now()), dt.now()]
+        ]
+    )
+]
 )
-
-
-def test_axis_lim_invalid():
-    global df
-    """
-    supplying ranges with str, datetime and
-    mixed int,str and float,str dtype to raise
-    ValueError. Valid dtypes are np.datetime64
-    int, and float.
-    """
-    lim = [
-        ["1", "3"],
-        [dt.now(), dt.now()],
-        [1, "2"],
-        [0.1, "0.2"],
-        [np.datetime64(dt.now()), dt.now()]
-    ]
+def test_axis_lim_invalid(df, lim):
     for elem in lim:
         with pytest.raises(ValueError, match="`xlim` contains values"):
             df.plot.line(x="A", xlim=elem)
 
 
-def test_axis_lim_valid():
-    global df
-    """
-    supplying ranges with
-    valid dtypes: np.datetime64
-    int, and float, this test
-    should not raise errors.
-    """
-    lim = [
-        [1, 3],
-        [np.datetime64(dt.now()), np.datetime64(dt.now())],
-        [0.1, 0.2],
-    ]
+@pytest.mark.parametrize("df, lim", [
+    (
+        DataFrame(
+            {
+                "A" : [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                "B": [dt.now() for i in range(0, 10)]
+            }
+        ),
+        [
+            [1, 3],
+            [0.1, 0.2],
+            [np.datetime64(dt.now()), np.datetime64(dt.now())]
+        ]
+    )
+]
+)
+def test_axis_lim_valid(df, lim):
     for elem in lim:
-        df.plot.line(x="A", ylim=elem)
+        df.plot.line(x="A", xlim=elem)

--- a/pandas/tests/plotting/test_xlim_ylim_dtype.py
+++ b/pandas/tests/plotting/test_xlim_ylim_dtype.py
@@ -1,122 +1,51 @@
 import pytest
 import pandas as pd
 from datetime import datetime as dt
+import numpy as np
 
 """targeting #GH40781"""
 
-
-def test_if_plotable_xlim_ylim_both_ints() -> bool:
-    # checks if ValueError is raised with invalid dtype
-    df = pd.DataFrame({
-        "A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        "B" : [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
-    })
-    try:
-        df.plot(kind="line", x="A", xlim=[1, 2], ylim=[3, 4])
-        return True
-    except ValueError:
-        pytest.raises(ValueError, match="FAILED")
+# arbitrary df to test
+df = pd.DataFrame(
+    {
+        "A" : [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "B": [dt.now() for i in range(0, 10)]
+    }
+)
 
 
-def test_if_plotable_xlim_first_int() -> bool:
-    # checks if ValueError is raised with invalid dtype
-    df = pd.DataFrame({
-        "A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        "B" : [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
-    })
-    try:
-        df.plot(kind="line", x="A", xlim=[1, "2"], ylim=[3, 4])
-        pytest.raises(ValueError, match="FAILED")
-    except ValueError:
-        return True
+def test_axis_lim_invalid():
+    global df
+    """
+    supplying ranges with str, datetime and
+    mixed int,str and float,str dtype to raise
+    ValueError. Valid dtypes are np.datetime64
+    int, and float.
+    """
+    lim = [
+        ["1", "3"],
+        [dt.now(), dt.now()],
+        [1, "2"],
+        [0.1, "0.2"],
+        [np.datetime64(dt.now()), dt.now()]
+    ]
+    for elem in lim:
+        with pytest.raises(ValueError, match="`xlim` contains values"):
+            df.plot.line(x="A", xlim=elem)
 
 
-def test_if_plotable_xlim_first_str() -> bool:
-    # checks if ValueError is raised with invalid dtype
-    df = pd.DataFrame({
-        "A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        "B" : [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
-    })
-    try:
-        df.plot(kind="line", x="A", xlim=["1", 2], ylim=[3, 4])
-        pytest.raises(ValueError, match="FAILED")
-    except ValueError:
-        return True
-
-
-def test_if_plotable_ylim_first_int() -> bool:
-    # checks if ValueError is raised with invalid dtype
-    df = pd.DataFrame({
-        "A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        "B" : [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
-    })
-    try:
-        df.plot(kind="line", x="A", xlim=[1, 2], ylim=[3, "4"])
-        pytest.raises(ValueError, match="FAILED")
-    except ValueError:
-        return True
-
-
-def test_if_plotable_ylim_first_str() -> bool:
-    # checks if ValueError is raised with invalid dtype
-    df = pd.DataFrame({
-        "A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        "B" : [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
-    })
-    try:
-        df.plot(kind="line", x="A", xlim=[1, 2], ylim=["3", 4])
-        pytest.raises(ValueError, match="FAILED")
-    except ValueError:
-        return True
-
-
-def test_if_plotable_ylim_both_str() -> bool:
-    # checks if ValueError is raised with invalid dtype
-    df = pd.DataFrame({
-        "A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        "B" : [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
-    })
-    try:
-        df.plot(kind="line", x="A", xlim=[1, 2], ylim=["3", "4"])
-        pytest.raises(ValueError, match="FAILED")
-    except ValueError:
-        return True
-
-
-def test_if_plotable_xlim_both_str() -> bool:
-    # checks if ValueError is raised with invalid dtype
-    df = pd.DataFrame({
-        "A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        "B" : [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
-    })
-    try:
-        df.plot(kind="line", x="A", xlim=["1", "2"], ylim=[3, 4])
-        pytest.raises(ValueError, match="FAILED")
-    except ValueError:
-        return True
-
-
-def test_if_plotable_xlim_datetime() -> bool:
-    # checks if ValueError is raised with invalid dtype
-    df = pd.DataFrame({
-        "A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        "B" : [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
-    })
-    try:
-        df.plot(kind="line", x="A", xlim=[dt.now(), dt.now()], ylim=[3, 4])
-        pytest.raises(ValueError, match="FAILED")
-    except ValueError:
-        return True
-
-
-def test_if_plotable_xlim_datetime_str() -> bool:
-    # checks if ValueError is raised with invalid dtype
-    df = pd.DataFrame({
-        "A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        "B" : [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
-    })
-    try:
-        df.plot(kind="line", x="A", xlim=[dt.now(), "1"], ylim=[3, 4])
-        pytest.raises(ValueError, match="FAILED")
-    except ValueError:
-        return True
+def test_axis_lim_valid():
+    global df
+    """
+    supplying ranges with
+    valid dtypes: np.datetime64
+    int, and float, this test
+    should not raise errors.
+    """
+    lim = [
+        [1, 3],
+        [np.datetime64(dt.now()), np.datetime64(dt.now())],
+        [0.1, 0.2],
+    ]
+    for elem in lim:
+        df.plot.line(x="A", ylim=elem)

--- a/pandas/tests/plotting/test_xlim_ylim_dtype.py
+++ b/pandas/tests/plotting/test_xlim_ylim_dtype.py
@@ -2,6 +2,8 @@ import pytest
 import pandas as pd
 from datetime import datetime as dt
 
+"""targeting #GH40781"""
+
 
 def test_if_plotable_xlim_ylim_both_ints() -> bool:
     # checks if ValueError is raised with invalid dtype

--- a/pandas/tests/plotting/test_xlim_ylim_dtype.py
+++ b/pandas/tests/plotting/test_xlim_ylim_dtype.py
@@ -9,23 +9,25 @@ from pandas import DataFrame
 pytestmark = pytest.mark.slow
 
 
-@pytest.mark.parametrize("df, lim", [
-    (
-        DataFrame(
-            {
-                "A" : [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-                "B": [dt.now() for i in range(0, 10)]
-            }
-        ),
-        [
-            ["1", "3"],
-            [dt.now(), dt.now()],
-            [1, "2"],
-            [0.1, "0.2"],
-            [np.datetime64(dt.now()), dt.now()]
-        ]
-    )
-]
+@pytest.mark.parametrize(
+    "df, lim",
+    [
+        (
+            DataFrame(
+                {
+                    "A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                    "B": [dt.now() for i in range(0, 10)],
+                }
+            ),
+            [
+                ["1", "3"],
+                [dt.now(), dt.now()],
+                [1, "2"],
+                [0.1, "0.2"],
+                [np.datetime64(dt.now()), dt.now()],
+            ],
+        )
+    ],
 )
 def test_axis_lim_invalid(df, lim):
     for elem in lim:
@@ -33,21 +35,19 @@ def test_axis_lim_invalid(df, lim):
             df.plot.line(x="A", xlim=elem)
 
 
-@pytest.mark.parametrize("df, lim", [
-    (
-        DataFrame(
-            {
-                "A" : [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-                "B": [dt.now() for i in range(0, 10)]
-            }
-        ),
-        [
-            [1, 3],
-            [0.1, 0.2],
-            [np.datetime64(dt.now()), np.datetime64(dt.now())]
-        ]
-    )
-]
+@pytest.mark.parametrize(
+    "df, lim",
+    [
+        (
+            DataFrame(
+                {
+                    "A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                    "B": [dt.now() for i in range(0, 10)],
+                }
+            ),
+            [[1, 3], [0.1, 0.2], [np.datetime64(dt.now()), np.datetime64(dt.now())]],
+        )
+    ],
 )
 def test_axis_lim_valid(df, lim):
     for elem in lim:

--- a/pandas/tests/plotting/test_xlim_ylim_dtype.py
+++ b/pandas/tests/plotting/test_xlim_ylim_dtype.py
@@ -1,0 +1,93 @@
+import pytest
+import pandas as pd
+
+
+def test_if_plotable_xlim_ylim_both_ints() -> bool:
+    # checks if ValueError is raised with invalid dtype
+    df = pd.DataFrame({
+        "A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "B" : [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+    })
+    try:
+        df.plot(kind="line", x="A", xlim=[1, 2], ylim=[3, 4])
+        return True
+    except ValueError:
+        pytest.raises(ValueError, match="FAILED")
+
+
+def test_if_plotable_xlim_first_int() -> bool:
+    # checks if ValueError is raised with invalid dtype
+    df = pd.DataFrame({
+        "A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "B" : [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+    })
+    try:
+        df.plot(kind="line", x="A", xlim=[1, "2"], ylim=[3, 4])
+        pytest.raises(ValueError, match="FAILED")
+    except ValueError:
+        return True
+
+
+def test_if_plotable_xlim_first_str() -> bool:
+    # checks if ValueError is raised with invalid dtype
+    df = pd.DataFrame({
+        "A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "B" : [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+    })
+    try:
+        df.plot(kind="line", x="A", xlim=["1", 2], ylim=[3, 4])
+        pytest.raises(ValueError, match="FAILED")
+    except ValueError:
+        return True
+
+
+def test_if_plotable_ylim_first_int() -> bool:
+    # checks if ValueError is raised with invalid dtype
+    df = pd.DataFrame({
+        "A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "B" : [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+    })
+    try:
+        df.plot(kind="line", x="A", xlim=[1, 2], ylim=[3, "4"])
+        pytest.raises(ValueError, match="FAILED")
+    except ValueError:
+        return True
+
+
+def test_if_plotable_ylim_first_str() -> bool:
+    # checks if ValueError is raised with invalid dtype
+    df = pd.DataFrame({
+        "A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "B" : [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+    })
+    try:
+        df.plot(kind="line", x="A", xlim=[1, 2], ylim=["3", 4])
+        pytest.raises(ValueError, match="FAILED")
+    except ValueError:
+        return True
+
+
+def test_if_plotable_ylim_both_str() -> bool:
+    # checks if ValueError is raised with invalid dtype
+    df = pd.DataFrame({
+        "A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "B" : [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+    })
+    try:
+        df.plot(kind="line", x="A", xlim=[1, 2], ylim=["3", "4"])
+        pytest.raises(ValueError, match="FAILED")
+    except ValueError:
+        return True
+
+
+def test_if_plotable_xlim_both_str() -> bool:
+    # checks if ValueError is raised with invalid dtype
+    df = pd.DataFrame({
+        "A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "B" : [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+    })
+    try:
+        df.plot(kind="line", x="A", xlim=["1", "2"], ylim=[3, 4])
+        pytest.raises(ValueError, match="FAILED")
+    except ValueError:
+        return True

--- a/pandas/tests/plotting/test_xlim_ylim_dtype.py
+++ b/pandas/tests/plotting/test_xlim_ylim_dtype.py
@@ -1,10 +1,12 @@
 from datetime import datetime as dt
 
-import matplotlib
 import numpy as np
 import pytest
 
+pytest.importorskip("matplotlib")
 from pandas import DataFrame
+
+pytestmark = pytest.mark.slow
 
 
 @pytest.mark.parametrize("df, lim", [

--- a/pandas/tests/plotting/test_xlim_ylim_dtype.py
+++ b/pandas/tests/plotting/test_xlim_ylim_dtype.py
@@ -1,5 +1,6 @@
 from datetime import datetime as dt
 
+import matplotlib
 import numpy as np
 import pytest
 

--- a/pandas/tests/plotting/test_xlim_ylim_dtype.py
+++ b/pandas/tests/plotting/test_xlim_ylim_dtype.py
@@ -1,5 +1,6 @@
 import pytest
 import pandas as pd
+from datetime import datetime as dt
 
 
 def test_if_plotable_xlim_ylim_both_ints() -> bool:
@@ -88,6 +89,32 @@ def test_if_plotable_xlim_both_str() -> bool:
     })
     try:
         df.plot(kind="line", x="A", xlim=["1", "2"], ylim=[3, 4])
+        pytest.raises(ValueError, match="FAILED")
+    except ValueError:
+        return True
+
+
+def test_if_plotable_xlim_datetime() -> bool:
+    # checks if ValueError is raised with invalid dtype
+    df = pd.DataFrame({
+        "A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "B" : [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+    })
+    try:
+        df.plot(kind="line", x="A", xlim=[dt.now(), dt.now()], ylim=[3, 4])
+        pytest.raises(ValueError, match="FAILED")
+    except ValueError:
+        return True
+
+
+def test_if_plotable_xlim_datetime_str() -> bool:
+    # checks if ValueError is raised with invalid dtype
+    df = pd.DataFrame({
+        "A": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "B" : [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+    })
+    try:
+        df.plot(kind="line", x="A", xlim=[dt.now(), "1"], ylim=[3, 4])
         pytest.raises(ValueError, match="FAILED")
     except ValueError:
         return True


### PR DESCRIPTION
- [x] closes #40781 
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
