### PR TITLE
DOC: fix small issues

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2988,7 +2988,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         --------
         DataFrame.to_csv : Write a DataFrame to a comma-separated values
             (csv) file.
-        read_clipboard : Read text from clipboard and pass to read_table.
+        read_clipboard : Read text from clipboard and pass to read_csv.
 
         Notes
         -----
@@ -2996,7 +2996,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
           - Linux : `xclip`, or `xsel` (with `PyQt4` modules)
           - Windows : none
-          - OS X : none
+          - macOS : none
 
         Examples
         --------


### PR DESCRIPTION
read_clipboard passes the text to read_csv not read_table. See here for example: https://pandas.pydata.org/docs/dev/reference/api/pandas.read_clipboard.html

also replace "OS X" -> macOS

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
