### PR TITLE
DOC: Uniform block directive syntax.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,6 +111,8 @@ repos:
             # Incorrect code-block / IPython directives
             |\.\.\ code-block\ ::
             |\.\.\ ipython\ ::
+            # directive should not have a space before ::
+            |\.\.\ \w+\ ::
 
             # Check for deprecated messages without sphinx directive
             |(DEPRECATED|DEPRECATE|Deprecated)(:|,|\.)

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -3546,9 +3546,9 @@ with ``on_demand=True``.
 Specifying sheets
 +++++++++++++++++
 
-.. note :: The second argument is ``sheet_name``, not to be confused with ``ExcelFile.sheet_names``.
+.. note:: The second argument is ``sheet_name``, not to be confused with ``ExcelFile.sheet_names``.
 
-.. note :: An ExcelFile's attribute ``sheet_names`` provides access to a list of sheets.
+.. note:: An ExcelFile's attribute ``sheet_names`` provides access to a list of sheets.
 
 * The arguments ``sheet_name`` allows specifying the sheet or sheets to read.
 * The default value for ``sheet_name`` is 0, indicating to read the first sheet

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -633,7 +633,7 @@ def factorize(
         is a Categorical. When `values` is some other pandas object, an
         `Index` is returned. Otherwise, a 1-D ndarray is returned.
 
-        .. note ::
+        .. note::
 
            Even if there's a missing value in `values`, `uniques` will
            *not* contain an entry for it.


### PR DESCRIPTION
block directive syntax technically does not have space before the
double-colon.

While this seem to be accepted by docutils – but not documented,
this can throw off other RST parser/syntax highlighter.
Sometime they can see that as comments, sometime they give garbage out.

Plus this is really uncommon with 3 occurrences in pandas codebase with
space and 4800 without:

    pandas[master]  $ rg '\.\. \w+::' | wc -l
    4853

Numpy and scipy used to have a few space in their block directive, but
current master/main branch of both should also be free of directive with
space before the double colon.

---

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

Note that this issue can be seen in the syntax highlighting of the diff of this PR itself, where the deleted lines are gray (comment), and added ones are blue/purple (directives)

