### PR TITLE
TST: avoid chained assignment in tests outside of specific tests on chaining

### DIFF
--- a/pandas/tests/frame/methods/test_combine_first.py
+++ b/pandas/tests/frame/methods/test_combine_first.py
@@ -66,7 +66,7 @@ class TestDataFrameCombineFirst:
         assert (combined["A"][:10] == 1).all()
 
         # reverse overlap
-        tail["A"][:10] = 0
+        tail.iloc[:10, tail.columns.get_loc("A")] = 0
         combined = tail.combine_first(head)
         assert (combined["A"][:10] == 0).all()
 

--- a/pandas/tests/frame/methods/test_cov_corr.py
+++ b/pandas/tests/frame/methods/test_cov_corr.py
@@ -27,8 +27,8 @@ class TestDataFrameCov:
 
         # with NAs
         frame = float_frame.copy()
-        frame["A"][:5] = np.nan
-        frame["B"][5:10] = np.nan
+        frame.iloc[:5, frame.columns.get_loc("A")] = np.nan
+        frame.iloc[5:10, frame.columns.get_loc("B")] = np.nan
         result = frame.cov(min_periods=len(frame) - 8)
         expected = frame.cov()
         expected.loc["A", "B"] = np.nan

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1333,7 +1333,8 @@ class TestFrameArithmeticUnsorted:
         frame_copy = float_frame.reindex(float_frame.index[::2])
 
         del frame_copy["D"]
-        frame_copy["C"][:5] = np.nan
+        # adding NAs to first 5 values of column "C"
+        frame_copy.loc[: frame_copy.index[4], "C"] = np.nan
 
         added = float_frame + frame_copy
 

--- a/pandas/tests/groupby/test_apply_mutate.py
+++ b/pandas/tests/groupby/test_apply_mutate.py
@@ -72,7 +72,7 @@ def test_apply_function_with_indexing():
     )
 
     def fn(x):
-        x.col2[x.index[-1]] = 0
+        x.loc[x.index[-1], "col2"] = 0
         return x.col2
 
     result = df.groupby(["col1"], as_index=False).apply(fn)

--- a/pandas/tests/indexing/multiindex/test_partial.py
+++ b/pandas/tests/indexing/multiindex/test_partial.py
@@ -128,7 +128,7 @@ class TestMultiIndexPartial:
         df = ymd.copy()
         exp = ymd.copy()
         df.loc[2000, 4] = 0
-        exp.loc[2000, 4].values[:] = 0
+        exp.iloc[65:85] = 0
         tm.assert_frame_equal(df, exp)
 
         df["A"].loc[2000, 4] = 1
@@ -136,7 +136,7 @@ class TestMultiIndexPartial:
         tm.assert_frame_equal(df, exp)
 
         df.loc[2000] = 5
-        exp.loc[2000].values[:] = 5
+        exp.iloc[:100] = 5
         tm.assert_frame_equal(df, exp)
 
         # this works...for now

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -53,7 +53,7 @@ from pandas.tests.indexing.common import Base
 def test_not_change_nan_loc(series, new_series, expected_ser):
     # GH 28403
     df = DataFrame({"A": series})
-    df["A"].loc[:] = new_series
+    df.loc[:, "A"] = new_series
     expected = DataFrame({"A": expected_ser})
     tm.assert_frame_equal(df.isna(), expected)
     tm.assert_frame_equal(df.notna(), ~expected)


### PR DESCRIPTION
A small part of the test changes from #46958 that can be done separately.

We have specific tests about chained indexing (eg `test_chaining_and_caching.py`), so outside those specific tests, I can think we can avoid using chained indexing (regardless of #46958, this would follow our own recommendation on best indexing practices, although it also shows that some cases of mixed positional/label based setting is somewhat convoluted)