### PR TITLE
ENH: Implement nlargest and nsmallest for DataFrameGroupBy

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -150,7 +150,7 @@ Other enhancements
 - Added ``validate`` argument to :meth:`DataFrame.join` (:issue:`46622`)
 - A :class:`errors.PerformanceWarning` is now thrown when using ``string[pyarrow]`` dtype with methods that don't dispatch to ``pyarrow.compute`` methods (:issue:`42613`)
 - Added ``numeric_only`` argument to :meth:`Resampler.sum`, :meth:`Resampler.prod`, :meth:`Resampler.min`, :meth:`Resampler.max`, :meth:`Resampler.first`, and :meth:`Resampler.last` (:issue:`46442`)
-- Implemented :meth:`nlargest` and `nsmallest` for :class:`DataFrameGroupBy` (:issue:`46924`)
+- Implemented :meth:`nlargest` and :meth:`nsmallest` methods for :class:`DataFrameGroupBy` (:issue:`46924`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_150.notable_bug_fixes:

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -150,6 +150,7 @@ Other enhancements
 - Added ``validate`` argument to :meth:`DataFrame.join` (:issue:`46622`)
 - A :class:`errors.PerformanceWarning` is now thrown when using ``string[pyarrow]`` dtype with methods that don't dispatch to ``pyarrow.compute`` methods (:issue:`42613`)
 - Added ``numeric_only`` argument to :meth:`Resampler.sum`, :meth:`Resampler.prod`, :meth:`Resampler.min`, :meth:`Resampler.max`, :meth:`Resampler.first`, and :meth:`Resampler.last` (:issue:`46442`)
+- Implemented :meth:`nlargest` and `nsmallest` for :class:`DataFrameGroupBy` (:issue:`46924`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_150.notable_bug_fixes:

--- a/pandas/core/groupby/base.py
+++ b/pandas/core/groupby/base.py
@@ -33,6 +33,8 @@ common_apply_allowlist = (
             "corr",
             "cov",
             "diff",
+            "nlargest",
+            "nsmallest",
         ]
     )
     | plotting_methods
@@ -40,9 +42,7 @@ common_apply_allowlist = (
 
 series_apply_allowlist: frozenset[str] = (
     common_apply_allowlist
-    | frozenset(
-        {"nlargest", "nsmallest", "is_monotonic_increasing", "is_monotonic_decreasing"}
-    )
+    | frozenset({"is_monotonic_increasing", "is_monotonic_decreasing"})
 ) | frozenset(["dtype", "unique"])
 
 dataframe_apply_allowlist: frozenset[str] = common_apply_allowlist | frozenset(
@@ -155,6 +155,8 @@ groupby_other_methods = frozenset(
         "transform",
         "sample",
         "value_counts",
+        "nlargest",
+        "nsmallest",
     ]
 )
 # Valid values  of `name` for `groupby.transform(name)`

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1812,6 +1812,24 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                 result = result_frame
             return result.__finalize__(self.obj, method="value_counts")
 
+    @doc(DataFrame.nlargest)
+    def nlargest(self, n, columns, keep: str = "first"):
+        f = partial(DataFrame.nlargest, n=n, columns=columns, keep=keep)
+        data = self._obj_with_exclusions
+        # Don't change behavior if result index happens to be the same, i.e.
+        # already ordered and n >= all group sizes.
+        result = self._python_apply_general(f, data, not_indexed_same=True)
+        return result
+
+    @doc(DataFrame.nsmallest)
+    def nsmallest(self, n, columns, keep: str = "first"):
+        f = partial(DataFrame.nsmallest, n=n, columns=columns, keep=keep)
+        data = self._obj_with_exclusions
+        # Don't change behavior if result index happens to be the same, i.e.
+        # already ordered and n >= all group sizes.
+        result = self._python_apply_general(f, data, not_indexed_same=True)
+        return result
+
 
 def _wrap_transform_general_frame(
     obj: DataFrame, group: DataFrame, res: DataFrame | Series

--- a/pandas/tests/groupby/test_allowlist.py
+++ b/pandas/tests/groupby/test_allowlist.py
@@ -51,6 +51,8 @@ df_allowlist = [
     "corr",
     "cov",
     "diff",
+    "nlargest",
+    "nsmallest",
 ]
 
 
@@ -322,6 +324,8 @@ def test_tab_completion(mframe):
         "sample",
         "ewm",
         "value_counts",
+        "nlargest",
+        "nsmallest",
     }
     assert results == expected
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2724,25 +2724,67 @@ def test_by_column_values_with_same_starting_value():
 
 
 @pytest.mark.parametrize(
-    "function, indices, expected_data",
+    "function, keep, indices, name, data",
     [
-        ("nlargest", [("bar", 5), ("bar", 4), ("foo", 2), ("foo", 1)], [6, 5, 3, 2]),
-        ("nsmallest", [("bar", 3), ("bar", 4), ("foo", 0), ("foo", 1)], [4, 5, 1, 2]),
+        (
+            "nlargest",
+            "first",
+            [("bar", 1), ("bar", 2), ("foo", 5), ("foo", 3)],
+            ["b2", "b3", "f3", "f1"],
+            [3, 3, 3, 1],
+        ),
+        (
+            "nlargest",
+            "last",
+            [("bar", 2), ("bar", 1), ("foo", 5), ("foo", 4)],
+            ["b3", "b2", "f3", "f2"],
+            [3, 3, 3, 1],
+        ),
+        (
+            "nlargest",
+            "all",
+            [("bar", 1), ("bar", 2), ("foo", 5), ("foo", 3), ("foo", 4)],
+            ["b2", "b3", "f3", "f1", "f2"],
+            [3, 3, 3, 1, 1],
+        ),
+        (
+            "nsmallest",
+            "first",
+            [("bar", 0), ("bar", 1), ("foo", 3), ("foo", 4)],
+            ["b1", "b2", "f1", "f2"],
+            [1, 3, 1, 1],
+        ),
+        (
+            "nsmallest",
+            "last",
+            [("bar", 0), ("bar", 2), ("foo", 4), ("foo", 3)],
+            ["b1", "b3", "f2", "f1"],
+            [1, 3, 1, 1],
+        ),
+        (
+            "nsmallest",
+            "all",
+            [("bar", 0), ("bar", 1), ("bar", 2), ("foo", 3), ("foo", 4)],
+            ["b1", "b2", "b3", "f1", "f2"],
+            [1, 3, 3, 1, 1],
+        ),
     ],
 )
-def test_nlargest_nsmallest(function, indices, expected_data):
+def test_nlargest_nsmallest(function, keep, indices, name, data):
     # test nlargest and nsmallest for DataFrameGroupBy
     # GH46924
     df = DataFrame(
         {
-            "group": ["foo", "foo", "foo", "bar", "bar", "bar"],
-            "data": [1, 2, 3, 4, 5, 6],
+            "group": ["bar", "bar", "bar", "foo", "foo", "foo"],
+            "name": ["b1", "b2", "b3", "f1", "f2", "f3"],
+            "data": [1, 3, 3, 1, 1, 3],
         }
     )
     grouped = df.groupby("group")
     func = getattr(grouped, function)
-    result = func(n=2, columns="data")
+    result = func(n=2, keep=keep, columns="data")
+
     expected_index = MultiIndex.from_tuples(indices, names=["group", None])
-    expected = DataFrame({"data": expected_data}, index=expected_index)
+    expected = DataFrame({"name": name, "data": data}, index=expected_index)
 
     tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #46924 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v1.5.0.rst` file if fixing a bug or adding a new feature.

Try to implement `nlargest` and `nsmallest` methods for `DataFrameGroupBy`. Appreciate any comments.

```python
>>> df
  group name  data
0   bar   b1     1
1   bar   b2     3
2   bar   b3     3
3   foo   f1     1
4   foo   f2     1
5   foo   f3     3


>>> df.groupby("group").nlargest(n=2)
        name  data
group
bar   1   b2     3
      2   b3     3
foo   5   f3     3
      3   f1     1


>>> df.groupby("group").nlargest(n=2, keep="all")
        name  data
group
bar   1   b2     3
      2   b3     3
foo   5   f3     3
      3   f1     1
      4   f2     1

>>> df.groupby("group").nsmallest(n=2)
        name  data
group
bar   0   b1     1
      1   b2     3
foo   3   f1     1
      4   f2     1


>>> df.groupby("group").nsmallest(n=2, keep="all")
        name  data
group
bar   0   b1     1
      1   b2     3
      2   b3     3
foo   3   f1     1
      4   f2     1
```