### PR TITLE
DOC: Update param doc of to_parquet about compression

### DIFF
--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -382,10 +382,11 @@ def to_parquet(
         ``io.parquet.engine`` is used. The default ``io.parquet.engine``
         behavior is to try 'pyarrow', falling back to 'fastparquet' if
         'pyarrow' is unavailable.
-    compression : {{'snappy', 'gzip', 'brotli', 'lz4', 'zstd', None}}, default 'snappy'
-        Name of the compression to use. Use ``None`` for no compression. The supported
-        compression methods actually depend on which engine is used. For 'pyarrow',
-        'snappy', 'gzip', 'brotli', 'lz4', 'zstd' are all supported. For 'fastparquet',
+    compression : {{'snappy', 'gzip', 'brotli', 'lz4', 'zstd', None}},
+        default 'snappy'. Name of the compression to use. Use ``None``
+        for no compression. The supported compression methods actually
+        depend on which engine is used. For 'pyarrow', 'snappy', 'gzip',
+        'brotli', 'lz4', 'zstd' are all supported. For 'fastparquet',
         only 'gzip' and 'snappy' are supported.
     index : bool, default None
         If ``True``, include the dataframe's index(es) in the file output. If

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -382,8 +382,11 @@ def to_parquet(
         ``io.parquet.engine`` is used. The default ``io.parquet.engine``
         behavior is to try 'pyarrow', falling back to 'fastparquet' if
         'pyarrow' is unavailable.
-    compression : {{'snappy', 'gzip', 'brotli', None}}, default 'snappy'
-        Name of the compression to use. Use ``None`` for no compression.
+    compression : {{'snappy', 'gzip', 'brotli', 'lz4', 'zstd', None}}, default 'snappy'
+        Name of the compression to use. Use ``None`` for no compression. The supported
+        compression methods actually depend on which engine is used. For 'pyarrow',
+        'snappy', 'gzip', 'brotli', 'lz4', 'zstd' are all supported. For 'fastparquet',
+        only 'gzip' and 'snappy' are supported.
     index : bool, default None
         If ``True``, include the dataframe's index(es) in the file output. If
         ``False``, they will not be written to the file.


### PR DESCRIPTION
Users are misled by current `compression` param doc. Actually more compressions like "ZSTD" are supported by pyarrow engine. This patch updates the param doc to reflect the supported compressions.