### PR TITLE
BUG: read_csv may interpret second row as index names even if index_col is False

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -861,6 +861,7 @@ I/O
 - Bug in :func:`read_csv` not recognizing line break for ``on_bad_lines="warn"`` for ``engine="c"`` (:issue:`41710`)
 - Bug in :meth:`DataFrame.to_csv` not respecting ``float_format`` for ``Float64`` dtype (:issue:`45991`)
 - Bug in :func:`read_csv` not respecting a specified converter to index columns in all cases (:issue:`40589`)
+- Bug in :func:`read_csv` interpreting second row as :class:`Index` names even when ``header`` is given as an integer (:issue:`46569`)
 - Bug in :func:`read_parquet` when ``engine="pyarrow"`` which caused partial write to disk when column of unsupported datatype was passed (:issue:`44914`)
 - Bug in :func:`DataFrame.to_excel` and :class:`ExcelWriter` would raise when writing an empty DataFrame to a ``.ods`` file (:issue:`45793`)
 - Bug in :func:`read_html` where elements surrounding ``<br>`` were joined without a space between them (:issue:`29528`)

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -861,7 +861,7 @@ I/O
 - Bug in :func:`read_csv` not recognizing line break for ``on_bad_lines="warn"`` for ``engine="c"`` (:issue:`41710`)
 - Bug in :meth:`DataFrame.to_csv` not respecting ``float_format`` for ``Float64`` dtype (:issue:`45991`)
 - Bug in :func:`read_csv` not respecting a specified converter to index columns in all cases (:issue:`40589`)
-- Bug in :func:`read_csv` interpreting second row as :class:`Index` names even when ``header`` is given as an integer (:issue:`46569`)
+- Bug in :func:`read_csv` interpreting second row as :class:`Index` names even when ``index_col=False`` (:issue:`46569`)
 - Bug in :func:`read_parquet` when ``engine="pyarrow"`` which caused partial write to disk when column of unsupported datatype was passed (:issue:`44914`)
 - Bug in :func:`DataFrame.to_excel` and :class:`ExcelWriter` would raise when writing an empty DataFrame to a ``.ods`` file (:issue:`45793`)
 - Bug in :func:`read_html` where elements surrounding ``<br>`` were joined without a space between them (:issue:`29528`)

--- a/pandas/io/parsers/python_parser.py
+++ b/pandas/io/parsers/python_parser.py
@@ -101,6 +101,8 @@ class PythonParser(ParserBase):
 
         self.comment = kwds["comment"]
 
+        self._passed_header = kwds.get("_header_passed")
+
         # Set self.data to something that can read lines.
         if isinstance(f, list):
             # read_excel: f is a list
@@ -933,7 +935,11 @@ class PythonParser(ParserBase):
                 implicit_first_cols = len(line) - self.num_original_columns
 
             # Case 0
-            if next_line is not None and self.header is not None:
+            if (
+                next_line is not None
+                and self.header is not None
+                and not isinstance(self._passed_header, int)
+            ):
                 if len(next_line) == len(line) + self.num_original_columns:
                     # column and index names on diff rows
                     self.index_col = list(range(len(line)))

--- a/pandas/io/parsers/python_parser.py
+++ b/pandas/io/parsers/python_parser.py
@@ -101,8 +101,6 @@ class PythonParser(ParserBase):
 
         self.comment = kwds["comment"]
 
-        self._passed_header = kwds.get("_header_passed")
-
         # Set self.data to something that can read lines.
         if isinstance(f, list):
             # read_excel: f is a list
@@ -938,7 +936,7 @@ class PythonParser(ParserBase):
             if (
                 next_line is not None
                 and self.header is not None
-                and not isinstance(self._passed_header, int)
+                and index_col is not False
             ):
                 if len(next_line) == len(line) + self.num_original_columns:
                     # column and index names on diff rows

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -1396,7 +1396,8 @@ class TextFileReader(abc.Iterator):
                 )
             kwds = _merge_with_dialect_properties(dialect, kwds)
 
-        if kwds.get("header", "infer") == "infer":
+        header = kwds.get("header", "infer")
+        if header == "infer":
             kwds["header"] = 0 if kwds.get("names") is None else None
 
         self.orig_options = kwds
@@ -1417,6 +1418,9 @@ class TextFileReader(abc.Iterator):
 
         if "has_index_names" in kwds:
             self.options["has_index_names"] = kwds["has_index_names"]
+
+        if self.engine == "python":
+            self.options["_header_passed"] = header
 
         self.handles: IOHandles | None = None
         self._engine = self._make_engine(f, self.engine)

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -1396,8 +1396,7 @@ class TextFileReader(abc.Iterator):
                 )
             kwds = _merge_with_dialect_properties(dialect, kwds)
 
-        header = kwds.get("header", "infer")
-        if header == "infer":
+        if kwds.get("header", "infer") == "infer":
             kwds["header"] = 0 if kwds.get("names") is None else None
 
         self.orig_options = kwds
@@ -1418,9 +1417,6 @@ class TextFileReader(abc.Iterator):
 
         if "has_index_names" in kwds:
             self.options["has_index_names"] = kwds["has_index_names"]
-
-        if self.engine == "python":
-            self.options["_header_passed"] = header
 
         self.handles: IOHandles | None = None
         self._engine = self._make_engine(f, self.engine)

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -466,6 +466,17 @@ def test_index_col_false_and_header_none(python_parser_only):
 0.5,0.03
 0.1,0.2,0.3,2
 """
-    result = parser.read_csv(StringIO(data), sep=",", header=None, index_col=False)
+    with tm.assert_produces_warning(ParserWarning, match="Length of header"):
+        result = parser.read_csv(StringIO(data), sep=",", header=None, index_col=False)
     expected = DataFrame({0: [0.5, 0.1], 1: [0.03, 0.2]})
+    tm.assert_frame_equal(result, expected)
+
+
+def test_header_int_do_not_infer_multiindex_names_on_different_line(python_parser_only):
+    # GH#46569
+    parser = python_parser_only
+    data = StringIO("a\na,b\nc,d,e\nf,g,h")
+    with tm.assert_produces_warning(ParserWarning, match="Length of header"):
+        result = parser.read_csv(data, engine="python", index_col=False, header=0)
+    expected = DataFrame({"a": ["a", "c", "f"]})
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -477,6 +477,6 @@ def test_header_int_do_not_infer_multiindex_names_on_different_line(python_parse
     parser = python_parser_only
     data = StringIO("a\na,b\nc,d,e\nf,g,h")
     with tm.assert_produces_warning(ParserWarning, match="Length of header"):
-        result = parser.read_csv(data, engine="python", index_col=False, header=0)
+        result = parser.read_csv(data, engine="python", index_col=False)
     expected = DataFrame({"a": ["a", "c", "f"]})
     tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #46569 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

I think index_col should take precedence over guessing