### PR TITLE
BUG: Fix `set_sticky` background

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -812,6 +812,7 @@ Styler
 ^^^^^^
 - Bug when attempting to apply styling functions to an empty DataFrame subset (:issue:`45313`)
 - Bug in :class:`CSSToExcelConverter` leading to ``TypeError`` when border color provided without border style for ``xlsxwriter`` engine (:issue:`42276`)
+- Bug in :meth:`Styler.set_sticky` leading to white text on white background in dark mode (:issue:`46984`)
 
 Metadata
 ^^^^^^^^

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -2283,7 +2283,7 @@ class Styler(StylerRenderer):
         obj = self.data.index if axis == 0 else self.data.columns
         pixel_size = (75 if axis == 0 else 25) if not pixel_size else pixel_size
 
-        props = "position:sticky; background-color:white;"
+        props = "position:sticky; background-color:inherit;"
         if not isinstance(obj, pd.MultiIndex):
             # handling MultiIndexes requires different CSS
 

--- a/pandas/tests/io/formats/style/test_html.py
+++ b/pandas/tests/io/formats/style/test_html.py
@@ -302,11 +302,11 @@ def test_sticky_basic(styler, index, columns, index_name):
         styler.set_sticky(axis=1)
 
     left_css = (
-        "#T_ {0} {{\n  position: sticky;\n  background-color: white;\n"
+        "#T_ {0} {{\n  position: sticky;\n  background-color: inherit;\n"
         "  left: 0px;\n  z-index: {1};\n}}"
     )
     top_css = (
-        "#T_ {0} {{\n  position: sticky;\n  background-color: white;\n"
+        "#T_ {0} {{\n  position: sticky;\n  background-color: inherit;\n"
         "  top: {1}px;\n  z-index: {2};\n{3}}}"
     )
 
@@ -338,11 +338,11 @@ def test_sticky_mi(styler_mi, index, columns):
         styler_mi.set_sticky(axis=1)
 
     left_css = (
-        "#T_ {0} {{\n  position: sticky;\n  background-color: white;\n"
+        "#T_ {0} {{\n  position: sticky;\n  background-color: inherit;\n"
         "  left: {1}px;\n  min-width: 75px;\n  max-width: 75px;\n  z-index: {2};\n}}"
     )
     top_css = (
-        "#T_ {0} {{\n  position: sticky;\n  background-color: white;\n"
+        "#T_ {0} {{\n  position: sticky;\n  background-color: inherit;\n"
         "  top: {1}px;\n  height: 25px;\n  z-index: {2};\n}}"
     )
 
@@ -374,11 +374,11 @@ def test_sticky_levels(styler_mi, index, columns, levels):
         styler_mi.set_sticky(axis=1, levels=levels)
 
     left_css = (
-        "#T_ {0} {{\n  position: sticky;\n  background-color: white;\n"
+        "#T_ {0} {{\n  position: sticky;\n  background-color: inherit;\n"
         "  left: {1}px;\n  min-width: 75px;\n  max-width: 75px;\n  z-index: {2};\n}}"
     )
     top_css = (
-        "#T_ {0} {{\n  position: sticky;\n  background-color: white;\n"
+        "#T_ {0} {{\n  position: sticky;\n  background-color: inherit;\n"
         "  top: {1}px;\n  height: 25px;\n  z-index: {2};\n}}"
     )
 


### PR DESCRIPTION
- [x] closes #46984 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Inherit the `background-color` of the sticky elements from its parents (with proper color alternation between rows) instead of hard-coding it to white. 

Example: 

```py
import pandas as pd
import numpy as np

pd.DataFrame(np.random.randn(16, 100)).style.set_sticky()
```

| Dark | Light |
| -- | -- |
| <img width="465" alt="image" src="https://user-images.githubusercontent.com/6421097/169643245-68b071c4-bdff-4813-9537-8eba341570f3.png"> | <img width="404" alt="image" src="https://user-images.githubusercontent.com/6421097/169643388-3ea02bcc-729d-43d9-a0df-1fe7fccb8459.png"> |


For reference, https://github.com/pandas-dev/pandas/issues/42072 introduced the `set_sticky` feature. 
