### PR TITLE
CI: Test doc build fails on ipython warning

### DIFF
--- a/doc/source/getting_started/comparison/comparison_with_sas.rst
+++ b/doc/source/getting_started/comparison/comparison_with_sas.rst
@@ -115,6 +115,8 @@ The pandas method is :func:`read_csv`, which works similarly.
        "https://raw.github.com/pandas-dev/"
        "pandas/master/pandas/tests/io/data/csv/tips.csv"
    )
+
+
    tips = pd.read_csv(url)
    tips
 


### PR DESCRIPTION
Testing build fails on ipython warning for #41410
