### PR TITLE
ENH: Provide a method to convert DataFrames to structured arrays.

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -38,6 +38,7 @@ Other enhancements
 - Added ``sparse_index`` and ``sparse_columns`` keyword arguments to :meth:`.Styler.to_html` (:issue:`41946`)
 - Added keyword argument ``environment`` to :meth:`.Styler.to_latex` also allowing a specific "longtable" entry with a separate jinja2 template (:issue:`41866`)
 - :meth:`.GroupBy.cummin` and :meth:`.GroupBy.cummax` now support the argument ``skipna`` (:issue:`34047`)
+- Added :meth:`DataFrame.to_structured`, which converts a DataFrame to a structured array (:issue:`42854`).
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2153,6 +2153,7 @@ class DataFrame(NDFrame, OpsMixin):
 
         See Also
         --------
+        DataFrame.to_structured: Convert DataFrame to structured array
         DataFrame.from_records: Convert structured or record ndarray
             to DataFrame.
         numpy.recarray: An ndarray that allows field access using
@@ -2284,6 +2285,50 @@ class DataFrame(NDFrame, OpsMixin):
                 raise ValueError(msg)
 
         return np.rec.fromarrays(arrays, dtype={"names": names, "formats": formats})
+
+    def to_structured(
+        self, index=True, column_dtypes=None, index_dtypes=None
+    ) -> np.recarray:
+        """
+        Convert DataFrame to a NumPy structured array.
+
+        Index will be included as the first field of the structured array if
+        requested.
+
+        Parameters
+        ----------
+        index : bool, default True
+            Include index in resulting structured array, stored in 'index'
+            field or using the index label, if set.
+        column_dtypes : str, type, dict, default None
+            If a string or type, the data type to store all columns. If
+            a dictionary, a mapping of column names and indices (zero-indexed)
+            to specific data types.
+        index_dtypes : str, type, dict, default None
+            If a string or type, the data type to store all index levels. If
+            a dictionary, a mapping of index level names and indices
+            (zero-indexed) to specific data types.
+
+            This mapping is applied only if `index=True`.
+
+        Returns
+        -------
+        numpy.array
+            NumPy ndarray with the DataFrame labels as fields and each row
+            of the DataFrame as entries.
+
+        See Also
+        --------
+        DataFrame.to_records: Convert DataFrame to recarray
+        DataFrame.from_records: Convert structured or record ndarray
+            to DataFrame.
+        """
+        r = self.to_records(
+            index=index,
+            column_dtypes=column_dtypes,
+            index_dtypes=index_dtypes,
+        )
+        return r.view(r.dtype.fields, np.ndarray)
 
     @classmethod
     def _from_arrays(


### PR DESCRIPTION
Structured arrays can be significantly faster than record arrays:
```
In [1]: s = np.random.rand(1000, 2).astype([("a", float), ("b", float)]); r = s.view(np.recarray)

In [2]: %timeit s["a"]
69.4 ns ± 0.0733 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [3]: %timeit r["a"]
1.2 µs ± 10 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [4]: %timeit r.a
1.86 µs ± 7.42 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```
Therefore it can be desirable to convert DataFrames to
structured arrays rather than record arrays (the recipe
for the conversion directly comes from the numpy docs at
https://numpy.org/doc/stable/user/basics.rec.html#record-arrays,
ignoring the handling of non-record inputs).

Currently the implementation simply reuses the to_record implementation.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
