### PR TITLE
BUG: IntervalArray.__cmp__(pd.NA)

### DIFF
--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -38,6 +38,7 @@ from pandas.core.dtypes.common import (
     is_unsigned_integer_dtype,
     pandas_dtype,
 )
+from pandas.core.dtypes.dtypes import IntervalDtype
 
 import pandas as pd
 from pandas import (
@@ -282,6 +283,10 @@ def to_array(obj):
         return DatetimeArray._from_sequence(obj)
     elif is_timedelta64_dtype(dtype):
         return TimedeltaArray._from_sequence(obj)
+    elif isinstance(obj, pd.core.arrays.BooleanArray):
+        return obj
+    elif isinstance(dtype, IntervalDtype):
+        return pd.core.arrays.IntervalArray(obj)
     else:
         return np.array(obj)
 

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -685,6 +685,13 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             other = pd_array(other)
         elif not isinstance(other, Interval):
             # non-interval scalar -> no matches
+            if other is NA:
+                # GH#31882
+                from pandas.core.arrays import BooleanArray
+
+                arr = np.empty(self.shape, dtype=bool)
+                mask = np.ones(self.shape, dtype=bool)
+                return BooleanArray(arr, mask)
             return invalid_comparison(self, other, op)
 
         # determine the dtype of the elements we want to compare
@@ -743,7 +750,8 @@ class IntervalArray(IntervalMixin, ExtensionArray):
                 if obj is NA:
                     # comparison with np.nan returns NA
                     # github.com/pandas-dev/pandas/pull/37124#discussion_r509095092
-                    result[i] = op is operator.ne
+                    result = result.astype(object)
+                    result[i] = NA
                 else:
                     raise
         return result


### PR DESCRIPTION
- [x] closes #31882
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

Could repurpose #31882 to be about the more general case and not just IntervalArray?

DataFrame cases fail in a way that would be avoided with 2D EAs.