### PR TITLE
TST: xfail test_arrowparquet_options for windows

### DIFF
--- a/pandas/tests/io/test_fsspec.py
+++ b/pandas/tests/io/test_fsspec.py
@@ -161,6 +161,7 @@ def test_to_parquet_new_file(monkeypatch, cleared_fs):
 
 
 @td.skip_if_no("pyarrow")
+@pytest.mark.xfail(td.is_platform_windows(), reason="GH 45344")
 def test_arrowparquet_options(fsspectest):
     """Regression test for writing to a not-yet-existent GCS Parquet file."""
     df = DataFrame({"a": [0]})

--- a/pandas/tests/io/test_fsspec.py
+++ b/pandas/tests/io/test_fsspec.py
@@ -1,4 +1,5 @@
 import io
+import sys
 
 import numpy as np
 import pytest
@@ -162,7 +163,9 @@ def test_to_parquet_new_file(monkeypatch, cleared_fs):
 
 
 @td.skip_if_no("pyarrow")
-@pytest.mark.xfail(is_platform_windows(), reason="GH 45344")
+@pytest.mark.xfail(
+    is_platform_windows() and sys.version_info[:2] == (3, 8), reason="GH 45344"
+)
 def test_arrowparquet_options(fsspectest):
     """Regression test for writing to a not-yet-existent GCS Parquet file."""
     df = DataFrame({"a": [0]})

--- a/pandas/tests/io/test_fsspec.py
+++ b/pandas/tests/io/test_fsspec.py
@@ -3,6 +3,7 @@ import io
 import numpy as np
 import pytest
 
+from pandas.compat import is_platform_windows
 from pandas.compat._optional import VERSIONS
 
 from pandas import (
@@ -161,7 +162,7 @@ def test_to_parquet_new_file(monkeypatch, cleared_fs):
 
 
 @td.skip_if_no("pyarrow")
-@pytest.mark.xfail(td.is_platform_windows(), reason="GH 45344")
+@pytest.mark.xfail(is_platform_windows(), reason="GH 45344")
 def test_arrowparquet_options(fsspectest):
     """Regression test for writing to a not-yet-existent GCS Parquet file."""
     df = DataFrame({"a": [0]})


### PR DESCRIPTION
- [x] xref #45344
- [ ] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

xfailing for now to get the CI to green