### PR TITLE
TYP: Return int instead of changing result type in nanops.py

### DIFF
--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1391,14 +1391,10 @@ def _maybe_arg_null_out(
     if axis is None or not getattr(result, "ndim", False):
         if skipna:
             if mask.all():
-                # error: Incompatible types in assignment (expression has type
-                # "int", variable has type "ndarray")
-                result = -1  # type: ignore[assignment]
+                return -1
         else:
             if mask.any():
-                # error: Incompatible types in assignment (expression has type
-                # "int", variable has type "ndarray")
-                result = -1  # type: ignore[assignment]
+                return -1
     else:
         if skipna:
             na_mask = mask.all(axis)


### PR DESCRIPTION
xref #37715

The error was about the lines that set ````result = -1````, which changed the type of result from np.ndarray to int. Changed it to return -1 from the if block since everywhere else its dealing with an np.ndarray