### PR TITLE
REGR: nanosecond timestamp comparisons to OOB datetimes

### DIFF
--- a/doc/source/whatsnew/v1.3.2.rst
+++ b/doc/source/whatsnew/v1.3.2.rst
@@ -18,7 +18,8 @@ Fixed regressions
 - Regression in updating values of :class:`pandas.Series` using boolean index, created by using :meth:`pandas.DataFrame.pop` (:issue:`42530`)
 - Regression in :meth:`DataFrame.from_records` with empty records (:issue:`42456`)
 - Fixed regression in :meth:`DataFrame.shift` where TypeError occurred when shifting DataFrame created by concatenation of slices and fills with values (:issue:`42719`)
-- Fixed regression in comparisons between :class:`Timestamp` object and ``datetime`` objects outside the implementation bounds for nanosecond ``datetime`` (:issue:`42794`)
+- Fixed regression in comparisons between :class:`Timestamp` object and ``datetime64`` objects outside the implementation bounds for nanosecond ``datetime64`` (:issue:`42794`)
+-
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.3.2.rst
+++ b/doc/source/whatsnew/v1.3.2.rst
@@ -18,7 +18,7 @@ Fixed regressions
 - Regression in updating values of :class:`pandas.Series` using boolean index, created by using :meth:`pandas.DataFrame.pop` (:issue:`42530`)
 - Regression in :meth:`DataFrame.from_records` with empty records (:issue:`42456`)
 - Fixed regression in :meth:`DataFrame.shift` where TypeError occurred when shifting DataFrame created by concatenation of slices and fills with values (:issue:`42719`)
--
+- Fixed regression in comparisons between :class:`Timestamp` object and ``datetime`` objects outside the implementation bounds for nanosecond ``datetime`` (:issue:`42794`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -270,9 +270,9 @@ cdef class _Timestamp(ABCTimestamp):
         if op == Py_EQ:
             return False
         if op == Py_LE or op == Py_LT:
-            return other.year <= self.year
+            return self.year <= other.year
         if op == Py_GE or op == Py_GT:
-            return other.year >= self.year
+            return self.year >= other.year
 
     cdef bint _can_compare(self, datetime other):
         if self.tzinfo is not None:

--- a/pandas/tests/scalar/timestamp/test_comparisons.py
+++ b/pandas/tests/scalar/timestamp/test_comparisons.py
@@ -266,6 +266,15 @@ class TestTimestampComparison:
         assert Timestamp.max < other + us
         # Note: numpy gets the reversed comparison wrong
 
+        # GH-42794
+        other = datetime(9999, 9, 9)
+        assert Timestamp.min < other
+        assert Timestamp.max < other
+
+        other = datetime(1, 1, 1)
+        assert Timestamp.max > other
+        assert Timestamp.min > other
+
     def test_compare_zerodim_array(self):
         # GH#26916
         ts = Timestamp.now()

--- a/pandas/tests/scalar/timestamp/test_comparisons.py
+++ b/pandas/tests/scalar/timestamp/test_comparisons.py
@@ -269,11 +269,15 @@ class TestTimestampComparison:
         # GH-42794
         other = datetime(9999, 9, 9)
         assert Timestamp.min < other
+        assert other > Timestamp.min
         assert Timestamp.max < other
+        assert other > Timestamp.max
 
         other = datetime(1, 1, 1)
         assert Timestamp.max > other
+        assert other < Timestamp.max
         assert Timestamp.min > other
+        assert other < Timestamp.min
 
     def test_compare_zerodim_array(self):
         # GH#26916

--- a/pandas/tests/series/methods/test_clip.py
+++ b/pandas/tests/series/methods/test_clip.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import numpy as np
 import pytest
 
@@ -126,6 +128,15 @@ class TestSeriesClip:
                 Timestamp("2015-12-01 09:30:30", tz="US/Eastern"),
             ]
         )
+        tm.assert_series_equal(result, expected)
+
+    def test_clip_with_timestamps_and_oob_datetimes(self):
+        # GH-42794
+        ser = Series([datetime(1, 1, 1), datetime(9999, 9, 9)])
+
+        result = ser.clip(lower=Timestamp.min, upper=Timestamp.max)
+        expected = Series([Timestamp.min, Timestamp.max], dtype="object")
+
         tm.assert_series_equal(result, expected)
 
     def test_clip_pos_args_deprecation(self):


### PR DESCRIPTION
- [x] closes #42794
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
