### PR TITLE
REGR: changed behavior in series[period].mask(foo, bar, inplace=True)

### DIFF
--- a/doc/source/whatsnew/v1.4.1.rst
+++ b/doc/source/whatsnew/v1.4.1.rst
@@ -14,7 +14,7 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
--
+- Regression in :meth:`Series.mask` with ``inplace=True`` and ``PeriodDtype`` and an incompatible ``other`` coercing to a common dtype instead of raising (:issue:`45546`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1417,8 +1417,6 @@ class EABackedBlock(Block):
                 #  isinstance(values, NDArrayBackedExtensionArray)
                 if isinstance(self.dtype, PeriodDtype):
                     # TODO: don't special-case
-                    # Note: this is the main place where the fallback logic
-                    #  is different from EABackedBlock.putmask.
                     raise
                 blk = self.coerce_to_target_dtype(other)
                 nbs = blk.where(other, cond)
@@ -1459,6 +1457,9 @@ class EABackedBlock(Block):
             elif isinstance(self, NDArrayBackedExtensionBlock):
                 # NB: not (yet) the same as
                 #  isinstance(values, NDArrayBackedExtensionArray)
+                if isinstance(self.dtype, PeriodDtype):
+                    # TODO: don't special-case
+                    raise
                 blk = self.coerce_to_target_dtype(new)
                 return blk.putmask(mask, new)
 

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -899,6 +899,9 @@ def test_where_period_invalid_na(frame_or_series, as_cat, request):
     with pytest.raises(TypeError, match=msg):
         obj.mask(mask, tdnat)
 
+    with pytest.raises(TypeError, match=msg):
+        obj.mask(mask, tdnat, inplace=True)
+
 
 def test_where_nullable_invalid_na(frame_or_series, any_numeric_ea_dtype):
     # GH#44697


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

Behavior change in 1.4rc was undocumented.