### PR TITLE
BUG: ArrayManager construction unwanted copy

### DIFF
--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -331,14 +331,14 @@ def ndarray_to_mgr(
         if dtype is None and is_object_dtype(values.dtype):
             arrays = [
                 ensure_wrapped_if_datetimelike(
-                    maybe_infer_to_datetimelike(values[:, i].copy())
+                    maybe_infer_to_datetimelike(values[:, i])
                 )
                 for i in range(values.shape[1])
             ]
         else:
             if is_datetime_or_timedelta_dtype(values.dtype):
                 values = ensure_wrapped_if_datetimelike(values)
-            arrays = [values[:, i].copy() for i in range(values.shape[1])]
+            arrays = [values[:, i] for i in range(values.shape[1])]
 
         return ArrayManager(arrays, [index, columns], verify_integrity=False)
 

--- a/pandas/tests/frame/methods/test_values.py
+++ b/pandas/tests/frame/methods/test_values.py
@@ -226,10 +226,7 @@ class TestDataFrameValues:
 
 
 class TestPrivateValues:
-    def test_private_values_dt64tz(self, using_array_manager, request):
-        if using_array_manager:
-            mark = pytest.mark.xfail(reason="doesn't share memory")
-            request.node.add_marker(mark)
+    def test_private_values_dt64tz(self, request):
 
         dta = date_range("2000", periods=4, tz="US/Central")._data.reshape(-1, 1)
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

This is also going to be necessary in order to allow round-tripping DataFrame(arr).values as a view on arr