### PR TITLE
TYP: enable reportPropertyTypeMismatch

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -340,7 +340,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         return self._attrs
 
     @attrs.setter
-    def attrs(self, value: Mapping[Hashable, Any]) -> None:
+    def attrs(self, value: dict[Hashable, Any]) -> None:
         self._attrs = dict(value)
 
     @final

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1,3 +1,4 @@
+# pyright: reportPropertyTypeMismatch=false
 from __future__ import annotations
 
 import collections
@@ -340,7 +341,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         return self._attrs
 
     @attrs.setter
-    def attrs(self, value: dict[Hashable, Any]) -> None:
+    def attrs(self, value: Mapping[Hashable, Any]) -> None:
         self._attrs = dict(value)
 
     @final

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,6 @@ reportOptionalOperand = false
 reportOptionalSubscript = false
 reportPrivateImportUsage = false
 reportPrivateUsage = false
-reportPropertyTypeMismatch = false
 reportUnboundVariable = false
 reportUnknownArgumentType = false
 reportUnknownLambdaType = false


### PR DESCRIPTION
This might be controversial. The setter allows any `Mapping` but the getter returns a `dict`.

[reportPropertyTypeMismatch](https://github.com/microsoft/pyright/blob/main/docs/configuration.md):

> [...] type of the value passed to the setter is not assignable to the value returned by the getter. Such mismatches violate the intended use of properties, which are meant to act like variables. The default value for this setting is 'error'.