### PR TITLE
TST/COMPAT: update csv test to infer time with pyarrow>=6.0

### DIFF
--- a/pandas/compat/pyarrow.py
+++ b/pandas/compat/pyarrow.py
@@ -12,6 +12,7 @@ try:
     pa_version_under3p0 = _palv < Version("3.0.0")
     pa_version_under4p0 = _palv < Version("4.0.0")
     pa_version_under5p0 = _palv < Version("5.0.0")
+    pa_version_under6p0 = _palv < Version("6.0.0")
 except ImportError:
     pa_version_under1p0 = True
     pa_version_under2p0 = True

--- a/pandas/compat/pyarrow.py
+++ b/pandas/compat/pyarrow.py
@@ -19,3 +19,4 @@ except ImportError:
     pa_version_under3p0 = True
     pa_version_under4p0 = True
     pa_version_under5p0 = True
+    pa_version_under6p0 = True

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -26,6 +26,7 @@ from pandas.compat import (
     is_platform_windows,
     np_array_datetime64_compat,
 )
+from pandas.compat.pyarrow import pa_version_under6p0
 
 import pandas as pd
 from pandas import (
@@ -431,6 +432,11 @@ KORD,19990127 22:00:00, 21:56:00, -0.5900, 1.7100, 5.1000, 0.0000, 290.0000
         columns=["X0", "X2", "X3", "X4", "X5", "X6", "X7"],
         index=index,
     )
+    if parser.engine == "pyarrow" and not pa_version_under6p0:
+        # https://github.com/pandas-dev/pandas/issues/44231
+        # pyarrow 6.0 starts to infer time type
+        expected["X2"] = pd.to_datetime(expected["X2"]).time
+
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -435,7 +435,7 @@ KORD,19990127 22:00:00, 21:56:00, -0.5900, 1.7100, 5.1000, 0.0000, 290.0000
     if parser.engine == "pyarrow" and not pa_version_under6p0:
         # https://github.com/pandas-dev/pandas/issues/44231
         # pyarrow 6.0 starts to infer time type
-        expected["X2"] = pd.to_datetime(expected["X2"]).time
+        expected["X2"] = pd.to_datetime("1970-01-01" + expected["X2"]).time
 
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -435,7 +435,7 @@ KORD,19990127 22:00:00, 21:56:00, -0.5900, 1.7100, 5.1000, 0.0000, 290.0000
     if parser.engine == "pyarrow" and not pa_version_under6p0:
         # https://github.com/pandas-dev/pandas/issues/44231
         # pyarrow 6.0 starts to infer time type
-        expected["X2"] = pd.to_datetime("1970-01-01" + expected["X2"]).time
+        expected["X2"] = pd.to_datetime("1970-01-01" + expected["X2"]).dt.time
 
     tm.assert_frame_equal(result, expected)
 


### PR DESCRIPTION
Closes #44231