### PR TITLE
BUG: fix timedelta floordiv with scalar float (correction of #44466)

### DIFF
--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -651,7 +651,7 @@ class TimedeltaArray(dtl.TimelikeOps):
 
             # at this point we should only have numeric scalars; anything
             #  else will raise
-            result = self._ndarray / other
+            result = self._ndarray // other
             freq = None
             if self.freq is not None:
                 # Note: freq gets division, not floor-division


### PR DESCRIPTION
Follow-up on https://github.com/pandas-dev/pandas/pull/44466#discussion_r749430496

I still need to add a test that would actually catch this