### PR TITLE
BUG: Correct numeric_only default for resample var and std

### DIFF
--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -937,7 +937,13 @@ class Resampler(BaseGroupBy, PandasObject):
         """
         return self._upsample("asfreq", fill_value=fill_value)
 
-    def std(self, ddof=1, numeric_only: bool = False, *args, **kwargs):
+    def std(
+        self,
+        ddof=1,
+        numeric_only: bool | lib.NoDefault = lib.no_default,
+        *args,
+        **kwargs,
+    ):
         """
         Compute standard deviation of groups, excluding missing values.
 
@@ -958,7 +964,13 @@ class Resampler(BaseGroupBy, PandasObject):
         nv.validate_resampler_func("std", args, kwargs)
         return self._downsample("std", ddof=ddof, numeric_only=numeric_only)
 
-    def var(self, ddof=1, numeric_only: bool = False, *args, **kwargs):
+    def var(
+        self,
+        ddof=1,
+        numeric_only: bool | lib.NoDefault = lib.no_default,
+        *args,
+        **kwargs,
+    ):
         """
         Compute variance of groups, excluding missing values.
 

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -859,6 +859,10 @@ def test_frame_downsample_method(method, numeric_only, expected_data):
     expected_index = date_range("2018-12-31", periods=1, freq="Y")
     df = DataFrame({"cat": ["cat_1", "cat_2"], "num": [5, 20]}, index=index)
     resampled = df.resample("Y")
+    if numeric_only is lib.no_default:
+        kwargs = {}
+    else:
+        kwargs = {"numeric_only": numeric_only}
 
     func = getattr(resampled, method)
     if numeric_only is lib.no_default and method not in (
@@ -882,9 +886,9 @@ def test_frame_downsample_method(method, numeric_only, expected_data):
         if isinstance(expected_data, str):
             klass = TypeError if method == "var" else ValueError
             with pytest.raises(klass, match=expected_data):
-                _ = func(numeric_only=numeric_only)
+                _ = func(**kwargs)
         else:
-            result = func(numeric_only=numeric_only)
+            result = func(**kwargs)
             expected = DataFrame(expected_data, index=expected_index)
             tm.assert_frame_equal(result, expected)
 


### PR DESCRIPTION
- [x] closes #46560 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

No whatsnew since this was introduced in 1.5.0. The test would have caught it but it was explicitly passing `numeric_only=lib.no_default` instead of just not passing any arg.

As far as I know, this was the last task for #46560.