### PR TITLE
ENH: Rename index when using DataFrame.reset_index

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -106,6 +106,7 @@ Other enhancements
 - :meth:`read_table` now supports the argument ``storage_options`` (:issue:`39167`)
 - Methods that relied on hashmap based algos such as :meth:`DataFrameGroupBy.value_counts`, :meth:`DataFrameGroupBy.count` and :func:`factorize` ignored imaginary component for complex numbers (:issue:`17927`)
 - Add :meth:`Series.str.removeprefix` and :meth:`Series.str.removesuffix` introduced in Python 3.9 to remove pre-/suffixes from string-type :class:`Series` (:issue:`36944`)
+- :meth:`DataFrame.reset_index` now accepts a ``names`` argument which renames the index names (:issue:`6878`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5614,7 +5614,7 @@ class DataFrame(NDFrame, OpsMixin):
         col_level: Hashable = 0,
         col_fill: Hashable = "",
         names: Hashable | Sequence[Hashable] = None,
-    ) -> Optional[DataFrame]:
+    ) -> DataFrame | None:
         """
         Reset the index, or a level of it.
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5639,6 +5639,12 @@ class DataFrame(NDFrame, OpsMixin):
         col_fill : object, default ''
             If the columns have multiple levels, determines how the other
             levels are named. If None then the index name is repeated.
+        names : str, tuple or list, default None
+            Using the given string, rename the DataFrame column which contains the index data.
+            If the DataFrame has a MultiIndex, this has to be a list or tuple with length
+            equal to the number of levels.
+
+            .. versionadded:: 1.4.0
 
         Returns
         -------
@@ -5781,6 +5787,14 @@ class DataFrame(NDFrame, OpsMixin):
             if len(level) < self.index.nlevels:
                 new_index = self.index.droplevel(level)
 
+        if names is not None:
+            if isinstance(self.index, MultiIndex):
+                if not isinstance(names, (tuple, list)):
+                    raise ValueError("Names must be a tuple or list")
+            else:
+                if not isinstance(names, str):
+                    raise ValueError("Names must be a string")
+
         if not drop:
             to_insert: Iterable[tuple[Any, Any | None]]
             if isinstance(self.index, MultiIndex):
@@ -5789,6 +5803,14 @@ class DataFrame(NDFrame, OpsMixin):
                         (n if n is not None else f"level_{i}")
                         for i, n in enumerate(self.index.names)
                     ]
+                else:
+
+                    if len(names) != self.index.nlevels:
+                        raise ValueError(
+                            f"The number of provided names "
+                            f"({len(names)}) does not match the number of"
+                            f" MultiIndex levels ({self.index.nlevels})"
+                        )
                 to_insert = zip(self.index.levels, self.index.codes)
             else:
                 default = "index" if "index" not in self else "level_0"

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5779,8 +5779,6 @@ class DataFrame(NDFrame, OpsMixin):
                         (n if n is not None else f"level_{i}")
                         for i, n in enumerate(self.index.names)
                     ]
-                else:
-                    names = names
                 to_insert = zip(self.index.levels, self.index.codes)
             else:
                 default = "index" if "index" not in self else "level_0"

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5542,6 +5542,7 @@ class DataFrame(NDFrame, OpsMixin):
         inplace: Literal[False] = ...,
         col_level: Hashable = ...,
         col_fill: Hashable = ...,
+        names: Hashable | Sequence[Hashable] = None,
     ) -> DataFrame:
         ...
 
@@ -5553,6 +5554,7 @@ class DataFrame(NDFrame, OpsMixin):
         inplace: Literal[True],
         col_level: Hashable = ...,
         col_fill: Hashable = ...,
+        names: Hashable | Sequence[Hashable] = None,
     ) -> None:
         ...
 
@@ -5564,6 +5566,7 @@ class DataFrame(NDFrame, OpsMixin):
         inplace: Literal[True],
         col_level: Hashable = ...,
         col_fill: Hashable = ...,
+        names: Hashable | Sequence[Hashable] = None,
     ) -> None:
         ...
 
@@ -5575,6 +5578,7 @@ class DataFrame(NDFrame, OpsMixin):
         inplace: Literal[True],
         col_level: Hashable = ...,
         col_fill: Hashable = ...,
+        names: Hashable | Sequence[Hashable] = None,
     ) -> None:
         ...
 
@@ -5585,6 +5589,7 @@ class DataFrame(NDFrame, OpsMixin):
         inplace: Literal[True],
         col_level: Hashable = ...,
         col_fill: Hashable = ...,
+        names: Hashable | Sequence[Hashable] = None,
     ) -> None:
         ...
 
@@ -5596,6 +5601,7 @@ class DataFrame(NDFrame, OpsMixin):
         inplace: bool = ...,
         col_level: Hashable = ...,
         col_fill: Hashable = ...,
+        names: Hashable | Sequence[Hashable] = None,
     ) -> DataFrame | None:
         ...
 
@@ -5607,7 +5613,8 @@ class DataFrame(NDFrame, OpsMixin):
         inplace: bool = False,
         col_level: Hashable = 0,
         col_fill: Hashable = "",
-    ) -> DataFrame | None:
+        names: Hashable | Sequence[Hashable] = None,
+    ) -> Optional[DataFrame]:
         """
         Reset the index, or a level of it.
 
@@ -5767,14 +5774,20 @@ class DataFrame(NDFrame, OpsMixin):
         if not drop:
             to_insert: Iterable[tuple[Any, Any | None]]
             if isinstance(self.index, MultiIndex):
-                names = [
-                    (n if n is not None else f"level_{i}")
-                    for i, n in enumerate(self.index.names)
-                ]
+                if not names:
+                    names = [
+                        (n if n is not None else f"level_{i}")
+                        for i, n in enumerate(self.index.names)
+                    ]
+                else:
+                    names = names
                 to_insert = zip(self.index.levels, self.index.codes)
             else:
                 default = "index" if "index" not in self else "level_0"
-                names = [default] if self.index.name is None else [self.index.name]
+                if not names:
+                    names = [default] if self.index.name is None else [self.index.name]
+                else:
+                    names = [names]
                 to_insert = ((self.index, None),)
 
             multi_col = isinstance(self.columns, MultiIndex)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5676,6 +5676,16 @@ class DataFrame(NDFrame, OpsMixin):
         2    lion  mammal       80.5
         3  monkey  mammal        NaN
 
+        Using the `names` parameter, it is possible to choose a name for
+        the old index column:
+
+        >>> df.reset_index(names='name')
+             name   class  max_speed
+        0  falcon    bird      389.0
+        1  parrot    bird       24.0
+        2    lion  mammal       80.5
+        3  monkey  mammal        NaN
+
         We can use the `drop` parameter to avoid the old index being added as
         a column:
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5640,9 +5640,9 @@ class DataFrame(NDFrame, OpsMixin):
             If the columns have multiple levels, determines how the other
             levels are named. If None then the index name is repeated.
         names : str, tuple or list, default None
-            Using the given string, rename the DataFrame column which contains the index data.
-            If the DataFrame has a MultiIndex, this has to be a list or tuple with length
-            equal to the number of levels.
+            Using the given string, rename the DataFrame column which contains the
+            index data. If the DataFrame has a MultiIndex, this has to be a list or
+            tuple with length equal to the number of levels.
 
             .. versionadded:: 1.4.0
 
@@ -5787,37 +5787,13 @@ class DataFrame(NDFrame, OpsMixin):
             if len(level) < self.index.nlevels:
                 new_index = self.index.droplevel(level)
 
-        if names is not None:
-            if isinstance(self.index, MultiIndex):
-                if not isinstance(names, (tuple, list)):
-                    raise ValueError("Names must be a tuple or list")
-            else:
-                if not isinstance(names, str):
-                    raise ValueError("Names must be a string")
-
         if not drop:
             to_insert: Iterable[tuple[Any, Any | None]]
             if isinstance(self.index, MultiIndex):
-                if not names:
-                    names = [
-                        (n if n is not None else f"level_{i}")
-                        for i, n in enumerate(self.index.names)
-                    ]
-                else:
-
-                    if len(names) != self.index.nlevels:
-                        raise ValueError(
-                            f"The number of provided names "
-                            f"({len(names)}) does not match the number of"
-                            f" MultiIndex levels ({self.index.nlevels})"
-                        )
+                names = self.index.get_default_index_names(names)
                 to_insert = zip(self.index.levels, self.index.codes)
             else:
-                default = "index" if "index" not in self else "level_0"
-                if not names:
-                    names = [default] if self.index.name is None else [self.index.name]
-                else:
-                    names = [names]
+                names = self.index.get_default_index_names(self, names)
                 to_insert = ((self.index, None),)
 
             multi_col = isinstance(self.columns, MultiIndex)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1559,6 +1559,18 @@ class Index(IndexOpsMixin, PandasObject):
 
         return new_names
 
+    def get_default_index_names(self, df: DataFrame, names: str = None):
+
+        if names is not None and not isinstance(names, str):
+            raise ValueError("Names must be a string")
+
+        default = "index" if "index" not in self else "level_0"
+        if not names:
+            names = [default] if df.index.name is None else [df.index.name]
+        else:
+            names = [names]
+        return names
+
     def _get_names(self) -> FrozenList:
         return FrozenList((self.name,))
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1559,16 +1559,19 @@ class Index(IndexOpsMixin, PandasObject):
 
         return new_names
 
-    def get_default_index_names(self, df: DataFrame, names: str = None):
+    def get_default_index_names(
+        self, df: DataFrame, names: str = None
+    ) -> Sequence[str]:
 
         if names is not None and not isinstance(names, str):
             raise ValueError("Names must be a string")
 
-        default = "index" if "index" not in self else "level_0"
+        default = "index" if "index" not in df else "level_0"
         if not names:
             names = [default] if df.index.name is None else [df.index.name]
         else:
             names = [names]
+
         return names
 
     def _get_names(self) -> FrozenList:

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1397,16 +1397,15 @@ class MultiIndex(Index):
             raise ValueError("Names must be a tuple or list")
 
         if not names:
-            names = [
+            return [
                 (n if n is not None else f"level_{i}") for i, n in enumerate(self.names)
             ]
-        else:
-            if len(names) != self.nlevels:
-                raise ValueError(
-                    f"The number of provided names "
-                    f"({len(names)}) does not match the number of "
-                    f"MultiIndex levels ({self.nlevels})"
-                )
+        if len(names) != self.nlevels:
+            raise ValueError(
+                f"The number of provided names "
+                f"({len(names)}) does not match the number of "
+                f"MultiIndex levels ({self.nlevels})"
+            )
 
         return names
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1391,6 +1391,25 @@ class MultiIndex(Index):
     # --------------------------------------------------------------------
     # Names Methods
 
+    def get_default_index_names(self, names=None):
+
+        if names is not None and not isinstance(names, (tuple, list)):
+            raise ValueError("Names must be a tuple or list")
+
+        if not names:
+            names = [
+                (n if n is not None else f"level_{i}") for i, n in enumerate(self.names)
+            ]
+        else:
+            if len(names) != self.nlevels:
+                raise ValueError(
+                    f"The number of provided names "
+                    f"({len(names)}) does not match the number of "
+                    f"MultiIndex levels ({self.nlevels})"
+                )
+
+        return names
+
     def _get_names(self) -> FrozenList:
         return FrozenList(self._names)
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1391,7 +1391,9 @@ class MultiIndex(Index):
     # --------------------------------------------------------------------
     # Names Methods
 
-    def get_default_index_names(self, names=None):
+    def get_default_index_names(
+        self, names: Sequence[Hashable] = None
+    ) -> Sequence[Hashable]:
 
         if names is not None and not isinstance(names, (tuple, list)):
             raise ValueError("Names must be a tuple or list")

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -189,6 +189,9 @@ class TestResetIndex:
         exp = Series(float_frame.index.values, name="new_name")
         tm.assert_series_equal(rdf["new_name"], exp)
 
+        with pytest.raises(ValueError, match="Names must be a string"):
+            float_frame.reset_index(names=1)
+
     def test_reset_index_rename_multiindex(self, float_frame):
         # GH 6878
         stacked = float_frame.stack()[::2]
@@ -204,6 +207,12 @@ class TestResetIndex:
         tm.assert_series_equal(
             deleveled["second"], deleveled2["new_second"], check_names=False
         )
+
+        with pytest.raises(ValueError, match=r".* number of provided names .*"):
+            stacked.reset_index(names=["new_first"])
+
+        with pytest.raises(ValueError, match="Names must be a tuple or list"):
+            stacked.reset_index(names={"first": "new_first", "second": "new_second"})
 
     def test_reset_index_level(self):
         df = DataFrame([[1, 2, 3, 4], [5, 6, 7, 8]], columns=["A", "B", "C", "D"])

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -183,6 +183,27 @@ class TestResetIndex:
         assert return_value is None
         assert df.index.name is None
 
+    def test_reset_index_rename(self, float_frame):
+        # index
+        rdf = float_frame.reset_index(names="new_name")
+        exp = Series(float_frame.index.values, name="new_name")
+        tm.assert_series_equal(rdf["new_name"], exp)
+
+        # multiindex
+        stacked = float_frame.stack()[::2]
+        stacked = DataFrame({"foo": stacked, "bar": stacked})
+
+        names = ["first", "second"]
+        stacked.index.names = names
+        deleveled = stacked.reset_index()
+        deleveled2 = stacked.reset_index(names=["new_first", "new_second"])
+        tm.assert_series_equal(
+            deleveled["first"], deleveled2["new_first"], check_names=False
+        )
+        tm.assert_series_equal(
+            deleveled["second"], deleveled2["new_second"], check_names=False
+        )
+
     def test_reset_index_level(self):
         df = DataFrame([[1, 2, 3, 4], [5, 6, 7, 8]], columns=["A", "B", "C", "D"])
 

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -184,13 +184,13 @@ class TestResetIndex:
         assert df.index.name is None
 
     def test_reset_index_rename(self, float_frame):
-
+        # GH 6878
         rdf = float_frame.reset_index(names="new_name")
         exp = Series(float_frame.index.values, name="new_name")
         tm.assert_series_equal(rdf["new_name"], exp)
 
     def test_reset_index_rename_multiindex(self, float_frame):
-
+        # GH 6878
         stacked = float_frame.stack()[::2]
         stacked = DataFrame({"foo": stacked, "bar": stacked})
 

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -184,12 +184,13 @@ class TestResetIndex:
         assert df.index.name is None
 
     def test_reset_index_rename(self, float_frame):
-        # index
+
         rdf = float_frame.reset_index(names="new_name")
         exp = Series(float_frame.index.values, name="new_name")
         tm.assert_series_equal(rdf["new_name"], exp)
 
-        # multiindex
+    def test_reset_index_rename_multiindex(self, float_frame):
+
         stacked = float_frame.stack()[::2]
         stacked = DataFrame({"foo": stacked, "bar": stacked})
 


### PR DESCRIPTION
- [x] closes #6878
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

Probably the hardest part of this PR is choosing a good name for the new argument. As mentioned in #6878 the `name` keyword is already used in `Series.reset_index`, although to rename the data column. It could be argued that using `name` also in this PR would not cause confusion, since it's hard to assume one can rename a column's name in `DataFrame.reset_index` (which column would it be?). 

Anyway, I've opted for `names`. I've also thought of `rename` but that sounds like asking for a boolean. `new_name` is an option too, although a bit ugly.