### PR TITLE
CLN: change jinja2 template name to `template_html`

### DIFF
--- a/doc/source/reference/style.rst
+++ b/doc/source/reference/style.rst
@@ -23,7 +23,7 @@ Styler properties
    :toctree: api/
 
    Styler.env
-   Styler.template
+   Styler.template_html
    Styler.loader
 
 Style application

--- a/doc/source/user_guide/style.ipynb
+++ b/doc/source/user_guide/style.ipynb
@@ -1710,7 +1710,7 @@
     "            Styler.loader,  # the default\n",
     "        ])\n",
     "    )\n",
-    "    template = env.get_template(\"myhtml.tpl\")"
+    "    template_html = env.get_template(\"myhtml.tpl\")"
    ]
   },
   {

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -1485,7 +1485,7 @@ class Styler(StylerRenderer):
         # error: Invalid base class "cls"
         class MyStyler(cls):  # type:ignore[valid-type,misc]
             env = jinja2.Environment(loader=loader)
-            template = env.get_template(name)
+            template_html = env.get_template(name)
 
         return MyStyler
 

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -58,7 +58,7 @@ class StylerRenderer:
 
     loader = jinja2.PackageLoader("pandas", "io/formats/templates")
     env = jinja2.Environment(loader=loader, trim_blocks=True)
-    template = env.get_template("html.tpl")
+    template_html = env.get_template("html.tpl")
 
     def __init__(
         self,
@@ -143,7 +143,7 @@ class StylerRenderer:
         # TODO: namespace all the pandas keys
         d = self._translate()
         d.update(kwargs)
-        return self.template.render(**d)
+        return self.template_html.render(**d)
 
     def _compute(self):
         """

--- a/pandas/tests/io/formats/style/test_style.py
+++ b/pandas/tests/io/formats/style/test_style.py
@@ -1367,7 +1367,7 @@ def test_block_names():
         "tr",
         "after_rows",
     }
-    result = set(Styler.template.blocks)
+    result = set(Styler.template_html.blocks)
     assert result == expected
 
 
@@ -1386,6 +1386,6 @@ def test_from_custom_template(tmpdir):
     result = Styler.from_custom_template(str(tmpdir.join("templates")), "myhtml.tpl")
     assert issubclass(result, Styler)
     assert result.env is not Styler.env
-    assert result.template is not Styler.template
+    assert result.template_html is not Styler.template_html
     styler = result(DataFrame({"A": [1, 2]}))
     assert styler.render()


### PR DESCRIPTION
prior to adding `template_latex` this changes the name of the html template to `template_html` including:

- updating docs on the new name for subclassing
- updating the custom method for subclassing
- updating tests which refer to it
