### PR TITLE
BUG: groupby.corrwith fails with axis=1 and other=df

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1024,7 +1024,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                 curried, self._obj_with_exclusions, is_transform=is_transform
             )
 
-            if self._selected_obj.ndim != 1 and self.axis != 1:
+            if self._selected_obj.ndim != 1 and self.axis != 1 and result.ndim != 1:
                 missing = self._obj_with_exclusions.columns.difference(result.columns)
                 if len(missing) > 0:
                     warn_dropping_nuisance_columns_deprecated(

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -1505,3 +1505,15 @@ def test_groupby_empty_dataset(dtype, kwargs):
     expected = df.groupby("A").B.describe(**kwargs).reset_index(drop=True).iloc[:0]
     expected.index = Index([])
     tm.assert_frame_equal(result, expected)
+
+
+def test_corrwith_with_1_axis():
+    # GH 47723
+    df = DataFrame({"a": [1, 1, 2], "b": [3, 7, 4]})
+    result = df.groupby("a").corrwith(df, axis=1)
+    index = pd.Index(
+        data=[(1, 0), (1, 1), (1, 2), (2, 2), (2, 0), (2, 1)],
+        name=("a", None),
+    )
+    expected = Series([np.nan] * 6, index=index)
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -1511,7 +1511,7 @@ def test_corrwith_with_1_axis():
     # GH 47723
     df = DataFrame({"a": [1, 1, 2], "b": [3, 7, 4]})
     result = df.groupby("a").corrwith(df, axis=1)
-    index = pd.Index(
+    index = Index(
         data=[(1, 0), (1, 1), (1, 2), (2, 2), (2, 0), (2, 1)],
         name=("a", None),
     )


### PR DESCRIPTION
- [x] closes #47723
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Since this one is only confirmed on master, whatsnew ommited.