### PR TITLE
CI: Allow more permissive HTTP retries/timeouts when connecting to conda

### DIFF
--- a/.github/actions/setup-conda/action.yml
+++ b/.github/actions/setup-conda/action.yml
@@ -18,10 +18,11 @@ runs:
       if: ${{ inputs.pyarrow-version }}
 
     - name: Install ${{ inputs.environment-file }}
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v2.1.1
       with:
         environment-file: ${{ inputs.environment-file }}
         channel-priority: ${{ runner.os == 'macOS' && 'flexible' || 'strict' }}
         channels: conda-forge
         mamba-version: "0.23"
         use-mamba: true
+        condarc-file: ci/condarc.yml

--- a/.github/workflows/asv-bot.yml
+++ b/.github/workflows/asv-bot.yml
@@ -47,6 +47,7 @@ jobs:
           channel-priority: strict
           environment-file: ${{ env.ENV_FILE }}
           use-only-tar-bz2: true
+          condarc-file: ci/condarc.yml
 
       - name: Run benchmarks
         id: bench

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -66,6 +66,7 @@ jobs:
         channel-priority: strict
         environment-file: ${{ env.ENV_FILE }}
         use-only-tar-bz2: true
+        condarc-file: ci/condarc.yml
 
     - name: Build Pandas
       id: build
@@ -135,6 +136,7 @@ jobs:
         channel-priority: strict
         environment-file: ${{ env.ENV_FILE }}
         use-only-tar-bz2: true
+        condarc-file: ci/condarc.yml
 
     - name: Build Pandas
       id: build

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -155,6 +155,7 @@ jobs:
         channel-priority: flexible
         environment-file: ${{ env.ENV_FILE }}
         use-only-tar-bz2: true
+        condarc-file: ci/condarc.yml
 
     - name: Upgrade Arrow version
       run: conda install -n pandas-dev -c conda-forge --no-update-deps pyarrow=${{ matrix.pyarrow_version }}

--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -64,6 +64,7 @@ jobs:
         activate-environment: pandas-sdist
         channels: conda-forge
         python-version: '${{ matrix.python-version }}'
+        condarc-file: ci/condarc.yml
 
     - name: Install pandas from sdist
       run: |

--- a/ci/condarc.yml
+++ b/ci/condarc.yml
@@ -1,0 +1,32 @@
+# https://docs.conda.io/projects/conda/en/latest/configuration.html
+
+# always_yes (NoneType, bool)
+#   aliases: yes
+#   Automatically choose the 'yes' option whenever asked to proceed with a
+#   conda operation, such as when running `conda install`.
+#
+always_yes: true
+
+# remote_connect_timeout_secs (float)
+#   The number seconds conda will wait for your client to establish a
+#   connection to a remote url resource.
+#
+remote_connect_timeout_secs: 30.0
+
+# remote_max_retries (int)
+#   The maximum number of retries each HTTP connection should attempt.
+#
+remote_max_retries: 10
+
+# remote_backoff_factor (int)
+#   The factor determines the time HTTP connection should wait for
+#   attempt.
+#
+remote_backoff_factor: 3
+
+# remote_read_timeout_secs (float)
+#   Once conda has connected to a remote resource and sent an HTTP
+#   request, the read timeout is the number of seconds conda will wait for
+#   the server to send a response.
+#
+remote_read_timeout_secs: 60.0


### PR DESCRIPTION
Hoping this alleviates the following traceback that has been occurring recently

```
     Traceback (most recent call last):
        File "/usr/share/miniconda/lib/python3.9/site-packages/urllib3/response.py", line 438, in _error_catcher
          yield
        File "/usr/share/miniconda/lib/python3.9/site-packages/urllib3/response.py", line 767, in read_chunked
          chunk = self._handle_chunk(amt)
        File "/usr/share/miniconda/lib/python3.9/site-packages/urllib3/response.py", line 711, in _handle_chunk
          value = self._fp._safe_read(amt)
        File "/usr/share/miniconda/lib/python3.9/http/client.py", line 626, in _safe_read
          chunk = self.fp.read(min(amt, MAXAMOUNT))
        File "/usr/share/miniconda/lib/python3.9/socket.py", line 704, in readinto
          return self._sock.recv_into(b)
        File "/usr/share/miniconda/lib/python3.9/ssl.py", line 1241, in recv_into
          return self.read(nbytes, buffer)
        File "/usr/share/miniconda/lib/python3.9/ssl.py", line 1099, in read
          return self._sslobj.read(len, buffer)
      ConnectionResetError: [Errno 104] Connection reset by peer
  
      During handling of the above exception, another exception occurred:
  
      Traceback (most recent call last):
        File "/usr/share/miniconda/lib/python3.9/site-packages/requests/models.py", line 760, in generate
          for chunk in self.raw.stream(chunk_size, decode_content=True):
        File "/usr/share/miniconda/lib/python3.9/site-packages/urllib3/response.py", line 572, in stream
          for line in self.read_chunked(amt, decode_content=decode_content):
        File "/usr/share/miniconda/lib/python3.9/site-packages/urllib3/response.py", line 793, in read_chunked
          self._original_response.close()
        File "/usr/share/miniconda/lib/python3.9/contextlib.py", line 137, in __exit__
          self.gen.throw(typ, value, traceback)
        File "/usr/share/miniconda/lib/python3.9/site-packages/urllib3/response.py", line 455, in _error_catcher
          raise ProtocolError("Connection broken: %r" % e, e)
      urllib3.exceptions.ProtocolError: ("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
```
