### PR TITLE
DEPS: use importlib for backend discovery #41815

### DIFF
--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -262,7 +262,6 @@ Visualization
 ========================= ================== =============================================================
 Dependency                Minimum Version    Notes
 ========================= ================== =============================================================
-setuptools                38.6.0             Utils for entry points of plotting backend
 matplotlib                3.3.2              Plotting library
 Jinja2                    2.11               Conditional formatting with DataFrame.style
 tabulate                  0.8.7              Printing in Markdown-friendly format (see `tabulate`_)

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -82,8 +82,6 @@ If installed, we now require:
 +-----------------+-----------------+----------+---------+
 | mypy (dev)      | 0.910           |          |    X    |
 +-----------------+-----------------+----------+---------+
-| setuptools      | 38.6.0          |          |         |
-+-----------------+-----------------+----------+---------+
 
 For `optional libraries <https://pandas.pydata.org/docs/getting_started/install.html>`_ the general recommendation is to use the latest version.
 The following table lists the lowest version per library that is currently being tested throughout the development of pandas.

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1760,11 +1760,12 @@ def _load_backend(backend: str) -> types.ModuleType:
     found_backend = False
 
     eps = entry_points()
-    for entry_point in eps.get("pandas_plotting_backends"):
-        found_backend = entry_point.name == backend
-        if found_backend:
-            module = entry_point.load()
-            break
+    if "pandas_plotting_backends" in eps:
+        for entry_point in eps["pandas_plotting_backends"]:
+            found_backend = entry_point.name == backend
+            if found_backend:
+                module = entry_point.load()
+                break
 
     if not found_backend:
         # Fall back to unregistered, module name approach.

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1743,7 +1743,7 @@ def _load_backend(backend: str) -> types.ModuleType:
     types.ModuleType
         The imported backend.
     """
-    import pkg_resources
+    from importlib.metadata import entry_points
 
     if backend == "matplotlib":
         # Because matplotlib is an optional dependency and first-party backend,
@@ -1759,7 +1759,8 @@ def _load_backend(backend: str) -> types.ModuleType:
 
     found_backend = False
 
-    for entry_point in pkg_resources.iter_entry_points("pandas_plotting_backends"):
+    eps = entry_points()
+    for entry_point in eps.get("pandas_plotting_backends"):
         found_backend = entry_point.name == backend
         if found_backend:
             module = entry_point.load()


### PR DESCRIPTION
- [x] closes #41815

We still use `pkg_resources` in mpl tests. But it doesn't affect end users. 