### PR TITLE
[ArrayManager] TST: remove more ArrayManager skips for JSON IO

### DIFF
--- a/pandas/tests/io/formats/test_printing.py
+++ b/pandas/tests/io/formats/test_printing.py
@@ -3,8 +3,6 @@ import pytest
 
 import pandas._config.config as cf
 
-import pandas.util._test_decorators as td
-
 import pandas as pd
 
 import pandas.io.formats.format as fmt
@@ -121,7 +119,6 @@ c        ff         いいい"""
         assert adjoined == expected
 
 
-@td.skip_array_manager_not_yet_implemented  # TODO(ArrayManager) JSON
 class TestTableSchemaRepr:
     @classmethod
     def setup_class(cls):

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -282,9 +282,7 @@ bar2,12,13,14,15
             ("to_excel", {"engine": "xlwt"}, "xlwt"),
             ("to_feather", {}, "pyarrow"),
             ("to_html", {}, "os"),
-            pytest.param(
-                "to_json", {}, "os", marks=td.skip_array_manager_not_yet_implemented
-            ),
+            ("to_json", {}, "os"),
             ("to_latex", {}, "os"),
             ("to_pickle", {}, "os"),
             ("to_stata", {"time_stamp": pd.to_datetime("2019-01-01 00:00")}, "os"),
@@ -435,10 +433,7 @@ def test_is_fsspec_url():
 
 
 @pytest.mark.parametrize("encoding", [None, "utf-8"])
-@pytest.mark.parametrize(
-    "format",
-    ["csv", pytest.param("json", marks=td.skip_array_manager_not_yet_implemented)],
-)
+@pytest.mark.parametrize("format", ["csv", "json"])
 def test_codecs_encoding(encoding, format):
     # GH39247
     expected = tm.makeDataFrame()

--- a/pandas/tests/io/test_compression.py
+++ b/pandas/tests/io/test_compression.py
@@ -8,14 +8,10 @@ import time
 
 import pytest
 
-import pandas.util._test_decorators as td
-
 import pandas as pd
 import pandas._testing as tm
 
 import pandas.io.common as icom
-
-pytestmark = td.skip_array_manager_not_yet_implemented
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/io/test_fsspec.py
+++ b/pandas/tests/io/test_fsspec.py
@@ -249,7 +249,6 @@ def test_pickle_options(fsspectest):
     tm.assert_frame_equal(df, out)
 
 
-@td.skip_array_manager_not_yet_implemented  # TODO(ArrayManager) JSON
 def test_json_options(fsspectest, compression):
     df = DataFrame({"a": [0]})
     df.to_json(

--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -44,16 +44,7 @@ def gcs_buffer(monkeypatch):
 
 
 @td.skip_if_no("gcsfs")
-@pytest.mark.parametrize(
-    "format",
-    [
-        "csv",
-        pytest.param("json", marks=td.skip_array_manager_not_yet_implemented),
-        "parquet",
-        "excel",
-        "markdown",
-    ],
-)
+@pytest.mark.parametrize("format", ["csv", "json", "parquet", "excel", "markdown"])
 def test_to_read_gcs(gcs_buffer, format):
     """
     Test that many to/read functions support GCS.

--- a/pandas/tests/io/test_user_agent.py
+++ b/pandas/tests/io/test_user_agent.py
@@ -182,12 +182,7 @@ class AllHeaderCSVResponder(http.server.BaseHTTPRequestHandler):
     "responder, read_method, parquet_engine",
     [
         (CSVUserAgentResponder, pd.read_csv, None),
-        pytest.param(
-            JSONUserAgentResponder,
-            pd.read_json,
-            None,
-            marks=td.skip_array_manager_not_yet_implemented,
-        ),
+        (JSONUserAgentResponder, pd.read_json, None),
         (ParquetPyArrowUserAgentResponder, pd.read_parquet, "pyarrow"),
         pytest.param(
             ParquetFastParquetUserAgentResponder,
@@ -199,12 +194,7 @@ class AllHeaderCSVResponder(http.server.BaseHTTPRequestHandler):
         (PickleUserAgentResponder, pd.read_pickle, None),
         (StataUserAgentResponder, pd.read_stata, None),
         (GzippedCSVUserAgentResponder, pd.read_csv, None),
-        pytest.param(
-            GzippedJSONUserAgentResponder,
-            pd.read_json,
-            None,
-            marks=td.skip_array_manager_not_yet_implemented,
-        ),
+        (GzippedJSONUserAgentResponder, pd.read_json, None),
     ],
 )
 def test_server_and_default_headers(responder, read_method, parquet_engine):
@@ -233,12 +223,7 @@ def test_server_and_default_headers(responder, read_method, parquet_engine):
     "responder, read_method, parquet_engine",
     [
         (CSVUserAgentResponder, pd.read_csv, None),
-        pytest.param(
-            JSONUserAgentResponder,
-            pd.read_json,
-            None,
-            marks=td.skip_array_manager_not_yet_implemented,
-        ),
+        (JSONUserAgentResponder, pd.read_json, None),
         (ParquetPyArrowUserAgentResponder, pd.read_parquet, "pyarrow"),
         pytest.param(
             ParquetFastParquetUserAgentResponder,
@@ -250,12 +235,7 @@ def test_server_and_default_headers(responder, read_method, parquet_engine):
         (PickleUserAgentResponder, pd.read_pickle, None),
         (StataUserAgentResponder, pd.read_stata, None),
         (GzippedCSVUserAgentResponder, pd.read_csv, None),
-        pytest.param(
-            GzippedJSONUserAgentResponder,
-            pd.read_json,
-            None,
-            marks=td.skip_array_manager_not_yet_implemented,
-        ),
+        (GzippedJSONUserAgentResponder, pd.read_json, None),
     ],
 )
 def test_server_and_custom_headers(responder, read_method, parquet_engine):

--- a/pandas/tests/io/xml/test_to_xml.py
+++ b/pandas/tests/io/xml/test_to_xml.py
@@ -1172,7 +1172,6 @@ def test_style_to_string():
     assert out_xml == out_str
 
 
-@td.skip_array_manager_not_yet_implemented  # TODO(ArrayManager) JSON
 @td.skip_if_no("lxml")
 def test_style_to_json():
     xsl = """\


### PR DESCRIPTION
Some more JSON skips that I missed in https://github.com/pandas-dev/pandas/pull/41081 can now be removed

xref https://github.com/pandas-dev/pandas/issues/39146