### PR TITLE
DOC: Remove unused/flaky statsmodels intersphinx_mapping

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -447,7 +447,6 @@ if include_api:
         "py": ("https://pylib.readthedocs.io/en/latest/", None),
         "python": ("https://docs.python.org/3/", None),
         "scipy": ("https://docs.scipy.org/doc/scipy/", None),
-        "statsmodels": ("https://www.statsmodels.org/devel/", None),
         "pyarrow": ("https://arrow.apache.org/docs/", None),
     }
 


### PR DESCRIPTION
The doc build can occasionally fail with 

```
2022-06-21T19:46:59.4564919Z WARNING: failed to reach any of the inventories with the following issues:
2022-06-21T19:46:59.4567149Z intersphinx inventory 'https://www.statsmodels.org/devel/objects.inv' not fetchable due to <class 'requests.exceptions.ConnectionError'>: HTTPSConnectionPool(host='www.statsmodels.org', port=443): Max retries exceeded with url: /devel/objects.inv (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7fd05f1ee8b0>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution'))
```

Looking through our docs, we don't have a sphinx reference to the statsmodel docs so probably safe to remove to avoid flakiness.
