### PR TITLE
CI: Don't run xdist if pytest.mark.single_cpu

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     resource_class: arm.medium
     environment:
       ENV_FILE: ci/deps/circle-38-arm64.yaml
-      PYTEST_WORKERS: auto
+      TEST_ARGS: "--numprocesses auto --dist=loadfile"
       PATTERN: "not slow and not network and not clipboard and not arm_slow"
       PYTEST_TARGET: "pandas"
     steps:

--- a/.github/workflows/datamanger.yml
+++ b/.github/workflows/datamanger.yml
@@ -47,7 +47,7 @@ jobs:
       env:
         PANDAS_DATA_MANAGER: array
         PATTERN: "not network and not clipboard and not single_cpu"
-        PYTEST_WORKERS: "auto"
+        TEST_ARGS: "--numprocesses auto --dist=loadfile"
         PYTEST_TARGET: pandas
       run: |
         source activate pandas-dev

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -125,6 +125,7 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@v2
       with:
+        mamba-version: "*"
         channels: conda-forge
         activate-environment: pandas-dev
         channel-priority: flexible

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -57,8 +57,8 @@ jobs:
       LANG: ${{ matrix.lang || '' }}
       LC_ALL: ${{ matrix.lc_all || '' }}
       PANDAS_TESTING_MODE: ${{ matrix.pandas_testing_mode || '' }}
-      TEST_ARGS: ${{ matrix.test_args || '' }}
-      PYTEST_WORKERS: ${{ contains(matrix.pattern, 'not single_cpu') && 'auto' || '1' }}
+      # Don't activate pytest-xdist (-n) if signle_cpu build
+      TEST_ARGS: ${{ format('{0} {1}', matrix.test_args || '', contains(matrix.pattern, 'not single_cpu') && '--numprocesses auto --dist=loadfile' || '' }}
       PYTEST_TARGET: ${{ matrix.pytest_target || 'pandas' }}
       IS_PYPY: ${{ contains(matrix.env_file, 'pypy') }}
       # TODO: re-enable coverage on pypy, its slow

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -58,7 +58,7 @@ jobs:
       LC_ALL: ${{ matrix.lc_all || '' }}
       PANDAS_TESTING_MODE: ${{ matrix.pandas_testing_mode || '' }}
       # Don't activate pytest-xdist (-n) if signle_cpu build
-      TEST_ARGS: ${{ format('{0} {1}', matrix.test_args || '', contains(matrix.pattern, 'not single_cpu') && '--numprocesses auto --dist=loadfile' || '' }}
+      TEST_ARGS: ${{ format('{0} {1}', matrix.test_args || '', contains(matrix.pattern, 'not single_cpu') && '--numprocesses auto --dist=loadfile' || '') }}
       PYTEST_TARGET: ${{ matrix.pytest_target || 'pandas' }}
       IS_PYPY: ${{ contains(matrix.env_file, 'pypy') }}
       # TODO: re-enable coverage on pypy, its slow

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -125,7 +125,6 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        mamba-version: "*"
         channels: conda-forge
         activate-environment: pandas-dev
         channel-priority: flexible

--- a/.github/workflows/python-dev.yml
+++ b/.github/workflows/python-dev.yml
@@ -21,7 +21,7 @@ on:
       - "doc/**"
 
 env:
-  PYTEST_WORKERS: "auto"
+  TEST_ARGS: "--numprocesses auto --dist=loadfile"
   PANDAS_CI: 1
   PATTERN: "not slow and not network and not clipboard and not single_cpu"
   COVERAGE: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ pr:
     - 1.4.x
 
 variables:
-  PYTEST_WORKERS: auto
+  TEST_ARGS: "--numprocesses auto --dist=loadfile"
   PYTEST_TARGET:  pandas
   PATTERN: "not slow and not high_memory and not db and not network and not single_cpu"
   PANDAS_CI: 1

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -24,7 +24,7 @@ if [[ $(uname) == "Linux" && -z $DISPLAY ]]; then
     XVFB="xvfb-run "
 fi
 
-PYTEST_CMD="${XVFB}pytest -r fEs -n $PYTEST_WORKERS --dist=loadfile $TEST_ARGS $COVERAGE $PYTEST_TARGET"
+PYTEST_CMD="${XVFB}pytest -r fEs $TEST_ARGS $COVERAGE $PYTEST_TARGET"
 
 if [[ "$PATTERN" ]]; then
   PYTEST_CMD="$PYTEST_CMD -m \"$PATTERN\""
@@ -39,7 +39,7 @@ sh -c "$PYTEST_CMD"
 
 if [[ "$PANDAS_DATA_MANAGER" != "array" ]]; then
     # The ArrayManager tests should have already been run by PYTEST_CMD if PANDAS_DATA_MANAGER was already set to array
-    PYTEST_AM_CMD="PANDAS_DATA_MANAGER=array pytest -n $PYTEST_WORKERS  --dist=loadfile $TEST_ARGS $COVERAGE pandas"
+    PYTEST_AM_CMD="PANDAS_DATA_MANAGER=array pytest -r fEs $TEST_ARGS $COVERAGE $PYTEST_TARGET"
 
     if [[ "$PATTERN" ]]; then
       PYTEST_AM_CMD="$PYTEST_AM_CMD -m \"$PATTERN and arraymanager\""

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -24,7 +24,7 @@ if [[ $(uname) == "Linux" && -z $DISPLAY ]]; then
     XVFB="xvfb-run "
 fi
 
-PYTEST_CMD="${XVFB}pytest -r fEs $TEST_ARGS $COVERAGE $PYTEST_TARGET"
+PYTEST_CMD="${XVFB}pytest -v -r fEs $TEST_ARGS $COVERAGE $PYTEST_TARGET"
 
 if [[ "$PATTERN" ]]; then
   PYTEST_CMD="$PYTEST_CMD -m \"$PATTERN\""

--- a/pandas/tests/io/parser/conftest.py
+++ b/pandas/tests/io/parser/conftest.py
@@ -110,9 +110,6 @@ def all_parsers(request):
         pytest.importorskip("pyarrow", VERSIONS["pyarrow"])
         # Try finding a way to disable threads all together
         # for more stable CI runs
-        import pyarrow
-
-        pyarrow.set_cpu_count(1)
     return parser
 
 


### PR DESCRIPTION
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Appears some of the single builds are still timing out. Checking if not activating xdist for this build does the trick

e.g. https://github.com/pandas-dev/pandas/runs/5206822069?check_suite_focus=true

EDIT: The timeouts are due to pyarrow engine in read_csv since mamba is installing pyarrow=2.0.0 (conda seems to install pyarrow=6.0.0 when unpinned)
