### PR TITLE
REF: avoid maybe_convert_platform

### DIFF
--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -32,7 +32,6 @@ from pandas._typing import (
 from pandas.compat.numpy import function as nv
 from pandas.util._decorators import Appender
 
-from pandas.core.dtypes.cast import maybe_convert_platform
 from pandas.core.dtypes.common import (
     is_categorical_dtype,
     is_datetime64_dtype,
@@ -1650,4 +1649,6 @@ def _maybe_convert_platform_interval(values) -> ArrayLike:
     else:
         values = extract_array(values, extract_numpy=True)
 
-    return maybe_convert_platform(values)
+    if not hasattr(values, "dtype"):
+        return np.asarray(values)
+    return values

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -537,9 +537,6 @@ def _prep_ndarray(values, copy: bool = True) -> np.ndarray:
         def convert(v):
             if not is_list_like(v) or isinstance(v, ABCDataFrame):
                 return v
-            elif not hasattr(v, "dtype") and not isinstance(v, (list, tuple, range)):
-                # TODO: should we cast these to list?
-                return v
 
             v = extract_array(v, extract_numpy=True)
             res = maybe_convert_platform(v)


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

After this it is exclusively used in core.construction and core.internals.construction