### PR TITLE
BUG: merge raising for Int64 and int64 dtype with missing values

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -454,6 +454,7 @@ Groupby/resample/rolling
 Reshaping
 ^^^^^^^^^
 - Bug in :func:`concat` between a :class:`Series` with integer dtype and another with :class:`CategoricalDtype` with integer categories and containing ``NaN`` values casting to object dtype instead of ``float64`` (:issue:`45359`)
+- Bug in :func:`merge` raising when ``Int64`` dtype with missing values on one side and ``int64`` on the other (:issue:`46178`)
 - Bug in :func:`get_dummies` that selected object and categorical dtypes but not string (:issue:`44965`)
 - Bug in :meth:`DataFrame.align` when aligning a :class:`MultiIndex` to a :class:`Series` with another :class:`MultiIndex` (:issue:`46001`)
 -

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -2219,6 +2219,13 @@ def _factorize_keys(
         # "_values_for_factorize"
         rk, _ = rk._values_for_factorize()  # type: ignore[union-attr]
 
+    elif is_integer_dtype(lk.dtype) and is_integer_dtype(rk.dtype):
+        if isinstance(lk, ExtensionArray):
+            lk, _ = lk._values_for_factorize()
+
+        if isinstance(rk, ExtensionArray):
+            rk, _ = rk._values_for_factorize()
+
     klass: type[libhashtable.Factorizer] | type[libhashtable.Int64Factorizer]
     if is_integer_dtype(lk.dtype) and is_integer_dtype(rk.dtype):
         # GH#23917 TODO: needs tests for case where lk is integer-dtype

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2669,3 +2669,19 @@ def test_merge_different_index_names():
     result = merge(left, right, left_on="c", right_on="d")
     expected = DataFrame({"a_x": [1], "a_y": 1})
     tm.assert_frame_equal(result, expected)
+
+
+def test_merge_int_ea_and_non_ea():
+    # GH#46178
+    left = DataFrame({"a": [1, 1, 3, pd.NA]}, dtype="Int64")
+    right = DataFrame({"b": ["a", "b"]}, index=pd.Index([1, 3], name="a"))
+
+    result = left.merge(right, left_on="a", right_index=True)
+    expected = DataFrame({"a": [1, 1, 3], "b": ["a", "a", "b"]})
+    expected["a"] = expected["a"].astype("Int64")
+    tm.assert_frame_equal(result, expected)
+
+    result = right.merge(left, right_on="a", left_index=True)
+    expected = DataFrame({"b": ["a", "a", "b"], "a": [1, 1, 3]})
+    expected["a"] = expected["a"].astype("Int64")
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #46178 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
