### PR TITLE
PERF: load plotting entrypoint only when necessary

### DIFF
--- a/asv_bench/benchmarks/plotting.py
+++ b/asv_bench/benchmarks/plotting.py
@@ -9,7 +9,6 @@ from pandas import (
     DataFrame,
     DatetimeIndex,
     Series,
-    __file__ as pd_file,
     date_range,
 )
 
@@ -113,11 +112,6 @@ class BackendLoading:
 
     def setup(self):
         dist = pkg_resources.get_distribution("pandas")
-        if dist.module_path not in pd_file:
-            # We are running from a non-installed pandas, and this benchmark is
-            # invalid
-            raise NotImplementedError("Testing a non-installed pandas")
-
         spec = importlib.machinery.ModuleSpec("my_backend", None)
         mod = importlib.util.module_from_spec(spec)
         mod.plot = lambda *args, **kwargs: 1
@@ -127,7 +121,7 @@ class BackendLoading:
             "pandas_plotting_backend", mod.__name__, dist=dist
         )
         backends["pandas_plotting_backends"][mod.__name__] = my_entrypoint
-        for i in range(1000):
+        for i in range(10):
             backends["pandas_plotting_backends"][str(i)] = my_entrypoint
         sys.modules["my_backend"] = mod
 

--- a/asv_bench/benchmarks/plotting.py
+++ b/asv_bench/benchmarks/plotting.py
@@ -107,6 +107,10 @@ class Misc:
 
 
 class BackendLoading:
+    repeat = 1
+    number = 1
+    warmup_time = 0
+
     def setup(self):
         dist = pkg_resources.get_distribution("pandas")
         if dist.module_path not in pd_file:

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -812,6 +812,7 @@ Performance improvements
 - Performance improvement in :meth:`.GroupBy.cummin` and :meth:`.GroupBy.cummax` with nullable data types (:issue:`37493`)
 - Performance improvement in :meth:`Series.nunique` with nan values (:issue:`40865`)
 - Performance improvement in :meth:`DataFrame.transpose`, :meth:`Series.unstack` with ``DatetimeTZDtype`` (:issue:`40149`)
+- Performance improvement in :meth:`Series.plot` and :meth:`DataFrame.plot` with entry point lazy loading (:issue:`41492`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1763,6 +1763,7 @@ def _load_backend(backend: str) -> types.ModuleType:
         found_backend = entry_point.name == backend
         if found_backend:
             module = entry_point.load()
+            break
 
     if not found_backend:
         # Fall back to unregistered, module name approach.

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import types
 from typing import (
     TYPE_CHECKING,
     Sequence,
@@ -1727,7 +1728,7 @@ class PlotAccessor(PandasObject):
         return self(kind="hexbin", x=x, y=y, C=C, **kwargs)
 
 
-_backends = {}
+_backends: dict[str, types.ModuleType] = {}
 
 
 def _load_backend(backend: str):
@@ -1745,19 +1746,19 @@ def _load_backend(backend: str):
     types.ModuleType
         The imported backend.
     """
+    module: types.ModuleType | None = None
+
     if backend == "matplotlib":
         # Because matplotlib is an optional dependency and first-party backend,
         # we need to attempt an import here to raise an ImportError if needed.
         try:
-            import pandas.plotting._matplotlib as module
+            module = __import__("pandas.plotting._matplotlib")
         except ImportError:
             raise ImportError(
                 "matplotlib is required for plotting when the "
                 'default backend "matplotlib" is selected.'
             ) from None
         return module
-
-    module = None
 
     for entry_point in pkg_resources.iter_entry_points("pandas_plotting_backends"):
         if entry_point.name == backend:


### PR DESCRIPTION
- [x] closes #41492
- [x] tests added / passed (I only ran plotting/test_backend.py, which seemed appropriate)
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry