### PR TITLE
Annotates `indexers/utils.py` functions that don't return anything with `None`

### DIFF
--- a/pandas/core/indexers/utils.py
+++ b/pandas/core/indexers/utils.py
@@ -363,7 +363,7 @@ def length_of_indexer(indexer, target=None) -> int:
     raise AssertionError("cannot find the length of the indexer")
 
 
-def deprecate_ndim_indexing(result, stacklevel: int = 3):
+def deprecate_ndim_indexing(result, stacklevel: int = 3) -> None:
     """
     Helper function to raise the deprecation warning for multi-dimensional
     indexing on 1D Series/Index.
@@ -409,7 +409,7 @@ def unpack_1tuple(tup):
     return tup
 
 
-def check_key_length(columns: Index, key, value: DataFrame):
+def check_key_length(columns: Index, key, value: DataFrame) -> None:
     """
     Checks if a key used as indexer has the same length as the columns it is
     associated with.


### PR DESCRIPTION
- [ ] does not close any issue, change is too trivial
- [ ] tests are not required for this
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] nothing new

Related https://github.com/python/mypy/pull/11273
