### PR TITLE
PERF: Index.get_loc

### DIFF
--- a/pandas/tests/indexes/base_class/test_indexing.py
+++ b/pandas/tests/indexes/base_class/test_indexing.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+import pandas as pd
 from pandas import Index
 import pandas._testing as tm
 
@@ -36,3 +37,22 @@ class TestGetIndexerNonUnique:
         indexes, missing = Index(["A", "B"]).get_indexer_non_unique(Index([0]))
         tm.assert_numpy_array_equal(np.array([-1], dtype=np.intp), indexes)
         tm.assert_numpy_array_equal(np.array([0], dtype=np.intp), missing)
+
+
+class TestGetLoc:
+    @pytest.mark.slow  # to_flat_index takes a while
+    def test_get_loc_tuple_monotonic_above_size_cutoff(self):
+        # Go through the libindex path for which using
+        # _bin_search vs ndarray.searchsorted makes a difference
+
+        lev = list("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+        dti = pd.date_range("2016-01-01", periods=100)
+
+        mi = pd.MultiIndex.from_product([lev, range(10 ** 3), dti])
+        oidx = mi.to_flat_index()
+
+        loc = len(oidx) // 2
+        tup = oidx[loc]
+
+        res = oidx.get_loc(tup)
+        assert res == loc

--- a/pandas/tests/indexes/numeric/test_indexing.py
+++ b/pandas/tests/indexes/numeric/test_indexing.py
@@ -152,6 +152,14 @@ class TestGetLoc:
             with tm.assert_produces_warning(FutureWarning, match="deprecated"):
                 idx.get_loc(np.nan, method=method)
 
+    @pytest.mark.parametrize("dtype", ["f8", "i8", "u8"])
+    def test_get_loc_numericindex_none_raises(self, dtype):
+        # case that goes through searchsorted and key is non-comparable to values
+        arr = np.arange(10 ** 7, dtype=dtype)
+        idx = Index(arr)
+        with pytest.raises(KeyError, match="None"):
+            idx.get_loc(None)
+
 
 class TestGetIndexer:
     def test_get_indexer(self):


### PR DESCRIPTION
Makes a big difference for Float64Index with integer key.

```
import numpy as np
import pandas as pd

idx = pd.Index(np.arange(10**7))
fidx = idx.astype('f8')


key = idx[len(idx) // 2]
key2 = idx[10]

%timeit idx.get_loc(key)
2.97 µs ± 36.2 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <- master
2.3 µs ± 36.3 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <- PR

%timeit idx.get_loc(key2)
3.2 µs ± 151 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <- master
2.1 µs ± 140 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  # <- PR

%timeit fidx.get_loc(key)
56.4 µs ± 1.22 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)  # <- master
2.11 µs ± 11.1 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <- PR

%timeit fidx.get_loc(key2)
54.7 µs ± 1.12 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)  # <- master
2 µs ± 21.7 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <- PR

```