### PR TITLE
TST: added test for to_string when max_rows is zero (GH35394)

### DIFF
--- a/pandas/tests/io/formats/test_to_string.py
+++ b/pandas/tests/io/formats/test_to_string.py
@@ -325,10 +325,6 @@ def test_to_string_na_rep_and_float_format(na_rep):
             "   col1  col2\n0     1     3\n1     2     4",
         ),
         (
-            {"col1": [0, 2, 4], "col2": [3, 4, 5]},
-            "   col1  col2\n0     0     3\n1     2     4\n2     4     5",
-        ),
-        (
             {"col1": ["Abc", 0.756], "col2": [np.nan, 4.5435]},
             "    col1    col2\n0    Abc     NaN\n1  0.756  4.5435",
         ),
@@ -341,5 +337,4 @@ def test_to_string_na_rep_and_float_format(na_rep):
 def test_to_string_max_rows_zero(data, expected):
     # GH35394
     result = DataFrame(data=data).to_string(max_rows=0)
-
     assert result == expected

--- a/pandas/tests/io/formats/test_to_string.py
+++ b/pandas/tests/io/formats/test_to_string.py
@@ -315,3 +315,31 @@ def test_to_string_na_rep_and_float_format(na_rep):
          1     A   {na_rep}"""
     )
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        (
+            {"col1": [1, 2], "col2": [3, 4]},
+            "   col1  col2\n0     1     3\n1     2     4",
+        ),
+        (
+            {"col1": [0, 2, 4], "col2": [3, 4, 5]},
+            "   col1  col2\n0     0     3\n1     2     4\n2     4     5",
+        ),
+        (
+            {"col1": ["Abc", 0.756], "col2": [np.nan, 4.5435]},
+            "    col1    col2\n0    Abc     NaN\n1  0.756  4.5435",
+        ),
+        (
+            {"col1": [np.nan, "a"], "col2": [0.009, 3.543], "col3": ["Abc", 23]},
+            "  col1   col2 col3\n0  NaN  0.009  Abc\n1    a  3.543   23",
+        ),
+    ],
+)
+def test_to_string_max_rows_zero(data, expected):
+    # GH35394
+    result = DataFrame(data=data).to_string(max_rows=0)
+
+    assert result == expected


### PR DESCRIPTION
- [x] closes #35394
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

Provided tests for `to_string` when `max_rows=0`.

Tests and linter pass locally.