### PR TITLE
DEPR: __array_wrap__

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -145,6 +145,7 @@ Other Deprecations
 - Deprecated behavior of :meth:`SparseArray.astype`, :meth:`Series.astype`, and :meth:`DataFrame.astype` with :class:`SparseDtype` when passing a non-sparse ``dtype``. In a future version, this will cast to that non-sparse dtype instead of wrapping it in a :class:`SparseDtype` (:issue:`34457`)
 - Deprecated behavior of :meth:`DatetimeIndex.intersection` and :meth:`DatetimeIndex.symmetric_difference` (``union`` behavior was already deprecated in version 1.3.0) with mixed timezones; in a future version both will be cast to UTC instead of object dtype (:issue:`39328`, :issue:`45357`)
 - Deprecated :meth:`DataFrame.iteritems`, :meth:`Series.iteritems`, :meth:`HDFStore.iteritems` in favor of :meth:`DataFrame.items`, :meth:`Series.items`, :meth:`HDFStore.items`  (:issue:`45321`)
+- Deprecated the ``__array_wrap__`` method of DataFrame and Series, rely on standard numpy ufuncs instead (:issue:`45451`)
 -
 
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2075,6 +2075,12 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         Series implements __array_ufunc_ so this not called for ufunc on Series.
         """
         # Note: at time of dask 2022.01.0, this is still used by dask
+        warnings.warn(
+            "The __array_wrap__ method of DataFrame and Series will be removed in "
+            "a future version",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         res = lib.item_from_zerodim(result)
         if is_scalar(res):
             # e.g. we get here with np.ptp(series)

--- a/pandas/tests/base/test_misc.py
+++ b/pandas/tests/base/test_misc.py
@@ -89,7 +89,8 @@ def test_array_wrap_compat():
     # (https://github.com/dask/dask/issues/8580).
     # This test is a small dummy ensuring coverage
     orig = Series([1, 2, 3], dtype="int64", index=["a", "b", "c"])
-    result = orig.__array_wrap__(np.array([2, 4, 6], dtype="int64"))
+    with tm.assert_produces_warning(DeprecationWarning):
+        result = orig.__array_wrap__(np.array([2, 4, 6], dtype="int64"))
     expected = orig * 2
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -56,6 +56,7 @@ def test_dask(df):
 
 
 @pytest.mark.filterwarnings("ignore:.*64Index is deprecated:FutureWarning")
+@pytest.mark.filterwarnings("ignore:The __array_wrap__:DeprecationWarning")
 def test_dask_ufunc():
     # At the time of dask 2022.01.0, dask is still directly using __array_wrap__
     # for some ufuncs (https://github.com/dask/dask/issues/8580).


### PR DESCRIPTION
Follow-up on https://github.com/pandas-dev/pandas/pull/45451 to deprecate the method, so we can actually remove it again in the future.