### PR TITLE
CI: Don't run PANDAS_DATA_MANAGER=array test for downstream tests

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -35,7 +35,7 @@ sh -c "$PYTEST_CMD"
 
 if [[ "$PANDAS_DATA_MANAGER" != "array" ]]; then
     # The ArrayManager tests should have already been run by PYTEST_CMD if PANDAS_DATA_MANAGER was already set to array
-    PYTEST_AM_CMD="PANDAS_DATA_MANAGER=array pytest -n $PYTEST_WORKERS  --dist=loadfile $TEST_ARGS $COVERAGE pandas"
+    PYTEST_AM_CMD="PANDAS_DATA_MANAGER=array pytest -n $PYTEST_WORKERS --dist=loadfile $TEST_ARGS $COVERAGE $PYTEST_TARGET"
 
     if [[ "$PATTERN" ]]; then
       PYTEST_AM_CMD="$PYTEST_AM_CMD -m \"$PATTERN and arraymanager\""

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -45,6 +45,7 @@ if [[ "$PANDAS_DATA_MANAGER" != "array" ]]; then
 
     echo $PYTEST_AM_CMD
     sh -c "$PYTEST_AM_CMD"
+    echo $?
     ret=$?
     if [ "$ret" = 5 ]; then
       # Okay if no tests are collected here e.g. downstream tests

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -33,9 +33,10 @@ fi
 echo $PYTEST_CMD
 sh -c "$PYTEST_CMD"
 
-if [[ "$PANDAS_DATA_MANAGER" != "array" ]]; then
+if [[ "$PANDAS_DATA_MANAGER" != "array" && $PYTEST_TARGET == "pandas" ]]; then
     # The ArrayManager tests should have already been run by PYTEST_CMD if PANDAS_DATA_MANAGER was already set to array
-    PYTEST_AM_CMD="PANDAS_DATA_MANAGER=array pytest -n $PYTEST_WORKERS --dist=loadfile $TEST_ARGS $COVERAGE $PYTEST_TARGET"
+    # If we're targeting specific files, e.g. test_downstream.py, don't run.
+    PYTEST_AM_CMD="PANDAS_DATA_MANAGER=array pytest -n $PYTEST_WORKERS --dist=loadfile $TEST_ARGS $COVERAGE pandas"
 
     if [[ "$PATTERN" ]]; then
       PYTEST_AM_CMD="$PYTEST_AM_CMD -m \"$PATTERN and arraymanager\""
@@ -45,12 +46,4 @@ if [[ "$PANDAS_DATA_MANAGER" != "array" ]]; then
 
     echo $PYTEST_AM_CMD
     sh -c "$PYTEST_AM_CMD"
-    echo $?
-    ret=$?
-    if [ "$ret" = 5 ]; then
-      # Okay if no tests are collected here e.g. downstream tests
-      echo "No tests collected. Exiting with 0 (instead of 5)."
-      exit 0
-    fi
-    exit "$ret"
 fi

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -33,7 +33,7 @@ fi
 echo $PYTEST_CMD
 sh -c "$PYTEST_CMD"
 
-if [[ "$PANDAS_DATA_MANAGER" != "array" && $PYTEST_TARGET == "pandas" ]]; then
+if [[ "$PANDAS_DATA_MANAGER" != "array" && "$PYTEST_TARGET" == "pandas" ]]; then
     # The ArrayManager tests should have already been run by PYTEST_CMD if PANDAS_DATA_MANAGER was already set to array
     # If we're targeting specific files, e.g. test_downstream.py, don't run.
     PYTEST_AM_CMD="PANDAS_DATA_MANAGER=array pytest -n $PYTEST_WORKERS --dist=loadfile $TEST_ARGS $COVERAGE pandas"

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -45,4 +45,11 @@ if [[ "$PANDAS_DATA_MANAGER" != "array" ]]; then
 
     echo $PYTEST_AM_CMD
     sh -c "$PYTEST_AM_CMD"
+    ret=$?
+    if [ "$ret" = 5 ]; then
+      # Okay if no tests are collected here e.g. downstream tests
+      echo "No tests collected. Exiting with 0 (instead of 5)."
+      exit 0
+    fi
+    exit "$ret"
 fi


### PR DESCRIPTION
This should shorten the downstream build such that `pandas/tests/test_downstream.py` is run instead of `pandas/`