### PR TITLE
BUG: SparseArray.min/max skipna

### DIFF
--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -1387,10 +1387,20 @@ class TestMinMax:
         ],
     )
     def test_nan_fill_value(self, raw_data, max_expected, min_expected):
-        max_result = SparseArray(raw_data).max()
-        min_result = SparseArray(raw_data).min()
+        arr = SparseArray(raw_data)
+        max_result = arr.max()
+        min_result = arr.min()
         assert max_result in max_expected
         assert min_result in min_expected
+
+        max_result = arr.max(skipna=False)
+        min_result = arr.min(skipna=False)
+        if np.isnan(raw_data).any():
+            assert np.isnan(max_result)
+            assert np.isnan(min_result)
+        else:
+            assert max_result in max_expected
+            assert min_result in min_expected
 
     @pytest.mark.parametrize(
         "fill_value,max_expected,min_expected",
@@ -1409,6 +1419,16 @@ class TestMinMax:
         min_result = arr.min()
         assert min_result == min_expected
 
+    def test_only_fill_value(self):
+        fv = 100
+        arr = SparseArray(np.array([fv, fv, fv]), dtype=SparseDtype("int", fv))
+        assert len(arr._valid_sp_values) == 0
+
+        assert arr.max() == fv
+        assert arr.min() == fv
+        assert arr.max(skipna=False) == fv
+        assert arr.min(skipna=False) == fv
+
     @pytest.mark.parametrize("func", ["min", "max"])
     @pytest.mark.parametrize("data", [np.array([]), np.array([np.nan, np.nan])])
     @pytest.mark.parametrize(
@@ -1423,7 +1443,8 @@ class TestMinMax:
     def test_na_value_if_no_valid_values(self, func, data, dtype, expected):
         arr = SparseArray(data, dtype=dtype)
         result = getattr(arr, func)()
-        if expected == pd.NaT:
-            assert result == pd.NaT
+        if expected is pd.NaT:
+            # TODO: pin down whether we wrap datetime64("NaT")
+            assert result is pd.NaT or np.isnat(result)
         else:
             assert np.isnan(result)


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

Not user-facing unless you're using SparseArray directly; Series and DataFrame will still mess this up until SparseArray._reduce is fixed, which will have to wait until this is addressed for all the SparseArray reductions.
