### PR TITLE
Update is_platform_arm() to detect 32-bit arm and other variants

### DIFF
--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -99,7 +99,9 @@ def is_platform_arm() -> bool:
     bool
         True if the running platform uses ARM architecture.
     """
-    return platform.machine() in ("arm64", "aarch64")
+    return platform.machine() in ("arm64", "aarch64") or platform.machine().startswith(
+        "armv"
+    )
 
 
 def import_lzma():


### PR DESCRIPTION
- When running an arm32 ("linux32'd") chroot on an arm64 machine,
  Python's platform.machine() will return "armv8l".

- In other cases, on "real" arm32, it'll return whatever uname says
  (just like in the first case) which might be e.g. armv7a.

Keeping the other options ("aarch64", "arm64") given that Windows
or other kernels might choose to return different values and these
were added for a reason, but at least this fixes detection on Linux.

This allows tests like test_subtype_integer_errors to be skipped
as intended on arm.

Bug: https://bugs.gentoo.org/818964
Signed-off-by: Sam James <sam@gentoo.org>

- [X] tests added / passed
- [X] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
