### PR TITLE
DOC: `styler.format` does not, in fact, raise a KeyError

### DIFF
--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -681,7 +681,7 @@ class StylerRenderer:
         to. If the ``formatter`` argument is given in dict form but does not include
         all columns within the subset then these columns will have the default formatter
         applied. Any columns in the formatter dict excluded from the subset will
-        raise a ``KeyError``.
+        be ignored.
 
         When using a ``formatter`` string the dtypes must be compatible, otherwise a
         `ValueError` will be raised.


### PR DESCRIPTION
This was actually never true from the start #40134. It might have been true at one point during the PR and then was overwritten without docs being corrected before final merge.

I.e. these docs have always been wrong since introduction.

Should be back portable.

```python
df = DataFrame([[1.0, 2.0]], columns=["A", "B"])
df.style.format({"A": "{:.1f}", "B": "{:.2f}"}, subset = ["A"])  
# does not raise a KeyError for "B", just ignores.
```