### PR TITLE
BUG: Fix implementation of temp_setattr

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -545,8 +545,10 @@ def temp_setattr(obj, attr: str, value) -> Iterator[None]:
     """
     old_value = getattr(obj, attr)
     setattr(obj, attr, value)
-    yield obj
-    setattr(obj, attr, old_value)
+    try:
+        yield obj
+    finally:
+        setattr(obj, attr, old_value)
 
 
 def require_length_match(data, index: Index):

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -220,13 +220,12 @@ def test_temp_setattr(with_exception):
     # GH#45954
     ser = Series(dtype=object)
     ser.name = "first"
-    try:
+    # Raise a ValueError in either case to satisfy pytest.raises
+    match = "Inside exception raised" if with_exception else "Outside exception raised"
+    with pytest.raises(ValueError, match=match):
         with com.temp_setattr(ser, "name", "second"):
             assert ser.name == "second"
             if with_exception:
-                raise ValueError("Exception raised")
-        assert ser.name == "first"
-    except ValueError:
-        pass
-
+                raise ValueError("Inside exception raised")
+        raise ValueError("Outside exception raised")
     assert ser.name == "first"

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -217,6 +217,7 @@ class TestIsBoolIndexer:
 
 @pytest.mark.parametrize("with_exception", [True, False])
 def test_temp_setattr(with_exception):
+    # GH#45954
     ser = Series()
     ser.name = "first"
     try:

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -218,7 +218,7 @@ class TestIsBoolIndexer:
 @pytest.mark.parametrize("with_exception", [True, False])
 def test_temp_setattr(with_exception):
     # GH#45954
-    ser = Series()
+    ser = Series(dtype=object)
     ser.name = "first"
     try:
         with com.temp_setattr(ser, "name", "second"):

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -213,3 +213,19 @@ class TestIsBoolIndexer:
         result = df[frozen]
         expected = df[[]]
         tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("with_exception", [True, False])
+def test_temp_setattr(with_exception):
+    ser = Series()
+    ser.name = "first"
+    try:
+        with com.temp_setattr(ser, "name", "second"):
+            assert ser.name == "second"
+            if with_exception:
+                raise ValueError("Exception raised")
+        assert ser.name == "first"
+    except ValueError:
+        pass
+
+    assert ser.name == "first"


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Doesn't fix any user-facing bug (at least, that I'm aware of), but the current implementation will not restore the original attribute if an exception is raised within the context manager.