### PR TITLE
Add 'virt' and 'group' settings for arm64-graviton2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ matrix:
 
   include:
     - arch: arm64-graviton2
+      virt: lxd
+      group: edge
       env:
         - JOB="3.7, arm64" PYTEST_WORKERS="auto" ENV_FILE="ci/deps/travis-37-arm64.yaml" PATTERN="(not slow and not network and not clipboard and not arm_slow)"
 


### PR DESCRIPTION
https://github.com/pandas-dev/pandas/pull/40868 tried to change from `arm64` to `arm64-graviton2` but actually changed it to `amd64` because of the missing `virt` and `group` settings, as explained at https://blog.travis-ci.com/2020-09-11-arm-on-aws, section "Quick tips"