### PR TITLE
ENH/TST: ArrowExtenstionArray.reshape raises NotImplementedError

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -264,6 +264,12 @@ class ArrowExtensionArray(ExtensionArray):
 
         return indices.values, uniques
 
+    def reshape(self, *args, **kwargs):
+        raise NotImplementedError(
+            f"{type(self)} does not support reshape "
+            f"as backed by a 1D pyarrow.ChunkedArray."
+        )
+
     def take(
         self,
         indices: TakeIndexer,

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -197,6 +197,10 @@ class TestGetitemTests(base.BaseGetitemTests):
         super().test_loc_iloc_frame_single_dtype(data)
 
 
+class TestBaseIndex(base.BaseIndexTests):
+    pass
+
+
 def test_arrowdtype_construct_from_string_type_with_parameters():
     with pytest.raises(NotImplementedError, match="Passing pyarrow type"):
         ArrowDtype.construct_from_string("timestamp[s][pyarrow]")

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -99,6 +99,10 @@ def na_value():
     return pd.NA
 
 
+class TestBaseCasting(base.BaseCastingTests):
+    pass
+
+
 class TestConstructors(base.BaseConstructorsTests):
     @pytest.mark.xfail(
         reason=(
@@ -109,6 +113,20 @@ class TestConstructors(base.BaseConstructorsTests):
     )
     def test_from_dtype(self, data):
         super().test_from_dtype(data)
+
+
+@pytest.mark.xfail(
+    raises=NotImplementedError, reason="pyarrow.ChunkedArray backing is 1D."
+)
+class TestDim2Compat(base.Dim2CompatTests):
+    pass
+
+
+@pytest.mark.xfail(
+    raises=NotImplementedError, reason="pyarrow.ChunkedArray backing is 1D."
+)
+class TestNDArrayBacked2D(base.NDArrayBacked2DTests):
+    pass
 
 
 class TestGetitemTests(base.BaseGetitemTests):


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Since the backing chunked array is always 1D and not reshapable to 2D with native pyarrow methods, raising a `NotImplementedError` for now. Possible to roll our own reshape possibly in the future.