### PR TITLE
PERF: select_dtypes

### DIFF
--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -474,7 +474,11 @@ class BaseArrayManager(DataManager):
         indices = [i for i, arr in enumerate(self.arrays) if predicate(arr)]
         arrays = [self.arrays[i] for i in indices]
         # TODO copy?
-        new_axes = [self._axes[0], self._axes[1][np.array(indices, dtype="intp")]]
+        # Note: using Index.take ensures we can retain e.g. DatetimeIndex.freq,
+        #  see test_describe_datetime_columns
+        taker = np.array(indices, dtype="intp")
+        new_cols = self._axes[1].take(taker)
+        new_axes = [self._axes[0], new_cols]
         return type(self)(arrays, new_axes, verify_integrity=False)
 
     def get_bool_data(self: T, copy: bool = False) -> T:


### PR DESCRIPTION
```
In [1]: from asv_bench.benchmarks.dtypes import *

In [2]: cls = SelectDtypes

In [3]: self = cls()

In [4]: dtype = "Int32"

In [5]: self.setup(dtype)

In [6]: %timeit self.time_select_dtype_string_exclude(dtype)
1.79 ms ± 50.7 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)   # <-- master
47.7 µs ± 461 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)  # <-- PR
```