### PR TITLE
REF: move short-circuiting up to get_indexer

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3423,11 +3423,18 @@ class Index(IndexOpsMixin, PandasObject):
 
             return ensure_platform_int(indexer)
 
+        if len(target) == 0:
+            return np.array([], dtype=np.intp)
+
         pself, ptarget = self._maybe_promote(target)
         if pself is not self or ptarget is not target:
             return pself.get_indexer(
                 ptarget, method=method, limit=limit, tolerance=tolerance
             )
+
+        if is_dtype_equal(self.dtype, target.dtype) and self.equals(target):
+            # Only call equals if we have same dtype to avoid inference/casting
+            return np.arange(len(target), dtype=np.intp)
 
         return self._get_indexer(target, method, limit, tolerance)
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -646,10 +646,6 @@ class IntervalIndex(ExtensionIndex):
         # returned ndarray is np.intp
 
         if isinstance(target, IntervalIndex):
-            # equal indexes -> 1:1 positional match
-            if self.equals(target):
-                return np.arange(len(self), dtype="intp")
-
             if not self._should_compare(target):
                 return self._get_indexer_non_comparable(target, method, unique=True)
 

--- a/pandas/tests/libs/test_hashtable.py
+++ b/pandas/tests/libs/test_hashtable.py
@@ -252,9 +252,9 @@ def test_get_labels_groupby_for_Int64(writable):
     vals = np.array([1, 2, -1, 2, 1, -1], dtype=np.int64)
     vals.flags.writeable = writable
     arr, unique = table.get_labels_groupby(vals)
-    expected_arr = np.array([0, 1, -1, 1, 0, -1], dtype=np.int64)
+    expected_arr = np.array([0, 1, -1, 1, 0, -1], dtype=np.intp)
     expected_unique = np.array([1, 2], dtype=np.int64)
-    tm.assert_numpy_array_equal(arr.astype(np.int64), expected_arr)
+    tm.assert_numpy_array_equal(arr, expected_arr)
     tm.assert_numpy_array_equal(unique, expected_unique)
 
 


### PR DESCRIPTION
This is the last of the boilerplate-cleanups I have for get_indexer, with some additional CLN thrown in for good measure.