### PR TITLE
PERF: GroupBy.apply

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1013,11 +1013,12 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
 
         if not not_indexed_same:
             result = concat(values, axis=self.axis)
-            ax = (
-                self.filter(lambda x: True).axes[self.axis]
-                if self.dropna
-                else self._selected_obj._get_axis(self.axis)
-            )
+
+            ax = self._selected_obj._get_axis(self.axis)
+            if self.dropna:
+                labels = self.grouper.group_info[0]
+                mask = labels != -1
+                ax = ax[mask]
 
             # this is a very unfortunate situation
             # we can't use reindex to restore the original order


### PR DESCRIPTION
```
from asv_bench.benchmarks.groupby import *
self = Apply()
self.setup(4)

%timeit self.time_copy_function_multi_col(4)
451 ms ± 2.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)  # <- PR
559 ms ± 1.35 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)  # <- master
```