### PR TITLE
REF: Simplify Index.union

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -68,7 +68,6 @@ from pandas.core.dtypes.common import (
     is_numeric_dtype,
     is_object_dtype,
     is_scalar,
-    is_signed_integer_dtype,
     is_string_dtype,
     is_timedelta64_dtype,
     is_unsigned_integer_dtype,
@@ -1780,14 +1779,13 @@ def ensure_nanosecond_dtype(dtype: DtypeObj) -> DtypeObj:
     return dtype
 
 
-def find_common_type(types: list[DtypeObj], *, strict_uint64: bool = False) -> DtypeObj:
+def find_common_type(types: list[DtypeObj]) -> DtypeObj:
     """
     Find a common data type among the given dtypes.
 
     Parameters
     ----------
     types : list of dtypes
-    strict_uint64 : if True, object dtype is returned if uint64 and signed int present.
 
     Returns
     -------
@@ -1832,13 +1830,6 @@ def find_common_type(types: list[DtypeObj], *, strict_uint64: bool = False) -> D
         for t in types:
             if is_integer_dtype(t) or is_float_dtype(t) or is_complex_dtype(t):
                 return np.dtype("object")
-
-    # Index.union is special: uint64 & signed int -> object
-    if strict_uint64:
-        has_uint64 = any(t == "uint64" for t in types)
-        has_signed_int = any(is_signed_integer_dtype(t) for t in types)
-        if has_uint64 and has_signed_int:
-            return np.dtype("object")
 
     # error: Argument 1 to "find_common_type" has incompatible type
     # "List[Union[dtype, ExtensionDtype]]"; expected "Sequence[Union[dtype,

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -77,7 +77,6 @@ from pandas.core.dtypes.common import (
     is_float_dtype,
     is_hashable,
     is_integer,
-    is_integer_dtype,
     is_interval_dtype,
     is_iterator,
     is_list_like,
@@ -2963,19 +2962,13 @@ class Index(IndexOpsMixin, PandasObject):
                     stacklevel=2,
                 )
 
-            dtype = find_common_type([self.dtype, other.dtype])
-            if self._is_numeric_dtype and other._is_numeric_dtype:
-                # Right now, we treat union(int, float) a bit special.
-                # See https://github.com/pandas-dev/pandas/issues/26778 for discussion
-                # We may change union(int, float) to go to object.
-                # float | [u]int -> float  (the special case)
-                # <T>   | <T>    -> T
-                # <T>   | <U>    -> object
-                if not (is_integer_dtype(self.dtype) and is_integer_dtype(other.dtype)):
-                    dtype = np.dtype("float64")
-                else:
-                    # one is int64 other is uint64
-                    dtype = np.dtype("object")
+            dtype = find_common_type([self.dtype, other.dtype], strict_uint64=True)
+            # Right now, we treat union(float, [u]int) a bit special.
+            # See https://github.com/pandas-dev/pandas/issues/26778 for discussion
+            # Now it's:
+            # * float | [u]int -> float
+            # * uint64 | signed int  -> object
+            # We may change union(float  [u]int) to go to object.
 
             left = self.astype(dtype, copy=False)
             right = other.astype(dtype, copy=False)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2968,7 +2968,7 @@ class Index(IndexOpsMixin, PandasObject):
             # Now it's:
             # * float | [u]int -> float
             # * uint64 | signed int  -> object
-            # We may change union(float  [u]int) to go to object.
+            # We may change union(float | [u]int) to go to object.
 
             left = self.astype(dtype, copy=False)
             right = other.astype(dtype, copy=False)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5397,7 +5397,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         target_dtype, _ = infer_dtype_from(target, pandas_dtype=True)
 
-        # special case: if either is uint64 and other dtype is signed int, return object
+        # special case: if one dtype is uint64 and the other a signed int, return object
         # See https://github.com/pandas-dev/pandas/issues/26778 for discussion
         # Now it's:
         # * float | [u]int -> float


### PR DESCRIPTION
This is the `Index.union` part of #41153. This helps simplify that PR.

The special casing in `Index.union` is currently active if both are numeric. After #41153 it should only be special cased if one dtype is uint64 and other a signed int. So after this and #41153:
* int8 & uint32 -> int64
* [u]int64 & float64 -> float64
* int64 & uint64 -> object
* int8 & uint64 -> object

The first and second case is handled correctly by `find_common_type`, but the others aren't currently.

This PR changes no functionality itself, but prepares for the changes in #41153, where we want e.g. `NumericIndex[int8] .union(NumericIndex[uint32])` to give `NumericIndex[int64]` and not `Index[object]`.