### PR TITLE
ENH: Add Storage Options kwarg to read_table

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -92,7 +92,7 @@ Other enhancements
 - :meth:`Series.sample`, :meth:`DataFrame.sample`, and :meth:`.GroupBy.sample` now accept a ``np.random.Generator`` as input to ``random_state``. A generator will be more performant, especially with ``replace=False`` (:issue:`38100`)
 - :meth:`Series.ewm`, :meth:`DataFrame.ewm`, now support a ``method`` argument with a ``'table'`` option that performs the windowing operation over an entire :class:`DataFrame`. See :ref:`Window Overview <window.overview>` for performance and functional benefits (:issue:`42273`)
 - :meth:`.GroupBy.cummin` and :meth:`.GroupBy.cummax` now support the argument ``skipna`` (:issue:`34047`)
--
+- :meth:`read_table` now supports the argument ``storage_options`` (:issue:`39167`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -646,6 +646,7 @@ def read_table(
     escapechar=None,
     comment=None,
     encoding=None,
+    encoding_errors: str | None = "strict",
     dialect=None,
     # Error Handling
     error_bad_lines=None,
@@ -653,7 +654,6 @@ def read_table(
     # TODO (2.0): set on_bad_lines to "error".
     # See _refine_defaults_read comment for why we do this.
     on_bad_lines=None,
-    encoding_errors: str | None = "strict",
     # Internal
     delim_whitespace=False,
     low_memory=_c_parser_defaults["low_memory"],

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -659,6 +659,7 @@ def read_table(
     low_memory=_c_parser_defaults["low_memory"],
     memory_map=False,
     float_precision=None,
+    storage_options: StorageOptions = None,
 ):
     # locals() should never be modified
     kwds = locals().copy()

--- a/pandas/tests/io/test_fsspec.py
+++ b/pandas/tests/io/test_fsspec.py
@@ -13,6 +13,7 @@ from pandas import (
     read_parquet,
     read_pickle,
     read_stata,
+    read_table,
 )
 import pandas._testing as tm
 from pandas.util import _test_decorators as td
@@ -119,6 +120,16 @@ def test_csv_options(fsspectest):
     )
     assert fsspectest.test[0] == "csv_write"
     read_csv("testmem://test/test.csv", storage_options={"test": "csv_read"})
+    assert fsspectest.test[0] == "csv_read"
+
+
+def test_read_table_options(fsspectest):
+    df = DataFrame({"a": [0]})
+    df.to_csv(
+        "testmem://test/test.csv", storage_options={"test": "csv_write"}, index=False
+    )
+    assert fsspectest.test[0] == "csv_write"
+    read_table("testmem://test/test.csv", storage_options={"test": "csv_read"})
     assert fsspectest.test[0] == "csv_read"
 
 

--- a/pandas/tests/io/test_fsspec.py
+++ b/pandas/tests/io/test_fsspec.py
@@ -124,6 +124,7 @@ def test_csv_options(fsspectest):
 
 
 def test_read_table_options(fsspectest):
+    # GH #39167
     df = DataFrame({"a": [0]})
     df.to_csv(
         "testmem://test/test.csv", storage_options={"test": "csv_write"}, index=False


### PR DESCRIPTION
- [x] closes #39167
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

Follow up from https://github.com/pandas-dev/pandas/pull/35381 - looks like this was missed

Not sure if this is an enhancements or a bug given the docs already mention this arg is supported.
https://pandas.pydata.org/docs/reference/api/pandas.read_table.html