### PR TITLE
Fix Stale Action commenting on issues

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -14,7 +14,8 @@ jobs:
         stale-pr-message: "This pull request is stale because it has been open for thirty days with no activity. Please [update](https://pandas.pydata.org/pandas-docs/stable/development/contributing.html#updating-your-pull-request) and respond to this comment if you're still interested in working on this."
         stale-pr-label: "Stale"
         exempt-pr-labels: "Needs Review,Blocked,Needs Discussion"
-        days-before-stale: 30
+        days-before-issue-stale: -1
+        days-before-pr-stale: 30
         days-before-close: -1
         remove-stale-when-updated: false
         debug-only: false


### PR DESCRIPTION
Seems when bumping `actions/stale` to v4, it started adding the `Stale` label on issues. Hopefully this fixes that.
