### PR TITLE
Allow to union `MultiIndex` with empty `RangeIndex`

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -754,7 +754,6 @@ Indexing
 - Bug in :meth:`DataFrame.loc.__setitem__` when setting-with-expansion incorrectly raising when the index in the expanding axis contains duplicates (:issue:`40096`)
 - Bug in :meth:`DataFrame.loc` incorrectly matching non-boolean index elements (:issue:`20432`)
 - Bug in :meth:`Series.__delitem__` with ``ExtensionDtype`` incorrectly casting to ``ndarray`` (:issue:`40386`)
-- Bug in :meth:`MultiIndex.union` raising for an empty ``RangeIndex`` (:issue:`41234`)
 
 Missing
 ^^^^^^^

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -754,6 +754,7 @@ Indexing
 - Bug in :meth:`DataFrame.loc.__setitem__` when setting-with-expansion incorrectly raising when the index in the expanding axis contains duplicates (:issue:`40096`)
 - Bug in :meth:`DataFrame.loc` incorrectly matching non-boolean index elements (:issue:`20432`)
 - Bug in :meth:`Series.__delitem__` with ``ExtensionDtype`` incorrectly casting to ``ndarray`` (:issue:`40386`)
+- Bug in :meth:`MultiIndex.union` raising for an empty ``RangeIndex`` (:issue:`41234`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2925,7 +2925,7 @@ class Index(IndexOpsMixin, PandasObject):
         if not is_dtype_equal(self.dtype, other.dtype):
             if isinstance(self, ABCMultiIndex) and not is_object_dtype(
                 unpack_nested_dtype(other)
-            ):
+            ) and len(other) > 0:
                 raise NotImplementedError(
                     "Can only union MultiIndex with MultiIndex or Index of tuples, "
                     "try mi.to_flat_index().union(other) instead."

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2923,9 +2923,11 @@ class Index(IndexOpsMixin, PandasObject):
         other, result_name = self._convert_can_do_setop(other)
 
         if not is_dtype_equal(self.dtype, other.dtype):
-            if isinstance(self, ABCMultiIndex) and not is_object_dtype(
-                unpack_nested_dtype(other)
-            ) and len(other) > 0:
+            if (
+                isinstance(self, ABCMultiIndex)
+                and not is_object_dtype(unpack_nested_dtype(other))
+                and len(other) > 0
+            ):
                 raise NotImplementedError(
                     "Can only union MultiIndex with MultiIndex or Index of tuples, "
                     "try mi.to_flat_index().union(other) instead."

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3597,7 +3597,7 @@ class MultiIndex(Index):
     def _maybe_match_names(self, other):
         """
         Try to find common names to attach to the result of an operation between
-        a and b.  Return a consensus list of names if they match at least partly
+        a and b. Return a consensus list of names if they match at least partly
         or list of None if they have completely different names.
         """
         if len(self.names) != len(other.names):

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -414,6 +414,14 @@ def test_union_empty_self_different_names():
     tm.assert_index_equal(result, expected)
 
 
+def test_union_multiindex_empty_rangeindex():
+    # GH#41234
+    mi = MultiIndex.from_arrays([[1, 2], [3, 4]], names=["a", "b"])
+    ri = pd.RangeIndex(0)
+    result = mi.union(mi)
+    tm.assert_index_equal(mi, result)
+
+
 @pytest.mark.parametrize(
     "method", ["union", "intersection", "difference", "symmetric_difference"]
 )

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -418,8 +418,8 @@ def test_union_multiindex_empty_rangeindex():
     # GH#41234
     mi = MultiIndex.from_arrays([[1, 2], [3, 4]], names=["a", "b"])
     ri = pd.RangeIndex(0)
-    result = mi.union(ri)
-    tm.assert_index_equal(mi, result, check_names=False)
+    tm.assert_index_equal(mi, mi.union(ri), check_names=False)
+    tm.assert_index_equal(mi, ri.union(mi), check_names=False)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -418,8 +418,8 @@ def test_union_multiindex_empty_rangeindex():
     # GH#41234
     mi = MultiIndex.from_arrays([[1, 2], [3, 4]], names=["a", "b"])
     ri = pd.RangeIndex(0)
-    result = mi.union(mi)
-    tm.assert_index_equal(mi, result)
+    result = mi.union(ri)
+    tm.assert_index_equal(mi, result, check_names=False)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -418,8 +418,12 @@ def test_union_multiindex_empty_rangeindex():
     # GH#41234
     mi = MultiIndex.from_arrays([[1, 2], [3, 4]], names=["a", "b"])
     ri = pd.RangeIndex(0)
-    tm.assert_index_equal(mi, mi.union(ri), check_names=False)
-    tm.assert_index_equal(mi, ri.union(mi), check_names=False)
+
+    result_left = mi.union(ri)
+    tm.assert_index_equal(mi, result_left, check_names=False)
+
+    result_right = ri.union(mi)
+    tm.assert_index_equal(mi, result_right, check_names=False)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/reshape/concat/test_concat.py
+++ b/pandas/tests/reshape/concat/test_concat.py
@@ -629,7 +629,7 @@ def test_concat_null_object_with_dti():
     tm.assert_frame_equal(result, expected)
 
 
-def test_concat_multiindex_with_empty_rangeindex(self):
+def test_concat_multiindex_with_empty_rangeindex():
     # GH#41234
     mi = MultiIndex.from_tuples([("B", 1), ("C", 1)])
     df1 = DataFrame([[1, 2]], columns=mi)

--- a/pandas/tests/reshape/concat/test_concat.py
+++ b/pandas/tests/reshape/concat/test_concat.py
@@ -627,3 +627,14 @@ def test_concat_null_object_with_dti():
         index=exp_index,
     )
     tm.assert_frame_equal(result, expected)
+
+
+def test_concat_multiindex_with_empty_rangeindex(self):
+    # GH#41234
+    mi = MultiIndex.from_tuples([("B", 1), ("C", 1)])
+    df1 = DataFrame([[1, 2]], columns=mi)
+    df2 = DataFrame(index=[1], columns=pd.RangeIndex(0))
+
+    result = concat([df1, df2])
+    expected = DataFrame([[1, 2], [np.nan, np.nan]], columns=mi)
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #41234
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

See also https://github.com/dask/dask/issues/7610 and https://github.com/JDASoftwareGroup/kartothek/issues/464. The regression seems to have been introduced in  pandas-dev/pandas#38671.