### PR TITLE
[ArrowStringArray] PERF: small perf gain for object fallback

### DIFF
--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -792,7 +792,8 @@ class ArrowStringArray(OpsMixin, ExtensionArray, ObjectStringArrayMixin):
             result = lib.map_infer_mask(
                 arr, f, mask.view("uint8"), convert=False, na_value=na_value
             )
-            return self._from_sequence(result)
+            result = pa.array(result, mask=mask, type=pa.string(), from_pandas=True)
+            return type(self)(result)
         else:
             # This is when the result type is object. We reach this when
             # -> We know the result type is truly object (e.g. .encode returns bytes


### PR DESCRIPTION
```
       before           after         ratio
     [a43c42c3]       [a5dd50ea]
     <master>         <small-perf>
-     26.8±0.05ms       26.1±0.1ms     0.97  strings.Methods.time_get('arrow_string')
-      21.2±0.1ms       20.3±0.1ms     0.96  strings.Methods.time_replace('arrow_string')
-      18.1±0.1ms       17.3±0.1ms     0.96  strings.Methods.time_lstrip('arrow_string')
-      18.5±0.1ms       17.7±0.2ms     0.95  strings.Methods.time_strip('arrow_string')
-      18.3±0.1ms      17.4±0.09ms     0.95  strings.Methods.time_rstrip('arrow_string')
-      28.0±0.3ms      26.6±0.07ms     0.95  strings.Methods.time_center('arrow_string')
-      21.2±0.2ms       20.1±0.1ms     0.95  strings.Methods.time_normalize('arrow_string')
-      28.1±0.2ms       26.5±0.2ms     0.94  strings.Methods.time_pad('arrow_string')
-      13.6±0.1ms       11.5±0.1ms     0.85  strings.Methods.time_isdigit('str')
-      13.6±0.2ms      11.3±0.04ms     0.83  strings.Methods.time_isnumeric('str')

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```