### PR TITLE
REGR: read_fwf interpreting infer as list of colspecs when checking names length

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -856,7 +856,7 @@ def read_fwf(
     # Ensure length of `colspecs` matches length of `names`
     names = kwds.get("names")
     if names is not None:
-        if len(names) != len(colspecs):
+        if len(names) != len(colspecs) and colspecs != "infer":
             # need to check len(index_col) as it might contain
             # unnamed indices, in which case it's name is not required
             len_index = 0

--- a/pandas/tests/io/parser/test_read_fwf.py
+++ b/pandas/tests/io/parser/test_read_fwf.py
@@ -920,3 +920,13 @@ def test_skiprows_passing_as_positional_deprecated():
         result = read_fwf(StringIO(data), [(0, 2)])
     expected = DataFrame({"0": [1, 2]})
     tm.assert_frame_equal(result, expected)
+
+
+def test_names_and_infer_colspecs():
+    # GH#45337
+    data = """X   Y   Z
+      959.0    345   22.2
+    """
+    result = read_fwf(StringIO(data), skiprows=1, usecols=[0, 2], names=["a", "b"])
+    expected = DataFrame({"a": [959.0], "b": 22.2})
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #45337
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

No whatsnew needed if this goes into 1.4, otherwise I will add one for 1.4.1 when available