### PR TITLE
DEPR: downcast kwd in fillna

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5207,7 +5207,7 @@ class DataFrame(NDFrame, OpsMixin):
         axis: Axis | None = None,
         inplace: bool = False,
         limit=None,
-        downcast=None,
+        downcast=lib.no_default,
     ) -> DataFrame | None:
         return super().fillna(
             value=value,
@@ -10862,7 +10862,7 @@ NaN 12.3   33.0
         axis: None | Axis = None,
         inplace: bool = False,
         limit: None | int = None,
-        downcast=None,
+        downcast=lib.no_default,
     ) -> DataFrame | None:
         return super().ffill(axis, inplace, limit, downcast)
 
@@ -10872,7 +10872,7 @@ NaN 12.3   33.0
         axis: None | Axis = None,
         inplace: bool = False,
         limit: None | int = None,
-        downcast=None,
+        downcast=lib.no_default,
     ) -> DataFrame | None:
         return super().bfill(axis, inplace, limit, downcast)
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2735,6 +2735,13 @@ class Index(IndexOpsMixin, PandasObject):
         DataFrame.fillna : Fill NaN values of a DataFrame.
         Series.fillna : Fill NaN Values of a Series.
         """
+        if downcast is not None:
+            warnings.warn(
+                "Index.fillna 'downcast' keyword is deprecated and will be "
+                "removed in a future version.",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
 
         value = self._require_scalar(value)
         if self.hasnans:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4876,7 +4876,7 @@ Keep all original rows and also all original values
         axis=None,
         inplace=False,
         limit=None,
-        downcast=None,
+        downcast=lib.no_default,
     ) -> Series | None:
         return super().fillna(
             value=value,
@@ -5475,7 +5475,7 @@ Keep all original rows and also all original values
         axis: None | Axis = None,
         inplace: bool = False,
         limit: None | int = None,
-        downcast=None,
+        downcast=lib.no_default,
     ) -> Series | None:
         return super().ffill(axis, inplace, limit, downcast)
 
@@ -5485,7 +5485,7 @@ Keep all original rows and also all original values
         axis: None | Axis = None,
         inplace: bool = False,
         limit: None | int = None,
-        downcast=None,
+        downcast=lib.no_default,
     ) -> Series | None:
         return super().bfill(axis, inplace, limit, downcast)
 

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -504,8 +504,9 @@ class TestDataFrameIndexingWhere:
         tm.assert_frame_equal(result, expected)
 
         warn = FutureWarning if using_array_manager else None
+        msg = "Downcasting integer-dtype"
         expected = DataFrame([[0, np.nan], [0, np.nan]])
-        with tm.assert_produces_warning(warn, match="Downcasting integer-dtype"):
+        with tm.assert_produces_warning(warn, match=msg):
             result = df.where(mask, s, axis="columns")
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -234,13 +234,15 @@ class TestFillNA:
         # GH#15277
         # infer int64 from float64
         df = DataFrame({"a": [1.0, np.nan]})
-        result = df.fillna(0, downcast="infer")
+        with tm.assert_produces_warning(FutureWarning, match="Casting behavior"):
+            result = df.fillna(0, downcast="infer")
         expected = DataFrame({"a": [1, 0]})
         tm.assert_frame_equal(result, expected)
 
         # infer int64 from float64 when fillna value is a dict
         df = DataFrame({"a": [1.0, np.nan]})
-        result = df.fillna({"a": 0}, downcast="infer")
+        with tm.assert_produces_warning(FutureWarning, match="Casting behavior"):
+            result = df.fillna({"a": 0}, downcast="infer")
         expected = DataFrame({"a": [1, 0]})
         tm.assert_frame_equal(result, expected)
 
@@ -563,7 +565,9 @@ class TestFillNA:
     def test_fillna_downcast_dict(self):
         # GH#40809
         df = DataFrame({"col1": [1, np.nan]})
-        result = df.fillna({"col1": 2}, downcast={"col1": "int64"})
+        msg = "fillna 'downcast' keyword"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            result = df.fillna({"col1": 2}, downcast={"col1": "int64"})
         expected = DataFrame({"col1": [1, 2]})
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -96,7 +96,8 @@ class TestDataFrameInterpolate:
         expected = Series([1.0, 2.0, 3.0, 4.0], name="A")
         tm.assert_series_equal(result, expected)
 
-        result = df["A"].interpolate(downcast="infer")
+        with tm.assert_produces_warning(FutureWarning, match="Casting behavior"):
+            result = df["A"].interpolate(downcast="infer")
         expected = Series([1, 2, 3, 4], name="A")
         tm.assert_series_equal(result, expected)
 
@@ -160,7 +161,8 @@ class TestDataFrameInterpolate:
         expected.loc[5, "A"] = 6
         tm.assert_frame_equal(result, expected)
 
-        result = df.interpolate(method="barycentric", downcast="infer")
+        with tm.assert_produces_warning(FutureWarning, match="Casting behavior"):
+            result = df.interpolate(method="barycentric", downcast="infer")
         tm.assert_frame_equal(result, expected.astype(np.int64))
 
         result = df.interpolate(method="krogh")
@@ -280,7 +282,8 @@ class TestDataFrameInterpolate:
         tm.assert_frame_equal(result, expected)
 
         result = df.copy()
-        return_value = result["a"].interpolate(inplace=True, downcast="infer")
+        with tm.assert_produces_warning(FutureWarning, match="Casting behavior"):
+            return_value = result["a"].interpolate(inplace=True, downcast="infer")
         assert return_value is None
         tm.assert_frame_equal(result, expected.astype("int64"))
 

--- a/pandas/tests/frame/test_logical_ops.py
+++ b/pandas/tests/frame/test_logical_ops.py
@@ -165,7 +165,9 @@ class TestDataFrameLogicalOperators:
         expected = Series([True, True])
         tm.assert_series_equal(result, expected)
 
-        result = d["a"].fillna(False, downcast=False) | d["b"]
+        msg = "Series.fillna 'downcast' keyword is deprecated"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            result = d["a"].fillna(False, downcast=False) | d["b"]
         expected = Series([True, True])
         tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1242,7 +1242,8 @@ def test_seriesgroupby_observed_false_or_none(df_cat, observed, operation):
 
     expected = Series(data=[2, 4, np.nan, 1, np.nan, 3], index=index, name="C")
     if operation == "agg":
-        expected = expected.fillna(0, downcast="infer")
+        with tm.assert_produces_warning(FutureWarning, match="Casting behavior"):
+            expected = expected.fillna(0, downcast="infer")
     grouped = df_cat.groupby(["A", "B"], observed=observed)["C"]
     result = getattr(grouped, operation)(sum)
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -519,7 +519,8 @@ class Base:
             msg = "does not support 'downcast'"
             with pytest.raises(NotImplementedError, match=msg):
                 # For now at least, we only raise if there are NAs present
-                idx.fillna(idx[0], downcast="infer")
+                with tm.assert_produces_warning(FutureWarning):
+                    idx.fillna(idx[0], downcast="infer")
 
             expected = np.array([False] * len(idx), dtype=bool)
             expected[1] = True

--- a/pandas/tests/series/methods/test_fillna.py
+++ b/pandas/tests/series/methods/test_fillna.py
@@ -178,14 +178,17 @@ class TestSeriesFillNA:
     def test_fillna_downcast(self):
         # GH#15277
         # infer int64 from float64
+        msg = "'downcast' keyword is deprecated"
         ser = Series([1.0, np.nan])
-        result = ser.fillna(0, downcast="infer")
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            result = ser.fillna(0, downcast="infer")
         expected = Series([1, 0])
         tm.assert_series_equal(result, expected)
 
         # infer int64 from float64 when fillna value is a dict
         ser = Series([1.0, np.nan])
-        result = ser.fillna({1: 0}, downcast="infer")
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            result = ser.fillna({1: 0}, downcast="infer")
         expected = Series([1, 0])
         tm.assert_series_equal(result, expected)
 
@@ -198,15 +201,19 @@ class TestSeriesFillNA:
 
         ser = Series(arr)
 
-        res = ser.fillna(3, downcast="infer")
+        msg = "'downcast' keyword is deprecated"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            res = ser.fillna(3, downcast="infer")
         expected = Series(np.arange(5), dtype=np.int64)
         tm.assert_series_equal(res, expected)
 
-        res = ser.ffill(downcast="infer")
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            res = ser.ffill(downcast="infer")
         expected = Series([0, 1, 2, 2, 4], dtype=np.int64)
         tm.assert_series_equal(res, expected)
 
-        res = ser.bfill(downcast="infer")
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            res = ser.bfill(downcast="infer")
         expected = Series([0, 1, 2, 4, 4], dtype=np.int64)
         tm.assert_series_equal(res, expected)
 
@@ -214,14 +221,17 @@ class TestSeriesFillNA:
         ser[2] = 2.5
 
         expected = Series([0, 1, 2.5, 3, 4], dtype=np.float64)
-        res = ser.fillna(3, downcast="infer")
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            res = ser.fillna(3, downcast="infer")
         tm.assert_series_equal(res, expected)
 
-        res = ser.ffill(downcast="infer")
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            res = ser.ffill(downcast="infer")
         expected = Series([0, 1, 2.5, 2.5, 4], dtype=np.float64)
         tm.assert_series_equal(res, expected)
 
-        res = ser.bfill(downcast="infer")
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            res = ser.bfill(downcast="infer")
         expected = Series([0, 1, 2.5, 4, 4], dtype=np.float64)
         tm.assert_series_equal(res, expected)
 

--- a/pandas/tests/series/methods/test_interpolate.py
+++ b/pandas/tests/series/methods/test_interpolate.py
@@ -281,6 +281,7 @@ class TestSeriesInterpolateData:
         result = s.interpolate(method="slinear")
         tm.assert_series_equal(result, expected)
 
+        msg = "Casting behavior.* columns is deprecated"
         result = s.interpolate(method="slinear", downcast="infer")
         tm.assert_series_equal(result, expected)
         # nearest
@@ -288,14 +289,16 @@ class TestSeriesInterpolateData:
         result = s.interpolate(method="nearest")
         tm.assert_series_equal(result, expected.astype("float"))
 
-        result = s.interpolate(method="nearest", downcast="infer")
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            result = s.interpolate(method="nearest", downcast="infer")
         tm.assert_series_equal(result, expected)
         # zero
         expected = Series([1, 3, 3, 12, 12, 25])
         result = s.interpolate(method="zero")
         tm.assert_series_equal(result, expected.astype("float"))
 
-        result = s.interpolate(method="zero", downcast="infer")
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            result = s.interpolate(method="zero", downcast="infer")
         tm.assert_series_equal(result, expected)
         # quadratic
         # GH #15662.

--- a/pandas/tests/series/methods/test_reindex.py
+++ b/pandas/tests/series/methods/test_reindex.py
@@ -134,7 +134,8 @@ def test_reindex_pad():
     result = s.reindex(new_index).ffill()
     tm.assert_series_equal(result, expected.astype("float64"))
 
-    result = s.reindex(new_index).ffill(downcast="infer")
+    with tm.assert_produces_warning(FutureWarning, match="Casting behavior"):
+        result = s.reindex(new_index).ffill(downcast="infer")
     tm.assert_series_equal(result, expected)
 
     expected = Series([1, 5, 3, 5], index=new_index)


### PR DESCRIPTION
- [x] closes #40988
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

I'm on the fence about this.  `downcast="infer"` seems pretty useful, as evidenced by how often it shows up in the tests.  We don't have anything analogous to `infer_objects` for "see if i can losslessly downcast numeric values".

If we go forward with this, probably need to deprecate within NDFrame.interpolate too, as apparently some but not all interpolate paths see this deprecation.