### PR TITLE
REF: avoid unnecessary argument to groupby numba funcs

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -228,9 +228,10 @@ class SeriesGroupBy(GroupBy[Series]):
         if maybe_use_numba(engine):
             with group_selection_context(self):
                 data = self._selected_obj
-            result, index = self._aggregate_with_numba(
+            result = self._aggregate_with_numba(
                 data.to_frame(), func, *args, engine_kwargs=engine_kwargs, **kwargs
             )
+            index = self._group_keys_index
             return self.obj._constructor(result.ravel(), index=index, name=data.name)
 
         relabeling = func is None
@@ -926,9 +927,10 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         if maybe_use_numba(engine):
             with group_selection_context(self):
                 data = self._selected_obj
-            result, index = self._aggregate_with_numba(
+            result = self._aggregate_with_numba(
                 data, func, *args, engine_kwargs=engine_kwargs, **kwargs
             )
+            index = self._group_keys_index
             return self.obj._constructor(result, index=index, columns=data.columns)
 
         relabeling, func, columns, order = reconstruct_func(func, **kwargs)

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1269,7 +1269,6 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
         data and indices into a Numba jitted function.
         """
         starts, ends, sorted_index, sorted_data = self._numba_prep(func, data)
-        group_keys = self.grouper.group_keys_seq
 
         numba_transform_func = numba_.generate_numba_transform_func(
             kwargs, func, engine_kwargs
@@ -1279,7 +1278,6 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
             sorted_index,
             starts,
             ends,
-            len(group_keys),
             len(data.columns),
             *args,
         )
@@ -1302,7 +1300,6 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
         data and indices into a Numba jitted function.
         """
         starts, ends, sorted_index, sorted_data = self._numba_prep(func, data)
-        index = self._group_keys_index
 
         numba_agg_func = numba_.generate_numba_agg_func(kwargs, func, engine_kwargs)
         result = numba_agg_func(
@@ -1310,7 +1307,6 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
             sorted_index,
             starts,
             ends,
-            len(index),
             len(data.columns),
             *args,
         )
@@ -1319,7 +1315,7 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
         if cache_key not in NUMBA_FUNC_CACHE:
             NUMBA_FUNC_CACHE[cache_key] = numba_agg_func
 
-        return result, index
+        return result
 
     # -----------------------------------------------------------------
     # apply/agg/transform

--- a/pandas/core/groupby/numba_.py
+++ b/pandas/core/groupby/numba_.py
@@ -59,9 +59,7 @@ def generate_numba_agg_func(
     kwargs: dict[str, Any],
     func: Callable[..., Scalar],
     engine_kwargs: dict[str, bool] | None,
-) -> Callable[
-    [np.ndarray, np.ndarray, np.ndarray, np.ndarray, int, int, Any], np.ndarray
-]:
+) -> Callable[[np.ndarray, np.ndarray, np.ndarray, np.ndarray, int, Any], np.ndarray]:
     """
     Generate a numba jitted agg function specified by values from engine_kwargs.
 
@@ -100,10 +98,13 @@ def generate_numba_agg_func(
         index: np.ndarray,
         begin: np.ndarray,
         end: np.ndarray,
-        num_groups: int,
         num_columns: int,
         *args: Any,
     ) -> np.ndarray:
+
+        assert len(begin) == len(end)
+        num_groups = len(begin)
+
         result = np.empty((num_groups, num_columns))
         for i in numba.prange(num_groups):
             group_index = index[begin[i] : end[i]]
@@ -119,9 +120,7 @@ def generate_numba_transform_func(
     kwargs: dict[str, Any],
     func: Callable[..., np.ndarray],
     engine_kwargs: dict[str, bool] | None,
-) -> Callable[
-    [np.ndarray, np.ndarray, np.ndarray, np.ndarray, int, int, Any], np.ndarray
-]:
+) -> Callable[[np.ndarray, np.ndarray, np.ndarray, np.ndarray, int, Any], np.ndarray]:
     """
     Generate a numba jitted transform function specified by values from engine_kwargs.
 
@@ -160,10 +159,13 @@ def generate_numba_transform_func(
         index: np.ndarray,
         begin: np.ndarray,
         end: np.ndarray,
-        num_groups: int,
         num_columns: int,
         *args: Any,
     ) -> np.ndarray:
+
+        assert len(begin) == len(end)
+        num_groups = len(begin)
+
         result = np.empty((len(values), num_columns))
         for i in numba.prange(num_groups):
             group_index = index[begin[i] : end[i]]


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

cc @mroeschke im pretty sure this is slightly more correct than the status quo, but i could use some help in coming up with test cases.  Two main cases to cover:

1) `res = df.groupby(more_than_one_column).transform(..., engine="numba", i_dont_know_off_the_top_the_calling_convention)`

I'm pretty sure in this case `res.index.names` will be wrong in master.

2) Cases with BinGrouper where there is a length mismatch (also an issue with non-numba paths)

```
import pandas as pd

df = pd.DataFrame(
        {
            "Buyer": "Carl Carl Carl Carl Joe Carl".split(),
            "Quantity": [18, 3, 5, 1, 9, 3],
            "Date": [
                pd.Timestamp(2013, 9, 1, 13, 0),
                pd.Timestamp(2013, 9, 1, 13, 5),
                pd.Timestamp(2013, 10, 1, 20, 0),
                pd.Timestamp(2013, 10, 3, 10, 0),
                pd.NaT,
                pd.Timestamp(2013, 9, 2, 14, 0),
            ],
        }
    )


gb = df.groupby(pd.Grouper(key="Date", freq="5D"))

gb.transform(lambda x: x, engine="numba", ...)  # <- pretty sure this raises
```

Or are these not reachable for some reason?