### PR TITLE
CI/TST: fix typo in #41982

### DIFF
--- a/pandas/tests/indexes/numeric/test_numeric.py
+++ b/pandas/tests/indexes/numeric/test_numeric.py
@@ -536,7 +536,7 @@ class TestUInt64Index(NumericInt):
         tm.assert_index_equal(res, idx)
 
     @pytest.mark.xfail(
-        not (is_platform_arm and is_platform_mac()),
+        not (is_platform_arm() and is_platform_mac()),
         reason="https://github.com/numpy/numpy/issues/19146",
     )
     def test_constructor_does_not_cast_to_float(self):


### PR DESCRIPTION
fix a typo in #41982, which is causing CI failure.