### PR TITLE
BUG: fixes PyPy build (do not use _PyHASH_Imag)

### DIFF
--- a/doc/source/whatsnew/v1.3.1.rst
+++ b/doc/source/whatsnew/v1.3.1.rst
@@ -14,7 +14,7 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
--
+- Pandas could not be build on PyPy (GH-42355)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.3.1.rst
+++ b/doc/source/whatsnew/v1.3.1.rst
@@ -14,7 +14,7 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
-- Pandas could not be build on PyPy (GH-42355)
+- Pandas could not be built on PyPy (:issue:`42355`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/_libs/src/klib/khash_python.h
+++ b/pandas/_libs/src/klib/khash_python.h
@@ -272,6 +272,8 @@ Py_hash_t PANDAS_INLINE floatobject_hash(PyFloatObject* key) {
 }
 
 
+#define _PandasHASH_IMAG 1000003UL
+
 // replaces _Py_HashDouble with _Pandas_HashDouble
 Py_hash_t PANDAS_INLINE complexobject_hash(PyComplexObject* key) {
     Py_uhash_t realhash = (Py_uhash_t)_Pandas_HashDouble(key->cval.real);
@@ -279,7 +281,7 @@ Py_hash_t PANDAS_INLINE complexobject_hash(PyComplexObject* key) {
     if (realhash == (Py_uhash_t)-1 || imaghash == (Py_uhash_t)-1) {
         return -1;
     }
-    Py_uhash_t combined = realhash + _PyHASH_IMAG * imaghash;
+    Py_uhash_t combined = realhash + _PandasHASH_IMAG * imaghash;
     if (combined == (Py_uhash_t)-1) {
         return -2;
     }


### PR DESCRIPTION
- [x] closes #42355
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] what's new entry

`_PyHASH_Imag` is not defined in PyPy, thus we define and use our own `_PandasHASH_Imag`.
