### PR TITLE
WARN: Clarify future warnings for read_csv

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -452,7 +452,7 @@ _pyarrow_unsupported = {
 
 class _DeprecationConfig(NamedTuple):
     default_value: Any
-    msg: str
+    msg: str | None
 
 
 _deprecated_defaults: dict[str, _DeprecationConfig] = {
@@ -940,7 +940,7 @@ class TextFileReader(abc.Iterator):
                     elif (
                         value
                         == _deprecated_defaults.get(
-                            argname, (default, None)
+                            argname, _DeprecationConfig(default, None)
                         ).default_value
                     ):
                         pass
@@ -950,7 +950,9 @@ class TextFileReader(abc.Iterator):
                             f"{repr(engine)} engine"
                         )
             else:
-                value = _deprecated_defaults.get(argname, (default, None)).default_value
+                value = _deprecated_defaults.get(
+                    argname, _DeprecationConfig(default, None)
+                ).default_value
             options[argname] = value
 
         if engine == "python-fwf":

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -446,10 +446,10 @@ _pyarrow_unsupported = {
     "low_memory",
 }
 
-_deprecated_defaults: dict[str, Any] = {
-    "error_bad_lines": None,
-    "warn_bad_lines": None,
-    "squeeze": None,
+_deprecated_defaults: dict[str, tuple[Any, str]] = {
+    "error_bad_lines": (None, "Use on_bad_lines in the future."),
+    "warn_bad_lines": (None, "Use on_bad_lines in the future."),
+    "squeeze": (None, 'Append .squeeze("columns") to the call to squeeze.'),
 }
 
 
@@ -926,7 +926,7 @@ class TextFileReader(abc.Iterator):
                 if engine != "c" and value != default:
                     if "python" in engine and argname not in _python_unsupported:
                         pass
-                    elif value == _deprecated_defaults.get(argname, default):
+                    elif value == _deprecated_defaults.get(argname, (default, None))[0]:
                         pass
                     else:
                         raise ValueError(
@@ -934,7 +934,7 @@ class TextFileReader(abc.Iterator):
                             f"{repr(engine)} engine"
                         )
             else:
-                value = _deprecated_defaults.get(argname, default)
+                value = _deprecated_defaults.get(argname, (default, None))[0]
             options[argname] = value
 
         if engine == "python-fwf":
@@ -1059,10 +1059,10 @@ class TextFileReader(abc.Iterator):
         for arg in _deprecated_defaults.keys():
             parser_default = _c_parser_defaults.get(arg, parser_defaults[arg])
             depr_default = _deprecated_defaults[arg]
-            if result.get(arg, depr_default) != depr_default:
+            if result.get(arg, depr_default) != depr_default[0]:
                 msg = (
                     f"The {arg} argument has been deprecated and will be "
-                    "removed in a future version.\n\n"
+                    f"removed in a future version. {depr_default[1]}\n\n"
                 )
                 warnings.warn(msg, FutureWarning, stacklevel=find_stack_level())
             else:

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -1197,7 +1197,8 @@ class TestReaders:
         with tm.assert_produces_warning(
             FutureWarning,
             match="The squeeze argument has been deprecated "
-            "and will be removed in a future version.\n\n",
+            "and will be removed in a future version. "
+            'Append .squeeze\\("columns"\\) to the call to squeeze.\n\n',
         ):
             actual = pd.read_excel(
                 f, sheet_name="two_columns", index_col=0, squeeze=True

--- a/pandas/tests/io/parser/common/test_common_basic.py
+++ b/pandas/tests/io/parser/common/test_common_basic.py
@@ -143,7 +143,8 @@ c,3
     result = parser.read_csv_check_warnings(
         FutureWarning,
         "The squeeze argument has been deprecated "
-        "and will be removed in a future version.\n\n",
+        "and will be removed in a future version. "
+        'Append .squeeze\\("columns"\\) to the call to squeeze.\n\n',
         StringIO(data),
         index_col=0,
         header=None,
@@ -877,7 +878,8 @@ def test_deprecated_bad_lines_warns(all_parsers, csv1, on_bad_lines):
     parser.read_csv_check_warnings(
         FutureWarning,
         f"The {on_bad_lines}_bad_lines argument has been deprecated "
-        "and will be removed in a future version.\n\n",
+        "and will be removed in a future version. "
+        "Use on_bad_lines in the future.\n\n",
         csv1,
         **kwds,
     )


### PR DESCRIPTION
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

In other places we emit a specific warning message what to use in the future. I find this quite helpful for the user. 

