### PR TITLE
DOC: added examples to DataFrame.std

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11189,9 +11189,9 @@ default `ddof=1`)"""
 _std_examples = """
 Examples
 --------
->>> df = pd.DataFrame({'person_id':[0,1,2,3],
-...                   'age':[21,25,62,43],
-...                   'height':[1.61,1.87,1.49,2.01]}
+>>> df = pd.DataFrame({'person_id': [0, 1, 2, 3],
+...                   'age': [21, 25, 62, 43],
+...                   'height': [1.61, 1.87, 1.49, 2.01]}
 ...                  ).set_index('person_id')
 >>> df
            age  height

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11215,8 +11215,7 @@ Alternatively, `ddof=0` can be set to normalize by N instead of N-1:
 
 >>> df.std(ddof=0)
 age       16.269219
-height     0.205609
-"""
+height     0.205609"""
 
 _bool_doc = """
 {desc}

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11211,7 +11211,7 @@ The standard deviation of the columns can be found as follows:
 age       18.786076
 height     0.237417
 
-Alternatively, `ddof=0` can be set to normalize by N instead of N-1.
+Alternatively, `ddof=0` can be set to normalize by N instead of N-1:
 
 >>> df.std(ddof=0)
 age       16.269219

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10679,10 +10679,11 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             _num_ddof_doc,
             desc="Return sample standard deviation over requested axis."
             "\n\nNormalized by N-1 by default. This can be changed using the "
-            "ddof argument",
+            "ddof argument.",
             name1=name1,
             name2=name2,
             axis_descr=axis_descr,
+            examples=_std_examples,
             notes=_std_notes,
         )
         def std(
@@ -11184,6 +11185,34 @@ Notes
 -----
 To have the same behaviour as `numpy.std`, use `ddof=0` (instead of the
 default `ddof=1`)"""
+
+_std_examples = """
+Examples
+--------
+>>> df = pd.DataFrame({'person_id':[0,1,2,3],
+...                   'age':[21,25,62,43],
+...                   'height':[1.61,1.87,1.49,2.01]}
+...                  ).set_index('person_id')
+>>> df
+           age  height
+person_id
+0           21    1.61
+1           25    1.87
+2           62    1.49
+3           43    2.01
+
+The standard deviation of the columns can be found as follows.
+
+>>> df.std()
+age       18.786076
+height     0.237417
+
+Alternatively, `ddof=0` can be set to normalize by N instead of N-1.
+
+>>> df.std(ddof=0)
+age       16.269219
+height     0.205609
+"""
 
 _bool_doc = """
 {desc}

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10639,6 +10639,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             name2=name2,
             axis_descr=axis_descr,
             notes="",
+            examples="",
         )
         def sem(
             self,
@@ -10661,6 +10662,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             name2=name2,
             axis_descr=axis_descr,
             notes="",
+            examples="",
         )
         def var(
             self,
@@ -10683,8 +10685,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             name1=name1,
             name2=name2,
             axis_descr=axis_descr,
-            examples=_std_examples,
             notes=_std_notes,
+            examples=_std_examples,
         )
         def std(
             self,
@@ -11177,6 +11179,8 @@ Returns
 -------
 {name1} or {name2} (if level specified) \
 {notes}
+
+{examples}
 """
 
 _std_notes = """
@@ -11186,7 +11190,7 @@ Notes
 To have the same behaviour as `numpy.std`, use `ddof=0` (instead of the
 default `ddof=1`)"""
 
-_std_examples = """
+_std_examples = """\
 Examples
 --------
 >>> df = pd.DataFrame({'person_id': [0, 1, 2, 3],

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11205,13 +11205,13 @@ person_id
 2           62    1.49
 3           43    2.01
 
-The standard deviation of the columns can be found as follows.
+The standard deviation of the columns can be found as follows:
 
 >>> df.std()
 age       18.786076
 height     0.237417
 
-Alternatively, `ddof=0` can be set to normalize by N instead of N-1.
+Alternatively, `ddof=0` can be set to normalize by N instead of N-1:
 
 >>> df.std(ddof=0)
 age       16.269219

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11205,7 +11205,7 @@ person_id
 2           62    1.49
 3           43    2.01
 
-The standard deviation of the columns can be found as follows.
+The standard deviation of the columns can be found as follows:
 
 >>> df.std()
 age       18.786076

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11178,8 +11178,7 @@ numeric_only : bool, default None
 Returns
 -------
 {name1} or {name2} (if level specified) \
-{notes}
-
+{notes}\
 {examples}
 """
 
@@ -11190,7 +11189,8 @@ Notes
 To have the same behaviour as `numpy.std`, use `ddof=0` (instead of the
 default `ddof=1`)"""
 
-_std_examples = """\
+_std_examples = """
+
 Examples
 --------
 >>> df = pd.DataFrame({'person_id': [0, 1, 2, 3],


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/44162
- [x] Added two examples to the documentation of DataFrame.std function so that users can understand how to use it with different delta degrees of freedom.
- [ ] Add examples to the documentation of DataFrame.var function
---
- [x] tests added / passed
- [x] All pre-commit linting tests pass
