### PR TITLE
DOC: Make ExtensionArray not experimental

### DIFF
--- a/doc/source/development/extending.rst
+++ b/doc/source/development/extending.rst
@@ -74,10 +74,11 @@ applies only to certain dtypes.
 Extension types
 ---------------
 
-.. warning::
+.. note::
 
-   The :class:`pandas.api.extensions.ExtensionDtype` and :class:`pandas.api.extensions.ExtensionArray` APIs are new and
-   experimental. They may change between versions without warning.
+   The :class:`pandas.api.extensions.ExtensionDtype` and :class:`pandas.api.extensions.ExtensionArray` APIs were
+   experimental prior to pandas 1.4. Starting with version 1.4, future changes will follow
+   the :ref:`pandas deprecation policy <policies.version>`.
 
 pandas defines an interface for implementing data types and arrays that *extend*
 NumPy's type system. pandas itself uses the extension system for some types

--- a/doc/source/development/extending.rst
+++ b/doc/source/development/extending.rst
@@ -77,7 +77,7 @@ Extension types
 .. note::
 
    The :class:`pandas.api.extensions.ExtensionDtype` and :class:`pandas.api.extensions.ExtensionArray` APIs were
-   experimental prior to pandas 1.4. Starting with version 1.4, future changes will follow
+   experimental prior to pandas 1.5. Starting with version 1.5, future changes will follow
    the :ref:`pandas deprecation policy <policies.version>`.
 
 pandas defines an interface for implementing data types and arrays that *extend*


### PR DESCRIPTION
- [x] closes #47148 

Updates docs to make `ExtensionArray` and `ExtensionDtype` not experimental