### PR TITLE
DOC: Correct docstring for Series.apply

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4204,7 +4204,7 @@ Keep all original rows and also all original values
         convert_dtype : bool, default True
             Try to find better dtype for elementwise function results. If
             False, leave as dtype=object. Note that the dtype is always
-            preserved for extension array dtypes, such as Categorical.
+            preserved for some extension array dtypes, such as Categorical.
         args : tuple
             Positional arguments passed to func after the series value.
         **kwargs


### PR DESCRIPTION
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

Ref: https://github.com/pandas-dev/pandas/pull/39941#issuecomment-829604511 and the conversation preceding it. While I don't find @MarcoGorelli's suggestion as implemented here very clear, it at least makes it correct and I don't see a better way.