### PR TITLE
PERF: Groupby.shift dont re-call libgroupby.group_shift_indexer

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -3031,15 +3031,18 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
         if freq is not None or axis != 0:
             return self.apply(lambda x: x.shift(periods, freq, axis, fill_value))
 
-        return self._get_cythonized_result(
-            "group_shift_indexer",
-            numeric_only=False,
-            cython_dtype=np.dtype(np.int64),
-            needs_ngroups=True,
-            result_is_index=True,
-            periods=periods,
+        ids, _, ngroups = self.grouper.group_info
+        res_indexer = np.zeros(len(ids), dtype=np.int64)
+
+        libgroupby.group_shift_indexer(res_indexer, ids, ngroups, periods)
+
+        obj = self._obj_with_exclusions
+
+        res = obj._reindex_with_indexers(
+            {self.axis: (obj.axes[self.axis], res_indexer)},
             fill_value=fill_value,
         )
+        return res
 
     @final
     @Substitution(name="groupby")

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -3041,6 +3041,7 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
         res = obj._reindex_with_indexers(
             {self.axis: (obj.axes[self.axis], res_indexer)},
             fill_value=fill_value,
+            allow_dups=True,
         )
         return res
 

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -183,7 +183,7 @@ def test_transform_axis_1(request, transformation_func, using_array_manager):
         result = df.groupby([0, 0, 1], axis=1).transform(transformation_func, *args)
         expected = df.T.groupby([0, 0, 1]).transform(transformation_func, *args).T
 
-    if transformation_func == "diff":
+    if transformation_func in ["diff", "shift"]:
         # Result contains nans, so transpose coerces to float
         expected["b"] = expected["b"].astype("int64")
 


### PR DESCRIPTION
ATM we're calling libgroupby.group_shift_indexer for every column, but we only need to call it once.