### PR TITLE
REF: make array_to_datetime single-pass

### DIFF
--- a/pandas/_libs/tslibs/conversion.pyi
+++ b/pandas/_libs/tslibs/conversion.pyi
@@ -30,12 +30,4 @@ def ensure_timedelta64ns(
 ) -> np.ndarray: ...  # np.ndarray[timedelta64ns]
 
 
-def datetime_to_datetime64(
-    values: np.ndarray,  # np.ndarray[object]
-) -> tuple[
-    np.ndarray,  # np.ndarray[dt64ns]
-    tzinfo | None,
-]: ...
-
-
 def localize_pydatetime(dt: datetime, tz: tzinfo | None) -> datetime: ...

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2162,26 +2162,17 @@ def objects_to_datetime64ns(
 
     flags = data.flags
     order: Literal["F", "C"] = "F" if flags.f_contiguous else "C"
-    try:
-        result, tz_parsed = tslib.array_to_datetime(
-            data.ravel("K"),
-            errors=errors,
-            utc=utc,
-            dayfirst=dayfirst,
-            yearfirst=yearfirst,
-            require_iso8601=require_iso8601,
-            allow_mixed=allow_mixed,
-        )
-        result = result.reshape(data.shape, order=order)
-    except ValueError as err:
-        try:
-            values, tz_parsed = conversion.datetime_to_datetime64(data.ravel("K"))
-            # If tzaware, these values represent unix timestamps, so we
-            #  return them as i8 to distinguish from wall times
-            values = values.reshape(data.shape, order=order)
-            return values.view("i8"), tz_parsed
-        except (ValueError, TypeError):
-            raise err
+
+    result, tz_parsed = tslib.array_to_datetime(
+        data.ravel("K"),
+        errors=errors,
+        utc=utc,
+        dayfirst=dayfirst,
+        yearfirst=yearfirst,
+        require_iso8601=require_iso8601,
+        allow_mixed=allow_mixed,
+    )
+    result = result.reshape(data.shape, order=order)
 
     if tz_parsed is not None:
         # We can take a shortcut since the datetime64 numpy array

--- a/pandas/tests/indexes/datetimes/test_constructors.py
+++ b/pandas/tests/indexes/datetimes/test_constructors.py
@@ -458,7 +458,8 @@ class TestDatetimeIndex:
                 name="idx",
             )
 
-        with pytest.raises(ValueError, match=msg):
+        msg2 = "Cannot mix tz-aware with tz-naive values"
+        with pytest.raises(ValueError, match=msg2):
             DatetimeIndex(
                 [
                     Timestamp("2011-01-01 10:00"),
@@ -478,7 +479,7 @@ class TestDatetimeIndex:
                 name="idx",
             )
 
-        with pytest.raises(ValueError, match=msg):
+        with pytest.raises(ValueError, match=msg2):
             # passing tz should results in DatetimeIndex, then mismatch raises
             # TypeError
             with tm.assert_produces_warning(FutureWarning):

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -1079,7 +1079,7 @@ class TestToDatetime:
 
     def test_mixed_offsets_with_native_datetime_raises(self):
         # GH 25978
-        s = Series(
+        ser = Series(
             [
                 "nan",
                 Timestamp("1990-01-01"),
@@ -1088,8 +1088,12 @@ class TestToDatetime:
                 None,
             ]
         )
-        with pytest.raises(ValueError, match="Tz-aware datetime.datetime"):
-            to_datetime(s)
+        msg = (
+            "Tz-aware datetime.datetime cannot be converted "
+            "to datetime64 unless utc=True"
+        )
+        with pytest.raises(ValueError, match=msg):
+            to_datetime(ser)
 
     def test_non_iso_strings_with_tz_offset(self):
         result = to_datetime(["March 1, 2018 12:00:00+0400"] * 2)


### PR DESCRIPTION
Or more specifically, remove the need for falling back to datetime_to_datetime64 which does a second pass.