### PR TITLE
TYP: make _engine_type consistently a property

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,7 +93,7 @@ repos:
         types: [python]
         stages: [manual]
         additional_dependencies: &pyright_dependencies
-        - pyright@1.1.253
+        - pyright@1.1.258
 -   repo: local
     hooks:
     -   id: pyright_reportGeneralTypeIssues

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -404,9 +404,12 @@ class Index(IndexOpsMixin, PandasObject):
     # associated code in pandas 2.0.
     _is_backward_compat_public_numeric_index: bool = False
 
-    _engine_type: type[libindex.IndexEngine] | type[
-        libindex.ExtensionEngine
-    ] = libindex.ObjectEngine
+    @property
+    def _engine_type(
+        self,
+    ) -> type[libindex.IndexEngine] | type[libindex.ExtensionEngine]:
+        return libindex.ObjectEngine
+
     # whether we support partial string indexing. Overridden
     # in DatetimeIndex and PeriodIndex
     _supports_partial_string_indexing = False

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -192,7 +192,7 @@ class CategoricalIndex(NDArrayBackedExtensionIndex):
     _values: Categorical
 
     @property
-    def _engine_type(self):
+    def _engine_type(self) -> type[libindex.IndexEngine]:
         # self.codes can have dtype int8, int16, int32 or int64, so we need
         # to return the corresponding engine type (libindex.Int8Engine, etc.).
         return {

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -252,8 +252,11 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
     _typ = "datetimeindex"
 
     _data_cls = DatetimeArray
-    _engine_type = libindex.DatetimeEngine
     _supports_partial_string_indexing = True
+
+    @property
+    def _engine_type(self) -> type[libindex.DatetimeEngine]:
+        return libindex.DatetimeEngine
 
     _data: DatetimeArray
     inferred_freq: str | None

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -106,7 +106,7 @@ class NumericIndex(Index):
     }
 
     @property
-    def _engine_type(self):
+    def _engine_type(self) -> type[libindex.IndexEngine]:
         # error: Invalid index type "Union[dtype[Any], ExtensionDtype]" for
         # "Dict[dtype[Any], Type[IndexEngine]]"; expected type "dtype[Any]"
         return self._engine_types[self.dtype]  # type: ignore[index]
@@ -373,9 +373,12 @@ class Int64Index(IntegerIndex):
     __doc__ = _num_index_shared_docs["class_descr"] % _index_descr_args
 
     _typ = "int64index"
-    _engine_type = libindex.Int64Engine
     _default_dtype = np.dtype(np.int64)
     _dtype_validation_metadata = (is_signed_integer_dtype, "signed integer")
+
+    @property
+    def _engine_type(self) -> type[libindex.Int64Engine]:
+        return libindex.Int64Engine
 
 
 class UInt64Index(IntegerIndex):
@@ -388,9 +391,12 @@ class UInt64Index(IntegerIndex):
     __doc__ = _num_index_shared_docs["class_descr"] % _index_descr_args
 
     _typ = "uint64index"
-    _engine_type = libindex.UInt64Engine
     _default_dtype = np.dtype(np.uint64)
     _dtype_validation_metadata = (is_unsigned_integer_dtype, "unsigned integer")
+
+    @property
+    def _engine_type(self) -> type[libindex.UInt64Engine]:
+        return libindex.UInt64Engine
 
 
 class Float64Index(NumericIndex):

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -159,8 +159,11 @@ class PeriodIndex(DatetimeIndexOpsMixin):
     dtype: PeriodDtype
 
     _data_cls = PeriodArray
-    _engine_type = libindex.PeriodEngine
     _supports_partial_string_indexing = True
+
+    @property
+    def _engine_type(self) -> type[libindex.PeriodEngine]:
+        return libindex.PeriodEngine
 
     @cache_readonly
     # Signature of "_resolution_obj" incompatible with supertype "DatetimeIndexOpsMixin"

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -104,10 +104,13 @@ class RangeIndex(NumericIndex):
     """
 
     _typ = "rangeindex"
-    _engine_type = libindex.Int64Engine
     _dtype_validation_metadata = (is_signed_integer_dtype, "signed integer")
     _range: range
     _is_backward_compat_public_numeric_index: bool = False
+
+    @property
+    def _engine_type(self) -> type[libindex.Int64Engine]:
+        return libindex.Int64Engine
 
     # --------------------------------------------------------------------
     # Constructors

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -101,7 +101,10 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
     _typ = "timedeltaindex"
 
     _data_cls = TimedeltaArray
-    _engine_type = libindex.TimedeltaEngine
+
+    @property
+    def _engine_type(self) -> type[libindex.TimedeltaEngine]:
+        return libindex.TimedeltaEngine
 
     _data: TimedeltaArray
 

--- a/pyright_reportGeneralTypeIssues.json
+++ b/pyright_reportGeneralTypeIssues.json
@@ -15,7 +15,6 @@
         "pandas/io/clipboard",
         "pandas/util/version",
         # and all files that currently don't pass
-        "pandas/_config/config.py",
         "pandas/_testing/__init__.py",
         "pandas/core/algorithms.py",
         "pandas/core/apply.py",
@@ -58,7 +57,6 @@
         "pandas/core/indexes/multi.py",
         "pandas/core/indexes/numeric.py",
         "pandas/core/indexes/period.py",
-        "pandas/core/indexes/range.py",
         "pandas/core/indexing.py",
         "pandas/core/internals/api.py",
         "pandas/core/internals/array_manager.py",
@@ -80,7 +78,6 @@
         "pandas/core/tools/datetimes.py",
         "pandas/core/tools/timedeltas.py",
         "pandas/core/util/hashing.py",
-        "pandas/core/util/numba_.py",
         "pandas/core/window/ewm.py",
         "pandas/core/window/rolling.py",
         "pandas/io/common.py",


### PR DESCRIPTION
`_engine_type` was sometimes a property and sometimes a class variable.