### PR TITLE
call pytest with python3 -m

### DIFF
--- a/test_fast.sh
+++ b/test_fast.sh
@@ -5,4 +5,4 @@
 # https://github.com/pytest-dev/pytest/issues/1075
 export PYTHONHASHSEED=$(python -c 'import random; print(random.randint(1, 4294967295))')
 
-pytest pandas --skip-slow --skip-network --skip-db -m "not single" -n 4 -r sxX --strict-markers "$@"
+python3 -m pytest pandas --skip-slow --skip-network --skip-db -m "not single" -n 4 -r sxX --strict-markers "$@"


### PR DESCRIPTION
This runs pytest as
```sh
python3 -m pytest  # ...
```
This allows running the tests in a venv. (Otherwise, if pytest is not installed in the venv, it falls back to the system pytest, leading to some surprises down the road.)