### PR TITLE
BUG: Fix regression in is_list_like

### DIFF
--- a/doc/source/whatsnew/v1.3.3.rst
+++ b/doc/source/whatsnew/v1.3.3.rst
@@ -19,7 +19,7 @@ Fixed regressions
 - Fixed regression in :meth:`.GroupBy.agg` incorrectly raising in some cases (:issue:`42390`)
 - Fixed regression in :meth:`RangeIndex.where` and :meth:`RangeIndex.putmask` raising ``AssertionError`` when result did not represent a :class:`RangeIndex` (:issue:`43240`)
 - Fixed regression in :meth:`read_parquet` where the ``fastparquet`` engine would not work properly with fastparquet 0.7.0 (:issue:`43075`)
-- Fixed regression in :func:`is_list_like` where objects with ``__iter__`` set to ``None`` would be identified as iterable
+- Fixed regression in :func:`is_list_like` where objects with ``__iter__`` set to ``None`` would be identified as iterable (:issue:`43373`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.3.3.rst
+++ b/doc/source/whatsnew/v1.3.3.rst
@@ -19,6 +19,7 @@ Fixed regressions
 - Fixed regression in :meth:`.GroupBy.agg` incorrectly raising in some cases (:issue:`42390`)
 - Fixed regression in :meth:`RangeIndex.where` and :meth:`RangeIndex.putmask` raising ``AssertionError`` when result did not represent a :class:`RangeIndex` (:issue:`43240`)
 - Fixed regression in :meth:`read_parquet` where the ``fastparquet`` engine would not work properly with fastparquet 0.7.0 (:issue:`43075`)
+- Fixed regression in :func:`is_list_like` where objects with ``__iter__`` set to ``None`` would be identified as iterable
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -1092,7 +1092,7 @@ def is_list_like(obj: object, allow_sets: bool = True) -> bool:
 cdef inline bint c_is_list_like(object obj, bint allow_sets) except -1:
     return (
         # equiv: `isinstance(obj, abc.Iterable)`
-        hasattr(obj, "__iter__") and not isinstance(obj, type)
+        getattr(obj, "__iter__", None) is not None and not isinstance(obj, type)
         # we do not count strings/unicode/bytes as list-like
         and not isinstance(obj, (str, bytes))
         # exclude zero-dimensional numpy arrays, effectively scalars

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -151,6 +151,8 @@ def test_is_list_like_recursion():
 
 
 def test_is_list_like_iter_is_none():
+    # GH 43373
+    # is_list_like was yielding false positives with __iter__ == None
     class NotListLike:
         def __getitem__(self, item):
             return self

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -150,6 +150,13 @@ def test_is_list_like_recursion():
         foo()
 
 
+def test_is_list_like_iter_is_none():
+    class NotListLike:
+        __iter__ = None
+
+    assert not inference.is_list_like(NotListLike())
+
+
 def test_is_sequence():
     is_seq = inference.is_sequence
     assert is_seq((1, 2))

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -152,6 +152,9 @@ def test_is_list_like_recursion():
 
 def test_is_list_like_iter_is_none():
     class NotListLike:
+        def __getitem__(self, item):
+            return self
+
         __iter__ = None
 
     assert not inference.is_list_like(NotListLike())

--- a/pandas/tests/libs/test_lib.py
+++ b/pandas/tests/libs/test_lib.py
@@ -206,10 +206,3 @@ def test_no_default_pickle():
     # GH#40397
     obj = tm.round_trip_pickle(lib.no_default)
     assert obj is lib.no_default
-
-
-def test_is_list_like_iter_is_none():
-    class NotListLike:
-        __iter__ = None
-
-    assert not lib.is_list_like(NotListLike())

--- a/pandas/tests/libs/test_lib.py
+++ b/pandas/tests/libs/test_lib.py
@@ -206,3 +206,10 @@ def test_no_default_pickle():
     # GH#40397
     obj = tm.round_trip_pickle(lib.no_default)
     assert obj is lib.no_default
+
+
+def test_is_list_like_iter_is_none():
+    class NotListLike:
+        __iter__ = None
+
+    assert not lib.is_list_like(NotListLike())


### PR DESCRIPTION
`is_list_like()` used to use `isinstance(obj, abc.Iterable)` before #39852 where it was optimized for performance. This resulted in a regression where objects that explicitly declare `__iter__` as `None` are considered "list like" but not instances of `abc.Iterable`.

Because the original original PR was focused on performance, here are the same timeit cases run on this PR:

```python
In[1]: import numpy as np
In[2]: from pandas._libs.lib import is_list_like
In[3]: arr = np.array(0)
In[4]: arr2 = np.array([0])

In[5]: %timeit is_list_like([])
51.3 ns ± 0.231 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  <- master
56.3 ns ± 0.44 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)   <- PR
153 ns ± 2.4 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)     <- isinstance(obj, abc.Iterable)

In[6]: %timeit is_list_like(0)
117 ns ± 2.19 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)    <- master
126 ns ± 2 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)       <- PR
154 ns ± 1.18 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)    <- isinstance(obj, abc.Iterable)

In[7]: %timeit is_list_like(arr)
49.5 ns ± 0.156 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  <- master
50.6 ns ± 0.14 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)   <- PR
152 ns ± 1.12 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)    <- isinstance(obj, abc.Iterable)

In[8]: %timeit is_list_like(arr2)
50.8 ns ± 1.36 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)   <- master
51.5 ns ± 0.179 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  <- PR
151 ns ± 0.582 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)   <- isinstance(obj, abc.Iterable)
```

- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
