### PR TITLE
REGR: concat materializing index even if sort is not necessary

### DIFF
--- a/doc/source/whatsnew/v1.4.4.rst
+++ b/doc/source/whatsnew/v1.4.4.rst
@@ -14,7 +14,7 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
--
+- Fixed regression in :func:`concat` materializing :class:`Index` during sorting even if :class:`Index` was already sorted (:issue:`47501`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -157,7 +157,7 @@ def _get_combined_index(
         index = union_indexes(indexes, sort=False)
         index = ensure_index(index)
 
-    if sort:
+    if sort and not index.is_monotonic_increasing:
         index = safe_sort_index(index)
     # GH 29879
     if copy:

--- a/pandas/tests/reshape/concat/test_index.py
+++ b/pandas/tests/reshape/concat/test_index.py
@@ -396,3 +396,5 @@ class TestMultiIndexConcat:
         result = concat([df1, df2], sort=True, axis=1)
         expected = DataFrame({"a": [1, 2], "b": [1, 2]})
         tm.assert_frame_equal(result, expected)
+        expected_index = pd.RangeIndex(0, 2)
+        tm.assert_index_equal(result.index, expected_index)

--- a/pandas/tests/reshape/concat/test_index.py
+++ b/pandas/tests/reshape/concat/test_index.py
@@ -387,3 +387,12 @@ class TestMultiIndexConcat:
         msg = "levels supported only when keys is not None"
         with pytest.raises(ValueError, match=msg):
             concat([df1, df2], levels=levels)
+
+    def test_concat_range_index_result(self):
+        # GH#47501
+        df1 = DataFrame({"a": [1, 2]})
+        df2 = DataFrame({"b": [1, 2]})
+
+        result = concat([df1, df2], sort=True, axis=1)
+        expected = DataFrame({"a": [1, 2], "b": [1, 2]})
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/reshape/concat/test_index.py
+++ b/pandas/tests/reshape/concat/test_index.py
@@ -397,4 +397,4 @@ class TestMultiIndexConcat:
         expected = DataFrame({"a": [1, 2], "b": [1, 2]})
         tm.assert_frame_equal(result, expected)
         expected_index = pd.RangeIndex(0, 2)
-        tm.assert_index_equal(result.index, expected_index)
+        tm.assert_index_equal(result.index, expected_index, exact=True)


### PR DESCRIPTION
- [x] closes #47501 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
