### PR TITLE
avoid a warning by PyTypeChecker

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -22,7 +22,7 @@ from typing import (
     cast,
     final,
     overload,
-)
+),Union
 import warnings
 import weakref
 
@@ -3337,7 +3337,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     @doc(storage_options=_shared_docs["storage_options"])
     def to_csv(
         self,
-        path_or_buf: FilePathOrBuffer[AnyStr] | None = None,
+        path_or_buf: Union[FilePathOrBuffer[AnyStr],None] = None,
         sep: str = ",",
         na_rep: str = "",
         float_format: str | None = None,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -22,7 +22,7 @@ from typing import (
     cast,
     final,
     overload,
-),Union
+), Union
 import warnings
 import weakref
 
@@ -3337,7 +3337,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     @doc(storage_options=_shared_docs["storage_options"])
     def to_csv(
         self,
-        path_or_buf: Union[FilePathOrBuffer[AnyStr],None] = None,
+        path_or_buf: Union[FilePathOrBuffer[AnyStr], None] = None,
         sep: str = ",",
         na_rep: str = "",
         float_format: str | None = None,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -22,7 +22,8 @@ from typing import (
     cast,
     final,
     overload,
-), Union
+    Union,
+)
 import warnings
 import weakref
 


### PR DESCRIPTION
NDFrame.to_csv(str) got a warning by PyTypeChecker, "Expected type 'None', got 'str' instead"
use typing.Union to combine type "FilePathOrBuffer[AnyStr]" and "None", instead of " | " can avoid it.
![image](https://user-images.githubusercontent.com/24448028/141879473-56355ca2-60de-4405-94a3-fdc3013cf5a7.png)

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
