### PR TITLE
DOC: Improve code example for DataFrame.join

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9124,17 +9124,17 @@ NaN 12.3   33.0
 
         Examples
         --------
-        >>> df = pd.DataFrame({'key': ['K0', 'K1', 'K2', 'K3', 'K4', 'K5'],
+        >>> df = pd.DataFrame({'key': ['K0', 'K1', 'K1', 'K3', 'K0', 'K1'],
         ...                    'A': ['A0', 'A1', 'A2', 'A3', 'A4', 'A5']})
 
         >>> df
           key   A
         0  K0  A0
         1  K1  A1
-        2  K2  A2
+        2  K1  A2
         3  K3  A3
-        4  K4  A4
-        5  K5  A5
+        4  K0  A4
+        5  K1  A5
 
         >>> other = pd.DataFrame({'key': ['K0', 'K1', 'K2'],
         ...                       'B': ['B0', 'B1', 'B2']})
@@ -9151,10 +9151,10 @@ NaN 12.3   33.0
           key_caller   A key_other    B
         0         K0  A0        K0   B0
         1         K1  A1        K1   B1
-        2         K2  A2        K2   B2
+        2         K1  A2        K2   B2
         3         K3  A3       NaN  NaN
-        4         K4  A4       NaN  NaN
-        5         K5  A5       NaN  NaN
+        4         K0  A4       NaN  NaN
+        5         K1  A5       NaN  NaN
 
         If we want to join using the key columns, we need to set key to be
         the index in both `df` and `other`. The joined DataFrame will have
@@ -9164,11 +9164,11 @@ NaN 12.3   33.0
               A    B
         key
         K0   A0   B0
+        K0   A4   B0
         K1   A1   B1
-        K2   A2   B2
+        K1   A2   B1
+        K1   A5   B1
         K3   A3  NaN
-        K4   A4  NaN
-        K5   A5  NaN
 
         Another option to join using the key columns is to use the `on`
         parameter. DataFrame.join always uses `other`'s index but we can use
@@ -9179,10 +9179,10 @@ NaN 12.3   33.0
           key   A    B
         0  K0  A0   B0
         1  K1  A1   B1
-        2  K2  A2   B2
+        2  K1  A2   B1
         3  K3  A3  NaN
-        4  K4  A4  NaN
-        5  K5  A5  NaN
+        4  K0  A4   B0
+        5  K1  A5   B1
         """
         return self._join_compat(
             other, on=on, how=how, lsuffix=lsuffix, rsuffix=rsuffix, sort=sort

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9126,7 +9126,7 @@ NaN 12.3   33.0
         --------
         >>> df = pd.DataFrame({'key': ['K0', 'K1', 'K2', 'K3', 'K4', 'K5'],
         ...                    'A': ['A0', 'A1', 'A2', 'A3', 'A4', 'A5']})
-        
+
         >>> df
           key   A
         0  K0  A0
@@ -9135,18 +9135,18 @@ NaN 12.3   33.0
         3  K3  A3
         4  K4  A4
         5  K5  A5
-        
+
         >>> other = pd.DataFrame({'key': ['K0', 'K1', 'K2'],
         ...                       'B': ['B0', 'B1', 'B2']})
-        
+
         >>> other
           key   B
         0  K0  B0
         1  K1  B1
         2  K2  B2
-        
+
         Join DataFrames using their indexes.
-        
+
         >>> df.join(other, lsuffix='_caller', rsuffix='_other')
           key_caller   A key_other    B
         0         K0  A0        K0   B0
@@ -9155,11 +9155,11 @@ NaN 12.3   33.0
         3         K3  A3       NaN  NaN
         4         K4  A4       NaN  NaN
         5         K5  A5       NaN  NaN
-        
+
         If we want to join using the key columns, we need to set key to be
         the index in both `df` and `other`. The joined DataFrame will have
         key as its index.
-        
+
         >>> df.set_index('key').join(other.set_index('key'))
               A    B
         key
@@ -9169,12 +9169,12 @@ NaN 12.3   33.0
         K3   A3  NaN
         K4   A4  NaN
         K5   A5  NaN
-        
+
         Another option to join using the key columns is to use the `on`
         parameter. DataFrame.join always uses `other`'s index but we can use
         any column in `df`. This method preserves the original DataFrame's
         index in the result.
-        
+
         >>> df.join(other.set_index('key'), on='key')
           key   A    B
         0  K0  A0   B0
@@ -9185,10 +9185,10 @@ NaN 12.3   33.0
         5  K5  A5  NaN
 
         Using non-unique key values shows how they are matched.
-        
+
         >>> df = pd.DataFrame({'key': ['K0', 'K1', 'K1', 'K3', 'K0', 'K1'],
         ...                    'A': ['A0', 'A1', 'A2', 'A3', 'A4', 'A5']})
-        
+
         >>> df
           key   A
         0  K0  A0
@@ -9197,7 +9197,7 @@ NaN 12.3   33.0
         3  K3  A3
         4  K0  A4
         5  K1  A5
-        
+
         >>> df.join(other.set_index('key'), on='key')
           key   A    B
         0  K0  A0   B0

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9124,9 +9124,71 @@ NaN 12.3   33.0
 
         Examples
         --------
+        >>> df = pd.DataFrame({'key': ['K0', 'K1', 'K2', 'K3', 'K4', 'K5'],
+        ...                    'A': ['A0', 'A1', 'A2', 'A3', 'A4', 'A5']})
+        
+        >>> df
+          key   A
+        0  K0  A0
+        1  K1  A1
+        2  K2  A2
+        3  K3  A3
+        4  K4  A4
+        5  K5  A5
+        
+        >>> other = pd.DataFrame({'key': ['K0', 'K1', 'K2'],
+        ...                       'B': ['B0', 'B1', 'B2']})
+        
+        >>> other
+          key   B
+        0  K0  B0
+        1  K1  B1
+        2  K2  B2
+        
+        Join DataFrames using their indexes.
+        
+        >>> df.join(other, lsuffix='_caller', rsuffix='_other')
+          key_caller   A key_other    B
+        0         K0  A0        K0   B0
+        1         K1  A1        K1   B1
+        2         K2  A2        K2   B2
+        3         K3  A3       NaN  NaN
+        4         K4  A4       NaN  NaN
+        5         K5  A5       NaN  NaN
+        
+        If we want to join using the key columns, we need to set key to be
+        the index in both `df` and `other`. The joined DataFrame will have
+        key as its index.
+        
+        >>> df.set_index('key').join(other.set_index('key'))
+              A    B
+        key
+        K0   A0   B0
+        K1   A1   B1
+        K2   A2   B2
+        K3   A3  NaN
+        K4   A4  NaN
+        K5   A5  NaN
+        
+        Another option to join using the key columns is to use the `on`
+        parameter. DataFrame.join always uses `other`'s index but we can use
+        any column in `df`. This method preserves the original DataFrame's
+        index in the result.
+        
+        >>> df.join(other.set_index('key'), on='key')
+          key   A    B
+        0  K0  A0   B0
+        1  K1  A1   B1
+        2  K2  A2   B2
+        3  K3  A3  NaN
+        4  K4  A4  NaN
+        5  K5  A5  NaN
+
+        Using non-unique key values shows how they are matched.
+        
         >>> df = pd.DataFrame({'key': ['K0', 'K1', 'K1', 'K3', 'K0', 'K1'],
         ...                    'A': ['A0', 'A1', 'A2', 'A3', 'A4', 'A5']})
-
+        
         >>> df
           key   A
         0  K0  A0
@@ -9135,46 +9197,7 @@ NaN 12.3   33.0
         3  K3  A3
         4  K0  A4
         5  K1  A5
-
-        >>> other = pd.DataFrame({'key': ['K0', 'K1', 'K2'],
-        ...                       'B': ['B0', 'B1', 'B2']})
-
-        >>> other
-          key   B
-        0  K0  B0
-        1  K1  B1
-        2  K2  B2
-
-        Join DataFrames using their indexes.
-
-        >>> df.join(other, lsuffix='_caller', rsuffix='_other')
-          key_caller   A key_other    B
-        0         K0  A0        K0   B0
-        1         K1  A1        K1   B1
-        2         K1  A2        K2   B2
-        3         K3  A3       NaN  NaN
-        4         K0  A4       NaN  NaN
-        5         K1  A5       NaN  NaN
-
-        If we want to join using the key columns, we need to set key to be
-        the index in both `df` and `other`. The joined DataFrame will have
-        key as its index.
-
-        >>> df.set_index('key').join(other.set_index('key'))
-              A    B
-        key
-        K0   A0   B0
-        K0   A4   B0
-        K1   A1   B1
-        K1   A2   B1
-        K1   A5   B1
-        K3   A3  NaN
-
-        Another option to join using the key columns is to use the `on`
-        parameter. DataFrame.join always uses `other`'s index but we can use
-        any column in `df`. This method preserves the original DataFrame's
-        index in the result.
-
+        
         >>> df.join(other.set_index('key'), on='key')
           key   A    B
         0  K0  A0   B0


### PR DESCRIPTION
The modified code example does not have unique values in the 'key' column in the calling DataFrame `df`. With unique keys the special behavior of `join` has not been highlighted, since it just added a new column. With the modified values the example shows that the 'key' column is really used as key.