### PR TITLE
:white_check_mark: TST: Update sync flake8 tests

### DIFF
--- a/scripts/tests/test_sync_flake8_versions.py
+++ b/scripts/tests/test_sync_flake8_versions.py
@@ -3,44 +3,6 @@ import pytest
 from ..sync_flake8_versions import get_revisions
 
 
-def test_wrong_yesqa_flake8(capsys):
-    precommit_config = {
-        "repos": [
-            {
-                "repo": "https://gitlab.com/pycqa/flake8",
-                "rev": "0.1.1",
-                "hooks": [
-                    {
-                        "id": "flake8",
-                    }
-                ],
-            },
-            {
-                "repo": "https://github.com/asottile/yesqa",
-                "rev": "v1.2.2",
-                "hooks": [
-                    {
-                        "id": "yesqa",
-                        "additional_dependencies": [
-                            "flake8==0.4.2",
-                        ],
-                    }
-                ],
-            },
-        ]
-    }
-    environment = {
-        "dependencies": [
-            "flake8=0.1.1",
-        ]
-    }
-    with pytest.raises(SystemExit, match=None):
-        get_revisions(precommit_config, environment)
-    result, _ = capsys.readouterr()
-    expected = "flake8 in 'yesqa' does not match in 'flake8' from 'pre-commit'\n"
-    assert result == expected
-
-
 def test_wrong_env_flake8(capsys):
     precommit_config = {
         "repos": [
@@ -50,18 +12,6 @@ def test_wrong_env_flake8(capsys):
                 "hooks": [
                     {
                         "id": "flake8",
-                    }
-                ],
-            },
-            {
-                "repo": "https://github.com/asottile/yesqa",
-                "rev": "v1.2.2",
-                "hooks": [
-                    {
-                        "id": "yesqa",
-                        "additional_dependencies": [
-                            "flake8==0.4.2",
-                        ],
                     }
                 ],
             },
@@ -77,52 +27,6 @@ def test_wrong_env_flake8(capsys):
     result, _ = capsys.readouterr()
     expected = (
         "flake8 in 'environment.yml' does not match in 'flake8' from 'pre-commit'\n"
-    )
-    assert result == expected
-
-
-def test_wrong_yesqa_add_dep(capsys):
-    precommit_config = {
-        "repos": [
-            {
-                "repo": "https://gitlab.com/pycqa/flake8",
-                "rev": "0.1.1",
-                "hooks": [
-                    {
-                        "id": "flake8",
-                        "additional_dependencies": [
-                            "flake8-bugs==1.1.1",
-                        ],
-                    }
-                ],
-            },
-            {
-                "repo": "https://github.com/asottile/yesqa",
-                "rev": "v1.2.2",
-                "hooks": [
-                    {
-                        "id": "yesqa",
-                        "additional_dependencies": [
-                            "flake8==0.4.2",
-                            "flake8-bugs>=1.1.1",
-                        ],
-                    }
-                ],
-            },
-        ]
-    }
-    environment = {
-        "dependencies": [
-            "flake8=1.5.6",
-            "flake8-bugs=1.1.1",
-        ]
-    }
-    with pytest.raises(SystemExit, match=None):
-        get_revisions(precommit_config, environment)
-    result, _ = capsys.readouterr()
-    expected = (
-        "Mismatch of 'flake8-bugs' version between 'flake8' and 'yesqa' in "
-        "'.pre-commit-config.yaml'\n"
     )
     assert result == expected
 


### PR DESCRIPTION

- [x] related to #44177
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

I sent a PR yesterday #44177 which was aimed at adding anchors to the `pre-commit-config.yaml` file 

However, somehow I forgot to also update the corresponding test so this PR should remove the references to `yesqa` dependencies checks 
