### PR TITLE
BUG: inconsistent behaviour when grouping a populated dataframe and a…

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -989,10 +989,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
     ):
 
         if len(values) == 0:
-            result = self.obj._constructor(
-                index=self.grouper.result_index, columns=data.columns
-            )
-            result = result.astype(data.dtypes, copy=False)
+            result = self.obj._constructor(index=self.grouper.result_index, columns=[])
             return result
 
         # GH12824

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -12,6 +12,7 @@ from pandas import (
     DataFrame,
     Index,
     MultiIndex,
+    RangeIndex,
     Series,
     bdate_range,
 )
@@ -1178,3 +1179,22 @@ def test_apply_empty_string_nan_coerce_bug():
         index=MultiIndex.from_tuples([(1, ""), (2, "")], names=["a", "b"]),
     )
     tm.assert_frame_equal(result, expected)
+
+
+class Test:
+    @pytest.mark.parametrize(
+        "obj, exp",
+        [
+            (
+                DataFrame(data={"f1": [1, 2], "f2": [3, 4], "f3": [5, 6]}),
+                DataFrame(data={"f1": [1, 2], 0: [1, 1]}),
+            ),
+            (
+                DataFrame(columns=["f1", "f2", "f3"]),
+                DataFrame(index=RangeIndex(start=0, stop=0, step=1), columns=["f1"]),
+            ),
+        ],
+    )
+    def test_apply_empty_frame(self, obj, exp):
+        res = obj.groupby("f1").apply(lambda x: x.loc[:, "f2"].nunique()).reset_index()
+        tm.assert_frame_equal(exp, res)


### PR DESCRIPTION
…n empty dataframe in terms of index naming

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
