### PR TITLE
BUG: use TypeError (not OSError) when read_csv expects file path name or file-like object

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -387,6 +387,7 @@ I/O
 - Column headers are dropped when constructing a :class:`DataFrame` from a sqlalchemy's ``Row`` object (:issue:`40682`)
 - Bug in unpickling a :class:`Index` with object dtype incorrectly inferring numeric dtypes (:issue:`43188`)
 - Bug in :func:`read_csv` where reading multi-header input with unequal lengths incorrectly raising uncontrolled ``IndexError`` (:issue:`43102`)
+- Bug in :func:`read_csv`, changed exception class when expecting a file path name or file-like object from ``OSError`` to ``TypeError`` (:issue:`43443`)
 
 Period
 ^^^^^^

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -607,8 +607,8 @@ cdef class TextReader:
             void *ptr
 
         if not hasattr(source, "read"):
-            raise IOError(f'Expected file path name or file-like object, '
-                          f'got {type(source)} type')
+            raise TypeError('Expected file path name or file-like object, '
+                            f'got {type(source)} type')
 
         ptr = new_rd_source(source)
         self.parser.source = ptr

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -738,6 +738,10 @@ def get_handle(
             isinstance(ioargs.filepath_or_buffer, str) or ioargs.should_close
         )
 
+    if not hasattr(handle, "read"):
+        raise TypeError('Expected file path name or file-like object, '
+                        f'got {type(ioargs.filepath_or_buffer)} type')
+
     handles.reverse()  # close the most recently added buffer first
     if ioargs.should_close:
         assert not isinstance(ioargs.filepath_or_buffer, str)

--- a/pandas/tests/io/parser/common/test_common_basic.py
+++ b/pandas/tests/io/parser/common/test_common_basic.py
@@ -493,6 +493,14 @@ def test_raise_on_sep_with_delim_whitespace(all_parsers):
         parser.read_csv(StringIO(data), sep=r"\s", delim_whitespace=True)
 
 
+def test_read_filepath_or_buffer(all_parsers):
+    # see gh-43443
+    parser = all_parsers
+
+    with pytest.raises(TypeError, match="Expected file path name or file-lik"):
+        parser.read_csv(filepath_or_buffer=b'input')
+
+
 @xfail_pyarrow
 @pytest.mark.parametrize("delim_whitespace", [True, False])
 def test_single_char_leading_whitespace(all_parsers, delim_whitespace):


### PR DESCRIPTION
The exception class was changed from `IOError` (alias of `OSError`) to `TypeError` when `read_csv` expects file path or file-like object.

This bug is split from #43366, but with more clear intent and added test.