### PR TITLE
DOC: add links to style.rst for `Styler.hide_columns` and `Styler.hide_index`

### DIFF
--- a/doc/source/reference/style.rst
+++ b/doc/source/reference/style.rst
@@ -35,6 +35,8 @@ Style application
    Styler.apply
    Styler.applymap
    Styler.format
+   Styler.hide_index
+   Styler.hide_columns
    Styler.set_td_classes
    Styler.set_table_styles
    Styler.set_table_attributes


### PR DESCRIPTION
should be backported 1.3.0
