### PR TITLE
STYLE: use option_context almost always

### DIFF
--- a/pandas/tests/indexes/multi/test_formats.py
+++ b/pandas/tests/indexes/multi/test_formats.py
@@ -8,7 +8,6 @@ from pandas import (
     Index,
     MultiIndex,
 )
-import pandas._testing as tm
 
 
 def test_format(idx):
@@ -27,12 +26,9 @@ def test_format_sparse_config(idx):
     warn_filters = warnings.filters
     warnings.filterwarnings("ignore", category=FutureWarning, module=".*format")
     # GH1538
-    pd.set_option("display.multi_sparse", False)
-
-    result = idx.format()
+    with pd.option_context("display.multi_sparse", False):
+        result = idx.format()
     assert result[1] == "foo  two"
-
-    tm.reset_display_options()
 
     warnings.filters = warn_filters
 

--- a/pandas/tests/indexing/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/test_chaining_and_caching.py
@@ -157,16 +157,17 @@ class TestChaining:
     @pytest.mark.arm_slow
     def test_detect_chained_assignment(self):
 
-        pd.set_option("chained_assignment", "raise")
+        with option_context("chained_assignment", "raise"):
+            # work with the chain
+            expected = DataFrame([[-5, 1], [-6, 3]], columns=list("AB"))
+            df = DataFrame(
+                np.arange(4).reshape(2, 2), columns=list("AB"), dtype="int64"
+            )
+            assert df._is_copy is None
 
-        # work with the chain
-        expected = DataFrame([[-5, 1], [-6, 3]], columns=list("AB"))
-        df = DataFrame(np.arange(4).reshape(2, 2), columns=list("AB"), dtype="int64")
-        assert df._is_copy is None
-
-        df["A"][0] = -5
-        df["A"][1] = -6
-        tm.assert_frame_equal(df, expected)
+            df["A"][0] = -5
+            df["A"][1] = -6
+            tm.assert_frame_equal(df, expected)
 
     @pytest.mark.arm_slow
     def test_detect_chained_assignment_raises(self, using_array_manager):

--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -18,8 +18,7 @@ from pandas import (
     DataFrame,
     Index,
     MultiIndex,
-    get_option,
-    set_option,
+    option_context,
 )
 import pandas._testing as tm
 
@@ -53,10 +52,8 @@ def set_engine(engine, ext):
     the test it rolls back said change to the global option.
     """
     option_name = f"io.excel.{ext.strip('.')}.writer"
-    prev_engine = get_option(option_name)
-    set_option(option_name, engine)
-    yield
-    set_option(option_name, prev_engine)  # Roll back option change
+    with option_context(option_name, engine):
+        yield
 
 
 @pytest.mark.parametrize(
@@ -1294,7 +1291,7 @@ class TestExcelWriterEngineTests:
             del called_save[:]
             del called_write_cells[:]
 
-        with pd.option_context("io.excel.xlsx.writer", "dummy"):
+        with option_context("io.excel.xlsx.writer", "dummy"):
             path = "something.xlsx"
             with tm.ensure_clean(path) as filepath:
                 register_writer(DummyClass)

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -1146,19 +1146,17 @@ class TestDataFrameFormatting:
         ):
             max_cols = get_option("display.max_columns")
             df = DataFrame(tm.rands_array(25, size=(10, max_cols - 1)))
-            set_option("display.expand_frame_repr", False)
-            rep_str = repr(df)
+            with option_context("display.expand_frame_repr", False):
+                rep_str = repr(df)
 
             assert f"10 rows x {max_cols - 1} columns" in rep_str
-            set_option("display.expand_frame_repr", True)
-            wide_repr = repr(df)
+            with option_context("display.expand_frame_repr", True):
+                wide_repr = repr(df)
             assert rep_str != wide_repr
 
             with option_context("display.width", 120):
                 wider_repr = repr(df)
                 assert len(wider_repr) < len(wide_repr)
-
-        reset_option("display.expand_frame_repr")
 
     def test_wide_repr_wide_columns(self):
         with option_context("mode.sim_interactive", True, "display.max_columns", 20):
@@ -1174,11 +1172,10 @@ class TestDataFrameFormatting:
             max_cols = get_option("display.max_columns")
             df = DataFrame(tm.rands_array(25, size=(10, max_cols - 1)))
             df.index.name = "DataFrame Index"
-            set_option("display.expand_frame_repr", False)
-
-            rep_str = repr(df)
-            set_option("display.expand_frame_repr", True)
-            wide_repr = repr(df)
+            with option_context("display.expand_frame_repr", False):
+                rep_str = repr(df)
+            with option_context("display.expand_frame_repr", True):
+                wide_repr = repr(df)
             assert rep_str != wide_repr
 
             with option_context("display.width", 150):
@@ -1188,18 +1185,16 @@ class TestDataFrameFormatting:
             for line in wide_repr.splitlines()[1::13]:
                 assert "DataFrame Index" in line
 
-        reset_option("display.expand_frame_repr")
-
     def test_wide_repr_multiindex(self):
         with option_context("mode.sim_interactive", True, "display.max_columns", 20):
             midx = MultiIndex.from_arrays(tm.rands_array(5, size=(2, 10)))
             max_cols = get_option("display.max_columns")
             df = DataFrame(tm.rands_array(25, size=(10, max_cols - 1)), index=midx)
             df.index.names = ["Level 0", "Level 1"]
-            set_option("display.expand_frame_repr", False)
-            rep_str = repr(df)
-            set_option("display.expand_frame_repr", True)
-            wide_repr = repr(df)
+            with option_context("display.expand_frame_repr", False):
+                rep_str = repr(df)
+            with option_context("display.expand_frame_repr", True):
+                wide_repr = repr(df)
             assert rep_str != wide_repr
 
             with option_context("display.width", 150):
@@ -1208,8 +1203,6 @@ class TestDataFrameFormatting:
 
             for line in wide_repr.splitlines()[1::13]:
                 assert "Level 0 Level 1" in line
-
-        reset_option("display.expand_frame_repr")
 
     def test_wide_repr_multiindex_cols(self):
         with option_context("mode.sim_interactive", True, "display.max_columns", 20):
@@ -1220,33 +1213,29 @@ class TestDataFrameFormatting:
                 tm.rands_array(25, (10, max_cols - 1)), index=midx, columns=mcols
             )
             df.index.names = ["Level 0", "Level 1"]
-            set_option("display.expand_frame_repr", False)
-            rep_str = repr(df)
-            set_option("display.expand_frame_repr", True)
-            wide_repr = repr(df)
+            with option_context("display.expand_frame_repr", False):
+                rep_str = repr(df)
+            with option_context("display.expand_frame_repr", True):
+                wide_repr = repr(df)
             assert rep_str != wide_repr
 
         with option_context("display.width", 150, "display.max_columns", 20):
             wider_repr = repr(df)
             assert len(wider_repr) < len(wide_repr)
 
-        reset_option("display.expand_frame_repr")
-
     def test_wide_repr_unicode(self):
         with option_context("mode.sim_interactive", True, "display.max_columns", 20):
             max_cols = 20
             df = DataFrame(tm.rands_array(25, size=(10, max_cols - 1)))
-            set_option("display.expand_frame_repr", False)
-            rep_str = repr(df)
-            set_option("display.expand_frame_repr", True)
-            wide_repr = repr(df)
+            with option_context("display.expand_frame_repr", False):
+                rep_str = repr(df)
+            with option_context("display.expand_frame_repr", True):
+                wide_repr = repr(df)
             assert rep_str != wide_repr
 
             with option_context("display.width", 150):
                 wider_repr = repr(df)
                 assert len(wider_repr) < len(wide_repr)
-
-        reset_option("display.expand_frame_repr")
 
     def test_wide_repr_wide_long_columns(self):
         with option_context("mode.sim_interactive", True):

--- a/pandas/tests/io/pytables/test_append.py
+++ b/pandas/tests/io/pytables/test_append.py
@@ -214,66 +214,66 @@ def test_append_all_nans(setup_path):
         tm.assert_frame_equal(store["df2"], df)
 
         # tests the option io.hdf.dropna_table
-        pd.set_option("io.hdf.dropna_table", False)
-        _maybe_remove(store, "df3")
-        store.append("df3", df[:10])
-        store.append("df3", df[10:])
-        tm.assert_frame_equal(store["df3"], df)
+        with pd.option_context("io.hdf.dropna_table", False):
+            _maybe_remove(store, "df3")
+            store.append("df3", df[:10])
+            store.append("df3", df[10:])
+            tm.assert_frame_equal(store["df3"], df)
 
-        pd.set_option("io.hdf.dropna_table", True)
-        _maybe_remove(store, "df4")
-        store.append("df4", df[:10])
-        store.append("df4", df[10:])
-        tm.assert_frame_equal(store["df4"], df[-4:])
+        with pd.option_context("io.hdf.dropna_table", True):
+            _maybe_remove(store, "df4")
+            store.append("df4", df[:10])
+            store.append("df4", df[10:])
+            tm.assert_frame_equal(store["df4"], df[-4:])
 
-        # nan some entire rows (string are still written!)
-        df = DataFrame(
-            {
-                "A1": np.random.randn(20),
-                "A2": np.random.randn(20),
-                "B": "foo",
-                "C": "bar",
-            },
-            index=np.arange(20),
-        )
+            # nan some entire rows (string are still written!)
+            df = DataFrame(
+                {
+                    "A1": np.random.randn(20),
+                    "A2": np.random.randn(20),
+                    "B": "foo",
+                    "C": "bar",
+                },
+                index=np.arange(20),
+            )
 
-        df.loc[0:15, :] = np.nan
+            df.loc[0:15, :] = np.nan
 
-        _maybe_remove(store, "df")
-        store.append("df", df[:10], dropna=True)
-        store.append("df", df[10:], dropna=True)
-        tm.assert_frame_equal(store["df"], df)
+            _maybe_remove(store, "df")
+            store.append("df", df[:10], dropna=True)
+            store.append("df", df[10:], dropna=True)
+            tm.assert_frame_equal(store["df"], df)
 
-        _maybe_remove(store, "df2")
-        store.append("df2", df[:10], dropna=False)
-        store.append("df2", df[10:], dropna=False)
-        tm.assert_frame_equal(store["df2"], df)
+            _maybe_remove(store, "df2")
+            store.append("df2", df[:10], dropna=False)
+            store.append("df2", df[10:], dropna=False)
+            tm.assert_frame_equal(store["df2"], df)
 
-        # nan some entire rows (but since we have dates they are still
-        # written!)
-        df = DataFrame(
-            {
-                "A1": np.random.randn(20),
-                "A2": np.random.randn(20),
-                "B": "foo",
-                "C": "bar",
-                "D": Timestamp("20010101"),
-                "E": datetime.datetime(2001, 1, 2, 0, 0),
-            },
-            index=np.arange(20),
-        )
+            # nan some entire rows (but since we have dates they are still
+            # written!)
+            df = DataFrame(
+                {
+                    "A1": np.random.randn(20),
+                    "A2": np.random.randn(20),
+                    "B": "foo",
+                    "C": "bar",
+                    "D": Timestamp("20010101"),
+                    "E": datetime.datetime(2001, 1, 2, 0, 0),
+                },
+                index=np.arange(20),
+            )
 
-        df.loc[0:15, :] = np.nan
+            df.loc[0:15, :] = np.nan
 
-        _maybe_remove(store, "df")
-        store.append("df", df[:10], dropna=True)
-        store.append("df", df[10:], dropna=True)
-        tm.assert_frame_equal(store["df"], df)
+            _maybe_remove(store, "df")
+            store.append("df", df[:10], dropna=True)
+            store.append("df", df[10:], dropna=True)
+            tm.assert_frame_equal(store["df"], df)
 
-        _maybe_remove(store, "df2")
-        store.append("df2", df[:10], dropna=False)
-        store.append("df2", df[10:], dropna=False)
-        tm.assert_frame_equal(store["df2"], df)
+            _maybe_remove(store, "df2")
+            store.append("df2", df[:10], dropna=False)
+            store.append("df2", df[10:], dropna=False)
+            tm.assert_frame_equal(store["df2"], df)
 
 
 def test_append_frame_column_oriented(setup_path):
@@ -898,8 +898,9 @@ def test_append_to_multiple_dropna_false(setup_path):
     df1.iloc[1, df1.columns.get_indexer(["A", "B"])] = np.nan
     df = concat([df1, df2], axis=1)
 
-    with ensure_clean_store(setup_path) as store:
-
+    with ensure_clean_store(setup_path) as store, pd.option_context(
+        "io.hdf.dropna_table", True
+    ):
         # dropna=False shouldn't synchronize row indexes
         store.append_to_multiple(
             {"df1a": ["A", "B"], "df2a": None}, df, selector="df1a", dropna=False

--- a/pandas/tests/plotting/test_backend.py
+++ b/pandas/tests/plotting/test_backend.py
@@ -18,9 +18,8 @@ pytestmark = pytest.mark.slow
 @pytest.fixture
 def restore_backend():
     """Restore the plotting backend to matplotlib"""
-    pandas.set_option("plotting.backend", "matplotlib")
-    yield
-    pandas.set_option("plotting.backend", "matplotlib")
+    with pandas.option_context("plotting.backend", "matplotlib"):
+        yield
 
 
 def test_backend_is_not_module():

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -5,7 +5,7 @@ import warnings
 import numpy as np
 import pytest
 
-from pandas import set_option
+from pandas import option_context
 import pandas._testing as tm
 from pandas.core.api import (
     DataFrame,
@@ -61,9 +61,8 @@ class TestExpressions:
         else:
             op = getattr(operator, opname)
 
-        set_option("compute.use_numexpr", False)
-        expected = op(df, other)
-        set_option("compute.use_numexpr", True)
+        with option_context("compute.use_numexpr", False):
+            expected = op(df, other)
 
         expr.get_test_result()
 
@@ -122,9 +121,8 @@ class TestExpressions:
         elsewhere.
         """
         arith = comparison_op.__name__
-        set_option("compute.use_numexpr", False)
-        other = df.copy() + 1
-        set_option("compute.use_numexpr", True)
+        with option_context("compute.use_numexpr", False):
+            other = df.copy() + 1
 
         expr._MIN_ELEMENTS = 0
         expr.set_test_mode(True)
@@ -184,9 +182,9 @@ class TestExpressions:
             result = expr._can_use_numexpr(op, op_str, right, right, "evaluate")
             assert not result
 
-        set_option("compute.use_numexpr", False)
-        testit()
-        set_option("compute.use_numexpr", True)
+        with option_context("compute.use_numexpr", False):
+            testit()
+
         expr.set_numexpr_threads(1)
         testit()
         expr.set_numexpr_threads()
@@ -220,9 +218,9 @@ class TestExpressions:
             result = expr._can_use_numexpr(op, op_str, right, f22, "evaluate")
             assert not result
 
-        set_option("compute.use_numexpr", False)
-        testit()
-        set_option("compute.use_numexpr", True)
+        with option_context("compute.use_numexpr", False):
+            testit()
+
         expr.set_numexpr_threads(1)
         testit()
         expr.set_numexpr_threads()
@@ -238,9 +236,9 @@ class TestExpressions:
             expected = np.where(c, df.values, df.values + 1)
             tm.assert_numpy_array_equal(result, expected)
 
-        set_option("compute.use_numexpr", False)
-        testit()
-        set_option("compute.use_numexpr", True)
+        with option_context("compute.use_numexpr", False):
+            testit()
+
         expr.set_numexpr_threads(1)
         testit()
         expr.set_numexpr_threads()
@@ -365,9 +363,8 @@ class TestExpressions:
 
         op_func = getattr(df, arith)
 
-        set_option("compute.use_numexpr", False)
-        expected = op_func(other, axis=axis)
-        set_option("compute.use_numexpr", True)
+        with option_context("compute.use_numexpr", False):
+            expected = op_func(other, axis=axis)
 
         result = op_func(other, axis=axis)
         tm.assert_frame_equal(expected, result)
@@ -392,9 +389,9 @@ class TestExpressions:
         result = method(scalar)
 
         # compare result with numpy
-        set_option("compute.use_numexpr", False)
-        expected = method(scalar)
-        set_option("compute.use_numexpr", True)
+        with option_context("compute.use_numexpr", False):
+            expected = method(scalar)
+
         tm.assert_equal(result, expected)
 
         # compare result element-wise with Python

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -1036,13 +1036,11 @@ def test_use_bottleneck():
 
     if nanops._BOTTLENECK_INSTALLED:
 
-        pd.set_option("use_bottleneck", True)
-        assert pd.get_option("use_bottleneck")
+        with pd.option_context("use_bottleneck", True):
+            assert pd.get_option("use_bottleneck")
 
-        pd.set_option("use_bottleneck", False)
-        assert not pd.get_option("use_bottleneck")
-
-        pd.set_option("use_bottleneck", use_bn)
+        with pd.option_context("use_bottleneck", False):
+            assert not pd.get_option("use_bottleneck")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Replaces `set_option` except when this function is directly tested.

Happy to revisit/revise if I missed anything. Thanks!

- [x] closes #38813
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
