### PR TITLE
DOC Make explicit in to_csv docs that compression kwarg is ignored if…

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3421,6 +3421,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             and mode is one of {{'zip', 'gzip', 'bz2'}}, or inferred as
             one of the above, other entries passed as
             additional compression options.
+            If `path_or_buf` is omitted or `None` or is a file opened in text
+            mode, this argument is ignored and an (uncompressed) string is
+            returned/written.
 
             .. versionchanged:: 1.0.0
 


### PR DESCRIPTION
I got confused because I tried `df.to_csv(compression='gzip')` and the result was not gzip compressed.
This PR makes it more clear in the documentation that this argument is silently ignored if there's no file object to save into.

Note that if you do `df.to_csv(io.StringIO(), compression='gzip')` that also ignores the `compression argument, but it prints a warning. If there is no file argument, there is no warning. Hence why this documentation is important.

Honestly I didn't bother doing most of the following because this is a two-line doc change.

- [ ] closes #xxxx 
- [ ] tests added / passed 
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
