### PR TITLE
BUG/PERF: MaskedArray.__setitem__ validation

### DIFF
--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -648,6 +648,9 @@ def is_valid_na_for_dtype(obj, dtype: DtypeObj) -> bool:
     elif dtype.kind in ["i", "u", "f", "c"]:
         # Numeric
         return obj is not NaT and not isinstance(obj, (np.datetime64, np.timedelta64))
+    elif dtype.kind == "b":
+        # We allow pd.NA, None, np.nan in BooleanArray (same as IntervalDtype)
+        return lib.is_float(obj) or obj is None or obj is libmissing.NA
 
     elif dtype == _dtype_str:
         # numpy string dtypes to avoid float np.nan

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -593,7 +593,8 @@ def _cast_to_stata_types(data: DataFrame) -> DataFrame:
             missing_loc = data[col].isna()
             if missing_loc.any():
                 # Replace with always safe value
-                data.loc[missing_loc, col] = 0
+                fv = 0 if isinstance(data[col].dtype, _IntegerDtype) else False
+                data.loc[missing_loc, col] = fv
             # Replace with NumPy-compatible column
             data[col] = data[col].astype(data[col].dtype.numpy_dtype)
         dtype = data[col].dtype

--- a/pandas/tests/arrays/masked/test_indexing.py
+++ b/pandas/tests/arrays/masked/test_indexing.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 class TestSetitemValidation:
     def _check_setitem_invalid(self, arr, invalid):
-        msg = f"Invalid value '{invalid}' for dtype {arr.dtype}"
+        msg = f"Invalid value '{str(invalid)}' for dtype {arr.dtype}"
         msg = re.escape(msg)
         with pytest.raises(TypeError, match=msg):
             arr[0] = invalid
@@ -43,18 +43,18 @@ class TestSetitemValidation:
     ]
 
     @pytest.mark.parametrize(
-        "invalid", [1, 1.0, np.int64(1), np.float64(1)] + _invalid_scalars
+        "invalid", _invalid_scalars + [1, 1.0, np.int64(1), np.float64(1)]
     )
     def test_setitem_validation_scalar_bool(self, invalid):
         arr = pd.array([True, False, None], dtype="boolean")
         self._check_setitem_invalid(arr, invalid)
 
-    @pytest.mark.parametrize("invalid", [True, 1.5, np.float64(1.5)] + _invalid_scalars)
+    @pytest.mark.parametrize("invalid", _invalid_scalars + [True, 1.5, np.float64(1.5)])
     def test_setitem_validation_scalar_int(self, invalid, any_int_ea_dtype):
         arr = pd.array([1, 2, None], dtype=any_int_ea_dtype)
         self._check_setitem_invalid(arr, invalid)
 
-    @pytest.mark.parametrize("invalid", [True] + _invalid_scalars)
+    @pytest.mark.parametrize("invalid", _invalid_scalars + [True])
     def test_setitem_validation_scalar_float(self, invalid, float_ea_dtype):
         arr = pd.array([1, 2, None], dtype=float_ea_dtype)
         self._check_setitem_invalid(arr, invalid)

--- a/pandas/tests/arrays/masked/test_indexing.py
+++ b/pandas/tests/arrays/masked/test_indexing.py
@@ -1,0 +1,60 @@
+import re
+
+import numpy as np
+import pytest
+
+import pandas as pd
+
+
+class TestSetitemValidation:
+    def _check_setitem_invalid(self, arr, invalid):
+        msg = f"Invalid value '{invalid}' for dtype {arr.dtype}"
+        msg = re.escape(msg)
+        with pytest.raises(TypeError, match=msg):
+            arr[0] = invalid
+
+        with pytest.raises(TypeError, match=msg):
+            arr[:] = invalid
+
+        with pytest.raises(TypeError, match=msg):
+            arr[[0]] = invalid
+
+        # FIXME: don't leave commented-out
+        # with pytest.raises(TypeError):
+        #    arr[[0]] = [invalid]
+
+        # with pytest.raises(TypeError):
+        #    arr[[0]] = np.array([invalid], dtype=object)
+
+        # Series non-coercion, behavior subject to change
+        ser = pd.Series(arr)
+        with pytest.raises(TypeError, match=msg):
+            ser[0] = invalid
+            # TODO: so, so many other variants of this...
+
+    _invalid_scalars = [
+        1 + 2j,
+        "True",
+        "1",
+        "1.0",
+        pd.NaT,
+        np.datetime64("NaT"),
+        np.timedelta64("NaT"),
+    ]
+
+    @pytest.mark.parametrize(
+        "invalid", [1, 1.0, np.int64(1), np.float64(1)] + _invalid_scalars
+    )
+    def test_setitem_validation_scalar_bool(self, invalid):
+        arr = pd.array([True, False, None], dtype="boolean")
+        self._check_setitem_invalid(arr, invalid)
+
+    @pytest.mark.parametrize("invalid", [True, 1.5, np.float64(1.5)] + _invalid_scalars)
+    def test_setitem_validation_scalar_int(self, invalid, any_int_ea_dtype):
+        arr = pd.array([1, 2, None], dtype=any_int_ea_dtype)
+        self._check_setitem_invalid(arr, invalid)
+
+    @pytest.mark.parametrize("invalid", [True] + _invalid_scalars)
+    def test_setitem_validation_scalar_float(self, invalid, float_ea_dtype):
+        arr = pd.array([1, 2, None], dtype=float_ea_dtype)
+        self._check_setitem_invalid(arr, invalid)

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -1240,12 +1240,10 @@ class TestDataFrameIndexing:
 
         msg = "|".join(
             [
-                r"int\(\) argument must be a string, a bytes-like object or a "
-                "(real )?number, not 'NaTType'",
                 r"timedelta64\[ns\] cannot be converted to an? (Floating|Integer)Dtype",
                 r"datetime64\[ns\] cannot be converted to an? (Floating|Integer)Dtype",
-                "object cannot be converted to a FloatingDtype",
                 "'values' contains non-numeric NA",
+                r"Invalid value '.*' for dtype (U?Int|Float)\d{1,2}",
             ]
         )
         with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -907,16 +907,7 @@ def test_where_nullable_invalid_na(frame_or_series, any_numeric_ea_dtype):
 
     mask = np.array([True, True, False], ndmin=obj.ndim).T
 
-    msg = "|".join(
-        [
-            r"datetime64\[.{1,2}\] cannot be converted to an? (Integer|Floating)Dtype",
-            r"timedelta64\[.{1,2}\] cannot be converted to an? (Integer|Floating)Dtype",
-            r"int\(\) argument must be a string, a bytes-like object or a number, "
-            "not 'NaTType'",
-            "object cannot be converted to a FloatingDtype",
-            "'values' contains non-numeric NA",
-        ]
-    )
+    msg = r"Invalid value '.*' for dtype (U?Int|Float)\d{1,2}"
 
     for null in tm.NP_NAT_OBJECTS + [pd.NaT]:
         # NaT is an NA value that we should *not* cast to pd.NA dtype


### PR DESCRIPTION
- [x] closes #44172
- [x] closes #44186
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

Fixes a bunch of ways we currently allow invalid setting, but ATM does _not_ fix the non-scalar equivalents.

Perf example from #44172 OP
```
df = pd.DataFrame([[True, False, pd.NA] * 200] * 200, dtype = "object")
df2 = df.astype("boolean")

%timeit res = df2.apply(lambda row: row.count(), axis = 1)
3.9 s ± 192 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)  # <- main
886 ms ± 40.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)  # <- PR
```