### PR TITLE
ENH: Implemented optional initializer for pd.concat (#40820)

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -226,7 +226,7 @@ Other enhancements
 - :meth:`.GroupBy.any` and :meth:`.GroupBy.all` return a ``BooleanDtype`` for columns with nullable data types (:issue:`33449`)
 - Constructing a :class:`DataFrame` or :class:`Series` with the ``data`` argument being a Python iterable that is *not* a NumPy ``ndarray`` consisting of NumPy scalars will now result in a dtype with a precision the maximum of the NumPy scalars; this was already the case when ``data`` is a NumPy ``ndarray`` (:issue:`40908`)
 - Add keyword ``sort`` to :func:`pivot_table` to allow non-sorting of the result (:issue:`39143`)
--
+- ``pandas.concat()`` now accepts a new parameter ``initializer`` which will allow for the concatenation of empty sequences and returns the DataFrame/Series object passed into the initializer parameter. (:issue:`40820`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/tests/reshape/concat/test_concat.py
+++ b/pandas/tests/reshape/concat/test_concat.py
@@ -348,9 +348,43 @@ class TestConcatenate:
         expected = concat([df, df], keys=["foo", "bar"])
         tm.assert_frame_equal(result, expected[:10])
 
-    def test_concat_no_items_raises(self):
-        with pytest.raises(ValueError, match="No objects to concatenate"):
+    def test_concat_no_items_and_initializer_raises(self):
+        with pytest.raises(
+            ValueError, match="No objects to concatenate and no initializer set"
+        ):
             concat([])
+
+    def test_concat_no_items_and_series_initializer(self):
+        result = concat([], initializer=Series())
+        expected = Series()
+        tm.assert_series_equal(result, expected)
+
+        expected = Series(np.random.randn(10))
+        series = expected.copy()
+        result = concat([], initializer=series)
+        tm.assert_series_equal(result, expected)
+
+    def test_concat_series_and_series_initializer(self):
+        series = Series(np.random.randn(10))
+
+        result = concat([series[5:]], initializer=series[:5])
+        tm.assert_series_equal(result, series)
+
+    def test_concat_no_items_and_df_initializer(self):
+        result = concat([], initializer=DataFrame())
+        expected = DataFrame()
+        tm.assert_frame_equal(result, expected)
+
+        expected = DataFrame(np.random.randn(1, 3))
+        df = expected.copy()
+        result = concat([], initializer=df)
+        tm.assert_frame_equal(result, expected)
+
+    def test_concat_df_and_df_initializer(self):
+        df = DataFrame(np.random.randn(10, 4))
+
+        result = concat([df[5:]], initializer=df[:5])
+        tm.assert_frame_equal(result, df)
 
     def test_concat_exclude_none(self):
         df = DataFrame(np.random.randn(10, 4))
@@ -360,6 +394,13 @@ class TestConcatenate:
         tm.assert_frame_equal(result, df)
         with pytest.raises(ValueError, match="All objects passed were None"):
             concat([None, None])
+
+    def test_concat_exclude_none_with_initializer(self):
+        df = DataFrame(np.random.randn(10, 4))
+
+        result = concat([None, None], initializer=df)
+        expected = df.copy()
+        tm.assert_frame_equal(result, expected)
 
     def test_concat_keys_with_none(self):
         # #1649


### PR DESCRIPTION
- [x] closes #40820 
- [x] tests added / passed (passed on azure checks)
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

A proposed solution for issue #40820, to accept an optional argument ``initializer`` which allows for concatenating empty sequences and return the object passed to initializer -- which can be useful for cases where users are running pd.concat on sequence variables which might potentially be empty -- and would like the result of the concatenation to be initialized to an empty Series/DataFrame

The new argument is made optional, and the ValueError is still thrown for cases where the ``initializer`` is not specified -- this should maintain expected behaviour / backward compatibility 
