### PR TITLE
REF: address the floating "_" in `styler.uuid`

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -349,7 +349,7 @@ ExtensionArray
 
 Styler
 ^^^^^^
--
+- Minor bug in :class:`.Styler` where the ``uuid`` at initialization maintained a floating underscore (:issue:`43037`)
 -
 
 Other

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -90,7 +90,7 @@ class StylerRenderer:
         if not isinstance(uuid_len, int) or not uuid_len >= 0:
             raise TypeError("``uuid_len`` must be an integer in range [0, 32].")
         self.uuid_len = min(32, uuid_len)
-        self.uuid = (uuid or uuid4().hex[: self.uuid_len]) + "_"
+        self.uuid = uuid or uuid4().hex[: self.uuid_len]
         self.table_styles = table_styles
         self.table_attributes = table_attributes
         self.caption = caption
@@ -1210,7 +1210,7 @@ class Tooltips:
         -------
         pseudo_css : List
         """
-        selector_id = "#T_" + uuid + "row" + str(row) + "_col" + str(col)
+        selector_id = "#T_" + uuid + "_row" + str(row) + "_col" + str(col)
         return [
             {
                 "selector": selector_id + f":hover .{name}",

--- a/pandas/io/formats/templates/html_style.tpl
+++ b/pandas/io/formats/templates/html_style.tpl
@@ -14,7 +14,7 @@
 {% block cellstyle %}
 {% for cs in [cellstyle, cellstyle_index, cellstyle_columns] %}
 {% for s in cs %}
-{% for selector in s.selectors %}{% if not loop.first %}, {% endif %}#T_{{uuid}}{{selector}}{% endfor %} {
+{% for selector in s.selectors %}{% if not loop.first %}, {% endif %}#T_{{uuid}}_{{selector}}{% endfor %} {
 {% for p,val in s.props %}
   {{p}}: {{val}};
 {% endfor %}

--- a/pandas/io/formats/templates/html_table.tpl
+++ b/pandas/io/formats/templates/html_table.tpl
@@ -27,7 +27,7 @@
 {% else %}
 {% for c in r %}
 {% if c.is_visible != False %}
-      <{{c.type}} {%- if c.id is defined %} id="T_{{uuid}}{{c.id}}" {%- endif %} class="{{c.class}}" {{c.attributes}}>{{c.value}}</{{c.type}}>
+      <{{c.type}} {%- if c.id is defined %} id="T_{{uuid}}_{{c.id}}" {%- endif %} class="{{c.class}}" {{c.attributes}}>{{c.value}}</{{c.type}}>
 {% endif %}
 {% endfor %}
 {% endif %}
@@ -49,7 +49,7 @@
 {% endif %}{% endfor %}
 {% else %}
 {% for c in r %}{% if c.is_visible != False %}
-      <{{c.type}} {%- if c.id is defined %} id="T_{{uuid}}{{c.id}}" {%- endif %} class="{{c.class}}" {{c.attributes}}>{{c.display_value}}</{{c.type}}>
+      <{{c.type}} {%- if c.id is defined %} id="T_{{uuid}}_{{c.id}}" {%- endif %} class="{{c.class}}" {{c.attributes}}>{{c.display_value}}</{{c.type}}>
 {% endif %}{% endfor %}
 {% endif %}
     </tr>

--- a/pandas/tests/io/formats/style/test_html.py
+++ b/pandas/tests/io/formats/style/test_html.py
@@ -99,7 +99,7 @@ def test_w3_html_format(styler):
         #T_ th {
           att2: v2;
         }
-        #T_row0_col0, #T_row1_col0 {
+        #T__row0_col0, #T__row1_col0 {
           att1: v1;
         }
         </style>
@@ -108,17 +108,17 @@ def test_w3_html_format(styler):
           <thead>
             <tr>
               <th class="blank level0" >&nbsp;</th>
-              <th id="T_level0_col0" class="col_heading level0 col0" >A</th>
+              <th id="T__level0_col0" class="col_heading level0 col0" >A</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <th id="T_level0_row0" class="row_heading level0 row0" >a</th>
-              <td id="T_row0_col0" class="data row0 col0 my-cls2" >2.6</td>
+              <th id="T__level0_row0" class="row_heading level0 row0" >a</th>
+              <td id="T__row0_col0" class="data row0 col0 my-cls2" >2.6</td>
             </tr>
             <tr>
-              <th id="T_level0_row1" class="row_heading level0 row1" >b</th>
-              <td id="T_row1_col0" class="data row1 col0" >2.7</td>
+              <th id="T__level0_row1" class="row_heading level0 row1" >b</th>
+              <td id="T__row1_col0" class="data row1 col0" >2.7</td>
             </tr>
           </tbody>
         </table>
@@ -142,7 +142,7 @@ def test_rowspan_w3():
 
 
 def test_styles(styler):
-    styler.set_uuid("abc_")
+    styler.set_uuid("abc")
     styler.set_table_styles([{"selector": "td", "props": "color: red;"}])
     result = styler.to_html(doctype_html=True)
     expected = dedent(
@@ -152,13 +152,13 @@ def test_styles(styler):
         <head>
         <meta charset="utf-8">
         <style type="text/css">
-        #T_abc_ td {
+        #T_abc td {
           color: red;
         }
         </style>
         </head>
         <body>
-        <table id="T_abc_">
+        <table id="T_abc">
           <thead>
             <tr>
               <th class="blank level0" >&nbsp;</th>
@@ -418,15 +418,15 @@ def test_applymap_header_cell_ids(styler, index, columns):
 
     # test index header ids where needed and css styles
     assert (
-        '<th id="T_level0_row0" class="row_heading level0 row0" >a</th>' in result
+        '<th id="T__level0_row0" class="row_heading level0 row0" >a</th>' in result
     ) is index
     assert (
-        '<th id="T_level0_row1" class="row_heading level0 row1" >b</th>' in result
+        '<th id="T__level0_row1" class="row_heading level0 row1" >b</th>' in result
     ) is index
-    assert ("#T_level0_row0, #T_level0_row1 {\n  attr: val;\n}" in result) is index
+    assert ("#T__level0_row0, #T__level0_row1 {\n  attr: val;\n}" in result) is index
 
     # test column header ids where needed and css styles
     assert (
-        '<th id="T_level0_col0" class="col_heading level0 col0" >A</th>' in result
+        '<th id="T__level0_col0" class="col_heading level0 col0" >A</th>' in result
     ) is columns
-    assert ("#T_level0_col0 {\n  attr: val;\n}" in result) is columns
+    assert ("#T__level0_col0 {\n  attr: val;\n}" in result) is columns

--- a/pandas/tests/io/formats/style/test_style.py
+++ b/pandas/tests/io/formats/style/test_style.py
@@ -1331,11 +1331,11 @@ class TestStyler:
         df = DataFrame(data=[[0, 1], [1, 2]], columns=["A", "B"])
         s = Styler(df, uuid_len=0)
         s = s.set_table_styles({"A": [{"selector": "", "props": [("color", "blue")]}]})
-        assert "#T__ .col0 {\n  color: blue;\n}" in s.render()
+        assert "#T_ .col0 {\n  color: blue;\n}" in s.render()
         s = s.set_table_styles(
             {0: [{"selector": "", "props": [("color", "blue")]}]}, axis=1
         )
-        assert "#T__ .row0 {\n  color: blue;\n}" in s.render()
+        assert "#T_ .row0 {\n  color: blue;\n}" in s.render()
 
     @pytest.mark.parametrize("len_", [1, 5, 32, 33, 100])
     def test_uuid_len(self, len_):
@@ -1345,9 +1345,9 @@ class TestStyler:
         strt = s.find('id="T_')
         end = s[strt + 6 :].find('"')
         if len_ > 32:
-            assert end == 32 + 1
+            assert end == 32
         else:
-            assert end == len_ + 1
+            assert end == len_
 
     @pytest.mark.parametrize("len_", [-2, "bad", None])
     def test_uuid_len_raises(self, len_):

--- a/pandas/tests/io/formats/style/test_tooltip.py
+++ b/pandas/tests/io/formats/style/test_tooltip.py
@@ -39,23 +39,23 @@ def test_tooltip_render(ttips, styler):
     result = styler.set_tooltips(ttips).render()
 
     # test tooltip table level class
-    assert "#T__ .pd-t {\n  visibility: hidden;\n" in result
+    assert "#T_ .pd-t {\n  visibility: hidden;\n" in result
 
     # test 'Min' tooltip added
-    assert "#T__ #T__row0_col0:hover .pd-t {\n  visibility: visible;\n}" in result
-    assert '#T__ #T__row0_col0 .pd-t::after {\n  content: "Min";\n}' in result
+    assert "#T_ #T__row0_col0:hover .pd-t {\n  visibility: visible;\n}" in result
+    assert '#T_ #T__row0_col0 .pd-t::after {\n  content: "Min";\n}' in result
     assert 'class="data row0 col0" >0<span class="pd-t"></span></td>' in result
 
     # test 'Max' tooltip added
-    assert "#T__ #T__row0_col2:hover .pd-t {\n  visibility: visible;\n}" in result
-    assert '#T__ #T__row0_col2 .pd-t::after {\n  content: "Max";\n}' in result
+    assert "#T_ #T__row0_col2:hover .pd-t {\n  visibility: visible;\n}" in result
+    assert '#T_ #T__row0_col2 .pd-t::after {\n  content: "Max";\n}' in result
     assert 'class="data row0 col2" >2<span class="pd-t"></span></td>' in result
 
     # test Nan, empty string and bad column ignored
-    assert "#T__ #T__row1_col0:hover .pd-t {\n  visibility: visible;\n}" not in result
-    assert "#T__ #T__row1_col1:hover .pd-t {\n  visibility: visible;\n}" not in result
-    assert "#T__ #T__row0_col1:hover .pd-t {\n  visibility: visible;\n}" not in result
-    assert "#T__ #T__row1_col2:hover .pd-t {\n  visibility: visible;\n}" not in result
+    assert "#T_ #T__row1_col0:hover .pd-t {\n  visibility: visible;\n}" not in result
+    assert "#T_ #T__row1_col1:hover .pd-t {\n  visibility: visible;\n}" not in result
+    assert "#T_ #T__row0_col1:hover .pd-t {\n  visibility: visible;\n}" not in result
+    assert "#T_ #T__row1_col2:hover .pd-t {\n  visibility: visible;\n}" not in result
     assert "Bad-Col" not in result
 
 
@@ -73,8 +73,8 @@ def test_tooltip_css_class(styler):
         css_class="other-class",
         props=[("color", "green")],
     ).render()
-    assert "#T__ .other-class {\n  color: green;\n" in result
-    assert '#T__ #T__row0_col0 .other-class::after {\n  content: "tooltip";\n' in result
+    assert "#T_ .other-class {\n  color: green;\n" in result
+    assert '#T_ #T__row0_col0 .other-class::after {\n  content: "tooltip";\n' in result
 
     # GH 39563
     result = styler.set_tooltips(  # set_tooltips overwrites previous
@@ -82,4 +82,4 @@ def test_tooltip_css_class(styler):
         css_class="another-class",
         props="color:green;color:red;",
     ).render()
-    assert "#T__ .another-class {\n  color: green;\n  color: red;\n}" in result
+    assert "#T_ .another-class {\n  color: green;\n  color: red;\n}" in result


### PR DESCRIPTION
addresses the issue whereby the set uuid at initialisation has a floating underscore:

```python
>>> styler = Styler(df, uuid="abc")
>>> print(styler.uuid)
abc_
```

Note: This is v minor but was discovered, and is useful to fix, due to an upcoming PR.
