### PR TITLE
DOC: Remove obsolete reference to CONTRIBUTING.md generation

### DIFF
--- a/doc/source/development/contributing_documentation.rst
+++ b/doc/source/development/contributing_documentation.rst
@@ -89,16 +89,6 @@ Some other important things to know about the docs:
   ``doc/source/reference``, else Sphinx
   will emit a warning.
 
-.. note::
-
-    The ``.rst`` files are used to automatically generate Markdown and HTML versions
-    of the docs. For this reason, please do not edit ``CONTRIBUTING.md`` directly,
-    but instead make any changes to ``doc/source/development/contributing.rst``. Then, to
-    generate ``CONTRIBUTING.md``, use `pandoc <https://johnmacfarlane.net/pandoc/>`_
-    with the following command::
-
-      pandoc doc/source/development/contributing.rst -t markdown_github > CONTRIBUTING.md
-
 The utility script ``scripts/validate_docstrings.py`` can be used to get a csv
 summary of the API documentation. And also validate common errors in the docstring
 of a specific class, function or method. The summary also compares the list of


### PR DESCRIPTION
It seems that a note was left over after https://github.com/pandas-dev/pandas/pull/45063 from the old CONTRIBUTING.md times ([still there in devdocs](https://pandas.pydata.org/docs/dev/development/contributing_documentation.html#about-the-pandas-documentation)). The note referred to generating the file from `contributing.rst` via pandoc, but that seems to no longer apply. Suspiciously these were also the only remaining hits for `git grep CONTRIBUTING`.

Removal seems straightforward enough, but I ran pre-commit just in case.