### PR TITLE
Pin aiobotocore to get ci passing

### DIFF
--- a/ci/deps/actions-39.yaml
+++ b/ci/deps/actions-39.yaml
@@ -31,6 +31,7 @@ dependencies:
   - python-dateutil
   - pytz
   - s3fs>=0.4.2
+  - aiobotocore<=1.3.3
   - scipy
   - sqlalchemy
   - xlrd

--- a/ci/deps/azure-windows-38.yaml
+++ b/ci/deps/azure-windows-38.yaml
@@ -30,6 +30,7 @@ dependencies:
   - python-dateutil
   - pytz
   - s3fs>=0.4.0
+  - aiobotocore<=1.3.3
   - scipy
   - xlrd
   - xlsxwriter

--- a/ci/deps/azure-windows-39.yaml
+++ b/ci/deps/azure-windows-39.yaml
@@ -32,6 +32,7 @@ dependencies:
   - python-dateutil
   - pytz
   - s3fs>=0.4.2
+  - aiobotocore<=1.3.3
   - scipy
   - sqlalchemy
   - xlrd

--- a/environment.yml
+++ b/environment.yml
@@ -54,7 +54,7 @@ dependencies:
 
   # testing
   - boto3
-  - botocore>=1.11
+  - botocore>=1.11, <1.14.0
   - hypothesis>=5.5.3
   - moto  # mock S3
   - flask

--- a/environment.yml
+++ b/environment.yml
@@ -54,7 +54,7 @@ dependencies:
 
   # testing
   - boto3
-  - botocore>=1.11, <1.14.0
+  - botocore>=1.11
   - hypothesis>=5.5.3
   - moto  # mock S3
   - flask
@@ -105,6 +105,7 @@ dependencies:
 
   - pytables>=3.6.1  # pandas.read_hdf, DataFrame.to_hdf
   - s3fs>=0.4.0  # file IO when using 's3://...' path
+  - aiobotocore<1.4.0  # Remove when s3fs is at 2021.08.0
   - fsspec>=0.7.4, <2021.6.0  # for generic remote file operations
   - gcsfs>=0.6.0  # file IO when using 'gcs://...' path
   - sqlalchemy  # pandas.read_sql, DataFrame.to_sql

--- a/environment.yml
+++ b/environment.yml
@@ -105,7 +105,7 @@ dependencies:
 
   - pytables>=3.6.1  # pandas.read_hdf, DataFrame.to_hdf
   - s3fs>=0.4.0  # file IO when using 's3://...' path
-  - aiobotocore<1.4.0  # Remove when s3fs is at 2021.08.0
+  - aiobotocore<=1.3.3  # Remove when s3fs is at 2021.08.0
   - fsspec>=0.7.4, <2021.6.0  # for generic remote file operations
   - gcsfs>=0.6.0  # file IO when using 'gcs://...' path
   - sqlalchemy  # pandas.read_sql, DataFrame.to_sql

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,7 +32,7 @@ feedparser
 pyyaml
 requests
 boto3
-botocore>=1.11, <1.14.0
+botocore>=1.11
 hypothesis>=5.5.3
 moto
 flask
@@ -69,6 +69,7 @@ pyarrow>=0.17.0
 python-snappy
 tables>=3.6.1
 s3fs>=0.4.0
+aiobotocore<1.4.0
 fsspec>=0.7.4, <2021.6.0
 gcsfs>=0.6.0
 sqlalchemy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,7 +32,7 @@ feedparser
 pyyaml
 requests
 boto3
-botocore>=1.11
+botocore>=1.11, <1.14.0
 hypothesis>=5.5.3
 moto
 flask

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -69,7 +69,7 @@ pyarrow>=0.17.0
 python-snappy
 tables>=3.6.1
 s3fs>=0.4.0
-aiobotocore<1.4.0
+aiobotocore<=1.3.3
 fsspec>=0.7.4, <2021.6.0
 gcsfs>=0.6.0
 sqlalchemy


### PR DESCRIPTION
- [x] xref #43168

Aiobotocore got an upgrade from 1.3.3 to 1.4.0, looks like this broke our ci

This comes with s3fs. The new release handles the dependency, but is not on conda-forge yet