### PR TITLE
TST: added test for cut when labels are tuples of Timestamps (#40661)

### DIFF
--- a/pandas/tests/reshape/test_cut.py
+++ b/pandas/tests/reshape/test_cut.py
@@ -729,10 +729,8 @@ def test_cut_with_nonexact_categorical_indices():
 
 def test_cut_with_timestamp_tuple_labels():
     # GH 40661
-    data = [2, 4, 6]
-    bins = [1, 3, 5, 7]
     labels = [(Timestamp(10),), (Timestamp(20),), (Timestamp(30),)]
-    result = cut(data, bins=bins, labels=labels)
+    result = cut([2, 4, 6], bins=[1, 3, 5, 7], labels=labels)
 
     expected = Categorical.from_codes([0, 1, 2], labels, ordered=True)
     tm.assert_categorical_equal(result, expected)

--- a/pandas/tests/reshape/test_cut.py
+++ b/pandas/tests/reshape/test_cut.py
@@ -725,3 +725,14 @@ def test_cut_with_nonexact_categorical_indices():
     )
 
     tm.assert_frame_equal(expected, result)
+
+
+def test_cut_with_timestamp_tuple_labels():
+    # GH 40661
+    data = [2, 4, 6]
+    bins = [1, 3, 5, 7]
+    labels = [(Timestamp(10),), (Timestamp(20),), (Timestamp(30),)]
+    result = cut(data, bins=bins, labels=labels)
+
+    expected = Categorical.from_codes([0, 1, 2], labels, ordered=True)
+    tm.assert_categorical_equal(result, expected)


### PR DESCRIPTION
- [x] closes #40661 
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

Added a test for the cut method which uses Timestamp tuples as labels. Using cut with such labels raised error in v1.2.3 as reported in the issue, but it runs correctly after v1.3.0.