### PR TITLE
EA: fillna should accept same type #32414

### DIFF
--- a/pandas/tests/series/methods/test_fillna.py
+++ b/pandas/tests/series/methods/test_fillna.py
@@ -7,6 +7,7 @@ from datetime import (
 import numpy as np
 import pytest
 import pytz
+from typing_extensions import Literal
 
 from pandas import (
     Categorical,
@@ -679,17 +680,17 @@ class TestSeriesFillNA:
         ],
     )
 
-    def test_series_fill(fill_value, expected_output):
+    def test_fillna_categorical(self, fill_value, expected_output):
         # GH32414
         data = ["A", "B", np.nan, np.nan, "C"]
         cat = Categorical(data, categories=["A", "B", "C"])
         ser = Series(cat)
-        exp = Categorical(expected_output, categories=["A", "B", "C"])
-        exp_ser = Series(exp)
-        result = ser.fillna(fill_value)
+        exp_cat = Categorical(expected_output, categories=["A", "B", "C"])
+        exp_ser = Series(exp_cat)
+        result_ser = ser.fillna(fill_value)
         filled = cat.fillna(fill_value)
-        tm.assert_almost_equal(result, exp_ser)
-        tm.assert_almost_equal(filled, exp)
+        tm.assert_almost_equal(result_ser, exp_ser)
+        tm.assert_almost_equal(filled, exp_cat)
 
 
     def test_fillna_categorical_raises(self):

--- a/pandas/tests/series/methods/test_fillna.py
+++ b/pandas/tests/series/methods/test_fillna.py
@@ -671,6 +671,27 @@ class TestSeriesFillNA:
         result = ser.fillna(fill_value)
         tm.assert_series_equal(result, exp)
 
+    @pytest.mark.parametrize(
+        "fill_value, expected_output",
+        [
+            ("B", ["A", "B", "B", "B", "C"]),
+            ("C", ["A", "B", "C", "C", "C"])
+        ],
+    )
+
+    def test_series_fill(self, fill_value, expected_output):
+        data = ["A", "B", np.nan, np.nan, "C"]
+        ser = Series(Categorical(data, categories=["A", "B"]))
+
+        msg = "Element not present in categories. Cannot be filled in series."
+        with pytest.raises(TypeError, match=msg):
+            ser.fillna("D")
+
+        exp = Series(Categorical(expected_output, categories=["A", "B"]))
+        result = ser.fillna(fill_value)
+        tm.assert_series_equal(result, exp)
+
+
     def test_fillna_categorical_raises(self):
         data = ["a", np.nan, "b", np.nan, np.nan]
         ser = Series(Categorical(data, categories=["a", "b"]))

--- a/pandas/tests/series/methods/test_fillna.py
+++ b/pandas/tests/series/methods/test_fillna.py
@@ -680,6 +680,7 @@ class TestSeriesFillNA:
     )
 
     def test_series_fill(self, fill_value, expected_output):
+        # GH#32414
         data = ["A", "B", np.nan, np.nan, "C"]
         ser = Series(Categorical(data, categories=["A", "B"]))
 

--- a/pandas/tests/series/methods/test_fillna.py
+++ b/pandas/tests/series/methods/test_fillna.py
@@ -679,18 +679,13 @@ class TestSeriesFillNA:
         ],
     )
 
-    def test_series_fill(fill_value, expected_output):
+    def test_series_fill(self, fill_value, expected_output):
         # GH#32414
         data = ["A", "B", np.nan, np.nan, "C"]
-        ser = Series(Categorical(data, categories=["A", "B", "C"]))
-
-        # msg = "Element not present in categories. Cannot be filled in series."
-        # with pytest.raises(TypeError, match=msg):
-        #     ser.fillna("D")
-
-        exp = Series(Categorical(expected_output, categories=["A", "B", "C"]))
-        result = ser.fillna(fill_value)
-        tm.assert_almost_equal(result, exp)
+        series = Series(Categorical(data, categories=["A", "B", "C"]))
+        expected = Series(Categorical(expected_output, categories=["A", "B", "C"]))
+        result = series.fillna(fill_value)
+        tm.assert_almost_equal(result, expected)
 
 
     def test_fillna_categorical_raises(self):

--- a/pandas/tests/series/methods/test_fillna.py
+++ b/pandas/tests/series/methods/test_fillna.py
@@ -679,13 +679,17 @@ class TestSeriesFillNA:
         ],
     )
 
-    def test_series_fill(self, fill_value, expected_output):
-        # GH#32414
+    def test_series_fill(fill_value, expected_output):
+        # GH32414
         data = ["A", "B", np.nan, np.nan, "C"]
-        series = Series(Categorical(data, categories=["A", "B", "C"]))
-        expected = Series(Categorical(expected_output, categories=["A", "B", "C"]))
-        result = series.fillna(fill_value)
-        tm.assert_almost_equal(result, expected)
+        cat = Categorical(data, categories=["A", "B", "C"])
+        ser = Series(cat)
+        exp = Categorical(expected_output, categories=["A", "B", "C"])
+        exp_ser = Series(exp)
+        result = ser.fillna(fill_value)
+        filled = cat.fillna(fill_value)
+        tm.assert_almost_equal(result, exp_ser)
+        tm.assert_almost_equal(filled, exp)
 
 
     def test_fillna_categorical_raises(self):

--- a/pandas/tests/series/methods/test_fillna.py
+++ b/pandas/tests/series/methods/test_fillna.py
@@ -679,18 +679,18 @@ class TestSeriesFillNA:
         ],
     )
 
-    def test_series_fill(self, fill_value, expected_output):
+    def test_series_fill(fill_value, expected_output):
         # GH#32414
         data = ["A", "B", np.nan, np.nan, "C"]
-        ser = Series(Categorical(data, categories=["A", "B"]))
+        ser = Series(Categorical(data, categories=["A", "B", "C"]))
 
-        msg = "Element not present in categories. Cannot be filled in series."
-        with pytest.raises(TypeError, match=msg):
-            ser.fillna("D")
+        # msg = "Element not present in categories. Cannot be filled in series."
+        # with pytest.raises(TypeError, match=msg):
+        #     ser.fillna("D")
 
-        exp = Series(Categorical(expected_output, categories=["A", "B"]))
+        exp = Series(Categorical(expected_output, categories=["A", "B", "C"]))
         result = ser.fillna(fill_value)
-        tm.assert_series_equal(result, exp)
+        tm.assert_almost_equal(result, exp)
 
 
     def test_fillna_categorical_raises(self):


### PR DESCRIPTION
A unit test has been added to check the validity of pd.Categorical() . This PR is with respect to the GitHub issue no. 32414.
Thanks

- [x] closes #32414