### PR TITLE
WEB: Fix maintainers grid not displaying correctly (GH41438)

### DIFF
--- a/web/pandas/about/team.md
+++ b/web/pandas/about/team.md
@@ -9,28 +9,26 @@ If you want to support pandas development, you can find information in the [dona
 ## Maintainers
 
 <div class="card-group maintainers">
-    {% for row in maintainers.people | batch(6, "") %}
-            {% for person in row %}
-                {% if person %}
-                    <div class="card">
-                        <img class="card-img-top" alt="" src="{{ person.avatar_url }}"/>
-                        <div class="card-body">
-                            <h6 class="card-title">
-                                {% if person.blog %}
-                                    <a href="{{ person.blog }}">
-                                        {{ person.name or person.login }}
-                                    </a>
-                                {% else %}
-                                    {{ person.name or person.login }}
-                                {% endif %}
-                            </h6>
-                            <p class="card-text small"><a href="{{ person.html_url }}">{{ person.login }}</a></p>
-                        </div>
-                    </div>
-                {% else %}
-                    <div class="card border-0"></div>
-                {% endif %}
-            {% endfor %}
+    {% for person in maintainers.people %}
+        {% if person %}
+            <div class="card">
+                <img class="card-img-top" alt="" src="{{ person.avatar_url }}"/>
+                <div class="card-body">
+                    <h6 class="card-title">
+                        {% if person.blog %}
+                            <a href="{{ person.blog }}">
+                                {{ person.name or person.login }}
+                            </a>
+                        {% else %}
+                            {{ person.name or person.login }}
+                        {% endif %}
+                    </h6>
+                    <p class="card-text small"><a href="{{ person.html_url }}">{{ person.login }}</a></p>
+                </div>
+            </div>
+        {% else %}
+            <div class="card border-0"></div>
+        {% endif %}
     {% endfor %}
 </div>
 

--- a/web/pandas/about/team.md
+++ b/web/pandas/about/team.md
@@ -10,25 +10,21 @@ If you want to support pandas development, you can find information in the [dona
 
 <div class="card-group maintainers">
     {% for person in maintainers.people %}
-        {% if person %}
-            <div class="card">
-                <img class="card-img-top" alt="" src="{{ person.avatar_url }}"/>
-                <div class="card-body">
-                    <h6 class="card-title">
-                        {% if person.blog %}
-                            <a href="{{ person.blog }}">
-                                {{ person.name or person.login }}
-                            </a>
-                        {% else %}
+        <div class="card">
+            <img class="card-img-top" alt="" src="{{ person.avatar_url }}"/>
+            <div class="card-body">
+                <h6 class="card-title">
+                    {% if person.blog %}
+                        <a href="{{ person.blog }}">
                             {{ person.name or person.login }}
-                        {% endif %}
-                    </h6>
-                    <p class="card-text small"><a href="{{ person.html_url }}">{{ person.login }}</a></p>
-                </div>
+                        </a>
+                    {% else %}
+                        {{ person.name or person.login }}
+                    {% endif %}
+                </h6>
+                <p class="card-text small"><a href="{{ person.html_url }}">{{ person.login }}</a></p>
             </div>
-        {% else %}
-            <div class="card border-0"></div>
-        {% endif %}
+        </div>
     {% endfor %}
 </div>
 

--- a/web/pandas/about/team.md
+++ b/web/pandas/about/team.md
@@ -8,9 +8,8 @@ If you want to support pandas development, you can find information in the [dona
 
 ## Maintainers
 
-<div class="row maintainers">
+<div class="card-group maintainers">
     {% for row in maintainers.people | batch(6, "") %}
-        <div class="card-group maintainers">
             {% for person in row %}
                 {% if person %}
                     <div class="card">
@@ -32,7 +31,6 @@ If you want to support pandas development, you can find information in the [dona
                     <div class="card border-0"></div>
                 {% endif %}
             {% endfor %}
-        </div>
     {% endfor %}
 </div>
 

--- a/web/pandas/static/css/pandas.css
+++ b/web/pandas/static/css/pandas.css
@@ -46,7 +46,7 @@ div.card {
     margin: 0 0 .2em .2em !important;
 }
 @media (min-width: 576px) {
-    div.card {
+    .card-group.maintainers div.card {
         min-width: 10rem;
         max-width: 10rem;
     }

--- a/web/pandas/static/css/pandas.css
+++ b/web/pandas/static/css/pandas.css
@@ -45,6 +45,12 @@ a.navbar-brand img {
 div.card {
     margin: 0 0 .2em .2em !important;
 }
+@media (min-width: 576px) {
+    div.card {
+        min-width: 10rem;
+        max-width: 10rem;
+    }
+}
 div.card .card-title {
     font-weight: 500;
     color: #130654;


### PR DESCRIPTION
- [x] closes #41438 
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

Screenshot taken on Google Chrome 90.0.4430.93

![screenshot](https://user-images.githubusercontent.com/18680207/118068760-ef740800-b370-11eb-902d-237da39e2b7f.png)

To reproduce, 
- go to https://pandas.pydata.org/about/team.html
- open developer tools
- go to elements tab
- navigate to <div class="row maintainers">
- edit as HTML
- delete <div class="row maintainers"> and the closing tag at the end
