### PR TITLE
Add DataFrame.iterrowdicts

### DIFF
--- a/doc/source/user_guide/basics.rst
+++ b/doc/source/user_guide/basics.rst
@@ -1541,7 +1541,12 @@ pandas objects also have the dict-like :meth:`~DataFrame.items` method to
 iterate over the (key, value) pairs.
 
 To iterate over the rows of a DataFrame, you can use the following methods:
-
+* :meth:`~DataFrame.iterrowdicts`: Iterate over DataFrame rows as dictionaries.
+  This converts the rows to dictionary objects. This is approximately as fast as
+  :meth:`~DataFrame.itertuples`. There is a slight overhead from the necessary
+  hashing of the column identifiers, but it also won't mangle the column
+  identifiers like :meth:`~DataFrame.itertuples` has to if they aren't valid
+  attribute identifiers.
 * :meth:`~DataFrame.iterrows`: Iterate over the rows of a DataFrame as (index, Series) pairs.
   This converts the rows to Series objects, which can change the dtypes and has some
   performance implications.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1422,7 +1422,7 @@ class DataFrame(NDFrame, OpsMixin):
 
         # fallback to regular tuples
         return zip(*arrays)
-    
+
     def iterrowdicts(self, index: bool = True) -> Iterable[dict[Any, Any]]:
         """
         Iterate over DataFrame rows as dictionaries.
@@ -1484,7 +1484,7 @@ class DataFrame(NDFrame, OpsMixin):
         columns.extend(self.columns)
 
         return [
-            { column_name : value for column_name, value in zip(columns, row_data) }
+            {column_name: value for column_name, value in zip(columns, row_data)}
             for row_data in zip(*arrays)
         ]
 

--- a/pandas/tests/frame/test_iteration.py
+++ b/pandas/tests/frame/test_iteration.py
@@ -139,7 +139,9 @@ class TestIteration:
 
     def test_iterrowdicts(self, float_frame):
         for i, row_dict in enumerate(float_frame.iterrowdicts()):
-            ser = DataFrame._constructor_sliced({ k : v for k, v in row_dict.items() if k != "index"})
+            ser = DataFrame._constructor_sliced(
+                {k: v for k, v in row_dict.items() if k != "index"}
+            )
             ser.name = row_dict["index"]
             expected = float_frame.iloc[i, :].reset_index(drop=True)
             tm.assert_series_equal(ser, expected)
@@ -154,7 +156,11 @@ class TestIteration:
         df = DataFrame(data={"a": [1, 2, 3], "b": [4, 5, 6]})
         dfaa = df[["a", "a"]]
 
-        assert list(dfaa.iterrowdicts()) == [{"index": 0, "a": 1}, {"index": 1, "a": 2}, {"index": 2, "a": 3}]
+        assert list(dfaa.iterrowdicts()) == [
+            {"index": 0, "a": 1},
+            {"index": 1, "a": 2},
+            {"index": 2, "a": 3},
+        ]
 
         # repr with int on 32-bit/windows
         if not (is_platform_windows() or not IS64):

--- a/pandas/tests/frame/test_iteration.py
+++ b/pandas/tests/frame/test_iteration.py
@@ -138,12 +138,6 @@ class TestIteration:
         assert hasattr(result_255_columns, "_fields")
 
     def test_iterrowdicts(self, float_frame):
-        for i, row_dict in enumerate(float_frame.iterrowdicts()):
-            ser = DataFrame._constructor_sliced({ k : v for k, v in row_dict.items() if k != "index"})
-            ser.name = row_dict["index"]
-            expected = float_frame.iloc[i, :].reset_index(drop=True)
-            tm.assert_series_equal(ser, expected)
-
         df = DataFrame(
             {"floats": np.random.randn(5), "ints": range(5)}, columns=["floats", "ints"]
         )


### PR DESCRIPTION
- [x] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry

I have not checked the linting / whatsnew stuff, will make a followup commit with those necessary changes.

----

### What is this?

Adds a method `DataFrame.iterrowdicts()` that is a very close relation to `DataFrame.itertuples()` that offers fast row-based iteration without the column name mangling of `DataFrame.itertuples()`.

I added it to the basics documentation but didn't change any of the documentation that currently recommends `DataFrame.itertuples()` as the "default" row-based iteration method. 