### PR TITLE
Added "." on to check_dtype and obj parameter

### DIFF
--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -540,7 +540,7 @@ def assert_categorical_equal(
     left : Categorical
     right : Categorical
     check_dtype : bool, default True
-        Check that integer dtype of the codes are the same
+        Check that integer dtype of the codes are the same.
     check_category_order : bool, default True
         Whether the order of the categories should be compared, which
         implies identical integer codes.  If False, only the resulting
@@ -548,7 +548,7 @@ def assert_categorical_equal(
         checked regardless.
     obj : str, default 'Categorical'
         Specify object name being compared, internally used to show appropriate
-        assertion message
+        assertion message.
     """
     _check_isinstance(left, right, Categorical)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10563,13 +10563,13 @@ NaN 12.3   33.0
 
         When ``values`` is a Series or DataFrame the index and column must
         match. Note that 'falcon' does not match based on the number of legs
-        in other.
+        in df2.
 
-        >>> other = pd.DataFrame({'num_legs': [8, 3], 'num_wings': [0, 2]},
+        >>> other = pd.DataFrame({'num_legs': [8, 2], 'num_wings': [0, 2]},
         ...                      index=['spider', 'falcon'])
         >>> df.isin(other)
                 num_legs  num_wings
-        falcon     False       True
+        falcon      True       True
         dog        False      False
         """
         if isinstance(values, dict):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10563,13 +10563,13 @@ NaN 12.3   33.0
 
         When ``values`` is a Series or DataFrame the index and column must
         match. Note that 'falcon' does not match based on the number of legs
-        in df2.
+        in other.
 
-        >>> other = pd.DataFrame({'num_legs': [8, 2], 'num_wings': [0, 2]},
+        >>> other = pd.DataFrame({'num_legs': [8, 3], 'num_wings': [0, 2]},
         ...                      index=['spider', 'falcon'])
         >>> df.isin(other)
                 num_legs  num_wings
-        falcon      True       True
+        falcon     False       True
         dog        False      False
         """
         if isinstance(values, dict):


### PR DESCRIPTION
- [] closes #xxxx
- [] tests added / passed
- [] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [] whatsnew entry

From #28602
`pandas.testing.assert_categorical_equal: Parameter "check_dtype" description should finish with "."
pandas.testing.assert_categorical_equal: Parameter "obj" description should finish with "."`