### PR TITLE
TYP: generate_regular_range

### DIFF
--- a/pandas/core/arrays/_ranges.py
+++ b/pandas/core/arrays/_ranges.py
@@ -14,14 +14,15 @@ from pandas._libs.tslibs import (
     Timestamp,
     iNaT,
 )
+from pandas._typing import npt
 
 
 def generate_regular_range(
-    start: Timestamp | Timedelta,
-    end: Timestamp | Timedelta,
-    periods: int,
+    start: Timestamp | Timedelta | None,
+    end: Timestamp | Timedelta | None,
+    periods: int | None,
     freq: BaseOffset,
-):
+) -> npt.NDArray[np.intp]:
     """
     Generate a range of dates or timestamps with the spans between dates
     described by the given `freq` DateOffset.
@@ -45,15 +46,15 @@ def generate_regular_range(
     iend = end.value if end is not None else None
     stride = freq.nanos
 
-    if periods is None:
+    if periods is None and istart is not None and iend is not None:
         b = istart
         # cannot just use e = Timestamp(end) + 1 because arange breaks when
         # stride is too large, see GH10887
         e = b + (iend - b) // stride * stride + stride // 2 + 1
-    elif istart is not None:
+    elif istart is not None and periods is not None:
         b = istart
         e = _generate_range_overflow_safe(b, periods, stride, side="start")
-    elif iend is not None:
+    elif iend is not None and periods is not None:
         e = iend + stride
         b = _generate_range_overflow_safe(e, periods, stride, side="end")
     else:

--- a/pandas/core/arrays/_ranges.py
+++ b/pandas/core/arrays/_ranges.py
@@ -33,7 +33,7 @@ def generate_regular_range(
         First point of produced date range.
     end : Timedelta, Timestamp or None
         Last point of produced date range.
-    periods : int
+    periods : int or None
         Number of periods in produced date range.
     freq : Tick
         Describes space between dates in produced date range.

--- a/pyright_reportGeneralTypeIssues.json
+++ b/pyright_reportGeneralTypeIssues.json
@@ -11,13 +11,15 @@
       [
         # exclude tests
         "pandas/tests",
+        # exclude vendored files
+        "pandas/io/clipboard",
+        "pandas/util/version",
         # and all files that currently don't pass
         "pandas/_config/config.py",
         "pandas/core/algorithms.py",
         "pandas/core/apply.py",
         "pandas/core/array_algos/take.py",
         "pandas/core/arrays/_mixins.py",
-        "pandas/core/arrays/_ranges.py",
         "pandas/core/arrays/arrow/array.py",
         "pandas/core/arrays/base.py",
         "pandas/core/arrays/boolean.py",


### PR DESCRIPTION
`generate_regular_range` seems to be only called from un-annotated places: mypy doesn't know that start/end/periods can actually be None.

edit:
I'm not annotating the functions calling `generate_regular_range` in this PR as my aim with this PR is to simply make `pandas/core/arrays/_ranges.py` compatible with pyright. 
