### PR TITLE
ENH: `Styler.relabel_index` for directly specifying display of index labels

### DIFF
--- a/doc/source/reference/style.rst
+++ b/doc/source/reference/style.rst
@@ -41,6 +41,7 @@ Style application
    Styler.applymap_index
    Styler.format
    Styler.format_index
+   Styler.relabel_index
    Styler.hide
    Styler.concat
    Styler.set_td_classes

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -45,7 +45,7 @@ Additionally there is an alternative output method :meth:`.Styler.to_string`,
 which allows using the Styler's formatting methods to create, for example, CSVs (:issue:`44502`).
 
 A new feature :meth:`.Styler.relabel_index` is also made available to provide full customisation of the display of
-index or column headers (:issue:`XXXXX`)
+index or column headers (:issue:`47864`)
 
 Minor feature improvements are:
 

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -44,6 +44,9 @@ e.g. totals and counts etc. (:issue:`43875`, :issue:`46186`)
 Additionally there is an alternative output method :meth:`.Styler.to_string`,
 which allows using the Styler's formatting methods to create, for example, CSVs (:issue:`44502`).
 
+A new feature :meth:`.Styler.relabel_index` is also made available to provide full customisation of the display of
+index or column headers (:issue:`XXXXX`)
+
 Minor feature improvements are:
 
   - Adding the ability to render ``border`` and ``border-{side}`` CSS properties in Excel (:issue:`42276`)

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -1395,11 +1395,10 @@ class StylerRenderer:
 
         .. code-block:: python
 
+            # relabel first, then hide
             df = pd.DataFrame({"col": ["a", "b", "c"]})
             df.style.relabel_index(["A", "B", "C"]).hide([0,1])
-
-         .. code-block:: python
-
+            # hide first, then relabel
             df = pd.DataFrame({"col": ["a", "b", "c"]})
             df.style.hide([0,1]).relabel_index(["C"])
 

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -1480,7 +1480,6 @@ class StylerRenderer:
             display_funcs_, obj = self._display_funcs_columns, self.columns
             hidden_labels, hidden_lvls = self.hidden_columns, self.hide_columns_
         visible_len = len(obj) - len(set(hidden_labels))
-        # visible_lvls = obj.nlevels - sum(hidden_lvls)
         if len(labels) != visible_len:
             raise ValueError(
                 "``labels`` must be of length equal to the number of "

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -1442,8 +1442,9 @@ class StylerRenderer:
            1  0     6
               1     7
         >>> styler.hide((midx.get_level_values(0)==0)|(midx.get_level_values(1)==0))
-        >>> styler.hide(level=[0,1])
-        >>> styler.relabel_index(["binary6", "binary7"])
+        ...  # doctest: +SKIP
+        >>> styler.hide(level=[0,1])  # doctest: +SKIP
+        >>> styler.relabel_index(["binary6", "binary7"])  # doctest: +SKIP
                   col
         binary6     6
         binary7     7
@@ -1452,6 +1453,7 @@ class StylerRenderer:
 
         >>> styler = df.loc[[(1,1,0), (1,1,1)]].style
         >>> styler.hide(level=[0,1]).relabel_index(["binary6", "binary7"])
+        ...  # doctest: +SKIP
                   col
         binary6     6
         binary7     7
@@ -1464,6 +1466,7 @@ class StylerRenderer:
         >>> df = pd.DataFrame({"samples": np.random.rand(10)})
         >>> styler = df.loc[np.random.randint(0,10,3)].style
         >>> styler.relabel_index([f"sample{i+1} ({{}})" for i in range(3)])
+        ...  # doctest: +SKIP
                          samples
         sample1 (5)     0.315811
         sample2 (0)     0.495941


### PR DESCRIPTION

<img width="645" alt="Screenshot 2022-07-26 at 18 10 00" src="https://user-images.githubusercontent.com/24256554/181057085-676c1987-25f7-44b4-9f63-5f7479354e5e.png">
<img width="627" alt="Screenshot 2022-07-26 at 18 10 13" src="https://user-images.githubusercontent.com/24256554/181057115-a143111d-b51d-472b-93f7-5113f74a77d5.png">
<img width="616" alt="Screenshot 2022-07-26 at 18 10 23" src="https://user-images.githubusercontent.com/24256554/181057131-d531de9e-947d-4d66-9060-105de858c498.png">

