### PR TITLE
CI fix ci-failure from bs4 new version

### DIFF
--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -577,7 +577,7 @@ class _BeautifulSoupHtml5LibFrameParser(_HtmlFrameParser):
                 for elem in table.find_all(style=re.compile(r"display:\s*none")):
                     elem.decompose()
 
-            if table not in unique_tables and table.find(text=match) is not None:
+            if table not in unique_tables and table.find(string=match) is not None:
                 result.append(table)
             unique_tables.add(table)
 


### PR DESCRIPTION
New BS4 release is throwing a deprecation warning

```
_____________ TestReadHtml.test_banklist_url_positional_match[bs4] _____________
[gw1] linux -- Python 3.8.13 /usr/share/miniconda/envs/pandas-dev/bin/python

self = <pandas.tests.io.test_html.TestReadHtml object at 0x7f7fd333a040>

    @pytest.mark.network
    @tm.network(
        url=(
            "https://www.fdic.gov/resources/resolutions/"
            "bank-failures/failed-bank-list/index.html"
        ),
        check_before_test=True,
    )
    def test_banklist_url_positional_match(self):
        url = "https://www.fdic.gov/resources/resolutions/bank-failures/failed-bank-list/index.html"  # noqa E501
        # Passing match argument as positional should cause a FutureWarning.
        with tm.assert_produces_warning(FutureWarning):
>           df1 = self.read_html(
                # lxml cannot find attrs leave out for now
                url,
                "First Federal Bank of Florida",  # attrs={"class": "dataTable"}
            )

pandas/tests/io/test_html.py:147: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/share/miniconda/envs/pandas-dev/lib/python3.8/contextlib.py:120: in __exit__
    next(self.gen)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def _assert_caught_no_extra_warnings(
        *,
        caught_warnings: Sequence[warnings.WarningMessage],
Warning: xpected_warning: type[Warning] | bool | None,
    ) -> None:
        """Assert that no extra warnings apart from the expected ones are caught."""
        extra_warnings = []
    
        for actual_warning in caught_warnings:
            if _is_unexpected_warning(actual_warning, expected_warning):
                # GH#38630 pytest.filterwarnings does not suppress these.
                if actual_warning.category == ResourceWarning:
                    # GH 44732: Don't make the CI flaky by filtering SSL-related
                    # ResourceWarning from dependencies
                    unclosed_ssl = (
                        "unclosed transport <asyncio.sslproto._SSLProtocolTransport",
                        "unclosed <ssl.SSLSocket",
                    )
                    if any(msg in str(actual_warning.message) for msg in unclosed_ssl):
                        continue
                    # GH 44844: Matplotlib leaves font files open during the entire process
                    # upon import. Don't make CI flaky if ResourceWarning raised
                    # due to these open files.
                    if any("matplotlib" in mod for mod in sys.modules):
                        continue
    
                extra_warnings.append(
                    (
                        actual_warning.category.__name__,
                        actual_warning.message,
                        actual_warning.filename,
                        actual_warning.lineno,
                    )
                )
    
        if extra_warnings:
>           raise AssertionError(f"Caused unexpected warning(s): {repr(extra_warnings)}")
E           AssertionError: Caused unexpected warning(s): [('DeprecationWarning', DeprecationWarning("The 'text' argument to find()-type methods is deprecated. Use 'string' instead."), '/usr/share/miniconda/envs/pandas-dev/lib/python3.8/site-packages/bs4/element.py', 784)]
```

From the [docs](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#string)

> The string argument is new in Beautiful Soup 4.4.0. In earlier versions it was called text:****