### PR TITLE
BUG: `styler.hide_columns` fails when no sparsification

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -440,6 +440,7 @@ Styler
 - Bug in :meth:`Styler.apply` where functions which returned Series objects were not correctly handled in terms of aligning their index labels (:issue:`13657`, :issue:`42014`)
 - Bug when rendering an empty DataFrame with a named index (:issue:`43305`).
 - Bug when rendering a single level MultiIndex (:issue:`43383`).
+- Bug when combining non-sparse rendering and :meth:`.Styler.hide_columns` (:issue:`43464`)
 
 Other
 ^^^^^

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -351,7 +351,8 @@ class StylerRenderer:
                             "th",
                             f"{col_heading_class} level{r} col{c}",
                             value,
-                            _is_visible(c, r, col_lengths),
+                            _is_visible(c, r, col_lengths)
+                            and c not in self.hidden_columns,
                             attributes=(
                                 f'colspan="{col_lengths.get((r, c), 0)}"'
                                 if col_lengths.get((r, c), 0) > 1

--- a/pandas/tests/io/formats/style/test_style.py
+++ b/pandas/tests/io/formats/style/test_style.py
@@ -1447,3 +1447,14 @@ def test_caption_raises(mi_styler, caption):
     msg = "`caption` must be either a string or 2-tuple of strings."
     with pytest.raises(ValueError, match=msg):
         mi_styler.set_caption(caption)
+
+
+def test_no_sparse_hiding_columns():
+    # GH 43464
+    midx = MultiIndex.from_product([[1, 2], ["a", "a", "b"]])
+    df = DataFrame(9, index=[0], columns=midx)
+    styler = df.style.hide_columns((1, "a"))
+    ctx = styler._translate(False, False)
+
+    for ix in [(0, 1), (0, 2), (1, 1), (1, 2)]:
+        assert ctx["head"][ix[0]][ix[1]]["is_visible"] is False


### PR DESCRIPTION
- [x] closes #43464
- [x] tests added / passed
- [x] whatsnew entry
