### PR TITLE
PERF: avoid calling .values to know the result dtype in eval()

### DIFF
--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -146,15 +146,18 @@ class Term:
     @property
     def type(self):
         try:
-            # potentially very slow for large, mixed dtype frames
-            return self._value.values.dtype
+            # .values for dataframe would be slow
+            return self._value._mgr.as_array_dtype()
         except AttributeError:
             try:
-                # ndarray
-                return self._value.dtype
+                return self._value.values.dtype
             except AttributeError:
-                # scalar
-                return type(self._value)
+                try:
+                    # ndarray
+                    return self._value.dtype
+                except AttributeError:
+                    # scalar
+                    return type(self._value)
 
     return_type = type
 

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -1145,6 +1145,15 @@ class ArrayManager(BaseArrayManager):
 
         return result
 
+    def as_array_dtype(self):
+        """
+        The dtype of the np.ndarray when you would convert self to a numpy array
+        (i.e. calling ``mgr.as_array()`` or ``df.values``).
+        """
+        if len(self.arrays) == 0:
+            return np.dtype(float)
+        return interleaved_dtype([arr.dtype for arr in self.arrays])
+
 
 class SingleArrayManager(BaseArrayManager, SingleDataManager):
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1549,6 +1549,22 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
 
         return arr.transpose()
 
+    def as_array_dtype(self):
+        """
+        The dtype of the np.ndarray when you would convert self to a numpy array
+        (i.e. calling ``mgr.as_array()`` or ``df.values``).
+        """
+        if len(self.blocks) == 0:
+            return np.dtype(float)
+
+        if self.is_single_block:
+            return self.blocks[0].dtype
+
+        dtype = interleaved_dtype(  # type: ignore[assignment]
+            [blk.dtype for blk in self.blocks]
+        )
+        return dtype
+
     def _interleave(
         self,
         dtype: np.dtype | None = None,


### PR DESCRIPTION
Currently, the `pd.eval(..)` expression parser calls `.values` several times just to know the dtype of that array. When you actually need to construct this array (which can be costly), we can know this dtype without actually constructing it.

TODO: I need to update the `as_array_dtype` method to ensure it always returns a `np.dtype` (now it can also return an extension dtype)