### PR TITLE
[ArrowStringArray] use pyarrow string trimming functions if available

### DIFF
--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -831,3 +831,30 @@ class ArrowStringArray(OpsMixin, ExtensionArray, ObjectStringArrayMixin):
 
     def _str_upper(self):
         return type(self)(pc.utf8_upper(self._data))
+
+    def _str_strip(self, to_strip=None):
+        if to_strip is None:
+            if hasattr(pc, "utf8_trim_whitespace"):
+                return type(self)(pc.utf8_trim_whitespace(self._data))
+        else:
+            if hasattr(pc, "utf8_trim"):
+                return type(self)(pc.utf8_trim(self._data, characters=to_strip))
+        return super()._str_strip(to_strip)
+
+    def _str_lstrip(self, to_strip=None):
+        if to_strip is None:
+            if hasattr(pc, "utf8_ltrim_whitespace"):
+                return type(self)(pc.utf8_ltrim_whitespace(self._data))
+        else:
+            if hasattr(pc, "utf8_ltrim"):
+                return type(self)(pc.utf8_ltrim(self._data, characters=to_strip))
+        return super()._str_lstrip(to_strip)
+
+    def _str_rstrip(self, to_strip=None):
+        if to_strip is None:
+            if hasattr(pc, "utf8_rtrim_whitespace"):
+                return type(self)(pc.utf8_rtrim_whitespace(self._data))
+        else:
+            if hasattr(pc, "utf8_rtrim"):
+                return type(self)(pc.utf8_rtrim(self._data, characters=to_strip))
+        return super()._str_rstrip(to_strip)

--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -570,19 +570,19 @@ def test_slice_replace():
     tm.assert_series_equal(result, exp)
 
 
-def test_strip_lstrip_rstrip():
-    values = Series(["  aa   ", " bb \n", np.nan, "cc  "])
+def test_strip_lstrip_rstrip(any_string_dtype):
+    values = Series(["  aa   ", " bb \n", np.nan, "cc  "], dtype=any_string_dtype)
 
     result = values.str.strip()
-    exp = Series(["aa", "bb", np.nan, "cc"])
+    exp = Series(["aa", "bb", np.nan, "cc"], dtype=any_string_dtype)
     tm.assert_series_equal(result, exp)
 
     result = values.str.lstrip()
-    exp = Series(["aa   ", "bb \n", np.nan, "cc  "])
+    exp = Series(["aa   ", "bb \n", np.nan, "cc  "], dtype=any_string_dtype)
     tm.assert_series_equal(result, exp)
 
     result = values.str.rstrip()
-    exp = Series(["  aa", " bb", np.nan, "cc"])
+    exp = Series(["  aa", " bb", np.nan, "cc"], dtype=any_string_dtype)
     tm.assert_series_equal(result, exp)
 
 
@@ -609,19 +609,19 @@ def test_strip_lstrip_rstrip_mixed():
     tm.assert_almost_equal(rs, xp)
 
 
-def test_strip_lstrip_rstrip_args():
-    values = Series(["xxABCxx", "xx BNSD", "LDFJH xx"])
+def test_strip_lstrip_rstrip_args(any_string_dtype):
+    values = Series(["xxABCxx", "xx BNSD", "LDFJH xx"], dtype=any_string_dtype)
 
     rs = values.str.strip("x")
-    xp = Series(["ABC", " BNSD", "LDFJH "])
+    xp = Series(["ABC", " BNSD", "LDFJH "], dtype=any_string_dtype)
     tm.assert_series_equal(rs, xp)
 
     rs = values.str.lstrip("x")
-    xp = Series(["ABCxx", " BNSD", "LDFJH xx"])
+    xp = Series(["ABCxx", " BNSD", "LDFJH xx"], dtype=any_string_dtype)
     tm.assert_series_equal(rs, xp)
 
     rs = values.str.rstrip("x")
-    xp = Series(["xxABC", "xx BNSD", "LDFJH "])
+    xp = Series(["xxABC", "xx BNSD", "LDFJH "], dtype=any_string_dtype)
     tm.assert_series_equal(rs, xp)
 
 


### PR DESCRIPTION
```
[ 27.78%] ··· strings.Methods.time_lstrip                                                                                                                 ok
[ 27.78%] ··· ============== ==========
                  dtype                
              -------------- ----------
                   str        22.7±0ms 
                  string      16.4±0ms 
               arrow_string   1.71±0ms 
              ============== ==========


[ 38.89%] ··· strings.Methods.time_rstrip                                                                                                                 ok
[ 38.89%] ··· ============== ==========
                  dtype                
              -------------- ----------
                   str        19.7±0ms 
                  string      13.9±0ms 
               arrow_string   1.71±0ms 
              ============== ==========


[ 43.06%] ··· strings.Methods.time_strip                                                                                                                  ok
[ 43.06%] ··· ============== ==========
                  dtype                
              -------------- ----------
                   str        18.9±0ms 
                  string      14.6±0ms 
               arrow_string   1.64±0ms 
              ============== ==========

```