### PR TITLE
DOC: Fix warnings on underline length

### DIFF
--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -62,7 +62,7 @@ class NumericIndex(Index):
     None
 
     Methods
-    ----------
+    -------
     None
 
     See Also

--- a/pandas/io/orc.py
+++ b/pandas/io/orc.py
@@ -41,7 +41,7 @@ def read_orc(
     DataFrame
 
     Notes
-    -------
+    -----
     Before using this function you should read the :ref:`user guide about ORC <io.orc>`
     and :ref:`install optional dependencies <install.warn_orc>`.
     """


### PR DESCRIPTION
In the CI run
 https://github.com/pandas-dev/pandas/runs/5413504567?check_suite_focus=true
I noticed a few warnings when building the docs such as

```
/home/runner/miniconda3/envs/pandas-dev/lib/python3.8/site-packages/numpydoc/docscrape.py:434: UserWarning: potentially wrong underline length...
Methods
---------- in
Immutable sequence used for indexing and alignment. The basic object
storing axis labels for all pandas objects. Int64Index is a special case... in the docstring of Int64Index in /home/runner/work/pandas/pandas/pandas/core/indexes/numeric.py.
```

So these were trivial enough to clean up

- [x] (simple enough I didn't make one) closes #xxxx (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
