### PR TITLE
BUG: all-NaT TDI division with object dtype preserve td64

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -475,7 +475,7 @@ Datetimelike
 
 Timedelta
 ^^^^^^^^^
--
+- Bug in division of all-``NaT`` :class:`TimeDeltaIndex`, :class:`Series` or :class:`DataFrame` column with object-dtype arraylike of numbers failing to infer the result as timedelta64-dtype (:issue:`39750`)
 -
 
 Timezones

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -684,11 +684,14 @@ class TimedeltaArray(dtl.TimelikeOps):
         elif is_object_dtype(other.dtype):
             # error: Incompatible types in assignment (expression has type
             # "List[Any]", variable has type "ndarray")
-            result = [  # type: ignore[assignment]
-                self[n] // other[n] for n in range(len(self))
-            ]
-            result = np.array(result)
-            inferred = lib.infer_dtype(result, skipna=False)
+            srav = self.ravel()
+            orav = other.ravel()
+            res_list = [srav[n] // orav[n] for n in range(len(srav))]
+            result_flat = np.asarray(res_list)
+            inferred = lib.infer_dtype(result_flat, skipna=False)
+
+            result = result_flat.reshape(self.shape)
+
             if inferred == "timedelta":
                 result, _ = sequence_to_td64ns(result)
                 return type(self)(result)

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -2137,6 +2137,19 @@ class TestTimedeltaArraylikeMulDivOps:
         else:
             tm.assert_equal(result, expected)
 
+    def test_td64arr_all_nat_div_object_dtype_numeric(self, box_with_array):
+        # GH#39750 make sure we infer the result as td64
+        tdi = TimedeltaIndex([NaT, NaT])
+
+        left = tm.box_expected(tdi, box_with_array)
+        right = np.array([2, 2.0], dtype=object)
+
+        result = left / right
+        tm.assert_equal(result, left)
+
+        result = left // right
+        tm.assert_equal(result, left)
+
 
 class TestTimedelta64ArrayLikeArithmetic:
     # Arithmetic tests for timedelta64[ns] vectors fully parametrized over

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -2022,7 +2022,7 @@ class TestTimedeltaArraylikeMulDivOps:
         ids=lambda x: type(x).__name__,
     )
     def test_td64arr_div_numeric_array(
-        self, box_with_array, vector, any_real_numpy_dtype, using_array_manager
+        self, box_with_array, vector, any_real_numpy_dtype
     ):
         # GH#4521
         # divide/multiply by integers
@@ -2061,14 +2061,6 @@ class TestTimedeltaArraylikeMulDivOps:
             expected = pd.Index(expected)  # do dtype inference
             expected = tm.box_expected(expected, xbox)
             assert tm.get_dtype(expected) == "m8[ns]"
-
-            if using_array_manager and box_with_array is DataFrame:
-                # TODO the behaviour is buggy here (third column with all-NaT
-                # as result doesn't get preserved as timedelta64 dtype).
-                # Reported at https://github.com/pandas-dev/pandas/issues/39750
-                # Changing the expected instead of xfailing to continue to test
-                # the correct behaviour for the other columns
-                expected[2] = Series([NaT, NaT], dtype=object)
 
             tm.assert_equal(result, expected)
 


### PR DESCRIPTION
- [x] closes #39750
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry
