### PR TITLE
PERF: improve efficiency of `BaseMaskedArray.__setitem__`

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -85,7 +85,7 @@ def frame_apply(
     args=None,
     kwargs=None,
 ) -> FrameApply:
-    """construct and return a row or column based frame apply object"""
+    """Construct and return a row- or column-based frame apply object."""
     axis = obj._get_axis_number(axis)
     klass: type[FrameApply]
     if axis == 0:
@@ -693,7 +693,7 @@ class FrameApply(NDFrameApply):
         return self.obj.dtypes
 
     def apply(self) -> DataFrame | Series:
-        """compute the results"""
+        """Compute the results."""
         # dispatch to agg
         if is_list_like(self.f):
             return self.apply_multiple()
@@ -1011,7 +1011,7 @@ class FrameColumnApply(FrameApply):
     def wrap_results_for_axis(
         self, results: ResType, res_index: Index
     ) -> DataFrame | Series:
-        """return the results for the columns"""
+        """Return the results for the columns."""
         result: DataFrame | Series
 
         # we have requested to expand

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -365,6 +365,9 @@ class BooleanArray(BaseMaskedArray):
     def _coerce_to_array(self, value) -> tuple[np.ndarray, np.ndarray]:
         return coerce_to_array(value)
 
+    def _validate_setitem_value(self, value):
+        return lib.is_bool(value)
+
     @overload
     def astype(self, dtype: npt.DTypeLike, copy: bool = ...) -> np.ndarray:
         ...

--- a/pandas/core/arrays/floating.py
+++ b/pandas/core/arrays/floating.py
@@ -270,6 +270,9 @@ class FloatingArray(NumericArray):
     def _coerce_to_array(self, value) -> tuple[np.ndarray, np.ndarray]:
         return coerce_to_array(value, dtype=self.dtype)
 
+    def _validate_setitem_value(self, value):
+        return lib.is_float(value)
+
     @overload
     def astype(self, dtype: npt.DTypeLike, copy: bool = ...) -> np.ndarray:
         ...

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -338,6 +338,9 @@ class IntegerArray(NumericArray):
     def _coerce_to_array(self, value) -> tuple[np.ndarray, np.ndarray]:
         return coerce_to_array(value, dtype=self.dtype)
 
+    def _validate_setitem_value(self, value):
+        return lib.is_integer(value)
+
     @overload
     def astype(self, dtype: npt.DTypeLike, copy: bool = ...) -> np.ndarray:
         ...


### PR DESCRIPTION
This somewhat deals with #44172, though that won't be fully resolved until 2D `ExtensionArray`s are supported (per the comments there).

CC @jbrockmendel

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry