### PR TITLE
TST/REF: split out replace regex into class

### DIFF
--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -57,217 +57,6 @@ class TestDataFrameReplace:
         assert return_value is None
         tm.assert_frame_equal(tsframe, datetime_frame.fillna(0))
 
-    def test_regex_replace_scalar(self, mix_ab):
-        obj = {"a": list("ab.."), "b": list("efgh")}
-        dfobj = DataFrame(obj)
-        dfmix = DataFrame(mix_ab)
-
-        # simplest cases
-        # regex -> value
-        # obj frame
-        res = dfobj.replace(r"\s*\.\s*", np.nan, regex=True)
-        tm.assert_frame_equal(dfobj, res.fillna("."))
-
-        # mixed
-        res = dfmix.replace(r"\s*\.\s*", np.nan, regex=True)
-        tm.assert_frame_equal(dfmix, res.fillna("."))
-
-        # regex -> regex
-        # obj frame
-        res = dfobj.replace(r"\s*(\.)\s*", r"\1\1\1", regex=True)
-        objc = obj.copy()
-        objc["a"] = ["a", "b", "...", "..."]
-        expec = DataFrame(objc)
-        tm.assert_frame_equal(res, expec)
-
-        # with mixed
-        res = dfmix.replace(r"\s*(\.)\s*", r"\1\1\1", regex=True)
-        mixc = mix_ab.copy()
-        mixc["b"] = ["a", "b", "...", "..."]
-        expec = DataFrame(mixc)
-        tm.assert_frame_equal(res, expec)
-
-        # everything with compiled regexs as well
-        res = dfobj.replace(re.compile(r"\s*\.\s*"), np.nan, regex=True)
-        tm.assert_frame_equal(dfobj, res.fillna("."))
-
-        # mixed
-        res = dfmix.replace(re.compile(r"\s*\.\s*"), np.nan, regex=True)
-        tm.assert_frame_equal(dfmix, res.fillna("."))
-
-        # regex -> regex
-        # obj frame
-        res = dfobj.replace(re.compile(r"\s*(\.)\s*"), r"\1\1\1")
-        objc = obj.copy()
-        objc["a"] = ["a", "b", "...", "..."]
-        expec = DataFrame(objc)
-        tm.assert_frame_equal(res, expec)
-
-        # with mixed
-        res = dfmix.replace(re.compile(r"\s*(\.)\s*"), r"\1\1\1")
-        mixc = mix_ab.copy()
-        mixc["b"] = ["a", "b", "...", "..."]
-        expec = DataFrame(mixc)
-        tm.assert_frame_equal(res, expec)
-
-        res = dfmix.replace(regex=re.compile(r"\s*(\.)\s*"), value=r"\1\1\1")
-        mixc = mix_ab.copy()
-        mixc["b"] = ["a", "b", "...", "..."]
-        expec = DataFrame(mixc)
-        tm.assert_frame_equal(res, expec)
-
-        res = dfmix.replace(regex=r"\s*(\.)\s*", value=r"\1\1\1")
-        mixc = mix_ab.copy()
-        mixc["b"] = ["a", "b", "...", "..."]
-        expec = DataFrame(mixc)
-        tm.assert_frame_equal(res, expec)
-
-    def test_regex_replace_scalar_inplace(self, mix_ab):
-        obj = {"a": list("ab.."), "b": list("efgh")}
-        dfobj = DataFrame(obj)
-        dfmix = DataFrame(mix_ab)
-
-        # simplest cases
-        # regex -> value
-        # obj frame
-        res = dfobj.copy()
-        return_value = res.replace(r"\s*\.\s*", np.nan, regex=True, inplace=True)
-        assert return_value is None
-        tm.assert_frame_equal(dfobj, res.fillna("."))
-
-        # mixed
-        res = dfmix.copy()
-        return_value = res.replace(r"\s*\.\s*", np.nan, regex=True, inplace=True)
-        assert return_value is None
-        tm.assert_frame_equal(dfmix, res.fillna("."))
-
-        # regex -> regex
-        # obj frame
-        res = dfobj.copy()
-        return_value = res.replace(r"\s*(\.)\s*", r"\1\1\1", regex=True, inplace=True)
-        assert return_value is None
-        objc = obj.copy()
-        objc["a"] = ["a", "b", "...", "..."]
-        expec = DataFrame(objc)
-        tm.assert_frame_equal(res, expec)
-
-        # with mixed
-        res = dfmix.copy()
-        return_value = res.replace(r"\s*(\.)\s*", r"\1\1\1", regex=True, inplace=True)
-        assert return_value is None
-        mixc = mix_ab.copy()
-        mixc["b"] = ["a", "b", "...", "..."]
-        expec = DataFrame(mixc)
-        tm.assert_frame_equal(res, expec)
-
-        # everything with compiled regexs as well
-        res = dfobj.copy()
-        return_value = res.replace(
-            re.compile(r"\s*\.\s*"), np.nan, regex=True, inplace=True
-        )
-        assert return_value is None
-        tm.assert_frame_equal(dfobj, res.fillna("."))
-
-        # mixed
-        res = dfmix.copy()
-        return_value = res.replace(
-            re.compile(r"\s*\.\s*"), np.nan, regex=True, inplace=True
-        )
-        assert return_value is None
-        tm.assert_frame_equal(dfmix, res.fillna("."))
-
-        # regex -> regex
-        # obj frame
-        res = dfobj.copy()
-        return_value = res.replace(
-            re.compile(r"\s*(\.)\s*"), r"\1\1\1", regex=True, inplace=True
-        )
-        assert return_value is None
-        objc = obj.copy()
-        objc["a"] = ["a", "b", "...", "..."]
-        expec = DataFrame(objc)
-        tm.assert_frame_equal(res, expec)
-
-        # with mixed
-        res = dfmix.copy()
-        return_value = res.replace(
-            re.compile(r"\s*(\.)\s*"), r"\1\1\1", regex=True, inplace=True
-        )
-        assert return_value is None
-        mixc = mix_ab.copy()
-        mixc["b"] = ["a", "b", "...", "..."]
-        expec = DataFrame(mixc)
-        tm.assert_frame_equal(res, expec)
-
-        res = dfobj.copy()
-        return_value = res.replace(regex=r"\s*\.\s*", value=np.nan, inplace=True)
-        assert return_value is None
-        tm.assert_frame_equal(dfobj, res.fillna("."))
-
-        # mixed
-        res = dfmix.copy()
-        return_value = res.replace(regex=r"\s*\.\s*", value=np.nan, inplace=True)
-        assert return_value is None
-        tm.assert_frame_equal(dfmix, res.fillna("."))
-
-        # regex -> regex
-        # obj frame
-        res = dfobj.copy()
-        return_value = res.replace(regex=r"\s*(\.)\s*", value=r"\1\1\1", inplace=True)
-        assert return_value is None
-        objc = obj.copy()
-        objc["a"] = ["a", "b", "...", "..."]
-        expec = DataFrame(objc)
-        tm.assert_frame_equal(res, expec)
-
-        # with mixed
-        res = dfmix.copy()
-        return_value = res.replace(regex=r"\s*(\.)\s*", value=r"\1\1\1", inplace=True)
-        assert return_value is None
-        mixc = mix_ab.copy()
-        mixc["b"] = ["a", "b", "...", "..."]
-        expec = DataFrame(mixc)
-        tm.assert_frame_equal(res, expec)
-
-        # everything with compiled regexs as well
-        res = dfobj.copy()
-        return_value = res.replace(
-            regex=re.compile(r"\s*\.\s*"), value=np.nan, inplace=True
-        )
-        assert return_value is None
-        tm.assert_frame_equal(dfobj, res.fillna("."))
-
-        # mixed
-        res = dfmix.copy()
-        return_value = res.replace(
-            regex=re.compile(r"\s*\.\s*"), value=np.nan, inplace=True
-        )
-        assert return_value is None
-        tm.assert_frame_equal(dfmix, res.fillna("."))
-
-        # regex -> regex
-        # obj frame
-        res = dfobj.copy()
-        return_value = res.replace(
-            regex=re.compile(r"\s*(\.)\s*"), value=r"\1\1\1", inplace=True
-        )
-        assert return_value is None
-        objc = obj.copy()
-        objc["a"] = ["a", "b", "...", "..."]
-        expec = DataFrame(objc)
-        tm.assert_frame_equal(res, expec)
-
-        # with mixed
-        res = dfmix.copy()
-        return_value = res.replace(
-            regex=re.compile(r"\s*(\.)\s*"), value=r"\1\1\1", inplace=True
-        )
-        assert return_value is None
-        mixc = mix_ab.copy()
-        mixc["b"] = ["a", "b", "...", "..."]
-        expec = DataFrame(mixc)
-        tm.assert_frame_equal(res, expec)
-
     def test_regex_replace_list_obj(self):
         obj = {"a": list("ab.."), "b": list("efgh"), "c": list("helo")}
         dfobj = DataFrame(obj)
@@ -1689,3 +1478,216 @@ class TestDataFrameReplace:
         expected = obj.copy()
         obj = obj.replace({None: np.nan})
         tm.assert_equal(obj, expected)
+
+
+class TestDataFrameReplaceRegex:
+    def test_regex_replace_scalar(self, mix_ab):
+        obj = {"a": list("ab.."), "b": list("efgh")}
+        dfobj = DataFrame(obj)
+        dfmix = DataFrame(mix_ab)
+
+        # simplest cases
+        # regex -> value
+        # obj frame
+        res = dfobj.replace(r"\s*\.\s*", np.nan, regex=True)
+        tm.assert_frame_equal(dfobj, res.fillna("."))
+
+        # mixed
+        res = dfmix.replace(r"\s*\.\s*", np.nan, regex=True)
+        tm.assert_frame_equal(dfmix, res.fillna("."))
+
+        # regex -> regex
+        # obj frame
+        res = dfobj.replace(r"\s*(\.)\s*", r"\1\1\1", regex=True)
+        objc = obj.copy()
+        objc["a"] = ["a", "b", "...", "..."]
+        expec = DataFrame(objc)
+        tm.assert_frame_equal(res, expec)
+
+        # with mixed
+        res = dfmix.replace(r"\s*(\.)\s*", r"\1\1\1", regex=True)
+        mixc = mix_ab.copy()
+        mixc["b"] = ["a", "b", "...", "..."]
+        expec = DataFrame(mixc)
+        tm.assert_frame_equal(res, expec)
+
+        # everything with compiled regexs as well
+        res = dfobj.replace(re.compile(r"\s*\.\s*"), np.nan, regex=True)
+        tm.assert_frame_equal(dfobj, res.fillna("."))
+
+        # mixed
+        res = dfmix.replace(re.compile(r"\s*\.\s*"), np.nan, regex=True)
+        tm.assert_frame_equal(dfmix, res.fillna("."))
+
+        # regex -> regex
+        # obj frame
+        res = dfobj.replace(re.compile(r"\s*(\.)\s*"), r"\1\1\1")
+        objc = obj.copy()
+        objc["a"] = ["a", "b", "...", "..."]
+        expec = DataFrame(objc)
+        tm.assert_frame_equal(res, expec)
+
+        # with mixed
+        res = dfmix.replace(re.compile(r"\s*(\.)\s*"), r"\1\1\1")
+        mixc = mix_ab.copy()
+        mixc["b"] = ["a", "b", "...", "..."]
+        expec = DataFrame(mixc)
+        tm.assert_frame_equal(res, expec)
+
+        res = dfmix.replace(regex=re.compile(r"\s*(\.)\s*"), value=r"\1\1\1")
+        mixc = mix_ab.copy()
+        mixc["b"] = ["a", "b", "...", "..."]
+        expec = DataFrame(mixc)
+        tm.assert_frame_equal(res, expec)
+
+        res = dfmix.replace(regex=r"\s*(\.)\s*", value=r"\1\1\1")
+        mixc = mix_ab.copy()
+        mixc["b"] = ["a", "b", "...", "..."]
+        expec = DataFrame(mixc)
+        tm.assert_frame_equal(res, expec)
+
+    def test_regex_replace_scalar_inplace(self, mix_ab):
+        obj = {"a": list("ab.."), "b": list("efgh")}
+        dfobj = DataFrame(obj)
+        dfmix = DataFrame(mix_ab)
+
+        # simplest cases
+        # regex -> value
+        # obj frame
+        res = dfobj.copy()
+        return_value = res.replace(r"\s*\.\s*", np.nan, regex=True, inplace=True)
+        assert return_value is None
+        tm.assert_frame_equal(dfobj, res.fillna("."))
+
+        # mixed
+        res = dfmix.copy()
+        return_value = res.replace(r"\s*\.\s*", np.nan, regex=True, inplace=True)
+        assert return_value is None
+        tm.assert_frame_equal(dfmix, res.fillna("."))
+
+        # regex -> regex
+        # obj frame
+        res = dfobj.copy()
+        return_value = res.replace(r"\s*(\.)\s*", r"\1\1\1", regex=True, inplace=True)
+        assert return_value is None
+        objc = obj.copy()
+        objc["a"] = ["a", "b", "...", "..."]
+        expec = DataFrame(objc)
+        tm.assert_frame_equal(res, expec)
+
+        # with mixed
+        res = dfmix.copy()
+        return_value = res.replace(r"\s*(\.)\s*", r"\1\1\1", regex=True, inplace=True)
+        assert return_value is None
+        mixc = mix_ab.copy()
+        mixc["b"] = ["a", "b", "...", "..."]
+        expec = DataFrame(mixc)
+        tm.assert_frame_equal(res, expec)
+
+        # everything with compiled regexs as well
+        res = dfobj.copy()
+        return_value = res.replace(
+            re.compile(r"\s*\.\s*"), np.nan, regex=True, inplace=True
+        )
+        assert return_value is None
+        tm.assert_frame_equal(dfobj, res.fillna("."))
+
+        # mixed
+        res = dfmix.copy()
+        return_value = res.replace(
+            re.compile(r"\s*\.\s*"), np.nan, regex=True, inplace=True
+        )
+        assert return_value is None
+        tm.assert_frame_equal(dfmix, res.fillna("."))
+
+        # regex -> regex
+        # obj frame
+        res = dfobj.copy()
+        return_value = res.replace(
+            re.compile(r"\s*(\.)\s*"), r"\1\1\1", regex=True, inplace=True
+        )
+        assert return_value is None
+        objc = obj.copy()
+        objc["a"] = ["a", "b", "...", "..."]
+        expec = DataFrame(objc)
+        tm.assert_frame_equal(res, expec)
+
+        # with mixed
+        res = dfmix.copy()
+        return_value = res.replace(
+            re.compile(r"\s*(\.)\s*"), r"\1\1\1", regex=True, inplace=True
+        )
+        assert return_value is None
+        mixc = mix_ab.copy()
+        mixc["b"] = ["a", "b", "...", "..."]
+        expec = DataFrame(mixc)
+        tm.assert_frame_equal(res, expec)
+
+        res = dfobj.copy()
+        return_value = res.replace(regex=r"\s*\.\s*", value=np.nan, inplace=True)
+        assert return_value is None
+        tm.assert_frame_equal(dfobj, res.fillna("."))
+
+        # mixed
+        res = dfmix.copy()
+        return_value = res.replace(regex=r"\s*\.\s*", value=np.nan, inplace=True)
+        assert return_value is None
+        tm.assert_frame_equal(dfmix, res.fillna("."))
+
+        # regex -> regex
+        # obj frame
+        res = dfobj.copy()
+        return_value = res.replace(regex=r"\s*(\.)\s*", value=r"\1\1\1", inplace=True)
+        assert return_value is None
+        objc = obj.copy()
+        objc["a"] = ["a", "b", "...", "..."]
+        expec = DataFrame(objc)
+        tm.assert_frame_equal(res, expec)
+
+        # with mixed
+        res = dfmix.copy()
+        return_value = res.replace(regex=r"\s*(\.)\s*", value=r"\1\1\1", inplace=True)
+        assert return_value is None
+        mixc = mix_ab.copy()
+        mixc["b"] = ["a", "b", "...", "..."]
+        expec = DataFrame(mixc)
+        tm.assert_frame_equal(res, expec)
+
+        # everything with compiled regexs as well
+        res = dfobj.copy()
+        return_value = res.replace(
+            regex=re.compile(r"\s*\.\s*"), value=np.nan, inplace=True
+        )
+        assert return_value is None
+        tm.assert_frame_equal(dfobj, res.fillna("."))
+
+        # mixed
+        res = dfmix.copy()
+        return_value = res.replace(
+            regex=re.compile(r"\s*\.\s*"), value=np.nan, inplace=True
+        )
+        assert return_value is None
+        tm.assert_frame_equal(dfmix, res.fillna("."))
+
+        # regex -> regex
+        # obj frame
+        res = dfobj.copy()
+        return_value = res.replace(
+            regex=re.compile(r"\s*(\.)\s*"), value=r"\1\1\1", inplace=True
+        )
+        assert return_value is None
+        objc = obj.copy()
+        objc["a"] = ["a", "b", "...", "..."]
+        expec = DataFrame(objc)
+        tm.assert_frame_equal(res, expec)
+
+        # with mixed
+        res = dfmix.copy()
+        return_value = res.replace(
+            regex=re.compile(r"\s*(\.)\s*"), value=r"\1\1\1", inplace=True
+        )
+        assert return_value is None
+        mixc = mix_ab.copy()
+        mixc["b"] = ["a", "b", "...", "..."]
+        expec = DataFrame(mixc)
+        tm.assert_frame_equal(res, expec)


### PR DESCRIPTION
Can move a bunch more, but the diff gets really garbled when moving more, so easier to do in chunks