### PR TITLE
CI: ignore ResourceWarning in tm.assert_produces_warning

### DIFF
--- a/pandas/_testing/_warnings.py
+++ b/pandas/_testing/_warnings.py
@@ -142,6 +142,14 @@ def _assert_caught_no_extra_warnings(
 
     for actual_warning in caught_warnings:
         if _is_unexpected_warning(actual_warning, expected_warning):
+            unclosed = "unclosed transport <asyncio.sslproto._SSLProtocolTransport"
+            if isinstance(actual_warning, ResourceWarning) and unclosed in str(
+                actual_warning
+            ):
+                # FIXME: kludge because pytest.filterwarnings does not
+                #  suppress these, xref GH#38630
+                continue
+
             extra_warnings.append(
                 (
                     actual_warning.category.__name__,

--- a/setup.cfg
+++ b/setup.cfg
@@ -137,7 +137,6 @@ xfail_strict = True
 filterwarnings =
     error:Sparse:FutureWarning
     error:The SparseArray:FutureWarning
-    ignore:unclosed transport <asyncio.sslproto:ResourceWarning
 junit_family = xunit2
 
 [codespell]


### PR DESCRIPTION
reverts a line in setup.cfg that was intended to do this but failed