### PR TITLE
BUG: Categorical.fillna with non-category tuple

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -874,7 +874,7 @@ Categorical
 - Bug in constructing a :class:`DataFrame` from an ``ndarray`` and a :class:`CategoricalDtype` (:issue:`38857`)
 - Bug in setting categorical values into an object-dtype column in a :class:`DataFrame` (:issue:`39136`)
 - Bug in :meth:`DataFrame.reindex` was raising an ``IndexError`` when the new index contained duplicates and the old index was a :class:`CategoricalIndex` (:issue:`38906`)
-- Bug in :meth:`Categorical.fillna` with a tuple-like category raising ``NotImplementedError`` instead of ``ValueError`` when filling with a non-category tuple (:issue:`??`)
+- Bug in :meth:`Categorical.fillna` with a tuple-like category raising ``NotImplementedError`` instead of ``ValueError`` when filling with a non-category tuple (:issue:`41914`)
 
 Datetimelike
 ^^^^^^^^^^^^

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -874,6 +874,7 @@ Categorical
 - Bug in constructing a :class:`DataFrame` from an ``ndarray`` and a :class:`CategoricalDtype` (:issue:`38857`)
 - Bug in setting categorical values into an object-dtype column in a :class:`DataFrame` (:issue:`39136`)
 - Bug in :meth:`DataFrame.reindex` was raising an ``IndexError`` when the new index contained duplicates and the old index was a :class:`CategoricalIndex` (:issue:`38906`)
+- Bug in :meth:`Categorical.fillna` with a tuple-like category raising ``NotImplementedError`` instead of ``ValueError`` when filling with a non-category tuple (:issue:`??`)
 
 Datetimelike
 ^^^^^^^^^^^^

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2030,7 +2030,8 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
         from pandas import Index
 
-        to_add = Index(rvalue).difference(self.categories)
+        # tupleize_cols=False for e.g. test_fillna_iterable_category
+        to_add = Index(rvalue, tupleize_cols=False).difference(self.categories)
 
         # no assignments of values not in categories, but it's always ok to set
         # something to np.nan

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2030,7 +2030,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
         from pandas import Index
 
-        # tupleize_cols=False for e.g. test_fillna_iterable_category
+        # tupleize_cols=False for e.g. test_fillna_iterable_category GH#41914
         to_add = Index(rvalue, tupleize_cols=False).difference(self.categories)
 
         # no assignments of values not in categories, but it's always ok to set

--- a/pandas/tests/arrays/categorical/test_missing.py
+++ b/pandas/tests/arrays/categorical/test_missing.py
@@ -101,7 +101,7 @@ class TestCategoricalMissing:
         tm.assert_categorical_equal(result, expected)
 
         # Case where the Point is not among our categories; we want ValueError,
-        #  not NotImplementedError
+        #  not NotImplementedError GH#41914
         cat = Categorical(np.array([Point(1, 0), Point(0, 1), None], dtype=object))
         msg = "Cannot setitem on a Categorical with a new category"
         with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/arrays/categorical/test_missing.py
+++ b/pandas/tests/arrays/categorical/test_missing.py
@@ -100,6 +100,13 @@ class TestCategoricalMissing:
 
         tm.assert_categorical_equal(result, expected)
 
+        # Case where the Point is not among our categories; we want ValueError,
+        #  not NotImplementedError
+        cat = Categorical(np.array([Point(1, 0), Point(0, 1), None], dtype=object))
+        msg = "Cannot setitem on a Categorical with a new category"
+        with pytest.raises(ValueError, match=msg):
+            cat.fillna(Point(0, 0))
+
     def test_fillna_array(self):
         # accept Categorical or ndarray value if it holds appropriate values
         cat = Categorical(["A", "B", "C", None, None])


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
