### PR TITLE
PERF: obj_with_exclusions

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -221,7 +221,11 @@ class SelectionMixin(Generic[FrameOrSeries]):
             return self.obj[self._selection_list]
 
         if len(self.exclusions) > 0:
-            return self.obj.drop(self.exclusions, axis=1)
+            # equivalent to `self.obj.drop(self.exclusions, axis=1)
+            #  but this avoids consolidating and making a copy
+            return self.obj._drop_axis(
+                self.exclusions, axis=1, consolidate=False, only_slice=True
+            )
         else:
             return self.obj
 


### PR DESCRIPTION
```
from asv_bench.benchmarks.groupby import *
self = Cumulative()
self.setup("int64", "cumsum")

%timeit self.setup("int64", "cumsum"); self.time_frame_transform("int64", "cumsum")
107 ms ± 7.57 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)  # <- master
74.6 ms ± 2.04 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)  # <- PR
```
