### PR TITLE
CI/TYP: pyright reportSelfClsParameterName

### DIFF
--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -182,7 +182,7 @@ class NDArrayBackedExtensionArray(NDArrayBacked, ExtensionArray):
             return False
         return bool(array_equivalent(self._ndarray, other._ndarray))
 
-    def _from_factorized(cls, values, original):
+    def _from_factorized(self, values, original):
         assert values.dtype == original._ndarray.dtype
         return original._from_backing_data(values)
 

--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -182,7 +182,8 @@ class NDArrayBackedExtensionArray(NDArrayBacked, ExtensionArray):
             return False
         return bool(array_equivalent(self._ndarray, other._ndarray))
 
-    def _from_factorized(self, values, original):
+    @classmethod
+    def _from_factorized(cls, values, original):
         assert values.dtype == original._ndarray.dtype
         return original._from_backing_data(values)
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3932,10 +3932,7 @@ class Index(IndexOpsMixin, PandasObject):
             else:
                 tgt_values = target._get_engine_target()
 
-            # error: Argument 1 to "get_indexer" of "IndexEngine" has incompatible
-            # type "Union[ExtensionArray, ndarray[Any, Any]]"; expected
-            # "ndarray[Any, Any]"
-            indexer = self._engine.get_indexer(tgt_values)  # type: ignore[arg-type]
+            indexer = self._engine.get_indexer(tgt_values)
 
         return ensure_platform_int(indexer)
 


### PR DESCRIPTION
Fixes:

> pandas/core/arrays/_mixins.py:185:26 - warning: Instance methods should take a "self" parameter (reportSelfClsParameterName)

I'm not familiar with the function, could also be a `classmethod` @jbrockmendel 

