### PR TITLE
[ArrowStringArray] use pyarrow.compute.match_substring_regex if available

### DIFF
--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from distutils.version import LooseVersion
+import re
 from typing import (
     TYPE_CHECKING,
     Any,
     Sequence,
     cast,
 )
+import warnings
 
 import numpy as np
 
@@ -754,14 +756,30 @@ class ArrowStringArray(OpsMixin, ExtensionArray, ObjectStringArrayMixin):
             return lib.map_infer_mask(arr, f, mask.view("uint8"))
 
     def _str_contains(self, pat, case=True, flags=0, na=np.nan, regex=True):
-        if not regex and case:
-            result = pc.match_substring(self._data, pat)
-            result = BooleanDtype().__from_arrow__(result)
-            if not isna(na):
-                result[isna(result)] = bool(na)
-            return result
-        else:
+        if flags:
             return super()._str_contains(pat, case, flags, na, regex)
+
+        if regex:
+            if hasattr(pc, "match_substring_regex") and case:
+                if re.compile(pat).groups:
+                    warnings.warn(
+                        "This pattern has match groups. To actually get the "
+                        "groups, use str.extract.",
+                        UserWarning,
+                        stacklevel=3,
+                    )
+                result = pc.match_substring_regex(self._data, pat)
+            else:
+                return super()._str_contains(pat, case, flags, na, regex)
+        else:
+            if case:
+                result = pc.match_substring(self._data, pat)
+            else:
+                result = pc.match_substring(pc.utf8_upper(self._data), pat.upper())
+        result = BooleanDtype().__from_arrow__(result)
+        if not isna(na):
+            result[isna(result)] = bool(na)
+        return result
 
     def _str_isalnum(self):
         if hasattr(pc, "utf8_is_alnum"):

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -760,6 +760,7 @@ class ArrowStringArray(OpsMixin, ExtensionArray, ObjectStringArrayMixin):
             return super()._str_contains(pat, case, flags, na, regex)
 
         if regex:
+            # match_substring_regex added in pyarrow 4.0.0
             if hasattr(pc, "match_substring_regex") and case:
                 if re.compile(pat).groups:
                     warnings.warn(
@@ -782,6 +783,7 @@ class ArrowStringArray(OpsMixin, ExtensionArray, ObjectStringArrayMixin):
         return result
 
     def _str_startswith(self, pat, na=None):
+        # match_substring_regex added in pyarrow 4.0.0
         if hasattr(pc, "match_substring_regex"):
             result = pc.match_substring_regex(self._data, "^" + re.escape(pat))
             result = BooleanDtype().__from_arrow__(result)
@@ -792,6 +794,7 @@ class ArrowStringArray(OpsMixin, ExtensionArray, ObjectStringArrayMixin):
             return super()._str_startswith(pat, na)
 
     def _str_endswith(self, pat, na=None):
+        # match_substring_regex added in pyarrow 4.0.0
         if hasattr(pc, "match_substring_regex"):
             result = pc.match_substring_regex(self._data, re.escape(pat) + "$")
             result = BooleanDtype().__from_arrow__(result)


### PR DESCRIPTION
follow-up to #41025

```
[ 50.00%] ··· strings.Contains.time_contains                                                                                                              ok
[ 50.00%] ··· ============== ========== ==========
              --                     regex        
              -------------- ---------------------
                  dtype         True      False   
              ============== ========== ==========
                   str        22.0±0ms   15.0±0ms 
                  string      17.2±0ms   10.9±0ms 
               arrow_string   6.84±0ms   2.37±0ms 
              ============== ========== ==========
```