### PR TITLE
POC: New UDF methods option

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -609,7 +609,9 @@ class Apply(metaclass=abc.ABCMeta):
             is_ndframe = [isinstance(r, ABCNDFrame) for r in results]
 
         # combine results
+        result: DataFrame | Series
         if all(is_ndframe):
+            keys_to_use: Iterable[Hashable]
             keys_to_use = [k for k in arg.keys() if not results[k].empty]
             keys_to_use = keys_to_use if keys_to_use != [] else arg.keys()
             if selected_obj.ndim == 2:
@@ -619,8 +621,6 @@ class Apply(metaclass=abc.ABCMeta):
                 keys_to_use = ktu
             keys = None if selected_obj.ndim == 1 else keys_to_use
             result = concat({k: results[k] for k in keys_to_use}, keys=keys, axis=1)
-            if result.ndim == 1:
-                result = result.to_frame()
         elif any(is_ndframe):
             # There is a mix of NDFrames and scalars
             raise ValueError(

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -511,6 +511,23 @@ with cf.config_prefix("mode"):
         validator=is_one_of_factory(["block", "array"]),
     )
 
+new_udf_methods = """
+: boolean
+    Whether to use the new UDF method implementations. Currently experimental.
+    Defaults to False.
+"""
+
+
+with cf.config_prefix("mode"):
+    cf.register_option(
+        "new_udf_methods",
+        # Get the default from an environment variable, if set, otherwise defaults
+        # to "block". This environment variable can be set for testing.
+        os.environ.get("PANDAS_NEW_UDF_METHODS", "false").lower() == "true",
+        new_udf_methods,
+        validator=is_bool,
+    )
+
 
 # user warnings
 chained_assignment = """

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8609,9 +8609,11 @@ NaN 12.3   33.0
 
         axis = self._get_axis_number(axis)
 
-        relabeling, func, columns, order = reconstruct_func(func, **kwargs)
+        relabeling, func, columns, order, renamer = reconstruct_func(func, **kwargs)
 
-        op = frame_apply(self, func=func, axis=axis, args=args, kwargs=kwargs)
+        op = frame_apply(
+            self, func=func, axis=axis, args=args, kwargs=kwargs, renamer=renamer
+        )
         result = op.agg()
 
         if relabeling:

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1450,9 +1450,9 @@ def test_apply_no_suffix_index(request):
     result = pdf.apply([np.square, lambda x: x, lambda x: x])
     if get_option("mode.new_udf_methods"):
         columns = MultiIndex.from_product(
-            [["A", "B"], ["square", "<lambda>", "<lambda>"]]
+            [["square", "<lambda>", "<lambda>"], ["A", "B"]]
         )
-        expected = DataFrame([[16, 4, 4, 81, 9, 9]], columns=columns)
+        expected = DataFrame(3 * [[16, 81, 4, 9, 4, 9]], columns=columns)
     else:
         columns = MultiIndex.from_product(
             [["A", "B"], ["square", "<lambda>", "<lambda>"]]

--- a/pandas/tests/groupby/aggregate/test_other.py
+++ b/pandas/tests/groupby/aggregate/test_other.py
@@ -8,6 +8,8 @@ from functools import partial
 import numpy as np
 import pytest
 
+from pandas._config import get_option
+
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -201,13 +203,21 @@ def test_aggregate_api_consistency():
     tm.assert_frame_equal(result, expected, check_like=True)
 
     result = grouped.agg([np.sum, np.mean])
-    expected = pd.concat([c_sum, c_mean, d_sum, d_mean], axis=1)
-    expected.columns = MultiIndex.from_product([["C", "D"], ["sum", "mean"]])
+    if get_option("new_udf_methods"):
+        expected = pd.concat([c_sum, d_sum, c_mean, d_mean], axis=1)
+        expected.columns = MultiIndex.from_product([["sum", "mean"], ["C", "D"]])
+    else:
+        expected = pd.concat([c_sum, c_mean, d_sum, d_mean], axis=1)
+        expected.columns = MultiIndex.from_product([["C", "D"], ["sum", "mean"]])
     tm.assert_frame_equal(result, expected, check_like=True)
 
     result = grouped[["D", "C"]].agg([np.sum, np.mean])
-    expected = pd.concat([d_sum, d_mean, c_sum, c_mean], axis=1)
-    expected.columns = MultiIndex.from_product([["D", "C"], ["sum", "mean"]])
+    if get_option("new_udf_methods"):
+        expected = pd.concat([d_sum, c_sum, d_mean, c_mean], axis=1)
+        expected.columns = MultiIndex.from_product([["sum", "mean"], ["D", "C"]])
+    else:
+        expected = pd.concat([d_sum, d_mean, c_sum, c_mean], axis=1)
+        expected.columns = MultiIndex.from_product([["D", "C"], ["sum", "mean"]])
     tm.assert_frame_equal(result, expected, check_like=True)
 
     result = grouped.agg({"C": "mean", "D": "sum"})
@@ -393,7 +403,10 @@ def test_agg_consistency():
     g = df.groupby("date")
 
     expected = g.agg([P1])
-    expected.columns = expected.columns.levels[0]
+    if get_option("new_udf_methods"):
+        expected.columns = expected.columns.levels[1]
+    else:
+        expected.columns = expected.columns.levels[0]
 
     result = g.agg(P1)
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -14,6 +14,7 @@ from pandas import (
     Series,
     Timestamp,
     date_range,
+    get_option,
 )
 import pandas._testing as tm
 import pandas.core.nanops as nanops
@@ -1138,7 +1139,10 @@ def test_apply_to_nullable_integer_returns_float(values, function):
     tm.assert_frame_equal(result, expected)
 
     result = groups.agg([function])
-    expected.columns = MultiIndex.from_tuples([("b", function)])
+    if get_option("new_udf_methods"):
+        expected.columns = MultiIndex.from_tuples([(function, "b")])
+    else:
+        expected.columns = MultiIndex.from_tuples([("b", function)])
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/resample/test_deprecated.py
+++ b/pandas/tests/resample/test_deprecated.py
@@ -10,6 +10,7 @@ import pandas as pd
 from pandas import (
     DataFrame,
     Series,
+    get_option,
 )
 import pandas._testing as tm
 from pandas.core.indexes.datetimes import date_range
@@ -97,7 +98,10 @@ def test_resample_loffset_arg_type(frame, create_index, arg):
         result_agg = df.resample("2D", loffset="2H").agg(arg)
 
     if isinstance(arg, list):
-        expected.columns = pd.MultiIndex.from_tuples([("value", "mean")])
+        if get_option("new_udf_methods"):
+            expected.columns = pd.MultiIndex.from_tuples([("mean", "value")])
+        else:
+            expected.columns = pd.MultiIndex.from_tuples([("value", "mean")])
 
     tm.assert_frame_equal(result_agg, expected)
 
@@ -216,7 +220,10 @@ def test_loffset_returns_datetimeindex(frame, kind, agg_arg):
     with tm.assert_produces_warning(FutureWarning):
         result_agg = df.resample("2D", loffset="2H", kind=kind).agg(agg_arg)
     if isinstance(agg_arg, list):
-        expected.columns = pd.MultiIndex.from_tuples([("value", "mean")])
+        if get_option("new_udf_methods"):
+            expected.columns = pd.MultiIndex.from_tuples([("mean", "value")])
+        else:
+            expected.columns = pd.MultiIndex.from_tuples([("value", "mean")])
     tm.assert_frame_equal(result_agg, expected)
 
 

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -8,6 +8,8 @@ from itertools import product
 import numpy as np
 import pytest
 
+from pandas._config import get_option
+
 import pandas as pd
 from pandas import (
     Categorical,
@@ -1905,8 +1907,14 @@ class TestPivotTable:
             frame, index=["foo"], aggfunc=len, margins=True, margins_name=greek
         )
         index = Index([1, 2, 3, greek], dtype="object", name="foo")
-        expected = DataFrame(index=index)
-        tm.assert_frame_equal(table, expected)
+
+        if get_option("new_udf_methods"):
+            expected = Series([1, 1, 1, 3], index=index)
+            expected.index.name = None
+            tm.assert_series_equal(table, expected)
+        else:
+            expected = DataFrame(index=index)
+            tm.assert_frame_equal(table, expected)
 
     def test_pivot_string_as_func(self):
         # GH #18713


### PR DESCRIPTION
Start of #41112

- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

The goal is to provide an implementation for apply on lists. See https://github.com/pandas-dev/pandas/issues/41112#issuecomment-902366002 for why this necessitates a change to agg behavior for lists. It is possible to break this up into several PRs, but wanted to give a view as to what it would appear in totality.

Attached is a notebook demonstrating the differences in behavior (github doesn't allow attaching the notebook directly).

[udfs.pdf](https://github.com/pandas-dev/pandas/files/7199652/udfs.pdf)

