### PR TITLE
BUG: Series.where with PeriodDtype raising on no-op

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -870,7 +870,7 @@ Period
 - Bug in :meth:`PeriodIndex.to_timestamp` when the index has ``freq="B"`` inferring ``freq="D"`` for its result instead of ``freq="B"`` (:issue:`44105`)
 - Bug in :class:`Period` constructor incorrectly allowing ``np.timedelta64("NaT")`` (:issue:`44507`)
 - Bug in :meth:`PeriodIndex.to_timestamp` giving incorrect values for indexes with non-contiguous data (:issue:`44100`)
-- Bug in :meth:`Series.where` with ``PeriodDtype`` incorrectly raising when the ``where`` call should not replace anything (:issue:`44181`)
+- Bug in :meth:`Series.where` with ``PeriodDtype`` incorrectly raising when the ``where`` call should not replace anything (:issue:`45135`)
 
 -
 

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -870,6 +870,8 @@ Period
 - Bug in :meth:`PeriodIndex.to_timestamp` when the index has ``freq="B"`` inferring ``freq="D"`` for its result instead of ``freq="B"`` (:issue:`44105`)
 - Bug in :class:`Period` constructor incorrectly allowing ``np.timedelta64("NaT")`` (:issue:`44507`)
 - Bug in :meth:`PeriodIndex.to_timestamp` giving incorrect values for indexes with non-contiguous data (:issue:`44100`)
+- Bug in :meth:`Series.where` with ``PeriodDtype`` incorrectly raising when the ``where`` call should not replace anything (:issue:`44181`)
+
 -
 
 Plotting

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1330,6 +1330,58 @@ class EABackedBlock(Block):
 
     values: ExtensionArray
 
+    def where(self, other, cond) -> list[Block]:
+        arr = self.values.T
+
+        cond = extract_bool_array(cond)
+
+        other = self._maybe_squeeze_arg(other)
+        cond = self._maybe_squeeze_arg(cond)
+
+        if other is lib.no_default:
+            other = self.fill_value
+
+        icond, noop = validate_putmask(arr, ~cond)
+        if noop:
+            # Avoid a) raising for Interval/PeriodDtype and b) unnecessary object upcast
+            return self.copy()
+
+        try:
+            res_values = arr._where(cond, other).T
+        except (ValueError, TypeError) as err:
+            if isinstance(err, ValueError):
+                # TODO(2.0): once DTA._validate_setitem_value deprecation
+                #  is enforced, stop catching ValueError here altogether
+                if "Timezones don't match" not in str(err):
+                    raise
+
+            if is_interval_dtype(self.dtype):
+                # TestSetitemFloatIntervalWithIntIntervalValues
+                blk = self.coerce_to_target_dtype(other)
+                if blk.dtype == _dtype_obj:
+                    # For now at least only support casting e.g.
+                    #  Interval[int64]->Interval[float64]
+                    raise
+                return blk.where(other, cond)
+
+            elif isinstance(self, NDArrayBackedExtensionBlock):
+                # NB: not (yet) the same as
+                #  isinstance(values, NDArrayBackedExtensionArray)
+                if isinstance(self.dtype, PeriodDtype):
+                    # TODO: don't special-case
+                    # Note: this is the main place where the fallback logic
+                    #  is different from EABackedBlock.putmask.
+                    raise
+                blk = self.coerce_to_target_dtype(other)
+                nbs = blk.where(other, cond)
+                return self._maybe_downcast(nbs, "infer")
+
+            else:
+                raise
+
+        nb = self.make_block_same_class(res_values)
+        return [nb]
+
     def putmask(self, mask, new) -> list[Block]:
         """
         See Block.putmask.__doc__
@@ -1648,36 +1700,6 @@ class ExtensionBlock(libinternals.Block, EABackedBlock):
         new_values = self.values.shift(periods=periods, fill_value=fill_value)
         return [self.make_block_same_class(new_values)]
 
-    def where(self, other, cond) -> list[Block]:
-
-        cond = extract_bool_array(cond)
-        assert not isinstance(other, (ABCIndex, ABCSeries, ABCDataFrame))
-
-        other = self._maybe_squeeze_arg(other)
-        cond = self._maybe_squeeze_arg(cond)
-
-        if other is lib.no_default:
-            other = self.fill_value
-
-        icond, noop = validate_putmask(self.values, ~cond)
-        if noop:
-            return self.copy()
-
-        try:
-            result = self.values._where(cond, other)
-        except TypeError:
-            if is_interval_dtype(self.dtype):
-                # TestSetitemFloatIntervalWithIntIntervalValues
-                blk = self.coerce_to_target_dtype(other)
-                if blk.dtype == _dtype_obj:
-                    # For now at least only support casting e.g.
-                    #  Interval[int64]->Interval[float64]
-                    raise
-                return blk.where(other, cond)
-            raise
-
-        return [self.make_block_same_class(result)]
-
     def _unstack(
         self,
         unstacker,
@@ -1759,26 +1781,6 @@ class NDArrayBackedExtensionBlock(libinternals.NDArrayBackedBlock, EABackedBlock
             values = values.T
         values[indexer] = value
         return self
-
-    def where(self, other, cond) -> list[Block]:
-        arr = self.values
-
-        cond = extract_bool_array(cond)
-        if other is lib.no_default:
-            other = self.fill_value
-
-        try:
-            res_values = arr.T._where(cond, other).T
-        except (ValueError, TypeError):
-            if isinstance(self.dtype, PeriodDtype):
-                # TODO: don't special-case
-                raise
-            blk = self.coerce_to_target_dtype(other)
-            nbs = blk.where(other, cond)
-            return self._maybe_downcast(nbs, "infer")
-
-        nb = self.make_block_same_class(res_values)
-        return [nb]
 
     def diff(self, n: int, axis: int = 0) -> list[Block]:
         """

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1343,6 +1343,7 @@ class EABackedBlock(Block):
 
         icond, noop = validate_putmask(arr, ~cond)
         if noop:
+            # GH#44181, GH#45135
             # Avoid a) raising for Interval/PeriodDtype and b) unnecessary object upcast
             return self.copy()
 

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -711,6 +711,36 @@ class TestDataFrameIndexingWhere:
         res = ser.where(ser.notna())
         tm.assert_series_equal(res, ser)
 
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            "timedelta64[ns]",
+            "datetime64[ns]",
+            "datetime64[ns, Asia/Tokyo]",
+            "Period[D]",
+        ],
+    )
+    def test_where_datetimelike_noop(self, dtype):
+        # GH#44181 analogue for Period don't raise on no-op
+        # For td64/dt64/dt64tz we already don't raise, but also are
+        #  checking that we don't unnecessarily upcast to object.
+        ser = Series(np.arange(3) * 10 ** 9).view(dtype)
+        df = ser.to_frame()
+        mask = np.array([False, False, False])
+
+        res = ser.where(~mask, "foo")
+        tm.assert_series_equal(res, ser)
+
+        mask2 = mask.reshape(-1, 1)
+        res2 = df.where(~mask2, "foo")
+        tm.assert_frame_equal(res2, df)
+
+        res3 = ser.mask(mask, "foo")
+        tm.assert_series_equal(res3, ser)
+
+        res4 = df.mask(mask2, "foo")
+        tm.assert_frame_equal(res4, df)
+
 
 def test_where_try_cast_deprecated(frame_or_series):
     obj = DataFrame(np.random.randn(4, 3))

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -721,7 +721,7 @@ class TestDataFrameIndexingWhere:
         ],
     )
     def test_where_datetimelike_noop(self, dtype):
-        # GH#44181 analogue for Period don't raise on no-op
+        # GH#45135, analogue to GH#44181 for Period don't raise on no-op
         # For td64/dt64/dt64tz we already don't raise, but also are
         #  checking that we don't unnecessarily upcast to object.
         ser = Series(np.arange(3) * 10 ** 9).view(dtype)

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -724,7 +724,7 @@ class TestDataFrameIndexingWhere:
         # GH#45135, analogue to GH#44181 for Period don't raise on no-op
         # For td64/dt64/dt64tz we already don't raise, but also are
         #  checking that we don't unnecessarily upcast to object.
-        ser = Series(np.arange(3) * 10 ** 9).view(dtype)
+        ser = Series(np.arange(3) * 10 ** 9, dtype=np.int64).view(dtype)
         df = ser.to_frame()
         mask = np.array([False, False, False])
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

In the process we get to de-duplicate Block where methods