### PR TITLE
BUG: GH42866 DatetimeIndex de-serializing fails in PYTHONOPTIMIZE mode

### DIFF
--- a/doc/source/whatsnew/v1.3.2.rst
+++ b/doc/source/whatsnew/v1.3.2.rst
@@ -32,7 +32,7 @@ Bug fixes
 ~~~~~~~~~
 - 1D slices over extension types turn into N-dimensional slices over ExtensionArrays (:issue:`42430`)
 - :meth:`.Styler.hide_columns` now hides the index name header row as well as column headers (:issue:`42101`)
-- Bug in :func:`_new_DatetimeIndex` when de-serializing datetime indexes in PYTHONOPTIMIZED mode (:issue:`42866`)
+- Bug in de-serializing datetime indexes in PYTHONOPTIMIZED mode (:issue:`42866`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.3.2.rst
+++ b/doc/source/whatsnew/v1.3.2.rst
@@ -31,6 +31,7 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 - 1D slices over extension types turn into N-dimensional slices over ExtensionArrays (:issue:`42430`)
+- Bug in :func:`_new_DatetimeIndex` when de-serializing datetime indexes in PYTHONOPTIMIZED mode (:issue:`42866`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -193,6 +193,7 @@ Categorical
 Datetimelike
 ^^^^^^^^^^^^
 - Bug in :class:`DataFrame` constructor unnecessarily copying non-datetimelike 2D object arrays (:issue:`39272`)
+- Bug in :func:`_new_DatetimeIndex` when de-serializing datetime indexes in PYTHONOPTIMIZED mode (:issue:`42866`)
 -
 
 Timedelta

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -193,7 +193,6 @@ Categorical
 Datetimelike
 ^^^^^^^^^^^^
 - Bug in :class:`DataFrame` constructor unnecessarily copying non-datetimelike 2D object arrays (:issue:`39272`)
-- Bug in :func:`_new_DatetimeIndex` when de-serializing datetime indexes in PYTHONOPTIMIZED mode (:issue:`42866`)
 -
 
 Timedelta

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -92,7 +92,8 @@ def _new_DatetimeIndex(cls, d):
                 # These are already stored in our DatetimeArray; if they are
                 #  also in the pickle and don't match, we have a problem.
                 if key in d:
-                    assert d.pop(key) == getattr(dta, key)
+                    assert d[key] == getattr(dta, key)
+                    d.pop(key)
         result = cls._simple_new(dta, **d)
     else:
         with warnings.catch_warnings():

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -75,13 +75,17 @@ def test_oo_optimizable():
 
 def test_oo_optimized_datetime_index_unpickle():
     # GH 42866
-    subprocess.check_call([
-        sys.executable, "-OO", "-c",
-        (
-            "import pandas as pd, pickle; "
-            "pickle.loads(pickle.dumps(pd.date_range('2021-01-01', periods=1)))"
-        ),
-    ])
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-OO",
+            "-c",
+            (
+                "import pandas as pd, pickle; "
+                "pickle.loads(pickle.dumps(pd.date_range('2021-01-01', periods=1)))"
+            ),
+        ]
+    )
 
 
 @tm.network

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -73,6 +73,14 @@ def test_oo_optimizable():
     subprocess.check_call([sys.executable, "-OO", "-c", "import pandas"])
 
 
+def test_oo_optimized_datetime_index_unpickle():
+    # GH 42866
+    subprocess.check_call([
+        sys.executable, "-OO", "-c",
+        "import pandas as pd, pickle; pickle.loads(pickle.dumps(pd.date_range('2021-01-01', periods=1)))",
+    ])
+
+
 @tm.network
 # Cython import warning
 @pytest.mark.filterwarnings("ignore:pandas.util.testing is deprecated")

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -77,7 +77,10 @@ def test_oo_optimized_datetime_index_unpickle():
     # GH 42866
     subprocess.check_call([
         sys.executable, "-OO", "-c",
-        "import pandas as pd, pickle; pickle.loads(pickle.dumps(pd.date_range('2021-01-01', periods=1)))",
+        (
+            "import pandas as pd, pickle; "
+            "pickle.loads(pickle.dumps(pd.date_range('2021-01-01', periods=1)))"
+        ),
     ])
 
 


### PR DESCRIPTION
- [x] closes #42866
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
