### PR TITLE
TST: Add regression tests for old issues

### DIFF
--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -1407,3 +1407,18 @@ def test_integer_array_add_list_like(
 
     assert_function(left, expected)
     assert_function(right, expected)
+
+
+def test_sub_multiindex_swapped_levels():
+    # GH 9952
+    df = pd.DataFrame(
+        {"a": np.random.randn(6)},
+        index=pd.MultiIndex.from_product(
+            [["a", "b"], [0, 1, 2]], names=["levA", "levB"]
+        ),
+    )
+    df2 = df.copy()
+    df2.index = df2.index.swaplevel(0, 1)
+    result = df - df2
+    expected = pd.DataFrame([0.0] * 6, columns=["a"], index=df.index)
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -729,3 +729,19 @@ def test_where_string_dtype(frame_or_series):
         dtype=StringDtype(),
     )
     tm.assert_equal(result, expected)
+
+
+def test_where_bool_comparison():
+    # GH 10336
+    df_mask = DataFrame(
+        {"AAA": [True] * 4, "BBB": [False] * 4, "CCC": [True, False, True, False]}
+    )
+    result = df_mask.where(df_mask == False)  # noqa:E712
+    expected = DataFrame(
+        {
+            "AAA": np.array([np.nan] * 4, dtype=object),
+            "BBB": [False] * 4,
+            "CCC": [np.nan, False, np.nan, False],
+        }
+    )
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -657,3 +657,17 @@ def test_reset_index_empty_frame_with_datetime64_multiindex_from_groupby():
     expected["c3"] = expected["c3"].astype("datetime64[ns]")
     expected["c1"] = expected["c1"].astype("float64")
     tm.assert_frame_equal(result, expected)
+
+
+def test_reset_index_multiindex_nat():
+    # GH 11479
+    idx = range(3)
+    tstamp = date_range("2015-07-01", freq="D", periods=3)
+    df = DataFrame({"id": idx, "tstamp": tstamp, "a": list("abc")})
+    df.loc[2, "tstamp"] = pd.NaT
+    result = df.set_index(["id", "tstamp"]).reset_index("id")
+    expected = DataFrame(
+        {"id": range(3), "a": list("abc")},
+        index=pd.DatetimeIndex(["2015-07-01", "2015-07-02", "NaT"], name="tstamp"),
+    )
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2398,6 +2398,12 @@ class TestDataFrameConstructors:
             # assert b[0] == 0
             assert df.iloc[0, 2] == 0
 
+    def test_from_series_with_name_with_columns(self):
+        # GH 7893
+        result = DataFrame(Series(1, name="foo"), columns=["bar"])
+        expected = DataFrame(columns=["bar"])
+        tm.assert_frame_equal(result, expected)
+
 
 class TestDataFrameConstructorWithDatetimeTZ:
     @pytest.mark.parametrize("tz", ["US/Eastern", "dateutil/US/Eastern"])

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -1998,3 +1998,23 @@ Thu,Lunch,Yes,51.51,17"""
             columns=Index([(0, None), (0, 2), (0, 3)]),
         )
         tm.assert_frame_equal(result, expected)
+
+    def test_stack_nan_level(self):
+        # GH 9406
+        df_nan = DataFrame(
+            np.arange(4).reshape(2, 2),
+            columns=MultiIndex.from_tuples(
+                [("A", np.nan), ("B", "b")], names=["Upper", "Lower"]
+            ),
+            index=Index([0, 1], name="Num"),
+            dtype=np.float64,
+        )
+        result = df_nan.stack()
+        expected = DataFrame(
+            [[0.0, np.nan], [np.nan, 1], [2.0, np.nan], [np.nan, 3.0]],
+            columns=Index(["A", "B"], name="Upper"),
+            index=MultiIndex.from_tuples(
+                [(0, np.nan), (0, "b"), (1, np.nan), (1, "b")], names=["Num", "Lower"]
+            ),
+        )
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -776,3 +776,15 @@ def test_loc_getitem_drops_levels_for_one_row_dataframe():
     result = ser.loc["x", :, "z"]
     expected = Series([0], index=Index(["y"], name="b"))
     tm.assert_series_equal(result, expected)
+
+
+def test_mi_columns_loc_list_label_order():
+    # GH 10710
+    cols = MultiIndex.from_product([["A", "B", "C"], [1, 2]])
+    df = DataFrame(np.zeros((5, 6)), columns=cols)
+    result = df.loc[:, ["B", "A"]]
+    expected = DataFrame(
+        np.zeros((5, 4)),
+        columns=MultiIndex.from_tuples([("B", 1), ("B", 2), ("A", 1), ("A", 2)]),
+    )
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/reshape/concat/test_datetimes.py
+++ b/pandas/tests/reshape/concat/test_datetimes.py
@@ -470,6 +470,14 @@ class TestTimezoneConcat:
 
         tm.assert_frame_equal(result, expected)
 
+    def test_concat_tz_with_empty(self):
+        # GH 9188
+        result = concat(
+            [DataFrame(date_range("2000", periods=1, tz="UTC")), DataFrame()]
+        )
+        expected = DataFrame(date_range("2000", periods=1, tz="UTC"))
+        tm.assert_frame_equal(result, expected)
+
 
 class TestPeriodConcat:
     def test_concat_period_series(self):

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -204,7 +204,7 @@ class TestSetitemSlices:
     def test_setitem_multiindex_slice(self, indexer_sli):
         # GH 8856
         mi = MultiIndex.from_product(([0, 1], list("abcde")))
-        result = Series(np.arange(10), mi)
+        result = Series(np.arange(10, dtype=np.int64), mi)
         indexer_sli(result)[::4] = 100
         expected = Series([100, 1, 2, 3, 100, 5, 6, 7, 100, 9], mi)
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -201,6 +201,14 @@ class TestSetitemSlices:
         series[::2] = 0
         assert (series[::2] == 0).all()
 
+    def test_setitem_multiindex_slice(self, indexer_sli):
+        # GH 8856
+        mi = MultiIndex.from_product(([0, 1], list("abcde")))
+        result = Series(np.arange(10), mi)
+        indexer_sli(result)[::4] = 100
+        expected = Series([100, 1, 2, 3, 100, 5, 6, 7, 100, 9], mi)
+        tm.assert_series_equal(result, expected)
+
 
 class TestSetitemBooleanMask:
     def test_setitem_boolean(self, string_series):


### PR DESCRIPTION
- [x] closes #7893
- [x] closes #8856
- [x] closes #9188
- [x] closes #9406
- [x] closes #9952
- [x] closes #10336
- [x] closes #10710
- [x] closes #11479
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

