### PR TITLE
CLN: remove redundant _get_unique_index

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2752,16 +2752,6 @@ class Index(IndexOpsMixin, PandasObject):
             return np.zeros(len(self), dtype=bool)
         return self._duplicated(keep=keep)
 
-    def _get_unique_index(self: _IndexT) -> _IndexT:
-        """
-        Returns an index containing unique values.
-
-        Returns
-        -------
-        Index
-        """
-        return self.unique()
-
     # --------------------------------------------------------------------
     # Arithmetic & Logical Methods
 
@@ -3198,7 +3188,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     def _difference(self, other, sort):
 
-        this = self._get_unique_index()
+        this = self.unique()
 
         indexer = this.get_indexer_for(other)
         indexer = indexer.take((indexer != -1).nonzero()[0])

--- a/pandas/core/indexes/extension.py
+++ b/pandas/core/indexes/extension.py
@@ -364,13 +364,6 @@ class ExtensionIndex(Index):
         """
         return self._data._validate_setitem_value(value)
 
-    def _get_unique_index(self):
-        if self.is_unique:
-            return self
-
-        result = self._data.unique()
-        return type(self)._simple_new(result, name=self.name)
-
     @doc(Index.map)
     def map(self, mapper, na_action=None):
         # Try to run function on index first, and then on elements of index

--- a/pandas/tests/indexes/multi/test_duplicates.py
+++ b/pandas/tests/indexes/multi/test_duplicates.py
@@ -74,15 +74,6 @@ def test_unique_level(idx, level):
     tm.assert_index_equal(result, expected)
 
 
-def test_get_unique_index(idx):
-    mi = idx[[0, 1, 0, 1, 1, 0, 0]]
-    expected = mi._shallow_copy(mi[[0, 1]])
-
-    result = mi._get_unique_index()
-    assert result.unique
-    tm.assert_index_equal(result, expected)
-
-
 def test_duplicate_multiindex_codes():
     # GH 17464
     # Make sure that a MultiIndex with duplicate levels throws a ValueError

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -126,7 +126,7 @@ class TestCommon:
         new_copy = index.copy(deep=True, name="banana")
         assert new_copy.name == "banana"
 
-    def test_unique(self, index_flat):
+    def test_unique_level(self, index_flat):
         # don't test a MultiIndex here (as its tested separated)
         index = index_flat
 
@@ -147,7 +147,7 @@ class TestCommon:
         with pytest.raises(KeyError, match=msg):
             index.unique(level="wrong")
 
-    def test_get_unique_index(self, index_flat):
+    def test_unique(self, index_flat):
         # MultiIndex tested separately
         index = index_flat
         if not len(index):
@@ -164,7 +164,7 @@ class TestCommon:
         except NotImplementedError:
             pass
 
-        result = idx._get_unique_index()
+        result = idx.unique()
         tm.assert_index_equal(result, idx_unique)
 
         # nans:
@@ -195,7 +195,7 @@ class TestCommon:
 
         expected = idx_unique_nan
         for i in [idx_nan, idx_unique_nan]:
-            result = i._get_unique_index()
+            result = i.unique()
             tm.assert_index_equal(result, expected)
 
     def test_searchsorted_monotonic(self, index_flat):


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
