### PR TITLE
BENCH: update `class SelectDtypes` to allow testing against 1.3.x

### DIFF
--- a/asv_bench/benchmarks/dtypes.py
+++ b/asv_bench/benchmarks/dtypes.py
@@ -50,15 +50,26 @@ class DtypesInvalid:
 
 class SelectDtypes:
 
-    params = [
-        tm.ALL_INT_NUMPY_DTYPES
-        + tm.ALL_INT_EA_DTYPES
-        + tm.FLOAT_NUMPY_DTYPES
-        + tm.COMPLEX_DTYPES
-        + tm.DATETIME64_DTYPES
-        + tm.TIMEDELTA64_DTYPES
-        + tm.BOOL_DTYPES
-    ]
+    try:
+        params = [
+            tm.ALL_INT_NUMPY_DTYPES
+            + tm.ALL_INT_EA_DTYPES
+            + tm.FLOAT_NUMPY_DTYPES
+            + tm.COMPLEX_DTYPES
+            + tm.DATETIME64_DTYPES
+            + tm.TIMEDELTA64_DTYPES
+            + tm.BOOL_DTYPES
+        ]
+    except AttributeError:
+        params = [
+            tm.ALL_INT_DTYPES
+            + tm.ALL_EA_INT_DTYPES
+            + tm.FLOAT_DTYPES
+            + tm.COMPLEX_DTYPES
+            + tm.DATETIME64_DTYPES
+            + tm.TIMEDELTA64_DTYPES
+            + tm.BOOL_DTYPES
+        ]
     param_names = ["dtype"]
 
     def setup(self, dtype):


### PR DESCRIPTION
doesn't need backport since benchmarks on master are used for comparing branches and finding performance regressions

xref #43047