### PR TITLE
BUG: RangeIndex.difference with sort=None and step<0

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -604,6 +604,7 @@ Other
 ^^^^^
 - Bug in :meth:`CustomBusinessMonthBegin.__add__` (:meth:`CustomBusinessMonthEnd.__add__`) not applying the extra ``offset`` parameter when beginning (end) of the target month is already a business day (:issue:`41356`)
 - Bug in :meth:`RangeIndex.union` with another ``RangeIndex`` with matching (even) ``step`` and starts differing by strictly less than ``step / 2`` (:issue:`44019`)
+- Bug in :meth:`RangeIndex.difference` with ``sort=None`` and ``step<0`` failing to sort (:issue:`??`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -604,7 +604,7 @@ Other
 ^^^^^
 - Bug in :meth:`CustomBusinessMonthBegin.__add__` (:meth:`CustomBusinessMonthEnd.__add__`) not applying the extra ``offset`` parameter when beginning (end) of the target month is already a business day (:issue:`41356`)
 - Bug in :meth:`RangeIndex.union` with another ``RangeIndex`` with matching (even) ``step`` and starts differing by strictly less than ``step / 2`` (:issue:`44019`)
-- Bug in :meth:`RangeIndex.difference` with ``sort=None`` and ``step<0`` failing to sort (:issue:`??`)
+- Bug in :meth:`RangeIndex.difference` with ``sort=None`` and ``step<0`` failing to sort (:issue:`44085`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -680,7 +680,10 @@ class RangeIndex(NumericIndex):
             overlap = overlap[::-1]
 
         if len(overlap) == 0:
-            return self.rename(name=res_name)
+            result = self.rename(name=res_name)
+            if sort is None and self.step < 0:
+                result = result[::-1]
+            return result
         if len(overlap) == len(self):
             return self[:0].rename(res_name)
         if not isinstance(overlap, RangeIndex):
@@ -703,6 +706,9 @@ class RangeIndex(NumericIndex):
 
         new_index = type(self)._simple_new(new_rng, name=res_name)
         if first is not self._range:
+            new_index = new_index[::-1]
+
+        if sort is None and new_index.step < 0:
             new_index = new_index[::-1]
         return new_index
 

--- a/pandas/tests/indexes/ranges/test_setops.py
+++ b/pandas/tests/indexes/ranges/test_setops.py
@@ -317,15 +317,43 @@ class TestRangeIndexSetOps:
         result = obj.difference(obj[-3:])
         tm.assert_index_equal(result, obj[:-3], exact=True)
 
+        # Flipping the step of 'other' doesn't affect the result, but
+        #  flipping the stepof 'self' does when sort=None
         result = obj[::-1].difference(obj[-3:])
+        tm.assert_index_equal(result, obj[:-3], exact=True)
+
+        result = obj[::-1].difference(obj[-3:], sort=False)
         tm.assert_index_equal(result, obj[:-3][::-1], exact=True)
 
         result = obj[::-1].difference(obj[-3:][::-1])
+        tm.assert_index_equal(result, obj[:-3], exact=True)
+
+        result = obj[::-1].difference(obj[-3:][::-1], sort=False)
         tm.assert_index_equal(result, obj[:-3][::-1], exact=True)
 
         result = obj.difference(obj[2:6])
         expected = Int64Index([1, 2, 7, 8, 9], name="foo")
         tm.assert_index_equal(result, expected)
+
+    def test_difference_sort(self):
+        # ensure we respect the sort keyword
+
+        idx = Index(range(4))[::-1]
+        other = Index(range(3, 4))
+
+        result = idx.difference(other)
+        expected = Index(range(3))
+        tm.assert_index_equal(result, expected, exact=True)
+
+        result = idx.difference(other, sort=False)
+        expected = expected[::-1]
+        tm.assert_index_equal(result, expected, exact=True)
+
+        # case where the intersection is empty
+        other = range(10, 12)
+        result = idx.difference(other, sort=None)
+        expected = idx[::-1]
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_difference_mismatched_step(self):
         obj = RangeIndex.from_range(range(1, 10), name="foo")

--- a/pandas/tests/indexes/ranges/test_setops.py
+++ b/pandas/tests/indexes/ranges/test_setops.py
@@ -336,7 +336,7 @@ class TestRangeIndexSetOps:
         tm.assert_index_equal(result, expected)
 
     def test_difference_sort(self):
-        # ensure we respect the sort keyword
+        # GH#44085 ensure we respect the sort keyword
 
         idx = Index(range(4))[::-1]
         other = Index(range(3, 4))


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry
