### PR TITLE
BUG: fix Dataframe.join with categorical index leads to unexpected reordering

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -1024,6 +1024,7 @@ Reshaping
 - Bug in :meth:`DataFrame.pivot_table` with ``sort=False`` results in sorted index (:issue:`17041`)
 - Bug in :meth:`concat` when ``axis=1`` and ``sort=False`` where the resulting Index was a :class:`Int64Index` instead of a :class:`RangeIndex` (:issue:`46675`)
 - Bug in :meth:`wide_to_long` raises when ``stubnames`` is missing in columns and ``i`` contains string dtype column (:issue:`46044`)
+- Bug in :meth:`DataFrame.join` with categorical index results in unexpected reordering (:issue:`47812`)
 
 Sparse
 ^^^^^^

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4682,6 +4682,7 @@ class Index(IndexOpsMixin, PandasObject):
                 not isinstance(self, ABCMultiIndex)
                 or not any(is_categorical_dtype(dtype) for dtype in self.dtypes)
             )
+            and not is_categorical_dtype(self.dtype)
         ):
             # Categorical is monotonic if data are ordered as categories, but join can
             #  not handle this in case of not lexicographically monotonic GH#38502

--- a/pandas/tests/reshape/merge/test_join.py
+++ b/pandas/tests/reshape/merge/test_join.py
@@ -723,7 +723,7 @@ class TestJoin:
         result = df1.join(df2)
         expected = DataFrame(
             {"c1": ["a", "b"], "c2": ["a", "b"]},
-            index=pd.CategoricalIndex(["a", "b"], categories=["a", "b"])
+            index=pd.CategoricalIndex(["a", "b"], categories=["a", "b"]),
         )
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/reshape/merge/test_join.py
+++ b/pandas/tests/reshape/merge/test_join.py
@@ -712,6 +712,21 @@ class TestJoin:
         )
         tm.assert_frame_equal(result, expected)
 
+    def test_join_with_categorical_index(self):
+        # GH47812
+        ix = ["a", "b"]
+        id1 = pd.CategoricalIndex(ix, categories=ix)
+        id2 = pd.CategoricalIndex(reversed(ix), categories=reversed(ix))
+
+        df1 = DataFrame({"c1": ix}, index=id1)
+        df2 = DataFrame({"c2": reversed(ix)}, index=id2)
+        result = df1.join(df2)
+        expected = DataFrame(
+            {"c1": ["a", "b"], "c2": ["a", "b"]},
+            index=pd.CategoricalIndex(["a", "b"], categories=["a", "b"])
+        )
+        tm.assert_frame_equal(result, expected)
+
 
 def _check_join(left, right, result, join_col, how="left", lsuffix="_x", rsuffix="_y"):
 


### PR DESCRIPTION
- [ ] closes #47812(Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
