### PR TITLE
TST: More type checking during .(i)loc

### DIFF
--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -54,7 +54,7 @@ class TestiLoc(Base):
 
 class TestiLocBaseIndependent:
     """Tests Independent Of Base Class"""
-    
+
     @pytest.mark.parametrize(
         "key",
         [
@@ -103,7 +103,6 @@ class TestiLocBaseIndependent:
 
         def check(frame, expected):
             df = frame.copy()
-            orig_vals = df.values
             indexer(df)[key, 0] = cat
             tm.assert_frame_equal(df, expected)
 
@@ -115,8 +114,8 @@ class TestiLocBaseIndependent:
         # Without a mixed dataframe, a the internal block is overwritten
         frame = DataFrame({0: np.array([0, 1, 2], dtype=object)})
         expected = DataFrame({0: cat})
-        check(frame, expected) 
-            
+        check(frame, expected)
+
     # TODO(ArrayManager) does not yet update parent
     @td.skip_array_manager_not_yet_implemented
     @pytest.mark.parametrize("box", [array, Series])

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -54,7 +54,7 @@ class TestiLoc(Base):
 
 class TestiLocBaseIndependent:
     """Tests Independent Of Base Class"""
-
+    
     @pytest.mark.parametrize(
         "key",
         [
@@ -101,14 +101,22 @@ class TestiLocBaseIndependent:
         else:
             assert cat[0] != "gamma"
 
+        def check(frame, expected):
+            df = frame.copy()
+            orig_vals = df.values
+            indexer(df)[key, 0] = cat
+            tm.assert_frame_equal(df, expected)
+
         # TODO with mixed dataframe ("split" path), we always overwrite the column
         frame = DataFrame({0: np.array([0, 1, 2], dtype=object), 1: range(3)})
-        df = frame.copy()
-        orig_vals = df.values
-        indexer(df)[key, 0] = cat
         expected = DataFrame({0: cat, 1: range(3)})
-        tm.assert_frame_equal(df, expected)
+        check(frame, expected)
 
+        # Without a mixed dataframe, a the internal block is overwritten
+        frame = DataFrame({0: np.array([0, 1, 2], dtype=object)})
+        expected = DataFrame({0: cat})
+        check(frame, expected) 
+            
     # TODO(ArrayManager) does not yet update parent
     @td.skip_array_manager_not_yet_implemented
     @pytest.mark.parametrize("box", [array, Series])


### PR DESCRIPTION
- [X] Related to #43996
- [X] tests added to `pandas/tests/indexing/test_iloc.py`
- [X] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [X] During assignment to a .iloc or a .loc indexer, depending on whether the data frame is with mixed types or singular, the typing of the resulting assignment is not consistent.

As explained in issue #43996, the update of v1.3.0 causes a change in dtype casting when assigning a series. The issue contains a minimal working example of this rather inconsistent behaviour. In short, the type of a column changes when the assignment happens on a data frame only containing one column. With multiple columns, assigning the same series retains the original type. 

This contribution includes a test case which performs an assignment operation on a single column data frame. Naturally, because of this inconsistency of typing in the current pandas code, this test case fails. Its aim is to serve the bug fix for this inconsistency.