### PR TITLE
REF: convert_dtypes return dtype objects

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -5065,10 +5065,7 @@ Keep all original rows and also all original values
                 convert_boolean,
                 convert_floating,
             )
-            try:
-                result = input_series.astype(inferred_dtype)
-            except TypeError:
-                result = input_series.copy()
+            result = input_series.astype(inferred_dtype)
         else:
             result = input_series.copy()
         return result


### PR DESCRIPTION
This turns out to be a blocker for sharing arrays.integers.safe_cast with maybe_cast_to_integer_array, which in turn is a blocker for #34460