### PR TITLE
BUG: fix regression with SerieGrouper with Timestamp index (#42390)

### DIFF
--- a/pandas/_libs/reduction.pyx
+++ b/pandas/_libs/reduction.pyx
@@ -165,10 +165,6 @@ cdef class SeriesBinGrouper(_BaseGrouper):
 
         result = np.empty(self.ngroups, dtype='O')
 
-        cached_index, cached_series = self._init_dummy_series_and_index(
-            islider, vslider
-        )
-
         start = 0
         try:
             for i in range(self.ngroups):
@@ -177,6 +173,11 @@ cdef class SeriesBinGrouper(_BaseGrouper):
 
                 islider.move(start, end)
                 vslider.move(start, end)
+
+                if cached_index is None:
+                    cached_index, cached_series = self._init_dummy_series_and_index(
+                        islider, vslider
+                    )
 
                 self._update_cached_objs(
                     cached_series, cached_index, islider, vslider)
@@ -254,10 +255,6 @@ cdef class SeriesGrouper(_BaseGrouper):
 
         result = np.empty(self.ngroups, dtype='O')
 
-        cached_index, cached_series = self._init_dummy_series_and_index(
-            islider, vslider
-        )
-
         start = 0
         try:
             for i in range(n):
@@ -274,6 +271,11 @@ cdef class SeriesGrouper(_BaseGrouper):
                     end = start + group_size
                     islider.move(start, end)
                     vslider.move(start, end)
+
+                    if cached_index is None:
+                        cached_index, cached_series = self._init_dummy_series_and_index(
+                            islider, vslider
+                        )
 
                     self._update_cached_objs(
                         cached_series, cached_index, islider, vslider)

--- a/pandas/tests/groupby/test_bin_groupby.py
+++ b/pandas/tests/groupby/test_bin_groupby.py
@@ -27,6 +27,23 @@ def test_series_grouper():
     tm.assert_almost_equal(counts, exp_counts)
 
 
+def test_series_grouper_timestamp():
+    # GH 42390
+    obj = Series([1], index=[pd.Timestamp("2018-01-16 00:00:00+00:00")], dtype=np.intp)
+    labels = np.array([0], dtype=np.intp)
+
+    def agg(series):
+        # this should not raise
+        if series.isna().values.all():
+            return None
+        return np.sum(series)
+
+    grouper = libreduction.SeriesGrouper(obj, agg, labels, 1)
+    result, counts = grouper.get_result()
+    tm.assert_numpy_array_equal(result, np.array([1], dtype=object))
+    tm.assert_numpy_array_equal(counts, np.array([1], dtype=np.int64))
+
+
 def test_series_grouper_result_length_difference():
     # GH 40014
     obj = Series(np.random.randn(10), dtype="float64")


### PR DESCRIPTION
closes https://github.com/pandas-dev/pandas/issues/42390

This fixes a regression introduced in c355ed1 where cache is not
initialized with correct state of islider and vslider.

On Timestamp index this trigger a "ValueError Length of values does not match length of index"