### PR TITLE
ENH/PERF: RangeIndex.argsort accept kind; pd.isna(rangeindex) fastpath

### DIFF
--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -496,6 +496,7 @@ class RangeIndex(NumericIndex):
         numpy.ndarray.argsort
         """
         ascending = kwargs.pop("ascending", True)  # EA compat
+        kwargs.pop("kind", None)  # e.g. "mergesort" is irrelevant
         nv.validate_argsort(args, kwargs)
 
         if self._range.step > 0:

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -333,11 +333,9 @@ class Base:
         expected = index.argsort()
         tm.assert_numpy_array_equal(result, expected)
 
-        if not isinstance(index, RangeIndex):
-            # TODO: add compatibility to RangeIndex?
-            result = np.argsort(index, kind="mergesort")
-            expected = index.argsort(kind="mergesort")
-            tm.assert_numpy_array_equal(result, expected)
+        result = np.argsort(index, kind="mergesort")
+        expected = index.argsort(kind="mergesort")
+        tm.assert_numpy_array_equal(result, expected)
 
         # these are the only two types that perform
         # pandas compatibility input validation - the


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

We could use the cached index.isna more if #44262 is addressed.