### PR TITLE
REF: use standard pattern in _tz_convert_from_utc

### DIFF
--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -412,3 +412,13 @@ class TestDatetimeArray:
 
         roundtrip = expected.tz_localize("US/Pacific")
         tm.assert_datetime_array_equal(roundtrip, dta)
+
+    def test_tz_localize_utc_to_naive_copies(self):
+        dti = pd.date_range("1994-05-12", periods=12, tz="UTC")
+        dta = dti._data
+
+        res = dta.tz_localize(None)
+        assert not tm.shares_memory(res, dta)
+
+        res = dti.tz_localize(None)
+        assert not tm.shares_memory(res, dti)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Avoid unnecessary copy in non-UTC cases.
Confirmed that the "TODO: How is this reached" case is not reachable, so removed it.