### PR TITLE
WEB add phofl to maintainers list

### DIFF
--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -86,6 +86,7 @@ maintainers:
   - dsaxton
   - MarcoGorelli
   - rhshadrach
+  - phofl
   emeritus:
   - Wouter Overmeire
   - Skipper Seabold


### PR DESCRIPTION
Am I OK to add a checklist (which would probably only have about 3 items: add to pandas-dev team on GitHub, add to mailing group, list on website) to the Wiki for next someone's added?