### PR TITLE
TST: added test for handling repeated keys when using Series.loc with Multiindex

### DIFF
--- a/pandas/tests/indexing/multiindex/test_multiindex.py
+++ b/pandas/tests/indexing/multiindex/test_multiindex.py
@@ -213,3 +213,12 @@ class TestMultiIndexBasic:
 
         tm.assert_series_equal(result[0], a_series_expected)
         tm.assert_series_equal(result[1], b_series_expected)
+
+    def test_multiindex_repeated_keys(self):
+        # GH19414
+        tm.assert_series_equal(
+            Series([1, 2], MultiIndex.from_arrays([["a", "b"]])).loc[
+                ["a", "a", "b", "b"]
+            ],
+            Series([1, 1, 2, 2], MultiIndex.from_arrays([["a", "a", "b", "b"]])),
+        )


### PR DESCRIPTION

- [x] closes #19414.
- [x] Tests added and passed.
- [x] All code checks passed.

Added test for handling repeated keys when using Series.loc with Multiindex.
Tests and linter pass locally.