### PR TITLE
ENH: Move PyperclipException and PyperclipWindowsException to error/_…

### DIFF
--- a/doc/source/reference/testing.rst
+++ b/doc/source/reference/testing.rst
@@ -43,6 +43,8 @@ Exceptions and warnings
    errors.ParserError
    errors.ParserWarning
    errors.PerformanceWarning
+   errors.PyperclipException
+   errors.PyperclipWindowsException
    errors.SettingWithCopyError
    errors.SettingWithCopyWarning
    errors.SpecificationError

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -1698,7 +1698,9 @@ def any_skipna_inferred_dtype(request):
 # ----------------------------------------------------------------
 @pytest.fixture
 def mock_ctypes(monkeypatch):
-    """ """
+    """
+    Mocks WinError to help with testing the clipboard.
+    """
 
     def _mock_win_error():
         return "Window Error"

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -15,7 +15,6 @@ Instead of splitting it was decided to define sections here:
 - Data sets/files
 - Time zones
 - Dtypes
-- Ctypes
 - Misc
 """
 
@@ -1691,22 +1690,6 @@ def any_skipna_inferred_dtype(request):
 
     # correctness of inference tested in tests/dtypes/test_inference.py
     return inferred_dtype, values
-
-
-# ----------------------------------------------------------------
-# Ctypes
-# ----------------------------------------------------------------
-@pytest.fixture
-def mock_ctypes(monkeypatch):
-    """
-    Mocks WinError to help with testing the clipboard.
-    """
-
-    def _mock_win_error():
-        return "Window Error"
-
-    # Set raising to False because WinError won't exist on non-windows platforms
-    monkeypatch.setattr("ctypes.WinError", _mock_win_error, raising=False)
 
 
 # ----------------------------------------------------------------

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -15,6 +15,7 @@ Instead of splitting it was decided to define sections here:
 - Data sets/files
 - Time zones
 - Dtypes
+- Ctypes
 - Misc
 """
 
@@ -1690,6 +1691,20 @@ def any_skipna_inferred_dtype(request):
 
     # correctness of inference tested in tests/dtypes/test_inference.py
     return inferred_dtype, values
+
+
+# ----------------------------------------------------------------
+# Ctypes
+# ----------------------------------------------------------------
+@pytest.fixture
+def mock_ctypes(monkeypatch):
+    """ """
+
+    def _mock_win_error():
+        return "Window Error"
+
+    # Set raising to False because WinError won't exist on non-windows platforms
+    monkeypatch.setattr("ctypes.WinError", _mock_win_error, raising=False)
 
 
 # ----------------------------------------------------------------

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -3,6 +3,8 @@ Expose public exceptions & warnings
 """
 from __future__ import annotations
 
+import ctypes
+
 from pandas._config.config import OptionError  # noqa:F401
 
 from pandas._libs.tslibs import (  # noqa:F401
@@ -374,3 +376,22 @@ class IndexingError(Exception):
     >>> s.loc["a", "c", "d"] # doctest: +SKIP
     ... # IndexingError: Too many indexers
     """
+
+
+class PyperclipException(RuntimeError):
+    """
+    Exception is raised when trying to use methods like to_clipboard() and
+    read_clipboard() on an unsupported OS/platform.
+    """
+
+
+class PyperclipWindowsException(PyperclipException):
+    """
+    Exception is raised when pandas is unable to get access to the clipboard handle
+    due to some other window process is accessing it.
+    """
+
+    def __init__(self, message: str) -> None:
+        # attr only exists on Windows, so typing fails on other platforms
+        message += f" ({ctypes.WinError()})"  # type: ignore[attr-defined]
+        super().__init__(message)

--- a/pandas/io/clipboard/__init__.py
+++ b/pandas/io/clipboard/__init__.py
@@ -58,6 +58,11 @@ import subprocess
 import time
 import warnings
 
+from pandas.errors import (
+    PyperclipException,
+    PyperclipWindowsException,
+)
+
 # `import PyQt4` sys.exit()s if DISPLAY is not in the environment.
 # Thus, we need to detect the presence of $DISPLAY manually
 # and not load PyQt4 if it is absent.
@@ -85,18 +90,6 @@ def _executable_exists(name):
         )
         == 0
     )
-
-
-# Exceptions
-class PyperclipException(RuntimeError):
-    pass
-
-
-class PyperclipWindowsException(PyperclipException):
-    def __init__(self, message) -> None:
-        # attr only exists on Windows, so typing fails on other platforms
-        message += f" ({ctypes.WinError()})"  # type: ignore[attr-defined]
-        super().__init__(message)
 
 
 def _stringifyText(text) -> str:

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -117,6 +117,21 @@ def df(request):
         raise ValueError
 
 
+@pytest.fixture
+def mock_ctypes(monkeypatch):
+    """
+    Mocks WinError to help with testing the clipboard.
+    """
+
+    def _mock_win_error():
+        return "Window Error"
+
+    # Set raising to False because WinError won't exist on non-windows platforms
+    with monkeypatch.context() as m:
+        m.setattr("ctypes.WinError", _mock_win_error, raising=False)
+        yield
+
+
 @pytest.mark.usefixtures("mock_ctypes")
 def test_checked_call_with_bad_call(monkeypatch):
     """
@@ -165,7 +180,7 @@ def test_checked_call_with_valid_call(monkeypatch):
 def test_stringify_text(text):
     valid_types = (str, int, float, bool)
 
-    if type(text) in valid_types:
+    if isinstance(text, valid_types):
         result = _stringifyText(text)
         assert result == str(text)
     else:

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -3,6 +3,11 @@ from textwrap import dedent
 import numpy as np
 import pytest
 
+from pandas.errors import (
+    PyperclipException,
+    PyperclipWindowsException,
+)
+
 from pandas import (
     DataFrame,
     get_option,
@@ -11,6 +16,8 @@ from pandas import (
 import pandas._testing as tm
 
 from pandas.io.clipboard import (
+    CheckedCall,
+    _stringifyText,
     clipboard_get,
     clipboard_set,
 )
@@ -108,6 +115,66 @@ def df(request):
         )
     else:
         raise ValueError
+
+
+@pytest.mark.usefixtures("mock_ctypes")
+def test_checked_call_with_bad_call(monkeypatch):
+    """
+    Give CheckCall a function that returns a falsey value and
+    mock get_errno so it returns false so an exception is raised.
+    """
+
+    def _return_false():
+        return False
+
+    monkeypatch.setattr("pandas.io.clipboard.get_errno", lambda: True)
+    msg = f"Error calling {_return_false.__name__} \\(Window Error\\)"
+
+    with pytest.raises(PyperclipWindowsException, match=msg):
+        CheckedCall(_return_false)()
+
+
+@pytest.mark.usefixtures("mock_ctypes")
+def test_checked_call_with_valid_call(monkeypatch):
+    """
+    Give CheckCall a function that returns a truthy value and
+    mock get_errno so it returns true so an exception is not raised.
+    The function should return the results from _return_true.
+    """
+
+    def _return_true():
+        return True
+
+    monkeypatch.setattr("pandas.io.clipboard.get_errno", lambda: False)
+
+    # Give CheckedCall a callable that returns a truthy value s
+    checked_call = CheckedCall(_return_true)
+    assert checked_call() is True
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "String_test",
+        True,
+        1,
+        1.0,
+        1j,
+    ],
+)
+def test_stringify_text(text):
+    valid_types = (str, int, float, bool)
+
+    if type(text) in valid_types:
+        result = _stringifyText(text)
+        assert result == str(text)
+    else:
+        msg = (
+            "only str, int, float, and bool values "
+            f"can be copied to the clipboard, not {type(text).__name__}"
+        )
+        with pytest.raises(PyperclipException, match=msg):
+            _stringifyText(text)
 
 
 @pytest.fixture

--- a/pandas/tests/test_errors.py
+++ b/pandas/tests/test_errors.py
@@ -2,6 +2,7 @@ import pytest
 
 from pandas.errors import (
     AbstractMethodError,
+    PyperclipWindowsException,
     UndefinedVariableError,
 )
 
@@ -28,6 +29,7 @@ import pandas as pd
         "SettingWithCopyWarning",
         "NumExprClobberingError",
         "IndexingError",
+        "PyperclipException",
     ],
 )
 def test_exception_importable(exc):
@@ -68,6 +70,13 @@ def test_catch_undefined_variable_error(is_local):
 
     with pytest.raises(UndefinedVariableError, match=msg):
         raise UndefinedVariableError(variable_name, is_local)
+
+
+@pytest.mark.usefixtures("mock_ctypes")
+def test_PyperclipWindowsException():
+    msg = "test \\(Window Error\\)"
+    with pytest.raises(PyperclipWindowsException, match=msg):
+        raise PyperclipWindowsException("test")
 
 
 class Foo:

--- a/pandas/tests/test_errors.py
+++ b/pandas/tests/test_errors.py
@@ -2,7 +2,6 @@ import pytest
 
 from pandas.errors import (
     AbstractMethodError,
-    PyperclipWindowsException,
     UndefinedVariableError,
 )
 
@@ -70,13 +69,6 @@ def test_catch_undefined_variable_error(is_local):
 
     with pytest.raises(UndefinedVariableError, match=msg):
         raise UndefinedVariableError(variable_name, is_local)
-
-
-@pytest.mark.usefixtures("mock_ctypes")
-def test_PyperclipWindowsException():
-    msg = "test \\(Window Error\\)"
-    with pytest.raises(PyperclipWindowsException, match=msg):
-        raise PyperclipWindowsException("test")
 
 
 class Foo:


### PR DESCRIPTION
- [x] xref #27656. this GitHub issue is being done in multiple parts
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

I noticed that there weren't a lot of test around the functions that used PyperclipException & PyperclipWindowsException. So, I took a stab at adding some. Let me know if this unwarranted.

Also, the github only mentioned  PyperclipException, so not sure if we also want to move PyperclipWindowsException, but I did so just in case. 