### PR TITLE
TYP: use from __future__ import annotations more - batch 1

### DIFF
--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import (
     ABC,
     abstractmethod,
@@ -10,10 +12,6 @@ from typing import (
     Any,
     Callable,
     Mapping,
-    Optional,
-    Tuple,
-    Type,
-    Union,
 )
 
 import numpy as np
@@ -78,12 +76,12 @@ TABLE_SCHEMA_VERSION = "0.20.0"
 def to_json(
     path_or_buf,
     obj: NDFrame,
-    orient: Optional[str] = None,
+    orient: str | None = None,
     date_format: str = "epoch",
     double_precision: int = 10,
     force_ascii: bool = True,
     date_unit: str = "ms",
-    default_handler: Optional[Callable[[Any], JSONSerializable]] = None,
+    default_handler: Callable[[Any], JSONSerializable] | None = None,
     lines: bool = False,
     compression: CompressionOptions = "infer",
     index: bool = True,
@@ -102,7 +100,7 @@ def to_json(
     if orient == "table" and isinstance(obj, Series):
         obj = obj.to_frame(name=obj.name or "values")
 
-    writer: Type[Writer]
+    writer: type[Writer]
     if orient == "table" and isinstance(obj, DataFrame):
         writer = JSONTableWriter
     elif isinstance(obj, Series):
@@ -143,13 +141,13 @@ class Writer(ABC):
     def __init__(
         self,
         obj,
-        orient: Optional[str],
+        orient: str | None,
         date_format: str,
         double_precision: int,
         ensure_ascii: bool,
         date_unit: str,
         index: bool,
-        default_handler: Optional[Callable[[Any], JSONSerializable]] = None,
+        default_handler: Callable[[Any], JSONSerializable] | None = None,
         indent: int = 0,
     ):
         self.obj = obj
@@ -187,7 +185,7 @@ class Writer(ABC):
 
     @property
     @abstractmethod
-    def obj_to_write(self) -> Union[NDFrame, Mapping[IndexLabel, Any]]:
+    def obj_to_write(self) -> NDFrame | Mapping[IndexLabel, Any]:
         """Object to write in JSON format."""
         pass
 
@@ -196,7 +194,7 @@ class SeriesWriter(Writer):
     _default_orient = "index"
 
     @property
-    def obj_to_write(self) -> Union[NDFrame, Mapping[IndexLabel, Any]]:
+    def obj_to_write(self) -> NDFrame | Mapping[IndexLabel, Any]:
         if not self.index and self.orient == "split":
             return {"name": self.obj.name, "data": self.obj.values}
         else:
@@ -211,7 +209,7 @@ class FrameWriter(Writer):
     _default_orient = "columns"
 
     @property
-    def obj_to_write(self) -> Union[NDFrame, Mapping[IndexLabel, Any]]:
+    def obj_to_write(self) -> NDFrame | Mapping[IndexLabel, Any]:
         if not self.index and self.orient == "split":
             obj_to_write = self.obj.to_dict(orient="split")
             del obj_to_write["index"]
@@ -243,13 +241,13 @@ class JSONTableWriter(FrameWriter):
     def __init__(
         self,
         obj,
-        orient: Optional[str],
+        orient: str | None,
         date_format: str,
         double_precision: int,
         ensure_ascii: bool,
         date_unit: str,
         index: bool,
-        default_handler: Optional[Callable[[Any], JSONSerializable]] = None,
+        default_handler: Callable[[Any], JSONSerializable] | None = None,
         indent: int = 0,
     ):
         """
@@ -313,7 +311,7 @@ class JSONTableWriter(FrameWriter):
         self.index = index
 
     @property
-    def obj_to_write(self) -> Union[NDFrame, Mapping[IndexLabel, Any]]:
+    def obj_to_write(self) -> NDFrame | Mapping[IndexLabel, Any]:
         return {"schema": self.schema, "data": self.obj}
 
 
@@ -326,7 +324,7 @@ def read_json(
     path_or_buf=None,
     orient=None,
     typ="frame",
-    dtype: Optional[DtypeArg] = None,
+    dtype: DtypeArg | None = None,
     convert_axes=None,
     convert_dates=True,
     keep_default_dates: bool = True,
@@ -334,11 +332,11 @@ def read_json(
     precise_float: bool = False,
     date_unit=None,
     encoding=None,
-    encoding_errors: Optional[str] = "strict",
+    encoding_errors: str | None = "strict",
     lines: bool = False,
-    chunksize: Optional[int] = None,
+    chunksize: int | None = None,
     compression: CompressionOptions = "infer",
-    nrows: Optional[int] = None,
+    nrows: int | None = None,
     storage_options: StorageOptions = None,
 ):
     """
@@ -639,11 +637,11 @@ class JsonReader(abc.Iterator):
         date_unit,
         encoding,
         lines: bool,
-        chunksize: Optional[int],
+        chunksize: int | None,
         compression: CompressionOptions,
-        nrows: Optional[int],
+        nrows: int | None,
         storage_options: StorageOptions = None,
-        encoding_errors: Optional[str] = "strict",
+        encoding_errors: str | None = "strict",
     ):
 
         self.orient = orient
@@ -663,7 +661,7 @@ class JsonReader(abc.Iterator):
         self.nrows_seen = 0
         self.nrows = nrows
         self.encoding_errors = encoding_errors
-        self.handles: Optional[IOHandles] = None
+        self.handles: IOHandles | None = None
 
         if self.chunksize is not None:
             self.chunksize = validate_integer("chunksize", self.chunksize, 1)
@@ -816,7 +814,7 @@ class JsonReader(abc.Iterator):
 
 
 class Parser:
-    _split_keys: Tuple[str, ...]
+    _split_keys: tuple[str, ...]
     _default_orient: str
 
     _STAMP_UNITS = ("s", "ms", "us", "ns")
@@ -831,7 +829,7 @@ class Parser:
         self,
         json,
         orient,
-        dtype: Optional[DtypeArg] = None,
+        dtype: DtypeArg | None = None,
         convert_axes=True,
         convert_dates=True,
         keep_default_dates=False,
@@ -865,7 +863,7 @@ class Parser:
         self.convert_dates = convert_dates
         self.date_unit = date_unit
         self.keep_default_dates = keep_default_dates
-        self.obj: Optional[FrameOrSeriesUnion] = None
+        self.obj: FrameOrSeriesUnion | None = None
 
     def check_keys_split(self, decoded):
         """

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -1,18 +1,13 @@
 """
 Module contains tools for processing files into DataFrames or other objects
 """
+from __future__ import annotations
+
 from collections import abc
 import csv
 import sys
 from textwrap import fill
-from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
-    Set,
-    Type,
-)
+from typing import Any
 import warnings
 
 import numpy as np
@@ -413,8 +408,8 @@ _fwf_defaults = {"colspecs": "infer", "infer_nrows": 100, "widths": None}
 _c_unsupported = {"skipfooter"}
 _python_unsupported = {"low_memory", "float_precision"}
 
-_deprecated_defaults: Dict[str, Any] = {"error_bad_lines": None, "warn_bad_lines": None}
-_deprecated_args: Set[str] = {"error_bad_lines", "warn_bad_lines"}
+_deprecated_defaults: dict[str, Any] = {"error_bad_lines": None, "warn_bad_lines": None}
+_deprecated_args: set[str] = {"error_bad_lines", "warn_bad_lines"}
 
 
 def validate_integer(name, val, min_val=0):
@@ -518,7 +513,7 @@ def read_csv(
     prefix=lib.no_default,
     mangle_dupe_cols=True,
     # General Parsing Configuration
-    dtype: Optional[DtypeArg] = None,
+    dtype: DtypeArg | None = None,
     engine=None,
     converters=None,
     true_values=None,
@@ -554,7 +549,7 @@ def read_csv(
     escapechar=None,
     comment=None,
     encoding=None,
-    encoding_errors: Optional[str] = "strict",
+    encoding_errors: str | None = "strict",
     dialect=None,
     # Error Handling
     error_bad_lines=None,
@@ -616,7 +611,7 @@ def read_table(
     prefix=lib.no_default,
     mangle_dupe_cols=True,
     # General Parsing Configuration
-    dtype: Optional[DtypeArg] = None,
+    dtype: DtypeArg | None = None,
     engine=None,
     converters=None,
     true_values=None,
@@ -659,7 +654,7 @@ def read_table(
     # TODO (2.0): set on_bad_lines to "error".
     # See _refine_defaults_read comment for why we do this.
     on_bad_lines=None,
-    encoding_errors: Optional[str] = "strict",
+    encoding_errors: str | None = "strict",
     # Internal
     delim_whitespace=False,
     low_memory=_c_parser_defaults["low_memory"],
@@ -823,7 +818,7 @@ class TextFileReader(abc.Iterator):
         kwds = self.orig_options
 
         options = {}
-        default: Optional[object]
+        default: object | None
 
         for argname, default in parser_defaults.items():
             value = kwds.get(argname, default)
@@ -1033,7 +1028,7 @@ class TextFileReader(abc.Iterator):
             raise
 
     def _make_engine(self, engine="c"):
-        mapping: Dict[str, Type[ParserBase]] = {
+        mapping: dict[str, type[ParserBase]] = {
             "c": CParserWrapper,
             "python": PythonParser,
             "python-fwf": FixedWidthFieldParser,
@@ -1147,7 +1142,7 @@ def TextParser(*args, **kwds):
 
 
 def _clean_na_values(na_values, keep_default_na=True):
-    na_fvalues: Union[Set, Dict]
+    na_fvalues: Union[set, dict]
     if na_values is None:
         if keep_default_na:
             na_values = STR_NA_VALUES
@@ -1198,7 +1193,7 @@ def _floatify_na_values(na_values):
 
 def _stringify_na_values(na_values):
     """ return a stringified and numeric for these values """
-    result: List[Union[int, str, float]] = []
+    result: list[Union[int, str, float]] = []
     for x in na_values:
         result.append(str(x))
         result.append(x)
@@ -1227,12 +1222,12 @@ def _refine_defaults_read(
     delim_whitespace: bool,
     engine: str,
     sep: Union[str, object],
-    error_bad_lines: Optional[bool],
-    warn_bad_lines: Optional[bool],
-    on_bad_lines: Optional[str],
-    names: Union[Optional[ArrayLike], object],
-    prefix: Union[Optional[str], object],
-    defaults: Dict[str, Any],
+    error_bad_lines: bool | None,
+    warn_bad_lines: bool | None,
+    on_bad_lines: str | None,
+    names: Union[ArrayLike | None, object],
+    prefix: Union[str | None, object],
+    defaults: dict[str, Any],
 ):
     """Validate/refine default values of input parameters of read_csv, read_table.
 
@@ -1287,7 +1282,7 @@ def _refine_defaults_read(
     """
     # fix types for sep, delimiter to Union(str, Any)
     delim_default = defaults["delimiter"]
-    kwds: Dict[str, Any] = {}
+    kwds: dict[str, Any] = {}
     # gh-23761
     #
     # When a dialect is passed, it overrides any of the overlapping
@@ -1381,7 +1376,7 @@ def _refine_defaults_read(
     return kwds
 
 
-def _extract_dialect(kwds: Dict[str, Any]) -> Optional[csv.Dialect]:
+def _extract_dialect(kwds: dict[str, Any]) -> csv.Dialect | None:
     """
     Extract concrete csv dialect instance.
 
@@ -1427,8 +1422,8 @@ def _validate_dialect(dialect: csv.Dialect) -> None:
 
 def _merge_with_dialect_properties(
     dialect: csv.Dialect,
-    defaults: Dict[str, Any],
-) -> Dict[str, Any]:
+    defaults: dict[str, Any],
+) -> dict[str, Any]:
     """
     Merge default kwargs in TextFileReader with dialect parameters.
 
@@ -1477,7 +1472,7 @@ def _merge_with_dialect_properties(
     return kwds
 
 
-def _validate_skipfooter(kwds: Dict[str, Any]) -> None:
+def _validate_skipfooter(kwds: dict[str, Any]) -> None:
     """
     Check whether skipfooter is compatible with other kwargs in TextFileReader.
 

--- a/pandas/plotting/_matplotlib/converter.py
+++ b/pandas/plotting/_matplotlib/converter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import datetime as pydt
 from datetime import (
@@ -6,13 +8,7 @@ from datetime import (
     tzinfo,
 )
 import functools
-from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-)
+from typing import Any
 
 from dateutil.relativedelta import relativedelta
 import matplotlib.dates as dates
@@ -169,7 +165,7 @@ class TimeConverter(units.ConversionInterface):
         return value
 
     @staticmethod
-    def axisinfo(unit, axis) -> Optional[units.AxisInfo]:
+    def axisinfo(unit, axis) -> units.AxisInfo | None:
         if unit != "time":
             return None
 
@@ -319,7 +315,7 @@ class DatetimeConverter(dates.DateConverter):
         return values
 
     @staticmethod
-    def axisinfo(unit: Optional[tzinfo], axis) -> units.AxisInfo:
+    def axisinfo(unit: tzinfo | None, axis) -> units.AxisInfo:
         """
         Return the :class:`~matplotlib.units.AxisInfo` for *unit*.
 
@@ -447,7 +443,7 @@ class MilliSecondLocator(dates.DateLocator):
         return self.nonsingular(vmin, vmax)
 
 
-def _from_ordinal(x, tz: Optional[tzinfo] = None) -> datetime:
+def _from_ordinal(x, tz: tzinfo | None = None) -> datetime:
     ix = int(x)
     dt = datetime.fromordinal(ix)
     remainder = float(x) - ix
@@ -476,7 +472,7 @@ def _from_ordinal(x, tz: Optional[tzinfo] = None) -> datetime:
 # -------------------------------------------------------------------------
 
 
-def _get_default_annual_spacing(nyears) -> Tuple[int, int]:
+def _get_default_annual_spacing(nyears) -> tuple[int, int]:
     """
     Returns a default spacing between consecutive ticks for annual data.
     """
@@ -1027,8 +1023,8 @@ class TimeSeries_DateFormatter(Formatter):
         freq = to_offset(freq)
         self.format = None
         self.freq = freq
-        self.locs: List[Any] = []  # unused, for matplotlib compat
-        self.formatdict: Optional[Dict[Any, Any]] = None
+        self.locs: list[Any] = []  # unused, for matplotlib compat
+        self.formatdict: dict[Any, Any] | None = None
         self.isminor = minor_locator
         self.isdynamic = dynamic_mode
         self.offset = 0

--- a/pandas/tests/extension/base/ops.py
+++ b/pandas/tests/extension/base/ops.py
@@ -1,7 +1,4 @@
-from typing import (
-    Optional,
-    Type,
-)
+from __future__ import annotations
 
 import pytest
 
@@ -67,10 +64,10 @@ class BaseArithmeticOpsTests(BaseOpsUtil):
     * divmod_exc = TypeError
     """
 
-    series_scalar_exc: Optional[Type[TypeError]] = TypeError
-    frame_scalar_exc: Optional[Type[TypeError]] = TypeError
-    series_array_exc: Optional[Type[TypeError]] = TypeError
-    divmod_exc: Optional[Type[TypeError]] = TypeError
+    series_scalar_exc: type[TypeError] | None = TypeError
+    frame_scalar_exc: type[TypeError] | None = TypeError
+    series_array_exc: type[TypeError] | None = TypeError
+    divmod_exc: type[TypeError] | None = TypeError
 
     def test_arith_series_with_scalar(self, data, all_arithmetic_operators):
         # series & scalar

--- a/pandas/tests/io/parser/conftest.py
+++ b/pandas/tests/io/parser/conftest.py
@@ -1,8 +1,6 @@
+from __future__ import annotations
+
 import os
-from typing import (
-    List,
-    Optional,
-)
 
 import pytest
 
@@ -13,9 +11,9 @@ from pandas import (
 
 
 class BaseParser:
-    engine: Optional[str] = None
+    engine: str | None = None
     low_memory = True
-    float_precision_choices: List[Optional[str]] = []
+    float_precision_choices: list[str | None] = []
 
     def update_kwargs(self, kwargs):
         kwargs = kwargs.copy()

--- a/pandas/tests/tseries/offsets/common.py
+++ b/pandas/tests/tseries/offsets/common.py
@@ -1,11 +1,9 @@
 """
 Assertion helpers and base class for offsets tests
 """
+from __future__ import annotations
+
 from datetime import datetime
-from typing import (
-    Optional,
-    Type,
-)
 
 from dateutil.tz.tz import tzlocal
 import pytest
@@ -61,7 +59,7 @@ class WeekDay:
 
 
 class Base:
-    _offset: Optional[Type[DateOffset]] = None
+    _offset: type[DateOffset] | None = None
     d = Timestamp(datetime(2008, 1, 2))
 
     timezones = [

--- a/pandas/util/version/__init__.py
+++ b/pandas/util/version/__init__.py
@@ -6,6 +6,7 @@
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
+from __future__ import annotations
 
 import collections
 import itertools
@@ -13,8 +14,6 @@ import re
 from typing import (
     Callable,
     Iterator,
-    List,
-    Optional,
     SupportsInt,
     Tuple,
     Union,
@@ -49,7 +48,7 @@ class InfinityType:
     def __ge__(self, other: object) -> bool:
         return True
 
-    def __neg__(self: object) -> "NegativeInfinityType":
+    def __neg__(self: object) -> NegativeInfinityType:
         return NegativeInfinity
 
 
@@ -115,7 +114,7 @@ _Version = collections.namedtuple(
 )
 
 
-def parse(version: str) -> Union["LegacyVersion", "Version"]:
+def parse(version: str) -> LegacyVersion | Version:
     """
     Parse the given version string and return either a :class:`Version` object
     or a :class:`LegacyVersion` object depending on if the given version is
@@ -134,7 +133,7 @@ class InvalidVersion(ValueError):
 
 
 class _BaseVersion:
-    _key: Union[CmpKey, LegacyCmpKey]
+    _key: CmpKey | LegacyCmpKey
 
     def __hash__(self) -> int:
         return hash(self._key)
@@ -142,13 +141,13 @@ class _BaseVersion:
     # Please keep the duplicated `isinstance` check
     # in the six comparisons hereunder
     # unless you find a way to avoid adding overhead function calls.
-    def __lt__(self, other: "_BaseVersion") -> bool:
+    def __lt__(self, other: _BaseVersion) -> bool:
         if not isinstance(other, _BaseVersion):
             return NotImplemented
 
         return self._key < other._key
 
-    def __le__(self, other: "_BaseVersion") -> bool:
+    def __le__(self, other: _BaseVersion) -> bool:
         if not isinstance(other, _BaseVersion):
             return NotImplemented
 
@@ -160,13 +159,13 @@ class _BaseVersion:
 
         return self._key == other._key
 
-    def __ge__(self, other: "_BaseVersion") -> bool:
+    def __ge__(self, other: _BaseVersion) -> bool:
         if not isinstance(other, _BaseVersion):
             return NotImplemented
 
         return self._key >= other._key
 
-    def __gt__(self, other: "_BaseVersion") -> bool:
+    def __gt__(self, other: _BaseVersion) -> bool:
         if not isinstance(other, _BaseVersion):
             return NotImplemented
 
@@ -279,7 +278,7 @@ def _legacy_cmpkey(version: str) -> LegacyCmpKey:
 
     # This scheme is taken from pkg_resources.parse_version setuptools prior to
     # it's adoption of the packaging library.
-    parts: List[str] = []
+    parts: list[str] = []
     for part in _parse_version_parts(version.lower()):
         if part.startswith("*"):
             # remove "-" before a prerelease tag
@@ -400,25 +399,25 @@ class Version(_BaseVersion):
         return _epoch
 
     @property
-    def release(self) -> Tuple[int, ...]:
-        _release: Tuple[int, ...] = self._version.release
+    def release(self) -> tuple[int, ...]:
+        _release: tuple[int, ...] = self._version.release
         return _release
 
     @property
-    def pre(self) -> Optional[Tuple[str, int]]:
-        _pre: Optional[Tuple[str, int]] = self._version.pre
+    def pre(self) -> tuple[str, int] | None:
+        _pre: tuple[str, int] | None = self._version.pre
         return _pre
 
     @property
-    def post(self) -> Optional[int]:
+    def post(self) -> int | None:
         return self._version.post[1] if self._version.post else None
 
     @property
-    def dev(self) -> Optional[int]:
+    def dev(self) -> int | None:
         return self._version.dev[1] if self._version.dev else None
 
     @property
-    def local(self) -> Optional[str]:
+    def local(self) -> str | None:
         if self._version.local:
             return ".".join(str(x) for x in self._version.local)
         else:
@@ -467,8 +466,8 @@ class Version(_BaseVersion):
 
 
 def _parse_letter_version(
-    letter: str, number: Union[str, bytes, SupportsInt]
-) -> Optional[Tuple[str, int]]:
+    letter: str, number: str | bytes | SupportsInt
+) -> tuple[str, int] | None:
 
     if letter:
         # We consider there to be an implicit 0 in a pre-release if there is
@@ -505,7 +504,7 @@ def _parse_letter_version(
 _local_version_separators = re.compile(r"[\._-]")
 
 
-def _parse_local_version(local: str) -> Optional[LocalType]:
+def _parse_local_version(local: str) -> LocalType | None:
     """
     Takes a string like abc.1.twelve and turns it into ("abc", 1, "twelve").
     """
@@ -519,11 +518,11 @@ def _parse_local_version(local: str) -> Optional[LocalType]:
 
 def _cmpkey(
     epoch: int,
-    release: Tuple[int, ...],
-    pre: Optional[Tuple[str, int]],
-    post: Optional[Tuple[str, int]],
-    dev: Optional[Tuple[str, int]],
-    local: Optional[Tuple[SubLocalType]],
+    release: tuple[int, ...],
+    pre: tuple[str, int] | None,
+    post: tuple[str, int] | None,
+    dev: tuple[str, int] | None,
+    local: tuple[SubLocalType] | None,
 ) -> CmpKey:
 
     # When we compare a release version, we want to compare it with all of the

--- a/scripts/no_bool_in_generic.py
+++ b/scripts/no_bool_in_generic.py
@@ -10,23 +10,18 @@ This is meant to be run as a pre-commit hook - to run it manually, you can do:
 The function `visit` is adapted from a function by the same name in pyupgrade:
 https://github.com/asottile/pyupgrade/blob/5495a248f2165941c5d3b82ac3226ba7ad1fa59d/pyupgrade/_data.py#L70-L113
 """
+from __future__ import annotations
 
 import argparse
 import ast
 import collections
-from typing import (
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-)
+from typing import Sequence
 
 
-def visit(tree: ast.Module) -> Dict[int, List[int]]:
+def visit(tree: ast.Module) -> dict[int, list[int]]:
     "Step through tree, recording when nodes are in annotations."
     in_annotation = False
-    nodes: List[Tuple[bool, ast.AST]] = [(in_annotation, tree)]
+    nodes: list[tuple[bool, ast.AST]] = [(in_annotation, tree)]
     to_replace = collections.defaultdict(list)
 
     while nodes:
@@ -62,7 +57,7 @@ def replace_bool_with_bool_t(to_replace, content: str) -> str:
     return "\n".join(new_lines)
 
 
-def check_for_bool_in_generic(content: str) -> Tuple[bool, str]:
+def check_for_bool_in_generic(content: str) -> tuple[bool, str]:
     tree = ast.parse(content)
     to_replace = visit(tree)
 
@@ -74,7 +69,7 @@ def check_for_bool_in_generic(content: str) -> Tuple[bool, str]:
     return mutated, replace_bool_with_bool_t(to_replace, content)
 
 
-def main(argv: Optional[Sequence[str]] = None) -> None:
+def main(argv: Sequence[str] | None = None) -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("paths", nargs="*")
     args = parser.parse_args(argv)

--- a/scripts/use_pd_array_in_core.py
+++ b/scripts/use_pd_array_in_core.py
@@ -9,13 +9,12 @@ This is meant to be run as a pre-commit hook - to run it manually, you can do:
 
 """
 
+from __future__ import annotations
+
 import argparse
 import ast
 import sys
-from typing import (
-    Optional,
-    Sequence,
-)
+from typing import Sequence
 
 ERROR_MESSAGE = (
     "{path}:{lineno}:{col_offset}: "
@@ -62,7 +61,7 @@ def use_pd_array(content: str, path: str) -> None:
     visitor.visit(tree)
 
 
-def main(argv: Optional[Sequence[str]] = None) -> None:
+def main(argv: Sequence[str] | None = None) -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("paths", nargs="*")
     args = parser.parse_args(argv)

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -13,6 +13,8 @@ Usage::
     $ ./validate_docstrings.py
     $ ./validate_docstrings.py pandas.DataFrame.head
 """
+from __future__ import annotations
+
 import argparse
 import doctest
 import glob
@@ -22,10 +24,6 @@ import os
 import subprocess
 import sys
 import tempfile
-from typing import (
-    List,
-    Optional,
-)
 
 try:
     from io import StringIO
@@ -315,7 +313,7 @@ def validate_all(prefix, ignore_deprecated=False):
 
 def print_validate_all_results(
     prefix: str,
-    errors: Optional[List[str]],
+    errors: list[str] | None,
     output_format: str,
     ignore_deprecated: bool,
 ):


### PR DESCRIPTION
I'm fairly sure that we agreed we would do this but leave it to just before the 1.3 release to reduce the chance of auto backports failing
