### PR TITLE
REGR: sample modifying `weights` inplace

### DIFF
--- a/pandas/core/sample.py
+++ b/pandas/core/sample.py
@@ -63,7 +63,11 @@ def preprocess_weights(obj: FrameOrSeries, weights, axis: int) -> np.ndarray:
     if (weights < 0).any():
         raise ValueError("weight vector many not include negative values")
 
-    weights[np.isnan(weights)] = 0
+    missing = np.isnan(weights)
+    if missing.any():
+        # Don't modify weights in place
+        weights = weights.copy()
+        weights[missing] = 0
     return weights
 
 

--- a/pandas/tests/frame/methods/test_sample.py
+++ b/pandas/tests/frame/methods/test_sample.py
@@ -340,7 +340,7 @@ class TestSampleDataFrame:
             df2["d"] = 1
 
     def test_sample_does_not_modify_weights(self):
-        # GH-?
+        # GH-42843
         result = np.array([np.nan, 1, np.nan])
         expected = result.copy()
         ser = Series([1, 2, 3])

--- a/pandas/tests/frame/methods/test_sample.py
+++ b/pandas/tests/frame/methods/test_sample.py
@@ -339,6 +339,24 @@ class TestSampleDataFrame:
         with tm.assert_produces_warning(None):
             df2["d"] = 1
 
+    def test_sample_does_not_modify_weights(self):
+        # GH-?
+        result = np.array([np.nan, 1, np.nan])
+        expected = result.copy()
+        ser = Series([1, 2, 3])
+
+        # Test numpy array weights won't be modified in place
+        ser.sample(weights=result)
+        tm.assert_numpy_array_equal(result, expected)
+
+        # Test DataFrame column won't be modified in place
+        df = DataFrame({"values": [1, 1, 1], "weights": [1, np.nan, np.nan]})
+        expected = df["weights"].copy()
+
+        df.sample(frac=1.0, replace=True, weights="weights")
+        result = df["weights"]
+        tm.assert_series_equal(result, expected)
+
     def test_sample_ignore_index(self):
         # GH 38581
         df = DataFrame(


### PR DESCRIPTION
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

Targeting 1.4 and no whatsnew since only a regression on master.
