### PR TITLE
CLN: Remove unused FLAKE8_FORMAT from ci/code_checks.sh

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -38,10 +38,7 @@ function invgrep {
 }
 
 if [[ "$GITHUB_ACTIONS" == "true" ]]; then
-    FLAKE8_FORMAT="##[error]%(path)s:%(row)s:%(col)s:%(code)s:%(text)s"
     INVGREP_PREPEND="##[error]"
-else
-    FLAKE8_FORMAT="default"
 fi
 
 ### LINTING ###


### PR DESCRIPTION
This variable is not used anymore, since flake8 is now run in pre-commit, and not in `ci/code_checks.sh`.