### PR TITLE
BUG: Fix to_datetime() cache behaviour to not omit duplicated output values

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -122,7 +122,7 @@ Categorical
 
 Datetimelike
 ^^^^^^^^^^^^
--
+- Bug in :func:`to_datetime` returning pd.NaT for inputs that produce duplicated values, when ``cache=True`` (:issue:`42259`)
 -
 
 Timedelta

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -194,9 +194,9 @@ def _maybe_cache(
         if len(unique_dates) < len(arg):
             cache_dates = convert_listlike(unique_dates, format)
             cache_array = Series(cache_dates, index=unique_dates)
-            if not cache_array.is_unique:
+            if not cache_array.index.is_unique:
                 # GH#39882 in case of None and NaT we get duplicates
-                cache_array = cache_array.drop_duplicates()
+                cache_array = cache_array[~cache_array.index.unique()]
     return cache_array
 
 

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -194,10 +194,9 @@ def _maybe_cache(
         if len(unique_dates) < len(arg):
             cache_dates = convert_listlike(unique_dates, format)
             cache_array = Series(cache_dates, index=unique_dates)
+            # GH#39882 and GH#35888
             if not cache_array.index.is_unique:
-                cache_array = cache_array[
-                    ~cache_array.index.duplicated()
-                ]
+                cache_array = cache_array[~cache_array.index.duplicated()]
     return cache_array
 
 

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -195,8 +195,9 @@ def _maybe_cache(
             cache_dates = convert_listlike(unique_dates, format)
             cache_array = Series(cache_dates, index=unique_dates)
             if not cache_array.index.is_unique:
-                # GH#39882 in case of None and NaT we get duplicates
-                cache_array = cache_array[~cache_array.index.unique()]
+                cache_array = cache_array[
+                    ~cache_array.index.duplicated()
+                ]
     return cache_array
 
 

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -194,7 +194,7 @@ def _maybe_cache(
         if len(unique_dates) < len(arg):
             cache_dates = convert_listlike(unique_dates, format)
             cache_array = Series(cache_dates, index=unique_dates)
-            # GH#39882 and GH#35888
+            # GH#39882 and GH#35888 in case of None and NaT we get duplicates
             if not cache_array.index.is_unique:
                 cache_array = cache_array[~cache_array.index.duplicated()]
     return cache_array

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -969,10 +969,11 @@ class TestToDatetime:
                 (NaT, Timestamp("2012-07-26")) + (NaT,) * start_caching_at,
             ),
             (
-                (None, "2012 July 26", Timestamp("2012-07-26"))
-                + (NaT,) * start_caching_at,
-                (NaT, Timestamp("2012-07-26"), Timestamp("2012-07-26"))
-                + (NaT,) * start_caching_at,
+                (None,)
+                + (NaT,) * start_caching_at
+                + ("2012 July 26", Timestamp("2012-07-26")),
+                (NaT,) * (start_caching_at + 1)
+                + (Timestamp("2012-07-26"), Timestamp("2012-07-26")),
             ),
         ),
     )

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -8,7 +8,6 @@ from datetime import (
 )
 from decimal import Decimal
 import locale
-from typing import Any, List, Union
 
 from dateutil.parser import parse
 from dateutil.tz.tz import tzoffset
@@ -977,7 +976,9 @@ class TestToDatetime:
             ),
         ),
     )
-    def test_convert_object_to_datetime_with_cache(self, datetimelikes, expected_values):
+    def test_convert_object_to_datetime_with_cache(
+        self, datetimelikes, expected_values
+    ):
         # GH#39882
         ser = Series(
             datetimelikes,

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -959,7 +959,7 @@ class TestToDatetime:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "datetimelikes,expected",
+        "datetimelikes,expected_values",
         (
             (
                 (None, np.nan) + (NaT,) * start_caching_at,
@@ -977,7 +977,7 @@ class TestToDatetime:
             ),
         ),
     )
-    def test_convert_object_to_datetime_with_cache(self, datetimelikes, expected):
+    def test_convert_object_to_datetime_with_cache(self, datetimelikes, expected_values):
         # GH#39882
         ser = Series(
             datetimelikes,
@@ -985,7 +985,7 @@ class TestToDatetime:
         )
         result_series = to_datetime(ser, errors="coerce")
         expected_series = Series(
-            expected,
+            expected_values,
             dtype="datetime64[ns]",
         )
         tm.assert_series_equal(result_series, expected_series)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -957,26 +957,41 @@ class TestToDatetime:
         expected = Timestamp("20130101 00:00:00")
         assert result == expected
 
-    @pytest.mark.parametrize("datetime_likes, expected", [
+    @pytest.mark.parametrize(
+        "datetimelikes, expected",
+        [
+            (
+                [None] + [NaT] * start_caching_at + [np.nan],
+                [NaT] * (start_caching_at + 2),
+            ),
             (
                 [None] + [NaT] * start_caching_at + [Timestamp("2012-07-26")],
                 [NaT] * (start_caching_at + 1) + [Timestamp("2012-07-26")],
             ),
             (
-                [None] + [NaT] * start_caching_at + [Timestamp("2012-07-26"), "2012 July 26", "2012-07-26"],
-                [NaT] * (start_caching_at + 1) + [Timestamp("2012-07-26"), Timestamp("2012-07-26"), Timestamp("2012-07-26")],
-            )
-        ]
+                [None]
+                + [NaT] * start_caching_at
+                + [
+                    "2012 July 26",
+                    Timestamp("2012-07-26"),
+                ],
+                [NaT] * (start_caching_at + 1)
+                + [
+                    Timestamp("2012-07-26"),
+                    Timestamp("2012-07-26"),
+                ],
+            ),
+        ],
     )
-    def test_convert_object_to_datetime_with_cache(self, datetime_likes, expected):
+    def test_convert_object_to_datetime_with_cache(self, datetimelikes, expected):
         # GH#39882
         ser = Series(
-            datetime_likes,
+            datetimelikes,
             dtype="object",
         )
         result = to_datetime(ser, errors="coerce")
         expected = Series(
-            
+            expected,
             dtype="datetime64[ns]",
         )
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -957,15 +957,26 @@ class TestToDatetime:
         expected = Timestamp("20130101 00:00:00")
         assert result == expected
 
-    def test_convert_object_to_datetime_with_cache(self):
+    @pytest.mark.parametrize("datetime_likes, expected", [
+            (
+                [None] + [NaT] * start_caching_at + [Timestamp("2012-07-26")],
+                [NaT] * (start_caching_at + 1) + [Timestamp("2012-07-26")],
+            ),
+            (
+                [None] + [NaT] * start_caching_at + [Timestamp("2012-07-26"), "2012 July 26", "2012-07-26"],
+                [NaT] * (start_caching_at + 1) + [Timestamp("2012-07-26"), Timestamp("2012-07-26"), Timestamp("2012-07-26")],
+            )
+        ]
+    )
+    def test_convert_object_to_datetime_with_cache(self, datetime_likes, expected):
         # GH#39882
         ser = Series(
-            [None] + [NaT] * start_caching_at + [Timestamp("2012-07-26")],
+            datetime_likes,
             dtype="object",
         )
         result = to_datetime(ser, errors="coerce")
         expected = Series(
-            [NaT] * (start_caching_at + 1) + [Timestamp("2012-07-26")],
+            
             dtype="datetime64[ns]",
         )
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -8,6 +8,7 @@ from datetime import (
 )
 from decimal import Decimal
 import locale
+from typing import Any, List, Union
 
 from dateutil.parser import parse
 from dateutil.tz.tz import tzoffset
@@ -958,30 +959,23 @@ class TestToDatetime:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "datetimelikes, expected",
-        [
+        "datetimelikes,expected",
+        (
             (
-                [None] + [NaT] * start_caching_at + [np.nan],
-                [NaT] * (start_caching_at + 2),
+                (None, np.nan) + (NaT,) * start_caching_at,
+                (NaT,) * (start_caching_at + 2),
             ),
             (
-                [None] + [NaT] * start_caching_at + [Timestamp("2012-07-26")],
-                [NaT] * (start_caching_at + 1) + [Timestamp("2012-07-26")],
+                (None, Timestamp("2012-07-26")) + (NaT,) * start_caching_at,
+                (NaT, Timestamp("2012-07-26")) + (NaT,) * start_caching_at,
             ),
             (
-                [None]
-                + [NaT] * start_caching_at
-                + [
-                    "2012 July 26",
-                    Timestamp("2012-07-26"),
-                ],
-                [NaT] * (start_caching_at + 1)
-                + [
-                    Timestamp("2012-07-26"),
-                    Timestamp("2012-07-26"),
-                ],
+                (None, "2012 July 26", Timestamp("2012-07-26"))
+                + (NaT,) * start_caching_at,
+                (NaT, Timestamp("2012-07-26"), Timestamp("2012-07-26"))
+                + (NaT,) * start_caching_at,
             ),
-        ],
+        ),
     )
     def test_convert_object_to_datetime_with_cache(self, datetimelikes, expected):
         # GH#39882
@@ -989,12 +983,12 @@ class TestToDatetime:
             datetimelikes,
             dtype="object",
         )
-        result = to_datetime(ser, errors="coerce")
-        expected = Series(
+        result_series = to_datetime(ser, errors="coerce")
+        expected_series = Series(
             expected,
             dtype="datetime64[ns]",
         )
-        tm.assert_series_equal(result, expected)
+        tm.assert_series_equal(result_series, expected_series)
 
     @pytest.mark.parametrize(
         "date, format",


### PR DESCRIPTION
- [x] closes #42259 
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
