### PR TITLE
TST: categorical reindex with added categories

### DIFF
--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -43,6 +43,7 @@ from pandas import (
     Series,
     Timedelta,
     Timestamp,
+    cut,
     date_range,
     isna,
 )
@@ -2352,6 +2353,32 @@ class TestDataFrameConstructors:
             columns=["f", "female", "m", "male", "unknown"],
         )
         tm.assert_frame_equal(result, expected)
+
+    def test_constructor_series_nonexact_categoricalindex(self):
+        # GH 42424
+        ser = Series(range(0, 100))
+        ser1 = cut(ser, 10).value_counts().head(5)
+        ser2 = cut(ser, 10).value_counts().tail(5)
+        result = DataFrame({"1": ser1, "2": ser2})
+        index = CategoricalIndex(
+            [
+                Interval(-0.099, 9.9, closed="right"),
+                Interval(9.9, 19.8, closed="right"),
+                Interval(19.8, 29.7, closed="right"),
+                Interval(29.7, 39.6, closed="right"),
+                Interval(39.6, 49.5, closed="right"),
+                Interval(49.5, 59.4, closed="right"),
+                Interval(59.4, 69.3, closed="right"),
+                Interval(69.3, 79.2, closed="right"),
+                Interval(79.2, 89.1, closed="right"),
+                Interval(89.1, 99, closed="right"),
+            ],
+            ordered=True,
+        )
+        expected = DataFrame(
+            {"1": [10] * 5 + [np.nan] * 5, "2": [np.nan] * 5 + [10] * 5}, index=index
+        )
+        tm.assert_frame_equal(expected, result)
 
     def test_from_M8_structured(self):
         dates = [(datetime(2012, 9, 9, 0, 0), datetime(2012, 9, 8, 15, 10))]

--- a/pandas/tests/indexes/categorical/test_reindex.py
+++ b/pandas/tests/indexes/categorical/test_reindex.py
@@ -6,6 +6,7 @@ from pandas import (
     CategoricalIndex,
     DataFrame,
     Index,
+    Interval,
     Series,
 )
 import pandas._testing as tm
@@ -103,3 +104,24 @@ class TestReindex:
         result = df.reindex(index=index_res)
         expected = DataFrame(index=index_exp)
         tm.assert_frame_equal(result, expected)
+
+    def test_reindex_categorical_added_category(self):
+        ci = CategoricalIndex(
+            [Interval(0, 1, closed="right"), Interval(1, 2, closed="right")],
+            ordered=True,
+        )
+
+        ci_add = CategoricalIndex(
+            [
+                Interval(0, 1, closed="right"),
+                Interval(1, 2, closed="right"),
+                Interval(2, 3, closed="right"),
+                Interval(3, 4, closed="right"),
+            ],
+            ordered=True,
+        )
+
+        result, _ = ci.reindex(ci_add)
+        expected = ci_add
+
+        tm.assert_index_equal(expected, result)

--- a/pandas/tests/indexes/categorical/test_reindex.py
+++ b/pandas/tests/indexes/categorical/test_reindex.py
@@ -110,7 +110,6 @@ class TestReindex:
             [Interval(0, 1, closed="right"), Interval(1, 2, closed="right")],
             ordered=True,
         )
-
         ci_add = CategoricalIndex(
             [
                 Interval(0, 1, closed="right"),
@@ -120,8 +119,6 @@ class TestReindex:
             ],
             ordered=True,
         )
-
         result, _ = ci.reindex(ci_add)
         expected = ci_add
-
         tm.assert_index_equal(expected, result)

--- a/pandas/tests/indexes/categorical/test_reindex.py
+++ b/pandas/tests/indexes/categorical/test_reindex.py
@@ -106,6 +106,7 @@ class TestReindex:
         tm.assert_frame_equal(result, expected)
 
     def test_reindex_categorical_added_category(self):
+        # GH 42424
         ci = CategoricalIndex(
             [Interval(0, 1, closed="right"), Interval(1, 2, closed="right")],
             ordered=True,


### PR DESCRIPTION
- [x] closes #42424 
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

The bug is specifically in the Interval index. The error arises in the example code from the issue while reindexing the categorical index with another categorical index(with new categories). 

The test (test_cut_with_nonexact_categorical_indices)  from PR [42425](https://github.com/pandas-dev/pandas/pull/42425) implicitly works in a similar way.
 
