### PR TITLE
DOC: Fix `DataFrame.plot.scatter` link in 1.5.0 changelog

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -421,7 +421,7 @@ Plotting
 - Bug in :meth:`DataFrame.plot.box` that prevented labeling the x-axis (:issue:`45463`)
 - Bug in :meth:`DataFrame.boxplot` that prevented passing in ``xlabel`` and ``ylabel`` (:issue:`45463`)
 - Bug in :meth:`DataFrame.boxplot` that prevented specifying ``vert=False`` (:issue:`36918`)
-- Bug in :meth:`DataFrame.scatter` that prevented specifying ``norm`` (:issue:`45809`)
+- Bug in :meth:`DataFrame.plot.scatter` that prevented specifying ``norm`` (:issue:`45809`)
 
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes `DataFrame.scatter` -> `DataFrame.plot.scatter` in the changelog entry for #45966