### PR TITLE
WEB: Updated list of active maintainers #43254

### DIFF
--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -87,6 +87,10 @@ maintainers:
   - MarcoGorelli
   - rhshadrach
   - phofl
+  - attack68
+  - fangchenli
+  - twoertwein
+  - tswast
   emeritus:
   - Wouter Overmeire
   - Skipper Seabold

--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -90,7 +90,6 @@ maintainers:
   - attack68
   - fangchenli
   - twoertwein
-  - tswast
   emeritus:
   - Wouter Overmeire
   - Skipper Seabold


### PR DESCRIPTION
Added *attack68, fangchenli, twoertwein, tswast* to the list of active maintainers.

- [X] closes #43254
- [X] tests added / passed
- [X] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
