### PR TITLE
TST: xfail(strict=False) flaky hashtable test

### DIFF
--- a/pandas/tests/libs/test_hashtable.py
+++ b/pandas/tests/libs/test_hashtable.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 
 from pandas._libs import hashtable as ht
-from pandas.compat import is_platform_arm
 
 import pandas as pd
 import pandas._testing as tm
@@ -253,8 +252,7 @@ class TestHashTableUnsorted:
                 "uint64",
                 False,
                 marks=pytest.mark.xfail(
-                    is_platform_arm(),
-                    reason="Sometimes doesn't raise on ARM.",
+                    reason="Sometimes doesn't raise.",
                     strict=False,
                 ),
             ),

--- a/pandas/tests/libs/test_hashtable.py
+++ b/pandas/tests/libs/test_hashtable.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from pandas._libs import hashtable as ht
+from pandas.compat import is_platform_arm
 
 import pandas as pd
 import pandas._testing as tm
@@ -246,7 +247,17 @@ class TestHashTableUnsorted:
             (ht.Float64HashTable, ht.Float64Vector, "float64", False),
             (ht.Int64HashTable, ht.Int64Vector, "int64", False),
             (ht.Int32HashTable, ht.Int32Vector, "int32", False),
-            (ht.UInt64HashTable, ht.UInt64Vector, "uint64", False),
+            pytest.param(
+                ht.UInt64HashTable,
+                ht.UInt64Vector,
+                "uint64",
+                False,
+                marks=pytest.mark.xfail(
+                    is_platform_arm(),
+                    reason="Sometimes doesn't raise on ARM.",
+                    strict=False,
+                ),
+            ),
         ],
     )
     def test_vector_resize(


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Example: https://app.circleci.com/pipelines/github/pandas-dev/pandas/8766/workflows/4a9ce4f4-0e1c-49aa-b035-ffcb6334be45/jobs/39610
