### PR TITLE
BUG: Fix issues with numeric_only deprecation

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -442,16 +442,9 @@ class SeriesGroupBy(GroupBy[Series]):
         )
 
     def _cython_transform(
-        self, how: str, numeric_only: bool = False, axis: int = 0, **kwargs
+        self, how: str, numeric_only: bool = True, axis: int = 0, **kwargs
     ):
         assert axis == 0  # handled by caller
-        if numeric_only:
-            warnings.warn(
-                f"Passing `numeric_only=True` to {type(self).__name__}.{how} is "
-                f"deprecated and will raise in a future version of pandas.",
-                category=FutureWarning,
-                stacklevel=find_stack_level(),
-            )
 
         obj = self._selected_obj
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -446,8 +446,11 @@ class SeriesGroupBy(GroupBy[Series]):
     ):
         assert axis == 0  # handled by caller
         if numeric_only:
-            raise NotImplementedError(
-                f"{type(self).__name__}.{how} does not implement numeric_only=True"
+            warnings.warn(
+                f"Passing `numeric_only=True` to {type(self).__name__}.{how} is "
+                f"deprecated and will raise in a future version of pandas.",
+                category=FutureWarning,
+                stacklevel=find_stack_level(),
             )
 
         obj = self._selected_obj

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -306,7 +306,7 @@ class TestGroupByNonCythonPaths:
         # non-cython calls should not include the grouper
         expected = DataFrame([[0.0], [np.nan]], columns=["B"], index=[1, 3])
         expected.index.name = "A"
-        msg = "The default value of numeric_only"
+        msg = "The default value of numeric_only in DataFrameGroupBy.idxmax"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             result = gb.idxmax()
         tm.assert_frame_equal(result, expected)
@@ -317,7 +317,7 @@ class TestGroupByNonCythonPaths:
         # non-cython calls should not include the grouper
         expected = DataFrame([[0.0], [np.nan]], columns=["B"], index=[1, 3])
         expected.index.name = "A"
-        msg = "The default value of numeric_only"
+        msg = "The default value of numeric_only in DataFrameGroupBy.idxmin"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             result = gb.idxmin()
         tm.assert_frame_equal(result, expected)
@@ -1354,6 +1354,76 @@ def test_deprecate_numeric_only(
         # Doesn't have numeric_only argument and fails on nuisance columns
         with pytest.raises(TypeError, match=r"unsupported operand type"):
             method(*args, **kwargs)
+
+
+def test_deprecate_numeric_only_series(groupby_func, request):
+    # GH#46560
+    if groupby_func in ("backfill", "mad", "pad", "tshift"):
+        pytest.skip("method is deprecated")
+    elif groupby_func == "corrwith":
+        msg = "corrwith is not implemented on SeriesGroupBy"
+        request.node.add_marker(pytest.mark.xfail(reason=msg))
+
+    ser = Series(list("xyz"))
+    gb = ser.groupby([0, 0, 1])
+
+    if groupby_func == "corrwith":
+        args = (ser,)
+    elif groupby_func == "corr":
+        args = (ser,)
+    elif groupby_func == "cov":
+        args = (ser,)
+    elif groupby_func == "nth":
+        args = (0,)
+    elif groupby_func == "fillna":
+        args = (True,)
+    elif groupby_func == "take":
+        args = ([0],)
+    elif groupby_func == "quantile":
+        args = (0.5,)
+    else:
+        args = ()
+    method = getattr(gb, groupby_func, None)
+
+    try:
+        _ = method(*args)
+    except (TypeError, ValueError) as err:
+        # ops that only work on numeric dtypes
+        assert groupby_func in (
+            "corr",
+            "cov",
+            "cummax",
+            "cummin",
+            "cumprod",
+            "cumsum",
+            "diff",
+            "idxmax",
+            "idxmin",
+            "mean",
+            "median",
+            "pct_change",
+            "prod",
+            "quantile",
+            "sem",
+            "skew",
+            "std",
+            "var",
+        )
+        assert (
+            "could not convert" in str(err).lower()
+            or "unsupported operand type" in str(err)
+            or "not allowed for this dtype" in str(err)
+            or "can't multiply sequence by non-int" in str(err)
+            or "cannot be performed against 'object' dtypes" in str(err)
+            or "is not supported for object dtype" in str(err)
+        ), str(err)
+
+    try:
+        method(*args, numeric_only=True)
+    except (TypeError, NotImplementedError) as err:
+        assert "got an unexpected keyword argument 'numeric_only'" in str(
+            err
+        ) or f"{groupby_func} does not implement numeric_only" in str(err), str(err)
 
 
 @pytest.mark.parametrize("dtype", [int, float, object])

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -1418,26 +1418,14 @@ def test_deprecate_numeric_only_series(groupby_func, request):
             or "is not supported for object dtype" in str(err)
         ), str(err)
 
-    if groupby_func in ("cummax", "cummin", "cumprod", "cumsum"):
-        # kernels that did not always raise when passing numeric_only=True in 1.4
-        try:
-            msg = (
-                f"Passing `numeric_only=True` to SeriesGroupBy.{groupby_func} "
-                "is deprecated"
-            )
-            with tm.assert_produces_warning(FutureWarning, match=msg):
-                method(*args, numeric_only=True)
-        except TypeError as err:
-            assert str(err) == f"{groupby_func} is not supported for object dtype", str(
-                err
-            )
-    else:
-        try:
-            method(*args, numeric_only=True)
-        except (NotImplementedError, TypeError) as err:
-            assert "got an unexpected keyword argument 'numeric_only'" in str(
-                err
-            ) or f"{groupby_func} does not implement numeric_only" in str(err), str(err)
+    try:
+        method(*args, numeric_only=True)
+    except (NotImplementedError, TypeError) as err:
+        assert (
+            "got an unexpected keyword argument 'numeric_only'" in str(err)
+            or f"{groupby_func} does not implement numeric_only" in str(err)
+            or str(err) == f"{groupby_func} is not supported for object dtype"
+        ), str(err)
 
 
 @pytest.mark.parametrize("dtype", [int, float, object])

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -1420,6 +1420,8 @@ def test_deprecate_numeric_only_series(groupby_func, request):
 
     try:
         method(*args, numeric_only=True)
+        # No method should allow numeric_only=True
+        assert False, groupby_func
     except (TypeError, NotImplementedError) as err:
         assert "got an unexpected keyword argument 'numeric_only'" in str(
             err

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -1383,7 +1383,7 @@ def test_deprecate_numeric_only_series(groupby_func, request):
         args = (0.5,)
     else:
         args = ()
-    method = getattr(gb, groupby_func, None)
+    method = getattr(gb, groupby_func)
 
     try:
         _ = method(*args)
@@ -1418,14 +1418,13 @@ def test_deprecate_numeric_only_series(groupby_func, request):
             or "is not supported for object dtype" in str(err)
         ), str(err)
 
-    try:
-        method(*args, numeric_only=True)
-    except (NotImplementedError, TypeError) as err:
-        assert (
-            "got an unexpected keyword argument 'numeric_only'" in str(err)
-            or f"{groupby_func} does not implement numeric_only" in str(err)
-            or str(err) == f"{groupby_func} is not supported for object dtype"
-        ), str(err)
+    msgs = (
+        "got an unexpected keyword argument 'numeric_only'",
+        f"{groupby_func} does not implement numeric_only",
+        f"{groupby_func} is not supported for object dtype",
+    )
+    with pytest.raises((NotImplementedError, TypeError), match=f"({'|'.join(msgs)})"):
+        _ = method(*args, numeric_only=True)
 
 
 @pytest.mark.parametrize("dtype", [int, float, object])


### PR DESCRIPTION
Part of #46560

- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

ref: https://github.com/pandas-dev/pandas/pull/47265#issuecomment-1150415159

Issues were introduced as part of 1.5, no need for a whatsnew note.