### PR TITLE
CI: Move Windows OS tests to GHA

### DIFF
--- a/.github/workflows/datamanger.yml
+++ b/.github/workflows/datamanger.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   data_manager:
+    if: false
     name: Test experimental data manager
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   web_and_docs:
+    if: false
     name: Doc Build and Upload
     runs-on: ubuntu-latest
 

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   pytest:
+    if: false
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   build:
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,42 +40,6 @@ jobs:
       group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.settings[0] }}-${{ matrix.settings[1] }}-windows
       cancel-in-progress: true
 
-    services:
-      mysql:
-        image: mysql
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_DATABASE: pandas
-        options: >-
-          --health-cmd "mysqladmin ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 3306:3306
-
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: pandas
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
-      moto:
-        image: motoserver/moto
-        env:
-          AWS_ACCESS_KEY_ID: foobar_key
-          AWS_SECRET_ACCESS_KEY: foobar_secret
-        ports:
-          - 5000:5000
-
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,4 +1,4 @@
-name: Posix
+name: Windows
 
 on:
   push:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,128 @@
+name: Posix
+
+on:
+  push:
+    branches:
+      - main
+      - 1.4.x
+  pull_request:
+    branches:
+      - main
+      - 1.4.x
+    paths-ignore:
+      - "doc/**"
+
+env:
+  PYTEST_WORKERS: "auto"
+  PANDAS_CI: 1
+
+jobs:
+  pytest:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      matrix:
+        settings: [
+          [actions-38.yaml, "not slow"],
+          [actions-39.yaml, "not slow"],
+          [actions-310.yaml, "not slow"],
+        ]
+      fail-fast: false
+    env:
+      ENV_FILE: ci/deps/${{ matrix.settings[0] }}
+      PATTERN: ${{ matrix.settings[1] }}
+      PYTEST_TARGET: pandas
+      COVERAGE: true
+    concurrency:
+      # https://github.community/t/concurrecy-not-work-for-push/183068/7
+      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.settings[0] }}-${{ matrix.settings[1] }}-windows
+      cancel-in-progress: true
+
+    services:
+      mysql:
+        image: mysql
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: pandas
+        options: >-
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 3306:3306
+
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: pandas
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+      moto:
+        image: motoserver/moto
+        env:
+          AWS_ACCESS_KEY_ID: foobar_key
+          AWS_SECRET_ACCESS_KEY: foobar_secret
+        ports:
+          - 5000:5000
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Cache conda
+      uses: actions/cache@v2
+      env:
+        CACHE_NUMBER: 0
+      with:
+        path: ~/conda_pkgs_dir
+        key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
+          hashFiles('${{ env.ENV_FILE }}') }}
+
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        mamba-version: "*"
+        channels: conda-forge
+        activate-environment: pandas-dev
+        channel-priority: flexible
+        environment-file: ${{ env.ENV_FILE }}
+        use-only-tar-bz2: true
+
+    - name: Build Pandas
+      uses: ./.github/actions/build_pandas
+
+    - name: Test
+      run: ci/run_tests.sh
+      if: always()
+
+    - name: Build Version
+      run: python -c "import pandas; pandas.show_versions();"
+
+    - name: Publish test results
+      uses: actions/upload-artifact@v2
+      with:
+        name: Test results
+        path: test-data.xml
+      if: failure()
+
+    - name: Print skipped tests
+      run: python ci/print_skipped.py
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v2
+      with:
+        flags: unittests
+        name: codecov-pandas
+        fail_ci_if_error: false


### PR DESCRIPTION
To hopefully address the annoying timeouts in Windows tests on Azure, moving these tests to GHA.

Azure has a timeout limit of 1 hour: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#server-jobs

GHA has a timeout limit of 6 hours (among other things): https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits
