### PR TITLE
PERF: DataFrame[object].fillna

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1084,6 +1084,23 @@ class Block(PandasObject):
             # If there are no NAs, then interpolate is a no-op
             return [self] if inplace else [self.copy()]
 
+        if self.is_object and self.ndim == 2 and self.shape[0] != 1 and axis == 0:
+            # split improves performance in ndarray.copy()
+            return self.split_and_operate(
+                type(self).interpolate,
+                method,
+                axis,
+                index,
+                inplace,
+                limit,
+                limit_direction,
+                limit_area,
+                fill_value,
+                coerce,
+                downcast,
+                **kwargs,
+            )
+
         try:
             m = missing.clean_fill_method(method)
         except ValueError:


### PR DESCRIPTION
```
from asv_bench.benchmarks.frame_methods import *

self5 = Fillna()
self5.setup(False, 'pad', 'object')

%timeit self5.time_frame_fillna(False, 'pad', 'object')
191 ms ± 5.41 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)  # <- master
127 ms ± 5.03 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)  # <- PR
```