### PR TITLE
BENCH: Fix makeCategoricalIndex

### DIFF
--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -187,7 +187,7 @@ class RemoveCategories:
 class Rank:
     def setup(self):
         N = 10**5
-        ncats = 20
+        ncats = 15
 
         self.s_str = pd.Series(tm.makeCategoricalIndex(N, ncats)).astype(str)
         self.s_str_cat = pd.Series(self.s_str, dtype="category")


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

@jreback looks like https://github.com/pandas-dev/pandas/pull/46429 was still making the benchmarks job fail. Locally constructing with `ncats = 15` works. 
