### PR TITLE
TYP: misc

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -104,6 +104,8 @@ Timezone = Union[str, tzinfo]
 # passed in, a DataFrame is always returned.
 NDFrameT = TypeVar("NDFrameT", bound="NDFrame")
 
+NumpyIndexT = TypeVar("NumpyIndexT", np.ndarray, Index)
+
 Axis = Union[str, int]
 IndexLabel = Union[Hashable, Sequence[Hashable]]
 Level = Union[Hashable, int]

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -104,7 +104,7 @@ Timezone = Union[str, tzinfo]
 # passed in, a DataFrame is always returned.
 NDFrameT = TypeVar("NDFrameT", bound="NDFrame")
 
-NumpyIndexT = TypeVar("NumpyIndexT", np.ndarray, Index)
+NumpyIndexT = TypeVar("NumpyIndexT", np.ndarray, "Index")
 
 Axis = Union[str, int]
 IndexLabel = Union[Hashable, Sequence[Hashable]]

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -295,7 +295,9 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
     # ----------------------------------------------------------------
     # Rendering Methods
 
-    def _format_native_types(self, *, na_rep="NaT", date_format=None):
+    def _format_native_types(
+        self, *, na_rep="NaT", date_format=None
+    ) -> npt.NDArray[np.object_]:
         """
         Helper method for astype when converting to strings.
 

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -635,7 +635,7 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
     @dtl.ravel_compat
     def _format_native_types(
         self, *, na_rep="NaT", date_format=None, **kwargs
-    ) -> np.ndarray:
+    ) -> npt.NDArray[np.object_]:
         """
         actually format my specific types
         """

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -37,6 +37,7 @@ from pandas._libs.tslibs.timedeltas import (
 from pandas._typing import (
     DtypeObj,
     NpDtype,
+    npt,
 )
 from pandas.compat.numpy import function as nv
 from pandas.util._validators import validate_endpoints
@@ -431,7 +432,7 @@ class TimedeltaArray(dtl.TimelikeOps):
     @dtl.ravel_compat
     def _format_native_types(
         self, *, na_rep="NaT", date_format=None, **kwargs
-    ) -> np.ndarray:
+    ) -> npt.NDArray[np.object_]:
         from pandas.io.formats.format import get_format_timedelta64
 
         formatter = get_format_timedelta64(self._ndarray, na_rep)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1511,7 +1511,9 @@ class Index(IndexOpsMixin, PandasObject):
             values = values[slicer]
         return values._format_native_types(**kwargs)
 
-    def _format_native_types(self, *, na_rep="", quoting=None, **kwargs):
+    def _format_native_types(
+        self, *, na_rep="", quoting=None, **kwargs
+    ) -> npt.NDArray[np.object_]:
         """
         Actually format specific types of the index.
         """

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -820,7 +820,9 @@ class IntervalIndex(ExtensionIndex):
         # matches base class except for whitespace padding
         return header + list(self._format_native_types(na_rep=na_rep))
 
-    def _format_native_types(self, *, na_rep="NaN", quoting=None, **kwargs):
+    def _format_native_types(
+        self, *, na_rep="NaN", quoting=None, **kwargs
+    ) -> npt.NDArray[np.object_]:
         # GH 28210: use base method but with different default na_rep
         return super()._format_native_types(na_rep=na_rep, quoting=quoting, **kwargs)
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1294,7 +1294,9 @@ class MultiIndex(Index):
         formatter_funcs = [level._formatter_func for level in self.levels]
         return tuple(func(val) for func, val in zip(formatter_funcs, tup))
 
-    def _format_native_types(self, *, na_rep="nan", **kwargs):
+    def _format_native_types(
+        self, *, na_rep="nan", **kwargs
+    ) -> npt.NDArray[np.object_]:
         new_levels = []
         new_codes = []
 

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -276,7 +276,7 @@ class NumericIndex(Index):
 
     def _format_native_types(
         self, *, na_rep="", float_format=None, decimal=".", quoting=None, **kwargs
-    ):
+    ) -> npt.NDArray[np.object_]:
         from pandas.io.formats.format import FloatArrayFormatter
 
         if is_float_dtype(self.dtype):

--- a/pandas/core/reshape/util.py
+++ b/pandas/core/reshape/util.py
@@ -55,7 +55,7 @@ def cartesian_product(X):
     return [tile_compat(np.repeat(x, b[i]), np.product(a[i])) for i, x in enumerate(X)]
 
 
-def tile_compat(arr:NumpyIndexT, num: int) -> NumpyIndexT:
+def tile_compat(arr: NumpyIndexT, num: int) -> NumpyIndexT:
     """
     Index compat for np.tile.
 

--- a/pandas/core/reshape/util.py
+++ b/pandas/core/reshape/util.py
@@ -1,8 +1,9 @@
 import numpy as np
 
+from pandas._typing import NumpyIndexT
+
 from pandas.core.dtypes.common import is_list_like
 
-from pandas._typing import NumpyIndexT
 
 def cartesian_product(X):
     """

--- a/pandas/core/reshape/util.py
+++ b/pandas/core/reshape/util.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from pandas.core.dtypes.common import is_list_like
 
+from pandas._typing import NumpyIndexT
 
 def cartesian_product(X):
     """
@@ -54,7 +55,7 @@ def cartesian_product(X):
     return [tile_compat(np.repeat(x, b[i]), np.product(a[i])) for i, x in enumerate(X)]
 
 
-def tile_compat(arr, num: int):
+def tile_compat(arr:NumpyIndexT, num: int) -> NumpyIndexT:
     """
     Index compat for np.tile.
 

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -73,7 +73,7 @@ class CSVFormatter:
 
         self.filepath_or_buffer = path_or_buf
         self.encoding = encoding
-        self.compression = compression
+        self.compression: CompressionOptions = compression
         self.mode = mode
         self.storage_options = storage_options
 


### PR DESCRIPTION
Small set of typing changes to reduce the number of errors of pyright's reportGeneralTypeIssues from 1365 to 1309:

- return value for `_format_native_types`
- TypeVar for `tile_compat`
- When assigning literals to an instance variable, they need explicit type annotations (in this case for `CompressionOptions`), see https://github.com/microsoft/pyright/issues/3256