### PR TITLE
BUG: added finalize to explode, GH28283

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -616,6 +616,11 @@ Styler
 - Bug when attempting to apply styling functions to an empty DataFrame subset (:issue:`45313`)
 -
 
+Metadata
+^^^^^^^^
+- Fixed metadata propagation in :meth:`DataFrame.explode` (:issue:`28283`)
+-
+
 Other
 ^^^^^
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8629,7 +8629,7 @@ Parrot 2  Parrot       24.0
             result.index = self.index.take(result.index)
         result = result.reindex(columns=self.columns, copy=False)
 
-        return result
+        return result.__finalize__(self, method="explode")
 
     def unstack(self, level: Level = -1, fill_value=None):
         """

--- a/pandas/tests/generic/test_finalize.py
+++ b/pandas/tests/generic/test_finalize.py
@@ -154,10 +154,7 @@ _all_methods = [
         operator.methodcaller("pivot_table", columns="A", aggfunc=["mean", "sum"]),
     ),
     (pd.DataFrame, frame_data, operator.methodcaller("stack")),
-    pytest.param(
-        (pd.DataFrame, frame_data, operator.methodcaller("explode", "A")),
-        marks=not_implemented_mark,
-    ),
+    (pd.DataFrame, frame_data, operator.methodcaller("explode", "A")),
     (pd.DataFrame, frame_mi_data, operator.methodcaller("unstack")),
     pytest.param(
         (


### PR DESCRIPTION
**Progress towards #28283**

This PR gives the `explode` method the ability to propagate metadata using `__finalize__`.

- [ ] xref #28283 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit)
- [x] Added an entry in the latest `doc/source/whatsnew/v1.5.0.rst` file

Contributors: 

- [Solomon Song](https://github.com/songsol1)
- [Edward Huang](https://github.com/edwhuang23)
