### PR TITLE
DOC: Improve examples of df.append to better show the ignore_index param

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8812,18 +8812,18 @@ NaN 12.3   33.0
 
         Examples
         --------
-        >>> df = pd.DataFrame([[1, 2], [3, 4]], columns=list('AB'), index=[0, 2])
+        >>> df = pd.DataFrame([[1, 2], [3, 4]], columns=list('AB'), index=['x', 'y'])
         >>> df
            A  B
-        0  1  2
-        2  3  4
-        >>> df2 = pd.DataFrame([[5, 6], [7, 8]], columns=list('AB'), index=[0, 4])
+        x  1  2
+        y  3  4
+        >>> df2 = pd.DataFrame([[5, 6], [7, 8]], columns=list('AB'), index=['x', 'y'])
         >>> df.append(df2)
            A  B
-        0  1  2
-        2  3  4
-        0  5  6
-        4  7  8
+        x  1  2
+        y  3  4
+        x  5  6
+        y  7  8
 
         With `ignore_index` set to True:
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8793,6 +8793,7 @@ NaN 12.3   33.0
         Returns
         -------
         DataFrame
+            A new DataFrame consisting of the rows of caller and the rows of `other`.
 
         See Also
         --------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8816,13 +8816,13 @@ NaN 12.3   33.0
            A  B
         0  1  2
         2  3  4
-        >>> df2 = pd.DataFrame([[5, 6], [7, 8]], columns=list('AB'), index=[0, 2])
+        >>> df2 = pd.DataFrame([[5, 6], [7, 8]], columns=list('AB'), index=[3, 5])
         >>> df.append(df2)
            A  B
         0  1  2
         2  3  4
-        0  5  6
-        2  7  8
+        3  5  6
+        5  7  8
 
         With `ignore_index` set to True:
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8811,12 +8811,12 @@ NaN 12.3   33.0
 
         Examples
         --------
-        >>> df = pd.DataFrame([[1, 2], [3, 4]], columns=list('AB'), index=[0,2])
+        >>> df = pd.DataFrame([[1, 2], [3, 4]], columns=list('AB'), index=[0, 2])
         >>> df
            A  B
         0  1  2
         2  3  4
-        >>> df2 = pd.DataFrame([[5, 6], [7, 8]], columns=list('AB'), index=[0,2])
+        >>> df2 = pd.DataFrame([[5, 6], [7, 8]], columns=list('AB'), index=[0, 2])
         >>> df.append(df2)
            A  B
         0  1  2

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8811,18 +8811,18 @@ NaN 12.3   33.0
 
         Examples
         --------
-        >>> df = pd.DataFrame([[1, 2], [3, 4]], columns=list('AB'))
+        >>> df = pd.DataFrame([[1, 2], [3, 4]], columns=list('AB'), index=[0,2])
         >>> df
            A  B
         0  1  2
-        1  3  4
-        >>> df2 = pd.DataFrame([[5, 6], [7, 8]], columns=list('AB'))
+        2  3  4
+        >>> df2 = pd.DataFrame([[5, 6], [7, 8]], columns=list('AB'), index=[0,2])
         >>> df.append(df2)
            A  B
         0  1  2
-        1  3  4
+        2  3  4
         0  5  6
-        1  7  8
+        2  7  8
 
         With `ignore_index` set to True:
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8816,13 +8816,13 @@ NaN 12.3   33.0
            A  B
         0  1  2
         2  3  4
-        >>> df2 = pd.DataFrame([[5, 6], [7, 8]], columns=list('AB'), index=[3, 5])
+        >>> df2 = pd.DataFrame([[5, 6], [7, 8]], columns=list('AB'), index=[0, 4])
         >>> df.append(df2)
            A  B
         0  1  2
         2  3  4
-        3  5  6
-        5  7  8
+        0  5  6
+        4  7  8
 
         With `ignore_index` set to True:
 


### PR DESCRIPTION
Change index to [0, 2] to stress that ignore_index=True resets the index of both dataframes

- [x] closes #41407 
- [x] tests passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

Test Output: 

```
################################################################################
################################## Validation ##################################
################################################################################

1 Errors found:
	Return value has no description
```

