### PR TITLE
BUG: Prevent segfault in roll_weighted_var

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -599,7 +599,7 @@ Groupby/resample/rolling
 - Bug in :meth:`GroupBy.cummax` with ``int64`` dtype with leading value being the smallest possible int64 (:issue:`46382`)
 - Bug in :meth:`GroupBy.max` with empty groups and ``uint64`` dtype incorrectly raising ``RuntimeError`` (:issue:`46408`)
 - Bug in :meth:`.GroupBy.apply` would fail when ``func`` was a string and args or kwargs were supplied (:issue:`46479`)
-- Bug in :meth:`.Rolling.var` would segfault when calculated weighted variance with large window size (:issue:`46760`)
+- Bug in :meth:`.Rolling.var` would segfault when calculating weighted variance with large window size (:issue:`46760`)
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -599,7 +599,7 @@ Groupby/resample/rolling
 - Bug in :meth:`GroupBy.cummax` with ``int64`` dtype with leading value being the smallest possible int64 (:issue:`46382`)
 - Bug in :meth:`GroupBy.max` with empty groups and ``uint64`` dtype incorrectly raising ``RuntimeError`` (:issue:`46408`)
 - Bug in :meth:`.GroupBy.apply` would fail when ``func`` was a string and args or kwargs were supplied (:issue:`46479`)
--
+- Bug in :meth:`.Rolling.var` would segfault when calculated weighted variance with large window size (:issue:`46760`)
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -599,7 +599,7 @@ Groupby/resample/rolling
 - Bug in :meth:`GroupBy.cummax` with ``int64`` dtype with leading value being the smallest possible int64 (:issue:`46382`)
 - Bug in :meth:`GroupBy.max` with empty groups and ``uint64`` dtype incorrectly raising ``RuntimeError`` (:issue:`46408`)
 - Bug in :meth:`.GroupBy.apply` would fail when ``func`` was a string and args or kwargs were supplied (:issue:`46479`)
-- Bug in :meth:`.Rolling.var` would segfault when calculating weighted variance with large window size (:issue:`46760`)
+- Bug in :meth:`.Rolling.var` would segfault calculating weighted variance when window size was larger than data size (:issue:`46760`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -1592,7 +1592,7 @@ def roll_weighted_var(const float64_t[:] values, const float64_t[:] weights,
 
     with nogil:
 
-        for i in range(win_n):
+        for i in range(min(win_n, n)):
             add_weighted_var(values[i], weights[i], &t,
                              &sum_w, &mean, &nobs)
 

--- a/pandas/tests/window/test_win_type.py
+++ b/pandas/tests/window/test_win_type.py
@@ -679,10 +679,10 @@ def test_cmov_window_special_linear_range(win_types_special, step):
 
 
 @td.skip_if_no_scipy
-def test_weighted_var_big_window_no_segfault():
+def test_weighted_var_big_window_no_segfault(win_types, center):
     # Github Issue #46772
     x = Series(0)
-    result = x.rolling(window=16, center=True, win_type="triang").var()
+    result = x.rolling(window=16, center=center, win_type=win_types).var()
     expected = Series(np.NaN)
 
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/window/test_win_type.py
+++ b/pandas/tests/window/test_win_type.py
@@ -682,7 +682,7 @@ def test_cmov_window_special_linear_range(win_types_special, step):
 def test_weighted_var_big_window_no_segfault():
     # Github Issue #46772
     x = Series(0)
-    result = x.rolling(window=16, center=True, win_type='triang').var()
+    result = x.rolling(window=16, center=True, win_type="triang").var()
     expected = Series(np.NaN)
 
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/window/test_win_type.py
+++ b/pandas/tests/window/test_win_type.py
@@ -676,3 +676,13 @@ def test_cmov_window_special_linear_range(win_types_special, step):
         .mean(**kwds[win_types_special])
     )
     tm.assert_series_equal(xp, rs)
+
+
+@td.skip_if_no_scipy
+def test_weighted_var_big_window_no_segfault():
+    # Github Issue #46772
+    x = Series(0)
+    result = x.rolling(window=16, center=True, win_type='triang').var()
+    expected = Series(np.NaN)
+
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- closes #46760
- edit: I added a test to `test_win_type.py`
- I added an entry in the latest `doc/source/whatsnew/v1.5.0.rst` file because this fixes a bug