### PR TITLE
FIX: clarify warning in read_sql_query()

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -748,9 +748,9 @@ def pandasSQL_builder(con, schema: str | None = None):
         return SQLDatabase(con, schema=schema)
 
     warnings.warn(
-        "pandas only support SQLAlchemy connectable(engine/connection) or"
-        "database string URI or sqlite3 DBAPI2 connection"
-        "other DBAPI2 objects are not tested, please consider using SQLAlchemy",
+        "pandas only supports SQLAlchemy connectable (engine/connection) or "
+        "database string URI or sqlite3 DBAPI2 connection. "
+        "Other DBAPI2 objects are not tested. Please consider using SQLAlchemy.",
         UserWarning,
     )
     return SQLiteDatabase(con)


### PR DESCRIPTION
- [x] closes #xxxx (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

When using `pandas.read_sql_query()` with a non-sqlalchemy connection, the following warning is raised.

> UserWarning: pandas only support SQLAlchemy connectable(engine/connection) ordatabase string URI or sqlite3 DBAPI2 connectionother DBAPI2 objects are not tested, please consider using SQLAlchemy

For example, I noticed this warning today using `psycopg2` to connect to Amazon Redshift, like this:

```python
import os
import pandas
import psycopg2

query = "SELECT * from some_table LIMIT 10"

with psycopg2.connect(...) as conn:
    df = pd.read_sql_query(sql=query, con=conn)
```

This PR proposes small grammatical changes to the warning:

* adds space to prevent unintended concatenation (e.g. `"or database"` instead of `"ordatabase"`)
* adds `.` to separate individual statements

Thanks very much for your time and consideration!