### PR TITLE
REF: groupby remove _selection_name

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -324,6 +324,7 @@ class Apply(metaclass=abc.ABCMeta):
             # i.e. obj is Series or DataFrame
             selected_obj = obj
         elif obj._selected_obj.ndim == 1:
+            # For SeriesGroupBy this matches _obj_with_exclusions
             selected_obj = obj._selected_obj
         else:
             selected_obj = obj._obj_with_exclusions

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -173,16 +173,6 @@ class SelectionMixin:
     _internal_names = ["_cache", "__setstate__"]
     _internal_names_set = set(_internal_names)
 
-    @property
-    def _selection_name(self):
-        """
-        Return a name for myself;
-
-        This would ideally be called the 'name' property,
-        but we cannot conflict with the Series.name property which can be set.
-        """
-        return self._selection
-
     @final
     @property
     def _selection_list(self):

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -168,10 +168,6 @@ class SeriesGroupBy(GroupBy[Series]):
     def _iterate_slices(self) -> Iterable[Series]:
         yield self._selected_obj
 
-    @property
-    def _selection_name(self) -> Hashable:
-        return self.obj.name
-
     _agg_examples_doc = dedent(
         """
     Examples
@@ -1050,16 +1046,6 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         return result._convert(datetime=True)
 
     agg = aggregate
-
-    @property
-    def _selection_name(self):
-        """
-        Return a name for myself;
-
-        This would ideally be called the 'name' property,
-        but we cannot conflict with the Series.name property which can be set.
-        """
-        return self._selection
 
     def _iterate_slices(self) -> Iterable[Series]:
         obj = self._selected_obj

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -11,7 +11,6 @@ from collections import (
     abc,
     namedtuple,
 )
-import copy
 from functools import partial
 from textwrap import dedent
 from typing import (
@@ -172,16 +171,8 @@ class SeriesGroupBy(GroupBy[Series]):
         yield self._selected_obj
 
     @property
-    def _selection_name(self):
-        """
-        since we are a series, we by definition only have
-        a single name, but may be the result of a selection or
-        the name of our object
-        """
-        if self._selection is None:
-            return self.obj.name
-        else:
-            return self._selection
+    def _selection_name(self) -> Hashable:
+        return self.obj.name
 
     _agg_examples_doc = dedent(
         """
@@ -316,15 +307,9 @@ class SeriesGroupBy(GroupBy[Series]):
 
         results: dict[base.OutputKey, FrameOrSeriesUnion] = {}
         for idx, (name, func) in enumerate(arg):
-            obj = self
 
-            # reset the cache so that we
-            # only include the named selection
-            if name in self._selected_obj:
-                obj = copy.copy(obj)
-                obj._reset_cache()
-                obj._selection = name
-            results[base.OutputKey(label=name, position=idx)] = obj.aggregate(func)
+            key = base.OutputKey(label=name, position=idx)
+            results[key] = self.aggregate(func)
 
         if any(isinstance(x, DataFrame) for x in results.values()):
             from pandas import concat
@@ -466,7 +451,7 @@ class SeriesGroupBy(GroupBy[Series]):
             # GH #6265
             return self.obj._constructor(
                 [],
-                name=self._selection_name,
+                name=self.obj.name,
                 index=self.grouper.result_index,
                 dtype=data.dtype,
             )
@@ -488,14 +473,14 @@ class SeriesGroupBy(GroupBy[Series]):
             # if self.observed is False,
             # keep all-NaN rows created while re-indexing
             result = result.stack(dropna=self.observed)
-            result.name = self._selection_name
+            result.name = self.obj.name
             return result
         elif isinstance(values[0], (Series, DataFrame)):
             return self._concat_objects(keys, values, not_indexed_same=not_indexed_same)
         else:
             # GH #6265 #24880
             result = self.obj._constructor(
-                data=values, index=_get_index(), name=self._selection_name
+                data=values, index=_get_index(), name=self.obj.name
             )
             return self._reindex_output(result)
 
@@ -533,7 +518,7 @@ class SeriesGroupBy(GroupBy[Series]):
         Transform with a callable func`.
         """
         assert callable(func)
-        klass = type(self._selected_obj)
+        klass = type(self.obj)
 
         results = []
         for name, group in self:
@@ -555,8 +540,10 @@ class SeriesGroupBy(GroupBy[Series]):
         else:
             result = self.obj._constructor(dtype=np.float64)
 
-        result.name = self._selected_obj.name
-        return result
+        result.name = self.obj.name
+        # error: Incompatible return value type (got "Union[DataFrame, Series]",
+        # expected "Series")
+        return result  # type: ignore[return-value]
 
     def _can_use_transform_fast(self, result) -> bool:
         return True
@@ -676,7 +663,7 @@ class SeriesGroupBy(GroupBy[Series]):
             res, out = np.zeros(len(ri), dtype=out.dtype), res
             res[ids[idx]] = out
 
-        result = self.obj._constructor(res, index=ri, name=self._selection_name)
+        result = self.obj._constructor(res, index=ri, name=self.obj.name)
         return self._reindex_output(result, fill_value=0)
 
     @doc(Series.describe)
@@ -782,7 +769,7 @@ class SeriesGroupBy(GroupBy[Series]):
         levels = [ping.group_index for ping in self.grouper.groupings] + [
             lev  # type: ignore[list-item]
         ]
-        names = self.grouper.names + [self._selection_name]
+        names = self.grouper.names + [self.obj.name]
 
         if dropna:
             mask = codes[-1] != -1
@@ -838,7 +825,7 @@ class SeriesGroupBy(GroupBy[Series]):
 
         if is_integer_dtype(out.dtype):
             out = ensure_int64(out)
-        return self.obj._constructor(out, index=mi, name=self._selection_name)
+        return self.obj._constructor(out, index=mi, name=self.obj.name)
 
     def count(self) -> Series:
         """
@@ -859,7 +846,7 @@ class SeriesGroupBy(GroupBy[Series]):
         result = self.obj._constructor(
             out,
             index=self.grouper.result_index,
-            name=self._selection_name,
+            name=self.obj.name,
             dtype="int64",
         )
         return self._reindex_output(result, fill_value=0)
@@ -1026,7 +1013,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
                     if isinstance(sobj, Series):
                         # GH#35246 test_groupby_as_index_select_column_sum_empty_df
-                        result.columns = [self._selected_obj.name]
+                        result.columns = [sobj.name]
                     else:
                         # select everything except for the last level, which is the one
                         # containing the name of the function(s), see GH#32040
@@ -1041,6 +1028,16 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         return result._convert(datetime=True)
 
     agg = aggregate
+
+    @property
+    def _selection_name(self):
+        """
+        Return a name for myself;
+
+        This would ideally be called the 'name' property,
+        but we cannot conflict with the Series.name property which can be set.
+        """
+        return self._selection
 
     def _iterate_slices(self) -> Iterable[Series]:
         obj = self._selected_obj
@@ -1152,11 +1149,11 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
             # TODO: sure this is right?  we used to do this
             #  after raising AttributeError above
             return self.obj._constructor_sliced(
-                values, index=key_index, name=self._selection_name
+                values, index=key_index, name=self._selection
             )
         elif not isinstance(first_not_none, Series):
             # values are not series or array-like but scalars
-            # self._selection_name not passed through to Series as the
+            # self._selection not passed through to Series as the
             # result should not take the name of original selection
             # of columns
             if self.as_index:

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1052,9 +1052,10 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
             values = reset_identity(values)
             result = concat(values, axis=self.axis)
 
-        if isinstance(result, Series) and self._selection_name is not None:
+        name = self.obj.name if self.obj.ndim == 1 else self._selection
+        if isinstance(result, Series) and name is not None:
 
-            result.name = self._selection_name
+            result.name = name
 
         return result
 


### PR DESCRIPTION
We use self._selected_obj and self._obj_with_exclusions in different places with no clear distinction as to when to use which.  I _think_ in pretty much all cases we really want obj_with_exclusions, am moving towards pinning that down.

The only non-trivial thing here is getting rid of pinning _selection in [here](https://github.com/pandas-dev/pandas/compare/master...jbrockmendel:cln-selection_name?expand=1#diff-f1ec980d06b0b54c8263f663f767636c3f5921f04f8a7ee91dfc71a2100b05cdL326).  We have no tests that reach that.  I can cook up a case that gets there, but haven't found any cases where removing it actually changes anything.