### PR TITLE
REF: format_object_attrs -> Index._format_attrs

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1215,7 +1215,7 @@ class Index(IndexOpsMixin, PandasObject):
         """
         Return a list of tuples of the (attr,formatted_value).
         """
-        attrs = []
+        attrs: list[tuple[str_t, str_t | int]] = []
 
         if not self._is_multi:
             attrs.append(("dtype", f"'{self.dtype}'"))

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -20,6 +20,8 @@ import warnings
 
 import numpy as np
 
+from pandas._config import get_option
+
 from pandas._libs import (
     algos as libalgos,
     index as libindex,
@@ -156,7 +158,6 @@ from pandas.core.strings import StringMethods
 from pandas.io.formats.printing import (
     PrettyDict,
     default_pprint,
-    format_object_attrs,
     format_object_summary,
     pprint_thing,
 )
@@ -1183,7 +1184,20 @@ class Index(IndexOpsMixin, PandasObject):
         """
         Return a list of tuples of the (attr,formatted_value).
         """
-        return format_object_attrs(self, include_dtype=not self._is_multi)
+        attrs = []
+
+        if not self._is_multi:
+            attrs.append(("dtype", f"'{self.dtype}'"))
+
+        if self.name is not None:
+            attrs.append(("name", default_pprint(self.name)))
+        elif self._is_multi and any(x is not None for x in self.names):
+            attrs.append(("names", default_pprint(self.names)))
+
+        max_seq_items = get_option("display.max_seq_items") or len(self)
+        if len(self) > max_seq_items:
+            attrs.append(("length", len(self)))
+        return attrs
 
     @final
     def _mpl_repr(self) -> np.ndarray:

--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -11,7 +11,6 @@ from typing import (
     Iterable,
     Mapping,
     Sequence,
-    Sized,
     TypeVar,
     Union,
 )
@@ -503,44 +502,6 @@ def _justify(
     #  List[Sequence[str]]]", expected "Tuple[List[Tuple[str, ...]],
     #  List[Tuple[str, ...]]]")
     return head, tail  # type: ignore[return-value]
-
-
-def format_object_attrs(
-    obj: Sized, include_dtype: bool = True
-) -> list[tuple[str, str | int]]:
-    """
-    Return a list of tuples of the (attr, formatted_value)
-    for common attrs, including dtype, name, length
-
-    Parameters
-    ----------
-    obj : object
-        Must be sized.
-    include_dtype : bool
-        If False, dtype won't be in the returned list
-
-    Returns
-    -------
-    list of 2-tuple
-
-    """
-    attrs: list[tuple[str, str | int]] = []
-    if hasattr(obj, "dtype") and include_dtype:
-        # error: "Sized" has no attribute "dtype"
-        attrs.append(("dtype", f"'{obj.dtype}'"))  # type: ignore[attr-defined]
-    if getattr(obj, "name", None) is not None:
-        # error: "Sized" has no attribute "name"
-        attrs.append(("name", default_pprint(obj.name)))  # type: ignore[attr-defined]
-    # error: "Sized" has no attribute "names"
-    elif getattr(obj, "names", None) is not None and any(
-        obj.names  # type: ignore[attr-defined]
-    ):
-        # error: "Sized" has no attribute "names"
-        attrs.append(("names", default_pprint(obj.names)))  # type: ignore[attr-defined]
-    max_seq_items = get_option("display.max_seq_items") or len(obj)
-    if len(obj) > max_seq_items:
-        attrs.append(("length", len(obj)))
-    return attrs
 
 
 class PrettyDict(Dict[_KT, _VT]):


### PR DESCRIPTION
Preliminary to trying to implement generic EA-backed Index (and in particular IntegerArray/BooleanArray), trying to identify all the Index methods that implicitly assume we have an ndarray.  This refactors a used-only-once function into the method to make it more obvious that it does _not_ assume an ndarray.