### PR TITLE
CI/DOC: temporary pin environment to python 3.8

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   # required
   - numpy>=1.17.3
-  - python=3
+  - python=3.8
   - python-dateutil>=2.7.3
   - pytz
 


### PR DESCRIPTION
The doc build is failing on master (`/home/runner/work/pandas/pandas/doc/source/reference/api/pandas.Series.dt.rst: WARNING: document isn't included in any toctree`), and the build that starts failing seems to have switched from python 3.8 to 3.9 (I don't see any other relevant change in the environment). I suppose the default python changed at the conda(-forge) side.