### PR TITLE
BUG: Float64Index.astype('u8') returns Int64Index

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -138,7 +138,7 @@ Numeric
 Conversion
 ^^^^^^^^^^
 - Bug in constructing a :class:`Series` from a float-containing list or a floating-dtype ndarray-like (e.g. ``dask.Array``) and an integer dtype raising instead of casting like we would with an ``np.ndarray`` (:issue:`40110`)
-- Bug in :meth:`Float64Index.astype` to unsigned integer dtype incorrect casting to ``np.int64`` dtype (:issue:`??`)
+- Bug in :meth:`Float64Index.astype` to unsigned integer dtype incorrectly casting to ``np.int64`` dtype (:issue:`45309`)
 - Bug in :meth:`Series.astype` and :meth:`DataFrame.astype` from floating dtype to unsigned integer dtype failing to raise in the presence of negative values (:issue:`45151`)
 -
 

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -138,6 +138,8 @@ Numeric
 Conversion
 ^^^^^^^^^^
 - Bug in constructing a :class:`Series` from a float-containing list or a floating-dtype ndarray-like (e.g. ``dask.Array``) and an integer dtype raising instead of casting like we would with an ``np.ndarray`` (:issue:`40110`)
+- Bug in :meth:`Float64Index.astype` to unsigned integer dtype incorrect casting to ``np.int64`` dtype (:issue:`??`)
+- Bug in :meth:`Series.astype` and :meth:`DataFrame.astype` from floating dtype to unsigned integer dtype failing to raise in the presence of negative values (:issue:`45151`)
 -
 
 Strings

--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -494,14 +494,19 @@ def all_timeseries_index_generator(k: int = 10) -> Iterable[Index]:
 
 
 # make series
-def makeFloatSeries(name=None):
+def make_rand_series(name=None, dtype=np.float64):
     index = makeStringIndex(_N)
-    return Series(np.random.randn(_N), index=index, name=name)
+    data = np.random.randn(_N)
+    data = data.astype(dtype, copy=False)
+    return Series(data, index=index, name=name)
+
+
+def makeFloatSeries(name=None):
+    return make_rand_series(name=name)
 
 
 def makeStringSeries(name=None):
-    index = makeStringIndex(_N)
-    return Series(np.random.randn(_N), index=index, name=name)
+    return make_rand_series(name=name)
 
 
 def makeObjectSeries(name=None):

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -728,7 +728,7 @@ def series_with_multilevel_index():
 
 
 _narrow_series = {
-    f"{dtype.__name__}-series": tm.makeFloatSeries(name="a").astype(dtype)
+    f"{dtype.__name__}-series": tm.make_rand_series(name="a", dtype=dtype)
     for dtype in tm.NARROW_NP_DTYPES
 }
 

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -39,6 +39,7 @@ from pandas._typing import (
     npt,
 )
 from pandas.compat.numpy import function as nv
+from pandas.errors import IntCastingNaNError
 from pandas.util._decorators import Appender
 
 from pandas.core.dtypes.common import (
@@ -906,7 +907,12 @@ class IntervalArray(IntervalMixin, ExtensionArray):
                 #  np.nan entries to int subtypes
                 new_left = Index(self._left, copy=False).astype(dtype.subtype)
                 new_right = Index(self._right, copy=False).astype(dtype.subtype)
-            except TypeError as err:
+            except IntCastingNaNError:
+                # e.g test_subtype_integer
+                raise
+            except (TypeError, ValueError) as err:
+                # e.g. test_subtype_integer_errors f8->u8 can be lossy
+                #  and raises ValueError
                 msg = (
                     f"Cannot convert {self.dtype} to {dtype}; subtypes are incompatible"
                 )

--- a/pandas/core/dtypes/astype.py
+++ b/pandas/core/dtypes/astype.py
@@ -196,6 +196,10 @@ def _astype_float_to_int_nansafe(
         raise IntCastingNaNError(
             "Cannot convert non-finite values (NA or inf) to integer"
         )
+    if dtype.kind == "u":
+        # GH#45151
+        if not (values >= 0).all():
+            raise ValueError(f"Cannot losslessly cast from {values.dtype} to {dtype}")
     return values.astype(dtype, copy=copy)
 
 

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -246,7 +246,10 @@ class NumericIndex(Index):
                 # GH 13149
                 arr = astype_nansafe(self._values, dtype=dtype)
                 if isinstance(self, Float64Index):
-                    return Int64Index(arr, name=self.name)
+                    if dtype.kind == "i":
+                        return Int64Index(arr, name=self.name)
+                    else:
+                        return UInt64Index(arr, name=self.name)
                 else:
                     return NumericIndex(arr, name=self.name, dtype=dtype)
         elif self._is_backward_compat_public_numeric_index:

--- a/pandas/tests/base/test_misc.py
+++ b/pandas/tests/base/test_misc.py
@@ -130,7 +130,7 @@ def test_memory_usage_components_series(series_with_simple_index):
 
 @pytest.mark.parametrize("dtype", tm.NARROW_NP_DTYPES)
 def test_memory_usage_components_narrow_series(dtype):
-    series = tm.makeFloatSeries(name="a").astype(dtype)
+    series = tm.make_rand_series(name="a", dtype=dtype)
     total_usage = series.memory_usage(index=True)
     non_index_usage = series.memory_usage(index=False)
     index_usage = series.index.memory_usage()

--- a/pandas/tests/indexes/interval/test_astype.py
+++ b/pandas/tests/indexes/interval/test_astype.py
@@ -3,8 +3,6 @@ import re
 import numpy as np
 import pytest
 
-from pandas.compat import is_platform_arm
-
 from pandas.core.dtypes.dtypes import (
     CategoricalDtype,
     IntervalDtype,
@@ -170,7 +168,6 @@ class TestFloatSubtype(AstypeTests):
         )
         tm.assert_index_equal(result, expected)
 
-    @pytest.mark.xfail(is_platform_arm(), reason="GH 41740")
     def test_subtype_integer_errors(self):
         # float64 -> uint64 fails with negative values
         index = interval_range(-10.0, 10.0)

--- a/pandas/tests/indexes/numeric/test_astype.py
+++ b/pandas/tests/indexes/numeric/test_astype.py
@@ -10,10 +10,22 @@ import pandas._testing as tm
 from pandas.core.indexes.api import (
     Float64Index,
     Int64Index,
+    UInt64Index,
 )
 
 
 class TestAstype:
+    def test_astype_float64_to_uint64(self):
+        # used to incorrectly return Int64Index
+        idx = Float64Index([0.0, 5.0, 10.0, 15.0, 20.0])
+        result = idx.astype("u8")
+        expected = UInt64Index([0, 5, 10, 15, 20])
+        tm.assert_index_equal(result, expected)
+
+        idx_with_negatives = idx - 10
+        with pytest.raises(ValueError, match="losslessly"):
+            idx_with_negatives.astype(np.uint64)
+
     def test_astype_float64_to_object(self):
         float_index = Float64Index([0.0, 2.5, 5.0, 7.5, 10.0])
         result = float_index.astype(object)

--- a/pandas/tests/indexes/numeric/test_astype.py
+++ b/pandas/tests/indexes/numeric/test_astype.py
@@ -16,7 +16,7 @@ from pandas.core.indexes.api import (
 
 class TestAstype:
     def test_astype_float64_to_uint64(self):
-        # used to incorrectly return Int64Index
+        # GH#45309 used to incorrectly return Int64Index
         idx = Float64Index([0.0, 5.0, 10.0, 15.0, 20.0])
         result = idx.astype("u8")
         expected = UInt64Index([0, 5, 10, 15, 20])

--- a/pandas/tests/series/methods/test_astype.py
+++ b/pandas/tests/series/methods/test_astype.py
@@ -322,6 +322,17 @@ class TestAstype:
         with pytest.raises(ValueError, match=msg):
             arr.astype(dtype)
 
+    def test_astype_float_to_uint_negatives_raise(
+        self, float_numpy_dtype, any_unsigned_int_numpy_dtype
+    ):
+        # GH#45151
+        # TODO: same for EA float/uint dtypes
+        arr = np.arange(5).astype(float_numpy_dtype) - 3  # includes negatives
+        ser = Series(arr)
+
+        with pytest.raises(ValueError, match="losslessly"):
+            ser.astype(any_unsigned_int_numpy_dtype)
+
     def test_astype_cast_object_int(self):
         arr = Series(["1", "2", "3", "4"], dtype=object)
         result = arr.astype(int)


### PR DESCRIPTION
- [x] closes #45151
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

We _could_ deprecate the casting instead of raising.  Or could decide we're OK allowing it I guess.