### PR TITLE
CI: use pytest-timeout to avoid windows timeouts

### DIFF
--- a/.github/workflows/python-dev.yml
+++ b/.github/workflows/python-dev.yml
@@ -51,7 +51,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         pip install -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
         pip install git+https://github.com/nedbat/coveragepy.git
-        pip install cython python-dateutil pytz hypothesis pytest>=6.2.5 pytest-xdist pytest-cov
+        pip install cython python-dateutil pytz hypothesis pytest>=6.2.5 pytest-xdist pytest-cov pytest-timeout
         pip list
 
     - name: Build Pandas

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
         /opt/python/cp38-cp38/bin/python -m venv ~/virtualenvs/pandas-dev && \
         . ~/virtualenvs/pandas-dev/bin/activate && \
         python -m pip install --no-deps -U pip wheel setuptools && \
-        pip install cython numpy python-dateutil pytz pytest pytest-xdist hypothesis pytest-azurepipelines && \
+        pip install cython numpy python-dateutil pytz pytest pytest-xdist hypothesis pytest-azurepipelines pytest-timeout && \
         python setup.py build_ext -q -j2 && \
         python -m pip install --no-build-isolation -e . && \
         pytest -m 'not slow and not network and not clipboard' pandas --junitxml=test-data.xml"

--- a/ci/deps/actions-38-db-min.yaml
+++ b/ci/deps/actions-38-db-min.yaml
@@ -9,6 +9,7 @@ dependencies:
   - pytest>=6.0
   - pytest-cov
   - pytest-xdist>=1.31
+  - pytest-timeout
   - hypothesis>=5.5.3
 
   # required

--- a/ci/deps/actions-38-db.yaml
+++ b/ci/deps/actions-38-db.yaml
@@ -8,6 +8,7 @@ dependencies:
   - cython>=0.29.24
   - pytest>=6.0
   - pytest-xdist>=1.31
+  - pytest-timeout
   - hypothesis>=5.5.3
   - pytest-cov>=2.10.1  # this is only needed in the coverage build, ref: GH 35737
 

--- a/ci/deps/actions-38-locale.yaml
+++ b/ci/deps/actions-38-locale.yaml
@@ -9,6 +9,7 @@ dependencies:
   - pytest>=6.0
   - pytest-cov
   - pytest-xdist>=1.31
+  - pytest-timeout
   - pytest-asyncio>=0.12.0
   - hypothesis>=5.5.3
 

--- a/ci/deps/actions-38-locale_slow.yaml
+++ b/ci/deps/actions-38-locale_slow.yaml
@@ -10,6 +10,7 @@ dependencies:
   - pytest>=6.0
   - pytest-cov
   - pytest-xdist>=1.31
+  - pytest-timeout
   - hypothesis>=5.5.3
 
   # pandas dependencies

--- a/ci/deps/actions-38-minimum_versions.yaml
+++ b/ci/deps/actions-38-minimum_versions.yaml
@@ -9,6 +9,7 @@ dependencies:
   - pytest>=6.0
   - pytest-cov
   - pytest-xdist>=1.31
+  - pytest-timeout
   - hypothesis>=5.5.3
   - psutil
 

--- a/ci/deps/actions-38-slow.yaml
+++ b/ci/deps/actions-38-slow.yaml
@@ -9,6 +9,7 @@ dependencies:
   - pytest>=6.0
   - pytest-cov
   - pytest-xdist>=1.31
+  - pytest-timeout
   - hypothesis>=5.5.3
 
   # pandas dependencies

--- a/ci/deps/actions-38.yaml
+++ b/ci/deps/actions-38.yaml
@@ -10,6 +10,7 @@ dependencies:
   - pytest>=6.0
   - pytest-cov
   - pytest-xdist>=1.31
+  - pytest-timeout
   - hypothesis>=5.5.3
 
   # pandas dependencies

--- a/ci/deps/actions-39-numpydev.yaml
+++ b/ci/deps/actions-39-numpydev.yaml
@@ -8,6 +8,7 @@ dependencies:
   - pytest>=6.0
   - pytest-cov
   - pytest-xdist>=1.31
+  - pytest-timeout
   - hypothesis>=5.5.3
 
   # pandas dependencies

--- a/ci/deps/actions-39-slow.yaml
+++ b/ci/deps/actions-39-slow.yaml
@@ -10,6 +10,7 @@ dependencies:
   - pytest>=6.0
   - pytest-cov
   - pytest-xdist>=1.31
+  - pytest-timeout
   - hypothesis>=5.5.3
 
   # pandas dependencies

--- a/ci/deps/actions-39.yaml
+++ b/ci/deps/actions-39.yaml
@@ -9,6 +9,7 @@ dependencies:
   - pytest>=6.0
   - pytest-cov
   - pytest-xdist>=1.31
+  - pytest-timeout
   - hypothesis>=5.5.3
 
   # pandas dependencies

--- a/ci/deps/azure-macos-38.yaml
+++ b/ci/deps/azure-macos-38.yaml
@@ -8,6 +8,7 @@ dependencies:
   # tools
   - pytest>=6.0
   - pytest-xdist>=1.31
+  - pytest-timeout
   - hypothesis>=5.5.3
   - pytest-azurepipelines
 

--- a/ci/deps/azure-windows-38.yaml
+++ b/ci/deps/azure-windows-38.yaml
@@ -9,6 +9,7 @@ dependencies:
   - cython>=0.29.24
   - pytest>=6.0
   - pytest-xdist>=1.31
+  - pytest-timeout
   - hypothesis>=5.5.3
   - pytest-azurepipelines
 

--- a/ci/deps/azure-windows-39.yaml
+++ b/ci/deps/azure-windows-39.yaml
@@ -9,6 +9,7 @@ dependencies:
   - cython>=0.29.24
   - pytest>=6.0
   - pytest-xdist>=1.31
+  - pytest-timeout
   - hypothesis>=5.5.3
   - pytest-azurepipelines
 

--- a/ci/deps/circle-38-arm64.yaml
+++ b/ci/deps/circle-38-arm64.yaml
@@ -8,6 +8,7 @@ dependencies:
   - cython>=0.29.24
   - pytest>=6.0
   - pytest-xdist>=1.31
+  - pytest-timeout
   - hypothesis>=5.5.3
 
   # pandas dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -61,6 +61,7 @@ dependencies:
   - pytest>=6.0
   - pytest-cov
   - pytest-xdist>=1.31
+  - pytest-timeout
   - pytest-asyncio
   - pytest-instafail
 

--- a/pandas/tests/io/__init__.py
+++ b/pandas/tests/io/__init__.py
@@ -24,4 +24,6 @@ pytestmark = [
     pytest.mark.filterwarnings(
         "ignore:As the xlwt package is no longer maintained:FutureWarning"
     ),
+    # Troubleshooting build failures that look like network timeouts
+    pytest.mark.timeout(60),
 ]

--- a/pandas/tests/io/test_user_agent.py
+++ b/pandas/tests/io/test_user_agent.py
@@ -13,6 +13,10 @@ import pandas.util._test_decorators as td
 import pandas as pd
 import pandas._testing as tm
 
+# Troubleshooting build failures on Windows that tentatively look like
+#  they are stalling in this file.
+pytestmark = pytest.mark.timeout(60)
+
 
 class BaseUserAgentResponder(http.server.BaseHTTPRequestHandler):
     """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -39,6 +39,7 @@ flask
 pytest>=6.0
 pytest-cov
 pytest-xdist>=1.31
+pytest-timeout
 pytest-asyncio
 pytest-instafail
 seaborn


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

Broken off from #44429, where I haven't seen any of the windows timeouts over quite a few runs.