### PR TITLE
CLN: ArrowStringArray._cmp_method - use ChunkedArray.to_numpy()

### DIFF
--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -332,8 +332,11 @@ class ArrowStringArray(
         else:
             return NotImplemented
 
-        # TODO(ARROW-9429): Add a .to_numpy() to ChunkedArray
-        return BooleanArray._from_sequence(result.to_pandas().values)
+        if pa_version_under2p0:
+            result = result.to_pandas().values
+        else:
+            result = result.to_numpy()
+        return BooleanArray._from_sequence(result)
 
     def insert(self, loc: int, item):
         if not isinstance(item, str) and item is not libmissing.NA:


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Addresses minor TODO comment in ArrowStringArray._cmp_method. 

Also, better perf:

```
import numpy as np
import pyarrow as pa

ca = pa.chunked_array([ 
    np.random.choice([0, 1], 1000),
    np.random.choice([0, 1], 1000),
], type=pa.bool_())

%timeit ca.to_pandas().values
45.9 µs ± 2.75 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

%timeit ca.to_numpy()
3.8 µs ± 273 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```