### PR TITLE
REF: astype_intsafe no longer needed

### DIFF
--- a/pandas/_libs/lib.pyi
+++ b/pandas/_libs/lib.pyi
@@ -157,10 +157,6 @@ def ensure_string_array(
 def infer_datetimelike_array(
     arr: npt.NDArray[np.object_],
 ) -> tuple[str, bool]: ...
-def astype_intsafe(
-    arr: npt.NDArray[np.object_],
-    new_dtype: np.dtype,
-) -> np.ndarray: ...
 def convert_nans_to_NA(
     arr: npt.NDArray[np.object_],
 ) -> npt.NDArray[np.object_]: ...

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -648,26 +648,6 @@ def array_equivalent_object(left: object[:], right: object[:]) -> bool:
     return True
 
 
-@cython.wraparound(False)
-@cython.boundscheck(False)
-def astype_intsafe(ndarray[object] arr, cnp.dtype new_dtype) -> ndarray:
-    cdef:
-        Py_ssize_t i, n = len(arr)
-        object val
-        bint is_datelike
-        ndarray result
-
-    is_datelike = new_dtype == 'm8[ns]'
-    result = np.empty(n, dtype=new_dtype)
-    for i in range(n):
-        val = arr[i]
-        if is_datelike and checknull(val):
-            result[i] = NPY_NAT
-        else:
-            result[i] = val
-
-    return result
-
 ctypedef fused ndarr_object:
     ndarray[object, ndim=1]
     ndarray[object, ndim=2]

--- a/pandas/core/dtypes/astype.py
+++ b/pandas/core/dtypes/astype.py
@@ -139,14 +139,10 @@ def astype_nansafe(
 
     elif is_object_dtype(arr.dtype):
 
-        # work around NumPy brokenness, #1987
-        if dtype.kind in ["i", "u"]:
-            return lib.astype_intsafe(arr, dtype)
-
         # if we have a datetime/timedelta array of objects
         # then coerce to a proper dtype and recall astype_nansafe
 
-        elif is_datetime64_dtype(dtype):
+        if is_datetime64_dtype(dtype):
             from pandas import to_datetime
 
             return astype_nansafe(


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

AFAICT numpy fixed this a while back.