### PR TITLE
BUG: to_datetime with xarray DataArray and specifie unit errors

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -467,6 +467,7 @@ Conversion
 ^^^^^^^^^^
 - Bug in :class:`UInt64Index` constructor when passing a list containing both positive integers small enough to cast to int64 and integers too large too hold in int64 (:issue:`42201`)
 - Bug in :class:`Series` constructor returning 0 for missing values with dtype ``int64`` and ``False`` for dtype ``bool`` (:issue:`43017`, :issue:`43018`)
+- Bug in :func:`to_datetime` with ``arg:xr.DataArray`` and ``unit="ns"`` specified raises TypeError (:issue:`44053`)
 -
 
 Strings

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -524,9 +524,9 @@ def _to_datetime_with_unit(arg, unit, name, tz, errors: str) -> Index:
         arr = arg.astype(f"datetime64[{unit}]")
         tz_parsed = None
     else:
-            arg = np.asarray(arg)
-            arr, tz_parsed = tslib.array_with_unit_to_datetime(arg, unit, errors=errors)
-            
+        arg = np.asarray(arg)
+        arr, tz_parsed = tslib.array_with_unit_to_datetime(arg, unit, errors=errors)
+
     if errors == "ignore":
         # Index constructor _may_ infer to DatetimeIndex
         result = Index._with_infer(arr, name=name)

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -524,9 +524,9 @@ def _to_datetime_with_unit(arg, unit, name, tz, errors: str) -> Index:
         arr = arg.astype(f"datetime64[{unit}]")
         tz_parsed = None
     else:
-        arg = np.array(arg)
-        arr, tz_parsed = tslib.array_with_unit_to_datetime(arg, unit, errors=errors)
-
+            arg = np.asarray(arg)
+            arr, tz_parsed = tslib.array_with_unit_to_datetime(arg, unit, errors=errors)
+            
     if errors == "ignore":
         # Index constructor _may_ infer to DatetimeIndex
         result = Index._with_infer(arr, name=name)

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -325,7 +325,6 @@ def _convert_listlike_datetimes(
     -------
     Index-like of parsed dates
     """
-
     if isinstance(arg, (list, tuple)):
         arg = np.array(arg, dtype="O")
 
@@ -525,6 +524,7 @@ def _to_datetime_with_unit(arg, unit, name, tz, errors: str) -> Index:
         arr = arg.astype(f"datetime64[{unit}]")
         tz_parsed = None
     else:
+        arg = np.array(arg)
         arr, tz_parsed = tslib.array_with_unit_to_datetime(arg, unit, errors=errors)
 
     if errors == "ignore":

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2640,9 +2640,27 @@ def test_empty_string_datetime_coerce__unit():
     tm.assert_index_equal(expected, result)
 
 
+@td.skip_if_no("xarray")
+def test_xarray_coerce_unit():
+    import xarray as xr
+
+    arr = xr.DataArray([1, 2, 3])
+    result = to_datetime(arr, unit="ns")
+    expected = DatetimeIndex(
+        [
+            "1970-01-01 00:00:00.000000001",
+            "1970-01-01 00:00:00.000000002",
+            "1970-01-01 00:00:00.000000003",
+        ],
+        dtype="datetime64[ns]",
+        freq=None,
+    )
+    tm.assert_index_equal(result, expected)
+
+
 @pytest.mark.parametrize("cache", [True, False])
 def test_to_datetime_monotonic_increasing_index(cache):
-    # GH28238
+    # 44053
     cstart = start_caching_at
     times = date_range(Timestamp("1980"), periods=cstart, freq="YS")
     times = times.to_frame(index=False, name="DT").sample(n=cstart, random_state=1)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2642,6 +2642,7 @@ def test_empty_string_datetime_coerce__unit():
 
 @td.skip_if_no("xarray")
 def test_xarray_coerce_unit():
+    # GH44053
     import xarray as xr
 
     arr = xr.DataArray([1, 2, 3])

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2660,7 +2660,7 @@ def test_xarray_coerce_unit():
 
 @pytest.mark.parametrize("cache", [True, False])
 def test_to_datetime_monotonic_increasing_index(cache):
-    # 44053
+    # GH28238
     cstart = start_caching_at
     times = date_range(Timestamp("1980"), periods=cstart, freq="YS")
     times = times.to_frame(index=False, name="DT").sample(n=cstart, random_state=1)


### PR DESCRIPTION
- [x] closes #44053
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] coerce to numpy array before calling ```tslib.array_with_unit_to_datetime```function

Let me know if any change need to be done. Let me know if you need to make any changes.
I love the package hope I can start helping more :)