### PR TITLE
CLN: Clean-up numeric index dtype validation

### DIFF
--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import (
     Callable,
     Hashable,
-    Optional,
 )
 import warnings
 
@@ -57,7 +56,7 @@ class NumericIndex(Index):
     _is_numeric_dtype = True
     _can_hold_strings = False
 
-    def __new__(cls, data=None, dtype: Optional[Dtype] = None, copy=False, name=None):
+    def __new__(cls, data=None, dtype: Dtype | None = None, copy=False, name=None):
         name = maybe_extract_name(name, data, cls)
 
         subarr = cls._ensure_array(data, dtype, copy)

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -1,4 +1,5 @@
 from typing import (
+    Callable,
     Hashable,
     Optional,
 )
@@ -49,6 +50,7 @@ class NumericIndex(Index):
     """
 
     _default_dtype: np.dtype
+    _dtype_validation_metadata: tuple[Callable[..., bool], str]
 
     _is_numeric_dtype = True
     _can_hold_strings = False
@@ -97,14 +99,8 @@ class NumericIndex(Index):
     def _validate_dtype(cls, dtype: Dtype) -> None:
         if dtype is None:
             return
-        validation_metadata = {
-            "int64index": (is_signed_integer_dtype, "signed integer"),
-            "uint64index": (is_unsigned_integer_dtype, "unsigned integer"),
-            "float64index": (is_float_dtype, "float"),
-            "rangeindex": (is_signed_integer_dtype, "signed integer"),
-        }
 
-        validation_func, expected = validation_metadata[cls._typ]
+        validation_func, expected = cls._dtype_validation_metadata
         if not validation_func(dtype):
             raise ValueError(
                 f"Incorrect `dtype` passed: expected {expected}, received {dtype}"
@@ -264,6 +260,7 @@ class Int64Index(IntegerIndex):
     _typ = "int64index"
     _engine_type = libindex.Int64Engine
     _default_dtype = np.dtype(np.int64)
+    _dtype_validation_metadata = (is_signed_integer_dtype, "signed integer")
 
 
 _uint64_descr_args = {
@@ -280,6 +277,7 @@ class UInt64Index(IntegerIndex):
     _typ = "uint64index"
     _engine_type = libindex.UInt64Engine
     _default_dtype = np.dtype(np.uint64)
+    _dtype_validation_metadata = (is_unsigned_integer_dtype, "unsigned integer")
 
     # ----------------------------------------------------------------
     # Indexing Methods
@@ -311,6 +309,7 @@ class Float64Index(NumericIndex):
     _typ = "float64index"
     _engine_type = libindex.Float64Engine
     _default_dtype = np.dtype(np.float64)
+    _dtype_validation_metadata = (is_float_dtype, "float")
 
     @property
     def inferred_type(self) -> str:

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import (
     Callable,
     Hashable,

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -94,6 +94,7 @@ class RangeIndex(NumericIndex):
 
     _typ = "rangeindex"
     _engine_type = libindex.Int64Engine
+    _dtype_validation_metadata = (is_signed_integer_dtype, "signed integer")
     _can_hold_na = False
     _range: range
 


### PR DESCRIPTION
The use of a dict with `_typ` attributes as keys in `NumericIndex._validate_dtype` makes it complicated to subclass numeric indexes and change the subclass' `_typ` attribute.

This PR makes the dtype validation in `NumericIndex._validate_dtype` not dependent on the value of the `_typ` attribute, making subclassing more robust.