### PR TITLE
[ArrowStringArray] REF: _str_startswith/_str_endswith

### DIFF
--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -820,29 +820,26 @@ class ArrowStringArray(OpsMixin, ExtensionArray, ObjectStringArrayMixin):
             result[isna(result)] = bool(na)
         return result
 
-    def _str_startswith(self, pat, na=None):
+    def _str_startswith(self, pat: str, na=None):
         if pa_version_under4p0:
             return super()._str_startswith(pat, na)
 
-        result = pc.match_substring_regex(self._data, "^" + re.escape(pat))
-        result = BooleanDtype().__from_arrow__(result)
-        if not isna(na):
-            result[isna(result)] = bool(na)
-        return result
+        pat = "^" + re.escape(pat)
+        return self._str_contains(pat, na=na, regex=True)
 
-    def _str_endswith(self, pat, na=None):
+    def _str_endswith(self, pat: str, na=None):
         if pa_version_under4p0:
             return super()._str_endswith(pat, na)
 
-        result = pc.match_substring_regex(self._data, re.escape(pat) + "$")
-        result = BooleanDtype().__from_arrow__(result)
-        if not isna(na):
-            result[isna(result)] = bool(na)
-        return result
+        pat = re.escape(pat) + "$"
+        return self._str_contains(pat, na=na, regex=True)
 
     def _str_match(
         self, pat: str, case: bool = True, flags: int = 0, na: Scalar = None
     ):
+        if pa_version_under4p0:
+            return super()._str_match(pat, case, flags, na)
+
         if not pat.startswith("^"):
             pat = "^" + pat
         return self._str_contains(pat, case, flags, na, regex=True)


### PR DESCRIPTION
using pyarrow native functions for _str_startswith/_str_endswith #41222 were merged before _str_contains #41217 so we can de-duplication some logic.

and also a change to _str_match for perf gain on object fallback

```
-      32.8±0.2ms       25.5±0.1ms     0.78  strings.Methods.time_match('arrow_string')
```