### PR TITLE
TST: Add test for col names during groupby().agg()

### DIFF
--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -1274,3 +1274,35 @@ def test_timeseries_groupby_agg():
 
     expected = DataFrame([[1.0]], index=[1])
     tm.assert_frame_equal(res, expected)
+
+
+def test_groupby_agg_column_names():
+    # GH42332
+
+    df = DataFrame(columns=["id1", "id2", "time", "values"], dtype="int").groupby(
+        ["id1", "id2"]
+    )
+
+    df_sum_idx = df.sum().index.names
+
+    df_agg1_idx = df.agg(
+        **{"start": pd.NamedAgg(column="time", aggfunc="min")}
+    ).index.names
+
+    df_agg2_idx = df.agg(
+        **{
+            "start": pd.NamedAgg(column="time", aggfunc="min"),
+            "peak_time": pd.NamedAgg(column="values", aggfunc="idxmax"),
+        }
+    ).index.names
+
+    df_agg3_idx = df.agg(
+        **{"peak_time": pd.NamedAgg(column="values", aggfunc="idxmax")}
+    ).index.names
+
+    expected = ["id1", "id2"]
+
+    assert df_sum_idx == expected
+    assert df_agg1_idx == expected
+    assert df_agg2_idx == expected
+    assert df_agg3_idx == expected


### PR DESCRIPTION
Column names should consistently be retained when using df.groupby().agg()

- [x] closes #42332
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry

Whats new:
Add a test to `pandas/tests/groupby/aggregate/test_aggregate.py`

The issue appears to be fixed now:

Tested on 1.4.0.dev0+508.g5fe02971f8

![Screenshot from 2021-08-27 00-06-24](https://user-images.githubusercontent.com/18680207/131070259-ac3d10f2-353c-4872-ba65-2a35abf37b51.png)

Output of `pd.show_versions()`

INSTALLED VERSIONS
------------------
commit           : 5fe02971f8bc40a6bbb742f1f376b3650c3c8eaa
python           : 3.9.5.final.0
python-bits      : 64
OS               : Linux
OS-release       : 5.11.0-31-generic
Version          : #33-Ubuntu SMP Wed Aug 11 13:19:04 UTC 2021
machine          : x86_64
processor        : x86_64
byteorder        : little
LC_ALL           : None
LANG             : en_CA.UTF-8
LOCALE           : en_CA.UTF-8

pandas           : 1.4.0.dev0+508.g5fe02971f8
numpy            : 1.20.3
pytz             : 2021.1
dateutil         : 2.8.2
pip              : 20.3.4
setuptools       : 57.4.0
Cython           : 0.29.24
pytest           : 6.2.4
hypothesis       : 6.14.9
sphinx           : 4.1.2
blosc            : 1.10.4
feather          : None
xlsxwriter       : 3.0.1
lxml.etree       : 4.6.3
html5lib         : 1.1
pymysql          : None
psycopg2         : None
jinja2           : 3.0.1
IPython          : 7.26.0
pandas_datareader: None
bs4              : 4.9.3
bottleneck       : 1.3.2
fsspec           : 2021.05.0
fastparquet      : 0.7.1
gcsfs            : 2021.05.0
matplotlib       : 3.4.3
numexpr          : 2.7.3
odfpy            : None
openpyxl         : 3.0.7
pandas_gbq       : None
pyarrow          : 5.0.0
pyxlsb           : None
s3fs             : 2021.05.0
scipy            : 1.7.1
sqlalchemy       : 1.4.23
tables           : 3.6.1
tabulate         : 0.8.9
xarray           : 0.18.2
xlrd             : 2.0.1
xlwt             : 1.3.0
numba            : 0.54.0