### PR TITLE
ENH - Improved error message for interpolating IntegerArrays (#41565)

### DIFF
--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -117,7 +117,10 @@ def clean_fill_method(method, allow_nearest: bool = False):
         valid_methods.append("nearest")
         expecting = "pad (ffill), backfill (bfill) or nearest"
     if method not in valid_methods:
-        raise ValueError(f"Invalid fill method. Expecting {expecting}. Got {method}")
+        raise ValueError(
+            f"Invalid fill method. Expecting {expecting}. Got {method}."
+            " Are you trying to interpolate an integer column?"
+        )
     return method
 
 


### PR DESCRIPTION
- [X] closes #41565
~~- [ ] tests added / passed~~
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [X] whatsnew entry

This PR improves the error message when trying to interpolate dtype integer with method="linear", as discussed in #41565.