### PR TITLE
Clean up ujson initialization

### DIFF
--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -35,11 +35,13 @@ https://www.opensource.apple.com/source/tcl/tcl-14/tcl/license.terms
 * Copyright (c) 1988-1993 The Regents of the University of California.
 * Copyright (c) 1994 Sun Microsystems, Inc.
 */
-#define PY_ARRAY_UNIQUE_SYMBOL UJSON_NUMPY
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <math.h>
+
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL UJSON_NUMPY
 #include <numpy/arrayobject.h>
 #include <numpy/arrayscalars.h>
 #include <numpy/ndarraytypes.h>
@@ -178,8 +180,6 @@ void *initObjToJSON(void) {
         Py_DECREF(mod_natype);
     }
 
-    /* Initialise numpy API */
-    import_array();
     // GH 31463
     return NULL;
 }

--- a/pandas/_libs/src/ujson/python/ujson.c
+++ b/pandas/_libs/src/ujson/python/ujson.c
@@ -38,6 +38,8 @@ https://www.opensource.apple.com/source/tcl/tcl-14/tcl/license.terms
 #include "version.h"
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+#define PY_ARRAY_UNIQUE_SYMBOL UJSON_NUMPY
+#include "numpy/arrayobject.h"
 
 /* objToJSON */
 PyObject *objToJSON(PyObject *self, PyObject *args, PyObject *kwargs);
@@ -73,6 +75,7 @@ static PyModuleDef moduledef = {
 
 
 PyMODINIT_FUNC PyInit_json(void) {
+  import_array()
   initObjToJSON();  // TODO(username): clean up, maybe via tp_free?
   return PyModuleDef_Init(&moduledef);
 }


### PR DESCRIPTION
The way we do this now is a little wonky as we are declaring the C API in the objToJSON file for re-use by JSONToObj; this happens to work because we call the objToJSON initialization function in the main extension module, but it's a bit funky and prone to errors on refactor

More background info:

https://numpy.org/doc/stable/reference/c-api/array.html#importing-the-api

https://stackoverflow.com/a/35362918/621736