### PR TITLE
TST: Added test for setitem loc using datetime-like str

### DIFF
--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -2749,22 +2749,19 @@ def test_loc_setitem_uint8_upcast(value):
 
 
 @pytest.mark.parametrize(
-        "fill_val,exp_dtype",
-        [
-            (pd.Timestamp("2022-01-06"), "datetime64[ns]"),
-            (pd.Timestamp("2022-01-07", tz="US/Eastern"), "datetime64[ns, US/Eastern]"),
-        ]
-    )
+    "fill_val,exp_dtype", [
+        (Timestamp("2022-01-06"), "datetime64[ns]"),
+        (Timestamp("2022-01-07", tz="US/Eastern"), "datetime64[ns, US/Eastern]")])
 def test_loc_setitem_using_datetimelike_str_as_index(fill_val, exp_dtype):
 
     data = ["2022-01-02", "2022-01-03", "2022-01-04", fill_val.date()]
-    index = pd.DatetimeIndex(data, tz=fill_val.tz, dtype=exp_dtype)
+    index = DatetimeIndex(data, tz=fill_val.tz, dtype=exp_dtype)
     df = DataFrame([10, 11, 12, 14], columns=["a"], index=index)
     # adding new row using an unexisting datetime-like str index
     df.loc["2022-01-08", "a"] = 13
 
     data.append("2022-01-08")
-    expected_index = pd.DatetimeIndex(data, dtype=exp_dtype)
+    expected_index = DatetimeIndex(data, dtype=exp_dtype)
     tm.assert_index_equal(df.index, expected_index, exact=True)
 
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -2749,9 +2749,12 @@ def test_loc_setitem_uint8_upcast(value):
 
 
 @pytest.mark.parametrize(
-    "fill_val,exp_dtype", [
+    "fill_val,exp_dtype",
+    [
         (Timestamp("2022-01-06"), "datetime64[ns]"),
-        (Timestamp("2022-01-07", tz="US/Eastern"), "datetime64[ns, US/Eastern]")])
+        (Timestamp("2022-01-07", tz="US/Eastern"), "datetime64[ns, US/Eastern]"),
+    ],
+)
 def test_loc_setitem_using_datetimelike_str_as_index(fill_val, exp_dtype):
 
     data = ["2022-01-02", "2022-01-03", "2022-01-04", fill_val.date()]

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -2748,6 +2748,26 @@ def test_loc_setitem_uint8_upcast(value):
     tm.assert_frame_equal(df, expected)
 
 
+@pytest.mark.parametrize(
+        "fill_val,exp_dtype",
+        [
+            (pd.Timestamp("2022-01-06"), "datetime64[ns]"),
+            (pd.Timestamp("2022-01-07", tz="US/Eastern"), "datetime64[ns, US/Eastern]"),
+        ]
+    )
+def test_loc_setitem_using_datetimelike_str_as_index(fill_val, exp_dtype):
+
+    data = ["2022-01-02", "2022-01-03", "2022-01-04", fill_val.date()]
+    index = pd.DatetimeIndex(data, tz=fill_val.tz, dtype=exp_dtype)
+    df = DataFrame([10, 11, 12, 14], columns=["a"], index=index)
+    # adding new row using an unexisting datetime-like str index
+    df.loc["2022-01-08", "a"] = 13
+
+    data.append("2022-01-08")
+    expected_index = pd.DatetimeIndex(data, dtype=exp_dtype)
+    tm.assert_index_equal(df.index, expected_index, exact=True)
+
+
 class TestLocSeries:
     @pytest.mark.parametrize("val,expected", [(2 ** 63 - 1, 3), (2 ** 63, 4)])
     def test_loc_uint64(self, val, expected):


### PR DESCRIPTION
Test to ensure index type conversion when updating existing dataframe
which has datetime as index with datetime-like str using loc

- [x] closes #28249
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
