### PR TITLE
REGR: SpooledTemporaryFile support in read_csv

### DIFF
--- a/doc/source/whatsnew/v1.3.3.rst
+++ b/doc/source/whatsnew/v1.3.3.rst
@@ -29,6 +29,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.corr` where Kendall correlation would produce incorrect results for columns with repeated values (:issue:`43401`)
 - Fixed regression in :meth:`DataFrame.groupby` where aggregation on columns with object types dropped results on those columns (:issue:`42395`, :issue:`43108`)
 - Fixed regression in :meth:`Series.fillna` raising ``TypeError`` when filling ``float`` ``Series`` with list-like fill value having a dtype which couldn't cast lostlessly (like ``float32`` filled with ``float64``) (:issue:`43424`)
+- Fixed regression in :func:`read_csv` throwing an ``AttributeError`` when the file handle is an ``tempfile.SpooledTemporaryFile`` object (:issue:`43439`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -17,6 +17,7 @@ from io import (
 )
 import mmap
 import os
+import tempfile
 from typing import (
     IO,
     Any,
@@ -723,25 +724,20 @@ def get_handle(
         # since get_handle would have opened it in binary mode
         is_wrapped = True
     elif is_text and (compression or _is_binary_mode(handle, ioargs.mode)):
-        try:
-            # GH43439: tempfile.SpooledTemporaryFile has no attribute 'readable'
-            handle = TextIOWrapper(
-                # error: Argument 1 to "TextIOWrapper" has incompatible type
-                # "Union[IO[bytes], IO[Any], RawIOBase, BufferedIOBase, TextIOBase, mmap]";
-                # expected "IO[bytes]"
-                handle,  # type: ignore[arg-type]
-                encoding=ioargs.encoding,
-                errors=errors,
-                newline="",
-            )
-            handles.append(handle)
-            # only marked as wrapped when the caller provided a handle
-            is_wrapped = not (
-                isinstance(ioargs.filepath_or_buffer, str) or ioargs.should_close
-            )
-        except AttributeError:
-            # read_csv(engine="c") might still be able to deal with binary handles
-            pass
+        handle = TextIOWrapper(
+            # error: Argument 1 to "TextIOWrapper" has incompatible type
+            # "Union[IO[bytes], IO[Any], RawIOBase, BufferedIOBase, TextIOBase, mmap]";
+            # expected "IO[bytes]"
+            handle,  # type: ignore[arg-type]
+            encoding=ioargs.encoding,
+            errors=errors,
+            newline="",
+        )
+        handles.append(handle)
+        # only marked as wrapped when the caller provided a handle
+        is_wrapped = not (
+            isinstance(ioargs.filepath_or_buffer, str) or ioargs.should_close
+        )
 
     handles.reverse()  # close the most recently added buffer first
     if ioargs.should_close:
@@ -998,8 +994,15 @@ def _is_binary_mode(handle: FilePathOrBuffer, mode: str) -> bool:
     if "t" in mode or "b" in mode:
         return "b" in mode
 
-    # classes that expect string but have 'b' in mode
-    text_classes = (codecs.StreamWriter, codecs.StreamReader, codecs.StreamReaderWriter)
+    # exceptions
+    text_classes = (
+        # classes that expect string but have 'b' in mode
+        codecs.StreamWriter,
+        codecs.StreamReader,
+        codecs.StreamReaderWriter,
+        # cannot be wrapped in TextIOWrapper GH43439
+        tempfile.SpooledTemporaryFile,
+    )
     if issubclass(type(handle), text_classes):
         return False
 

--- a/pandas/tests/io/parser/test_encoding.py
+++ b/pandas/tests/io/parser/test_encoding.py
@@ -252,7 +252,8 @@ def test_encoding_memory_map(all_parsers, encoding):
     tm.assert_frame_equal(df, expected)
 
 
-def test_non_readable(all_parsers):
+def test_not_readable(all_parsers):
+    # GH43439
     parser = all_parsers
     if parser.engine == "python":
         pytest.skip("SpooledTemporaryFile does not work with Python engine")

--- a/pandas/tests/io/parser/test_encoding.py
+++ b/pandas/tests/io/parser/test_encoding.py
@@ -250,3 +250,15 @@ def test_encoding_memory_map(all_parsers, encoding):
         expected.to_csv(file, index=False, encoding=encoding)
         df = parser.read_csv(file, encoding=encoding, memory_map=True)
     tm.assert_frame_equal(df, expected)
+
+
+def test_non_readable(all_parsers):
+    parser = all_parsers
+    if parser.engine == "python":
+        pytest.skip("SpooledTemporaryFile does not work with Python engine")
+    with tempfile.SpooledTemporaryFile() as handle:
+        handle.write(b"abcd")
+        handle.seek(0)
+        df = parser.read_csv(handle)
+    expected = DataFrame([], columns=["abcd"])
+    tm.assert_frame_equal(df, expected)

--- a/pandas/tests/io/parser/test_encoding.py
+++ b/pandas/tests/io/parser/test_encoding.py
@@ -255,8 +255,8 @@ def test_encoding_memory_map(all_parsers, encoding):
 def test_not_readable(all_parsers):
     # GH43439
     parser = all_parsers
-    if parser.engine == "python":
-        pytest.skip("SpooledTemporaryFile does not work with Python engine")
+    if parser.engine in ("python", "pyarrow"):
+        pytest.skip("SpooledTemporaryFile does only work with the c-engine")
     with tempfile.SpooledTemporaryFile() as handle:
         handle.write(b"abcd")
         handle.seek(0)


### PR DESCRIPTION
- [ ] closes #43439
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry


Probably should throw a warning, if we cannot wrap the handle with `io.TextIOWrapper`.

To avoid the try-except, we could check whether the handle has the `readable` attribute, but there might be other attribute errors that might occur inside `TextIOWrapper`.