### PR TITLE
fix pandas.show_versions() and remove pin for setuptools

### DIFF
--- a/.github/workflows/python-dev.yml
+++ b/.github/workflows/python-dev.yml
@@ -54,11 +54,10 @@ jobs:
       with:
         python-version: '3.11-dev'
 
-    # TODO: GH#44980 https://github.com/pypa/setuptools/issues/2941
     - name: Install dependencies
       shell: bash -el {0}
       run: |
-        python -m pip install --upgrade pip "setuptools<60.0.0" wheel
+        python -m pip install --upgrade pip setuptools wheel
         pip install -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
         pip install git+https://github.com/nedbat/coveragepy.git
         pip install cython python-dateutil pytz hypothesis pytest>=6.2.5 pytest-xdist pytest-cov

--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -41,10 +41,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    # TODO: GH#44980 https://github.com/pypa/setuptools/issues/2941
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip "setuptools<60.0.0" wheel
+        python -m pip install --upgrade pip setuptools wheel
 
         # GH 39416
         pip install numpy
@@ -66,10 +65,8 @@ jobs:
         channels: conda-forge
         python-version: '${{ matrix.python-version }}'
 
-    # TODO: GH#44980 https://github.com/pypa/setuptools/issues/2941
     - name: Install pandas from sdist
       run: |
-        python -m pip install --upgrade "setuptools<60.0.0"
         pip list
         python -m pip install dist/*.gz
 

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -51,8 +51,7 @@ echo
 echo "update conda"
 conda config --set ssl_verify false
 conda config --set quiet true --set always_yes true --set changeps1 false
-# TODO: GH#44980 https://github.com/pypa/setuptools/issues/2941
-conda install -y -c conda-forge -n base 'mamba>=0.21.2' pip
+conda install -y -c conda-forge -n base 'mamba>=0.21.2' pip setuptools
 
 echo "conda info -a"
 conda info -a
@@ -67,8 +66,6 @@ echo "mamba env update --file=${ENV_FILE}"
 # See https://github.com/mamba-org/mamba/issues/633
 mamba create -q -n pandas-dev
 time mamba env update -n pandas-dev --file="${ENV_FILE}"
-# TODO: GH#44980 https://github.com/pypa/setuptools/issues/2941
-mamba install -n pandas-dev 'setuptools<60'
 
 echo "conda list -n pandas-dev"
 conda list -n pandas-dev

--- a/pandas/tests/util/test_show_versions.py
+++ b/pandas/tests/util/test_show_versions.py
@@ -7,7 +7,6 @@ import pytest
 from pandas.compat import (
     IS64,
     is_ci_environment,
-    is_numpy_dev,
 )
 from pandas.util._print_versions import (
     _get_dependency_info,
@@ -15,14 +14,6 @@ from pandas.util._print_versions import (
 )
 
 import pandas as pd
-
-# This is failing on the Numpy Dev build,
-# but the error may just be from distutils?
-pytestmark = pytest.mark.xfail(
-    is_numpy_dev,
-    reason="_distutils not in python3.10/distutils/core.py",
-    raises=AssertionError,
-)
 
 
 @pytest.mark.filterwarnings(

--- a/pandas/util/_print_versions.py
+++ b/pandas/util/_print_versions.py
@@ -60,8 +60,8 @@ def _get_dependency_info() -> dict[str, JSONSerializable]:
         "pytz",
         "dateutil",
         # install / build,
-        "pip",
         "setuptools",
+        "pip",
         "Cython",
         # test
         "pytest",


### PR DESCRIPTION
closes #44980

labelled as 1.4.3 as seeing failures on release checks

(strange I cannot reproduce issue on editable install on 1.4.x or main)