### PR TITLE
BUG: Tick + np.timedelta64

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -538,7 +538,7 @@ Datetimelike
 - Bug in inplace addition and subtraction of :class:`DatetimeIndex` or :class:`TimedeltaIndex` with :class:`DatetimeArray` or :class:`TimedeltaArray` (:issue:`43904`)
 - Bug in in calling ``np.isnan``, ``np.isfinite``, or ``np.isinf`` on a timezone-aware :class:`DatetimeIndex` incorrectly raising ``TypeError`` (:issue:`43917`)
 - Bug in constructing a :class:`Series` from datetime-like strings with mixed timezones incorrectly partially-inferring datetime values (:issue:`40111`)
--
+- Bug in addition with a :class:`Tick` object and a ``np.timedelta64`` object incorrectly raising instead of returning :class:`Timedelta` (:issue:`44474`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/tests/tseries/offsets/test_business_day.py
+++ b/pandas/tests/tseries/offsets/test_business_day.py
@@ -7,6 +7,7 @@ from datetime import (
     timedelta,
 )
 
+import numpy as np
 import pytest
 
 from pandas._libs.tslibs.offsets import (
@@ -17,6 +18,7 @@ from pandas._libs.tslibs.offsets import (
 
 from pandas import (
     DatetimeIndex,
+    Timedelta,
     _testing as tm,
 )
 from pandas.tests.tseries.offsets.common import (
@@ -57,11 +59,30 @@ class TestBusinessDay(Base):
 
         assert (self.d + offset) == datetime(2008, 1, 2, 2)
 
-    def test_with_offset_index(self):
-        dti = DatetimeIndex([self.d])
-        result = dti + (self.offset + timedelta(hours=2))
+    @pytest.mark.parametrize("reverse", [True, False])
+    @pytest.mark.parametrize(
+        "td",
+        [
+            Timedelta(hours=2),
+            Timedelta(hours=2).to_pytimedelta(),
+            Timedelta(hours=2).to_timedelta64(),
+        ],
+        ids=lambda x: type(x),
+    )
+    def test_with_offset_index(self, reverse, td, request):
+        if reverse and isinstance(td, np.timedelta64):
+            mark = pytest.mark.xfail(
+                reason="need __array_priority__, but that causes other errors"
+            )
+            request.node.add_marker(mark)
 
+        dti = DatetimeIndex([self.d])
         expected = DatetimeIndex([datetime(2008, 1, 2, 2)])
+
+        if reverse:
+            result = dti + (td + self.offset)
+        else:
+            result = dti + (self.offset + td)
         tm.assert_index_equal(result, expected)
 
     def test_eq(self):

--- a/pandas/tests/tseries/offsets/test_custom_business_day.py
+++ b/pandas/tests/tseries/offsets/test_custom_business_day.py
@@ -19,6 +19,7 @@ from pandas.compat import np_datetime64_compat
 
 from pandas import (
     DatetimeIndex,
+    Timedelta,
     _testing as tm,
     read_pickle,
 )
@@ -62,11 +63,30 @@ class TestCustomBusinessDay(Base):
 
         assert (self.d + offset) == datetime(2008, 1, 2, 2)
 
-    def test_with_offset_index(self):
-        dti = DatetimeIndex([self.d])
-        result = dti + (self.offset + timedelta(hours=2))
+    @pytest.mark.parametrize("reverse", [True, False])
+    @pytest.mark.parametrize(
+        "td",
+        [
+            Timedelta(hours=2),
+            Timedelta(hours=2).to_pytimedelta(),
+            Timedelta(hours=2).to_timedelta64(),
+        ],
+        ids=lambda x: type(x),
+    )
+    def test_with_offset_index(self, reverse, td, request):
+        if reverse and isinstance(td, np.timedelta64):
+            mark = pytest.mark.xfail(
+                reason="need __array_priority__, but that causes other errors"
+            )
+            request.node.add_marker(mark)
 
+        dti = DatetimeIndex([self.d])
         expected = DatetimeIndex([datetime(2008, 1, 2, 2)])
+
+        if reverse:
+            result = dti + (td + self.offset)
+        else:
+            result = dti + (self.offset + td)
         tm.assert_index_equal(result, expected)
 
     def test_eq(self):

--- a/pandas/tests/tseries/offsets/test_ticks.py
+++ b/pandas/tests/tseries/offsets/test_ticks.py
@@ -230,9 +230,16 @@ def test_Nanosecond():
 )
 def test_tick_addition(kls, expected):
     offset = kls(3)
-    result = offset + Timedelta(hours=2)
-    assert isinstance(result, Timedelta)
-    assert result == expected
+    td = Timedelta(hours=2)
+
+    for other in [td, td.to_pytimedelta(), td.to_timedelta64()]:
+        result = offset + other
+        assert isinstance(result, Timedelta)
+        assert result == expected
+
+        result = other + offset
+        assert isinstance(result, Timedelta)
+        assert result == expected
 
 
 @pytest.mark.parametrize("cls", tick_classes)


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

Looks like a pass to de-duplicate the test_business_day and test_custom_business_day files would be worthwhile