### PR TITLE
BUG 1.4: do not suppress errors when closing file handles

### DIFF
--- a/doc/source/whatsnew/v1.4.3.rst
+++ b/doc/source/whatsnew/v1.4.3.rst
@@ -30,7 +30,7 @@ Fixed regressions
 
 Bug fixes
 ~~~~~~~~~
--
+- Most I/O methods do no longer suppress ``OSError`` and ``ValueError`` when closing file handles (:issue:`47136`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -112,11 +112,8 @@ class IOHandles(Generic[AnyStr]):
             self.handle.flush()
             self.handle.detach()
             self.created_handles.remove(self.handle)
-        try:
-            for handle in self.created_handles:
-                handle.close()
-        except (OSError, ValueError):
-            pass
+        for handle in self.created_handles:
+            handle.close()
         self.created_handles = []
         self.is_wrapped = False
 

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -600,3 +600,15 @@ def test_fail_mmap():
     with pytest.raises(UnsupportedOperation, match="fileno"):
         with BytesIO() as buffer:
             icom.get_handle(buffer, "rb", memory_map=True)
+
+
+def test_close_on_error():
+    # GH 47136
+    class TestError:
+        def close(self):
+            raise OSError("test")
+
+    with pytest.raises(OSError, match="test"):
+        with BytesIO() as buffer:
+            with icom.get_handle(buffer, "rb") as handles:
+                handles.created_handles.append(TestError())


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/47153#discussion_r884156873, closes https://github.com/pandas-dev/pandas/issues/47136