### PR TITLE
CI: skip json tests for Python 3.10 #42130

### DIFF
--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -28,8 +28,6 @@ from pandas import (
 )
 import pandas._testing as tm
 
-pytestmark = pytest.mark.skipif(PY310, reason="timeout with coverage")
-
 _seriesd = tm.getSeriesData()
 
 _frame = DataFrame(_seriesd)
@@ -1181,6 +1179,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         expected = s.to_json()
         assert expected == ss.to_json()
 
+    pytest.mark.xfail(PY310, reason="segfail GH 42130")
     @pytest.mark.parametrize(
         "ts",
         [

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1179,7 +1179,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         expected = s.to_json()
         assert expected == ss.to_json()
 
-    pytest.mark.xfail(PY310, reason="segfault GH 42130")
+    @pytest.mark.xfail(PY310, reason="segfault GH 42130")
     @pytest.mark.parametrize(
         "ts",
         [

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1179,7 +1179,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         expected = s.to_json()
         assert expected == ss.to_json()
 
-    pytest.mark.xfail(PY310, reason="segfail GH 42130")
+    pytest.mark.xfail(PY310, reason="segfault GH 42130")
     @pytest.mark.parametrize(
         "ts",
         [

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1179,7 +1179,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         expected = s.to_json()
         assert expected == ss.to_json()
 
-    @pytest.mark.xfail(PY310, reason="segfault GH 42130")
+    @pytest.mark.skipif(PY310, reason="segfault GH 42130")
     @pytest.mark.parametrize(
         "ts",
         [
@@ -1197,6 +1197,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         dt = ts.to_pydatetime()
         assert dumps(dt, iso_dates=True) == exp
 
+    @pytest.mark.skipif(PY310, reason="segfault GH 42130")
     @pytest.mark.parametrize(
         "tz_range",
         [


### PR DESCRIPTION
xref #42130 
