### PR TITLE
DEP: Deprecate non boolean sort for concat

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -467,6 +467,7 @@ Other Deprecations
 - Deprecated casting behavior when passing an item with mismatched-timezone to :meth:`DatetimeIndex.insert`, :meth:`DatetimeIndex.putmask`, :meth:`DatetimeIndex.where` :meth:`DatetimeIndex.fillna`, :meth:`Series.mask`, :meth:`Series.where`, :meth:`Series.fillna`, :meth:`Series.shift`, :meth:`Series.replace`, :meth:`Series.reindex` (and :class:`DataFrame` column analogues). In the past this has cast to object dtype. In a future version, these will cast the passed item to the index or series's timezone (:issue:`37605`)
 - Deprecated the 'errors' keyword argument in :meth:`Series.where`, :meth:`DataFrame.where`, :meth:`Series.mask`, and meth:`DataFrame.mask`; in a future version the argument will be removed (:issue:`44294`)
 - Deprecated :meth:`PeriodIndex.astype` to ``datetime64[ns]`` or ``DatetimeTZDtype``, use ``obj.to_timestamp(how).tz_localize(dtype.tz)`` instead (:issue:`44398`)
+- Deprecated passing non boolean argument to sort in :func:`concat` (:issue:`41518`)
 - Deprecated passing ``skipna=None`` for :meth:`DataFrame.mad` and :meth:`Series.mad`, pass ``skipna=True`` instead (:issue:`44580`)
 - Deprecated :meth:`DateOffset.apply`, use ``offset + other`` instead (:issue:`44522`)
 - A deprecation warning is now shown for :meth:`DataFrame.to_latex` indicating the arguments signature may change and emulate more the arguments to :meth:`.Styler.to_latex` in future versions (:issue:`44411`)

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -13,6 +13,7 @@ from typing import (
     cast,
     overload,
 )
+import warnings
 
 import numpy as np
 
@@ -21,12 +22,14 @@ from pandas.util._decorators import (
     cache_readonly,
     deprecate_nonkeyword_arguments,
 )
+from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.concat import concat_compat
 from pandas.core.dtypes.generic import (
     ABCDataFrame,
     ABCSeries,
 )
+from pandas.core.dtypes.inference import is_bool
 from pandas.core.dtypes.missing import isna
 
 from pandas.core.arrays.categorical import (
@@ -519,6 +522,14 @@ class _Concatenator:
         self.keys = keys
         self.names = names or getattr(keys, "names", None)
         self.levels = levels
+
+        if not is_bool(sort):
+            warnings.warn(
+                "Passing non boolean values for sort is deprecated and "
+                "will error in a future version!",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
         self.sort = sort
 
         self.ignore_index = ignore_index

--- a/pandas/tests/reshape/concat/test_series.py
+++ b/pandas/tests/reshape/concat/test_series.py
@@ -50,7 +50,7 @@ class TestSeriesConcat:
         result = concat([s1, s2])
         tm.assert_series_equal(result, expected)
 
-    def test_concat_series_axis1(self, sort=sort):
+    def test_concat_series_axis1(self, sort):
         ts = tm.makeTimeSeries()
 
         pieces = [ts[:-2], ts[2:], ts[2:-2]]
@@ -79,7 +79,9 @@ class TestSeriesConcat:
         s = Series(np.random.randn(3), index=["c", "a", "b"], name="A")
         s2 = Series(np.random.randn(4), index=["d", "a", "b", "c"], name="B")
         result = concat([s, s2], axis=1, sort=sort)
-        expected = DataFrame({"A": s, "B": s2})
+        expected = DataFrame({"A": s, "B": s2}, index=["c", "a", "b", "d"])
+        if sort:
+            expected = expected.sort_index()
         tm.assert_frame_equal(result, expected)
 
     def test_concat_series_axis1_names_applied(self):

--- a/pandas/tests/reshape/concat/test_sort.py
+++ b/pandas/tests/reshape/concat/test_sort.py
@@ -92,3 +92,9 @@ class TestConcatSort:
         expected = DataFrame([[2, np.nan], [np.nan, 1]], index=[2, 1], columns=[2, 1])
 
         tm.assert_frame_equal(result, expected)
+
+    def test_concat_sort_none_warning(self):
+        # GH#41518
+        df = DataFrame({1: [1, 2], "a": [3, 4]})
+        with tm.assert_produces_warning(FutureWarning, match="sort"):
+            pd.concat([df, df], sort=None)


### PR DESCRIPTION
- [x] closes #41518
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry
