### PR TITLE
[ArrowStringArray] CLN: move and rename test_string_methods

### DIFF
--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -1,6 +1,6 @@
 """
-This module tests the functionality of ArrowStringArray.
-Tests for the str accessor are in pandas/tests/strings/test_string_array.py
+This module tests the functionality of StringArray and ArrowStringArray.
+Tests for the str accessors are in pandas/tests/strings/test_string_array.py
 """
 
 import numpy as np

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -1,4 +1,7 @@
-import operator
+"""
+This module tests the functionality of ArrowStringArray.
+Tests for the str accessor are in pandas/tests/strings/test_string_array.py
+"""
 
 import numpy as np
 import pytest
@@ -86,23 +89,6 @@ def test_setitem_with_scalar_string(dtype):
     arr[0] = "d"
     expected = pd.array(["d", "c"], dtype=dtype)
     tm.assert_extension_array_equal(arr, expected)
-
-
-@pytest.mark.parametrize(
-    "input, method",
-    [
-        (["a", "b", "c"], operator.methodcaller("capitalize")),
-        (["a b", "a bc. de"], operator.methodcaller("capitalize")),
-    ],
-)
-def test_string_methods(input, method, dtype):
-    a = pd.Series(input, dtype=dtype)
-    b = pd.Series(input, dtype="object")
-    result = method(a.str)
-    expected = method(b.str)
-
-    assert result.dtype.name == dtype
-    tm.assert_series_equal(result.astype(object), expected)
 
 
 def test_astype_roundtrip(dtype, request):

--- a/pandas/tests/strings/test_string_array.py
+++ b/pandas/tests/strings/test_string_array.py
@@ -1,3 +1,5 @@
+import operator
+
 import numpy as np
 import pytest
 
@@ -117,3 +119,20 @@ def test_str_get_stringarray_multiple_nans(nullable_string_dtype):
     result = s.str.get(2)
     expected = Series(pd.array([pd.NA, pd.NA, pd.NA, "c"], dtype=nullable_string_dtype))
     tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "input, method",
+    [
+        (["a", "b", "c"], operator.methodcaller("capitalize")),
+        (["a b", "a bc. de"], operator.methodcaller("capitalize")),
+    ],
+)
+def test_capitalize(input, method, nullable_string_dtype):
+    a = Series(input, dtype=nullable_string_dtype)
+    b = Series(input, dtype="object")
+    result = method(a.str)
+    expected = method(b.str)
+
+    assert result.dtype.name == nullable_string_dtype
+    tm.assert_series_equal(result.astype(object), expected)


### PR DESCRIPTION
follow-up to #40708

in #40708 the str accessor was enabled and tests changed in `pandas/tests/arrays/string_/test_string.py` and `pandas/tests/strings/test_string_array.py`

This PR colocates the str accessor test in `pandas/tests/arrays/string_/test_string.py` with those in `pandas/tests/strings/test_string_array.py` and renames it `test_string_methods` -> `test_capitalize`