### PR TITLE
"Backport PR #47508 on branch 1.4.x REGR: concat materializing index even if sort is not necessary )"

### DIFF
--- a/doc/source/whatsnew/v1.4.4.rst
+++ b/doc/source/whatsnew/v1.4.4.rst
@@ -14,7 +14,7 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
--
+- Fixed regression in :func:`concat` materializing :class:`Index` during sorting even if :class:`Index` was already sorted (:issue:`47501`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -156,7 +156,7 @@ def _get_combined_index(
         index = union_indexes(indexes, sort=False)
         index = ensure_index(index)
 
-    if sort:
+    if sort and not index.is_monotonic_increasing:
         try:
             array_sorted = safe_sort(index)
             array_sorted = cast(np.ndarray, array_sorted)

--- a/pandas/tests/reshape/concat/test_index.py
+++ b/pandas/tests/reshape/concat/test_index.py
@@ -306,3 +306,14 @@ class TestMultiIndexConcat:
             result_df = concat((df1, df2), axis=1)
 
         tm.assert_frame_equal(expected_df, result_df)
+
+    def test_concat_range_index_result(self):
+        # GH#47501
+        df1 = DataFrame({"a": [1, 2]})
+        df2 = DataFrame({"b": [1, 2]})
+
+        result = concat([df1, df2], sort=True, axis=1)
+        expected = DataFrame({"a": [1, 2], "b": [1, 2]})
+        tm.assert_frame_equal(result, expected)
+        expected_index = pd.RangeIndex(0, 2)
+        tm.assert_index_equal(result.index, expected_index, exact=True)


### PR DESCRIPTION
Backport PR #47508