### PR TITLE
BUG: allow use of both default+input resolvers in df.eval, GH34966

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -977,6 +977,7 @@ Other
 - Bug in :meth:`DataFrame.diff` when passing a NumPy integer object instead of an ``int`` object (:issue:`44572`)
 - Bug in :meth:`Series.replace` raising ``ValueError`` when using ``regex=True`` with a :class:`Series` containing ``np.nan`` values (:issue:`43344`)
 - Bug in :meth:`DataFrame.to_records` where an incorrect ``n`` was used when missing names were replaced by ``level_n`` (:issue:`44818`)
+- Bug in :meth:`DataFrame.eval` where ``resolvers`` argument was overriding the default resolvers
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -977,7 +977,7 @@ Other
 - Bug in :meth:`DataFrame.diff` when passing a NumPy integer object instead of an ``int`` object (:issue:`44572`)
 - Bug in :meth:`Series.replace` raising ``ValueError`` when using ``regex=True`` with a :class:`Series` containing ``np.nan`` values (:issue:`43344`)
 - Bug in :meth:`DataFrame.to_records` where an incorrect ``n`` was used when missing names were replaced by ``level_n`` (:issue:`44818`)
-- Bug in :meth:`DataFrame.eval` where ``resolvers`` argument was overriding the default resolvers
+- Bug in :meth:`DataFrame.eval` where ``resolvers`` argument was overriding the default resolvers (:issue:`34966`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4221,15 +4221,13 @@ class DataFrame(NDFrame, OpsMixin):
         from pandas.core.computation.eval import eval as _eval
 
         inplace = validate_bool_kwarg(inplace, "inplace")
-        resolvers = kwargs.pop("resolvers", None)
         kwargs["level"] = kwargs.pop("level", 0) + 1
-        if resolvers is None:
-            index_resolvers = self._get_index_resolvers()
-            column_resolvers = self._get_cleaned_column_resolvers()
-            resolvers = column_resolvers, index_resolvers
+        index_resolvers = self._get_index_resolvers()
+        column_resolvers = self._get_cleaned_column_resolvers()
+        resolvers = column_resolvers, index_resolvers
         if "target" not in kwargs:
             kwargs["target"] = self
-        kwargs["resolvers"] = kwargs.get("resolvers", ()) + tuple(resolvers)
+        kwargs["resolvers"] = tuple(kwargs.get("resolvers", ())) + resolvers
 
         return _eval(expr, inplace=inplace, **kwargs)
 

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -165,7 +165,7 @@ class TestDataFrameEval:
         assert df.eval("a + b", resolvers=[dict1, dict2]) == dict1["a"] + dict2["b"]
         assert pd.eval("a + b", resolvers=[dict1, dict2]) == dict1["a"] + dict2["b"]
 
-        def test_eval_resolvers_combined(self):
+    def test_eval_resolvers_combined(self):
         # GH 34966
         df = DataFrame(np.random.randn(10, 2), columns=list("ab"))
         dict1 = {"c": 2}

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -173,7 +173,7 @@ class TestDataFrameEval:
         # Both input and default index/column resolvers should be usable
         result = df.eval("a + b * c", resolvers=[dict1])
 
-        expected = df[["a"]] + df[["b"]] * dict1["c"]
+        expected = df["a"] + df["b"] * dict1["c"]
         tm.assert_series_equal(result, expected)
 
     def test_eval_object_dtype_binop(self):

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -164,6 +164,17 @@ class TestDataFrameEval:
         dict2 = {"b": 2}
         assert df.eval("a + b", resolvers=[dict1, dict2]) == dict1["a"] + dict2["b"]
         assert pd.eval("a + b", resolvers=[dict1, dict2]) == dict1["a"] + dict2["b"]
+    
+    def test_eval_resolvers_combined(self):
+        # GH 34966
+        df = DataFrame(np.random.randn(10,2), columns=list("ab"))
+        dict1 = {"c": 2}
+        
+        # Both input and default index/column resolvers should be usable
+        result = df.eval("a + b * c", resolvers = [dict1])
+        
+        expected = df["a"] + df["b"] * dict1["c"]
+        tm.assert_frame_equal(result, expected)
 
     def test_eval_object_dtype_binop(self):
         # GH#24883

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -164,17 +164,17 @@ class TestDataFrameEval:
         dict2 = {"b": 2}
         assert df.eval("a + b", resolvers=[dict1, dict2]) == dict1["a"] + dict2["b"]
         assert pd.eval("a + b", resolvers=[dict1, dict2]) == dict1["a"] + dict2["b"]
-    
-    def test_eval_resolvers_combined(self):
+
+        def test_eval_resolvers_combined(self):
         # GH 34966
-        df = DataFrame(np.random.randn(10,2), columns=list("ab"))
+        df = DataFrame(np.random.randn(10, 2), columns=list("ab"))
         dict1 = {"c": 2}
-        
+
         # Both input and default index/column resolvers should be usable
-        result = df.eval("a + b * c", resolvers = [dict1])
-        
-        expected = df["a"] + df["b"] * dict1["c"]
-        tm.assert_frame_equal(result, expected)
+        result = df.eval("a + b * c", resolvers=[dict1])
+
+        expected = df[["a"]] + df[["b"]] * dict1["c"]
+        tm.assert_series_equal(result, expected)
 
     def test_eval_object_dtype_binop(self):
         # GH#24883


### PR DESCRIPTION
- [x] closes #34966
- [x] tests added / passed (all tests passed except those which were auto-cancelled for taking too long)
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

Allows default resolvers to be used with input resolvers in `pandas.dataframe.eval`. Previously cases such as this would break:
```python
import pandas as pd

df = pd.DataFrame({'a':[0,1,2], 'b':[7,8,9]}) 
d = {'c': 5}
df.eval('a+b*c', resolvers=[d])
```
with `pandas.core.computation.ops.UndefinedVariableError: name 'a' is not defined` as explained in #34966. Following this update, the above works as expected.
Added a test similar to the above: `tests.frame.test_query_eval.TestDataFrameEval.test_eval_resolvers_combined`