### PR TITLE
BUG: .get_indexer_non_unique() must return an array of ints (#44084)

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -515,7 +515,7 @@ Strings
 
 Interval
 ^^^^^^^^
--
+- Bug in :meth:`IntervalIndex.get_indexer_non_unique` returning boolean mask instead of array of integers for a non unique and non monotonic index (:issue:`44084`)
 -
 
 Indexing

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -727,6 +727,8 @@ class IntervalIndex(ExtensionIndex):
                 if isinstance(locs, slice):
                     # Only needed for get_indexer_non_unique
                     locs = np.arange(locs.start, locs.stop, locs.step, dtype="intp")
+                elif not self.is_unique and not self.is_monotonic:
+                    locs = np.where(locs)[0]
                 locs = np.array(locs, ndmin=1)
             except KeyError:
                 missing.append(i)

--- a/pandas/tests/indexes/interval/test_indexing.py
+++ b/pandas/tests/indexes/interval/test_indexing.py
@@ -373,6 +373,16 @@ class TestGetIndexer:
         expected = np.array([0, 1], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
 
+    def test_get_index_non_unique_non_monotonic(self):
+        # GH#44084
+        index = IntervalIndex.from_tuples(
+            [(0.0, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 2.0)]
+        )
+
+        result, _ = index.get_indexer_non_unique([Interval(1.0, 2.0)])
+        expected = np.array([1, 3])
+        tm.assert_numpy_array_equal(result, expected)
+
 
 class TestSliceLocs:
     def test_slice_locs_with_interval(self):

--- a/pandas/tests/indexes/interval/test_indexing.py
+++ b/pandas/tests/indexes/interval/test_indexing.py
@@ -382,7 +382,7 @@ class TestGetIndexer:
         )
 
         result, _ = index.get_indexer_non_unique([Interval(1.0, 2.0)])
-        expected = np.array([1, 3])
+        expected = np.array([1, 3], dtype=np.int64)
         tm.assert_numpy_array_equal(result, expected)
 
     def test_get_indexer_multiindex_with_intervals(self):
@@ -394,10 +394,11 @@ class TestGetIndexer:
 
         multi_index = MultiIndex.from_product([foo_index, interval_index])
 
-        chosen_interval_indexer = multi_index.get_level_values(
-            "interval"
-        ).get_indexer_for([Interval(0.0, 1.0)])
-        tm.assert_numpy_array_equal(chosen_interval_indexer, np.array([1, 4, 7]))
+        result = multi_index.get_level_values("interval").get_indexer_for(
+            [Interval(0.0, 1.0)]
+        )
+        expected = np.array([1, 4, 7], dtype=np.int64)
+        tm.assert_numpy_array_equal(result, expected)
 
 
 class TestSliceLocs:

--- a/pandas/tests/indexes/interval/test_indexing.py
+++ b/pandas/tests/indexes/interval/test_indexing.py
@@ -382,7 +382,7 @@ class TestGetIndexer:
         )
 
         result, _ = index.get_indexer_non_unique([Interval(1.0, 2.0)])
-        expected = np.array([1, 3], dtype=np.int64)
+        expected = np.array([1, 3], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
 
     def test_get_indexer_multiindex_with_intervals(self):
@@ -397,7 +397,7 @@ class TestGetIndexer:
         result = multi_index.get_level_values("interval").get_indexer_for(
             [Interval(0.0, 1.0)]
         )
-        expected = np.array([1, 4, 7], dtype=np.int64)
+        expected = np.array([1, 4, 7], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
 
 


### PR DESCRIPTION
GH#44084 boils down to the following.

According to the docs `.get_indexer_non_unique()` is supposed to return
"integers from 0 to n - 1 indicating that the index at these positions matches
the corresponding target values".  However, for an index that is non unique and
non monotonic it returns a boolean mask.  That is because it uses `.get_loc()`
which for non unique, non monotonic indexes returns a boolean mask.

This patch catches that case and converts the boolean mask from `.get_loc()`
into the corresponding array of integers if the index is not unique and not
monotonic.

- [x] closes #44084
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry
