### PR TITLE
BUG: KeyError when a series popped from data frame with bool indexer

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -224,7 +224,7 @@ Indexing
 - Bug in :meth:`Series.loc` when with a :class:`MultiIndex` whose first level contains only ``np.nan`` values (:issue:`42055`)
 - Bug in indexing on a :class:`Series` or :class:`DataFrame` with a :class:`DatetimeIndex` when passing a string, the return type depended on whether the index was monotonic (:issue:`24892`)
 - Bug in indexing on a :class:`MultiIndex` failing to drop scalar levels when the indexer is a tuple containing a datetime-like string (:issue:`42476`)
--
+- Bug in updating values of :class:`pandas.Series` using boolean index, created by using :meth:`pandas.DataFrame.pop` (:issue:`42530`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1233,14 +1233,15 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             # a copy
             if ref is None:
                 del self._cacher
+            elif len(self) == len(ref) and self.name in ref.columns:
+                # GH#42530 self.name must be in ref.columns
+                # to ensure column still in dataframe
+                # otherwise, either self or ref has swapped in new arrays
+                ref._maybe_cache_changed(cacher[0], self)
             else:
-                if len(self) == len(ref) and self.name in ref.columns:  # GH#42530
-                    # otherwise, either self or ref has swapped in new arrays
-                    ref._maybe_cache_changed(cacher[0], self)
-                else:
-                    # GH#33675 we have swapped in a new array, so parent
-                    #  reference to self is now invalid
-                    ref._item_cache.pop(cacher[0], None)
+                # GH#33675 we have swapped in a new array, so parent
+                #  reference to self is now invalid
+                ref._item_cache.pop(cacher[0], None)
 
         super()._maybe_update_cacher(clear=clear, verify_is_copy=verify_is_copy)
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1234,7 +1234,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             if ref is None:
                 del self._cacher
             else:
-                if len(self) == len(ref):
+                if len(self) == len(ref) and self.name in ref.columns:  # GH#42530
                     # otherwise, either self or ref has swapped in new arrays
                     ref._maybe_cache_changed(cacher[0], self)
                 else:

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -957,6 +957,6 @@ def test_setitem_with_bool_indexer():
     expected = Series(data=[9, 5, 6], name="b")
     tm.assert_series_equal(result, expected)
 
-    df["a"][[True, False, False]] = 10
+    df.loc[[True, False, False], "a"] = 10
     expected = DataFrame({"a": [10, 2, 3]})
     tm.assert_frame_equal(df, expected)

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -8,6 +8,7 @@ import pytest
 
 from pandas import (
     Categorical,
+    DataFrame,
     DatetimeIndex,
     Index,
     IntervalIndex,
@@ -945,3 +946,17 @@ def test_setitem_int_as_positional_fallback_deprecation():
     with tm.assert_produces_warning(FutureWarning, match=msg):
         ser3[4] = 99
     tm.assert_series_equal(ser3, expected3)
+
+
+def test_setitem_with_bool_indexer():
+    # GH#42530
+
+    df = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    result = df.pop("b")
+    result[[True, False, False]] = 9
+    expected = Series(data=[9, 5, 6], index=range(3), name="b")
+    tm.assert_series_equal(result, expected)
+
+    df["a"][[True, False, False]] = 10
+    expected_df = DataFrame({"a": [10, 2, 3]})
+    tm.assert_frame_equal(df, expected_df)

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -954,9 +954,9 @@ def test_setitem_with_bool_indexer():
     df = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     result = df.pop("b")
     result[[True, False, False]] = 9
-    expected = Series(data=[9, 5, 6], index=range(3), name="b")
+    expected = Series(data=[9, 5, 6], name="b")
     tm.assert_series_equal(result, expected)
 
     df["a"][[True, False, False]] = 10
-    expected_df = DataFrame({"a": [10, 2, 3]})
-    tm.assert_frame_equal(df, expected_df)
+    expected = DataFrame({"a": [10, 2, 3]})
+    tm.assert_frame_equal(df, expected)


### PR DESCRIPTION

- [x] closes #42530
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
