### PR TITLE
BUG: GroupBy.apply with Grouper and NaT

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -417,6 +417,7 @@ Groupby/resample/rolling
 - Bug in :meth:`Series.rolling` when the :class:`Series` ``dtype`` was ``Int64`` (:issue:`43016`)
 - Bug in :meth:`DataFrame.rolling.corr` when the :class:`DataFrame` columns was a :class:`MultiIndex` (:issue:`21157`)
 - Bug in :meth:`DataFrame.groupby.rolling` when specifying ``on`` and calling ``__getitem__`` would subsequently return incorrect results (:issue:`43355`)
+- Bug in :meth:`GroupBy.apply` with time-based :class:`Grouper` objects incorrectly raising ``ValueError`` in corner cases where the grouping vector contains a ``NaT`` (:issue:`??`)
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -417,7 +417,7 @@ Groupby/resample/rolling
 - Bug in :meth:`Series.rolling` when the :class:`Series` ``dtype`` was ``Int64`` (:issue:`43016`)
 - Bug in :meth:`DataFrame.rolling.corr` when the :class:`DataFrame` columns was a :class:`MultiIndex` (:issue:`21157`)
 - Bug in :meth:`DataFrame.groupby.rolling` when specifying ``on`` and calling ``__getitem__`` would subsequently return incorrect results (:issue:`43355`)
-- Bug in :meth:`GroupBy.apply` with time-based :class:`Grouper` objects incorrectly raising ``ValueError`` in corner cases where the grouping vector contains a ``NaT`` (:issue:`??`)
+- Bug in :meth:`GroupBy.apply` with time-based :class:`Grouper` objects incorrectly raising ``ValueError`` in corner cases where the grouping vector contains a ``NaT`` (:issue:`43500`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -415,7 +415,7 @@ class SeriesGroupBy(GroupBy[Series]):
         else:
             # GH #6265 #24880
             result = self.obj._constructor(
-                data=values, index=self._group_keys_index, name=self.obj.name
+                data=values, index=self.grouper.result_index, name=self.obj.name
             )
             return self._reindex_output(result)
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -402,7 +402,7 @@ class SeriesGroupBy(GroupBy[Series]):
 
         if isinstance(values[0], dict):
             # GH #823 #24880
-            index = self._group_keys_index
+            index = self.grouper.result_index
             res_df = self.obj._constructor_expanddim(values, index=index)
             res_df = self._reindex_output(res_df)
             # if self.observed is False,

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -818,7 +818,7 @@ class TestGroupBy:
     def test_groupby_apply_timegrouper_with_nat_dict_returns(
         self, groupby_with_truncated_bingrouper
     ):
-        # case where gb.grouper.result_index and gb.grouper.group_keys_seq
+        # GH#43500 case where gb.grouper.result_index and gb.grouper.group_keys_seq
         #  have different lengths that goes through the `isinstance(values[0], dict)`
         #  path
         gb = groupby_with_truncated_bingrouper
@@ -833,8 +833,8 @@ class TestGroupBy:
     def test_groupby_apply_timegrouper_with_nat_scalar_returns(
         self, groupby_with_truncated_bingrouper
     ):
-        # Previously raised ValueError bc used index with incorrect length
-        #  in wrap_applied_result
+        # GH#43500 Previously raised ValueError bc used index with incorrect
+        #  length in wrap_applied_result
         gb = groupby_with_truncated_bingrouper
 
         res = gb["Quantity"].apply(lambda x: x.iloc[0] if len(x) else np.nan)

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -23,6 +23,41 @@ from pandas.core.groupby.grouper import Grouper
 from pandas.core.groupby.ops import BinGrouper
 
 
+@pytest.fixture
+def groupby_with_truncated_bingrouper():
+    """
+    GroupBy object such that gb.grouper is a BinGrouper and
+    len(gb.grouper.result_index) < len(gb.grouper.group_keys_seq)
+
+    Aggregations on this groupby should have
+
+        dti = date_range("2013-09-01", "2013-10-01", freq="5D", name="Date")
+
+    As either the index or an index level.
+    """
+    df = DataFrame(
+        {
+            "Quantity": [18, 3, 5, 1, 9, 3],
+            "Date": [
+                Timestamp(2013, 9, 1, 13, 0),
+                Timestamp(2013, 9, 1, 13, 5),
+                Timestamp(2013, 10, 1, 20, 0),
+                Timestamp(2013, 10, 3, 10, 0),
+                pd.NaT,
+                Timestamp(2013, 9, 2, 14, 0),
+            ],
+        }
+    )
+
+    tdg = Grouper(key="Date", freq="5D")
+    gb = df.groupby(tdg)
+
+    # check we're testing the case we're interested in
+    assert len(gb.grouper.result_index) != len(gb.grouper.group_keys_seq)
+
+    return gb
+
+
 class TestGroupBy:
     def test_groupby_with_timegrouper(self):
         # GH 4161
@@ -780,33 +815,35 @@ class TestGroupBy:
         )
         tm.assert_series_equal(result, expected)
 
-    def test_groupby_apply_timegrouper_with_nat_dict_returns(self):
+    def test_groupby_apply_timegrouper_with_nat_dict_returns(
+        self, groupby_with_truncated_bingrouper
+    ):
         # case where gb.grouper.result_index and gb.grouper.group_keys_seq
-        #  have different lengths
-
-        df = DataFrame(
-            {
-                "Quantity": [18, 3, 5, 1, 9, 3],
-                "Date": [
-                    Timestamp(2013, 9, 1, 13, 0),
-                    Timestamp(2013, 9, 1, 13, 5),
-                    Timestamp(2013, 10, 1, 20, 0),
-                    Timestamp(2013, 10, 3, 10, 0),
-                    pd.NaT,
-                    Timestamp(2013, 9, 2, 14, 0),
-                ],
-            }
-        )
-
-        tdg = Grouper(key="Date", freq="5D")
-        gb = df.groupby(tdg)
-
-        # check we're testing the case we're interested in
-        assert len(gb.grouper.result_index) != len(gb.grouper.group_keys_seq)
+        #  have different lengths that goes through the `isinstance(values[0], dict)`
+        #  path
+        gb = groupby_with_truncated_bingrouper
 
         res = gb["Quantity"].apply(lambda x: {"foo": len(x)})
 
         dti = date_range("2013-09-01", "2013-10-01", freq="5D", name="Date")
         mi = MultiIndex.from_arrays([dti, ["foo"] * len(dti)])
         expected = Series([3, 0, 0, 0, 0, 0, 2], index=mi, name="Quantity")
+        tm.assert_series_equal(res, expected)
+
+    def test_groupby_apply_timegrouper_with_nat_scalar_returns(
+        self, groupby_with_truncated_bingrouper
+    ):
+        # Previously raised ValueError bc used index with incorrect length
+        #  in wrap_applied_result
+        gb = groupby_with_truncated_bingrouper
+
+        res = gb["Quantity"].apply(lambda x: x.iloc[0] if len(x) else np.nan)
+
+        dti = date_range("2013-09-01", "2013-10-01", freq="5D", name="Date")
+        expected = Series(
+            [18, np.nan, np.nan, np.nan, np.nan, np.nan, 5],
+            index=dti._with_freq(None),
+            name="Quantity",
+        )
+
         tm.assert_series_equal(res, expected)


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

Inching towards getting rid of redundant index-like attributes