### PR TITLE
BUG: hash_pandas_object ignores optional arguments when the input is a DataFrame.

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -1205,6 +1205,7 @@ Other
 - Bug in :class:`Series` backed by :class:`DatetimeArray` or :class:`TimedeltaArray` sometimes failing to set the array's ``freq`` to ``None`` (:issue:`41425`)
 - Bug in creating a :class:`Series` from a ``range`` object that does not fit in the bounds of ``int64`` dtype (:issue:`30173`)
 - Bug in creating a :class:`Series` from a ``dict`` with all-tuple keys and an :class:`Index` that requires reindexing (:issue:`41707`)
+- Bug in :func:`pandas.util.hash_pandas_object` not recognizing ``hash_key``, ``encoding`` and ``categorize`` when the input object type is a :class:`DataFrame` (:issue:`41404`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/util/hashing.py
+++ b/pandas/core/util/hashing.py
@@ -139,7 +139,10 @@ def hash_pandas_object(
         ser = Series(h, index=obj.index, dtype="uint64", copy=False)
 
     elif isinstance(obj, ABCDataFrame):
-        hashes = (hash_array(series._values) for _, series in obj.items())
+        hashes = (
+            hash_array(series._values, encoding, hash_key, categorize)
+            for _, series in obj.items()
+        )
         num_items = len(obj.columns)
         if index:
             index_hash_generator = (

--- a/pandas/tests/util/test_hashing.py
+++ b/pandas/tests/util/test_hashing.py
@@ -256,13 +256,29 @@ def test_hash_keys():
 
 
 def test_df_hash_keys():
-    # DataFrame version of the test_hash_keys
+    # DataFrame version of the test_hash_keys.
+    # https://github.com/pandas-dev/pandas/issues/41404
     obj = DataFrame({"x": np.arange(3), "y": list("abc")})
 
     a = hash_pandas_object(obj, hash_key="9876543210123456")
     b = hash_pandas_object(obj, hash_key="9876543210123465")
 
     assert (a != b).all()
+
+
+def test_df_encoding():
+    # Check that DataFrame recognizes optional encoding.
+    # https://github.com/pandas-dev/pandas/issues/41404
+    # https://github.com/pandas-dev/pandas/pull/42049
+    obj = DataFrame({"x": np.arange(3), "y": list("a+c")})
+
+    a = hash_pandas_object(obj, encoding="utf8")
+    b = hash_pandas_object(obj, encoding="utf7")
+
+    # Note that the "+" is encoded as "+-" in utf-7.
+    assert a[0] == b[0]
+    assert a[1] != b[1]
+    assert a[2] == b[2]
 
 
 def test_invalid_key():

--- a/pandas/tests/util/test_hashing.py
+++ b/pandas/tests/util/test_hashing.py
@@ -255,6 +255,16 @@ def test_hash_keys():
     assert (a != b).all()
 
 
+def test_df_hash_keys():
+    # DataFrame version of the test_hash_keys
+    obj = DataFrame({"x": np.arange(3), "y": list("abc")})
+
+    a = hash_pandas_object(obj, hash_key="9876543210123456")
+    b = hash_pandas_object(obj, hash_key="9876543210123465")
+
+    assert (a != b).all()
+
+
 def test_invalid_key():
     # This only matters for object dtypes.
     msg = "key should be a 16-byte string encoded"


### PR DESCRIPTION
- [x] closes #41404
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

In this PR, I will try to solve issue #41404.
I would appreciate it if you could review this.

## About the issue

In the current `pandas.util.hash_pandas_object` function implementation, the hash_key argument is ignored when the input object type is a DataFrame.
This is a reproducible example.

```py
df = pd.DataFrame({"x": list("abc")})
new_hash_key = "a"*16
print("Series")
print(pd.util.hash_pandas_object(df["x"]).values)
print(pd.util.hash_pandas_object(df["x"], hash_key=new_hash_key).values)
print("DataFrame")
print(pd.util.hash_pandas_object(df).values)
print(pd.util.hash_pandas_object(df, hash_key=new_hash_key).values)
```

The output is here.

```
Series
[ 4578374827886788867 17338122309987883691  5473791562133574857]
[14372590553486244284 12017144478307119910    34790805896362026]
DataFrame
[ 4578374827886788867 17338122309987883691  5473791562133574857]
[ 4578374827886788867 17338122309987883691  5473791562133574857]
```

The last output should be
```
[14372590553486244284 12017144478307119910    34790805896362026]
```

## About the fix

When the input object is a DataFrame, the hash values are calculated by applying `hash_array` function for each Series.
However, optional arguments, including `hash_key`, are not passed to the hash_array function in the current implementation.
To fix this, I passed the optional arguments to the hash_array function.