### PR TITLE
REF: remove no-op casting

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -59,9 +59,7 @@ from pandas.util._decorators import (
     doc,
 )
 
-from pandas.core.dtypes.cast import maybe_downcast_numeric
 from pandas.core.dtypes.common import (
-    ensure_float,
     is_bool_dtype,
     is_datetime64_dtype,
     is_integer_dtype,
@@ -1271,19 +1269,7 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
             except TypeError:
                 continue
 
-            assert result is not None
             key = base.OutputKey(label=name, position=idx)
-
-            if self.grouper._filter_empty_groups:
-                mask = counts.ravel() > 0
-
-                # since we are masking, make sure that we have a float object
-                values = result
-                if is_numeric_dtype(values.dtype):
-                    values = ensure_float(values)
-
-                    result = maybe_downcast_numeric(values[mask], result.dtype)
-
             output[key] = result
 
         if not output:
@@ -3035,9 +3021,7 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
             Object (potentially) re-indexed to include all possible groups.
         """
         groupings = self.grouper.groupings
-        if groupings is None:
-            return output
-        elif len(groupings) == 1:
+        if len(groupings) == 1:
             return output
 
         # if we only care about the observed values


### PR DESCRIPTION
In _python_agg_general:

```
            if self.grouper._filter_empty_groups:
                mask = counts.ravel() > 0
```

It isn't entirely trivial, but we can show that we will always have `mask.all()`, as a result of which the remainder of this code chunk of code is a no-op.  This PR removes it.

As a consequence, we can remove `_filter_empty_groups` and `compressed`
