### PR TITLE
CI: Fix concurrency group for min versions posix builds

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -52,7 +52,7 @@ jobs:
       COVERAGE: ${{ !contains(matrix.settings[0], 'pypy') }}
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7
-      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.settings[0] }}
+      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.settings[0] }}-${{ matrix.settings[1] }}
       cancel-in-progress: true
 
     services:


### PR DESCRIPTION
- [x] tests added / passed

In the effort of sharing more dependency yaml files, the concurrency group definition will need to change since separate builds won't be unique on these yaml files anymore