### PR TITLE
TST: Add test to verify DataFrame's constructor doesn't convert Nones to strings on string columns

### DIFF
--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2397,17 +2397,18 @@ class TestDataFrameConstructors:
             assert df.iloc[0, 2] == 0
 
     def test_consistency_of_string_columns_with_none(self):
-        # df created from list, None is casted to str
+        # https://github.com/pandas-dev/pandas/issues/32218
+
         df = DataFrame(["1", "2", None], columns=["a"], dtype="str")
 
-        assert isinstance(df.loc[0].values[0], str)
-        assert df.loc[2].values[0] is None
+        assert isinstance(df.loc[0, "a"], str)
+        assert df.loc[2, "a"] is None
 
         # Equivalent df created from dict, None remains NoneType
         df = DataFrame({"a": ["1", "2", None]}, dtype="str")
 
-        assert isinstance(df.loc[0].values[0], str)
-        assert df.loc[2].values[0] is None
+        assert isinstance(df.loc[0, "a"], str)
+        assert df.loc[2, "a"] is None
 
 
 class TestDataFrameConstructorWithDatetimeTZ:

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2396,6 +2396,15 @@ class TestDataFrameConstructors:
             # assert b[0] == 0
             assert df.iloc[0, 2] == 0
 
+    def test_consistency_of_string_columns_with_none(self):
+        # df created from list, None is casted to str
+        df = DataFrame(["1", "2", None], columns=["a"], dtype="str")
+        type(df.loc[2].values[0])
+
+        # Equivalent df created from dict, None remains NoneType
+        df = DataFrame({"a": ["1", "2", None]}, dtype="str")
+        type(df.loc[2].values[0])
+
 
 class TestDataFrameConstructorWithDatetimeTZ:
     @pytest.mark.parametrize("tz", ["US/Eastern", "dateutil/US/Eastern"])

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2399,11 +2399,15 @@ class TestDataFrameConstructors:
     def test_consistency_of_string_columns_with_none(self):
         # df created from list, None is casted to str
         df = DataFrame(["1", "2", None], columns=["a"], dtype="str")
-        type(df.loc[2].values[0])
+
+        assert isinstance(df.loc[0].values[0], str)
+        assert df.loc[2].values[0] is None
 
         # Equivalent df created from dict, None remains NoneType
         df = DataFrame({"a": ["1", "2", None]}, dtype="str")
-        type(df.loc[2].values[0])
+
+        assert isinstance(df.loc[0].values[0], str)
+        assert df.loc[2].values[0] is None
 
 
 class TestDataFrameConstructorWithDatetimeTZ:


### PR DESCRIPTION
- [x] closes #32218
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

### whatsnew
Adds a very simple test to verify that `None`s are not casted to strings as `"None"` inside the DataFrame's constructor for string columns.

Questions:
* Should the test be more general?
* What is the proper location for the test?
