### PR TITLE
CI: Prefer conda-forge over defaults

### DIFF
--- a/ci/deps/azure-windows-39.yaml
+++ b/ci/deps/azure-windows-39.yaml
@@ -1,7 +1,7 @@
 name: pandas-dev
 channels:
-  - defaults
   - conda-forge
+  - defaults
 dependencies:
   - python=3.9
 
@@ -26,7 +26,7 @@ dependencies:
   - numexpr
   - numpy
   - openpyxl
-  # - pyarrow  GH 42370
+  - pyarrow
   - pytables
   - python-dateutil
   - pytz


### PR DESCRIPTION
- [ ] closes #42370
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

Apparently its recommended to install pyarrow from conda forge instead of the default conda channel(xref https://github.com/ContinuumIO/anaconda-issues/issues/12314, https://arrow.apache.org/docs/python/install.html#using-conda), trying to see if this fixes it. I don't think this will mess up any other packages since conda-forge packages are published by package maintainers, so they shouldn't have build issues?