### PR TITLE
BUG: groupby.value_counts subset arg not working

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1701,20 +1701,25 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                         f"Keys {clashing} in subset cannot be in "
                         "the groupby column keys"
                     )
-                key_names = subset
-            else:
-                key_names = set(self._selected_obj.columns) - set(in_axis_names)
 
             if isinstance(self._selected_obj, Series):
                 name = self._selected_obj.name
                 keys = [] if name in in_axis_names else [self._selected_obj]
             else:
-                keys = [
-                    # Can't use .values because the column label needs to be preserved
-                    self._selected_obj.iloc[:, idx]
-                    for idx, name in enumerate(self._selected_obj.columns)
-                    if name in key_names
-                ]
+                if subset:
+                    keys = [
+                        self._selected_obj.iloc[:, idx]
+                        for idx, name in enumerate(self._selected_obj.columns)
+                        if name in subset
+                    ]
+                else:
+                    keys = [
+                        # Can't use .values because the column label needs to
+                        # be preserved
+                        self._selected_obj.iloc[:, idx]
+                        for idx, name in enumerate(self._selected_obj.columns)
+                        if name not in in_axis_names
+                    ]
 
             groupings = list(self.grouper.groupings)
             for key in keys:

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1694,6 +1694,17 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
             in_axis_names = {
                 grouping.name for grouping in self.grouper.groupings if grouping.in_axis
             }
+            if subset is not None:
+                clashing = set(subset) & set(in_axis_names)
+                if clashing:
+                    raise ValueError(
+                        f"Keys {clashing} in subset cannot be in "
+                        "the groupby column keys"
+                    )
+                key_names = subset
+            else:
+                key_names = set(self._selected_obj.columns) - set(in_axis_names)
+
             if isinstance(self._selected_obj, Series):
                 name = self._selected_obj.name
                 keys = [] if name in in_axis_names else [self._selected_obj]
@@ -1702,16 +1713,8 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                     # Can't use .values because the column label needs to be preserved
                     self._selected_obj.iloc[:, idx]
                     for idx, name in enumerate(self._selected_obj.columns)
-                    if name not in in_axis_names
+                    if name in key_names
                 ]
-
-            if subset is not None:
-                clashing = set(subset) & set(in_axis_names)
-                if clashing:
-                    raise ValueError(
-                        f"Keys {clashing} in subset cannot be in "
-                        "the groupby column keys"
-                    )
 
             groupings = list(self.grouper.groupings)
             for key in keys:

--- a/pandas/tests/groupby/test_value_counts.py
+++ b/pandas/tests/groupby/test_value_counts.py
@@ -192,3 +192,20 @@ def test_series_groupby_value_counts_on_categorical():
     # Name: 0, dtype: int64
 
     tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("columns", [["c1"], ["c2"], ["c2", "c3"], ["c1", "c2", "c3"]])
+def test_series_groupby_value_counts_subset(columns):
+    # GH46383
+    df = DataFrame(
+        {
+            "c1": ["a", "b", "c", "d", "c"],
+            "c2": ["x", "y", "y", "x", "z"],
+            "c3": [2, 1, 1, 2, 1],
+        },
+        index=[0, 1, 1, 2, 0],
+    )
+    result = df.groupby(level=0).value_counts(subset=columns)
+    expected = df.groupby(level=0)[columns].value_counts()
+
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #46383
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests)
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

It works but I'm not sure it is the right approach. Alternatively I could add an if-else in l.1712 to check for subset and create `keys` with two separate list comprehensions and leave the rest as it was.