### PR TITLE
PERF: Series.mad

### DIFF
--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1714,8 +1714,10 @@ class SingleBlockManager(BaseBlockManager, SingleDataManager):
         """The array that Series.array returns"""
         return self._block.array_values
 
-    def get_numeric_data(self) -> SingleBlockManager:
+    def get_numeric_data(self, copy: bool = False):
         if self._block.is_numeric:
+            if copy:
+                return self.copy()
             return self
         return self.make_empty()
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1714,6 +1714,11 @@ class SingleBlockManager(BaseBlockManager, SingleDataManager):
         """The array that Series.array returns"""
         return self._block.array_values
 
+    def get_numeric_data(self) -> SingleBlockManager:
+        if self._block.is_numeric:
+            return self
+        return self.make_empty()
+
     @property
     def _can_hold_na(self) -> bool:
         return self._block._can_hold_na


### PR DESCRIPTION
```
from asv_bench.benchmarks.stat_ops import *
self = SeriesOps()
self.setup("mad", "int")

%timeit self.time_op("mad", "int")
1.45 ms ± 22.6 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)  # <- master
474 µs ± 2.77 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)  # <- PR
```