### PR TITLE
PERF: Performance improvement on dataframe.update. 

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8000,7 +8000,7 @@ Keep all original rows and columns and also all original values
             if mask.all():
                 continue
 
-            self[col] = expressions.where(mask, this, that)
+            self.loc[:, col] = expressions.where(mask, this, that)
 
     # ----------------------------------------------------------------------
     # Data reshaping


### PR DESCRIPTION
the setitem under the hood is doing df copy per https://github.com/pandas-dev/pandas/issues/46267
therefore, the performance is compromised, per the suggestion, using loc for assignment instead 
see the detail example in the issue link for metrics.

- [X] closes #47392 (Replace xxxx with the Github issue number)

~Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature~
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

~Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.~
~Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.~
