### PR TITLE
CI: Pin pre-commit python version

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,4 +16,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9.7'
     - uses: pre-commit/action@v2.0.0


### PR DESCRIPTION
- [x] closes #44116

Looks like GH actions/setup-python seems to have randomly jumped from python 3.9.7 to python 3.10.0

Working:
https://github.com/pandas-dev/pandas/runs/3947277622?check_suite_focus=true#step:3:5

Failing:
https://github.com/pandas-dev/pandas/runs/3960125988?check_suite_focus=true#step:3:5

We can pin to a specific python version as per:
https://github.com/actions/setup-python#usage


Needs backport to 1.3.x also failing there to: https://github.com/pandas-dev/pandas/runs/3959049188?check_suite_focus=true