### PR TITLE
BUG: boolean indexer with NA raising when reindex is necessary

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -1,4 +1,3 @@
-
 .. _whatsnew_150:
 
 What's new in 1.5.0 (??)

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -1,3 +1,4 @@
+
 .. _whatsnew_150:
 
 What's new in 1.5.0 (??)
@@ -885,6 +886,7 @@ Indexing
 - Bug when setting a value too large for a :class:`Series` dtype failing to coerce to a common type (:issue:`26049`, :issue:`32878`)
 - Bug in :meth:`loc.__setitem__` treating ``range`` keys as positional instead of label-based (:issue:`45479`)
 - Bug in :meth:`Series.__setitem__` when setting ``boolean`` dtype values containing ``NA`` incorrectly raising instead of casting to ``boolean`` dtype (:issue:`45462`)
+- Bug in :meth:`Series.loc` raising with boolean indexer containing ``NA`` when :class:`Index` did not match (:issue:`46551`)
 - Bug in :meth:`Series.__setitem__` where setting :attr:`NA` into a numeric-dtype :class:`Series` would incorrectly upcast to object-dtype rather than treating the value as ``np.nan`` (:issue:`44199`)
 - Bug in :meth:`DataFrame.loc` when setting values to a column and right hand side is a dictionary (:issue:`47216`)
 - Bug in :meth:`DataFrame.loc` when setting a :class:`DataFrame` not aligning index in some cases (:issue:`47578`)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2532,18 +2532,20 @@ def check_bool_indexer(index: Index, key) -> np.ndarray:
     """
     result = key
     if isinstance(key, ABCSeries) and not key.index.equals(index):
-        if is_extension_array_dtype(result):
-            result[result.values._mask] = False
-
-        result = result.reindex(index)
-        mask = isna(result._values)
-        if mask.any():
+        indexer = result.index.get_indexer_for(index)
+        if -1 in indexer:
             raise IndexingError(
                 "Unalignable boolean Series provided as "
                 "indexer (index of the boolean Series and of "
                 "the indexed object do not match)."
             )
-        return result.astype(bool)._values
+
+        result = result.take(indexer)
+
+        # fall through for boolean
+        if not is_extension_array_dtype(result.dtype):
+            return result.astype(bool)._values
+
     if is_object_dtype(key):
         # key might be object-dtype bool, check_array_indexer needs bool array
         result = np.asarray(result, dtype=bool)

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -5,7 +5,10 @@ import re
 import numpy as np
 import pytest
 
+from pandas.errors import IndexingError
+
 from pandas import (
+    NA,
     DataFrame,
     IndexSlice,
     MultiIndex,
@@ -328,6 +331,22 @@ def test_loc_setitem_all_false_indexer():
     rhs = Series([6, 7], index=["a", "b"])
     ser.loc[ser > 100] = rhs
     tm.assert_series_equal(ser, expected)
+
+
+def test_loc_boolean_indexer_non_matching_index():
+    # GH#46551
+    ser = Series([1])
+    result = ser.loc[Series([NA, False], dtype="boolean")]
+    expected = Series([], dtype="int64")
+    tm.assert_series_equal(result, expected)
+
+
+def test_loc_boolean_indexer_miss_matching_index():
+    # GH#46551
+    ser = Series([1])
+    indexer = Series([NA, False], dtype="boolean", index=[1, 2])
+    with pytest.raises(IndexingError, match="Unalignable"):
+        ser.loc[indexer]
 
 
 class TestDeprecatedIndexers:


### PR DESCRIPTION
- [x] closes #46551 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

There are multiple options how to solve this. Alternatively, we could get the indexeer for the reindexing operation and check for -1 instead of filling the NAs