### PR TITLE
TST: Ensure makeCategoricalIndex categories are unique

### DIFF
--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -187,7 +187,7 @@ class RemoveCategories:
 class Rank:
     def setup(self):
         N = 10**5
-        ncats = 100
+        ncats = 20
 
         self.s_str = pd.Series(tm.makeCategoricalIndex(N, ncats)).astype(str)
         self.s_str_cat = pd.Series(self.s_str, dtype="category")

--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -305,7 +305,7 @@ def makeUnicodeIndex(k=10, name=None):
 
 def makeCategoricalIndex(k=10, n=3, name=None, **kwargs):
     """make a length k index or n categories"""
-    x = rands_array(nchars=4, size=n)
+    x = rands_array(nchars=4, size=n, replace=False)
     return CategoricalIndex(
         Categorical.from_codes(np.arange(k) % n, categories=x), name=name, **kwargs
     )

--- a/pandas/_testing/_random.py
+++ b/pandas/_testing/_random.py
@@ -14,12 +14,12 @@ RANDU_CHARS = np.array(
 )
 
 
-def rands_array(nchars, size, dtype="O"):
+def rands_array(nchars, size, dtype="O", replace=True):
     """
     Generate an array of byte strings.
     """
     retval = (
-        np.random.choice(RANDS_CHARS, size=nchars * np.prod(size))
+        np.random.choice(RANDS_CHARS, size=nchars * np.prod(size), replace=replace)
         .view((np.str_, nchars))
         .reshape(size)
     )


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

If the flaky lottery is won and the random categories are not unique can raise

```
ImportError while loading conftest 'D:\a\1\s\pandas\conftest.py'.
pandas\conftest.py:564: in <module>
    "categorical": tm.makeCategoricalIndex(100),
pandas\_testing\__init__.py:310: in makeCategoricalIndex
    Categorical.from_codes(np.arange(k) % n, categories=x), name=name, **kwargs
pandas\core\arrays\categorical.py:678: in from_codes
    dtype = CategoricalDtype._from_values_or_dtype(
pandas\core\dtypes\dtypes.py:298: in _from_values_or_dtype
    dtype = CategoricalDtype(categories, ordered)
pandas\core\dtypes\dtypes.py:185: in __init__
    self._finalize(categories, ordered, fastpath=False)
pandas\core\dtypes\dtypes.py:339: in _finalize
    categories = self.validate_categories(categories, fastpath=fastpath)
pandas\core\dtypes\dtypes.py:536: in validate_categories
    raise ValueError("Categorical categories must be unique")
E   ValueError: Categorical categories must be unique
```
