### PR TITLE
TST: Mock unstack and pivot_table test for PerformanceWarning

### DIFF
--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -18,6 +18,7 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
+from pandas.core.reshape import reshape as reshape_lib
 
 
 class TestDataFrameReshape:
@@ -1826,19 +1827,26 @@ Thu,Lunch,Yes,51.51,17"""
         tm.assert_frame_equal(recons, df)
 
     @pytest.mark.slow
-    def test_unstack_number_of_levels_larger_than_int32(self):
+    def test_unstack_number_of_levels_larger_than_int32(self, monkeypatch):
         # GH#20601
         # GH 26314: Change ValueError to PerformanceWarning
-        df = DataFrame(
-            np.random.randn(2 ** 16, 2), index=[np.arange(2 ** 16), np.arange(2 ** 16)]
-        )
-        msg = "The following operation may generate"
-        with tm.assert_produces_warning(PerformanceWarning, match=msg):
-            try:
-                df.unstack()
-            except MemoryError:
-                # Just checking the warning
-                return
+
+        class MockUnstacker(reshape_lib._Unstacker):
+            def __init__(self, *args, **kwargs):
+                # __init__ will raise the warning
+                super().__init__(*args, **kwargs)
+                raise Exception("Don't compute final result.")
+
+        with monkeypatch.context() as m:
+            m.setattr(reshape_lib, "_Unstacker", MockUnstacker)
+            df = DataFrame(
+                np.random.randn(2 ** 16, 2),
+                index=[np.arange(2 ** 16), np.arange(2 ** 16)],
+            )
+            msg = "The following operation may generate"
+            with tm.assert_produces_warning(PerformanceWarning, match=msg):
+                with pytest.raises(Exception, match="Don't compute final result."):
+                    df.unstack()
 
     def test_stack_order_with_unsorted_levels(self):
         # GH#16323


### PR DESCRIPTION
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

xref https://github.com/pandas-dev/pandas/pull/45084#issuecomment-1002708717

Makes these tests run quicker locally.
