### PR TITLE
PERF/REGR: astype changing order of some 2d data

### DIFF
--- a/doc/source/whatsnew/v1.3.1.rst
+++ b/doc/source/whatsnew/v1.3.1.rst
@@ -18,6 +18,8 @@ Fixed regressions
 - :class:`DataFrame` constructed with with an older version of pandas could not be unpickled (:issue:`42345`)
 - Performance regression in constructing a :class:`DataFrame` from a dictionary of dictionaries (:issue:`42338`)
 - Fixed regression in :meth:`DataFrame.agg` dropping values when the DataFrame had an Extension Array dtype, a duplicate index, and ``axis=1`` (:issue:`42380`)
+- Fixed regression in :meth:`DataFrame.astype` changing the order of noncontiguous data (:issue:`42396`)
+- Performance regression in :class:`DataFrame` in reduction operations requiring casting such as :meth:`DataFrame.mean` on integer data (:issue:`38592`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -14,7 +14,6 @@ import inspect
 from typing import (
     TYPE_CHECKING,
     Any,
-    Literal,
     Sized,
     TypeVar,
     cast,
@@ -1095,13 +1094,11 @@ def astype_nansafe(
     """
     if arr.ndim > 1:
         # Make sure we are doing non-copy ravel and reshape.
-        flags = arr.flags
-        flat = arr.ravel("K")
+        flat = arr.ravel()
         result = astype_nansafe(flat, dtype, copy=copy, skipna=skipna)
-        order: Literal["C", "F"] = "F" if flags.f_contiguous else "C"
         # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no
         # attribute "reshape"
-        return result.reshape(arr.shape, order=order)  # type: ignore[union-attr]
+        return result.reshape(arr.shape)  # type: ignore[union-attr]
 
     # We get here with 0-dim from sparse
     arr = np.atleast_1d(arr)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1093,7 +1093,7 @@ def astype_nansafe(
         The dtype was a datetime64/timedelta64 dtype, but it had no unit.
     """
     if arr.ndim > 1:
-        # Make sure we are doing non-copy ravel and reshape.
+        # TODO: try to use contiguity to avoid potentially copying here, see #42475
         flat = arr.ravel()
         result = astype_nansafe(flat, dtype, copy=copy, skipna=skipna)
         # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1093,7 +1093,6 @@ def astype_nansafe(
         The dtype was a datetime64/timedelta64 dtype, but it had no unit.
     """
     if arr.ndim > 1:
-        # TODO: try to use contiguity to avoid potentially copying here, see #42475
         flat = arr.ravel()
         result = astype_nansafe(flat, dtype, copy=copy, skipna=skipna)
         # error: Item "ExtensionArray" of "Union[ExtensionArray, ndarray]" has no

--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -674,10 +674,14 @@ class TestAstype:
     def test_astype_noncontiguous(self, step1, step2):
         # GH#42396
         data = np.arange(16).reshape(4, 4)
-        df = DataFrame(data)
+        df = DataFrame(data, dtype=np.intp)
 
         result = df.iloc[:step1, :step2].astype("int16").astype(np.intp)
         expected = df.iloc[:step1, :step2]
+        tm.assert_frame_equal(result, expected)
+
+        result = df.iloc[::step1, ::step2].astype("int16").astype(np.intp)
+        expected = df.iloc[::step1, ::step2]
         tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -686,9 +686,9 @@ class TestAstype:
         data = np.arange(16).reshape(4, 4)
         df = DataFrame(data)
 
-        result = df.iloc[index_slice].astype("int16").to_numpy()
-        expected = data[index_slice].astype("int16")
-        tm.assert_numpy_array_equal(result, expected)
+        result = df.iloc[index_slice].astype("int16")
+        expected = df.iloc[index_slice]
+        tm.assert_frame_equal(result, expected, check_dtype=False)
 
 
 class TestAstypeCategorical:

--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -670,18 +670,24 @@ class TestAstype:
         result = DataFrame(["foo", "bar", "baz"]).astype(bytes)
         assert result.dtypes[0] == np.dtype("S3")
 
-    @pytest.mark.parametrize("step1,step2", [(2, 2), (2, 1), (1, 2)])
-    def test_astype_noncontiguous(self, step1, step2):
+    @pytest.mark.parametrize(
+        "index_slice",
+        [
+            np.s_[:2, :2],
+            np.s_[:1, :2],
+            np.s_[:2, :1],
+            np.s_[::2, ::2],
+            np.s_[::1, ::2],
+            np.s_[::2, ::1],
+        ],
+    )
+    def test_astype_noncontiguous(self, index_slice):
         # GH#42396
         data = np.arange(16).reshape(4, 4)
         df = DataFrame(data, dtype=np.intp)
 
-        result = df.iloc[:step1, :step2].astype("int16").astype(np.intp)
-        expected = df.iloc[:step1, :step2]
-        tm.assert_frame_equal(result, expected)
-
-        result = df.iloc[::step1, ::step2].astype("int16").astype(np.intp)
-        expected = df.iloc[::step1, ::step2]
+        result = df.iloc[index_slice].astype("int16").astype(np.intp)
+        expected = df.iloc[index_slice]
         tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -670,6 +670,16 @@ class TestAstype:
         result = DataFrame(["foo", "bar", "baz"]).astype(bytes)
         assert result.dtypes[0] == np.dtype("S3")
 
+    @pytest.mark.parametrize("step1,step2", [(6, 3), (6, 1), (1, 3)])
+    def test_astype_noncontiguous(self, step1, step2):
+        # GH#42396
+        data = np.arange(72).reshape(12, 6)
+        df = DataFrame(data)
+
+        result = df.iloc[:step1, :step2].astype("int32").astype("int64")
+        expected = df.iloc[:step1, :step2]
+        tm.assert_frame_equal(result, expected)
+
 
 class TestAstypeCategorical:
     def test_astype_from_categorical3(self):

--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -684,11 +684,11 @@ class TestAstype:
     def test_astype_noncontiguous(self, index_slice):
         # GH#42396
         data = np.arange(16).reshape(4, 4)
-        df = DataFrame(data, dtype=np.intp)
+        df = DataFrame(data)
 
-        result = df.iloc[index_slice].astype("int16").astype(np.intp)
-        expected = df.iloc[index_slice]
-        tm.assert_frame_equal(result, expected)
+        result = df.iloc[index_slice].astype("int16").to_numpy()
+        expected = data[index_slice].astype("int16")
+        tm.assert_numpy_array_equal(result, expected)
 
 
 class TestAstypeCategorical:

--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -676,7 +676,7 @@ class TestAstype:
         data = np.arange(16).reshape(4, 4)
         df = DataFrame(data)
 
-        result = df.iloc[:step1, :step2].astype("int32").astype("int64")
+        result = df.iloc[:step1, :step2].astype("int16").astype(np.intp)
         expected = df.iloc[:step1, :step2]
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -670,10 +670,10 @@ class TestAstype:
         result = DataFrame(["foo", "bar", "baz"]).astype(bytes)
         assert result.dtypes[0] == np.dtype("S3")
 
-    @pytest.mark.parametrize("step1,step2", [(6, 3), (6, 1), (1, 3)])
+    @pytest.mark.parametrize("step1,step2", [(2, 2), (2, 1), (1, 2)])
     def test_astype_noncontiguous(self, step1, step2):
         # GH#42396
-        data = np.arange(72).reshape(12, 6)
+        data = np.arange(16).reshape(4, 4)
         df = DataFrame(data)
 
         result = df.iloc[:step1, :step2].astype("int32").astype("int64")


### PR DESCRIPTION
- [x] closes #42396
- [x] closes #38592
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

This just lets `numpy` stick with the default of `order="C"` for both `ravel` and `reshape` so no reordering occurs. 

Benchmarks:

```
       before           after         ratio
     [87d78559]       [0c9d5496]
     <master>         <regr_astype>
-      9.34±0.7ms       4.95±0.9ms     0.53  stat_ops.FrameOps.time_op('kurt', 'int', 1)
-      5.08±0.8ms       2.63±0.1ms     0.52  stat_ops.FrameOps.time_op('skew', 'Int64', 0)
-      4.46±0.2ms       2.25±0.3ms     0.50  stat_ops.FrameOps.time_op('std', 'int', 1)
-      5.76±0.2ms       2.73±0.6ms     0.47  stat_ops.FrameOps.time_op('var', 'int', 1)
-      11.5±0.7ms       5.09±0.3ms     0.44  stat_ops.FrameOps.time_op('sem', 'int', 0)
-      1.36±0.2ms         600±50μs     0.44  stat_ops.FrameOps.time_op('prod', 'int', 0)
-        17.5±5ms       7.60±0.7ms     0.43  stat_ops.FrameOps.time_op('skew', 'int', 1)
-      8.64±0.7ms       3.37±0.4ms     0.39  stat_ops.FrameOps.time_op('kurt', 'int', 0)
-      9.03±0.6ms       3.21±0.2ms     0.36  stat_ops.FrameOps.time_op('skew', 'int', 0)
-      9.49±0.6ms       3.27±0.4ms     0.34  stat_ops.FrameOps.time_op('mad', 'int', 0)
-     1.31±0.08ms         420±20μs     0.32  stat_ops.FrameOps.time_op('sum', 'int', 1)
-      5.87±0.5ms       1.87±0.5ms     0.32  stat_ops.FrameOps.time_op('var', 'int', 0)
-     1.49±0.09ms         467±20μs     0.31  stat_ops.FrameOps.time_op('sum', 'int', 0)
-      4.44±0.3ms       1.39±0.1ms     0.31  stat_ops.FrameOps.time_op('std', 'int', 0)
-     1.90±0.06ms         569±70μs     0.30  stat_ops.FrameOps.time_op('mean', 'int', 0)
-      1.22±0.1ms          346±4μs     0.28  stat_ops.FrameOps.time_op('prod', 'int', 1)
-      1.86±0.1ms         519±60μs     0.28  stat_ops.FrameOps.time_op('mean', 'int', 1)
```

Will look to come up with a benchmark hitting this regression more squarely (which would help test if a more clever contiguity approach than always defaulting to "C" can improve performance).

EDIT: after regression is fixed, might be worth looking into reinstating something like the original approach. Some timings show performance benefit we lose here:

```
In [1]: import numpy as np

In [2]: import pandas as pd

In [3]: data = np.ones((2000, 2000), order="F")

In [4]: df = pd.DataFrame(data)

In [5]: %timeit df.astype(np.int32)
5.63 ms ± 114 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  # this pr
5.7 ms ± 115 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  # master

In [6]: data = np.ones((2000, 2000), order="C")

In [7]: df = pd.DataFrame(data)

In [8]: %timeit df.astype(np.int32)
26.8 ms ± 313 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)  # this pr
5.63 ms ± 77.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  # master
```

EDIT: This slowdown comes down to the ravel copying because of contiguity that doesn't match. Let me know if it's better to try to fix the slowdown shown above in this pr or to leave as a followup for 1.4