### PR TITLE
BUG: Fix __instancecheck__ and __subclasscheck__ of metaclass in pandas.core.dtypes.generic

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -498,6 +498,7 @@ Conversion
 - Bug in :meth:`Series.astype` and :meth:`DataFrame.astype` from floating dtype to unsigned integer dtype failing to raise in the presence of negative values (:issue:`45151`)
 - Bug in :func:`array` with ``FloatingDtype`` and values containing float-castable strings incorrectly raising (:issue:`45424`)
 - Bug when comparing string and datetime64ns objects causing ``OverflowError`` exception. (:issue:`45506`)
+- Bug in metaclass of generic abstract dtypes causing :meth:`DataFrame.apply` and :meth:`Series.apply` to raise for the built-in function ``type``
 
 Strings
 ^^^^^^^

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -498,7 +498,7 @@ Conversion
 - Bug in :meth:`Series.astype` and :meth:`DataFrame.astype` from floating dtype to unsigned integer dtype failing to raise in the presence of negative values (:issue:`45151`)
 - Bug in :func:`array` with ``FloatingDtype`` and values containing float-castable strings incorrectly raising (:issue:`45424`)
 - Bug when comparing string and datetime64ns objects causing ``OverflowError`` exception. (:issue:`45506`)
-- Bug in metaclass of generic abstract dtypes causing :meth:`DataFrame.apply` and :meth:`Series.apply` to raise for the built-in function ``type``
+- Bug in metaclass of generic abstract dtypes causing :meth:`DataFrame.apply` and :meth:`Series.apply` to raise for the built-in function ``type`` (:issue:`46684`)
 
 Strings
 ^^^^^^^

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1568,12 +1568,12 @@ def test_apply_type():
     )
     tm.assert_frame_equal(result, expected)
 
-    # axis 0
+    # axis=0
     result = df.apply(type, axis=0)
     expected = Series({"col1": Series, "col2": Series})
     tm.assert_series_equal(result, expected)
 
-    # axis 1
+    # axis=1
     result = df.apply(type, axis=1)
     expected = Series({"a": Series, "b": Series, "c": Series})
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1551,3 +1551,29 @@ def test_nuisance_depr_passes_through_warnings():
     df = DataFrame({"a": [1, 2, 3]})
     with tm.assert_produces_warning(UserWarning, match="Hello, World!"):
         df.agg([foo])
+
+
+def test_apply_type():
+    # GH 46719
+    df = DataFrame(
+        {"col1": [3, "string", float], "col2": [0.25, datetime(2020, 1, 1), np.nan]},
+        index=["a", "b", "c"],
+    )
+
+    # applymap
+    result = df.applymap(type)
+    expected = DataFrame(
+        {"col1": [int, str, type], "col2": [float, datetime, float]},
+        index=["a", "b", "c"],
+    )
+    tm.assert_frame_equal(result, expected)
+
+    # axis 0
+    result = df.apply(type, axis=0)
+    expected = Series({"col1": Series, "col2": Series})
+    tm.assert_series_equal(result, expected)
+
+    # axis 1
+    result = df.apply(type, axis=1)
+    expected = Series({"a": Series, "b": Series, "c": Series})
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/apply/test_series_apply.py
+++ b/pandas/tests/apply/test_series_apply.py
@@ -889,3 +889,11 @@ def test_apply_retains_column_name():
         index=Index(range(3), name="x"),
     )
     tm.assert_frame_equal(result, expected)
+
+
+def test_apply_type():
+    # GH 46719
+    s = Series([3, "string", float], index=["a", "b", "c"])
+    result = s.apply(type)
+    expected = Series([int, str, type], index=["a", "b", "c"])
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/dtypes/test_generic.py
+++ b/pandas/tests/dtypes/test_generic.py
@@ -1,3 +1,4 @@
+import re
 from warnings import catch_warnings
 
 import numpy as np
@@ -49,12 +50,27 @@ class TestABCClasses:
 
     @pytest.mark.parametrize("abctype1, inst", abc_pairs)
     @pytest.mark.parametrize("abctype2, _", abc_pairs)
-    def test_abc_pairs(self, abctype1, abctype2, inst, _):
+    def test_abc_pairs_instance_check(self, abctype1, abctype2, inst, _):
         # GH 38588
         if abctype1 == abctype2:
             assert isinstance(inst, getattr(gt, abctype2))
+            assert not isinstance(type(inst), getattr(gt, abctype2))
         else:
             assert not isinstance(inst, getattr(gt, abctype2))
+
+    @pytest.mark.parametrize("abctype1, inst", abc_pairs)
+    @pytest.mark.parametrize("abctype2, _", abc_pairs)
+    def test_abc_pairs_subclass_check(self, abctype1, abctype2, inst, _):
+        # GH 38588
+        if abctype1 == abctype2:
+            assert issubclass(type(inst), getattr(gt, abctype2))
+
+            with pytest.raises(
+                TypeError, match=re.escape("issubclass() arg 1 must be a class")
+            ):
+                issubclass(inst, getattr(gt, abctype2))
+        else:
+            assert not issubclass(type(inst), getattr(gt, abctype2))
 
     abc_subclasses = {
         "ABCIndex": [

--- a/pandas/tests/dtypes/test_generic.py
+++ b/pandas/tests/dtypes/test_generic.py
@@ -51,7 +51,7 @@ class TestABCClasses:
     @pytest.mark.parametrize("abctype1, inst", abc_pairs)
     @pytest.mark.parametrize("abctype2, _", abc_pairs)
     def test_abc_pairs_instance_check(self, abctype1, abctype2, inst, _):
-        # GH 38588
+        # GH 38588, 46719
         if abctype1 == abctype2:
             assert isinstance(inst, getattr(gt, abctype2))
             assert not isinstance(type(inst), getattr(gt, abctype2))
@@ -61,7 +61,7 @@ class TestABCClasses:
     @pytest.mark.parametrize("abctype1, inst", abc_pairs)
     @pytest.mark.parametrize("abctype2, _", abc_pairs)
     def test_abc_pairs_subclass_check(self, abctype1, abctype2, inst, _):
-        # GH 38588
+        # GH 38588, 46719
         if abctype1 == abctype2:
             assert issubclass(type(inst), getattr(gt, abctype2))
 


### PR DESCRIPTION
- [x] closes #46684 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

---

#46684 is caused by wrong `__instancecheck__` implementation, but `__subclasscheck__` implementation is also wrong. I fixed both.

```python
import pandas as pd
from pandas.core.dtypes.generic import ABCDataFrame

print(isinstance(pd.DataFrame, ABCDataFrame)) # Should have returned False, returned True instead
print(issubclass(pd.DataFrame(), ABCDataFrame)) # Should have raised, returned True instead
```