### PR TITLE
ENH: make ``levels`` consistent and name responsive

### DIFF
--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -1814,7 +1814,7 @@ class Styler(StylerRenderer):
         self,
         axis: Axis = 0,
         pixel_size: int | None = None,
-        levels: list[int] | None = None,
+        levels: Level | list[Level] | None = None,
     ) -> Styler:
         """
         Add CSS to permanently display the index or column headers in a scrolling frame.
@@ -1827,7 +1827,7 @@ class Styler(StylerRenderer):
             Required to configure the width of index cells or the height of column
             header cells when sticking a MultiIndex (or with a named Index).
             Defaults to 75 and 25 respectively.
-        levels : list of int
+        levels : int, str, list, optional
             If ``axis`` is a MultiIndex the specific levels to stick. If ``None`` will
             stick all levels.
 
@@ -1891,11 +1891,12 @@ class Styler(StylerRenderer):
         else:
             # handle the MultiIndex case
             range_idx = list(range(obj.nlevels))
-            levels = sorted(levels) if levels else range_idx
+            levels_: list[int] = refactor_levels(levels, obj) if levels else range_idx
+            levels_ = sorted(levels_)
 
             if axis == 1:
                 styles = []
-                for i, level in enumerate(levels):
+                for i, level in enumerate(levels_):
                     styles.append(
                         {
                             "selector": f"thead tr:nth-child({level+1}) th",
@@ -1920,7 +1921,7 @@ class Styler(StylerRenderer):
 
             else:
                 styles = []
-                for i, level in enumerate(levels):
+                for i, level in enumerate(levels_):
                     props_ = props + (
                         f"left:{i * pixel_size}px; "
                         f"min-width:{pixel_size}px; "

--- a/pandas/tests/io/formats/style/test_html.py
+++ b/pandas/tests/io/formats/style/test_html.py
@@ -365,11 +365,13 @@ def test_sticky_mi(styler_mi, index, columns):
 
 @pytest.mark.parametrize("index", [False, True])
 @pytest.mark.parametrize("columns", [False, True])
-def test_sticky_levels(styler_mi, index, columns):
+@pytest.mark.parametrize("levels", [[1], ["one"], "one"])
+def test_sticky_levels(styler_mi, index, columns, levels):
+    styler_mi.index.names, styler_mi.columns.names = ["zero", "one"], ["zero", "one"]
     if index:
-        styler_mi.set_sticky(axis=0, levels=[1])
+        styler_mi.set_sticky(axis=0, levels=levels)
     if columns:
-        styler_mi.set_sticky(axis=1, levels=[1])
+        styler_mi.set_sticky(axis=1, levels=levels)
 
     left_css = (
         "#T_ {0} {{\n  position: sticky;\n  background-color: white;\n"


### PR DESCRIPTION
- [x] closes #43483 
- [x] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
