### PR TITLE
REGR: drop raising with ea index and duplicates

### DIFF
--- a/doc/source/whatsnew/v1.4.2.rst
+++ b/doc/source/whatsnew/v1.4.2.rst
@@ -14,7 +14,7 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
--
+- Fixed regression in :meth:`DataFrame.drop` and :meth:`Series.drop` when :class:`Index` had extension dtype and duplicates (:issue:`45820`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4342,6 +4342,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 if errors == "raise" and labels_missing:
                     raise KeyError(f"{labels} not found in axis")
 
+            if is_extension_array_dtype(mask.dtype):
+                mask = mask.to_numpy()
+
             indexer = mask.nonzero()[0]
             new_axis = axis.take(indexer)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4343,7 +4343,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                     raise KeyError(f"{labels} not found in axis")
 
             if is_extension_array_dtype(mask.dtype):
-                mask = mask.to_numpy()
+                # GH#45860
+                mask = mask.to_numpy(dtype=bool)
 
             indexer = mask.nonzero()[0]
             new_axis = axis.take(indexer)

--- a/pandas/tests/frame/methods/test_drop.py
+++ b/pandas/tests/frame/methods/test_drop.py
@@ -544,8 +544,8 @@ class TestDataFrameDrop:
         df = DataFrame(
             {"a": [1, 2, 2, pd.NA], "b": 100}, dtype=any_numeric_ea_dtype
         ).set_index(idx)
-        result = df.drop(Index([2]), level=level)
+        result = df.drop(Index([2, pd.NA]), level=level)
         expected = DataFrame(
-            {"a": [1, pd.NA], "b": 100}, dtype=any_numeric_ea_dtype
+            {"a": [1], "b": 100}, dtype=any_numeric_ea_dtype
         ).set_index(idx)
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/methods/test_drop.py
+++ b/pandas/tests/frame/methods/test_drop.py
@@ -537,3 +537,15 @@ class TestDataFrameDrop:
         df = DataFrame(index=MultiIndex.from_product([range(3), range(3)]))
         with pytest.raises(KeyError, match="labels \\[5\\] not found in level"):
             df.drop(5, level=0)
+
+    @pytest.mark.parametrize("idx, level", [(["a", "b"], 0), (["a"], None)])
+    def test_drop_index_ea_dtype(self, any_numeric_ea_dtype, idx, level):
+        # GH#45860
+        df = DataFrame(
+            {"a": [1, 2, 2], "b": 100}, dtype=any_numeric_ea_dtype
+        ).set_index(idx)
+        result = df.drop(Index([2]), level=level)
+        expected = DataFrame(
+            {"a": [1], "b": 100}, dtype=any_numeric_ea_dtype
+        ).set_index(idx)
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/methods/test_drop.py
+++ b/pandas/tests/frame/methods/test_drop.py
@@ -542,10 +542,10 @@ class TestDataFrameDrop:
     def test_drop_index_ea_dtype(self, any_numeric_ea_dtype, idx, level):
         # GH#45860
         df = DataFrame(
-            {"a": [1, 2, 2], "b": 100}, dtype=any_numeric_ea_dtype
+            {"a": [1, 2, 2, pd.NA], "b": 100}, dtype=any_numeric_ea_dtype
         ).set_index(idx)
         result = df.drop(Index([2]), level=level)
         expected = DataFrame(
-            {"a": [1], "b": 100}, dtype=any_numeric_ea_dtype
+            {"a": [1, pd.NA], "b": 100}, dtype=any_numeric_ea_dtype
         ).set_index(idx)
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/series/methods/test_drop.py
+++ b/pandas/tests/series/methods/test_drop.py
@@ -1,6 +1,9 @@
 import pytest
 
-from pandas import Series
+from pandas import (
+    Index,
+    Series,
+)
 import pandas._testing as tm
 
 
@@ -97,4 +100,13 @@ def test_drop_pos_args_deprecation():
     with tm.assert_produces_warning(FutureWarning, match=msg):
         result = ser.drop(1, 0)
     expected = Series([1, 3], index=[0, 2])
+    tm.assert_series_equal(result, expected)
+
+
+def test_drop_index_ea_dtype(any_numeric_ea_dtype):
+    # GH#45860
+    df = Series(100, index=Index([1, 2, 2], dtype=any_numeric_ea_dtype))
+    idx = Index([df.index[1]])
+    result = df.drop(idx)
+    expected = Series(100, index=Index([1], dtype=any_numeric_ea_dtype))
     tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #45860 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

We handle this case similarly for loc