### PR TITLE
DOC: Remove old note about default unit

### DIFF
--- a/doc/source/whatsnew/v1.4.2.rst
+++ b/doc/source/whatsnew/v1.4.2.rst
@@ -32,7 +32,7 @@ Bug fixes
 
 Other
 ~~~~~
-- Removed docstring comment indicating incorrectly that default unit is 'ms' rather than 'ns'
+-
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.4.2.rst
+++ b/doc/source/whatsnew/v1.4.2.rst
@@ -32,7 +32,7 @@ Bug fixes
 
 Other
 ~~~~~
--
+- Removed docstring comment indicating incorrectly that default unit is 'ms' rather than 'ns'
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -765,8 +765,8 @@ def to_datetime(
     unit : str, default 'ns'
         The unit of the arg (D,s,ms,us,ns) denote the unit, which is an
         integer or float number. This will be based off the origin.
-        Example, with ``unit='ms'`` and ``origin='unix'`` (the default), this
-        would calculate the number of milliseconds to the unix epoch start.
+        Example, with ``unit='ms'`` and ``origin='unix'``, this would calculate
+        the number of milliseconds to the unix epoch start.
     infer_datetime_format : bool, default False
         If :const:`True` and no `format` is given, attempt to infer the format
         of the datetime strings based on the first non-NaN element,


### PR DESCRIPTION
`to_datetime` docstring indicates that the default unit is 'ms', but it is 'ns'. This PR simply removes that comment so that there is no need to keep it in sync with the implementation.

- [ ] ~closes #xxxx (Replace xxxx with the Github issue number)~ NA
- [ ] ~[Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature~ NA
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] ~Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.~ NA
