### PR TITLE
DOC: specify regex=True in str.replace

### DIFF
--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1287,7 +1287,7 @@ class StringMethods(NoNewAttributesMixin):
 
         To get the idea:
 
-        >>> pd.Series(['foo', 'fuz', np.nan]).str.replace('f', repr)
+        >>> pd.Series(['foo', 'fuz', np.nan]).str.replace('f', repr, regex=True)
         0    <re.Match object; span=(0, 1), match='f'>oo
         1    <re.Match object; span=(0, 1), match='f'>uz
         2                                            NaN
@@ -1296,7 +1296,8 @@ class StringMethods(NoNewAttributesMixin):
         Reverse every lowercase alphabetic word:
 
         >>> repl = lambda m: m.group(0)[::-1]
-        >>> pd.Series(['foo 123', 'bar baz', np.nan]).str.replace(r'[a-z]+', repl)
+        >>> ser = pd.Series(['foo 123', 'bar baz', np.nan])
+        >>> ser.str.replace(r'[a-z]+', repl, regex=True)
         0    oof 123
         1    rab zab
         2        NaN
@@ -1306,7 +1307,8 @@ class StringMethods(NoNewAttributesMixin):
 
         >>> pat = r"(?P<one>\w+) (?P<two>\w+) (?P<three>\w+)"
         >>> repl = lambda m: m.group('two').swapcase()
-        >>> pd.Series(['One Two Three', 'Foo Bar Baz']).str.replace(pat, repl)
+        >>> ser = pd.Series(['One Two Three', 'Foo Bar Baz'])
+        >>> ser.str.replace(pat, repl, regex=True)
         0    tWO
         1    bAR
         dtype: object
@@ -1315,18 +1317,14 @@ class StringMethods(NoNewAttributesMixin):
 
         >>> import re
         >>> regex_pat = re.compile(r'FUZ', flags=re.IGNORECASE)
-        >>> pd.Series(['foo', 'fuz', np.nan]).str.replace(regex_pat, 'bar')
+        >>> pd.Series(['foo', 'fuz', np.nan]).str.replace(regex_pat, 'bar', regex=True)
         0    foo
         1    bar
         2    NaN
         dtype: object
         """
         if regex is None:
-            if (
-                isinstance(pat, str)
-                and not callable(repl)
-                and any(c in pat for c in ".+*|^$?[](){}\\")
-            ):
+            if isinstance(pat, str) and any(c in pat for c in ".+*|^$?[](){}\\"):
                 # warn only in cases where regex behavior would differ from literal
                 msg = (
                     "The default value of regex will change from True to False "
@@ -1338,7 +1336,6 @@ class StringMethods(NoNewAttributesMixin):
                         "*not* be treated as literal strings when regex=True."
                     )
                 warnings.warn(msg, FutureWarning, stacklevel=3)
-            # GH 41397 - When regex default is False, ignore regex when repl is callable
             regex = True
 
         # Check whether repl is valid (GH 13438, GH 15055)

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1338,7 +1338,7 @@ class StringMethods(NoNewAttributesMixin):
                         "*not* be treated as literal strings when regex=True."
                     )
                 warnings.warn(msg, FutureWarning, stacklevel=3)
-            # When changing default False, do not use False when repl is callable
+            # When changing default to False, do not use False when repl is callable
             regex = True
 
         # Check whether repl is valid (GH 13438, GH 15055)

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1322,7 +1322,11 @@ class StringMethods(NoNewAttributesMixin):
         dtype: object
         """
         if regex is None:
-            if isinstance(pat, str) and any(c in pat for c in ".+*|^$?[](){}\\"):
+            if (
+                isinstance(pat, str)
+                and not callable(repl)
+                and any(c in pat for c in ".+*|^$?[](){}\\")
+            ):
                 # warn only in cases where regex behavior would differ from literal
                 msg = (
                     "The default value of regex will change from True to False "
@@ -1334,6 +1338,7 @@ class StringMethods(NoNewAttributesMixin):
                         "*not* be treated as literal strings when regex=True."
                     )
                 warnings.warn(msg, FutureWarning, stacklevel=3)
+            # When changing default False, do not use False when repl is callable
             regex = True
 
         # Check whether repl is valid (GH 13438, GH 15055)

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1231,7 +1231,7 @@ class StringMethods(NoNewAttributesMixin):
             Regex module flags, e.g. re.IGNORECASE. Cannot be set if `pat` is a compiled
             regex.
         regex : bool, default True
-            Determines if assumes the passed-in pattern is a regular expression:
+            Determines if the passed-in pattern is a regular expression:
 
             - If True, assumes the passed-in pattern is a regular expression.
             - If False, treats the pattern as a literal string

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1338,7 +1338,7 @@ class StringMethods(NoNewAttributesMixin):
                         "*not* be treated as literal strings when regex=True."
                     )
                 warnings.warn(msg, FutureWarning, stacklevel=3)
-            # When changing default to False, do not use False when repl is callable
+            # GH 41397 - When regex default is False, ignore regex when repl is callable
             regex = True
 
         # Check whether repl is valid (GH 13438, GH 15055)


### PR DESCRIPTION
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

ref #36695

When passing a callable repl, str.replace will raise if regex is False. So it seems to me that in the future, when the default is changed, we should be ignoring the regex argument completely (and update the documentation to that effect). This is slightly magical, but I think better than having a default that raises.

If this is the correct way forward, then we don't need to warn when repl is callable.

cc @dsaxton @jorisvandenbossche
