### PR TITLE
BUG: `styler.hide_columns` now hides the index name header row

### DIFF
--- a/doc/source/whatsnew/v1.3.2.rst
+++ b/doc/source/whatsnew/v1.3.2.rst
@@ -31,7 +31,7 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 - 1D slices over extension types turn into N-dimensional slices over ExtensionArrays (:issue:`42430`)
--
+- :meth:`.Styler.hide_columns` now hides the index name header row as well as column headers (:issue:`42101`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -353,6 +353,7 @@ class StylerRenderer:
             self.data.index.names
             and com.any_not_none(*self.data.index.names)
             and not self.hide_index_
+            and not self.hide_columns_
         ):
             index_names = [
                 _element(

--- a/pandas/tests/io/formats/style/test_style.py
+++ b/pandas/tests/io/formats/style/test_style.py
@@ -1131,7 +1131,7 @@ class TestStyler:
 
         self.df.index.name = "some_name"
         ctx = self.df.style.hide_columns()._translate(True, True)
-        assert len(ctx["head"]) == 1  # only a single row for index names: no col heads
+        assert len(ctx["head"]) == 0  # no header for index names, changed in #42101
 
     def test_hide_single_index(self):
         # GH 14194


### PR DESCRIPTION
- [x] closes #42101
- [x] closes #42190 (stale pr)

Fixes `hide_columns` so that the index header row is also hidden alongside column headers.
Can be back ported to 1.3.2
