### PR TITLE
Fix DataFrame.agg produces different types if the DataFrame is empty

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8536,7 +8536,7 @@ NaN 12.3   33.0
 
         if isinstance(result, DataFrame):
             result = result.squeeze()
-            
+
         return result
 
     agg = aggregate

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8534,6 +8534,9 @@ NaN 12.3   33.0
             result_in_dict = relabel_result(result, func, columns, order)
             result = DataFrame(result_in_dict, index=columns)
 
+        if isinstance(result, DataFrame):
+            result = result.squeeze()
+            
         return result
 
     agg = aggregate

--- a/pandas/tests/frame/test_aggregate.py
+++ b/pandas/tests/frame/test_aggregate.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 from pandas import (
     DataFrame,
-    Series
+    Series,
 )
 
 import pandas._testing as tm

--- a/pandas/tests/frame/test_aggregate.py
+++ b/pandas/tests/frame/test_aggregate.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+import pandas as pd
+
+from pandas import (
+    DataFrame,
+    Series,
+    date_range,
+    timedelta_range,
+)
+
+import pandas._testing as tm
+
+
+def _check_mixed_int(df, dtype=None):
+    # GH#41672
+    result = DataFrame([], columns=['lang', 'name'])
+    result = result.agg({'name': lambda y: y.values})
+    assert type(result) == Series
+
+    result = DataFrame([['a', 'boof']], columns=['lang', 'name'])
+    result = result.agg({'name': lambda y: y.values})
+    assert type(result) == Series

--- a/pandas/tests/frame/test_aggregate.py
+++ b/pandas/tests/frame/test_aggregate.py
@@ -1,12 +1,10 @@
 import numpy as np
 
 import pandas as pd
-
 from pandas import (
     DataFrame,
     Series,
 )
-
 import pandas._testing as tm
 
 

--- a/pandas/tests/frame/test_aggregate.py
+++ b/pandas/tests/frame/test_aggregate.py
@@ -4,9 +4,7 @@ import pandas as pd
 
 from pandas import (
     DataFrame,
-    Series,
-    date_range,
-    timedelta_range,
+    Series
 )
 
 import pandas._testing as tm

--- a/pandas/tests/frame/test_aggregate.py
+++ b/pandas/tests/frame/test_aggregate.py
@@ -12,10 +12,10 @@ import pandas._testing as tm
 
 def _check_mixed_int(df, dtype=None):
     # GH#41672
-    result = DataFrame([], columns=['lang', 'name'])
-    result = result.agg({'name': lambda y: y.values})
+    result = DataFrame([], columns=["lang", "name"])
+    result = result.agg({"name": lambda y: y.values})
     assert type(result) == Series
 
-    result = DataFrame([['a', 'boof']], columns=['lang', 'name'])
-    result = result.agg({'name': lambda y: y.values})
+    result = DataFrame([["a", "boof"]], columns=["lang", "name"])
+    result = result.agg({"name": lambda y: y.values})
     assert type(result) == Series

--- a/pandas/tests/frame/test_aggregate.py
+++ b/pandas/tests/frame/test_aggregate.py
@@ -10,7 +10,7 @@ from pandas import (
 import pandas._testing as tm
 
 
-def _check_mixed_int(df, dtype=None):
+def test_frame_aggregate():
     # GH#41672
     result = DataFrame([], columns=["lang", "name"])
     result = result.agg({"name": lambda y: y.values})


### PR DESCRIPTION
- [ ✔] closes https://github.com/pandas-dev/pandas/issues/41672
- [ ❌] tests added / passed
- [ ❌] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

