### PR TITLE
Don't suppress exception chaining for optional dependencies

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -126,6 +126,7 @@ Other enhancements
 - Attempting to write into a file in missing parent directory with :meth:`DataFrame.to_csv`, :meth:`DataFrame.to_html`, :meth:`DataFrame.to_excel`, :meth:`DataFrame.to_feather`, :meth:`DataFrame.to_parquet`, :meth:`DataFrame.to_stata`, :meth:`DataFrame.to_json`, :meth:`DataFrame.to_pickle`, and :meth:`DataFrame.to_xml` now explicitly mentions missing parent directory, the same is true for :class:`Series` counterparts (:issue:`24306`)
 - :meth:`IntegerArray.all` , :meth:`IntegerArray.any`, :meth:`FloatingArray.any`, and :meth:`FloatingArray.all` use Kleene logic (:issue:`41967`)
 - Added support for nullable boolean and integer types in :meth:`DataFrame.to_stata`, :class:`~pandas.io.stata.StataWriter`, :class:`~pandas.io.stata.StataWriter117`, and :class:`~pandas.io.stata.StataWriterUTF8` (:issue:`40855`)
+- The error raised when an optional dependency can't be imported now includes the original exception, for easier investigation.
 -
 
 .. ---------------------------------------------------------------------------
@@ -142,7 +143,8 @@ These are bug fixes that might have notable behavior changes.
 Inconsistent date string parsing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``dayfirst`` option of :func:`to_datetime` isn't strict, and this can lead to surprising behaviour:
+The ``dayfirst`` option of :func:`to_datetime` isn't strict, and this can lead to sur
+ising behaviour:
 
 .. ipython:: python
     :okwarning:

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -143,8 +143,7 @@ These are bug fixes that might have notable behavior changes.
 Inconsistent date string parsing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``dayfirst`` option of :func:`to_datetime` isn't strict, and this can lead to sur
-ising behaviour:
+The ``dayfirst`` option of :func:`to_datetime` isn't strict, and this can lead to surprising behaviour:
 
 .. ipython:: python
     :okwarning:

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -127,7 +127,7 @@ Other enhancements
 - :meth:`IntegerArray.all` , :meth:`IntegerArray.any`, :meth:`FloatingArray.any`, and :meth:`FloatingArray.all` use Kleene logic (:issue:`41967`)
 - Added support for nullable boolean and integer types in :meth:`DataFrame.to_stata`, :class:`~pandas.io.stata.StataWriter`, :class:`~pandas.io.stata.StataWriter117`, and :class:`~pandas.io.stata.StataWriterUTF8` (:issue:`40855`)
 - :meth:`DataFrame.__pos__`, :meth:`DataFrame.__neg__` now retain ``ExtensionDtype`` dtypes (:issue:`43883`)
-- The error raised when an optional dependency can't be imported now includes the original exception, for easier investigation.
+- The error raised when an optional dependency can't be imported now includes the original exception, for easier investigation (:issue:`43882`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/compat/_optional.py
+++ b/pandas/compat/_optional.py
@@ -115,7 +115,7 @@ def import_optional_dependency(
         module = importlib.import_module(name)
     except ImportError:
         if errors == "raise":
-            raise ImportError(msg) from None
+            raise ImportError(msg)
         else:
             return None
 

--- a/pandas/tests/test_optional_dependency.py
+++ b/pandas/tests/test_optional_dependency.py
@@ -16,7 +16,7 @@ def test_import_optional():
     with pytest.raises(ImportError, match=match) as exc_info:
         import_optional_dependency("notapackage")
     # The original exception should be there as context:
-    assert isinstance(excinfo.value.__context__, ImportError)
+    assert isinstance(exc_info.value.__context__, ImportError)
 
     result = import_optional_dependency("notapackage", errors="ignore")
     assert result is None

--- a/pandas/tests/test_optional_dependency.py
+++ b/pandas/tests/test_optional_dependency.py
@@ -13,8 +13,10 @@ import pandas._testing as tm
 
 def test_import_optional():
     match = "Missing .*notapackage.* pip .* conda .* notapackage"
-    with pytest.raises(ImportError, match=match):
+    with pytest.raises(ImportError, match=match) as exc_info:
         import_optional_dependency("notapackage")
+    # The original exception should be there as context:
+    assert isinstance(excinfo.value.__context__, ImportError)
 
     result = import_optional_dependency("notapackage", errors="ignore")
     assert result is None


### PR DESCRIPTION
I've just been [helping someone](https://stackoverflow.com/questions/69352179/package-streamlit-app-and-run-executable-on-windows) for whom the helpful error message appears to have obscured the real cause of the problem. Specifically, Jinja2 is present, but one of *its* dependencies is not. So the error message saying "Missing optional dependency: 'Jinja2'..." is rather confusing.

Automatic exception chaining is really great for things like this - you can provide a more descriptive error message while still having the original exception details available for inspection. I'd argue that it should only be disabled (`raise ... from None`) if you're absolutely sure that there will be no useful information in the original exception.