### PR TITLE
Manual Backport PR #47803 on branch 1.4.x (TST/CI: xfail test_round_sanity for 32 bit)

### DIFF
--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -13,6 +13,7 @@ from pandas._libs.tslibs import (
     NaT,
     iNaT,
 )
+from pandas.compat import IS64
 
 import pandas as pd
 from pandas import (
@@ -413,6 +414,7 @@ class TestTimedeltas:
         with pytest.raises(OverflowError, match=msg):
             Timedelta.max.ceil("s")
 
+    @pytest.mark.xfail(not IS64, reason="Failing on 32 bit build", strict=False)
     @given(val=st.integers(min_value=iNaT + 1, max_value=lib.i8max))
     @pytest.mark.parametrize(
         "method", [Timedelta.round, Timedelta.floor, Timedelta.ceil]

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -20,6 +20,7 @@ from pandas._libs.tslibs import (
     to_offset,
 )
 from pandas._libs.tslibs.period import INVALID_FREQ_ERR_MSG
+from pandas.compat import IS64
 import pandas.util._test_decorators as td
 
 import pandas._testing as tm
@@ -280,6 +281,7 @@ class TestTimestampUnaryOps:
         with pytest.raises(OverflowError, match=msg):
             Timestamp.max.ceil("s")
 
+    @pytest.mark.xfail(not IS64, reason="Failing on 32 bit build", strict=False)
     @given(val=st.integers(iNaT + 1, lib.i8max))
     @pytest.mark.parametrize(
         "method", [Timestamp.round, Timestamp.floor, Timestamp.ceil]


### PR DESCRIPTION
Manual Backport PR #47803

- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

