### PR TITLE
MAINT: Correct small cast issues on Windows

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -543,7 +543,7 @@ def has_infs(floating[:] arr) -> bool:
 def maybe_indices_to_slice(ndarray[intp_t, ndim=1] indices, int max_len):
     cdef:
         Py_ssize_t i, n = len(indices)
-        int k, vstart, vlast, v
+        intp_t k, vstart, vlast, v
 
     if n == 0:
         return slice(0, 0)
@@ -553,7 +553,7 @@ def maybe_indices_to_slice(ndarray[intp_t, ndim=1] indices, int max_len):
         return indices
 
     if n == 1:
-        return slice(vstart, vstart + 1)
+        return slice(vstart, <intp_t>(vstart + 1))
 
     vlast = indices[n - 1]
     if vlast < 0 or max_len <= vlast:
@@ -569,12 +569,12 @@ def maybe_indices_to_slice(ndarray[intp_t, ndim=1] indices, int max_len):
                 return indices
 
         if k > 0:
-            return slice(vstart, vlast + 1, k)
+            return slice(vstart, <intp_t>(vlast + 1), k)
         else:
             if vlast == 0:
                 return slice(vstart, None, k)
             else:
-                return slice(vstart, vlast - 1, k)
+                return slice(vstart, <intp_t>(vlast - 1), k)
 
 
 @cython.wraparound(False)

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -203,7 +203,7 @@ cdef extern from "parser/tokenizer.h":
 
         int usecols
 
-        int expected_fields
+        Py_ssize_t expected_fields
         BadLineHandleMethod on_bad_lines
 
         # floating point options
@@ -398,7 +398,7 @@ cdef class TextReader:
         else:
             if len(delimiter) > 1:
                 raise ValueError('only length-1 separators excluded right now')
-            self.parser.delimiter = ord(delimiter)
+            self.parser.delimiter = <char>ord(delimiter)
 
         # ----------------------------------------
         # parser options
@@ -410,21 +410,21 @@ cdef class TextReader:
         if lineterminator is not None:
             if len(lineterminator) != 1:
                 raise ValueError('Only length-1 line terminators supported')
-            self.parser.lineterminator = ord(lineterminator)
+            self.parser.lineterminator = <char>ord(lineterminator)
 
         if len(decimal) != 1:
             raise ValueError('Only length-1 decimal markers supported')
-        self.parser.decimal = ord(decimal)
+        self.parser.decimal = <char>ord(decimal)
 
         if thousands is not None:
             if len(thousands) != 1:
                 raise ValueError('Only length-1 thousands markers supported')
-            self.parser.thousands = ord(thousands)
+            self.parser.thousands = <char>ord(thousands)
 
         if escapechar is not None:
             if len(escapechar) != 1:
                 raise ValueError('Only length-1 escapes supported')
-            self.parser.escapechar = ord(escapechar)
+            self.parser.escapechar = <char>ord(escapechar)
 
         self._set_quoting(quotechar, quoting)
 
@@ -437,7 +437,7 @@ cdef class TextReader:
         if comment is not None:
             if len(comment) > 1:
                 raise ValueError('Only length-1 comment characters supported')
-            self.parser.commentchar = ord(comment)
+            self.parser.commentchar = <char>ord(comment)
 
         self.parser.on_bad_lines = on_bad_lines
 
@@ -591,7 +591,7 @@ cdef class TextReader:
             raise TypeError('"quotechar" must be a 1-character string')
         else:
             self.parser.quoting = quoting
-            self.parser.quotechar = ord(quote_char)
+            self.parser.quotechar = <char>ord(quote_char)
 
     cdef _make_skiprow_set(self):
         if util.is_integer_object(self.skiprows):
@@ -1045,8 +1045,8 @@ cdef class TextReader:
         return results
 
     # -> tuple["ArrayLike", int]:
-    cdef inline _convert_tokens(self, Py_ssize_t i, int start, int end,
-                                object name, bint na_filter,
+    cdef inline _convert_tokens(self, Py_ssize_t i, int64_t start,
+                                int64_t end, object name, bint na_filter,
                                 kh_str_starts_t *na_hashset,
                                 object na_flist, object col_dtype):
 
@@ -1537,7 +1537,7 @@ cdef inline int _try_double_nogil(parser_t *parser,
                                   float64_t (*double_converter)(
                                       const char *, char **, char,
                                       char, char, int, int *, int *) nogil,
-                                  int col, int line_start, int line_end,
+                                  int64_t col, int64_t line_start, int64_t line_end,
                                   bint na_filter, kh_str_starts_t *na_hashset,
                                   bint use_na_flist,
                                   const kh_float64_t *na_flist,

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -25,7 +25,8 @@ GitHub. See Python Software Foundation License and BSD licenses for these.
 
 #include "../headers/portable.h"
 
-void coliter_setup(coliter_t *self, parser_t *parser, int i, int start) {
+void coliter_setup(coliter_t *self, parser_t *parser, int64_t i,
+                   int64_t start) {
     // column i, starting at 0
     self->words = parser->words;
     self->col = i;
@@ -411,7 +412,7 @@ static void append_warning(parser_t *self, const char *msg) {
 static int end_line(parser_t *self) {
     char *msg;
     int64_t fields;
-    int ex_fields = self->expected_fields;
+    int64_t ex_fields = self->expected_fields;
     int64_t bufsize = 100;  // for error or warning messages
 
     fields = self->line_fields[self->lines];
@@ -459,8 +460,8 @@ static int end_line(parser_t *self) {
         if (self->on_bad_lines == ERROR) {
             self->error_msg = malloc(bufsize);
             snprintf(self->error_msg, bufsize,
-                    "Expected %d fields in line %" PRIu64 ", saw %" PRId64 "\n",
-                    ex_fields, self->file_lines, fields);
+                    "Expected %" PRId64 " fields in line %" PRIu64 ", saw %"
+                    PRId64 "\n", ex_fields, self->file_lines, fields);
 
             TRACE(("Error at line %d, %d fields\n", self->file_lines, fields));
 
@@ -471,8 +472,9 @@ static int end_line(parser_t *self) {
                 // pass up error message
                 msg = malloc(bufsize);
                 snprintf(msg, bufsize,
-                        "Skipping line %" PRIu64 ": expected %d fields, saw %"
-                        PRId64 "\n", self->file_lines, ex_fields, fields);
+                        "Skipping line %" PRIu64 ": expected %" PRId64
+                        " fields, saw %" PRId64 "\n",
+                        self->file_lines, ex_fields, fields);
                 append_warning(self, msg);
                 free(msg);
             }

--- a/pandas/_libs/src/parser/tokenizer.h
+++ b/pandas/_libs/src/parser/tokenizer.h
@@ -141,7 +141,7 @@ typedef struct parser_t {
 
     int usecols;  // Boolean: 1: usecols provided, 0: none provided
 
-    int expected_fields;
+    Py_ssize_t expected_fields;
     BadLineHandleMethod on_bad_lines;
 
     // floating point options
@@ -175,7 +175,7 @@ typedef struct coliter_t {
     int64_t col;
 } coliter_t;
 
-void coliter_setup(coliter_t *self, parser_t *parser, int i, int start);
+void coliter_setup(coliter_t *self, parser_t *parser, int64_t i, int64_t start);
 
 #define COLITER_NEXT(iter, word)                           \
     do {                                                   \

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -422,7 +422,8 @@ cdef inline object _parse_dateabbr_string(object date_string, datetime default,
     cdef:
         object ret
         # year initialized to prevent compiler warnings
-        int year = -1, quarter = -1, month, mnum, date_len
+        int year = -1, quarter = -1, month, mnum
+        Py_ssize_t date_len
 
     # special handling for possibilities eg, 2Q2005, 2Q05, 2005Q1, 05Q1
     assert isinstance(date_string, str)


### PR DESCRIPTION
Use correct types to avoid downcasts on Windows

- [X] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
