### PR TITLE
BUG: encoding_errors=None with read_csv c-engine

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -877,7 +877,7 @@ I/O
 - Bug in :func:`read_csv` silently ignoring errors when failing to create a memory-mapped file (:issue:`44766`)
 - Bug in :func:`read_csv` when passing a ``tempfile.SpooledTemporaryFile`` opened in binary mode (:issue:`44748`)
 - Bug in :func:`read_json` raising ``ValueError`` when attempting to parse json strings containing "://" (:issue:`36271`)
-- Bug in :func:`read_csv` when `engine="c"` and `encoding_errors=None` which caused a segfault (:issue:`45180`)
+- Bug in :func:`read_csv` when ``engine="c"`` and ``encoding_errors=None`` which caused a segfault (:issue:`45180`)
 -
 
 Period

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -877,6 +877,7 @@ I/O
 - Bug in :func:`read_csv` silently ignoring errors when failing to create a memory-mapped file (:issue:`44766`)
 - Bug in :func:`read_csv` when passing a ``tempfile.SpooledTemporaryFile`` opened in binary mode (:issue:`44748`)
 - Bug in :func:`read_json` raising ``ValueError`` when attempting to parse json strings containing "://" (:issue:`36271`)
+- Bug in :func:`read_csv` when `engine="c"` and `encoding_errors=None` which caused a segfault (:issue:`45180`)
 -
 
 Period

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -375,6 +375,8 @@ cdef class TextReader:
         # set encoding for native Python and C library
         if isinstance(encoding_errors, str):
             encoding_errors = encoding_errors.encode("utf-8")
+        elif encoding_errors is None:
+            encoding_errors = b"strict"
         Py_INCREF(encoding_errors)
         self.encoding_errors = PyBytes_AsString(encoding_errors)
 

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -549,7 +549,7 @@ def test_explicit_encoding(io_class, mode, msg):
 
 @pytest.mark.parametrize("encoding_errors", [None, "strict", "replace"])
 @pytest.mark.parametrize("format", ["csv", "json"])
-def test_encoding_errors(encoding_errors, format, request):
+def test_encoding_errors(encoding_errors, format):
     # GH39450
     msg = "'utf-8' codec can't decode byte"
     bad_encoding = b"\xe4"

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -549,15 +549,18 @@ def test_explicit_encoding(io_class, mode, msg):
 
 @pytest.mark.parametrize("encoding_errors", [None, "strict", "replace"])
 @pytest.mark.parametrize("format", ["csv", "json"])
-def test_encoding_errors(encoding_errors, format):
+def test_encoding_errors(encoding_errors, format, request):
     # GH39450
     msg = "'utf-8' codec can't decode byte"
     bad_encoding = b"\xe4"
 
     if format == "csv":
-        return
         content = bad_encoding + b"\n" + bad_encoding
         reader = pd.read_csv
+        if encoding_errors == "replace":
+            request.applymarker(
+                pytest.mark.xfail(reason="Should work but needs more time to debug.")
+            )
     else:
         content = (
             b'{"'

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -555,12 +555,8 @@ def test_encoding_errors(encoding_errors, format, request):
     bad_encoding = b"\xe4"
 
     if format == "csv":
-        content = bad_encoding + b"\n" + bad_encoding
-        reader = pd.read_csv
-        if encoding_errors == "replace":
-            request.applymarker(
-                pytest.mark.xfail(reason="Should work but needs more time to debug.")
-            )
+        content = b"," + bad_encoding + b"\n" + bad_encoding * 2 + b"," + bad_encoding
+        reader = partial(pd.read_csv, index_col=0)
     else:
         content = (
             b'{"'


### PR DESCRIPTION
The c-engine did not handle `encoding_errors=None`.

The test case for `replace` was simply wrong in case of read_csv.

Un-blocks @MarcoGorelli's #45173.