### PR TITLE
BUG/TST/DOC: added finalize to melt, GH28283

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -618,6 +618,11 @@ Styler
 - Bug when attempting to apply styling functions to an empty DataFrame subset (:issue:`45313`)
 -
 
+Metadata
+^^^^^^^^
+- Fixed metadata propagation in :meth:`DataFrame.melt` (:issue:`28283`)
+-
+
 Other
 ^^^^^
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8717,7 +8717,7 @@ Parrot 2  Parrot       24.0
             value_name=value_name,
             col_level=col_level,
             ignore_index=ignore_index,
-        )
+        ).__finalize__(self, method="melt")
 
     # ----------------------------------------------------------------------
     # Time series-related

--- a/pandas/tests/generic/test_finalize.py
+++ b/pandas/tests/generic/test_finalize.py
@@ -159,13 +159,10 @@ _all_methods = [
         marks=not_implemented_mark,
     ),
     (pd.DataFrame, frame_mi_data, operator.methodcaller("unstack")),
-    pytest.param(
-        (
-            pd.DataFrame,
-            ({"A": ["a", "b", "c"], "B": [1, 3, 5], "C": [2, 4, 6]},),
-            operator.methodcaller("melt", id_vars=["A"], value_vars=["B"]),
-        ),
-        marks=not_implemented_mark,
+    (
+        pd.DataFrame,
+        ({"A": ["a", "b", "c"], "B": [1, 3, 5], "C": [2, 4, 6]},),
+        operator.methodcaller("melt", id_vars=["A"], value_vars=["B"]),
     ),
     pytest.param(
         (pd.DataFrame, frame_data, operator.methodcaller("applymap", lambda x: x))


### PR DESCRIPTION
Progress towards #28283

This PR gives the `melt` method the ability to propagate metadata using `__finalize__`.

- [ ] xref #28283
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests)
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v1.5.0.rst` file

Contributors:
- [Edward Huang](https://github.com/edwhuang23)
- [Solomon Song](https://github.com/songsol1)