### PR TITLE
[ArrowStringArray] Use utf8_upper and utf8_lower functions from Apache Arrow

### DIFF
--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -757,3 +757,9 @@ class ArrowStringArray(OpsMixin, ExtensionArray, ObjectStringArrayMixin):
             #    or .findall returns a list).
             # -> We don't know the result type. E.g. `.get` can return anything.
             return lib.map_infer_mask(arr, f, mask.view("uint8"))
+
+    def _str_lower(self):
+        return type(self)(pc.utf8_lower(self._data))
+
+    def _str_upper(self):
+        return type(self)(pc.utf8_upper(self._data))


### PR DESCRIPTION
```
data = ["Mouse", "dog", "house and parrot", "23", np.NaN] * 100_000
s = pd.Series(data, dtype="string")
s1 = pd.Series(data, dtype="arrow_string")

%timeit s.str.upper()
# 63.8 ms ± 259 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

%timeit s1.str.upper()
# 92 ms ± 152 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)  <-- master
# 4.44 ms ± 35.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  <-- PR

%timeit s.str.lower()
# 49.1 ms ± 273 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

%timeit s1.str.lower()
# 78.2 ms ± 814 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)  <-- master
# 4.34 ms ± 32.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  <-- PR

```