### PR TITLE
REGR: memory_map with non-UTF8 encoding

### DIFF
--- a/doc/source/whatsnew/v1.2.5.rst
+++ b/doc/source/whatsnew/v1.2.5.rst
@@ -15,7 +15,7 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Regression in :func:`concat` between two :class:`DataFrames` where one has an :class:`Index` that is all-None and the other is :class:`DatetimeIndex` incorrectly raising (:issue:`40841`)
--
+- Regression in :func:`read_csv` when using ``memory_map=True`` with an non-UTF8 encoding (:issue:`40986`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/io/parsers/c_parser_wrapper.py
+++ b/pandas/io/parsers/c_parser_wrapper.py
@@ -30,25 +30,6 @@ class CParserWrapper(ParserBase):
         assert self.handles is not None
         for key in ("storage_options", "encoding", "memory_map", "compression"):
             kwds.pop(key, None)
-        if self.handles.is_mmap and hasattr(self.handles.handle, "mmap"):
-            # error: Item "IO[Any]" of "Union[IO[Any], RawIOBase, BufferedIOBase,
-            # TextIOBase, TextIOWrapper, mmap]" has no attribute "mmap"
-
-            # error: Item "RawIOBase" of "Union[IO[Any], RawIOBase, BufferedIOBase,
-            # TextIOBase, TextIOWrapper, mmap]" has no attribute "mmap"
-
-            # error: Item "BufferedIOBase" of "Union[IO[Any], RawIOBase, BufferedIOBase,
-            # TextIOBase, TextIOWrapper, mmap]" has no attribute "mmap"
-
-            # error: Item "TextIOBase" of "Union[IO[Any], RawIOBase, BufferedIOBase,
-            # TextIOBase, TextIOWrapper, mmap]" has no attribute "mmap"
-
-            # error: Item "TextIOWrapper" of "Union[IO[Any], RawIOBase, BufferedIOBase,
-            # TextIOBase, TextIOWrapper, mmap]" has no attribute "mmap"
-
-            # error: Item "mmap" of "Union[IO[Any], RawIOBase, BufferedIOBase,
-            # TextIOBase, TextIOWrapper, mmap]" has no attribute "mmap"
-            self.handles.handle = self.handles.handle.mmap  # type: ignore[union-attr]
 
         try:
             self._reader = parsers.TextReader(self.handles.handle, **kwds)

--- a/pandas/tests/io/parser/test_encoding.py
+++ b/pandas/tests/io/parser/test_encoding.py
@@ -220,3 +220,20 @@ def test_parse_encoded_special_characters(encoding):
 
     expected = DataFrame(data=[["：foo", 0], ["bar", 1], ["baz", 2]], columns=["a", "b"])
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("encoding", ["utf-8", None, "utf-16", "cp1255", "latin-1"])
+def test_encoding_memory_map(all_parsers, encoding):
+    # GH40986
+    parser = all_parsers
+    expected = DataFrame(
+        {
+            "name": ["Raphael", "Donatello", "Miguel Angel", "Leonardo"],
+            "mask": ["red", "purple", "orange", "blue"],
+            "weapon": ["sai", "bo staff", "nunchunk", "katana"],
+        }
+    )
+    with tm.ensure_clean() as file:
+        expected.to_csv(file, index=False, encoding=encoding)
+        df = parser.read_csv(file, encoding=encoding, memory_map=True)
+    tm.assert_frame_equal(df, expected)


### PR DESCRIPTION
- [x] closes #40986
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

My best guess is that `memory_map=True` always assumed UTF-8 with the python engine. Now that the c and python engine use the same IO code, the c engine assumed UTF-8 as well.
