### PR TITLE
TST/CI: Mark TestS3 as xfail(strict=False) due to flakiness

### DIFF
--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -69,14 +69,14 @@ def tips_df(datapath):
 
 
 @pytest.mark.usefixtures("s3_resource")
+@pytest.mark.xfail(
+    reason="CI race condition GH 45433, GH 44584",
+    raises=FileNotFoundError,
+    strict=False,
+)
 @td.skip_if_not_us_locale()
 class TestS3:
     @td.skip_if_no("s3fs")
-    @pytest.mark.xfail(
-        reason="CI race condition GH 45433, GH 44584",
-        raises=FileNotFoundError,
-        strict=False,
-    )
     def test_parse_public_s3_bucket(self, tips_df, s3so):
 
         # more of an integration test due to the not-public contents portion


### PR DESCRIPTION
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

Another example: https://github.com/pandas-dev/pandas/runs/4930469212?check_suite_focus=true#step:10:58
