### PR TITLE
TST: Avoid stack overflow on Windows CI with recursion test

### DIFF
--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -17,6 +17,7 @@ from io import StringIO
 import itertools
 from numbers import Number
 import re
+import sys
 
 import numpy as np
 import pytest
@@ -205,8 +206,14 @@ def test_is_list_like_recursion():
         inference.is_list_like([])
         foo()
 
-    with tm.external_error_raised(RecursionError):
-        foo()
+    rec_limit = sys.getrecursionlimit()
+    try:
+        # Limit to avoid stack overflow on Windows CI
+        sys.setrecursionlimit(100)
+        with tm.external_error_raised(RecursionError):
+            foo()
+    finally:
+        sys.setrecursionlimit(rec_limit)
 
 
 def test_is_list_like_iter_is_none():


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Trying to avoid this outcome: https://dev.azure.com/pandas-dev/pandas/_build/results?buildId=75264&view=logs&jobId=f64eb602-b0ed-5dcc-0a60-a7288ad39597&j=f64eb602-b0ed-5dcc-0a60-a7288ad39597&t=129bd72d-2137-55bd-1811-c4ce50c6dce8

```
.......................Windows fatal exception: stack overflow
Thread 0x0000148c (most recent call first):
  File "C:\Miniconda\envs\pandas-dev\lib\site-packages\execnet\gateway_base.py", line 400 in read
  File "C:\Miniconda\envs\pandas-dev\lib\site-packages\execnet\gateway_base.py", line 432 in from_io
  File "C:\Miniconda\envs\pandas-dev\lib\site-packages\execnet\gateway_base.py", line 967 in _thread_receiver
  File "C:\Miniconda\envs\pandas-dev\lib\site-packages\execnet\gateway_base.py", line 220 in run
  File "C:\Miniconda\envs\pandas-dev\lib\site-packages\execnet\gateway_base.py", line 285 in _perform_spawn

Current thread 0x00000750 (most recent call first):
  File "D:\a\1\s\pandas\tests\dtypes\test_inference.py", line 206 in foo
```
