### PR TITLE
ENH: Ability to coerce floats when reading csv files GH2570

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -129,6 +129,7 @@ Other enhancements
 - :meth:`DataFrame.__pos__`, :meth:`DataFrame.__neg__` now retain ``ExtensionDtype`` dtypes (:issue:`43883`)
 - The error raised when an optional dependency can't be imported now includes the original exception, for easier investigation (:issue:`43882`)
 - Added :meth:`.ExponentialMovingWindow.sum` (:issue:`13297`)
+- :meth:`read_csv` ``dtype`` argument now supports automatic coercion of floats (:issue:`2570`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1792,3 +1792,30 @@ def pandas_dtype(dtype) -> DtypeObj:
         raise TypeError(f"dtype '{dtype}' not understood")
 
     return npdtype
+
+
+def coerce_dtype(dtype):
+    """
+    Determine whether this dtype should be coerced.
+
+    Parameters
+    ----------
+    dtype : object or tuple to be checked
+
+    Returns
+    -------
+    dtype : np.dtype or a pandas dtype
+    coerce : bool
+        Should the dtype be coerced
+
+    Raises
+    ------
+    ValueError if coercion for the dtype is not supported
+    """
+    if isinstance(dtype, tuple):
+        dtype, coerce = dtype
+        if not is_float_dtype(dtype) or coerce != "coerce":
+            raise ValueError('Only "coerce" is supported when dtype is a float type')
+        return dtype, True
+    else:
+        return dtype, False

--- a/pandas/io/parsers/c_parser_wrapper.py
+++ b/pandas/io/parsers/c_parser_wrapper.py
@@ -403,7 +403,12 @@ def ensure_dtype_objs(dtype):
     dtype objects.
     """
     if isinstance(dtype, dict):
-        dtype = {k: pandas_dtype(dtype[k]) for k in dtype}
+        dtype = {
+            col: (pandas_dtype(col_dtype[0]), col_dtype[1])
+            if isinstance(col_dtype, tuple)
+            else pandas_dtype(col_dtype)
+            for col, col_dtype in dtype.items()
+        }
     elif dtype is not None:
         dtype = pandas_dtype(dtype)
     return dtype

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -142,9 +142,10 @@ mangle_dupe_cols : bool, default True
     Duplicate columns will be specified as 'X', 'X.1', ...'X.N', rather than
     'X'...'X'. Passing in False will cause data to be overwritten if there
     are duplicate names in the columns.
-dtype : Type name or dict of column -> type, optional
+dtype : Type name or dict of column -> type or column -> (type, 'coerce'), optional
     Data type for data or columns. E.g. {{'a': np.float64, 'b': np.int32,
-    'c': 'Int64'}}
+    'c': 'Int64'}}. Specify {{'a': (np.float64, 'coerce')}} to coerce values to NA that
+    cannot convert to float.
     Use `str` or `object` together with suitable `na_values` settings
     to preserve and not interpret dtype.
     If converters are specified, they will be applied INSTEAD

--- a/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
+++ b/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
@@ -314,3 +314,45 @@ def test_dtype_multi_index(all_parsers):
     )
 
     tm.assert_frame_equal(result, expected)
+
+
+def test_dtype_coerce(all_parsers):
+    parser = all_parsers
+    data = """a,b\n1,2\na,3"""
+    result = parser.read_csv(
+        StringIO(data), dtype={"a": (float, "coerce"), "b": np.int64}
+    )
+    expected = DataFrame({"a": [1.0, np.nan], "b": [2, 3]})
+    tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "dtype", [{"a": (float, "coerce"), "b": (int, "coerce")}, {"a": (float, "fail")}]
+)
+def test_dtype_coerce_invalid_args_raises(all_parsers, dtype):
+    parser = all_parsers
+    data = """a,b\n1,2\na,3"""
+    with pytest.raises(
+        ValueError, match='Only "coerce" is supported when dtype is a float type'
+    ):
+        parser.read_csv(StringIO(data), dtype=dtype)
+
+
+@pytest.mark.parametrize(
+    "na_values,expected",
+    [
+        ({8200.0}, DataFrame({"a": [np.nan, np.nan], "b": [2, 3]})),
+        ({"B"}, DataFrame({"a": [8200.0, np.nan], "b": [2, 3]})),
+    ],
+)
+def test_dtype_coerce_with_nas(all_parsers, na_values, expected):
+    parser = all_parsers
+    data = """a|b\n8,200.0|2\nB|3"""
+    result = parser.read_csv(
+        StringIO(data),
+        dtype={"a": (float, "coerce")},
+        sep="|",
+        thousands=",",
+        na_values=na_values,
+    )
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/parser/dtypes/test_empty.py
+++ b/pandas/tests/io/parser/dtypes/test_empty.py
@@ -180,3 +180,11 @@ def test_empty_dtype(all_parsers, dtype, expected):
 
     result = parser.read_csv(StringIO(data), header=0, dtype=dtype)
     tm.assert_frame_equal(result, expected)
+
+
+def test_dtype_coerce_empty(all_parsers):
+    parser = all_parsers
+    data = "a,b"
+    result = parser.read_csv(StringIO(data), dtype={"a": (float, "coerce"), "b": float})
+    expected = DataFrame([], columns=["a", "b"], dtype=float)
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #2570
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

Ran the `io.csv.Read*` benchmarks which resulted in `BENCHMARKS NOT SIGNIFICANTLY CHANGED.`

I believe that `Dict[Hashable, Tuple[Dtype, str]]` should be added to `DtypeArg` to fix the failing typing check. However, that results in 20 additional errors in io\sql.py and io\parsers\base_parser.py with the additional tuple type. Perhaps there should be a distinction and an additional `CSVDtypeArg`. Looking for advice on how best to approach fixing this.