### PR TITLE
BUG: Fix multi-index colname references in read_csv c engine.

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -230,7 +230,7 @@ MultiIndex
 I/O
 ^^^
 - Bug in :func:`read_excel` attempting to read chart sheets from .xlsx files (:issue:`41448`)
--
+- Bug in :func:`read_csv` with multi-header input and arguments referencing column names as tuples (:issue:`42446`)
 -
 
 Period

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1280,11 +1280,10 @@ cdef class TextReader:
                 # generate extra (bogus) headers if there are more columns than headers
                 if j >= len(self.header[0]):
                     return j
+                elif self.has_mi_columns:
+                    return tuple(header_row[j] for header_row in self.header)
                 else:
-                    if self.has_mi_columns:
-                        return tuple(header_row[j] for header_row in self.header)
-                    else:
-                        return self.header[0][j]
+                    return self.header[0][j]
             else:
                 return None
 

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1281,7 +1281,10 @@ cdef class TextReader:
                 if j >= len(self.header[0]):
                     return j
                 else:
-                    return self.header[0][j]
+                    if self.has_mi_columns:
+                        return tuple(header_row[j] for header_row in self.header)
+                    else:
+                        return self.header[0][j]
             else:
                 return None
 

--- a/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
+++ b/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
@@ -260,6 +260,7 @@ def test_dtype_mangle_dup_cols_single_dtype(all_parsers):
 
 
 def test_dtype_multi_index(all_parsers):
+    # GH 42446
     parser = all_parsers
     data = "A,B,B\nX,Y,Z\n1,2,3"
 

--- a/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
+++ b/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
@@ -257,3 +257,28 @@ def test_dtype_mangle_dup_cols_single_dtype(all_parsers):
     result = parser.read_csv(StringIO(data), dtype=str)
     expected = DataFrame({"a": ["1"], "a.1": ["1"]})
     tm.assert_frame_equal(result, expected)
+
+
+def test_dtype_multi_index(all_parsers):
+    parser = all_parsers
+    data = "A,B,B\nX,Y,Z\n1,2,3"
+
+    result = parser.read_csv(
+        StringIO(data),
+        header=list(range(2)),
+        dtype={
+            ("A", "X"): np.int32,
+            ("B", "Y"): np.int32,
+            ("B", "Z"): np.float32,
+        },
+    )
+
+    expected = DataFrame(
+        {
+            ("A", "X"): np.int32([1]),
+            ("B", "Y"): np.int32([2]),
+            ("B", "Z"): np.float32([3]),
+        }
+    )
+
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/parser/test_converters.py
+++ b/pandas/tests/io/parser/test_converters.py
@@ -164,6 +164,7 @@ def test_converter_index_col_bug(all_parsers):
 
 
 def test_converter_multi_index(all_parsers):
+    # GH 42446
     parser = all_parsers
     data = "A,B,B\nX,Y,Z\n1,2,3"
 

--- a/pandas/tests/io/parser/test_converters.py
+++ b/pandas/tests/io/parser/test_converters.py
@@ -161,3 +161,28 @@ def test_converter_index_col_bug(all_parsers):
 
     xp = DataFrame({"B": [2, 4]}, index=Index([1, 3], name="A"))
     tm.assert_frame_equal(rs, xp)
+
+
+def test_converter_multi_index(all_parsers):
+    parser = all_parsers
+    data = "A,B,B\nX,Y,Z\n1,2,3"
+
+    result = parser.read_csv(
+        StringIO(data),
+        header=list(range(2)),
+        converters={
+            ("A", "X"): np.int32,
+            ("B", "Y"): np.int32,
+            ("B", "Z"): np.float32,
+        },
+    )
+
+    expected = DataFrame(
+        {
+            ("A", "X"): np.int32([1]),
+            ("B", "Y"): np.int32([2]),
+            ("B", "Z"): np.float32([3]),
+        }
+    )
+
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -570,3 +570,22 @@ foo,,bar
     )
 
     tm.assert_frame_equal(result, expected)
+
+
+def test_nan_multi_index(all_parsers):
+    parser = all_parsers
+    data = "A,B,B\nX,Y,Z\n1,2,inf"
+
+    result = parser.read_csv(
+        StringIO(data), header=list(range(2)), na_values={("B", "Z"): "inf"}
+    )
+
+    expected = DataFrame(
+        {
+            ("A", "X"): [1],
+            ("B", "Y"): [2],
+            ("B", "Z"): [np.nan],
+        }
+    )
+
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -573,6 +573,7 @@ foo,,bar
 
 
 def test_nan_multi_index(all_parsers):
+    # GH 42446
     parser = all_parsers
     data = "A,B,B\nX,Y,Z\n1,2,inf"
 


### PR DESCRIPTION
This fixes an issue with the read_csv c engine when the input has more than one header row and arguments to dtype, na_values, or converters reference multi-index column names as tuples.

- [x] closes #42446
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

I added a whatsnew entry for v1.4.0 since that's what other recent bug fixes have done, but I'm not yet sure of the criteria for that. Is it appropriate to add it for whichever release "owns" master?