### PR TITLE
REGR: Outer merge failing with integer and NaN keys

### DIFF
--- a/doc/source/whatsnew/v1.3.4.rst
+++ b/doc/source/whatsnew/v1.3.4.rst
@@ -14,7 +14,7 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
--
+- Fixed regression in :meth:`merge` with integer and ``NaN`` keys failing with ``outer`` merge (:issue:`43550`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -37,6 +37,7 @@ from pandas.util._decorators import (
     Substitution,
 )
 
+from pandas.core.dtypes.cast import find_common_type
 from pandas.core.dtypes.common import (
     ensure_float64,
     ensure_int64,
@@ -912,7 +913,7 @@ class _MergeOperation:
                     result_dtype = lvals.dtype
                 else:
                     key_col = Index(lvals).where(~mask_left, rvals)
-                    result_dtype = lvals.dtype
+                    result_dtype = find_common_type([lvals.dtype, rvals.dtype])
 
                 if result._is_label_reference(name):
                     result[name] = Series(

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2571,3 +2571,18 @@ def test_mergeerror_on_left_index_mismatched_dtypes():
     df_2 = DataFrame(data=["X"], columns=["C"], index=[999])
     with pytest.raises(MergeError, match="Can only pass argument"):
         merge(df_1, df_2, on=["C"], left_index=True)
+
+
+def test_merge_outer_with_NaN():
+    # GH#43550
+    left = DataFrame({"key": [1, 2], "col1": [1, 2]})
+    right = DataFrame({"key": [np.nan, np.nan], "col2": [3, 4]})
+    result = merge(left, right, on="key", how="outer")
+    expected = DataFrame(
+        {
+            "key": [1, 2, np.nan, np.nan],
+            "col1": [1, 2, np.nan, np.nan],
+            "col2": [np.nan, np.nan, 3, 4],
+        }
+    )
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2573,16 +2573,30 @@ def test_mergeerror_on_left_index_mismatched_dtypes():
         merge(df_1, df_2, on=["C"], left_index=True)
 
 
-def test_merge_outer_with_NaN():
+@pytest.mark.parametrize("dtype", [None, "Int64"])
+def test_merge_outer_with_NaN(dtype):
     # GH#43550
-    left = DataFrame({"key": [1, 2], "col1": [1, 2]})
-    right = DataFrame({"key": [np.nan, np.nan], "col2": [3, 4]})
+    left = DataFrame({"key": [1, 2], "col1": [1, 2]}, dtype=dtype)
+    right = DataFrame({"key": [np.nan, np.nan], "col2": [3, 4]}, dtype=dtype)
     result = merge(left, right, on="key", how="outer")
     expected = DataFrame(
         {
             "key": [1, 2, np.nan, np.nan],
             "col1": [1, 2, np.nan, np.nan],
             "col2": [np.nan, np.nan, 3, 4],
-        }
+        },
+        dtype=dtype,
+    )
+    tm.assert_frame_equal(result, expected)
+
+    # switch left and right
+    result = merge(right, left, on="key", how="outer")
+    expected = DataFrame(
+        {
+            "key": [np.nan, np.nan, 1, 2],
+            "col2": [3, 4, np.nan, np.nan],
+            "col1": [np.nan, np.nan, 1, 2],
+        },
+        dtype=dtype,
     )
     tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #43550 
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry
