### PR TITLE
CI: Fix doctests

### DIFF
--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -405,9 +405,7 @@ def extract_array(
     For an ndarray-backed Series / Index a PandasArray is returned.
 
     >>> extract_array(pd.Series([1, 2, 3]))
-    <PandasArray>
-    [1, 2, 3]
-    Length: 3, dtype: int64
+    array([1, 2, 3])
 
     To extract all the way down to the ndarray, pass ``extract_numpy=True``.
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5407,6 +5407,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         keyarr = self.take(indexer)
         if isinstance(key, Index):
+            # GH 42790 - Preserve name from an Index
             keyarr.name = key.name
         if keyarr.dtype.kind in ["m", "M"]:
             # DTI/TDI.take can infer a freq in some cases when we dont want one

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5406,6 +5406,8 @@ class Index(IndexOpsMixin, PandasObject):
         self._raise_if_missing(keyarr, indexer, axis_name)
 
         keyarr = self.take(indexer)
+        if isinstance(key, Index):
+            keyarr.name = key.name
         if keyarr.dtype.kind in ["m", "M"]:
             # DTI/TDI.take can infer a freq in some cases when we dont want one
             if isinstance(key, list) or (

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -2433,7 +2433,7 @@ class TestLocListlike:
             ser.loc[keys]
 
     def test_loc_named_index(self):
-        # GH ???
+        # GH 42790
         df = DataFrame(
             [[1, 2], [4, 5], [7, 8]],
             index=["cobra", "viper", "sidewinder"],

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -2432,6 +2432,18 @@ class TestLocListlike:
         with pytest.raises(KeyError, match="not in index"):
             ser.loc[keys]
 
+    def test_loc_named_index(self):
+        # GH ???
+        df = DataFrame(
+            [[1, 2], [4, 5], [7, 8]],
+            index=["cobra", "viper", "sidewinder"],
+            columns=["max_speed", "shield"],
+        )
+        expected = df.iloc[:2]
+        expected.index.name = "foo"
+        result = df.loc[Index(["cobra", "viper"], name="foo")]
+        tm.assert_frame_equal(result, expected)
+
 
 @pytest.mark.parametrize(
     "columns, column_key, expected_columns",


### PR DESCRIPTION
- [x] closes #42798
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

Fixes three doctest failures on master. 

One is from #42569, where name is no longer preserved when passing a named Index into `.loc`. We want to preserve the name when passed an Index (this was documented), but certainly not a boolean Series mask. Not certain if there are cases outside of Index where it should be preserved. cc @jbrockmendel