### PR TITLE
DOC: DatetimeArray.std

### DIFF
--- a/doc/source/reference/indexing.rst
+++ b/doc/source/reference/indexing.rst
@@ -407,6 +407,7 @@ Methods
     :toctree: api/
 
     DatetimeIndex.mean
+    DatetimeIndex.std
 
 TimedeltaIndex
 --------------

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1930,7 +1930,7 @@ default 'raise'
 
         Parameters
         ----------
-        axis : optional, default None
+        axis : int optional, default None
             Axis for the function to be applied on.
         ddof : int, default 1
             Degrees of Freedom. The divisor used in calculations is N - ddof,

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1923,6 +1923,26 @@ default 'raise'
         keepdims: bool = False,
         skipna: bool = True,
     ):
+        """
+        Return sample standard deviation over requested axis.
+
+        Normalized by N-1 by default. This can be changed using the ddof argument
+
+        Parameters
+        ----------
+        axis : optional, default None
+            Axis for the function to be applied on.
+        ddof : int, default 1
+            Degrees of Freedom. The divisor used in calculations is N - ddof,
+            where N represents the number of elements.
+        skipna : bool, default True
+            Exclude NA/null values. If an entire row/column is NA, the result will be
+            NA.
+
+        Returns
+        -------
+        Timedelta
+        """
         # Because std is translation-invariant, we can get self.std
         #  by calculating (self - Timestamp(0)).std, and we can do it
         #  without creating a copy by using a view on self._ndarray


### PR DESCRIPTION
`DatetimeIndex.std` is missing a doc-string. Add doc-string to `DatetimeArray.std` as `DatetimeIndex` is re-using `DatetimeArray.std`.


There are a few more keywords, but they seem to be not implemented (numpy-compatiblity?)

```py
pd.DatetimeIndex([1, 2]).std(out=[])
ValueError: the 'out' parameter is not supported in the pandas implementation of std()

pd.DatetimeIndex([1, 2]).std(keepdims=True)
ValueError: the 'keepdims' parameter is not supported in the pandas implementation of std()

pd.DatetimeIndex([1, 2]).std(dtype=np.dtype("datetime64[ns]"))
ValueError: the 'dtype' parameter is not supported in the pandas implementation of std()
```

For some reason, this doc-string is needed for #43828.