### PR TITLE
DOC: add json_normalize in See Also for read_json

### DIFF
--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -502,6 +502,7 @@ def read_json(
     --------
     DataFrame.to_json : Convert a DataFrame to a JSON string.
     Series.to_json : Convert a Series to a JSON string.
+    json_normalize : Normalize semi-structured JSON data into a flat table
 
     Notes
     -----

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -502,7 +502,7 @@ def read_json(
     --------
     DataFrame.to_json : Convert a DataFrame to a JSON string.
     Series.to_json : Convert a Series to a JSON string.
-    json_normalize : Normalize semi-structured JSON data into a flat table
+    json_normalize : Normalize semi-structured JSON data into a flat table.
 
     Notes
     -----


### PR DESCRIPTION
I believe this should link https://pandas.pydata.org/pandas-docs/version/1.2.0/reference/api/pandas.json_normalize.html in https://pandas.pydata.org/docs/reference/api/pandas.io.json.read_json.html#pandas.io.json.read_json

`json_normalize` is great and it may help people working with JSON data who are likely to have an entry point of the `read_json` page