### PR TITLE
BUG: categorical-with-nas to float64 instead of object

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -191,7 +191,7 @@ Groupby/resample/rolling
 
 Reshaping
 ^^^^^^^^^
--
+- Bug in :func:`concat` between a :class:`Series` with integer dtype and another with :class:`CategoricalDtype` with integer categories and containing ``NaN`` values casting to object dtype instead of ``float64`` (:issue:`??`)
 -
 
 Sparse

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -191,7 +191,7 @@ Groupby/resample/rolling
 
 Reshaping
 ^^^^^^^^^
-- Bug in :func:`concat` between a :class:`Series` with integer dtype and another with :class:`CategoricalDtype` with integer categories and containing ``NaN`` values casting to object dtype instead of ``float64`` (:issue:`??`)
+- Bug in :func:`concat` between a :class:`Series` with integer dtype and another with :class:`CategoricalDtype` with integer categories and containing ``NaN`` values casting to object dtype instead of ``float64`` (:issue:`45359`)
 -
 
 Sparse

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -40,17 +40,13 @@ def cast_to_common_type(arr: ArrayLike, dtype: DtypeObj) -> ArrayLike:
     """
     if is_dtype_equal(arr.dtype, dtype):
         return arr
-    if (
-        is_categorical_dtype(arr.dtype)
-        and isinstance(dtype, np.dtype)
-        and np.issubdtype(dtype, np.integer)
-    ):
-        # problem case: categorical of int -> gives int as result dtype,
-        # but categorical can contain NAs -> fall back to object dtype
-        try:
-            return arr.astype(dtype, copy=False)
-        except ValueError:
-            return arr.astype(object, copy=False)
+
+    if isinstance(dtype, np.dtype) and dtype.kind in ["i", "u"]:
+
+        if is_categorical_dtype(arr.dtype) and arr._hasnans:
+            # problem case: categorical of int -> gives int as result dtype,
+            # but categorical can contain NAs -> float64 instead
+            dtype = np.dtype(np.float64)
 
     if is_sparse(arr) and not is_sparse(dtype):
         # problem case: SparseArray.astype(dtype) doesn't follow the specified

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -46,6 +46,7 @@ def cast_to_common_type(arr: ArrayLike, dtype: DtypeObj) -> ArrayLike:
         if is_categorical_dtype(arr.dtype) and arr._hasnans:
             # problem case: categorical of int -> gives int as result dtype,
             # but categorical can contain NAs -> float64 instead
+            # GH#45359
             dtype = np.dtype(np.float64)
 
     if is_sparse(arr) and not is_sparse(dtype):

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -30,6 +30,7 @@ from pandas.core.dtypes.generic import (
 )
 
 if TYPE_CHECKING:
+    from pandas import Categorical
     from pandas.core.arrays.sparse import SparseArray
 
 
@@ -43,7 +44,7 @@ def cast_to_common_type(arr: ArrayLike, dtype: DtypeObj) -> ArrayLike:
 
     if isinstance(dtype, np.dtype) and dtype.kind in ["i", "u"]:
 
-        if is_categorical_dtype(arr.dtype) and arr._hasnans:
+        if is_categorical_dtype(arr.dtype) and cast("Categorical", arr)._hasnans:
             # problem case: categorical of int -> gives int as result dtype,
             # but categorical can contain NAs -> float64 instead
             # GH#45359

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -576,7 +576,7 @@ class CategoricalIndex(NDArrayBackedExtensionIndex):
             # not all to_concat elements are among our categories (or NA)
             from pandas.core.dtypes.concat import concat_compat
 
-            res = concat_compat(to_concat)
+            res = concat_compat([x._values for x in to_concat])
             return Index(res, name=name)
         else:
             cat = self._data._from_backing_data(codes)

--- a/pandas/tests/reshape/concat/test_append_common.py
+++ b/pandas/tests/reshape/concat/test_append_common.py
@@ -508,7 +508,7 @@ class TestConcatAppendCommon:
         s1 = Series([10, 11, np.nan], dtype="category")
         s2 = Series([np.nan, 1, 3, 2], dtype="category")
 
-        exp = Series([10, 11, np.nan, np.nan, 1, 3, 2], dtype="object")
+        exp = Series([10, 11, np.nan, np.nan, 1, 3, 2], dtype=np.float64)
         tm.assert_series_equal(pd.concat([s1, s2], ignore_index=True), exp)
         tm.assert_series_equal(s1._append(s2, ignore_index=True), exp)
 
@@ -529,12 +529,12 @@ class TestConcatAppendCommon:
         s1 = Series([1, 2, np.nan], dtype="category")
         s2 = Series([2, 1, 2])
 
-        exp = Series([1, 2, np.nan, 2, 1, 2], dtype="object")
+        exp = Series([1, 2, np.nan, 2, 1, 2], dtype=np.float64)
         tm.assert_series_equal(pd.concat([s1, s2], ignore_index=True), exp)
         tm.assert_series_equal(s1._append(s2, ignore_index=True), exp)
 
         # result shouldn't be affected by 1st elem dtype
-        exp = Series([2, 1, 2, 1, 2, np.nan], dtype="object")
+        exp = Series([2, 1, 2, 1, 2, np.nan], dtype=np.float64)
         tm.assert_series_equal(pd.concat([s2, s1], ignore_index=True), exp)
         tm.assert_series_equal(s2._append(s1, ignore_index=True), exp)
 
@@ -554,11 +554,11 @@ class TestConcatAppendCommon:
         s1 = Series([10, 11, np.nan], dtype="category")
         s2 = Series([1, 3, 2])
 
-        exp = Series([10, 11, np.nan, 1, 3, 2], dtype="object")
+        exp = Series([10, 11, np.nan, 1, 3, 2], dtype=np.float64)
         tm.assert_series_equal(pd.concat([s1, s2], ignore_index=True), exp)
         tm.assert_series_equal(s1._append(s2, ignore_index=True), exp)
 
-        exp = Series([1, 3, 2, 10, 11, np.nan], dtype="object")
+        exp = Series([1, 3, 2, 10, 11, np.nan], dtype=np.float64)
         tm.assert_series_equal(pd.concat([s2, s1], ignore_index=True), exp)
         tm.assert_series_equal(s2._append(s1, ignore_index=True), exp)
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

This makes us match what we do in Index._find_common_type_compat, after which we'll be able to refactor both into a helper.