### PR TITLE
Fix signature of initObjToJSON

### DIFF
--- a/pandas/_libs/src/ujson/python/ujson.c
+++ b/pandas/_libs/src/ujson/python/ujson.c
@@ -43,7 +43,7 @@ https://www.opensource.apple.com/source/tcl/tcl-14/tcl/license.terms
 
 /* objToJSON */
 PyObject *objToJSON(PyObject *self, PyObject *args, PyObject *kwargs);
-void initObjToJSON(void);
+void *initObjToJSON(void);
 
 /* JSONToObj */
 PyObject *JSONToObj(PyObject *self, PyObject *args, PyObject *kwargs);


### PR DESCRIPTION
This patch is required to make Pandas compile with `-Wl,--fatal-warnings`. It is also needed to prevent an "indirect call signature mismatch" error when using pandas in wasm. This is the only patch Pyodide currently applies to Pandas.