### PR TITLE
CLN: avoid catching AttributeErorr in DataFrameGroupBy.aggregate

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1035,24 +1035,28 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
             else:
 
                 # try to treat as if we are passing a list
+                gba = GroupByApply(self, [func], args=(), kwargs={})
                 try:
-                    result = GroupByApply(self, [func], args=(), kwargs={}).agg()
-
-                    # select everything except for the last level, which is the one
-                    # containing the name of the function(s), see GH 32040
-                    result.columns = result.columns.rename(
-                        [self._selected_obj.columns.name] * result.columns.nlevels
-                    ).droplevel(-1)
+                    result = gba.agg()
 
                 except ValueError as err:
                     if "no results" not in str(err):
                         # raised directly by _aggregate_multiple_funcs
                         raise
                     result = self._aggregate_frame(func)
-                except AttributeError:
-                    # catch exception from line 969
-                    # (Series does not have attribute "columns"), see GH 35246
-                    result = self._aggregate_frame(func)
+
+                else:
+                    sobj = self._selected_obj
+
+                    if isinstance(sobj, Series):
+                        # GH#35246 test_groupby_as_index_select_column_sum_empty_df
+                        result.columns = [self._selected_obj.name]
+                    else:
+                        # select everything except for the last level, which is the one
+                        # containing the name of the function(s), see GH#32040
+                        result.columns = result.columns.rename(
+                            [sobj.columns.name] * result.columns.nlevels
+                        ).droplevel(-1)
 
         if relabeling:
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
