### PR TITLE
REF: extract params used in DataFrame.__repr__

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -994,24 +994,10 @@ class DataFrame(NDFrame, OpsMixin):
             self.info(buf=buf)
             return buf.getvalue()
 
-        repr_params = self._get_repr_params()
+        repr_params = fmt.get_dataframe_repr_params()
         self.to_string(buf=buf, **repr_params)
 
         return buf.getvalue()
-
-    def _get_repr_params(self) -> dict[str, Any]:
-        if get_option("display.expand_frame_repr"):
-            line_width, _ = console.get_console_size()
-        else:
-            line_width = None
-        return {
-            "max_rows": get_option("display.max_rows"),
-            "min_rows": get_option("display.min_rows"),
-            "max_cols": get_option("display.max_columns"),
-            "max_colwidth": get_option("display.max_colwidth"),
-            "show_dimensions": get_option("display.show_dimensions"),
-            "line_width": line_width,
-        }
 
     def _repr_html_(self) -> str | None:
         """

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1001,16 +1001,16 @@ class DataFrame(NDFrame, OpsMixin):
 
     def _get_repr_params(self) -> dict[str, Any]:
         if get_option("display.expand_frame_repr"):
-            width, _ = console.get_console_size()
+            line_width, _ = console.get_console_size()
         else:
-            width = None
+            line_width = None
         return {
             "max_rows": get_option("display.max_rows"),
             "min_rows": get_option("display.min_rows"),
             "max_cols": get_option("display.max_columns"),
             "max_colwidth": get_option("display.max_colwidth"),
             "show_dimensions": get_option("display.show_dimensions"),
-            "width": width,
+            "line_width": line_width,
         }
 
     def _repr_html_(self) -> str | None:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -994,26 +994,24 @@ class DataFrame(NDFrame, OpsMixin):
             self.info(buf=buf)
             return buf.getvalue()
 
-        max_rows = get_option("display.max_rows")
-        min_rows = get_option("display.min_rows")
-        max_cols = get_option("display.max_columns")
-        max_colwidth = get_option("display.max_colwidth")
-        show_dimensions = get_option("display.show_dimensions")
+        repr_params = self._get_repr_params()
+        self.to_string(buf=buf, **repr_params)
+
+        return buf.getvalue()
+
+    def _get_repr_params(self) -> dict[str, Any]:
         if get_option("display.expand_frame_repr"):
             width, _ = console.get_console_size()
         else:
             width = None
-        self.to_string(
-            buf=buf,
-            max_rows=max_rows,
-            min_rows=min_rows,
-            max_cols=max_cols,
-            line_width=width,
-            max_colwidth=max_colwidth,
-            show_dimensions=show_dimensions,
-        )
-
-        return buf.getvalue()
+        return {
+            "max_rows": get_option("display.max_rows"),
+            "min_rows": get_option("display.min_rows"),
+            "max_cols": get_option("display.max_columns"),
+            "max_colwidth": get_option("display.max_colwidth"),
+            "show_dimensions": get_option("display.show_dimensions"),
+            "width": width,
+        }
 
     def _repr_html_(self) -> str | None:
         """

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -483,6 +483,37 @@ def get_adjustment() -> TextAdjustment:
         return TextAdjustment()
 
 
+def get_dataframe_repr_params() -> dict[str, Any]:
+    """Get the parameters used to repr(dataFrame) calls using DataFrame.to_string.
+
+    Supplying these parameters to DataFrame.to_string is equivalent to calling
+    ``repr(DataFrame)``. This is useful if you want to adjust the repr output.
+
+    Example
+    -------
+    >>> import pandas as pd
+    >>>
+    >>> df = pd.DataFrame([[1, 2], [3, 4]])
+    >>> repr_params = pd.io.formats.format.get_dataframe_repr_params()
+    >>> assert repr(df) == df.to_string(**repr_params)
+    True
+    """
+    from pandas.io.formats import console
+
+    if get_option("display.expand_frame_repr"):
+        line_width, _ = console.get_console_size()
+    else:
+        line_width = None
+    return {
+        "max_rows": get_option("display.max_rows"),
+        "min_rows": get_option("display.min_rows"),
+        "max_cols": get_option("display.max_columns"),
+        "max_colwidth": get_option("display.max_colwidth"),
+        "show_dimensions": get_option("display.show_dimensions"),
+        "line_width": line_width,
+    }
+
+
 class DataFrameFormatter:
     """Class for processing dataframe formatting options and data."""
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -495,7 +495,7 @@ def get_dataframe_repr_params() -> dict[str, Any]:
     >>>
     >>> df = pd.DataFrame([[1, 2], [3, 4]])
     >>> repr_params = pd.io.formats.format.get_dataframe_repr_params()
-    >>> assert repr(df) == df.to_string(**repr_params)
+    >>> repr(df) == df.to_string(**repr_params)
     True
     """
     from pandas.io.formats import console


### PR DESCRIPTION
`DataFrame.__repr__` used different parameters than `DataFrame.to_string` and I've got a case where I want to use the `__repr__` ones, but with a change to one of the parameters. This refactoring makes it possible to extract those parameters so we can do:

```python
>>> params = pd.io.formats.format.get_frame_repr_params()
>>> params[my_param] = new_value
>>> df.to_string(**params)
```
