### PR TITLE
TST: Check float format in object column (#35603)

### DIFF
--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1493,15 +1493,6 @@ class TestSeriesConstructors:
         exp = Series(index).astype(object)
         tm.assert_series_equal(s, exp)
 
-    def test_constructor_with_float_cast_object(self):
-        # GH#35603
-        # check float format when cast to object
-        ser = Series([1.0]).astype(object)
-        val = ser.iloc[0]
-        assert ser.dtype == "object"
-        assert isinstance(val, float)
-        assert "." in str(val)
-
     @pytest.mark.parametrize("dtype", [np.datetime64, np.timedelta64])
     def test_constructor_generic_timestamp_no_frequency(self, dtype, request):
         # see gh-15524, gh-15987

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1495,12 +1495,12 @@ class TestSeriesConstructors:
     
     def test_constructor_with_float_cast_object(self):
         # GH#35603
-        # data after casting is float not int
+        # check float format when cast to object
         ser = Series([1.0]).astype(object)
         val = ser.iloc[0]
         assert ser.dtype == "object"
         assert isinstance(val, float)
-        assert val == 1.0
+        assert "." in str(val)
     
     @pytest.mark.parametrize("dtype", [np.datetime64, np.timedelta64])
     def test_constructor_generic_timestamp_no_frequency(self, dtype, request):

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1492,7 +1492,16 @@ class TestSeriesConstructors:
         s = Series(index.astype(object), dtype=object)
         exp = Series(index).astype(object)
         tm.assert_series_equal(s, exp)
-
+    
+    def test_constructor_with_float_cast_object(self):
+        # GH#35603
+        # data after casting is float not int
+        ser = Series([1.0]).astype(object)
+        val = ser.iloc[0]
+        assert ser.dtype == "object"
+        assert isinstance(val, float)
+        assert val == 1.0
+    
     @pytest.mark.parametrize("dtype", [np.datetime64, np.timedelta64])
     def test_constructor_generic_timestamp_no_frequency(self, dtype, request):
         # see gh-15524, gh-15987

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1492,7 +1492,7 @@ class TestSeriesConstructors:
         s = Series(index.astype(object), dtype=object)
         exp = Series(index).astype(object)
         tm.assert_series_equal(s, exp)
-    
+
     def test_constructor_with_float_cast_object(self):
         # GH#35603
         # check float format when cast to object
@@ -1501,7 +1501,7 @@ class TestSeriesConstructors:
         assert ser.dtype == "object"
         assert isinstance(val, float)
         assert "." in str(val)
-    
+
     @pytest.mark.parametrize("dtype", [np.datetime64, np.timedelta64])
     def test_constructor_generic_timestamp_no_frequency(self, dtype, request):
         # see gh-15524, gh-15987

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -240,6 +240,15 @@ class TestSeriesRepr:
         )
         assert result == expected
 
+    def test_float_repr_in_frame(self):
+        # GH#35603
+        # check float format when cast to object
+        ser = Series([1.0]).astype(object)
+        expected = (
+            "0    1.0\n"
+            "dtype: object"
+        )
+        assert repr(ser) == expected
 
 class TestCategoricalRepr:
     def test_categorical_repr_unicode(self):

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -244,10 +244,7 @@ class TestSeriesRepr:
         # GH#35603
         # check float format when cast to object
         ser = Series([1.0]).astype(object)
-        expected = (
-            "0    1.0\n"
-            "dtype: object"
-        )
+        expected = "0    1.0\ndtype: object"
         assert repr(ser) == expected
 
 class TestCategoricalRepr:

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -247,6 +247,7 @@ class TestSeriesRepr:
         expected = "0    1.0\ndtype: object"
         assert repr(ser) == expected
 
+
 class TestCategoricalRepr:
     def test_categorical_repr_unicode(self):
         # see gh-21002

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -240,7 +240,7 @@ class TestSeriesRepr:
         )
         assert result == expected
 
-    def test_float_repr_in_frame(self):
+    def test_float_repr(self):
         # GH#35603
         # check float format when cast to object
         ser = Series([1.0]).astype(object)


### PR DESCRIPTION
- [ ] closes #35603
- [x] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

This test checks if a Series cast to object still shows data in float format.

Ran `pytest pandas/tests/series/test_constructors.py`
Output:
```
================================================= test session starts =================================================
platform win32 -- Python 3.8.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: C:\Users\mdhsi\pandas-michael, configfile: pyproject.toml
plugins: hypothesis-6.12.0, asyncio-0.14.0, cov-2.11.1, forked-1.3.0, instafail-0.4.1, xdist-2.2.1
collected 301 items

pandas\tests\series\test_constructors.py .......................................................................................................................................................................................................x.....................................................................................................

--------------------------- generated xml file: C:\Users\mdhsi\pandas-michael\test-data.xml ---------------------------
================================================ slowest 30 durations =================================================
0.25s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_empty_constructor[<lambda>-True0]
0.13s call     pandas/tests/series/test_constructors.py::TestSeriesConstructorIndexCoercion::test_series_constructor_datetimelike_index_coercion
0.09s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_data_aware_dtype_naive['dateutil/US/Pacific'-True]
0.04s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_dtype_datetime64_10
0.02s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_empty[OrderedDict]
0.02s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_empty[dict]
0.02s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_cant_cast_datetimelike[PeriodIndex]
0.02s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_cant_cast_datetimelike[DatetimeIndex]
0.02s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_cant_cast_datetimelike[TimedeltaIndex]
0.02s setup    pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_datetimelike_scalar_to_string_dtype[string]
0.02s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_pass_none
0.02s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_categorical_with_coercion
0.02s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_dtype_timedelta64
0.01s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_data_aware_dtype_naive[pytz.FixedOffset(300)-False]
0.01s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_data_aware_dtype_naive['Asia/Tokyo'-True]
0.01s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_data_aware_dtype_naive[pytz.FixedOffset(300)-True]
0.01s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_data_aware_dtype_naive[tzlocal()-False]
0.01s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_data_aware_dtype_naive['dateutil/Asia/Singapore'-False]
0.01s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_data_aware_dtype_naive[datetime.timezone(datetime.timedelta(seconds=3600))-False]
0.01s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_data_aware_dtype_naive[tzutc()-False]
0.01s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_data_aware_dtype_naive['+01:15'-True]
0.01s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor
0.01s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_data_aware_dtype_naive['UTC'-False]
0.01s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_data_aware_dtype_naive['UTC-02:15'-True]
0.01s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_data_aware_dtype_naive[tzlocal()-True]
0.01s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_data_aware_dtype_naive[pytz.FixedOffset(-300)-True]
0.01s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_data_aware_dtype_naive['dateutil/Asia/Singapore'-True]
0.01s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_data_aware_dtype_naive['UTC'-True]
0.01s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_data_aware_dtype_naive['-02:15'-False]
0.01s call     pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_data_aware_dtype_naive[pytz.FixedOffset(-300)-False]
=========================================== 300 passed, 1 xfailed in 2.22s ============================================
```