### PR TITLE
Updated the return type section of to_datetime 

### DIFF
--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -765,7 +765,7 @@ def to_datetime(
         - list-like: DatetimeIndex
         - Series: Series of datetime64 dtype
         - scalar: Timestamp
-        - list-like with mixed timezones: Index of object
+        - list-like with mixed timezones: Index of object dtype
 
         In case when it is not possible to return designated types (e.g. when
         any element of input is before Timestamp.min or after Timestamp.max)

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -768,7 +768,6 @@ def to_datetime(
         - Series: Series of datetime64 dtype
         - scalar: Timestamp
 
-
         In case when it is not possible to return designated types (e.g. when
         any element of input is before Timestamp.min or after Timestamp.max)
         return will have datetime.datetime type (or corresponding

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -764,7 +764,7 @@ def to_datetime(
 
         - list-like:
             - DatetimeIndex, if timezone naive or aware with the same timezone
-            - Index of object dtype, if timezone aware with mixed timezones
+            - Index of object dtype, if timezone aware with mixed time offsets
         - Series: Series of datetime64 dtype
         - scalar: Timestamp
 

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -765,6 +765,7 @@ def to_datetime(
         - list-like: DatetimeIndex
         - Series: Series of datetime64 dtype
         - scalar: Timestamp
+        - list-like with mixed timezones: Index of object
 
         In case when it is not possible to return designated types (e.g. when
         any element of input is before Timestamp.min or after Timestamp.max)

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -762,10 +762,12 @@ def to_datetime(
         If parsing succeeded.
         Return type depends on input:
 
-        - list-like: DatetimeIndex
+        - list-like:
+            - DatetimeIndex, if timezone naive or aware with the same timezone
+            - Index of object dtype, if timezone aware with mixed timezones
         - Series: Series of datetime64 dtype
         - scalar: Timestamp
-        - list-like with mixed timezones: Index of object dtype
+
 
         In case when it is not possible to return designated types (e.g. when
         any element of input is before Timestamp.min or after Timestamp.max)


### PR DESCRIPTION
Updated the return type section of to_datetime to include list-like mixed timezone inputs

- [x] closes #42229
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry - Updated the return type section of to_datetime to include list-like mixed timezone inputs
