### PR TITLE
REF: re-use sanitize_array in DataFrame._sanitize_columns

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4499,14 +4499,9 @@ class DataFrame(NDFrame, OpsMixin):
         if isinstance(value, Series):
             return _reindex_for_setitem(value, self.index)
 
-        elif len(self) or not is_list_like(value):
-            if is_list_like(value):
-                com.require_length_match(value, self.index)
-            return sanitize_array(value, self.index, copy=True, allow_2d=True)
-
-        else:
+        if is_list_like(value):
             com.require_length_match(value, self.index)
-            return sanitize_array(value, None, copy=True, allow_2d=True)
+        return sanitize_array(value, self.index, copy=True, allow_2d=True)
 
     @property
     def _series(self):

--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -386,58 +386,51 @@ class TestPartialSetting:
         with pytest.raises(ValueError, match=msg):
             df.loc[:, 1] = 1
 
+    def test_partial_set_empty_frame2(self):
         # these work as they don't really change
         # anything but the index
         # GH5632
         expected = DataFrame(columns=["foo"], index=Index([], dtype="object"))
 
-        def f():
-            df = DataFrame(index=Index([], dtype="object"))
-            df["foo"] = Series([], dtype="object")
-            return df
+        df = DataFrame(index=Index([], dtype="object"))
+        df["foo"] = Series([], dtype="object")
 
-        tm.assert_frame_equal(f(), expected)
+        tm.assert_frame_equal(df, expected)
 
-        def f():
-            df = DataFrame()
-            df["foo"] = Series(df.index)
-            return df
+        df = DataFrame()
+        df["foo"] = Series(df.index)
 
-        tm.assert_frame_equal(f(), expected)
+        tm.assert_frame_equal(df, expected)
 
-        def f():
-            df = DataFrame()
-            df["foo"] = df.index
-            return df
+        df = DataFrame()
+        df["foo"] = df.index
 
-        tm.assert_frame_equal(f(), expected)
+        tm.assert_frame_equal(df, expected)
 
+    def test_partial_set_empty_frame3(self):
         expected = DataFrame(columns=["foo"], index=Index([], dtype="int64"))
         expected["foo"] = expected["foo"].astype("float64")
 
-        def f():
-            df = DataFrame(index=Index([], dtype="int64"))
-            df["foo"] = []
-            return df
+        df = DataFrame(index=Index([], dtype="int64"))
+        df["foo"] = []
 
-        tm.assert_frame_equal(f(), expected)
+        tm.assert_frame_equal(df, expected)
 
-        def f():
-            df = DataFrame(index=Index([], dtype="int64"))
-            df["foo"] = Series(np.arange(len(df)), dtype="float64")
-            return df
+        df = DataFrame(index=Index([], dtype="int64"))
+        df["foo"] = Series(np.arange(len(df)), dtype="float64")
 
-        tm.assert_frame_equal(f(), expected)
+        tm.assert_frame_equal(df, expected)
 
-        def f():
-            df = DataFrame(index=Index([], dtype="int64"))
-            df["foo"] = range(len(df))
-            return df
+    def test_partial_set_empty_frame4(self):
+        df = DataFrame(index=Index([], dtype="int64"))
+        df["foo"] = range(len(df))
 
         expected = DataFrame(columns=["foo"], index=Index([], dtype="int64"))
-        expected["foo"] = expected["foo"].astype("float64")
-        tm.assert_frame_equal(f(), expected)
+        # range is int-dtype-like, so we get int64 dtype
+        expected["foo"] = expected["foo"].astype("int64")
+        tm.assert_frame_equal(df, expected)
 
+    def test_partial_set_empty_frame5(self):
         df = DataFrame()
         tm.assert_index_equal(df.columns, Index([], dtype=object))
         df2 = DataFrame()
@@ -446,6 +439,7 @@ class TestPartialSetting:
         tm.assert_frame_equal(df, DataFrame([[1]], index=["foo"], columns=[1]))
         tm.assert_frame_equal(df, df2)
 
+    def test_partial_set_empty_frame_no_index(self):
         # no index to start
         expected = DataFrame({0: Series(1, index=range(4))}, columns=["A", "B", 0])
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

A big partial-indexing test is split and has a non-trivial diff, but the only _actual_ change is this line https://github.com/pandas-dev/pandas/compare/master...jbrockmendel:ref-sanitize_column?expand=1#diff-1723bf927d192314f9d8c4faa220e26b1c3b39c2fe3bb65d8c43966ec7e596e8R430 declaring that empty range is int-dtype-like instead of float-dtype-like, which i think we should call a bug.