### PR TITLE
CI/TST: Skip another s3 test that can crash GHA worker

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -50,7 +50,7 @@ jobs:
       COVERAGE: ${{ !contains(matrix.settings[0], 'pypy') }}
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7
-      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.settings[0] }}-${{ matrix.settings[1] }}
+      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.settings[0] }}-${{ matrix.settings[1] }}-${{ matrix.settings[2] }}
       cancel-in-progress: true
 
     services:

--- a/pandas/tests/base/test_unique.py
+++ b/pandas/tests/base/test_unique.py
@@ -106,7 +106,7 @@ def test_nunique_null(null_obj, index_or_series_obj):
 
 @pytest.mark.single
 @pytest.mark.xfail(
-    "Flaky in the CI. Remove once CI has a single build: GH 44584", strict=False
+    reason="Flaky in the CI. Remove once CI has a single build: GH 44584", strict=False
 )
 def test_unique_bad_unicode(index_or_series):
     # regression test for #34550

--- a/pandas/tests/base/test_unique.py
+++ b/pandas/tests/base/test_unique.py
@@ -105,6 +105,9 @@ def test_nunique_null(null_obj, index_or_series_obj):
 
 
 @pytest.mark.single
+@pytest.mark.xfail(
+    "Flaky in the CI. Remove once CI has a single build: GH 44584", strict=False
+)
 def test_unique_bad_unicode(index_or_series):
     # regression test for #34550
     uval = "\ud83d"  # smiley emoji

--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -269,7 +269,7 @@ class TestS3:
         os.environ.get("PANDAS_CI", "0") == "1",
         reason="This test can hang in our CI min_versions build "
         "and leads to '##[error]The runner has "
-        "received a shutdown signal...' in GHA",
+        "received a shutdown signal...' in GHA. GH: 45651",
     )
     def test_read_csv_chunked_download(self, s3_resource, caplog, s3so):
         # 8 MB, S3FS uses 5MB chunks

--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -7,6 +7,7 @@ from io import (
     StringIO,
 )
 import logging
+import os
 
 import numpy as np
 import pytest
@@ -264,6 +265,12 @@ class TestS3:
         expected = read_csv(tips_file)
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.skipif(
+        os.environ.get("PANDAS_CI", "0") == "1",
+        reason="This test can hang in our CI min_versions build "
+        "and leads to '##[error]The runner has "
+        "received a shutdown signal...' in GHA",
+    )
     def test_read_csv_chunked_download(self, s3_resource, caplog, s3so):
         # 8 MB, S3FS uses 5MB chunks
         import s3fs

--- a/pandas/tests/io/test_fsspec.py
+++ b/pandas/tests/io/test_fsspec.py
@@ -3,7 +3,6 @@ import io
 import numpy as np
 import pytest
 
-from pandas.compat import PY310
 from pandas.compat._optional import VERSIONS
 
 from pandas import (
@@ -182,7 +181,6 @@ def test_arrowparquet_options(fsspectest):
 
 @td.skip_array_manager_not_yet_implemented  # TODO(ArrayManager) fastparquet
 @td.skip_if_no("fastparquet")
-@pytest.mark.xfail(PY310, reason="fastparquet failing on 3.10")
 def test_fastparquet_options(fsspectest):
     """Regression test for writing to a not-yet-existent GCS Parquet file."""
     df = DataFrame({"a": [0]})

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -404,7 +404,7 @@ class TestBasic(Base):
             msg = "to_parquet only supports IO with DataFrames"
             self.check_error_on_write(obj, engine, ValueError, msg)
 
-    def test_columns_dtypes(self, request, engine):
+    def test_columns_dtypes(self, engine):
         df = pd.DataFrame({"string": list("abc"), "int": list(range(1, 4))})
 
         # unicode
@@ -430,7 +430,8 @@ class TestBasic(Base):
         ]
         self.check_error_on_write(df, engine, ValueError, msg)
 
-    def test_compression(self, engine, compression, request):
+    @pytest.mark.parametrize("compression", [None, "gzip", "snappy", "brotli"])
+    def test_compression(self, engine, compression):
 
         if compression == "snappy":
             pytest.importorskip("snappy")
@@ -441,7 +442,7 @@ class TestBasic(Base):
         df = pd.DataFrame({"A": [1, 2, 3]})
         check_round_trip(df, engine, write_kwargs={"compression": compression})
 
-    def test_read_columns(self, engine, request):
+    def test_read_columns(self, engine):
         # GH18154
         df = pd.DataFrame({"string": list("abc"), "int": list(range(1, 4))})
 
@@ -450,7 +451,7 @@ class TestBasic(Base):
             df, engine, expected=expected, read_kwargs={"columns": ["string"]}
         )
 
-    def test_write_index(self, engine, request):
+    def test_write_index(self, engine):
         check_names = engine != "fastparquet"
 
         df = pd.DataFrame({"A": [1, 2, 3]})
@@ -499,7 +500,7 @@ class TestBasic(Base):
                 df, engine, read_kwargs={"columns": ["A", "B"]}, expected=df[["A", "B"]]
             )
 
-    def test_write_ignoring_index(self, engine, request):
+    def test_write_ignoring_index(self, engine):
         # ENH 20768
         # Ensure index=False omits the index from the written Parquet file.
         df = pd.DataFrame({"a": [1, 2, 3], "b": ["q", "r", "s"]})

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -13,10 +13,7 @@ import pytest
 
 from pandas._config import get_option
 
-from pandas.compat import (
-    PY310,
-    is_platform_windows,
-)
+from pandas.compat import is_platform_windows
 from pandas.compat.pyarrow import (
     pa_version_under2p0,
     pa_version_under5p0,
@@ -265,7 +262,6 @@ def test_options_py(df_compat, pa):
         check_round_trip(df_compat)
 
 
-@pytest.mark.xfail(PY310, reason="fastparquet failing on 3.10")
 def test_options_fp(df_compat, fp):
     # use the set option
 
@@ -343,7 +339,6 @@ def test_get_engine_auto_error_message():
                 get_engine("auto")
 
 
-@pytest.mark.xfail(PY310, reason="fastparquet failing on 3.10")
 def test_cross_engine_pa_fp(df_cross_compat, pa, fp):
     # cross-compat with differing reading/writing engines
 
@@ -410,10 +405,6 @@ class TestBasic(Base):
             self.check_error_on_write(obj, engine, ValueError, msg)
 
     def test_columns_dtypes(self, request, engine):
-        if PY310 and engine == "fastparquet":
-            request.node.add_marker(
-                pytest.mark.xfail(reason="fastparquet failing on 3.10")
-            )
         df = pd.DataFrame({"string": list("abc"), "int": list(range(1, 4))})
 
         # unicode
@@ -439,7 +430,6 @@ class TestBasic(Base):
         ]
         self.check_error_on_write(df, engine, ValueError, msg)
 
-    @pytest.mark.parametrize("compression", [None, "gzip", "snappy", "brotli"])
     def test_compression(self, engine, compression, request):
 
         if compression == "snappy":
@@ -448,19 +438,11 @@ class TestBasic(Base):
         elif compression == "brotli":
             pytest.importorskip("brotli")
 
-        if PY310 and engine == "fastparquet":
-            request.node.add_marker(
-                pytest.mark.xfail(reason="fastparquet failing on 3.10")
-            )
         df = pd.DataFrame({"A": [1, 2, 3]})
         check_round_trip(df, engine, write_kwargs={"compression": compression})
 
     def test_read_columns(self, engine, request):
         # GH18154
-        if PY310 and engine == "fastparquet":
-            request.node.add_marker(
-                pytest.mark.xfail(reason="fastparquet failing on 3.10")
-            )
         df = pd.DataFrame({"string": list("abc"), "int": list(range(1, 4))})
 
         expected = pd.DataFrame({"string": list("abc")})
@@ -469,10 +451,6 @@ class TestBasic(Base):
         )
 
     def test_write_index(self, engine, request):
-        if PY310 and engine == "fastparquet":
-            request.node.add_marker(
-                pytest.mark.xfail(reason="fastparquet failing on 3.10")
-            )
         check_names = engine != "fastparquet"
 
         df = pd.DataFrame({"A": [1, 2, 3]})
@@ -524,10 +502,6 @@ class TestBasic(Base):
     def test_write_ignoring_index(self, engine, request):
         # ENH 20768
         # Ensure index=False omits the index from the written Parquet file.
-        if PY310 and engine == "fastparquet":
-            request.node.add_marker(
-                pytest.mark.xfail(reason="fastparquet failing on 3.10")
-            )
         df = pd.DataFrame({"a": [1, 2, 3], "b": ["q", "r", "s"]})
 
         write_kwargs = {"compression": None, "index": False}
@@ -1011,7 +985,6 @@ class TestParquetPyArrow(Base):
 
 
 class TestParquetFastParquet(Base):
-    @pytest.mark.xfail(PY310, reason="fastparquet failing on 3.10")
     def test_basic(self, fp, df_full):
         df = df_full
 
@@ -1029,7 +1002,6 @@ class TestParquetFastParquet(Base):
         msg = "Cannot create parquet dataset with duplicate column names"
         self.check_error_on_write(df, fp, ValueError, msg)
 
-    @pytest.mark.xfail(PY310, reason="fastparquet failing on 3.10")
     def test_bool_with_none(self, fp):
         df = pd.DataFrame({"a": [True, None, False]})
         expected = pd.DataFrame({"a": [1.0, np.nan, 0.0]}, dtype="float16")
@@ -1049,12 +1021,10 @@ class TestParquetFastParquet(Base):
         msg = "Can't infer object conversion type"
         self.check_error_on_write(df, fp, ValueError, msg)
 
-    @pytest.mark.xfail(PY310, reason="fastparquet failing on 3.10")
     def test_categorical(self, fp):
         df = pd.DataFrame({"a": pd.Categorical(list("abc"))})
         check_round_trip(df, fp)
 
-    @pytest.mark.xfail(PY310, reason="fastparquet failing on 3.10")
     def test_filter_row_groups(self, fp):
         d = {"a": list(range(0, 3))}
         df = pd.DataFrame(d)
@@ -1073,7 +1043,6 @@ class TestParquetFastParquet(Base):
             write_kwargs={"compression": None, "storage_options": s3so},
         )
 
-    @pytest.mark.xfail(PY310, reason="fastparquet failing on 3.10")
     def test_partition_cols_supported(self, fp, df_full):
         # GH #23283
         partition_cols = ["bool", "int"]
@@ -1091,7 +1060,6 @@ class TestParquetFastParquet(Base):
             actual_partition_cols = fastparquet.ParquetFile(path, False).cats
             assert len(actual_partition_cols) == 2
 
-    @pytest.mark.xfail(PY310, reason="fastparquet failing on 3.10")
     def test_partition_cols_string(self, fp, df_full):
         # GH #27117
         partition_cols = "bool"
@@ -1109,7 +1077,6 @@ class TestParquetFastParquet(Base):
             actual_partition_cols = fastparquet.ParquetFile(path, False).cats
             assert len(actual_partition_cols) == 1
 
-    @pytest.mark.xfail(PY310, reason="fastparquet failing on 3.10")
     def test_partition_on_supported(self, fp, df_full):
         # GH #23283
         partition_cols = ["bool", "int"]
@@ -1145,7 +1112,6 @@ class TestParquetFastParquet(Base):
                     partition_cols=partition_cols,
                 )
 
-    @pytest.mark.xfail(PY310, reason="fastparquet failing on 3.10")
     def test_empty_dataframe(self, fp):
         # GH #27339
         df = pd.DataFrame()
@@ -1153,7 +1119,6 @@ class TestParquetFastParquet(Base):
         expected.index.name = "index"
         check_round_trip(df, fp, expected=expected)
 
-    @pytest.mark.xfail(PY310, reason="fastparquet failing on 3.10")
     def test_timezone_aware_index(self, fp, timezone_aware_date_list):
         idx = 5 * [timezone_aware_date_list]
 

--- a/pandas/tests/io/test_user_agent.py
+++ b/pandas/tests/io/test_user_agent.py
@@ -5,6 +5,7 @@ import gzip
 import http.server
 from io import BytesIO
 import multiprocessing
+import os
 import socket
 import time
 import urllib.error
@@ -16,6 +17,13 @@ import pandas.util._test_decorators as td
 
 import pandas as pd
 import pandas._testing as tm
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("PANDAS_CI", "0") == "1",
+    reason="This test can hang in our CI min_versions build "
+    "and leads to '##[error]The runner has "
+    "received a shutdown signal...' in GHA. GH 45651",
+)
 
 
 class BaseUserAgentResponder(http.server.BaseHTTPRequestHandler):

--- a/pandas/tests/io/test_user_agent.py
+++ b/pandas/tests/io/test_user_agent.py
@@ -12,7 +12,6 @@ import urllib.error
 
 import pytest
 
-from pandas.compat import PY310
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -253,7 +252,6 @@ def responder(request):
             # TODO(ArrayManager) fastparquet
             marks=[
                 td.skip_array_manager_not_yet_implemented,
-                pytest.mark.xfail(PY310, reason="fastparquet failing on 3.10"),
             ],
         ),
         (PickleUserAgentResponder, pd.read_pickle, None),
@@ -291,7 +289,6 @@ def test_server_and_default_headers(responder, read_method, parquet_engine):
             # TODO(ArrayManager) fastparquet
             marks=[
                 td.skip_array_manager_not_yet_implemented,
-                pytest.mark.xfail(PY310, reason="fastparquet failing on 3.10"),
             ],
         ),
         (PickleUserAgentResponder, pd.read_pickle, None),


### PR DESCRIPTION
Example from https://github.com/pandas-dev/pandas/runs/4957463823?check_suite_focus=true

```
.....ss...s...s.........sss..........ss..........ss..................ssssss...s...s...x.............................XXXXXXXXX.XxXX2022-01-26 21:25:12,489 - s3fs - DEBUG - Setting up s3fs instance
2022-01-26T21:25:12.5442600Z 2022-01-26 21:25:12,543 - s3fs - DEBUG - Get directory listing page for pandas-test
2022-01-26T21:25:12.5650735Z 2022-01-26 21:25:12,564 - s3fs - DEBUG - Fetch: pandas-test/large-file.csv, 0-5505024
2022-01-26T22:08:22.5747205Z ##[error]The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.
2022-01-26T22:08:23.3842467Z 
```
