### PR TITLE
BUG: Unignore .c files under _libs/src. (#42116)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,10 +93,10 @@ scikits
 # Generated Sources #
 #####################
 !skts.c
-!np_datetime.c
-!np_datetime_strings.c
 *.c
 *.cpp
+# Unignore source c files
+!pandas/_libs/src/**/*.c
 
 # Unit / Performance Testing #
 ##############################


### PR DESCRIPTION
- [x] closes #42116

Not 100% what tests I could write for this. This works locally. git status shows no untracked files while `rg on_bad_lines` now shows results from `pandas/_libs/src/parser/tokenizer.c`