### PR TITLE
DOC: whatsnew for the improvement to warning messages

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -15,6 +15,31 @@ including other versions of pandas.
 Enhancements
 ~~~~~~~~~~~~
 
+Improved warning messages
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. _whatsnew_140.enhancements.warning_lineno:
+
+Previously, warning messages may have pointed to lines with the pandas library. Running the script ``setting_with_copy_warning.py``
+
+.. code-block:: python
+
+    import pandas as pd
+
+    df = pd.DataFrame({'a': [1, 2, 3]})
+    df[:2].loc[:, 'a'] = 5
+
+with pandas 1.3 resulted in::
+
+    .../site-packages/pandas/core/indexing.py:1951: SettingWithCopyWarning:
+    A value is trying to be set on a copy of a slice from a DataFrame.
+
+This made it difficult to determine where the warning was being generated from. Now pandas will inspect the call stack, reporting the first line outside of the pandas library that gave rise to the warning. The output of the above script is now::
+
+    setting_with_copy_warning.py:4: SettingWithCopyWarning:
+    A value is trying to be set on a copy of a slice from a DataFrame.
+
+
 .. _whatsnew_140.enhancements.numeric_index:
 
 More flexible numeric dtypes for indexes

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -20,7 +20,7 @@ Enhancements
 Improved warning messages
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Previously, warning messages may have pointed to lines with the pandas library. Running the script ``setting_with_copy_warning.py``
+Previously, warning messages may have pointed to lines within the pandas library. Running the script ``setting_with_copy_warning.py``
 
 .. code-block:: python
 

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -15,10 +15,10 @@ including other versions of pandas.
 Enhancements
 ~~~~~~~~~~~~
 
+.. _whatsnew_140.enhancements.warning_lineno:
+
 Improved warning messages
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. _whatsnew_140.enhancements.warning_lineno:
 
 Previously, warning messages may have pointed to lines with the pandas library. Running the script ``setting_with_copy_warning.py``
 


### PR DESCRIPTION
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

The use of find_stack_level is a significant improvement for users, thought it should go in the whatsnew. It appears to me that the ipython directive in sphinx will suppress any warning message, so I've just made it a literal block.

![image](https://user-images.githubusercontent.com/45562402/141593623-2ff651b4-9eb4-4bc8-8b79-0ee26a6676fb.png)

cc @phofl 

