### PR TITLE
Add "rows" as option to "axis" docstring

### DIFF
--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -171,7 +171,7 @@ def concat(
         argument, unless it is passed, in which case the values will be
         selected (see below). Any None objects will be dropped silently unless
         they are all None in which case a ValueError will be raised.
-    axis : {0/'index', 1/'columns'}, default 0
+    axis : {0 or 'index' or 'rows', 1 or 'columns'}, default 0
         The axis to concatenate along.
     join : {'inner', 'outer'}, default 'outer'
         How to handle indexes on other axis (or axes).


### PR DESCRIPTION
The "axis" parameter of `pd.concat()` can take the string `'rows'` as an optional way of explicitly defining the default row axis for concatenation:

```python
import pandas as pd

pd.concat([pd.DataFrame(), pd.DataFrame()], axis="rows")
```

Using `'rows'` instead of `'index'` or `0` might be more intuitive as a counterpart to `'columns'`. In any case, it's a possible option, so it might be helpful to represent that in the docstring.

The proposed update in the docstring uses the suggested format based on pandas docstring guide:
https://pandas.pydata.org/docs/dev/development/contributing_docstring.html#parameter-types

>For axis, the convention is to use something like:
>axis : {0 or ‘index’, 1 or ‘columns’, None}, default None

- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
