### PR TITLE
DOC: More subtotals / margins in pivot_table

### DIFF
--- a/doc/source/user_guide/reshaping.rst
+++ b/doc/source/user_guide/reshaping.rst
@@ -474,14 +474,14 @@ rows and columns:
 
 .. ipython:: python
 
-   df.pivot_table(index=["A", "B"], columns="C", margins=True, aggfunc=np.std)
+   table = df.pivot_table(index=["A", "B"], columns="C", margins=True, aggfunc=np.std)
+   table
 
 Additionally, you can call :meth:`DataFrame.stack` to display a pivoted DataFrame
 as having a multi-level index:
 
 .. ipython:: python
 
-    table = df.pivot_table(index=["A", "B"], columns="C", margins=True, aggfunc=np.sum)
     table.stack()
 
 .. _reshaping.crosstabulations:

--- a/doc/source/user_guide/reshaping.rst
+++ b/doc/source/user_guide/reshaping.rst
@@ -476,6 +476,14 @@ rows and columns:
 
    df.pivot_table(index=["A", "B"], columns="C", margins=True, aggfunc=np.std)
 
+Additionally, you can call :meth:`DataFrame.stack` to display a pivoted DataFrame
+as having a multi-level index:
+
+.. ipython:: python
+
+    table = df.pivot_table(index=["A", "B"], columns="C", margins=True, aggfunc=np.sum)
+    table.stack()
+
 .. _reshaping.crosstabulations:
 
 Cross tabulations


### PR DESCRIPTION
- [ ] closes #4817 
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

Added an example in the documentation for DataFrame.pivot_table to show how to display a pivot table as having a multi-level index, simulating Excel's pivot table with MI and partial group aggregates.