### PR TITLE
TST: Allow “no setter” messages from Python 3.11

### DIFF
--- a/pandas/tests/arrays/categorical/test_api.py
+++ b/pandas/tests/arrays/categorical/test_api.py
@@ -53,7 +53,7 @@ class TestCategoricalAPI:
         assert not cat2.ordered
 
         # removed in 0.19.0
-        msg = "can't set attribute"
+        msg = "can't set attribute|property .* of .* object has no setter"
         with pytest.raises(AttributeError, match=msg):
             cat.ordered = True
         with pytest.raises(AttributeError, match=msg):
@@ -507,7 +507,8 @@ class TestPrivateCategoricalAPI:
         tm.assert_numpy_array_equal(c.codes, exp)
 
         # Assignments to codes should raise
-        with pytest.raises(AttributeError, match="can't set attribute"):
+        msg = "can't set attribute|property .* of .* object has no setter"
+        with pytest.raises(AttributeError, match=msg):
             c.codes = np.array([0, 1, 2, 0, 1], dtype="int8")
 
         # changes in the codes array should raise

--- a/pandas/tests/indexes/multi/test_get_set.py
+++ b/pandas/tests/indexes/multi/test_get_set.py
@@ -139,7 +139,7 @@ def test_set_levels_codes_directly(idx):
     minor_codes = [(x + 1) % 1 for x in minor_codes]
     new_codes = [major_codes, minor_codes]
 
-    msg = "[Cc]an't set attribute"
+    msg = "[Cc]an't set attribute|property .* of .* object has no setter"
     with pytest.raises(AttributeError, match=msg):
         idx.levels = new_levels
     with pytest.raises(AttributeError, match=msg):

--- a/pandas/tests/indexes/period/test_freq_attr.py
+++ b/pandas/tests/indexes/period/test_freq_attr.py
@@ -17,5 +17,6 @@ class TestFreq:
             idx.freq
 
         # warning for setter
-        with pytest.raises(AttributeError, match="can't set attribute"):
+        msg = "can't set attribute|property .* of .* object has no setter"
+        with pytest.raises(AttributeError, match=msg):
             idx.freq = offsets.Day()


### PR DESCRIPTION
Loosen “`can't set attribute`” expected messages to also allow messages of the form “`property … of … object has no setter`”, fixing several assertion failures in the tests on Python 3.11.

- [ ] closes #xxxx (Replace xxxx with the Github issue number) **This is a partial fix for https://github.com/pandas-dev/pandas/issues/46680, but does not close it.**
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature **This PR fixes tests.**
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. **N/A**
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature. **N/A, only a partial bug fix**