### PR TITLE
BUG: DateOffset(n) not defaulting to days

### DIFF
--- a/doc/source/whatsnew/v1.4.1.rst
+++ b/doc/source/whatsnew/v1.4.1.rst
@@ -24,7 +24,7 @@ Fixed regressions
 - Regression in :meth:`~Index.join` with overlapping :class:`IntervalIndex` raising an ``InvalidIndexError`` (:issue:`45661`)
 - Regression when setting values with :meth:`Series.loc` raising with all ``False`` indexer and :class:`Series` on the right hand side (:issue:`45778`)
 - Regression in :func:`read_sql` with a DBAPI2 connection that is not an instance of ``sqlite3.Connection`` incorrectly requiring SQLAlchemy be installed (:issue:`45660`)
--
+- Regression in :class:`DateOffset` when constructing with an integer argument with no keywords (e.g. ``pd.DateOffset(n)``) would behave like ``datetime.timedelta(days=0)`` (:issue:`45643`, :issue:`45890`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -333,8 +333,12 @@ cdef _determine_offset(kwds):
         else:
             # sub-daily offset - use timedelta (tz-aware)
             offset = timedelta(**kwds_no_nanos)
+    elif any(nano in kwds for nano in ('nanosecond', 'nanoseconds')):
+        offset = timedelta(days=0)
     else:
-        offset = timedelta(0)
+        # GH 45643/45890: (historically) defaults to 1 day for non-nano
+        # since datetime.timedelta doesn't handle nanoseconds
+        offset = timedelta(days=1)
     return offset, use_relativedelta
 
 
@@ -1223,6 +1227,7 @@ class DateOffset(RelativeDeltaOffset, metaclass=OffsetMeta):
     ----------
     n : int, default 1
         The number of time periods the offset represents.
+        If specified without a temporal pattern, defaults to n days.
     normalize : bool, default False
         Whether to round the result of a DateOffset addition down to the
         previous midnight.

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -854,3 +854,13 @@ def test_dateoffset_misc():
     oset.freqstr
 
     assert not offsets.DateOffset(months=2) == 2
+
+
+@pytest.mark.parametrize("n", [-1, 1, 3])
+def test_construct_int_arg_no_kwargs_assumed_days(n):
+    # GH 45890, 45643
+    offset = DateOffset(n)
+    assert offset._offset == timedelta(1)
+    result = Timestamp(2022, 1, 2) + offset
+    expected = Timestamp(2022, 1, 2 + n)
+    assert result == expected


### PR DESCRIPTION
- [x] closes #45890 (Replace xxxx with the Github issue number)
- [x] closes #45643
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Regression from 1.3.5