### PR TITLE
ENH: Infer inner file name of zip archive (GH39465)

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -210,6 +210,7 @@ Other enhancements
 - :meth:`read_excel` now accepts a ``decimal`` argument that allow the user to specify the decimal point when parsing string columns to numeric (:issue:`14403`)
 - :meth:`.GroupBy.mean` now supports `Numba <http://numba.pydata.org/>`_ execution with the ``engine`` keyword (:issue:`43731`)
 - :meth:`Timestamp.isoformat`, now handles the ``timespec`` argument from the base :class:``datetime`` class (:issue:`26131`)
+- :meth:`DataFrame.to_csv` and :meth:`Series.to_csv` with ``compression`` set to ``'zip'`` no longer create a zip file that contains another zip file. Instead, they try to infer the inner file name more smartly. (:issue:`39465`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -210,7 +210,6 @@ Other enhancements
 - :meth:`read_excel` now accepts a ``decimal`` argument that allow the user to specify the decimal point when parsing string columns to numeric (:issue:`14403`)
 - :meth:`.GroupBy.mean` now supports `Numba <http://numba.pydata.org/>`_ execution with the ``engine`` keyword (:issue:`43731`)
 - :meth:`Timestamp.isoformat`, now handles the ``timespec`` argument from the base :class:``datetime`` class (:issue:`26131`)
-- :meth:`DataFrame.to_csv` and :meth:`Series.to_csv` with ``compression`` set to ``'zip'`` no longer create a zip file that contains another zip file. Instead, they try to infer the inner file name more smartly. (:issue:`39465`)
 
 .. ---------------------------------------------------------------------------
 
@@ -640,7 +639,7 @@ I/O
 - Bug in :func:`read_csv` with :code:`float_precision="round_trip"` which did not skip initial/trailing whitespace (:issue:`43713`)
 - Bug in dumping/loading a :class:`DataFrame` with ``yaml.dump(frame)`` (:issue:`42748`)
 - Bug in :func:`read_csv` raising ``ValueError`` when ``parse_dates`` was used with ``MultiIndex`` columns (:issue:`8991`)
--
+- :meth:`DataFrame.to_csv` and :meth:`Series.to_csv` with ``compression`` set to ``'zip'`` no longer create a zip file containing a file ending with ".zip". Instead, they try to infer the inner file name more smartly. (:issue:`39465`)
 
 Period
 ^^^^^^

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -805,21 +805,17 @@ class _BytesZipFile(zipfile.ZipFile, BytesIO):  # type: ignore[misc]
         # _PathLike[str]], IO[bytes]]"
         super().__init__(file, mode, **kwargs_zip)  # type: ignore[arg-type]
 
-    """
-    GH39465
-    If an explicit archive_name is not given, we still want the file _inside_ the zip
-    file _not_ to be named something.zip, because that causes massive confusion.
-    """
-
     def infer_filename(self):
+        """
+        If an explicit archive_name is not given, we still want the file inside the zip
+        file not to be named something.zip, because that causes confusion (GH39465).
+        """
         if isinstance(self.filename, (os.PathLike, str)):
             filename = Path(self.filename)
             if filename.suffix == ".zip":
                 return filename.with_suffix("").name
-            else:
-                return filename.name
-        else:
-            return None
+            return filename.name
+        return None
 
     def write(self, data):
         # buffer multiple write calls, write on flush

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -805,9 +805,12 @@ class _BytesZipFile(zipfile.ZipFile, BytesIO):  # type: ignore[misc]
         # _PathLike[str]], IO[bytes]]"
         super().__init__(file, mode, **kwargs_zip)  # type: ignore[arg-type]
 
-    # GH39465
-    # If an explicit archive_name is not given, we still want the file _inside_ the zip
-    # file _not_ to be named something.zip, because that causes massive confusion.
+    """
+    GH39465
+    If an explicit archive_name is not given, we still want the file _inside_ the zip
+    file _not_ to be named something.zip, because that causes massive confusion.
+    """
+
     def infer_filename(self):
         if isinstance(self.filename, (os.PathLike, str)):
             filename = Path(self.filename)

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -556,13 +556,22 @@ z
                 archived_file = zp.filelist[0].filename
                 assert archived_file == archive_name
 
-    @pytest.mark.parametrize("compression", ["zip", "infer"])
-    def test_to_csv_zip_infer_name(self, compression):
+    @pytest.mark.parametrize(
+        "filename,expected_arcname",
+        [
+            ("archive.csv", "archive.csv"),
+            ("archive.tsv", "archive.tsv"),
+            ("archive.csv.zip", "archive.csv"),
+            ("archive.tsv.zip", "archive.tsv"),
+            ("archive.zip", "archive"),
+        ],
+    )
+    def test_to_csv_zip_infer_name(self, filename, expected_arcname):
         # GH 39465
         df = DataFrame({"ABC": [1]})
-        with tm.ensure_clean("archive.csv.zip") as path:
-            df.to_csv(path, compression=compression)
-            expected_arcname = Path(path).with_suffix("").name
+        with tm.ensure_clean_dir() as dir:
+            path = Path(dir, filename)
+            df.to_csv(path, compression="zip")
             with ZipFile(path) as zp:
                 assert len(zp.filelist) == 1
                 archived_file = zp.filelist[0].filename

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -1,6 +1,8 @@
 import io
 import os
+from pathlib import Path
 import sys
+from zipfile import ZipFile
 
 import numpy as np
 import pytest
@@ -541,23 +543,29 @@ z
                 df.to_csv(path, compression=compression)
 
     @pytest.mark.parametrize("compression", ["zip", "infer"])
-    @pytest.mark.parametrize(
-        "archive_name", [None, "test_to_csv.csv", "test_to_csv.zip"]
-    )
+    @pytest.mark.parametrize("archive_name", ["test_to_csv.csv", "test_to_csv.zip"])
     def test_to_csv_zip_arguments(self, compression, archive_name):
         # GH 26023
-        from zipfile import ZipFile
-
         df = DataFrame({"ABC": [1]})
         with tm.ensure_clean("to_csv_archive_name.zip") as path:
             df.to_csv(
                 path, compression={"method": compression, "archive_name": archive_name}
             )
             with ZipFile(path) as zp:
-                expected_arcname = path if archive_name is None else archive_name
-                expected_arcname = os.path.basename(expected_arcname)
                 assert len(zp.filelist) == 1
-                archived_file = os.path.basename(zp.filelist[0].filename)
+                archived_file = zp.filelist[0].filename
+                assert archived_file == archive_name
+
+    @pytest.mark.parametrize("compression", ["zip", "infer"])
+    def test_to_csv_zip_infer_name(self, compression):
+        # GH 39465
+        df = DataFrame({"ABC": [1]})
+        with tm.ensure_clean("archive.csv.zip") as path:
+            df.to_csv(path, compression=compression)
+            expected_arcname = Path(path).with_suffix("").name
+            with ZipFile(path) as zp:
+                assert len(zp.filelist) == 1
+                archived_file = zp.filelist[0].filename
                 assert archived_file == expected_arcname
 
     @pytest.mark.parametrize("df_new_type", ["Int64"])


### PR DESCRIPTION
relevant for `DataFrame.to_csv` and `Series.to_csv` with `compression='zip'`

- [x] closes #39465
  - also relevant for #26023
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

This fix is similar-in-spirit to #40387, which has been abandoned.


## Before / After
```py
from pandas import pd

df = pd.DataFrame()
df.to_csv('../test.csv.zip')
```

### Before
```
> unzip -l test.csv.zip

Archive:  test.csv.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
        3  2021-11-14 13:39   ../test.csv.zip
---------                     -------
        3                     1 file
```
Notice the `..` in the path - bad! And, of course, that the file _inside_ the zip file is also called `test.csv.zip`.

### After
```
> unzip -l test.csv.zip

Archive:  test.csv.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
        3  2021-11-14 13:44   test.csv
---------                     -------
        3                     1 file
```