### PR TITLE
DEPR: ‘names’ param in Index.copy

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -537,6 +537,7 @@ Other Deprecations
 - Deprecated passing arguments as positional for :func:`read_fwf` other than ``filepath_or_buffer`` (:issue:`41485`):
 - Deprecated passing ``skipna=None`` for :meth:`DataFrame.mad` and :meth:`Series.mad`, pass ``skipna=True`` instead (:issue:`44580`)
 - Deprecated :meth:`DateOffset.apply`, use ``offset + other`` instead (:issue:`44522`)
+- Deprecated parameter ``names`` in :meth:`Index.copy` (:issue:`xxxx`)
 - A deprecation warning is now shown for :meth:`DataFrame.to_latex` indicating the arguments signature may change and emulate more the arguments to :meth:`.Styler.to_latex` in future versions (:issue:`44411`)
 -
 

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -537,7 +537,7 @@ Other Deprecations
 - Deprecated passing arguments as positional for :func:`read_fwf` other than ``filepath_or_buffer`` (:issue:`41485`):
 - Deprecated passing ``skipna=None`` for :meth:`DataFrame.mad` and :meth:`Series.mad`, pass ``skipna=True`` instead (:issue:`44580`)
 - Deprecated :meth:`DateOffset.apply`, use ``offset + other`` instead (:issue:`44522`)
-- Deprecated parameter ``names`` in :meth:`Index.copy` (:issue:`xxxx`)
+- Deprecated parameter ``names`` in :meth:`Index.copy` (:issue:`44916`)
 - A deprecation warning is now shown for :meth:`DataFrame.to_latex` indicating the arguments signature may change and emulate more the arguments to :meth:`.Styler.to_latex` in future versions (:issue:`44411`)
 -
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1181,7 +1181,6 @@ class Index(IndexOpsMixin, PandasObject):
             .. deprecated:: 1.4.0
                 use ``name`` instead.
 
-
         Returns
         -------
         Index

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1178,6 +1178,10 @@ class Index(IndexOpsMixin, PandasObject):
         names : list-like, optional
             Kept for compatibility with MultiIndex. Should not be used.
 
+            .. deprecated:: 1.4.0
+                use ``name`` instead.
+
+
         Returns
         -------
         Index
@@ -1188,6 +1192,14 @@ class Index(IndexOpsMixin, PandasObject):
         In most cases, there should be no functional difference from using
         ``deep``, but if ``deep`` is passed it will attempt to deepcopy.
         """
+        if names is not None:
+            warnings.warn(
+                "parameter names is deprecated and will be removed in a future "
+                "version. Use the name parameter instead.",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
+
         name = self._validate_names(name=name, names=names, deep=deep)[0]
         if deep:
             new_data = self._data.copy()

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1270,7 +1270,7 @@ class TestMixedIntIndex(Base):
             assert index3.names == ["NewName"]
 
     def test_copy_names_deprecated(self, simple_index):
-        # GH#xxxxx
+        # GH44916
         with tm.assert_produces_warning(FutureWarning):
             simple_index.copy(names=["a"])
 

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1261,7 +1261,7 @@ class TestMixedIntIndex(Base):
         assert index.name == "MyName"
         assert index2.name == "NewName"
 
-        with catch_warnings(record=True):
+        with tm.assert_produces_warning(FutureWarning):
             index3 = index.copy(names=["NewName"])
         tm.assert_index_equal(index, index3, check_names=False)
         assert index.name == "MyName"

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from io import StringIO
 import math
 import re
+from warnings import catch_warnings
 
 import numpy as np
 import pytest
@@ -1260,12 +1261,18 @@ class TestMixedIntIndex(Base):
         assert index.name == "MyName"
         assert index2.name == "NewName"
 
-        index3 = index.copy(names=["NewName"])
-        tm.assert_index_equal(index, index3, check_names=False)
-        assert index.name == "MyName"
-        assert index.names == ["MyName"]
-        assert index3.name == "NewName"
-        assert index3.names == ["NewName"]
+        with catch_warnings(record=True):
+            index3 = index.copy(names=["NewName"])
+            tm.assert_index_equal(index, index3, check_names=False)
+            assert index.name == "MyName"
+            assert index.names == ["MyName"]
+            assert index3.name == "NewName"
+            assert index3.names == ["NewName"]
+
+    def test_copy_names_deprecated(self, simple_index):
+        # GH#xxxxx
+        with tm.assert_produces_warning(FutureWarning):
+            simple_index.copy(names=["a"])
 
     def test_unique_na(self):
         idx = Index([2, np.nan, 2, 1], name="my_index")

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from io import StringIO
 import math
 import re
-from warnings import catch_warnings
 
 import numpy as np
 import pytest

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1263,11 +1263,11 @@ class TestMixedIntIndex(Base):
 
         with catch_warnings(record=True):
             index3 = index.copy(names=["NewName"])
-            tm.assert_index_equal(index, index3, check_names=False)
-            assert index.name == "MyName"
-            assert index.names == ["MyName"]
-            assert index3.name == "NewName"
-            assert index3.names == ["NewName"]
+        tm.assert_index_equal(index, index3, check_names=False)
+        assert index.name == "MyName"
+        assert index.names == ["MyName"]
+        assert index3.name == "NewName"
+        assert index3.names == ["NewName"]
 
     def test_copy_names_deprecated(self, simple_index):
         # GH44916


### PR DESCRIPTION
Deprecates this parameter. `names` is not used in `Index.__init__`, so no reason to be used in `Index.copy`.