### PR TITLE
REF: use oldest-supported-numpy

### DIFF
--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -58,7 +58,16 @@ jobs:
     - name: Install pandas from sdist
       run: |
         conda list
-        python -m pip install dist/*.gz
+        python -m pip install dist/*.gz -v
+
+    - name: Force oldest supported NumPy
+      run: |
+        case "${{matrix.python-version}}" in
+        3.8)
+          pip install numpy==1.17.3 ;;
+        3.9)
+          pip install numpy==1.19.3 ;;
+        esac
 
     - name: Import pandas
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,17 +5,9 @@ requires = [
     "setuptools>=51.0.0",
     "wheel",
     "Cython>=0.29.21,<3",  # Note: sync with setup.py
-    # Numpy requirements for different OS/architectures
-    # Copied from https://github.com/scipy/scipy/blob/master/pyproject.toml (which is also licensed under BSD)
-    "numpy==1.17.3; python_version=='3.7' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64'",
-    "numpy==1.18.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64'",
-    "numpy==1.19.3; python_version>='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64'",
-    # Aarch64(Python 3.9 requirements are the same as AMD64)
-    "numpy==1.19.2; python_version=='3.7' and platform_machine=='aarch64'",
-    "numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64'",
-    # Darwin Arm64
-    "numpy>=1.20.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'",
-    "numpy>=1.20.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'"
+    # Numpy requirements for different OS/architectures, see
+    # https://github.com/scipy/oldest-supported-numpy/blob/master/setup.cfg
+    "oldest-supported-numpy>=0.10",
 ]
 # uncomment to enable pep517 after versioneer problem is fixed.
 # https://github.com/python-versioneer/python-versioneer/issues/193


### PR DESCRIPTION
This code is currently hand-copied from SciPy, now there's a package that exists to do just that. As a bonus, NumPy will no longer need to build wheels on 3.10 (Linux 64-bit only currently)

- [x] closes #40307
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

Two things to consider: first, for Python 3.7, this sets an older _build time_ requirement for NumPy than is there currently. According to the NumPy devs, this is fine, older build time requirements than the run requirement is okay. But we could use selectors and manually set NumPy for this one case, it's not something that changes.

Second, we could pin here, but given that this just pins old versions, I don't think it needs pinning. We could set a minimum, though, >=0.10 for example.