### PR TITLE
Fix a few test failures on big-endian systems

### DIFF
--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -8,6 +8,7 @@ import operator
 import os
 import re
 import string
+from sys import byteorder
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -167,6 +168,8 @@ NARROW_NP_DTYPES = [
     np.uint16,
     np.uint32,
 ]
+
+ENDIAN = {"little": "<", "big": ">"}[byteorder]
 
 NULL_OBJECTS = [None, np.nan, pd.NaT, float("nan"), pd.NA, Decimal("NaN")]
 NP_NAT_OBJECTS = [

--- a/pandas/tests/arrays/boolean/test_astype.py
+++ b/pandas/tests/arrays/boolean/test_astype.py
@@ -1,5 +1,3 @@
-from sys import byteorder
-
 import numpy as np
 import pytest
 
@@ -22,8 +20,7 @@ def test_astype():
     tm.assert_numpy_array_equal(result, expected)
 
     result = arr.astype("str")
-    endian = {"little": "<", "big": ">"}[byteorder]
-    expected = np.array(["True", "False", "<NA>"], dtype=f"{endian}U5")
+    expected = np.array(["True", "False", "<NA>"], dtype=f"{tm.ENDIAN}U5")
     tm.assert_numpy_array_equal(result, expected)
 
     # no missing values

--- a/pandas/tests/arrays/boolean/test_astype.py
+++ b/pandas/tests/arrays/boolean/test_astype.py
@@ -1,3 +1,5 @@
+from sys import byteorder
+
 import numpy as np
 import pytest
 
@@ -20,7 +22,8 @@ def test_astype():
     tm.assert_numpy_array_equal(result, expected)
 
     result = arr.astype("str")
-    expected = np.array(["True", "False", "<NA>"], dtype="<U5")
+    endian = {"little": "<", "big": ">"}[byteorder]
+    expected = np.array(["True", "False", "<NA>"], dtype=f"{endian}U5")
     tm.assert_numpy_array_equal(result, expected)
 
     # no missing values

--- a/pandas/tests/arrays/boolean/test_construction.py
+++ b/pandas/tests/arrays/boolean/test_construction.py
@@ -1,3 +1,5 @@
+from sys import byteorder
+
 import numpy as np
 import pytest
 
@@ -273,7 +275,8 @@ def test_to_numpy(box):
 
     arr = con([True, False, None], dtype="boolean")
     result = arr.to_numpy(dtype="str")
-    expected = np.array([True, False, pd.NA], dtype="<U5")
+    endian = {"little": "<", "big": ">"}[byteorder]
+    expected = np.array([True, False, pd.NA], dtype=f"{endian}U5")
     tm.assert_numpy_array_equal(result, expected)
 
     # no missing values -> can convert to bool, otherwise raises

--- a/pandas/tests/arrays/boolean/test_construction.py
+++ b/pandas/tests/arrays/boolean/test_construction.py
@@ -1,5 +1,3 @@
-from sys import byteorder
-
 import numpy as np
 import pytest
 
@@ -275,8 +273,7 @@ def test_to_numpy(box):
 
     arr = con([True, False, None], dtype="boolean")
     result = arr.to_numpy(dtype="str")
-    endian = {"little": "<", "big": ">"}[byteorder]
-    expected = np.array([True, False, pd.NA], dtype=f"{endian}U5")
+    expected = np.array([True, False, pd.NA], dtype=f"{tm.ENDIAN}U5")
     tm.assert_numpy_array_equal(result, expected)
 
     # no missing values -> can convert to bool, otherwise raises

--- a/pandas/tests/arrays/floating/test_to_numpy.py
+++ b/pandas/tests/arrays/floating/test_to_numpy.py
@@ -1,3 +1,5 @@
+from sys import byteorder
+
 import numpy as np
 import pytest
 
@@ -115,7 +117,8 @@ def test_to_numpy_string(box, dtype):
     arr = con([0.0, 1.0, None], dtype="Float64")
 
     result = arr.to_numpy(dtype="str")
-    expected = np.array([0.0, 1.0, pd.NA], dtype="<U32")
+    endian = {"little": "<", "big": ">"}[byteorder]
+    expected = np.array([0.0, 1.0, pd.NA], dtype=f"{endian}U32")
     tm.assert_numpy_array_equal(result, expected)
 
 

--- a/pandas/tests/arrays/floating/test_to_numpy.py
+++ b/pandas/tests/arrays/floating/test_to_numpy.py
@@ -1,5 +1,3 @@
-from sys import byteorder
-
 import numpy as np
 import pytest
 
@@ -117,8 +115,7 @@ def test_to_numpy_string(box, dtype):
     arr = con([0.0, 1.0, None], dtype="Float64")
 
     result = arr.to_numpy(dtype="str")
-    endian = {"little": "<", "big": ">"}[byteorder]
-    expected = np.array([0.0, 1.0, pd.NA], dtype=f"{endian}U32")
+    expected = np.array([0.0, 1.0, pd.NA], dtype=f"{tm.ENDIAN}U32")
     tm.assert_numpy_array_equal(result, expected)
 
 

--- a/pandas/tests/arrays/integer/test_dtypes.py
+++ b/pandas/tests/arrays/integer/test_dtypes.py
@@ -1,5 +1,3 @@
-from sys import byteorder
-
 import numpy as np
 import pytest
 
@@ -285,8 +283,7 @@ def test_to_numpy_na_raises(dtype):
 
 def test_astype_str():
     a = pd.array([1, 2, None], dtype="Int64")
-    endian = {"little": "<", "big": ">"}[byteorder]
-    expected = np.array(["1", "2", "<NA>"], dtype=f"{endian}U21")
+    expected = np.array(["1", "2", "<NA>"], dtype=f"{tm.ENDIAN}U21")
 
     tm.assert_numpy_array_equal(a.astype(str), expected)
     tm.assert_numpy_array_equal(a.astype("str"), expected)

--- a/pandas/tests/arrays/integer/test_dtypes.py
+++ b/pandas/tests/arrays/integer/test_dtypes.py
@@ -1,3 +1,5 @@
+from sys import byteorder
+
 import numpy as np
 import pytest
 
@@ -283,7 +285,8 @@ def test_to_numpy_na_raises(dtype):
 
 def test_astype_str():
     a = pd.array([1, 2, None], dtype="Int64")
-    expected = np.array(["1", "2", "<NA>"], dtype="<U21")
+    endian = {"little": "<", "big": ">"}[byteorder]
+    expected = np.array(["1", "2", "<NA>"], dtype=f"{endian}U21")
 
     tm.assert_numpy_array_equal(a.astype(str), expected)
     tm.assert_numpy_array_equal(a.astype("str"), expected)

--- a/pandas/tests/frame/methods/test_to_records.py
+++ b/pandas/tests/frame/methods/test_to_records.py
@@ -1,4 +1,5 @@
 from collections import abc
+from sys import byteorder
 
 import numpy as np
 import pytest
@@ -12,6 +13,9 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
+
+
+endian = {"little": "<", "big": ">"}[byteorder]
 
 
 class TestDataFrameToRecords:
@@ -151,7 +155,12 @@ class TestDataFrameToRecords:
                 {},
                 np.rec.array(
                     [(0, 1, 0.2, "a"), (1, 2, 1.5, "bc")],
-                    dtype=[("index", "<i8"), ("A", "<i8"), ("B", "<f8"), ("C", "O")],
+                    dtype=[
+                        ("index", f"{endian}i8"),
+                        ("A", f"{endian}i8"),
+                        ("B", f"{endian}f8"),
+                        ("C", "O"),
+                    ],
                 ),
             ),
             # Should have no effect in this case.
@@ -159,23 +168,38 @@ class TestDataFrameToRecords:
                 {"index": True},
                 np.rec.array(
                     [(0, 1, 0.2, "a"), (1, 2, 1.5, "bc")],
-                    dtype=[("index", "<i8"), ("A", "<i8"), ("B", "<f8"), ("C", "O")],
+                    dtype=[
+                        ("index", f"{endian}i8"),
+                        ("A", f"{endian}i8"),
+                        ("B", f"{endian}f8"),
+                        ("C", "O"),
+                    ],
                 ),
             ),
             # Column dtype applied across the board. Index unaffected.
             (
-                {"column_dtypes": "<U4"},
+                {"column_dtypes": f"{endian}U4"},
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
-                    dtype=[("index", "<i8"), ("A", "<U4"), ("B", "<U4"), ("C", "<U4")],
+                    dtype=[
+                        ("index", f"{endian}i8"),
+                        ("A", f"{endian}U4"),
+                        ("B", f"{endian}U4"),
+                        ("C", f"{endian}U4"),
+                    ],
                 ),
             ),
             # Index dtype applied across the board. Columns unaffected.
             (
-                {"index_dtypes": "<U1"},
+                {"index_dtypes": f"{endian}U1"},
                 np.rec.array(
                     [("0", 1, 0.2, "a"), ("1", 2, 1.5, "bc")],
-                    dtype=[("index", "<U1"), ("A", "<i8"), ("B", "<f8"), ("C", "O")],
+                    dtype=[
+                        ("index", f"{endian}U1"),
+                        ("A", f"{endian}i8"),
+                        ("B", f"{endian}f8"),
+                        ("C", "O"),
+                    ],
                 ),
             ),
             # Pass in a type instance.
@@ -183,7 +207,12 @@ class TestDataFrameToRecords:
                 {"column_dtypes": str},
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
-                    dtype=[("index", "<i8"), ("A", "<U"), ("B", "<U"), ("C", "<U")],
+                    dtype=[
+                        ("index", f"{endian}i8"),
+                        ("A", f"{endian}U"),
+                        ("B", f"{endian}U"),
+                        ("C", f"{endian}U"),
+                    ],
                 ),
             ),
             # Pass in a dtype instance.
@@ -191,15 +220,25 @@ class TestDataFrameToRecords:
                 {"column_dtypes": np.dtype("unicode")},
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
-                    dtype=[("index", "<i8"), ("A", "<U"), ("B", "<U"), ("C", "<U")],
+                    dtype=[
+                        ("index", f"{endian}i8"),
+                        ("A", f"{endian}U"),
+                        ("B", f"{endian}U"),
+                        ("C", f"{endian}U"),
+                    ],
                 ),
             ),
             # Pass in a dictionary (name-only).
             (
-                {"column_dtypes": {"A": np.int8, "B": np.float32, "C": "<U2"}},
+                {"column_dtypes": {"A": np.int8, "B": np.float32, "C": f"{endian}U2"}},
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
-                    dtype=[("index", "<i8"), ("A", "i1"), ("B", "<f4"), ("C", "<U2")],
+                    dtype=[
+                        ("index", f"{endian}i8"),
+                        ("A", "i1"),
+                        ("B", f"{endian}f4"),
+                        ("C", f"{endian}U2"),
+                    ],
                 ),
             ),
             # Pass in a dictionary (indices-only).
@@ -207,15 +246,20 @@ class TestDataFrameToRecords:
                 {"index_dtypes": {0: "int16"}},
                 np.rec.array(
                     [(0, 1, 0.2, "a"), (1, 2, 1.5, "bc")],
-                    dtype=[("index", "i2"), ("A", "<i8"), ("B", "<f8"), ("C", "O")],
+                    dtype=[
+                        ("index", "i2"),
+                        ("A", f"{endian}i8"),
+                        ("B", f"{endian}f8"),
+                        ("C", "O"),
+                    ],
                 ),
             ),
             # Ignore index mappings if index is not True.
             (
-                {"index": False, "index_dtypes": "<U2"},
+                {"index": False, "index_dtypes": f"{endian}U2"},
                 np.rec.array(
                     [(1, 0.2, "a"), (2, 1.5, "bc")],
-                    dtype=[("A", "<i8"), ("B", "<f8"), ("C", "O")],
+                    dtype=[("A", f"{endian}i8"), ("B", f"{endian}f8"), ("C", "O")],
                 ),
             ),
             # Non-existent names / indices in mapping should not error.
@@ -223,7 +267,12 @@ class TestDataFrameToRecords:
                 {"index_dtypes": {0: "int16", "not-there": "float32"}},
                 np.rec.array(
                     [(0, 1, 0.2, "a"), (1, 2, 1.5, "bc")],
-                    dtype=[("index", "i2"), ("A", "<i8"), ("B", "<f8"), ("C", "O")],
+                    dtype=[
+                        ("index", "i2"),
+                        ("A", f"{endian}i8"),
+                        ("B", f"{endian}f8"),
+                        ("C", "O"),
+                    ],
                 ),
             ),
             # Names / indices not in mapping default to array dtype.
@@ -231,7 +280,12 @@ class TestDataFrameToRecords:
                 {"column_dtypes": {"A": np.int8, "B": np.float32}},
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
-                    dtype=[("index", "<i8"), ("A", "i1"), ("B", "<f4"), ("C", "O")],
+                    dtype=[
+                        ("index", f"{endian}i8"),
+                        ("A", "i1"),
+                        ("B", f"{endian}f4"),
+                        ("C", "O"),
+                    ],
                 ),
             ),
             # Names / indices not in dtype mapping default to array dtype.
@@ -239,18 +293,28 @@ class TestDataFrameToRecords:
                 {"column_dtypes": {"A": np.dtype("int8"), "B": np.dtype("float32")}},
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
-                    dtype=[("index", "<i8"), ("A", "i1"), ("B", "<f4"), ("C", "O")],
+                    dtype=[
+                        ("index", f"{endian}i8"),
+                        ("A", "i1"),
+                        ("B", f"{endian}f4"),
+                        ("C", "O"),
+                    ],
                 ),
             ),
             # Mixture of everything.
             (
                 {
                     "column_dtypes": {"A": np.int8, "B": np.float32},
-                    "index_dtypes": "<U2",
+                    "index_dtypes": f"{endian}U2",
                 },
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
-                    dtype=[("index", "<U2"), ("A", "i1"), ("B", "<f4"), ("C", "O")],
+                    dtype=[
+                        ("index", f"{endian}U2"),
+                        ("A", "i1"),
+                        ("B", f"{endian}f4"),
+                        ("C", "O"),
+                    ],
                 ),
             ),
             # Invalid dype values.
@@ -299,7 +363,7 @@ class TestDataFrameToRecords:
                 {"column_dtypes": "float64", "index_dtypes": {0: "int32", 1: "int8"}},
                 np.rec.array(
                     [(1, 2, 3.0), (4, 5, 6.0), (7, 8, 9.0)],
-                    dtype=[("a", "<i4"), ("b", "i1"), ("c", "<f8")],
+                    dtype=[("a", f"{endian}i4"), ("b", "i1"), ("c", f"{endian}f8")],
                 ),
             ),
             # MultiIndex in the columns.
@@ -310,14 +374,17 @@ class TestDataFrameToRecords:
                         [("a", "d"), ("b", "e"), ("c", "f")]
                     ),
                 ),
-                {"column_dtypes": {0: "<U1", 2: "float32"}, "index_dtypes": "float32"},
+                {
+                    "column_dtypes": {0: f"{endian}U1", 2: "float32"},
+                    "index_dtypes": "float32",
+                },
                 np.rec.array(
                     [(0.0, "1", 2, 3.0), (1.0, "4", 5, 6.0), (2.0, "7", 8, 9.0)],
                     dtype=[
-                        ("index", "<f4"),
-                        ("('a', 'd')", "<U1"),
-                        ("('b', 'e')", "<i8"),
-                        ("('c', 'f')", "<f4"),
+                        ("index", f"{endian}f4"),
+                        ("('a', 'd')", f"{endian}U1"),
+                        ("('b', 'e')", f"{endian}i8"),
+                        ("('c', 'f')", f"{endian}f4"),
                     ],
                 ),
             ),
@@ -332,7 +399,10 @@ class TestDataFrameToRecords:
                         [("d", -4), ("d", -5), ("f", -6)], names=list("cd")
                     ),
                 ),
-                {"column_dtypes": "float64", "index_dtypes": {0: "<U2", 1: "int8"}},
+                {
+                    "column_dtypes": "float64",
+                    "index_dtypes": {0: f"{endian}U2", 1: "int8"},
+                },
                 np.rec.array(
                     [
                         ("d", -4, 1.0, 2.0, 3.0),
@@ -340,11 +410,11 @@ class TestDataFrameToRecords:
                         ("f", -6, 7, 8, 9.0),
                     ],
                     dtype=[
-                        ("c", "<U2"),
+                        ("c", f"{endian}U2"),
                         ("d", "i1"),
-                        ("('a', 'd')", "<f8"),
-                        ("('b', 'e')", "<f8"),
-                        ("('c', 'f')", "<f8"),
+                        ("('a', 'd')", f"{endian}f8"),
+                        ("('b', 'e')", f"{endian}f8"),
+                        ("('c', 'f')", f"{endian}f8"),
                     ],
                 ),
             ),
@@ -374,13 +444,18 @@ class TestDataFrameToRecords:
 
         dtype_mappings = {
             "column_dtypes": DictLike(**{"A": np.int8, "B": np.float32}),
-            "index_dtypes": "<U2",
+            "index_dtypes": f"{endian}U2",
         }
 
         result = df.to_records(**dtype_mappings)
         expected = np.rec.array(
             [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
-            dtype=[("index", "<U2"), ("A", "i1"), ("B", "<f4"), ("C", "O")],
+            dtype=[
+                ("index", f"{endian}U2"),
+                ("A", "i1"),
+                ("B", f"{endian}f4"),
+                ("C", "O"),
+            ],
         )
         tm.assert_almost_equal(result, expected)
 

--- a/pandas/tests/frame/methods/test_to_records.py
+++ b/pandas/tests/frame/methods/test_to_records.py
@@ -1,5 +1,4 @@
 from collections import abc
-from sys import byteorder
 
 import numpy as np
 import pytest
@@ -13,9 +12,6 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
-
-
-endian = {"little": "<", "big": ">"}[byteorder]
 
 
 class TestDataFrameToRecords:
@@ -156,9 +152,9 @@ class TestDataFrameToRecords:
                 np.rec.array(
                     [(0, 1, 0.2, "a"), (1, 2, 1.5, "bc")],
                     dtype=[
-                        ("index", f"{endian}i8"),
-                        ("A", f"{endian}i8"),
-                        ("B", f"{endian}f8"),
+                        ("index", f"{tm.ENDIAN}i8"),
+                        ("A", f"{tm.ENDIAN}i8"),
+                        ("B", f"{tm.ENDIAN}f8"),
                         ("C", "O"),
                     ],
                 ),
@@ -169,35 +165,35 @@ class TestDataFrameToRecords:
                 np.rec.array(
                     [(0, 1, 0.2, "a"), (1, 2, 1.5, "bc")],
                     dtype=[
-                        ("index", f"{endian}i8"),
-                        ("A", f"{endian}i8"),
-                        ("B", f"{endian}f8"),
+                        ("index", f"{tm.ENDIAN}i8"),
+                        ("A", f"{tm.ENDIAN}i8"),
+                        ("B", f"{tm.ENDIAN}f8"),
                         ("C", "O"),
                     ],
                 ),
             ),
             # Column dtype applied across the board. Index unaffected.
             (
-                {"column_dtypes": f"{endian}U4"},
+                {"column_dtypes": f"{tm.ENDIAN}U4"},
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
                     dtype=[
-                        ("index", f"{endian}i8"),
-                        ("A", f"{endian}U4"),
-                        ("B", f"{endian}U4"),
-                        ("C", f"{endian}U4"),
+                        ("index", f"{tm.ENDIAN}i8"),
+                        ("A", f"{tm.ENDIAN}U4"),
+                        ("B", f"{tm.ENDIAN}U4"),
+                        ("C", f"{tm.ENDIAN}U4"),
                     ],
                 ),
             ),
             # Index dtype applied across the board. Columns unaffected.
             (
-                {"index_dtypes": f"{endian}U1"},
+                {"index_dtypes": f"{tm.ENDIAN}U1"},
                 np.rec.array(
                     [("0", 1, 0.2, "a"), ("1", 2, 1.5, "bc")],
                     dtype=[
-                        ("index", f"{endian}U1"),
-                        ("A", f"{endian}i8"),
-                        ("B", f"{endian}f8"),
+                        ("index", f"{tm.ENDIAN}U1"),
+                        ("A", f"{tm.ENDIAN}i8"),
+                        ("B", f"{tm.ENDIAN}f8"),
                         ("C", "O"),
                     ],
                 ),
@@ -208,10 +204,10 @@ class TestDataFrameToRecords:
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
                     dtype=[
-                        ("index", f"{endian}i8"),
-                        ("A", f"{endian}U"),
-                        ("B", f"{endian}U"),
-                        ("C", f"{endian}U"),
+                        ("index", f"{tm.ENDIAN}i8"),
+                        ("A", f"{tm.ENDIAN}U"),
+                        ("B", f"{tm.ENDIAN}U"),
+                        ("C", f"{tm.ENDIAN}U"),
                     ],
                 ),
             ),
@@ -221,23 +217,29 @@ class TestDataFrameToRecords:
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
                     dtype=[
-                        ("index", f"{endian}i8"),
-                        ("A", f"{endian}U"),
-                        ("B", f"{endian}U"),
-                        ("C", f"{endian}U"),
+                        ("index", f"{tm.ENDIAN}i8"),
+                        ("A", f"{tm.ENDIAN}U"),
+                        ("B", f"{tm.ENDIAN}U"),
+                        ("C", f"{tm.ENDIAN}U"),
                     ],
                 ),
             ),
             # Pass in a dictionary (name-only).
             (
-                {"column_dtypes": {"A": np.int8, "B": np.float32, "C": f"{endian}U2"}},
+                {
+                    "column_dtypes": {
+                        "A": np.int8,
+                        "B": np.float32,
+                        "C": f"{tm.ENDIAN}U2",
+                    }
+                },
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
                     dtype=[
-                        ("index", f"{endian}i8"),
+                        ("index", f"{tm.ENDIAN}i8"),
                         ("A", "i1"),
-                        ("B", f"{endian}f4"),
-                        ("C", f"{endian}U2"),
+                        ("B", f"{tm.ENDIAN}f4"),
+                        ("C", f"{tm.ENDIAN}U2"),
                     ],
                 ),
             ),
@@ -248,18 +250,22 @@ class TestDataFrameToRecords:
                     [(0, 1, 0.2, "a"), (1, 2, 1.5, "bc")],
                     dtype=[
                         ("index", "i2"),
-                        ("A", f"{endian}i8"),
-                        ("B", f"{endian}f8"),
+                        ("A", f"{tm.ENDIAN}i8"),
+                        ("B", f"{tm.ENDIAN}f8"),
                         ("C", "O"),
                     ],
                 ),
             ),
             # Ignore index mappings if index is not True.
             (
-                {"index": False, "index_dtypes": f"{endian}U2"},
+                {"index": False, "index_dtypes": f"{tm.ENDIAN}U2"},
                 np.rec.array(
                     [(1, 0.2, "a"), (2, 1.5, "bc")],
-                    dtype=[("A", f"{endian}i8"), ("B", f"{endian}f8"), ("C", "O")],
+                    dtype=[
+                        ("A", f"{tm.ENDIAN}i8"),
+                        ("B", f"{tm.ENDIAN}f8"),
+                        ("C", "O"),
+                    ],
                 ),
             ),
             # Non-existent names / indices in mapping should not error.
@@ -269,8 +275,8 @@ class TestDataFrameToRecords:
                     [(0, 1, 0.2, "a"), (1, 2, 1.5, "bc")],
                     dtype=[
                         ("index", "i2"),
-                        ("A", f"{endian}i8"),
-                        ("B", f"{endian}f8"),
+                        ("A", f"{tm.ENDIAN}i8"),
+                        ("B", f"{tm.ENDIAN}f8"),
                         ("C", "O"),
                     ],
                 ),
@@ -281,9 +287,9 @@ class TestDataFrameToRecords:
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
                     dtype=[
-                        ("index", f"{endian}i8"),
+                        ("index", f"{tm.ENDIAN}i8"),
                         ("A", "i1"),
-                        ("B", f"{endian}f4"),
+                        ("B", f"{tm.ENDIAN}f4"),
                         ("C", "O"),
                     ],
                 ),
@@ -294,9 +300,9 @@ class TestDataFrameToRecords:
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
                     dtype=[
-                        ("index", f"{endian}i8"),
+                        ("index", f"{tm.ENDIAN}i8"),
                         ("A", "i1"),
-                        ("B", f"{endian}f4"),
+                        ("B", f"{tm.ENDIAN}f4"),
                         ("C", "O"),
                     ],
                 ),
@@ -305,14 +311,14 @@ class TestDataFrameToRecords:
             (
                 {
                     "column_dtypes": {"A": np.int8, "B": np.float32},
-                    "index_dtypes": f"{endian}U2",
+                    "index_dtypes": f"{tm.ENDIAN}U2",
                 },
                 np.rec.array(
                     [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
                     dtype=[
-                        ("index", f"{endian}U2"),
+                        ("index", f"{tm.ENDIAN}U2"),
                         ("A", "i1"),
-                        ("B", f"{endian}f4"),
+                        ("B", f"{tm.ENDIAN}f4"),
                         ("C", "O"),
                     ],
                 ),
@@ -363,7 +369,11 @@ class TestDataFrameToRecords:
                 {"column_dtypes": "float64", "index_dtypes": {0: "int32", 1: "int8"}},
                 np.rec.array(
                     [(1, 2, 3.0), (4, 5, 6.0), (7, 8, 9.0)],
-                    dtype=[("a", f"{endian}i4"), ("b", "i1"), ("c", f"{endian}f8")],
+                    dtype=[
+                        ("a", f"{tm.ENDIAN}i4"),
+                        ("b", "i1"),
+                        ("c", f"{tm.ENDIAN}f8"),
+                    ],
                 ),
             ),
             # MultiIndex in the columns.
@@ -375,16 +385,16 @@ class TestDataFrameToRecords:
                     ),
                 ),
                 {
-                    "column_dtypes": {0: f"{endian}U1", 2: "float32"},
+                    "column_dtypes": {0: f"{tm.ENDIAN}U1", 2: "float32"},
                     "index_dtypes": "float32",
                 },
                 np.rec.array(
                     [(0.0, "1", 2, 3.0), (1.0, "4", 5, 6.0), (2.0, "7", 8, 9.0)],
                     dtype=[
-                        ("index", f"{endian}f4"),
-                        ("('a', 'd')", f"{endian}U1"),
-                        ("('b', 'e')", f"{endian}i8"),
-                        ("('c', 'f')", f"{endian}f4"),
+                        ("index", f"{tm.ENDIAN}f4"),
+                        ("('a', 'd')", f"{tm.ENDIAN}U1"),
+                        ("('b', 'e')", f"{tm.ENDIAN}i8"),
+                        ("('c', 'f')", f"{tm.ENDIAN}f4"),
                     ],
                 ),
             ),
@@ -401,7 +411,7 @@ class TestDataFrameToRecords:
                 ),
                 {
                     "column_dtypes": "float64",
-                    "index_dtypes": {0: f"{endian}U2", 1: "int8"},
+                    "index_dtypes": {0: f"{tm.ENDIAN}U2", 1: "int8"},
                 },
                 np.rec.array(
                     [
@@ -410,11 +420,11 @@ class TestDataFrameToRecords:
                         ("f", -6, 7, 8, 9.0),
                     ],
                     dtype=[
-                        ("c", f"{endian}U2"),
+                        ("c", f"{tm.ENDIAN}U2"),
                         ("d", "i1"),
-                        ("('a', 'd')", f"{endian}f8"),
-                        ("('b', 'e')", f"{endian}f8"),
-                        ("('c', 'f')", f"{endian}f8"),
+                        ("('a', 'd')", f"{tm.ENDIAN}f8"),
+                        ("('b', 'e')", f"{tm.ENDIAN}f8"),
+                        ("('c', 'f')", f"{tm.ENDIAN}f8"),
                     ],
                 ),
             ),
@@ -444,16 +454,16 @@ class TestDataFrameToRecords:
 
         dtype_mappings = {
             "column_dtypes": DictLike(**{"A": np.int8, "B": np.float32}),
-            "index_dtypes": f"{endian}U2",
+            "index_dtypes": f"{tm.ENDIAN}U2",
         }
 
         result = df.to_records(**dtype_mappings)
         expected = np.rec.array(
             [("0", "1", "0.2", "a"), ("1", "2", "1.5", "bc")],
             dtype=[
-                ("index", f"{endian}U2"),
+                ("index", f"{tm.ENDIAN}U2"),
                 ("A", "i1"),
-                ("B", f"{endian}f4"),
+                ("B", f"{tm.ENDIAN}f4"),
                 ("C", "O"),
             ],
         )

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -12,7 +12,6 @@ from io import (
 )
 import mmap
 import os
-from sys import byteorder
 import tarfile
 
 import numpy as np
@@ -30,9 +29,6 @@ from pandas import (
     concat,
 )
 import pandas._testing as tm
-
-
-endian = {"little": "<", "big": ">"}[byteorder]
 
 
 @pytest.mark.parametrize(
@@ -148,9 +144,12 @@ nan 2
             "the dtype timedelta64 is not supported for parsing",
             {"dtype": {"A": "timedelta64", "B": "float64"}},
         ),
-        (f"the dtype {endian}U8 is not supported for parsing", {"dtype": {"A": "U8"}}),
+        (
+            f"the dtype {tm.ENDIAN}U8 is not supported for parsing",
+            {"dtype": {"A": "U8"}},
+        ),
     ],
-    ids=["dt64-0", "dt64-1", "td64", f"{endian}U8"],
+    ids=["dt64-0", "dt64-1", "td64", f"{tm.ENDIAN}U8"],
 )
 def test_unsupported_dtype(c_parser_only, match, kwargs):
     parser = c_parser_only

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -12,6 +12,7 @@ from io import (
 )
 import mmap
 import os
+from sys import byteorder
 import tarfile
 
 import numpy as np
@@ -29,6 +30,9 @@ from pandas import (
     concat,
 )
 import pandas._testing as tm
+
+
+endian = {"little": "<", "big": ">"}[byteorder]
 
 
 @pytest.mark.parametrize(
@@ -144,9 +148,9 @@ nan 2
             "the dtype timedelta64 is not supported for parsing",
             {"dtype": {"A": "timedelta64", "B": "float64"}},
         ),
-        ("the dtype <U8 is not supported for parsing", {"dtype": {"A": "U8"}}),
+        (f"the dtype {endian}U8 is not supported for parsing", {"dtype": {"A": "U8"}}),
     ],
-    ids=["dt64-0", "dt64-1", "td64", "<U8"],
+    ids=["dt64-0", "dt64-1", "td64", f"{endian}U8"],
 )
 def test_unsupported_dtype(c_parser_only, match, kwargs):
     parser = c_parser_only

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -2,6 +2,7 @@ from datetime import (
     time,
     timedelta,
 )
+from sys import byteorder
 
 import numpy as np
 import pytest
@@ -197,8 +198,9 @@ class TestTimedeltas:
         timedelta_NaT = np.timedelta64("NaT")
 
         actual = to_timedelta(Series(["00:00:01", np.nan]))
+        endian = {"little": "<", "big": ">"}[byteorder]
         expected = Series(
-            [np.timedelta64(1000000000, "ns"), timedelta_NaT], dtype="<m8[ns]"
+            [np.timedelta64(1000000000, "ns"), timedelta_NaT], dtype=f"{endian}m8[ns]"
         )
         tm.assert_series_equal(actual, expected)
 

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -2,7 +2,6 @@ from datetime import (
     time,
     timedelta,
 )
-from sys import byteorder
 
 import numpy as np
 import pytest
@@ -198,9 +197,9 @@ class TestTimedeltas:
         timedelta_NaT = np.timedelta64("NaT")
 
         actual = to_timedelta(Series(["00:00:01", np.nan]))
-        endian = {"little": "<", "big": ">"}[byteorder]
         expected = Series(
-            [np.timedelta64(1000000000, "ns"), timedelta_NaT], dtype=f"{endian}m8[ns]"
+            [np.timedelta64(1000000000, "ns"), timedelta_NaT],
+            dtype=f"{tm.ENDIAN}m8[ns]",
         )
         tm.assert_series_equal(actual, expected)
 


### PR DESCRIPTION
These are all due to tests expecting little-endian dtypes, where in fact the endianness of the dtype is that of the host.

- [ ] closes #xxxx (Replace xxxx with the Github issue number) **No issue filed**
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature **Not applicable; fixes some tests on big-endian platforms**
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.