### PR TITLE
REGR: groupby with as_index=False on an empty frame

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1676,7 +1676,8 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
     def _wrap_agged_manager(self, mgr: Manager2D) -> DataFrame:
         if not self.as_index:
-            index = Index(range(mgr.shape[1]))
+            rows = mgr.shape[1] if not mgr.shape[0] == 0 else 0
+            index = Index(range(rows))
             mgr.set_axis(1, index)
             result = self.obj._constructor(mgr)
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1676,6 +1676,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
     def _wrap_agged_manager(self, mgr: Manager2D) -> DataFrame:
         if not self.as_index:
+            # GH 41998 - empty mgr always gets index of length 0
             rows = mgr.shape[1] if mgr.shape[0] > 0 else 0
             index = Index(range(rows))
             mgr.set_axis(1, index)

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1676,7 +1676,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
     def _wrap_agged_manager(self, mgr: Manager2D) -> DataFrame:
         if not self.as_index:
-            rows = mgr.shape[1] if not mgr.shape[0] == 0 else 0
+            rows = mgr.shape[1] if mgr.shape[0] > 0 else 0
             index = Index(range(rows))
             mgr.set_axis(1, index)
             result = self.obj._constructor(mgr)

--- a/pandas/tests/groupby/conftest.py
+++ b/pandas/tests/groupby/conftest.py
@@ -12,6 +12,11 @@ from pandas.core.groupby.base import (
 )
 
 
+@pytest.fixture(params=[True, False])
+def as_index(request):
+    return request.param
+
+
 @pytest.fixture
 def mframe():
     index = MultiIndex(


### PR DESCRIPTION
- [x] closes #41998
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

No whatsnew because this was introduced in 1.3
