### PR TITLE
TST: Add test inconsistency in group by (#44803)

### DIFF
--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -32,6 +32,20 @@ import pandas.core.common as com
 from pandas.core.groupby.base import maybe_normalize_deprecated_kernels
 
 
+def test_group_by_copy():
+    # GH#44803
+    df = DataFrame(
+        {
+            "name": ["Alice", "Bob", "Carl"],
+            "age": [20, 21, 20],
+        }
+    ).set_index("name")
+
+    grp_by_same_value = df.groupby(["age"]).apply(lambda group: group)
+    grp_by_copy = df.groupby(["age"]).apply(lambda group: group.copy())
+    assert grp_by_same_value == grp_by_copy
+
+
 def test_repr():
     # GH18203
     result = repr(Grouper(key="A", level="B"))

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -43,7 +43,7 @@ def test_group_by_copy():
 
     grp_by_same_value = df.groupby(["age"]).apply(lambda group: group)
     grp_by_copy = df.groupby(["age"]).apply(lambda group: group.copy())
-    assert grp_by_same_value == grp_by_copy
+    tm.assert_frame_equal(grp_by_same_value, grp_by_copy)
 
 
 def test_repr():


### PR DESCRIPTION
- [X] closes #44803
- [X] tests added / passed
- [X] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
