### PR TITLE
DOC: Add clearer info when copy is False but memory shared only for certain objects

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -223,7 +223,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     name : str, optional
         The name to give to the Series.
     copy : bool, default False
-        Copy input data.
+        Copy input data. Only affects Series or 1d ndarray input. See examples.
 
     Examples
     --------
@@ -251,6 +251,38 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     Note that the Index is first build with the keys from the dictionary.
     After this the Series is reindexed with the given Index values, hence we
     get all NaN as a result.
+
+    Constructing Series from a list with `copy=False`.
+
+    >>> r = [1, 2]
+    >>> ser = pd.Series(r, copy=False)
+    >>> ser.iloc[0] = 999
+    >>> r
+    [1, 2]
+    >>> ser
+    0    999
+    1      2
+    dtype: int64
+
+    Due to input data type the Series has a `copy` of
+    the original data even though `copy=False`, so
+    the data is unchanged.
+
+    Constructing Series from a 1d ndarray with `copy=False`.
+
+    >>> r = np.array([1, 2])
+    >>> ser = pd.Series(r, copy=False)
+    >>> ser.iloc[0] = 999
+    >>> r
+    array([999,   2])
+    >>> ser
+    0    999
+    1      2
+    dtype: int32
+
+    Due to input data type the Series has a `view` on
+    the original data, so
+    the data is changed as well.
     """
 
     _typ = "series"

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -256,6 +256,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     get all NaN as a result.
     
     Constructing Series from an array with `copy=False`.
+    
     >>> r = [1,2]
     >>> ser = pd.Series(r, copy=False)
     >>> ser.iloc[0] = 999
@@ -267,9 +268,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     dtype: int64
     
     The Series returns a `copy` of the original data, so
-    `r` is unchanged.
+    the original data is unchanged.
     
     Constructing Series from a `numpy.array` with `copy=False`.
+    
     >>> r = np.array([1,2])
     >>> ser = pd.Series(r, copy=False)
     >>> ser.iloc[0] = 999
@@ -281,7 +283,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     dtype: int32
     
     The Series returns a `view` on the original data, so
-    `r` is changed as well.
+    the original data is changed as well.
     """
 
     _typ = "series"

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -223,9 +223,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     name : str, optional
         The name to give to the Series.
     copy : bool, default False
-        Copy input data. If False and the Series returns a `view` of the data,
-        the memory location for the values is shared. If False and the Series returns a `copy`
+        Copy input data. If False and the Series returns a `copy`
         of the data, the memory location for the values is not shared.
+        If False and the Series returns a `view` on the data,
+        the memory location for the values is shared.
 
     Examples
     --------
@@ -253,6 +254,34 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     Note that the Index is first build with the keys from the dictionary.
     After this the Series is reindexed with the given Index values, hence we
     get all NaN as a result.
+    
+    Constructing Series from an array with `copy=False`.
+    >>> r = [1,2]
+    >>> ser = pd.Series(r, copy=False)
+    >>> ser.iloc[0] = 999
+    >>> r
+    [1, 2]
+    >>> ser
+    0    999
+    1      2
+    dtype: int64
+    
+    The Series returns a `copy` of the original data, so
+    `r` is unchanged.
+    
+    Constructing Series from a `numpy.array` with `copy=False`.
+    >>> r = np.array([1,2])
+    >>> ser = pd.Series(r, copy=False)
+    >>> ser.iloc[0] = 999
+    >>> r
+    array([999,   2])
+    >>> ser
+    0    999
+    1      2
+    dtype: int32
+    
+    The Series returns a `view` on the original data, so
+    `r` is changed as well.
     """
 
     _typ = "series"

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -264,8 +264,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     1      2
     dtype: int64
 
-    Due to input data type the Series has a `copy` of the original data even though `copy=False`, so
-    the data is unchanged.
+    Due to input data type the Series has a `copy` of the original data 
+    even though `copy=False`, so the data is unchanged.
 
     Constructing Series from a 1d ndarray with `copy=False`.
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -251,7 +251,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     Note that the Index is first build with the keys from the dictionary.
     After this the Series is reindexed with the given Index values, hence we
     get all NaN as a result.
-    
+
     Constructing Series from a list with `copy=False`.
 
     >>> r = [1, 2]

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -223,7 +223,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     name : str, optional
         The name to give to the Series.
     copy : bool, default False
-        Copy input data.
+        Copy input data. If False and the Series returns a `view` of the data,
+        the memory location for the values is shared. If False and the Series returns a `copy`
+        of the data, the memory location for the values is not shared.
 
     Examples
     --------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -223,10 +223,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     name : str, optional
         The name to give to the Series.
     copy : bool, default False
-        Copy input data. If False and the Series returns a `copy`
-        of the data, the memory location for the values is not shared.
-        If False and the Series returns a `view` on the data,
-        the memory location for the values is shared.
+        Copy input data. Only affects Series or 1d ndarray input. See examples.
 
     Examples
     --------
@@ -255,9 +252,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     After this the Series is reindexed with the given Index values, hence we
     get all NaN as a result.
     
-    Constructing Series from an array with `copy=False`.
-    
-    >>> r = [1,2]
+    Constructing Series from a list with `copy=False`.
+
+    >>> r = [1, 2]
     >>> ser = pd.Series(r, copy=False)
     >>> ser.iloc[0] = 999
     >>> r
@@ -266,13 +263,13 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     0    999
     1      2
     dtype: int64
-    
-    The Series returns a `copy` of the original data, so
-    the original data is unchanged.
-    
-    Constructing Series from a `numpy.array` with `copy=False`.
-    
-    >>> r = np.array([1,2])
+
+    Due to input data type the Series has a `copy` of the original data even though `copy=False`, so
+    the data is unchanged.
+
+    Constructing Series from a 1d ndarray with `copy=False`.
+
+    >>> r = np.array([1, 2])
     >>> ser = pd.Series(r, copy=False)
     >>> ser.iloc[0] = 999
     >>> r
@@ -281,9 +278,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     0    999
     1      2
     dtype: int32
-    
-    The Series returns a `view` on the original data, so
-    the original data is changed as well.
+
+    Due to input data type the Series has a `view` on the original data, so
+    the data is changed as well.
     """
 
     _typ = "series"

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -278,7 +278,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     >>> ser
     0    999
     1      2
-    dtype: int32
+    dtype: int64
 
     Due to input data type the Series has a `view` on
     the original data, so

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -223,7 +223,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     name : str, optional
         The name to give to the Series.
     copy : bool, default False
-        Copy input data. Only affects Series or 1d ndarray input. See examples.
+        Copy input data.
 
     Examples
     --------
@@ -251,36 +251,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     Note that the Index is first build with the keys from the dictionary.
     After this the Series is reindexed with the given Index values, hence we
     get all NaN as a result.
-
-    Constructing Series from a list with `copy=False`.
-
-    >>> r = [1, 2]
-    >>> ser = pd.Series(r, copy=False)
-    >>> ser.iloc[0] = 999
-    >>> r
-    [1, 2]
-    >>> ser
-    0    999
-    1      2
-    dtype: int64
-
-    Due to input data type the Series has a `copy` of the original data 
-    even though `copy=False`, so the data is unchanged.
-
-    Constructing Series from a 1d ndarray with `copy=False`.
-
-    >>> r = np.array([1, 2])
-    >>> ser = pd.Series(r, copy=False)
-    >>> ser.iloc[0] = 999
-    >>> r
-    array([999,   2])
-    >>> ser
-    0    999
-    1      2
-    dtype: int32
-
-    Due to input data type the Series has a `view` on the original data, so
-    the data is changed as well.
     """
 
     _typ = "series"


### PR DESCRIPTION
- [ ] closes #41423
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

Added to Series section more info in `copy` constructor parameter and 2 examples.

Ran validation script:
```
python scripts/validate_docstrings.py pandas.Series
```

Output:
```
################################################################################
########################## Docstring (pandas.Series)  ##########################
################################################################################

One-dimensional ndarray with axis labels (including time series).

Labels need not be unique but must be a hashable type. The object
supports both integer- and label-based indexing and provides a host of
methods for performing operations involving the index. Statistical
methods from ndarray have been overridden to automatically exclude
missing data (currently represented as NaN).

Operations between Series (+, -, /, *, **) align values based on their
associated index values-- they need not be the same length. The result
index will be the sorted union of the two indexes.

Parameters
----------
data : array-like, Iterable, dict, or scalar value
    Contains data stored in Series. If data is a dict, argument order is
    maintained.
index : array-like or Index (1d)
    Values must be hashable and have the same length as `data`.
    Non-unique index values are allowed. Will default to
    RangeIndex (0, 1, 2, ..., n) if not provided. If data is dict-like
    and index is None, then the keys in the data are used as the index. If the
    index is not None, the resulting Series is reindexed with the index values.
dtype : str, numpy.dtype, or ExtensionDtype, optional
    Data type for the output Series. If not specified, this will be
    inferred from `data`.
    See the :ref:`user guide <basics.dtypes>` for more usages.
name : str, optional
    The name to give to the Series.
copy : bool, default False
    Copy input data. If False and the Series returns a `copy`
    of the data, the memory location for the values is not shared.
    If False and the Series returns a `view` on the data,
    the memory location for the values is shared.

Examples
--------
Constructing Series from a dictionary with an Index specified

>>> d = {'a': 1, 'b': 2, 'c': 3}
>>> ser = pd.Series(data=d, index=['a', 'b', 'c'])
>>> ser
a   1
b   2
c   3
dtype: int64

The keys of the dictionary match with the Index values, hence the Index
values have no effect.

>>> d = {'a': 1, 'b': 2, 'c': 3}
>>> ser = pd.Series(data=d, index=['x', 'y', 'z'])
>>> ser
x   NaN
y   NaN
z   NaN
dtype: float64

Note that the Index is first build with the keys from the dictionary.
After this the Series is reindexed with the given Index values, hence we
get all NaN as a result.

Constructing Series from an array with `copy=False`.

>>> r = [1,2]
>>> ser = pd.Series(r, copy=False)
>>> ser.iloc[0] = 999
>>> r
[1, 2]
>>> ser
0    999
1      2
dtype: int64

The Series returns a `copy` of the original data, so
the original data is unchanged.

Constructing Series from a `numpy.array` with `copy=False`.

>>> r = np.array([1,2])
>>> ser = pd.Series(r, copy=False)
>>> ser.iloc[0] = 999
>>> r
array([999,   2])
>>> ser
0    999
1      2
dtype: int32

The Series returns a `view` on the original data, so
the original data is changed as well.

################################################################################
################################## Validation ##################################
################################################################################

3 Errors found:
        Parameters {'fastpath'} not documented
        See Also section not found
        flake8 error: E902 PermissionError: [Errno 13] Permission denied: 'C:\\Users\\mdhsi\\AppData\\Local\\Temp\\tmpxz50buet'
```