### PR TITLE
PERF: avoid warnings in IndexEngine.get_loc

### DIFF
--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -1,5 +1,3 @@
-import warnings
-
 cimport cython
 
 import numpy as np

--- a/pandas/_libs/index_class_helper.pxi.in
+++ b/pandas/_libs/index_class_helper.pxi.in
@@ -37,8 +37,8 @@ cdef class {{name}}Engine(IndexEngine):
         if not util.is_integer_object(val):
             raise KeyError(val)
     {{else}}
-        if util.is_bool_object(val):
-            # avoid casting to True -> 1.0
+        if not util.is_integer_object(val) and not util.is_float_object(val):
+            # in particular catch bool and avoid casting True -> 1.0
             raise KeyError(val)
     {{endif}}
 
@@ -53,22 +53,15 @@ cdef class {{name}}Engine(IndexEngine):
         self._check_type(val)
 
         values = self.values
-        try:
-            with warnings.catch_warnings():
-                # e.g. if values is float64 and `val` is a str, suppress warning
-                warnings.filterwarnings("ignore", category=FutureWarning)
-                {{if name in {'Float64', 'Float32'} }}
-                if util.is_nan(val):
-                    indexer = np.isnan(values)
-                else:
-                    indexer = values == val
-                {{else}}
-                indexer = values == val
-                {{endif}}
-        except TypeError:
-            # if the equality above returns a bool, cython will raise TypeError
-            #  when trying to cast it to ndarray
-            raise KeyError(val)
+
+        {{if name in {'Float64', 'Float32'} }}
+        if util.is_nan(val):
+            indexer = np.isnan(values)
+        else:
+            indexer = values == val
+        {{else}}
+        indexer = values == val
+        {{endif}}
 
         return indexer
 


### PR DESCRIPTION
Only reached for non-unique indexes.  Makes a big difference for small indexes.

Room for de-duplication in follow-ups.

```
import numpy as np
import pandas as pd

np.random.seed(90)
arr = np.random.randn(4).repeat(2)
idx = pd.Index(arr)
assert not idx.is_unique
key = arr[4]
engine = idx._engine

%timeit engine.get_loc(key)
6.6 µs ± 50.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <- master
2.62 µs ± 127 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <- PR
```