### PR TITLE
DOC: fix link to pickle in msgpack section

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -31,7 +31,6 @@ The pandas I/O API is a set of top level ``reader`` functions accessed like
     binary;`Feather Format <https://github.com/wesm/feather>`__;:ref:`read_feather<io.feather>`;:ref:`to_feather<io.feather>`
     binary;`Parquet Format <https://parquet.apache.org/>`__;:ref:`read_parquet<io.parquet>`;:ref:`to_parquet<io.parquet>`
     binary;`ORC Format <https://orc.apache.org/>`__;:ref:`read_orc<io.orc>`;
-    binary;`Msgpack <https://msgpack.org/>`__;:ref:`read_msgpack<io.msgpack>`;:ref:`to_msgpack<io.msgpack>`
     binary;`Stata <https://en.wikipedia.org/wiki/Stata>`__;:ref:`read_stata<io.stata_reader>`;:ref:`to_stata<io.stata_writer>`
     binary;`SAS <https://en.wikipedia.org/wiki/SAS_(software)>`__;:ref:`read_sas<io.sas_reader>`;
     binary;`SPSS <https://en.wikipedia.org/wiki/SPSS>`__;:ref:`read_spss<io.spss_reader>`;
@@ -4010,7 +4009,7 @@ msgpack
 -------
 
 pandas support for ``msgpack`` has been removed in version 1.0.0. It is
-recommended to use :ref:`pickle <io.pickle` instead.
+recommended to use :ref:`pickle <io.pickle>` instead.
 
 Alternatively, you can also the Arrow IPC serialization format for on-the-wire
 transmission of pandas objects. For documentation on pyarrow, see


### PR DESCRIPTION
That failed the doc build. In addition also removed the msgpack row in the table at the top of the page, since those functions don't exist anymore.