### PR TITLE
Revert "Skipt failing tests for numpy dev (#40877)"

### DIFF
--- a/pandas/tests/arrays/boolean/test_arithmetic.py
+++ b/pandas/tests/arrays/boolean/test_arithmetic.py
@@ -69,10 +69,7 @@ def test_div(left_array, right_array):
 @pytest.mark.parametrize(
     "opname",
     [
-        pytest.param(
-            "floordiv",
-            marks=pytest.mark.xfail(reason="NumpyDev GH#40874", strict=False),
-        ),
+        "floordiv",
         "mod",
         pytest.param(
             "pow", marks=pytest.mark.xfail(reason="TODO follow int8 behaviour? GH34686")

--- a/pandas/tests/arrays/masked/test_arithmetic.py
+++ b/pandas/tests/arrays/masked/test_arithmetic.py
@@ -6,8 +6,6 @@ from typing import (
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
-
 import pandas as pd
 import pandas._testing as tm
 from pandas.core.arrays import ExtensionArray
@@ -54,8 +52,6 @@ def test_array_scalar_like_equivalence(data, all_arithmetic_operators):
 def test_array_NA(data, all_arithmetic_operators):
     if "truediv" in all_arithmetic_operators:
         pytest.skip("division with pd.NA raises")
-    if "floordiv" in all_arithmetic_operators and is_numpy_dev:
-        pytest.skip("NumpyDev behavior GH#40874")
     data, _ = data
     op = tm.get_op_from_name(all_arithmetic_operators)
     check_skip(data, all_arithmetic_operators)

--- a/pandas/tests/extension/test_boolean.py
+++ b/pandas/tests/extension/test_boolean.py
@@ -16,8 +16,6 @@ be added to the array-specific tests in `pandas/tests/arrays/`.
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
-
 import pandas as pd
 import pandas._testing as tm
 from pandas.core.arrays.boolean import BooleanDtype
@@ -141,26 +139,6 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
         else:
             with pytest.raises(exc):
                 op(obj, other)
-
-    def test_arith_series_with_scalar(self, data, all_arithmetic_operators):
-        if "floordiv" in all_arithmetic_operators and is_numpy_dev:
-            pytest.skip("NumpyDev behavior GH#40874")
-        super().test_arith_series_with_scalar(data, all_arithmetic_operators)
-
-    def test_arith_frame_with_scalar(self, data, all_arithmetic_operators):
-        if "floordiv" in all_arithmetic_operators and is_numpy_dev:
-            pytest.skip("NumpyDev behavior GH#40874")
-        super().test_arith_frame_with_scalar(data, all_arithmetic_operators)
-
-    def test_arith_series_with_array(self, data, all_arithmetic_operators):
-        if "floordiv" in all_arithmetic_operators and is_numpy_dev:
-            pytest.skip("NumpyDev behavior GH#40874")
-        super().test_arith_series_with_scalar(data, all_arithmetic_operators)
-
-    def test_divmod_series_array(self, data, data_for_twos):
-        if is_numpy_dev:
-            pytest.skip("NumpyDev behavior GH#40874")
-        super().test_divmod_series_array(data, data_for_twos)
 
     def _check_divmod_op(self, s, op, other, exc=None):
         # override to not raise an error


### PR DESCRIPTION
- [x] closes #40874

new numpy wheel is out, bug was fixed during the week
