### PR TITLE
pd.to_datetime() fails for KeyError when raising monotonic increasing index ValueError

### DIFF
--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2535,8 +2535,8 @@ def test_empty_string_datetime_coerce__unit():
 @pytest.mark.parametrize("cache", [True, False])
 def test_to_datetime_monotonic_increasing_index(cache):
     # GH28238
-    times = date_range(pd.Timestamp("2002"), periods=3, freq="h")
-    times = times.to_frame(index=False, name="DT").sample()
+    times = Series([Timestamp("2002"), Timestamp("2012"), Timestamp("2020")])
+    times = times.to_frame(name="DT").sample(3)
     times.index = times.index.to_series().astype(float) / 1000
     result = to_datetime(times.iloc[:, 0], cache=cache)
     expected = times.iloc[:, 0]

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2535,8 +2535,8 @@ def test_empty_string_datetime_coerce__unit():
 @pytest.mark.parametrize("cache", [True, False])
 def test_to_datetime_monotonic_increasing_index(cache):
     # GH28238
-    times = Series([Timestamp("2002"), Timestamp("2012"), Timestamp("2020")])
-    times = times.to_frame(name="DT").sample(3)
+    times = pd.date_range(pd.Timestamp("1980"), periods=50, freq="YS")
+    times = times.to_frame(index=False, name="DT").sample(50)
     times.index = times.index.to_series().astype(float) / 1000
     result = to_datetime(times.iloc[:, 0], cache=cache)
     expected = times.iloc[:, 0]

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2530,3 +2530,16 @@ def test_empty_string_datetime_coerce__unit():
     # verify that no exception is raised even when errors='raise' is set
     result = to_datetime([1, ""], unit="s", errors="raise")
     tm.assert_index_equal(expected, result)
+
+
+def test_to_datetime_monotonic_increasing_index():
+    # GH28238
+    # Create date range of 1000 hour periods
+    times = pd.date_range(datetime.now(), periods=1000, freq='h')
+    # Random sort
+    times = times.to_frame(index=False, name='DT').sample(1000)
+    # Divide index integers by 1000
+    times.index = times.index.to_series().astype(float) / 1000
+    # Convert to datetime
+    result = pd.to_datetime(times.iloc[:, 0])
+    assert result.values.dtype == np.dtype('datetime64[ns]')

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2532,12 +2532,12 @@ def test_empty_string_datetime_coerce__unit():
     tm.assert_index_equal(expected, result)
 
 
-def test_to_datetime_monotonic_increasing_index():
+@pytest.mark.parametrize("cache", [True, False])
+def test_to_datetime_monotonic_increasing_index(cache):
     # GH28238
-    times = date_range(datetime.now(), periods=1000, freq="h")
-    times = times.to_frame(index=False, name="DT").sample(1000)
+    times = date_range(pd.Timestamp("2002"), periods=3, freq="h")
+    times = times.to_frame(index=False, name="DT").sample()
     times.index = times.index.to_series().astype(float) / 1000
-    converted = to_datetime(times.iloc[:, 0])
-    expected = np.ravel(times.values)
-    result = np.ravel(converted.values)
-    tm.assert_equal(result, expected)
+    result = to_datetime(times.iloc[:, 0], cache=cache)
+    expected = times.iloc[:, 0]
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2535,8 +2535,8 @@ def test_empty_string_datetime_coerce__unit():
 @pytest.mark.parametrize("cache", [True, False])
 def test_to_datetime_monotonic_increasing_index(cache):
     # GH28238
-    times = pd.date_range(pd.Timestamp("1980"), periods=50, freq="YS")
-    times = times.to_frame(index=False, name="DT").sample(50)
+    times = date_range(Timestamp("1980"), periods=50, freq="YS")
+    times = times.to_frame(index=False, name="DT").sample(n=50, random_state=1)
     times.index = times.index.to_series().astype(float) / 1000
     result = to_datetime(times.iloc[:, 0], cache=cache)
     expected = times.iloc[:, 0]

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2535,8 +2535,9 @@ def test_empty_string_datetime_coerce__unit():
 @pytest.mark.parametrize("cache", [True, False])
 def test_to_datetime_monotonic_increasing_index(cache):
     # GH28238
+    cstart = start_caching_at
     times = date_range(Timestamp("1980"), periods=50, freq="YS")
-    times = times.to_frame(index=False, name="DT").sample(n=50, random_state=1)
+    times = times.to_frame(index=False, name="DT").sample(n=cstart, random_state=1)
     times.index = times.index.to_series().astype(float) / 1000
     result = to_datetime(times.iloc[:, 0], cache=cache)
     expected = times.iloc[:, 0]

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2534,12 +2534,10 @@ def test_empty_string_datetime_coerce__unit():
 
 def test_to_datetime_monotonic_increasing_index():
     # GH28238
-    # Create date range of 1000 hour periods
     times = date_range(datetime.now(), periods=1000, freq="h")
-    # Random sort
     times = times.to_frame(index=False, name="DT").sample(1000)
-    # Divide index integers by 1000
     times.index = times.index.to_series().astype(float) / 1000
-    # Convert to datetime
-    result = to_datetime(times.iloc[:, 0])
-    assert result.values.dtype == np.dtype("datetime64[ns]")
+    converted = to_datetime(times.iloc[:, 0])
+    expected = np.ravel(times.values)
+    result = np.ravel(converted.values)
+    tm.assert_equal(result, expected)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2535,11 +2535,11 @@ def test_empty_string_datetime_coerce__unit():
 def test_to_datetime_monotonic_increasing_index():
     # GH28238
     # Create date range of 1000 hour periods
-    times = pd.date_range(datetime.now(), periods=1000, freq='h')
+    times = date_range(datetime.now(), periods=1000, freq="h")
     # Random sort
-    times = times.to_frame(index=False, name='DT').sample(1000)
+    times = times.to_frame(index=False, name="DT").sample(1000)
     # Divide index integers by 1000
     times.index = times.index.to_series().astype(float) / 1000
     # Convert to datetime
-    result = pd.to_datetime(times.iloc[:, 0])
-    assert result.values.dtype == np.dtype('datetime64[ns]')
+    result = to_datetime(times.iloc[:, 0])
+    assert result.values.dtype == np.dtype("datetime64[ns]")

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2536,7 +2536,7 @@ def test_empty_string_datetime_coerce__unit():
 def test_to_datetime_monotonic_increasing_index(cache):
     # GH28238
     cstart = start_caching_at
-    times = date_range(Timestamp("1980"), periods=50, freq="YS")
+    times = date_range(Timestamp("1980"), periods=cstart, freq="YS")
     times = times.to_frame(index=False, name="DT").sample(n=cstart, random_state=1)
     times.index = times.index.to_series().astype(float) / 1000
     result = to_datetime(times.iloc[:, 0], cache=cache)


### PR DESCRIPTION
- [x] closes #28238
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

Test added to test_to_datetime.py to test the conversion to datetime for a series with a float index.