### PR TITLE
Revert "Backport PR #44204 on branch 1.3.x (CI: Python Dev build)"

### DIFF
--- a/.github/workflows/python-dev.yml
+++ b/.github/workflows/python-dev.yml
@@ -17,6 +17,7 @@ env:
   PANDAS_CI: 1
   PATTERN: "not slow and not network and not clipboard"
   COVERAGE: true
+  PYTEST_TARGET:  pandas
 
 jobs:
   build:
@@ -25,13 +26,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        pytest_target: ["pandas/tests/[a-h]*", "pandas/tests/[i-z]*"]
 
     name: actions-310-dev
-    timeout-minutes: 80
+    timeout-minutes: 60
 
     concurrency:
-      group: ${{ github.ref }}-${{ matrix.os }}-${{ matrix.pytest_target }}-dev
+      group: ${{ github.ref }}-${{ matrix.os }}-dev
       cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
     steps:
@@ -63,8 +63,6 @@ jobs:
         python -c "import pandas; pandas.show_versions();"
 
     - name: Test with pytest
-      env:
-          PYTEST_TARGET: ${{ matrix.pytest_target }}
       shell: bash
       run: |
         ci/run_tests.sh


### PR DESCRIPTION
Reverts pandas-dev/pandas#44208

THIS IS ONLY ON 1.3.x.

Let's try reverting this. In theory, the test changes that caused the timeouts shouldn't be backported, so this shouldn't be needed.