### PR TITLE
ASV: add benchmark for reindex with MultiIndex containing dates

### DIFF
--- a/asv_bench/benchmarks/reindex.py
+++ b/asv_bench/benchmarks/reindex.py
@@ -30,6 +30,10 @@ class Reindex:
         self.s_subset = self.s[::2]
         self.s_subset_no_cache = self.s[::2].copy()
 
+        mi = MultiIndex.from_product([rng, range(100)])
+        self.s2 = Series(np.random.randn(len(mi)), index=mi)
+        self.s2_subset = self.s2[::2].copy()
+
     def time_reindex_dates(self):
         self.df.reindex(self.rng_subset)
 
@@ -43,6 +47,10 @@ class Reindex:
     def time_reindex_multiindex_no_cache(self):
         # Copy to avoid MultiIndex._values getting cached
         self.s.reindex(self.s_subset_no_cache.index.copy())
+
+    def time_reindex_multiindex_no_cache_dates(self):
+        # Copy to avoid MultiIndex._values getting cached
+        self.s2_subset.reindex(self.s2.index.copy())
 
 
 class ReindexMethod:


### PR DESCRIPTION
- [x] closes #23735
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Adding a benchmark per the discussion in the linked issue. 

```
from asv_bench.benchmarks.reindex import Reindex

b = Reindex()
b.setup()

%timeit b.time_reindex_multiindex_no_cache_dates()
```

```
603 ms ± 20.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)    <- 1.4.2
45.6 ms ± 995 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)  <- main
```