### PR TITLE
TST/CI: speed up chunksize test

### DIFF
--- a/pandas/tests/io/parser/common/test_chunksize.py
+++ b/pandas/tests/io/parser/common/test_chunksize.py
@@ -177,13 +177,16 @@ def test_chunks_have_consistent_numerical_type(all_parsers):
 def test_warn_if_chunks_have_mismatched_type(all_parsers, request):
     warning_type = None
     parser = all_parsers
-    integers = [str(i) for i in range(499999)]
-    data = "a\n" + "\n".join(integers + ["a", "b"] + integers)
+    size = 10000
 
     # see gh-3866: if chunks are different types and can't
     # be coerced using numerical types, then issue warning.
     if parser.engine == "c" and parser.low_memory:
         warning_type = DtypeWarning
+        size = 499999
+
+    integers = [str(i) for i in range(size)]
+    data = "a\n" + "\n".join(integers + ["a", "b"] + integers)
 
     buf = StringIO(data)
 


### PR DESCRIPTION
Seeing lots of CI timeouts - this test sometimes takes > 5 min for the python parser, guessing dependent on memory availability. 

AFAICT the data size is only so large to test the warning given by the c parser and low memory case, so shrank size for other cases.