### PR TITLE
Bug in xs raising KeyError for MultiIndex columns with droplevel False and list indexe

### DIFF
--- a/doc/source/whatsnew/v1.2.5.rst
+++ b/doc/source/whatsnew/v1.2.5.rst
@@ -21,12 +21,19 @@ Fixed regressions
 
 .. ---------------------------------------------------------------------------
 
+.. _whatsnew_125.deprecations:
+
+Deprecations
+~~~~~~~~~~~~
+
+- Deprecated passing lists as ``key`` to :meth:`DataFrame.xs` and :meth:`Series.xs` with same length as ``level`` keyword (:issue:`41789`)
+
 .. _whatsnew_125.bug_fixes:
 
 Bug fixes
 ~~~~~~~~~
 
--
+- Bug in :meth:`DataFrame.xs` and :meth:`Series.xs` accepting list as ``key`` and casting elements to different levels per index in list, now raises ``TypeError`` (:issue:`41760`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.2.5.rst
+++ b/doc/source/whatsnew/v1.2.5.rst
@@ -26,14 +26,14 @@ Fixed regressions
 Deprecations
 ~~~~~~~~~~~~
 
-- Deprecated passing lists as ``key`` to :meth:`DataFrame.xs` and :meth:`Series.xs` with same length as ``level`` keyword (:issue:`41789`)
+- Deprecated passing lists as ``key`` to :meth:`DataFrame.xs` and :meth:`Series.xs` (:issue:`41760`)
 
 .. _whatsnew_125.bug_fixes:
 
 Bug fixes
 ~~~~~~~~~
 
-- Bug in :meth:`DataFrame.xs` and :meth:`Series.xs` accepting list as ``key`` and casting elements to different levels per index in list, now raises ``TypeError`` (:issue:`41760`)
+-
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.2.5.rst
+++ b/doc/source/whatsnew/v1.2.5.rst
@@ -18,7 +18,6 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.sum` and :meth:`DataFrame.prod` when ``min_count`` and ``numeric_only`` are both given (:issue:`41074`)
 - Regression in :func:`read_csv` when using ``memory_map=True`` with an non-UTF8 encoding (:issue:`40986`)
 - Regression in :meth:`DataFrame.replace` and :meth:`Series.replace` when the values to replace is a NumPy float array (:issue:`40371`)
-- Regression in :meth:`DataFrame.xs` raising ``KeyError`` for existing element with list-like indexer for :class:`MultiIndex` columns with ``droplevel=False`` (:issue:`41760`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.2.5.rst
+++ b/doc/source/whatsnew/v1.2.5.rst
@@ -18,6 +18,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.sum` and :meth:`DataFrame.prod` when ``min_count`` and ``numeric_only`` are both given (:issue:`41074`)
 - Regression in :func:`read_csv` when using ``memory_map=True`` with an non-UTF8 encoding (:issue:`40986`)
 - Regression in :meth:`DataFrame.replace` and :meth:`Series.replace` when the values to replace is a NumPy float array (:issue:`40371`)
+- Regression in :meth:`DataFrame.xs` raising ``KeyError`` for existing element with list-like indexer for :class:`MultiIndex` columns with ``droplevel=False`` (:issue:`41760`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -708,7 +708,6 @@ Deprecations
 - Deprecated passing arguments as positional (other than ``filepath_or_buffer``) in :func:`read_csv` (:issue:`41485`)
 - Deprecated passing arguments as positional in :meth:`DataFrame.drop` (other than ``"labels"``) and :meth:`Series.drop` (:issue:`41485`)
 - Deprecated passing arguments as positional (other than ``filepath_or_buffer``) in :func:`read_table` (:issue:`41485`)
-- Deprecated passing lists as ``key`` to :meth:`DataFrame.xs` and :meth:`Series.xs` with same length as ``level`` keyword (:issue:`41789`)
 
 .. _whatsnew_130.deprecations.nuisance_columns:
 
@@ -947,7 +946,6 @@ Indexing
 - Bug in :meth:`DataFrame.__setitem__` raising ``TypeError`` when using a str subclass as the column name with a :class:`DatetimeIndex` (:issue:`37366`)
 - Bug in :meth:`PeriodIndex.get_loc` failing to raise ``KeyError`` when given a :class:`Period` with a mismatched ``freq`` (:issue:`41670`)
 - Bug ``.loc.__getitem__`` with a :class:`UInt64Index` and negative-integer keys raising ``OverflowError`` instead of ``KeyError`` in some cases, wrapping around to positive integers in others (:issue:`41777`)
-- Bug in :meth:`DataFrame.xs` and :meth:`Series.xs` accepting list as ``key`` and casting elements to different levels per index in list, now raises ``TypeError`` (:issue:`41760`)
 
 Missing
 ^^^^^^^

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -707,7 +707,7 @@ Deprecations
 - Deprecated passing arguments as positional (other than ``filepath_or_buffer``) in :func:`read_csv` (:issue:`41485`)
 - Deprecated passing arguments as positional in :meth:`DataFrame.drop` (other than ``"labels"``) and :meth:`Series.drop` (:issue:`41485`)
 - Deprecated passing arguments as positional (other than ``filepath_or_buffer``) in :func:`read_table` (:issue:`41485`)
-
+- Deprecated passing lists as ``key`` to :meth:`DataFrame.xs` and :meth:`Series.xs` with same length as ``level`` keyword (:issue:`41789`)
 
 .. _whatsnew_130.deprecations.nuisance_columns:
 
@@ -945,6 +945,7 @@ Indexing
 - Bug in :meth:`DataFrame.loc` returning :class:`MultiIndex` in wrong order if indexer has duplicates (:issue:`40978`)
 - Bug in :meth:`DataFrame.__setitem__` raising ``TypeError`` when using a str subclass as the column name with a :class:`DatetimeIndex` (:issue:`37366`)
 - Bug in :meth:`PeriodIndex.get_loc` failing to raise ``KeyError`` when given a :class:`Period` with a mismatched ``freq`` (:issue:`41670`)
+- Bug in :meth:`DataFrame.xs` and :meth:`Series.xs` accepting list as ``key`` and casting elements to different levels per index in list, now raises ``TypeError`` (:issue:`41760`)
 
 Missing
 ^^^^^^^

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -709,7 +709,7 @@ Deprecations
 - Deprecated passing arguments as positional in :meth:`DataFrame.drop` (other than ``"labels"``) and :meth:`Series.drop` (:issue:`41485`)
 - Deprecated passing arguments as positional (other than ``filepath_or_buffer``) in :func:`read_table` (:issue:`41485`)
 
--
+
 .. _whatsnew_130.deprecations.nuisance_columns:
 
 Deprecated Dropping Nuisance Columns in DataFrame Reductions and DataFrameGroupBy Operations

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -709,6 +709,7 @@ Deprecations
 - Deprecated passing arguments as positional in :meth:`DataFrame.drop` (other than ``"labels"``) and :meth:`Series.drop` (:issue:`41485`)
 - Deprecated passing arguments as positional (other than ``filepath_or_buffer``) in :func:`read_table` (:issue:`41485`)
 
+-
 .. _whatsnew_130.deprecations.nuisance_columns:
 
 Deprecated Dropping Nuisance Columns in DataFrame Reductions and DataFrameGroupBy Operations

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3771,7 +3771,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             return result
 
         if axis == 1:
-            if drop_level:
+            if drop_level or not is_scalar(key):
                 return self[key]
             index = self.columns
         else:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3758,9 +3758,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         labels = self._get_axis(axis)
 
         if isinstance(key, list):
-            len_levels = 1 if level is None or is_scalar(level) else len(level)
-            if len(key) != len_levels:
-                raise TypeError("Passing lists as key for xs is not allowed.")
             warnings.warn(
                 "Passing lists as key for xs is deprecated and will be removed in a "
                 "future version. Pass key as a tuple instead.",

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3756,6 +3756,18 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         """
         axis = self._get_axis_number(axis)
         labels = self._get_axis(axis)
+
+        if isinstance(key, list):
+            len_levels = 1 if level is None or is_scalar(level) else len(level)
+            if len(key) != len_levels:
+                raise TypeError("Passing lists as key for xs is not allowed.")
+            warnings.warn(
+                "Passing lists as key for xs is deprecated and will be removed in a "
+                "future version. Pass key as a tuple instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+
         if level is not None:
             if not isinstance(labels, MultiIndex):
                 raise TypeError("Index must be a MultiIndex")
@@ -3771,7 +3783,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             return result
 
         if axis == 1:
-            if drop_level or not is_scalar(key):
+            if drop_level:
                 return self[key]
             index = self.columns
         else:

--- a/pandas/tests/frame/indexing/test_xs.py
+++ b/pandas/tests/frame/indexing/test_xs.py
@@ -358,3 +358,11 @@ class TestXSWithMultiIndex:
         df.iloc[0, 0] = 2
         expected = DataFrame({"a": [1]})
         tm.assert_frame_equal(result, expected)
+
+    def test_xs_list_indexer_droplevel_false(self):
+        # GH#41760
+        mi = MultiIndex.from_tuples([("x", "y", "a"), ("x", "z", "b"), ("v", "w", "c")])
+        df = DataFrame([[1, 2, 3], [4, 5, 6]], columns=mi)
+        expected = df.copy()
+        result = df.xs(["x", "v"], drop_level=False, axis=1)
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/indexing/test_xs.py
+++ b/pandas/tests/frame/indexing/test_xs.py
@@ -366,8 +366,8 @@ class TestXSWithMultiIndex:
 
     def test_xs_list_indexer_droplevel_false(self):
         # GH#41760
-        mi = MultiIndex.from_tuples([("x", "y", "a"), ("x", "z", "b"), ("v", "w", "c")])
+        mi = MultiIndex.from_tuples([("x", "m", "a"), ("x", "n", "b"), ("y", "o", "c")])
         df = DataFrame([[1, 2, 3], [4, 5, 6]], columns=mi)
-        msg = "Passing lists as key for xs is not allowed."
-        with pytest.raises(TypeError, match=msg):
-            df.xs(["x", "v"], drop_level=False, axis=1)
+        with tm.assert_produces_warning(FutureWarning):
+            with pytest.raises(KeyError, match="y"):
+                df.xs(["x", "y"], drop_level=False, axis=1)

--- a/pandas/tests/indexing/multiindex/test_partial.py
+++ b/pandas/tests/indexing/multiindex/test_partial.py
@@ -69,7 +69,7 @@ class TestMultiIndexPartial:
         )
         df = DataFrame(np.random.randn(8, 4), index=index, columns=list("abcd"))
 
-        result = df.xs(["foo", "one"])
+        result = df.xs(("foo", "one"))
         expected = df.loc["foo", "one"]
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/indexing/multiindex/test_partial.py
+++ b/pandas/tests/indexing/multiindex/test_partial.py
@@ -69,7 +69,8 @@ class TestMultiIndexPartial:
         )
         df = DataFrame(np.random.randn(8, 4), index=index, columns=list("abcd"))
 
-        result = df.xs(("foo", "one"))
+        with tm.assert_produces_warning(FutureWarning):
+            result = df.xs(["foo", "one"])
         expected = df.loc["foo", "one"]
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/series/indexing/test_xs.py
+++ b/pandas/tests/series/indexing/test_xs.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from pandas import (
     MultiIndex,
@@ -75,8 +74,7 @@ class TestXSWithMultiIndex:
         # GH#41760
         mi = MultiIndex.from_tuples([("a", "x")], names=["level1", "level2"])
         ser = Series([1], index=mi)
-        msg = "Passing lists as key for xs is not allowed."
-        with pytest.raises(TypeError, match=msg):
+        with tm.assert_produces_warning(FutureWarning):
             ser.xs(["a", "x"], axis=0, drop_level=False)
 
         with tm.assert_produces_warning(FutureWarning):

--- a/pandas/tests/series/indexing/test_xs.py
+++ b/pandas/tests/series/indexing/test_xs.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from pandas import (
     MultiIndex,
@@ -69,3 +70,14 @@ class TestXSWithMultiIndex:
             ),
         )
         tm.assert_series_equal(result, expected)
+
+    def test_xs_key_as_list(self):
+        # GH#41760
+        mi = MultiIndex.from_tuples([("a", "x")], names=["level1", "level2"])
+        ser = Series([1], index=mi)
+        msg = "Passing lists as key for xs is not allowed."
+        with pytest.raises(TypeError, match=msg):
+            ser.xs(["a", "x"], axis=0, drop_level=False)
+
+        with tm.assert_produces_warning(FutureWarning):
+            ser.xs(["a"], axis=0, drop_level=False)


### PR DESCRIPTION
- [x] closes #41760
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

cc @simonjayhawkins Should we include in 1.2.5 or push to 1.3?