### PR TITLE
BUG: `to_xml` with `index=False` and offset input index

### DIFF
--- a/doc/source/whatsnew/v1.3.1.rst
+++ b/doc/source/whatsnew/v1.3.1.rst
@@ -27,6 +27,7 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 - Fixed bug in :meth:`DataFrame.transpose` dropping values when the DataFrame had an Extension Array dtype and a duplicate index (:issue:`42380`)
+- Fixed bug in :meth:`DataFrame.to_xml` raising ``KeyError`` when called with ``index=False`` and an offset index (:issue:`42458`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/io/formats/xml.py
+++ b/pandas/io/formats/xml.py
@@ -198,8 +198,10 @@ class BaseXMLFormatter:
         if not self.index:
             return
 
-        first_dict = next(iter(self.frame_dicts.values()))
-        indexes: list[str] = [x for x in first_dict.keys() if x not in self.orig_cols]
+        first_key = next(iter(self.frame_dicts))
+        indexes: list[str] = [
+            x for x in self.frame_dicts[first_key].keys() if x not in self.orig_cols
+        ]
 
         if self.attr_cols:
             self.attr_cols = indexes + self.attr_cols
@@ -309,7 +311,7 @@ class EtreeXMLFormatter(BaseXMLFormatter):
             self.elem_row = SubElement(self.root, f"{self.prefix_uri}{self.row_name}")
 
             if not self.attr_cols and not self.elem_cols:
-                self.elem_cols = list(d.keys())
+                self.elem_cols = list(self.d.keys())
                 self.build_elems()
 
             else:
@@ -479,7 +481,7 @@ class LxmlXMLFormatter(BaseXMLFormatter):
             self.elem_row = SubElement(self.root, f"{self.prefix_uri}{self.row_name}")
 
             if not self.attr_cols and not self.elem_cols:
-                self.elem_cols = list(d.keys())
+                self.elem_cols = list(self.d.keys())
                 self.build_elems()
 
             else:

--- a/pandas/io/formats/xml.py
+++ b/pandas/io/formats/xml.py
@@ -195,14 +195,16 @@ class BaseXMLFormatter:
         This method will add indexes into attr_cols or elem_cols.
         """
 
-        indexes: list[str] = [
-            x for x in self.frame_dicts[0].keys() if x not in self.orig_cols
-        ]
+        if not self.index:
+            return
 
-        if self.attr_cols and self.index:
+        first_dict = next(iter(self.frame_dicts.values()))
+        indexes: list[str] = [x for x in first_dict.keys() if x not in self.orig_cols]
+
+        if self.attr_cols:
             self.attr_cols = indexes + self.attr_cols
 
-        if self.elem_cols and self.index:
+        if self.elem_cols:
             self.elem_cols = indexes + self.elem_cols
 
     def get_prefix_uri(self) -> str:
@@ -307,7 +309,7 @@ class EtreeXMLFormatter(BaseXMLFormatter):
             self.elem_row = SubElement(self.root, f"{self.prefix_uri}{self.row_name}")
 
             if not self.attr_cols and not self.elem_cols:
-                self.elem_cols = list(self.frame_dicts[0].keys())
+                self.elem_cols = list(d.keys())
                 self.build_elems()
 
             else:
@@ -477,7 +479,7 @@ class LxmlXMLFormatter(BaseXMLFormatter):
             self.elem_row = SubElement(self.root, f"{self.prefix_uri}{self.row_name}")
 
             if not self.attr_cols and not self.elem_cols:
-                self.elem_cols = list(self.frame_dicts[0].keys())
+                self.elem_cols = list(d.keys())
                 self.build_elems()
 
             else:

--- a/pandas/tests/io/xml/test_to_xml.py
+++ b/pandas/tests/io/xml/test_to_xml.py
@@ -13,7 +13,7 @@ import pandas.util._test_decorators as td
 
 from pandas import (
     DataFrame,
-    RangeIndex,
+    Index,
 )
 import pandas._testing as tm
 
@@ -293,7 +293,10 @@ def test_index_false_rename_row_root(datapath, parser):
         assert output == expected
 
 
-def test_index_false_with_offset_input_index(parser):
+@pytest.mark.parametrize(
+    "offset_index", [list(range(10, 13)), [str(i) for i in range(10, 13)]]
+)
+def test_index_false_with_offset_input_index(parser, offset_index):
     """
     Tests that the output does not contain the `<index>` field when the index of the
     input Dataframe has an offset.
@@ -322,7 +325,7 @@ def test_index_false_with_offset_input_index(parser):
 </data>"""
 
     offset_geom_df = geom_df.copy()
-    offset_geom_df.index = RangeIndex(start=10, stop=13, step=1)
+    offset_geom_df.index = Index(offset_index)
     output = offset_geom_df.to_xml(index=False, parser=parser)
     output = equalize_decl(output)
 

--- a/pandas/tests/io/xml/test_to_xml.py
+++ b/pandas/tests/io/xml/test_to_xml.py
@@ -11,7 +11,10 @@ import pytest
 
 import pandas.util._test_decorators as td
 
-from pandas import DataFrame
+from pandas import (
+    DataFrame,
+    RangeIndex,
+)
 import pandas._testing as tm
 
 from pandas.io.common import get_handle
@@ -288,6 +291,42 @@ def test_index_false_rename_row_root(datapath, parser):
         output = equalize_decl(output)
 
         assert output == expected
+
+
+def test_index_false_with_offset_input_index(parser):
+    """
+    Tests that the output does not contain the `<index>` field when the index of the
+    input Dataframe has an offset.
+
+    This is a regression test for issue #42458.
+    """
+
+    expected = """\
+<?xml version='1.0' encoding='utf-8'?>
+<data>
+  <row>
+    <shape>square</shape>
+    <degrees>360</degrees>
+    <sides>4.0</sides>
+  </row>
+  <row>
+    <shape>circle</shape>
+    <degrees>360</degrees>
+    <sides/>
+  </row>
+  <row>
+    <shape>triangle</shape>
+    <degrees>180</degrees>
+    <sides>3.0</sides>
+  </row>
+</data>"""
+
+    offset_geom_df = geom_df.copy()
+    offset_geom_df.index = RangeIndex(start=10, stop=13, step=1)
+    output = offset_geom_df.to_xml(index=False, parser=parser)
+    output = equalize_decl(output)
+
+    assert output == expected
 
 
 # NA_REP


### PR DESCRIPTION
Fixes #42458

It was assumed that the index contains the element `0`. This led to a
defect when the index of the input Dataframe has an offset, which is a
common use case when streaming Dataframes via generators.

This fix consists of not relying on accessing the `0` element of
`frame_dicts`.

- [x] closes #42458 
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
