### PR TITLE
WIP: Debug Slow Database CI

### DIFF
--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -74,7 +74,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: pandas-dev
-        channel-priority: flexible
+        channel-priority: strict
         environment-file: ${{ matrix.ENV_FILE }}
         use-only-tar-bz2: true
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry


Database / Linux_py37_IO (ci/deps/actions-37-db-min.yaml) (pull_request) is the offending job, taking up to 6 hours to resolve dependencies. Let's find out why.
