### PR TITLE
TYP: Fix typehints for ExtensionDtype

### DIFF
--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from typing import (
     TYPE_CHECKING,
     Any,
+    TypeVar,
 )
 
 import numpy as np
@@ -25,6 +26,9 @@ from pandas.core.dtypes.generic import (
 
 if TYPE_CHECKING:
     from pandas.core.arrays import ExtensionArray
+
+    # To parameterize on same ExtensionDtype
+    E = TypeVar("E", bound="ExtensionDtype")
 
 
 class ExtensionDtype:
@@ -151,7 +155,7 @@ class ExtensionDtype:
         return np.nan
 
     @property
-    def type(self) -> type[Any]:
+    def type(self) -> type_t[Any]:
         """
         The scalar type for the array, e.g. ``int``
 
@@ -209,7 +213,7 @@ class ExtensionDtype:
         raise NotImplementedError
 
     @classmethod
-    def construct_from_string(cls, string: str):
+    def construct_from_string(cls, string: str) -> ExtensionDtype:
         r"""
         Construct this type from a string.
 
@@ -364,7 +368,7 @@ class ExtensionDtype:
             return None
 
 
-def register_extension_dtype(cls: type[ExtensionDtype]) -> type[ExtensionDtype]:
+def register_extension_dtype(cls: type[E]) -> type[E]:
     """
     Register an ExtensionType with pandas as class decorator.
 
@@ -420,7 +424,7 @@ class Registry:
 
         self.dtypes.append(dtype)
 
-    def find(self, dtype: type[ExtensionDtype] | str) -> type[ExtensionDtype] | None:
+    def find(self, dtype: type[E] | E | str) -> type[E] | E | ExtensionDtype | None:
         """
         Parameters
         ----------
@@ -431,8 +435,9 @@ class Registry:
         return the first matching dtype, otherwise return None
         """
         if not isinstance(dtype, str):
-            dtype_type = dtype
-            if not isinstance(dtype, type):
+            if isinstance(dtype, type):
+                dtype_type = dtype
+            else:
                 dtype_type = type(dtype)
             if issubclass(dtype_type, ExtensionDtype):
                 return dtype

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -213,7 +213,7 @@ class ExtensionDtype:
         raise NotImplementedError
 
     @classmethod
-    def construct_from_string(cls, string: str) -> ExtensionDtype:
+    def construct_from_string(cls, string: str):
         r"""
         Construct this type from a string.
 
@@ -424,7 +424,7 @@ class Registry:
 
         self.dtypes.append(dtype)
 
-    def find(self, dtype: type[E] | E | str) -> type[E] | E | ExtensionDtype | None:
+    def find(self, dtype: type[ExtensionDtype] | str) -> type[ExtensionDtype] | None:
         """
         Parameters
         ----------
@@ -435,9 +435,8 @@ class Registry:
         return the first matching dtype, otherwise return None
         """
         if not isinstance(dtype, str):
-            if isinstance(dtype, type):
-                dtype_type = dtype
-            else:
+            dtype_type = dtype
+            if not isinstance(dtype, type):
                 dtype_type = type(dtype)
             if issubclass(dtype_type, ExtensionDtype):
                 return dtype


### PR DESCRIPTION
This is a fix for type hints of `ExtensionDtype`. `register_extension_dtype` was confusing pyright autocomplete. It was fixed by parameterizing its return value on its input value.

Example:

```python
import pandas as pd

pd.CategoricalDtype(categories=['a', 'b'])
```

Before this change:
```console
$ pyright --version
pyright 1.1.133
$ pyright --lib pd.py
No configuration file found.
No pyproject.toml file found.
stubPath /home/omer/src/ext/typings is not a valid directory.
Assuming Python platform Linux
Searching for source files
Found 1 source file
/home/omer/src/ext/pd.py
  /home/omer/src/ext/pd.py:3:1 - error: Expected no arguments to "ExtensionDtype" constructor (reportGeneralTypeIssues)
1 error, 0 warnings, 0 infos
Completed in 0.72sec
```

After:
```console
$ pyright --lib ../pd.py
No configuration file found.
pyproject.toml file found at /home/omer/src/ext/pandas.
Loading pyproject.toml file at /home/omer/src/ext/pandas/pyproject.toml
Pyproject file "/home/omer/src/ext/pandas/pyproject.toml" is missing "[tool.pyright] section.
stubPath /home/omer/src/ext/pandas/typings is not a valid directory.
Assuming Python platform Linux
Searching for source files
Found 1 source file
0 errors, 0 warnings, 0 infos
Completed in 0.777sec
```