### PR TITLE
DOC: Fix cheatsheet automatic uploading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,9 @@ jobs:
         echo "${{ secrets.server_ip }} ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBE1Kkopomm7FHG5enATf7SgnpICZ4W2bw+Ho+afqin+w7sMcrsa0je7sbztFAV8YchDkiBKnWTG4cRT+KZgZCaY=" > ~/.ssh/known_hosts
       if: ${{github.event_name == 'push' && github.ref == 'refs/heads/master'}}
 
+    - name: Copy cheatsheets into site directory
+      run: cp doc/cheatsheet/Pandas_Cheat_Sheet* web/build/
+
     - name: Upload web
       run: rsync -az --delete --exclude='pandas-docs' --exclude='docs' web/build/ docs@${{ secrets.server_ip }}:/usr/share/nginx/pandas
       if: ${{github.event_name == 'push' && github.ref == 'refs/heads/master'}}
@@ -146,9 +149,6 @@ jobs:
 
     - name: Move docs into site directory
       run: mv doc/build/html web/build/docs
-
-    - name: Copy cheatsheets into site directory
-      run: cp doc/cheatsheet/Pandas_Cheat_Sheet* web/build/
 
     - name: Save website as an artifact
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
Follow up of #44018.

I didn't realize before merging that we were first uploading the web directory, and then copying the cheatsheets to it, so they won't be uploaded. The cheatsheets will be removed from the website in the CI of hte previous PR, so would be good to merge this asap, so the cheatsheets are restored.
