### PR TITLE
PERF: short-circuit allocations in infer_dtype, ensure_datetime64ns

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -1450,9 +1450,10 @@ def infer_dtype(value: object, skipna: bool = True) -> str:
         # This should not be reached
         values = values.astype(object)
 
+    # for f-contiguous array 1000 x 1000, passing order="K" gives 5000x speedup
+    values = values.ravel(order="K")
+
     if skipna:
-        # for f-contiguous array 1000 x 1000, passing order="K" gives 5000x speedup
-        values = values.ravel(order="K")
         values = values[~isnaobj(values)]
 
     n = cnp.PyArray_SIZE(values)

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -1440,25 +1440,27 @@ def infer_dtype(value: object, skipna: bool = True) -> str:
         from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
         values = construct_1d_object_array_from_listlike(value)
 
-    # make contiguous
-    # for f-contiguous array 1000 x 1000, passing order="K" gives 5000x speedup
-    values = values.ravel(order="K")
-
     val = _try_infer_map(values.dtype)
     if val is not None:
+        # Anything other than object-dtype should return here.
         return val
 
-    if values.dtype != np.object_:
-        values = values.astype("O")
+    if values.descr.type_num != NPY_OBJECT:
+        # i.e. values.dtype != np.object
+        # This should not be reached
+        values = values.astype(object)
 
     if skipna:
+        # for f-contiguous array 1000 x 1000, passing order="K" gives 5000x speedup
+        values = values.ravel(order="K")
         values = values[~isnaobj(values)]
 
-    n = len(values)
+    n = cnp.PyArray_SIZE(values)
     if n == 0:
         return "empty"
 
-    # try to use a valid value
+    # Iterate until we find our first valid value. We will use this
+    #  value to decide which of the is_foo_array functions to call.
     for i in range(n):
         val = values[i]
 

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -227,12 +227,7 @@ def ensure_datetime64ns(arr: ndarray, copy: bool = True):
         dtype = arr.dtype
         arr = arr.astype(dtype.newbyteorder("<"))
 
-    ivalues = arr.view(np.int64).ravel("K")
-
-    result = np.empty_like(arr, dtype=DT64NS_DTYPE)
-    iresult = result.ravel("K").view(np.int64)
-
-    if len(iresult) == 0:
+    if arr.size == 0:
         result = arr.view(DT64NS_DTYPE)
         if copy:
             result = result.copy()
@@ -245,17 +240,23 @@ def ensure_datetime64ns(arr: ndarray, copy: bool = True):
         raise ValueError("datetime64/timedelta64 must have a unit specified")
 
     if unit == NPY_FR_ns:
+        # Check this before allocating result for perf, might save some memory
         if copy:
-            arr = arr.copy()
-        result = arr
-    else:
-        for i in range(n):
-            if ivalues[i] != NPY_NAT:
-                pandas_datetime_to_datetimestruct(ivalues[i], unit, &dts)
-                iresult[i] = dtstruct_to_dt64(&dts)
-                check_dts_bounds(&dts)
-            else:
-                iresult[i] = NPY_NAT
+            return arr.copy()
+        return arr
+
+    ivalues = arr.view(np.int64).ravel("K")
+
+    result = np.empty_like(arr, dtype=DT64NS_DTYPE)
+    iresult = result.ravel("K").view(np.int64)
+
+    for i in range(n):
+        if ivalues[i] != NPY_NAT:
+            pandas_datetime_to_datetimestruct(ivalues[i], unit, &dts)
+            iresult[i] = dtstruct_to_dt64(&dts)
+            check_dts_bounds(&dts)
+        else:
+            iresult[i] = NPY_NAT
 
     return result
 


### PR DESCRIPTION
```
from pandas._libs.tslibs.conversion import *

arr = np.arange(10**6).view("M8[ns]")

%timeit ensure_datetime64ns(arr, copy=False)
423 ns ± 10.3 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  # <- PR
3.5 µs ± 17.3 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <- master

%timeit ensure_datetime64ns(arr, copy=True)
517 µs ± 11.4 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)   # <- PR
1.77 ms ± 4.44 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)  # <- master


from pandas._libs.lib import *

farr = np.arange(10**6)[::2]

%timeit infer_dtype(farr, skipna=True)
2.94 µs ± 48.2 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <- PR
412 µs ± 34.4 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)  # <- master
```