### PR TITLE
DOC: fix cookbook groupby & transform example

### DIFF
--- a/doc/source/user_guide/cookbook.rst
+++ b/doc/source/user_guide/cookbook.rst
@@ -511,7 +511,7 @@ Unlike agg, apply's callable is passed a sub-DataFrame which gives you access to
 
    def replace(g):
        mask = g < 0
-       return g.where(mask, g[~mask].mean())
+       return g.where(~mask, g[~mask].mean())
 
    gb.transform(replace)
 


### PR DESCRIPTION
In the example, all negative values of a group should be replaced by the mean of the rest of the group. The linked stackoverflow output has it right: https://stackoverflow.com/questions/14760757/replacing-values-with-groupby-means

We have to negate the first argument of `DataFrame.where` here, since this should be the condition when the value stays the same (and this should be the case for `g>=0`.)

pandas `df.where` behavior is pretty weird when coming from Spark world :)


- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
