### PR TITLE
Fixing Typo in BYearEnd example

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -1929,7 +1929,7 @@ cdef class BYearEnd(YearOffset):
 
     Examples
     --------
-    >>> from pandas.tseries.offset import BYearEnd
+    >>> from pandas.tseries.offsets import BYearEnd
     >>> ts = pd.Timestamp('2020-05-24 05:01:15')
     >>> ts - BYearEnd()
     Timestamp('2019-12-31 05:01:15')


### PR DESCRIPTION
- [ ] closes #43749
- [ ] Fixes example for BYearEnd
- [ ] pandas/pandas/_libs/tslibs/offsets.pyx file updated
