### PR TITLE
Revert "REF: isinstance(x, int) -> is_integer(x)"

### DIFF
--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -25,11 +25,6 @@ from pandas._libs import lib
 from pandas._typing import Level
 from pandas.compat._optional import import_optional_dependency
 
-from pandas.core.dtypes.common import (
-    is_complex,
-    is_float,
-    is_integer,
-)
 from pandas.core.dtypes.generic import ABCSeries
 
 from pandas import (
@@ -1532,9 +1527,9 @@ def _default_formatter(x: Any, precision: int, thousands: bool = False) -> Any:
     value : Any
         Matches input type, or string if input is float or complex or int with sep.
     """
-    if is_float(x) or is_complex(x):
+    if isinstance(x, (float, complex)):
         return f"{x:,.{precision}f}" if thousands else f"{x:.{precision}f}"
-    elif is_integer(x):
+    elif isinstance(x, int):
         return f"{x:,.0f}" if thousands else f"{x:.0f}"
     return x
 
@@ -1549,7 +1544,7 @@ def _wrap_decimal_thousands(
     """
 
     def wrapper(x):
-        if is_float(x) or is_integer(x) or is_complex(x):
+        if isinstance(x, (float, complex, int)):
             if decimal != "." and thousands is not None and thousands != ",":
                 return (
                     formatter(x)


### PR DESCRIPTION
Reverts pandas-dev/pandas#46119

It looks like this can be auto reverted. (won't know till ci has run)

@attack68 if we revert this, we could redo and add a regression test for #46384 to address https://github.com/pandas-dev/pandas/pull/46119#issuecomment-1049069600, add a release note for the bugfix and maybe backport to 1.4.x. wdyt?

I think should probably reopen #46384 and add a test to close that issue off anyway.