### PR TITLE
DEPR: special-casing dt64/td64 in Series.unique

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -15,6 +15,7 @@ from typing import (
     cast,
     final,
 )
+import warnings
 
 import numpy as np
 
@@ -34,6 +35,7 @@ from pandas.util._decorators import (
     cache_readonly,
     doc,
 )
+from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.common import (
     is_categorical_dtype,
@@ -977,6 +979,14 @@ class IndexOpsMixin(OpsMixin):
             if self.dtype.kind in ["m", "M"] and isinstance(self, ABCSeries):
                 # GH#31182 Series._values returns EA, unpack for backward-compat
                 if getattr(self.dtype, "tz", None) is None:
+
+                    warnings.warn(
+                        f"Series.unique behavior with {self.dtype} dtype is "
+                        "deprecated. In a future version this will return a "
+                        f"{type(self._values)} instead of a np.ndarray",
+                        FutureWarning,
+                        stacklevel=find_stack_level(),
+                    )
                     result = np.asarray(result)
         else:
             result = unique1d(values)

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -70,7 +70,9 @@ def assert_stat_op_calc(
     f = getattr(frame, opname)
 
     if check_dates:
-        expected_warning = FutureWarning if opname in ["mean", "median"] else None
+        expected_warning = (
+            FutureWarning if opname in ["mean", "median", "nunique"] else None
+        )
         df = DataFrame({"b": date_range("1/1/2001", periods=2)})
         with tm.assert_produces_warning(expected_warning):
             result = getattr(df, opname)()

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -625,7 +625,8 @@ class TestMerge:
             ],
         }
         df = DataFrame.from_dict(d)
-        var3 = df.var3.unique()
+        with tm.assert_produces_warning(FutureWarning, match="DatetimeArray"):
+            var3 = df.var3.unique()
         var3.sort()
         new = DataFrame.from_dict({"var3": var3, "var8": np.random.random(7)})
 
@@ -633,7 +634,10 @@ class TestMerge:
         exp = merge(df, new, on="var3", sort=False)
         tm.assert_frame_equal(result, exp)
 
-        assert (df.var3.unique() == result.var3.unique()).all()
+        with tm.assert_produces_warning(FutureWarning, match="DatetimeArray"):
+            res = df.var3.unique()
+            expected = result.var3.unique()
+        assert (res == expected).all()
 
     @pytest.mark.parametrize(
         ("sort", "values"), [(False, [1, 1, 0, 1, 1]), (True, [0, 1, 1, 1, 1])]

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -534,7 +534,13 @@ class TestUnique:
             data = [1, 2, 2]
             uniques = [1, 2]
 
-        result = Series(data, dtype=any_numpy_dtype).unique()
+        warn = None
+        if np.dtype(any_numpy_dtype).kind in ["m", "M"]:
+            warn = FutureWarning
+
+        ser = Series(data, dtype=any_numpy_dtype)
+        with tm.assert_produces_warning(warn, match="DatetimeArray|TimedeltaArray"):
+            result = ser.unique()
         expected = np.array(uniques, dtype=any_numpy_dtype)
 
         tm.assert_numpy_array_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

```
dti = pd.date_range('2016-01-01', periods=3).repeat(2)
ser = pd.Series(dti)

>>> ser.unique()
<stdin>:1: FutureWarning: Series.unique behavior with datetime64[ns] dtype is deprecated. In a future version this will return a <class 'pandas.core.arrays.datetimes.DatetimeArray'> instead of a np.ndarray
array(['2016-01-01T00:00:00.000000000', '2016-01-02T00:00:00.000000000',
       '2016-01-03T00:00:00.000000000'], dtype='datetime64[ns]')

```