### PR TITLE
REGR: Index(pd.array(foo), dtype=object)

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -453,6 +453,9 @@ class Index(IndexOpsMixin, PandasObject):
                 if dtype is not None:
                     return result.astype(dtype, copy=False)
                 return result
+            elif dtype is not None:
+                # GH#45206
+                data = data.astype(dtype, copy=False)
 
             disallow_kwargs(kwargs)
             data = extract_array(data, extract_numpy=True)

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -422,9 +422,11 @@ class Base:
             #  fails for IntervalIndex
             return
 
+        is_ea_idx = type(index) is Index and not isinstance(index.dtype, np.dtype)
+
         assert index.equals(index)
         assert index.equals(index.copy())
-        if not (type(index) is Index and not isinstance(index.dtype, np.dtype)):
+        if not is_ea_idx:
             # doesn't hold for e.g. IntegerDtype
             assert index.equals(index.astype(object))
 
@@ -432,7 +434,7 @@ class Base:
         assert not index.equals(np.array(index))
 
         # Cannot pass in non-int64 dtype to RangeIndex
-        if not isinstance(index, RangeIndex):
+        if not isinstance(index, RangeIndex) and not is_ea_idx:
             same_values = Index(index, dtype=object)
             assert index.equals(same_values)
             assert same_values.equals(index)

--- a/pandas/tests/indexes/test_index_new.py
+++ b/pandas/tests/indexes/test_index_new.py
@@ -25,6 +25,7 @@ from pandas import (
     Series,
     TimedeltaIndex,
     Timestamp,
+    array,
     date_range,
     period_range,
     timedelta_range,
@@ -158,6 +159,13 @@ class TestIndexConstructorInference:
 
 class TestDtypeEnforced:
     # check we don't silently ignore the dtype keyword
+
+    def test_constructor_object_dtype_with_ea_data(self, any_numeric_ea_dtype):
+        # GH#45206
+        arr = array([0], dtype=any_numeric_ea_dtype)
+
+        idx = Index(arr, dtype=object)
+        assert idx.dtype == object
 
     @pytest.mark.parametrize("dtype", [object, "float64", "uint64", "category"])
     def test_constructor_range_values_mismatched_dtype(self, dtype):


### PR DESCRIPTION
- [x] closes #45206
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

Could try to get into 1.4 to avoid the regression (in which case no whatsnew needed)