### PR TITLE
BUG: Fix lost precision when reading from Oracle Number column GH34988

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -752,6 +752,7 @@ Numeric
 - Bug in arithmetic operations involving :class:`Series` where the result could have the incorrect ``name`` when the operands having matching NA or matching tuple names (:issue:`44459`)
 - Bug in division with ``IntegerDtype`` or ``BooleanDtype`` array and NA scalar incorrectly raising (:issue:`44685`)
 - Bug in multiplying a :class:`Series` with ``FloatingDtype`` with a timedelta-like scalar incorrectly raising (:issue:`44772`)
+- Bug in :meth:`SQLTable._get_dtype` treating ``sqlalchemy.dialects.oracle.NUMBER`` as ``sqlalchemy.types.Integer`` which results in lost precision (:issue:`34988`)
 
 Conversion
 ^^^^^^^^^^

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1221,9 +1221,12 @@ class SQLTable(PandasObject):
             DateTime,
             Float,
             Integer,
+            Numeric,
         )
 
         if isinstance(sqltype, Float):
+            return float
+        elif isinstance(sqltype, Numeric):
             return float
         elif isinstance(sqltype, Integer):
             # TODO: Refine integer size.


### PR DESCRIPTION
Fixes: https://github.com/pandas-dev/pandas/issues/34988

- [x] closes #34988
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry
