### PR TITLE
Deprecate inplace=True for reset_index

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -645,6 +645,7 @@ Deprecations
 - The ``inplace`` parameter of :meth:`Categorical.remove_categories`, :meth:`Categorical.add_categories`, :meth:`Categorical.reorder_categories`, :meth:`Categorical.rename_categories`, :meth:`Categorical.set_categories` is deprecated and will be removed in a future version (:issue:`37643`)
 - Deprecated :func:`merge` producing duplicated columns through the ``suffixes`` keyword  and already existing columns (:issue:`22818`)
 - Deprecated setting :attr:`Categorical._codes`, create a new :class:`Categorical` with the desired codes instead (:issue:`40606`)
+- Deprecated ``inplace`` keyword in :meth:`DataFrame.reset_index` (:issue:`16529`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -44,7 +44,10 @@ from pandas._libs import (
     properties,
 )
 from pandas._libs.hashtable import duplicated
-from pandas._libs.lib import no_default
+from pandas._libs.lib import (
+    NoDefault,
+    no_default,
+)
 from pandas._typing import (
     AggFuncType,
     AnyArrayLike,
@@ -5571,7 +5574,7 @@ class DataFrame(NDFrame, OpsMixin):
         self,
         level: Hashable | Sequence[Hashable] | None = None,
         drop: bool = False,
-        inplace: bool = False,
+        inplace: bool | NoDefault = no_default,
         col_level: Hashable = 0,
         col_fill: Hashable = "",
     ) -> DataFrame | None:
@@ -5717,7 +5720,7 @@ class DataFrame(NDFrame, OpsMixin):
         monkey         mammal    NaN    jump
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
-        if inplace:
+        if inplace is not no_default:
             warnings.warn(
                 "'inplace' will be removed in a future version "
                 "and the current default behaviour ('inplace=False') will "
@@ -5725,6 +5728,8 @@ class DataFrame(NDFrame, OpsMixin):
                 DeprecationWarning,
                 stacklevel=2,
             )
+        else:
+            inplace = False
         self._check_inplace_and_allows_duplicate_labels(inplace)
         if inplace:
             new_obj = self

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5717,6 +5717,14 @@ class DataFrame(NDFrame, OpsMixin):
         monkey         mammal    NaN    jump
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
+        if inplace:
+            warnings.warn(
+                "'inplace' will be removed in a future version "
+                "and the current default behaviour ('inplace=False') will "
+                "be used. Set 'inplace=False' to silence this warning.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._check_inplace_and_allows_duplicate_labels(inplace)
         if inplace:
             new_obj = self

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5719,17 +5719,17 @@ class DataFrame(NDFrame, OpsMixin):
         lion           mammal   80.5     run
         monkey         mammal    NaN    jump
         """
-        inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace is not no_default:
             warnings.warn(
                 "'inplace' will be removed in a future version "
                 "and the current default behaviour ('inplace=False') will "
-                "be used. Set 'inplace=False' to silence this warning.",
+                "be used. Remove the 'inplace' argument to silence this warning.",
                 DeprecationWarning,
                 stacklevel=2,
             )
         else:
             inplace = False
+        inplace = validate_bool_kwarg(inplace, "inplace")
         self._check_inplace_and_allows_duplicate_labels(inplace)
         if inplace:
             new_obj = self

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5724,7 +5724,7 @@ class DataFrame(NDFrame, OpsMixin):
                 "'inplace' will be removed in a future version "
                 "and the current default behaviour ('inplace=False') will "
                 "be used. Remove the 'inplace' argument to silence this warning.",
-                DeprecationWarning,
+                FutureWarning,
                 stacklevel=2,
             )
         else:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1847,11 +1847,11 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         if axis == 0:
             # Handle dropping index levels
             if levels_to_drop:
-                dropped.reset_index(levels_to_drop, drop=True, inplace=True)
+                dropped = dropped.reset_index(levels_to_drop, drop=True)
 
             # Handle dropping columns labels
             if labels_to_drop:
-                dropped.drop(labels_to_drop, axis=1, inplace=True)
+                dropped = dropped.drop(labels_to_drop, axis=1)
         else:
             # Handle dropping column levels
             if levels_to_drop:

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -900,7 +900,7 @@ class SQLTable(PandasObject):
             temp = self.frame.copy()
             temp.index.names = self.index
             try:
-                temp.reset_index(inplace=True)
+                temp = temp.reset_index(inplace=False)
             except ValueError as err:
                 raise ValueError(f"duplicate name in index/columns: {err}") from err
         else:

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -900,7 +900,7 @@ class SQLTable(PandasObject):
             temp = self.frame.copy()
             temp.index.names = self.index
             try:
-                temp = temp.reset_index(inplace=False)
+                temp = temp.reset_index()
             except ValueError as err:
                 raise ValueError(f"duplicate name in index/columns: {err}") from err
         else:

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -160,7 +160,13 @@ class TestResetIndex:
         # test resetting in place
         df = float_frame.copy()
         reset = float_frame.reset_index()
-        return_value = df.reset_index(inplace=True)
+        msg = (
+            r"'inplace' will be removed in a future version "
+            r"and the current default behaviour \('inplace=False'\) will "
+            r"be used. Set 'inplace=False' to silence this warning."
+        )
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
+            return_value = df.reset_index(inplace=True)
         assert return_value is None
         tm.assert_frame_equal(df, reset, check_names=False)
 
@@ -179,7 +185,13 @@ class TestResetIndex:
         )
         assert df.reset_index().index.name is None
         assert df.reset_index(drop=True).index.name is None
-        return_value = df.reset_index(inplace=True)
+        msg = (
+            r"'inplace' will be removed in a future version "
+            r"and the current default behaviour \('inplace=False'\) will "
+            r"be used. Set 'inplace=False' to silence this warning."
+        )
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
+            return_value = df.reset_index(inplace=True)
         assert return_value is None
         assert df.index.name is None
 

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -671,3 +671,15 @@ def test_reset_index_multiindex_nat():
         index=pd.DatetimeIndex(["2015-07-01", "2015-07-02", "NaT"], name="tstamp"),
     )
     tm.assert_frame_equal(result, expected)
+
+
+def test_inplace_deprecation_warning():
+    # GH16529
+    df = DataFrame({"a": [1, 2, 3]})
+    msg = (
+        r"'inplace' will be removed in a future version "
+        r"and the current default behaviour \('inplace=False'\) will "
+        r"be used. Set 'inplace=False' to silence this warning."
+    )
+    with tm.assert_produces_warning(DeprecationWarning, match=msg):
+        df.reset_index(inplace=True)

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -685,7 +685,8 @@ def test_reset_index_multiindex_nat():
     tm.assert_frame_equal(result, expected)
 
 
-def test_inplace_deprecation_warning():
+@pytest.mark.parametrize("inplace", [True, False])
+def test_inplace_deprecation_warning(inplace):
     # GH16529
     df = DataFrame({"a": [1, 2, 3]})
     msg = (
@@ -694,4 +695,4 @@ def test_inplace_deprecation_warning():
         r"be used\. Remove the 'inplace' argument to silence this warning\."
     )
     with tm.assert_produces_warning(DeprecationWarning, match=msg):
-        df.reset_index(inplace=True)
+        df.reset_index(inplace=inplace)

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -165,7 +165,7 @@ class TestResetIndex:
             r"and the current default behaviour \('inplace=False'\) will "
             r"be used\. Remove the 'inplace' argument to silence this warning\."
         )
-        with tm.assert_produces_warning(DeprecationWarning, match=msg):
+        with tm.assert_produces_warning(FutureWarning, match=msg):
             return_value = df.reset_index(inplace=True)
         assert return_value is None
         tm.assert_frame_equal(df, reset, check_names=False)
@@ -190,7 +190,7 @@ class TestResetIndex:
             r"and the current default behaviour \('inplace=False'\) will "
             r"be used\. Remove the 'inplace' argument to silence this warning\."
         )
-        with tm.assert_produces_warning(DeprecationWarning, match=msg):
+        with tm.assert_produces_warning(FutureWarning, match=msg):
             return_value = df.reset_index(inplace=True)
         assert return_value is None
         assert df.index.name is None
@@ -694,5 +694,5 @@ def test_inplace_deprecation_warning(inplace):
         r"and the current default behaviour \('inplace=False'\) will "
         r"be used\. Remove the 'inplace' argument to silence this warning\."
     )
-    with tm.assert_produces_warning(DeprecationWarning, match=msg):
+    with tm.assert_produces_warning(FutureWarning, match=msg):
         df.reset_index(inplace=inplace)

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -163,7 +163,7 @@ class TestResetIndex:
         msg = (
             r"'inplace' will be removed in a future version "
             r"and the current default behaviour \('inplace=False'\) will "
-            r"be used\. Set 'inplace=False' to silence this warning\."
+            r"be used\. Remove the 'inplace' argument to silence this warning\."
         )
         with tm.assert_produces_warning(DeprecationWarning, match=msg):
             return_value = df.reset_index(inplace=True)
@@ -188,7 +188,7 @@ class TestResetIndex:
         msg = (
             r"'inplace' will be removed in a future version "
             r"and the current default behaviour \('inplace=False'\) will "
-            r"be used\. Set 'inplace=False' to silence this warning\."
+            r"be used\. Remove the 'inplace' argument to silence this warning\."
         )
         with tm.assert_produces_warning(DeprecationWarning, match=msg):
             return_value = df.reset_index(inplace=True)
@@ -691,7 +691,7 @@ def test_inplace_deprecation_warning():
     msg = (
         r"'inplace' will be removed in a future version "
         r"and the current default behaviour \('inplace=False'\) will "
-        r"be used\. Set 'inplace=False' to silence this warning\."
+        r"be used\. Remove the 'inplace' argument to silence this warning\."
     )
     with tm.assert_produces_warning(DeprecationWarning, match=msg):
         df.reset_index(inplace=True)

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -163,7 +163,7 @@ class TestResetIndex:
         msg = (
             r"'inplace' will be removed in a future version "
             r"and the current default behaviour \('inplace=False'\) will "
-            r"be used. Set 'inplace=False' to silence this warning."
+            r"be used\. Set 'inplace=False' to silence this warning\."
         )
         with tm.assert_produces_warning(DeprecationWarning, match=msg):
             return_value = df.reset_index(inplace=True)
@@ -188,7 +188,7 @@ class TestResetIndex:
         msg = (
             r"'inplace' will be removed in a future version "
             r"and the current default behaviour \('inplace=False'\) will "
-            r"be used. Set 'inplace=False' to silence this warning."
+            r"be used\. Set 'inplace=False' to silence this warning\."
         )
         with tm.assert_produces_warning(DeprecationWarning, match=msg):
             return_value = df.reset_index(inplace=True)
@@ -691,7 +691,7 @@ def test_inplace_deprecation_warning():
     msg = (
         r"'inplace' will be removed in a future version "
         r"and the current default behaviour \('inplace=False'\) will "
-        r"be used. Set 'inplace=False' to silence this warning."
+        r"be used\. Set 'inplace=False' to silence this warning\."
     )
     with tm.assert_produces_warning(DeprecationWarning, match=msg):
         df.reset_index(inplace=True)

--- a/pandas/tests/frame/methods/test_to_csv.py
+++ b/pandas/tests/frame/methods/test_to_csv.py
@@ -538,7 +538,7 @@ class TestDataFrameToCSV:
             msg = (
                 r"'inplace' will be removed in a future version "
                 r"and the current default behaviour \('inplace=False'\) will "
-                r"be used\. Set 'inplace=False' to silence this warning\."
+                r"be used\. Remove the 'inplace' argument to silence this warning\."
             )
             with tm.assert_produces_warning(DeprecationWarning, match=msg):
                 return_value = recons.reset_index(inplace=True)

--- a/pandas/tests/frame/methods/test_to_csv.py
+++ b/pandas/tests/frame/methods/test_to_csv.py
@@ -540,7 +540,7 @@ class TestDataFrameToCSV:
                 r"and the current default behaviour \('inplace=False'\) will "
                 r"be used\. Remove the 'inplace' argument to silence this warning\."
             )
-            with tm.assert_produces_warning(DeprecationWarning, match=msg):
+            with tm.assert_produces_warning(FutureWarning, match=msg):
                 return_value = recons.reset_index(inplace=True)
             assert return_value is None
             tm.assert_frame_equal(to_df, recons)

--- a/pandas/tests/frame/methods/test_to_csv.py
+++ b/pandas/tests/frame/methods/test_to_csv.py
@@ -535,7 +535,13 @@ class TestDataFrameToCSV:
             from_df.to_csv(path, index=False, header=["X", "Y"])
             recons = self.read_csv(path)
 
-            return_value = recons.reset_index(inplace=True)
+            msg = (
+                r"'inplace' will be removed in a future version "
+                r"and the current default behaviour \('inplace=False'\) will "
+                r"be used\. Set 'inplace=False' to silence this warning\."
+            )
+            with tm.assert_produces_warning(DeprecationWarning, match=msg):
+                return_value = recons.reset_index(inplace=True)
             assert return_value is None
             tm.assert_frame_equal(to_df, recons)
 

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -226,7 +226,7 @@ class TestDataFrameMisc:
         msg = (
             r"'inplace' will be removed in a future version "
             r"and the current default behaviour \('inplace=False'\) will "
-            r"be used\. Set 'inplace=False' to silence this warning\."
+            r"be used\. Remove the 'inplace' argument to silence this warning\."
         )
         with tm.assert_produces_warning(DeprecationWarning, match=msg):
             _check_f(data.set_index("a"), f)

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -259,6 +259,7 @@ class TestDataFrameMisc:
         d = data.copy()["c"]
 
         # reset_index
+        f = lambda x: x.reset_index(inplace=True, drop=True)
         _check_f(data.set_index("a")["c"], f)
 
         # fillna

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -223,7 +223,13 @@ class TestDataFrameMisc:
 
         # reset_index
         f = lambda x: x.reset_index(inplace=True)
-        _check_f(data.set_index("a"), f)
+        msg = (
+            r"'inplace' will be removed in a future version "
+            r"and the current default behaviour \('inplace=False'\) will "
+            r"be used\. Set 'inplace=False' to silence this warning\."
+        )
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
+            _check_f(data.set_index("a"), f)
 
         # drop_duplicates
         f = lambda x: x.drop_duplicates(inplace=True)
@@ -253,7 +259,6 @@ class TestDataFrameMisc:
         d = data.copy()["c"]
 
         # reset_index
-        f = lambda x: x.reset_index(inplace=True, drop=True)
         _check_f(data.set_index("a")["c"], f)
 
         # fillna

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -228,7 +228,7 @@ class TestDataFrameMisc:
             r"and the current default behaviour \('inplace=False'\) will "
             r"be used\. Remove the 'inplace' argument to silence this warning\."
         )
-        with tm.assert_produces_warning(DeprecationWarning, match=msg):
+        with tm.assert_produces_warning(FutureWarning, match=msg):
             _check_f(data.set_index("a"), f)
 
         # drop_duplicates

--- a/pandas/tests/frame/test_validate.py
+++ b/pandas/tests/frame/test_validate.py
@@ -1,5 +1,6 @@
 import pytest
 
+import pandas._testing as tm
 from pandas.core.frame import DataFrame
 
 
@@ -17,7 +18,6 @@ class TestDataFrameValidate:
             "query",
             "eval",
             "set_index",
-            "reset_index",
             "dropna",
             "drop_duplicates",
             "sort_values",
@@ -38,4 +38,27 @@ class TestDataFrameValidate:
             kwargs["by"] = ["a"]
 
         with pytest.raises(ValueError, match=msg):
+            getattr(dataframe, func)(**kwargs)
+
+    @pytest.mark.parametrize(
+        "func",
+        [
+            "reset_index",
+        ],
+    )
+    @pytest.mark.parametrize("inplace", [1, "True", [1, 2, 3], 5.0])
+    def test_validate_bool_args_with_deprecation_warning(
+        self, dataframe, func, inplace
+    ):
+        # GH16529
+        msg = 'For argument "inplace" expected type bool'
+        kwargs = {"inplace": inplace}
+
+        warning_msg = (
+            r"'inplace' will be removed in a future version "
+            r"and the current default behaviour \('inplace=False'\) will "
+            r"be used\. Remove the 'inplace' argument to silence this warning\."
+        )
+        warning_ctx = tm.assert_produces_warning(DeprecationWarning, match=warning_msg)
+        with pytest.raises(ValueError, match=msg), warning_ctx:
             getattr(dataframe, func)(**kwargs)

--- a/pandas/tests/frame/test_validate.py
+++ b/pandas/tests/frame/test_validate.py
@@ -59,6 +59,6 @@ class TestDataFrameValidate:
             r"and the current default behaviour \('inplace=False'\) will "
             r"be used\. Remove the 'inplace' argument to silence this warning\."
         )
-        warning_ctx = tm.assert_produces_warning(DeprecationWarning, match=warning_msg)
+        warning_ctx = tm.assert_produces_warning(FutureWarning, match=warning_msg)
         with pytest.raises(ValueError, match=msg), warning_ctx:
             getattr(dataframe, func)(**kwargs)

--- a/pandas/tests/frame/test_validate.py
+++ b/pandas/tests/frame/test_validate.py
@@ -46,7 +46,7 @@ class TestDataFrameValidate:
             "reset_index",
         ],
     )
-    @pytest.mark.parametrize("inplace", [1, "True", [1, 2, 3], 5.0])
+    @pytest.mark.parametrize("inplace", [1, "True", "False", [1, 2, 3], 5.0])
     def test_validate_bool_args_with_deprecation_warning(
         self, dataframe, func, inplace
     ):

--- a/pandas/tests/generic/test_duplicate_labels.py
+++ b/pandas/tests/generic/test_duplicate_labels.py
@@ -466,11 +466,10 @@ def test_inplace_raises_with_deprecation_warning(method, frame_only):
         r"be used\. Set 'inplace=False' to silence this warning\."
     )
     warning_ctx = tm.assert_produces_warning(DeprecationWarning, match=warning_msg)
-    error_ctx = pytest.raises(ValueError, match=error_msg)  # noqa: PDF010
-    with error_ctx, warning_ctx:
+    with pytest.raises(ValueError, match=error_msg), warning_ctx:
         method(df)
     if not frame_only:
-        with error_ctx, warning_ctx:
+        with pytest.raises(ValueError, match=error_msg), warning_ctx:
             method(s)
 
 

--- a/pandas/tests/generic/test_duplicate_labels.py
+++ b/pandas/tests/generic/test_duplicate_labels.py
@@ -463,7 +463,7 @@ def test_inplace_raises_with_deprecation_warning(method, frame_only):
     warning_msg = (
         r"'inplace' will be removed in a future version "
         r"and the current default behaviour \('inplace=False'\) will "
-        r"be used\. Set 'inplace=False' to silence this warning\."
+        r"be used\. Remove the 'inplace' argument to silence this warning\."
     )
     warning_ctx = tm.assert_produces_warning(DeprecationWarning, match=warning_msg)
     with pytest.raises(ValueError, match=error_msg), warning_ctx:

--- a/pandas/tests/generic/test_duplicate_labels.py
+++ b/pandas/tests/generic/test_duplicate_labels.py
@@ -465,7 +465,7 @@ def test_inplace_raises_with_deprecation_warning(method, frame_only):
         r"and the current default behaviour \('inplace=False'\) will "
         r"be used\. Remove the 'inplace' argument to silence this warning\."
     )
-    warning_ctx = tm.assert_produces_warning(DeprecationWarning, match=warning_msg)
+    warning_ctx = tm.assert_produces_warning(FutureWarning, match=warning_msg)
     with pytest.raises(ValueError, match=error_msg), warning_ctx:
         method(df)
     if not frame_only:

--- a/pandas/tests/io/sas/test_sas7bdat.py
+++ b/pandas/tests/io/sas/test_sas7bdat.py
@@ -306,7 +306,7 @@ def test_max_sas_date_iterator(datapath):
         msg = (
             r"'inplace' will be removed in a future version "
             r"and the current default behaviour \('inplace=False'\) will "
-            r"be used\. Set 'inplace=False' to silence this warning\."
+            r"be used\. Remove the 'inplace' argument to silence this warning\."
         )
         with tm.assert_produces_warning(DeprecationWarning, match=msg):
             df.reset_index(inplace=True, drop=True)

--- a/pandas/tests/io/sas/test_sas7bdat.py
+++ b/pandas/tests/io/sas/test_sas7bdat.py
@@ -303,7 +303,13 @@ def test_max_sas_date_iterator(datapath):
             df = df.applymap(round_datetime_to_ms)
         except AttributeError:
             df["dt_as_dt"] = df["dt_as_dt"].apply(round_datetime_to_ms)
-        df.reset_index(inplace=True, drop=True)
+        msg = (
+            r"'inplace' will be removed in a future version "
+            r"and the current default behaviour \('inplace=False'\) will "
+            r"be used\. Set 'inplace=False' to silence this warning\."
+        )
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
+            df.reset_index(inplace=True, drop=True)
         results.append(df)
     expected = [
         pd.DataFrame(

--- a/pandas/tests/io/sas/test_sas7bdat.py
+++ b/pandas/tests/io/sas/test_sas7bdat.py
@@ -308,7 +308,7 @@ def test_max_sas_date_iterator(datapath):
             r"and the current default behaviour \('inplace=False'\) will "
             r"be used\. Remove the 'inplace' argument to silence this warning\."
         )
-        with tm.assert_produces_warning(DeprecationWarning, match=msg):
+        with tm.assert_produces_warning(FutureWarning, match=msg):
             df.reset_index(inplace=True, drop=True)
         results.append(df)
     expected = [


### PR DESCRIPTION
- [ ] xref #16529
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

Per the discussion yesterday, I just wanted to clarify that putting in a deprecation warning (such as thing one) in v1.3.0 gives enough time to remove `inplace` in v2.0.0 if, as is likely, there is not another minor version between v1.3.0 and v2.0.0. Will it be OK to change it to a `FutureWarning` in a patch release of v1.3?

If this is OK, then I'm running a little sprint on Saturday for PyLadiesLondon, and putting in more of these warning will make for a good sprint issue