### PR TITLE
TST: Add testing to df.where() typecasting as per GH 42295

### DIFF
--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -777,7 +777,7 @@ def test_where_columns_casting():
     # GH 42295
 
     df = DataFrame({"a": [1.0, 2.0], "b": [3, np.nan]})
+    expected = df.copy()
     result = df.where(pd.notnull(df), None)
     # make sure dtypes don't change
-    expected = df.copy()
     tm.assert_frame_equal(expected, result)

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -776,8 +776,8 @@ def test_where_non_keyword_deprecation():
 def test_where_columns_casting():
     # GH 42295
 
-    d1 = DataFrame({"a": [1.0, 2.0], "b": [3, np.nan]})
-    result = d1.where(pd.notnull(d1), None)
+    df = DataFrame({"a": [1.0, 2.0], "b": [3, np.nan]})
+    result = df.where(pd.notnull(df), None)
     # make sure dtypes don't change
-    expected = d1
+    expected = df.copy()
     tm.assert_frame_equal(expected, result)

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -771,3 +771,12 @@ def test_where_non_keyword_deprecation():
         result = s.where(s > 1, 10, False)
     expected = DataFrame([10, 10, 2, 3, 4])
     tm.assert_frame_equal(expected, result)
+
+def test_where_columns_casting():
+    # GH 42295
+
+    d1 = DataFrame({"a": [1.0, 2.0], 'b': [3, np.nan]})
+    result = d1.where(pd.notnull(d1), None).dtypes
+    # make sure dtypes don't change
+    expected = d1.dtypes
+    tm.assert_series_equal(expected, result)

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -776,7 +776,7 @@ def test_where_non_keyword_deprecation():
 def test_where_columns_casting():
     # GH 42295
 
-    d1 = DataFrame({"a": [1.0, 2.0], 'b': [3, np.nan]})
+    d1 = DataFrame({"a": [1.0, 2.0], "b": [3, np.nan]})
     result = d1.where(pd.notnull(d1), None)
     # make sure dtypes don't change
     expected = d1

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -777,7 +777,7 @@ def test_where_columns_casting():
     # GH 42295
 
     d1 = DataFrame({"a": [1.0, 2.0], 'b': [3, np.nan]})
-    result = d1.where(pd.notnull(d1), None).dtypes
+    result = d1.where(pd.notnull(d1), None)
     # make sure dtypes don't change
-    expected = d1.dtypes
-    tm.assert_series_equal(expected, result)
+    expected = d1
+    tm.assert_frame_equal(expected, result)

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -772,6 +772,7 @@ def test_where_non_keyword_deprecation():
     expected = DataFrame([10, 10, 2, 3, 4])
     tm.assert_frame_equal(expected, result)
 
+
 def test_where_columns_casting():
     # GH 42295
 


### PR DESCRIPTION
- [x] closes #42295
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

This makes sure that df.where does not cast floats to integers.