### PR TITLE
CI/TST: numpy 1.22.3 release fixes

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1088,9 +1088,7 @@ class MultiIndex(Index):
         # equivalent to sorting lexicographically the codes themselves. Notice
         # that each level needs to be shifted by the number of bits needed to
         # represent the _previous_ ones:
-        offsets = np.concatenate([lev_bits[1:], [0]]).astype(  # type: ignore[arg-type]
-            "uint64"
-        )
+        offsets = np.concatenate([lev_bits[1:], [0]]).astype("uint64")
 
         # Check the total number of bits needed for our representation:
         if lev_bits[0] > 64:

--- a/pandas/tests/frame/test_ufunc.py
+++ b/pandas/tests/frame/test_ufunc.py
@@ -263,12 +263,6 @@ def test_alignment_deprecation_many_inputs(request):
     )
 
     if np_version_gte1p22:
-        mark = pytest.mark.xfail(
-            reason="ufunc 'my_ufunc' did not contain a loop with signature matching "
-            "types",
-        )
-        request.node.add_marker(mark)
-
         mark = pytest.mark.filterwarnings(
             "ignore:`np.MachAr` is deprecated.*:DeprecationWarning"
         )


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Looks like this is xpassing now

```
___________________ test_alignment_deprecation_many_inputs ____________________
[gw0] win32 -- Python 3.9.10 C:\Miniconda\envs\pandas-dev\python.exe
[XPASS(strict)] ufunc 'my_ufunc' did not contain a loop with signature matching types
```
