### PR TITLE
ci: add GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/32-bit-linux.yml
+++ b/.github/workflows/32-bit-linux.yml
@@ -12,6 +12,9 @@ on:
     paths-ignore:
       - "doc/**"
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     runs-on: ubuntu-latest

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -9,8 +9,8 @@ permissions:
 jobs:
   issue_assign:
     permissions:
-      issues: write  
-      pull-requests: write  
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - if: github.event.comment.body == 'take'

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -3,8 +3,14 @@ on:
   issue_comment:
     types: created
 
+permissions:
+  contents: read
+
 jobs:
   issue_assign:
+    permissions:
+      issues: write  
+      pull-requests: write  
     runs-on: ubuntu-latest
     steps:
     - if: github.event.comment.body == 'take'

--- a/.github/workflows/asv-bot.yml
+++ b/.github/workflows/asv-bot.yml
@@ -15,9 +15,9 @@ permissions:
 jobs:
   autotune:
     permissions:
-      contents: read  
-      issues: write  
-      pull-requests: write  
+      contents: read
+      issues: write
+      pull-requests: write
     name: "Run benchmarks"
     # TODO: Support more benchmarking options later, against different branches, against self, etc
     if: startsWith(github.event.comment.body, '@github-actions benchmark')

--- a/.github/workflows/asv-bot.yml
+++ b/.github/workflows/asv-bot.yml
@@ -9,8 +9,15 @@ env:
   ENV_FILE: environment.yml
   COMMENT: ${{github.event.comment.body}}
 
+permissions:
+  contents: read
+
 jobs:
   autotune:
+    permissions:
+      contents: read  
+      issues: write  
+      pull-requests: write  
     name: "Run benchmarks"
     # TODO: Support more benchmarking options later, against different branches, against self, etc
     if: startsWith(github.event.comment.body, '@github-actions benchmark')

--- a/.github/workflows/autoupdate-pre-commit-config.yml
+++ b/.github/workflows/autoupdate-pre-commit-config.yml
@@ -5,8 +5,14 @@ on:
     - cron: "0 7 1 * *" # At 07:00 on 1st of every month.
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update-pre-commit:
+    permissions:
+      contents: write  # for technote-space/create-pr-action to push code
+      pull-requests: write  # for technote-space/create-pr-action to create a PR
     if: github.repository_owner == 'pandas-dev'
     name: Autoupdate pre-commit config
     runs-on: ubuntu-latest

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -14,6 +14,9 @@ env:
   ENV_FILE: environment.yml
   PANDAS_CI: 1
 
+permissions:
+  contents: read
+
 jobs:
   pre_commit:
     name: pre-commit

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -14,6 +14,9 @@ env:
   ENV_FILE: environment.yml
   PANDAS_CI: 1
 
+permissions:
+  contents: read
+
 jobs:
   web_and_docs:
     name: Doc Build and Upload

--- a/.github/workflows/macos-windows.yml
+++ b/.github/workflows/macos-windows.yml
@@ -18,6 +18,9 @@ env:
   PATTERN: "not slow and not db and not network and not single_cpu"
 
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     defaults:

--- a/.github/workflows/python-dev.yml
+++ b/.github/workflows/python-dev.yml
@@ -27,6 +27,9 @@ env:
   COVERAGE: true
   PYTEST_TARGET: pandas
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: false # Comment this line out to "unfreeze"

--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -13,6 +13,9 @@ on:
     paths-ignore:
       - "doc/**"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: ${{ github.event.label.name == 'Build' || contains(github.event.pull_request.labels.*.name, 'Build') || github.event_name == 'push'}}

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -4,8 +4,14 @@ on:
   # * is a special character in YAML so you have to quote this string
   - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v4

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -10,8 +10,7 @@ permissions:
 jobs:
   stale:
     permissions:
-      issues: write  # for actions/stale to close stale issues
-      pull-requests: write  # for actions/stale to close stale PRs
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v4

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -15,6 +15,9 @@ on:
 env:
   PANDAS_CI: 1
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds minimum token permissions for the GITHUB_TOKEN using https://github.com/step-security/secure-workflows.

GitHub recommends defining minimum GITHUB_TOKEN permissions for securing GitHub Actions workflows 
- https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/  
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) treats not setting token permissions as a high-risk issue 

This project is part of the top 100 critical projects as per OpenSSF (https://github.com/ossf/wg-securing-critical-projects), so fixing the token permissions to improve security.

Signed-off-by: Varun Sharma <varunsh@stepsecurity.io>

- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
