### PR TITLE
Backport PR #45364 on branch 1.4.x (CI/TST: update pyarrow pin in windows-3.8 env / fix failing parquet test on windows)

### DIFF
--- a/ci/deps/actions-38-locale.yaml
+++ b/ci/deps/actions-38-locale.yaml
@@ -32,5 +32,5 @@ dependencies:
   - xlrd
   - xlsxwriter
   - xlwt
-  - pyarrow=1.0.1
+  - pyarrow=4
   - pyxlsb

--- a/ci/deps/actions-39.yaml
+++ b/ci/deps/actions-39.yaml
@@ -25,7 +25,7 @@ dependencies:
   - numba
   - numexpr
   - openpyxl
-  - pyarrow>2.0.1
+  - pyarrow=5
   - pytables
   - python-dateutil
   - pytz

--- a/ci/deps/azure-windows-38.yaml
+++ b/ci/deps/azure-windows-38.yaml
@@ -23,7 +23,7 @@ dependencies:
   - numpy=1.18
   - openpyxl
   - jinja2
-  - pyarrow=1.0.1
+  - pyarrow=2
   - pytables
   - python-dateutil
   - pytz

--- a/ci/deps/azure-windows-39.yaml
+++ b/ci/deps/azure-windows-39.yaml
@@ -25,7 +25,7 @@ dependencies:
   - numexpr
   - numpy
   - openpyxl
-  - pyarrow
+  - pyarrow=6
   - pytables
   - python-dateutil
   - pytz

--- a/pandas/tests/arrays/period/test_arrow_compat.py
+++ b/pandas/tests/arrays/period/test_arrow_compat.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pandas.compat import pa_version_under2p0
+from pandas.compat import pa_version_under4p0
 
 from pandas.core.dtypes.dtypes import PeriodDtype
 
@@ -72,7 +72,7 @@ def test_arrow_array_missing():
 
 
 @pytest.mark.xfail(
-    pa_version_under2p0, reason="pyarrow incorrectly uses pandas internals API"
+    pa_version_under4p0, reason="pyarrow incorrectly uses pandas internals API"
 )
 def test_arrow_table_roundtrip():
     from pandas.core.arrays._arrow_utils import ArrowPeriodType
@@ -94,7 +94,7 @@ def test_arrow_table_roundtrip():
 
 
 @pytest.mark.xfail(
-    pa_version_under2p0, reason="pyarrow incorrectly uses pandas internals API"
+    pa_version_under4p0, reason="pyarrow incorrectly uses pandas internals API"
 )
 def test_arrow_load_from_zero_chunks():
     # GH-41040
@@ -115,7 +115,7 @@ def test_arrow_load_from_zero_chunks():
 
 
 @pytest.mark.xfail(
-    pa_version_under2p0, reason="pyarrow incorrectly uses pandas internals API"
+    pa_version_under4p0, reason="pyarrow incorrectly uses pandas internals API"
 )
 def test_arrow_table_roundtrip_without_metadata():
     arr = PeriodArray([1, 2, 3], freq="H")

--- a/pandas/tests/io/test_feather.py
+++ b/pandas/tests/io/test_feather.py
@@ -2,7 +2,7 @@
 import numpy as np
 import pytest
 
-from pandas.compat.pyarrow import pa_version_under2p0
+from pandas.compat.pyarrow import pa_version_under4p0
 
 import pandas as pd
 import pandas._testing as tm
@@ -87,7 +87,7 @@ class TestFeather:
                 ),
             }
         )
-        if not pa_version_under2p0:
+        if not pa_version_under4p0:
             # older pyarrow incorrectly uses pandas internal API, so
             #  constructs invalid Block
             df["periods"] = pd.period_range("2013", freq="M", periods=3)

--- a/pandas/tests/io/test_fsspec.py
+++ b/pandas/tests/io/test_fsspec.py
@@ -1,10 +1,8 @@
 import io
-import sys
 
 import numpy as np
 import pytest
 
-from pandas.compat import is_platform_windows
 from pandas.compat._optional import VERSIONS
 
 from pandas import (
@@ -162,10 +160,7 @@ def test_to_parquet_new_file(monkeypatch, cleared_fs):
     )
 
 
-@td.skip_if_no("pyarrow")
-@pytest.mark.xfail(
-    is_platform_windows() and sys.version_info[:2] == (3, 8), reason="GH 45344"
-)
+@td.skip_if_no("pyarrow", min_version="2")
 def test_arrowparquet_options(fsspectest):
     """Regression test for writing to a not-yet-existent GCS Parquet file."""
     df = DataFrame({"a": [0]})

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -15,6 +15,7 @@ from pandas._config import get_option
 
 from pandas.compat.pyarrow import (
     pa_version_under2p0,
+    pa_version_under4p0,
     pa_version_under5p0,
     pa_version_under6p0,
 )
@@ -653,10 +654,8 @@ class TestBasic(Base):
             "float",
             pytest.param(
                 "period[D]",
-                # Note: I don't know exactly what version the cutoff is;
-                #  On the CI it fails with 1.0.1
                 marks=pytest.mark.xfail(
-                    pa_version_under2p0,
+                    pa_version_under4p0,
                     reason="pyarrow uses pandas internal API incorrectly",
                 ),
             ),
@@ -899,7 +898,7 @@ class TestParquetPyArrow(Base):
 
     @td.skip_if_no("pyarrow")
     @pytest.mark.xfail(
-        pa_version_under2p0, reason="pyarrow uses pandas internal API incorrectly"
+        pa_version_under4p0, reason="pyarrow uses pandas internal API incorrectly"
     )
     def test_additional_extension_types(self, pa):
         # test additional ExtensionArrays that are supported through the


### PR DESCRIPTION
Manual backport of https://github.com/pandas-dev/pandas/pull/45364