### PR TITLE
CI: xfail geopandas downstream test on MacOS due to fiona install

### DIFF
--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -8,11 +8,7 @@ import sys
 import numpy as np
 import pytest
 
-from pandas.compat import (
-    PY39,
-    PY310,
-    is_platform_mac,
-)
+from pandas.compat import is_platform_mac
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -202,7 +198,7 @@ def test_pandas_datareader():
 # importing from pandas, Cython import warning
 @pytest.mark.filterwarnings("ignore:can't resolve:ImportWarning")
 @pytest.mark.xfail(
-    is_platform_mac() and (PY39 or PY310),
+    is_platform_mac(),
     raises=ImportError,
     reason="ImportError: the 'read_file' function requires the 'fiona' package, "
     "but it is not installed or does not import correctly",

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -8,6 +8,7 @@ import sys
 import numpy as np
 import pytest
 
+from pandas.compat import is_platform_mac
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -196,6 +197,13 @@ def test_pandas_datareader():
 
 # importing from pandas, Cython import warning
 @pytest.mark.filterwarnings("ignore:can't resolve:ImportWarning")
+@pytest.mark.xfail(
+    is_platform_mac(),
+    raises=ImportError,
+    reason="ImportError: the 'read_file' function requires the 'fiona' package, "
+    "but it is not installed or does not import correctly",
+    strict=False,
+)
 def test_geopandas():
 
     geopandas = import_module("geopandas")

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -8,7 +8,11 @@ import sys
 import numpy as np
 import pytest
 
-from pandas.compat import is_platform_mac
+from pandas.compat import (
+    PY39,
+    PY310,
+    is_platform_mac,
+)
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -198,7 +202,7 @@ def test_pandas_datareader():
 # importing from pandas, Cython import warning
 @pytest.mark.filterwarnings("ignore:can't resolve:ImportWarning")
 @pytest.mark.xfail(
-    is_platform_mac(),
+    is_platform_mac() and (PY39 or PY310),
     raises=ImportError,
     reason="ImportError: the 'read_file' function requires the 'fiona' package, "
     "but it is not installed or does not import correctly",


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Not really familiar with geopandas to know why this install fails on MacOS, so xfailing for now (maybe there's a more lightweight test that doesn't read a file?)

cc @jorisvandenbossche  

https://dev.azure.com/pandas-dev/pandas/_build/results?buildId=75056&view=logs&jobId=b1891a80-bdb0-5193-5f59-ce68a0874df0&j=b1891a80-bdb0-5193-5f59-ce68a0874df0&t=0a58a9e9-0673-539c-5bde-d78a5a3b655e

```
=================================== FAILURES ===================================
________________________________ test_geopandas ________________________________
[gw0] darwin -- Python 3.9.10 /usr/local/miniconda/envs/pandas-dev/bin/python

    @pytest.mark.filterwarnings("ignore:can't resolve:ImportWarning")
    def test_geopandas():
    
        geopandas = import_module("geopandas")
        fp = geopandas.datasets.get_path("naturalearth_lowres")
>       assert geopandas.read_file(fp) is not None

pandas/tests/test_downstream.py:203: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/local/miniconda/envs/pandas-dev/lib/python3.9/site-packages/geopandas/io/file.py:166: in _read_file
    _check_fiona("'read_file' function")
E           ImportError: the 'read_file' function requires the 'fiona' package, but it is not installed or does not import correctly.
E           Importing fiona resulted in: dlopen(/usr/local/miniconda/envs/pandas-dev/lib/python3.9/site-packages/fiona/ogrext.cpython-39-darwin.so, 2): Library not loaded: @rpath/libfontconfig.1.dylib
E             Referenced from: /usr/local/miniconda/envs/pandas-dev/lib/libpoppler.117.0.0.dylib
E             Reason: Incompatible library version: libpoppler.117.dylib requires version 14.0.0 or later, but libfontconfig.1.dylib provides version 13.0.0

```