### PR TITLE
PERF: read_sas

### DIFF
--- a/pandas/tests/io/sas/test_sas7bdat.py
+++ b/pandas/tests/io/sas/test_sas7bdat.py
@@ -7,10 +7,7 @@ import dateutil.parser
 import numpy as np
 import pytest
 
-from pandas.errors import (
-    EmptyDataError,
-    PerformanceWarning,
-)
+from pandas.errors import EmptyDataError
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -202,15 +199,11 @@ def test_compact_numerical_values(datapath):
     tm.assert_series_equal(result, expected, check_exact=True)
 
 
-def test_many_columns(datapath, using_array_manager):
+def test_many_columns(datapath):
     # Test for looking for column information in more places (PR #22628)
     fname = datapath("io", "sas", "data", "many_columns.sas7bdat")
-    expected_warning = None
-    if not using_array_manager:
-        expected_warning = PerformanceWarning
-    with tm.assert_produces_warning(expected_warning):
-        # Many DataFrame.insert calls
-        df = pd.read_sas(fname, encoding="latin-1")
+
+    df = pd.read_sas(fname, encoding="latin-1")
 
     fname = datapath("io", "sas", "data", "many_columns.csv")
     df0 = pd.read_csv(fname, encoding="latin-1")


### PR DESCRIPTION
```
from asv_bench.benchmarks.io.sas import *
self8 = SAS()
self8.setup("sas7bdat")

%timeit self8.time_read_sas("sas7bdat")
41.6 ms ± 1.77 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)  # <- master
22.7 ms ± 1.04 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)  # <- PR

```