### PR TITLE
CLN: memory-mapping code

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -746,6 +746,8 @@ I/O
 - Bug in :func:`read_csv` raising ``AttributeError`` when attempting to read a .csv file and infer index column dtype from an nullable integer type (:issue:`44079`)
 - :meth:`DataFrame.to_csv` and :meth:`Series.to_csv` with ``compression`` set to ``'zip'`` no longer create a zip file containing a file ending with ".zip". Instead, they try to infer the inner file name more smartly. (:issue:`39465`)
 - Bug in :func:`read_csv` when passing simultaneously a parser in ``date_parser`` and ``parse_dates=False``, the parsing was still called (:issue:`44366`)
+- Bug in :func:`read_csv` when passing a ``tempfile.SpooledTemporaryFile`` opened in binary mode (:issue:`44748`)
+-
 
 Period
 ^^^^^^

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -747,6 +747,7 @@ I/O
 - :meth:`DataFrame.to_csv` and :meth:`Series.to_csv` with ``compression`` set to ``'zip'`` no longer create a zip file containing a file ending with ".zip". Instead, they try to infer the inner file name more smartly. (:issue:`39465`)
 - Bug in :func:`read_csv` when passing simultaneously a parser in ``date_parser`` and ``parse_dates=False``, the parsing was still called (:issue:`44366`)
 - Bug in :func:`read_csv` when passing a ``tempfile.SpooledTemporaryFile`` opened in binary mode (:issue:`44748`)
+- Bug in :func:`read_csv` silently ignoring errors when failling to create a memory-mapped file (:issue:`44766`)
 -
 
 Period

--- a/pandas/io/parsers/base_parser.py
+++ b/pandas/io/parsers/base_parser.py
@@ -231,7 +231,7 @@ class ParserBase:
         self,
         src: FilePath | ReadCsvBuffer[bytes] | ReadCsvBuffer[str],
         kwds: dict[str, Any],
-        is_text:bool = True,
+        is_text: bool = True,
     ) -> None:
         """
         Let the readers open IOHandles after they are done with their potential raises.

--- a/pandas/io/parsers/base_parser.py
+++ b/pandas/io/parsers/base_parser.py
@@ -231,6 +231,7 @@ class ParserBase:
         self,
         src: FilePath | ReadCsvBuffer[bytes] | ReadCsvBuffer[str],
         kwds: dict[str, Any],
+        is_text:bool = True,
     ) -> None:
         """
         Let the readers open IOHandles after they are done with their potential raises.
@@ -243,6 +244,7 @@ class ParserBase:
             memory_map=kwds.get("memory_map", False),
             storage_options=kwds.get("storage_options", None),
             errors=kwds.get("encoding_errors", "strict"),
+            is_text=is_text,
         )
 
     def _validate_parse_dates_presence(self, columns: Sequence[Hashable]) -> Iterable:

--- a/pandas/io/parsers/c_parser_wrapper.py
+++ b/pandas/io/parsers/c_parser_wrapper.py
@@ -51,7 +51,9 @@ class CParserWrapper(ParserBase):
         kwds["usecols"] = self.usecols
 
         # open handles
-        self._open_handles(src, kwds)
+        # The c-engine can cope with utf-8 bytes: no need to use TextIOWrapper when the
+        # encoding is utf-8: get_handle(..., is_text=Flase)
+        self._open_handles(src, kwds, is_text=kwds.get("encoding") != "utf-8")
         assert self.handles is not None
 
         # Have to pass int, would break tests using TextReader directly otherwise :(

--- a/pandas/tests/io/parser/common/test_file_buffer_url.py
+++ b/pandas/tests/io/parser/common/test_file_buffer_url.py
@@ -347,25 +347,6 @@ def test_read_csv_file_handle(all_parsers, io_class, encoding):
     assert not handle.closed
 
 
-def test_memory_map_file_handle_silent_fallback(all_parsers, compression):
-    """
-    Do not fail for buffers with memory_map=True (cannot memory map BytesIO).
-
-    GH 37621
-    """
-    parser = all_parsers
-    expected = DataFrame({"a": [1], "b": [2]})
-
-    handle = BytesIO()
-    expected.to_csv(handle, index=False, compression=compression, mode="wb")
-    handle.seek(0)
-
-    tm.assert_frame_equal(
-        parser.read_csv(handle, memory_map=True, compression=compression),
-        expected,
-    )
-
-
 def test_memory_map_compression(all_parsers, compression):
     """
     Support memory map for compressed files.

--- a/pandas/tests/io/parser/test_encoding.py
+++ b/pandas/tests/io/parser/test_encoding.py
@@ -299,17 +299,21 @@ def test_readcsv_memmap_utf8(all_parsers):
     tm.assert_frame_equal(df, dfr)
 
 
-def test_not_readable(all_parsers, request):
+@pytest.mark.usefixtures("pyarrow_xfail")
+@pytest.mark.parametrize("mode", ["w+b", "w+t"])
+def test_not_readable(all_parsers, mode, request):
     # GH43439
     parser = all_parsers
-    if parser.engine in ("python", "pyarrow"):
+    if parser.engine == "pyarrow":
         mark = pytest.mark.xfail(
-            reason="SpooledTemporaryFile does only work with the c-engine"
+            reason="SpooledTemporaryFile does only work with the pyarrow-engine"
         )
         request.node.add_marker(mark)
-
-    with tempfile.SpooledTemporaryFile() as handle:
-        handle.write(b"abcd")
+    content = b"abcd"
+    if "t" in mode:
+        content = "abcd"
+    with tempfile.SpooledTemporaryFile(mode=mode) as handle:
+        handle.write(content)
         handle.seek(0)
         df = parser.read_csv(handle)
     expected = DataFrame([], columns=["abcd"])

--- a/pandas/tests/io/parser/test_encoding.py
+++ b/pandas/tests/io/parser/test_encoding.py
@@ -236,9 +236,14 @@ def test_parse_encoded_special_characters(encoding):
 def test_encoding_memory_map(all_parsers, encoding):
     # GH40986
     parser = all_parsers
+
+    # add one entry with a special character
+    encoding_ = encoding or "utf-8"
+    leonardo = "Léonardo".encode(encoding_, errors="ignore").decode(encoding_)
+
     expected = DataFrame(
         {
-            "name": ["Raphael", "Donatello", "Miguel Angel", "Leonardo"],
+            "name": ["Raphael", "Donatello", "Miguel Angel", leonardo],
             "mask": ["red", "purple", "orange", "blue"],
             "weapon": ["sai", "bo staff", "nunchunk", "katana"],
         }

--- a/pandas/tests/io/parser/test_read_fwf.py
+++ b/pandas/tests/io/parser/test_read_fwf.py
@@ -699,15 +699,15 @@ def test_encoding_mmap(memory_map):
     GH 23254.
     """
     encoding = "iso8859_1"
-    data = BytesIO(" 1 A Ä 2\n".encode(encoding))
-    df = read_fwf(
-        data,
-        header=None,
-        widths=[2, 2, 2, 2],
-        encoding=encoding,
-        memory_map=memory_map,
-    )
-    data.seek(0)
+    with tm.ensure_clean() as path:
+        Path(path).write_bytes(" 1 A Ä 2\n".encode(encoding))
+        df = read_fwf(
+            path,
+            header=None,
+            widths=[2, 2, 2, 2],
+            encoding=encoding,
+            memory_map=memory_map,
+        )
     df_reference = DataFrame([[1, "A", "Ä", 2]])
     tm.assert_frame_equal(df, df_reference)
 


### PR DESCRIPTION
Rebased on #44761

No need for `codecs.getincrementaldecoder` as `io.TextWrapperIO` will do that (and we can use `io.TextWrapperIO` because mmap is wrapped inside `_IOWrapper`). `io.TextWrapperIO` also provides `__next__` for us :)

Probably will need some benchmarking with utf-8/non-utf8 files.