### PR TITLE
TST: Add test for masking timedelta (#39548)

### DIFF
--- a/pandas/tests/frame/indexing/test_mask.py
+++ b/pandas/tests/frame/indexing/test_mask.py
@@ -9,6 +9,7 @@ from pandas import (
     DataFrame,
     Series,
     StringDtype,
+    Timedelta,
     isna,
 )
 import pandas._testing as tm
@@ -136,3 +137,16 @@ def test_mask_stringdtype():
         dtype=StringDtype(),
     )
     tm.assert_frame_equal(result, expected)
+
+
+def test_mask_where_dtype_timedelta():
+    # https://github.com/pandas-dev/pandas/issues/39548
+    df = DataFrame([Timedelta(i, unit="d") for i in range(5)])
+
+    expected = DataFrame(np.full(5, np.nan, dtype="timedelta64[ns]"))
+    tm.assert_frame_equal(df.mask(df.notna()), expected)
+
+    expected = DataFrame(
+        [np.nan, np.nan, np.nan, Timedelta("3 day"), Timedelta("4 day")]
+    )
+    tm.assert_frame_equal(df.where(df > Timedelta(2, unit="d")), expected)


### PR DESCRIPTION
- [x] closes #39548
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
