### PR TITLE
CLN: remove unused out kwd from take functions

### DIFF
--- a/pandas/core/array_algos/take.py
+++ b/pandas/core/array_algos/take.py
@@ -100,14 +100,13 @@ def take_nd(
         return arr.take(indexer, fill_value=fill_value, allow_fill=allow_fill)
 
     arr = np.asarray(arr)
-    return _take_nd_ndarray(arr, indexer, axis, None, fill_value, allow_fill)
+    return _take_nd_ndarray(arr, indexer, axis, fill_value, allow_fill)
 
 
 def _take_nd_ndarray(
     arr: np.ndarray,
     indexer,
     axis: int,
-    out: np.ndarray | None,
     fill_value,
     allow_fill: bool,
 ) -> np.ndarray:
@@ -119,7 +118,7 @@ def _take_nd_ndarray(
         indexer = ensure_platform_int(indexer)
 
     indexer, dtype, fill_value, mask_info = _take_preprocess_indexer_and_fill_value(
-        arr, indexer, out, fill_value, allow_fill
+        arr, indexer, fill_value, allow_fill
     )
 
     flip_order = False
@@ -129,23 +128,20 @@ def _take_nd_ndarray(
     if flip_order:
         arr = arr.T
         axis = arr.ndim - axis - 1
-        if out is not None:
-            out = out.T
 
     # at this point, it's guaranteed that dtype can hold both the arr values
     # and the fill_value
-    if out is None:
-        out_shape_ = list(arr.shape)
-        out_shape_[axis] = len(indexer)
-        out_shape = tuple(out_shape_)
-        if arr.flags.f_contiguous and axis == arr.ndim - 1:
-            # minor tweak that can make an order-of-magnitude difference
-            # for dataframes initialized directly from 2-d ndarrays
-            # (s.t. df.values is c-contiguous and df._mgr.blocks[0] is its
-            # f-contiguous transpose)
-            out = np.empty(out_shape, dtype=dtype, order="F")
-        else:
-            out = np.empty(out_shape, dtype=dtype)
+    out_shape_ = list(arr.shape)
+    out_shape_[axis] = len(indexer)
+    out_shape = tuple(out_shape_)
+    if arr.flags.f_contiguous and axis == arr.ndim - 1:
+        # minor tweak that can make an order-of-magnitude difference
+        # for dataframes initialized directly from 2-d ndarrays
+        # (s.t. df.values is c-contiguous and df._mgr.blocks[0] is its
+        # f-contiguous transpose)
+        out = np.empty(out_shape, dtype=dtype, order="F")
+    else:
+        out = np.empty(out_shape, dtype=dtype)
 
     func = _get_take_nd_function(
         arr.ndim, arr.dtype, out.dtype, axis=axis, mask_info=mask_info
@@ -190,7 +186,7 @@ def take_1d(
         return arr.take(indexer)
 
     indexer, dtype, fill_value, mask_info = _take_preprocess_indexer_and_fill_value(
-        arr, indexer, None, fill_value, True
+        arr, indexer, fill_value, True
     )
 
     # at this point, it's guaranteed that dtype can hold both the arr values
@@ -516,7 +512,6 @@ def _take_2d_multi_object(
 def _take_preprocess_indexer_and_fill_value(
     arr: np.ndarray,
     indexer: np.ndarray,
-    out: np.ndarray | None,
     fill_value,
     allow_fill: bool,
 ):
@@ -534,10 +529,7 @@ def _take_preprocess_indexer_and_fill_value(
             mask = indexer == -1
             needs_masking = mask.any()
             mask_info = mask, needs_masking
-            if needs_masking:
-                if out is not None and out.dtype != dtype:
-                    raise TypeError("Incompatible type for fill_value")
-            else:
+            if not needs_masking:
                 # if not, then depromote, set fill_value to dummy
                 # (it won't be used but we don't want the cython code
                 # to crash when trying to cast it to dtype)


### PR DESCRIPTION
Un-revert part of #40510 in the hopes of tracking down where the perf impact was.  xref #40852 which un-reverted a different part.

Let's not merge for a few days to make sure that any surprising effects from #40852 show up in the asvs.
