### PR TITLE
ENH: Timestamp.month_name, day_name support non-nano

### DIFF
--- a/asv_bench/benchmarks/tslibs/fields.py
+++ b/asv_bench/benchmarks/tslibs/fields.py
@@ -66,9 +66,9 @@ class TimeGetStartEndField:
 
     def setup(self, size, side, period, freqstr, month_kw):
         arr = np.random.randint(0, 10, size=size, dtype="i8")
-        self.dt64data = arr.view("M8[ns]")
+        self.i8data = arr
 
         self.attrname = f"is_{period}_{side}"
 
     def time_get_start_end_field(self, size, side, period, freqstr, month_kw):
-        get_start_end_field(self.dt64data, self.attrname, freqstr, month_kw=month_kw)
+        get_start_end_field(self.i8data, self.attrname, freqstr, month_kw=month_kw)

--- a/pandas/_libs/tslibs/fields.pyi
+++ b/pandas/_libs/tslibs/fields.pyi
@@ -7,7 +7,7 @@ def build_field_sarray(
 ) -> np.ndarray: ...
 def month_position_check(fields, weekdays) -> str | None: ...
 def get_date_name_field(
-    dtindex: npt.NDArray[np.int64],
+    dtindex: npt.NDArray[np.int64],  # const int64_t[:]
     field: str,
     locale: str | None = ...,
     reso: int = ...,  # NPY_DATETIMEUNIT

--- a/pandas/_libs/tslibs/fields.pyi
+++ b/pandas/_libs/tslibs/fields.pyi
@@ -7,15 +7,17 @@ def build_field_sarray(
 ) -> np.ndarray: ...
 def month_position_check(fields, weekdays) -> str | None: ...
 def get_date_name_field(
-    dtindex: npt.NDArray[np.int64],  # const int64_t[:]
+    dtindex: npt.NDArray[np.int64],
     field: str,
     locale: str | None = ...,
+    reso: int = ...,  # NPY_DATETIMEUNIT
 ) -> npt.NDArray[np.object_]: ...
 def get_start_end_field(
-    dt64values: npt.NDArray[np.datetime64],
+    dtindex: npt.NDArray[np.int64],
     field: str,
     freqstr: str | None = ...,
     month_kw: int = ...,
+    reso: int = ...,  # NPY_DATETIMEUNIT
 ) -> npt.NDArray[np.bool_]: ...
 def get_date_field(
     dtindex: npt.NDArray[np.int64],  # const int64_t[:]

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -487,7 +487,6 @@ cdef class _Timestamp(ABCTimestamp):
             dict kwds
             ndarray[uint8_t, cast=True] out
             int month_kw
-            str unit
 
         if freq:
             kwds = freq.kwds
@@ -499,9 +498,8 @@ cdef class _Timestamp(ABCTimestamp):
 
         val = self._maybe_convert_value_to_local()
 
-        unit = npy_unit_to_abbrev(self._reso)
-        out = get_start_end_field(np.array([val], dtype=f"M8[{unit}]"),
-                                  field, freqstr, month_kw)
+        out = get_start_end_field(np.array([val], dtype=np.int64),
+                                  field, freqstr, month_kw, self._reso)
         return out[0]
 
     cdef _warn_on_field_deprecation(self, freq, str field):
@@ -661,12 +659,10 @@ cdef class _Timestamp(ABCTimestamp):
             int64_t val
             object[::1] out
 
-        if self._reso != NPY_FR_ns:
-            raise NotImplementedError(self._reso)
-
         val = self._maybe_convert_value_to_local()
+
         out = get_date_name_field(np.array([val], dtype=np.int64),
-                                  field, locale=locale)
+                                  field, locale=locale, reso=self._reso)
         return out[0]
 
     def day_name(self, locale=None) -> str:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -38,11 +38,13 @@ from pandas._libs.tslibs import (
     tz_convert_from_utc,
     tzconversion,
 )
+from pandas._libs.tslibs.np_datetime import py_get_unit_from_dtype
 from pandas._typing import npt
 from pandas.errors import (
     OutOfBoundsDatetime,
     PerformanceWarning,
 )
+from pandas.util._decorators import cache_readonly
 from pandas.util._exceptions import find_stack_level
 from pandas.util._validators import validate_inclusive
 
@@ -131,7 +133,7 @@ def _field_accessor(name: str, field: str, docstring=None):
                     month_kw = kwds.get("startingMonth", kwds.get("month", 12))
 
                 result = fields.get_start_end_field(
-                    values.view(self._ndarray.dtype), field, self.freqstr, month_kw
+                    values, field, self.freqstr, month_kw, reso=self._reso
                 )
             else:
                 result = fields.get_date_field(values, field)
@@ -140,7 +142,7 @@ def _field_accessor(name: str, field: str, docstring=None):
             return result
 
         if field in self._object_ops:
-            result = fields.get_date_name_field(values, field)
+            result = fields.get_date_name_field(values, field, reso=self._reso)
             result = self._maybe_mask_results(result, fill_value=None)
 
         else:
@@ -543,6 +545,10 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
 
     # -----------------------------------------------------------------
     # Descriptive Properties
+
+    @cache_readonly
+    def _reso(self):
+        return py_get_unit_from_dtype(self._ndarray.dtype)
 
     def _box_func(self, x: np.datetime64) -> Timestamp | NaTType:
         # GH#42228
@@ -1270,7 +1276,9 @@ default 'raise'
         """
         values = self._local_timestamps()
 
-        result = fields.get_date_name_field(values, "month_name", locale=locale)
+        result = fields.get_date_name_field(
+            values, "month_name", locale=locale, reso=self._reso
+        )
         result = self._maybe_mask_results(result, fill_value=None)
         return result
 
@@ -1313,7 +1321,9 @@ default 'raise'
         """
         values = self._local_timestamps()
 
-        result = fields.get_date_name_field(values, "day_name", locale=locale)
+        result = fields.get_date_name_field(
+            values, "day_name", locale=locale, reso=self._reso
+        )
         result = self._maybe_mask_results(result, fill_value=None)
         return result
 

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -753,6 +753,14 @@ class TestNonNano:
             assert not ts.is_month_end
             assert not ts.is_month_end
 
+    def test_day_name(self, dt64, ts):
+        alt = Timestamp(dt64)
+        assert ts.day_name() == alt.day_name()
+
+    def test_month_name(self, dt64, ts):
+        alt = Timestamp(dt64)
+        assert ts.month_name() == alt.month_name()
+
     def test_repr(self, dt64, ts):
         alt = Timestamp(dt64)
 

--- a/pandas/tests/tslibs/test_fields.py
+++ b/pandas/tests/tslibs/test_fields.py
@@ -28,10 +28,7 @@ def test_get_date_field_readonly(dtindex):
 
 
 def test_get_start_end_field_readonly(dtindex):
-    dt64values = dtindex.view("M8[ns]")
-    dt64values.flags.writeable = False
-
-    result = fields.get_start_end_field(dt64values, "is_month_start", None)
+    result = fields.get_start_end_field(dtindex, "is_month_start", None)
     expected = np.array([True, False, False, False, False], dtype=np.bool_)
     tm.assert_numpy_array_equal(result, expected)
 


### PR DESCRIPTION
Should also fix an asv that currently fails when run on e.g. v1.4.0