### PR TITLE
[ArrowStringArray] PERF: Series.str.get_dummies

### DIFF
--- a/asv_bench/benchmarks/strings.py
+++ b/asv_bench/benchmarks/strings.py
@@ -249,10 +249,18 @@ class Split:
 
 
 class Dummies:
-    def setup(self):
-        self.s = Series(tm.makeStringIndex(10 ** 5)).str.join("|")
+    params = ["str", "string", "arrow_string"]
+    param_names = ["dtype"]
 
-    def time_get_dummies(self):
+    def setup(self, dtype):
+        from pandas.core.arrays.string_arrow import ArrowStringDtype  # noqa: F401
+
+        try:
+            self.s = Series(tm.makeStringIndex(10 ** 5), dtype=dtype).str.join("|")
+        except ImportError:
+            raise NotImplementedError
+
+    def time_get_dummies(self, dtype):
         self.s.str.get_dummies("|")
 
 

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -24,6 +24,7 @@ from pandas.core.dtypes.common import (
     is_categorical_dtype,
     is_integer,
     is_list_like,
+    is_object_dtype,
     is_re,
 )
 from pandas.core.dtypes.generic import (
@@ -265,7 +266,11 @@ class StringMethods(NoNewAttributesMixin):
             # infer from ndim if expand is not specified
             expand = result.ndim != 1
 
-        elif expand is True and not isinstance(self._orig, ABCIndex):
+        elif (
+            expand is True
+            and is_object_dtype(result)
+            and not isinstance(self._orig, ABCIndex)
+        ):
             # required when expand=True is explicitly specified
             # not needed when inferred
 

--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -301,17 +301,19 @@ def test_isnumeric(any_string_dtype):
     tm.assert_series_equal(s.str.isdecimal(), Series(decimal_e, dtype=dtype))
 
 
-def test_get_dummies():
-    s = Series(["a|b", "a|c", np.nan])
+def test_get_dummies(any_string_dtype):
+    s = Series(["a|b", "a|c", np.nan], dtype=any_string_dtype)
     result = s.str.get_dummies("|")
     expected = DataFrame([[1, 1, 0], [1, 0, 1], [0, 0, 0]], columns=list("abc"))
     tm.assert_frame_equal(result, expected)
 
-    s = Series(["a;b", "a", 7])
+    s = Series(["a;b", "a", 7], dtype=any_string_dtype)
     result = s.str.get_dummies(";")
     expected = DataFrame([[0, 1, 1], [0, 1, 0], [1, 0, 0]], columns=list("7ab"))
     tm.assert_frame_equal(result, expected)
 
+
+def test_get_dummies_index():
     # GH9980, GH8028
     idx = Index(["a|b", "a|c", "b|c"])
     result = idx.str.get_dummies("|")
@@ -322,14 +324,18 @@ def test_get_dummies():
     tm.assert_index_equal(result, expected)
 
 
-def test_get_dummies_with_name_dummy():
+def test_get_dummies_with_name_dummy(any_string_dtype):
     # GH 12180
     # Dummies named 'name' should work as expected
-    s = Series(["a", "b,name", "b"])
+    s = Series(["a", "b,name", "b"], dtype=any_string_dtype)
     result = s.str.get_dummies(",")
     expected = DataFrame([[1, 0, 0], [0, 1, 1], [0, 1, 0]], columns=["a", "b", "name"])
     tm.assert_frame_equal(result, expected)
 
+
+def test_get_dummies_with_name_dummy_index():
+    # GH 12180
+    # Dummies named 'name' should work as expected
     idx = Index(["a|b", "name|c", "b|name"])
     result = idx.str.get_dummies("|")
 


### PR DESCRIPTION
planning to remove the padding code from _wrap_result eventually, but until then we can skip it when we return a integer array from get_dummies

adding tests and benchmarks as precursor to potential changes to _wrap_result  #41372

have a working implementation for ArrowStringArray using pyarrow native functions but is slower than object fallback, so am leaving that for a followup.

```
       before           after         ratio
     [4ec6925c]       [091b0b02]
     <master>         <get_dummies>
-      2.58±0.02s         655±10ms     0.25  strings.Dummies.time_get_dummies('arrow_string')
-      2.58±0.03s          643±9ms     0.25  strings.Dummies.time_get_dummies('string')
-      2.59±0.07s          638±7ms     0.25  strings.Dummies.time_get_dummies('str')

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```
