### PR TITLE
TST: MultiIndex with complex

### DIFF
--- a/pandas/tests/indexing/multiindex/test_multiindex.py
+++ b/pandas/tests/indexing/multiindex/test_multiindex.py
@@ -101,21 +101,20 @@ class TestMultiIndexBasic:
 
     def test_multiindex_complex(self):
         # GH#42145
-        complex_data = [1 + 2j, 4 - 3j, 10 - 1j, 4 + 5j, 5 - 8j]
-        non_complex_data1 = [3, 4, 5, 6, 7]
-        non_complex_data2 = [0.1, 0.2, 0.3, 0.4, 0.5]
+        complex_data = [1 + 2j, 4 - 3j, 10 - 1j]
+        non_complex_data = [3, 4, 5]
         result = DataFrame(
             {
                 "x": complex_data,
-                "y": non_complex_data1,
-                "z": non_complex_data2,
+                "y": non_complex_data,
+                "z": non_complex_data,
             }
         )
         result.set_index(["x", "y"], inplace=True)
         expected = DataFrame(
-            {"z": non_complex_data2},
+            {"z": non_complex_data},
             index=MultiIndex.from_arrays(
-                [complex_data, non_complex_data1],
+                [complex_data, non_complex_data],
                 names=("x", "y"),
             ),
         )

--- a/pandas/tests/indexing/multiindex/test_multiindex.py
+++ b/pandas/tests/indexing/multiindex/test_multiindex.py
@@ -98,3 +98,25 @@ class TestMultiIndexBasic:
         result = df.loc[0].index
         tm.assert_index_equal(result, dti)
         assert result.freq == dti.freq
+
+    def test_multiindex_complex(self):
+        # GH#42145
+        complex_data = [1 + 2j, 4 - 3j, 10 - 1j, 4 + 5j, 5 - 8j]
+        non_complex_data1 = [3, 4, 5, 6, 7]
+        non_complex_data2 = [0.1, 0.2, 0.3, 0.4, 0.5]
+        result = DataFrame(
+            {
+                "x": complex_data,
+                "y": non_complex_data1,
+                "z": non_complex_data2,
+            }
+        )
+        result.set_index(["x", "y"], inplace=True)
+        expected = DataFrame(
+            {"z": non_complex_data2},
+            index=MultiIndex.from_arrays(
+                [complex_data, non_complex_data1],
+                names=("x", "y"),
+            ),
+        )
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #42145 
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

This has been resolved in the master. I think adding a test will close it.