### PR TITLE
REF: remove Index._convert_list_indexer

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3720,7 +3720,7 @@ class Index(IndexOpsMixin, PandasObject):
         else:
             keyarr = self._convert_arr_indexer(keyarr)
 
-        indexer = self._convert_list_indexer(keyarr)
+        indexer = None
         return indexer, keyarr
 
     def _convert_arr_indexer(self, keyarr) -> np.ndarray:
@@ -3737,22 +3737,6 @@ class Index(IndexOpsMixin, PandasObject):
         converted_keyarr : array-like
         """
         return com.asarray_tuplesafe(keyarr)
-
-    def _convert_list_indexer(self, keyarr):
-        """
-        Convert a list-like indexer to the appropriate dtype.
-
-        Parameters
-        ----------
-        keyarr : Index (or sub-class)
-            Indexer to convert.
-        kind : iloc, loc, optional
-
-        Returns
-        -------
-        positional indexer or None
-        """
-        return None
 
     @final
     def _invalid_indexer(self, form: str_t, key) -> TypeError:

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -525,18 +525,6 @@ class CategoricalIndex(NDArrayBackedExtensionIndex, accessor.PandasDelegate):
         indexer, missing = self._engine.get_indexer_non_unique(codes)
         return ensure_platform_int(indexer), ensure_platform_int(missing)
 
-    @doc(Index._convert_list_indexer)
-    def _convert_list_indexer(self, keyarr):
-        # Return our indexer or raise if all of the values are not included in
-        # the categories
-
-        if self.categories._defer_to_indexing:
-            # See tests.indexing.interval.test_interval:test_loc_getitem_frame
-            indexer = self.categories._convert_list_indexer(keyarr)
-            return Index(self.codes).get_indexer_for(indexer)
-
-        return self.get_indexer_for(keyarr)
-
     # --------------------------------------------------------------------
 
     def _is_comparable_dtype(self, dtype: DtypeObj) -> bool:

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -815,20 +815,6 @@ class IntervalIndex(ExtensionIndex):
         self._deprecated_arg(kind, "kind", "_maybe_cast_slice_bound")
         return getattr(self, side)._maybe_cast_slice_bound(label, side)
 
-    @Appender(Index._convert_list_indexer.__doc__)
-    def _convert_list_indexer(self, keyarr):
-        """
-        we are passed a list-like indexer. Return the
-        indexer for matching intervals.
-        """
-        locs = self.get_indexer_for(keyarr)
-
-        # we have missing values
-        if (locs == -1).any():
-            raise KeyError(keyarr[locs == -1].tolist())
-
-        return locs
-
     def _is_comparable_dtype(self, dtype: DtypeObj) -> bool:
         if not isinstance(dtype, IntervalDtype):
             return False

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -51,8 +51,11 @@ from pandas.core.indexers import (
     length_of_indexer,
 )
 from pandas.core.indexes.api import (
+    CategoricalIndex,
     Index,
+    IntervalIndex,
     MultiIndex,
+    ensure_index,
 )
 
 if TYPE_CHECKING:
@@ -1297,6 +1300,11 @@ class _LocIndexer(_LocationIndexer):
             keyarr, indexer, new_indexer = ax._reindex_non_unique(keyarr)
 
         self._validate_read_indexer(keyarr, indexer, axis)
+
+        if isinstance(ax, (IntervalIndex, CategoricalIndex)):
+            # take instead of reindex to preserve dtype.  For IntervalIndex
+            #  this is to map integers to the Intervals they match to.
+            keyarr = ax.take(indexer)
         return keyarr, indexer
 
     def _validate_read_indexer(self, key, indexer, axis: int):
@@ -1329,13 +1337,24 @@ class _LocIndexer(_LocationIndexer):
         missing = (missing_mask).sum()
 
         if missing:
-            if missing == len(indexer):
-                axis_name = self.obj._get_axis_name(axis)
-                raise KeyError(f"None of [{key}] are in the [{axis_name}]")
-
             ax = self.obj._get_axis(axis)
 
-            not_found = list(set(key) - set(ax))
+            # TODO: remove special-case; this is just to keep exception
+            #  message tests from raising while debugging
+            use_interval_msg = isinstance(ax, IntervalIndex) or (
+                isinstance(ax, CategoricalIndex)
+                and isinstance(ax.categories, IntervalIndex)
+            )
+
+            if missing == len(indexer):
+                axis_name = self.obj._get_axis_name(axis)
+                if use_interval_msg:
+                    raise KeyError(list(key))
+                raise KeyError(f"None of [{key}] are in the [{axis_name}]")
+
+            not_found = list(ensure_index(key)[missing_mask.nonzero()[0]].unique())
+            if use_interval_msg:
+                raise KeyError(not_found)
             raise KeyError(f"{not_found} not in index")
 
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1349,12 +1349,10 @@ class _LocIndexer(_LocationIndexer):
             if missing == len(indexer):
                 axis_name = self.obj._get_axis_name(axis)
                 if use_interval_msg:
-                    raise KeyError(list(key))
+                    key = list(key)
                 raise KeyError(f"None of [{key}] are in the [{axis_name}]")
 
             not_found = list(ensure_index(key)[missing_mask.nonzero()[0]].unique())
-            if use_interval_msg:
-                raise KeyError(not_found)
             raise KeyError(f"{not_found} not in index")
 
 

--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -65,10 +65,10 @@ class TestIntervalIndex:
 
         # this is a departure from our current
         # indexing scheme, but simpler
-        with pytest.raises(KeyError, match=r"^\[-1\]$"):
+        with pytest.raises(KeyError, match=r"\[-1\] not in index"):
             indexer_sl(ser)[[-1, 3, 4, 5]]
 
-        with pytest.raises(KeyError, match=r"^\[-1\]$"):
+        with pytest.raises(KeyError, match=r"\[-1\] not in index"):
             indexer_sl(ser)[[-1, 3]]
 
     @pytest.mark.slow
@@ -107,11 +107,11 @@ class TestIntervalIndex:
         expected = df.take([4, 5, 4, 5])
         tm.assert_frame_equal(result, expected)
 
-        with pytest.raises(KeyError, match=r"^\[10\]$"):
+        with pytest.raises(KeyError, match=r"None of \[\[10\]\] are"):
             df.loc[[10]]
 
         # partial missing
-        with pytest.raises(KeyError, match=r"^\[10\]$"):
+        with pytest.raises(KeyError, match=r"\[10\] not in index"):
             df.loc[[10, 4]]
 
 

--- a/pandas/tests/indexing/interval/test_interval_new.py
+++ b/pandas/tests/indexing/interval/test_interval_new.py
@@ -150,7 +150,8 @@ class TestIntervalIndex:
         with pytest.raises(KeyError, match=re.escape("Interval(3, 5, closed='right')")):
             indexer_sl(ser)[Interval(3, 5)]
 
-        with pytest.raises(KeyError, match=r"^\[Interval\(3, 5, closed='right'\)\]$"):
+        msg = r"None of \[\[Interval\(3, 5, closed='right'\)\]\]"
+        with pytest.raises(KeyError, match=msg):
             indexer_sl(ser)[[Interval(3, 5)]]
 
         # slices with interval (only exact matches)

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -338,7 +338,7 @@ class TestFancy:
         # GH 10610
         df = DataFrame(np.random.random((10, 5)), columns=["a"] + [20, 21, 22, 23])
 
-        with pytest.raises(KeyError, match=re.escape("'[-8, 26] not in index'")):
+        with pytest.raises(KeyError, match=re.escape("'[26, -8] not in index'")):
             df[[22, 26, -8]]
         assert df[21].shape[0] == df.shape[0]
 


### PR DESCRIPTION
xref #41803 

<s>This doesn't yet address the special-cased exception messages we issue for IntervalIndex/CategoricalIndex.</s>
update: this half-addresses the special-cased exception messages