### PR TITLE
BUG: Allow string keys with higher resolution than index in PeriodIndex.get_loc

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -289,6 +289,7 @@ Indexing
 - Bug in :meth:`Index.get_indexer_non_unique` when index contains multiple ``np.nan`` (:issue:`35392`)
 - Bug in :meth:`DataFrame.query` did not handle the degree sign in a backticked column name, such as \`Temp(°C)\`, used in an expression to query a dataframe (:issue:`42826`)
 - Bug in :meth:`DataFrame.drop` where the error message did not show missing labels with commas when raising ``KeyError`` (:issue:`42881`)
+- Bug in :meth:`PeriodIndex.get_loc` raised ``KeyError`` with string key corresponding to higher resolution than the index (:issue:`40145`)
 -
 
 Missing

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -427,15 +427,14 @@ class PeriodIndex(DatetimeIndexOpsMixin):
                     raise KeyError(key) from err
 
             if reso == self.dtype.resolution:
-                # the reso < self.dtype.resolution case goes through _get_string_slice
+                # the reso > self.dtype.resolution case goes through _partial_date_slice
                 key = Period(parsed, freq=self.freq)
                 loc = self.get_loc(key, method=method, tolerance=tolerance)
                 # Recursing instead of falling through matters for the exception
                 #  message in test_get_loc3 (though not clear if that really matters)
                 return loc
-            elif method is None:
-                raise KeyError(key)
-            else:
+            elif reso < self.dtype.resolution:
+                # GH 40145 Fall through
                 key = Period(parsed, freq=self.freq)
 
         elif isinstance(key, Period):


### PR DESCRIPTION
- [x] closes #40145
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
