### PR TITLE
TYP: annotation of __init__ return type (PEP 484) (misc modules)

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -45,7 +45,7 @@ class DocBuilder:
         single_doc=None,
         verbosity=0,
         warnings_are_errors=False,
-    ):
+    ) -> None:
         self.num_jobs = num_jobs
         self.include_api = include_api
         self.whatsnew = whatsnew

--- a/pandas/_config/config.py
+++ b/pandas/_config/config.py
@@ -204,7 +204,7 @@ def get_default_val(pat: str):
 class DictWrapper:
     """provide attribute-style access to a nested dict"""
 
-    def __init__(self, d: dict[str, Any], prefix: str = ""):
+    def __init__(self, d: dict[str, Any], prefix: str = "") -> None:
         object.__setattr__(self, "d", d)
         object.__setattr__(self, "prefix", prefix)
 
@@ -248,7 +248,7 @@ class DictWrapper:
 
 
 class CallableDynamicDoc:
-    def __init__(self, func, doc_tmpl):
+    def __init__(self, func, doc_tmpl) -> None:
         self.__doc_tmpl__ = doc_tmpl
         self.__func__ = func
 
@@ -422,7 +422,7 @@ class option_context(ContextDecorator):
     ...     pass
     """
 
-    def __init__(self, *args):
+    def __init__(self, *args) -> None:
         if len(args) % 2 != 0 or len(args) < 2:
             raise ValueError(
                 "Need to invoke as option_context(pat, val, [(pat, val), ...])."

--- a/pandas/_testing/contexts.py
+++ b/pandas/_testing/contexts.py
@@ -228,7 +228,7 @@ class RNGContext:
         np.random.randn()
     """
 
-    def __init__(self, seed):
+    def __init__(self, seed) -> None:
         self.seed = seed
 
     def __enter__(self):

--- a/pandas/compat/numpy/function.py
+++ b/pandas/compat/numpy/function.py
@@ -40,7 +40,7 @@ class CompatValidator:
         fname=None,
         method: str | None = None,
         max_fname_arg_count=None,
-    ):
+    ) -> None:
         self.fname = fname
         self.method = method
         self.defaults = defaults

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -447,7 +447,7 @@ def dict_subclass():
     """
 
     class TestSubDict(dict):
-        def __init__(self, *args, **kwargs):
+        def __init__(self, *args, **kwargs) -> None:
             dict.__init__(self, *args, **kwargs)
 
     return TestSubDict
@@ -460,7 +460,7 @@ def non_dict_mapping_subclass():
     """
 
     class TestNonDictMapping(abc.Mapping):
-        def __init__(self, underlying_dict):
+        def __init__(self, underlying_dict) -> None:
             self._data = underlying_dict
 
         def __getitem__(self, key):
@@ -1709,7 +1709,7 @@ def fsspectest():
         protocol = "testmem"
         test = [None]
 
-        def __init__(self, **kwargs):
+        def __init__(self, **kwargs) -> None:
             self.test[0] = kwargs.pop("test", None)
             super().__init__(**kwargs)
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1088,9 +1088,7 @@ class MultiIndex(Index):
         # equivalent to sorting lexicographically the codes themselves. Notice
         # that each level needs to be shifted by the number of bits needed to
         # represent the _previous_ ones:
-        offsets = np.concatenate([lev_bits[1:], [0]]).astype(  # type: ignore[arg-type]
-            "uint64"
-        )
+        offsets = np.concatenate([lev_bits[1:], [0]]).astype("uint64")
 
         # Check the total number of bits needed for our representation:
         if lev_bits[0] > 64:

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -186,7 +186,7 @@ class AbstractMethodError(NotImplementedError):
     while keeping compatibility with Python 2 and Python 3.
     """
 
-    def __init__(self, class_instance, methodtype="method"):
+    def __init__(self, class_instance, methodtype="method") -> None:
         types = {"method", "classmethod", "staticmethod", "property"}
         if methodtype not in types:
             raise ValueError(

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -209,7 +209,7 @@ class _FrequencyInferer:
     Not sure if I can avoid the state machine here
     """
 
-    def __init__(self, index, warn: bool = True):
+    def __init__(self, index, warn: bool = True) -> None:
         self.index = index
         self.i8values = index.asi8
 

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -160,7 +160,7 @@ class Holiday:
         start_date=None,
         end_date=None,
         days_of_week=None,
-    ):
+    ) -> None:
         """
         Parameters
         ----------
@@ -393,7 +393,7 @@ class AbstractHolidayCalendar(metaclass=HolidayCalendarMetaClass):
     end_date = Timestamp(datetime(2200, 12, 31))
     _cache = None
 
-    def __init__(self, name=None, rules=None):
+    def __init__(self, name=None, rules=None) -> None:
         """
         Initializes holiday object with a given set a rules.  Normally
         classes just have the rules defined within them.

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -136,7 +136,7 @@ def get_api_items(api_doc_fd):
 
 
 class PandasDocstring(Validator):
-    def __init__(self, func_name: str, doc_obj=None):
+    def __init__(self, func_name: str, doc_obj=None) -> None:
         self.func_name = func_name
         if doc_obj is None:
             doc_obj = get_doc_object(Validator._load_obj(func_name))


### PR DESCRIPTION
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

According to [documentation](https://pandas.pydata.org/docs/dev/development/contributing_codebase.html#type-hints) pandas uses [PEP484](https://www.python.org/dev/peps/pep-0484/) for type hints.
PEP484 states that `__init__` function should have `-> None` return type annotation.
In this PR I added return type annotation to `__init__` functions in the following modules:
`doc`, `pandas/_config`, `pandas/_testing`, `pandas/compat`, `pandas/conftests`, `pandas/errors`, `pandas/tseries`, `scripts`