### PR TITLE
TYP: changed variable from vals to array_vals in pandas/core/indexes/multi.py

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3118,11 +3118,15 @@ class MultiIndex(Index):
                 mapper = Series(indexer)
                 indexer = codes.take(ensure_platform_int(indexer))
                 result = Series(Index(indexer).isin(r).nonzero()[0])
-                mapped_result = result.map(mapper)
-                m = np.asarray(mapped_result)
+                m = result.map(mapper)
+                # error: Incompatible types in assignment (expression has type
+                # "ndarray", variable has type "Series")
+                m = np.asarray(m)  # type: ignore[assignment]
 
             else:
-                m = np.zeros(len(codes), dtype=bool)
+                # error: Incompatible types in assignment (expression has type
+                # "ndarray", variable has type "Series")
+                m = np.zeros(len(codes), dtype=bool)  # type: ignore[assignment]
                 m[np.in1d(codes, r, assume_unique=Index(codes).is_unique)] = True
 
             return m

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3118,15 +3118,11 @@ class MultiIndex(Index):
                 mapper = Series(indexer)
                 indexer = codes.take(ensure_platform_int(indexer))
                 result = Series(Index(indexer).isin(r).nonzero()[0])
-                m = result.map(mapper)
-                # error: Incompatible types in assignment (expression has type
-                # "ndarray", variable has type "Series")
-                m = np.asarray(m)  # type: ignore[assignment]
+                mapped_result = result.map(mapper)
+                m = np.asarray(mapped_result)
 
             else:
-                # error: Incompatible types in assignment (expression has type
-                # "ndarray", variable has type "Series")
-                m = np.zeros(len(codes), dtype=bool)  # type: ignore[assignment]
+                m = np.zeros(len(codes), dtype=bool)
                 m[np.in1d(codes, r, assume_unique=Index(codes).is_unique)] = True
 
             return m

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -702,10 +702,8 @@ class MultiIndex(Index):
                 vals, (ABCDatetimeIndex, ABCTimedeltaIndex)
             ):
                 vals = vals.astype(object)
-            # error: Incompatible types in assignment (expression has type "ndarray",
-            # variable has type "Index")
-            vals = np.array(vals, copy=False)  # type: ignore[assignment]
-            values.append(vals)
+            array_vals = np.array(vals, copy=False)
+            values.append(array_vals)
 
         arr = lib.fast_zip(values)
         return arr


### PR DESCRIPTION
xref #37715

Changed variable name from vals to array_vals in pandas/core/index/multi.py: 705 and 706 
To remove type: ignore[assignment] mypy error

Changed variable name from m to mapped_result in pandas/core/index/multi.py: 3121
Removed type: ignore[assignment] mypy error in line 3126 and 3131