### PR TITLE
CI: run pyright with mypy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Install pyright
       # note: keep version in sync with .pre-commit-config.yaml
-      run: npm install pyright@1.1.171
+      run: npm install -g pyright@1.1.171
 
     - name: Build Pandas
       uses: ./.github/actions/build_pandas

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,8 @@ jobs:
         node-version: "16"
 
     - name: Install pyright
-      run: npm install pyright
+      # note: keep version in sync with .pre-commit-config.yaml
+      run: npm install pyright@1.1.171
 
     - name: Build Pandas
       uses: ./.github/actions/build_pandas

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,14 @@ jobs:
         environment-file: ${{ env.ENV_FILE }}
         use-only-tar-bz2: true
 
+    - name: Install node.js (for pyright)
+      uses: actions/setup-node@v2
+      with:
+        node-version: "16"
+
+    - name: Install pyright
+      run: npm install pyright
+
     - name: Build Pandas
       uses: ./.github/actions/build_pandas
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,6 +13,8 @@ jobs:
     concurrency:
       group: ${{ github.ref }}-pre-commit
       cancel-in-progress: ${{github.event_name == 'pull_request'}}
+    env:
+      SKIP: pyright
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,6 +89,7 @@ repos:
         language: node
         pass_filenames: false
         types: [python]
+        # note: keep version in sync with .github/workflows/ci.yml
         additional_dependencies: ['pyright@1.1.171']
 -   repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,7 +89,7 @@ repos:
         language: node
         pass_filenames: false
         types: [python]
-        additional_dependencies: ['pyright@1.1.170']
+        additional_dependencies: ['pyright@1.1.171']
 -   repo: local
     hooks:
     -   id: flake8-rst

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -104,6 +104,13 @@ if [[ -z "$CHECK" || "$CHECK" == "typing" ]]; then
     MSG='Performing static analysis using mypy' ; echo $MSG
     mypy pandas
     RET=$(($RET + $?)) ; echo $MSG "DONE"
+
+    # run pyright, if it is installed
+    if command -v pyright &> /dev/null ; then
+        MSG='Performing static analysis using pyright' ; echo $MSG
+        pre-commit run --all-files --hook-stage manual pyright
+        RET=$(($RET + $?)) ; echo $MSG "DONE"
+    fi
 fi
 
 exit $RET

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -108,7 +108,7 @@ if [[ -z "$CHECK" || "$CHECK" == "typing" ]]; then
     # run pyright, if it is installed
     if command -v pyright &> /dev/null ; then
         MSG='Performing static analysis using pyright' ; echo $MSG
-        pre-commit run --all-files --hook-stage manual pyright
+        pyright
         RET=$(($RET + $?)) ; echo $MSG "DONE"
     fi
 fi

--- a/doc/source/development/contributing_codebase.rst
+++ b/doc/source/development/contributing_codebase.rst
@@ -395,11 +395,16 @@ This module will ultimately house types for repeatedly used concepts like "path-
 Validating type hints
 ~~~~~~~~~~~~~~~~~~~~~
 
-pandas uses `mypy <http://mypy-lang.org>`_ to statically analyze the code base and type hints. After making any change you can ensure your type hints are correct by running
+pandas uses `mypy <http://mypy-lang.org>`_ and `pyright <https://github.com/microsoft/pyright>`_ to statically analyze the code base and type hints. After making any change you can ensure your type hints are correct by running
 
 .. code-block:: shell
 
    mypy pandas
+
+   # let pre-commit setup and run pyright
+   pre-commit run --all-files pyright
+   # or if pyright is installed (requires node.js)
+   pyright
 
 .. _contributing.ci:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,6 @@ reportOptionalIterable = false
 reportOptionalMemberAccess = false
 reportOptionalOperand = false
 reportOptionalSubscript = false
-reportOverlappingOverload = false
 reportPrivateImportUsage = false
 reportPrivateUsage = false
 reportPropertyTypeMismatch = false


### PR DESCRIPTION
The github action running the pre-commit checks does not install all necessary python packages for type checking. This triggered a few unnecessary `reportOverlappingOverload` by pyright because numpy was not installed.

Keep pyright in the pre-commit but disable it on the CI (SKIP=pyright). Instead, run pyright together with mypy in code_checks.sh.
