### PR TITLE
DOC: Add examples for categorical functions

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1170,6 +1170,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         >>> c
         ['c', 'b', 'c']
         Categories (2, object): ['b', 'c']
+
         >>> c.add_categories(['d', 'a'])
         ['c', 'b', 'c']
         Categories (4, object): ['b', 'c', 'd', 'a']
@@ -1244,6 +1245,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         >>> c
         ['a', 'c', 'b', 'c', 'd']
         Categories (4, object): ['a', 'b', 'c', 'd']
+
         >>> c.remove_categories(['d', 'a'])
         [NaN, 'c', 'b', 'c', NaN]
         Categories (2, object): ['b', 'c']
@@ -1313,11 +1315,13 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         >>> c
         ['a', 'c', 'b', 'c', 'd']
         Categories (4, object): ['a', 'b', 'c', 'd']
+
         >>> c[2] = 'a'
         >>> c[4] = 'c'
         >>> c
         ['a', 'c', 'a', 'c', 'c']
         Categories (4, object): ['a', 'b', 'c', 'd']
+
         >>> c.remove_unused_categories()
         ['a', 'c', 'a', 'c', 'c']
         Categories (2, object): ['a', 'c']

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1163,6 +1163,16 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         remove_categories : Remove the specified categories.
         remove_unused_categories : Remove categories which are not used.
         set_categories : Set the categories to the specified ones.
+
+        Examples
+        --------
+        >>> c = pd.Categorical(['c', 'b', 'c'])
+        >>> c
+        ['c', 'b', 'c']
+        Categories (2, object): ['b', 'c']
+        >>> c.add_categories(['d', 'a'])
+        ['c', 'b', 'c']
+        Categories (4, object): ['b', 'c', 'd', 'a']
         """
         if inplace is not no_default:
             warn(
@@ -1227,6 +1237,16 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         add_categories : Add new categories.
         remove_unused_categories : Remove categories which are not used.
         set_categories : Set the categories to the specified ones.
+
+        Examples
+        --------
+        >>> c = pd.Categorical(['a', 'c', 'b', 'c', 'd'])
+        >>> c
+        ['a', 'c', 'b', 'c', 'd']
+        Categories (4, object): ['a', 'b', 'c', 'd']
+        >>> c.remove_categories(['d', 'a'])
+        [NaN, 'c', 'b', 'c', NaN]
+        Categories (2, object): ['b', 'c']
         """
         if inplace is not no_default:
             warn(
@@ -1286,6 +1306,21 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         add_categories : Add new categories.
         remove_categories : Remove the specified categories.
         set_categories : Set the categories to the specified ones.
+
+        Examples
+        --------
+        >>> c = pd.Categorical(['a', 'c', 'b', 'c', 'd'])
+        >>> c
+        ['a', 'c', 'b', 'c', 'd']
+        Categories (4, object): ['a', 'b', 'c', 'd']
+        >>> c[2] = 'a'
+        >>> c[4] = 'c'
+        >>> c
+        ['a', 'c', 'a', 'c', 'c']
+        Categories (4, object): ['a', 'b', 'c', 'd']
+        >>> c.remove_unused_categories()
+        ['a', 'c', 'a', 'c', 'c']
+        Categories (2, object): ['a', 'c']
         """
         if inplace is not no_default:
             warn(


### PR DESCRIPTION
Adds simple examples to docstrings for `add_categories`, `remove_categories`, and `remove_unused_categories`.
