### PR TITLE
Fix compression misspelling in ExcelWriter

### DIFF
--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -1000,7 +1000,7 @@ class ExcelWriter(metaclass=abc.ABCMeta):
 
         # cast ExcelWriter to avoid adding 'if self.handles is not None'
         self.handles = IOHandles(
-            cast(IO[bytes], path), compression={"copression": None}
+            cast(IO[bytes], path), compression={"compression": None}
         )
         if not isinstance(path, ExcelWriter):
             self.handles = get_handle(


### PR DESCRIPTION
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

Should still be a no-op since compression is being set to `None`
