### PR TITLE
Series.map Performance Improvement When Using Dictionaries

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -4,7 +4,6 @@ Base and utility classes for pandas objects.
 
 from __future__ import annotations
 
-from collections import defaultdict
 import textwrap
 from typing import (
     TYPE_CHECKING,
@@ -70,7 +69,6 @@ from pandas.core.algorithms import (
 from pandas.core.arraylike import OpsMixin
 from pandas.core.arrays import ExtensionArray
 from pandas.core.construction import (
-    create_series_with_explicit_dtype,
     ensure_wrapped_if_datetimelike,
     extract_array,
 )
@@ -187,9 +185,10 @@ class SpecificationError(Exception):
 
 class ReadOnlyNanDefaultDict:
     """
-    Mimics the missing functionality of defaultdict(lambda: np.nan, dictionary_object) without copying the data.
+    Mimics the missing functionality defaultdict without copying the data.
 
-    Used for IndexOpsMixin._map_values when a non-default-dictionary is provided as a mapping.
+    Used for IndexOpsMixin._map_values when a non-default-dictionary is
+    provided as a mapping.
     """
 
     def __init__(self, data):

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -813,7 +813,7 @@ class IndexOpsMixin(OpsMixin):
         return func(skipna=skipna, **kwds)
 
     @final
-    def _map_values(self, mapper, na_action=None):
+    def _map_values(self, mapper, na_action: Literal["ignore"] | None = None):
         """
         An internal function that maps values using the input
         correspondence (which can be a dict, Series, or function).


### PR DESCRIPTION
- [x] closes #46248
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Hello, first time contributing to pandas so if I did something wrong, please let me know!

In the discussion for #46248 I proposed a very simple solution using `collections.defaultdict`. However, after implementing the change, I found a performance improvement of 10x, but that was still a far stretch from the 1000-10000x improvement I was expecting. After more testing I found that the majority of the time was now being spent by copying the dictionary to the `defaultdict`. To avoid unnecessarily copying the dictionary's data, I use `dict.get` with a default of `np.nan` for dictionaries that do not implement the `__missing__` method ~~added `ReadOnlyNanDefaultDict` which gives us the behavior of `defaultdict(lambda: np.nan, dictionary_object)` without copying the data. As given by the name, it is also read only since that is all that is needed by `IndexOpsMixin._map_values`.~~  With this change, I see the huge performance boost of 1000-10000x.

This is a slight deviation from the `defaultdict` solution proposed in the issue, but it performs much better and behaves in the same way.

Lastly, I tried to add type hints for `IndexOpsMixin._map_values` but could not find the proper way of typing `Series` without causing a circular import. Is `"Series"` the way to go, or is there something better?