### PR TITLE
BUG: dataframe setitem error on size incompatible assignment

### DIFF
--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1235,7 +1235,7 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
             if blk.should_store(value):
                 if (
                     value.shape[0] != 1
-                    and len(blk_locs) != value.shape[0]
+                    and len(blklocs) != value.shape[0]
                     and value.ndim == 2
                 ):
                     raise ValueError("Errored123")

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1233,6 +1233,12 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
             blk = self.blocks[blkno]
             blk_locs = blklocs[val_locs.indexer]
             if blk.should_store(value):
+                if (
+                    value.shape[0] != 1
+                    and len(blk_locs) != value.shape[0]
+                    and value.ndim == 2
+                ):
+                    raise ValueError("Errored123")
                 blk.set_inplace(blk_locs, value_getitem(val_locs))
             else:
                 unfit_mgr_locs.append(blk.mgr_locs.as_array[blk_locs])

--- a/pandas/tests/test_mytests.py
+++ b/pandas/tests/test_mytests.py
@@ -38,6 +38,35 @@ def test_setitem_size_incompatible_ndarray(arr):
         data["A"] = np.random.randn(arr[0], arr[1])
 
 
+# @pytest.mark.parametrize(
+#     argnames="arr",
+#     argvalues=[
+#         # (4, 3),
+#          (4, 4), (4, 10), (4, 20), (4, 30)
+#     ],
+# )
+# def test_setitem_size_incompatible_ndarray2(arr):
+#     # GH#40827
+#     # Assigning a dataframe column to an ndarray with more than one columns
+#     # should raise an exception.
+#     data = DataFrame(
+#         [[1, "A", 1.0], [2, "B", 2.0], [3, "C", 3.0], [4, "D", 4.0]],
+#         columns=["A", "A", "B"],
+#     )
+#     msg = "Errored123"
+#     with pytest.raises(ValueError, match=msg):
+#         data["A"] = np.random.randn(arr[0], arr[1])
+
+#     data = DataFrame(
+#         [[1, 1.0], [2, 2.0], [3, 3.0], [4, 4.0]],
+#         columns=["A", "B"],
+#     )
+#     msg = "Errored123"
+#     # TODO: This should fail with pytest.raises()
+#     with pytest.raises(ValueError, match=msg):
+#         data["A"] = np.random.randn(arr[0], arr[1])
+
+
 def test_setitem_size_compatible_ndarray():
     data = DataFrame(np.zeros(4), columns=["A"])
 
@@ -50,8 +79,7 @@ def test_setitem_size_compatible_ndarray():
 
 
 @pytest.mark.parametrize(
-    argnames="arr",
-    argvalues=[(4, 2), (4, 3), (4, 4), (4, 10), (4, 20), (4, 30)],
+    argnames="arr", argvalues=[(4, 2), (4, 3), (4, 4), (4, 10), (4, 20), (4, 30)],
 )
 def test_loc_setitem_with_size_incompatible_ndarray(arr):
     # GH#40827

--- a/pandas/tests/test_mytests.py
+++ b/pandas/tests/test_mytests.py
@@ -1,0 +1,102 @@
+import re
+
+import numpy as np
+import pytest
+
+from pandas import DataFrame
+import pandas._testing as tm
+
+
+def test_dup_with_mismatched_column_lengths():
+    # dup across dtypes
+    df = DataFrame(
+        np.random.randn(3, 4),
+        columns=["foo", "bar", "foo", "hello"],
+    )
+    # check(df)
+
+    msg = "Errored123"
+    with pytest.raises(ValueError, match=msg):
+        df["foo"] = np.random.randn(3, 3)
+
+    df["foo"] = np.random.randn(3, 2)
+    df["foo"] = np.random.randn(3, 1)
+
+
+@pytest.mark.parametrize(
+    argnames="arr",
+    argvalues=[(4, 3), (4, 4), (4, 10), (4, 20), (4, 30)],
+)
+def test_setitem_size_incompatible_ndarray(arr):
+    # GH#40827
+    # Assigning a dataframe column to an ndarray with more than one columns
+    # should raise an exception.
+    data = DataFrame(np.zeros((4, 2)), columns=["A", "B"])
+    msg = ""
+    msg = "Errored123"
+    with pytest.raises(ValueError, match=msg):
+        data["A"] = np.random.randn(arr[0], arr[1])
+
+
+def test_setitem_size_compatible_ndarray():
+    data = DataFrame(np.zeros(4), columns=["A"])
+
+    data_to_set = np.random.randn(4, 1)
+
+    expected = DataFrame(data=data_to_set, columns=["A"])
+
+    data["A"] = data_to_set
+    tm.assert_frame_equal(data, expected)
+
+
+@pytest.mark.parametrize(
+    argnames="arr",
+    argvalues=[(4, 2), (4, 3), (4, 4), (4, 10), (4, 20), (4, 30)],
+)
+def test_loc_setitem_with_size_incompatible_ndarray(arr):
+    # GH#40827
+    # Assigning a dataframe column to an ndarray with more than one columns
+    # should raise an exception.
+    data = DataFrame(np.zeros(4), columns=["A"])
+    msg = re.escape(
+        f"could not broadcast input array from shape (4,{arr[1]}) into shape (4,1)"
+    )
+    with pytest.raises(Exception, match=msg):
+        data.iloc[:] = np.random.randn(arr[0], arr[1])
+
+
+def test_loc_setitem_with_size_compatible_ndarray():
+    data = DataFrame(np.zeros(4), columns=["A"])
+
+    data_to_set = np.random.randn(4, 1)
+
+    expected = DataFrame(data=data_to_set, columns=["A"])
+
+    data.iloc[:] = data_to_set
+    tm.assert_frame_equal(data, expected)
+
+
+def test_iloc_setitem_with_size_compatible_ndarray():
+    data = DataFrame(np.zeros(4), columns=["A"])
+
+    data_to_set = np.random.randn(4, 1)
+
+    expected = DataFrame(data=data_to_set, columns=["A"])
+
+    data.iloc[:] = data_to_set
+    tm.assert_frame_equal(data, expected)
+
+
+@pytest.mark.parametrize(
+    argnames="arr", argvalues=[(4, 2), (4, 3), (4, 4), (4, 10), (4, 20), (4, 30)]
+)
+def test_iloc_setitem_with_size_incompatible_ndarray(arr):
+    # GH#40827
+    # Assigning a dataframe column to an ndarray with more than one columns
+    # should raise an exception.
+    data = DataFrame(np.zeros(4), columns=["A"])
+    msg = re.escape(
+        f"could not broadcast input array from shape (4,{arr[1]}) " "into shape (4,1)"
+    )
+    with pytest.raises(Exception, match=msg):
+        data.iloc[:] = np.random.randn(arr[0], arr[1])


### PR DESCRIPTION
- [ ] closes #40827
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

I've labeled the error something silly but that can be fixed later.

This pull request replaces this older pr #41008 

I've put all my tests inside one file for easier review.

### Issues
I'm unsure how to stop this test from failing `test_pivot_table_doctest_case` Could you help with this?

This test (`test_invalid_colormap`) also fails but when I rerun it individually, it passes ...

I also had an issue with flake8 and black not working together ... in my most recent commit so I just committed it with `--no-verify`.