### PR TITLE
PERF: dropna

### DIFF
--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -462,6 +462,7 @@ def maybe_operate_rowwise(func: F) -> F:
             and values.ndim == 2
             and values.flags["C_CONTIGUOUS"]
             and values.dtype != object
+            and values.dtype != bool
         ):
             arrs = list(values)
             if kwargs.get("mask") is not None:


### PR DESCRIPTION
```
from asv_bench.benchmarks.frame_methods import *
self3 = Dropna()
self3.setup("all", 0)

%timeit self3.time_dropna('all', 0)
125 ms ± 3.03 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)  # <- master
34.8 ms ± 269 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)  # <- PR
```