### PR TITLE
TST: fix casting extension tests for external users

### DIFF
--- a/pandas/tests/extension/base/casting.py
+++ b/pandas/tests/extension/base/casting.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+import pandas.util._test_decorators as td
+
 import pandas as pd
 from pandas.core.internals import ObjectBlock
 from pandas.tests.extension.base.base import BaseExtensionTests
@@ -43,8 +45,19 @@ class BaseCastingTests(BaseExtensionTests):
         expected = pd.Series([str(x) for x in data[:5]], dtype=str)
         self.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize(
+        "nullable_string_dtype",
+        [
+            "string",
+            pytest.param(
+                "arrow_string", marks=td.skip_if_no("pyarrow", min_version="1.0.0")
+            ),
+        ],
+    )
     def test_astype_string(self, data, nullable_string_dtype):
         # GH-33465
+        from pandas.core.arrays.string_arrow import ArrowStringDtype  # noqa: F401
+
         result = pd.Series(data[:5]).astype(nullable_string_dtype)
         expected = pd.Series([str(x) for x in data[:5]], dtype=nullable_string_dtype)
         self.assert_series_equal(result, expected)


### PR DESCRIPTION
cc @simonjayhawkins fixtures defined by pandas are not known when inheriting the tests as external package. There are a bunch of fixtures that external packages are expected to define in `pandas/tests/extension/conftest.py`, but I think for the string dtype here this is not worth it to expect downstream users to define it themselves (certainly given that it is still going to change)