### PR TITLE
TYP: make IOHandles generic

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -7,7 +7,6 @@ from io import (
     BufferedIOBase,
     RawIOBase,
     TextIOBase,
-    TextIOWrapper,
 )
 from mmap import mmap
 from os import PathLike
@@ -170,7 +169,7 @@ AggObjType = Union[
 PythonFuncType = Callable[[Any], Any]
 
 # filenames and file-like-objects
-Buffer = Union[IO[AnyStr], RawIOBase, BufferedIOBase, TextIOBase, TextIOWrapper, mmap]
+Buffer = Union[IO[AnyStr], RawIOBase, BufferedIOBase, TextIOBase, mmap]
 FileOrBuffer = Union[str, Buffer[AnyStr]]
 FilePathOrBuffer = Union["PathLike[str]", FileOrBuffer[AnyStr]]
 

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -1,3 +1,4 @@
+# pyright: strict
 """Common IO api utilities"""
 from __future__ import annotations
 
@@ -543,24 +544,9 @@ def get_handle(
     *,
     encoding: str | None = ...,
     compression: CompressionOptions = ...,
-    is_text: Literal[True],
     memory_map: bool = ...,
-    errors: str | None = ...,
-    storage_options: StorageOptions = ...,
-) -> IOHandles[str]:
-    ...
-
-
-@overload
-def get_handle(
-    path_or_buf: FilePathOrBuffer,
-    mode: str,
-    *,
-    encoding: str | None = ...,
-    compression: CompressionOptions = ...,
     is_text: Literal[False],
     errors: str | None = ...,
-    memory_map: bool = ...,
     storage_options: StorageOptions = ...,
 ) -> IOHandles[bytes]:
     ...
@@ -574,6 +560,7 @@ def get_handle(
     encoding: str | None = ...,
     compression: CompressionOptions = ...,
     memory_map: bool = ...,
+    is_text: Literal[True] = True,
     errors: str | None = ...,
     storage_options: StorageOptions = ...,
 ) -> IOHandles[str]:

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -1,4 +1,3 @@
-# pyright: strict
 """Common IO api utilities"""
 from __future__ import annotations
 

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -941,7 +941,7 @@ class ExcelWriter(metaclass=abc.ABCMeta):
         mode = mode.replace("a", "r+")
 
         # cast ExcelWriter to avoid adding 'if self.handles is not None'
-        self.handles = IOHandles(cast(Buffer, path), compression={"copression": None})
+        self.handles = IOHandles(cast(Buffer[bytes], path), compression={"copression": None})
         if not isinstance(path, ExcelWriter):
             self.handles = get_handle(
                 path, mode, storage_options=storage_options, is_text=False

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -941,7 +941,9 @@ class ExcelWriter(metaclass=abc.ABCMeta):
         mode = mode.replace("a", "r+")
 
         # cast ExcelWriter to avoid adding 'if self.handles is not None'
-        self.handles = IOHandles(cast(Buffer[bytes], path), compression={"copression": None})
+        self.handles = IOHandles(
+            cast(Buffer[bytes], path), compression={"copression": None}
+        )
         if not isinstance(path, ExcelWriter):
             self.handles = get_handle(
                 path, mode, storage_options=storage_options, is_text=False

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -661,7 +661,7 @@ class JsonReader(abc.Iterator):
         self.nrows_seen = 0
         self.nrows = nrows
         self.encoding_errors = encoding_errors
-        self.handles: IOHandles | None = None
+        self.handles: IOHandles[str] | None = None
 
         if self.chunksize is not None:
             self.chunksize = validate_integer("chunksize", self.chunksize, 1)

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -74,7 +74,7 @@ def _get_path_or_handle(
     storage_options: StorageOptions = None,
     mode: str = "rb",
     is_dir: bool = False,
-) -> tuple[FilePathOrBuffer, IOHandles | None, Any]:
+) -> tuple[FilePathOrBuffer, IOHandles[bytes] | None, Any]:
     """File handling for PyArrow."""
     path_or_handle = stringify_path(path)
     if is_fsspec_url(path_or_handle) and fs is None:

--- a/pandas/io/parsers/base_parser.py
+++ b/pandas/io/parsers/base_parser.py
@@ -212,7 +212,7 @@ class ParserBase:
 
         self.usecols, self.usecols_dtype = self._validate_usecols_arg(kwds["usecols"])
 
-        self.handles: IOHandles | None = None
+        self.handles: IOHandles[str] | None = None
 
         # Fallback to error to pass a sketchy test(test_override_set_noconvert_columns)
         # Normally, this arg would get pre-processed earlier on

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -2294,7 +2294,7 @@ class StataWriter(StataParser):
         self._value_labels: list[StataValueLabel] = []
         self._has_value_labels = np.array([], dtype=bool)
         self._compression = compression
-        self._output_file: Buffer | None = None
+        self._output_file: Buffer[bytes] | None = None
         self._converted_names: dict[Hashable, str] = {}
         # attach nobs, nvars, data, varlist, typlist
         self._prepare_pandas(data)

--- a/pandas/io/xml.py
+++ b/pandas/io/xml.py
@@ -575,7 +575,7 @@ def get_data_from_filepath(
     encoding,
     compression,
     storage_options,
-) -> str | bytes | Buffer:
+) -> str | bytes | Buffer[str]:
     """
     Extract raw XML data.
 

--- a/pandas/io/xml.py
+++ b/pandas/io/xml.py
@@ -575,7 +575,7 @@ def get_data_from_filepath(
     encoding,
     compression,
     storage_options,
-) -> str | bytes | Buffer[str]:
+) -> str | bytes | Buffer:
     """
     Extract raw XML data.
 

--- a/pandas/tests/io/xml/test_to_xml.py
+++ b/pandas/tests/io/xml/test_to_xml.py
@@ -1287,7 +1287,8 @@ def test_compression_output(parser, comp):
 
     output = equalize_decl(output)
 
-    assert geom_xml == output.strip()
+    # error: Item "None" of "Union[str, bytes, None]" has no attribute "strip"
+    assert geom_xml == output.strip()  # type: ignore[union-attr]
 
 
 @pytest.mark.parametrize("comp", ["bz2", "gzip", "xz", "zip"])
@@ -1305,7 +1306,8 @@ def test_filename_and_suffix_comp(parser, comp, compfile):
 
     output = equalize_decl(output)
 
-    assert geom_xml == output.strip()
+    # error: Item "None" of "Union[str, bytes, None]" has no attribute "strip"
+    assert geom_xml == output.strip()  # type: ignore[union-attr]
 
 
 def test_unsuported_compression(datapath, parser):


### PR DESCRIPTION
Towards #41610

This doesn't help with any ignore statements, as `Buffer` is defined as `Buffer = Union[IO[AnyStr], RawIOBase, BufferedIOBase, TextIOBase, TextIOWrapper, mmap]`: `IO[AnyStr]` will be replaced with `IO[str]` or `IO[bytes]`.

btw., `Buffer` is a "bad" union as it contains one generic and many actual types (I think, I'm the one to blame for that). It is often used without an actual type (`Buffer` instead of `Buffer[str]` or `Buffer[bytes]`).