### PR TITLE
DOC: Removed link to Engarde project. It doesn't develop anymore. #44543

### DIFF
--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -35,11 +35,13 @@ Data cleaning and validation
 
 Pyjanitor provides a clean API for cleaning data, using method chaining.
 
-`Engarde <https://engarde.readthedocs.io/en/latest/>`__
+`Pandera <https://pandera.readthedocs.io/en/stable/>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Engarde is a lightweight library used to explicitly state assumptions about your datasets
-and check that they're *actually* true.
+Pandera provides a flexible and expressive API for performing data validation on dataframes
+to make data processing pipelines more readable and robust.
+Dataframes contain information that pandera explicitly validates at runtime. This is useful in
+production-critical data pipelines or reproducible research settings.
 
 `pandas-path <https://github.com/drivendataorg/pandas-path/>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
issues #44543 

Removed link to [Engarde](https://engarde.readthedocs.io/en/latest/) project. It doesn't develop anymore [GitHab](https://github.com/engarde-dev/engarde#readme).

Added a link to the actively developing project  [Pandera](https://pandera.readthedocs.io/en/stable/) [GitHab](https://github.com/pandera-dev/pandera).



