### PR TITLE
BUG: fix get_indexer_non_unique() with 'object' targets with NaNs (#4…

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -592,8 +592,8 @@ Strings
 
 Interval
 ^^^^^^^^
-- Bug in :meth:`IntervalIndex.get_indexer_non_unique` returning boolean mask instead of array of integers for a non unique and non monotonic index (:issue:`44084`)
 - Bug in :meth:`Series.where` with ``IntervalDtype`` incorrectly raising when the ``where`` call should not replace anything (:issue:`44181`)
+-
 -
 
 Indexing
@@ -625,6 +625,8 @@ Indexing
 - Bug in :meth:`DataFrame.loc.__setitem__` and :meth:`DataFrame.iloc.__setitem__` with mixed dtypes sometimes failing to operate in-place (:issue:`44345`)
 - Bug in :meth:`DataFrame.loc.__getitem__` incorrectly raising ``KeyError`` when selecting a single column with a boolean key (:issue:`44322`).
 - Bug in indexing on columns with ``loc`` or ``iloc`` using a slice with a negative step with ``ExtensionDtype`` columns incorrectly raising (:issue:`44551`)
+- Bug in :meth:`IntervalIndex.get_indexer_non_unique` returning boolean mask instead of array of integers for a non unique and non monotonic index (:issue:`44084`)
+- Bug in :meth:`IntervalIndex.get_indexer_non_unique` not handling targets of ``dtype`` 'object' with NaNs correctly (:issue:`44482`)
 -
 
 Missing

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -338,7 +338,12 @@ cdef class IndexEngine:
         missing = np.empty(n_t, dtype=np.intp)
 
         # map each starget to its position in the index
-        if stargets and len(stargets) < 5 and self.is_monotonic_increasing:
+        if (
+                stargets and
+                len(stargets) < 5 and
+                not any([checknull(t) for t in stargets]) and
+                self.is_monotonic_increasing
+        ):
             # if there are few enough stargets and the index is monotonically
             # increasing, then use binary search for each starget
             remaining_stargets = set()

--- a/pandas/tests/indexes/test_indexing.py
+++ b/pandas/tests/indexes/test_indexing.py
@@ -332,3 +332,12 @@ def test_get_indexer_non_unique_multiple_nans(idx, target, expected):
     axis = Index(idx)
     actual = axis.get_indexer_for(target)
     tm.assert_numpy_array_equal(actual, expected)
+
+
+def test_get_indexer_non_unique_nans_in_object_dtype_target(nulls_fixture):
+    idx = Index([1.0, 2.0])
+    target = Index([1, nulls_fixture], dtype="object")
+
+    result_idx, result_missing = idx.get_indexer_non_unique(target)
+    tm.assert_numpy_array_equal(result_idx, np.array([0, -1], dtype=np.intp))
+    tm.assert_numpy_array_equal(result_missing, np.array([1], dtype=np.intp))


### PR DESCRIPTION
…4482)

numpy.searchsorted() does not handle NaNs in 'object' arrays as
expected (numpy/numpy#15499).  Therefore we cannot search NaNs using binary
search.  So we use binary search only for targets without NaNs.

- [x] closes #44482 
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

This does also put the whatsnew of #44404 to the correct place.