### PR TITLE
PEP 561

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ test =
     pytest-xdist>=1.31
 
 [options.package_data]
-* = templates/*, _libs/**/*.dll
+* = templates/*, _libs/**/*.dll, py.typed
 
 [build_ext]
 inplace = True


### PR DESCRIPTION
According to PEP 561, we just need to add this file to mark the lib as typed.

I don't know if all the lib is typed, maybe we also need to do that before merging.

- [ ] tests passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
