### PR TITLE
TST: stop skipping 1986 tests in test_eval

### DIFF
--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -831,8 +831,8 @@ class TestEvalPythonPython(TestEvalNumexprPython):
 class TestEvalPythonPandas(TestEvalPythonPython):
     engine = "python"
     parser = "pandas"
-    exclude_bool = []
-    exclude_cmp = []
+    exclude_bool: list[str] = []
+    exclude_cmp: list[str] = []
 
     def check_chained_cmp_op(self, lhs, cmp1, mid, cmp2, rhs):
         TestEvalNumexprPandas.check_chained_cmp_op(self, lhs, cmp1, mid, cmp2, rhs)

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -782,8 +782,8 @@ class TestEvalNumexprPandas:
 
 @td.skip_if_no_ne
 class TestEvalNumexprPython(TestEvalNumexprPandas):
-    exclude_cmp = ["in", "not in"]
-    exclude_bool = ["and", "or"]
+    exclude_cmp: list[str] = ["in", "not in"]
+    exclude_bool: list[str] = ["and", "or"]
 
     engine = "numexpr"
     parser = "python"


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

Get 8 xfails instead.  They may turn out to be easy, leaving that for another day.

This constitutes almost 40% of currently-skipped tests, at least with my setup.