### PR TITLE
BUG: Timestamp with unit=Y or unit=M

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -726,7 +726,7 @@ Datetimelike
 - Bug in :meth:`SeriesGroupBy.value_counts` index when passing categorical column (:issue:`44324`)
 - Bug in :meth:`DatetimeIndex.tz_localize` localizing to UTC failing to make a copy of the underlying data (:issue:`46460`)
 - Bug in :meth:`DatetimeIndex.resolution` incorrectly returning "day" instead of "nanosecond" for nanosecond-resolution indexes (:issue:`46903`)
-- Bug in :class:`Timestamp` with an integer or float value and ``unit="Y"`` or ``unit="M"`` giving slightly-wrong results (:issue:`??`)
+- Bug in :class:`Timestamp` with an integer or float value and ``unit="Y"`` or ``unit="M"`` giving slightly-wrong results (:issue:`47266`)
 -
 
 Timedelta

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -726,6 +726,7 @@ Datetimelike
 - Bug in :meth:`SeriesGroupBy.value_counts` index when passing categorical column (:issue:`44324`)
 - Bug in :meth:`DatetimeIndex.tz_localize` localizing to UTC failing to make a copy of the underlying data (:issue:`46460`)
 - Bug in :meth:`DatetimeIndex.resolution` incorrectly returning "day" instead of "nanosecond" for nanosecond-resolution indexes (:issue:`46903`)
+- Bug in :class:`Timestamp` with an integer or float value and ``unit="Y"`` or ``unit="M"`` giving slightly-wrong results (:issue:`??`)
 -
 
 Timedelta

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -253,7 +253,7 @@ cdef _TSObject convert_to_tsobject(object ts, tzinfo tz, str unit,
             if unit in ["Y", "M"]:
                 # GH#47266 cast_from_unit leads to weird results e.g. with "Y"
                 #  and 150 we'd get 2120-01-01 09:00:00
-                ts = np.datetime64(ts, unit.upper())
+                ts = np.datetime64(ts, unit)
                 return convert_to_tsobject(ts, tz, None, False, False)
 
             ts = ts * cast_from_unit(None, unit)

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -249,8 +249,8 @@ cdef _TSObject convert_to_tsobject(object ts, tzinfo tz, str unit,
             obj.value = NPY_NAT
         else:
             if unit in ["Y", "M"]:
-                # cast_from_unit leads to weird results e.g. with "Y" and 150
-                #  we'd get 2120-01-01 09:00:00
+                # GH#47266 cast_from_unit leads to weird results e.g. with "Y"
+                #  and 150 we'd get 2120-01-01 09:00:00
                 ts = np.datetime64(ts, unit.upper())
                 return convert_to_tsobject(ts, tz, None, False, False)
 
@@ -263,8 +263,8 @@ cdef _TSObject convert_to_tsobject(object ts, tzinfo tz, str unit,
         else:
             if unit in ["Y", "M"]:
                 if ts == int(ts):
-                    # Avoid cast_from_unit, which would give weird results e.g.
-                    #  with "Y" and 150.0 we'd get 2120-01-01 09:00:00
+                    # GH#47266 Avoid cast_from_unit, which would give weird results
+                    #  e.g. with "Y" and 150.0 we'd get 2120-01-01 09:00:00
                     return convert_to_tsobject(int(ts), tz, unit, False, False)
 
             ts = cast_from_unit(ts, unit)

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -248,6 +248,12 @@ cdef _TSObject convert_to_tsobject(object ts, tzinfo tz, str unit,
         if ts == NPY_NAT:
             obj.value = NPY_NAT
         else:
+            if unit in ["Y", "M"]:
+                # cast_from_unit leads to weird results e.g. with "Y" and 150
+                #  we'd get 2120-01-01 09:00:00
+                ts = np.datetime64(ts, unit.upper())
+                return convert_to_tsobject(ts, tz, None, False, False)
+
             ts = ts * cast_from_unit(None, unit)
             obj.value = ts
             dt64_to_dtstruct(ts, &obj.dts)
@@ -255,6 +261,12 @@ cdef _TSObject convert_to_tsobject(object ts, tzinfo tz, str unit,
         if ts != ts or ts == NPY_NAT:
             obj.value = NPY_NAT
         else:
+            if unit in ["Y", "M"]:
+                if ts == int(ts):
+                    # Avoid cast_from_unit, which would give weird results e.g.
+                    #  with "Y" and 150.0 we'd get 2120-01-01 09:00:00
+                    return convert_to_tsobject(int(ts), tz, unit, False, False)
+
             ts = cast_from_unit(ts, unit)
             obj.value = ts
             dt64_to_dtstruct(ts, &obj.dts)

--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -27,7 +27,7 @@ from pandas.tseries import offsets
 class TestTimestampConstructors:
     @pytest.mark.parametrize("typ", [int, float])
     def test_constructor_int_float_with_YM_unit(self, typ):
-        # avoid the conversions in cast_from_unit
+        # GH#47266 avoid the conversions in cast_from_unit
         val = typ(150)
 
         ts = Timestamp(val, unit="Y")

--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -25,6 +25,19 @@ from pandas.tseries import offsets
 
 
 class TestTimestampConstructors:
+    @pytest.mark.parametrize("typ", [int, float])
+    def test_constructor_int_float_with_YM_unit(self, typ):
+        # avoid the conversions in cast_from_unit
+        val = typ(150)
+
+        ts = Timestamp(val, unit="Y")
+        expected = Timestamp("2120-01-01")
+        assert ts == expected
+
+        ts = Timestamp(val, unit="M")
+        expected = Timestamp("1982-07-01")
+        assert ts == expected
+
     def test_constructor_datetime64_with_tz(self):
         # GH#42288, GH#24559
         dt = np.datetime64("1970-01-01 05:00:00")


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
