### PR TITLE
BUG: correctly instantiate subclassed DataFrame/Series in groupby apply

### DIFF
--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -753,6 +753,7 @@ class BaseGrouper:
         zipped = zip(group_keys, splitter)
 
         for key, group in zipped:
+            group = group.__finalize__(data, method="groupby")
             object.__setattr__(group, "name", key)
 
             # group might be modified
@@ -1000,6 +1001,7 @@ class BaseGrouper:
         splitter = get_splitter(obj, ids, ngroups, axis=0)
 
         for i, group in enumerate(splitter):
+            group = group.__finalize__(obj, method="groupby")
             res = func(group)
             res = libreduction.extract_result(res)
 
@@ -1243,13 +1245,7 @@ class SeriesSplitter(DataSplitter):
         # fastpath equivalent to `sdata.iloc[slice_obj]`
         mgr = sdata._mgr.get_slice(slice_obj)
         # __finalize__ not called here, must be applied by caller if applicable
-
-        # fastpath equivalent to:
-        # `return sdata._constructor(mgr, name=sdata.name, fastpath=True)`
-        obj = type(sdata)._from_mgr(mgr)
-        object.__setattr__(obj, "_flags", sdata._flags)
-        object.__setattr__(obj, "_name", sdata._name)
-        return obj
+        return sdata._constructor(mgr, name=sdata.name, fastpath=True)
 
 
 class FrameSplitter(DataSplitter):
@@ -1261,11 +1257,7 @@ class FrameSplitter(DataSplitter):
         #     return sdata.iloc[:, slice_obj]
         mgr = sdata._mgr.get_slice(slice_obj, axis=1 - self.axis)
         # __finalize__ not called here, must be applied by caller if applicable
-
-        # fastpath equivalent to `return sdata._constructor(mgr)`
-        obj = type(sdata)._from_mgr(mgr)
-        object.__setattr__(obj, "_flags", sdata._flags)
-        return obj
+        return sdata._constructor(mgr)
 
 
 def get_splitter(

--- a/pandas/tests/generic/test_finalize.py
+++ b/pandas/tests/generic/test_finalize.py
@@ -746,6 +746,7 @@ def test_categorical_accessor(method):
     "method",
     [
         operator.methodcaller("sum"),
+        lambda x: x.apply(lambda y: y),
         lambda x: x.agg("sum"),
         lambda x: x.agg("mean"),
         lambda x: x.agg("median"),
@@ -764,7 +765,6 @@ def test_groupby_finalize(obj, method):
     "method",
     [
         lambda x: x.agg(["sum", "count"]),
-        lambda x: x.apply(lambda y: y),
         lambda x: x.agg("std"),
         lambda x: x.agg("var"),
         lambda x: x.agg("sem"),

--- a/pandas/tests/groupby/test_groupby_subclass.py
+++ b/pandas/tests/groupby/test_groupby_subclass.py
@@ -5,6 +5,7 @@ import pytest
 
 from pandas import (
     DataFrame,
+    Index,
     Series,
 )
 import pandas._testing as tm
@@ -63,6 +64,28 @@ def test_groupby_preserves_metadata():
     custom_df.testattr = "hello"
     for _, group_df in custom_df.groupby("c"):
         assert group_df.testattr == "hello"
+
+    # GH-45314
+    def func(group):
+        assert isinstance(group, tm.SubclassedDataFrame)
+        assert hasattr(group, "testattr")
+        return group.testattr
+
+    result = custom_df.groupby("c").apply(func)
+    expected = tm.SubclassedSeries(["hello"] * 3, index=Index([7, 8, 9], name="c"))
+    tm.assert_series_equal(result, expected)
+
+    def func2(group):
+        assert isinstance(group, tm.SubclassedSeries)
+        assert hasattr(group, "testattr")
+        return group.testattr
+
+    custom_series = tm.SubclassedSeries([1, 2, 3])
+    custom_series.testattr = "hello"
+    result = custom_series.groupby(custom_df["c"]).apply(func2)
+    tm.assert_series_equal(result, expected)
+    result = custom_series.groupby(custom_df["c"]).agg(func2)
+    tm.assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize("obj", [DataFrame, tm.SubclassedDataFrame])


### PR DESCRIPTION
closes #45314

- [ ] whatsnew entry

This reverts the "fastpath" construction in groupby.apply from https://github.com/pandas-dev/pandas/pull/40236 and restores the code from https://github.com/pandas-dev/pandas/pull/37461, and expands the metadata propagation that was added in that PR to more cases.

The problem is that subclasses can have logic in their `_constructor` that is not captured by the `_from_mgr` fastpath. Will check the performance impact now, and if needed we could also do this only for subclasses, and keep `_from_mgr` for base DataFrame.