### PR TITLE
STYLE: Use from future import annotations (pandas-dev#41901)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,4 +142,15 @@ repos:
         language: pygrep
         args: [--negate]
         entry: 'from __future__ import annotations'
-        exclude: __init__.py|api.py|setup.py|asv_bench|tests|web
+        exclude: >
+          (?x)(
+            __init__.py|
+            api.py|
+            setup.py|
+            versioneer.py|
+            asv_bench|
+            ci|
+            doc|
+            tests|
+            web
+          )

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,4 +142,4 @@ repos:
         language: pygrep
         args: [--negate]
         entry: 'from __future__ import annotations'
-        exclude: __init__.py|api.py|setup.py|tests
+        exclude: __init__.py|api.py|setup.py|asv_bench|tests|web

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -136,3 +136,9 @@ repos:
         entry: python scripts/no_bool_in_generic.py
         language: python
         files: ^pandas/core/generic\.py$
+    -   id: always-use-future-annotations
+        name: ensure that "from __future__ import annotations" is always used
+        types: [python]
+        language: pygrep
+        args: [--negate]
+        entry: 'from __future__ import annotations'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,3 +142,4 @@ repos:
         language: pygrep
         args: [--negate]
         entry: 'from __future__ import annotations'
+        exclude: __init__.py|api.py|setup.py|tests


### PR DESCRIPTION
- [X] closes #41901
- [ ]  no tests added
- [ ]  pre-commit hook, no python files added
- [ ] No docstrings added; docs not rebuilt. _**Where do pre-commit hooks get added to “What’s New"?**_


Implementation:
   * Name set to always-use-future-annotations (rather than always-use-from-future-annotations)
   * We filter with` types: [python]` [rather than](https://pre-commit.com/#filtering-files-with-types) `files: "\\.(py)$”` 
   * No minimum pre-commit version. 

What else is needed here for a merge? 

