### PR TITLE
BUG Fix: DataFrameGroupBy.sum() drops column names when applied to an empty dataframe

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1668,7 +1668,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                 raise NotImplementedError(
                     f"{type(self).__name__}.{how} does not implement {kwd_name}."
                 )
-            elif not is_ser:
+            elif not is_ser and data.shape[1] != 0:
                 data = data.get_numeric_data(copy=False)
 
         def array_func(values: ArrayLike) -> ArrayLike:

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2776,3 +2776,51 @@ def test_by_column_values_with_same_starting_value():
     ).set_index("Name")
 
     tm.assert_frame_equal(result, expected_result)
+
+
+@pytest.mark.parametrize(
+    "numeric_only",
+    [False, None, True],
+)
+def test_empty_frame_groupby_numeric_only(numeric_only):
+    # GH 46375
+    df = DataFrame(columns=["a", "b"])
+    expected = DataFrame(columns=["a", "b"]).set_index(["a"])
+    result = df.groupby(["a"]).first(numeric_only=numeric_only)
+    tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "numeric_only, expected_data",
+    [
+        (
+            False,
+            {
+                "a": [0, 1],
+                "b": [1, 2],
+                "c": [1, 2],
+            },
+        ),
+        (
+            None,
+            {
+                "a": [0, 1],
+                "b": [1, 2],
+                "c": [1, 2],
+            },
+        ),
+        (
+            True,
+            {
+                "a": [0, 1],
+                "c": [1, 2],
+            },
+        ),
+    ],
+)
+def test_frame_groupby_numeric_only(numeric_only, expected_data):
+    # GH 46375
+    df = DataFrame({"a": [0, 0, 1, 1], "b": [1, "x", 2, "y"], "c": [1, 1, 2, 2]})
+    result = df.groupby(["a"]).first(numeric_only=numeric_only)
+    expected = DataFrame(expected_data).set_index(["a"])
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #46375
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
