### PR TITLE
REF: re-use tz_convert_from_utc_single in _localize_tso

### DIFF
--- a/pandas/_libs/tslibs/__init__.py
+++ b/pandas/_libs/tslibs/__init__.py
@@ -55,7 +55,9 @@ from pandas._libs.tslibs.timedeltas import (
 )
 from pandas._libs.tslibs.timestamps import Timestamp
 from pandas._libs.tslibs.timezones import tz_compare
-from pandas._libs.tslibs.tzconversion import tz_convert_from_utc_single
+from pandas._libs.tslibs.tzconversion import (
+    py_tz_convert_from_utc_single as tz_convert_from_utc_single,
+)
 from pandas._libs.tslibs.vectorized import (
     dt64arr_to_periodarr,
     get_resolution,

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -534,12 +534,6 @@ cdef _TSObject _create_tsobject_tz_using_offset(npy_datetimestruct dts,
             pos = bisect_right_i8(tdata, obj.value, trans.shape[0]) - 1
             obj.fold = infer_dateutil_fold(obj.value, trans, deltas, pos)
 
-    #else:
-    #    # TODO: are we doing unnecessary work for pytz/fixed case? can we
-    #    #  use the local_val returned from this call to make some
-    #    #  of the rest of the function unnecessary?
-    #    tz_convert_from_utc_single(obj.value, tz, &obj.fold)
-
     # Keep the converter same as PyDateTime's
     dt = datetime(obj.dts.year, obj.dts.month, obj.dts.day,
                   obj.dts.hour, obj.dts.min, obj.dts.sec,
@@ -690,8 +684,7 @@ cdef inline void _localize_tso(_TSObject obj, tzinfo tz):
         int64_t[::1] deltas
         int64_t local_val
         int64_t* tdata
-        intp_t outpos = -1
-        Py_ssize_t pos, ntrans
+        Py_ssize_t pos, ntrans, outpos = -1
         str typ
 
     assert obj.tzinfo is None

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -72,7 +72,9 @@ from pandas._libs.tslibs.nattype cimport (
 )
 from pandas._libs.tslibs.tzconversion cimport (
     bisect_right_i8,
+    infer_dateutil_fold,
     localize_tzinfo_api,
+    tz_convert_from_utc_single,
     tz_localize_to_utc_single,
 )
 
@@ -522,15 +524,8 @@ cdef _TSObject _create_tsobject_tz_using_offset(npy_datetimestruct dts,
     # see PEP 495 https://www.python.org/dev/peps/pep-0495/#the-fold-attribute
     if is_utc(tz):
         pass
-    elif is_tzlocal(tz):
-        localize_tzinfo_api(obj.value, tz, &obj.fold)
     else:
-        trans, deltas, typ = get_dst_info(tz)
-
-        if typ == 'dateutil':
-            tdata = <int64_t*>cnp.PyArray_DATA(trans)
-            pos = bisect_right_i8(tdata, obj.value, trans.shape[0]) - 1
-            obj.fold = _infer_tsobject_fold(obj, trans, deltas, pos)
+        tz_convert_from_utc_single(obj.value, tz, &obj.fold)
 
     # Keep the converter same as PyDateTime's
     dt = datetime(obj.dts.year, obj.dts.month, obj.dts.day,
@@ -714,7 +709,7 @@ cdef inline void _localize_tso(_TSObject obj, tzinfo tz):
             local_val = obj.value + deltas[pos]
 
             # dateutil supports fold, so we infer fold from value
-            obj.fold = _infer_tsobject_fold(obj, trans, deltas, pos)
+            obj.fold = infer_dateutil_fold(obj.value, trans, deltas, pos)
         else:
             # All other cases have len(deltas) == 1. As of 2018-07-17
             #  (and 2022-03-07), all test cases that get here have
@@ -725,49 +720,6 @@ cdef inline void _localize_tso(_TSObject obj, tzinfo tz):
 
     obj.tzinfo = tz
 
-
-cdef inline bint _infer_tsobject_fold(
-    _TSObject obj,
-    const int64_t[:] trans,
-    const int64_t[:] deltas,
-    intp_t pos,
-):
-    """
-    Infer _TSObject fold property from value by assuming 0 and then setting
-    to 1 if necessary.
-
-    Parameters
-    ----------
-    obj : _TSObject
-    trans : ndarray[int64_t]
-        ndarray of offset transition points in nanoseconds since epoch.
-    deltas : int64_t[:]
-        array of offsets corresponding to transition points in trans.
-    pos : intp_t
-        Position of the last transition point before taking fold into account.
-
-    Returns
-    -------
-    bint
-        Due to daylight saving time, one wall clock time can occur twice
-        when shifting from summer to winter time; fold describes whether the
-        datetime-like corresponds  to the first (0) or the second time (1)
-        the wall clock hits the ambiguous time
-
-    References
-    ----------
-    .. [1] "PEP 495 - Local Time Disambiguation"
-           https://www.python.org/dev/peps/pep-0495/#the-fold-attribute
-    """
-    cdef:
-        bint fold = 0
-
-    if pos > 0:
-        fold_delta = deltas[pos - 1] - deltas[pos]
-        if obj.value - fold_delta < trans[pos]:
-            fold = 1
-
-    return fold
 
 cdef inline datetime _localize_pydatetime(datetime dt, tzinfo tz):
     """

--- a/pandas/_libs/tslibs/tzconversion.pxd
+++ b/pandas/_libs/tslibs/tzconversion.pxd
@@ -8,7 +8,7 @@ from numpy cimport (
 cdef int64_t localize_tzinfo_api(
     int64_t utc_val, tzinfo tz, bint* fold=*
 ) except? -1
-cdef int64_t tz_convert_from_utc_single(int64_t utc_val, tzinfo tz, bint* fold=?, intp_t* outpos=?)
+cdef int64_t tz_convert_from_utc_single(int64_t utc_val, tzinfo tz, bint* fold=?, Py_ssize_t* outpos=?)
 cdef int64_t tz_localize_to_utc_single(
     int64_t val, tzinfo tz, object ambiguous=*, object nonexistent=*
 ) except? -1

--- a/pandas/_libs/tslibs/tzconversion.pxd
+++ b/pandas/_libs/tslibs/tzconversion.pxd
@@ -8,7 +8,9 @@ from numpy cimport (
 cdef int64_t localize_tzinfo_api(
     int64_t utc_val, tzinfo tz, bint* fold=*
 ) except? -1
-cdef int64_t tz_convert_from_utc_single(int64_t utc_val, tzinfo tz, bint* fold=?, Py_ssize_t* outpos=?)
+cdef int64_t tz_convert_from_utc_single(
+    int64_t utc_val, tzinfo tz, bint* fold=?, Py_ssize_t* outpos=?
+) except? -1
 cdef int64_t tz_localize_to_utc_single(
     int64_t val, tzinfo tz, object ambiguous=*, object nonexistent=*
 ) except? -1

--- a/pandas/_libs/tslibs/tzconversion.pxd
+++ b/pandas/_libs/tslibs/tzconversion.pxd
@@ -1,13 +1,24 @@
 from cpython.datetime cimport tzinfo
-from numpy cimport int64_t
+from numpy cimport (
+    int64_t,
+    intp_t,
+)
 
 
 cdef int64_t localize_tzinfo_api(
     int64_t utc_val, tzinfo tz, bint* fold=*
 ) except? -1
-cpdef int64_t tz_convert_from_utc_single(int64_t val, tzinfo tz)
+cdef int64_t tz_convert_from_utc_single(int64_t utc_val, tzinfo tz, bint* fold=?)
 cdef int64_t tz_localize_to_utc_single(
     int64_t val, tzinfo tz, object ambiguous=*, object nonexistent=*
 ) except? -1
 
 cdef Py_ssize_t bisect_right_i8(int64_t *data, int64_t val, Py_ssize_t n)
+
+
+cdef bint infer_dateutil_fold(
+    int64_t value,
+    const int64_t[::1] trans,
+    const int64_t[::1] deltas,
+    intp_t pos,
+)

--- a/pandas/_libs/tslibs/tzconversion.pxd
+++ b/pandas/_libs/tslibs/tzconversion.pxd
@@ -8,7 +8,7 @@ from numpy cimport (
 cdef int64_t localize_tzinfo_api(
     int64_t utc_val, tzinfo tz, bint* fold=*
 ) except? -1
-cdef int64_t tz_convert_from_utc_single(int64_t utc_val, tzinfo tz, bint* fold=?)
+cdef int64_t tz_convert_from_utc_single(int64_t utc_val, tzinfo tz, bint* fold=?, intp_t* outpos=?)
 cdef int64_t tz_localize_to_utc_single(
     int64_t val, tzinfo tz, object ambiguous=*, object nonexistent=*
 ) except? -1

--- a/pandas/_libs/tslibs/tzconversion.pyi
+++ b/pandas/_libs/tslibs/tzconversion.pyi
@@ -12,7 +12,9 @@ def tz_convert_from_utc(
     vals: npt.NDArray[np.int64],  # const int64_t[:]
     tz: tzinfo,
 ) -> npt.NDArray[np.int64]: ...
-def tz_convert_from_utc_single(val: np.int64, tz: tzinfo) -> np.int64: ...
+
+# py_tz_convert_from_utc_single exposed for testing
+def py_tz_convert_from_utc_single(val: np.int64, tz: tzinfo) -> np.int64: ...
 def tz_localize_to_utc(
     vals: npt.NDArray[np.int64],
     tz: tzinfo | None,

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -444,7 +444,13 @@ cdef int64_t localize_tzinfo_api(
     return _tz_localize_using_tzinfo_api(utc_val, tz, to_utc=False, fold=fold)
 
 
-cpdef int64_t tz_convert_from_utc_single(int64_t utc_val, tzinfo tz):
+def py_tz_convert_from_utc_single(int64_t utc_val, tzinfo tz):
+    # The 'bint* fold=NULL' in tz_convert_from_utc_single means we cannot
+    #  make it cdef, so this is version exposed for testing from python.
+    return tz_convert_from_utc_single(utc_val, tz)
+
+
+cdef int64_t tz_convert_from_utc_single(int64_t utc_val, tzinfo tz, bint* fold=NULL):
     """
     Convert the val (in i8) from UTC to tz
 
@@ -454,6 +460,7 @@ cpdef int64_t tz_convert_from_utc_single(int64_t utc_val, tzinfo tz):
     ----------
     utc_val : int64
     tz : tzinfo
+    fold : bint*, default NULL
 
     Returns
     -------
@@ -473,15 +480,26 @@ cpdef int64_t tz_convert_from_utc_single(int64_t utc_val, tzinfo tz):
         return utc_val
     elif is_tzlocal(tz):
         return utc_val + _tz_localize_using_tzinfo_api(utc_val, tz, to_utc=False)
-    elif is_fixed_offset(tz):
-        _, deltas, _ = get_dst_info(tz)
-        delta = deltas[0]
-        return utc_val + delta
     else:
-        trans, deltas, _ = get_dst_info(tz)
+        trans, deltas, typ = get_dst_info(tz)
         tdata = <int64_t*>cnp.PyArray_DATA(trans)
-        pos = bisect_right_i8(tdata, utc_val, trans.shape[0]) - 1
-        return utc_val + deltas[pos]
+
+        if typ == "dateutil":
+            pos = bisect_right_i8(tdata, utc_val, trans.shape[0]) - 1
+
+            if fold is not NULL:
+                fold[0] = infer_dateutil_fold(utc_val, trans, deltas, pos)
+            return utc_val + deltas[pos]
+
+        elif typ == "pytz":
+            pos = bisect_right_i8(tdata, utc_val, trans.shape[0]) - 1
+            return utc_val + deltas[pos]
+
+        else:
+            # All other cases have len(deltas) == 1. As of 2018-07-17
+            #  (and 2022-03-07), all test cases that get here have
+            #  is_fixed_offset(tz).
+            return utc_val + deltas[0]
 
 
 def tz_convert_from_utc(const int64_t[:] vals, tzinfo tz):
@@ -632,3 +650,48 @@ cdef int64_t _tz_localize_using_tzinfo_api(
     td = tz.utcoffset(dt)
     delta = int(td.total_seconds() * 1_000_000_000)
     return delta
+
+
+# NB: this relies on dateutil internals and is subject to change.
+cdef bint infer_dateutil_fold(
+    int64_t value,
+    const int64_t[::1] trans,
+    const int64_t[::1] deltas,
+    intp_t pos,
+):
+    """
+    Infer _TSObject fold property from value by assuming 0 and then setting
+    to 1 if necessary.
+
+    Parameters
+    ----------
+    value : int64_t
+    trans : ndarray[int64_t]
+        ndarray of offset transition points in nanoseconds since epoch.
+    deltas : int64_t[:]
+        array of offsets corresponding to transition points in trans.
+    pos : intp_t
+        Position of the last transition point before taking fold into account.
+
+    Returns
+    -------
+    bint
+        Due to daylight saving time, one wall clock time can occur twice
+        when shifting from summer to winter time; fold describes whether the
+        datetime-like corresponds  to the first (0) or the second time (1)
+        the wall clock hits the ambiguous time
+
+    References
+    ----------
+    .. [1] "PEP 495 - Local Time Disambiguation"
+           https://www.python.org/dev/peps/pep-0495/#the-fold-attribute
+    """
+    cdef:
+        bint fold = 0
+
+    if pos > 0:
+        fold_delta = deltas[pos - 1] - deltas[pos]
+        if value - fold_delta < trans[pos]:
+            fold = 1
+
+    return fold

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -450,7 +450,12 @@ def py_tz_convert_from_utc_single(int64_t utc_val, tzinfo tz):
     return tz_convert_from_utc_single(utc_val, tz)
 
 
-cdef int64_t tz_convert_from_utc_single(int64_t utc_val, tzinfo tz, bint* fold=NULL, intp_t* outpos=NULL):
+cdef int64_t tz_convert_from_utc_single(
+    int64_t utc_val,
+    tzinfo tz,
+    bint* fold=NULL,
+    Py_ssize_t* outpos=NULL,
+):
     """
     Convert the val (in i8) from UTC to tz
 
@@ -461,7 +466,7 @@ cdef int64_t tz_convert_from_utc_single(int64_t utc_val, tzinfo tz, bint* fold=N
     utc_val : int64
     tz : tzinfo
     fold : bint*, default NULL
-    outpos : intp_t*, default NULL
+    outpos : Py_ssize_t*, default NULL
 
     Returns
     -------
@@ -495,6 +500,8 @@ cdef int64_t tz_convert_from_utc_single(int64_t utc_val, tzinfo tz, bint* fold=N
         elif typ == "pytz":
             pos = bisect_right_i8(tdata, utc_val, trans.shape[0]) - 1
 
+            # We need to get 'pos' back to the caller so it can pick the
+            #  correct "standardized" tzinfo objecg.
             if outpos is not NULL:
                 outpos[0] = pos
             return utc_val + deltas[pos]

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -455,7 +455,7 @@ cdef int64_t tz_convert_from_utc_single(
     tzinfo tz,
     bint* fold=NULL,
     Py_ssize_t* outpos=NULL,
-):
+) except? -1:
     """
     Convert the val (in i8) from UTC to tz
 

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -450,7 +450,7 @@ def py_tz_convert_from_utc_single(int64_t utc_val, tzinfo tz):
     return tz_convert_from_utc_single(utc_val, tz)
 
 
-cdef int64_t tz_convert_from_utc_single(int64_t utc_val, tzinfo tz, bint* fold=NULL):
+cdef int64_t tz_convert_from_utc_single(int64_t utc_val, tzinfo tz, bint* fold=NULL, intp_t* outpos=NULL):
     """
     Convert the val (in i8) from UTC to tz
 
@@ -461,6 +461,7 @@ cdef int64_t tz_convert_from_utc_single(int64_t utc_val, tzinfo tz, bint* fold=N
     utc_val : int64
     tz : tzinfo
     fold : bint*, default NULL
+    outpos : intp_t*, default NULL
 
     Returns
     -------
@@ -493,6 +494,9 @@ cdef int64_t tz_convert_from_utc_single(int64_t utc_val, tzinfo tz, bint* fold=N
 
         elif typ == "pytz":
             pos = bisect_right_i8(tdata, utc_val, trans.shape[0]) - 1
+
+            if outpos is not NULL:
+                outpos[0] = pos
             return utc_val + deltas[pos]
 
         else:

--- a/pandas/tests/tslibs/test_conversion.py
+++ b/pandas/tests/tslibs/test_conversion.py
@@ -21,7 +21,7 @@ import pandas._testing as tm
 
 def _compare_utc_to_local(tz_didx):
     def f(x):
-        return tzconversion.tz_convert_from_utc_single(x, tz_didx.tz)
+        return tzconversion.py_tz_convert_from_utc_single(x, tz_didx.tz)
 
     result = tzconversion.tz_convert_from_utc(tz_didx.asi8, tz_didx.tz)
     expected = np.vectorize(f)(tz_didx.asi8)


### PR DESCRIPTION
Largely sits on top of #46516 

The observation is that what _localize_tso is doing is similar to what tz_convert_from_utc_single is doing if we could just get a couple more pieces of information back from the latter call.   Getting `fold` back is easy to do by passing via pointer (which we do elsewhere).  Getting `new_tz` back is uglier but its the best we got.  (im assuming that returning a tuple`(int64_t, bint, Py_ssize_t)` would incur a perf penalty but ive bothered the cython folks enough already recently)

May be able to get some extra de-duplication in _create_tsobject_tz_using_offset and/or ints_to_pydatetime.  But I'm skittish perf-wise.

#46516 should definitely be merged.  This I won't be offended if reviewers ask for %timeits out the wazoo.

At some point, someone with just the right amount of adderall drip should figure out the optimal way to check for `typ=="dateutil" etc.