### PR TITLE
BUG: truncate has incorrect behavior when index has only one unique v…

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -159,7 +159,7 @@ Interval
 Indexing
 ^^^^^^^^
 - Bug in indexing on a :class:`Series` or :class:`DataFrame` with a :class:`DatetimeIndex` when passing a string, the return type depended on whether the index was monotonic (:issue:`24892`)
--
+- Bug in :meth:`DataFrame.truncate` and :meth:`Series.truncate` when the object's Index has a length greater than one but only one unique value (:issue:`42365`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9381,7 +9381,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         if before is not None and after is not None and before > after:
             raise ValueError(f"Truncate: {after} must be after {before}")
 
-        if len(ax) > 1 and ax.is_monotonic_decreasing:
+        if len(ax) > 1 and ax.is_monotonic_decreasing and ax.nunique() > 1:
             before, after = after, before
 
         slicer = [slice(None, None)] * self._AXIS_LEN

--- a/pandas/tests/frame/methods/test_truncate.py
+++ b/pandas/tests/frame/methods/test_truncate.py
@@ -148,3 +148,13 @@ class TestDataFrameTruncate:
             expected = expected["col"]
 
         tm.assert_equal(result, expected)
+
+    def test_truncate_index_only_one_unique_value(self, frame_or_series):
+        # GH 42365
+        obj = Series(0, index=date_range("2021-06-30", "2021-06-30")).repeat(5)
+        if frame_or_series is DataFrame:
+            obj = obj.to_frame(name="a")
+
+        truncated = obj.truncate("2021-06-28", "2021-07-01")
+
+        tm.assert_equal(truncated, obj)

--- a/pandas/tests/series/methods/test_truncate.py
+++ b/pandas/tests/series/methods/test_truncate.py
@@ -55,3 +55,11 @@ class TestTruncate:
 
         # the input Series and the expected Series are the same
         tm.assert_series_equal(result, series)
+
+    def test_truncate_index_only_one_unique_value(self):
+        # GH 42365
+        obj = Series(0, index=date_range("2021-06-30", "2021-06-30")).repeat(5)
+
+        truncated = obj.truncate("2021-06-28", "2021-07-01")
+
+        tm.assert_series_equal(truncated, obj)


### PR DESCRIPTION
…alue (#42365)

- [x] closes #42365
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
