### PR TITLE
Fix segmentation fault when JSON serializing a PeriodIndex

### DIFF
--- a/doc/source/whatsnew/v1.4.3.rst
+++ b/doc/source/whatsnew/v1.4.3.rst
@@ -30,7 +30,7 @@ Fixed regressions
 - Fixed regression in :func:`assert_index_equal` when ``check_order=False`` and :class:`Index` has extension or object dtype (:issue:`47207`)
 - Fixed regression in :func:`read_excel` returning ints as floats on certain input sheets (:issue:`46988`)
 - Fixed regression in :meth:`DataFrame.shift` when ``axis`` is ``columns`` and ``fill_value`` is absent, ``freq`` is ignored (:issue:`47039`)
-- Fixed regression in :meth:`DataFrame.to_json` when ``index`` is of the type :class:`PeriodIndex` causing a segmentation violation (:issue:`46683`)
+- Fixed regression in :meth:`DataFrame.to_json` causing a segmentation violation when :class:`DataFrame` is created with an ``index`` of the type :class:`PeriodIndex` (:issue:`46683`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.4.3.rst
+++ b/doc/source/whatsnew/v1.4.3.rst
@@ -30,7 +30,7 @@ Fixed regressions
 - Fixed regression in :func:`assert_index_equal` when ``check_order=False`` and :class:`Index` has extension or object dtype (:issue:`47207`)
 - Fixed regression in :func:`read_excel` returning ints as floats on certain input sheets (:issue:`46988`)
 - Fixed regression in :meth:`DataFrame.shift` when ``axis`` is ``columns`` and ``fill_value`` is absent, ``freq`` is ignored (:issue:`47039`)
-- Fixed regression in :meth:`DataFrame.to_json` when ``index`` is of the type ``PeriodIndex`` causing a segmentation violation (:issue:`46683`)
+- Fixed regression in :meth:`DataFrame.to_json` when ``index`` is of the type :class:`PeriodIndex` causing a segmentation violation (:issue:`46683`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.4.3.rst
+++ b/doc/source/whatsnew/v1.4.3.rst
@@ -30,7 +30,7 @@ Fixed regressions
 - Fixed regression in :func:`assert_index_equal` when ``check_order=False`` and :class:`Index` has extension or object dtype (:issue:`47207`)
 - Fixed regression in :func:`read_excel` returning ints as floats on certain input sheets (:issue:`46988`)
 - Fixed regression in :meth:`DataFrame.shift` when ``axis`` is ``columns`` and ``fill_value`` is absent, ``freq`` is ignored (:issue:`47039`)
-- Fixed regression in :meth:`DataFrame.to_json` causing a segmentation violation when :class:`DataFrame` is created with an ``index`` of the type :class:`PeriodIndex` (:issue:`46683`)
+- Fixed regression in :meth:`DataFrame.to_json` causing a segmentation violation when :class:`DataFrame` is created with an ``index`` parameter of the type :class:`PeriodIndex` (:issue:`46683`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.4.3.rst
+++ b/doc/source/whatsnew/v1.4.3.rst
@@ -30,6 +30,7 @@ Fixed regressions
 - Fixed regression in :func:`assert_index_equal` when ``check_order=False`` and :class:`Index` has extension or object dtype (:issue:`47207`)
 - Fixed regression in :func:`read_excel` returning ints as floats on certain input sheets (:issue:`46988`)
 - Fixed regression in :meth:`DataFrame.shift` when ``axis`` is ``columns`` and ``fill_value`` is absent, ``freq`` is ignored (:issue:`47039`)
+- Fixed regression in :meth:`DataFrame.to_json` when ``index`` is of the type ``PeriodIndex`` causing a segmentation violation (:issue:`46683`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -238,7 +238,8 @@ static PyObject *get_values(PyObject *obj) {
             PyErr_Clear();
         } else if (PyObject_HasAttrString(values, "__array__")) {
             // We may have gotten a Categorical or Sparse array so call np.array
-            PyObject *array_values = PyObject_CallMethod(values, "__array__", NULL);
+            PyObject *array_values = PyObject_CallMethod(values, "__array__",
+                                                         NULL);
             Py_DECREF(values);
             values = array_values;
         } else if (!PyArray_CheckExact(values)) {

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -238,8 +238,9 @@ static PyObject *get_values(PyObject *obj) {
             PyErr_Clear();
         } else if (PyObject_HasAttrString(values, "__array__")) {
             // We may have gotten a Categorical or Sparse array so call np.array
+            PyObject *array_values = PyObject_CallMethod(values, "__array__", NULL);
             Py_DECREF(values);
-            values = PyObject_CallMethod(values, "__array__", NULL);
+            values = array_values;
         } else if (!PyArray_CheckExact(values)) {
             // Didn't get a numpy array, so keep trying
             Py_DECREF(values);

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -23,6 +23,7 @@ from pandas import (
     DatetimeIndex,
     Index,
     NaT,
+    PeriodIndex,
     Series,
     Timedelta,
     Timestamp,
@@ -1240,3 +1241,9 @@ class TestPandasJSONTests:
         expected = f'"{td.isoformat()}"'
 
         assert result == expected
+
+    def test_encode_periodindex(self):
+        # GH 46683
+        p = PeriodIndex(["2022-04-06", "2022-04-07"], freq="D")
+        df = DataFrame(index=p)
+        assert df.to_json() == "{}"


### PR DESCRIPTION
Fixes #46683

- [x] closes #46683
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
