### PR TITLE
BUG: No error raised in to_stata() for -np.inf #45350

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -171,7 +171,7 @@ MultiIndex
 
 I/O
 ^^^
--
+- Bug in :meth:`DataFrame.to_stata` where no error is raised if the :class:`DataFrame` contains ``-np.inf`` (:issue:`45350`)
 -
 
 Period

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -625,10 +625,11 @@ def _cast_to_stata_types(data: DataFrame) -> DataFrame:
                 if data[col].max() >= 2 ** 53 or data[col].min() <= -(2 ** 53):
                     ws = precision_loss_doc.format("int64", "float64")
         elif dtype in (np.float32, np.float64):
-            value = data[col].max()
+            value = np.abs(data[col]).max()
             if np.isinf(value):
                 raise ValueError(
-                    f"Column {col} has a maximum value of infinity which is outside "
+                    f"Column {col} has a maximum value of infinity "
+                    "or a minimum value of -infinity which is outside "
                     "the range supported by Stata."
                 )
             if dtype == np.float32 and value > float32_max:

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -625,12 +625,11 @@ def _cast_to_stata_types(data: DataFrame) -> DataFrame:
                 if data[col].max() >= 2 ** 53 or data[col].min() <= -(2 ** 53):
                     ws = precision_loss_doc.format("int64", "float64")
         elif dtype in (np.float32, np.float64):
-            value = np.abs(data[col]).max()
-            if np.isinf(value):
+            value = data[col].max()
+            if np.isinf(data[col]).any():
                 raise ValueError(
-                    f"Column {col} has a maximum value of infinity "
-                    "or a minimum value of -infinity which is outside "
-                    "the range supported by Stata."
+                    f"Column {col} contains infinity or -infinity"
+                    "which is outside the range supported by Stata."
                 )
             if dtype == np.float32 and value > float32_max:
                 data[col] = data[col].astype(np.float64)

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -625,12 +625,12 @@ def _cast_to_stata_types(data: DataFrame) -> DataFrame:
                 if data[col].max() >= 2 ** 53 or data[col].min() <= -(2 ** 53):
                     ws = precision_loss_doc.format("int64", "float64")
         elif dtype in (np.float32, np.float64):
-            value = data[col].max()
             if np.isinf(data[col]).any():
                 raise ValueError(
                     f"Column {col} contains infinity or -infinity"
                     "which is outside the range supported by Stata."
                 )
+            value = data[col].max()
             if dtype == np.float32 and value > float32_max:
                 data[col] = data[col].astype(np.float64)
             elif dtype == np.float64:

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -1475,8 +1475,19 @@ The repeated labels are:\n-+\nwolof
 
         df.loc[2, "ColumnTooBig"] = np.inf
         msg = (
-            "Column ColumnTooBig has a maximum value of infinity which is outside "
-            "the range supported by Stata"
+            "Column ColumnTooBig has a maximum value of infinity "
+            "or a minimum value of -infinity which is outside "
+            "the range supported by Stata."
+        )
+        with pytest.raises(ValueError, match=msg):
+            with tm.ensure_clean() as path:
+                df.to_stata(path)
+
+        df.loc[2, "ColumnTooBig"] = -np.inf
+        msg = (
+            "Column ColumnTooBig has a maximum value of infinity "
+            "or a minimum value of -infinity which is outside "
+            "the range supported by Stata."
         )
         with pytest.raises(ValueError, match=msg):
             with tm.ensure_clean() as path:
@@ -1509,8 +1520,19 @@ The repeated labels are:\n-+\nwolof
 
         original.loc[2, "ColumnTooBig"] = np.inf
         msg = (
-            "Column ColumnTooBig has a maximum value of infinity which "
-            "is outside the range supported by Stata"
+            "Column ColumnTooBig has a maximum value of infinity "
+            "or a minimum value of -infinity which is outside "
+            "the range supported by Stata."
+        )
+        with pytest.raises(ValueError, match=msg):
+            with tm.ensure_clean() as path:
+                original.to_stata(path)
+
+        original.loc[2, "ColumnTooBig"] = -np.inf
+        msg = (
+            "Column ColumnTooBig has a maximum value of infinity "
+            "or a minimum value of -infinity which is outside "
+            "the range supported by Stata."
         )
         with pytest.raises(ValueError, match=msg):
             with tm.ensure_clean() as path:

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -1473,26 +1473,6 @@ The repeated labels are:\n-+\nwolof
             with tm.ensure_clean() as path:
                 df.to_stata(path)
 
-        df.loc[2, "ColumnTooBig"] = np.inf
-        msg = (
-            "Column ColumnTooBig has a maximum value of infinity "
-            "or a minimum value of -infinity which is outside "
-            "the range supported by Stata."
-        )
-        with pytest.raises(ValueError, match=msg):
-            with tm.ensure_clean() as path:
-                df.to_stata(path)
-
-        df.loc[2, "ColumnTooBig"] = -np.inf
-        msg = (
-            "Column ColumnTooBig has a maximum value of infinity "
-            "or a minimum value of -infinity which is outside "
-            "the range supported by Stata."
-        )
-        with pytest.raises(ValueError, match=msg):
-            with tm.ensure_clean() as path:
-                df.to_stata(path)
-
     def test_out_of_range_float(self):
         original = DataFrame(
             {
@@ -1518,25 +1498,17 @@ The repeated labels are:\n-+\nwolof
             original["ColumnTooBig"] = original["ColumnTooBig"].astype(np.float64)
             tm.assert_frame_equal(original, reread.set_index("index"))
 
-        original.loc[2, "ColumnTooBig"] = np.inf
+    @pytest.mark.parametrize("infval", [np.inf, -np.inf])
+    def test_inf(self, infval):
+        # GH 45350
+        df = DataFrame({"WithoutInf": [0.0, 1.0], "WithInf": [2.0, infval]})
         msg = (
-            "Column ColumnTooBig has a maximum value of infinity "
-            "or a minimum value of -infinity which is outside "
-            "the range supported by Stata."
+            "Column WithInf contains infinity or -infinity"
+            "which is outside the range supported by Stata."
         )
         with pytest.raises(ValueError, match=msg):
             with tm.ensure_clean() as path:
-                original.to_stata(path)
-
-        original.loc[2, "ColumnTooBig"] = -np.inf
-        msg = (
-            "Column ColumnTooBig has a maximum value of infinity "
-            "or a minimum value of -infinity which is outside "
-            "the range supported by Stata."
-        )
-        with pytest.raises(ValueError, match=msg):
-            with tm.ensure_clean() as path:
-                original.to_stata(path)
+                df.to_stata(path)
 
     def test_path_pathlib(self):
         df = tm.makeDataFrame()


### PR DESCRIPTION
* Add an absolute function when checking infinity, which includes both np.inf and -np.inf. Also changed the error message a bit.
* Add similar tests but replacing np.inf with -np.inf and change the correct error message accordingly

- [ ] closes #45350
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
