### PR TITLE
REF: ensure to_arrays returns matched-length arrays/columns

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2323,6 +2323,8 @@ class DataFrame(NDFrame, OpsMixin):
 
         manager = get_option("mode.data_manager")
         columns = ensure_index(columns)
+        if len(columns) != len(arrays):
+            raise ValueError("len(columns) must match len(arrays)")
         mgr = arrays_to_mgr(
             arrays,
             columns,

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -433,7 +433,7 @@ def dict_to_mgr(
             arrays.loc[missing] = [val] * missing.sum()
 
         arrays = list(arrays)
-        data_names = columns
+        data_names = ensure_index(columns)
 
     else:
         keys = list(data.keys())

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -433,6 +433,7 @@ def dict_to_mgr(
             arrays.loc[missing] = [val] * missing.sum()
 
         arrays = list(arrays)
+        data_names = columns
 
     else:
         keys = list(data.keys())
@@ -738,6 +739,17 @@ def to_arrays(
 ) -> tuple[list[ArrayLike], Index]:
     """
     Return list of arrays, columns.
+
+    Returns
+    -------
+    list[ArrayLike]
+        These will become columns in a DataFrame.
+    Index
+        This will become frame.columns.
+
+    Notes
+    -----
+    Ensures that len(result_arrays) == len(result_index).
     """
     if isinstance(data, ABCDataFrame):
         # see test_from_records_with_index_data, test_from_records_bad_index_column
@@ -783,6 +795,11 @@ def to_arrays(
         )
         if columns is None:
             columns = ibase.default_index(len(data))
+        elif len(columns) > len(data):
+            raise ValueError("len(columns) > len(data)")
+        elif len(columns) < len(data):
+            # doing this here is akin to a pre-emptive reindex
+            data = data[: len(columns)]
         return data, columns
 
     elif isinstance(data, np.ndarray) and data.dtype.names is not None:


### PR DESCRIPTION
ATM we pass both 'columns' and `arr_names` to arrays_to_mgr and create_block_manager_from_arrays.  This is part of en effort to align these before calling arrays_to_mgr, which will let us improve the performance of _form_blocks.