### PR TITLE
TST: use correct input in test

### DIFF
--- a/pandas/tests/io/formats/style/test_style.py
+++ b/pandas/tests/io/formats/style/test_style.py
@@ -839,12 +839,16 @@ class TestStyler:
     def test_table_styles_dict_multiple_selectors(self):
         # GH 44011
         result = self.df.style.set_table_styles(
-            [{"selector": "th,td", "props": [("border-left", "2px solid black")]}]
+            {
+                "B": [
+                    {"selector": "th,td", "props": [("border-left", "2px solid black")]}
+                ]
+            }
         )._translate(True, True)["table_styles"]
 
         expected = [
-            {"selector": "th", "props": [("border-left", "2px solid black")]},
-            {"selector": "td", "props": [("border-left", "2px solid black")]},
+            {"selector": "th.col1", "props": [("border-left", "2px solid black")]},
+            {"selector": "td.col1", "props": [("border-left", "2px solid black")]},
         ]
 
         assert result == expected


### PR DESCRIPTION
This PR uses the correct input to ensure that the bug #44011 was correctly fixed.

This change was requested here: https://github.com/pandas-dev/pandas/issues/44011#issuecomment-973278817