### PR TITLE
CI: use pyarrow 0.17.1 instead of 0.17.0 for py37_macos build

### DIFF
--- a/ci/deps/azure-macos-37.yaml
+++ b/ci/deps/azure-macos-37.yaml
@@ -22,7 +22,7 @@ dependencies:
   - numexpr
   - numpy=1.17.3
   - openpyxl
-  - pyarrow=0.17.0
+  - pyarrow=0.17
   - pytables
   - python-dateutil==2.7.3
   - pytz


### PR DESCRIPTION
Closes #41937