### PR TITLE
TYP: Many typing constructs are invariant

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -76,8 +76,8 @@ else:
 
 # Functions that take Dict/Mapping/List/Sequence/Callable as arguments can be
 # tricky to type:
-# - keys of Dict and Mapping cannot be sub-classes
-# - elements of List and Sequence cannot be sub-classes
+# - keys of Dict and Mapping cannot be sub-classes (Mapping allows them for values)
+# - elements of List cannot be sub-classes (Sequence does)
 # - input arguments of Callable cannot be sub-classes
 # If you want to allow any type and it's sub-classes in the above cases, you can
 # use TypeVar("AllowsSubclasses", bound=class); List[AllowsSubclasses]
@@ -114,7 +114,7 @@ Timezone = Union[str, tzinfo]
 NDFrameT = TypeVar("NDFrameT", bound="NDFrame")
 
 Axis = Union[str, int]
-IndexLabel = Union[Hashable, Sequence[HashableT]]
+IndexLabel = Union[Hashable, Sequence[Hashable]]
 Level = Union[Hashable, int]
 Shape = Tuple[int, ...]
 Suffixes = Tuple[Optional[str], Optional[str]]

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -74,6 +74,15 @@ else:
     npt: Any = None
 
 
+# Functions that take Dict/Mapping/List/Sequence/Callable as arguments can be
+# tricky to type:
+# - keys of Dict and Mapping cannot be sub-classes
+# - elements of List and Sequence cannot be sub-classes
+# - input arguments of Callable cannot be sub-classes
+# If you want to allow any type and it's sub-classes in the above cases, you can
+# use TypeVar("AllowsSubclasses", bound=class); List[AllowsSubclasses]
+HashableT = TypeVar("HashableT", bound=Hashable)
+
 # array-like
 
 ArrayLike = Union["ExtensionArray", np.ndarray]
@@ -105,7 +114,7 @@ Timezone = Union[str, tzinfo]
 NDFrameT = TypeVar("NDFrameT", bound="NDFrame")
 
 Axis = Union[str, int]
-IndexLabel = Union[Hashable, Sequence[Hashable]]
+IndexLabel = Union[Hashable, Sequence[HashableT]]
 Level = Union[Hashable, int]
 Shape = Tuple[int, ...]
 Suffixes = Tuple[Optional[str], Optional[str]]
@@ -127,19 +136,19 @@ NpDtype = Union[str, np.dtype, type_t[Union[str, float, int, complex, bool, obje
 Dtype = Union["ExtensionDtype", NpDtype]
 AstypeArg = Union["ExtensionDtype", "npt.DTypeLike"]
 # DtypeArg specifies all allowable dtypes in a functions its dtype argument
-DtypeArg = Union[Dtype, Dict[Hashable, Dtype]]
+DtypeArg = Union[Dtype, Dict[HashableT, Dtype]]
 DtypeObj = Union[np.dtype, "ExtensionDtype"]
 
 # converters
-ConvertersArg = Dict[Hashable, Callable[[Dtype], Dtype]]
+ConvertersArg = Dict[HashableT, Callable[[Dtype], Dtype]]
 
 # parse_dates
 ParseDatesArg = Union[
-    bool, List[Hashable], List[List[Hashable]], Dict[Hashable, List[Hashable]]
+    bool, List[HashableT], List[List[HashableT]], Dict[HashableT, List[Hashable]]
 ]
 
 # For functions like rename that convert one label to another
-Renamer = Union[Mapping[Hashable, Any], Callable[[Hashable], Hashable]]
+Renamer = Union[Mapping[HashableT, Any], Callable[[HashableT], Hashable]]
 
 # to maintain type information across generic functions and parametrization
 T = TypeVar("T")
@@ -156,7 +165,7 @@ IndexKeyFunc = Optional[Callable[["Index"], Union["Index", AnyArrayLike]]]
 
 # types of `func` kwarg for DataFrame.aggregate and Series.aggregate
 AggFuncTypeBase = Union[Callable, str]
-AggFuncTypeDict = Dict[Hashable, Union[AggFuncTypeBase, List[AggFuncTypeBase]]]
+AggFuncTypeDict = Dict[HashableT, Union[AggFuncTypeBase, List[AggFuncTypeBase]]]
 AggFuncType = Union[
     AggFuncTypeBase,
     List[AggFuncTypeBase],
@@ -260,10 +269,10 @@ CompressionOptions = Optional[
 FormattersType = Union[
     List[Callable], Tuple[Callable, ...], Mapping[Union[str, int], Callable]
 ]
-ColspaceType = Mapping[Hashable, Union[str, int]]
+ColspaceType = Mapping[HashableT, Union[str, int]]
 FloatFormatType = Union[str, Callable, "EngFormatter"]
 ColspaceArgType = Union[
-    str, int, Sequence[Union[str, int]], Mapping[Hashable, Union[str, int]]
+    str, int, Sequence[Union[str, int]], Mapping[HashableT, Union[str, int]]
 ]
 
 # Arguments for fillna()


### PR DESCRIPTION
Indexes and columns can be of any hashable type: we often have functions accepting a list/dict/callables of hashable types.

Unfortunately, List/Dict/Mapping/Callable are all invariant in their (first) argument, which leads to unintuitive behavior:

```py
from typing import Hashable

def test(x: list[Hashable]) -> None:
    ...

x1: list[str] = ["a"]  # str is Hashable
test(x1)  # but this still errors

x2: list[Hashable] = ["a"]
test(x2)  # works
```

One (honestly not well-promotet) use case of TypeVars is to allow sub-classes in these cases:

```py
from typing import Hashable, TypeVar

HashableT = TypeVar("HashableT", bound=Hashable)

def test(x: list[HashableT]) -> None:
    ...

x1: list[str] = ["a"]  # str is Hashable
test(x1)  # works :)

x2: list[Hashable] = ["a"]
test(x2)  # still works
```

If we had type tests, we would have noticed this earlier - Thanks to @Dr-Irv for finding this!

xref https://github.com/pandas-dev/pandas/pull/46428#discussion_r835795663

It might be worth preventing Hashable being the first argument to the above typing containers by enforcing that in pandas-dev-flaker