### PR TITLE
TYP/CI: fix to_string overload

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1069,7 +1069,7 @@ class DataFrame(NDFrame, OpsMixin):
     @overload
     def to_string(
         self,
-        buf: FilePathOrBuffer[str],
+        buf: FilePath | WriteBuffer[str],
         columns: Sequence[str] | None = ...,
         col_space: int | list[int] | dict[Hashable, int] | None = ...,
         header: bool | Sequence[str] = ...,


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/44426#issuecomment-972699248