### PR TITLE
WEB: Update NumFOCUS committee members

### DIFF
--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -101,11 +101,11 @@ maintainers:
   - Camille Scott
   - Nathaniel Smith
   numfocus:
-  - Phillip Cloud
-  - Stephan Hoyer
   - Wes McKinney
   - Jeff Reback
   - Joris Van den Bossche
+  - Tom Augspurger
+  - Matthew Roeschke
 sponsors:
   active:
   - name: "NumFOCUS"


### PR DESCRIPTION
After initial discussion in the mailing list about updating the NumFOCUS committee, I did some research, and based on the [governance docs](https://github.com/pandas-dev/pandas-governance/blob/master/governance.md#numfocus-subcommittee) the main goal of the committee is to manage the funds coming from NumFOCUS.

So, I guess it makes sense that the list matches the approvers of NumFOCUS funds previously discussed.

The governance also mentions that the committee must have at least 5 members. Leaving Wes in the list even if he's not one of the 4 approvers. Being the BDFL of the project I guess it makes sense to keep.

We can always continue the discussion, but for now I think the new list makes more sense than the previous.

CC: @wesm @cpcloud @shoyer @TomAugspurger @mroeschke 