### PR TITLE
Backport PR #44452: Revert "CI: xfail tests failing on numpy dev"

### DIFF
--- a/pandas/tests/window/moments/test_moments_rolling.py
+++ b/pandas/tests/window/moments/test_moments_rolling.py
@@ -558,7 +558,6 @@ def test_rolling_quantile_np_percentile():
     tm.assert_almost_equal(df_quantile.values, np.array(np_percentile))
 
 
-@pytest.mark.xfail(reason="GH#44343", strict=False)
 @pytest.mark.parametrize("quantile", [0.0, 0.1, 0.45, 0.5, 1])
 @pytest.mark.parametrize(
     "interpolation", ["linear", "lower", "higher", "nearest", "midpoint"]


### PR DESCRIPTION
Backport PR #44452