### PR TITLE
DOC: Unsuppress relevant dataframe in split-apply-combine guide

### DIFF
--- a/doc/source/user_guide/groupby.rst
+++ b/doc/source/user_guide/groupby.rst
@@ -400,7 +400,7 @@ getting a column from a DataFrame, you can do:
            "D": np.random.randn(8),
        }
    )
-   
+
    df
 
    grouped = df.groupby(["A"])

--- a/doc/source/user_guide/groupby.rst
+++ b/doc/source/user_guide/groupby.rst
@@ -391,7 +391,6 @@ something different for each of the columns. Thus, using ``[]`` similar to
 getting a column from a DataFrame, you can do:
 
 .. ipython:: python
-   :suppress:
 
    df = pd.DataFrame(
        {
@@ -401,8 +400,8 @@ getting a column from a DataFrame, you can do:
            "D": np.random.randn(8),
        }
    )
-
-.. ipython:: python
+   
+   df
 
    grouped = df.groupby(["A"])
    grouped_C = grouped["C"]


### PR DESCRIPTION
Currently, the [user guide for groupby](https://pandas.pydata.org/docs/dev/user_guide/groupby.html#dataframe-column-selection-in-groupby) shows the following code, but it is unclear where the "C" and "D" columns come from.

![image](https://user-images.githubusercontent.com/7686641/124226033-48346700-dabd-11eb-90a1-be764c93f934.png)

In the rendered documentation, the preceding definition of `df` does not have "C" and "D" columns.

```python
In [50]: arrays = [
   ....:     ["bar", "bar", "baz", "baz", "foo", "foo", "qux", "qux"],
   ....:     ["one", "two", "one", "two", "one", "two", "one", "two"],
   ....: ]
   ....: 

In [51]: index = pd.MultiIndex.from_arrays(arrays, names=["first", "second"])

In [52]: df = pd.DataFrame({"A": [1, 1, 1, 1, 2, 2, 3, 3], "B": np.arange(8)}, index=index)

In [53]: df
Out[53]: 
              A  B
first second      
bar   one     1  0
      two     1  1
baz   one     1  2
      two     1  3
foo   one     2  4
      two     2  5
qux   one     3  6
      two     3  7
```

Instead, the code under the heading "DataFrame column selection in GroupBy" is referring to a completely different dataframe which is in the RST file but is suppressed in the rendered documentation.

This pull request un-suppresses that relevant dataframe so that readers can see where the "C" and "D" columns come from.