### PR TITLE
DOC: inconsistency in doc argument types #40560

### DIFF
--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -24,7 +24,7 @@ from pandas.core.dtypes.common import (
     is_datetime_or_timedelta_dtype,
     is_extension_array_dtype,
     is_integer,
-    is_integer_dtype,
+    is_numeric_dtype,
     is_list_like,
     is_scalar,
     is_timedelta64_dtype,
@@ -488,7 +488,7 @@ def _coerce_to_type(x):
     # Will properly support in the future.
     # https://github.com/pandas-dev/pandas/pull/31290
     # https://github.com/pandas-dev/pandas/issues/31389
-    elif is_extension_array_dtype(x.dtype) and is_integer_dtype(x.dtype):
+    elif is_extension_array_dtype(x.dtype) and is_numeric_dtype(x.dtype):
         x = x.to_numpy(dtype=np.float64, na_value=np.nan)
 
     if dtype is not None:


### PR DESCRIPTION
This PR is used to address documentation inconsistencies as in issue #40560. All Array_like has been changed to array-like. However, Array_like that is used as a parameter cannot be changed as it would be identified as "array minus like".