### PR TITLE
TYP: loosen types of to_markdown, align to docs

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -18,7 +18,6 @@ from io import StringIO
 import itertools
 from textwrap import dedent
 from typing import (
-    IO,
     TYPE_CHECKING,
     Any,
     Callable,
@@ -2717,7 +2716,7 @@ class DataFrame(NDFrame, OpsMixin):
     )
     def to_markdown(
         self,
-        buf: IO[str] | str | None = None,
+        buf: FilePath | WriteBuffer[str] | None = None,
         mode: str = "wt",
         index: bool = True,
         storage_options: StorageOptions = None,


### PR DESCRIPTION
Docs already allowed pathlib.Path objects and such
code runs, but failed mypy typechecks. This fixes it.

- [x] closes #46211 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
