### PR TITLE
ENH: Initial implementation of support for SQLAlchemy 2.0 in read_sql etc (WIP)

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -22,9 +22,8 @@ from typing import (
 )
 import warnings
 
-from sqlalchemy.sql.expression import text
-
 import numpy as np
+from sqlalchemy.sql.expression import text
 
 import pandas._libs.lib as lib
 from pandas._typing import DtypeArg


### PR DESCRIPTION
Fixes #40460

This is an early-stage draft PR that I would love some feedback on. It is an initial implementation of support for SQLAlchemy v2.0. This hasn't actually been released yet, but v1.40 has been released and it provides 2.0-style behaviour when the `future=True` flag is used when creating an engine. Current pandas fails when a 'future-style' engine is passed to any of the `read_sql` (or similar) functions.

This PR fixes that, but there are some potential problems that I would like some advice on:

1. The new SQLAlchemy API _requires_ you to explicitly begin and end all connections/transactions, so we have to keep the connections open where relevant, and close them when finished. This means that the `execute` function in `sql.py` (the raw function, not the method of any of the classes in there) does an `isinstance` check on the database class, and behaves differently depending on whether the class is `SQLiteDatabase` (which is just using the sqlite module, not SQLAlchemy) or `SQLDatabase` (which uses SQLAlchemy). For the latter we need to explicitly start/end a connection/transaction. This transaction handling logic can't be inside the `SQLDatabase.execute` method as in other locations this method is used we need to keep the connection open longer than the life of the `execute` method run, so that we can actually get the data out. This feels like a code smell, and I don't like making the two classes diverge - but I can't think of a better way of doing this without radically changing how the classes behave - which I'm not keen to do. Any thoughts would be very welcome.

2. I want to test this with engines that have `future=False` and also ones that have `future=True`. Ideally I'd like to parametrise the tests in `test_sql.py` so that they can be run twice - once for False and once for True. However, the `create_engine` calls are in the `connect` method of the classes (eg. `TestSQLApi.connect`) and I can't work out if there is a way to parametrise this through pytest. Any ideas?

In general any thoughts would be very welcome: I'm happy to work on this more to get it into a state where pandas can accept it.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
