### PR TITLE
ENH: Read and write pandas attrs to parquet with pyarrow engine

### DIFF
--- a/doc/source/development/developer.rst
+++ b/doc/source/development/developer.rst
@@ -40,6 +40,8 @@ So that a ``pandas.DataFrame`` can be faithfully reconstructed, we store a
    {'index_columns': [<descr0>, <descr1>, ...],
     'column_indexes': [<ci0>, <ci1>, ..., <ciN>],
     'columns': [<c0>, <c1>, ...],
+    'attrs': {...},
+    'column_attrs': {<column_name0>: {...}, <column_name1>: {...}, ...},
     'pandas_version': $VERSION,
     'creator': {
       'library': $LIBRARY,
@@ -181,6 +183,52 @@ As an example of fully-formed metadata:
          'metadata': None}
     ],
     'pandas_version': '0.20.0',
+    'creator': {
+      'library': 'pyarrow',
+      'version': '0.13.0'
+    }}
+
+
+Attribute metadata
+~~~~~~~~~~~~~~~~~~
+
+.. warning:: This only works with the ``pyarrow`` engine as of ``pandas`` 1.3.
+
+The attributes of both the ``DataFrame`` and each ``Series`` are written to and read
+from using:
+
+- :attr:`DataFrame.attrs`
+- :attr:`Series.attrs`
+
+Here is an example:
+
+.. code-block:: python
+
+    df = pd.DataFrame({"a": [1], "b": [1]})
+    df.attrs = {"name": "my custom dataset"}
+    df.a.attrs = {
+        "long_name": "Description about data",
+        "nodata": -1,
+        "units": "metre",
+    }
+    df.to_parquet("file.parquet")
+
+
+Here is an example of the metadata:
+
+.. code-block:: text
+
+   {
+   ...
+    'attrs': {'name': 'my custom dataset'},
+    'column_attrs': {
+        'a': {
+            'long_name': 'Description about data',
+            'nodata': -1,
+            'units': 'metre',
+        },
+    },
+    'pandas_version': '1.3.0',
     'creator': {
       'library': 'pyarrow',
       'version': '0.13.0'

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -234,6 +234,7 @@ Other enhancements
 - Add keyword ``dropna`` to :meth:`DataFrame.value_counts` to allow counting rows that include ``NA`` values (:issue:`41325`)
 - :meth:`Series.replace` will now cast results to ``PeriodDtype`` where possible instead of ``object`` dtype (:issue:`41526`)
 - Improved error message in ``corr`` and ``cov`` methods on :class:`.Rolling`, :class:`.Expanding`, and :class:`.ExponentialMovingWindow` when ``other`` is not a :class:`DataFrame` or :class:`Series` (:issue:`41741`)
+- Read and write :class:`DataFrame` and :class:`Series` attrs to parquet with pyarrow engine (:issue:`20521`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -178,8 +178,8 @@ class PyArrowImpl(BaseImpl):
         pandas_metadata = json.loads(schema_metadata.get(b"pandas", "{}"))
         df.attrs = pandas_metadata.get("attrs", {})
         col_attrs = pandas_metadata.get("column_attrs", {})
-        for col, attrs in col_attrs.items():
-            df[col].attrs = attrs
+        for col in df.columns:
+            df[col].attrs = col_attrs.get(col, {})
 
     def write(
         self,

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -907,6 +907,26 @@ class TestParquetPyArrow(Base):
         else:
             assert isinstance(result._mgr, pd.core.internals.BlockManager)
 
+    @td.skip_if_no("pyarrow")
+    def test_read_write_attrs(self, pa):
+        df = pd.DataFrame({"a": [1]})
+        df.attrs = {"name": "my custom dataset"}
+        df.a.attrs = {
+            "long_name": "Description about data",
+            "nodata": -1,
+            "units": "metre",
+        }
+        with tm.ensure_clean() as path:
+            df.to_parquet(path)
+            result = read_parquet(path)
+
+        assert result.attrs == {"name": "my custom dataset"}
+        assert result["a"].attrs == {
+            "long_name": "Description about data",
+            "nodata": -1,
+            "units": "metre",
+        }
+
 
 class TestParquetFastParquet(Base):
     def test_basic(self, fp, df_full):

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -909,23 +909,25 @@ class TestParquetPyArrow(Base):
 
     @td.skip_if_no("pyarrow")
     def test_read_write_attrs(self, pa):
-        df = pd.DataFrame({"a": [1]})
+        df = pd.DataFrame({"a": [1], "b": [1]})
         df.attrs = {"name": "my custom dataset"}
         df.a.attrs = {
             "long_name": "Description about data",
             "nodata": -1,
             "units": "metre",
         }
+        df.b.attrs = {}
         with tm.ensure_clean() as path:
             df.to_parquet(path)
             result = read_parquet(path)
 
         assert result.attrs == {"name": "my custom dataset"}
-        assert result["a"].attrs == {
+        assert result.a.attrs == {
             "long_name": "Description about data",
             "nodata": -1,
             "units": "metre",
         }
+        assert result.b.attrs == {}
 
 
 class TestParquetFastParquet(Base):

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -929,6 +929,17 @@ class TestParquetPyArrow(Base):
         }
         assert result.b.attrs == {}
 
+    @td.skip_if_no("pyarrow")
+    def test_read_write_attrs__invalid(self, pa):
+        df = pd.DataFrame({"a": [1], "b": [1]})
+        df.attrs = {-1: np.array(1)}
+        df.a.attrs = {-1: np.array(1)}
+        df.b.attrs = {}
+        with tm.ensure_clean() as path, pytest.raises(
+            TypeError, match="not JSON serializable"
+        ):
+            df.to_parquet(path)
+
 
 class TestParquetFastParquet(Base):
     def test_basic(self, fp, df_full):


### PR DESCRIPTION
- [x] closes #20521
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
