### PR TITLE
CI: Fix failing CI for test_alignment_deprecation_many_inputs

### DIFF
--- a/pandas/compat/numpy/__init__.py
+++ b/pandas/compat/numpy/__init__.py
@@ -9,7 +9,7 @@ _nlv = Version(_np_version)
 np_version_under1p19 = _nlv < Version("1.19")
 np_version_under1p20 = _nlv < Version("1.20")
 np_version_under1p22 = _nlv < Version("1.22")
-np_version_is1p22 = _nlv == Version("1.22")
+np_version_gte1p22 = _nlv >= Version("1.22")
 is_numpy_dev = _nlv.dev is not None
 _min_numpy_ver = "1.18.5"
 

--- a/pandas/tests/frame/test_ufunc.py
+++ b/pandas/tests/frame/test_ufunc.py
@@ -3,7 +3,7 @@ from functools import partial
 import numpy as np
 import pytest
 
-from pandas.compat.numpy import np_version_is1p22
+from pandas.compat.numpy import np_version_gte1p22
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -262,7 +262,7 @@ def test_alignment_deprecation_many_inputs(request):
         vectorize,
     )
 
-    if np_version_is1p22:
+    if np_version_gte1p22:
         mark = pytest.mark.xfail(
             reason="ufunc 'my_ufunc' did not contain a loop with signature matching "
             "types",


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/45182

https://github.com/pandas-dev/pandas/pull/45179 was a little too strict since numpy just had a point release.

This should (hopefully) get us to green @jbrockmendel 
