### PR TITLE
Datetime series slicing - error without loc()

### DIFF
--- a/doc/source/getting_started/intro_tutorials/09_timeseries.rst
+++ b/doc/source/getting_started/intro_tutorials/09_timeseries.rst
@@ -263,7 +263,7 @@ Create a plot of the :math:`NO_2` values in the different stations from the 20th
     :okwarning:
 
     @savefig 09_time_section.png
-    no_2["2019-05-20":"2019-05-21"].plot();
+    no_2.loc["2019-05-20":"2019-05-21"].plot();
 
 By providing a **string that parses to a datetime**, a specific subset of the data can be selected on a ``DatetimeIndex``.
 


### PR DESCRIPTION
Problem:
Date time series on slicing might produce errors for different reasons(change in data format for each, unsorted DateTime inputs etc.)  which can be avoided with "loc() on the DateTime".
The error was like *** Slicing with this method is *always* positional.***

After correcting the Issue : (Screenshots)
https://docs.google.com/document/d/1L5Ei0q5BfHCTnfzG43exvTug_N1OE7UEmxbgB0KjIh4/edit?usp=sharing

Issue: 43223

Code testing :
    
    import pandas as pd
    import numpy as np
    df = pd.DataFrame(
        {'ind': [i for i in range(5)]}, 
        index=pd.DatetimeIndex(["11.01.2011 22:00", "11.01.2011 23:00", "12.01.2011 00:00", "2011-01-13 00:00","2011-01-14 00:00"]))
    
    df.loc["2011-01-01": "2011-11-01"].plot()

Test Dataset:

                     ind
        2011-11-01 22:00:00    0
        2011-11-01 23:00:00    1
        2011-12-01 00:00:00    2
        2011-01-13 00:00:00    3
        2011-01-14 00:00:00    4

The above code works perfectly with loc() added and is one of the test case examples.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
