### PR TITLE
[CLN] call __finalize__ in quantile

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10936,10 +10936,8 @@ Parrot 2  Parrot       24.0
                 if needs_i8_conversion(cdtype):
                     dtype = cdtype
 
-            if is_list_like(q):
-                res = self._constructor([], index=q, columns=cols, dtype=dtype)
-                return res.__finalize__(self, method="quantile")
-            return self._constructor_sliced([], index=cols, name=q, dtype=dtype)
+            res = self._constructor([], index=q, columns=cols, dtype=dtype)
+            return res.__finalize__(self, method="quantile")
 
         res = data._mgr.quantile(qs=q, axis=1, interpolation=interpolation)
 

--- a/pandas/tests/generic/test_finalize.py
+++ b/pandas/tests/generic/test_finalize.py
@@ -262,6 +262,13 @@ _all_methods = [
             operator.methodcaller("quantile", numeric_only=False),
         ),
     ),
+    pytest.param(
+        (
+            pd.DataFrame,
+            ({"A": [np.datetime64("2022-01-01"), np.datetime64("2022-01-02")]},),
+            operator.methodcaller("quantile", numeric_only=True),
+        ),
+    ),
     (
         pd.DataFrame,
         ({"A": [1]}, [pd.Period("2000", "D")]),


### PR DESCRIPTION
- [x] [Tests added and passed]
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

In reference to #28283, this PR intends to ensure that `__finalize__` is always called before returning the result of `DataFrame.quantile`.

This was already the case though, because `__finalize__` is already called explicitly wherever necessary. Furthermore, my previous PR #46101 fixed the remaining problem with metadata propagation in `quantile` as that was caused by `.iloc`.

There remained one return statement with no call to finalize. This code is unreachable though and now removed. The check `if is_list_like(q):` is guaranteed to be true because a few lines up `q = Index(...)` and `Index` is list-like.

Additionally, I have added one more test to increase the coverage of the finalize tests in quantile.

(In case I am wrong and `Index` is not guaranteed to always be list-like, I'll add this code back and add the missing finalize call instead.)