### PR TITLE
BUG: DataFrameGroupby.transform("size") fails

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -306,7 +306,7 @@ Plotting
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 - Bug in :meth:`DataFrame.resample` ignoring ``closed="right"`` on :class:`TimedeltaIndex` (:issue:`45414`)
--
+- Bug in :meth:`.DataFrameGroupBy.transform` fails when the input DataFrame has multiple columns (:issue:`27469`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -472,7 +472,7 @@ class SeriesGroupBy(GroupBy[Series]):
         result.name = self.obj.name
         return result
 
-    def _can_use_transform_fast(self, result) -> bool:
+    def _can_use_transform_fast(self, func: str, result) -> bool:
         return True
 
     def filter(self, func, dropna: bool = True, *args, **kwargs):
@@ -1185,9 +1185,10 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
             func, *args, engine=engine, engine_kwargs=engine_kwargs, **kwargs
         )
 
-    def _can_use_transform_fast(self, result) -> bool:
-        return isinstance(result, DataFrame) and result.columns.equals(
-            self._obj_with_exclusions.columns
+    def _can_use_transform_fast(self, func: str, result) -> bool:
+        return func == "size" or (
+            isinstance(result, DataFrame)
+            and result.columns.equals(self._obj_with_exclusions.columns)
         )
 
     def _define_paths(self, func, *args, **kwargs):

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1650,7 +1650,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             with com.temp_setattr(self, "observed", True):
                 result = getattr(self, func)(*args, **kwargs)
 
-            if self._can_use_transform_fast(result):
+            if self._can_use_transform_fast(func, result):
                 return self._wrap_transform_fast_result(result)
 
             # only reached for DataFrameGroupBy

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -803,39 +803,29 @@ def test_transform_with_non_scalar_group():
 
 
 @pytest.mark.parametrize(
-    "cols,exp,comp_func",
+    "cols,expected",
     [
-        ("a", Series([1, 1, 1], name="a"), tm.assert_series_equal),
+        ("a", Series([1, 1, 1], name="a")),
         (
             ["a", "c"],
             DataFrame({"a": [1, 1, 1], "c": [1, 1, 1]}),
-            tm.assert_frame_equal,
         ),
     ],
 )
 @pytest.mark.parametrize("agg_func", ["count", "rank", "size"])
-def test_transform_numeric_ret(cols, exp, comp_func, agg_func, request):
-    if agg_func == "size" and isinstance(cols, list):
-        # https://github.com/pytest-dev/pytest/issues/6300
-        # workaround to xfail fixture/param permutations
-        reason = "'size' transformation not supported with NDFrameGroupy"
-        request.node.add_marker(pytest.mark.xfail(reason=reason))
-
-    # GH 19200
+def test_transform_numeric_ret(cols, expected, agg_func):
+    # GH#19200 and GH#27469
     df = DataFrame(
         {"a": date_range("2018-01-01", periods=3), "b": range(3), "c": range(7, 10)}
     )
-
-    warn = FutureWarning
-    if isinstance(exp, Series) or agg_func != "size":
-        warn = None
-    with tm.assert_produces_warning(warn, match="Dropping invalid columns"):
-        result = df.groupby("b")[cols].transform(agg_func)
+    result = df.groupby("b")[cols].transform(agg_func)
 
     if agg_func == "rank":
-        exp = exp.astype("float")
-
-    comp_func(result, exp)
+        expected = expected.astype("float")
+    elif agg_func == "size" and cols == ["a", "c"]:
+        # transform("size") returns a Series
+        expected = expected["a"].rename(None)
+    tm.assert_equal(result, expected)
 
 
 def test_transform_ffill():
@@ -1131,27 +1121,19 @@ def test_transform_agg_by_name(request, reduction_func, obj):
         request.node.add_marker(
             pytest.mark.xfail(reason="TODO: g.transform('ngroup') doesn't work")
         )
-    if func == "size" and obj.ndim == 2:  # GH#27469
-        request.node.add_marker(
-            pytest.mark.xfail(reason="TODO: g.transform('size') doesn't work")
-        )
     if func == "corrwith" and isinstance(obj, Series):  # GH#32293
         request.node.add_marker(
             pytest.mark.xfail(reason="TODO: implement SeriesGroupBy.corrwith")
         )
 
     args = {"nth": [0], "quantile": [0.5], "corrwith": [obj]}.get(func, [])
-
-    warn = None
-    if isinstance(obj, DataFrame) and func == "size":
-        warn = FutureWarning
-
-    with tm.assert_produces_warning(warn, match="Dropping invalid columns"):
-        result = g.transform(func, *args)
+    result = g.transform(func, *args)
 
     # this is the *definition* of a transformation
     tm.assert_index_equal(result.index, obj.index)
-    if hasattr(obj, "columns"):
+
+    if func != "size" and obj.ndim == 2:
+        # size returns a Series, unlike other transforms
         tm.assert_index_equal(result.columns, obj.columns)
 
     # verify that values were broadcasted across each group


### PR DESCRIPTION
- [x] closes #27469
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [x] whatsnew entry

axis=1 produces incorrect results for both aggregations and transforms. Opened #45715 and will be tackling separately.