### PR TITLE
TST: Un-xfail tests on numpy-dev

### DIFF
--- a/pandas/tests/frame/methods/test_to_records.py
+++ b/pandas/tests/frame/methods/test_to_records.py
@@ -3,8 +3,6 @@ from collections import abc
 import numpy as np
 import pytest
 
-from pandas.compat import is_numpy_dev
-
 from pandas import (
     CategoricalDtype,
     DataFrame,
@@ -173,27 +171,19 @@ class TestDataFrameToRecords:
                 ),
             ),
             # Pass in a type instance.
-            pytest.param(
+            (
                 {"column_dtypes": str},
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
                     dtype=[("index", "<i8"), ("A", "<U"), ("B", "<U"), ("C", "<U")],
                 ),
-                marks=pytest.mark.xfail(
-                    is_numpy_dev,
-                    reason="https://github.com/numpy/numpy/issues/19078",
-                ),
             ),
             # Pass in a dtype instance.
-            pytest.param(
+            (
                 {"column_dtypes": np.dtype("unicode")},
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
                     dtype=[("index", "<i8"), ("A", "<U"), ("B", "<U"), ("C", "<U")],
-                ),
-                marks=pytest.mark.xfail(
-                    is_numpy_dev,
-                    reason="https://github.com/numpy/numpy/issues/19078",
                 ),
             ),
             # Pass in a dictionary (name-only).


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

Makes 3.8 npdev green. 