### PR TITLE
Deprecate passing args as positional in DataFrame/Series.interpolate

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -647,6 +647,7 @@ Deprecations
 - Deprecated setting :attr:`Categorical._codes`, create a new :class:`Categorical` with the desired codes instead (:issue:`40606`)
 - Deprecated behavior of :meth:`DatetimeIndex.union` with mixed timezones; in a future version both will be cast to UTC instead of object dtype (:issue:`39328`)
 - Deprecated using ``usecols`` with out of bounds indices for ``read_csv`` with ``engine="c"`` (:issue:`25623`)
+- Deprecated passing arguments as positional in :meth:`DataFrame.interpolate` and :meth:`Series.interpolate` (:issue:`41485`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -647,7 +647,7 @@ Deprecations
 - Deprecated setting :attr:`Categorical._codes`, create a new :class:`Categorical` with the desired codes instead (:issue:`40606`)
 - Deprecated behavior of :meth:`DatetimeIndex.union` with mixed timezones; in a future version both will be cast to UTC instead of object dtype (:issue:`39328`)
 - Deprecated using ``usecols`` with out of bounds indices for ``read_csv`` with ``engine="c"`` (:issue:`25623`)
-- Deprecated passing arguments as positional in :meth:`DataFrame.interpolate` and :meth:`Series.interpolate` (:issue:`41485`)
+- Deprecated passing arguments as positional (except for ``"method"``) in :meth:`DataFrame.interpolate` and :meth:`Series.interpolate` (:issue:`41485`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -77,6 +77,7 @@ from pandas.util._decorators import (
     Appender,
     Substitution,
     deprecate_kwarg,
+    deprecate_nonkeyword_arguments,
     doc,
     rewrite_axis_style_signature,
 )
@@ -10625,6 +10626,29 @@ NaN 12.3   33.0
     def _values(self) -> np.ndarray:
         """internal implementation"""
         return self.values
+
+    @deprecate_nonkeyword_arguments(version=None, allowed_args=["self", "method"])
+    def interpolate(
+        self: DataFrame,
+        method: str = "linear",
+        axis: Axis = 0,
+        limit: int | None = None,
+        inplace: bool = False,
+        limit_direction: str | None = None,
+        limit_area: str | None = None,
+        downcast: str | None = None,
+        **kwargs,
+    ) -> DataFrame | None:
+        return super().interpolate(
+            method,
+            axis,
+            limit,
+            inplace,
+            limit_direction,
+            limit_area,
+            downcast,
+            **kwargs,
+        )
 
 
 DataFrame._add_numeric_operations()

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -61,6 +61,7 @@ from pandas.errors import (
     InvalidIndexError,
 )
 from pandas.util._decorators import (
+    deprecate_nonkeyword_arguments,
     doc,
     rewrite_axis_style_signature,
 )
@@ -6696,6 +6697,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         else:
             return result.__finalize__(self, method="replace")
 
+    @deprecate_nonkeyword_arguments(version="2.0", allowed_args=["self"])
     @final
     def interpolate(
         self: FrameOrSeries,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -61,7 +61,6 @@ from pandas.errors import (
     InvalidIndexError,
 )
 from pandas.util._decorators import (
-    deprecate_nonkeyword_arguments,
     doc,
     rewrite_axis_style_signature,
 )
@@ -6697,8 +6696,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         else:
             return result.__finalize__(self, method="replace")
 
-    @deprecate_nonkeyword_arguments(version="2.0", allowed_args=["self", "method"])
-    @final
     def interpolate(
         self: FrameOrSeries,
         method: str = "linear",

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6697,7 +6697,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         else:
             return result.__finalize__(self, method="replace")
 
-    @deprecate_nonkeyword_arguments(version="2.0", allowed_args=["self"])
+    @deprecate_nonkeyword_arguments(version="2.0", allowed_args=["self", "method"])
     @final
     def interpolate(
         self: FrameOrSeries,

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -51,6 +51,7 @@ from pandas.errors import InvalidIndexError
 from pandas.util._decorators import (
     Appender,
     Substitution,
+    deprecate_nonkeyword_arguments,
     doc,
 )
 from pandas.util._validators import (
@@ -5254,6 +5255,29 @@ Keep all original rows and also all original values
         new_index = self.index.to_period(freq=freq)
         return self._constructor(new_values, index=new_index).__finalize__(
             self, method="to_period"
+        )
+
+    @deprecate_nonkeyword_arguments(version=None, allowed_args=["self", "method"])
+    def interpolate(
+        self: Series,
+        method: str = "linear",
+        axis: Axis = 0,
+        limit: int | None = None,
+        inplace: bool = False,
+        limit_direction: str | None = None,
+        limit_area: str | None = None,
+        downcast: str | None = None,
+        **kwargs,
+    ) -> Series | None:
+        return super().interpolate(
+            method,
+            axis,
+            limit,
+            inplace,
+            limit_direction,
+            limit_area,
+            downcast,
+            **kwargs,
         )
 
     # ----------------------------------------------------------------------

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -348,7 +348,7 @@ class TestDataFrameInterpolate:
         df = DataFrame({"a": [1, 2, 3]})
         msg = (
             r"Starting with Pandas version 2\.0 all arguments of interpolate except "
-            r"for the argument 'self' will be keyword-only"
+            r"for the arguments 'self' and 'method' will be keyword-only"
         )
         with tm.assert_produces_warning(FutureWarning, match=msg):
-            df.interpolate(0)
+            df.interpolate("pad", 0)

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -342,3 +342,13 @@ class TestDataFrameInterpolate:
         expected = df.fillna(axis=axis, method=method)
         result = df.interpolate(method=method, axis=axis)
         tm.assert_frame_equal(result, expected)
+
+    def test_interpolate_pos_args_deprecation(self):
+        # https://github.com/pandas-dev/pandas/issues/41485
+        df = DataFrame({"a": [1, 2, 3]})
+        msg = (
+            r"Starting with Pandas version 2\.0 all arguments of interpolate except "
+            r"for the argument 'self' will be keyword-only"
+        )
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            df.interpolate(0)

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -347,8 +347,10 @@ class TestDataFrameInterpolate:
         # https://github.com/pandas-dev/pandas/issues/41485
         df = DataFrame({"a": [1, 2, 3]})
         msg = (
-            r"Starting with Pandas version 2\.0 all arguments of interpolate except "
-            r"for the arguments 'self' and 'method' will be keyword-only"
+            r"In a future version of pandas all arguments of DataFrame.interpolate "
+            r"except for the argument 'method' will be keyword-only"
         )
         with tm.assert_produces_warning(FutureWarning, match=msg):
-            df.interpolate("pad", 0)
+            result = df.interpolate("pad", 0)
+        expected = DataFrame({"a": [1, 2, 3]})
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -1026,14 +1026,12 @@ def test_resample_dtype_coercion():
     df = {"a": [1, 3, 1, 4]}
     df = DataFrame(df, index=date_range("2017-01-01", "2017-01-04"))
 
-    expected = (
-        df.astype("float64").resample("H").mean()["a"].interpolate(method="cubic")
-    )
+    expected = df.astype("float64").resample("H").mean()["a"].interpolate("cubic")
 
-    result = df.resample("H")["a"].mean().interpolate(method="cubic")
+    result = df.resample("H")["a"].mean().interpolate("cubic")
     tm.assert_series_equal(result, expected)
 
-    result = df.resample("H").mean()["a"].interpolate(method="cubic")
+    result = df.resample("H").mean()["a"].interpolate("cubic")
     tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -1026,12 +1026,14 @@ def test_resample_dtype_coercion():
     df = {"a": [1, 3, 1, 4]}
     df = DataFrame(df, index=date_range("2017-01-01", "2017-01-04"))
 
-    expected = df.astype("float64").resample("H").mean()["a"].interpolate("cubic")
+    expected = (
+        df.astype("float64").resample("H").mean()["a"].interpolate(method="cubic")
+    )
 
-    result = df.resample("H")["a"].mean().interpolate("cubic")
+    result = df.resample("H")["a"].mean().interpolate(method="cubic")
     tm.assert_series_equal(result, expected)
 
-    result = df.resample("H").mean()["a"].interpolate("cubic")
+    result = df.resample("H").mean()["a"].interpolate(method="cubic")
     tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/series/methods/test_interpolate.py
+++ b/pandas/tests/series/methods/test_interpolate.py
@@ -816,8 +816,10 @@ class TestSeriesInterpolateData:
         # https://github.com/pandas-dev/pandas/issues/41485
         ser = Series([1, 2, 3])
         msg = (
-            r"Starting with Pandas version 2\.0 all arguments of interpolate except "
-            r"for the arguments 'self' and 'method' will be keyword-only"
+            r"In a future version of pandas all arguments of Series.interpolate except "
+            r"for the argument 'method' will be keyword-only"
         )
         with tm.assert_produces_warning(FutureWarning, match=msg):
-            ser.interpolate("pad", 0)
+            result = ser.interpolate("pad", 0)
+        expected = Series([1, 2, 3])
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/methods/test_interpolate.py
+++ b/pandas/tests/series/methods/test_interpolate.py
@@ -817,7 +817,7 @@ class TestSeriesInterpolateData:
         ser = Series([1, 2, 3])
         msg = (
             r"Starting with Pandas version 2\.0 all arguments of interpolate except "
-            r"for the argument 'self' will be keyword-only"
+            r"for the arguments 'self' and 'method' will be keyword-only"
         )
         with tm.assert_produces_warning(FutureWarning, match=msg):
-            ser.interpolate(0)
+            ser.interpolate("pad", 0)

--- a/pandas/tests/series/methods/test_interpolate.py
+++ b/pandas/tests/series/methods/test_interpolate.py
@@ -811,3 +811,13 @@ class TestSeriesInterpolateData:
         result = ts.sort_index(ascending=ascending).interpolate(method="index")
         expected = Series(data=expected_values, index=expected_values, dtype=float)
         tm.assert_series_equal(result, expected)
+
+    def test_interpolate_pos_args_deprecation(self):
+        # https://github.com/pandas-dev/pandas/issues/41485
+        ser = Series([1, 2, 3])
+        msg = (
+            r"Starting with Pandas version 2\.0 all arguments of interpolate except "
+            r"for the argument 'self' will be keyword-only"
+        )
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            ser.interpolate(0)


### PR DESCRIPTION
- [ ] xref #41485
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
