### PR TITLE
TYP: annotation of __init__ return type (PEP 484) (pandas/core/computation)

### DIFF
--- a/pandas/core/computation/engines.py
+++ b/pandas/core/computation/engines.py
@@ -48,7 +48,7 @@ class AbstractEngine(metaclass=abc.ABCMeta):
 
     has_neg_frac = False
 
-    def __init__(self, expr):
+    def __init__(self, expr) -> None:
         self.expr = expr
         self.aligned_axes = None
         self.result_type = None

--- a/pandas/core/computation/expr.py
+++ b/pandas/core/computation/expr.py
@@ -393,7 +393,7 @@ class BaseExprVisitor(ast.NodeVisitor):
 
     unsupported_nodes: tuple[str, ...]
 
-    def __init__(self, env, engine, parser, preparser=_preparse):
+    def __init__(self, env, engine, parser, preparser=_preparse) -> None:
         self.env = env
         self.engine = engine
         self.parser = parser
@@ -768,13 +768,13 @@ class PandasExprVisitor(BaseExprVisitor):
             _preparse,
             f=_compose(_replace_locals, _replace_booleans, clean_backtick_quoted_toks),
         ),
-    ):
+    ) -> None:
         super().__init__(env, engine, parser, preparser)
 
 
 @disallow(_unsupported_nodes | _python_not_supported | frozenset(["Not"]))
 class PythonExprVisitor(BaseExprVisitor):
-    def __init__(self, env, engine, parser, preparser=lambda x: x):
+    def __init__(self, env, engine, parser, preparser=lambda x: x) -> None:
         super().__init__(env, engine, parser, preparser=preparser)
 
 
@@ -802,7 +802,7 @@ class Expr:
         parser: str = "pandas",
         env: Scope | None = None,
         level: int = 0,
-    ):
+    ) -> None:
         self.expr = expr
         self.env = env or Scope(level=level + 1)
         self.engine = engine

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -70,7 +70,7 @@ class UndefinedVariableError(NameError):
     NameError subclass for local variables.
     """
 
-    def __init__(self, name: str, is_local: bool | None = None):
+    def __init__(self, name: str, is_local: bool | None = None) -> None:
         base_msg = f"{repr(name)} is not defined"
         if is_local:
             msg = f"local variable {base_msg}"
@@ -88,7 +88,7 @@ class Term:
 
     is_local: bool
 
-    def __init__(self, name, env, side=None, encoding=None):
+    def __init__(self, name, env, side=None, encoding=None) -> None:
         # name is a str for Term, but may be something else for subclasses
         self._name = name
         self.env = env
@@ -189,7 +189,7 @@ class Term:
 
 
 class Constant(Term):
-    def __init__(self, value, env, side=None, encoding=None):
+    def __init__(self, value, env, side=None, encoding=None) -> None:
         super().__init__(value, env, side=side, encoding=encoding)
 
     def _resolve_name(self):
@@ -215,7 +215,7 @@ class Op:
 
     op: str
 
-    def __init__(self, op: str, operands: Iterable[Term | Op], encoding=None):
+    def __init__(self, op: str, operands: Iterable[Term | Op], encoding=None) -> None:
         self.op = _bool_op_map.get(op, op)
         self.operands = operands
         self.encoding = encoding
@@ -375,7 +375,7 @@ class BinOp(Op):
     rhs : Term or Op
     """
 
-    def __init__(self, op: str, lhs, rhs):
+    def __init__(self, op: str, lhs, rhs) -> None:
         super().__init__(op, (lhs, rhs))
         self.lhs = lhs
         self.rhs = rhs
@@ -530,7 +530,7 @@ class Div(BinOp):
         The Terms or Ops in the ``/`` expression.
     """
 
-    def __init__(self, lhs, rhs):
+    def __init__(self, lhs, rhs) -> None:
         super().__init__("/", lhs, rhs)
 
         if not isnumeric(lhs.return_type) or not isnumeric(rhs.return_type):
@@ -566,7 +566,7 @@ class UnaryOp(Op):
         * If no function associated with the passed operator token is found.
     """
 
-    def __init__(self, op: str, operand):
+    def __init__(self, op: str, operand) -> None:
         super().__init__(op, (operand,))
         self.operand = operand
 
@@ -598,7 +598,7 @@ class UnaryOp(Op):
 
 
 class MathCall(Op):
-    def __init__(self, func, args):
+    def __init__(self, func, args) -> None:
         super().__init__(func.name, args)
         self.func = func
 
@@ -614,7 +614,7 @@ class MathCall(Op):
 
 
 class FuncNode:
-    def __init__(self, name: str):
+    def __init__(self, name: str) -> None:
         if name not in MATHOPS:
             raise ValueError(f'"{name}" is not a supported function')
         self.name = name

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -48,7 +48,7 @@ class PyTablesScope(_scope.Scope):
         global_dict=None,
         local_dict=None,
         queryables: dict[str, Any] | None = None,
-    ):
+    ) -> None:
         super().__init__(level + 1, global_dict=global_dict, local_dict=local_dict)
         self.queryables = queryables or {}
 
@@ -63,7 +63,7 @@ class Term(ops.Term):
             klass = Constant
         return object.__new__(klass)
 
-    def __init__(self, name, env: PyTablesScope, side=None, encoding=None):
+    def __init__(self, name, env: PyTablesScope, side=None, encoding=None) -> None:
         super().__init__(name, env, side=side, encoding=encoding)
 
     def _resolve_name(self):
@@ -87,7 +87,7 @@ class Term(ops.Term):
 
 
 class Constant(Term):
-    def __init__(self, value, env: PyTablesScope, side=None, encoding=None):
+    def __init__(self, value, env: PyTablesScope, side=None, encoding=None) -> None:
         assert isinstance(env, PyTablesScope), type(env)
         super().__init__(value, env, side=side, encoding=encoding)
 
@@ -103,7 +103,7 @@ class BinOp(ops.BinOp):
     queryables: dict[str, Any]
     condition: str | None
 
-    def __init__(self, op: str, lhs, rhs, queryables: dict[str, Any], encoding):
+    def __init__(self, op: str, lhs, rhs, queryables: dict[str, Any], encoding) -> None:
         super().__init__(op, lhs, rhs)
         self.queryables = queryables
         self.encoding = encoding
@@ -407,7 +407,7 @@ class PyTablesExprVisitor(BaseExprVisitor):
     const_type = Constant
     term_type = Term
 
-    def __init__(self, env, engine, parser, **kwargs):
+    def __init__(self, env, engine, parser, **kwargs) -> None:
         super().__init__(env, engine, parser)
         for bin_op in self.binary_ops:
             bin_node = self.binary_op_nodes_map[bin_op]
@@ -552,7 +552,7 @@ class PyTablesExpr(expr.Expr):
         queryables: dict[str, Any] | None = None,
         encoding=None,
         scope_level: int = 0,
-    ):
+    ) -> None:
 
         where = _validate_where(where)
 
@@ -624,7 +624,7 @@ class PyTablesExpr(expr.Expr):
 class TermValue:
     """hold a term value the we use to construct a condition/filter"""
 
-    def __init__(self, value, converted, kind: str):
+    def __init__(self, value, converted, kind: str) -> None:
         assert isinstance(kind, str), kind
         self.value = value
         self.converted = converted

--- a/pandas/core/computation/scope.py
+++ b/pandas/core/computation/scope.py
@@ -113,7 +113,7 @@ class Scope:
 
     def __init__(
         self, level: int, global_dict=None, local_dict=None, resolvers=(), target=None
-    ):
+    ) -> None:
         self.level = level + 1
 
         # shallow copy because we don't want to keep filling this up with what


### PR DESCRIPTION
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

According to [documentation](https://pandas.pydata.org/docs/dev/development/contributing_codebase.html#type-hints) pandas uses [PEP484](https://www.python.org/dev/peps/pep-0484/) for type hints.
PEP484 states that `__init__` function should have `-> None` return type annotation.
In this PR I added return type annotation to `__init__` functions in `pandas/core/computation` module