### PR TITLE
REG: DataFrame.agg where func returns lists and axis=1

### DIFF
--- a/doc/source/whatsnew/v1.3.2.rst
+++ b/doc/source/whatsnew/v1.3.2.rst
@@ -17,6 +17,7 @@ Fixed regressions
 - Performance regression in :meth:`DataFrame.isin` and :meth:`Series.isin` for nullable data types (:issue:`42714`)
 - Regression in updating values of :class:`pandas.Series` using boolean index, created by using :meth:`pandas.DataFrame.pop` (:issue:`42530`)
 - Regression in :meth:`DataFrame.from_records` with empty records (:issue:`42456`)
+- Regression in :meth:`DataFrame.agg` when the ``func`` argument returned lists and ``axis=1`` (:issue:`42727`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -644,13 +644,14 @@ def test_apply_dup_names_multi_agg():
     tm.assert_frame_equal(result, expected)
 
 
-def test_apply_nested_result_axis_1():
+@pytest.mark.parametrize("op", ["apply", "agg"])
+def test_apply_nested_result_axis_1(op):
     # GH 13820
     def apply_list(row):
         return [2 * row["A"], 2 * row["C"], 2 * row["B"]]
 
     df = DataFrame(np.zeros((4, 4)), columns=list("ABCD"))
-    result = df.apply(apply_list, axis=1)
+    result = getattr(df, op)(apply_list, axis=1)
     expected = Series(
         [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
     )


### PR DESCRIPTION
- [x] closes #42727
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

This reverts #40428. Once agg/apply paths are sorted out so that agg doesn't fall back to apply, we can redo #40428. See https://github.com/pandas-dev/pandas/issues/42727#issuecomment-887191683 for more details.