### PR TITLE
DOC: Run doctests over pandas directory

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -65,23 +65,8 @@ fi
 if [[ -z "$CHECK" || "$CHECK" == "doctests" ]]; then
 
     MSG='Doctests' ; echo $MSG
-    python -m pytest --doctest-modules \
-      pandas/_config/ \
-      pandas/_libs/ \
-      pandas/_testing/ \
-      pandas/api/ \
-      pandas/arrays/ \
-      pandas/compat/ \
-      pandas/core \
-      pandas/errors/ \
-      pandas/io/ \
-      pandas/plotting/ \
-      pandas/tseries/ \
-      pandas/util/ \
-      pandas/_typing.py \
-      pandas/_version.py \
-      pandas/conftest.py \
-      pandas/testing.py
+    # Ignore test_*.py files or else the unit tests will run
+    python -m pytest --doctest-modules --ignore-glob="**/test_*.py" pandas
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
     MSG='Cython Doctests' ; echo $MSG

--- a/pandas/tests/arithmetic/conftest.py
+++ b/pandas/tests/arithmetic/conftest.py
@@ -24,7 +24,9 @@ def switch_numexpr_min_elements(request):
 
 # ------------------------------------------------------------------
 
-
+# doctest with +SKIP for one fixture fails during setup with
+# 'DoctestItem' object has no attribute 'callspec'
+# due to switch_numexpr_min_elements fixture
 @pytest.fixture(params=[1, np.array(1, dtype=np.int64)])
 def one(request):
     """
@@ -37,11 +39,11 @@ def one(request):
 
     Examples
     --------
-    >>> dti = pd.date_range('2016-01-01', periods=2, freq='H')
-    >>> dti
+    dti = pd.date_range('2016-01-01', periods=2, freq='H')
+    dti
     DatetimeIndex(['2016-01-01 00:00:00', '2016-01-01 01:00:00'],
     dtype='datetime64[ns]', freq='H')
-    >>> dti + one
+    dti + one
     DatetimeIndex(['2016-01-01 01:00:00', '2016-01-01 02:00:00'],
     dtype='datetime64[ns]', freq='H')
     """
@@ -61,6 +63,9 @@ zeros.extend([np.array(-0.0, dtype=np.float64)])
 zeros.extend([0, 0.0, -0.0])
 
 
+# doctest with +SKIP for zero fixture fails during setup with
+# 'DoctestItem' object has no attribute 'callspec'
+# due to switch_numexpr_min_elements fixture
 @pytest.fixture(params=zeros)
 def zero(request):
     """
@@ -74,8 +79,8 @@ def zero(request):
 
     Examples
     --------
-    >>> arr = RangeIndex(5)
-    >>> arr / zeros
+    arr = RangeIndex(5)
+    arr / zeros
     Float64Index([nan, inf, inf, inf, inf], dtype='float64')
     """
     return request.param


### PR DESCRIPTION
- [x] closes #22459


`--ignore-glob="**/test_*.py"` is necessary or else unit tests are collected and run

```
% pytest --doctest-modules pandas --collect-only
...
    <Function test_rolling_consistency_var_debiasing_factors[all_data16-rolling_consistency_cases0-False]>
    <Function test_rolling_consistency_var_debiasing_factors[all_data16-rolling_consistency_cases1-True]>
    <Function test_rolling_consistency_var_debiasing_factors[all_data16-rolling_consistency_cases1-False]>
    <Function test_rolling_consistency_var_debiasing_factors[all_data17-rolling_consistency_cases0-True]>
    <Function test_rolling_consistency_var_debiasing_factors[all_data17-rolling_consistency_cases0-False]>
    <Function test_rolling_consistency_var_debiasing_factors[all_data17-rolling_consistency_cases1-True]>
    <Function test_rolling_consistency_var_debiasing_factors[all_data17-rolling_consistency_cases1-False]>
<Package tseries>
  <DoctestModule frequencies.py>
    <DoctestItem pandas.tseries.frequencies.infer_freq>
  <DoctestModule holiday.py>
    <DoctestItem pandas.tseries.holiday.Holiday.__init__>
<Package util>
  <DoctestModule _decorators.py>
    <DoctestItem pandas.util._decorators.deprecate_kwarg>
  <DoctestModule _validators.py>
    <DoctestItem pandas.util._validators.validate_axis_style_args>

=================================================================== 153109 tests collected in 46.60s ===================================================================
```

