### PR TITLE
DOC/CI: add missing import to ipython directive in `whatsnew/v0.11.0.rst`

### DIFF
--- a/doc/source/whatsnew/v0.11.0.rst
+++ b/doc/source/whatsnew/v0.11.0.rst
@@ -305,6 +305,7 @@ Furthermore ``datetime64[ns]`` columns are created by default, when passed datet
 Astype conversion on ``datetime64[ns]`` to ``object``, implicitly converts ``NaT`` to ``np.nan``
 
 .. ipython:: python
+   :okexcept:
 
    s = pd.Series([datetime.datetime(2001, 1, 2, 0, 0) for i in range(3)])
    s.dtype

--- a/doc/source/whatsnew/v0.11.0.rst
+++ b/doc/source/whatsnew/v0.11.0.rst
@@ -305,8 +305,8 @@ Furthermore ``datetime64[ns]`` columns are created by default, when passed datet
 Astype conversion on ``datetime64[ns]`` to ``object``, implicitly converts ``NaT`` to ``np.nan``
 
 .. ipython:: python
-   :okexcept:
 
+   import datetime
    s = pd.Series([datetime.datetime(2001, 1, 2, 0, 0) for i in range(3)])
    s.dtype
    s[1] = np.nan


### PR DESCRIPTION
some of the builds have failed recently due to this ipython directive, so I added the fix as advised in the error warning.