### PR TITLE
CI/DOC: pin pydata-sphinx-theme to 0.8.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
   - gitdb
   - numpydoc
   - pandas-dev-flaker=0.5.0
-  - pydata-sphinx-theme
+  - pydata-sphinx-theme=0.8.0
   - pytest-cython
   - sphinx
   - sphinx-panels

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,7 +20,7 @@ gitpython
 gitdb
 numpydoc
 pandas-dev-flaker==0.5.0
-pydata-sphinx-theme
+pydata-sphinx-theme==0.8.0
 pytest-cython
 sphinx
 sphinx-panels


### PR DESCRIPTION
Temporary fix for https://github.com/pandas-dev/pandas/issues/46615