### PR TITLE
PERF: tolist

### DIFF
--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -189,12 +189,6 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex):
         tolerance = np.asarray(to_timedelta(tolerance).to_numpy())
         return super()._convert_tolerance(tolerance, target)
 
-    def tolist(self) -> list:
-        """
-        Return a list of the underlying data.
-        """
-        return list(self.astype(object))
-
     # --------------------------------------------------------------------
     # Rendering Methods
 


### PR DESCRIPTION
The parent class implementation is faster.

```
dti = pd.date_range("2016-01-01", periods=10**5, freq="S")

%timeit dti.tolist()
286 ms ± 3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)  # <- master
62.8 ms ± 765 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)  # <- PR
```