### PR TITLE
DOC: add links to pre-commit in contributing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 - [ ] closes #xxxx
 - [ ] tests added / passed
-- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
+- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
 - [ ] whatsnew entry

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -334,7 +334,7 @@ can comment::
 on that pull request. This will trigger a workflow which will autofix formatting
 errors. To automatically fix formatting errors on each commit you make, you can
 set up pre-commit yourself. First, create a Python :ref:`environment
-<contributing.python-env>` , and then set up :ref:`pre-commit <contributing.pre-commit>`
+<contributing.python-env>` , and then set up :ref:`pre-commit <contributing.pre-commit>`.
 
 Delete your merged branch (optional)
 ------------------------------------

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -331,7 +331,10 @@ can comment::
 
     @github-actions pre-commit
 
-on that pull request. This will trigger a workflow which will autofix formatting errors.
+on that pull request. This will trigger a workflow which will autofix formatting
+errors. To automatically fix formatting errors on each commit you make, you can
+set up pre-commit yourself. First, create a Python :ref:`environment
+<contributing.python-env>` , and then set up :ref:`pre-commit <contributing.pre-commit>`
 
 Delete your merged branch (optional)
 ------------------------------------

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -332,9 +332,11 @@ can comment::
     @github-actions pre-commit
 
 on that pull request. This will trigger a workflow which will autofix formatting
-errors. To automatically fix formatting errors on each commit you make, you can
+errors.
+
+To automatically fix formatting errors on each commit you make, you can
 set up pre-commit yourself. First, create a Python :ref:`environment
-<contributing.python-env>` , and then set up :ref:`pre-commit <contributing.pre-commit>`.
+<contributing.python-env>` and then set up :ref:`pre-commit <contributing.pre-commit>`.
 
 Delete your merged branch (optional)
 ------------------------------------

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -336,7 +336,7 @@ errors.
 
 To automatically fix formatting errors on each commit you make, you can
 set up pre-commit yourself. First, create a Python :ref:`environment
-<contributing.python-env>` and then set up :ref:`pre-commit <contributing.pre-commit>`.
+<contributing_environment>` and then set up :ref:`pre-commit <contributing.pre-commit>`.
 
 Delete your merged branch (optional)
 ------------------------------------

--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -133,8 +133,6 @@ compiler installation instructions.
 
 Let us know if you have any difficulties by opening an issue or reaching out on `Gitter <https://gitter.im/pydata/pandas/>`_.
 
-.. _contributing.python-env:
-
 Creating a Python environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -133,6 +133,7 @@ compiler installation instructions.
 
 Let us know if you have any difficulties by opening an issue or reaching out on `Gitter <https://gitter.im/pydata/pandas/>`_.
 
+.. _contributing.python-env
 
 Creating a Python environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -133,7 +133,7 @@ compiler installation instructions.
 
 Let us know if you have any difficulties by opening an issue or reaching out on `Gitter <https://gitter.im/pydata/pandas/>`_.
 
-.. _contributing.python-env
+.. _contributing.python-env:
 
 Creating a Python environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
The contributing page has comments on style, but does not link to setting up pre-commits yourself. It would be nice to be guided there