### PR TITLE
PERF: TimedeltaArray.astype(object)

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -37,6 +37,7 @@ from pandas._libs.tslibs import (
     delta_to_nanoseconds,
     iNaT,
     ints_to_pydatetime,
+    ints_to_pytimedelta,
     to_offset,
 )
 from pandas._libs.tslibs.fields import (
@@ -419,6 +420,11 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
                     freq=self.freq,
                     box="timestamp",
                 )
+                return converted.reshape(self.shape)
+
+            elif self.dtype.kind == "m":
+                i8data = self.asi8.ravel()
+                converted = ints_to_pytimedelta(i8data, box=True)
                 return converted.reshape(self.shape)
 
             return self._box_values(self.asi8.ravel()).reshape(self.shape)


### PR DESCRIPTION
```
In [2]: tdi = pd.timedelta_range("1 second", periods=10**5, freq="s")

In [5]: %timeit tdi.astype(object)
388 ms ± 43.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)   # <- PR
588 ms ± 63.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)   # <- main
```