### PR TITLE
Allow passing custom sentinel into MultiIndex.format

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1318,8 +1318,9 @@ class MultiIndex(Index):
         na_rep: str | None = None,
         names: bool = False,
         space: int = 2,
-        sparsify=None,
+        sparsify: bool | None = None,
         adjoin: bool = True,
+        sentinel="",
     ) -> list:
         if name is not None:
             names = name
@@ -1368,10 +1369,15 @@ class MultiIndex(Index):
             sparsify = get_option("display.multi_sparse")
 
         if sparsify:
-            sentinel = ""
-            # GH3547 use value of sparsify as sentinel if it's "Falsey"
-            assert isinstance(sparsify, bool) or sparsify is lib.no_default
-            if sparsify in [False, lib.no_default]:
+            # GH3547 use value of sparsify as sentinel, unless it's an obvious
+            # "Truthy" value
+            if sparsify not in [True, 1]:
+                warnings.warn(
+                    "passing non-bool value of sparsify to MultiIndex.format is "
+                    "deprecated, use sentinel argument instead.",
+                    FutureWarning,
+                    stacklevel=2,
+                )
                 sentinel = sparsify
             # little bit of a kludge job for #1217
             result_levels = sparsify_labels(

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -13,8 +13,6 @@ from typing import (
 
 from pandas._config import get_option
 
-from pandas._libs import lib
-
 from pandas import (
     MultiIndex,
     option_context,
@@ -253,14 +251,10 @@ class HTMLFormatter:
         is_truncated_horizontally = self.fmt.is_truncated_horizontally
         if isinstance(self.columns, MultiIndex):
             template = 'colspan="{span:d}" halign="left"'
-
-            sentinel: lib.NoDefault | bool
-            if self.fmt.sparsify:
-                # GH3547
-                sentinel = lib.no_default
-            else:
-                sentinel = False
-            levels = self.columns.format(sparsify=sentinel, adjoin=False, names=False)
+            # GH3547
+            sentinel = object()
+            levels = self.columns.format(sparsify=self.fmt.sparsify, sentinel=sentinel,
+                                         adjoin=False, names=False)
             level_lengths = get_level_lengths(levels, sentinel)
             inner_lvl = len(level_lengths) - 1
             for lnum, (records, values) in enumerate(zip(level_lengths, levels)):
@@ -464,9 +458,9 @@ class HTMLFormatter:
 
         if self.fmt.sparsify:
             # GH3547
-            sentinel = lib.no_default
-            levels = frame.index.format(sparsify=sentinel, adjoin=False, names=False)
-
+            sentinel = object()
+            levels = frame.index.format(sparsify=True, sentinel=sentinel, adjoin=False,
+                                        names=False)
             level_lengths = get_level_lengths(levels, sentinel)
             inner_lvl = len(level_lengths) - 1
             if is_truncated_vertically:

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -19,7 +19,6 @@ import numpy as np
 
 from pandas._config import get_option
 
-from pandas._libs import lib
 from pandas._typing import (
     FrameOrSeriesUnion,
     TypedDict,
@@ -811,8 +810,9 @@ def _get_level_lengths(
     Dict :
         Result is a dictionary of (level, initial_position): span
     """
+    sentinel = object()
     if isinstance(index, MultiIndex):
-        levels = index.format(sparsify=lib.no_default, adjoin=False)
+        levels = index.format(sparsify=sparsify, sentinel=sentinel, adjoin=False)
     else:
         levels = index.format()
 
@@ -833,10 +833,10 @@ def _get_level_lengths(
                 break
             if not sparsify:
                 lengths[(i, j)] = 1
-            elif (row is not lib.no_default) and (j not in hidden_elements):
+            elif (row is not sentinel) and (j not in hidden_elements):
                 last_label = j
                 lengths[(i, last_label)] = 1
-            elif row is not lib.no_default:
+            elif row is not sentinel:
                 # even if its hidden, keep track of it in case
                 # length >1 and later elements are visible
                 last_label = j

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -3198,6 +3198,34 @@ class TestDatetimeIndexUnicode:
         assert "'2014-01-01 00:00:00']" in text
 
 
+class TestMultiIndexFormat:
+    def test_sparsify(self):
+        idx = pd.MultiIndex.from_tuples(
+            [("A", "1"), ("A", "2"), ("B", "1"), ("B", "2")]
+        )
+        assert idx.format(sparsify=False) == ["A  1", "A  2", "B  1", "B  2"]
+        assert idx.format(sparsify=True) == ["A  1", "   2", "B  1", "   2"]
+        assert idx.format(sparsify=1) == ["A  1", "   2", "B  1", "   2"]
+        expected = ["A  1", "*  2", "B  1", "*  2"]
+        assert idx.format(sparsify="*") == expected
+        assert idx.format(sparsify=True, sentinel="*") == expected
+        expected = ["A    1", "...  2", "B    1", "...  2"]
+        assert idx.format(sparsify="...") == expected
+        assert idx.format(sparsify=True, sentinel="...") == expected
+
+        expected = [["A", "A", "B", "B"], ["1", "2", "1", "2"]]
+        assert idx.format(adjoin=False, sparsify=False) == expected
+        expected = [("A", "", "B", ""), ("1", "2", "1", "2")]
+        assert idx.format(adjoin=False, sparsify=True) == expected
+        expected = [("A", "...", "B", "..."), ("1", "2", "1", "2")]
+        assert idx.format(adjoin=False, sparsify="...") == expected
+        assert idx.format(adjoin=False, sparsify=True, sentinel="...") == expected
+        sentinel = object()
+        expected = [("A", sentinel, "B", sentinel), ("1", "2", "1", "2")]
+        assert idx.format(adjoin=False, sparsify=sentinel) == expected
+        assert idx.format(adjoin=False, sparsify=True, sentinel=sentinel) == expected
+
+
 class TestStringRepTimestamp:
     def test_no_tz(self):
         dt_date = datetime(2013, 1, 2)


### PR DESCRIPTION
Commit b0468aa45f3 seems to have unintentionally removed functionality
to pass custom sentinel values for sparsifying in MultiIndex.format().
Previously, any "Truthy" value other than 1 and True was used as the
sentinel, which is useful particularly with adjoin=False. The current
logic does not make sense: it checks sparsify for "Falsey" values under
"if sparsify:" condition. Under this if sparsify cannot be Falsey.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
