### PR TITLE
CI/TYP: require mypy error-codes in ignore comments

### DIFF
--- a/pandas/_libs/tslibs/timestamps.pyi
+++ b/pandas/_libs/tslibs/timestamps.pyi
@@ -133,10 +133,10 @@ class Timestamp(datetime):
     def utcoffset(self) -> timedelta | None: ...
     def tzname(self) -> str | None: ...
     def dst(self) -> timedelta | None: ...
-    def __le__(self, other: datetime) -> bool: ...  # type: ignore
-    def __lt__(self, other: datetime) -> bool: ...  # type: ignore
-    def __ge__(self, other: datetime) -> bool: ...  # type: ignore
-    def __gt__(self, other: datetime) -> bool: ...  # type: ignore
+    def __le__(self, other: datetime) -> bool: ...  # type: ignore[override]
+    def __lt__(self, other: datetime) -> bool: ...  # type: ignore[override]
+    def __ge__(self, other: datetime) -> bool: ...  # type: ignore[override]
+    def __gt__(self, other: datetime) -> bool: ...  # type: ignore[override]
     # error: Signature of "__add__" incompatible with supertype "date"/"datetime"
     @overload  # type: ignore[override]
     def __add__(self, other: np.ndarray) -> np.ndarray: ...
@@ -145,7 +145,7 @@ class Timestamp(datetime):
         self: _DatetimeT, other: timedelta | np.timedelta64 | Tick
     ) -> _DatetimeT: ...
     def __radd__(self: _DatetimeT, other: timedelta) -> _DatetimeT: ...
-    @overload  # type: ignore
+    @overload  # type: ignore[override]
     def __sub__(self, other: datetime) -> Timedelta: ...
     @overload
     def __sub__(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ warn_unreachable = false # GH#27396
 # Suppressing errors
 show_none_errors = true
 ignore_errors = false
+enable_error_code = "ignore-without-code"
 # Miscellaneous strictness flags
 allow_untyped_globals = false
 allow_redefinition = false


### PR DESCRIPTION
`enable_error_code = "ignore-without-code"` is a new feature added in mypy 0.940.