### PR TITLE
TYP simplify overloads for fillna

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5029,9 +5029,10 @@ class DataFrame(NDFrame, OpsMixin):
     def fillna(
         self,
         value,
-        method: FillnaOptions | None,
-        axis: Axis | None,
+        *,
         inplace: Literal[True],
+        method: FillnaOptions | None = ...,
+        axis: Axis | None = ...,
         limit=...,
         downcast=...,
     ) -> None:
@@ -5042,75 +5043,8 @@ class DataFrame(NDFrame, OpsMixin):
         self,
         *,
         inplace: Literal[True],
-        limit=...,
-        downcast=...,
-    ) -> None:
-        ...
-
-    @overload
-    def fillna(
-        self,
-        value,
-        *,
-        inplace: Literal[True],
-        limit=...,
-        downcast=...,
-    ) -> None:
-        ...
-
-    @overload
-    def fillna(
-        self,
-        *,
-        method: FillnaOptions | None,
-        inplace: Literal[True],
-        limit=...,
-        downcast=...,
-    ) -> None:
-        ...
-
-    @overload
-    def fillna(
-        self,
-        *,
-        axis: Axis | None,
-        inplace: Literal[True],
-        limit=...,
-        downcast=...,
-    ) -> None:
-        ...
-
-    @overload
-    def fillna(
-        self,
-        *,
-        method: FillnaOptions | None,
-        axis: Axis | None,
-        inplace: Literal[True],
-        limit=...,
-        downcast=...,
-    ) -> None:
-        ...
-
-    @overload
-    def fillna(
-        self,
-        value,
-        *,
-        axis: Axis | None,
-        inplace: Literal[True],
-        limit=...,
-        downcast=...,
-    ) -> None:
-        ...
-
-    @overload
-    def fillna(
-        self,
-        value,
-        method: FillnaOptions | None,
-        *,
-        inplace: Literal[True],
+        method: FillnaOptions | None = ...,
+        axis: Axis | None = ...,
         limit=...,
         downcast=...,
     ) -> None:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4607,9 +4607,10 @@ Keep all original rows and also all original values
     def fillna(
         self,
         value,
-        method: FillnaOptions | None,
-        axis: Axis | None,
+        *,
         inplace: Literal[True],
+        method: FillnaOptions | None = ...,
+        axis: Axis | None = ...,
         limit=...,
         downcast=...,
     ) -> None:
@@ -4620,75 +4621,8 @@ Keep all original rows and also all original values
         self,
         *,
         inplace: Literal[True],
-        limit=...,
-        downcast=...,
-    ) -> None:
-        ...
-
-    @overload
-    def fillna(
-        self,
-        value,
-        *,
-        inplace: Literal[True],
-        limit=...,
-        downcast=...,
-    ) -> None:
-        ...
-
-    @overload
-    def fillna(
-        self,
-        *,
-        method: FillnaOptions | None,
-        inplace: Literal[True],
-        limit=...,
-        downcast=...,
-    ) -> None:
-        ...
-
-    @overload
-    def fillna(
-        self,
-        *,
-        axis: Axis | None,
-        inplace: Literal[True],
-        limit=...,
-        downcast=...,
-    ) -> None:
-        ...
-
-    @overload
-    def fillna(
-        self,
-        *,
-        method: FillnaOptions | None,
-        axis: Axis | None,
-        inplace: Literal[True],
-        limit=...,
-        downcast=...,
-    ) -> None:
-        ...
-
-    @overload
-    def fillna(
-        self,
-        value,
-        *,
-        axis: Axis | None,
-        inplace: Literal[True],
-        limit=...,
-        downcast=...,
-    ) -> None:
-        ...
-
-    @overload
-    def fillna(
-        self,
-        value,
-        method: FillnaOptions | None,
-        *,
-        inplace: Literal[True],
+        method: FillnaOptions | None = ...,
+        axis: Axis | None = ...,
         limit=...,
         downcast=...,
     ) -> None:


### PR DESCRIPTION
`fillna` doesn't allow users to pass both `value` and `method`, so in effect the arguments after `value` are already keyword-only. So, the overloads can be simplified immediately.

```python
import pandas as pd

inplace : bool  

reveal_type(pd.Series([1,2,3]).fillna(value=0, inplace=False))
reveal_type(pd.Series([1,2,3]).fillna(method='pad', inplace=False))
reveal_type(pd.Series([1,2,3]).fillna(value=0, axis=0, inplace=False))
reveal_type(pd.Series([1,2,3]).fillna(method='pad', axis=0, inplace=False))

reveal_type(pd.Series([1,2,3]).fillna(value=0, inplace=True))
reveal_type(pd.Series([1,2,3]).fillna(method='pad', inplace=True))
reveal_type(pd.Series([1,2,3]).fillna(value=0, axis=0, inplace=True))
reveal_type(pd.Series([1,2,3]).fillna(method='pad', axis=0, inplace=True))

reveal_type(pd.Series([1,2,3]).fillna(value=0, inplace=inplace))
reveal_type(pd.Series([1,2,3]).fillna(method='pad', inplace=inplace))
reveal_type(pd.Series([1,2,3]).fillna(value=0, axis=0, inplace=inplace))
reveal_type(pd.Series([1,2,3]).fillna(method='pad', axis=0, inplace=inplace))


reveal_type(pd.DataFrame([1,2,3]).fillna(value=0, inplace=False))
reveal_type(pd.DataFrame([1,2,3]).fillna(method='pad', inplace=False))
reveal_type(pd.DataFrame([1,2,3]).fillna(value=0, axis=0, inplace=False))
reveal_type(pd.DataFrame([1,2,3]).fillna(method='pad', axis=0, inplace=False))

reveal_type(pd.DataFrame([1,2,3]).fillna(value=0, inplace=True))
reveal_type(pd.DataFrame([1,2,3]).fillna(method='pad', inplace=True))
reveal_type(pd.DataFrame([1,2,3]).fillna(value=0, axis=0, inplace=True))
reveal_type(pd.DataFrame([1,2,3]).fillna(method='pad', axis=0, inplace=True))

reveal_type(pd.DataFrame([1,2,3]).fillna(value=0, inplace=inplace))
reveal_type(pd.DataFrame([1,2,3]).fillna(method='pad', inplace=inplace))
reveal_type(pd.DataFrame([1,2,3]).fillna(value=0, axis=0, inplace=inplace))
reveal_type(pd.DataFrame([1,2,3]).fillna(method='pad', axis=0, inplace=inplace))

```
still type checks correctly:
```
$ mypy t.py 
t.py:5: note: Revealed type is 'pandas.core.series.Series'
t.py:6: note: Revealed type is 'pandas.core.series.Series'
t.py:7: note: Revealed type is 'pandas.core.series.Series'
t.py:8: note: Revealed type is 'pandas.core.series.Series'
t.py:10: note: Revealed type is 'None'
t.py:11: note: Revealed type is 'None'
t.py:12: note: Revealed type is 'None'
t.py:13: note: Revealed type is 'None'
t.py:15: note: Revealed type is 'Union[pandas.core.series.Series, None]'
t.py:16: note: Revealed type is 'Union[pandas.core.series.Series, None]'
t.py:17: note: Revealed type is 'Union[pandas.core.series.Series, None]'
t.py:18: note: Revealed type is 'Union[pandas.core.series.Series, None]'
t.py:21: note: Revealed type is 'pandas.core.frame.DataFrame'
t.py:22: note: Revealed type is 'pandas.core.frame.DataFrame'
t.py:23: note: Revealed type is 'pandas.core.frame.DataFrame'
t.py:24: note: Revealed type is 'pandas.core.frame.DataFrame'
t.py:26: note: Revealed type is 'None'
t.py:27: note: Revealed type is 'None'
t.py:28: note: Revealed type is 'None'
t.py:29: note: Revealed type is 'None'
t.py:31: note: Revealed type is 'Union[pandas.core.frame.DataFrame, None]'
t.py:32: note: Revealed type is 'Union[pandas.core.frame.DataFrame, None]'
t.py:33: note: Revealed type is 'Union[pandas.core.frame.DataFrame, None]'
t.py:34: note: Revealed type is 'Union[pandas.core.frame.DataFrame, None]'
```