### PR TITLE
BUG: Do not allow urllib to hijack all non-HTTP protocols

### DIFF
--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -324,7 +324,7 @@ def _get_filepath_or_buffer(
     if (
         isinstance(filepath_or_buffer, str)
         and is_url(filepath_or_buffer)
-        and parse_url(filepath_or_buffer).scheme != 'sftp'
+        and parse_url(filepath_or_buffer).scheme != "sftp"
     ):
         # TODO: fsspec can also handle HTTP via requests, but leaving this
         # unchanged. using fsspec appears to break the ability to infer if the

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -322,9 +322,9 @@ def _get_filepath_or_buffer(
         fsspec_mode += "b"
 
     if (
-        isinstance(filepath_or_buffer, str) and
-        is_url(filepath_or_buffer) and
-        parse_url(filepath_or_buffer).scheme != 'sftp'
+        isinstance(filepath_or_buffer, str)
+        and is_url(filepath_or_buffer)
+        and parse_url(filepath_or_buffer).scheme != 'sftp'
     ):
         # TODO: fsspec can also handle HTTP via requests, but leaving this
         # unchanged. using fsspec appears to break the ability to infer if the

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -321,10 +321,11 @@ def _get_filepath_or_buffer(
     if "t" not in fsspec_mode and "b" not in fsspec_mode:
         fsspec_mode += "b"
 
-    if isinstance(filepath_or_buffer, str) and parse_url(filepath_or_buffer).scheme in [
-        "http",
-        "https"
-    ]:
+    if (
+            isinstance(filepath_or_buffer, str) and
+            is_url(filepath_or_buffer) and
+            parse_url(filepath_or_buffer).scheme != 'sftp'
+    ):
         # TODO: fsspec can also handle HTTP via requests, but leaving this
         # unchanged. using fsspec appears to break the ability to infer if the
         # server responded with gzipped data

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -322,9 +322,9 @@ def _get_filepath_or_buffer(
         fsspec_mode += "b"
 
     if (
-            isinstance(filepath_or_buffer, str) and
-            is_url(filepath_or_buffer) and
-            parse_url(filepath_or_buffer).scheme != 'sftp'
+        isinstance(filepath_or_buffer, str) and
+        is_url(filepath_or_buffer) and
+        parse_url(filepath_or_buffer).scheme != 'sftp'
     ):
         # TODO: fsspec can also handle HTTP via requests, but leaving this
         # unchanged. using fsspec appears to break the ability to infer if the

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -322,8 +322,7 @@ def _get_filepath_or_buffer(
         fsspec_mode += "b"
 
     if (
-        isinstance(filepath_or_buffer, str)
-        and parse_url(filepath_or_buffer).scheme in ["http", "https"]
+        isinstance(filepath_or_buffer, str) and not is_fsspec_url(filepath_or_buffer)
     ):
         # TODO: fsspec can also handle HTTP via requests, but leaving this
         # unchanged. using fsspec appears to break the ability to infer if the

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -321,9 +321,7 @@ def _get_filepath_or_buffer(
     if "t" not in fsspec_mode and "b" not in fsspec_mode:
         fsspec_mode += "b"
 
-    if (
-        isinstance(filepath_or_buffer, str) and not is_fsspec_url(filepath_or_buffer)
-    ):
+    if isinstance(filepath_or_buffer, str) and not is_fsspec_url(filepath_or_buffer):
         # TODO: fsspec can also handle HTTP via requests, but leaving this
         # unchanged. using fsspec appears to break the ability to infer if the
         # server responded with gzipped data

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -321,7 +321,10 @@ def _get_filepath_or_buffer(
     if "t" not in fsspec_mode and "b" not in fsspec_mode:
         fsspec_mode += "b"
 
-    if isinstance(filepath_or_buffer, str) and not is_fsspec_url(filepath_or_buffer):
+    if isinstance(filepath_or_buffer, str) and parse_url(filepath_or_buffer).scheme in [
+        'http',
+        'https'
+    ]:
         # TODO: fsspec can also handle HTTP via requests, but leaving this
         # unchanged. using fsspec appears to break the ability to infer if the
         # server responded with gzipped data

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -322,8 +322,8 @@ def _get_filepath_or_buffer(
         fsspec_mode += "b"
 
     if isinstance(filepath_or_buffer, str) and parse_url(filepath_or_buffer).scheme in [
-        'http',
-        'https'
+        "http",
+        "https"
     ]:
         # TODO: fsspec can also handle HTTP via requests, but leaving this
         # unchanged. using fsspec appears to break the ability to infer if the

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -321,7 +321,10 @@ def _get_filepath_or_buffer(
     if "t" not in fsspec_mode and "b" not in fsspec_mode:
         fsspec_mode += "b"
 
-    if isinstance(filepath_or_buffer, str) and parse_url(filepath_or_buffer).scheme == 'http':
+    if (
+        isinstance(filepath_or_buffer, str)
+        and parse_url(filepath_or_buffer).scheme == "http"
+    ):
         # TODO: fsspec can also handle HTTP via requests, but leaving this
         # unchanged. using fsspec appears to break the ability to infer if the
         # server responded with gzipped data

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -321,7 +321,7 @@ def _get_filepath_or_buffer(
     if "t" not in fsspec_mode and "b" not in fsspec_mode:
         fsspec_mode += "b"
 
-    if isinstance(filepath_or_buffer, str) and is_url(filepath_or_buffer):
+    if isinstance(filepath_or_buffer, str) and parse_url(filepath_or_buffer).scheme == 'http':
         # TODO: fsspec can also handle HTTP via requests, but leaving this
         # unchanged. using fsspec appears to break the ability to infer if the
         # server responded with gzipped data

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -323,7 +323,7 @@ def _get_filepath_or_buffer(
 
     if (
         isinstance(filepath_or_buffer, str)
-        and parse_url(filepath_or_buffer).scheme == "http"
+        and parse_url(filepath_or_buffer).scheme in ["http", "https"]
     ):
         # TODO: fsspec can also handle HTTP via requests, but leaving this
         # unchanged. using fsspec appears to break the ability to infer if the


### PR DESCRIPTION
Currently, many non HTTP protocols are routed to urllib to open, even when not supported by urllib.  In particular, opening files via SFTP will always fail, since the attempt to open the file is not sent to fsspec, which supports that protocol.

The following code demonstrates the issue. It will fail pre-patch, and succeed after.

```
pandas.read_csv('sftp://some.server/file.csv', storage_options={'username': 'my_username', 'password': 'my_password', 'allow_agent': False})
```

I apologize for not adding a test, as I didn't find any other sftp tests in test_fsspec.py, and I wasn't sure how to best handle a functional test for that protocol. Also, the real problem is misuse of `is_url`. There may be a different support function that would be correct to use in its place, but a quick search didn't find anything. However, please feel free to throw this pull request away and fix in a more appropriate manner if necessary.