### PR TITLE
BUG: add css conversion for new `Styler.apply_index` styles

### DIFF
--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -1636,7 +1636,11 @@ def _parse_latex_cell_styles(
 
 
 def _parse_latex_header_span(
-    cell: dict[str, Any], multirow_align: str, multicol_align: str, wrap: bool = False
+    cell: dict[str, Any],
+    multirow_align: str,
+    multicol_align: str,
+    wrap: bool = False,
+    convert_css: bool = False,
 ) -> str:
     r"""
     Refactor the cell `display_value` if a 'colspan' or 'rowspan' attribute is present.
@@ -1657,7 +1661,9 @@ def _parse_latex_header_span(
     >>> _parse_latex_header_span(cell, 't', 'c')
     '\\multicolumn{3}{c}{text}'
     """
-    display_val = _parse_latex_cell_styles(cell["cellstyle"], cell["display_value"])
+    display_val = _parse_latex_cell_styles(
+        cell["cellstyle"], cell["display_value"], convert_css
+    )
     if "attributes" in cell:
         attrs = cell["attributes"]
         if 'colspan="' in attrs:

--- a/pandas/io/formats/templates/latex_table.tpl
+++ b/pandas/io/formats/templates/latex_table.tpl
@@ -31,7 +31,7 @@
 \{{toprule}}
 {% endif %}
 {% for row in head %}
-{% for c in row %}{%- if not loop.first %} & {% endif %}{{parse_header(c, multirow_align, multicol_align, siunitx)}}{% endfor %} \\
+{% for c in row %}{%- if not loop.first %} & {% endif %}{{parse_header(c, multirow_align, multicol_align, siunitx, convert_css)}}{% endfor %} \\
 {% endfor %}
 {% set midrule = parse_table(table_styles, 'midrule') %}
 {% if midrule is not none %}
@@ -39,7 +39,7 @@
 {% endif %}
 {% for row in body %}
 {% for c in row %}{% if not loop.first %} & {% endif %}
-  {%- if c.type == 'th' %}{{parse_header(c, multirow_align, multicol_align)}}{% else %}{{parse_cell(c.cellstyle, c.display_value, convert_css)}}{% endif %}
+  {%- if c.type == 'th' %}{{parse_header(c, multirow_align, multicol_align, False, convert_css)}}{% else %}{{parse_cell(c.cellstyle, c.display_value, convert_css)}}{% endif %}
 {%- endfor %} \\
 {% endfor %}
 {% set bottomrule = parse_table(table_styles, 'bottomrule') %}

--- a/pandas/tests/io/formats/style/test_to_latex.py
+++ b/pandas/tests/io/formats/style/test_to_latex.py
@@ -782,3 +782,10 @@ def test_repr_option(styler):
 def test_siunitx_basic_headers(styler):
     assert "{} & {A} & {B} & {C} \\\\" in styler.to_latex(siunitx=True)
     assert " & A & B & C \\\\" in styler.to_latex()  # default siunitx=False
+
+
+@pytest.mark.parametrize("axis", ["index", "columns"])
+def test_css_convert_apply_index(styler, axis):
+    styler.applymap_index(lambda x: "font-weight: bold;", axis=axis)
+    for label in getattr(styler, axis):
+        assert f"\\bfseries {label}" in styler.to_latex(convert_css=True)


### PR DESCRIPTION
- [x] closes #43648

no whats new needed since `apply_index` is new to 1.4.0 and this just makes it more complete.
