### PR TITLE
REF: test_invalid_dtype in numeric index tests

### DIFF
--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -832,8 +832,9 @@ class NumericBase(Base):
         result = a - fidx
         tm.assert_index_equal(result, expected)
 
-    def check_invalid_dtype(self, dtype):
+    def test_invalid_dtype(self, invalid_dtype):
         # GH 29539
+        dtype = invalid_dtype
         with pytest.raises(
             ValueError,
             match=rf"Incorrect `dtype` passed: expected \w+(?: \w+)?, received {dtype}",

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -831,3 +831,11 @@ class NumericBase(Base):
         a = np.zeros(5, dtype="float64")
         result = a - fidx
         tm.assert_index_equal(result, expected)
+
+    def check_invalid_dtype(self, dtype):
+        # GH 29539
+        with pytest.raises(
+            ValueError,
+            match=rf"Incorrect `dtype` passed: expected \w+(?: \w+)?, received {dtype}",
+        ):
+            self._index_cls([1, 2, 3], dtype=dtype)

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -835,8 +835,6 @@ class NumericBase(Base):
     def test_invalid_dtype(self, invalid_dtype):
         # GH 29539
         dtype = invalid_dtype
-        with pytest.raises(
-            ValueError,
-            match=rf"Incorrect `dtype` passed: expected \w+(?: \w+)?, received {dtype}",
-        ):
+        msg = fr"Incorrect `dtype` passed: expected \w+(?: \w+)?, received {dtype}"
+        with pytest.raises(ValueError, match=msg):
             self._index_cls([1, 2, 3], dtype=dtype)

--- a/pandas/tests/indexes/numeric/test_numeric.py
+++ b/pandas/tests/indexes/numeric/test_numeric.py
@@ -19,6 +19,12 @@ class TestFloat64Index(NumericBase):
     _index_cls = Float64Index
     _dtype = np.float64
 
+    @pytest.fixture(
+        params=["int64", "uint64", "category", "datetime64"],
+    )
+    def invalid_dtype(self, request):
+        return request.param
+
     @pytest.fixture
     def simple_index(self) -> Index:
         values = np.arange(5, dtype=self._dtype)
@@ -102,18 +108,6 @@ class TestFloat64Index(NumericBase):
         assert isinstance(result, index_cls)
         assert result.dtype == dtype
         assert pd.isna(result.values).all()
-
-    @pytest.mark.parametrize(
-        "dtype",
-        [
-            "int64",
-            "uint64",
-            "category",
-            "datetime64",
-        ],
-    )
-    def test_invalid_dtype(self, dtype):
-        self.check_invalid_dtype(dtype)
 
     def test_constructor_invalid(self):
         index_cls = self._index_cls
@@ -388,6 +382,12 @@ class TestInt64Index(NumericInt):
     _index_cls = Int64Index
     _dtype = np.int64
 
+    @pytest.fixture(
+        params=["uint64", "float64", "category", "datetime64"],
+    )
+    def invalid_dtype(self, request):
+        return request.param
+
     @pytest.fixture
     def simple_index(self) -> Index:
         return self._index_cls(range(0, 20, 2), dtype=self._dtype)
@@ -480,23 +480,17 @@ class TestInt64Index(NumericInt):
         arr = Index([1, 2, 3, 4], dtype=object)
         assert isinstance(arr, Index)
 
-    @pytest.mark.parametrize(
-        "dtype",
-        [
-            "uint64",
-            "float64",
-            "category",
-            "datetime64",
-        ],
-    )
-    def test_invalid_dtype(self, dtype):
-        self.check_invalid_dtype(dtype)
-
 
 class TestUInt64Index(NumericInt):
 
     _index_cls = UInt64Index
     _dtype = np.uint64
+
+    @pytest.fixture(
+        params=["int64", "float64", "category", "datetime64"],
+    )
+    def invalid_dtype(self, request):
+        return request.param
 
     @pytest.fixture
     def simple_index(self) -> Index:
@@ -537,18 +531,6 @@ class TestUInt64Index(NumericInt):
         idx = index_cls([1, 2 ** 63 + 1], dtype=dtype)
         res = Index([1, 2 ** 63 + 1], dtype=dtype)
         tm.assert_index_equal(res, idx)
-
-    @pytest.mark.parametrize(
-        "dtype",
-        [
-            "int64",
-            "float64",
-            "category",
-            "datetime64",
-        ],
-    )
-    def test_invalid_dtype(self, dtype):
-        self.check_invalid_dtype(dtype)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/indexes/numeric/test_numeric.py
+++ b/pandas/tests/indexes/numeric/test_numeric.py
@@ -108,7 +108,7 @@ class TestFloat64Index(NumericBase):
         [
             "int64",
             "uint64",
-            "categorical",
+            "category",
             "datetime64",
         ],
     )
@@ -485,7 +485,7 @@ class TestInt64Index(NumericInt):
         [
             "uint64",
             "float64",
-            "categorical",
+            "category",
             "datetime64",
         ],
     )
@@ -543,7 +543,7 @@ class TestUInt64Index(NumericInt):
         [
             "int64",
             "float64",
-            "categorical",
+            "category",
             "datetime64",
         ],
     )

--- a/pandas/tests/indexes/numeric/test_numeric.py
+++ b/pandas/tests/indexes/numeric/test_numeric.py
@@ -8,7 +8,6 @@ from pandas import (
     Float64Index,
     Index,
     Int64Index,
-    RangeIndex,
     Series,
     UInt64Index,
 )
@@ -105,21 +104,16 @@ class TestFloat64Index(NumericBase):
         assert pd.isna(result.values).all()
 
     @pytest.mark.parametrize(
-        "index, dtype",
+        "dtype",
         [
-            (Int64Index, "float64"),
-            (UInt64Index, "categorical"),
-            (Float64Index, "datetime64"),
-            (RangeIndex, "float64"),
+            "int64",
+            "uint64",
+            "categorical",
+            "datetime64",
         ],
     )
-    def test_invalid_dtype(self, index, dtype):
-        # GH 29539
-        with pytest.raises(
-            ValueError,
-            match=rf"Incorrect `dtype` passed: expected \w+(?: \w+)?, received {dtype}",
-        ):
-            index([1, 2, 3], dtype=dtype)
+    def test_invalid_dtype(self, dtype):
+        self.check_invalid_dtype(dtype)
 
     def test_constructor_invalid(self):
         index_cls = self._index_cls
@@ -486,6 +480,18 @@ class TestInt64Index(NumericInt):
         arr = Index([1, 2, 3, 4], dtype=object)
         assert isinstance(arr, Index)
 
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            "uint64",
+            "float64",
+            "categorical",
+            "datetime64",
+        ],
+    )
+    def test_invalid_dtype(self, dtype):
+        self.check_invalid_dtype(dtype)
+
 
 class TestUInt64Index(NumericInt):
 
@@ -531,6 +537,18 @@ class TestUInt64Index(NumericInt):
         idx = index_cls([1, 2 ** 63 + 1], dtype=dtype)
         res = Index([1, 2 ** 63 + 1], dtype=dtype)
         tm.assert_index_equal(res, idx)
+
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            "int64",
+            "float64",
+            "categorical",
+            "datetime64",
+        ],
+    )
+    def test_invalid_dtype(self, dtype):
+        self.check_invalid_dtype(dtype)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -376,6 +376,18 @@ class TestRangeIndex(NumericBase):
         # RangeIndex() is a valid constructor
         pass
 
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            "uint64",
+            "float64",
+            "categorical",
+            "datetime64",
+        ],
+    )
+    def test_invalid_dtype(self, dtype):
+        self.check_invalid_dtype(dtype)
+
     def test_slice_specialised(self, simple_index):
         index = simple_index
         index.name = "foo"

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -381,7 +381,7 @@ class TestRangeIndex(NumericBase):
         [
             "uint64",
             "float64",
-            "categorical",
+            "category",
             "datetime64",
         ],
     )

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -23,6 +23,12 @@ OI = Index
 class TestRangeIndex(NumericBase):
     _index_cls = RangeIndex
 
+    @pytest.fixture(
+        params=["uint64", "float64", "category", "datetime64"],
+    )
+    def invalid_dtype(self, request):
+        return request.param
+
     @pytest.fixture
     def simple_index(self) -> Index:
         return self._index_cls(start=0, stop=20, step=2)
@@ -375,18 +381,6 @@ class TestRangeIndex(NumericBase):
     def test_pickle_compat_construction(self):
         # RangeIndex() is a valid constructor
         pass
-
-    @pytest.mark.parametrize(
-        "dtype",
-        [
-            "uint64",
-            "float64",
-            "category",
-            "datetime64",
-        ],
-    )
-    def test_invalid_dtype(self, dtype):
-        self.check_invalid_dtype(dtype)
 
     def test_slice_specialised(self, simple_index):
         index = simple_index


### PR DESCRIPTION
The invalid dtype tests for all the numeric index types are currently done in `tests.numeric.test_numeric.py::TestFloat64Index::test_invalid_dtype`. This PR moves them to the appropriate test class (`TestInt64Index` etc.).