### PR TITLE
REF: Manager.fast_xs to return SingleBlockManager instead of array

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3484,16 +3484,13 @@ class DataFrame(NDFrame, OpsMixin):
         """
         # irow
         if axis == 0:
-            new_values = self._mgr.fast_xs(i)
+            new_mgr = self._mgr.fast_xs(i)
 
             # if we are a copy, mark as such
-            copy = isinstance(new_values, np.ndarray) and new_values.base is None
-            result = self._constructor_sliced(
-                new_values,
-                index=self.columns,
-                name=self.index[i],
-                dtype=new_values.dtype,
-            ).__finalize__(self)
+            copy = isinstance(new_mgr.array, np.ndarray) and new_mgr.array.base is None
+            result = self._constructor_sliced(new_mgr, name=self.index[i]).__finalize__(
+                self
+            )
             result._set_is_copy(self, copy=copy)
             return result
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3815,13 +3815,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 # so just return them (GH 6394)
                 return self._values[loc]
 
-            new_values = self._mgr.fast_xs(loc)
+            new_mgr = self._mgr.fast_xs(loc)
 
             result = self._constructor_sliced(
-                new_values,
-                index=self.columns,
-                name=self.index[loc],
-                dtype=new_values.dtype,
+                new_mgr, name=self.index[loc]
             ).__finalize__(self)
         elif is_scalar(loc):
             result = self.iloc[:, slice(loc, loc + 1)]

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -749,7 +749,7 @@ class ArrayManager(BaseArrayManager):
     # --------------------------------------------------------------------
     # Indexing
 
-    def fast_xs(self, loc: int) -> ArrayLike:
+    def fast_xs(self, loc: int) -> SingleArrayManager:
         """
         Return the array corresponding to `frame.iloc[loc]`.
 
@@ -773,7 +773,7 @@ class ArrayManager(BaseArrayManager):
             result = TimedeltaArray._from_sequence(values, dtype=dtype)._data
         else:
             result = np.array(values, dtype=dtype)
-        return result
+        return SingleArrayManager([result], [self._axes[1]])
 
     def get_slice(self, slobj: slice, axis: int = 0) -> ArrayManager:
         axis = self._normalize_axis(axis)
@@ -1261,7 +1261,7 @@ class SingleArrayManager(BaseArrayManager, SingleDataManager):
     def is_single_block(self) -> bool:
         return True
 
-    def fast_xs(self, loc: int) -> ArrayLike:
+    def fast_xs(self, loc: int) -> SingleArrayManager:
         raise NotImplementedError("Use series._values[loc] instead")
 
     def get_slice(self, slobj: slice, axis: int = 0) -> SingleArrayManager:

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -945,7 +945,7 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
     # ----------------------------------------------------------------
     # Indexing
 
-    def fast_xs(self, loc: int) -> ArrayLike:
+    def fast_xs(self, loc: int) -> SingleBlockManager:
         """
         Return the array corresponding to `frame.iloc[loc]`.
 
@@ -958,7 +958,9 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         np.ndarray or ExtensionArray
         """
         if len(self.blocks) == 1:
-            return self.blocks[0].iget((slice(None), loc))
+            result = self.blocks[0].iget((slice(None), loc))
+            block = new_block(result, placement=slice(0, len(result)), ndim=1)
+            return SingleBlockManager(block, self.axes[0])
 
         dtype = interleaved_dtype([blk.dtype for blk in self.blocks])
 
@@ -976,7 +978,8 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
             for i, rl in enumerate(blk.mgr_locs):
                 result[rl] = blk.iget((i, loc))
 
-        return result
+        block = new_block(result, placement=slice(0, len(result)), ndim=1)
+        return SingleBlockManager(block, self.axes[0])
 
     def iget(self, i: int) -> SingleBlockManager:
         """

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -1355,7 +1355,7 @@ def test_object_casting_indexing_wraps_datetimelike(using_array_manager):
 
     mgr = df._mgr
     mgr._rebuild_blknos_and_blklocs()
-    arr = mgr.fast_xs(0)
+    arr = mgr.fast_xs(0).array
     assert isinstance(arr[1], Timestamp)
     assert isinstance(arr[2], pd.Timedelta)
 


### PR DESCRIPTION
This is something that I encountered in https://github.com/pandas-dev/pandas/pull/46958, but again something that can be broken off / potentially useful anyway. 

Currently the `fast_xs` method returns an array, but the only two places where it is being used (`xs` / `_ixs`), this array is directly wrapped in a Series. So by letting ``fast_xs`` return a manager instead, this gives a slight simplification / faster series construction.

The reason that it is also useful for https://github.com/pandas-dev/pandas/pull/46958 is because the CoW is handled at the manager level, so when creating a subset of a DataFrame (here in `xs`), ideally that is done by creating a subset manager (with proper references if needed) instead of going through raw arrays (as how it is done for example when accessing a column as a Series).