### PR TITLE
BUG: Use isinstance for is_iterator on Cygwin

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -268,7 +268,10 @@ def is_iterator(obj: object) -> bool:
     >>> is_iterator(1)
     False
     """
-    return PyIter_Check(obj)
+    IF UNAME_SYSNAME.startswith("CYGWIN"):
+        return isinstance(obj, abc.Iterator)
+    ELSE:
+        return PyIter_Check(obj)
 
 
 def item_from_zerodim(val: object) -> object:


### PR DESCRIPTION
Fixes #45158 

Keep original implementation if not on Cygwin, and choose the implementation at compile time to avoid performance hits from the extra branch.

[Test results on Cygwin are available are available here](https://github.com/DWesl/pandas/runs/5648361139?check_suite_focus=true)

- [X] closes #45158
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
