### PR TITLE
TYP: to_csv accepts IO[bytes] and fix FilePathOrBuffer

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -170,8 +170,8 @@ PythonFuncType = Callable[[Any], Any]
 
 # filenames and file-like-objects
 Buffer = Union[IO[AnyStr], RawIOBase, BufferedIOBase, TextIOBase, TextIOWrapper, mmap]
-FileOrBuffer = Union[str, Buffer[T]]
-FilePathOrBuffer = Union["PathLike[str]", FileOrBuffer[T]]
+FileOrBuffer = Union[str, Buffer[AnyStr]]
+FilePathOrBuffer = Union["PathLike[str]", FileOrBuffer[AnyStr]]
 
 # for arbitrary kwargs passed during reading/writing files
 StorageOptions = Optional[Dict[str, Any]]

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3295,7 +3295,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     @doc(storage_options=_shared_docs["storage_options"])
     def to_csv(
         self,
-        path_or_buf: FilePathOrBuffer | None = None,
+        path_or_buf: FilePathOrBuffer[str] | FilePathOrBuffer[bytes] | None = None,
         sep: str = ",",
         na_rep: str = "",
         float_format: str | None = None,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11,6 +11,7 @@ import re
 from typing import (
     TYPE_CHECKING,
     Any,
+    AnyStr,
     Callable,
     Hashable,
     Mapping,
@@ -3295,7 +3296,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     @doc(storage_options=_shared_docs["storage_options"])
     def to_csv(
         self,
-        path_or_buf: FilePathOrBuffer[str] | FilePathOrBuffer[bytes] | None = None,
+        path_or_buf: FilePathOrBuffer[AnyStr] | None = None,
         sep: str = ",",
         na_rep: str = "",
         float_format: str | None = None,

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -48,7 +48,7 @@ class CSVFormatter:
     def __init__(
         self,
         formatter: DataFrameFormatter,
-        path_or_buf: FilePathOrBuffer[str] = "",
+        path_or_buf: FilePathOrBuffer[str] | FilePathOrBuffer[bytes] = "",
         sep: str = ",",
         cols: Sequence[Hashable] | None = None,
         index_label: IndexLabel | None = None,

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -9,6 +9,7 @@ import os
 from typing import (
     TYPE_CHECKING,
     Any,
+    AnyStr,
     Hashable,
     Iterator,
     Sequence,
@@ -48,7 +49,7 @@ class CSVFormatter:
     def __init__(
         self,
         formatter: DataFrameFormatter,
-        path_or_buf: FilePathOrBuffer[str] | FilePathOrBuffer[bytes] = "",
+        path_or_buf: FilePathOrBuffer[AnyStr] = "",
         sep: str = ",",
         cols: Sequence[Hashable] | None = None,
         index_label: IndexLabel | None = None,

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1054,7 +1054,7 @@ class DataFrameRenderer:
 
     def to_csv(
         self,
-        path_or_buf: FilePathOrBuffer[str] | None = None,
+        path_or_buf: FilePathOrBuffer[str] | FilePathOrBuffer[bytes] | None = None,
         encoding: str | None = None,
         sep: str = ",",
         columns: Sequence[Hashable] | None = None,

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -19,6 +19,7 @@ from typing import (
     IO,
     TYPE_CHECKING,
     Any,
+    AnyStr,
     Callable,
     Hashable,
     Iterable,
@@ -1054,7 +1055,7 @@ class DataFrameRenderer:
 
     def to_csv(
         self,
-        path_or_buf: FilePathOrBuffer[str] | FilePathOrBuffer[bytes] | None = None,
+        path_or_buf: FilePathOrBuffer[AnyStr] | None = None,
         encoding: str | None = None,
         sep: str = ",",
         columns: Sequence[Hashable] | None = None,


### PR DESCRIPTION
Two small typing fixes:

- `to_csv` accepts `IO[bytes]` (replace `FilePathOrBuffer[str]` with `FilePathOrBuffer[AnyStr]`)
- pyright was not able to parse `FilePathOrBuffer` because the unconstrained TypeVar `pandas._typing.T` was used when the constrained TyepVar `typing.AnyStr` should have been used: Could not specialize type "Buffer[AnyStr@Buffer]"   Type "T@FileOrBuffer" is incompatible with constrained type variable "AnyStr"