### PR TITLE
DOC: Modify pandas.ExcelWriter default engine in docstring (#43359)

### DIFF
--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -647,7 +647,7 @@ class ExcelWriter(metaclass=abc.ABCMeta):
     """
     Class for writing DataFrame objects into excel sheets.
 
-    Default is to use xlwt for xls, openpyxl for xlsx, odf for ods.
+    Default is to use xlwt for xls, xlsxwriter for xlsx, odf for ods.
     See DataFrame.to_excel for typical usage.
 
     The writer should be used as a context manager. Otherwise, call `close()` to save
@@ -721,14 +721,14 @@ class ExcelWriter(metaclass=abc.ABCMeta):
     Default usage:
 
     >>> df = pd.DataFrame([["ABC", "XYZ"]], columns=["Foo", "Bar"])
-    >>> with ExcelWriter("path_to_file.xlsx") as writer:
+    >>> with pd.ExcelWriter("path_to_file.xlsx") as writer:
     ...     df.to_excel(writer)
 
     To write to separate sheets in a single file:
 
     >>> df1 = pd.DataFrame([["AAA", "BBB"]], columns=["Spam", "Egg"])
     >>> df2 = pd.DataFrame([["ABC", "XYZ"]], columns=["Foo", "Bar"])
-    >>> with ExcelWriter("path_to_file.xlsx") as writer:
+    >>> with pd.ExcelWriter("path_to_file.xlsx") as writer:
     ...     df1.to_excel(writer, sheet_name="Sheet1")
     ...     df2.to_excel(writer, sheet_name="Sheet2")
 
@@ -743,7 +743,7 @@ class ExcelWriter(metaclass=abc.ABCMeta):
     ...     index=["Date", "Datetime"],
     ...     columns=["X", "Y"],
     ... )
-    >>> with ExcelWriter(
+    >>> with pd.ExcelWriter(
     ...     "path_to_file.xlsx",
     ...     date_format="YYYY-MM-DD",
     ...     datetime_format="YYYY-MM-DD HH:MM:SS"
@@ -752,7 +752,7 @@ class ExcelWriter(metaclass=abc.ABCMeta):
 
     You can also append to an existing Excel file:
 
-    >>> with ExcelWriter("path_to_file.xlsx", mode="a", engine="openpyxl") as writer:
+    >>> with pd.ExcelWriter("path_to_file.xlsx", mode="a", engine="openpyxl") as writer:
     ...     df.to_excel(writer, sheet_name="Sheet3")
 
     You can store Excel file in RAM:

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -647,7 +647,10 @@ class ExcelWriter(metaclass=abc.ABCMeta):
     """
     Class for writing DataFrame objects into excel sheets.
 
-    Default is to use xlwt for xls, xlsxwriter for xlsx, odf for ods.
+    Default is to use :
+    * xlwt for xls
+    * xlsxwriter for xlsx if xlsxwriter is installed otherwise openpyxl
+    * odf for ods.
     See DataFrame.to_excel for typical usage.
 
     The writer should be used as a context manager. Otherwise, call `close()` to save
@@ -1103,7 +1106,7 @@ def inspect_excel_format(
         return "zip"
 
 
-class ExcelFile:
+jupyterclass ExcelFile:
     """
     Class for parsing tabular excel sheets into DataFrame objects.
 

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -1106,7 +1106,7 @@ def inspect_excel_format(
         return "zip"
 
 
-jupyterclass ExcelFile:
+class ExcelFile:
     """
     Class for parsing tabular excel sheets into DataFrame objects.
 


### PR DESCRIPTION
* engine for xlsx : xlsxwriter instead of openpyxl
* correction to pass the doctest

- [x] closes #43359
- [x] tests added / passed : script/validate_docstrings.py detected 3 errors before my pull request. It's now resolved
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them : black pandas didn't change anything
- [x] whatsnew entry : one word changed in docstring


Script validate_docstings report : [validate_docstrings.txt](https://github.com/pandas-dev/pandas/files/7117843/validate_docstrings.txt)
