### PR TITLE
BLD: Upload sdist artifact from CI

### DIFF
--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Upload sdist artifact
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ github.sha }}-${{matrix.python-version}}-sdist.gz
+        name: ${{matrix.python-version}}-sdist.gz
         path: dist/*.gz
 
     - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -54,6 +54,12 @@ jobs:
         pip list
         python setup.py sdist --formats=gztar
 
+    - name: Upload sdist artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.ref }}-${{matrix.python-version}}-sdist.gz
+        path: dist/*.gz
+
     - uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: pandas-sdist

--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Upload sdist artifact
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ github.ref }}-${{matrix.python-version}}-sdist.gz
+        name: ${{ github.sha }}-${{matrix.python-version}}-sdist.gz
         path: dist/*.gz
 
     - uses: conda-incubator/setup-miniconda@v2


### PR DESCRIPTION
Now it is possible to inspect the sdist that is built, to
see what was included and
for debugging.

Inspired by needing to see what was acutally included in the sdist at
https://github.com/pandas-dev/pandas/pull/46271

- [x] related to #46271 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] NA Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

@fangchenli again. Thank you!