### PR TITLE
DOC: fix docs after deprecation of args

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -5072,9 +5072,9 @@ Keep all original rows and also all original values
         4    False
         dtype: bool
 
-        With `inclusive` set to ``False`` boundary values are excluded:
+        With `inclusive` set to ``"neither"`` boundary values are excluded:
 
-        >>> s.between(1, 4, inclusive=False)
+        >>> s.between(1, 4, inclusive="neither")
         0     True
         1    False
         2    False


### PR DESCRIPTION
follows up an oversigh from #40628.
`False` was deprecated as an input so the example should be updated.