### PR TITLE
CI/TST: Call join on server process test

### DIFF
--- a/pandas/tests/io/test_user_agent.py
+++ b/pandas/tests/io/test_user_agent.py
@@ -218,6 +218,7 @@ def responder(request):
     )
     server_process.start()
     yield port
+    server_process.join(10)
     server_process.terminate()
     kill_time = 5
     wait_time = 0


### PR DESCRIPTION
Troubleshooting this current CI failure

```
    @pytest.fixture
    def responder(request):
        """
        Fixture that starts a local http server in a separate process on localhost
        and returns the port.
    
        Running in a separate process instead of a thread to allow termination/killing
        of http server upon cleanup.
        """
        # Find an available port
        with socket.socket() as sock:
            sock.bind(("localhost", 0))
            port = sock.getsockname()[1]
    
        server_process = multiprocessing.Process(
            target=process_server, args=(request.param, port)
        )
        server_process.start()
        yield port
        server_process.terminate()
        kill_time = 5
        wait_time = 0
        while server_process.is_alive():
            if wait_time > kill_time:
                server_process.kill()
                break
            else:
                wait_time += 0.1
                time.sleep(0.1)
>       server_process.close()

pandas/tests/io/test_user_agent.py:231: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <Process name='Process-10' pid=13556 parent=8289 started>

    def close(self):
        '''
        Close the Process object.
    
        This method releases resources held by the Process object.  It is
        an error to call this method if the child process is still running.
        '''
        if self._popen is not None:
            if self._popen.poll() is None:
>               raise ValueError("Cannot close a process while it is still running. "
                                 "You should first call join() or terminate().")
E               ValueError: Cannot close a process while it is still running. You should first call join() or terminate().

```
