### PR TITLE
BUG: UInt64Index construction casting to float64

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -142,7 +142,7 @@ Numeric
 
 Conversion
 ^^^^^^^^^^
-- Bug in :class:`UInt64Index` constructor when passing a list containing both positive integers small enough to cast to int64 and integers too large too hold in int64 (:issue:`??`)
+- Bug in :class:`UInt64Index` constructor when passing a list containing both positive integers small enough to cast to int64 and integers too large too hold in int64 (:issue:`42201`)
 -
 
 Strings

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -142,7 +142,7 @@ Numeric
 
 Conversion
 ^^^^^^^^^^
--
+- Bug in :class:`UInt64Index` constructor when passing a list containing both positive integers small enough to cast to int64 and integers too large too hold in int64 (:issue:`??`)
 -
 
 Strings

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -153,7 +153,12 @@ class NumericIndex(Index):
             if not isinstance(data, (ABCSeries, list, tuple)):
                 data = list(data)
 
+            orig = data
             data = np.asarray(data, dtype=dtype)
+            if dtype is None and data.dtype.kind == "f":
+                if cls is UInt64Index and (data >= 0).all():
+                    # https://github.com/numpy/numpy/issues/19146
+                    data = np.asarray(orig, dtype=np.uint64)
 
         if issubclass(data.dtype.type, str):
             cls._string_data_error(data)

--- a/pandas/tests/indexes/numeric/test_numeric.py
+++ b/pandas/tests/indexes/numeric/test_numeric.py
@@ -2,10 +2,6 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs import Timestamp
-from pandas.compat import (
-    is_platform_arm,
-    is_platform_mac,
-)
 
 import pandas as pd
 from pandas import (
@@ -535,10 +531,6 @@ class TestUInt64Index(NumericInt):
         res = Index([1, 2 ** 63 + 1], dtype=dtype)
         tm.assert_index_equal(res, idx)
 
-    @pytest.mark.xfail(
-        not (is_platform_arm() and is_platform_mac()),
-        reason="https://github.com/numpy/numpy/issues/19146",
-    )
     def test_constructor_does_not_cast_to_float(self):
         # https://github.com/numpy/numpy/issues/19146
         values = [0, np.iinfo(np.uint64).max]


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
