### PR TITLE
REF: remove create_block_manager_from_arrays

### DIFF
--- a/pandas/core/internals/__init__.py
+++ b/pandas/core/internals/__init__.py
@@ -1,7 +1,4 @@
-from pandas.core.internals.api import (
-    create_block_manager_from_arrays,
-    make_block,
-)
+from pandas.core.internals.api import make_block
 from pandas.core.internals.array_manager import (
     ArrayManager,
     SingleArrayManager,
@@ -39,8 +36,7 @@ __all__ = [
     "SingleBlockManager",
     "SingleArrayManager",
     "concatenate_managers",
-    # those two are preserved here for downstream compatibility (GH-33892)
-    "create_block_manager_from_arrays",
+    # this is preserved here for downstream compatibility (GH-33892)
     "create_block_manager_from_blocks",
 ]
 

--- a/pandas/core/internals/api.py
+++ b/pandas/core/internals/api.py
@@ -8,16 +8,10 @@ authors
 """
 from __future__ import annotations
 
-from collections import defaultdict
-from typing import DefaultDict
-
 import numpy as np
 
 from pandas._libs.internals import BlockPlacement
-from pandas._typing import (
-    ArrayLike,
-    Dtype,
-)
+from pandas._typing import Dtype
 
 from pandas.core.dtypes.common import (
     is_datetime64tz_dtype,
@@ -26,24 +20,14 @@ from pandas.core.dtypes.common import (
 
 from pandas.core.arrays import DatetimeArray
 from pandas.core.construction import extract_array
-from pandas.core.indexes.api import Index
 from pandas.core.internals.blocks import (
     Block,
-    CategoricalBlock,
     DatetimeTZBlock,
-    ExtensionBlock,
     check_ndim,
     ensure_block_shape,
     extract_pandas_array,
     get_block_type,
     maybe_coerce_values,
-    new_block,
-)
-from pandas.core.internals.managers import (
-    BlockManager,
-    construction_error,
-    multi_blockify,
-    simple_blockify,
 )
 
 
@@ -102,110 +86,3 @@ def maybe_infer_ndim(values, placement: BlockPlacement, ndim: int | None) -> int
         else:
             ndim = values.ndim
     return ndim
-
-
-def create_block_manager_from_arrays(
-    arrays,
-    names: Index,
-    axes: list[Index],
-    consolidate: bool = True,
-) -> BlockManager:
-    # Assertions disabled for performance
-    # assert isinstance(names, Index)
-    # assert isinstance(axes, list)
-    # assert all(isinstance(x, Index) for x in axes)
-
-    arrays = [extract_array(x, extract_numpy=True) for x in arrays]
-
-    try:
-        blocks = _form_blocks(arrays, names, axes, consolidate)
-        mgr = BlockManager(blocks, axes)
-    except ValueError as e:
-        raise construction_error(len(arrays), arrays[0].shape, axes, e)
-    if consolidate:
-        mgr._consolidate_inplace()
-    return mgr
-
-
-def _form_blocks(
-    arrays: list[ArrayLike], names: Index, axes: list[Index], consolidate: bool
-) -> list[Block]:
-    # put "leftover" items in float bucket, where else?
-    # generalize?
-    items_dict: DefaultDict[str, list] = defaultdict(list)
-    extra_locs = []
-
-    names_idx = names
-    if names_idx.equals(axes[0]):
-        names_indexer = np.arange(len(names_idx))
-    else:
-        # Assertion disabled for performance
-        # assert names_idx.intersection(axes[0]).is_unique
-        names_indexer = names_idx.get_indexer_for(axes[0])
-
-    for i, name_idx in enumerate(names_indexer):
-        if name_idx == -1:
-            extra_locs.append(i)
-            continue
-
-        v = arrays[name_idx]
-
-        block_type = get_block_type(v)
-        items_dict[block_type.__name__].append((i, v))
-
-    blocks: list[Block] = []
-    if len(items_dict["NumericBlock"]):
-        numeric_blocks = multi_blockify(
-            items_dict["NumericBlock"], consolidate=consolidate
-        )
-        blocks.extend(numeric_blocks)
-
-    if len(items_dict["DatetimeLikeBlock"]):
-        dtlike_blocks = multi_blockify(
-            items_dict["DatetimeLikeBlock"], consolidate=consolidate
-        )
-        blocks.extend(dtlike_blocks)
-
-    if len(items_dict["DatetimeTZBlock"]):
-        dttz_blocks = [
-            DatetimeTZBlock(
-                ensure_block_shape(extract_array(array), 2),
-                placement=BlockPlacement(i),
-                ndim=2,
-            )
-            for i, array in items_dict["DatetimeTZBlock"]
-        ]
-        blocks.extend(dttz_blocks)
-
-    if len(items_dict["ObjectBlock"]) > 0:
-        object_blocks = simple_blockify(
-            items_dict["ObjectBlock"], np.object_, consolidate=consolidate
-        )
-        blocks.extend(object_blocks)
-
-    if len(items_dict["CategoricalBlock"]) > 0:
-        cat_blocks = [
-            CategoricalBlock(array, placement=BlockPlacement(i), ndim=2)
-            for i, array in items_dict["CategoricalBlock"]
-        ]
-        blocks.extend(cat_blocks)
-
-    if len(items_dict["ExtensionBlock"]):
-        external_blocks = [
-            ExtensionBlock(array, placement=BlockPlacement(i), ndim=2)
-            for i, array in items_dict["ExtensionBlock"]
-        ]
-
-        blocks.extend(external_blocks)
-
-    if len(extra_locs):
-        shape = (len(extra_locs),) + tuple(len(x) for x in axes[1:])
-
-        # empty items -> dtype object
-        block_values = np.empty(shape, dtype=object)
-        block_values.fill(np.nan)
-
-        na_block = new_block(block_values, placement=extra_locs, ndim=2)
-        blocks.append(na_block)
-
-    return blocks

--- a/pandas/tests/internals/test_api.py
+++ b/pandas/tests/internals/test_api.py
@@ -39,7 +39,6 @@ def test_namespace():
         "SingleBlockManager",
         "SingleArrayManager",
         "concatenate_managers",
-        "create_block_manager_from_arrays",
         "create_block_manager_from_blocks",
     ]
 


### PR DESCRIPTION
Looks like dask uses create_block_manager_from_blocks, but I haven't seen any evidence that any downstream package uses create_block_manager_from_arrays.