### PR TITLE
BUG: Add fix for hashing timestamps with folds

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -712,6 +712,7 @@ Datetimelike
 - Bug in :class:`DateOffset`` addition with :class:`Timestamp` where ``offset.nanoseconds`` would not be included in the result (:issue:`43968`, :issue:`36589`)
 - Bug in :meth:`Timestamp.fromtimestamp` not supporting the ``tz`` argument (:issue:`45083`)
 - Bug in :class:`DataFrame` construction from dict of :class:`Series` with mismatched index dtypes sometimes raising depending on the ordering of the passed dict (:issue:`44091`)
+- Bug in :class:`Timestamp` hashing during some DST transitions caused a segmentation fault (:issue:`33931`)
 -
 
 Timedelta

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -712,7 +712,7 @@ Datetimelike
 - Bug in :class:`DateOffset`` addition with :class:`Timestamp` where ``offset.nanoseconds`` would not be included in the result (:issue:`43968`, :issue:`36589`)
 - Bug in :meth:`Timestamp.fromtimestamp` not supporting the ``tz`` argument (:issue:`45083`)
 - Bug in :class:`DataFrame` construction from dict of :class:`Series` with mismatched index dtypes sometimes raising depending on the ordering of the passed dict (:issue:`44091`)
-- Bug in :class:`Timestamp` hashing during some DST transitions caused a segmentation fault (:issue:`33931`)
+- Bug in :class:`Timestamp` hashing during some DST transitions caused a segmentation fault (:issue:`33931` and :issue:`40817`)
 -
 
 Timedelta

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -180,6 +180,8 @@ cdef class _Timestamp(ABCTimestamp):
     def __hash__(_Timestamp self):
         if self.nanosecond:
             return hash(self.value)
+        if self.fold:
+            return datetime.__hash__(self.replace(fold=0))
         return datetime.__hash__(self)
 
     def __richcmp__(_Timestamp self, object other, int op):

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -452,6 +452,33 @@ class TestTimestamp:
         stamp = Timestamp(datetime(2011, 1, 1))
         assert d[stamp] == 5
 
+    @pytest.mark.parametrize(
+        "timezone, year, month, day, hour",
+        [["America/Chicago", 2013, 11, 3, 1], ["America/Santiago", 2021, 4, 3, 23]],
+    )
+    def test_hash_timestamp_with_fold(self, timezone, year, month, day, hour):
+        # see gh-33931
+        test_timezone = gettz(timezone)
+        transition_1 = Timestamp(
+            year=year,
+            month=month,
+            day=day,
+            hour=hour,
+            minute=0,
+            fold=0,
+            tzinfo=test_timezone,
+        )
+        transition_2 = Timestamp(
+            year=year,
+            month=month,
+            day=day,
+            hour=hour,
+            minute=0,
+            fold=1,
+            tzinfo=test_timezone,
+        )
+        assert hash(transition_1) == hash(transition_2)
+
     def test_tz_conversion_freq(self, tz_naive_fixture):
         # GH25241
         with tm.assert_produces_warning(FutureWarning, match="freq"):

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -510,8 +510,10 @@ class TestTimestamp:
             .set_index("index")
             .reindex(["1", "2"])
         )
-        assert df.index.values[0] == "1"
-        assert df.index.values[1] == "2"
+        tm.assert_frame_equal(
+            df,
+            DataFrame({"index": ["1", "2"], "vals": [None, None]}).set_index("index"),
+        )
 
     def test_tz_conversion_freq(self, tz_naive_fixture):
         # GH25241

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -25,7 +25,6 @@ from pandas._libs.tslibs.timezones import (
 import pandas.util._test_decorators as td
 
 from pandas import (
-    DataFrame,
     NaT,
     Timedelta,
     Timestamp,
@@ -479,41 +478,6 @@ class TestTimestamp:
             tzinfo=test_timezone,
         )
         assert hash(transition_1) == hash(transition_2)
-
-    @pytest.mark.parametrize(
-        "timezone, year, month, day, hour",
-        [["America/Chicago", 2013, 11, 3, 1], ["America/Santiago", 2021, 4, 3, 23]],
-    )
-    def test_reindex_timestamp_with_fold(self, timezone, year, month, day, hour):
-        # see gh-40817
-        test_timezone = gettz(timezone)
-        transition_1 = Timestamp(
-            year=year,
-            month=month,
-            day=day,
-            hour=hour,
-            minute=0,
-            fold=0,
-            tzinfo=test_timezone,
-        )
-        transition_2 = Timestamp(
-            year=year,
-            month=month,
-            day=day,
-            hour=hour,
-            minute=0,
-            fold=1,
-            tzinfo=test_timezone,
-        )
-        df = (
-            DataFrame({"index": [transition_1, transition_2], "vals": ["a", "b"]})
-            .set_index("index")
-            .reindex(["1", "2"])
-        )
-        tm.assert_frame_equal(
-            df,
-            DataFrame({"index": ["1", "2"], "vals": [None, None]}).set_index("index"),
-        )
 
     def test_tz_conversion_freq(self, tz_naive_fixture):
         # GH25241

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -25,6 +25,7 @@ from pandas._libs.tslibs.timezones import (
 import pandas.util._test_decorators as td
 
 from pandas import (
+    DataFrame,
     NaT,
     Timedelta,
     Timestamp,
@@ -478,6 +479,39 @@ class TestTimestamp:
             tzinfo=test_timezone,
         )
         assert hash(transition_1) == hash(transition_2)
+
+    @pytest.mark.parametrize(
+        "timezone, year, month, day, hour",
+        [["America/Chicago", 2013, 11, 3, 1], ["America/Santiago", 2021, 4, 3, 23]],
+    )
+    def test_reindex_timestamp_with_fold(self, timezone, year, month, day, hour):
+        # see gh-40817
+        test_timezone = gettz(timezone)
+        transition_1 = Timestamp(
+            year=year,
+            month=month,
+            day=day,
+            hour=hour,
+            minute=0,
+            fold=0,
+            tzinfo=test_timezone,
+        )
+        transition_2 = Timestamp(
+            year=year,
+            month=month,
+            day=day,
+            hour=hour,
+            minute=0,
+            fold=1,
+            tzinfo=test_timezone,
+        )
+        df = (
+            DataFrame({"index": [transition_1, transition_2], "vals": ["a", "b"]})
+            .set_index("index")
+            .reindex(["1", "2"])
+        )
+        assert df.index.values[0] == "1"
+        assert df.index.values[1] == "2"
 
     def test_tz_conversion_freq(self, tz_naive_fixture):
         # GH25241

--- a/pandas/tests/tslibs/test_timezones.py
+++ b/pandas/tests/tslibs/test_timezones.py
@@ -166,24 +166,3 @@ def test_maybe_get_tz_offset_only():
 
     tz = timezones.maybe_get_tz("UTC-02:45")
     assert tz == timezone(-timedelta(hours=2, minutes=45))
-
-
-def test_hash_timestamp_with_fold():
-    # see gh-33931
-    america_chicago = dateutil.tz.gettz("America/Chicago")
-    transition_1 = Timestamp(
-        year=2013, month=11, day=3, hour=1, minute=0, tzinfo=america_chicago
-    )
-    transition_2 = Timestamp(
-        year=2013, month=11, day=3, hour=1, minute=0, fold=1, tzinfo=america_chicago
-    )
-    assert hash(transition_1) == hash(transition_2)
-
-    america_santiago = dateutil.tz.gettz("America/Santiago")
-    transition_3 = Timestamp(
-        year=2021, month=4, day=3, hour=23, minute=0, tz=america_santiago
-    )
-    transition_4 = Timestamp(
-        year=2021, month=4, day=3, hour=23, minute=0, fold=1, tz=america_santiago
-    )
-    assert hash(transition_3) == hash(transition_4)

--- a/pandas/tests/tslibs/test_timezones.py
+++ b/pandas/tests/tslibs/test_timezones.py
@@ -166,3 +166,24 @@ def test_maybe_get_tz_offset_only():
 
     tz = timezones.maybe_get_tz("UTC-02:45")
     assert tz == timezone(-timedelta(hours=2, minutes=45))
+
+
+def test_hash_timestamp_with_fold():
+    # see gh-33931
+    america_chicago = dateutil.tz.gettz("America/Chicago")
+    transition_1 = Timestamp(
+        year=2013, month=11, day=3, hour=1, minute=0, tzinfo=america_chicago
+    )
+    transition_2 = Timestamp(
+        year=2013, month=11, day=3, hour=1, minute=0, fold=1, tzinfo=america_chicago
+    )
+    assert hash(transition_1) == hash(transition_2)
+
+    america_santiago = dateutil.tz.gettz("America/Santiago")
+    transition_3 = Timestamp(
+        year=2021, month=4, day=3, hour=23, minute=0, tz=america_santiago
+    )
+    transition_4 = Timestamp(
+        year=2021, month=4, day=3, hour=23, minute=0, fold=1, tz=america_santiago
+    )
+    assert hash(transition_3) == hash(transition_4)


### PR DESCRIPTION
- [x] closes #33931, #40817
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry


Edit: 

https://github.com/pandas-dev/pandas/issues/42305#issuecomment-895218386
This comment identifies the problem as being upstream in datetime's construction of timestamps which fails during some DST changes.

The datetime hash function then being used tries to unset the fold representing the DST change, (https://github.com/python/cpython/blob/main/Lib/datetime.py#L2117). But it does this using the datetime replace function - this change fixes that problem by removing the fold prior to calling the datetime hash function using timestamp's replace function instead.