### PR TITLE
BUG: Groupby-Apply with modifying dataframe and sorting overwrites group values 

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -171,6 +171,10 @@ _apply_docs = {
         The resulting dtype will reflect the return value of the passed ``func``,
         see the examples below.
 
+    Functions that mutate the passed object can produce unexpected
+    behavior or errors and are not supported. See :ref:`gotchas.udf-mutation`
+    for more details.
+
     Examples
     --------
     {examples}


### PR DESCRIPTION
xref #36602 

- [x] closes #36602
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
