### PR TITLE
Revert "TST: de-xfail"

### DIFF
--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -93,9 +93,11 @@ def assert_stat_op_calc(
         tm.assert_series_equal(
             result0, frame.apply(wrapper), check_dtype=check_dtype, rtol=rtol, atol=atol
         )
+        # FIXME: HACK: win32
         tm.assert_series_equal(
             result1,
             frame.apply(wrapper, axis=1),
+            check_dtype=False,
             rtol=rtol,
             atol=atol,
         )
@@ -198,7 +200,9 @@ def assert_bool_op_calc(opname, alternative, frame, has_skipna=True):
         result1 = f(axis=1, skipna=False)
 
         tm.assert_series_equal(result0, frame.apply(wrapper))
-        tm.assert_series_equal(result1, frame.apply(wrapper, axis=1))
+        tm.assert_series_equal(
+            result1, frame.apply(wrapper, axis=1), check_dtype=False
+        )  # FIXME: HACK: win32
     else:
         skipna_wrapper = alternative
         wrapper = alternative

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -651,6 +651,10 @@ class TestGetIndexer:
             ([date(9999, 1, 1), date(9999, 1, 1)], [-1, -1]),
         ],
     )
+    # FIXME: these warnings are flaky GH#36131
+    @pytest.mark.filterwarnings(
+        "ignore:Comparison of Timestamp with datetime.date:FutureWarning"
+    )
     def test_get_indexer_out_of_bounds_date(self, target, positions):
         values = DatetimeIndex([Timestamp("2020-01-01"), Timestamp("2020-01-02")])
 


### PR DESCRIPTION
Reverts pandas-dev/pandas#44659

The test_warn_if_chunks_have_mismatched_type one is already failing on other builds.