### PR TITLE
PERF: avoid going through .values for reindexing both index/columns for ArrayManager

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4675,7 +4675,11 @@ class DataFrame(NDFrame, OpsMixin):
         new_index, row_indexer = self.index.reindex(axes["index"])
         new_columns, col_indexer = self.columns.reindex(axes["columns"])
 
-        if row_indexer is not None and col_indexer is not None:
+        if (
+            row_indexer is not None
+            and col_indexer is not None
+            and not isinstance(self._mgr, ArrayManager)
+        ):
             # Fastpath. By doing two 'take's at once we avoid making an
             #  unnecessary copy.
             # We only get here with `not self._is_mixed_type`, which (almost)


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/39146

This fastpath calls `self.values` and thus is only a fastpath for BlockManager (we only get here with all columns having the same dtype).