### PR TITLE
TST: Adding test for checking that plotting grid param by default is mpl.rcParams['axes.grid']

### DIFF
--- a/pandas/tests/plotting/test_style.py
+++ b/pandas/tests/plotting/test_style.py
@@ -1,6 +1,9 @@
 import pytest
 
-from pandas import Series
+from pandas import (
+    DataFrame,
+    Series,
+)
 
 pytest.importorskip("matplotlib")
 from pandas.plotting._matplotlib.style import get_standard_colors
@@ -157,3 +160,14 @@ class TestGetStandardColors:
     def test_bad_color_raises(self, color):
         with pytest.raises(ValueError, match="Invalid color"):
             get_standard_colors(color=color, num_colors=5)
+
+
+class TestDefaultMplStyleParams:
+    @pytest.mark.parametrize("rcGrid", [True, False])
+    def test_mplback_df_plot_by_default_use_axes_grid_from_rcparams(self, rcGrid):
+        import matplotlib as mpl
+
+        # GH 3188
+        mpl.rcParams["axes.grid"] = rcGrid
+        ax = DataFrame([1, 2, 3, 4, 5]).plot()
+        assert mpl.rcParams["axes.grid"] == ax._gridOn


### PR DESCRIPTION
- [ ] Related to #3188
- [ ] tests added to pandas/tests/plotting/test_style.py and passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] Seems the issue is obsolete. As I can see now the tested behavior is by design with matplotlib backend for visualization, but more tests is better ;)
