### PR TITLE
WIP: BUG: fix Timestamp.normalize with nonexistent midnight on DST change

### DIFF
--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -536,7 +536,7 @@ cdef class _Timestamp(ABCTimestamp):
             int64_t normalized
 
         normalized = normalize_i8_stamp(local_val)
-        return Timestamp(normalized).tz_localize(self.tzinfo)
+        return Timestamp(normalized, tzinfo=self.tzinfo)
 
     # -----------------------------------------------------------------
     # Pickle Methods


### PR DESCRIPTION
- [ ] closes #40517
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

Attempting an approach to fix this. Let's see if it works.

Not surprisingly, the bruteforce approach breaks a bunch of stuff, because I ended up with twice the utcoffset shift instead of once, which makes perfect sense.

What we want here instead is to get the first valid nanosecond of the day by default and normalize to that. And probably expose to the user the ability to shift back for normalization if midnight does not exist.

Will try to fix this tomorrow.