### PR TITLE
BUG: Set y-axis label, limits and ticks for a secondary y-axis (#47753)

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -977,6 +977,7 @@ Plotting
 - The function :meth:`DataFrame.plot.scatter` now accepts ``color`` as an alias for ``c`` and ``size`` as an alias for ``s`` for consistency to other plotting functions (:issue:`44670`)
 - Fix showing "None" as ylabel in :meth:`Series.plot` when not setting ylabel (:issue:`46129`)
 - Bug in :meth:`DataFrame.plot` that led to xticks and vertical grids being improperly placed when plotting a quarterly series (:issue:`47602`)
+- Bug in :meth:`DataFrame.plot` that prevented setting y-axis label, limits and ticks for a secondary y-axis (:issue:`47753`)
 
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -679,6 +679,7 @@ class MPLPlot(ABC):
             )
 
         for ax in self.axes:
+            ax = getattr(ax, "right_ax", ax)
             if self.yticks is not None:
                 ax.set_yticks(self.yticks)
 

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -2204,6 +2204,17 @@ class TestDataFramePlots(TestPlotBase):
         assert ax.get_xlabel() == (xcol if xlabel is None else xlabel)
         assert ax.get_ylabel() == (ycol if ylabel is None else ylabel)
 
+    @pytest.mark.parametrize("secondary_y", (False, True))
+    def test_secondary_y(self, secondary_y):
+        ax_df = DataFrame([0]).plot(
+            secondary_y=secondary_y, ylabel="Y", ylim=(0, 100), yticks=[99]
+        )
+        for ax in ax_df.figure.axes:
+            if ax.yaxis.get_visible():
+                assert ax.get_ylabel() == "Y"
+                assert ax.get_ylim() == (0, 100)
+                assert ax.get_yticks()[0] == 99
+
 
 def _generate_4_axes_via_gridspec():
     import matplotlib as mpl


### PR DESCRIPTION
When passing `secondary_y=True` to a plotting function, a second axes with a
y-axis on the right side is created. Passing `ylabel`, `ylim` or `yticks` changed
these properties of the original invisible left y-axis, not the secondary
y-axis.

- [x] closes #47753 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
