### PR TITLE
CLN: TODOs and FIXMEs

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -928,7 +928,8 @@ cdef class Tick(SingleConstructorOffset):
         if util.is_timedelta64_object(other) or PyDelta_Check(other):
             return other + self.delta
         elif isinstance(other, type(self)):
-            # TODO: this is reached in tests that specifically call apply,
+            # TODO(2.0): remove once apply deprecation is enforced.
+            #  This is reached in tests that specifically call apply,
             #  but should not be reached "naturally" because __add__ should
             #  catch this case first.
             return type(self)(self.n + other.n)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -214,6 +214,7 @@ import pandas.plotting
 if TYPE_CHECKING:
 
     from pandas.core.groupby.generic import DataFrameGroupBy
+    from pandas.core.internals import SingleDataManager
     from pandas.core.resample import Resampler
 
     from pandas.io.formats.style import Styler
@@ -3430,8 +3431,8 @@ class DataFrame(NDFrame, OpsMixin):
         else:
             label = self.columns[i]
 
-            values = self._mgr.iget(i)
-            result = self._box_col_values(values, i)
+            col_mgr = self._mgr.iget(i)
+            result = self._box_col_values(col_mgr, i)
 
             # this is a cached value, mark it so
             result._set_as_cached(label, self)
@@ -3894,7 +3895,7 @@ class DataFrame(NDFrame, OpsMixin):
 
             self._mgr = self._mgr.reindex_axis(index_copy, axis=1, fill_value=np.nan)
 
-    def _box_col_values(self, values, loc: int) -> Series:
+    def _box_col_values(self, values: SingleDataManager, loc: int) -> Series:
         """
         Provide boxed values for a column.
         """
@@ -3919,8 +3920,8 @@ class DataFrame(NDFrame, OpsMixin):
             #  pending resolution of GH#33047
 
             loc = self.columns.get_loc(item)
-            values = self._mgr.iget(loc)
-            res = self._box_col_values(values, loc).__finalize__(self)
+            col_mgr = self._mgr.iget(loc)
+            res = self._box_col_values(col_mgr, loc).__finalize__(self)
 
             cache[item] = res
             res._set_as_cached(item, self)

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -249,7 +249,7 @@ class NumericIndex(Index):
                     "values are required for conversion"
                 )
             elif is_integer_dtype(dtype) and not is_extension_array_dtype(dtype):
-                # TODO(jreback); this can change once we have an EA Index type
+                # TODO(ExtensionIndex); this can change once we have an EA Index type
                 # GH 13149
                 arr = astype_nansafe(self._values, dtype=dtype)
                 if isinstance(self, Float64Index):

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -913,7 +913,9 @@ class Parser:
     def _try_convert_types(self):
         raise AbstractMethodError(self)
 
-    def _try_convert_data(self, name, data, use_dtypes=True, convert_dates=True):
+    def _try_convert_data(
+        self, name, data, use_dtypes: bool = True, convert_dates: bool = True
+    ):
         """
         Try to parse a ndarray like into a column by inferring dtype.
         """

--- a/pandas/tests/arrays/integer/test_function.py
+++ b/pandas/tests/arrays/integer/test_function.py
@@ -120,7 +120,8 @@ def test_value_counts_empty():
     # https://github.com/pandas-dev/pandas/issues/33317
     ser = pd.Series([], dtype="Int64")
     result = ser.value_counts()
-    # TODO: The dtype of the index seems wrong (it's int64 for non-empty)
+    # TODO(ExtensionIndex): The dtype of the index seems wrong
+    #  (it's int64 for non-empty)
     idx = pd.Index([], dtype="object")
     expected = pd.Series([], index=idx, dtype="Int64")
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/base/test_conversion.py
+++ b/pandas/tests/base/test_conversion.py
@@ -193,26 +193,15 @@ class TestToIterable:
             pd.core.dtypes.dtypes.PeriodDtype("A-DEC"),
         ),
         (pd.IntervalIndex.from_breaks([0, 1, 2]), IntervalArray, "interval"),
-        # This test is currently failing for datetime64[ns] and timedelta64[ns].
-        # The NumPy type system is sufficient for representing these types, so
-        # we just use NumPy for Series / DataFrame columns of these types (so
-        # we get consolidation and so on).
-        # However, DatetimeIndex and TimedeltaIndex use the DateLikeArray
-        # abstraction to for code reuse.
-        # At the moment, we've judged that allowing this test to fail is more
-        # practical that overriding Series._values to special case
-        # Series[M8[ns]] and Series[m8[ns]] to return a DateLikeArray.
-        pytest.param(
+        (
             pd.DatetimeIndex(["2017", "2018"]),
-            np.ndarray,
+            DatetimeArray,
             "datetime64[ns]",
-            marks=[pytest.mark.xfail(reason="datetime _values")],
         ),
-        pytest.param(
+        (
             pd.TimedeltaIndex([10 ** 10]),
-            np.ndarray,
+            TimedeltaArray,
             "m8[ns]",
-            marks=[pytest.mark.xfail(reason="timedelta _values")],
         ),
     ],
 )

--- a/pandas/tests/extension/base/reshaping.py
+++ b/pandas/tests/extension/base/reshaping.py
@@ -5,7 +5,7 @@ import pytest
 
 import pandas as pd
 from pandas.api.extensions import ExtensionArray
-from pandas.core.internals import EABackedBlock
+from pandas.core.internals.blocks import EABackedBlock
 from pandas.tests.extension.base.base import BaseExtensionTests
 
 

--- a/pandas/tests/extension/base/reshaping.py
+++ b/pandas/tests/extension/base/reshaping.py
@@ -5,7 +5,7 @@ import pytest
 
 import pandas as pd
 from pandas.api.extensions import ExtensionArray
-from pandas.core.internals import ExtensionBlock
+from pandas.core.internals import EABackedBlock
 from pandas.tests.extension.base.base import BaseExtensionTests
 
 
@@ -28,7 +28,7 @@ class BaseReshapingTests(BaseExtensionTests):
 
         assert dtype == data.dtype
         if hasattr(result._mgr, "blocks"):
-            assert isinstance(result._mgr.blocks[0], ExtensionBlock)
+            assert isinstance(result._mgr.blocks[0], EABackedBlock)
         assert isinstance(result._mgr.arrays[0], ExtensionArray)
 
     @pytest.mark.parametrize("in_frame", [True, False])

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -93,11 +93,9 @@ def assert_stat_op_calc(
         tm.assert_series_equal(
             result0, frame.apply(wrapper), check_dtype=check_dtype, rtol=rtol, atol=atol
         )
-        # FIXME: HACK: win32
         tm.assert_series_equal(
             result1,
             frame.apply(wrapper, axis=1),
-            check_dtype=False,
             rtol=rtol,
             atol=atol,
         )
@@ -200,9 +198,7 @@ def assert_bool_op_calc(opname, alternative, frame, has_skipna=True):
         result1 = f(axis=1, skipna=False)
 
         tm.assert_series_equal(result0, frame.apply(wrapper))
-        tm.assert_series_equal(
-            result1, frame.apply(wrapper, axis=1), check_dtype=False
-        )  # FIXME: HACK: win32
+        tm.assert_series_equal(result1, frame.apply(wrapper, axis=1))
     else:
         skipna_wrapper = alternative
         wrapper = alternative

--- a/pandas/tests/plotting/frame/test_frame_color.py
+++ b/pandas/tests/plotting/frame/test_frame_color.py
@@ -659,36 +659,6 @@ class TestDataFrameColor(TestPlotBase):
 
     def test_invalid_colormap(self):
         df = DataFrame(np.random.randn(3, 2), columns=["A", "B"])
-        msg = (
-            "'invalid_colormap' is not a valid value for name; supported values are "
-            "'Accent', 'Accent_r', 'Blues', 'Blues_r', 'BrBG', 'BrBG_r', 'BuGn', "
-            "'BuGn_r', 'BuPu', 'BuPu_r', 'CMRmap', 'CMRmap_r', 'Dark2', 'Dark2_r', "
-            "'GnBu', 'GnBu_r', 'Greens', 'Greens_r', 'Greys', 'Greys_r', 'OrRd', "
-            "'OrRd_r', 'Oranges', 'Oranges_r', 'PRGn', 'PRGn_r', 'Paired', "
-            "'Paired_r', 'Pastel1', 'Pastel1_r', 'Pastel2', 'Pastel2_r', 'PiYG', "
-            "'PiYG_r', 'PuBu', 'PuBuGn', 'PuBuGn_r', 'PuBu_r', 'PuOr', 'PuOr_r', "
-            "'PuRd', 'PuRd_r', 'Purples', 'Purples_r', 'RdBu', 'RdBu_r', 'RdGy', "
-            "'RdGy_r', 'RdPu', 'RdPu_r', 'RdYlBu', 'RdYlBu_r', 'RdYlGn', "
-            "'RdYlGn_r', 'Reds', 'Reds_r', 'Set1', 'Set1_r', 'Set2', 'Set2_r', "
-            "'Set3', 'Set3_r', 'Spectral', 'Spectral_r', 'Wistia', 'Wistia_r', "
-            "'YlGn', 'YlGnBu', 'YlGnBu_r', 'YlGn_r', 'YlOrBr', 'YlOrBr_r', "
-            "'YlOrRd', 'YlOrRd_r', 'afmhot', 'afmhot_r', 'autumn', 'autumn_r', "
-            "'binary', 'binary_r', 'bone', 'bone_r', 'brg', 'brg_r', 'bwr', "
-            "'bwr_r', 'cividis', 'cividis_r', 'cool', 'cool_r', 'coolwarm', "
-            "'coolwarm_r', 'copper', 'copper_r', 'cubehelix', 'cubehelix_r', "
-            "'flag', 'flag_r', 'gist_earth', 'gist_earth_r', 'gist_gray', "
-            "'gist_gray_r', 'gist_heat', 'gist_heat_r', 'gist_ncar', "
-            "'gist_ncar_r', 'gist_rainbow', 'gist_rainbow_r', 'gist_stern', "
-            "'gist_stern_r', 'gist_yarg', 'gist_yarg_r', 'gnuplot', 'gnuplot2', "
-            "'gnuplot2_r', 'gnuplot_r', 'gray', 'gray_r', 'hot', 'hot_r', 'hsv', "
-            "'hsv_r', 'inferno', 'inferno_r', 'jet', 'jet_r', 'magma', 'magma_r', "
-            "'nipy_spectral', 'nipy_spectral_r', 'ocean', 'ocean_r', 'pink', "
-            "'pink_r', 'plasma', 'plasma_r', 'prism', 'prism_r', 'rainbow', "
-            "'rainbow_r', 'seismic', 'seismic_r', 'spring', 'spring_r', 'summer', "
-            "'summer_r', 'tab10', 'tab10_r', 'tab20', 'tab20_r', 'tab20b', "
-            "'tab20b_r', 'tab20c', 'tab20c_r', 'terrain', 'terrain_r', 'turbo', "
-            "'turbo_r', 'twilight', 'twilight_r', 'twilight_shifted', "
-            "'twilight_shifted_r', 'viridis', 'viridis_r', 'winter', 'winter_r'"
-        )
+        msg = "'invalid_colormap' is not a valid value for name; supported values are "
         with pytest.raises(ValueError, match=msg):
             df.plot(colormap="invalid_colormap")

--- a/pandas/tests/reshape/concat/test_empty.py
+++ b/pandas/tests/reshape/concat/test_empty.py
@@ -197,14 +197,12 @@ class TestEmptyConcat:
         result = concat(
             [Series(dtype="float64").astype("Sparse"), Series(dtype="float64")]
         )
-        # TODO(TomAugspurger#22325): release-note: concat sparse dtype
         expected = pd.SparseDtype(np.float64)
         assert result.dtype == expected
 
         result = concat(
             [Series(dtype="float64").astype("Sparse"), Series(dtype="object")]
         )
-        # TODO(TomAugspurger#22325): release-note: concat sparse dtype
         expected = pd.SparseDtype("object")
         assert result.dtype == expected
 

--- a/pandas/tests/reshape/concat/test_empty.py
+++ b/pandas/tests/reshape/concat/test_empty.py
@@ -197,14 +197,14 @@ class TestEmptyConcat:
         result = concat(
             [Series(dtype="float64").astype("Sparse"), Series(dtype="float64")]
         )
-        # TODO: release-note: concat sparse dtype
+        # TODO(TomAugspurger#22325): release-note: concat sparse dtype
         expected = pd.SparseDtype(np.float64)
         assert result.dtype == expected
 
         result = concat(
             [Series(dtype="float64").astype("Sparse"), Series(dtype="object")]
         )
-        # TODO: release-note: concat sparse dtype
+        # TODO(TomAugspurger#22325): release-note: concat sparse dtype
         expected = pd.SparseDtype("object")
         assert result.dtype == expected
 


### PR DESCRIPTION
Fixes test_invalid_colormap which is failing locally AFAICT the available colors in matplotlib changed so the old exception message isn't quite right. 