### PR TITLE
TYP deprecate_nonkeyword_arguments

### DIFF
--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -261,7 +261,7 @@ def deprecate_nonkeyword_arguments(
     version: str | None,
     allowed_args: list[str] | None = None,
     stacklevel: int = 2,
-) -> Callable:
+) -> Callable[[F], F]:
     """
     Decorator to deprecate a use of non-keyword arguments of a function.
 


### PR DESCRIPTION
If we have
```python
import pandas as pd

reveal_type(pd.Series(range(3)).interpolate('linear'))
```

then on master we get:
```console
$ mypy t.py 
t.py:3: note: Revealed type is 'Any'
```
while here
```console
$ mypy t.py 
t.py:3: note: Revealed type is 'Union[pandas.core.series.Series, None]'
```