### PR TITLE
TST/CI: Reduce number of unnecessary numba tests in groupby ops

### DIFF
--- a/pandas/tests/groupby/conftest.py
+++ b/pandas/tests/groupby/conftest.py
@@ -137,13 +137,17 @@ def parallel(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
+# Can parameterize nogil & nopython over True | False, but limiting per
+# https://github.com/pandas-dev/pandas/pull/41971#issuecomment-860607472
+
+
+@pytest.fixture(params=[False])
 def nogil(request):
     """nogil keyword argument for numba.jit"""
     return request.param
 
 
-@pytest.fixture(params=[True, False])
+@pytest.fixture(params=[True])
 def nopython(request):
     """nopython keyword argument for numba.jit"""
     return request.param


### PR DESCRIPTION
- [x] closes #42236
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

Limiting the numba `engine_kwargs` parameterization for groupby tests similar to #42024

cc @mzeitlin11 