### PR TITLE
BUG: Series.setitem losing precision when enlarging

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -823,6 +823,7 @@ Indexing
 - Bug in :meth:`Series.__setitem__` where setting :attr:`NA` into a numeric-dtpye :class:`Series` would incorrectly upcast to object-dtype rather than treating the value as ``np.nan`` (:issue:`44199`)
 - Bug in :meth:`Series.__setitem__` with ``datetime64[ns]`` dtype, an all-``False`` boolean mask, and an incompatible value incorrectly casting to ``object`` instead of retaining ``datetime64[ns]`` dtype (:issue:`45967`)
 - Bug in :meth:`Index.__getitem__`  raising ``ValueError`` when indexer is from boolean dtype with ``NA`` (:issue:`45806`)
+- Bug in :meth:`Series.__setitem__` losing precision when enlarging :class:`Series` with scalar (:issue:`32346`)
 - Bug in :meth:`Series.mask` with ``inplace=True`` or setting values with a boolean mask with small integer dtypes incorrectly raising (:issue:`45750`)
 - Bug in :meth:`DataFrame.mask` with ``inplace=True`` and ``ExtensionDtype`` columns incorrectly raising (:issue:`45577`)
 - Bug in getting a column from a DataFrame with an object-dtype row index with datetime-like values: the resulting Series now preserves the exact object-dtype Index from the parent DataFrame (:issue:`42950`)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2087,7 +2087,7 @@ class _iLocIndexer(_LocationIndexer):
                     return self._setitem_with_indexer(new_indexer, value, "loc")
 
             # this preserves dtype of the value and of the object
-            if isna(value):
+            if isna(value == value):
                 new_dtype = self.obj.dtype
             elif not self.obj.empty and not is_object_dtype(self.obj.dtype):
                 # We should not cast, if we have object dtype because we can

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2092,7 +2092,7 @@ class _iLocIndexer(_LocationIndexer):
             if is_valid_na_for_dtype(value, self.obj.dtype):
                 value = na_value_for_dtype(self.obj.dtype, compat=False)
                 new_dtype = maybe_promote(self.obj.dtype, value)[0]
-            elif not is_valid_na_for_dtype(value, self.obj.dtype):
+            elif isna(value):
                 new_dtype = None
             elif not self.obj.empty and not is_object_dtype(self.obj.dtype):
                 # We should not cast, if we have object dtype because we can

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -550,6 +550,7 @@ class TestSetitemWithExpansion:
             (NaT, NaT, "int64", "object"),
             (np.nan, NA, "Int64", "Int64"),
             (np.nan, NA, "Float64", "Float64"),
+            (np.nan, np.nan, "int64", "float64"),
         ],
     )
     def test_setitem_enlarge_with_na(self, na, target_na, dtype, target_dtype, indexer):
@@ -558,13 +559,6 @@ class TestSetitemWithExpansion:
         ser[indexer] = na
         expected_values = [1, target_na] if indexer == 1 else [1, 2, target_na]
         expected = Series(expected_values, dtype=target_dtype)
-        tm.assert_series_equal(ser, expected)
-
-    def test_setitem_enlarge_with_nan(self):
-        # GH#32346
-        ser = Series([1, 2])
-        ser[2] = np.nan
-        expected = Series([1, 2, np.nan])
         tm.assert_series_equal(ser, expected)
 
 

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -541,11 +541,23 @@ class TestSetitemWithExpansion:
         expected = Series([1, 2, 10], dtype=any_numeric_ea_dtype)
         tm.assert_series_equal(ser, expected)
 
-    def test_setitem_enlarge_with_na(self):
+    @pytest.mark.parametrize("indexer", [1, 2])
+    @pytest.mark.parametrize(
+        "na, target_na, dtype, target_dtype",
+        [
+            (NA, NA, "Int64", "Int64"),
+            (NA, np.nan, "int64", "float64"),
+            (NaT, NaT, "int64", "object"),
+            (np.nan, NA, "Int64", "Int64"),
+            (np.nan, NA, "Float64", "Float64"),
+        ],
+    )
+    def test_setitem_enlarge_with_na(self, na, target_na, dtype, target_dtype, indexer):
         # GH#32346
-        ser = Series([1, 2], dtype="Int64")
-        ser[2] = NA
-        expected = Series([1, 2, NA], dtype="Int64")
+        ser = Series([1, 2], dtype=dtype)
+        ser[indexer] = na
+        expected_values = [1, target_na] if indexer == 1 else [1, 2, target_na]
+        expected = Series(expected_values, dtype=target_dtype)
         tm.assert_series_equal(ser, expected)
 
     def test_setitem_enlarge_with_nan(self):

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -548,6 +548,13 @@ class TestSetitemWithExpansion:
         expected = Series([1, 2, NA], dtype="Int64")
         tm.assert_series_equal(ser, expected)
 
+    def test_setitem_enlarge_with_nan(self):
+        # GH#32346
+        ser = Series([1, 2])
+        ser[2] = np.nan
+        expected = Series([1, 2, np.nan])
+        tm.assert_series_equal(ser, expected)
+
 
 def test_setitem_scalar_into_readonly_backing_data():
     # GH#14359: test that you cannot mutate a read only buffer

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -534,6 +534,20 @@ class TestSetitemWithExpansion:
         expected = concat([string_series, app])
         tm.assert_series_equal(ser, expected)
 
+    def test_setitem_keep_precision(self, any_numeric_ea_dtype):
+        # GH#32346
+        ser = Series([1, 2], dtype=any_numeric_ea_dtype)
+        ser[2] = 10
+        expected = Series([1, 2, 10], dtype=any_numeric_ea_dtype)
+        tm.assert_series_equal(ser, expected)
+
+    def test_setitem_enlarge_with_na(self):
+        # GH#32346
+        ser = Series([1, 2], dtype="Int64")
+        ser[2] = NA
+        expected = Series([1, 2, NA], dtype="Int64")
+        tm.assert_series_equal(ser, expected)
+
 
 def test_setitem_scalar_into_readonly_backing_data():
     # GH#14359: test that you cannot mutate a read only buffer


### PR DESCRIPTION
- [x] xref #32346 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

We have to preserve the dtype here. This only fixes this case for Series, not for DataFames
