### PR TITLE
CI: Ensure GHA uses major versions of actions

### DIFF
--- a/.github/workflows/asv-bot.yml
+++ b/.github/workflows/asv-bot.yml
@@ -65,7 +65,7 @@ jobs:
           echo 'EOF' >> $GITHUB_ENV
           echo "REGEX=$REGEX" >> $GITHUB_ENV
 
-      - uses: actions/github-script@v4
+      - uses: actions/github-script@v5
         env:
           BENCH_OUTPUT: ${{env.BENCH_OUTPUT}}
           REGEX: ${{env.REGEX}}
@@ -73,7 +73,7 @@ jobs:
           script: |
             const ENV_VARS = process.env
             const run_url = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -32,7 +32,7 @@ jobs:
         python-version: '3.9.7'
 
     - name: Run pre-commit
-      uses: pre-commit/action@v2.0.3
+      uses: pre-commit/action@v2
 
   typing_and_docstring_validation:
     name: Docstring and typing validation
@@ -151,7 +151,7 @@ jobs:
       if: ${{ steps.build.outcome == 'success' }}
 
     - name: Publish benchmarks artifact
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v2
       with:
         name: Benchmarks log
         path: asv_bench/benchmarks.log

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -32,7 +32,7 @@ jobs:
         python-version: '3.9.7'
 
     - name: Run pre-commit
-      uses: pre-commit/action@v2
+      uses: pre-commit/action@v2.0.3
 
   typing_and_docstring_validation:
     name: Docstring and typing validation

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: r-lib/actions/pr-fetch@master
+      - uses: r-lib/actions/pr-fetch@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache multiple paths
@@ -35,6 +35,6 @@ jobs:
           git config user.name "$(git log -1 --pretty=format:%an)"
           git config user.email "$(git log -1 --pretty=format:%ae)"
           git commit -a -m 'Fixes from pre-commit [automated commit]' || echo "No changes to commit"
-      - uses: r-lib/actions/pr-push@master
+      - uses: r-lib/actions/pr-push@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -120,7 +120,7 @@ jobs:
       if: ${{ env.IS_PYPY == 'false' }} # No pypy3.8 support
 
     - name: Setup PyPy
-      uses: actions/setup-python@v2.3.1
+      uses: actions/setup-python@v2
       with:
         python-version: "pypy-3.8"
       if: ${{ env.IS_PYPY == 'true' }}
@@ -146,7 +146,7 @@ jobs:
       run: pushd /tmp && python -c "import pandas; pandas.show_versions();" && popd
 
     - name: Publish test results
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v2
       with:
         name: Test results
         path: test-data.xml

--- a/.github/workflows/python-dev.yml
+++ b/.github/workflows/python-dev.yml
@@ -70,7 +70,7 @@ jobs:
         ci/run_tests.sh
 
     - name: Publish test results
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v2
       with:
         name: Test results
         path: test-data.xml


### PR DESCRIPTION
* Change `@master` to `@<major version>` for more stability
* Change specifically pinned version to `@<major version>` to ensure bug & security changes are picked up
* Bump actions/github-script from `@v4` to `@v5`
