### PR TITLE
CI/TST: xfail(strict=False) s3 networking tests

### DIFF
--- a/pandas/tests/io/json/test_compression.py
+++ b/pandas/tests/io/json/test_compression.py
@@ -38,6 +38,11 @@ def test_read_zipped_json(datapath):
 
 
 @td.skip_if_not_us_locale
+@pytest.mark.xfail(
+    reason="CI race condition GH 45433, GH 44584",
+    raises=FileNotFoundError,
+    strict=False,
+)
 def test_with_s3_url(compression, s3_resource, s3so):
     # Bucket "pandas-test" created in tests/io/conftest.py
 

--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -72,6 +72,11 @@ def tips_df(datapath):
 @td.skip_if_not_us_locale()
 class TestS3:
     @td.skip_if_no("s3fs")
+    @pytest.mark.xfail(
+        reason="CI race condition GH 45433, GH 44584",
+        raises=FileNotFoundError,
+        strict=False,
+    )
     def test_parse_public_s3_bucket(self, tips_df, s3so):
 
         # more of an integration test due to the not-public contents portion


### PR DESCRIPTION
Band-aid for https://github.com/pandas-dev/pandas/issues/45433 to ensure more CI stability before https://github.com/pandas-dev/pandas/issues/44584 or alternative is implemented

cc @jbrockmendel  