### PR TITLE
CI: Make codecov patch checks informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,7 @@ coverage:
     patch:
       default:
         target: '50'
+        informational: true
 
 github_checks:
     annotations: false


### PR DESCRIPTION
To avoid some false positive coverage results which can make an entire PR appear that it's failing:

https://github.com/pandas-dev/pandas/pull/44546/checks?check_run_id=4275864618
https://github.com/pandas-dev/pandas/pull/44461/checks?check_run_id=4276518961

Change codecov patch builds to always pass but still report the % coverage of the PR:

https://docs.codecov.com/docs/commit-status#informational

IMO our code review process should ensure that new code has associated tests.