### PR TITLE
STYLE ban np.testing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -135,6 +135,12 @@ repos:
         entry: 'np\.random\.seed'
         files: ^asv_bench/benchmarks
         exclude: ^asv_bench/benchmarks/pandas_vb_common\.py
+    -   id: np-testing-array-equal
+        name: Check for usage of numpy testing or array_equal
+        language: pygrep
+        entry: '(numpy|np)(\.testing|\.array_equal)'
+        files: ^pandas/tests/
+        types: [python]
     -   id: invalid-ea-testing
         name: Check for invalid EA testing
         language: pygrep

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -1256,7 +1256,7 @@ class TestAccessor:
             row_levels=(0, 1), column_levels=(2, 3), sort_labels=sort_labels
         )
         assert isinstance(A, scipy.sparse.coo.coo_matrix)
-        np.testing.assert_array_equal(A.toarray(), expected_A)
+        tm.assert_numpy_array_equal(A.toarray(), expected_A)
         assert rows == expected_rows
         assert cols == expected_cols
 


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/43674#discussion_r720831806

There used to be a linting rule for this, but I missed it when moving linting rules over to `pandas-dev-flaker` in https://github.com/pandas-dev/pandas/pull/40906 - sorry about that, I thought I'd checked that everything had been preserved

Would be good to use this one from `pandas-dev-flaker` directly, but without a `--per-file-selects` option it'd be rather cumbersome (https://github.com/PyCQA/flake8/issues/344#issuecomment-940054283)