### PR TITLE
DOC : DataFrame.to_parquet doesn't round-trip pyarrow StringDtype #42664

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -5491,6 +5491,27 @@ The above example creates a partitioned dataset that may look like:
    except OSError:
        pass
 
+.. note::
+
+   * The parquet representation of ``StringDtype`` is the same, regardless of the storage.
+   * The data will be read in accordance with the ``string_storage`` settings.
+
+.. ipython:: python
+
+    df1 = pd.DataFrame({"A": pd.array(['a', 'b'], dtype=pd.StringDtype("pyarrow"))})
+    df2 = pd.DataFrame({"A": pd.array(['a', 'b'], dtype=pd.StringDtype("python"))})
+
+    df1.to_parquet("test.parquet")
+    with pd.option_context("string_storage", "pyarrow"):
+        b = pd.read_parquet("test.parquet")
+    pd.testing.assert_frame_equal(b, a)
+
+    df2.to_parquet("test.parquet")
+    with pd.option_context("string_storage", "pyarrow"):
+        b = pd.read_parquet("test.parquet")
+    pd.testing.assert_frame_equal(b, a)
+
+
 .. _io.orc:
 
 ORC

--- a/doc/source/user_guide/text.rst
+++ b/doc/source/user_guide/text.rst
@@ -85,6 +85,11 @@ or convert from existing pandas data:
    s2
    type(s2[0])
 
+.. note::
+
+   * The parquet representation of `StringDtype` is the same, regardless of the storage.
+   * The data will be read in accordance with the `string_storage` settings.
+
 
 .. _text.differences:
 


### PR DESCRIPTION
- [ ] closes #42664 

Added a small note, both in _user_guide/text.rst_ and _user_guide/io.rst_ and example.
