### PR TITLE
PERF: RangeIndex.insert

### DIFF
--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -713,6 +713,20 @@ class RangeIndex(NumericIndex):
 
     # --------------------------------------------------------------------
 
+    def insert(self, loc: int, item) -> Index:
+        if len(self) and (is_integer(item) or is_float(item)):
+            # We can retain RangeIndex is inserting at the beginning or end
+            rng = self._range
+            if loc == 0 and item == self[0] - self.step:
+                new_rng = range(rng.start - rng.step, rng.stop, rng.step)
+                return type(self)._simple_new(new_rng, name=self.name)
+
+            elif loc == len(self) and item == self[-1] + self.step:
+                new_rng = range(rng.start, rng.stop + rng.step, rng.step)
+                return type(self)._simple_new(new_rng, name=self.name)
+
+        return super().insert(loc, item)
+
     def _concat(self, indexes: list[Index], name: Hashable) -> Index:
         """
         Overriding parent method for the case of all RangeIndex instances.

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -818,7 +818,7 @@ class NumericBase(Base):
             cls = Int64Index
 
         expected = cls([index[0]] + list(index), dtype=index.dtype)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_insert_na(self, nulls_fixture, simple_index):
         # GH 18295 (test missing)


### PR DESCRIPTION
```
index = pd.Index(range(2))

%timeit index.insert(2, 2)
48.4 µs ± 2.03 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)  # <- master
2.54 µs ± 70.1 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <- PR
```