### PR TITLE
CI: Test various Pyarrow version on Linux

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -26,8 +26,8 @@ jobs:
       matrix:
         env_file: [actions-38.yaml, actions-39.yaml, actions-310.yaml]
         pattern: ["not single_cpu", "single_cpu"]
-        # Don't test pyarrow v2: Causes timeouts in read_csv engine
-        pyarrow_version: ["3", "5", "7"]
+        # Don't test pyarrow v2/3: Causes timeouts in read_csv engine
+        pyarrow_version: ["5", "6", "7"]
         include:
           - env_file: actions-38-downstream_compat.yaml
             pattern: "not slow and not network and not single_cpu"
@@ -136,7 +136,7 @@ jobs:
       if: ${{ env.IS_PYPY == 'false' }} # No pypy3.8 support
 
     - name: Upgrade Arrow version
-      run: mamba update -n pandas-dev -c conda-forge pyarrow=${{ matrix.pyarrow_version }}
+      run: conda update -n pandas-dev -c conda-forge pyarrow=${{ matrix.pyarrow_version }}
       if: ${{ matrix.pyarrow_version }}
 
     - name: Setup PyPy

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -27,6 +27,7 @@ jobs:
         env_file: [actions-38.yaml, actions-39.yaml, actions-310.yaml]
         pattern: ["not single_cpu", "single_cpu"]
         # Don't test pyarrow v2/3: Causes timeouts in read_csv engine
+        # even if tests are skipped/xfailed
         pyarrow_version: ["5", "6", "7"]
         include:
           - env_file: actions-38-downstream_compat.yaml

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -26,6 +26,8 @@ jobs:
       matrix:
         env_file: [actions-38.yaml, actions-39.yaml, actions-310.yaml]
         pattern: ["not single_cpu", "single_cpu"]
+        # Don't test pyarrow v2: Causes timeouts in read_csv engine
+        pyarrow_version: ["3", "5", "7"]
         include:
           - env_file: actions-38-downstream_compat.yaml
             pattern: "not slow and not network and not single_cpu"
@@ -132,6 +134,10 @@ jobs:
         environment-file: ${{ env.ENV_FILE }}
         use-only-tar-bz2: true
       if: ${{ env.IS_PYPY == 'false' }} # No pypy3.8 support
+
+    - name: Upgrade Arrow version
+      run: mamba update -n pandas-dev -c conda-forge pyarrow=${{ matrix.pyarrow_version }}
+      if: ${{ matrix.pyarrow_version }}
 
     - name: Setup PyPy
       uses: actions/setup-python@v2

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -136,7 +136,7 @@ jobs:
       if: ${{ env.IS_PYPY == 'false' }} # No pypy3.8 support
 
     - name: Upgrade Arrow version
-      run: conda install -n pandas-dev -c conda-forge pyarrow=${{ matrix.pyarrow_version }}
+      run: conda install -n pandas-dev -c conda-forge --no-update-deps pyarrow=${{ matrix.pyarrow_version }}
       if: ${{ matrix.pyarrow_version }}
 
     - name: Setup PyPy

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -67,7 +67,7 @@ jobs:
       COVERAGE: ${{ !contains(matrix.env_file, 'pypy') }}
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7
-      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.env_file }}-${{ matrix.pattern }}-${{ matrix.extra_apt || '' }}
+      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.env_file }}-${{ matrix.pattern }}-${{ matrix.pyarrow_version || '' }}-${{ matrix.extra_apt || '' }}
       cancel-in-progress: true
 
     services:

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -136,7 +136,7 @@ jobs:
       if: ${{ env.IS_PYPY == 'false' }} # No pypy3.8 support
 
     - name: Upgrade Arrow version
-      run: conda update -n pandas-dev -c conda-forge pyarrow=${{ matrix.pyarrow_version }}
+      run: conda install -n pandas-dev -c conda-forge pyarrow=${{ matrix.pyarrow_version }}
       if: ${{ matrix.pyarrow_version }}
 
     - name: Setup PyPy

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -176,7 +176,8 @@ def test_seaborn():
 
 
 def test_pandas_gbq():
-
+    # Older versions import from non-public, non-existent pandas funcs
+    pytest.importorskip("pandas_gbq", minversion="0.10.0")
     pandas_gbq = import_module("pandas_gbq")  # noqa:F841
 
 


### PR DESCRIPTION
- [x] closes #45705 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature

As discovered in https://github.com/pandas-dev/pandas/pull/46014, pyarrow v2 seems to cause timeouts in read_csv (mamba resolves to v2 but conda resolves to v6 when pyarrow is unpinned, interestingly) so skipping that version.