### PR TITLE
CI: Sync all 3.9 builds

### DIFF
--- a/ci/deps/actions-39-slow.yaml
+++ b/ci/deps/actions-39-slow.yaml
@@ -14,25 +14,29 @@ dependencies:
 
   # pandas dependencies
   - beautifulsoup4
-  - fsspec>=0.7.4, <2021.6.0
+  - bottleneck
+  - fsspec>=0.8.0, <2021.6.0
+  - gcsfs
   - html5lib
+  - jinja2
   - lxml
   - matplotlib
+  - moto>=1.3.14
+  - flask
   - numexpr
   - numpy
   - openpyxl
-  - patsy
-  - psycopg2
-  - pymysql
+  - pyarrow
   - pytables
   - python-dateutil
   - pytz
-  - s3fs>=0.4.0
-  - moto>=1.3.14
+  - s3fs>=0.4.2
   - scipy
   - sqlalchemy
   - xlrd
   - xlsxwriter
-  - moto
-  - flask
-  - numba
+  - xlwt
+  - pyreadstat
+  - pip
+  - pip:
+    - pyxlsb

--- a/ci/deps/actions-39.yaml
+++ b/ci/deps/actions-39.yaml
@@ -12,11 +12,30 @@ dependencies:
   - hypothesis>=5.5.3
 
   # pandas dependencies
+  - beautifulsoup4
+  - bottleneck
+  - fsspec>=0.8.0, <2021.6.0
+  - gcsfs
+  - html5lib
+  - jinja2
+  - lxml
+  - matplotlib
+  - moto>=1.3.14
+  - flask
+  - numexpr
   - numpy
+  - openpyxl
+  - pyarrow
+  - pytables
   - python-dateutil
   - pytz
-
-  # optional dependencies
-  - pytables
+  - s3fs>=0.4.2
   - scipy
-  - pyarrow=1.0
+  - sqlalchemy
+  - xlrd
+  - xlsxwriter
+  - xlwt
+  - pyreadstat
+  - pip
+  - pip:
+    - pyxlsb


### PR DESCRIPTION
- [x] closes #37826

IIUC, all the 3.9 builds(except numpydev) should have all dependencies.
