### PR TITLE
BUG: Index with object dtype and negative loc for insert adding none and replacing existing value

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -546,6 +546,7 @@ Datetimelike
 - Bug in constructing a :class:`Series` from datetime-like strings with mixed timezones incorrectly partially-inferring datetime values (:issue:`40111`)
 - Bug in addition with a :class:`Tick` object and a ``np.timedelta64`` object incorrectly raising instead of returning :class:`Timedelta` (:issue:`44474`)
 - Bug in adding a ``np.timedelta64`` object to a :class:`BusinessDay` or :class:`CustomBusinessDay` object incorrectly raising (:issue:`44532`)
+- Bug in :meth:`Index.insert` for inserting ``np.datetime64``, ``np.timedelta64`` or ``tuple`` into :class:`Index` with ``dtype='object'`` with negative loc addine ``None`` and replacing existing value (:issue:`44509`)
 -
 
 Timedelta

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -1496,7 +1496,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     def insert(self: IntervalArrayT, loc: int, item: Interval) -> IntervalArrayT:
         """
         Return a new IntervalArray inserting new item at location. Follows
-        Python list.append semantics for negative values.  Only Interval
+        Python np.insert semantics for negative values.  Only Interval
         objects and NA can be inserted into an IntervalIndex
 
         Parameters

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -1496,7 +1496,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     def insert(self: IntervalArrayT, loc: int, item: Interval) -> IntervalArrayT:
         """
         Return a new IntervalArray inserting new item at location. Follows
-        Python np.insert semantics for negative values.  Only Interval
+        Python numpy.insert semantics for negative values.  Only Interval
         objects and NA can be inserted into an IntervalIndex
 
         Parameters

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6433,7 +6433,7 @@ class Index(IndexOpsMixin, PandasObject):
         """
         Make new Index inserting new item at location.
 
-        Follows Python np.insert semantics for negative values.
+        Follows Python numpy.insert semantics for negative values.
 
         Parameters
         ----------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6433,7 +6433,7 @@ class Index(IndexOpsMixin, PandasObject):
         """
         Make new Index inserting new item at location.
 
-        Follows Python list.append semantics for negative values.
+        Follows Python np.insert semantics for negative values.
 
         Parameters
         ----------
@@ -6476,6 +6476,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         else:
             new_values = np.insert(arr, loc, None)
+            loc = loc if loc >= 0 else loc - 1
             new_values[loc] = item
 
         # Use self._constructor instead of Index to retain NumericIndex GH#43921

--- a/pandas/tests/indexes/base_class/test_reshape.py
+++ b/pandas/tests/indexes/base_class/test_reshape.py
@@ -1,6 +1,7 @@
 """
 Tests for ndarray-like method on the base Index class
 """
+import numpy as np
 import pytest
 
 from pandas import Index
@@ -40,6 +41,17 @@ class TestReshape:
         # test there is no mangling of NA values
         expected = Index(["a", nulls_fixture, "b", "c"])
         result = Index(list("abc")).insert(1, nulls_fixture)
+        tm.assert_index_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "val", [(1, 2), np.datetime64("2019-12-31"), np.timedelta64(1, "D")]
+    )
+    @pytest.mark.parametrize("loc", [-1, 2])
+    def test_insert_datetime_into_object(self, loc, val):
+        # GH#44509
+        idx = Index(["1", "2", "3"])
+        result = idx.insert(loc, val)
+        expected = Index(["1", "2", val, "3"])
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize(

--- a/pandas/tests/indexes/base_class/test_reshape.py
+++ b/pandas/tests/indexes/base_class/test_reshape.py
@@ -53,6 +53,7 @@ class TestReshape:
         result = idx.insert(loc, val)
         expected = Index(["1", "2", val, "3"])
         tm.assert_index_equal(result, expected)
+        assert type(expected[2]) is type(val)
 
     @pytest.mark.parametrize(
         "pos,expected",


### PR DESCRIPTION
- [x] closes #44509
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

This behaves like np.insert, so changed the docstring. Making this compatible with list.insert would be a breaking change

Nevertheless the else block in the base implementation had a bug, so fixed that one too
