### PR TITLE
PERF: clipping with scalar

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7244,10 +7244,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         with np.errstate(all="ignore"):
             if upper is not None:
-                subset = (self <= upper).to_numpy()
+                subset = self <= upper
                 result = result.where(subset, upper, axis=None, inplace=False)
             if lower is not None:
-                subset = (self >= lower).to_numpy()
+                subset = self >= lower
                 result = result.where(subset, lower, axis=None, inplace=False)
 
         if np.any(mask):


### PR DESCRIPTION
Removes conversion of boolean series to array-like in `_clip_with_scalar`.

- [x] closes #41434
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

I may also add type annotations to `_clip_with_scalar`, let me know if that's welcome.
