### PR TITLE
REF: pass arguments to Index._foo_indexer correctly

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4112,8 +4112,8 @@ class Index(IndexOpsMixin, PandasObject):
         # We only get here if dtypes match
         assert self.dtype == other.dtype
 
-        lvalues = self._get_engine_target()
-        rvalues = other._get_engine_target()
+        lvalues = self._get_join_target()
+        rvalues = other._get_join_target()
 
         left_idx, right_idx = get_join_indexers(
             [lvalues], [rvalues], how=how, sort=True
@@ -4126,7 +4126,8 @@ class Index(IndexOpsMixin, PandasObject):
         mask = left_idx == -1
         np.putmask(join_array, mask, rvalues.take(right_idx))
 
-        join_index = self._wrap_joined_index(join_array, other)
+        join_arraylike = self._from_join_target(join_array)
+        join_index = self._wrap_joined_index(join_arraylike, other)
 
         return join_index, left_idx, right_idx
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -20,7 +20,6 @@ from pandas._libs import (
     NaT,
     Timedelta,
     iNaT,
-    join as libjoin,
     lib,
 )
 from pandas._libs.tslibs import (
@@ -29,7 +28,10 @@ from pandas._libs.tslibs import (
     Resolution,
     Tick,
 )
-from pandas._typing import Callable
+from pandas._typing import (
+    ArrayLike,
+    Callable,
+)
 from pandas.compat.numpy import function as nv
 from pandas.util._decorators import (
     Appender,
@@ -73,36 +75,6 @@ if TYPE_CHECKING:
 _index_doc_kwargs = dict(ibase._index_doc_kwargs)
 
 _T = TypeVar("_T", bound="DatetimeIndexOpsMixin")
-
-
-def _join_i8_wrapper(joinf, with_indexers: bool = True):
-    """
-    Create the join wrapper methods.
-    """
-
-    # error: 'staticmethod' used with a non-method
-    @staticmethod  # type: ignore[misc]
-    def wrapper(left, right):
-        # Note: these only get called with left.dtype == right.dtype
-        orig_left = left
-
-        left = left.view("i8")
-        right = right.view("i8")
-
-        results = joinf(left, right)
-        if with_indexers:
-
-            join_index, left_indexer, right_indexer = results
-            if not isinstance(orig_left, np.ndarray):
-                # When called from Index._intersection/_union, we have the EA
-                join_index = join_index.view(orig_left._ndarray.dtype)
-                join_index = orig_left._from_backing_data(join_index)
-
-            return join_index, left_indexer, right_indexer
-
-        return results
-
-    return wrapper
 
 
 @inherit_names(
@@ -603,13 +575,6 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex):
     # --------------------------------------------------------------------
     # Join/Set Methods
 
-    _inner_indexer = _join_i8_wrapper(libjoin.inner_join_indexer)
-    _outer_indexer = _join_i8_wrapper(libjoin.outer_join_indexer)
-    _left_indexer = _join_i8_wrapper(libjoin.left_join_indexer)
-    _left_indexer_unique = _join_i8_wrapper(
-        libjoin.left_join_indexer_unique, with_indexers=False
-    )
-
     def _get_join_freq(self, other):
         """
         Get the freq to attach to the result of a join operation.
@@ -621,13 +586,21 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex):
             freq = self.freq if self._can_fast_union(other) else None
         return freq
 
-    def _wrap_joined_index(self, joined: np.ndarray, other):
+    def _wrap_joined_index(self, joined: ArrayLike, other):
         assert other.dtype == self.dtype, (other.dtype, self.dtype)
-        assert joined.dtype == "i8" or joined.dtype == self.dtype, joined.dtype
-        joined = joined.view(self._data._ndarray.dtype)
         result = super()._wrap_joined_index(joined, other)
         result._data._freq = self._get_join_freq(other)
         return result
+
+    def _get_join_target(self) -> np.ndarray:
+        return self._data._ndarray.view("i8")
+
+    def _from_join_target(self, result: np.ndarray):
+        # view e.g. i8 back to M8[ns]
+        result = result.view(self._data._ndarray.dtype)
+        return self._data._from_backing_data(result)
+
+    # --------------------------------------------------------------------
 
     @doc(Index._convert_arr_indexer)
     def _convert_arr_indexer(self, keyarr):

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -28,10 +28,7 @@ from pandas._libs.tslibs import (
     Resolution,
     Tick,
 )
-from pandas._typing import (
-    ArrayLike,
-    Callable,
-)
+from pandas._typing import Callable
 from pandas.compat.numpy import function as nv
 from pandas.util._decorators import (
     Appender,
@@ -586,7 +583,7 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex):
             freq = self.freq if self._can_fast_union(other) else None
         return freq
 
-    def _wrap_joined_index(self, joined: ArrayLike, other):
+    def _wrap_joined_index(self, joined, other):
         assert other.dtype == self.dtype, (other.dtype, self.dtype)
         result = super()._wrap_joined_index(joined, other)
         result._data._freq = self._get_join_freq(other)

--- a/pandas/core/indexes/extension.py
+++ b/pandas/core/indexes/extension.py
@@ -11,6 +11,7 @@ from typing import (
 
 import numpy as np
 
+from pandas._typing import ArrayLike
 from pandas.compat.numpy import function as nv
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import (
@@ -300,6 +301,11 @@ class ExtensionIndex(Index):
     def _get_engine_target(self) -> np.ndarray:
         return np.asarray(self._data)
 
+    def _from_join_target(self, result: np.ndarray) -> ArrayLike:
+        # ATM this is only for IntervalIndex, implicit assumption
+        #  about _get_engine_target
+        return type(self._data)._from_sequence(result, dtype=self.dtype)
+
     def delete(self, loc):
         """
         Make new Index with passed location(-s) deleted
@@ -410,6 +416,10 @@ class NDArrayBackedExtensionIndex(ExtensionIndex):
     def _get_engine_target(self) -> np.ndarray:
         return self._data._ndarray
 
+    def _from_join_target(self, result: np.ndarray) -> ArrayLike:
+        assert result.dtype == self._data._ndarray.dtype
+        return self._data._from_backing_data(result)
+
     def insert(self: _T, loc: int, item) -> Index:
         """
         Make new Index inserting new item at location. Follows
@@ -458,7 +468,18 @@ class NDArrayBackedExtensionIndex(ExtensionIndex):
 
         return type(self)._simple_new(res_values, name=self.name)
 
-    def _wrap_joined_index(self: _T, joined: np.ndarray, other: _T) -> _T:
+    def _wrap_joined_index(self: _T, joined: ArrayLike, other: _T) -> _T:
         name = get_op_result_name(self, other)
-        arr = self._data._from_backing_data(joined)
-        return type(self)._simple_new(arr, name=name)
+
+        if isinstance(joined, np.ndarray):
+            # Reached from _join_non_unique, view back e.g. i8 to M8ns/m8ns
+            joined = joined.view(self._data._ndarray.dtype)
+            joined_ea = self._data._from_backing_data(joined)
+        else:
+            # error: Incompatible types in assignment (expression has type
+            # "ExtensionArray", variable has type "NDArrayBackedExtensionArray")
+            joined_ea = joined  # type: ignore[assignment]
+            assert type(joined) is type(self._data)  # noqa: E721
+            assert joined.dtype == self.dtype
+
+        return type(self)._simple_new(joined_ea, name=name)

--- a/pandas/core/indexes/extension.py
+++ b/pandas/core/indexes/extension.py
@@ -468,18 +468,11 @@ class NDArrayBackedExtensionIndex(ExtensionIndex):
 
         return type(self)._simple_new(res_values, name=self.name)
 
-    def _wrap_joined_index(self: _T, joined: ArrayLike, other: _T) -> _T:
+    # error: Argument 1 of "_wrap_joined_index" is incompatible with supertype
+    # "Index"; supertype defines the argument type as "Union[ExtensionArray, ndarray]"
+    def _wrap_joined_index(  # type: ignore[override]
+        self: _T, joined: NDArrayBackedExtensionArray, other: _T
+    ) -> _T:
         name = get_op_result_name(self, other)
 
-        if isinstance(joined, np.ndarray):
-            # Reached from _join_non_unique, view back e.g. i8 to M8ns/m8ns
-            joined = joined.view(self._data._ndarray.dtype)
-            joined_ea = self._data._from_backing_data(joined)
-        else:
-            # error: Incompatible types in assignment (expression has type
-            # "ExtensionArray", variable has type "NDArrayBackedExtensionArray")
-            joined_ea = joined  # type: ignore[assignment]
-            assert type(joined) is type(self._data)  # noqa: E721
-            assert joined.dtype == self.dtype
-
-        return type(self)._simple_new(joined_ea, name=name)
+        return type(self)._simple_new(joined, name=name)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3613,14 +3613,12 @@ class MultiIndex(Index):
 
     def _intersection(self, other, sort=False) -> MultiIndex:
         other, result_names = self._convert_can_do_setop(other)
-
-        lvals = self._values
-        rvals = other._values.astype(object, copy=False)
+        other = other.astype(object, copy=False)
 
         uniq_tuples = None  # flag whether _inner_indexer was successful
         if self.is_monotonic and other.is_monotonic:
             try:
-                inner_tuples = self._inner_indexer(lvals, rvals)[0]
+                inner_tuples = self._inner_indexer(other)[0]
                 sort = False  # inner_tuples is already sorted
             except TypeError:
                 pass

--- a/pandas/tests/indexes/period/test_join.py
+++ b/pandas/tests/indexes/period/test_join.py
@@ -15,7 +15,7 @@ class TestJoin:
     def test_join_outer_indexer(self):
         pi = period_range("1/1/2000", "1/20/2000", freq="D")
 
-        result = pi._outer_indexer(pi._values, pi._values)
+        result = pi._outer_indexer(pi)
         tm.assert_extension_array_equal(result[0], pi._values)
         tm.assert_numpy_array_equal(result[1], np.arange(len(pi), dtype=np.intp))
         tm.assert_numpy_array_equal(result[2], np.arange(len(pi), dtype=np.intp))


### PR DESCRIPTION
ATM when we call self._inner_indexer in Index._union it raises on CategoricalIndex bc we are calling it incorrectly.  Fixing that required moving the unwrapping/wrapping for Index._foo_indexer closer to just around the cython calls.