### PR TITLE
COMPAT: Python 3.9.8

### DIFF
--- a/pandas/tests/io/parser/test_quoting.py
+++ b/pandas/tests/io/parser/test_quoting.py
@@ -24,7 +24,7 @@ pytestmark = pytest.mark.usefixtures("pyarrow_skip")
             {"quotechar": None, "quoting": csv.QUOTE_MINIMAL},
             "quotechar must be set if quoting enabled",
         ),
-        ({"quotechar": 2}, '"quotechar" must be string, not int'),
+        ({"quotechar": 2}, '"quotechar" must be string( or None)?, not int'),
     ],
 )
 def test_bad_quote_char(all_parsers, kwargs, msg):


### PR DESCRIPTION
Please see bpo 20028. https://github.com/python/cpython/pull/28705. 
This breaks our nightlies, but doesn't on regular CI. It should show up pretty soon in regular CI, once the conda-forge folks add it. 
This means unfortuanately that I have no way to test this.
Can someone with with the perms on the MacPython repo please trigger the nightlies manually to see if that fixes the builds after this? Thanks.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
