### PR TITLE
BUG: fix timedelta floordiv with scalar float

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -543,7 +543,7 @@ Datetimelike
 Timedelta
 ^^^^^^^^^
 - Bug in division of all-``NaT`` :class:`TimeDeltaIndex`, :class:`Series` or :class:`DataFrame` column with object-dtype arraylike of numbers failing to infer the result as timedelta64-dtype (:issue:`39750`)
--
+- Bug in floor division of ``timedelta64[ns]`` data with a scalar returning garbage values (:issue:`44466`)
 
 Timezones
 ^^^^^^^^^

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -635,7 +635,7 @@ class TimedeltaArray(dtl.TimelikeOps):
 
     @unpack_zerodim_and_defer("__floordiv__")
     def __floordiv__(self, other):
-
+        # breakpoint()
         if is_scalar(other):
             if isinstance(other, self._recognized_scalars):
                 other = Timedelta(other)
@@ -651,8 +651,7 @@ class TimedeltaArray(dtl.TimelikeOps):
 
             # at this point we should only have numeric scalars; anything
             #  else will raise
-            result = self.asi8 // other
-            np.putmask(result, self._isnan, iNaT)
+            result = self._ndarray / other
             freq = None
             if self.freq is not None:
                 # Note: freq gets division, not floor-division
@@ -661,7 +660,7 @@ class TimedeltaArray(dtl.TimelikeOps):
                     # e.g. if self.freq is Nano(1) then dividing by 2
                     #  rounds down to zero
                     freq = None
-            return type(self)(result.view("m8[ns]"), freq=freq)
+            return type(self)(result, freq=freq)
 
         if not hasattr(other, "dtype"):
             # list, tuple

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -635,7 +635,7 @@ class TimedeltaArray(dtl.TimelikeOps):
 
     @unpack_zerodim_and_defer("__floordiv__")
     def __floordiv__(self, other):
-        # breakpoint()
+
         if is_scalar(other):
             if isinstance(other, self._recognized_scalars):
                 other = Timedelta(other)

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -1987,6 +1987,20 @@ class TestTimedeltaArraylikeMulDivOps:
         with pytest.raises(TypeError, match="Cannot divide"):
             two / tdser
 
+    @pytest.mark.parametrize("two", [2, 2.0, np.array(2), np.array(2.0)])
+    def test_td64arr_floordiv_numeric_scalar(self, box_with_array, two):
+        tdser = Series(["59 Days", "59 Days", "NaT"], dtype="m8[ns]")
+        expected = Series(["29.5D", "29.5D", "NaT"], dtype="timedelta64[ns]")
+
+        tdser = tm.box_expected(tdser, box_with_array)
+        expected = tm.box_expected(expected, box_with_array)
+
+        result = tdser // two
+        tm.assert_equal(result, expected)
+
+        with pytest.raises(TypeError, match="Cannot divide"):
+            two // tdser
+
     @pytest.mark.parametrize(
         "vector",
         [np.array([20, 30, 40]), pd.Index([20, 30, 40]), Series([20, 30, 40])],


### PR DESCRIPTION
Discovered while trying to fix test failures in https://github.com/pandas-dev/pandas/pull/40482. Currently normal division with a float scalar works, but floordiv doesn't (returns garbage):

```
In [42]: arr = pd.timedelta_range(0, periods=3)

In [43]: pd.Series(arr) / 2.0
Out[43]: 
0   0 days 00:00:00
1   0 days 12:00:00
2   1 days 00:00:00
dtype: timedelta64[ns]

In [44]: pd.Series(arr) // 2.0
Out[44]: 
0                 0 days 00:00:00
1   55681 days 08:53:22.404319232
2   55733 days 11:53:22.031689728
dtype: timedelta64[ns]

In [45]: pd.__version__
Out[45]: '1.3.3'
```

It's only the scalar case; dividing with eg float array already works:

```
In [46]: pd.Series(arr) // np.array([2.0]*3)
Out[46]: 
0   0 days 00:00:00
1   0 days 12:00:00
2   1 days 00:00:00
dtype: timedelta64[ns]
```

I suppose the current code uses the workaround of `asi8` and casting back to timedelta, because numpy didn't support floordiv in the past (didn't check which version started to implement this, will see what CI says)

- [ ] whatsnew entry
