### PR TITLE
BUG: Styler `hide` compatible with `max_columns`

### DIFF
--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -1280,15 +1280,15 @@ def _get_level_lengths(
             elif j not in hidden_elements:
                 # then element must be part of sparsified section and is visible
                 visible_row_count += 1
+                if visible_row_count > max_index:
+                    break  # do not add a length since the render trim limit reached
                 if lengths[(i, last_label)] == 0:
                     # if previous iteration was first-of-section but hidden then offset
                     last_label = j
                     lengths[(i, last_label)] = 1
                 else:
-                    # else add to previous iteration but do not extend more than max
-                    lengths[(i, last_label)] = min(
-                        max_index, 1 + lengths[(i, last_label)]
-                    )
+                    # else add to previous iteration
+                    lengths[(i, last_label)] += 1
 
     non_zero_lengths = {
         element: length for element, length in lengths.items() if length >= 1

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -316,7 +316,7 @@ class StylerRenderer:
             self.columns, sparsify_cols, max_cols, self.hidden_columns
         )
 
-        clabels = self.data.columns.tolist()[:max_cols]  # slice to allow trimming
+        clabels = self.data.columns.tolist()
         if self.data.columns.nlevels == 1:
             clabels = [[x] for x in clabels]
         clabels = list(zip(*clabels))
@@ -389,9 +389,28 @@ class StylerRenderer:
             )
         ]
 
-        column_headers = []
+        column_headers, col_count = [], 0
         for c, value in enumerate(clabels[r]):
             header_element_visible = _is_visible(c, r, col_lengths)
+
+            if header_element_visible:
+                col_count += 1
+            if col_count > max_cols:
+                # add an extra column with `...` value to indicate trimming
+                column_headers.append(
+                    _element(
+                        "th",
+                        (
+                            f"{self.css['col_heading']} {self.css['level']}{r} "
+                            f"{self.css['col_trim']}"
+                        ),
+                        "...",
+                        True,
+                        attributes="",
+                    )
+                )
+                break
+
             header_element = _element(
                 "th",
                 (
@@ -422,20 +441,6 @@ class StylerRenderer:
 
             column_headers.append(header_element)
 
-        if len(self.data.columns) > max_cols:
-            # add an extra column with `...` value to indicate trimming
-            column_headers.append(
-                _element(
-                    "th",
-                    (
-                        f"{self.css['col_heading']} {self.css['level']}{r} "
-                        f"{self.css['col_trim']}"
-                    ),
-                    "...",
-                    True,
-                    attributes="",
-                )
-            )
         return index_blanks + column_name + column_headers
 
     def _generate_index_names_row(self, iter: tuple, max_cols):

--- a/pandas/tests/io/formats/style/test_html.py
+++ b/pandas/tests/io/formats/style/test_html.py
@@ -3,7 +3,6 @@ from textwrap import dedent
 import numpy as np
 import pytest
 
-import pandas as pd
 from pandas import (
     DataFrame,
     MultiIndex,

--- a/pandas/tests/io/formats/style/test_html.py
+++ b/pandas/tests/io/formats/style/test_html.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 import numpy as np
 import pytest
 
+import pandas as pd
 from pandas import (
     DataFrame,
     MultiIndex,
@@ -667,4 +668,100 @@ def test_hiding_index_columns_multiindex_alignment():
     </table>
     """
     )
+    assert result == expected
+
+
+def test_hiding_index_columns_multiindex_trimming():
+    # gh 44272
+    df = DataFrame(np.arange(64).reshape(8, 8))
+    df.columns = MultiIndex.from_product([[0, 1, 2, 3], [0, 1]])
+    df.index = MultiIndex.from_product([[0, 1, 2, 3], [0, 1]])
+    df.index.names, df.columns.names = ["a", "b"], ["c", "d"]
+    styler = Styler(df, cell_ids=False, uuid_len=0)
+    styler.hide([(0, 0), (0, 1), (1, 0)], axis=1).hide([(0, 0), (0, 1), (1, 0)], axis=0)
+    with option_context("styler.render.max_rows", 4, "styler.render.max_columns", 4):
+        result = styler.to_html()
+
+    expected = dedent(
+        """\
+    <style type="text/css">
+    </style>
+    <table id="T_">
+      <thead>
+        <tr>
+          <th class="blank" >&nbsp;</th>
+          <th class="index_name level0" >c</th>
+          <th class="col_heading level0 col3" >1</th>
+          <th class="col_heading level0 col4" colspan="2">2</th>
+          <th class="col_heading level0 col6" >3</th>
+        </tr>
+        <tr>
+          <th class="blank" >&nbsp;</th>
+          <th class="index_name level1" >d</th>
+          <th class="col_heading level1 col3" >1</th>
+          <th class="col_heading level1 col4" >0</th>
+          <th class="col_heading level1 col5" >1</th>
+          <th class="col_heading level1 col6" >0</th>
+          <th class="col_heading level1 col_trim" >...</th>
+        </tr>
+        <tr>
+          <th class="index_name level0" >a</th>
+          <th class="index_name level1" >b</th>
+          <th class="blank col3" >&nbsp;</th>
+          <th class="blank col4" >&nbsp;</th>
+          <th class="blank col5" >&nbsp;</th>
+          <th class="blank col6" >&nbsp;</th>
+          <th class="blank col7 col_trim" >&nbsp;</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th class="row_heading level0 row3" >1</th>
+          <th class="row_heading level1 row3" >1</th>
+          <td class="data row3 col3" >27</td>
+          <td class="data row3 col4" >28</td>
+          <td class="data row3 col5" >29</td>
+          <td class="data row3 col6" >30</td>
+          <td class="data row3 col_trim" >...</td>
+        </tr>
+        <tr>
+          <th class="row_heading level0 row4" rowspan="2">2</th>
+          <th class="row_heading level1 row4" >0</th>
+          <td class="data row4 col3" >35</td>
+          <td class="data row4 col4" >36</td>
+          <td class="data row4 col5" >37</td>
+          <td class="data row4 col6" >38</td>
+          <td class="data row4 col_trim" >...</td>
+        </tr>
+        <tr>
+          <th class="row_heading level1 row5" >1</th>
+          <td class="data row5 col3" >43</td>
+          <td class="data row5 col4" >44</td>
+          <td class="data row5 col5" >45</td>
+          <td class="data row5 col6" >46</td>
+          <td class="data row5 col_trim" >...</td>
+        </tr>
+        <tr>
+          <th class="row_heading level0 row6" >3</th>
+          <th class="row_heading level1 row6" >0</th>
+          <td class="data row6 col3" >51</td>
+          <td class="data row6 col4" >52</td>
+          <td class="data row6 col5" >53</td>
+          <td class="data row6 col6" >54</td>
+          <td class="data row6 col_trim" >...</td>
+        </tr>
+        <tr>
+          <th class="row_heading level0 row_trim" >...</th>
+          <th class="row_heading level1 row_trim" >...</th>
+          <td class="data col3 row_trim" >...</td>
+          <td class="data col4 row_trim" >...</td>
+          <td class="data col5 row_trim" >...</td>
+          <td class="data col6 row_trim" >...</td>
+          <td class="data row_trim col_trim" >...</td>
+        </tr>
+      </tbody>
+    </table>
+    """
+    )
+
     assert result == expected

--- a/pandas/tests/io/formats/style/test_style.py
+++ b/pandas/tests/io/formats/style/test_style.py
@@ -1577,3 +1577,14 @@ def test_row_trimming_hide_index():
     assert len(ctx["body"]) == 3
     for r, val in enumerate(["3", "4", "..."]):
         assert ctx["body"][r][1]["display_value"] == val
+
+
+def test_col_trimming_hide_columns():
+    df = DataFrame([[1, 2, 3, 4, 5]])
+    with pd.option_context("styler.render.max_columns", 2):
+        ctx = df.style.hide([0, 1], axis="columns")._translate(True, True)
+
+    assert len(ctx["head"][0]) == 6  # blank, [0, 1 (hidden)], [2 ,3 (visible)], + trim
+    for c, vals in enumerate([(1, False), (2, True), (3, True), ("...", True)]):
+        assert ctx["head"][0][c + 2]["value"] == vals[0]
+        assert ctx["head"][0][c + 2]["is_visible"] == vals[1]

--- a/pandas/tests/io/formats/style/test_style.py
+++ b/pandas/tests/io/formats/style/test_style.py
@@ -1609,3 +1609,5 @@ def test_col_trimming_hide_columns():
     for c, vals in enumerate([(1, False), (2, True), (3, True), ("...", True)]):
         assert ctx["head"][0][c + 2]["value"] == vals[0]
         assert ctx["head"][0][c + 2]["is_visible"] == vals[1]
+
+    assert len(ctx["body"][0]) == 6  # index + 2 hidden + 2 visible + trimming col

--- a/pandas/tests/io/formats/style/test_style.py
+++ b/pandas/tests/io/formats/style/test_style.py
@@ -216,9 +216,6 @@ def test_render_trimming_mi():
     assert {"class": "data row_trim col_trim"}.items() <= ctx["body"][2][4].items()
     assert len(ctx["body"]) == 3  # 2 data rows + trimming row
 
-    assert len(ctx["head"][0]) == 5  # 2 indexes + 2 column headers + trimming col
-    assert {"attributes": 'colspan="2"'}.items() <= ctx["head"][0][2].items()
-
 
 def test_render_empty_mi():
     # GH 43305
@@ -1603,6 +1600,7 @@ def test_row_trimming_hide_index_mi():
 
 
 def test_col_trimming_hide_columns():
+
     df = DataFrame([[1, 2, 3, 4, 5]])
     with pd.option_context("styler.render.max_columns", 2):
         ctx = df.style.hide([0, 1], axis="columns")._translate(True, True)

--- a/pandas/tests/io/formats/style/test_style.py
+++ b/pandas/tests/io/formats/style/test_style.py
@@ -1600,7 +1600,7 @@ def test_row_trimming_hide_index_mi():
 
 
 def test_col_trimming_hide_columns():
-
+    # gh 44272
     df = DataFrame([[1, 2, 3, 4, 5]])
     with pd.option_context("styler.render.max_columns", 2):
         ctx = df.style.hide([0, 1], axis="columns")._translate(True, True)


### PR DESCRIPTION
closes #43704

Description of render trimming and maximums bug:

```
pd.options.styler.render.max_columns = 5
pd.options.styler.render.max_rows = 5
df = DataFrame(np.random.rand(10,10))
df.columns = pd.MultiIndex.from_product([[0,1,2,3,4], [0,1]])
df.index = pd.MultiIndex.from_product([[0,1,2,3,4], [0,1]])
df.index.names, df.columns.names = ["a", "b"], ["c", "d"]
df.style.hide([(0,0), (0,1), (1,0)], axis=1).hide([(0,0), (0,1), (1,0)], axis=0)
```

## Pre #44248
![Screen Shot 2021-11-01 at 19 02 48](https://user-images.githubusercontent.com/24256554/139718765-88bce097-e5f0-445f-8614-9b351d15e336.png)

## After #44248 (merged)
![Screen Shot 2021-11-01 at 19 03 47](https://user-images.githubusercontent.com/24256554/139718908-c3ce3e29-4360-4f6b-b917-192b516d8ec6.png)


## After this PR
![Screen Shot 2021-11-01 at 19 05 04](https://user-images.githubusercontent.com/24256554/139719076-16d303ed-9688-4305-9f74-04988193f4bb.png)

