### PR TITLE
CLN: Removed _SAFE_NAMES_WARNING in io.sql

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1817,12 +1817,6 @@ def _get_valid_sqlite_name(name):
     return '"' + uname.replace('"', '""') + '"'
 
 
-_SAFE_NAMES_WARNING = (
-    "The spaces in these column names will not be changed. "
-    "In pandas versions < 0.14, spaces were converted to underscores."
-)
-
-
 class SQLiteTable(SQLTable):
     """
     Patch the SQLTable for fallback support.
@@ -1882,11 +1876,6 @@ class SQLiteTable(SQLTable):
         statement while the rest will be CREATE INDEX statements.
         """
         column_names_and_types = self._get_column_names_and_types(self._sql_type_name)
-
-        pat = re.compile(r"\s+")
-        column_names = [col_name for col_name, _, _ in column_names_and_types]
-        if any(map(pat.search, column_names)):
-            warnings.warn(_SAFE_NAMES_WARNING, stacklevel=6)
 
         escape = _get_valid_sqlite_name
 

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1366,13 +1366,6 @@ class TestSQLiteFallbackApi(SQLiteMixIn, _TestSQLApi):
         with pytest.raises(sql.DatabaseError, match=msg):
             sql.read_sql("iris", self.conn)
 
-    def test_safe_names_warning(self):
-        # GH 6798
-        df = DataFrame([[1, 2], [3, 4]], columns=["a", "b "])  # has a space
-        # warns on create table with spaces in names
-        with tm.assert_produces_warning(UserWarning):
-            sql.to_sql(df, "test_frame3_legacy", self.conn, index=False)
-
     def test_get_schema2(self, test_frame1):
         # without providing a connection object (available for backwards comp)
         create_sql = sql.get_schema(test_frame1, "test")


### PR DESCRIPTION
- [x] closes #44295
- [x] tests passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

Please let me know if I should improve/change something. Thank you very much!