### PR TITLE
opt out of bottleneck for nanmean

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -844,7 +844,7 @@ Numeric
 - Bug in operations with array-likes with ``dtype="boolean"`` and :attr:`NA` incorrectly altering the array in-place (:issue:`45421`)
 - Bug in division, ``pow`` and ``mod`` operations on array-likes with ``dtype="boolean"`` not being like their ``np.bool_`` counterparts (:issue:`46063`)
 - Bug in multiplying a :class:`Series` with ``IntegerDtype`` or ``FloatingDtype`` by an array-like with ``timedelta64[ns]`` dtype incorrectly raising (:issue:`45622`)
-- Bug in :meth:`mean` where the optional dependency ``bottleneck`` causes precision loss linear in the length of the array. By falling back to numpy the loss is now log-linear (:issue:`42878`)
+- Bug in :meth:`mean` where the optional dependency ``bottleneck`` causes precision loss linear in the length of the array. ``bottleneck`` has been disabled for :meth:`mean` improving the loss to log-linear but may result in a performance decrease. (:issue:`42878`)
 
 Conversion
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -844,7 +844,7 @@ Numeric
 - Bug in operations with array-likes with ``dtype="boolean"`` and :attr:`NA` incorrectly altering the array in-place (:issue:`45421`)
 - Bug in division, ``pow`` and ``mod`` operations on array-likes with ``dtype="boolean"`` not being like their ``np.bool_`` counterparts (:issue:`46063`)
 - Bug in multiplying a :class:`Series` with ``IntegerDtype`` or ``FloatingDtype`` by an array-like with ``timedelta64[ns]`` dtype incorrectly raising (:issue:`45622`)
--
+- Bug in :meth:`mean` where the optional dependency ``bottleneck`` causes precision loss linear in the length of the array. By falling back to numpy the loss is now log-linear (:issue:`42878`)
 
 Conversion
 ^^^^^^^^^^

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -165,6 +165,7 @@ def _bn_ok_dtype(dtype: DtypeObj, name: str) -> bool:
         # GH 42878
         # Bottleneck uses naive summation leading to O(n) loss of precision
         # unlike numpy which implements pairwise summation, which has O(log(n)) loss
+        # crossref: https://github.com/pydata/bottleneck/issues/379
 
         # GH 15507
         # bottleneck does not properly upcast during the sum

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -162,6 +162,9 @@ class bottleneck_switch:
 def _bn_ok_dtype(dtype: DtypeObj, name: str) -> bool:
     # Bottleneck chokes on datetime64, PeriodDtype (or and EA)
     if not is_object_dtype(dtype) and not needs_i8_conversion(dtype):
+        # GH 42878
+        # Bottleneck uses naive summation leading to O(n) loss of precision 
+        # unlike numpy which implements pairwise summation, which has O(log(n)) loss
 
         # GH 15507
         # bottleneck does not properly upcast during the sum
@@ -171,7 +174,7 @@ def _bn_ok_dtype(dtype: DtypeObj, name: str) -> bool:
         # further we also want to preserve NaN when all elements
         # are NaN, unlike bottleneck/numpy which consider this
         # to be 0
-        return name not in ["nansum", "nanprod"]
+        return name not in ["nansum", "nanprod", "nanmean"]
     return False
 
 

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -163,7 +163,7 @@ def _bn_ok_dtype(dtype: DtypeObj, name: str) -> bool:
     # Bottleneck chokes on datetime64, PeriodDtype (or and EA)
     if not is_object_dtype(dtype) and not needs_i8_conversion(dtype):
         # GH 42878
-        # Bottleneck uses naive summation leading to O(n) loss of precision 
+        # Bottleneck uses naive summation leading to O(n) loss of precision
         # unlike numpy which implements pairwise summation, which has O(log(n)) loss
 
         # GH 15507

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -1534,30 +1534,3 @@ class TestSeriesMode:
         # Complex numbers are sorted by their magnitude
         result = Series(array, dtype=dtype).mode()
         tm.assert_series_equal(result, expected)
-
-
-@pytest.mark.parametrize("dtype", ["float32", "float64"])
-def test_numerical_precision_mean(dtype):
-    np_dtype = np.dtype(dtype)
-    eps = np.finfo(np_dtype).eps
-    answer = 0.1
-    n = 1_000_000
-    max_error = answer * eps * np.log2(n)
-
-    series = Series(np.full(n, fill_value=answer, dtype=np_dtype))
-    assert series.dtype == np_dtype
-    assert np.abs(series.mean() - answer) < max_error
-
-
-@pytest.mark.parametrize("dtype", ["float32", "float64"])
-def test_numerical_precision_sum(dtype):
-    np_dtype = np.dtype(dtype)
-    eps = np.finfo(np_dtype).eps
-    value = 0.1
-    n = 1_000_000
-    answer = value * n
-    max_error = answer * eps * np.log2(n)
-
-    series = Series(np.full(n, fill_value=value, dtype=np_dtype))
-    assert series.dtype == np_dtype
-    assert np.abs(series.sum() - answer) < max_error

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -1534,3 +1534,30 @@ class TestSeriesMode:
         # Complex numbers are sorted by their magnitude
         result = Series(array, dtype=dtype).mode()
         tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("dtype", ["float16", "float32", "float64"])
+def test_numerical_precision_mean(dtype):
+    np_dtype = np.dtype(dtype)
+    eps = np.finfo(np_dtype).eps
+    answer = 0.1
+    n = 10_000_000
+    log_error = np.log(n) * eps
+
+    series = Series(np.zeros(n, dtype=np_dtype)) + answer
+    assert series.dtype == np_dtype
+    assert np.abs(series.mean() - answer) < log_error
+
+
+@pytest.mark.parametrize("dtype", ["float16", "float32", "float64"])
+def test_numerical_precision_sum(dtype):
+    np_dtype = np.dtype(dtype)
+    eps = np.finfo(np_dtype).eps
+    value = 0.1
+    n = 10_000_000
+    log_error = np.log(n) * eps
+    answer = value * n
+
+    series = Series(np.zeros(n, dtype=np_dtype)) + value
+    assert series.dtype == np_dtype
+    assert np.abs(series.sum() - answer) < log_error

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -1536,28 +1536,28 @@ class TestSeriesMode:
         tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize("dtype", ["float16", "float32", "float64"])
+@pytest.mark.parametrize("dtype", ["float32", "float64"])
 def test_numerical_precision_mean(dtype):
     np_dtype = np.dtype(dtype)
     eps = np.finfo(np_dtype).eps
     answer = 0.1
-    n = 10_000_000
-    log_error = np.log(n) * eps
+    n = 1_000_000
+    max_error = answer * eps * np.log2(n)
 
-    series = Series(np.zeros(n, dtype=np_dtype)) + answer
+    series = Series(np.full(n, fill_value=answer, dtype=np_dtype))
     assert series.dtype == np_dtype
-    assert np.abs(series.mean() - answer) < log_error
+    assert np.abs(series.mean() - answer) < max_error
 
 
-@pytest.mark.parametrize("dtype", ["float16", "float32", "float64"])
+@pytest.mark.parametrize("dtype", ["float32", "float64"])
 def test_numerical_precision_sum(dtype):
     np_dtype = np.dtype(dtype)
     eps = np.finfo(np_dtype).eps
     value = 0.1
-    n = 10_000_000
-    log_error = np.log(n) * eps
+    n = 1_000_000
     answer = value * n
+    max_error = answer * eps * np.log2(n)
 
-    series = Series(np.zeros(n, dtype=np_dtype)) + value
+    series = Series(np.full(n, fill_value=value, dtype=np_dtype))
     assert series.dtype == np_dtype
-    assert np.abs(series.sum() - answer) < log_error
+    assert np.abs(series.sum() - answer) < max_error

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -1123,7 +1123,22 @@ def test_check_below_min_count__large_shape(min_count, expected_result):
 
 
 @pytest.mark.parametrize("func", ["nanmean", "nansum"])
-@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.float16,
+        np.float32,
+        np.float64,
+    ],
+)
 def test_check_bottleneck_disallow(dtype, func):
     # GH 42878 bottleneck sometimes produces unreliable results for mean and sum
     assert not nanops._bn_ok_dtype(dtype, func)

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -1120,3 +1120,9 @@ def test_check_below_min_count__large_shape(min_count, expected_result):
     shape = (2244367, 1253)
     result = nanops.check_below_min_count(shape, mask=None, min_count=min_count)
     assert result == expected_result
+
+
+@pytest.mark.parametrize("func", ["nanmean", "nansum"])
+@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
+def test_check_bottleneck_disallow(dtype, func):
+    assert not nanops._bn_ok_dtype(dtype, func)

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -1125,4 +1125,5 @@ def test_check_below_min_count__large_shape(min_count, expected_result):
 @pytest.mark.parametrize("func", ["nanmean", "nansum"])
 @pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
 def test_check_bottleneck_disallow(dtype, func):
+    # GH 42878 bottleneck sometimes produces unreliable results for mean and sum
     assert not nanops._bn_ok_dtype(dtype, func)


### PR DESCRIPTION
- [x] closes #42878
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
