### PR TITLE
CI: Fix docbuild upload web step on main

### DIFF
--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -54,11 +54,11 @@ jobs:
       run: cp doc/cheatsheet/Pandas_Cheat_Sheet* web/build/
 
     - name: Upload web
-      run: rsync -az --delete --exclude='pandas-docs' --exclude='docs' web/build/ docs@${{ secrets.server_ip }}:/usr/share/nginx/pandas
+      run: rsync -az --delete --inplace --exclude='pandas-docs' --exclude='docs' web/build/ docs@${{ secrets.server_ip }}:/usr/share/nginx/pandas
       if: ${{github.event_name == 'push' && github.ref == 'refs/heads/main'}}
 
     - name: Upload dev docs
-      run: rsync -az --delete doc/build/html/ docs@${{ secrets.server_ip }}:/usr/share/nginx/pandas/pandas-docs/dev
+      run: rsync -az --delete --inplace doc/build/html/ docs@${{ secrets.server_ip }}:/usr/share/nginx/pandas/pandas-docs/dev
       if: ${{github.event_name == 'push' && github.ref == 'refs/heads/main'}}
 
     - name: Move docs into site directory


### PR DESCRIPTION
@datapythonista the main branch docbuild step has been failing on the web upload with

```
Run rsync -az --delete --exclude='pandas-docs' --exclude='docs' web/build/ docs@***:/usr/share/nginx/pandas
  rsync -az --delete --exclude='pandas-docs' --exclude='docs' web/build/ docs@***:/usr/share/nginx/pandas
  shell: /usr/bin/bash -e {0}
  env:
    ENV_FILE: environment.yml
    PANDAS_CI: 1
rsync: write failed on "/usr/share/nginx/pandas/Pandas_Cheat_Sheet.pdf": No space left on device (28)
rsync error: error in file IO (code 11) at receiver.c(393) [receiver=3.1.1]
Error: Process completed with exit code 11.
```

It was suggested in https://serverfault.com/questions/688680/rsync-write-failed-no-space-left-on-device-28 that rsync should use the --inplace flag to help resolve. Not sure if there's anything else that should be considered.