### PR TITLE
ERR: improve error message for unsupported reductions

### DIFF
--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1355,8 +1355,7 @@ class ExtensionArray:
         meth = getattr(self, name, None)
         if meth is None:
             raise TypeError(
-                f"'{type(self).__name__}' with dtype {self.dtype} "
-                f"does not support reduction '{name}'"
+                f"reduction '{name}' is not supported for data with dtype {self.dtype}"
             )
         return meth(skipna=skipna, **kwargs)
 


### PR DESCRIPTION
Follow-up on https://github.com/pandas-dev/pandas/pull/44737: keeping the change to use "not supported", but removing the class name (end users only know dtypes, not array class names)

Will update the tests if there is agreement on the message.