### PR TITLE
TYP: annotation of __init__ return type (PEP 484) (pandas/io)

### DIFF
--- a/pandas/io/clipboard/__init__.py
+++ b/pandas/io/clipboard/__init__.py
@@ -93,7 +93,7 @@ class PyperclipException(RuntimeError):
 
 
 class PyperclipWindowsException(PyperclipException):
-    def __init__(self, message):
+    def __init__(self, message) -> None:
         message += f" ({ctypes.WinError()})"
         super().__init__(message)
 
@@ -305,7 +305,7 @@ def init_no_clipboard():
 
 # Windows-related clipboard functions:
 class CheckedCall:
-    def __init__(self, f):
+    def __init__(self, f) -> None:
         super().__setattr__("f", f)
 
     def __call__(self, *args):

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -872,7 +872,7 @@ class _BytesZipFile(zipfile.ZipFile, BytesIO):  # type: ignore[misc]
         mode: str,
         archive_name: str | None = None,
         **kwargs,
-    ):
+    ) -> None:
         mode = mode.replace("b", "")
         self.archive_name = archive_name
         self.multiple_write_buffer: StringIO | BytesIO | None = None
@@ -944,7 +944,7 @@ class _MMapWrapper(abc.Iterator):
         encoding: str = "utf-8",
         errors: str = "strict",
         decode: bool = True,
-    ):
+    ) -> None:
         self.encoding = encoding
         self.errors = errors
         self.decoder = codecs.getincrementaldecoder(encoding)(errors=errors)
@@ -999,7 +999,7 @@ class _IOWrapper:
     # methods, e.g., tempfile.SpooledTemporaryFile.
     # If a buffer does not have the above "-able" methods, we simple assume they are
     # seek/read/writ-able.
-    def __init__(self, buffer: BaseBuffer):
+    def __init__(self, buffer: BaseBuffer) -> None:
         self.buffer = buffer
 
     def __getattr__(self, name: str):
@@ -1026,7 +1026,7 @@ class _IOWrapper:
 class _BytesIOWrapper:
     # Wrapper that wraps a StringIO buffer and reads bytes from it
     # Created for compat with pyarrow read_csv
-    def __init__(self, buffer: StringIO | TextIOBase, encoding: str = "utf-8"):
+    def __init__(self, buffer: StringIO | TextIOBase, encoding: str = "utf-8") -> None:
         self.buffer = buffer
         self.encoding = encoding
         # Because a character can be represented by more than 1 byte,

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -497,7 +497,7 @@ def read_excel(
 
 
 class BaseExcelReader(metaclass=abc.ABCMeta):
-    def __init__(self, filepath_or_buffer, storage_options: StorageOptions = None):
+    def __init__(self, filepath_or_buffer, storage_options: StorageOptions = None) -> None:
         # First argument can also be bytes, so create a buffer
         if isinstance(filepath_or_buffer, bytes):
             filepath_or_buffer = BytesIO(filepath_or_buffer)
@@ -1131,7 +1131,7 @@ class ExcelWriter(metaclass=abc.ABCMeta):
         if_sheet_exists: str | None = None,
         engine_kwargs: dict[str, Any] | None = None,
         **kwargs,
-    ):
+    ) -> None:
         # validate that this engine can handle the extension
         if isinstance(path, str):
             ext = os.path.splitext(path)[-1]
@@ -1454,7 +1454,7 @@ class ExcelFile:
         path_or_buffer,
         engine: str | None = None,
         storage_options: StorageOptions = None,
-    ):
+    ) -> None:
         if engine is not None and engine not in self._engines:
             raise ValueError(f"Unknown engine: {engine}")
 

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -497,7 +497,9 @@ def read_excel(
 
 
 class BaseExcelReader(metaclass=abc.ABCMeta):
-    def __init__(self, filepath_or_buffer, storage_options: StorageOptions = None) -> None:
+    def __init__(
+        self, filepath_or_buffer, storage_options: StorageOptions = None
+    ) -> None:
         # First argument can also be bytes, so create a buffer
         if isinstance(filepath_or_buffer, bytes):
             filepath_or_buffer = BytesIO(filepath_or_buffer)

--- a/pandas/io/excel/_odfreader.py
+++ b/pandas/io/excel/_odfreader.py
@@ -41,7 +41,7 @@ class ODFReader(BaseExcelReader):
         self,
         filepath_or_buffer: FilePath | ReadBuffer[bytes],
         storage_options: StorageOptions = None,
-    ):
+    ) -> None:
         import_optional_dependency("odf")
         super().__init__(filepath_or_buffer, storage_options=storage_options)
 

--- a/pandas/io/excel/_odswriter.py
+++ b/pandas/io/excel/_odswriter.py
@@ -39,7 +39,7 @@ class ODSWriter(ExcelWriter):
         if_sheet_exists: str | None = None,
         engine_kwargs: dict[str, Any] | None = None,
         **kwargs,
-    ):
+    ) -> None:
         from odf.opendocument import OpenDocumentSpreadsheet
 
         if mode == "a":

--- a/pandas/io/excel/_openpyxl.py
+++ b/pandas/io/excel/_openpyxl.py
@@ -50,7 +50,7 @@ class OpenpyxlWriter(ExcelWriter):
         if_sheet_exists: str | None = None,
         engine_kwargs: dict[str, Any] | None = None,
         **kwargs,
-    ):
+    ) -> None:
         # Use the openpyxl module as the Excel writer.
         from openpyxl.workbook import Workbook
 

--- a/pandas/io/excel/_pyxlsb.py
+++ b/pandas/io/excel/_pyxlsb.py
@@ -21,7 +21,7 @@ class PyxlsbReader(BaseExcelReader):
         self,
         filepath_or_buffer: FilePath | ReadBuffer[bytes],
         storage_options: StorageOptions = None,
-    ):
+    ) -> None:
         """
         Reader using pyxlsb engine.
 

--- a/pandas/io/excel/_xlrd.py
+++ b/pandas/io/excel/_xlrd.py
@@ -13,7 +13,9 @@ from pandas.io.excel._base import BaseExcelReader
 
 class XlrdReader(BaseExcelReader):
     @doc(storage_options=_shared_docs["storage_options"])
-    def __init__(self, filepath_or_buffer, storage_options: StorageOptions = None) -> None:
+    def __init__(
+        self, filepath_or_buffer, storage_options: StorageOptions = None
+    ) -> None:
         """
         Reader using xlrd engine.
 

--- a/pandas/io/excel/_xlrd.py
+++ b/pandas/io/excel/_xlrd.py
@@ -13,7 +13,7 @@ from pandas.io.excel._base import BaseExcelReader
 
 class XlrdReader(BaseExcelReader):
     @doc(storage_options=_shared_docs["storage_options"])
-    def __init__(self, filepath_or_buffer, storage_options: StorageOptions = None):
+    def __init__(self, filepath_or_buffer, storage_options: StorageOptions = None) -> None:
         """
         Reader using xlrd engine.
 

--- a/pandas/io/excel/_xlsxwriter.py
+++ b/pandas/io/excel/_xlsxwriter.py
@@ -183,7 +183,7 @@ class XlsxWriter(ExcelWriter):
         if_sheet_exists: str | None = None,
         engine_kwargs: dict[str, Any] | None = None,
         **kwargs,
-    ):
+    ) -> None:
         # Use the xlsxwriter module as the Excel writer.
         from xlsxwriter import Workbook
 

--- a/pandas/io/excel/_xlwt.py
+++ b/pandas/io/excel/_xlwt.py
@@ -40,7 +40,7 @@ class XlwtWriter(ExcelWriter):
         if_sheet_exists: str | None = None,
         engine_kwargs: dict[str, Any] | None = None,
         **kwargs,
-    ):
+    ) -> None:
         # Use the xlwt module as the Excel writer.
         import xlwt
 

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -66,7 +66,7 @@ class CSVFormatter:
         doublequote: bool = True,
         escapechar: str | None = None,
         storage_options: StorageOptions = None,
-    ):
+    ) -> None:
         self.fmt = formatter
 
         self.obj = self.fmt.frame

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -62,7 +62,7 @@ class ExcelCell:
         style=None,
         mergestart: int | None = None,
         mergeend: int | None = None,
-    ):
+    ) -> None:
         self.row = row
         self.col = col
         self.val = val
@@ -83,7 +83,7 @@ class CssExcelCell(ExcelCell):
         css_col: int,
         css_converter: Callable | None,
         **kwargs,
-    ):
+    ) -> None:
         if css_styles and css_converter:
             css = ";".join(
                 [a + ":" + str(v) for (a, v) in css_styles[css_row, css_col]]
@@ -158,7 +158,7 @@ class CSSToExcelConverter:
     #     without monkey-patching.
     inherited: dict[str, str] | None
 
-    def __init__(self, inherited: str | None = None):
+    def __init__(self, inherited: str | None = None) -> None:
         if inherited is not None:
             self.inherited = self.compute_css(inherited)
         else:
@@ -493,7 +493,7 @@ class ExcelFormatter:
         merge_cells: bool = False,
         inf_rep: str = "inf",
         style_converter: Callable | None = None,
-    ):
+    ) -> None:
         self.rowcounter = 0
         self.na_rep = na_rep
         if not isinstance(df, DataFrame):

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -204,7 +204,7 @@ class CategoricalFormatter:
         length: bool = True,
         na_rep: str = "NaN",
         footer: bool = True,
-    ):
+    ) -> None:
         self.categorical = categorical
         self.buf = buf if buf is not None else StringIO("")
         self.na_rep = na_rep
@@ -274,7 +274,7 @@ class SeriesFormatter:
         dtype: bool = True,
         max_rows: int | None = None,
         min_rows: int | None = None,
-    ):
+    ) -> None:
         self.series = series
         self.buf = buf if buf is not None else StringIO()
         self.name = name
@@ -421,7 +421,7 @@ class SeriesFormatter:
 
 
 class TextAdjustment:
-    def __init__(self):
+    def __init__(self) -> None:
         self.encoding = get_option("display.encoding")
 
     def len(self, text: str) -> int:
@@ -435,7 +435,7 @@ class TextAdjustment:
 
 
 class EastAsianTextAdjustment(TextAdjustment):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         if get_option("display.unicode.ambiguous_as_wide"):
             self.ambiguous_width = 2
@@ -578,7 +578,7 @@ class DataFrameFormatter:
         decimal: str = ".",
         bold_rows: bool = False,
         escape: bool = True,
-    ):
+    ) -> None:
         self.frame = frame
         self.columns = self._initialize_columns(columns)
         self.col_space = self._initialize_colspace(col_space)
@@ -1017,7 +1017,7 @@ class DataFrameRenderer:
         Formatter with the formatting options.
     """
 
-    def __init__(self, fmt: DataFrameFormatter):
+    def __init__(self, fmt: DataFrameFormatter) -> None:
         self.fmt = fmt
 
     def to_latex(
@@ -1332,7 +1332,7 @@ class GenericArrayFormatter:
         quoting: int | None = None,
         fixed_width: bool = True,
         leading_space: bool | None = True,
-    ):
+    ) -> None:
         self.values = values
         self.digits = digits
         self.na_rep = na_rep
@@ -1425,7 +1425,7 @@ class GenericArrayFormatter:
 
 
 class FloatArrayFormatter(GenericArrayFormatter):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         # float_format is expected to be a string
@@ -1614,7 +1614,7 @@ class Datetime64Formatter(GenericArrayFormatter):
         nat_rep: str = "NaT",
         date_format: None = None,
         **kwargs,
-    ):
+    ) -> None:
         super().__init__(values, **kwargs)
         self.nat_rep = nat_rep
         self.date_format = date_format
@@ -1823,7 +1823,7 @@ class Timedelta64Formatter(GenericArrayFormatter):
         nat_rep: str = "NaT",
         box: bool = False,
         **kwargs,
-    ):
+    ) -> None:
         super().__init__(values, **kwargs)
         self.nat_rep = nat_rep
         self.box = box
@@ -2023,7 +2023,7 @@ class EngFormatter:
         24: "Y",
     }
 
-    def __init__(self, accuracy: int | None = None, use_eng_prefix: bool = False):
+    def __init__(self, accuracy: int | None = None, use_eng_prefix: bool = False) -> None:
         self.accuracy = accuracy
         self.use_eng_prefix = use_eng_prefix
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -2023,7 +2023,9 @@ class EngFormatter:
         24: "Y",
     }
 
-    def __init__(self, accuracy: int | None = None, use_eng_prefix: bool = False) -> None:
+    def __init__(
+        self, accuracy: int | None = None, use_eng_prefix: bool = False
+    ) -> None:
         self.accuracy = accuracy
         self.use_eng_prefix = use_eng_prefix
 

--- a/pandas/io/formats/info.py
+++ b/pandas/io/formats/info.py
@@ -459,7 +459,7 @@ class DataFrameInfo(BaseInfo):
         self,
         data: DataFrame,
         memory_usage: bool | str | None = None,
-    ):
+    ) -> None:
         self.data: DataFrame = data
         self.memory_usage = _initialize_memory_usage(memory_usage)
 
@@ -535,7 +535,7 @@ class SeriesInfo(BaseInfo):
         self,
         data: Series,
         memory_usage: bool | str | None = None,
-    ):
+    ) -> None:
         self.data: Series = data
         self.memory_usage = _initialize_memory_usage(memory_usage)
 
@@ -629,7 +629,7 @@ class DataFrameInfoPrinter(InfoPrinterAbstract):
         max_cols: int | None = None,
         verbose: bool | None = None,
         show_counts: bool | None = None,
-    ):
+    ) -> None:
         self.info = info
         self.data = info.data
         self.verbose = verbose
@@ -706,7 +706,7 @@ class SeriesInfoPrinter(InfoPrinterAbstract):
         info: SeriesInfo,
         verbose: bool | None = None,
         show_counts: bool | None = None,
-    ):
+    ) -> None:
         self.info = info
         self.data = info.data
         self.verbose = verbose
@@ -797,7 +797,7 @@ class DataFrameTableBuilder(TableBuilderAbstract):
         Instance of DataFrameInfo.
     """
 
-    def __init__(self, *, info: DataFrameInfo):
+    def __init__(self, *, info: DataFrameInfo) -> None:
         self.info: DataFrameInfo = info
 
     def get_lines(self) -> list[str]:
@@ -959,7 +959,7 @@ class DataFrameTableBuilderVerbose(DataFrameTableBuilder, TableBuilderVerboseMix
         *,
         info: DataFrameInfo,
         with_counts: bool,
-    ):
+    ) -> None:
         self.info = info
         self.with_counts = with_counts
         self.strrows: Sequence[Sequence[str]] = list(self._gen_rows())
@@ -1025,7 +1025,7 @@ class SeriesTableBuilder(TableBuilderAbstract):
         Instance of SeriesInfo.
     """
 
-    def __init__(self, *, info: SeriesInfo):
+    def __init__(self, *, info: SeriesInfo) -> None:
         self.info: SeriesInfo = info
 
     def get_lines(self) -> list[str]:
@@ -1071,7 +1071,7 @@ class SeriesTableBuilderVerbose(SeriesTableBuilder, TableBuilderVerboseMixin):
         *,
         info: SeriesInfo,
         with_counts: bool,
-    ):
+    ) -> None:
         self.info = info
         self.with_counts = with_counts
         self.strrows: Sequence[Sequence[str]] = list(self._gen_rows())

--- a/pandas/io/formats/latex.py
+++ b/pandas/io/formats/latex.py
@@ -74,7 +74,7 @@ class RowStringConverter(ABC):
         multicolumn: bool = False,
         multicolumn_format: str | None = None,
         multirow: bool = False,
-    ):
+    ) -> None:
         self.fmt = formatter
         self.frame = self.fmt.frame
         self.multicolumn = multicolumn
@@ -336,7 +336,7 @@ class TableBuilderAbstract(ABC):
         short_caption: str | None = None,
         label: str | None = None,
         position: str | None = None,
-    ):
+    ) -> None:
         self.fmt = formatter
         self.column_format = column_format
         self.multicolumn = multicolumn
@@ -697,7 +697,7 @@ class LatexFormatter:
         caption: str | tuple[str, str] | None = None,
         label: str | None = None,
         position: str | None = None,
-    ):
+    ) -> None:
         self.fmt = formatter
         self.frame = self.fmt.frame
         self.longtable = longtable

--- a/pandas/io/formats/string.py
+++ b/pandas/io/formats/string.py
@@ -15,7 +15,7 @@ from pandas.io.formats.printing import pprint_thing
 class StringFormatter:
     """Formatter for string representation of a dataframe."""
 
-    def __init__(self, fmt: DataFrameFormatter, line_width: int | None = None):
+    def __init__(self, fmt: DataFrameFormatter, line_width: int | None = None) -> None:
         self.fmt = fmt
         self.adj = fmt.adj
         self.frame = fmt.frame

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -241,7 +241,7 @@ class Styler(StylerRenderer):
         thousands: str | None = None,
         escape: str | None = None,
         formatter: ExtFormatter | None = None,
-    ):
+    ) -> None:
         super().__init__(
             data=data,
             uuid=uuid,

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -91,7 +91,7 @@ class StylerRenderer:
         caption: str | tuple | None = None,
         cell_ids: bool = True,
         precision: int | None = None,
-    ):
+    ) -> None:
 
         # validate ordered args
         if isinstance(data, Series):
@@ -1789,7 +1789,7 @@ class Tooltips:
         ],
         css_name: str = "pd-t",
         tooltips: DataFrame = DataFrame(),
-    ):
+    ) -> None:
         self.class_name = css_name
         self.class_properties = css_props
         self.tt_data = tooltips

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -221,7 +221,7 @@ class _HtmlFrameParser:
         attrs: dict[str, str] | None,
         encoding: str,
         displayed_only: bool,
-    ):
+    ) -> None:
         self.io = io
         self.match = match
         self.attrs = attrs
@@ -555,7 +555,7 @@ class _BeautifulSoupHtml5LibFrameParser(_HtmlFrameParser):
     :class:`pandas.io.html._HtmlFrameParser`.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         from bs4 import SoupStrainer
 

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -146,7 +146,7 @@ class Writer(ABC):
         index: bool,
         default_handler: Callable[[Any], JSONSerializable] | None = None,
         indent: int = 0,
-    ):
+    ) -> None:
         self.obj = obj
 
         if orient is None:
@@ -246,7 +246,7 @@ class JSONTableWriter(FrameWriter):
         index: bool,
         default_handler: Callable[[Any], JSONSerializable] | None = None,
         indent: int = 0,
-    ):
+    ) -> None:
         """
         Adds a `schema` attribute with the Table Schema, resets
         the index (can't do in caller, because the schema inference needs
@@ -640,7 +640,7 @@ class JsonReader(abc.Iterator):
         nrows: int | None,
         storage_options: StorageOptions = None,
         encoding_errors: str | None = "strict",
-    ):
+    ) -> None:
 
         self.orient = orient
         self.typ = typ
@@ -834,7 +834,7 @@ class Parser:
         numpy=False,
         precise_float=False,
         date_unit=None,
-    ):
+    ) -> None:
         self.json = json
 
         if orient is None:

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -144,7 +144,7 @@ class BaseImpl:
 
 
 class PyArrowImpl(BaseImpl):
-    def __init__(self):
+    def __init__(self) -> None:
         import_optional_dependency(
             "pyarrow", extra="pyarrow is required for parquet support."
         )
@@ -256,7 +256,7 @@ class PyArrowImpl(BaseImpl):
 
 
 class FastParquetImpl(BaseImpl):
-    def __init__(self):
+    def __init__(self) -> None:
         # since pandas is a dependency of fastparquet
         # we need to import on first use
         fastparquet = import_optional_dependency(

--- a/pandas/io/parsers/arrow_parser_wrapper.py
+++ b/pandas/io/parsers/arrow_parser_wrapper.py
@@ -15,7 +15,7 @@ class ArrowParserWrapper(ParserBase):
     Wrapper for the pyarrow engine for read_csv()
     """
 
-    def __init__(self, src: ReadBuffer[bytes], **kwds):
+    def __init__(self, src: ReadBuffer[bytes], **kwds) -> None:
         super().__init__(kwds)
         self.kwds = kwds
         self.src = src

--- a/pandas/io/parsers/base_parser.py
+++ b/pandas/io/parsers/base_parser.py
@@ -80,7 +80,7 @@ class ParserBase:
     _implicit_index: bool = False
     _first_chunk: bool
 
-    def __init__(self, kwds):
+    def __init__(self, kwds) -> None:
 
         self.names = kwds.get("names")
         self.orig_names: list | None = None

--- a/pandas/io/parsers/c_parser_wrapper.py
+++ b/pandas/io/parsers/c_parser_wrapper.py
@@ -42,7 +42,7 @@ class CParserWrapper(ParserBase):
     low_memory: bool
     _reader: parsers.TextReader
 
-    def __init__(self, src: ReadCsvBuffer[str], **kwds):
+    def __init__(self, src: ReadCsvBuffer[str], **kwds) -> None:
         super().__init__(kwds)
         self.kwds = kwds
         kwds = kwds.copy()

--- a/pandas/io/parsers/python_parser.py
+++ b/pandas/io/parsers/python_parser.py
@@ -56,7 +56,7 @@ _BOM = "\ufeff"
 
 
 class PythonParser(ParserBase):
-    def __init__(self, f: ReadCsvBuffer[str] | list, **kwds):
+    def __init__(self, f: ReadCsvBuffer[str] | list, **kwds) -> None:
         """
         Workhorse function for processing nested list into DataFrame
         """

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -1369,7 +1369,7 @@ class TextFileReader(abc.Iterator):
         f: FilePath | ReadCsvBuffer[bytes] | ReadCsvBuffer[str] | list,
         engine: CSVEngine | None = None,
         **kwds,
-    ):
+    ) -> None:
         if engine is not None:
             engine_specified = True
         else:

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -565,7 +565,7 @@ class HDFStore:
         complib=None,
         fletcher32: bool = False,
         **kwargs,
-    ):
+    ) -> None:
 
         if "format" in kwargs:
             raise ValueError("format is not a defined argument for HDFStore")
@@ -1880,7 +1880,7 @@ class TableIterator:
         iterator: bool = False,
         chunksize: int | None = None,
         auto_close: bool = False,
-    ):
+    ) -> None:
         self.store = store
         self.s = s
         self.func = func
@@ -1993,7 +1993,7 @@ class IndexCol:
         table=None,
         meta=None,
         metadata=None,
-    ):
+    ) -> None:
 
         if not isinstance(name, str):
             raise ValueError("`name` must be a str.")
@@ -2310,7 +2310,7 @@ class DataCol(IndexCol):
         metadata=None,
         dtype: DtypeArg | None = None,
         data=None,
-    ):
+    ) -> None:
         super().__init__(
             name=name,
             values=values,
@@ -2625,7 +2625,7 @@ class Fixed:
         group: Node,
         encoding: str = "UTF-8",
         errors: str = "strict",
-    ):
+    ) -> None:
         assert isinstance(parent, HDFStore), type(parent)
         assert _table_mod is not None  # needed for mypy
         assert isinstance(group, _table_mod.Node), type(group)
@@ -3307,7 +3307,7 @@ class Table(Fixed):
         data_columns=None,
         info=None,
         nan_rep=None,
-    ):
+    ) -> None:
         super().__init__(parent, group, encoding=encoding, errors=errors)
         self.index_axes = index_axes or []
         self.non_index_axes = non_index_axes or []
@@ -5210,7 +5210,7 @@ class Selection:
         where=None,
         start: int | None = None,
         stop: int | None = None,
-    ):
+    ) -> None:
         self.table = table
         self.where = where
         self.start = start

--- a/pandas/io/sas/sas7bdat.py
+++ b/pandas/io/sas/sas7bdat.py
@@ -92,7 +92,7 @@ class _SubheaderPointer:
     compression: int
     ptype: int
 
-    def __init__(self, offset: int, length: int, compression: int, ptype: int):
+    def __init__(self, offset: int, length: int, compression: int, ptype: int) -> None:
         self.offset = offset
         self.length = length
         self.compression = compression
@@ -116,7 +116,7 @@ class _Column:
         format: str | bytes,
         ctype: bytes,
         length: int,
-    ):
+    ) -> None:
         self.col_id = col_id
         self.name = name
         self.label = label
@@ -168,7 +168,7 @@ class SAS7BDATReader(ReaderBase, abc.Iterator):
         encoding=None,
         convert_text=True,
         convert_header_text=True,
-    ):
+    ) -> None:
 
         self.index = index
         self.convert_dates = convert_dates

--- a/pandas/io/sas/sas_xport.py
+++ b/pandas/io/sas/sas_xport.py
@@ -256,7 +256,7 @@ class XportReader(ReaderBase, abc.Iterator):
         index=None,
         encoding: str | None = "ISO-8859-1",
         chunksize=None,
-    ):
+    ) -> None:
 
         self._encoding = encoding
         self._lines_read = 0

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -779,7 +779,7 @@ class SQLTable(PandasObject):
         schema=None,
         keys=None,
         dtype: DtypeArg | None = None,
-    ):
+    ) -> None:
         self.name = name
         self.pd_sql = pandas_sql_engine
         self.prefix = prefix
@@ -1284,7 +1284,7 @@ class BaseEngine:
 
 
 class SQLAlchemyEngine(BaseEngine):
-    def __init__(self):
+    def __init__(self) -> None:
         import_optional_dependency(
             "sqlalchemy", extra="sqlalchemy is required for SQL support."
         )
@@ -1365,7 +1365,7 @@ class SQLDatabase(PandasSQL):
 
     """
 
-    def __init__(self, engine, schema: str | None = None):
+    def __init__(self, engine, schema: str | None = None) -> None:
         from sqlalchemy.schema import MetaData
 
         self.connectable = engine
@@ -1826,7 +1826,7 @@ class SQLiteTable(SQLTable):
     Instead of a table variable just use the Create Table statement.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         # GH 8341
         # register an adapter callable for datetime.time object
         import sqlite3
@@ -1971,7 +1971,7 @@ class SQLiteDatabase(PandasSQL):
 
     """
 
-    def __init__(self, con):
+    def __init__(self, con) -> None:
         self.con = con
 
     @contextmanager

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -663,7 +663,7 @@ class StataValueLabel:
         Encoding to use for value labels.
     """
 
-    def __init__(self, catarray: Series, encoding: str = "latin-1"):
+    def __init__(self, catarray: Series, encoding: str = "latin-1") -> None:
 
         if encoding not in ("latin-1", "utf-8"):
             raise ValueError("Only latin-1 and utf-8 are supported.")
@@ -792,7 +792,7 @@ class StataNonCatValueLabel(StataValueLabel):
         labname: str,
         value_labels: dict[float | int, str],
         encoding: Literal["latin-1", "utf-8"] = "latin-1",
-    ):
+    ) -> None:
 
         if encoding not in ("latin-1", "utf-8"):
             raise ValueError("Only latin-1 and utf-8 are supported.")
@@ -879,7 +879,7 @@ class StataMissingValue:
         "float64": struct.unpack("<d", float64_base)[0],
     }
 
-    def __init__(self, value: int | float):
+    def __init__(self, value: int | float) -> None:
         self._value = value
         # Conversion to int to avoid hash issues on 32 bit platforms #8968
         value = int(value) if value < 2147483648 else float(value)
@@ -940,7 +940,7 @@ class StataMissingValue:
 
 
 class StataParser:
-    def __init__(self):
+    def __init__(self) -> None:
 
         # type          code.
         # --------------------
@@ -1117,7 +1117,7 @@ class StataReader(StataParser, abc.Iterator):
         chunksize: int | None = None,
         compression: CompressionOptions = "infer",
         storage_options: StorageOptions = None,
-    ):
+    ) -> None:
         super().__init__()
         self.col_sizes: list[int] = []
 
@@ -2265,7 +2265,7 @@ class StataWriter(StataParser):
         storage_options: StorageOptions = None,
         *,
         value_labels: dict[Hashable, dict[float | int, str]] | None = None,
-    ):
+    ) -> None:
         super().__init__()
         self.data = data
         self._convert_dates = {} if convert_dates is None else convert_dates
@@ -2943,7 +2943,7 @@ class StataStrLWriter:
         columns: Sequence[str],
         version: int = 117,
         byteorder: str | None = None,
-    ):
+    ) -> None:
         if version not in (117, 118, 119):
             raise ValueError("Only dta versions 117, 118 and 119 supported")
         self._dta_ver = version
@@ -3195,7 +3195,7 @@ class StataWriter117(StataWriter):
         storage_options: StorageOptions = None,
         *,
         value_labels: dict[Hashable, dict[float | int, str]] | None = None,
-    ):
+    ) -> None:
         # Copy to new list since convert_strl might be modified later
         self._convert_strl: list[Hashable] = []
         if convert_strl is not None:
@@ -3592,7 +3592,7 @@ class StataWriterUTF8(StataWriter117):
         storage_options: StorageOptions = None,
         *,
         value_labels: dict[Hashable, dict[float | int, str]] | None = None,
-    ):
+    ) -> None:
         if version is None:
             version = 118 if data.shape[1] <= 32767 else 119
         elif version not in (118, 119):

--- a/pandas/io/xml.py
+++ b/pandas/io/xml.py
@@ -137,7 +137,7 @@ class _XMLFrameParser:
         stylesheet: FilePath | ReadBuffer[bytes] | ReadBuffer[str] | None,
         compression: CompressionOptions,
         storage_options: StorageOptions,
-    ):
+    ) -> None:
         self.path_or_buffer = path_or_buffer
         self.xpath = xpath
         self.namespaces = namespaces


### PR DESCRIPTION
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

According to [documentation](https://pandas.pydata.org/docs/dev/development/contributing_codebase.html#type-hints) pandas uses [PEP484](https://www.python.org/dev/peps/pep-0484/) for type hints.
PEP484 states that `__init__` function should have `-> None` return type annotation.
In this PR I added return type annotation to `__init__` functions in `pandas/io` module.
Thanks!
