### PR TITLE
WEB: update web/pandas/versions.json for docs dropdown menu

### DIFF
--- a/web/pandas/versions.json
+++ b/web/pandas/versions.json
@@ -4,12 +4,8 @@
         "version": "docs/dev"
     },
     {
-        "name": "1.4 (rc)",
+        "name": "1.4 (stable)",
         "version": "pandas-docs/version/1.4"
-    },
-    {
-        "name": "1.3 (stable)",
-        "version": "docs"
     },
     {
         "name": "1.3",


### PR DESCRIPTION
I don't think the milestone is relevant for web updates so backport not needed?