### PR TITLE
CLN: no need to catch libgroupby validation ValueError

### DIFF
--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -354,11 +354,15 @@ def test_apply_to_one_column_of_df():
         {"col": range(10), "col1": range(10, 20)},
         index=date_range("2012-01-01", periods=10, freq="20min"),
     )
+
+    # access "col" via getattr -> make sure we handle AttributeError
     result = df.resample("H").apply(lambda group: group.col.sum())
     expected = Series(
         [3, 12, 21, 9], index=date_range("2012-01-01", periods=4, freq="H")
     )
     tm.assert_series_equal(result, expected)
+
+    # access "col" via _getitem__ -> make sure we handle KeyErrpr
     result = df.resample("H").apply(lambda group: group["col"].sum())
     tm.assert_series_equal(result, expected)
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
