### PR TITLE
CI/TST: Make test_vector_resize more deterministic

### DIFF
--- a/pandas/tests/libs/test_hashtable.py
+++ b/pandas/tests/libs/test_hashtable.py
@@ -246,16 +246,7 @@ class TestHashTableUnsorted:
             (ht.Float64HashTable, ht.Float64Vector, "float64", False),
             (ht.Int64HashTable, ht.Int64Vector, "int64", False),
             (ht.Int32HashTable, ht.Int32Vector, "int32", False),
-            pytest.param(
-                ht.UInt64HashTable,
-                ht.UInt64Vector,
-                "uint64",
-                False,
-                marks=pytest.mark.xfail(
-                    reason="Sometimes doesn't raise.",
-                    strict=False,
-                ),
-            ),
+            (ht.UInt64HashTable, ht.UInt64Vector, "uint64", False),
         ],
     )
     def test_vector_resize(
@@ -263,7 +254,9 @@ class TestHashTableUnsorted:
     ):
         # Test for memory errors after internal vector
         # reallocations (GH 7157)
-        vals = np.array(np.random.randn(1000), dtype=dtype)
+        # Changed from using np.random.rand to range
+        # which could cause flaky CI failures when safely_resizes=False
+        vals = np.array(range(1000), dtype=dtype)
 
         # GH 21688 ensures we can deal with read-only memory views
         vals.setflags(write=writable)


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

I had to `xfail(strict=True)` this test once before which leads me to believe that the initial random data may be causing this test to be flaky.

https://dev.azure.com/pandas-dev/pandas/_build/results?buildId=76111&view=logs&jobId=b1891a80-bdb0-5193-5f59-ce68a0874df0&j=b1891a80-bdb0-5193-5f59-ce68a0874df0&t=0a58a9e9-0673-539c-5bde-d78a5a3b655e

```
=================================== FAILURES ===================================
_ TestHashTableUnsorted.test_vector_resize[False-Int32HashTable-Int32Vector-int32-False-10] _
[gw1] darwin -- Python 3.9.12 /usr/local/miniconda/envs/pandas-dev/bin/python

self = <pandas.tests.libs.test_hashtable.TestHashTableUnsorted object at 0x161a3d7c0>
writable = False
htable = <pandas._libs.hashtable.Int32HashTable object at 0x1764fee30>
uniques = <pandas._libs.hashtable.Int32Vector object at 0x176528e00>
dtype = 'int32', safely_resizes = False, nvals = 10

    @pytest.mark.parametrize("nvals", [0, 10])  # resizing to 0 is special case
    @pytest.mark.parametrize(
        "htable, uniques, dtype, safely_resizes",
        [
            (ht.PyObjectHashTable, ht.ObjectVector, "object", False),
            (ht.StringHashTable, ht.ObjectVector, "object", True),
            (ht.Float64HashTable, ht.Float64Vector, "float64", False),
            (ht.Int64HashTable, ht.Int64Vector, "int64", False),
            (ht.Int32HashTable, ht.Int32Vector, "int32", False),
            pytest.param(
                ht.UInt64HashTable,
                ht.UInt64Vector,
                "uint64",
                False,
                marks=pytest.mark.xfail(
                    reason="Sometimes doesn't raise.",
        else:
            with pytest.raises(ValueError, match="external reference.*"):
>               htable.get_labels(vals, uniques, 0, -1)
E               Failed: DID NOT RAISE <class 'ValueError'>
```
