### PR TITLE
CI: Unpin fsspec

### DIFF
--- a/ci/deps/actions-38-db.yaml
+++ b/ci/deps/actions-38-db.yaml
@@ -16,7 +16,7 @@ dependencies:
   - botocore>=1.11
   - dask
   - fastparquet>=0.4.0
-  - fsspec>=0.7.4, <2021.6.0
+  - fsspec>=0.7.4
   - gcsfs>=0.6.0
   - geopandas
   - html5lib

--- a/ci/deps/actions-38-slow.yaml
+++ b/ci/deps/actions-38-slow.yaml
@@ -13,7 +13,7 @@ dependencies:
 
   # pandas dependencies
   - beautifulsoup4
-  - fsspec>=0.7.4, <2021.6.0
+  - fsspec>=0.7.4
   - html5lib
   - lxml
   - matplotlib

--- a/ci/deps/actions-39-slow.yaml
+++ b/ci/deps/actions-39-slow.yaml
@@ -15,7 +15,7 @@ dependencies:
   # pandas dependencies
   - beautifulsoup4
   - bottleneck
-  - fsspec>=0.8.0, <2021.6.0
+  - fsspec>=0.8.0
   - gcsfs
   - html5lib
   - jinja2

--- a/ci/deps/actions-39.yaml
+++ b/ci/deps/actions-39.yaml
@@ -14,7 +14,7 @@ dependencies:
   # pandas dependencies
   - beautifulsoup4
   - bottleneck
-  - fsspec>=0.8.0, <2021.6.0
+  - fsspec>=0.8.0
   - gcsfs
   - html5lib
   - jinja2

--- a/ci/deps/azure-windows-38.yaml
+++ b/ci/deps/azure-windows-38.yaml
@@ -17,7 +17,7 @@ dependencies:
   - bottleneck
   - fastparquet>=0.4.0
   - flask
-  - fsspec>=0.8.0, <2021.6.0
+  - fsspec>=0.8.0
   - matplotlib=3.3.2
   - moto>=1.3.14
   - numba

--- a/ci/deps/azure-windows-39.yaml
+++ b/ci/deps/azure-windows-39.yaml
@@ -15,7 +15,7 @@ dependencies:
   # pandas dependencies
   - beautifulsoup4
   - bottleneck
-  - fsspec>=0.8.0, <2021.6.0
+  - fsspec>=0.8.0
   - gcsfs
   - html5lib
   - jinja2

--- a/environment.yml
+++ b/environment.yml
@@ -106,7 +106,7 @@ dependencies:
   - pytables>=3.6.1  # pandas.read_hdf, DataFrame.to_hdf
   - s3fs>=0.4.0  # file IO when using 's3://...' path
   - aiobotocore
-  - fsspec>=0.7.4, <2021.6.0  # for generic remote file operations
+  - fsspec>=0.7.4  # for generic remote file operations
   - gcsfs>=0.6.0  # file IO when using 'gcs://...' path
   - sqlalchemy  # pandas.read_sql, DataFrame.to_sql
   - xarray<0.19  # DataFrame.to_xarray

--- a/pandas/tests/io/test_fsspec.py
+++ b/pandas/tests/io/test_fsspec.py
@@ -41,7 +41,7 @@ def cleared_fs():
 def test_read_csv(cleared_fs):
     from fsspec.implementations.memory import MemoryFile
 
-    cleared_fs.store["test/test.csv"] = MemoryFile(data=text)
+    cleared_fs.store["/test/test.csv"] = MemoryFile(data=text)
     df2 = read_csv("memory://test/test.csv", parse_dates=["dt"])
 
     tm.assert_frame_equal(df1, df2)

--- a/pandas/tests/io/test_fsspec.py
+++ b/pandas/tests/io/test_fsspec.py
@@ -38,12 +38,9 @@ def cleared_fs():
     memfs.store.clear()
 
 
-# Different behavior for before 2021.6.0
-@td.skip_if_no("fsspec", "2021.6.0")
 def test_read_csv(cleared_fs):
-    from fsspec.implementations.memory import MemoryFile
-
-    cleared_fs.store["/test/test.csv"] = MemoryFile(data=text)
+    with cleared_fs.open("test/test.csv", "wb") as w:
+        w.write(text)
     df2 = read_csv("memory://test/test.csv", parse_dates=["dt"])
 
     tm.assert_frame_equal(df1, df2)

--- a/pandas/tests/io/test_fsspec.py
+++ b/pandas/tests/io/test_fsspec.py
@@ -38,6 +38,8 @@ def cleared_fs():
     memfs.store.clear()
 
 
+# Different behavior for before 2021.6.0
+@td.skip_if_no("fsspec", "2021.6.0")
 def test_read_csv(cleared_fs):
     from fsspec.implementations.memory import MemoryFile
 
@@ -294,7 +296,7 @@ def test_markdown_options(fsspectest):
     df = DataFrame({"a": [0]})
     df.to_markdown("testmem://afile", storage_options={"test": "md_write"})
     assert fsspectest.test[0] == "md_write"
-    assert fsspectest.cat("afile")
+    assert fsspectest.cat("testmem://afile")
 
 
 @td.skip_if_no("pyarrow")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -70,7 +70,7 @@ python-snappy
 tables>=3.6.1
 s3fs>=0.4.0
 aiobotocore
-fsspec>=0.7.4, <2021.6.0
+fsspec>=0.7.4
 gcsfs>=0.6.0
 sqlalchemy
 xarray<0.19


### PR DESCRIPTION
- [ ] closes #42026
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

Testing a change out to see if it fixes it. Not sure if this is a bug on our side our on fsspec side. 

It seems the change is that fastparquet apends a slash in front of paths now.

cc @martindurant 