### PR TITLE
CI: re-enable geopandas downstream test on MacOS

### DIFF
--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -8,7 +8,6 @@ import sys
 import numpy as np
 import pytest
 
-from pandas.compat import is_platform_mac
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -197,13 +196,6 @@ def test_pandas_datareader():
 
 # importing from pandas, Cython import warning
 @pytest.mark.filterwarnings("ignore:can't resolve:ImportWarning")
-@pytest.mark.xfail(
-    is_platform_mac(),
-    raises=ImportError,
-    reason="ImportError: the 'read_file' function requires the 'fiona' package, "
-    "but it is not installed or does not import correctly",
-    strict=False,
-)
 def test_geopandas():
 
     geopandas = import_module("geopandas")


### PR DESCRIPTION
See pandas-dev/pandas#46296. I don't have a Mac, so can't check locally if the install issue is solved (I would assume so, since the relevant libraries on conda-forge have been rebuilt), and thus directly checking here on CI.