### PR TITLE
Regression in read csv causing segfault for invalid file input

### DIFF
--- a/doc/source/whatsnew/v1.4.2.rst
+++ b/doc/source/whatsnew/v1.4.2.rst
@@ -15,7 +15,7 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Fixed regression in :meth:`DataFrame.drop` and :meth:`Series.drop` when :class:`Index` had extension dtype and duplicates (:issue:`45860`)
-- Fixed regression in :func:`read_csv` killing python process when invalid file input was given for ``engine="c"` (:issue:`45957`)
+- Fixed regression in :func:`read_csv` killing python process when invalid file input was given for ``engine="c"`` (:issue:`45957`)
 - Fixed memory performance regression in :meth:`Series.fillna` when called on a :class:`DataFrame` column with ``inplace=True`` (:issue:`46149`)
 - Provided an alternative solution for passing custom Excel formats in :meth:`.Styler.to_excel`, which was a regression based on stricter CSS validation. Examples available in the documentation for :meth:`.Styler.format` (:issue:`46152`)
 -

--- a/doc/source/whatsnew/v1.4.2.rst
+++ b/doc/source/whatsnew/v1.4.2.rst
@@ -15,6 +15,7 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Fixed regression in :meth:`DataFrame.drop` and :meth:`Series.drop` when :class:`Index` had extension dtype and duplicates (:issue:`45860`)
+- Fixed regression in :func:`read_csv` killing python process when invalid file input was given for ``engine="c"` (:issue:`45957`)
 - Fixed memory performance regression in :meth:`Series.fillna` when called on a :class:`DataFrame` column with ``inplace=True`` (:issue:`46149`)
 - Provided an alternative solution for passing custom Excel formats in :meth:`.Styler.to_excel`, which was a regression based on stricter CSS validation. Examples available in the documentation for :meth:`.Styler.format` (:issue:`46152`)
 -

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -1710,7 +1710,7 @@ class TextFileReader(abc.Iterator):
             assert self.handles is not None
             f = self.handles.handle
 
-        elif not engine == "python":
+        elif engine != "python":
             msg = f"Invalid file path or buffer object type: {type(f)}"
             raise ValueError(msg)
 

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -1710,6 +1710,10 @@ class TextFileReader(abc.Iterator):
             assert self.handles is not None
             f = self.handles.handle
 
+        elif not engine == "python":
+            msg = f"Invalid file path or buffer object type: {type(f)}"
+            raise ValueError(msg)
+
         try:
             return mapping[engine](f, **self.options)
         except Exception:

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -680,3 +680,10 @@ def test_float_precision_options(c_parser_only):
 
     with pytest.raises(ValueError, match=msg):
         parser.read_csv(StringIO(s), float_precision="junk")
+
+
+def test_invalid_file_inputs(c_parser_only):
+    # GH#45957
+    parser = c_parser_only
+    with pytest.raises(ValueError, match="Invalid"):
+        parser.read_csv([])

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -680,10 +680,3 @@ def test_float_precision_options(c_parser_only):
 
     with pytest.raises(ValueError, match=msg):
         parser.read_csv(StringIO(s), float_precision="junk")
-
-
-def test_invalid_file_inputs(c_parser_only):
-    # GH#45957
-    parser = c_parser_only
-    with pytest.raises(ValueError, match="Invalid"):
-        parser.read_csv([])

--- a/pandas/tests/io/parser/test_unsupported.py
+++ b/pandas/tests/io/parser/test_unsupported.py
@@ -189,3 +189,13 @@ def test_close_file_handle_on_invalid_usecols(all_parsers):
                 parser.read_csv(fname, usecols=["col1", "col2", "col3"])
         # unlink fails on windows if file handles still point to it
         os.unlink(fname)
+
+
+def test_invalid_file_inputs(all_parsers):
+    # GH#45957
+    parser = all_parsers
+    if parser.engine == "python":
+        pytest.skip("Python engine supports lists.")
+
+    with pytest.raises(ValueError, match="Invalid"):
+        parser.read_csv([])


### PR DESCRIPTION
- [x] closes #45957 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
