### PR TITLE
BUG: Segfault in to_json with tzaware datetime

### DIFF
--- a/doc/source/whatsnew/v1.4.1.rst
+++ b/doc/source/whatsnew/v1.4.1.rst
@@ -23,7 +23,7 @@ Fixed regressions
 
 Bug fixes
 ~~~~~~~~~
--
+- Fixed segfault in :meth:``DataFrame.to_json`` when dumping tz-aware datetimes in Python 3.10 (:issue:`42130`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/_libs/tslibs/src/datetime/np_datetime.c
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime.c
@@ -360,6 +360,7 @@ int convert_pydatetime_to_datetimestruct(PyObject *dtobj,
             Py_DECREF(tmp);
         } else {
             PyObject *offset;
+            PyObject *tmp_int;
             int seconds_offset, minutes_offset;
 
             /* The utcoffset function should return a timedelta */
@@ -378,11 +379,14 @@ int convert_pydatetime_to_datetimestruct(PyObject *dtobj,
             if (tmp == NULL) {
                 return -1;
             }
-            seconds_offset = PyInt_AsLong(PyNumber_Long(tmp));
+            tmp_int = PyNumber_Long(tmp);
+            seconds_offset = PyInt_AsLong(tmp_int);
             if (seconds_offset == -1 && PyErr_Occurred()) {
+                Py_DECREF(tmp_int);
                 Py_DECREF(tmp);
                 return -1;
             }
+            Py_DECREF(tmp_int);
             Py_DECREF(tmp);
 
             /* Convert to a minutes offset and apply it */

--- a/pandas/_libs/tslibs/src/datetime/np_datetime.c
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime.c
@@ -378,7 +378,7 @@ int convert_pydatetime_to_datetimestruct(PyObject *dtobj,
             if (tmp == NULL) {
                 return -1;
             }
-            seconds_offset = PyInt_AsLong(tmp);
+            seconds_offset = PyInt_AsLong(PyNumber_Long(tmp));
             if (seconds_offset == -1 && PyErr_Occurred()) {
                 Py_DECREF(tmp);
                 return -1;

--- a/pandas/_libs/tslibs/src/datetime/np_datetime.c
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime.c
@@ -380,6 +380,10 @@ int convert_pydatetime_to_datetimestruct(PyObject *dtobj,
                 return -1;
             }
             tmp_int = PyNumber_Long(tmp);
+            if (tmp_int == NULL) {
+                Py_DECREF(tmp);
+                return -1;
+            }
             seconds_offset = PyInt_AsLong(tmp_int);
             if (seconds_offset == -1 && PyErr_Occurred()) {
                 Py_DECREF(tmp_int);

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -11,7 +11,6 @@ import pytest
 
 from pandas.compat import (
     IS64,
-    PY310,
     is_platform_windows,
 )
 import pandas.util._test_decorators as td
@@ -1177,7 +1176,6 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         expected = s.to_json()
         assert expected == ss.to_json()
 
-    @pytest.mark.skipif(PY310, reason="segfault GH 42130")
     @pytest.mark.parametrize(
         "ts",
         [
@@ -1195,7 +1193,6 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         dt = ts.to_pydatetime()
         assert dumps(dt, iso_dates=True) == exp
 
-    @pytest.mark.skipif(PY310, reason="segfault GH 42130")
     @pytest.mark.parametrize(
         "tz_range",
         [


### PR DESCRIPTION
- [ ] closes #42130
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

Basically, timedelta.total_seconds returns a float. PyInt_AsLong(actually PyLong_AsLong) wants an int, but would cast using __int__ for Pythons < 3.10. This stopped happening in python 3.10. (https://docs.python.org/3/c-api/long.html#c.PyLong_AsLong). 

IMO, it probably is fine to cast the result from float to int, as I don't think that any timezone has an offset from UTC that contains fractions of a second. But, I could be wrong given that I don't use timezones and are not too familiar with them.