### PR TITLE
Fix styling of `DataFrame` for columns with boolean label

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -1042,6 +1042,7 @@ Styler
 - Bug in :meth:`Styler.set_sticky` leading to white text on white background in dark mode (:issue:`46984`)
 - Bug in :meth:`Styler.to_latex` causing ``UnboundLocalError`` when ``clines="all;data"`` and the ``DataFrame`` has no rows. (:issue:`47203`)
 - Bug in :meth:`Styler.to_excel` when using ``vertical-align: middle;`` with ``xlsxwriter`` engine (:issue:`30107`)
+- Bug when applying styles to a DataFrame with boolean column labels (:issue:`47838`)
 
 Metadata
 ^^^^^^^^

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -2977,7 +2977,10 @@ class Styler(StylerRenderer):
     # A collection of "builtin" styles
     # -----------------------------------------------------------------------
 
-    def _get_subset_default(self):
+    def _get_numeric_subset_default(self):
+        # Returns a boolean mask indicating where `self.data` has numerical columns.
+        # Choosing a mask as opposed to the column names also works for
+        # boolean column labels (GH47838).
         return self.data.columns.isin(self.data.select_dtypes(include=np.number))
 
     @doc(
@@ -3123,7 +3126,7 @@ class Styler(StylerRenderer):
         .. figure:: ../../_static/style/{image_prefix}_axNone_gmap.png
         """
         if subset is None and gmap is None:
-            subset = self._get_subset_default()
+            subset = self._get_numeric_subset_default()
 
         self.apply(
             _background_gradient,
@@ -3158,7 +3161,7 @@ class Styler(StylerRenderer):
         gmap: Sequence | None = None,
     ) -> Styler:
         if subset is None and gmap is None:
-            subset = self._get_subset_default()
+            subset = self._get_numeric_subset_default()
 
         return self.apply(
             _background_gradient,
@@ -3311,7 +3314,7 @@ class Styler(StylerRenderer):
             raise ValueError(f"`height` must be a value in [0, 100], got {height}")
 
         if subset is None:
-            subset = self._get_subset_default()
+            subset = self._get_numeric_subset_default()
 
         self.apply(
             _bar,

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -2977,6 +2977,9 @@ class Styler(StylerRenderer):
     # A collection of "builtin" styles
     # -----------------------------------------------------------------------
 
+    def _get_subset_default(self):
+        return self.data.columns.isin(self.data.select_dtypes(include=np.number))
+
     @doc(
         name="background",
         alt="text",
@@ -3120,7 +3123,7 @@ class Styler(StylerRenderer):
         .. figure:: ../../_static/style/{image_prefix}_axNone_gmap.png
         """
         if subset is None and gmap is None:
-            subset = self.data.select_dtypes(include=np.number).columns
+            subset = self._get_subset_default()
 
         self.apply(
             _background_gradient,
@@ -3155,7 +3158,7 @@ class Styler(StylerRenderer):
         gmap: Sequence | None = None,
     ) -> Styler:
         if subset is None and gmap is None:
-            subset = self.data.select_dtypes(include=np.number).columns
+            subset = self._get_subset_default()
 
         return self.apply(
             _background_gradient,
@@ -3308,7 +3311,7 @@ class Styler(StylerRenderer):
             raise ValueError(f"`height` must be a value in [0, 100], got {height}")
 
         if subset is None:
-            subset = self.data.select_dtypes(include=np.number).columns
+            subset = self._get_subset_default()
 
         self.apply(
             _bar,


### PR DESCRIPTION
- [x] closes #47838
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. (Not applicable since no new public functions added or signatures modified.)
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Summary of changes
* Make the `subset` argument in styling by default a boolean mask indicating where the numerical columns of the data frame are.
* Add new test cases for checking that the expected columns are styled in `.ctx`.