### PR TITLE
CI: Set Azure job timeouts to max limit and don't split

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   pre_commit:
+    if: false
     name: pre-commit
     runs-on: ubuntu-latest
     concurrency:

--- a/.github/workflows/datamanger.yml
+++ b/.github/workflows/datamanger.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   data_manager:
+    if: false
     name: Test experimental data manager
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   web_and_docs:
+    if: false
     name: Doc Build and Upload
     runs-on: ubuntu-latest
 

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   pytest:
+    if: false
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   build:
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 60
     defaults:

--- a/ci/azure/posix.yml
+++ b/ci/azure/posix.yml
@@ -4,6 +4,7 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
+  timeoutInMinutes: 0
   pool:
     vmImage: ${{ parameters.vmImage }}
   strategy:

--- a/ci/azure/posix.yml
+++ b/ci/azure/posix.yml
@@ -9,36 +9,23 @@ jobs:
     vmImage: ${{ parameters.vmImage }}
   strategy:
     matrix:
-      py38_macos_1:
+      py38_macos:
         ENV_FILE: ci/deps/azure-macos-38.yaml
         CONDA_PY: "38"
         PATTERN: "not slow"
-        PYTEST_TARGET: "pandas/tests/[a-h]*"
-      py38_macos_2:
-        ENV_FILE: ci/deps/azure-macos-38.yaml
-        CONDA_PY: "38"
-        PATTERN: "not slow"
-        PYTEST_TARGET: "pandas/tests/[i-z]*"
-      py39_macos_1:
+        PYTEST_TARGET: "pandas"
+
+      py39_macos:
         ENV_FILE: ci/deps/azure-macos-39.yaml
         CONDA_PY: "39"
         PATTERN: "not slow"
-        PYTEST_TARGET: "pandas/tests/[a-h]*"
-      py39_macos_2:
-        ENV_FILE: ci/deps/azure-macos-39.yaml
-        CONDA_PY: "39"
-        PATTERN: "not slow"
-        PYTEST_TARGET: "pandas/tests/[i-z]*"
-      py310_macos_1:
+        PYTEST_TARGET: "pandas"
+
+      py310_macos:
         ENV_FILE: ci/deps/azure-macos-310.yaml
         CONDA_PY: "310"
         PATTERN: "not slow"
-        PYTEST_TARGET: "pandas/tests/[a-h]*"
-      py310_macos_2:
-        ENV_FILE: ci/deps/azure-macos-310.yaml
-        CONDA_PY: "310"
-        PATTERN: "not slow"
-        PYTEST_TARGET: "pandas/tests/[i-z]*"
+        PYTEST_TARGET: "pandas"
 
   steps:
     - script: echo '##vso[task.prependpath]$(HOME)/miniconda3/bin'

--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -4,6 +4,7 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
+  timeoutInMinutes: 0
   pool:
     vmImage: ${{ parameters.vmImage }}
   strategy:

--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -28,7 +28,7 @@ jobs:
         CONDA_PY: "310"
         PATTERN: "not slow and not high_memory"
         PYTEST_WORKERS: 2  # GH-42236
-        PYTEST_TARGET: "pandas/tests/[a-h]*"
+        PYTEST_TARGET: "pandas"
 
   steps:
     - powershell: |

--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -9,47 +9,26 @@ jobs:
     vmImage: ${{ parameters.vmImage }}
   strategy:
     matrix:
-      py38_np18_1:
+      py38_np18:
         ENV_FILE: ci/deps/azure-windows-38.yaml
         CONDA_PY: "38"
         PATTERN: "not slow"
         PYTEST_WORKERS: 2  # GH-42236
-        PYTEST_TARGET: "pandas/tests/[a-h]*"
+        PYTEST_TARGET: "pandas"
 
-      py38_np18_2:
-        ENV_FILE: ci/deps/azure-windows-38.yaml
-        CONDA_PY: "38"
-        PATTERN: "not slow"
-        PYTEST_WORKERS: 2  # GH-42236
-        PYTEST_TARGET: "pandas/tests/[i-z]*"
-
-      py39_1:
+      py39:
         ENV_FILE: ci/deps/azure-windows-39.yaml
         CONDA_PY: "39"
         PATTERN: "not slow and not high_memory"
         PYTEST_WORKERS: 2  # GH-42236
-        PYTEST_TARGET: "pandas/tests/[a-h]*"
+        PYTEST_TARGET: "pandas"
 
-      py39_2:
-        ENV_FILE: ci/deps/azure-windows-39.yaml
-        CONDA_PY: "39"
-        PATTERN: "not slow and not high_memory"
-        PYTEST_WORKERS: 2  # GH-42236
-        PYTEST_TARGET: "pandas/tests/[i-z]*"
-
-      py310_1:
+      py310:
         ENV_FILE: ci/deps/azure-windows-310.yaml
         CONDA_PY: "310"
         PATTERN: "not slow and not high_memory"
         PYTEST_WORKERS: 2  # GH-42236
         PYTEST_TARGET: "pandas/tests/[a-h]*"
-
-      py310_2:
-        ENV_FILE: ci/deps/azure-windows-310.yaml
-        CONDA_PY: "310"
-        PATTERN: "not slow and not high_memory"
-        PYTEST_WORKERS: 2  # GH-42236
-        PYTEST_TARGET: "pandas/tests/[i-z]*"
 
   steps:
     - powershell: |

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -24,7 +24,7 @@ if [[ $(uname) == "Linux" && -z $DISPLAY ]]; then
     XVFB="xvfb-run "
 fi
 
-PYTEST_CMD="${XVFB}pytest -vv -m \"$PATTERN\" -n $PYTEST_WORKERS --dist=loadfile $TEST_ARGS $COVERAGE $PYTEST_TARGET"
+PYTEST_CMD="${XVFB}pytest -vv --setup-show -m \"$PATTERN\" -n $PYTEST_WORKERS --dist=loadfile $TEST_ARGS $COVERAGE $PYTEST_TARGET"
 
 if [[ $(uname) != "Linux"  && $(uname) != "Darwin" ]]; then
     PYTEST_CMD="$PYTEST_CMD --ignore=pandas/tests/plotting/"

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -24,7 +24,7 @@ if [[ $(uname) == "Linux" && -z $DISPLAY ]]; then
     XVFB="xvfb-run "
 fi
 
-PYTEST_CMD="${XVFB}pytest -m \"$PATTERN\" -n $PYTEST_WORKERS --dist=loadfile $TEST_ARGS $COVERAGE $PYTEST_TARGET"
+PYTEST_CMD="${XVFB}pytest -vv -m \"$PATTERN\" -n $PYTEST_WORKERS --dist=loadfile $TEST_ARGS $COVERAGE $PYTEST_TARGET"
 
 if [[ $(uname) != "Linux"  && $(uname) != "Darwin" ]]; then
     PYTEST_CMD="$PYTEST_CMD --ignore=pandas/tests/plotting/"


### PR DESCRIPTION
Bumps the Azure job limits from 1 hour to 6 hours and unsplits the jobs (due to the time constraints originally).  https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml&viewFallbackFrom=vsts#timeouts

Hopefully this is also enough time for the timeouts we've been seeing in Azure jobs.