### PR TITLE
BUG: Series.where with IntervalDtype when no-op

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -587,6 +587,7 @@ Strings
 Interval
 ^^^^^^^^
 - Bug in :meth:`IntervalIndex.get_indexer_non_unique` returning boolean mask instead of array of integers for a non unique and non monotonic index (:issue:`44084`)
+- Bug in :meth:`Series.where` with ``IntervalDtype`` incorrectly raising when the ``where`` call should not replace anything (:issue:`44181`)
 -
 
 Indexing

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1632,6 +1632,10 @@ class ExtensionBlock(libinternals.Block, EABackedBlock):
             # attribute "na_value"
             other = self.dtype.na_value  # type: ignore[union-attr]
 
+        icond, noop = validate_putmask(self.values, ~cond)
+        if noop:
+            return self.copy()
+
         try:
             result = self.values._where(cond, other)
         except TypeError:

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -688,6 +688,16 @@ class TestDataFrameIndexingWhere:
         result = df.where(mask, ser2, axis=1)
         tm.assert_frame_equal(result, expected)
 
+    def test_where_interval_noop(self):
+        # GH#44181
+        df = DataFrame([pd.Interval(0, 0)])
+        res = df.where(df.notna())
+        tm.assert_frame_equal(res, df)
+
+        ser = df[0]
+        res = ser.where(ser.notna())
+        tm.assert_series_equal(res, ser)
+
 
 def test_where_try_cast_deprecated(frame_or_series):
     obj = DataFrame(np.random.randn(4, 3))


### PR DESCRIPTION
- [x] closes #44181
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry
