### PR TITLE
TYP: annotation of __init__ return type (PEP 484) (pandas/core)

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1098,7 +1098,7 @@ def checked_add_with_arr(
 
 
 class SelectN:
-    def __init__(self, obj, n: int, keep: str):
+    def __init__(self, obj, n: int, keep: str) -> None:
         self.obj = obj
         self.n = n
         self.keep = keep
@@ -1218,7 +1218,7 @@ class SelectNFrame(SelectN):
     nordered : DataFrame
     """
 
-    def __init__(self, obj: DataFrame, n: int, keep: str, columns: IndexLabel):
+    def __init__(self, obj: DataFrame, n: int, keep: str, columns: IndexLabel) -> None:
         super().__init__(obj, n, keep)
         if not is_list_like(columns) or isinstance(columns, tuple):
             columns = [columns]

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -113,7 +113,7 @@ class Apply(metaclass=abc.ABCMeta):
         result_type: str | None,
         args,
         kwargs,
-    ):
+    ) -> None:
         self.obj = obj
         self.raw = raw
         self.args = args or ()
@@ -1053,7 +1053,7 @@ class SeriesApply(NDFrameApply):
         convert_dtype: bool,
         args,
         kwargs,
-    ):
+    ) -> None:
         self.convert_dtype = convert_dtype
 
         super().__init__(
@@ -1157,7 +1157,7 @@ class GroupByApply(Apply):
         func: AggFuncType,
         args,
         kwargs,
-    ):
+    ) -> None:
         kwargs = kwargs.copy()
         self.axis = obj.obj._get_axis_number(kwargs.get("axis", 0))
         super().__init__(
@@ -1186,7 +1186,7 @@ class ResamplerWindowApply(Apply):
         func: AggFuncType,
         args,
         kwargs,
-    ):
+    ) -> None:
         super().__init__(
             obj,
             func,

--- a/pandas/core/describe.py
+++ b/pandas/core/describe.py
@@ -106,7 +106,7 @@ class NDFrameDescriberAbstract(ABC):
         Whether to treat datetime dtypes as numeric.
     """
 
-    def __init__(self, obj: DataFrame | Series, datetime_is_numeric: bool):
+    def __init__(self, obj: DataFrame | Series, datetime_is_numeric: bool) -> None:
         self.obj = obj
         self.datetime_is_numeric = datetime_is_numeric
 
@@ -156,7 +156,7 @@ class DataFrameDescriber(NDFrameDescriberAbstract):
         include: str | Sequence[str] | None,
         exclude: str | Sequence[str] | None,
         datetime_is_numeric: bool,
-    ):
+    ) -> None:
         self.include = include
         self.exclude = exclude
 

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -430,7 +430,7 @@ class Registry:
     These are tried in order.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.dtypes: list[type_t[ExtensionDtype]] = []
 
     def register(self, dtype: type_t[ExtensionDtype]) -> None:

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -181,7 +181,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
     _metadata = ("categories", "ordered")
     _cache_dtypes: dict[str_type, PandasExtensionDtype] = {}
 
-    def __init__(self, categories=None, ordered: Ordered = False):
+    def __init__(self, categories=None, ordered: Ordered = False) -> None:
         self._finalize(categories, ordered, fastpath=False)
 
     @classmethod
@@ -672,7 +672,7 @@ class DatetimeTZDtype(PandasExtensionDtype):
     _match = re.compile(r"(datetime64|M8)\[(?P<unit>.+), (?P<tz>.+)\]")
     _cache_dtypes: dict[str_type, PandasExtensionDtype] = {}
 
-    def __init__(self, unit: str_type | DatetimeTZDtype = "ns", tz=None):
+    def __init__(self, unit: str_type | DatetimeTZDtype = "ns", tz=None) -> None:
         if isinstance(unit, DatetimeTZDtype):
             # error: "str" has no attribute "tz"
             unit, tz = unit.unit, unit.tz  # type: ignore[attr-defined]
@@ -1303,7 +1303,7 @@ class PandasDtype(ExtensionDtype):
 
     _metadata = ("_dtype",)
 
-    def __init__(self, dtype: npt.DTypeLike | PandasDtype | None):
+    def __init__(self, dtype: npt.DTypeLike | PandasDtype | None) -> None:
         if isinstance(dtype, PandasDtype):
             # make constructor univalent
             dtype = dtype.numpy_dtype

--- a/pandas/core/flags.py
+++ b/pandas/core/flags.py
@@ -44,7 +44,7 @@ class Flags:
 
     _keys = {"allows_duplicate_labels"}
 
-    def __init__(self, obj, *, allows_duplicate_labels):
+    def __init__(self, obj, *, allows_duplicate_labels) -> None:
         self._allows_duplicate_labels = allows_duplicate_labels
         self._obj = weakref.ref(obj)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -595,7 +595,7 @@ class DataFrame(NDFrame, OpsMixin):
         columns: Axes | None = None,
         dtype: Dtype | None = None,
         copy: bool | None = None,
-    ):
+    ) -> None:
 
         if data is None:
             data = {}

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -243,7 +243,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         data: Manager,
         copy: bool_t = False,
         attrs: Mapping[Hashable, Any] | None = None,
-    ):
+    ) -> None:
         # copy kwarg is retained for mypy compat, is not used
 
         object.__setattr__(self, "_is_copy", None)

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -533,7 +533,7 @@ class GroupByPlot(PandasObject):
     Class implementing the .plot attribute for groupby objects.
     """
 
-    def __init__(self, groupby: GroupBy):
+    def __init__(self, groupby: GroupBy) -> None:
         self._groupby = groupby
 
     def __call__(self, *args, **kwargs):
@@ -854,7 +854,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         observed: bool = False,
         mutated: bool = False,
         dropna: bool = True,
-    ):
+    ) -> None:
 
         self._selection = selection
 

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -281,7 +281,7 @@ class Grouper:
         axis: int = 0,
         sort: bool = False,
         dropna: bool = True,
-    ):
+    ) -> None:
         self.key = key
         self.level = level
         self.freq = freq
@@ -475,7 +475,7 @@ class Grouping:
         observed: bool = False,
         in_axis: bool = False,
         dropna: bool = True,
-    ):
+    ) -> None:
         self.level = level
         self._orig_grouper = grouper
         self.grouping_vector = _convert_grouper(index, grouper)

--- a/pandas/core/groupby/indexing.py
+++ b/pandas/core/groupby/indexing.py
@@ -245,7 +245,7 @@ class GroupByIndexingMixin:
 
 @doc(GroupByIndexingMixin._positional_selector)
 class GroupByPositionalSelector:
-    def __init__(self, groupby_object: groupby.GroupBy):
+    def __init__(self, groupby_object: groupby.GroupBy) -> None:
         self.groupby_object = groupby_object
 
     def __getitem__(self, arg: PositionalIndexer | tuple) -> DataFrame | Series:
@@ -289,7 +289,7 @@ class GroupByNthSelector:
     Dynamically substituted for GroupBy.nth to enable both call and index
     """
 
-    def __init__(self, groupby_object: groupby.GroupBy):
+    def __init__(self, groupby_object: groupby.GroupBy) -> None:
         self.groupby_object = groupby_object
 
     def __call__(

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -104,7 +104,7 @@ class WrappedCythonOp:
     #  back to the original dtype.
     cast_blocklist = frozenset(["rank", "count", "size", "idxmin", "idxmax"])
 
-    def __init__(self, kind: str, how: str):
+    def __init__(self, kind: str, how: str) -> None:
         self.kind = kind
         self.how = how
 
@@ -687,7 +687,7 @@ class BaseGrouper:
         mutated: bool = False,
         indexer: npt.NDArray[np.intp] | None = None,
         dropna: bool = True,
-    ):
+    ) -> None:
         assert isinstance(axis, Index), axis
 
         self.axis = axis
@@ -1091,7 +1091,7 @@ class BinGrouper(BaseGrouper):
         binlabels,
         mutated: bool = False,
         indexer=None,
-    ):
+    ) -> None:
         self.bins = ensure_int64(bins)
         self.binlabels = ensure_index(binlabels)
         self.mutated = mutated
@@ -1237,7 +1237,7 @@ class DataSplitter(Generic[NDFrameT]):
         labels: npt.NDArray[np.intp],
         ngroups: int,
         axis: int = 0,
-    ):
+    ) -> None:
         self.data = data
         self.labels = ensure_platform_int(labels)  # _should_ already be np.intp
         self.ngroups = ngroups

--- a/pandas/core/indexers/objects.py
+++ b/pandas/core/indexers/objects.py
@@ -45,7 +45,7 @@ class BaseIndexer:
 
     def __init__(
         self, index_array: np.ndarray | None = None, window_size: int = 0, **kwargs
-    ):
+    ) -> None:
         """
         Parameters
         ----------
@@ -139,7 +139,7 @@ class VariableOffsetWindowIndexer(BaseIndexer):
         index=None,
         offset=None,
         **kwargs,
-    ):
+    ) -> None:
         super().__init__(index_array, window_size, **kwargs)
         self.index = index
         self.offset = offset
@@ -300,7 +300,7 @@ class GroupbyIndexer(BaseIndexer):
         window_indexer: type[BaseIndexer] = BaseIndexer,
         indexer_kwargs: dict | None = None,
         **kwargs,
-    ):
+    ) -> None:
         """
         Parameters
         ----------

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -47,7 +47,7 @@ class Properties(PandasDelegate, PandasObject, NoNewAttributesMixin):
         "name",
     }
 
-    def __init__(self, data: Series, orig):
+    def __init__(self, data: Series, orig) -> None:
         if not isinstance(data, ABCSeries):
             raise TypeError(
                 f"cannot convert an object of type {type(data)} to a datetimelike index"

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1088,9 +1088,7 @@ class MultiIndex(Index):
         # equivalent to sorting lexicographically the codes themselves. Notice
         # that each level needs to be shifted by the number of bits needed to
         # represent the _previous_ ones:
-        offsets = np.concatenate([lev_bits[1:], [0]]).astype(  # type: ignore[arg-type]
-            "uint64"
-        )
+        offsets = np.concatenate([lev_bits[1:], [0]]).astype("uint64")
 
         # Check the total number of bits needed for our representation:
         if lev_bits[0] > 64:

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -129,7 +129,7 @@ class BaseArrayManager(DataManager):
         arrays: list[np.ndarray | ExtensionArray],
         axes: list[Index],
         verify_integrity: bool = True,
-    ):
+    ) -> None:
         raise NotImplementedError
 
     def make_empty(self: T, axes=None) -> T:
@@ -710,7 +710,7 @@ class ArrayManager(BaseArrayManager):
         arrays: list[np.ndarray | ExtensionArray],
         axes: list[Index],
         verify_integrity: bool = True,
-    ):
+    ) -> None:
         # Note: we are storing the axes in "_axes" in the (row, columns) order
         # which contrasts the order how it is stored in BlockManager
         self._axes = axes
@@ -1182,7 +1182,7 @@ class SingleArrayManager(BaseArrayManager, SingleDataManager):
         arrays: list[np.ndarray | ExtensionArray],
         axes: list[Index],
         verify_integrity: bool = True,
-    ):
+    ) -> None:
         self._axes = axes
         self.arrays = arrays
 
@@ -1347,7 +1347,7 @@ class NullArrayProxy:
 
     ndim = 1
 
-    def __init__(self, n: int):
+    def __init__(self, n: int) -> None:
         self.n = n
 
     @property

--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -382,7 +382,7 @@ def _get_mgr_concatenation_plan(mgr: BlockManager):
 
 
 class JoinUnit:
-    def __init__(self, block: Block):
+    def __init__(self, block: Block) -> None:
         self.block = block
 
     def __repr__(self) -> str:

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -146,7 +146,7 @@ class BaseBlockManager(DataManager):
     _known_consolidated: bool
     _is_consolidated: bool
 
-    def __init__(self, blocks, axes, verify_integrity: bool = True):
+    def __init__(self, blocks, axes, verify_integrity: bool = True) -> None:
         raise NotImplementedError
 
     @classmethod
@@ -886,7 +886,7 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         blocks: Sequence[Block],
         axes: Sequence[Index],
         verify_integrity: bool = True,
-    ):
+    ) -> None:
 
         if verify_integrity:
             # Assertion disabled for performance
@@ -1676,7 +1676,7 @@ class SingleBlockManager(BaseBlockManager, SingleDataManager):
         axis: Index,
         verify_integrity: bool = False,
         fastpath=lib.no_default,
-    ):
+    ) -> None:
         # Assertions disabled for performance
         # assert isinstance(block, Block), type(block)
         # assert isinstance(axis, Index), type(axis)

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -72,7 +72,7 @@ set_use_bottleneck(get_option("compute.use_bottleneck"))
 
 
 class disallow:
-    def __init__(self, *dtypes: Dtype):
+    def __init__(self, *dtypes: Dtype) -> None:
         super().__init__()
         self.dtypes = tuple(pandas_dtype(dtype).type for dtype in dtypes)
 
@@ -104,7 +104,7 @@ class disallow:
 
 
 class bottleneck_switch:
-    def __init__(self, name=None, **kwargs):
+    def __init__(self, name=None, **kwargs) -> None:
         self.name = name
         self.kwargs = kwargs
 

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -151,7 +151,7 @@ class Resampler(BaseGroupBy, PandasObject):
         *,
         selection=None,
         **kwargs,
-    ):
+    ) -> None:
         self.groupby = groupby
         self.keys = None
         self.sort = True
@@ -1060,7 +1060,7 @@ class _GroupByMixin(PandasObject):
     _attributes: list[str]  # in practice the same as Resampler._attributes
     _selection: IndexLabel | None = None
 
-    def __init__(self, obj, parent=None, groupby=None, **kwargs):
+    def __init__(self, obj, parent=None, groupby=None, **kwargs) -> None:
         # reached via ._gotitem and _get_resampler_for_grouping
 
         if parent is None:
@@ -1478,7 +1478,7 @@ class TimeGrouper(Grouper):
         origin: str | TimestampConvertibleTypes = "start_day",
         offset: TimedeltaConvertibleTypes | None = None,
         **kwargs,
-    ):
+    ) -> None:
         # Check for correctness of the keyword arguments which would
         # otherwise silently use the default if misspelled
         if label not in {None, "left", "right"}:

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -377,7 +377,7 @@ class _Concatenator:
         verify_integrity: bool = False,
         copy: bool = True,
         sort=False,
-    ):
+    ) -> None:
         if isinstance(objs, (ABCSeries, ABCDataFrame, str)):
             raise TypeError(
                 "first argument must be an iterable of pandas "

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -625,7 +625,7 @@ class _MergeOperation:
         copy: bool = True,
         indicator: bool = False,
         validate: str | None = None,
-    ):
+    ) -> None:
         _left = _validate_operand(left)
         _right = _validate_operand(right)
         self.left = self.orig_left = _left
@@ -1633,7 +1633,7 @@ class _OrderedMerge(_MergeOperation):
         copy: bool = True,
         fill_method: str | None = None,
         how: str = "outer",
-    ):
+    ) -> None:
 
         self.fill_method = fill_method
         _MergeOperation.__init__(
@@ -1741,7 +1741,7 @@ class _AsOfMerge(_OrderedMerge):
         tolerance=None,
         allow_exact_matches: bool = True,
         direction: str = "backward",
-    ):
+    ) -> None:
 
         self.by = by
         self.left_by = left_by

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -90,7 +90,7 @@ class _Unstacker:
     unstacked : DataFrame
     """
 
-    def __init__(self, index: MultiIndex, level=-1, constructor=None):
+    def __init__(self, index: MultiIndex, level=-1, constructor=None) -> None:
 
         if constructor is None:
             constructor = DataFrame

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -329,7 +329,7 @@ class Series(base.IndexOpsMixin, NDFrame):
         name=None,
         copy: bool = False,
         fastpath: bool = False,
-    ):
+    ) -> None:
 
         if (
             isinstance(data, (SingleBlockManager, SingleArrayManager))

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -171,7 +171,7 @@ class StringMethods(NoNewAttributesMixin):
     # * cat
     # * extractall
 
-    def __init__(self, data):
+    def __init__(self, data) -> None:
         from pandas.core.arrays.string_ import StringDtype
 
         self._inferred_dtype = self._validate(data)

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -349,7 +349,7 @@ class ExponentialMovingWindow(BaseWindow):
         method: str = "single",
         *,
         selection=None,
-    ):
+    ) -> None:
         super().__init__(
             obj=obj,
             min_periods=1 if min_periods is None else max(int(min_periods), 1),
@@ -832,7 +832,7 @@ class ExponentialMovingWindowGroupby(BaseWindowGroupby, ExponentialMovingWindow)
 
     _attributes = ExponentialMovingWindow._attributes + BaseWindowGroupby._attributes
 
-    def __init__(self, obj, *args, _grouper=None, **kwargs):
+    def __init__(self, obj, *args, _grouper=None, **kwargs) -> None:
         super().__init__(obj, *args, _grouper=_grouper, **kwargs)
 
         if not obj.empty and self.times is not None:
@@ -875,7 +875,7 @@ class OnlineExponentialMovingWindow(ExponentialMovingWindow):
         engine_kwargs: dict[str, bool] | None = None,
         *,
         selection=None,
-    ):
+    ) -> None:
         if times is not None:
             raise NotImplementedError(
                 "times is not implemented with online operations."

--- a/pandas/core/window/expanding.py
+++ b/pandas/core/window/expanding.py
@@ -128,7 +128,7 @@ class Expanding(RollingAndExpandingMixin):
         axis: Axis = 0,
         method: str = "single",
         selection=None,
-    ):
+    ) -> None:
         super().__init__(
             obj=obj,
             min_periods=min_periods,

--- a/pandas/core/window/online.py
+++ b/pandas/core/window/online.py
@@ -86,7 +86,7 @@ def generate_online_numba_ewma_func(
 
 
 class EWMMeanState:
-    def __init__(self, com, adjust, ignore_na, axis, shape):
+    def __init__(self, com, adjust, ignore_na, axis, shape) -> None:
         alpha = 1.0 / (1.0 + com)
         self.axis = axis
         self.shape = shape

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -131,7 +131,7 @@ class BaseWindow(SelectionMixin):
         method: str = "single",
         *,
         selection=None,
-    ):
+    ) -> None:
         self.obj = obj
         self.on = on
         self.closed = closed
@@ -682,7 +682,7 @@ class BaseWindowGroupby(BaseWindow):
         _grouper: BaseGrouper,
         _as_index: bool = True,
         **kwargs,
-    ):
+    ) -> None:
         from pandas.core.groupby.ops import BaseGrouper
 
         if not isinstance(_grouper, BaseGrouper):


### PR DESCRIPTION
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

According to [documentation](https://pandas.pydata.org/docs/dev/development/contributing_codebase.html#type-hints) pandas uses [PEP484](https://www.python.org/dev/peps/pep-0484/) for type hints.
PEP484 states that `__init__ `function should have `-> None` return type annotation.
In this PR I added return type annotation to `__init__` functions in `pandas/core` module.
Thanks!
