### PR TITLE
REGR: dont warn on unpickle Timestamp

### DIFF
--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -129,6 +129,13 @@ cdef inline object create_timestamp_from_ts(int64_t value,
     return ts_base
 
 
+def _unpickle_timestamp(value, freq, tz):
+    # GH#41949 dont warn on unpickle if we have a freq
+    ts = Timestamp(value, tz=tz)
+    ts._set_freq(freq)
+    return ts
+
+
 # ----------------------------------------------------------------------
 
 def integer_op_not_supported(obj):
@@ -725,7 +732,7 @@ cdef class _Timestamp(ABCTimestamp):
 
     def __reduce__(self):
         object_state = self.value, self._freq, self.tzinfo
-        return (Timestamp, object_state)
+        return (_unpickle_timestamp, object_state)
 
     # -----------------------------------------------------------------
     # Rendering Methods

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -6,6 +6,7 @@ from datetime import (
     timedelta,
 )
 import locale
+import pickle
 import unicodedata
 
 from dateutil.tz import tzutc
@@ -439,6 +440,17 @@ class TestTimestamp:
         with tm.assert_produces_warning(FutureWarning, match="freq"):
             t2 = Timestamp("2019-01-02 12:00", tz="UTC", freq="T")
             assert t2.tz_convert(tz="UTC").freq == t2.freq
+
+    def test_pickle_freq_no_warning(self):
+        # GH#41949 we don't want a warning on unpickling
+        with tm.assert_produces_warning(FutureWarning, match="freq"):
+            ts = Timestamp("2019-01-01 10:00", freq="H")
+
+        out = pickle.dumps(ts)
+        with tm.assert_produces_warning(None):
+            res = pickle.loads(out)
+
+        assert res._freq == ts._freq
 
 
 class TestTimestampNsOperations:


### PR DESCRIPTION
- [x] closes #41949
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
