### PR TITLE
BUG: dropna changing index when nothing is dropped

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -726,7 +726,7 @@ Missing
 - Bug in constructing a :class:`DataFrame` with a dictionary ``np.datetime64`` as a value and ``dtype='timedelta64[ns]'``, or vice-versa, incorrectly casting instead of raising (:issue:`??`)
 - Bug in :meth:`Series.interpolate` and :meth:`DataFrame.interpolate` with ``inplace=True`` not writing to the underlying array(s) in-place (:issue:`44749`)
 - Bug in :meth:`Index.fillna` incorrectly returning an un-filled :class:`Index` when NA values are present and ``downcast`` argument is specified. This now raises ``NotImplementedError`` instead; do not pass ``downcast`` argument (:issue:`44873`)
--
+- Bug in :meth:`DataFrame.dropna` changing :class:`Index` even if no entries were dropped (:issue:`41965`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5999,7 +5999,10 @@ class DataFrame(NDFrame, OpsMixin):
             else:
                 raise TypeError("must specify how or thresh")
 
-        result = self.loc(axis=axis)[mask]
+        if np.all(mask):
+            result = self.copy()
+        else:
+            result = self.loc(axis=axis)[mask]
 
         if inplace:
             self._update_inplace(result)

--- a/pandas/tests/frame/methods/test_dropna.py
+++ b/pandas/tests/frame/methods/test_dropna.py
@@ -267,3 +267,10 @@ class TestDataFrameMissingData:
         expected = DataFrame({"A": [1.0], "B": ["a"], "C": [4.0]})
         result = df.dropna(subset=np.array(["A", "C"]))
         tm.assert_frame_equal(result, expected)
+
+    def test_no_nans_in_frame(self, axis):
+        # GH#41965
+        df = DataFrame([[1, 2], [3, 4]], columns=pd.RangeIndex(0, 2))
+        expected = df.copy()
+        result = df.dropna(axis=axis)
+        tm.assert_frame_equal(result, expected, check_index_type=True)


### PR DESCRIPTION
- [x] closes #41965
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

```
# With nan as last element
# before
# 1.63 ms ± 113 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# after
# 1.68 ms ± 91.5 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)


# without nan
# before
# 1.6 ms ± 68.5 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# after
# 714 µs ± 63.3 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```