### PR TITLE
BUG: 43909 - check monoticity of rolling groupby

### DIFF
--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -662,13 +662,7 @@ class BaseWindowGroupby(BaseWindow):
         numba_args: tuple[Any, ...] = (),
         **kwargs,
     ) -> DataFrame | Series:
-        result = super()._apply(
-            func,
-            name,
-            numba_cache_key,
-            numba_args,
-            **kwargs,
-        )
+        result = super()._apply(func, name, numba_cache_key, numba_args, **kwargs,)
         # Reconstruct the resulting MultiIndex
         # 1st set of levels = group by labels
         # 2nd set of levels = original DataFrame/Series index
@@ -1263,9 +1257,7 @@ class RollingAndExpandingMixin(BaseWindow):
             raise ValueError("engine must be either 'numba' or 'cython'")
 
         return self._apply(
-            apply_func,
-            numba_cache_key=numba_cache_key,
-            numba_args=numba_args,
+            apply_func, numba_cache_key=numba_cache_key, numba_args=numba_args,
         )
 
     def _generate_cython_apply_func(
@@ -1307,10 +1299,7 @@ class RollingAndExpandingMixin(BaseWindow):
                 func = np.nansum
 
             return self.apply(
-                func,
-                raw=True,
-                engine=engine,
-                engine_kwargs=engine_kwargs,
+                func, raw=True, engine=engine, engine_kwargs=engine_kwargs,
             )
         window_func = window_aggregations.roll_sum
         return self._apply(window_func, name="sum", **kwargs)
@@ -1330,10 +1319,7 @@ class RollingAndExpandingMixin(BaseWindow):
                 func = np.nanmax
 
             return self.apply(
-                func,
-                raw=True,
-                engine=engine,
-                engine_kwargs=engine_kwargs,
+                func, raw=True, engine=engine, engine_kwargs=engine_kwargs,
             )
         window_func = window_aggregations.roll_max
         return self._apply(window_func, name="max", **kwargs)
@@ -1353,10 +1339,7 @@ class RollingAndExpandingMixin(BaseWindow):
                 func = np.nanmin
 
             return self.apply(
-                func,
-                raw=True,
-                engine=engine,
-                engine_kwargs=engine_kwargs,
+                func, raw=True, engine=engine, engine_kwargs=engine_kwargs,
             )
         window_func = window_aggregations.roll_min
         return self._apply(window_func, name="min", **kwargs)
@@ -1373,10 +1356,7 @@ class RollingAndExpandingMixin(BaseWindow):
             if self.method == "table":
                 func = generate_manual_numpy_nan_agg_with_axis(np.nanmean)
                 return self.apply(
-                    func,
-                    raw=True,
-                    engine=engine,
-                    engine_kwargs=engine_kwargs,
+                    func, raw=True, engine=engine, engine_kwargs=engine_kwargs,
                 )
             else:
                 from pandas.core._numba.kernels import sliding_mean
@@ -1398,10 +1378,7 @@ class RollingAndExpandingMixin(BaseWindow):
                 func = np.nanmedian
 
             return self.apply(
-                func,
-                raw=True,
-                engine=engine,
-                engine_kwargs=engine_kwargs,
+                func, raw=True, engine=engine, engine_kwargs=engine_kwargs,
             )
         window_func = window_aggregations.roll_median_c
         return self._apply(window_func, name="median", **kwargs)
@@ -1413,39 +1390,23 @@ class RollingAndExpandingMixin(BaseWindow):
         def zsqrt_func(values, begin, end, min_periods):
             return zsqrt(window_func(values, begin, end, min_periods, ddof=ddof))
 
-        return self._apply(
-            zsqrt_func,
-            name="std",
-            **kwargs,
-        )
+        return self._apply(zsqrt_func, name="std", **kwargs,)
 
     def var(self, ddof: int = 1, *args, **kwargs):
         nv.validate_window_func("var", args, kwargs)
         window_func = partial(window_aggregations.roll_var, ddof=ddof)
-        return self._apply(
-            window_func,
-            name="var",
-            **kwargs,
-        )
+        return self._apply(window_func, name="var", **kwargs,)
 
     def skew(self, **kwargs):
         window_func = window_aggregations.roll_skew
-        return self._apply(
-            window_func,
-            name="skew",
-            **kwargs,
-        )
+        return self._apply(window_func, name="skew", **kwargs,)
 
     def sem(self, ddof: int = 1, *args, **kwargs):
         return self.std(*args, **kwargs) / (self.count() - ddof).pow(0.5)
 
     def kurt(self, **kwargs):
         window_func = window_aggregations.roll_kurt
-        return self._apply(
-            window_func,
-            name="kurt",
-            **kwargs,
-        )
+        return self._apply(window_func, name="kurt", **kwargs,)
 
     def quantile(self, quantile: float, interpolation: str = "linear", **kwargs):
         if quantile == 1.0:
@@ -2223,9 +2184,7 @@ class Rolling(RollingAndExpandingMixin):
     )
     def quantile(self, quantile: float, interpolation: str = "linear", **kwargs):
         return super().quantile(
-            quantile=quantile,
-            interpolation=interpolation,
-            **kwargs,
+            quantile=quantile, interpolation=interpolation, **kwargs,
         )
 
     @doc(
@@ -2296,12 +2255,7 @@ class Rolling(RollingAndExpandingMixin):
         pct: bool = False,
         **kwargs,
     ):
-        return super().rank(
-            method=method,
-            ascending=ascending,
-            pct=pct,
-            **kwargs,
-        )
+        return super().rank(method=method, ascending=ascending, pct=pct, **kwargs,)
 
     @doc(
         template_header,
@@ -2513,8 +2467,9 @@ class RollingGroupby(BaseWindowGroupby, Rolling):
     def _validate_monotonic(self):
         """
         Validate that on is monotonic;
-        in this case we have to check only for nans, because
-        monotonicity was already validated at a higher level.
         """
-        if self._on.hasnans:
+        if (
+            not (self._on.is_monotonic_increasing or self._on.is_monotonic_decreasing)
+            or self._on.hasnans
+        ):
             self._raise_monotonic_error()

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -662,7 +662,13 @@ class BaseWindowGroupby(BaseWindow):
         numba_args: tuple[Any, ...] = (),
         **kwargs,
     ) -> DataFrame | Series:
-        result = super()._apply(func, name, numba_cache_key, numba_args, **kwargs,)
+        result = super()._apply(
+            func,
+            name,
+            numba_cache_key,
+            numba_args,
+            **kwargs,
+        )
         # Reconstruct the resulting MultiIndex
         # 1st set of levels = group by labels
         # 2nd set of levels = original DataFrame/Series index
@@ -1257,7 +1263,9 @@ class RollingAndExpandingMixin(BaseWindow):
             raise ValueError("engine must be either 'numba' or 'cython'")
 
         return self._apply(
-            apply_func, numba_cache_key=numba_cache_key, numba_args=numba_args,
+            apply_func,
+            numba_cache_key=numba_cache_key,
+            numba_args=numba_args,
         )
 
     def _generate_cython_apply_func(
@@ -1299,7 +1307,10 @@ class RollingAndExpandingMixin(BaseWindow):
                 func = np.nansum
 
             return self.apply(
-                func, raw=True, engine=engine, engine_kwargs=engine_kwargs,
+                func,
+                raw=True,
+                engine=engine,
+                engine_kwargs=engine_kwargs,
             )
         window_func = window_aggregations.roll_sum
         return self._apply(window_func, name="sum", **kwargs)
@@ -1319,7 +1330,10 @@ class RollingAndExpandingMixin(BaseWindow):
                 func = np.nanmax
 
             return self.apply(
-                func, raw=True, engine=engine, engine_kwargs=engine_kwargs,
+                func,
+                raw=True,
+                engine=engine,
+                engine_kwargs=engine_kwargs,
             )
         window_func = window_aggregations.roll_max
         return self._apply(window_func, name="max", **kwargs)
@@ -1339,7 +1353,10 @@ class RollingAndExpandingMixin(BaseWindow):
                 func = np.nanmin
 
             return self.apply(
-                func, raw=True, engine=engine, engine_kwargs=engine_kwargs,
+                func,
+                raw=True,
+                engine=engine,
+                engine_kwargs=engine_kwargs,
             )
         window_func = window_aggregations.roll_min
         return self._apply(window_func, name="min", **kwargs)
@@ -1356,7 +1373,10 @@ class RollingAndExpandingMixin(BaseWindow):
             if self.method == "table":
                 func = generate_manual_numpy_nan_agg_with_axis(np.nanmean)
                 return self.apply(
-                    func, raw=True, engine=engine, engine_kwargs=engine_kwargs,
+                    func,
+                    raw=True,
+                    engine=engine,
+                    engine_kwargs=engine_kwargs,
                 )
             else:
                 from pandas.core._numba.kernels import sliding_mean
@@ -1378,7 +1398,10 @@ class RollingAndExpandingMixin(BaseWindow):
                 func = np.nanmedian
 
             return self.apply(
-                func, raw=True, engine=engine, engine_kwargs=engine_kwargs,
+                func,
+                raw=True,
+                engine=engine,
+                engine_kwargs=engine_kwargs,
             )
         window_func = window_aggregations.roll_median_c
         return self._apply(window_func, name="median", **kwargs)
@@ -1390,23 +1413,39 @@ class RollingAndExpandingMixin(BaseWindow):
         def zsqrt_func(values, begin, end, min_periods):
             return zsqrt(window_func(values, begin, end, min_periods, ddof=ddof))
 
-        return self._apply(zsqrt_func, name="std", **kwargs,)
+        return self._apply(
+            zsqrt_func,
+            name="std",
+            **kwargs,
+        )
 
     def var(self, ddof: int = 1, *args, **kwargs):
         nv.validate_window_func("var", args, kwargs)
         window_func = partial(window_aggregations.roll_var, ddof=ddof)
-        return self._apply(window_func, name="var", **kwargs,)
+        return self._apply(
+            window_func,
+            name="var",
+            **kwargs,
+        )
 
     def skew(self, **kwargs):
         window_func = window_aggregations.roll_skew
-        return self._apply(window_func, name="skew", **kwargs,)
+        return self._apply(
+            window_func,
+            name="skew",
+            **kwargs,
+        )
 
     def sem(self, ddof: int = 1, *args, **kwargs):
         return self.std(*args, **kwargs) / (self.count() - ddof).pow(0.5)
 
     def kurt(self, **kwargs):
         window_func = window_aggregations.roll_kurt
-        return self._apply(window_func, name="kurt", **kwargs,)
+        return self._apply(
+            window_func,
+            name="kurt",
+            **kwargs,
+        )
 
     def quantile(self, quantile: float, interpolation: str = "linear", **kwargs):
         if quantile == 1.0:
@@ -2184,7 +2223,9 @@ class Rolling(RollingAndExpandingMixin):
     )
     def quantile(self, quantile: float, interpolation: str = "linear", **kwargs):
         return super().quantile(
-            quantile=quantile, interpolation=interpolation, **kwargs,
+            quantile=quantile,
+            interpolation=interpolation,
+            **kwargs,
         )
 
     @doc(
@@ -2255,7 +2296,12 @@ class Rolling(RollingAndExpandingMixin):
         pct: bool = False,
         **kwargs,
     ):
-        return super().rank(method=method, ascending=ascending, pct=pct, **kwargs,)
+        return super().rank(
+            method=method,
+            ascending=ascending,
+            pct=pct,
+            **kwargs,
+        )
 
     @doc(
         template_header,

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -84,13 +84,15 @@ def test_constructor_with_timedelta_window(window):
     # GH 15440
     n = 10
     df = DataFrame(
-        {"value": np.arange(n)}, index=date_range("2015-12-24", periods=n, freq="D"),
+        {"value": np.arange(n)},
+        index=date_range("2015-12-24", periods=n, freq="D"),
     )
     expected_data = np.append([0.0, 1.0], np.arange(3.0, 27.0, 3))
 
     result = df.rolling(window=window).sum()
     expected = DataFrame(
-        {"value": expected_data}, index=date_range("2015-12-24", periods=n, freq="D"),
+        {"value": expected_data},
+        index=date_range("2015-12-24", periods=n, freq="D"),
     )
     tm.assert_frame_equal(result, expected)
     expected = df.rolling("3D").sum()
@@ -102,7 +104,8 @@ def test_constructor_timedelta_window_and_minperiods(window, raw):
     # GH 15305
     n = 10
     df = DataFrame(
-        {"value": np.arange(n)}, index=date_range("2017-08-08", periods=n, freq="D"),
+        {"value": np.arange(n)},
+        index=date_range("2017-08-08", periods=n, freq="D"),
     )
     expected = DataFrame(
         {"value": np.append([np.NaN, 1.0], np.arange(3.0, 27.0, 3))},
@@ -133,9 +136,13 @@ def test_closed_fixed(closed, arithmetic_win_operators):
     df_fixed = DataFrame({"A": [0, 1, 2, 3, 4]})
     df_time = DataFrame({"A": [0, 1, 2, 3, 4]}, index=date_range("2020", periods=5))
 
-    result = getattr(df_fixed.rolling(2, closed=closed, min_periods=1), func_name,)()
+    result = getattr(
+        df_fixed.rolling(2, closed=closed, min_periods=1),
+        func_name,
+    )()
     expected = getattr(
-        df_time.rolling("2D", closed=closed, min_periods=1), func_name,
+        df_time.rolling("2D", closed=closed, min_periods=1),
+        func_name,
     )().reset_index(drop=True)
 
     tm.assert_frame_equal(result, expected)
@@ -206,7 +213,8 @@ def test_datetimelike_centered_selections(
         kwargs = {}
 
     result = getattr(
-        df_time.rolling("2D", closed=closed, min_periods=1, center=True), func_name,
+        df_time.rolling("2D", closed=closed, min_periods=1, center=True),
+        func_name,
     )(**kwargs)
 
     tm.assert_frame_equal(result, expected, check_dtype=False)
@@ -337,7 +345,8 @@ def test_closed_one_entry(func):
 def test_closed_one_entry_groupby(func):
     # GH24718
     ser = DataFrame(
-        data={"A": [1, 1, 2], "B": [3, 2, 1]}, index=date_range("2000", periods=3),
+        data={"A": [1, 1, 2], "B": [3, 2, 1]},
+        index=date_range("2000", periods=3),
     )
     result = getattr(
         ser.groupby("A", sort=False)["B"].rolling("10D", closed="left"), func
@@ -364,7 +373,8 @@ def test_closed_one_entry_groupby(func):
 def test_closed_min_max_datetime(input_dtype, func, closed, expected):
     # see gh-21704
     ser = Series(
-        data=np.arange(10).astype(input_dtype), index=date_range("2000", periods=10),
+        data=np.arange(10).astype(input_dtype),
+        index=date_range("2000", periods=10),
     )
 
     result = getattr(ser.rolling("3D", closed=closed), func)()
@@ -839,8 +849,18 @@ def test_iter_rolling_on_dataframe_unordered():
             3,
             1,
         ),
-        (Series([1, 2, 3]), [([1], [0]), ([1, 2], [0, 1]), ([2, 3], [1, 2])], 2, 1,),
-        (Series([1, 2, 3]), [([1], [0]), ([1, 2], [0, 1]), ([2, 3], [1, 2])], 2, 2,),
+        (
+            Series([1, 2, 3]),
+            [([1], [0]), ([1, 2], [0, 1]), ([2, 3], [1, 2])],
+            2,
+            1,
+        ),
+        (
+            Series([1, 2, 3]),
+            [([1], [0]), ([1, 2], [0, 1]), ([2, 3], [1, 2])],
+            2,
+            2,
+        ),
         (Series([1, 2, 3]), [([1], [0]), ([2], [1]), ([3], [2])], 1, 0),
         (Series([1, 2, 3]), [([1], [0]), ([2], [1]), ([3], [2])], 1, 1),
         (Series([1, 2]), [([1], [0]), ([1, 2], [0, 1])], 2, 0),
@@ -1012,7 +1032,18 @@ def test_rolling_numerical_too_large_numbers():
     ds[2] = -9e33
     result = ds.rolling(5).mean()
     expected = Series(
-        [np.nan, np.nan, np.nan, np.nan, -1.8e33, -1.8e33, -1.8e33, 5.0, 6.0, 7.0,],
+        [
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            -1.8e33,
+            -1.8e33,
+            -1.8e33,
+            5.0,
+            6.0,
+            7.0,
+        ],
         index=dates,
     )
     tm.assert_series_equal(result, expected)
@@ -1028,7 +1059,8 @@ def test_rolling_mixed_dtypes_axis_1(func, value):
     df["c"] = 1.0
     result = getattr(df.rolling(window=2, min_periods=1, axis=1), func)()
     expected = DataFrame(
-        {"a": [1.0, 1.0], "b": [value, value], "c": [value, value]}, index=[1, 2],
+        {"a": [1.0, 1.0], "b": [value, value], "c": [value, value]},
+        index=[1, 2],
     )
     tm.assert_frame_equal(result, expected)
 
@@ -1054,7 +1086,8 @@ def test_rolling_axis_one_with_nan():
 
 
 @pytest.mark.parametrize(
-    "value", ["test", to_datetime("2019-12-31"), to_timedelta("1 days 06:05:01.00003")],
+    "value",
+    ["test", to_datetime("2019-12-31"), to_timedelta("1 days 06:05:01.00003")],
 )
 def test_rolling_axis_1_non_numeric_dtypes(value):
     # GH: 20649
@@ -1244,7 +1277,11 @@ def test_rolling_decreasing_indices_centered(window, closed, expected, frame_or_
 
 
 @pytest.mark.parametrize(
-    "window,expected", [("1ns", [1.0, 1.0, 1.0, 1.0]), ("3ns", [2.0, 3.0, 3.0, 2.0]),],
+    "window,expected",
+    [
+        ("1ns", [1.0, 1.0, 1.0, 1.0]),
+        ("3ns", [2.0, 3.0, 3.0, 2.0]),
+    ],
 )
 def test_rolling_center_nanosecond_resolution(
     window, closed, expected, frame_or_series
@@ -1272,8 +1309,14 @@ def test_rolling_center_nanosecond_resolution(
                 318.0,
             ],
         ),
-        ("mean", [float("nan"), 7.5, float("nan"), 21.5, 6.0, 9.166667, 13.0, 17.5],),
-        ("sum", [float("nan"), 30.0, float("nan"), 86.0, 30.0, 55.0, 91.0, 140.0],),
+        (
+            "mean",
+            [float("nan"), 7.5, float("nan"), 21.5, 6.0, 9.166667, 13.0, 17.5],
+        ),
+        (
+            "sum",
+            [float("nan"), 30.0, float("nan"), 86.0, 30.0, 55.0, 91.0, 140.0],
+        ),
         (
             "skew",
             [
@@ -1337,7 +1380,10 @@ def test_rolling_non_monotonic(method, expected):
 
 @pytest.mark.parametrize(
     ("index", "window"),
-    [([0, 1, 2, 3, 4], 2), (date_range("2001-01-01", freq="D", periods=5), "2D"),],
+    [
+        ([0, 1, 2, 3, 4], 2),
+        (date_range("2001-01-01", freq="D", periods=5), "2D"),
+    ],
 )
 def test_rolling_corr_timedelta_index(index, window):
     # GH: 31286
@@ -1439,7 +1485,13 @@ def test_rolling_var_floating_artifact_precision():
 
 def test_rolling_std_small_values():
     # GH 37051
-    s = Series([0.00000054, 0.00000053, 0.00000054,])
+    s = Series(
+        [
+            0.00000054,
+            0.00000053,
+            0.00000054,
+        ]
+    )
     result = s.rolling(2).std()
     expected = Series([np.nan, 7.071068e-9, 7.071068e-9])
     tm.assert_series_equal(result, expected, atol=1.0e-15, rtol=1.0e-15)
@@ -1483,7 +1535,10 @@ def test_rolling_mean_all_nan_window_floating_artifacts(start, exp_values):
         0.005,
         0.102500,
     ]
-    expected = DataFrame(values, index=list(range(start, len(values) + start)),)
+    expected = DataFrame(
+        values,
+        index=list(range(start, len(values) + start)),
+    )
     result = df.iloc[start:].rolling(5, min_periods=0).mean()
     tm.assert_frame_equal(result, expected)
 
@@ -1508,7 +1563,8 @@ def test_rolling_float_dtype(float_numpy_dtype):
     # GH#42452
     df = DataFrame({"A": range(5), "B": range(10, 15)}, dtype=float_numpy_dtype)
     expected = DataFrame(
-        {"A": [np.nan] * 5, "B": range(10, 20, 2)}, dtype=float_numpy_dtype,
+        {"A": [np.nan] * 5, "B": range(10, 20, 2)},
+        dtype=float_numpy_dtype,
     )
     result = df.rolling(2, axis=1).sum()
     tm.assert_frame_equal(result, expected, check_dtype=False)

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -84,15 +84,13 @@ def test_constructor_with_timedelta_window(window):
     # GH 15440
     n = 10
     df = DataFrame(
-        {"value": np.arange(n)},
-        index=date_range("2015-12-24", periods=n, freq="D"),
+        {"value": np.arange(n)}, index=date_range("2015-12-24", periods=n, freq="D"),
     )
     expected_data = np.append([0.0, 1.0], np.arange(3.0, 27.0, 3))
 
     result = df.rolling(window=window).sum()
     expected = DataFrame(
-        {"value": expected_data},
-        index=date_range("2015-12-24", periods=n, freq="D"),
+        {"value": expected_data}, index=date_range("2015-12-24", periods=n, freq="D"),
     )
     tm.assert_frame_equal(result, expected)
     expected = df.rolling("3D").sum()
@@ -104,8 +102,7 @@ def test_constructor_timedelta_window_and_minperiods(window, raw):
     # GH 15305
     n = 10
     df = DataFrame(
-        {"value": np.arange(n)},
-        index=date_range("2017-08-08", periods=n, freq="D"),
+        {"value": np.arange(n)}, index=date_range("2017-08-08", periods=n, freq="D"),
     )
     expected = DataFrame(
         {"value": np.append([np.NaN, 1.0], np.arange(3.0, 27.0, 3))},
@@ -136,13 +133,9 @@ def test_closed_fixed(closed, arithmetic_win_operators):
     df_fixed = DataFrame({"A": [0, 1, 2, 3, 4]})
     df_time = DataFrame({"A": [0, 1, 2, 3, 4]}, index=date_range("2020", periods=5))
 
-    result = getattr(
-        df_fixed.rolling(2, closed=closed, min_periods=1),
-        func_name,
-    )()
+    result = getattr(df_fixed.rolling(2, closed=closed, min_periods=1), func_name,)()
     expected = getattr(
-        df_time.rolling("2D", closed=closed, min_periods=1),
-        func_name,
+        df_time.rolling("2D", closed=closed, min_periods=1), func_name,
     )().reset_index(drop=True)
 
     tm.assert_frame_equal(result, expected)
@@ -213,8 +206,7 @@ def test_datetimelike_centered_selections(
         kwargs = {}
 
     result = getattr(
-        df_time.rolling("2D", closed=closed, min_periods=1, center=True),
-        func_name,
+        df_time.rolling("2D", closed=closed, min_periods=1, center=True), func_name,
     )(**kwargs)
 
     tm.assert_frame_equal(result, expected, check_dtype=False)
@@ -345,8 +337,7 @@ def test_closed_one_entry(func):
 def test_closed_one_entry_groupby(func):
     # GH24718
     ser = DataFrame(
-        data={"A": [1, 1, 2], "B": [3, 2, 1]},
-        index=date_range("2000", periods=3),
+        data={"A": [1, 1, 2], "B": [3, 2, 1]}, index=date_range("2000", periods=3),
     )
     result = getattr(
         ser.groupby("A", sort=False)["B"].rolling("10D", closed="left"), func
@@ -373,8 +364,7 @@ def test_closed_one_entry_groupby(func):
 def test_closed_min_max_datetime(input_dtype, func, closed, expected):
     # see gh-21704
     ser = Series(
-        data=np.arange(10).astype(input_dtype),
-        index=date_range("2000", periods=10),
+        data=np.arange(10).astype(input_dtype), index=date_range("2000", periods=10),
     )
 
     result = getattr(ser.rolling("3D", closed=closed), func)()
@@ -849,18 +839,8 @@ def test_iter_rolling_on_dataframe_unordered():
             3,
             1,
         ),
-        (
-            Series([1, 2, 3]),
-            [([1], [0]), ([1, 2], [0, 1]), ([2, 3], [1, 2])],
-            2,
-            1,
-        ),
-        (
-            Series([1, 2, 3]),
-            [([1], [0]), ([1, 2], [0, 1]), ([2, 3], [1, 2])],
-            2,
-            2,
-        ),
+        (Series([1, 2, 3]), [([1], [0]), ([1, 2], [0, 1]), ([2, 3], [1, 2])], 2, 1,),
+        (Series([1, 2, 3]), [([1], [0]), ([1, 2], [0, 1]), ([2, 3], [1, 2])], 2, 2,),
         (Series([1, 2, 3]), [([1], [0]), ([2], [1]), ([3], [2])], 1, 0),
         (Series([1, 2, 3]), [([1], [0]), ([2], [1]), ([3], [2])], 1, 1),
         (Series([1, 2]), [([1], [0]), ([1, 2], [0, 1])], 2, 0),
@@ -1032,18 +1012,7 @@ def test_rolling_numerical_too_large_numbers():
     ds[2] = -9e33
     result = ds.rolling(5).mean()
     expected = Series(
-        [
-            np.nan,
-            np.nan,
-            np.nan,
-            np.nan,
-            -1.8e33,
-            -1.8e33,
-            -1.8e33,
-            5.0,
-            6.0,
-            7.0,
-        ],
+        [np.nan, np.nan, np.nan, np.nan, -1.8e33, -1.8e33, -1.8e33, 5.0, 6.0, 7.0,],
         index=dates,
     )
     tm.assert_series_equal(result, expected)
@@ -1059,8 +1028,7 @@ def test_rolling_mixed_dtypes_axis_1(func, value):
     df["c"] = 1.0
     result = getattr(df.rolling(window=2, min_periods=1, axis=1), func)()
     expected = DataFrame(
-        {"a": [1.0, 1.0], "b": [value, value], "c": [value, value]},
-        index=[1, 2],
+        {"a": [1.0, 1.0], "b": [value, value], "c": [value, value]}, index=[1, 2],
     )
     tm.assert_frame_equal(result, expected)
 
@@ -1086,8 +1054,7 @@ def test_rolling_axis_one_with_nan():
 
 
 @pytest.mark.parametrize(
-    "value",
-    ["test", to_datetime("2019-12-31"), to_timedelta("1 days 06:05:01.00003")],
+    "value", ["test", to_datetime("2019-12-31"), to_timedelta("1 days 06:05:01.00003")],
 )
 def test_rolling_axis_1_non_numeric_dtypes(value):
     # GH: 20649
@@ -1277,11 +1244,7 @@ def test_rolling_decreasing_indices_centered(window, closed, expected, frame_or_
 
 
 @pytest.mark.parametrize(
-    "window,expected",
-    [
-        ("1ns", [1.0, 1.0, 1.0, 1.0]),
-        ("3ns", [2.0, 3.0, 3.0, 2.0]),
-    ],
+    "window,expected", [("1ns", [1.0, 1.0, 1.0, 1.0]), ("3ns", [2.0, 3.0, 3.0, 2.0]),],
 )
 def test_rolling_center_nanosecond_resolution(
     window, closed, expected, frame_or_series
@@ -1309,14 +1272,8 @@ def test_rolling_center_nanosecond_resolution(
                 318.0,
             ],
         ),
-        (
-            "mean",
-            [float("nan"), 7.5, float("nan"), 21.5, 6.0, 9.166667, 13.0, 17.5],
-        ),
-        (
-            "sum",
-            [float("nan"), 30.0, float("nan"), 86.0, 30.0, 55.0, 91.0, 140.0],
-        ),
+        ("mean", [float("nan"), 7.5, float("nan"), 21.5, 6.0, 9.166667, 13.0, 17.5],),
+        ("sum", [float("nan"), 30.0, float("nan"), 86.0, 30.0, 55.0, 91.0, 140.0],),
         (
             "skew",
             [
@@ -1380,10 +1337,7 @@ def test_rolling_non_monotonic(method, expected):
 
 @pytest.mark.parametrize(
     ("index", "window"),
-    [
-        ([0, 1, 2, 3, 4], 2),
-        (date_range("2001-01-01", freq="D", periods=5), "2D"),
-    ],
+    [([0, 1, 2, 3, 4], 2), (date_range("2001-01-01", freq="D", periods=5), "2D"),],
 )
 def test_rolling_corr_timedelta_index(index, window):
     # GH: 31286
@@ -1415,6 +1369,17 @@ def test_groupby_rolling_nan_included():
         ),
     )
     tm.assert_frame_equal(result, expected)
+
+
+def test_groupby_rolling_non_monotonic():
+    # GH 43909
+    shuffled = [3, 0, 1, 2]
+    sec = 1_000_000_000
+    df = DataFrame(
+        [{"t": Timestamp(2 * x * sec), "x": x + 1, "c": 42} for x in shuffled]
+    )
+    with pytest.raises(ValueError, match=r".* must be monotonic"):
+        df.groupby("c").rolling(on="t", window="3s")
 
 
 @pytest.mark.parametrize("method", ["skew", "kurt"])
@@ -1474,13 +1439,7 @@ def test_rolling_var_floating_artifact_precision():
 
 def test_rolling_std_small_values():
     # GH 37051
-    s = Series(
-        [
-            0.00000054,
-            0.00000053,
-            0.00000054,
-        ]
-    )
+    s = Series([0.00000054, 0.00000053, 0.00000054,])
     result = s.rolling(2).std()
     expected = Series([np.nan, 7.071068e-9, 7.071068e-9])
     tm.assert_series_equal(result, expected, atol=1.0e-15, rtol=1.0e-15)
@@ -1524,10 +1483,7 @@ def test_rolling_mean_all_nan_window_floating_artifacts(start, exp_values):
         0.005,
         0.102500,
     ]
-    expected = DataFrame(
-        values,
-        index=list(range(start, len(values) + start)),
-    )
+    expected = DataFrame(values, index=list(range(start, len(values) + start)),)
     result = df.iloc[start:].rolling(5, min_periods=0).mean()
     tm.assert_frame_equal(result, expected)
 
@@ -1552,8 +1508,7 @@ def test_rolling_float_dtype(float_numpy_dtype):
     # GH#42452
     df = DataFrame({"A": range(5), "B": range(10, 15)}, dtype=float_numpy_dtype)
     expected = DataFrame(
-        {"A": [np.nan] * 5, "B": range(10, 20, 2)},
-        dtype=float_numpy_dtype,
+        {"A": [np.nan] * 5, "B": range(10, 20, 2)}, dtype=float_numpy_dtype,
     )
     result = df.rolling(2, axis=1).sum()
     tm.assert_frame_equal(result, expected, check_dtype=False)


### PR DESCRIPTION
- [y ] closes #43909 
- [y ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ test and bugfix ] whatsnew entry
