### PR TITLE
REF: add internal mechanics to separate index/columns sparsification in Styler

### DIFF
--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -538,17 +538,18 @@ def _get_level_lengths(index, sparsify, hidden_elements=None):
 
     Parameters
     ----------
-        index : Index
-            Index or columns to determine lengths of each element
-        sparsify : bool
-            Whether to hide or show each distinct element in a MultiIndex
-        hidden_element : list
-            Index positions of elements hidden from display in the index affecting
-            length
+    index : Index
+        Index or columns to determine lengths of each element
+    sparsify : bool
+        Whether to hide or show each distinct element in a MultiIndex
+    hidden_elements : list
+        Index positions of elements hidden from display in the index affecting
+        length
+
     Returns
     -------
-        Dict :
-            Result is a dictionary of (level, initial_position): span
+    Dict :
+        Result is a dictionary of (level, initial_position): span
     """
     if isinstance(index, MultiIndex):
         levels = index.format(sparsify=lib.no_default, adjoin=False)

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -532,7 +532,9 @@ def _element(
     }
 
 
-def _get_level_lengths(index, sparsify, hidden_elements=None):
+def _get_level_lengths(
+    index: Index, sparsify: bool, hidden_elements: Sequence[int] | None = None
+):
     """
     Given an index, find the level length for each element.
 
@@ -542,7 +544,7 @@ def _get_level_lengths(index, sparsify, hidden_elements=None):
         Index or columns to determine lengths of each element
     sparsify : bool
         Whether to hide or show each distinct element in a MultiIndex
-    hidden_elements : list
+    hidden_elements : sequence of int
         Index positions of elements hidden from display in the index affecting
         length
 

--- a/pandas/tests/io/formats/style/test_style.py
+++ b/pandas/tests/io/formats/style/test_style.py
@@ -844,7 +844,24 @@ class TestStyler:
             (1, 4): 1,
             (1, 5): 1,
         }
-        result = _get_level_lengths(index)
+        result = _get_level_lengths(index, sparsify=True)
+        tm.assert_dict_equal(result, expected)
+
+        expected = {
+            (0, 0): 1,
+            (0, 1): 1,
+            (0, 2): 1,
+            (0, 3): 1,
+            (0, 4): 1,
+            (0, 5): 1,
+            (1, 0): 1,
+            (1, 1): 1,
+            (1, 2): 1,
+            (1, 3): 1,
+            (1, 4): 1,
+            (1, 5): 1,
+        }
+        result = _get_level_lengths(index, sparsify=False)
         tm.assert_dict_equal(result, expected)
 
     def test_get_level_lengths_un_sorted(self):
@@ -858,7 +875,20 @@ class TestStyler:
             (1, 2): 1,
             (1, 3): 1,
         }
-        result = _get_level_lengths(index)
+        result = _get_level_lengths(index, sparsify=True)
+        tm.assert_dict_equal(result, expected)
+
+        expected = {
+            (0, 0): 1,
+            (0, 1): 1,
+            (0, 2): 1,
+            (0, 3): 1,
+            (1, 0): 1,
+            (1, 1): 1,
+            (1, 2): 1,
+            (1, 3): 1,
+        }
+        result = _get_level_lengths(index, sparsify=False)
         tm.assert_dict_equal(result, expected)
 
     def test_mi_sparse(self):


### PR DESCRIPTION
This is not a user facing change.

It adds only the necessary code to permit separate control of index/column MultIndex sparsification. Essentially it removes the `get_option("display.multi_sparse")` from a low level method to a higher level method where it can be overwritten by user-args later.

partly addresses #41142 