### PR TITLE
BUG: also use Float Nullable dtypes in read_parquet when use_nullable_dtypes=True

### DIFF
--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -231,6 +231,8 @@ class PyArrowImpl(BaseImpl):
                 self.api.uint64(): pd.UInt64Dtype(),
                 self.api.bool_(): pd.BooleanDtype(),
                 self.api.string(): pd.StringDtype(),
+                self.api.float32(): pd.Float32Dtype(),
+                self.api.float64(): pd.Float64Dtype(),
             }
             to_pandas_kwargs["types_mapper"] = mapping.get
         manager = get_option("mode.data_manager")

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -618,6 +618,8 @@ class TestBasic(Base):
                 "d": pyarrow.array([True, False, True, None]),
                 # Test that nullable dtypes used even in absence of nulls
                 "e": pyarrow.array([1, 2, 3, 4], "int64"),
+                "f": pyarrow.array([1.0, 2.0, 3.0, None], "float32"),
+                "g": pyarrow.array([1.0, 2.0, 3.0, None], "float64"),
             }
         )
         with tm.ensure_clean() as path:
@@ -634,6 +636,8 @@ class TestBasic(Base):
                 "c": pd.array(["a", "b", "c", None], dtype="string"),
                 "d": pd.array([True, False, True, None], dtype="boolean"),
                 "e": pd.array([1, 2, 3, 4], dtype="Int64"),
+                "f": pd.array([1.0, 2.0, 3.0, None], dtype="Float32"),
+                "g": pd.array([1.0, 2.0, 3.0, None], dtype="Float64"),
             }
         )
         if engine == "fastparquet":


### PR DESCRIPTION
fixes #45694 
Add float types in the mapping dictionary


