### PR TITLE
Remove hack and change a benchmark to fail

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -144,10 +144,7 @@ jobs:
         git remote add upstream https://github.com/pandas-dev/pandas.git
         git fetch upstream
         asv machine --yes
-        asv dev | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
-        if grep "failed" benchmarks.log > /dev/null ; then
-            exit 1
-        fi
+        asv dev
       if: ${{ steps.build.outcome == 'success' }}
 
     - name: Publish benchmarks artifact

--- a/asv_bench/benchmarks/attrs_caching.py
+++ b/asv_bench/benchmarks/attrs_caching.py
@@ -34,7 +34,7 @@ class SeriesArrayAttribute:
         elif dtype == "category":
             self.series = pd.Series(["a", "b", "c"], dtype="category")
         elif dtype == "datetime64":
-            self.series = pd.Series(pd.date_range("2013", periods=3))
+            self.series = pd.Series(pd.date_range("hello", periods=3))
         elif dtype == "datetime64tz":
             self.series = pd.Series(pd.date_range("2013", periods=3, tz="UTC"))
 


### PR DESCRIPTION
We are improving the use of asv for Pandas benchmarks. On this PR, I'm removing a hack on the .github/workflows/code-checks.yml file and creating an error on the `attrs_caching.py` file to make the benchmark fail and check the CI output.

cc @datapythonista 