### PR TITLE
DEPR: Deprecate set and dict as indexers

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -545,6 +545,7 @@ Other Deprecations
 - Deprecated parameter ``names`` in :meth:`Index.copy` (:issue:`44916`)
 - A deprecation warning is now shown for :meth:`DataFrame.to_latex` indicating the arguments signature may change and emulate more the arguments to :meth:`.Styler.to_latex` in future versions (:issue:`44411`)
 - Deprecated :meth:`Categorical.replace`, use :meth:`Series.replace` instead (:issue:`44929`)
+- Deprecated passing ``set`` or ``dict`` as indexer for :meth:`DataFrame.loc.__setitem__`, :meth:`DataFrame.loc.__getitem__`, :meth:`Series.loc.__setitem__`, :meth:`Series.loc.__getitem__`, :meth:`DataFrame.__getitem__`, :meth:`Series.__getitem__` and :meth:`Series.__setitem__` (:issue:`42825`)
 - Deprecated :meth:`Index.__getitem__` with a bool key; use ``index.values[key]`` to get the old behavior (:issue:`44051`)
 - Deprecated downcasting column-by-column in :meth:`DataFrame.where` with integer-dtypes (:issue:`44597`)
 -

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3456,7 +3456,32 @@ class DataFrame(NDFrame, OpsMixin):
         for i in range(len(self.columns)):
             yield self._get_column_array(i)
 
+    def _check_deprecated_indexers(self, key):
+        if (
+            isinstance(key, set)
+            or isinstance(key, tuple)
+            and any(isinstance(x, set) for x in key)
+        ):
+            warnings.warn(
+                "Passing a set as an indexer is deprecated and will raise in "
+                "a future version. Use a list instead.",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
+        if (
+            isinstance(key, dict)
+            or isinstance(key, tuple)
+            and any(isinstance(x, dict) for x in key)
+        ):
+            warnings.warn(
+                "Passing a dict as an indexer is deprecated and will raise in "
+                "a future version. Use a list instead.",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
+
     def __getitem__(self, key):
+        self._check_deprecated_indexers(key)
         key = lib.item_from_zerodim(key)
         key = com.apply_if_callable(key, self)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -170,6 +170,7 @@ from pandas.core.indexes.multi import (
 )
 from pandas.core.indexing import (
     check_bool_indexer,
+    check_deprecated_indexers,
     convert_to_index_sliceable,
 )
 from pandas.core.internals import (
@@ -3456,32 +3457,8 @@ class DataFrame(NDFrame, OpsMixin):
         for i in range(len(self.columns)):
             yield self._get_column_array(i)
 
-    def _check_deprecated_indexers(self, key):
-        if (
-            isinstance(key, set)
-            or isinstance(key, tuple)
-            and any(isinstance(x, set) for x in key)
-        ):
-            warnings.warn(
-                "Passing a set as an indexer is deprecated and will raise in "
-                "a future version. Use a list instead.",
-                FutureWarning,
-                stacklevel=find_stack_level(),
-            )
-        if (
-            isinstance(key, dict)
-            or isinstance(key, tuple)
-            and any(isinstance(x, dict) for x in key)
-        ):
-            warnings.warn(
-                "Passing a dict as an indexer is deprecated and will raise in "
-                "a future version. Use a list instead.",
-                FutureWarning,
-                stacklevel=find_stack_level(),
-            )
-
     def __getitem__(self, key):
-        self._check_deprecated_indexers(key)
+        check_deprecated_indexers(key)
         key = lib.item_from_zerodim(key)
         key = com.apply_if_callable(key, self)
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -643,7 +643,7 @@ class _LocationIndexer(NDFrameIndexerBase):
 
         if isinstance(key, tuple):
             for x in key:
-                self._check_deprecated_indexers(x)
+                check_deprecated_indexers(x)
 
         if self.axis is not None:
             return self._convert_tuple(key)
@@ -702,7 +702,7 @@ class _LocationIndexer(NDFrameIndexerBase):
             )
 
     def __setitem__(self, key, value):
-        self._check_deprecated_indexers(key)
+        check_deprecated_indexers(key)
         if isinstance(key, tuple):
             key = tuple(list(x) if is_iterator(x) else x for x in key)
             key = tuple(com.apply_if_callable(x, self.obj) for x in key)
@@ -896,7 +896,7 @@ class _LocationIndexer(NDFrameIndexerBase):
         # we should be able to match up the dimensionality here
 
         for key in tup:
-            self._check_deprecated_indexers(key)
+            check_deprecated_indexers(key)
 
         # we have too many indexers for our dim, but have at least 1
         # multi-index dimension, try to see if we have something like
@@ -950,32 +950,8 @@ class _LocationIndexer(NDFrameIndexerBase):
     def _convert_to_indexer(self, key, axis: int):
         raise AbstractMethodError(self)
 
-    def _check_deprecated_indexers(self, key):
-        if (
-            isinstance(key, set)
-            or isinstance(key, tuple)
-            and any(isinstance(x, set) for x in key)
-        ):
-            warnings.warn(
-                "Passing a set as an indexer is deprecated and will raise in "
-                "a future version. Use a list instead.",
-                FutureWarning,
-                stacklevel=find_stack_level(),
-            )
-        if (
-            isinstance(key, dict)
-            or isinstance(key, tuple)
-            and any(isinstance(x, dict) for x in key)
-        ):
-            warnings.warn(
-                "Passing a dict as an indexer is deprecated and will raise in "
-                "a future version. Use a list instead.",
-                FutureWarning,
-                stacklevel=find_stack_level(),
-            )
-
     def __getitem__(self, key):
-        self._check_deprecated_indexers(key)
+        check_deprecated_indexers(key)
         if type(key) is tuple:
             key = tuple(list(x) if is_iterator(x) else x for x in key)
             key = tuple(com.apply_if_callable(x, self.obj) for x in key)
@@ -2477,3 +2453,29 @@ def need_slice(obj: slice) -> bool:
         or obj.stop is not None
         or (obj.step is not None and obj.step != 1)
     )
+
+
+def check_deprecated_indexers(key) -> None:
+    """Checks if the key is a deprecated indexer."""
+    if (
+        isinstance(key, set)
+        or isinstance(key, tuple)
+        and any(isinstance(x, set) for x in key)
+    ):
+        warnings.warn(
+            "Passing a set as an indexer is deprecated and will raise in "
+            "a future version. Use a list instead.",
+            FutureWarning,
+            stacklevel=find_stack_level(),
+        )
+    if (
+        isinstance(key, dict)
+        or isinstance(key, tuple)
+        and any(isinstance(x, dict) for x in key)
+    ):
+        warnings.warn(
+            "Passing a dict as an indexer is deprecated and will raise in "
+            "a future version. Use a list instead.",
+            FutureWarning,
+            stacklevel=find_stack_level(),
+        )

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -938,7 +938,32 @@ class Series(base.IndexOpsMixin, NDFrame):
         #  _slice is *always* positional
         return self._get_values(slobj)
 
+    def _check_deprecated_indexers(self, key):
+        if (
+            isinstance(key, set)
+            or isinstance(key, tuple)
+            and any(isinstance(x, set) for x in key)
+        ):
+            warnings.warn(
+                "Passing a set as an indexer is deprecated and will raise in "
+                "a future version. Use a list instead.",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
+        if (
+            isinstance(key, dict)
+            or isinstance(key, tuple)
+            and any(isinstance(x, dict) for x in key)
+        ):
+            warnings.warn(
+                "Passing a dict as an indexer is deprecated and will raise in "
+                "a future version. Use a list instead.",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
+
     def __getitem__(self, key):
+        self._check_deprecated_indexers(key)
         key = com.apply_if_callable(key, self)
 
         if key is Ellipsis:
@@ -1065,6 +1090,7 @@ class Series(base.IndexOpsMixin, NDFrame):
         return self.index._get_values_for_loc(self, loc, label)
 
     def __setitem__(self, key, value) -> None:
+        self._check_deprecated_indexers(key)
         key = com.apply_if_callable(key, self)
         cacher_needs_updating = self._check_is_chained_assignment_possible()
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -124,7 +124,10 @@ from pandas.core.indexes.api import (
     ensure_index,
 )
 import pandas.core.indexes.base as ibase
-from pandas.core.indexing import check_bool_indexer
+from pandas.core.indexing import (
+    check_bool_indexer,
+    check_deprecated_indexers,
+)
 from pandas.core.internals import (
     SingleArrayManager,
     SingleBlockManager,
@@ -938,32 +941,8 @@ class Series(base.IndexOpsMixin, NDFrame):
         #  _slice is *always* positional
         return self._get_values(slobj)
 
-    def _check_deprecated_indexers(self, key):
-        if (
-            isinstance(key, set)
-            or isinstance(key, tuple)
-            and any(isinstance(x, set) for x in key)
-        ):
-            warnings.warn(
-                "Passing a set as an indexer is deprecated and will raise in "
-                "a future version. Use a list instead.",
-                FutureWarning,
-                stacklevel=find_stack_level(),
-            )
-        if (
-            isinstance(key, dict)
-            or isinstance(key, tuple)
-            and any(isinstance(x, dict) for x in key)
-        ):
-            warnings.warn(
-                "Passing a dict as an indexer is deprecated and will raise in "
-                "a future version. Use a list instead.",
-                FutureWarning,
-                stacklevel=find_stack_level(),
-            )
-
     def __getitem__(self, key):
-        self._check_deprecated_indexers(key)
+        check_deprecated_indexers(key)
         key = com.apply_if_callable(key, self)
 
         if key is Ellipsis:
@@ -1090,7 +1069,7 @@ class Series(base.IndexOpsMixin, NDFrame):
         return self.index._get_values_for_loc(self, loc, label)
 
     def __setitem__(self, key, value) -> None:
-        self._check_deprecated_indexers(key)
+        check_deprecated_indexers(key)
         key = com.apply_if_callable(key, self)
         cacher_needs_updating = self._check_is_chained_assignment_possible()
 

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -1526,3 +1526,65 @@ class TestLocILocDataFrameCategorical:
         # "c" not part of the categories
         with pytest.raises(TypeError, match=msg1):
             indexer(df)[key] = ["c", "c"]
+
+
+class TestDepreactedIndexers:
+    @pytest.mark.parametrize(
+        "key", [{1}, {1: 1}, ({1}, "a"), ({1: 1}, "a"), (1, {"a"}), (1, {"a": "a"})]
+    )
+    def test_getitem_dict_and_set_deprecated(self, key):
+        # GH#42825
+        df = DataFrame([[1, 2], [3, 4]], columns=["a", "b"])
+        with tm.assert_produces_warning(FutureWarning):
+            df.loc[key]
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            {1},
+            {1: 1},
+            (({1}, 2), "a"),
+            (({1: 1}, 2), "a"),
+            ((1, 2), {"a"}),
+            ((1, 2), {"a": "a"}),
+        ],
+    )
+    def test_getitem_dict_and_set_deprecated_multiindex(self, key):
+        # GH#42825
+        df = DataFrame(
+            [[1, 2], [3, 4]],
+            columns=["a", "b"],
+            index=MultiIndex.from_tuples([(1, 2), (3, 4)]),
+        )
+        with tm.assert_produces_warning(FutureWarning):
+            df.loc[key]
+
+    @pytest.mark.parametrize(
+        "key", [{1}, {1: 1}, ({1}, "a"), ({1: 1}, "a"), (1, {"a"}), (1, {"a": "a"})]
+    )
+    def test_setitem_dict_and_set_deprecated(self, key):
+        # GH#42825
+        df = DataFrame([[1, 2], [3, 4]], columns=["a", "b"])
+        with tm.assert_produces_warning(FutureWarning):
+            df.loc[key] = 1
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            {1},
+            {1: 1},
+            (({1}, 2), "a"),
+            (({1: 1}, 2), "a"),
+            ((1, 2), {"a"}),
+            ((1, 2), {"a": "a"}),
+        ],
+    )
+    def test_setitem_dict_and_set_deprecated_multiindex(self, key):
+        # GH#42825
+        df = DataFrame(
+            [[1, 2], [3, 4]],
+            columns=["a", "b"],
+            index=MultiIndex.from_tuples([(1, 2), (3, 4)]),
+        )
+        with tm.assert_produces_warning(FutureWarning):
+            df.loc[key] = 1

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -339,8 +339,11 @@ class TestMultiIndexLoc:
             convert_nested_indexer(indexer_type, k)
             for indexer_type, k in zip(types, keys)
         )
-
-        result = df.loc[indexer, "Data"]
+        if indexer_type_1 is set or indexer_type_2 is set:
+            with tm.assert_produces_warning(FutureWarning):
+                result = df.loc[indexer, "Data"]
+        else:
+            result = df.loc[indexer, "Data"]
         expected = Series(
             [1, 2, 4, 5], name="Data", index=MultiIndex.from_product(keys)
         )

--- a/pandas/tests/series/indexing/test_getitem.py
+++ b/pandas/tests/series/indexing/test_getitem.py
@@ -696,3 +696,19 @@ def test_duplicated_index_getitem_positional_indexer(index_vals):
     s = Series(range(5), index=list(index_vals))
     result = s[3]
     assert result == 3
+
+
+class TestGetitemDeprecatedIndexers:
+    @pytest.mark.parametrize("key", [{1}, {1: 1}])
+    def test_getitem_dict_and_set_deprecated(self, key):
+        # GH#42825
+        ser = Series([1, 2, 3])
+        with tm.assert_produces_warning(FutureWarning):
+            ser[key]
+
+    @pytest.mark.parametrize("key", [{1}, {1: 1}])
+    def test_setitem_dict_and_set_deprecated(self, key):
+        # GH#42825
+        ser = Series([1, 2, 3])
+        with tm.assert_produces_warning(FutureWarning):
+            ser[key] = 1

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -8,6 +8,7 @@ import pytest
 from pandas import (
     DataFrame,
     IndexSlice,
+    MultiIndex,
     Series,
     Timedelta,
     Timestamp,
@@ -316,3 +317,33 @@ def test_frozenset_index():
     assert s[idx1] == 2
     s[idx1] = 3
     assert s[idx1] == 3
+
+
+class TestDepreactedIndexers:
+    @pytest.mark.parametrize("key", [{1}, {1: 1}])
+    def test_getitem_dict_and_set_deprecated(self, key):
+        # GH#42825
+        ser = Series([1, 2])
+        with tm.assert_produces_warning(FutureWarning):
+            ser.loc[key]
+
+    @pytest.mark.parametrize("key", [{1}, {1: 1}, ({1}, 2), ({1: 1}, 2)])
+    def test_getitem_dict_and_set_deprecated_multiindex(self, key):
+        # GH#42825
+        ser = Series([1, 2], index=MultiIndex.from_tuples([(1, 2), (3, 4)]))
+        with tm.assert_produces_warning(FutureWarning):
+            ser.loc[key]
+
+    @pytest.mark.parametrize("key", [{1}, {1: 1}])
+    def test_setitem_dict_and_set_deprecated(self, key):
+        # GH#42825
+        ser = Series([1, 2])
+        with tm.assert_produces_warning(FutureWarning):
+            ser.loc[key] = 1
+
+    @pytest.mark.parametrize("key", [{1}, {1: 1}, ({1}, 2), ({1: 1}, 2)])
+    def test_setitem_dict_and_set_deprecated_multiindex(self, key):
+        # GH#42825
+        ser = Series([1, 2], index=MultiIndex.from_tuples([(1, 2), (3, 4)]))
+        with tm.assert_produces_warning(FutureWarning):
+            ser.loc[key] = 1


### PR DESCRIPTION
- [x] closes #42825
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

- ``DataFrame.__setitem__`` does not work for unhashable object
- ``iloc`` does not work for unhashable objects for __getitem__ and __setitem__