### PR TITLE
CI: Try to speed up ArrayManager

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -30,7 +30,7 @@ fi
 echo $PYTEST_CMD
 sh -c "$PYTEST_CMD"
 
-if [[ $(PANDAS_DATA_MANAGER) != "array"]]; then
+if [[ $(PANDAS_DATA_MANAGER) != "array" ]]; then
     # The ArrayManager tests should have already been run by PYTEST_CMD if PANDAS_DATA_MANAGER was already set to array
     PYTEST_AM_CMD="PANDAS_DATA_MANAGER=array pytest -m \"$PATTERN and arraymanager\" -n $PYTEST_WORKERS  --dist=loadfile $TEST_ARGS $COVERAGE pandas"
 

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -30,7 +30,10 @@ fi
 echo $PYTEST_CMD
 sh -c "$PYTEST_CMD"
 
-PYTEST_AM_CMD="PANDAS_DATA_MANAGER=array pytest -m \"$PATTERN and arraymanager\" -n $PYTEST_WORKERS  --dist=loadfile $TEST_ARGS $COVERAGE pandas"
+if [[ $(PANDAS_DATA_MANAGER) != "array"]]; then
+    # The ArrayManager tests should have already been run by PYTEST_CMD if PANDAS_DATA_MANAGER was already set to array
+    PYTEST_AM_CMD="PANDAS_DATA_MANAGER=array pytest -m \"$PATTERN and arraymanager\" -n $PYTEST_WORKERS  --dist=loadfile $TEST_ARGS $COVERAGE pandas"
 
-echo $PYTEST_AM_CMD
-sh -c "$PYTEST_AM_CMD"
+    echo $PYTEST_AM_CMD
+    sh -c "$PYTEST_AM_CMD"
+fi

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -30,7 +30,7 @@ fi
 echo $PYTEST_CMD
 sh -c "$PYTEST_CMD"
 
-if [[ $(PANDAS_DATA_MANAGER) != "array" ]]; then
+if [[ "$PANDAS_DATA_MANAGER" != "array" ]]; then
     # The ArrayManager tests should have already been run by PYTEST_CMD if PANDAS_DATA_MANAGER was already set to array
     PYTEST_AM_CMD="PANDAS_DATA_MANAGER=array pytest -m \"$PATTERN and arraymanager\" -n $PYTEST_WORKERS  --dist=loadfile $TEST_ARGS $COVERAGE pandas"
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

Don't re-run ArrayManager tests if we are already in ArrayManager mode.

P.S. I'm not sure what the arraymanager marker is supposed to be for. If it only runs the frame tests, wouldn't it be better to just specify that directly in the ``PYTEST_AM_CMD``.
