### PR TITLE
Add labels for github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -7,7 +7,7 @@ body:
   - type: checkboxes
     id: checks
     attributes:
-      label: Version Checks
+      label: Pandas version checks
       options:
         - label: >
             I have checked that this issue has not already been reported.

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -7,6 +7,7 @@ body:
   - type: checkboxes
     id: checks
     attributes:
+      label: Version Checks
       options:
         - label: >
             I have checked that this issue has not already been reported.

--- a/.github/ISSUE_TEMPLATE/documentation_improvement.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation_improvement.yaml
@@ -6,6 +6,7 @@ labels: [Docs, Needs Triage]
 body:
   - type: checkboxes
     attributes:
+      label: Pandas version checks
       options:
         - label: >
             I have checked that the issue still exists on the latest versions of the docs

--- a/.github/ISSUE_TEMPLATE/installation_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/installation_issue.yaml
@@ -7,6 +7,7 @@ body:
   - type: checkboxes
     id: checks
     attributes:
+      label: Pandas version checks
       options:
         - label: >
             I have read the [installation guide](https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html#installing-pandas).

--- a/.github/ISSUE_TEMPLATE/installation_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/installation_issue.yaml
@@ -7,7 +7,7 @@ body:
   - type: checkboxes
     id: checks
     attributes:
-      label: Pandas version checks
+      label: Installation check
       options:
         - label: >
             I have read the [installation guide](https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html#installing-pandas).

--- a/.github/ISSUE_TEMPLATE/performance_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/performance_issue.yaml
@@ -7,6 +7,7 @@ body:
   - type: checkboxes
     id: checks
     attributes:
+      label: Pandas version checks
       options:
         - label: >
             I have checked that this issue has not already been reported.

--- a/.github/ISSUE_TEMPLATE/submit_question.yml
+++ b/.github/ISSUE_TEMPLATE/submit_question.yml
@@ -11,6 +11,7 @@ body:
         usage questions, we ask that all usage questions are first asked on StackOverflow.
   - type: checkboxes
     attributes:
+      label: Research
       options:
         - label: >
             I have searched the [[pandas] tag](https://stackoverflow.com/questions/tagged/pandas)


### PR DESCRIPTION
- [x] closes #44905

Looks like they changed the format a bit

You can check how they look under https://github.com/phofl/pandas/issues/new/choose

cc @twoertwein 