### PR TITLE
DOC: Improve .at indexer API docs

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -539,14 +539,30 @@ class IndexingMixin:
         Raises
         ------
         KeyError
-            If 'label' does not exist in DataFrame.
+            * If getting a value and 'label' does not exist in a DataFrame or
+                Series.
+        ValueError
+            * If row/column label pair is not a tuple or if any label from
+                the pair is not a scalar for DataFrame.
+            * If label is list-like (*excluding* NamedTuple) for Series.
 
         See Also
         --------
+        DataFrame.at : Access a single value for a row/column pair by label.
         DataFrame.iat : Access a single value for a row/column pair by integer
             position.
         DataFrame.loc : Access a group of rows and columns by label(s).
-        Series.at : Access a single value using a label.
+        DataFrame.iloc : Access a group of rows and columns by integer
+            position(s).
+        Series.at : Access a single value by label.
+        Series.iat : Access a single value by integer position.
+        Series.loc : Access a group of rows by label(s).
+        Series.iloc : Access a group of rows by integer position(s).
+
+        Notes
+        -----
+        See :ref:`Fast scalar value getting and setting <indexing.basics.get_value>`
+        for more details.
 
         Examples
         --------


### PR DESCRIPTION
- [x] closes #46722 

Not sure about the wording of the `ValueError` and whether it is worth adding the additional methods under `See Also` but the same doc is used for both DataFrame and Series so I thought that mentioning all the methods is good for the sake of completeness