### PR TITLE
REGR: indexing with list subclass

### DIFF
--- a/doc/source/whatsnew/v1.3.1.rst
+++ b/doc/source/whatsnew/v1.3.1.rst
@@ -18,6 +18,7 @@ Fixed regressions
 - :class:`DataFrame` constructed with with an older version of pandas could not be unpickled (:issue:`42345`)
 - Performance regression in constructing a :class:`DataFrame` from a dictionary of dictionaries (:issue:`42338`)
 - Fixed regression in :meth:`DataFrame.agg` dropping values when the DataFrame had an Extension Array dtype, a duplicate index, and ``axis=1`` (:issue:`42380`)
+- Fixed regression in indexing with a ``list`` subclass incorrectly raising ``TypeError`` (:issue:`42433`, :issue:42461`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -145,7 +145,11 @@ def is_bool_indexer(key: Any) -> bool:
             return True
     elif isinstance(key, list):
         # check if np.array(key).dtype would be bool
-        return len(key) > 0 and lib.is_bool_list(key)
+        if len(key) > 0:
+            if type(key) is not list:
+                # GH#42461 cython will raise TypeError if we pass a subclass
+                key = list(key)
+            return lib.is_bool_list(key)
 
     return False
 

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -162,3 +162,28 @@ class TestIsBoolIndexer:
         # in particular, this should not raise
         arr = np.array(["A", "B", np.nan], dtype=object)
         assert not com.is_bool_indexer(arr)
+
+    def test_list_subclass(self):
+        # GH#42433
+
+        class MyList(list):
+            pass
+
+        val = MyList(["a"])
+
+        assert not com.is_bool_indexer(val)
+
+        val = MyList([True])
+        assert com.is_bool_indexer(val)
+
+    def test_frozenlist(self):
+        # GH#42461
+        data = {"col1": [1, 2], "col2": [3, 4]}
+        df = pd.DataFrame(data=data)
+
+        frozen = df.index.names[1:]
+        assert not com.is_bool_indexer(frozen)
+
+        result = df[frozen]
+        expected = df[[]]
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #42461
- [x] closes #42433
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
