### PR TITLE
CI/TYP: run pyright at manual stage in pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: numpy>=1.21.0 for type checkers
+      run: sed -i "s/numpy>=1.18.5/numpy>=1.21.0/g" ${{ env.ENV_FILE }}
+
     - name: Cache conda
       uses: actions/cache@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: numpy>=1.21.0 for type checkers
-      run: sed -i "s/numpy>=1.18.5/numpy>=1.21.0/g" ${{ env.ENV_FILE }}
-
     - name: Cache conda
       uses: actions/cache@v2
       with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,8 +13,6 @@ jobs:
     concurrency:
       group: ${{ github.ref }}-pre-commit
       cancel-in-progress: ${{github.event_name == 'pull_request'}}
-    env:
-      SKIP: pyright
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,6 +89,7 @@ repos:
         language: node
         pass_filenames: false
         types: [python]
+        stages: [manual]
         # note: keep version in sync with .github/workflows/ci.yml
         additional_dependencies: ['pyright@1.1.171']
 -   repo: local

--- a/doc/source/development/contributing_codebase.rst
+++ b/doc/source/development/contributing_codebase.rst
@@ -402,7 +402,7 @@ pandas uses `mypy <http://mypy-lang.org>`_ and `pyright <https://github.com/micr
    mypy pandas
 
    # let pre-commit setup and run pyright
-   pre-commit run --all-files pyright
+   pre-commit run --hook-stage manual --all-files pyright
    # or if pyright is installed (requires node.js)
    pyright
 

--- a/doc/source/development/contributing_codebase.rst
+++ b/doc/source/development/contributing_codebase.rst
@@ -406,7 +406,7 @@ pandas uses `mypy <http://mypy-lang.org>`_ and `pyright <https://github.com/micr
    # or if pyright is installed (requires node.js)
    pyright
 
-Please make sure to have `numpy>=1.21.0` installed when validating types, since this is the first version that provides `numpy.typing`.
+Please make sure to have ``numpy>=1.21.0`` installed when validating types, since this is the first version that provides ``numpy.typing``.
 
 .. _contributing.ci:
 

--- a/doc/source/development/contributing_codebase.rst
+++ b/doc/source/development/contributing_codebase.rst
@@ -406,6 +406,8 @@ pandas uses `mypy <http://mypy-lang.org>`_ and `pyright <https://github.com/micr
    # or if pyright is installed (requires node.js)
    pyright
 
+Please make sure to have `numpy>=1.21.0` installed when validating types, since this is the first version that provides `numpy.typing`.
+
 .. _contributing.ci:
 
 Testing with continuous integration

--- a/doc/source/development/contributing_codebase.rst
+++ b/doc/source/development/contributing_codebase.rst
@@ -406,7 +406,7 @@ pandas uses `mypy <http://mypy-lang.org>`_ and `pyright <https://github.com/micr
    # or if pyright is installed (requires node.js)
    pyright
 
-Please make sure to have ``numpy>=1.21.0`` installed when validating types, since this is the first version that provides ``numpy.typing``.
+A recent version of ``numpy`` (>=1.21.0) is required for type validation.
 
 .. _contributing.ci:
 


### PR DESCRIPTION
with numpy<1.21.0 pyright (and mypy?) cannot determine some types which leads to overlapping overloads. See https://github.com/pandas-dev/pandas/pull/43747#issuecomment-930343454

@attack68 
