### PR TITLE
ENH/TST: Add BaseUnaryOpsTests tests for ArrowExtensionArray

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -236,6 +236,8 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray):
         return self._data
 
     def __invert__(self: ArrowExtensionArrayT) -> ArrowExtensionArrayT:
+        if pa_version_under2p0:
+            raise NotImplementedError("__invert__ not implement for pyarrow < 2.0")
         return type(self)(pc.invert(self._data))
 
     def __neg__(self: ArrowExtensionArrayT) -> ArrowExtensionArrayT:

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -235,6 +235,18 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray):
         """Convert myself to a pyarrow ChunkedArray."""
         return self._data
 
+    def __invert__(self: ArrowExtensionArrayT) -> ArrowExtensionArrayT:
+        return type(self)(pc.invert(self._data))
+
+    def __neg__(self: ArrowExtensionArrayT) -> ArrowExtensionArrayT:
+        return type(self)(pc.negate_checked(self._data))
+
+    def __pos__(self: ArrowExtensionArrayT) -> ArrowExtensionArrayT:
+        return type(self)(self._data)
+
+    def __abs__(self: ArrowExtensionArrayT) -> ArrowExtensionArrayT:
+        return type(self)(pc.abs_checked(self._data))
+
     def _cmp_method(self, other, op):
         from pandas.arrays import BooleanArray
 

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -1210,6 +1210,19 @@ class TestBaseParsing(base.BaseParsingTests):
         super().test_EA_types(engine, data)
 
 
+class TestBaseUnaryOps(base.BaseUnaryOpsTests):
+    def test_invert(self, data, request):
+        pa_dtype = data.dtype.pyarrow_dtype
+        if not pa.types.is_boolean(pa_dtype):
+            request.node.add_marker(
+                pytest.mark.xfail(
+                    raises=pa.ArrowNotImplementedError,
+                    reason=f"pyarrow.compute.invert does support {pa_dtype}",
+                )
+            )
+        super().test_invert(data)
+
+
 class TestBaseMethods(base.BaseMethodsTests):
     @pytest.mark.parametrize("dropna", [True, False])
     def test_value_counts(self, all_data, dropna, request):

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -1220,6 +1220,13 @@ class TestBaseUnaryOps(base.BaseUnaryOpsTests):
                     reason=f"pyarrow.compute.invert does support {pa_dtype}",
                 )
             )
+        elif pa_version_under2p0:
+            request.node.add_marker(
+                pytest.mark.xfail(
+                    raises=NotImplementedError,
+                    reason="pyarrow.compute.invert not supported in pyarrow<2.0",
+                )
+            )
         super().test_invert(data)
 
 

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -1211,6 +1211,11 @@ class TestBaseParsing(base.BaseParsingTests):
 
 
 class TestBaseUnaryOps(base.BaseUnaryOpsTests):
+    @pytest.mark.xfail(
+        pa_version_under2p0,
+        raises=NotImplementedError,
+        reason="pyarrow.compute.invert not supported in pyarrow<2.0",
+    )
     def test_invert(self, data, request):
         pa_dtype = data.dtype.pyarrow_dtype
         if not pa.types.is_boolean(pa_dtype):
@@ -1218,13 +1223,6 @@ class TestBaseUnaryOps(base.BaseUnaryOpsTests):
                 pytest.mark.xfail(
                     raises=pa.ArrowNotImplementedError,
                     reason=f"pyarrow.compute.invert does support {pa_dtype}",
-                )
-            )
-        elif pa_version_under2p0:
-            request.node.add_marker(
-                pytest.mark.xfail(
-                    raises=NotImplementedError,
-                    reason="pyarrow.compute.invert not supported in pyarrow<2.0",
                 )
             )
         super().test_invert(data)


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
