### PR TITLE
TYP: StorageExtensionDtype.na_values

### DIFF
--- a/pandas/core/arrays/arrow/dtype.py
+++ b/pandas/core/arrays/arrow/dtype.py
@@ -22,7 +22,6 @@ class ArrowDtype(StorageExtensionDtype):
     Modeled after BaseMaskedDtype
     """
 
-    na_value = libmissing.NA
     _metadata = ("storage", "pyarrow_dtype")  # type: ignore[assignment]
 
     def __init__(self, pyarrow_dtype: pa.DataType) -> None:

--- a/pandas/core/arrays/arrow/dtype.py
+++ b/pandas/core/arrays/arrow/dtype.py
@@ -5,7 +5,6 @@ import re
 import numpy as np
 import pyarrow as pa
 
-from pandas._libs import missing as libmissing
 from pandas._typing import DtypeObj
 from pandas.util._decorators import cache_readonly
 

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -395,7 +395,6 @@ class StorageExtensionDtype(ExtensionDtype):
     """ExtensionDtype that may be backed by more than one implementation."""
 
     name: str
-    na_value = libmissing.NA
     _metadata = ("storage",)
 
     def __init__(self, storage=None) -> None:
@@ -415,6 +414,10 @@ class StorageExtensionDtype(ExtensionDtype):
     def __hash__(self) -> int:
         # custom __eq__ so have to override __hash__
         return super().__hash__()
+
+    @property
+    def na_value(self) -> libmissing.NAType:
+        return libmissing.NA
 
 
 def register_extension_dtype(cls: type_t[ExtensionDtypeT]) -> type_t[ExtensionDtypeT]:

--- a/pyright_reportGeneralTypeIssues.json
+++ b/pyright_reportGeneralTypeIssues.json
@@ -37,7 +37,6 @@
         "pandas/core/computation/align.py",
         "pandas/core/construction.py",
         "pandas/core/describe.py",
-        "pandas/core/dtypes/base.py",
         "pandas/core/dtypes/cast.py",
         "pandas/core/dtypes/common.py",
         "pandas/core/dtypes/concat.py",


### PR DESCRIPTION
`ExtensionDtype.na_value` is a property: sub-classes should also use `property` and not a variable (or `ExtensionDtype` should use a variable).