### PR TITLE
BUG: PeriodIndex fails to handle NA, rather than putting NaT in its place (#46673)

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -906,6 +906,7 @@ Indexing
 - Bug in :meth:`NDFrame.xs`, :meth:`DataFrame.iterrows`, :meth:`DataFrame.loc` and :meth:`DataFrame.iloc` not always propagating metadata (:issue:`28283`)
 - Bug in :meth:`DataFrame.sum` min_count changes dtype if input contains NaNs (:issue:`46947`)
 - Bug in :class:`IntervalTree` that lead to an infinite recursion. (:issue:`46658`)
+- Bug in :class:`PeriodIndex` raising ``AttributeError`` when indexing on ``NA``, rather than putting ``NaT`` in its place. (:issue:`46673`)
 -
 
 Missing

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -28,6 +28,7 @@ from numpy cimport int64_t
 cnp.import_array()
 
 cimport pandas._libs.tslibs.util as util
+from pandas._libs.missing cimport C_NA
 from pandas._libs.tslibs.np_datetime cimport (
     get_datetime64_value,
     get_timedelta64_value,
@@ -1217,7 +1218,7 @@ cdef inline bint checknull_with_nat(object val):
     """
     Utility to check if a value is a nat or not.
     """
-    return val is None or util.is_nan(val) or val is c_NaT
+    return val is None or util.is_nan(val) or val is c_NaT or val is C_NA
 
 
 cdef inline bint is_dt64nat(object val):

--- a/pandas/tests/arrays/categorical/test_indexing.py
+++ b/pandas/tests/arrays/categorical/test_indexing.py
@@ -1,12 +1,16 @@
+import math
+
 import numpy as np
 import pytest
 
 from pandas import (
+    NA,
     Categorical,
     CategoricalIndex,
     Index,
     Interval,
     IntervalIndex,
+    NaT,
     PeriodIndex,
     Series,
     Timedelta,
@@ -193,6 +197,17 @@ class TestCategoricalIndexing:
         cat.categories = [1, 2, 3]
         tm.assert_numpy_array_equal(cat.__array__(), exp)
         tm.assert_index_equal(cat.categories, Index([1, 2, 3]))
+
+    @pytest.mark.parametrize(
+        "null_val",
+        [None, np.nan, NaT, NA, math.nan, "NaT", "nat", "NAT", "nan", "NaN", "NAN"],
+    )
+    def test_periodindex_on_null_types(self, null_val):
+        # GH 46673
+        result = PeriodIndex(["2022-04-06", "2022-04-07", null_val], freq="D")
+        expected = PeriodIndex(["2022-04-06", "2022-04-07", "NaT"], dtype="period[D]")
+        assert type(result[2]) == type(NaT)
+        tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("new_categories", [[1, 2, 3, 4], [1, 2]])
     def test_categories_assignments_wrong_length_raises(self, new_categories):


### PR DESCRIPTION
- [x] closes #46673
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
