### PR TITLE
REGR: SeriesGrouper using Timestamp index

### DIFF
--- a/doc/source/whatsnew/v1.3.2.rst
+++ b/doc/source/whatsnew/v1.3.2.rst
@@ -26,7 +26,6 @@ Fixed regressions
 - Fixed regression in :func:`concat` where ``copy=False`` was not honored in ``axis=1`` Series concatenation (:issue:`42501`)
 - Regression in :meth:`Series.nlargest` and :meth:`Series.nsmallest` with nullable integer or float dtype (:issue:`42816`)
 - Fixed regression in :meth:`Series.quantile` with :class:`Int64Dtype` (:issue:`42626`)
-- Fixed regression in :meth:`.GroupBy.agg` with [???] (:issue:`42390`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.3.2.rst
+++ b/doc/source/whatsnew/v1.3.2.rst
@@ -26,6 +26,7 @@ Fixed regressions
 - Fixed regression in :func:`concat` where ``copy=False`` was not honored in ``axis=1`` Series concatenation (:issue:`42501`)
 - Regression in :meth:`Series.nlargest` and :meth:`Series.nsmallest` with nullable integer or float dtype (:issue:`42816`)
 - Fixed regression in :meth:`Series.quantile` with :class:`Int64Dtype` (:issue:`42626`)
+- Fixed regression in :meth:`.GroupBy.agg` with [???] (:issue:`42390`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.3.3.rst
+++ b/doc/source/whatsnew/v1.3.3.rst
@@ -15,7 +15,7 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Performance regression in :meth:`core.window.ewm.ExponentialMovingWindow.mean` (:issue:`42333`)
--
+- Fixed regression in :meth:`.GroupBy.agg` incorrectly raising in some cases (:issue:`42390`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -551,7 +551,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin):
     @property
     def _has_complex_internals(self) -> bool:
         # used to avoid libreduction code paths, which raise or require conversion
-        return False
+        return True
 
     def is_type_compatible(self, kind: str) -> bool:
         warnings.warn(

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -1259,3 +1259,18 @@ def test_groupby_index_object_dtype():
     )
     expected = Series([False, True], index=expected_index, name="p")
     tm.assert_series_equal(res, expected)
+
+
+def test_timeseries_groupby_agg():
+    # GH#43290
+
+    def func(ser):
+        if ser.isna().all():
+            return None
+        return np.sum(ser)
+
+    df = DataFrame([1.0], index=[pd.Timestamp("2018-01-16 00:00:00+00:00")])
+    res = df.groupby(lambda x: 1).agg(func)
+
+    expected = DataFrame([[1.0]], index=[1])
+    tm.assert_frame_equal(res, expected)


### PR DESCRIPTION
- [x] closes https://github.com/pandas-dev/pandas/issues/42390
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

Not sure what the defining characteristic of the failing cases is so there's a blank in the whatsnew note.