### PR TITLE
CI: xfail geopandas downstream test on Windows due to fiona install

### DIFF
--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -8,6 +8,7 @@ import sys
 import numpy as np
 import pytest
 
+from pandas.compat import is_platform_windows
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -225,6 +226,13 @@ def test_pandas_datareader():
 
 # importing from pandas, Cython import warning
 @pytest.mark.filterwarnings("ignore:can't resolve:ImportWarning")
+@pytest.mark.xfail(
+    is_platform_windows(),
+    raises=ImportError,
+    reason="ImportError: the 'read_file' function requires the 'fiona' package, "
+    "but it is not installed or does not import correctly",
+    strict=False,
+)
 def test_geopandas():
 
     geopandas = import_module("geopandas")


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Similar to https://github.com/pandas-dev/pandas/pull/46296 but now happening on Windows

```
    def _check_fiona(func):
        if fiona is None:
>           raise ImportError(
                f"the {func} requires the 'fiona' package, but it is not installed or does "
                f"not import correctly.\nImporting fiona resulted in: {fiona_import_error}"
            )
E           ImportError: the 'read_file' function requires the 'fiona' package, but it is not installed or does not import correctly.
E           Importing fiona resulted in: DLL load failed while importing ogrext: The specified procedure could not be found.
```

cc @jorisvandenbossche can this downstream test be changed to not go through fiona?

