### PR TITLE
CI: Fix concurrency group for locale tests

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -50,7 +50,7 @@ jobs:
       COVERAGE: ${{ !contains(matrix.settings[0], 'pypy') }}
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7
-      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.settings[0] }}-${{ matrix.settings[1] }} - -${{ matrix.settings[2] }}
+      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.settings[0] }}-${{ matrix.settings[1] }}-${{ matrix.settings[2] }}
       cancel-in-progress: true
 
     services:

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -50,7 +50,7 @@ jobs:
       COVERAGE: ${{ !contains(matrix.settings[0], 'pypy') }}
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7
-      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.settings[0] }}-${{ matrix.settings[1] }}
+      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.settings[0] }}-${{ matrix.settings[1] }} - -${{ matrix.settings[2] }}
       cancel-in-progress: true
 
     services:


### PR DESCRIPTION
Since our locale tests use the same dependency file and pytest pattern, the concurrency key needs to be unique on the locale (download) as well.
