### PR TITLE
TST: Use hypothesis for test_round_sanity

### DIFF
--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -1,6 +1,10 @@
 """ test the scalar Timedelta """
 from datetime import timedelta
 
+from hypothesis import (
+    given,
+    strategies as st,
+)
 import numpy as np
 import pytest
 
@@ -394,12 +398,12 @@ class TestTimedeltas:
         with pytest.raises(OverflowError, match=msg):
             Timedelta.max.ceil("s")
 
-    @pytest.mark.parametrize("n", range(100))
+    @given(val=st.integers(min_value=iNaT + 1, max_value=lib.i8max))
     @pytest.mark.parametrize(
         "method", [Timedelta.round, Timedelta.floor, Timedelta.ceil]
     )
-    def test_round_sanity(self, method, n, request):
-        val = np.random.randint(iNaT + 1, lib.i8max, dtype=np.int64)
+    def test_round_sanity(self, val, method):
+        val = np.int64(val)
         td = Timedelta(val)
 
         assert method(td, "ns") == td

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -1,6 +1,10 @@
 from datetime import datetime
 
 from dateutil.tz import gettz
+from hypothesis import (
+    given,
+    strategies as st,
+)
 import numpy as np
 import pytest
 import pytz
@@ -276,12 +280,12 @@ class TestTimestampUnaryOps:
         with pytest.raises(OverflowError, match=msg):
             Timestamp.max.ceil("s")
 
-    @pytest.mark.parametrize("n", range(100))
+    @given(val=st.integers(iNaT + 1, lib.i8max))
     @pytest.mark.parametrize(
         "method", [Timestamp.round, Timestamp.floor, Timestamp.ceil]
     )
-    def test_round_sanity(self, method, n):
-        val = np.random.randint(iNaT + 1, lib.i8max, dtype=np.int64)
+    def test_round_sanity(self, val, method):
+        val = np.int64(val)
         ts = Timestamp(val)
 
         def checker(res, ts, nanos):


### PR DESCRIPTION
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

Found this test was flaky in https://github.com/pandas-dev/pandas/runs/4275006116?check_suite_focus=true#step:7:51

Decided to parameterize the value instead of `n` so it appears in the logs and used `hypothesis` instead of 100 random values.
