### PR TITLE
REF: reuse self.grouper.result_index

### DIFF
--- a/pandas/_libs/reduction.pyx
+++ b/pandas/_libs/reduction.pyx
@@ -30,8 +30,4 @@ cpdef inline extract_result(object res):
         if res.ndim == 1 and len(res) == 1:
             # see test_agg_lambda_with_timezone, test_resampler_grouper.py::test_apply
             res = res[0]
-    if is_array(res):
-        if res.ndim == 1 and len(res) == 1:
-            # see test_resampler_grouper.py::test_apply
-            res = res[0]
     return res

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -287,7 +287,8 @@ class SeriesGroupBy(GroupBy[Series]):
                 #  see test_groupby.test_basic
                 result = self._aggregate_named(func, *args, **kwargs)
 
-                index = Index(sorted(result), name=self.grouper.names[0])
+                # result is a dict whose keys are the elements of result_index
+                index = self.grouper.result_index
                 return create_series_with_explicit_dtype(
                     result, index=index, dtype_if_empty=object
                 )


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
