### PR TITLE
BUG: set numpy requirement for aarch64 and py3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
     # Copied from https://github.com/scipy/scipy/blob/master/pyproject.toml (which is also licensed under BSD)
     "numpy==1.17.3; python_version=='3.7' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64'",
     "numpy==1.18.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64'",
-    "numpy==1.19.3; python_version>='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64'",
+    "numpy==1.19.3; python_version>='3.9' and (platform_machine!='arm64' or platform_system!='Darwin')",
     # Aarch64(Python 3.9 requirements are the same as AMD64)
     "numpy==1.19.2; python_version=='3.7' and platform_machine=='aarch64'",
     "numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64'",


### PR DESCRIPTION
It is stated in this file on line 13 that `# Aarch64(Python 3.9 requirements are the same as AMD64)`
However, the python 3.9 numpy requirement is excluding `aarch64`, therefore there is no `aarch64` numpy requirement defined at all for py3.9.
When one tries to build pandas from source on `aarch64` with py3.9 (such as alpine 3.14, which is musl based), there is no matching numpy found and therefore the build fails.

This commit sets the numpy version requirement for `aarch64` on py3.9 the same as amd64 as stated.

Here's a log of a failed build:
```
Collecting pandas==1.3.0
  Downloading pandas-1.3.0.tar.gz (4.7 MB)
  Installing build dependencies: started
  Running command /usr/bin/python3 /tmp/pip-standalone-pip-y3p0bgt2/__env_pip__.zip/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-ha64_wsb/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple --find-links https://wheel-index.linuxserver.io/alpine/ -- 'setuptools>=38.6.0' wheel 'Cython>=0.29.21,<3' 'numpy==1.17.3; python_version=='"'"'3.7'"'"' and (platform_machine!='"'"'arm64'"'"' or platform_system!='"'"'Darwin'"'"') and platform_machine!='"'"'aarch64'"'"'' 'numpy==1.18.3; python_version=='"'"'3.8'"'"' and (platform_machine!='"'"'arm64'"'"' or platform_system!='"'"'Darwin'"'"') and platform_machine!='"'"'aarch64'"'"'' 'numpy==1.19.3; python_version>='"'"'3.9'"'"' and (platform_machine!='"'"'arm64'"'"' or platform_system!='"'"'Darwin'"'"') and platform_machine!='"'"'aarch64'"'"'' 'numpy==1.19.2; python_version=='"'"'3.7'"'"' and platform_machine=='"'"'aarch64'"'"'' 'numpy==1.19.2; python_version=='"'"'3.8'"'"' and platform_machine=='"'"'aarch64'"'"'' 'numpy>=1.20.0; python_version=='"'"'3.8'"'"' and platform_machine=='"'"'arm64'"'"' and platform_system=='"'"'Darwin'"'"'' 'numpy>=1.20.0; python_version=='"'"'3.9'"'"' and platform_machine=='"'"'arm64'"'"' and platform_system=='"'"'Darwin'"'"''
  Looking in links: https://wheel-index.linuxserver.io/alpine/
  Ignoring numpy: markers 'python_version == "3.7" and (platform_machine != "arm64" or platform_system != "Darwin") and platform_machine != "aarch64"' don't match your environment
  Ignoring numpy: markers 'python_version == "3.8" and (platform_machine != "arm64" or platform_system != "Darwin") and platform_machine != "aarch64"' don't match your environment
  Ignoring numpy: markers 'python_version >= "3.9" and (platform_machine != "arm64" or platform_system != "Darwin") and platform_machine != "aarch64"' don't match your environment
  Ignoring numpy: markers 'python_version == "3.7" and platform_machine == "aarch64"' don't match your environment
  Ignoring numpy: markers 'python_version == "3.8" and platform_machine == "aarch64"' don't match your environment
  Ignoring numpy: markers 'python_version == "3.8" and platform_machine == "arm64" and platform_system == "Darwin"' don't match your environment
  Ignoring numpy: markers 'python_version == "3.9" and platform_machine == "arm64" and platform_system == "Darwin"' don't match your environment
  Collecting setuptools>=38.6.0
    Using cached setuptools-58.1.0-py3-none-any.whl (816 kB)
  Collecting wheel
    Using cached wheel-0.37.0-py2.py3-none-any.whl (35 kB)
  Collecting Cython<3,>=0.29.21
    Downloading Cython-0.29.24-py2.py3-none-any.whl (979 kB)
  Installing collected packages: wheel, setuptools, Cython
  Successfully installed Cython-0.29.24 setuptools-58.1.0 wheel-0.37.0
  WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Running command /usr/bin/python3 /usr/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py get_requires_for_build_wheel /tmp/tmpmg6hkkyk
  Traceback (most recent call last):
    File "/usr/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 349, in <module>
      main()
    File "/usr/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 331, in main
      json_out['return_val'] = hook(**hook_input['kwargs'])
    File "/usr/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 117, in get_requires_for_build_wheel
      return hook(config_settings)
    File "/tmp/pip-build-env-ha64_wsb/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 154, in get_requires_for_build_wheel
      return self._get_build_requires(
    File "/tmp/pip-build-env-ha64_wsb/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 135, in _get_build_requires
      self.run_setup()
    File "/tmp/pip-build-env-ha64_wsb/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 258, in run_setup
      super(_BuildMetaLegacyBackend,
    File "/tmp/pip-build-env-ha64_wsb/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 150, in run_setup
      exec(compile(code, __file__, 'exec'), locals())
    File "setup.py", line 18, in <module>
      import numpy
  ModuleNotFoundError: No module named 'numpy'
  Getting requirements to build wheel: finished with status 'error'
WARNING: Discarding https://files.pythonhosted.org/packages/53/05/bf382e8bc60731906a2e7261648bcea3a6b309ad2b9952010737a1b9413e/pandas-1.3.0.tar.gz#sha256=c554e6c9cf2d5ea1aba5979cc837b3649539ced0e18ece186f055450c86622e2 (from https://pypi.org/simple/pandas/) (requires-python:>=3.7.1). Command errored out with exit status 1: /usr/bin/python3 /usr/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py get_requires_for_build_wheel /tmp/tmpmg6hkkyk Check the logs for full command output.
ERROR: Could not find a version that satisfies the requirement pandas==1.3.0 (from versions: 0.1, 0.2, 0.3.0, 0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.5.0, 0.6.0, 0.6.1, 0.7.0, 0.7.1, 0.7.2, 0.7.3, 0.8.0, 0.8.1, 0.9.0, 0.9.1, 0.10.0, 0.10.1, 0.11.0, 0.12.0, 0.13.0, 0.13.1, 0.14.0, 0.14.1, 0.15.0, 0.15.1, 0.15.2, 0.16.0, 0.16.1, 0.16.2, 0.17.0, 0.17.1, 0.18.0, 0.18.1, 0.19.0, 0.19.1, 0.19.2, 0.20.0, 0.20.1, 0.20.2, 0.20.3, 0.21.0, 0.21.1, 0.22.0, 0.23.0, 0.23.1, 0.23.2, 0.23.3, 0.23.4, 0.24.0, 0.24.1, 0.24.2, 0.25.0, 0.25.1, 0.25.2, 0.25.3, 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.1.4, 1.1.5, 1.2.0, 1.2.1, 1.2.2, 1.2.3, 1.2.4, 1.2.5, 1.3.0, 1.3.1, 1.3.2, 1.3.3)
ERROR: No matching distribution found for pandas==1.3.0
```

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
