### PR TITLE
TST: Dynamically use doctest_namespace only if running the doctest

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -115,6 +115,12 @@ def pytest_collection_modifyitems(items, config):
     ]
 
     for item in items:
+        if config.getoption("--doctest-modules") or config.getoption(
+            "--doctest-cython"
+        ):
+            # autouse=True for the add_doctest_imports can lead to expensive teardowns
+            # since doctest_namespace is a session fixture
+            item.add_marker(pytest.mark.usefixtures("add_doctest_imports"))
         # mark all tests in the pandas/tests/frame directory with "arraymanager"
         if "/frame/" in item.nodeid:
             item.add_marker(pytest.mark.arraymanager)
@@ -187,6 +193,15 @@ for name in "QuarterBegin QuarterEnd BQuarterBegin BQuarterEnd".split():
     )
 
 
+@pytest.fixture
+def add_doctest_imports(doctest_namespace):
+    """
+    Make `np` and `pd` names available for doctests.
+    """
+    doctest_namespace["np"] = np
+    doctest_namespace["pd"] = pd
+
+
 # ----------------------------------------------------------------
 # Autouse fixtures
 # ----------------------------------------------------------------
@@ -196,15 +211,6 @@ def configure_tests():
     Configure settings for all tests and test modules.
     """
     pd.set_option("chained_assignment", "raise")
-
-
-@pytest.fixture(autouse=True)
-def add_imports(doctest_namespace):
-    """
-    Make `np` and `pd` names available for doctests.
-    """
-    doctest_namespace["np"] = np
-    doctest_namespace["pd"] = pd
 
 
 # ----------------------------------------------------------------

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -116,7 +116,7 @@ def pytest_collection_modifyitems(items, config):
 
     for item in items:
         if config.getoption("--doctest-modules") or config.getoption(
-            "--doctest-cython"
+            "--doctest-cython", default=False
         ):
             # autouse=True for the add_doctest_imports can lead to expensive teardowns
             # since doctest_namespace is a session fixture


### PR DESCRIPTION
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

Will probably speed up the test suite. Example locally with running `pandas/tests/window/moments`

Main
```
======================================================================= slowest 30 durations =======================================================================
0.07s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data4-True-False-0]
0.06s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_std[all_data9-False-False-2-False]
0.06s teardown pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data4-False-True-2]
0.05s teardown pandas/tests/window/moments/test_moments_consistency_rolling.py::test_rolling_consistency_var_debiasing_factors[all_data17-rolling_consistency_cases1-False]
0.03s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data3-False-False-2]
0.03s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data6-False-False-0]
0.03s setup    pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data3-False-True-0]
0.03s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data11-False-False-2]
0.03s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data3-False-False-0]
0.03s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data5-False-False-2]
0.03s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data7-True-True-0]
0.03s setup    pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data5-True-False-2]
0.03s setup    pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data6-False-False-0]
0.03s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data11-False-False-0]
0.02s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data6-True-True-2]
0.02s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data9-True-False-0]
0.02s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data11-True-True-0]
0.02s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data7-True-False-0]
0.02s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data3-False-True-0]
0.02s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data9-False-True-0]
0.02s setup    pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data9-False-False-0]
0.02s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data8-True-True-0]
0.02s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data12-True-False-0]
0.02s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data9-True-False-2]
0.02s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data10-True-False-0]
0.02s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data8-False-False-0]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data8-False-False-2]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data10-False-False-0]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data5-True-True-0]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data10-True-True-0]
```

This PR
```
======================================== slowest 30 durations =======================================================================
0.01s call     pandas/tests/window/moments/test_moments_consistency_expanding.py::test_expanding_consistency_var_std_cov[all_data13-2-0]
0.01s call     pandas/tests/window/moments/test_moments_consistency_expanding.py::test_expanding_consistency_var_std_cov[all_data11-2-1]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_var_debiasing_factors[all_data9-True-True-2]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_series_cov_corr[series_data6-True-False-2-True]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_var_debiasing_factors[all_data9-False-False-0]
0.01s call     pandas/tests/window/moments/test_moments_consistency_expanding.py::test_expanding_consistency_var_std_cov[all_data16-2-0]
0.01s call     pandas/tests/window/moments/test_moments_consistency_rolling.py::test_rolling_consistency_series_cov_corr[series_data1-rolling_consistency_cases1-True-0]
0.01s call     pandas/tests/window/moments/test_moments_consistency_rolling.py::test_rolling_consistency_series_cov_corr[series_data5-rolling_consistency_cases0-True-0]
0.01s call     pandas/tests/window/moments/test_moments_consistency_rolling.py::test_rolling_consistency_series_cov_corr[series_data3-rolling_consistency_cases0-False-0]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_var_debiasing_factors[all_data12-False-True-0]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_series_cov_corr[series_data7-False-True-2-True]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_series_cov_corr[series_data2-False-True-0-True]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_series_cov_corr[series_data4-False-True-2-True]
0.01s call     pandas/tests/window/moments/test_moments_consistency_rolling.py::test_rolling_consistency_var_std_cov[all_data17-rolling_consistency_cases1-True-1]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_mean[all_data4-False-False-0]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_series_cov_corr[series_data5-False-True-0-True]
0.01s call     pandas/tests/window/moments/test_moments_consistency_rolling.py::test_rolling_consistency_var_std_cov[all_data9-rolling_consistency_cases0-True-0]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_series_cov_corr[series_data6-False-False-0-True]
0.01s call     pandas/tests/window/moments/test_moments_consistency_expanding.py::test_expanding_consistency_var_std_cov[all_data14-2-1]
0.01s call     pandas/tests/window/moments/test_moments_consistency_rolling.py::test_rolling_consistency_var_debiasing_factors[all_data9-rolling_consistency_cases1-True]
0.01s call     pandas/tests/window/moments/test_moments_consistency_rolling.py::test_rolling_consistency_series_cov_corr[series_data6-rolling_consistency_cases1-False-0]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_var_debiasing_factors[all_data13-True-False-2]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_std[all_data14-False-True-0-False]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_std[all_data16-True-False-2-True]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_series_cov_corr[series_data5-True-True-0-False]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_std[all_data9-False-True-0-False]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_moments_consistency_var_constant[consistent_data3-True-True-0-False]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_std[all_data9-True-True-0-False]
0.01s call     pandas/tests/window/moments/test_moments_consistency_expanding.py::test_expanding_consistency_var_std_cov[all_data6-2-0]
0.01s call     pandas/tests/window/moments/test_moments_consistency_ewm.py::test_ewm_consistency_var_debiasing_factors[all_data10-False-True-2]
```