### PR TITLE
change default value (for index) of func named to_csv

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3401,7 +3401,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         float_format: str | None = None,
         columns: Sequence[Hashable] | None = None,
         header: bool_t | list[str] = True,
-        index: bool_t = True,
+        index: bool_t = False,
         index_label: IndexLabel | None = None,
         mode: str = "w",
         encoding: str | None = None,


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

# Objective
We find the extra index output annoying, and to remedy that.

# Changes
```python
...
def to_csv(
        self,
        path_or_buf: FilePath | WriteBuffer[bytes] | WriteBuffer[str] | None = None,
        sep: str = ",",
        na_rep: str = "",
        float_format: str | None = None,
        columns: Sequence[Hashable] | None = None,
        header: bool_t | list[str] = True,
#       index: bool_t = True,
        index: bool_t = False,  # My Suggestion
        index_label: IndexLabel | None = None,
        mode: str = "w",
        encoding: str | None = None,
        compression: CompressionOptions = "infer",
        quoting: int | None = None,
        quotechar: str = '"',
        lineterminator: str | None = None,
        chunksize: int | None = None,
        date_format: str | None = None,
        doublequote: bool_t = True,
        escapechar: str | None = None,
        decimal: str = ".",
        errors: str = "strict",
        storage_options: StorageOptions = None,
    ) -> str | None:
...
```