### PR TITLE
Added the note of class DataFrame

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -472,7 +472,9 @@ class DataFrame(NDFrame, OpsMixin):
     data : ndarray (structured or homogeneous), Iterable, dict, or DataFrame
         Dict can contain Series, arrays, constants, dataclass or list-like objects. If
         data is a dict, column order follows insertion-order. If a dict contains Series
-        which have an index defined, it is aligned by its index.
+        which have an index defined, it is aligned by its index.For best performance,
+        iterable objects, such as a Pytorch Tensor, that can efficiently be converted to a Numpy Array,
+        should be converted before passing it to pd.DataFrame.
 
         .. versionchanged:: 0.25.0
            If data is a list of dicts, column order follows insertion-order.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -473,8 +473,8 @@ class DataFrame(NDFrame, OpsMixin):
         Dict can contain Series, arrays, constants, dataclass or list-like objects. If
         data is a dict, column order follows insertion-order. If a dict contains Series
         which have an index defined, it is aligned by its index.For best performance,
-        iterable objects, such as a Pytorch Tensor, that can efficiently be converted to a Numpy Array,
-        should be converted before passing it to pd.DataFrame.
+        iterable objects, such as a Pytorch Tensor, that can efficiently be converted
+        to a Numpy Array,should be converted before passing it to pd.DataFrame.
 
         .. versionchanged:: 0.25.0
            If data is a list of dicts, column order follows insertion-order.


### PR DESCRIPTION
Added the note of class DataFrame, if the data type is torch.Tensor when creating DataFrame, it should be converted to Numpy Array for better performance.
More More detailed description in https://github.com/pandas-dev/pandas/issues/44616.
Originally, the judgment was added directly in the init method of DataFrame: whether data is torch.Tensor
if isinstance(data,torch.Tensor):
     data = data.numpy()
This can solve the time-consuming problem of DataFrame (tensor), but need to import torch, which may affect other uses of pandas, so it is more appropriate to add an explanation in the class comment. 