### PR TITLE
REF: simplify ohlc

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1109,20 +1109,10 @@ class BaseGroupBy(PandasObject, SelectionMixin, Generic[FrameOrSeries]):
             result = self.grouper._cython_operation(
                 "aggregate", obj._values, how, axis=0, min_count=min_count
             )
-
-            if how == "ohlc":
-                # e.g. ohlc
-                agg_names = ["open", "high", "low", "close"]
-                assert len(agg_names) == result.shape[1]
-                for result_column, result_name in zip(result.T, agg_names):
-                    key = base.OutputKey(label=result_name, position=idx)
-                    output[key] = result_column
-                    idx += 1
-            else:
-                assert result.ndim == 1
-                key = base.OutputKey(label=name, position=idx)
-                output[key] = result
-                idx += 1
+            assert result.ndim == 1
+            key = base.OutputKey(label=name, position=idx)
+            output[key] = result
+            idx += 1
 
         if not output:
             raise DataError("No numeric types to aggregate")
@@ -1804,7 +1794,25 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
         DataFrame
             Open, high, low and close values within each group.
         """
-        return self._apply_to_column_groupbys(lambda x: x._cython_agg_general("ohlc"))
+        if self.obj.ndim == 1:
+            # self._iterate_slices() yields only self._selected_obj
+            obj = self._selected_obj
+
+            is_numeric = is_numeric_dtype(obj.dtype)
+            if not is_numeric:
+                raise DataError("No numeric types to aggregate")
+
+            res_values = self.grouper._cython_operation(
+                "aggregate", obj._values, "ohlc", axis=0, min_count=-1
+            )
+
+            agg_names = ["open", "high", "low", "close"]
+            result = self.obj._constructor_expanddim(
+                res_values, index=self.grouper.result_index, columns=agg_names
+            )
+            return self._reindex_output(result)
+
+        return self._apply_to_column_groupbys(lambda x: x.ohlc())
 
     @final
     @doc(DataFrame.describe)

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -58,14 +58,16 @@ def test_custom_grouper(index):
     g = s.groupby(b)
 
     # check all cython functions work
-    funcs = ["add", "mean", "prod", "ohlc", "min", "max", "var"]
+    g.ohlc()  # doesn't use _cython_agg_general
+    funcs = ["add", "mean", "prod", "min", "max", "var"]
     for f in funcs:
         g._cython_agg_general(f)
 
     b = Grouper(freq=Minute(5), closed="right", label="right")
     g = s.groupby(b)
     # check all cython functions work
-    funcs = ["add", "mean", "prod", "ohlc", "min", "max", "var"]
+    g.ohlc()  # doesn't use _cython_agg_general
+    funcs = ["add", "mean", "prod", "min", "max", "var"]
     for f in funcs:
         g._cython_agg_general(f)
 
@@ -79,7 +81,7 @@ def test_custom_grouper(index):
     idx = DatetimeIndex(idx, freq="5T")
     expect = Series(arr, index=idx)
 
-    # GH2763 - return in put dtype if we can
+    # GH2763 - return input dtype if we can
     result = g.agg(np.sum)
     tm.assert_series_equal(result, expect)
 


### PR DESCRIPTION
Or more accurately, simplify BaseGroupBy._cython_agg_general by not having ohlc go through it.  This will in turn allow us to simplify SeriesGroupBy._wrap_aggregated_output.

This will have a merge conflict with #41066.  Doesn't matter which order they are merged in.