### PR TITLE
TST: add read_json test with date values GH33787

### DIFF
--- a/pandas/tests/io/json/test_readlines.py
+++ b/pandas/tests/io/json/test_readlines.py
@@ -26,6 +26,21 @@ def test_read_jsonl():
     tm.assert_frame_equal(result, expected)
 
 
+def test_read_datetime():
+    # GH33787
+    df = DataFrame(
+        [([1, 2], ["2020-03-05", "2020-04-08T09:58:49+00:00"], "hector")],
+        columns=["accounts", "date", "name"],
+    )
+    json_line = df.to_json(lines=True, orient="records")
+    result = read_json(json_line)
+    expected = DataFrame(
+        [[1, "2020-03-05", "hector"], [2, "2020-04-08T09:58:49+00:00", "hector"]],
+        columns=["accounts", "date", "name"],
+    )
+    tm.assert_frame_equal(result, expected)
+
+
 def test_read_jsonl_unicode_chars():
     # GH15132: non-ascii unicode characters
     # \u201d == RIGHT DOUBLE QUOTATION MARK


### PR DESCRIPTION
- [x ] closes #33787
- [x ] tests added / passed
- [x ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

First attempt at contributing to pandas, or any open source projects! I think all the linting tests passed, since I installed and used the pre-commit package described in the documentation and everything was either passed or skipped.

This change added a short test for GH33787, which was to make sure that read_json was able to convert lists with date values.
