### PR TITLE
BUG: fix Frame getitem when column keys are nested tuples

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -240,7 +240,8 @@ def asarray_tuplesafe(values, dtype: NpDtype | None = None) -> np.ndarray:
     if issubclass(result.dtype.type, str):
         result = np.asarray(values, dtype=object)
 
-    if result.ndim == 2:
+    # For ndim > 2 distinguish between nested tuples and multidimensional arrays
+    if result.ndim == 2 or (result.ndim > 2 and isinstance(values[0][0], tuple)):
         # Avoid building an array of arrays:
         values = [tuple(x) for x in values]
         result = construct_1d_object_array_from_listlike(values)

--- a/pandas/tests/frame/indexing/test_getitem.py
+++ b/pandas/tests/frame/indexing/test_getitem.py
@@ -160,6 +160,15 @@ class TestGetitemListLike:
         expected = Series([5, 6], name="b", index=[1, 2])
         tm.assert_series_equal(result, expected)
 
+    def test_getitem_key_nested_tuple(self):
+        # GH 43780
+        df = DataFrame([[0, 0]], columns=Index([(("a",), (1,)), (("b",), (2,))]))
+        key_list = [df.columns[0]]
+        result = df[key_list]
+
+        expected = DataFrame([0], columns=Index(key_list))
+        tm.assert_frame_equal(result, expected)
+
 
 class TestGetitemCallable:
     def test_getitem_callable(self, float_frame):


### PR DESCRIPTION
- [x] closes #43780 
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

Multi-column selection when the column labels are nested tuples, for example atomic labels of form `((1,),)` or MultiIndex having tuples at each level as reported in the issue raised error due to a condition in asarray_tuplesafe.

A key list of form `[((1,))]` converts to `[[[1]]]` through the call to np.array, resulting in ndim>2. However, only the case ndim==2 was further handled, causing a multi-dimensional array to be returned and subsequently an error.

This extends the ndim==2 condition for nested-tuple keys, but excludes multi-dimensional arrays so that errors are raised in accordance with [test_getitem_ndarray_3d](https://github.com/pandas-dev/pandas/blob/d30aeeba0c79fb8e4b651a8f528e87c3de8cb898/pandas/tests/indexing/test_indexing.py#L73).


