### PR TITLE
BUG: using read_xml with iterparse and names will ignore duplicate values

### DIFF
--- a/pandas/io/xml.py
+++ b/pandas/io/xml.py
@@ -342,7 +342,7 @@ class _XMLFrameParser:
                     for col, nm in zip(self.iterparse[row_node], self.names):
                         if curr_elem == col:
                             elem_val = elem.text.strip() if elem.text else None
-                            if elem_val not in row.values() and nm not in row:
+                            if row.get(nm) != elem_val and nm not in row:
                                 row[nm] = elem_val
                         if col in elem.attrib:
                             if elem.attrib[col] not in row.values() and nm not in row:

--- a/pandas/tests/io/xml/test_xml.py
+++ b/pandas/tests/io/xml/test_xml.py
@@ -824,6 +824,46 @@ def test_repeat_names(parser):
     tm.assert_frame_equal(df_iter, df_expected)
 
 
+def test_repeat_values_new_names(parser):
+    xml = """\
+<shapes>
+  <shape>
+    <name>rectangle</name>
+    <family>rectangle</family>
+  </shape>
+  <shape>
+    <name>square</name>
+    <family>rectangle</family>
+  </shape>
+  <shape>
+    <name>ellipse</name>
+    <family>ellipse</family>
+  </shape>
+  <shape>
+    <name>circle</name>
+    <family>ellipse</family>
+  </shape>
+</shapes>"""
+    df_xpath = read_xml(xml, xpath=".//shape", parser=parser, names=["name", "group"])
+
+    df_iter = read_xml_iterparse(
+        xml,
+        parser=parser,
+        iterparse={"shape": ["name", "family"]},
+        names=["name", "group"],
+    )
+
+    df_expected = DataFrame(
+        {
+            "name": ["rectangle", "square", "ellipse", "circle"],
+            "group": ["rectangle", "rectangle", "ellipse", "ellipse"],
+        }
+    )
+
+    tm.assert_frame_equal(df_xpath, df_expected)
+    tm.assert_frame_equal(df_iter, df_expected)
+
+
 def test_names_option_wrong_length(datapath, parser):
     filename = datapath("io", "data", "xml", "books.xml")
 


### PR DESCRIPTION
- [X] closes #47483
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. _(not necessary)_
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature. _(not necessary)_
