### PR TITLE
REF: concat on bm_axis==0

### DIFF
--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -37,7 +37,6 @@ from pandas.core.dtypes.concat import (
 )
 from pandas.core.dtypes.dtypes import ExtensionDtype
 
-import pandas.core.algorithms as algos
 from pandas.core.arrays import (
     DatetimeArray,
     ExtensionArray,
@@ -201,35 +200,17 @@ def concatenate_managers(
     # assert all(not x[1] for x in mgrs_indexers)
 
     if concat_axis == 0:
-        mgrs = [x[0] for x in mgrs_indexers]
+        return _concat_managers_axis0(mgrs_indexers, axes, copy)
 
-        offset = 0
-        blocks = []
-        for mgr in mgrs:
-            for blk in mgr.blocks:
-                if copy:
-                    nb = blk.copy()
-                else:
-                    # by slicing instead of copy(deep=False), we get a new array
-                    #  object, see test_concat_copy
-                    nb = blk.getitem_block(slice(None))
-                nb._mgr_locs = nb._mgr_locs.add(offset)
-                blocks.append(nb)
-
-            offset += len(mgr.items)
-        return BlockManager(tuple(blocks), axes)
-
-    concat_plans = [
-        _get_mgr_concatenation_plan(mgr, indexers) for mgr, indexers in mgrs_indexers
-    ]
-    concat_plan = _combine_concat_plans(concat_plans, concat_axis)
+    concat_plans = [_get_mgr_concatenation_plan(mgr) for mgr, _ in mgrs_indexers]
+    concat_plan = _combine_concat_plans(concat_plans)
     blocks = []
 
     for placement, join_units in concat_plan:
         unit = join_units[0]
         blk = unit.block
 
-        if len(join_units) == 1 and not join_units[0].indexers:
+        if len(join_units) == 1:
             values = blk.values
             if copy:
                 values = values.copy()
@@ -253,7 +234,7 @@ def concatenate_managers(
 
             fastpath = blk.values.dtype == values.dtype
         else:
-            values = _concatenate_join_units(join_units, concat_axis, copy=copy)
+            values = _concatenate_join_units(join_units, copy=copy)
             fastpath = False
 
         if fastpath:
@@ -263,6 +244,32 @@ def concatenate_managers(
 
         blocks.append(b)
 
+    return BlockManager(tuple(blocks), axes)
+
+
+def _concat_managers_axis0(
+    mgrs_indexers, axes: list[Index], copy: bool
+) -> BlockManager:
+    """
+    concat_managers specialized to concat_axis=0, with reindexing already
+    having been done in _maybe_reindex_columns_na_proxy.
+    """
+    mgrs = [x[0] for x in mgrs_indexers]
+
+    offset = 0
+    blocks = []
+    for mgr in mgrs:
+        for blk in mgr.blocks:
+            if copy:
+                nb = blk.copy()
+            else:
+                # by slicing instead of copy(deep=False), we get a new array
+                #  object, see test_concat_copy
+                nb = blk.getitem_block(slice(None))
+            nb._mgr_locs = nb._mgr_locs.add(offset)
+            blocks.append(nb)
+
+        offset += len(mgr.items)
     return BlockManager(tuple(blocks), axes)
 
 
@@ -295,14 +302,13 @@ def _maybe_reindex_columns_na_proxy(
     return new_mgrs_indexers
 
 
-def _get_mgr_concatenation_plan(mgr: BlockManager, indexers: dict[int, np.ndarray]):
+def _get_mgr_concatenation_plan(mgr: BlockManager):
     """
-    Construct concatenation plan for given block manager and indexers.
+    Construct concatenation plan for given block manager.
 
     Parameters
     ----------
     mgr : BlockManager
-    indexers : dict of {axis: indexer}
 
     Returns
     -------
@@ -312,27 +318,11 @@ def _get_mgr_concatenation_plan(mgr: BlockManager, indexers: dict[int, np.ndarra
     # Calculate post-reindex shape , save for item axis which will be separate
     # for each block anyway.
     mgr_shape_list = list(mgr.shape)
-    for ax, indexer in indexers.items():
-        mgr_shape_list[ax] = len(indexer)
     mgr_shape = tuple(mgr_shape_list)
-
-    assert 0 not in indexers
-
-    needs_filling = False
-    if 1 in indexers:
-        # indexers[1] is shared by all the JoinUnits, so we can save time
-        #  by only doing this check once
-        if (indexers[1] == -1).any():
-            needs_filling = True
 
     if mgr.is_single_block:
         blk = mgr.blocks[0]
-        return [
-            (
-                blk.mgr_locs,
-                JoinUnit(blk, mgr_shape, indexers, needs_filling=needs_filling),
-            )
-        ]
+        return [(blk.mgr_locs, JoinUnit(blk, mgr_shape))]
 
     blknos = mgr.blknos
     blklocs = mgr.blklocs
@@ -342,8 +332,6 @@ def _get_mgr_concatenation_plan(mgr: BlockManager, indexers: dict[int, np.ndarra
 
         assert placements.is_slice_like
         assert blkno != -1
-
-        join_unit_indexers = indexers.copy()
 
         shape_list = list(mgr_shape)
         shape_list[0] = len(placements)
@@ -376,7 +364,7 @@ def _get_mgr_concatenation_plan(mgr: BlockManager, indexers: dict[int, np.ndarra
         # Assertions disabled for performance
         # assert blk._mgr_locs.as_slice == placements.as_slice
         # assert blk.shape[0] == shape[0]
-        unit = JoinUnit(blk, shape, join_unit_indexers, needs_filling=needs_filling)
+        unit = JoinUnit(blk, shape)
 
         plan.append((placements, unit))
 
@@ -384,22 +372,13 @@ def _get_mgr_concatenation_plan(mgr: BlockManager, indexers: dict[int, np.ndarra
 
 
 class JoinUnit:
-    def __init__(
-        self, block: Block, shape: Shape, indexers=None, *, needs_filling: bool = False
-    ):
+    def __init__(self, block: Block, shape: Shape):
         # Passing shape explicitly is required for cases when block is None.
-        # Note: block is None implies indexers is None, but not vice-versa
-        if indexers is None:
-            indexers = {}
-        # we should *never* have `0 in indexers`
         self.block = block
-        self.indexers = indexers
         self.shape = shape
 
-        self.needs_filling = needs_filling
-
     def __repr__(self) -> str:
-        return f"{type(self).__name__}({repr(self.block)}, {self.indexers})"
+        return f"{type(self).__name__}({repr(self.block)})"
 
     @cache_readonly
     def is_na(self) -> bool:
@@ -416,23 +395,13 @@ class JoinUnit:
 
         else:
 
-            if (not self.indexers) and (not self.block._can_consolidate):
+            if not self.block._can_consolidate:
                 # preserve these for validation in concat_compat
                 return self.block.values
 
             # No dtype upcasting is done here, it will be performed during
             # concatenation itself.
             values = self.block.values
-
-        if not self.indexers:
-            # If there's no indexing to be done, we want to signal outside
-            # code that this array must be copied explicitly.  This is done
-            # by returning a view and checking `retval.base`.
-            values = values.view()
-
-        else:
-            for ax, indexer in self.indexers.items():
-                values = algos.take_nd(values, indexer, axis=ax)
 
         return values
 
@@ -471,15 +440,10 @@ def make_na_array(dtype: DtypeObj, shape: Shape) -> ArrayLike:
         return missing_arr
 
 
-def _concatenate_join_units(
-    join_units: list[JoinUnit], concat_axis: int, copy: bool
-) -> ArrayLike:
+def _concatenate_join_units(join_units: list[JoinUnit], copy: bool) -> ArrayLike:
     """
-    Concatenate values from several join units along selected axis.
+    Concatenate values from several join units along axis=1.
     """
-    if concat_axis == 0 and len(join_units) > 1:
-        # Concatenating join units along ax0 is handled in _merge_blocks.
-        raise AssertionError("Concatenating join units along axis0")
 
     empty_dtype = _get_empty_dtype(join_units)
 
@@ -513,7 +477,7 @@ def _concatenate_join_units(
         concat_values = ensure_block_shape(concat_values, 2)
 
     else:
-        concat_values = concat_compat(to_concat, axis=concat_axis)
+        concat_values = concat_compat(to_concat, axis=1)
 
     return concat_values
 
@@ -594,9 +558,6 @@ def _is_uniform_join_units(join_units: list[JoinUnit]) -> bool:
         # unless we're an extension dtype.
         all(not ju.is_na or ju.block.is_extension for ju in join_units)
         and
-        # no blocks with indexers (as then the dimensions do not fit)
-        all(not ju.indexers for ju in join_units)
-        and
         # only use this path when there is something to concatenate
         len(join_units) > 1
     )
@@ -616,8 +577,6 @@ def _trim_join_unit(join_unit: JoinUnit, length: int) -> JoinUnit:
 
     Extra items that didn't fit are returned as a separate block.
     """
-    assert 0 not in join_unit.indexers
-    extra_indexers = join_unit.indexers
 
     extra_block = join_unit.block.getitem_block(slice(length, None))
     join_unit.block = join_unit.block.getitem_block(slice(length))
@@ -625,16 +584,10 @@ def _trim_join_unit(join_unit: JoinUnit, length: int) -> JoinUnit:
     extra_shape = (join_unit.shape[0] - length,) + join_unit.shape[1:]
     join_unit.shape = (length,) + join_unit.shape[1:]
 
-    # extra_indexers does not introduce any -1s, so we can inherit needs_filling
-    return JoinUnit(
-        block=extra_block,
-        indexers=extra_indexers,
-        shape=extra_shape,
-        needs_filling=join_unit.needs_filling,
-    )
+    return JoinUnit(block=extra_block, shape=extra_shape)
 
 
-def _combine_concat_plans(plans, concat_axis: int):
+def _combine_concat_plans(plans):
     """
     Combine multiple concatenation plans into one.
 
@@ -643,18 +596,6 @@ def _combine_concat_plans(plans, concat_axis: int):
     if len(plans) == 1:
         for p in plans[0]:
             yield p[0], [p[1]]
-
-    elif concat_axis == 0:
-        offset = 0
-        for plan in plans:
-            last_plc = None
-
-            for plc, unit in plan:
-                yield plc.add(offset), [unit]
-                last_plc = plc
-
-            if last_plc is not None:
-                offset += last_plc.as_slice.stop
 
     else:
         # singleton list so we can modify it as a side-effect within _next_or_none

--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -293,7 +293,8 @@ def _maybe_reindex_columns_na_proxy(
     Columns added in this reindexing have dtype=np.void, indicating they
     should be ignored when choosing a column's final dtype.
     """
-    new_mgrs_indexers = []
+    new_mgrs_indexers: list[tuple[BlockManager, dict[int, np.ndarray]]] = []
+
     for mgr, indexers in mgrs_indexers:
         # For axis=0 (i.e. columns) we use_na_proxy and only_slice, so this
         #  is a cheap reindexing.


### PR DESCRIPTION
Makes it so we no longer need `indexers` in `JoinUnit` (and in fact, so that JoinUnit is only used for axis==1)

```
asv continuous -E virtualenv -f 1.01 master HEAD --append-samples --record-samples -b join_merge
[...]
       before           after         ratio
     [26064f0f]       [5dedf170]
     <master>         <ref-concat-axis0>
-      15.8±0.9ms       15.0±0.4ms     0.95  join_merge.MergeAsof.time_on_int('backward', None)
-      16.8±0.4ms       15.9±0.3ms     0.94  join_merge.MergeAsof.time_on_int('forward', None)
-      19.6±0.9ms       18.5±0.2ms     0.94  join_merge.MergeAsof.time_on_int('nearest', None)
-      16.1±0.4ms       15.1±0.3ms     0.94  join_merge.MergeAsof.time_on_int('backward', 5)
-      17.8±0.9ms       16.7±0.4ms     0.94  join_merge.MergeAsof.time_on_int32('backward', None)
-        84.4±6ms         78.6±2ms     0.93  join_merge.MergeAsof.time_by_object('backward', 5)
-        83.1±3ms         77.3±2ms     0.93  join_merge.MergeAsof.time_by_object('backward', None)
-        20.1±1ms       18.6±0.5ms     0.93  join_merge.MergeAsof.time_on_uint64('nearest', 5)
-      20.2±0.8ms       18.7±0.3ms     0.93  join_merge.MergeAsof.time_on_int('nearest', 5)
-        17.5±1ms       16.2±0.3ms     0.92  join_merge.MergeAsof.time_on_int('forward', 5)
-        22.3±2ms       20.5±0.4ms     0.92  join_merge.MergeAsof.time_on_int32('nearest', 5)
-      18.2±0.4ms       16.8±0.4ms     0.92  join_merge.MergeAsof.time_on_int32('backward', 5)
-        21.8±1ms       19.9±0.4ms     0.91  join_merge.MergeAsof.time_on_int32('nearest', None)
-      19.0±0.9ms       17.2±0.3ms     0.91  join_merge.MergeAsof.time_on_int32('forward', None)
-        17.6±1ms       15.9±0.6ms     0.90  join_merge.MergeAsof.time_on_uint64('forward', 5)
-        335±10ms          300±9ms     0.89  join_merge.Merge.time_merge_dataframes_cross(False)
-         334±7ms         299±10ms     0.89  join_merge.Merge.time_merge_dataframes_cross(True)
-        19.4±2ms         17.2±1ms     0.89  join_merge.Join.time_join_dataframe_index_multi(True)
-        17.1±1ms       15.1±0.2ms     0.88  join_merge.MergeAsof.time_on_uint64('backward', None)
-        10.3±1ms       8.97±0.4ms     0.87  join_merge.Join.time_join_dataframe_index_shuffle_key_bigger_sort(True)
-      19.9±0.7ms       17.4±0.4ms     0.87  join_merge.MergeAsof.time_on_int32('forward', 5)
-        18.6±1ms       15.9±0.2ms     0.86  join_merge.MergeAsof.time_on_uint64('forward', None)
-        8.44±1ms       7.20±0.7ms     0.85  join_merge.Join.time_join_dataframe_index_single_key_small(False)
-      1.98±0.09s       1.58±0.04s     0.80  join_merge.JoinIndex.time_left_outer_join_index
-      9.80±0.8ms       7.61±0.8ms     0.78  join_merge.Join.time_join_dataframe_index_single_key_bigger(False)
-      9.39±0.5ms       7.25±0.4ms     0.77  join_merge.Concat.time_concat_small_frames(1)
-        221±20ms          170±4ms     0.77  join_merge.MergeCategoricals.time_merge_cat
-        439±10ms          300±9ms     0.68  join_merge.MergeCategoricals.time_merge_object
```