### PR TITLE
return nan on empty groups

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -960,7 +960,10 @@ class Series(base.IndexOpsMixin, NDFrame):
             key = unpack_1tuple(key)
 
         if is_integer(key) and self.index._should_fallback_to_positional:
-            return self._values[key]
+            try:
+                return self._values[key]
+            except IndexError:
+                return np.nan
 
         elif key_is_scalar:
             return self._get_value(key)


### PR DESCRIPTION
- [ ] closes #46496

I'm not sure where in the rst file to specify this behavior change. If its a bug fix or just an enhancement. Any help would be appreciated. 

I also ran some of the `test...apply` files and they passed, please let me know what else I should do.
thank you!