### PR TITLE
BUG :  Allow axis = 'columns' with limit and no method to work on fillna. 

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -224,7 +224,7 @@ Indexing
 
 Missing
 ^^^^^^^
--
+- Bug in :meth:`DataFrame.fillna` with limit and no method ignores axis='columns' or ``axis = 1`` (:issue:`40989`)
 -
 
 MultiIndex

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6314,7 +6314,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             else:
                 raise ValueError(f"invalid fill value with a {type(value)}")
 
-            if axis == 1 and limit != None:
+            if axis == 1 and limit is not None:
                 raise NotImplementedError(
                     "If limit is specified, "
                     "values can only be filled "

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6155,7 +6155,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             NaN values to forward/backward fill. In other words, if there is
             a gap with more than this number of consecutive NaNs, it will only
             be partially filled. If method is not specified, this is the
-            maximum number of entries along the entire axis where NaNs will be
+            maximum number of entries along the entire index axis where NaNs will be
             filled. Must be greater than 0 if not None.
         downcast : dict, default is None
             A dict of item->dtype of what to downcast if possible,
@@ -6313,6 +6313,13 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 new_data = self.where(self.notna(), value)._data
             else:
                 raise ValueError(f"invalid fill value with a {type(value)}")
+
+            if axis == 1 and limit != None:
+                raise NotImplementedError(
+                    "If limit is specified, "
+                    "values can only be filled "
+                    "along the index axis"
+                )
 
         result = self._constructor(new_data)
         if inplace:

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -438,6 +438,22 @@ class TestFillNA:
         df.fillna(method="ffill", inplace=True)
         tm.assert_frame_equal(df, expected)
 
+        df = DataFrame(
+            [
+                [np.nan, 2, np.nan, 0],
+                [3, 4, np.nan, 1],
+                [np.nan, np.nan, np.nan, 5],
+                [np.nan, 3, np.nan, 4],
+            ],
+            columns=list("ABCD"),
+        )
+
+        expected = df.fillna(axis=1, value=100, limit=1)
+        assert expected is not df
+
+        df.fillna(axis=1, value=100, limit=1, inplace=True)
+        tm.assert_frame_equal(df, expected)
+
     def test_fillna_dict_series(self):
         df = DataFrame(
             {
@@ -573,6 +589,42 @@ class TestFillNA:
             result = df.fillna(0, None, None)
         expected = DataFrame({"a": [1, 2, 3, 0]}, dtype=float)
         tm.assert_frame_equal(result, expected)
+
+    def test_fillna_with_columns_and_limit(self):
+        # GH40989
+        df = DataFrame(
+            [
+                [np.nan, 2, np.nan, 0],
+                [3, 4, np.nan, 1],
+                [np.nan, np.nan, np.nan, 5],
+                [np.nan, 3, np.nan, 4],
+            ],
+            columns=list("ABCD"),
+        )
+        result = df.fillna(axis=1, value=100, limit=1)
+        result2 = df.fillna(axis=1, value=100, limit=2)
+
+        expected = DataFrame(
+            {
+                "A": Series([100, 3, 100, 100], dtype="float64"),
+                "B": [2, 4, np.nan, 3],
+                "C": [np.nan, 100, np.nan, np.nan],
+                "D": Series([0, 1, 5, 4], dtype="float64"),
+            },
+            index=[0, 1, 2, 3],
+        )
+        expected2 = DataFrame(
+            {
+                "A": Series([100, 3, 100, 100], dtype="float64"),
+                "B": Series([2, 4, 100, 3], dtype="float64"),
+                "C": [100, 100, np.nan, 100],
+                "D": Series([0, 1, 5, 4], dtype="float64"),
+            },
+            index=[0, 1, 2, 3],
+        )
+
+        tm.assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result2, expected2)
 
 
 def test_fillna_nonconsolidated_frame():

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -438,22 +438,6 @@ class TestFillNA:
         df.fillna(method="ffill", inplace=True)
         tm.assert_frame_equal(df, expected)
 
-        df = DataFrame(
-            [
-                [np.nan, 2, np.nan, 0],
-                [3, 4, np.nan, 1],
-                [np.nan, np.nan, np.nan, 5],
-                [np.nan, 3, np.nan, 4],
-            ],
-            columns=list("ABCD"),
-        )
-
-        expected = df.fillna(axis=1, value=100, limit=1)
-        assert expected is not df
-
-        df.fillna(axis=1, value=100, limit=1, inplace=True)
-        tm.assert_frame_equal(df, expected)
-
     def test_fillna_dict_series(self):
         df = DataFrame(
             {
@@ -625,6 +609,24 @@ class TestFillNA:
 
         tm.assert_frame_equal(result, expected)
         tm.assert_frame_equal(result2, expected2)
+
+    def test_fillna_inplace_with_columns_limit_and_value(self):
+        # GH40989
+        df = DataFrame(
+            [
+                [np.nan, 2, np.nan, 0],
+                [3, 4, np.nan, 1],
+                [np.nan, np.nan, np.nan, 5],
+                [np.nan, 3, np.nan, 4],
+            ],
+            columns=list("ABCD"),
+        )
+
+        expected = df.fillna(axis=1, value=100, limit=1)
+        assert expected is not df
+
+        df.fillna(axis=1, value=100, limit=1, inplace=True)
+        tm.assert_frame_equal(df, expected)
 
 
 def test_fillna_nonconsolidated_frame():

--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -213,22 +213,3 @@ class TestDataFrame2:
 
         with pytest.raises(TypeError, match=msg):
             ts.fillna(0, in_place=True)
-
-    def test_fillna_with_columns_and_limit(self):
-        # 40989
-        df = DataFrame(
-            [
-                [np.nan, 2, np.nan, 0],
-                [3, 4, np.nan, 1],
-                [np.nan, np.nan, np.nan, 5],
-                [np.nan, 3, np.nan, 4],
-            ],
-            columns=list("ABCD"),
-        )
-
-        msg = "If limit is specified, values can only be filled along the index axis"
-        with pytest.raises(NotImplementedError, match=msg):
-            df.fillna(axis="columns", value=100, limit=2)
-
-        with pytest.raises(NotImplementedError, match=msg):
-            df.fillna(axis=1, value=100, limit=1)

--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -213,3 +213,22 @@ class TestDataFrame2:
 
         with pytest.raises(TypeError, match=msg):
             ts.fillna(0, in_place=True)
+
+    def test_fillna_with_columns_and_limit(self):
+        # 40989
+        df = DataFrame(
+            [
+                [np.nan, 2, np.nan, 0],
+                [3, 4, np.nan, 1],
+                [np.nan, np.nan, np.nan, 5],
+                [np.nan, 3, np.nan, 4],
+            ],
+            columns=list("ABCD"),
+        )
+
+        msg = "If limit is specified, values can only be filled along the index axis"
+        with pytest.raises(NotImplementedError, match=msg):
+            df.fillna(axis="columns", value=100, limit=2)
+
+        with pytest.raises(NotImplementedError, match=msg):
+            df.fillna(axis=1, value=100, limit=1)


### PR DESCRIPTION
- [x] closes #40989
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

Added an if-condition for when axis = 1 so as to transpose the result in pandas/tests/frame/methods/test_fillna.py, and created a test for this change. The test also tests for `inplace =True`. This solves issue #40989 