### PR TITLE
DOC: Upload cheatsheets to site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,9 +148,7 @@ jobs:
       run: mv doc/build/html web/build/docs
 
     - name: Copy cheatsheets into site directory
-      run: |
-        mkdir -p web/build/docs/cheatsheets
-        cp doc/cheatsheet/Pandas_Cheat_Sheet* web/build/docs/cheatsheets
+      run: cp doc/cheatsheet/Pandas_Cheat_Sheet* web/build/
 
     - name: Save website as an artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
       if: ${{github.event_name == 'push' && github.ref == 'refs/heads/master'}}
 
     - name: Upload web
-      run: rsync -az --delete --exclude='pandas-docs' --exclude='docs' --exclude='Pandas_Cheat_Sheet*' web/build/ docs@${{ secrets.server_ip }}:/usr/share/nginx/pandas
+      run: rsync -az --delete --exclude='pandas-docs' --exclude='docs' web/build/ docs@${{ secrets.server_ip }}:/usr/share/nginx/pandas
       if: ${{github.event_name == 'push' && github.ref == 'refs/heads/master'}}
 
     - name: Upload dev docs
@@ -146,6 +146,10 @@ jobs:
 
     - name: Move docs into site directory
       run: mv doc/build/html web/build/docs
+
+    - name: Copy cheatsheets into site directory
+      run: cp doc/cheatsheet/Pandas_Cheat_Sheet* web/build/docs/cheatsheet
+
     - name: Save website as an artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,9 @@ jobs:
       run: mv doc/build/html web/build/docs
 
     - name: Copy cheatsheets into site directory
-      run: cp doc/cheatsheet/Pandas_Cheat_Sheet* web/build/docs/cheatsheet
+      run: |
+        mkdir -p web/build/docs/cheatsheets
+        cp doc/cheatsheet/Pandas_Cheat_Sheet* web/build/docs/cheatsheets
 
     - name: Save website as an artifact
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
- [x] closes #40949
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry


I went ahead and modified the `.github/workflows/ci.yml` so that the cheatsheets are copied to the docs build directory once the Sphinx site is built