### PR TITLE
TST: Add a test for `series name should be preserved in pser.mode() `

### DIFF
--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -2283,9 +2283,11 @@ class TestMode:
             algos.mode(idx)
 
     def test_ser_mode_with_name(self):
-        ser = Series([1, 2, 3])
-        ser.name = "foo"
-        tm.assert_equal(ser.mode().name, "foo")
+        # GH 46737
+        ser = Series([1, 1, 3], name="foo")
+        result = ser.mode()
+        expected = Series([1], name="foo")
+        tm.assert_series_equal(result, expected)
 
 
 class TestDiff:

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -2282,6 +2282,11 @@ class TestMode:
             # algos.mode expects Arraylike, does *not* unwrap TimedeltaIndex
             algos.mode(idx)
 
+    def test_ser_mode_with_name(self):
+        ser = Series([1, 2, 3])
+        ser.name = "foo"
+        tm.assert_equal(ser.mode().name, "foo")
+
 
 class TestDiff:
     @pytest.mark.parametrize("dtype", ["M8[ns]", "m8[ns]"])


### PR DESCRIPTION
Add a test for pser.mode() should set series name

- [x] closes #46737
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
