### PR TITLE
PERF: optimize conversion from boolean Arrow array to masked BooleanArray

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -624,6 +624,7 @@ Performance improvements
 - Performance improvement in :class:`Styler` where render times are more than 50% reduced (:issue:`39972` :issue:`39952`)
 - Performance improvement in :meth:`core.window.ewm.ExponentialMovingWindow.mean` with ``times`` (:issue:`39784`)
 - Performance improvement in :meth:`.GroupBy.apply` when requiring the python fallback implementation (:issue:`40176`)
+- Performance improvement in the conversion of pyarrow boolean array to a pandas nullable boolean array (:issue:`41051`)
 - Performance improvement for concatenation of data with type :class:`CategoricalDtype` (:issue:`40193`)
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -114,6 +114,9 @@ class BooleanDtype(BaseMaskedDtype):
         """
         import pyarrow
 
+        if array.type != pyarrow.bool_():
+            raise TypeError(f"Expected array of boolean type, got {array.type} instead")
+
         if isinstance(array, pyarrow.Array):
             chunks = [array]
         else:

--- a/pandas/tests/arrays/masked/test_arrow_compat.py
+++ b/pandas/tests/arrays/masked/test_arrow_compat.py
@@ -55,12 +55,19 @@ def test_arrow_from_arrow_uint():
 
 
 @td.skip_if_no("pyarrow", min_version="0.16.0")
-def test_arrow_sliced():
+def test_arrow_sliced(data):
     # https://github.com/pandas-dev/pandas/issues/38525
     import pyarrow as pa
 
-    df = pd.DataFrame({"a": pd.array([0, None, 2, 3, None], dtype="Int64")})
+    df = pd.DataFrame({"a": data})
     table = pa.table(df)
     result = table.slice(2, None).to_pandas()
     expected = df.iloc[2:].reset_index(drop=True)
+    tm.assert_frame_equal(result, expected)
+
+    # no missing values
+    df2 = df.fillna(data[0])
+    table = pa.table(df2)
+    result = table.slice(2, None).to_pandas()
+    expected = df2.iloc[2:].reset_index(drop=True)
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/arrays/masked/test_arrow_compat.py
+++ b/pandas/tests/arrays/masked/test_arrow_compat.py
@@ -71,3 +71,23 @@ def test_arrow_sliced(data):
     result = table.slice(2, None).to_pandas()
     expected = df2.iloc[2:].reset_index(drop=True)
     tm.assert_frame_equal(result, expected)
+
+
+@td.skip_if_no("pyarrow", min_version="0.16.0")
+def test_from_arrow_type_error(request, data):
+    # ensure that __from_arrow__ returns a TypeError when getting a wrong
+    # array type
+    import pyarrow as pa
+
+    if data.dtype != "boolean":
+        # TODO numeric dtypes cast any incoming array to the correct dtype
+        # instead of erroring
+        request.node.add_marker(
+            pytest.mark.xfail(reason="numeric dtypes don't error but cast")
+        )
+
+    arr = pa.array(data).cast("string")
+    with pytest.raises(TypeError, match=None):
+        # we don't test the exact error message, only the fact that it raises
+        # a TypeError is relevant
+        data.dtype.__from_arrow__(arr)


### PR DESCRIPTION
For arrays without missing values it doesn't change, but gives a decent speed-up when having missing values:

```
In [1]: arr1 = pa.array([True, False, True, True, False]*100_000)

In [2]: arr2 = pa.array([True, False, None, True, False]*100_000)

In [3]: %timeit pd.BooleanDtype().__from_arrow__(arr1)
9.34 ms ± 27.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)   <-- master
9.31 ms ± 23.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)   <-- PR

In [4]: %timeit pd.BooleanDtype().__from_arrow__(arr2)
60.6 ms ± 678 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)   <-- master
18.8 ms ± 99.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)   <-- PR
```

cc @simonjayhawkins 