### PR TITLE
BUG: ExcelWriter's engine and supported_extensions are properties

### DIFF
--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -945,9 +945,9 @@ class ExcelWriter(metaclass=abc.ABCMeta):
     # - Mandatory
     #   - ``write_cells(self, cells, sheet_name=None, startrow=0, startcol=0)``
     #     --> called to write additional DataFrames to disk
-    #   - ``supported_extensions`` (tuple of supported extensions), used to
+    #   - ``_supported_extensions`` (tuple of supported extensions), used to
     #      check that engine supports the given extension.
-    #   - ``engine`` - string that gives the engine name. Necessary to
+    #   - ``_engine`` - string that gives the engine name. Necessary to
     #     instantiate class directly and bypass ``ExcelWriterMeta`` engine
     #     lookup.
     #   - ``save(self)`` --> called to save file to disk
@@ -961,6 +961,10 @@ class ExcelWriter(metaclass=abc.ABCMeta):
     # You also need to register the class with ``register_writer()``.
     # Technically, ExcelWriter implementations don't need to subclass
     # ExcelWriter.
+
+    _engine: str
+    _supported_extensions: tuple[str, ...] | list[str]
+
     def __new__(
         cls,
         path: FilePath | WriteExcelBuffer | ExcelWriter,
@@ -983,7 +987,6 @@ class ExcelWriter(metaclass=abc.ABCMeta):
             )
 
         # only switch class if generic(ExcelWriter)
-
         if cls is ExcelWriter:
             if engine is None or (isinstance(engine, str) and engine == "auto"):
                 if isinstance(path, str):
@@ -1027,16 +1030,14 @@ class ExcelWriter(metaclass=abc.ABCMeta):
     _path = None
 
     @property
-    @abc.abstractmethod
     def supported_extensions(self) -> tuple[str, ...] | list[str]:
         """Extensions that writer engine supports."""
-        pass
+        return self._supported_extensions
 
     @property
-    @abc.abstractmethod
     def engine(self) -> str:
         """Name of engine."""
-        pass
+        return self._engine
 
     @property
     @abc.abstractmethod

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -963,7 +963,7 @@ class ExcelWriter(metaclass=abc.ABCMeta):
     # ExcelWriter.
 
     _engine: str
-    _supported_extensions: tuple[str, ...] | list[str]
+    _supported_extensions: tuple[str, ...]
 
     def __new__(
         cls,
@@ -1030,7 +1030,7 @@ class ExcelWriter(metaclass=abc.ABCMeta):
     _path = None
 
     @property
-    def supported_extensions(self) -> tuple[str, ...] | list[str]:
+    def supported_extensions(self) -> tuple[str, ...]:
         """Extensions that writer engine supports."""
         return self._supported_extensions
 

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -1293,12 +1293,7 @@ class ExcelWriter(metaclass=abc.ABCMeta):
         """
         if ext.startswith("."):
             ext = ext[1:]
-        # error: "Callable[[ExcelWriter], Any]" has no attribute "__iter__" (not
-        #  iterable)
-        if not any(
-            ext in extension
-            for extension in cls.supported_extensions  # type: ignore[attr-defined]
-        ):
+        if not any(ext in extension for extension in cls._supported_extensions):
             raise ValueError(f"Invalid extension for engine '{cls.engine}': '{ext}'")
         else:
             return True

--- a/pandas/io/excel/_odswriter.py
+++ b/pandas/io/excel/_odswriter.py
@@ -25,8 +25,8 @@ from pandas.io.formats.excel import ExcelCell
 
 
 class ODSWriter(ExcelWriter):
-    engine = "odf"
-    supported_extensions = (".ods",)
+    _engine = "odf"
+    _supported_extensions = (".ods",)
 
     def __init__(
         self,

--- a/pandas/io/excel/_openpyxl.py
+++ b/pandas/io/excel/_openpyxl.py
@@ -36,8 +36,8 @@ if TYPE_CHECKING:
 
 
 class OpenpyxlWriter(ExcelWriter):
-    engine = "openpyxl"
-    supported_extensions = (".xlsx", ".xlsm")
+    _engine = "openpyxl"
+    _supported_extensions = (".xlsx", ".xlsm")
 
     def __init__(
         self,

--- a/pandas/io/excel/_util.py
+++ b/pandas/io/excel/_util.py
@@ -41,9 +41,7 @@ def register_writer(klass: ExcelWriter_t) -> None:
     """
     if not callable(klass):
         raise ValueError("Can only register callables as engines")
-    engine_name = klass.engine
-    # for mypy
-    assert isinstance(engine_name, str)
+    engine_name = klass._engine
     _writers[engine_name] = klass
 
 

--- a/pandas/io/excel/_xlsxwriter.py
+++ b/pandas/io/excel/_xlsxwriter.py
@@ -169,8 +169,8 @@ class _XlsxStyler:
 
 
 class XlsxWriter(ExcelWriter):
-    engine = "xlsxwriter"
-    supported_extensions = (".xlsx",)
+    _engine = "xlsxwriter"
+    _supported_extensions = (".xlsx",)
 
     def __init__(
         self,

--- a/pandas/io/excel/_xlwt.py
+++ b/pandas/io/excel/_xlwt.py
@@ -25,8 +25,8 @@ if TYPE_CHECKING:
 
 
 class XlwtWriter(ExcelWriter):
-    engine = "xlwt"
-    supported_extensions = (".xls",)
+    _engine = "xlwt"
+    _supported_extensions = (".xls",)
 
     def __init__(
         self,

--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -1313,7 +1313,7 @@ class TestExcelWriterEngineTests:
             called_save = False
             called_write_cells = False
             called_sheets = False
-            _supported_extensions = ["xlsx", "xls"]
+            _supported_extensions = ("xlsx", "xls")
             _engine = "dummy"
 
             def book(self):

--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -1313,8 +1313,8 @@ class TestExcelWriterEngineTests:
             called_save = False
             called_write_cells = False
             called_sheets = False
-            supported_extensions = ["xlsx", "xls"]
-            engine = "dummy"
+            _supported_extensions = ["xlsx", "xls"]
+            _engine = "dummy"
 
             def book(self):
                 pass


### PR DESCRIPTION
`engine` and `supported_extensions` are declared to be properties in `ExcelWriter` but sub-classes simply assign variables to them. While the differences are subtle, we should either consistently use properties or variables (pyright doesn't like mixing them; mypy doesn't seem to care).

There are more cases where a sub-class does not use a property (found by pyright when enabling reportGeneralTypeIssues):
<details>

```
pandas/core/arrays/datetimes.py:193:20 - error: Expression of type "_scalar_type" cannot be assigned to declared type "property"
pandas/core/arrays/interval.py:200:12 - error: Expression of type "Literal[1]" cannot be assigned to declared type "property"
pandas/core/arrays/period.py:165:20 - error: Expression of type "_scalar_type" cannot be assigned to declared type "property"
pandas/core/arrays/string_.py:94:12 - error: Expression of type "Literal['string']" cannot be assigned to declared type "property"
pandas/core/arrays/string_.py:97:16 - error: Expression of type "NAType" cannot be assigned to declared type "property"
pandas/core/arrays/timedeltas.py:132:20 - error: Expression of type "_scalar_type" cannot be assigned to declared type "property"
pandas/core/dtypes/dtypes.py:176:12 - error: Expression of type "Literal['category']" cannot be assigned to declared type "property"
pandas/core/dtypes/dtypes.py:670:16 - error: Expression of type "NaTType" cannot be assigned to declared type "property"
pandas/core/dtypes/dtypes.py:1045:12 - error: Expression of type "Literal['interval']" cannot be assigned to declared type "property
pandas/core/dtypes/dtypes.py:1394:16 - error: Expression of type "NAType" cannot be assigned to declared type "property"
pandas/core/indexes/numeric.py:372:20 - error: Expression of type "_engine_type" cannot be assigned to declared type "property"
pandas/core/indexes/numeric.py:387:20 - error: Expression of type "_engine_type" cannot be assigned to declared type "property"
pandas/core/indexes/numeric.py:402:20 - error: Expression of type "_engine_type" cannot be assigned to declared type "property"
pandas/core/indexes/range.py:104:20 - error: Expression of type "_engine_type" cannot be assigned to declared type "property"
pandas/core/internals/array_manager.py:706:12 - error: Expression of type "Literal[2]" cannot be assigned to declared type "property
pandas/core/internals/base.py:158:12 - error: Expression of type "Literal[1]" cannot be assigned to declared type "property"
pandas/core/internals/blocks.py:1981:20 - error: Expression of type "Literal[True]" cannot be assigned to declared type "property"
pandas/core/internals/managers.py:1671:23 - error: Expression of type "Literal[True]" cannot be assigned to declared type "property"
pandas/plotting/_matplotlib/core.py:1038:13 - error: Expression of type "Literal['scatter']" cannot be assigned to declared type "property"
pandas/plotting/_matplotlib/core.py:1126:13 - error: Expression of type "Literal['hexbin']" cannot be assigned to declared type "property"
pandas/plotting/_matplotlib/core.py:1156:13 - error: Expression of type "Literal['line']" cannot be assigned to declared type "property"
pandas/plotting/_matplotlib/core.py:1423:13 - error: Expression of type "Literal['bar']" cannot be assigned to declared type "property"
pandas/plotting/_matplotlib/core.py:1606:13 - error: Expression of type "Literal['pie']" cannot be assigned to declared type "property"
pandas/plotting/_matplotlib/hist.py:171:19 - error: Expression of type "Literal['vertical']" cannot be assigned to declared type "property"
```