### PR TITLE
CI: use pipx and build to simplify and remove a workaround

### DIFF
--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -38,17 +38,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-
-        # GH 39416
-        pip install numpy
-
     - name: Build pandas sdist
       run: |
-        pip list
-        python setup.py sdist --formats=gztar
+        pipx run build --sdist
 
     - uses: conda-incubator/setup-miniconda@v2
       with:

--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -33,13 +33,9 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-
     - name: Build pandas sdist
       run: |
+        pipx run build --version
         pipx run build --sdist
 
     - uses: conda-incubator/setup-miniconda@v2


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry


This cleans up the SDist build slightly. First, it uses PyPA's "build" instead of directly calling `setup.py`, which will respect PEP 518 requirements and avoids the workaround of installing NumPy to be able to run setup.py. It also uses pipx to avoid needless setup; PyPA's pipx is provides as a first-class package manager on GitHub Actions (and Azure, they share images).
