### PR TITLE
CI/TST: Disable tests/window/moments for Azure timeouts

### DIFF
--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -4,6 +4,7 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
+  timeoutInMinutes: 90
   pool:
     vmImage: ${{ parameters.vmImage }}
   strategy:

--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -4,7 +4,6 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
-  timeoutInMinutes: 90
   pool:
     vmImage: ${{ parameters.vmImage }}
   strategy:

--- a/ci/deps/azure-windows-310.yaml
+++ b/ci/deps/azure-windows-310.yaml
@@ -8,7 +8,7 @@ dependencies:
   # tools
   - cython>=0.29.24
   - pytest>=6.0
-  - pytest-xdist>=1.31
+  - pytest-xdist=2.4.0
   - hypothesis>=5.5.3
   - pytest-azurepipelines
 

--- a/ci/deps/azure-windows-38.yaml
+++ b/ci/deps/azure-windows-38.yaml
@@ -8,7 +8,7 @@ dependencies:
   # tools
   - cython>=0.29.24
   - pytest>=6.0
-  - pytest-xdist>=1.31
+  - pytest-xdist=2.4.0
   - hypothesis>=5.5.3
   - pytest-azurepipelines
 

--- a/ci/deps/azure-windows-39.yaml
+++ b/ci/deps/azure-windows-39.yaml
@@ -8,7 +8,7 @@ dependencies:
   # tools
   - cython>=0.29.24
   - pytest>=6.0
-  - pytest-xdist>=1.31
+  - pytest-xdist=2.4.0
   - hypothesis>=5.5.3
   - pytest-azurepipelines
 

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -26,8 +26,8 @@ fi
 
 PYTEST_CMD="${XVFB}pytest -m \"$PATTERN\" -n $PYTEST_WORKERS --dist=loadfile $TEST_ARGS $COVERAGE $PYTEST_TARGET"
 
-if [[ $(uname) != "Linux"  && $(uname) != "Darwin" ]]; then
-    PYTEST_CMD="$PYTEST_CMD --ignore=pandas/tests/plotting/"
+if [[ $(uname) != "Linux" ]]; then
+    PYTEST_CMD="$PYTEST_CMD --ignore=pandas/tests/window/moments --ignore=pandas/tests/plotting/"
 fi
 
 echo $PYTEST_CMD

--- a/pandas/tests/window/moments/conftest.py
+++ b/pandas/tests/window/moments/conftest.py
@@ -41,7 +41,6 @@ def is_constant(x):
         for obj in itertools.chain(create_series(), create_dataframes())
         if is_constant(obj)
     ),
-    scope="module",
 )
 def consistent_data(request):
     return request.param


### PR DESCRIPTION
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

My hypothesis (so far) why Azure is timing out is because `pandas/tests/window/moments` tests are hanging on the teardown step. Skipping these tests to see if it fixes things.
