### PR TITLE
CI: Activating CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2.1
+
+jobs:
+  test-arm:
+    machine:
+      image: ubuntu-2004:202101-01
+    resource_class: arm.medium
+    environment:
+      ENV_FILE: ci/deps/circle-37-arm64.yaml
+      PYTEST_WORKERS: auto
+      PATTERN: "not slow and not network and not clipboard and not arm_slow"
+    steps:
+      - checkout
+
+workflows:
+  test:
+    jobs:
+      - test-arm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       PYTEST_WORKERS: auto
       PATTERN: "not slow and not network and not clipboard and not arm_slow"
     steps:
-      - checkout
+      - run: echo "CircleCI is working"
 
 workflows:
   test:


### PR DESCRIPTION
We'll start running ARM tests in #41739. In order to see the result of the execution in that PR, we need `.circleci/config.yml` to exist in master, so CircleCI starts showing in GitHub. Adding the config file, but just doing an echo (and not the checkout,  set up or the environment or the running of the tests). So we can add CircleCI safely, and see results before merging #41739.

