### PR TITLE
BUG: CustomBusinessMonthBegin(End) sometimes ignores extra offset (GH41356)

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -281,6 +281,7 @@ Styler
 
 Other
 ^^^^^
+- Bug in :meth:`CustomBusinessMonthBegin.__add__` (:meth:`CustomBusinessMonthEnd.__add__`) not applying the extra ``offset`` parameter when beginning (end) of the target month is already a business day (:issue:`41356`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -3370,7 +3370,10 @@ cdef class _CustomBusinessMonth(BusinessMixin):
         """
         Define default roll function to be called in apply method.
         """
-        cbday = CustomBusinessDay(n=self.n, normalize=False, **self.kwds)
+        cbday_kwds = self.kwds.copy()
+        cbday_kwds['offset'] = timedelta(0)
+
+        cbday = CustomBusinessDay(n=1, normalize=False, **cbday_kwds)
 
         if self._prefix.endswith("S"):
             # MonthBegin
@@ -3414,6 +3417,9 @@ cdef class _CustomBusinessMonth(BusinessMixin):
 
         new = cur_month_offset_date + n * self.m_offset
         result = self.cbday_roll(new)
+
+        if self.offset:
+            result = result + self.offset
         return result
 
 

--- a/pandas/tests/tseries/offsets/test_custom_business_month.py
+++ b/pandas/tests/tseries/offsets/test_custom_business_month.py
@@ -7,6 +7,7 @@ Tests for the following offsets:
 from datetime import (
     date,
     datetime,
+    timedelta,
 )
 
 import numpy as np
@@ -200,6 +201,59 @@ class TestCustomBusinessMonthBegin(CustomBusinessMonthBase, Base):
             0
         ] == datetime(2012, 1, 3)
 
+    @pytest.mark.parametrize(
+        "case",
+        [
+            (
+                CBMonthBegin(n=1, offset=timedelta(days=5)),
+                {
+                    datetime(2021, 3, 1): datetime(2021, 4, 1) + timedelta(days=5),
+                    datetime(2021, 4, 17): datetime(2021, 5, 3) + timedelta(days=5),
+                },
+            ),
+            (
+                CBMonthBegin(n=2, offset=timedelta(days=40)),
+                {
+                    datetime(2021, 3, 10): datetime(2021, 5, 3) + timedelta(days=40),
+                    datetime(2021, 4, 30): datetime(2021, 6, 1) + timedelta(days=40),
+                },
+            ),
+            (
+                CBMonthBegin(n=1, offset=timedelta(days=-5)),
+                {
+                    datetime(2021, 3, 1): datetime(2021, 4, 1) - timedelta(days=5),
+                    datetime(2021, 4, 11): datetime(2021, 5, 3) - timedelta(days=5),
+                },
+            ),
+            (
+                -2 * CBMonthBegin(n=1, offset=timedelta(days=10)),
+                {
+                    datetime(2021, 3, 1): datetime(2021, 1, 1) + timedelta(days=10),
+                    datetime(2021, 4, 3): datetime(2021, 3, 1) + timedelta(days=10),
+                },
+            ),
+            (
+                CBMonthBegin(n=0, offset=timedelta(days=1)),
+                {
+                    datetime(2021, 3, 2): datetime(2021, 4, 1) + timedelta(days=1),
+                    datetime(2021, 4, 1): datetime(2021, 4, 1) + timedelta(days=1),
+                },
+            ),
+            (
+                CBMonthBegin(
+                    n=1, holidays=["2021-04-01", "2021-04-02"], offset=timedelta(days=1)
+                ),
+                {
+                    datetime(2021, 3, 2): datetime(2021, 4, 5) + timedelta(days=1),
+                },
+            ),
+        ],
+    )
+    def test_apply_with_extra_offset(self, case):
+        offset, cases = case
+        for base, expected in cases.items():
+            assert_offset_equal(offset, base, expected)
+
 
 class TestCustomBusinessMonthEnd(CustomBusinessMonthBase, Base):
     _offset = CBMonthEnd
@@ -337,3 +391,54 @@ class TestCustomBusinessMonthEnd(CustomBusinessMonthBase, Base):
         assert date_range(start="20120101", end="20130101", freq=freq).tolist()[
             0
         ] == datetime(2012, 1, 31)
+
+    @pytest.mark.parametrize(
+        "case",
+        [
+            (
+                CBMonthEnd(n=1, offset=timedelta(days=5)),
+                {
+                    datetime(2021, 3, 1): datetime(2021, 3, 31) + timedelta(days=5),
+                    datetime(2021, 4, 17): datetime(2021, 4, 30) + timedelta(days=5),
+                },
+            ),
+            (
+                CBMonthEnd(n=2, offset=timedelta(days=40)),
+                {
+                    datetime(2021, 3, 10): datetime(2021, 4, 30) + timedelta(days=40),
+                    datetime(2021, 4, 30): datetime(2021, 6, 30) + timedelta(days=40),
+                },
+            ),
+            (
+                CBMonthEnd(n=1, offset=timedelta(days=-5)),
+                {
+                    datetime(2021, 3, 1): datetime(2021, 3, 31) - timedelta(days=5),
+                    datetime(2021, 4, 11): datetime(2021, 4, 30) - timedelta(days=5),
+                },
+            ),
+            (
+                -2 * CBMonthEnd(n=1, offset=timedelta(days=10)),
+                {
+                    datetime(2021, 3, 1): datetime(2021, 1, 29) + timedelta(days=10),
+                    datetime(2021, 4, 3): datetime(2021, 2, 26) + timedelta(days=10),
+                },
+            ),
+            (
+                CBMonthEnd(n=0, offset=timedelta(days=1)),
+                {
+                    datetime(2021, 3, 2): datetime(2021, 3, 31) + timedelta(days=1),
+                    datetime(2021, 4, 1): datetime(2021, 4, 30) + timedelta(days=1),
+                },
+            ),
+            (
+                CBMonthEnd(n=1, holidays=["2021-03-31"], offset=timedelta(days=1)),
+                {
+                    datetime(2021, 3, 2): datetime(2021, 3, 30) + timedelta(days=1),
+                },
+            ),
+        ],
+    )
+    def test_apply_with_extra_offset(self, case):
+        offset, cases = case
+        for base, expected in cases.items():
+            assert_offset_equal(offset, base, expected)


### PR DESCRIPTION
- [x] closes #41356 #14869
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

-----------------
**Problem description**: _CustomBusinessMonth does not apply extra offset when initially rolled month begin `new` is already a business day. This happens because we currently use CustomBusinessDay.rollforward (rollback) to both 1) roll to a business day and 2) apply the extra offset. 
**Fix**: Separating the logic to 1) roll to a business day and 2) apply the extra offset.