### PR TITLE
Revert "REGR: concat(ints, bools) casting to object #42092"

### DIFF
--- a/doc/source/whatsnew/v1.3.1.rst
+++ b/doc/source/whatsnew/v1.3.1.rst
@@ -23,7 +23,7 @@ Fixed regressions
 - Performance regression in :meth:`DataFrame.to_dict` and :meth:`Series.to_dict` when ``orient`` argument one of "records", "dict", or "split" (:issue:`42352`)
 - Fixed regression in indexing with a ``list`` subclass incorrectly raising ``TypeError`` (:issue:`42433`, :issue:`42461`)
 - Fixed regression in :meth:`DataFrame.isin` and :meth:`Series.isin` raising ``TypeError`` with nullable data containing at least one missing value (:issue:`42405`)
-- Regression in :func:`concat` between objects with bool dtype and integer dtype casting to object instead of to integer (:issue:`42092`)
+-
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -592,9 +592,6 @@ def _is_uniform_join_units(join_units: list[JoinUnit]) -> bool:
         # e.g. DatetimeLikeBlock can be dt64 or td64, but these are not uniform
         all(
             is_dtype_equal(ju.block.dtype, join_units[0].block.dtype)
-            # GH#42092 we only want the dtype_equal check for non-numeric blocks
-            #  (for now, may change but that would need a deprecation)
-            or ju.block.dtype.kind in ["b", "i", "u"]
             for ju in join_units
         )
         and

--- a/pandas/tests/reshape/concat/test_dataframe.py
+++ b/pandas/tests/reshape/concat/test_dataframe.py
@@ -170,13 +170,3 @@ class TestDataFrameConcat:
         # it works
         result = concat([t1, t2], axis=1, keys=["t1", "t2"], sort=sort)
         assert list(result.columns) == [("t1", "value"), ("t2", "value")]
-
-    def test_concat_bool_with_int(self):
-        # GH#42092 we may want to change this to return object, but that
-        #  would need a deprecation
-        df1 = DataFrame(Series([True, False, True, True], dtype="bool"))
-        df2 = DataFrame(Series([1, 0, 1], dtype="int64"))
-
-        result = concat([df1, df2])
-        expected = concat([df1.astype("int64"), df2])
-        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
Reverts pandas-dev/pandas#42541

This fails ArrayManager. 

cc @jbrockmendel 