### PR TITLE
DOC: arguments options correction

### DIFF
--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -1685,7 +1685,7 @@ class Styler(StylerRenderer):
 
         Parameters
         ----------
-        axis : {0 or 'index', 1 or 'columns', None}, default 0
+        axis : {0 or 'index', 1 or 'columns'}, default 0
             Whether to make the index or column headers sticky.
         pixel_size : int, optional
             Required to configure the width of index cells or the height of column


### PR DESCRIPTION
oversight in recent method addition for 1.4.0 / 1.3.2. backport.

no release note necessary. Can also be backported to 1.3.2.
