### PR TITLE
DOC: Typo fix in "Extending Pandas"

### DIFF
--- a/doc/source/development/extending.rst
+++ b/doc/source/development/extending.rst
@@ -50,7 +50,7 @@ decorate a class, providing the name of attribute to add. The class's
 
 Now users can access your methods using the ``geo`` namespace:
 
-      >>> ds = pd.Dataframe(
+      >>> ds = pd.DataFrame(
       ...     {"longitude": np.linspace(0, 10), "latitude": np.linspace(0, 20)}
       ... )
       >>> ds.geo.center


### PR DESCRIPTION
Fixes typo in docs `Dataframe` -> `DataFrame`
