### PR TITLE
Set threadsafe behavior for numba parallelism

### DIFF
--- a/pandas/core/util/numba_.py
+++ b/pandas/core/util/numba_.py
@@ -11,6 +11,14 @@ from pandas.errors import NumbaUtilError
 
 from pandas.util.version import Version
 
+try:
+    # Reduce likelihood of segfaulting during parallelism
+    # https://github.com/numba/numba/issues/6839#issuecomment-868352174
+    numba = import_optional_dependency("numba")
+    numba.config.THREADING_LAYER = "threadsafe"
+except ImportError:
+    pass
+
 GLOBAL_USE_NUMBA: bool = False
 NUMBA_FUNC_CACHE: dict[tuple[Callable, str], Callable] = {}
 


### PR DESCRIPTION
- xref #https://github.com/numba/numba/issues/6839#issuecomment-867977583
- [x] tests added / passed

Applicable for 1.3.0 since this behavior can appear for the new `method="table"` feature for rolling/expanding

cc @jbrockmendel 
