### PR TITLE
ENH: add render_links for Styler.to_html formatting

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -111,6 +111,7 @@ Additionally there are specific enhancements to the HTML specific rendering:
   - :meth:`.Styler.to_html` introduces keyword arguments ``sparse_index``, ``sparse_columns``, ``bold_headers``, ``caption``, ``max_rows`` and ``max_columns`` (:issue:`41946`, :issue:`43149`, :issue:`42972`).
   - :meth:`.Styler.to_html` omits CSSStyle rules for hidden table elements as a performance enhancement (:issue:`43619`)
   - Custom CSS classes can now be directly specified without string replacement (:issue:`43686`)
+  - Ability to render hyperlinks automatically via a new ``render_links`` formatting keyword argument (:issue:`45058`)
 
 There are also some LaTeX specific enhancements:
 

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -111,7 +111,7 @@ Additionally there are specific enhancements to the HTML specific rendering:
   - :meth:`.Styler.to_html` introduces keyword arguments ``sparse_index``, ``sparse_columns``, ``bold_headers``, ``caption``, ``max_rows`` and ``max_columns`` (:issue:`41946`, :issue:`43149`, :issue:`42972`).
   - :meth:`.Styler.to_html` omits CSSStyle rules for hidden table elements as a performance enhancement (:issue:`43619`)
   - Custom CSS classes can now be directly specified without string replacement (:issue:`43686`)
-  - Ability to render hyperlinks automatically via a new ``render_links`` formatting keyword argument (:issue:`45058`)
+  - Ability to render hyperlinks automatically via a new ``hyperlinks`` formatting keyword argument (:issue:`45058`)
 
 There are also some LaTeX specific enhancements:
 

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -623,6 +623,7 @@ class Styler(StylerRenderer):
                               | \\sisetup{detect-all = true}  *(within {document})*
         environment           \\usepackage{longtable} if arg is "longtable"
                               | or any other relevant environment package
+        hyperlinks            \\usepackage{hyperref}
         ===================== ==========================================================
 
         **Cell Styles**

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -843,7 +843,7 @@ class StylerRenderer:
 
             .. versionadded:: 1.3.0
 
-        render_links : bool, optional
+        render_links : bool
             Convert string patterns containing https://, http://, ftp:// or www. to
             HTML <a> tags as clickable URL hyperlinks.
 
@@ -1037,7 +1037,7 @@ class StylerRenderer:
             ``{``, ``}``, ``~``, ``^``, and ``\`` in the cell display string with
             LaTeX-safe sequences.
             Escaping is done before ``formatter``.
-        render_links : bool, optional
+        render_links : bool
             Convert string patterns containing https://, http://, ftp:// or www. to
             HTML <a> tags as clickable URL hyperlinks.
 

--- a/pandas/tests/io/formats/style/test_html.py
+++ b/pandas/tests/io/formats/style/test_html.py
@@ -794,3 +794,13 @@ def test_rendered_links(type, text, exp, found):
     result = styler.to_html()
     assert (rendered in result) is exp
     assert (text in result) is not exp  # test conversion done when expected and not
+
+
+def test_multiple_rendered_links():
+    links = ("www.a.b", "http://a.c", "https://a.d", "ftp://a.e")
+    df = DataFrame(["text {} {} text {} {}".format(*links)])
+    result = df.style.format(render_links=True).to_html()
+    href = '<a href="{0}" target="_blank">{0}</a>'
+    for link in links:
+        assert href.format(link) in result
+    assert href.format("text") not in result

--- a/pandas/tests/io/formats/style/test_html.py
+++ b/pandas/tests/io/formats/style/test_html.py
@@ -764,3 +764,33 @@ def test_hiding_index_columns_multiindex_trimming():
     )
 
     assert result == expected
+
+
+@pytest.mark.parametrize("type", ["data", "index"])
+@pytest.mark.parametrize(
+    "text, exp, found",
+    [
+        ("no link, just text", False, ""),
+        ("subdomain not www: sub.web.com", False, ""),
+        ("www subdomain: www.web.com other", True, "www.web.com"),
+        ("scheme full structure: http://www.web.com", True, "http://www.web.com"),
+        ("scheme no top-level: http://www.web", True, "http://www.web"),
+        ("no scheme, no top-level: www.web", False, "www.web"),
+        ("https scheme: https://www.web.com", True, "https://www.web.com"),
+        ("ftp scheme: ftp://www.web", True, "ftp://www.web"),
+        ("subdirectories: www.web.com/directory", True, "www.web.com/directory"),
+        ("Multiple domains: www.1.2.3.4", True, "www.1.2.3.4"),
+    ],
+)
+def test_rendered_links(type, text, exp, found):
+    if type == "data":
+        df = DataFrame([text])
+        styler = df.style.format(render_links=True)
+    else:
+        df = DataFrame([0], index=[text])
+        styler = df.style.format_index(render_links=True)
+
+    rendered = '<a href="{0}" target="_blank">{0}</a>'.format(found)
+    result = styler.to_html()
+    assert (rendered in result) is exp
+    assert (text in result) is not exp  # test conversion done when expected and not

--- a/pandas/tests/io/formats/style/test_html.py
+++ b/pandas/tests/io/formats/style/test_html.py
@@ -785,10 +785,10 @@ def test_hiding_index_columns_multiindex_trimming():
 def test_rendered_links(type, text, exp, found):
     if type == "data":
         df = DataFrame([text])
-        styler = df.style.format(render_links=True)
+        styler = df.style.format(hyperlinks="html")
     else:
         df = DataFrame([0], index=[text])
-        styler = df.style.format_index(render_links=True)
+        styler = df.style.format_index(hyperlinks="html")
 
     rendered = '<a href="{0}" target="_blank">{0}</a>'.format(found)
     result = styler.to_html()
@@ -799,7 +799,7 @@ def test_rendered_links(type, text, exp, found):
 def test_multiple_rendered_links():
     links = ("www.a.b", "http://a.c", "https://a.d", "ftp://a.e")
     df = DataFrame(["text {} {} text {} {}".format(*links)])
-    result = df.style.format(render_links=True).to_html()
+    result = df.style.format(hyperlinks="html").to_html()
     href = '<a href="{0}" target="_blank">{0}</a>'
     for link in links:
         assert href.format(link) in result

--- a/pandas/tests/io/formats/style/test_to_latex.py
+++ b/pandas/tests/io/formats/style/test_to_latex.py
@@ -845,3 +845,11 @@ def test_latex_hiding_index_columns_multiindex_alignment():
         """
     )
     assert result == expected
+
+
+def test_rendered_links():
+    # note the majority of testing is done in test_html.py: test_rendered_links
+    # these test only the alternative latex format is functional
+    df = DataFrame(["text www.domain.com text"])
+    result = df.style.format(hyperlinks="latex").to_latex()
+    assert r"text \href{www.domain.com}{www.domain.com} text" in result


### PR DESCRIPTION
This came about as a requirement for converting DataFrame.to_html into Styler.to_html, citing @jorisvandenbossche in favour of the functionality.

Note that the `DataFrame.to_html` `render_links` argument is rather limited to just detecting only a URL in a cell.

The function added for Styler here is a more general pattern search, and it allows the result to be viewed in Jupyter Notebook directly, which the precursor does not.


![Screen Shot 2021-12-24 at 22 20 45](https://user-images.githubusercontent.com/24256554/147372493-5458f18a-4cf3-417a-86a1-7750e430b145.png)


