### PR TITLE
BUG: Categorical of booleans has object .categories

### DIFF
--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -1107,3 +1107,15 @@ def test_compare_complex_dtypes():
 
     with pytest.raises(TypeError, match=msg):
         df.lt(df.astype(object))
+
+
+def test_categorical_of_booleans_is_boolean():
+    # https://github.com/pandas-dev/pandas/issues/46313
+    df = pd.DataFrame(
+        {"int_cat": [1, 2, 3], "bool_cat": [True, False, False]}, dtype="category"
+    )
+    value = df["bool_cat"].cat.categories.dtype
+    expected = np.dtype(np.bool_)
+    not_expected = np.dtype(np.object_)
+    assert value is expected
+    assert value is not not_expected

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -1107,15 +1107,3 @@ def test_compare_complex_dtypes():
 
     with pytest.raises(TypeError, match=msg):
         df.lt(df.astype(object))
-
-
-def test_categorical_of_booleans_is_boolean():
-    # https://github.com/pandas-dev/pandas/issues/46313
-    df = pd.DataFrame(
-        {"int_cat": [1, 2, 3], "bool_cat": [True, False, False]}, dtype="category"
-    )
-    value = df["bool_cat"].cat.categories.dtype
-    expected = np.dtype(np.bool_)
-    not_expected = np.dtype(np.object_)
-    assert value is expected
-    assert value is not not_expected

--- a/pandas/tests/series/accessors/test_cat_accessor.py
+++ b/pandas/tests/series/accessors/test_cat_accessor.py
@@ -282,3 +282,12 @@ class TestCatAccessor:
         # values should not be coerced to NaN
         assert list(df["Sex"]) == ["female", "male", "male"]
         assert list(df["Survived"]) == ["Yes", "No", "Yes"]
+
+    def test_categorical_of_booleans_is_boolean(self):
+        # https://github.com/pandas-dev/pandas/issues/46313
+        df = DataFrame(
+            {"int_cat": [1, 2, 3], "bool_cat": [True, False, False]}, dtype="category"
+        )
+        value = df["bool_cat"].cat.categories.dtype
+        expected = np.dtype(np.bool_)
+        assert value is expected


### PR DESCRIPTION
- [x] closes #46313 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This patch adds a test for checking regression behavior as described in #46313. The bug was reported to be fixed and I could not reproduce the bug in the latest version as Mar.18, 2022. So, only a test was added.

This is my first contribution to the open-source project. Please let me know if something needs to be fixed. Thanks!