### PR TITLE
Bug in to_datetime raising ValueError with None and NaT and more than 50 elements

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -813,6 +813,7 @@ Reshaping
 - Bug in :meth:`DataFrame.stack` not preserving ``CategoricalDtype`` in a ``MultiIndex`` (:issue:`36991`)
 - Bug in :func:`to_datetime` raising error when input sequence contains unhashable items (:issue:`39756`)
 - Bug in :meth:`Series.explode` preserving index when ``ignore_index`` was ``True`` and values were scalars (:issue:`40487`)
+- Bug in :func:`to_datetime` raising ``ValueError`` when :class:`Series` contains ``None`` and ``NaT`` and has more than 50 elements (:issue:`39882`)
 
 Sparse
 ^^^^^^

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -193,6 +193,9 @@ def _maybe_cache(
         if len(unique_dates) < len(arg):
             cache_dates = convert_listlike(unique_dates, format)
             cache_array = Series(cache_dates, index=unique_dates)
+            if not cache_array.is_unique:
+                # GH#39882 in case of None and NaT we get duplicates
+                cache_array = cache_array.drop_duplicates()
     return cache_array
 
 

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -84,6 +84,7 @@ ArrayConvertible = Union[List, Tuple, AnyArrayLike, "Series"]
 Scalar = Union[int, float, str]
 DatetimeScalar = TypeVar("DatetimeScalar", Scalar, datetime)
 DatetimeScalarOrArrayConvertible = Union[DatetimeScalar, ArrayConvertible]
+start_caching_at = 50
 
 
 # ---------------------------------------------------------------------
@@ -130,7 +131,7 @@ def should_cache(
     # default realization
     if check_count is None:
         # in this case, the gain from caching is negligible
-        if len(arg) <= 50:
+        if len(arg) <= start_caching_at:
             return False
 
         if len(arg) <= 5000:

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -225,3 +225,14 @@ class TestSeriesConvertDtypes:
         # GH32287
         df = pd.DataFrame({"A": pd.array([True])})
         tm.assert_frame_equal(df, df.convert_dtypes())
+
+    def test_convert_object_to_datetime_with_cache(self):
+        # GH#39882
+        ser = pd.Series(
+            [None] + [pd.NaT] * 50 + [pd.Timestamp("2012-07-26")], dtype="object"
+        )
+        result = pd.to_datetime(ser, errors="coerce")
+        expected = pd.Series(
+            [pd.NaT] * 51 + [pd.Timestamp("2012-07-26")], dtype="datetime64[ns]"
+        )
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -13,7 +13,6 @@ import pandas._testing as tm
 # for most cases), and the specific cases where the result deviates from
 # this default. Those overrides are defined as a dict with (keyword, val) as
 # dictionary key. In case of multiple items, the last override takes precedence.
-from pandas.core.tools.datetimes import start_caching_at
 
 test_cases = [
     (
@@ -227,16 +226,3 @@ class TestSeriesConvertDtypes:
         # GH32287
         df = pd.DataFrame({"A": pd.array([True])})
         tm.assert_frame_equal(df, df.convert_dtypes())
-
-    def test_convert_object_to_datetime_with_cache(self):
-        # GH#39882
-        ser = pd.Series(
-            [None] + [pd.NaT] * start_caching_at + [pd.Timestamp("2012-07-26")],
-            dtype="object",
-        )
-        result = pd.to_datetime(ser, errors="coerce")
-        expected = pd.Series(
-            [pd.NaT] * (start_caching_at + 1) + [pd.Timestamp("2012-07-26")],
-            dtype="datetime64[ns]",
-        )
-        tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -13,6 +13,8 @@ import pandas._testing as tm
 # for most cases), and the specific cases where the result deviates from
 # this default. Those overrides are defined as a dict with (keyword, val) as
 # dictionary key. In case of multiple items, the last override takes precedence.
+from pandas.core.tools.datetimes import start_caching_at
+
 test_cases = [
     (
         # data
@@ -229,10 +231,12 @@ class TestSeriesConvertDtypes:
     def test_convert_object_to_datetime_with_cache(self):
         # GH#39882
         ser = pd.Series(
-            [None] + [pd.NaT] * 50 + [pd.Timestamp("2012-07-26")], dtype="object"
+            [None] + [pd.NaT] * start_caching_at + [pd.Timestamp("2012-07-26")],
+            dtype="object",
         )
         result = pd.to_datetime(ser, errors="coerce")
         expected = pd.Series(
-            [pd.NaT] * 51 + [pd.Timestamp("2012-07-26")], dtype="datetime64[ns]"
+            [pd.NaT] * (start_caching_at + 1) + [pd.Timestamp("2012-07-26")],
+            dtype="datetime64[ns]",
         )
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -43,6 +43,7 @@ from pandas import (
 import pandas._testing as tm
 from pandas.core.arrays import DatetimeArray
 from pandas.core.tools import datetimes as tools
+from pandas.core.tools.datetimes import start_caching_at
 
 
 class TestTimeConversionFormats:
@@ -955,6 +956,19 @@ class TestToDatetime:
         result = to_datetime(date, cache=True)
         expected = Timestamp("20130101 00:00:00")
         assert result == expected
+
+    def test_convert_object_to_datetime_with_cache(self):
+        # GH#39882
+        ser = Series(
+            [None] + [NaT] * start_caching_at + [Timestamp("2012-07-26")],
+            dtype="object",
+        )
+        result = to_datetime(ser, errors="coerce")
+        expected = Series(
+            [NaT] * (start_caching_at + 1) + [Timestamp("2012-07-26")],
+            dtype="datetime64[ns]",
+        )
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize(
         "date, format",


### PR DESCRIPTION
- [x] closes #39882
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

None and NaT are different for unique while convert_listlike casts None to NaT, hence causing dups
Not sure if we could do something better.