### PR TITLE
TST: Test Series' settitem with Interval and NaN

### DIFF
--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -932,13 +932,14 @@ class TestiLocBaseIndependent:
         tm.assert_series_equal(series, expected)
 
     @pytest.mark.parametrize("not_na", [Interval(0, 1), "a", 1.0])
-    @pytest.mark.parametrize("na", [np.nan, NaT])
-    def test_setitem_mix_of_nan_and_interval(self, not_na, na):
+    def test_setitem_mix_of_nan_and_interval(self, not_na, nulls_fixture):
         # GH#27937
         dtype = CategoricalDtype(categories=[not_na])
-        ser = Series([na, na, na, na], dtype=dtype)
-        ser.iloc[:3] = [na, not_na, na]
-        exp = Series([na, not_na, na, na], dtype=dtype)
+        ser = Series([nulls_fixture, nulls_fixture, nulls_fixture,
+                      nulls_fixture], dtype=dtype)
+        ser.iloc[:3] = [nulls_fixture, not_na, nulls_fixture]
+        exp = Series([nulls_fixture, not_na, nulls_fixture,
+                      nulls_fixture], dtype=dtype)
         tm.assert_series_equal(ser, exp)
 
     def test_iloc_setitem_empty_frame_raises_with_3d_ndarray(self):

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -935,11 +935,11 @@ class TestiLocBaseIndependent:
     def test_setitem_mix_of_nan_and_interval(self, not_na, nulls_fixture):
         # GH#27937
         dtype = CategoricalDtype(categories=[not_na])
-        ser = Series([nulls_fixture, nulls_fixture, nulls_fixture,
-                      nulls_fixture], dtype=dtype)
+        ser = Series(
+            [nulls_fixture, nulls_fixture, nulls_fixture, nulls_fixture], dtype=dtype
+        )
         ser.iloc[:3] = [nulls_fixture, not_na, nulls_fixture]
-        exp = Series([nulls_fixture, not_na, nulls_fixture,
-                      nulls_fixture], dtype=dtype)
+        exp = Series([nulls_fixture, not_na, nulls_fixture, nulls_fixture], dtype=dtype)
         tm.assert_series_equal(ser, exp)
 
     def test_iloc_setitem_empty_frame_raises_with_3d_ndarray(self):

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -931,7 +931,7 @@ class TestiLocBaseIndependent:
         expected = Series([NaT, 1, 2], dtype="timedelta64[ns]")
         tm.assert_series_equal(series, expected)
 
-    @pytest.mark.parametrize("not_na", [Interval(0, 1), 'a', 1.0])
+    @pytest.mark.parametrize("not_na", [Interval(0, 1), "a", 1.0])
     @pytest.mark.parametrize("na", [np.nan, NaT])
     def test_setitem_mix_of_nan_and_interval(self, not_na, na):
         # GH#27937

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -931,6 +931,16 @@ class TestiLocBaseIndependent:
         expected = Series([NaT, 1, 2], dtype="timedelta64[ns]")
         tm.assert_series_equal(series, expected)
 
+    @pytest.mark.parametrize("not_na", [Interval(0, 1), 'a', 1.0])
+    @pytest.mark.parametrize("na", [np.nan, NaT])
+    def test_setitem_mix_of_nan_and_interval(self, not_na, na):
+        # GH#27937
+        dtype = CategoricalDtype(categories=[not_na])
+        ser = Series([na, na, na, na], dtype=dtype)
+        ser.iloc[:3] = [na, not_na, na]
+        exp = Series([na, not_na, na, na], dtype=dtype)
+        tm.assert_series_equal(ser, exp)
+
     def test_iloc_setitem_empty_frame_raises_with_3d_ndarray(self):
         idx = Index([])
         obj = DataFrame(np.random.randn(len(idx), len(idx)), index=idx, columns=idx)


### PR DESCRIPTION
Fixes #27937. As described in that issue, assigning a mixture of NaN and
Interval values into a slice of a categorical-typed series would raise
an exception.  This is no longer the case.

- [x] closes #27937
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
