### PR TITLE
PERF: improve perf of conversion to string arrays

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -347,6 +347,7 @@ Other Deprecations
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 - Performance improvement in :meth:`.GroupBy.sample`, especially when ``weights`` argument provided (:issue:`34483`)
+- Performance improvement when converting non-string arrays to string arrays (:issue:`34483`)
 - Performance improvement in :meth:`.GroupBy.transform` for user-defined functions (:issue:`41598`)
 - Performance improvement in constructing :class:`DataFrame` objects (:issue:`42631`)
 - Performance improvement in :meth:`GroupBy.shift` when ``fill_value`` argument is provided (:issue:`26615`)

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -727,8 +727,12 @@ cpdef ndarray[object] ensure_string_array(
             continue
 
         if not checknull(val):
-            # f"{val}" is faster than str(val)
-            result[i] = f"{val}"
+            if not isinstance(val, np.floating):
+                # f"{val}" is faster than str(val)
+                result[i] = f"{val}"
+            else:
+                # f"{val}" is not always equivalent to str(val) for floats
+                result[i] = str(val)
         else:
             if convert_na_value:
                 val = na_value

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -727,14 +727,15 @@ cpdef ndarray[object] ensure_string_array(
             continue
 
         if not checknull(val):
-            result[i] = str(val)
+            # f"{val}" is faster than str(val)
+            result[i] = f"{val}"
         else:
             if convert_na_value:
                 val = na_value
             if skipna:
                 result[i] = val
             else:
-                result[i] = str(val)
+                result[i] = f"{val}"
 
     return result
 


### PR DESCRIPTION
`f"{val}"` is faster than `str(val)`. Utilizing this in the tight string conversion loop in `ensure_string_array` gives a nice performance boost.

```python
>>> int_arr = np.arange(1_000_000)
>>> %timeit pd.Series(int_arr, dtype="string")
850 ms ± 8.65 ms per loop  # master
455 ms ± 8.65 ms per loop  # this PR
>>> ser = pd.Series(int_arr)
>>> %timeit ser.astype("string")
890 ms ± 8.65 ms per loop  # master
505 ms ± 8.65 ms per loop  # this PR
```

The same improvement is given when we use `dtype=str`.
