### PR TITLE
DOC: Fix Docstring for DataFrame nlargest `keep` option (#44040)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6584,8 +6584,8 @@ class DataFrame(NDFrame, OpsMixin):
         keep : {'first', 'last', 'all'}, default 'first'
             Where there are duplicate values:
 
-            - `first` : prioritize the first occurrence(s)
-            - `last` : prioritize the last occurrence(s)
+            - ``first`` : prioritize the first occurrence(s)
+            - ``last`` : prioritize the last occurrence(s)
             - ``all`` : do not drop any duplicates, even it means
               selecting more than `n` items.
 


### PR DESCRIPTION
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] Add double backticks for DataFrame nlargest `keep` option to keep the style consistent

From
https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.nlargest.html
![image](https://user-images.githubusercontent.com/25895405/137416950-97b0db11-382f-410f-ac90-50ef2b25c32b.png)
To
![image](https://user-images.githubusercontent.com/25895405/137420535-275670da-094c-4533-9eac-82a36f52d5f4.png)

