### PR TITLE
BUG: Fix nanosecond timedeltas

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -236,7 +236,6 @@ Other enhancements
 - :meth:`is_list_like` now identifies duck-arrays as list-like unless ``.ndim == 0`` (:issue:`35131`)
 - :class:`ExtensionDtype` and :class:`ExtensionArray` are now (de)serialized when exporting a :class:`DataFrame` with :meth:`DataFrame.to_json` using ``orient='table'`` (:issue:`20612`, :issue:`44705`).
 - Add support for `Zstandard <http://facebook.github.io/zstd/>`_ compression to :meth:`DataFrame.to_pickle`/:meth:`read_pickle` and friends (:issue:`43925`)
-- :class:`Timedelta` now properly taking into account any nanoseconds contribution (:issue:`43764`)
 -
 
 
@@ -715,6 +714,8 @@ Timedelta
 ^^^^^^^^^
 - Bug in division of all-``NaT`` :class:`TimeDeltaIndex`, :class:`Series` or :class:`DataFrame` column with object-dtype arraylike of numbers failing to infer the result as timedelta64-dtype (:issue:`39750`)
 - Bug in floor division of ``timedelta64[ns]`` data with a scalar returning garbage values (:issue:`44466`)
+- Bug in :class:`Timedelta` now properly taking into account any nanoseconds contribution of any kwarg (:issue:`43764`)
+-
 
 Timezones
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -236,8 +236,7 @@ Other enhancements
 - :meth:`is_list_like` now identifies duck-arrays as list-like unless ``.ndim == 0`` (:issue:`35131`)
 - :class:`ExtensionDtype` and :class:`ExtensionArray` are now (de)serialized when exporting a :class:`DataFrame` with :meth:`DataFrame.to_json` using ``orient='table'`` (:issue:`20612`, :issue:`44705`).
 - Add support for `Zstandard <http://facebook.github.io/zstd/>`_ compression to :meth:`DataFrame.to_pickle`/:meth:`read_pickle` and friends (:issue:`43925`)
-- :class:`Timedelta` now properly taking into account any nanoseconds contribution (:issue: `43764`)
-- :meth:`Timedelta.total_seconds()` now properly taking into account any nanoseconds contribution (:issue: `40946`)
+- :class:`Timedelta` now properly taking into account any nanoseconds contribution (:issue:`43764`)
 -
 
 

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -236,6 +236,8 @@ Other enhancements
 - :meth:`is_list_like` now identifies duck-arrays as list-like unless ``.ndim == 0`` (:issue:`35131`)
 - :class:`ExtensionDtype` and :class:`ExtensionArray` are now (de)serialized when exporting a :class:`DataFrame` with :meth:`DataFrame.to_json` using ``orient='table'`` (:issue:`20612`, :issue:`44705`).
 - Add support for `Zstandard <http://facebook.github.io/zstd/>`_ compression to :meth:`DataFrame.to_pickle`/:meth:`read_pickle` and friends (:issue:`43925`)
+- :class:`Timedelta` now properly taking into account any nanoseconds contribution (:issue: `43764`)
+- :meth:`Timedelta.total_seconds()` now properly taking into account any nanoseconds contribution (:issue: `40946`)
 -
 
 

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1268,7 +1268,8 @@ class Timedelta(_Timedelta):
 
             kwargs = {key: _to_py_int_float(kwargs[key]) for key in kwargs}
 
-            # GH43764, making sure any nanoseconds contributions from any kwarg is taken into consideration
+            # GH43764, making sure any nanoseconds contributions from any kwarg
+            # is taken into consideration
             nano = convert_to_timedelta64(
                 (
                     kwargs.pop('nanoseconds', 0)
@@ -1528,10 +1529,6 @@ class Timedelta(_Timedelta):
         # Naive implementation, room for optimization
         div = other // self
         return div, other - div * self
-
-    # GH40946
-    def total_seconds(self):
-        return self.value / 1e9
 
 
 cdef bint is_any_td_scalar(object obj):

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1268,7 +1268,16 @@ class Timedelta(_Timedelta):
 
             kwargs = {key: _to_py_int_float(kwargs[key]) for key in kwargs}
 
-            nano = convert_to_timedelta64(kwargs.pop('nanoseconds', 0), 'ns')
+            # GH43764, making sure any nanoseconds contributions from any kwarg is taken into consideration
+            nano = convert_to_timedelta64(
+                (
+                    kwargs.pop('nanoseconds', 0)
+                    + kwargs.pop('microseconds', 0) * 1000
+                    + kwargs.pop('milliseconds', 0) * 1000000
+                    + kwargs.pop('seconds', 0) * 1000000000
+                ), 'ns'
+            )
+
             try:
                 value = nano + convert_to_timedelta64(timedelta(**kwargs),
                                                       'ns')
@@ -1519,6 +1528,10 @@ class Timedelta(_Timedelta):
         # Naive implementation, room for optimization
         div = other // self
         return div, other - div * self
+
+    # GH40946
+    def total_seconds(self):
+        return self.value / 1e9
 
 
 cdef bint is_any_td_scalar(object obj):

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1278,8 +1278,10 @@ class Timedelta(_Timedelta):
                     "milliseconds, microseconds, nanoseconds]"
                 )
 
-            # GH43764, making sure any nanoseconds contributions from any kwarg
-            # is taken into consideration
+            # GH43764, convert any input to nanoseconds first and then
+            # create the timestamp. This ensures that any potential
+            # nanosecond contributions from kwargs parsed as floats
+            # are taken into consideration.
             seconds = int((
                 (
                     (kwargs.get('days', 0) + kwargs.get('weeks', 0) * 7) * 24
@@ -1290,12 +1292,11 @@ class Timedelta(_Timedelta):
                 ) * 1_000_000_000
             )
 
-            value = convert_to_timedelta64(
-                kwargs.get('nanoseconds', 0)
+            value = np.timedelta64(
+                int(kwargs.get('nanoseconds', 0))
                 + int(kwargs.get('microseconds', 0) * 1_000)
                 + int(kwargs.get('milliseconds', 0) * 1_000_000)
                 + seconds
-                , 'ns'
             )
 
         if unit in {'Y', 'y', 'M'}:

--- a/pandas/tests/tslibs/test_timedeltas.py
+++ b/pandas/tests/tslibs/test_timedeltas.py
@@ -15,6 +15,9 @@ from pandas import (
         (np.timedelta64(14, "D"), 14 * 24 * 3600 * 1e9),
         (Timedelta(minutes=-7), -7 * 60 * 1e9),
         (Timedelta(minutes=-7).to_pytimedelta(), -7 * 60 * 1e9),
+        (Timedelta(seconds=1234e-9), 1234),  # GH43764, GH40946
+        (Timedelta(seconds=1e-9, milliseconds=1e-5, microseconds=1e-1), 111),  # GH43764, GH40946
+        (Timedelta(days=1, seconds=1e-9, milliseconds=1e-5, microseconds=1e-1), 24 * 3600e9 + 111),  # GH43764, GH40946
         (offsets.Nano(125), 125),
         (1, 1),
         (np.int64(2), 2),

--- a/pandas/tests/tslibs/test_timedeltas.py
+++ b/pandas/tests/tslibs/test_timedeltas.py
@@ -19,11 +19,11 @@ from pandas import (
         (
             Timedelta(seconds=1e-9, milliseconds=1e-5, microseconds=1e-1),
             111,
-        ),  # GH43764, GH40946
+        ),  # GH43764
         (
             Timedelta(days=1, seconds=1e-9, milliseconds=1e-5, microseconds=1e-1),
             24 * 3600e9 + 111,
-        ),  # GH43764, GH40946
+        ),  # GH43764
         (offsets.Nano(125), 125),
         (1, 1),
         (np.int64(2), 2),

--- a/pandas/tests/tslibs/test_timedeltas.py
+++ b/pandas/tests/tslibs/test_timedeltas.py
@@ -16,8 +16,14 @@ from pandas import (
         (Timedelta(minutes=-7), -7 * 60 * 1e9),
         (Timedelta(minutes=-7).to_pytimedelta(), -7 * 60 * 1e9),
         (Timedelta(seconds=1234e-9), 1234),  # GH43764, GH40946
-        (Timedelta(seconds=1e-9, milliseconds=1e-5, microseconds=1e-1), 111),  # GH43764, GH40946
-        (Timedelta(days=1, seconds=1e-9, milliseconds=1e-5, microseconds=1e-1), 24 * 3600e9 + 111),  # GH43764, GH40946
+        (
+            Timedelta(seconds=1e-9, milliseconds=1e-5, microseconds=1e-1),
+            111,
+        ),  # GH43764, GH40946
+        (
+            Timedelta(days=1, seconds=1e-9, milliseconds=1e-5, microseconds=1e-1),
+            24 * 3600e9 + 111,
+        ),  # GH43764, GH40946
         (offsets.Nano(125), 125),
         (1, 1),
         (np.int64(2), 2),


### PR DESCRIPTION
- [x] closes #43764
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

Fixes the construction of `Timedelta` objects with any nanosecond contribution.