### PR TITLE
TST: Fix test related to reverting fastparquet nullable support

### DIFF
--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -311,7 +311,7 @@ class FastParquetImpl(BaseImpl):
     ):
         parquet_kwargs: dict[str, Any] = {}
         use_nullable_dtypes = kwargs.pop("use_nullable_dtypes", False)
-        if Version(self.api.__version__) >= Version("0.7.1"):
+        if Version(self.api.__version__) >= Version("0.7.0"):
             # We are disabling nullable dtypes for fastparquet pending discussion
             parquet_kwargs["pandas_nulls"] = False
         if use_nullable_dtypes:

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -1079,11 +1079,6 @@ class TestParquetFastParquet(Base):
     def test_use_nullable_dtypes_not_supported(self, monkeypatch, fp):
         df = pd.DataFrame({"a": [1, 2]})
 
-        # This is supported now in fastparquet 0.7.1 and above actually
-        # Still need to ensure that this raises in all versions below
-        import fastparquet as fp
-
-        monkeypatch.setattr(fp, "__version__", "0.4")
         with tm.ensure_clean() as path:
             df.to_parquet(path)
             with pytest.raises(ValueError, match="not supported for the fastparquet"):


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

xref https://github.com/pandas-dev/pandas/pull/42987#discussion_r687209605