### PR TITLE
DEPR: args and kwargs in rolling, expanding, and ewm ops

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -773,6 +773,7 @@ Other Deprecations
 - Deprecated :class:`Series` and :class:`Resampler` reducers (e.g. ``min``, ``max``, ``sum``, ``mean``) raising a ``NotImplementedError`` when the dtype is non-numric and ``numeric_only=True`` is provided; this will raise a ``TypeError`` in a future version (:issue:`47500`)
 - Deprecated :meth:`Series.rank` returning an empty result when the dtype is non-numeric and ``numeric_only=True`` is provided; this will raise a ``TypeError`` in a future version (:issue:`47500`)
 - Deprecated argument ``errors`` for :meth:`Series.mask`, :meth:`Series.where`, :meth:`DataFrame.mask`, and :meth:`DataFrame.where` as ``errors`` had no effect on this methods (:issue:`47728`)
+- Deprecated arguments ``*args`` and ``**kwargs`` in :class:`Rolling`, :class:`Expanding`, and :class:`ExponentialMovingWindow` ops. (:issue:`47836`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_150.performance:

--- a/pandas/core/window/common.py
+++ b/pandas/core/window/common.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 
 from collections import defaultdict
 from typing import cast
+import warnings
 
 import numpy as np
+
+from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.generic import (
     ABCDataFrame,
@@ -167,3 +170,38 @@ def prep_binary(arg1, arg2):
     X = arg1 + 0 * arg2
     Y = arg2 + 0 * arg1
     return X, Y
+
+
+def maybe_warn_args_and_kwargs(cls, kernel: str, args, kwargs) -> None:
+    """
+    Warn for deprecation of args and kwargs in rolling/expanding functions.
+
+    Parameters
+    ----------
+    cls : type
+        Class to warn about.
+    kernel : str
+        Operation name.
+    args : tuple or None
+        args passed by user. Will be None if and only if kernel does not have args.
+    kwargs : dict or None
+        kwargs passed by user. Will be None if and only if kernel does not have kwargs.
+    """
+    warn_args = args is not None and len(args) > 0
+    warn_kwargs = kwargs is not None and len(kwargs) > 0
+    if warn_args and warn_kwargs:
+        msg = "args and kwargs"
+    elif warn_args:
+        msg = "args"
+    elif warn_kwargs:
+        msg = "kwargs"
+    else:
+        msg = ""
+    if msg != "":
+        warnings.warn(
+            f"Passing additional {msg} to {cls.__name__}.{kernel} has "
+            "no impact on the result and is deprecated. This will "
+            "raise a TypeError in a future version of pandas.",
+            category=FutureWarning,
+            stacklevel=find_stack_level(),
+        )

--- a/pandas/core/window/doc.py
+++ b/pandas/core/window/doc.py
@@ -43,14 +43,18 @@ kwargs_numeric_only = dedent(
 args_compat = dedent(
     """
     *args
-        For NumPy compatibility and will not have an effect on the result.\n
+        For NumPy compatibility and will not have an effect on the result.
+
+        .. deprecated:: 1.5.0\n
     """
 ).replace("\n", "", 1)
 
 kwargs_compat = dedent(
     """
     **kwargs
-        For NumPy compatibility and will not have an effect on the result.\n
+        For NumPy compatibility and will not have an effect on the result.
+
+        .. deprecated:: 1.5.0\n
     """
 ).replace("\n", "", 1)
 

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -42,7 +42,10 @@ from pandas.core.util.numba_ import (
     get_jit_arguments,
     maybe_use_numba,
 )
-from pandas.core.window.common import zsqrt
+from pandas.core.window.common import (
+    maybe_warn_args_and_kwargs,
+    zsqrt,
+)
 from pandas.core.window.doc import (
     _shared_docs,
     args_compat,
@@ -546,6 +549,7 @@ class ExponentialMovingWindow(BaseWindow):
         engine_kwargs=None,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "mean", args, kwargs)
         if maybe_use_numba(engine):
             if self.method == "single":
                 func = generate_numba_ewm_func
@@ -603,6 +607,7 @@ class ExponentialMovingWindow(BaseWindow):
         engine_kwargs=None,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "sum", args, kwargs)
         if not self.adjust:
             raise NotImplementedError("sum is not implemented with adjust=False")
         if maybe_use_numba(engine):
@@ -658,6 +663,7 @@ class ExponentialMovingWindow(BaseWindow):
         agg_method="std",
     )
     def std(self, bias: bool = False, numeric_only: bool = False, *args, **kwargs):
+        maybe_warn_args_and_kwargs(type(self), "std", args, kwargs)
         nv.validate_window_func("std", args, kwargs)
         if (
             numeric_only
@@ -702,6 +708,7 @@ class ExponentialMovingWindow(BaseWindow):
         agg_method="var",
     )
     def var(self, bias: bool = False, numeric_only: bool = False, *args, **kwargs):
+        maybe_warn_args_and_kwargs(type(self), "var", args, kwargs)
         nv.validate_window_func("var", args, kwargs)
         window_func = window_aggregations.ewmcov
         wfunc = partial(
@@ -756,6 +763,7 @@ class ExponentialMovingWindow(BaseWindow):
     ):
         from pandas import Series
 
+        maybe_warn_args_and_kwargs(type(self), "cov", None, kwargs)
         self._validate_numeric_only("cov", numeric_only)
 
         def cov_func(x, y):
@@ -829,6 +837,7 @@ class ExponentialMovingWindow(BaseWindow):
     ):
         from pandas import Series
 
+        maybe_warn_args_and_kwargs(type(self), "corr", None, kwargs)
         self._validate_numeric_only("corr", numeric_only)
 
         def cov_func(x, y):

--- a/pandas/core/window/expanding.py
+++ b/pandas/core/window/expanding.py
@@ -565,9 +565,9 @@ class Expanding(RollingAndExpandingMixin):
         aggregation_description="standard error of mean",
         agg_method="sem",
     )
-    def sem(self, ddof: int = 1, *args, **kwargs):
+    def sem(self, ddof: int = 1, numeric_only: bool = False, *args, **kwargs):
         maybe_warn_args_and_kwargs(type(self), "sem", args, kwargs)
-        return super().sem(ddof=ddof, **kwargs)
+        return super().sem(ddof=ddof, numeric_only=numeric_only, **kwargs)
 
     @doc(
         template_header,

--- a/pandas/core/window/expanding.py
+++ b/pandas/core/window/expanding.py
@@ -25,6 +25,7 @@ from pandas.core.indexers.objects import (
     ExpandingIndexer,
     GroupbyIndexer,
 )
+from pandas.core.window.common import maybe_warn_args_and_kwargs
 from pandas.core.window.doc import (
     _shared_docs,
     args_compat,
@@ -252,6 +253,7 @@ class Expanding(RollingAndExpandingMixin):
         engine_kwargs: dict[str, bool] | None = None,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "sum", args, kwargs)
         nv.validate_expanding_func("sum", args, kwargs)
         return super().sum(
             numeric_only=numeric_only,
@@ -285,6 +287,7 @@ class Expanding(RollingAndExpandingMixin):
         engine_kwargs: dict[str, bool] | None = None,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "max", args, kwargs)
         nv.validate_expanding_func("max", args, kwargs)
         return super().max(
             numeric_only=numeric_only,
@@ -318,6 +321,7 @@ class Expanding(RollingAndExpandingMixin):
         engine_kwargs: dict[str, bool] | None = None,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "min", args, kwargs)
         nv.validate_expanding_func("min", args, kwargs)
         return super().min(
             numeric_only=numeric_only,
@@ -351,6 +355,7 @@ class Expanding(RollingAndExpandingMixin):
         engine_kwargs: dict[str, bool] | None = None,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "mean", args, kwargs)
         nv.validate_expanding_func("mean", args, kwargs)
         return super().mean(
             numeric_only=numeric_only,
@@ -382,6 +387,7 @@ class Expanding(RollingAndExpandingMixin):
         engine_kwargs: dict[str, bool] | None = None,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "median", None, kwargs)
         return super().median(
             numeric_only=numeric_only,
             engine=engine,
@@ -446,6 +452,7 @@ class Expanding(RollingAndExpandingMixin):
         engine_kwargs: dict[str, bool] | None = None,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "std", args, kwargs)
         nv.validate_expanding_func("std", args, kwargs)
         return super().std(
             ddof=ddof,
@@ -512,6 +519,7 @@ class Expanding(RollingAndExpandingMixin):
         engine_kwargs: dict[str, bool] | None = None,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "var", args, kwargs)
         nv.validate_expanding_func("var", args, kwargs)
         return super().var(
             ddof=ddof,
@@ -558,6 +566,7 @@ class Expanding(RollingAndExpandingMixin):
         agg_method="sem",
     )
     def sem(self, ddof: int = 1, *args, **kwargs):
+        maybe_warn_args_and_kwargs(type(self), "sem", args, kwargs)
         return super().sem(ddof=ddof, **kwargs)
 
     @doc(
@@ -577,6 +586,7 @@ class Expanding(RollingAndExpandingMixin):
         agg_method="skew",
     )
     def skew(self, numeric_only: bool = False, **kwargs):
+        maybe_warn_args_and_kwargs(type(self), "skew", None, kwargs)
         return super().skew(numeric_only=numeric_only, **kwargs)
 
     @doc(
@@ -618,6 +628,7 @@ class Expanding(RollingAndExpandingMixin):
         agg_method="kurt",
     )
     def kurt(self, numeric_only: bool = False, **kwargs):
+        maybe_warn_args_and_kwargs(type(self), "kurt", None, kwargs)
         return super().kurt(numeric_only=numeric_only, **kwargs)
 
     @doc(
@@ -656,6 +667,7 @@ class Expanding(RollingAndExpandingMixin):
         numeric_only: bool = False,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "quantile", None, kwargs)
         return super().quantile(
             quantile=quantile,
             interpolation=interpolation,
@@ -733,6 +745,7 @@ class Expanding(RollingAndExpandingMixin):
         numeric_only: bool = False,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "rank", None, kwargs)
         return super().rank(
             method=method,
             ascending=ascending,
@@ -779,6 +792,7 @@ class Expanding(RollingAndExpandingMixin):
         numeric_only: bool = False,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "cov", None, kwargs)
         return super().cov(
             other=other,
             pairwise=pairwise,
@@ -852,6 +866,7 @@ class Expanding(RollingAndExpandingMixin):
         numeric_only: bool = False,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "corr", None, kwargs)
         return super().corr(
             other=other,
             pairwise=pairwise,

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -79,6 +79,7 @@ from pandas.core.util.numba_ import (
 )
 from pandas.core.window.common import (
     flex_binary_moment,
+    maybe_warn_args_and_kwargs,
     zsqrt,
 )
 from pandas.core.window.doc import (
@@ -2080,6 +2081,7 @@ class Rolling(RollingAndExpandingMixin):
         engine_kwargs: dict[str, bool] | None = None,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "sum", args, kwargs)
         nv.validate_rolling_func("sum", args, kwargs)
         return super().sum(
             numeric_only=numeric_only,
@@ -2113,6 +2115,7 @@ class Rolling(RollingAndExpandingMixin):
         engine_kwargs: dict[str, bool] | None = None,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "max", args, kwargs)
         nv.validate_rolling_func("max", args, kwargs)
         return super().max(
             numeric_only=numeric_only,
@@ -2161,6 +2164,7 @@ class Rolling(RollingAndExpandingMixin):
         engine_kwargs: dict[str, bool] | None = None,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "min", args, kwargs)
         nv.validate_rolling_func("min", args, kwargs)
         return super().min(
             numeric_only=numeric_only,
@@ -2216,6 +2220,7 @@ class Rolling(RollingAndExpandingMixin):
         engine_kwargs: dict[str, bool] | None = None,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "mean", args, kwargs)
         nv.validate_rolling_func("mean", args, kwargs)
         return super().mean(
             numeric_only=numeric_only,
@@ -2262,6 +2267,7 @@ class Rolling(RollingAndExpandingMixin):
         engine_kwargs: dict[str, bool] | None = None,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "median", None, kwargs)
         return super().median(
             numeric_only=numeric_only,
             engine=engine,
@@ -2325,6 +2331,7 @@ class Rolling(RollingAndExpandingMixin):
         engine_kwargs: dict[str, bool] | None = None,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "std", args, kwargs)
         nv.validate_rolling_func("std", args, kwargs)
         return super().std(
             ddof=ddof,
@@ -2390,6 +2397,7 @@ class Rolling(RollingAndExpandingMixin):
         engine_kwargs: dict[str, bool] | None = None,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "var", args, kwargs)
         nv.validate_rolling_func("var", args, kwargs)
         return super().var(
             ddof=ddof,
@@ -2416,6 +2424,7 @@ class Rolling(RollingAndExpandingMixin):
         agg_method="skew",
     )
     def skew(self, numeric_only: bool = False, **kwargs):
+        maybe_warn_args_and_kwargs(type(self), "skew", None, kwargs)
         return super().skew(numeric_only=numeric_only, **kwargs)
 
     @doc(
@@ -2454,6 +2463,7 @@ class Rolling(RollingAndExpandingMixin):
         agg_method="sem",
     )
     def sem(self, ddof: int = 1, numeric_only: bool = False, *args, **kwargs):
+        maybe_warn_args_and_kwargs(type(self), "sem", args, kwargs)
         nv.validate_rolling_func("sem", args, kwargs)
         # Raise here so error message says sem instead of std
         self._validate_numeric_only("sem", numeric_only)
@@ -2500,6 +2510,7 @@ class Rolling(RollingAndExpandingMixin):
         agg_method="kurt",
     )
     def kurt(self, numeric_only: bool = False, **kwargs):
+        maybe_warn_args_and_kwargs(type(self), "kurt", None, kwargs)
         return super().kurt(numeric_only=numeric_only, **kwargs)
 
     @doc(
@@ -2557,6 +2568,7 @@ class Rolling(RollingAndExpandingMixin):
         numeric_only: bool = False,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "quantile", None, kwargs)
         return super().quantile(
             quantile=quantile,
             interpolation=interpolation,
@@ -2634,6 +2646,7 @@ class Rolling(RollingAndExpandingMixin):
         numeric_only: bool = False,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "rank", None, kwargs)
         return super().rank(
             method=method,
             ascending=ascending,
@@ -2680,6 +2693,7 @@ class Rolling(RollingAndExpandingMixin):
         numeric_only: bool = False,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "cov", None, kwargs)
         return super().cov(
             other=other,
             pairwise=pairwise,
@@ -2813,6 +2827,7 @@ class Rolling(RollingAndExpandingMixin):
         numeric_only: bool = False,
         **kwargs,
     ):
+        maybe_warn_args_and_kwargs(type(self), "corr", None, kwargs)
         return super().corr(
             other=other,
             pairwise=pairwise,

--- a/pandas/tests/window/test_api.py
+++ b/pandas/tests/window/test_api.py
@@ -1,7 +1,10 @@
 import numpy as np
 import pytest
 
-from pandas.errors import SpecificationError
+from pandas.errors import (
+    SpecificationError,
+    UnsupportedFunctionCall,
+)
 
 from pandas import (
     DataFrame,
@@ -409,3 +412,65 @@ def test_rolling_max_min_periods(step):
     msg = "min_periods 5 must be <= window 3"
     with pytest.raises(ValueError, match=msg):
         Series([1, 2, 3]).rolling(window=3, min_periods=5, step=step).max()
+
+
+@pytest.mark.parametrize(
+    "roll_type, class_name",
+    [
+        ("rolling", "Rolling"),
+        ("expanding", "Expanding"),
+        ("ewm", "ExponentialMovingWindow"),
+    ],
+)
+@pytest.mark.parametrize(
+    "kernel, has_args, raises",
+    [
+        ("sum", True, True),
+        ("max", True, True),
+        ("min", True, True),
+        ("mean", True, True),
+        ("median", False, False),
+        ("std", True, True),
+        ("var", True, True),
+        ("skew", False, False),
+        ("sem", True, True),
+        ("kurt", False, False),
+        ("quantile", False, False),
+        ("rank", False, False),
+        ("cov", False, False),
+        ("corr", False, False),
+    ],
+)
+def test_args_kwargs_depr(roll_type, class_name, kernel, has_args, raises):
+    r = getattr(Series([2, 4, 6]), roll_type)(2)
+    error_msg = "numpy operations are not valid with window objects"
+    if kernel == "quantile":
+        required_args = (0.5,)
+    else:
+        required_args = ()
+
+    warn_msg = f"Passing additional kwargs to {class_name}.{kernel}"
+    with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+        if raises:
+            with pytest.raises(UnsupportedFunctionCall, match=error_msg):
+                getattr(r, kernel)(*required_args, dtype=np.float64)
+        else:
+            getattr(r, kernel)(*required_args, dtype=np.float64)
+
+    if has_args:
+        warn_msg = f"Passing additional args to {class_name}.{kernel}"
+        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+            # sem raises for rolling but not expanding
+            if raises and (roll_type != "expanding" or kernel != "sem"):
+                with pytest.raises(UnsupportedFunctionCall, match=error_msg):
+                    getattr(r, kernel)(*required_args, 1, 2, 3, 4)
+            else:
+                getattr(r, kernel)(*required_args, 1, 2, 3, 4)
+
+        warn_msg = f"Passing additional args and kwargs to {class_name}.{kernel}"
+        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+            if raises:
+                with pytest.raises(UnsupportedFunctionCall, match=error_msg):
+                    getattr(r, kernel)(*required_args, 1, 2, 3, 4, dtype=np.float64)
+            else:
+                getattr(r, kernel)(*required_args, 1, 2, 3, 4, dtype=np.float64)

--- a/pandas/tests/window/test_api.py
+++ b/pandas/tests/window/test_api.py
@@ -450,28 +450,40 @@ def test_args_kwargs_depr(roll_type, class_name, kernel, has_args, raises):
     else:
         required_args = ()
 
-    warn_msg = f"Passing additional kwargs to {class_name}.{kernel}"
-    with tm.assert_produces_warning(FutureWarning, match=warn_msg):
-        if raises:
-            with pytest.raises(UnsupportedFunctionCall, match=error_msg):
-                getattr(r, kernel)(*required_args, dtype=np.float64)
-        else:
-            getattr(r, kernel)(*required_args, dtype=np.float64)
-
-    if has_args:
-        warn_msg = f"Passing additional args to {class_name}.{kernel}"
-        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
-            # sem raises for rolling but not expanding
-            if raises and (roll_type != "expanding" or kernel != "sem"):
-                with pytest.raises(UnsupportedFunctionCall, match=error_msg):
-                    getattr(r, kernel)(*required_args, 1, 2, 3, 4)
-            else:
-                getattr(r, kernel)(*required_args, 1, 2, 3, 4)
-
-        warn_msg = f"Passing additional args and kwargs to {class_name}.{kernel}"
+    if roll_type == "ewm" and kernel not in (
+        "sum",
+        "mean",
+        "std",
+        "var",
+        "cov",
+        "corr",
+    ):
+        # kernels not implemented for ewm
+        with pytest.raises(AttributeError, match=f"has no attribute '{kernel}'"):
+            getattr(r, kernel)
+    else:
+        warn_msg = f"Passing additional kwargs to {class_name}.{kernel}"
         with tm.assert_produces_warning(FutureWarning, match=warn_msg):
             if raises:
                 with pytest.raises(UnsupportedFunctionCall, match=error_msg):
-                    getattr(r, kernel)(*required_args, 1, 2, 3, 4, dtype=np.float64)
+                    getattr(r, kernel)(*required_args, dtype=np.float64)
             else:
-                getattr(r, kernel)(*required_args, 1, 2, 3, 4, dtype=np.float64)
+                getattr(r, kernel)(*required_args, dtype=np.float64)
+
+        if has_args:
+            warn_msg = f"Passing additional args to {class_name}.{kernel}"
+            with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+                # sem raises for rolling but not expanding
+                if raises and (roll_type != "expanding" or kernel != "sem"):
+                    with pytest.raises(UnsupportedFunctionCall, match=error_msg):
+                        getattr(r, kernel)(*required_args, 1, 2, 3, 4)
+                else:
+                    getattr(r, kernel)(*required_args, 1, 2, 3, 4)
+
+            warn_msg = f"Passing additional args and kwargs to {class_name}.{kernel}"
+            with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+                if raises:
+                    with pytest.raises(UnsupportedFunctionCall, match=error_msg):
+                        getattr(r, kernel)(*required_args, 1, 2, 3, 4, dtype=np.float64)
+                else:
+                    getattr(r, kernel)(*required_args, 1, 2, 3, 4, dtype=np.float64)

--- a/pandas/tests/window/test_api.py
+++ b/pandas/tests/window/test_api.py
@@ -442,6 +442,7 @@ def test_rolling_max_min_periods(step):
     ],
 )
 def test_args_kwargs_depr(roll_type, class_name, kernel, has_args, raises):
+    # GH#47836
     r = getattr(Series([2, 4, 6]), roll_type)(2)
     error_msg = "numpy operations are not valid with window objects"
     if kernel == "quantile":

--- a/pandas/tests/window/test_ewm.py
+++ b/pandas/tests/window/test_ewm.py
@@ -69,12 +69,16 @@ def test_numpy_compat(method):
     # see gh-12811
     e = ExponentialMovingWindow(Series([2, 4, 6]), alpha=0.5)
 
-    msg = "numpy operations are not valid with window objects"
+    error_msg = "numpy operations are not valid with window objects"
 
-    with pytest.raises(UnsupportedFunctionCall, match=msg):
-        getattr(e, method)(1, 2, 3)
-    with pytest.raises(UnsupportedFunctionCall, match=msg):
-        getattr(e, method)(dtype=np.float64)
+    warn_msg = f"Passing additional args to ExponentialMovingWindow.{method}"
+    with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+        with pytest.raises(UnsupportedFunctionCall, match=error_msg):
+            getattr(e, method)(1, 2, 3)
+    warn_msg = f"Passing additional kwargs to ExponentialMovingWindow.{method}"
+    with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+        with pytest.raises(UnsupportedFunctionCall, match=error_msg):
+            getattr(e, method)(dtype=np.float64)
 
 
 def test_ewma_times_not_datetime_type():

--- a/pandas/tests/window/test_expanding.py
+++ b/pandas/tests/window/test_expanding.py
@@ -59,12 +59,16 @@ def test_numpy_compat(method):
     # see gh-12811
     e = Expanding(Series([2, 4, 6]))
 
-    msg = "numpy operations are not valid with window objects"
+    error_msg = "numpy operations are not valid with window objects"
 
-    with pytest.raises(UnsupportedFunctionCall, match=msg):
-        getattr(e, method)(1, 2, 3)
-    with pytest.raises(UnsupportedFunctionCall, match=msg):
-        getattr(e, method)(dtype=np.float64)
+    warn_msg = f"Passing additional args to Expanding.{method}"
+    with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+        with pytest.raises(UnsupportedFunctionCall, match=error_msg):
+            getattr(e, method)(1, 2, 3)
+    warn_msg = f"Passing additional kwargs to Expanding.{method}"
+    with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+        with pytest.raises(UnsupportedFunctionCall, match=error_msg):
+            getattr(e, method)(dtype=np.float64)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -158,12 +158,16 @@ def test_numpy_compat(method):
     # see gh-12811
     r = Rolling(Series([2, 4, 6]), window=2)
 
-    msg = "numpy operations are not valid with window objects"
+    error_msg = "numpy operations are not valid with window objects"
 
-    with pytest.raises(UnsupportedFunctionCall, match=msg):
-        getattr(r, method)(1, 2, 3)
-    with pytest.raises(UnsupportedFunctionCall, match=msg):
-        getattr(r, method)(dtype=np.float64)
+    warn_msg = f"Passing additional args to Rolling.{method}"
+    with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+        with pytest.raises(UnsupportedFunctionCall, match=error_msg):
+            getattr(r, method)(1, 2, 3)
+    warn_msg = f"Passing additional kwargs to Rolling.{method}"
+    with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+        with pytest.raises(UnsupportedFunctionCall, match=error_msg):
+            getattr(r, method)(dtype=np.float64)
 
 
 @pytest.mark.parametrize("closed", ["right", "left", "both", "neither"])

--- a/pandas/tests/window/test_win_type.py
+++ b/pandas/tests/window/test_win_type.py
@@ -79,12 +79,16 @@ def test_numpy_compat(method):
     # see gh-12811
     w = Series([2, 4, 6]).rolling(window=2)
 
-    msg = "numpy operations are not valid with window objects"
+    error_msg = "numpy operations are not valid with window objects"
 
-    with pytest.raises(UnsupportedFunctionCall, match=msg):
-        getattr(w, method)(1, 2, 3)
-    with pytest.raises(UnsupportedFunctionCall, match=msg):
-        getattr(w, method)(dtype=np.float64)
+    warn_msg = f"Passing additional args to Rolling.{method}"
+    with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+        with pytest.raises(UnsupportedFunctionCall, match=error_msg):
+            getattr(w, method)(1, 2, 3)
+    warn_msg = f"Passing additional kwargs to Rolling.{method}"
+    with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+        with pytest.raises(UnsupportedFunctionCall, match=error_msg):
+            getattr(w, method)(dtype=np.float64)
 
 
 @td.skip_if_no_scipy


### PR DESCRIPTION
- [x] closes #47836 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

We can't call `maybe_warn_args_and_kwargs` any further in the stack (e.g. in `_apply`) because args aren't passed along.