### PR TITLE
TST: pytest --strict-config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ exclude = '''
 [tool.pytest.ini_options]
 # sync minversion with pyproject.toml & install.rst
 minversion =  "6.0"
-addopts = "--strict-data-files --strict-markers --capture=no --durations=30 --junitxml=test-data.xml"
+addopts = "--strict-data-files --strict-markers --strict-config --capture=no --durations=30 --junitxml=test-data.xml"
 xfail_strict = true
 testpaths = "pandas"
 doctest_optionflags = [


### PR DESCRIPTION
`any warnings encountered while parsing the pytest section of the configuration file raise errors.`
