### PR TITLE
TST: added test for to_json when called on numbers exceeding the int64 limit

### DIFF
--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1909,19 +1909,14 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         result = data.to_json()
         assert result == expected
 
-    @pytest.mark.parametrize(
-        "data", [{"col1": [13342205958987758245, 12388075603347835679]}]
-    )
-    @pytest.mark.parametrize(
-        "expected",
-        [
+    def test_json_uint64(self):
+        # GH21073
+        data = {"col1": [13342205958987758245, 12388075603347835679]}
+        expected = (
             '{"columns":["col1"],"index":[0,1],'
             '"data":[[13342205958987758245],[12388075603347835679]]}'
-        ],
-    )
-    @pytest.mark.parametrize("orient", ["split"])
-    def test_json_uint64(self, data, expected, orient):
-        # GH21073
+        )
+        orient = "split"
         df = DataFrame(data=data)
         result = df.to_json(orient=orient)
         assert result == expected

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1908,3 +1908,20 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         # GH41174
         result = data.to_json()
         assert result == expected
+
+    @pytest.mark.parametrize(
+        "data", [{"col1": [13342205958987758245, 12388075603347835679]}]
+    )
+    @pytest.mark.parametrize(
+        "expected",
+        [
+            '{"columns":["col1"],"index":[0,1],'
+            '"data":[[13342205958987758245],[12388075603347835679]]}'
+        ],
+    )
+    @pytest.mark.parametrize("orient", ["split"])
+    def test_json_uint64(self, data, expected, orient):
+        # GH21073
+        df = DataFrame(data=data)
+        result = df.to_json(orient=orient)
+        assert result == expected

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1911,12 +1911,10 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
 
     def test_json_uint64(self):
         # GH21073
-        data = {"col1": [13342205958987758245, 12388075603347835679]}
         expected = (
             '{"columns":["col1"],"index":[0,1],'
             '"data":[[13342205958987758245],[12388075603347835679]]}'
         )
-        orient = "split"
-        df = DataFrame(data=data)
-        result = df.to_json(orient=orient)
+        df = DataFrame(data={"col1": [13342205958987758245, 12388075603347835679]})
+        result = df.to_json(orient="split")
         assert result == expected


### PR DESCRIPTION


- [x] closes #21073
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) 
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Added test for to_json() when called on numbers exceeding the int64 limit.
Tests and linter pass locally.