### PR TITLE
BUG: inconsistency in dtype of replace() #44864

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -738,8 +738,8 @@ class Block(PandasObject):
         new_values = self.values if inplace else self.values.copy()
         replace_regex(new_values, rx, value, mask)
 
-        block = self.make_block(new_values).convert(numeric=False, copy=False)
-        return [block]
+        block = self.make_block(new_values)
+        return block.convert(numeric=False, copy=False)
 
     @final
     def _replace_list(

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -738,7 +738,7 @@ class Block(PandasObject):
         new_values = self.values if inplace else self.values.copy()
         replace_regex(new_values, rx, value, mask)
 
-        block = self.make_block(new_values)
+        block = self.make_block(new_values).convert(numeric=False, copy=False)
         return [block]
 
     @final

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -512,10 +512,10 @@ class TestSeriesReplace:
         result = ser.replace(regex_mapping, regex=True)
         exp = pd.Series(["CC", "CC", "CC-REPL", "DD", "CC", "", pd.NA], dtype="string")
         tm.assert_series_equal(result, exp)
-        
+
     def test_replace_regex_dtype(self):
-        #GH-48644
+        # GH-48644
         s = pd.Series(['0'])
-        exp = s.replace(to_replace = '0', value = 1, regex = False).dtype
-        res = s.replace(to_replace = '0', value = 1, regex = True).dtype
+        exp = s.replace(to_replace='0', value=1, regex=False).dtype
+        res = s.replace(to_replace='0', value=1, regex=True).dtype
         assert exp == res

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -512,3 +512,10 @@ class TestSeriesReplace:
         result = ser.replace(regex_mapping, regex=True)
         exp = pd.Series(["CC", "CC", "CC-REPL", "DD", "CC", "", pd.NA], dtype="string")
         tm.assert_series_equal(result, exp)
+        
+    def test_replace_regex_dtype(self):
+        #GH-48644
+        s = pd.Series(['0'])
+        exp = s.replace(to_replace = '0', value = 1, regex = False).dtype
+        res = s.replace(to_replace = '0', value = 1, regex = True).dtype
+        assert exp == res


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
