### PR TITLE
BUG: isna not returning copy for MaskedArray

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -749,6 +749,7 @@ Missing
 - Bug in :class:`Grouper` now correctly propagates ``dropna`` argument and :meth:`DataFrameGroupBy.transform` now correctly handles missing values for ``dropna=True`` (:issue:`35612`)
 - Bug in :func:`isna`, and :meth:`Series.isna`, :meth:`Index.isna`, :meth:`DataFrame.isna` (and the corresponding ``notna`` functions) not recognizing ``Decimal("NaN")`` objects (:issue:`39409`)
 - Bug in :meth:`DataFrame.fillna` not accepting dictionary for ``downcast`` keyword (:issue:`40809`)
+- Bug in :func:`isna` not returning a copy of the mask for nullable types, causing any subsequent mask modification to change the original array (:issue:`40935`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -352,7 +352,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
         return self._mask.any()  # type: ignore[return-value]
 
     def isna(self) -> np.ndarray:
-        return self._mask
+        return self._mask.copy()
 
     @property
     def _na_value(self):

--- a/pandas/tests/extension/base/missing.py
+++ b/pandas/tests/extension/base/missing.py
@@ -1,8 +1,9 @@
 import numpy as np
-
+import pytest
 import pandas as pd
 import pandas._testing as tm
 from pandas.tests.extension.base.base import BaseExtensionTests
+from pandas.api.types import is_sparse
 
 
 class BaseMissingTests(BaseExtensionTests):
@@ -19,6 +20,17 @@ class BaseMissingTests(BaseExtensionTests):
         # GH 21189
         result = pd.Series(data_missing).drop([0, 1]).isna()
         expected = pd.Series([], dtype=bool)
+        self.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("na_func", ["isna", "notna"])
+    def test_isna_returns_copy(self, data_missing, na_func):
+        result = pd.Series(data_missing)
+        expected = result.copy()
+        mask = getattr(result, na_func)()
+        if is_sparse(mask):
+            mask = np.array(mask)
+
+        mask[:] = True
         self.assert_series_equal(result, expected)
 
     def test_dropna_array(self, data_missing):

--- a/pandas/tests/extension/base/missing.py
+++ b/pandas/tests/extension/base/missing.py
@@ -1,9 +1,10 @@
 import numpy as np
 import pytest
+
 import pandas as pd
 import pandas._testing as tm
-from pandas.tests.extension.base.base import BaseExtensionTests
 from pandas.api.types import is_sparse
+from pandas.tests.extension.base.base import BaseExtensionTests
 
 
 class BaseMissingTests(BaseExtensionTests):


### PR DESCRIPTION
- [x] closes #40935
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

Think further improvements like zero-copy access fall under #34873, so #40935 can be closed.