### PR TITLE
PERF: get_loc

### DIFF
--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -116,12 +116,14 @@ cdef class IndexEngine:
     cdef:
         bint unique, monotonic_inc, monotonic_dec
         bint need_monotonic_check, need_unique_check
+        object _np_type
 
     def __init__(self, ndarray values):
         self.values = values
 
         self.over_size_threshold = len(values) >= _SIZE_CUTOFF
         self.clear_mapping()
+        self._np_type = values.dtype.type
 
     def __contains__(self, val: object) -> bool:
         # We assume before we get here:
@@ -168,7 +170,7 @@ cdef class IndexEngine:
         See ObjectEngine._searchsorted_left.__doc__.
         """
         # Caller is responsible for ensuring _check_type has already been called
-        loc = self.values.searchsorted(val, side="left")
+        loc = self.values.searchsorted(self._np_type(val), side="left")
         return loc
 
     cdef inline _get_loc_duplicates(self, object val):


### PR DESCRIPTION
Fixes a perf regression from 1.2.x

```
from asv_bench.benchmarks.indexing import *
setup()
self = NumericSeriesIndexing()
self.setup(UInt64Index, "unique_monotonic_inc")

%timeit self.time_getitem_scalar(UInt64Index, "unique_monotonic_inc")
6.34 µs ± 257 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <- PR
46.5 µs ± 724 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)  # <- 1.2.0
1.43 ms ± 36.9 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)  # <- master

%timeit self.time_loc_scalar(UInt64Index, "unique_monotonic_inc")
12.6 µs ± 163 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <- PR
53.9 µs ± 1.1 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)  # <- 1.2.0
1.38 ms ± 5.33 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)  # <- master


%timeit self.time_loc_slice(UInt64Index, "unique_monotonic_inc")
32.5 µs ± 2.63 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)  # <- PR
75.6 µs ± 1.22 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)  # <- 1.2.0
1.41 ms ± 10.4 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)  # <- master
```