### PR TITLE
DOC: cross reference similar `Series.unique` and `Series.drop_duplicates` methods

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2073,6 +2073,7 @@ Name: Max Speed, dtype: float64
 
         See Also
         --------
+        Series.drop_duplicates : Return Series with duplicate values removed.
         unique : Top-level unique method for any 1-d array-like object.
         Index.unique : Return Index with unique values from an Index object.
 
@@ -2163,6 +2164,7 @@ Name: Max Speed, dtype: float64
         DataFrame.drop_duplicates : Equivalent method on DataFrame.
         Series.duplicated : Related method on Series, indicating duplicate
             Series values.
+        Series.unique : Return unique values as an array.
 
         Examples
         --------


### PR DESCRIPTION
- [x] closes #xxxx (Replace xxxx with the Github issue number)
- [N/A] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [N/A] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [N/A] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Personally, I found `unique()` before I found `drop_duplicates()`, even though the latter is closer to what I wanted to achieve. As discussed in https://github.com/pandas-dev/pandas/issues/1923#issuecomment-515465111, cross-referencing these methods would help with discovering the desired method.

Closes #1923