### PR TITLE
DOC: sync 1.3.4 release notes on 1.3.x with master

### DIFF
--- a/doc/source/whatsnew/v1.3.4.rst
+++ b/doc/source/whatsnew/v1.3.4.rst
@@ -15,10 +15,10 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Fixed regression in :meth:`merge` with integer and ``NaN`` keys failing with ``outer`` merge (:issue:`43550`)
+- Fixed regression in :meth:`DataFrame.corr` raising ``ValueError`` with ``method="spearman`` on 32-bit platforms (:issue:`43588`)
 - Fixed performance regression in :meth:`MultiIndex.equals` (:issue:`43549`)
 - Fixed regression in :meth:`Series.cat.reorder_categories` failing to update the categories on the ``Series`` (:issue:`43232`)
 - Fixed regression in :meth:`Series.cat.categories` setter failing to update the categories on the ``Series`` (:issue:`43334`)
-- Fixed regression in :meth:`DataFrame.corr` raising ``ValueError`` with ``method="spearman`` on 32-bit platforms (:issue:`43588`)
 -
 
 .. ---------------------------------------------------------------------------


### PR DESCRIPTION
This is directly against 1.3.x branch so no backport required.