### PR TITLE
ENH: omit CSSStyle rules for hidden table elements (#43619)

### DIFF
--- a/doc/source/whatsnew/v1.3.4.rst
+++ b/doc/source/whatsnew/v1.3.4.rst
@@ -33,9 +33,10 @@ Bug fixes
 
 .. _whatsnew_134.other:
 
-Performance improvements
-~~~~~~~~~~~~~~~~~~~~~~~~
-- Performance improvement in :meth:`Styler.to_html` by omitting CSSStyle rules for hidden table cells (:issue:`43619`)
+Other
+~~~~~
+-
+-
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.3.4.rst
+++ b/doc/source/whatsnew/v1.3.4.rst
@@ -33,10 +33,9 @@ Bug fixes
 
 .. _whatsnew_134.other:
 
-Other
-~~~~~
--
--
+Performance improvements
+~~~~~~~~~~~~~~~~~~~~~~~~
+- Performance improvement in :meth:`Styler.to_html` by omitting CSSStyle rules for hidden table cells (:issue:`43619`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -79,6 +79,7 @@ Styler
   - Keyword arguments ``level`` and ``names`` added to :meth:`.Styler.hide_index` and :meth:`.Styler.hide_columns` for additional control of visibility of MultiIndexes and index names (:issue:`25475`, :issue:`43404`, :issue:`43346`)
   - Global options have been extended to configure default ``Styler`` properties including formatting and encoding and mathjax options and LaTeX (:issue:`41395`)
   - Naive sparsification is now possible for LaTeX without the multirow package (:issue:`43369`)
+  - :meth:`Styler.to_html` omits CSSStyle rules for hidden table elements (:issue:`43619`)
 
 Formerly Styler relied on ``display.html.use_mathjax``, which has now been replaced by ``styler.html.mathjax``.
 

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -537,11 +537,14 @@ class StylerRenderer:
 
             index_headers = []
             for c, value in enumerate(rlabels[r]):
+                header_element_visible = (
+                    _is_visible(r, c, idx_lengths) and not self.hide_index_[c]
+                )
                 header_element = _element(
                     "th",
                     f"{row_heading_class} level{c} row{r}",
                     value,
-                    _is_visible(r, c, idx_lengths) and not self.hide_index_[c],
+                    header_element_visible,
                     display_value=self._display_funcs_index[(r, c)](value),
                     attributes=(
                         f'rowspan="{idx_lengths.get((c, r), 0)}"'
@@ -552,7 +555,11 @@ class StylerRenderer:
 
                 if self.cell_ids:
                     header_element["id"] = f"level{c}_row{r}"  # id is specified
-                if (r, c) in self.ctx_index and self.ctx_index[r, c]:
+                if (
+                    header_element_visible
+                    and (r, c) in self.ctx_index
+                    and self.ctx_index[r, c]
+                ):
                     # always add id if a style is specified
                     header_element["id"] = f"level{c}_row{r}"
                     self.cellstyle_map_index[tuple(self.ctx_index[r, c])].append(
@@ -580,21 +587,21 @@ class StylerRenderer:
                 if (r, c) in self.cell_context:
                     cls = " " + self.cell_context[r, c]
 
-                data_element_is_visible = (
+                data_element_visible = (
                     c not in self.hidden_columns and r not in self.hidden_rows
                 )
                 data_element = _element(
                     "td",
                     f"{data_class} row{r} col{c}{cls}",
                     value,
-                    data_element_is_visible,
+                    data_element_visible,
                     attributes="",
                     display_value=self._display_funcs[(r, c)](value),
                 )
 
                 if self.cell_ids:
                     data_element["id"] = f"row{r}_col{c}"
-                if data_element_is_visible and (r, c) in self.ctx and self.ctx[r, c]:
+                if data_element_visible and (r, c) in self.ctx and self.ctx[r, c]:
                     # always add id if needed due to specified style
                     data_element["id"] = f"row{r}_col{c}"
                     self.cellstyle_map[tuple(self.ctx[r, c])].append(f"row{r}_col{c}")

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -378,11 +378,12 @@ class StylerRenderer:
                 if clabels:
                     column_headers = []
                     for c, value in enumerate(clabels[r]):
+                        header_element_visible = _is_visible(c, r, col_lengths)
                         header_element = _element(
                             "th",
                             f"{col_heading_class} level{r} col{c}",
                             value,
-                            _is_visible(c, r, col_lengths),
+                            header_element_visible,
                             display_value=self._display_funcs_columns[(r, c)](value),
                             attributes=(
                                 f'colspan="{col_lengths.get((r, c), 0)}"'
@@ -393,7 +394,11 @@ class StylerRenderer:
 
                         if self.cell_ids:
                             header_element["id"] = f"level{r}_col{c}"
-                        if (r, c) in self.ctx_columns and self.ctx_columns[r, c]:
+                        if (
+                            header_element_visible
+                            and (r, c) in self.ctx_columns
+                            and self.ctx_columns[r, c]
+                        ):
                             header_element["id"] = f"level{r}_col{c}"
                             self.cellstyle_map_columns[
                                 tuple(self.ctx_columns[r, c])

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -580,18 +580,21 @@ class StylerRenderer:
                 if (r, c) in self.cell_context:
                     cls = " " + self.cell_context[r, c]
 
+                data_element_is_visible = (
+                    c not in self.hidden_columns and r not in self.hidden_rows
+                )
                 data_element = _element(
                     "td",
                     f"{data_class} row{r} col{c}{cls}",
                     value,
-                    (c not in self.hidden_columns and r not in self.hidden_rows),
+                    data_element_is_visible,
                     attributes="",
                     display_value=self._display_funcs[(r, c)](value),
                 )
 
                 if self.cell_ids:
                     data_element["id"] = f"row{r}_col{c}"
-                if (r, c) in self.ctx and self.ctx[r, c]:
+                if data_element_is_visible and (r, c) in self.ctx and self.ctx[r, c]:
                     # always add id if needed due to specified style
                     data_element["id"] = f"row{r}_col{c}"
                     self.cellstyle_map[tuple(self.ctx[r, c])].append(f"row{r}_col{c}")

--- a/pandas/tests/io/formats/style/test_html.py
+++ b/pandas/tests/io/formats/style/test_html.py
@@ -467,3 +467,42 @@ def test_maximums(styler_mi, rows, cols):
     assert ">5</td>" in result  # [[0,1], [4,5]] always visible
     assert (">8</td>" in result) is not rows  # first trimmed vertical element
     assert (">2</td>" in result) is not cols  # first trimmed horizontal element
+
+
+def test_omit_css_style_rules_for_hidden_cells():
+    # GH 43619
+    df = DataFrame([[1, 2], [3, 4]], columns=["A", "B"])
+    result = (
+        df.style.set_uuid("")
+        .background_gradient()
+        .hide_columns(["A"])
+        .hide_index([0])
+        .to_html()
+    )
+    expected = dedent(
+        """\
+        <style type="text/css">
+        #T__row1_col1 {
+          background-color: #023858;
+          color: #f1f1f1;
+        }
+        </style>
+        <table id="T_">
+          <thead>
+            <tr>
+              <th class="blank level0" >&nbsp;</th>
+              <th id="T__level0_col1" class="col_heading level0 col1" >B</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+            </tr>
+            <tr>
+              <th id="T__level0_row1" class="row_heading level0 row1" >1</th>
+              <td id="T__row1_col1" class="data row1 col1" >4</td>
+            </tr>
+          </tbody>
+        </table>
+        """
+    )
+    assert result == expected

--- a/pandas/tests/io/formats/style/test_html.py
+++ b/pandas/tests/io/formats/style/test_html.py
@@ -469,40 +469,22 @@ def test_maximums(styler_mi, rows, cols):
     assert (">2</td>" in result) is not cols  # first trimmed horizontal element
 
 
-def test_omit_css_style_rules_for_hidden_cells():
+def test_include_css_style_rules_only_for_visible_cells(styler_mi):
     # GH 43619
-    df = DataFrame([[1, 2], [3, 4]], columns=["A", "B"])
     result = (
-        df.style.set_uuid("")
-        .background_gradient()
-        .hide_columns(["A"])
-        .hide_index([0])
+        styler_mi.set_uuid("")
+        .applymap(lambda v: "color: blue;")
+        .hide_columns(styler_mi.data.columns[1:])
+        .hide_index(styler_mi.data.index[1:])
         .to_html()
     )
-    expected = dedent(
+    expected_styles = dedent(
         """\
         <style type="text/css">
-        #T__row1_col1 {
-          background-color: #023858;
-          color: #f1f1f1;
+        #T__row0_col0 {
+          color: blue;
         }
         </style>
-        <table id="T_">
-          <thead>
-            <tr>
-              <th class="blank level0" >&nbsp;</th>
-              <th id="T__level0_col1" class="col_heading level0 col1" >B</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-            </tr>
-            <tr>
-              <th id="T__level0_row1" class="row_heading level0 row1" >1</th>
-              <td id="T__row1_col1" class="data row1 col1" >4</td>
-            </tr>
-          </tbody>
-        </table>
         """
     )
-    assert result == expected
+    assert expected_styles in result

--- a/pandas/tests/io/formats/style/test_html.py
+++ b/pandas/tests/io/formats/style/test_html.py
@@ -488,3 +488,24 @@ def test_include_css_style_rules_only_for_visible_cells(styler_mi):
         """
     )
     assert expected_styles in result
+
+
+def test_include_css_style_rules_only_for_visible_index_labels(styler_mi):
+    # GH 43619
+    result = (
+        styler_mi.set_uuid("")
+        .applymap_index(lambda v: "color: blue;", axis="index")
+        .hide_columns(styler_mi.data.columns)
+        .hide_index(styler_mi.data.index[1:])
+        .to_html()
+    )
+    expected_styles = dedent(
+        """\
+        <style type="text/css">
+        #T__level0_row0, #T__level1_row0 {
+          color: blue;
+        }
+        </style>
+        """
+    )
+    assert expected_styles in result

--- a/pandas/tests/io/formats/style/test_html.py
+++ b/pandas/tests/io/formats/style/test_html.py
@@ -509,3 +509,24 @@ def test_include_css_style_rules_only_for_visible_index_labels(styler_mi):
         """
     )
     assert expected_styles in result
+
+
+def test_include_css_style_rules_only_for_visible_column_labels(styler_mi):
+    # GH 43619
+    result = (
+        styler_mi.set_uuid("")
+        .applymap_index(lambda v: "color: blue;", axis="columns")
+        .hide_columns(styler_mi.data.columns[1:])
+        .hide_index(styler_mi.data.index)
+        .to_html()
+    )
+    expected_styles = dedent(
+        """\
+        <style type="text/css">
+        #T__level0_col0, #T__level1_col0 {
+          color: blue;
+        }
+        </style>
+        """
+    )
+    assert expected_styles in result


### PR DESCRIPTION
- [x] closes #43619
- [x] tests added / passed (but canceled due to another error)
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

I couldn't run all tests, because of the following problem, which isn't related to my changes:
```
pandas/tests/io/test_orc.py terminate called after throwing an instance of 'orc::TimezoneError'
  what():  Can't open /etc/localtime
Fatal Python error: Aborted
``` 