### PR TITLE
REGR: Bar plot axis timestamp to string conversion error

### DIFF
--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -555,8 +555,10 @@ class TestDataFramePlots(TestPlotBase):
         # GH 38736
         # Ensure string x-axis from the second plot will not be converted to datetime
         # due to axis data from first plot
-        DataFrame(
+        df = DataFrame(
             [1.0],
             index=[Timestamp("2022-02-22 22:22:22")],
-        ).plot()
-        Series({"A": 1.0}).plot.bar()
+        )
+        _check_plot_works(df.plot)
+        s = Series({"A": 1.0})
+        _check_plot_works(s.plot.bar)

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -8,6 +8,7 @@ import pandas.util._test_decorators as td
 from pandas import (
     DataFrame,
     Series,
+    Timestamp,
 )
 import pandas._testing as tm
 from pandas.tests.plotting.common import (
@@ -549,3 +550,13 @@ class TestDataFramePlots(TestPlotBase):
         assert not plots[0][0].xaxis.get_label().get_visible()
         assert plots[0][1].xaxis.get_label().get_visible()
         assert not plots[0][2].xaxis.get_label().get_visible()
+
+    def test_plot_bar_axis_units_timestamp_conversion(self):
+        # GH 38736
+        # Ensure string x-axis from the second plot will not be converted to datetime
+        # due to axis data from first plot
+        DataFrame(
+            [1.0],
+            index=[Timestamp("2022-02-22 22:22:22")],
+        ).plot()
+        Series({"A": 1.0}).plot.bar()


### PR DESCRIPTION
Added regression test to prevent bar plot from attempting to convert x-axis from string to timestamp due to previous plot's axis units.

Problematic example:
https://github.com/pandas-dev/pandas/blob/fb353446651067fafec03301256e93d59065c520/pandas/plotting/_matplotlib/core.py#L1433


- [x] closes #38736
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
