### PR TITLE
Bug in melt raising Error with dup columns as value vars

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -1148,6 +1148,7 @@ Reshaping
 - Bug in :func:`to_datetime` raising an error when the input sequence contained unhashable items (:issue:`39756`)
 - Bug in :meth:`Series.explode` preserving the index when ``ignore_index`` was ``True`` and values were scalars (:issue:`40487`)
 - Bug in :func:`to_datetime` raising a ``ValueError`` when :class:`Series` contains ``None`` and ``NaT`` and has more than 50 elements (:issue:`39882`)
+- Bug in :meth:`DataFrame.melt` raising ``InvalidIndexError`` when :class:`DataFrame` has duplicate columns used as ``value_vars`` (:issue:`41951`)
 
 Sparse
 ^^^^^^

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -21,6 +21,7 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.concat import concat_compat
 from pandas.core.dtypes.missing import notna
 
+import pandas.core.algorithms as algos
 from pandas.core.arrays import Categorical
 import pandas.core.common as com
 from pandas.core.indexes.api import (
@@ -106,7 +107,7 @@ def melt(
                 id_vars + value_vars
             )
         else:
-            idx = frame.columns.get_indexer(id_vars + value_vars)
+            idx = algos.unique(frame.columns.get_indexer_for(id_vars + value_vars))
         frame = frame.iloc[:, idx]
     else:
         frame = frame.copy()

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -403,6 +403,15 @@ class TestMelt:
 
         tm.assert_frame_equal(result, expected)
 
+    def test_melt_with_duplicate_columns(self):
+        # GH#41951
+        df = DataFrame([["id", 2, 3]], columns=["a", "b", "b"])
+        result = df.melt(id_vars=["a"], value_vars=["b"])
+        expected = DataFrame(
+            [["id", "b", 2], ["id", "b", 3]], columns=["a", "variable", "value"]
+        )
+        tm.assert_frame_equal(result, expected)
+
 
 class TestLreshape:
     def test_pairs(self):


### PR DESCRIPTION
- [x] closes #41951
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

@simonjayhawkins I think this changed in May last year, so probably not woth backporting?