### PR TITLE
Troubleshoot minimum version build - Skip timed out test

### DIFF
--- a/pandas/tests/io/parser/common/test_common_basic.py
+++ b/pandas/tests/io/parser/common/test_common_basic.py
@@ -706,7 +706,7 @@ def test_first_row_bom(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow
+@skip_pyarrow
 def test_first_row_bom_unquoted(all_parsers):
     # see gh-36343
     parser = all_parsers


### PR DESCRIPTION
This test timed out repeatedly with pyarrow 1.0.1 locally. 
