### PR TITLE
REF: Avoid fallback in GroupBy._agg_general

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1238,7 +1238,10 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
             # corner case where self._selected_obj is a Series
             # reached in test_groupby_as_index_select_column_sum_empty_df
             res_ser = self.obj._constructor_sliced(
-                values, index=self.grouper.result_index, name=data.name
+                values,
+                index=self.grouper.result_index,
+                name=data.name,
+                dtype=data.dtype,
             )
             result = res_ser.to_frame()
             if not self.as_index:


### PR DESCRIPTION
pre-emptively use non-cython path in explicit cases instead of try/except.  Many of the affected cases involve empty DataFrames and I think the tested behavior is sketchy (e.g. the fallback paths ignore the `numeric_only` kwarg), so putting this in draft mode while I look at that.

@WillAyd can i get your help with _wrap_applied_output here?  As commented, the added case is pretty much a kludge and I think we can do better.  Am I remembering correctly that you refactored a bunch of the wrapping code ~18 months ago?