### PR TITLE
Backport PR #41092: CI/DOC: temporary pin environment to python 3.8

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   # required
   - numpy>=1.16.5
-  - python=3
+  - python=3.8
   - python-dateutil>=2.7.3
   - pytz
 


### PR DESCRIPTION
Backport PR #41092