### PR TITLE
Add a new material in Community tutorials page 

### DIFF
--- a/doc/source/getting_started/tutorials.rst
+++ b/doc/source/getting_started/tutorials.rst
@@ -75,6 +75,16 @@ Excel charts with pandas, vincent and xlsxwriter
 
 *  `Using Pandas and XlsxWriter to create Excel charts <https://pandas-xlsxwriter-charts.readthedocs.io/>`_
 
+Joyful pandas
+-------------
+
+A tutorial written in Chinese by Yuanhao Geng. It covers the basic operations
+for NumPy and pandas, 4 main data manipulation methods (including indexing, groupby, reshaping
+and concatenation) and 4 main data types (including missing data, string data, categorical
+data and time series data). At the end of each chapter, corresponding exercises are posted.
+All the datasets and related materials can be found in the GitHub repository
+`datawhalechina/joyful-pandas <https://github.com/datawhalechina/joyful-pandas>`_.
+
 Video tutorials
 ---------------
 


### PR DESCRIPTION
Currently, [Joyful pandas](https://github.com/datawhalechina/joyful-pandas) is one of the popular tutorials for pandas on GitHub, which ranks after guipsamora/pandas_exercises and Julia Evans' pandas cookbook by stars. This tutorial is based on pandas with
a newer version and includes most of the essential parts in pandas. The webpage for the tutorial follows pandas's sphinx template. I believe this can be helpful for the community. Thanks.