### PR TITLE
BUG: Scalar assignment to empty dataframe with loc. Closes GH41891

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1646,10 +1646,11 @@ class _iLocIndexer(_LocationIndexer):
                     if self.ndim > 1 and i == info_axis:
 
                         # add the new item, and set the value
-                        # must have all defined axes if we have a scalar
-                        # or a list-like on the non-info axes if we have a
-                        # list-like
-                        if not len(self.obj):
+                        # If we have a scalar as values, must have all defined
+                        # axes or be an empty slice.
+                        # If we have a list-like as value, must have a
+                        # list-like on the non-info axes
+                        if not len(self.obj) and not com.is_null_slice(indexer[0]):
                             if not is_list_like_indexer(value):
                                 raise ValueError(
                                     "cannot set a frame with no "

--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -384,7 +384,11 @@ class TestPartialSetting:
 
         msg = "cannot set a frame with no defined index and a scalar"
         with pytest.raises(ValueError, match=msg):
-            df.loc[:, 1] = 1
+            df.loc[3:4, 1] = 1
+
+        df.loc[:, 1] = 1
+        assert df.columns.to_list() == [1]
+        assert len(df) == 0
 
     def test_partial_set_empty_frame2(self):
         # these work as they don't really change


### PR DESCRIPTION
This weakens a check introduced in 7bbeb79297532d209d67f7bdc61394ddee3acbb1  in PR #5227 addressing issue #5226 ("New appending behavior doesn't work on an empty DataFrame") which caused ValueErrors for `df[:, 1] = 1` if df is an empty DataFrame. With this commit no error is thrown and the column is added to the dataframe (which remains empty).
 
See #41891 for why this makes sense. 

- [x] closes #41891
- [x] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
