### PR TITLE
PERF: read_stata

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -222,6 +222,7 @@ Performance improvements
 - Performance improvement in :meth:`GroupBy.shift` when ``fill_value`` argument is provided (:issue:`26615`)
 - Performance improvement in :meth:`DataFrame.corr` for ``method=pearson`` on data without missing values (:issue:`40956`)
 - Performance improvement in some :meth:`GroupBy.apply` operations (:issue:`42992`)
+- Performance improvement in :func:`read_stata` (:issue:`43059`)
 -
 
 .. ---------------------------------------------------------------------------


### PR DESCRIPTION
```
from asv_bench.benchmarks.io.stata import *

self = StataMissing()
self.setup("tc")

%timeit self.time_read_stata("tc")
150 ms ± 3.3 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)  # <- master
114 ms ± 2.81 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)  # <- PR
```

cc @bashtage