### PR TITLE
STYLE: pre-commit check on get/set_option usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,6 +103,11 @@ repos:
             |\.\.\ code-block\ ::
             |\.\.\ ipython\ ::
         types_or: [python, cython, rst]
+    -   id: check-set-get-options
+        name: Check if set_option or get_option is use-pd_array-in-core
+        language: pygrep
+        entry: ' (get|set)_option'
+        types: [python]
     -   id: pip-to-conda
         name: Generate pip dependency from conda
         description: This hook checks if the conda environment.yml and requirements-dev.txt are equal

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,7 +104,7 @@ repos:
             |\.\.\ ipython\ ::
         types_or: [python, cython, rst]
     -   id: check-set-get-options
-        name: Check if set_option or get_option is use-pd_array-in-core
+        name: Check if set_option or get_option is used
         language: pygrep
         entry: ' (get|set)_option'
         types: [python]


### PR DESCRIPTION
- [x] closes #38813
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

This is failing across multiple locations. Is there a specific location where get/set_option can be used? or across everything?
