### PR TITLE
split macos tests in 2

### DIFF
--- a/ci/azure/posix.yml
+++ b/ci/azure/posix.yml
@@ -9,10 +9,16 @@ jobs:
   strategy:
     matrix:
       ${{ if eq(parameters.name, 'macOS') }}:
-        py38_macos:
+        py38_macos_1:
           ENV_FILE: ci/deps/azure-macos-38.yaml
           CONDA_PY: "38"
           PATTERN: "not slow and not network"
+          PYTEST_TARGET: "pandas/tests/[a-i]*"
+        py38_macos_2:
+          ENV_FILE: ci/deps/azure-macos-38.yaml
+          CONDA_PY: "38"
+          PATTERN: "not slow and not network"
+          PYTEST_TARGET: "pandas/tests/[j-z]*"
 
   steps:
     - script: echo '##vso[task.prependpath]$(HOME)/miniconda3/bin'

--- a/ci/azure/posix.yml
+++ b/ci/azure/posix.yml
@@ -13,12 +13,12 @@ jobs:
           ENV_FILE: ci/deps/azure-macos-38.yaml
           CONDA_PY: "38"
           PATTERN: "not slow and not network"
-          PYTEST_TARGET: "pandas/tests/[a-i]*"
+          PYTEST_TARGET: "pandas/tests/[a-h]*"
         py38_macos_2:
           ENV_FILE: ci/deps/azure-macos-38.yaml
           CONDA_PY: "38"
           PATTERN: "not slow and not network"
-          PYTEST_TARGET: "pandas/tests/[j-z]*"
+          PYTEST_TARGET: "pandas/tests/[i-z]*"
 
   steps:
     - script: echo '##vso[task.prependpath]$(HOME)/miniconda3/bin'

--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -13,28 +13,28 @@ jobs:
         CONDA_PY: "38"
         PATTERN: "not slow and not network"
         PYTEST_WORKERS: 2  # GH-42236
-        PYTEST_TARGET: "pandas/tests/[a-i]*"
+        PYTEST_TARGET: "pandas/tests/[a-h]*"
 
       py38_np18_2:
         ENV_FILE: ci/deps/azure-windows-38.yaml
         CONDA_PY: "38"
         PATTERN: "not slow and not network"
         PYTEST_WORKERS: 2  # GH-42236
-        PYTEST_TARGET: "pandas/tests/[j-z]*"
+        PYTEST_TARGET: "pandas/tests/[i-z]*"
 
       py39_1:
         ENV_FILE: ci/deps/azure-windows-39.yaml
         CONDA_PY: "39"
         PATTERN: "not slow and not network and not high_memory"
         PYTEST_WORKERS: 2  # GH-42236
-        PYTEST_TARGET: "pandas/tests/[a-i]*"
+        PYTEST_TARGET: "pandas/tests/[a-h]*"
 
       py39_2:
         ENV_FILE: ci/deps/azure-windows-39.yaml
         CONDA_PY: "39"
         PATTERN: "not slow and not network and not high_memory"
         PYTEST_WORKERS: 2  # GH-42236
-        PYTEST_TARGET: "pandas/tests/[j-z]*"
+        PYTEST_TARGET: "pandas/tests/[i-z]*"
 
   steps:
     - powershell: |


### PR DESCRIPTION
follow up to #43468 to also split MacOS tests in half to speed up CI tests per comment from @jreback https://github.com/pandas-dev/pandas/pull/43468#issuecomment-916860226
