### PR TITLE
BUG: no `label` render in `Styler.to_latex` if `caption` and `"longtable"` 

### DIFF
--- a/pandas/io/formats/templates/latex_longtable.tpl
+++ b/pandas/io/formats/templates/latex_longtable.tpl
@@ -23,6 +23,11 @@
 {%- if label is not none %}
  \label{{label}}
 {%- endif %} \\
+{% else %}
+{%- set label = parse_table(table_styles, 'label') %}
+{%- if label is not none %}
+ \label{{label}} \\
+{%- endif %}
 {% endif %}
 {% set toprule = parse_table(table_styles, 'toprule') %}
 {% if toprule is not none %}

--- a/pandas/io/formats/templates/latex_longtable.tpl
+++ b/pandas/io/formats/templates/latex_longtable.tpl
@@ -26,8 +26,8 @@
 {% else %}
 {%- set label = parse_table(table_styles, 'label') %}
 {%- if label is not none %}
- \label{{label}} \\
-{%- endif %}
+\label{{label}} \\
+{% endif %}
 {% endif %}
 {% set toprule = parse_table(table_styles, 'toprule') %}
 {% if toprule is not none %}

--- a/pandas/tests/io/formats/style/test_to_latex.py
+++ b/pandas/tests/io/formats/style/test_to_latex.py
@@ -111,9 +111,9 @@ def test_position(styler):
 
 @pytest.mark.parametrize("env", [None, "longtable"])
 def test_label(styler, env):
-    assert "\\label{text}" in styler.to_latex(label="text", environment=env)
+    assert "\n\\label{text}" in styler.to_latex(label="text", environment=env)
     styler.set_table_styles([{"selector": "label", "props": ":{more §text}"}])
-    assert "\\label{more :text}" in styler.to_latex(environment=env)
+    assert "\n\\label{more :text}" in styler.to_latex(environment=env)
 
 
 def test_position_float_raises(styler):

--- a/pandas/tests/io/formats/style/test_to_latex.py
+++ b/pandas/tests/io/formats/style/test_to_latex.py
@@ -109,10 +109,11 @@ def test_position(styler):
     assert "\\end{table}" in styler.to_latex()
 
 
-def test_label(styler):
-    assert "\\label{text}" in styler.to_latex(label="text")
+@pytest.mark.parametrize("env", [None, "longtable"])
+def test_label(styler, env):
+    assert "\\label{text}" in styler.to_latex(label="text", environment=env)
     styler.set_table_styles([{"selector": "label", "props": ":{more §text}"}])
-    assert "\\label{more :text}" in styler.to_latex()
+    assert "\\label{more :text}" in styler.to_latex(environment=env)
 
 
 def test_position_float_raises(styler):


### PR DESCRIPTION
No whats new this is a 1.4.0 feature fix.
