### PR TITLE
TYP: annotation of __init__ return type (PEP 484) (pandas/plotting)

### DIFF
--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -783,7 +783,7 @@ class PlotAccessor(PandasObject):
     _kind_aliases = {"density": "kde"}
     _all_kinds = _common_kinds + _series_kinds + _dataframe_kinds
 
-    def __init__(self, data):
+    def __init__(self, data) -> None:
         self._parent = data
 
     @staticmethod

--- a/pandas/plotting/_matplotlib/boxplot.py
+++ b/pandas/plotting/_matplotlib/boxplot.py
@@ -44,7 +44,7 @@ class BoxPlot(LinePlot):
         ax: Axes
         lines: dict[str, list[Line2D]]
 
-    def __init__(self, data, return_type="axes", **kwargs):
+    def __init__(self, data, return_type="axes", **kwargs) -> None:
         # Do not call LinePlot.__init__ which may fill nan
         if return_type not in self._valid_return_types:
             raise ValueError("return_type must be {None, 'axes', 'dict', 'both'}")

--- a/pandas/plotting/_matplotlib/converter.py
+++ b/pandas/plotting/_matplotlib/converter.py
@@ -184,7 +184,7 @@ class TimeConverter(units.ConversionInterface):
 
 # time formatter
 class TimeFormatter(Formatter):
-    def __init__(self, locs):
+    def __init__(self, locs) -> None:
         self.locs = locs
 
     def __call__(self, x, pos=0) -> str:
@@ -339,7 +339,7 @@ class DatetimeConverter(dates.DateConverter):
 
 
 class PandasAutoDateFormatter(dates.AutoDateFormatter):
-    def __init__(self, locator, tz=None, defaultfmt="%Y-%m-%d"):
+    def __init__(self, locator, tz=None, defaultfmt="%Y-%m-%d") -> None:
         dates.AutoDateFormatter.__init__(self, locator, tz, defaultfmt)
 
 
@@ -371,7 +371,7 @@ class MilliSecondLocator(dates.DateLocator):
 
     UNIT = 1.0 / (24 * 3600 * 1000)
 
-    def __init__(self, tz):
+    def __init__(self, tz) -> None:
         dates.DateLocator.__init__(self, tz)
         self._interval = 1.0
 
@@ -941,7 +941,7 @@ class TimeSeries_DateLocator(Locator):
         month=1,
         day=1,
         plot_obj=None,
-    ):
+    ) -> None:
         freq = to_offset(freq)
         self.freq = freq
         self.base = base
@@ -1025,7 +1025,7 @@ class TimeSeries_DateFormatter(Formatter):
         minor_locator: bool = False,
         dynamic_mode: bool = True,
         plot_obj=None,
-    ):
+    ) -> None:
         freq = to_offset(freq)
         self.format = None
         self.freq = freq

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -128,7 +128,7 @@ class MPLPlot:
         include_bool=False,
         column: IndexLabel | None = None,
         **kwds,
-    ):
+    ) -> None:
 
         import matplotlib.pyplot as plt
 
@@ -984,7 +984,7 @@ class PlanePlot(MPLPlot):
 
     _layout_type = "single"
 
-    def __init__(self, data, x, y, **kwargs):
+    def __init__(self, data, x, y, **kwargs) -> None:
         MPLPlot.__init__(self, data, **kwargs)
         if x is None or y is None:
             raise ValueError(self._kind + " requires an x and y column")
@@ -1037,7 +1037,7 @@ class PlanePlot(MPLPlot):
 class ScatterPlot(PlanePlot):
     _kind = "scatter"
 
-    def __init__(self, data, x, y, s=None, c=None, **kwargs):
+    def __init__(self, data, x, y, s=None, c=None, **kwargs) -> None:
         if s is None:
             # hide the matplotlib default for size, in case we want to change
             # the handling of this argument later
@@ -1125,7 +1125,7 @@ class ScatterPlot(PlanePlot):
 class HexBinPlot(PlanePlot):
     _kind = "hexbin"
 
-    def __init__(self, data, x, y, C=None, **kwargs):
+    def __init__(self, data, x, y, C=None, **kwargs) -> None:
         super().__init__(data, x, y, **kwargs)
         if is_integer(C) and not self.data.columns.holds_integer():
             C = self.data.columns[C]
@@ -1157,7 +1157,7 @@ class LinePlot(MPLPlot):
     _default_rot = 0
     orientation = "vertical"
 
-    def __init__(self, data, **kwargs):
+    def __init__(self, data, **kwargs) -> None:
         from pandas.plotting import plot_params
 
         MPLPlot.__init__(self, data, **kwargs)
@@ -1349,7 +1349,7 @@ class LinePlot(MPLPlot):
 class AreaPlot(LinePlot):
     _kind = "area"
 
-    def __init__(self, data, **kwargs):
+    def __init__(self, data, **kwargs) -> None:
         kwargs.setdefault("stacked", True)
         data = data.fillna(value=0)
         LinePlot.__init__(self, data, **kwargs)
@@ -1424,7 +1424,7 @@ class BarPlot(MPLPlot):
     _default_rot = 90
     orientation = "vertical"
 
-    def __init__(self, data, **kwargs):
+    def __init__(self, data, **kwargs) -> None:
         # we have to treat a series differently than a
         # 1-column DataFrame w.r.t. color handling
         self._is_series = isinstance(data, ABCSeries)
@@ -1606,7 +1606,7 @@ class PiePlot(MPLPlot):
     _kind = "pie"
     _layout_type = "horizontal"
 
-    def __init__(self, data, kind=None, **kwargs):
+    def __init__(self, data, kind=None, **kwargs) -> None:
         data = data.fillna(value=0)
         if (data < 0).any().any():
             raise ValueError(f"{self._kind} plot doesn't allow negative values")

--- a/pandas/plotting/_matplotlib/hist.py
+++ b/pandas/plotting/_matplotlib/hist.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
 class HistPlot(LinePlot):
     _kind = "hist"
 
-    def __init__(self, data, bins=10, bottom=0, **kwargs):
+    def __init__(self, data, bins=10, bottom=0, **kwargs) -> None:
         self.bins = bins  # use mpl default
         self.bottom = bottom
         # Do not call LinePlot.__init__ which may fill nan
@@ -170,7 +170,7 @@ class KdePlot(HistPlot):
     _kind = "kde"
     orientation = "vertical"
 
-    def __init__(self, data, bw_method=None, ind=None, **kwargs):
+    def __init__(self, data, bw_method=None, ind=None, **kwargs) -> None:
         MPLPlot.__init__(self, data, **kwargs)
         self.bw_method = bw_method
         self.ind = ind

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -521,7 +521,7 @@ class _Options(dict):
     _ALIASES = {"x_compat": "xaxis.compat"}
     _DEFAULT_KEYS = ["xaxis.compat"]
 
-    def __init__(self, deprecated=False):
+    def __init__(self, deprecated=False) -> None:
         self._deprecated = deprecated
         super().__setitem__("xaxis.compat", False)
 


### PR DESCRIPTION
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

According to [documentation](https://pandas.pydata.org/docs/dev/development/contributing_codebase.html#type-hints) pandas uses [PEP484](https://www.python.org/dev/peps/pep-0484/) for type hints.
PEP484 states that `__init__` function should have `-> None` return type annotation.
In this PR I added return type annotation to `__init__` functions in `pandas/plotting` module.
Thanks!
