### PR TITLE
fixed rolling for a decreasing index, added a test for that

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -502,6 +502,7 @@ Groupby/resample/rolling
 - Bug in :meth:`DataFrame.groupby.rolling` when specifying ``on`` and calling ``__getitem__`` would subsequently return incorrect results (:issue:`43355`)
 - Bug in :meth:`GroupBy.apply` with time-based :class:`Grouper` objects incorrectly raising ``ValueError`` in corner cases where the grouping vector contains a ``NaT`` (:issue:`43500`, :issue:`43515`)
 - Bug in :meth:`GroupBy.mean` failing with ``complex`` dtype (:issue:`43701`)
+- Fixed bug in :meth:`Series.rolling` and :meth:`DataFrame.rolling` not calculating window bounds correctly for the first row when ``center=True`` and index is decreasing (:issue:`43927`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/_libs/window/indexers.pyx
+++ b/pandas/_libs/window/indexers.pyx
@@ -81,9 +81,11 @@ def calculate_variable_window_bounds(
     if center:
         end_bound = index[0] + index_growth_sign * window_size / 2
         for j in range(0, num_values):
-            if (index[j] < end_bound) or (index[j] == end_bound and right_closed):
+            if (index[j] - end_bound) * index_growth_sign < 0:
                 end[0] = j + 1
-            elif index[j] >= end_bound:
+            elif (index[j] - end_bound) * index_growth_sign == 0 and right_closed:
+                end[0] = j + 1
+            elif (index[j] - end_bound) * index_growth_sign >= 0:
                 end[0] = j
                 break
 

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -1210,6 +1210,22 @@ def test_rolling_decreasing_indices(method):
     assert np.abs(decreasing.values[::-1][:-4] - increasing.values[4:]).max() < 1e-12
 
 
+@pytest.mark.parametrize("window", ["0s", "2s", "3s"])
+def test_rolling_decreasing_indices_invariant(window, center, closed):
+    """
+    Ensure that a symmetrical inverted index return same result as non-inverted.
+    """
+
+    index = date_range("2020", periods=4, freq="1s")
+    df_inc = Series(range(4), index=index)
+    df_dec = Series(range(4), index=index[::-1])
+
+    result = df_dec.rolling(window, closed=closed, center=center).sum()
+    expected = df_inc.rolling(window, closed=closed, center=center).sum()
+
+    tm.assert_equal(result.values, expected.values)
+
+
 @pytest.mark.parametrize(
     "method,expected",
     [

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -1210,20 +1210,37 @@ def test_rolling_decreasing_indices(method):
     assert np.abs(decreasing.values[::-1][:-4] - increasing.values[4:]).max() < 1e-12
 
 
-@pytest.mark.parametrize("window", ["0s", "2s", "3s"])
-def test_rolling_decreasing_indices_invariant(window, center, closed):
+@pytest.mark.parametrize(
+    "window,closed,expected",
+    [
+        ("2s", "right", [1.0, 3.0, 5.0, 3.0]),
+        ("2s", "left", [0.0, 1.0, 3.0, 5.0]),
+        ("2s", "both", [1.0, 3.0, 6.0, 5.0]),
+        ("2s", "neither", [0.0, 1.0, 2.0, 3.0]),
+        ("3s", "right", [1.0, 3.0, 6.0, 5.0]),
+        ("3s", "left", [1.0, 3.0, 6.0, 5.0]),
+        ("3s", "both", [1.0, 3.0, 6.0, 5.0]),
+        ("3s", "neither", [1.0, 3.0, 6.0, 5.0]),
+    ],
+)
+def test_rolling_decreasing_indices_centered(window, closed, expected, frame_or_series):
     """
     Ensure that a symmetrical inverted index return same result as non-inverted.
     """
+    #  GH 43927
 
     index = date_range("2020", periods=4, freq="1s")
-    df_inc = Series(range(4), index=index)
-    df_dec = Series(range(4), index=index[::-1])
+    df_inc = frame_or_series(range(4), index=index)
+    df_dec = frame_or_series(range(4), index=index[::-1])
 
-    result = df_dec.rolling(window, closed=closed, center=center).sum()
-    expected = df_inc.rolling(window, closed=closed, center=center).sum()
+    expected_inc = frame_or_series(expected, index=index)
+    expected_dec = frame_or_series(expected, index=index[::-1])
 
-    tm.assert_equal(result.values, expected.values)
+    result_inc = df_inc.rolling(window, closed=closed, center=True).sum()
+    result_dec = df_dec.rolling(window, closed=closed, center=True).sum()
+
+    tm.assert_equal(result_inc, expected_inc)
+    tm.assert_equal(result_dec, expected_dec)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] closes #43927
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry
