### PR TITLE
CI/TST: add is_ci_environment to test_close_file_handle_on_invalid_usecols skip

### DIFF
--- a/pandas/tests/io/parser/test_unsupported.py
+++ b/pandas/tests/io/parser/test_unsupported.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from pandas.compat import (
+    is_ci_environment,
     is_platform_mac,
     is_platform_windows,
 )
@@ -177,7 +178,7 @@ def test_close_file_handle_on_invalid_usecols(all_parsers):
     if parser.engine == "pyarrow":
         pyarrow = pytest.importorskip("pyarrow")
         error = pyarrow.lib.ArrowKeyError
-        if is_platform_windows() or is_platform_mac():
+        if is_ci_environment() and (is_platform_windows() or is_platform_mac()):
             # GH#45547 causes timeouts on windows/mac builds
             pytest.skip("GH#45547 causing timeouts on windows/mac builds 2022-01-22")
 


### PR DESCRIPTION
follow-up to #45507 and #45771, xref https://github.com/pandas-dev/pandas/pull/45786#discussion_r798163348