### PR TITLE
BUG: pd.DataFrame.from_records() raises a KeyError if passed a string index and an empty iterable

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -776,7 +776,7 @@ Conversion
 Strings
 ^^^^^^^
 - Bug in :meth:`str.startswith` and :meth:`str.endswith` when using other series as parameter _pat_. Now raises ``TypeError`` (:issue:`3485`)
--
+- Bug in :meth:`DataFrame.from_records` raises a ``KeyError`` if passed a string index and an empty iterable (:isue:`#47285`)
 
 Interval
 ^^^^^^^^

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -776,7 +776,7 @@ Conversion
 Strings
 ^^^^^^^
 - Bug in :meth:`str.startswith` and :meth:`str.endswith` when using other series as parameter _pat_. Now raises ``TypeError`` (:issue:`3485`)
-- Bug in :meth:`DataFrame.from_records` raises a ``KeyError`` if passed a string field label and an empty iterable (:isue:`#47285`)
+- Bug in :meth:`DataFrame.from_records` raises a ``KeyError`` if passed a string field label and an empty iterable (:issue:`47285`)
 
 Interval
 ^^^^^^^^

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -776,7 +776,7 @@ Conversion
 Strings
 ^^^^^^^
 - Bug in :meth:`str.startswith` and :meth:`str.endswith` when using other series as parameter _pat_. Now raises ``TypeError`` (:issue:`3485`)
-- Bug in :meth:`DataFrame.from_records` raises a ``KeyError`` if passed a string index and an empty iterable (:isue:`#47285`)
+- Bug in :meth:`DataFrame.from_records` raises a ``KeyError`` if passed a string field label and an empty iterable (:isue:`#47285`)
 
 Interval
 ^^^^^^^^

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2291,6 +2291,13 @@ class DataFrame(NDFrame, OpsMixin):
             arr_columns = ensure_index(arr_columns)
             if columns is None:
                 columns = arr_columns
+
+                if index is not None:
+                    if isinstance(index, str) or not hasattr(index, "__iter__"):
+                        if index not in columns:
+                            result_index = [index]
+                            index = None
+
             else:
                 arrays, arr_columns, result_index = maybe_reorder(
                     arrays, arr_columns, columns, index

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2296,7 +2296,9 @@ class DataFrame(NDFrame, OpsMixin):
                     if index is not None:
                         if isinstance(index, str) or not hasattr(index, "__iter__"):
                             if index not in columns:
-                                result_index = [index]
+                                # error: Incompatible types in assignment
+                                # type "List[Any]"; expected "Optional[Index]"
+                                result_index = [index]  # type: ignore[assignment]
                                 index = None
 
             else:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2292,11 +2292,12 @@ class DataFrame(NDFrame, OpsMixin):
             if columns is None:
                 columns = arr_columns
 
-                if index is not None:
-                    if isinstance(index, str) or not hasattr(index, "__iter__"):
-                        if index not in columns:
-                            result_index = [index]
-                            index = None
+                if len(arrays) == 0:
+                    if index is not None:
+                        if isinstance(index, str) or not hasattr(index, "__iter__"):
+                            if index not in columns:
+                                result_index = [index]
+                                index = None
 
             else:
                 arrays, arr_columns, result_index = maybe_reorder(

--- a/pandas/tests/io/formats/test_info.py
+++ b/pandas/tests/io/formats/test_info.py
@@ -495,6 +495,5 @@ def test_info_int_columns():
 def test_info_from_rec():
     # GH47285
     df = DataFrame.from_records([], index="foo")
-    print(df.info())
-    #buf = StringIO()
-    #df.info(buf=buf)
+    buf = StringIO()
+    df.info(buf=buf)

--- a/pandas/tests/io/formats/test_info.py
+++ b/pandas/tests/io/formats/test_info.py
@@ -492,6 +492,7 @@ def test_info_int_columns():
     )
     assert result == expected
 
+
 def test_info_from_rec():
     # GH47285
     df = DataFrame.from_records([], index="foo")

--- a/pandas/tests/io/formats/test_info.py
+++ b/pandas/tests/io/formats/test_info.py
@@ -491,3 +491,10 @@ def test_info_int_columns():
         """
     )
     assert result == expected
+
+def test_info_from_rec():
+    # GH47285
+    df = DataFrame.from_records([], index="foo")
+    print(df.info())
+    #buf = StringIO()
+    #df.info(buf=buf)

--- a/pandas/tests/io/formats/test_info.py
+++ b/pandas/tests/io/formats/test_info.py
@@ -492,16 +492,19 @@ def test_info_int_columns():
     )
     assert result == expected
 
+
 def test_info_from_rec():
     # GH47285
     df = DataFrame.from_records([], index="foo")
     buf = StringIO()
     df.info(buf=buf)
 
-    itr = [{"col_1": 3, "col_2": "a"},
-            {"col_1": 2, "col_2": "b"},
-            {"col_1": 1, "col_2": "c"},
-            {"col_1": 0, "col_2": "d"}]
+    itr = [
+        {"col_1": 3, "col_2": "a"},
+        {"col_1": 2, "col_2": "b"},
+        {"col_1": 1, "col_2": "c"},
+        {"col_1": 0, "col_2": "d"},
+    ]
     with pytest.raises(KeyError) as err:
         df = DataFrame.from_records(itr, index="col_14")
     assert "col_14" in str(err.value)

--- a/pandas/tests/io/formats/test_info.py
+++ b/pandas/tests/io/formats/test_info.py
@@ -492,9 +492,17 @@ def test_info_int_columns():
     )
     assert result == expected
 
-
+#@pytest.mark.xfail(raises=KeyError, reason="GH47285: fail on iterable is populated")
 def test_info_from_rec():
     # GH47285
     df = DataFrame.from_records([], index="foo")
     buf = StringIO()
     df.info(buf=buf)
+
+    itr = [{"col_1": 3, "col_2": "a"},
+            {"col_1": 2, "col_2": "b"},
+            {"col_1": 1, "col_2": "c"},
+            {"col_1": 0, "col_2": "d"}]
+    with pytest.raises(KeyError) as err:
+        df = DataFrame.from_records(itr, index="col_14")
+    assert "col_14" in str(err.value)

--- a/pandas/tests/io/formats/test_info.py
+++ b/pandas/tests/io/formats/test_info.py
@@ -492,7 +492,6 @@ def test_info_int_columns():
     )
     assert result == expected
 
-#@pytest.mark.xfail(raises=KeyError, reason="GH47285: fail on iterable is populated")
 def test_info_from_rec():
     # GH47285
     df = DataFrame.from_records([], index="foo")

--- a/pandas/tests/io/formats/test_info.py
+++ b/pandas/tests/io/formats/test_info.py
@@ -505,6 +505,5 @@ def test_info_from_rec():
         {"col_1": 1, "col_2": "c"},
         {"col_1": 0, "col_2": "d"},
     ]
-    with pytest.raises(KeyError) as err:
+    with pytest.raises(KeyError, match="^'col_14'$"):
         df = DataFrame.from_records(itr, index="col_14")
-    assert "col_14" in str(err.value)

--- a/pandas/tests/io/formats/test_info.py
+++ b/pandas/tests/io/formats/test_info.py
@@ -499,6 +499,9 @@ def test_info_from_rec():
     buf = StringIO()
     df.info(buf=buf)
 
+
+def test_info_from_rec_with_itr():
+    # GH47285
     itr = [
         {"col_1": 3, "col_2": "a"},
         {"col_1": 2, "col_2": "b"},
@@ -506,4 +509,4 @@ def test_info_from_rec():
         {"col_1": 0, "col_2": "d"},
     ]
     with pytest.raises(KeyError, match="^'col_14'$"):
-        df = DataFrame.from_records(itr, index="col_14")
+        DataFrame.from_records(itr, index="col_14")


### PR DESCRIPTION
- [x] closes #47285(Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
