### PR TITLE
TST: read_csv raisin error with string dtype and parse dates

### DIFF
--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -1960,3 +1960,16 @@ def test_replace_nans_before_parsing_dates(all_parsers):
         }
     )
     tm.assert_frame_equal(result, expected)
+
+
+@skip_pyarrow
+def test_parse_dates_and_string_dtype(all_parsers):
+    # GH#34066
+    parser = all_parsers
+    data = """a,b
+1,2019-12-31
+"""
+    result = parser.read_csv(StringIO(data), dtype="string", parse_dates=["b"])
+    expected = DataFrame({"a": ["1"], "b": [Timestamp("2019-12-31")]})
+    expected["a"] = expected["a"].astype("string")
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #34066
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

