### PR TITLE
DOC: Add link to previous versions documentation

### DIFF
--- a/doc/source/index.rst.template
+++ b/doc/source/index.rst.template
@@ -12,6 +12,9 @@ pandas documentation
 
 **Download documentation**: `PDF Version <pandas.pdf>`__ | `Zipped HTML <pandas.zip>`__
 
+**Previous versions**: Documentation of previous pandas versions is available at
+`pandas.pydata.org <https://pandas.pydata.org/>`__.
+
 **Useful links**:
 `Binary Installers <https://pypi.org/project/pandas>`__ |
 `Source Repository <https://github.com/pandas-dev/pandas>`__ |


### PR DESCRIPTION
Add a "Previous versions" block with link to https://pandas.pydata.org where links to the documentation of prior versions are available. See preview below.

![image](https://user-images.githubusercontent.com/22901938/135364568-9f22f930-b7b4-42c7-ba39-c57f6290afc2.png)

- [x] closes #43782 
- [ ] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
