### PR TITLE
Add json normalize back into doc and move read_json to pd namespace

### DIFF
--- a/doc/source/reference/io.rst
+++ b/doc/source/reference/io.rst
@@ -57,7 +57,7 @@ Excel
 
    ExcelWriter
 
-.. currentmodule:: pandas.io.json
+.. currentmodule:: pandas
 
 JSON
 ~~~~
@@ -65,7 +65,10 @@ JSON
    :toctree: api/
 
    read_json
-   to_json
+   json_normalize
+   DataFrame.to_json
+
+.. currentmodule:: pandas.io.json
 
 .. autosummary::
    :toctree: api/


### PR DESCRIPTION
- [x] closes #42540 

read_json looked like it had to be used like pandas.io.json.read_json and json_normalize was missing alltogether. Maybe backporting as well?

Edit: Build Docs locally, look fine now