### PR TITLE
BUG: pytz.AmbiguousTimeError not caught in hypothesis test test_on_offset_implementations (GH41906)

### DIFF
--- a/pandas/tests/tseries/offsets/test_dst.py
+++ b/pandas/tests/tseries/offsets/test_dst.py
@@ -4,6 +4,7 @@ Tests for DateOffset additions over Daylight Savings Time
 from datetime import timedelta
 
 import pytest
+import pytz
 
 from pandas._libs.tslibs import Timestamp
 from pandas._libs.tslibs.offsets import (
@@ -15,6 +16,7 @@ from pandas._libs.tslibs.offsets import (
     BYearEnd,
     CBMonthBegin,
     CBMonthEnd,
+    CustomBusinessDay,
     DateOffset,
     Day,
     MonthBegin,
@@ -173,3 +175,48 @@ class TestDST:
         first = Timestamp(test_values[0], tz="US/Eastern") + offset()
         second = Timestamp(test_values[1], tz="US/Eastern")
         assert first == second
+
+
+@pytest.mark.parametrize(
+    "original_dt, target_dt, offset, tz",
+    [
+        (
+            Timestamp("1900-01-01"),
+            Timestamp("1905-07-01"),
+            MonthBegin(66),
+            "Africa/Kinshasa",
+        ),  # GH41906
+        (
+            Timestamp("2021-10-01 01:15"),
+            Timestamp("2021-10-31 01:15"),
+            MonthEnd(1),
+            "Europe/London",
+        ),
+        (
+            Timestamp("2010-12-05 02:59"),
+            Timestamp("2010-10-31 02:59"),
+            SemiMonthEnd(-3),
+            "Europe/Paris",
+        ),
+        (
+            Timestamp("2021-10-31 01:20"),
+            Timestamp("2021-11-07 01:20"),
+            CustomBusinessDay(2, weekmask="Sun Mon"),
+            "US/Eastern",
+        ),
+        (
+            Timestamp("2020-04-03 01:30"),
+            Timestamp("2020-11-01 01:30"),
+            YearBegin(1, month=11),
+            "America/Chicago",
+        ),
+    ],
+)
+def test_nontick_offset_with_ambiguous_time_error(original_dt, target_dt, offset, tz):
+    # .apply for non-Tick offsets throws AmbiguousTimeError when the target dt
+    # is dst-ambiguous
+    localized_dt = original_dt.tz_localize(tz)
+
+    msg = f"Cannot infer dst time from {target_dt}, try using the 'ambiguous' argument"
+    with pytest.raises(pytz.AmbiguousTimeError, match=msg):
+        localized_dt + offset

--- a/pandas/tests/tseries/offsets/test_dst.py
+++ b/pandas/tests/tseries/offsets/test_dst.py
@@ -177,6 +177,9 @@ class TestDST:
         assert first == second
 
 
+@pytest.mark.xfail(
+    strict=False, reason="'Africa/Kinshasa' test case fails under pytz=2017.3"
+)
 @pytest.mark.parametrize(
     "original_dt, target_dt, offset, tz",
     [

--- a/pandas/tests/tseries/offsets/test_offsets_properties.py
+++ b/pandas/tests/tseries/offsets/test_offsets_properties.py
@@ -100,7 +100,7 @@ def test_on_offset_implementations(dt, offset):
     #   (dt + offset) - offset == dt
     try:
         compare = (dt + offset) - offset
-    except pytz.NonExistentTimeError:
+    except (pytz.NonExistentTimeError, pytz.AmbiguousTimeError):
         # dt + offset does not exist, assume(False) to indicate
         #  to hypothesis that this is not a valid test case
         assume(False)

--- a/pandas/tests/tseries/offsets/test_offsets_properties.py
+++ b/pandas/tests/tseries/offsets/test_offsets_properties.py
@@ -101,8 +101,11 @@ def test_on_offset_implementations(dt, offset):
     try:
         compare = (dt + offset) - offset
     except (pytz.NonExistentTimeError, pytz.AmbiguousTimeError):
-        # dt + offset does not exist, assume(False) to indicate
-        #  to hypothesis that this is not a valid test case
+        # When dt + offset does not exist or is DST-ambiguous, assume(False) to
+        # indicate to hypothesis that this is not a valid test case
+        # DST-ambiguous example (GH41906):
+        # dt = datetime.datetime(1900, 1, 1, tzinfo=pytz.timezone('Africa/Kinshasa'))
+        # offset = MonthBegin(66)
         assume(False)
 
     assert offset.is_on_offset(dt) == (compare == dt)


### PR DESCRIPTION
- [x] closes #41906
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry: let me know if needed
