### PR TITLE
TST/CLN: use dtype fixture in numeric tests

### DIFF
--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -772,6 +772,12 @@ class NumericBase(Base):
     Base class for numeric index (incl. RangeIndex) sub-class tests.
     """
 
+    def test_constructor_unwraps_index(self, dtype):
+        idx = Index([1, 2], dtype=dtype)
+        result = self._index_cls(idx)
+        expected = np.array([1, 2], dtype=dtype)
+        tm.assert_numpy_array_equal(result._data, expected)
+
     def test_where(self):
         # Tested in numeric.test_indexing
         pass

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -39,7 +39,7 @@ class Base:
     _index_cls: Type[Index]
 
     @pytest.fixture
-    def simple_index(self) -> Index:
+    def simple_index(self):
         raise NotImplementedError("Method not implemented")
 
     def create_index(self) -> Index:

--- a/pandas/tests/indexes/numeric/test_numeric.py
+++ b/pandas/tests/indexes/numeric/test_numeric.py
@@ -29,7 +29,7 @@ class TestFloat64Index(NumericBase):
         return request.param
 
     @pytest.fixture
-    def simple_index(self, dtype) -> Index:
+    def simple_index(self, dtype):
         values = np.arange(5, dtype=dtype)
         return self._index_cls(values)
 
@@ -393,7 +393,7 @@ class TestInt64Index(NumericInt):
         return request.param
 
     @pytest.fixture
-    def simple_index(self, dtype) -> Index:
+    def simple_index(self, dtype):
         return self._index_cls(range(0, 20, 2), dtype=dtype)
 
     @pytest.fixture(
@@ -492,7 +492,7 @@ class TestUInt64Index(NumericInt):
         return request.param
 
     @pytest.fixture
-    def simple_index(self, dtype) -> Index:
+    def simple_index(self, dtype):
         # compat with shared Int64/Float64 tests
         return self._index_cls(np.arange(5, dtype=dtype))
 

--- a/pandas/tests/indexes/numeric/test_numeric.py
+++ b/pandas/tests/indexes/numeric/test_numeric.py
@@ -17,7 +17,10 @@ from pandas.tests.indexes.common import NumericBase
 
 class TestFloat64Index(NumericBase):
     _index_cls = Float64Index
-    _dtype = np.float64
+
+    @pytest.fixture
+    def dtype(self, request):
+        return np.float64
 
     @pytest.fixture(
         params=["int64", "uint64", "category", "datetime64"],
@@ -26,8 +29,8 @@ class TestFloat64Index(NumericBase):
         return request.param
 
     @pytest.fixture
-    def simple_index(self) -> Index:
-        values = np.arange(5, dtype=self._dtype)
+    def simple_index(self, dtype) -> Index:
+        values = np.arange(5, dtype=dtype)
         return self._index_cls(values)
 
     @pytest.fixture(
@@ -65,9 +68,8 @@ class TestFloat64Index(NumericBase):
         else:
             self.check_is_index(b)
 
-    def test_constructor(self):
+    def test_constructor(self, dtype):
         index_cls = self._index_cls
-        dtype = self._dtype
 
         # explicit construction
         index = index_cls([1, 2, 3, 4, 5])
@@ -204,8 +206,7 @@ class TestFloat64Index(NumericBase):
             pd.timedelta_range("1 Day", periods=3),
         ],
     )
-    def test_lookups_datetimelike_values(self, vals):
-        dtype = self._dtype
+    def test_lookups_datetimelike_values(self, vals, dtype):
 
         # If we have datetime64 or timedelta64 values, make sure they are
         #  wrappped correctly  GH#31163
@@ -277,14 +278,14 @@ class TestFloat64Index(NumericBase):
 
 
 class NumericInt(NumericBase):
-    def test_view(self):
+    def test_view(self, dtype):
         index_cls = self._index_cls
 
         idx = index_cls([], name="Foo")
         idx_view = idx.view()
         assert idx_view.name == "Foo"
 
-        idx_view = idx.view(self._dtype)
+        idx_view = idx.view(dtype)
         tm.assert_index_equal(idx, index_cls(idx_view, name="Foo"))
 
         idx_view = idx.view(index_cls)
@@ -334,7 +335,7 @@ class NumericInt(NumericBase):
         assert idx.all() == idx.values.all()
         assert idx.any() == idx.values.any()
 
-    def test_identical(self, simple_index):
+    def test_identical(self, simple_index, dtype):
         index = simple_index
 
         idx = Index(index.copy())
@@ -351,7 +352,7 @@ class NumericInt(NumericBase):
         assert not idx.identical(index)
         assert Index(same_values, name="foo", dtype=object).identical(idx)
 
-        assert not index.astype(dtype=object).identical(index.astype(dtype=self._dtype))
+        assert not index.astype(dtype=object).identical(index.astype(dtype=dtype))
 
     def test_cant_or_shouldnt_cast(self):
         msg = (
@@ -380,7 +381,10 @@ class NumericInt(NumericBase):
 
 class TestInt64Index(NumericInt):
     _index_cls = Int64Index
-    _dtype = np.int64
+
+    @pytest.fixture
+    def dtype(self):
+        return np.int64
 
     @pytest.fixture(
         params=["uint64", "float64", "category", "datetime64"],
@@ -389,8 +393,8 @@ class TestInt64Index(NumericInt):
         return request.param
 
     @pytest.fixture
-    def simple_index(self) -> Index:
-        return self._index_cls(range(0, 20, 2), dtype=self._dtype)
+    def simple_index(self, dtype) -> Index:
+        return self._index_cls(range(0, 20, 2), dtype=dtype)
 
     @pytest.fixture(
         params=[range(0, 20, 2), range(19, -1, -1)], ids=["index_inc", "index_dec"]
@@ -398,9 +402,8 @@ class TestInt64Index(NumericInt):
     def index(self, request):
         return self._index_cls(request.param)
 
-    def test_constructor(self):
+    def test_constructor(self, dtype):
         index_cls = self._index_cls
-        dtype = self._dtype
 
         # pass list, coerce fine
         index = index_cls([-5, 0, 1, 2])
@@ -439,9 +442,8 @@ class TestInt64Index(NumericInt):
             ]:
                 tm.assert_index_equal(idx, expected)
 
-    def test_constructor_corner(self):
+    def test_constructor_corner(self, dtype):
         index_cls = self._index_cls
-        dtype = self._dtype
 
         arr = np.array([1, 2, 3, 4], dtype=object)
         index = index_cls(arr)
@@ -465,12 +467,6 @@ class TestInt64Index(NumericInt):
         with pytest.raises(OverflowError, match=msg):
             Index([-1], dtype=uint_dtype)
 
-    def test_constructor_unwraps_index(self):
-        idx = Index([1, 2])
-        result = self._index_cls(idx)
-        expected = np.array([1, 2], dtype=self._dtype)
-        tm.assert_numpy_array_equal(result._data, expected)
-
     def test_coerce_list(self):
         # coerce things
         arr = Index([1, 2, 3, 4])
@@ -478,13 +474,16 @@ class TestInt64Index(NumericInt):
 
         # but not if explicit dtype passed
         arr = Index([1, 2, 3, 4], dtype=object)
-        assert isinstance(arr, Index)
+        assert type(arr) is Index
 
 
 class TestUInt64Index(NumericInt):
 
     _index_cls = UInt64Index
-    _dtype = np.uint64
+
+    @pytest.fixture
+    def dtype(self):
+        return np.uint64
 
     @pytest.fixture(
         params=["int64", "float64", "category", "datetime64"],
@@ -493,9 +492,9 @@ class TestUInt64Index(NumericInt):
         return request.param
 
     @pytest.fixture
-    def simple_index(self) -> Index:
+    def simple_index(self, dtype) -> Index:
         # compat with shared Int64/Float64 tests
-        return self._index_cls(np.arange(5, dtype=self._dtype))
+        return self._index_cls(np.arange(5, dtype=dtype))
 
     @pytest.fixture(
         params=[
@@ -507,9 +506,8 @@ class TestUInt64Index(NumericInt):
     def index(self, request):
         return self._index_cls(request.param)
 
-    def test_constructor(self):
+    def test_constructor(self, dtype):
         index_cls = self._index_cls
-        dtype = self._dtype
 
         idx = index_cls([1, 2, 3])
         res = Index([1, 2, 3], dtype=dtype)

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -23,6 +23,10 @@ OI = Index
 class TestRangeIndex(NumericBase):
     _index_cls = RangeIndex
 
+    @pytest.fixture
+    def dtype(self):
+        return np.int64
+
     @pytest.fixture(
         params=["uint64", "float64", "category", "datetime64"],
     )
@@ -42,6 +46,11 @@ class TestRangeIndex(NumericBase):
     )
     def index(self, request):
         return request.param
+
+    def test_constructor_unwraps_index(self, dtype):
+        result = self._index_cls(1, 3)
+        expected = np.array([1, 2], dtype=dtype)
+        tm.assert_numpy_array_equal(result._data, expected)
 
     def test_can_hold_identifiers(self, simple_index):
         idx = simple_index


### PR DESCRIPTION
small cleanup to make tests amenable to tests againt several dtypes.