### PR TITLE
Backport PR #45449: DEPR: undo deprecation of astype(int64) for datetimelike values

### DIFF
--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -811,7 +811,7 @@ Other Deprecations
 - Deprecated allowing scalars to be passed to the :class:`Categorical` constructor (:issue:`38433`)
 - Deprecated constructing :class:`CategoricalIndex` without passing list-like data (:issue:`38944`)
 - Deprecated allowing subclass-specific keyword arguments in the :class:`Index` constructor, use the specific subclass directly instead (:issue:`14093`, :issue:`21311`, :issue:`22315`, :issue:`26974`)
-- Deprecated the :meth:`astype` method of datetimelike (``timedelta64[ns]``, ``datetime64[ns]``, ``Datetime64TZDtype``, ``PeriodDtype``) to convert to integer dtypes, use ``values.view(...)`` instead (:issue:`38544`)
+- Deprecated the :meth:`astype` method of datetimelike (``timedelta64[ns]``, ``datetime64[ns]``, ``Datetime64TZDtype``, ``PeriodDtype``) to convert to integer dtypes, use ``values.view(...)`` instead (:issue:`38544`). This deprecation was later reverted in pandas 1.4.0.
 - Deprecated :meth:`MultiIndex.is_lexsorted` and :meth:`MultiIndex.lexsort_depth`, use :meth:`MultiIndex.is_monotonic_increasing` instead (:issue:`32259`)
 - Deprecated keyword ``try_cast`` in :meth:`Series.where`, :meth:`Series.mask`, :meth:`DataFrame.where`, :meth:`DataFrame.mask`; cast results manually if desired (:issue:`38836`)
 - Deprecated comparison of :class:`Timestamp` objects with ``datetime.date`` objects.  Instead of e.g. ``ts <= mydate`` use ``ts <= pd.Timestamp(mydate)`` or ``ts.date() <= mydate`` (:issue:`36131`)

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -430,14 +430,6 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         elif is_integer_dtype(dtype):
             # we deliberately ignore int32 vs. int64 here.
             # See https://github.com/pandas-dev/pandas/issues/24381 for more.
-            warnings.warn(
-                f"casting {self.dtype} values to int64 with .astype(...) is "
-                "deprecated and will raise in a future version. "
-                "Use .view(...) instead.",
-                FutureWarning,
-                stacklevel=find_stack_level(),
-            )
-
             values = self.asi8
 
             if is_unsigned_integer_dtype(dtype):

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1123,13 +1123,6 @@ def astype_nansafe(
 
     elif is_datetime64_dtype(arr.dtype):
         if dtype == np.int64:
-            warnings.warn(
-                f"casting {arr.dtype} values to int64 with .astype(...) "
-                "is deprecated and will raise in a future version. "
-                "Use .view(...) instead.",
-                FutureWarning,
-                stacklevel=find_stack_level(),
-            )
             if isna(arr).any():
                 raise ValueError("Cannot convert NaT values to integer")
             return arr.view(dtype)
@@ -1142,13 +1135,6 @@ def astype_nansafe(
 
     elif is_timedelta64_dtype(arr.dtype):
         if dtype == np.int64:
-            warnings.warn(
-                f"casting {arr.dtype} values to int64 with .astype(...) "
-                "is deprecated and will raise in a future version. "
-                "Use .view(...) instead.",
-                FutureWarning,
-                stacklevel=find_stack_level(),
-            )
             if isna(arr).any():
                 raise ValueError("Cannot convert NaT values to integer")
             return arr.view(dtype)

--- a/pandas/tests/arrays/period/test_astype.py
+++ b/pandas/tests/arrays/period/test_astype.py
@@ -13,18 +13,14 @@ def test_astype(dtype):
     # We choose to ignore the sign and size of integers for
     # Period/Datetime/Timedelta astype
     arr = period_array(["2000", "2001", None], freq="D")
-    with tm.assert_produces_warning(FutureWarning):
-        # astype(int..) deprecated
-        result = arr.astype(dtype)
+    result = arr.astype(dtype)
 
     if np.dtype(dtype).kind == "u":
         expected_dtype = np.dtype("uint64")
     else:
         expected_dtype = np.dtype("int64")
 
-    with tm.assert_produces_warning(FutureWarning):
-        # astype(int..) deprecated
-        expected = arr.astype(expected_dtype)
+    expected = arr.astype(expected_dtype)
 
     assert result.dtype == expected_dtype
     tm.assert_numpy_array_equal(result, expected)
@@ -32,17 +28,13 @@ def test_astype(dtype):
 
 def test_astype_copies():
     arr = period_array(["2000", "2001", None], freq="D")
-    with tm.assert_produces_warning(FutureWarning):
-        # astype(int..) deprecated
-        result = arr.astype(np.int64, copy=False)
+    result = arr.astype(np.int64, copy=False)
 
     # Add the `.base`, since we now use `.asi8` which returns a view.
     # We could maybe override it in PeriodArray to return ._data directly.
     assert result.base is arr._data
 
-    with tm.assert_produces_warning(FutureWarning):
-        # astype(int..) deprecated
-        result = arr.astype(np.int64, copy=True)
+    result = arr.astype(np.int64, copy=True)
     assert result is not arr._data
     tm.assert_numpy_array_equal(result, arr._data.view("i8"))
 

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -77,18 +77,13 @@ class TestDatetimeArray:
     @pytest.mark.parametrize("dtype", [int, np.int32, np.int64, "uint32", "uint64"])
     def test_astype_int(self, dtype):
         arr = DatetimeArray._from_sequence([pd.Timestamp("2000"), pd.Timestamp("2001")])
-        with tm.assert_produces_warning(FutureWarning):
-            # astype(int..) deprecated
-            result = arr.astype(dtype)
+        result = arr.astype(dtype)
 
         if np.dtype(dtype).kind == "u":
             expected_dtype = np.dtype("uint64")
         else:
             expected_dtype = np.dtype("int64")
-
-        with tm.assert_produces_warning(FutureWarning):
-            # astype(int..) deprecated
-            expected = arr.astype(expected_dtype)
+        expected = arr.astype(expected_dtype)
 
         assert result.dtype == expected_dtype
         tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/arrays/test_timedeltas.py
+++ b/pandas/tests/arrays/test_timedeltas.py
@@ -11,18 +11,13 @@ class TestTimedeltaArray:
     @pytest.mark.parametrize("dtype", [int, np.int32, np.int64, "uint32", "uint64"])
     def test_astype_int(self, dtype):
         arr = TimedeltaArray._from_sequence([Timedelta("1H"), Timedelta("2H")])
-        with tm.assert_produces_warning(FutureWarning):
-            # astype(int..) deprecated
-            result = arr.astype(dtype)
+        result = arr.astype(dtype)
 
         if np.dtype(dtype).kind == "u":
             expected_dtype = np.dtype("uint64")
         else:
             expected_dtype = np.dtype("int64")
-
-        with tm.assert_produces_warning(FutureWarning):
-            # astype(int..) deprecated
-            expected = arr.astype(expected_dtype)
+        expected = arr.astype(expected_dtype)
 
         assert result.dtype == expected_dtype
         tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -743,9 +743,7 @@ def test_astype_nansafe(val, typ):
 
     msg = "Cannot convert NaT values to integer"
     with pytest.raises(ValueError, match=msg):
-        with tm.assert_produces_warning(FutureWarning):
-            # datetimelike astype(int64) deprecated
-            astype_nansafe(arr, dtype=typ)
+        astype_nansafe(arr, dtype=typ)
 
 
 def test_astype_nansafe_copy_false(any_int_numpy_dtype):

--- a/pandas/tests/indexes/datetimes/methods/test_astype.py
+++ b/pandas/tests/indexes/datetimes/methods/test_astype.py
@@ -32,8 +32,7 @@ class TestDatetimeIndex:
         )
         tm.assert_index_equal(result, expected)
 
-        with tm.assert_produces_warning(FutureWarning):
-            result = idx.astype(int)
+        result = idx.astype(int)
         expected = Int64Index(
             [1463356800000000000] + [-9223372036854775808] * 3,
             dtype=np.int64,
@@ -42,8 +41,7 @@ class TestDatetimeIndex:
         tm.assert_index_equal(result, expected)
 
         rng = date_range("1/1/2000", periods=10, name="idx")
-        with tm.assert_produces_warning(FutureWarning):
-            result = rng.astype("i8")
+        result = rng.astype("i8")
         tm.assert_index_equal(result, Index(rng.asi8, name="idx"))
         tm.assert_numpy_array_equal(result.values, rng.asi8)
 
@@ -53,9 +51,8 @@ class TestDatetimeIndex:
             np.array([946684800000000000, 946771200000000000], dtype="uint64"),
             name="idx",
         )
-        with tm.assert_produces_warning(FutureWarning):
-            tm.assert_index_equal(arr.astype("uint64"), expected)
-            tm.assert_index_equal(arr.astype("uint32"), expected)
+        tm.assert_index_equal(arr.astype("uint64"), expected)
+        tm.assert_index_equal(arr.astype("uint32"), expected)
 
     def test_astype_with_tz(self):
 

--- a/pandas/tests/indexes/interval/test_astype.py
+++ b/pandas/tests/indexes/interval/test_astype.py
@@ -208,13 +208,10 @@ class TestDatetimelikeSubtype(AstypeTests):
     @pytest.mark.parametrize("subtype", ["int64", "uint64"])
     def test_subtype_integer(self, index, subtype):
         dtype = IntervalDtype(subtype, "right")
-        with tm.assert_produces_warning(FutureWarning):
-            result = index.astype(dtype)
-            expected = IntervalIndex.from_arrays(
-                index.left.astype(subtype),
-                index.right.astype(subtype),
-                closed=index.closed,
-            )
+        result = index.astype(dtype)
+        expected = IntervalIndex.from_arrays(
+            index.left.astype(subtype), index.right.astype(subtype), closed=index.closed
+        )
         tm.assert_index_equal(result, expected)
 
     def test_subtype_float(self, index):

--- a/pandas/tests/indexes/interval/test_constructors.py
+++ b/pandas/tests/indexes/interval/test_constructors.py
@@ -74,21 +74,13 @@ class ConstructorTests:
     )
     def test_constructor_dtype(self, constructor, breaks, subtype):
         # GH 19262: conversion via dtype parameter
-        warn = None
-        if subtype == "int64" and breaks.dtype.kind in ["M", "m"]:
-            # astype(int64) deprecated
-            warn = FutureWarning
-
-        with tm.assert_produces_warning(warn):
-            expected_kwargs = self.get_kwargs_from_breaks(breaks.astype(subtype))
+        expected_kwargs = self.get_kwargs_from_breaks(breaks.astype(subtype))
         expected = constructor(**expected_kwargs)
 
         result_kwargs = self.get_kwargs_from_breaks(breaks)
         iv_dtype = IntervalDtype(subtype, "right")
         for dtype in (iv_dtype, str(iv_dtype)):
-            with tm.assert_produces_warning(warn):
-
-                result = constructor(dtype=dtype, **result_kwargs)
+            result = constructor(dtype=dtype, **result_kwargs)
             tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize(

--- a/pandas/tests/indexes/period/methods/test_astype.py
+++ b/pandas/tests/indexes/period/methods/test_astype.py
@@ -39,8 +39,7 @@ class TestPeriodIndexAsType:
         )
         tm.assert_index_equal(result, expected)
 
-        with tm.assert_produces_warning(FutureWarning):
-            result = idx.astype(np.int64)
+        result = idx.astype(np.int64)
         expected = Int64Index(
             [16937] + [-9223372036854775808] * 3, dtype=np.int64, name="idx"
         )
@@ -51,17 +50,15 @@ class TestPeriodIndexAsType:
         tm.assert_index_equal(result, expected)
 
         idx = period_range("1990", "2009", freq="A", name="idx")
-        with tm.assert_produces_warning(FutureWarning):
-            result = idx.astype("i8")
+        result = idx.astype("i8")
         tm.assert_index_equal(result, Index(idx.asi8, name="idx"))
         tm.assert_numpy_array_equal(result.values, idx.asi8)
 
     def test_astype_uint(self):
         arr = period_range("2000", periods=2, name="idx")
         expected = UInt64Index(np.array([10957, 10958], dtype="uint64"), name="idx")
-        with tm.assert_produces_warning(FutureWarning):
-            tm.assert_index_equal(arr.astype("uint64"), expected)
-            tm.assert_index_equal(arr.astype("uint32"), expected)
+        tm.assert_index_equal(arr.astype("uint64"), expected)
+        tm.assert_index_equal(arr.astype("uint32"), expected)
 
     def test_astype_object(self):
         idx = PeriodIndex([], freq="M")

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -10,10 +10,7 @@ import pytest
 
 from pandas.compat import IS64
 
-from pandas.core.dtypes.common import (
-    is_integer_dtype,
-    needs_i8_conversion,
-)
+from pandas.core.dtypes.common import is_integer_dtype
 
 import pandas as pd
 from pandas import (
@@ -383,10 +380,7 @@ class TestCommon:
             index.name = "idx"
 
         warn = None
-        if dtype in ["int64", "uint64"]:
-            if needs_i8_conversion(index.dtype):
-                warn = FutureWarning
-        elif (
+        if (
             isinstance(index, DatetimeIndex)
             and index.tz is not None
             and dtype == "datetime64[ns]"

--- a/pandas/tests/indexes/timedeltas/methods/test_astype.py
+++ b/pandas/tests/indexes/timedeltas/methods/test_astype.py
@@ -58,8 +58,7 @@ class TestTimedeltaIndex:
         )
         tm.assert_index_equal(result, expected)
 
-        with tm.assert_produces_warning(FutureWarning):
-            result = idx.astype(int)
+        result = idx.astype(int)
         expected = Int64Index(
             [100000000000000] + [-9223372036854775808] * 3, dtype=np.int64, name="idx"
         )
@@ -70,8 +69,7 @@ class TestTimedeltaIndex:
         tm.assert_index_equal(result, expected)
 
         rng = timedelta_range("1 days", periods=10)
-        with tm.assert_produces_warning(FutureWarning):
-            result = rng.astype("i8")
+        result = rng.astype("i8")
         tm.assert_index_equal(result, Index(rng.asi8))
         tm.assert_numpy_array_equal(rng.asi8, result.values)
 
@@ -80,9 +78,8 @@ class TestTimedeltaIndex:
         expected = UInt64Index(
             np.array([3600000000000, 90000000000000], dtype="uint64")
         )
-        with tm.assert_produces_warning(FutureWarning):
-            tm.assert_index_equal(arr.astype("uint64"), expected)
-            tm.assert_index_equal(arr.astype("uint32"), expected)
+        tm.assert_index_equal(arr.astype("uint64"), expected)
+        tm.assert_index_equal(arr.astype("uint32"), expected)
 
     def test_astype_timedelta64(self):
         # GH 13149, GH 13209

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -540,9 +540,6 @@ class TestBlockManager:
         # coerce all
         mgr = create_mgr("c: f4; d: f2; e: f8")
 
-        warn = FutureWarning if t == "int64" else None
-        # datetimelike.astype(int64) deprecated
-
         t = np.dtype(t)
         tmgr = mgr.astype(t)
         assert tmgr.iget(0).dtype.type == t
@@ -553,8 +550,7 @@ class TestBlockManager:
         mgr = create_mgr("a,b: object; c: bool; d: datetime; e: f4; f: f2; g: f8")
 
         t = np.dtype(t)
-        with tm.assert_produces_warning(warn):
-            tmgr = mgr.astype(t, errors="ignore")
+        tmgr = mgr.astype(t, errors="ignore")
         assert tmgr.iget(2).dtype.type == t
         assert tmgr.iget(4).dtype.type == t
         assert tmgr.iget(5).dtype.type == t

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -877,9 +877,7 @@ class TestSeriesConstructors:
         dts = Series(dates, dtype="datetime64[ns]")
 
         # valid astype
-        with tm.assert_produces_warning(FutureWarning):
-            # astype(np.int64) deprecated
-            dts.astype("int64")
+        dts.astype("int64")
 
         # invalid casting
         msg = r"cannot astype a datetimelike from \[datetime64\[ns\]\] to \[int32\]"
@@ -889,10 +887,8 @@ class TestSeriesConstructors:
         # ints are ok
         # we test with np.int64 to get similar results on
         # windows / 32-bit platforms
-        with tm.assert_produces_warning(FutureWarning):
-            # astype(np.int64) deprecated
-            result = Series(dts, dtype=np.int64)
-            expected = Series(dts.astype(np.int64))
+        result = Series(dts, dtype=np.int64)
+        expected = Series(dts.astype(np.int64))
         tm.assert_series_equal(result, expected)
 
     def test_constructor_dtype_datetime64_9(self):
@@ -1403,9 +1399,7 @@ class TestSeriesConstructors:
         assert td.dtype == "timedelta64[ns]"
 
         # valid astype
-        with tm.assert_produces_warning(FutureWarning):
-            # astype(int64) deprecated
-            td.astype("int64")
+        td.astype("int64")
 
         # invalid casting
         msg = r"cannot astype a datetimelike from \[timedelta64\[ns\]\] to \[int32\]"
@@ -1531,10 +1525,8 @@ class TestSeriesConstructors:
         # ints are ok
         # we test with np.int64 to get similar results on
         # windows / 32-bit platforms
-        with tm.assert_produces_warning(FutureWarning):
-            # asype(np.int64) deprecated, use .view(np.int64) instead
-            result = Series(index, dtype=np.int64)
-            expected = Series(index.astype(np.int64))
+        result = Series(index, dtype=np.int64)
+        expected = Series(index.astype(np.int64))
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Manual backport of https://github.com/pandas-dev/pandas/pull/45449