### PR TITLE
BUG: `Styler.apply_index` fails with LaTeX conversion with hidden Multi levels

### DIFF
--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -748,16 +748,17 @@ class StylerRenderer:
           - Remove hidden indexes or reinsert missing th elements if part of multiindex
             or multirow sparsification (so that \multirow and \multicol work correctly).
         """
+        index_levels = self.index.nlevels
+        visible_index_levels = index_levels - sum(self.hide_index_)
         d["head"] = [
             [
-                {**col, "cellstyle": self.ctx_columns[r, c - self.index.nlevels]}
+                {**col, "cellstyle": self.ctx_columns[r, c - visible_index_levels]}
                 for c, col in enumerate(row)
                 if col["is_visible"]
             ]
             for r, row in enumerate(d["head"])
         ]
         body = []
-        index_levels = self.data.index.nlevels
         for r, row in zip(
             [r for r in range(len(self.data.index)) if r not in self.hidden_rows],
             d["body"],

--- a/pandas/tests/io/formats/style/test_to_latex.py
+++ b/pandas/tests/io/formats/style/test_to_latex.py
@@ -853,3 +853,26 @@ def test_rendered_links():
     df = DataFrame(["text www.domain.com text"])
     result = df.style.format(hyperlinks="latex").to_latex()
     assert r"text \href{www.domain.com}{www.domain.com} text" in result
+
+
+def test_apply_index_hidden_levels():
+    # gh 45156
+    styler = DataFrame(
+        [[1]],
+        index=MultiIndex.from_tuples([(0, 1)], names=["l0", "l1"]),
+        columns=MultiIndex.from_tuples([(0, 1)], names=["c0", "c1"]),
+    ).style
+    styler.hide(level=1)
+    styler.applymap_index(lambda v: "color: red;", level=0, axis=1)
+    result = styler.to_latex(convert_css=True)
+    expected = dedent(
+        """\
+        \\begin{tabular}{lr}
+        c0 & \\color{red} 0 \\\\
+        c1 & 1 \\\\
+        l0 &  \\\\
+        0 & 1 \\\\
+        \\end{tabular}
+        """
+    )
+    assert result == expected


### PR DESCRIPTION
- [x] closes #45156 
- [x] whatsnew entry not required since this fixes functionality introduced in the same release (if this PR is in 1.4.0).


Failure is unrelated:
`FAILED pandas/tests/io/parser/test_network.py::TestS3::test_parse_public_s3_bucket_python`