### PR TITLE
BUG: startswith function gives misleading results when passed a series #3485

### DIFF
--- a/pandas/core/strings/object_array.py
+++ b/pandas/core/strings/object_array.py
@@ -134,7 +134,7 @@ class ObjectStringArrayMixin(BaseStringArrayMethods):
         return self._str_map(f, na, dtype=np.dtype("bool"))
 
     def _str_startswith(self, pat, na=None):
-        if type(pat)==_Core.series.Series:
+        if type(pat) == _Core.series.Series:
             pat = tuple(i for i in pat.tolist() if i)
         f = lambda x: x.startswith(pat)
         return self._str_map(f, na_value=na, dtype=np.dtype(bool))

--- a/pandas/core/strings/object_array.py
+++ b/pandas/core/strings/object_array.py
@@ -24,6 +24,7 @@ from pandas.core.strings.base import BaseStringArrayMethods
 if TYPE_CHECKING:
     from pandas import Series
 
+import pandas.core as _Core
 
 class ObjectStringArrayMixin(BaseStringArrayMethods):
     """
@@ -133,6 +134,8 @@ class ObjectStringArrayMixin(BaseStringArrayMethods):
         return self._str_map(f, na, dtype=np.dtype("bool"))
 
     def _str_startswith(self, pat, na=None):
+        if type(pat)==_Core.series.Series:
+            pat = tuple(i for i in pat.tolist() if i)
         f = lambda x: x.startswith(pat)
         return self._str_map(f, na_value=na, dtype=np.dtype(bool))
 

--- a/pandas/core/strings/object_array.py
+++ b/pandas/core/strings/object_array.py
@@ -24,7 +24,7 @@ from pandas.core.strings.base import BaseStringArrayMethods
 if TYPE_CHECKING:
     from pandas import Series
 
-import pandas.core as _Core
+from pandas import Series
 
 class ObjectStringArrayMixin(BaseStringArrayMethods):
     """
@@ -134,7 +134,7 @@ class ObjectStringArrayMixin(BaseStringArrayMethods):
         return self._str_map(f, na, dtype=np.dtype("bool"))
 
     def _str_startswith(self, pat, na=None):
-        if type(pat) == _Core.series.Series:
+        if type(pat) == Series:
             pat = tuple(i for i in pat.tolist() if i)
         f = lambda x: x.startswith(pat)
         return self._str_map(f, na_value=na, dtype=np.dtype(bool))


### PR DESCRIPTION

- [x] closes #3485
- [] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
``` python import pandas
d = pandas.DataFrame([['hi,hi 2'],['bye','bye 2']], columns=['one','two'])
print(d.one.str.startswith(d.two))
```