### PR TITLE
REF: avoid unnecessary raise in DataFrameGroupBy._cython_agg_general

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -360,7 +360,10 @@ class Apply(metaclass=abc.ABCMeta):
                         # raised directly in _aggregate_named
                         pass
                     elif "no results" in str(err):
-                        # raised directly in _aggregate_multiple_funcs
+                        # reached in test_frame_apply.test_nuiscance_columns
+                        #  where the colg.aggregate(arg) ends up going through
+                        #  the selected_obj.ndim == 1 branch above with arg == ["sum"]
+                        #  on a datetime64[ns] column
                         pass
                     else:
                         raise

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1100,6 +1100,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         # Note: we never get here with how="ohlc"; that goes through SeriesGroupBy
 
         data: Manager2D = self._get_data_to_aggregate()
+        orig = data
 
         if numeric_only:
             data = data.get_numeric_data(copy=False)
@@ -1177,7 +1178,8 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         #  continue and exclude the block
         new_mgr = data.grouped_reduce(array_func, ignore_failures=True)
 
-        if not len(new_mgr):
+        if not len(new_mgr) and len(orig):
+            # If the original Manager was already empty, no need to raise
             raise DataError("No numeric types to aggregate")
 
         return self._wrap_agged_manager(new_mgr)

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1287,7 +1287,11 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
                 ) or "category dtype not supported" in str(err):
                     # raised in _get_cython_function, in some cases can
                     #  be trimmed by implementing cython funcs for more dtypes
-                    pass
+                    if self.obj.ndim != 1:
+                        # We expect to get here for SeriesGroupBy; but for
+                        #  DataFrameGroupBy these should be handled within
+                        #  _cython_agg_general
+                        raise
                 else:
                     raise
 


### PR DESCRIPTION
Untangling these layered try/excepts is turning out to be an exceptional PITA, so splitting it into extra-small pieces.