### PR TITLE
BUG: read_csv with engine pyarrow doesn't handle missing values

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -966,6 +966,7 @@ I/O
 - Bug in :func:`read_sas` with RLE-compressed SAS7BDAT files that contain 0x00 control bytes (:issue:`47099`)
 - Bug in :func:`read_parquet` with ``use_nullable_dtypes=True`` where ``float64`` dtype was returned instead of nullable ``Float64`` dtype (:issue:`45694`)
 - Bug in :meth:`DataFrame.to_json` where ``PeriodDtype`` would not make the serialization roundtrip when read back with :meth:`read_json` (:issue:`44720`)
+- Bug in :func:`read_csv` when ``engine=="pyarrow"`` where missing dates were not being parsed as ``NaT`` (:issue:`47950`)
 
 Period
 ^^^^^^

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -1776,6 +1776,26 @@ def test_missing_parse_dates_column_raises(
         )
 
 
+def test_parse_missing_values(all_parsers):
+    # https://github.com/pandas-dev/pandas/issues/47950
+    parser = all_parsers
+    content = StringIO("""A,B\n2,2000-01-01\n,""")
+    result = parser.read_csv(content, parse_dates=["B"], usecols=["B"])
+    expected = DataFrame({"B": {0: Timestamp("2000-01-01 00:00:00"), 1: pd.NaT}})
+    tm.assert_frame_equal(result, expected)
+
+
+def test_concat_dates_with_missing_values():
+    # https://github.com/pandas-dev/pandas/issues/47950
+    # TODO: add test which gets here from read_csv, once
+    # https://github.com/pandas-dev/pandas/issues/47961 is addressed
+    dates = np.array(["3/31/2019", None], dtype=object)
+    times = np.array(["11:20", "10:45"], dtype=object)
+    result = pd._libs.tslibs.parsing.concat_date_cols((dates, times))
+    expected = np.array(["3/31/2019 11:20", None], dtype=object)
+    tm.assert_numpy_array_equal(result, expected)
+
+
 @skip_pyarrow
 def test_date_parser_and_names(all_parsers):
     # GH#33699


### PR DESCRIPTION
- [x] closes #47950 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
