### PR TITLE
Specify that both ``by`` and ``level`` should not be specified in ``groupby`` - GH40378 

### DIFF
--- a/doc/source/user_guide/groupby.rst
+++ b/doc/source/user_guide/groupby.rst
@@ -345,17 +345,6 @@ Index level names may be supplied as keys.
 
 More on the ``sum`` function and aggregation later.
 
-When using ``.groupby()`` on a DatFrame with a  MultiIndex, do not specify both ``by`` and ``level``.
-The argument validation should be done in ``.groupby()``, using the name of the specific index.
-
-.. ipython:: python
-
-   df = pd.DataFrame({"col1": ["a", "b", "c"]})
-   df.index = pd.MultiIndex.from_arrays([["a", "a", "b"],
-                                        [1, 2, 1]],
-                                        names=["x", "y"])
-   df.groupby(["col1", "x"])
-
 Grouping DataFrame with Index levels and columns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 A DataFrame may be grouped by a combination of columns and index levels by

--- a/pandas/core/shared_docs.py
+++ b/pandas/core/shared_docs.py
@@ -110,7 +110,7 @@ axis : {0 or 'index', 1 or 'columns'}, default 0
     is unused and defaults to 0.
 level : int, level name, or sequence of such, default None
     If the axis is a MultiIndex (hierarchical), group by a particular
-    level or levels.
+    level or levels. Do not specify both ``by`` and ``level``.
 as_index : bool, default True
     For aggregated output, return object with group labels as the
     index. Only relevant for DataFrame input. as_index=False is


### PR DESCRIPTION
- [x] closes #40378 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Ref: https://github.com/pandas-dev/pandas/pull/47778#discussion_r923860446