### PR TITLE
CI: pin more fsspec

### DIFF
--- a/ci/deps/actions-37-slow.yaml
+++ b/ci/deps/actions-37-slow.yaml
@@ -14,7 +14,7 @@ dependencies:
 
   # pandas dependencies
   - beautifulsoup4
-  - fsspec>=0.7.4
+  - fsspec>=0.7.4, <2021.6.0
   - html5lib
   - lxml
   - matplotlib

--- a/ci/deps/actions-38-slow.yaml
+++ b/ci/deps/actions-38-slow.yaml
@@ -13,7 +13,7 @@ dependencies:
 
   # pandas dependencies
   - beautifulsoup4
-  - fsspec>=0.7.4
+  - fsspec>=0.7.4, <2021.6.0
   - html5lib
   - lxml
   - matplotlib

--- a/ci/deps/azure-windows-38.yaml
+++ b/ci/deps/azure-windows-38.yaml
@@ -17,7 +17,7 @@ dependencies:
   - bottleneck
   - fastparquet>=0.4.0
   - flask
-  - fsspec>=0.8.0
+  - fsspec>=0.8.0, <2021.6.0
   - matplotlib=3.1.3
   - moto>=1.3.14
   - numba


### PR DESCRIPTION
Not sure why the new failing azure build picked up the new version later, but looks like under same umbrella as #42026
