### PR TITLE
TST: use custom parametrization for consistency in base extension array tests

### DIFF
--- a/pandas/tests/extension/base/ops.py
+++ b/pandas/tests/extension/base/ops.py
@@ -162,13 +162,12 @@ class BaseComparisonOpsTests(BaseOpsUtil):
         other = pd.Series([data[0]] * len(data))
         self._compare_other(ser, data, comparison_op, other)
 
-    def test_direct_arith_with_ndframe_returns_not_implemented(
-        self, data, frame_or_series
-    ):
+    @pytest.mark.parametrize("box", [pd.Series, pd.DataFrame])
+    def test_direct_arith_with_ndframe_returns_not_implemented(self, data, box):
         # EAs should return NotImplemented for ops with Series/DataFrame
         # Pandas takes care of unboxing the series and calling the EA's op.
         other = pd.Series(data)
-        if frame_or_series is pd.DataFrame:
+        if box is pd.DataFrame:
             other = other.to_frame()
 
         if hasattr(data, "__eq__"):


### PR DESCRIPTION
Follow-up on https://github.com/pandas-dev/pandas/pull/44242, as that broke geopandas CI. This adds back the custom parametrization, which also makes it consistent with the other occurrence of this test (for a different op) which is still using this:

https://github.com/pandas-dev/pandas/blob/057c6f81b464c6bbb667d326e203ad0dbd17cbde/pandas/tests/extension/base/ops.py#L116-L127

Since this is the only occurrence of `frame_or_series` in the base extension tests, I think it's not warranted to make it a fixture. If we would rather want this, we should add it to `tests/extension/conftest.py` instead (can always be done in a follow-up).