### PR TITLE
BUG: read_csv with mixed bools and NaNs sometimes reads NaNs as 1.0 (#42808)

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -260,6 +260,7 @@ I/O
 - Bug in :func:`read_excel` attempting to read chart sheets from .xlsx files (:issue:`41448`)
 - Bug in :func:`json_normalize` where ``errors=ignore`` could fail to ignore missing values of ``meta`` when ``record_path`` has a length greater than one (:issue:`41876`)
 - Bug in :func:`read_csv` with multi-header input and arguments referencing column names as tuples (:issue:`42446`)
+- Bug in :func:`read_csv` where reading a mixed column of booleans and missing values to a float type results in the missing values becoming 1.0 rather than NaN (:issue:`42808`)
 -
 
 Period

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -590,3 +590,17 @@ def test_nan_multi_index(all_parsers):
     )
 
     tm.assert_frame_equal(result, expected)
+
+
+def test_bool_to_float_with_nans(all_parsers):
+    # GH 42808: Ensure that when reading a file of mixed-bools-and-nans to a
+    # float dtype, we get back the correct result.
+    parser = all_parsers
+    data = """0
+NaN
+True
+False
+"""
+    result = parser.read_csv(StringIO(data), dtype="float")
+    expected = DataFrame.from_dict({"0": [np.nan, 1.0, 0.0]})
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -592,9 +592,32 @@ def test_nan_multi_index(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-def test_bool_to_float_with_nans(all_parsers):
-    # GH 42808: Ensure that when reading a file of mixed-bools-and-nans to a
-    # float dtype, we get back the correct result.
+def test_bool_and_nan_to_bool(all_parsers):
+    # GH 42808: (bool | NaN) => bool should error.
+    parser = all_parsers
+    data = """0
+NaN
+True
+False
+"""
+    with pytest.raises(ValueError, match="NA values"):
+        parser.read_csv(StringIO(data), dtype="bool")
+
+
+def test_bool_and_nan_to_int(all_parsers):
+    # GH 42808: (bool | NaN) => int should error.
+    parser = all_parsers
+    data = """0
+NaN
+True
+False
+"""
+    with pytest.raises(ValueError, match="convert"):
+        print(parser.read_csv(StringIO(data), dtype="int"))
+
+
+def test_bool_and_nan_to_float(all_parsers):
+    # GH 42808: (bool | NaN) => float should return 0.0/1.0/NaN.
     parser = all_parsers
     data = """0
 NaN


### PR DESCRIPTION
When reading a column of mixed booleans and missing values into a specific floating dtype, for example `read_csv(..., dtype='float')`, missing values were being incorrectly converted to 1.0 rather than NaN. This patch fixes this issue.

- [x] closes #42808
- [x] closes #34120
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

I've never been in the CSV parsing code before, so I've tried to put this change in the spot that makes the most sense and causes the least impact, but corrections are very welcome.

Why this issue was happening is that the [_try_bool_flex()](https://github.com/pandas-dev/pandas/blob/126a19d038b65493729e21ca969fbb58dab9a408/pandas/_libs/parsers.pyx#L1752) function parses a mixed column of bools and missing values into a uint8 array, storing False/True/missing as 0/1/255. It then returns a bool view of this array, "hiding" the missing values and making them just look like True. These missing values are meant to be later 'unhidden' by a call to [_maybe_upcast()](https://github.com/pandas-dev/pandas/blob/126a19d038b65493729e21ca969fbb58dab9a408/pandas/_libs/parsers.pyx#L1040), which views the array as uint8 again, and maps to a dtype=object array containing False/True/NaN.

However, when the user specifies an explicit float dtype, this upcast is skipped since the bool array gets converted to a float array before hitting _maybe_upcast(). This patch just replicates the upcast logic in this case.

Like I said above, this is the spot in the code that made the most sense to me to put the correction - I feel like a more robust fix would be to rewrite the `_convert_tokens()` function (and the methods it calls, and so on) to actually return the positions of the missing values, as well as the parsed values, which would be a large change.