### PR TITLE
BUG: frame.mask(foo, bar, inplace=True) with EAs incorrectly raising

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -219,6 +219,7 @@ Indexing
 - Bug in :meth:`Series.__setitem__` with a non-integer :class:`Index` when using an integer key to set a value that cannot be set inplace where a ``ValueError`` was raised insead of casting to a common dtype (:issue:`45070`)
 - Bug when setting a value too large for a :class:`Series` dtype failing to coerce to a common type (:issue:`26049`, :issue:`32878`)
 - Bug in :meth:`Series.__setitem__` where setting :attr:`NA` into a numeric-dtpye :class:`Series` would incorrectly upcast to object-dtype rather than treating the value as ``np.nan`` (:issue:`44199`)
+- Bug in :meth:`DataFrame.mask` with ``inplace=True`` and ``ExtensionDtype`` columns incorrectly raising (:issue:`45577`)
 -
 
 Missing

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1436,6 +1436,7 @@ class EABackedBlock(Block):
 
         values = self.values
 
+        new = self._maybe_squeeze_arg(new)
         mask = self._maybe_squeeze_arg(mask)
 
         try:

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -443,7 +443,8 @@ class BaseMethodsTests(BaseExtensionTests):
         cls = type(data)
         a, b = data[:2]
 
-        ser = pd.Series(cls._from_sequence([a, a, b, b], dtype=data.dtype))
+        orig = pd.Series(cls._from_sequence([a, a, b, b], dtype=data.dtype))
+        ser = orig.copy()
         cond = np.array([True, True, False, False])
 
         if as_frame:
@@ -459,7 +460,13 @@ class BaseMethodsTests(BaseExtensionTests):
             expected = expected.to_frame(name="a")
         self.assert_equal(result, expected)
 
+        ser.mask(~cond, inplace=True)
+        self.assert_equal(ser, expected)
+
         # array other
+        ser = orig.copy()
+        if as_frame:
+            ser = ser.to_frame(name="a")
         cond = np.array([True, False, True, True])
         other = cls._from_sequence([a, b, a, b], dtype=data.dtype)
         if as_frame:
@@ -470,6 +477,9 @@ class BaseMethodsTests(BaseExtensionTests):
         if as_frame:
             expected = expected.to_frame(name="a")
         self.assert_equal(result, expected)
+
+        ser.mask(~cond, other, inplace=True)
+        self.assert_equal(ser, expected)
 
     @pytest.mark.parametrize("repeats", [0, 1, 2, [1, 2, 3]])
     def test_repeat(self, data, repeats, as_series, use_numpy):

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -812,6 +812,12 @@ def test_where_string_dtype(frame_or_series):
     )
     tm.assert_equal(result, expected)
 
+    result = obj.mask(~filter_ser, filtered_obj)
+    tm.assert_equal(result, expected)
+
+    obj.mask(~filter_ser, filtered_obj, inplace=True)
+    tm.assert_equal(result, expected)
+
 
 def test_where_bool_comparison():
     # GH 10336


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry
