### PR TITLE
PR for DOC: inconsistency in doc argument types #40560

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1546,13 +1546,13 @@ def searchsorted(arr, value, side="left", sorter=None) -> np.ndarray:
         Input array. If `sorter` is None, then it must be sorted in
         ascending order, otherwise `sorter` must be an array of indices
         that sort it.
-    value : array_like
+    value : array-like
         Values to insert into `arr`.
     side : {'left', 'right'}, optional
         If 'left', the index of the first suitable location found is given.
         If 'right', return the last such index.  If there is no suitable
         index, return either 0 or N (where N is the length of `self`).
-    sorter : 1-D array_like, optional
+    sorter : 1-D array-like, optional
         Optional array of integer indices that sort array a into ascending
         order. They are typically the result of argsort.
 

--- a/pandas/core/array_algos/replace.py
+++ b/pandas/core/array_algos/replace.py
@@ -45,14 +45,14 @@ def compare_or_regex_search(
     a: ArrayLike, b: Union[Scalar, Pattern], regex: bool, mask: np.ndarray
 ) -> Union[ArrayLike, bool]:
     """
-    Compare two array_like inputs of the same shape or two scalar values
+    Compare two array-like inputs of the same shape or two scalar values
 
     Calls operator.eq or re.search, depending on regex argument. If regex is
     True, perform an element-wise regex matching.
 
     Parameters
     ----------
-    a : array_like
+    a : array-like
     b : scalar or regex pattern
     regex : bool
     mask : np.ndarray[bool]

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -832,7 +832,7 @@ class ExtensionArray:
             If 'left', the index of the first suitable location found is given.
             If 'right', return the last such index.  If there is no suitable
             index, return either 0 or N (where N is the length of `self`).
-        sorter : 1-D array_like, optional
+        sorter : 1-D array-like, optional
             Optional array of integer indices that sort array a into ascending
             order. They are typically the result of argsort.
 

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -826,7 +826,7 @@ class ExtensionArray:
 
         Parameters
         ----------
-        value : array_like
+        value : array-like
             Values to insert into `self`.
         side : {'left', 'right'}, optional
             If 'left', the index of the first suitable location found is given.

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1159,13 +1159,13 @@ class IndexOpsMixin(OpsMixin):
 
         Parameters
         ----------
-        value : array_like
+        value : array-like
             Values to insert into `self`.
         side : {{'left', 'right'}}, optional
             If 'left', the index of the first suitable location found is given.
             If 'right', return the last such index.  If there is no suitable
             index, return either 0 or N (where N is the length of `self`).
-        sorter : 1-D array_like, optional
+        sorter : 1-D array-like, optional
             Optional array of integer indices that sort `self` into ascending
             order. They are typically the result of ``np.argsort``.
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6010,8 +6010,8 @@ class Index(IndexOpsMixin, PandasObject):
 
         Returns
         -------
-        any : bool or array_like (if axis is specified)
-            A single element array_like may be converted to bool.
+        any : bool or array-like (if axis is specified)
+            A single element array-like may be converted to bool.
 
         See Also
         --------
@@ -6054,7 +6054,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         Returns
         -------
-        all : bool or array_like (if axis is specified)
+        all : bool or array-like (if axis is specified)
             A single element array_like may be converted to bool.
 
         See Also

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3893,7 +3893,7 @@ def maybe_droplevels(index: Index, key) -> Index:
     return index
 
 
-def _coerce_indexer_frozen(array_like, categories, copy: bool = False) -> np.ndarray:
+def _coerce_indexer_frozen(array-like, categories, copy: bool = False) -> np.ndarray:
     """
     Coerce the array_like indexer to the smallest integer dtype that can encode all
     of the given categories.

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1280,7 +1280,7 @@ class Block(PandasObject):
         -------
         blocks : list of Block
             New blocks of unstacked values.
-        mask : array_like of bool
+        mask : array-like of bool
             The mask of columns of `blocks` we should keep.
         """
         new_values, mask = unstacker.get_new_values(

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -524,7 +524,7 @@ def _from_derivatives(xi, yi, x, order=None, der=0, extrapolate=False):
 
     Parameters
     ----------
-    xi : array_like
+    xi : array-like
         sorted 1D array of x-coordinates
     yi : array_like or list of array-likes
         yi[i][j] is the j-th derivative known at xi[i]

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -526,9 +526,9 @@ def _from_derivatives(xi, yi, x, order=None, der=0, extrapolate=False):
     ----------
     xi : array-like
         sorted 1D array of x-coordinates
-    yi : array_like or list of array-likes
+    yi : array-like or list of array-likes
         yi[i][j] is the j-th derivative known at xi[i]
-    order: None or int or array_like of ints. Default: None.
+    order: None or int or array-like of ints. Default: None.
         Specifies the degree of local polynomials. If not None, some
         derivatives are ignored.
     der : int or list

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -427,7 +427,7 @@ _bar_or_line_doc = """
         y : label or position, optional
             Allows plotting of one column versus another. If not specified,
             all numerical columns are used.
-        color : str, array_like, or dict, optional
+        color : str, array-like, or dict, optional
             The color for each of the DataFrame's columns. Possible values are:
 
             - A single color string referred to by name, RGB or RGBA code,
@@ -1568,7 +1568,7 @@ class PlotAccessor(PandasObject):
         y : int or str
             The column name or column position to be used as vertical
             coordinates for each point.
-        s : str, scalar or array_like, optional
+        s : str, scalar or array-like, optional
             The size of each point. Possible values are:
 
             - A string with the name of the column to be used for marker's size.


### PR DESCRIPTION
This PR is used to address documentation inconsistencies as in issue #40560. Array_like have been changed to array-like 