### PR TITLE
BUG: Multiindex.equals not commutative for ea dtype

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -347,7 +347,7 @@ Missing
 
 MultiIndex
 ^^^^^^^^^^
--
+- Bug in :class:`MultiIndex.equals` not commutative when only one side has extension array dtype (:issue:`46026`)
 -
 
 I/O

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3611,10 +3611,10 @@ class MultiIndex(Index):
                 # i.e. ExtensionArray
                 if not self_values.equals(other_values):
                     return False
-                elif not isinstance(other_values, np.ndarray):
-                    # i.e. other is ExtensionArray
-                    if not other_values.equals(self_values):
-                        return False
+            elif not isinstance(other_values, np.ndarray):
+                # i.e. other is ExtensionArray
+                if not other_values.equals(self_values):
+                    return False
             else:
                 if not array_equivalent(self_values, other_values):
                     return False

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3611,6 +3611,10 @@ class MultiIndex(Index):
                 # i.e. ExtensionArray
                 if not self_values.equals(other_values):
                     return False
+                elif not isinstance(other_values, np.ndarray):
+                    # i.e. other is ExtensionArray
+                    if not other_values.equals(self_values):
+                        return False
             else:
                 if not array_equivalent(self_values, other_values):
                     return False

--- a/pandas/tests/indexes/multi/test_equivalence.py
+++ b/pandas/tests/indexes/multi/test_equivalence.py
@@ -288,3 +288,11 @@ def test_multiindex_compare():
     expected = Series([False, False])
     result = Series(midx > midx)
     tm.assert_series_equal(result, expected)
+
+
+def test_equals_ea_int_regular_int():
+    # GH#46026
+    mi1 = MultiIndex.from_arrays([Index([1, 2], dtype="Int64"), [3, 4]])
+    mi2 = MultiIndex.from_arrays([[1, 2], [3, 4]])
+    assert not mi1.equals(mi2)
+    assert not mi2.equals(mi1)


### PR DESCRIPTION
- [x] closes #46026 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
