### PR TITLE
PERF: Improve SeriesGroupBy.value_counts performances with categorical values.

### DIFF
--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -677,6 +677,15 @@ class Categories:
     def time_groupby_extra_cat_nosort(self):
         self.df_extra_cat.groupby("a", sort=False)["b"].count()
 
+    def time_series_groupby_value_counts_many_categories(self):
+        df = self.df_extra_cat[0:10**4]
+        df.groupby("b")["a"].value_counts()
+
+    def time_series_groupby_value_counts_few_categories(self):
+        df = self.df_extra_cat[0:10**4].copy()
+        df["a"] = df["a"].cat.remove_unused_categories()
+        df.groupby("b")["a"].value_counts()
+
 
 class Datelike:
     # GH 14338

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -468,6 +468,7 @@ Performance improvements
 - Performance improvement when setting values in a pyarrow backed string array (:issue:`46400`)
 - Performance improvement in :func:`factorize` (:issue:`46109`)
 - Performance improvement in :class:`DataFrame` and :class:`Series` constructors for extension dtype scalars (:issue:`45854`)
+- Performance improvement in :meth:`SeriesGroupBy.value_counts` with categorical values. (:issue:`46202`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_150.bug_fixes:


### PR DESCRIPTION
- [X] closes #46202
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

The performance issue comes from the fact the categorical path relies on `GroupBy.apply`. Actually, `SeriesGroupby.value_counts` and `DataFrameGroupBy.value_counts` have different implementations, and I feel they should both rely on a single one. Typically, the Series implementation looks more complicated than the DataFrame one (which relies on `GroupBy.size`), this is why this change creates a `DataFrameGroupBy` object to rely on the DataFrame implementation. Ideally, I think the entire Series implementation could rely on the DataFrame one (not only the categorical path). Also, I have a small doubt whether creating a new `DataFrameGroupBy` object out of a `SeriesGroupBy` one is a good practice or not, so if there is a better way to do here feel free to suggest it.

Note I did not add a test in this PR as it fixes performance only, but I manually tested and confirmed the performance improvement.