### PR TITLE
BUG: ser.loc[range] = foo treating key as positional

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -212,6 +212,7 @@ Indexing
 - Bug in :meth:`DataFrame.iloc` where indexing a single row on a :class:`DataFrame` with a single ExtensionDtype column gave a copy instead of a view on the underlying data (:issue:`45241`)
 - Bug in :meth:`Series.__setitem__` with a non-integer :class:`Index` when using an integer key to set a value that cannot be set inplace where a ``ValueError`` was raised insead of casting to a common dtype (:issue:`45070`)
 - Bug when setting a value too large for a :class:`Series` dtype failing to coerce to a common type (:issue:`26049`, :issue:`32878`)
+- Bug in :meth:`loc.__setitem__` treating ``range`` keys as positional instead of label-based (:issue:`45479`)
 -
 
 Missing

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -665,7 +665,7 @@ class _LocationIndexer(NDFrameIndexerBase):
                 return self._convert_tuple(key)
 
         if isinstance(key, range):
-            # test_loc_setitem_range_key
+            # GH#45479 test_loc_setitem_range_key
             key = list(key)
 
         return self._convert_to_indexer(key, axis=0)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -665,7 +665,8 @@ class _LocationIndexer(NDFrameIndexerBase):
                 return self._convert_tuple(key)
 
         if isinstance(key, range):
-            return list(key)
+            # test_loc_setitem_range_key
+            key = list(key)
 
         return self._convert_to_indexer(key, axis=0)
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1555,6 +1555,19 @@ class TestLocBaseIndependent:
         df.one = np.int8(7)
         assert df.dtypes.one == np.dtype(np.int8)
 
+    def test_loc_setitem_range_key(self, frame_or_series):
+        # don't treat range key as positional
+        obj = frame_or_series(range(5), index=[3, 4, 1, 0, 2])
+
+        values = [9, 10, 11]
+        if obj.ndim == 2:
+            values = [[9], [10], [11]]
+
+        obj.loc[range(3)] = values
+
+        expected = frame_or_series([0, 1, 10, 9, 11], index=obj.index)
+        tm.assert_equal(obj, expected)
+
 
 class TestLocWithEllipsis:
     @pytest.fixture(params=[tm.loc, tm.iloc])

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1556,7 +1556,7 @@ class TestLocBaseIndependent:
         assert df.dtypes.one == np.dtype(np.int8)
 
     def test_loc_setitem_range_key(self, frame_or_series):
-        # don't treat range key as positional
+        # GH#45479 don't treat range key as positional
         obj = frame_or_series(range(5), index=[3, 4, 1, 0, 2])
 
         values = [9, 10, 11]


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry
