### PR TITLE
TST: xfail(strict=False) flaky numexpr test

### DIFF
--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -833,8 +833,21 @@ class TestAlignment:
     )
     @pytest.mark.filterwarnings("ignore::RuntimeWarning")
     def test_basic_series_frame_alignment(
-        self, engine, parser, index_name, r_idx_type, c_idx_type
+        self, request, engine, parser, index_name, r_idx_type, c_idx_type
     ):
+        if (
+            engine == "numexpr"
+            and parser == "pandas"
+            and index_name == "index"
+            and r_idx_type == "i"
+            and c_idx_type == "c"
+        ):
+            reason = (
+                f"Flaky column ordering when engine={engine}, "
+                f"parser={parser}, index_name={index_name}, "
+                f"r_idx_type={r_idx_type}, c_idx_type={c_idx_type}"
+            )
+            request.node.add_marker(pytest.mark.xfail(reason=reason, strict=False))
         df = tm.makeCustomDataframe(
             10, 7, data_gen_f=f, r_idx_type=r_idx_type, c_idx_type=c_idx_type
         )


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Seen in a few builds

https://github.com/pandas-dev/pandas/runs/6052443919?check_suite_focus=true
https://github.com/pandas-dev/pandas/runs/6052443074?check_suite_focus=true

```
=================================== FAILURES ===================================
__ TestAlignment.test_basic_series_frame_alignment[numexpr-pandas-i-s-index] ___
[gw0] linux -- Python 3.10.4 /usr/share/miniconda/envs/pandas-dev/bin/python

self = <pandas.tests.computation.test_eval.TestAlignment object at 0x7f86e56d6b00>
engine = 'numexpr', parser = 'pandas', index_name = 'index', r_idx_type = 'i'
c_idx_type = 's'

    @pytest.mark.parametrize("index_name", ["index", "columns"])
    @pytest.mark.parametrize(
        "r_idx_type, c_idx_type",
        list(product(["i", "u", "s"], ["i", "u", "s"])) + [("dt", "dt")],
    )
    @pytest.mark.filterwarnings("ignore::RuntimeWarning")
    def test_basic_series_frame_alignment(
        self, engine, parser, index_name, r_idx_type, c_idx_type
    ):
        df = tm.makeCustomDataframe(
            10, 7, data_gen_f=f, r_idx_type=r_idx_type, c_idx_type=c_idx_type
        )
        index = getattr(df, index_name)
        s = Series(np.random.randn(5), index[:5])
        if should_warn(s.index, df.index):
            with tm.assert_produces_warning(RuntimeWarning):
                res = pd.eval("s + df", engine=engine, parser=parser)
        else:
            res = pd.eval("s + df", engine=engine, parser=parser)
    
        if r_idx_type == "dt" or c_idx_type == "dt":
            expected = df.add(s) if engine == "numexpr" else s + df
        else:
            expected = s + df
>       tm.assert_frame_equal(res, expected)

pandas/tests/computation/test_eval.py:853: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
pandas/_libs/testing.pyx:52: in pandas._libs.testing.assert_almost_equal
    cpdef assert_almost_equal(a, b,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   raise_assert_detail(obj, msg, lobj, robj, index_values=index_values)
E   AssertionError: DataFrame.columns are different
E   
E   DataFrame.columns values are different (100.0 %)
E   [left]:  Index([           0,            1,            2,            3,            4,
E          '1uPmHSYZ5l', '89NmFYDIOy', 'MxzsqA02uI', 'RamOYq02XE', 'a07yqdDij6',
E          'lK9fuRNolw', 'mOsLpdbrNC'],
E         dtype='object')
E   [right]: Index(['1uPmHSYZ5l', '89NmFYDIOy', 'MxzsqA02uI', 'RamOYq02XE', 'a07yqdDij6',
E          'lK9fuRNolw', 'mOsLpdbrNC',            0,            1,            2,
E                     3,            4],
E         dtype='object')
```
