### PR TITLE
REG: Regression in explode when column is non string

### DIFF
--- a/doc/source/whatsnew/v1.3.4.rst
+++ b/doc/source/whatsnew/v1.3.4.rst
@@ -21,6 +21,7 @@ Fixed regressions
 - Fixed regression in :meth:`Series.cat.reorder_categories` failing to update the categories on the ``Series`` (:issue:`43232`)
 - Fixed regression in :meth:`Series.cat.categories` setter failing to update the categories on the ``Series`` (:issue:`43334`)
 - Fixed regression in :meth:`pandas.read_csv` raising ``UnicodeDecodeError`` exception when ``memory_map=True`` (:issue:`43540`)
+- Fixed regression in :meth:`DataFrame.explode` raising ``AssertionError`` when ``column`` is any scalar which is not a string (:issue:`43314`)
 - Fixed regression in :meth:`Series.aggregate` attempting to pass ``args`` and ``kwargs`` multiple times to the user supplied ``func`` in certain cases (:issue:`43357`)
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8295,7 +8295,6 @@ NaN 12.3   33.0
 
         columns: list[str | tuple]
         if is_scalar(column) or isinstance(column, tuple):
-            assert isinstance(column, (str, tuple))
             columns = [column]
         elif isinstance(column, list) and all(
             map(lambda c: is_scalar(c) or isinstance(c, tuple), column)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8201,7 +8201,7 @@ NaN 12.3   33.0
 
     def explode(
         self,
-        column: str | tuple | list[str | tuple],
+        column: Scalar | tuple | list[Scalar | tuple],
         ignore_index: bool = False,
     ) -> DataFrame:
         """
@@ -8211,7 +8211,7 @@ NaN 12.3   33.0
 
         Parameters
         ----------
-        column : str or tuple or list thereof
+        column : Scalar or tuple or list thereof
             Column(s) to explode.
             For multiple columns, specify a non-empty list with each element
             be str or tuple, and all specified columns their list-like data

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8293,7 +8293,7 @@ NaN 12.3   33.0
         if not self.columns.is_unique:
             raise ValueError("columns must be unique")
 
-        columns: list[str | tuple]
+        columns: list[Scalar | tuple]
         if is_scalar(column) or isinstance(column, tuple):
             columns = [column]
         elif isinstance(column, list) and all(

--- a/pandas/tests/frame/methods/test_explode.py
+++ b/pandas/tests/frame/methods/test_explode.py
@@ -53,14 +53,18 @@ def test_error_multi_columns(input_subset, error_message):
         df.explode(input_subset)
 
 
-def test_basic():
+@pytest.mark.parametrize(
+    "scalar",
+    ["a", 0, 1.5, pd.Timedelta("1 days"), pd.Timestamp("2019-12-31")],
+)
+def test_basic(scalar):
     df = pd.DataFrame(
-        {"A": pd.Series([[0, 1, 2], np.nan, [], (3, 4)], index=list("abcd")), "B": 1}
+        {scalar: pd.Series([[0, 1, 2], np.nan, [], (3, 4)], index=list("abcd")), "B": 1}
     )
-    result = df.explode("A")
+    result = df.explode(scalar)
     expected = pd.DataFrame(
         {
-            "A": pd.Series(
+            scalar: pd.Series(
                 [0, 1, 2, np.nan, np.nan, 3, 4], index=list("aaabcdd"), dtype=object
             ),
             "B": 1,


### PR DESCRIPTION
- [x] closes #43314
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

This should cover the issue since the other pr did not make any progress.

Is there a fixture providing all scalar dtypes?
