### PR TITLE
REF: separate numpy-specific part of can_hold_element

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -2186,7 +2186,7 @@ def can_hold_element(arr: ArrayLike, element: Any) -> bool:
         return True
 
     try:
-        np_can_hold_element(arr.dtype, element)
+        np_can_hold_element(dtype, element)
         return True
     except (TypeError, ValueError):
         return False

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -2192,7 +2192,7 @@ def can_hold_element(arr: ArrayLike, element: Any) -> bool:
         return False
 
 
-def np_can_hold_element(dtype: np.dtype, element: Any):
+def np_can_hold_element(dtype: np.dtype, element: Any) -> Any:
     """
     Raise if we cannot losslessly set this element into an ndarray with this dtype.
 
@@ -2200,7 +2200,10 @@ def np_can_hold_element(dtype: np.dtype, element: Any):
     cases where numpy will raise in doing the setitem that we do not check
     for here, e.g. setting str "X" into a numeric ndarray.
 
-    Returns the element, potentially cast to the dtype.
+    Returns
+    -------
+    Any
+        The element, potentially cast to the dtype.
 
     Raises
     ------


### PR DESCRIPTION
By returning the value instead of just a bool, we open the option to return the _casted_ value, which is what we'll do in the follow-up, which will let us de-duplicate NumericIndex._validate_fill_value.  By separating out the np-specific parts, we'll be able to improve perf in a couple of places.