### PR TITLE
CI: Fix Failing Doc Build

### DIFF
--- a/doc/source/whatsnew/v1.3.3.rst
+++ b/doc/source/whatsnew/v1.3.3.rst
@@ -19,6 +19,7 @@ Fixed regressions
 - Fixed regression in :meth:`.GroupBy.agg` incorrectly raising in some cases (:issue:`42390`)
 - Fixed regression in :meth:`RangeIndex.where` and :meth:`RangeIndex.putmask` raising ``AssertionError`` when result did not represent a :class:`RangeIndex` (:issue:`43240`)
 - Fixed regression in :meth:`read_parquet` where the ``fastparquet`` engine would not work properly with fastparquet 0.7.0 (:issue:`43075`)
+
 .. ---------------------------------------------------------------------------
 
 .. _whatsnew_133.performance:


### PR DESCRIPTION
https://github.com/pandas-dev/pandas/pull/43145 had failing code checks

https://github.com/pandas-dev/pandas/pull/43347/checks?check_run_id=3488498926

```
/home/runner/work/pandas/pandas/doc/source/whatsnew/v1.3.3.rst:36: WARNING: Bullet list ends without a blank line; unexpected unindent.
```