### PR TITLE
ENH: Add numeric_only to resampler methods

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -96,6 +96,7 @@ Other enhancements
 - :meth:`pd.concat` now raises when ``levels`` contains duplicate values (:issue:`46653`)
 - Added ``numeric_only`` argument to :meth:`DataFrame.corr`, :meth:`DataFrame.corrwith`, and :meth:`DataFrame.cov` (:issue:`46560`)
 - A :class:`errors.PerformanceWarning` is now thrown when using ``string[pyarrow]`` dtype with methods that don't dispatch to ``pyarrow.compute`` methods (:issue:`42613`)
+- Added ``numeric_only`` argument to :meth:`Resampler.sum`, :meth:`Resampler.prod`, :meth:`Resampler.min`, :meth:`Resampler.max`, :meth:`Resampler.first`, and :meth:`Resampler.last` (:issue:`46442`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_150.notable_bug_fixes:

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1033,19 +1033,16 @@ for method in ["sum", "prod", "min", "max", "first", "last"]:
         numeric_only: bool | lib.NoDefault = lib.no_default,
         min_count: int = 0,
         *args,
-        **kwargs
+        **kwargs,
     ):
         if numeric_only is lib.no_default:
-            if self.obj.ndim == 1:
-                # SeriesGroupBy
-                numeric_only = None
-            elif _method != "sum":
+            if (self.obj.ndim == 1) or (_method != "sum"):
+                # For SeriesGroupBy, set the default to be False.
+                # For DataFrameGroupBy, set it to be False for methods other than `sum`.
                 numeric_only = False
 
         nv.validate_resampler_func(_method, args, kwargs)
-        return self._downsample(
-            _method, numeric_only=numeric_only, min_count=min_count
-        )
+        return self._downsample(_method, numeric_only=numeric_only, min_count=min_count)
 
     f.__doc__ = getattr(GroupBy, method).__doc__
     setattr(Resampler, method, f)

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -101,6 +101,21 @@ if TYPE_CHECKING:
 
 _shared_docs_kwargs: dict[str, str] = {}
 
+_resample_agg_method_template = """
+Compute {fname} of group values.
+
+Parameters
+----------
+min_count : int, default {mc}
+    The required number of valid values to perform the operation. If fewer
+    than ``min_count`` non-NA values are present the result will be NA.
+
+Returns
+-------
+Series or DataFrame
+    Computed {fname} of values within each group.
+"""
+
 
 class Resampler(BaseGroupBy, PandasObject):
     """
@@ -1027,11 +1042,11 @@ class Resampler(BaseGroupBy, PandasObject):
 # downsample methods
 for method in ["sum", "prod", "min", "max", "first", "last"]:
 
+    @doc(_resample_agg_method_template, fname=method, mc=0)
     def f(self, _method=method, min_count=0, *args, **kwargs):
         nv.validate_resampler_func(_method, args, kwargs)
         return self._downsample(_method, min_count=min_count)
 
-    f.__doc__ = getattr(GroupBy, method).__doc__
     setattr(Resampler, method, f)
 
 

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1037,8 +1037,9 @@ for method in ["sum", "prod", "min", "max", "first", "last"]:
     ):
         if numeric_only is lib.no_default:
             if self.obj.ndim == 1:
+                # SeriesGroupBy
                 numeric_only = None
-            elif _method in ["first", "min"]:
+            elif _method != "sum":
                 numeric_only = False
 
         nv.validate_resampler_func(_method, args, kwargs)

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1036,8 +1036,7 @@ for method in ["sum", "prod", "min", "max", "first", "last"]:
         **kwargs,
     ):
         if numeric_only is lib.no_default:
-            if (self.obj.ndim == 1) or (_method != "sum"):
-                # For SeriesGroupBy, set the default to be False.
+            if _method != "sum":
                 # For DataFrameGroupBy, set it to be False for methods other than `sum`.
                 numeric_only = False
 

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -771,3 +771,58 @@ def test_end_and_end_day_origin(
     )
 
     tm.assert_series_equal(res, expected)
+
+
+@pytest.mark.parametrize("numeric_only", [True, False])
+def test_downsample_method(numeric_only):
+    # test if `numeric_only` behave as expected for Resampler downsample methods.
+
+    index = date_range("2018-01-01", periods=2, freq="D")
+    expected_index = date_range("2018-12-31", periods=1, freq="Y")
+    df = DataFrame({"cat": ["cat_1", "cat_2"], "num": [5, 20]}, index=index)
+    resampled = df.resample("Y")
+
+    # test Resampler.sum
+    result = resampled.sum(numeric_only=numeric_only)
+    if numeric_only:
+        expected = DataFrame({"num": [25]}, index=expected_index)
+    else:
+        expected = DataFrame({"cat": ["cat_1cat_2"], "num": [25]}, index=expected_index)
+    tm.assert_frame_equal(result, expected)
+
+    # test Resampler.prod
+    result = resampled.prod(numeric_only=numeric_only)
+    expected = DataFrame({"num": [100]}, index=expected_index)
+    tm.assert_frame_equal(result, expected)
+
+    # test Resampler.min
+    result = resampled.min(numeric_only=numeric_only)
+    if numeric_only:
+        expected = DataFrame({"num": [5]}, index=expected_index)
+    else:
+        expected = DataFrame({"cat": ["cat_1"], "num": [5]}, index=expected_index)
+    tm.assert_frame_equal(result, expected)
+
+    # test Resampler.max
+    result = resampled.max(numeric_only=numeric_only)
+    if numeric_only:
+        expected = DataFrame({"num": [20]}, index=expected_index)
+    else:
+        expected = DataFrame({"cat": ["cat_2"], "num": [20]}, index=expected_index)
+    tm.assert_frame_equal(result, expected)
+
+    # test Resampler.first
+    result = resampled.first(numeric_only=numeric_only)
+    if numeric_only:
+        expected = DataFrame({"num": [5]}, index=expected_index)
+    else:
+        expected = DataFrame({"cat": ["cat_1"], "num": [5]}, index=expected_index)
+    tm.assert_frame_equal(result, expected)
+
+    # test Resampler.last
+    result = resampled.last(numeric_only=numeric_only)
+    if numeric_only:
+        expected = DataFrame({"num": [20]}, index=expected_index)
+    else:
+        expected = DataFrame({"cat": ["cat_2"], "num": [20]}, index=expected_index)
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #46442
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

After examining the reported issue #46442, I found the issue exists in all the following docs.
https://pandas.pydata.org/docs/reference/api/pandas.core.resample.Resampler.sum.html
https://pandas.pydata.org/docs/reference/api/pandas.core.resample.Resampler.prod.html
https://pandas.pydata.org/docs/reference/api/pandas.core.resample.Resampler.min.html
https://pandas.pydata.org/docs/reference/api/pandas.core.resample.Resampler.max.html
https://pandas.pydata.org/docs/reference/api/pandas.core.resample.Resampler.first.html
https://pandas.pydata.org/docs/reference/api/pandas.core.resample.Resampler.last.html

The problem seems to be caused by the fact that the docstrings of `sum`, `prod`, `min`, `max`, `first`, `last` methods
in the `Resampler` class borrow the `_groupby_agg_method_template` template from `GroupBy` class. I think one possible fix is
creating a `_resample_agg_method_template` and using this template to create docstrings for the methods mentioned above.

I am a first-time contributor. Appreciate any suggestions and ideas for fixing this issue.
