### PR TITLE
DOC: add version dropdown to the online doc site

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -225,11 +225,24 @@ html_theme = "pydata_sphinx_theme"
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
+
+switcher_version = version
+if ".dev" in version:
+    switcher_version = version.split(".0.dev")[0] + " (dev)"
+elif "rc" in version:
+    switcher_version = version.split("rc")[0] + " (rc)"
+
 html_theme_options = {
     "external_links": [],
     "github_url": "https://github.com/pandas-dev/pandas",
     "twitter_url": "https://twitter.com/pandas_dev",
     "google_analytics_id": "UA-27880019-2",
+    "navbar_end": ["version-switcher", "navbar-icon-links"],
+    "switcher": {
+        "json_url": "https://pandas.pydata.org/versions.json",
+        "url_template": "https://pandas.pydata.org/{version}/",
+        "version_match": switcher_version,
+    },
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -228,7 +228,7 @@ html_theme = "pydata_sphinx_theme"
 
 switcher_version = version
 if ".dev" in version:
-    switcher_version = version.split(".0.dev")[0] + " (dev)"
+    switcher_version = "dev"
 elif "rc" in version:
     switcher_version = version.split("rc")[0] + " (rc)"
 

--- a/web/pandas/versions.json
+++ b/web/pandas/versions.json
@@ -1,30 +1,30 @@
 [
     {
-        "name": "1.5 (dev)",
+        "name": "dev",
         "version": "docs/dev"
     },
     {
-        "name": "1.4.0 (rc)",
+        "name": "1.4 (rc)",
         "version": "pandas-docs/version/1.4"
     },
     {
-        "name": "1.3.5 (stable)",
+        "name": "1.3 (stable)",
         "version": "docs"
     },
     {
-        "name": "1.3.5",
+        "name": "1.3",
         "version": "pandas-docs/version/1.3"
     },
     {
-        "name": "1.2.5",
+        "name": "1.2",
         "version": "pandas-docs/version/1.2"
     },
     {
-        "name": "1.1.5",
+        "name": "1.1",
         "version": "pandas-docs/version/1.1"
     },
     {
-        "name": "1.0.5",
+        "name": "1.0",
         "version": "pandas-docs/version/1.0"
     }
 ]

--- a/web/pandas/versions.json
+++ b/web/pandas/versions.json
@@ -1,0 +1,30 @@
+[
+    {
+        "name": "1.5 (dev)",
+        "version": "docs/dev"
+    },
+    {
+        "name": "1.4.0 (rc)",
+        "version": "pandas-docs/version/1.4"
+    },
+    {
+        "name": "1.3.5 (stable)",
+        "version": "docs"
+    },
+    {
+        "name": "1.3.5",
+        "version": "pandas-docs/version/1.3"
+    },
+    {
+        "name": "1.2.5",
+        "version": "pandas-docs/version/1.2"
+    },
+    {
+        "name": "1.1.5",
+        "version": "pandas-docs/version/1.1"
+    },
+    {
+        "name": "1.0.5",
+        "version": "pandas-docs/version/1.0"
+    }
+]


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/42722

This adds a version dropdown to our documentation site. 

Currently, it is added on the right side of the top nav bar (for the rest using the default styling from the upstream sphinx theme):

![Screenshot from 2022-01-14 17-28-30](https://user-images.githubusercontent.com/1020496/149550901-7680421d-2989-460c-9a78-0e4ecabfbf46.png)

(my mouse was hovering the "1.3.5 (stable") entry (not visible on the screenshot), which is why that entry has a different shade of grey)

An alternative location could be next to the logo (on the left side of the top nav bar)

The entries that are included are controlled by the `versions.json` file that is added.  
We will need to update that file after a new release. But, that file is not included in the docs itself, but lives in the `/web` for the main website, and since that is directly served from the main branch, we can always easily update that (so the update doesn't strictly need to happen before cutting the release to have it included). 