### PR TITLE
BUG: Write compliant Parquet with `pyarrow`

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -186,9 +186,45 @@ Now the float-dtype is respected. Since the common dtype for these DataFrames is
 
     res
 
-.. _whatsnew_140.notable_bug_fixes.notable_bug_fix3:
+.. _whatsnew_140.notable_bug_fixes.write_compliant_parquet_nested_type:
 
-notable_bug_fix3
+Write compliant Parquet nested types if possible
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When using :meth:`DataFrame.to_parquet` to write a DataFrame to Parquet, if any of the columns contained arrays
+of values the :mod:`pyarrow` engine would write a non-compliant format. This behavior is now fixed when the installed
+version of PyArrow is at least ``4.0.0``.
+
+https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#nested-types
+
+.. ipython:: python
+
+    import pandas as pd
+    import pyarrow.parquet as pq
+
+    df = pd.DataFrame({"int_array_col": [[1, 2, 3], [4, 5, 6]]})
+    df.to_parquet("/tmp/sample_df")
+    parquet_table = pq.read_table("/tmp/sample_df")
+
+*Previous behavior*:
+
+.. code-block:: ipython
+
+    In [4]: parquet_table.schema.types
+    Out[4]:
+    [ListType(list<item: int64>)]
+
+*New behavior*:
+
+.. code-block:: ipython
+
+    In [4]: parquet_table.schema.types
+    Out[4]:
+    [ListType(list<element: int64>)]
+
+.. _whatsnew_140.notable_bug_fixes.notable_bug_fix4:
+
+notable_bug_fix4
 ^^^^^^^^^^^^^^^^
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -125,6 +125,7 @@ Other enhancements
 - Attempting to write into a file in missing parent directory with :meth:`DataFrame.to_csv`, :meth:`DataFrame.to_html`, :meth:`DataFrame.to_excel`, :meth:`DataFrame.to_feather`, :meth:`DataFrame.to_parquet`, :meth:`DataFrame.to_stata`, :meth:`DataFrame.to_json`, :meth:`DataFrame.to_pickle`, and :meth:`DataFrame.to_xml` now explicitly mentions missing parent directory, the same is true for :class:`Series` counterparts (:issue:`24306`)
 - :meth:`IntegerArray.all` , :meth:`IntegerArray.any`, :meth:`FloatingArray.any`, and :meth:`FloatingArray.all` use Kleene logic (:issue:`41967`)
 - Added support for nullable boolean and integer types in :meth:`DataFrame.to_stata`, :class:`~pandas.io.stata.StataWriter`, :class:`~pandas.io.stata.StataWriter117`, and :class:`~pandas.io.stata.StataWriterUTF8` (:issue:`40855`)
+- :meth:`DataFrame.to_parquet` now writes Parquet compliant data for columns which contain lists or arrays when using PyArrow 4.0.0 or greater (:issue:`43689`)
 -
 
 .. ---------------------------------------------------------------------------
@@ -186,45 +187,9 @@ Now the float-dtype is respected. Since the common dtype for these DataFrames is
 
     res
 
-.. _whatsnew_140.notable_bug_fixes.write_compliant_parquet_nested_type:
+.. _whatsnew_140.notable_bug_fixes.notable_bug_fix3:
 
-Write compliant Parquet nested types if possible
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-When using :meth:`DataFrame.to_parquet` to write a DataFrame to Parquet, if any of the columns contained arrays
-of values the :mod:`pyarrow` engine would write a non-compliant format. This behavior is now fixed when the installed
-version of PyArrow is at least ``4.0.0``.
-
-https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#nested-types
-
-.. ipython:: python
-
-    import pandas as pd
-    import pyarrow.parquet as pq
-
-    df = pd.DataFrame({"int_array_col": [[1, 2, 3], [4, 5, 6]]})
-    df.to_parquet("/tmp/sample_df")
-    parquet_table = pq.read_table("/tmp/sample_df")
-
-*Previous behavior*:
-
-.. code-block:: ipython
-
-    In [4]: parquet_table.schema.types
-    Out[4]:
-    [ListType(list<item: int64>)]
-
-*New behavior*:
-
-.. code-block:: ipython
-
-    In [4]: parquet_table.schema.types
-    Out[4]:
-    [ListType(list<element: int64>)]
-
-.. _whatsnew_140.notable_bug_fixes.notable_bug_fix4:
-
-notable_bug_fix4
+notable_bug_fix3
 ^^^^^^^^^^^^^^^^
 
 .. ---------------------------------------------------------------------------

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -24,6 +24,7 @@ from pandas.compat.pyarrow import (
     pa_version_under2p0,
     pa_version_under3p0,
     pa_version_under4p0,
+    pa_version_under5p0,
 )
 
 PY39 = sys.version_info >= (3, 9)
@@ -155,4 +156,5 @@ __all__ = [
     "pa_version_under2p0",
     "pa_version_under3p0",
     "pa_version_under4p0",
+    "pa_version_under5p0",
 ]

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -13,6 +13,7 @@ from pandas._typing import (
     FilePathOrBuffer,
     StorageOptions,
 )
+from pandas.compat import pa_version_under4p0
 from pandas.compat._optional import import_optional_dependency
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import doc
@@ -179,6 +180,12 @@ class PyArrowImpl(BaseImpl):
             mode="wb",
             is_dir=partition_cols is not None,
         )
+
+        # Output compliant Parquet if PyArrow supports it and the user hasn't
+        # explicitly set the desired behavior
+        if not pa_version_under4p0 and "use_compliant_nested_type" not in kwargs:
+            kwargs["use_compliant_nested_type"] = True
+
         try:
             if partition_cols is not None:
                 # writes to multiple files under the given path

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -941,6 +941,7 @@ class TestParquetPyArrow(Base):
             result = pyarrow.parquet.read_table(path)
 
         assert str(result.schema.field_by_name("a").type) == "list<element: int64>"
+        check_round_trip(df, pa)
 
 
 class TestParquetFastParquet(Base):

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -931,6 +931,17 @@ class TestParquetPyArrow(Base):
         else:
             assert isinstance(result._mgr, pd.core.internals.BlockManager)
 
+    @td.skip_if_no("pyarrow", min_version="4.0.0")
+    def test_list_column_results_in_compliant_parquet(self, pa):
+        # https://github.com/pandas-dev/pandas/issues/43689
+        df = pd.DataFrame({"a": [[1], [2]]})
+
+        with tm.ensure_clean() as path:
+            df.to_parquet(path, pa)
+            result = pyarrow.parquet.read_table(path)
+
+        assert str(result.schema.field_by_name("a").type) == "list<element: int64>"
+
 
 class TestParquetFastParquet(Base):
     def test_basic(self, fp, df_full):


### PR DESCRIPTION
- [x] closes #43689
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry
