### PR TITLE
BUG: convert dtypes copies column_index names

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6179,7 +6179,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 for col_name, col in self.items()
             ]
             if len(results) > 0:
-                return concat(results, axis=1, copy=False)
+                return concat(results, axis=1, copy=False, names=self.columns.names)
             else:
                 return self.copy()
 

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -498,6 +498,8 @@ class _Concatenator:
                 index, columns = self.new_axes
                 df = cons(data, index=index)
                 df.columns = columns
+                if self.names:
+                    df.columns.names = self.names
                 return df.__finalize__(self, method="concat")
 
         # combine block managers

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -501,3 +501,10 @@ class TestNDFrame:
 
         with tm.assert_produces_warning(FutureWarning):
             obj.slice_shift()
+
+    def test_convert_dtypes_name(self):
+        # GH 41435
+        df = DataFrame({"a": [1, 2], "b": [3, 4]})
+        df.columns.name = "cols"
+        result = df.convert_dtypes()
+        assert result.columns.names == df.columns.names


### PR DESCRIPTION
- [x] closes #41435 
- [x] tests added / passed

tests may be in wrong place.

solution may be the easiest, but it maybe not the best or most robust.
