### PR TITLE
BUG: .transform(...) with "first" and "last" fail when axis=1

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -379,6 +379,7 @@ Groupby/resample/rolling
 - Bug in :meth:`DataFrame.resample` ignoring ``closed="right"`` on :class:`TimedeltaIndex` (:issue:`45414`)
 - Bug in :meth:`.DataFrameGroupBy.transform` fails when ``func="size"`` and the input DataFrame has multiple columns (:issue:`27469`)
 - Bug in :meth:`.DataFrameGroupBy.size` and :meth:`.DataFrameGroupBy.transform` with ``func="size"`` produced incorrect results when ``axis=1`` (:issue:`45715`)
+- Bug in :meth:`.DataFrameGroupby.transform` fails when ``axis=1`` and ``func`` is ``"first"`` or ``"last"`` (:issue:`45986`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -472,9 +472,6 @@ class SeriesGroupBy(GroupBy[Series]):
         result.name = self.obj.name
         return result
 
-    def _can_use_transform_fast(self, func: str, result) -> bool:
-        return True
-
     def filter(self, func, dropna: bool = True, *args, **kwargs):
         """
         Return a copy of a Series excluding elements from groups that
@@ -1182,12 +1179,6 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
     def transform(self, func, *args, engine=None, engine_kwargs=None, **kwargs):
         return self._transform(
             func, *args, engine=engine, engine_kwargs=engine_kwargs, **kwargs
-        )
-
-    def _can_use_transform_fast(self, func: str, result) -> bool:
-        return func == "size" or (
-            isinstance(result, DataFrame)
-            and result.columns.equals(self._obj_with_exclusions.columns)
         )
 
     def _define_paths(self, func, *args, **kwargs):

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1650,11 +1650,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             with com.temp_setattr(self, "observed", True):
                 result = getattr(self, func)(*args, **kwargs)
 
-            if self._can_use_transform_fast(func, result):
-                return self._wrap_transform_fast_result(result)
-
-            # only reached for DataFrameGroupBy
-            return self._transform_general(func, *args, **kwargs)
+            return self._wrap_transform_fast_result(result)
 
     @final
     def _wrap_transform_fast_result(self, result: NDFrameT) -> NDFrameT:

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -21,10 +21,7 @@ from pandas import (
 )
 import pandas._testing as tm
 from pandas.core.groupby.base import maybe_normalize_deprecated_kernels
-from pandas.core.groupby.generic import (
-    DataFrameGroupBy,
-    SeriesGroupBy,
-)
+from pandas.core.groupby.generic import DataFrameGroupBy
 
 
 def assert_fp_equal(a, b):
@@ -195,10 +192,8 @@ def test_transform_axis_1_reducer(request, reduction_func):
     # GH#45715
     if reduction_func in (
         "corrwith",
-        "first",
         "idxmax",
         "idxmin",
-        "last",
         "ngroup",
         "nth",
     ):
@@ -418,45 +413,36 @@ def test_transform_select_columns(df):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.parametrize("duplicates", [True, False])
-def test_transform_exclude_nuisance(df, duplicates):
+def test_transform_exclude_nuisance(df):
     # case that goes through _transform_item_by_item
 
-    if duplicates:
-        # make sure we work with duplicate columns GH#41427
-        df.columns = ["A", "C", "C", "D"]
+    df.columns = ["A", "B", "B", "D"]
 
     # this also tests orderings in transform between
     # series/frame to make sure it's consistent
     expected = {}
     grouped = df.groupby("A")
 
-    gbc = grouped["C"]
-    warn = FutureWarning if duplicates else None
-    with tm.assert_produces_warning(warn, match="Dropping invalid columns"):
-        expected["C"] = gbc.transform(np.mean)
-    if duplicates:
-        # squeeze 1-column DataFrame down to Series
-        expected["C"] = expected["C"]["C"]
+    gbc = grouped["B"]
+    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid columns"):
+        expected["B"] = gbc.transform(lambda x: np.mean(x))
+    # squeeze 1-column DataFrame down to Series
+    expected["B"] = expected["B"]["B"]
 
-        assert isinstance(gbc.obj, DataFrame)
-        assert isinstance(gbc, DataFrameGroupBy)
-    else:
-        assert isinstance(gbc, SeriesGroupBy)
-        assert isinstance(gbc.obj, Series)
+    assert isinstance(gbc.obj, DataFrame)
+    assert isinstance(gbc, DataFrameGroupBy)
 
     expected["D"] = grouped["D"].transform(np.mean)
     expected = DataFrame(expected)
     with tm.assert_produces_warning(FutureWarning, match="Dropping invalid columns"):
-        result = df.groupby("A").transform(np.mean)
+        result = df.groupby("A").transform(lambda x: np.mean(x))
 
     tm.assert_frame_equal(result, expected)
 
 
 def test_transform_function_aliases(df):
-    with tm.assert_produces_warning(FutureWarning, match="Dropping invalid columns"):
-        result = df.groupby("A").transform("mean")
-        expected = df.groupby("A").transform(np.mean)
+    result = df.groupby("A").transform("mean")
+    expected = df.groupby("A").transform(np.mean)
     tm.assert_frame_equal(result, expected)
 
     result = df.groupby("A")["C"].transform("mean")


### PR DESCRIPTION
Part of #45986 (first/last)

- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This removes warnings of dropping nuisance columns when using e.g. `.transform("mean")`. This makes it consistent with `.agg`, and in #46072 both `transform` and `agg` will warn about the default switching from `numeric_only=False` to `numeric_only=True`. Doing this first will make #46072 slightly easier.

Not falling back to `_transform_item_by_item` is also better for performance. For the benchmark, I disabled the warning being emitted in main to make sure that wasn't messing up the results.

```
size = 1_000_000
df = pd.DataFrame(
    {
        "A": size * ["foo", "bar"],
        "B": "one",
        "C": np.random.randn(2*size),
        "D": np.random.randn(2*size),
    }
)
%timeit df.groupby("A").transform("mean")

# This PR
108 ms ± 966 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
# main, but with size set to 100_000 (1mm was taking very very long)
920 ms ± 7.95 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```