### PR TITLE
BLD: updated pydata-sphinx-theme to master in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -120,9 +120,6 @@ dependencies:
   - tabulate>=0.8.3  # DataFrame.to_markdown
   - natsort  # DataFrame.sort_values
   - pip:
-      #issue with building environment in conda on windows. Issue: https://github.com/pandas-dev/pandas/issues/45123
-      #issue with pydata-sphix-theme on windows. Issue: https://github.com/pydata/pydata-sphinx-theme/issues/523
-      #using previous stable version as workaround
-    - git+https://github.com/pydata/pydata-sphinx-theme.git@41764f5
+    - git+https://github.com/pydata/pydata-sphinx-theme.git@master
     - pandas-dev-flaker==0.2.0
     - pytest-cython

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -83,7 +83,7 @@ cftime
 pyreadstat
 tabulate>=0.8.3
 natsort
-git+https://github.com/pydata/pydata-sphinx-theme.git@41764f5
+git+https://github.com/pydata/pydata-sphinx-theme.git@master
 pandas-dev-flaker==0.2.0
 pytest-cython
 setuptools>=51.0.0


### PR DESCRIPTION
- [X] closes #45123
- [X] Ensure all linting tests pass

Changed pip `pydata-sphinx-theme` to `master` from `41764f5` in `environment.yml`
Pre-commit hook changed `requirements-dev.txt` accordingly.

Can be changed to master because issue fixed with `pydata-sphinx-theme` master. 
[pydata-issue](https://github.com/pydata/pydata-sphinx-theme/issues/523)
 
