### PR TITLE
BUG: Index.get_loc always raise InvalidIndexError on listlike

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3464,7 +3464,8 @@ class DataFrame(NDFrame, OpsMixin):
         key = lib.item_from_zerodim(key)
         key = com.apply_if_callable(key, self)
 
-        if is_hashable(key):
+        if is_hashable(key) and not is_iterator(key):
+            # is_iterator to exclude generator e.g. test_getitem_listlike
             # shortcut if the key is in columns
             if self.columns.is_unique and key in self.columns:
                 if isinstance(self.columns, MultiIndex):

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3601,7 +3601,9 @@ class Index(IndexOpsMixin, PandasObject):
             except KeyError as err:
                 raise KeyError(key) from err
             except TypeError:
-                # If we have a listlike key, raise InvalidIndexError instead
+                # If we have a listlike key, _check_indexing_error will raise
+                #  InvalidIndexError. Otherwise we fall through and re-raise
+                #  the TypeError.
                 self._check_indexing_error(key)
                 raise
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3599,6 +3599,10 @@ class Index(IndexOpsMixin, PandasObject):
                 return self._engine.get_loc(casted_key)
             except KeyError as err:
                 raise KeyError(key) from err
+            except TypeError:
+                # If we have a listlike key, raise InvalidIndexError instead
+                self._check_indexing_error(key)
+                raise
 
         # GH#42269
         warnings.warn(

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2817,7 +2817,7 @@ class MultiIndex(Index):
                 "currently supported for MultiIndex"
             )
 
-        hash(key)
+        self._check_indexing_error(key)
 
         def _maybe_to_slice(loc):
             """convert integer indexer to boolean mask or slice if possible"""

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -966,7 +966,9 @@ class Series(base.IndexOpsMixin, NDFrame):
 
                 return result
 
-            except (KeyError, TypeError):
+            except (KeyError, TypeError, InvalidIndexError):
+                # InvalidIndexError for e.g. generator
+                #  see test_series_getitem_corner_generator
                 if isinstance(key, tuple) and isinstance(self.index, MultiIndex):
                     # We still have the corner case where a tuple is a key
                     # in the first level of our MultiIndex

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 from pandas._libs import iNaT
+from pandas.errors import InvalidIndexError
 import pandas.util._test_decorators as td
 
 from pandas.core.dtypes.common import is_integer
@@ -1171,7 +1172,7 @@ class TestDataFrameIndexing:
         dg = DataFrame(
             [[1, 1, 2, 2], [3, 3, 4, 4]], columns=mi, index=Index([0, 1], name="i")
         )
-        with pytest.raises(TypeError, match="unhashable type"):
+        with pytest.raises(InvalidIndexError, match="slice"):
             dg[:, 0]
 
         index = Index(range(2), name="i")

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -652,7 +652,7 @@ class TestGetLoc:
             idx.get_loc(3)
         with pytest.raises(KeyError, match=r"^nan$"):
             idx.get_loc(np.nan)
-        with pytest.raises(TypeError, match="unhashable type: 'list'"):
+        with pytest.raises(InvalidIndexError, match=r"\[nan\]"):
             # listlike/non-hashable raises TypeError
             idx.get_loc([np.nan])
 
@@ -699,8 +699,8 @@ class TestGetLoc:
     def test_multiindex_get_loc_list_raises(self):
         # GH#35878
         idx = MultiIndex.from_tuples([("a", 1), ("b", 2)])
-        msg = "unhashable type"
-        with pytest.raises(TypeError, match=msg):
+        msg = r"\[\]"
+        with pytest.raises(InvalidIndexError, match=msg):
             idx.get_loc([])
 
     def test_get_loc_nested_tuple_raises_keyerror(self):

--- a/pandas/tests/indexes/numeric/test_indexing.py
+++ b/pandas/tests/indexes/numeric/test_indexing.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from pandas.errors import InvalidIndexError
+
 from pandas import (
     Index,
     RangeIndex,
@@ -41,10 +43,12 @@ class TestGetLoc:
         index = Index([0, 1, 2])
         if method:
             msg = "not supported between"
+            err = TypeError
         else:
-            msg = "invalid key"
+            msg = r"\[1, 2\]"
+            err = InvalidIndexError
 
-        with pytest.raises(TypeError, match=msg):
+        with pytest.raises(err, match=msg):
             index.get_loc([1, 2], method=method)
 
     @pytest.mark.parametrize(
@@ -141,7 +145,7 @@ class TestGetLoc:
             idx.get_loc(3)
         with pytest.raises(KeyError, match="^nan$"):
             idx.get_loc(np.nan)
-        with pytest.raises(TypeError, match=r"'\[nan\]' is an invalid key"):
+        with pytest.raises(InvalidIndexError, match=r"\[nan\]"):
             # listlike/non-hashable raises TypeError
             idx.get_loc([np.nan])
 

--- a/pandas/tests/indexes/test_any_index.py
+++ b/pandas/tests/indexes/test_any_index.py
@@ -3,7 +3,10 @@ Tests that can be parametrized over _any_ Index object.
 """
 import re
 
+import numpy as np
 import pytest
+
+from pandas.errors import InvalidIndexError
 
 import pandas._testing as tm
 
@@ -125,6 +128,16 @@ class TestRoundTrips:
 
 
 class TestIndexing:
+    def test_get_loc_listlike_raises_invalid_index_error(self, index):
+        # and never TypeError
+        key = np.array([0, 1], dtype=np.intp)
+
+        with pytest.raises(InvalidIndexError, match=r"\[0 1\]"):
+            index.get_loc(key)
+
+        with pytest.raises(InvalidIndexError, match=r"\[False  True\]"):
+            index.get_loc(key.astype(bool))
+
     def test_getitem_ellipsis(self, index):
         # GH#21282
         result = index[...]

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 from pandas.compat import IS64
+from pandas.errors import InvalidIndexError
 from pandas.util._test_decorators import async_mark
 
 import pandas as pd
@@ -398,11 +399,15 @@ class TestIndex(Base):
         left = Index([1, 2, 3])
         right = Index([True, False])
 
-        msg = "'<' not supported between instances"
+        msg = "Cannot compare dtypes int64 and object"
         with pytest.raises(TypeError, match=msg):
+            left.asof(right[0])
+        # TODO: should right.asof(left[0]) also raise?
+
+        with pytest.raises(InvalidIndexError, match=re.escape(str(right))):
             left.asof(right)
 
-        with pytest.raises(TypeError, match=msg):
+        with pytest.raises(InvalidIndexError, match=re.escape(str(left))):
             right.asof(left)
 
     @pytest.mark.parametrize("index", ["string"], indirect=True)

--- a/pandas/tests/indexes/test_indexing.py
+++ b/pandas/tests/indexes/test_indexing.py
@@ -206,7 +206,14 @@ class TestGetLoc:
         exc = KeyError
         if isinstance(
             index,
-            (DatetimeIndex, TimedeltaIndex, PeriodIndex, RangeIndex, IntervalIndex),
+            (
+                DatetimeIndex,
+                TimedeltaIndex,
+                PeriodIndex,
+                RangeIndex,
+                IntervalIndex,
+                MultiIndex,
+            ),
         ):
             # TODO: make these more consistent?
             exc = InvalidIndexError


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

Shouldn't be user-facing unless user is using Index.get_loc directly since we catch this in the relevant Series/DataFrame indexing methods.  The upshot here is this will allow us to simplify `Series.__setitem__` (and maybe others)