### PR TITLE
ENH: add timezone awareness for formatting iso8601 datetimes to json

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -218,6 +218,7 @@ Other enhancements
 - :meth:`Series.loc.__getitem__` and :meth:`Series.loc.__setitem__` with :class:`MultiIndex` now raising helpful error message when indexer has too many dimensions (:issue:`35349`)
 - :meth:`pandas.read_stata` and :class:`StataReader` support reading data from compressed files.
 - Add support for parsing ``ISO 8601``-like timestamps with negative signs to :meth:`pandas.Timedelta` (:issue:`37172`)
+- Add support for making ``ISO 8601``-like timestamps with timezone information in pd.io.json.dumps (:issue:`12997`)
 - Add support for unary operators in :class:`FloatingArray` (:issue:`38749`)
 - :class:`RangeIndex` can now be constructed by passing a ``range`` object directly e.g. ``pd.RangeIndex(range(3))`` (:issue:`12067`)
 - :meth:`round` being enabled for the nullable integer and floating dtypes (:issue:`38844`)

--- a/pandas/_libs/src/ujson/python/date_conversions.c
+++ b/pandas/_libs/src/ujson/python/date_conversions.c
@@ -96,6 +96,9 @@ char *PyDateTimeToIso(PyObject *obj, NPY_DATETIMEUNIT base,
 
         if ((tzinfo != NULL) && (tzinfo != Py_None)){
             tzoffset = get_tzoffset_from_pytzinfo(tzinfo, &dts);
+            if (tzoffset == 0){
+                tzoffset = -1;
+            }
         }
     }
 

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -538,9 +538,7 @@ int NpyArr_iterNext(JSOBJ _obj, JSONTypeContext *tc) {
 }
 
 JSOBJ NpyArr_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
-    JSOBJ ret;
-    ret = GET_TC(tc)->itemValue;
-    return ret;
+    return GET_TC(tc)->itemValue;
 }
 
 char *NpyArr_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -216,13 +216,13 @@ static TypeContext *createTypeContext(void) {
     return pc;
 }
 
-static PyObject *get_tzinfo(PyObject *obj){
-    if (PyObject_HasAttrString(obj, "tzinfo")){
-        PyObject *tzinfo = PyObject_GetAttrString(obj, "tzinfo");
-        return tzinfo;
-    }
-    return Py_None;
-}
+// static PyObject *get_tzinfo(PyObject *obj){
+//     if (PyObject_HasAttrString(obj, "tzinfo")){
+//         PyObject *tzinfo = PyObject_GetAttrString(obj, "tzinfo");
+//         return tzinfo;
+//     }
+//     return Py_None;
+// }
 
 static PyObject *get_values(PyObject *obj) {
     PyObject *values = NULL;

--- a/pandas/_libs/tslibs/src/datetime/np_datetime.c
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime.c
@@ -795,19 +795,18 @@ int get_tzoffset_from_pytzinfo(PyObject *timezone_obj, npy_datetimestruct *dts)
 {
     PyDateTime_Date *dt;
     PyDateTime_Delta *tzoffset;
-    npy_datetimestruct loc_dts;
 
     /* Create a Python datetime to give to the timezone object */
-    dt = PyDateTime_FromDateAndTimeAndZone((int)dts->year, dts->month, dts->day,
+    dt = (PyDateTime_Date *) PyDateTime_FromDateAndTimeAndZone((int)dts->year, dts->month, dts->day,
                             dts->hour, dts->min, 0, 0, timezone_obj);
-    if (dt == NULL || !(PyDateTime_Check(dt))) {
+    if (!(PyDateTime_Check(dt))) {
         Py_DECREF(dt);
         return -1;
     }
-    tzoffset = PyObject_CallMethod(timezone_obj, "utcoffset", "O", dt);
+    tzoffset = (PyDateTime_Delta *) PyObject_CallMethod(timezone_obj, "utcoffset", "O", dt);
     
     Py_DECREF(dt);
-    if ((tzoffset == Py_None || tzoffset == NULL) || !(PyDelta_Check(tzoffset))){
+    if (!(PyDelta_Check(tzoffset))){
         Py_DECREF(tzoffset);
         return -1;
     }

--- a/pandas/_libs/tslibs/src/datetime/np_datetime.c
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime.c
@@ -776,18 +776,6 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
 }
 
 /*
- * Calculates the minutes offset from the 1970 epoch.
- */
-static npy_int64 get_datetimestruct_minutes(const npy_datetimestruct *dts)
-{
-    npy_int64 days = get_datetimestruct_days(dts) * 24 * 60;
-    days += dts->hour * 60;
-    days += dts->min;
-
-    return days;
-}
-
-/*
  * Gets a tzoffset in minutes by calling the fromutc() function on
  * the Python datetime.tzinfo object.
  */

--- a/pandas/_libs/tslibs/src/datetime/np_datetime.h
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime.h
@@ -33,6 +33,7 @@ extern const npy_datetimestruct _NS_MAX_DTS;
 
 // stuff pandas needs
 // ----------------------------------------------------------------------------
+void pandas_pydatetime_import(void);
 
 int convert_pydatetime_to_datetimestruct(PyObject *dtobj,
                                          npy_datetimestruct *out);
@@ -75,5 +76,10 @@ int cmp_npy_datetimestruct(const npy_datetimestruct *a,
 void
 add_minutes_to_datetimestruct(npy_datetimestruct *dts, int minutes);
 
+/*
+ * Gets a tzoffset in minutes by calling the fromutc() function on
+ * the Python datetime.tzinfo object.
+ */
+int get_tzoffset_from_pytzinfo(PyObject *timezone_obj, npy_datetimestruct *dts);
 
 #endif  // PANDAS__LIBS_TSLIBS_SRC_DATETIME_NP_DATETIME_H_

--- a/pandas/_libs/tslibs/src/datetime/np_datetime_strings.h
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime_strings.h
@@ -78,7 +78,7 @@ get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base);
  */
 int
 make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
-                       NPY_DATETIMEUNIT base);
+                       NPY_DATETIMEUNIT base, int tzoffset);
 
 /*
  * Converts an pandas_timedeltastruct to an ISO 8601 string.

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1211,7 +1211,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         assert dumps(ts, iso_dates=True) == exp
         dt = ts.to_pydatetime()
         assert dumps(dt, iso_dates=True) == exp
-    
+
     @pytest.mark.parametrize(
         "tz_range",
         [
@@ -1234,7 +1234,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         df = DataFrame({"DT": dti})
         result = dumps(df, iso_dates=True)
         assert result == dfexp
-    
+
     @pytest.mark.parametrize(
         "tz_range",
         [

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1185,8 +1185,6 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         "ts",
         [
             Timestamp("2013-01-10 05:00:00Z"),
-            Timestamp("2013-01-10 00:00:00", tz="US/Eastern"),
-            Timestamp("2013-01-10 00:00:00-0500"),
         ],
     )
     def test_tz_is_utc(self, ts):
@@ -1199,11 +1197,25 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         assert dumps(dt, iso_dates=True) == exp
 
     @pytest.mark.parametrize(
+        "ts",
+        [
+            Timestamp("2013-01-10 00:00:00", tz="US/Eastern"),
+            Timestamp("2013-01-10 00:00:00-0500"),
+        ],
+    )
+    def test_tz_is_localized(self, ts):
+        from pandas.io.json import dumps
+
+        exp = '"2013-01-10T00:00:00.000-05:00"'
+
+        assert dumps(ts, iso_dates=True) == exp
+        dt = ts.to_pydatetime()
+        assert dumps(dt, iso_dates=True) == exp
+    
+    @pytest.mark.parametrize(
         "tz_range",
         [
-            pd.date_range("2013-01-01 05:00:00Z", periods=2),
-            pd.date_range("2013-01-01 00:00:00", periods=2, tz="US/Eastern"),
-            pd.date_range("2013-01-01 00:00:00-0500", periods=2),
+            pd.date_range("2013-01-01 05:00:00Z", periods=2)
         ],
     )
     def test_tz_range_is_utc(self, tz_range):
@@ -1214,6 +1226,30 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
             '{"DT":{'
             '"0":"2013-01-01T05:00:00.000Z",'
             '"1":"2013-01-02T05:00:00.000Z"}}'
+        )
+
+        assert dumps(tz_range, iso_dates=True) == exp
+        dti = DatetimeIndex(tz_range)
+        assert dumps(dti, iso_dates=True) == exp
+        df = DataFrame({"DT": dti})
+        result = dumps(df, iso_dates=True)
+        assert result == dfexp
+    
+    @pytest.mark.parametrize(
+        "tz_range",
+        [
+            pd.date_range("2013-01-01 00:00:00", periods=2, tz='US/Eastern'),
+            pd.date_range("2013-01-01 00:00:00-0500", periods=2)
+        ],
+    )
+    def test_tz_range_is_local(self, tz_range):
+        from pandas.io.json import dumps
+
+        exp = '["2013-01-01T05:00:00.000Z","2013-01-02T05:00:00.000Z"]'
+        dfexp = (
+            '{"DT":{'
+            '"0":"2013-01-01T00:00:00.000-05:00",'
+            '"1":"2013-01-02T00:00:00.000-05:00"}}'
         )
 
         assert dumps(tz_range, iso_dates=True) == exp

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -391,7 +391,7 @@ class TestUltraJSONTests:
 
     def test_encode_time_conversion_pytz(self):
         # see gh-11473: to_json segfaults with timezone-aware datetimes
-        test = datetime.datetime(10, 12, 15, 343243, pytz.timezone('US/Eastern'))
+        test = datetime.datetime(2021, 5, 25, 10, 12, 15, 343243, pytz.timezone('US/Eastern'))
         output = ujson.encode(test, iso_dates=True, date_unit='us')
         expected = f'"{test.isoformat()}"'
         assert expected == output

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -391,7 +391,8 @@ class TestUltraJSONTests:
 
     def test_encode_time_conversion_pytz(self):
         # see gh-11473: to_json segfaults with timezone-aware datetimes
-        test = datetime.datetime(2021, 5, 25, 10, 12, 15, 343243, pytz.timezone('US/Eastern'))
+        test = datetime.datetime(2021, 5, 25, 10, 12, 15, 343243, \
+                                 pytz.timezone('US/Eastern'))
         output = ujson.encode(test, iso_dates=True, date_unit='us')
         expected = f'"{test.isoformat()}"'
         assert expected == output

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -391,8 +391,8 @@ class TestUltraJSONTests:
 
     def test_encode_time_conversion_pytz(self):
         # see gh-11473: to_json segfaults with timezone-aware datetimes
-        test = datetime.time(10, 12, 15, 343243, pytz.utc)
-        output = ujson.encode(test)
+        test = datetime.datetime(10, 12, 15, 343243, pytz.timezone('US/Eastern'))
+        output = ujson.encode(test, iso_dates=True, date_unit='us')
         expected = f'"{test.isoformat()}"'
         assert expected == output
 

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -391,7 +391,7 @@ class TestUltraJSONTests:
 
     def test_encode_time_conversion_pytz(self):
         # see gh-11473: to_json segfaults with timezone-aware datetimes
-        test = datetime.datetime(2021, 5, 25, 10, 12, 15, 343243, \
+        test = datetime.datetime(2021, 5, 25, 10, 12, 15, 343243,
                                  pytz.timezone('US/Eastern'))
         output = ujson.encode(test, iso_dates=True, date_unit='us')
         expected = f'"{test.isoformat()}"'


### PR DESCRIPTION
This PR allows for non-UTC printing of datetime strings from the `to_json` method when passing in local timestamps

- [x]  closes #12997
- [x]  tests modified
- [ ]  Ensure all linting tests pass, see here for how to run them
- [x]  whatsnew entry
Ok, so this is a doozy AND it's not done, but it can be merged as is.
What do we do:
We add timezones to json output!
Before:
```
ts = pd.Timestamp('2020-10-5 4:00:05', tz='US/Pacific')
print(pd.io.json.dumps(ts, iso_dates=True))
print(ts.isoformat())
```
would produce
`"2020-10-05T11:00:05.000Z"`
and
`"2020-10-05T04:00:05.000-07:00"`
respectively.

Now they both produce
`"2020-10-05T04:00:05.000-07:00"`

So what do I mean by not complete?
This still doesn't work for arrays that have datetime values. This only works for single datetime values.
So:
`pd.DataFrame({'foo': range(5)}, index=pd.date_range('2020-10-12', freq='H', periods=5, tz='US/Eastern')).to_json(date_format='iso')`

will still produce:
`'{"foo":{"2020-10-12T04:00:00.000Z":0,"2020-10-12T05:00:00.000Z":1,"2020-10-12T06:00:00.000Z":2,"2020-10-12T07:00:00.000Z":3,"2020-10-12T08:00:00.000Z":4}}'`

and not
`'{"foo":{"2020-10-12T00:00:00.000-04:00":0,"2020-10-12T01:00:00.000-04:00":1,"2020-10-12T02:00:00.000-04:00":2,"2020-10-12T03:00:00.000-04:00":3,"2020-10-12T04:00:00.000-04:00":4}}'`

Working on it currently. Open to recommendations!