### PR TITLE
REF: extract params used in Series.__repr__

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3,8 +3,6 @@ Data structure for 1-dimensional cross-sectional and time series data
 """
 from __future__ import annotations
 
-from io import StringIO
-from shutil import get_terminal_size
 from textwrap import dedent
 from typing import (
     IO,
@@ -1460,29 +1458,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         Return a string representation for a particular Series.
         """
-        buf = StringIO("")
-        width, height = get_terminal_size()
-        max_rows = (
-            height
-            if get_option("display.max_rows") == 0
-            else get_option("display.max_rows")
-        )
-        min_rows = (
-            height
-            if get_option("display.max_rows") == 0
-            else get_option("display.min_rows")
-        )
-        show_dimensions = get_option("display.show_dimensions")
-
-        self.to_string(
-            buf=buf,
-            name=self.name,
-            dtype=self.dtype,
-            min_rows=min_rows,
-            max_rows=max_rows,
-            length=show_dimensions,
-        )
-        return buf.getvalue()
+        repr_params = fmt.get_series_repr_params(self)
+        return self.to_string(**repr_params)
 
     def to_string(
         self,

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -489,6 +489,8 @@ def get_dataframe_repr_params() -> dict[str, Any]:
     Supplying these parameters to DataFrame.to_string is equivalent to calling
     ``repr(DataFrame)``. This is useful if you want to adjust the repr output.
 
+    .. versionadded:: 1.4.0
+
     Example
     -------
     >>> import pandas as pd
@@ -511,6 +513,44 @@ def get_dataframe_repr_params() -> dict[str, Any]:
         "max_colwidth": get_option("display.max_colwidth"),
         "show_dimensions": get_option("display.show_dimensions"),
         "line_width": line_width,
+    }
+
+
+def get_series_repr_params(series: Series) -> dict[str, Any]:
+    """Get the parameters used to repr(Series) calls using Series.to_string.
+
+    Supplying these parameters to Series.to_string is equivalent to calling
+    ``repr(series)``. This is useful if you want to adjust the series repr output.
+
+    .. versionadded:: 1.4.0
+
+    Example
+    -------
+    >>> import pandas as pd
+    >>>
+    >>> ser = pd.Series([1, 2, 3, 4])
+    >>> repr_params = pd.io.formats.format.get_series_repr_params(ser)
+    >>> repr(ser) == ser.to_string(**repr_params)
+    True
+    """
+    width, height = get_terminal_size()
+    max_rows = (
+        height
+        if get_option("display.max_rows") == 0
+        else get_option("display.max_rows")
+    )
+    min_rows = (
+        height
+        if get_option("display.max_rows") == 0
+        else get_option("display.min_rows")
+    )
+
+    return {
+        "name": series.name,
+        "dtype": series.dtype,
+        "min_rows": min_rows,
+        "max_rows": max_rows,
+        "length": get_option("display.show_dimensions"),
     }
 
 


### PR DESCRIPTION
This PR gives flexibility if we want the series string output to be like the Series repr, but with some adjustments.

So with this PR we we can now do:

```python
>>> params = pd.io.formats.format.get_series_repr_params(ser)
>>> params[my_param] = new_value
>>> ser.to_string(**params)
```

Followup to #43987.
