### PR TITLE
CLN: test_holiday

### DIFF
--- a/pandas/tests/tseries/holiday/test_holiday.py
+++ b/pandas/tests/tseries/holiday/test_holiday.py
@@ -26,29 +26,6 @@ from pandas.tseries.holiday import (
 )
 
 
-def _check_holiday_results(holiday, start, end, expected):
-    """
-    Check that the dates for a given holiday match in date and timezone.
-
-    Parameters
-    ----------
-    holiday : Holiday
-        The holiday to check.
-    start : datetime-like
-        The start date of range in which to collect dates for a given holiday.
-    end : datetime-like
-        The end date of range in which to collect dates for a given holiday.
-    expected : list
-        The list of dates we expect to get.
-    """
-    assert list(holiday.dates(start, end)) == expected
-
-    # Verify that timezone info is preserved.
-    assert list(
-        holiday.dates(utc.localize(Timestamp(start)), utc.localize(Timestamp(end)))
-    ) == [utc.localize(dt) for dt in expected]
-
-
 @pytest.mark.parametrize(
     "holiday,start_date,end_date,expected",
     [
@@ -141,46 +118,61 @@ def _check_holiday_results(holiday, start, end, expected):
     ],
 )
 def test_holiday_dates(holiday, start_date, end_date, expected):
-    _check_holiday_results(holiday, start_date, end_date, expected)
+    assert list(holiday.dates(start_date, end_date)) == expected
+
+    # Verify that timezone info is preserved.
+    assert list(
+        holiday.dates(
+            utc.localize(Timestamp(start_date)), utc.localize(Timestamp(end_date))
+        )
+    ) == [utc.localize(dt) for dt in expected]
 
 
 @pytest.mark.parametrize(
     "holiday,start,expected",
     [
         (USMemorialDay, datetime(2015, 7, 1), []),
-        (USMemorialDay, "2015-05-25", "2015-05-25"),
+        (USMemorialDay, "2015-05-25", [Timestamp("2015-05-25")]),
         (USLaborDay, datetime(2015, 7, 1), []),
-        (USLaborDay, "2015-09-07", "2015-09-07"),
+        (USLaborDay, "2015-09-07", [Timestamp("2015-09-07")]),
         (USColumbusDay, datetime(2015, 7, 1), []),
-        (USColumbusDay, "2015-10-12", "2015-10-12"),
+        (USColumbusDay, "2015-10-12", [Timestamp("2015-10-12")]),
         (USThanksgivingDay, datetime(2015, 7, 1), []),
-        (USThanksgivingDay, "2015-11-26", "2015-11-26"),
+        (USThanksgivingDay, "2015-11-26", [Timestamp("2015-11-26")]),
         (USMartinLutherKingJr, datetime(2015, 7, 1), []),
-        (USMartinLutherKingJr, "2015-01-19", "2015-01-19"),
+        (USMartinLutherKingJr, "2015-01-19", [Timestamp("2015-01-19")]),
         (USPresidentsDay, datetime(2015, 7, 1), []),
-        (USPresidentsDay, "2015-02-16", "2015-02-16"),
+        (USPresidentsDay, "2015-02-16", [Timestamp("2015-02-16")]),
         (GoodFriday, datetime(2015, 7, 1), []),
-        (GoodFriday, "2015-04-03", "2015-04-03"),
-        (EasterMonday, "2015-04-06", "2015-04-06"),
+        (GoodFriday, "2015-04-03", [Timestamp("2015-04-03")]),
+        (EasterMonday, "2015-04-06", [Timestamp("2015-04-06")]),
         (EasterMonday, datetime(2015, 7, 1), []),
         (EasterMonday, "2015-04-05", []),
-        ("New Year's Day", "2015-01-01", "2015-01-01"),
-        ("New Year's Day", "2010-12-31", "2010-12-31"),
+        ("New Year's Day", "2015-01-01", [Timestamp("2015-01-01")]),
+        ("New Year's Day", "2010-12-31", [Timestamp("2010-12-31")]),
         ("New Year's Day", datetime(2015, 7, 1), []),
         ("New Year's Day", "2011-01-01", []),
-        ("Independence Day", "2015-07-03", "2015-07-03"),
+        ("Independence Day", "2015-07-03", [Timestamp("2015-07-03")]),
         ("Independence Day", datetime(2015, 7, 1), []),
         ("Independence Day", "2015-07-04", []),
-        ("Veterans Day", "2012-11-12", "2012-11-12"),
+        ("Veterans Day", "2012-11-12", [Timestamp("2012-11-12")]),
         ("Veterans Day", datetime(2015, 7, 1), []),
         ("Veterans Day", "2012-11-11", []),
-        ("Christmas Day", "2011-12-26", "2011-12-26"),
+        ("Christmas Day", "2011-12-26", [Timestamp("2011-12-26")]),
         ("Christmas Day", datetime(2015, 7, 1), []),
         ("Christmas Day", "2011-12-25", []),
         ("Juneteenth National Independence Day", "2020-06-19", []),
-        ("Juneteenth National Independence Day", "2021-06-18", "2021-06-18"),
+        (
+            "Juneteenth National Independence Day",
+            "2021-06-18",
+            [Timestamp("2021-06-18")],
+        ),
         ("Juneteenth National Independence Day", "2022-06-19", []),
-        ("Juneteenth National Independence Day", "2022-06-20", "2022-06-20"),
+        (
+            "Juneteenth National Independence Day",
+            "2022-06-20",
+            [Timestamp("2022-06-20")],
+        ),
     ],
 )
 def test_holidays_within_dates(holiday, start, expected):
@@ -193,10 +185,12 @@ def test_holidays_within_dates(holiday, start, expected):
         calendar = get_calendar("USFederalHolidayCalendar")
         holiday = calendar.rule_from_name(holiday)
 
-    if isinstance(expected, str):
-        expected = [Timestamp(expected)]
+    assert list(holiday.dates(start, start)) == expected
 
-    _check_holiday_results(holiday, start, start, expected)
+    # Verify that timezone info is preserved.
+    assert list(
+        holiday.dates(utc.localize(Timestamp(start)), utc.localize(Timestamp(start)))
+    ) == [utc.localize(dt) for dt in expected]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

In-line a helper function to reduce misdirection in tests. In-line input argument logic.
