### PR TITLE
REGR: RecursionError when attempting to replace np.nan values

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1454,7 +1454,7 @@ def _ensure_nanosecond_dtype(dtype: DtypeObj) -> DtypeObj:
 
 # TODO: other value-dependent functions to standardize here include
 #  dtypes.concat.cast_to_common_type and Index._find_common_type_compat
-def find_result_type(left: ArrayLike, right: Any) -> DtypeObj:
+def find_result_type(left: ArrayLike, right: Any, strict_na: bool = False) -> DtypeObj:
     """
     Find the type/dtype for a the result of an operation between these objects.
 
@@ -1466,6 +1466,7 @@ def find_result_type(left: ArrayLike, right: Any) -> DtypeObj:
     ----------
     left : np.ndarray or ExtensionArray
     right : Any
+    strict_na: bool
 
     Returns
     -------
@@ -1491,7 +1492,7 @@ def find_result_type(left: ArrayLike, right: Any) -> DtypeObj:
 
         new_dtype = np.result_type(left, right)
 
-    elif is_valid_na_for_dtype(right, left.dtype):
+    elif not strict_na and is_valid_na_for_dtype(right, left.dtype):
         # e.g. IntervalDtype[int] and None/np.nan
         new_dtype = ensure_dtype_can_hold_na(left.dtype)
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -436,7 +436,7 @@ class Block(PandasObject):
     # Up/Down-casting
 
     @final
-    def coerce_to_target_dtype(self, other) -> Block:
+    def coerce_to_target_dtype(self, other, strict_na: bool = False) -> Block:
         """
         coerce the current block to a dtype compat for other
         we will return a block, possibly object, and not raise
@@ -444,7 +444,7 @@ class Block(PandasObject):
         we can also safely try to coerce to the same dtype
         and will receive the same block
         """
-        new_dtype = find_result_type(self.values, other)
+        new_dtype = find_result_type(self.values, other, strict_na=strict_na)
 
         return self.astype(new_dtype, copy=False)
 
@@ -601,7 +601,7 @@ class Block(PandasObject):
             return blocks
 
         elif self.ndim == 1 or self.shape[0] == 1:
-            blk = self.coerce_to_target_dtype(value)
+            blk = self.coerce_to_target_dtype(value, strict_na=True)
             return blk.replace(
                 to_replace=to_replace,
                 value=value,

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -675,6 +675,13 @@ class TestDataFrameReplace:
         expected = DataFrame([None, None])
         tm.assert_frame_equal(result, expected)
 
+    def test_replace_float_nan_with_pd_NA(self):
+        # gh-45725
+        df = DataFrame([np.nan, np.nan], dtype=float)
+        result = df.replace({np.nan: pd.NA})
+        expected = DataFrame([pd.NA, pd.NA], dtype=object)
+        tm.assert_frame_equal(result, expected)
+
     def test_replace_value_is_none(self, datetime_frame):
         orig_value = datetime_frame.iloc[0, 0]
         orig2 = datetime_frame.iloc[1, 0]


### PR DESCRIPTION
- [ ] closes #45725 (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.


`self._can_hold_element(value)` for pd.NA on a float block is `False` so we need to ensure the block is coerced to a dtype with can hold the value to prevent the RecursionError 

The `None` case in the issue OP was already fixed by #46404 which short circuits for the list like case and does not split the block for backwards compatibility

The test added here is NOT parametrized for various null values since this is a targeted regression fix of the recursion error and to maintain the pre-regression behavior and NOT looking to make null value handling consistent for replace.

This targeted regression fix is milestoned 1.5 as the regression that resulted in the RecursionError  is only on main.