### PR TITLE
REGR: Barplot broken on Index(dtype='object')

### DIFF
--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -466,7 +466,7 @@ class TestDataFramePlots(TestPlotBase):
 
         try:
             plot_bar = df.plot.bar()
-            assert all([a.__eq__(b) for a, b in zip(plot_bar.get_xticklabels(), expected)])
+            assert all([(a.get_text() == b.get_text()) for a, b in zip(plot_bar.get_xticklabels(), expected)])
         except TypeError as e:
             assert False
 

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -2,12 +2,13 @@
 
 import numpy as np
 import pytest
+from matplotlib.text import Text
 
 import pandas.util._test_decorators as td
 
 from pandas import (
     DataFrame,
-    Series,
+    Series, Index,
 )
 import pandas._testing as tm
 from pandas.tests.plotting.common import (
@@ -449,6 +450,25 @@ class TestDataFramePlots(TestPlotBase):
         ax = df1.plot(kind="line", color=dic_color)
         colors = [rect.get_color() for rect in ax.get_lines()[0:2]]
         assert all(color == expected[index] for index, color in enumerate(colors))
+
+    def test_bar_plot(self):
+        # issue-38947
+        # Test bar plot with string index
+
+        expected = [Text(0, 0, '0'), Text(1, 0, 'Total')]
+
+        df = DataFrame(
+            {
+                'a': [1, 2],
+            },
+            index=Index([0, 'Total'])
+        )
+
+        try:
+            plot_bar = df.plot.bar()
+            assert all([a.__eq__(b) for a, b in zip(plot_bar.get_xticklabels(), expected)])
+        except TypeError as e:
+            assert False
 
     def test_has_externally_shared_axis_x_axis(self):
         # GH33819

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -466,7 +466,8 @@ class TestDataFramePlots(TestPlotBase):
 
         try:
             plot_bar = df.plot.bar()
-            assert all([(a.get_text() == b.get_text()) for a, b in zip(plot_bar.get_xticklabels(), expected)])
+            assert all([(a.get_text() == b.get_text())
+                        for a, b in zip(plot_bar.get_xticklabels(), expected)])
         except TypeError as e:
             assert False
 


### PR DESCRIPTION
- [ ] closes #38947
- [x] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
