### PR TITLE
TST: Change test_groupby_copy to apply_mutate.py

### DIFF
--- a/pandas/tests/groupby/test_apply_mutate.py
+++ b/pandas/tests/groupby/test_apply_mutate.py
@@ -4,6 +4,20 @@ import pandas as pd
 import pandas._testing as tm
 
 
+def test_group_by_copy():
+    # GH#44803
+    df = pd.DataFrame(
+        {
+            "name": ["Alice", "Bob", "Carl"],
+            "age": [20, 21, 20],
+        }
+    ).set_index("name")
+
+    grp_by_same_value = df.groupby(["age"]).apply(lambda group: group)
+    grp_by_copy = df.groupby(["age"]).apply(lambda group: group.copy())
+    tm.assert_frame_equal(grp_by_same_value, grp_by_copy)
+
+
 def test_mutate_groups():
 
     # GH3380

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -32,20 +32,6 @@ import pandas.core.common as com
 from pandas.core.groupby.base import maybe_normalize_deprecated_kernels
 
 
-def test_group_by_copy():
-    # GH#44803
-    df = DataFrame(
-        {
-            "name": ["Alice", "Bob", "Carl"],
-            "age": [20, 21, 20],
-        }
-    ).set_index("name")
-
-    grp_by_same_value = df.groupby(["age"]).apply(lambda group: group)
-    grp_by_copy = df.groupby(["age"]).apply(lambda group: group.copy())
-    tm.assert_frame_equal(grp_by_same_value, grp_by_copy)
-
-
 def test_repr():
     # GH18203
     result = repr(Grouper(key="A", level="B"))


### PR DESCRIPTION
Pending tasks from #45509
In line with issue #44803

Change test_groupby_copy from `pandas/tests/groupby/test_groupby.py` to `pandas/tests/groupby/test_apply_mutate.py`

- [X] Already closed #44803 via #45509