### PR TITLE
DOC: redocument the `subset` arg in styler for clarity of use

### DIFF
--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -1,14 +1,5 @@
 """
 Module for applying conditional formatting to DataFrames and Series.
-
-.. |subset_doc| replace:: A valid 2d input to `DataFrame.loc[<subset>]`, or, in the case
-                          of a 1d input or single key, to `DataFrame.loc[:, <subset>]`
-                          where the columns are prioritised, to limit ``data`` to
-                          *before* applying the function.
-
-.. |subset_doc_1d| replace:: A valid 1d input or single key along the appropriate
-                             axis within `DataFrame.loc[]`, to limit ``data`` to
-                             *before* applying the function.
 """
 from __future__ import annotations
 
@@ -624,7 +615,9 @@ class Styler(StylerRenderer):
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.
         subset : key, array-like, IndexSlice, optional
-            |subset_doc|
+            A valid 2d input to `DataFrame.loc[<subset>]`, or, in the case of a 1d input
+            or single key, to `DataFrame.loc[:, <subset>]` where the columns are
+            prioritised, to limit ``data`` to *before* applying the function.
         **kwargs : dict
             Pass along to ``func``.
 
@@ -694,7 +687,9 @@ class Styler(StylerRenderer):
         func : function
             ``func`` should take a scalar and return a scalar.
         subset : key, array-like, IndexSlice, optional
-            |subset_doc|
+            A valid 2d input to `DataFrame.loc[<subset>]`, or, in the case of a 1d input
+            or single key, to `DataFrame.loc[:, <subset>]` where the columns are
+            prioritised, to limit ``data`` to *before* applying the function.
         **kwargs : dict
             Pass along to ``func``.
 
@@ -760,7 +755,9 @@ class Styler(StylerRenderer):
         other : str
             Applied when ``cond`` returns false.
         subset : label, array-like, IndexSlice, optional
-            |subset_doc|
+            A valid 2d input to `DataFrame.loc[<subset>]`, or, in the case of a 1d input
+            or single key, to `DataFrame.loc[:, <subset>]` where the columns are
+            prioritised, to limit ``data`` to *before* applying the function.
         **kwargs : dict
             Pass along to ``cond``.
 
@@ -1099,7 +1096,8 @@ class Styler(StylerRenderer):
         Parameters
         ----------
         subset : label, array-like, IndexSlice
-            |subset_doc_1d|
+            A valid 1d input or single key along the appropriate axis within
+            `DataFrame.loc[]`, to limit ``data`` to *before* applying the function.
 
         Returns
         -------
@@ -1153,7 +1151,9 @@ class Styler(StylerRenderer):
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.
         subset : label, array-like, IndexSlice, optional
-            |subset_doc|
+            A valid 2d input to `DataFrame.loc[<subset>]`, or, in the case of a 1d input
+            or single key, to `DataFrame.loc[:, <subset>]` where the columns are
+            prioritised, to limit ``data`` to *before* applying the function.
         text_color_threshold : float or int
             Luminance threshold for determining text color in [0, 1]. Facilitates text
             visibility across varying background colors. All text is dark if 0, and
@@ -1277,7 +1277,9 @@ class Styler(StylerRenderer):
         Parameters
         ----------
         subset : label, array-like, IndexSlice, optional
-            |subset_doc|
+            A valid 2d input to `DataFrame.loc[<subset>]`, or, in the case of a 1d input
+            or single key, to `DataFrame.loc[:, <subset>]` where the columns are
+            prioritised, to limit ``data`` to *before* applying the function.
         **kwargs : dict
             A dictionary of property, value pairs to be set for each cell.
 
@@ -1375,7 +1377,9 @@ class Styler(StylerRenderer):
         Parameters
         ----------
         subset : label, array-like, IndexSlice, optional
-            |subset_doc|.
+            A valid 2d input to `DataFrame.loc[<subset>]`, or, in the case of a 1d input
+            or single key, to `DataFrame.loc[:, <subset>]` where the columns are
+            prioritised, to limit ``data`` to *before* applying the function.
         axis : {0 or 'index', 1 or 'columns', None}, default 0
             Apply to each column (``axis=0`` or ``'index'``), to each row
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
@@ -1457,7 +1461,9 @@ class Styler(StylerRenderer):
         ----------
         null_color : str, default 'red'
         subset : label, array-like, IndexSlice, optional
-            |subset_doc|
+            A valid 2d input to `DataFrame.loc[<subset>]`, or, in the case of a 1d input
+            or single key, to `DataFrame.loc[:, <subset>]` where the columns are
+            prioritised, to limit ``data`` to *before* applying the function.
 
             .. versionadded:: 1.1.0
 
@@ -1503,7 +1509,9 @@ class Styler(StylerRenderer):
         Parameters
         ----------
         subset : label, array-like, IndexSlice, optional
-            |subset_doc|
+            A valid 2d input to `DataFrame.loc[<subset>]`, or, in the case of a 1d input
+            or single key, to `DataFrame.loc[:, <subset>]` where the columns are
+            prioritised, to limit ``data`` to *before* applying the function.
         color : str, default 'yellow'
             Background color to use for highlighting.
         axis : {0 or 'index', 1 or 'columns', None}, default 0
@@ -1552,7 +1560,9 @@ class Styler(StylerRenderer):
         Parameters
         ----------
         subset : label, array-like, IndexSlice, optional
-            |subset_doc|
+            A valid 2d input to `DataFrame.loc[<subset>]`, or, in the case of a 1d input
+            or single key, to `DataFrame.loc[:, <subset>]` where the columns are
+            prioritised, to limit ``data`` to *before* applying the function.
         color : str, default 'yellow'
             Background color to use for highlighting.
         axis : {0 or 'index', 1 or 'columns', None}, default 0
@@ -1606,7 +1616,9 @@ class Styler(StylerRenderer):
         Parameters
         ----------
         subset : label, array-like, IndexSlice, optional
-            |subset_doc|
+            A valid 2d input to `DataFrame.loc[<subset>]`, or, in the case of a 1d input
+            or single key, to `DataFrame.loc[:, <subset>]` where the columns are
+            prioritised, to limit ``data`` to *before* applying the function.
         color : str, default 'yellow'
             Background color to use for highlighting.
         axis : {0 or 'index', 1 or 'columns', None}, default 0
@@ -1714,7 +1726,9 @@ class Styler(StylerRenderer):
         Parameters
         ----------
         subset : label, array-like, IndexSlice, optional
-            |subset_doc|
+            A valid 2d input to `DataFrame.loc[<subset>]`, or, in the case of a 1d input
+            or single key, to `DataFrame.loc[:, <subset>]` where the columns are
+            prioritised, to limit ``data`` to *before* applying the function.
         color : str, default 'yellow'
             Background color to use for highlighting
         axis : {0 or 'index', 1 or 'columns', None}, default 0

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -614,7 +614,7 @@ class Styler(StylerRenderer):
             Apply to each column (``axis=0`` or ``'index'``), to each row
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.
-        subset : key, array-like, IndexSlice, optional
+        subset : label, array-like, IndexSlice, optional
             A valid 2d input to `DataFrame.loc[<subset>]`, or, in the case of a 1d input
             or single key, to `DataFrame.loc[:, <subset>]` where the columns are
             prioritised, to limit ``data`` to *before* applying the function.
@@ -686,7 +686,7 @@ class Styler(StylerRenderer):
         ----------
         func : function
             ``func`` should take a scalar and return a scalar.
-        subset : key, array-like, IndexSlice, optional
+        subset : label, array-like, IndexSlice, optional
             A valid 2d input to `DataFrame.loc[<subset>]`, or, in the case of a 1d input
             or single key, to `DataFrame.loc[:, <subset>]` where the columns are
             prioritised, to limit ``data`` to *before* applying the function.

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -1,5 +1,14 @@
 """
 Module for applying conditional formatting to DataFrames and Series.
+
+.. |subset_doc| replace:: A valid 2d input to `DataFrame.loc[<subset>]`, or, in the case
+                          of a 1d input or single key, to `DataFrame.loc[:, <subset>]`
+                          where the columns are prioritised, to limit ``data`` to
+                          *before* applying the function.
+
+.. |subset_doc_1d| replace:: A valid 1d input or single key along the appropriate
+                             axis within `DataFrame.loc[]`, to limit ``data`` to
+                             *before* applying the function.
 """
 from __future__ import annotations
 
@@ -614,9 +623,8 @@ class Styler(StylerRenderer):
             Apply to each column (``axis=0`` or ``'index'``), to each row
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.
-        subset : IndexSlice
-            A valid indexer to limit ``data`` to *before* applying the
-            function. Consider using a pandas.IndexSlice.
+        subset : key, array-like, IndexSlice
+            |subset_doc|
         **kwargs : dict
             Pass along to ``func``.
 
@@ -642,10 +650,20 @@ class Styler(StylerRenderer):
         --------
         >>> def highlight_max(x, color):
         ...     return np.where(x == np.nanmax(x.to_numpy()), f"color: {color};", None)
-        >>> df = pd.DataFrame(np.random.randn(5, 2))
+        >>> df = pd.DataFrame(np.random.randn(5, 2), columns=["A", "B"])
         >>> df.style.apply(highlight_max, color='red')
         >>> df.style.apply(highlight_max, color='blue', axis=1)
         >>> df.style.apply(highlight_max, color='green', axis=None)
+
+        Using ``subset`` to restrict application to a single column or multiple columns
+
+        >>> df.style.apply(highlight_max, color='red', subset="A")
+        >>> df.style.apply(highlight_max, color='red', subset=["A", "B"])
+
+        Using a 2d input to ``subset`` to select rows in addition to columns
+
+        >>> df.style.apply(highlight_max, color='red', subset=([0,1,2], slice(None))
+        >>> df.style.apply(highlight_max, color='red', subset=(slice(0,5,2), "A")
         """
         self._todo.append(
             (lambda instance: getattr(instance, "_apply"), (func, axis, subset), kwargs)
@@ -675,9 +693,8 @@ class Styler(StylerRenderer):
         ----------
         func : function
             ``func`` should take a scalar and return a scalar.
-        subset : IndexSlice
-            A valid indexer to limit ``data`` to *before* applying the
-            function. Consider using a pandas.IndexSlice.
+        subset : key, array-like, IndexSlice
+            |subset_doc|
         **kwargs : dict
             Pass along to ``func``.
 
@@ -699,8 +716,18 @@ class Styler(StylerRenderer):
         --------
         >>> def color_negative(v, color):
         ...     return f"color: {color};" if v < 0 else None
-        >>> df = pd.DataFrame(np.random.randn(5, 2))
+        >>> df = pd.DataFrame(np.random.randn(5, 2), columns=["A", "B"])
         >>> df.style.applymap(color_negative, color='red')
+
+        Using ``subset`` to restrict application to a single column or multiple columns
+
+        >>> df.style.applymap(color_negative, color='red', subset="A")
+        >>> df.style.applymap(color_negative, color='red', subset=["A", "B"])
+
+        Using a 2d input to ``subset`` to select rows in addition to columns
+
+        >>> df.style.applymap(color_negative, color='red', subset=([0,1,2], slice(None))
+        >>> df.style.applymap(color_negative, color='red', subset=(slice(0,5,2), "A")
         """
         self._todo.append(
             (lambda instance: getattr(instance, "_applymap"), (func, subset), kwargs)
@@ -732,9 +759,8 @@ class Styler(StylerRenderer):
             Applied when ``cond`` returns true.
         other : str
             Applied when ``cond`` returns false.
-        subset : IndexSlice
-            A valid indexer to limit ``data`` to *before* applying the
-            function. Consider using a pandas.IndexSlice.
+        subset : label, array-like, IndexSlice
+            |subset_doc|
         **kwargs : dict
             Pass along to ``cond``.
 
@@ -1072,9 +1098,8 @@ class Styler(StylerRenderer):
 
         Parameters
         ----------
-        subset : IndexSlice
-            An argument to ``DataFrame.loc`` that identifies which columns
-            are hidden.
+        subset : label, array-like, IndexSlice
+            |subset_doc_1d|
 
         Returns
         -------
@@ -1127,8 +1152,8 @@ class Styler(StylerRenderer):
             Apply to each column (``axis=0`` or ``'index'``), to each row
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.
-        subset : IndexSlice
-            A valid slice for ``data`` to limit the style application to.
+        subset : label, array-like, IndexSlice
+            |subset_doc|
         text_color_threshold : float or int
             Luminance threshold for determining text color in [0, 1]. Facilitates text
             visibility across varying background colors. All text is dark if 0, and
@@ -1251,8 +1276,8 @@ class Styler(StylerRenderer):
 
         Parameters
         ----------
-        subset : IndexSlice
-            A valid slice for ``data`` to limit the style application to.
+        subset : label, array-like, IndexSlice
+            |subset_doc|
         **kwargs : dict
             A dictionary of property, value pairs to be set for each cell.
 
@@ -1349,8 +1374,8 @@ class Styler(StylerRenderer):
 
         Parameters
         ----------
-        subset : IndexSlice, optional
-            A valid slice for `data` to limit the style application to.
+        subset : label, array-like, IndexSlice
+            |subset_doc|.
         axis : {0 or 'index', 1 or 'columns', None}, default 0
             Apply to each column (``axis=0`` or ``'index'``), to each row
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
@@ -1431,8 +1456,8 @@ class Styler(StylerRenderer):
         Parameters
         ----------
         null_color : str, default 'red'
-        subset : label or list of labels, default None
-            A valid slice for ``data`` to limit the style application to.
+        subset : label, array-like, IndexSlice
+            |subset_doc|
 
             .. versionadded:: 1.1.0
 
@@ -1477,8 +1502,8 @@ class Styler(StylerRenderer):
 
         Parameters
         ----------
-        subset : IndexSlice, default None
-            A valid slice for ``data`` to limit the style application to.
+        subset : label, array-like, IndexSlice
+            |subset_doc|
         color : str, default 'yellow'
             Background color to use for highlighting.
         axis : {0 or 'index', 1 or 'columns', None}, default 0
@@ -1526,8 +1551,8 @@ class Styler(StylerRenderer):
 
         Parameters
         ----------
-        subset : IndexSlice, default None
-            A valid slice for ``data`` to limit the style application to.
+        subset : label, array-like, IndexSlice
+            |subset_doc|
         color : str, default 'yellow'
             Background color to use for highlighting.
         axis : {0 or 'index', 1 or 'columns', None}, default 0
@@ -1580,8 +1605,8 @@ class Styler(StylerRenderer):
 
         Parameters
         ----------
-        subset : IndexSlice, default None
-            A valid slice for ``data`` to limit the style application to.
+        subset : label, array-like, IndexSlice
+            |subset_doc|
         color : str, default 'yellow'
             Background color to use for highlighting.
         axis : {0 or 'index', 1 or 'columns', None}, default 0
@@ -1688,8 +1713,8 @@ class Styler(StylerRenderer):
 
         Parameters
         ----------
-        subset : IndexSlice, default None
-            A valid slice for ``data`` to limit the style application to.
+        subset : label, array-like, IndexSlice
+            |subset_doc|
         color : str, default 'yellow'
             Background color to use for highlighting
         axis : {0 or 'index', 1 or 'columns', None}, default 0

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -623,7 +623,7 @@ class Styler(StylerRenderer):
             Apply to each column (``axis=0`` or ``'index'``), to each row
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.
-        subset : key, array-like, IndexSlice
+        subset : key, array-like, IndexSlice, optional
             |subset_doc|
         **kwargs : dict
             Pass along to ``func``.
@@ -693,7 +693,7 @@ class Styler(StylerRenderer):
         ----------
         func : function
             ``func`` should take a scalar and return a scalar.
-        subset : key, array-like, IndexSlice
+        subset : key, array-like, IndexSlice, optional
             |subset_doc|
         **kwargs : dict
             Pass along to ``func``.
@@ -759,7 +759,7 @@ class Styler(StylerRenderer):
             Applied when ``cond`` returns true.
         other : str
             Applied when ``cond`` returns false.
-        subset : label, array-like, IndexSlice
+        subset : label, array-like, IndexSlice, optional
             |subset_doc|
         **kwargs : dict
             Pass along to ``cond``.
@@ -1152,7 +1152,7 @@ class Styler(StylerRenderer):
             Apply to each column (``axis=0`` or ``'index'``), to each row
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.
-        subset : label, array-like, IndexSlice
+        subset : label, array-like, IndexSlice, optional
             |subset_doc|
         text_color_threshold : float or int
             Luminance threshold for determining text color in [0, 1]. Facilitates text
@@ -1276,7 +1276,7 @@ class Styler(StylerRenderer):
 
         Parameters
         ----------
-        subset : label, array-like, IndexSlice
+        subset : label, array-like, IndexSlice, optional
             |subset_doc|
         **kwargs : dict
             A dictionary of property, value pairs to be set for each cell.
@@ -1374,7 +1374,7 @@ class Styler(StylerRenderer):
 
         Parameters
         ----------
-        subset : label, array-like, IndexSlice
+        subset : label, array-like, IndexSlice, optional
             |subset_doc|.
         axis : {0 or 'index', 1 or 'columns', None}, default 0
             Apply to each column (``axis=0`` or ``'index'``), to each row
@@ -1456,7 +1456,7 @@ class Styler(StylerRenderer):
         Parameters
         ----------
         null_color : str, default 'red'
-        subset : label, array-like, IndexSlice
+        subset : label, array-like, IndexSlice, optional
             |subset_doc|
 
             .. versionadded:: 1.1.0
@@ -1502,7 +1502,7 @@ class Styler(StylerRenderer):
 
         Parameters
         ----------
-        subset : label, array-like, IndexSlice
+        subset : label, array-like, IndexSlice, optional
             |subset_doc|
         color : str, default 'yellow'
             Background color to use for highlighting.
@@ -1551,7 +1551,7 @@ class Styler(StylerRenderer):
 
         Parameters
         ----------
-        subset : label, array-like, IndexSlice
+        subset : label, array-like, IndexSlice, optional
             |subset_doc|
         color : str, default 'yellow'
             Background color to use for highlighting.
@@ -1605,7 +1605,7 @@ class Styler(StylerRenderer):
 
         Parameters
         ----------
-        subset : label, array-like, IndexSlice
+        subset : label, array-like, IndexSlice, optional
             |subset_doc|
         color : str, default 'yellow'
             Background color to use for highlighting.
@@ -1713,7 +1713,7 @@ class Styler(StylerRenderer):
 
         Parameters
         ----------
-        subset : label, array-like, IndexSlice
+        subset : label, array-like, IndexSlice, optional
             |subset_doc|
         color : str, default 'yellow'
             Background color to use for highlighting

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -418,10 +418,9 @@ class StylerRenderer:
         formatter : str, callable, dict or None
             Object to define how values are displayed. See notes.
         subset : label, array-like, IndexSlice, optional
-            A valid 2d input to `DataFrame.loc[<subset>]`, or, in the case
-            of a 1d input or single key, to `DataFrame.loc[:, <subset>]`
-            where the columns are prioritised, to limit ``data`` to
-            *before* applying the function.
+            A valid 2d input to `DataFrame.loc[<subset>]`, or, in the case of a 1d input
+            or single key, to `DataFrame.loc[:, <subset>]` where the columns are
+            prioritised, to limit ``data`` to *before* applying the function.
         na_rep : str, optional
             Representation for missing values.
             If ``na_rep`` is None, no special formatting is applied.

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -417,9 +417,11 @@ class StylerRenderer:
         ----------
         formatter : str, callable, dict or None
             Object to define how values are displayed. See notes.
-        subset : IndexSlice
-            An argument to ``DataFrame.loc`` that restricts which elements
-            ``formatter`` is applied to.
+        subset : label, array-like, IndexSlice, optional
+            A valid 2d input to `DataFrame.loc[<subset>]`, or, in the case
+            of a 1d input or single key, to `DataFrame.loc[:, <subset>]`
+            where the columns are prioritised, to limit ``data`` to
+            *before* applying the function.
         na_rep : str, optional
             Representation for missing values.
             If ``na_rep`` is None, no special formatting is applied.


### PR DESCRIPTION
came up in a comment to another PR, so here it is changed for all appropriate methods.
