### PR TITLE
[ArrowStringArray] PERF: bypass some padding code in _wrap_result

### DIFF
--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -277,19 +277,13 @@ class StringMethods(NoNewAttributesMixin):
             # required when expand=True is explicitly specified
             # not needed when inferred
 
-            def cons_row(x):
-                if is_list_like(x):
-                    return x
-                else:
-                    return [x]
+            mask = isna(result)
+            result = [[x] if mask[i] else x for i, x in enumerate(result)]
 
-            result = [cons_row(x) for x in result]
             if result and not self._is_string:
                 # propagate nan values to match longest sequence (GH 18450)
                 max_len = max(len(x) for x in result)
-                result = [
-                    x * max_len if len(x) == 0 or x[0] is np.nan else x for x in result
-                ]
+                result = [x * max_len if mask[i] else x for i, x in enumerate(result)]
 
         if not isinstance(expand, bool):
             raise ValueError("expand must be True or False")

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -284,7 +284,7 @@ class StringMethods(NoNewAttributesMixin):
                     return [x]
 
             result = [cons_row(x) for x in result]
-            if result:
+            if result and not self._is_string:
                 # propagate nan values to match longest sequence (GH 18450)
                 max_len = max(len(x) for x in result)
                 result = [

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -277,13 +277,19 @@ class StringMethods(NoNewAttributesMixin):
             # required when expand=True is explicitly specified
             # not needed when inferred
 
-            mask = isna(result)
-            result = [[x] if mask[i] else x for i, x in enumerate(result)]
+            def cons_row(x):
+                if is_list_like(x):
+                    return x
+                else:
+                    return [x]
 
+            result = [cons_row(x) for x in result]
             if result and not self._is_string:
                 # propagate nan values to match longest sequence (GH 18450)
                 max_len = max(len(x) for x in result)
-                result = [x * max_len if mask[i] else x for i, x in enumerate(result)]
+                result = [
+                    x * max_len if len(x) == 0 or x[0] is np.nan else x for x in result
+                ]
 
         if not isinstance(expand, bool):
             raise ValueError("expand must be True or False")


### PR DESCRIPTION
The padding of np.nan across all columns is not needed for StringArray/ArrowStringArray

```
       before           after         ratio
     [896256ee]       [1c883e0d]
     <master>         <bypass>  
-      99.3±0.6ms         87.4±1ms     0.88  strings.Split.time_split('string', True)
-      89.6±0.3ms         78.7±1ms     0.88  strings.Split.time_rsplit('arrow_string', True)
-      71.3±0.5ms       58.7±0.8ms     0.82  strings.Split.time_rsplit('string', True)
-      60.0±0.4ms         49.1±1ms     0.82  strings.Methods.time_partition('arrow_string')
-      59.0±0.7ms         47.5±1ms     0.80  strings.Methods.time_rpartition('arrow_string')
-     50.5±0.08ms       38.3±0.4ms     0.76  strings.Methods.time_partition('string')
-      49.5±0.3ms       37.2±0.2ms     0.75  strings.Methods.time_rpartition('string')

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```

this is a small change for perf.

The padding code logic does not work for st.extract since the first value of a list maybe np.nan followed by other values. I made that change here and then reverted as is moreless perf neutral. so will do in another PR that uses _wrap_result more for str_extract. (str.extract returns list of lists where any value in the list could be np.nan, str.split returns array of lists with different lengths without np.nans and the np.nans returned as scalars)

some further gains can also be achieved by bypassing the converting of `np.nan` to `[np.nan]` for partition (for StringArray/ArrowStringArray) since the DataFrame constructor does not need this for a list of tuples. (str.partition returns array of tuples, str.split returns array of lists) #41507