### PR TITLE
ENH: Implement Index.__invert__

### DIFF
--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1401,7 +1401,7 @@ class Timedelta(_Timedelta):
     # Arithmetic Methods
     # TODO: Can some of these be defined in the cython class?
 
-    __inv__ = _op_unary_method(lambda x: -x, '__inv__')
+    __inverse__ = _op_unary_method(lambda x: -x, '__inverse__')
     __neg__ = _op_unary_method(lambda x: -x, '__neg__')
     __pos__ = _op_unary_method(lambda x: x, '__pos__')
     __abs__ = _op_unary_method(lambda x: abs(x), '__abs__')

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1401,7 +1401,6 @@ class Timedelta(_Timedelta):
     # Arithmetic Methods
     # TODO: Can some of these be defined in the cython class?
 
-    __inverse__ = _op_unary_method(lambda x: -x, '__inverse__')
     __neg__ = _op_unary_method(lambda x: -x, '__neg__')
     __pos__ = _op_unary_method(lambda x: x, '__pos__')
     __abs__ = _op_unary_method(lambda x: abs(x), '__abs__')

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6636,10 +6636,9 @@ class Index(IndexOpsMixin, PandasObject):
     def __pos__(self):
         return self._unary_method(operator.pos)
 
-    def __inv__(self):
-        # TODO: why not operator.inv?
-        # TODO: __inv__ vs __invert__?
-        return self._unary_method(lambda x: -x)
+    def __invert__(self):
+        # GH#8875
+        return self._unary_method(operator.inv)
 
     # --------------------------------------------------------------------
     # Reductions

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3802,7 +3802,7 @@ class MultiIndex(Index):
     __neg__ = make_invalid_op("__neg__")
     __pos__ = make_invalid_op("__pos__")
     __abs__ = make_invalid_op("__abs__")
-    __inv__ = make_invalid_op("__inv__")
+    __invert__ = make_invalid_op("__invert__")
 
 
 def _lexsort_depth(codes: list[np.ndarray], nlevels: int) -> int:

--- a/pandas/tests/frame/test_unary.py
+++ b/pandas/tests/frame/test_unary.py
@@ -8,7 +8,7 @@ import pandas._testing as tm
 
 
 class TestDataFrameUnaryOperators:
-    # __pos__, __neg__, __inv__
+    # __pos__, __neg__, __invert__
 
     @pytest.mark.parametrize(
         "df,expected",

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -740,6 +740,30 @@ class Base:
         alt = index.take(list(range(N)) * 2)
         tm.assert_index_equal(result, alt, check_exact=True)
 
+    def test_inv(self, simple_index):
+        idx = simple_index
+
+        if idx.dtype.kind in ["i", "u"]:
+            res = ~idx
+            expected = Index(~idx.values, name=idx.name)
+            tm.assert_index_equal(res, expected)
+
+            # check that we are matching Series behavior
+            res2 = ~Series(idx)
+            # TODO(2.0): once we preserve dtype, check_dtype can be True
+            tm.assert_series_equal(res2, Series(expected), check_dtype=False)
+        else:
+            if idx.dtype.kind == "f":
+                msg = "ufunc 'invert' not supported for the input types"
+            else:
+                msg = "bad operand"
+            with pytest.raises(TypeError, match=msg):
+                ~idx
+
+            # check that we get the same behavior with Series
+            with pytest.raises(TypeError, match=msg):
+                ~Series(idx)
+
 
 class NumericBase(Base):
     """

--- a/pandas/tests/indexes/multi/test_compat.py
+++ b/pandas/tests/indexes/multi/test_compat.py
@@ -27,7 +27,7 @@ def test_numeric_compat(idx):
         1 // idx
 
 
-@pytest.mark.parametrize("method", ["all", "any"])
+@pytest.mark.parametrize("method", ["all", "any", "__invert__"])
 def test_logical_compat(idx, method):
     msg = f"cannot perform {method}"
 

--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -25,6 +25,21 @@ import pandas._testing as tm
 
 
 class TestTimedeltaUnaryOps:
+    def test_invert(self):
+        td = Timedelta(10, unit="d")
+
+        msg = "bad operand type for unary ~"
+        with pytest.raises(TypeError, match=msg):
+            ~td
+
+        # check this matches pytimedelta and timedelta64
+        with pytest.raises(TypeError, match=msg):
+            ~(td.to_pytimedelta())
+
+        umsg = "ufunc 'invert' not supported for the input types"
+        with pytest.raises(TypeError, match=umsg):
+            ~(td.to_timedelta64())
+
     def test_unary_ops(self):
         td = Timedelta(10, unit="d")
 

--- a/pandas/tests/series/test_unary.py
+++ b/pandas/tests/series/test_unary.py
@@ -5,7 +5,7 @@ import pandas._testing as tm
 
 
 class TestSeriesUnaryOps:
-    # __neg__, __pos__, __inv__
+    # __neg__, __pos__, __invert__
 
     def test_neg(self):
         ser = tm.makeStringSeries()


### PR DESCRIPTION
- [x] closes #8875
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

Could be considered a bugfix, as we have `__inv__`, which i think is a py2 leftover