### PR TITLE
BUG: Fix file leaks in csv parsers (GH#45384)

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -874,6 +874,7 @@ I/O
 - Bug in :func:`read_csv` when passing a ``tempfile.SpooledTemporaryFile`` opened in binary mode (:issue:`44748`)
 - Bug in :func:`read_json` raising ``ValueError`` when attempting to parse json strings containing "://" (:issue:`36271`)
 - Bug in :func:`read_csv` when ``engine="c"`` and ``encoding_errors=None`` which caused a segfault (:issue:`45180`)
+- Bug in :func:`read_csv` allowing file handles to be leaked if an Exception is raised during parser initialisation (e.g. if the file does not pass ``usecols`` validation) (:issue:`45384`)
 
 Period
 ^^^^^^

--- a/pandas/io/parsers/c_parser_wrapper.py
+++ b/pandas/io/parsers/c_parser_wrapper.py
@@ -65,135 +65,136 @@ class CParserWrapper(ParserBase):
         self._open_handles(src, kwds)
         assert self.handles is not None
 
-        # Have to pass int, would break tests using TextReader directly otherwise :(
-        kwds["on_bad_lines"] = self.on_bad_lines.value
-
-        for key in (
-            "storage_options",
-            "encoding",
-            "memory_map",
-            "compression",
-            "error_bad_lines",
-            "warn_bad_lines",
-        ):
-            kwds.pop(key, None)
-
-        kwds["dtype"] = ensure_dtype_objs(kwds.get("dtype", None))
         try:
+            # Have to pass int, would break tests using TextReader directly otherwise :(
+            kwds["on_bad_lines"] = self.on_bad_lines.value
+
+            for key in (
+                "storage_options",
+                "encoding",
+                "memory_map",
+                "compression",
+                "error_bad_lines",
+                "warn_bad_lines",
+            ):
+                kwds.pop(key, None)
+
+            kwds["dtype"] = ensure_dtype_objs(kwds.get("dtype", None))
+
             self._reader = parsers.TextReader(self.handles.handle, **kwds)
+
+            self.unnamed_cols = self._reader.unnamed_cols
+
+            # error: Cannot determine type of 'names'
+            passed_names = self.names is None  # type: ignore[has-type]
+
+            if self._reader.header is None:
+                self.names = None
+            else:
+                # error: Cannot determine type of 'names'
+                # error: Cannot determine type of 'index_names'
+                (
+                    self.names,  # type: ignore[has-type]
+                    self.index_names,
+                    self.col_names,
+                    passed_names,
+                ) = self._extract_multi_indexer_columns(
+                    self._reader.header,
+                    self.index_names,  # type: ignore[has-type]
+                    passed_names,
+                )
+
+            # error: Cannot determine type of 'names'
+            if self.names is None:  # type: ignore[has-type]
+                if self.prefix:
+                    # error: Cannot determine type of 'names'
+                    self.names = [  # type: ignore[has-type]
+                        f"{self.prefix}{i}" for i in range(self._reader.table_width)
+                    ]
+                else:
+                    # error: Cannot determine type of 'names'
+                    self.names = list(  # type: ignore[has-type]
+                        range(self._reader.table_width)
+                    )
+
+            # gh-9755
+            #
+            # need to set orig_names here first
+            # so that proper indexing can be done
+            # with _set_noconvert_columns
+            #
+            # once names has been filtered, we will
+            # then set orig_names again to names
+            # error: Cannot determine type of 'names'
+            self.orig_names = self.names[:]  # type: ignore[has-type]
+
+            if self.usecols:
+                usecols = self._evaluate_usecols(self.usecols, self.orig_names)
+
+                # GH 14671
+                # assert for mypy, orig_names is List/None, None would error in issubset
+                assert self.orig_names is not None
+                if self.usecols_dtype == "string" and not set(usecols).issubset(
+                    self.orig_names
+                ):
+                    self._validate_usecols_names(usecols, self.orig_names)
+
+                # error: Cannot determine type of 'names'
+                if len(self.names) > len(usecols):  # type: ignore[has-type]
+                    # error: Cannot determine type of 'names'
+                    self.names = [  # type: ignore[has-type]
+                        n
+                        # error: Cannot determine type of 'names'
+                        for i, n in enumerate(self.names)  # type: ignore[has-type]
+                        if (i in usecols or n in usecols)
+                    ]
+
+                # error: Cannot determine type of 'names'
+                if len(self.names) < len(usecols):  # type: ignore[has-type]
+                    # error: Cannot determine type of 'names'
+                    self._validate_usecols_names(
+                        usecols,
+                        self.names,  # type: ignore[has-type]
+                    )
+
+            # error: Cannot determine type of 'names'
+            self._validate_parse_dates_presence(self.names)  # type: ignore[has-type]
+            self._set_noconvert_columns()
+
+            # error: Cannot determine type of 'names'
+            self.orig_names = self.names  # type: ignore[has-type]
+
+            if not self._has_complex_date_col:
+                # error: Cannot determine type of 'index_col'
+                if self._reader.leading_cols == 0 and is_index_col(
+                    self.index_col  # type: ignore[has-type]
+                ):
+
+                    self._name_processed = True
+                    (
+                        index_names,
+                        # error: Cannot determine type of 'names'
+                        self.names,  # type: ignore[has-type]
+                        self.index_col,
+                    ) = self._clean_index_names(
+                        # error: Cannot determine type of 'names'
+                        self.names,  # type: ignore[has-type]
+                        # error: Cannot determine type of 'index_col'
+                        self.index_col,  # type: ignore[has-type]
+                        self.unnamed_cols,
+                    )
+
+                    if self.index_names is None:
+                        self.index_names = index_names
+
+                if self._reader.header is None and not passed_names:
+                    assert self.index_names is not None
+                    self.index_names = [None] * len(self.index_names)
+
+            self._implicit_index = self._reader.leading_cols > 0
         except Exception:
             self.handles.close()
             raise
-
-        self.unnamed_cols = self._reader.unnamed_cols
-
-        # error: Cannot determine type of 'names'
-        passed_names = self.names is None  # type: ignore[has-type]
-
-        if self._reader.header is None:
-            self.names = None
-        else:
-            # error: Cannot determine type of 'names'
-            # error: Cannot determine type of 'index_names'
-            (
-                self.names,  # type: ignore[has-type]
-                self.index_names,
-                self.col_names,
-                passed_names,
-            ) = self._extract_multi_indexer_columns(
-                self._reader.header,
-                self.index_names,  # type: ignore[has-type]
-                passed_names,
-            )
-
-        # error: Cannot determine type of 'names'
-        if self.names is None:  # type: ignore[has-type]
-            if self.prefix:
-                # error: Cannot determine type of 'names'
-                self.names = [  # type: ignore[has-type]
-                    f"{self.prefix}{i}" for i in range(self._reader.table_width)
-                ]
-            else:
-                # error: Cannot determine type of 'names'
-                self.names = list(  # type: ignore[has-type]
-                    range(self._reader.table_width)
-                )
-
-        # gh-9755
-        #
-        # need to set orig_names here first
-        # so that proper indexing can be done
-        # with _set_noconvert_columns
-        #
-        # once names has been filtered, we will
-        # then set orig_names again to names
-        # error: Cannot determine type of 'names'
-        self.orig_names = self.names[:]  # type: ignore[has-type]
-
-        if self.usecols:
-            usecols = self._evaluate_usecols(self.usecols, self.orig_names)
-
-            # GH 14671
-            # assert for mypy, orig_names is List or None, None would error in issubset
-            assert self.orig_names is not None
-            if self.usecols_dtype == "string" and not set(usecols).issubset(
-                self.orig_names
-            ):
-                self._validate_usecols_names(usecols, self.orig_names)
-
-            # error: Cannot determine type of 'names'
-            if len(self.names) > len(usecols):  # type: ignore[has-type]
-                # error: Cannot determine type of 'names'
-                self.names = [  # type: ignore[has-type]
-                    n
-                    # error: Cannot determine type of 'names'
-                    for i, n in enumerate(self.names)  # type: ignore[has-type]
-                    if (i in usecols or n in usecols)
-                ]
-
-            # error: Cannot determine type of 'names'
-            if len(self.names) < len(usecols):  # type: ignore[has-type]
-                # error: Cannot determine type of 'names'
-                self._validate_usecols_names(
-                    usecols,
-                    self.names,  # type: ignore[has-type]
-                )
-
-        # error: Cannot determine type of 'names'
-        self._validate_parse_dates_presence(self.names)  # type: ignore[has-type]
-        self._set_noconvert_columns()
-
-        # error: Cannot determine type of 'names'
-        self.orig_names = self.names  # type: ignore[has-type]
-
-        if not self._has_complex_date_col:
-            # error: Cannot determine type of 'index_col'
-            if self._reader.leading_cols == 0 and is_index_col(
-                self.index_col  # type: ignore[has-type]
-            ):
-
-                self._name_processed = True
-                (
-                    index_names,
-                    # error: Cannot determine type of 'names'
-                    self.names,  # type: ignore[has-type]
-                    self.index_col,
-                ) = self._clean_index_names(
-                    # error: Cannot determine type of 'names'
-                    self.names,  # type: ignore[has-type]
-                    # error: Cannot determine type of 'index_col'
-                    self.index_col,  # type: ignore[has-type]
-                    self.unnamed_cols,
-                )
-
-                if self.index_names is None:
-                    self.index_names = index_names
-
-            if self._reader.header is None and not passed_names:
-                assert self.index_names is not None
-                self.index_names = [None] * len(self.index_names)
-
-        self._implicit_index = self._reader.leading_cols > 0
 
     def close(self) -> None:
         super().close()


### PR DESCRIPTION
- [x] closes #45384
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

I originally tried to implement the tests using the `@td.check_file_leaks` decorator but couldn't get this to cause a failing test. e.g. the following test:
```
import pandas.util._test_decorators as td

@td.check_file_leaks
def test_file_leaks(datapath):
    test2csv = datapath("io", "parser", "data", "test2.csv")
    h = open(test2csv, "r")
```

Run with:
```
python -W default -m pytest pandas/tests/io/parser/ -k test_file_leaks
```

Passes with the following output on Ubuntu 20 - note that the warning indicates that there is definitely a leak, but the decorator hasn't caught it:
```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /home/ubuntu/pandas, configfile: pyproject.toml
plugins: hypothesis-6.35.0
collected 4651 items / 4650 deselected / 1 selected

pandas/tests/io/parser/test_parse_dates.py .

================================================================================================ warnings summary =================================================================================================
pandas/tests/io/parser/test_parse_dates.py::test_file_leaks
  /home/ubuntu/pandas/.venv/lib/python3.9/site-packages/_pytest/python.py:183: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/ubuntu/pandas/pandas/tests/io/parser/data/test2.csv' mode='r' encoding='UTF-8'>
    result = testfunction(**testargs)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
------------------------------------------------------------------------------ generated xml file: /home/ubuntu/pandas/test-data.xml ------------------------------------------------------------------------------
============================================================================================== slowest 30 durations ===============================================================================================

(3 durations < 0.005s hidden.  Use -vv to show these durations.)
================================================================================== 1 passed, 4650 deselected, 1 warning in 0.97s ==================================================================================
```