### PR TITLE
TST/CI: xfail test_round_sanity for 32 bit

### DIFF
--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -691,19 +691,14 @@ class TestTimedeltas:
         with pytest.raises(OverflowError, match=msg):
             Timedelta.max.ceil("s")
 
+    @pytest.mark.xfail(not IS64, reason="Failing on 32 bit build")
     @given(val=st.integers(min_value=iNaT + 1, max_value=lib.i8max))
     @pytest.mark.parametrize(
         "method",
         [
-            pytest.param(
-                Timedelta.round,
-                marks=pytest.mark.xfail(not IS64, reason="Failing on 32 bit build"),
-            ),
+            Timedelta.round,
             Timedelta.floor,
-            pytest.param(
-                Timedelta.ceil,
-                marks=pytest.mark.xfail(not IS64, reason="Failing on 32 bit build"),
-            ),
+            Timedelta.ceil,
         ],
     )
     def test_round_sanity(self, val, method):

--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -14,6 +14,7 @@ from pandas._libs.tslibs import (
     iNaT,
 )
 from pandas._libs.tslibs.dtypes import NpyDatetimeUnit
+from pandas.compat import IS64
 from pandas.errors import OutOfBoundsTimedelta
 
 import pandas as pd
@@ -692,7 +693,18 @@ class TestTimedeltas:
 
     @given(val=st.integers(min_value=iNaT + 1, max_value=lib.i8max))
     @pytest.mark.parametrize(
-        "method", [Timedelta.round, Timedelta.floor, Timedelta.ceil]
+        "method",
+        [
+            pytest.param(
+                Timedelta.round,
+                marks=pytest.mark.xfail(not IS64, reason="Failing on 32 bit build"),
+            ),
+            Timedelta.floor,
+            pytest.param(
+                Timedelta.ceil,
+                marks=pytest.mark.xfail(not IS64, reason="Failing on 32 bit build"),
+            ),
+        ],
     )
     def test_round_sanity(self, val, method):
         val = np.int64(val)

--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -691,7 +691,7 @@ class TestTimedeltas:
         with pytest.raises(OverflowError, match=msg):
             Timedelta.max.ceil("s")
 
-    @pytest.mark.xfail(not IS64, reason="Failing on 32 bit build")
+    @pytest.mark.xfail(not IS64, reason="Failing on 32 bit build", strict=False)
     @given(val=st.integers(min_value=iNaT + 1, max_value=lib.i8max))
     @pytest.mark.parametrize(
         "method", [Timedelta.round, Timedelta.floor, Timedelta.ceil]

--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -695,11 +695,7 @@ class TestTimedeltas:
     @given(val=st.integers(min_value=iNaT + 1, max_value=lib.i8max))
     @pytest.mark.parametrize(
         "method",
-        [
-            Timedelta.round,
-            Timedelta.floor,
-            Timedelta.ceil,
-        ],
+        [Timedelta.round, Timedelta.floor, Timedelta.ceil],
     )
     def test_round_sanity(self, val, method):
         val = np.int64(val)

--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -694,8 +694,7 @@ class TestTimedeltas:
     @pytest.mark.xfail(not IS64, reason="Failing on 32 bit build")
     @given(val=st.integers(min_value=iNaT + 1, max_value=lib.i8max))
     @pytest.mark.parametrize(
-        "method",
-        [Timedelta.round, Timedelta.floor, Timedelta.ceil],
+        "method", [Timedelta.round, Timedelta.floor, Timedelta.ceil]
     )
     def test_round_sanity(self, val, method):
         val = np.int64(val)

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -302,11 +302,7 @@ class TestTimestampUnaryOps:
     @given(val=st.integers(iNaT + 1, lib.i8max))
     @pytest.mark.parametrize(
         "method",
-        [
-            Timestamp.round,
-            Timedelta.floor,
-            Timestamp.ceil,
-        ],
+        [Timestamp.round, Timedelta.floor, Timestamp.ceil],
     )
     def test_round_sanity(self, val, method):
         val = np.int64(val)

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -298,7 +298,7 @@ class TestTimestampUnaryOps:
         with pytest.raises(OverflowError, match=msg):
             Timestamp.max.ceil("s")
 
-    @pytest.mark.xfail(not IS64, reason="Failing on 32 bit build")
+    @pytest.mark.xfail(not IS64, reason="Failing on 32 bit build", strict=False)
     @given(val=st.integers(iNaT + 1, lib.i8max))
     @pytest.mark.parametrize(
         "method", [Timestamp.round, Timestamp.floor, Timestamp.ceil]

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -21,6 +21,7 @@ from pandas._libs.tslibs import (
 )
 from pandas._libs.tslibs.dtypes import NpyDatetimeUnit
 from pandas._libs.tslibs.period import INVALID_FREQ_ERR_MSG
+from pandas.compat import IS64
 import pandas.util._test_decorators as td
 
 import pandas._testing as tm
@@ -299,7 +300,15 @@ class TestTimestampUnaryOps:
 
     @given(val=st.integers(iNaT + 1, lib.i8max))
     @pytest.mark.parametrize(
-        "method", [Timestamp.round, Timestamp.floor, Timestamp.ceil]
+        "method",
+        [
+            Timestamp.round,
+            pytest.param(
+                Timedelta.floor,
+                marks=pytest.mark.xfail(not IS64, reason="Failing on 32 bit build"),
+            ),
+            Timestamp.ceil,
+        ],
     )
     def test_round_sanity(self, val, method):
         val = np.int64(val)

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -298,15 +298,13 @@ class TestTimestampUnaryOps:
         with pytest.raises(OverflowError, match=msg):
             Timestamp.max.ceil("s")
 
+    @pytest.mark.xfail(not IS64, reason="Failing on 32 bit build")
     @given(val=st.integers(iNaT + 1, lib.i8max))
     @pytest.mark.parametrize(
         "method",
         [
             Timestamp.round,
-            pytest.param(
-                Timedelta.floor,
-                marks=pytest.mark.xfail(not IS64, reason="Failing on 32 bit build"),
-            ),
+            Timedelta.floor,
             Timestamp.ceil,
         ],
     )

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -301,8 +301,7 @@ class TestTimestampUnaryOps:
     @pytest.mark.xfail(not IS64, reason="Failing on 32 bit build")
     @given(val=st.integers(iNaT + 1, lib.i8max))
     @pytest.mark.parametrize(
-        "method",
-        [Timestamp.round, Timedelta.floor, Timestamp.ceil],
+        "method", [Timestamp.round, Timestamp.floor, Timestamp.ceil]
     )
     def test_round_sanity(self, val, method):
         val = np.int64(val)


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

xfailing just to get the CI to green. Might be addressable in the future cc @jbrockmendel 
