### PR TITLE
Fix out-of-bounds heap access in internals.pyx.

### DIFF
--- a/pandas/_libs/internals.pyx
+++ b/pandas/_libs/internals.pyx
@@ -469,12 +469,14 @@ def get_blkno_indexers(
 
     n = blknos.shape[0]
     result = list()
+
+    if n == 0:
+        return result
+
     start = 0
     cur_blkno = blknos[start]
 
-    if n == 0:
-        pass
-    elif group is False:
+    if group is False:
         for i in range(1, n):
             if blknos[i] != cur_blkno:
                 result.append((cur_blkno, slice(start, i)))


### PR DESCRIPTION
If blknos is empty, we unconditionally access blknos[start] where start
is 0. This is an out-of-bounds heap access that can be caught by
AddressSanitizer, but it's easy to avoid since
we are going to ignore the result anyway.

No new tests, because this does not change any observable behaviors.