### PR TITLE
CI: Remove grep from asv call (using strict parameter instead)

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -141,11 +141,7 @@ jobs:
       run: |
         cd asv_bench
         asv machine --yes
-        # TODO add `--durations` when we start using asv >= 0.5 (#46598)
-        asv run --quick --dry-run --python=same | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
-        if grep "failed" benchmarks.log > /dev/null ; then
-            exit 1
-        fi
+        asv run --quick --dry-run --strict --durations --python=same
 
   build_docker_dev_environment:
     name: Build Docker Dev Environment

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -141,7 +141,7 @@ jobs:
       run: |
         cd asv_bench
         asv machine --yes
-        asv run --quick --dry-run --strict --durations --python=same
+        asv run --quick --dry-run --strict --durations=30 --python=same
 
   build_docker_dev_environment:
     name: Build Docker Dev Environment

--- a/asv_bench/benchmarks/fail.py
+++ b/asv_bench/benchmarks/fail.py
@@ -1,0 +1,3 @@
+class FailBenchmarks:
+    def time_cause_asv_to_exit_with_non_zero_code(self):
+        raise ValueError('If the CI build is red, things work as expected')

--- a/asv_bench/benchmarks/fail.py
+++ b/asv_bench/benchmarks/fail.py
@@ -1,3 +1,0 @@
-class FailBenchmarks:
-    def time_cause_asv_to_exit_with_non_zero_code(self):
-        raise ValueError('If the CI build is red, things work as expected')


### PR DESCRIPTION
Looks like asv didn't fail the CI, because if requires a `--strict` parameter to do so. Adding it here. And will change this behavior in asv: https://github.com/airspeed-velocity/asv/issues/1199

Adding a failing benchmark to make sure this works as expected. Will remove if CI is red because of it.