### PR TITLE
CI: Fix changed flake8 error message after upgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         exclude: ^pandas/_libs/src/(klib|headers)/
         args: [--quiet, '--extensions=c,h', '--headers=h', --recursive, '--filter=-readability/casting,-runtime/int,-build/include_subdir']
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.1
+    rev: 3.9.2
     hooks:
     -   id: flake8
         additional_dependencies:
@@ -75,7 +75,7 @@ repos:
     hooks:
     -   id: yesqa
         additional_dependencies:
-            - flake8==3.9.1
+            - flake8==3.9.2
             - flake8-comprehensions==3.1.0
             - flake8-bugbear==21.3.2
             - pandas-dev-flaker==0.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   # code checks
   - black=20.8b1
   - cpplint
-  - flake8=3.9.1
+  - flake8=3.9.2
   - flake8-bugbear=21.3.2  # used by flake8, find likely bugs
   - flake8-comprehensions=3.1.0  # used by flake8, linting of unnecessary comprehensions
   - isort>=5.2.1  # check that imports are in the right order

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ asv
 cython>=0.29.21
 black==20.8b1
 cpplint
-flake8==3.9.1
+flake8==3.9.2
 flake8-bugbear==21.3.2
 flake8-comprehensions==3.1.0
 isort>=5.2.1

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -165,7 +165,7 @@ class TestValidator:
                 "indentation_is_not_a_multiple_of_four",
                 # with flake8 3.9.0, the message ends with four spaces,
                 #  whereas in earlier versions, it ended with "four"
-                ("flake8 error: E111 indentation is not a multiple of     ",),
+                ("flake8 error: E111 indentation is not a multiple of 4",),
             ),
             (
                 "BadDocstrings",


### PR DESCRIPTION
Upgrade caused ci on 1.2.x to fail. Should backport probably