### PR TITLE
CI: runtime warning in npdev build

### DIFF
--- a/pandas/tests/scalar/timedelta/test_arithmetic.py
+++ b/pandas/tests/scalar/timedelta/test_arithmetic.py
@@ -18,7 +18,6 @@ from pandas import (
     NaT,
     Timedelta,
     Timestamp,
-    compat,
     offsets,
 )
 import pandas._testing as tm
@@ -438,7 +437,7 @@ class TestTimedeltaMultiplicationDivision:
                 np.float64("NaN"),
                 marks=pytest.mark.xfail(
                     # Works on numpy dev only in python 3.9
-                    is_numpy_dev and not compat.PY39,
+                    is_numpy_dev,
                     raises=RuntimeWarning,
                     reason="https://github.com/pandas-dev/pandas/issues/31992",
                 ),


### PR DESCRIPTION
- [x] closes #42381
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
