### PR TITLE
BUG: lib.infer_dtype with mixed-freq Periods

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -228,7 +228,7 @@ Other enhancements
 - Constructing a :class:`DataFrame` or :class:`Series` with the ``data`` argument being a Python iterable that is *not* a NumPy ``ndarray`` consisting of NumPy scalars will now result in a dtype with a precision the maximum of the NumPy scalars; this was already the case when ``data`` is a NumPy ``ndarray`` (:issue:`40908`)
 - Add keyword ``sort`` to :func:`pivot_table` to allow non-sorting of the result (:issue:`39143`)
 - Add keyword ``dropna`` to :meth:`DataFrame.value_counts` to allow counting rows that include ``NA`` values (:issue:`41325`)
--
+- :meth:`Series.replace` will now cast results to ``PeriodDtype`` where possible instead of ``object`` dtype (:issue:`41526`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/_libs/lib.pyi
+++ b/pandas/_libs/lib.pyi
@@ -40,7 +40,6 @@ def is_integer(val: object) -> bool: ...
 def is_float(val: object) -> bool: ...
 
 def is_interval_array(values: np.ndarray) -> bool: ...
-def is_period_array(values: np.ndarray) -> bool: ...
 def is_datetime64_array(values: np.ndarray) -> bool: ...
 def is_timedelta_or_timedelta64_array(values: np.ndarray) -> bool: ...
 def is_datetime_with_singletz_array(values: np.ndarray) -> bool: ...
@@ -67,50 +66,60 @@ def map_infer(
 @overload  # both convert_datetime and convert_to_nullable_integer False -> np.ndarray
 def maybe_convert_objects(
     objects: np.ndarray,  # np.ndarray[object]
+    *,
     try_float: bool = ...,
     safe: bool = ...,
     convert_datetime: Literal[False] = ...,
     convert_timedelta: bool = ...,
+    convert_period: Literal[False] = ...,
     convert_to_nullable_integer: Literal[False] = ...,
 ) -> np.ndarray: ...
 
 @overload
 def maybe_convert_objects(
     objects: np.ndarray,  # np.ndarray[object]
-    try_float: bool = ...,
-    safe: bool = ...,
-    convert_datetime: Literal[False] = False,
-    convert_timedelta: bool = ...,
-    convert_to_nullable_integer: Literal[True] = ...,
-) -> ArrayLike: ...
-
-@overload
-def maybe_convert_objects(
-    objects: np.ndarray,  # np.ndarray[object]
-    try_float: bool = ...,
-    safe: bool = ...,
-    convert_datetime: Literal[True] = ...,
-    convert_timedelta: bool = ...,
-    convert_to_nullable_integer: Literal[False] = ...,
-) -> ArrayLike: ...
-
-@overload
-def maybe_convert_objects(
-    objects: np.ndarray,  # np.ndarray[object]
-    try_float: bool = ...,
-    safe: bool = ...,
-    convert_datetime: Literal[True] = ...,
-    convert_timedelta: bool = ...,
-    convert_to_nullable_integer: Literal[True] = ...,
-) -> ArrayLike: ...
-
-@overload
-def maybe_convert_objects(
-    objects: np.ndarray,  # np.ndarray[object]
+    *,
     try_float: bool = ...,
     safe: bool = ...,
     convert_datetime: bool = ...,
     convert_timedelta: bool = ...,
+    convert_period: bool = ...,
+    convert_to_nullable_integer: Literal[True] = ...,
+) -> ArrayLike: ...
+
+@overload
+def maybe_convert_objects(
+    objects: np.ndarray,  # np.ndarray[object]
+    *,
+    try_float: bool = ...,
+    safe: bool = ...,
+    convert_datetime: Literal[True] = ...,
+    convert_timedelta: bool = ...,
+    convert_period: bool = ...,
+    convert_to_nullable_integer: bool = ...,
+) -> ArrayLike: ...
+
+@overload
+def maybe_convert_objects(
+    objects: np.ndarray,  # np.ndarray[object]
+    *,
+    try_float: bool = ...,
+    safe: bool = ...,
+    convert_datetime: bool = ...,
+    convert_timedelta: bool = ...,
+    convert_period: Literal[True] = ...,
+    convert_to_nullable_integer: bool = ...,
+) -> ArrayLike: ...
+
+@overload
+def maybe_convert_objects(
+    objects: np.ndarray,  # np.ndarray[object]
+    *,
+    try_float: bool = ...,
+    safe: bool = ...,
+    convert_datetime: bool = ...,
+    convert_timedelta: bool = ...,
+    convert_period: bool = ...,
     convert_to_nullable_integer: bool = ...,
 ) -> ArrayLike: ...
 

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -261,7 +261,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         """
         apply box func to passed values
         """
-        return lib.map_infer(values, self._box_func)
+        return lib.map_infer(values, self._box_func, convert=False)
 
     def __iter__(self):
         if self.ndim > 1:

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1315,6 +1315,7 @@ def soft_convert_objects(
     datetime: bool = True,
     numeric: bool = True,
     timedelta: bool = True,
+    period: bool = True,
     copy: bool = True,
 ) -> ArrayLike:
     """
@@ -1327,6 +1328,7 @@ def soft_convert_objects(
     datetime : bool, default True
     numeric: bool, default True
     timedelta : bool, default True
+    period : bool, default True
     copy : bool, default True
 
     Returns
@@ -1348,7 +1350,10 @@ def soft_convert_objects(
         # bound of nanosecond-resolution 64-bit integers.
         try:
             converted = lib.maybe_convert_objects(
-                values, convert_datetime=datetime, convert_timedelta=timedelta
+                values,
+                convert_datetime=datetime,
+                convert_timedelta=timedelta,
+                convert_period=period,
             )
         except (OutOfBoundsDatetime, ValueError):
             return values

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1021,11 +1021,9 @@ class TestDataFrameReplace:
             columns=["fname"],
         )
         assert set(df.fname.values) == set(d["fname"].keys())
-        # We don't support converting object -> specialized EA in
-        # replace yet.
-        expected = DataFrame(
-            {"fname": [d["fname"][k] for k in df.fname.values]}, dtype=object
-        )
+
+        expected = DataFrame({"fname": [d["fname"][k] for k in df.fname.values]})
+        assert expected.dtypes[0] == "Period[M]"
         result = df.replace(d)
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/series/methods/test_describe.py
+++ b/pandas/tests/series/methods/test_describe.py
@@ -11,31 +11,35 @@ import pandas._testing as tm
 
 
 class TestSeriesDescribe:
-    def test_describe(self):
-        s = Series([0, 1, 2, 3, 4], name="int_data")
-        result = s.describe()
+    def test_describe_ints(self):
+        ser = Series([0, 1, 2, 3, 4], name="int_data")
+        result = ser.describe()
         expected = Series(
-            [5, 2, s.std(), 0, 1, 2, 3, 4],
+            [5, 2, ser.std(), 0, 1, 2, 3, 4],
             name="int_data",
             index=["count", "mean", "std", "min", "25%", "50%", "75%", "max"],
         )
         tm.assert_series_equal(result, expected)
 
-        s = Series([True, True, False, False, False], name="bool_data")
-        result = s.describe()
+    def test_describe_bools(self):
+        ser = Series([True, True, False, False, False], name="bool_data")
+        result = ser.describe()
         expected = Series(
             [5, 2, False, 3], name="bool_data", index=["count", "unique", "top", "freq"]
         )
         tm.assert_series_equal(result, expected)
 
-        s = Series(["a", "a", "b", "c", "d"], name="str_data")
-        result = s.describe()
+    def test_describe_strs(self):
+
+        ser = Series(["a", "a", "b", "c", "d"], name="str_data")
+        result = ser.describe()
         expected = Series(
             [5, 4, "a", 2], name="str_data", index=["count", "unique", "top", "freq"]
         )
         tm.assert_series_equal(result, expected)
 
-        s = Series(
+    def test_describe_timedelta64(self):
+        ser = Series(
             [
                 Timedelta("1 days"),
                 Timedelta("2 days"),
@@ -45,21 +49,22 @@ class TestSeriesDescribe:
             ],
             name="timedelta_data",
         )
-        result = s.describe()
+        result = ser.describe()
         expected = Series(
-            [5, s[2], s.std(), s[0], s[1], s[2], s[3], s[4]],
+            [5, ser[2], ser.std(), ser[0], ser[1], ser[2], ser[3], ser[4]],
             name="timedelta_data",
             index=["count", "mean", "std", "min", "25%", "50%", "75%", "max"],
         )
         tm.assert_series_equal(result, expected)
 
-        s = Series(
+    def test_describe_period(self):
+        ser = Series(
             [Period("2020-01", "M"), Period("2020-01", "M"), Period("2019-12", "M")],
             name="period_data",
         )
-        result = s.describe()
+        result = ser.describe()
         expected = Series(
-            [3, 2, s[0], 2],
+            [3, 2, ser[0], 2],
             name="period_data",
             index=["count", "unique", "top", "freq"],
         )


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

Also adds a convert_period option to lib.maybe_infer_objects
