### PR TITLE
BLD: Fix black to match pre-commit black version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - cython>=0.29.24
 
   # code checks
-  - black=21.5b2
+  - black=22.1.0
   - cpplint
   - flake8=4.0.1
   - flake8-bugbear=21.3.2  # used by flake8, find likely bugs

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ python-dateutil>=2.8.1
 pytz
 asv < 0.5.0
 cython>=0.29.24
-black==21.5b2
+black==22.1.0
 cpplint
 flake8==4.0.1
 flake8-bugbear==21.3.2


### PR DESCRIPTION
Black version is not synced now across relevant files (pre-commit's version is higher than requirements-dev's and environment's). This PR aims to fix that.

I am not aware of any issue mentioning this problem, hence no reference.