### PR TITLE
TST: pass exact to assert_index_equal

### DIFF
--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -553,6 +553,7 @@ def assert_categorical_equal(
     """
     _check_isinstance(left, right, Categorical)
 
+    exact: bool | str
     if isinstance(left.categories, RangeIndex) or isinstance(
         right.categories, RangeIndex
     ):

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -33,6 +33,7 @@ from pandas import (
     IntervalIndex,
     MultiIndex,
     PeriodIndex,
+    RangeIndex,
     Series,
     TimedeltaIndex,
 )
@@ -552,8 +553,18 @@ def assert_categorical_equal(
     """
     _check_isinstance(left, right, Categorical)
 
+    if isinstance(left.categories, RangeIndex) or isinstance(
+        right.categories, RangeIndex
+    ):
+        exact = "equiv"
+    else:
+        # We still want to require exact matches for NumericIndex
+        exact = True
+
     if check_category_order:
-        assert_index_equal(left.categories, right.categories, obj=f"{obj}.categories")
+        assert_index_equal(
+            left.categories, right.categories, obj=f"{obj}.categories", exact=exact
+        )
         assert_numpy_array_equal(
             left.codes, right.codes, check_dtype=check_dtype, obj=f"{obj}.codes"
         )
@@ -564,11 +575,12 @@ def assert_categorical_equal(
         except TypeError:
             # e.g. '<' not supported between instances of 'int' and 'str'
             lc, rc = left.categories, right.categories
-        assert_index_equal(lc, rc, obj=f"{obj}.categories")
+        assert_index_equal(lc, rc, obj=f"{obj}.categories", exact=exact)
         assert_index_equal(
             left.categories.take(left.codes),
             right.categories.take(right.codes),
             obj=f"{obj}.values",
+            exact=exact,
         )
 
     assert_attr_equal("ordered", left, right, obj=obj)

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -1215,12 +1215,12 @@ class TestNumericArithmeticUnsorted:
                 b = b._rename("bar")
                 result = op(a, b)
                 expected = op(Int64Index(a), Int64Index(b))
-                tm.assert_index_equal(result, expected)
+                tm.assert_index_equal(result, expected, exact="equiv")
             for idx in idxs:
                 for scalar in scalars:
                     result = op(idx, scalar)
                     expected = op(Int64Index(idx), scalar)
-                    tm.assert_index_equal(result, expected)
+                    tm.assert_index_equal(result, expected, exact="equiv")
 
     def test_binops(self):
         ops = [

--- a/pandas/tests/frame/methods/test_sample.py
+++ b/pandas/tests/frame/methods/test_sample.py
@@ -363,5 +363,5 @@ class TestSampleDataFrame:
             {"col1": range(10, 20), "col2": range(20, 30), "colString": ["a"] * 10}
         )
         result = df.sample(3, ignore_index=True)
-        expected_index = Index([0, 1, 2])
-        tm.assert_index_equal(result.index, expected_index)
+        expected_index = Index(range(3))
+        tm.assert_index_equal(result.index, expected_index, exact=True)

--- a/pandas/tests/indexes/ranges/test_constructors.py
+++ b/pandas/tests/indexes/ranges/test_constructors.py
@@ -31,7 +31,7 @@ class TestRangeIndexConstructors:
         assert isinstance(result, RangeIndex)
         assert result.name is name
         assert result._range == range(start, stop, step)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact="equiv")
 
     def test_constructor_invalid_args(self):
         msg = "RangeIndex\\(\\.\\.\\.\\) must be called with integers"
@@ -149,7 +149,9 @@ class TestRangeIndexConstructors:
         index = RangeIndex(1, 5)
         assert index.values.dtype == np.int64
         with tm.assert_produces_warning(FutureWarning, match="will not infer"):
-            tm.assert_index_equal(index, Index(arr).astype("int64"))
+            expected = Index(arr).astype("int64")
+
+        tm.assert_index_equal(index, expected, exact="equiv")
 
         # non-int raise Exception
         with pytest.raises(TypeError, match=r"Wrong type \<class 'str'\>"):

--- a/pandas/tests/indexes/ranges/test_join.py
+++ b/pandas/tests/indexes/ranges/test_join.py
@@ -77,7 +77,7 @@ class TestJoin:
         res, lidx, ridx = index.join(other, how="inner", return_indexers=True)
 
         assert isinstance(res, RangeIndex)
-        tm.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres, exact="equiv")
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -115,7 +115,7 @@ class TestRangeIndex(NumericBase):
         result = idx[1:4]
 
         # test 0th element
-        tm.assert_index_equal(idx[0:4], result.insert(0, idx[0]))
+        tm.assert_index_equal(idx[0:4], result.insert(0, idx[0]), exact="equiv")
 
         # GH 18295 (test missing)
         expected = Float64Index([0, np.nan, 1, 2, 3, 4])
@@ -132,12 +132,13 @@ class TestRangeIndex(NumericBase):
         idx = RangeIndex(5, name="Foo")
         expected = idx[1:].astype(int)
         result = idx.delete(0)
-        tm.assert_index_equal(result, expected)
+        # TODO: could preserve RangeIndex at the ends
+        tm.assert_index_equal(result, expected, exact="equiv")
         assert result.name == expected.name
 
         expected = idx[:-1].astype(int)
         result = idx.delete(-1)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact="equiv")
         assert result.name == expected.name
 
         msg = "index 5 is out of bounds for axis 0 with size 5"
@@ -300,7 +301,7 @@ class TestRangeIndex(NumericBase):
 
         # memory savings vs int index
         idx = RangeIndex(0, 1000)
-        assert idx.nbytes < Int64Index(idx.values).nbytes / 10
+        assert idx.nbytes < Int64Index(idx._values).nbytes / 10
 
         # constant memory usage
         i2 = RangeIndex(0, 10)
@@ -395,38 +396,38 @@ class TestRangeIndex(NumericBase):
         # positive slice values
         index_slice = index[7:10:2]
         expected = Index(np.array([14, 18]), name="foo")
-        tm.assert_index_equal(index_slice, expected)
+        tm.assert_index_equal(index_slice, expected, exact="equiv")
 
         # negative slice values
         index_slice = index[-1:-5:-2]
         expected = Index(np.array([18, 14]), name="foo")
-        tm.assert_index_equal(index_slice, expected)
+        tm.assert_index_equal(index_slice, expected, exact="equiv")
 
         # stop overshoot
         index_slice = index[2:100:4]
         expected = Index(np.array([4, 12]), name="foo")
-        tm.assert_index_equal(index_slice, expected)
+        tm.assert_index_equal(index_slice, expected, exact="equiv")
 
         # reverse
         index_slice = index[::-1]
         expected = Index(index.values[::-1], name="foo")
-        tm.assert_index_equal(index_slice, expected)
+        tm.assert_index_equal(index_slice, expected, exact="equiv")
 
         index_slice = index[-8::-1]
         expected = Index(np.array([4, 2, 0]), name="foo")
-        tm.assert_index_equal(index_slice, expected)
+        tm.assert_index_equal(index_slice, expected, exact="equiv")
 
         index_slice = index[-40::-1]
         expected = Index(np.array([], dtype=np.int64), name="foo")
-        tm.assert_index_equal(index_slice, expected)
+        tm.assert_index_equal(index_slice, expected, exact="equiv")
 
         index_slice = index[40::-1]
         expected = Index(index.values[40::-1], name="foo")
-        tm.assert_index_equal(index_slice, expected)
+        tm.assert_index_equal(index_slice, expected, exact="equiv")
 
         index_slice = index[10::-1]
         expected = Index(index.values[::-1], name="foo")
-        tm.assert_index_equal(index_slice, expected)
+        tm.assert_index_equal(index_slice, expected, exact="equiv")
 
     @pytest.mark.parametrize("step", set(range(-5, 6)) - {0})
     def test_len_specialised(self, step):

--- a/pandas/tests/indexes/ranges/test_setops.py
+++ b/pandas/tests/indexes/ranges/test_setops.py
@@ -75,17 +75,17 @@ class TestRangeIndexSetOps:
         other = RangeIndex(1, 6)
         result = index.intersection(other, sort=sort)
         expected = Index(np.sort(np.intersect1d(index.values, other.values)))
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact="equiv")
 
         # intersect with decreasing RangeIndex
         other = RangeIndex(5, 0, -1)
         result = index.intersection(other, sort=sort)
         expected = Index(np.sort(np.intersect1d(index.values, other.values)))
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact="equiv")
 
         # reversed (GH 17296)
         result = other.intersection(index, sort=sort)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact="equiv")
 
         # GH 17296: intersect two decreasing RangeIndexes
         first = RangeIndex(10, -2, -2)
@@ -288,7 +288,7 @@ class TestRangeIndexSetOps:
         res2 = idx2.union(idx1, sort=None)
         res3 = Int64Index(idx1._values, name=idx1.name).union(idx2, sort=None)
         tm.assert_index_equal(res2, expected_sorted, exact=True)
-        tm.assert_index_equal(res3, expected_sorted)
+        tm.assert_index_equal(res3, expected_sorted, exact="equiv")
 
     def test_difference(self):
         # GH#12034 Cases where we operate against another RangeIndex and may

--- a/pandas/tests/indexes/test_any_index.py
+++ b/pandas/tests/indexes/test_any_index.py
@@ -60,7 +60,7 @@ def test_map_identity_mapping(index):
             expected = index.astype(np.int64)
     else:
         expected = index
-    tm.assert_index_equal(result, expected)
+    tm.assert_index_equal(result, expected, exact="equiv")
 
 
 def test_wrong_number_names(index):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -22,6 +22,7 @@ from pandas import (
     DataFrame,
     DatetimeIndex,
     IntervalIndex,
+    NumericIndex,
     PeriodIndex,
     RangeIndex,
     Series,
@@ -680,8 +681,8 @@ class TestIndex(Base):
 
     def test_map_tseries_indices_accsr_return_index(self):
         date_index = tm.makeDateIndex(24, freq="h", name="hourly")
-        expected = Index(range(24), name="hourly")
-        tm.assert_index_equal(expected, date_index.map(lambda x: x.hour))
+        expected = Int64Index(range(24), name="hourly")
+        tm.assert_index_equal(expected, date_index.map(lambda x: x.hour), exact=True)
 
     @pytest.mark.parametrize(
         "mapper",
@@ -1751,14 +1752,15 @@ def test_validate_1d_input():
         [Float64Index, {}],
         [DatetimeIndex, {}],
         [TimedeltaIndex, {}],
+        [NumericIndex, {}],
         [PeriodIndex, {"freq": "Y"}],
     ],
 )
 def test_construct_from_memoryview(klass, extra_kwargs):
     # GH 13120
     result = klass(memoryview(np.arange(2000, 2005)), **extra_kwargs)
-    expected = klass(range(2000, 2005), **extra_kwargs)
-    tm.assert_index_equal(result, expected)
+    expected = klass(list(range(2000, 2005)), **extra_kwargs)
+    tm.assert_index_equal(result, expected, exact=True)
 
 
 def test_index_set_names_pos_args_deprecation():

--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -15,6 +15,7 @@ from pandas import (
     DatetimeIndex,
     Index,
     MultiIndex,
+    RangeIndex,
     Series,
     TimedeltaIndex,
     Timestamp,
@@ -453,19 +454,20 @@ class TestSetOps:
     "method", ["intersection", "union", "difference", "symmetric_difference"]
 )
 def test_setop_with_categorical(index, sort, method):
-    if isinstance(index, MultiIndex):
+    if isinstance(index, MultiIndex):  # TODO: flat_index?
         # tested separately in tests.indexes.multi.test_setops
         return
 
     other = index.astype("category")
+    exact = "equiv" if isinstance(index, RangeIndex) else True
 
     result = getattr(index, method)(other, sort=sort)
     expected = getattr(index, method)(index, sort=sort)
-    tm.assert_index_equal(result, expected)
+    tm.assert_index_equal(result, expected, exact=exact)
 
     result = getattr(index, method)(other[:5], sort=sort)
     expected = getattr(index, method)(index[:5], sort=sort)
-    tm.assert_index_equal(result, expected)
+    tm.assert_index_equal(result, expected, exact=exact)
 
 
 def test_intersection_duplicates_all_indexes(index):

--- a/pandas/tests/window/test_groupby.py
+++ b/pandas/tests/window/test_groupby.py
@@ -680,6 +680,7 @@ class TestRolling:
         )
         tm.assert_index_equal(result.index, expected_index)
 
+    def test_groupby_rolling_resulting_multiindex2(self):
         # grouping by 2 columns -> 3-level MI as result
         df = DataFrame({"a": np.arange(12.0), "b": [1, 2] * 6, "c": [1, 2, 3, 4] * 3})
         result = df.groupby(["b", "c"]).rolling(2).sum()
@@ -702,6 +703,7 @@ class TestRolling:
         )
         tm.assert_index_equal(result.index, expected_index)
 
+    def test_groupby_rolling_resulting_multiindex3(self):
         # grouping with 1 level on dataframe with 2-level MI -> 3-level MI as result
         df = DataFrame({"a": np.arange(8.0), "b": [1, 2] * 4, "c": [1, 2, 3, 4] * 2})
         df = df.set_index("c", append=True)
@@ -719,7 +721,7 @@ class TestRolling:
             ],
             names=["b", None, "c"],
         )
-        tm.assert_index_equal(result.index, expected_index)
+        tm.assert_index_equal(result.index, expected_index, exact="equiv")
 
     def test_groupby_rolling_object_doesnt_affect_groupby_apply(self):
         # GH 39732


### PR DESCRIPTION
After this we're close to being able to change the default from "equiv" to True (not that we would since that would be an API change)