### PR TITLE
PERF: IntervalIndex.intersection

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3089,7 +3089,13 @@ class Index(IndexOpsMixin, PandasObject):
         """
         intersection specialized to the case with matching dtypes.
         """
-        if self.is_monotonic and other.is_monotonic:
+        if (
+            self.is_monotonic
+            and other.is_monotonic
+            and not is_interval_dtype(self.dtype)
+        ):
+            # For IntervalIndex _inner_indexer is not more performant than get_indexer,
+            #  so don't take this fastpath
             try:
                 result = self._inner_indexer(other)[0]
             except TypeError:


### PR DESCRIPTION
- [x] closes #42240
- [ ] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

```
import pandas as pd
import numpy as np

N = 10 ** 5
left = pd.IntervalIndex.from_breaks(np.arange(N))
right = pd.IntervalIndex.from_breaks(np.arange(N - 3, 2 * N - 3))

%timeit left.intersection(right)
146 ms ± 1.82 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)  # <- master
5.6 ms ± 277 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)  # <- PR
```

We're also going to get a nice bump in join_monotonic/_inner_indexer, but not big enough to warrant not-special-casing IntervalIndex's intersection.