### PR TITLE
Backport PR #43468: CI: split Windows Azure tests in half

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
         PANDAS_DATA_MANAGER: array
         PATTERN: ${{ matrix.pattern }}
         PYTEST_WORKERS: "auto"
+        PYTEST_TARGET: pandas
       run: |
         source activate pandas-dev
         ci/run_tests.sh

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -45,6 +45,7 @@ jobs:
       LC_ALL: ${{ matrix.settings[4] }}
       PANDAS_TESTING_MODE: ${{ matrix.settings[5] }}
       TEST_ARGS: ${{ matrix.settings[6] }}
+      PYTEST_TARGET:  pandas
 
     steps:
     - name: Checkout

--- a/.github/workflows/python-dev.yml
+++ b/.github/workflows/python-dev.yml
@@ -17,6 +17,7 @@ env:
   PANDAS_CI: 1
   PATTERN: "not slow and not network and not clipboard"
   COVERAGE: true
+  PYTEST_TARGET:  pandas
 
 jobs:
   build:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,7 @@ pr:
 
 variables:
   PYTEST_WORKERS: auto
+  PYTEST_TARGET:  pandas
 
 jobs:
 # Mac and Linux use the same template

--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -36,20 +36,6 @@ jobs:
         PYTEST_WORKERS: 2  # GH-42236
         PYTEST_TARGET: "pandas/tests/[j-z]*"
 
-      py39_1:
-        ENV_FILE: ci/deps/azure-windows-39.yaml
-        CONDA_PY: "39"
-        PATTERN: "not slow and not network and not high_memory"
-        PYTEST_WORKERS: 2  # GH-42236
-        PYTEST_TARGET: "pandas/tests/[a-i]*"
-
-      py39_2:
-        ENV_FILE: ci/deps/azure-windows-39.yaml
-        CONDA_PY: "39"
-        PATTERN: "not slow and not network and not high_memory"
-        PYTEST_WORKERS: 2  # GH-42236
-        PYTEST_TARGET: "pandas/tests/[j-z]*"
-
   steps:
     - powershell: |
         Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"

--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -8,17 +8,47 @@ jobs:
     vmImage: ${{ parameters.vmImage }}
   strategy:
     matrix:
-      py37_np17:
+      py37_np17_1:
         ENV_FILE: ci/deps/azure-windows-37.yaml
         CONDA_PY: "37"
         PATTERN: "not slow and not network"
         PYTEST_WORKERS: 2  # GH-42236
+        PYTEST_TARGET: "pandas/tests/[a-i]*"
 
-      py38_np18:
+      py37_np17_2:
+        ENV_FILE: ci/deps/azure-windows-37.yaml
+        CONDA_PY: "37"
+        PATTERN: "not slow and not network"
+        PYTEST_WORKERS: 2  # GH-42236
+        PYTEST_TARGET: "pandas/tests/[j-z]*"
+
+      py38_np18_1:
         ENV_FILE: ci/deps/azure-windows-38.yaml
         CONDA_PY: "38"
+        PATTERN: "not slow and not network"
+        PYTEST_WORKERS: 2  # GH-42236
+        PYTEST_TARGET: "pandas/tests/[a-i]*"
+
+      py38_np18_2:
+        ENV_FILE: ci/deps/azure-windows-38.yaml
+        CONDA_PY: "38"
+        PATTERN: "not slow and not network"
+        PYTEST_WORKERS: 2  # GH-42236
+        PYTEST_TARGET: "pandas/tests/[j-z]*"
+
+      py39_1:
+        ENV_FILE: ci/deps/azure-windows-39.yaml
+        CONDA_PY: "39"
         PATTERN: "not slow and not network and not high_memory"
         PYTEST_WORKERS: 2  # GH-42236
+        PYTEST_TARGET: "pandas/tests/[a-i]*"
+
+      py39_2:
+        ENV_FILE: ci/deps/azure-windows-39.yaml
+        CONDA_PY: "39"
+        PATTERN: "not slow and not network and not high_memory"
+        PYTEST_WORKERS: 2  # GH-42236
+        PYTEST_TARGET: "pandas/tests/[j-z]*"
 
   steps:
     - powershell: |
@@ -42,6 +72,7 @@ jobs:
 
     - bash: |
         source activate pandas-dev
+        wmic.exe cpu get caption, deviceid, name, numberofcores, maxclockspeed
         ci/run_tests.sh
       displayName: 'Test'
 

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -19,7 +19,7 @@ if [[ $(uname) == "Linux" && -z $DISPLAY ]]; then
     XVFB="xvfb-run "
 fi
 
-PYTEST_CMD="${XVFB}pytest -m \"$PATTERN\" -n $PYTEST_WORKERS --dist=loadfile $TEST_ARGS $COVERAGE pandas"
+PYTEST_CMD="${XVFB}pytest -m \"$PATTERN\" -n $PYTEST_WORKERS --dist=loadfile $TEST_ARGS $COVERAGE $PYTEST_TARGET"
 
 if [[ $(uname) != "Linux"  && $(uname) != "Darwin" ]]; then
     # GH#37455 windows py38 build appears to be running out of memory


### PR DESCRIPTION
Backport #43468 to 1.3.x