### PR TITLE
[NOMERGE] Test object array copying

### DIFF
--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2868,3 +2868,13 @@ class TestFromScalar:
 
         assert np.all(result.dtypes == "M8[ns]")
         assert np.all(result == ts_naive)
+
+    def test_1d_object_array_does_not_copy(self):
+        a = np.array(["a", "b"], dtype="object")
+        df = DataFrame(a, copy=False)
+        assert np.shares_memory(df.values, a)
+
+    def test_2d_object_array_does_not_copy(self):
+        b = np.array([["a", "b"], ["c", "d"]], dtype="object")
+        df2 = DataFrame(b, copy=False)
+        assert np.shares_memory(df2.values, b)


### PR DESCRIPTION
In an effort to debug what's wrong with https://github.com/pandas-dev/pandas/pull/39272/, I'm opening a separate pull request with some tests to run on Azure pipelines. I can't reproduce these test fails locally with `environment.yml` or a docker developer environment.

`test_1d_object_array_does_not_copy` DIDN'T fail a little over a month ago (when I'd started writing the PR), so I'll be bisecting back to see when it happened.
