### PR TITLE
DOC: removed .value_counts() and .nunique() from the docs for 'table …

### DIFF
--- a/doc/source/reference/groupby.rst
+++ b/doc/source/reference/groupby.rst
@@ -132,9 +132,7 @@ The following methods are available only for ``SeriesGroupBy`` objects.
    SeriesGroupBy.hist
    SeriesGroupBy.nlargest
    SeriesGroupBy.nsmallest
-   SeriesGroupBy.nunique
    SeriesGroupBy.unique
-   SeriesGroupBy.value_counts
    SeriesGroupBy.is_monotonic_increasing
    SeriesGroupBy.is_monotonic_decreasing
 


### PR DESCRIPTION
…methods available only for SeriesGroupBy' objects. GH46670

- [x] closes #46670 (Replace xxxx with the Github issue number)
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).