### PR TITLE
CLN: remove unused Series._index attribute

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -211,7 +211,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         "_is_copy",
         "_subtyp",
         "_name",
-        "_index",
         "_default_kind",
         "_default_fill_value",
         "_metadata",

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -519,8 +519,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     def _can_hold_na(self) -> bool:
         return self._mgr._can_hold_na
 
-    _index: Index | None = None
-
     def _set_axis(self, axis: int, labels, fastpath: bool = False) -> None:
         """
         Override generic, we want to set the _typ here.
@@ -549,7 +547,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                     # or not be a DatetimeIndex
                     pass
 
-        object.__setattr__(self, "_index", labels)
         if not fastpath:
             # The ensure_index call above ensures we have an Index object
             self._mgr.set_axis(axis, labels)


### PR DESCRIPTION
Noticed this in https://github.com/pandas-dev/pandas/pull/42950, the attribute seems completely unused. 

(cc @jbrockmendel do you have any idea what the reason is/was for this?)