### PR TITLE
BUG: fixed fillna('') on a Int64 column causes TypeError: <U3 cannot b…

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -598,6 +598,12 @@ class DataFrame(NDFrame, OpsMixin):
         if data is None:
             data = {}
         if dtype is not None:
+            if isinstance(dtype, str):
+                if dtype == "Int64":
+                    dtype = "int64"
+                elif dtype == "Float64":
+                    dtype = "float64"
+
             dtype = self._validate_dtype(dtype)
 
         if isinstance(data, DataFrame):

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -647,3 +647,87 @@ def test_fillna_nonconsolidated_frame():
     df_nonconsol = df.pivot("i1", "i2")
     result = df_nonconsol.fillna(0)
     assert result.isna().sum().sum() == 0
+
+
+def test_fillna_with_int_and_string_nonempty():
+    df = DataFrame(
+        {
+            "A": [1, 2, np.nan],
+            "B": [4, np.nan, 8],
+        },
+        dtype="Int64",
+    )
+    df.fillna("nan")
+
+    expected = df = DataFrame(
+        {
+            "A": [1, 2, " "],
+            "B": [4, " ", 8],
+        },
+        dtype="Int64",
+    )
+
+    tm.assert_frame_equal(df, expected)
+
+
+def test_fillna_with_int_and_string_empty():
+    df = DataFrame(
+        {
+            "A": [1, 2, np.nan],
+            "B": [4, np.nan, 8],
+        },
+        dtype="Int64",
+    )
+    df.fillna(" ")
+
+    expected = df = DataFrame(
+        {
+            "A": [1, 2, " "],
+            "B": [4, " ", 8],
+        },
+        dtype="Int64",
+    )
+
+    tm.assert_frame_equal(df, expected)
+
+
+def test_fillna_with_float_and_string_nonempty():
+    df = DataFrame(
+        {
+            "A": [1, 2, np.nan],
+            "B": [4, np.nan, 8],
+        },
+        dtype="Float64",
+    )
+    df.fillna("nan")
+
+    expected = df = DataFrame(
+        {
+            "A": [1, 2, " "],
+            "B": [4, " ", 8],
+        },
+        dtype="Float64",
+    )
+
+    tm.assert_frame_equal(df, expected)
+
+
+def test_fillna_with_float_and_string_empty():
+    df = DataFrame(
+        {
+            "A": [1, 2, np.nan],
+            "B": [4, np.nan, 8],
+        },
+        dtype="Float64",
+    )
+    df.fillna(" ")
+
+    expected = df = DataFrame(
+        {
+            "A": [1, 2, " "],
+            "B": [4, " ", 8],
+        },
+        dtype="Float64",
+    )
+
+    tm.assert_frame_equal(df, expected)


### PR DESCRIPTION
…e converted to an IntegerDtype(#44289)

- [x] closes #44289
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

this contribution is for a class project and need not be accepted but feedback is always appreciated