### PR TITLE
ENH: add `cline` to `Styler.to_latex`

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -117,6 +117,7 @@ There are also some LaTeX specific enhancements:
 
   - :meth:`.Styler.to_latex` introduces keyword argument ``environment``, which also allows a specific "longtable" entry through a separate jinja2 template (:issue:`41866`).
   - Naive sparsification is now possible for LaTeX without the necessity of including the multirow package (:issue:`43369`)
+  - *cline* support has been added for MultiIndex row sparsification through a keyword argument (:issue:`45138`)
 
 .. _whatsnew_140.enhancements.pyarrow_csv_engine:
 

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -548,13 +548,13 @@ class Styler(StylerRenderer):
             Possible values are:
 
               - `None`: no cline commands are added (default).
-              - `"all-data"`: a cline is added for every index value extending the
+              - `"all;data"`: a cline is added for every index value extending the
                 width of the table, including data entries.
-              - `"all-index"`: as above with lines extending only the width of the
+              - `"all;index"`: as above with lines extending only the width of the
                 index entries.
-              - `"skip-last-data": a cline is added for each index value except the last
+              - `"skip-last;data": a cline is added for each index value except the last
                 level (which is never sparsified), extending the widtn of the table.
-              - `"skip-last-index"`: as above with lines extending only the width of the
+              - `"skip-last;index"`: as above with lines extending only the width of the
                 index entries.
 
             .. versionadded:: 1.4.0

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -548,8 +548,8 @@ class Styler(StylerRenderer):
             Possible values are:
 
               - `None`: no cline commands are added (default).
-              - `"all-data"`: a cline is added for every index value the width of the
-                table, including data entries.
+              - `"all-data"`: a cline is added for every index value extending the
+                width of the table, including data entries.
               - `"all-index"`: as above with lines extending only the width of the
                 index entries.
               - `"skip-last-data": a cline is added for each index value except the last

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -552,8 +552,9 @@ class Styler(StylerRenderer):
                 width of the table, including data entries.
               - `"all;index"`: as above with lines extending only the width of the
                 index entries.
-              - `"skip-last;data": a cline is added for each index value except the last
-                level (which is never sparsified), extending the widtn of the table.
+              - `"skip-last;data"`: a cline is added for each index value except the
+                last level (which is never sparsified), extending the widtn of the
+                table.
               - `"skip-last;index"`: as above with lines extending only the width of the
                 index entries.
 

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -494,6 +494,7 @@ class Styler(StylerRenderer):
         position: str | None = None,
         position_float: str | None = None,
         hrules: bool | None = None,
+        clines: str | None = None,
         label: str | None = None,
         caption: str | tuple | None = None,
         sparse_index: bool | None = None,
@@ -542,6 +543,21 @@ class Styler(StylerRenderer):
             Defaults to ``pandas.options.styler.latex.hrules``, which is `False`.
 
             .. versionchanged:: 1.4.0
+        clines : str, optional
+            Use to control adding \\cline commands for the index labels separation.
+            Possible values are:
+
+              - `None`: no cline commands are added (default).
+              - `"all-data"`: a cline is added for every index value the width of the
+                table, including data entries.
+              - `"all-index"`: as above with lines extending only the width of the
+                index entries.
+              - `"skip-last-data": a cline is added for each index value except the last
+                level (which is never sparsified), extending the widtn of the table.
+              - `"skip-last-index"`: as above with lines extending only the width of the
+                index entries.
+
+            .. versionadded:: 1.4.0
         label : str, optional
             The LaTeX label included as: \\label{<label>}.
             This is used with \\ref{<label>} in the main .tex file.
@@ -911,6 +927,7 @@ class Styler(StylerRenderer):
             environment=environment,
             convert_css=convert_css,
             siunitx=siunitx,
+            clines=clines,
         )
 
         encoding = encoding or get_option("styler.render.encoding")

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -257,13 +257,18 @@ class StylerRenderer:
         head = self._translate_header(sparse_cols, max_cols)
         d.update({"head": head})
 
+        idx_lengths = _get_level_lengths(
+            self.index, sparse_index, max_rows, self.hidden_rows
+        )
+        d.update({"index_lengths": idx_lengths})
+
         self.cellstyle_map: DefaultDict[tuple[CSSPair, ...], list[str]] = defaultdict(
             list
         )
         self.cellstyle_map_index: DefaultDict[
             tuple[CSSPair, ...], list[str]
         ] = defaultdict(list)
-        body = self._translate_body(sparse_index, max_rows, max_cols)
+        body = self._translate_body(idx_lengths, max_rows, max_cols)
         d.update({"body": body})
 
         ctx_maps = {
@@ -515,7 +520,7 @@ class StylerRenderer:
 
         return index_names + column_blanks
 
-    def _translate_body(self, sparsify_index: bool, max_rows: int, max_cols: int):
+    def _translate_body(self, idx_lengths: dict, max_rows: int, max_cols: int):
         """
         Build each <tr> within table <body> as a list
 
@@ -538,10 +543,6 @@ class StylerRenderer:
             The associated HTML elements needed for template rendering.
         """
         # for sparsifying a MultiIndex
-        idx_lengths = _get_level_lengths(
-            self.index, sparsify_index, max_rows, self.hidden_rows
-        )
-
         rlabels = self.data.index.tolist()
         if not isinstance(self.data.index, MultiIndex):
             rlabels = [[x] for x in rlabels]

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -807,7 +807,7 @@ class StylerRenderer:
                 for idx_lvl in range(idx_range):
                     idx_len = d["index_lengths"].get((idx_lvl, r), None)
                     if idx_len is not None:  # sparsified entry
-                        d["clines"][rn - 1 + idx_len].append(
+                        d["clines"][rn + idx_len].append(
                             f"\\cline{{{idx_lvl+1}-{index_levels+data_len}}}"
                         )
 

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -259,6 +259,7 @@ class StylerRenderer:
         head = self._translate_header(sparse_cols, max_cols)
         d.update({"head": head})
 
+        # for sparsifying a MultiIndex and for use with latex clines
         idx_lengths = _get_level_lengths(
             self.index, sparse_index, max_rows, self.hidden_rows
         )
@@ -544,7 +545,6 @@ class StylerRenderer:
         body : list
             The associated HTML elements needed for template rendering.
         """
-        # for sparsifying a MultiIndex
         rlabels = self.data.index.tolist()
         if not isinstance(self.data.index, MultiIndex):
             rlabels = [[x] for x in rlabels]

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -799,7 +799,7 @@ class StylerRenderer:
                     idx_len = d["index_lengths"].get((idx_lvl, r), None)
                     if idx_len is not None:  # sparsified entry
                         d["clines"][row_count - 1 + idx_len].append(
-                            fr"\cline{{{idx_lvl+1}-{index_levels}}}"
+                            f"\\cline{{{idx_lvl+1}-{index_levels}}}"
                         )
 
     def format(

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -790,6 +790,18 @@ class StylerRenderer:
             body.append(row_body_headers + row_body_cells)
         d["body"] = body
 
+        d["clines"] = defaultdict(list)
+        rlabels, row_count = self.data.index.tolist(), 0
+        for r, _ in enumerate(rlabels):
+            if r not in self.hidden_rows:
+                row_count += 1
+                for idx_lvl in range(index_levels):
+                    idx_len = d["index_lengths"].get((idx_lvl, r), None)
+                    if idx_len is not None:  # sparsified entry
+                        d["clines"][row_count - 1 + idx_len].append(
+                            fr"\cline{{{idx_lvl+1}-{index_levels}}}"
+                        )
+
     def format(
         self,
         formatter: ExtFormatter | None = None,

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -752,10 +752,10 @@ class StylerRenderer:
             or multirow sparsification (so that \multirow and \multicol work correctly).
         """
         index_levels = self.index.nlevels
-        visible_index_levels = index_levels - sum(self.hide_index_)
+        visible_index_level_n = index_levels - sum(self.hide_index_)
         d["head"] = [
             [
-                {**col, "cellstyle": self.ctx_columns[r, c - visible_index_levels]}
+                {**col, "cellstyle": self.ctx_columns[r, c - visible_index_level_n]}
                 for c, col in enumerate(row)
                 if col["is_visible"]
             ]
@@ -810,10 +810,10 @@ class StylerRenderer:
             data_len = len(row_body_cells) if "data" in clines else 0
 
             d["clines"] = defaultdict(list)
-            visible_row_indexes = [
+            visible_row_indexes: list[int] = [
                 r for r in range(len(self.data.index)) if r not in self.hidden_rows
             ]
-            visible_index_levels = [
+            visible_index_levels: list[int] = [
                 i for i in range(index_levels) if not self.hide_index_[i]
             ]
             for rn, r in enumerate(visible_row_indexes):

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -795,20 +795,23 @@ class StylerRenderer:
         # clines are determined from info on index_lengths and hidden_rows and input
         # to a dict defining which row clines should be added in the template.
         if clines is not None:
-            # define cline construction from kwarg input
-            idx_range = index_levels if "all" in clines else index_levels - 1
             data_len = len(row_body_cells) if "data" in clines else 0
 
             d["clines"] = defaultdict(list)
             visible_row_indexes = [
                 r for r in range(len(self.data.index)) if r not in self.hidden_rows
             ]
+            visible_index_levels = [
+                i for i in range(index_levels) if not self.hide_index_[i]
+            ]
             for rn, r in enumerate(visible_row_indexes):
-                for idx_lvl in range(idx_range):
-                    idx_len = d["index_lengths"].get((idx_lvl, r), None)
-                    if idx_len is not None:  # sparsified entry
+                for lvln, lvl in enumerate(visible_index_levels):
+                    if lvl == index_levels - 1 and "skip-last" in clines:
+                        continue
+                    idx_len = d["index_lengths"].get((lvl, r), None)
+                    if idx_len is not None:  # i.e. not a sparsified entry
                         d["clines"][rn + idx_len].append(
-                            f"\\cline{{{idx_lvl+1}-{index_levels+data_len}}}"
+                            f"\\cline{{{lvln+1}-{len(visible_index_levels)+data_len}}}"
                         )
 
     def format(

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -800,16 +800,16 @@ class StylerRenderer:
             data_len = len(row_body_cells) if "data" in clines else 0
 
             d["clines"] = defaultdict(list)
-            row_count = 0
-            for r in range(len(self.data.index)):
-                if r not in self.hidden_rows:
-                    row_count += 1
-                    for idx_lvl in range(idx_range):
-                        idx_len = d["index_lengths"].get((idx_lvl, r), None)
-                        if idx_len is not None:  # sparsified entry
-                            d["clines"][row_count - 1 + idx_len].append(
-                                f"\\cline{{{idx_lvl+1}-{index_levels+data_len}}}"
-                            )
+            visible_row_indexes = [
+                r for r in range(len(self.data.index)) if r not in self.hidden_rows
+            ]
+            for rn, r in enumerate(visible_row_indexes):
+                for idx_lvl in range(idx_range):
+                    idx_len = d["index_lengths"].get((idx_lvl, r), None)
+                    if idx_len is not None:  # sparsified entry
+                        d["clines"][rn - 1 + idx_len].append(
+                            f"\\cline{{{idx_lvl+1}-{index_levels+data_len}}}"
+                        )
 
     def format(
         self,

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -795,15 +795,16 @@ class StylerRenderer:
 
         # clines are determined from info on index_lengths and hidden_rows and input
         # to a dict defining which row clines should be added in the template.
-        if clines is not None and (
-            not ("data" in clines or "index" in clines)
-            or not ("all" in clines or "skip-last" in clines)
-        ):
-            raise AttributeError(
-                f"`clines` value of {clines} is invalid. Should"
-                f"contain either 'index' or 'data' for determining the"
-                f"line endpoint, and either 'all' or 'skip-last' to "
-                f"determine the index levels applied, e.g. 'all;data'"
+        if clines not in [
+            None,
+            "all;data",
+            "all;index",
+            "skip-last;data",
+            "skip-last;index",
+        ]:
+            raise ValueError(
+                f"`clines` value of {clines} is invalid. Should either be None or one "
+                f"of 'all;data', 'all;index', 'skip-last;data', 'skip-last;index'."
             )
         elif clines is not None:
             data_len = len(row_body_cells) if "data" in clines else 0

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -794,7 +794,17 @@ class StylerRenderer:
 
         # clines are determined from info on index_lengths and hidden_rows and input
         # to a dict defining which row clines should be added in the template.
-        if clines is not None:
+        if clines is not None and (
+            not ("data" in clines or "index" in clines)
+            or not ("all" in clines or "skip-last" in clines)
+        ):
+            raise AttributeError(
+                f"`clines` value of {clines} is invalid. Should"
+                f"contain either 'index' or 'data' for determining the"
+                f"line endpoint, and either 'all' or 'skip-last' to "
+                f"determine the index levels applied, e.g. 'all;data'"
+            )
+        elif clines is not None:
             data_len = len(row_body_cells) if "data" in clines else 0
 
             d["clines"] = defaultdict(list)

--- a/pandas/io/formats/templates/latex_longtable.tpl
+++ b/pandas/io/formats/templates/latex_longtable.tpl
@@ -73,6 +73,10 @@
 {% for c in row %}{% if not loop.first %} & {% endif %}
   {%- if c.type == 'th' %}{{parse_header(c, multirow_align, multicol_align)}}{% else %}{{parse_cell(c.cellstyle, c.display_value, convert_css)}}{% endif %}
 {%- endfor %} \\
+{% if clines and clines[loop.index] | length > 0 %}
+  {%- for cline in clines[loop.index] %}{% if not loop.first %} {% endif %}{{ cline }}{% endfor %}
+
+{% endif %}
 {% endfor %}
 \end{longtable}
 {% raw %}{% endraw %}

--- a/pandas/io/formats/templates/latex_table.tpl
+++ b/pandas/io/formats/templates/latex_table.tpl
@@ -31,15 +31,15 @@
 \{{toprule}}
 {% endif %}
 {% for row in head %}
-{% for col in row %}{%- if not loop.first %} & {% endif %}{{parse_header(col, multirow_align, multicol_align, siunitx, convert_css)}}{% endfor %} \\
+{% for c in row %}{%- if not loop.first %} & {% endif %}{{parse_header(c, multirow_align, multicol_align, siunitx, convert_css)}}{% endfor %} \\
 {% endfor %}
 {% set midrule = parse_table(table_styles, 'midrule') %}
 {% if midrule is not none %}
 \{{midrule}}
 {% endif %}
 {% for row in body %}
-{% for col in row %}{% if not loop.first %} & {% endif %}
-  {%- if col.type == 'th' %}{{parse_header(col, multirow_align, multicol_align, False, convert_css)}}{% else %}{{parse_cell(col.cellstyle, col.display_value, convert_css)}}{% endif %}
+{% for c in row %}{% if not loop.first %} & {% endif %}
+  {%- if c.type == 'th' %}{{parse_header(c, multirow_align, multicol_align, False, convert_css)}}{% else %}{{parse_cell(c.cellstyle, c.display_value, convert_css)}}{% endif %}
 {%- endfor %} \\
 {% if clines and clines[loop.index] | length > 0 %}
   {%- for cline in clines[loop.index] %}{% if not loop.first %} {% endif %}{{ cline }}{% endfor %}

--- a/pandas/io/formats/templates/latex_table.tpl
+++ b/pandas/io/formats/templates/latex_table.tpl
@@ -31,16 +31,17 @@
 \{{toprule}}
 {% endif %}
 {% for row in head %}
-{% for c in row %}{%- if not loop.first %} & {% endif %}{{parse_header(c, multirow_align, multicol_align, siunitx, convert_css)}}{% endfor %} \\
+{% for col in row %}{%- if not loop.first %} & {% endif %}{{parse_header(col, multirow_align, multicol_align, siunitx, convert_css)}}{% endfor %} \\
 {% endfor %}
 {% set midrule = parse_table(table_styles, 'midrule') %}
 {% if midrule is not none %}
 \{{midrule}}
 {% endif %}
 {% for row in body %}
-{% for c in row %}{% if not loop.first %} & {% endif %}
-  {%- if c.type == 'th' %}{{parse_header(c, multirow_align, multicol_align, False, convert_css)}}{% else %}{{parse_cell(c.cellstyle, c.display_value, convert_css)}}{% endif %}
+{% for col in row %}{% if not loop.first %} & {% endif %}
+  {%- if col.type == 'th' %}{{parse_header(col, multirow_align, multicol_align, False, convert_css)}}{% else %}{{parse_cell(col.cellstyle, col.display_value, convert_css)}}{% endif %}
 {%- endfor %} \\
+{% for cline in clines[loop.index] %}{% if not loop.first %} {% endif %}{{ cline }}{% endfor %}
 {% endfor %}
 {% set bottomrule = parse_table(table_styles, 'bottomrule') %}
 {% if bottomrule is not none %}

--- a/pandas/io/formats/templates/latex_table.tpl
+++ b/pandas/io/formats/templates/latex_table.tpl
@@ -41,7 +41,10 @@
 {% for col in row %}{% if not loop.first %} & {% endif %}
   {%- if col.type == 'th' %}{{parse_header(col, multirow_align, multicol_align, False, convert_css)}}{% else %}{{parse_cell(col.cellstyle, col.display_value, convert_css)}}{% endif %}
 {%- endfor %} \\
-{% for cline in clines[loop.index] %}{% if not loop.first %} {% endif %}{{ cline }}{% endfor %}
+{% if clines and clines[loop.index] | length > 0 %}
+  {%- for cline in clines[loop.index] %}{% if not loop.first %} {% endif %}{{ cline }}{% endfor %}
+
+{% endif %}
 {% endfor %}
 {% set bottomrule = parse_table(table_styles, 'bottomrule') %}
 {% if bottomrule is not none %}

--- a/pandas/tests/io/formats/style/test_to_latex.py
+++ b/pandas/tests/io/formats/style/test_to_latex.py
@@ -950,9 +950,13 @@ def test_clines_index(clines, exp, env):
         ),
     ],
 )
-@pytest.mark.parametrize("env", ["table", "longtable"])
+@pytest.mark.parametrize("env", ["table"])
 def test_clines_multiindex(clines, expected, env):
-    midx = MultiIndex.from_product([["A", "B"], ["X", "Y"]])
-    df = DataFrame([[1], [2], [3], [4]], index=midx)
-    result = df.style.to_latex(clines=clines, environment=env)
+    # also tests simultaneously with hidden rows and a hidden multiindex level
+    midx = MultiIndex.from_product([["A", "-", "B"], [0], ["X", "Y"]])
+    df = DataFrame([[1], [2], [99], [99], [3], [4]], index=midx)
+    styler = df.style
+    styler.hide([("-", 0, "X"), ("-", 0, "Y")])
+    styler.hide(level=1)
+    result = styler.to_latex(clines=clines, environment=env)
     assert expected in result

--- a/pandas/tests/io/formats/style/test_to_latex.py
+++ b/pandas/tests/io/formats/style/test_to_latex.py
@@ -858,10 +858,10 @@ def test_rendered_links():
 @pytest.mark.parametrize(
     "clines, exp",
     [
-        ("all-index", "\n\\cline{1-1}"),
-        ("all-data", "\n\\cline{1-2}"),
-        ("skip-last-index", ""),
-        ("skip-last-data", ""),
+        ("all;index", "\n\\cline{1-1}"),
+        ("all;data", "\n\\cline{1-2}"),
+        ("skip-last;index", ""),
+        ("skip-last;data", ""),
         (None, ""),
     ],
 )
@@ -893,7 +893,7 @@ def test_clines_index(clines, exp, env):
             ),
         ),
         (
-            "skip-last-index",
+            "skip-last;index",
             dedent(
                 """\
             \\multirow[c]{2}{*}{A} & X & 1 \\\\
@@ -906,7 +906,7 @@ def test_clines_index(clines, exp, env):
             ),
         ),
         (
-            "skip-last-data",
+            "skip-last;data",
             dedent(
                 """\
             \\multirow[c]{2}{*}{A} & X & 1 \\\\
@@ -919,7 +919,7 @@ def test_clines_index(clines, exp, env):
             ),
         ),
         (
-            "all-index",
+            "all;index",
             dedent(
                 """\
             \\multirow[c]{2}{*}{A} & X & 1 \\\\
@@ -934,7 +934,7 @@ def test_clines_index(clines, exp, env):
             ),
         ),
         (
-            "all-data",
+            "all;data",
             dedent(
                 """\
             \\multirow[c]{2}{*}{A} & X & 1 \\\\

--- a/pandas/tests/io/formats/style/test_to_latex.py
+++ b/pandas/tests/io/formats/style/test_to_latex.py
@@ -881,7 +881,7 @@ def test_apply_index_hidden_levels():
 @pytest.mark.parametrize("clines", ["bad", "index", "skip-last", "all", "data"])
 def test_clines_validation(clines, styler):
     msg = f"`clines` value of {clines} is invalid."
-    with pytest.raises(AttributeError, match=msg):
+    with pytest.raises(ValueError, match=msg):
         styler.to_latex(clines=clines)
 
 

--- a/pandas/tests/io/formats/style/test_to_latex.py
+++ b/pandas/tests/io/formats/style/test_to_latex.py
@@ -855,6 +855,13 @@ def test_rendered_links():
     assert r"text \href{www.domain.com}{www.domain.com} text" in result
 
 
+@pytest.mark.parametrize("clines", ["bad", "index", "skip-last", "all", "data"])
+def test_clines_validation(clines, styler):
+    msg = f"`clines` value of {clines} is invalid."
+    with pytest.raises(AttributeError, match=msg):
+        styler.to_latex(clines=clines)
+
+
 @pytest.mark.parametrize(
     "clines, exp",
     [

--- a/pandas/tests/io/formats/style/test_to_latex.py
+++ b/pandas/tests/io/formats/style/test_to_latex.py
@@ -876,3 +876,83 @@ def test_clines_index(clines, exp, env):
 3 & 4 \\\\{exp}
 """
     assert expected in result
+
+
+@pytest.mark.parametrize(
+    "clines, expected",
+    [
+        (
+            None,
+            dedent(
+                """\
+            \\multirow[c]{2}{*}{A} & X & 1 \\\\
+             & Y & 2 \\\\
+            \\multirow[c]{2}{*}{B} & X & 3 \\\\
+             & Y & 4 \\\\
+            """
+            ),
+        ),
+        (
+            "skip-last-index",
+            dedent(
+                """\
+            \\multirow[c]{2}{*}{A} & X & 1 \\\\
+             & Y & 2 \\\\
+            \\cline{1-2}
+            \\multirow[c]{2}{*}{B} & X & 3 \\\\
+             & Y & 4 \\\\
+            \\cline{1-2}
+            """
+            ),
+        ),
+        (
+            "skip-last-data",
+            dedent(
+                """\
+            \\multirow[c]{2}{*}{A} & X & 1 \\\\
+             & Y & 2 \\\\
+            \\cline{1-3}
+            \\multirow[c]{2}{*}{B} & X & 3 \\\\
+             & Y & 4 \\\\
+            \\cline{1-3}
+            """
+            ),
+        ),
+        (
+            "all-index",
+            dedent(
+                """\
+            \\multirow[c]{2}{*}{A} & X & 1 \\\\
+            \\cline{2-2}
+             & Y & 2 \\\\
+            \\cline{1-2} \\cline{2-2}
+            \\multirow[c]{2}{*}{B} & X & 3 \\\\
+            \\cline{2-2}
+             & Y & 4 \\\\
+            \\cline{1-2} \\cline{2-2}
+            """
+            ),
+        ),
+        (
+            "all-data",
+            dedent(
+                """\
+            \\multirow[c]{2}{*}{A} & X & 1 \\\\
+            \\cline{2-3}
+             & Y & 2 \\\\
+            \\cline{1-3} \\cline{2-3}
+            \\multirow[c]{2}{*}{B} & X & 3 \\\\
+            \\cline{2-3}
+             & Y & 4 \\\\
+            \\cline{1-3} \\cline{2-3}
+            """
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize("env", ["table", "longtable"])
+def test_clines_multiindex(clines, expected, env):
+    midx = MultiIndex.from_product([["A", "B"], ["X", "Y"]])
+    df = DataFrame([[1], [2], [3], [4]], index=midx)
+    result = df.style.to_latex(clines=clines, environment=env)
+    assert expected in result

--- a/pandas/tests/io/formats/style/test_to_latex.py
+++ b/pandas/tests/io/formats/style/test_to_latex.py
@@ -853,3 +853,26 @@ def test_rendered_links():
     df = DataFrame(["text www.domain.com text"])
     result = df.style.format(hyperlinks="latex").to_latex()
     assert r"text \href{www.domain.com}{www.domain.com} text" in result
+
+
+@pytest.mark.parametrize(
+    "clines, exp",
+    [
+        ("all-index", "\n\\cline{1-1}"),
+        ("all-data", "\n\\cline{1-2}"),
+        ("skip-last-index", ""),
+        ("skip-last-data", ""),
+        (None, ""),
+    ],
+)
+@pytest.mark.parametrize("env", ["table", "longtable"])
+def test_clines_index(clines, exp, env):
+    df = DataFrame([[1], [2], [3], [4]])
+    result = df.style.to_latex(clines=clines, environment=env)
+    expected = f"""\
+0 & 1 \\\\{exp}
+1 & 2 \\\\{exp}
+2 & 3 \\\\{exp}
+3 & 4 \\\\{exp}
+"""
+    assert expected in result


### PR DESCRIPTION
- [x] closes #21673

This allows `Styler.to_latex` to also render `\cline` to separate sparse MultiIndex rows according to user input. Tests are also included to demonstrate functionality with hidden rows and hidden index levels.

Note that DataFrame.to_latex also uses `\cline` but it is forced in certain cases without options.

```
midx = pd.MultiIndex.from_product([["A", "-", "B"], [0], ["X", "Y"]], names=["lvl 0", "lvl 1", "last lvl"])
df = pd.DataFrame([[1, "pig"], [2, "coin"], [99, ""], [99, ""], [3, "sky"], [4, "pie"]], 
                  index=midx, columns=["int", "str"])
styler = df.style
styler.hide([("-", 0, "X"), ("-", 0, "Y")])
styler.hide(level=[1,3])
print(styler.to_latex(clines="all;index", hrules=True, multirow_align="t"))
```

| | `all` | `skip-last` |
--- | --- | --- |
**`index`** | <img width="236" alt="Screenshot 2021-12-31 at 14 49 53" src="https://user-images.githubusercontent.com/24256554/147826613-bedb3728-738b-4c06-ac52-93caf4e3e652.png"> | <img width="227" alt="Screenshot 2021-12-31 at 14 55 22" src="https://user-images.githubusercontent.com/24256554/147826866-c58219a5-fef2-4e26-a769-4b0ea8277b56.png">
**`data`** | <img width="233" alt="Screenshot 2021-12-31 at 14 51 30" src="https://user-images.githubusercontent.com/24256554/147826673-d91875ab-512e-46ef-971f-621f595bf0bb.png"> | <img width="237" alt="Screenshot 2021-12-31 at 14 52 59" src="https://user-images.githubusercontent.com/24256554/147826752-664ad7de-092f-4b48-bfbb-7e1b654b6b34.png"> |

Default render without ``clines``:


<img width="218" alt="Screenshot 2021-12-31 at 15 03 14" src="https://user-images.githubusercontent.com/24256554/147827219-f604fdea-35e9-4394-8fd7-9b75b3fba351.png">





