### PR TITLE
ENH: Timestamp.__sub__(datetimelike) support non-nano

### DIFF
--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -479,10 +479,17 @@ cdef class _Timestamp(ABCTimestamp):
 
             # We allow silent casting to the lower resolution if and only
             #  if it is lossless.
-            if self._reso < other._reso:
-                other = (<_Timestamp>other)._as_reso(self._reso, round_ok=False)
-            elif self._reso > other._reso:
-                self = (<_Timestamp>self)._as_reso(other._reso, round_ok=False)
+            try:
+                if self._reso < other._reso:
+                    other = (<_Timestamp>other)._as_reso(self._reso, round_ok=False)
+                elif self._reso > other._reso:
+                    self = (<_Timestamp>self)._as_reso(other._reso, round_ok=False)
+            except ValueError as err:
+                raise ValueError(
+                    "Timestamp subtraction with mismatched resolutions is not "
+                    "allowed when casting to the lower resolution would require "
+                    "lossy rounding."
+                ) from err
 
             # scalar Timestamp/datetime - Timestamp/datetime -> yields a
             # Timedelta

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -400,10 +400,14 @@ cdef class _Timestamp(ABCTimestamp):
                 new_value = int(self.value) + int(nanos)
 
             try:
-                result = type(self)._from_value_and_reso(new_value, reso=self._reso, tz=self.tzinfo)
+                result = type(self)._from_value_and_reso(
+                    new_value, reso=self._reso, tz=self.tzinfo
+                )
             except OverflowError as err:
                 # TODO: don't hard-code nanosecond here
-                raise OutOfBoundsDatetime(f"Out of bounds nanosecond timestamp: {new_value}") from err
+                raise OutOfBoundsDatetime(
+                    f"Out of bounds nanosecond timestamp: {new_value}"
+                ) from err
 
             if result is not NaT:
                 result._set_freq(self._freq)  # avoid warning in constructor

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -914,11 +914,22 @@ class TestNonNano:
         assert result.month == 12
         assert tz_compare(result.tz, ts_tz.tz)
 
+        result = ts_tz - off
+
+        assert isinstance(result, Timestamp)
+        assert result._reso == ts_tz._reso
+        assert result.year == ts_tz.year - 1
+        assert result.day == 31
+        assert result.month == 12
+        assert tz_compare(result.tz, ts_tz.tz)
+
     def test_sub_datetimelike_mismatched_reso(self, ts_tz):
         # case with non-lossy rounding
         ts = ts_tz
 
-        #  choose a unit for `other` that doesn't match ts_tz's
+        # choose a unit for `other` that doesn't match ts_tz's;
+        #  this construction ensures we get cases with other._reso < ts._reso
+        #  and cases with other._reso > ts._reso
         unit = {
             NpyDatetimeUnit.NPY_FR_us.value: "ms",
             NpyDatetimeUnit.NPY_FR_ms.value: "s",
@@ -937,8 +948,7 @@ class TestNonNano:
         assert result.value == 0
         assert result._reso == min(ts._reso, other._reso)
 
-        # TODO: clarify in message that add/sub is allowed only when lossless?
-        msg = "Cannot losslessly convert units"
+        msg = "Timestamp subtraction with mismatched resolutions"
         if ts._reso < other._reso:
             # Case where rounding is lossy
             other2 = other + Timedelta._from_value_and_reso(1, other._reso)

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -22,6 +22,7 @@ from pandas._libs.tslibs.dtypes import NpyDatetimeUnit
 from pandas._libs.tslibs.timezones import (
     dateutil_gettz as gettz,
     get_timezone,
+    maybe_get_tz,
     tz_compare,
 )
 from pandas.errors import OutOfBoundsDatetime
@@ -712,6 +713,11 @@ class TestNonNano:
     def ts(self, dt64):
         return Timestamp._from_dt64(dt64)
 
+    @pytest.fixture
+    def ts_tz(self, ts, tz_aware_fixture):
+        tz = maybe_get_tz(tz_aware_fixture)
+        return Timestamp._from_value_and_reso(ts.value, ts._reso, tz)
+
     def test_non_nano_construction(self, dt64, ts, reso):
         assert ts.value == dt64.view("i8")
 
@@ -892,6 +898,60 @@ class TestNonNano:
         assert isinstance(result, Timestamp)
         assert result._reso == ts._reso
         assert result == expected
+
+    @pytest.mark.xfail(reason="tz_localize not yet implemented for non-nano")
+    def test_addsub_offset(self, ts_tz):
+        # specifically non-Tick offset
+        off = offsets.YearBegin(1)
+        result = ts_tz + off
+
+        assert isinstance(result, Timestamp)
+        assert result._reso == ts_tz._reso
+        # If ts_tz is ever on the last day of the year, the year would be
+        #  incremented by one
+        assert result.year == ts_tz.year
+        assert result.day == 31
+        assert result.month == 12
+        assert tz_compare(result.tz, ts_tz.tz)
+
+    def test_sub_datetimelike_mismatched_reso(self, ts_tz):
+        # case with non-lossy rounding
+        ts = ts_tz
+
+        #  choose a unit for `other` that doesn't match ts_tz's
+        unit = {
+            NpyDatetimeUnit.NPY_FR_us.value: "ms",
+            NpyDatetimeUnit.NPY_FR_ms.value: "s",
+            NpyDatetimeUnit.NPY_FR_s.value: "us",
+        }[ts._reso]
+        other = ts._as_unit(unit)
+        assert other._reso != ts._reso
+
+        result = ts - other
+        assert isinstance(result, Timedelta)
+        assert result.value == 0
+        assert result._reso == min(ts._reso, other._reso)
+
+        result = other - ts
+        assert isinstance(result, Timedelta)
+        assert result.value == 0
+        assert result._reso == min(ts._reso, other._reso)
+
+        # TODO: clarify in message that add/sub is allowed only when lossless?
+        msg = "Cannot losslessly convert units"
+        if ts._reso < other._reso:
+            # Case where rounding is lossy
+            other2 = other + Timedelta._from_value_and_reso(1, other._reso)
+            with pytest.raises(ValueError, match=msg):
+                ts - other2
+            with pytest.raises(ValueError, match=msg):
+                other2 - ts
+        else:
+            ts2 = ts + Timedelta._from_value_and_reso(1, ts._reso)
+            with pytest.raises(ValueError, match=msg):
+                ts2 - other
+            with pytest.raises(ValueError, match=msg):
+                other - ts2
 
 
 class TestAsUnit:


### PR DESCRIPTION
With mixed resos, cast to the lower reso, and only if doing so is lossless.