### PR TITLE
BUG: take nans correctly into consideration in complex and tuple

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -1033,7 +1033,7 @@ Missing
 - Bug in :meth:`DataFrame.fillna` not accepting a dictionary for the ``downcast`` keyword (:issue:`40809`)
 - Bug in :func:`isna` not returning a copy of the mask for nullable types, causing any subsequent mask modification to change the original array (:issue:`40935`)
 - Bug in :class:`DataFrame` construction with float data containing ``NaN`` and an integer ``dtype`` casting instead of retaining the ``NaN`` (:issue:`26919`)
-- Bug in :func:`isin` didn't treat all nans as equivalent if they were in tuples (:issue:`41836`)
+- Bug in :meth:`Series.isin` and :meth:`MultiIndex.isin` didn't treat all nans as equivalent if they were in tuples (:issue:`41836`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -1033,6 +1033,7 @@ Missing
 - Bug in :meth:`DataFrame.fillna` not accepting a dictionary for the ``downcast`` keyword (:issue:`40809`)
 - Bug in :func:`isna` not returning a copy of the mask for nullable types, causing any subsequent mask modification to change the original array (:issue:`40935`)
 - Bug in :class:`DataFrame` construction with float data containing ``NaN`` and an integer ``dtype`` casting instead of retaining the ``NaN`` (:issue:`26919`)
+- Bug in :func:`isin` didn't treat all nans as equivalent if they were in tuples (:issue:`41836`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/pandas/_libs/src/klib/khash_python.h
+++ b/pandas/_libs/src/klib/khash_python.h
@@ -190,6 +190,24 @@ int PANDAS_INLINE complexobject_cmp(PyObject* a, PyObject* b){
            );
 }
 
+int PANDAS_INLINE pyobject_cmp(PyObject* a, PyObject* b);
+
+
+int PANDAS_INLINE tupleobject_cmp(PyObject* a, PyObject* b){
+    Py_ssize_t i;
+
+    if (Py_SIZE(a) != Py_SIZE(b)) {
+        return 0;
+    }
+
+    for (i = 0; i < Py_SIZE(a); ++i) {
+        if (!pyobject_cmp(PyTuple_GET_ITEM(a, i), PyTuple_GET_ITEM(b, i))) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
 
 int PANDAS_INLINE pyobject_cmp(PyObject* a, PyObject* b) {
 	int result = PyObject_RichCompareBool(a, b, Py_EQ);
@@ -206,6 +224,9 @@ int PANDAS_INLINE pyobject_cmp(PyObject* a, PyObject* b) {
         }
         if (PyComplex_CheckExact(a)) {
             return complexobject_cmp(a, b);
+        }
+        if (PyTuple_CheckExact(a)) {
+            return tupleobject_cmp(a, b);
         }
     }
 	return result;

--- a/pandas/_libs/src/klib/khash_python.h
+++ b/pandas/_libs/src/klib/khash_python.h
@@ -163,37 +163,37 @@ KHASH_MAP_INIT_COMPLEX128(complex128, size_t)
 #define kh_exist_complex128(h, k) (kh_exist(h, k))
 
 
-int PANDAS_INLINE floatobject_cmp(PyObject* a, PyObject* b){
+int PANDAS_INLINE floatobject_cmp(PyFloatObject* a, PyFloatObject* b){
     return Py_IS_NAN(PyFloat_AS_DOUBLE(a)) &&
            Py_IS_NAN(PyFloat_AS_DOUBLE(b));
 }
 
 
-int PANDAS_INLINE complexobject_cmp(PyObject* a, PyObject* b){
+int PANDAS_INLINE complexobject_cmp(PyComplexObject* a, PyComplexObject* b){
     return (
-                Py_IS_NAN(PyComplex_RealAsDouble(a)) &&
-                Py_IS_NAN(PyComplex_RealAsDouble(b)) &&
-                Py_IS_NAN(PyComplex_ImagAsDouble(a)) &&
-                Py_IS_NAN(PyComplex_ImagAsDouble(b))
+                Py_IS_NAN(a->cval.real) &&
+                Py_IS_NAN(b->cval.real) &&
+                Py_IS_NAN(a->cval.imag) &&
+                Py_IS_NAN(b->cval.imag)
            )
            ||
            (
-                Py_IS_NAN(PyComplex_RealAsDouble(a)) &&
-                Py_IS_NAN(PyComplex_RealAsDouble(b)) &&
-                PyComplex_ImagAsDouble(a) == PyComplex_ImagAsDouble(b)
+                Py_IS_NAN(a->cval.real) &&
+                Py_IS_NAN(b->cval.real) &&
+                a->cval.imag == b->cval.imag
            )
            ||
            (
-                PyComplex_RealAsDouble(a) == PyComplex_RealAsDouble(b) &&
-                Py_IS_NAN(PyComplex_ImagAsDouble(a)) &&
-                Py_IS_NAN(PyComplex_ImagAsDouble(b))
+                a->cval.real == b->cval.real &&
+                Py_IS_NAN(a->cval.imag) &&
+                Py_IS_NAN(b->cval.imag)
            );
 }
 
 int PANDAS_INLINE pyobject_cmp(PyObject* a, PyObject* b);
 
 
-int PANDAS_INLINE tupleobject_cmp(PyObject* a, PyObject* b){
+int PANDAS_INLINE tupleobject_cmp(PyTupleObject* a, PyTupleObject* b){
     Py_ssize_t i;
 
     if (Py_SIZE(a) != Py_SIZE(b)) {
@@ -220,13 +220,13 @@ int PANDAS_INLINE pyobject_cmp(PyObject* a, PyObject* b) {
             return 0;
         }
         if (PyFloat_CheckExact(a)) {
-            return floatobject_cmp(a, b);
+            return floatobject_cmp((PyFloatObject*)a, (PyFloatObject*)b);
         }
         if (PyComplex_CheckExact(a)) {
-            return complexobject_cmp(a, b);
+            return complexobject_cmp((PyComplexObject*)a, (PyComplexObject*)b);
         }
         if (PyTuple_CheckExact(a)) {
-            return tupleobject_cmp(a, b);
+            return tupleobject_cmp((PyTupleObject*)a, (PyTupleObject*)b);
         }
     }
 	return result;

--- a/pandas/tests/indexes/multi/test_isin.py
+++ b/pandas/tests/indexes/multi/test_isin.py
@@ -1,14 +1,11 @@
 import numpy as np
 import pytest
 
-from pandas.compat import PYPY
-
 from pandas import MultiIndex
 import pandas._testing as tm
 
 
-@pytest.mark.skipif(not PYPY, reason="tuples cmp recursively on PyPy")
-def test_isin_nan_pypy():
+def test_isin_nan():
     idx = MultiIndex.from_arrays([["foo", "bar"], [1.0, np.nan]])
     tm.assert_numpy_array_equal(idx.isin([("bar", np.nan)]), np.array([False, True]))
     tm.assert_numpy_array_equal(
@@ -29,15 +26,6 @@ def test_isin():
     result = idx.isin(values)
     assert len(result) == 0
     assert result.dtype == np.bool_
-
-
-@pytest.mark.skipif(PYPY, reason="tuples cmp recursively on PyPy")
-def test_isin_nan_not_pypy():
-    idx = MultiIndex.from_arrays([["foo", "bar"], [1.0, np.nan]])
-    tm.assert_numpy_array_equal(idx.isin([("bar", np.nan)]), np.array([False, False]))
-    tm.assert_numpy_array_equal(
-        idx.isin([("bar", float("nan"))]), np.array([False, False])
-    )
 
 
 def test_isin_level_kwarg():

--- a/pandas/tests/libs/test_hashtable.py
+++ b/pandas/tests/libs/test_hashtable.py
@@ -178,6 +178,24 @@ class TestHashTable:
             assert n_buckets_start == clean_table.get_state()["n_buckets"]
 
 
+class TestPyObjectHashTableWithNans:
+    def test_nan_float(self):
+        nan1 = float("nan")
+        nan2 = float("nan")
+        assert nan1 is not nan2
+        table = ht.PyObjectHashTable()
+        table.set_item(nan1, 42)
+        assert table.get_item(nan2) == 42
+
+    def test_nan_complex(self):
+        nan1 = 1j * float("nan")
+        nan2 = 1j * float("nan")
+        assert nan1 is not nan2
+        table = ht.PyObjectHashTable()
+        table.set_item(nan1, 42)
+        assert table.get_item(nan2) == 42
+
+
 def test_get_labels_groupby_for_Int64(writable):
     table = ht.Int64HashTable()
     vals = np.array([1, 2, -1, 2, 1, -1], dtype=np.int64)

--- a/pandas/tests/libs/test_hashtable.py
+++ b/pandas/tests/libs/test_hashtable.py
@@ -8,6 +8,7 @@ from pandas._libs import hashtable as ht
 
 import pandas as pd
 import pandas._testing as tm
+from pandas.core.algorithms import isin
 
 
 @contextmanager
@@ -487,3 +488,12 @@ class TestHelpFunctionsWithNans:
         values = np.array([42, np.nan, np.nan, np.nan], dtype=dtype)
         assert mode(values, True) == 42
         assert np.isnan(mode(values, False))
+
+
+def test_ismember_tuple_with_nans():
+    # GH-41836
+    values = [("a", float("nan")), ("b", 1)]
+    comps = [("a", float("nan"))]
+    result = isin(values, comps)
+    expected = np.array([True, False], dtype=np.bool_)
+    tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/libs/test_hashtable.py
+++ b/pandas/tests/libs/test_hashtable.py
@@ -187,13 +187,37 @@ class TestPyObjectHashTableWithNans:
         table.set_item(nan1, 42)
         assert table.get_item(nan2) == 42
 
-    def test_nan_complex(self):
-        nan1 = 1j * float("nan")
-        nan2 = 1j * float("nan")
+    def test_nan_complex_both(self):
+        nan1 = complex(float("nan"), float("nan"))
+        nan2 = complex(float("nan"), float("nan"))
         assert nan1 is not nan2
         table = ht.PyObjectHashTable()
         table.set_item(nan1, 42)
         assert table.get_item(nan2) == 42
+
+    def test_nan_complex_real(self):
+        nan1 = complex(float("nan"), 1)
+        nan2 = complex(float("nan"), 1)
+        other = complex(float("nan"), 2)
+        assert nan1 is not nan2
+        table = ht.PyObjectHashTable()
+        table.set_item(nan1, 42)
+        assert table.get_item(nan2) == 42
+        with pytest.raises(KeyError, match=None) as error:
+            table.get_item(other)
+        assert str(error.value) == str(other)
+
+    def test_nan_complex_imag(self):
+        nan1 = complex(1, float("nan"))
+        nan2 = complex(1, float("nan"))
+        other = complex(2, float("nan"))
+        assert nan1 is not nan2
+        table = ht.PyObjectHashTable()
+        table.set_item(nan1, 42)
+        assert table.get_item(nan2) == 42
+        with pytest.raises(KeyError, match=None) as error:
+            table.get_item(other)
+        assert str(error.value) == str(other)
 
 
 def test_get_labels_groupby_for_Int64(writable):

--- a/pandas/tests/libs/test_hashtable.py
+++ b/pandas/tests/libs/test_hashtable.py
@@ -219,6 +219,25 @@ class TestPyObjectHashTableWithNans:
             table.get_item(other)
         assert str(error.value) == str(other)
 
+    def test_nan_in_tuple(self):
+        nan1 = (float("nan"),)
+        nan2 = (float("nan"),)
+        assert nan1[0] is not nan2[0]
+        table = ht.PyObjectHashTable()
+        table.set_item(nan1, 42)
+        assert table.get_item(nan2) == 42
+
+    def test_nan_in_nested_tuple(self):
+        nan1 = (1, (2, (float("nan"),)))
+        nan2 = (1, (2, (float("nan"),)))
+        other = (1, 2)
+        table = ht.PyObjectHashTable()
+        table.set_item(nan1, 42)
+        assert table.get_item(nan2) == 42
+        with pytest.raises(KeyError, match=None) as error:
+            table.get_item(other)
+        assert str(error.value) == str(other)
+
 
 def test_get_labels_groupby_for_Int64(writable):
     table = ht.Int64HashTable()


### PR DESCRIPTION
- [x] closes #41836
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

NaNs as Float are already handled correctly (all nans are the same equavalency class), this PR adds similar functionality for complex and tuple.

It doesn't handle `frozenset` (see also discussion in #41836) because it would require to duplicate a lot of code/internal details from setobject.