### PR TITLE
REF: do remove DTI._convert_arr_indexer

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3428,7 +3428,7 @@ class Index(IndexOpsMixin, PandasObject):
     ) -> np.ndarray:
         # returned ndarray is np.intp
         method = missing.clean_reindex_fill_method(method)
-        target = ensure_index(target)
+        target = self._maybe_cast_listlike_indexer(target)
 
         self._check_indexing_method(method)
 
@@ -5693,6 +5693,12 @@ class Index(IndexOpsMixin, PandasObject):
         if not self.is_floating():
             return com.cast_scalar_indexer(key)
         return key
+
+    def _maybe_cast_listlike_indexer(self, target) -> Index:
+        """
+        Analogue to maybe_cast_indexer for get_indexer instead of get_loc.
+        """
+        return ensure_index(target)
 
     @final
     def _validate_indexer(self, form: str_t, key, kind: str_t):

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -49,6 +49,7 @@ from pandas.core.arrays import (
     TimedeltaArray,
 )
 from pandas.core.arrays.datetimelike import DatetimeLikeArrayMixin
+import pandas.core.common as com
 import pandas.core.indexes.base as ibase
 from pandas.core.indexes.base import (
     Index,
@@ -593,12 +594,13 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex):
 
     # --------------------------------------------------------------------
 
-    @doc(Index._convert_arr_indexer)
-    def _convert_arr_indexer(self, keyarr):
+    @doc(Index._maybe_cast_listlike_indexer)
+    def _maybe_cast_listlike_indexer(self, keyarr):
         try:
-            return self._data._validate_listlike(keyarr, allow_object=True)
+            res = self._data._validate_listlike(keyarr, allow_object=True)
         except (ValueError, TypeError):
-            return super()._convert_arr_indexer(keyarr)
+            res = com.asarray_tuplesafe(keyarr)
+        return Index(res, dtype=res.dtype)
 
 
 class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin):

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1308,11 +1308,11 @@ class _LocIndexer(_LocationIndexer):
             # For CategoricalIndex take instead of reindex to preserve dtype.
             #  For IntervalIndex this is to map integers to the Intervals they match to.
             keyarr = ax.take(indexer)
-            if isinstance(key, list) or (
-                isinstance(key, type(ax)) and key.freq is None
-            ):
+            if keyarr.dtype.kind in ["m", "M"]:
                 # DTI/TDI.take can infer a freq in some cases when we dont want one
-                if keyarr.dtype.kind in ["m", "M"]:
+                if isinstance(key, list) or (
+                    isinstance(key, type(ax)) and key.freq is None
+                ):
                     keyarr = keyarr._with_freq(None)
 
         return keyarr, indexer

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -30,6 +30,7 @@ from pandas.core.dtypes.common import (
     is_object_dtype,
     is_scalar,
     is_sequence,
+    needs_i8_conversion,
 )
 from pandas.core.dtypes.concat import concat_compat
 from pandas.core.dtypes.generic import (
@@ -1297,6 +1298,16 @@ class _LocIndexer(_LocationIndexer):
             keyarr, indexer, new_indexer = ax._reindex_non_unique(keyarr)
 
         self._validate_read_indexer(keyarr, indexer, axis)
+
+        if needs_i8_conversion(ax.dtype):
+            keyarr = ax.take(indexer)
+            if isinstance(key, list) or (
+                isinstance(key, type(ax)) and key.freq is None
+            ):
+                # DTI/TDI.take can infer a freq in some cases when we dont want one
+                if keyarr.dtype.kind in ["m", "M"]:
+                    keyarr = keyarr._with_freq(None)
+
         return keyarr, indexer
 
     def _validate_read_indexer(self, key, indexer, axis: int):

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -94,6 +94,8 @@ class TestFancy:
             msgs.append("Index data must be 1-dimensional")
         if isinstance(index, pd.IntervalIndex) and indexer_sli is tm.iloc:
             msgs.append("Index data must be 1-dimensional")
+        if isinstance(index, (pd.TimedeltaIndex, pd.DatetimeIndex, pd.PeriodIndex)):
+            msgs.append("Data must be 1-dimensional")
         if len(index) == 0 or isinstance(index, pd.MultiIndex):
             msgs.append("positional indexers are out-of-bounds")
         msg = "|".join(msgs)
@@ -127,6 +129,7 @@ class TestFancy:
                     r"Buffer has wrong number of dimensions \(expected 1, got 3\)",
                     "Cannot set values with ndim > 1",
                     "Index data must be 1-dimensional",
+                    "Data must be 1-dimensional",
                     "Array conditional must be same shape as self",
                 ]
             )


### PR DESCRIPTION
Motivation: get rid of `_convert_listlike_indexer`, `_convert_arr_indexer`, `_convert_list_indexer`.  These are just convoluted bits of casting before a (inefficient-because-repeated) call to `get_indexer`.

This moves the relevant casting for the DTI/TDI/PI case directly into get_indexer, mirroring how get_loc works for these subclasses.

Upcoming PR does analogous thing for IntervalIndex and CategoricalIndex.  MultiIndex is the last one, haven't landed on a solution there.

cc @phofl