### PR TITLE
DOC: Only include numpy.std note for std, not all ddof methods

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10557,6 +10557,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             name1=name1,
             name2=name2,
             axis_descr=axis_descr,
+            notes="",
         )
         def sem(
             self,
@@ -10578,6 +10579,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             name1=name1,
             name2=name2,
             axis_descr=axis_descr,
+            notes="",
         )
         def var(
             self,
@@ -10600,6 +10602,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             name1=name1,
             name2=name2,
             axis_descr=axis_descr,
+            notes=_std_notes,
         )
         def std(
             self,
@@ -11090,12 +11093,16 @@ numeric_only : bool, default None
 
 Returns
 -------
-{name1} or {name2} (if level specified)
+{name1} or {name2} (if level specified) \
+{notes}
+"""
+
+_std_notes = """
 
 Notes
 -----
 To have the same behaviour as `numpy.std`, use `ddof=0` (instead of the
-default `ddof=1`)\n"""
+default `ddof=1`)"""
 
 _bool_doc = """
 {desc}


### PR DESCRIPTION
I noticed that this note was mistakenly added to all methods that use `num_ddof_doc`, e.g. including [`sem`](https://pandas.pydata.org/docs/reference/api/pandas.Series.sem.html), which is misleading - this statement is only true for `std`. This PR makes sure we only add the note in that case.
