### PR TITLE
TST: groupby.first/last retains categorical dtype

### DIFF
--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1749,6 +1749,7 @@ def test_groupby_last_first_preserve_categoricaldtype(func):
     df = DataFrame({"a": [1, 2, 3]})
     df["b"] = df["a"].astype("category")
     result = getattr(df.groupby("a")["b"], func)()
-    expected = Series(Categorical([1, 2, 3]), name="b", index=[1, 2, 3])
-    expected.index.name = "a"
+    expected = Series(
+        Categorical([1, 2, 3]), name="b", index=Index([1, 2, 3], name="a")
+    )
     tm.assert_series_equal(expected, result)

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1741,3 +1741,15 @@ def test_groupby_categorical_indices_unused_categories():
     assert result.keys() == expected.keys()
     for key in result.keys():
         tm.assert_numpy_array_equal(result[key], expected[key])
+
+
+def test_groupby_last_first_preserve_categoricaldtype():
+    # GH#33090
+    df = DataFrame({"a": [1, 2, 3]})
+    df["b"] = df["a"].astype("category")
+    result = df.groupby("a")["b"].last()
+    expected = Series(Categorical([1, 2, 3]), name="b", index=[1, 2, 3])
+    expected.index.name = "a"
+    tm.assert_series_equal(expected, result)
+    result = df.groupby("a")["b"].first()
+    tm.assert_series_equal(expected, result)

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1743,13 +1743,12 @@ def test_groupby_categorical_indices_unused_categories():
         tm.assert_numpy_array_equal(result[key], expected[key])
 
 
-def test_groupby_last_first_preserve_categoricaldtype():
+@pytest.mark.parametrize("func", ["first", "last"])
+def test_groupby_last_first_preserve_categoricaldtype(func):
     # GH#33090
     df = DataFrame({"a": [1, 2, 3]})
     df["b"] = df["a"].astype("category")
-    result = df.groupby("a")["b"].last()
+    result = getattr(df.groupby("a")["b"], func)()
     expected = Series(Categorical([1, 2, 3]), name="b", index=[1, 2, 3])
     expected.index.name = "a"
-    tm.assert_series_equal(expected, result)
-    result = df.groupby("a")["b"].first()
     tm.assert_series_equal(expected, result)


### PR DESCRIPTION
- [x] closes #33090
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
