### PR TITLE
GH: Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,6 @@
 cff-version: 1.2.0
 title: 'pandas-dev/pandas: Pandas'
 message: 'If you use this software, please cite it as below.'
-type: software
 authors:
   - name: "The pandas development team"
 license: BSD-3-Clause
@@ -9,18 +8,3 @@ license-url: "https://github.com/pandas-dev/pandas/blob/main/LICENSE"
 repository-code: "https://github.com/pandas-dev/pandas"
 type: software
 url: "https://github.com/pandas-dev/pandas"
-
-cff-version: 1.2.0
-message: "If you use this software, please cite it as below."
-authors:
-- family-names: "Lisa"
-  given-names: "Mona"
-  orcid: "https://orcid.org/0000-0000-0000-0000"
-- family-names: "Bot"
-  given-names: "Hew"
-  orcid: "https://orcid.org/0000-0000-0000-0000"
-title: "My Research Software"
-version: 2.0.4
-doi: 10.5281/zenodo.1234
-date-released: 2017-12-18
-url: "https://github.com/github/linguist"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+cff-version: 1.2.0
+title: 'pandas-dev/pandas: Pandas'
+message: 'If you use this software, please cite it as below.'
+type: software
+authors:
+  - name: "The pandas development team"
+license: BSD-3-Clause
+license-url: "https://github.com/pandas-dev/pandas/blob/main/LICENSE"
+repository-code: "https://github.com/pandas-dev/pandas"
+type: software
+url: "https://github.com/pandas-dev/pandas"
+
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Lisa"
+  given-names: "Mona"
+  orcid: "https://orcid.org/0000-0000-0000-0000"
+- family-names: "Bot"
+  given-names: "Hew"
+  orcid: "https://orcid.org/0000-0000-0000-0000"
+title: "My Research Software"
+version: 2.0.4
+doi: 10.5281/zenodo.1234
+date-released: 2017-12-18
+url: "https://github.com/github/linguist"

--- a/web/pandas/about/citing.md
+++ b/web/pandas/about/citing.md
@@ -5,7 +5,7 @@
 If you use _pandas_ for a scientific publication, we would appreciate citations to the published software and the
 following paper:
 
-- [pandas on Zenodo](https://zenodo.org/record/3715232#.XoqFyC2ZOL8),
+- [pandas on Zenodo](https://zenodo.org/search?page=1&size=20&q=conceptrecid%3A%223509134%22&sort=-version&all_versions=True),
    Please find us on Zenodo and replace with the citation for the version you are using. You can replace the full author
    list from there with "The pandas development team" like in the example below.
 


### PR DESCRIPTION
Enables a citation widget on the side of the repository that provides a copy-pastable ABA & Bibtex citation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files

Followed this schema: https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md
