### PR TITLE
Use license_files instead of license_file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ url = https://pandas.pydata.org
 author = The Pandas Development Team
 author_email = pandas-dev@python.org
 license = BSD-3-Clause
-license_file = LICENSE
+license_files = LICENSE
 platforms = any
 classifiers =
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
The license_file parameter is deprecated, use license_files instead

We get this deprecation warning when rebuilding the extensions
