### PR TITLE
REF: re-use machinery for DataFrameGroupBy.nunique

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1627,21 +1627,21 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
         return self._reindex_output(result)._convert(datetime=True)
 
-    def _iterate_column_groupbys(self):
-        for i, colname in enumerate(self._selected_obj.columns):
+    def _iterate_column_groupbys(self, obj: FrameOrSeries):
+        for i, colname in enumerate(obj.columns):
             yield colname, SeriesGroupBy(
-                self._selected_obj.iloc[:, i],
+                obj.iloc[:, i],
                 selection=colname,
                 grouper=self.grouper,
                 exclusions=self.exclusions,
             )
 
-    def _apply_to_column_groupbys(self, func) -> DataFrame:
+    def _apply_to_column_groupbys(self, func, obj: FrameOrSeries) -> DataFrame:
         from pandas.core.reshape.concat import concat
 
-        columns = self._selected_obj.columns
+        columns = obj.columns
         results = [
-            func(col_groupby) for _, col_groupby in self._iterate_column_groupbys()
+            func(col_groupby) for _, col_groupby in self._iterate_column_groupbys(obj)
         ]
 
         if not len(results):
@@ -1730,39 +1730,46 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         """
         from pandas.core.reshape.concat import concat
 
-        # TODO: this is duplicative of how GroupBy naturally works
-        # Try to consolidate with normal wrapping functions
-
         obj = self._obj_with_exclusions
+
         if self.axis == 0:
-            iter_func = obj.items
+            results = self._apply_to_column_groupbys(
+                lambda sgb: sgb.nunique(dropna), obj=obj
+            )
+            results.columns.names = obj.columns.names  # TODO: do at higher level?
         else:
+            # see test_groupby_crash_on_nunique
+            # TODO: this is duplicative of how GroupBy naturally works
+            # Try to consolidate with normal wrapping functions
+
             iter_func = obj.iterrows
 
-        res_list = [
-            SeriesGroupBy(content, selection=label, grouper=self.grouper).nunique(
-                dropna
-            )
-            for label, content in iter_func()
-        ]
-        if res_list:
-            results = concat(res_list, axis=1)
-            results = cast(DataFrame, results)
-        else:
-            # concat would raise
-            results = DataFrame(
-                [], index=self.grouper.result_index, columns=obj.columns[:0]
-            )
+            res_list = [
+                SeriesGroupBy(content, selection=label, grouper=self.grouper).nunique(
+                    dropna
+                )
+                for label, content in iter_func()
+            ]
+            if res_list:
+                results = concat(res_list, axis=1)
+                results = cast(DataFrame, results)
+            else:
+                # concat would raise
+                results = DataFrame(
+                    [], index=self.grouper.result_index, columns=obj.columns[:0]
+                )
 
-        if self.axis == 1:
             results = results.T
 
-        other_axis = 1 - self.axis
-        results._get_axis(other_axis).names = obj._get_axis(other_axis).names
+            results.index.names = obj.index.names
+            if results.index.equals(obj.index):
+                # retain freq attribute on DatetimeIndex/TimedeltaIndex
+                results.index = obj.index.copy()
 
         if not self.as_index:
             results.index = ibase.default_index(len(results))
             self._insert_inaxis_grouper_inplace(results)
+
         return results
 
     @Appender(DataFrame.idxmax.__doc__)

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1904,7 +1904,9 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
             )
             return self._reindex_output(result)
 
-        return self._apply_to_column_groupbys(lambda x: x.ohlc())
+        return self._apply_to_column_groupbys(
+            lambda x: x.ohlc(), self._obj_with_exclusions
+        )
 
     @final
     @doc(DataFrame.describe)

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2060,23 +2060,28 @@ def test_dup_labels_output_shape(groupby_func, idx):
 
 def test_groupby_crash_on_nunique(axis):
     # Fix following 30253
+    dti = date_range("2016-01-01", periods=2, name="foo")
     df = DataFrame({("A", "B"): [1, 2], ("A", "C"): [1, 3], ("D", "B"): [0, 0]})
+    df.columns.names = ("bar", "baz")
+    df.index = dti
 
     axis_number = df._get_axis_number(axis)
     if not axis_number:
         df = df.T
 
-    result = df.groupby(axis=axis_number, level=0).nunique()
+    gb = df.groupby(axis=axis_number, level=0)
+    result = gb.nunique()
 
-    expected = DataFrame({"A": [1, 2], "D": [1, 1]})
+    expected = DataFrame({"A": [1, 2], "D": [1, 1]}, index=dti)
+    expected.columns.name = "bar"
     if not axis_number:
         expected = expected.T
 
     tm.assert_frame_equal(result, expected)
 
     # same thing, but empty columns
-    gb = df[[]].groupby(axis=axis_number, level=0)
-    res = gb.nunique()
+    gb2 = df[[]].groupby(axis=axis_number, level=0)
+    res = gb2.nunique()
     exp = expected[[]]
     tm.assert_frame_equal(res, exp)
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2079,10 +2079,17 @@ def test_groupby_crash_on_nunique(axis):
 
     tm.assert_frame_equal(result, expected)
 
-    # same thing, but empty columns
-    gb2 = df[[]].groupby(axis=axis_number, level=0)
+    if axis_number == 0:
+        # same thing, but empty columns
+        gb2 = df[[]].groupby(axis=axis_number, level=0)
+        exp = expected[[]]
+    else:
+        # same thing, but empty rows
+        gb2 = df.loc[[]].groupby(axis=axis_number, level=0)
+        # default for empty when we can't infer a dtype is float64
+        exp = expected.loc[[]].astype(np.float64)
+
     res = gb2.nunique()
-    exp = expected[[]]
     tm.assert_frame_equal(res, exp)
 
 

--- a/pandas/tests/resample/test_time_grouper.py
+++ b/pandas/tests/resample/test_time_grouper.py
@@ -121,12 +121,8 @@ def test_aaa_group_order():
     tm.assert_frame_equal(grouped.get_group(datetime(2013, 1, 5)), df[4::5])
 
 
-def test_aggregate_normal(request, resample_method):
+def test_aggregate_normal(resample_method):
     """Check TimeGrouper's aggregation is identical as normal groupby."""
-    if resample_method == "ohlc":
-        request.node.add_marker(
-            pytest.mark.xfail(reason="DataError: No numeric types to aggregate")
-        )
 
     data = np.random.randn(20, 4)
     normal_df = DataFrame(data, columns=["A", "B", "C", "D"])


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
