### PR TITLE
BUG: Pass copy argument to expanddim constructor in concat.

### DIFF
--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -504,7 +504,7 @@ class _Concatenator:
                 cons = sample._constructor_expanddim
 
                 index, columns = self.new_axes
-                df = cons(data, index=index)
+                df = cons(data, index=index, copy=self.copy)
                 df.columns = columns
                 return df.__finalize__(self, method="concat")
 

--- a/pandas/tests/reshape/concat/test_concat.py
+++ b/pandas/tests/reshape/concat/test_concat.py
@@ -653,3 +653,14 @@ def test_concat_posargs_deprecation():
         result = concat([df, df2], 0)
     expected = DataFrame([[1, 2, 3], [4, 5, 6]], index=["a", "b"])
     tm.assert_frame_equal(result, expected)
+
+
+def test_concat_series_copy_false():
+    # GH 42501
+    first_position_value = 1
+    first_series = Series([first_position_value, 2], dtype=np.int64)
+
+    df = concat([first_series, Series([3, 4], dtype=np.int64)], axis=1, copy=False)
+
+    df.iloc[0, 0] = first_position_value + 1
+    assert first_series.iloc[0] != first_position_value


### PR DESCRIPTION
- [x] closes #42501
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

Pass the provided copy argument through to the DataFrame constructor when constructing a DataFrame from a Series iterable, as is done with the other DataFrame construction call in the get_result method.