### PR TITLE
DEPR: groupby nuisance warnings

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1105,7 +1105,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
     def _cython_transform(
         self,
         how: str,
-        numeric_only: bool | lib.no_default = lib.no_default,
+        numeric_only: bool | lib.NoDefault = lib.no_default,
         axis: int = 0,
         **kwargs,
     ) -> DataFrame:

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1494,7 +1494,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
     @final
     def _agg_general(
         self,
-        numeric_only: bool | lib.no_default = True,
+        numeric_only: bool | lib.NoDefault = True,
         min_count: int = -1,
         *,
         alias: str,
@@ -1556,7 +1556,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         self,
         how: str,
         alt: Callable,
-        numeric_only: bool | lib.no_default,
+        numeric_only: bool | lib.NoDefault,
         min_count: int = -1,
     ):
         # Note: we never get here with how="ohlc" for DataFrameGroupBy;
@@ -1988,9 +1988,10 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         Series or DataFrame
             Median of values within each group.
         """
+        numeric_only_bool = self._resolve_numeric_only(numeric_only)
         result = self._cython_agg_general(
             "median",
-            alt=lambda x: Series(x).median(numeric_only=numeric_only),
+            alt=lambda x: Series(x).median(numeric_only=numeric_only_bool),
             numeric_only=numeric_only,
         )
         return result.__finalize__(self.obj, method="groupby")

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -3928,6 +3928,9 @@ def _insert_quantile_level(idx: Index, qs: npt.NDArray[np.float64]) -> MultiInde
 
 
 def warn_dropping_nuisance_columns_deprecated(cls, how: str) -> None:
+    if how == "add":
+        # groupby internally uses "add" instead of "sum" in some places
+        how = "sum"
     warnings.warn(
         "Dropping invalid columns in "
         f"{cls.__name__}.{how} is deprecated. "

--- a/pandas/tests/extension/base/groupby.py
+++ b/pandas/tests/extension/base/groupby.py
@@ -96,7 +96,8 @@ class BaseGroupbyTests(BaseExtensionTests):
                 "C": [1, 1, 1, 1, 1, 1, 1, 1],
             }
         )
-        result = df.groupby("A").sum().columns
+        with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+            result = df.groupby("A").sum().columns
 
         if data_for_grouping.dtype._is_numeric:
             expected = pd.Index(["B", "C"])

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -1777,7 +1777,8 @@ Thu,Lunch,Yes,51.51,17"""
         multi = df.set_index(["DATE", "ID"])
         multi.columns.name = "Params"
         unst = multi.unstack("ID")
-        down = unst.resample("W-THU").mean()
+        with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+            down = unst.resample("W-THU").mean()
 
         rs = down.stack("ID")
         xp = unst.loc[:, ["VAR1"]].resample("W-THU").mean().stack("ID")

--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -71,7 +71,8 @@ class TestDataFrame:
                 "D": np.random.randn(8),
             }
         )
-        result = df.groupby("A").sum()
+        with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+            result = df.groupby("A").sum()
         tm.assert_metadata_equivalent(df, result)
 
     def test_metadata_propagation_indiv_resample(self):

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -103,7 +103,8 @@ def test_basic():  # TODO: split this test
     gb = df.groupby("A", observed=False)
     exp_idx = CategoricalIndex(["a", "b", "z"], name="A", ordered=True)
     expected = DataFrame({"values": Series([3, 7, 0], index=exp_idx)})
-    result = gb.sum()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = gb.sum()
     tm.assert_frame_equal(result, expected)
 
     # GH 8623
@@ -344,7 +345,8 @@ def test_observed(observed):
     gb = df.groupby(["A", "B"], observed=observed)
     exp_index = MultiIndex.from_arrays([cat1, cat2], names=["A", "B"])
     expected = DataFrame({"values": [1, 2, 3, 4]}, index=exp_index)
-    result = gb.sum()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = gb.sum()
     if not observed:
         expected = cartesian_product_for_groupers(
             expected, [cat1, cat2], list("AB"), fill_value=0

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -807,8 +807,11 @@ def test_preserve_categorical_dtype():
         }
     )
     for col in ["C1", "C2"]:
-        result1 = df.groupby(by=col, as_index=False, observed=False).mean()
-        result2 = df.groupby(by=col, as_index=True, observed=False).mean().reset_index()
+        with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+            result1 = df.groupby(by=col, as_index=False, observed=False).mean()
+            result2 = (
+                df.groupby(by=col, as_index=True, observed=False).mean().reset_index()
+            )
         expected = exp_full.reindex(columns=result1.columns)
         tm.assert_frame_equal(result1, expected)
         tm.assert_frame_equal(result2, expected)

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -258,6 +258,8 @@ class TestNumericOnly:
         elif method in ["min", "max"]:
             # these have numeric_only kwarg, but default to False
             warn = FutureWarning
+        elif method in ["mean", "median", "prod", "cumprod", "sum", "cumsum"]:
+            warn = FutureWarning
 
         with tm.assert_produces_warning(warn, match="Dropping invalid columns"):
             result = getattr(gb, method)()

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -668,8 +668,9 @@ def test_groupby_as_index_agg(df):
     tm.assert_frame_equal(result, expected)
 
     result2 = grouped.agg({"C": np.mean, "D": np.sum})
-    expected2 = grouped.mean()
-    expected2["D"] = grouped.sum()["D"]
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        expected2 = grouped.mean()
+        expected2["D"] = grouped.sum()["D"]
     tm.assert_frame_equal(result2, expected2)
 
     grouped = df.groupby("A", as_index=True)
@@ -762,7 +763,8 @@ def test_as_index_series_return_frame(df):
     tm.assert_frame_equal(result2, expected2)
 
     result = grouped["C"].sum()
-    expected = grouped.sum().loc[:, ["A", "C"]]
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        expected = grouped.sum().loc[:, ["A", "C"]]
     assert isinstance(result, DataFrame)
     tm.assert_frame_equal(result, expected)
 
@@ -916,8 +918,9 @@ def test_omit_nuisance_warnings(df):
 def test_omit_nuisance_python_multiple(three_group):
     grouped = three_group.groupby(["A", "B"])
 
-    agged = grouped.agg(np.mean)
-    exp = grouped.mean()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        agged = grouped.agg(np.mean)
+        exp = grouped.mean()
     tm.assert_frame_equal(agged, exp)
 
 
@@ -934,8 +937,9 @@ def test_empty_groups_corner(mframe):
     )
 
     grouped = df.groupby(["k1", "k2"])
-    result = grouped.agg(np.mean)
-    expected = grouped.mean()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = grouped.agg(np.mean)
+        expected = grouped.mean()
     tm.assert_frame_equal(result, expected)
 
     grouped = mframe[3:5].groupby(level=0)
@@ -957,7 +961,8 @@ def test_wrap_aggregated_output_multindex(mframe):
     df["baz", "two"] = "peekaboo"
 
     keys = [np.array([0, 0, 1]), np.array([0, 0, 1])]
-    agged = df.groupby(keys).agg(np.mean)
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        agged = df.groupby(keys).agg(np.mean)
     assert isinstance(agged.columns, MultiIndex)
 
     def aggfun(ser):
@@ -1118,15 +1123,17 @@ def test_groupby_with_hier_columns():
     # add a nuisance column
     sorted_columns, _ = columns.sortlevel(0)
     df["A", "foo"] = "bar"
-    result = df.groupby(level=0).mean()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = df.groupby(level=0).mean()
     tm.assert_index_equal(result.columns, df.columns[:-1])
 
 
 def test_grouping_ndarray(df):
     grouped = df.groupby(df["A"].values)
 
-    result = grouped.sum()
-    expected = df.groupby("A").sum()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = grouped.sum()
+        expected = df.groupby("A").sum()
     tm.assert_frame_equal(
         result, expected, check_names=False
     )  # Note: no names when grouping by value
@@ -1154,13 +1161,15 @@ def test_groupby_wrong_multi_labels():
 
 
 def test_groupby_series_with_name(df):
-    result = df.groupby(df["A"]).mean()
-    result2 = df.groupby(df["A"], as_index=False).mean()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = df.groupby(df["A"]).mean()
+        result2 = df.groupby(df["A"], as_index=False).mean()
     assert result.index.name == "A"
     assert "A" in result2
 
-    result = df.groupby([df["A"], df["B"]]).mean()
-    result2 = df.groupby([df["A"], df["B"]], as_index=False).mean()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = df.groupby([df["A"], df["B"]]).mean()
+        result2 = df.groupby([df["A"], df["B"]], as_index=False).mean()
     assert result.index.names == ("A", "B")
     assert "A" in result2
     assert "B" in result2
@@ -1306,8 +1315,9 @@ def test_groupby_unit64_float_conversion():
 
 
 def test_groupby_list_infer_array_like(df):
-    result = df.groupby(list(df["A"])).mean()
-    expected = df.groupby(df["A"]).mean()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = df.groupby(list(df["A"])).mean()
+        expected = df.groupby(df["A"]).mean()
     tm.assert_frame_equal(result, expected, check_names=False)
 
     with pytest.raises(KeyError, match=r"^'foo'$"):
@@ -1420,7 +1430,8 @@ def test_groupby_2d_malformed():
     d["zeros"] = [0, 0]
     d["ones"] = [1, 1]
     d["label"] = ["l1", "l2"]
-    tmp = d.groupby(["group"]).mean()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        tmp = d.groupby(["group"]).mean()
     res_values = np.array([[0.0, 1.0], [0.0, 1.0]])
     tm.assert_index_equal(tmp.columns, Index(["zeros", "ones"]))
     tm.assert_numpy_array_equal(tmp.values, res_values)
@@ -1586,10 +1597,12 @@ def test_group_name_available_in_inference_pass():
 
 def test_no_dummy_key_names(df):
     # see gh-1291
-    result = df.groupby(df["A"].values).sum()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = df.groupby(df["A"].values).sum()
     assert result.index.name is None
 
-    result = df.groupby([df["A"].values, df["B"].values]).sum()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = df.groupby([df["A"].values, df["B"].values]).sum()
     assert result.index.names == (None, None)
 
 
@@ -2566,7 +2579,8 @@ def test_groupby_aggregation_numeric_with_non_numeric_dtype():
     )
 
     gb = df.groupby(by=["x"])
-    result = gb.sum()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = gb.sum()
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -473,13 +473,16 @@ def test_frame_groupby_columns(tsframe):
 def test_frame_set_name_single(df):
     grouped = df.groupby("A")
 
-    result = grouped.mean()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = grouped.mean()
     assert result.index.name == "A"
 
-    result = df.groupby("A", as_index=False).mean()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = df.groupby("A", as_index=False).mean()
     assert result.index.name != "A"
 
-    result = grouped.agg(np.mean)
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = grouped.agg(np.mean)
     assert result.index.name == "A"
 
     result = grouped.agg({"C": np.mean, "D": np.std})
@@ -502,7 +505,8 @@ def test_multi_func(df):
     col2 = df["B"]
 
     grouped = df.groupby([col1.get, col2.get])
-    agged = grouped.mean()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        agged = grouped.mean()
     expected = df.groupby(["A", "B"]).mean()
 
     # TODO groupby get drops names
@@ -658,8 +662,9 @@ def test_groupby_as_index_agg(df):
 
     # single-key
 
-    result = grouped.agg(np.mean)
-    expected = grouped.mean()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = grouped.agg(np.mean)
+        expected = grouped.mean()
     tm.assert_frame_equal(result, expected)
 
     result2 = grouped.agg({"C": np.mean, "D": np.sum})
@@ -746,7 +751,8 @@ def test_as_index_series_return_frame(df):
     grouped2 = df.groupby(["A", "B"], as_index=False)
 
     result = grouped["C"].agg(np.sum)
-    expected = grouped.agg(np.sum).loc[:, ["A", "C"]]
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        expected = grouped.agg(np.sum).loc[:, ["A", "C"]]
     assert isinstance(result, DataFrame)
     tm.assert_frame_equal(result, expected)
 
@@ -780,8 +786,9 @@ def test_groupby_as_index_cython(df):
 
     # single-key
     grouped = data.groupby("A", as_index=False)
-    result = grouped.mean()
-    expected = data.groupby(["A"]).mean()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = grouped.mean()
+        expected = data.groupby(["A"]).mean()
     expected.insert(0, "A", expected.index)
     expected.index = np.arange(len(expected))
     tm.assert_frame_equal(result, expected)
@@ -850,15 +857,17 @@ def test_groupby_multi_corner(df):
 
 def test_omit_nuisance(df):
     grouped = df.groupby("A")
-    agged = grouped.agg(np.mean)
-    exp = grouped.mean()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        agged = grouped.agg(np.mean)
+        exp = grouped.mean()
     tm.assert_frame_equal(agged, exp)
 
     df = df.loc[:, ["A", "C", "D"]]
     df["E"] = datetime.now()
     grouped = df.groupby("A")
-    result = grouped.agg(np.sum)
-    expected = grouped.sum()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = grouped.agg(np.sum)
+        expected = grouped.sum()
     tm.assert_frame_equal(result, expected)
 
     # won't work with axis = 1
@@ -889,7 +898,8 @@ def test_keep_nuisance_agg(df, agg_function):
 def test_omit_nuisance_agg(df, agg_function):
     # GH 38774, GH 38815
     grouped = df.groupby("A")
-    result = getattr(grouped, agg_function)()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = getattr(grouped, agg_function)()
     expected = getattr(df.loc[:, ["A", "C", "D"]].groupby("A"), agg_function)()
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/groupby/test_groupby_subclass.py
+++ b/pandas/tests/groupby/test_groupby_subclass.py
@@ -109,5 +109,6 @@ def test_groupby_resample_preserves_subclass(obj):
     df = df.set_index("Date")
 
     # Confirm groupby.resample() preserves dataframe type
-    result = df.groupby("Buyer").resample("5D").sum()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = df.groupby("Buyer").resample("5D").sum()
     assert isinstance(result, obj)

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -59,8 +59,9 @@ class TestSelection:
         tm.assert_series_equal(result, expected)
 
         df["mean"] = 1.5
-        result = df.groupby("A").mean()
-        expected = df.groupby("A").agg(np.mean)
+        with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+            result = df.groupby("A").mean()
+            expected = df.groupby("A").agg(np.mean)
         tm.assert_frame_equal(result, expected)
 
     def test_getitem_list_of_columns(self):
@@ -284,25 +285,29 @@ class TestGrouping:
             {"A": np.arange(6), "B": ["one", "one", "two", "two", "one", "one"]},
             index=idx,
         )
-        result = df_multi.groupby(["B", pd.Grouper(level="inner")]).mean()
-        expected = df_multi.reset_index().groupby(["B", "inner"]).mean()
+        with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+            result = df_multi.groupby(["B", pd.Grouper(level="inner")]).mean()
+            expected = df_multi.reset_index().groupby(["B", "inner"]).mean()
         tm.assert_frame_equal(result, expected)
 
         # Test the reverse grouping order
-        result = df_multi.groupby([pd.Grouper(level="inner"), "B"]).mean()
-        expected = df_multi.reset_index().groupby(["inner", "B"]).mean()
+        with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+            result = df_multi.groupby([pd.Grouper(level="inner"), "B"]).mean()
+            expected = df_multi.reset_index().groupby(["inner", "B"]).mean()
         tm.assert_frame_equal(result, expected)
 
         # Grouping a single-index frame by a column and the index should
         # be equivalent to resetting the index and grouping by two columns
         df_single = df_multi.reset_index("outer")
-        result = df_single.groupby(["B", pd.Grouper(level="inner")]).mean()
-        expected = df_single.reset_index().groupby(["B", "inner"]).mean()
+        with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+            result = df_single.groupby(["B", pd.Grouper(level="inner")]).mean()
+            expected = df_single.reset_index().groupby(["B", "inner"]).mean()
         tm.assert_frame_equal(result, expected)
 
         # Test the reverse grouping order
-        result = df_single.groupby([pd.Grouper(level="inner"), "B"]).mean()
-        expected = df_single.reset_index().groupby(["inner", "B"]).mean()
+        with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+            result = df_single.groupby([pd.Grouper(level="inner"), "B"]).mean()
+            expected = df_single.reset_index().groupby(["inner", "B"]).mean()
         tm.assert_frame_equal(result, expected)
 
     def test_groupby_levels_and_columns(self):
@@ -376,8 +381,9 @@ class TestGrouping:
     def test_groupby_grouper(self, df):
         grouped = df.groupby("A")
 
-        result = df.groupby(grouped.grouper).mean()
-        expected = grouped.mean()
+        with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+            result = df.groupby(grouped.grouper).mean()
+            expected = grouped.mean()
         tm.assert_frame_equal(result, expected)
 
     def test_groupby_dict_mapping(self):

--- a/pandas/tests/groupby/test_index_as_string.py
+++ b/pandas/tests/groupby/test_index_as_string.py
@@ -47,8 +47,9 @@ def series():
     ],
 )
 def test_grouper_index_level_as_string(frame, key_strs, groupers):
-    result = frame.groupby(key_strs).mean()
-    expected = frame.groupby(groupers).mean()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = frame.groupby(key_strs).mean()
+        expected = frame.groupby(groupers).mean()
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/groupby/test_pipe.py
+++ b/pandas/tests/groupby/test_pipe.py
@@ -65,7 +65,8 @@ def test_pipe_args():
     def h(df, arg3):
         return df.x + df.y - arg3
 
-    result = df.groupby("group").pipe(f, 0).pipe(g, 10).pipe(h, 100)
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = df.groupby("group").pipe(f, 0).pipe(g, 10).pipe(h, 100)
 
     # Assert the results here
     index = Index(["A", "B", "C"], name="group")

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -105,14 +105,17 @@ class TestGroupBy:
             )
             expected.iloc[[0, 6, 18], 0] = np.array([24, 6, 9], dtype="int64")
 
-            result1 = df.resample("5D").sum()
+            with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+                result1 = df.resample("5D").sum()
             tm.assert_frame_equal(result1, expected)
 
             df_sorted = df.sort_index()
-            result2 = df_sorted.groupby(Grouper(freq="5D")).sum()
+            with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+                result2 = df_sorted.groupby(Grouper(freq="5D")).sum()
             tm.assert_frame_equal(result2, expected)
 
-            result3 = df.groupby(Grouper(freq="5D")).sum()
+            with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+                result3 = df.groupby(Grouper(freq="5D")).sum()
             tm.assert_frame_equal(result3, expected)
 
     @pytest.mark.parametrize("should_sort", [True, False])
@@ -186,7 +189,8 @@ class TestGroupBy:
                 }
             ).set_index(["Date", "Buyer"])
 
-            result = df.groupby([Grouper(freq="A"), "Buyer"]).sum()
+            with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+                result = df.groupby([Grouper(freq="A"), "Buyer"]).sum()
             tm.assert_frame_equal(result, expected)
 
             expected = DataFrame(
@@ -201,7 +205,8 @@ class TestGroupBy:
                     ],
                 }
             ).set_index(["Date", "Buyer"])
-            result = df.groupby([Grouper(freq="6MS"), "Buyer"]).sum()
+            with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+                result = df.groupby([Grouper(freq="6MS"), "Buyer"]).sum()
             tm.assert_frame_equal(result, expected)
 
         df_original = DataFrame(
@@ -239,10 +244,12 @@ class TestGroupBy:
                 }
             ).set_index(["Date", "Buyer"])
 
-            result = df.groupby([Grouper(freq="1D"), "Buyer"]).sum()
+            with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+                result = df.groupby([Grouper(freq="1D"), "Buyer"]).sum()
             tm.assert_frame_equal(result, expected)
 
-            result = df.groupby([Grouper(freq="1M"), "Buyer"]).sum()
+            with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+                result = df.groupby([Grouper(freq="1M"), "Buyer"]).sum()
             expected = DataFrame(
                 {
                     "Buyer": "Carl Joe Mark".split(),
@@ -258,11 +265,15 @@ class TestGroupBy:
 
             # passing the name
             df = df.reset_index()
-            result = df.groupby([Grouper(freq="1M", key="Date"), "Buyer"]).sum()
+            with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+                result = df.groupby([Grouper(freq="1M", key="Date"), "Buyer"]).sum()
             tm.assert_frame_equal(result, expected)
 
-            with pytest.raises(KeyError, match="'The grouper name foo is not found'"):
-                df.groupby([Grouper(freq="1M", key="foo"), "Buyer"]).sum()
+            with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+                with pytest.raises(
+                    KeyError, match="'The grouper name foo is not found'"
+                ):
+                    df.groupby([Grouper(freq="1M", key="foo"), "Buyer"]).sum()
 
             # passing the level
             df = df.set_index("Date")

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -88,9 +88,9 @@ def test_groupby_resample_on_api():
         }
     )
 
-    expected = df.set_index("dates").groupby("key").resample("D").mean()
-
-    result = df.groupby("key").resample("D", on="dates").mean()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        expected = df.set_index("dates").groupby("key").resample("D").mean()
+        result = df.groupby("key").resample("D", on="dates").mean()
     tm.assert_frame_equal(result, expected)
 
 
@@ -169,7 +169,8 @@ def tests_skip_nuisance(test_frame):
     tm.assert_frame_equal(result, expected)
 
     expected = r[["A", "B", "C"]].sum()
-    result = r.sum()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        result = r.sum()
     tm.assert_frame_equal(result, expected)
 
 
@@ -607,10 +608,12 @@ def test_selection_api_validation():
 
     exp = df_exp.resample("2D").sum()
     exp.index.name = "date"
-    tm.assert_frame_equal(exp, df.resample("2D", on="date").sum())
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        tm.assert_frame_equal(exp, df.resample("2D", on="date").sum())
 
     exp.index.name = "d"
-    tm.assert_frame_equal(exp, df.resample("2D", level="d").sum())
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        tm.assert_frame_equal(exp, df.resample("2D", level="d").sum())
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -408,7 +408,8 @@ def test_resample_groupby_agg():
     df["date"] = pd.to_datetime(df["date"])
 
     resampled = df.groupby("cat").resample("Y", on="date")
-    expected = resampled.sum()
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+        expected = resampled.sum()
     result = resampled.agg({"num": "sum"})
 
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/reshape/merge/test_join.py
+++ b/pandas/tests/reshape/merge/test_join.py
@@ -555,7 +555,8 @@ class TestJoin:
         df.insert(5, "dt", "foo")
 
         grouped = df.groupby("id")
-        mn = grouped.mean()
+        with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+            mn = grouped.mean()
         cn = grouped.count()
 
         # it works!

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -146,8 +146,9 @@ class TestPivotTable:
         df = DataFrame(
             {"rows": ["a", "b", "c"], "cols": ["x", "y", "z"], "values": [1, 2, 3]}
         )
-        rs = df.pivot_table(columns="cols", aggfunc=np.sum)
-        xp = df.pivot_table(index="cols", aggfunc=np.sum).T
+        with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+            rs = df.pivot_table(columns="cols", aggfunc=np.sum)
+            xp = df.pivot_table(index="cols", aggfunc=np.sum).T
         tm.assert_frame_equal(rs, xp)
 
         rs = df.pivot_table(columns="cols", aggfunc={"values": "mean"})
@@ -903,12 +904,18 @@ class TestPivotTable:
 
         # to help with a buglet
         self.data.columns = [k * 2 for k in self.data.columns]
-        table = self.data.pivot_table(index=["AA", "BB"], margins=True, aggfunc=np.mean)
+        with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+            table = self.data.pivot_table(
+                index=["AA", "BB"], margins=True, aggfunc=np.mean
+            )
         for value_col in table.columns:
             totals = table.loc[("All", ""), value_col]
             assert totals == self.data[value_col].mean()
 
-        table = self.data.pivot_table(index=["AA", "BB"], margins=True, aggfunc="mean")
+        with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+            table = self.data.pivot_table(
+                index=["AA", "BB"], margins=True, aggfunc="mean"
+            )
         for item in ["DD", "EE", "FF"]:
             totals = table.loc[("All", ""), item]
             assert totals == self.data[item].mean()
@@ -964,7 +971,8 @@ class TestPivotTable:
             }
         )
 
-        result = df.pivot_table(columns=columns, margins=True, aggfunc=aggfunc)
+        with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+            result = df.pivot_table(columns=columns, margins=True, aggfunc=aggfunc)
         expected = DataFrame(values, index=Index(["D", "E"]), columns=expected_columns)
 
         tm.assert_frame_equal(result, expected)
@@ -1990,8 +1998,9 @@ class TestPivotTable:
     def test_pivot_string_func_vs_func(self, f, f_numpy):
         # GH #18713
         # for consistency purposes
-        result = pivot_table(self.data, index="A", columns="B", aggfunc=f)
-        expected = pivot_table(self.data, index="A", columns="B", aggfunc=f_numpy)
+        with tm.assert_produces_warning(FutureWarning, match="Dropping invalid"):
+            result = pivot_table(self.data, index="A", columns="B", aggfunc=f)
+            expected = pivot_table(self.data, index="A", columns="B", aggfunc=f_numpy)
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.slow


### PR DESCRIPTION
Follow up to #41475

- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

The warning currently generated for pivot_table says groupby - but it points to the correct line of user code, and I think it's easy to understand what's going on from a user perspective. E.g.

```
df = pd.DataFrame(
    {
        "A": ["foo", "bar"],
        "B": ["small", "large"],
        "C": [1, 2],
        "D": ["3", "4"],
    }
)
result = pd.pivot_table(df, values=["C", "D"], index=["A"], columns=["B"], aggfunc="sum")
```

gives


> scratch.py:61: FutureWarning: Dropping invalid columns in DataFrameGroupBy.sum is deprecated. In a future version, a TypeError will be raised. Before calling .sum, select only columns which should be valid for the function.
  result = pd.pivot_table(df, values=["C", "D"], index=["A"], columns=["B"], aggfunc="sum")

cc @jbrockmendel 