### PR TITLE
PERF: check first for recognized scalars in DatetimeArray._validate_scalar

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -635,8 +635,8 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         -------
         self._scalar_type or NaT
         """
-        if isinstance(value, self._recognized_scalars):
-            value = self._scalar_type(value)
+        if isinstance(value, self._scalar_type):
+            pass
 
         elif isinstance(value, str):
             # NB: Careful about tzawareness
@@ -655,6 +655,9 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
             #  or else we'll fail to raise in _unbox_scalar
             msg = self._validation_error_message(value, allow_listlike)
             raise TypeError(msg)
+
+        elif isinstance(value, self._recognized_scalars):
+            value = self._scalar_type(value)
 
         else:
             msg = self._validation_error_message(value, allow_listlike)

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -635,7 +635,10 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         -------
         self._scalar_type or NaT
         """
-        if isinstance(value, str):
+        if isinstance(value, self._recognized_scalars):
+            value = self._scalar_type(value)
+
+        elif isinstance(value, str):
             # NB: Careful about tzawareness
             try:
                 value = self._scalar_from_string(value)
@@ -652,9 +655,6 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
             #  or else we'll fail to raise in _unbox_scalar
             msg = self._validation_error_message(value, allow_listlike)
             raise TypeError(msg)
-
-        elif isinstance(value, self._recognized_scalars):
-            value = self._scalar_type(value)
 
         else:
             msg = self._validation_error_message(value, allow_listlike)

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -508,7 +508,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
         self._assert_tzawareness_compat(other)
         if setitem:
             # Stricter check for setitem vs comparison methods
-            if not timezones.tz_compare(self.tz, other.tz):
+            if self.tz is not None and not timezones.tz_compare(self.tz, other.tz):
                 # TODO(2.0): remove this check. GH#37605
                 warnings.warn(
                     "Setitem-like behavior with mismatched timezones is deprecated "


### PR DESCRIPTION
Something small, but most of the time we will be setting with actual scalars, so putting that first improves this case a bit:

```python
arr = pd.date_range("2012-01-01", periods=3).array
scalar = arr[0]

In [3]: %timeit arr._validate_setitem_value(scalar)
3.04 µs ± 58.5 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <-- master
2.08 µs ± 27.2 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <-- PR
```

(it gives a noticeable difference in eg fillna benchmarks)