### PR TITLE
CI: Don't auto-cancel on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     concurrency:
       group: ${{ github.ref }}-checks
-      cancel-in-progress: true
+      cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
     steps:
     - name: Checkout

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -31,7 +31,7 @@ jobs:
 
     concurrency:
       group: ${{ github.ref }}-${{ matrix.ENV_FILE }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{github.event_name == "pull_request"}}
 
     services:
       mysql:

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -31,7 +31,7 @@ jobs:
 
     concurrency:
       group: ${{ github.ref }}-${{ matrix.ENV_FILE }}
-      cancel-in-progress: ${{github.event_name == "pull_request"}}
+      cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
     services:
       mysql:

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -45,7 +45,7 @@ jobs:
       TEST_ARGS: ${{ matrix.settings[6] }}
     concurrency:
       group: ${{ github.ref }}-${{ matrix.settings[0] }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
     steps:
     - name: Checkout

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.ref }}-pre-commit
-      cancel-in-progress: true
+      cancel-in-progress: ${{github.event_name == 'pull_request'}}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.github/workflows/python-dev.yml
+++ b/.github/workflows/python-dev.yml
@@ -25,7 +25,7 @@ jobs:
 
     concurrency:
       group: ${{ github.ref }}-dev
-      cancel-in-progress: true
+      cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -25,6 +25,7 @@ jobs:
         python-version: ["3.8", "3.9"]
     concurrency:
       group: ${{github.ref}}-${{matrix.python-version}}-sdist
+      cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -23,6 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9"]
+    concurrency:
+      group: ${{github.ref}}-${{matrix.python-version}}-sdist
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
- [ ] closes #42076 
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

I haven't tested that this skips the cancel on master branch, only that it cancels already running workflows on PRs(e.g. https://github.com/lithomas1/pandas/pull/3). 
So, be ready to revert if needed.
