### PR TITLE
Adding unixtime property to Timestamp and DatetimeIndex

### DIFF
--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -859,6 +859,21 @@ cdef class _Timestamp(ABCTimestamp):
         """
         return np.datetime64(self.value, 'ns')
 
+    @property
+    def unixtime(self):
+        """
+        Return POSIX timestamp as float.
+
+        Examples
+        --------
+        >>> ts = pd.Timestamp('2020-03-14T15:32:52.192548')
+        >>> ts.unixtime
+        1584199972.192548
+        """
+        # GH 17329
+        # Note: Naive timestamps will not match datetime.stdlib
+        return round(self.value / 1e9, 6)
+
     def timestamp(self):
         """
         Return POSIX timestamp as float.
@@ -871,7 +886,13 @@ cdef class _Timestamp(ABCTimestamp):
         """
         # GH 17329
         # Note: Naive timestamps will not match datetime.stdlib
-        return round(self.value / 1e9, 6)
+        warnings.warn(
+                    "The timestamp() method is deprecated and will be removed in a future "
+                    "version. Use unixtime property instead",
+                    DeprecationWarning,
+                    stacklevel=1,
+                )     
+        return self.unixtime
 
     cpdef datetime to_pydatetime(_Timestamp self, bint warn=True):
         """

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -886,12 +886,6 @@ cdef class _Timestamp(ABCTimestamp):
         """
         # GH 17329
         # Note: Naive timestamps will not match datetime.stdlib
-        warnings.warn(
-                    "The timestamp() method is deprecated and will be removed in a future "
-                    "version. Use unixtime property instead",
-                    DeprecationWarning,
-                    stacklevel=1,
-                )     
         return self.unixtime
 
     cpdef datetime to_pydatetime(_Timestamp self, bint warn=True):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -210,6 +210,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
     is_year_end
     is_leap_year
     inferred_freq
+    unixtime
 
     Methods
     -------
@@ -867,6 +868,20 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         mask = join_op(lop(start_micros, time_micros), rop(time_micros, end_micros))
 
         return mask.nonzero()[0]
+
+    @property
+    def unixtime(self):
+        """
+        Return POSIX timestamp as float.
+
+        Examples
+        --------
+        >>> ts = pd.Timestamp('2020-03-14T15:32:52.192548')
+        >>> ts.unixtime
+        1584199972.192548
+        """
+        unixtime_ns = self._data.view(np.int64)
+        return np.round(unixtime_ns/ 1e9, 6)
 
 
 def date_range(

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -881,7 +881,8 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         1584199972.192548
         """
         unixtime_ns = self._data.view(np.int64)
-        return np.round(unixtime_ns / 1e9, 6)
+        #The 1e-9 is cast as an array to silence mypy static type checking error
+        return np.round(unixtime_ns * np.array(1e-9), 6)  
 
 
 def date_range(

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -881,8 +881,8 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         1584199972.192548
         """
         unixtime_ns = self._data.view(np.int64)
-        #The 1e-9 is cast as an array to silence mypy static type checking error
-        return np.round(unixtime_ns * np.array(1e-9), 6)  
+        # The 1e-9 is cast as an array to silence mypy static type checking error
+        return np.round(unixtime_ns * np.array(1e-9), 6)
 
 
 def date_range(

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -881,7 +881,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         1584199972.192548
         """
         unixtime_ns = self._data.view(np.int64)
-        return np.round(unixtime_ns/ 1e9, 6)
+        return np.round(unixtime_ns / 1e9, 6)
 
 
 def date_range(

--- a/pandas/tests/indexes/datetimes/test_formats.py
+++ b/pandas/tests/indexes/datetimes/test_formats.py
@@ -63,6 +63,13 @@ def test_to_native_types():
     tm.assert_numpy_array_equal(result, expected)
 
 
+def test_unixtime():
+    index = pd.date_range("2011-09-18 15:30", "2011-09-18 17:30", freq='D')
+    assert len(index) == 1
+    ux = index.unixtime 
+    assert len(ux) == 1
+
+
 class TestDatetimeIndexRendering:
     def test_dti_repr_short(self):
         dr = pd.date_range(start="1/1/2012", periods=1)

--- a/pandas/tests/indexes/datetimes/test_formats.py
+++ b/pandas/tests/indexes/datetimes/test_formats.py
@@ -64,9 +64,9 @@ def test_to_native_types():
 
 
 def test_unixtime():
-    index = pd.date_range("2011-09-18 15:30", "2011-09-18 17:30", freq='D')
+    index = pd.date_range("2011-09-18 15:30", "2011-09-18 17:30", freq="D")
     assert len(index) == 1
-    ux = index.unixtime 
+    ux = index.unixtime
     assert len(ux) == 1
 
 

--- a/pandas/tests/scalar/test_nat.py
+++ b/pandas/tests/scalar/test_nat.py
@@ -188,7 +188,10 @@ def test_nat_iso_format(get_nat):
 @pytest.mark.parametrize(
     "klass,expected",
     [
-        (Timestamp, ["freqstr", "normalize", "to_julian_date", "to_period", "tz", "unixtime"]),
+        (
+            Timestamp,
+            ["freqstr", "normalize", "to_julian_date", "to_period", "tz", "unixtime"],
+        ),
         (
             Timedelta,
             [

--- a/pandas/tests/scalar/test_nat.py
+++ b/pandas/tests/scalar/test_nat.py
@@ -188,7 +188,7 @@ def test_nat_iso_format(get_nat):
 @pytest.mark.parametrize(
     "klass,expected",
     [
-        (Timestamp, ["freqstr", "normalize", "to_julian_date", "to_period", "tz"]),
+        (Timestamp, ["freqstr", "normalize", "to_julian_date", "to_period", "tz", "unixtime"]),
         (
             Timedelta,
             [

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -498,7 +498,7 @@ class TestTimestampUnaryOps:
         """Calling ts.timestamp() depcrecated in favour of ts.unixtime"""
         ts = fixed_now_ts
         ts.timestamp() == ts.unixtime
-        
+
     @td.skip_if_windows
     def test_unixtime(self, fixed_now_ts):
         # GH#17329

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -499,12 +499,11 @@ class TestTimestampUnaryOps:
         ts = fixed_now_ts
         with pytest.deprecated_call():
             ts.timestamp()
-            
 
     @td.skip_if_windows
     def test_unixtime(self, fixed_now_ts):
         # GH#17329
-        # tz-naive --> treat it as if it were UTC 
+        # tz-naive --> treat it as if it were UTC
         ts = fixed_now_ts
         uts = ts.replace(tzinfo=utc)
         assert ts.unixtime == uts.unixtime
@@ -520,6 +519,7 @@ class TestTimestampUnaryOps:
             # should agree with datetime.timestamp method
             dt = ts.to_pydatetime()
             assert dt.timestamp() == ts.unixtime
+
 
 @pytest.mark.parametrize("fold", [0, 1])
 def test_replace_preserves_fold(fold):

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -495,7 +495,7 @@ class TestTimestampUnaryOps:
 
     @td.skip_if_windows
     def test_timestamp(self, fixed_now_ts):
-        """Calling ts.timestamp() depcrecated in favour of ts.unixtime()"""
+        """Calling ts.timestamp() depcrecated in favour of ts.unixtime"""
         ts = fixed_now_ts
         with pytest.deprecated_call():
             ts.timestamp()
@@ -504,7 +504,7 @@ class TestTimestampUnaryOps:
     @td.skip_if_windows
     def test_unixtime(self, fixed_now_ts):
         # GH#17329
-        # tz-naive --> treat it as if it were UTC for purposes of timestamp()
+        # tz-naive --> treat it as if it were UTC 
         ts = fixed_now_ts
         uts = ts.replace(tzinfo=utc)
         assert ts.unixtime == uts.unixtime

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -497,9 +497,8 @@ class TestTimestampUnaryOps:
     def test_timestamp(self, fixed_now_ts):
         """Calling ts.timestamp() depcrecated in favour of ts.unixtime"""
         ts = fixed_now_ts
-        with pytest.deprecated_call():
-            ts.timestamp()
-
+        ts.timestamp() == ts.unixtime
+        
     @td.skip_if_windows
     def test_unixtime(self, fixed_now_ts):
         # GH#17329

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -414,7 +414,7 @@ class TestTimestampUnaryOps:
 
         # datetime.timestamp() converts in the local timezone
         with tm.set_timezone("UTC"):
-            assert result_dt.timestamp() == result_pd.timestamp()
+            assert result_dt.timestamp() == result_pd.unixtime
 
         assert result_dt == result_pd
         assert result_dt == result_pd.to_pydatetime()
@@ -424,7 +424,7 @@ class TestTimestampUnaryOps:
 
         # datetime.timestamp() converts in the local timezone
         with tm.set_timezone("UTC"):
-            assert result_dt.timestamp() == result_pd.timestamp()
+            assert result_dt.timestamp() == result_pd.unixtime
 
         assert result_dt == result_pd
         assert result_dt == result_pd.to_pydatetime()
@@ -495,24 +495,31 @@ class TestTimestampUnaryOps:
 
     @td.skip_if_windows
     def test_timestamp(self, fixed_now_ts):
+        """Calling ts.timestamp() depcrecated in favour of ts.unixtime()"""
+        ts = fixed_now_ts
+        with pytest.deprecated_call():
+            ts.timestamp()
+            
+
+    @td.skip_if_windows
+    def test_unixtime(self, fixed_now_ts):
         # GH#17329
         # tz-naive --> treat it as if it were UTC for purposes of timestamp()
         ts = fixed_now_ts
         uts = ts.replace(tzinfo=utc)
-        assert ts.timestamp() == uts.timestamp()
+        assert ts.unixtime == uts.unixtime
 
         tsc = Timestamp("2014-10-11 11:00:01.12345678", tz="US/Central")
         utsc = tsc.tz_convert("UTC")
 
         # utsc is a different representation of the same time
-        assert tsc.timestamp() == utsc.timestamp()
+        assert tsc.unixtime == utsc.unixtime
 
         # datetime.timestamp() converts in the local timezone
         with tm.set_timezone("UTC"):
             # should agree with datetime.timestamp method
             dt = ts.to_pydatetime()
-            assert dt.timestamp() == ts.timestamp()
-
+            assert dt.timestamp() == ts.unixtime
 
 @pytest.mark.parametrize("fold", [0, 1])
 def test_replace_preserves_fold(fold):


### PR DESCRIPTION
This PR implements #43975 (https://github.com/pandas-dev/pandas/issues/43975), adding a unixtime property to Timestamp and Datetime index.

In the course of developing this PR, I discovered that the Timestamp class already has a method called timestamp() which calculates a unixtime. I deprecated the timestamp method, as I found the name ambiguous (there's nothing about the phrase timestamp that leads me to think of unixtimes). 

This is my first PR against pandas, so apologies for any violations of conventions for code or PRs.