### PR TITLE
CLN: simplify take2d_axis0 generated code

### DIFF
--- a/pandas/_libs/algos_take_helper.pxi.in
+++ b/pandas/_libs/algos_take_helper.pxi.in
@@ -109,32 +109,33 @@ def take_2d_axis0_{{name}}_{{dest}}(ndarray[{{c_type_in}}, ndim=2] values,
     cdef:
         Py_ssize_t i, j, k, n, idx
         {{c_type_out}} fv
+        {{if c_type_in == c_type_out != "object"}}
+        const {{c_type_out}} *v
+        {{c_type_out}} *o
+        {{endif}}
 
     n = len(indexer)
     k = values.shape[1]
 
     fv = fill_value
 
-    IF {{True if c_type_in == c_type_out != "object" else False}}:
-        cdef:
-            const {{c_type_out}} *v
-            {{c_type_out}} *o
+    {{if c_type_in == c_type_out != "object"}}
+    # GH#3130
+    if (values.strides[1] == out.strides[1] and
+        values.strides[1] == sizeof({{c_type_out}}) and
+        sizeof({{c_type_out}}) * n >= 256):
 
-        # GH#3130
-        if (values.strides[1] == out.strides[1] and
-            values.strides[1] == sizeof({{c_type_out}}) and
-            sizeof({{c_type_out}}) * n >= 256):
-
-            for i in range(n):
-                idx = indexer[i]
-                if idx == -1:
-                    for j in range(k):
-                        out[i, j] = fv
-                else:
-                    v = &values[idx, 0]
-                    o = &out[i, 0]
-                    memmove(o, v, <size_t>(sizeof({{c_type_out}}) * k))
-            return
+        for i in range(n):
+            idx = indexer[i]
+            if idx == -1:
+                for j in range(k):
+                    out[i, j] = fv
+            else:
+                v = &values[idx, 0]
+                o = &out[i, 0]
+                memmove(o, v, <size_t>(sizeof({{c_type_out}}) * k))
+        return
+    {{endif}}
 
     for i in range(n):
         idx = indexer[i]


### PR DESCRIPTION
For example, on master we generate:

```
@cython.wraparound(False)
@cython.boundscheck(False)
def take_2d_axis0_int8_int32(const int8_t[:, :] values,
                                    ndarray[intp_t] indexer,
                                    int32_t[:, :] out,
                                    fill_value=np.nan):
    cdef:
        Py_ssize_t i, j, k, n, idx
        int32_t fv

    n = len(indexer)
    k = values.shape[1]

    fv = fill_value

    IF False:
        cdef:
            const int32_t *v
            int32_t *o

        # GH#3130
        if (values.strides[1] == out.strides[1] and
            values.strides[1] == sizeof(int32_t) and
            sizeof(int32_t) * n >= 256):

            for i in range(n):
                idx = indexer[i]
                if idx == -1:
                    for j in range(k):
                        out[i, j] = fv
                else:
                    v = &values[idx, 0]
                    o = &out[i, 0]
                    memmove(o, v, <size_t>(sizeof(int32_t) * k))
            return

    for i in range(n):
        idx = indexer[i]
        if idx == -1:
            for j in range(k):
                out[i, j] = fv
        else:
            for j in range(k):
                out[i, j] = values[idx, j]
```

On this pr:

```
@cython.wraparound(False)
@cython.boundscheck(False)
def take_2d_axis0_int8_int32(const int8_t[:, :] values,
                                    ndarray[intp_t] indexer,
                                    int32_t[:, :] out,
                                    fill_value=np.nan):
    cdef:
        Py_ssize_t i, j, k, n, idx
        int32_t fv

    n = len(indexer)
    k = values.shape[1]

    fv = fill_value


    for i in range(n):
        idx = indexer[i]
        if idx == -1:
            for j in range(k):
                out[i, j] = fv
        else:
            for j in range(k):
                out[i, j] = values[idx, j]
```

Not too impactful since just generated code, but makes looking at all the take helpers clearer (and the file shorter).
