### PR TITLE
TST: add test to check numeric precision GH33234

### DIFF
--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -1282,10 +1282,6 @@ def test_groupby_agg_precision(dtype):
     df = DataFrame(
         {"key1": ["a"], "key2": ["b"], "key3": [1583715738627261039]}
     ).astype({"key3": dtype})
-    df1 = df.groupby(["key1"]).agg(lambda x: x)
-    df2 = df.groupby(["key1", "key2"]).agg(lambda x: x)
-    expected = df.iloc[0]["key3"]
-    result1 = df1.iloc[0]["key3"]
-    result2 = df2.iloc[0]["key3"]
-    assert result1 == expected
-    assert result2 == expected
+    result = df.groupby(["key1", "key2"]).agg(lambda x: x).reset_index()[["key3"]]
+    expected = df.groupby(["key1"]).agg(lambda x: x).reset_index()[["key3"]]
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -1274,3 +1274,18 @@ def test_timeseries_groupby_agg():
 
     expected = DataFrame([[1.0]], index=[1])
     tm.assert_frame_equal(res, expected)
+
+
+@pytest.mark.parametrize("dtype", ["int64", "int32", "float64", "float32"])
+def test_groupby_agg_precision(dtype):
+    # GH33234
+    df = DataFrame(
+        {"key1": ["a"], "key2": ["b"], "key3": [1583715738627261039]}
+    ).astype({"key3": dtype})
+    df1 = df.groupby(["key1"]).agg(lambda x: x)
+    df2 = df.groupby(["key1", "key2"]).agg(lambda x: x)
+    expected = df.iloc[0]["key3"]
+    result1 = df1.iloc[0]["key3"]
+    result2 = df2.iloc[0]["key3"]
+    assert result1 == expected
+    assert result2 == expected


### PR DESCRIPTION
test to check numeric precision after .groupby and .agg

- [X] closes #33234
- [X] tests added / passed
- [X] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [X] whatsnew entry
