### PR TITLE
TYP: annotation of __init__ return type (PEP 484) (pandas/tests)

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1088,9 +1088,7 @@ class MultiIndex(Index):
         # equivalent to sorting lexicographically the codes themselves. Notice
         # that each level needs to be shifted by the number of bits needed to
         # represent the _previous_ ones:
-        offsets = np.concatenate([lev_bits[1:], [0]]).astype(  # type: ignore[arg-type]
-            "uint64"
-        )
+        offsets = np.concatenate([lev_bits[1:], [0]]).astype("uint64")
 
         # Check the total number of bits needed for our representation:
         if lev_bits[0] > 64:

--- a/pandas/tests/base/test_constructors.py
+++ b/pandas/tests/base/test_constructors.py
@@ -51,7 +51,7 @@ class TestPandasDelegate:
             pass
 
     class Delegate(PandasDelegate, PandasObject):
-        def __init__(self, obj):
+        def __init__(self, obj) -> None:
             self.obj = obj
 
     def test_invalid_delegation(self):

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -91,7 +91,7 @@ class MockNumpyLikeArray:
     a scalar (`is_scalar(np.array(1)) == False`), but it is not list-like either.
     """
 
-    def __init__(self, values):
+    def __init__(self, values) -> None:
         self._values = values
 
     def __iter__(self):
@@ -323,7 +323,7 @@ def test_is_dict_like_fails(ll):
 @pytest.mark.parametrize("has_contains", [True, False])
 def test_is_dict_like_duck_type(has_keys, has_getitem, has_contains):
     class DictLike:
-        def __init__(self, d):
+        def __init__(self, d) -> None:
             self.d = d
 
         if has_keys:
@@ -1937,7 +1937,7 @@ class TestIsScalar:
         #  subclasses are.
 
         class Numeric(Number):
-            def __init__(self, value):
+            def __init__(self, value) -> None:
                 self.value = value
 
             def __int__(self):

--- a/pandas/tests/extension/arrow/arrays.py
+++ b/pandas/tests/extension/arrow/arrays.py
@@ -179,7 +179,7 @@ class ArrowExtensionArray(OpsMixin, _ArrowExtensionArray):
 
 
 class ArrowBoolArray(ArrowExtensionArray):
-    def __init__(self, values):
+    def __init__(self, values) -> None:
         if not isinstance(values, pa.ChunkedArray):
             raise ValueError
 
@@ -189,7 +189,7 @@ class ArrowBoolArray(ArrowExtensionArray):
 
 
 class ArrowStringArray(ArrowExtensionArray):
-    def __init__(self, values):
+    def __init__(self, values) -> None:
         if not isinstance(values, pa.ChunkedArray):
             raise ValueError
 

--- a/pandas/tests/extension/arrow/test_timestamp.py
+++ b/pandas/tests/extension/arrow/test_timestamp.py
@@ -40,7 +40,7 @@ class ArrowTimestampUSDtype(ExtensionDtype):
 
 
 class ArrowTimestampUSArray(ArrowExtensionArray):
-    def __init__(self, values):
+    def __init__(self, values) -> None:
         if not isinstance(values, pa.ChunkedArray):
             raise ValueError
 

--- a/pandas/tests/extension/decimal/array.py
+++ b/pandas/tests/extension/decimal/array.py
@@ -41,7 +41,7 @@ class DecimalDtype(ExtensionDtype):
     na_value = decimal.Decimal("NaN")
     _metadata = ("context",)
 
-    def __init__(self, context=None):
+    def __init__(self, context=None) -> None:
         self.context = context or decimal.getcontext()
 
     def __repr__(self) -> str:
@@ -66,7 +66,7 @@ class DecimalDtype(ExtensionDtype):
 class DecimalArray(OpsMixin, ExtensionScalarOpsMixin, ExtensionArray):
     __array_priority__ = 1000
 
-    def __init__(self, values, dtype=None, copy=False, context=None):
+    def __init__(self, values, dtype=None, copy=False, context=None) -> None:
         for i, val in enumerate(values):
             if is_float(val):
                 if np.isnan(val):

--- a/pandas/tests/extension/json/array.py
+++ b/pandas/tests/extension/json/array.py
@@ -67,7 +67,7 @@ class JSONArray(ExtensionArray):
     dtype = JSONDtype()
     __array_priority__ = 1000
 
-    def __init__(self, values, dtype=None, copy=False):
+    def __init__(self, values, dtype=None, copy=False) -> None:
         for val in values:
             if not isinstance(val, self.dtype.type):
                 raise TypeError("All values must be of type " + str(self.dtype.type))

--- a/pandas/tests/extension/list/array.py
+++ b/pandas/tests/extension/list/array.py
@@ -44,7 +44,7 @@ class ListArray(ExtensionArray):
     dtype = ListDtype()
     __array_priority__ = 1000
 
-    def __init__(self, values, dtype=None, copy=False):
+    def __init__(self, values, dtype=None, copy=False) -> None:
         if not isinstance(values, np.ndarray):
             raise TypeError("Need to pass a numpy array as values")
         for val in values:

--- a/pandas/tests/extension/test_common.py
+++ b/pandas/tests/extension/test_common.py
@@ -14,7 +14,7 @@ class DummyDtype(dtypes.ExtensionDtype):
 
 
 class DummyArray(ExtensionArray):
-    def __init__(self, data):
+    def __init__(self, data) -> None:
         self.data = data
 
     def __array__(self, dtype):

--- a/pandas/tests/extension/test_extension.py
+++ b/pandas/tests/extension/test_extension.py
@@ -8,7 +8,7 @@ from pandas.core.arrays import ExtensionArray
 
 
 class MyEA(ExtensionArray):
-    def __init__(self, values):
+    def __init__(self, values) -> None:
         self._values = values
 
 

--- a/pandas/tests/frame/constructors/test_from_records.py
+++ b/pandas/tests/frame/constructors/test_from_records.py
@@ -194,7 +194,7 @@ class TestFromRecords:
 
     def test_from_records_non_tuple(self):
         class Record:
-            def __init__(self, *args):
+            def __init__(self, *args) -> None:
                 self.args = args
 
             def __getitem__(self, i):

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -15,7 +15,7 @@ from pandas.core.arrays import ExtensionArray
 class DummyDtype(ExtensionDtype):
     type = int
 
-    def __init__(self, numeric):
+    def __init__(self, numeric) -> None:
         self._numeric = numeric
 
     @property
@@ -28,7 +28,7 @@ class DummyDtype(ExtensionDtype):
 
 
 class DummyArray(ExtensionArray):
-    def __init__(self, data, dtype):
+    def __init__(self, data, dtype) -> None:
         self.data = data
         self._dtype = dtype
 

--- a/pandas/tests/frame/methods/test_set_index.py
+++ b/pandas/tests/frame/methods/test_set_index.py
@@ -595,7 +595,7 @@ class TestSetIndexCustomLabelType:
         # GH#24969
 
         class Thing:
-            def __init__(self, name, color):
+            def __init__(self, name, color) -> None:
                 self.name = name
                 self.color = color
 
@@ -673,7 +673,7 @@ class TestSetIndexCustomLabelType:
 
         # purposefully inherit from something unhashable
         class Thing(set):
-            def __init__(self, name, color):
+            def __init__(self, name, color) -> None:
                 self.name = name
                 self.color = color
 

--- a/pandas/tests/frame/methods/test_to_records.py
+++ b/pandas/tests/frame/methods/test_to_records.py
@@ -358,7 +358,7 @@ class TestDataFrameToRecords:
     def test_to_records_dict_like(self):
         # see GH#18146
         class DictLike:
-            def __init__(self, **kwargs):
+            def __init__(self, **kwargs) -> None:
                 self.d = kwargs.copy()
 
             def __getitem__(self, key):

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -41,7 +41,7 @@ def switch_numexpr_min_elements(request):
 
 
 class DummyElement:
-    def __init__(self, value, dtype):
+    def __init__(self, value, dtype) -> None:
         self.value = value
         self.dtype = np.dtype(dtype)
 

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1363,7 +1363,7 @@ class TestDataFrameConstructors:
         # collections.Sequence like
 
         class DummyContainer(abc.Sequence):
-            def __init__(self, lst):
+            def __init__(self, lst) -> None:
                 self._lst = lst
 
             def __getitem__(self, n):

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -1861,7 +1861,7 @@ Thu,Lunch,Yes,51.51,17"""
         # GH 26314: Change ValueError to PerformanceWarning
 
         class MockUnstacker(reshape_lib._Unstacker):
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs) -> None:
                 # __init__ will raise the warning
                 super().__init__(*args, **kwargs)
                 raise Exception("Don't compute final result.")

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -42,7 +42,7 @@ class TestDataFrameSubclassing:
             custom plotting functions.
             """
 
-            def __init__(self, *args, **kw):
+            def __init__(self, *args, **kw) -> None:
                 super().__init__(*args, **kw)
 
             @property

--- a/pandas/tests/groupby/test_counting.py
+++ b/pandas/tests/groupby/test_counting.py
@@ -364,7 +364,7 @@ def test_count_uses_size_on_exception():
         pass
 
     class RaisingObject:
-        def __init__(self, msg="I will raise inside Cython"):
+        def __init__(self, msg="I will raise inside Cython") -> None:
             super().__init__()
             self.msg = msg
 

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -40,7 +40,7 @@ import pandas._testing as tm
 class FixedOffset(tzinfo):
     """Fixed offset in minutes east from UTC."""
 
-    def __init__(self, offset, name):
+    def __init__(self, offset, name) -> None:
         self.__offset = timedelta(minutes=offset)
         self.__name = name
 

--- a/pandas/tests/indexes/test_index_new.py
+++ b/pandas/tests/indexes/test_index_new.py
@@ -352,7 +352,7 @@ class TestIndexConstructorUnwrapping:
         # it should be possible to convert any object that satisfies the numpy
         # ndarray interface directly into an Index
         class ArrayLike:
-            def __init__(self, array):
+            def __init__(self, array) -> None:
                 self.array = array
 
             def __array__(self, dtype=None) -> np.ndarray:

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -1072,7 +1072,7 @@ class TestiLocBaseIndependent:
     def test_iloc_setitem_custom_object(self):
         # iloc with an object
         class TO:
-            def __init__(self, value):
+            def __init__(self, value) -> None:
                 self.value = value
 
             def __str__(self) -> str:

--- a/pandas/tests/io/formats/test_console.py
+++ b/pandas/tests/io/formats/test_console.py
@@ -12,7 +12,7 @@ class MockEncoding:
     side effect should be an exception that will be raised.
     """
 
-    def __init__(self, encoding):
+    def __init__(self, encoding) -> None:
         super().__init__()
         self.val = encoding
 

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1817,7 +1817,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
 
     def test_to_json_series_of_objects(self):
         class _TestObject:
-            def __init__(self, a, b, _c, d) -> None
+            def __init__(self, a, b, _c, d) -> None:
                 self.a = a
                 self.b = b
                 self._c = _c

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -585,7 +585,7 @@ class TestPandasContainer:
         # GH14256: failing column caused segfaults, if it is not the last one
 
         class BinaryThing:
-            def __init__(self, hexed):
+            def __init__(self, hexed) -> None:
                 self.hexed = hexed
                 self.binary = bytes.fromhex(hexed)
 
@@ -1817,7 +1817,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
 
     def test_to_json_series_of_objects(self):
         class _TestObject:
-            def __init__(self, a, b, _c, d):
+            def __init__(self, a, b, _c, d) -> None
                 self.a = a
                 self.b = b
                 self._c = _c

--- a/pandas/tests/io/json/test_readlines.py
+++ b/pandas/tests/io/json/test_readlines.py
@@ -281,7 +281,7 @@ def test_chunksize_is_incremental():
     )
 
     class MyReader:
-        def __init__(self, contents):
+        def __init__(self, contents) -> None:
             self.read_count = 0
             self.stringio = StringIO(contents)
 

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -660,7 +660,7 @@ class TestUltraJSONTests:
 
     def test_default_handler(self):
         class _TestObject:
-            def __init__(self, val):
+            def __init__(self, val) -> None:
                 self.val = val
 
             @property
@@ -714,7 +714,7 @@ class TestUltraJSONTests:
 
     def test_encode_object(self):
         class _TestObject:
-            def __init__(self, a, b, _c, d):
+            def __init__(self, a, b, _c, d) -> None:
                 self.a = a
                 self.b = b
                 self._c = _c

--- a/pandas/tests/io/parser/common/test_common_basic.py
+++ b/pandas/tests/io/parser/common/test_common_basic.py
@@ -41,7 +41,7 @@ def test_override_set_noconvert_columns():
     # Usecols needs to be sorted in _set_noconvert_columns based
     # on the test_usecols_with_parse_dates test from test_usecols.py
     class MyTextFileReader(TextFileReader):
-        def __init__(self):
+        def __init__(self) -> None:
             self._currow = 0
             self.squeeze = False
 

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -319,7 +319,7 @@ def test_python_engine_file_no_next(python_parser_only):
     parser = python_parser_only
 
     class NoNextBuffer:
-        def __init__(self, csv_data):
+        def __init__(self, csv_data) -> None:
             self.data = csv_data
 
         def __iter__(self):

--- a/pandas/tests/io/parser/test_unsupported.py
+++ b/pandas/tests/io/parser/test_unsupported.py
@@ -114,7 +114,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
     def test_python_engine_file_no_iter(self, python_engine):
         # see gh-16530
         class NoNextBuffer:
-            def __init__(self, csv_data):
+            def __init__(self, csv_data) -> None:
                 self.data = csv_data
 
             def __next__(self):

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -28,7 +28,7 @@ import pandas.io.common as icom
 class CustomFSPath:
     """For testing fspath on unknown objects"""
 
-    def __init__(self, path):
+    def __init__(self, path) -> None:
         self.path = path
 
     def __fspath__(self):

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -1243,7 +1243,7 @@ class TestReadHtml:
         # Issue #17975
 
         class MockFile:
-            def __init__(self, data):
+            def __init__(self, data) -> None:
                 self.data = data
                 self.at_end = False
 

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -441,7 +441,7 @@ def test_pickle_generalurl_read(monkeypatch, mockurl):
             if "gzip" in path:
                 self.headers = {"Content-Encoding": "gzip"}
             else:
-                self.headers = {"Content-Encoding": None}
+                self.headers = {"Content-Encoding": ""}
 
         def __enter__(self):
             return self

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -436,7 +436,7 @@ def test_pickle_generalurl_read(monkeypatch, mockurl):
             pickle.dump(obj, fh, protocol=-1)
 
     class MockReadResponse:
-        def __init__(self, path):
+        def __init__(self, path) -> None:
             self.file = open(path, "rb")
             if "gzip" in path:
                 self.headers = {"Content-Encoding": "gzip"}
@@ -478,7 +478,7 @@ def test_pickle_fsspec_roundtrip():
 
 
 class MyTz(datetime.tzinfo):
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
 

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1538,7 +1538,7 @@ class TestSQLiteFallbackApi(SQLiteMixIn, _TestSQLApi):
         self,
     ):
         class MockSqliteConnection:
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs) -> None:
                 self.conn = sqlite3.Connection(*args, **kwargs)
 
             def __getattr__(self, name):

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1999,7 +1999,7 @@ class TestPivotTable:
         # GH 20601
         # GH 26314: Change ValueError to PerformanceWarning
         class MockUnstacker(reshape_lib._Unstacker):
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs) -> None:
                 # __init__ will raise the warning
                 super().__init__(*args, **kwargs)
                 raise Exception("Don't compute final result.")

--- a/pandas/tests/scalar/timedelta/test_arithmetic.py
+++ b/pandas/tests/scalar/timedelta/test_arithmetic.py
@@ -988,7 +988,7 @@ class TestTimedeltaComparison:
         """
 
         class CustomClass:
-            def __init__(self, cmp_result=None):
+            def __init__(self, cmp_result=None) -> None:
                 self.cmp_result = cmp_result
 
             def generic_result(self):

--- a/pandas/tests/series/methods/test_is_unique.py
+++ b/pandas/tests/series/methods/test_is_unique.py
@@ -26,7 +26,7 @@ def test_is_unique(data, expected):
 def test_is_unique_class_ne(capsys):
     # GH#20661
     class Foo:
-        def __init__(self, val):
+        def __init__(self, val) -> None:
             self._value = val
 
         def __ne__(self, other):

--- a/pandas/tests/series/test_ufunc.py
+++ b/pandas/tests/series/test_ufunc.py
@@ -238,7 +238,7 @@ def test_binary_ufunc_drops_series_name(ufunc, sparse, arrays_for_binary_ufunc):
 
 def test_object_series_ok():
     class Dummy:
-        def __init__(self, value):
+        def __init__(self, value) -> None:
             self.value = value
 
         def __add__(self, other):
@@ -413,7 +413,7 @@ def test_binary_ufunc_other_types(type_):
 
 def test_object_dtype_ok():
     class Thing:
-        def __init__(self, value):
+        def __init__(self, value) -> None:
             self.value = value
 
         def __add__(self, other):

--- a/pandas/tests/test_register_accessor.py
+++ b/pandas/tests/test_register_accessor.py
@@ -14,7 +14,7 @@ def test_dirname_mixin():
         x = 1
         y: int
 
-        def __init__(self):
+        def __init__(self) -> None:
             self.z = 3
 
     result = [attr_name for attr_name in dir(X()) if not attr_name.startswith("_")]
@@ -38,7 +38,7 @@ def ensure_removed(obj, attr):
 
 
 class MyAccessor:
-    def __init__(self, obj):
+    def __init__(self, obj) -> None:
         self.obj = obj
         self.item = "item"
 
@@ -102,7 +102,7 @@ def test_raises_attribute_error():
 
         @pd.api.extensions.register_series_accessor("bad")
         class Bad:
-            def __init__(self, data):
+            def __init__(self, data) -> None:
                 raise AttributeError("whoops")
 
         with pytest.raises(AttributeError, match="whoops"):

--- a/pandas/tests/tseries/holiday/test_calendar.py
+++ b/pandas/tests/tseries/holiday/test_calendar.py
@@ -50,7 +50,7 @@ def test_calendar_caching():
     # see gh-9552.
 
     class TestCalendar(AbstractHolidayCalendar):
-        def __init__(self, name=None, rules=None):
+        def __init__(self, name=None, rules=None) -> None:
             super().__init__(name=name, rules=rules)
 
     jan1 = TestCalendar(rules=[Holiday("jan1", year=2015, month=1, day=1)])


### PR DESCRIPTION
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

According to [documentation](https://pandas.pydata.org/docs/dev/development/contributing_codebase.html#type-hints) pandas uses [PEP484](https://www.python.org/dev/peps/pep-0484/) for type hints.
PEP484 states that `__init__` function should have `-> None` return type annotation.
In this PR I added return type annotation to `__init__` functions in `pandas/tests` module
