### PR TITLE
BUG: Fix joining overlapping IntervalIndex objects (GH-45661)

### DIFF
--- a/doc/source/whatsnew/v1.4.1.rst
+++ b/doc/source/whatsnew/v1.4.1.rst
@@ -16,6 +16,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Regression in :meth:`Series.mask` with ``inplace=True`` and ``PeriodDtype`` and an incompatible ``other`` coercing to a common dtype instead of raising (:issue:`45546`)
 - Regression in :meth:`DataFrame.loc.__setitem__` losing :class:`Index` name if :class:`DataFrame` was empty before (:issue:`45621`)
+- Regression in :func:`join` with overlapping :class:`IntervalIndex` raising an ``InvalidIndexError`` (:issue:`45661`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4580,11 +4580,11 @@ class Index(IndexOpsMixin, PandasObject):
         if join_index is self:
             lindexer = None
         else:
-            lindexer = self.get_indexer(join_index)
+            lindexer = self.get_indexer_for(join_index)
         if join_index is other:
             rindexer = None
         else:
-            rindexer = other.get_indexer(join_index)
+            rindexer = other.get_indexer_for(join_index)
         return join_index, lindexer, rindexer
 
     @final

--- a/pandas/tests/indexes/interval/test_join.py
+++ b/pandas/tests/indexes/interval/test_join.py
@@ -1,0 +1,44 @@
+import pytest
+
+from pandas import (
+    IntervalIndex,
+    MultiIndex,
+    RangeIndex,
+)
+import pandas._testing as tm
+
+
+@pytest.fixture
+def range_index():
+    return RangeIndex(3, name="range_index")
+
+
+@pytest.fixture
+def interval_index():
+    return IntervalIndex.from_tuples(
+        [(0.0, 1.0), (1.0, 2.0), (1.5, 2.5)], name="interval_index"
+    )
+
+
+def test_join_overlapping_in_mi_to_same_intervalindex(range_index, interval_index):
+    #  GH-45661
+    multi_index = MultiIndex.from_product([interval_index, range_index])
+    result = multi_index.join(interval_index)
+
+    tm.assert_index_equal(result, multi_index)
+
+
+def test_join_overlapping_to_multiindex_with_same_interval(range_index, interval_index):
+    #  GH-45661
+    multi_index = MultiIndex.from_product([interval_index, range_index])
+    result = interval_index.join(multi_index)
+
+    tm.assert_index_equal(result, multi_index)
+
+
+def test_join_overlapping_interval_to_another_intervalindex(interval_index):
+    #  GH-45661
+    flipped_interval_index = interval_index[::-1]
+    result = interval_index.join(flipped_interval_index)
+
+    tm.assert_index_equal(result, interval_index)


### PR DESCRIPTION
Replacing calls to `get_indexer()` with `get_indexer_for()` as
`IntervalIndex`es can be unique and overlapping.

Similar to #44588

- [x] closes #45661
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry
