### PR TITLE
TST: unhoused test_offsets fn to custom business hour (#27045)

### DIFF
--- a/pandas/tests/tseries/offsets/test_custom_business_hour.py
+++ b/pandas/tests/tseries/offsets/test_custom_business_hour.py
@@ -308,3 +308,21 @@ class TestCustomBusinessHour(Base):
         result = t0 + bhour_us * 8
         expected = Timestamp("2014-01-21 15:00:00")
         assert result == expected
+
+
+@pytest.mark.parametrize(
+    "weekmask, expected_time, mult",
+    [
+        ["Mon Tue Wed Thu Fri Sat", "2018-11-10 09:00:00", 10],
+        ["Tue Wed Thu Fri Sat", "2018-11-13 08:00:00", 18],
+    ],
+)
+def test_custom_businesshour_weekmask_and_holidays(weekmask, expected_time, mult):
+    # GH 23542
+    holidays = ["2018-11-09"]
+    bh = CustomBusinessHour(
+        start="08:00", end="17:00", weekmask=weekmask, holidays=holidays
+    )
+    result = Timestamp("2018-11-08 08:00") + mult * bh
+    expected = Timestamp(expected_time)
+    assert result == expected

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -795,21 +795,3 @@ def test_dateoffset_immutable(attribute):
     msg = "DateOffset objects are immutable"
     with pytest.raises(AttributeError, match=msg):
         setattr(offset, attribute, 5)
-
-
-@pytest.mark.parametrize(
-    "weekmask, expected_time, mult",
-    [
-        ["Mon Tue Wed Thu Fri Sat", "2018-11-10 09:00:00", 10],
-        ["Tue Wed Thu Fri Sat", "2018-11-13 08:00:00", 18],
-    ],
-)
-def test_custom_businesshour_weekmask_and_holidays(weekmask, expected_time, mult):
-    # GH 23542
-    holidays = ["2018-11-09"]
-    bh = CustomBusinessHour(
-        start="08:00", end="17:00", weekmask=weekmask, holidays=holidays
-    )
-    result = Timestamp("2018-11-08 08:00") + mult * bh
-    expected = Timestamp(expected_time)
-    assert result == expected


### PR DESCRIPTION
- [ ] xref #27085 (chips away at, yes)
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

* https://github.com/pandas-dev/pandas/pull/42284 
* https://github.com/pandas-dev/pandas/pull/42896 
* https://github.com/pandas-dev/pandas/pull/42909
* https://github.com/pandas-dev/pandas/pull/42930
* https://github.com/pandas-dev/pandas/pull/42932
* https://github.com/pandas-dev/pandas/pull/42952
* https://github.com/pandas-dev/pandas/pull/42989
* https://github.com/pandas-dev/pandas/pull/42990
* https://github.com/pandas-dev/pandas/pull/42991