### PR TITLE
TST: remove chained assignment outside indexing tests

### DIFF
--- a/pandas/tests/frame/methods/test_dropna.py
+++ b/pandas/tests/frame/methods/test_dropna.py
@@ -66,7 +66,7 @@ class TestDataFrameMissingData:
 
     def test_dropna(self):
         df = DataFrame(np.random.randn(6, 4))
-        df[2][:2] = np.nan
+        df.iloc[:2, 2] = np.nan
 
         dropped = df.dropna(axis=1)
         expected = df.loc[:, [0, 1, 3]]

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -102,34 +102,34 @@ class TestDataFrameInterpolate:
         expected = df.copy()
         result = df.interpolate(method="polynomial", order=1)
 
-        expected.A.loc[3] = 2.66666667
-        expected.A.loc[13] = 5.76923076
+        expected.loc[3, "A"] = 2.66666667
+        expected.loc[13, "A"] = 5.76923076
         tm.assert_frame_equal(result, expected)
 
         result = df.interpolate(method="cubic")
         # GH #15662.
-        expected.A.loc[3] = 2.81547781
-        expected.A.loc[13] = 5.52964175
+        expected.loc[3, "A"] = 2.81547781
+        expected.loc[13, "A"] = 5.52964175
         tm.assert_frame_equal(result, expected)
 
         result = df.interpolate(method="nearest")
-        expected.A.loc[3] = 2
-        expected.A.loc[13] = 5
+        expected.loc[3, "A"] = 2
+        expected.loc[13, "A"] = 5
         tm.assert_frame_equal(result, expected, check_dtype=False)
 
         result = df.interpolate(method="quadratic")
-        expected.A.loc[3] = 2.82150771
-        expected.A.loc[13] = 6.12648668
+        expected.loc[3, "A"] = 2.82150771
+        expected.loc[13, "A"] = 6.12648668
         tm.assert_frame_equal(result, expected)
 
         result = df.interpolate(method="slinear")
-        expected.A.loc[3] = 2.66666667
-        expected.A.loc[13] = 5.76923077
+        expected.loc[3, "A"] = 2.66666667
+        expected.loc[13, "A"] = 5.76923077
         tm.assert_frame_equal(result, expected)
 
         result = df.interpolate(method="zero")
-        expected.A.loc[3] = 2.0
-        expected.A.loc[13] = 5
+        expected.loc[3, "A"] = 2.0
+        expected.loc[13, "A"] = 5
         tm.assert_frame_equal(result, expected, check_dtype=False)
 
     @td.skip_if_no_scipy
@@ -218,7 +218,7 @@ class TestDataFrameInterpolate:
         )
         result = df.interpolate()
         expected = df.copy()
-        expected["B"].loc[3] = -3.75
+        expected.loc[3, "B"] = -3.75
         tm.assert_frame_equal(result, expected)
 
         if check_scipy:

--- a/pandas/tests/frame/methods/test_isin.py
+++ b/pandas/tests/frame/methods/test_isin.py
@@ -79,8 +79,8 @@ class TestDataFrameIsIn:
         df2 = DataFrame({"A": [0, 2, 12, 4], "B": [2, np.nan, 4, 5]})
         expected = DataFrame(False, df1.index, df1.columns)
         result = df1.isin(df2)
-        expected["A"].loc[[1, 3]] = True
-        expected["B"].loc[[0, 2]] = True
+        expected.loc[[1, 3], "A"] = True
+        expected.loc[[0, 2], "B"] = True
         tm.assert_frame_equal(result, expected)
 
         # partial overlapping columns
@@ -133,7 +133,7 @@ class TestDataFrameIsIn:
         )
         s = Series([1, 3, 11, 4], index=["a", "b", "c", "d"])
         expected = DataFrame(False, index=df.index, columns=df.columns)
-        expected["A"].loc["a"] = True
+        expected.loc["a", "A"] = True
         expected.loc["d"] = True
         result = df.isin(s)
         tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
Small piece broken off from https://github.com/pandas-dev/pandas/pull/41878

This updates a  bunch of tests that are unnecessarily using chained assignment. Outside tests specifically about indexing, I think it's better/cleaner to use the more idiomatic single .loc call (and also makes it easier to change the behaviour as I am doing in https://github.com/pandas-dev/pandas/pull/41878).