### PR TITLE
TST: Skip flaky, crashing test in Windows

### DIFF
--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from datetime import datetime
 from itertools import product
+import os
 
 import numpy as np
 import pytest
@@ -427,7 +428,7 @@ class TestSafeSort:
         tm.assert_numpy_array_equal(result_codes, expected_codes)
 
     @pytest.mark.skipif(
-        is_platform_windows(),
+        is_platform_windows() and os.environ.get("PANDAS_CI", "0") == "1",
         reason="In CI environment can crash thread with: "
         "Windows fatal exception: access violation",
     )

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -5,6 +5,8 @@ from itertools import product
 import numpy as np
 import pytest
 
+from pandas.compat import is_platform_windows
+
 from pandas import (
     DataFrame,
     MultiIndex,
@@ -424,6 +426,11 @@ class TestSafeSort:
         tm.assert_numpy_array_equal(result, expected)
         tm.assert_numpy_array_equal(result_codes, expected_codes)
 
+    @pytest.mark.skipif(
+        is_platform_windows(),
+        reason="In CI environment can crash thread with: "
+        "Windows fatal exception: access violation",
+    )
     @pytest.mark.parametrize("na_sentinel", [-1, 99])
     def test_codes_out_of_bound(self, na_sentinel):
         values = [3, 1, 2, 0, 4]


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Discovered while working on https://github.com/pandas-dev/pandas/pull/45478

Logs: https://dev.azure.com/pandas-dev/e01c9671-576d-40f3-a1a1-7bef78604087/_apis/build/builds/73534/logs/54

```
2022-02-02T19:12:27.1410114Z pandas/tests/test_sorting.py::TestSafeSort::test_codes_out_of_bound[-1] Windows fatal exception: access violation
2022-02-02T19:12:27.1411407Z 
2022-02-02T19:12:27.1414872Z Thread 0x000011cc (most recent call first):
2022-02-02T19:12:27.1417026Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\execnet\gateway_base.py", line 400 in read
2022-02-02T19:12:27.1418547Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\execnet\gateway_base.py", line 432 in from_io
2022-02-02T19:12:27.1420140Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\execnet\gateway_base.py", line 967 in _thread_receiver
2022-02-02T19:12:27.1424677Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\execnet\gateway_base.py", line 220 in run
2022-02-02T19:12:27.1426225Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\execnet\gateway_base.py", line 285 in _perform_spawn
2022-02-02T19:12:27.1427290Z 
2022-02-02T19:12:27.1428448Z Current thread 0x00001088 (most recent call first):
2022-02-02T19:12:27.1434554Z   File "D:\a\1\s\pandas\core\array_algos\take.py", line 163 in _take_nd_ndarray
2022-02-02T19:12:27.1435976Z   File "D:\a\1\s\pandas\core\array_algos\take.py", line 117 in take_nd
2022-02-02T19:12:27.1438483Z   File "D:\a\1\s\pandas\core\algorithms.py", line 1771 in safe_sort
2022-02-02T19:12:27.1441486Z   File "D:\a\1\s\pandas\tests\test_sorting.py", line 434 in test_codes_out_of_bound
2022-02-02T19:12:27.1447616Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\_pytest\python.py", line 183 in pytest_pyfunc_call
2022-02-02T19:12:27.1450037Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\pluggy\_callers.py", line 39 in _multicall
2022-02-02T19:12:27.1455665Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\pluggy\_manager.py", line 80 in _hookexec
2022-02-02T19:12:27.1458131Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\pluggy\_hooks.py", line 265 in __call__
2022-02-02T19:12:27.1461448Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\_pytest\python.py", line 1641 in runtest
2022-02-02T19:12:27.1466555Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\_pytest\runner.py", line 162 in pytest_runtest_call
2022-02-02T19:12:27.1474703Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\pluggy\_callers.py", line 39 in _multicall
2022-02-02T19:12:27.1477211Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\pluggy\_manager.py", line 80 in _hookexec
2022-02-02T19:12:27.1479949Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\pluggy\_hooks.py", line 265 in __call__
2022-02-02T19:12:27.1483707Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\_pytest\runner.py", line 255 in <lambda>
2022-02-02T19:12:27.1487056Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\_pytest\runner.py", line 311 in from_call
2022-02-02T19:12:27.1490846Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\_pytest\runner.py", line 254 in call_runtest_hook
2022-02-02T19:12:27.1496618Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\_pytest\runner.py", line 215 in call_and_report
2022-02-02T19:12:27.1498412Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\_pytest\runner.py", line 126 in runtestprotocol
2022-02-02T19:12:27.1501905Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\_pytest\runner.py", line 109 in pytest_runtest_protocol
2022-02-02T19:12:27.1503892Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\pluggy\_callers.py", line 39 in _multicall
2022-02-02T19:12:27.1505686Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\pluggy\_manager.py", line 80 in _hookexec
2022-02-02T19:12:27.1508520Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\pluggy\_hooks.py", line 265 in __call__
2022-02-02T19:12:27.1515729Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\xdist\remote.py", line 110 in run_one_test
2022-02-02T19:12:27.1517749Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\xdist\remote.py", line 91 in pytest_runtestloop
2022-02-02T19:12:27.1520191Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\pluggy\_callers.py", line 39 in _multicall
2022-02-02T19:12:27.1522404Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\pluggy\_manager.py", line 80 in _hookexec
2022-02-02T19:12:27.1524427Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\pluggy\_hooks.py", line 265 in __call__
2022-02-02T19:12:27.1526201Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\_pytest\main.py", line 323 in _main
2022-02-02T19:12:27.1528352Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\_pytest\main.py", line 269 in wrap_session
2022-02-02T19:12:27.1531223Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\_pytest\main.py", line 316 in pytest_cmdline_main
2022-02-02T19:12:27.1533340Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\pluggy\_callers.py", line 39 in _multicall
2022-02-02T19:12:27.1536051Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\pluggy\_manager.py", line 80 in _hookexec
2022-02-02T19:12:27.1538727Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\pluggy\_hooks.py", line 265 in __call__
2022-02-02T19:12:27.1541284Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\xdist\remote.py", line 291 in <module>
2022-02-02T19:12:27.1543577Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\execnet\gateway_base.py", line 1084 in executetask
2022-02-02T19:12:27.1545576Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\execnet\gateway_base.py", line 220 in run
2022-02-02T19:12:27.1547427Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\execnet\gateway_base.py", line 285 in _perform_spawn
2022-02-02T19:12:27.1549546Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\execnet\gateway_base.py", line 267 in integrate_as_primary_thread
2022-02-02T19:12:27.1553621Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\execnet\gateway_base.py", line 1060 in serve
2022-02-02T19:12:27.1555282Z   File "C:\Miniconda\envs\pandas-dev\lib\site-packages\execnet\gateway_base.py", line 1554 in serve
2022-02-02T19:12:27.1556281Z   File "<string>", line 8 in <module>
2022-02-02T19:12:27.1558066Z   File "<string>", line 1 in <module>
2022-02-02T19:12:27.1604672Z 
2022-02-02T19:12:27.1606666Z [gw0] node down: Not properly terminated
2022-02-02T19:12:27.3719566Z [gw0] FAILED pandas/tests/test_sorting.py::TestSafeSort::test_codes_out_of_bound[-1] 
2022-02-02T19:12:27.3723006Z 
2022-02-02T19:12:27.3724654Z replacing crashed worker gw0
```