### PR TITLE
TST: add ASV check for groupby with uint64 col

### DIFF
--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -389,6 +389,26 @@ class FillNA:
         self.df.groupby("group")["value"].fillna(method="bfill")
 
 
+class UInt64:
+    def setup(self):
+        N = 100
+        uints = np.random.randint(0, 10, size=N).astype("uint64")
+        ints = np.random.randint(0, 10, size=N).astype("int64")
+        self.df = DataFrame({"u": uints, "i": ints})
+
+    def time_df_min_uint_groups(self):
+        self.df.groupby("u").min()
+
+    def time_df_min_uint_vals(self):
+        self.df.groupby("i").min()
+
+    def time_srs_min_uint_groups(self):
+        self.df.groupby("u")["i"].min()
+
+    def time_srs_min_uint_vals(self):
+        self.df.groupby("i")["u"].min()
+
+
 class GroupByMethods:
 
     param_names = ["dtype", "method", "application"]

--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -389,31 +389,11 @@ class FillNA:
         self.df.groupby("group")["value"].fillna(method="bfill")
 
 
-class UInt64:
-    def setup(self):
-        N = 100
-        uints = np.random.randint(0, 10, size=N).astype("uint64")
-        ints = np.random.randint(0, 10, size=N).astype("int64")
-        self.df = DataFrame({"u": uints, "i": ints})
-
-    def time_df_min_uint_groups(self):
-        self.df.groupby("u").min()
-
-    def time_df_min_uint_vals(self):
-        self.df.groupby("i").min()
-
-    def time_srs_min_uint_groups(self):
-        self.df.groupby("u")["i"].min()
-
-    def time_srs_min_uint_vals(self):
-        self.df.groupby("i")["u"].min()
-
-
 class GroupByMethods:
 
     param_names = ["dtype", "method", "application"]
     params = [
-        ["int", "float", "object", "datetime"],
+        ["int", "float", "object", "datetime", "uint"],
         [
             "all",
             "any",
@@ -462,6 +442,8 @@ class GroupByMethods:
         values = rng.take(np.random.randint(0, ngroups, size=size))
         if dtype == "int":
             key = np.random.randint(0, size, size=size)
+        elif dtype == "uint":
+            key = np.random.randint(0, size, size=size, dtype=dtype)
         elif dtype == "float":
             key = np.concatenate(
                 [np.random.random(ngroups) * 0.1, np.random.random(ngroups) * 10.0]


### PR DESCRIPTION
- [x] closes #28122 
- [x] tests added/passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

The performance regression reported in the original issue was fixed somewhere between 0.25.1 and 1.2.4. This PR just adds an ASV test to monitor for the same regression in the future. 
