### PR TITLE
BUG: pd.concat with identical key leads to multi-indexing error

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -536,7 +536,8 @@ Reshaping
 - Bug in :func:`get_dummies` that selected object and categorical dtypes but not string (:issue:`44965`)
 - Bug in :meth:`DataFrame.align` when aligning a :class:`MultiIndex` to a :class:`Series` with another :class:`MultiIndex` (:issue:`46001`)
 - Bug in concanenation with ``IntegerDtype``, or ``FloatingDtype`` arrays where the resulting dtype did not mirror the behavior of the non-nullable dtypes (:issue:`46379`)
-- Bug in concanenation with identical key leads to error when indexing :class:`MultiIndex` (:issue:`46519`)
+- Bug in :func:`concat` with identical key leads to error when indexing :class:`MultiIndex` (:issue:`46519`)
+-
 
 Sparse
 ^^^^^^

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -536,7 +536,7 @@ Reshaping
 - Bug in :func:`get_dummies` that selected object and categorical dtypes but not string (:issue:`44965`)
 - Bug in :meth:`DataFrame.align` when aligning a :class:`MultiIndex` to a :class:`Series` with another :class:`MultiIndex` (:issue:`46001`)
 - Bug in concanenation with ``IntegerDtype``, or ``FloatingDtype`` arrays where the resulting dtype did not mirror the behavior of the non-nullable dtypes (:issue:`46379`)
--
+- Bug in concanenation with identical key leads to error when indexing :class:`MultiIndex` (:issue:`46519`)
 
 Sparse
 ^^^^^^

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -709,6 +709,10 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None) -> MultiInde
         else:
             levels = [ensure_index(x) for x in levels]
 
+    for level in levels:
+        if not level.is_unique:
+            raise ValueError(f"Level values not unique: {level.tolist()}")
+            
     if not all_indexes_same(indexes) or not all(level.is_unique for level in levels):
         codes_list = []
 

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -709,10 +709,6 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None) -> MultiInde
         else:
             levels = [ensure_index(x) for x in levels]
 
-    for level in levels:
-        if not level.is_unique:
-            raise ValueError(f"Level values not unique: {level.tolist()}")
-            
     if not all_indexes_same(indexes) or not all(level.is_unique for level in levels):
         codes_list = []
 

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -705,7 +705,7 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None) -> MultiInde
             names = [None]
 
         if levels is None:
-            levels = [ensure_index(keys)]
+            levels = [ensure_index(keys).unique()]
         else:
             levels = [ensure_index(x) for x in levels]
 

--- a/pandas/tests/reshape/concat/test_index.py
+++ b/pandas/tests/reshape/concat/test_index.py
@@ -9,6 +9,7 @@ from pandas import (
     Series,
     concat,
 )
+from pandas.errors import PerformanceWarning
 import pandas._testing as tm
 
 

--- a/pandas/tests/reshape/concat/test_index.py
+++ b/pandas/tests/reshape/concat/test_index.py
@@ -334,8 +334,7 @@ class TestMultiIndexConcat:
         df_a = concat([df1, df2, df3], keys=["x", "y", "x"])
         # the warning is caused by indexing unsorted multi-index
         with tm.assert_produces_warning(
-            PerformanceWarning,
-            match="indexing past lexsort depth"
+            PerformanceWarning, match="indexing past lexsort depth"
         ):
             out_a = df_a.loc[("x", 0), :]
 
@@ -343,8 +342,7 @@ class TestMultiIndexConcat:
             {"name": [1, 2, 3]}, index=Index([("x", 0), ("y", 0), ("x", 0)])
         )
         with tm.assert_produces_warning(
-            PerformanceWarning,
-            match="indexing past lexsort depth"
+            PerformanceWarning, match="indexing past lexsort depth"
         ):
             out_b = df_b.loc[("x", 0)]
 
@@ -355,8 +353,7 @@ class TestMultiIndexConcat:
         df3 = DataFrame({"name": ["c", "d"]})
         df_a = concat([df1, df2, df3], keys=["x", "y", "x"])
         with tm.assert_produces_warning(
-            PerformanceWarning,
-            match="indexing past lexsort depth"
+            PerformanceWarning, match="indexing past lexsort depth"
         ):
             out_a = df_a.loc[("x", 0), :]
 
@@ -369,8 +366,7 @@ class TestMultiIndexConcat:
         ).set_index(["a", "b"])
         df_b.index.names = [None, None]
         with tm.assert_produces_warning(
-            PerformanceWarning,
-            match="indexing past lexsort depth"
+            PerformanceWarning, match="indexing past lexsort depth"
         ):
             out_b = df_b.loc[("x", 0), :]
 

--- a/pandas/tests/reshape/concat/test_index.py
+++ b/pandas/tests/reshape/concat/test_index.py
@@ -329,21 +329,21 @@ class TestMultiIndexConcat:
         [["x", "y", "x"]],
     )
     def test_concat_with_key_not_unique(
-        self, keys: list,
+        self,
+        keys: list,
     ):
         # GitHub #46519
-        df1 = DataFrame({'name': [1]})
-        df2 = DataFrame({'name': [2]})
+        df1 = DataFrame({"name": [1]})
+        df2 = DataFrame({"name": [2]})
         df3 = DataFrame({"name": [3]})
-        df_a = pd.concat([df1, df2, df3], keys=keys)
-        out_a = df_a.loc[("x", 0), :]
+        df_a = concat([df1, df2, df3], keys=keys)
+        with tm.assert_produces_warning(PerformanceWarning):
+            out_a = df_a.loc[("x", 0), :]
 
-        df_b = pd.DataFrame(
-            {
-                "name": [1, 2, 3]
-            },
-            index=Index([("x", 0), ("y", 0), ("x", 0)])
+        df_b = DataFrame(
+            {"name": [1, 2, 3]}, index=Index([("x", 0), ("y", 0), ("x", 0)])
         )
-        out_b = df_b.loc[("x", 0)]
+        with tm.assert_produces_warning(PerformanceWarning):
+            out_b = df_b.loc[("x", 0)]
 
         tm.assert_frame_equal(out_a, out_b)

--- a/pandas/tests/reshape/concat/test_index.py
+++ b/pandas/tests/reshape/concat/test_index.py
@@ -323,3 +323,27 @@ class TestMultiIndexConcat:
             {"col": ["a", "b", "c"]}, index=MultiIndex.from_product(iterables)
         )
         tm.assert_frame_equal(result_df, expected_df)
+
+    @pytest.mark.parametrize(
+        "keys",
+        [["x", "y", "x"]],
+    )
+    def test_concat_with_key_not_unique(
+        self, keys: list,
+    ):
+        # GitHub #46519
+        df1 = DataFrame({'name': [1]})
+        df2 = DataFrame({'name': [2]})
+        df3 = DataFrame({"name": [3]})
+        df_a = pd.concat([df1, df2, df3], keys=keys)
+        out_a = df_a.loc[("x", 0), :]
+
+        df_b = pd.DataFrame(
+            {
+                "name": [1, 2, 3]
+            },
+            index=Index([("x", 0), ("y", 0), ("x", 0)])
+        )
+        out_b = df_b.loc[("x", 0)]
+
+        tm.assert_frame_equal(out_a, out_b)

--- a/pandas/tests/reshape/concat/test_index.py
+++ b/pandas/tests/reshape/concat/test_index.py
@@ -348,3 +348,23 @@ class TestMultiIndexConcat:
             out_b = df_b.loc[("x", 0)]
 
         tm.assert_frame_equal(out_a, out_b)
+
+        df1 = DataFrame({"name": ["a", "a", "b"]})
+        df2 = DataFrame({"name": ["a", "b"]})
+        df3 = DataFrame({"name": ["c", "d"]})
+        df_a = concat([df1, df2, df3], keys=keys)
+        with tm.assert_produces_warning(PerformanceWarning):
+            out_a = df_a.loc[("x", 0), :]
+
+        df_b = DataFrame(
+            {
+                "a": ["x", "x", "x", "y", "y", "x", "x"],
+                "b": [0, 1, 2, 0, 1, 0, 1],
+                "name": list("aababcd"),
+            }
+        ).set_index(["a", "b"])
+        df_b.index.names = [None, None]
+        with tm.assert_produces_warning(PerformanceWarning):
+            out_b = df_b.loc[("x", 0), :]
+
+        tm.assert_frame_equal(out_a, out_b)

--- a/pandas/tests/reshape/concat/test_index.py
+++ b/pandas/tests/reshape/concat/test_index.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from pandas.errors import PerformanceWarning
+
 import pandas as pd
 from pandas import (
     DataFrame,
@@ -9,7 +11,6 @@ from pandas import (
     Series,
     concat,
 )
-from pandas.errors import PerformanceWarning
 import pandas._testing as tm
 
 

--- a/pandas/tests/reshape/concat/test_index.py
+++ b/pandas/tests/reshape/concat/test_index.py
@@ -326,10 +326,6 @@ class TestMultiIndexConcat:
         )
         tm.assert_frame_equal(result_df, expected_df)
 
-    @pytest.mark.parametrize(
-        "keys",
-        [["x", "y", "x"]],
-    )
     def test_concat_with_key_not_unique(
         self,
         keys: list,
@@ -338,7 +334,7 @@ class TestMultiIndexConcat:
         df1 = DataFrame({"name": [1]})
         df2 = DataFrame({"name": [2]})
         df3 = DataFrame({"name": [3]})
-        df_a = concat([df1, df2, df3], keys=keys)
+        df_a = concat([df1, df2, df3], keys=[["x", "y", "x"]])
         with tm.assert_produces_warning(PerformanceWarning):
             out_a = df_a.loc[("x", 0), :]
 
@@ -353,7 +349,7 @@ class TestMultiIndexConcat:
         df1 = DataFrame({"name": ["a", "a", "b"]})
         df2 = DataFrame({"name": ["a", "b"]})
         df3 = DataFrame({"name": ["c", "d"]})
-        df_a = concat([df1, df2, df3], keys=keys)
+        df_a = concat([df1, df2, df3], keys=[["x", "y", "x"]])
         with tm.assert_produces_warning(PerformanceWarning):
             out_a = df_a.loc[("x", 0), :]
 

--- a/pandas/tests/reshape/concat/test_index.py
+++ b/pandas/tests/reshape/concat/test_index.py
@@ -331,7 +331,7 @@ class TestMultiIndexConcat:
         df1 = DataFrame({"name": [1]})
         df2 = DataFrame({"name": [2]})
         df3 = DataFrame({"name": [3]})
-        df_a = concat([df1, df2, df3], keys=[["x", "y", "x"]])
+        df_a = concat([df1, df2, df3], keys=["x", "y", "x"])
         with tm.assert_produces_warning(PerformanceWarning):
             out_a = df_a.loc[("x", 0), :]
 
@@ -346,7 +346,7 @@ class TestMultiIndexConcat:
         df1 = DataFrame({"name": ["a", "a", "b"]})
         df2 = DataFrame({"name": ["a", "b"]})
         df3 = DataFrame({"name": ["c", "d"]})
-        df_a = concat([df1, df2, df3], keys=[["x", "y", "x"]])
+        df_a = concat([df1, df2, df3], keys=["x", "y", "x"])
         with tm.assert_produces_warning(PerformanceWarning):
             out_a = df_a.loc[("x", 0), :]
 

--- a/pandas/tests/reshape/concat/test_index.py
+++ b/pandas/tests/reshape/concat/test_index.py
@@ -332,13 +332,20 @@ class TestMultiIndexConcat:
         df2 = DataFrame({"name": [2]})
         df3 = DataFrame({"name": [3]})
         df_a = concat([df1, df2, df3], keys=["x", "y", "x"])
-        with tm.assert_produces_warning(PerformanceWarning):
+        # the warning is caused by indexing unsorted multi-index
+        with tm.assert_produces_warning(
+            PerformanceWarning,
+            match="indexing past lexsort depth"
+        ):
             out_a = df_a.loc[("x", 0), :]
 
         df_b = DataFrame(
             {"name": [1, 2, 3]}, index=Index([("x", 0), ("y", 0), ("x", 0)])
         )
-        with tm.assert_produces_warning(PerformanceWarning):
+        with tm.assert_produces_warning(
+            PerformanceWarning,
+            match="indexing past lexsort depth"
+        ):
             out_b = df_b.loc[("x", 0)]
 
         tm.assert_frame_equal(out_a, out_b)
@@ -347,7 +354,10 @@ class TestMultiIndexConcat:
         df2 = DataFrame({"name": ["a", "b"]})
         df3 = DataFrame({"name": ["c", "d"]})
         df_a = concat([df1, df2, df3], keys=["x", "y", "x"])
-        with tm.assert_produces_warning(PerformanceWarning):
+        with tm.assert_produces_warning(
+            PerformanceWarning,
+            match="indexing past lexsort depth"
+        ):
             out_a = df_a.loc[("x", 0), :]
 
         df_b = DataFrame(
@@ -358,7 +368,10 @@ class TestMultiIndexConcat:
             }
         ).set_index(["a", "b"])
         df_b.index.names = [None, None]
-        with tm.assert_produces_warning(PerformanceWarning):
+        with tm.assert_produces_warning(
+            PerformanceWarning,
+            match="indexing past lexsort depth"
+        ):
             out_b = df_b.loc[("x", 0), :]
 
         tm.assert_frame_equal(out_a, out_b)

--- a/pandas/tests/reshape/concat/test_index.py
+++ b/pandas/tests/reshape/concat/test_index.py
@@ -326,10 +326,7 @@ class TestMultiIndexConcat:
         )
         tm.assert_frame_equal(result_df, expected_df)
 
-    def test_concat_with_key_not_unique(
-        self,
-        keys: list,
-    ):
+    def test_concat_with_key_not_unique(self):
         # GitHub #46519
         df1 = DataFrame({"name": [1]})
         df2 = DataFrame({"name": [2]})


### PR DESCRIPTION
- [x] closes #46519 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
