### PR TITLE
BENCH: Add pyarrow to env

### DIFF
--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -46,17 +46,14 @@
         "numba": [],
         "numexpr": [],
         "pytables": [null, ""],  // platform dependent, see excludes below
+        "pyarrow": [],
         "tables": [null, ""],
         "openpyxl": [],
         "xlsxwriter": [],
         "xlrd": [],
         "xlwt": [],
         "odfpy": [],
-        "pytest": [],
         "jinja2": [],
-        // If using Windows with python 2.7 and want to build using the
-        // mingw toolchain (rather than MSVC), uncomment the following line.
-        // "libpython": [],
     },
     "conda_channels": ["defaults", "conda-forge"],
     // Combinations of libraries/python versions can be excluded/included


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

This came up while I was benchmarking the pyarrow csv reader that I am planning to PR soon, which was erroring with an ImportError for pyarrow. Anyone know if this is the right patch? (It works correctly for me afterwards, however I am curious as to how ArrowStringArray was getting benchmarked)

pytest also should be removable I think. (there really shouldn't be any reason why we are benchmarking that)
cc @simonjayhawkins @TomAugspurger 