### PR TITLE
EA interface: rename ExtensionArray._hasnans to ._hasna

### DIFF
--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -427,7 +427,7 @@ class ExtensionArray:
             if not self._can_hold_na:
                 return False
             elif item is self.dtype.na_value or isinstance(item, self.dtype.type):
-                return self._hasnans
+                return self._hasna
             else:
                 return False
         else:
@@ -606,7 +606,7 @@ class ExtensionArray:
         raise AbstractMethodError(self)
 
     @property
-    def _hasnans(self) -> bool:
+    def _hasna(self) -> bool:
         # GH#22680
         """
         Equivalent to `self.isna().any()`.
@@ -698,7 +698,7 @@ class ExtensionArray:
         ExtensionArray.argmax
         """
         validate_bool_kwarg(skipna, "skipna")
-        if not skipna and self._hasnans:
+        if not skipna and self._hasna:
             raise NotImplementedError
         return nargminmax(self, "argmin")
 
@@ -722,7 +722,7 @@ class ExtensionArray:
         ExtensionArray.argmin
         """
         validate_bool_kwarg(skipna, "skipna")
-        if not skipna and self._hasnans:
+        if not skipna and self._hasna:
             raise NotImplementedError
         return nargminmax(self, "argmax")
 
@@ -1534,6 +1534,9 @@ class ExtensionArray:
         ExtensionDtype.empty
             ExtensionDtype.empty is the 'official' public version of this API.
         """
+        # Implementer note: while ExtensionDtype.empty is the public way to
+        # call this method, it is still required to implement this `_empty`
+        # method as well (it is called internally in pandas)
         obj = cls._from_sequence([], dtype=dtype)
 
         taker = np.broadcast_to(np.intp(-1), shape)

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -841,7 +841,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         return self.asi8 == iNaT
 
     @property  # NB: override with cache_readonly in immutable subclasses
-    def _hasnans(self) -> bool:
+    def _hasna(self) -> bool:
         """
         return if I have any nans; enables various perf speedups
         """
@@ -866,7 +866,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
 
         This is an internal routine.
         """
-        if self._hasnans:
+        if self._hasna:
             if convert:
                 result = result.astype(convert)
             if fill_value is None:
@@ -1125,7 +1125,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         new_values = checked_add_with_arr(
             self_i8, other_i8, arr_mask=self._isnan, b_mask=other._isnan
         )
-        if self._hasnans or other._hasnans:
+        if self._hasna or other._hasna:
             mask = self._isnan | other._isnan
             np.putmask(new_values, mask, iNaT)
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -738,7 +738,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
         other_i8 = other.asi8
         arr_mask = self._isnan | other._isnan
         new_values = checked_add_with_arr(self_i8, -other_i8, arr_mask=arr_mask)
-        if self._hasnans or other._hasnans:
+        if self._hasna or other._hasna:
             np.putmask(new_values, arr_mask, iNaT)
         return new_values.view("timedelta64[ns]")
 
@@ -1356,7 +1356,7 @@ default 'raise'
         iso_calendar_df = DataFrame(
             sarray, columns=["year", "week", "day"], dtype="UInt32"
         )
-        if self._hasnans:
+        if self._hasna:
             iso_calendar_df.iloc[self._isnan] = None
         return iso_calendar_df
 

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -548,7 +548,7 @@ class PeriodArray(dtl.DatelikeOps):
                 f"{type(self).__name__}._time_shift"
             )
         values = self.asi8 + periods * self.freq.n
-        if self._hasnans:
+        if self._hasna:
             values[self._isnan] = iNaT
         return type(self)(values, freq=self.freq)
 
@@ -618,7 +618,7 @@ class PeriodArray(dtl.DatelikeOps):
 
         new_data = period_asfreq_arr(ordinal, base1, base2, end)
 
-        if self._hasnans:
+        if self._hasna:
             new_data[self._isnan] = iNaT
 
         return type(self)(new_data, freq=freq)
@@ -645,7 +645,7 @@ class PeriodArray(dtl.DatelikeOps):
         else:
             formatter = lambda dt: str(dt)
 
-        if self._hasnans:
+        if self._hasna:
             mask = self._isnan
             values[mask] = na_rep
             imask = ~mask
@@ -712,7 +712,7 @@ class PeriodArray(dtl.DatelikeOps):
         new_data = asi8 - other.ordinal
         new_data = np.array([self.freq * x for x in new_data])
 
-        if self._hasnans:
+        if self._hasna:
             new_data[self._isnan] = NaT
 
         return new_data
@@ -739,7 +739,7 @@ class PeriodArray(dtl.DatelikeOps):
         )
 
         new_values = np.array([self.freq.base * x for x in new_values])
-        if self._hasnans or other._hasnans:
+        if self._hasna or other._hasna:
             mask = self._isnan | other._isnan
             new_values[mask] = NaT
         return new_values

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -82,7 +82,7 @@ def _field_accessor(name: str, alias: str, docstring: str):
     def f(self) -> np.ndarray:
         values = self.asi8
         result = get_timedelta_field(values, alias)
-        if self._hasnans:
+        if self._hasna:
             result = self._maybe_mask_results(
                 result, fill_value=None, convert="float64"
             )
@@ -911,7 +911,7 @@ class TimedeltaArray(dtl.TimelikeOps):
             "microseconds",
             "nanoseconds",
         ]
-        hasnans = self._hasnans
+        hasnans = self._hasna
         if hasnans:
 
             def f(x):

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1507,7 +1507,7 @@ def common_dtype_categorical_compat(
                     hasnas = obj.hasnans
                 else:
                     # Categorical
-                    hasnas = cast("Categorical", obj)._hasnans
+                    hasnas = cast("Categorical", obj)._hasna
 
                 if hasnas:
                     # see test_union_int_categorical_with_nan

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -96,7 +96,7 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex):
     hasnans = cast(
         bool,
         cache_readonly(
-            DatetimeLikeArrayMixin._hasnans.fget  # type: ignore[attr-defined]
+            DatetimeLikeArrayMixin._hasna.fget  # type: ignore[attr-defined]
         ),
     )
 

--- a/pandas/tests/extension/base/constructors.py
+++ b/pandas/tests/extension/base/constructors.py
@@ -135,3 +135,8 @@ class BaseConstructorsTests(BaseExtensionTests):
         assert isinstance(result2, cls)
         assert result2.dtype == dtype
         assert result2.shape == (4,)
+
+        result2 = dtype.empty(4)
+        assert isinstance(result2, cls)
+        assert result2.dtype == dtype
+        assert result2.shape == (4,)


### PR DESCRIPTION
As discussed in follow-up on https://github.com/pandas-dev/pandas/pull/45024#discussion_r774711601

Since this is "public" for developers, we need to decide on a name now for 1.4. Using "na" instead of "nan" makes it consistent with the other missing values related methods in the EA interface (isna, dropna, fillna, _can_hold_na)