### PR TITLE
ENH: Create directories when missing in to_* methods

### DIFF
--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -957,11 +957,17 @@ def dir_exists(filepath_or_buffer: FilePathOrBuffer) -> bool:
     filepath_or_buffer = stringify_path(filepath_or_buffer)
     if not isinstance(filepath_or_buffer, str):
         return exists
-    try:
-        exists = os.path.exists(os.path.dirname(filepath_or_buffer))
-        # gh-5874: if the filepath is too long will raise here
-    except (TypeError, ValueError):
-        pass
+
+    dirname = os.path.dirname(filepath_or_buffer)
+    if not len(dirname):
+        # This is the current working directory
+        exists = True
+    else:
+        try:
+            exists = os.path.exists(dirname)
+            # gh-5874: if the filepath is too long will raise here
+        except (TypeError, ValueError):
+            pass
     return exists
 
 

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -635,9 +635,9 @@ def get_handle(
 
     # If the parent directory doesn't exist initializing the stream will fail (GH 24306)
     if (
-        _is_writable_mode(mode)
-        and is_path
+        is_path
         and not ioargs.parent_exists
+        and _is_writable_mode(mode)
     ):
         os.makedirs(
             os.path.dirname(ioargs.filepath_or_buffer),

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -635,9 +635,9 @@ def get_handle(
 
     # If the parent directory doesn't exist initializing the stream will fail (GH 24306)
     if (
-            _is_writable_mode(mode)
-            and is_path
-            and not ioargs.parent_exists
+        _is_writable_mode(mode)
+        and is_path
+        and not ioargs.parent_exists
     ):
         os.makedirs(
             os.path.dirname(ioargs.filepath_or_buffer),

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -533,3 +533,16 @@ def test_errno_attribute():
     with pytest.raises(FileNotFoundError, match="\\[Errno 2\\]") as err:
         pd.read_csv("doesnt_exist")
         assert err.errno == errno.ENOENT
+
+
+def test_create_missing_dirs():
+    # GH 24306
+    df = tm.makeDataFrame()
+    filepath = 'nonexistent/path/to/file.csv'
+    df.to_csv(filepath)
+    assert os.path.exists(filepath)
+    # Cleanup after test:
+    os.remove(filepath)
+    components = filepath.split('/')
+    for i in reversed(range(1, len(components))):
+        os.rmdir(os.path.join(*components[:i]))

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -538,11 +538,7 @@ def test_errno_attribute():
 def test_create_missing_dirs():
     # GH 24306
     df = tm.makeDataFrame()
-    filepath = 'nonexistent/path/to/file.csv'
-    df.to_csv(filepath)
-    assert os.path.exists(filepath)
-    # Cleanup after test:
-    os.remove(filepath)
-    components = filepath.split('/')
-    for i in reversed(range(1, len(components))):
-        os.rmdir(os.path.join(*components[:i]))
+    with tm.ensure_clean() as fp:
+        full_path = os.path.join(fp, '/nonexistent/path/to/file.csv')
+        df.to_csv(full_path)
+        assert os.path.exists(full_path)

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -538,7 +538,7 @@ def test_errno_attribute():
 def test_create_missing_dirs():
     # GH 24306
     df = tm.makeDataFrame()
-    with tm.ensure_clean() as fp:
-        full_path = os.path.join(fp, '/nonexistent/path/to/file.csv')
+    with tm.ensure_clean_dir() as fp:
+        full_path = os.path.join(fp, 'nonexistent/path/to/file.csv')
         df.to_csv(full_path)
         assert os.path.exists(full_path)

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -737,8 +737,6 @@ class TestParquetPyArrow(Base):
         monkeypatch.setenv("USERPROFILE", "TestingUser")
         with pytest.raises(OSError, match=r".*TestingUser.*"):
             read_parquet("~/file.parquet")
-        with pytest.raises(OSError, match=r".*TestingUser.*"):
-            df_compat.to_parquet("~/file.parquet")
 
     def test_partition_cols_supported(self, pa, df_full):
         # GH #23283

--- a/pandas/tests/io/xml/test_to_xml.py
+++ b/pandas/tests/io/xml/test_to_xml.py
@@ -199,13 +199,6 @@ def test_str_output(datapath, parser):
     assert output == from_file_expected
 
 
-def test_wrong_file_path(parser):
-    with pytest.raises(
-        FileNotFoundError, match=("No such file or directory|没有那个文件或目录")
-    ):
-        geom_df.to_xml("/my/fake/path/output.xml", parser=parser)
-
-
 # INDEX
 
 


### PR DESCRIPTION
This is the most fundamental approach to creating new folders when a user specifies a path that is missing in file creation methods like `to_csv`, `to_excel`, `to_feather` etc. We can do this in [io/common.py:`get_handle()`](https://github.com/pandas-dev/pandas/blob/50a59bac1f2bcbf9ac87c7a4160d4355be512294/pandas/io/common.py#L521) conditionally when the file buffer provided is in a writable mode.

- [x] closes #24306
   - Can use the existing #42250 to extend documentation for each of the `to_*` methods (@Joeperdefloep)
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
