### PR TITLE
Fix groupby any/all on an empty series/frame

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1750,7 +1750,9 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             if is_object_dtype(vals.dtype):
                 # GH#37501: don't raise on pd.NA when skipna=True
                 if skipna:
-                    func = np.vectorize(lambda x: bool(x) if not isna(x) else True)
+                    func = np.vectorize(
+                        lambda x: bool(x) if not isna(x) else True, otypes=[bool]
+                    )
                     vals = func(vals)
                 else:
                     vals = vals.astype(bool, copy=False)

--- a/pandas/tests/groupby/test_any_all.py
+++ b/pandas/tests/groupby/test_any_all.py
@@ -180,12 +180,11 @@ def test_object_NA_raises_with_skipna_false(bool_agg_func):
         ser.groupby([1]).agg(bool_agg_func, skipna=False)
 
 
-@pytest.mark.parametrize("box", [DataFrame, Series])
 @pytest.mark.parametrize("bool_agg_func", ["any", "all"])
-def test_empty(box, bool_agg_func):
+def test_empty(frame_or_series, bool_agg_func):
     # GH 45231
-    kwargs = {"columns": ["a"]} if box is DataFrame else {"name": "a"}
-    obj = box(**kwargs, dtype=object)
+    kwargs = {"columns": ["a"]} if frame_or_series is DataFrame else {"name": "a"}
+    obj = frame_or_series(**kwargs, dtype=object)
     result = getattr(obj.groupby(obj.index), bool_agg_func)()
-    expected = box(**kwargs, dtype=bool)
+    expected = frame_or_series(**kwargs, dtype=bool)
     tm.assert_equal(result, expected)

--- a/pandas/tests/groupby/test_any_all.py
+++ b/pandas/tests/groupby/test_any_all.py
@@ -178,3 +178,14 @@ def test_object_NA_raises_with_skipna_false(bool_agg_func):
     ser = Series([pd.NA], dtype=object)
     with pytest.raises(TypeError, match="boolean value of NA is ambiguous"):
         ser.groupby([1]).agg(bool_agg_func, skipna=False)
+
+
+@pytest.mark.parametrize("box", [DataFrame, Series])
+@pytest.mark.parametrize("bool_agg_func", ["any", "all"])
+def test_empty(box, bool_agg_func):
+    # GH 45231
+    kwargs = {"columns": ["a"]} if box is DataFrame else {"name": "a"}
+    obj = box(**kwargs, dtype=object)
+    result = getattr(obj.groupby(obj.index), bool_agg_func)()
+    expected = box(**kwargs, dtype=bool)
+    tm.assert_equal(result, expected)


### PR DESCRIPTION
- [x] closes #45231
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

Confirmed this issue did not exist on 1.3.x, so no whatsnew entry necessary.