### PR TITLE
ENH: support 'out' keyword in Categorical.__array_ufunc__

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1517,6 +1517,12 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         if result is not NotImplemented:
             return result
 
+        if "out" in kwargs:
+            # e.g. test_numpy_ufuncs_out
+            return arraylike.dispatch_ufunc_with_out(
+                self, ufunc, method, *inputs, **kwargs
+            )
+
         if method == "reduce":
             # e.g. TestCategoricalAnalytics::test_min_max_ordered
             result = arraylike.dispatch_reduction_ufunc(

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -141,6 +141,12 @@ class PandasArray(
         if result is not NotImplemented:
             return result
 
+        if "out" in kwargs:
+            # e.g. test_ufunc_unary
+            return arraylike.dispatch_ufunc_with_out(
+                self, ufunc, method, *inputs, **kwargs
+            )
+
         if method == "reduce":
             result = arraylike.dispatch_reduction_ufunc(
                 self, ufunc, method, *inputs, **kwargs

--- a/pandas/tests/arrays/test_numpy.py
+++ b/pandas/tests/arrays/test_numpy.py
@@ -237,6 +237,11 @@ def test_ufunc_unary(ufunc):
     expected = PandasArray(ufunc(arr._ndarray))
     tm.assert_extension_array_equal(result, expected)
 
+    # same thing but with the 'out' keyword
+    out = PandasArray(np.array([-9.0, -9.0, -9.0]))
+    ufunc(arr, out=out)
+    tm.assert_extension_array_equal(out, expected)
+
 
 def test_ufunc():
     arr = PandasArray(np.array([-1.0, 0.0, 1.0]))

--- a/pandas/tests/extension/decimal/array.py
+++ b/pandas/tests/extension/decimal/array.py
@@ -119,6 +119,18 @@ class DecimalArray(OpsMixin, ExtensionScalarOpsMixin, ExtensionArray):
         ):
             return NotImplemented
 
+        result = arraylike.maybe_dispatch_ufunc_to_dunder_op(
+            self, ufunc, method, *inputs, **kwargs
+        )
+        if result is not NotImplemented:
+            # e.g. test_array_ufunc_series_scalar_other
+            return result
+
+        if "out" in kwargs:
+            return arraylike.dispatch_ufunc_with_out(
+                self, ufunc, method, *inputs, **kwargs
+            )
+
         inputs = tuple(x._data if isinstance(x, DecimalArray) else x for x in inputs)
         result = getattr(ufunc, method)(*inputs, **kwargs)
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
