### PR TITLE
CI: pin numpy in the actions-37 env (pyarrow incompatibility)

### DIFF
--- a/ci/deps/actions-37.yaml
+++ b/ci/deps/actions-37.yaml
@@ -15,7 +15,7 @@ dependencies:
   # pandas dependencies
   - botocore>=1.11
   - fsspec>=0.7.4
-  - numpy
+  - numpy=1.19
   - python-dateutil
   - nomkl
   - pyarrow=0.15.1


### PR DESCRIPTION
This build is currently failing because it started to install numpy 1.20.1 yesterday, which gives an incompatibility with pyarrow. 