### PR TITLE
REF: implement Index._can_use_libjoin

### DIFF
--- a/pandas/core/indexes/extension.py
+++ b/pandas/core/indexes/extension.py
@@ -246,11 +246,6 @@ class ExtensionIndex(Index):
     def _get_engine_target(self) -> np.ndarray:
         return np.asarray(self._data)
 
-    def _from_join_target(self, result: np.ndarray) -> ArrayLike:
-        # ATM this is only for IntervalIndex, implicit assumption
-        #  about _get_engine_target
-        return type(self._data)._from_sequence(result, dtype=self.dtype)
-
     def delete(self, loc):
         """
         Make new Index with passed location(-s) deleted

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -38,7 +38,6 @@ from pandas.util._decorators import (
 from pandas.util._exceptions import rewrite_exception
 
 from pandas.core.dtypes.cast import (
-    construct_1d_object_array_from_listlike,
     find_common_type,
     infer_dtype_from_scalar,
     maybe_box_datetimelike,
@@ -894,17 +893,13 @@ class IntervalIndex(ExtensionIndex):
         return False
 
     def _get_join_target(self) -> np.ndarray:
-        # constructing tuples is much faster than constructing Intervals
-        tups = list(zip(self.left, self.right))
-        target = construct_1d_object_array_from_listlike(tups)
-        return target
+        # Note: we _could_ use libjoin functions by either casting to object
+        #  dtype or constructing tuples (faster than constructing Intervals)
+        #  but the libjoin fastpaths are no longer fast in these cases.
+        raise NotImplementedError("IntervalIndex does not use libjoin fastpaths")
 
     def _from_join_target(self, result):
-        left, right = list(zip(*result))
-        arr = type(self._data).from_arrays(
-            left, right, dtype=self.dtype, closed=self.closed
-        )
-        return type(self)._simple_new(arr, name=self.name)
+        raise NotImplementedError("IntervalIndex does not use libjoin fastpaths")
 
     # TODO: arithmetic operations
 


### PR DESCRIPTION
Arbitrary EA-backed Indexes (e.g. Nullable) will not go down that path.