### PR TITLE
TYP: ExtensionArray unique and repeat

### DIFF
--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -69,6 +69,7 @@ from pandas.core.sorting import (
 )
 
 if TYPE_CHECKING:
+    from typing import Literal
 
     class ExtensionArraySupportsAnyAll("ExtensionArray"):
         def any(self, *, skipna: bool = True) -> bool:
@@ -794,7 +795,7 @@ class ExtensionArray:
             b = empty
         return self._concat_same_type([a, b])
 
-    def unique(self):
+    def unique(self: ExtensionArrayT) -> ExtensionArrayT:
         """
         Compute the ExtensionArray of unique values.
 
@@ -1023,7 +1024,7 @@ class ExtensionArray:
 
     @Substitution(klass="ExtensionArray")
     @Appender(_extension_array_shared_docs["repeat"])
-    def repeat(self, repeats, axis=None):
+    def repeat(self, repeats: int | Sequence[int], axis: Literal[0] | None = None):
         nv.validate_repeat((), {"axis": axis})
         ind = np.arange(len(self)).repeat(repeats)
         return self.take(ind)

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -69,7 +69,6 @@ from pandas.core.sorting import (
 )
 
 if TYPE_CHECKING:
-    from typing import Literal
 
     class ExtensionArraySupportsAnyAll("ExtensionArray"):
         def any(self, *, skipna: bool = True) -> bool:
@@ -1024,7 +1023,7 @@ class ExtensionArray:
 
     @Substitution(klass="ExtensionArray")
     @Appender(_extension_array_shared_docs["repeat"])
-    def repeat(self, repeats: int | Sequence[int], axis: Literal[0] | None = None):
+    def repeat(self, repeats: int | Sequence[int], axis: int | None = None):
         nv.validate_repeat((), {"axis": axis})
         ind = np.arange(len(self)).repeat(repeats)
         return self.take(ind)

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -7,7 +7,6 @@ from operator import (
 )
 import textwrap
 from typing import (
-    TYPE_CHECKING,
     Sequence,
     TypeVar,
     cast,
@@ -85,9 +84,6 @@ from pandas.core.ops import (
     invalid_comparison,
     unpack_zerodim_and_defer,
 )
-
-if TYPE_CHECKING:
-    from typing import Literal
 
 IntervalArrayT = TypeVar("IntervalArrayT", bound="IntervalArray")
 
@@ -1525,7 +1521,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     def repeat(
         self: IntervalArrayT,
         repeats: int | Sequence[int],
-        axis: Literal[0] | None = None,
+        axis: int | None = None,
     ) -> IntervalArrayT:
         nv.validate_repeat((), {"axis": axis})
         left_repeat = self.left.repeat(repeats)

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -7,6 +7,7 @@ from operator import (
 )
 import textwrap
 from typing import (
+    TYPE_CHECKING,
     Sequence,
     TypeVar,
     cast,
@@ -84,6 +85,9 @@ from pandas.core.ops import (
     invalid_comparison,
     unpack_zerodim_and_defer,
 )
+
+if TYPE_CHECKING:
+    from typing import Literal
 
 IntervalArrayT = TypeVar("IntervalArrayT", bound="IntervalArray")
 
@@ -1518,7 +1522,11 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         return self._shallow_copy(left=new_left, right=new_right)
 
     @Appender(_extension_array_shared_docs["repeat"] % _shared_docs_kwargs)
-    def repeat(self: IntervalArrayT, repeats: int, axis=None) -> IntervalArrayT:
+    def repeat(
+        self: IntervalArrayT,
+        repeats: int | Sequence[int],
+        axis: Literal[0] | None = None,
+    ) -> IntervalArrayT:
         nv.validate_repeat((), {"axis": axis})
         left_repeat = self.left.repeat(repeats)
         right_repeat = self.right.repeat(repeats)

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -16,6 +16,7 @@ import numpy as np
 
 import pandas._libs.lib as lib
 from pandas._typing import (
+    ArrayLike,
     Dtype,
     DtypeObj,
     IndexLabel,
@@ -996,7 +997,7 @@ class IndexOpsMixin(OpsMixin):
         values = self._values
 
         if not isinstance(values, np.ndarray):
-            result = values.unique()
+            result: ArrayLike = values.unique()
             if self.dtype.kind in ["m", "M"] and isinstance(self, ABCSeries):
                 # GH#31182 Series._values returns EA, unpack for backward-compat
                 if getattr(self.dtype, "tz", None) is None:


### PR DESCRIPTION
Typing fixes for `ExtensionArray.unique()` and `ExtensionArray.repeat()`
