### PR TITLE
Backport PR #45227 on branch 1.4.x (BUG: raise on wrong keyword arguments in Timedelta)

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -734,7 +734,7 @@ Timedelta
 ^^^^^^^^^
 - Bug in division of all-``NaT`` :class:`TimeDeltaIndex`, :class:`Series` or :class:`DataFrame` column with object-dtype arraylike of numbers failing to infer the result as timedelta64-dtype (:issue:`39750`)
 - Bug in floor division of ``timedelta64[ns]`` data with a scalar returning garbage values (:issue:`44466`)
-- Bug in :class:`Timedelta` now properly taking into account any nanoseconds contribution of any kwarg (:issue:`43764`)
+- Bug in :class:`Timedelta` now properly taking into account any nanoseconds contribution of any kwarg (:issue:`43764`, :issue:`45227`)
 
 Timezones
 ^^^^^^^^^

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1289,7 +1289,10 @@ class Timedelta(_Timedelta):
                                  "(days,seconds....)")
 
             kwargs = {key: _to_py_int_float(kwargs[key]) for key in kwargs}
-            if not cls._req_any_kwargs_new.intersection(kwargs):
+
+            unsupported_kwargs = set(kwargs)
+            unsupported_kwargs.difference_update(cls._req_any_kwargs_new)
+            if unsupported_kwargs or not cls._req_any_kwargs_new.intersection(kwargs):
                 raise ValueError(
                     "cannot construct a Timedelta from the passed arguments, "
                     "allowed keywords are "

--- a/pandas/tests/tslibs/test_timedeltas.py
+++ b/pandas/tests/tslibs/test_timedeltas.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import pytest
 
@@ -46,3 +48,18 @@ def test_huge_nanoseconds_overflow():
     # GH 32402
     assert delta_to_nanoseconds(Timedelta(1e10)) == 1e10
     assert delta_to_nanoseconds(Timedelta(nanoseconds=1e10)) == 1e10
+
+
+@pytest.mark.parametrize(
+    "kwargs", [{"Seconds": 1}, {"seconds": 1, "Nanoseconds": 1}, {"Foo": 2}]
+)
+def test_kwarg_assertion(kwargs):
+    err_message = (
+        "cannot construct a Timedelta from the passed arguments, "
+        "allowed keywords are "
+        "[weeks, days, hours, minutes, seconds, "
+        "milliseconds, microseconds, nanoseconds]"
+    )
+
+    with pytest.raises(ValueError, match=re.escape(err_message)):
+        Timedelta(**kwargs)


### PR DESCRIPTION
Backport PR #45227