### PR TITLE
CI: add back xfail for flaky chunksize test

### DIFF
--- a/pandas/tests/io/parser/common/test_chunksize.py
+++ b/pandas/tests/io/parser/common/test_chunksize.py
@@ -191,8 +191,24 @@ def test_warn_if_chunks_have_mismatched_type(all_parsers, request):
 
     buf = StringIO(data)
 
-    with tm.assert_produces_warning(warning_type):
-        df = parser.read_csv(buf)
+    try:
+        with tm.assert_produces_warning(warning_type):
+            df = parser.read_csv(buf)
+    except AssertionError as err:
+        # 2021-02-21 this occasionally fails on the CI with an unexpected
+        #  ResourceWarning that we have been unable to track down,
+        #  see GH#38630
+        if "ResourceWarning" not in str(err) or parser.engine != "python":
+            raise
+
+        # Check the main assertion of the test before re-raising
+        assert df.a.dtype == object
+
+        mark = pytest.mark.xfail(
+            reason="ResourceWarning for unclosed SSL Socket, GH#38630"
+        )
+        request.node.add_marker(mark)
+        raise
 
     assert df.a.dtype == object
 


### PR DESCRIPTION
This reverts the part of #42174 that (optimistically it turns out) removed the xfail for a `ResourceWarning` with the python parser. 
