### PR TITLE
BUG/TST fix replace with panda NAType #47480

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -910,6 +910,7 @@ Missing
 - Bug in :meth:`Series.fillna` and :meth:`DataFrame.fillna` with :class:`IntervalDtype` and incompatible value raising instead of casting to a common (usually object) dtype (:issue:`45796`)
 - Bug in :meth:`DataFrame.interpolate` with object-dtype column not returning a copy with ``inplace=False`` (:issue:`45791`)
 - Bug in :meth:`DataFrame.dropna` allows to set both ``how`` and ``thresh`` incompatible arguments (:issue:`46575`)
+- Bug in :meth:`DataFrame.replace` now works when ``pandas.NA`` is a value in the dara frame (:issue:`47480`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/pandas/_libs/missing.pyx
+++ b/pandas/_libs/missing.pyx
@@ -409,7 +409,6 @@ class NAType(C_NAType):
     __rdivmod__ = _create_binary_propagating_op("__rdivmod__", is_divmod=True)
     # __lshift__ and __rshift__ are not implemented
 
-    __eq__ = _create_binary_propagating_op("__eq__")
     __ne__ = _create_binary_propagating_op("__ne__")
     __le__ = _create_binary_propagating_op("__le__")
     __lt__ = _create_binary_propagating_op("__lt__")
@@ -422,6 +421,12 @@ class NAType(C_NAType):
     __pos__ = _create_unary_propagating_op("__pos__")
     __abs__ = _create_unary_propagating_op("__abs__")
     __invert__ = _create_unary_propagating_op("__invert__")
+
+    def __eq__(self, other):
+        if other is C_NA:
+            return True
+        else:
+            return False
 
     # pow has special
     def __pow__(self, other):

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -92,7 +92,19 @@ def mask_missing(arr: ArrayLike, values_to_mask) -> npt.NDArray[np.bool_]:
             # GH#29553 prevent numpy deprecation warnings
             pass
         else:
-            new_mask = arr == x
+            # Numpy Currently can't handle comparisons with "NAType" instances
+            arr_shape = arr.shape
+            arr = np.array(arr)
+            arr = arr.flatten()
+            new_mask = np.array([])
+            for i in arr:
+                if isna(i):
+                    new_mask = np.append(new_mask, False)
+                else:
+                    new_mask = np.append(new_mask, x == i)
+            new_mask.shape = arr_shape
+            new_mask = new_mask == 1
+
             if not isinstance(new_mask, np.ndarray):
                 # usually BooleanArray
                 new_mask = new_mask.to_numpy(dtype=bool, na_value=False)

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -92,18 +92,7 @@ def mask_missing(arr: ArrayLike, values_to_mask) -> npt.NDArray[np.bool_]:
             # GH#29553 prevent numpy deprecation warnings
             pass
         else:
-            # Numpy Currently can't handle comparisons with "NAType" instances
-            arr_shape = arr.shape
-            arr = np.array(arr)
-            arr = arr.flatten()
-            new_mask = np.array([])
-            for i in arr:
-                if isna(i):
-                    new_mask = np.append(new_mask, False)
-                else:
-                    new_mask = np.append(new_mask, x == i)
-            new_mask.shape = arr_shape
-            new_mask = new_mask == 1
+            new_mask = arr == x
 
             if not isinstance(new_mask, np.ndarray):
                 # usually BooleanArray

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1567,3 +1567,10 @@ class TestDataFrameReplaceRegex:
         result = df.replace({0: 1, 1: np.nan})
         expected = DataFrame({"A": [1, np.nan, 2], "B": [np.nan, 1, 2]})
         tm.assert_frame_equal(result, expected)
+
+    def test_replace_with_pandas_NA(self):
+        # GH47480
+        df = DataFrame({"A": [pd.NA, 1, 2], "B": [1, 0, 2]})
+        result = df.replace(2, 3)
+        expected = DataFrame({"A": [pd.NA, 1, 3], "B": [1, 0, 3]})
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #47480 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) 
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/v1.0.5.rst`.

Currently numpy does not support elementwise operations with pd.NA, therefore replace including this type didn't work or different errors arose. Fixed issue by manually iterating. 
