### PR TITLE
DOC: Improve to_datetime() documentation

### DIFF
--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -857,6 +857,13 @@ def to_datetime(
     ...                origin=pd.Timestamp('1960-01-01'))
     DatetimeIndex(['1960-01-02', '1960-01-03', '1960-01-04'], \
 dtype='datetime64[ns]', freq=None)
+
+    In case input is list-like and the elements of input are of mixed
+    timezones, return will have object type Index if utc parameter is not
+    passed in as True.
+
+    >>> pd.to_datetime(["2018-10-26 12:00 -0530", "2018-10-26 12:00 -0500"])
+    Index([2018-10-26 12:00:00-05:30, 2018-10-26 12:00:00-05:00], dtype='object')
     """
     if arg is None:
         return None

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -787,7 +787,7 @@ def to_datetime(
         array/Series).
 
         In case input is list-like and the elements of input are of mixed
-        timezones, return will have object type Index if utc parameter is not 
+        timezones, return will have object type Index if utc parameter is not
         passed in as True.
 
     See Also

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -851,8 +851,8 @@ def to_datetime(
 
     >>> pd.to_datetime([1, 2, 3], unit='D',
     ...                origin=pd.Timestamp('1960-01-01'))
-    DatetimeIndex(['1960-01-02', '1960-01-03', '1960-01-04'], \
-dtype='datetime64[ns]', freq=None)
+    DatetimeIndex(['1960-01-02', '1960-01-03', '1960-01-04'],
+                  dtype='datetime64[ns]', freq=None)
 
     In case input is list-like and the elements of input are of mixed
     timezones, return will have object type Index if utc=False.

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -862,8 +862,8 @@ dtype='datetime64[ns]', freq=None)
 
     >>> pd.to_datetime(['2018-10-26 12:00 -0530', '2018-10-26 12:00 -0500'],
     ...                utc=True)
-    DatetimeIndex(['2018-10-26 17:30:00+00:00', '2018-10-26 17:00:00+00:00'], \
-dtype='datetime64[ns, UTC]', freq=None)
+    DatetimeIndex(['2018-10-26 17:30:00+00:00', '2018-10-26 17:00:00+00:00'],
+                  dtype='datetime64[ns, UTC]', freq=None)
     """
     if arg is None:
         return None

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -787,8 +787,7 @@ def to_datetime(
         array/Series).
 
         In case input is list-like and the elements of input are of mixed
-        timezones, return will have object type Index if utc parameter is not
-        passed in as True.
+        timezones, return will have object type Index if utc=False.
 
     See Also
     --------
@@ -859,11 +858,15 @@ def to_datetime(
 dtype='datetime64[ns]', freq=None)
 
     In case input is list-like and the elements of input are of mixed
-    timezones, return will have object type Index if utc parameter is not
-    passed in as True.
+    timezones, return will have object type Index if utc=False.
 
     >>> pd.to_datetime(['2018-10-26 12:00 -0530', '2018-10-26 12:00 -0500'])
     Index([2018-10-26 12:00:00-05:30, 2018-10-26 12:00:00-05:00], dtype='object')
+
+    >>> pd.to_datetime(['2018-10-26 12:00 -0530', '2018-10-26 12:00 -0500'],
+    ...                utc=True)
+    DatetimeIndex(['2018-10-26 17:30:00+00:00', '2018-10-26 17:00:00+00:00'], \
+dtype='datetime64[ns, UTC]', freq=None)
     """
     if arg is None:
         return None

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -786,9 +786,6 @@ def to_datetime(
         return will have datetime.datetime type (or corresponding
         array/Series).
 
-        In case input is list-like and the elements of input are of mixed
-        timezones, return will have object type Index if utc=False.
-
     See Also
     --------
     DataFrame.astype : Cast argument to a specified dtype.

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -786,6 +786,10 @@ def to_datetime(
         return will have datetime.datetime type (or corresponding
         array/Series).
 
+        In case input is list-like and the elements of input are of mixed
+        timezones, return will have object type Index if utc parameter is not 
+        passed in as True.
+
     See Also
     --------
     DataFrame.astype : Cast argument to a specified dtype.

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -862,7 +862,7 @@ dtype='datetime64[ns]', freq=None)
     timezones, return will have object type Index if utc parameter is not
     passed in as True.
 
-    >>> pd.to_datetime(["2018-10-26 12:00 -0530", "2018-10-26 12:00 -0500"])
+    >>> pd.to_datetime(['2018-10-26 12:00 -0530', '2018-10-26 12:00 -0500'])
     Index([2018-10-26 12:00:00-05:30, 2018-10-26 12:00:00-05:00], dtype='object')
     """
     if arg is None:


### PR DESCRIPTION
Returns Object Type Index when Mixed Timezones are used in list-like input to pandas.to_datetime()

- [x] closes #40808 
- [ ] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
