### PR TITLE
ENH: Use yaml anchors for pre-commit hooks additional dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,10 +39,11 @@ repos:
     rev: 3.9.2
     hooks:
     -   id: flake8
-        additional_dependencies:
-            - flake8-comprehensions==3.1.0
-            - flake8-bugbear==21.3.2
-            - pandas-dev-flaker==0.2.0
+        additional_dependencies: &flake8_dependencies
+        - flake8==3.9.2
+        - flake8-comprehensions==3.1.0
+        - flake8-bugbear==21.3.2
+        - pandas-dev-flaker==0.2.0
     -   id: flake8
         alias: flake8-cython
         name: flake8 (cython)
@@ -76,11 +77,7 @@ repos:
     rev: v1.2.3
     hooks:
     -   id: yesqa
-        additional_dependencies:
-            - flake8==3.9.2
-            - flake8-comprehensions==3.1.0
-            - flake8-bugbear==21.3.2
-            - pandas-dev-flaker==0.2.0
+        additional_dependencies: *flake8_dependencies
 -   repo: local
     hooks:
     -   id: pyright

--- a/scripts/sync_flake8_versions.py
+++ b/scripts/sync_flake8_versions.py
@@ -68,16 +68,9 @@ def _conda_to_pip_compat(dep):
 
 def _validate_additional_dependencies(
     flake8_additional_dependencies,
-    yesqa_additional_dependencies,
     environment_additional_dependencies,
 ) -> None:
     for dep in flake8_additional_dependencies:
-        if dep not in yesqa_additional_dependencies:
-            sys.stdout.write(
-                f"Mismatch of '{dep.name}' version between 'flake8' "
-                "and 'yesqa' in '.pre-commit-config.yaml'\n"
-            )
-            sys.exit(1)
         if dep not in environment_additional_dependencies:
             sys.stdout.write(
                 f"Mismatch of '{dep.name}' version between 'enviroment.yml' "
@@ -91,13 +84,6 @@ def _validate_revisions(revisions):
         sys.stdout.write(
             f"{revisions.name} in 'environment.yml' does not "
             "match in 'flake8' from 'pre-commit'\n"
-        )
-        sys.exit(1)
-
-    if revisions.yesqa != revisions.pre_commit:
-        sys.stdout.write(
-            f"{revisions.name} in 'yesqa' does not match "
-            "in 'flake8' from 'pre-commit'\n"
         )
         sys.exit(1)
 
@@ -127,18 +113,8 @@ def get_revisions(
     for dep in _process_dependencies(flake8_hook.get("additional_dependencies", [])):
         if dep.name == "pandas-dev-flaker":
             pandas_dev_flaker_revisions.pre_commit = dep
-        else:
+        elif dep.name != "flake8":
             flake8_additional_dependencies.append(dep)
-
-    _, yesqa_hook = _get_repo_hook(repos, "yesqa")
-    yesqa_additional_dependencies = []
-    for dep in _process_dependencies(yesqa_hook.get("additional_dependencies", [])):
-        if dep.name == "flake8":
-            flake8_revisions.yesqa = dep
-        elif dep.name == "pandas-dev-flaker":
-            pandas_dev_flaker_revisions.yesqa = dep
-        else:
-            yesqa_additional_dependencies.append(dep)
 
     environment_dependencies = environment["dependencies"]
     environment_additional_dependencies = []
@@ -152,7 +128,6 @@ def get_revisions(
 
     _validate_additional_dependencies(
         flake8_additional_dependencies,
-        yesqa_additional_dependencies,
         environment_additional_dependencies,
     )
 

--- a/scripts/sync_flake8_versions.py
+++ b/scripts/sync_flake8_versions.py
@@ -113,7 +113,7 @@ def get_revisions(
     for dep in _process_dependencies(flake8_hook.get("additional_dependencies", [])):
         if dep.name == "pandas-dev-flaker":
             pandas_dev_flaker_revisions.pre_commit = dep
-        elif dep.name != "flake8":
+        else:
             flake8_additional_dependencies.append(dep)
 
     environment_dependencies = environment["dependencies"]
@@ -121,6 +121,7 @@ def get_revisions(
     for dep in _process_dependencies(environment_dependencies):
         if dep.name == "flake8":
             flake8_revisions.environment = dep
+            environment_additional_dependencies.append(dep)
         elif dep.name == "pandas-dev-flaker":
             pandas_dev_flaker_revisions.environment = dep
         else:


### PR DESCRIPTION
- [x] closes #43282 
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry


This PR adds:
- use of yaml anchors for the `flake8` and `yesqa` hooks 
- updates to `scripts/sync_flake8_versions.py`  since now both `yesqa` and `flake8` hooks have the same additional dependencies declared through a reusable anchor there is no need to check for sync between these two 


PD. I am not sure this needs a `whatsnew` entry so I did not add it - unless y'all think there should be one