### PR TITLE
CI: Run all GHA checks on backport branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 1.3.x
   pull_request:
     branches:
       - master
@@ -132,15 +133,15 @@ jobs:
         echo "${{ secrets.server_ssh_key }}" > ~/.ssh/id_rsa
         chmod 600 ~/.ssh/id_rsa
         echo "${{ secrets.server_ip }} ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBE1Kkopomm7FHG5enATf7SgnpICZ4W2bw+Ho+afqin+w7sMcrsa0je7sbztFAV8YchDkiBKnWTG4cRT+KZgZCaY=" > ~/.ssh/known_hosts
-      if: github.event_name == 'push'
+      if: ${{github.event_name == 'push' && github.ref == 'refs/head/master'}}
 
     - name: Upload web
       run: rsync -az --delete --exclude='pandas-docs' --exclude='docs' --exclude='Pandas_Cheat_Sheet*' web/build/ docs@${{ secrets.server_ip }}:/usr/share/nginx/pandas
-      if: github.event_name == 'push'
+      if: ${{github.event_name == 'push' && github.ref == 'refs/head/master'}}
 
     - name: Upload dev docs
       run: rsync -az --delete doc/build/html/ docs@${{ secrets.server_ip }}:/usr/share/nginx/pandas/pandas-docs/dev
-      if: github.event_name == 'push'
+      if: ${{github.event_name == 'push' && github.ref == 'refs/head/master'}}
 
     - name: Move docs into site directory
       run: mv doc/build/html web/build/docs


### PR DESCRIPTION
- [ ] closes #39696
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

cc @simonjayhawkins 

How this was tested

I made a fake 1.3.x branch which is actually just a copy of master.

I applied these changes, and GHA triggered on my fork. I also verifyed that Installing the ssh key and uploading docs were skipped.
See the run here.
https://github.com/lithomas1/pandas/runs/3081634451?check_suite_focus=true
