### PR TITLE
REF: split out grouped masked cummin/max algo

### DIFF
--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -1345,11 +1345,9 @@ cdef group_cummin_max(groupby_t[:, ::1] out,
     This method modifies the `out` parameter, rather than returning an object.
     """
     cdef:
-        Py_ssize_t N, K
         groupby_t[:, ::1] accum
 
-    N, K = (<object>values).shape
-    accum = np.empty((ngroups, K), dtype=values.dtype)
+    accum = np.empty((ngroups, (<object>values).shape[1]), dtype=values.dtype)
     if groupby_t is int64_t:
         accum[:] = -_int64_max if compute_max else _int64_max
     elif groupby_t is uint64_t:

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -1345,13 +1345,8 @@ cdef group_cummin_max(groupby_t[:, ::1] out,
     This method modifies the `out` parameter, rather than returning an object.
     """
     cdef:
-        Py_ssize_t i, j, N, K, size
-        groupby_t val, mval
+        Py_ssize_t N, K
         groupby_t[:, ::1] accum
-        intp_t lab
-        bint val_is_nan, use_mask
-
-    use_mask = mask is not None
 
     N, K = (<object>values).shape
     accum = np.empty((ngroups, K), dtype=values.dtype)
@@ -1362,36 +1357,78 @@ cdef group_cummin_max(groupby_t[:, ::1] out,
     else:
         accum[:] = -np.inf if compute_max else np.inf
 
+    if mask is not None:
+        masked_cummin_max(out, values, mask, labels, accum, N, K, compute_max)
+    else:
+        cummin_max(out, values, labels, accum, N, K, is_datetimelike, compute_max)
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef cummin_max(groupby_t[:, ::1] out,
+                ndarray[groupby_t, ndim=2] values,
+                const intp_t[:] labels,
+                groupby_t[:, ::1] accum,
+                Py_ssize_t N,
+                Py_ssize_t K,
+                bint is_datetimelike,
+                bint compute_max):
+    """
+    Compute the cumulative minimum/maximum of columns of `values`, in row groups
+    `labels`.
+    """
+    cdef:
+        Py_ssize_t i, j
+        groupby_t val, mval
+        intp_t lab
+
     with nogil:
         for i in range(N):
             lab = labels[i]
-
             if lab < 0:
                 continue
             for j in range(K):
-                val_is_nan = False
-
-                if use_mask:
-                    if mask[i, j]:
-
-                        # `out` does not need to be set since it
-                        # will be masked anyway
-                        val_is_nan = True
+                val = values[i, j]
+                if not _treat_as_na(val, is_datetimelike):
+                    mval = accum[lab, j]
+                    if compute_max:
+                        if val > mval:
+                            accum[lab, j] = mval = val
                     else:
-
-                        # If using the mask, we can avoid grabbing the
-                        # value unless necessary
-                        val = values[i, j]
-
-                # Otherwise, `out` must be set accordingly if the
-                # value is missing
+                        if val < mval:
+                            accum[lab, j] = mval = val
+                    out[i, j] = mval
                 else:
-                    val = values[i, j]
-                    if _treat_as_na(val, is_datetimelike):
-                        val_is_nan = True
-                        out[i, j] = val
+                    out[i, j] = val
 
-                if not val_is_nan:
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef masked_cummin_max(groupby_t[:, ::1] out,
+                       ndarray[groupby_t, ndim=2] values,
+                       uint8_t[:, ::1] mask,
+                       const intp_t[:] labels,
+                       groupby_t[:, ::1] accum,
+                       Py_ssize_t N,
+                       Py_ssize_t K,
+                       bint compute_max):
+    """
+    Compute the cumulative minimum/maximum of columns of `values`, in row groups
+    `labels` with a masked algorithm.
+    """
+    cdef:
+        Py_ssize_t i, j
+        groupby_t val, mval
+        intp_t lab
+
+    with nogil:
+        for i in range(N):
+            lab = labels[i]
+            if lab < 0:
+                continue
+            for j in range(K):
+                if not mask[i, j]:
+                    val = values[i, j]
                     mval = accum[lab, j]
                     if compute_max:
                         if val > mval:

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -1358,9 +1358,9 @@ cdef group_cummin_max(groupby_t[:, ::1] out,
         accum[:] = -np.inf if compute_max else np.inf
 
     if mask is not None:
-        masked_cummin_max(out, values, mask, labels, accum, N, K, compute_max)
+        masked_cummin_max(out, values, mask, labels, accum, compute_max)
     else:
-        cummin_max(out, values, labels, accum, N, K, is_datetimelike, compute_max)
+        cummin_max(out, values, labels, accum, is_datetimelike, compute_max)
 
 
 @cython.boundscheck(False)
@@ -1369,8 +1369,6 @@ cdef cummin_max(groupby_t[:, ::1] out,
                 ndarray[groupby_t, ndim=2] values,
                 const intp_t[:] labels,
                 groupby_t[:, ::1] accum,
-                Py_ssize_t N,
-                Py_ssize_t K,
                 bint is_datetimelike,
                 bint compute_max):
     """
@@ -1378,10 +1376,11 @@ cdef cummin_max(groupby_t[:, ::1] out,
     `labels`.
     """
     cdef:
-        Py_ssize_t i, j
+        Py_ssize_t i, j, N, K
         groupby_t val, mval
         intp_t lab
 
+    N, K = (<object>values).shape
     with nogil:
         for i in range(N):
             lab = labels[i]
@@ -1409,18 +1408,17 @@ cdef masked_cummin_max(groupby_t[:, ::1] out,
                        uint8_t[:, ::1] mask,
                        const intp_t[:] labels,
                        groupby_t[:, ::1] accum,
-                       Py_ssize_t N,
-                       Py_ssize_t K,
                        bint compute_max):
     """
     Compute the cumulative minimum/maximum of columns of `values`, in row groups
     `labels` with a masked algorithm.
     """
     cdef:
-        Py_ssize_t i, j
+        Py_ssize_t i, j, N, K
         groupby_t val, mval
         intp_t lab
 
+    N, K = (<object>values).shape
     with nogil:
         for i in range(N):
             lab = labels[i]


### PR DESCRIPTION
No user-facing change here, but I think makes logic clearer and future changes easier to understand

Benchmarks look unaffected:
<details>

```
before           after         ratio
[3f67dc33]       [51f8f9c8]
<master>         <masked_cummin_ref>
17.0±2ms         16.3±2ms     0.96  groupby.CumminMax.time_frame_transform('Float64', 'cummax')
17.7±2ms         18.4±2ms     1.04  groupby.CumminMax.time_frame_transform('Float64', 'cummin')
20.8±3ms       16.9±0.3ms    ~0.81  groupby.CumminMax.time_frame_transform('Int64', 'cummax')
20.7±3ms         18.2±3ms    ~0.88  groupby.CumminMax.time_frame_transform('Int64', 'cummin')
15.7±2ms       13.0±0.3ms    ~0.83  groupby.CumminMax.time_frame_transform('float64', 'cummax')
15.5±0.7ms       13.6±0.7ms    ~0.88  groupby.CumminMax.time_frame_transform('float64', 'cummin')
29.8±0.7ms       28.0±0.4ms     0.94  groupby.CumminMax.time_frame_transform('int64', 'cummax')
29.9±1ms         30.0±2ms     1.00  groupby.CumminMax.time_frame_transform('int64', 'cummin')
19.2±2ms         16.9±3ms    ~0.88  groupby.CumminMax.time_frame_transform_many_nulls('Float64', 'cummax')
22.6±2ms         15.6±2ms    ~0.69  groupby.CumminMax.time_frame_transform_many_nulls('Float64', 'cummin')
15.7±3ms         19.3±3ms    ~1.23  groupby.CumminMax.time_frame_transform_many_nulls('Int64', 'cummax')
19.5±2ms         14.7±1ms    ~0.75  groupby.CumminMax.time_frame_transform_many_nulls('Int64', 'cummin')
14.5±2ms       11.4±0.8ms    ~0.79  groupby.CumminMax.time_frame_transform_many_nulls('float64', 'cummax')
13.2±1ms       12.4±0.2ms     0.94  groupby.CumminMax.time_frame_transform_many_nulls('float64', 'cummin')
14.2±1ms       13.1±0.1ms     0.92  groupby.CumminMax.time_frame_transform_many_nulls('int64', 'cummax')
14.1±0.5ms       13.4±0.4ms     0.95  groupby.CumminMax.time_frame_transform_many_nulls('int64', 'cummin')
```

</details>
