### PR TITLE
ASV: remove duplicated SelectDtypes benchmark

### DIFF
--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -731,17 +731,6 @@ class Describe:
         self.df.describe()
 
 
-class SelectDtypes:
-    params = [100, 1000]
-    param_names = ["n"]
-
-    def setup(self, n):
-        self.df = DataFrame(np.random.randn(10, n))
-
-    def time_select_dtypes(self, n):
-        self.df.select_dtypes(include="int")
-
-
 class MemoryUsage:
     def setup(self):
         self.df = DataFrame(np.random.randn(100000, 2), columns=list("AB"))


### PR DESCRIPTION
https://github.com/pandas-dev/pandas/pull/36839 added an extensive benchmark class for `select_dtypes` (`dtypes.py::SelectDtypes`), but we actually already had a benchmark in `frame_methods.py`. Now, the new ones are more extensive, testing multiple dtypes and both include/exclude, instead of only including int, so I think the one in frame_methods can be safely removed to avoid duplication of benchmarks:

https://github.com/pandas-dev/pandas/blob/7b78b730aee122bb7d6e90723c4208da234de19e/asv_bench/benchmarks/dtypes.py#L51-L112