### PR TITLE
CI: Fix warning from SSL transport (again)

### DIFF
--- a/pandas/_testing/_warnings.py
+++ b/pandas/_testing/_warnings.py
@@ -143,7 +143,7 @@ def _assert_caught_no_extra_warnings(
     for actual_warning in caught_warnings:
         if _is_unexpected_warning(actual_warning, expected_warning):
             unclosed = "unclosed transport <asyncio.sslproto._SSLProtocolTransport"
-            if isinstance(actual_warning, ResourceWarning) and unclosed in str(
+            if actual_warning.category == ResourceWarning and unclosed in str(
                 actual_warning.message
             ):
                 # FIXME: kludge because pytest.filterwarnings does not

--- a/pandas/_testing/_warnings.py
+++ b/pandas/_testing/_warnings.py
@@ -144,7 +144,7 @@ def _assert_caught_no_extra_warnings(
         if _is_unexpected_warning(actual_warning, expected_warning):
             unclosed = "unclosed transport <asyncio.sslproto._SSLProtocolTransport"
             if isinstance(actual_warning, ResourceWarning) and unclosed in str(
-                actual_warning
+                actual_warning.message
             ):
                 # FIXME: kludge because pytest.filterwarnings does not
                 #  suppress these, xref GH#38630


### PR DESCRIPTION
Turns out that the issue was the comparison of the type.  Loop has `WarningMessage`, but the type of warning is in `actual_warning.category`