### PR TITLE
TST: add test Index.where infers dtype instead of converting string to float (#32413)

### DIFF
--- a/pandas/tests/indexes/numeric/test_indexing.py
+++ b/pandas/tests/indexes/numeric/test_indexing.py
@@ -424,6 +424,17 @@ class TestWhere:
         result = idx.putmask(~mask, other)
         tm.assert_index_equal(result, expected)
 
+    def test_where_infers_type_instead_of_trying_to_convert_string_to_float(self):
+        # GH 32413
+        index = Index([1, np.nan])
+        cond = index.notna()
+        other = Index(["a", "b"], dtype="string")
+
+        expected = Index([1.0, "b"])
+        result = index.where(cond, other)
+
+        tm.assert_index_equal(result, expected)
+
 
 class TestTake:
     @pytest.mark.parametrize("klass", [Float64Index, Int64Index, UInt64Index])


### PR DESCRIPTION
- [x] closes #32413
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This PR provides a test case for the already fixed problem #32413.

If the test name is not suitable, it would be good if you can suggest a better one.