### PR TITLE
BUG: url regex in `style_render` does not pass colon and other valid

### DIFF
--- a/doc/source/whatsnew/v1.4.2.rst
+++ b/doc/source/whatsnew/v1.4.2.rst
@@ -31,7 +31,7 @@ Bug fixes
 ~~~~~~~~~
 - Fix some cases for subclasses that define their ``_constructor`` properties as general callables (:issue:`46018`)
 - Fixed "longtable" formatting in :meth:`.Styler.to_latex` when ``column_format`` is given in extended format (:issue:`46037`)
--
+- Fix incorrect hyperlink rendering when the url contains colon or other special characters (:issue:`46389`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.4.2.rst
+++ b/doc/source/whatsnew/v1.4.2.rst
@@ -31,7 +31,7 @@ Bug fixes
 ~~~~~~~~~
 - Fix some cases for subclasses that define their ``_constructor`` properties as general callables (:issue:`46018`)
 - Fixed "longtable" formatting in :meth:`.Styler.to_latex` when ``column_format`` is given in extended format (:issue:`46037`)
-- Fix incorrect hyperlink rendering when the url contains colon or other special characters (:issue:`46389`)
+- Fixed incorrect rendering in :meth:`.Styler.format` with ``hyperlinks="html"`` when the url contains a colon or other special characters (:issue:`46389`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -1589,7 +1589,7 @@ def _render_href(x, format):
             href = r"\href{{{0}}}{{{0}}}"
         else:
             raise ValueError("``hyperlinks`` format can only be 'html' or 'latex'")
-        pat = r"(https?:\/\/|ftp:\/\/|www.)[\w/\-?=%.]+\.[\w/\-&?=%.]+"
+        pat = r"((http|ftp)s?:\/\/|www.)[\w/\-?=%.:@]+\.[\w/\-&?=%.,':;~!@#$*()\[\]]+"
         return re.sub(pat, lambda m: href.format(m.group(0)), x)
     return x
 

--- a/pandas/tests/io/formats/style/test_html.py
+++ b/pandas/tests/io/formats/style/test_html.py
@@ -778,8 +778,20 @@ def test_hiding_index_columns_multiindex_trimming():
         ("no scheme, no top-level: www.web", False, "www.web"),
         ("https scheme: https://www.web.com", True, "https://www.web.com"),
         ("ftp scheme: ftp://www.web", True, "ftp://www.web"),
+        ("ftps scheme: ftps://www.web", True, "ftps://www.web"),
         ("subdirectories: www.web.com/directory", True, "www.web.com/directory"),
         ("Multiple domains: www.1.2.3.4", True, "www.1.2.3.4"),
+        ("with port: http://web.com:80", True, "http://web.com:80"),
+        (
+            "full net_loc scheme: http://user:pass@web.com",
+            True,
+            "http://user:pass@web.com",
+        ),
+        (
+            "with valid special chars: http://web.com/,.':;~!@#$*()[]",
+            True,
+            "http://web.com/,.':;~!@#$*()[]",
+        ),
     ],
 )
 def test_rendered_links(type, text, exp, found):


### PR DESCRIPTION
URLs containing some valid characters such as colon in port numbers get
cut off when html-formatting. As a workaround, expanded the regex to
match a wider variety of URLs.

- [x] closes #46389 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v1.4.2.rst` file if fixing a bug or adding a new feature.
