### PR TITLE
PERF/CLN: to_csv

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -105,7 +105,7 @@ Deprecations
 
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
--
+- Performance improvement in :meth:`DataFrame.to_csv`` (:issue:`41468`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/_libs/writers.pyx
+++ b/pandas/_libs/writers.pyx
@@ -44,7 +44,7 @@ def write_csv_rows(
         list row
 
     # pre-allocate rows
-    rows = [[None] * (nlevels + ncols) for _ in range(chunksize)]
+    rows = [[None] * (nlevels + ncols) for _ in range(min(chunksize, k))]
 
     if nlevels == 1:
         for j in range(k):

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -160,7 +160,7 @@ class CSVFormatter:
 
     def _initialize_chunksize(self, chunksize: int | None) -> int:
         if chunksize is None:
-            return (100000 // (len(self.cols) or 1)) or 1
+            return 100000 // len(self.cols) or 1
         return int(chunksize)
 
     @property

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -160,7 +160,10 @@ class CSVFormatter:
 
     def _initialize_chunksize(self, chunksize: int | None) -> int:
         if chunksize is None:
-            return 100000 // len(self.cols) or 1
+            if len(self.cols) > 0:
+                return max(100000 // len(self.cols), 1)
+            else:
+                return 1
         return int(chunksize)
 
     @property

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -290,28 +290,35 @@ class CSVFormatter:
             yield self.encoded_labels + [""] * len(columns)
 
     def _save_body(self) -> None:
-        nrows = len(self.data_index)
-        chunks = (nrows // self.chunksize) + 1
-        for i in range(chunks):
-            start_i = i * self.chunksize
-            end_i = min(start_i + self.chunksize, nrows)
-            if start_i >= end_i:
-                break
-            self._save_chunk(start_i, end_i)
+        if len(self.obj) > 0:
+            res = self.obj._mgr.to_native_types(**self._number_format)
+            data = [res.iget_values(i) for i in range(len(res.items))]
+            ix = self.data_index._format_native_types(**self._number_format)
+            libwriters.write_csv_rows(
+                data, ix, self.nlevels, len(self.cols), self.writer, self.chunksize
+            )
+        # nrows = len(self.data_index)
+        # chunks = (nrows // self.chunksize) + 1
+        # for i in range(chunks):
+        #     start_i = i * self.chunksize
+        #     end_i = min(start_i + self.chunksize, nrows)
+        #     if start_i >= end_i:
+        #         break
+        #     self._save_chunk(start_i, end_i)
 
-    def _save_chunk(self, start_i: int, end_i: int) -> None:
-        # create the data for a chunk
-        slicer = slice(start_i, end_i)
-        df = self.obj.iloc[slicer]
-
-        res = df._mgr.to_native_types(**self._number_format)
-        data = [res.iget_values(i) for i in range(len(res.items))]
-
-        ix = self.data_index[slicer]._format_native_types(**self._number_format)
-        libwriters.write_csv_rows(
-            data,
-            ix,
-            self.nlevels,
-            self.cols,
-            self.writer,
-        )
+    # def _save_chunk(self, start_i: int, end_i: int) -> None:
+    #     # create the data for a chunk
+    #     slicer = slice(start_i, end_i)
+    #     df = self.obj.iloc[slicer]
+    #
+    #     res = df._mgr.to_native_types(**self._number_format)
+    #     data = [res.iget_values(i) for i in range(len(res.items))]
+    #
+    #     ix = self.data_index[slicer]._format_native_types(**self._number_format)
+    #     libwriters.write_csv_rows(
+    #         data,
+    #         ix,
+    #         self.nlevels,
+    #         len(self.cols),
+    #         self.writer,
+    #     )

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -297,28 +297,3 @@ class CSVFormatter:
             libwriters.write_csv_rows(
                 data, ix, self.nlevels, len(self.cols), self.writer, self.chunksize
             )
-        # nrows = len(self.data_index)
-        # chunks = (nrows // self.chunksize) + 1
-        # for i in range(chunks):
-        #     start_i = i * self.chunksize
-        #     end_i = min(start_i + self.chunksize, nrows)
-        #     if start_i >= end_i:
-        #         break
-        #     self._save_chunk(start_i, end_i)
-
-    # def _save_chunk(self, start_i: int, end_i: int) -> None:
-    #     # create the data for a chunk
-    #     slicer = slice(start_i, end_i)
-    #     df = self.obj.iloc[slicer]
-    #
-    #     res = df._mgr.to_native_types(**self._number_format)
-    #     data = [res.iget_values(i) for i in range(len(res.items))]
-    #
-    #     ix = self.data_index[slicer]._format_native_types(**self._number_format)
-    #     libwriters.write_csv_rows(
-    #         data,
-    #         ix,
-    #         self.nlevels,
-    #         len(self.cols),
-    #         self.writer,
-    #     )


### PR DESCRIPTION
- [ ] xref #41468
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

More of a cleanup than a performance improvement. Perf only seems to improve for multiindexes.
Will try to squeeze out more improvement.

Here are the asv's (run 3 times)
```
asv continuous -f 1.1 upstream/master HEAD -b ^io.csv.ToCSV
```
```
       before           after         ratio
     [5153334c]       [a7a839bd]
     <perf-to-csv~2^2>       <perf-to-csv>
-        28.3±5ms       13.6±0.8ms     0.48  io.csv.ToCSVDatetime.time_frame_date_formatting
-       2.77±0.1s       1.10±0.01s     0.40  io.csv.ToCSVIndexes.time_head_of_multiindex

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.

       before           after         ratio
     [5153334c]       [a7a839bd]
     <perf-to-csv~2^2>       <perf-to-csv>
-        29.8±6ms       15.9±0.3ms     0.53  io.csv.ToCSVDatetime.time_frame_date_formatting
-       2.51±0.2s       1.25±0.06s     0.50  io.csv.ToCSVIndexes.time_head_of_multiindex

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.

       before           after         ratio
     [5153334c]       [a7a839bd]
     <perf-to-csv~2^2>       <perf-to-csv>
-        934±30ms         767±30ms     0.82  io.csv.ToCSVIndexes.time_multiindex
-      3.49±0.08s       1.08±0.03s     0.31  io.csv.ToCSVIndexes.time_head_of_multiindex

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.

```
