### PR TITLE
Update config.yml to add Donate page to the nav bar

### DIFF
--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -51,6 +51,8 @@ navbar:
       target: /community/ecosystem.html
   - name: "Contribute"
     target: /contribute.html
+  - name: "Donate"
+    taget: /donate.html
 blog:
   num_posts: 50
   posts_path: community/blog


### PR DESCRIPTION
It would also be really great to enable GitHub sponsors specifically for the Pandas Org since people might want to sponsor the org directly on GitHub (dev's / org's want to highlight their sponsorship publicly so GitHub sponsors is a great way to do so).
