### PR TITLE
DOC: Remove use of as_type for PeriodIndex to DatetimeIndex conversion

### DIFF
--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -2073,14 +2073,18 @@ The ``period`` dtype can be used in ``.astype(...)``. It allows one to change th
    # change monthly freq to daily freq
    pi.astype("period[D]")
 
-   # convert to DatetimeIndex
-   pi.astype("datetime64[ns]")
-
    # convert to PeriodIndex
    dti = pd.date_range("2011-01-01", freq="M", periods=3)
    dti
    dti.astype("period[M]")
 
+.. deprecated:: 1.4.0
+    Converting PeriodIndex to DatetimeIndex with ``.astype(...)`` is deprecated and will raise in a future version. Use ``obj.to_timestamp(how).tz_localize(dtype.tz)`` instead.
+
+.. ipython:: python
+
+    # convert to DatetimeIndex
+    pi.to_timestamp(how="start")
 
 PeriodIndex partial string indexing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

Followup to #44398. Should get docs build to green. cc @jbrockmendel 

![image](https://user-images.githubusercontent.com/45562402/141684919-f8e79f49-a2c8-4001-bd2d-13849e5c0b41.png)

