### PR TITLE
DOC: fix shared compression_options and decompression_options 

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3296,7 +3296,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     @final
     @doc(
         storage_options=_shared_docs["storage_options"],
-        compression_options=_shared_docs["compression_options"],
+        compression_options=_shared_docs["compression_options"] % "path_or_buf",
     )
     @deprecate_kwarg(old_arg_name="line_terminator", new_arg_name="lineterminator")
     def to_csv(

--- a/pandas/core/shared_docs.py
+++ b/pandas/core/shared_docs.py
@@ -432,7 +432,7 @@ _shared_docs[
     to one of {``'zip'``, ``'gzip'``, ``'bz2'``, ``'zstd'``, ``'tar'``} and other
     key-value pairs are forwarded to
     ``zipfile.ZipFile``, ``gzip.GzipFile``,
-    ``bz2.BZ2File``, ``zstandard.ZstdDecompressor`` or
+    ``bz2.BZ2File``, ``zstandard.ZstdCompressor`` or
     ``tarfile.TarFile``, respectively.
     As an example, the following could be passed for faster compression and to create
     a reproducible gzip archive:

--- a/pandas/core/shared_docs.py
+++ b/pandas/core/shared_docs.py
@@ -423,7 +423,7 @@ _shared_docs[
 _shared_docs[
     "compression_options"
 ] = """compression : str or dict, default 'infer'
-    For on-the-fly compression of the output data. If 'infer' and '%s'
+    For on-the-fly compression of the output data. If 'infer' and '%s' is
     path-like, then detect compression from the following extensions: '.gz',
     '.bz2', '.zip', '.xz', '.zst', '.tar', '.tar.gz', '.tar.xz' or '.tar.bz2'
     (otherwise no compression).

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -852,7 +852,8 @@ def read_csv(
         summary="Read a comma-separated values (csv) file into DataFrame.",
         _default_sep="','",
         storage_options=_shared_docs["storage_options"],
-        decompression_options=_shared_docs["decompression_options"],
+        decompression_options=_shared_docs["decompression_options"]
+        % "filepath_or_buffer",
     )
 )
 def read_csv(
@@ -1189,7 +1190,8 @@ def read_table(
         summary="Read general delimited file into DataFrame.",
         _default_sep=r"'\\t' (tab-stop)",
         storage_options=_shared_docs["storage_options"],
-        decompression_options=_shared_docs["decompression_options"],
+        decompression_options=_shared_docs["decompression_options"]
+        % "filepath_or_buffer",
     )
 )
 def read_table(

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -79,7 +79,7 @@ def read_sas(
 
 
 @deprecate_nonkeyword_arguments(version=None, allowed_args=["filepath_or_buffer"])
-@doc(decompression_options=_shared_docs["decompression_options"])
+@doc(decompression_options=_shared_docs["decompression_options"] % "filepath_or_buffer")
 def read_sas(
     filepath_or_buffer: FilePath | ReadBuffer[bytes],
     format: str | None = None,

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -140,7 +140,7 @@ filepath_or_buffer : str, path object or file-like object
 {_statafile_processing_params2}
 {_chunksize_params}
 {_iterator_params}
-{_shared_docs["decompression_options"]}
+{_shared_docs["decompression_options"] % "filepath_or_buffer"}
 {_shared_docs["storage_options"]}
 
 Returns


### PR DESCRIPTION
Both compression_options and decompression_options made the same
reference to zstandard.ZstdDecompressor however compression uses
zstandard.ZstdCompressor and so the documentation for
compression_options should refer to this class instead

The shared doc strings compression_options and decompression_options
require an interpolated string for the name of the parameter that takes
a filepath/buffer, with the name of this parameter.
It was missing in a few places.

Also fix a small gramatical error in compression_options

It took me a while to find the documentation for the python zstandard library to see what options are available to pass in as a dictionary, do you think it's worth updating the text `zstandard.ZstdDecompressor ` in the docs to be a link to https://python-zstandard.readthedocs.io/en/latest/decompressor.html?

I saw some test failures when running test_fast.sh inside the provided Docker image, but from what I can tell, these are not related to the changes that I made, and I also see the same failure when running tests from `main`:

<details>
  <summary>test failure</summary>
  
```
pandas/tests/test_expressions.py:133: AssertionError
________________ TestExpressions.test_run_binary[gt-False-df2] _________________
[gw2] linux -- Python 3.8.13 /opt/conda/bin/python

self = <pandas.tests.test_expressions.TestExpressions object at 0x7fcc8c9f3fd0>
df =         A   B   C   D
0       0   0  12   0
1      22  22  54  17
2       0   0  21   0
3       0  95   0   0
4       ...3  91
9997   25   0  32   5
9998    0  55   0  62
9999   42  25  30   1
10000   3   0  75  56

[10001 rows x 4 columns]
flex = False, comparison_op = <built-in function gt>

    @pytest.mark.parametrize(
        "df",
        [
            _integer,
            _integer2,
            # randint to get a case with zeros
            _integer * np.random.randint(0, 2, size=np.shape(_integer)),
            _frame,
            _frame2,
            _mixed,
            _mixed2,
        ],
    )
    @pytest.mark.parametrize("flex", [True, False])
    def test_run_binary(self, df, flex, comparison_op):
        """
        tests solely that the result is the same whether or not numexpr is
        enabled.  Need to test whether the function does the correct thing
        elsewhere.
        """
        arith = comparison_op.__name__
        with option_context("compute.use_numexpr", False):
            other = df.copy() + 1

        expr._MIN_ELEMENTS = 0
        expr.set_test_mode(True)

        result, expected = self.call_op(df, other, flex, arith)

        used_numexpr = expr.get_test_result()
>       assert used_numexpr, "Did not use numexpr as expected."
E       AssertionError: Did not use numexpr as expected.
E       assert []
```
</details>

- [x] no related ticket
- [x] Built and inspected docs
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] N/A Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] N/A Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
