### PR TITLE
ENH: Add `drop_na` keyword to "to_json()" function

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2309,6 +2309,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         index: bool_t = True,
         indent: int | None = None,
         storage_options: StorageOptions = None,
+        drop_na: bool_t = False,
     ) -> str | None:
         """
         Convert the object to a JSON string.
@@ -2369,6 +2370,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             If 'orient' is 'records' write out line delimited json format. Will
             throw ValueError if incorrect 'orient' since others are not list
             like.
+        drop_na : bool, default False
+            If 'orient' is 'records' remove `null` items from the output. Will
+            throw ValueError if incorrect 'orient'.
 
         compression : {{'infer', 'gzip', 'bz2', 'zip', 'xz', None}}
 
@@ -2574,6 +2578,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             index=index,
             indent=indent,
             storage_options=storage_options,
+            drop_na=drop_na,
         )
 
     @final

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -62,6 +62,7 @@ from pandas.io.common import (
     stringify_path,
 )
 from pandas.io.json._normalize import convert_to_line_delimits
+from pandas.io.json._normalize import remove_null_items
 from pandas.io.json._table_schema import (
     build_table_schema,
     parse_table_schema,
@@ -89,6 +90,7 @@ def to_json(
     index: bool = True,
     indent: int = 0,
     storage_options: StorageOptions = None,
+    drop_na: bool = False,
 ):
 
     if not index and orient not in ["split", "table"]:
@@ -98,6 +100,9 @@ def to_json(
 
     if lines and orient != "records":
         raise ValueError("'lines' keyword only valid when 'orient' is records")
+
+    if drop_na and orient != "records":
+        raise ValueError("'drop_na' keyword only valid when 'orient' is records")
 
     if orient == "table" and isinstance(obj, Series):
         obj = obj.to_frame(name=obj.name or "values")
@@ -123,6 +128,9 @@ def to_json(
         index=index,
         indent=indent,
     ).write()
+
+    if drop_na:
+        s = remove_null_items(s)
 
     if lines:
         s = convert_to_line_delimits(s)

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -101,8 +101,9 @@ def to_json(
     if lines and orient != "records":
         raise ValueError("'lines' keyword only valid when 'orient' is records")
 
-    if drop_na and orient != "records":
-        raise ValueError("'drop_na' keyword only valid when 'orient' is records")
+    if drop_na and (orient != "records" or not isinstance(obj, DataFrame)):
+        raise ValueError(("'drop_na' keyword only valid when 'orient' is "
+                          "records and input is a DataFrame"))
 
     if orient == "table" and isinstance(obj, Series):
         obj = obj.to_frame(name=obj.name or "values")

--- a/pandas/io/json/_normalize.py
+++ b/pandas/io/json/_normalize.py
@@ -22,6 +22,8 @@ from pandas.util._decorators import deprecate
 import pandas as pd
 from pandas import DataFrame
 
+import re
+
 
 def convert_to_line_delimits(s: str) -> str:
     """
@@ -34,6 +36,18 @@ def convert_to_line_delimits(s: str) -> str:
     s = s[1:-1]
 
     return convert_json_to_lines(s)
+
+
+def remove_null_items(s: str) -> str:
+    """
+    Helper function that removes null items from a JSON object.
+    """
+    s = re.sub(r',"([^"]*)":null', '', s)
+    s = re.sub(r'"([^"]*)":null,', '', s)
+    s = re.sub(r'{"([^"]*)":null}', '', s)
+    s = re.sub(r'\[,', '[', s)
+    s = re.sub(r',\]', ']', s)
+    return s
 
 
 def nested_to_record(

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1326,6 +1326,28 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         assert result == expected
         tm.assert_frame_equal(read_json(result, lines=True), df)
 
+    def test_to_json_drop_na(self):
+        df = DataFrame([[1, 2], [1, np.nan], [np.nan, np.nan]], columns=["a", "b"])
+        result = df.to_json(orient="records", drop_na=False)
+        expected = '[{"a":1.0,"b":2.0},{"a":1.0,"b":null},{"a":null,"b":null}]'
+        assert result == expected
+
+        df = DataFrame([[1, 2], [1, np.nan], [np.nan, np.nan]], columns=["a", "b"])
+        result = df.to_json(orient="records", drop_na=True)
+        expected = '[{"a":1.0,"b":2.0},{"a":1.0}]'
+        assert result == expected
+
+    def test_to_jsonl_drop_na(self):
+        df = DataFrame([[1, 2], [1, np.nan], [np.nan, np.nan]], columns=["a", "b"])
+        result = df.to_json(orient="records", lines=True, drop_na=False)
+        expected = '{"a":1.0,"b":2.0}\n{"a":1.0,"b":null}\n{"a":null,"b":null}\n'
+        assert result == expected
+
+        df = DataFrame([[1, 2], [1, np.nan], [np.nan, np.nan]], columns=["a", "b"])
+        result = df.to_json(orient="records", lines=True, drop_na=True)
+        expected = '{"a":1.0,"b":2.0}\n{"a":1.0}\n'
+        assert result == expected
+
     # TODO: there is a near-identical test for pytables; can we share?
     def test_latin_encoding(self):
         # GH 13774


### PR DESCRIPTION
__What's new__

This PR introduces a new keyword, `drop_na`, to the `to_json()` function. It can be set to either `True` or `False`.

When `drop_na=False`, `to_json()` works just like it did before.

When `drop_na=True`, items with value `null` in the output of `to_json()` will be removed. Using this feature is (currently) only possible in combination with `orient="records"` and when the input object is of type `pd.DataFrame`. Removing the `null` items is done through string substitution with `re.sub()` in a new helper function (`remove_null_items()` in `_normalize.py`).

- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

__Notes__

I imagine that, ideally, the `ultrajson`/`ujson` package had a `drop_none` parameter that would be adapted to include `NaN` values from pandas. IMO, this would be a better solution because it 1) is likely much faster and 2) avoids the use of regex. I started implementing such a parameter in `ujson` (see [here](https://github.com/romanhaa/ultrajson/commits/drop_none)), but and wondered whether it would introduce too much conditionality to be compatible with their philosophy (being ultra-fast). That's why I decided to propose a sub-optimal but working solution to `pandas` directly.

__Performance__

I ran some performance tests and compared it to a [workaround](https://stackoverflow.com/a/46955083) intended to achieve the same goal.

The input is a dataframe with 214,066 rows and 12 columns (read from a `.json` file, 58M in size, that can be found [here](http://ftp.ebi.ac.uk/pub/databases/opentargets/genetics/20022712/v2g/)).

Code snippet for testing:

```py
df = pd.read_json('part-00001-7a4fb376-056a-4f34-ad92-248989cd92d4-c000.json', lines=True)

print("export with `drop_na=False`")
start_time = time.time()
df.to_json("~/some_file_1.json", orient="records", lines=False, drop_na=False)
print("--- %s seconds ---" % (time.time() - start_time))

print("export with `drop_na=True`")
start_time = time.time()
df.to_json("~/some_file_2.json", orient="records", lines=False, drop_na=True)
print("--- %s seconds ---" % (time.time() - start_time))

print("export with workaround")
start_time = time.time()
with open("/Users/roman/some_file_3.json", "w", encoding="utf-8") as f:
    json.dump([row.dropna().to_dict() for index, row in df.iterrows()], f)
print("--- %s seconds ---" % (time.time() - start_time))
```

Output:

```
export with `to_json(orient='records', drop_na=False)`
--- 0.4323728084564209 seconds ---
export with `to_json(orient='records', drop_na=True)`
--- 1.6985130310058594 seconds ---
export with workaround
--- 79.73292803764343 seconds ---
```

The implementation I propose is not only (much) faster than the workaround, but is also compatible with generating output in `jsonlines` format.