### PR TITLE
"Backport PR #47387 on branch 1.4.x (TST,WARN: read_csv raises warning at wrong stacklevel, but _assert_raised_with_correct_stacklevel doesn't fail )"

### DIFF
--- a/doc/source/whatsnew/v1.4.4.rst
+++ b/doc/source/whatsnew/v1.4.4.rst
@@ -23,7 +23,7 @@ Fixed regressions
 
 Bug fixes
 ~~~~~~~~~
--
+- The :class:`errors.FutureWarning` raised when passing arguments (other than ``filepath_or_buffer``) as positional in :func:`read_csv` is now raised at the correct stacklevel (:issue:`47385`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -581,9 +581,7 @@ def _read(
         return parser.read(nrows)
 
 
-@deprecate_nonkeyword_arguments(
-    version=None, allowed_args=["filepath_or_buffer"], stacklevel=3
-)
+@deprecate_nonkeyword_arguments(version=None, allowed_args=["filepath_or_buffer"])
 @Appender(
     _doc_read_csv_and_table.format(
         func_name="read_csv",

--- a/pandas/tests/io/parser/common/test_common_basic.py
+++ b/pandas/tests/io/parser/common/test_common_basic.py
@@ -806,8 +806,7 @@ def test_read_csv_posargs_deprecation(all_parsers):
         "In a future version of pandas all arguments of read_csv "
         "except for the argument 'filepath_or_buffer' will be keyword-only"
     )
-    with tm.assert_produces_warning(FutureWarning, match=msg):
-        parser.read_csv(f, " ")
+    parser.read_csv_check_warnings(FutureWarning, msg, f, " ")
 
 
 @pytest.mark.parametrize("delimiter", [",", "\t"])


### PR DESCRIPTION
Backport PR #47387