### PR TITLE
BUG: Series.loc[dtstr] type depends on monotonicity

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -158,7 +158,7 @@ Interval
 
 Indexing
 ^^^^^^^^
--
+- Bug in indexing on a :class:`Series` or :class:`DataFrame` with a :class:`DatetimeIndex` when passing a string, the return type depended on whether the index was monotonic (:issue:`24892`)
 -
 
 Missing

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -604,23 +604,8 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         return start, end
 
     def _can_partial_date_slice(self, reso: Resolution) -> bool:
-        assert isinstance(reso, Resolution), (type(reso), reso)
-        if (
-            self.is_monotonic
-            and reso.attrname in ["day", "hour", "minute", "second"]
-            and self._resolution_obj >= reso
-        ):
-            # These resolution/monotonicity validations came from GH3931,
-            # GH3452 and GH2369.
-
-            # See also GH14826
-            return False
-
-        if reso.attrname == "microsecond":
-            # _partial_date_slice doesn't allow microsecond resolution, but
-            # _parsed_string_to_bounds allows it.
-            return False
-        return True
+        # History of conversation GH#3452, GH#3931, GH#2369, GH#14826
+        return reso > self._resolution_obj
 
     def _deprecate_mismatched_indexing(self, key) -> None:
         # GH#36148


### PR DESCRIPTION
- [x] closes #24892
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

xref #42258 which makes the same change for PeriodIndex._can_partial_date_slice but its behavior-neutral there.

cc @mroeschke 