### PR TITLE
Temporarily add back Index._get_attributes_dict for dask compat

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -739,6 +739,12 @@ class Index(IndexOpsMixin, PandasObject):
         Temporarily added back for compatibility issue in dask, see
         https://github.com/pandas-dev/pandas/pull/43895
         """
+        warnings.warn(
+            "The Index._get_attributes_dict method is deprecated, and will be "
+            "removed in a future version",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return {k: getattr(self, k, None) for k in self._attributes}
 
     def _shallow_copy(self: _IndexT, values, name: Hashable = no_default) -> _IndexT:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -731,6 +731,16 @@ class Index(IndexOpsMixin, PandasObject):
     # --------------------------------------------------------------------
     # Index Internals Methods
 
+    @final
+    def _get_attributes_dict(self) -> dict[str_t, Any]:
+        """
+        Return an attributes dict for my class.
+
+        Temporarily added back for compatibility issue in dask, see
+        https://github.com/pandas-dev/pandas/pull/43895
+        """
+        return {k: getattr(self, k, None) for k in self._attributes}
+
     def _shallow_copy(self: _IndexT, values, name: Hashable = no_default) -> _IndexT:
         """
         Create a new Index with the same class as the caller, don't copy the

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1788,3 +1788,11 @@ def test_drop_duplicates_pos_args_deprecation():
         result = idx.drop_duplicates("last")
     expected = Index([2, 3, 1])
     tm.assert_index_equal(expected, result)
+
+
+def test_get_attributes_dict_deprecated():
+    # https://github.com/pandas-dev/pandas/pull/44028
+    idx = Index([1, 2, 3, 1])
+    with tm.assert_produces_warning(DeprecationWarning):
+        attrs = idx._get_attributes_dict()
+    assert attrs == {"name": None}


### PR DESCRIPTION
See https://github.com/pandas-dev/pandas/pull/43895#issuecomment-938472299. There was of course no need to revert the full PR, just to add this method again. 