### PR TITLE
CLN/TST: remove used-once fixtures

### DIFF
--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -161,6 +161,17 @@ ALL_NUMPY_DTYPES = (
     + BYTES_DTYPES
 )
 
+NARROW_NP_DTYPES = [
+    np.float16,
+    np.float32,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+]
+
 NULL_OBJECTS = [None, np.nan, pd.NaT, float("nan"), pd.NA, Decimal("NaN")]
 NP_NAT_OBJECTS = [
     cls("NaT", unit)

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -600,11 +600,6 @@ def index_with_missing(request):
 # Series'
 # ----------------------------------------------------------------
 @pytest.fixture
-def empty_series():
-    return Series([], index=[], dtype=np.float64)
-
-
-@pytest.fixture
 def string_series():
     """
     Fixture for Series of floats with Index of unique strings
@@ -672,29 +667,10 @@ def series_with_multilevel_index():
     return ser
 
 
-_narrow_dtypes = [
-    np.float16,
-    np.float32,
-    np.int8,
-    np.int16,
-    np.int32,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-]
 _narrow_series = {
     f"{dtype.__name__}-series": tm.makeFloatSeries(name="a").astype(dtype)
-    for dtype in _narrow_dtypes
+    for dtype in tm.NARROW_NP_DTYPES
 }
-
-
-@pytest.fixture(params=_narrow_series.keys())
-def narrow_series(request):
-    """
-    Fixture for Series with low precision data types
-    """
-    # copy to avoid mutation, e.g. setting .name
-    return _narrow_series[request.param].copy()
 
 
 _index_or_series_objs = {**indices_dict, **_series, **_narrow_series}
@@ -712,11 +688,6 @@ def index_or_series_obj(request):
 # ----------------------------------------------------------------
 # DataFrames
 # ----------------------------------------------------------------
-@pytest.fixture
-def empty_frame():
-    return DataFrame()
-
-
 @pytest.fixture
 def int_frame():
     """

--- a/pandas/tests/base/test_misc.py
+++ b/pandas/tests/base/test_misc.py
@@ -18,6 +18,7 @@ from pandas import (
     Index,
     Series,
 )
+import pandas._testing as tm
 
 
 @pytest.mark.parametrize(
@@ -109,8 +110,9 @@ def test_memory_usage_components_series(series_with_simple_index):
     assert total_usage == non_index_usage + index_usage
 
 
-def test_memory_usage_components_narrow_series(narrow_series):
-    series = narrow_series
+@pytest.mark.parametrize("dtype", tm.NARROW_NP_DTYPES)
+def test_memory_usage_components_narrow_series(dtype):
+    series = tm.makeFloatSeries(name="a").astype(dtype)
     total_usage = series.memory_usage(index=True)
     non_index_usage = series.memory_usage(index=False)
     index_usage = series.index.memory_usage()

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1384,8 +1384,9 @@ class TestDataFrameReplace:
 
     @pytest.mark.xfail(
         reason="category dtype gets changed to object type after replace, see #35268",
+        raises=AssertionError,
     )
-    def test_replace_dict_category_type(self, input_category_df, expected_category_df):
+    def test_replace_dict_category_type(self):
         """
         Test to ensure category dtypes are maintained
         after replace with dict values

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -244,7 +244,8 @@ class TestPandasContainer:
 
     @pytest.mark.parametrize("convert_axes", [True, False])
     @pytest.mark.parametrize("numpy", [True, False])
-    def test_roundtrip_empty(self, orient, convert_axes, numpy, empty_frame):
+    def test_roundtrip_empty(self, orient, convert_axes, numpy):
+        empty_frame = DataFrame()
         data = empty_frame.to_json(orient=orient)
         result = read_json(data, orient=orient, convert_axes=convert_axes, numpy=numpy)
         expected = empty_frame.copy()
@@ -673,7 +674,8 @@ class TestPandasContainer:
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("numpy", [True, False])
-    def test_series_roundtrip_empty(self, orient, numpy, empty_series):
+    def test_series_roundtrip_empty(self, orient, numpy):
+        empty_series = Series([], index=[], dtype=np.float64)
         data = empty_series.to_json(orient=orient)
         result = read_json(data, typ="series", orient=orient, numpy=numpy)
 


### PR DESCRIPTION
And fix a test that is silently failing incorrectly by trying to access nonexistent fixtures.