### PR TITLE
CI: fix deprecation warning on interpolation

### DIFF
--- a/pandas/compat/numpy/__init__.py
+++ b/pandas/compat/numpy/__init__.py
@@ -11,8 +11,14 @@ _np_version = np.__version__
 _nlv = Version(_np_version)
 np_version_under1p19 = _nlv < Version("1.19")
 np_version_under1p20 = _nlv < Version("1.20")
+np_version_under1p22 = _nlv < Version("1.22")
 is_numpy_dev = _nlv.dev is not None
 _min_numpy_ver = "1.18.5"
+
+if is_numpy_dev or not np_version_under1p22:
+    np_percentile_argname = "method"
+else:
+    np_percentile_argname = "interpolation"
 
 
 if _nlv < Version(_min_numpy_ver):

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -30,6 +30,7 @@ from pandas._typing import (
     npt,
 )
 from pandas.compat._optional import import_optional_dependency
+from pandas.compat.numpy import np_percentile_argname
 
 from pandas.core.dtypes.common import (
     is_any_int_dtype,
@@ -1694,7 +1695,7 @@ def _nanpercentile_1d(
     if len(values) == 0:
         return np.array([na_value] * len(q), dtype=values.dtype)
 
-    return np.percentile(values, q, interpolation=interpolation)
+    return np.percentile(values, q, **{np_percentile_argname: interpolation})
 
 
 def nanpercentile(
@@ -1747,7 +1748,9 @@ def nanpercentile(
         result = np.array(result, dtype=values.dtype, copy=False).T
         return result
     else:
-        return np.percentile(values, q, axis=1, interpolation=interpolation)
+        return np.percentile(
+            values, q, axis=1, **{np_percentile_argname: interpolation}
+        )
 
 
 def na_accum_func(values: ArrayLike, accum_func, *, skipna: bool) -> ArrayLike:

--- a/pandas/tests/frame/methods/test_quantile.py
+++ b/pandas/tests/frame/methods/test_quantile.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from pandas.compat.numpy import np_percentile_argname
+
 import pandas as pd
 from pandas import (
     DataFrame,
@@ -153,7 +155,10 @@ class TestDataFrameQuantile:
 
         # cross-check interpolation=nearest results in original dtype
         exp = np.percentile(
-            np.array([[1, 2, 3], [2, 3, 4]]), 0.5, axis=0, interpolation="nearest"
+            np.array([[1, 2, 3], [2, 3, 4]]),
+            0.5,
+            axis=0,
+            **{np_percentile_argname: "nearest"},
         )
         expected = Series(exp, index=[1, 2, 3], name=0.5, dtype="int64")
         tm.assert_series_equal(result, expected)
@@ -167,7 +172,7 @@ class TestDataFrameQuantile:
             np.array([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]]),
             0.5,
             axis=0,
-            interpolation="nearest",
+            **{np_percentile_argname: "nearest"},
         )
         expected = Series(exp, index=[1, 2, 3], name=0.5, dtype="float64")
         tm.assert_series_equal(result, expected)


### PR DESCRIPTION
Let's see if this fixes npdev / python dev builds