### PR TITLE
Bug tojson memleak

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -966,7 +966,7 @@ I/O
 - Bug in :func:`read_json` raising ``ValueError`` when attempting to parse json strings containing "://" (:issue:`36271`)
 - Bug in :func:`read_csv` when ``engine="c"`` and ``encoding_errors=None`` which caused a segfault (:issue:`45180`)
 - Bug in :func:`read_csv` an invalid value of ``usecols`` leading to an unclosed file handle (:issue:`45384`)
-- Bug in :meth:`to_json` fix memory leak (:issue:`43877`)
+- Bug in :meth:`DataFrame.to_json` fix memory leak (:issue:`43877`)
 
 Period
 ^^^^^^

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -935,6 +935,7 @@ I/O
 - Bug in :func:`read_json` raising ``ValueError`` when attempting to parse json strings containing "://" (:issue:`36271`)
 - Bug in :func:`read_csv` when ``engine="c"`` and ``encoding_errors=None`` which caused a segfault (:issue:`45180`)
 - Bug in :func:`read_csv` an invalid value of ``usecols`` leading to an un-closed file handle (:issue:`45384`)
+- Bug in :meth:`to_json` fix memory leak (:issue:`43877`)
 
 Period
 ^^^^^^

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -227,7 +227,7 @@ MultiIndex
 I/O
 ^^^
 - Bug in :meth:`DataFrame.to_stata` where no error is raised if the :class:`DataFrame` contains ``-np.inf`` (:issue:`45350`)
--
+- Bug in :meth:`to_json` fix memory leak (:issue:`43877`)
 
 Period
 ^^^^^^

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -227,7 +227,7 @@ MultiIndex
 I/O
 ^^^
 - Bug in :meth:`DataFrame.to_stata` where no error is raised if the :class:`DataFrame` contains ``-np.inf`` (:issue:`45350`)
-- Bug in :meth:`to_json` fix memory leak (:issue:`43877`)
+-
 
 Period
 ^^^^^^

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -228,6 +228,7 @@ static PyObject *get_values(PyObject *obj) {
             PyErr_Clear();
         } else if (PyObject_HasAttrString(values, "__array__")) {
             // We may have gotten a Categorical or Sparse array so call np.array
+            Py_DECREF(values);
             values = PyObject_CallMethod(values, "__array__", NULL);
         } else if (!PyArray_CheckExact(values)) {
             // Didn't get a numpy array, so keep trying


### PR DESCRIPTION
- [x] closes #43877
- [x] tests passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

Fix memory leak when calling `to_json` appeared in 1.1.0. From these [changes](https://github.com/pandas-dev/pandas/commit/402c5cdd580a25699f6b8b0bade22b9eb0282d08), in `get_values` function, it looks like `values` from [here ](https://github.com/pandas-dev/pandas/blob/main/pandas/_libs/src/ujson/python/objToJSON.c#L224) are not cleaned in this [path](https://github.com/pandas-dev/pandas/blob/main/pandas/_libs/src/ujson/python/objToJSON.c#L231).


I run the following loop and plot the memory usage using [memory_profiler](https://pypi.org/project/memory-profiler/):

``` python
def foo():
    data = {str(c): list(range(100_000)) for c in range(10)}
    for i in range(500):
        print(i)
        df = pd.DataFrame(data)
        df.to_json(orient='split', indent=0)
```

Here on linux (python 3.8.10)
pandas/main:
![mem_x_main](https://user-images.githubusercontent.com/52132110/150327298-c5026ad0-3122-438f-9d26-9d3d17bca236.jpg)

with changes in this PR:
![mem_x_pr](https://user-images.githubusercontent.com/52132110/150327744-94e950a3-6e72-495a-a204-681fb644168c.jpg)

On Windows 10 (python 3.8.5):
pandas/main:
![mem_win_main](https://user-images.githubusercontent.com/52132110/150327861-50fecdde-5070-46bd-8f0e-19dd46626142.jpg)

with changes in this PR:
![mem_win_fix](https://user-images.githubusercontent.com/52132110/150327898-738a3a07-31c6-4124-a715-76f0672671fd.jpg)


I run under valgrind (10 loops), less revealing but there're diff:
pandas/main:
``` text
...
==3116== LEAK SUMMARY:
==3116==    definitely lost: 94,024 bytes in 583 blocks
==3116==    indirectly lost: 7,248,888 bytes in 537 blocks
==3116==      possibly lost: 5,900,491 bytes in 40,529 blocks
==3116==    still reachable: 10,492,550 bytes in 67,907 blocks
==3116==                       of which reachable via heuristic:
==3116==                         stdstring          : 2,484 bytes in 62 blocks
==3116==         suppressed: 0 bytes in 0 blocks
==3116== Reachable blocks (those to which a pointer was found) are not shown.
==3116== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==3116== 
==3116== For lists of detected and suppressed errors, rerun with: -s
==3116== ERROR SUMMARY: 6706 errors from 6703 contexts (suppressed: 4 from 4)
```

with changes in this PR:
``` text
...
==3026== LEAK SUMMARY:
==3026==    definitely lost: 92,296 bytes in 565 blocks
==3026==    indirectly lost: 47,232 bytes in 483 blocks
==3026==      possibly lost: 5,099,615 bytes in 40,511 blocks
==3026==    still reachable: 10,492,630 bytes in 67,908 blocks
==3026==                       of which reachable via heuristic:
==3026==                         stdstring          : 2,484 bytes in 62 blocks
==3026==         suppressed: 0 bytes in 0 blocks
==3026== Reachable blocks (those to which a pointer was found) are not shown.
==3026== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==3026== 
==3026== For lists of detected and suppressed errors, rerun with: -s
==3026== ERROR SUMMARY: 6698 errors from 6695 contexts (suppressed: 8 from 4)
```