### PR TITLE
TST: multi indexing when one column exclusively contains NaT(#38025)

### DIFF
--- a/pandas/tests/indexing/multiindex/test_multiindex.py
+++ b/pandas/tests/indexing/multiindex/test_multiindex.py
@@ -78,15 +78,20 @@ class TestMultiIndexBasic:
                 "c": [10, 15, np.nan, 20],
             }
         )
-        df = df.set_index(["a", "b"], drop=False)
+        df = df.set_index(["a", "b"])
         expected = DataFrame(
             {
                 "a": [pd.NaT, pd.NaT, pd.NaT, pd.NaT],
                 "b": ["C1", "C2", "C3", "C4"],
                 "c": [10, 15, np.nan, 20],
-            }
+            },
+            index=[
+                Index([pd.NaT, pd.NaT, pd.NaT, pd.NaT], name="a"),
+                Index(["C1", "C2", "C3", "C4"], name="b"),
+            ],
         )
-        tm.assert_equal(df.values, expected.values)
+        expected = expected.drop(columns=["a", "b"])
+        tm.assert_frame_equal(df, expected)
 
     def test_nested_tuples_duplicates(self):
         # GH#30892

--- a/pandas/tests/indexing/multiindex/test_multiindex.py
+++ b/pandas/tests/indexing/multiindex/test_multiindex.py
@@ -15,7 +15,6 @@ import pandas._testing as tm
 
 class TestMultiIndexBasic:
     def test_multiindex_perf_warn(self):
-
         df = DataFrame(
             {
                 "jim": [0, 0, 1, 1],
@@ -47,7 +46,6 @@ class TestMultiIndexBasic:
         _index._SIZE_CUTOFF = old_cutoff
 
     def test_multi_nan_indexing(self):
-
         # GH 3588
         df = DataFrame(
             {
@@ -69,6 +67,26 @@ class TestMultiIndexBasic:
             ],
         )
         tm.assert_frame_equal(result, expected)
+
+    def test_exclusive_nat_column_indexing(self):
+        # GH 38025
+        # test multi indexing when one column exclusively contains NaT values
+        df = DataFrame(
+            {
+                "a": [pd.NaT, pd.NaT, pd.NaT, pd.NaT],
+                "b": ["C1", "C2", "C3", "C4"],
+                "c": [10, 15, np.nan, 20],
+            }
+        )
+        df = df.set_index(["a", "b"])
+        expected = DataFrame(
+            {
+                "a": [pd.NaT, pd.NaT, pd.NaT, pd.NaT],
+                "b": ["C1", "C2", "C3", "C4"],
+                "c": [10, 15, np.nan, 20],
+            }
+        )
+        tm.assert_equal(df.values, expected.values)
 
     def test_nested_tuples_duplicates(self):
         # GH#30892

--- a/pandas/tests/indexing/multiindex/test_multiindex.py
+++ b/pandas/tests/indexing/multiindex/test_multiindex.py
@@ -78,7 +78,7 @@ class TestMultiIndexBasic:
                 "c": [10, 15, np.nan, 20],
             }
         )
-        df = df.set_index(["a", "b"])
+        df = df.set_index(["a", "b"], drop=False)
         expected = DataFrame(
             {
                 "a": [pd.NaT, pd.NaT, pd.NaT, pd.NaT],

--- a/pandas/tests/indexing/multiindex/test_multiindex.py
+++ b/pandas/tests/indexing/multiindex/test_multiindex.py
@@ -81,8 +81,6 @@ class TestMultiIndexBasic:
         df = df.set_index(["a", "b"])
         expected = DataFrame(
             {
-                "a": [pd.NaT, pd.NaT, pd.NaT, pd.NaT],
-                "b": ["C1", "C2", "C3", "C4"],
                 "c": [10, 15, np.nan, 20],
             },
             index=[
@@ -90,7 +88,6 @@ class TestMultiIndexBasic:
                 Index(["C1", "C2", "C3", "C4"], name="b"),
             ],
         )
-        expected = expected.drop(columns=["a", "b"])
         tm.assert_frame_equal(df, expected)
 
     def test_nested_tuples_duplicates(self):


### PR DESCRIPTION
- [X] closes #38025
- [X] tests added / passed
- [X] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
