### PR TITLE
BUG: PeriodArray subtraction returning wrong results

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -358,7 +358,7 @@ I/O
 
 Period
 ^^^^^^
--
+- Bug in subtraction of :class:`Period` from :class:`PeriodArray` returning wrong results (:issue:`45999`)
 -
 
 Plotting

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -710,7 +710,7 @@ class PeriodArray(dtl.DatelikeOps):
         self._check_compatible_with(other)
         asi8 = self.asi8
         new_data = asi8 - other.ordinal
-        new_data = np.array([self.freq * x for x in new_data])
+        new_data = np.array([self.freq.base * x for x in new_data])
 
         if self._hasna:
             new_data[self._isnan] = NaT

--- a/pandas/tests/extension/test_period.py
+++ b/pandas/tests/extension/test_period.py
@@ -25,9 +25,9 @@ from pandas.core.arrays import PeriodArray
 from pandas.tests.extension import base
 
 
-@pytest.fixture
-def dtype():
-    return PeriodDtype(freq="D")
+@pytest.fixture(params=["D", "2D"])
+def dtype(request):
+    return PeriodDtype(freq=request.param)
 
 
 @pytest.fixture


### PR DESCRIPTION
- [x] closes #45999 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
