### PR TITLE
Revert "CI: Pin cython on 32bit build"

### DIFF
--- a/.github/workflows/32-bit-linux.yml
+++ b/.github/workflows/32-bit-linux.yml
@@ -38,7 +38,7 @@ jobs:
           /opt/python/cp38-cp38/bin/python -m venv ~/virtualenvs/pandas-dev && \
           . ~/virtualenvs/pandas-dev/bin/activate && \
           python -m pip install --no-deps -U pip wheel 'setuptools<60.0.0' && \
-          pip install cython==0.29.30 numpy python-dateutil pytz pytest pytest-xdist pytest-asyncio>=0.17 hypothesis && \
+          pip install cython numpy python-dateutil pytz pytest pytest-xdist pytest-asyncio>=0.17 hypothesis && \
           python setup.py build_ext -q -j2 && \
           python -m pip install --no-build-isolation --no-use-pep517 -e . && \
           export PANDAS_CI=1 && \

--- a/ci/deps/actions-310-numpydev.yaml
+++ b/ci/deps/actions-310-numpydev.yaml
@@ -16,8 +16,7 @@ dependencies:
   - pytz
   - pip
   - pip:
-    #- cython # TODO: don't install from master after Cython 3.0.0a11 is released
-    - "git+https://github.com/cython/cython.git@master"
+    - "cython"
     - "--extra-index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple"
     - "--pre"
     - "numpy"

--- a/ci/deps/actions-310.yaml
+++ b/ci/deps/actions-310.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.10
 
   # test dependencies
-  - cython=0.29.30
+  - cython>=0.29.30
   - pytest>=6.0
   - pytest-cov
   - pytest-xdist>=1.31

--- a/ci/deps/actions-38-downstream_compat.yaml
+++ b/ci/deps/actions-38-downstream_compat.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.8
 
   # test dependencies
-  - cython=0.29.30
+  - cython>=0.29.30
   - pytest>=6.0
   - pytest-cov
   - pytest-xdist>=1.31

--- a/ci/deps/actions-38-minimum_versions.yaml
+++ b/ci/deps/actions-38-minimum_versions.yaml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.8.0
 
   # test dependencies
-  - cython=0.29.30
+  - cython>=0.29.30
   - pytest>=6.0
   - pytest-cov
   - pytest-xdist>=1.31

--- a/ci/deps/actions-38.yaml
+++ b/ci/deps/actions-38.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.8
 
   # test dependencies
-  - cython=0.29.30
+  - cython>=0.29.30
   - pytest>=6.0
   - pytest-cov
   - pytest-xdist>=1.31

--- a/ci/deps/actions-39.yaml
+++ b/ci/deps/actions-39.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.9
 
   # test dependencies
-  - cython=0.29.30
+  - cython>=0.29.30
   - pytest>=6.0
   - pytest-cov
   - pytest-xdist>=1.31

--- a/ci/deps/circle-38-arm64.yaml
+++ b/ci/deps/circle-38-arm64.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.8
 
   # test dependencies
-  - cython=0.29.30
+  - cython>=0.29.30
   - pytest>=6.0
   - pytest-cov
   - pytest-xdist>=1.31


### PR DESCRIPTION
Reverts pandas-dev/pandas#47889

Let's see if cython 0.29.32 fixes this