### PR TITLE
Fix formatting typo in user_guide/style.ipynb

### DIFF
--- a/doc/source/user_guide/style.ipynb
+++ b/doc/source/user_guide/style.ipynb
@@ -1412,7 +1412,7 @@
    "source": [
     "## Limitations\n",
     "\n",
-    "- DataFrame only `(use Series.to_frame().style)`\n",
+    "- DataFrame only (use `Series.to_frame().style`)\n",
     "- The index and columns must be unique\n",
     "- No large repr, and construction performance isn't great; although we have some [HTML optimizations](#Optimization)\n",
     "- You can only style the *values*, not the index or columns (except with `table_styles` above)\n",


### PR DESCRIPTION
Seems to be incorrect:
> - DataFrame only `(use Series.to_frame().style)`

Fixed:
> - DataFrame only (use `Series.to_frame().style`)