### PR TITLE
Updated qcut for Float64DType Issue #40730

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -663,7 +663,7 @@ Conversion
 - Bug in :class:`Index` construction silently ignoring a passed ``dtype`` when the data cannot be cast to that dtype (:issue:`21311`)
 - Bug in :meth:`StringArray.astype` falling back to numpy and raising when converting to ``dtype='categorical'`` (:issue:`40450`)
 - Bug in :class:`DataFrame` construction with a dictionary containing an arraylike with ``ExtensionDtype`` and ``copy=True`` failing to make a copy (:issue:`38939`)
--
+- Bug in :func:`_coerce_to_type` failing to convert ``Float64DType`` input into numpy array (:issue:`40730`)
 
 Strings
 ^^^^^^^

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -695,7 +695,7 @@ Conversion
 - Bug in :class:`Index` construction silently ignoring a passed ``dtype`` when the data cannot be cast to that dtype (:issue:`21311`)
 - Bug in :meth:`StringArray.astype` falling back to numpy and raising when converting to ``dtype='categorical'`` (:issue:`40450`)
 - Bug in :class:`DataFrame` construction with a dictionary containing an arraylike with ``ExtensionDtype`` and ``copy=True`` failing to make a copy (:issue:`38939`)
-- Bug in :func:`_coerce_to_type` failing to convert ``Float64DType`` input into numpy array (:issue:`40730`)
+- Bug in :meth:`qcut` raising error when taking ``Float64DType`` as input (:issue:`40730`)
 
 Strings
 ^^^^^^^

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -24,7 +24,7 @@ from pandas.core.dtypes.common import (
     is_datetime_or_timedelta_dtype,
     is_extension_array_dtype,
     is_integer,
-    is_integer_dtype,
+    is_numeric_dtype,
     is_list_like,
     is_scalar,
     is_timedelta64_dtype,
@@ -488,7 +488,7 @@ def _coerce_to_type(x):
     # Will properly support in the future.
     # https://github.com/pandas-dev/pandas/pull/31290
     # https://github.com/pandas-dev/pandas/issues/31389
-    elif is_extension_array_dtype(x.dtype) and is_integer_dtype(x.dtype):
+    elif is_extension_array_dtype(x.dtype) and is_numeric_dtype(x.dtype):
         x = x.to_numpy(dtype=np.float64, na_value=np.nan)
 
     if dtype is not None:

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -24,8 +24,8 @@ from pandas.core.dtypes.common import (
     is_datetime_or_timedelta_dtype,
     is_extension_array_dtype,
     is_integer,
-    is_numeric_dtype,
     is_list_like,
+    is_numeric_dtype,
     is_scalar,
     is_timedelta64_dtype,
 )

--- a/pandas/tests/reshape/test_qcut.py
+++ b/pandas/tests/reshape/test_qcut.py
@@ -301,3 +301,19 @@ def test_qcut_nullable_integer(q, any_nullable_int_dtype):
     expected = qcut(arr.astype(float), q)
 
     tm.assert_categorical_equal(result, expected)
+    
+
+@pytest.mark.parametrize("Data_type,Data_type_string",
+                         [
+                             (pd.Float64Dtype(),"Float64Dtype"),
+                             (pd.Int64Dtype(),"Int64Dtype")
+                          ]
+                         )
+def test_qcut_numeric_dtype(Data_type,Data_type_string):
+    series = pd.Series([1.0, 2.0, 3.0, 4.0], dtype=Data_type)
+
+    try:
+        pd.qcut(series,2)
+    except:
+        Fail_string=Data_type_string+" is not supported"
+        pytest.fail(msg=Fail_string )

--- a/pandas/tests/reshape/test_qcut.py
+++ b/pandas/tests/reshape/test_qcut.py
@@ -303,17 +303,20 @@ def test_qcut_nullable_integer(q, any_nullable_int_dtype):
     tm.assert_categorical_equal(result, expected)
     
 
-@pytest.mark.parametrize("Data_type,Data_type_string",
-                         [
-                             (pd.Float64Dtype(),"Float64Dtype"),
-                             (pd.Int64Dtype(),"Int64Dtype")
-                          ]
-                         )
+@pytest.mark.parametrize(
+    "Data_type,Data_type_string",
+    [
+        (pd.Float64Dtype(),"Float64Dtype"),    
+        (pd.Int64Dtype(),"Int64Dtype") 
+    ]
+)
 def test_qcut_numeric_dtype(Data_type,Data_type_string):
     series = pd.Series([1.0, 2.0, 3.0, 4.0], dtype=Data_type)
 
     try:
         pd.qcut(series,2)
     except:
-        Fail_string=Data_type_string+" is not supported"
-        pytest.fail(msg=Fail_string )
+        Fail_string = Data_type_string + " is not supported"
+        pytest.fail( msg = Fail_string )
+        
+        

--- a/pandas/tests/reshape/test_qcut.py
+++ b/pandas/tests/reshape/test_qcut.py
@@ -293,8 +293,8 @@ def test_qcut_bool_coercion_to_int(bins, box, compare):
 
 
 @pytest.mark.parametrize("q", [2, 5, 10])
-def test_qcut_nullable_integer(q, any_nullable_int_dtype):
-    arr = pd.array(np.arange(100), dtype=any_nullable_int_dtype)
+def test_qcut_nullable_integer(q, any_nullable_numeric_dtype):
+    arr = pd.array(np.arange(100), dtype=any_nullable_numeric_dtype)
     arr[::2] = pd.NA
 
     result = qcut(arr, q)
@@ -302,21 +302,4 @@ def test_qcut_nullable_integer(q, any_nullable_int_dtype):
 
     tm.assert_categorical_equal(result, expected)
     
-
-@pytest.mark.parametrize(
-    "Data_type,Data_type_string",
-    [
-        (pd.Float64Dtype(),"Float64Dtype"),    
-        (pd.Int64Dtype(),"Int64Dtype") 
-    ]
-)
-def test_qcut_numeric_dtype(Data_type,Data_type_string):
-    series = pd.Series([1.0, 2.0, 3.0, 4.0], dtype=Data_type)
-
-    try:
-        pd.qcut(series,2)
-    except:
-        Fail_string = Data_type_string + " is not supported"
-        pytest.fail( msg = Fail_string )
-        
-        
+               

--- a/pandas/tests/reshape/test_qcut.py
+++ b/pandas/tests/reshape/test_qcut.py
@@ -301,5 +301,3 @@ def test_qcut_nullable_integer(q, any_nullable_numeric_dtype):
     expected = qcut(arr.astype(float), q)
 
     tm.assert_categorical_equal(result, expected)
-    
-               


### PR DESCRIPTION
This PR is used to address #40730 . qcut is now able to support both intdtype and floatdtype