### PR TITLE
BUG: Fix `pd.to_numeric` to have consistent behavior for date-like arguments

### DIFF
--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -137,6 +137,11 @@ def to_numeric(arg, errors="raise", downcast=None):
     if errors not in ("ignore", "raise", "coerce"):
         raise ValueError("invalid error value specified")
 
+    # Handle inputs of "date" type as objects
+    arg_dtype = getattr(arg, "dtype", None)
+    if is_datetime_or_timedelta_dtype(arg_dtype):
+        arg = arg._constructor(arg, dtype="O")
+
     is_series = False
     is_index = False
     is_scalars = False

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -102,18 +102,22 @@ def to_numeric(arg, errors="raise", downcast=None):
     1    2
     2   -3
     dtype: int8
-    >>> s = pd.Series(['apple', '1.0', '2', -3])
+    >>> s = pd.Series(['apple', '1.0', '2', -3, pd.to_datetime(0), pd.NaT])
     >>> pd.to_numeric(s, errors='ignore')
-    0    apple
-    1      1.0
-    2        2
-    3       -3
+    0                  apple
+    1                    1.0
+    2                      2
+    3                     -3
+    4    1970-01-01 00:00:00
+    5                    NaT
     dtype: object
     >>> pd.to_numeric(s, errors='coerce')
     0    NaN
     1    1.0
     2    2.0
     3   -3.0
+    4    NaN
+    5    NaN
     dtype: float64
 
     Downcasting of nullable integer and floating dtypes is supported:

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -144,7 +144,11 @@ def to_numeric(arg, errors="raise", downcast=None):
     # Handle inputs of "date" type as objects
     arg_dtype = getattr(arg, "dtype", None)
     if is_datetime_or_timedelta_dtype(arg_dtype):
-        arg = arg._constructor(arg, dtype="O")
+        try:
+            arg = arg._constructor(arg, dtype="O")
+        except AttributeError:
+            # when `arg` is a a numpy array
+            arg = arg.astype("O")
 
     is_series = False
     is_index = False
@@ -155,10 +159,7 @@ def to_numeric(arg, errors="raise", downcast=None):
         values = arg.values
     elif isinstance(arg, ABCIndex):
         is_index = True
-        if needs_i8_conversion(arg.dtype):
-            values = arg.asi8
-        else:
-            values = arg.values
+        values = arg.values
     elif isinstance(arg, (list, tuple)):
         values = np.array(arg, dtype="O")
     elif is_scalar(arg):

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -450,7 +450,6 @@ def test_errors_invalid_value():
     [
         ["1", 2, 3],
         [1, 2, 3],
-        np.array(["1970-01-02", "1970-01-03", "1970-01-04"], dtype="datetime64[D]"),
     ],
 )
 @pytest.mark.parametrize(
@@ -478,7 +477,6 @@ def test_downcast_basic(data, kwargs, exp_dtype):
     [
         ["1", 2, 3],
         [1, 2, 3],
-        np.array(["1970-01-02", "1970-01-03", "1970-01-04"], dtype="datetime64[D]"),
     ],
 )
 def test_signed_downcast(data, signed_downcast):

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -417,39 +417,6 @@ def test_str(data, exp, transform_assert_equal):
     assert_equal(result, expected)
 
 
-def test_datetime_like(tz_naive_fixture, transform_assert_equal):
-    transform, assert_equal = transform_assert_equal
-    idx = pd.date_range("20130101", periods=3, tz=tz_naive_fixture)
-
-    result = to_numeric(transform(idx))
-    expected = transform(idx.asi8)
-    assert_equal(result, expected)
-
-
-def test_timedelta(transform_assert_equal):
-    transform, assert_equal = transform_assert_equal
-    idx = pd.timedelta_range("1 days", periods=3, freq="D")
-
-    result = to_numeric(transform(idx))
-    expected = transform(idx.asi8)
-    assert_equal(result, expected)
-
-
-def test_period(transform_assert_equal):
-    transform, assert_equal = transform_assert_equal
-
-    idx = pd.period_range("2011-01", periods=3, freq="M", name="")
-    inp = transform(idx)
-
-    if isinstance(inp, Index):
-        result = to_numeric(inp)
-        expected = transform(idx.asi8)
-        assert_equal(result, expected)
-    else:
-        # TODO: PeriodDtype, so support it in to_numeric.
-        pytest.skip("Missing PeriodDtype support in to_numeric")
-
-
 @pytest.mark.parametrize(
     "errors,expected",
     [

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -138,7 +138,10 @@ def test_error(data, msg):
     "data,msg",
     [
         ([22.06, "-86", pd.NaT], "Invalid object type at position 2"),
-        ([pd.to_datetime(0), 22.06, "-86", pd.NaT], "Invalid object type at position 0"),
+        (
+            [pd.to_datetime(0), 22.06, "-86", pd.NaT],
+            "Invalid object type at position 0"
+        ),
     ],
 )
 def test_type_error(data, msg):

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -111,10 +111,28 @@ def test_error(data, msg):
 
 
 @pytest.mark.parametrize(
-    "errors,exp_data", [("ignore", [1, -3.14, "apple"]), ("coerce", [1, -3.14, np.nan])]
+    "data,msg",
+    [
+        ([22.06, "-86", pd.NaT], "Invalid object type at position 2"),
+        ([pd.to_datetime(0), 22.06, "-86", pd.NaT], "Invalid object type at position 0"),
+    ],
+)
+def test_type_error(data, msg):
+    ser = Series(data)
+
+    with pytest.raises(TypeError, match=msg):
+        to_numeric(ser, errors="raise")
+
+
+@pytest.mark.parametrize(
+    "errors,exp_data",
+    [
+        ("ignore", [1, -3.14, "apple", pd.to_datetime(0), pd.NaT]),
+        ("coerce", [1, -3.14, np.nan, np.nan, np.nan])
+    ],
 )
 def test_ignore_error(errors, exp_data):
-    ser = Series([1, -3.14, "apple"])
+    ser = Series([1, -3.14, "apple", pd.to_datetime(0), pd.NaT])
     result = to_numeric(ser, errors=errors)
 
     expected = Series(exp_data)

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -78,6 +78,30 @@ def test_series(last_val):
 
 
 @pytest.mark.parametrize(
+    "list_data,kwargs",
+    [
+        (["-3.14", 7], {}),
+        (
+            ["-3.14", 7, pd.to_datetime(0), pd.NaT, ["30", -10]],
+            {"errors": "coerce"}
+        ),
+        (
+            ["-3.14", 7, pd.to_datetime(0), pd.NaT, ["30", -10]],
+            {"errors": "ignore"}
+        ),
+    ]
+)
+def test_list_series(list_data, kwargs):
+    lis = list_data
+    ser = Series(list_data)
+
+    result = to_numeric(lis, **kwargs)
+    expected = to_numeric(ser, **kwargs).values
+
+    tm.assert_numpy_array_equal(result, expected)
+
+
+@pytest.mark.parametrize(
     "data",
     [
         [1, 3, 4, 5],


### PR DESCRIPTION
- [ ] closes #43280
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

`pd.to_numeric` was having an inconsistent behavior when using in datelike objects and was returning wrong result when using with `pd.NaT`


**In master:**
```python
>>> import pandas as pd
>>> from datetime import datetime
>>> from functools import partial
>>> pd.to_numeric(datetime(2021, 8, 22), errors="coerce")
nan
>>> pd.to_numeric(pd.Series(datetime(2021, 8, 22)), errors="coerce")
0    1629590400000000000
dtype: int64
>>> pd.Series([datetime(2021, 8, 22)]).apply(partial(pd.to_numeric), errors="coerce")
0   NaN
dtype: float64
>>>
>>> pd.to_numeric(pd.NaT, errors="coerce")
nan
>>> pd.to_numeric(pd.Series(pd.NaT), errors="coerce")
0   -9223372036854775808
dtype: int64
>>> pd.Series(pd.NaT).apply(partial(pd.to_numeric), errors="coerce")
0   NaN
dtype: float64

```

**In this PR:**
```python
>>> import pandas as pd
>>> from datetime import datetime
>>> from functools import partial
>>> pd.to_numeric(datetime(2021, 8, 22), errors="coerce")
nan
>>> pd.to_numeric(pd.Series(datetime(2021, 8, 22)), errors="coerce")
0   NaN
dtype: float64
>>> pd.Series([datetime(2021, 8, 22)]).apply(partial(pd.to_numeric), errors="coerce")
0   NaN
dtype: float64
>>>
>>> pd.to_numeric(pd.NaT, errors="coerce")
nan
>>> pd.to_numeric(pd.Series(pd.NaT), errors="coerce")
0   NaN
dtype: float64
>>> pd.Series(pd.NaT).apply(partial(pd.to_numeric), errors="coerce")
0   NaN
dtype: float64
```

Please let me know if this approach makes sense so I can add the tests.