### PR TITLE
CI: Filter any SSLSocket ResouceWarnings from dependencies

### DIFF
--- a/pandas/_testing/_warnings.py
+++ b/pandas/_testing/_warnings.py
@@ -153,9 +153,8 @@ def _assert_caught_no_extra_warnings(
                 "unclosed transport <asyncio.sslproto._SSLProtocolTransport",
                 "unclosed <ssl.SSLSocket",
             )
-            if (
-                actual_warning.category == ResourceWarning
-                and str(actual_warning.message) in unclosed_ssl
+            if actual_warning.category == ResourceWarning and any(
+                msg in str(actual_warning.message) for msg in unclosed_ssl
             ):
                 # FIXME(GH#38630): kludge because pytest.filterwarnings does not
                 #  suppress these

--- a/pandas/_testing/_warnings.py
+++ b/pandas/_testing/_warnings.py
@@ -147,9 +147,15 @@ def _assert_caught_no_extra_warnings(
 
     for actual_warning in caught_warnings:
         if _is_unexpected_warning(actual_warning, expected_warning):
-            unclosed = "unclosed transport <asyncio.sslproto._SSLProtocolTransport"
-            if actual_warning.category == ResourceWarning and unclosed in str(
-                actual_warning.message
+            # GH 44732: Don't make the CI flaky by filtering SSL-related
+            # ResourceWarning from dependencies
+            unclosed_ssl = (
+                "unclosed transport <asyncio.sslproto._SSLProtocolTransport",
+                "unclosed <ssl.SSLSocket",
+            )
+            if (
+                actual_warning.category == ResourceWarning
+                and str(actual_warning.message) in unclosed_ssl
             ):
                 # FIXME(GH#38630): kludge because pytest.filterwarnings does not
                 #  suppress these


### PR DESCRIPTION
- [x] closes #44732
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

