### PR TITLE
ASV: reduce overall run time for GroupByMethods benchmarks

### DIFF
--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -465,9 +465,9 @@ class GroupByMethods:
             # DataFrameGroupBy doesn't have these methods
             raise NotImplementedError
 
-        if method == "describe" and ncols == 5:
+        if method == "describe":
             ngroups = 20
-        elif method in ["describe", "mad", "skew"]:
+        elif method in ["mad", "skew"]:
             ngroups = 100
         else:
             ngroups = 1000

--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -443,7 +443,7 @@ class GroupByMethods:
             "var",
         ],
         ["direct", "transformation"],
-        [1, 2, 5, 10],
+        [1, 5],
     ]
 
     def setup(self, dtype, method, application, ncols):
@@ -455,6 +455,7 @@ class GroupByMethods:
             raise NotImplementedError
 
         if application == "transformation" and method in [
+            "describe",
             "head",
             "tail",
             "unique",
@@ -464,7 +465,12 @@ class GroupByMethods:
             # DataFrameGroupBy doesn't have these methods
             raise NotImplementedError
 
-        ngroups = 1000
+        if method == "describe" and ncols == 5:
+            ngroups = 20
+        elif method in ["describe", "mad", "skew"]:
+            ngroups = 100
+        else:
+            ngroups = 1000
         size = ngroups * 2
         rng = np.arange(ngroups).reshape(-1, 1)
         rng = np.broadcast_to(rng, (len(rng), ncols))
@@ -491,9 +497,6 @@ class GroupByMethods:
             cols = cols[0]
 
         if application == "transformation":
-            if method == "describe":
-                raise NotImplementedError
-
             self.as_group_method = lambda: df.groupby("key")[cols].transform(method)
             self.as_field_method = lambda: df.groupby(cols)["key"].transform(method)
         else:


### PR DESCRIPTION
See https://github.com/pandas-dev/pandas/issues/44450#issuecomment-969016669

This reduces 1) the data size for `describe`, `mad` and `skew` (all the slowest benchmarks that take more than a second is for one of those three), and 2) reduces the parametrization for ncols (this was added in https://github.com/pandas-dev/pandas/pull/42841 to also benchmark the case of multiple columns (block-wise), but so I think by keeping two options (single col / multiple col) that aspect should still be captured adequately).

This reduces the total runtime for this single class of benchmarks from 18min to 3min (and the `--quick` runtime (as used on CI) from 4min to 10s. Note this is only the sum of the actual (repeated) timings, so not including the setup and other overhead of running the benchmarks).


