### PR TITLE
Backport PR #40555: BUG: Fix behavior of replace_list with mixed types.

### DIFF
--- a/doc/source/whatsnew/v1.2.5.rst
+++ b/doc/source/whatsnew/v1.2.5.rst
@@ -16,7 +16,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Regression in :func:`concat` between two :class:`DataFrames` where one has an :class:`Index` that is all-None and the other is :class:`DatetimeIndex` incorrectly raising (:issue:`40841`)
 - Regression in :func:`read_csv` when using ``memory_map=True`` with an non-UTF8 encoding (:issue:`40986`)
--
+- Regression in :meth:`DataFrame.replace` and :meth:`Series.replace` when the values to replace is a NumPy float array (:issue:`40371`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -860,6 +860,15 @@ class Block(PandasObject):
         """
         See BlockManager._replace_list docstring.
         """
+
+        # https://github.com/pandas-dev/pandas/issues/40371
+        # the following pairs check code caused a regression so we catch that case here
+        # until the issue is fixed properly in can_hold_element
+
+        # error: "Iterable[Any]" has no attribute "tolist"
+        if hasattr(src_list, "tolist"):
+            src_list = src_list.tolist()  # type: ignore[attr-defined]
+
         # Exclude anything that we know we won't contain
         pairs = [
             (x, y) for x, y in zip(src_list, dest_list) if self._can_hold_element(x)

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1665,3 +1665,22 @@ class TestDataFrameReplace:
         expected = obj.copy()
         obj = obj.replace({None: np.nan})
         tm.assert_equal(obj, expected)
+
+    @pytest.mark.parametrize(
+        "data, to_replace, value, expected",
+        [
+            ([1], [1.0], [0], [0]),
+            ([1], [1], [0], [0]),
+            ([1.0], [1.0], [0], [0.0]),
+            ([1.0], [1], [0], [0.0]),
+        ],
+    )
+    @pytest.mark.parametrize("box", [list, tuple, np.array])
+    def test_replace_list_with_mixed_type(
+        self, data, to_replace, value, expected, box, frame_or_series
+    ):
+        # GH#40371
+        obj = frame_or_series(data)
+        expected = frame_or_series(expected)
+        result = obj.replace(box(to_replace), value)
+        tm.assert_equal(result, expected)


### PR DESCRIPTION
Backport PR #40555 (removed typing changes - changes related to handling Categorical on master)