### PR TITLE
TST: xfail unit test on min build

### DIFF
--- a/pandas/compat/numpy/__init__.py
+++ b/pandas/compat/numpy/__init__.py
@@ -11,6 +11,7 @@ np_version_under1p22 = _nlv < Version("1.22")
 np_version_gte1p22 = _nlv >= Version("1.22")
 is_numpy_dev = _nlv.dev is not None
 _min_numpy_ver = "1.19.5"
+is_numpy_min = _nlv == Version(_min_numpy_ver)
 
 if is_numpy_dev or not np_version_under1p22:
     np_percentile_argname = "method"

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -10,6 +10,7 @@ from warnings import (
 import numpy as np
 import pytest
 
+from pandas.compat.numpy import is_numpy_min
 import pandas.util._test_decorators as td
 
 from pandas import (
@@ -1198,6 +1199,7 @@ class TestiLocBaseIndependent:
         arr[2] = arr[-1]
         assert ser[0] == arr[-1]
 
+    @pytest.mark.xfail(is_numpy_min, reason="Column A gets coerced to integer type")
     def test_iloc_setitem_multicolumn_to_datetime(self, using_array_manager):
 
         # GH#20511


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

xref https://github.com/pandas-dev/pandas/runs/6753263999?check_suite_focus=true

Not 100% certain why this fails on the min build, but can be investigated later.
