### PR TITLE
Build: unpin version of base image of dockered development environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/condaforge/miniforge3:4.11.0-0
+FROM quay.io/condaforge/miniforge3
 
 # if you forked pandas, you can pass in your own GitHub username to use your fork
 # i.e. gh_username=myname


### PR DESCRIPTION
This PR removes the pinned version for the base image.

The latest version of the base image, `quay.io/condaforge/miniforge3:4.11.0-4` (released Feb 26, 2022),  works again.

The pinned version was needed temporarily because of a misbehaving version of the base image: https://github.com/pandas-dev/pandas/pull/45889#issuecomment-1040827073