### PR TITLE
Backport PR #40924: BUG: concat with DTI and all-None Index

### DIFF
--- a/doc/source/whatsnew/v1.2.5.rst
+++ b/doc/source/whatsnew/v1.2.5.rst
@@ -14,7 +14,7 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
-
+- Regression in :func:`concat` between two :class:`DataFrames` where one has an :class:`Index` that is all-None and the other is :class:`DatetimeIndex` incorrectly raising (:issue:`40841`)
 -
 -
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2742,7 +2742,8 @@ class Index(IndexOpsMixin, PandasObject):
                 # worth making this faster? a very unusual case
                 value_set = set(lvals)
                 result.extend([x for x in rvals if x not in value_set])
-                result = Index(result)._values  # do type inference here
+                # If objects are unorderable, we must have object dtype.
+                return np.array(result, dtype=object)
         else:
             # find indexes of things in "other" that are not in "self"
             if self.is_unique:

--- a/pandas/tests/reshape/concat/test_concat.py
+++ b/pandas/tests/reshape/concat/test_concat.py
@@ -572,3 +572,23 @@ def test_concat_repeated_keys(keys, integrity):
     tuples = list(zip(keys, ["a", "b", "c"]))
     expected = Series([1, 2, 3], index=MultiIndex.from_tuples(tuples))
     tm.assert_series_equal(result, expected)
+
+
+def test_concat_null_object_with_dti():
+    # GH#40841
+    dti = pd.DatetimeIndex(
+        ["2021-04-08 21:21:14+00:00"], dtype="datetime64[ns, UTC]", name="Time (UTC)"
+    )
+    right = DataFrame(data={"C": [0.5274]}, index=dti)
+
+    idx = Index([None], dtype="object", name="Maybe Time (UTC)")
+    left = DataFrame(data={"A": [None], "B": [np.nan]}, index=idx)
+
+    result = concat([left, right], axis="columns")
+
+    exp_index = Index([None, dti[0]], dtype=object)
+    expected = DataFrame(
+        {"A": [None, None], "B": [np.nan, np.nan], "C": [np.nan, 0.5274]},
+        index=exp_index,
+    )
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
Backport PR #40924