### PR TITLE
PERF: slow tests

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -333,8 +333,9 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         only handle list-likes, slices, and integer scalars
         """
         # Use cast as we know we will get back a DatetimeLikeArray or DTScalar
+        # GH#44624 skip evaluating the Union at runtime for performance.
         result = cast(
-            Union[DatetimeLikeArrayT, DTScalarOrNaT], super().__getitem__(key)
+            "Union[DatetimeLikeArrayT, DTScalarOrNaT]", super().__getitem__(key)
         )
         if lib.is_scalar(result):
             return result

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -410,7 +410,11 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
                 #  for e.g. test_get_loc_tuple_monotonic_above_size_cutoff
                 i8data = self.asi8.ravel()
                 converted = ints_to_pydatetime(
-                    i8data, tz=self.tz, freq=self.freq, box="timestamp"
+                    i8data,
+                    # error: "DatetimeLikeArrayMixin" has no attribute "tz"
+                    tz=self.tz,  # type: ignore[attr-defined]
+                    freq=self.freq,
+                    box="timestamp",
                 )
                 return converted.reshape(self.shape)
 

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -532,7 +532,9 @@ def is_string_or_object_np_dtype(dtype: np.dtype) -> bool:
     """
     Faster alternative to is_string_dtype, assumes we have a np.dtype object.
     """
-    return dtype == object or dtype.kind in "SU"
+    # error: Non-overlapping equality check (left operand type: "dtype[Any]",
+    # right operand type: "Type[object]")
+    return dtype == object or dtype.kind in "SU"  # type: ignore[comparison-overlap]
 
 
 def is_string_dtype(arr_or_dtype) -> bool:

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -528,6 +528,13 @@ def is_categorical_dtype(arr_or_dtype) -> bool:
     return CategoricalDtype.is_dtype(arr_or_dtype)
 
 
+def is_string_or_object_np_dtype(dtype: np.dtype) -> bool:
+    """
+    Faster alternative to is_string_dtype, assumes we have a np.dtype object.
+    """
+    return dtype == object or dtype.kind in "SU"
+
+
 def is_string_dtype(arr_or_dtype) -> bool:
     """
     Check whether the provided array or dtype is of the string dtype.

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -376,8 +376,8 @@ def isna_compat(arr, fill_value=np.nan) -> bool:
 
 
 def array_equivalent(
-    left: np.ndarray,
-    right: np.ndarray,
+    left,
+    right,
     strict_nan: bool = False,
     dtype_equal: bool = False,
 ) -> bool:

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -33,6 +33,7 @@ from pandas.core.dtypes.common import (
     is_integer_dtype,
     is_object_dtype,
     is_scalar,
+    is_string_or_object_np_dtype,
     needs_i8_conversion,
 )
 from pandas.core.dtypes.dtypes import (
@@ -241,7 +242,7 @@ def _isna_array(values: ArrayLike, inf_as_na: bool = False):
             result = libmissing.isnaobj(values.to_numpy(), inf_as_na=inf_as_na)
         else:
             result = values.isna()
-    elif _is_string_dtype(dtype):
+    elif is_string_or_object_np_dtype(dtype):
         result = _isna_string_dtype(values, inf_as_na=inf_as_na)
     elif needs_i8_conversion(dtype):
         # this is the NaT pattern
@@ -429,7 +430,7 @@ def array_equivalent(
             return False
         elif needs_i8_conversion(left.dtype):
             return _array_equivalent_datetimelike(left, right)
-        elif _is_string_dtype(left.dtype):
+        elif is_string_or_object_np_dtype(left.dtype):
             # TODO: fastpath for pandas' StringDtype
             return _array_equivalent_object(left, right, strict_nan)
         else:
@@ -646,8 +647,3 @@ def is_valid_na_for_dtype(obj, dtype: DtypeObj) -> bool:
 
     # fallback, default to allowing NaN, None, NA, NaT
     return not isinstance(obj, (np.datetime64, np.timedelta64, Decimal))
-
-
-def _is_string_dtype(dtype: np.dtype) -> bool:
-    # Faster implementation of dtypes.common.is_string_dtype
-    return dtype == object or dtype.kind in "SU"

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -242,7 +242,7 @@ def _isna_array(values: ArrayLike, inf_as_na: bool = False):
             result = libmissing.isnaobj(values.to_numpy(), inf_as_na=inf_as_na)
         else:
             result = values.isna()
-    elif is_string_or_object_np_dtype(dtype):
+    elif is_string_or_object_np_dtype(values.dtype):
         result = _isna_string_dtype(values, inf_as_na=inf_as_na)
     elif needs_i8_conversion(dtype):
         # this is the NaT pattern

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -154,6 +154,7 @@ def get_is_dtype_funcs():
 
     """
     fnames = [f for f in dir(com) if (f.startswith("is_") and f.endswith("dtype"))]
+    fnames.remove("is_string_or_object_np_dtype")  # fastpath requires np.dtype obj
     return [getattr(com, fname) for fname in fnames]
 
 

--- a/pandas/tests/indexing/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/test_chaining_and_caching.py
@@ -20,14 +20,12 @@ msg = "A value is trying to be set on a copy of a slice from a DataFrame"
 
 
 def random_text(nobs=100):
-    df = []
-    for i in range(nobs):
-        idx = np.random.randint(len(letters), size=2)
-        idx.sort()
+    # Construct a DataFrame where each row is a random slice from 'letters'
+    idxs = np.random.randint(len(letters), size=(nobs, 2))
+    idxs.sort(axis=1)
+    strings = [letters[x[0] : x[1]] for x in idxs]
 
-        df.append([letters[idx[0] : idx[1]]])
-
-    return DataFrame(df, columns=["letters"])
+    return DataFrame(strings, columns=["letters"])
 
 
 class TestCaching:


### PR DESCRIPTION
- [x] closes #44624
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

Biggest difference is in test_get_loc_tuple_monotonic_above_size_cutoff going from 12.92 seconds t 4.72, all in improving DatetimeLikeArray.astype.