### PR TITLE
CLN: various related to numeric indexes

### DIFF
--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -298,6 +298,7 @@ def makeBoolIndex(k=10, name=None):
 
 def makeNumericIndex(k=10, name=None, *, dtype):
     dtype = pandas_dtype(dtype)
+    assert isinstance(dtype, np.dtype)
 
     if dtype.kind == "i":
         values = list(range(k))
@@ -314,7 +315,7 @@ def makeNumericIndex(k=10, name=None, *, dtype):
 
 
 def makeIntIndex(k=10, name=None):
-    base_idx = makeNumericIndex(k, dtype="int64")
+    base_idx = makeNumericIndex(k, name=name, dtype="int64")
     return Int64Index(base_idx)
 
 

--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -33,6 +33,7 @@ from pandas.core.dtypes.common import (
     is_period_dtype,
     is_sequence,
     is_timedelta64_dtype,
+    pandas_dtype,
 )
 
 import pandas as pd
@@ -41,11 +42,14 @@ from pandas import (
     CategoricalIndex,
     DataFrame,
     DatetimeIndex,
+    Float64Index,
     Index,
+    Int64Index,
     IntervalIndex,
     MultiIndex,
     RangeIndex,
     Series,
+    UInt64Index,
     bdate_range,
 )
 from pandas._testing._io import (  # noqa:F401
@@ -292,12 +296,31 @@ def makeBoolIndex(k=10, name=None):
     return Index([False, True] + [False] * (k - 2), name=name)
 
 
+def makeNumericIndex(k=10, name=None, *, dtype):
+    dtype = pandas_dtype(dtype)
+
+    if dtype.kind == "i":
+        values = list(range(k))
+    elif dtype.kind == "u":
+        start_num = 2 ** (dtype.itemsize * 8 - 1)
+        values = [start_num + i for i in range(k)]
+    elif dtype.kind == "f":
+        values = sorted(np.random.random_sample(k)) - np.random.random_sample(1)
+        values = values * (10 ** np.random.randint(0, 9))
+    else:
+        raise NotImplementedError(f"wrong dtype {dtype}")
+
+    return Index(values, dtype=dtype, name=name)
+
+
 def makeIntIndex(k=10, name=None):
-    return Index(list(range(k)), name=name)
+    base_idx = makeNumericIndex(k, dtype="int64")
+    return Int64Index(base_idx)
 
 
 def makeUIntIndex(k=10, name=None):
-    return Index([2 ** 63 + i for i in range(k)], name=name)
+    base_idx = makeNumericIndex(k, name=name, dtype="uint64")
+    return UInt64Index(base_idx)
 
 
 def makeRangeIndex(k=10, name=None, **kwargs):
@@ -305,8 +328,8 @@ def makeRangeIndex(k=10, name=None, **kwargs):
 
 
 def makeFloatIndex(k=10, name=None):
-    values = sorted(np.random.random_sample(k)) - np.random.random_sample(1)
-    return Index(values * (10 ** np.random.randint(0, 9)), name=name)
+    base_idx = makeNumericIndex(k, name=name, dtype="float64")
+    return Float64Index(base_idx)
 
 
 def makeDateIndex(k: int = 10, freq="B", name=None, **kwargs) -> DatetimeIndex:

--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -30,9 +30,12 @@ from pandas._typing import Dtype
 from pandas.core.dtypes.common import (
     is_datetime64_dtype,
     is_datetime64tz_dtype,
+    is_float_dtype,
+    is_integer_dtype,
     is_period_dtype,
     is_sequence,
     is_timedelta64_dtype,
+    is_unsigned_integer_dtype,
     pandas_dtype,
 )
 
@@ -300,13 +303,13 @@ def makeNumericIndex(k=10, name=None, *, dtype):
     dtype = pandas_dtype(dtype)
     assert isinstance(dtype, np.dtype)
 
-    if dtype.kind == "i":
-        values = list(range(k))
-    elif dtype.kind == "u":
-        start_num = 2 ** (dtype.itemsize * 8 - 1)
-        values = [start_num + i for i in range(k)]
-    elif dtype.kind == "f":
-        values = sorted(np.random.random_sample(k)) - np.random.random_sample(1)
+    if is_integer_dtype(dtype):
+        values = np.arange(k, dtype=dtype)
+        if is_unsigned_integer_dtype(dtype):
+            values += 2 ** (dtype.itemsize * 8 - 1)
+    elif is_float_dtype(dtype):
+        values = np.random.random_sample(k) - np.random.random_sample(1)
+        values.sort()
         values = values * (10 ** np.random.randint(0, 9))
     else:
         raise NotImplementedError(f"wrong dtype {dtype}")

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -308,7 +308,7 @@ def assert_index_equal(
     """
     __tracebackhide__ = True
 
-    def _check_types(left, right, obj="Index"):
+    def _check_types(left, right, obj="Index") -> None:
         if not exact:
             return
 

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -106,7 +106,7 @@ class NumericIndex(Index):
         else:
             return False
 
-    _engine_types: dict[np.dtype, libindex.IndexEngine] = {
+    _engine_types: dict[np.dtype, type[libindex.IndexEngine]] = {
         np.dtype(np.int8): libindex.Int8Engine,
         np.dtype(np.int16): libindex.Int16Engine,
         np.dtype(np.int32): libindex.Int32Engine,
@@ -120,7 +120,7 @@ class NumericIndex(Index):
     }
 
     @property
-    def _engine_type(self) -> libindex.IndexEngine:
+    def _engine_type(self):
         return self._engine_types[self.dtype]
 
     @cache_readonly

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -106,7 +106,7 @@ class NumericIndex(Index):
         else:
             return False
 
-    @cache_readonly
+    @property
     def _engine_type(self):
         return {
             np.int8: libindex.Int8Engine,
@@ -228,7 +228,10 @@ class NumericIndex(Index):
 
     @doc(Index._should_fallback_to_positional)
     def _should_fallback_to_positional(self) -> bool:
-        return False
+        if is_float_dtype(self.dtype):
+            return False
+        else:
+            return super()._should_fallback_to_positional()
 
     @doc(Index._convert_slice_indexer)
     def _convert_slice_indexer(self, key: slice, kind: str):

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -106,7 +106,7 @@ class NumericIndex(Index):
         else:
             return False
 
-    _engine_types: dict[np.dtype : libindex.IndexEngine] = {
+    _engine_types: dict[np.dtype, libindex.IndexEngine] = {
         np.dtype(np.int8): libindex.Int8Engine,
         np.dtype(np.int16): libindex.Int16Engine,
         np.dtype(np.int32): libindex.Int32Engine,
@@ -120,7 +120,7 @@ class NumericIndex(Index):
     }
 
     @property
-    def _engine_type(self):
+    def _engine_type(self) -> libindex.IndexEngine:
         return self._engine_types[self.dtype]
 
     @cache_readonly

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -228,10 +228,7 @@ class NumericIndex(Index):
 
     @doc(Index._should_fallback_to_positional)
     def _should_fallback_to_positional(self) -> bool:
-        if is_float_dtype(self.dtype):
-            return False
-        else:
-            return super()._should_fallback_to_positional()
+        return False
 
     @doc(Index._convert_slice_indexer)
     def _convert_slice_indexer(self, key: slice, kind: str):

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -106,20 +106,22 @@ class NumericIndex(Index):
         else:
             return False
 
+    _engine_types: dict[np.dtype : libindex.IndexEngine] = {
+        np.dtype(np.int8): libindex.Int8Engine,
+        np.dtype(np.int16): libindex.Int16Engine,
+        np.dtype(np.int32): libindex.Int32Engine,
+        np.dtype(np.int64): libindex.Int64Engine,
+        np.dtype(np.uint8): libindex.UInt8Engine,
+        np.dtype(np.uint16): libindex.UInt16Engine,
+        np.dtype(np.uint32): libindex.UInt32Engine,
+        np.dtype(np.uint64): libindex.UInt64Engine,
+        np.dtype(np.float32): libindex.Float32Engine,
+        np.dtype(np.float64): libindex.Float64Engine,
+    }
+
     @property
     def _engine_type(self):
-        return {
-            np.int8: libindex.Int8Engine,
-            np.int16: libindex.Int16Engine,
-            np.int32: libindex.Int32Engine,
-            np.int64: libindex.Int64Engine,
-            np.uint8: libindex.UInt8Engine,
-            np.uint16: libindex.UInt16Engine,
-            np.uint32: libindex.UInt32Engine,
-            np.uint64: libindex.UInt64Engine,
-            np.float32: libindex.Float32Engine,
-            np.float64: libindex.Float64Engine,
-        }[self.dtype.type]
+        return self._engine_types[self.dtype]
 
     @cache_readonly
     def inferred_type(self) -> str:

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -214,7 +214,7 @@ class TestPDApi(Base):
             + self.funcs_to
             + self.private_modules
         )
-        self.check(pd, checkthese, self.ignored)
+        self.check(namespace=pd, expected=checkthese, ignored=self.ignored)
 
     def test_depr(self):
         deprecated_list = (

--- a/pandas/tests/base/test_unique.py
+++ b/pandas/tests/base/test_unique.py
@@ -23,12 +23,12 @@ def test_unique(index_or_series_obj):
     if isinstance(obj, pd.MultiIndex):
         expected = pd.MultiIndex.from_tuples(unique_values)
         expected.names = obj.names
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
     elif isinstance(obj, pd.Index):
         expected = pd.Index(unique_values, dtype=obj.dtype)
         if is_datetime64tz_dtype(obj.dtype):
             expected = expected.normalize()
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
     else:
         expected = np.array(unique_values)
         tm.assert_numpy_array_equal(result, expected)
@@ -67,7 +67,7 @@ def test_unique_null(null_obj, index_or_series_obj):
         if is_datetime64tz_dtype(obj.dtype):
             result = result.normalize()
             expected = expected.normalize()
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
     else:
         expected = np.array(unique_values, dtype=obj.dtype)
         tm.assert_numpy_array_equal(result, expected)
@@ -118,7 +118,7 @@ def test_unique_bad_unicode(idx_or_series_w_bad_unicode):
 
     if isinstance(obj, pd.Index):
         expected = pd.Index(["\ud83d"], dtype=object)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
     else:
         expected = np.array(["\ud83d"], dtype=object)
         tm.assert_numpy_array_equal(result, expected)


### PR DESCRIPTION
A few bits to make #41153 smaller.

Also fixes an issue with the current implementation of NumericIndex._engine_type:

The implementation currently uses `self.dtype.type`, which is a problem when we are given platform-specific dtypes, e.g. `np.intc`.

For example:

```python
>>> d1 = np.dtype(np.intc)
>>> d1
dtype('int32')
>>> d2 = np.dtype(np.int32)
>>> d1 == d2
True
>>> d1.type == d2.type
False  # a problem
```

So the _engine_type dict should use np.dtype(np.int64) etc., so avoid such problems.