### PR TITLE
BUG: Check for null values when infering excel in read_clipboard

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -925,7 +925,7 @@ I/O
 - Bug in :func:`read_csv` and :func:`read_table` misinterpreting arguments when ``sys.setprofile`` had been previously called (:issue:`41069`)
 - Bug in the conversion from pyarrow to pandas (e.g. for reading Parquet) with nullable dtypes and a pyarrow array whose data buffer size is not a multiple of dtype size (:issue:`40896`)
 - Bug in :func:`read_excel` would raise an error when pandas could not determine the file type, even when user specified the ``engine`` argument (:issue:`41225`)
--
+- Bug in :func:`read_clipboard` when copying from excel and the first column contains null values (:issue:`41108`)
 
 Period
 ^^^^^^

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -925,7 +925,7 @@ I/O
 - Bug in :func:`read_csv` and :func:`read_table` misinterpreting arguments when ``sys.setprofile`` had been previously called (:issue:`41069`)
 - Bug in the conversion from pyarrow to pandas (e.g. for reading Parquet) with nullable dtypes and a pyarrow array whose data buffer size is not a multiple of dtype size (:issue:`40896`)
 - Bug in :func:`read_excel` would raise an error when pandas could not determine the file type, even when user specified the ``engine`` argument (:issue:`41225`)
-- Bug in :func:`read_clipboard` when copying from excel and the first column contains null values (:issue:`41108`)
+- Bug in :func:`read_clipboard` copying from an excel file shifts values into the wrong column if there are null values in first column (:issue:`41108`)
 
 Period
 ^^^^^^

--- a/pandas/io/clipboards.py
+++ b/pandas/io/clipboards.py
@@ -58,11 +58,15 @@ def read_clipboard(sep=r"\s+", **kwargs):  # pragma: no cover
     # 0  1  2
     # 1  3  4
 
-    counts = {
-        x.count("\t") if i > 0 else x.lstrip().count("\t") for i, x in enumerate(lines)
-    }
+    counts = {x.lstrip(" ").count("\t") for x in lines}
     if len(lines) > 1 and len(counts) == 1 and counts.pop() != 0:
         sep = "\t"
+        # check the number of leading tabs in the first line
+        # to account for index columns
+        index_length = len(lines[0]) - len(lines[0].lstrip(" \t"))
+        if index_length != 0:
+            print(index_length)
+            kwargs.setdefault("index_col", [0, index_length - 1])
 
     # Edge case where sep is specified to be None, return to default
     if sep is None and kwargs.get("delim_whitespace") is None:

--- a/pandas/io/clipboards.py
+++ b/pandas/io/clipboards.py
@@ -59,8 +59,7 @@ def read_clipboard(sep=r"\s+", **kwargs):  # pragma: no cover
     # 1  3  4
 
     counts = {
-        x.count("\t") if i > 0 else x.lstrip().count("\t")
-        for i, x in enumerate(lines)
+        x.count("\t") if i > 0 else x.lstrip().count("\t") for i, x in enumerate(lines)
     }
     if len(lines) > 1 and len(counts) == 1 and counts.pop() != 0:
         sep = "\t"

--- a/pandas/io/clipboards.py
+++ b/pandas/io/clipboards.py
@@ -58,7 +58,10 @@ def read_clipboard(sep=r"\s+", **kwargs):  # pragma: no cover
     # 0  1  2
     # 1  3  4
 
-    counts = {x.lstrip().count("\t") for x in lines}
+    counts = {
+        x.count("\t") if i > 0 else x.lstrip().count("\t")
+        for i, x in enumerate(lines)
+    }
     if len(lines) > 1 and len(counts) == 1 and counts.pop() != 0:
         sep = "\t"
 

--- a/pandas/io/clipboards.py
+++ b/pandas/io/clipboards.py
@@ -65,7 +65,6 @@ def read_clipboard(sep=r"\s+", **kwargs):  # pragma: no cover
         # to account for index columns
         index_length = len(lines[0]) - len(lines[0].lstrip(" \t"))
         if index_length != 0:
-            print(index_length)
             kwargs.setdefault("index_col", [0, index_length - 1])
 
     # Edge case where sep is specified to be None, return to default

--- a/pandas/io/clipboards.py
+++ b/pandas/io/clipboards.py
@@ -65,7 +65,7 @@ def read_clipboard(sep=r"\s+", **kwargs):  # pragma: no cover
         # to account for index columns
         index_length = len(lines[0]) - len(lines[0].lstrip(" \t"))
         if index_length != 0:
-            kwargs.setdefault("index_col", [0, index_length - 1])
+            kwargs.setdefault("index_col", list(range(index_length)))
 
     # Edge case where sep is specified to be None, return to default
     if sep is None and kwargs.get("delim_whitespace") is None:

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -254,8 +254,7 @@ class TestClipboard:
         )
 
         # excel data is parsed correctly
-        assert df.iloc[1][1] == "blue"
-        assert df.equals(df_expected)
+        tm.assert_frame_equal(df, df_expected)
 
     def test_invalid_encoding(self, df):
         msg = "clipboard only supports utf-8 encoding"

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -5,7 +5,6 @@ import pytest
 
 from pandas import (
     DataFrame,
-    MultiIndex,
     get_option,
     read_clipboard,
 )
@@ -257,16 +256,34 @@ class TestClipboard:
         # excel data is parsed correctly
         tm.assert_frame_equal(df, df_expected)
 
-    def test_infer_excel_with_multiindex(self, request, mock_clipboard):
+    @pytest.mark.parametrize(
+        "multiindex",
+        [
+            (
+                """\t\t\tcol1\tcol2
+                A\t0\tTrue\t1\tred
+                A\t1\tTrue\t\tblue
+                B\t0\tFalse\t2\tgreen""",
+                [["A", "A", "B"], [0, 1, 0], [True, True, False]],
+            ),
+            (
+                """\t\tcol1\tcol2
+                A\t0\t1\tred
+                A\t1\t\tblue
+                B\t0\t2\tgreen""",
+                [["A", "A", "B"], [0, 1, 0]],
+            ),
+        ],
+    )
+    def test_infer_excel_with_multiindex(self, request, mock_clipboard, multiindex):
         # GH41108
-        text = "\t\tcol1\tcol2\nA\t0\t1\tred\nA\t1\t\tblue\nB\t0\t2\tgreen"
 
-        mock_clipboard[request.node.name] = text
+        # the `.replace()` is because `.dedent()` does not like the leading `\t`
+        mock_clipboard[request.node.name] = multiindex[0].replace(" ", "")
         df = read_clipboard()
-        multiindex = MultiIndex.from_tuples([("A", 0), ("A", 1), ("B", 0)])
         df_expected = DataFrame(
             data={"col1": [1, None, 2], "col2": ["red", "blue", "green"]},
-            index=multiindex,
+            index=multiindex[1],
         )
 
         # excel data is parsed correctly

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -243,16 +243,19 @@ class TestClipboard:
 
         tm.assert_frame_equal(res, exp)
 
-    # Tests that nulls on the first column do not trip infering excel format
     def test_infer_excel_with_nulls(self, request, mock_clipboard):
         # GH41108
         text = "col1\tcol2\n1\tred\n\tblue\n2\tgreen"
 
         mock_clipboard[request.node.name] = text
         df = read_clipboard()
+        df_expected = DataFrame(
+            data={"col1": [1, None, 2], "col2": ["red", "blue", "green"]}
+        )
 
         # excel data is parsed correctly
         assert df.iloc[1][1] == "blue"
+        assert df.equals(df_expected)
 
     def test_invalid_encoding(self, df):
         msg = "clipboard only supports utf-8 encoding"

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -5,6 +5,7 @@ import pytest
 
 from pandas import (
     DataFrame,
+    MultiIndex,
     get_option,
     read_clipboard,
 )
@@ -251,6 +252,21 @@ class TestClipboard:
         df = read_clipboard()
         df_expected = DataFrame(
             data={"col1": [1, None, 2], "col2": ["red", "blue", "green"]}
+        )
+
+        # excel data is parsed correctly
+        tm.assert_frame_equal(df, df_expected)
+
+    def test_infer_excel_with_multiindex(self, request, mock_clipboard):
+        # GH41108
+        text = "\t\tcol1\tcol2\nA\t0\t1\tred\nA\t1\t\tblue\nB\t0\t2\tgreen"
+
+        mock_clipboard[request.node.name] = text
+        df = read_clipboard()
+        multiindex = MultiIndex.from_tuples([("A", 0), ("A", 1), ("B", 0)])
+        df_expected = DataFrame(
+            data={"col1": [1, None, 2], "col2": ["red", "blue", "green"]},
+            index=multiindex,
         )
 
         # excel data is parsed correctly

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -220,6 +220,21 @@ class TestClipboard:
         # excel data is parsed correctly
         assert df.iloc[1][1] == "Harry Carney"
 
+        # a null on the first column works
+        text = dedent(
+            """
+            John James	Charlie Mingus
+            1	2
+            	Harry Carney
+            7	Carl Miney
+            """.strip()
+        )
+        mock_clipboard[request.node.name] = text
+        df = read_clipboard(**clip_kwargs)
+
+        # excel data is parsed correctly
+        assert df.iloc[1][1] == "Harry Carney"
+
         # having diff tab counts doesn't trigger it
         text = dedent(
             """

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -220,21 +220,6 @@ class TestClipboard:
         # excel data is parsed correctly
         assert df.iloc[1][1] == "Harry Carney"
 
-        # a null on the first column works
-        text = dedent(
-            """
-            John James	Charlie Mingus
-            1	2
-            	Harry Carney
-            7	Carl Miney
-            """.strip()
-        )
-        mock_clipboard[request.node.name] = text
-        df = read_clipboard(**clip_kwargs)
-
-        # excel data is parsed correctly
-        assert df.iloc[1][1] == "Harry Carney"
-
         # having diff tab counts doesn't trigger it
         text = dedent(
             """
@@ -257,6 +242,17 @@ class TestClipboard:
         exp = read_clipboard(**clip_kwargs)
 
         tm.assert_frame_equal(res, exp)
+
+    # Tests that nulls on the first column do not trip infering excel format
+    def test_infer_excel_with_nulls(self, request, mock_clipboard):
+        # GH41108
+        text = "col1\tcol2\n1\tred\n\tblue\n2\tgreen"
+
+        mock_clipboard[request.node.name] = text
+        df = read_clipboard()
+
+        # excel data is parsed correctly
+        assert df.iloc[1][1] == "blue"
 
     def test_invalid_encoding(self, df):
         msg = "clipboard only supports utf-8 encoding"

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -260,17 +260,21 @@ class TestClipboard:
         "multiindex",
         [
             (
-                """\t\t\tcol1\tcol2
-                A\t0\tTrue\t1\tred
-                A\t1\tTrue\t\tblue
-                B\t0\tFalse\t2\tgreen""",
+                (  # Can't use `dedent` here as it will remove the leading `\t`
+                    "\t\t\tcol1\tcol2\n"
+                    "A\t0\tTrue\t1\tred\n"
+                    "A\t1\tTrue\t\tblue\n"
+                    "B\t0\tFalse\t2\tgreen\n"
+                ),
                 [["A", "A", "B"], [0, 1, 0], [True, True, False]],
             ),
             (
-                """\t\tcol1\tcol2
-                A\t0\t1\tred
-                A\t1\t\tblue
-                B\t0\t2\tgreen""",
+                (
+                    "\t\tcol1\tcol2\n"
+                    "A\t0\t1\tred\n"
+                    "A\t1\t\tblue\n"
+                    "B\t0\t2\tgreen\n"
+                ),
                 [["A", "A", "B"], [0, 1, 0]],
             ),
         ],
@@ -278,8 +282,7 @@ class TestClipboard:
     def test_infer_excel_with_multiindex(self, request, mock_clipboard, multiindex):
         # GH41108
 
-        # the `.replace()` is because `.dedent()` does not like the leading `\t`
-        mock_clipboard[request.node.name] = multiindex[0].replace(" ", "")
+        mock_clipboard[request.node.name] = multiindex[0]
         df = read_clipboard()
         df_expected = DataFrame(
             data={"col1": [1, None, 2], "col2": ["red", "blue", "green"]},

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -259,21 +259,20 @@ class TestClipboard:
     @pytest.mark.parametrize(
         "multiindex",
         [
-            (
-                (  # Can't use `dedent` here as it will remove the leading `\t`
-                    "\t\t\tcol1\tcol2\n"
-                    "A\t0\tTrue\t1\tred\n"
-                    "A\t1\tTrue\t\tblue\n"
-                    "B\t0\tFalse\t2\tgreen\n"
+            (  # Can't use `dedent` here as it will remove the leading `\t`
+                "\n".join(
+                    [
+                        "\t\t\tcol1\tcol2",
+                        "A\t0\tTrue\t1\tred",
+                        "A\t1\tTrue\t\tblue",
+                        "B\t0\tFalse\t2\tgreen",
+                    ]
                 ),
                 [["A", "A", "B"], [0, 1, 0], [True, True, False]],
             ),
             (
-                (
-                    "\t\tcol1\tcol2\n"
-                    "A\t0\t1\tred\n"
-                    "A\t1\t\tblue\n"
-                    "B\t0\t2\tgreen\n"
+                "\n".join(
+                    ["\t\tcol1\tcol2", "A\t0\t1\tred", "A\t1\t\tblue", "B\t0\t2\tgreen"]
                 ),
                 [["A", "A", "B"], [0, 1, 0]],
             ),


### PR DESCRIPTION
GH41108
Stripping whitespace on read_clipboard causes data copied from
excel to lose the tab separator between the first column and
the nexts, shifting the data into the wrong column

This just removes the .lstrip() except for the first line
containing headers, to avoid breaking header-less index in csv
files

- [x] closes #41108
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
