### PR TITLE
add ignore for new mypy error 'type-var'

### DIFF
--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -205,7 +205,7 @@ class Resampler(BaseGroupBy, PandasObject):
 
     # error: Signature of "obj" incompatible with supertype "BaseGroupBy"
     @property
-    def obj(self) -> NDFrameT:  # type: ignore[override]
+    def obj(self) -> NDFrameT:  # type: ignore[override, type-var]
         # error: Incompatible return value type (got "Optional[Any]",
         # expected "NDFrameT")
         return self.groupby.obj  # type: ignore[return-value]

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -205,9 +205,7 @@ class Resampler(BaseGroupBy, PandasObject):
 
     # error: Signature of "obj" incompatible with supertype "BaseGroupBy"
     @property
-    def obj(self) -> NDFrameT:  # type: ignore[override, type-var]
-        # error: Incompatible return value type (got "Optional[Any]",
-        # expected "NDFrameT")
+    def obj(self) -> NDFrame:
         return self.groupby.obj  # type: ignore[return-value]
 
     @property

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -205,7 +205,9 @@ class Resampler(BaseGroupBy, PandasObject):
 
     # error: Signature of "obj" incompatible with supertype "BaseGroupBy"
     @property
-    def obj(self) -> NDFrame:
+    def obj(self) -> NDFrame:  # type: ignore[override]
+        # error: Incompatible return value type (got "Optional[Any]",
+        # expected "NDFrameT")
         return self.groupby.obj  # type: ignore[return-value]
 
     @property


### PR DESCRIPTION
A new error introduced to mypy is detected in pandas' repository. This PR adds comment to ignore that error.

> pandas (https://github.com/pandas-dev/pandas)
> + pandas/core/resample.py:208: error: A function returning TypeVar should receive at least one argument containing the same Typevar  [type-var]
> + pandas/core/resample.py:208: note: Error code "type-var" not covered by "type: ignore" comment

Reference:
https://github.com/python/mypy/pull/13166

- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.