### PR TITLE
ENH: Move CSSWarning to error/__init__.py per GH27656

### DIFF
--- a/doc/source/reference/testing.rst
+++ b/doc/source/reference/testing.rst
@@ -26,6 +26,7 @@ Exceptions and warnings
 
    errors.AbstractMethodError
    errors.AccessorRegistrationWarning
+   errors.CSSWarning
    errors.DataError
    errors.DtypeWarning
    errors.DuplicateLabelError

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -399,7 +399,7 @@ class PyperclipWindowsException(PyperclipException):
 
 class CSSWarning(UserWarning):
     """
-    Warning is raised when trying to convert styling to a css format and it failing.
+    Warning is raised when trying to convert styling to a css format and it fails.
     This can be due to the styling not having an equivalent value or because the
     styling isn't properly formatted.
 

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -395,3 +395,21 @@ class PyperclipWindowsException(PyperclipException):
         # attr only exists on Windows, so typing fails on other platforms
         message += f" ({ctypes.WinError()})"  # type: ignore[attr-defined]
         super().__init__(message)
+
+
+class CSSWarning(UserWarning):
+    """
+    Warning is raised when trying to convert styling to a css format and it failing.
+    This can be due to the styling not having an equivalent value or because the
+    styling isn't properly formatted.
+
+    Examples
+    --------
+    >>> df = pd.DataFrame({'A': [1, 1, 1]})
+    >>> df.style.applymap(lambda x: 'background-color: blueGreenRed;')
+    ...         .to_excel('styled.xlsx') # doctest: +SKIP
+    ... # CSSWarning: Unhandled color format: 'blueGreenRed'
+    >>> df.style.applymap(lambda x: 'border: 1px solid red red;')
+    ...         .to_excel('styled.xlsx') # doctest: +SKIP
+    ... # CSSWarning: Too many tokens provided to "border" (expected 1-3)
+    """

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -399,7 +399,7 @@ class PyperclipWindowsException(PyperclipException):
 
 class CSSWarning(UserWarning):
     """
-    Warning is raised when trying to convert styling to a css format and it fails.
+    Warning is raised when converting css styling fails.
     This can be due to the styling not having an equivalent value or because the
     styling isn't properly formatted.
 

--- a/pandas/io/formats/css.py
+++ b/pandas/io/formats/css.py
@@ -12,11 +12,7 @@ from typing import (
 )
 import warnings
 
-
-class CSSWarning(UserWarning):
-    """
-    This CSS syntax cannot currently be parsed.
-    """
+from pandas.errors import CSSWarning
 
 
 def _side_expander(prop_fmt: str) -> Callable:

--- a/pandas/tests/io/formats/test_css.py
+++ b/pandas/tests/io/formats/test_css.py
@@ -1,11 +1,10 @@
 import pytest
 
+from pandas.errors import CSSWarning
+
 import pandas._testing as tm
 
-from pandas.io.formats.css import (
-    CSSResolver,
-    CSSWarning,
-)
+from pandas.io.formats.css import CSSResolver
 
 
 def assert_resolves(css, props, inherited=None):

--- a/pandas/tests/io/formats/test_to_excel.py
+++ b/pandas/tests/io/formats/test_to_excel.py
@@ -6,11 +6,11 @@ import string
 
 import pytest
 
+from pandas.errors import CSSWarning
 import pandas.util._test_decorators as td
 
 import pandas._testing as tm
 
-from pandas.io.formats.css import CSSWarning
 from pandas.io.formats.excel import (
     CssExcelCell,
     CSSToExcelConverter,

--- a/pandas/tests/test_errors.py
+++ b/pandas/tests/test_errors.py
@@ -29,6 +29,7 @@ import pandas as pd
         "NumExprClobberingError",
         "IndexingError",
         "PyperclipException",
+        "CSSWarning",
     ],
 )
 def test_exception_importable(exc):


### PR DESCRIPTION
- [x] xref #27656. this GitHub issue is being done in multiple parts
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
