### PR TITLE
BUG: .asof casting bool results to float64 GH#16063

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -207,6 +207,8 @@ Styler
 
 Other
 ^^^^^
+- Bug in :meth:`Series.asof` and :meth:`DataFrame.asof` incorrectly casting bool-dtype results to ``float64`` dtype (:issue:`16063`)
+-
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7118,9 +7118,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         >>> df.asof(pd.DatetimeIndex(['2018-02-27 09:03:30',
         ...                           '2018-02-27 09:04:30']),
         ...         subset=['a'])
-                                 a   b
-        2018-02-27 09:03:30   30.0 NaN
-        2018-02-27 09:04:30   40.0 NaN
+                              a   b
+        2018-02-27 09:03:30  30 NaN
+        2018-02-27 09:04:30  40 NaN
         """
         if isinstance(where, str):
             where = Timestamp(where)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7191,7 +7191,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         missing = locs == -1
         data = self.take(locs)
         data.index = where
-        data.loc[missing] = np.nan
+        if missing.any():
+            # GH#16063 only do this setting when necessary, otherwise
+            #  we'd cast e.g. bools to floats
+            data.loc[missing] = np.nan
         return data if is_list else data.iloc[-1]
 
     # ----------------------------------------------------------------------

--- a/pandas/tests/frame/methods/test_asof.py
+++ b/pandas/tests/frame/methods/test_asof.py
@@ -68,8 +68,8 @@ class TestFrameAsof:
         result = df.asof(dates, subset="B")
         expected = df.resample("25s", closed="right").ffill().reindex(dates)
         expected.iloc[20:] = 9
-        # no "missing", so "B" can retain int dtype
-        expected["B"] = expected["B"].astype(np.int64)
+        # no "missing", so "B" can retain int dtype (df["A"].dtype platform-dependent)
+        expected["B"] = expected["B"].astype(df["B"].dtype)
 
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/frame/methods/test_asof.py
+++ b/pandas/tests/frame/methods/test_asof.py
@@ -68,6 +68,8 @@ class TestFrameAsof:
         result = df.asof(dates, subset="B")
         expected = df.resample("25s", closed="right").ffill().reindex(dates)
         expected.iloc[20:] = 9
+        # no "missing", so "B" can retain int dtype
+        expected["B"] = expected["B"].astype(np.int64)
 
         tm.assert_frame_equal(result, expected)
 
@@ -135,11 +137,11 @@ class TestFrameAsof:
         [
             (
                 Timestamp("2018-01-01 23:22:43.325+00:00"),
-                Series(2.0, name=Timestamp("2018-01-01 23:22:43.325+00:00")),
+                Series(2, name=Timestamp("2018-01-01 23:22:43.325+00:00")),
             ),
             (
                 Timestamp("2018-01-01 22:33:20.682+01:00"),
-                Series(1.0, name=Timestamp("2018-01-01 22:33:20.682+01:00")),
+                Series(1, name=Timestamp("2018-01-01 22:33:20.682+01:00")),
             ),
         ],
     )
@@ -180,3 +182,14 @@ class TestFrameAsof:
         msg = "Input has different freq"
         with pytest.raises(IncompatibleFrequency, match=msg):
             df.asof(rng.asfreq("D"))
+
+    def test_asof_preserves_bool_dtype(self):
+        # GH#16063 was casting bools to floats
+        dti = date_range("2017-01-01", freq="MS", periods=4)
+        ser = Series([True, False, True], index=dti[:-1])
+
+        ts = dti[-1]
+        res = ser.asof([ts])
+
+        expected = Series([True], index=[ts])
+        tm.assert_series_equal(res, expected)


### PR DESCRIPTION
- [x] closes #16063
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry
