### PR TITLE
ENH: Move IndexingError to error/__init__.py per GH27656

### DIFF
--- a/doc/source/reference/testing.rst
+++ b/doc/source/reference/testing.rst
@@ -30,6 +30,7 @@ Exceptions and warnings
    errors.DtypeWarning
    errors.DuplicateLabelError
    errors.EmptyDataError
+   errors.IndexingError
    errors.InvalidIndexError
    errors.IntCastingNaNError
    errors.MergeError

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -174,7 +174,7 @@ Other enhancements
 - A :class:`errors.PerformanceWarning` is now thrown when using ``string[pyarrow]`` dtype with methods that don't dispatch to ``pyarrow.compute`` methods (:issue:`42613`)
 - Added ``numeric_only`` argument to :meth:`Resampler.sum`, :meth:`Resampler.prod`, :meth:`Resampler.min`, :meth:`Resampler.max`, :meth:`Resampler.first`, and :meth:`Resampler.last` (:issue:`46442`)
 - ``times`` argument in :class:`.ExponentialMovingWindow` now accepts ``np.timedelta64`` (:issue:`47003`)
-- :class:`DataError`, :class:`SpecificationError`, :class:`SettingWithCopyError`, :class:`SettingWithCopyWarning`, :class:`NumExprClobberingError`, :class:`UndefinedVariableError` are now exposed in ``pandas.errors`` (:issue:`27656`)
+- :class:`DataError`, :class:`SpecificationError`, :class:`SettingWithCopyError`, :class:`SettingWithCopyWarning`, :class:`NumExprClobberingError`, :class:`UndefinedVariableError`, and :class:`IndexingError` are now exposed in ``pandas.errors`` (:issue:`27656`)
 - Added ``check_like`` argument to :func:`testing.assert_series_equal` (:issue:`47247`)
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -16,6 +16,7 @@ from pandas._libs.indexing import NDFrameIndexerBase
 from pandas._libs.lib import item_from_zerodim
 from pandas.errors import (
     AbstractMethodError,
+    IndexingError,
     InvalidIndexError,
 )
 from pandas.util._decorators import doc
@@ -119,10 +120,6 @@ class _IndexSlice:
 
 
 IndexSlice = _IndexSlice()
-
-
-class IndexingError(Exception):
-    pass
 
 
 class IndexingMixin:

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -353,3 +353,24 @@ class UndefinedVariableError(NameError):
         else:
             msg = f"name {base_msg}"
         super().__init__(msg)
+
+
+class IndexingError(Exception):
+    """
+    Exception is raised when trying to index and there is a mismatch in dimensions.
+
+    Examples
+    --------
+    >>> df = pd.DataFrame({'A': [1, 1, 1]})
+    >>> df.loc[..., ..., 'A'] # doctest: +SKIP
+    ... # IndexingError: indexer may only contain one '...' entry
+    >>> df = pd.DataFrame({'A': [1, 1, 1]})
+    >>> df.loc[1, ..., ...] # doctest: +SKIP
+    ... # IndexingError: Too many indexers
+    >>> df[pd.Series([True], dtype=bool)] # doctest: +SKIP
+    ... # IndexingError: Unalignable boolean Series provided as indexer...
+    >>> s = pd.Series(range(2),
+    ...               index = pd.MultiIndex.from_product([["a", "b"], ["c"]]))
+    >>> s.loc["a", "c", "d"] # doctest: +SKIP
+    ... # IndexingError: Too many indexers
+    """

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -3,6 +3,7 @@ import operator
 import numpy as np
 import pytest
 
+from pandas.errors import UndefinedVariableError
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -495,8 +496,6 @@ class TestDataFrameQueryNumExprPandas:
             df.query("i - +", engine=engine, parser=parser)
 
     def test_query_scope(self):
-        from pandas.errors import UndefinedVariableError
-
         engine, parser = self.engine, self.parser
         skip_if_no_pandas_parser(parser)
 
@@ -522,8 +521,6 @@ class TestDataFrameQueryNumExprPandas:
             df.query("@a > b > c", engine=engine, parser=parser)
 
     def test_query_doesnt_pickup_local(self):
-        from pandas.errors import UndefinedVariableError
-
         engine, parser = self.engine, self.parser
         n = m = 10
         df = DataFrame(np.random.randint(m, size=(n, 3)), columns=list("abc"))
@@ -618,8 +615,6 @@ class TestDataFrameQueryNumExprPandas:
         tm.assert_frame_equal(result, expected)
 
     def test_nested_raises_on_local_self_reference(self):
-        from pandas.errors import UndefinedVariableError
-
         df = DataFrame(np.random.randn(5, 3))
 
         # can't reference ourself b/c we're a local so @ is necessary
@@ -678,8 +673,6 @@ class TestDataFrameQueryNumExprPandas:
         tm.assert_frame_equal(result, expected)
 
     def test_query_undefined_local(self):
-        from pandas.errors import UndefinedVariableError
-
         engine, parser = self.engine, self.parser
         skip_if_no_pandas_parser(parser)
 
@@ -838,8 +831,6 @@ class TestDataFrameQueryNumExprPython(TestDataFrameQueryNumExprPandas):
             df.query("index < 20130101 < dates3", engine=engine, parser=parser)
 
     def test_nested_scope(self):
-        from pandas.errors import UndefinedVariableError
-
         engine = self.engine
         parser = self.parser
         # smoke test

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -1,7 +1,10 @@
 import numpy as np
 import pytest
 
-from pandas.errors import PerformanceWarning
+from pandas.errors import (
+    IndexingError,
+    PerformanceWarning,
+)
 
 import pandas as pd
 from pandas import (
@@ -11,7 +14,6 @@ from pandas import (
     Series,
 )
 import pandas._testing as tm
-from pandas.core.indexing import IndexingError
 
 
 @pytest.fixture

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 
 from pandas.compat.numpy import is_numpy_min
+from pandas.errors import IndexingError
 import pandas.util._test_decorators as td
 
 from pandas import (
@@ -32,7 +33,6 @@ from pandas import (
 )
 import pandas._testing as tm
 from pandas.api.types import is_scalar
-from pandas.core.indexing import IndexingError
 from pandas.tests.indexing.common import Base
 
 # We pass through the error message from numpy

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -7,6 +7,8 @@ import weakref
 import numpy as np
 import pytest
 
+from pandas.errors import IndexingError
+
 from pandas.core.dtypes.common import (
     is_float_dtype,
     is_integer_dtype,
@@ -24,7 +26,6 @@ from pandas import (
 )
 import pandas._testing as tm
 from pandas.core.api import Float64Index
-from pandas.core.indexing import IndexingError
 from pandas.tests.indexing.common import _mklbl
 from pandas.tests.indexing.test_floats import gen_obj
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -12,6 +12,7 @@ from dateutil.tz import gettz
 import numpy as np
 import pytest
 
+from pandas.errors import IndexingError
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -36,10 +37,7 @@ from pandas import (
 import pandas._testing as tm
 from pandas.api.types import is_scalar
 from pandas.core.api import Float64Index
-from pandas.core.indexing import (
-    IndexingError,
-    _one_ellipsis_message,
-)
+from pandas.core.indexing import _one_ellipsis_message
 from pandas.tests.indexing.common import Base
 
 

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -6,6 +6,8 @@ from datetime import (
 import numpy as np
 import pytest
 
+from pandas.errors import IndexingError
+
 from pandas.core.dtypes.common import is_list_like
 
 from pandas import (
@@ -30,7 +32,6 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.core.indexing import IndexingError
 
 from pandas.tseries.offsets import BDay
 

--- a/pandas/tests/test_errors.py
+++ b/pandas/tests/test_errors.py
@@ -27,6 +27,7 @@ import pandas as pd
         "SettingWithCopyError",
         "SettingWithCopyWarning",
         "NumExprClobberingError",
+        "IndexingError",
     ],
 )
 def test_exception_importable(exc):


### PR DESCRIPTION
- [x] xref #27656. this GitHub issue is being done in multiple parts
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v1.5.0.rst` file if fixing a bug or adding a new feature.

I moved the `from pandas.errors import UndefinedVariableError` statement to the top for `pandas/tests/frame/test_query_eval.py` as a follow up from a comment on https://github.com/pandas-dev/pandas/pull/47338.
