### PR TITLE
CLN: Remove Categorical.itemsize

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -43,7 +43,6 @@ from pandas._typing import (
 )
 from pandas.compat.numpy import function as nv
 from pandas.util._decorators import (
-    cache_readonly,
     deprecate_kwarg,
     deprecate_nonkeyword_arguments,
 )

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -563,13 +563,6 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
         return result
 
-    @cache_readonly
-    def itemsize(self) -> int:
-        """
-        return the size of a single category
-        """
-        return self.categories.itemsize
-
     def to_list(self):
         """
         Alias for tolist.


### PR DESCRIPTION
The method doesn't even work in main, it is useless and removal keeps the same error code as before, so I think it's OK to just remove and not do a deprecation cycle here:

```python
>>> cat = pd.Categorical([9, 6])
>>> cat.itemsize
AttributeError: 'Int64Index' object has no attribute 'itemsize'  # main
AttributeError: 'Categorical' object has no attribute 'itemsize'  # new
```

