### PR TITLE
ENH: Implemented a check to test if filepath_or_buffer is a valid JSON string or a valid filepath and raises an error in the case that it is neither.

### DIFF
--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -690,6 +690,31 @@ class JsonReader(abc.Iterator):
             data = StringIO(data)
 
         return data
+    
+    def check_jsonstring_or_filepath(self, filepath_or_buffer):
+        """
+        This function takes filepath_or_buffer and checks to see
+        if filepath_or_buffer is intended as a JSON string or is
+        intended as a valid filepath. This is because we cannot say
+        that since a string is not a valid path, raise a
+        FileNotFound Exception.
+
+        This function provides a check on when the filepath does not
+        exist and when the filepath_or_buffer is not a json, what
+        the course of action should be.
+        """
+
+        # Use json.loads() which will throw a ValueError if the string you
+        # pass can't be decoded as JSON.
+        try:
+            json.loads(filepath_or_buffer)
+            return "json"
+        except ValueError:
+            # Then, check if filepath_or_buffer is a valid filepath.
+            if file_exists(filepath_or_buffer):
+                return "filepath"
+            else:
+                return "string"
 
     def _get_data_from_filepath(self, filepath_or_buffer):
         """
@@ -701,6 +726,21 @@ class JsonReader(abc.Iterator):
         This method turns (1) into (2) to simplify the rest of the processing.
         It returns input types (2) and (3) unchanged.
         """
+
+        # Provides a check on when the filepath does not exist and the filepath_or_buffer
+        # is not a json, what should be our action.
+        jsonstring_or_filepath = check_jsonstring_or_filepath(filepath_or_buffer)
+        if jsonstring_or_filepath == "json":
+            return
+        elif jsonstring_or_filepath == "filepath":
+            pass
+        else:
+            raise ValueError(
+                "This filepath {filepath} does not occur and is not a valid JSON string".format(
+                    filepath_or_buffer
+                )
+            )
+
         # if it is a string but the file does not exist, it might be a JSON string
         filepath_or_buffer = stringify_path(filepath_or_buffer)
         if (

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -200,7 +200,8 @@ Look,a snake,🐍"""
             (pd.read_hdf, "tables", FileNotFoundError, "h5"),
             (pd.read_stata, "os", FileNotFoundError, "dta"),
             (pd.read_sas, "os", FileNotFoundError, "sas7bdat"),
-            (pd.read_json, "os", ValueError, "json"),
+            # (pd.read_json, "os", ValueError, "json"),
+            (pd.read_json, "os", FileNotFoundError, "json"),
             (pd.read_pickle, "os", FileNotFoundError, "pickle"),
         ],
     )
@@ -266,7 +267,8 @@ Look,a snake,🐍"""
             (pd.read_hdf, "tables", FileNotFoundError, "h5"),
             (pd.read_stata, "os", FileNotFoundError, "dta"),
             (pd.read_sas, "os", FileNotFoundError, "sas7bdat"),
-            (pd.read_json, "os", ValueError, "json"),
+            # (pd.read_json, "os", ValueError, "json"),
+            (pd.read_json, "os", FileNotFoundError, "json"),
             (pd.read_pickle, "os", FileNotFoundError, "pickle"),
         ],
     )

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -199,7 +199,8 @@ Look,a snake,🐍"""
             (pd.read_hdf, "tables", FileNotFoundError, "h5"),
             (pd.read_stata, "os", FileNotFoundError, "dta"),
             (pd.read_sas, "os", FileNotFoundError, "sas7bdat"),
-            (pd.read_json, "os", ValueError, "json"),
+            # (pd.read_json, "os", ValueError, "json"),
+            (pd.read_json, "os", FileNotFoundError, "json"),
             (pd.read_pickle, "os", FileNotFoundError, "pickle"),
         ],
     )
@@ -265,7 +266,8 @@ Look,a snake,🐍"""
             (pd.read_hdf, "tables", FileNotFoundError, "h5"),
             (pd.read_stata, "os", FileNotFoundError, "dta"),
             (pd.read_sas, "os", FileNotFoundError, "sas7bdat"),
-            (pd.read_json, "os", ValueError, "json"),
+            # (pd.read_json, "os", ValueError, "json"),
+            (pd.read_json, "os", FileNotFoundError, "json"),
             (pd.read_pickle, "os", FileNotFoundError, "pickle"),
         ],
     )


### PR DESCRIPTION
- [x] closes #29104 thread.
- [ ] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

ENH: Implemented a check to test if filepath_or_buffer is a valid JSON string or a valid filepath and raises an error in the case that it is neither. Per the thread in #29102 and related thread in #29104, there should be a way to differentiate between a json string passed as input and a file_path. We cannot just say that since a string is not a valid path, raise a FileNotFoundException. So this PR attempts to check intent.