### PR TITLE
Revert "Backport PR #47318 on branch 1.4.x (CI: Pin PYTEST_WORKERS=1 for Windows builds due to memory errors)"

### DIFF
--- a/.github/workflows/macos-windows.yml
+++ b/.github/workflows/macos-windows.yml
@@ -15,6 +15,7 @@ on:
 env:
   PANDAS_CI: 1
   PYTEST_TARGET: pandas
+  PYTEST_WORKERS: auto
   PATTERN: "not slow and not db and not network and not single_cpu"
 
 
@@ -35,9 +36,6 @@ jobs:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7
       group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.env_file }}-${{ matrix.os }}
       cancel-in-progress: true
-    env:
-      # GH 47443: PYTEST_WORKERS > 1 crashes Windows builds with memory related errors
-      PYTEST_WORKERS: ${{ matrix.os == 'macos-latest' && 'auto' || '1' }}
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Reverts pandas-dev/pandas#47445

checking ci with this reverted.