### PR TITLE
CI: Pin numpydev wheels

### DIFF
--- a/.github/workflows/python-dev.yml
+++ b/.github/workflows/python-dev.yml
@@ -49,7 +49,8 @@ jobs:
       shell: bash
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
+        # TODO: unpin
+        pip install -i https://pypi.anaconda.org/scipy-wheels-nightly/simple "numpy==1.23.0.dev0+101.ga81535a36"
         pip install git+https://github.com/nedbat/coveragepy.git
         pip install cython python-dateutil pytz hypothesis pytest>=6.2.5 pytest-xdist pytest-cov pytest-timeout
         pip list

--- a/ci/deps/actions-39-numpydev.yaml
+++ b/ci/deps/actions-39-numpydev.yaml
@@ -19,5 +19,6 @@ dependencies:
     - cython==0.29.24 # GH#34014
     - "--extra-index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple"
     - "--pre"
-    - "numpy"
+    # TODO: Unpin
+    - "numpy==1.23.0.dev0+101.ga81535a36"
     - "scipy"


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

Honestly, Python 3.10 should be moved to the posix file, xref #43890. I don't have time for that though rn.

Probably not gonna be available tmrw, feel free to push commits to this branch for me.

This pins to a 4 day old wheel.
