### PR TITLE
REF: disallow ints from delta_to_nanoseconds

### DIFF
--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -173,11 +173,11 @@ cpdef int64_t delta_to_nanoseconds(delta) except? -1:
     if is_tick_object(delta):
         return delta.nanos
     if isinstance(delta, _Timedelta):
-        delta = delta.value
+        return delta.value
+
     if is_timedelta64_object(delta):
         return get_timedelta64_value(ensure_td64ns(delta))
-    if is_integer_object(delta):
-        return delta
+
     if PyDelta_Check(delta):
         try:
             return (

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1316,7 +1316,9 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         elif is_integer_dtype(other_dtype):
             if not is_period_dtype(self.dtype):
                 raise integer_op_not_supported(self)
-            result = cast("PeriodArray", self)._addsub_int_array(other, operator.add)
+            result = cast("PeriodArray", self)._addsub_int_array_or_scalar(
+                other, operator.add
+            )
         else:
             # Includes Categorical, other ExtensionArrays
             # For PeriodDtype, if self is a TimedeltaArray and other is a
@@ -1376,7 +1378,9 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         elif is_integer_dtype(other_dtype):
             if not is_period_dtype(self.dtype):
                 raise integer_op_not_supported(self)
-            result = cast("PeriodArray", self)._addsub_int_array(other, operator.sub)
+            result = cast("PeriodArray", self)._addsub_int_array_or_scalar(
+                other, operator.sub
+            )
         else:
             # Includes ExtensionArrays, float_dtype
             return NotImplemented

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -272,7 +272,7 @@ class PeriodIndex(DatetimeIndexOpsMixin):
     def values(self) -> np.ndarray:
         return np.asarray(self, dtype=object)
 
-    def _maybe_convert_timedelta(self, other):
+    def _maybe_convert_timedelta(self, other) -> int | npt.NDArray[np.int64]:
         """
         Convert timedelta-like input to an integer multiple of self.freq
 

--- a/pandas/tests/tslibs/test_timedeltas.py
+++ b/pandas/tests/tslibs/test_timedeltas.py
@@ -30,9 +30,6 @@ from pandas import (
             24 * 3600e9 + 111,
         ),  # GH43764
         (offsets.Nano(125), 125),
-        (1, 1),
-        (np.int64(2), 2),
-        (np.int32(3), 3),
     ],
 )
 def test_delta_to_nanoseconds(obj, expected):
@@ -45,6 +42,15 @@ def test_delta_to_nanoseconds_error():
 
     with pytest.raises(TypeError, match="<class 'numpy.ndarray'>"):
         delta_to_nanoseconds(obj)
+
+    with pytest.raises(TypeError, match="float"):
+        delta_to_nanoseconds(1.5)
+    with pytest.raises(TypeError, match="int"):
+        delta_to_nanoseconds(1)
+    with pytest.raises(TypeError, match="int"):
+        delta_to_nanoseconds(np.int64(2))
+    with pytest.raises(TypeError, match="int"):
+        delta_to_nanoseconds(np.int32(3))
 
 
 def test_huge_nanoseconds_overflow():


### PR DESCRIPTION
chipping away at non-nano roadblocks