### PR TITLE
PERF: DataFrame.T

### DIFF
--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -295,7 +295,7 @@ def ndarray_to_mgr(
     copy_on_sanitize = False if typ == "array" else copy
 
     vdtype = getattr(values, "dtype", None)
-    if is_1d_only_ea_dtype(vdtype) or isinstance(dtype, ExtensionDtype):
+    if is_1d_only_ea_dtype(vdtype) or is_1d_only_ea_dtype(dtype):
         # GH#19157
 
         if isinstance(values, (np.ndarray, ExtensionArray)) and values.ndim > 1:

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -70,13 +70,16 @@ MIXED_INT_DTYPES = [
 
 
 class TestDataFrameConstructors:
-    def test_constructor_from_2d_datetimearray(self):
+    def test_constructor_from_2d_datetimearray(self, using_array_manager):
         dti = date_range("2016-01-01", periods=6, tz="US/Pacific")
         dta = dti._data.reshape(3, 2)
 
         df = DataFrame(dta)
         expected = DataFrame({0: dta[:, 0], 1: dta[:, 1]})
         tm.assert_frame_equal(df, expected)
+        if not using_array_manager:
+            # GH#??? big performance hit if we de-consolidate
+            assert len(df._mgr.blocks) == 1
 
     def test_constructor_dict_with_tzaware_scalar(self):
         # GH#42505

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -78,7 +78,7 @@ class TestDataFrameConstructors:
         expected = DataFrame({0: dta[:, 0], 1: dta[:, 1]})
         tm.assert_frame_equal(df, expected)
         if not using_array_manager:
-            # GH#??? big performance hit if we de-consolidate
+            # GH#44724 big performance hit if we de-consolidate
             assert len(df._mgr.blocks) == 1
 
     def test_constructor_dict_with_tzaware_scalar(self):


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

Perf regression caused by #44593 (not yet released, so no whatsnew)

```
from asv_bench.benchmarks.reshape import *
cls = ReshapeExtensionDtype
dtype = cls.params[0]
self = cls()
self.setup(dtype)

%timeit self.df.T
91.1 ms ± 1.75 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)  # <- master
163 µs ± 3.8 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)  # <- PR

```