### PR TITLE
CI/DOC: Fix docbuild link warnings

### DIFF
--- a/doc/source/development/contributing_codebase.rst
+++ b/doc/source/development/contributing_codebase.rst
@@ -490,8 +490,7 @@ Writing tests
 All tests should go into the ``tests`` subdirectory of the specific package.
 This folder contains many current examples of tests, and we suggest looking to these for
 inspiration.  If your test requires working with files or
-network connectivity, there is more information on the `testing page
-<https://github.com/pandas-dev/pandas/wiki/Testing>`_ of the wiki.
+network connectivity, there is more information on the :wiki:`Testing` of the wiki.
 
 The ``pandas._testing`` module has many special ``assert`` functions that
 make it easier to make statements about whether Series or DataFrame objects are

--- a/doc/source/development/roadmap.rst
+++ b/doc/source/development/roadmap.rst
@@ -74,8 +74,7 @@ types. This includes consistent behavior in all operations (indexing, arithmetic
 operations, comparisons, etc.). There has been discussion of eventually making
 the new semantics the default.
 
-This has been discussed at
-`github #28095 <https://github.com/pandas-dev/pandas/issues/28095>`__ (and
+This has been discussed at :issue:`28095` (and
 linked issues), and described in more detail in this
 `design doc <https://hackmd.io/@jorisvandenbossche/Sk0wMeAmB>`__.
 
@@ -129,8 +128,7 @@ We propose that it should only work with positional indexing, and the translatio
 to positions should be entirely done at a higher level.
 
 Indexing is a complicated API with many subtleties. This refactor will require care
-and attention. More details are discussed at
-https://github.com/pandas-dev/pandas/wiki/(Tentative)-rules-for-restructuring-indexing-code
+and attention. More details are discussed at :wiki:`(Tentative)-rules-for-restructuring-indexing-code`
 
 Numba-accelerated operations
 ----------------------------

--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -586,7 +586,6 @@ Development tools
 While pandas repository is partially typed, the package itself doesn't expose this information for external use.
 Install pandas-stubs to enable basic type coverage of pandas API.
 
-Learn more by reading through these issues `14468 <https://github.com/pandas-dev/pandas/issues/14468>`_,
-`26766 <https://github.com/pandas-dev/pandas/issues/26766>`_, `28142 <https://github.com/pandas-dev/pandas/issues/28142>`_.
+Learn more by reading through :issue:`14468`, :issue:`26766`, :issue:`28142`.
 
 See installation and usage instructions on the `github page <https://github.com/VirtusLab/pandas-stubs>`__.

--- a/doc/source/user_guide/advanced.rst
+++ b/doc/source/user_guide/advanced.rst
@@ -1246,5 +1246,5 @@ This is because the (re)indexing operations above silently inserts ``NaNs`` and 
 changes accordingly.  This can cause some issues when using ``numpy`` ``ufuncs``
 such as ``numpy.logical_and``.
 
-See the `this old issue <https://github.com/pandas-dev/pandas/issues/2388>`__ for a more
+See the :issue:`2388` for a more
 detailed discussion.

--- a/doc/source/user_guide/cookbook.rst
+++ b/doc/source/user_guide/cookbook.rst
@@ -193,8 +193,7 @@ The :ref:`indexing <indexing>` docs.
 
    df[(df.AAA <= 6) & (df.index.isin([0, 2, 4]))]
 
-`Use loc for label-oriented slicing and iloc positional slicing
-<https://github.com/pandas-dev/pandas/issues/2904>`__
+Use loc for label-oriented slicing and iloc positional slicing :issue:`2904`
 
 .. ipython:: python
 
@@ -395,8 +394,7 @@ Sorting
 
    df.sort_values(by=("Labs", "II"), ascending=False)
 
-`Partial selection, the need for sortedness;
-<https://github.com/pandas-dev/pandas/issues/2995>`__
+Partial selection, the need for sortedness :issue:`2995`
 
 Levels
 ******
@@ -910,8 +908,7 @@ Valid frequency arguments to Grouper :ref:`Timeseries <timeseries.offset_aliases
 `Grouping using a MultiIndex
 <https://stackoverflow.com/questions/41483763/pandas-timegrouper-on-multiindex>`__
 
-`Using TimeGrouper and another grouping to create subgroups, then apply a custom function
-<https://github.com/pandas-dev/pandas/issues/3791>`__
+Using TimeGrouper and another grouping to create subgroups, then apply a custom function :issue:`3791`
 
 `Resampling with custom periods
 <https://stackoverflow.com/questions/15408156/resampling-with-custom-periods>`__
@@ -947,8 +944,7 @@ Depending on df construction, ``ignore_index`` may be needed
    df = pd.concat([df1, df2], ignore_index=True)
    df
 
-`Self Join of a DataFrame
-<https://github.com/pandas-dev/pandas/issues/2996>`__
+Self Join of a DataFrame :issue:`2996`
 
 .. ipython:: python
 
@@ -1070,8 +1066,7 @@ using that handle to read.
 `Inferring dtypes from a file
 <https://stackoverflow.com/questions/15555005/get-inferred-dataframe-types-iteratively-using-chunksize>`__
 
-`Dealing with bad lines
-<https://github.com/pandas-dev/pandas/issues/2886>`__
+Dealing with bad lines :issue:`2886`
 
 `Write a multi-row index CSV without writing duplicates
 <https://stackoverflow.com/questions/17349574/pandas-write-multiindex-rows-with-to-csv>`__
@@ -1205,8 +1200,7 @@ The :ref:`Excel <io.excel>` docs
 `Modifying formatting in XlsxWriter output
 <https://pbpython.com/improve-pandas-excel-output.html>`__
 
-`Loading only visible sheets
-<https://github.com/pandas-dev/pandas/issues/19842#issuecomment-892150745>`__
+Loading only visible sheets :issue:`19842#issuecomment-892150745`
 
 .. _cookbook.html:
 
@@ -1226,8 +1220,7 @@ The :ref:`HDFStores <io.hdf5>` docs
 `Simple queries with a Timestamp Index
 <https://stackoverflow.com/questions/13926089/selecting-columns-from-pandas-hdfstore-table>`__
 
-`Managing heterogeneous data using a linked multiple table hierarchy
-<https://github.com/pandas-dev/pandas/issues/3032>`__
+Managing heterogeneous data using a linked multiple table hierarchy :issue:`3032`
 
 `Merging on-disk tables with millions of rows
 <https://stackoverflow.com/questions/14614512/merging-two-tables-with-millions-of-rows-in-python/14617925#14617925>`__

--- a/doc/source/whatsnew/v0.17.1.rst
+++ b/doc/source/whatsnew/v0.17.1.rst
@@ -37,9 +37,7 @@ Conditional HTML formatting
 .. warning::
     This is a new feature and is under active development.
     We'll be adding features an  possibly making breaking changes in future
-    releases. Feedback is welcome_.
-
-.. _welcome: https://github.com/pandas-dev/pandas/issues/11610
+    releases. Feedback is welcome in :issue:`11610`
 
 We've added *experimental* support for conditional HTML formatting:
 the visual styling of a DataFrame based on the data.


### PR DESCRIPTION
Showing up in recent builds

```
/home/runner/work/pandas/pandas/doc/source/user_guide/advanced.rst:1263: WARNING: hardcoded link 'https://github.com/pandas-dev/pandas/issues/2388' could be replaced by an extlink (try using ':issue:`2388`' instead)
/home/runner/work/pandas/pandas/doc/source/user_guide/cookbook.rst:210: WARNING: hardcoded link 'https://github.com/pandas-dev/pandas/issues/2904' could be replaced by an extlink (try using ':issue:`2904`' instead)
/home/runner/work/pandas/pandas/doc/source/user_guide/cookbook.rst:412: WARNING: hardcoded link 'https://github.com/pandas-dev/pandas/issues/2995' could be replaced by an extlink (try using ':issue:`2995`' instead)
/home/runner/work/pandas/pandas/doc/source/user_guide/cookbook.rst:927: WARNING: hardcoded link 'https://github.com/pandas-dev/pandas/issues/3791' could be replaced by an extlink (try using ':issue:`3791`' instead)
/home/runner/work/pandas/pandas/doc/source/user_guide/cookbook.rst:964: WARNING: hardcoded link 'https://github.com/pandas-dev/pandas/issues/2996' could be replaced by an extlink (try using ':issue:`2996`' instead)
/home/runner/work/pandas/pandas/doc/source/user_guide/cookbook.rst:1087: WARNING: hardcoded link 'https://github.com/pandas-dev/pandas/issues/2886' could be replaced by an extlink (try using ':issue:`2886`' instead)
/home/runner/work/pandas/pandas/doc/source/user_guide/cookbook.rst:1222: WARNING: hardcoded link 'https://github.com/pandas-dev/pandas/issues/19842#issuecomment-892150745' could be replaced by an extlink (try using ':issue:`19842#issuecomment-892150745`' instead)
/home/runner/work/pandas/pandas/doc/source/user_guide/cookbook.rst:1243: WARNING: hardcoded link 'https://github.com/pandas-dev/pandas/issues/3032' could be replaced by an extlink (try using ':issue:`3032`' instead)
/home/runner/work/pandas/pandas/doc/source/whatsnew/v0.17.1.rst:52: WARNING: hardcoded link 'https://github.com/pandas-dev/pandas/issues/11610' could be replaced by an extlink (try using ':issue:`11610`' instead)
```