### PR TITLE
CLN: Refactor extract multiindex header call

### DIFF
--- a/pandas/io/parsers/base_parser.py
+++ b/pandas/io/parsers/base_parser.py
@@ -314,14 +314,14 @@ class ParserBase:
 
     @final
     def _extract_multi_indexer_columns(
-        self, header, index_names, col_names, passed_names: bool = False
+        self, header, index_names, passed_names: bool = False
     ):
         """
         extract and return the names, index_names, col_names
         header is a list-of-lists returned from the parsers
         """
         if len(header) < 2:
-            return header[0], index_names, col_names, passed_names
+            return header[0], index_names, None, passed_names
 
         # the names are the tuples of the header that are not the index cols
         # 0 is the name of the index, assuming index_col is a list of column

--- a/pandas/io/parsers/c_parser_wrapper.py
+++ b/pandas/io/parsers/c_parser_wrapper.py
@@ -78,25 +78,18 @@ class CParserWrapper(ParserBase):
         if self._reader.header is None:
             self.names = None
         else:
-            if len(self._reader.header) > 1:
-                # we have a multi index in the columns
-                # error: Cannot determine type of 'names'
-                # error: Cannot determine type of 'index_names'
-                # error: Cannot determine type of 'col_names'
-                (
-                    self.names,  # type: ignore[has-type]
-                    self.index_names,
-                    self.col_names,
-                    passed_names,
-                ) = self._extract_multi_indexer_columns(
-                    self._reader.header,
-                    self.index_names,  # type: ignore[has-type]
-                    self.col_names,  # type: ignore[has-type]
-                    passed_names,
-                )
-            else:
-                # error: Cannot determine type of 'names'
-                self.names = list(self._reader.header[0])  # type: ignore[has-type]
+            # error: Cannot determine type of 'names'
+            # error: Cannot determine type of 'index_names'
+            (
+                self.names,  # type: ignore[has-type]
+                self.index_names,
+                self.col_names,
+                passed_names,
+            ) = self._extract_multi_indexer_columns(
+                self._reader.header,
+                self.index_names,  # type: ignore[has-type]
+                passed_names,
+            )
 
         # error: Cannot determine type of 'names'
         if self.names is None:  # type: ignore[has-type]

--- a/pandas/io/parsers/python_parser.py
+++ b/pandas/io/parsers/python_parser.py
@@ -117,24 +117,16 @@ class PythonParser(ParserBase):
 
         # Now self.columns has the set of columns that we will process.
         # The original set is stored in self.original_columns.
-        if len(self.columns) > 1:
-            # we are processing a multi index column
-            # error: Cannot determine type of 'index_names'
-            # error: Cannot determine type of 'col_names'
-            (
-                self.columns,
-                self.index_names,
-                self.col_names,
-                _,
-            ) = self._extract_multi_indexer_columns(
-                self.columns,
-                self.index_names,  # type: ignore[has-type]
-                self.col_names,  # type: ignore[has-type]
-            )
-            # Update list of original names to include all indices.
-            self.num_original_columns = len(self.columns)
-        else:
-            self.columns = self.columns[0]
+        # error: Cannot determine type of 'index_names'
+        (
+            self.columns,
+            self.index_names,
+            self.col_names,
+            _,
+        ) = self._extract_multi_indexer_columns(
+            self.columns,
+            self.index_names,  # type: ignore[has-type]
+        )
 
         # get popped off for index
         self.orig_names: list[int | str | tuple] = list(self.columns)


### PR DESCRIPTION
I am in the process of typing parts of the parser modules. I stumbled across this function. The check I have removed is performed inside the function and self.col_names is always None when inserting, so no need to pass it at all