### PR TITLE
BENCH: Fix ASV branch to main

### DIFF
--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -13,6 +13,10 @@
     // benchmarked
     "repo": "..",
 
+    // List of branches to benchmark. If not provided, defaults to "master"
+    // (for git) or "default" (for mercurial).
+    "branches": ["main"],
+
     // The tool to use to create environments.  May be "conda",
     // "virtualenv" or other value depending on the plugins in use.
     // If missing or the empty string, the tool will be automatically
@@ -25,7 +29,6 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    // "pythons": ["2.7", "3.4"],
     "pythons": ["3.8"],
 
     // The matrix of dependencies to test.  Each key is the name of a


### PR DESCRIPTION
Needed post main renaming to run `asv run ...`
