### PR TITLE
BUG: Series[Interval[int64]] setitem Interval[float]

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -530,7 +530,7 @@ Indexing
 - Bug in :meth:`Series.__setitem__` with object dtype when setting an array with matching size and dtype='datetime64[ns]' or dtype='timedelta64[ns]' incorrectly converting the datetime/timedeltas to integers (:issue:`43868`)
 - Bug in :meth:`DataFrame.sort_index` where ``ignore_index=True`` was not being respected when the index was already sorted (:issue:`43591`)
 - Bug in :meth:`Index.get_indexer_non_unique` when index contains multiple ``np.datetime64("NaT")`` and ``np.timedelta64("NaT")`` (:issue:`43869`)
-- Bug in setting a scalar :class:`Interval` value into a :class:`Series` with ``IntervalDtype`` when the scalar's sides are floats and the values' sides are integers (:issue:`??`)
+- Bug in setting a scalar :class:`Interval` value into a :class:`Series` with ``IntervalDtype`` when the scalar's sides are floats and the values' sides are integers (:issue:`44201`)
 -
 
 

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -530,7 +530,9 @@ Indexing
 - Bug in :meth:`Series.__setitem__` with object dtype when setting an array with matching size and dtype='datetime64[ns]' or dtype='timedelta64[ns]' incorrectly converting the datetime/timedeltas to integers (:issue:`43868`)
 - Bug in :meth:`DataFrame.sort_index` where ``ignore_index=True`` was not being respected when the index was already sorted (:issue:`43591`)
 - Bug in :meth:`Index.get_indexer_non_unique` when index contains multiple ``np.datetime64("NaT")`` and ``np.timedelta64("NaT")`` (:issue:`43869`)
+- Bug in setting a scalar :class:`Interval` value into a :class:`Series` with ``IntervalDtype`` when the scalar's sides are floats and the values' sides are integers (:issue:`??`)
 -
+
 
 Missing
 ^^^^^^^

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -11,6 +11,7 @@ from pandas import (
     DataFrame,
     DatetimeIndex,
     Index,
+    Interval,
     IntervalIndex,
     MultiIndex,
     NaT,
@@ -926,6 +927,38 @@ class TestSeriesNoneCoercion(SetitemCastingEquivalents):
     def is_inplace(self, obj):
         # This is specific to the 4 cases currently implemented for this class.
         return obj.dtype.kind != "i"
+
+
+class TestSetitemFloatIntervalWithIntIntervalValues(SetitemCastingEquivalents):
+    # Cast to shared IntervalDtype rather than object
+
+    def test_setitem_example(self):
+        # Just a case here to make obvious what this test class is aimed at
+        idx = IntervalIndex.from_breaks(range(4))
+        obj = Series(idx)
+        val = Interval(0.5, 1.5)
+
+        obj[0] = val
+        assert obj.dtype == "Interval[float64, right]"
+
+    @pytest.fixture
+    def obj(self):
+        idx = IntervalIndex.from_breaks(range(4))
+        return Series(idx)
+
+    @pytest.fixture
+    def val(self):
+        return Interval(0.5, 1.5)
+
+    @pytest.fixture
+    def key(self):
+        return 0
+
+    @pytest.fixture
+    def expected(self, obj, val):
+        data = [val] + list(obj[1:])
+        idx = IntervalIndex(data, dtype="Interval[float64]")
+        return Series(idx)
 
 
 def test_setitem_int_as_positional_fallback_deprecation():

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -930,7 +930,7 @@ class TestSeriesNoneCoercion(SetitemCastingEquivalents):
 
 
 class TestSetitemFloatIntervalWithIntIntervalValues(SetitemCastingEquivalents):
-    # Cast to shared IntervalDtype rather than object
+    # GH#44201 Cast to shared IntervalDtype rather than object
 
     def test_setitem_example(self):
         # Just a case here to make obvious what this test class is aimed at


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

Cast to common dtype instead of object, match IntervalIndex behavior.