### PR TITLE
CI: Fix import of coo_matrix after scipy dev upgrade

### DIFF
--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -1255,7 +1255,7 @@ class TestAccessor:
         A, rows, cols = ss.sparse.to_coo(
             row_levels=(0, 1), column_levels=(2, 3), sort_labels=sort_labels
         )
-        assert isinstance(A, scipy.sparse.coo.coo_matrix)
+        assert isinstance(A, scipy.sparse.coo_matrix)
         tm.assert_numpy_array_equal(A.toarray(), expected_A)
         assert rows == expected_rows
         assert cols == expected_cols


### PR DESCRIPTION
New scipy_dev renamed ``coo`` to ``_coo`` to make it private