### PR TITLE
DOC: Fix Series nlargest and nsmallest doc strings (#43964)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,5 +120,3 @@ doc/build/html/index.html
 doc/tmp.sv
 env/
 doc/source/savefig/
-
-.history

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,5 @@ doc/build/html/index.html
 doc/tmp.sv
 env/
 doc/source/savefig/
+
+.history

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6597,7 +6597,7 @@ class DataFrame(NDFrame, OpsMixin):
             - `first` : prioritize the first occurrence(s)
             - `last` : prioritize the last occurrence(s)
             - ``all`` : do not drop any duplicates, even it means
-                        selecting more than `n` items.
+              selecting more than `n` items.
 
         Returns
         -------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3692,11 +3692,11 @@ Keep all original rows and also all original values
             Series of `n` elements:
 
             - ``first`` : return the first `n` occurrences in order
-                of appearance.
+              of appearance.
             - ``last`` : return the last `n` occurrences in reverse
-                order of appearance.
+              order of appearance.
             - ``all`` : keep all occurrences. This can result in a Series of
-                size larger than `n`.
+              size larger than `n`.
 
         Returns
         -------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3790,11 +3790,11 @@ Keep all original rows and also all original values
             Series of `n` elements:
 
             - ``first`` : return the first `n` occurrences in order
-                of appearance.
+              of appearance.
             - ``last`` : return the last `n` occurrences in reverse
-                order of appearance.
+              order of appearance.
             - ``all`` : keep all occurrences. This can result in a Series of
-                size larger than `n`.
+              size larger than `n`.
 
         Returns
         -------

--- a/pandas/core/shared_docs.py
+++ b/pandas/core/shared_docs.py
@@ -492,7 +492,7 @@ _shared_docs[
     ------
     AssertionError
         * If `regex` is not a ``bool`` and `to_replace` is not
-            ``None``.
+          ``None``.
 
     TypeError
         * If `to_replace` is not a scalar, array-like, ``dict``, or ``None``


### PR DESCRIPTION
- [x] closes #43937
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] Cancel nlargest and nsmallest's doc list item text bold effect, detail could see below.

From
![Clip_20211011_094600](https://user-images.githubusercontent.com/25895405/136727253-30d20e21-ba1c-4be0-b1ad-87239b66d59e.png)
To
![Clip_20211011_105541](https://user-images.githubusercontent.com/25895405/136727262-f28a75e0-48e8-478b-a460-7690181d97d0.png)