### PR TITLE
BUG: pandas.to_datetime raises exception when more than 50 values needs coercion to NaT (#43732)

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2223,14 +2223,14 @@ def objects_to_datetime64ns(
             allow_mixed=allow_mixed,
         )
         result = result.reshape(data.shape, order=order)
-    except ValueError as err:
+    except ValueError:
         try:
             values, tz_parsed = conversion.datetime_to_datetime64(data.ravel("K"))
             # If tzaware, these values represent unix timestamps, so we
             #  return them as i8 to distinguish from wall times
             values = values.reshape(data.shape, order=order)
             return values.view("i8"), tz_parsed
-        except (ValueError, TypeError):
+        except (ValueError, TypeError) as err:
             raise err
 
     if tz_parsed is not None:


### PR DESCRIPTION
- [x] closes #43732 
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
