### PR TITLE
TST: Fix flaky xfail condition typo

### DIFF
--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -840,7 +840,7 @@ class TestAlignment:
             and parser == "pandas"
             and index_name == "index"
             and r_idx_type == "i"
-            and c_idx_type == "c"
+            and c_idx_type == "s"
         ):
             reason = (
                 f"Flaky column ordering when engine={engine}, "


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

This flaky test resurfaced in https://github.com/pandas-dev/pandas/runs/6152914367?check_suite_focus=true but that was due to a typo in the if condition in https://github.com/pandas-dev/pandas/pull/46796
