### PR TITLE
BUG: `Styler.to_latex` now doesn't manipulate the `Styler` object.

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -136,7 +136,7 @@ which has been revised and improved (:issue:`39720`, :issue:`39317`, :issue:`404
  - Many features of the :class:`.Styler` class are now either partially or fully usable on a DataFrame with a non-unique indexes or columns (:issue:`41143`)
  - One has greater control of the display through separate sparsification of the index or columns using the :ref:`new styler options <options.available>`, which are also usable via :func:`option_context` (:issue:`41142`)
  - Added the option ``styler.render.max_elements`` to avoid browser overload when styling large DataFrames (:issue:`40712`)
- - Added the method :meth:`.Styler.to_latex` (:issue:`21673`), which also allows some limited CSS conversion (:issue:`40731`)
+ - Added the method :meth:`.Styler.to_latex` (:issue:`21673`, :issue:`42320`), which also allows some limited CSS conversion (:issue:`40731`)
  - Added the method :meth:`.Styler.to_html` (:issue:`13379`)
  - Added the method :meth:`.Styler.set_sticky` to make index and column headers permanently visible in scrolling HTML frames (:issue:`29072`)
 

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -709,6 +709,8 @@ class Styler(StylerRenderer):
         0 & {\bfseries}{\Huge{1}} \\
         \end{tabular}
         """
+        obj = self._copy(deepcopy=True)  # manipulate table_styles on obj, not self
+
         table_selectors = (
             [style["selector"] for style in self.table_styles]
             if self.table_styles is not None
@@ -717,7 +719,7 @@ class Styler(StylerRenderer):
 
         if column_format is not None:
             # add more recent setting to table_styles
-            self.set_table_styles(
+            obj.set_table_styles(
                 [{"selector": "column_format", "props": f":{column_format}"}],
                 overwrite=False,
             )
@@ -735,13 +737,13 @@ class Styler(StylerRenderer):
                     column_format += (
                         ("r" if not siunitx else "S") if ci in numeric_cols else "l"
                     )
-            self.set_table_styles(
+            obj.set_table_styles(
                 [{"selector": "column_format", "props": f":{column_format}"}],
                 overwrite=False,
             )
 
         if position:
-            self.set_table_styles(
+            obj.set_table_styles(
                 [{"selector": "position", "props": f":{position}"}],
                 overwrite=False,
             )
@@ -753,13 +755,13 @@ class Styler(StylerRenderer):
                     f"'raggedright', 'raggedleft', 'centering', "
                     f"got: '{position_float}'"
                 )
-            self.set_table_styles(
+            obj.set_table_styles(
                 [{"selector": "position_float", "props": f":{position_float}"}],
                 overwrite=False,
             )
 
         if hrules:
-            self.set_table_styles(
+            obj.set_table_styles(
                 [
                     {"selector": "toprule", "props": ":toprule"},
                     {"selector": "midrule", "props": ":midrule"},
@@ -769,20 +771,20 @@ class Styler(StylerRenderer):
             )
 
         if label:
-            self.set_table_styles(
+            obj.set_table_styles(
                 [{"selector": "label", "props": f":{{{label.replace(':', '§')}}}"}],
                 overwrite=False,
             )
 
         if caption:
-            self.set_caption(caption)
+            obj.set_caption(caption)
 
         if sparse_index is None:
             sparse_index = get_option("styler.sparse.index")
         if sparse_columns is None:
             sparse_columns = get_option("styler.sparse.columns")
 
-        latex = self._render_latex(
+        latex = obj._render_latex(
             sparse_index=sparse_index,
             sparse_columns=sparse_columns,
             multirow_align=multirow_align,

--- a/pandas/tests/io/formats/style/test_to_latex.py
+++ b/pandas/tests/io/formats/style/test_to_latex.py
@@ -489,3 +489,18 @@ def test_parse_latex_css_conversion_option():
     expected = [("command", "option--wrap")]
     result = _parse_latex_css_conversion(css)
     assert result == expected
+
+
+def test_styler_object_after_render(styler):
+    pre_render = styler._copy(deepcopy=True)
+    styler.to_latex(
+        column_format="rllr",
+        position="h",
+        position_float="centering",
+        hrules=True,
+        label="my lab",
+        caption="my cap",
+    )
+
+    assert pre_render.table_styles == styler.table_styles
+    assert pre_render.caption == styler.caption

--- a/pandas/tests/io/formats/style/test_to_latex.py
+++ b/pandas/tests/io/formats/style/test_to_latex.py
@@ -492,6 +492,7 @@ def test_parse_latex_css_conversion_option():
 
 
 def test_styler_object_after_render(styler):
+    # GH 42320
     pre_render = styler._copy(deepcopy=True)
     styler.to_latex(
         column_format="rllr",


### PR DESCRIPTION
- [x] closes #42320 
- [x] tests added / passed
- [x] whatsnew entry not needed if included in 1.3.0 (although will be needed for 1.3.1)
