### PR TITLE
Deprecate positional arguments for read_fwf

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -519,6 +519,7 @@ Other Deprecations
 - Deprecated the 'errors' keyword argument in :meth:`Series.where`, :meth:`DataFrame.where`, :meth:`Series.mask`, and meth:`DataFrame.mask`; in a future version the argument will be removed (:issue:`44294`)
 - Deprecated :meth:`PeriodIndex.astype` to ``datetime64[ns]`` or ``DatetimeTZDtype``, use ``obj.to_timestamp(how).tz_localize(dtype.tz)`` instead (:issue:`44398`)
 - Deprecated passing non boolean argument to sort in :func:`concat` (:issue:`41518`)
+- Deprecated passing arguments as positional for :func:`read_fwf` other than ``filepath_or_buffer`` (:issue:`41485`):
 - Deprecated passing ``skipna=None`` for :meth:`DataFrame.mad` and :meth:`Series.mad`, pass ``skipna=True`` instead (:issue:`44580`)
 - Deprecated :meth:`DateOffset.apply`, use ``offset + other`` instead (:issue:`44522`)
 - A deprecation warning is now shown for :meth:`DataFrame.to_latex` indicating the arguments signature may change and emulate more the arguments to :meth:`.Styler.to_latex` in future versions (:issue:`44411`)

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -758,6 +758,9 @@ def read_table(
     return _read(filepath_or_buffer, kwds)
 
 
+@deprecate_nonkeyword_arguments(
+    version=None, allowed_args=["filepath_or_buffer"], stacklevel=3
+)
 def read_fwf(
     filepath_or_buffer: FilePath | ReadCsvBuffer[bytes] | ReadCsvBuffer[str],
     colspecs="infer",

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -759,7 +759,7 @@ def read_table(
 
 
 @deprecate_nonkeyword_arguments(
-    version=None, allowed_args=["filepath_or_buffer"], stacklevel=3
+    version=None, allowed_args=["filepath_or_buffer"], stacklevel=2
 )
 def read_fwf(
     filepath_or_buffer: FilePath | ReadCsvBuffer[bytes] | ReadCsvBuffer[str],

--- a/pandas/tests/io/parser/test_read_fwf.py
+++ b/pandas/tests/io/parser/test_read_fwf.py
@@ -907,3 +907,15 @@ def test_skiprows_with_iterator():
     ]
     for i, result in enumerate(df_iter):
         tm.assert_frame_equal(result, expected_frames[i])
+
+
+def test_skiprows_passing_as_positional_deprecated():
+    # GH#41485
+    data = """0
+1
+2
+"""
+    with tm.assert_produces_warning(FutureWarning, match="keyword-only"):
+        result = read_fwf(StringIO(data), [(0, 2)])
+    expected = DataFrame({"0": [1, 2]})
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/parser/test_read_fwf.py
+++ b/pandas/tests/io/parser/test_read_fwf.py
@@ -218,7 +218,7 @@ bar2,12,13,14,15
     msg = "Each column specification must be.+"
 
     with pytest.raises(TypeError, match=msg):
-        read_fwf(StringIO(data), [("a", 1)])
+        read_fwf(StringIO(data), colspecs=[("a", 1)])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] xref #41485
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

Similar to read_csv this will simplify typing the return values