### PR TITLE
CI/TST: Use pytest.mark.skipif instead of marker for CI clipboard tests

### DIFF
--- a/.github/workflows/datamanger.yml
+++ b/.github/workflows/datamanger.yml
@@ -28,7 +28,7 @@ jobs:
           - 5000:5000
     strategy:
       matrix:
-        pattern: ["not slow and not network and not clipboard", "slow"]
+        pattern: ["not slow and not network", "slow"]
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7
       group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-data_manager-${{ matrix.pattern }}

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -25,17 +25,17 @@ jobs:
     strategy:
       matrix:
         settings: [
-          [actions-38-downstream_compat.yaml, "not slow and not network and not clipboard", "", "", "", "", ""],
+          [actions-38-downstream_compat.yaml, "not slow and not network", "", "", "", "", ""],
           [actions-38-minimum_versions.yaml, "slow", "", "", "", "", ""],
-          [actions-38-minimum_versions.yaml, "not slow and not network and not clipboard", "", "", "", "", ""],
+          [actions-38-minimum_versions.yaml, "not slow and not network", "", "", "", "", ""],
           [actions-38-locale_slow.yaml, "slow", "language-pack-it xsel", "it_IT.utf8", "it_IT.utf8", "", ""],
-          [actions-38.yaml, "not slow and not clipboard", "", "", "", "", ""],
+          [actions-38.yaml, "not slow", "", "", "", "", ""],
           [actions-38-slow.yaml, "slow", "", "", "", "", ""],
           [actions-38-locale.yaml, "not slow and not network", "language-pack-zh-hans xsel", "zh_CN.utf8", "zh_CN.utf8", "", ""],
           [actions-39-slow.yaml, "slow", "", "", "", "", ""],
-          [actions-pypy-38.yaml, "not slow and not clipboard", "", "", "", "", "--max-worker-restart 0"],
+          [actions-pypy-38.yaml, "not slow", "", "", "", "", "--max-worker-restart 0"],
           [actions-39-numpydev.yaml, "not slow and not network", "xsel", "", "", "deprecate", "-W error"],
-          [actions-39.yaml, "not slow and not clipboard", "", "", "", "", ""]
+          [actions-39.yaml, "not slow", "", "", "", "", ""]
         ]
       fail-fast: false
     env:

--- a/.github/workflows/python-dev.yml
+++ b/.github/workflows/python-dev.yml
@@ -15,7 +15,7 @@ on:
 env:
   PYTEST_WORKERS: "auto"
   PANDAS_CI: 1
-  PATTERN: "not slow and not network and not clipboard"
+  PATTERN: "not slow and not network"
   COVERAGE: true
   PYTEST_TARGET: pandas
 

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -17,7 +17,7 @@ from pandas.io.clipboard import (
 )
 
 pytestmark = pytest.mark.skipif(
-    determine_clipboard()[0].__name__ == "ClipboardUnavailable",
+    all(not bool(clip) for clip in determine_clipboard()),
     reason="Clipboard not available.",
 )
 

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -13,6 +13,12 @@ import pandas._testing as tm
 from pandas.io.clipboard import (
     clipboard_get,
     clipboard_set,
+    determine_clipboard,
+)
+
+pytestmark = pytest.mark.skipif(
+    determine_clipboard()[0].__name__ == "ClipboardUnavailable",
+    reason="Clipboard not available.",
 )
 
 


### PR DESCRIPTION
- [ ] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

Allows us not to have to always set the clipboard marker and will just skip those tests if not available in CI tests.