### PR TITLE
PERF: Avoid copy in DataFrame._reduce corner cases

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9810,8 +9810,12 @@ NaN 12.3   33.0
                 FutureWarning,
                 stacklevel=5,
             )
-            cols = self.columns[~dtype_is_dt]
-            self = self[cols]
+            # Non-copy equivalent to
+            #  cols = self.columns[~dtype_is_dt]
+            #  self = self[cols]
+            predicate = lambda x: not is_datetime64_any_dtype(x.dtype)
+            mgr = self._mgr._get_data_subset(predicate)
+            self = type(self)(mgr)
 
         # TODO: Make other agg func handle axis=None properly GH#21597
         axis = self._get_axis_number(axis)

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -479,6 +479,10 @@ class BaseBlockManager(DataManager):
 
         return False
 
+    def _get_data_subset(self: T, predicate: Callable) -> T:
+        blocks = [blk for blk in self.blocks if predicate(blk.values)]
+        return self._combine(blocks, copy=False)
+
     def get_bool_data(self: T, copy: bool = False) -> T:
         """
         Select blocks that are bool-dtype and columns from object-dtype blocks


### PR DESCRIPTION
This implements BlockManager._get_data_subset (which ArrayManager already has) to avoid making a copy in a `DataFrame.__getitem__` usage inside DataFrame._reduce.

This path is deprecated so this snippet will be removed in 2.0.

