### PR TITLE
CLN: Remove duplicate skip windows decorators

### DIFF
--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -94,7 +94,7 @@ class TestTimestampEquivDateRange:
         ts = Timestamp("20090415", tz=pytz.timezone("US/Eastern"))
         assert ts == stamp
 
-    @td.skip_if_windows_python_3
+    @td.skip_if_windows
     def test_date_range_timestamp_equiv_explicit_dateutil(self):
         from pandas._libs.tslibs.timezones import dateutil_gettz as gettz
 

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -515,7 +515,7 @@ class TestBusinessDatetimeIndex:
 
         early_dr.union(late_dr, sort=sort)
 
-    @td.skip_if_windows_python_3
+    @td.skip_if_windows
     def test_month_range_union_tz_dateutil(self, sort):
         from pandas._libs.tslibs.timezones import dateutil_gettz
 

--- a/pandas/tests/io/pytables/test_put.py
+++ b/pandas/tests/io/pytables/test_put.py
@@ -176,7 +176,7 @@ def test_put_compression(setup_path):
             store.put("b", df, format="fixed", complib="zlib")
 
 
-@td.skip_if_windows_python_3
+@td.skip_if_windows
 def test_put_compression_blosc(setup_path):
     df = tm.makeTimeDataFrame()
 

--- a/pandas/tests/io/pytables/test_round_trip.py
+++ b/pandas/tests/io/pytables/test_round_trip.py
@@ -354,7 +354,7 @@ def test_timeseries_preepoch(setup_path):
 
 
 @pytest.mark.parametrize(
-    "compression", [False, pytest.param(True, marks=td.skip_if_windows_python_3)]
+    "compression", [False, pytest.param(True, marks=td.skip_if_windows)]
 )
 def test_frame(compression, setup_path):
 
@@ -435,7 +435,7 @@ def test_store_hierarchical(setup_path):
 
 
 @pytest.mark.parametrize(
-    "compression", [False, pytest.param(True, marks=td.skip_if_windows_python_3)]
+    "compression", [False, pytest.param(True, marks=td.skip_if_windows)]
 )
 def test_store_mixed(compression, setup_path):
     def _make_one():

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -579,7 +579,7 @@ class TestTimestampConversion:
         assert stamp == dtval
         assert stamp.tzinfo == dtval.tzinfo
 
-    @td.skip_if_windows_python_3
+    @td.skip_if_windows
     def test_timestamp_to_datetime_explicit_dateutil(self):
         stamp = Timestamp("20090415", tz=gettz("US/Eastern"))
         dtval = stamp.to_pydatetime()

--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -184,9 +184,6 @@ skip_if_no_mpl = pytest.mark.skipif(
 skip_if_mpl = pytest.mark.skipif(not _skip_if_no_mpl(), reason="matplotlib is present")
 skip_if_32bit = pytest.mark.skipif(not IS64, reason="skipping for 32 bit")
 skip_if_windows = pytest.mark.skipif(is_platform_windows(), reason="Running on Windows")
-skip_if_windows_python_3 = pytest.mark.skipif(
-    is_platform_windows(), reason="not used on win32"
-)
 skip_if_has_locale = pytest.mark.skipif(
     _skip_if_has_locale(), reason=f"Specific locale is set {locale.getlocale()[0]}"
 )


### PR DESCRIPTION
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

`skip_if_windows_python_3` appears equivalent to `skip_if_windows`