### PR TITLE
BUG: Don't supply name to Series when using 'size' with agg/apply

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -842,7 +842,7 @@ class FrameApply(NDFrameApply):
             # Special-cased because DataFrame.size returns a single scalar
             obj = self.obj
             value = obj.shape[self.axis]
-            return obj._constructor_sliced(value, index=self.agg_axis, name="size")
+            return obj._constructor_sliced(value, index=self.agg_axis)
         return super().apply_str()
 
 

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1279,9 +1279,9 @@ def test_size_as_str(how, axis):
     # on the columns
     result = getattr(df, how)("size", axis=axis)
     if axis == 0 or axis == "index":
-        expected = Series(df.shape[0], index=df.columns, name="size")
+        expected = Series(df.shape[0], index=df.columns)
     else:
-        expected = Series(df.shape[1], index=df.index, name="size")
+        expected = Series(df.shape[1], index=df.index)
     tm.assert_series_equal(result, expected)
 
 


### PR DESCRIPTION
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

Ref: https://github.com/pandas-dev/pandas/pull/39935#discussion_r651989373

Doing e.g.

    print(DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]}).apply('sum'))
    print(DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]}).agg('sum'))

produce a Series with `name=None`. This was introduced in 1.3, so does not need a whatsnew.