### PR TITLE
CI: Mark slow tests as slow to speed up ci

### DIFF
--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1011,6 +1011,7 @@ class TestDataFrameConstructors:
         alt = DataFrame({name: data[name] for name in data.dtype.names}, dtype=int)
         tm.assert_frame_equal(result, alt)
 
+    @pytest.mark.slow
     def test_constructor_mrecarray(self):
         # Ensure mrecarray produces frame identical to dict of masked arrays
         # from GH3479

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -631,7 +631,7 @@ def test_groupby_cum_skipna(op, skipna, input, exp):
     tm.assert_series_equal(expected, result)
 
 
-@pytest.mark.arm_slow
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "op, args, targop",
     [

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -146,6 +146,7 @@ class TestDateRanges:
         with pytest.raises(OutOfBoundsDatetime, match=msg):
             date_range(end="1969-11-14", periods=106752 * 24, freq="H")
 
+    @pytest.mark.slow
     def test_date_range_int64_overflow_stride_endpoint_different_signs(self):
         # cases where stride * periods overflow int64 and stride/endpoint
         #  have different signs

--- a/pandas/tests/indexes/multi/test_integrity.py
+++ b/pandas/tests/indexes/multi/test_integrity.py
@@ -122,7 +122,7 @@ def test_consistency():
     assert index.is_unique is False
 
 
-@pytest.mark.arm_slow
+@pytest.mark.slow
 def test_hash_collisions():
     # non-smoke test that we don't get hash collisions
 

--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -71,7 +71,7 @@ class TestIntervalIndex:
         with pytest.raises(KeyError, match=r"^\[-1\]$"):
             indexer_sl(ser)[[-1, 3]]
 
-    @pytest.mark.arm_slow
+    @pytest.mark.slow
     def test_loc_getitem_large_series(self):
         ser = Series(
             np.arange(1000000), index=IntervalIndex.from_breaks(np.arange(1000001))

--- a/pandas/tests/indexing/multiindex/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/multiindex/test_chaining_and_caching.py
@@ -56,7 +56,7 @@ def test_cache_updating():
     assert result == 2
 
 
-@pytest.mark.arm_slow
+@pytest.mark.slow
 def test_indexer_caching():
     # GH5727
     # make sure that indexers are in the _internal_names_set

--- a/pandas/tests/io/parser/common/test_chunksize.py
+++ b/pandas/tests/io/parser/common/test_chunksize.py
@@ -177,7 +177,6 @@ def test_chunks_have_consistent_numerical_type(all_parsers):
     assert result.a.dtype == float
 
 
-@pytest.mark.slow
 def test_warn_if_chunks_have_mismatched_type(all_parsers, request):
     warning_type = None
     parser = all_parsers

--- a/pandas/tests/io/parser/common/test_chunksize.py
+++ b/pandas/tests/io/parser/common/test_chunksize.py
@@ -162,6 +162,7 @@ def test_chunk_begins_with_newline_whitespace(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.slow
 @pytest.mark.xfail(reason="GH38630, sometimes gives ResourceWarning", strict=False)
 def test_chunks_have_consistent_numerical_type(all_parsers):
     parser = all_parsers
@@ -176,6 +177,7 @@ def test_chunks_have_consistent_numerical_type(all_parsers):
     assert result.a.dtype == float
 
 
+@pytest.mark.slow
 def test_warn_if_chunks_have_mismatched_type(all_parsers, request):
     warning_type = None
     parser = all_parsers

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -159,6 +159,7 @@ def test_unsupported_dtype(c_parser_only, match, kwargs):
 
 
 @td.skip_if_32bit
+@pytest.mark.slow
 def test_precise_conversion(c_parser_only):
     from decimal import Decimal
 
@@ -300,6 +301,7 @@ def test_tokenize_CR_with_quoting(c_parser_only):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.slow
 def test_grow_boundary_at_cap(c_parser_only):
     # See gh-12494
     #

--- a/pandas/tests/io/sas/test_sas7bdat.py
+++ b/pandas/tests/io/sas/test_sas7bdat.py
@@ -39,6 +39,7 @@ class TestSAS7BDAT:
                     df.iloc[:, k] = df.iloc[:, k].astype(np.float64)
             self.data.append(df)
 
+    @pytest.mark.slow
     def test_from_file(self):
         for j in 0, 1:
             df0 = self.data[j]
@@ -47,6 +48,7 @@ class TestSAS7BDAT:
                 df = pd.read_sas(fname, encoding="utf-8")
                 tm.assert_frame_equal(df, df0)
 
+    @pytest.mark.slow
     def test_from_buffer(self):
         for j in 0, 1:
             df0 = self.data[j]
@@ -61,6 +63,7 @@ class TestSAS7BDAT:
                     df = rdr.read()
                 tm.assert_frame_equal(df, df0, check_exact=False)
 
+    @pytest.mark.slow
     def test_from_iterator(self):
         for j in 0, 1:
             df0 = self.data[j]
@@ -72,6 +75,7 @@ class TestSAS7BDAT:
                     df = rdr.read(3)
                     tm.assert_frame_equal(df, df0.iloc[2:5, :])
 
+    @pytest.mark.slow
     def test_path_pathlib(self):
         for j in 0, 1:
             df0 = self.data[j]
@@ -81,6 +85,7 @@ class TestSAS7BDAT:
                 tm.assert_frame_equal(df, df0)
 
     @td.skip_if_no("py.path")
+    @pytest.mark.slow
     def test_path_localpath(self):
         from py.path import local as LocalPath
 
@@ -91,6 +96,7 @@ class TestSAS7BDAT:
                 df = pd.read_sas(fname, encoding="utf-8")
                 tm.assert_frame_equal(df, df0)
 
+    @pytest.mark.slow
     def test_iterator_loop(self):
         # github #13654
         for j in 0, 1:

--- a/pandas/tests/io/sas/test_xport.py
+++ b/pandas/tests/io/sas/test_xport.py
@@ -34,6 +34,7 @@ class TestXport:
         with td.file_leak_context():
             yield
 
+    @pytest.mark.slow
     def test1_basic(self):
         # Tests with DEMO_G.xpt (all numeric file)
 

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -67,7 +67,6 @@ class TestSorting:
             assert left[k] == v
         assert len(left) == len(right)
 
-    @pytest.mark.slow
     def test_int64_overflow_moar(self):
 
         # GH9096

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -67,7 +67,7 @@ class TestSorting:
             assert left[k] == v
         assert len(left) == len(right)
 
-    @pytest.mark.arm_slow
+    @pytest.mark.slow
     def test_int64_overflow_moar(self):
 
         # GH9096

--- a/pandas/tests/window/moments/test_moments_rolling_skew_kurt.py
+++ b/pandas/tests/window/moments/test_moments_rolling_skew_kurt.py
@@ -152,6 +152,7 @@ def test_center_reindex_series(series, roll_func):
     tm.assert_series_equal(series_xp, series_rs)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("roll_func", ["kurt", "skew"])
 def test_center_reindex_frame(frame, roll_func):
     # shifter index


### PR DESCRIPTION
We have a few tests which are really slow and not marked as such. I went through the list below and marked everything greater than 4 seconds as slow. Should give us between 4 and 5 minutes performance boost

<details>
# 29.68s call     pandas/tests/io/sas/test_sas7bdat.py::TestSAS7BDAT::test_iterator_loop
# 12.98s call     pandas/tests/test_sorting.py::TestSorting::test_int64_overflow_moar
# 11.43s call     pandas/tests/indexing/multiindex/test_chaining_and_caching.py::test_indexer_caching
# 10.13s call     pandas/tests/groupby/transform/test_transform.py::test_cython_transform_frame[shift-args3-<lambda>]
# 9.87s call     pandas/tests/io/sas/test_sas7bdat.py::TestSAS7BDAT::test_from_iterator
# 9.79s call     pandas/tests/groupby/transform/test_transform.py::test_cython_transform_frame[shift-args2-<lambda>]
# 9.41s teardown pandas/tests/window/moments/test_moments_rolling_quantile.py::test_center_reindex_frame[1.0]
# 8.82s call     pandas/tests/io/sas/test_xport.py::TestXport::test1_basic
# 8.43s call     pandas/tests/io/parser/common/test_chunksize.py::test_warn_if_chunks_have_mismatched_type[python]
# 8.38s call     pandas/tests/io/parser/common/test_chunksize.py::test_chunks_have_consistent_numerical_type[python]
# 8.13s call     pandas/tests/io/parser/test_c_parser_only.py::test_grow_boundary_at_cap[c_low]
# 8.12s call     pandas/tests/io/parser/test_c_parser_only.py::test_grow_boundary_at_cap[c_high]
# 6.97s call     pandas/tests/indexes/datetimes/test_date_range.py::TestDateRanges::test_date_range_int64_overflow_stride_endpoint_different_signs
# 5.90s call     pandas/tests/frame/test_constructors.py::TestDataFrameConstructors::test_constructor_mrecarray
# 5.84s teardown pandas/tests/window/moments/test_moments_rolling_skew_kurt.py::test_center_reindex_frame[skew]
# 5.61s call     pandas/tests/io/parser/test_c_parser_only.py::test_precise_conversion[c_high]
# 5.29s call     pandas/tests/io/sas/test_sas7bdat.py::TestSAS7BDAT::test_path_pathlib
# 5.13s call     pandas/tests/groupby/transform/test_transform.py::test_cython_transform_frame[cumsum-args1-<lambda>]
# 4.93s call     pandas/tests/io/sas/test_sas7bdat.py::TestSAS7BDAT::test_from_file
# 4.86s call     pandas/tests/io/sas/test_sas7bdat.py::TestSAS7BDAT::test_from_buffer
# 4.84s call     pandas/tests/io/sas/test_sas7bdat.py::TestSAS7BDAT::test_path_localpath
# 4.59s call     pandas/tests/indexes/multi/test_integrity.py::test_hash_collisions
# 4.26s call     pandas/tests/indexing/interval/test_interval.py::TestIntervalIndex::test_loc_getitem_large_series
# 3.99s call     pandas/tests/io/parser/test_c_parser_only.py::test_precise_conversion[c_low]

</details>