### PR TITLE
REF: avoid passing empty list to concat in groupby methods

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1754,11 +1754,16 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
     def _apply_to_column_groupbys(self, func) -> DataFrame:
         from pandas.core.reshape.concat import concat
 
-        return concat(
-            (func(col_groupby) for _, col_groupby in self._iterate_column_groupbys()),
-            keys=self._selected_obj.columns,
-            axis=1,
-        )
+        columns = self._selected_obj.columns
+        results = [
+            func(col_groupby) for _, col_groupby in self._iterate_column_groupbys()
+        ]
+
+        if not len(results):
+            # concat would raise
+            return DataFrame([], columns=columns, index=self.grouper.result_index)
+        else:
+            return concat(results, keys=columns, axis=1)
 
     def count(self) -> DataFrame:
         """
@@ -1850,27 +1855,30 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         # Try to consolidate with normal wrapping functions
 
         obj = self._obj_with_exclusions
-        axis_number = obj._get_axis_number(self.axis)
-        other_axis = int(not axis_number)
-        if axis_number == 0:
+        if self.axis == 0:
             iter_func = obj.items
         else:
             iter_func = obj.iterrows
 
-        results = concat(
-            [
-                SeriesGroupBy(content, selection=label, grouper=self.grouper).nunique(
-                    dropna
-                )
-                for label, content in iter_func()
-            ],
-            axis=1,
-        )
-        results = cast(DataFrame, results)
+        res_list = [
+            SeriesGroupBy(content, selection=label, grouper=self.grouper).nunique(
+                dropna
+            )
+            for label, content in iter_func()
+        ]
+        if res_list:
+            results = concat(res_list, axis=1)
+            results = cast(DataFrame, results)
+        else:
+            # concat would raise
+            results = DataFrame(
+                [], index=self.grouper.result_index, columns=obj.columns[:0]
+            )
 
-        if axis_number == 1:
+        if self.axis == 1:
             results = results.T
 
+        other_axis = 1 - self.axis
         results._get_axis(other_axis).names = obj._get_axis(other_axis).names
 
         if not self.as_index:

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -450,11 +450,6 @@ class Resampler(BaseGroupBy, PandasObject):
             elif "len(index) != len(labels)" in str(err):
                 # raised in libgroupby validation
                 pass
-            elif "No objects to concatenate" in str(err):
-                # raised in concat call
-                #  In tests this is reached via either
-                #  _apply_to_column_groupbys (ohlc) or DataFrameGroupBy.nunique
-                pass
             else:
                 raise
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2020,6 +2020,12 @@ def test_groupby_crash_on_nunique(axis):
 
     tm.assert_frame_equal(result, expected)
 
+    # same thing, but empty columns
+    gb = df[[]].groupby(axis=axis_number, level=0)
+    res = gb.nunique()
+    exp = expected[[]]
+    tm.assert_frame_equal(res, exp)
+
 
 def test_groupby_list_level():
     # GH 9790


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
