### PR TITLE
CI/TST: Fix xfail(strict=False) condition

### DIFF
--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -58,6 +58,12 @@ def test_union_different_types(index_flat, index_flat2, request):
         and idx2.dtype.kind == "i"
         and idx1.dtype.kind == "b"
     ):
+        # Each condition had idx[1|2].is_monotonic_decreasing
+        # but failed when e.g.
+        # idx1 = Index(
+        # [True, True, True, True, True, True, True, True, False, False], dtype='bool'
+        # )
+        # idx2 = Int64Index([0, 0, 1, 1, 2, 2], dtype='int64')
         mark = pytest.mark.xfail(
             reason="GH#44000 True==1", raises=ValueError, strict=False
         )

--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -50,13 +50,11 @@ def test_union_different_types(index_flat, index_flat2, request):
     if (
         not idx1.is_unique
         and not idx2.is_unique
-        and not idx2.is_monotonic_decreasing
         and idx1.dtype.kind == "i"
         and idx2.dtype.kind == "b"
     ) or (
         not idx2.is_unique
         and not idx1.is_unique
-        and not idx1.is_monotonic_decreasing
         and idx2.dtype.kind == "i"
         and idx1.dtype.kind == "b"
     ):


### PR DESCRIPTION
- xref #46144
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

cc @jbrockmendel For this example, the monotonic condition was too strict

```
In [1]: index_flat = Index([True, True, True, True, True, True, True, True, False, False], dtype='bool')

In [2]: index_flat2 = pd.Int64Index([0, 0, 1, 1, 2, 2], dtype='int64')
<ipython-input-2-0cd74eb77800>:1: FutureWarning: pandas.Int64Index is deprecated and will be removed from pandas in a future version. Use pandas.Index with the appropriate dtype instead.
  index_flat2 = pd.Int64Index([0, 0, 1, 1, 2, 2], dtype='int64')

In [3]: idx1 = index_flat

In [4]: idx2 = index_flat2

In [5]: (
   ...:             not idx1.is_unique
   ...:             and not idx2.is_unique
   ...:             and not idx2.is_monotonic_decreasing
   ...:             and idx1.dtype.kind == "i"
   ...:             and idx2.dtype.kind == "b"
   ...:         )
Out[5]: False

In [6]: (
   ...:             not idx2.is_unique
   ...:             and not idx1.is_unique
   ...:             and not idx1.is_monotonic_decreasing
   ...:             and idx2.dtype.kind == "i"
   ...:             and idx1.dtype.kind == "b"
   ...:         )
Out[6]: False
```