### PR TITLE
BUG: DataFrame.explode is failing on scalar int value.

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8271,7 +8271,7 @@ NaN 12.3   33.0
 
         columns: list[str | tuple]
         if is_scalar(column) or isinstance(column, tuple):
-            assert isinstance(column, (str, tuple))
+            assert isinstance(column, (str, tuple, int))
             columns = [column]
         elif isinstance(column, list) and all(
             map(lambda c: is_scalar(c) or isinstance(c, tuple), column)


### PR DESCRIPTION
closes #43314 

The **int** datatype of the column was raising this issue.

- [x] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
