### PR TITLE
REF: avoid python-space calls in _get_dst_hours

### DIFF
--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -15,7 +15,6 @@ from cpython.datetime cimport (
 
 import_datetime()
 
-from dateutil.tz import tzutc
 import numpy as np
 import pytz
 
@@ -345,11 +344,10 @@ cdef ndarray[int64_t] _get_dst_hours(
 ):
     cdef:
         Py_ssize_t i, n = vals.shape[0]
-        ndarray[uint8_t, cast=True] both_nat, both_eq
+        ndarray[uint8_t, cast=True] mismatch
         ndarray[int64_t] delta, dst_hours
-        ndarray grp, a_idx, b_idx, one_diff
+        ndarray[intp_t] switch_idxs, trans_idx, grp, a_idx, b_idx, one_diff
         list trans_grp
-        ndarray[intp_t] switch_idxs, trans_idx
         intp_t switch_idx
         int64_t left, right
 

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -399,7 +399,7 @@ cdef ndarray[int64_t] _get_dst_hours(
             switch_idxs = (delta <= 0).nonzero()[0]
             if switch_idxs.size > 1:
                 raise pytz.AmbiguousTimeError(
-                    f"There are {switch_idx.size} dst switches when "
+                    f"There are {switch_idxs.size} dst switches when "
                     "there should only be 1."
                 )
 

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -193,6 +193,8 @@ timedelta-like}
     result_b[:] = NPY_NAT
 
     for i in range(n):
+        # This loops resembles the "Find the two best possibilities" block
+        #  in pytz's DstTZInfo.localize method.
         val = vals[i]
         if val == NPY_NAT:
             continue

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -39,7 +39,6 @@ from pandas._libs.tslibs.np_datetime cimport (
 )
 from pandas._libs.tslibs.timezones cimport (
     get_dst_info,
-    get_utcoffset,
     is_fixed_offset,
     is_tzlocal,
     is_utc,


### PR DESCRIPTION
There's still a few more to be gotten, but its a start.