### PR TITLE
Concatenating unordered ``CategoricalIndex`` overrides indices - GH24845

### DIFF
--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -571,6 +571,26 @@ class CategoricalIndex(NDArrayBackedExtensionIndex):
 
     def _concat(self, to_concat: list[Index], name: Hashable) -> Index:
         # if calling index is category, don't check dtype of others
+
+        permutations = True
+
+        dummy_cat1 = CategoricalIndex([], categories=to_concat[0].categories,
+                                      ordered=False
+                                      )
+        for i in to_concat[1:]:
+
+            dummy_cat2 = CategoricalIndex([], categories=i.categories,
+                                          ordered=False
+                                          )
+            if not dummy_cat1.equals(dummy_cat2):
+                permutations = False
+
+        cat_dummy = CategoricalIndex([], categories=to_concat[0].categories,
+                                     ordered=True
+                                     )
+        if permutations:
+            to_concat.append(cat_dummy)
+
         try:
             codes = np.concatenate([self._is_dtype_compat(c).codes for c in to_concat])
         except TypeError:

--- a/pandas/tests/reshape/concat/test_categorical.py
+++ b/pandas/tests/reshape/concat/test_categorical.py
@@ -184,7 +184,7 @@ class TestCategoricalConcat:
         )
         tm.assert_equal(result, expected)
 
-    def test_categorical_concat_same_categories_different_order(self):
+    def test_categorical_concat_same_cat(self):
         # https://github.com/pandas-dev/pandas/issues/24845
 
         c1 = CategoricalIndex(["a", "a"], categories=["a", "b"],
@@ -200,7 +200,7 @@ class TestCategoricalConcat:
         df1 = DataFrame({"A": [1, 2]}, index=c1)
         df2 = DataFrame({"A": [3, 4]}, index=c2)
 
-        result = concat((df1, df2))
+        result = pd.concat((df1, df2))
 
         expected = DataFrame({"A": [1, 2, 3, 4]}, index=c3)
 

--- a/pandas/tests/reshape/concat/test_categorical.py
+++ b/pandas/tests/reshape/concat/test_categorical.py
@@ -200,7 +200,7 @@ class TestCategoricalConcat:
         df1 = DataFrame({"A": [1, 2]}, index=c1)
         df2 = DataFrame({"A": [3, 4]}, index=c2)
 
-        result = pd.concat((df1, df2))
+        result = pd.concat([df1, df2])
 
         expected = DataFrame({"A": [1, 2, 3, 4]}, index=c3)
 

--- a/pandas/tests/reshape/concat/test_categorical.py
+++ b/pandas/tests/reshape/concat/test_categorical.py
@@ -184,6 +184,28 @@ class TestCategoricalConcat:
         )
         tm.assert_equal(result, expected)
 
+    def test_concat_categorical_same_categories_different_order(self):
+        # https://github.com/pandas-dev/pandas/issues/24845
+
+        c1 = CategoricalIndex(["a", "a"], categories=["a", "b"],
+                              ordered=False
+                              )
+        c2 = CategoricalIndex(["b", "b"], categories=["b", "a"],
+                              ordered=False
+                              )
+        c3 = CategoricalIndex(["a", "a", "b", "b"],
+                              categories=["a", "b"], ordered=False
+                              )
+
+        df1 = DataFrame({"A": [1, 2]}, index=c1)
+        df2 = DataFrame({"A": [3, 4]}, index=c2)
+
+        result = concat((df1, df2))
+
+        expected = DataFrame({"A": [1, 2, 3, 4]}, index=c3)
+
+        tm.assert_frame_equal(result, expected)
+
     def test_categorical_concat_gh7864(self):
         # GH 7864
         # make sure ordering is preserved
@@ -237,26 +259,4 @@ class TestCategoricalConcat:
             },
             index=[0, 1, 2, 0, 1, 2],
         )
-        tm.assert_frame_equal(result, expected)
-
-    def test_concat_categorical_same_categories_different_order(self):
-        # https://github.com/pandas-dev/pandas/issues/24845
-
-        c1 = CategoricalIndex(["a", "a"], categories=["a", "b"],
-                              ordered=False
-                              )
-        c2 = CategoricalIndex(["b", "b"], categories=["b", "a"],
-                              ordered=False
-                              )
-        c3 = CategoricalIndex(["a", "a", "b", "b"],
-                              categories=["a", "b"], ordered=False
-                              )
-
-        df1 = DataFrame({"A": [1, 2]}, index=c1)
-        df2 = DataFrame({"A": [3, 4]}, index=c2)
-
-        result = concat((df1, df2))
-
-        expected = DataFrame({"A": [1, 2, 3, 4]}, index=c3)
-
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/reshape/concat/test_categorical.py
+++ b/pandas/tests/reshape/concat/test_categorical.py
@@ -238,3 +238,25 @@ class TestCategoricalConcat:
             index=[0, 1, 2, 0, 1, 2],
         )
         tm.assert_frame_equal(result, expected)
+
+    def test_concat_categorical_same_categories_different_order(self):
+        # https://github.com/pandas-dev/pandas/issues/24845
+
+        c1 = CategoricalIndex(["a", "a"], categories=["a", "b"],
+                              ordered=False
+                              )
+        c2 = CategoricalIndex(["b", "b"], categories=["b", "a"],
+                              ordered=False
+                              )
+        c3 = CategoricalIndex(["a", "a", "b", "b"],
+                              categories=["a", "b"], ordered=False
+                              )
+
+        df1 = DataFrame({"A": [1, 2]}, index=c1)
+        df2 = DataFrame({"A": [3, 4]}, index=c2)
+
+        result = concat((df1, df2))
+
+        expected = DataFrame({"A": [1, 2, 3, 4]}, index=c3)
+
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/reshape/concat/test_categorical.py
+++ b/pandas/tests/reshape/concat/test_categorical.py
@@ -184,7 +184,7 @@ class TestCategoricalConcat:
         )
         tm.assert_equal(result, expected)
 
-    def test_categorical_concat_same_cat(self):
+    def test_categorical_concat_same_categories_different_order(self):
         # https://github.com/pandas-dev/pandas/issues/24845
 
         c1 = CategoricalIndex(["a", "a"], categories=["a", "b"],

--- a/pandas/tests/reshape/concat/test_categorical.py
+++ b/pandas/tests/reshape/concat/test_categorical.py
@@ -184,7 +184,7 @@ class TestCategoricalConcat:
         )
         tm.assert_equal(result, expected)
 
-    def test_concat_categorical_same_categories_different_order(self):
+    def test_categorical_concat_same_categories_different_order(self):
         # https://github.com/pandas-dev/pandas/issues/24845
 
         c1 = CategoricalIndex(["a", "a"], categories=["a", "b"],


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
