### PR TITLE
CI/TST: Ignore Matplotlib related ResouceWarnings from assert_produces_warning

### DIFF
--- a/pandas/_testing/_warnings.py
+++ b/pandas/_testing/_warnings.py
@@ -164,7 +164,8 @@ def _assert_caught_no_extra_warnings(
                     lsof = subprocess.check_output(
                         ["lsof", "-d", "0-25", "-F", "n"]
                     ).decode("utf-8")
-                except subprocess.CalledProcessError:
+                except (subprocess.CalledProcessError, FileNotFoundError):
+                    # FileNotFoundError for Windows
                     lsof = ""
                 if re.search(r"\.ttf|\.ttc|\.otf", lsof):
                     continue

--- a/pandas/_testing/_warnings.py
+++ b/pandas/_testing/_warnings.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 import re
+import subprocess
 from typing import (
     Sequence,
     Type,
@@ -147,17 +148,26 @@ def _assert_caught_no_extra_warnings(
 
     for actual_warning in caught_warnings:
         if _is_unexpected_warning(actual_warning, expected_warning):
-            # GH 44732: Don't make the CI flaky by filtering SSL-related
-            # ResourceWarning from dependencies
             # GH#38630 pytest.filterwarnings does not suppress these.
-            unclosed_ssl = (
-                "unclosed transport <asyncio.sslproto._SSLProtocolTransport",
-                "unclosed <ssl.SSLSocket",
-            )
-            if actual_warning.category == ResourceWarning and any(
-                msg in str(actual_warning.message) for msg in unclosed_ssl
-            ):
-                continue
+            if actual_warning.category == ResourceWarning:
+                # GH 44732: Don't make the CI flaky by filtering SSL-related
+                # ResourceWarning from dependencies
+                unclosed_ssl = (
+                    "unclosed transport <asyncio.sslproto._SSLProtocolTransport",
+                    "unclosed <ssl.SSLSocket",
+                )
+                if any(msg in str(actual_warning.message) for msg in unclosed_ssl):
+                    continue
+                # GH 44844: Matplotlib leaves font files open during the entire process
+                # Don't make CI flaky if ResourceWarning raised due to these open files.
+                try:
+                    lsof = subprocess.check_output(
+                        ["lsof", "-d", "0-25", "-F", "n"]
+                    ).decode("utf-8")
+                except subprocess.CalledProcessError:
+                    lsof = ""
+                if re.search(r"\.ttf|\.ttc|\.otf", lsof):
+                    continue
 
             extra_warnings.append(
                 (


### PR DESCRIPTION
cc @jbrockmendel went with a version of 7) in https://github.com/pandas-dev/pandas/issues/44844#issuecomment-998216752

Couldn't find a reliable way to close font files from Matplotlib, so if `ResourceWarning` is seen while a font file is open fromm `lsof`, ignore.
