### PR TITLE
TST: Skip pyarrow hanging in MacOS CI

### DIFF
--- a/pandas/tests/io/parser/test_unsupported.py
+++ b/pandas/tests/io/parser/test_unsupported.py
@@ -12,7 +12,10 @@ from pathlib import Path
 
 import pytest
 
-from pandas.compat import is_platform_windows
+from pandas.compat import (
+    is_platform_mac,
+    is_platform_windows,
+)
 from pandas.errors import ParserError
 
 import pandas._testing as tm
@@ -174,9 +177,9 @@ def test_close_file_handle_on_invalid_usecols(all_parsers):
     if parser.engine == "pyarrow":
         pyarrow = pytest.importorskip("pyarrow")
         error = pyarrow.lib.ArrowKeyError
-        if is_platform_windows():
-            # GH#45547 causes timeouts on windows builds
-            pytest.skip("GH#45547 causing timeouts on windows builds 2022-01-22")
+        if is_platform_windows() or is_platform_mac:
+            # GH#45547 causes timeouts on windows/mac builds
+            pytest.skip("GH#45547 causing timeouts on windows/mac builds 2022-01-22")
 
     with tm.ensure_clean("test.csv") as fname:
         Path(fname).write_text("col1,col2\na,b\n1,2")

--- a/pandas/tests/io/parser/test_unsupported.py
+++ b/pandas/tests/io/parser/test_unsupported.py
@@ -177,7 +177,7 @@ def test_close_file_handle_on_invalid_usecols(all_parsers):
     if parser.engine == "pyarrow":
         pyarrow = pytest.importorskip("pyarrow")
         error = pyarrow.lib.ArrowKeyError
-        if is_platform_windows() or is_platform_mac:
+        if is_platform_windows() or is_platform_mac():
             # GH#45547 causes timeouts on windows/mac builds
             pytest.skip("GH#45547 causing timeouts on windows/mac builds 2022-01-22")
 


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/45507

Saw this test hang a process while working on https://github.com/pandas-dev/pandas/pull/45478

```

2022-02-01T23:22:15.3331120Z pandas/tests/io/parser/test_unsupported.py::test_close_file_handle_on_invalid_usecols[c_high] 
2022-02-01T23:22:15.3377730Z [gw0] PASSED pandas/tests/io/parser/test_unsupported.py::test_close_file_handle_on_invalid_usecols[c_high] 
2022-02-01T23:22:15.4241640Z pandas/tests/io/parser/test_unsupported.py::test_close_file_handle_on_invalid_usecols[c_low] 
2022-02-01T23:22:15.6520590Z [gw0] PASSED pandas/tests/io/parser/test_unsupported.py::test_close_file_handle_on_invalid_usecols[c_low] 
2022-02-01T23:22:15.6527280Z pandas/tests/io/parser/test_unsupported.py::test_close_file_handle_on_invalid_usecols[python] 
2022-02-01T23:22:15.6529130Z [gw0] PASSED pandas/tests/io/parser/test_unsupported.py::test_close_file_handle_on_invalid_usecols[python] 
2022-02-01T23:22:16.0842680Z pandas/tests/io/parser/test_unsupported.py::test_close_file_handle_on_invalid_usecols[pyarrow] 
...
2022-02-02T00:20:32.2973430Z ##[error]The operation was canceled.
2022-02-02T00:20:32.3006150Z ##[section]Finishing: Test
```


