### PR TITLE
COMPAT: Support fastparquet 0.7.1

### DIFF
--- a/ci/deps/actions-38-db.yaml
+++ b/ci/deps/actions-38-db.yaml
@@ -15,7 +15,7 @@ dependencies:
   - beautifulsoup4
   - botocore>=1.11
   - dask
-  - fastparquet>=0.4.0, < 0.7.0
+  - fastparquet>=0.4.0
   - fsspec>=0.7.4, <2021.6.0
   - gcsfs>=0.6.0
   - geopandas

--- a/ci/deps/azure-windows-38.yaml
+++ b/ci/deps/azure-windows-38.yaml
@@ -15,7 +15,7 @@ dependencies:
   # pandas dependencies
   - blosc
   - bottleneck
-  - fastparquet>=0.4.0, <0.7.0
+  - fastparquet>=0.4.0
   - flask
   - fsspec>=0.8.0, <2021.6.0
   - matplotlib=3.3.2

--- a/doc/source/whatsnew/v1.3.2.rst
+++ b/doc/source/whatsnew/v1.3.2.rst
@@ -39,7 +39,7 @@ Bug fixes
 
 Other
 ~~~~~
-- :meth:`pandas.read_parquet` now supports reading with ``fastparquet`` versions above 0.7.1.
+- :meth:`pandas.read_parquet` now supports reading nullable dtypes with ``fastparquet`` versions above 0.7.1.
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.3.2.rst
+++ b/doc/source/whatsnew/v1.3.2.rst
@@ -39,7 +39,7 @@ Bug fixes
 
 Other
 ~~~~~
--
+- :meth:`pandas.read_parquet` now supports reading with ``fastparquet`` versions above 0.7.1.
 -
 
 .. ---------------------------------------------------------------------------

--- a/environment.yml
+++ b/environment.yml
@@ -99,7 +99,7 @@ dependencies:
   - xlwt
   - odfpy
 
-  - fastparquet>=0.4.0, <0.7.0  # pandas.read_parquet, DataFrame.to_parquet
+  - fastparquet>=0.4.0  # pandas.read_parquet, DataFrame.to_parquet
   - pyarrow>=0.17.0  # pandas.read_parquet, DataFrame.to_parquet, pandas.read_feather, DataFrame.to_feather
   - python-snappy  # required by pyarrow
 

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -313,7 +313,7 @@ class FastParquetImpl(BaseImpl):
         use_nullable_dtypes = kwargs.pop("use_nullable_dtypes", False)
         # Technically works with 0.7.0, but was incorrect
         # so lets just require 0.7.1
-        if Version(self.api.__version__) > Version("0.7.1"):
+        if Version(self.api.__version__) >= Version("0.7.1"):
             # Need to set even for use_nullable_dtypes = False,
             # since our defaults differ
             parquet_kwargs["pandas_nulls"] = use_nullable_dtypes

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -64,7 +64,7 @@ xlrd
 xlsxwriter
 xlwt
 odfpy
-fastparquet>=0.4.0, <0.7.0
+fastparquet>=0.4.0
 pyarrow>=0.17.0
 python-snappy
 tables>=3.6.1


### PR DESCRIPTION
- [ ] closes #42588
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

Also adds support for ``use_nullable_dtypes`` keyword. Technically, its not our enhancement its fastparquet's, so I think can backport. IMO, users shouldn't have to wait 6 months for 1.4 to get this new feature.
