### PR TITLE
DataFrame.rename renames wrong elements

### DIFF
--- a/pandas/tests/frame/methods/test_rename.py
+++ b/pandas/tests/frame/methods/test_rename.py
@@ -406,3 +406,14 @@ class TestRename:
             ],
         ).set_index(["STK_ID", "RPT_Date"], drop=False)
         tm.assert_frame_equal(result, expected)
+
+    def test_rename_boolean_index(self):
+        df = DataFrame(np.arange(15).reshape(3, 5), columns=[False, True, 2, 3, 4])
+        mapper = {0: "foo", 1: "bar", 2: "bah"}
+        res = df.rename(index=mapper)
+        exp = DataFrame(
+            np.arange(15).reshape(3, 5),
+            columns=[False, True, 2, 3, 4],
+            index=["foo", "bar", "bah"],
+        )
+        tm.assert_frame_equal(res, exp)


### PR DESCRIPTION
- [x] closes #4980
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
