### PR TITLE
BUG: wide_to_long fails when stubname misses and i contains string type column

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -1019,6 +1019,7 @@ Reshaping
 - Bug in :meth:`DataFrame.join` with a list when using suffixes to join DataFrames with duplicate column names (:issue:`46396`)
 - Bug in :meth:`DataFrame.pivot_table` with ``sort=False`` results in sorted index (:issue:`17041`)
 - Bug in :meth:`concat` when ``axis=1`` and ``sort=False`` where the resulting Index was a :class:`Int64Index` instead of a :class:`RangeIndex` (:issue:`46675`)
+- Bug in :meth:`wide_to_long` raises when stubname misses in columns and ``i`` contains string dtype column (:issue:`46044`)
 
 Sparse
 ^^^^^^

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -1019,7 +1019,7 @@ Reshaping
 - Bug in :meth:`DataFrame.join` with a list when using suffixes to join DataFrames with duplicate column names (:issue:`46396`)
 - Bug in :meth:`DataFrame.pivot_table` with ``sort=False`` results in sorted index (:issue:`17041`)
 - Bug in :meth:`concat` when ``axis=1`` and ``sort=False`` where the resulting Index was a :class:`Int64Index` instead of a :class:`RangeIndex` (:issue:`46675`)
-- Bug in :meth:`wide_to_long` raises when stubname misses in columns and ``i`` contains string dtype column (:issue:`46044`)
+- Bug in :meth:`wide_to_long` raises when ``stubnames`` is missing in columns and ``i`` contains string dtype column (:issue:`46044`)
 
 Sparse
 ^^^^^^

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -130,7 +130,7 @@ def melt(
     mdata = {}
     for col in id_vars:
         id_data = frame.pop(col)
-        if is_extension_array_dtype(id_data):
+        if is_extension_array_dtype(id_data) and K > 0:
             id_data = concat([id_data] * K, ignore_index=True)
         else:
             # error: Incompatible types in assignment (expression has type

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -131,7 +131,13 @@ def melt(
     for col in id_vars:
         id_data = frame.pop(col)
         if is_extension_array_dtype(id_data):
-            id_data = concat([id_data] * K, ignore_index=True) if K > 0 else []
+            if K > 0:
+                id_data = concat([id_data] * K, ignore_index=True)
+            else:
+                # We can't concat empty list. (GH 46044)
+                # Desired result is an empty Series, but we can't construct it by
+                # pd.Series() since circular import
+                id_data = id_data.iloc[:0]
         else:
             # error: Incompatible types in assignment (expression has type
             # "ndarray[Any, dtype[Any]]", variable has type "Series")

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -130,8 +130,8 @@ def melt(
     mdata = {}
     for col in id_vars:
         id_data = frame.pop(col)
-        if is_extension_array_dtype(id_data) and K > 0:
-            id_data = concat([id_data] * K, ignore_index=True)
+        if is_extension_array_dtype(id_data):
+            id_data = concat([id_data] * K, ignore_index=True) if K > 0 else []
         else:
             # error: Incompatible types in assignment (expression has type
             # "ndarray[Any, dtype[Any]]", variable has type "Series")

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -135,9 +135,7 @@ def melt(
                 id_data = concat([id_data] * K, ignore_index=True)
             else:
                 # We can't concat empty list. (GH 46044)
-                # Desired result is an empty Series, but we can't construct it by
-                # pd.Series() since circular import
-                id_data = id_data.iloc[:0]
+                id_data = type(id_data)([], name=id_data.name, dtype=id_data.dtype)
         else:
             # error: Incompatible types in assignment (expression has type
             # "ndarray[Any, dtype[Any]]", variable has type "Series")

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -1087,9 +1087,11 @@ class TestWideToLong:
             result = df.melt(id_vars="value")
             tm.assert_frame_equal(result, expected)
 
-    def test_missing_stubname(self):
+    @pytest.mark.parametrize("dtype", ["O", "string"])
+    def test_missing_stubname(self, dtype):
         # GH46044
         df = DataFrame({"id": ["1", "2"], "a-1": [100, 200], "a-2": [300, 400]})
+        df = df.astype({"id": dtype})
         result = wide_to_long(
             df,
             stubnames=["a", "b"],
@@ -1105,16 +1107,6 @@ class TestWideToLong:
             {"a": [100, 200, 300, 400], "b": [np.nan] * 4},
             index=index,
         )
-        tm.assert_frame_equal(result, expected)
-        # test extension string array
-        df_str = df.astype({"id": "string"})
-        result_str = wide_to_long(
-            df_str,
-            stubnames=["a", "b"],
-            i="id",
-            j="num",
-            sep="-",
-        )
-        new_level = expected.index.levels[0].astype("string")
+        new_level = expected.index.levels[0].astype(dtype)
         expected.index = expected.index.set_levels(new_level, level=0)
-        tm.assert_frame_equal(result_str, expected)
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -1086,3 +1086,31 @@ class TestWideToLong:
         with tm.assert_produces_warning(FutureWarning):
             result = df.melt(id_vars="value")
             tm.assert_frame_equal(result, expected)
+
+    def test_missing_stubname(self):
+        # GH46044
+        df = DataFrame({"id": ["1", "2"], "a-1": [100, 200], "a-2": [300, 400]})
+        result = wide_to_long(
+            df,
+            stubnames=["a", "b"],
+            i="id",
+            j="num",
+            sep="-",
+        )
+        index = pd.Index(
+            [("1", 1), ("2", 1), ("1", 2), ("2", 2)],
+            name=("id", "num"),
+        )
+        expected = DataFrame(
+            {"a": [100, 200, 300, 400], "b": [np.nan] * 4},
+            index=index,
+        )
+        tm.assert_frame_equal(result, expected)
+        # test extension string array
+        df_str = df.astype({"id": "string"})
+        result_str = wide_to_long(
+            df_str, stubnames=["a", "b"], i="id", j="num", sep="-",
+        )
+        new_level = expected.index.levels[0].astype("string")
+        expected.index = expected.index.set_levels(new_level, level=0)
+        tm.assert_frame_equal(result_str, expected)

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -1109,7 +1109,11 @@ class TestWideToLong:
         # test extension string array
         df_str = df.astype({"id": "string"})
         result_str = wide_to_long(
-            df_str, stubnames=["a", "b"], i="id", j="num", sep="-",
+            df_str,
+            stubnames=["a", "b"],
+            i="id",
+            j="num",
+            sep="-",
         )
         new_level = expected.index.levels[0].astype("string")
         expected.index = expected.index.set_levels(new_level, level=0)


### PR DESCRIPTION
- [x] closes #46044
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
