### PR TITLE
DEBUG: Debug failing macpython wheels

### DIFF
--- a/ci/deps/actions-39.yaml
+++ b/ci/deps/actions-39.yaml
@@ -26,7 +26,6 @@ dependencies:
   - fastparquet
   - fsspec
   - html5lib
-  - hypothesis=6.52.3
   - gcsfs
   - jinja2
   - lxml
@@ -52,3 +51,5 @@ dependencies:
   - xlsxwriter
   - xlwt
   - zstandard
+  - pip:
+    - hypothesis==6.52.3

--- a/ci/deps/actions-39.yaml
+++ b/ci/deps/actions-39.yaml
@@ -26,7 +26,7 @@ dependencies:
   - fastparquet
   - fsspec
   - html5lib
-  - hypothesis
+  - hypothesis=6.52.3
   - gcsfs
   - jinja2
   - lxml


### PR DESCRIPTION
might be because of a change in hypothesis
