### PR TITLE
PERF: nsmallest

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6351,8 +6351,11 @@ class Index(IndexOpsMixin, PandasObject):
         KeyError
             If not all of the labels are found in the selected axis
         """
-        arr_dtype = "object" if self.dtype == "object" else None
-        labels = com.index_labels_to_array(labels, dtype=arr_dtype)
+        if not isinstance(labels, Index):
+            # avoid materializing e.g. RangeIndex
+            arr_dtype = "object" if self.dtype == "object" else None
+            labels = com.index_labels_to_array(labels, dtype=arr_dtype)
+
         indexer = self.get_indexer_for(labels)
         mask = indexer == -1
         if mask.any():


### PR DESCRIPTION
```
from asv_bench.benchmarks.series_methods import *
self6 = NSort()
self6.setup("last")

%timeit self6.time_nsmallest('last')
10.6 ms ± 43.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  # <- master
1.5 ms ± 17.2 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)  # <- PR
```