### PR TITLE
PERF: Groupby.any/all object dtype

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1658,6 +1658,8 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
                     vals = func(vals)
                 else:
                     vals = vals.astype(bool, copy=False)
+
+                vals = cast(np.ndarray, vals)
             elif isinstance(vals, BaseMaskedArray):
                 vals = vals._data.astype(bool, copy=False)
             else:

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1654,9 +1654,10 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
             if is_object_dtype(vals.dtype):
                 # GH#37501: don't raise on pd.NA when skipna=True
                 if skipna:
-                    vals = np.array([bool(x) if not isna(x) else True for x in vals])
+                    func = np.vectorize(lambda x: bool(x) if not isna(x) else True)
+                    vals = func(vals)
                 else:
-                    vals = np.array([bool(x) for x in vals])
+                    vals = vals.astype(bool, copy=False)
             elif isinstance(vals, BaseMaskedArray):
                 vals = vals._data.astype(bool, copy=False)
             else:


### PR DESCRIPTION
```
from asv_bench.benchmarks.groupby import *
self = GroupByMethods()
self.setup("object", "any", "direct", 10)
 

%timeit self.time_dtype_as_field("object", "any", "direct", 10)
1.12 ms ± 60.7 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)  # <- PR
11.4 ms ± 49.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)   # <- master
```