### PR TITLE
DOC: fix rsplit doc

### DIFF
--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -660,7 +660,7 @@ class StringMethods(NoNewAttributesMixin):
     Parameters
     ----------
     pat : str%(pat_regex)s, optional
-        String or regular expression to split on.
+        %(pat_description)s.
         If not specified, split on whitespace.
     n : int, default -1 (all)
         Limit number of splits in output.
@@ -771,7 +771,37 @@ class StringMethods(NoNewAttributesMixin):
     0          this is a regular sentence        None
     1  https://docs.python.org/3/tutorial  index.html
     2                                 NaN         NaN
+    %(regex_examples)s"""
 
+    @Appender(
+        _shared_docs["str_split"]
+        % {
+            "side": "beginning",
+            "pat_regex": " or compiled regex",
+            "pat_description": "String or regular expression to split on",
+            "regex_argument": """
+    regex : bool, default None
+        Determines if the passed-in pattern is a regular expression:
+
+        - If ``True``, assumes the passed-in pattern is a regular expression
+        - If ``False``, treats the pattern as a literal string.
+        - If ``None`` and `pat` length is 1, treats `pat` as a literal string.
+        - If ``None`` and `pat` length is not 1, treats `pat` as a regular expression.
+        - Cannot be set to False if `pat` is a compiled regex
+
+        .. versionadded:: 1.4.0
+         """,
+            "raises_split": """
+                      Raises
+                      ------
+                      ValueError
+                          * if `regex` is False and `pat` is a compiled regex
+                      """,
+            "regex_pat_note": """
+    Use of `regex =False` with a `pat` as a compiled regex will raise an error.
+            """,
+            "method": "split",
+            "regex_examples": r"""
     Remember to escape special characters when explicitly using regular expressions.
 
     >>> s = pd.Series(["foo and bar plus baz"])
@@ -810,35 +840,7 @@ class StringMethods(NoNewAttributesMixin):
     >>> s.str.split(r"\.jpg", regex=False, expand=True)
                    0
     0  foojpgbar.jpg
-    """
-
-    @Appender(
-        _shared_docs["str_split"]
-        % {
-            "side": "beginning",
-            "pat_regex": " or compiled regex",
-            "regex_argument": """
-    regex : bool, default None
-        Determines if the passed-in pattern is a regular expression:
-
-        - If ``True``, assumes the passed-in pattern is a regular expression
-        - If ``False``, treats the pattern as a literal string.
-        - If ``None`` and `pat` length is 1, treats `pat` as a literal string.
-        - If ``None`` and `pat` length is not 1, treats `pat` as a regular expression.
-        - Cannot be set to False if `pat` is a compiled regex
-
-        .. versionadded:: 1.4.0
-         """,
-            "raises_split": """
-                      Raises
-                      ------
-                      ValueError
-                          * if `regex` is False and `pat` is a compiled regex
-                      """,
-            "regex_pat_note": """
-    Use of `regex =False` with a `pat` as a compiled regex will raise an error.
-            """,
-            "method": "split",
+    """,
         }
     )
     @forbid_nonstring_types(["bytes"])
@@ -864,10 +866,12 @@ class StringMethods(NoNewAttributesMixin):
         % {
             "side": "end",
             "pat_regex": "",
+            "pat_description": "String to split on",
             "regex_argument": "",
             "raises_split": "",
             "regex_pat_note": "",
             "method": "rsplit",
+            "regex_examples": "",
         }
     )
     @forbid_nonstring_types(["bytes"])

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -659,7 +659,7 @@ class StringMethods(NoNewAttributesMixin):
 
     Parameters
     ----------
-    pat : str or compiled regex, optional
+    pat : str%(pat_regex)s, optional
         String or regular expression to split on.
         If not specified, split on whitespace.
     n : int, default -1 (all)
@@ -670,28 +670,12 @@ class StringMethods(NoNewAttributesMixin):
 
         - If ``True``, return DataFrame/MultiIndex expanding dimensionality.
         - If ``False``, return Series/Index, containing lists of strings.
-
-    regex : bool, default None
-        Determines if the passed-in pattern is a regular expression:
-
-        - If ``True``, assumes the passed-in pattern is a regular expression
-        - If ``False``, treats the pattern as a literal string.
-        - If ``None`` and `pat` length is 1, treats `pat` as a literal string.
-        - If ``None`` and `pat` length is not 1, treats `pat` as a regular expression.
-        - Cannot be set to False if `pat` is a compiled regex
-
-        .. versionadded:: 1.4.0
-
+    %(regex_argument)s
     Returns
     -------
     Series, Index, DataFrame or MultiIndex
         Type matches caller unless ``expand=True`` (see Notes).
-
-    Raises
-    ------
-    ValueError
-        * if `regex` is False and `pat` is a compiled regex
-
+    %(raises_split)s
     See Also
     --------
     Series.str.split : Split strings around given separator/delimiter.
@@ -713,10 +697,7 @@ class StringMethods(NoNewAttributesMixin):
 
     If using ``expand=True``, Series and Index callers return DataFrame and
     MultiIndex objects, respectively.
-
-    Use of `regex=False` with a `pat` as a compiled regex will raise
-    an error.
-
+    %(regex_pat_note)s
     Examples
     --------
     >>> s = pd.Series(
@@ -831,7 +812,35 @@ class StringMethods(NoNewAttributesMixin):
     0  foojpgbar.jpg
     """
 
-    @Appender(_shared_docs["str_split"] % {"side": "beginning", "method": "split"})
+    @Appender(
+        _shared_docs["str_split"]
+        % {
+            "side": "beginning",
+            "pat_regex": " or compiled regex",
+            "regex_argument": """
+    regex : bool, default None
+        Determines if the passed-in pattern is a regular expression:
+
+        - If ``True``, assumes the passed-in pattern is a regular expression
+        - If ``False``, treats the pattern as a literal string.
+        - If ``None`` and `pat` length is 1, treats `pat` as a literal string.
+        - If ``None`` and `pat` length is not 1, treats `pat` as a regular expression.
+        - Cannot be set to False if `pat` is a compiled regex
+
+        .. versionadded:: 1.4.0
+         """,
+            "raises_split": """
+                      Raises
+                      ------
+                      ValueError
+                          * if `regex` is False and `pat` is a compiled regex
+                      """,
+            "regex_pat_note": """
+    Use of `regex =False` with a `pat` as a compiled regex will raise an error.
+            """,
+            "method": "split",
+        }
+    )
     @forbid_nonstring_types(["bytes"])
     def split(
         self,
@@ -850,7 +859,17 @@ class StringMethods(NoNewAttributesMixin):
         result = self._data.array._str_split(pat, n, expand, regex)
         return self._wrap_result(result, returns_string=expand, expand=expand)
 
-    @Appender(_shared_docs["str_split"] % {"side": "end", "method": "rsplit"})
+    @Appender(
+        _shared_docs["str_split"]
+        % {
+            "side": "end",
+            "pat_regex": "",
+            "regex_argument": "",
+            "raises_split": "",
+            "regex_pat_note": "",
+            "method": "rsplit",
+        }
+    )
     @forbid_nonstring_types(["bytes"])
     def rsplit(self, pat=None, n=-1, expand=False):
         result = self._data.array._str_rsplit(pat, n=n)


### PR DESCRIPTION
- [x] closes #46488 (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Gets rid of the `regex` argument in `.str.rsplit`. The docs for `.str.split` remains unchanged

<img width="954" alt="Screenshot 2022-04-22 at 14 07 54" src="https://user-images.githubusercontent.com/15383974/164720328-0375c2d1-ce65-45d1-81f6-968c5869f059.png">

<img width="882" alt="Screenshot 2022-04-22 at 14 10 55" src="https://user-images.githubusercontent.com/15383974/164720818-d202d4eb-fa27-4fb6-8af4-a0e3151fde0a.png">

