### PR TITLE
PERF/ENH: allow Generator in sampling methods

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -29,7 +29,7 @@ enhancement2
 
 Other enhancements
 ^^^^^^^^^^^^^^^^^^
--
+- :meth:`Series.sample`, :meth:`DataFrame.sample`, and :meth:`.GroupBy.sample` now accept a ``np.random.Generator`` as input to ``random_state``. A generator will be more performant, especially with ``replace=False`` (:issue:`38100`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -122,9 +122,17 @@ Ordered = Optional[bool]
 JSONSerializable = Optional[Union[PythonScalar, List, Dict]]
 Frequency = Union[str, "DateOffset"]
 Axes = Collection[Any]
-RandomState = Union[
-    int, ArrayLike, np.random.Generator, np.random.BitGenerator, np.random.RandomState
-]
+
+if TYPE_CHECKING:
+    RandomState = Union[
+        int,
+        ArrayLike,
+        np.random.Generator,
+        np.random.BitGenerator,
+        np.random.RandomState,
+    ]
+else:
+    RandomState = Union[int, ArrayLike, np.random.Generator, np.random.RandomState]
 
 # dtypes
 NpDtype = Union[str, np.dtype]

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -122,7 +122,9 @@ Ordered = Optional[bool]
 JSONSerializable = Optional[Union[PythonScalar, List, Dict]]
 Frequency = Union[str, "DateOffset"]
 Axes = Collection[Any]
-RandomState = Union[int, ArrayLike, np.random.Generator, np.random.RandomState]
+RandomState = Union[
+    int, ArrayLike, np.random.Generator, np.random.BitGenerator, np.random.RandomState
+]
 
 # dtypes
 NpDtype = Union[str, np.dtype]

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -126,6 +126,7 @@ JSONSerializable = Optional[Union[PythonScalar, List, Dict]]
 Frequency = Union[str, "DateOffset"]
 Axes = Collection[Any]
 
+# BitGenerator isn't exposed until 1.18
 if TYPE_CHECKING:
     RandomState = Union[
         int,
@@ -134,8 +135,6 @@ if TYPE_CHECKING:
         np.random.BitGenerator,
         np.random.RandomState,
     ]
-else:
-    RandomState = Union[int, ArrayLike, np.random.Generator, np.random.RandomState]
 
 # dtypes
 NpDtype = Union[str, np.dtype]

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -32,7 +32,6 @@ from pandas._typing import (
     AnyArrayLike,
     ArrayLike,
     NpDtype,
-    RandomState,
     Scalar,
     T,
 )
@@ -54,6 +53,9 @@ from pandas.core.dtypes.inference import iterable_not_string
 from pandas.core.dtypes.missing import isna
 
 if TYPE_CHECKING:
+    # Includes BitGenerator, which only exists >= 1.18
+    from pandas._typing import RandomState
+
     from pandas import Index
 
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -403,7 +403,7 @@ def random_state(
     ...
 
 
-def random_state(state: RandomState | None):
+def random_state(state: RandomState | None = None):
     """
     Helper function for processing random_state arguments.
 
@@ -421,9 +421,11 @@ def random_state(state: RandomState | None):
             array-like and BitGenerator object now passed to np.random.RandomState()
             as seed
 
+        Default None.
+
     Returns
     -------
-    np.random.RandomState or np.random.Generator
+    np.random.RandomState or np.random.Generator. If state is None, returns np.random
 
     """
     if (

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -21,6 +21,7 @@ from typing import (
     Iterable,
     Iterator,
     cast,
+    overload,
 )
 import warnings
 
@@ -29,6 +30,7 @@ import numpy as np
 from pandas._libs import lib
 from pandas._typing import (
     AnyArrayLike,
+    ArrayLike,
     NpDtype,
     RandomState,
     Scalar,
@@ -389,16 +391,28 @@ def standardize_mapping(into):
     return into
 
 
-def random_state(state: RandomState | None = None) -> np.random.RandomState:
+@overload
+def random_state(state: np.random.Generator) -> np.random.Generator:
+    ...
+
+
+@overload
+def random_state(
+    state: int | ArrayLike | np.random.BitGenerator | np.random.RandomState | None,
+) -> np.random.RandomState:
+    ...
+
+
+def random_state(state: RandomState | None):
     """
     Helper function for processing random_state arguments.
 
     Parameters
     ----------
-    state : int, array-like, BitGenerator, np.random.RandomState, None.
+    state : int, array-like, BitGenerator, Generator, np.random.RandomState, None.
         If receives an int, array-like, or BitGenerator, passes to
         np.random.RandomState() as seed.
-        If receives an np.random.RandomState object, just returns object.
+        If receives an np.random RandomState or Generator, just returns that unchanged.
         If receives `None`, returns np.random.
         If receives anything else, raises an informative ValueError.
 
@@ -407,11 +421,9 @@ def random_state(state: RandomState | None = None) -> np.random.RandomState:
             array-like and BitGenerator object now passed to np.random.RandomState()
             as seed
 
-        Default None.
-
     Returns
     -------
-    np.random.RandomState or np.random if state is None
+    np.random.RandomState or np.random.Generator
 
     """
     if (
@@ -434,12 +446,13 @@ def random_state(state: RandomState | None = None) -> np.random.RandomState:
         return np.random.RandomState(state)  # type: ignore[arg-type]
     elif isinstance(state, np.random.RandomState):
         return state
+    elif isinstance(state, np.random.Generator):
+        return state
     elif state is None:
-        # error: Incompatible return value type (got Module, expected "RandomState")
-        return np.random  # type: ignore[return-value]
+        return np.random
     else:
         raise ValueError(
-            "random_state must be an integer, array-like, a BitGenerator, "
+            "random_state must be an integer, array-like, a BitGenerator, Generator, "
             "a numpy RandomState, or None"
         )
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5178,14 +5178,19 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             If weights do not sum to 1, they will be normalized to sum to 1.
             Missing values in the weights column will be treated as zero.
             Infinite values not allowed.
-        random_state : int, array-like, BitGenerator, np.random.RandomState, optional
-            If int, array-like, or BitGenerator, seed for random number generator.
-            If np.random.RandomState, use as numpy RandomState object.
+        random_state : int, array-like, BitGenerator, np.random.RandomState,
+            np.random.Generator, optional. If int, array-like, or BitGenerator, seed for
+            random number generator. If np.random.RandomState or np.random.Generator,
+            use as given.
 
             .. versionchanged:: 1.1.0
 
-                array-like and BitGenerator (for NumPy>=1.17) object now passed to
-                np.random.RandomState() as seed
+                array-like and BitGenerator object now passed to np.random.RandomState()
+                as seed
+
+            .. versionchanged:: 1.4.0
+
+                np.random.Generator objects now accepted
 
         axis : {0 or ‘index’, 1 or ‘columns’, None}, default None
             Axis to sample. Accepts axis number or name. Default is stat axis

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -46,7 +46,6 @@ from pandas._typing import (
     JSONSerializable,
     Level,
     Manager,
-    RandomState,
     Renamer,
     StorageOptions,
     T,
@@ -158,6 +157,7 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from pandas._libs.tslibs import BaseOffset
+    from pandas._typing import RandomState
 
     from pandas.core.frame import DataFrame
     from pandas.core.resample import Resampler

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -3211,9 +3211,14 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
             sampling probabilities after normalization within each group.
             Values must be non-negative with at least one positive element
             within each group.
-        random_state : int, array-like, BitGenerator, np.random.RandomState, optional
-            If int, array-like, or BitGenerator, seed for random number generator.
-            If np.random.RandomState, use as numpy RandomState object.
+        random_state : int, array-like, BitGenerator, np.random.RandomState,
+            np.random.Generator, optional. If int, array-like, or BitGenerator, seed for
+            random number generator. If np.random.RandomState or np.random.Generator,
+            use as given.
+
+            .. versionchanged:: 1.4.0
+
+                np.random.Generator objects now accepted
 
         Returns
         -------

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -47,7 +47,6 @@ from pandas._typing import (
     FrameOrSeries,
     FrameOrSeriesUnion,
     IndexLabel,
-    RandomState,
     Scalar,
     T,
     final,
@@ -112,6 +111,8 @@ from pandas.core.util.numba_ import (
 
 if TYPE_CHECKING:
     from typing import Literal
+
+    from pandas._typing import RandomState
 
 _common_see_also = """
         See Also

--- a/pandas/core/sample.py
+++ b/pandas/core/sample.py
@@ -109,7 +109,7 @@ def sample(
     size: int,
     replace: bool,
     weights: np.ndarray | None,
-    random_state: np.random.RandomState,
+    random_state: np.random.RandomState | np.random.Generator,
 ) -> np.ndarray:
     """
     Randomly sample `size` indices in `np.arange(obj_len)`
@@ -125,7 +125,7 @@ def sample(
     weights : np.ndarray[np.float64] or None
         If None, equal probability weighting, otherwise weights according
         to the vector normalized
-    random_state: np.random.RandomState
+    random_state: np.random.RandomState or np.random.Generator
         State used for the random sampling
 
     Returns

--- a/pandas/tests/frame/methods/test_sample.py
+++ b/pandas/tests/frame/methods/test_sample.py
@@ -71,8 +71,8 @@ class TestSample:
     def test_sample_invalid_random_state(self, obj):
         # Check for error when random_state argument invalid.
         msg = (
-            "random_state must be an integer, array-like, a BitGenerator, a numpy "
-            "RandomState, or None"
+            "random_state must be an integer, array-like, a BitGenerator, Generator, "
+            "a numpy RandomState, or None"
         )
         with pytest.raises(ValueError, match=msg):
             obj.sample(random_state="a_string")
@@ -176,6 +176,22 @@ class TestSample:
         result = obj.sample(n=3, random_state=eval(func_str)(arg))
         expected = obj.sample(n=3, random_state=com.random_state(eval(func_str)(arg)))
         tm.assert_equal(result, expected)
+
+    def test_sample_generator(self, frame_or_series):
+        # GH#38100
+        obj = frame_or_series(np.arange(100))
+        rng = np.random.default_rng()
+
+        # Consecutive calls should advance the seed
+        result1 = obj.sample(n=50, random_state=rng)
+        result2 = obj.sample(n=50, random_state=rng)
+        assert not (result1.index.values == result2.index.values).all()
+
+        # Matching generator initialization must give same result
+        # Consecutive calls should advance the seed
+        result1 = obj.sample(n=50, random_state=np.random.default_rng(11))
+        result2 = obj.sample(n=50, random_state=np.random.default_rng(11))
+        tm.assert_equal(result1, result2)
 
     def test_sample_upsampling_without_replacement(self, frame_or_series):
         # GH#27451

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -84,7 +84,7 @@ def test_random_state():
 
     # Error for floats or strings
     msg = (
-        "random_state must be an integer, array-like, a BitGenerator, "
+        "random_state must be an integer, array-like, a BitGenerator, Generator, "
         "a numpy RandomState, or None"
     )
     with pytest.raises(ValueError, match=msg):


### PR DESCRIPTION
- [x] closes #38100 
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

The perf gap is pretty crazy:

```

In [10]: rng = np.random.default_rng()

In [11]: ser = pd.Series(np.zeros(10 ** 6))

In [12]: %timeit ser.sample(n=10 ** 4)
13.8 ms ± 231 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [13]: %timeit ser.sample(n=10 ** 4, random_state=rng)
569 µs ± 8.11 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

```

Leaving #28440 open because I think the end goal should still be to make using these the default. But assuming that change isn't too easy since will be a breaking change?