### PR TITLE
PERF: `Styler.tooltips` 

### DIFF
--- a/asv_bench/benchmarks/io/style.py
+++ b/asv_bench/benchmarks/io/style.py
@@ -87,7 +87,7 @@ class Render:
         self.st.hide_columns(self.st.columns[1:])
 
     def _style_tooltips(self):
-        ttips = DataFrame("text", index=self.df.index[::2], columns=self.columns[::2])
+        ttips = DataFrame("abc", index=self.df.index[::2], columns=self.df.columns[::2])
         self.st = self.df.style.set_tooltips(ttips)
         self.st.hide_index(self.st.index[12:])
         self.st.hide_columns(self.st.columns[12:])

--- a/asv_bench/benchmarks/io/style.py
+++ b/asv_bench/benchmarks/io/style.py
@@ -34,6 +34,14 @@ class Render:
         self._style_classes()
         self.st._render_html(True, True)
 
+    def time_tooltips_render(self, cols, rows):
+        self._style_tooltips()
+        self.st._render_html(True, True)
+
+    def peakmem_tooltips_render(self, cols, rows):
+        self._style_tooltips()
+        self.st._render_html(True, True)
+
     def time_format_render(self, cols, rows):
         self._style_format()
         self.st._render_html(True, True)
@@ -77,3 +85,9 @@ class Render:
         self.st.format("{:.3f}")
         self.st.hide_index(self.st.index[1:])
         self.st.hide_columns(self.st.columns[1:])
+
+    def _style_tooltips(self):
+        ttips = DataFrame("text", index=self.df.index[::2], columns=self.columns[::2])
+        self.st = self.df.style.set_tooltips(ttips)
+        self.st.hide_index(self.st.index[12:])
+        self.st.hide_columns(self.st.columns[12:])


### PR DESCRIPTION
When tooltips were developed there were no hidden_rows or hidden_columns and no max_rows or max_columns.

This adds some benchmarks and a minimal change to improve performance. Scope to do a bit better here in future also.

```
       before           after         ratio
     [cd13e3a4]       [7766f055]
     <master>         <styler_tooltips_perf>
-        52.5±2ms       47.4±0.7ms     0.90  io.style.Render.time_apply_format_hide_render(24, 120)
-       196±0.6ms        173±0.9ms     0.88  io.style.Render.time_tooltips_render(36, 120)
-        78.0±2ms       67.0±0.4ms     0.86  io.style.Render.time_tooltips_render(12, 120)
-         140±2ms        120±0.3ms     0.85  io.style.Render.time_tooltips_render(24, 120)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```

