### PR TITLE
BUG: PeriodIndex.get_loc with mismatched freq

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -937,6 +937,7 @@ Indexing
 - Bug in :meth:`Series.__delitem__` with ``ExtensionDtype`` incorrectly casting to ``ndarray`` (:issue:`40386`)
 - Bug in :meth:`DataFrame.loc` returning :class:`MultiIndex` in wrong order if indexer has duplicates (:issue:`40978`)
 - Bug in :meth:`DataFrame.__setitem__` raising ``TypeError`` when using a str subclass as the column name with a :class:`DatetimeIndex` (:issue:`37366`)
+- Bug in :meth:`PeriodIndex.get_loc` failing to raise ``KeyError`` when given a :class:`Period` with a mismatched ``freq`` (:issue:`41670`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -4,10 +4,7 @@ from datetime import (
     datetime,
     timedelta,
 )
-from typing import (
-    Any,
-    Hashable,
-)
+from typing import Hashable
 import warnings
 
 import numpy as np
@@ -322,24 +319,6 @@ class PeriodIndex(DatetimeIndexOpsMixin):
         return dtype.freq == self.freq
 
     # ------------------------------------------------------------------------
-    # Indexing
-
-    @doc(Index.__contains__)
-    def __contains__(self, key: Any) -> bool:
-        if isinstance(key, Period):
-            if key.freq != self.freq:
-                return False
-            else:
-                return key.ordinal in self._engine
-        else:
-            hash(key)
-            try:
-                self.get_loc(key)
-                return True
-            except KeyError:
-                return False
-
-    # ------------------------------------------------------------------------
     # Index Methods
 
     def asof_locs(self, where: Index, mask: np.ndarray) -> np.ndarray:
@@ -474,6 +453,8 @@ class PeriodIndex(DatetimeIndexOpsMixin):
 
         elif is_integer(key):
             # Period constructor will cast to string, which we dont want
+            raise KeyError(key)
+        elif isinstance(key, Period) and key.freq != self.freq:
             raise KeyError(key)
 
         try:


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
