### PR TITLE
DOC: update styler user guide for ref to hiding cols and index and link to to_LaTeX

### DIFF
--- a/doc/source/user_guide/style.ipynb
+++ b/doc/source/user_guide/style.ipynb
@@ -152,7 +152,7 @@
     "\n",
     "Before adding styles it is useful to show that the [Styler][styler] can distinguish the *display* value from the *actual* value. To control the display value, the text is printed in each cell, and we can use the [.format()][formatfunc] method to manipulate this according to a [format spec string][format] or a callable that takes a single value and returns a string. It is possible to define this for the whole table or for individual columns. \n",
     "\n",
-    "Additionally, the format function has a **precision** argument to specifically help formatting floats, an **na_rep** argument to display missing data, and an **escape** argument to help displaying safe-HTML. The default formatter is configured to adopt pandas' regular `display.precision` option, controllable using `with pd.option_context('display.precision', 2):`\n",
+    "Additionally, the format function has a **precision** argument to specifically help formatting floats, as well as **decimal** and **thousands** separators to support other locales, an **na_rep** argument to display missing data, and an **escape** argument to help displaying safe-HTML or safe-LaTeX. The default formatter is configured to adopt pandas' regular `display.precision` option, controllable using `with pd.option_context('display.precision', 2):`\n",
     "\n",
     "Here is an example of using the multiple options to control the formatting generally and with specific column formatters.\n",
     "\n",
@@ -167,9 +167,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.style.format(precision=0, na_rep='MISSING', \n",
+    "df.style.format(precision=0, na_rep='MISSING', thousands=\" \",\n",
     "                formatter={('Decision Tree', 'Tumour'): \"{:.2f}\",\n",
-    "                           ('Regression', 'Non-Tumour'): lambda x: \"$ {:,.1f}\".format(x*-1e3)\n",
+    "                           ('Regression', 'Non-Tumour'): lambda x: \"$ {:,.1f}\".format(x*-1e6)\n",
     "                          })"
    ]
   },
@@ -179,9 +179,11 @@
    "source": [
     "### Hiding Data\n",
     "\n",
-    "The index can be hidden from rendering by calling [.hide_index()][hideidx], which might be useful if your index is integer based.\n",
+    "The index and column headers can be completely hidden, as well subselecting rows or columns that one wishes to exclude. Both these options are performed using the same methods.\n",
     "\n",
-    "Columns can be hidden from rendering by calling [.hide_columns()][hidecols] and passing in the name of a column, or a slice of columns.\n",
+    "The index can be hidden from rendering by calling [.hide_index()][hideidx] without any arguments, which might be useful if your index is integer based. Similarly column headers can be hidden by calling [.hide_columns()][hidecols] without any arguments.\n",
+    "\n",
+    "Specific rows or columns can be hidden from rendering by calling the same [.hide_index()][hideidx] or [.hide_columns()][hidecols] methods and passing in a row/column label, a list-like or a slice of row/column labels to for the ``subset`` argument.\n",
     "\n",
     "Hiding does not change the integer arrangement of CSS classes, e.g. hiding the first two columns of a DataFrame means the column class indexing will start at `col2`, since `col0` and `col1` are simply ignored.\n",
     "\n",
@@ -1423,24 +1425,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Hiding Headers\n",
-    "\n",
-    "We don't yet have any API to hide headers so a quick fix is:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df3.style.set_table_styles([{'selector': 'thead tr', 'props': 'display: none;'}])  # or 'thead th'"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### HTML Escaping\n",
     "\n",
     "Suppose you have to display HTML within HTML, that can be a bit of pain when the renderer can't distinguish. You can use the `escape` formatting option to handle this, and even use it within a formatter that contains HTML itself."
@@ -1522,6 +1506,17 @@
     "A screenshot of the output:\n",
     "\n",
     "![Excel spreadsheet with styled DataFrame](../_static/style-excel.png)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export to LaTeX\n",
+    "\n",
+    "There is support (*since version 1.3.0*) to export `Styler` to LaTeX. The documentation for the [.to_latex][latex] method gives further detail and numerous examples.\n",
+    "\n",
+    "[latex]: ../reference/api/pandas.io.formats.style.Styler.to_latex.rst"
    ]
   },
   {


### PR DESCRIPTION
should be backported to 1.3.0 as it references the features add there.
