### PR TITLE
CLN: Remove old docs README

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -1,1 +1,0 @@
-See `contributing.rst <https://pandas-docs.github.io/pandas-docs-travis/contributing.html>`_ in this repo.


### PR DESCRIPTION
Not sure why a README was created under `docs` in the first place. But having a docs/README that instead of having docs related information, just points to the contributing page, doesn't seem very useful, since the main README is already providing better information on how to contribute.

And in any case, the link in that README file is very old.