### PR TITLE
BUG: fillna not replacing missing values when duplicate colnames

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -369,6 +369,7 @@ Indexing
 Missing
 ^^^^^^^
 - Bug in :meth:`DataFrame.fillna` with limit and no method ignores axis='columns' or ``axis = 1`` (:issue:`40989`)
+- Bug in :meth:`DataFrame.fillna` not replacing missing values when using a dict-like ``value`` and duplicate column names (:issue:`43476`)
 -
 
 MultiIndex

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6339,9 +6339,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 for k, v in value.items():
                     if k not in result:
                         continue
-                    obj = result[k]
                     downcast_k = downcast if not is_dict else downcast.get(k)
-                    result[k] = obj.fillna(v, limit=limit, downcast=downcast_k)
+                    result[k] = result[k].fillna(v, limit=limit, downcast=downcast_k)
                 return result if not inplace else None
 
             elif not is_list_like(value):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6341,7 +6341,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                         continue
                     obj = result[k]
                     downcast_k = downcast if not is_dict else downcast.get(k)
-                    obj.fillna(v, limit=limit, inplace=True, downcast=downcast_k)
+                    result[k] = obj.fillna(v, limit=limit, downcast=downcast_k)
                 return result if not inplace else None
 
             elif not is_list_like(value):

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -247,6 +247,17 @@ class TestFillNA:
         expected = DataFrame({"a": [1, 0]})
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.parametrize("columns", [["A", "A", "B"], ["A", "A"]])
+    def test_fillna_dictlike_value_duplicate_colnames(self, columns):
+        # GH#43476
+        df = DataFrame(np.nan, index=[0, 1], columns=columns)
+        with tm.assert_produces_warning(None):
+            result = df.fillna({"A": 0})
+
+        expected = df.copy()
+        expected["A"] = 0.0
+        tm.assert_frame_equal(result, expected)
+
     @td.skip_array_manager_not_yet_implemented  # TODO(ArrayManager) object upcasting
     def test_fillna_dtype_conversion(self):
         # make sure that fillna on an empty frame works


### PR DESCRIPTION
- [x] closes #43476
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry
