### PR TITLE
CLN/TST: Remove agg test from groupby

### DIFF
--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -1213,21 +1213,6 @@ def test_nonagg_agg():
     tm.assert_frame_equal(result, expected)
 
 
-def test_agg_no_suffix_index():
-    # GH36189
-    df = DataFrame([[4, 9]] * 3, columns=["A", "B"])
-    result = df.agg(["sum", lambda x: x.sum(), lambda x: x.sum()])
-    expected = DataFrame(
-        {"A": [12, 12, 12], "B": [27, 27, 27]}, index=["sum", "<lambda>", "<lambda>"]
-    )
-    tm.assert_frame_equal(result, expected)
-
-    # test Series case
-    result = df["A"].agg(["sum", lambda x: x.sum(), lambda x: x.sum()])
-    expected = Series([12, 12, 12], index=["sum", "<lambda>", "<lambda>"], name="A")
-    tm.assert_series_equal(result, expected)
-
-
 def test_aggregate_datetime_objects():
     # https://github.com/pandas-dev/pandas/issues/36003
     # ensure we don't raise an error but keep object dtype for out-of-bounds


### PR DESCRIPTION
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

Removed test is duplicated of

https://github.com/pandas-dev/pandas/blob/e9d0a58c4152a16153dfb330164991d37fdd02dc/pandas/tests/apply/test_frame_apply.py#L1398-L1406

and

https://github.com/pandas-dev/pandas/blob/e9d0a58c4152a16153dfb330164991d37fdd02dc/pandas/tests/apply/test_series_apply.py#L410-L416