### PR TITLE
CLN: Deprecate non-keyword arguments in read_table #41485

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -700,7 +700,7 @@ Deprecations
 - Deprecated passing arguments as positional in :meth:`DataFrame.where` and :meth:`Series.where` (other than ``"cond"`` and ``"other"``) (:issue:`41485`)
 - Deprecated passing arguments as positional (other than ``filepath_or_buffer``) in :func:`read_csv` (:issue:`41485`)
 - Deprecated passing arguments as positional in :meth:`DataFrame.drop` (other than ``"labels"``) and :meth:`Series.drop` (:issue:`41485`)
--
+- Deprecated passing arguments as positional (other than ``filepath_or_buffer``) in :func:`read_table` (:issue:`41485`)
 
 
 .. _whatsnew_130.deprecations.nuisance_columns:

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -591,7 +591,9 @@ def read_csv(
 
     return _read(filepath_or_buffer, kwds)
 
-
+@deprecate_nonkeyword_arguments(
+    version=None, allowed_args=["filepath_or_buffer"], stacklevel=3
+)
 @Appender(
     _doc_read_csv_and_table.format(
         func_name="read_table",

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -591,6 +591,7 @@ def read_csv(
 
     return _read(filepath_or_buffer, kwds)
 
+
 @deprecate_nonkeyword_arguments(
     version=None, allowed_args=["filepath_or_buffer"], stacklevel=3
 )

--- a/pandas/tests/io/parser/common/test_common_basic.py
+++ b/pandas/tests/io/parser/common/test_common_basic.py
@@ -827,11 +827,11 @@ def test_malformed_second_line(all_parsers):
 
 def test_read_table_posargs_deprecation(all_parsers):
     # https://github.com/pandas-dev/pandas/issues/41485
-    f = StringIO("a\tb\n1\t2")
+    data = StringIO("a\tb\n1\t2")
     parser = all_parsers
     msg = (
         "In a future version of pandas all arguments of read_table "
         "except for the argument 'filepath_or_buffer' will be keyword-only"
     )
     with tm.assert_produces_warning(FutureWarning, match=msg):
-        parser.read_table(f, " ")
+        parser.read_table(data, " ")

--- a/pandas/tests/io/parser/common/test_common_basic.py
+++ b/pandas/tests/io/parser/common/test_common_basic.py
@@ -823,3 +823,14 @@ def test_malformed_second_line(all_parsers):
     result = parser.read_csv(StringIO(data), skip_blank_lines=False, header=1)
     expected = DataFrame({"a": ["b"]})
     tm.assert_frame_equal(result, expected)
+
+def test_read_table_posargs_deprecation(all_parsers):
+    # https://github.com/pandas-dev/pandas/issues/41485
+    f = StringIO("a\tb\n1\t2")
+    parser = all_parsers
+    msg = (
+        "In a future version of pandas all arguments of read_table "
+        "except for the argument 'filepath_or_buffer' will be keyword-only"
+    )
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        parser.read_table(f, " ")

--- a/pandas/tests/io/parser/common/test_common_basic.py
+++ b/pandas/tests/io/parser/common/test_common_basic.py
@@ -824,6 +824,7 @@ def test_malformed_second_line(all_parsers):
     expected = DataFrame({"a": ["b"]})
     tm.assert_frame_equal(result, expected)
 
+
 def test_read_table_posargs_deprecation(all_parsers):
     # https://github.com/pandas-dev/pandas/issues/41485
     f = StringIO("a\tb\n1\t2")


### PR DESCRIPTION
- [x] xref #41485
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
