### PR TITLE
DOC: fix small typo in HDF section of cookbook docs

### DIFF
--- a/doc/source/user_guide/cookbook.rst
+++ b/doc/source/user_guide/cookbook.rst
@@ -1300,7 +1300,7 @@ is closed.
 
 .. ipython:: python
 
-   store = pd.HDFStore("test.h5", "w", diver="H5FD_CORE")
+   store = pd.HDFStore("test.h5", "w", driver="H5FD_CORE")
 
    df = pd.DataFrame(np.random.randn(8, 3))
    store["test"] = df


### PR DESCRIPTION
This merge request fixes a trivial typo (diver -> driver) I found while reading docs about HDF support.

- [-] closes #xxxx
- [-] tests added / passed
- [-] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [-] whatsnew entry
