### PR TITLE
CI: mark user-agent tests as network

### DIFF
--- a/pandas/tests/io/test_user_agent.py
+++ b/pandas/tests/io/test_user_agent.py
@@ -178,6 +178,7 @@ class AllHeaderCSVResponder(http.server.BaseHTTPRequestHandler):
         self.wfile.write(response_bytes)
 
 
+@pytest.mark.network
 @pytest.mark.parametrize(
     "responder, read_method, parquet_engine",
     [
@@ -219,6 +220,7 @@ def test_server_and_default_headers(responder, read_method, parquet_engine):
     assert not df_http.empty
 
 
+@pytest.mark.network
 @pytest.mark.parametrize(
     "responder, read_method, parquet_engine",
     [
@@ -272,6 +274,7 @@ def test_server_and_custom_headers(responder, read_method, parquet_engine):
     tm.assert_frame_equal(df_true, df_http)
 
 
+@pytest.mark.network
 @pytest.mark.parametrize(
     "responder, read_method",
     [


### PR DESCRIPTION
cc @jbrockmendel, inspired by https://github.com/pandas-dev/pandas/pull/43517#issuecomment-917464806. This being the source of the timeout is also supported by starting to see timeouts on windows2 after changing the split such that the io tests were included in windows2.
