### PR TITLE
PERF: grouped_reduce

### DIFF
--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1248,6 +1248,7 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         BlockManager
         """
         result_blocks: list[Block] = []
+        dropped_any = False
 
         for blk in self.blocks:
             if blk.is_object:
@@ -1259,6 +1260,7 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
                     except (TypeError, NotImplementedError):
                         if not ignore_failures:
                             raise
+                        dropped_any = True
                         continue
                     result_blocks = extend_blocks(applied, result_blocks)
             else:
@@ -1267,6 +1269,7 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
                 except (TypeError, NotImplementedError):
                     if not ignore_failures:
                         raise
+                    dropped_any = True
                     continue
                 result_blocks = extend_blocks(applied, result_blocks)
 
@@ -1275,7 +1278,8 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         else:
             index = Index(range(result_blocks[0].values.shape[-1]))
 
-        if ignore_failures:
+        if dropped_any:
+            # faster to skip _combine if we haven't dropped any blocks
             return self._combine(result_blocks, copy=False, index=index)
 
         return type(self).from_blocks(result_blocks, [self.axes[0], index])


### PR DESCRIPTION
```
from asv_bench.benchmarks.groupby import *
self = GroupByMethods()
self.setup("int", "std", "transformation", 10)

%timeit self.time_dtype_as_field('int', 'std', 'transformation', 10)
325 µs ± 9.84 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)  # <- PR
361 µs ± 2.05 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)  # <- master
```