### PR TITLE
Fix showing "None" as ylabel in :meth:`Series.plot` when not setting ylabel

### DIFF
--- a/doc/source/whatsnew/v1.4.2.rst
+++ b/doc/source/whatsnew/v1.4.2.rst
@@ -30,7 +30,7 @@ Bug fixes
 ~~~~~~~~~
 - Fix some cases for subclasses that define their ``_constructor`` properties as general callables (:issue:`46018`)
 - Fixed "longtable" formatting in :meth:`.Styler.to_latex` when ``column_format`` is given in extended format (:issue:`46037`)
--
+- Fix showing "None" as ylabel in :meth:`Series.plot` when not setting ylabel (:issue:`46129`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.4.2.rst
+++ b/doc/source/whatsnew/v1.4.2.rst
@@ -30,7 +30,7 @@ Bug fixes
 ~~~~~~~~~
 - Fix some cases for subclasses that define their ``_constructor`` properties as general callables (:issue:`46018`)
 - Fixed "longtable" formatting in :meth:`.Styler.to_latex` when ``column_format`` is given in extended format (:issue:`46037`)
-- Fix showing "None" as ylabel in :meth:`Series.plot` when not setting ylabel (:issue:`46129`)
+-
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -109,7 +109,7 @@ did not have the same index as the input.
     df.groupby('a', dropna=True).transform(lambda x: x)
     df.groupby('a', dropna=True).transform('sum')
 
-.. _whatsnew_150.notable_bug_fixes.visualization
+.. _whatsnew_150.notable_bug_fixes.visualization:
 
 Styler
 ^^^^^^

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -109,6 +109,13 @@ did not have the same index as the input.
     df.groupby('a', dropna=True).transform(lambda x: x)
     df.groupby('a', dropna=True).transform('sum')
 
+.. _whatsnew_150.notable_bug_fixes.visualization
+
+Styler
+^^^^^^
+
+- Fix showing "None" as ylabel in :meth:`Series.plot` when not setting ylabel (:issue:`46129`)
+
 .. _whatsnew_150.notable_bug_fixes.notable_bug_fix2:
 
 notable_bug_fix2

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -458,7 +458,7 @@ class MPLPlot:
         if isinstance(data, ABCSeries):
             label = self.label
             if label is None and data.name is None:
-                label = "None"
+                label = ""
             if label is None:
                 # We'll end up with columns of [0] instead of [None]
                 data = data.to_frame()

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -1189,7 +1189,7 @@ class TestDataFramePlots(TestPlotBase):
         assert ax.get_legend() is None
 
         ax = s.plot(legend=True)
-        assert ax.get_legend().get_texts()[0].get_text() == "None"
+        assert ax.get_legend().get_texts()[0].get_text() == ""
 
     @pytest.mark.parametrize(
         "props, expected",

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -179,7 +179,7 @@ class TestSeriesPlots(TestPlotBase):
         self.plt.close()
         _, ax = self.plt.subplots()
         ax = s.plot(legend=True, ax=ax)
-        self._check_legend_labels(ax, labels=["None"])
+        self._check_legend_labels(ax, labels=[""])
         self.plt.close()
         # get name from index
         s.name = "NAME"


### PR DESCRIPTION
- [ ] closes #46129
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

[here](https://github.com/pandas-dev/pandas/issues/46129#issuecomment-1055224345), Mctoel mentioned that if series.plot(kind=pie) does not specify `ylabel`, "None" will appear as ylabel in the figure.
![image](https://user-images.githubusercontent.com/42494185/159170646-8e4013f3-9be5-4873-92f7-7b948666efbc.png)
