### PR TITLE
Update frame.py

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5615,7 +5615,8 @@ class DataFrame(NDFrame, OpsMixin):
             Only remove the given levels from the index. Removes all levels by
             default.
         drop : bool, default False
-            Do not try to insert index into dataframe columns. This resets
+            Do not try to insert index into dataframe columns. Unless the 
+            index is a MultiIndex with additional levels, this resets
             the index to the default integer index.
         inplace : bool, default False
             Modify the DataFrame in place (do not create a new object).


### PR DESCRIPTION
If not all levels are removed, the index is not reset to default integer values.

import pandas as pd

x = pd.Series(range(3), index=pd.MultiIndex.from_arrays([['a', 'b', 'c'], [1, 2, 3]], names=['letters', 'numbers']))

print(x.reset_index('numbers', drop=True))

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
