### PR TITLE
CI: Use xsel instead of xclip for numpydev

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -35,7 +35,7 @@ jobs:
           [actions-pypy-38.yaml, "not slow and not clipboard", "", "", "", "", "--max-worker-restart 0"],
           [actions-39.yaml, "slow", "", "", "", "", ""],
           [actions-39.yaml, "not slow and not clipboard", "", "", "", "", ""],
-          [actions-310-numpydev.yaml, "not slow and not network", "xclip", "", "", "deprecate", "-W error"],
+          [actions-310-numpydev.yaml, "not slow and not network", "xsel", "", "", "deprecate", "-W error"],
           [actions-310.yaml, "not slow and not clipboard", "", "", "", "", ""],
           [actions-310.yaml, "slow", "", "", "", "", ""],
         ]

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -307,6 +307,11 @@ class TestClipboard:
 @pytest.mark.single
 @pytest.mark.clipboard
 @pytest.mark.parametrize("data", ["\U0001f44d...", "Ωœ∑´...", "abcd..."])
+@pytest.mark.xfail(
+    reason="Flaky test in multi-process CI environment: GH 44584",
+    raises=AssertionError,
+    strict=False,
+)
 def test_raw_roundtrip(data):
     # PR #25040 wide unicode wasn't copied correctly on PY3 on windows
     clipboard_set(data)


### PR DESCRIPTION
Hopefully fixes this flaky clipboard test

```
_________________________ test_raw_roundtrip[abcd...] __________________________
[gw1] linux -- Python 3.10.0 /usr/share/miniconda/envs/pandas-dev/bin/python

data = 'abcd...'

    @pytest.mark.single
    @pytest.mark.clipboard
    @pytest.mark.parametrize("data", ["\U0001f44d...", "Ωœ∑´...", "abcd..."])
    def test_raw_roundtrip(data):
        # PR #25040 wide unicode wasn't copied correctly on PY3 on windows
        clipboard_set(data)
>       assert data == clipboard_get()
E       AssertionError: assert 'abcd...' == 'Ωœ∑´...'
E         - Ωœ∑´...
E         + abcd...

pandas/tests/io/test_clipboard.py:313: AssertionError
```
