### PR TITLE
REF: avoid converting input to cut if passing IntervalIndex bins

### DIFF
--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -240,7 +240,9 @@ def cut(
 
     original = x
     x = _preprocess_for_cut(x)
-    x, dtype = _coerce_to_type(x)
+    dtype = None
+    if not isinstance(bins, IntervalIndex):
+        x, dtype = _coerce_to_type(x)
 
     if not np.iterable(bins):
         if is_scalar(bins) and bins < 1:


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/47772, https://github.com/pandas-dev/pandas/issues/46218#issuecomment-1186600310