### PR TITLE
Added improvements in to_datetime Error reporting message

### DIFF
--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -664,11 +664,11 @@ cpdef array_to_datetime(
 
                         # Still raise OutOfBoundsDatetime,
                         # as error message is informative.
-                        raise
+                        raise OutOfBoundsDatetime(f"Cannot convert \"{val}\" at position {i} to datetime")
 
                     assert is_ignore
                     return values, tz_out
-                raise
+                raise OutOfBoundsDatetime(f"Cannot convert \"{val}\" at position {i} to datetime")
 
     except OutOfBoundsDatetime:
         if is_raise:

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -595,7 +595,7 @@ cpdef array_to_datetime(
                                 continue
                             elif is_raise:
                                 raise ValueError(
-                                    f"time data {val} doesn't match format specified"
+                                    f"time data \"{val}\" at position {i} doesn't match format specified"
                                 )
                             return values, tz_out
 
@@ -821,7 +821,7 @@ cdef _array_to_datetime_object(
                     oresult[i] = <object>NaT
                     continue
                 if is_raise:
-                    raise
+                    raise ValueError(f"Unable to parse string \"{val}\" at position {i}")
                 return values, None
         else:
             if is_raise:

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -282,7 +282,7 @@ def parse_datetime_string(
         pass
 
     try:
-            dt = du_parse(date_string, default=_DEFAULT_DATETIME,
+        dt = du_parse(date_string, default=_DEFAULT_DATETIME,
                       dayfirst=dayfirst, yearfirst=yearfirst, **kwargs)
     except TypeError:
         # following may be raised from dateutil

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -282,9 +282,9 @@ def parse_datetime_string(
         pass
 
     try:
-        if date_string == 'today':
+        if date_string == "today":
             dt = datetime.today()
-        elif date_string == 'now':
+        elif date_string == "now":
             dt = datetime.now()
         else:
             dt = du_parse(date_string, default=_DEFAULT_DATETIME,

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -282,7 +282,12 @@ def parse_datetime_string(
         pass
 
     try:
-        dt = du_parse(date_string, default=_DEFAULT_DATETIME,
+        if date_string == 'today':
+            dt = datetime.today()
+        elif date_string == 'now':
+            dt = datetime.now()
+        else:
+            dt = du_parse(date_string, default=_DEFAULT_DATETIME,
                       dayfirst=dayfirst, yearfirst=yearfirst, **kwargs)
     except TypeError:
         # following may be raised from dateutil

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -261,7 +261,7 @@ def parse_datetime_string(
         datetime dt
 
     if not _does_string_look_like_datetime(date_string):
-        raise ValueError('Given date string not likely a datetime.')
+        raise ValueError(f'Given date string {date_string} not likely a datetime.')
 
     if does_string_look_like_time(date_string):
         # use current datetime as default, not pass _DEFAULT_DATETIME
@@ -282,17 +282,12 @@ def parse_datetime_string(
         pass
 
     try:
-        if date_string == "today":
-            dt = datetime.today()
-        elif date_string == "now":
-            dt = datetime.now()
-        else:
             dt = du_parse(date_string, default=_DEFAULT_DATETIME,
                       dayfirst=dayfirst, yearfirst=yearfirst, **kwargs)
     except TypeError:
         # following may be raised from dateutil
         # TypeError: 'NoneType' object is not iterable
-        raise ValueError('Given date string not likely a datetime.')
+        raise ValueError(f'Given date string {date_string} not likely a datetime.')
 
     return dt
 
@@ -368,7 +363,7 @@ cdef parse_datetime_string_with_reso(
         int out_tzoffset
 
     if not _does_string_look_like_datetime(date_string):
-        raise ValueError('Given date string not likely a datetime.')
+        raise ValueError(f'Given date string {date_string} not likely a datetime.')
 
     parsed, reso = _parse_delimited_date(date_string, dayfirst)
     if parsed is not None:


### PR DESCRIPTION
- This PR aims to close 3 related issues - 
#16757 , 
#46509 , 
#47495

- Changes description
    -  For issue #16757 - added more details in error message about field and its position causing the issue in `pandas/_libs/tslib.pyx` in `_array_to_datetime_object` and `array_to_datetime`
    -  For issue #46509 -  added more details in OutOfBoundsDatetime exception about field and its position causing the issue in `pandas/_libs/tslib.pyx` in `array_to_datetime`
    - For issue #47495 - made change in `pandas/_libs/tslibs/parsing.pyx` to accept "now" and "today" values. These values are accepted in other parts of parsing ( `_parse_today_now` in `pandas/_libs/tslib.pyx` ) but when `pd.to_datetime` is supplied with an list having an error value(eg - `pd.to_datetime(["today", "yesterday"])` ), the parsing done post raised exception in `parse_datetime_string` in `pandas/_libs/tslibs/parsing.pyx` does not accept "now" and "today", hence the wrong element is shown in the error

- Examples of changed error messages


    | Code       | Old Error ( on 1.4.3 ) | New Error |
    | ------------- | ------------- | ------------- |
    | pd.to_datetime(pd.Series(['2016-01-01', 'unparseable']), errors='raise')  | dateutil.parser._parser.ParserError: Unknown string format: unparseable  | ValueError: Unable to parse string "unparseable" at position 1 |
    | pd.to_datetime(pd.Series(['2016-01-01', 'unparseable']), format='%Y-%m-%d', errors='raise') | ValueError: time data unparseable doesn't match format specified  | ValueError: time data "unparseable" at position 1 doesn't match format specified |
    | pd.to_datetime(pd.Series(['2016-01-01', '12']), errors='raise') | ValueError: Given date string not likely a datetime.  | ValueError: Unable to parse string "12" at position 1 |
    | pd.to_datetime('11:0') | pandas._libs.tslibs.np_datetime.OutOfBoundsDatetime: Out of bounds nanosecond timestamp: 1-01-01 11:00:00  | pandas._libs.tslibs.np_datetime.OutOfBoundsDatetime: Cannot convert "11:0" at position 0 to datetime |
    | pd.to_datetime(["today", "yesterday"]) | dateutil.parser._parser.ParserError: Unknown string format: today  | ValueError: Unable to parse string "yesterday" at position 1 |

**To Do**
- [ ] add testcases covering above errors once given the initial go ahead. ( am bit new here, was thinking of sending the changes in chunks, instead of going more ahead in wrong direction 🙂  )
