### PR TITLE
REF: simplify DatetimeEngine.__contains__

### DIFF
--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -422,7 +422,7 @@ cdef class DatetimeEngine(Int64Engine):
         try:
             self.get_loc(val)
             return True
-        except (KeyError, TypeError):
+        except KeyError:
             return False
 
     cdef _call_monotonic(self, values):

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -418,19 +418,12 @@ cdef class DatetimeEngine(Int64Engine):
     def __contains__(self, val: object) -> bool:
         # We assume before we get here:
         #  - val is hashable
-        cdef:
-            int64_t loc, conv
-
-        conv = self._unbox_scalar(val)
-        if self.over_size_threshold and self.is_monotonic_increasing:
-            if not self.is_unique:
-                return self._get_loc_duplicates(conv)
-            values = self.values
-            loc = values.searchsorted(conv, side='left')
-            return values[loc] == conv
-
-        self._ensure_mapping_populated()
-        return conv in self.mapping
+        self._unbox_scalar(val)
+        try:
+            self.get_loc(val)
+            return True
+        except (KeyError, TypeError):
+            return False
 
     cdef _call_monotonic(self, values):
         return algos.is_monotonic(values, timelike=True)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3953,6 +3953,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         maybe_shortcut = False
         if self.ndim == 2 and isinstance(self.columns, MultiIndex):
             try:
+                # By using engine's __contains__ we effectively
+                # restrict to same-length tuples
                 maybe_shortcut = key not in self.columns._engine
             except TypeError:
                 pass


### PR DESCRIPTION
This is never called outside of tests so not a big deal, but the code is redundant and in one place returns the wrong type.