### PR TITLE
BUG : Min/max markers on box plot are not visible with 'dark_background' (#40769)

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -849,7 +849,7 @@ Plotting
 - Prevent warnings when matplotlib's ``constrained_layout`` is enabled (:issue:`25261`)
 - Bug in :func:`DataFrame.plot` was showing the wrong colors in the legend if the function was called repeatedly and some calls used ``yerr`` while others didn't (partial fix of :issue:`39522`)
 - Bug in :func:`DataFrame.plot` was showing the wrong colors in the legend if the function was called repeatedly and some calls used ``secondary_y`` and others use ``legend=False`` (:issue:`40044`)
-- Bug in :meth:`DataFrame.plot.box` in box plot when 'dark_background' theme was selected, caps or min/max markers for the plot was not visible (:issue:`40769`)
+- Bug in :meth:`DataFrame.plot.box` in box plot when ``dark_background`` theme was selected, caps or min/max markers for the plot was not visible (:issue:`40769`)
 
 
 Groupby/resample/rolling

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -849,7 +849,7 @@ Plotting
 - Prevent warnings when matplotlib's ``constrained_layout`` is enabled (:issue:`25261`)
 - Bug in :func:`DataFrame.plot` was showing the wrong colors in the legend if the function was called repeatedly and some calls used ``yerr`` while others didn't (partial fix of :issue:`39522`)
 - Bug in :func:`DataFrame.plot` was showing the wrong colors in the legend if the function was called repeatedly and some calls used ``secondary_y`` and others use ``legend=False`` (:issue:`40044`)
-- Bug in :meth:`BoxPlot._validate_color_args` in box plot when 'dark_background' theme was selected, caps or min/max markers for the plot was not visible (:issue:`40769`)
+- Bug in :meth:`DataFrame.plot.box` in box plot when 'dark_background' theme was selected, caps or min/max markers for the plot was not visible (:issue:`40769`)
 
 
 Groupby/resample/rolling

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -849,6 +849,7 @@ Plotting
 - Prevent warnings when matplotlib's ``constrained_layout`` is enabled (:issue:`25261`)
 - Bug in :func:`DataFrame.plot` was showing the wrong colors in the legend if the function was called repeatedly and some calls used ``yerr`` while others didn't (partial fix of :issue:`39522`)
 - Bug in :func:`DataFrame.plot` was showing the wrong colors in the legend if the function was called repeatedly and some calls used ``secondary_y`` and others use ``legend=False`` (:issue:`40044`)
+- Bug in :meth:`BoxPlot._validate_color_args` in box plot when 'dark_background' theme was selected, caps or min/max markers for the plot was not visible (:issue:`40769`)
 
 
 Groupby/resample/rolling

--- a/pandas/plotting/_matplotlib/boxplot.py
+++ b/pandas/plotting/_matplotlib/boxplot.py
@@ -101,7 +101,7 @@ class BoxPlot(LinePlot):
         self._boxes_c = colors[0]
         self._whiskers_c = colors[0]
         self._medians_c = colors[2]
-        self._caps_c = "k"  # mpl default
+        self._caps_c = colors[0]
 
     def _get_colors(self, num_colors=None, color_kwds="color"):
         pass

--- a/pandas/tests/plotting/frame/test_frame_color.py
+++ b/pandas/tests/plotting/frame/test_frame_color.py
@@ -546,7 +546,13 @@ class TestDataFrameColor(TestPlotBase):
 
         df = DataFrame(np.random.randn(5, 5))
         bp = df.plot.box(return_type="dict")
-        _check_colors(bp, default_colors[0], default_colors[0], default_colors[2])
+        _check_colors(
+            bp,
+            default_colors[0],
+            default_colors[0],
+            default_colors[2],
+            default_colors[0],
+        )
         tm.close()
 
         dict_colors = {
@@ -569,7 +575,7 @@ class TestDataFrameColor(TestPlotBase):
         # partial colors
         dict_colors = {"whiskers": "c", "medians": "m"}
         bp = df.plot.box(color=dict_colors, return_type="dict")
-        _check_colors(bp, default_colors[0], "c", "m")
+        _check_colors(bp, default_colors[0], "c", "m", default_colors[0])
         tm.close()
 
         from matplotlib import cm
@@ -577,12 +583,12 @@ class TestDataFrameColor(TestPlotBase):
         # Test str -> colormap functionality
         bp = df.plot.box(colormap="jet", return_type="dict")
         jet_colors = [cm.jet(n) for n in np.linspace(0, 1, 3)]
-        _check_colors(bp, jet_colors[0], jet_colors[0], jet_colors[2])
+        _check_colors(bp, jet_colors[0], jet_colors[0], jet_colors[2], jet_colors[0])
         tm.close()
 
         # Test colormap functionality
         bp = df.plot.box(colormap=cm.jet, return_type="dict")
-        _check_colors(bp, jet_colors[0], jet_colors[0], jet_colors[2])
+        _check_colors(bp, jet_colors[0], jet_colors[0], jet_colors[2], jet_colors[0])
         tm.close()
 
         # string color is applied to all artists except fliers

--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -196,6 +196,39 @@ class TestDataFramePlots(TestPlotBase):
             assert result[k][0].get_color() == v
 
     @pytest.mark.parametrize(
+        "scheme,expected",
+        [
+            (
+                "dark_background",
+                {
+                    "boxes": "#8dd3c7",
+                    "whiskers": "#8dd3c7",
+                    "medians": "#bfbbd9",
+                    "caps": "#8dd3c7",
+                },
+            ),
+            (
+                "default",
+                {
+                    "boxes": "#1f77b4",
+                    "whiskers": "#1f77b4",
+                    "medians": "#2ca02c",
+                    "caps": "#1f77b4",
+                },
+            ),
+        ],
+    )
+    def test_colors_in_theme(self, scheme, expected):
+        # GH: 40769
+        df = DataFrame(np.random.rand(10, 2))
+        import matplotlib.pyplot as plt
+
+        plt.style.use(scheme)
+        result = df.plot.box(return_type="dict")
+        for k, v in expected.items():
+            assert result[k][0].get_color() == v
+
+    @pytest.mark.parametrize(
         "dict_colors, msg",
         [({"boxes": "r", "invalid_key": "r"}, "invalid key 'invalid_key'")],
     )


### PR DESCRIPTION
- [x] closes #40769
- [x] tests added / passed
- [x] Ensure all linting tests pass, see here for how to run them

Color in boxplot.py should be a hex value. Letter based color will be at matplotlib level. Using same color as that of boxes for the caps as well. The color will be fetched based on the selected theme. We are over riding color with "k" , rather need to use the one set at matplotlib level.
Before Fix :

Caps for the box plot is not visible :
![![image](https://user-images.githubusercontent.com/9417467/117279259-2634b480-ae7f-11eb-933c-350cff0133de.png)](https://user-images.githubusercontent.com/9417467/117279207-1a48f280-ae7f-11eb-9f0f-fe477d80dc77.png)


After Fix :

Caps for the box plow will be visible in dark background mode :
![image](https://user-images.githubusercontent.com/9417467/117279282-2df45900-ae7f-11eb-8107-9fe3ae2fe15f.png)


Whats New : Box Plot's Caps will have same color as boxes unless color is explicitly specified by user arguments. Hence theme changes will not adversly effect caps color.