### PR TITLE
CI: Run all code checks even if one fails

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -65,37 +65,39 @@ jobs:
       id: build
       uses: ./.github/actions/build_pandas
 
+    # The following checks are independent of each other and should still be run if one fails
     - name: Check for no warnings when building single-page docs
       run: ci/code_checks.sh single-docs
-      if: ${{ steps.build.outcome == 'success' }}
+      if: ${{ steps.build.outcome == 'success' && always() }}
 
     - name: Run checks on imported code
       run: ci/code_checks.sh code
-      if: ${{ steps.build.outcome == 'success' }}
+      if: ${{ steps.build.outcome == 'success' && always() }}
 
     - name: Run doctests
       run: ci/code_checks.sh doctests
-      if: ${{ steps.build.outcome == 'success' }}
+      if: ${{ steps.build.outcome == 'success' && always() }}
 
     - name: Run docstring validation
       run: ci/code_checks.sh docstrings
-      if: ${{ steps.build.outcome == 'success' }}
+      if: ${{ steps.build.outcome == 'success' && always() }}
 
     - name: Use existing environment for type checking
       run: |
         echo $PATH >> $GITHUB_PATH
         echo "PYTHONHOME=$PYTHONHOME" >> $GITHUB_ENV
         echo "PYTHONPATH=$PYTHONPATH" >> $GITHUB_ENV
+      if: ${{ steps.build.outcome == 'success' && always() }}
 
     - name: Typing
       uses: pre-commit/action@v2.0.3
       with:
         extra_args: --hook-stage manual --all-files
-      if: ${{ steps.build.outcome == 'success' }}
+      if: ${{ steps.build.outcome == 'success' && always() }}
 
     - name: Run docstring validation script tests
       run: pytest scripts
-      if: ${{ steps.build.outcome == 'success' }}
+      if: ${{ steps.build.outcome == 'success' && always() }}
 
   asv-benchmarks:
     name: ASV Benchmarks


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/47469#issuecomment-1163790491=

Solution gleaned from: https://stackoverflow.com/a/58859404

Want to `always()` run all these steps _If_ pandas was built correctly

Note: Cannot use `continue-on-error` because if a check fails the build will still pass which we don't want https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error=