### PR TITLE
ERR: clarify PerformanceWarning for fragmented frame

### DIFF
--- a/doc/source/whatsnew/v1.3.2.rst
+++ b/doc/source/whatsnew/v1.3.2.rst
@@ -45,7 +45,6 @@ Bug fixes
 Other
 ~~~~~
 - :meth:`pandas.read_parquet` now supports reading nullable dtypes with ``fastparquet`` versions above 0.7.1.
-- Clarified suggested fix for ``PerformanceWarning`` emitted with a highly fragmented :class:`DataFrame` (:issue:`42579`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.3.2.rst
+++ b/doc/source/whatsnew/v1.3.2.rst
@@ -48,7 +48,6 @@ Other
 - Clarified suggested fix for ``PerformanceWarning`` emitted with a highly fragmented :class:`DataFrame` (:issue:`42579`)
 -
 
-
 .. ---------------------------------------------------------------------------
 
 .. _whatsnew_132.contributors:

--- a/doc/source/whatsnew/v1.3.2.rst
+++ b/doc/source/whatsnew/v1.3.2.rst
@@ -45,7 +45,9 @@ Bug fixes
 Other
 ~~~~~
 - :meth:`pandas.read_parquet` now supports reading nullable dtypes with ``fastparquet`` versions above 0.7.1.
+- Clarified suggested fix for ``PerformanceWarning`` emitted with a highly fragmented :class:`DataFrame` (:issue:`42579`)
 -
+
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1177,9 +1177,9 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         if len(self.blocks) > 100:
             warnings.warn(
                 "DataFrame is highly fragmented.  This is usually the result "
-                "of calling `frame.insert` many times, which has poor performance.  "
-                "Consider using pd.concat instead.  To get a de-fragmented frame, "
-                "use `newframe = frame.copy()`",
+                "of calling `frame.insert` many times, which has poor performance. "
+                "Consider joining all columns at once using pd.concat(axis=1) instead. "
+                "To get a de-fragmented frame, use `newframe = frame.copy()`",
                 PerformanceWarning,
                 stacklevel=5,
             )

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1177,9 +1177,9 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         if len(self.blocks) > 100:
             warnings.warn(
                 "DataFrame is highly fragmented.  This is usually the result "
-                "of calling `frame.insert` many times, which has poor performance. "
-                "Consider joining all columns at once using pd.concat(axis=1) instead. "
-                "To get a de-fragmented frame, use `newframe = frame.copy()`",
+                "of calling `frame.insert` many times, which has poor performance.  "
+                "Consider joining all columns at once using pd.concat(axis=1) "
+                "instead.  To get a de-fragmented frame, use `newframe = frame.copy()`",
                 PerformanceWarning,
                 stacklevel=5,
             )


### PR DESCRIPTION
xref some confusion in #42477. If this is thought an improvement, could target 1.3.2 since more users now see this error than in 1.2.x