### PR TITLE
TST: changed behavior of df.loc on multiindex

### DIFF
--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -912,3 +912,13 @@ def test_loc_keyerror_rightmost_key_missing():
     df = df.set_index(["A", "B"])
     with pytest.raises(KeyError, match="^1$"):
         df.loc[(100, 1)]
+def test_loc_multiindex():
+    #43599
+    df = DataFrame(
+        index = MultiIndex.from_product([list("abc"), list("de"), list("f")]), columns = ["Val"]
+        )
+    result = df.loc[np.s_[:,"d",:]]
+    expected = DataFrame(
+        index = MultiIndex.from_product([list("abc"), list("d"), list("f")]), columns = ["Val"]
+        )
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -38,6 +38,7 @@ import pandas._testing as tm
 from pandas.api.types import is_scalar
 from pandas.core.api import Float64Index
 from pandas.tests.indexing.common import Base
+import unittest
 
 
 class TestLoc(Base):
@@ -2833,7 +2834,7 @@ class TestLocSeries:
 
     @td.skip_array_manager_invalid_test
     def test_loc_setitem_dict_timedelta_multiple_set(self):
-        # GH 16309
+        # GH 16309s
         result = DataFrame(columns=["time", "value"])
         result.loc[1] = {"time": Timedelta(6, unit="s"), "value": "foo"}
         result.loc[1] = {"time": Timedelta(6, unit="s"), "value": "foo"}
@@ -2857,3 +2858,15 @@ class TestLocSeries:
         )
 
         tm.assert_frame_equal(df, expected)
+
+
+class TestLoc3(unittest.TestCase): #test case for issue #43599
+    def test_loc_multiindex(self):
+        df = pd.DataFrame(index=pd.MultiIndex.from_product([list('abc'), list('de'), list('f')]), columns=['Val'])
+        df1=df.loc[np.s_[:,'d',:]]
+        df2=pd.DataFrame(index=pd.MultiIndex.from_product([list('abc'), list('d'), list('f')]), columns=['Val'])
+
+        
+        tm.assert_frame_equal(df1,df2)
+
+

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -2834,7 +2834,7 @@ class TestLocSeries:
 
     @td.skip_array_manager_invalid_test
     def test_loc_setitem_dict_timedelta_multiple_set(self):
-        # GH 16309s
+        # GH 16309
         result = DataFrame(columns=["time", "value"])
         result.loc[1] = {"time": Timedelta(6, unit="s"), "value": "foo"}
         result.loc[1] = {"time": Timedelta(6, unit="s"), "value": "foo"}
@@ -2858,15 +2858,3 @@ class TestLocSeries:
         )
 
         tm.assert_frame_equal(df, expected)
-
-
-class TestLoc3(unittest.TestCase): #test case for issue #43599
-    def test_loc_multiindex(self):
-        df = pd.DataFrame(index=pd.MultiIndex.from_product([list('abc'), list('de'), list('f')]), columns=['Val'])
-        df1=df.loc[np.s_[:,'d',:]]
-        df2=pd.DataFrame(index=pd.MultiIndex.from_product([list('abc'), list('d'), list('f')]), columns=['Val'])
-
-        
-        tm.assert_frame_equal(df1,df2)
-
-

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -38,7 +38,7 @@ import pandas._testing as tm
 from pandas.api.types import is_scalar
 from pandas.core.api import Float64Index
 from pandas.tests.indexing.common import Base
-import unittest
+
 
 
 class TestLoc(Base):


### PR DESCRIPTION
-added unittest for issue #43599
-error occurs due to different versions of pandas
-made the requested changes 
