### PR TITLE
BUG?: `hide_columns` now doesn't hide index names

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -76,7 +76,7 @@ Styler
   - :meth:`.Styler.bar` introduces additional arguments to control alignment and display (:issue:`26070`, :issue:`36419`), and it also validates the input arguments ``width`` and ``height`` (:issue:`42511`).
   - :meth:`.Styler.to_latex` introduces keyword argument ``environment``, which also allows a specific "longtable" entry through a separate jinja2 template (:issue:`41866`).
   - :meth:`.Styler.to_html` introduces keyword arguments ``sparse_index``, ``sparse_columns``, ``bold_headers``, ``caption`` (:issue:`41946`, :issue:`43149`).
-  - Keyword argument ``level`` is added to :meth:`.Styler.hide_index` and :meth:`.Styler.hide_columns` for optionally controlling hidden levels in a MultiIndex (:issue:`25475`)
+  - Keyword arguments ``level`` and ``names`` added to :meth:`.Styler.hide_index` and :meth:`.Styler.hide_columns` for additional control of visibility of MultiIndexes and index names (:issue:`25475`, :issue:`43404`, :issue:`43346`)
   - Global options have been extended to configure default ``Styler`` properties including formatting and encoding and mathjax options and LaTeX (:issue:`41395`)
 
 Formerly Styler relied on ``display.html.use_mathjax``, which has now been replaced by ``styler.html.mathjax``.

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -387,7 +387,6 @@ class StylerRenderer:
             self.data.index.names
             and com.any_not_none(*self.data.index.names)
             and not all(self.hide_index_)
-            and not all(self.hide_columns_)
             and not self.hide_index_names
         ):
             index_names = [

--- a/pandas/tests/io/formats/style/test_style.py
+++ b/pandas/tests/io/formats/style/test_style.py
@@ -1063,7 +1063,7 @@ class TestStyler:
         self.df.index.name = "some_name"
         ctx = self.df.style.hide_columns()._translate(True, True)
         assert len(ctx["head"]) == 1
-        # no header for index names, changed in #42101, reverted in xxxxx
+        # index names still visible, changed in #42101, reverted in 43404
 
     def test_hide_single_index(self):
         # GH 14194

--- a/pandas/tests/io/formats/style/test_style.py
+++ b/pandas/tests/io/formats/style/test_style.py
@@ -1062,7 +1062,8 @@ class TestStyler:
 
         self.df.index.name = "some_name"
         ctx = self.df.style.hide_columns()._translate(True, True)
-        assert len(ctx["head"]) == 0  # no header for index names, changed in #42101
+        assert len(ctx["head"]) == 1
+        # no header for index names, changed in #42101, reverted in xxxxx
 
     def test_hide_single_index(self):
         # GH 14194


### PR DESCRIPTION
After #43346 it is now possible to control index names visibility. This PR adds full flexibility.
This actually reverts #42839, but only because there is now an explicit method to hide index names.

Also linking this to an old master tracker #24546.

<img width="644" alt="Screenshot 2021-09-04 at 20 51 13" src="https://user-images.githubusercontent.com/24256554/132105167-f6a202c1-d2bb-4b1a-aabc-905ec1697321.png">
<img width="564" alt="Screenshot 2021-09-04 at 20 50 46" src="https://user-images.githubusercontent.com/24256554/132105172-7de05beb-d270-4792-9a86-262cc3f80660.png">

