### PR TITLE
REGR: Avoid regression warning with ea dtype and assert_index_equal order False

### DIFF
--- a/doc/source/whatsnew/v1.4.3.rst
+++ b/doc/source/whatsnew/v1.4.3.rst
@@ -24,6 +24,7 @@ Fixed regressions
 - Fixed regression in :func:`read_csv` with ``index_col=False`` identifying first row as index names when ``header=None`` (:issue:`46955`)
 - Fixed regression in :meth:`.DataFrameGroupBy.agg` when used with list-likes or dict-likes and ``axis=1`` that would give incorrect results; now raises ``NotImplementedError`` (:issue:`46995`)
 - Fixed regression in :meth:`DataFrame.resample` and :meth:`DataFrame.rolling` when used with list-likes or dict-likes and ``axis=1`` that would raise an unintuitive error message; now raises ``NotImplementedError`` (:issue:`46904`)
+- Fixed regression in :func:`assert_index_equal` when ``check_order=False`` and :class:`Index` has extension dtype (:issue:`47207`)
 - Fixed regression in :func:`read_excel` returning ints as floats on certain input sheets (:issue:`46988`)
 - Fixed regression in :meth:`DataFrame.shift` when ``axis`` is ``columns`` and ``fill_value`` is absent, ``freq`` is ignored (:issue:`47039`)
 

--- a/doc/source/whatsnew/v1.4.3.rst
+++ b/doc/source/whatsnew/v1.4.3.rst
@@ -24,7 +24,7 @@ Fixed regressions
 - Fixed regression in :func:`read_csv` with ``index_col=False`` identifying first row as index names when ``header=None`` (:issue:`46955`)
 - Fixed regression in :meth:`.DataFrameGroupBy.agg` when used with list-likes or dict-likes and ``axis=1`` that would give incorrect results; now raises ``NotImplementedError`` (:issue:`46995`)
 - Fixed regression in :meth:`DataFrame.resample` and :meth:`DataFrame.rolling` when used with list-likes or dict-likes and ``axis=1`` that would raise an unintuitive error message; now raises ``NotImplementedError`` (:issue:`46904`)
-- Fixed regression in :func:`assert_index_equal` when ``check_order=False`` and :class:`Index` has extension dtype (:issue:`47207`)
+- Fixed regression in :func:`assert_index_equal` when ``check_order=False`` and :class:`Index` has extension or object dtype (:issue:`47207`)
 - Fixed regression in :func:`read_excel` returning ints as floats on certain input sheets (:issue:`46988`)
 - Fixed regression in :meth:`DataFrame.shift` when ``axis`` is ``columns`` and ``fill_value`` is absent, ``freq`` is ignored (:issue:`47039`)
 

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -367,8 +367,8 @@ def assert_index_equal(
 
     # If order doesn't matter then sort the index entries
     if not check_order:
-        left = Index(safe_sort(left))
-        right = Index(safe_sort(right))
+        left = Index(safe_sort(left), dtype=left.dtype)
+        right = Index(safe_sort(right), dtype=right.dtype)
 
     # MultiIndex special comparison for little-friendly error messages
     if left.nlevels > 1:

--- a/pandas/tests/util/test_assert_index_equal.py
+++ b/pandas/tests/util/test_assert_index_equal.py
@@ -242,3 +242,10 @@ def test_assert_index_equal_mixed_dtype():
     # GH#39168
     idx = Index(["foo", "bar", 42])
     tm.assert_index_equal(idx, idx, check_order=False)
+
+
+def test_assert_index_equal_ea_dtype_order_false(any_numeric_ea_dtype):
+    # GH#47207
+    idx1 = Index([1, 3], dtype=any_numeric_ea_dtype)
+    idx2 = Index([3, 1], dtype=any_numeric_ea_dtype)
+    tm.assert_index_equal(idx1, idx2, check_order=False)

--- a/pandas/tests/util/test_assert_index_equal.py
+++ b/pandas/tests/util/test_assert_index_equal.py
@@ -249,3 +249,10 @@ def test_assert_index_equal_ea_dtype_order_false(any_numeric_ea_dtype):
     idx1 = Index([1, 3], dtype=any_numeric_ea_dtype)
     idx2 = Index([3, 1], dtype=any_numeric_ea_dtype)
     tm.assert_index_equal(idx1, idx2, check_order=False)
+
+
+def test_assert_index_equal_object_ints_order_false(any_numeric_ea_dtype):
+    # GH#47207
+    idx1 = Index([1, 3], dtype="object")
+    idx2 = Index([3, 1], dtype="object")
+    tm.assert_index_equal(idx1, idx2, check_order=False)

--- a/pandas/tests/util/test_assert_index_equal.py
+++ b/pandas/tests/util/test_assert_index_equal.py
@@ -251,7 +251,7 @@ def test_assert_index_equal_ea_dtype_order_false(any_numeric_ea_dtype):
     tm.assert_index_equal(idx1, idx2, check_order=False)
 
 
-def test_assert_index_equal_object_ints_order_false(any_numeric_ea_dtype):
+def test_assert_index_equal_object_ints_order_false():
     # GH#47207
     idx1 = Index([1, 3], dtype="object")
     idx2 = Index([3, 1], dtype="object")


### PR DESCRIPTION
- [x] closes #47207 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
