### PR TITLE
REGR: spearman corr raising on 32-bit

### DIFF
--- a/doc/source/whatsnew/v1.3.4.rst
+++ b/doc/source/whatsnew/v1.3.4.rst
@@ -15,6 +15,7 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Fixed regression in :meth:`merge` with integer and ``NaN`` keys failing with ``outer`` merge (:issue:`43550`)
+- Fixed regression in :meth:`DataFrame.corr` raising ``ValueError`` with ``method="spearman`` on 32-bit platforms (:issue:`43588`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/tests/frame/methods/test_cov_corr.py
+++ b/pandas/tests/frame/methods/test_cov_corr.py
@@ -100,7 +100,6 @@ class TestDataFrameCorr:
 
     # ---------------------------------------------------------------------
 
-    @td.skip_if_no_scipy
     def test_corr_non_numeric(self, float_string_frame):
         # exclude non-numeric types
         result = float_string_frame.corr()
@@ -125,11 +124,9 @@ class TestDataFrameCorr:
         assert rs.loc["B", "B"] == 1
         assert isna(rs.loc["C", "C"])
 
-    @td.skip_if_no_scipy
     @pytest.mark.parametrize("meth", ["pearson", "spearman"])
     def test_corr_constant(self, meth):
         # constant --> all NA
-
         df = DataFrame(
             {
                 "A": [1, 1, 1, np.nan, np.nan, np.nan],


### PR DESCRIPTION
- [x] closes #43588
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

This works on master, so this PR just adds a regression test (by removing the unnecessary `scipy` skips, this should be ensuring that some `spearman` tests will be run on 32-bit).

In the backport, these tests with the skip removed should fail, but the fix should be tiny (replacing 2 `int64` with `intp`)