### PR TITLE
BUG: .loc failing to drop first level

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3030,16 +3030,20 @@ class MultiIndex(Index):
                                 # everything
                                 continue
                             else:
-                                raise TypeError(
-                                    f"Expected label or tuple of labels, got {key}"
-                                )
+                                # e.g. test_xs_IndexSlice_argument_not_implemented
+                                k_index = np.zeros(len(self), dtype=bool)
+                                k_index[loc_level] = True
+
                         else:
                             k_index = loc_level
 
                     elif com.is_null_slice(k):
                         # taking everything, does not affect `indexer` below
                         continue
+
                     else:
+                        # FIXME: this message can be inaccurate, e.g.
+                        #  test_series_varied_multiindex_alignment
                         raise TypeError(f"Expected label or tuple of labels, got {key}")
 
                     if indexer is None:

--- a/pandas/tests/frame/indexing/test_xs.py
+++ b/pandas/tests/frame/indexing/test_xs.py
@@ -318,12 +318,13 @@ class TestXSWithMultiIndex:
         if klass is Series:
             obj = obj[0]
 
-        msg = (
-            "Expected label or tuple of labels, got "
-            r"\(\('foo', 'qux', 0\), slice\(None, None, None\)\)"
-        )
-        with pytest.raises(TypeError, match=msg):
-            obj.xs(IndexSlice[("foo", "qux", 0), :])
+        expected = obj.iloc[-2:].droplevel(0)
+
+        result = obj.xs(IndexSlice[("foo", "qux", 0), :])
+        tm.assert_equal(result, expected)
+
+        result = obj.loc[IndexSlice[("foo", "qux", 0), :]]
+        tm.assert_equal(result, expected)
 
     @pytest.mark.parametrize("klass", [DataFrame, Series])
     def test_xs_levels_raises(self, klass):

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1663,6 +1663,18 @@ class TestLocWithMultiIndex:
         with pytest.raises(KeyError, match=r"\['b'\] not in index"):
             df.loc[df["a"] < lt_value, :].loc[["b"], :]
 
+    def test_loc_drops_level(self):
+        # Based on test_series_varied_multiindex_alignment, where
+        #  this used to fail to drop the first level
+        mi = MultiIndex.from_product(
+            [list("ab"), list("xy"), [1, 2]], names=["ab", "xy", "num"]
+        )
+        ser = Series(range(8), index=mi)
+
+        loc_result = ser.loc["a", :, :]
+        expected = ser.index.droplevel(0)[:4]
+        tm.assert_index_equal(loc_result.index, expected)
+
 
 class TestLocSetitemWithExpansion:
     @pytest.mark.slow

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -924,7 +924,7 @@ def test_series_varied_multiindex_alignment():
         [1000 * i for i in range(1, 5)],
         index=pd.MultiIndex.from_product([list("xy"), [1, 2]], names=["xy", "num"]),
     )
-    result = s1.loc[pd.IndexSlice["a", :, :]] + s2
+    result = s1.loc[pd.IndexSlice[["a"], :, :]] + s2
     expected = Series(
         [1000, 2001, 3002, 4003],
         index=pd.MultiIndex.from_tuples(


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

This does not fix any of the existing GH issues for dropping of levels.