### PR TITLE
BUG: Fix series clipping NA issue

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -696,6 +696,7 @@ Numeric
 - Bug in :meth:`DataFrame.transform` would raise ``SpecificationError`` when passed a dictionary and columns were missing; will now raise a ``KeyError`` instead (:issue:`40004`)
 - Bug in :meth:`DataFrameGroupBy.rank` giving incorrect results with ``pct=True`` and equal values between consecutive groups (:issue:`40518`)
 - Bug in :meth:`Series.count` would result in an ``int32`` result on 32-bit platforms when argument ``level=None`` (:issue:`40908`)
+- Bug in :meth:`Series.clip` would fail if series contains NA values and has nullable int or float as a data type (:issue:`40851`)
 
 Conversion
 ^^^^^^^^^^

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7404,10 +7404,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         with np.errstate(all="ignore"):
             if upper is not None:
-                subset = self.to_numpy() <= upper
+                subset = (self <= upper).to_numpy()
                 result = result.where(subset, upper, axis=None, inplace=False)
             if lower is not None:
-                subset = self.to_numpy() >= lower
+                subset = (self >= lower).to_numpy()
                 result = result.where(subset, lower, axis=None, inplace=False)
 
         if np.any(mask):

--- a/pandas/tests/series/methods/test_clip.py
+++ b/pandas/tests/series/methods/test_clip.py
@@ -40,17 +40,22 @@ class TestSeriesClip:
             assert list(isna(s)) == list(isna(lower))
             assert list(isna(s)) == list(isna(upper))
 
-    @pytest.mark.parametrize("dtypes", ["Float64", "Int64", "Float32", "Int32"])
-    def test_series_clipping_with_na_values(self, dtypes):
+    def test_series_clipping_with_na_values(
+        self, any_nullable_numeric_dtype, nulls_fixture
+    ):
         # Ensure that clipping method can handle NA values with out failing
         # GH#40581
 
-        s = Series([pd.NA, 1.0, 3.0], dtype=dtypes)
+        s = Series([nulls_fixture, 1.0, 3.0], dtype=any_nullable_numeric_dtype)
         s_clipped_upper = s.clip(upper=2.0)
         s_clipped_lower = s.clip(lower=2.0)
 
-        expected_upper = Series([pd.NA, 1.0, 2.0], dtype=dtypes)
-        expected_lower = Series([pd.NA, 2.0, 3.0], dtype=dtypes)
+        expected_upper = Series(
+            [nulls_fixture, 1.0, 2.0], dtype=any_nullable_numeric_dtype
+        )
+        expected_lower = Series(
+            [nulls_fixture, 2.0, 3.0], dtype=any_nullable_numeric_dtype
+        )
 
         tm.assert_series_equal(s_clipped_upper, expected_upper)
         tm.assert_series_equal(s_clipped_lower, expected_lower)

--- a/pandas/tests/series/methods/test_clip.py
+++ b/pandas/tests/series/methods/test_clip.py
@@ -40,6 +40,21 @@ class TestSeriesClip:
             assert list(isna(s)) == list(isna(lower))
             assert list(isna(s)) == list(isna(upper))
 
+    @pytest.mark.parametrize("dtypes", ["Float64", "Int64", "Float32", "Int32"])
+    def test_series_clipping_with_na_values(self, dtypes):
+        # Ensure that clipping method can handle NA values with out failing
+        # GH#40581
+
+        s = Series([pd.NA, 1.0, 3.0], dtype=dtypes)
+        s_clipped_upper = s.clip(upper=2.0)
+        s_clipped_lower = s.clip(lower=2.0)
+
+        expected_upper = Series([pd.NA, 1.0, 2.0], dtype=dtypes)
+        expected_lower = Series([pd.NA, 2.0, 3.0], dtype=dtypes)
+
+        tm.assert_series_equal(s_clipped_upper, expected_upper)
+        tm.assert_series_equal(s_clipped_lower, expected_lower)
+
     def test_clip_with_na_args(self):
         """Should process np.nan argument as None """
         # GH#17276


### PR DESCRIPTION
Series clipping method could not handle series with NA values.
Issue was fixed by first comparing values and only after then converted
to numpy array. Now the test code provided with the issue ticket provides an expected result.

- [x] closes #40581
- [x] tests added / passed
 - I did run test_fast.sh and 3 test failed but I think they are not related to my changes
   -  test_can_set_locale_valid_set 
   -  test_header_multi_index_blank_line[c_high]
   - test_header_multi_index_blank_line[c_high]
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

