### PR TITLE
TYP: Changed variable name repeats to ensured_repeats in pandas/core/indexes/multi.py

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2158,8 +2158,6 @@ class MultiIndex(Index):
     @Appender(_index_shared_docs["repeat"] % _index_doc_kwargs)
     def repeat(self, repeats: int, axis=None) -> MultiIndex:
         nv.validate_repeat((), {"axis": axis})
-        # error: Incompatible types in assignment (expression has type "ndarray",
-        # variable has type "int")
         ensured_repeats = ensure_platform_int(repeats)
         return MultiIndex(
             levels=self.levels,

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2160,11 +2160,13 @@ class MultiIndex(Index):
         nv.validate_repeat((), {"axis": axis})
         # error: Incompatible types in assignment (expression has type "ndarray",
         # variable has type "int")
-        repeats = ensure_platform_int(repeats)  # type: ignore[assignment]
+        ensured_repeats = ensure_platform_int(repeats)
         return MultiIndex(
             levels=self.levels,
             codes=[
-                level_codes.view(np.ndarray).astype(np.intp, copy=False).repeat(repeats)
+                level_codes.view(np.ndarray)
+                .astype(np.intp, copy=False)
+                .repeat(ensured_repeats)
                 for level_codes in self.codes
             ],
             names=self.names,


### PR DESCRIPTION
xref #37715

Changed variable name `repeats` to `ensured_repeats` pandas/core/indexes/multi.py: 2161 and 2167
Removed type[ignore] assignment and mypy error comment. 

