### PR TITLE
BUG: compute.use_numexpr option not respected

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -201,7 +201,7 @@ Numeric
 ^^^^^^^
 - Bug in :meth:`DataFrame.rank` raising ``ValueError`` with ``object`` columns and ``method="first"`` (:issue:`41931`)
 - Bug in :meth:`DataFrame.rank` treating missing values and extreme values as equal (for example ``np.nan`` and ``np.inf``), causing incorrect results when ``na_option="bottom"`` or ``na_option="top`` used (:issue:`41931`)
--
+- Bug in ``numexpr`` engine still being used when the option ``compute.use_numexpr`` is set to ``False`` (:issue:`32556`)
 
 Conversion
 ^^^^^^^^^^

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -43,9 +43,10 @@ def _check_engine(engine: str | None) -> str:
         Engine name.
     """
     from pandas.core.computation.check import NUMEXPR_INSTALLED
+    from pandas.core.computation.expressions import USE_NUMEXPR
 
     if engine is None:
-        engine = "numexpr" if NUMEXPR_INSTALLED else "python"
+        engine = "numexpr" if USE_NUMEXPR else "python"
 
     if engine not in ENGINES:
         valid_engines = list(ENGINES.keys())

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -1880,6 +1880,18 @@ def test_numexpr_option_respected(use_numexpr):
 
 
 @td.skip_if_no_ne
+def test_numexpr_option_incompatible_op():
+    # GH 32556
+    with pd.option_context("compute.use_numexpr", False):
+        df = DataFrame(
+            {"A": [True, False, True, False, None, None], "B": [1, 2, 3, 4, 5, 6]}
+        )
+        result = df.query("A.isnull()")
+        expected = DataFrame({"A": [None, None], "B": [5, 6]}, index=[4, 5])
+        tm.assert_frame_equal(result, expected)
+
+
+@td.skip_if_no_ne
 def test_invalid_parser():
     msg = "Invalid parser 'asdf' passed"
     with pytest.raises(KeyError, match=msg):

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -1866,17 +1866,20 @@ def test_invalid_engine():
 
 
 @td.skip_if_no_ne
-@pytest.mark.parametrize("use_numexpr", [True, False])
-def test_numexpr_option_respected(use_numexpr):
+@pytest.mark.parametrize(
+    ("use_numexpr", "expected"),
+    (
+        (True, "numexpr"),
+        (False, "python"),
+    ),
+)
+def test_numexpr_option_respected(use_numexpr, expected):
     # GH 32556
     from pandas.core.computation.eval import _check_engine
 
     with pd.option_context("compute.use_numexpr", use_numexpr):
         result = _check_engine(None)
-        if use_numexpr:
-            assert result == "numexpr"
-        else:
-            assert result == "python"
+        assert result == expected
 
 
 @td.skip_if_no_ne

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -1866,6 +1866,16 @@ def test_invalid_engine():
 
 
 @td.skip_if_no_ne
+def test_numexpr_option_respected():
+    # GH 32556
+    from pandas.core.computation.eval import _check_engine
+
+    with pd.option_context("compute.use_numexpr", False):
+        result = _check_engine(None)
+        assert result == "python"
+
+
+@td.skip_if_no_ne
 def test_invalid_parser():
     msg = "Invalid parser 'asdf' passed"
     with pytest.raises(KeyError, match=msg):

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -1866,13 +1866,17 @@ def test_invalid_engine():
 
 
 @td.skip_if_no_ne
-def test_numexpr_option_respected():
+@pytest.mark.parametrize("use_numexpr", [True, False])
+def test_numexpr_option_respected(use_numexpr):
     # GH 32556
     from pandas.core.computation.eval import _check_engine
 
-    with pd.option_context("compute.use_numexpr", False):
+    with pd.option_context("compute.use_numexpr", use_numexpr):
         result = _check_engine(None)
-        assert result == "python"
+        if use_numexpr:
+            assert result == "numexpr"
+        else:
+            assert result == "python"
 
 
 @td.skip_if_no_ne


### PR DESCRIPTION
- [x] closes #32556
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
