### PR TITLE
DOC: restore SciPy intersphinx

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -446,7 +446,7 @@ if include_api:
         "pandas-gbq": ("https://pandas-gbq.readthedocs.io/en/latest/", None),
         "py": ("https://pylib.readthedocs.io/en/latest/", None),
         "python": ("https://docs.python.org/3/", None),
-        "scipy": ("https://docs.scipy.org/doc/scipy-1.7.1/reference/", None),
+        "scipy": ("https://docs.scipy.org/doc/scipy/", None),
         "statsmodels": ("https://www.statsmodels.org/devel/", None),
         "pyarrow": ("https://arrow.apache.org/docs/", None),
     }


### PR DESCRIPTION
See: https://github.com/scipy/scipy/issues/15545#issuecomment-1032825234

Sorry about that--needed some `.htaccess` fixups with our new docs theme.