### PR TITLE
TST: added test for groupby when calling first, last, nth (GH29645)

### DIFF
--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2422,18 +2422,16 @@ def test_rolling_wrong_param_min_period():
 
 
 @pytest.mark.parametrize("method", ["first", "last", "nth"])
-@pytest.mark.parametrize("nans", [None, np.nan])
-def test_groupby_last_first_nth_with_none(method, nans):
+def test_groupby_last_first_nth_with_none(method, nulls_fixture):
     # GH29645
-    expected = Series([True])
-    data = (
-        Series([nans, "x", nans, "y", nans], index=[0, 0, 0, 0, 0])
-        .isna()
-        .groupby(level=0)
-    )
+    expected = Series(["y"])
+    data = Series(
+        [nulls_fixture, nulls_fixture, nulls_fixture, "y", nulls_fixture],
+        index=[0, 0, 0, 0, 0],
+    ).groupby(level=0)
 
     if method == "nth":
-        result = getattr(data, method)(2)
+        result = getattr(data, method)(3)
     else:
         result = getattr(data, method)()
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2422,24 +2422,19 @@ def test_rolling_wrong_param_min_period():
 
 
 @pytest.mark.parametrize("method", ["first", "last", "nth"])
-def test_groupby_last_first_nth_with_none(method):
+@pytest.mark.parametrize("nans", [None, np.nan])
+def test_groupby_last_first_nth_with_none(method, nans):
     # GH29645
-    s1 = (
-        Series([None, "x", None, "y", None], index=[0, 0, 0, 0, 0])
-        .isna()
-        .groupby(level=0)
-    )
-    s2 = (
-        Series([np.nan, "x", np.nan, "y", np.nan], index=[0, 0, 0, 0, 0])
+    expected = Series([True])
+    data = (
+        Series([nans, "x", nans, "y", nans], index=[0, 0, 0, 0, 0])
         .isna()
         .groupby(level=0)
     )
 
     if method == "nth":
-        s_none = getattr(s1, method)(2)
-        s_nan = getattr(s2, method)(2)
+        result = getattr(data, method)(2)
     else:
-        s_none = getattr(s1, method)()
-        s_nan = getattr(s2, method)()
+        result = getattr(data, method)()
 
-    tm.assert_series_equal(s_none, s_nan)
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2419,20 +2419,3 @@ def test_rolling_wrong_param_min_period():
     result_error_msg = r"__init__\(\) got an unexpected keyword argument 'min_period'"
     with pytest.raises(TypeError, match=result_error_msg):
         test_df.groupby("name")["val"].rolling(window=2, min_period=1).sum()
-
-
-@pytest.mark.parametrize("method", ["first", "last", "nth"])
-def test_groupby_last_first_nth_with_none(method, nulls_fixture):
-    # GH29645
-    expected = Series(["y"])
-    data = Series(
-        [nulls_fixture, nulls_fixture, nulls_fixture, "y", nulls_fixture],
-        index=[0, 0, 0, 0, 0],
-    ).groupby(level=0)
-
-    if method == "nth":
-        result = getattr(data, method)(3)
-    else:
-        result = getattr(data, method)()
-
-    tm.assert_series_equal(result, expected)

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2419,3 +2419,27 @@ def test_rolling_wrong_param_min_period():
     result_error_msg = r"__init__\(\) got an unexpected keyword argument 'min_period'"
     with pytest.raises(TypeError, match=result_error_msg):
         test_df.groupby("name")["val"].rolling(window=2, min_period=1).sum()
+
+
+@pytest.mark.parametrize("method", ["first", "last", "nth"])
+def test_groupby_last_first_nth_with_none(method):
+    # GH29645
+    s1 = (
+        Series([None, "x", None, "y", None], index=[0, 0, 0, 0, 0])
+        .isna()
+        .groupby(level=0)
+    )
+    s2 = (
+        Series([np.nan, "x", np.nan, "y", np.nan], index=[0, 0, 0, 0, 0])
+        .isna()
+        .groupby(level=0)
+    )
+
+    if method == "nth":
+        s_none = getattr(s1, method)(2)
+        s_nan = getattr(s2, method)(2)
+    else:
+        s_none = getattr(s1, method)()
+        s_nan = getattr(s2, method)()
+
+    tm.assert_series_equal(s_none, s_nan)

--- a/pandas/tests/groupby/test_nth.py
+++ b/pandas/tests/groupby/test_nth.py
@@ -689,3 +689,20 @@ def test_first_multi_key_groupbby_categorical():
         [(1, 100), (1, 200), (2, 100)], names=["A", "B"]
     )
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("method", ["first", "last", "nth"])
+def test_groupby_last_first_nth_with_none(method, nulls_fixture):
+    # GH29645
+    expected = Series(["y"])
+    data = Series(
+        [nulls_fixture, nulls_fixture, nulls_fixture, "y", nulls_fixture],
+        index=[0, 0, 0, 0, 0],
+    ).groupby(level=0)
+
+    if method == "nth":
+        result = getattr(data, method)(3)
+    else:
+        result = getattr(data, method)()
+
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #29645
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them

Provided test for `groupby` when callling `first`, `last`, `nth` on a `Series` with `None` or `np.nan`.

Tests and linter pass locally.
