### PR TITLE
[ArrowStringArray] PERF: use pa.compute.match_substring_regex for str.match if available

### DIFF
--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -19,6 +19,7 @@ from pandas._typing import (
     Dtype,
     NpDtype,
     PositionalIndexer,
+    Scalar,
     type_t,
 )
 from pandas.util._decorators import doc
@@ -807,6 +808,13 @@ class ArrowStringArray(OpsMixin, ExtensionArray, ObjectStringArrayMixin):
             return result
         else:
             return super()._str_endswith(pat, na)
+
+    def _str_match(
+        self, pat: str, case: bool = True, flags: int = 0, na: Scalar = None
+    ):
+        if not pat.startswith("^"):
+            pat = "^" + pat
+        return self._str_contains(pat, case, flags, na, regex=True)
 
     def _str_isalnum(self):
         result = pc.utf8_is_alnum(self._data)

--- a/pandas/core/strings/base.py
+++ b/pandas/core/strings/base.py
@@ -61,11 +61,7 @@ class BaseStringArrayMethods(abc.ABC):
 
     @abc.abstractmethod
     def _str_match(
-        self,
-        pat: Union[str, Pattern],
-        case: bool = True,
-        flags: int = 0,
-        na: Scalar = np.nan,
+        self, pat: str, case: bool = True, flags: int = 0, na: Scalar = np.nan
     ):
         pass
 

--- a/pandas/core/strings/object_array.py
+++ b/pandas/core/strings/object_array.py
@@ -186,11 +186,7 @@ class ObjectStringArrayMixin(BaseStringArrayMethods):
             return result
 
     def _str_match(
-        self,
-        pat: Union[str, Pattern],
-        case: bool = True,
-        flags: int = 0,
-        na: Scalar = None,
+        self, pat: str, case: bool = True, flags: int = 0, na: Scalar = None
     ):
         if not case:
             flags |= re.IGNORECASE


### PR DESCRIPTION

```
[ 50.00%] ··· strings.Methods.time_match                                                                                                                  ok
[ 50.00%] ··· ============== ==========
                  dtype                
              -------------- ----------
                   str        28.3±0ms 
                  string      22.5±0ms 
               arrow_string   2.46±0ms 
              ============== ==========
```