### PR TITLE
Fix typo in user guide

### DIFF
--- a/doc/source/user_guide/integer_na.rst
+++ b/doc/source/user_guide/integer_na.rst
@@ -29,7 +29,7 @@ Construction
 ------------
 
 pandas can represent integer data with possibly missing values using
-:class:`arrays.IntegerArray`. This is an :ref:`extension types <extending.extension-types>`
+:class:`arrays.IntegerArray`. This is an :ref:`extension type <extending.extension-types>`
 implemented within pandas.
 
 .. ipython:: python


### PR DESCRIPTION
changed  
"... arrays.IntegerArray. This is an extension types ..." 

to 
"... arrays.IntegerArray. This is an extension type ..."