### PR TITLE
REF: collect methods in NumericIndex

### DIFF
--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -231,8 +231,7 @@ class NumericIndex(Index):
 
     @doc(Index._should_fallback_to_positional)
     def _should_fallback_to_positional(self) -> bool:
-        if self.inferred_type == "floating":
-            return False
+        return False
 
     @doc(Index._convert_slice_indexer)
     def _convert_slice_indexer(self, key: slice, kind: str):

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -296,7 +296,7 @@ class NumericIndex(Index):
         return is_numeric_dtype(dtype)
 
     @classmethod
-    def _assert_safe_casting(cls, data, subarr) -> None:
+    def _assert_safe_casting(cls, data: np.ndarray, subarr: np.ndarray) -> None:
         """
         Ensure incoming data can be represented with matching signed-ness.
 

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -16,7 +16,10 @@ from pandas._typing import (
     Dtype,
     DtypeObj,
 )
-from pandas.util._decorators import doc
+from pandas.util._decorators import (
+    cache_readonly,
+    doc,
+)
 
 from pandas.core.dtypes.cast import astype_nansafe
 from pandas.core.dtypes.common import (
@@ -41,129 +44,6 @@ from pandas.core.indexes.base import (
 )
 
 _num_index_shared_docs = {}
-
-
-class NumericIndex(Index):
-    """
-    Provide numeric type operations.
-
-    This is an abstract class.
-    """
-
-    _values: np.ndarray
-    _default_dtype: np.dtype
-    _dtype_validation_metadata: tuple[Callable[..., bool], str]
-
-    _is_numeric_dtype = True
-    _can_hold_strings = False
-
-    def __new__(cls, data=None, dtype: Dtype | None = None, copy=False, name=None):
-        name = maybe_extract_name(name, data, cls)
-
-        subarr = cls._ensure_array(data, dtype, copy)
-        return cls._simple_new(subarr, name=name)
-
-    @classmethod
-    def _ensure_array(cls, data, dtype, copy: bool):
-        """
-        Ensure we have a valid array to pass to _simple_new.
-        """
-        cls._validate_dtype(dtype)
-
-        if not isinstance(data, (np.ndarray, Index)):
-            # Coerce to ndarray if not already ndarray or Index
-            if is_scalar(data):
-                raise cls._scalar_data_error(data)
-
-            # other iterable of some kind
-            if not isinstance(data, (ABCSeries, list, tuple)):
-                data = list(data)
-
-            data = np.asarray(data, dtype=dtype)
-
-        if issubclass(data.dtype.type, str):
-            cls._string_data_error(data)
-
-        if copy or not is_dtype_equal(data.dtype, cls._default_dtype):
-            subarr = np.array(data, dtype=cls._default_dtype, copy=copy)
-            cls._assert_safe_casting(data, subarr)
-        else:
-            subarr = data
-
-        if subarr.ndim > 1:
-            # GH#13601, GH#20285, GH#27125
-            raise ValueError("Index data must be 1-dimensional")
-
-        subarr = np.asarray(subarr)
-        return subarr
-
-    @classmethod
-    def _validate_dtype(cls, dtype: Dtype | None) -> None:
-        if dtype is None:
-            return
-
-        validation_func, expected = cls._dtype_validation_metadata
-        if not validation_func(dtype):
-            raise ValueError(
-                f"Incorrect `dtype` passed: expected {expected}, received {dtype}"
-            )
-
-    # ----------------------------------------------------------------
-    # Indexing Methods
-
-    @doc(Index._maybe_cast_slice_bound)
-    def _maybe_cast_slice_bound(self, label, side: str, kind=lib.no_default):
-        assert kind in ["loc", "getitem", None, lib.no_default]
-        self._deprecated_arg(kind, "kind", "_maybe_cast_slice_bound")
-
-        # we will try to coerce to integers
-        return self._maybe_cast_indexer(label)
-
-    # ----------------------------------------------------------------
-
-    @doc(Index._shallow_copy)
-    def _shallow_copy(self, values, name: Hashable = lib.no_default):
-        if not self._can_hold_na and values.dtype.kind == "f":
-            name = self._name if name is lib.no_default else name
-            # Ensure we are not returning an Int64Index with float data:
-            return Float64Index._simple_new(values, name=name)
-        return super()._shallow_copy(values=values, name=name)
-
-    def _convert_tolerance(self, tolerance, target):
-        tolerance = super()._convert_tolerance(tolerance, target)
-
-        if not np.issubdtype(tolerance.dtype, np.number):
-            if tolerance.ndim > 0:
-                raise ValueError(
-                    f"tolerance argument for {type(self).__name__} must contain "
-                    "numeric elements if it is list type"
-                )
-            else:
-                raise ValueError(
-                    f"tolerance argument for {type(self).__name__} must be numeric "
-                    f"if it is a scalar: {repr(tolerance)}"
-                )
-        return tolerance
-
-    def _is_comparable_dtype(self, dtype: DtypeObj) -> bool:
-        # If we ever have BoolIndex or ComplexIndex, this may need to be tightened
-        return is_numeric_dtype(dtype)
-
-    @classmethod
-    def _assert_safe_casting(cls, data, subarr):
-        """
-        Subclasses need to override this only if the process of casting data
-        from some accepted dtype to the internal dtype(s) bears the risk of
-        truncation (e.g. float to int).
-        """
-        pass
-
-    @property
-    def _is_all_dates(self) -> bool:
-        """
-        Checks that all the labels are datetime objects.
-        """
-        return False
 
 
 _num_index_shared_docs[
@@ -199,35 +79,127 @@ _num_index_shared_docs[
     An Index instance can **only** contain hashable objects.
 """
 
-_int64_descr_args = {
-    "klass": "Int64Index",
-    "ltype": "integer",
-    "dtype": "int64",
+
+_numeric_index_descr_args = {
+    "klass": "NumericIndex",
+    "ltype": "integer or float",
+    "dtype": "inferred",
     "extra": "",
 }
 
 
-class IntegerIndex(NumericIndex):
+class NumericIndex(Index):
     """
-    This is an abstract class for Int64Index, UInt64Index.
+    Provide numeric type operations.
+
+    This is an abstract class.
     """
 
+    _values: np.ndarray
     _default_dtype: np.dtype
-    _can_hold_na = False
+    _dtype_validation_metadata: tuple[Callable[..., bool], str]
+
+    _is_numeric_dtype = True
+    _can_hold_strings = False
+
+    @cache_readonly
+    def _can_hold_na(self) -> bool:
+        if is_float_dtype(self.dtype):
+            return True
+        else:
+            return False
+
+    @property
+    def _engine_type(self):
+        return {
+            np.int8: libindex.Int8Engine,
+            np.int16: libindex.Int16Engine,
+            np.int32: libindex.Int32Engine,
+            np.int64: libindex.Int64Engine,
+            np.uint8: libindex.UInt8Engine,
+            np.uint16: libindex.UInt16Engine,
+            np.uint32: libindex.UInt32Engine,
+            np.uint64: libindex.UInt64Engine,
+            np.float32: libindex.Float32Engine,
+            np.float64: libindex.Float64Engine,
+        }[self.dtype.type]
+
+    @property
+    def inferred_type(self) -> str:
+        return {
+            "i": "integer",
+            "u": "integer",
+            "f": "floating",
+        }[self.dtype.kind]
+
+    def __new__(cls, data=None, dtype: Dtype | None = None, copy=False, name=None):
+        name = maybe_extract_name(name, data, cls)
+
+        subarr = cls._ensure_array(data, dtype, copy)
+        return cls._simple_new(subarr, name=name)
 
     @classmethod
-    def _assert_safe_casting(cls, data, subarr):
+    def _ensure_array(cls, data, dtype, copy: bool):
         """
-        Ensure incoming data can be represented with matching signed-ness.
+        Ensure we have a valid array to pass to _simple_new.
         """
-        if data.dtype.kind != cls._default_dtype.kind:
-            if not np.array_equal(data, subarr):
-                raise TypeError("Unsafe NumPy casting, you must explicitly cast")
+        cls._validate_dtype(dtype)
+
+        if not isinstance(data, (np.ndarray, Index)):
+            # Coerce to ndarray if not already ndarray or Index
+            if is_scalar(data):
+                raise cls._scalar_data_error(data)
+
+            # other iterable of some kind
+            if not isinstance(data, (ABCSeries, list, tuple)):
+                data = list(data)
+
+            data = np.asarray(data, dtype=dtype)
+
+        if issubclass(data.dtype.type, str):
+            cls._string_data_error(data)
+
+        dtype = cls._ensure_dtype(dtype)
+
+        if copy or not is_dtype_equal(data.dtype, dtype):
+            subarr = np.array(data, dtype=dtype, copy=copy)
+            cls._assert_safe_casting(data, subarr)
+        else:
+            subarr = data
+
+        if subarr.ndim > 1:
+            # GH#13601, GH#20285, GH#27125
+            raise ValueError("Index data must be 1-dimensional")
+
+        subarr = np.asarray(subarr)
+        return subarr
+
+    @classmethod
+    def _validate_dtype(cls, dtype: Dtype | None) -> None:
+        if dtype is None:
+            return
+
+        validation_func, expected = cls._dtype_validation_metadata
+        if not validation_func(dtype):
+            raise ValueError(
+                f"Incorrect `dtype` passed: expected {expected}, received {dtype}"
+            )
+
+    @classmethod
+    def _ensure_dtype(
+        cls,
+        dtype: Dtype | None,
+    ) -> np.dtype | None:
+        """Ensure int64 dtype for Int64Index, etc. Assumed dtype is validated."""
+        return cls._default_dtype
 
     def __contains__(self, key) -> bool:
         """
         Check if key is a float and has a decimal. If it has, return False.
         """
+        if not is_integer_dtype(self.dtype):
+            return super().__contains__(key)
+
         hash(key)
         try:
             if is_float(key) and int(key) != key:
@@ -237,12 +209,143 @@ class IntegerIndex(NumericIndex):
         except (OverflowError, TypeError, ValueError):
             return False
 
+    @doc(Index.astype)
+    def astype(self, dtype, copy=True):
+        if is_float_dtype(self.dtype):
+            dtype = pandas_dtype(dtype)
+            if needs_i8_conversion(dtype):
+                raise TypeError(
+                    f"Cannot convert Float64Index to dtype {dtype}; integer "
+                    "values are required for conversion"
+                )
+            elif is_integer_dtype(dtype) and not is_extension_array_dtype(dtype):
+                # TODO(jreback); this can change once we have an EA Index type
+                # GH 13149
+                arr = astype_nansafe(self._values, dtype=dtype)
+                return Int64Index(arr, name=self.name)
+
+        return super().astype(dtype, copy=copy)
+
+    # ----------------------------------------------------------------
+    # Indexing Methods
+
+    @doc(Index._should_fallback_to_positional)
+    def _should_fallback_to_positional(self) -> bool:
+        if self.inferred_type == "floating":
+            return False
+
+    @doc(Index._convert_slice_indexer)
+    def _convert_slice_indexer(self, key: slice, kind: str):
+        if is_float_dtype(self.dtype):
+            assert kind in ["loc", "getitem"]
+
+            # We always treat __getitem__ slicing as label-based
+            # translate to locations
+            return self.slice_indexer(key.start, key.stop, key.step, kind=kind)
+
+        return super()._convert_slice_indexer(key, kind=kind)
+
+    @doc(Index._maybe_cast_slice_bound)
+    def _maybe_cast_slice_bound(self, label, side: str, kind=lib.no_default):
+        assert kind in ["loc", "getitem", None, lib.no_default]
+        self._deprecated_arg(kind, "kind", "_maybe_cast_slice_bound")
+
+        # we will try to coerce to integers
+        return self._maybe_cast_indexer(label)
+
+    @doc(Index._convert_arr_indexer)
+    def _convert_arr_indexer(self, keyarr) -> np.ndarray:
+        if not is_unsigned_integer_dtype(self.dtype):
+            return super()._convert_arr_indexer(keyarr)
+
+        # Cast the indexer to uint64 if possible so that the values returned
+        # from indexing are also uint64.
+        dtype = None
+        if is_integer_dtype(keyarr) or (
+            lib.infer_dtype(keyarr, skipna=False) == "integer"
+        ):
+            dtype = np.dtype(np.uint64)
+
+        return com.asarray_tuplesafe(keyarr, dtype=dtype)
+
+    # ----------------------------------------------------------------
+
+    @doc(Index._shallow_copy)
+    def _shallow_copy(self, values, name: Hashable = lib.no_default):
+        if not self._can_hold_na and values.dtype.kind == "f":
+            name = self._name if name is lib.no_default else name
+            # Ensure we are not returning an Int64Index with float data:
+            return Float64Index._simple_new(values, name=name)
+        return super()._shallow_copy(values=values, name=name)
+
+    def _convert_tolerance(self, tolerance, target):
+        tolerance = super()._convert_tolerance(tolerance, target)
+
+        if not np.issubdtype(tolerance.dtype, np.number):
+            if tolerance.ndim > 0:
+                raise ValueError(
+                    f"tolerance argument for {type(self).__name__} must contain "
+                    "numeric elements if it is list type"
+                )
+            else:
+                raise ValueError(
+                    f"tolerance argument for {type(self).__name__} must be numeric "
+                    f"if it is a scalar: {repr(tolerance)}"
+                )
+        return tolerance
+
+    def _is_comparable_dtype(self, dtype: DtypeObj) -> bool:
+        # If we ever have BoolIndex or ComplexIndex, this may need to be tightened
+        return is_numeric_dtype(dtype)
+
+    @classmethod
+    def _assert_safe_casting(cls, data, subarr) -> None:
+        """
+        Ensure incoming data can be represented with matching signed-ness.
+
+        Needed if the process of casting data from some accepted dtype to the internal
+        dtype(s) bears the risk of truncation (e.g. float to int).
+        """
+        if is_integer_dtype(subarr.dtype):
+            if not np.array_equal(data, subarr):
+                raise TypeError("Unsafe NumPy casting, you must explicitly cast")
+
     @property
-    def inferred_type(self) -> str:
+    def _is_all_dates(self) -> bool:
         """
-        Always 'integer' for ``Int64Index`` and ``UInt64Index``
+        Checks that all the labels are datetime objects.
         """
-        return "integer"
+        return False
+
+    def _format_native_types(
+        self, na_rep="", float_format=None, decimal=".", quoting=None, **kwargs
+    ):
+        from pandas.io.formats.format import FloatArrayFormatter
+
+        if is_float_dtype(self.dtype):
+            formatter = FloatArrayFormatter(
+                self._values,
+                na_rep=na_rep,
+                float_format=float_format,
+                decimal=decimal,
+                quoting=quoting,
+                fixed_width=False,
+            )
+            return formatter.get_result_as_array()
+
+        return super()._format_native_types(
+            na_rep=na_rep,
+            float_format=float_format,
+            decimal=decimal,
+            quoting=quoting,
+            **kwargs,
+        )
+
+
+class IntegerIndex(NumericIndex):
+    """
+    This is an abstract class for Int64Index, UInt64Index.
+    """
 
     @property
     def asi8(self) -> np.ndarray:
@@ -253,6 +356,14 @@ class IntegerIndex(NumericIndex):
             stacklevel=2,
         )
         return self._values.view(self._default_dtype)
+
+
+_int64_descr_args = {
+    "klass": "Int64Index",
+    "ltype": "integer",
+    "dtype": "int64",
+    "extra": "",
+}
 
 
 class Int64Index(IntegerIndex):
@@ -280,21 +391,6 @@ class UInt64Index(IntegerIndex):
     _default_dtype = np.dtype(np.uint64)
     _dtype_validation_metadata = (is_unsigned_integer_dtype, "unsigned integer")
 
-    # ----------------------------------------------------------------
-    # Indexing Methods
-
-    @doc(Index._convert_arr_indexer)
-    def _convert_arr_indexer(self, keyarr):
-        # Cast the indexer to uint64 if possible so that the values returned
-        # from indexing are also uint64.
-        dtype = None
-        if is_integer_dtype(keyarr) or (
-            lib.infer_dtype(keyarr, skipna=False) == "integer"
-        ):
-            dtype = np.dtype(np.uint64)
-
-        return com.asarray_tuplesafe(keyarr, dtype=dtype)
-
 
 _float64_descr_args = {
     "klass": "Float64Index",
@@ -311,57 +407,3 @@ class Float64Index(NumericIndex):
     _engine_type = libindex.Float64Engine
     _default_dtype = np.dtype(np.float64)
     _dtype_validation_metadata = (is_float_dtype, "float")
-
-    @property
-    def inferred_type(self) -> str:
-        """
-        Always 'floating' for ``Float64Index``
-        """
-        return "floating"
-
-    @doc(Index.astype)
-    def astype(self, dtype, copy=True):
-        dtype = pandas_dtype(dtype)
-        if needs_i8_conversion(dtype):
-            raise TypeError(
-                f"Cannot convert Float64Index to dtype {dtype}; integer "
-                "values are required for conversion"
-            )
-        elif is_integer_dtype(dtype) and not is_extension_array_dtype(dtype):
-            # TODO(jreback); this can change once we have an EA Index type
-            # GH 13149
-            arr = astype_nansafe(self._values, dtype=dtype)
-            return Int64Index(arr, name=self.name)
-        return super().astype(dtype, copy=copy)
-
-    # ----------------------------------------------------------------
-    # Indexing Methods
-
-    @doc(Index._should_fallback_to_positional)
-    def _should_fallback_to_positional(self) -> bool:
-        return False
-
-    @doc(Index._convert_slice_indexer)
-    def _convert_slice_indexer(self, key: slice, kind: str):
-        assert kind in ["loc", "getitem"]
-
-        # We always treat __getitem__ slicing as label-based
-        # translate to locations
-        return self.slice_indexer(key.start, key.stop, key.step)
-
-    # ----------------------------------------------------------------
-
-    def _format_native_types(
-        self, na_rep="", float_format=None, decimal=".", quoting=None, **kwargs
-    ):
-        from pandas.io.formats.format import FloatArrayFormatter
-
-        formatter = FloatArrayFormatter(
-            self._values,
-            na_rep=na_rep,
-            float_format=float_format,
-            decimal=decimal,
-            quoting=quoting,
-            fixed_width=False,
-        )
-        return formatter.get_result_as_array()

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -80,14 +80,6 @@ _num_index_shared_docs[
 """
 
 
-_numeric_index_descr_args = {
-    "klass": "NumericIndex",
-    "ltype": "integer or float",
-    "dtype": "inferred",
-    "extra": "",
-}
-
-
 class NumericIndex(Index):
     """
     Provide numeric type operations.
@@ -95,6 +87,12 @@ class NumericIndex(Index):
     This is an abstract class.
     """
 
+    _index_descr_args = {
+        "klass": "NumericIndex",
+        "ltype": "integer or float",
+        "dtype": "inferred",
+        "extra": "",
+    }
     _values: np.ndarray
     _default_dtype: np.dtype
     _dtype_validation_metadata: tuple[Callable[..., bool], str]
@@ -109,7 +107,7 @@ class NumericIndex(Index):
         else:
             return False
 
-    @property
+    @cache_readonly
     def _engine_type(self):
         return {
             np.int8: libindex.Int8Engine,
@@ -124,7 +122,7 @@ class NumericIndex(Index):
             np.float64: libindex.Float64Engine,
         }[self.dtype.type]
 
-    @property
+    @cache_readonly
     def inferred_type(self) -> str:
         return {
             "i": "integer",
@@ -357,16 +355,14 @@ class IntegerIndex(NumericIndex):
         return self._values.view(self._default_dtype)
 
 
-_int64_descr_args = {
-    "klass": "Int64Index",
-    "ltype": "integer",
-    "dtype": "int64",
-    "extra": "",
-}
-
-
 class Int64Index(IntegerIndex):
-    __doc__ = _num_index_shared_docs["class_descr"] % _int64_descr_args
+    _index_descr_args = {
+        "klass": "Int64Index",
+        "ltype": "integer",
+        "dtype": "int64",
+        "extra": "",
+    }
+    __doc__ = _num_index_shared_docs["class_descr"] % _index_descr_args
 
     _typ = "int64index"
     _engine_type = libindex.Int64Engine
@@ -374,16 +370,14 @@ class Int64Index(IntegerIndex):
     _dtype_validation_metadata = (is_signed_integer_dtype, "signed integer")
 
 
-_uint64_descr_args = {
-    "klass": "UInt64Index",
-    "ltype": "unsigned integer",
-    "dtype": "uint64",
-    "extra": "",
-}
-
-
 class UInt64Index(IntegerIndex):
-    __doc__ = _num_index_shared_docs["class_descr"] % _uint64_descr_args
+    _index_descr_args = {
+        "klass": "UInt64Index",
+        "ltype": "unsigned integer",
+        "dtype": "uint64",
+        "extra": "",
+    }
+    __doc__ = _num_index_shared_docs["class_descr"] % _index_descr_args
 
     _typ = "uint64index"
     _engine_type = libindex.UInt64Engine
@@ -391,16 +385,14 @@ class UInt64Index(IntegerIndex):
     _dtype_validation_metadata = (is_unsigned_integer_dtype, "unsigned integer")
 
 
-_float64_descr_args = {
-    "klass": "Float64Index",
-    "dtype": "float64",
-    "ltype": "float",
-    "extra": "",
-}
-
-
 class Float64Index(NumericIndex):
-    __doc__ = _num_index_shared_docs["class_descr"] % _float64_descr_args
+    _index_descr_args = {
+        "klass": "Float64Index",
+        "dtype": "float64",
+        "ltype": "float",
+        "extra": "",
+    }
+    __doc__ = _num_index_shared_docs["class_descr"] % _index_descr_args
 
     _typ = "float64index"
     _engine_type = libindex.Float64Engine

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -97,7 +97,6 @@ class RangeIndex(NumericIndex):
     _typ = "rangeindex"
     _engine_type = libindex.Int64Engine
     _dtype_validation_metadata = (is_signed_integer_dtype, "signed integer")
-    _can_hold_na = False
     _range: range
 
     # --------------------------------------------------------------------


### PR DESCRIPTION
Seperates the refactoring of existing methods out of #41153. Will make it easier to see what #41153 actually brings in of new things.

This PR changes no functionality, but only makes the exisiting numeric indexes into thin subclasses of the existing `NumericIndex`.