### PR TITLE
[ArrowStringArray] ENH: raise an ImportError when trying to create an arrow string dtype if pyarrow is not installed

### DIFF
--- a/pandas/tests/arrays/string_/test_string_arrow.py
+++ b/pandas/tests/arrays/string_/test_string_arrow.py
@@ -3,14 +3,25 @@ import re
 import numpy as np
 import pytest
 
-from pandas.core.arrays.string_arrow import ArrowStringArray
+from pandas.compat import pa_version_under1p0
 
-pa = pytest.importorskip("pyarrow", minversion="1.0.0")
+from pandas.core.arrays.string_arrow import (
+    ArrowStringArray,
+    ArrowStringDtype,
+)
 
 
+@pytest.mark.skipif(
+    pa_version_under1p0,
+    reason="pyarrow>=1.0.0 is required for PyArrow backed StringArray",
+)
 @pytest.mark.parametrize("chunked", [True, False])
-@pytest.mark.parametrize("array", [np, pa])
+@pytest.mark.parametrize("array", ["numpy", "pyarrow"])
 def test_constructor_not_string_type_raises(array, chunked):
+    import pyarrow as pa
+
+    array = pa if array == "pyarrow" else np
+
     arr = array.array([1, 2, 3])
     if chunked:
         if array is np:
@@ -24,3 +35,20 @@ def test_constructor_not_string_type_raises(array, chunked):
         )
     with pytest.raises(ValueError, match=msg):
         ArrowStringArray(arr)
+
+
+@pytest.mark.skipif(
+    not pa_version_under1p0,
+    reason="pyarrow is installed",
+)
+def test_pyarrow_not_installed_raises():
+    msg = re.escape("pyarrow>=1.0.0 is required for PyArrow backed StringArray")
+
+    with pytest.raises(ImportError, match=msg):
+        ArrowStringDtype()
+
+    with pytest.raises(ImportError, match=msg):
+        ArrowStringArray([])
+
+    with pytest.raises(ImportError, match=msg):
+        ArrowStringArray._from_sequence(["a", None, "b"])


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/39908#discussion_r585581525