### PR TITLE
TST: Add unmatched warning messages to assert_produces_warning() error

### DIFF
--- a/pandas/_testing/_warnings.py
+++ b/pandas/_testing/_warnings.py
@@ -106,6 +106,7 @@ def _assert_caught_expected_warning(
     """Assert that there was the expected warning among the caught warnings."""
     saw_warning = False
     matched_message = False
+    unmatched_messages = []
 
     for actual_warning in caught_warnings:
         if issubclass(actual_warning.category, expected_warning):
@@ -116,8 +117,11 @@ def _assert_caught_expected_warning(
             ):
                 _assert_raised_with_correct_stacklevel(actual_warning)
 
-            if match is not None and re.search(match, str(actual_warning.message)):
-                matched_message = True
+            if match is not None:
+                if re.search(match, str(actual_warning.message)):
+                    matched_message = True
+                else:
+                    unmatched_messages.append(actual_warning.message)
 
     if not saw_warning:
         raise AssertionError(
@@ -128,7 +132,8 @@ def _assert_caught_expected_warning(
     if match and not matched_message:
         raise AssertionError(
             f"Did not see warning {repr(expected_warning.__name__)} "
-            f"matching {match}"
+            f"matching '{match}'. The emitted warning messages are "
+            f"{unmatched_messages}"
         )
 
 

--- a/pandas/tests/util/test_assert_produces_warning.py
+++ b/pandas/tests/util/test_assert_produces_warning.py
@@ -94,36 +94,42 @@ def test_catch_warning_category_and_match(category, message, match):
         warnings.warn(message, category)
 
 
-def test_fail_to_match_1():
+def test_fail_to_match_runtime_warning():
     category = RuntimeWarning
     match = "Did not see this warning"
-    unmatched = r"Did not see warning 'RuntimeWarning' matching 'Did not see this warning'. "\
-        r"The emitted warning messages are \[RuntimeWarning\('This is not a match.'\),"\
-        r" RuntimeWarning\('Another unmatched warning.'\)\]"
+    unmatched = (
+        r"Did not see warning 'RuntimeWarning' matching 'Did not see this "
+        r"warning'. The emitted warning messages are \[RuntimeWarning\('This is not a "
+        r"match.'\), RuntimeWarning\('Another unmatched warning.'\)\]"
+    )
     with pytest.raises(AssertionError, match=unmatched):
         with tm.assert_produces_warning(category, match=match):
             warnings.warn("This is not a match.", category)
             warnings.warn("Another unmatched warning.", category)
 
 
-def test_fail_to_match_2():
+def test_fail_to_match_future_warning():
     category = FutureWarning
     match = "Warning"
-    unmatched = r"Did not see warning 'FutureWarning' matching 'Warning'. "\
-        r"The emitted warning messages are \[FutureWarning\('This is not a match.'\),"\
+    unmatched = (
+        r"Did not see warning 'FutureWarning' matching 'Warning'. "
+        r"The emitted warning messages are \[FutureWarning\('This is not a match.'\),"
         r" FutureWarning\('Another unmatched warning.'\)\]"
+    )
     with pytest.raises(AssertionError, match=unmatched):
         with tm.assert_produces_warning(category, match=match):
             warnings.warn("This is not a match.", category)
             warnings.warn("Another unmatched warning.", category)
 
 
-def test_fail_to_match_3():
+def test_fail_to_match_resource_warning():
     category = ResourceWarning
     match = r"\d+"
-    unmatched = r"Did not see warning 'ResourceWarning' matching '\\d\+'. "\
-        r"The emitted warning messages are \[ResourceWarning\('This is not a match.'\),"\
-        r" ResourceWarning\('Another unmatched warning.'\)\]"
+    unmatched = (
+        r"Did not see warning 'ResourceWarning' matching '\\d\+'. "
+        r"The emitted warning messages are \[ResourceWarning\('This is not a match.'\)"
+        r", ResourceWarning\('Another unmatched warning.'\)\]"
+    )
     with pytest.raises(AssertionError, match=unmatched):
         with tm.assert_produces_warning(category, match=match):
             warnings.warn("This is not a match.", category)

--- a/pandas/tests/util/test_assert_produces_warning.py
+++ b/pandas/tests/util/test_assert_produces_warning.py
@@ -99,8 +99,9 @@ def test_fail_to_match_runtime_warning():
     match = "Did not see this warning"
     unmatched = (
         r"Did not see warning 'RuntimeWarning' matching 'Did not see this warning'. "
-        r"The emitted warning messages are \[RuntimeWarning\('This is not a "
-        r"match.'\), RuntimeWarning\('Another unmatched warning.'\)\]"
+        r"The emitted warning messages are "
+        r"\[RuntimeWarning\('This is not a match.'\), "
+        r"RuntimeWarning\('Another unmatched warning.'\)\]"
     )
     with pytest.raises(AssertionError, match=unmatched):
         with tm.assert_produces_warning(category, match=match):
@@ -113,7 +114,8 @@ def test_fail_to_match_future_warning():
     match = "Warning"
     unmatched = (
         r"Did not see warning 'FutureWarning' matching 'Warning'. "
-        r"The emitted warning messages are \[FutureWarning\('This is not a match.'\), "
+        r"The emitted warning messages are "
+        r"\[FutureWarning\('This is not a match.'\), "
         r"FutureWarning\('Another unmatched warning.'\)\]"
     )
     with pytest.raises(AssertionError, match=unmatched):
@@ -127,8 +129,9 @@ def test_fail_to_match_resource_warning():
     match = r"\d+"
     unmatched = (
         r"Did not see warning 'ResourceWarning' matching '\\d\+'. "
-        r"The emitted warning messages are \[ResourceWarning\('This is not a match.'\)"
-        r", ResourceWarning\('Another unmatched warning.'\)\]"
+        r"The emitted warning messages are "
+        r"\[ResourceWarning\('This is not a match.'\), "
+        r"ResourceWarning\('Another unmatched warning.'\)\]"
     )
     with pytest.raises(AssertionError, match=unmatched):
         with tm.assert_produces_warning(category, match=match):

--- a/pandas/tests/util/test_assert_produces_warning.py
+++ b/pandas/tests/util/test_assert_produces_warning.py
@@ -95,18 +95,21 @@ def test_catch_warning_category_and_match(category, message, match):
 
 
 @pytest.mark.parametrize(
-    "message, match",
+    "match",
     [
-        ("Warning message", "Not this message"),
-        ("Warning message", "warning"),
-        ("Warning message", r"\d+"),
+        ("Not this message"),
+        ("Warning"),
+        (r"\d+"),
     ],
 )
-def test_fail_to_match(category, message, match):
-    msg = f"Did not see warning {repr(category.__name__)} matching"
-    with pytest.raises(AssertionError, match=msg):
+def test_fail_to_match(category, match):
+    msg1 = "This is not a match."
+    msg2 = "Another unmatched warning."
+    unmatched = rf"{category.__name__}\('{msg1}'\), {category.__name__}\('{msg2}'\)"
+    with pytest.raises(AssertionError, match=unmatched):
         with tm.assert_produces_warning(category, match=match):
-            warnings.warn(message, category)
+            warnings.warn(msg1, category)
+            warnings.warn(msg2, category)
 
 
 def test_fail_to_catch_actual_warning(pair_different_warnings):

--- a/pandas/tests/util/test_assert_produces_warning.py
+++ b/pandas/tests/util/test_assert_produces_warning.py
@@ -98,8 +98,8 @@ def test_fail_to_match_runtime_warning():
     category = RuntimeWarning
     match = "Did not see this warning"
     unmatched = (
-        r"Did not see warning 'RuntimeWarning' matching 'Did not see this "
-        r"warning'. The emitted warning messages are \[RuntimeWarning\('This is not a "
+        r"Did not see warning 'RuntimeWarning' matching 'Did not see this warning'. "
+        r"The emitted warning messages are \[RuntimeWarning\('This is not a "
         r"match.'\), RuntimeWarning\('Another unmatched warning.'\)\]"
     )
     with pytest.raises(AssertionError, match=unmatched):
@@ -113,8 +113,8 @@ def test_fail_to_match_future_warning():
     match = "Warning"
     unmatched = (
         r"Did not see warning 'FutureWarning' matching 'Warning'. "
-        r"The emitted warning messages are \[FutureWarning\('This is not a match.'\),"
-        r" FutureWarning\('Another unmatched warning.'\)\]"
+        r"The emitted warning messages are \[FutureWarning\('This is not a match.'\), "
+        r"FutureWarning\('Another unmatched warning.'\)\]"
     )
     with pytest.raises(AssertionError, match=unmatched):
         with tm.assert_produces_warning(category, match=match):

--- a/pandas/tests/util/test_assert_produces_warning.py
+++ b/pandas/tests/util/test_assert_produces_warning.py
@@ -94,22 +94,40 @@ def test_catch_warning_category_and_match(category, message, match):
         warnings.warn(message, category)
 
 
-@pytest.mark.parametrize(
-    "match",
-    [
-        ("Not this message"),
-        ("Warning"),
-        (r"\d+"),
-    ],
-)
-def test_fail_to_match(category, match):
-    msg1 = "This is not a match."
-    msg2 = "Another unmatched warning."
-    unmatched = rf"{category.__name__}\('{msg1}'\), {category.__name__}\('{msg2}'\)"
+def test_fail_to_match_1():
+    category = RuntimeWarning
+    match = "Did not see this warning"
+    unmatched = r"Did not see warning 'RuntimeWarning' matching 'Did not see this warning'. "\
+        r"The emitted warning messages are \[RuntimeWarning\('This is not a match.'\),"\
+        r" RuntimeWarning\('Another unmatched warning.'\)\]"
     with pytest.raises(AssertionError, match=unmatched):
         with tm.assert_produces_warning(category, match=match):
-            warnings.warn(msg1, category)
-            warnings.warn(msg2, category)
+            warnings.warn("This is not a match.", category)
+            warnings.warn("Another unmatched warning.", category)
+
+
+def test_fail_to_match_2():
+    category = FutureWarning
+    match = "Warning"
+    unmatched = r"Did not see warning 'FutureWarning' matching 'Warning'. "\
+        r"The emitted warning messages are \[FutureWarning\('This is not a match.'\),"\
+        r" FutureWarning\('Another unmatched warning.'\)\]"
+    with pytest.raises(AssertionError, match=unmatched):
+        with tm.assert_produces_warning(category, match=match):
+            warnings.warn("This is not a match.", category)
+            warnings.warn("Another unmatched warning.", category)
+
+
+def test_fail_to_match_3():
+    category = ResourceWarning
+    match = r"\d+"
+    unmatched = r"Did not see warning 'ResourceWarning' matching '\\d\+'. "\
+        r"The emitted warning messages are \[ResourceWarning\('This is not a match.'\),"\
+        r" ResourceWarning\('Another unmatched warning.'\)\]"
+    with pytest.raises(AssertionError, match=unmatched):
+        with tm.assert_produces_warning(category, match=match):
+            warnings.warn("This is not a match.", category)
+            warnings.warn("Another unmatched warning.", category)
 
 
 def test_fail_to_catch_actual_warning(pair_different_warnings):


### PR DESCRIPTION
- [x] closes #[42103](https://github.com/pandas-dev/pandas/issues/42103)
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

I didn't add anything to the whatsnew file, as it seems it's not always necessary depending on the change?

Error message for a failed assert_produces_warning(match=". . .") now looks like e.g.:
```
Did not see warning 'DtypeWarning' matching 'Warning'. The emitted warning messages are [DtypeWarning('This is not a match.'), DtypeWarning('Another unmatched warning.')]
```

Thanks for any feedback if I've done something wrong here.