### PR TITLE
REF: Grouping.grouper -> Grouping.grouping_vector

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -3063,7 +3063,7 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
 
         # reindexing only applies to a Categorical grouper
         elif not any(
-            isinstance(ping.grouper, (Categorical, CategoricalIndex))
+            isinstance(ping.grouping_vector, (Categorical, CategoricalIndex))
             for ping in groupings
         ):
             return output

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -454,7 +454,7 @@ class Grouping:
     ):
         self.level = level
         self._orig_grouper = grouper
-        self.grouper = _convert_grouper(index, grouper)
+        self.grouping_vector = _convert_grouper(index, grouper)
         self.all_grouper = None
         self.index = index
         self.sort = sort
@@ -471,19 +471,19 @@ class Grouping:
         ilevel = self._ilevel
         if ilevel is not None:
             (
-                self.grouper,  # Index
+                self.grouping_vector,  # Index
                 self._codes,
                 self._group_index,
-            ) = index._get_grouper_for_level(self.grouper, ilevel)
+            ) = index._get_grouper_for_level(self.grouping_vector, ilevel)
 
         # a passed Grouper like, directly get the grouper in the same way
         # as single grouper groupby, use the group_info to get codes
-        elif isinstance(self.grouper, Grouper):
+        elif isinstance(self.grouping_vector, Grouper):
             # get the new grouper; we already have disambiguated
             # what key/level refer to exactly, don't need to
             # check again as we have by this point converted these
             # to an actual value (rather than a pd.Grouper)
-            _, newgrouper, newobj = self.grouper._get_grouper(
+            _, newgrouper, newobj = self.grouping_vector._get_grouper(
                 # error: Value of type variable "FrameOrSeries" of "_get_grouper"
                 # of "Grouper" cannot be "Optional[FrameOrSeries]"
                 self.obj,  # type: ignore[type-var]
@@ -494,45 +494,45 @@ class Grouping:
             ng = newgrouper._get_grouper()
             if isinstance(newgrouper, ops.BinGrouper):
                 # in this case we have `ng is newgrouper`
-                self.grouper = ng
+                self.grouping_vector = ng
             else:
                 # ops.BaseGrouper
                 # use Index instead of ndarray so we can recover the name
-                self.grouper = Index(ng, name=newgrouper.result_index.name)
+                self.grouping_vector = Index(ng, name=newgrouper.result_index.name)
 
         else:
             # a passed Categorical
-            if is_categorical_dtype(self.grouper):
+            if is_categorical_dtype(self.grouping_vector):
                 self._passed_categorical = True
 
-                self.grouper, self.all_grouper = recode_for_groupby(
-                    self.grouper, self.sort, observed
+                self.grouping_vector, self.all_grouper = recode_for_groupby(
+                    self.grouping_vector, self.sort, observed
                 )
 
             # no level passed
             elif not isinstance(
-                self.grouper, (Series, Index, ExtensionArray, np.ndarray)
+                self.grouping_vector, (Series, Index, ExtensionArray, np.ndarray)
             ):
-                if getattr(self.grouper, "ndim", 1) != 1:
-                    t = self.name or str(type(self.grouper))
+                if getattr(self.grouping_vector, "ndim", 1) != 1:
+                    t = self.name or str(type(self.grouping_vector))
                     raise ValueError(f"Grouper for '{t}' not 1-dimensional")
-                self.grouper = self.index.map(self.grouper)
+                self.grouping_vector = self.index.map(self.grouping_vector)
                 if not (
-                    hasattr(self.grouper, "__len__")
-                    and len(self.grouper) == len(self.index)
+                    hasattr(self.grouping_vector, "__len__")
+                    and len(self.grouping_vector) == len(self.index)
                 ):
-                    grper = pprint_thing(self.grouper)
+                    grper = pprint_thing(self.grouping_vector)
                     errmsg = (
                         "Grouper result violates len(labels) == "
                         f"len(data)\nresult: {grper}"
                     )
-                    self.grouper = None  # Try for sanity
+                    self.grouping_vector = None  # Try for sanity
                     raise AssertionError(errmsg)
 
-        if isinstance(self.grouper, np.ndarray):
+        if isinstance(self.grouping_vector, np.ndarray):
             # if we have a date/time-like grouper, make sure that we have
             # Timestamps like
-            self.grouper = sanitize_to_nanoseconds(self.grouper)
+            self.grouping_vector = sanitize_to_nanoseconds(self.grouping_vector)
 
     def __repr__(self) -> str:
         return f"Grouping({self.name})"
@@ -549,11 +549,11 @@ class Grouping:
         if isinstance(self._orig_grouper, (Index, Series)):
             return self._orig_grouper.name
 
-        elif isinstance(self.grouper, ops.BaseGrouper):
-            return self.grouper.result_index.name
+        elif isinstance(self.grouping_vector, ops.BaseGrouper):
+            return self.grouping_vector.result_index.name
 
-        elif isinstance(self.grouper, Index):
-            return self.grouper.name
+        elif isinstance(self.grouping_vector, Index):
+            return self.grouping_vector.name
 
         return None
 
@@ -579,10 +579,10 @@ class Grouping:
     @cache_readonly
     def indices(self):
         # we have a list of groupers
-        if isinstance(self.grouper, ops.BaseGrouper):
-            return self.grouper.indices
+        if isinstance(self.grouping_vector, ops.BaseGrouper):
+            return self.grouping_vector.indices
 
-        values = Categorical(self.grouper)
+        values = Categorical(self.grouping_vector)
         return values._reverse_indexer()
 
     @property
@@ -590,7 +590,7 @@ class Grouping:
         if self._passed_categorical:
             # we make a CategoricalIndex out of the cat grouper
             # preserving the categories / ordered attributes
-            cat = self.grouper
+            cat = self.grouping_vector
             return cat.codes
 
         if self._codes is None:
@@ -612,7 +612,7 @@ class Grouping:
         if self._passed_categorical:
             # we make a CategoricalIndex out of the cat grouper
             # preserving the categories / ordered attributes
-            cat = self.grouper
+            cat = self.grouping_vector
             categories = cat.categories
 
             if self.observed:
@@ -640,9 +640,9 @@ class Grouping:
             return
 
         # we have a list of groupers
-        if isinstance(self.grouper, ops.BaseGrouper):
-            codes = self.grouper.codes_info
-            uniques = self.grouper.result_index
+        if isinstance(self.grouping_vector, ops.BaseGrouper):
+            codes = self.grouping_vector.codes_info
+            uniques = self.grouping_vector.result_index
         else:
             # GH35667, replace dropna=False with na_sentinel=None
             if not self.dropna:
@@ -650,7 +650,7 @@ class Grouping:
             else:
                 na_sentinel = -1
             codes, uniques = algorithms.factorize(
-                self.grouper, sort=self.sort, na_sentinel=na_sentinel
+                self.grouping_vector, sort=self.sort, na_sentinel=na_sentinel
             )
             uniques = Index(uniques, name=self.name)
         self._codes = codes

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -734,7 +734,7 @@ class BaseGrouper:
         We have a specific method of grouping, so cannot
         convert to a Index for our grouper.
         """
-        return self.groupings[0].grouper
+        return self.groupings[0].grouping_vector
 
     @final
     def _get_group_keys(self):
@@ -858,7 +858,7 @@ class BaseGrouper:
         if len(self.groupings) == 1:
             return self.groupings[0].groups
         else:
-            to_groupby = zip(*(ping.grouper for ping in self.groupings))
+            to_groupby = zip(*(ping.grouping_vector for ping in self.groupings))
             index = Index(to_groupby)
             return self.axis.groupby(index)
 

--- a/pandas/tests/extension/base/groupby.py
+++ b/pandas/tests/extension/base/groupby.py
@@ -15,8 +15,8 @@ class BaseGroupbyTests(BaseExtensionTests):
         gr1 = df.groupby("A").grouper.groupings[0]
         gr2 = df.groupby("B").grouper.groupings[0]
 
-        tm.assert_numpy_array_equal(gr1.grouper, df.A.values)
-        tm.assert_extension_array_equal(gr2.grouper, data_for_grouping)
+        tm.assert_numpy_array_equal(gr1.grouping_vector, df.A.values)
+        tm.assert_extension_array_equal(gr2.grouping_vector, data_for_grouping)
 
     @pytest.mark.parametrize("as_index", [True, False])
     def test_groupby_extension_agg(self, as_index, data_for_grouping):

--- a/pandas/tests/extension/test_boolean.py
+++ b/pandas/tests/extension/test_boolean.py
@@ -262,8 +262,8 @@ class TestGroupby(base.BaseGroupbyTests):
         gr1 = df.groupby("A").grouper.groupings[0]
         gr2 = df.groupby("B").grouper.groupings[0]
 
-        tm.assert_numpy_array_equal(gr1.grouper, df.A.values)
-        tm.assert_extension_array_equal(gr2.grouper, data_for_grouping)
+        tm.assert_numpy_array_equal(gr1.grouping_vector, df.A.values)
+        tm.assert_extension_array_equal(gr2.grouping_vector, data_for_grouping)
 
     @pytest.mark.parametrize("as_index", [True, False])
     def test_groupby_extension_agg(self, as_index, data_for_grouping):

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -161,7 +161,7 @@ def test_agg_grouping_is_list_tuple(ts):
     df = tm.makeTimeDataFrame()
 
     grouped = df.groupby(lambda x: x.year)
-    grouper = grouped.grouper.groupings[0].grouper
+    grouper = grouped.grouper.groupings[0].grouping_vector
     grouped.grouper.groupings[0] = Grouping(ts.index, list(grouper))
 
     result = grouped.agg(np.mean)


### PR DESCRIPTION
Too many things have a .grouper attribute which makes it really difficult to follow what type of object we're dealing with at different places in the stack.  This changes the most-ambiguous attribute to grouping_vector.  I'm open to other names.