### PR TITLE
Testing to_datetime, converting none to NaT

### DIFF
--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2554,6 +2554,8 @@ def test_to_datetime_monotonic_increasing_index(cache):
         ),
         (pd.Series([None] * 200), pd.Series([pd.NaT] * 200, dtype="datetime64[ns]")),
         (pd.Series([""] * 200), pd.Series([pd.NaT] * 200, dtype="datetime64[ns]")),
+        (pd.Series([pd.NA] * 200), pd.Series([pd.NaT] * 200, dtype="datetime64[ns]")),
+        (pd.Series([np.NaN] * 200), pd.Series([pd.NaT] * 200, dtype="datetime64[ns]")),
     ),
 )
 def test_to_datetime_converts_null_like_to_nat(cache, input, expected):

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -992,6 +992,25 @@ class TestToDatetime:
         )
         tm.assert_series_equal(result_series, expected_series)
 
+    @pytest.mark.parametrize("cache", [True, False])
+    @pytest.mark.parametrize(
+        ("input", "expected"),
+        (
+            (
+                Series([NaT] * 200 + [None] * 200, dtype="object"),
+                Series([NaT] * 400, dtype="datetime64[ns]"),
+            ),
+            (Series([None] * 200), Series([NaT] * 200, dtype="datetime64[ns]")),
+            (Series([""] * 200), Series([NaT] * 200, dtype="datetime64[ns]")),
+            (Series([pd.NA] * 200), Series([NaT] * 200, dtype="datetime64[ns]")),
+            (Series([np.NaN] * 200), Series([NaT] * 200, dtype="datetime64[ns]")),
+        ),
+    )
+    def test_to_datetime_converts_null_like_to_nat(cache, input, expected):
+        # GH35888
+        result = to_datetime(input)
+        tm.assert_series_equal(result, expected)
+
     @pytest.mark.parametrize(
         "date, format",
         [
@@ -2541,24 +2560,4 @@ def test_to_datetime_monotonic_increasing_index(cache):
     times.index = times.index.to_series().astype(float) / 1000
     result = to_datetime(times.iloc[:, 0], cache=cache)
     expected = times.iloc[:, 0]
-    tm.assert_series_equal(result, expected)
-
-
-@pytest.mark.parametrize("cache", [True, False])
-@pytest.mark.parametrize(
-    ("input", "expected"),
-    (
-        (
-            pd.Series([pd.NaT] * 200 + [None] * 200, dtype="object"),
-            pd.Series([pd.NaT] * 400, dtype="datetime64[ns]"),
-        ),
-        (pd.Series([None] * 200), pd.Series([pd.NaT] * 200, dtype="datetime64[ns]")),
-        (pd.Series([""] * 200), pd.Series([pd.NaT] * 200, dtype="datetime64[ns]")),
-        (pd.Series([pd.NA] * 200), pd.Series([pd.NaT] * 200, dtype="datetime64[ns]")),
-        (pd.Series([np.NaN] * 200), pd.Series([pd.NaT] * 200, dtype="datetime64[ns]")),
-    ),
-)
-def test_to_datetime_converts_null_like_to_nat(cache, input, expected):
-    # GH35888
-    result = to_datetime(input)
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2542,3 +2542,21 @@ def test_to_datetime_monotonic_increasing_index(cache):
     result = to_datetime(times.iloc[:, 0], cache=cache)
     expected = times.iloc[:, 0]
     tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("cache", [True, False])
+@pytest.mark.parametrize(
+    ("input", "expected"),
+    (
+        (
+            pd.Series([pd.NaT] * 200 + [None] * 200, dtype="object"),
+            pd.Series([pd.NaT] * 400, dtype="datetime64[ns]"),
+        ),
+        (pd.Series([None] * 200), pd.Series([pd.NaT] * 200, dtype="datetime64[ns]")),
+        (pd.Series([""] * 200), pd.Series([pd.NaT] * 200, dtype="datetime64[ns]")),
+    ),
+)
+def test_to_datetime_converts_null_like_to_nat(cache, input, expected):
+    # GH35888
+    result = to_datetime(input)
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -1006,9 +1006,9 @@ class TestToDatetime:
             (Series([np.NaN] * 200), Series([NaT] * 200, dtype="datetime64[ns]")),
         ),
     )
-    def test_to_datetime_converts_null_like_to_nat(cache, input, expected):
+    def test_to_datetime_converts_null_like_to_nat(self, cache, input, expected):
         # GH35888
-        result = to_datetime(input)
+        result = to_datetime(input, cache=cache)
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Addition of a test. Bug was fixed for #35888 somewhere in the main branch, this test just adds a unit test. 

- [x] closes #35888
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry (not sure if applicable here, can someone advise?) 
