### PR TITLE
CI: Remove testing pyarrow 6

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -28,7 +28,7 @@ jobs:
         pattern: ["not single_cpu", "single_cpu"]
         # Don't test pyarrow v2/3: Causes timeouts in read_csv engine
         # even if tests are skipped/xfailed
-        pyarrow_version: ["5", "6", "7"]
+        pyarrow_version: ["5", "7"]
         include:
           - env_file: actions-38-downstream_compat.yaml
             pattern: "not slow and not network and not single_cpu"


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/46003#issuecomment-1053830181

(Still testing pyarrow 1.0.1 (min version), 5, and 7)
