### PR TITLE
CI: Fix pytorch installation error

### DIFF
--- a/ci/deps/actions-38-db.yaml
+++ b/ci/deps/actions-38-db.yaml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.8
+  - pip
 
   # tools
   - cython>=0.29.24
@@ -33,7 +34,6 @@ dependencies:
   - pyarrow>=1.0.1
   - pymysql
   - pytables
-  - pytorch
   - python-snappy
   - python-dateutil
   - pytz
@@ -50,3 +50,5 @@ dependencies:
   - coverage
   - pandas-datareader
   - pyxlsb
+  - pip:
+    - torch


### PR DESCRIPTION
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

The conda installation expects mkl locally, which does not work . So installing via pip for now to get ci back to green