### PR TITLE
TST: Avoid time dependency in GCS zip test

### DIFF
--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -1,5 +1,6 @@
 from io import BytesIO
 import os
+import zipfile
 
 import numpy as np
 import pytest
@@ -88,16 +89,22 @@ def test_to_read_gcs(gcs_buffer, format):
     tm.assert_frame_equal(df1, df2)
 
 
-def assert_equal_zip_safe(result: bytes, expected: bytes):
+def assert_equal_zip_safe(result: bytes, expected: bytes, compression: str):
     """
-    We would like to assert these are equal, but the 10th and 11th bytes are a
-    last-modified timestamp, which in some builds is off-by-one, so we check around
-    that.
+    For zip compression, only compare the CRC-32 checksum of the file contents
+    to avoid checking the time-dependent last-modified timestamp which
+    in some CI builds is off-by-one
 
     See https://en.wikipedia.org/wiki/ZIP_(file_format)#File_headers
     """
-    assert result[:9] == expected[:9]
-    assert result[11:] == expected[11:]
+    if compression == "zip":
+        # Only compare the CRC checksum of the file contents
+        res = zipfile.ZipFile(BytesIO(result))
+        exp = zipfile.ZipFile(BytesIO(expected))
+        for res_info, exp_info in zip(res.infolist(), exp.infolist()):
+            assert res_info.CRC == exp_info.CRC
+    else:
+        assert result == expected
 
 
 @td.skip_if_no("gcsfs")
@@ -126,7 +133,7 @@ def test_to_csv_compression_encoding_gcs(gcs_buffer, compression_only, encoding)
     df.to_csv(path_gcs, compression=compression, encoding=encoding)
     res = gcs_buffer.getvalue()
     expected = buffer.getvalue()
-    assert_equal_zip_safe(res, expected)
+    assert_equal_zip_safe(res, expected, compression_only)
 
     read_df = read_csv(
         path_gcs, index_col=0, compression=compression_only, encoding=encoding
@@ -142,7 +149,7 @@ def test_to_csv_compression_encoding_gcs(gcs_buffer, compression_only, encoding)
 
     res = gcs_buffer.getvalue()
     expected = buffer.getvalue()
-    assert_equal_zip_safe(res, expected)
+    assert_equal_zip_safe(res, expected, compression_only)
 
     read_df = read_csv(path_gcs, index_col=0, compression="infer", encoding=encoding)
     tm.assert_frame_equal(df, read_df)

--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -99,10 +99,11 @@ def assert_equal_zip_safe(result: bytes, expected: bytes, compression: str):
     """
     if compression == "zip":
         # Only compare the CRC checksum of the file contents
-        res = zipfile.ZipFile(BytesIO(result))
-        exp = zipfile.ZipFile(BytesIO(expected))
-        for res_info, exp_info in zip(res.infolist(), exp.infolist()):
-            assert res_info.CRC == exp_info.CRC
+        with zipfile.ZipFile(BytesIO(result)) as exp, zipfile.ZipFile(
+            BytesIO(expected)
+        ) as res:
+            for res_info, exp_info in zip(res.infolist(), exp.infolist()):
+                assert res_info.CRC == exp_info.CRC
     else:
         assert result == expected
 


### PR DESCRIPTION
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

To avoid CI flakiness from this test, only compare the checksum of the ZIP contents to avoid comparing the flaky last modified timestamp of the ZIP archive. IMO, the CI stability is worth the the trade off of being a little less strict here.

cc @jbrockmendel 
