### PR TITLE
DOC: more accurate wording in roadmap

### DIFF
--- a/doc/source/development/roadmap.rst
+++ b/doc/source/development/roadmap.rst
@@ -71,8 +71,8 @@ instead of comparing as False).
 
 Long term, we want to introduce consistent missing data handling for all data
 types. This includes consistent behavior in all operations (indexing, arithmetic
-operations, comparisons, etc.). We want to eventually make the new semantics the
-default.
+operations, comparisons, etc.). There has been discussion of eventually making
+the new semantics the default.
 
 This has been discussed at
 `github #28095 <https://github.com/pandas-dev/pandas/issues/28095>`__ (and


### PR DESCRIPTION
This came up the other day in https://github.com/pandas-dev/pandas/pull/40651#issuecomment-820671958.  As I [originally](https://github.com/pandas-dev/pandas/pull/35208#issuecomment-656879885) said in the PR that put this inaccurate wording in, this overstates the degree to which there is consensus.