### PR TITLE
COMPAT: fix _bootlocale import error on py310

### DIFF
--- a/pandas/tests/io/json/test_readlines.py
+++ b/pandas/tests/io/json/test_readlines.py
@@ -192,7 +192,7 @@ def test_readjson_chunks_multiple_empty_lines(chunksize):
 
 def test_readjson_unicode(monkeypatch):
     with tm.ensure_clean("test.json") as path:
-        monkeypatch.setattr("_bootlocale.getpreferredencoding", lambda l: "cp949")
+        monkeypatch.setattr("locale.getpreferredencoding", lambda l: "cp949")
         with open(path, "w", encoding="utf-8") as f:
             f.write('{"£©µÀÆÖÞßéöÿ":["АБВГДабвгд가"]}')
 


### PR DESCRIPTION
The _bootlocale module has been removed from Python 3.10.

https://github.com/python/cpython/commit/b62bdf71ea0cd52041d49691d8ae3dc645bd48e1