### PR TITLE
Removed broken link from NDFrame#interpolate docs.

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6871,7 +6871,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         For more information on their behavior, see the
         `SciPy documentation
         <https://docs.scipy.org/doc/scipy/reference/interpolate.html#univariate-interpolation>`__.
-        
+
         Examples
         --------
         Filling in ``NaN`` in a :class:`~pandas.Series` via linear

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6870,10 +6870,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         similar names. These use the actual numerical values of the index.
         For more information on their behavior, see the
         `SciPy documentation
-        <https://docs.scipy.org/doc/scipy/reference/interpolate.html#univariate-interpolation>`__
-        and `SciPy tutorial
-        <https://docs.scipy.org/doc/scipy/reference/tutorial/interpolate.html>`__.
-
+        <https://docs.scipy.org/doc/scipy/reference/interpolate.html#univariate-interpolation>`__.
+        
         Examples
         --------
         Filling in ``NaN`` in a :class:`~pandas.Series` via linear


### PR DESCRIPTION
The link at https://docs.scipy.org/doc/scipy/reference/tutorial/interpolate.html pointing to the SciPy Interpolation tutorial is broken. An alternative tutorial was not found in the new documentation.

- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
