### PR TITLE
PERF: GroupBy.cumsum

### DIFF
--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -526,7 +526,13 @@ class BaseBlockManager(DataManager):
         copy : bool, default False
             Whether to copy the blocks
         """
-        return self._combine([b for b in self.blocks if b.is_numeric], copy)
+        numeric_blocks = [blk for blk in self.blocks if blk.is_numeric]
+        if len(numeric_blocks) == len(self.blocks):
+            # Avoid somewhat expensive _combine
+            if copy:
+                return self.copy(deep=True)
+            return self
+        return self._combine(numeric_blocks, copy)
 
     def _combine(
         self: T, blocks: list[Block], copy: bool = True, index: Index | None = None


### PR DESCRIPTION
```
from asv_bench.benchmarks.groupby import *
self = GroupByMethods()
self.setup('int', 'cumsum', 'transformation', 2)

%timeit self.time_dtype_as_group('int', 'cumsum', 'transformation', 2)
128 µs ± 7.81 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)  # <- master
99.7 µs ± 1.13 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)  # <- PR
```