### PR TITLE
Backport PR #42451: CI: Sync all 3.9 builds (part)

### DIFF
--- a/ci/deps/actions-39.yaml
+++ b/ci/deps/actions-39.yaml
@@ -12,11 +12,30 @@ dependencies:
   - hypothesis>=3.58.0
 
   # pandas dependencies
+  - beautifulsoup4
+  - bottleneck
+  - fsspec>=0.8.0, <2021.6.0
+  - gcsfs
+  - html5lib
+  - jinja2
+  - lxml
+  - matplotlib
+  - moto>=1.3.14
+  - flask
+  - numexpr
   - numpy
+  - openpyxl
+  - pyarrow
+  - pytables
   - python-dateutil
   - pytz
-
-  # optional dependencies
-  - pytables
+  - s3fs>=0.4.2
   - scipy
-  - pyarrow=1.0
+  - sqlalchemy
+  - xlrd
+  - xlsxwriter
+  - xlwt
+  - pyreadstat
+  - pip
+  - pip:
+    - pyxlsb


### PR DESCRIPTION
Backport PR #42451

xref https://github.com/pandas-dev/pandas/pull/42451#issuecomment-878918384

> I think for the backport, will only backport changes in ci/deps/actions-39.yaml and leave ci/deps/actions-39-slow.yaml which maps to ci/deps/actions-37-slow.yaml unchanged.