### PR TITLE
TST: JSONArray test_combine_first sometimes passes

### DIFF
--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -267,7 +267,11 @@ class TestMethods(BaseJSON, base.BaseMethodsTests):
     def test_combine_add(self, data_repeated):
         super().test_combine_add(data_repeated)
 
-    @pytest.mark.xfail(reason="combine for JSONArray not supported")
+    @pytest.mark.xfail(
+        reason="combine for JSONArray not supported - "
+        "may pass depending on random data",
+        strict=False,
+    )
     def test_combine_first(self, data):
         super().test_combine_first(data)
 


### PR DESCRIPTION
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

xref https://github.com/pandas-dev/pandas/pull/46427

Encountered a build where this xpassed

https://dev.azure.com/pandas-dev/pandas/_build/results?buildId=75611&view=ms.vss-test-web.build-test-results-tab&runId=3135400&resultId=171966&paneView=debug
