### PR TITLE
Backport PR #41987: TST: Un-xfail tests on numpy-dev

### DIFF
--- a/pandas/tests/frame/methods/test_to_records.py
+++ b/pandas/tests/frame/methods/test_to_records.py
@@ -3,8 +3,6 @@ from collections import abc
 import numpy as np
 import pytest
 
-from pandas.compat.numpy import is_numpy_dev
-
 from pandas import (
     CategoricalDtype,
     DataFrame,
@@ -164,27 +162,19 @@ class TestDataFrameToRecords:
                 ),
             ),
             # Pass in a type instance.
-            pytest.param(
+            (
                 {"column_dtypes": str},
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
                     dtype=[("index", "<i8"), ("A", "<U"), ("B", "<U"), ("C", "<U")],
                 ),
-                marks=pytest.mark.xfail(
-                    is_numpy_dev,
-                    reason="https://github.com/numpy/numpy/issues/19078",
-                ),
             ),
             # Pass in a dtype instance.
-            pytest.param(
+            (
                 {"column_dtypes": np.dtype("unicode")},
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
                     dtype=[("index", "<i8"), ("A", "<U"), ("B", "<U"), ("C", "<U")],
-                ),
-                marks=pytest.mark.xfail(
-                    is_numpy_dev,
-                    reason="https://github.com/numpy/numpy/issues/19078",
                 ),
             ),
             # Pass in a dictionary (name-only).


### PR DESCRIPTION
Backport PR #41987