### PR TITLE
updated period.daysinmonth definition to match period.days_in_month

### DIFF
--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2253,7 +2253,7 @@ cdef class _Period(PeriodMixin):
     @property
     def daysinmonth(self) -> int:
         """
-        Get the total number of days of the month that the Period falls in.
+        Get the total number of days of the month that this period falls on.
 
         Returns
         -------


### PR DESCRIPTION
- [DOC] The definition for period.daysinmonth in the .pyx file was worded slightly differently than period.days_in_month, despite both methods being exactly the same. This change updates the definition of daysinmonth to match that of days_in_month. 
