### PR TITLE
TST: Allow tm.network to catch urllib.error.URLError

### DIFF
--- a/pandas/_testing/_io.py
+++ b/pandas/_testing/_io.py
@@ -163,8 +163,8 @@ def network(
     Tests decorated with @network will fail if it's possible to make a network
     connection to another URL (defaults to google.com)::
 
-      >>> from pandas import _testing as ts
-      >>> @ts.network
+      >>> from pandas import _testing as tm
+      >>> @tm.network
       ... def test_network():
       ...     with pd.io.common.urlopen("rabbit://bonanza.com"):
       ...         pass
@@ -175,10 +175,10 @@ def network(
 
       You can specify alternative URLs::
 
-        >>> @ts.network("https://www.yahoo.com")
+        >>> @tm.network("https://www.yahoo.com")
         ... def test_something_with_yahoo():
         ...    raise OSError("Failure Message")
-        >>> test_something_with_yahoo()
+        >>> test_something_with_yahoo()  # doctest: +SKIP
         Traceback (most recent call last):
             ...
         OSError: Failure Message
@@ -186,7 +186,7 @@ def network(
     If you set check_before_test, it will check the url first and not run the
     test on failure::
 
-        >>> @ts.network("failing://url.blaher", check_before_test=True)
+        >>> @tm.network("failing://url.blaher", check_before_test=True)
         ... def test_something():
         ...     print("I ran!")
         ...     raise ValueError("Failure")


### PR DESCRIPTION
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Addresses these flaky network errors due to external servers: https://github.com/pandas-dev/pandas/runs/4992270675?check_suite_focus=true

```
    def http_error_default(self, req, fp, code, msg, hdrs):
>       raise HTTPError(req.full_url, code, msg, hdrs, fp)
E       urllib.error.HTTPError: HTTP Error 500: Internal Server Error
```

Also modifies a condition that just because the test can connect to a "check url" (google) doesn't necessarily mean the test can connect to the target server.
