### PR TITLE
BUG: Tackle GH47203; Ensure body is non-empty when accessing row_body_cells

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -890,6 +890,7 @@ Styler
 - Bug when attempting to apply styling functions to an empty DataFrame subset (:issue:`45313`)
 - Bug in :class:`CSSToExcelConverter` leading to ``TypeError`` when border color provided without border style for ``xlsxwriter`` engine (:issue:`42276`)
 - Bug in :meth:`Styler.set_sticky` leading to white text on white background in dark mode (:issue:`46984`)
+- Bug in :meth:`Styler.to_latex` causing ``UnboundLocalError`` when ``clines="all;data"`` and the ``DataFrame`` has no rows. (:issue:`47203`)
 
 Metadata
 ^^^^^^^^

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -908,7 +908,7 @@ class StylerRenderer:
                 f"of 'all;data', 'all;index', 'skip-last;data', 'skip-last;index'."
             )
         elif clines is not None:
-            data_len = len(row_body_cells) if "data" in clines else 0
+            data_len = len(row_body_cells) if "data" in clines and d["body"] else 0
 
             d["clines"] = defaultdict(list)
             visible_row_indexes: list[int] = [

--- a/pandas/tests/io/formats/style/test_to_latex.py
+++ b/pandas/tests/io/formats/style/test_to_latex.py
@@ -1032,3 +1032,15 @@ def test_concat_recursion():
     """
     )
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "df",
+    [
+        DataFrame(),
+        DataFrame(columns=["a", "b", "c"]),
+    ],
+)
+def test_empty_clines(df: DataFrame):
+    # GH 47203
+    df.style.to_latex(clines="all;data")

--- a/pandas/tests/io/formats/style/test_to_latex.py
+++ b/pandas/tests/io/formats/style/test_to_latex.py
@@ -1035,12 +1035,33 @@ def test_concat_recursion():
 
 
 @pytest.mark.parametrize(
-    "df",
+    "df, expected",
     [
-        DataFrame(),
-        DataFrame(columns=["a", "b", "c"]),
+        (
+            DataFrame(),
+            dedent(
+                """\
+            \\begin{tabular}{l}
+            \\end{tabular}
+            """
+            ),
+        ),
+        (
+            DataFrame(columns=["a", "b", "c"]),
+            dedent(
+                """\
+            \\begin{tabular}{llll}
+             & a & b & c \\\\
+            \\end{tabular}
+            """
+            ),
+        ),
     ],
 )
-def test_empty_clines(df: DataFrame):
+@pytest.mark.parametrize(
+    "clines", [None, "all;data", "all;index", "skip-last;data", "skip-last;index"]
+)
+def test_empty_clines(df: DataFrame, expected: str, clines: str):
     # GH 47203
-    df.style.to_latex(clines="all;data")
+    result = df.style.to_latex(clines=clines)
+    assert result == expected

--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -1528,14 +1528,3 @@ class TestRowStringConverter:
         )
         with tm.assert_produces_warning(FutureWarning, match=msg):
             df.to_latex()
-
-
-@pytest.mark.parametrize(
-    "df",
-    [
-        DataFrame(),
-        DataFrame(columns=["a", "b", "c"]),
-    ],
-)
-def test_empty_clines(df: DataFrame):
-    df.style.to_latex(clines="all;data")

--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -1528,3 +1528,14 @@ class TestRowStringConverter:
         )
         with tm.assert_produces_warning(FutureWarning, match=msg):
             df.to_latex()
+
+
+@pytest.mark.parametrize(
+    "df",
+    [
+        DataFrame(),
+        DataFrame(columns=["a", "b", "c"]),
+    ],
+)
+def test_empty_clines(df: DataFrame):
+    df.style.to_latex(clines="all;data")


### PR DESCRIPTION
- [x] closes #47203
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests).
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v1.5.0.rst` file.
