### PR TITLE
TST: added test for ea dtypes conversion to datetimetzdtype (GH37553)

### DIFF
--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -691,38 +691,6 @@ class TestAstype:
         expected = df.iloc[index_slice]
         tm.assert_frame_equal(result, expected, check_dtype=False)
 
-    @pytest.mark.parametrize(
-        "dtype",
-        tm.ALL_INT_EA_DTYPES + tm.FLOAT_EA_DTYPES,
-    )
-    def test_astype_ea_to_datetimetzdtype(self, dtype):
-        # GH37553
-        result = Series([4, 0, 9], dtype=dtype).astype(DatetimeTZDtype(tz="US/Pacific"))
-        expected = Series(
-            {
-                0: Timestamp("1969-12-31 16:00:00.000000004-08:00", tz="US/Pacific"),
-                1: Timestamp("1969-12-31 16:00:00.000000000-08:00", tz="US/Pacific"),
-                2: Timestamp("1969-12-31 16:00:00.000000009-08:00", tz="US/Pacific"),
-            }
-        )
-
-        if dtype in tm.FLOAT_EA_DTYPES:
-            expected = Series(
-                {
-                    0: Timestamp(
-                        "1970-01-01 00:00:00.000000004-08:00", tz="US/Pacific"
-                    ),
-                    1: Timestamp(
-                        "1970-01-01 00:00:00.000000000-08:00", tz="US/Pacific"
-                    ),
-                    2: Timestamp(
-                        "1970-01-01 00:00:00.000000009-08:00", tz="US/Pacific"
-                    ),
-                }
-            )
-
-        tm.assert_equal(result, expected)
-
 
 class TestAstypeCategorical:
     def test_astype_from_categorical3(self):

--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -691,6 +691,38 @@ class TestAstype:
         expected = df.iloc[index_slice]
         tm.assert_frame_equal(result, expected, check_dtype=False)
 
+    @pytest.mark.parametrize(
+        "dtype",
+        tm.ALL_INT_EA_DTYPES + tm.FLOAT_EA_DTYPES,
+    )
+    def test_astype_ea_to_datetimetzdtype(self, dtype):
+        # GH37553
+        result = Series([4, 0, 9], dtype=dtype).astype(DatetimeTZDtype(tz="US/Pacific"))
+        expected = Series(
+            {
+                0: Timestamp("1969-12-31 16:00:00.000000004-08:00", tz="US/Pacific"),
+                1: Timestamp("1969-12-31 16:00:00.000000000-08:00", tz="US/Pacific"),
+                2: Timestamp("1969-12-31 16:00:00.000000009-08:00", tz="US/Pacific"),
+            }
+        )
+
+        if dtype in tm.FLOAT_EA_DTYPES:
+            expected = Series(
+                {
+                    0: Timestamp(
+                        "1970-01-01 00:00:00.000000004-08:00", tz="US/Pacific"
+                    ),
+                    1: Timestamp(
+                        "1970-01-01 00:00:00.000000000-08:00", tz="US/Pacific"
+                    ),
+                    2: Timestamp(
+                        "1970-01-01 00:00:00.000000009-08:00", tz="US/Pacific"
+                    ),
+                }
+            )
+
+        tm.assert_equal(result, expected)
+
 
 class TestAstypeCategorical:
     def test_astype_from_categorical3(self):

--- a/pandas/tests/series/methods/test_astype.py
+++ b/pandas/tests/series/methods/test_astype.py
@@ -16,6 +16,7 @@ from pandas import (
     NA,
     Categorical,
     CategoricalDtype,
+    DatetimeTZDtype,
     Index,
     Interval,
     NaT,
@@ -361,6 +362,38 @@ class TestAstype:
         ser = Series(np.nan, dtype="object")
         result = ser.astype("bool")
         expected = Series(True, dtype="bool")
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "dtype",
+        tm.ALL_INT_EA_DTYPES + tm.FLOAT_EA_DTYPES,
+    )
+    def test_astype_ea_to_datetimetzdtype(self, dtype):
+        # GH37553
+        result = Series([4, 0, 9], dtype=dtype).astype(DatetimeTZDtype(tz="US/Pacific"))
+        expected = Series(
+            {
+                0: Timestamp("1969-12-31 16:00:00.000000004-08:00", tz="US/Pacific"),
+                1: Timestamp("1969-12-31 16:00:00.000000000-08:00", tz="US/Pacific"),
+                2: Timestamp("1969-12-31 16:00:00.000000009-08:00", tz="US/Pacific"),
+            }
+        )
+
+        if dtype in tm.FLOAT_EA_DTYPES:
+            expected = Series(
+                {
+                    0: Timestamp(
+                        "1970-01-01 00:00:00.000000004-08:00", tz="US/Pacific"
+                    ),
+                    1: Timestamp(
+                        "1970-01-01 00:00:00.000000000-08:00", tz="US/Pacific"
+                    ),
+                    2: Timestamp(
+                        "1970-01-01 00:00:00.000000009-08:00", tz="US/Pacific"
+                    ),
+                }
+            )
+
         tm.assert_series_equal(result, expected)
 
 


### PR DESCRIPTION
- [x] closes #37553
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

Provided tests for type cast `ExtensionDtypes` -> `DatetimeTZDtype`.

Tests and linter pass locally.