### PR TITLE
TST: avoid sort when concat int-index Dataframes with sort=False

### DIFF
--- a/pandas/tests/reshape/concat/test_sort.py
+++ b/pandas/tests/reshape/concat/test_sort.py
@@ -107,6 +107,7 @@ class TestConcatSort:
             index=[3, 1, 6, 2],
             columns=["c", "d", "a", "b"],
         )
+        tm.assert_frame_equal(result, expected)
 
     def test_concat_sort_none_warning(self):
         # GH#41518

--- a/pandas/tests/reshape/concat/test_sort.py
+++ b/pandas/tests/reshape/concat/test_sort.py
@@ -92,7 +92,7 @@ class TestConcatSort:
         expected = DataFrame([[2, np.nan], [np.nan, 1]], index=[2, 1], columns=[2, 1])
 
         tm.assert_frame_equal(result, expected)
-        
+
         # GH 37937
         df1 = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=[1, 2, 3])
         df2 = DataFrame({"c": [7, 8, 9], "d": [10, 11, 12]}, index=[3, 1, 6])
@@ -107,7 +107,7 @@ class TestConcatSort:
             index=[3, 1, 6, 2],
             columns=["c", "d", "a", "b"],
         )
-        
+
     def test_concat_sort_none_warning(self):
         # GH#41518
         df = DataFrame({1: [1, 2], "a": [3, 4]})

--- a/pandas/tests/reshape/concat/test_sort.py
+++ b/pandas/tests/reshape/concat/test_sort.py
@@ -92,7 +92,22 @@ class TestConcatSort:
         expected = DataFrame([[2, np.nan], [np.nan, 1]], index=[2, 1], columns=[2, 1])
 
         tm.assert_frame_equal(result, expected)
-
+        
+        # GH 37937
+        df1 = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=[1, 2, 3])
+        df2 = DataFrame({"c": [7, 8, 9], "d": [10, 11, 12]}, index=[3, 1, 6])
+        result = pd.concat([df2, df1], axis=1, sort=False)
+        expected = DataFrame(
+            [
+                [7.0, 10.0, 3.0, 6.0],
+                [8.0, 11.0, 1.0, 4.0],
+                [9.0, 12.0, np.nan, np.nan],
+                [np.nan, np.nan, 2.0, 5.0],
+            ],
+            index=[3, 1, 6, 2],
+            columns=["c", "d", "a", "b"],
+        )
+        
     def test_concat_sort_none_warning(self):
         # GH#41518
         df = DataFrame({1: [1, 2], "a": [3, 4]})


### PR DESCRIPTION
- [x] closes #37937
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

This issue may have been fixed by #36299. Add the test and close.