### PR TITLE
Removed a manual file handler pitfall

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -1168,12 +1168,11 @@ def do_vcs_install(manifest_in, versionfile_source, ipy):
     files.append(versioneer_file)
     present = False
     try:
-        f = open(".gitattributes")
-        for line in f.readlines():
-            if line.strip().startswith(versionfile_source):
-                if "export-subst" in line.strip().split()[1:]:
-                    present = True
-        f.close()
+        with open(".gitattributes") as f:
+            for line in f.readlines():
+                if line.strip().startswith(versionfile_source):
+                    if "export-subst" in line.strip().split()[1:]:
+                        present = True
     except OSError:
         pass
     if not present:


### PR DESCRIPTION
It is a simple PR. 

It only removes a manual file handler pitfall from versioneer.py

As stated by [Pylint documentation](https://pylint.pycqa.org/en/latest/technical_reference/features.html)

"
consider-using-with (R1732)
Consider using 'with' for resource-allocating operations Emitted if a resource-allocating assignment or call may be replaced by a 'with' block. By using 'with' the release of the allocated resources is ensured even in the case of an exception.
"