### PR TITLE
DOC: Fix mistake in code example

### DIFF
--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -2424,7 +2424,7 @@ you can use the ``tz_convert`` method.
 
     For ``pytz`` time zones, it is incorrect to pass a time zone object directly into
     the ``datetime.datetime`` constructor
-    (e.g., ``datetime.datetime(2011, 1, 1, tz=pytz.timezone('US/Eastern'))``.
+    (e.g., ``datetime.datetime(2011, 1, 1, tzinfo=pytz.timezone('US/Eastern'))``.
     Instead, the datetime needs to be localized using the ``localize`` method
     on the ``pytz`` time zone object.
 


### PR DESCRIPTION
### Location of the documentation

<https://pandas.pydata.org/docs/user_guide/timeseries.html#working-with-time-zones>

```python
import datetime
import pytz

datetime.datetime(2011, 1, 1, tz=pytz.timezone('US/Eastern'))
```

```python
TypeError: 'tz' is an invalid keyword argument for this function
```

Replace ``tz`` with ``tzinfo`` can fix it.

```python
import datetime
import pytz
datetime.datetime(2011, 1, 1, tzinfo=pytz.timezone('US/Eastern'))
```

```python
datetime.datetime(2011, 1, 1, 0, 0, tzinfo=<DstTzInfo 'US/Eastern' LMT-1 day, 19:04:00 STD>)
```