### PR TITLE
BUG: read_csv with mixed bools and int sometimes reads 1 as a bool function.

### DIFF
--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -594,7 +594,8 @@ def test_nan_multi_index(all_parsers):
 def test_bool_and_nan_to_int(all_parsers):
     p = all_parsers
     test_data_val = """0 NaN True False"""
-    with pytest.raises(ValueError, match="convert"):        print(p.read_csv(StringIO(test_data_val), dtype = "int"))
+    with pytest.raises(ValueError, match = "convert"):
+        print(p.read_csv(StringIO(test_data_val), dtype = "int"))
 
 def test_bool_and_nan_to_float(all_parsers):
     p = all_parsers
@@ -606,6 +607,5 @@ def test_bool_and_nan_to_float(all_parsers):
 def test_bool_and_nan_to_bool(all_parsers):
     p = all_parsers
     test_data_val = """0 NaN True False """
-    with pytest.raises(ValueError, match="NA values"):        p.read_csv(StringIO(test_data_val), dtype = "bool")
-
-
+    with pytest.raises(ValueError, match = "NA values"):
+        p.read_csv(StringIO(test_data_val), dtype = "bool")

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -590,3 +590,22 @@ def test_nan_multi_index(all_parsers):
     )
 
     tm.assert_frame_equal(result, expected)
+
+def test_bool_and_nan_to_int(all_parsers):
+    p = all_parsers
+    test_data_val = """0 NaN True False"""
+    with pytest.raises(ValueError, match="convert"):        print(p.read_csv(StringIO(test_data_val), dtype = "int"))
+
+def test_bool_and_nan_to_float(all_parsers):
+    p = all_parsers
+    test_data_val = """0 NaN True False"""
+    result = p.read_csv(StringIO(test_data_val), dtype = "float")
+    expected = DataFrame.from_dict({"0": [np.nan, 1.0, 0.0]})
+    tm.assert_frame_equal(result, expected)
+
+def test_bool_and_nan_to_bool(all_parsers):
+    p = all_parsers
+    test_data_val = """0 NaN True False """
+    with pytest.raises(ValueError, match="NA values"):        p.read_csv(StringIO(test_data_val), dtype = "bool")
+
+


### PR DESCRIPTION
- [x] closes #42808
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

The major issue is that the parser is reading 1 as a boolean expression and not as an integer.

So, making 2 different tests based on the data type of the input or return of a function can help split the parsing as two seperate entities.

Reference: https://github.com/pandas-dev/pandas/pull/42944