### PR TITLE
DOC: Fix a typo in documentation for qyear

### DIFF
--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2202,7 +2202,7 @@ cdef class _Period(PeriodMixin):
         2018
 
         If the fiscal year starts in April (`Q-MAR`), the first quarter of
-        2018 will start in April 2017. `year` will then be 2018, but `qyear`
+        2018 will start in April 2017. `year` will then be 2017, but `qyear`
         will be the fiscal year, 2018.
 
         >>> per = pd.Period('2018Q1', freq='Q-MAR')


### PR DESCRIPTION
This fixes a typo that I ran across in the [documentation](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Period.qyear.html?highlight=qyear#pandas.Period.qyear). This change corrects the wording to match the given example that is just below.