### PR TITLE
modified changes for datetime and NaT Objects Behavior closes #43280

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -267,7 +267,7 @@ Datetimelike
 ^^^^^^^^^^^^
 - Bug in :class:`DataFrame` constructor unnecessarily copying non-datetimelike 2D object arrays (:issue:`39272`)
 - :func:`to_datetime` would silently swap ``MM/DD/YYYY`` and ``DD/MM/YYYY`` formats if the given ``dayfirst`` option could not be respected - now, a warning is raised in the case of delimited date strings (e.g. ``31-12-2012``) (:issue:`12585`)
--Bug in :class:'Series' to_numeric as inconsistent behaviour for datatime object (:issue:'43280')
+-Bug in :class:'Series and scalar' to_numeric as inconsistent behaviour for datatime object (:issue:'43280')
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -267,7 +267,7 @@ Datetimelike
 ^^^^^^^^^^^^
 - Bug in :class:`DataFrame` constructor unnecessarily copying non-datetimelike 2D object arrays (:issue:`39272`)
 - :func:`to_datetime` would silently swap ``MM/DD/YYYY`` and ``DD/MM/YYYY`` formats if the given ``dayfirst`` option could not be respected - now, a warning is raised in the case of delimited date strings (e.g. ``31-12-2012``) (:issue:`12585`)
--
+-Bug in :class:'Series' to_numeric as inconsistent behaviour for datatime object (:issue:'43280')
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -180,7 +180,10 @@ def to_numeric(arg, errors="raise", downcast=None):
     if is_numeric_dtype(values_dtype):
         pass
     elif is_datetime_or_timedelta_dtype(values_dtype):
-        
+        if pd.isnull(arg.values):
+            values = np.nan
+        else: 
+            values = pd.to_datetime(values).strftime("%Y%m%d").astype(np.int64)
     else:
         values = ensure_object(values)
         coerce_numeric = errors not in ("ignore", "raise")

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -130,19 +130,6 @@ def to_numeric(arg, errors="raise", downcast=None):
     1    2.1
     2    3.0
     dtype: Float32
-
-    Datetime dTypes is supported
-
-    >>> s = pd.to_numeric(datetime(2021, 8, 22), errors="coerce")
-    0 20210822
-    dtype: Int64
-    >>> s = pd.to_numeric(pd.NaT, errors="coerce")
-    nan
-    >>> s = pd.to_numeric(pd.Series(datetime(2021, 8, 22)), errors="coerce")
-    0 20210822
-    dtype: Int64
-    >>> s = pd.to_numeric(pd.Series(pd.NaT), errors="coerce")
-    NaN
     """
     if downcast not in (None, "integer", "signed", "unsigned", "float"):
         raise ValueError("invalid downcasting method provided")

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -175,7 +175,10 @@ def to_numeric(arg, errors="raise", downcast=None):
     if is_numeric_dtype(values_dtype):
         pass
     elif is_datetime_or_timedelta_dtype(values_dtype):
-        values = values.view(np.int64)
+        if pd.isnull(arg.values):
+            values = np.nan
+        else: 
+            values = pd.to_datetime(values).strftime("%Y%m%d").astype(np.int64)
     else:
         values = ensure_object(values)
         coerce_numeric = errors not in ("ignore", "raise")
@@ -236,7 +239,5 @@ def to_numeric(arg, errors="raise", downcast=None):
         # because we want to coerce to numeric if possible,
         # do not use _shallow_copy
         return pd.Index(values, name=arg.name)
-    elif is_scalars:
-        return values[0]
     else:
-        return values
+        return values[0]

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -789,3 +789,29 @@ def test_to_numeric_scientific_notation():
     result = to_numeric("1.7e+308")
     expected = np.float64(1.7e308)
     assert result == expected
+
+
+def test_to_numeric_series_date():
+    #GH 43280
+    result = pd.to_numeric(pd.Series(datetime(2021, 8, 22)), errors="coerce")
+    expected = np.Int64(20210822)
+    assert result == expected
+
+def test_to_numeric_series_nat():
+    #GH 43280
+    result = pd.to_numeric(pd.Series(pd.NaT), errors="coerce")
+    expected = np.float64(NaN)
+    assert result == expected
+
+def test_to_numeric_scalar_date():
+    #GH 43280
+    result = pd.to_numeric(datetime(2021, 8, 22), errors="coerce")
+    expected = np.Int64(20210822)
+    assert result == expected
+
+def test_to_numeric_scalar_nat():
+    #GH 43280
+    result = pd.to_numeric(pd.NaT, errors="coerce")
+    expected = np.float64(NaN)
+    assert result == expected
+

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -794,24 +794,23 @@ def test_to_numeric_scientific_notation():
 def test_to_numeric_series_date():
     #GH 43280
     result = pd.to_numeric(pd.Series(datetime(2021, 8, 22)), errors="coerce")
-    expected = np.Int64(20210822)
-    assert result == expected
+    expected = pd.Series([20210822])
+    tm.assert_series_equal(result, expected)
 
 def test_to_numeric_series_nat():
     #GH 43280
     result = pd.to_numeric(pd.Series(pd.NaT), errors="coerce")
-    expected = np.float64(NaN)
-    assert result == expected
+    expected = pd.Series([np.nan])
+    tm.assert_series_equal(result, expected)
 
 def test_to_numeric_scalar_date():
     #GH 43280
     result = pd.to_numeric(datetime(2021, 8, 22), errors="coerce")
-    expected = np.Int64(20210822)
+    expected = np.int64(20210822)
     assert result == expected
 
 def test_to_numeric_scalar_nat():
     #GH 43280
     result = pd.to_numeric(pd.NaT, errors="coerce")
-    expected = np.float64(NaN)
-    assert result == expected
+    assert pd.isnull(result)
 


### PR DESCRIPTION
- [ #] Closes #43280
- [ #] tests added / passed

**Modified  datatime object 👍 ** 
i have changed view values to numeric of date and missing data found in pd series is returns Nan when coerce errors . 

**Example for solved changes 💯 **
```
>>> pd.to_numeric(pd.Series(datetime(2021, 8, 22)), errors="coerce")
[OUT]
0    20210822
dtype: int64

>>> pd.to_numeric(pd.Series(pd.NaT), errors="coerce")
[OUT]
0   NaN
dtype: float64

>>> s = pd.to_numeric(datetime(2021, 8, 22), errors="coerce")
0 20210822
dtype: Int64
>>> s = pd.to_numeric(pd.NaT, errors="coerce")
 nan

```

