### PR TITLE
CI: Simplify call to asv

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -141,6 +141,7 @@ jobs:
       run: |
         cd asv_bench
         # TODO add `--durations` when we start using asv >= 0.5 (#46598)
+        asv machine --yes
         asv run --quick --dry-run --python=same | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
         if grep "failed" benchmarks.log > /dev/null ; then
             exit 1

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -140,8 +140,8 @@ jobs:
     - name: Run ASV benchmarks
       run: |
         cd asv_bench
-        # TODO add `--durations` when we start using asv >= 0.5 (#46598)
         asv machine --yes
+        # TODO add `--durations` when we start using asv >= 0.5 (#46598)
         asv run --quick --dry-run --python=same | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
         if grep "failed" benchmarks.log > /dev/null ; then
             exit 1

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -140,22 +140,11 @@ jobs:
     - name: Run ASV benchmarks
       run: |
         cd asv_bench
-        asv check -E existing
-        git remote add upstream https://github.com/pandas-dev/pandas.git
-        git fetch upstream
-        asv machine --yes
-        asv dev | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
+        # TODO add `--durations` when we start using asv >= 0.5 (#46598)
+        asv run --quick --dry-run --python=same | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
         if grep "failed" benchmarks.log > /dev/null ; then
             exit 1
         fi
-      if: ${{ steps.build.outcome == 'success' }}
-
-    - name: Publish benchmarks artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: Benchmarks log
-        path: asv_bench/benchmarks.log
-      if: failure()
 
   build_docker_dev_environment:
     name: Build Docker Dev Environment

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - pytz
 
   # benchmarks
-  - asv < 0.5.0  # 2022-02-08: v0.5.0 > leads to ASV checks running > 3 hours on CI
+  - asv
 
   # building
   # The compiler packages are meta-packages and install the correct compiler (activation) packages on the respective platforms.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 numpy>=1.18.5
 python-dateutil>=2.8.1
 pytz
-asv < 0.5.0
+asv
 cython>=0.29.24
 black==22.3.0
 cpplint


### PR DESCRIPTION
The way we are calling `asv` in the CI is too complex for no reason. Removing the next unnecessary things:

- `asv check` not worth calling, since just imports the benchmarks which will be later imported anyway when calling `asv run`
- Adding the `remote` to git doesn't have any effect I think, since we don't specify the commit, and we should be running benchmarks for what's been checked out
- `asv machine` is not useful, since we won't save the results, or compare them with other runs
- `asv dev` just avoids creating environments, but we can speed up things a bit by just running each benchmark once, and not save the results, which are not used anyway
- The conditional to just run the benchmarks if the previous step build is successful, is the default. It makes sense in other parts of this file, since there are several steps depending on a build, but not in this case
- I don't think publishing the asv log makes a lot of sense. I think I added that myself in the past, but now feels just a waste of time and resources (unless someone used that artifact, then please let me know)

I'm going to see how to remove the hacky grep and just leave the asv call, but I think this needs a new asv release.