### PR TITLE
DOC: clarified read_csv example

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -432,7 +432,7 @@ read_fwf : Read a table of fixed-width formatted lines into DataFrame.
 
 Examples
 --------
->>> pd.{func_name}('data.csv')  # doctest: +SKIP
+>>> df = pd.{func_name}('data.csv')  # doctest: +SKIP
 """
 )
 


### PR DESCRIPTION
* Simple clarification to the read_csv/read_fwf docs so that the example actually loads data into a dataframe.
