### PR TITLE
TYP: _item_cache and _ixs

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3565,9 +3565,9 @@ class DataFrame(NDFrame, OpsMixin):
         i : int
         axis : int
 
-        Notes
-        -----
-        If slice passed, the resulting data will be a view.
+        Returns
+        -------
+        Series
         """
         # irow
         if axis == 0:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3558,7 +3558,7 @@ class DataFrame(NDFrame, OpsMixin):
     # ----------------------------------------------------------------------
     # Indexing Methods
 
-    def _ixs(self, i: int, axis: int = 0):
+    def _ixs(self, i: int, axis: int = 0) -> Series:
         """
         Parameters
         ----------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2047,7 +2047,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         elif len(state) == 2:
             raise NotImplementedError("Pre-0.12 pickles are no longer supported")
 
-        self._item_cache: Dict[Hashable, Series] = {}
+        self._item_cache: dict[Hashable, Series] = {}
 
     # ----------------------------------------------------------------------
     # Rendering Methods

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2014,7 +2014,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         }
 
     @final
-    def __setstate__(self, state):
+    def __setstate__(self, state) -> None:
         if isinstance(state, BlockManager):
             self._mgr = state
         elif isinstance(state, dict):
@@ -2047,7 +2047,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         elif len(state) == 2:
             raise NotImplementedError("Pre-0.12 pickles are no longer supported")
 
-        self._item_cache = {}
+        self._item_cache: Dict[Hashable, Series] = {}
 
     # ----------------------------------------------------------------------
     # Rendering Methods

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -932,7 +932,7 @@ class Series(base.IndexOpsMixin, NDFrame):
         """
         return self.take(indices=indices, axis=axis)
 
-    def _ixs(self, i: int, axis: int = 0):
+    def _ixs(self, i: int, axis: int = 0) -> Any:
         """
         Return the i-th value or values in the Series by location.
 


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Noticed these in #47497

I have a question about the `_ixs` docstring in `frame.py` - it says that if a slice is passed, then
the result is a view. However, the arguments are annotated to be `int` only. Is the docstring
correct, or is the type annotation too tight?

I presume it's the former, since I'm not able to pass a slice:

```python
>>> df = pd.DataFrame({'a': [1,2, 3], 'b': [4,5,6]})
>>> df
   a  b
0  1  4
1  2  5
2  3  6
>>> df._ixs(0, axis=1)
0    1
1    2
2    3
Name: a, dtype: int64
>>> df._ixs(slice(0, 2, None), axis=1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/megorelli/pandas-dev/pandas/core/frame.py", line 3588, in _ixs
    col_mgr = self._mgr.iget(i)
  File "/home/megorelli/pandas-dev/pandas/core/internals/managers.py", line 988, in iget
    block = self.blocks[self.blknos[i]]
TypeError: only integer scalar arrays can be converted to a scalar index
```

Also, typing `_ixs` as that's what's called within `get_item_cache`.
For `Series._ixs`, I've annotated the return type as `Any`, as that's what the return
type of `Series.pop` is.