### PR TITLE
DOC: 'if_sheet_exists' only on openpyxl in stead of 'append'

### DIFF
--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -683,7 +683,7 @@ class ExcelWriter(metaclass=abc.ABCMeta):
         .. versionadded:: 1.2.0
     if_sheet_exists : {'error', 'new', 'replace'}, default 'error'
         How to behave when trying to write to a sheet that already
-        exists (append mode only).
+        exists (openpyxl only).
 
         * error: raise a ValueError.
         * new: Create a new sheet, with a name determined by the engine.


### PR DESCRIPTION
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry

The `if_sheet_exists` parameter works also in write mode of openpyxl. e.g.:
```python
import pandas as pd
with pd.ExcelWriter("f.xlsx",engine="openpyxl") as writer:
    pd.DataFrame([1,2]).to_excel(writer)
    pd.DataFrame([3,4]).to_excel(writer)
```
will raise an error, because the default `if_sheet_exists` is set to "error". This could be fixed by this simple docs change, or changing the default of `if_sheet_exists` to "overlay". However, if that is the case, it could also very well be implemented for other engines.