### PR TITLE
CLN: simplify io.formats.format.get_series_repr_params

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1458,7 +1458,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         Return a string representation for a particular Series.
         """
-        repr_params = fmt.get_series_repr_params(self)
+        repr_params = fmt.get_series_repr_params()
         return self.to_string(**repr_params)
 
     def to_string(

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -516,7 +516,7 @@ def get_dataframe_repr_params() -> dict[str, Any]:
     }
 
 
-def get_series_repr_params(series: Series) -> dict[str, Any]:
+def get_series_repr_params() -> dict[str, Any]:
     """Get the parameters used to repr(Series) calls using Series.to_string.
 
     Supplying these parameters to Series.to_string is equivalent to calling
@@ -529,7 +529,7 @@ def get_series_repr_params(series: Series) -> dict[str, Any]:
     >>> import pandas as pd
     >>>
     >>> ser = pd.Series([1, 2, 3, 4])
-    >>> repr_params = pd.io.formats.format.get_series_repr_params(ser)
+    >>> repr_params = pd.io.formats.format.get_series_repr_params()
     >>> repr(ser) == ser.to_string(**repr_params)
     True
     """
@@ -546,8 +546,8 @@ def get_series_repr_params(series: Series) -> dict[str, Any]:
     )
 
     return {
-        "name": series.name,
-        "dtype": series.dtype,
+        "name": True,
+        "dtype": True,
         "min_rows": min_rows,
         "max_rows": max_rows,
         "length": get_option("display.show_dimensions"),


### PR DESCRIPTION
Some of the returned values should be booleans. Follow-up to #44218.