### PR TITLE
DOC fix typo in describe_option

### DIFF
--- a/pandas/_config/config.py
+++ b/pandas/_config/config.py
@@ -333,7 +333,7 @@ describe_option(pat, _print_desc=False)
 
 Prints the description for one or more registered options.
 
-Call with not arguments to get a listing for all registered options.
+Call with no arguments to get a listing for all registered options.
 
 Available options:
 

--- a/pandas/_config/config.py
+++ b/pandas/_config/config.py
@@ -333,7 +333,7 @@ describe_option(pat, _print_desc=False)
 
 Prints the description for one or more registered options.
 
-Call with no arguments to get a listing for all registered options.
+Call with not arguments to get a listing for all registered options.
 
 Available options:
 


### PR DESCRIPTION
I updated pandas/_config/config.py fixing a typo - 
Call with not arguments to get a listing for all registered options to Call with no arguments to get a listing for all registered options.

closes #44970