### PR TITLE
ENH: Fix total seconds in timedelta

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -225,7 +225,8 @@ Other enhancements
 - :class:`ExtensionDtype` and :class:`ExtensionArray` are now (de)serialized when exporting a :class:`DataFrame` with :meth:`DataFrame.to_json` using ``orient='table'`` (:issue:`20612`, :issue:`44705`).
 - Add support for `Zstandard <http://facebook.github.io/zstd/>`_ compression to :meth:`DataFrame.to_pickle`/:meth:`read_pickle` and friends (:issue:`43925`)
 - :meth:`DataFrame.to_sql` now returns an ``int`` of the number of written rows (:issue:`23998`)
-
+- :meth:`Timedelta.total_seconds()` now properly taking into account any nanoseconds contribution (:issue:`40946`)
+-
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -504,7 +504,7 @@ cdef _TSObject convert_datetime_to_tsobject(datetime ts, tzinfo tz,
 
     if obj.tzinfo is not None and not is_utc(obj.tzinfo):
         offset = get_utcoffset(obj.tzinfo, ts)
-        obj.value -= int(offset.total_seconds() * 1e9)
+        obj.value -= int(offset.total_seconds() * 1_000_000_000)
 
     if isinstance(ts, ABCTimestamp):
         obj.value += <int64_t>ts.nanosecond

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -465,7 +465,6 @@ class NaTType(_NaT):
 
         >>> td.total_seconds(ns_precision=True)
         521403.010010012
-
         """
     )
     month_name = _make_nan_func(

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -442,7 +442,32 @@ class NaTType(_NaT):
         Monday == 1 ... Sunday == 7.
         """,
     )
-    total_seconds = _make_nan_func("total_seconds", timedelta.total_seconds.__doc__)
+    total_seconds = _make_nan_func(
+        "total_seconds",
+        """
+        Total seconds in the duration with default us precision
+        (for compatibility with `datetime.timedelta`).
+
+        Parameters
+        ----------
+        ns_precision : bool, default False
+            Return the duration with ns precision.
+
+        Examples
+        --------
+        >>> td = pd.Timedelta(days=6, minutes=50, seconds=3,
+        ...                   milliseconds=10, microseconds=10, nanoseconds=12)
+        >>> td
+        Timedelta('6 days 00:50:03.010010012')
+
+        >>> td.total_seconds()
+        521403.01001
+
+        >>> td.total_seconds(ns_precision=True)
+        521403.010010012
+
+        """
+    )
     month_name = _make_nan_func(
         "month_name",
         """

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1562,7 +1562,6 @@ class Timedelta(_Timedelta):
 
         >>> td.total_seconds(ns_precision=True)
         521403.010010012
-
         """
         if ns_precision:
             return self.value / 1_000_000_000

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1539,6 +1539,10 @@ class Timedelta(_Timedelta):
         div = other // self
         return div, other - div * self
 
+    def total_seconds(self):
+        """Total seconds in the duration."""
+        return self.value / 1_000_000_000
+
 
 cdef bint is_any_td_scalar(object obj):
     """

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1539,9 +1539,34 @@ class Timedelta(_Timedelta):
         div = other // self
         return div, other - div * self
 
-    def total_seconds(self):
-        """Total seconds in the duration."""
-        return self.value / 1_000_000_000
+    # GH45129
+    def total_seconds(self, *, ns_precision=False) -> float:
+        """
+        Total seconds in the duration with default us precision
+        (for compatibility with `datetime.timedelta`).
+
+        Parameters
+        ----------
+        ns_precision : bool, default False
+            Return the duration with ns precision.
+
+        Examples
+        --------
+        >>> td = pd.Timedelta(days=6, minutes=50, seconds=3,
+        ...                   milliseconds=10, microseconds=10, nanoseconds=12)
+        >>> td
+        Timedelta('6 days 00:50:03.010010012')
+
+        >>> td.total_seconds()
+        521403.01001
+
+        >>> td.total_seconds(ns_precision=True)
+        521403.010010012
+
+        """
+        if ns_precision:
+            return self.value / 1_000_000_000
+        return super().total_seconds()
 
 
 cdef bint is_any_td_scalar(object obj):

--- a/pandas/tests/tslibs/test_timedeltas.py
+++ b/pandas/tests/tslibs/test_timedeltas.py
@@ -46,3 +46,23 @@ def test_huge_nanoseconds_overflow():
     # GH 32402
     assert delta_to_nanoseconds(Timedelta(1e10)) == 1e10
     assert delta_to_nanoseconds(Timedelta(nanoseconds=1e10)) == 1e10
+
+
+# GH40946
+@pytest.mark.parametrize(
+    "obj, expected",
+    [
+        (Timedelta("1us"), 1e-6),
+        (Timedelta("500ns"), 5e-7),
+        (Timedelta(nanoseconds=500), 5e-7),
+        (Timedelta(seconds=1, nanoseconds=500), 1 + 5e-7),
+        # require GH45108
+        # (Timedelta(seconds=1e-9, milliseconds=1e-5, microseconds=1e-1), 111e-9),
+        # (
+        #     Timedelta(days=1, seconds=1e-9, milliseconds=1e-5, microseconds=1e-1),
+        #     24 * 3600 + 111e-9
+        # )
+    ],
+)
+def test_total_seconds(obj, expected):
+    assert obj.total_seconds() == expected

--- a/pandas/tests/tslibs/test_timedeltas.py
+++ b/pandas/tests/tslibs/test_timedeltas.py
@@ -50,19 +50,20 @@ def test_huge_nanoseconds_overflow():
 
 # GH40946
 @pytest.mark.parametrize(
-    "obj, expected",
+    "obj, expected_ns, expected_us",
     [
-        (Timedelta("1us"), 1e-6),
-        (Timedelta("500ns"), 5e-7),
-        (Timedelta(nanoseconds=500), 5e-7),
-        (Timedelta(seconds=1, nanoseconds=500), 1 + 5e-7),
-        # require GH45108
-        # (Timedelta(seconds=1e-9, milliseconds=1e-5, microseconds=1e-1), 111e-9),
-        # (
-        #     Timedelta(days=1, seconds=1e-9, milliseconds=1e-5, microseconds=1e-1),
-        #     24 * 3600 + 111e-9
-        # )
+        (Timedelta("1us"), 1e-6, 1e-6),
+        (Timedelta("500ns"), 5e-7, 0.0),
+        (Timedelta(nanoseconds=500), 5e-7, 0.0),
+        (Timedelta(seconds=1, nanoseconds=500), 1 + 5e-7, 1.0),
+        (Timedelta(seconds=1e-9, milliseconds=1e-5, microseconds=1e-1), 111e-9, 0.0),
+        (
+            Timedelta(days=1, seconds=1e-9, milliseconds=1e-5, microseconds=1e-1),
+            24 * 3600 + 111e-9,
+            24 * 3600,
+        ),
     ],
 )
-def test_total_seconds(obj, expected):
-    assert obj.total_seconds() == expected
+def test_total_seconds(obj: Timedelta, expected_ns, expected_us):
+    assert obj.total_seconds() == expected_us
+    assert obj.total_seconds(ns_precision=True) == expected_ns


### PR DESCRIPTION
- [x] closes #40946
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

As of now, I could not figure out what's leading to test failing in pandas\tests\scalar\timestamp\test_constructors.py:609.