### PR TITLE
REF: use more explicit to_numpy(object) instead of astype(object) in EA implementation

### DIFF
--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -172,7 +172,7 @@ class ExtensionArray:
     * _formatter : Print scalars inside a Series or DataFrame.
 
     Some methods require casting the ExtensionArray to an ndarray of Python
-    objects with ``self.astype(object)``, which may be expensive. When
+    objects with ``self.to_numpy(object)``, which may be expensive. When
     performance is a concern, we highly recommend overriding the following
     methods:
 
@@ -770,7 +770,7 @@ class ExtensionArray:
         if mask.any():
             if method is not None:
                 func = missing.get_fill_func(method)
-                new_values, _ = func(self.astype(object), limit=limit, mask=mask)
+                new_values, _ = func(self.to_numpy(object), limit=limit, mask=mask)
                 new_values = self._from_sequence(new_values, dtype=self.dtype)
             else:
                 # fill with value
@@ -849,7 +849,7 @@ class ExtensionArray:
         -------
         uniques : ExtensionArray
         """
-        uniques = unique(self.astype(object))
+        uniques = unique(self.to_numpy(object))
         return self._from_sequence(uniques, dtype=self.dtype)
 
     def searchsorted(
@@ -901,7 +901,7 @@ class ExtensionArray:
         # 1. Values outside the range of the `data_for_sorting` fixture
         # 2. Values between the values in the `data_for_sorting` fixture
         # 3. Missing values.
-        arr = self.astype(object)
+        arr = self.to_numpy(object)
         if isinstance(value, ExtensionArray):
             value = value.astype(object)
         return arr.searchsorted(value, side=side, sorter=sorter)
@@ -978,7 +978,7 @@ class ExtensionArray:
         The values returned by this method are also used in
         :func:`pandas.util.hash_pandas_object`.
         """
-        return self.astype(object), np.nan
+        return self.to_numpy(object), np.nan
 
     def factorize(self, na_sentinel: int = -1) -> tuple[np.ndarray, ExtensionArray]:
         """
@@ -1156,7 +1156,7 @@ class ExtensionArray:
 
                # If the ExtensionArray is backed by an ndarray, then
                # just pass that here instead of coercing to object.
-               data = self.astype(object)
+               data = self.to_numpy(object)
 
                if allow_fill and fill_value is None:
                    fill_value = self.dtype.na_value
@@ -1493,7 +1493,7 @@ class ExtensionArray:
         func = missing.get_fill_func(method)
         # NB: if we don't copy mask here, it may be altered inplace, which
         #  would mess up the `self[mask] = ...` below.
-        new_values, _ = func(self.astype(object), limit=limit, mask=mask.copy())
+        new_values, _ = func(self.to_numpy(object), limit=limit, mask=mask.copy())
         new_values = self._from_sequence(new_values, dtype=self.dtype)
         self[mask] = new_values[mask]
         return

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -314,7 +314,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
     def __array__(self, dtype: NpDtype | None = None) -> np.ndarray:
         # used for Timedelta/DatetimeArray, overwritten by PeriodArray
         if is_object_dtype(dtype):
-            return np.array(list(self), dtype=object)
+            return self.astype(object)
         return self._ndarray
 
     @overload

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -810,14 +810,14 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
                         pass
 
                     elif "mixed" in inferred:
-                        return isin(self.astype(object), values)
+                        return isin(self.to_numpy(object), values)
                     else:
                         return np.zeros(self.shape, dtype=bool)
 
             try:
                 values = type(self)._from_sequence(values)
             except ValueError:
-                return isin(self.astype(object), values)
+                return isin(self.to_numpy(object), values)
 
         try:
             self._check_compatible_with(values)
@@ -1016,7 +1016,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
             #  comparing tz-aware and tz-naive
             with np.errstate(all="ignore"):
                 result = ops.comp_method_OBJECT_ARRAY(
-                    op, np.asarray(self.astype(object)), other
+                    op, np.asarray(self.to_numpy(object)), other
                 )
             return result
 

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -1659,7 +1659,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
                 # not comparable -> no overlap
                 return np.zeros(self.shape, dtype=bool)
 
-        return isin(self.astype(object), values.astype(object))
+        return isin(self.to_numpy(object), values.astype(object))
 
     @property
     def _combined(self) -> ArrayLike:

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -638,7 +638,7 @@ class PeriodArray(dtl.DatelikeOps):
         """
         actually format my specific types
         """
-        values = self.astype(object)
+        values = self.to_numpy(object)
 
         if date_format:
             formatter = lambda dt: dt.strftime(date_format)


### PR DESCRIPTION
Somewhat related to https://github.com/pandas-dev/pandas/issues/24877 / https://github.com/pandas-dev/pandas/pull/43699, but regardless of whether we want to stop `astype` returning numpy arrays or not, I think when we know we want to get an object-dtype numpy array as result, using `to_numpy(object)` is more explicit about this when reading the code.