### PR TITLE
DOC PR09 Add "." on to_hdf format parameter

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2645,7 +2645,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
               which may perform worse but allow more flexible operations
               like searching / selecting subsets of the data.
             - If None, pd.get_option('io.hdf.default_format') is checked,
-              followed by fallback to "fixed"
+              followed by fallback to "fixed".
         errors : str, default 'strict'
             Specifies how encoding and decoding errors are to be handled.
             See the errors argument for :func:`open` for a full list


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

From #28602:
```
pandas.Series.to_hdf: Parameter "format" description should finish with "."
pandas.DataFrame.to_hdf: Parameter "format" description should finish with "."
```