### PR TITLE
Specify that both ``by`` and ``level`` should not be specified in ``groupby`` - GH40378

### DIFF
--- a/doc/source/user_guide/groupby.rst
+++ b/doc/source/user_guide/groupby.rst
@@ -345,6 +345,16 @@ Index level names may be supplied as keys.
 
 More on the ``sum`` function and aggregation later.
 
+When using ``.groupby()`` on a DatFrame with a  MultiIndex, do not specify both ``by`` and ``level``.
+The argument validation should be done in ``.groupby()``, using the name of the specific index.
+
+.. ipython:: python
+   df = pd.DataFrame({"col1": ["a", "b", "c"]})
+   df.index = pd.MultiIndex.from_arrays([["a", "a", "b"],
+                                        [1, 2, 1]],
+                                        names=["x", "y"])
+   df.groupby(["col1", "x"])
+
 Grouping DataFrame with Index levels and columns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 A DataFrame may be grouped by a combination of columns and index levels by

--- a/doc/source/user_guide/groupby.rst
+++ b/doc/source/user_guide/groupby.rst
@@ -349,6 +349,7 @@ When using ``.groupby()`` on a DatFrame with a  MultiIndex, do not specify both 
 The argument validation should be done in ``.groupby()``, using the name of the specific index.
 
 .. ipython:: python
+
    df = pd.DataFrame({"col1": ["a", "b", "c"]})
    df.index = pd.MultiIndex.from_arrays([["a", "a", "b"],
                                         [1, 2, 1]],

--- a/doc/source/user_guide/groupby.rst
+++ b/doc/source/user_guide/groupby.rst
@@ -355,6 +355,8 @@ The argument validation should be done in ``.groupby()``, using the name of the 
                                         names=["x", "y"])
    df.groupby(["col1", "x"])
 
+
+
 Grouping DataFrame with Index levels and columns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 A DataFrame may be grouped by a combination of columns and index levels by

--- a/doc/source/user_guide/groupby.rst
+++ b/doc/source/user_guide/groupby.rst
@@ -355,8 +355,6 @@ The argument validation should be done in ``.groupby()``, using the name of the 
                                         names=["x", "y"])
    df.groupby(["col1", "x"])
 
-
-
 Grouping DataFrame with Index levels and columns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 A DataFrame may be grouped by a combination of columns and index levels by


### PR DESCRIPTION
- [ ] closes #40378 (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
