### PR TITLE
TST: update message in skip_array_manager mark

### DIFF
--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -286,7 +286,8 @@ def async_mark():
 
 
 skip_array_manager_not_yet_implemented = pytest.mark.skipif(
-    get_option("mode.data_manager") == "array", reason="JSON C code relies on Blocks"
+    get_option("mode.data_manager") == "array",
+    reason="Not yet implemented for ArrayManager",
 )
 
 skip_array_manager_invalid_test = pytest.mark.skipif(


### PR DESCRIPTION
Tiny PR, but I noticed this confusing message while running some tests (this skip is used generally, and JSON C code now actually no longer relies on the Block)
