### PR TITLE
TST: GH39126 Test barh plot with string and integer at the same column

### DIFF
--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -461,7 +461,7 @@ class TestDataFramePlots(TestPlotBase):
             for a, b in zip(plot_bar.get_xticklabels(), expected)
         )
 
-    def test_barh_plot(self):
+    def test_barh_plot_labels_mixed_integer_string(self):
         # GH39126
         # Test barh plot with string and integer at the same column
         from matplotlib.text import Text

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -461,6 +461,21 @@ class TestDataFramePlots(TestPlotBase):
             for a, b in zip(plot_bar.get_xticklabels(), expected)
         )
 
+    def test_barh_plot(self):
+        # GH39126
+        # Test barh plot with string and integer at the same column
+        from matplotlib.text import Text
+
+        df = DataFrame([{"word": 1, "value": 0}, {"word": "knowledg", "value": 2}])
+        plot_barh = df.plot.barh(x="word", legend=None)
+        expected_yticklabels = [Text(0, 0, "1"), Text(0, 1, "knowledg")]
+        assert all(
+            actual.get_text() == expected.get_text()
+            for actual, expected in zip(
+                plot_barh.get_yticklabels(), expected_yticklabels
+            )
+        )
+
     def test_has_externally_shared_axis_x_axis(self):
         # GH33819
         # Test _has_externally_shared_axis() works for x-axis


### PR DESCRIPTION
- [x] closes #39126
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests)
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
