### PR TITLE
TYP: Replace namedtuple with dataclass #40531

### DIFF
--- a/pandas/core/groupby/base.py
+++ b/pandas/core/groupby/base.py
@@ -5,9 +5,14 @@ SeriesGroupBy and the DataFrameGroupBy objects.
 """
 from __future__ import annotations
 
-import collections
+import dataclasses
+from typing import Hashable
 
-OutputKey = collections.namedtuple("OutputKey", ["label", "position"])
+
+@dataclasses.dataclass(order=True, frozen=True)
+class OutputKey:
+    label: Hashable
+    position: int
 
 # special case to prevent duplicate plots when catching exceptions when
 # forwarding methods from NDFrames

--- a/pandas/core/groupby/base.py
+++ b/pandas/core/groupby/base.py
@@ -14,6 +14,7 @@ class OutputKey:
     label: Hashable
     position: int
 
+
 # special case to prevent duplicate plots when catching exceptions when
 # forwarding methods from NDFrames
 plotting_methods = frozenset(["plot", "hist"])


### PR DESCRIPTION
This PR replaces namedtuple with dataclass in pandas/core/groupby/base.py and closes #40531.

The parameters `order` and `frozen` is set equal to True to make sure that that behaviour of OutputKey does not change. 

