### PR TITLE
BUG: df.fillna ignores axis when df is single block

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -914,7 +914,7 @@ Missing
 - Bug in :meth:`Series.fillna` and :meth:`DataFrame.fillna` with :class:`IntervalDtype` and incompatible value raising instead of casting to a common (usually object) dtype (:issue:`45796`)
 - Bug in :meth:`DataFrame.interpolate` with object-dtype column not returning a copy with ``inplace=False`` (:issue:`45791`)
 - Bug in :meth:`DataFrame.dropna` allows to set both ``how`` and ``thresh`` incompatible arguments (:issue:`46575`)
-- Bug in :meth:`DataFrame.fillna` ignored `axis` when :class:`DataFrame` is single block (:issue:`47713`)
+- Bug in :meth:`DataFrame.fillna` ignored ``axis`` when :class:`DataFrame` is single block (:issue:`47713`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -914,6 +914,7 @@ Missing
 - Bug in :meth:`Series.fillna` and :meth:`DataFrame.fillna` with :class:`IntervalDtype` and incompatible value raising instead of casting to a common (usually object) dtype (:issue:`45796`)
 - Bug in :meth:`DataFrame.interpolate` with object-dtype column not returning a copy with ``inplace=False`` (:issue:`45791`)
 - Bug in :meth:`DataFrame.dropna` allows to set both ``how`` and ``thresh`` incompatible arguments (:issue:`46575`)
+- Bug in :meth:`DataFrame.fillna` on single block :class:`DataFrame` with ``axis=1`` (:issue:`47713`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -914,7 +914,7 @@ Missing
 - Bug in :meth:`Series.fillna` and :meth:`DataFrame.fillna` with :class:`IntervalDtype` and incompatible value raising instead of casting to a common (usually object) dtype (:issue:`45796`)
 - Bug in :meth:`DataFrame.interpolate` with object-dtype column not returning a copy with ``inplace=False`` (:issue:`45791`)
 - Bug in :meth:`DataFrame.dropna` allows to set both ``how`` and ``thresh`` incompatible arguments (:issue:`46575`)
-- Bug in :meth:`DataFrame.fillna` on single block :class:`DataFrame` with ``axis=1`` (:issue:`47713`)
+- Bug in :meth:`DataFrame.fillna` ignored `axis` when :class:`DataFrame` is single block (:issue:`47713`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6679,7 +6679,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 return result if not inplace else None
 
             elif not is_list_like(value):
-                if not self._mgr.is_single_block and axis == 1:
+                if axis == 1:
 
                     result = self.T.fillna(value=value, limit=limit).T
 

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -698,11 +698,11 @@ class TestFillNA:
         result = df.fillna(50, limit=1, axis=1)
         expected = DataFrame(
             [
-                [ 5.,  7., 12., 50.],
-                [ 0., 50., np.nan,  1.],
-                [50., np.nan,  1.,  1.],
-                [10.,  5.,  2., 50.],
-                [50.,  3.,  0., 18.],
+                [5., 7., 12., 50.],
+                [0., 50., np.nan, 1.],
+                [50., np.nan, 1., 1.],
+                [10., 5., 2., 50.],
+                [50., 3., 0., 18.],
             ],
             columns=["col1", "col2", "col3", "col4"],
         )

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -685,6 +685,29 @@ class TestFillNA:
         tm.assert_frame_equal(df, expected)
         tm.assert_frame_equal(result_view, expected)
 
+    def test_single_block_df_with_horizontal_axis(self):
+        # GH 47713
+        df = DataFrame(
+            {
+                'col1': [5, 0, np.nan, 10, np.nan],
+                'col2': [7, np.nan, np.nan, 5, 3],
+                'col3': [12, np.nan, 1, 2, 0],
+                'col4': [np.nan, 1, 1, np.nan, 18],
+            }
+        )
+        result = df.fillna(50, limit=1, axis=1)
+        expected = DataFrame(
+            [
+                [ 5.,  7., 12., 50.],
+                [ 0., 50., np.nan,  1.],
+                [50., np.nan,  1.,  1.],
+                [10.,  5.,  2., 50.],
+                [50.,  3.,  0., 18.],
+            ],
+            columns=["col1", "col2", "col3", "col4"],
+        )
+        tm.assert_frame_equal(result, expected)
+
 
 def test_fillna_nonconsolidated_frame():
     # https://github.com/pandas-dev/pandas/issues/36495

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -689,20 +689,20 @@ class TestFillNA:
         # GH 47713
         df = DataFrame(
             {
-                'col1': [5, 0, np.nan, 10, np.nan],
-                'col2': [7, np.nan, np.nan, 5, 3],
-                'col3': [12, np.nan, 1, 2, 0],
-                'col4': [np.nan, 1, 1, np.nan, 18],
+                "col1": [5, 0, np.nan, 10, np.nan],
+                "col2": [7, np.nan, np.nan, 5, 3],
+                "col3": [12, np.nan, 1, 2, 0],
+                "col4": [np.nan, 1, 1, np.nan, 18],
             }
         )
         result = df.fillna(50, limit=1, axis=1)
         expected = DataFrame(
             [
-                [5., 7., 12., 50.],
-                [0., 50., np.nan, 1.],
-                [50., np.nan, 1., 1.],
-                [10., 5., 2., 50.],
-                [50., 3., 0., 18.],
+                [5.0, 7.0, 12.0, 50.0],
+                [0.0, 50.0, np.nan, 1.0],
+                [50.0, np.nan, 1.0, 1.0],
+                [10.0, 5.0, 2.0, 50.0],
+                [50.0, 3.0, 0.0, 18.0],
             ],
             columns=["col1", "col2", "col3", "col4"],
         )


### PR DESCRIPTION
- [x] closes #47713
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
