### PR TITLE
Pandas pivot_table MultiIndex and dropna=False generates all combinations of modalities instead of keeping existing one only

### DIFF
--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -203,32 +203,12 @@ def __internal_pivot_table(
                 to_unstack.append(name)
         table = agged.unstack(to_unstack)
 
-    # BEGIN Issue #18030
-    # Commenting these lines in view of #18030.
-    # The cartesian product makes little sense and deprecation of this behaviour should be considered.
-    # It is unexpected that a pivot operation returns a larger index than is given.
-    # Secondly, this behaviour was never documented. The documentation says
-    #
-    # dropna:bool, default True
-    #
-    #   Do not include columns whose entries are all NaN.
-    #
-    # However the code below creates rows.
-
-    # if not dropna:
-    #     if isinstance(table.index, MultiIndex):
-    #         m = MultiIndex.from_arrays(
-    #             cartesian_product(table.index.levels), names=table.index.names
-    #         )
-    #         table = table.reindex(m, axis=0)
-    #
-    #     if isinstance(table.columns, MultiIndex):
-    #         m = MultiIndex.from_arrays(
-    #             cartesian_product(table.columns.levels), names=table.columns.names
-    #         )
-    #         table = table.reindex(m, axis=1)
-
-    # END Issue #18030
+    if not dropna:
+        if isinstance(table.columns, MultiIndex):
+            m = MultiIndex.from_arrays(
+                cartesian_product(table.columns.levels), names=table.columns.names
+            )
+            table = table.reindex(m, axis=1)
 
     if isinstance(table, ABCDataFrame):
         table = table.sort_index(axis=1)

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -203,18 +203,32 @@ def __internal_pivot_table(
                 to_unstack.append(name)
         table = agged.unstack(to_unstack)
 
-    if not dropna:
-        if isinstance(table.index, MultiIndex):
-            m = MultiIndex.from_arrays(
-                cartesian_product(table.index.levels), names=table.index.names
-            )
-            table = table.reindex(m, axis=0)
+    # BEGIN Issue #18030
+    # Commenting these lines in view of #18030.
+    # The cartesian product makes little sense and deprecation of this behaviour should be considered.
+    # It is unexpected that a pivot operation returns a larger index than is given.
+    # Secondly, this behaviour was never documented. The documentation says
+    #
+    # dropna:bool, default True
+    #
+    #   Do not include columns whose entries are all NaN.
+    #
+    # However the code below creates rows.
 
-        if isinstance(table.columns, MultiIndex):
-            m = MultiIndex.from_arrays(
-                cartesian_product(table.columns.levels), names=table.columns.names
-            )
-            table = table.reindex(m, axis=1)
+    # if not dropna:
+    #     if isinstance(table.index, MultiIndex):
+    #         m = MultiIndex.from_arrays(
+    #             cartesian_product(table.index.levels), names=table.index.names
+    #         )
+    #         table = table.reindex(m, axis=0)
+    #
+    #     if isinstance(table.columns, MultiIndex):
+    #         m = MultiIndex.from_arrays(
+    #             cartesian_product(table.columns.levels), names=table.columns.names
+    #         )
+    #         table = table.reindex(m, axis=1)
+
+    # END Issue #18030
 
     if isinstance(table, ABCDataFrame):
         table = table.sort_index(axis=1)


### PR DESCRIPTION
- [ ] closes #18030

There was already another proposed fix #28540 which never concluded. I propose a more straightforward solution to simply deprecate the current behaviour, for the following reasons:

- The current behaviour was never documented. [`pivot_table`](https://pandas.pydata.org/docs/reference/api/pandas.pivot_table.html) says:
   -  dropna: bool, default True: Do not include columns whose entries are all NaN.
   - However the deprecated behaviour is about adding rows.
- In the discussion of #18030 no one could explain the purpose of the Cartesian product, and it is unlogical, there is no case where `pivot_table` should return more rows than what is given by the index input, if `index`, `columns` and `values` are all strict, pairwise disjoint subsets of the original tables columns+index-columns.

If one calls `df.pivot_table(index=df.index.names, columns=..., values=..., dropna=False)`, it currently creates a table with `product(df.index.names)` many rows. However, the documentation specifies for the input `index`:

> If an array is passed, it must be the same length as the data. The list can contain any of the other types (except list). Keys to group by on the pivot table index. If an array is passed, it is being used as the same manner as column values

Which of course is a bit self-contradictory, but the gist is: if `len(index)=len(values)`, then use `index` as the new index, else, use the columns looked up via `df[index]`. This documented behaviour is violated by the current, unlogical behaviour when `dropna=False`