### PR TITLE
CI: split Windows Azure tests in half

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,7 @@ jobs:
         PANDAS_DATA_MANAGER: array
         PATTERN: ${{ matrix.pattern }}
         PYTEST_WORKERS: "auto"
+        PYTEST_TARGET: pandas
       run: |
         source activate pandas-dev
         ci/run_tests.sh

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -44,6 +44,7 @@ jobs:
       LC_ALL: ${{ matrix.settings[4] }}
       PANDAS_TESTING_MODE: ${{ matrix.settings[5] }}
       TEST_ARGS: ${{ matrix.settings[6] }}
+      PYTEST_TARGET:  pandas
     concurrency:
       group: ${{ github.ref }}-${{ matrix.settings[0] }}
       cancel-in-progress: ${{github.event_name == 'pull_request'}}

--- a/.github/workflows/python-dev.yml
+++ b/.github/workflows/python-dev.yml
@@ -17,6 +17,7 @@ env:
   PANDAS_CI: 1
   PATTERN: "not slow and not network and not clipboard"
   COVERAGE: true
+  PYTEST_TARGET:  pandas
 
 jobs:
   build:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,7 @@ pr:
 
 variables:
   PYTEST_WORKERS: auto
+  PYTEST_TARGET:  pandas
 
 jobs:
 # Mac and Linux use the same template

--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -8,17 +8,33 @@ jobs:
     vmImage: ${{ parameters.vmImage }}
   strategy:
     matrix:
-      py38_np18:
+      py38_np18_1:
         ENV_FILE: ci/deps/azure-windows-38.yaml
         CONDA_PY: "38"
-        PATTERN: "not (slow or network)"
-        PYTEST_WORKERS: 1  # GH-43468
+        PATTERN: "not slow and not network"
+        PYTEST_WORKERS: 2  # GH-42236
+        PYTEST_TARGET: "pandas/tests/[a-i]*"
 
-      py39:
+      py38_np18_2:
+        ENV_FILE: ci/deps/azure-windows-38.yaml
+        CONDA_PY: "38"
+        PATTERN: "not slow and not network"
+        PYTEST_WORKERS: 2  # GH-42236
+        PYTEST_TARGET: "pandas/tests/[j-z]*"
+
+      py39_1:
         ENV_FILE: ci/deps/azure-windows-39.yaml
         CONDA_PY: "39"
-        PATTERN: "not (slow or network or high_memory)"
-        PYTEST_WORKERS: 1  # GH-43468
+        PATTERN: "not slow and not network and not high_memory"
+        PYTEST_WORKERS: 2  # GH-42236
+        PYTEST_TARGET: "pandas/tests/[a-i]*"
+
+      py39_2:
+        ENV_FILE: ci/deps/azure-windows-39.yaml
+        CONDA_PY: "39"
+        PATTERN: "not slow and not network and not high_memory"
+        PYTEST_WORKERS: 2  # GH-42236
+        PYTEST_TARGET: "pandas/tests/[j-z]*"
 
   steps:
     - powershell: |

--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -12,13 +12,13 @@ jobs:
         ENV_FILE: ci/deps/azure-windows-38.yaml
         CONDA_PY: "38"
         PATTERN: "not slow and not network"
-        PYTEST_WORKERS: 2  # GH-42236
+        PYTEST_WORKERS: "auto"
 
       py39:
         ENV_FILE: ci/deps/azure-windows-39.yaml
         CONDA_PY: "39"
         PATTERN: "not slow and not network and not high_memory"
-        PYTEST_WORKERS: 2  # GH-42236
+        PYTEST_WORKERS: "auto"
 
   steps:
     - powershell: |

--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -12,13 +12,13 @@ jobs:
         ENV_FILE: ci/deps/azure-windows-38.yaml
         CONDA_PY: "38"
         PATTERN: "not (slow or network)"
-        PYTEST_WORKERS: 2  # GH-42236
+        PYTEST_WORKERS: 1  # GH-43468
 
       py39:
         ENV_FILE: ci/deps/azure-windows-39.yaml
         CONDA_PY: "39"
         PATTERN: "not (slow or network or high_memory)"
-        PYTEST_WORKERS: 2  # GH-42236
+        PYTEST_WORKERS: 1  # GH-43468
 
   steps:
     - powershell: |
@@ -39,6 +39,7 @@ jobs:
       displayName: 'Build'
     - bash: |
         source activate pandas-dev
+        wmic.exe cpu get caption, deviceid, name, numberofcores, maxclockspeed
         ci/run_tests.sh
       displayName: 'Test'
     - task: PublishTestResults@2

--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -11,14 +11,12 @@ jobs:
       py38_np18:
         ENV_FILE: ci/deps/azure-windows-38.yaml
         CONDA_PY: "38"
-        PATTERN: "not slow and not network"
-        PYTEST_WORKERS: "auto"
+        PATTERN: "not (slow or network)"
 
       py39:
         ENV_FILE: ci/deps/azure-windows-39.yaml
         CONDA_PY: "39"
-        PATTERN: "not slow and not network and not high_memory"
-        PYTEST_WORKERS: "auto"
+        PATTERN: "not (slow or network or high_memory)"
 
   steps:
     - powershell: |

--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -12,11 +12,13 @@ jobs:
         ENV_FILE: ci/deps/azure-windows-38.yaml
         CONDA_PY: "38"
         PATTERN: "not (slow or network)"
+        PYTEST_WORKERS: 2  # GH-42236
 
       py39:
         ENV_FILE: ci/deps/azure-windows-39.yaml
         CONDA_PY: "39"
         PATTERN: "not (slow or network or high_memory)"
+        PYTEST_WORKERS: 2  # GH-42236
 
   steps:
     - powershell: |

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -19,7 +19,7 @@ if [[ $(uname) == "Linux" && -z $DISPLAY ]]; then
     XVFB="xvfb-run "
 fi
 
-PYTEST_CMD="${XVFB}pytest -m \"$PATTERN\" -n $PYTEST_WORKERS --dist=loadfile $TEST_ARGS $COVERAGE pandas"
+PYTEST_CMD="${XVFB}pytest -m \"$PATTERN\" -n $PYTEST_WORKERS --dist=loadfile $TEST_ARGS $COVERAGE $PYTEST_TARGET"
 
 if [[ $(uname) != "Linux"  && $(uname) != "Darwin" ]]; then
     # GH#37455 windows py38 build appears to be running out of memory


### PR DESCRIPTION
Trying an experiment for Windows CI where `PYTEST_WORKERS` is `auto` rather than 2.
