### PR TITLE
Revert fastparquet nullable dtype support

### DIFF
--- a/doc/source/whatsnew/v1.3.2.rst
+++ b/doc/source/whatsnew/v1.3.2.rst
@@ -44,7 +44,6 @@ Bug fixes
 
 Other
 ~~~~~
-- :meth:`pandas.read_parquet` now supports reading nullable dtypes with ``fastparquet`` versions above 0.7.1.
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -309,7 +309,7 @@ class FastParquetImpl(BaseImpl):
     def read(
         self, path, columns=None, storage_options: StorageOptions = None, **kwargs
     ):
-        parquet_kwargs = {}
+        parquet_kwargs: dict[bool, Any] = {}
         use_nullable_dtypes = kwargs.pop("use_nullable_dtypes", False)
         if Version(self.api.__version__) >= Version("0.7.1"):
             # We are disabling nullable dtypes for fastparquet pending discussion

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -309,20 +309,14 @@ class FastParquetImpl(BaseImpl):
     def read(
         self, path, columns=None, storage_options: StorageOptions = None, **kwargs
     ):
-        parquet_kwargs = {}
+        # We are disabling nullable dtypes for fastparquet pending discussion
+        parquet_kwargs = {"pandas_nulls": False}
         use_nullable_dtypes = kwargs.pop("use_nullable_dtypes", False)
-        # Technically works with 0.7.0, but was incorrect
-        # so lets just require 0.7.1
-        if Version(self.api.__version__) >= Version("0.7.1"):
-            # Need to set even for use_nullable_dtypes = False,
-            # since our defaults differ
-            parquet_kwargs["pandas_nulls"] = use_nullable_dtypes
-        else:
-            if use_nullable_dtypes:
-                raise ValueError(
-                    "The 'use_nullable_dtypes' argument is not supported for the "
-                    "fastparquet engine for fastparquet versions less than 0.7.1"
-                )
+        if use_nullable_dtypes:
+            raise ValueError(
+                "The 'use_nullable_dtypes' argument is not supported for the"
+                " fastparquet engine"
+            )
         path = stringify_path(path)
         handles = None
         if is_fsspec_url(path):
@@ -478,17 +472,14 @@ def read_parquet(
 
     use_nullable_dtypes : bool, default False
         If True, use dtypes that use ``pd.NA`` as missing value indicator
-        for the resulting DataFrame.
+        for the resulting DataFrame. (only applicable for the ``pyarrow``
+        engine)
         As new dtypes are added that support ``pd.NA`` in the future, the
         output with this option will change to use those dtypes.
         Note: this is an experimental option, and behaviour (e.g. additional
         support dtypes) may change without notice.
 
         .. versionadded:: 1.2.0
-
-        .. versionchanged:: 1.3.2
-            ``use_nullable_dtypes`` now works with the the ``fastparquet`` engine
-            if ``fastparquet`` is version 0.7.1 or higher.
 
     **kwargs
         Any additional kwargs are passed to the engine.

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -309,7 +309,7 @@ class FastParquetImpl(BaseImpl):
     def read(
         self, path, columns=None, storage_options: StorageOptions = None, **kwargs
     ):
-        parquet_kwargs: dict[bool, Any] = {}
+        parquet_kwargs: dict[str, Any] = {}
         use_nullable_dtypes = kwargs.pop("use_nullable_dtypes", False)
         if Version(self.api.__version__) >= Version("0.7.1"):
             # We are disabling nullable dtypes for fastparquet pending discussion

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -309,9 +309,11 @@ class FastParquetImpl(BaseImpl):
     def read(
         self, path, columns=None, storage_options: StorageOptions = None, **kwargs
     ):
-        # We are disabling nullable dtypes for fastparquet pending discussion
-        parquet_kwargs = {"pandas_nulls": False}
+        parquet_kwargs = {}
         use_nullable_dtypes = kwargs.pop("use_nullable_dtypes", False)
+        if Version(self.api.__version__) >= Version("0.7.1"):
+            # We are disabling nullable dtypes for fastparquet pending discussion
+            parquet_kwargs["pandas_nulls"] = False
         if use_nullable_dtypes:
             raise ValueError(
                 "The 'use_nullable_dtypes' argument is not supported for the"

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -316,8 +316,8 @@ class FastParquetImpl(BaseImpl):
             parquet_kwargs["pandas_nulls"] = False
         if use_nullable_dtypes:
             raise ValueError(
-                "The 'use_nullable_dtypes' argument is not supported for the"
-                " fastparquet engine"
+                "The 'use_nullable_dtypes' argument is not supported for the "
+                "fastparquet engine"
             )
         path = stringify_path(path)
         handles = None

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -627,7 +627,7 @@ class TestBasic(Base):
                 "b": pd.array([1, 2, 3, None], dtype="UInt8"),
                 "c": pd.array(["a", "b", "c", None], dtype="string"),
                 "d": pd.array([True, False, True, None], dtype="boolean"),
-                "e": pd.array([1, 2, 3, 4], dtype="Int64")
+                "e": pd.array([1, 2, 3, 4], dtype="Int64"),
             }
         )
         if engine == "fastparquet":

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -611,7 +611,7 @@ class TestBasic(Base):
                 "c": pyarrow.array(["a", "b", "c", None]),
                 "d": pyarrow.array([True, False, True, None]),
                 # Test that nullable dtypes used even in absence of nulls
-                "e": pyarrow.array([1,2,3,4], "int64"),
+                "e": pyarrow.array([1, 2, 3, 4], "int64"),
             }
         )
         with tm.ensure_clean() as path:
@@ -627,7 +627,7 @@ class TestBasic(Base):
                 "b": pd.array([1, 2, 3, None], dtype="UInt8"),
                 "c": pd.array(["a", "b", "c", None], dtype="string"),
                 "d": pd.array([True, False, True, None], dtype="boolean"),
-                "e": pd.array([1,2,3,4], dtype="Int64")
+                "e": pd.array([1, 2, 3, 4], dtype="Int64")
             }
         )
         if engine == "fastparquet":

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -600,11 +600,9 @@ class TestBasic(Base):
         import pyarrow.parquet as pq
 
         if engine == "fastparquet":
-            pytest.importorskip(
-                "fastparquet",
-                "0.7.1",
-                reason="fastparquet must be 0.7.1 or higher for nullable dtype support",
-            )
+            # We are manually disabling fastparquet's
+            # nullable dtype support pending discussion
+            pytest.skip("Fastparquet nullable dtype support is disabled")
 
         table = pyarrow.table(
             {
@@ -612,6 +610,8 @@ class TestBasic(Base):
                 "b": pyarrow.array([1, 2, 3, None], "uint8"),
                 "c": pyarrow.array(["a", "b", "c", None]),
                 "d": pyarrow.array([True, False, True, None]),
+                # Test that nullable dtypes used even in absence of nulls
+                "e": pyarrow.array([1,2,3,4], "int64"),
             }
         )
         with tm.ensure_clean() as path:
@@ -627,6 +627,7 @@ class TestBasic(Base):
                 "b": pd.array([1, 2, 3, None], dtype="UInt8"),
                 "c": pd.array(["a", "b", "c", None], dtype="string"),
                 "d": pd.array([True, False, True, None], dtype="boolean"),
+                "e": pd.array([1,2,3,4], dtype="Int64")
             }
         )
         if engine == "fastparquet":


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
