### PR TITLE
BUG: MultiIndex dtypes incorrect if level names not unique

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -835,7 +835,7 @@ MultiIndex
 - Bug in :meth:`MultiIndex.get_loc` raising ``TypeError`` instead of ``KeyError`` on nested tuple (:issue:`42440`)
 - Bug in :meth:`MultiIndex.union` setting wrong ``sortorder`` causing errors in subsequent indexing operations with slices (:issue:`44752`)
 - Bug in :meth:`MultiIndex.putmask` where the other value was also a :class:`MultiIndex` (:issue:`43212`)
-- Bug in :meth:`MultiIndex.dtypes` when duplicate level names returned only one dtype (:issue:`45174`)
+- Bug in :meth:`MultiIndex.dtypes` duplicate level names returned only one dtype per name (:issue:`45174`)
 -
 
 I/O

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -835,6 +835,7 @@ MultiIndex
 - Bug in :meth:`MultiIndex.get_loc` raising ``TypeError`` instead of ``KeyError`` on nested tuple (:issue:`42440`)
 - Bug in :meth:`MultiIndex.union` setting wrong ``sortorder`` causing errors in subsequent indexing operations with slices (:issue:`44752`)
 - Bug in :meth:`MultiIndex.putmask` where the other value was also a :class:`MultiIndex` (:issue:`43212`)
+- Bug in :meth:`MultiIndex.dtypes` when duplicate level names returned only one dtype (:issue:`45174`)
 -
 
 I/O

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -735,13 +735,14 @@ class MultiIndex(Index):
     def dtypes(self) -> Series:
         """
         Return the dtypes as a Series for the underlying MultiIndex.
+
+        .. versionchanged:: 1.4.0
+            Correct result when there are duplicated level names.
         """
         from pandas import Series
 
         names = com.fill_missing_names([level.name for level in self.levels])
-        return Series(
-            {names[idx]: level.dtype for idx, level in enumerate(self.levels)}
-        )
+        return Series([level.dtype for level in self.levels], index=names)
 
     def __len__(self) -> int:
         return len(self.codes[0])

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -735,9 +735,6 @@ class MultiIndex(Index):
     def dtypes(self) -> Series:
         """
         Return the dtypes as a Series for the underlying MultiIndex.
-
-        .. versionchanged:: 1.4.0
-            Correct result when there are duplicated level names.
         """
         from pandas import Series
 

--- a/pandas/tests/indexes/multi/test_get_set.py
+++ b/pandas/tests/indexes/multi/test_get_set.py
@@ -67,6 +67,13 @@ def test_get_dtypes_no_level_name():
     tm.assert_series_equal(expected, idx_multitype.dtypes)
 
 
+def test_get_dtypes_duplicate_level_names():
+    # Test MultiIndex.dtypes with non-unique level names (# GH45174 )
+    result = pd.MultiIndex.from_arrays([[1], [2]], names=[1, 1]).dtypes
+    expected = pd.Series([np.dtype("int64"), np.dtype("int64")], index=[1, 1])
+    tm.assert_series_equal(result, expected)
+
+
 def test_get_level_number_out_of_bounds(multiindex_dataframe_random_data):
     frame = multiindex_dataframe_random_data
 

--- a/pandas/tests/indexes/multi/test_get_set.py
+++ b/pandas/tests/indexes/multi/test_get_set.py
@@ -75,15 +75,11 @@ def test_get_dtypes_duplicate_level_names():
             ["a", "b", "c"],
             pd.date_range("20200101", periods=2, tz="UTC"),
         ],
-        names=["A", "A", "A"]
+        names=["A", "A", "A"],
     ).dtypes
     expected = pd.Series(
-        [
-                np.dtype("int64"),
-                np.dtype("O"),
-                DatetimeTZDtype(tz="utc")
-        ],
-        index=["A", "A", "A"]
+        [np.dtype("int64"), np.dtype("O"), DatetimeTZDtype(tz="utc")],
+        index=["A", "A", "A"],
     )
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/indexes/multi/test_get_set.py
+++ b/pandas/tests/indexes/multi/test_get_set.py
@@ -69,7 +69,7 @@ def test_get_dtypes_no_level_name():
 
 def test_get_dtypes_duplicate_level_names():
     # Test MultiIndex.dtypes with non-unique level names (# GH45174 )
-    result = pd.MultiIndex.from_arrays([[1], [2]], names=[1, 1]).dtypes
+    result = MultiIndex.from_arrays([[1], [2]], names=[1, 1]).dtypes
     expected = pd.Series([np.dtype("int64"), np.dtype("int64")], index=[1, 1])
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/indexes/multi/test_get_set.py
+++ b/pandas/tests/indexes/multi/test_get_set.py
@@ -68,9 +68,23 @@ def test_get_dtypes_no_level_name():
 
 
 def test_get_dtypes_duplicate_level_names():
-    # Test MultiIndex.dtypes with non-unique level names (# GH45174 )
-    result = MultiIndex.from_arrays([[1], [2]], names=[1, 1]).dtypes
-    expected = pd.Series([np.dtype("int64"), np.dtype("int64")], index=[1, 1])
+    # Test MultiIndex.dtypes with non-unique level names (# GH45174)
+    result = MultiIndex.from_product(
+        [
+            [1, 2, 3],
+            ["a", "b", "c"],
+            pd.date_range("20200101", periods=2, tz="UTC"),
+        ],
+        names=["A", "A", "A"]
+    ).dtypes
+    expected = pd.Series(
+        [
+                np.dtype("int64"),
+                np.dtype("O"),
+                DatetimeTZDtype(tz="utc")
+        ],
+        index=["A", "A", "A"]
+    )
     tm.assert_series_equal(result, expected)
 
 


### PR DESCRIPTION
- [x] closes #45174
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry
