### PR TITLE
ASV: time_reindex_both_axes to reindex existing columns

### DIFF
--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -76,7 +76,7 @@ class Reindex:
         self.df.reindex(columns=self.idx)
 
     def time_reindex_both_axes(self):
-        self.df.reindex(index=self.idx, columns=self.idx)
+        self.df.reindex(index=self.idx, columns=self.idx_cols)
 
     def time_reindex_upcast(self):
         self.df2.reindex(np.random.permutation(range(1200)))


### PR DESCRIPTION
As a follow-up on https://github.com/pandas-dev/pandas/pull/40247: in that PR I added a separate benchmark case (`time_reindex_axis1_missing`) to explicitly test the case of reindexing non-existing columns. But I forgot to use the column-specific indexer (with existing columns) in the case of reindexing both rows and cols. Since the "non-existing columns" case is already covered by the separate benchmark, I think it's more useful to test the case of "both row and column indexer" with existing columns.
