### PR TITLE
Added the round( ) function to avoid error while multiplication of float numbers issue: #46362

### DIFF
--- a/doc/source/whatsnew/v1.4.2.rst
+++ b/doc/source/whatsnew/v1.4.2.rst
@@ -30,7 +30,7 @@ Bug fixes
 ~~~~~~~~~
 - Fix some cases for subclasses that define their ``_constructor`` properties as general callables (:issue:`46018`)
 - Fixed "longtable" formatting in :meth:`.Styler.to_latex` when ``column_format`` is given in extended format (:issue:`46037`)
--
+- Fixed a case where the format of printing percentiles in not correct for the describe function in ``format.py`` (:issue:`46362`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.4.2.rst
+++ b/doc/source/whatsnew/v1.4.2.rst
@@ -30,7 +30,7 @@ Bug fixes
 ~~~~~~~~~
 - Fix some cases for subclasses that define their ``_constructor`` properties as general callables (:issue:`46018`)
 - Fixed "longtable" formatting in :meth:`.Styler.to_latex` when ``column_format`` is given in extended format (:issue:`46037`)
-- Fixed a case where the format of printing percentiles in not correct for the describe function in ``format.py`` (:issue:`46362`)
+
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -362,6 +362,7 @@ Conversion
 - Bug in :meth:`Series.astype` and :meth:`DataFrame.astype` from floating dtype to unsigned integer dtype failing to raise in the presence of negative values (:issue:`45151`)
 - Bug in :func:`array` with ``FloatingDtype`` and values containing float-castable strings incorrectly raising (:issue:`45424`)
 - Bug when comparing string and datetime64ns objects causing ``OverflowError`` exception. (:issue:`45506`)
+- Bug in :meth:`format.py` the percentiles values are converted to integer dtype, which ignores the floating point error while multiplying. (:issue:`46362`)
 
 Strings
 ^^^^^^^

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1713,10 +1713,10 @@ def format_percentiles(
 
     percentiles = 100 * percentiles
 
-    int_idx = np.isclose(percentiles.astype(int), percentiles)
+    int_idx = np.isclose(percentiles.round(), percentiles)
 
     if np.all(int_idx):
-        out = percentiles.astype(int).astype(str)
+        out = percentiles.round().astype(int).astype(str)
         return [i + "%" for i in out]
 
     unique_pcts = np.unique(percentiles)
@@ -1729,7 +1729,7 @@ def format_percentiles(
     ).astype(int)
     prec = max(1, prec)
     out = np.empty_like(percentiles, dtype=object)
-    out[int_idx] = percentiles[int_idx].astype(int).astype(str)
+    out[int_idx] = percentiles[int_idx].round().astype(int).astype(str)
 
     out[~int_idx] = percentiles[~int_idx].round(prec).astype(str)
     return [i + "%" for i in out]

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -3262,6 +3262,11 @@ def test_format_percentiles():
     expected = ["0%", "50%", "2.0%", "50%", "66.67%", "99.99%"]
     assert result == expected
 
+    # Issue #46362
+    result = fmt.format_percentiles([0.281,0.57,0.58,0.29])
+    expected = ['28.1%', '57%', '58%', '29%']
+    assert result == expected
+
     msg = r"percentiles should all be in the interval \[0,1\]"
     with pytest.raises(ValueError, match=msg):
         fmt.format_percentiles([0.1, np.nan, 0.5])


### PR DESCRIPTION
- Added round( ) function to round the values and then convert it to int type while they are passed into the list-out, so that we can avoid conversations of int(28.999999999999996) to 28.
- if we round the value first it will be converted into 29 and then formating them to int type.
- ✅ closes #46362 
- ✅ [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- ✅ All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- ✅ Added an entry in the latest `doc/source/whatsnew/v1.4.2.rst`
