### PR TITLE
Backport PR #45784 on branch 1.4.x (Regression: Series.loc.setitem raising with all false indexer and series on rhs)

### DIFF
--- a/doc/source/whatsnew/v1.4.1.rst
+++ b/doc/source/whatsnew/v1.4.1.rst
@@ -20,6 +20,7 @@ Fixed regressions
 - Regression in :meth:`DataFrame.iat` setting values leading to not propagating correctly in subsequent lookups (:issue:`45684`)
 - Regression when setting values with :meth:`DataFrame.loc` losing :class:`Index` name if :class:`DataFrame` was empty before (:issue:`45621`)
 - Regression in :meth:`~Index.join` with overlapping :class:`IntervalIndex` raising an ``InvalidIndexError`` (:issue:`45661`)
+- Regression in :meth:`Series.loc.__setitem__` raising with all ``False`` indexer and :class:`Series` on the right hand side (:issue:`45778`)
 - Regression in :func:`read_sql` with a DBAPI2 connection that is not an instance of ``sqlite3.Connection`` incorrectly requiring SQLAlchemy be installed (:issue:`45660`)
 -
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2078,7 +2078,8 @@ class _iLocIndexer(_LocationIndexer):
             # we have a frame, with multiple indexers on both axes; and a
             # series, so need to broadcast (see GH5206)
             if sum_aligners == self.ndim and all(is_sequence(_) for _ in indexer):
-                if is_empty_indexer(indexer[0], ser._values):
+                # TODO: This is hacky, align Series and DataFrame behavior GH#45778
+                if obj.ndim == 2 and is_empty_indexer(indexer[0], ser._values):
                     return ser._values.copy()
                 ser = ser.reindex(obj.axes[0][indexer[0]], copy=True)._values
 

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -321,6 +321,15 @@ def test_frozenset_index():
     assert s[idx1] == 3
 
 
+def test_loc_setitem_all_false_indexer():
+    # GH#45778
+    ser = Series([1, 2], index=["a", "b"])
+    expected = ser.copy()
+    rhs = Series([6, 7], index=["a", "b"])
+    ser.loc[ser > 100] = rhs
+    tm.assert_series_equal(ser, expected)
+
+
 class TestDepreactedIndexers:
     @pytest.mark.parametrize("key", [{1}, {1: 1}])
     def test_getitem_dict_and_set_deprecated(self, key):


### PR DESCRIPTION
Backport PR #45784