### PR TITLE
[ArrowStringArray] startswith/endswith using native pyarrow method

### DIFF
--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from distutils.version import LooseVersion
+import re
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -762,6 +763,26 @@ class ArrowStringArray(OpsMixin, ExtensionArray, ObjectStringArrayMixin):
             return result
         else:
             return super()._str_contains(pat, case, flags, na, regex)
+
+    def _str_startswith(self, pat, na=None):
+        if hasattr(pc, "match_substring_regex"):
+            result = pc.match_substring_regex(self._data, "^" + re.escape(pat))
+            result = BooleanDtype().__from_arrow__(result)
+            if not isna(na):
+                result[isna(result)] = bool(na)
+            return result
+        else:
+            return super()._str_startswith(pat, na)
+
+    def _str_endswith(self, pat, na=None):
+        if hasattr(pc, "match_substring_regex"):
+            result = pc.match_substring_regex(self._data, re.escape(pat) + "$")
+            result = BooleanDtype().__from_arrow__(result)
+            if not isna(na):
+                result[isna(result)] = bool(na)
+            return result
+        else:
+            return super()._str_endswith(pat, na)
 
     def _str_isalnum(self):
         if hasattr(pc, "utf8_is_alnum"):

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -200,6 +200,25 @@ def test_startswith(dtype, null_value, na):
     tm.assert_series_equal(rs, xp)
 
 
+@pytest.mark.parametrize("na", [None, True, False])
+def test_startswith_nullable_string_dtype(nullable_string_dtype, na):
+    values = Series(
+        ["om", None, "foo_nom", "nom", "bar_foo", None, "foo", "regex", "rege."],
+        dtype=nullable_string_dtype,
+    )
+    result = values.str.startswith("foo", na=na)
+    exp = Series(
+        [False, na, True, False, False, na, True, False, False], dtype="boolean"
+    )
+    tm.assert_series_equal(result, exp)
+
+    result = values.str.startswith("rege.", na=na)
+    exp = Series(
+        [False, na, False, False, False, na, False, False, True], dtype="boolean"
+    )
+    tm.assert_series_equal(result, exp)
+
+
 @pytest.mark.parametrize("dtype", [None, "category"])
 @pytest.mark.parametrize("null_value", [None, np.nan, pd.NA])
 @pytest.mark.parametrize("na", [True, False])
@@ -226,6 +245,25 @@ def test_endswith(dtype, null_value, na):
     rs = Series(mixed).str.endswith("f")
     xp = Series([False, np.nan, False, np.nan, np.nan, False, np.nan, np.nan, np.nan])
     tm.assert_series_equal(rs, xp)
+
+
+@pytest.mark.parametrize("na", [None, True, False])
+def test_endswith_nullable_string_dtype(nullable_string_dtype, na):
+    values = Series(
+        ["om", None, "foo_nom", "nom", "bar_foo", None, "foo", "regex", "rege."],
+        dtype=nullable_string_dtype,
+    )
+    result = values.str.endswith("foo", na=na)
+    exp = Series(
+        [False, na, False, False, True, na, True, False, False], dtype="boolean"
+    )
+    tm.assert_series_equal(result, exp)
+
+    result = values.str.endswith("rege.", na=na)
+    exp = Series(
+        [False, na, False, False, False, na, False, False, True], dtype="boolean"
+    )
+    tm.assert_series_equal(result, exp)
 
 
 def test_replace():


### PR DESCRIPTION
```
[ 50.00%] ··· strings.Methods.time_startswith                                                                                                             ok
[ 50.00%] ··· ============== ==========
                  dtype                
              -------------- ----------
                   str        19.2±0ms 
                  string      16.0±0ms 
               arrow_string   2.42±0ms 
              ============== ==========

[ 50.00%] ··· strings.Methods.time_endswith                                                                                                               ok
[ 50.00%] ··· ============== ==========
                  dtype                
              -------------- ----------
                   str        19.3±0ms 
                  string      15.0±0ms 
               arrow_string   6.68±0ms 
              ============== ==========

```