### PR TITLE
ENH: Let callables in .loc and .iloc take an optional axis parameter

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -60,7 +60,8 @@ of multi-axis indexing.
       index! See :ref:`Slicing with labels <indexing.slicing_with_labels>`
       and :ref:`Endpoints are inclusive <advanced.endpoints_are_inclusive>`.)
     * A boolean array (any ``NA`` values will be treated as ``False``).
-    * A ``callable`` function with one argument (the calling Series or DataFrame) and
+    * A ``callable`` with one argument (the calling Series or DataFrame)
+      or two arguments (the calling Series or DataFrame and the relevant axis) and
       that returns valid output for indexing (one of the above).
 
   See more at :ref:`Selection by Label <indexing.label>`.
@@ -76,7 +77,8 @@ of multi-axis indexing.
     * A list or array of integers ``[4, 3, 0]``.
     * A slice object with ints ``1:7``.
     * A boolean array (any ``NA`` values will be treated as ``False``).
-    * A ``callable`` function with one argument (the calling Series or DataFrame) and
+    * A ``callable`` function with one argument (the calling Series or DataFrame) or
+      two arguments (the calling Series or DataFrame and the axis )and
       that returns valid output for indexing (one of the above).
 
   See more at :ref:`Selection by Position <indexing.integer>`,
@@ -554,7 +556,13 @@ Selection by callable
 ---------------------
 
 ``.loc``, ``.iloc``, and also ``[]`` indexing can accept a ``callable`` as indexer.
-The ``callable`` must be a function with one argument (the calling Series or DataFrame) that returns valid output for indexing.
+The ``callable`` must be a function with one argument (the calling Series or DataFrame)
+or two arguments (the calling Series or DataFrame and the axis) that returns valid output for indexing.
+
+.. versionchanged:: 1.5
+
+  The callable can take two arguments (the calling Series or DataFrame and the axis).
+  Previously it could only take one argument.
 
 .. ipython:: python
 
@@ -570,6 +578,7 @@ The ``callable`` must be a function with one argument (the calling Series or Dat
 
    df1[lambda df: df.columns[0]]
 
+   df1.loc[:, lambda df, axis: df.axes[axis].isin(["B", "D"])]
 
 You can use callable indexing in ``Series``.
 

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -91,6 +91,8 @@ parameters (the calling DataFrame or Series and the axis) (:issue:`46226`).
    df = pd.DataFrame({"X": [1, 2, 3, 4], "Y": list("aabb")}, index=list("ABCD"))
    df.loc[:, lambda x, axis: x.axes[axis].isin(['X'])]
 
+This allows more flexibility when constructing the callables.
+
 .. _whatsnew_150.enhancements.other:
 
 Other enhancements

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -75,6 +75,21 @@ as seen in the following example.
                1 2021-01-02 08:00:00  4
                2 2021-01-02 16:00:00  5
 
+.. _whatsnew_140.enhancements.warning_lineno:
+
+.loc and .iloc can now take callables with two parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Previously, you could filter dataframes and Series using callables with one parameter
+(the calling DataFrame or Series). Now it is possible for the callable to have two
+parameters (the calling DataFrame or Series and the axis).
+
+.. code-block:: python
+
+    df = pd.DataFrame({"X": [1, 2, 3, 4], "Y": list("aabb")}, index=list("ABCD"))
+    df.loc[:, lambda x, axis: x.axes[axis].isin(['X'])]
+
+
 .. _whatsnew_150.enhancements.other:
 
 Other enhancements

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -91,7 +91,6 @@ parameters (the calling DataFrame or Series and the axis) (:issue:`46226`).
    df = pd.DataFrame({"X": [1, 2, 3, 4], "Y": list("aabb")}, index=list("ABCD"))
    df.loc[:, lambda x, axis: x.axes[axis].isin(['X'])]
 
-
 .. _whatsnew_150.enhancements.other:
 
 Other enhancements

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -24,7 +24,6 @@ Styler
   - Added a new method :meth:`.Styler.concat` which allows adding customised footer rows to visualise additional calculations on the data, e.g. totals and counts etc. (:issue:`43875`, :issue:`46186`)
   - :meth:`.Styler.highlight_null` now accepts ``color`` consistently with other builtin methods and deprecates ``null_color`` although this remains backwards compatible (:issue:`45907`)
 
-<<<<<<< HEAD
 .. _whatsnew_150.enhancements.resample_group_keys:
 
 Control of index with ``group_keys`` in :meth:`DataFrame.resample`
@@ -79,7 +78,6 @@ as seen in the following example.
 .. _whatsnew_140.enhancements.warning_lineno:
 =======
 .. _whatsnew_150.loc_iloc_callables:
->>>>>>> a428e999b2 (fix minor issues)
 
 .loc and .iloc can now take callables with two parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -24,6 +24,7 @@ Styler
   - Added a new method :meth:`.Styler.concat` which allows adding customised footer rows to visualise additional calculations on the data, e.g. totals and counts etc. (:issue:`43875`, :issue:`46186`)
   - :meth:`.Styler.highlight_null` now accepts ``color`` consistently with other builtin methods and deprecates ``null_color`` although this remains backwards compatible (:issue:`45907`)
 
+<<<<<<< HEAD
 .. _whatsnew_150.enhancements.resample_group_keys:
 
 Control of index with ``group_keys`` in :meth:`DataFrame.resample`
@@ -76,13 +77,16 @@ as seen in the following example.
                2 2021-01-02 16:00:00  5
 
 .. _whatsnew_140.enhancements.warning_lineno:
+=======
+.. _whatsnew_150.loc_iloc_callables:
+>>>>>>> a428e999b2 (fix minor issues)
 
 .loc and .iloc can now take callables with two parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Previously, you could filter dataframes and Series using callables with one parameter
 (the calling DataFrame or Series). Now it is possible for the callable to have two
-parameters (the calling DataFrame or Series and the axis).
+parameters (the calling DataFrame or Series and the axis) (:issue:`46226`).
 
 .. code-block:: python
 

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -88,8 +88,8 @@ parameters (the calling DataFrame or Series and the axis) (:issue:`46226`).
 
 .. code-block:: python
 
-    df = pd.DataFrame({"X": [1, 2, 3, 4], "Y": list("aabb")}, index=list("ABCD"))
-    df.loc[:, lambda x, axis: x.axes[axis].isin(['X'])]
+   df = pd.DataFrame({"X": [1, 2, 3, 4], "Y": list("aabb")}, index=list("ABCD"))
+   df.loc[:, lambda x, axis: x.axes[axis].isin(['X'])]
 
 
 .. _whatsnew_150.enhancements.other:

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -361,6 +361,32 @@ def apply_if_callable(maybe_callable, obj, **kwargs):
     return maybe_callable
 
 
+def apply_maybe_callable_with_axis(maybe_callable, obj, axis: int):
+    """
+    Evaluate possibly callable input using obj and axis if it is callable,
+    otherwise return as it is.
+
+    Parameters
+    ----------
+    maybe_callable : possibly a callable
+    obj : NDFrame
+    axis : int
+    """
+    if not callable(maybe_callable):
+        return maybe_callable
+
+    sign = inspect.signature(maybe_callable)
+    len_parameters = len(sign.parameters)
+
+    if len_parameters == 1:
+        return maybe_callable(obj)
+    elif len_parameters == 2:
+        return maybe_callable(obj, axis)
+    else:
+        msg = f"callable must take 1 or 2 parameters, takes {len_parameters} parameters"
+        raise TypeError(msg)
+
+
 def standardize_mapping(into):
     """
     Helper function to standardize a supplied mapping.

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -1364,7 +1364,7 @@ class TestILocCallable:
         tm.assert_frame_equal(res, exp)
 
     def test_frame_iloc_getitem_callable_two_params(self):
-        # GH#XXXXX
+        # GH#46226
         df = DataFrame({"X": [1, 2, 3, 4], "Y": list("aabb")}, index=list("ABCD"))
 
         # axis 0
@@ -1386,7 +1386,7 @@ class TestILocCallable:
         tm.assert_series_equal(res, df.iloc[[1, 3], 0])
 
     def test_frame_iloc_setitem_callable_two_params(self):
-        # GH#XXXXX
+        # GH#46226
         df = DataFrame({"X": [1, 2, 3, 4], "Y": list("aabb")}, index=list("ABCD"))
 
         # return location

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -1363,6 +1363,61 @@ class TestILocCallable:
         exp.iloc[[1, 3], [0]] = [-5, -5]
         tm.assert_frame_equal(res, exp)
 
+    def test_frame_iloc_getitem_callable_two_params(self):
+        # GH#XXXXX
+        df = DataFrame({"X": [1, 2, 3, 4], "Y": list("aabb")}, index=list("ABCD"))
+
+        # axis 0
+        res = df.iloc[lambda x, axis: x.axes[axis].get_indexer(["B", "D"])]
+        tm.assert_frame_equal(res, df.iloc[[1, 3]])
+
+        res = df.iloc[lambda x, axis: x.axes[axis].get_indexer(["B", "D"]), :]
+        tm.assert_frame_equal(res, df.iloc[[1, 3]])
+
+        # axis 1
+        res = df.iloc[:, lambda x, axis: x.axes[axis].get_loc("X")]
+        tm.assert_series_equal(res, df.iloc[:, 0])
+
+        # axis 0 & 1
+        res = df.iloc[
+            lambda x, axis: x.axes[axis].get_indexer(["B", "D"]),
+            lambda x, axis: x.axes[axis].get_loc("X"),
+        ]
+        tm.assert_series_equal(res, df.iloc[[1, 3], 0])
+
+    def test_frame_iloc_setitem_callable_two_params(self):
+        # GH#XXXXX
+        df = DataFrame({"X": [1, 2, 3, 4], "Y": list("aabb")}, index=list("ABCD"))
+
+        # return location
+        res = df.copy()
+        res.iloc[lambda x, axis: x.axes[axis].get_indexer(["B", "D"])] = 0
+        exp = df.copy()
+        exp.iloc[[1, 3]] = 0
+        tm.assert_frame_equal(res, exp)
+
+        res = df.copy()
+        res.iloc[lambda x, axis: x.axes[axis].get_indexer(["B", "D"]), :] = -1
+        exp = df.copy()
+        exp.iloc[[1, 3], :] = -1
+        tm.assert_frame_equal(res, exp)
+
+        res = df.copy()
+        res.iloc[
+            lambda x, axis: x.axes[axis].get_indexer(["B", "D"]),
+            lambda x, axis: x.axes[axis].get_indexer(["X"]),
+        ] = 5
+        exp = df.copy()
+        exp.iloc[[1, 3], 0] = 5
+        tm.assert_frame_equal(res, exp)
+
+        # mixture
+        res = df.copy()
+        res.iloc[[1, 3], lambda x, axis: x.axes[axis].get_indexer(["X"])] = -3
+        exp = df.copy()
+        exp.iloc[[1, 3], 0] = -3
+        tm.assert_frame_equal(res, exp)
+
 
 class TestILocSeries:
     def test_iloc(self):

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -2169,7 +2169,7 @@ class TestLocCallable:
         tm.assert_frame_equal(res, exp)
 
     def test_frame_loc_getitem_callable_two_params(self):
-        # GH#XXXXX
+        # GH#46226
         df = DataFrame({"A": [1, 2, 3, 4], "B": list("aabb"), "C": [1, 2, 3, 4]})
 
         res = df.loc[lambda x, axis: x.axes[axis].isin([1, 2])]
@@ -2189,7 +2189,7 @@ class TestLocCallable:
         tm.assert_frame_equal(res, expected)
 
     def test_frame_loc_setitem_callable_two_params(self):
-        # GH#XXXXX
+        # GH#46226
         df = DataFrame({"X": [1, 2, 3, 4], "Y": list("aabb")}, index=list("ABCD"))
 
         res = df.copy()

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -2168,6 +2168,87 @@ class TestLocCallable:
         exp.loc[["A", "C"], ["X"]] = -4
         tm.assert_frame_equal(res, exp)
 
+    def test_frame_loc_getitem_callable_two_params(self):
+        # GH#XXXXX
+        df = DataFrame({"A": [1, 2, 3, 4], "B": list("aabb"), "C": [1, 2, 3, 4]})
+
+        res = df.loc[lambda x, axis: x.axes[axis].isin([1, 2])]
+        tm.assert_frame_equal(res, df.loc[df.index.isin([1, 2])])
+
+        res = df.loc[lambda x, axis: x.axes[axis].isin([1, 2]), :]
+        tm.assert_frame_equal(res, df.loc[df.index.isin([1, 2])])
+
+        res = df.loc[:, lambda x, axis: x.axes[axis].isin(["A", "B"])]
+        tm.assert_frame_equal(res, df.loc[:, df.columns.isin(["A", "B"])])
+
+        res = df.loc[
+            lambda x, axis: x.axes[axis].isin([1, 2]),
+            lambda x, axis: x.axes[axis].isin(["A", "B"]),
+        ]
+        expected = df.loc[df.index.isin([1, 2]), df.columns.isin(["A", "B"])]
+        tm.assert_frame_equal(res, expected)
+
+    def test_frame_loc_setitem_callable_two_params(self):
+        # GH#XXXXX
+        df = DataFrame({"X": [1, 2, 3, 4], "Y": list("aabb")}, index=list("ABCD"))
+
+        res = df.copy()
+        res.loc[lambda x, axis: x.axes[axis].isin(["A", "C"])] = -20
+        exp = df.copy()
+        exp.loc[["A", "C"]] = -20
+        tm.assert_frame_equal(res, exp)
+
+        res = df.copy()
+        res.loc[lambda x, axis: x.axes[axis].isin(["A", "C"]), :] = 20
+        exp = df.copy()
+        exp.loc[["A", "C"], :] = 20
+        tm.assert_frame_equal(res, exp)
+
+        res = df.copy()
+        res.loc[
+            lambda x, axis: x.axes[axis].isin(["A", "C"]),
+            lambda x, axis: x.axes[axis].isin(["X"]),
+        ] = -1
+        exp = df.copy()
+        exp.loc[["A", "C"], "X"] = -1
+        tm.assert_frame_equal(res, exp)
+
+        res = df.copy()
+        res.loc[
+            lambda x, axis: x.axes[axis].isin(["A", "C"]),
+            lambda x, axis: x.axes[axis].isin(["X"]),
+        ] = [5, 10]
+        exp = df.copy()
+        exp.loc[["A", "C"], ["X"]] = [5, 10]
+        tm.assert_frame_equal(res, exp)
+
+        # mixture
+        res = df.copy()
+        res.loc[["A", "C"], lambda x, axis: x.axes[axis].isin(["X"])] = np.array(
+            [-1, -2]
+        )
+        exp = df.copy()
+        exp.loc[["A", "C"], "X"] = np.array([-1, -2])
+        tm.assert_frame_equal(res, exp)
+
+        res = df.copy()
+        res.loc[["A", "C"], lambda x, axis: x.axes[axis].isin(["X"])] = 10
+        exp = df.copy()
+        exp.loc[["A", "C"], ["X"]] = 10
+        tm.assert_frame_equal(res, exp)
+
+        res = df.copy()
+        res.loc[lambda x, axis: x.axes[axis].isin(["A", "C"]), "X"] = -2
+        exp = df.copy()
+        exp.loc[["A", "C"], "X"] = -2
+        tm.assert_frame_equal(res, exp)
+
+        res = df.copy()
+        res.loc[lambda x, axis: x.axes[axis].isin(["A", "C"]), ["X"]] = -4
+        exp = df.copy()
+        exp.loc[["A", "C"], ["X"]] = -4
+        tm.assert_frame_equal(res, exp)
+
 
 class TestPartialStringSlicing:
     def test_loc_getitem_partial_string_slicing_datetimeindex(self):


### PR DESCRIPTION
Currently, when supplying callables to ``.loc``and ``.iloc`` we can't know which axis the callable is supplied for. This makes is  difficult to make more general filtering callables, e.g. if we want the callable to filter over transposed axes.

This PR allows the callables supplied to ``.loc`` and ``.iloc`` to take either one or two arguments, instead of only one argument, as it could previously.

This PR is fully backwards compatible.