### PR TITLE
DOC: update references to deprecated methods

### DIFF
--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -754,8 +754,8 @@ class Styler(StylerRenderer):
         **Formatting**
 
         To format values :meth:`Styler.format` should be used prior to calling
-        `Styler.to_latex`, as well as other methods such as :meth:`Styler.hide_index`
-        or :meth:`Styler.hide_columns`, for example:
+        `Styler.to_latex`, as well as other methods such as :meth:`Styler.hide`
+        for example:
 
         >>> s.clear()
         >>> s.table_styles = []
@@ -1106,7 +1106,7 @@ class Styler(StylerRenderer):
         >>> df = pd.DataFrame([[1]])
         >>> css = pd.DataFrame([["other-class"]])
         >>> s = Styler(df, uuid="_", cell_ids=False).set_td_classes(css)
-        >>> s.hide_index().to_html()  # doctest: +SKIP
+        >>> s.hide(axis=0).to_html()  # doctest: +SKIP
         '<style type="text/css"></style>'
         '<table id="T__">'
         '  <thead>'
@@ -1809,7 +1809,7 @@ class Styler(StylerRenderer):
 
         >>> styler = DataFrame([[1, 2], [3, 4]]).style
         >>> styler2 = DataFrame([[9, 9, 9]]).style
-        >>> styler.hide_index().highlight_max(axis=1)  # doctest: +SKIP
+        >>> styler.hide(axis=0).highlight_max(axis=1)  # doctest: +SKIP
         >>> export = styler.export()
         >>> styler2.use(export)  # doctest: +SKIP
         """
@@ -1861,7 +1861,7 @@ class Styler(StylerRenderer):
 
         >>> styler = DataFrame([[1, 2], [3, 4]]).style
         >>> styler2 = DataFrame([[9, 9, 9]]).style
-        >>> styler.hide_index().highlight_max(axis=1)  # doctest: +SKIP
+        >>> styler.hide(axis=0).highlight_max(axis=1)  # doctest: +SKIP
         >>> export = styler.export()
         >>> styler2.use(export)  # doctest: +SKIP
         """
@@ -1970,8 +1970,8 @@ class Styler(StylerRenderer):
         This method uses the CSS 'position: sticky;' property to display. It is
         designed to work with visible axes, therefore both:
 
-          - `styler.set_sticky(axis="index").hide_index()`
-          - `styler.set_sticky(axis="columns").hide_columns()`
+          - `styler.set_sticky(axis="index").hide(axis="index")`
+          - `styler.set_sticky(axis="columns").hide(axis="columns")`
 
         may produce strange behaviour due to CSS controls with missing elements.
         """
@@ -2265,7 +2265,7 @@ class Styler(StylerRenderer):
         .. versionchanged:: 1.3.0
 
         .. deprecated:: 1.4.0
-           This method should be replaced by ``hide(axis="columns", **kwargs)``
+           This method should be replaced by ``hide(axis="index", **kwargs)``
 
         Parameters
         ----------


### PR DESCRIPTION
simple fixes should have been made after deprecating `styler.hide_index` and `styler.hide_columns`
