### PR TITLE
BUG: extra row created when calling to_excel for multi-index columns

### DIFF
--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -705,8 +705,8 @@ class ExcelFormatter:
             else:
                 index_label = self.df.index.names[0]
 
-            if isinstance(self.columns, MultiIndex):
-                self.rowcounter += 1
+            # if isinstance(self.columns, MultiIndex):
+            #     self.rowcounter += 1
 
             if index_label and self.header is not False:
                 yield ExcelCell(self.rowcounter - 1, 0, index_label, self.header_style)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.



When multi-level columns are written into excel, use to_ Excel method, there will be an extra row in the saved xlsx file

![image](https://user-images.githubusercontent.com/20391209/165278268-c8319b4f-572b-4b37-8ba8-f0ed4318f053.png)

I tried to fix and welcome to comment for this update.


