### PR TITLE
REF: use idiomatic checks in __array_ufunc__

### DIFF
--- a/pandas/core/arraylike.py
+++ b/pandas/core/arraylike.py
@@ -326,12 +326,15 @@ def array_ufunc(self, ufunc: np.ufunc, method: str, *inputs: Any, **kwargs: Any)
         reconstruct_kwargs = {}
 
     def reconstruct(result):
+        if ufunc.nout > 1:
+            # np.modf, np.frexp, np.divmod
+            return tuple(_reconstruct(x) for x in result)
+
+        return _reconstruct(result)
+
+    def _reconstruct(result):
         if lib.is_scalar(result):
             return result
-
-        if isinstance(result, tuple):
-            # np.modf, np.frexp, np.divmod
-            return tuple(reconstruct(x) for x in result)
 
         if result.ndim != self.ndim:
             if method == "outer":

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -476,7 +476,8 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
             return x
 
         result = getattr(ufunc, method)(*inputs2, **kwargs)
-        if isinstance(result, tuple):
+        if ufunc.nout > 1:
+            # e.g. np.divmod
             return tuple(reconstruct(x) for x in result)
         else:
             return reconstruct(result)

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -163,7 +163,7 @@ class PandasArray(
             )
         result = getattr(ufunc, method)(*inputs, **kwargs)
 
-        if type(result) is tuple and len(result):
+        if ufunc.nout > 1:
             # multiple return values
             if not lib.is_scalar(result[0]):
                 # re-box array-like results
@@ -174,6 +174,13 @@ class PandasArray(
         elif method == "at":
             # no return value
             return None
+        elif method == "reduce":
+            if isinstance(result, np.ndarray):
+                # e.g. test_np_reduce_2d
+                return type(self)(result)
+
+            # e.g. test_np_max_nested_tuples
+            return result
         else:
             # one return value
             if not lib.is_scalar(result):

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1579,7 +1579,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
             sp_values = getattr(ufunc, method)(self.sp_values, **kwargs)
             fill_value = getattr(ufunc, method)(self.fill_value, **kwargs)
 
-            if isinstance(sp_values, tuple):
+            if ufunc.nout > 1:
                 # multiple outputs. e.g. modf
                 arrays = tuple(
                     self._simple_new(
@@ -1588,7 +1588,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
                     for sp_value, fv in zip(sp_values, fill_value)
                 )
                 return arrays
-            elif is_scalar(sp_values):
+            elif method == "reduce":
                 # e.g. reductions
                 return sp_values
 
@@ -1602,7 +1602,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
                 out = out[0]
             return out
 
-        if type(result) is tuple:
+        if ufunc.nout > 1:
             return tuple(type(self)(x) for x in result)
         elif method == "at":
             # no return value

--- a/pandas/tests/arrays/test_numpy.py
+++ b/pandas/tests/arrays/test_numpy.py
@@ -194,6 +194,38 @@ def test_validate_reduction_keyword_args():
         arr.all(keepdims=True)
 
 
+def test_np_max_nested_tuples():
+    # case where checking in ufunc.nout works while checking for tuples
+    #  does not
+    vals = [
+        (("j", "k"), ("l", "m")),
+        (("l", "m"), ("o", "p")),
+        (("o", "p"), ("j", "k")),
+    ]
+    ser = pd.Series(vals)
+    arr = ser.array
+
+    assert arr.max() is arr[2]
+    assert ser.max() is arr[2]
+
+    result = np.maximum.reduce(arr)
+    assert result == arr[2]
+
+    result = np.maximum.reduce(ser)
+    assert result == arr[2]
+
+
+def test_np_reduce_2d():
+    raw = np.arange(12).reshape(4, 3)
+    arr = PandasArray(raw)
+
+    res = np.maximum.reduce(arr, axis=0)
+    tm.assert_extension_array_equal(res, arr[-1])
+
+    alt = arr.max(axis=0)
+    tm.assert_extension_array_equal(alt, arr[-1])
+
+
 # ----------------------------------------------------------------------------
 # Ops
 

--- a/pandas/tests/extension/decimal/array.py
+++ b/pandas/tests/extension/decimal/array.py
@@ -124,7 +124,7 @@ class DecimalArray(OpsMixin, ExtensionScalarOpsMixin, ExtensionArray):
             else:
                 return DecimalArray._from_sequence(x)
 
-        if isinstance(result, tuple):
+        if ufunc.nout > 1:
             return tuple(reconstruct(x) for x in result)
         else:
             return reconstruct(result)


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

The current checks can bite us in corner cases with nested tuples.  Though woe betide any users who actually use data like in test_np_max_nested_tuples.