### PR TITLE
TYP: Overload series/ffill and bfill

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6472,30 +6472,40 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     @overload
     def ffill(
         self: FrameOrSeries,
-        axis: None | str | int = ...,
+        axis: None | Axis = ...,
         inplace: Literal[False] = ...,
         limit: None | int = ...,
-        downcast: None | str | dict = ...,
+        downcast=...,
     ) -> FrameOrSeries:
         ...
 
     @overload
     def ffill(
         self: FrameOrSeries,
-        axis: None | str | int = ...,
-        inplace: Literal[True] = ...,
+        axis: None | Axis,
+        inplace: Literal[True],
         limit: None | int = ...,
-        downcast: None | str | dict = ...,
+        downcast=...,
     ) -> None:
         ...
 
     @overload
     def ffill(
         self: FrameOrSeries,
-        axis: None | str | int = ...,
+        *,
+        inplace: Literal[True],
+        limit: None | int = ...,
+        downcast=...,
+    ) -> None:
+        ...
+
+    @overload
+    def ffill(
+        self: FrameOrSeries,
+        axis: None | Axis = ...,
         inplace: bool_t = ...,
         limit: None | int = ...,
-        downcast: None | str | dict = ...,
+        downcast=...,
     ) -> FrameOrSeries | None:
         ...
 
@@ -6503,10 +6513,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     @doc(klass=_shared_doc_kwargs["klass"])
     def ffill(
         self: FrameOrSeries,
-        axis: None | str | int = None,
+        axis: None | Axis = None,
         inplace: bool_t = False,
         limit: None | int = None,
-        downcast: None | str | dict = None,
+        downcast=None,
     ):
         """
         Synonym for :meth:`DataFrame.fillna` with ``method='ffill'``.
@@ -6525,30 +6535,40 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     @overload
     def bfill(
         self: FrameOrSeries,
-        axis: None | str | int = ...,
+        axis: None | Axis = ...,
         inplace: Literal[False] = ...,
         limit: None | int = ...,
-        downcast: None | str | dict = ...,
+        downcast=...,
     ) -> FrameOrSeries:
         ...
 
     @overload
     def bfill(
         self: FrameOrSeries,
-        axis: None | str | int = ...,
-        inplace: Literal[True] = ...,
+        axis: None | Axis,
+        inplace: Literal[True],
         limit: None | int = ...,
-        downcast: None | str | dict = ...,
+        downcast=...,
     ) -> None:
         ...
 
     @overload
     def bfill(
         self: FrameOrSeries,
-        axis: None | str | int = ...,
+        *,
+        inplace: Literal[True],
+        limit: None | int = ...,
+        downcast=...,
+    ) -> None:
+        ...
+
+    @overload
+    def bfill(
+        self: FrameOrSeries,
+        axis: None | Axis = ...,
         inplace: bool_t = ...,
         limit: None | int = ...,
-        downcast: None | str | dict = ...,
+        downcast=...,
     ) -> FrameOrSeries | None:
         ...
 
@@ -6556,10 +6576,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     @doc(klass=_shared_doc_kwargs["klass"])
     def bfill(
         self: FrameOrSeries,
-        axis: None | str | int = None,
+        axis: None | Axis = None,
         inplace: bool_t = False,
         limit: None | int = None,
-        downcast: None | str | dict = None,
+        downcast=None,
     ):
         """
         Synonym for :meth:`DataFrame.fillna` with ``method='bfill'``.

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6517,7 +6517,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         inplace: bool_t = False,
         limit: None | int = None,
         downcast=None,
-    ):
+    ) -> FrameOrSeries | None:
         """
         Synonym for :meth:`DataFrame.fillna` with ``method='ffill'``.
 
@@ -6580,7 +6580,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         inplace: bool_t = False,
         limit: None | int = None,
         downcast=None,
-    ):
+    ) -> FrameOrSeries | None:
         """
         Synonym for :meth:`DataFrame.fillna` with ``method='bfill'``.
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6469,15 +6469,45 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         else:
             return result.__finalize__(self, method="fillna")
 
+    @overload
+    def ffill(
+        self: FrameOrSeries,
+        axis: None | str | int = ...,
+        inplace: Literal[False] = ...,
+        limit: None | int = ...,
+        downcast: None | str | dict = ...,
+    ) -> FrameOrSeries:
+        ...
+
+    @overload
+    def ffill(
+        self: FrameOrSeries,
+        axis: None | str | int = ...,
+        inplace: Literal[True] = ...,
+        limit: None | int = ...,
+        downcast: None | str | dict = ...,
+    ) -> None:
+        ...
+
+    @overload
+    def ffill(
+        self: FrameOrSeries,
+        axis: None | str | int = ...,
+        inplace: bool_t = ...,
+        limit: None | int = ...,
+        downcast: None | str | dict = ...,
+    ) -> FrameOrSeries | None:
+        ...
+
     @final
     @doc(klass=_shared_doc_kwargs["klass"])
     def ffill(
         self: FrameOrSeries,
-        axis=None,
+        axis: None | str | int = None,
         inplace: bool_t = False,
-        limit=None,
-        downcast=None,
-    ) -> FrameOrSeries | None:
+        limit: None | int = None,
+        downcast: None | str | dict = None,
+    ):
         """
         Synonym for :meth:`DataFrame.fillna` with ``method='ffill'``.
 
@@ -6492,15 +6522,45 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
     pad = ffill
 
+    @overload
+    def bfill(
+        self: FrameOrSeries,
+        axis: None | str | int = ...,
+        inplace: Literal[False] = ...,
+        limit: None | int = ...,
+        downcast: None | str | dict = ...,
+    ) -> FrameOrSeries:
+        ...
+
+    @overload
+    def bfill(
+        self: FrameOrSeries,
+        axis: None | str | int = ...,
+        inplace: Literal[True] = ...,
+        limit: None | int = ...,
+        downcast: None | str | dict = ...,
+    ) -> None:
+        ...
+
+    @overload
+    def bfill(
+        self: FrameOrSeries,
+        axis: None | str | int = ...,
+        inplace: bool_t = ...,
+        limit: None | int = ...,
+        downcast: None | str | dict = ...,
+    ) -> FrameOrSeries | None:
+        ...
+
     @final
     @doc(klass=_shared_doc_kwargs["klass"])
     def bfill(
         self: FrameOrSeries,
-        axis=None,
+        axis: None | str | int = None,
         inplace: bool_t = False,
-        limit=None,
-        downcast=None,
-    ) -> FrameOrSeries | None:
+        limit: None | int = None,
+        downcast: None | str | dict = None,
+    ):
         """
         Synonym for :meth:`DataFrame.fillna` with ``method='bfill'``.
 


### PR DESCRIPTION
- Closes part of MarcoGorelli/pyladieslondon-sprints#29

- Adds `typing.overload` to: `ffill` and ``bfill` from https://github.com/pandas-dev/pandas/blob/master/pandas/core/generic.py

## Setup and Output for `ffill`
```python
# t_ffill.py
import pandas as pd

inplace: bool

reveal_type(pd.DataFrame([1, None, None]).ffill(inplace=False))
reveal_type(pd.DataFrame([1, None, None]).ffill(inplace=True))
reveal_type(pd.DataFrame([1, None, None]).ffill())
reveal_type(pd.DataFrame([1, None, None]).ffill(inplace=inplace))

reveal_type(pd.DataFrame([1, None, None]).ffill(axis=0, inplace=False))
reveal_type(pd.DataFrame([1, None, None]).ffill(axis=0, inplace=True))
reveal_type(pd.DataFrame([1, None, None]).ffill(axis=0))
reveal_type(pd.DataFrame([1, None, None]).ffill(axis=0, inplace=inplace))

reveal_type(pd.DataFrame([1, None, None]).ffill(inplace=False, limit=1))
reveal_type(pd.DataFrame([1, None, None]).ffill(inplace=True, limit=1))
reveal_type(pd.DataFrame([1, None, None]).ffill(limit=1))
reveal_type(pd.DataFrame([1, None, None]).ffill(inplace=inplace, limit=1))

reveal_type(pd.DataFrame([1, None, None]).ffill(inplace=False, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).ffill(inplace=True, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).ffill(downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).ffill(inplace=inplace, downcast="infer"))

reveal_type(pd.DataFrame([1, None, None]).ffill(axis=0, inplace=False, limit=1))
reveal_type(pd.DataFrame([1, None, None]).ffill(axis=0, inplace=True, limit=1))
reveal_type(pd.DataFrame([1, None, None]).ffill(axis=0, limit=1))
reveal_type(pd.DataFrame([1, None, None]).ffill(axis=0, inplace=inplace, limit=1))

reveal_type(pd.DataFrame([1, None, None]).ffill(axis=0, inplace=False, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).ffill(axis=0, inplace=True, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).ffill(axis=0, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).ffill(axis=0, inplace=inplace, downcast="infer"))

reveal_type(pd.DataFrame([1, None, None]).ffill(inplace=False, limit=1, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).ffill(inplace=True, limit=1, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).ffill(limit=1, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).ffill(inplace=inplace, limit=1, downcast="infer"))

reveal_type(pd.DataFrame([1, None, None]).ffill(axis=0, inplace=False, limit=1, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).ffill(axis=0, inplace=True, limit=1, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).ffill(axis=0, limit=1, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).ffill(axis=0, inplace=inplace, limit=1, downcast="infer"))
```
which results in the following `mypy` output:
```bash
$ mypy t_ffill.py
  t_ffill.py:6: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:7: note: Revealed type is 'None'
  t_ffill.py:8: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:9: note: Revealed type is 'Union[pandas.core.frame.DataFrame*, None]'
  t_ffill.py:11: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:12: note: Revealed type is 'None'
  t_ffill.py:13: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:14: note: Revealed type is 'Union[pandas.core.frame.DataFrame*, None]'
  t_ffill.py:16: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:17: note: Revealed type is 'None'
  t_ffill.py:18: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:19: note: Revealed type is 'Union[pandas.core.frame.DataFrame*, None]'
  t_ffill.py:21: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:22: note: Revealed type is 'None'
  t_ffill.py:23: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:24: note: Revealed type is 'Union[pandas.core.frame.DataFrame*, None]'
  t_ffill.py:26: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:27: note: Revealed type is 'None'
  t_ffill.py:28: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:29: note: Revealed type is 'Union[pandas.core.frame.DataFrame*, None]'
  t_ffill.py:31: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:32: note: Revealed type is 'None'
  t_ffill.py:33: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:34: note: Revealed type is 'Union[pandas.core.frame.DataFrame*, None]'
  t_ffill.py:36: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:37: note: Revealed type is 'None'
  t_ffill.py:38: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:39: note: Revealed type is 'Union[pandas.core.frame.DataFrame*, None]'
  t_ffill.py:41: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:42: note: Revealed type is 'None'
  t_ffill.py:43: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:44: note: Revealed type is 'Union[pandas.core.frame.DataFrame*, None]'
```

## Setup and Ouput for `bfill`
```python
# t_bfill.py
import pandas as pd

inplace: bool

reveal_type(pd.DataFrame([1, None, None]).bfill(inplace=False))
reveal_type(pd.DataFrame([1, None, None]).bfill(inplace=True))
reveal_type(pd.DataFrame([1, None, None]).bfill())
reveal_type(pd.DataFrame([1, None, None]).bfill(inplace=inplace))

reveal_type(pd.DataFrame([1, None, None]).bfill(axis=0, inplace=False))
reveal_type(pd.DataFrame([1, None, None]).bfill(axis=0, inplace=True))
reveal_type(pd.DataFrame([1, None, None]).bfill(axis=0))
reveal_type(pd.DataFrame([1, None, None]).bfill(axis=0, inplace=inplace))

reveal_type(pd.DataFrame([1, None, None]).bfill(inplace=False, limit=1))
reveal_type(pd.DataFrame([1, None, None]).bfill(inplace=True, limit=1))
reveal_type(pd.DataFrame([1, None, None]).bfill(limit=1))
reveal_type(pd.DataFrame([1, None, None]).bfill(inplace=inplace, limit=1))

reveal_type(pd.DataFrame([1, None, None]).bfill(inplace=False, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).bfill(inplace=True, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).bfill(downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).bfill(inplace=inplace, downcast="infer"))

reveal_type(pd.DataFrame([1, None, None]).bfill(axis=0, inplace=False, limit=1))
reveal_type(pd.DataFrame([1, None, None]).bfill(axis=0, inplace=True, limit=1))
reveal_type(pd.DataFrame([1, None, None]).bfill(axis=0, limit=1))
reveal_type(pd.DataFrame([1, None, None]).bfill(axis=0, inplace=inplace, limit=1))

reveal_type(pd.DataFrame([1, None, None]).bfill(axis=0, inplace=False, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).bfill(axis=0, inplace=True, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).bfill(axis=0, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).bfill(axis=0, inplace=inplace, downcast="infer"))

reveal_type(pd.DataFrame([1, None, None]).bfill(inplace=False, limit=1, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).bfill(inplace=True, limit=1, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).bfill(limit=1, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).bfill(inplace=inplace, limit=1, downcast="infer"))

reveal_type(pd.DataFrame([1, None, None]).bfill(axis=0, inplace=False, limit=1, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).bfill(axis=0, inplace=True, limit=1, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).bfill(axis=0, limit=1, downcast="infer"))
reveal_type(pd.DataFrame([1, None, None]).bfill(axis=0, inplace=inplace, limit=1, downcast="infer"))
```
which results in the following `mypy` output:
```bash
$ mypy t_bfill.py
  t_ffill.py:6: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:7: note: Revealed type is 'None'
  t_ffill.py:8: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:9: note: Revealed type is 'Union[pandas.core.frame.DataFrame*, None]'
  t_ffill.py:11: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:12: note: Revealed type is 'None'
  t_ffill.py:13: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:14: note: Revealed type is 'Union[pandas.core.frame.DataFrame*, None]'
  t_ffill.py:16: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:17: note: Revealed type is 'None'
  t_ffill.py:18: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:19: note: Revealed type is 'Union[pandas.core.frame.DataFrame*, None]'
  t_ffill.py:21: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:22: note: Revealed type is 'None'
  t_ffill.py:23: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:24: note: Revealed type is 'Union[pandas.core.frame.DataFrame*, None]'
  t_ffill.py:26: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:27: note: Revealed type is 'None'
  t_ffill.py:28: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:29: note: Revealed type is 'Union[pandas.core.frame.DataFrame*, None]'
  t_ffill.py:31: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:32: note: Revealed type is 'None'
  t_ffill.py:33: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:34: note: Revealed type is 'Union[pandas.core.frame.DataFrame*, None]'
  t_ffill.py:36: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:37: note: Revealed type is 'None'
  t_ffill.py:38: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:39: note: Revealed type is 'Union[pandas.core.frame.DataFrame*, None]'
  t_ffill.py:41: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:42: note: Revealed type is 'None'
  t_ffill.py:43: note: Revealed type is 'pandas.core.frame.DataFrame*'
  t_ffill.py:44: note: Revealed type is 'Union[pandas.core.frame.DataFrame*, None]'
```