### PR TITLE
BUG: seperate df dtypes from different initialization

### DIFF
--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -709,8 +709,7 @@ def _try_cast(
 
         else:
             # i.e. list
-            # GH #42971 making dtype=object
-            varr = np.array(arr, copy=False, dtype=object)
+            varr = np.array(arr, copy=False)
             # filter out cases that we _dont_ want to go through
             #  maybe_infer_to_datetimelike
             if varr.dtype != object or varr.size == 0:

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -709,7 +709,8 @@ def _try_cast(
 
         else:
             # i.e. list
-            varr = np.array(arr, copy=False)
+            # GH #42971 making dtype=object
+            varr = np.array(arr, copy=False, dtype=object)
             # filter out cases that we _dont_ want to go through
             #  maybe_infer_to_datetimelike
             if varr.dtype != object or varr.size == 0:

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -456,6 +456,17 @@ def dict_to_mgr(
         ]
         # TODO: can we get rid of the dt64tz special case above?
 
+    if dtype is None and index is None:
+        data_len = 0
+        for each in data.values():
+            if isinstance(each, (int, str)):
+                data_len += 1
+            elif each is None:
+                continue
+            else:
+                data_len += len(each)
+        if data_len == 0:
+            dtype = object
     return arrays_to_mgr(
         arrays, data_names, index, columns, dtype=dtype, typ=typ, consolidate=copy
     )

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -1095,3 +1095,10 @@ def test_period_dtype_compare_to_string():
     dtype = PeriodDtype(freq="M")
     assert (dtype == "period[M]") is True
     assert (dtype != "period[M]") is False
+
+
+def test_constructor_dtype():
+    # GH#42971
+    expected = pd.DataFrame(columns=["a"])
+    result = pd.DataFrame({"a": []})
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -1097,8 +1097,8 @@ def test_period_dtype_compare_to_string():
     assert (dtype != "period[M]") is False
 
 
-def test_constructor_dtype():
+def test_dataframe_constructor_dtype():
     # GH#42971
     expected = pd.DataFrame(columns=["a"])
     result = pd.DataFrame({"a": []})
-    tm.assert_frame_equal(result, expected)
+    tm.assert_series_equal(result.dtypes, expected.dtypes)


### PR DESCRIPTION
- [x] closes #42971
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
