### PR TITLE
CLN: groupby.ops follow-up cleanup

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -809,6 +809,7 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
     grouper: ops.BaseGrouper
     as_index: bool
 
+    @final
     def __init__(
         self,
         obj: FrameOrSeries,


### PR DESCRIPTION
get the namespaces/privateness "right"
avoid runtime imports
fix "type: ignore"s