### PR TITLE
[ArrayManager] TST: enable JSON tests (except for table schema)

### DIFF
--- a/pandas/tests/io/json/test_compression.py
+++ b/pandas/tests/io/json/test_compression.py
@@ -7,8 +7,6 @@ import pandas.util._test_decorators as td
 import pandas as pd
 import pandas._testing as tm
 
-pytestmark = td.skip_array_manager_not_yet_implemented
-
 
 def test_compression_roundtrip(compression):
     df = pd.DataFrame(

--- a/pandas/tests/io/json/test_deprecated_kwargs.py
+++ b/pandas/tests/io/json/test_deprecated_kwargs.py
@@ -2,14 +2,10 @@
 Tests for the deprecated keyword arguments for `read_json`.
 """
 
-import pandas.util._test_decorators as td
-
 import pandas as pd
 import pandas._testing as tm
 
 from pandas.io.json import read_json
-
-pytestmark = td.skip_array_manager_not_yet_implemented
 
 
 def test_deprecated_kwargs():

--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -15,8 +15,6 @@ import pandas._testing as tm
 
 from pandas.io.json._normalize import nested_to_record
 
-pytestmark = td.skip_array_manager_not_yet_implemented
-
 
 @pytest.fixture
 def deep_nested():
@@ -153,6 +151,8 @@ class TestJSONNormalize:
 
         tm.assert_frame_equal(result, expected)
 
+    # TODO(ArrayManager) sanitize S/U numpy dtypes to object
+    @td.skip_array_manager_not_yet_implemented
     def test_simple_normalize(self, state_data):
         result = json_normalize(state_data[0], "counties")
         expected = DataFrame(state_data[0]["counties"])
@@ -372,6 +372,8 @@ class TestJSONNormalize:
         for val in ["metafoo", "metabar", "foo", "bar"]:
             assert val in result
 
+    # TODO(ArrayManager) sanitize S/U numpy dtypes to object
+    @td.skip_array_manager_not_yet_implemented
     def test_record_prefix(self, state_data):
         result = json_normalize(state_data[0], "counties")
         expected = DataFrame(state_data[0]["counties"])

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -27,9 +27,6 @@ from pandas import (
 )
 import pandas._testing as tm
 
-pytestmark = td.skip_array_manager_not_yet_implemented
-
-
 _seriesd = tm.getSeriesData()
 
 _frame = DataFrame(_seriesd)
@@ -318,7 +315,13 @@ class TestPandasContainer:
                 '{"columns":["A","B"],'
                 '"index":["2","3"],'
                 '"data":[[1.0,"1"],[2.0,"2"],[null,"3"]]}',
-                r"Shape of passed values is \(3, 2\), indices imply \(2, 2\)",
+                "|".join(
+                    [
+                        r"Shape of passed values is \(3, 2\), indices imply \(2, 2\)",
+                        "Passed arrays should have the same length as the rows Index: "
+                        "3 vs 2 rows",
+                    ]
+                ),
                 "split",
             ),
             # too many columns

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -857,6 +857,8 @@ class TestPandasContainer:
         result = read_json(dumps(data))[["id", infer_word]]
         tm.assert_frame_equal(result, expected)
 
+    # TODO(ArrayManager) JSON
+    @td.skip_array_manager_not_yet_implemented
     @pytest.mark.parametrize(
         "date,date_unit",
         [

--- a/pandas/tests/io/json/test_readlines.py
+++ b/pandas/tests/io/json/test_readlines.py
@@ -3,8 +3,6 @@ from pathlib import Path
 
 import pytest
 
-import pandas.util._test_decorators as td
-
 import pandas as pd
 from pandas import (
     DataFrame,
@@ -13,8 +11,6 @@ from pandas import (
 import pandas._testing as tm
 
 from pandas.io.json._json import JsonReader
-
-pytestmark = td.skip_array_manager_not_yet_implemented
 
 
 @pytest.fixture

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -18,7 +18,6 @@ from pandas.compat import (
     IS64,
     is_platform_windows,
 )
-import pandas.util._test_decorators as td
 
 from pandas import (
     DataFrame,
@@ -31,8 +30,6 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
-
-pytestmark = td.skip_array_manager_not_yet_implemented
 
 
 def _clean_dict(d):


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/39146

This already enables most of the JSON tests (it are only the table schema tests that are segfaulting). Those are mostly working because the JSON writer falls back to using `df.values`. This only gives some errors with datetime formatting, for which one test is skipped (and this will then be fixed by letting the JSON code work column-by-column)