### PR TITLE
ENH: Add axis=None for statistical methods

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10675,16 +10675,16 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             # user must have explictly passed axis=None and numeric_only=True
             # Converting to numpy array since using numpy statistical methods
             arr = self.to_numpy()
-            if name=="max":
+            if name == "max":
                 if skipna:
                     return arr.max(axis=axis)
-            elif name=="min":
+            elif name == "min":
                 if skipna:
                     return arr.min(axis=axis)
-            elif name=="mean":
+            elif name == "mean":
                 if skipna:
                     return arr.mean(axis=axis)
-            elif name=="median":
+            elif name == "median":
                 if skipna:
                     return np.median(arr, axis=axis)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10671,6 +10671,23 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         validate_bool_kwarg(skipna, "skipna", none_allowed=False)
 
+        if axis is None and level is None and self.ndim > 1 and numeric_only:
+            # user must have explictly passed axis=None and numeric_only=True
+            # Converting to numpy array since using numpy statistical methods
+            arr = self.to_numpy()
+            if name=="max":
+                if skipna:
+                    return arr.max(axis=axis)
+            elif name=="min":
+                if skipna:
+                    return arr.min(axis=axis)
+            elif name=="mean":
+                if skipna:
+                    return arr.mean(axis=axis)
+            elif name=="median":
+                if skipna:
+                    return np.median(arr, axis=axis)
+
         if axis is None and level is None and self.ndim > 1:
             # user must have explicitly passed axis=None
             # GH#21597

--- a/pandas/tests/frame/test_methods_none.py
+++ b/pandas/tests/frame/test_methods_none.py
@@ -1,0 +1,136 @@
+"""Test For axis=None."""
+from pandas import (
+    DataFrame,
+)
+
+
+class TestDataFrameNone:
+    """TestDataFrameReductions class."""
+    def test_any_all_int(self):
+        """Other methods should model this behavior."""
+        # DataFrame consists of ints
+        df_1 = DataFrame(
+            {
+                "foo1": [1, 10, 15],
+                "foo": [4, 5, 6]
+            }
+        )
+
+        res = df_1.any(axis=None)
+        exp = True
+        assert res == exp
+
+        # DataFrame consists of ints
+        df_2 = DataFrame(
+            {
+                "foo1": [2, 4, 1],
+                "foo": [1, 1, 0]
+            }
+        )
+
+        res = df_2.all(axis=None)
+        exp = False
+        assert res == exp
+
+    def test_min_max_int(self):
+        """Testing methods min and max."""
+        # DataFrame consists of ints
+        df_1 = DataFrame(
+            {
+                "foo1": [1, 10, 15],
+                "foo": [4, 5, 6]
+            }
+        )
+
+        res = df_1.max(axis=None, numeric_only=True)
+        exp = 15
+        assert res == exp
+
+        # DataFrame consists of ints
+        df_2 = DataFrame(
+            {
+                "foo1": [10, 99, 13],
+                "foo": [2, 5, 7]
+            }
+        )
+
+        res = df_2.max(axis=None, numeric_only=True)
+        exp = 99
+        assert res == exp
+
+        # DataFrame consists of ints
+        df_3 = DataFrame(
+            {
+                "foo1": [1, 10, 15],
+                "foo": [4, 5, 6]
+            }
+        )
+
+        res = df_3.min(axis=None, numeric_only=True)
+        exp = 1
+        assert res == exp
+
+        # DataFrame consists of ints
+        df_4 = DataFrame(
+            {
+                "foo1": [10, 99, 13],
+                "foo": [2, 5, 7]
+            }
+        )
+
+        res = df_4.min(axis=None, numeric_only=True)
+        exp = 2
+        assert res == exp
+
+    def test_mean_int(self):
+        """Testing method mean."""
+        # DataFrame consists of ints
+        df_1 = DataFrame(
+            {
+                "foo1": [1, 10, 15],
+                "foo": [4, 5, 6]
+            }
+        )
+
+        res = df_1.mean(axis=None, numeric_only=True)
+        exp = 41/6
+        assert res == exp
+
+        # DataFrame consists of ints
+        df_2 = DataFrame(
+            {
+                "foo1": [10, 99, 13],
+                "foo": [2, 5, 7]
+            }
+        )
+
+        res = df_2.mean(axis=None, numeric_only=True)
+        exp = 136/6
+        assert res == exp
+
+    def test_median_int(self):
+        """Testing method median."""
+        # DataFrame consists of ints
+        df_1 = DataFrame(
+            {
+                "foo1": [1, 10, 15],
+                "foo": [4, 5, 6]
+            }
+        )
+
+        res = df_1.median(axis=None, numeric_only=True)
+        exp = 5.5
+        assert res == exp
+
+        # DataFrame consists of ints
+        df_2 = DataFrame(
+            {
+                "foo1": [10, 99, 13],
+                "foo": [2, 5, 7],
+                "foo2": [1, 6, 5]
+            }
+        )
+
+        res = df_2.median(axis=None, numeric_only=True)
+        exp = 6
+        assert res == exp

--- a/pandas/tests/frame/test_methods_none.py
+++ b/pandas/tests/frame/test_methods_none.py
@@ -93,7 +93,7 @@ class TestDataFrameNone:
         )
 
         res = df_1.mean(axis=None, numeric_only=True)
-        exp = 41/6
+        exp = 41 / 6
         assert res == exp
 
         # DataFrame consists of ints
@@ -105,7 +105,7 @@ class TestDataFrameNone:
         )
 
         res = df_2.mean(axis=None, numeric_only=True)
-        exp = 136/6
+        exp = 136 / 6
         assert res == exp
 
     def test_median_int(self):


### PR DESCRIPTION
Issue #43889. Adding axis=None option for statistical methods: .min, .max, .median, and .mean.