### PR TITLE
TYP and DOC: pd.merge accepts Series

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -260,6 +260,8 @@ _numeric_only_doc = """numeric_only : bool or None, default None
 _merge_doc = """
 Merge DataFrame or named Series objects with a database-style join.
 
+A named Series object is treated as a DataFrame with a single named column.
+
 The join is done on columns or indexes. If joining columns on
 columns, the DataFrame indexes *will be ignored*. Otherwise if joining indexes
 on indexes or indexes on a column or columns, the index will be passed on.

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -27,7 +27,6 @@ from pandas._typing import (
     ArrayLike,
     DtypeObj,
     FrameOrSeries,
-    FrameOrSeriesUnion,
     IndexLabel,
     Suffixes,
 )
@@ -81,15 +80,15 @@ from pandas.core.internals import concatenate_managers
 from pandas.core.sorting import is_int64_overflow_possible
 
 if TYPE_CHECKING:
-    from pandas import DataFrame
+    from pandas import DataFrame, Series
     from pandas.core.arrays import DatetimeArray
 
 
 @Substitution("\nleft : DataFrame or named Series")
 @Appender(_merge_doc, indents=0)
 def merge(
-    left: FrameOrSeriesUnion,
-    right: FrameOrSeriesUnion,
+    left: DataFrame | Series,
+    right: DataFrame | Series,
     how: str = "inner",
     on: IndexLabel | None = None,
     left_on: IndexLabel | None = None,
@@ -322,8 +321,8 @@ def merge_ordered(
 
 
 def merge_asof(
-    left: FrameOrSeriesUnion,
-    right: FrameOrSeriesUnion,
+    left: DataFrame | Series,
+    right: DataFrame | Series,
     on: IndexLabel | None = None,
     left_on: IndexLabel | None = None,
     right_on: IndexLabel | None = None,
@@ -608,8 +607,8 @@ class _MergeOperation:
 
     def __init__(
         self,
-        left: FrameOrSeriesUnion,
-        right: FrameOrSeriesUnion,
+        left: DataFrame | Series,
+        right: DataFrame | Series,
         how: str = "inner",
         on: IndexLabel | None = None,
         left_on: IndexLabel | None = None,
@@ -1599,8 +1598,8 @@ class _OrderedMerge(_MergeOperation):
 
     def __init__(
         self,
-        left: FrameOrSeriesUnion,
-        right: FrameOrSeriesUnion,
+        left: DataFrame | Series,
+        right: DataFrame | Series,
         on: IndexLabel | None = None,
         left_on: IndexLabel | None = None,
         right_on: IndexLabel | None = None,
@@ -1704,8 +1703,8 @@ class _AsOfMerge(_OrderedMerge):
 
     def __init__(
         self,
-        left: FrameOrSeriesUnion,
-        right: FrameOrSeriesUnion,
+        left: DataFrame | Series,
+        right: DataFrame | Series,
         on: IndexLabel | None = None,
         left_on: IndexLabel | None = None,
         right_on: IndexLabel | None = None,

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -80,7 +80,10 @@ from pandas.core.internals import concatenate_managers
 from pandas.core.sorting import is_int64_overflow_possible
 
 if TYPE_CHECKING:
-    from pandas import DataFrame, Series
+    from pandas import (
+        DataFrame,
+        Series,
+    )
     from pandas.core.arrays import DatetimeArray
 
 

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -85,7 +85,7 @@ if TYPE_CHECKING:
     from pandas.core.arrays import DatetimeArray
 
 
-@Substitution("\nleft : DataFrame")
+@Substitution("\nleft : DataFrame or named Series")
 @Appender(_merge_doc, indents=0)
 def merge(
     left: FrameOrSeriesUnion,
@@ -322,8 +322,8 @@ def merge_ordered(
 
 
 def merge_asof(
-    left: DataFrame,
-    right: DataFrame,
+    left: FrameOrSeriesUnion,
+    right: FrameOrSeriesUnion,
     on: IndexLabel | None = None,
     left_on: IndexLabel | None = None,
     right_on: IndexLabel | None = None,
@@ -362,8 +362,8 @@ def merge_asof(
 
     Parameters
     ----------
-    left : DataFrame
-    right : DataFrame
+    left : DataFrame or named Series
+    right : DataFrame or named Series
     on : label
         Field name to join on. Must be found in both DataFrames.
         The data MUST be ordered. Furthermore this must be a numeric column,
@@ -1599,8 +1599,8 @@ class _OrderedMerge(_MergeOperation):
 
     def __init__(
         self,
-        left: DataFrame,
-        right: DataFrame,
+        left: FrameOrSeriesUnion,
+        right: FrameOrSeriesUnion,
         on: IndexLabel | None = None,
         left_on: IndexLabel | None = None,
         right_on: IndexLabel | None = None,
@@ -1704,8 +1704,8 @@ class _AsOfMerge(_OrderedMerge):
 
     def __init__(
         self,
-        left: DataFrame,
-        right: DataFrame,
+        left: FrameOrSeriesUnion,
+        right: FrameOrSeriesUnion,
         on: IndexLabel | None = None,
         left_on: IndexLabel | None = None,
         right_on: IndexLabel | None = None,


### PR DESCRIPTION
I noticed that the docs for `pd.merge()` and `pd.merge_asof()` were requiring the first argument to be a `DataFrame`, but in fact, they can be a `Series`.  This PR updates the docs and the types to fix that issue.

Didn't think a `whatsnew` entry was needed, and I skipped creating an issue, but will do so if required.
