### PR TITLE
REF: use _unary_method for SparseArray.__abs__

### DIFF
--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1597,9 +1597,6 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         else:
             return type(self)(result)
 
-    def __abs__(self):
-        return np.abs(self)
-
     # ------------------------------------------------------------------------
     # Ops
     # ------------------------------------------------------------------------
@@ -1680,6 +1677,9 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
     def __invert__(self) -> SparseArray:
         return self._unary_method(operator.invert)
+
+    def __abs__(self) -> SparseArray:
+        return self._unary_method(operator.abs)
 
     # ----------
     # Formatting


### PR DESCRIPTION
Upcoming PR will expand maybe_dispatch_ufunc_to_dunder_op to include unary methods, so this is needed to prevent circularity.