### PR TITLE
DEPR: inplace setting of Categorical.categories

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -631,6 +631,7 @@ Other Deprecations
 - Deprecated the behavior of :meth:`Timestamp.utcfromtimestamp`, in the future it will return a timezone-aware UTC :class:`Timestamp` (:issue:`22451`)
 - Deprecated :meth:`NaT.freq` (:issue:`45071`)
 - Deprecated behavior of :class:`Series` and :class:`DataFrame` construction when passed float-dtype data containing ``NaN`` and an integer dtype ignoring the dtype argument; in a future version this will raise (:issue:`40110`)
+- Deprecating setting the ``categories`` attribute of a :class:`Categorical` object; use :meth:`Categorical.rename_categories` instead (:issue:`??`)
 -
 
 

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -631,7 +631,7 @@ Other Deprecations
 - Deprecated the behavior of :meth:`Timestamp.utcfromtimestamp`, in the future it will return a timezone-aware UTC :class:`Timestamp` (:issue:`22451`)
 - Deprecated :meth:`NaT.freq` (:issue:`45071`)
 - Deprecated behavior of :class:`Series` and :class:`DataFrame` construction when passed float-dtype data containing ``NaN`` and an integer dtype ignoring the dtype argument; in a future version this will raise (:issue:`40110`)
-- Deprecating setting the ``categories`` attribute of a :class:`Categorical` object; use :meth:`Categorical.rename_categories` instead (:issue:`??`)
+- Deprecating setting the ``categories`` attribute of a :class:`Categorical` object; use :meth:`Categorical.rename_categories` instead (:issue:`45186`)
 -
 
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -747,6 +747,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
     @categories.setter
     def categories(self, categories):
         warn(
+            # GH#45186
             "Changing the categories of a Categorical in-place is deprecated and "
             "will raise in a future version. Use "
             "obj.rename_categories(categories) instead.",

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -746,6 +746,14 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
     @categories.setter
     def categories(self, categories):
+        warn(
+            "Changing the categories of a Categorical in-place is deprecated and "
+            "will raise in a future version. Use "
+            "obj.rename_categories(categories) instead.",
+            FutureWarning,
+            stacklevel=find_stack_level(),
+        )
+
         new_dtype = CategoricalDtype(categories, ordered=self.ordered)
         if self.dtype.categories is not None and len(self.dtype.categories) != len(
             new_dtype.categories
@@ -1062,11 +1070,19 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         cat = self if inplace else self.copy()
 
         if is_dict_like(new_categories):
-            cat.categories = [new_categories.get(item, item) for item in cat.categories]
+            with catch_warnings():
+                simplefilter("ignore")
+                cat.categories = [
+                    new_categories.get(item, item) for item in cat.categories
+                ]
         elif callable(new_categories):
-            cat.categories = [new_categories(item) for item in cat.categories]
+            with catch_warnings():
+                simplefilter("ignore")
+                cat.categories = [new_categories(item) for item in cat.categories]
         else:
-            cat.categories = new_categories
+            with catch_warnings():
+                simplefilter("ignore")
+                cat.categories = new_categories
         if not inplace:
             return cat
 

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1925,7 +1925,7 @@ the string values returned are correct."""
                     categories = list(vl.values())
                 try:
                     # Try to catch duplicate categories
-                    cat_data.categories = categories
+                    cat_data = cat_data.rename_categories(categories)
                 except ValueError as err:
                     vc = Series(categories).value_counts()
                     repeated_cats = list(vc.index[vc > 1])

--- a/pandas/tests/arrays/categorical/test_indexing.py
+++ b/pandas/tests/arrays/categorical/test_indexing.py
@@ -191,7 +191,9 @@ class TestCategoricalIndexing:
     def test_categories_assignments(self):
         s = Categorical(["a", "b", "c", "a"])
         exp = np.array([1, 2, 3, 1], dtype=np.int64)
-        s.categories = [1, 2, 3]
+        msg = "Changing the categories of a Categorical in-place"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            s.categories = [1, 2, 3]
         tm.assert_numpy_array_equal(s.__array__(), exp)
         tm.assert_index_equal(s.categories, Index([1, 2, 3]))
 
@@ -202,8 +204,10 @@ class TestCategoricalIndexing:
             "new categories need to have the same number of items "
             "as the old categories!"
         )
+        warn_msg = "Changing the categories of a Categorical in-place"
         with pytest.raises(ValueError, match=msg):
-            cat.categories = new_categories
+            with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+                cat.categories = new_categories
 
     # Combinations of sorted/unique:
     @pytest.mark.parametrize(

--- a/pandas/tests/series/accessors/test_cat_accessor.py
+++ b/pandas/tests/series/accessors/test_cat_accessor.py
@@ -110,7 +110,9 @@ class TestCatAccessor:
         ser = Series(Categorical(["a", "b", "c", "a"], ordered=True))
         exp_categories = Index(["a", "b", "c"])
         tm.assert_index_equal(ser.cat.categories, exp_categories)
-        ser.cat.categories = [1, 2, 3]
+        msg = "Changing the categories of a Categorical in-place"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            ser.cat.categories = [1, 2, 3]
         exp_categories = Index([1, 2, 3])
         tm.assert_index_equal(ser.cat.categories, exp_categories)
 
@@ -266,9 +268,11 @@ class TestCatAccessor:
 
         df = DataFrame({"Survived": [1, 0, 1], "Sex": [0, 1, 1]}, dtype="category")
 
-        # change the dtype in-place
-        df["Survived"].cat.categories = ["No", "Yes"]
-        df["Sex"].cat.categories = ["female", "male"]
+        msg = "Changing the categories of a Categorical in-place"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            # change the dtype in-place
+            df["Survived"].cat.categories = ["No", "Yes"]
+            df["Sex"].cat.categories = ["female", "male"]
 
         # values should not be coerced to NaN
         assert list(df["Sex"]) == ["female", "male", "male"]

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -480,7 +480,9 @@ class TestSeriesConstructors:
         cat = Categorical(["a", "b", "c", "a"])
         s = Series(cat, copy=True)
         assert s.cat is not cat
-        s.cat.categories = [1, 2, 3]
+        msg = "Changing the categories of a Categorical in-place"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            s.cat.categories = [1, 2, 3]
         exp_s = np.array([1, 2, 3, 1], dtype=np.int64)
         exp_cat = np.array(["a", "b", "c", "a"], dtype=np.object_)
         tm.assert_numpy_array_equal(s.__array__(), exp_s)
@@ -497,7 +499,8 @@ class TestSeriesConstructors:
         cat = Categorical(["a", "b", "c", "a"])
         s = Series(cat)
         assert s.values is cat
-        s.cat.categories = [1, 2, 3]
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            s.cat.categories = [1, 2, 3]
         exp_s = np.array([1, 2, 3, 1], dtype=np.int64)
         tm.assert_numpy_array_equal(s.__array__(), exp_s)
         tm.assert_numpy_array_equal(cat.__array__(), exp_s)


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

I thought we had gotten all of these, but apparently not.