### PR TITLE
Backport PR #45453 on branch 1.4.x (REF: move np_can_hold_element to mgr method)

### DIFF
--- a/pandas/core/internals/base.py
+++ b/pandas/core/internals/base.py
@@ -187,7 +187,7 @@ class SingleDataManager(DataManager):
             #  dt64/td64, which do their own validation.
             value = np_can_hold_element(arr.dtype, value)
 
-        self.array[indexer] = value
+        arr[indexer] = value
 
     def grouped_reduce(self, func, ignore_failures: bool = False):
         """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -62,7 +62,6 @@ from pandas.util._validators import (
 )
 
 from pandas.core.dtypes.cast import (
-    can_hold_element,
     convert_dtypes,
     maybe_box_native,
     maybe_cast_pointwise_result,
@@ -1145,12 +1144,6 @@ class Series(base.IndexOpsMixin, NDFrame):
 
     def _set_with_engine(self, key, value) -> None:
         loc = self.index.get_loc(key)
-        dtype = self.dtype
-        if isinstance(dtype, np.dtype) and dtype.kind not in ["m", "M"]:
-            # otherwise we have EA values, and this check will be done
-            #  via setitem_inplace
-            if not can_hold_element(self._values, value):
-                raise ValueError
 
         # this is equivalent to self._values[key] = value
         self._mgr.setitem_inplace(loc, value)


### PR DESCRIPTION
Backport PR #45453

#45744 includes a partial backport of #45453. xref https://github.com/pandas-dev/pandas/pull/45744#issuecomment-1032546988

This PR is for completeness or alternatively we could remove the parts of #45453 included in #45744 added in https://github.com/pandas-dev/pandas/pull/45744/commits/0464ea8f0f5ec40cfd02394c1a848d1b9e278417 from 1.4.x

cc @jbrockmendel 