### PR TITLE
BUG: 1D slices over extension types turn into N-dimensional slices over ExtensionArrays

### DIFF
--- a/doc/source/whatsnew/v1.3.2.rst
+++ b/doc/source/whatsnew/v1.3.2.rst
@@ -26,7 +26,7 @@ Fixed regressions
 
 Bug fixes
 ~~~~~~~~~
--
+- 1D slices over extension types turn into N-dimensional slices over ExtensionArrays (:issue:`42430`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1552,12 +1552,8 @@ class ExtensionBlock(libinternals.Block, EABackedBlock):
     def getitem_block_index(self, slicer: slice) -> ExtensionBlock:
         """
         Perform __getitem__-like specialized to slicing along index.
-
-        Assumes self.ndim == 2
         """
-        # error: Invalid index type "Tuple[ellipsis, slice]" for
-        # "Union[ndarray, ExtensionArray]"; expected type "Union[int, slice, ndarray]"
-        new_values = self.values[..., slicer]  # type: ignore[index]
+        new_values = self.array_values[slicer]
         return type(self)(new_values, self._mgr_locs, ndim=self.ndim)
 
     def fillna(

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1553,7 +1553,9 @@ class ExtensionBlock(libinternals.Block, EABackedBlock):
         """
         Perform __getitem__-like specialized to slicing along index.
         """
-        new_values = self.array_values[slicer]
+        # GH#42787 in principle this is equivalent to values[..., slicer], but we don't
+        # require subclasses of ExtensionArray to support that form (for now).
+        new_values = self.values[slicer]
         return type(self)(new_values, self._mgr_locs, ndim=self.ndim)
 
     def fillna(

--- a/pandas/tests/arrays/test_array.py
+++ b/pandas/tests/arrays/test_array.py
@@ -327,7 +327,8 @@ def test_ellipsis_index():
             return super().__getitem__(item)
 
     df = pd.DataFrame(
-        {"col1": CapturingStringArray(np.array(["hello", "world"], dtype=object))})
+        {"col1": CapturingStringArray(np.array(["hello", "world"], dtype=object))}
+    )
     _ = df.iloc[:1]
 
     # String comparison because there's no native way to compare slices.

--- a/pandas/tests/arrays/test_array.py
+++ b/pandas/tests/arrays/test_array.py
@@ -317,26 +317,6 @@ def test_bounds_check():
         pd.array([-1, 2, 3], dtype="UInt16")
 
 
-def test_ellipsis_index():
-    # GH42430
-    class CapturingStringArray(pd.arrays.StringArray):
-        """Extend StringArray to capture arguments to __getitem__"""
-
-        def __getitem__(self, item):
-            self.last_item_arg = item
-            return super().__getitem__(item)
-
-    df = pd.DataFrame(
-        {"col1": CapturingStringArray(np.array(["hello", "world"], dtype=object))}
-    )
-    _ = df.iloc[:1]
-
-    # String comparison because there's no native way to compare slices.
-    # Before the fix for GH42430, last_item_arg would get set to the 2D slice
-    # (Ellipsis, slice(None, 1, None))
-    tm.assert_equal(str(df["col1"].array.last_item_arg), "slice(None, 1, None)")
-
-
 # ---------------------------------------------------------------------------
 # A couple dummy classes to ensure that Series and Indexes are unboxed before
 # getting to the EA classes.

--- a/pandas/tests/extension/base/getitem.py
+++ b/pandas/tests/extension/base/getitem.py
@@ -425,3 +425,23 @@ class BaseGetitemTests(BaseExtensionTests):
 
         with pytest.raises(ValueError, match=msg):
             s.item()
+
+    def test_ellipsis_index(self):
+        # GH42430 1D slices over extension types turn into N-dimensional slices over
+        #  ExtensionArrays
+        class CapturingStringArray(pd.arrays.StringArray):
+            """Extend StringArray to capture arguments to __getitem__"""
+
+            def __getitem__(self, item):
+                self.last_item_arg = item
+                return super().__getitem__(item)
+
+        df = pd.DataFrame(
+            {"col1": CapturingStringArray(np.array(["hello", "world"], dtype=object))}
+        )
+        _ = df.iloc[:1]
+
+        # String comparison because there's no native way to compare slices.
+        # Before the fix for GH42430, last_item_arg would get set to the 2D slice
+        # (Ellipsis, slice(None, 1, None))
+        self.assert_equal(str(df["col1"].array.last_item_arg), "slice(None, 1, None)")


### PR DESCRIPTION
- [X] closes #42430
- [X] tests added / passed
- [X] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [X] whatsnew entry

This PR contains a 1-line patch for issue #42430, plus a regression test to ensure the issue does not recur.

Before this change, `ExtensionBlock. getitem_block_index()` would request 2D slices of a block's underlying extension array, even though the `__getitem__()` method of `ExtensionArray` is (currently) only supposed to support 1D slicing. After the change, `getitem_block_index()` requests 1D slices. The change also fixes some linter/type checking errors.