### PR TITLE
ENH: Add Redis IO functionality

### DIFF
--- a/doc/source/reference/io.rst
+++ b/doc/source/reference/io.rst
@@ -157,7 +157,7 @@ ORC
    :toctree: api/
 
    read_orc
-   
+
 Redis
 ~~~~
 .. autosummary::

--- a/doc/source/reference/io.rst
+++ b/doc/source/reference/io.rst
@@ -157,6 +157,14 @@ ORC
    :toctree: api/
 
    read_orc
+   
+Redis
+~~~~
+.. autosummary::
+   :toctree: api/
+
+   read_redis
+   DataFrame.to_redis
 
 SAS
 ~~~

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -93,6 +93,23 @@ Multithreaded CSV reading with a new CSV Engine based on pyarrow
 :func:`pandas.read_csv` now accepts ``engine="pyarrow"`` (requires at least ``pyarrow`` 0.17.0) as an argument, allowing for faster csv parsing on multicore machines
 with pyarrow installed. See the :doc:`I/O docs </user_guide/io>` for more info. (:issue:`23697`)
 
+.. _whatsnew_140.enhancements.redis_io:
+
+Redis IO Functionality
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+We've added Redis to our supported IO capabilities. This allows one to serialize DataFrame obects to and from Redis, while maintaining datatypes. (:issue:`43415`) 
+
+.. code-block:: python 
+
+    import pandas as pd 
+    import redis
+
+    df = pd.DataFrame(data=[1.2.3], columns=['A'. 'B', 'C'])
+    
+    redis_conn = redis.StrictRedis(host="your host", port=6379, db=0)
+
+    df.redis.to_redis(redis_conn, alias="test")
+
 .. _whatsnew_140.enhancements.other:
 
 Other enhancements

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -108,7 +108,7 @@ We've added Redis to our supported IO capabilities. This allows one to serialize
     
     redis_conn = redis.StrictRedis(host="your host", port=6379, db=0)
 
-    df.redis.to_redis(redis_conn, alias="test")
+    df.to_redis(redis_conn, alias="test")
 
 .. _whatsnew_140.enhancements.other:
 

--- a/environment.yml
+++ b/environment.yml
@@ -63,6 +63,7 @@ dependencies:
   - pytest-xdist>=1.31
   - pytest-asyncio
   - pytest-instafail
+  
   #redis IO testing
   - fakeredis
 

--- a/environment.yml
+++ b/environment.yml
@@ -63,6 +63,8 @@ dependencies:
   - pytest-xdist>=1.31
   - pytest-asyncio
   - pytest-instafail
+  #redis IO testing
+  - fakeredis
 
   # downstream tests
   - seaborn
@@ -98,6 +100,9 @@ dependencies:
   - xlsxwriter
   - xlwt
   - odfpy
+
+  #pd.read_redis, DataFrame.to_redis
+  - redis
 
   - fastparquet>=0.4.0  # pandas.read_parquet, DataFrame.to_parquet
   - pyarrow>=0.17.0  # pandas.read_parquet, DataFrame.to_parquet, pandas.read_feather, DataFrame.to_feather

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -165,6 +165,7 @@ from pandas.io.api import (
     read_stata,
     read_sas,
     read_spss,
+    read_redis,
 )
 
 from pandas.io.json import _json_normalize as json_normalize

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2335,27 +2335,25 @@ class DataFrame(NDFrame, OpsMixin):
 
         Parameters
         ----------
-        :param redis_conn: Redis connection object created by the python-redis library
-        :type redis_conn: redis.client.Redis
-        :param alias: String used to reference the cached dataframe in redis, defaults to a randomly generated UUID. This can be accessed after caching via df.redis.alias
-        :type alias: str, optional
-        :param if_exists: How to handle an alias that already exists, options are "Overwrite", "Append", "Duplicate", "Quit". Note that duplicate will generate a UUID alias for the new cached DataFrame, defaults to "Overwrite"
-        :type if_exists: str, optional
+        redis_conn: redis.client.Redis
+            Redis connection object created by the python-redis library
+        alias: str, default None
+            String used to reference the cached dataframe in redis, defaults to a randomly generated UUID. This can be accessed after caching via df.redis.alias
+        if_exists: str, default "Overwrite"
+             How to handle an alias that already exists, options are "Overwrite", "Append", "Duplicate", "Quit". Note that duplicate will generate a UUID alias for the new cached DataFrame, defaults to "Overwrite"
 
-        .. highlight::
+        Example
+        -------
+         >>> import pandas as pd
+         >>> import redis
 
-            import pandas as pd
-            import redis
+         >>> df = pd.DataFrame(data=[1.2.3], columns=['A'. 'B', 'C'])
 
-            df = pd.DataFrame(data=[1.2.3], columns=['A'. 'B', 'C'])
+         >>> redis_conn = redis.StrictRedis(host="your host", port=6379, db=0)
 
-            redis_conn = redis.StrictRedis(host="your host", port=6379, db=0)
+         >>> df.redis.to_redis(redis_conn, alias="test")
 
-            df.redis.to_redis(redis_conn, alias="test")
-
-            alias = df.redis.alias
-
-        .. highlight::
+         >>> alias = df.redis.alias
 
         See Also
         --------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2317,20 +2317,21 @@ class DataFrame(NDFrame, OpsMixin):
 
         return np.rec.fromarrays(arrays, dtype={"names": names, "formats": formats})
 
-    def to_redis(self, 
-        redis_conn: redis.client.Redis, 
-        alias:str = None, 
-        if_exists:str = "Overwrite"
-        ):
-        """ Pandas IO method to cache a Dataframe to Redis. This uses pyarrow to serialize the Dataframe and stores it as a string value in Redis. 
+    def to_redis(
+        self,
+        redis_conn: redis.client.Redis,
+        alias: str = None,
+        if_exists: str = "Overwrite",
+    ):
+        """Pandas IO method to cache a Dataframe to Redis. This uses pyarrow to serialize the Dataframe and stores it as a string value in Redis.
 
-        *Note* Redis has a 512 MB limit on values, so If the serialized Dataframe is over 512MB, a ValueError will be raised. 
+        *Note* Redis has a 512 MB limit on values, so If the serialized Dataframe is over 512MB, a ValueError will be raised.
 
-        If you are using if_exists="Append", the following logic is applied: 
-            - If the existing DataFrame has columns that don't exist in the new DataFrame, we just append which will add values to the columns that exist in the new DataFrame. 
-            - If the new DataFrame has columns that don't exist in the existing DataFrame, we throw an error. This is due to a desire to maintain integrity of what has already been cached. 
+        If you are using if_exists="Append", the following logic is applied:
+            - If the existing DataFrame has columns that don't exist in the new DataFrame, we just append which will add values to the columns that exist in the new DataFrame.
+            - If the new DataFrame has columns that don't exist in the existing DataFrame, we throw an error. This is due to a desire to maintain integrity of what has already been cached.
 
-        This operation is registered with Pandas under the redis namespace once installed. See example usage below: 
+        This operation is registered with Pandas under the redis namespace once installed. See example usage below:
 
         Parameters
         ----------
@@ -2343,32 +2344,28 @@ class DataFrame(NDFrame, OpsMixin):
 
         .. highlight::
 
-            import pandas as pd 
+            import pandas as pd
             import redis
 
             df = pd.DataFrame(data=[1.2.3], columns=['A'. 'B', 'C'])
-            
+
             redis_conn = redis.StrictRedis(host="your host", port=6379, db=0)
 
             df.redis.to_redis(redis_conn, alias="test")
 
             alias = df.redis.alias
-        
+
         .. highlight::
 
         See Also
         --------
         read_redis : Read a DataFrame from Redis.
         """
-        
+
         from pandas.io import redis
 
         redpandas = Redis_IO(pandas_obj=self)
-        redpandas.to_redis(
-            redis_conn=redis_conn, 
-            alias=alias,
-            if_exists=if_exists
-        )
+        redpandas.to_redis(redis_conn=redis_conn, alias=alias, if_exists=if_exists)
 
     @classmethod
     def _from_arrays(

--- a/pandas/io/api.py
+++ b/pandas/io/api.py
@@ -29,6 +29,7 @@ from pandas.io.pytables import (
     HDFStore,
     read_hdf,
 )
+from pandas.io.redis import read_redis
 from pandas.io.sas import read_sas
 from pandas.io.spss import read_spss
 from pandas.io.sql import (
@@ -38,5 +39,3 @@ from pandas.io.sql import (
 )
 from pandas.io.stata import read_stata
 from pandas.io.xml import read_xml
-
-from pandas.io.redis import read_redis

--- a/pandas/io/api.py
+++ b/pandas/io/api.py
@@ -38,3 +38,5 @@ from pandas.io.sql import (
 )
 from pandas.io.stata import read_stata
 from pandas.io.xml import read_xml
+
+from pandas.io.redis import read_redis

--- a/pandas/io/redis.py
+++ b/pandas/io/redis.py
@@ -1,9 +1,11 @@
-import pandas as pd 
-import pickle
 import logging
+import pickle
 import uuid
 
 from pandas.compat._optional import import_optional_dependency
+
+import pandas as pd
+
 
 def _try_import():
     # since pandas is a dependency of redis
@@ -15,55 +17,68 @@ def _try_import():
     redis = import_optional_dependency("redis", extra=msg)
     return redis
 
+
 redis = _try_import()
 
+
 class Redis_IO:
-    """ Core module for caching Pandas DataFrames to Redis. 
-    """
-    def __init__(self,  pandas_obj: pd.DataFrame):
+    """Core module for caching Pandas DataFrames to Redis."""
+
+    def __init__(self, pandas_obj: pd.DataFrame):
         self._validate(pandas_obj)
         self.obj = pandas_obj
         self.alias = None
-        self.logger = logging.getLogger('Redis_IO')
+        self.logger = logging.getLogger("Redis_IO")
         self.to_cache = pandas_obj
 
     @staticmethod
     def _validate(obj: pd.DataFrame):
         """Simple method to validate that the method is being attached to a DataFame and not any other type.
 
-        :param obj: object being chained via the namespace. 
+        :param obj: object being chained via the namespace.
         :type obj: pd.DataFrame
         :raises TypeError: Not a DataFrame
         """
         if not isinstance(obj, pd.DataFrame):
-            raise TypeError(f"Object to cache should be of type DataFrame, but is {type(obj)}")
-    
-    def _validate_conn(self,redis_conn: redis.client.Redis):
+            raise TypeError(
+                f"Object to cache should be of type DataFrame, but is {type(obj)}"
+            )
+
+    def _validate_conn(self, redis_conn: redis.client.Redis):
         """Helper method to verify Redis connectivity
 
-        :param redis_conn: 
+        :param redis_conn:
         :type redis_conn: redis.client.Redis
         :raises TypeError: Not a Redis connection object
-        :raises ConnectionError: Can't connect to Redis, wrapper to the specific connection error from the Redis library 
+        :raises ConnectionError: Can't connect to Redis, wrapper to the specific connection error from the Redis library
         """
         if not isinstance(redis_conn, redis.client.Redis):
-            raise TypeError(f"Redis connection object should be of type redis.Client.Redis but is {type(redis_conn)}")
-        try: 
+            raise TypeError(
+                f"Redis connection object should be of type redis.Client.Redis but is {type(redis_conn)}"
+            )
+        try:
             redis_conn.ping()
             self.logger.info("Connected to Redis")
         except redis.exceptions.ConnectionError as r_con_error:
-            raise ConnectionError(f"Cannot connect to Redis instance: f{str(r_con_error)}")
-    
-    def to_redis(self, redis_conn: redis.client.Redis, alias:str = None, if_exists:str = "Overwrite"):
-        """ Pandas IO method to cache a Dataframe to Redis. This uses pickle (previously PyArrow, but the serialization was deprecated) to serialize the Dataframe and stores it as a string value in Redis. 
+            raise ConnectionError(
+                f"Cannot connect to Redis instance: f{str(r_con_error)}"
+            )
 
-        *Note* Redis has a 512 MB limit on values, so If the serialized Dataframe is over 512MB, a ValueError will be raised. 
+    def to_redis(
+        self,
+        redis_conn: redis.client.Redis,
+        alias: str = None,
+        if_exists: str = "Overwrite",
+    ):
+        """Pandas IO method to cache a Dataframe to Redis. This uses pickle (previously PyArrow, but the serialization was deprecated) to serialize the Dataframe and stores it as a string value in Redis.
 
-        If you are using if_exists="Append", the following logic is applied: 
-            - If the existing DataFrame has columns that don't exist in the new DataFrame, we just append which will add values to the columns that exist in the new DataFrame. 
-            - If the new DataFrame has columns that don't exist in the existing DataFrame, we throw an error. This is due to a desire to maintain integrity of what has already been cached. 
+        *Note* Redis has a 512 MB limit on values, so If the serialized Dataframe is over 512MB, a ValueError will be raised.
 
-        This operation is registered with Pandas under the redis namespace once installed. See example usage below: 
+        If you are using if_exists="Append", the following logic is applied:
+            - If the existing DataFrame has columns that don't exist in the new DataFrame, we just append which will add values to the columns that exist in the new DataFrame.
+            - If the new DataFrame has columns that don't exist in the existing DataFrame, we throw an error. This is due to a desire to maintain integrity of what has already been cached.
+
+        This operation is registered with Pandas under the redis namespace once installed. See example usage below:
 
         Parameters
         ----------
@@ -76,68 +91,73 @@ class Redis_IO:
 
         .. highlight::
 
-            import pandas as pd 
+            import pandas as pd
             import redis
 
             df = pd.DataFrame(data=[1.2.3], columns=['A'. 'B', 'C'])
-            
+
             redis_conn = redis.StrictRedis(host="your host", port=6379, db=0)
 
             df.redis.to_redis(redis_conn, alias="test")
 
             alias = df.redis.alias
-        
+
         .. highlight::
         """
 
-        if if_exists.upper() not in ["OVERWRITE", "APPEND", "DUPLICATE", "QUIT"]: 
-            raise ValueError(f"Keyword argument if_exists must be one of 'Overwrite', 'Append', 'Quit' or  'Duplicate', but recieved {if_exists}")
-        
-        alias = alias if alias != None else str(uuid.uuid4()) 
-        
+        if if_exists.upper() not in ["OVERWRITE", "APPEND", "DUPLICATE", "QUIT"]:
+            raise ValueError(
+                f"Keyword argument if_exists must be one of 'Overwrite', 'Append', 'Quit' or  'Duplicate', but recieved {if_exists}"
+            )
+
+        alias = alias if alias != None else str(uuid.uuid4())
+
         self._validate_conn(redis_conn)
 
         if redis_conn.exists(alias):
             logging.info(f"{alias} exists")
             if if_exists.upper() == "APPEND":
                 existing_df = pd.read_redis(redis_conn, alias)
-                extra_cols = [col for col in self.obj.columns if col not in existing_df.columns]
+                extra_cols = [
+                    col for col in self.obj.columns if col not in existing_df.columns
+                ]
                 if extra_cols:
-                    raise IndexError(f"Cannot append new DataFrame to one currently in cache. The new Dataframe contains the following extra columns{str(extra_cols)}" )
-                appended_df = existing_df.append(self.obj,ignore_index=True)
+                    raise IndexError(
+                        f"Cannot append new DataFrame to one currently in cache. The new Dataframe contains the following extra columns{str(extra_cols)}"
+                    )
+                appended_df = existing_df.append(self.obj, ignore_index=True)
                 self.to_cache = appended_df
-            elif if_exists.upper() == "DUPLICATE": 
+            elif if_exists.upper() == "DUPLICATE":
                 alias = str(uuid.uuid4())
             elif if_exists.upper() == "QUIT":
                 return
-                        
+
         df_serialzed = pickle.dumps(self.obj)
 
-        res = redis_conn.set(alias,df_serialzed)
+        res = redis_conn.set(alias, df_serialzed)
         if res == True:
             self.alias = alias
-            logging.info('Dataframe cached')
+            logging.info("Dataframe cached")
             logging.info(f"Key {alias}")
 
-            
 
-def read_redis(redis_conn: redis.client.Redis, key:str) -> pd.DataFrame :
-    """ Pandas IO method to retrieve a cached Dataframe. 
-    
+def read_redis(redis_conn: redis.client.Redis, key: str) -> pd.DataFrame:
+    """Pandas IO method to retrieve a cached Dataframe.
+
     Parameters
     ----------
     :param redis_conn: Redis connection object
     :type redis_conn: redis.client.Redis
-    :param key: String used to refer to the cached DataFrame you wish to retrieve. 
+    :param key: String used to refer to the cached DataFrame you wish to retrieve.
     :type key: str
     :raises KeyError: These are not the droids you're looking for.
-    :return: DataFrame retrieved from cache. 
+    :return: DataFrame retrieved from cache.
     :rtype: pd.DataFrame
 
     .. highlight::
-            import pandas as pd 
+            import pandas as pd
             import redis
-            
+
             redis_conn = redis.StrictRedis(host="your host", port=6379, db=0)
 
             df = pd.read_redis(redis_conn, alias="test")

--- a/pandas/io/redis.py
+++ b/pandas/io/redis.py
@@ -98,7 +98,7 @@ class Redis_IO:
 
             redis_conn = redis.StrictRedis(host="your host", port=6379, db=0)
 
-            df.redis.to_redis(redis_conn, alias="test")
+            df.to_redis(redis_conn, alias="test")
 
             alias = df.redis.alias
 

--- a/pandas/io/redis.py
+++ b/pandas/io/redis.py
@@ -1,0 +1,157 @@
+import pandas as pd 
+import pickle
+import logging
+import uuid
+
+from pandas.compat._optional import import_optional_dependency
+
+def _try_import():
+    # since pandas is a dependency of redis
+    # we need to import on first use
+    msg = (
+        "The redis package is required to load data from Redis. "
+        "See the docs: https://pypi.org/project/redis/"
+    )
+    redis = import_optional_dependency("redis", extra=msg)
+    return redis
+
+redis = _try_import()
+
+class Redis_IO:
+    """ Core module for caching Pandas DataFrames to Redis. 
+    """
+    def __init__(self,  pandas_obj: pd.DataFrame):
+        self._validate(pandas_obj)
+        self.obj = pandas_obj
+        self.alias = None
+        self.logger = logging.getLogger('Redis_IO')
+        self.to_cache = pandas_obj
+
+    @staticmethod
+    def _validate(obj: pd.DataFrame):
+        """Simple method to validate that the method is being attached to a DataFame and not any other type.
+
+        :param obj: object being chained via the namespace. 
+        :type obj: pd.DataFrame
+        :raises TypeError: Not a DataFrame
+        """
+        if not isinstance(obj, pd.DataFrame):
+            raise TypeError(f"Object to cache should be of type DataFrame, but is {type(obj)}")
+    
+    def _validate_conn(self,redis_conn: redis.client.Redis):
+        """Helper method to verify Redis connectivity
+
+        :param redis_conn: 
+        :type redis_conn: redis.client.Redis
+        :raises TypeError: Not a Redis connection object
+        :raises ConnectionError: Can't connect to Redis, wrapper to the specific connection error from the Redis library 
+        """
+        if not isinstance(redis_conn, redis.client.Redis):
+            raise TypeError(f"Redis connection object should be of type redis.Client.Redis but is {type(redis_conn)}")
+        try: 
+            redis_conn.ping()
+            self.logger.info("Connected to Redis")
+        except redis.exceptions.ConnectionError as r_con_error:
+            raise ConnectionError(f"Cannot connect to Redis instance: f{str(r_con_error)}")
+    
+    def to_redis(self, redis_conn: redis.client.Redis, alias:str = None, if_exists:str = "Overwrite"):
+        """ Pandas IO method to cache a Dataframe to Redis. This uses pickle (previously PyArrow, but the serialization was deprecated) to serialize the Dataframe and stores it as a string value in Redis. 
+
+        *Note* Redis has a 512 MB limit on values, so If the serialized Dataframe is over 512MB, a ValueError will be raised. 
+
+        If you are using if_exists="Append", the following logic is applied: 
+            - If the existing DataFrame has columns that don't exist in the new DataFrame, we just append which will add values to the columns that exist in the new DataFrame. 
+            - If the new DataFrame has columns that don't exist in the existing DataFrame, we throw an error. This is due to a desire to maintain integrity of what has already been cached. 
+
+        This operation is registered with Pandas under the redis namespace once installed. See example usage below: 
+
+        Parameters
+        ----------
+        :param redis_conn: Redis connection object created by the python-redis library
+        :type redis_conn: redis.client.Redis
+        :param alias: String used to reference the cached dataframe in redis, defaults to a randomly generated UUID. This can be accessed after caching via df.redis.alias
+        :type alias: str, optional
+        :param if_exists: How to handle an alias that already exists, options are "Overwrite", "Append", "Duplicate", "Quit". Note that duplicate will generate a UUID alias for the new cached DataFrame, defaults to "Overwrite"
+        :type if_exists: str, optional
+
+        .. highlight::
+
+            import pandas as pd 
+            import redis
+
+            df = pd.DataFrame(data=[1.2.3], columns=['A'. 'B', 'C'])
+            
+            redis_conn = redis.StrictRedis(host="your host", port=6379, db=0)
+
+            df.redis.to_redis(redis_conn, alias="test")
+
+            alias = df.redis.alias
+        
+        .. highlight::
+        """
+
+        if if_exists.upper() not in ["OVERWRITE", "APPEND", "DUPLICATE", "QUIT"]: 
+            raise ValueError(f"Keyword argument if_exists must be one of 'Overwrite', 'Append', 'Quit' or  'Duplicate', but recieved {if_exists}")
+        
+        alias = alias if alias != None else str(uuid.uuid4()) 
+        
+        self._validate_conn(redis_conn)
+
+        if redis_conn.exists(alias):
+            logging.info(f"{alias} exists")
+            if if_exists.upper() == "APPEND":
+                existing_df = pd.read_redis(redis_conn, alias)
+                extra_cols = [col for col in self.obj.columns if col not in existing_df.columns]
+                if extra_cols:
+                    raise IndexError(f"Cannot append new DataFrame to one currently in cache. The new Dataframe contains the following extra columns{str(extra_cols)}" )
+                appended_df = existing_df.append(self.obj,ignore_index=True)
+                self.to_cache = appended_df
+            elif if_exists.upper() == "DUPLICATE": 
+                alias = str(uuid.uuid4())
+            elif if_exists.upper() == "QUIT":
+                return
+                        
+        df_serialzed = pickle.dumps(self.obj)
+
+        res = redis_conn.set(alias,df_serialzed)
+        if res == True:
+            self.alias = alias
+            logging.info('Dataframe cached')
+            logging.info(f"Key {alias}")
+
+            
+
+def read_redis(redis_conn: redis.client.Redis, key:str) -> pd.DataFrame :
+    """ Pandas IO method to retrieve a cached Dataframe. 
+    
+    Parameters
+    ----------
+    :param redis_conn: Redis connection object
+    :type redis_conn: redis.client.Redis
+    :param key: String used to refer to the cached DataFrame you wish to retrieve. 
+    :type key: str
+    :raises KeyError: These are not the droids you're looking for.
+    :return: DataFrame retrieved from cache. 
+    :rtype: pd.DataFrame
+
+    .. highlight::
+            import pandas as pd 
+            import redis
+            
+            redis_conn = redis.StrictRedis(host="your host", port=6379, db=0)
+
+            df = pd.read_redis(redis_conn, alias="test")
+
+    .. highlight::
+
+    """
+
+    redis_pandas = Redis_IO(pd.DataFrame())
+    redis_pandas._validate_conn(redis_conn)
+
+    if not redis_conn.exists(key):
+        raise KeyError(f"{key} does not exist in the specifed Redis instance")
+
+    serialized_df = redis_conn.get(key)
+    dataframe = pickle.loads(serialized_df)
+    return dataframe

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -164,6 +164,7 @@ class TestPDApi(Base):
         "read_xml",
         "read_json",
         "read_pickle",
+        "read_redis",
         "read_sas",
         "read_sql",
         "read_sql_query",

--- a/pandas/tests/io/test_redis.py
+++ b/pandas/tests/io/test_redis.py
@@ -1,0 +1,149 @@
+import random
+import sys 
+
+import pandas
+import pytest
+
+import redis
+import fakeredis
+
+def generate_df(n_rows: int, n_cols: int) -> pandas.DataFrame:
+    """Method for generating a random Dataframe of n number of rows by n number of columns.
+
+    :param n_rows: Number of rows to populate.
+    :type n_rows: int
+    :param n_cols: Number of columns to populate
+    :type n_cols: int
+    :return: Randomly generated DataFrame
+    :rtype: pd.DataFrame
+    """
+
+    data = []
+    cols = [str(x) for x in range(1, n_cols)]
+    for i in range(1, n_rows):
+        col_vals = [random.randint(1000000, 9999999) for y in range(1, n_cols)]
+        data.append(col_vals)
+
+    df = pandas.DataFrame(data, columns=cols)
+    return df
+
+@pytest.fixture()
+def rp():
+    df = generate_df(50, 8)
+    rp = pandas.io.redis.Redis_IO(df)
+    return rp
+
+
+def test_object_validation_success():
+    """Test that the dataframe validation works on a dataframe
+    """
+    df = generate_df(50, 8)
+    assert pandas.io.redis.Redis_IO(df)
+
+
+def test_object_validation_fails():
+    """Test that the dataframe validation fails on objects other than dataframe
+    """
+    with pytest.raises(TypeError):
+        pandas.io.redis.Redis_IO(5)
+
+
+def test_redis_conn_validation_success(rp):
+    """Test that the Redis connection validation works successfully
+    """
+    assert rp._validate_conn(fakeredis.FakeStrictRedis()) is None
+
+
+def test_redis_conn_validation_connection_failure(rp):
+    """Test that the Redis connection validation successfully errors when it can't connect to the provided Redis instance 
+    """
+    conn = redis.StrictRedis(host="fake_host", port=6379, db=0)
+
+    with pytest.raises(ConnectionError):
+        rp._validate_conn(conn)
+
+
+def test_to_redis_invalid_exists_param(rp):
+    """Test that the to_redis method enforces allowed values for the if_exists param
+    """
+
+    with pytest.raises(ValueError):
+        rp.to_redis(fakeredis.FakeStrictRedis(), if_exists="Do Nothing")
+
+def test_to_redis_if_exists_quit_success(rp):
+    """Test that the to_redis method successfully returns when if_exists="Append"
+    """
+    conn = fakeredis.FakeStrictRedis()
+    rp.to_redis(conn, alias='quit')
+
+    df2 = generate_df(50, 8)
+    rp2 = pandas.io.redis.Redis_IO(df2)
+    assert rp2.to_redis(conn, alias='quit', if_exists="Quit") is None
+
+
+
+def test_to_redis_if_exists_append_success(rp):
+    """Test that the to_redis method successfully appends a given dataframe to the existing DataFrame when if_exists="Append"
+    """
+    conn = fakeredis.FakeStrictRedis()
+    rp.to_redis(conn, alias='append')
+
+    df2 = generate_df(50, 8)
+    rp2 = pandas.io.redis.Redis_IO(df2)
+    assert rp2.to_redis(conn, alias='append', if_exists="Append") is None
+    assert rp2.alias == "append"
+
+
+def test_to_redis_if_exists_append_less_columns_success(rp):
+    """Test that the to_redis method successfully appends a given dataframe to the existing DataFrame when if_exists="Append" and the new DataFrame has a subset of columns of the cached DataFrame. 
+    """
+    conn = fakeredis.FakeStrictRedis()
+    rp.to_redis(conn, alias='append')
+
+    df2 = generate_df(50, 6) 
+    rp2 = pandas.io.redis.Redis_IO(df2)
+    assert rp2.to_redis(conn, alias='append', if_exists="Append") is None
+
+def test_to_redis_if_exists_append_more_columns_error(rp):
+    """Test that the to_redis method fails to append a given dataframe to the existing DataFrame when if_exists="Append" and the new DataFrame has columns that are not present in the cached DataFrame. 
+    """
+    conn = fakeredis.FakeStrictRedis()
+    rp.to_redis(conn, alias='append')
+
+    df2 = generate_df(50, 10) 
+    rp2 = pandas.io.redis.Redis_IO(df2)
+    with pytest.raises(IndexError):
+        rp2.to_redis(conn, alias='append', if_exists="Append")
+
+def test_to_redis_if_exists_duplicate_success(rp):
+    """Test that the to_redis method successfully duplicates a given dataframe when if_exists="Duplicate". 
+    """
+    conn = fakeredis.FakeStrictRedis()
+    rp.to_redis(conn, alias='duplicate')
+
+    df2 = generate_df(50, 8)
+    rp2 = pandas.io.redis.Redis_IO(df2)
+    assert rp2.to_redis(conn, alias='duplicate', if_exists="Duplicate") is None
+
+def test_to_redis_success(rp):
+    """Test that the to_redis method successfully caches a given DataFrame. 
+    """
+    assert rp.to_redis(fakeredis.FakeStrictRedis(), alias='SuccessfulTest') is None
+    assert rp.alias == 'SuccessfulTest'
+
+
+def test_read_redis_doesnt_exist_error():
+    """Test that the read_redis method throws an error when the requested key does not exist
+    """
+    with pytest.raises(KeyError):
+        pandas.io.redis.read_redis(fakeredis.FakeStrictRedis(), "DoesntExist")
+    
+
+def test_read_redis_success(rp):
+    """Test that the read_redis method successfully retrieves a cached DataFrame.
+    """
+    conn = fakeredis.FakeStrictRedis()
+    rp.to_redis(conn, alias='readRedis')
+    
+    assert pandas.io.redis.read_redis(redis_conn=conn, key="readRedis") is not None
+

--- a/pandas/tests/io/test_redis.py
+++ b/pandas/tests/io/test_redis.py
@@ -1,11 +1,12 @@
 import random
-import sys 
+import sys
+
+import fakeredis
+import pytest
+import redis
 
 import pandas
-import pytest
 
-import redis
-import fakeredis
 
 def generate_df(n_rows: int, n_cols: int) -> pandas.DataFrame:
     """Method for generating a random Dataframe of n number of rows by n number of columns.
@@ -27,6 +28,7 @@ def generate_df(n_rows: int, n_cols: int) -> pandas.DataFrame:
     df = pandas.DataFrame(data, columns=cols)
     return df
 
+
 @pytest.fixture()
 def rp():
     df = generate_df(50, 8)
@@ -35,28 +37,24 @@ def rp():
 
 
 def test_object_validation_success():
-    """Test that the dataframe validation works on a dataframe
-    """
+    """Test that the dataframe validation works on a dataframe"""
     df = generate_df(50, 8)
     assert pandas.io.redis.Redis_IO(df)
 
 
 def test_object_validation_fails():
-    """Test that the dataframe validation fails on objects other than dataframe
-    """
+    """Test that the dataframe validation fails on objects other than dataframe"""
     with pytest.raises(TypeError):
         pandas.io.redis.Redis_IO(5)
 
 
 def test_redis_conn_validation_success(rp):
-    """Test that the Redis connection validation works successfully
-    """
+    """Test that the Redis connection validation works successfully"""
     assert rp._validate_conn(fakeredis.FakeStrictRedis()) is None
 
 
 def test_redis_conn_validation_connection_failure(rp):
-    """Test that the Redis connection validation successfully errors when it can't connect to the provided Redis instance 
-    """
+    """Test that the Redis connection validation successfully errors when it can't connect to the provided Redis instance"""
     conn = redis.StrictRedis(host="fake_host", port=6379, db=0)
 
     with pytest.raises(ConnectionError):
@@ -64,86 +62,79 @@ def test_redis_conn_validation_connection_failure(rp):
 
 
 def test_to_redis_invalid_exists_param(rp):
-    """Test that the to_redis method enforces allowed values for the if_exists param
-    """
+    """Test that the to_redis method enforces allowed values for the if_exists param"""
 
     with pytest.raises(ValueError):
         rp.to_redis(fakeredis.FakeStrictRedis(), if_exists="Do Nothing")
 
+
 def test_to_redis_if_exists_quit_success(rp):
-    """Test that the to_redis method successfully returns when if_exists="Append"
-    """
+    """Test that the to_redis method successfully returns when if_exists="Append" """
     conn = fakeredis.FakeStrictRedis()
-    rp.to_redis(conn, alias='quit')
+    rp.to_redis(conn, alias="quit")
 
     df2 = generate_df(50, 8)
     rp2 = pandas.io.redis.Redis_IO(df2)
-    assert rp2.to_redis(conn, alias='quit', if_exists="Quit") is None
-
+    assert rp2.to_redis(conn, alias="quit", if_exists="Quit") is None
 
 
 def test_to_redis_if_exists_append_success(rp):
-    """Test that the to_redis method successfully appends a given dataframe to the existing DataFrame when if_exists="Append"
-    """
+    """Test that the to_redis method successfully appends a given dataframe to the existing DataFrame when if_exists="Append" """
     conn = fakeredis.FakeStrictRedis()
-    rp.to_redis(conn, alias='append')
+    rp.to_redis(conn, alias="append")
 
     df2 = generate_df(50, 8)
     rp2 = pandas.io.redis.Redis_IO(df2)
-    assert rp2.to_redis(conn, alias='append', if_exists="Append") is None
+    assert rp2.to_redis(conn, alias="append", if_exists="Append") is None
     assert rp2.alias == "append"
 
 
 def test_to_redis_if_exists_append_less_columns_success(rp):
-    """Test that the to_redis method successfully appends a given dataframe to the existing DataFrame when if_exists="Append" and the new DataFrame has a subset of columns of the cached DataFrame. 
-    """
+    """Test that the to_redis method successfully appends a given dataframe to the existing DataFrame when if_exists="Append" and the new DataFrame has a subset of columns of the cached DataFrame."""
     conn = fakeredis.FakeStrictRedis()
-    rp.to_redis(conn, alias='append')
+    rp.to_redis(conn, alias="append")
 
-    df2 = generate_df(50, 6) 
+    df2 = generate_df(50, 6)
     rp2 = pandas.io.redis.Redis_IO(df2)
-    assert rp2.to_redis(conn, alias='append', if_exists="Append") is None
+    assert rp2.to_redis(conn, alias="append", if_exists="Append") is None
+
 
 def test_to_redis_if_exists_append_more_columns_error(rp):
-    """Test that the to_redis method fails to append a given dataframe to the existing DataFrame when if_exists="Append" and the new DataFrame has columns that are not present in the cached DataFrame. 
-    """
+    """Test that the to_redis method fails to append a given dataframe to the existing DataFrame when if_exists="Append" and the new DataFrame has columns that are not present in the cached DataFrame."""
     conn = fakeredis.FakeStrictRedis()
-    rp.to_redis(conn, alias='append')
+    rp.to_redis(conn, alias="append")
 
-    df2 = generate_df(50, 10) 
+    df2 = generate_df(50, 10)
     rp2 = pandas.io.redis.Redis_IO(df2)
     with pytest.raises(IndexError):
-        rp2.to_redis(conn, alias='append', if_exists="Append")
+        rp2.to_redis(conn, alias="append", if_exists="Append")
+
 
 def test_to_redis_if_exists_duplicate_success(rp):
-    """Test that the to_redis method successfully duplicates a given dataframe when if_exists="Duplicate". 
-    """
+    """Test that the to_redis method successfully duplicates a given dataframe when if_exists="Duplicate"."""
     conn = fakeredis.FakeStrictRedis()
-    rp.to_redis(conn, alias='duplicate')
+    rp.to_redis(conn, alias="duplicate")
 
     df2 = generate_df(50, 8)
     rp2 = pandas.io.redis.Redis_IO(df2)
-    assert rp2.to_redis(conn, alias='duplicate', if_exists="Duplicate") is None
+    assert rp2.to_redis(conn, alias="duplicate", if_exists="Duplicate") is None
+
 
 def test_to_redis_success(rp):
-    """Test that the to_redis method successfully caches a given DataFrame. 
-    """
-    assert rp.to_redis(fakeredis.FakeStrictRedis(), alias='SuccessfulTest') is None
-    assert rp.alias == 'SuccessfulTest'
+    """Test that the to_redis method successfully caches a given DataFrame."""
+    assert rp.to_redis(fakeredis.FakeStrictRedis(), alias="SuccessfulTest") is None
+    assert rp.alias == "SuccessfulTest"
 
 
 def test_read_redis_doesnt_exist_error():
-    """Test that the read_redis method throws an error when the requested key does not exist
-    """
+    """Test that the read_redis method throws an error when the requested key does not exist"""
     with pytest.raises(KeyError):
         pandas.io.redis.read_redis(fakeredis.FakeStrictRedis(), "DoesntExist")
-    
+
 
 def test_read_redis_success(rp):
-    """Test that the read_redis method successfully retrieves a cached DataFrame.
-    """
+    """Test that the read_redis method successfully retrieves a cached DataFrame."""
     conn = fakeredis.FakeStrictRedis()
-    rp.to_redis(conn, alias='readRedis')
-    
-    assert pandas.io.redis.read_redis(redis_conn=conn, key="readRedis") is not None
+    rp.to_redis(conn, alias="readRedis")
 
+    assert pandas.io.redis.read_redis(redis_conn=conn, key="readRedis") is not None

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -41,6 +41,7 @@ pytest-cov
 pytest-xdist>=1.31
 pytest-asyncio
 pytest-instafail
+fakeredis
 seaborn
 statsmodels
 ipywidgets
@@ -64,6 +65,7 @@ xlrd
 xlsxwriter
 xlwt
 odfpy
+redis
 fastparquet>=0.4.0
 pyarrow>=0.17.0
 python-snappy


### PR DESCRIPTION
Adds two primary IO methods: to_redis() and read_redis() 

TL;DR: Serializes DataFrames in and out of Redis. I've used a version of this code in production previously to share a cached DF across multiple worker processes. 

- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [x] whatsnew entry
