### PR TITLE
CLN/PERF: no need for kahan for int group_cumsum

### DIFF
--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -505,7 +505,7 @@ class GroupByCythonAgg:
         self.df.groupby("key").agg(method)
 
 
-class CumminMax:
+class Cumulative:
     param_names = ["dtype", "method"]
     params = [
         ["float64", "int64", "Float64", "Int64"],

--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -509,7 +509,7 @@ class CumminMax:
     param_names = ["dtype", "method"]
     params = [
         ["float64", "int64", "Float64", "Int64"],
-        ["cummin", "cummax"],
+        ["cummin", "cummax", "cumsum"],
     ]
 
     def setup(self, dtype, method):

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -247,6 +247,8 @@ def group_cumsum(numeric[:, ::1] out,
             for j in range(K):
                 val = values[i, j]
 
+                # For floats, use Kahan summation to reduce floating-point
+                # error (https://en.wikipedia.org/wiki/Kahan_summation_algorithm)
                 if numeric == float32_t or numeric == float64_t:
                     if val == val:
                         y = val - compensation[lab, j]

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -260,10 +260,7 @@ def group_cumsum(numeric[:, ::1] out,
                             accum[lab, j] = NaN
                             break
                 else:
-                    y = val - compensation[lab, j]
-                    t = accum[lab, j] + y
-                    compensation[lab, j] = t - accum[lab, j] - y
-                    accum[lab, j] = t
+                    accum[lab, j] = val + accum[lab, j]
                     out[i, j] = accum[lab, j]
 
 

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -230,7 +230,7 @@ def group_cumsum(numeric[:, ::1] out,
     """
     cdef:
         Py_ssize_t i, j, N, K, size
-        numeric val, y, t
+        numeric val, next_val, y, t
         numeric[:, ::1] accum, compensation
         intp_t lab
 
@@ -260,8 +260,9 @@ def group_cumsum(numeric[:, ::1] out,
                             accum[lab, j] = NaN
                             break
                 else:
-                    accum[lab, j] = val + accum[lab, j]
-                    out[i, j] = accum[lab, j]
+                    next_val = val + accum[lab, j]
+                    accum[lab, j] = next_val
+                    out[i, j] = next_val
 
 
 @cython.boundscheck(False)

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -230,7 +230,7 @@ def group_cumsum(numeric[:, ::1] out,
     """
     cdef:
         Py_ssize_t i, j, N, K, size
-        numeric val, next_val, y, t
+        numeric val, y, t
         numeric[:, ::1] accum, compensation
         intp_t lab
 
@@ -253,16 +253,16 @@ def group_cumsum(numeric[:, ::1] out,
                         t = accum[lab, j] + y
                         compensation[lab, j] = t - accum[lab, j] - y
                         accum[lab, j] = t
-                        out[i, j] = accum[lab, j]
+                        out[i, j] = t
                     else:
                         out[i, j] = NaN
                         if not skipna:
                             accum[lab, j] = NaN
                             break
                 else:
-                    next_val = val + accum[lab, j]
-                    accum[lab, j] = next_val
-                    out[i, j] = next_val
+                    t = val + accum[lab, j]
+                    accum[lab, j] = t
+                    out[i, j] = t
 
 
 @cython.boundscheck(False)


### PR DESCRIPTION
Surprised at lack of impact here - doesn't noticeably affect benchmarks.

Targeting the cython algo specifically shows an improvement (but smaller than I'd expect given the removed operations):
```
import numpy as np
import pandas._libs.groupby as libgroupby

N = 4_000_000
vals = np.random.randint(0, 10, (N, 5), dtype=np.int64)
result = np.empty_like(vals)

%timeit libgroupby.group_cumsum(result, vals, np.ones(N, dtype="int"), 1, False)
# 28.9 ms ± 805 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)  # this pr
# 37.3 ms ± 206 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)   # master
```