### PR TITLE
BUG/PERF: MaskedArray.searchsorted(np.nan)

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -196,7 +196,7 @@ Sparse
 
 ExtensionArray
 ^^^^^^^^^^^^^^
--
+- Bug in :meth:`IntegerArray.searchsorted` and :meth:`FloatingArray.searchsorted` returning inconsistent results when acting on ``np.nan`` (:issue:`45255`)
 -
 
 Styler

--- a/pandas/tests/arrays/masked_shared.py
+++ b/pandas/tests/arrays/masked_shared.py
@@ -55,6 +55,14 @@ class ComparisonOps(BaseOpsUtil):
 class NumericOps:
     # Shared by IntegerArray and FloatingArray, not BooleanArray
 
+    def test_searchsorted_nan(self, dtype):
+        # The base class casts to object dtype, for which searchsorted returns
+        #  0 from the left and 10 from the right.
+        arr = pd.array(range(10), dtype=dtype)
+
+        assert arr.searchsorted(np.nan, side="left") == 10
+        assert arr.searchsorted(np.nan, side="right") == 10
+
     def test_no_shared_mask(self, data):
         result = data + 1
         assert not tm.shares_memory(result, data)


### PR DESCRIPTION
Needed for follow-up to ExtensionIndex to avoid object-dtype cast for engine.

```
arr = pd.array(range(10**5))

%timeit arr.searchsorted(4)
2.87 ms ± 223 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
6.67 µs ± 178 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```