### PR TITLE
Allow using datetime64[ns, UTC] in IntervalDtype

### DIFF
--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -1054,7 +1054,7 @@ class IntervalDtype(PandasExtensionDtype):
         "closed",
     )
     _match = re.compile(
-        r"(I|i)nterval\[(?P<subtype>[^,]+)(, (?P<closed>(right|left|both|neither)))?\]"
+        r"(I|i)nterval\[(?P<subtype>[^,]+(\[.+\])?)(, (?P<closed>(right|left|both|neither)))?\]"
     )
     _cache_dtypes: dict[str_type, PandasExtensionDtype] = {}
 

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -1054,7 +1054,8 @@ class IntervalDtype(PandasExtensionDtype):
         "closed",
     )
     _match = re.compile(
-        r"(I|i)nterval\[(?P<subtype>[^,]+(\[.+\])?)(, (?P<closed>(right|left|both|neither)))?\]"
+        r"(I|i)nterval\[(?P<subtype>[^,]+(\[.+\])?)"
+        r"(, (?P<closed>(right|left|both|neither)))?\]"
     )
     _cache_dtypes: dict[str_type, PandasExtensionDtype] = {}
 


### PR DESCRIPTION
The current regexp doesn't allow the use of comma in the interval `subtype`, which means this statement fails
```
pd.IntervalIndex.from_arrays([1, 2], [2, 3], dtype='interval[datetime64[ns, UTC], right]')
```
with `TypeError: data type 'interval[datetime64[ns, UTC], right]' not understood`

The proposed change allows the use of comma inside square brackets in the `subtype`.
