### PR TITLE
PERF: avoid double copy in `to_numpy` functions if `np.asarray` is used

### DIFF
--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -488,9 +488,15 @@ class ExtensionArray:
         """
         result = np.asarray(self, dtype=dtype)
         if copy or na_value is not lib.no_default:
-            result = result.copy()
-        if na_value is not lib.no_default:
-            result[self.isna()] = na_value
+            # We only consider copying if `self` implements a custom numpy
+            # array container, i.e. if the __array__function in implemented. If
+            # not, copying is done anyway by numpy.asarray. Also, numpy.asarray
+            # might copy the __array__() nonetheless if the dtype didn't match,
+            # so we only copy if the result is a reference to the input array.
+            if hasattr(self, "__array__") and result is self.__array__():
+                result = result.copy()
+            if na_value is not lib.no_default:
+                result[self.isna()] = na_value
         return result
 
     # ------------------------------------------------------------------------

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -11,7 +11,6 @@ from typing import (
     Callable,
     Literal,
     Sequence,
-    Tuple,
     TypeVar,
     Union,
     cast,
@@ -312,19 +311,13 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
     # ----------------------------------------------------------------
     # Array-Like / EA-Interface Methods
 
-    def _to_numpy(self, dtype=None, copy=False) -> Tuple[np.ndarray, bool]:
+    def _to_numpy(self, dtype: NpDtype | None = None) -> Tuple[np.ndarray, bool]:
+        # used for Timedelta/DatetimeArray, overwritten by PeriodArray
         if is_object_dtype(dtype):
             return np.array(list(self), dtype=object), True
         arr = np.asarray(self._ndarray, dtype=dtype)
         copied = arr is not self._ndarray
-        if copy and not copied:
-            arr = arr.copy()
-            copied = True
         return arr, copied
-
-    def __array__(self, dtype: NpDtype | None = None) -> np.ndarray:
-        # used for Timedelta/DatetimeArray, overwritten by PeriodArray
-        return self._to_numpy(dtype)[0]
 
     @overload
     def __getitem__(self, item: ScalarIndexer) -> DTScalarOrNaT:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -612,12 +612,12 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
     # ----------------------------------------------------------------
     # Array-Like / EA-Interface Methods
 
-    def __array__(self, dtype=None) -> np.ndarray:
+    def _to_numpy(self, dtype=None) -> Tuple[np.ndarray, bool]:
         if dtype is None and self.tz:
             # The default for tz-aware is object, to preserve tz info
             dtype = object
 
-        return super().__array__(dtype=dtype)
+        return super()._to_numpy(dtype=dtype)
 
     def __iter__(self):
         """

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -1410,7 +1410,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     # ---------------------------------------------------------------------
     # Conversion
 
-    def __array__(self, dtype: NpDtype | None = None) -> np.ndarray:
+    def _to_numpy(self, dtype: NpDtype | None = None) -> Tuple[np.ndarray, bool]:
         """
         Return the IntervalArray's data as a numpy array of Interval
         objects (with dtype='object')
@@ -1426,7 +1426,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
                 result[i] = np.nan
             else:
                 result[i] = Interval(left[i], right[i], closed)
-        return result
+        return result, True
 
     def __arrow_array__(self, type=None):
         """

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -478,13 +478,6 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
 
     __array_priority__ = 1000  # higher than ndarray so ops dispatch to us
 
-    def __array__(self, dtype: NpDtype | None = None) -> np.ndarray:
-        """
-        the array interface, return my values
-        We return an object array here to preserve our scalar values
-        """
-        return self.to_numpy(dtype=dtype)
-
     _HANDLED_TYPES: tuple[type, ...]
 
     def __array_ufunc__(self, ufunc: np.ufunc, method: str, *inputs, **kwargs):

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -125,9 +125,6 @@ class PandasArray(
     # ------------------------------------------------------------------------
     # NumPy Array Interface
 
-    def __array__(self, dtype: NpDtype | None = None) -> np.ndarray:
-        return np.asarray(self._ndarray, dtype=dtype)
-
     def __array_ufunc__(self, ufunc: np.ufunc, method: str, *inputs, **kwargs):
         # Lightly modified version of
         # https://numpy.org/doc/stable/reference/generated/numpy.lib.mixins.NDArrayOperatorsMixin.html
@@ -363,24 +360,10 @@ class PandasArray(
     # ------------------------------------------------------------------------
     # Additional Methods
 
-    def to_numpy(
-        self,
-        dtype: npt.DTypeLike | None = None,
-        copy: bool = False,
-        na_value=lib.no_default,
-    ) -> np.ndarray:
-        result = np.asarray(self._ndarray, dtype=dtype)
-
-        if copy or na_value is not lib.no_default:
-            # The numpy.asarray function might have already copied the array,
-            # so only copy if the result is a reference to the input array.
-            if result is self._ndarray:
-                result = result.copy()
-
-            if na_value is not lib.no_default:
-                result[self.isna()] = na_value
-
-        return result
+    def _to_numpy(self, dtype: npt.DTypeLike | None = None) -> Tuple[np.ndarray, bool]:
+        arr = np.asarray(self._ndarray, dtype=dtype)
+        copied = arr is not self._ndarray
+        return arr, copied
 
     # ------------------------------------------------------------------------
     # Ops

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -371,11 +371,14 @@ class PandasArray(
     ) -> np.ndarray:
         result = np.asarray(self._ndarray, dtype=dtype)
 
-        if (copy or na_value is not lib.no_default) and result is self._ndarray:
-            result = result.copy()
+        if copy or na_value is not lib.no_default:
+            # The numpy.asarray function might have already copied the array,
+            # so only copy if the result is a reference to the input array.
+            if result is self._ndarray:
+                result = result.copy()
 
-        if na_value is not lib.no_default:
-            result[self.isna()] = na_value
+            if na_value is not lib.no_default:
+                result[self.isna()] = na_value
 
         return result
 

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -350,14 +350,14 @@ class PeriodArray(dtl.DatelikeOps):
         """
         return self.dtype.freq
 
-    def __array__(self, dtype: NpDtype | None = None) -> np.ndarray:
+    def _to_numpy(self, dtype: NpDtype | None = None) -> Tuple[np.ndarray, bool]:
         if dtype == "i8":
-            return self.asi8
+            return self.asi8, False
         elif dtype == bool:
-            return ~self._isnan
+            return ~self._isnan, True
 
         # This will raise TypeError for non-object dtypes
-        return np.array(list(self), dtype=object)
+        return np.array(list(self), dtype=object), True
 
     def __arrow_array__(self, type=None):
         """

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -577,12 +577,12 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
         return cls._simple_new(arr, index, dtype)
 
-    def __array__(self, dtype: NpDtype | None = None) -> np.ndarray:
+    def _to_numpy(self, dtype: NpDtype | None = None) -> Tuple[np.ndarray, bool]:
         fill_value = self.fill_value
 
         if self.sp_index.ngaps == 0:
             # Compat for na dtype and int values.
-            return self.sp_values
+            return self.sp_values, False
         if dtype is None:
             # Can NumPy represent this type?
             # If not, `np.result_type` will raise. We catch that
@@ -600,7 +600,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
         out = np.full(self.shape, fill_value, dtype=dtype)
         out[self.sp_index.indices] = self.sp_values
-        return out
+        return out, True
 
     def __setitem__(self, key, value):
         # I suppose we could allow setting of non-fill_value elements.

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -187,10 +187,6 @@ class ArrowStringArray(OpsMixin, BaseStringArray, ObjectStringArrayMixin):
         """
         return self._dtype
 
-    def __array__(self, dtype: NpDtype | None = None) -> np.ndarray:
-        """Correctly construct numpy arrays when passed to `np.asarray()`."""
-        return self.to_numpy(dtype=dtype)
-
     def __arrow_array__(self, type=None):
         """Convert myself to a pyarrow Array or ChunkedArray."""
         return self._data

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -537,9 +537,11 @@ class IndexOpsMixin(OpsMixin):
             )
 
         result = np.asarray(self._values, dtype=dtype)
-        # TODO(GH-24345): Avoid potential double copy
         if copy or na_value is not lib.no_default:
-            result = result.copy()
+            # The numpy.asarray function might have already copied the array,
+            # so only copy if the result is a reference to the input array.
+            if result is self._values:
+                result = result.copy()
             if na_value is not lib.no_default:
                 result[self.isna()] = na_value
         return result

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -542,7 +542,7 @@ class IndexOpsMixin(OpsMixin):
             # The pandas-internal _to_numpy function is just like __array__,
             # but returns also a second value indicating if copying happened,
             # so we don't need to do guesswork like in the other cases below.
-            result, copied = self._values._to_numpy(dtype=dtype, copy=copy)
+            result, copied = self._values._to_numpy(dtype=dtype)
         else:
             result = np.asarray(self._values, dtype=dtype)
             copied = True

--- a/pandas/tests/extension/decimal/array.py
+++ b/pandas/tests/extension/decimal/array.py
@@ -107,7 +107,10 @@ class DecimalArray(OpsMixin, ExtensionScalarOpsMixin, ExtensionArray):
     def to_numpy(
         self, dtype=None, copy: bool = False, na_value=no_default, decimals=None
     ) -> np.ndarray:
-        result = np.asarray(self, dtype=dtype)
+        if decimals is not None:
+            # make sure to copy when numbers are rounded
+            copy = True
+        result = super().to_numpy(dtype=dtype, copy=copy, na_value=na_value)
         if decimals is not None:
             result = np.asarray([round(x, decimals) for x in result])
         return result


### PR DESCRIPTION
As reported in #24345, there is a problem with possible double copying
in the different `to_numpy` functions implemented for some pandas
objects.

In particular, we are talking about the `to_numpy` functions that use
`np.asarray` here, because `np.asarray` might have already copied the
object if the input was not a numpy array or the requested dtype didn't
match.

In #24345, a possible solution was suggested: replacing `np.asarray`
with a custom function that reports whether a copy happened. However, we
can easily check this also when using `np.asarray` by checking object
equality (`arr_out is arr_in`), as shown in the numpy documentation [1].
This commit implements these checks to avoid the possible double copy.

In the case of the ExtensionArray implemented in
`pandas/core/arrays/base.py`, the object equality is only meaningful to
check if the ExtensionArray implements a custom array container [2], and
then we need to compare the array object returned by `np.asarray` to the
object returned by `__array__()`.

This commit also includes a small bugfix. The `arr_out is arr_in` check
was actually used already in `pandas/core/arrays/numpy_.py`, but at the
wrong place: if a copy already happened, the optional NaN value filling
was skipped. This commit fixes that.

Finally, the intendation level of some of the NaN-filling code is
changed to not redundantly check `na_value is not lib.no_default`.

[1] https://numpy.org/doc/stable/reference/generated/numpy.asarray.html
[2] https://numpy.org/devdocs/user/basics.dispatch.html

- [ ] closes #24345
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
