### PR TITLE
CI: remove styler from doctests

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -121,8 +121,7 @@ if [[ -z "$CHECK" || "$CHECK" == "doctests" ]]; then
       pandas/io/parsers/ \
       pandas/io/sas/ \
       pandas/io/sql.py \
-      pandas/tseries/ \
-      pandas/io/formats/style_render.py
+      pandas/tseries/
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
 fi


### PR DESCRIPTION
`styler_render.py` was prematurely added to doctesting in #42700 

We should revert this before the necessary devleopment is done to make the file ready for doctesting (that PR only fixed one example)
