### PR TITLE
CI/TST: Change id to is for flaky tests

### DIFF
--- a/pandas/tests/frame/methods/test_rename.py
+++ b/pandas/tests/frame/methods/test_rename.py
@@ -184,14 +184,16 @@ class TestRename:
         assert "C" in float_frame
         assert "foo" not in float_frame
 
-        c_id = id(float_frame["C"])
+        c_values = float_frame["C"]._values
         float_frame = float_frame.copy()
         return_value = float_frame.rename(columns={"C": "foo"}, inplace=True)
         assert return_value is None
 
         assert "C" not in float_frame
         assert "foo" in float_frame
-        assert id(float_frame["foo"]) != c_id
+        # GH 44153
+        # Used to be id(float_frame["foo"]) != c_id, but flaky in the CI
+        assert not np.shares_memory(float_frame["foo"]._values, c_values)
 
     def test_rename_bug(self):
         # GH 5344

--- a/pandas/tests/frame/methods/test_rename.py
+++ b/pandas/tests/frame/methods/test_rename.py
@@ -184,7 +184,7 @@ class TestRename:
         assert "C" in float_frame
         assert "foo" not in float_frame
 
-        c_values = float_frame["C"]._values
+        c_values = float_frame["C"]
         float_frame = float_frame.copy()
         return_value = float_frame.rename(columns={"C": "foo"}, inplace=True)
         assert return_value is None
@@ -193,7 +193,7 @@ class TestRename:
         assert "foo" in float_frame
         # GH 44153
         # Used to be id(float_frame["foo"]) != c_id, but flaky in the CI
-        assert not np.shares_memory(float_frame["foo"]._values, c_values)
+        assert float_frame["foo"] is not c_values
 
     def test_rename_bug(self):
         # GH 5344

--- a/pandas/tests/frame/methods/test_sort_index.py
+++ b/pandas/tests/frame/methods/test_sort_index.py
@@ -224,7 +224,7 @@ class TestDataFrameSortIndex:
 
         # axis=0
         unordered = frame.loc[[3, 2, 4, 1]]
-        a_values = unordered["A"]._values
+        a_values = unordered["A"]
         df = unordered.copy()
         return_value = df.sort_index(inplace=True)
         assert return_value is None
@@ -232,7 +232,7 @@ class TestDataFrameSortIndex:
         tm.assert_frame_equal(df, expected)
         # GH 44153 related
         # Used to be a_id != id(df["A"]), but flaky in the CI
-        assert not np.shares_memory(a_values, df["A"]._values)
+        assert a_values is not df["A"]._values
 
         df = unordered.copy()
         return_value = df.sort_index(ascending=False, inplace=True)

--- a/pandas/tests/frame/methods/test_sort_index.py
+++ b/pandas/tests/frame/methods/test_sort_index.py
@@ -232,7 +232,7 @@ class TestDataFrameSortIndex:
         tm.assert_frame_equal(df, expected)
         # GH 44153 related
         # Used to be a_id != id(df["A"]), but flaky in the CI
-        assert a_values is not df["A"]._values
+        assert a_values is not df["A"]
 
         df = unordered.copy()
         return_value = df.sort_index(ascending=False, inplace=True)

--- a/pandas/tests/frame/methods/test_sort_index.py
+++ b/pandas/tests/frame/methods/test_sort_index.py
@@ -224,13 +224,15 @@ class TestDataFrameSortIndex:
 
         # axis=0
         unordered = frame.loc[[3, 2, 4, 1]]
-        a_id = id(unordered["A"])
+        a_values = unordered["A"]._values
         df = unordered.copy()
         return_value = df.sort_index(inplace=True)
         assert return_value is None
         expected = frame
         tm.assert_frame_equal(df, expected)
-        assert a_id != id(df["A"])
+        # GH 44153 related
+        # Used to be a_id != id(df["A"]), but flaky in the CI
+        assert not np.shares_memory(a_values, df["A"]._values)
 
         df = unordered.copy()
         return_value = df.sort_index(ascending=False, inplace=True)


### PR DESCRIPTION
- [x] closes #44153
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

I _think_ this should be in the spirit of the intended test to make things less flaky hopefully cc @jbrockmendel 