### PR TITLE
BUG: Changing return is_named_tuble to a tuple sublclass #40682

### DIFF
--- a/pandas/core/dtypes/inference.py
+++ b/pandas/core/dtypes/inference.py
@@ -315,7 +315,7 @@ def is_named_tuple(obj) -> bool:
     >>> is_named_tuple((1, 2))
     False
     """
-    return isinstance(obj, tuple) and hasattr(obj, "_fields")
+    return isinstance(obj, abc.Sequence) and hasattr(obj, "_fields")
 
 
 def is_hashable(obj) -> bool:


### PR DESCRIPTION
- [ ] closes #40682
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

Changed pandas/core/dtypes/inference.py so that the return of the is_named_tuple function to be a tuple subclass so that it is compatible with sqlalchemy.

Passed test_inference.py