### PR TITLE
BUG: `pd.period_range` ignores multiple of `start` frequency.

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -959,6 +959,7 @@ Period
 - Bug in adding ``np.timedelta64("NaT", "ns")`` to a :class:`Period` with a timedelta-like freq incorrectly raising ``IncompatibleFrequency`` instead of returning ``NaT`` (:issue:`47196`)
 - Bug in adding an array of integers to an array with :class:`PeriodDtype` giving incorrect results when ``dtype.freq.n > 1`` (:issue:`47209`)
 - Bug in subtracting a :class:`Period` from an array with :class:`PeriodDtype` returning incorrect results instead of raising ``OverflowError`` when the operation overflows (:issue:`47538`)
+- Bug in :func:`period_range` ignoring frequency multiple when deriving `freq` from `start` or `end` field (:issue:`47465`)
 -
 
 Plotting

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -959,7 +959,7 @@ Period
 - Bug in adding ``np.timedelta64("NaT", "ns")`` to a :class:`Period` with a timedelta-like freq incorrectly raising ``IncompatibleFrequency`` instead of returning ``NaT`` (:issue:`47196`)
 - Bug in adding an array of integers to an array with :class:`PeriodDtype` giving incorrect results when ``dtype.freq.n > 1`` (:issue:`47209`)
 - Bug in subtracting a :class:`Period` from an array with :class:`PeriodDtype` returning incorrect results instead of raising ``OverflowError`` when the operation overflows (:issue:`47538`)
-- Bug in :func:`period_range` ignoring frequency multiple when deriving `freq` from `start` or `end` field (:issue:`47465`)
+- Bug in :func:`period_range` ignoring frequency multiple when deriving ``freq`` from ``start`` or ``end`` field (:issue:`47465`)
 -
 
 Plotting

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -1063,6 +1063,10 @@ def _get_ordinal_range(start, end, periods, freq):
     start = Period(start, freq)
     end = Period(end, freq)
 
+    if periods is not None:
+        # we decrease periods here, since we later do end + 1
+        periods -= 1
+
     if start is NaT and end is NaT:
         raise ValueError("start and end must not be NaT")
 
@@ -1074,7 +1078,7 @@ def _get_ordinal_range(start, end, periods, freq):
     else:
         end = start + periods
 
-    data = np.arange(start.ordinal, end.ordinal + 1, start.freq.n, dtype=np.int64)
+    data = np.arange(start.ordinal, (end + 1).ordinal, start.freq.n, dtype=np.int64)
 
     return data, start.freq
 

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -1056,7 +1056,7 @@ def _get_ordinal_range(start, end, periods, freq):
 
     # If `freq` is passed, it will overwrite the freq of start and end, but
     # doesn't change it if it is None.
-    # `to_offset(None) == None`.
+    # Note: `to_offset(None) == None`.
     freq = to_offset(freq)
 
     # become NaT, in case of None

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1255,7 +1255,6 @@ class TestSeriesConstructors:
 
     def test_constructor_periodindex_multiple(self):
         # GH47465
-        # converting a PeriodIndex when put in a Series
 
         p = Period("2020-01-01")
         pi = period_range(p, periods=5)

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1253,6 +1253,15 @@ class TestSeriesConstructors:
         expected = Series(pi.astype(object))
         tm.assert_series_equal(s, expected)
 
+    def test_constructor_periodindex_multiple(self):
+        # GH47465
+        # converting a PeriodIndex when put in a Series
+
+        p = Period("2020-01-01")
+        pi = period_range(p, periods=5)
+
+        assert pi[0] + 1 == pi[1]
+
     def test_constructor_dict(self):
         d = {"a": 0.0, "b": 1.0, "c": 2.0}
 


### PR DESCRIPTION
Fixes: #47465

- [x] closes #47465
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
