### PR TITLE
PERF: indexing

### DIFF
--- a/doc/source/whatsnew/v1.3.3.rst
+++ b/doc/source/whatsnew/v1.3.3.rst
@@ -21,6 +21,15 @@ Fixed regressions
 
 .. ---------------------------------------------------------------------------
 
+.. _whatsnew_133.performance:
+
+Performance improvements
+~~~~~~~~~~~~~~~~~~~~~~~~
+- Performance improvement for :meth:`DataFrame.__setitem__`
+-
+-
+.. ---------------------------------------------------------------------------
+
 .. _whatsnew_133.bug_fixes:
 
 Bug fixes

--- a/doc/source/whatsnew/v1.3.3.rst
+++ b/doc/source/whatsnew/v1.3.3.rst
@@ -25,7 +25,7 @@ Fixed regressions
 
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
-- Performance improvement for :meth:`DataFrame.__setitem__` when the key or value is not a dataframe, or key is not list-like (:issue:`43274`)
+- Performance improvement for :meth:`DataFrame.__setitem__` when the key or value is not a :class:`DataFrame`, or key is not list-like (:issue:`43274`)
 -
 -
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.3.3.rst
+++ b/doc/source/whatsnew/v1.3.3.rst
@@ -25,7 +25,7 @@ Fixed regressions
 
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
-- Performance improvement for :meth:`DataFrame.__setitem__` with dataframes containing unique columns
+- Performance improvement for :meth:`DataFrame.__setitem__` with dataframes containing unique columns (:issue:`43274`)
 -
 -
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.3.3.rst
+++ b/doc/source/whatsnew/v1.3.3.rst
@@ -25,7 +25,7 @@ Fixed regressions
 
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
-- Performance improvement for :meth:`DataFrame.__setitem__` with dataframes containing unique columns (:issue:`43274`)
+- Performance improvement for :meth:`DataFrame.__setitem__` when the key or value is not a dataframe, or key is not list-like (:issue:`43274`)
 -
 -
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.3.3.rst
+++ b/doc/source/whatsnew/v1.3.3.rst
@@ -28,6 +28,7 @@ Performance improvements
 - Performance improvement for :meth:`DataFrame.__setitem__` when the key or value is not a :class:`DataFrame`, or key is not list-like (:issue:`43274`)
 -
 -
+
 .. ---------------------------------------------------------------------------
 
 .. _whatsnew_133.bug_fixes:

--- a/doc/source/whatsnew/v1.3.3.rst
+++ b/doc/source/whatsnew/v1.3.3.rst
@@ -25,7 +25,7 @@ Fixed regressions
 
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
-- Performance improvement for :meth:`DataFrame.__setitem__` with dataframes containing unique columns and list-like values
+- Performance improvement for :meth:`DataFrame.__setitem__` with dataframes containing unique columns
 -
 -
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.3.3.rst
+++ b/doc/source/whatsnew/v1.3.3.rst
@@ -25,7 +25,7 @@ Fixed regressions
 
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
-- Performance improvement for :meth:`DataFrame.__setitem__`
+- Performance improvement for :meth:`DataFrame.__setitem__` with dataframes containing unique columns and list-like values
 -
 -
 .. ---------------------------------------------------------------------------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3620,9 +3620,11 @@ class DataFrame(NDFrame, OpsMixin):
             self._setitem_array(key, value)
         elif isinstance(value, DataFrame):
             self._set_item_frame_value(key, value)
-        elif is_list_like(value) and 1 < len(
-            self.columns.get_indexer_for([key])
-        ) == len(value):
+        elif (
+            is_list_like(value)
+            and not self.columns.is_unique
+            and 1 < len(self.columns.get_indexer_for([key])) == len(value)
+        ):
             # Column to set is duplicated
             self._setitem_array([key], value)
         else:


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

Added a check as suggested in https://github.com/pandas-dev/pandas/pull/39280#issuecomment-764753400

```python
In [1]: from asv_bench.benchmarks.indexing import InsertColumns

In [2]: self = InsertColumns()

In [3]: self.setup()

In [4]: %timeit self.time_assign_with_setitem()
27.6 ms ± 68.1 µs per loop (mean ± std. dev. of 7 runs, 10 loops each) #master

In [4]: %timeit self.time_assign_with_setitem()
8.6 ms ± 6.43 µs per loop (mean ± std. dev. of 7 runs, 100 loops each) #PR
```
Edit:
```
       before           after         ratio
     [2b3a9b16]       [fa9c7140]
     <master>         <indexing.InsertColumns.time_assign_with_setitem>
-         179±4μs        163±0.6μs     0.91  indexing.NumericSeriesIndexing.time_iloc_array(<class 'pandas.core.indexes.numeric.UInt64Index'>, 'unique_monotonic_inc')
-        838±50μs          759±7μs     0.90  indexing.NonNumericSeriesIndexing.time_getitem_list_like('datetime', 'nonunique_monotonic_inc')
-        37.7±4μs       34.0±0.5μs     0.90  indexing.NumericSeriesIndexing.time_getitem_slice(<class 'pandas.core.indexes.numeric.UInt64Index'>, 'nonunique_monotonic_inc')
-     2.91±0.09ms       2.61±0.1ms     0.90  indexing.NumericSeriesIndexing.time_loc_list_like(<class 'pandas.core.indexes.numeric.UInt64Index'>, 'unique_monotonic_inc')
-        60.1±2μs       54.0±0.5μs     0.90  indexing.NumericSeriesIndexing.time_iloc_list_like(<class 'pandas.core.indexes.numeric.Int64Index'>, 'unique_monotonic_inc')
-     1.56±0.03ms      1.40±0.04ms     0.90  indexing.NumericSeriesIndexing.time_loc_list_like(<class 'pandas.core.indexes.numeric.Int64Index'>, 'nonunique_monotonic_inc')
-        183±20μs          164±1μs     0.89  indexing.NumericSeriesIndexing.time_iloc_array(<class 'pandas.core.indexes.numeric.Int64Index'>, 'unique_monotonic_inc')
-     2.39±0.05ms         2.14±0ms     0.89  indexing.NumericSeriesIndexing.time_getitem_list_like(<class 'pandas.core.indexes.numeric.UInt64Index'>, 'nonunique_monotonic_inc')
-        879±30μs         780±50μs     0.89  indexing.CategoricalIndexIndexing.time_get_indexer_list('monotonic_incr')
-        184±20μs          163±1μs     0.88  indexing.NumericSeriesIndexing.time_iloc_array(<class 'pandas.core.indexes.numeric.Int64Index'>, 'nonunique_monotonic_inc')
-         131±7μs          115±4μs     0.87  indexing.NumericSeriesIndexing.time_loc_scalar(<class 'pandas.core.indexes.numeric.Float64Index'>, 'nonunique_monotonic_inc')
-     3.02±0.03ms      2.63±0.09ms     0.87  indexing.NumericSeriesIndexing.time_loc_list_like(<class 'pandas.core.indexes.numeric.Float64Index'>, 'nonunique_monotonic_inc')
-     3.19±0.04ms      2.78±0.04ms     0.87  indexing.NumericSeriesIndexing.time_getitem_list_like(<class 'pandas.core.indexes.numeric.Float64Index'>, 'nonunique_monotonic_inc')
-      11.7±0.2ms       10.2±0.2ms     0.87  indexing.NumericSeriesIndexing.time_loc_array(<class 'pandas.core.indexes.numeric.Float64Index'>, 'unique_monotonic_inc')
-     1.89±0.04ms         1.65±0ms     0.87  indexing.NumericSeriesIndexing.time_getitem_list_like(<class 'pandas.core.indexes.numeric.Int64Index'>, 'unique_monotonic_inc')
-      4.63±0.1ms      3.99±0.02ms     0.86  indexing.NumericSeriesIndexing.time_getitem_array(<class 'pandas.core.indexes.numeric.Int64Index'>, 'unique_monotonic_inc')
-     1.82±0.04ms      1.56±0.01ms     0.86  indexing.NumericSeriesIndexing.time_getitem_list_like(<class 'pandas.core.indexes.numeric.Int64Index'>, 'nonunique_monotonic_inc')
-      3.69±0.1ms       3.14±0.1ms     0.85  indexing.NumericSeriesIndexing.time_loc_list_like(<class 'pandas.core.indexes.numeric.Float64Index'>, 'unique_monotonic_inc')
-     4.08±0.06ms      3.43±0.02ms     0.84  indexing.NumericSeriesIndexing.time_getitem_list_like(<class 'pandas.core.indexes.numeric.Float64Index'>, 'unique_monotonic_inc')
-        150±30μs          120±3μs     0.80  indexing.NumericSeriesIndexing.time_loc_slice(<class 'pandas.core.indexes.numeric.UInt64Index'>, 'unique_monotonic_inc')
-        961±30μs         762±20μs     0.79  indexing.CategoricalIndexIndexing.time_get_indexer_list('monotonic_decr')
-        295±30μs          231±3μs     0.78  indexing.NumericSeriesIndexing.time_loc_slice(<class 'pandas.core.indexes.numeric.Int64Index'>, 'nonunique_monotonic_inc')
-      1.11±0.3ms         825±20μs     0.74  indexing_engines.NumericEngineIndexing.time_get_loc((<class 'pandas._libs.index.UInt8Engine'>, <class 'numpy.uint8'>), 'monotonic_incr')
-        741±80μs          288±9μs     0.39  indexing.AssignTimeseriesIndex.time_frame_assign_timeseries_index
-        49.3±2ms       18.2±0.2ms     0.37  indexing.InsertColumns.time_assign_with_setitem
-       54.3±20ms         18.5±1ms     0.34  indexing.InsertColumns.time_assign_list_like_with_setitem
```
