### PR TITLE
TST: de-duplicate assert_slics_equivalent

### DIFF
--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -82,6 +82,7 @@ from pandas._testing.asserters import (  # noqa:F401
     assert_extension_array_equal,
     assert_frame_equal,
     assert_index_equal,
+    assert_indexing_slices_equivalent,
     assert_interval_array_equal,
     assert_is_sorted,
     assert_is_valid_plot_return_object,

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -1444,3 +1444,17 @@ def is_extension_array_dtype_and_needs_i8_conversion(left_dtype, right_dtype) ->
     Related to issue #37609
     """
     return is_extension_array_dtype(left_dtype) and needs_i8_conversion(right_dtype)
+
+
+def assert_indexing_slices_equivalent(ser: Series, l_slc: slice, i_slc: slice):
+    """
+    Check that ser.iloc[i_slc] matches ser.loc[l_slc] and, if applicable,
+    ser[l_slc].
+    """
+    expected = ser.iloc[i_slc]
+
+    assert_series_equal(ser.loc[l_slc], expected)
+
+    if not ser.index.is_integer():
+        # For integer indices, .loc and plain getitem are position-based.
+        assert_series_equal(ser[l_slc], expected)

--- a/pandas/tests/indexing/multiindex/test_slice.py
+++ b/pandas/tests/indexing/multiindex/test_slice.py
@@ -702,32 +702,30 @@ class TestMultiIndexSlicers:
         tm.assert_frame_equal(df, expected)
 
     def test_multiindex_label_slicing_with_negative_step(self):
-        s = Series(
+        ser = Series(
             np.arange(20), MultiIndex.from_product([list("abcde"), np.arange(4)])
         )
         SLC = pd.IndexSlice
 
-        def assert_slices_equivalent(l_slc, i_slc):
-            tm.assert_series_equal(s.loc[l_slc], s.iloc[i_slc])
-            tm.assert_series_equal(s[l_slc], s.iloc[i_slc])
+        tm.assert_indexing_slices_equivalent(ser, SLC[::-1], SLC[::-1])
 
-        assert_slices_equivalent(SLC[::-1], SLC[::-1])
+        tm.assert_indexing_slices_equivalent(ser, SLC["d"::-1], SLC[15::-1])
+        tm.assert_indexing_slices_equivalent(ser, SLC[("d",)::-1], SLC[15::-1])
 
-        assert_slices_equivalent(SLC["d"::-1], SLC[15::-1])
-        assert_slices_equivalent(SLC[("d",)::-1], SLC[15::-1])
+        tm.assert_indexing_slices_equivalent(ser, SLC[:"d":-1], SLC[:11:-1])
+        tm.assert_indexing_slices_equivalent(ser, SLC[:("d",):-1], SLC[:11:-1])
 
-        assert_slices_equivalent(SLC[:"d":-1], SLC[:11:-1])
-        assert_slices_equivalent(SLC[:("d",):-1], SLC[:11:-1])
+        tm.assert_indexing_slices_equivalent(ser, SLC["d":"b":-1], SLC[15:3:-1])
+        tm.assert_indexing_slices_equivalent(ser, SLC[("d",):"b":-1], SLC[15:3:-1])
+        tm.assert_indexing_slices_equivalent(ser, SLC["d":("b",):-1], SLC[15:3:-1])
+        tm.assert_indexing_slices_equivalent(ser, SLC[("d",):("b",):-1], SLC[15:3:-1])
+        tm.assert_indexing_slices_equivalent(ser, SLC["b":"d":-1], SLC[:0])
 
-        assert_slices_equivalent(SLC["d":"b":-1], SLC[15:3:-1])
-        assert_slices_equivalent(SLC[("d",):"b":-1], SLC[15:3:-1])
-        assert_slices_equivalent(SLC["d":("b",):-1], SLC[15:3:-1])
-        assert_slices_equivalent(SLC[("d",):("b",):-1], SLC[15:3:-1])
-        assert_slices_equivalent(SLC["b":"d":-1], SLC[:0])
-
-        assert_slices_equivalent(SLC[("c", 2)::-1], SLC[10::-1])
-        assert_slices_equivalent(SLC[:("c", 2):-1], SLC[:9:-1])
-        assert_slices_equivalent(SLC[("e", 0):("c", 2):-1], SLC[16:9:-1])
+        tm.assert_indexing_slices_equivalent(ser, SLC[("c", 2)::-1], SLC[10::-1])
+        tm.assert_indexing_slices_equivalent(ser, SLC[:("c", 2):-1], SLC[:9:-1])
+        tm.assert_indexing_slices_equivalent(
+            ser, SLC[("e", 0):("c", 2):-1], SLC[16:9:-1]
+        )
 
     def test_multiindex_slice_first_level(self):
         # GH 12697

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -709,21 +709,17 @@ class TestMisc:
     def test_str_label_slicing_with_negative_step(self):
         SLC = pd.IndexSlice
 
-        def assert_slices_equivalent(l_slc, i_slc):
-            tm.assert_series_equal(s.loc[l_slc], s.iloc[i_slc])
-
-            if not idx.is_integer:
-                # For integer indices, .loc and plain getitem are position-based.
-                tm.assert_series_equal(s[l_slc], s.iloc[i_slc])
-                tm.assert_series_equal(s.loc[l_slc], s.iloc[i_slc])
-
         for idx in [_mklbl("A", 20), np.arange(20) + 100, np.linspace(100, 150, 20)]:
             idx = Index(idx)
-            s = Series(np.arange(20), index=idx)
-            assert_slices_equivalent(SLC[idx[9] :: -1], SLC[9::-1])
-            assert_slices_equivalent(SLC[: idx[9] : -1], SLC[:8:-1])
-            assert_slices_equivalent(SLC[idx[13] : idx[9] : -1], SLC[13:8:-1])
-            assert_slices_equivalent(SLC[idx[9] : idx[13] : -1], SLC[:0])
+            ser = Series(np.arange(20), index=idx)
+            tm.assert_indexing_slices_equivalent(ser, SLC[idx[9] :: -1], SLC[9::-1])
+            tm.assert_indexing_slices_equivalent(ser, SLC[: idx[9] : -1], SLC[:8:-1])
+            tm.assert_indexing_slices_equivalent(
+                ser, SLC[idx[13] : idx[9] : -1], SLC[13:8:-1]
+            )
+            tm.assert_indexing_slices_equivalent(
+                ser, SLC[idx[9] : idx[13] : -1], SLC[:0]
+            )
 
     def test_slice_with_zero_step_raises(self, indexer_sl, frame_or_series):
         obj = frame_or_series(np.arange(20), index=_mklbl("A", 20))

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -338,26 +338,19 @@ def test_slice_with_zero_step_raises(index, frame_or_series, indexer_sli):
     ],
 )
 def test_slice_with_negative_step(index):
-    def assert_slices_equivalent(l_slc, i_slc):
-        expected = ts.iloc[i_slc]
-
-        tm.assert_series_equal(ts[l_slc], expected)
-        tm.assert_series_equal(ts.loc[l_slc], expected)
-
     keystr1 = str(index[9])
     keystr2 = str(index[13])
-    box = type(index[0])
 
-    ts = Series(np.arange(20), index)
+    ser = Series(np.arange(20), index)
     SLC = IndexSlice
 
-    for key in [keystr1, box(keystr1)]:
-        assert_slices_equivalent(SLC[key::-1], SLC[9::-1])
-        assert_slices_equivalent(SLC[:key:-1], SLC[:8:-1])
+    for key in [keystr1, index[9]]:
+        tm.assert_indexing_slices_equivalent(ser, SLC[key::-1], SLC[9::-1])
+        tm.assert_indexing_slices_equivalent(ser, SLC[:key:-1], SLC[:8:-1])
 
-        for key2 in [keystr2, box(keystr2)]:
-            assert_slices_equivalent(SLC[key2:key:-1], SLC[13:8:-1])
-            assert_slices_equivalent(SLC[key:key2:-1], SLC[0:0:-1])
+        for key2 in [keystr2, index[13]]:
+            tm.assert_indexing_slices_equivalent(ser, SLC[key2:key:-1], SLC[13:8:-1])
+            tm.assert_indexing_slices_equivalent(ser, SLC[key:key2:-1], SLC[0:0:-1])
 
 
 def test_tuple_index():


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

Also fixes one of the usages that uses `.is_integer` instead of `.is_integer()`