### PR TITLE
DOC: add contributors to 1.3 release notes

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -1189,3 +1189,5 @@ Other
 
 Contributors
 ~~~~~~~~~~~~
+
+.. contributors:: v1.2.4..v1.3.0|HEAD


### PR DESCRIPTION
I think we should do this for the rc.

We will be publishing the docs at https://pandas.pydata.org/pandas-docs/version/1.3.0/ and linked from the rc announcement. (It's the same url for the actual release and the rc docs are replaced)

we haven't yet released 1.2.5 so the 1.2.5 tag does not yet exist. used 1.2.4 for now.