### PR TITLE
PERF: GroupBy.count

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1745,6 +1745,8 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
         ids, _, ngroups = self.grouper.group_info
         mask = ids != -1
 
+        is_series = data.ndim == 1
+
         def hfunc(bvalues: ArrayLike) -> ArrayLike:
             # TODO(2DEA): reshape would not be necessary with 2D EAs
             if bvalues.ndim == 1:
@@ -1754,6 +1756,10 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
                 masked = mask & ~isna(bvalues)
 
             counted = lib.count_level_2d(masked, labels=ids, max_bin=ngroups, axis=1)
+            if is_series:
+                assert counted.ndim == 2
+                assert counted.shape[0] == 1
+                return counted[0]
             return counted
 
         new_mgr = data.grouped_reduce(hfunc)
@@ -2702,7 +2708,7 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
         mgr = self._get_data_to_aggregate()
 
         res_mgr = mgr.grouped_reduce(blk_func, ignore_failures=True)
-        if len(res_mgr.items) != len(mgr.items):
+        if not is_ser and len(res_mgr.items) != len(mgr.items):
             warnings.warn(
                 "Dropping invalid columns in "
                 f"{type(self).__name__}.quantile is deprecated. "
@@ -3134,14 +3140,15 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
         obj = self._obj_with_exclusions
 
         # Operate block-wise instead of column-by-column
-        orig_ndim = obj.ndim
+        is_ser = obj.ndim == 1
         mgr = self._get_data_to_aggregate()
 
         if numeric_only:
             mgr = mgr.get_numeric_data()
 
         res_mgr = mgr.grouped_reduce(blk_func, ignore_failures=True)
-        if len(res_mgr.items) != len(mgr.items):
+
+        if not is_ser and len(res_mgr.items) != len(mgr.items):
             howstr = how.replace("group_", "")
             warnings.warn(
                 "Dropping invalid columns in "
@@ -3162,7 +3169,7 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
                 # We should never get here
                 raise TypeError("All columns were dropped in grouped_reduce")
 
-        if orig_ndim == 1:
+        if is_ser:
             out = self._wrap_agged_manager(res_mgr)
             out.index = self.grouper.result_index
         else:

--- a/pandas/core/internals/base.py
+++ b/pandas/core/internals/base.py
@@ -10,6 +10,7 @@ from typing import (
 )
 
 from pandas._typing import (
+    ArrayLike,
     DtypeObj,
     Shape,
 )
@@ -18,7 +19,10 @@ from pandas.errors import AbstractMethodError
 from pandas.core.dtypes.cast import find_common_type
 
 from pandas.core.base import PandasObject
-from pandas.core.indexes.api import Index
+from pandas.core.indexes.api import (
+    Index,
+    default_index,
+)
 
 T = TypeVar("T", bound="DataManager")
 
@@ -170,6 +174,23 @@ class SingleDataManager(DataManager):
         the dtype.
         """
         self.array[indexer] = value
+
+    def grouped_reduce(self, func, ignore_failures: bool = False):
+        """
+        ignore_failures : bool, default False
+            Not used; for compatibility with ArrayManager/BlockManager.
+        """
+
+        arr = self.array
+        res = func(arr)
+        index = default_index(len(res))
+
+        mgr = type(self).from_array(res, index)
+        return mgr
+
+    @classmethod
+    def from_array(cls, arr: ArrayLike, index: Index):
+        raise AbstractMethodError(cls)
 
 
 def interleaved_dtype(dtypes: list[DtypeObj]) -> DtypeObj | None:

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -350,11 +350,10 @@ def test_agg():
     expected = pd.concat([a_mean, a_std, b_mean, b_std], axis=1)
     expected.columns = pd.MultiIndex.from_product([["A", "B"], ["mean", "std"]])
     for t in cases:
-        warn = FutureWarning if t in cases[1:3] else None
-        with tm.assert_produces_warning(
-            warn, match="Dropping invalid columns", check_stacklevel=False
-        ):
-            # .var on dt64 column raises and is dropped
+        with tm.assert_produces_warning(None):
+            # .var on dt64 column raises and is dropped, but the path in core.apply
+            #  that it goes through will still suppress a TypeError even
+            #  once the deprecations in the groupby code are enforced
             result = t.aggregate([np.mean, np.std])
         tm.assert_frame_equal(result, expected)
 


### PR DESCRIPTION
```
from asv_bench.benchmarks.groupby import *
self = GroupByMethods()
self.setup("datetime", "count", "direct", 2)

%timeit self.time_dtype_as_field('datetime', 'count', 'direct', 2)
73.7 µs ± 982 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)  # <- master
48.7 µs ± 473 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)  # <- PR
```