### PR TITLE
TYP: Appender also works with properties

### DIFF
--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -12,7 +12,10 @@ from typing import (
 import warnings
 
 from pandas._libs.properties import cache_readonly
-from pandas._typing import F
+from pandas._typing import (
+    F,
+    T,
+)
 from pandas.util._exceptions import find_stack_level
 
 
@@ -485,7 +488,7 @@ class Appender:
             self.addendum = addendum
         self.join = join
 
-    def __call__(self, func: F) -> F:
+    def __call__(self, func: T) -> T:
         func.__doc__ = func.__doc__ if func.__doc__ else ""
         self.addendum = self.addendum if self.addendum else ""
         docitems = [func.__doc__, self.addendum]


### PR DESCRIPTION
Technically, `Appender` works with literally any `object` as all of them have `__doc__`.

This change helps pyright in this case https://github.com/pandas-dev/pandas/blob/bdd9314c7006611021bab2b7adf7210cd874a0c2/pandas/core/series.py#L738

Mypy still needs the ignore because it doesn't support decorating a property.