### PR TITLE
DEPR: Int64Index, UInt64Index & Float64Index

### DIFF
--- a/doc/source/user_guide/advanced.rst
+++ b/doc/source/user_guide/advanced.rst
@@ -982,7 +982,7 @@ NumericIndex
 
     In pandas 2.0, :class:`NumericIndex` will become the default index type for numeric types
     instead of :class:`Int64Index`, :class:`Float64Index` and :class:`UInt64Index` and those index types
-    are therefore deprecated and will be removed in a futureversion.
+    are therefore deprecated and will be removed in a future version.
     :class:`RangeIndex` will not be removed as it represents an optimized version of an integer index.
 
 :class:`NumericIndex` is an index type that can hold data of any numpy int/uint/float dtype. For example:

--- a/doc/source/user_guide/advanced.rst
+++ b/doc/source/user_guide/advanced.rst
@@ -854,9 +854,9 @@ Int64Index and RangeIndex
 .. deprecated:: 1.4.0
     In pandas 2.0, :class:`NumericIndex` will become the default index type for numeric types
     instead of ``Int64Index``, ``Float64Index`` and ``UInt64Index`` and those index types
-    are therefore deprecated and will be removed in Pandas 2.0.
+    are therefore deprecated and will be removed in a futire version.
     See :ref:`here <advanced.numericindex>` for more.
-    ``RangeIndex`` however, will not be removed, as it represents an optimized version of an integer index.
+    ``RangeIndex`` will not be removed, as it represents an optimized version of an integer index.
 
 :class:`Int64Index` is a fundamental basic index in pandas. This is an immutable array
 implementing an ordered, sliceable set.
@@ -870,11 +870,11 @@ Float64Index
 ~~~~~~~~~~~~
 
 .. deprecated:: 1.4.0
-    In pandas 2.0, :class:`NumericIndex` will become the default index type for numeric types
+    :class:`NumericIndex` will become the default index type for numeric types in the future
     instead of ``Int64Index``, ``Float64Index`` and ``UInt64Index`` and those index types
-    are therefore deprecated and will be removed in Pandas 2.0.
+    are therefore deprecated and will be removed in a future version of Pandas.
     See :ref:`here <advanced.numericindex>` for more.
-    ``RangeIndex`` however, will not be removed, as it represents an optimized version of an integer index.
+    ``RangeIndex`` will not be removed as it represents an optimized version of an integer index.
 
 By default a :class:`Float64Index` will be automatically created when passing floating, or mixed-integer-floating values in index creation.
 This enables a pure label-based slicing paradigm that makes ``[],ix,loc`` for scalar indexing and slicing work exactly the
@@ -982,8 +982,8 @@ NumericIndex
 
     In pandas 2.0, :class:`NumericIndex` will become the default index type for numeric types
     instead of :class:`Int64Index`, :class:`Float64Index` and :class:`UInt64Index` and those index types
-    are therefore deprecated and will be removed in Pandas 2.0.
-    :class:`RangeIndex` however, will not be removed, as it represents an optimized version of an integer index.
+    are therefore deprecated and will be removed in a futureversion.
+    :class:`RangeIndex` will not be removed as it represents an optimized version of an integer index.
 
 :class:`NumericIndex` is an index type that can hold data of any numpy int/uint/float dtype. For example:
 
@@ -998,7 +998,7 @@ NumericIndex
 ``UInt64Index`` except that it can hold any numpy int, uint or float dtype.
 
 Until Pandas 2.0, you will have to call ``NumericIndex`` explicitly in order to use it, like in the example above.
-In Pandas 2.0, ``NumericIndex`` will become the default pandas numeric index type and will automatically be used where appropriate.
+In the future, ``NumericIndex`` will become the default pandas numeric index type and will automatically be used where appropriate.
 
 Please notice that ``NumericIndex`` *can not* hold Pandas numeric dtypes (:class:`Int64Dtype`, :class:`Int32Dtype` etc.).
 

--- a/doc/source/user_guide/advanced.rst
+++ b/doc/source/user_guide/advanced.rst
@@ -851,11 +851,11 @@ values **not** in the categories, similarly to how you can reindex **any** panda
 Int64Index and RangeIndex
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. note::
-
+.. deprecated:: 1.4.0
     In pandas 2.0, :class:`NumericIndex` will become the default index type for numeric types
     instead of ``Int64Index``, ``Float64Index`` and ``UInt64Index`` and those index types
-    will be removed. See :ref:`here <advanced.numericindex>` for more.
+    are therefore deprecated and will be removed in Pandas 2.0.
+    See :ref:`here <advanced.numericindex>` for more.
     ``RangeIndex`` however, will not be removed, as it represents an optimized version of an integer index.
 
 :class:`Int64Index` is a fundamental basic index in pandas. This is an immutable array
@@ -869,11 +869,11 @@ implementing an ordered, sliceable set.
 Float64Index
 ~~~~~~~~~~~~
 
-.. note::
-
+.. deprecated:: 1.4.0
     In pandas 2.0, :class:`NumericIndex` will become the default index type for numeric types
     instead of ``Int64Index``, ``Float64Index`` and ``UInt64Index`` and those index types
-    will be removed. See :ref:`here <advanced.numericindex>` for more.
+    are therefore deprecated and will be removed in Pandas 2.0.
+    See :ref:`here <advanced.numericindex>` for more.
     ``RangeIndex`` however, will not be removed, as it represents an optimized version of an integer index.
 
 By default a :class:`Float64Index` will be automatically created when passing floating, or mixed-integer-floating values in index creation.
@@ -981,9 +981,9 @@ NumericIndex
 .. note::
 
     In pandas 2.0, :class:`NumericIndex` will become the default index type for numeric types
-    instead of ``Int64Index``, ``Float64Index`` and ``UInt64Index`` and those index types
-    will be removed.
-    ``RangeIndex`` however, will not be removed, as it represents an optimized version of an integer index.
+    instead of :class:`Int64Index`, :class:`Float64Index` and :class:`UInt64Index` and those index types
+    are therefore deprecated and will be removed in Pandas 2.0.
+    :class:`RangeIndex` however, will not be removed, as it represents an optimized version of an integer index.
 
 :class:`NumericIndex` is an index type that can hold data of any numpy int/uint/float dtype. For example:
 

--- a/doc/source/whatsnew/v0.20.0.rst
+++ b/doc/source/whatsnew/v0.20.0.rst
@@ -248,11 +248,12 @@ or purely non-negative, integers. Previously, handling these integers would
 result in improper rounding or data-type casting, leading to incorrect results.
 Notably, a new numerical index, ``UInt64Index``, has been created (:issue:`14937`)
 
-.. ipython:: python
+.. code-block:: ipython
 
-   idx = pd.UInt64Index([1, 2, 3])
-   df = pd.DataFrame({'A': ['a', 'b', 'c']}, index=idx)
-   df.index
+   In [1]: idx = pd.UInt64Index([1, 2, 3])
+   In [2]: df = pd.DataFrame({'A': ['a', 'b', 'c']}, index=idx)
+   In [3]: df.index
+   Out[3]: UInt64Index([1, 2, 3], dtype='uint64')
 
 - Bug in converting object elements of array-like objects to unsigned 64-bit integers (:issue:`4471`, :issue:`14982`)
 - Bug in ``Series.unique()`` in which unsigned 64-bit integers were causing overflow (:issue:`14721`)

--- a/doc/source/whatsnew/v0.23.0.rst
+++ b/doc/source/whatsnew/v0.23.0.rst
@@ -861,21 +861,21 @@ Previous behavior:
 
 Current behavior:
 
-.. ipython:: python
+.. code-block:: ipython
 
-    index = pd.Int64Index([-1, 0, 1])
+    In [12]: index = pd.Int64Index([-1, 0, 1])
     # division by zero gives -infinity where negative,
     # +infinity where positive, and NaN for 0 / 0
-    index / 0
+    In [13]: index / 0
 
     # The result of division by zero should not depend on
     # whether the zero is int or float
-    index / 0.0
+    In [14]: index / 0.0
 
-    index = pd.UInt64Index([0, 1])
-    index / np.array([0, 0], dtype=np.uint64)
+    In [15]: index = pd.UInt64Index([0, 1])
+    In [16]: index / np.array([0, 0], dtype=np.uint64)
 
-    pd.RangeIndex(1, 5) / 0
+    In [17]: pd.RangeIndex(1, 5) / 0
 
 .. _whatsnew_0230.api_breaking.extract:
 

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -473,10 +473,12 @@ considered commutative, such that ``A.union(B) == B.union(A)`` (:issue:`23525`).
 
 *New behavior*:
 
-.. ipython:: python
+.. code-block:: python
 
-    pd.period_range('19910905', periods=2).union(pd.Int64Index([1, 2, 3]))
-    pd.Index([], dtype=object).union(pd.Index([1, 2, 3]))
+    In [3]: pd.period_range('19910905', periods=2).union(pd.Int64Index([1, 2, 3]))
+    Out[3]: Index([1991-09-05, 1991-09-06, 1, 2, 3], dtype='object')
+    In [4]: pd.Index([], dtype=object).union(pd.Index([1, 2, 3]))
+    Out[4]: Index([1, 2, 3], dtype='object')
 
 Note that integer- and floating-dtype indexes are considered "compatible". The integer
 values are coerced to floating point, which may result in loss of precision. See

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -38,11 +38,10 @@ For example, the code below returns an ``Int64Index`` with dtype ``int64``:
     In [1]: pd.Index([1, 2, 3], dtype="int8")
     Int64Index([1, 2, 3], dtype='int64')
 
-For the duration of Pandas 1.x, in order to maintain backwards compatibility, all
-operations that until now have returned :class:`Int64Index`, :class:`UInt64Index` and
-:class:`Float64Index` will continue to so. This means, that in order to use
-``NumericIndex``, you will have to call ``NumericIndex`` explicitly. For example the below series
-will have an ``Int64Index``:
+More generally, for the duration of Pandas 1.x, all operations that until now have
+returned :class:`Int64Index`, :class:`UInt64Index` and :class:`Float64Index` will
+continue to so. This means, that in order to use ``NumericIndex``, you will have to call
+``NumericIndex`` explicitly. For example the below series will have an ``Int64Index``:
 
 .. code-block:: ipython
 
@@ -50,7 +49,7 @@ will have an ``Int64Index``:
     In [3]: ser.index
     Int64Index([1, 2, 3], dtype='int64')
 
-Instead if you want to use a ``NumericIndex``, you should do:
+Instead, if you want to use a ``NumericIndex`` in Pandas 1.x, you should do:
 
 .. ipython:: python
 
@@ -59,7 +58,8 @@ Instead if you want to use a ``NumericIndex``, you should do:
     ser.index
 
 In Pandas 2.0, :class:`NumericIndex` will become the default numeric index type and
-``Int64Index``, ``UInt64Index`` and ``Float64Index`` will be removed.
+``Int64Index``, ``UInt64Index`` and ``Float64Index`` are therefore deprecated and will
+be removed in pandas 2.0.
 
 See :ref:`here <advanced.numericindex>` for more.
 
@@ -224,6 +224,9 @@ Other API changes
 
 Deprecations
 ~~~~~~~~~~~~
+- Deprecated :class:`Int64Index` (:issue:`xxxxx`).
+- Deprecated :class:`UInt64Index` (:issue:`xxxxx`).
+- Deprecated :class:`Float64Index` (:issue:`xxxxx`).
 - Deprecated :meth:`Index.is_type_compatible` (:issue:`42113`)
 - Deprecated ``method`` argument in :meth:`Index.get_loc`, use ``index.get_indexer([label], method=...)`` instead (:issue:`42269`)
 - Deprecated treating integer keys in :meth:`Series.__setitem__` as positional when the index is a :class:`Float64Index` not containing the key, a :class:`IntervalIndex` with no entries containing the key, or a :class:`MultiIndex` with leading :class:`Float64Index` level not containing the key (:issue:`33469`)

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -230,7 +230,7 @@ Deprecations
 .. _whatsnew_140.deprecations.int64_uint64_float64index:
 
 Deprecated Int64Index, UInt64Index & Float64Index
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 :class:`Int64Index`, :class:`UInt64Index` (:issue:`43028`) and :class:`Float64Index` have
 been deprecated in favor of the new :class:`NumericIndex` (:issue:`43028`).
 

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -231,14 +231,14 @@ Deprecations
 
 Deprecated Int64Index, UInt64Index & Float64Index
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-:class:`Int64Index`, :class:`UInt64Index` (:issue:`43028`) and :class:`Float64Index` have
-been deprecated in favor of the new :class:`NumericIndex` (:issue:`43028`).
+:class:`Int64Index`, :class:`UInt64Index` and :class:`Float64Index` have been deprecated
+in favor of the new :class:`NumericIndex` and will be removed in Pandas 2.0 (:issue:`43028`).
 
 For the duration of Pandas 1.x, in order to maintain backward compatibility, calls to
 :class:`Index` will continue to return :class:`Int64Index`, :class:`UInt64Index` and :class:`Float64Index`
 when given numeric data, but in Pandas 2.0, a :class:`NumericIndex` will be returned.
 
-*Current behavior (Pandas 1.x)*:
+*Current behavior*:
 
 .. code-block:: ipython
 
@@ -247,7 +247,7 @@ when given numeric data, but in Pandas 2.0, a :class:`NumericIndex` will be retu
     In [1]: pd.Index([1, 2, 3], dtype="uint64")
     Out [1]: UInt64Index([1, 2, 3], dtype='uint64')
 
-*Future behavior (Pandas 2.0)*:
+*Future behavior*:
 
 .. code-block:: ipython
 

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -29,8 +29,8 @@ It is now possible to create an index of any numpy int/uint/float dtype using th
     pd.NumericIndex([1, 2, 3], dtype="uint32")
     pd.NumericIndex([1, 2, 3], dtype="float32")
 
-In order to maintain backwards compatibility, calls to the base :class:`Index` will in
-pandas 1.x. return :class:`Int64Index`, :class:`UInt64Index` and :class:`Float64Index`, where relevant.
+In order to maintain backwards compatibility, calls to the base :class:`Index` will currently
+return :class:`Int64Index`, :class:`UInt64Index` and :class:`Float64Index`, where relevant.
 For example, the code below returns an ``Int64Index`` with dtype ``int64``:
 
 .. code-block:: ipython
@@ -38,11 +38,11 @@ For example, the code below returns an ``Int64Index`` with dtype ``int64``:
     In [1]: pd.Index([1, 2, 3], dtype="int8")
     Int64Index([1, 2, 3], dtype='int64')
 
-but will in Pandas 2.0 return a :class:`NumericIndex` with dtype ``int8``.
+but will in a future version return a :class:`NumericIndex` with dtype ``int8``.
 
-More generally, for the duration of Pandas 1.x, all operations that until now have
+More generally, currently, all operations that until now have
 returned :class:`Int64Index`, :class:`UInt64Index` and :class:`Float64Index` will
-continue to so. This means, that in order to use ``NumericIndex`` in Pandas 1.x, you
+continue to so. This means, that in order to use ``NumericIndex`` in the current version, you
 will have to call ``NumericIndex`` explicitly. For example the below series will have an ``Int64Index``:
 
 .. code-block:: ipython
@@ -51,7 +51,7 @@ will have to call ``NumericIndex`` explicitly. For example the below series will
     In [3]: ser.index
     Int64Index([1, 2, 3], dtype='int64')
 
-Instead, if you want to use a ``NumericIndex`` in Pandas 1.x, you should do:
+Instead, if you want to use a ``NumericIndex``, you should do:
 
 .. ipython:: python
 
@@ -59,9 +59,9 @@ Instead, if you want to use a ``NumericIndex`` in Pandas 1.x, you should do:
     ser = pd.Series([1, 2, 3], index=idx)
     ser.index
 
-In Pandas 2.0, :class:`NumericIndex` will become the default numeric index type and
+In a future version of Pandas, :class:`NumericIndex` will become the default numeric index type and
 ``Int64Index``, ``UInt64Index`` and ``Float64Index`` are therefore deprecated and will
-be removed in pandas 2.0, see :ref:`here <whatsnew_140.deprecations.int64_uint64_float64index>` for more.
+be removed in the future, see :ref:`here <whatsnew_140.deprecations.int64_uint64_float64index>` for more.
 
 See :ref:`here <advanced.numericindex>` for more about :class:`NumericIndex`.
 
@@ -234,9 +234,9 @@ Deprecated Int64Index, UInt64Index & Float64Index
 :class:`Int64Index`, :class:`UInt64Index` and :class:`Float64Index` have been deprecated
 in favor of the new :class:`NumericIndex` and will be removed in Pandas 2.0 (:issue:`43028`).
 
-For the duration of Pandas 1.x, in order to maintain backward compatibility, calls to
+Currently, in order to maintain backward compatibility, calls to
 :class:`Index` will continue to return :class:`Int64Index`, :class:`UInt64Index` and :class:`Float64Index`
-when given numeric data, but in Pandas 2.0, a :class:`NumericIndex` will be returned.
+when given numeric data, but in the future, a :class:`NumericIndex` will be returned.
 
 *Current behavior*:
 

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -30,7 +30,7 @@ It is now possible to create an index of any numpy int/uint/float dtype using th
     pd.NumericIndex([1, 2, 3], dtype="float32")
 
 In order to maintain backwards compatibility, calls to the base :class:`Index` will in
-pandas 1.x. return :class:`Int64Index`, :class:`UInt64Index` and :class:`Float64Index`.
+pandas 1.x. return :class:`Int64Index`, :class:`UInt64Index` and :class:`Float64Index`, where relevant.
 For example, the code below returns an ``Int64Index`` with dtype ``int64``:
 
 .. code-block:: ipython
@@ -38,10 +38,12 @@ For example, the code below returns an ``Int64Index`` with dtype ``int64``:
     In [1]: pd.Index([1, 2, 3], dtype="int8")
     Int64Index([1, 2, 3], dtype='int64')
 
+but will in Pandas 2.0 return a :class:`NumericIndex` with dtype ``int8``.
+
 More generally, for the duration of Pandas 1.x, all operations that until now have
 returned :class:`Int64Index`, :class:`UInt64Index` and :class:`Float64Index` will
-continue to so. This means, that in order to use ``NumericIndex``, you will have to call
-``NumericIndex`` explicitly. For example the below series will have an ``Int64Index``:
+continue to so. This means, that in order to use ``NumericIndex`` in Pandas 1.x, you
+will have to call ``NumericIndex`` explicitly. For example the below series will have an ``Int64Index``:
 
 .. code-block:: ipython
 
@@ -59,9 +61,9 @@ Instead, if you want to use a ``NumericIndex`` in Pandas 1.x, you should do:
 
 In Pandas 2.0, :class:`NumericIndex` will become the default numeric index type and
 ``Int64Index``, ``UInt64Index`` and ``Float64Index`` are therefore deprecated and will
-be removed in pandas 2.0.
+be removed in pandas 2.0, see :ref:`here <whatsnew_140.deprecations.int64_uint64_float64index>` for more.
 
-See :ref:`here <advanced.numericindex>` for more.
+See :ref:`here <advanced.numericindex>` for more about :class:`NumericIndex`.
 
 .. _whatsnew_140.enhancements.styler:
 
@@ -224,9 +226,41 @@ Other API changes
 
 Deprecations
 ~~~~~~~~~~~~
-- Deprecated :class:`Int64Index` (:issue:`43028`).
-- Deprecated :class:`UInt64Index` (:issue:`43028`).
-- Deprecated :class:`Float64Index` (:issue:`43028`).
+
+.. _whatsnew_140.deprecations.int64_uint64_float64index:
+
+Deprecated Int64Index, UInt64Index & Float64Index
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:class:`Int64Index`, :class:`UInt64Index` (:issue:`43028`) and :class:`Float64Index` have
+been deprecated in favor of the new :class:`NumericIndex` (:issue:`43028`).
+
+For the duration of Pandas 1.x, in order to maintain backward compatibility, calls to
+:class:`Index` will continue to return :class:`Int64Index`, :class:`UInt64Index` and :class:`Float64Index`
+when given numeric data, but in Pandas 2.0, a :class:`NumericIndex` will be returned.
+
+*Current behavior (Pandas 1.x)*:
+
+.. code-block:: ipython
+
+    In [1]: pd.Index([1, 2, 3], dtype="int32")
+    Out [1]: Int64Index([1, 2, 3], dtype='int64')
+    In [1]: pd.Index([1, 2, 3], dtype="uint64")
+    Out [1]: UInt64Index([1, 2, 3], dtype='uint64')
+
+*Future behavior (Pandas 2.0)*:
+
+.. code-block:: ipython
+
+    In [3]: pd.Index([1, 2, 3], dtype="int32")
+    Out [3]: NumericIndex([1, 2, 3], dtype='int32')
+    In [4]: pd.Index([1, 2, 3], dtype="uint64")
+    Out [4]: NumericIndex([1, 2, 3], dtype='uint64')
+
+
+.. _whatsnew_140.deprecations.other:
+
+Other Deprecations
+^^^^^^^^^^^^^^^^^^
 - Deprecated :meth:`Index.is_type_compatible` (:issue:`42113`)
 - Deprecated ``method`` argument in :meth:`Index.get_loc`, use ``index.get_indexer([label], method=...)`` instead (:issue:`42269`)
 - Deprecated treating integer keys in :meth:`Series.__setitem__` as positional when the index is a :class:`Float64Index` not containing the key, a :class:`IntervalIndex` with no entries containing the key, or a :class:`MultiIndex` with leading :class:`Float64Index` level not containing the key (:issue:`33469`)

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -224,9 +224,9 @@ Other API changes
 
 Deprecations
 ~~~~~~~~~~~~
-- Deprecated :class:`Int64Index` (:issue:`xxxxx`).
-- Deprecated :class:`UInt64Index` (:issue:`xxxxx`).
-- Deprecated :class:`Float64Index` (:issue:`xxxxx`).
+- Deprecated :class:`Int64Index` (:issue:`43028`).
+- Deprecated :class:`UInt64Index` (:issue:`43028`).
+- Deprecated :class:`Float64Index` (:issue:`43028`).
 - Deprecated :meth:`Index.is_type_compatible` (:issue:`42113`)
 - Deprecated ``method`` argument in :meth:`Index.get_loc`, use ``index.get_indexer([label], method=...)`` instead (:issue:`42269`)
 - Deprecated treating integer keys in :meth:`Series.__setitem__` as positional when the index is a :class:`Float64Index` not containing the key, a :class:`IntervalIndex` with no entries containing the key, or a :class:`MultiIndex` with leading :class:`Float64Index` level not containing the key (:issue:`33469`)

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -70,7 +70,6 @@ from pandas.core.api import (
     # indexes
     Index,
     CategoricalIndex,
-    Int64Index,
     UInt64Index,
     RangeIndex,
     Float64Index,
@@ -186,10 +185,41 @@ del get_versions, v
 
 
 # GH 27101
+deprecated_num_index_names = ["Float64Index", "Int64Index", "UInt64Index"]
+
+
+def __dir__():
+    return list(globals().keys()) + deprecated_num_index_names
+
+
 def __getattr__(name):
     import warnings
 
-    if name == "datetime":
+    if name in deprecated_num_index_names:
+        num_msg = (
+            f"The pandas.{name} class is deprecated "
+            "and will be removed from pandas in a future version. "
+            "Use pandas.NumericIndex with the appropriate dtype instead."
+        )
+        if name == "Int64Index":
+            from pandas.core.api import Int64Index
+
+            warnings.warn(num_msg, FutureWarning, stacklevel=2)
+            return Int64Index
+        elif name == "Unt64Index":
+            from pandas.core.api import UInt64Index
+
+            warnings.warn(num_msg, FutureWarning, stacklevel=2)
+            return UInt64Index
+        elif name == "Float64Index":
+            from pandas.core.api import Float64Index
+
+            warnings.warn(num_msg, FutureWarning, stacklevel=2)
+            return Float64Index
+        else:
+            raise NameError(name)
+
+    elif name == "datetime":
         warnings.warn(
             "The pandas.datetime class is deprecated "
             "and will be removed from pandas in a future version. "

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -192,6 +192,7 @@ def __dir__():
 
 def __getattr__(name):
     import warnings
+    from pandas.core.api import Float64Index, Int64Index, UInt64Index
 
     if name in __deprecated_num_index_names:
         num_msg = (
@@ -199,24 +200,12 @@ def __getattr__(name):
             "and will be removed from pandas in a future version. "
             "Use pandas.NumericIndex with the appropriate dtype instead."
         )
-        if name == "Int64Index":
-            from pandas.core.api import Int64Index
-
-            warnings.warn(num_msg, FutureWarning, stacklevel=2)
-            return Int64Index
-        elif name == "UInt64Index":
-            from pandas.core.api import UInt64Index
-
-            warnings.warn(num_msg, FutureWarning, stacklevel=2)
-            return UInt64Index
-        elif name == "Float64Index":
-            from pandas.core.api import Float64Index
-
-            warnings.warn(num_msg, FutureWarning, stacklevel=2)
-            return Float64Index
-        else:
-            raise NameError(name)
-
+        warnings.warn(num_msg, FutureWarning, stacklevel=2)
+        return {
+            "Float64Index": Float64Index,
+            "Int64Index": Int64Index,
+            "UInt64Index": UInt64Index,
+        }[name]
     elif name == "datetime":
         warnings.warn(
             "The pandas.datetime class is deprecated "

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -70,9 +70,7 @@ from pandas.core.api import (
     # indexes
     Index,
     CategoricalIndex,
-    UInt64Index,
     RangeIndex,
-    Float64Index,
     NumericIndex,
     MultiIndex,
     IntervalIndex,
@@ -185,19 +183,19 @@ del get_versions, v
 
 
 # GH 27101
-deprecated_num_index_names = ["Float64Index", "Int64Index", "UInt64Index"]
+__deprecated_num_index_names = ["Float64Index", "Int64Index", "UInt64Index"]
 
 
 def __dir__():
-    return list(globals().keys()) + deprecated_num_index_names
+    return list(globals().keys()) + __deprecated_num_index_names
 
 
 def __getattr__(name):
     import warnings
 
-    if name in deprecated_num_index_names:
+    if name in __deprecated_num_index_names:
         num_msg = (
-            f"The pandas.{name} class is deprecated "
+            f"pandas.{name} is deprecated "
             "and will be removed from pandas in a future version. "
             "Use pandas.NumericIndex with the appropriate dtype instead."
         )
@@ -206,7 +204,7 @@ def __getattr__(name):
 
             warnings.warn(num_msg, FutureWarning, stacklevel=2)
             return Int64Index
-        elif name == "Unt64Index":
+        elif name == "UInt64Index":
             from pandas.core.api import UInt64Index
 
             warnings.warn(num_msg, FutureWarning, stacklevel=2)

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -192,15 +192,17 @@ def __dir__():
 
 def __getattr__(name):
     import warnings
-    from pandas.core.api import Float64Index, Int64Index, UInt64Index
 
     if name in __deprecated_num_index_names:
-        num_msg = (
+        warnings.warn(
             f"pandas.{name} is deprecated "
             "and will be removed from pandas in a future version. "
-            "Use pandas.NumericIndex with the appropriate dtype instead."
+            "Use pandas.NumericIndex with the appropriate dtype instead.",
+            FutureWarning,
+            stacklevel=2,
         )
-        warnings.warn(num_msg, FutureWarning, stacklevel=2)
+        from pandas.core.api import Float64Index, Int64Index, UInt64Index
+
         return {
             "Float64Index": Float64Index,
             "Int64Index": Int64Index,

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -187,6 +187,9 @@ __deprecated_num_index_names = ["Float64Index", "Int64Index", "UInt64Index"]
 
 
 def __dir__():
+    # GH43028
+    # Int64Index etc. are deprecated, but we still want them to be available in the dir.
+    # Remove in Pandas 2.0, when we remove Int64Index etc. from the code base.
     return list(globals().keys()) + __deprecated_num_index_names
 
 

--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -45,15 +45,12 @@ from pandas import (
     CategoricalIndex,
     DataFrame,
     DatetimeIndex,
-    Float64Index,
     Index,
-    Int64Index,
     IntervalIndex,
     MultiIndex,
     NumericIndex,
     RangeIndex,
     Series,
-    UInt64Index,
     bdate_range,
 )
 from pandas._testing._io import (  # noqa:F401
@@ -105,6 +102,11 @@ from pandas._testing.contexts import (  # noqa:F401
     set_timezone,
     use_numexpr,
     with_csv_dialect,
+)
+from pandas.core.api import (
+    Float64Index,
+    Int64Index,
+    UInt64Index,
 )
 from pandas.core.arrays import (
     DatetimeArray,

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1334,7 +1334,7 @@ class SelectNFrame(SelectN):
 
     def compute(self, method: str) -> DataFrame:
 
-        from pandas import Int64Index
+        from pandas.core.api import Int64Index
 
         n = self.n
         frame = self.obj

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -572,15 +572,15 @@ class Index(IndexOpsMixin, PandasObject):
             return TimedeltaIndex
 
         elif is_float_dtype(dtype):
-            from pandas import Float64Index
+            from pandas.core.api import Float64Index
 
             return Float64Index
         elif is_unsigned_integer_dtype(dtype):
-            from pandas import UInt64Index
+            from pandas.core.api import UInt64Index
 
             return UInt64Index
         elif is_signed_integer_dtype(dtype):
-            from pandas import Int64Index
+            from pandas.core.api import Int64Index
 
             return Int64Index
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -276,9 +276,10 @@ class Index(IndexOpsMixin, PandasObject):
     DatetimeIndex : Index of datetime64 data.
     TimedeltaIndex : Index of timedelta64 data.
     PeriodIndex : Index of Period data.
-    Int64Index : A special case of :class:`Index` with purely integer labels.
-    UInt64Index : A special case of :class:`Index` with purely unsigned integer labels.
-    Float64Index : A special case of :class:`Index` with purely float labels.
+    NumericIndex : Index of numpy int/uint/float data.
+    Int64Index : Index of purely int64 labels (deprecated).
+    UInt64Index : Index of purely uint64 labels (deprecated).
+    Float64Index : Index of  purely float64 labels (deprecated).
 
     Notes
     -----

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -51,12 +51,6 @@ class NumericIndex(Index):
 
     .. versionadded:: 1.4.0
 
-    Notes
-    -----
-    An NumericIndex instance can **only** contain numpy int64/32/16/8, uint64/32/16/8 or
-    float64/32/16 dtype. In Particulat, ``NumericIndex`` *can not* hold Pandas numeric
-    dtypes (:class:`Int64Dtype`, :class:`Int32Dtype` etc.).
-
     Parameters
     ----------
     data : array-like (1-dimensional)
@@ -81,12 +75,18 @@ class NumericIndex(Index):
     UInt64Index : Index of purely uint64 labels (deprecated).
     Float64Index : Index of  purely float64 labels (deprecated).
 
+    Notes
+    -----
+    An NumericIndex instance can **only** contain numpy int64/32/16/8, uint64/32/16/8 or
+    float64/32/16 dtype. In particular, ``NumericIndex`` *can not* hold Pandas numeric
+    dtypes (:class:`Int64Dtype`, :class:`Int32Dtype` etc.).
+
     Examples
     --------
-    >>> pd.NumericIndex([1, 2, 3])
-    NumericIndex([1, 2, 3], dtype='int32')
     >>> pd.NumericIndex([1, 2, 3], dtype="int8")
     NumericIndex([1, 2, 3], dtype='int8')
+    >>> pd.NumericIndex([1, 2, 3], dtype="float32")
+    NumericIndex([1, 2, 3], dtype='float32')
     """
 
     _typ = "numericindex"

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -42,51 +42,44 @@ from pandas.core.indexes.base import (
     maybe_extract_name,
 )
 
-_num_index_shared_docs = {}
 
-
-_num_index_shared_docs[
-    "class_descr"
-] = """
+class NumericIndex(Index):
+    """
     Immutable sequence used for indexing and alignment. The basic object
-    storing axis labels for all pandas objects. %(klass)s is a special case
-    of `Index` with purely %(ltype)s labels. %(extra)s.
+    storing axis labels for all pandas objects. NumericIndex is a special case
+    of `Index` with purely numpy int/uint/float labels.
+
+    .. versionadded:: 1.4.0
+
+    Notes
+    -----
+    An NumericIndex instance can **only** contain numpy int64/32/16/8, uint64/32/16/8 or
+    float64/32/16 dtype. In Particulat, ``NumericIndex`` *can not* hold Pandas numeric
+    dtypes (:class:`Int64Dtype`, :class:`Int32Dtype` etc.).
 
     Parameters
     ----------
     data : array-like (1-dimensional)
-    dtype : NumPy dtype (default: %(dtype)s)
+    dtype : NumPy dtype (default: None)
     copy : bool
         Make a copy of input ndarray.
     name : object
         Name to be stored in the index.
 
-    Attributes
-    ----------
-    None
-
-    Methods
-    -------
-    None
-
     See Also
     --------
     Index : The base pandas Index type.
+    Int64Index : Index of purely int64 labels (deprecated).
+    UInt64Index : Index of purely uint64 labels (deprecated).
+    Float64Index : Index of  purely float64 labels (deprecated).
 
-    Notes
-    -----
-    An Index instance can **only** contain hashable objects.
-"""
-
-
-class NumericIndex(Index):
-    _index_descr_args = {
-        "klass": "NumericIndex",
-        "ltype": "integer or float",
-        "dtype": "inferred",
-        "extra": "",
-    }
-    __doc__ = _num_index_shared_docs["class_descr"] % _index_descr_args
+    Examples
+    --------
+    >>> pd.NumericIndex([1, 2, 3])
+    NumericIndex([1, 2, 3], dtype='int32')
+    >>> pd.NumericIndex([1, 2, 3], dtype="int8")
+    NumericIndex([1, 2, 3], dtype='int8')
+    """
 
     _typ = "numericindex"
     _values: np.ndarray
@@ -358,6 +351,40 @@ class NumericIndex(Index):
             quoting=quoting,
             **kwargs,
         )
+
+
+_num_index_shared_docs = {}
+
+
+_num_index_shared_docs[
+    "class_descr"
+] = """
+    Immutable sequence used for indexing and alignment. The basic object
+    storing axis labels for all pandas objects. %(klass)s is a special case
+    of `Index` with purely %(ltype)s labels. %(extra)s.
+
+    .. deprecated:: 1.4.0
+        In pandas v2.0 %(klass)s will be removed and :class:`NumericIndex` used instead.
+        %(klass)s will remain fully functional for the duration of pandas 1.x.
+
+    Parameters
+    ----------
+    data : array-like (1-dimensional)
+    dtype : NumPy dtype (default: %(dtype)s)
+    copy : bool
+        Make a copy of input ndarray.
+    name : object
+        Name to be stored in the index.
+
+    See Also
+    --------
+    Index : The base pandas Index type.
+    NumericIndex : Index of numpy int/uint/float data.
+
+    Notes
+    -----
+    An Index instance can **only** contain hashable objects.
+"""
 
 
 class IntegerIndex(NumericIndex):

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -86,7 +86,7 @@ class NumericIndex(Index):
     >>> pd.NumericIndex([1, 2, 3], dtype="int8")
     NumericIndex([1, 2, 3], dtype='int8')
     >>> pd.NumericIndex([1, 2, 3], dtype="float32")
-    NumericIndex([1, 2, 3], dtype='float32')
+    NumericIndex([1.0, 2.0, 3.0], dtype='float32')
     """
 
     _typ = "numericindex"

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -66,6 +66,14 @@ class NumericIndex(Index):
     name : object
         Name to be stored in the index.
 
+    Attributes
+    ----------
+    None
+
+    Methods
+    ----------
+    None
+
     See Also
     --------
     Index : The base pandas Index type.
@@ -375,6 +383,14 @@ _num_index_shared_docs[
         Make a copy of input ndarray.
     name : object
         Name to be stored in the index.
+
+    Attributes
+    ----------
+    None
+
+    Methods
+    ----------
+    None
 
     See Also
     --------

--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -9,12 +9,12 @@ from pandas._typing import (
 from pandas.compat._optional import import_optional_dependency
 from pandas.util._decorators import doc
 
-from pandas import (
+from pandas.core import generic
+from pandas.core.api import (
     DataFrame,
     Int64Index,
     RangeIndex,
 )
-from pandas.core import generic
 
 from pandas.io.common import get_handle
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -65,7 +65,6 @@ from pandas import (
     DataFrame,
     DatetimeIndex,
     Index,
-    Int64Index,
     MultiIndex,
     PeriodIndex,
     Series,
@@ -73,6 +72,7 @@ from pandas import (
     concat,
     isna,
 )
+from pandas.core.api import Int64Index
 from pandas.core.arrays import (
     Categorical,
     DatetimeArray,

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -100,7 +100,7 @@ class TestPDApi(Base):
     ]
 
     # these are already deprecated; awaiting removal
-    deprecated_classes: list[str] = []
+    deprecated_classes: list[str] = ["Float64Index", "Int64Index", "UInt64Index"]
 
     # these should be deprecated in the future
     deprecated_classes_in_future: list[str] = ["SparseArray"]

--- a/pandas/tests/arithmetic/conftest.py
+++ b/pandas/tests/arithmetic/conftest.py
@@ -2,13 +2,13 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas import (
+from pandas import RangeIndex
+import pandas._testing as tm
+from pandas.core.api import (
     Float64Index,
     Int64Index,
-    RangeIndex,
     UInt64Index,
 )
-import pandas._testing as tm
 from pandas.core.computation import expressions as expr
 
 

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -14,18 +14,20 @@ import pytest
 
 import pandas as pd
 from pandas import (
-    Float64Index,
     Index,
-    Int64Index,
     RangeIndex,
     Series,
     Timedelta,
     TimedeltaIndex,
-    UInt64Index,
     array,
 )
 import pandas._testing as tm
 from pandas.core import ops
+from pandas.core.api import (
+    Float64Index,
+    Int64Index,
+    UInt64Index,
+)
 from pandas.core.computation import expressions as expr
 
 

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -26,6 +26,11 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
+from pandas.core.api import (
+    Float64Index,
+    Int64Index,
+    UInt64Index,
+)
 from pandas.tests.arithmetic.common import (
     assert_invalid_addsub_type,
     assert_invalid_comparison,
@@ -489,10 +494,10 @@ class TestTimedelta64ArithmeticUnsorted:
         # random indexes
         msg = "Addition/subtraction of integers and integer-arrays"
         with pytest.raises(TypeError, match=msg):
-            tdi + pd.Int64Index([1, 2, 3])
+            tdi + Int64Index([1, 2, 3])
 
         # this is a union!
-        # pytest.raises(TypeError, lambda : pd.Int64Index([1,2,3]) + tdi)
+        # pytest.raises(TypeError, lambda : Int64Index([1,2,3]) + tdi)
 
         result = tdi + dti  # name will be reset
         expected = DatetimeIndex(["20130102", NaT, "20130105"])
@@ -1570,9 +1575,9 @@ class TestTimedeltaArraylikeMulDivOps:
         "other",
         [
             np.arange(1, 11),
-            pd.Int64Index(range(1, 11)),
-            pd.UInt64Index(range(1, 11)),
-            pd.Float64Index(range(1, 11)),
+            Int64Index(range(1, 11)),
+            UInt64Index(range(1, 11)),
+            Float64Index(range(1, 11)),
             pd.RangeIndex(1, 11),
         ],
         ids=lambda x: type(x).__name__,
@@ -1642,7 +1647,7 @@ class TestTimedeltaArraylikeMulDivOps:
         xbox = np.ndarray if box is pd.array else box
 
         rng = timedelta_range("1 days", "10 days", name="foo")
-        expected = pd.Float64Index((np.arange(10) + 1) * 12, name="foo")
+        expected = Float64Index((np.arange(10) + 1) * 12, name="foo")
 
         rng = tm.box_expected(rng, box)
         expected = tm.box_expected(expected, xbox)
@@ -1685,7 +1690,7 @@ class TestTimedeltaArraylikeMulDivOps:
         xbox = np.ndarray if box is pd.array else box
 
         rng = TimedeltaIndex(["1 days", NaT, "2 days"], name="foo")
-        expected = pd.Float64Index([12, np.nan, 24], name="foo")
+        expected = Float64Index([12, np.nan, 24], name="foo")
 
         rng = tm.box_expected(rng, box)
         expected = tm.box_expected(expected, xbox)
@@ -1703,7 +1708,7 @@ class TestTimedeltaArraylikeMulDivOps:
         xbox = np.ndarray if box is pd.array else box
 
         rng = TimedeltaIndex(["1 days", NaT, "2 days"])
-        expected = pd.Float64Index([12, np.nan, 24])
+        expected = Float64Index([12, np.nan, 24])
 
         rng = tm.box_expected(rng, box)
         expected = tm.box_expected(expected, xbox)
@@ -1846,7 +1851,7 @@ class TestTimedeltaArraylikeMulDivOps:
         xbox = np.ndarray if box is pd.array else box
 
         tdi = timedelta_range("1 days", "10 days", name="foo")
-        expected = pd.Int64Index((np.arange(10) + 1) * 12, name="foo")
+        expected = Int64Index((np.arange(10) + 1) * 12, name="foo")
 
         tdi = tm.box_expected(tdi, box)
         expected = tm.box_expected(expected, xbox)

--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -34,6 +34,7 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
+from pandas.core.api import Int64Index
 
 
 class TestCategoricalConstructors:
@@ -71,7 +72,7 @@ class TestCategoricalConstructors:
         tm.assert_index_equal(c.categories, expected)
 
         c = Categorical([], categories=[1, 2, 3])
-        expected = pd.Int64Index([1, 2, 3])
+        expected = Int64Index([1, 2, 3])
         tm.assert_index_equal(c.categories, expected)
 
     def test_constructor_empty_boolean(self):

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -11,6 +11,7 @@ import pandas.util._test_decorators as td
 import pandas as pd
 from pandas import isna
 import pandas._testing as tm
+from pandas.core.api import Int64Index
 from pandas.core.arrays.sparse import (
     SparseArray,
     SparseDtype,
@@ -1309,7 +1310,7 @@ def test_dropna(fill_value):
     tm.assert_sp_array_equal(arr.dropna(), exp)
 
     df = pd.DataFrame({"a": [0, 1], "b": arr})
-    expected_df = pd.DataFrame({"a": [1], "b": exp}, index=pd.Int64Index([1]))
+    expected_df = pd.DataFrame({"a": [1], "b": exp}, index=Int64Index([1]))
     tm.assert_equal(df.dropna(), expected_df)
 
 

--- a/pandas/tests/dtypes/test_generic.py
+++ b/pandas/tests/dtypes/test_generic.py
@@ -7,6 +7,11 @@ from pandas.core.dtypes import generic as gt
 
 import pandas as pd
 import pandas._testing as tm
+from pandas.core.api import (
+    Float64Index,
+    Int64Index,
+    UInt64Index,
+)
 
 
 class TestABCClasses:
@@ -23,9 +28,9 @@ class TestABCClasses:
     timedelta_array = pd.core.arrays.TimedeltaArray(timedelta_index)
 
     abc_pairs = [
-        ("ABCInt64Index", pd.Int64Index([1, 2, 3])),
-        ("ABCUInt64Index", pd.UInt64Index([1, 2, 3])),
-        ("ABCFloat64Index", pd.Float64Index([1, 2, 3])),
+        ("ABCInt64Index", Int64Index([1, 2, 3])),
+        ("ABCUInt64Index", UInt64Index([1, 2, 3])),
+        ("ABCFloat64Index", Float64Index([1, 2, 3])),
         ("ABCMultiIndex", multi_index),
         ("ABCDatetimeIndex", datetime_index),
         ("ABCRangeIndex", pd.RangeIndex(3)),

--- a/pandas/tests/dtypes/test_missing.py
+++ b/pandas/tests/dtypes/test_missing.py
@@ -35,13 +35,13 @@ from pandas.core.dtypes.missing import (
 import pandas as pd
 from pandas import (
     DatetimeIndex,
-    Float64Index,
     NaT,
     Series,
     TimedeltaIndex,
     date_range,
 )
 import pandas._testing as tm
+from pandas.core.api import Float64Index
 
 now = pd.Timestamp.now()
 utcnow = pd.Timestamp.now("UTC")

--- a/pandas/tests/frame/constructors/test_from_records.py
+++ b/pandas/tests/frame/constructors/test_from_records.py
@@ -11,7 +11,6 @@ from pandas import (
     CategoricalIndex,
     DataFrame,
     Index,
-    Int64Index,
     Interval,
     RangeIndex,
     Series,
@@ -448,7 +447,7 @@ class TestFromRecords:
         a = np.array([(1, 2)], dtype=[("id", np.int64), ("value", np.int64)])
         df = DataFrame.from_records(a, index="id")
 
-        ex_index = Int64Index([1], name="id")
+        ex_index = Index([1], name="id")
         expected = DataFrame({"value": [2]}, index=ex_index, columns=["value"])
         tm.assert_frame_equal(df, expected)
 

--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -17,12 +17,12 @@ from pandas import (
     Series,
     Timedelta,
     Timestamp,
-    UInt64Index,
     concat,
     date_range,
     option_context,
 )
 import pandas._testing as tm
+from pandas.core.api import UInt64Index
 from pandas.core.arrays.integer import coerce_to_array
 
 

--- a/pandas/tests/frame/methods/test_truncate.py
+++ b/pandas/tests/frame/methods/test_truncate.py
@@ -4,10 +4,12 @@ import pytest
 import pandas as pd
 from pandas import (
     DataFrame,
+    DatetimeIndex,
     Series,
     date_range,
 )
 import pandas._testing as tm
+from pandas.core.api import Int64Index
 
 
 class TestDataFrameTruncate:
@@ -116,13 +118,13 @@ class TestDataFrameTruncate:
         "before, after, indices",
         [(1, 2, [2, 1]), (None, 2, [2, 1, 0]), (1, None, [3, 2, 1])],
     )
-    @pytest.mark.parametrize("klass", [pd.Int64Index, pd.DatetimeIndex])
+    @pytest.mark.parametrize("klass", [Int64Index, DatetimeIndex])
     def test_truncate_decreasing_index(
         self, before, after, indices, klass, frame_or_series
     ):
         # https://github.com/pandas-dev/pandas/issues/33756
         idx = klass([3, 2, 1, 0])
-        if klass is pd.DatetimeIndex:
+        if klass is DatetimeIndex:
             before = pd.Timestamp(before) if before is not None else None
             after = pd.Timestamp(after) if after is not None else None
             indices = [pd.Timestamp(i) for i in indices]

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -54,6 +54,7 @@ from pandas.arrays import (
     PeriodArray,
     SparseArray,
 )
+from pandas.core.api import Int64Index
 
 MIXED_FLOAT_DTYPES = ["float16", "float32", "float64"]
 MIXED_INT_DTYPES = [
@@ -581,7 +582,7 @@ class TestDataFrameConstructors:
         df = DataFrame([[1]], columns=[[1]], index=[1, 2])
         expected = DataFrame(
             [1, 1],
-            index=pd.Int64Index([1, 2], dtype="int64"),
+            index=Int64Index([1, 2], dtype="int64"),
             columns=MultiIndex(levels=[[1]], codes=[[0]]),
         )
         tm.assert_frame_equal(df, expected)

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -16,6 +16,7 @@ from pandas import (
     bdate_range,
 )
 import pandas._testing as tm
+from pandas.core.api import Int64Index
 
 
 def test_apply_issues():
@@ -785,10 +786,10 @@ def test_apply_with_mixed_types():
 
 def test_func_returns_object():
     # GH 28652
-    df = DataFrame({"a": [1, 2]}, index=pd.Int64Index([1, 2]))
+    df = DataFrame({"a": [1, 2]}, index=Int64Index([1, 2]))
     result = df.groupby("a").apply(lambda g: g.index)
     expected = Series(
-        [pd.Int64Index([1]), pd.Int64Index([2])], index=pd.Int64Index([1, 2], name="a")
+        [Int64Index([1]), Int64Index([2])], index=Int64Index([1, 2], name="a")
     )
 
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -14,6 +14,10 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
+from pandas.core.api import (
+    Float64Index,
+    Int64Index,
+)
 from pandas.core.groupby.grouper import Grouping
 
 # selection
@@ -634,11 +638,11 @@ class TestGrouping:
             ),
             (
                 "agg",
-                Series(name=2, dtype=np.float64, index=pd.Float64Index([], name=1)),
+                Series(name=2, dtype=np.float64, index=Float64Index([], name=1)),
             ),
             (
                 "apply",
-                Series(name=2, dtype=np.float64, index=pd.Float64Index([], name=1)),
+                Series(name=2, dtype=np.float64, index=Float64Index([], name=1)),
             ),
         ],
     )
@@ -702,7 +706,7 @@ class TestGrouping:
         empty = df[df.value < 0]
         result = empty.groupby("id").sum()
         expected = DataFrame(
-            dtype="float64", columns=["value"], index=pd.Int64Index([], name="id")
+            dtype="float64", columns=["value"], index=Int64Index([], name="id")
         )
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/groupby/test_min_max.py
+++ b/pandas/tests/groupby/test_min_max.py
@@ -10,6 +10,7 @@ from pandas import (
     Series,
 )
 import pandas._testing as tm
+from pandas.core.api import Int64Index
 
 
 def test_max_min_non_numeric():
@@ -120,7 +121,7 @@ def test_groupby_aggregate_period_column(func):
     df = DataFrame({"a": groups, "b": periods})
 
     result = getattr(df.groupby("a")["b"], func)()
-    idx = pd.Int64Index([1, 2], name="a")
+    idx = Int64Index([1, 2], name="a")
     expected = Series(periods, index=idx, name="b")
 
     tm.assert_series_equal(result, expected)
@@ -134,7 +135,7 @@ def test_groupby_aggregate_period_frame(func):
     df = DataFrame({"a": groups, "b": periods})
 
     result = getattr(df.groupby("a"), func)()
-    idx = pd.Int64Index([1, 2], name="a")
+    idx = Int64Index([1, 2], name="a")
     expected = DataFrame({"b": periods}, index=idx)
 
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/test_pipe.py
+++ b/pandas/tests/groupby/test_pipe.py
@@ -6,6 +6,7 @@ from pandas import (
     Index,
 )
 import pandas._testing as tm
+from pandas.core.api import Int64Index
 
 
 def test_pipe():
@@ -76,6 +77,6 @@ def test_pipe_args():
     ser = pd.Series([1, 1, 2, 2, 3, 3])
     result = ser.groupby(ser).pipe(lambda grp: grp.sum() * grp.count())
 
-    expected = pd.Series([4, 8, 12], index=pd.Int64Index([1, 2, 3]))
+    expected = pd.Series([4, 8, 12], index=Int64Index([1, 2, 3]))
 
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -21,9 +21,7 @@ import pandas as pd
 from pandas import (
     CategoricalIndex,
     DatetimeIndex,
-    Float64Index,
     Index,
-    Int64Index,
     IntervalIndex,
     MultiIndex,
     NumericIndex,
@@ -33,8 +31,12 @@ from pandas import (
     TimedeltaIndex,
     isna,
 )
-from pandas import UInt64Index  # noqa:F401
 import pandas._testing as tm
+from pandas.core.api import (  # noqa:F401
+    Float64Index,
+    Int64Index,
+    UInt64Index,
+)
 from pandas.core.indexes.datetimelike import DatetimeIndexOpsMixin
 
 

--- a/pandas/tests/indexes/datetimes/methods/test_astype.py
+++ b/pandas/tests/indexes/datetimes/methods/test_astype.py
@@ -9,13 +9,13 @@ import pandas as pd
 from pandas import (
     DatetimeIndex,
     Index,
-    Int64Index,
     NaT,
     PeriodIndex,
     Timestamp,
     date_range,
 )
 import pandas._testing as tm
+from pandas.core.api import Int64Index
 
 
 class TestDatetimeIndex:

--- a/pandas/tests/indexes/datetimes/methods/test_astype.py
+++ b/pandas/tests/indexes/datetimes/methods/test_astype.py
@@ -15,7 +15,10 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
+from pandas.core.api import (
+    Int64Index,
+    UInt64Index,
+)
 
 
 class TestDatetimeIndex:
@@ -46,7 +49,7 @@ class TestDatetimeIndex:
 
     def test_astype_uint(self):
         arr = date_range("2000", periods=2, name="idx")
-        expected = pd.UInt64Index(
+        expected = UInt64Index(
             np.array([946684800000000000, 946771200000000000], dtype="uint64"),
             name="idx",
         )

--- a/pandas/tests/indexes/datetimes/test_scalar_compat.py
+++ b/pandas/tests/indexes/datetimes/test_scalar_compat.py
@@ -19,6 +19,7 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
+from pandas.core.api import Float64Index
 
 
 class TestDatetimeIndexOps:
@@ -332,33 +333,33 @@ class TestDateTimeIndexToJulianDate:
         dr = date_range(start=Timestamp("1710-10-01"), periods=5, freq="D")
         r1 = pd.Index([x.to_julian_date() for x in dr])
         r2 = dr.to_julian_date()
-        assert isinstance(r2, pd.Float64Index)
+        assert isinstance(r2, Float64Index)
         tm.assert_index_equal(r1, r2)
 
     def test_2000(self):
         dr = date_range(start=Timestamp("2000-02-27"), periods=5, freq="D")
         r1 = pd.Index([x.to_julian_date() for x in dr])
         r2 = dr.to_julian_date()
-        assert isinstance(r2, pd.Float64Index)
+        assert isinstance(r2, Float64Index)
         tm.assert_index_equal(r1, r2)
 
     def test_hour(self):
         dr = date_range(start=Timestamp("2000-02-27"), periods=5, freq="H")
         r1 = pd.Index([x.to_julian_date() for x in dr])
         r2 = dr.to_julian_date()
-        assert isinstance(r2, pd.Float64Index)
+        assert isinstance(r2, Float64Index)
         tm.assert_index_equal(r1, r2)
 
     def test_minute(self):
         dr = date_range(start=Timestamp("2000-02-27"), periods=5, freq="T")
         r1 = pd.Index([x.to_julian_date() for x in dr])
         r2 = dr.to_julian_date()
-        assert isinstance(r2, pd.Float64Index)
+        assert isinstance(r2, Float64Index)
         tm.assert_index_equal(r1, r2)
 
     def test_second(self):
         dr = date_range(start=Timestamp("2000-02-27"), periods=5, freq="S")
         r1 = pd.Index([x.to_julian_date() for x in dr])
         r2 = dr.to_julian_date()
-        assert isinstance(r2, pd.Float64Index)
+        assert isinstance(r2, Float64Index)
         tm.assert_index_equal(r1, r2)

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -10,12 +10,12 @@ from pandas import (
     DataFrame,
     DatetimeIndex,
     Index,
-    Int64Index,
     Series,
     bdate_range,
     date_range,
 )
 import pandas._testing as tm
+from pandas.core.api import Int64Index
 
 from pandas.tseries.offsets import (
     BMonthEnd,

--- a/pandas/tests/indexes/interval/test_constructors.py
+++ b/pandas/tests/indexes/interval/test_constructors.py
@@ -9,9 +9,7 @@ from pandas.core.dtypes.dtypes import IntervalDtype
 from pandas import (
     Categorical,
     CategoricalIndex,
-    Float64Index,
     Index,
-    Int64Index,
     Interval,
     IntervalIndex,
     date_range,
@@ -20,6 +18,10 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
+from pandas.core.api import (
+    Float64Index,
+    Int64Index,
+)
 from pandas.core.arrays import IntervalArray
 import pandas.core.common as com
 

--- a/pandas/tests/indexes/interval/test_formats.py
+++ b/pandas/tests/indexes/interval/test_formats.py
@@ -3,7 +3,6 @@ import pytest
 
 from pandas import (
     DataFrame,
-    Float64Index,
     Interval,
     IntervalIndex,
     Series,
@@ -11,6 +10,7 @@ from pandas import (
     Timestamp,
 )
 import pandas._testing as tm
+from pandas.core.api import Float64Index
 
 
 class TestIntervalIndexRendering:

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -20,6 +20,7 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
+from pandas.core.api import Float64Index
 import pandas.core.common as com
 
 
@@ -406,7 +407,7 @@ class TestIntervalIndex:
         index = IntervalIndex.from_breaks(breaks)
 
         to_convert = breaks._constructor([pd.NaT] * 3)
-        expected = pd.Float64Index([np.nan] * 3)
+        expected = Float64Index([np.nan] * 3)
         result = index._maybe_convert_i8(to_convert)
         tm.assert_index_equal(result, expected)
 

--- a/pandas/tests/indexes/multi/test_analytics.py
+++ b/pandas/tests/indexes/multi/test_analytics.py
@@ -9,6 +9,7 @@ from pandas import (
     period_range,
 )
 import pandas._testing as tm
+from pandas.core.api import UInt64Index
 
 
 def test_shift(idx):
@@ -174,7 +175,7 @@ def test_map(idx):
     index = idx
 
     # we don't infer UInt64
-    if isinstance(index, pd.UInt64Index):
+    if isinstance(index, UInt64Index):
         expected = index.astype("int64")
     else:
         expected = index
@@ -198,7 +199,7 @@ def test_map_dictlike(idx, mapper):
     identity = mapper(idx.values, idx)
 
     # we don't infer to UInt64 for a dict
-    if isinstance(idx, pd.UInt64Index) and isinstance(identity, dict):
+    if isinstance(idx, UInt64Index) and isinstance(identity, dict):
         expected = idx.astype("int64")
     else:
         expected = idx

--- a/pandas/tests/indexes/multi/test_drop.py
+++ b/pandas/tests/indexes/multi/test_drop.py
@@ -189,5 +189,5 @@ def test_droplevel_multiindex_one_level():
     # GH#37208
     index = MultiIndex.from_tuples([(2,)], names=("b",))
     result = index.droplevel([])
-    expected = pd.Int64Index([2], name="b")
+    expected = Index([2], name="b")
     tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/multi/test_integrity.py
+++ b/pandas/tests/indexes/multi/test_integrity.py
@@ -12,6 +12,7 @@ from pandas import (
     RangeIndex,
 )
 import pandas._testing as tm
+from pandas.core.api import Int64Index
 
 
 def test_labels_dtypes():
@@ -83,8 +84,8 @@ def test_values_multiindex_periodindex():
     idx = MultiIndex.from_arrays([ints, pidx])
     result = idx.values
 
-    outer = pd.Int64Index([x[0] for x in result])
-    tm.assert_index_equal(outer, pd.Int64Index(ints))
+    outer = Int64Index([x[0] for x in result])
+    tm.assert_index_equal(outer, Int64Index(ints))
 
     inner = pd.PeriodIndex([x[1] for x in result])
     tm.assert_index_equal(inner, pidx)
@@ -92,8 +93,8 @@ def test_values_multiindex_periodindex():
     # n_lev > n_lab
     result = idx[:2].values
 
-    outer = pd.Int64Index([x[0] for x in result])
-    tm.assert_index_equal(outer, pd.Int64Index(ints[:2]))
+    outer = Int64Index([x[0] for x in result])
+    tm.assert_index_equal(outer, Int64Index(ints[:2]))
 
     inner = pd.PeriodIndex([x[1] for x in result])
     tm.assert_index_equal(inner, pidx[:2])
@@ -246,11 +247,11 @@ def test_rangeindex_fallback_coercion_bug():
     tm.assert_frame_equal(df, expected, check_like=True)
 
     result = df.index.get_level_values("fizz")
-    expected = pd.Int64Index(np.arange(10), name="fizz").repeat(10)
+    expected = Int64Index(np.arange(10), name="fizz").repeat(10)
     tm.assert_index_equal(result, expected)
 
     result = df.index.get_level_values("buzz")
-    expected = pd.Int64Index(np.tile(np.arange(10), 10), name="buzz")
+    expected = Int64Index(np.tile(np.arange(10), 10), name="buzz")
     tm.assert_index_equal(result, expected)
 
 

--- a/pandas/tests/indexes/multi/test_names.py
+++ b/pandas/tests/indexes/multi/test_names.py
@@ -148,7 +148,7 @@ def test_setting_names_from_levels_raises():
         new.index.name = "bar"
 
     assert pd.Index._no_setting_name is False
-    assert pd.Int64Index._no_setting_name is False
+    assert pd.NumericIndex._no_setting_name is False
     assert pd.RangeIndex._no_setting_name is False
 
 

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -23,7 +23,10 @@ from pandas import (
     period_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
+from pandas.core.api import (
+    Float64Index,
+    Int64Index,
+)
 
 dti4 = date_range("2016-01-01", periods=4)
 dti = dti4[:-1]
@@ -933,7 +936,7 @@ class TestAsOfLocs:
             pi.asof_locs(Int64Index(pi.asi8), mask)
 
         with pytest.raises(TypeError, match=msg):
-            pi.asof_locs(pd.Float64Index(pi.asi8), mask)
+            pi.asof_locs(Float64Index(pi.asi8), mask)
 
         with pytest.raises(TypeError, match=msg):
             # TimedeltaIndex

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -23,6 +23,7 @@ from pandas import (
     period_range,
 )
 import pandas._testing as tm
+from pandas.core.api import Int64Index
 
 dti4 = date_range("2016-01-01", periods=4)
 dti = dti4[:-1]
@@ -929,7 +930,7 @@ class TestAsOfLocs:
 
         msg = "must be DatetimeIndex or PeriodIndex"
         with pytest.raises(TypeError, match=msg):
-            pi.asof_locs(pd.Int64Index(pi.asi8), mask)
+            pi.asof_locs(Int64Index(pi.asi8), mask)
 
         with pytest.raises(TypeError, match=msg):
             pi.asof_locs(pd.Float64Index(pi.asi8), mask)

--- a/pandas/tests/indexes/ranges/test_indexing.py
+++ b/pandas/tests/indexes/ranges/test_indexing.py
@@ -1,9 +1,9 @@
 import numpy as np
 import pytest
 
-import pandas as pd
 from pandas import RangeIndex
 import pandas._testing as tm
+from pandas.core.api import Int64Index
 
 
 class TestGetIndexer:
@@ -55,7 +55,7 @@ class TestTake:
         # GH#12631
         idx = RangeIndex(1, 4, name="xxx")
         result = idx.take(np.array([1, 0, -1]))
-        expected = pd.Int64Index([2, 1, 3], name="xxx")
+        expected = Int64Index([2, 1, 3], name="xxx")
         tm.assert_index_equal(result, expected)
 
         # fill_value
@@ -65,7 +65,7 @@ class TestTake:
 
         # allow_fill=False
         result = idx.take(np.array([1, 0, -1]), allow_fill=False, fill_value=True)
-        expected = pd.Int64Index([2, 1, 3], name="xxx")
+        expected = Int64Index([2, 1, 3], name="xxx")
         tm.assert_index_equal(result, expected)
 
         msg = "Unable to fill values because RangeIndex cannot contain NA"

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -21,21 +21,23 @@ from pandas import (
     CategoricalIndex,
     DataFrame,
     DatetimeIndex,
-    Float64Index,
-    Int64Index,
     IntervalIndex,
     PeriodIndex,
     RangeIndex,
     Series,
     TimedeltaIndex,
     Timestamp,
-    UInt64Index,
     date_range,
     isna,
     period_range,
 )
 import pandas._testing as tm
 from pandas.api.types import is_float_dtype
+from pandas.core.api import (
+    Float64Index,
+    Int64Index,
+    UInt64Index,
+)
 from pandas.core.indexes.api import (
     Index,
     MultiIndex,

--- a/pandas/tests/indexes/test_index_new.py
+++ b/pandas/tests/indexes/test_index_new.py
@@ -14,7 +14,6 @@ from pandas import (
     CategoricalIndex,
     DatetimeIndex,
     Index,
-    Int64Index,
     IntervalIndex,
     MultiIndex,
     NaT,
@@ -22,12 +21,15 @@ from pandas import (
     Series,
     TimedeltaIndex,
     Timestamp,
-    UInt64Index,
     date_range,
     period_range,
     timedelta_range,
 )
 import pandas._testing as tm
+from pandas.core.api import (
+    Int64Index,
+    UInt64Index,
+)
 
 
 class TestIndexConstructorInference:

--- a/pandas/tests/indexes/test_indexing.py
+++ b/pandas/tests/indexes/test_indexing.py
@@ -21,9 +21,7 @@ from pandas.errors import InvalidIndexError
 
 from pandas import (
     DatetimeIndex,
-    Float64Index,
     Index,
-    Int64Index,
     IntervalIndex,
     MultiIndex,
     NaT,
@@ -31,9 +29,13 @@ from pandas import (
     RangeIndex,
     Series,
     TimedeltaIndex,
-    UInt64Index,
 )
 import pandas._testing as tm
+from pandas.core.api import (
+    Float64Index,
+    Int64Index,
+    UInt64Index,
+)
 
 
 class TestTake:

--- a/pandas/tests/indexes/test_numpy_compat.py
+++ b/pandas/tests/indexes/test_numpy_compat.py
@@ -3,13 +3,13 @@ import pytest
 
 from pandas import (
     DatetimeIndex,
-    Float64Index,
     Index,
     NumericIndex,
     PeriodIndex,
     TimedeltaIndex,
 )
 import pandas._testing as tm
+from pandas.core.api import Float64Index
 from pandas.core.indexes.datetimelike import DatetimeIndexOpsMixin
 
 

--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -13,20 +13,22 @@ from pandas.core.dtypes.cast import find_common_type
 from pandas import (
     CategoricalIndex,
     DatetimeIndex,
-    Float64Index,
     Index,
-    Int64Index,
     MultiIndex,
     Series,
     TimedeltaIndex,
     Timestamp,
-    UInt64Index,
 )
 import pandas._testing as tm
 from pandas.api.types import (
     is_datetime64tz_dtype,
     is_signed_integer_dtype,
     pandas_dtype,
+)
+from pandas.core.api import (
+    Float64Index,
+    Int64Index,
+    UInt64Index,
 )
 
 COMPATIBLE_INCONSISTENT_PAIRS = [

--- a/pandas/tests/indexes/timedeltas/methods/test_astype.py
+++ b/pandas/tests/indexes/timedeltas/methods/test_astype.py
@@ -5,15 +5,18 @@ import pytest
 
 import pandas as pd
 from pandas import (
-    Float64Index,
     Index,
-    Int64Index,
     NaT,
     Timedelta,
     TimedeltaIndex,
     timedelta_range,
 )
 import pandas._testing as tm
+from pandas.core.api import (
+    Float64Index,
+    Int64Index,
+    UInt64Index,
+)
 
 
 class TestTimedeltaIndex:
@@ -74,7 +77,7 @@ class TestTimedeltaIndex:
 
     def test_astype_uint(self):
         arr = timedelta_range("1H", periods=2)
-        expected = pd.UInt64Index(
+        expected = UInt64Index(
             np.array([3600000000000, 90000000000000], dtype="uint64")
         )
         with tm.assert_produces_warning(FutureWarning):

--- a/pandas/tests/indexes/timedeltas/test_setops.py
+++ b/pandas/tests/indexes/timedeltas/test_setops.py
@@ -3,11 +3,11 @@ import pytest
 
 import pandas as pd
 from pandas import (
-    Int64Index,
     TimedeltaIndex,
     timedelta_range,
 )
 import pandas._testing as tm
+from pandas.core.api import Int64Index
 
 from pandas.tseries.offsets import Hour
 

--- a/pandas/tests/indexing/common.py
+++ b/pandas/tests/indexing/common.py
@@ -5,13 +5,15 @@ import numpy as np
 
 from pandas import (
     DataFrame,
-    Float64Index,
     MultiIndex,
     Series,
-    UInt64Index,
     date_range,
 )
 import pandas._testing as tm
+from pandas.core.api import (
+    Float64Index,
+    UInt64Index,
+)
 
 
 def _mklbl(prefix, n):

--- a/pandas/tests/indexing/multiindex/test_partial.py
+++ b/pandas/tests/indexing/multiindex/test_partial.py
@@ -5,13 +5,15 @@ import pandas.util._test_decorators as td
 
 from pandas import (
     DataFrame,
-    Float64Index,
-    Int64Index,
     MultiIndex,
     date_range,
     to_datetime,
 )
 import pandas._testing as tm
+from pandas.core.api import (
+    Float64Index,
+    Int64Index,
+)
 
 
 class TestMultiIndexPartial:

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -13,6 +13,10 @@ from pandas.compat import (
 
 import pandas as pd
 import pandas._testing as tm
+from pandas.core.api import (
+    Float64Index,
+    Int64Index,
+)
 
 ###############################################################
 # Index / Series common tests which may trigger dtype coercions
@@ -405,7 +409,7 @@ class TestInsertIndexCoercion(CoercionBase):
         ],
     )
     def test_insert_index_int64(self, insert, coerced_val, coerced_dtype):
-        obj = pd.Int64Index([1, 2, 3, 4])
+        obj = Int64Index([1, 2, 3, 4])
         assert obj.dtype == np.int64
 
         exp = pd.Index([1, coerced_val, 2, 3, 4])
@@ -421,7 +425,7 @@ class TestInsertIndexCoercion(CoercionBase):
         ],
     )
     def test_insert_index_float64(self, insert, coerced_val, coerced_dtype):
-        obj = pd.Float64Index([1.0, 2.0, 3.0, 4.0])
+        obj = Float64Index([1.0, 2.0, 3.0, 4.0])
         assert obj.dtype == np.float64
 
         exp = pd.Index([1.0, coerced_val, 2.0, 3.0, 4.0])

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -3,13 +3,15 @@ import pytest
 
 from pandas import (
     DataFrame,
-    Float64Index,
     Index,
-    Int64Index,
     RangeIndex,
     Series,
 )
 import pandas._testing as tm
+from pandas.core.api import (
+    Float64Index,
+    Int64Index,
+)
 
 
 def gen_obj(klass, index):

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -25,6 +25,7 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
+from pandas.core.api import Float64Index
 from pandas.tests.indexing.common import _mklbl
 from pandas.tests.indexing.test_floats import gen_obj
 
@@ -143,7 +144,7 @@ class TestFancy:
         assert df.loc[np.inf, 0] == 3
 
         result = df.index
-        expected = pd.Float64Index([1, 2, np.inf])
+        expected = Float64Index([1, 2, np.inf])
         tm.assert_index_equal(result, expected)
 
     def test_setitem_dtype_upcast(self):

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -36,6 +36,7 @@ from pandas import (
 )
 import pandas._testing as tm
 from pandas.api.types import is_scalar
+from pandas.core.api import Float64Index
 from pandas.tests.indexing.common import Base
 
 
@@ -1838,7 +1839,7 @@ class TestLocSetitemWithExpansion:
         df.loc[0, np.inf] = 3
 
         result = df.columns
-        expected = pd.Float64Index([0, 1, np.inf])
+        expected = Float64Index([0, 1, np.inf])
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.filterwarnings("ignore:indexing past lexsort depth")

--- a/pandas/tests/io/pytables/test_put.py
+++ b/pandas/tests/io/pytables/test_put.py
@@ -15,13 +15,13 @@ from pandas import (
     DataFrame,
     HDFStore,
     Index,
-    Int64Index,
     MultiIndex,
     RangeIndex,
     Series,
     _testing as tm,
     concat,
 )
+from pandas.core.api import Int64Index
 from pandas.tests.io.pytables.common import (
     _maybe_remove,
     ensure_clean_path,

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -1955,7 +1955,7 @@ def test_chunked_categorical_partial(dirpath):
                 if i < 2:
                     idx = pd.Index(["a", "b"])
                 else:
-                    idx = pd.Float64Index([3.0])
+                    idx = pd.Index([3.0], dtype="float64")
                 tm.assert_index_equal(block.cats.cat.categories, idx)
     with tm.assert_produces_warning(CategoricalConversionWarning):
         with StataReader(dta_file, chunksize=5) as reader:

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -14,6 +14,7 @@ from pandas import (
     Timestamp,
 )
 import pandas._testing as tm
+from pandas.core.api import Int64Index
 from pandas.core.indexes.datetimes import date_range
 
 test_frame = DataFrame(
@@ -324,7 +325,7 @@ def test_consistency_with_window():
 
     # consistent return values with window
     df = test_frame
-    expected = pd.Int64Index([1, 2, 3], name="A")
+    expected = Int64Index([1, 2, 3], name="A")
     result = df.groupby("A").resample("2s").mean()
     assert result.index.nlevels == 2
     tm.assert_index_equal(result.index.levels[0], expected)

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -21,18 +21,20 @@ from pandas import (
     CategoricalIndex,
     DataFrame,
     DatetimeIndex,
-    Float64Index,
-    Int64Index,
     IntervalIndex,
     MultiIndex,
     PeriodIndex,
     RangeIndex,
     Series,
     TimedeltaIndex,
-    UInt64Index,
 )
 import pandas._testing as tm
 from pandas.api.types import CategoricalDtype as CDT
+from pandas.core.api import (
+    Float64Index,
+    Int64Index,
+    UInt64Index,
+)
 from pandas.core.reshape.concat import concat
 from pandas.core.reshape.merge import (
     MergeError,

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1856,7 +1856,7 @@ class TestPivotTable:
             observed=observed,
             aggfunc="sum",
         )
-        expected_columns = pd.Int64Index([2013, 2014], name="Year")
+        expected_columns = Index([2013, 2014], name="Year", dtype="int64")
         expected_index = pd.CategoricalIndex(
             months, categories=months, ordered=False, name="Month"
         )

--- a/pandas/tests/reshape/test_pivot_multilevel.py
+++ b/pandas/tests/reshape/test_pivot_multilevel.py
@@ -4,7 +4,6 @@ import pytest
 import pandas as pd
 from pandas import (
     Index,
-    Int64Index,
     MultiIndex,
 )
 import pandas._testing as tm
@@ -222,7 +221,7 @@ def test_pivot_multiindexed_rows_and_cols(using_array_manager):
         columns=MultiIndex.from_tuples(
             [(0, 1, 0), (0, 1, 1)], names=["col_L0", "col_L1", "idx_L1"]
         ),
-        index=Int64Index([0, 1], dtype="int64", name="idx_L0"),
+        index=Index([0, 1], dtype="int64", name="idx_L0"),
     )
     if not using_array_manager:
         # BlockManager does not preserve the dtypes

--- a/pandas/tests/series/indexing/test_get.py
+++ b/pandas/tests/series/indexing/test_get.py
@@ -4,6 +4,7 @@ import pytest
 import pandas as pd
 from pandas import Series
 import pandas._testing as tm
+from pandas.core.api import Float64Index
 
 
 def test_get():
@@ -64,7 +65,7 @@ def test_get():
                 54,
             ]
         ),
-        index=pd.Float64Index(
+        index=Float64Index(
             [
                 25.0,
                 36.0,
@@ -111,7 +112,7 @@ def test_get():
 
 def test_get_nan():
     # GH 8569
-    s = pd.Float64Index(range(10)).to_series()
+    s = Float64Index(range(10)).to_series()
     assert s.get(np.nan) is None
     assert s.get(np.nan, default="Missing") == "Missing"
 
@@ -120,7 +121,7 @@ def test_get_nan_multiple():
     # GH 8569
     # ensure that fixing "test_get_nan" above hasn't broken get
     # with multiple elements
-    s = pd.Float64Index(range(10)).to_series()
+    s = Float64Index(range(10)).to_series()
 
     idx = [2, 30]
     assert s.get(idx) is None

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -41,6 +41,7 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
+from pandas.core.api import Int64Index
 from pandas.core.arrays import (
     IntervalArray,
     period_array,
@@ -660,7 +661,7 @@ class TestSeriesConstructors:
             timedelta_range("1 day", periods=3),
             period_range("2012Q1", periods=3, freq="Q"),
             Index(list("abc")),
-            pd.Int64Index([1, 2, 3]),
+            Int64Index([1, 2, 3]),
             RangeIndex(0, 3),
         ],
         ids=lambda x: type(x).__name__,

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -153,7 +153,12 @@ def infer_freq(index, warn: bool = True) -> str | None:
     >>> pd.infer_freq(idx)
     'D'
     """
-    import pandas as pd
+    from pandas.core.api import (
+        DatetimeIndex,
+        Float64Index,
+        Index,
+        Int64Index,
+    )
 
     if isinstance(index, ABCSeries):
         values = index._values
@@ -182,15 +187,15 @@ def infer_freq(index, warn: bool = True) -> str | None:
         inferer = _TimedeltaFrequencyInferer(index, warn=warn)
         return inferer.get_freq()
 
-    if isinstance(index, pd.Index) and not isinstance(index, pd.DatetimeIndex):
-        if isinstance(index, (pd.Int64Index, pd.Float64Index)):
+    if isinstance(index, Index) and not isinstance(index, DatetimeIndex):
+        if isinstance(index, (Int64Index, Float64Index)):
             raise TypeError(
                 f"cannot infer freq from a non-convertible index type {type(index)}"
             )
         index = index._values
 
-    if not isinstance(index, pd.DatetimeIndex):
-        index = pd.DatetimeIndex(index)
+    if not isinstance(index, DatetimeIndex):
+        index = DatetimeIndex(index)
 
     inferer = _FrequencyInferer(index, warn=warn)
     return inferer.get_freq()


### PR DESCRIPTION
* [x] xref #42717
* [x] xref #41153 & #42706

Deprecates Int64Index, UInt64Index & Float64Index.

I don't think it will be sensible to emit a deprecation warning for these because they have a lot of internal usage as is, so I've just added texts explaining that these are deprecated and will be removed in Pandas 2.0.

EDIT: it does now emit an deprecation warning when accessed from the main namespace. See changes to `pandas.__init__.py` for implementation.

```python
>>> pd.Int64Index
FutureWarning: pandas.Int64Index is deprecated and will be removed from pandas in a future version. Use pandas.NumericIndex with the appropriate dtype instead.
```
