### PR TITLE
DOC GH29075 close database connections after creation

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -5526,12 +5526,22 @@ below and the SQLAlchemy `documentation <https://docs.sqlalchemy.org/en/latest/c
    # Create your engine.
    engine = create_engine("sqlite:///:memory:")
 
-If you want to manage your own connections you can pass one of those instead:
+If you want to manage your own connections you can pass one of those instead. The example below opens a
+connection to the database using a Python context manager that automatically closes the connection after
+the block has completed.
+See the `SQLAlchemy docs <https://docs.sqlalchemy.org/en/latest/core/connections.html#basic-usage>`__
+for an explanation of how the database connection is handled.
 
 .. code-block:: python
 
    with engine.connect() as conn, conn.begin():
        data = pd.read_sql_table("data", conn)
+
+.. warning::
+
+	When you open a connection to a database you are also responsible for closing it.
+	Side effects of leaving a connection open may include locking the database or
+	other breaking behaviour.
 
 Writing DataFrames
 ''''''''''''''''''


### PR DESCRIPTION
- [x] closes #29075 
- [ ] whatsnew entry

I've expanded on the use of a context manager to handle the closing of the database connection after the connection has been opened. I've also included a warning at the end of the section highlighting problems with leaving the database connection open. I think these additions tackle the docs problem associated with this issue.

Whilst psycopg2 is supported through sqlalchemy it appears to not be explicitly supported in its own right. I linked to the section in the sqlalchemy docs which discusses what happens when you use a Python context manager to handle connecting to a database. Hopefully users will now have a better idea on how or why database connections are being made in the recommended manner and can access the relevant documentation quickly.