### PR TITLE
CI: Add numba back to 3.9 env

### DIFF
--- a/ci/deps/actions-39-slow.yaml
+++ b/ci/deps/actions-39-slow.yaml
@@ -23,6 +23,7 @@ dependencies:
   - matplotlib
   - moto>=1.3.14
   - flask
+  - numba
   - numexpr
   - numpy
   - openpyxl

--- a/ci/deps/actions-39.yaml
+++ b/ci/deps/actions-39.yaml
@@ -22,6 +22,7 @@ dependencies:
   - matplotlib
   - moto>=1.3.14
   - flask
+  - numba
   - numexpr
   - numpy
   - openpyxl

--- a/ci/deps/azure-windows-39.yaml
+++ b/ci/deps/azure-windows-39.yaml
@@ -23,6 +23,7 @@ dependencies:
   - matplotlib
   - moto>=1.3.14
   - flask
+  - numba
   - numexpr
   - numpy
   - openpyxl


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

Oversight from my other PR syncing 3.9 builds