### PR TITLE
Regression: Loc raising when indexing mi with one level

### DIFF
--- a/doc/source/whatsnew/v1.4.1.rst
+++ b/doc/source/whatsnew/v1.4.1.rst
@@ -16,6 +16,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Regression in :meth:`Series.mask` with ``inplace=True`` and ``PeriodDtype`` and an incompatible ``other`` coercing to a common dtype instead of raising (:issue:`45546`)
 - Regression in :func:`.assert_frame_equal` not respecting ``check_flags=False`` (:issue:`45554`)
+- Regression in :meth:`DataFrame.loc.__getitem__` raising ``ValueError`` when indexing on a :class:`MultiIndex` with one level (:issue:`45779`)
 - Regression in :meth:`Series.fillna` with ``downcast=False`` incorrectly downcasting ``object`` dtype (:issue:`45603`)
 - Regression in :meth:`DataFrame.iat` setting values leading to not propagating correctly in subsequent lookups (:issue:`45684`)
 - Regression when setting values with :meth:`DataFrame.loc` losing :class:`Index` name if :class:`DataFrame` was empty before (:issue:`45621`)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2995,6 +2995,10 @@ class MultiIndex(Index):
 
         # different name to distinguish from maybe_droplevels
         def maybe_mi_droplevels(indexer, levels):
+            """
+            If level does not exist or all levels were dropped, the exception
+            has to be handled outside.
+            """
             new_index = self[indexer]
 
             for i in sorted(levels, reverse=True):

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3128,7 +3128,12 @@ class MultiIndex(Index):
                     # e.g. test_partial_string_timestamp_multiindex
                     return indexer, self[indexer]
 
-            return indexer, maybe_mi_droplevels(indexer, [level])
+            try:
+                result_index = maybe_mi_droplevels(indexer, [level])
+            except ValueError:
+                result_index = self[indexer]
+
+            return indexer, result_index
 
     def _get_level_indexer(
         self, key, level: int = 0, indexer: Int64Index | None = None

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -1546,6 +1546,18 @@ class TestLocILocDataFrameCategorical:
 
         assert ser.index.dtype == object
 
+    def test_loc_on_multiindex_one_level(self):
+        # GH#45779
+        df = DataFrame(
+            data=[[0], [1]],
+            index=MultiIndex.from_tuples([("a",), ("b",)], names=["first"]),
+        )
+        expected = DataFrame(
+            data=[[0]], index=MultiIndex.from_tuples([("a",)], names=["first"])
+        )
+        result = df.loc["a"]
+        tm.assert_frame_equal(result, expected)
+
 
 class TestDepreactedIndexers:
     @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] closes #45779 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

@jbrockmendel You moved the error catching logic out of maybe_mi_droplevels. Is this necessary for one of the other code paths?