### PR TITLE
DEPR: PeriodIndex.astype(dt64)

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -400,7 +400,7 @@ Other Deprecations
 - Deprecated casting behavior when setting timezone-aware value(s) into a timezone-aware :class:`Series` or :class:`DataFrame` column when the timezones do not match. Previously this cast to object dtype. In a future version, the values being inserted will be converted to the series or column's existing timezone (:issue:`37605`)
 - Deprecated casting behavior when passing an item with mismatched-timezone to :meth:`DatetimeIndex.insert`, :meth:`DatetimeIndex.putmask`, :meth:`DatetimeIndex.where` :meth:`DatetimeIndex.fillna`, :meth:`Series.mask`, :meth:`Series.where`, :meth:`Series.fillna`, :meth:`Series.shift`, :meth:`Series.replace`, :meth:`Series.reindex` (and :class:`DataFrame` column analogues). In the past this has cast to object dtype. In a future version, these will cast the passed item to the index or series's timezone (:issue:`37605`)
 - Deprecated the 'errors' keyword argument in :meth:`Series.where`, :meth:`DataFrame.where`, :meth:`Series.mask`, and meth:`DataFrame.mask`; in a future version the argument will be removed (:issue:`44294`)
-- Deprecated :meth:`PeriodIndex.astype` to ``datetime64[ns]`` or ``DatetimeTZDtype``, use ``obj.to_timestamp(how).tz_localize(dtype.tz)`` instead (:issue:`??`)
+- Deprecated :meth:`PeriodIndex.astype` to ``datetime64[ns]`` or ``DatetimeTZDtype``, use ``obj.to_timestamp(how).tz_localize(dtype.tz)`` instead (:issue:`44398`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -400,6 +400,8 @@ Other Deprecations
 - Deprecated casting behavior when setting timezone-aware value(s) into a timezone-aware :class:`Series` or :class:`DataFrame` column when the timezones do not match. Previously this cast to object dtype. In a future version, the values being inserted will be converted to the series or column's existing timezone (:issue:`37605`)
 - Deprecated casting behavior when passing an item with mismatched-timezone to :meth:`DatetimeIndex.insert`, :meth:`DatetimeIndex.putmask`, :meth:`DatetimeIndex.where` :meth:`DatetimeIndex.fillna`, :meth:`Series.mask`, :meth:`Series.where`, :meth:`Series.fillna`, :meth:`Series.shift`, :meth:`Series.replace`, :meth:`Series.reindex` (and :class:`DataFrame` column analogues). In the past this has cast to object dtype. In a future version, these will cast the passed item to the index or series's timezone (:issue:`37605`)
 - Deprecated the 'errors' keyword argument in :meth:`Series.where`, :meth:`DataFrame.where`, :meth:`Series.mask`, and meth:`DataFrame.mask`; in a future version the argument will be removed (:issue:`44294`)
+- Deprecated :meth:`PeriodIndex.astype` to ``datetime64[ns]`` or ``DatetimeTZDtype``, use ``obj.to_timestamp(how).tz_localize(dtype.tz)`` instead (:issue:`??`)
+-
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -25,6 +25,7 @@ from pandas._typing import (
     DtypeObj,
 )
 from pandas.util._decorators import doc
+from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.common import (
     is_datetime64_any_dtype,
@@ -353,6 +354,13 @@ class PeriodIndex(DatetimeIndexOpsMixin):
 
         if is_datetime64_any_dtype(dtype):
             # 'how' is index-specific, isn't part of the EA interface.
+            warnings.warn(
+                f"Converting {type(self).__name__} to DatetimeIndex with "
+                "'astype' is deprecated and will raise in a future version. "
+                "Use `obj.to_timestamp(how).tz_localize(dtype.tz)` instead.",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
             tz = getattr(dtype, "tz", None)
             return self.to_timestamp(how=how).tz_localize(tz)
 

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -354,6 +354,7 @@ class PeriodIndex(DatetimeIndexOpsMixin):
 
         if is_datetime64_any_dtype(dtype):
             # 'how' is index-specific, isn't part of the EA interface.
+            # GH#44398 deprecate astype(dt64), matching Series behavior
             warnings.warn(
                 f"Converting {type(self).__name__} to DatetimeIndex with "
                 "'astype' is deprecated and will raise in a future version. "

--- a/pandas/tests/indexes/period/methods/test_astype.py
+++ b/pandas/tests/indexes/period/methods/test_astype.py
@@ -166,6 +166,7 @@ class TestPeriodIndexAsType:
         exp = DatetimeIndex(["2011-01-01", "2011-02-01", "2011-03-01"], tz="US/Eastern")
         msg = "Use `obj.to_timestamp"
         with tm.assert_produces_warning(FutureWarning, match=msg):
+            # GH#44398
             res = pi.astype("datetime64[ns, US/Eastern]")
         tm.assert_index_equal(res, exp)
         assert res.freq == exp.freq

--- a/pandas/tests/indexes/period/methods/test_astype.py
+++ b/pandas/tests/indexes/period/methods/test_astype.py
@@ -164,7 +164,9 @@ class TestPeriodIndexAsType:
         assert res.freq == exp.freq
 
         exp = DatetimeIndex(["2011-01-01", "2011-02-01", "2011-03-01"], tz="US/Eastern")
-        res = pi.astype("datetime64[ns, US/Eastern]")
+        msg = "Use `obj.to_timestamp"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            res = pi.astype("datetime64[ns, US/Eastern]")
         tm.assert_index_equal(res, exp)
         assert res.freq == exp.freq
 

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -332,6 +332,9 @@ class TestCommon:
         ):
             # This astype is deprecated in favor of tz_localize
             warn = FutureWarning
+        elif isinstance(index, PeriodIndex) and dtype == "datetime64[ns]":
+            # Deprecated in favor of to_timestamp
+            warn = FutureWarning
         try:
             # Some of these conversions cannot succeed so we use a try / except
             with tm.assert_produces_warning(warn):

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -333,7 +333,7 @@ class TestCommon:
             # This astype is deprecated in favor of tz_localize
             warn = FutureWarning
         elif isinstance(index, PeriodIndex) and dtype == "datetime64[ns]":
-            # Deprecated in favor of to_timestamp
+            # Deprecated in favor of to_timestamp GH#44398
             warn = FutureWarning
         try:
             # Some of these conversions cannot succeed so we use a try / except


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

Match the Series/EA behavior