### PR TITLE
ENH: adding saving and reading of dataframe `attrs` field in parquet metadata

### DIFF
--- a/ci/deps/actions-38-minimum_versions.yaml
+++ b/ci/deps/actions-38-minimum_versions.yaml
@@ -25,7 +25,7 @@ dependencies:
   - blosc=1.20.1
   - bottleneck=1.3.1
   - brotlipy=0.7.0
-  - fastparquet=0.4.0
+  - fastparquet=0.6.0
   - fsspec=0.7.4
   - html5lib=1.1
   - hypothesis=5.5.3

--- a/pandas/compat/_optional.py
+++ b/pandas/compat/_optional.py
@@ -14,7 +14,7 @@ VERSIONS = {
     "blosc": "1.20.1",
     "bottleneck": "1.3.1",
     "brotli": "0.7.0",
-    "fastparquet": "0.4.0",
+    "fastparquet": "0.6.0",
     "fsspec": "0.7.4",
     "html5lib": "1.1",
     "hypothesis": "5.5.3",

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import io
 import os
-from typing import Any
+from typing import Any, Union
 from warnings import catch_warnings
 from json import (dumps as json_dumps, 
                   loads as json_loads)
@@ -278,8 +278,10 @@ class PyArrowImpl(BaseImpl):
                                                        **kwargs)
             
             result: DataFrame = result_table.to_pandas(**to_pandas_kwargs)
-            metadata: dict = result_table.schema.metadata
-            if metadata.get('pandas_attrs'.encode(), None) is not None:
+            # TODO: figure out when metadata is None
+            metadata: Union[dict, None] = result_table.schema.metadata
+            if (metadata is not None and
+                metadata.get('pandas_attrs'.encode(), None) is not None):
                 result.attrs = json_loads(metadata['pandas_attrs'.encode()].decode())
 
             if manager == "array":

--- a/scripts/tests/test_read_write_parquet_w_attrs.py
+++ b/scripts/tests/test_read_write_parquet_w_attrs.py
@@ -1,29 +1,33 @@
-import pytest
 from typing import Union
+
+import pytest
+
 import pandas as pd
-from os import remove
+import pandas._testing as tm
+
 
 @pytest.fixture
 def dataframe(attr_param: Union[list, None, int, float, str]) -> pd.DataFrame:
-    df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
-    df.attrs['test_attr'] = attr_param
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    df.attrs["test_attr"] = attr_param
     return df
 
-@pytest.mark.parametrize('attr_param', [[1,2,3], ['a', 'b', 'c'],None, 'test_attr_str', 1, 1.0])
+
+@pytest.mark.parametrize(
+    "attr_param", [[1, 2, 3], ["a", "b", "c"], None, "test_attr_str", 1, 1.0]
+)
 def test_read_write_pyarrow(dataframe):
-    dataframe.to_parquet('test_read_write_parquet_w_attrs.parquet', 
-                         engine='pyarrow')
-    dataframe_read = pd.read_parquet('test_read_write_parquet_w_attrs.parquet', 
-                                     engine='pyarrow')
-    remove('test_read_write_parquet_w_attrs.parquet')
+    with tm.ensure_clean("__tmp_to_parquet_from_parquet__") as path:
+        dataframe.to_parquet(path, engine="pyarrow")
+        dataframe_read = pd.read_parquet(path, engine="pyarrow")
     assert dataframe.attrs == dataframe_read.attrs
-    
-@pytest.mark.parametrize('attr_param', [[1,2,3], ['a', 'b', 'c'],None, 'test_attr_str', 1, 1.0])
+
+
+@pytest.mark.parametrize(
+    "attr_param", [[1, 2, 3], ["a", "b", "c"], None, "test_attr_str", 1, 1.0]
+)
 def test_read_write_fastparquet(dataframe):
-    dataframe.to_parquet('test_read_write_parquet_w_attrs.parquet', 
-                         engine='fastparquet')
-    dataframe_read = pd.read_parquet('test_read_write_parquet_w_attrs.parquet', 
-                                     engine='fastparquet')
-    remove('test_read_write_prquet_w_attrs.parquet')
+    with tm.ensure_clean("__tmp_to_parquet_from_parquet__") as path:
+        dataframe.to_parquet(path, engine="fastparquet")
+        dataframe_read = pd.read_parquet(path, engine="fastparquet")
     assert dataframe.attrs == dataframe_read.attrs
-    

--- a/scripts/tests/test_read_write_parquet_w_attrs.py
+++ b/scripts/tests/test_read_write_parquet_w_attrs.py
@@ -1,0 +1,29 @@
+import pytest
+from typing import Union
+import pandas as pd
+from os import remove
+
+@pytest.fixture
+def dataframe(attr_param: Union[list, None, int, float, str]) -> pd.DataFrame:
+    df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
+    df.attrs['test_attr'] = attr_param
+    return df
+
+@pytest.mark.parametrize('attr_param', [[1,2,3], ['a', 'b', 'c'],None, 'test_attr_str', 1, 1.0])
+def test_read_write_pyarrow(dataframe):
+    dataframe.to_parquet('test_read_write_parquet_w_attrs.parquet', 
+                         engine='pyarrow')
+    dataframe_read = pd.read_parquet('test_read_write_parquet_w_attrs.parquet', 
+                                     engine='pyarrow')
+    remove('test_read_write_parquet_w_attrs.parquet')
+    assert dataframe.attrs == dataframe_read.attrs
+    
+@pytest.mark.parametrize('attr_param', [[1,2,3], ['a', 'b', 'c'],None, 'test_attr_str', 1, 1.0])
+def test_read_write_fastparquet(dataframe):
+    dataframe.to_parquet('test_read_write_parquet_w_attrs.parquet', 
+                         engine='fastparquet')
+    dataframe_read = pd.read_parquet('test_read_write_parquet_w_attrs.parquet', 
+                                     engine='fastparquet')
+    remove('test_read_write_prquet_w_attrs.parquet')
+    assert dataframe.attrs == dataframe_read.attrs
+    


### PR DESCRIPTION
I implemented the saving and reading of the custom `attrs` field of a dataframe inside parquet files. This is done using a field called `"pandas_attrs"` inside the parquet metadata, even though this passage is hidden to the user, who can just keep on using `to_parquet` and `pandas.read_parquet` as before.
I hope it might be interesting to someone to use, since it allows to retain information which otherwise would need custom setup or be lost.

I left some 'TODOs', even though may not be strictly necessary.

The modifications allow for this paradigm to be implemented for both engines, i.e. `pyarrow` and `fastparquet`, with their own caveats. 

I wrote a simple pytest, which I locally managed to pass. I am not 100% sure it is the correct way, even though I follow the [guidelines](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests).

I shall leave some default checklist, but I am not sure it is needed.
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).