### PR TITLE
DO NOT MERGE: Testing if benchmarks build is slow with latest asv

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - pytz
 
   # benchmarks
-  - asv < 0.5.0  # 2022-02-08: v0.5.0 > leads to ASV checks running > 3 hours on CI
+  - asv
 
   # building
   # The compiler packages are meta-packages and install the correct compiler (activation) packages on the respective platforms.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 numpy>=1.18.5
 python-dateutil>=2.8.1
 pytz
-asv < 0.5.0
+asv
 cython>=0.29.24
 black==21.5b2
 cpplint


### PR DESCRIPTION
xref https://github.com/airspeed-velocity/asv/issues/1026 #44450

We pinned asv in #45886 since the benchmarks build took a very long time to complete after the release.

Testing here if this is consistent, and can be reproduced, or if it was something that happened just once.

CC: @LucyJimenez