### PR TITLE
Revert "CI: runtime warning in npdev build"

### DIFF
--- a/pandas/tests/scalar/timedelta/test_arithmetic.py
+++ b/pandas/tests/scalar/timedelta/test_arithmetic.py
@@ -18,6 +18,7 @@ from pandas import (
     NaT,
     Timedelta,
     Timestamp,
+    compat,
     offsets,
 )
 import pandas._testing as tm
@@ -437,7 +438,7 @@ class TestTimedeltaMultiplicationDivision:
                 np.float64("NaN"),
                 marks=pytest.mark.xfail(
                     # Works on numpy dev only in python 3.9
-                    is_numpy_dev,
+                    is_numpy_dev and not compat.PY39,
                     raises=RuntimeWarning,
                     reason="https://github.com/pandas-dev/pandas/issues/31992",
                 ),


### PR DESCRIPTION
Reverts pandas-dev/pandas#42413

Test passing on 3.9 numpydev again?
Numpydev is red again b/c of this I think.
