### PR TITLE
[ArrowStringArray] PERF: str.partition object fallback

### DIFF
--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -266,29 +266,26 @@ class StringMethods(NoNewAttributesMixin):
             # infer from ndim if expand is not specified
             expand = result.ndim != 1
 
-        elif expand in ("split", "rsplit"):
-            expand = True
-            if not isinstance(self._orig, ABCIndex):
+        elif expand in ("split", "rsplit") and not isinstance(self._orig, ABCIndex):
 
-                def cons_row(x):
-                    if is_list_like(x):
-                        return x
-                    else:
-                        return [x]
+            def cons_row(x):
+                if is_list_like(x):
+                    return x
+                else:
+                    return [x]
 
-                result = [cons_row(x) for x in result]
-                if result:
-                    # propagate nan values to match longest sequence (GH 18450)
-                    max_len = max(len(x) for x in result)
-                    result = [
-                        x * max_len if len(x) == 0 or x[0] is np.nan else x
-                        for x in result
-                    ]
+            result = [cons_row(x) for x in result]
+            if result:
+                # propagate nan values to match longest sequence (GH 18450)
+                max_len = max(len(x) for x in result)
+                result = [
+                    x * max_len if len(x) == 0 or x[0] is np.nan else x for x in result
+                ]
 
-        elif expand in ("partition", "rpartition"):
-            expand = True
-            if not isinstance(self._orig, ABCIndex):
-                result = list(result)
+        elif expand in ("partition", "rpartition") and not isinstance(
+            self._orig, ABCIndex
+        ):
+            result = list(result)
 
         if expand is False:
             # if expand is False, result should have the same name

--- a/pandas/tests/strings/test_split_partition.py
+++ b/pandas/tests/strings/test_split_partition.py
@@ -235,8 +235,12 @@ def test_split_to_dataframe(any_string_dtype):
     )
     tm.assert_frame_equal(result, exp)
 
-    with pytest.raises(ValueError, match="expand must be"):
-        s.str.split("_", expand="not_a_boolean")
+
+def test_split_expand_kwarg_raises(any_string_dtype):
+    ser = Series([], dtype=any_string_dtype)
+    msg = 'For argument "expand" expected type bool, received type str'
+    with pytest.raises(ValueError, match=msg):
+        ser.str.split("_", expand="not_a_boolean")
 
 
 def test_split_to_multiindex_expand():
@@ -274,7 +278,11 @@ def test_split_to_multiindex_expand():
     tm.assert_index_equal(result, exp)
     assert result.nlevels == 6
 
-    with pytest.raises(ValueError, match="expand must be"):
+
+def test_split_index_expand_kwarg_raises():
+    idx = Index(["some_unequal_splits", "one_of_these_things_is_not", np.nan, None])
+    msg = 'For argument "expand" expected type bool, received type str'
+    with pytest.raises(ValueError, match=msg):
         idx.str.split("_", expand="not_a_boolean")
 
 


### PR DESCRIPTION
```
       before           after         ratio
     [40482273]       [5d1bc3e0]
     <master>         <wrap-result>
-      59.6±0.5ms       36.2±0.6ms     0.61  strings.Methods.time_partition('arrow_string')
-      57.8±0.5ms       34.9±0.2ms     0.60  strings.Methods.time_rpartition('arrow_string')
-      54.5±0.3ms       32.0±0.4ms     0.59  strings.Methods.time_partition('str')
-      53.3±0.2ms       30.9±0.5ms     0.58  strings.Methods.time_rpartition('str')
-      49.0±0.5ms       26.4±0.3ms     0.54  strings.Methods.time_partition('string')
-      48.2±0.2ms       25.7±0.4ms     0.53  strings.Methods.time_rpartition('string')

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```