### PR TITLE
REG/REF: close file handles engine-independently in read_csv

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -874,6 +874,7 @@ I/O
 - Bug in :func:`read_csv` when passing a ``tempfile.SpooledTemporaryFile`` opened in binary mode (:issue:`44748`)
 - Bug in :func:`read_json` raising ``ValueError`` when attempting to parse json strings containing "://" (:issue:`36271`)
 - Bug in :func:`read_csv` when ``engine="c"`` and ``encoding_errors=None`` which caused a segfault (:issue:`45180`)
+- Bug in :func:`read_csv` an invalide value of ``usecols`` leading to an un-closed file handle (:issue:`45384`)
 
 Period
 ^^^^^^

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -874,7 +874,7 @@ I/O
 - Bug in :func:`read_csv` when passing a ``tempfile.SpooledTemporaryFile`` opened in binary mode (:issue:`44748`)
 - Bug in :func:`read_json` raising ``ValueError`` when attempting to parse json strings containing "://" (:issue:`36271`)
 - Bug in :func:`read_csv` when ``engine="c"`` and ``encoding_errors=None`` which caused a segfault (:issue:`45180`)
-- Bug in :func:`read_csv` an invalide value of ``usecols`` leading to an un-closed file handle (:issue:`45384`)
+- Bug in :func:`read_csv` an invalid value of ``usecols`` leading to an un-closed file handle (:issue:`45384`)
 
 Period
 ^^^^^^

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -292,3 +292,6 @@ else:
 
 # Windowing rank methods
 WindowingRankType = Literal["average", "min", "max"]
+
+# read_csv engines
+CSVEngine = Literal["c", "python", "pyarrow", "python-fwf"]

--- a/pandas/io/parsers/base_parser.py
+++ b/pandas/io/parsers/base_parser.py
@@ -7,7 +7,6 @@ import datetime
 from enum import Enum
 import itertools
 from typing import (
-    Any,
     Callable,
     DefaultDict,
     Hashable,
@@ -32,8 +31,6 @@ from pandas._libs.tslibs import parsing
 from pandas._typing import (
     ArrayLike,
     DtypeArg,
-    FilePath,
-    ReadCsvBuffer,
 )
 from pandas.errors import (
     ParserError,
@@ -71,10 +68,6 @@ from pandas.core.indexes.api import (
 from pandas.core.series import Series
 from pandas.core.tools import datetimes as tools
 
-from pandas.io.common import (
-    IOHandles,
-    get_handle,
-)
 from pandas.io.date_converters import generic_parser
 
 
@@ -176,29 +169,9 @@ class ParserBase:
 
         self.usecols, self.usecols_dtype = self._validate_usecols_arg(kwds["usecols"])
 
-        self.handles: IOHandles[str] | None = None
-
         # Fallback to error to pass a sketchy test(test_override_set_noconvert_columns)
         # Normally, this arg would get pre-processed earlier on
         self.on_bad_lines = kwds.get("on_bad_lines", self.BadLineHandleMethod.ERROR)
-
-    def _open_handles(
-        self,
-        src: FilePath | ReadCsvBuffer[bytes] | ReadCsvBuffer[str],
-        kwds: dict[str, Any],
-    ) -> None:
-        """
-        Let the readers open IOHandles after they are done with their potential raises.
-        """
-        self.handles = get_handle(
-            src,
-            "r",
-            encoding=kwds.get("encoding", None),
-            compression=kwds.get("compression", None),
-            memory_map=kwds.get("memory_map", False),
-            storage_options=kwds.get("storage_options", None),
-            errors=kwds.get("encoding_errors", "strict"),
-        )
 
     def _validate_parse_dates_presence(self, columns: Sequence[Hashable]) -> Iterable:
         """
@@ -262,8 +235,7 @@ class ParserBase:
         ]
 
     def close(self):
-        if self.handles is not None:
-            self.handles.close()
+        pass
 
     @final
     @property

--- a/pandas/io/parsers/python_parser.py
+++ b/pandas/io/parsers/python_parser.py
@@ -25,7 +25,6 @@ import numpy as np
 import pandas._libs.lib as lib
 from pandas._typing import (
     ArrayLike,
-    FilePath,
     ReadCsvBuffer,
     Scalar,
 )
@@ -51,13 +50,11 @@ _BOM = "\ufeff"
 
 
 class PythonParser(ParserBase):
-    def __init__(
-        self, f: FilePath | ReadCsvBuffer[bytes] | ReadCsvBuffer[str] | list, **kwds
-    ):
+    def __init__(self, f: ReadCsvBuffer[str] | list, **kwds):
         """
         Workhorse function for processing nested list into DataFrame
         """
-        ParserBase.__init__(self, kwds)
+        super().__init__(kwds)
 
         self.data: Iterator[str] | None = None
         self.buf: list = []
@@ -104,28 +101,18 @@ class PythonParser(ParserBase):
             # read_excel: f is a list
             self.data = cast(Iterator[str], f)
         else:
-            self._open_handles(f, kwds)
-            assert self.handles is not None
-            assert hasattr(self.handles.handle, "readline")
-            try:
-                self._make_reader(self.handles.handle)
-            except (csv.Error, UnicodeDecodeError):
-                self.close()
-                raise
+            assert hasattr(f, "readline")
+            self._make_reader(f)
 
         # Get columns in two steps: infer from data, then
         # infer column indices from self.usecols if it is specified.
         self._col_indices: list[int] | None = None
         columns: list[list[Scalar | None]]
-        try:
-            (
-                columns,
-                self.num_original_columns,
-                self.unnamed_cols,
-            ) = self._infer_columns()
-        except (TypeError, ValueError):
-            self.close()
-            raise
+        (
+            columns,
+            self.num_original_columns,
+            self.unnamed_cols,
+        ) = self._infer_columns()
 
         # Now self.columns has the set of columns that we will process.
         # The original set is stored in self.original_columns.
@@ -1259,9 +1246,7 @@ class FixedWidthFieldParser(PythonParser):
     See PythonParser for details.
     """
 
-    def __init__(
-        self, f: FilePath | ReadCsvBuffer[bytes] | ReadCsvBuffer[str], **kwds
-    ) -> None:
+    def __init__(self, f: ReadCsvBuffer[str], **kwds) -> None:
         # Support iterators, convert to a list.
         self.colspecs = kwds.pop("colspecs")
         self.infer_nrows = kwds.pop("infer_nrows")

--- a/pandas/tests/io/parser/common/test_file_buffer_url.py
+++ b/pandas/tests/io/parser/common/test_file_buffer_url.py
@@ -371,13 +371,13 @@ def test_context_manager(all_parsers, datapath):
     path = datapath("io", "data", "csv", "iris.csv")
 
     reader = parser.read_csv(path, chunksize=1)
-    assert not reader._engine.handles.handle.closed
+    assert not reader.handles.handle.closed
     try:
         with reader:
             next(reader)
             assert False
     except AssertionError:
-        assert reader._engine.handles.handle.closed
+        assert reader.handles.handle.closed
 
 
 def test_context_manageri_user_provided(all_parsers, datapath):
@@ -387,13 +387,13 @@ def test_context_manageri_user_provided(all_parsers, datapath):
     with open(datapath("io", "data", "csv", "iris.csv")) as path:
 
         reader = parser.read_csv(path, chunksize=1)
-        assert not reader._engine.handles.handle.closed
+        assert not reader.handles.handle.closed
         try:
             with reader:
                 next(reader)
                 assert False
         except AssertionError:
-            assert not reader._engine.handles.handle.closed
+            assert not reader.handles.handle.closed
 
 
 def test_file_descriptor_leak(all_parsers):

--- a/pandas/tests/io/parser/test_unsupported.py
+++ b/pandas/tests/io/parser/test_unsupported.py
@@ -7,6 +7,8 @@ Ultimately, the goal is to remove test cases from this
 test suite as new feature support is added to the parsers.
 """
 from io import StringIO
+import os
+from pathlib import Path
 
 import pytest
 
@@ -161,3 +163,21 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
                 parser.read_csv(sio, on_bad_lines=bad_lines_func)
         else:
             parser.read_csv(sio, on_bad_lines=bad_lines_func)
+
+
+def test_close_file_handle_on_invalide_usecols(all_parsers):
+    # GH 45384
+    parser = all_parsers
+
+    error = ValueError
+    if parser.engine == "pyarrow":
+        pyarrow = pytest.importorskip("pyarrow")
+        error = pyarrow.lib.ArrowKeyError
+
+    with tm.ensure_clean("test.csv") as fname:
+        Path(fname).write_text("col1,col2\na,b\n1,2")
+        with tm.assert_produces_warning(False):
+            with pytest.raises(error, match="col3"):
+                parser.read_csv(fname, usecols=["col1", "col2", "col3"])
+        # unlink fails on windows if file handles still point to it
+        os.unlink(fname)


### PR DESCRIPTION
- [ ] closes #45384
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

Open file handles in TextFileParser instead of in the read_csv engines. This makes it easier to close file handles in case of an  error.

It is probably better to merge #45388 (for 1.4.x) and then this PR for 1.5.