### PR TITLE
DOC: Adds Hamilton as a development tool

### DIFF
--- a/web/pandas/community/ecosystem.md
+++ b/web/pandas/community/ecosystem.md
@@ -400,3 +400,20 @@ Learn more by reading through these issues [14468](https://github.com/pandas-dev
 [26766](https://github.com/pandas-dev/pandas/issues/26766), [28142](https://github.com/pandas-dev/pandas/issues/28142).
 
 See installation and usage instructions on the [github page](https://github.com/VirtusLab/pandas-stubs).
+
+### [Hamilton](https://github.com/stitchfix/hamilton)
+
+Hamilton is a declarative dataflow framework that came out of Stitch Fix. It was designed to help one manage a
+Pandas code base, specifically with respect to feature engineering for machine learning models.
+
+It prescibes an opinionated paradigm, that ensures all code is:
+
+* unit testable
+* integration testing friendly
+* documentation friendly
+* transformation logic is reuseable, as it is decoupled from the context of where it is used.
+* integrateable with runtime data quality checks.
+
+This helps one to scale your pandas code base, at the same time, keeping maintenance costs low.
+
+For more information, see [documentation](https://hamilton-docs.gitbook.io/).


### PR DESCRIPTION
Hamilton is a paradigm that helps one manage a pandas code base in an opinionated manner.

We have had great success with it at Stitch Fix, and it's got a growing open source
following. I think it helps one to write pandas in a way that gives
confidence if you want to run Pandas in production jobs.

- [x] N/A: closes #xxxx (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
