### PR TITLE
CLN: Replace sphinx's rpartition with python's in-built one

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -461,7 +461,6 @@ ipython_execlines = [
 # eg pandas.Series.str and pandas.Series.dt (see GH9322)
 
 import sphinx  # isort:skip
-from sphinx.util import rpartition  # isort:skip
 from sphinx.ext.autodoc import (  # isort:skip
     AttributeDocumenter,
     Documenter,
@@ -521,8 +520,8 @@ class AccessorLevelDocumenter(Documenter):
             # HACK: this is added in comparison to ClassLevelDocumenter
             # mod_cls still exists of class.accessor, so an extra
             # rpartition is needed
-            modname, accessor = rpartition(mod_cls, ".")
-            modname, cls = rpartition(modname, ".")
+            modname, _, accessor = mod_cls.rpartition(".")
+            modname, _, cls = modname.rpartition(".")
             parents = [cls, accessor]
             # if the module name is still missing, get it like above
             if not modname:


### PR DESCRIPTION
Closes #43348 

Replaced Sphinx's `rpartition` which was deprecated with Python's in-built method
