### PR TITLE
TYP: move imports inside TYPE_CHECKING

### DIFF
--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -77,7 +77,6 @@ from pandas.core.dtypes.missing import isna
 
 import pandas.core.algorithms as algos
 from pandas.core.arrays import datetimelike as dtl
-from pandas.core.arrays.base import ExtensionArray
 import pandas.core.common as com
 
 if TYPE_CHECKING:
@@ -91,6 +90,8 @@ if TYPE_CHECKING:
         DatetimeArray,
         TimedeltaArray,
     )
+    from pandas.core.arrays.base import ExtensionArray
+
 
 BaseOffsetT = TypeVar("BaseOffsetT", bound=BaseOffset)
 

--- a/pandas/core/computation/engines.py
+++ b/pandas/core/computation/engines.py
@@ -4,6 +4,7 @@ Engine classes for :func:`~pandas.eval`
 from __future__ import annotations
 
 import abc
+from typing import TYPE_CHECKING
 
 from pandas.errors import NumExprClobberingError
 
@@ -11,13 +12,15 @@ from pandas.core.computation.align import (
     align_terms,
     reconstruct_object,
 )
-from pandas.core.computation.expr import Expr
 from pandas.core.computation.ops import (
     MATHOPS,
     REDUCTIONS,
 )
 
 import pandas.io.formats.printing as printing
+
+if TYPE_CHECKING:
+    from pandas.core.computation.expr import Expr
 
 _ne_builtins = frozenset(MATHOPS + REDUCTIONS)
 

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -4,6 +4,7 @@ Top level ``eval`` module.
 from __future__ import annotations
 
 import tokenize
+from typing import TYPE_CHECKING
 import warnings
 
 from pandas._libs.lib import no_default
@@ -15,11 +16,13 @@ from pandas.core.computation.expr import (
     PARSERS,
     Expr,
 )
-from pandas.core.computation.ops import BinOp
 from pandas.core.computation.parsing import tokenize_string
 from pandas.core.computation.scope import ensure_scope
 
 from pandas.io.formats.printing import pprint_thing
+
+if TYPE_CHECKING:
+    from pandas.core.computation.ops import BinOp
 
 
 def _check_engine(engine: str | None) -> str:

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 import ast
 from functools import partial
-from typing import Any
+from typing import (
+    TYPE_CHECKING,
+    Any,
+)
 
 import numpy as np
 
@@ -12,7 +15,6 @@ from pandas._libs.tslibs import (
     Timestamp,
 )
 from pandas._typing import npt
-from pandas.compat.chainmap import DeepChainMap
 from pandas.errors import UndefinedVariableError
 
 from pandas.core.dtypes.common import is_list_like
@@ -33,6 +35,9 @@ from pandas.io.formats.printing import (
     pprint_thing,
     pprint_thing_encoded,
 )
+
+if TYPE_CHECKING:
+    from pandas.compat.chainmap import DeepChainMap
 
 
 class PyTablesScope(_scope.Scope):

--- a/pandas/core/groupby/categorical.py
+++ b/pandas/core/groupby/categorical.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 from pandas.core.algorithms import unique1d
@@ -8,7 +10,9 @@ from pandas.core.arrays.categorical import (
     CategoricalDtype,
     recode_for_categories,
 )
-from pandas.core.indexes.api import CategoricalIndex
+
+if TYPE_CHECKING:
+    from pandas.core.indexes.api import CategoricalIndex
 
 
 def recode_for_groupby(

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -11,6 +11,7 @@ from collections import abc
 from functools import partial
 from textwrap import dedent
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Hashable,
@@ -72,7 +73,6 @@ from pandas.core.apply import (
 import pandas.core.common as com
 from pandas.core.construction import create_series_with_explicit_dtype
 from pandas.core.frame import DataFrame
-from pandas.core.generic import NDFrame
 from pandas.core.groupby import base
 from pandas.core.groupby.groupby import (
     GroupBy,
@@ -92,6 +92,9 @@ from pandas.core.shared_docs import _shared_docs
 from pandas.core.util.numba_ import maybe_use_numba
 
 from pandas.plotting import boxplot_frame_groupby
+
+if TYPE_CHECKING:
+    from pandas.core.generic import NDFrame
 
 # TODO(typing) the return value on this callable should be any *scalar*.
 AggScalar = Union[str, Callable[..., Any]]

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import collections
 import functools
 from typing import (
+    TYPE_CHECKING,
     Callable,
     Generic,
     Hashable,
@@ -77,7 +78,6 @@ from pandas.core.arrays.masked import (
 )
 from pandas.core.arrays.string_ import StringDtype
 from pandas.core.frame import DataFrame
-from pandas.core.generic import NDFrame
 from pandas.core.groupby import grouper
 from pandas.core.indexes.api import (
     CategoricalIndex,
@@ -94,6 +94,9 @@ from pandas.core.sorting import (
     get_group_index_sorter,
     get_indexer_dict,
 )
+
+if TYPE_CHECKING:
+    from pandas.core.generic import NDFrame
 
 
 class WrappedCythonOp:

--- a/pandas/core/indexes/extension.py
+++ b/pandas/core/indexes/extension.py
@@ -4,6 +4,7 @@ Shared methods for Index subclasses backed by ExtensionArray.
 from __future__ import annotations
 
 from typing import (
+    TYPE_CHECKING,
     Callable,
     TypeVar,
 )
@@ -21,9 +22,11 @@ from pandas.util._decorators import (
 
 from pandas.core.dtypes.generic import ABCDataFrame
 
-from pandas.core.arrays import IntervalArray
-from pandas.core.arrays._mixins import NDArrayBackedExtensionArray
 from pandas.core.indexes.base import Index
+
+if TYPE_CHECKING:
+    from pandas.core.arrays import IntervalArray
+    from pandas.core.arrays._mixins import NDArrayBackedExtensionArray
 
 _T = TypeVar("_T", bound="NDArrayBackedExtensionIndex")
 _ExtensionIndexT = TypeVar("_ExtensionIndexT", bound="ExtensionIndex")

--- a/pandas/core/interchange/dataframe.py
+++ b/pandas/core/interchange/dataframe.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from collections import abc
 from typing import TYPE_CHECKING
 
-import pandas as pd
 from pandas.core.interchange.column import PandasColumn
 from pandas.core.interchange.dataframe_protocol import DataFrame as DataFrameXchg
 
 if TYPE_CHECKING:
+    import pandas as pd
     from pandas import Index
 
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -98,7 +98,6 @@ from pandas.core.arrays import (
     PeriodArray,
     TimedeltaArray,
 )
-from pandas.core.arrays._mixins import NDArrayBackedExtensionArray
 from pandas.core.arrays.sparse import SparseDtype
 from pandas.core.base import PandasObject
 import pandas.core.common as com
@@ -115,6 +114,7 @@ if TYPE_CHECKING:
         Float64Index,
         Index,
     )
+    from pandas.core.arrays._mixins import NDArrayBackedExtensionArray
 
 # comparison is faster than is_object_dtype
 _dtype_obj = np.dtype("object")

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -68,7 +68,6 @@ from pandas.core.groupby.groupby import (
 )
 from pandas.core.groupby.grouper import Grouper
 from pandas.core.groupby.ops import BinGrouper
-from pandas.core.indexes.api import Index
 from pandas.core.indexes.datetimes import (
     DatetimeIndex,
     date_range,
@@ -96,6 +95,7 @@ from pandas.tseries.offsets import (
 if TYPE_CHECKING:
     from pandas import (
         DataFrame,
+        Index,
         Series,
     )
 

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -73,7 +73,6 @@ from pandas import (
     MultiIndex,
     Series,
 )
-from pandas.core import groupby
 import pandas.core.algorithms as algos
 from pandas.core.arrays import ExtensionArray
 from pandas.core.arrays._mixins import NDArrayBackedExtensionArray
@@ -85,6 +84,7 @@ from pandas.core.sorting import is_int64_overflow_possible
 
 if TYPE_CHECKING:
     from pandas import DataFrame
+    from pandas.core import groupby
     from pandas.core.arrays import DatetimeArray
 
 

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -30,7 +30,6 @@ from pandas.core.indexes.api import (
     Index,
     MultiIndex,
 )
-from pandas.core.indexes.frozen import FrozenList
 from pandas.core.series import Series
 from pandas.core.sorting import (
     compress_group_index,
@@ -42,6 +41,7 @@ from pandas.core.sorting import (
 
 if TYPE_CHECKING:
     from pandas.core.arrays import ExtensionArray
+    from pandas.core.indexes.frozen import FrozenList
 
 
 class _Unstacker:

--- a/pandas/io/excel/_odswriter.py
+++ b/pandas/io/excel/_odswriter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 import datetime
 from typing import (
+    TYPE_CHECKING,
     Any,
     DefaultDict,
     Tuple,
@@ -21,7 +22,9 @@ from pandas.io.excel._util import (
     combine_kwargs,
     validate_freeze_panes,
 )
-from pandas.io.formats.excel import ExcelCell
+
+if TYPE_CHECKING:
+    from pandas.io.formats.excel import ExcelCell
 
 
 class ODSWriter(ExcelWriter):

--- a/pandas/io/formats/info.py
+++ b/pandas/io/formats/info.py
@@ -21,14 +21,13 @@ from pandas._typing import (
     WriteBuffer,
 )
 
-from pandas.core.indexes.api import Index
-
 from pandas.io.formats import format as fmt
 from pandas.io.formats.printing import pprint_thing
 
 if TYPE_CHECKING:
-    from pandas.core.frame import (
+    from pandas import (
         DataFrame,
+        Index,
         Series,
     )
 

--- a/pandas/io/formats/latex.py
+++ b/pandas/io/formats/latex.py
@@ -8,6 +8,7 @@ from abc import (
     abstractmethod,
 )
 from typing import (
+    TYPE_CHECKING,
     Iterator,
     Sequence,
 )
@@ -16,7 +17,8 @@ import numpy as np
 
 from pandas.core.dtypes.generic import ABCMultiIndex
 
-from pandas.io.formats.format import DataFrameFormatter
+if TYPE_CHECKING:
+    from pandas.io.formats.format import DataFrameFormatter
 
 
 def _split_into_full_short_caption(

--- a/pandas/io/formats/string.py
+++ b/pandas/io/formats/string.py
@@ -4,12 +4,17 @@ Module for formatting output data in console (to string).
 from __future__ import annotations
 
 from shutil import get_terminal_size
-from typing import Iterable
+from typing import (
+    TYPE_CHECKING,
+    Iterable,
+)
 
 import numpy as np
 
-from pandas.io.formats.format import DataFrameFormatter
 from pandas.io.formats.printing import pprint_thing
+
+if TYPE_CHECKING:
+    from pandas.io.formats.format import DataFrameFormatter
 
 
 class StringFormatter:

--- a/pandas/io/formats/xml.py
+++ b/pandas/io/formats/xml.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 import codecs
 import io
-from typing import Any
+from typing import (
+    TYPE_CHECKING,
+    Any,
+)
 
 from pandas._typing import (
     CompressionOptions,
@@ -20,7 +23,6 @@ from pandas.util._decorators import doc
 from pandas.core.dtypes.common import is_list_like
 from pandas.core.dtypes.missing import isna
 
-from pandas.core.frame import DataFrame
 from pandas.core.shared_docs import _shared_docs
 
 from pandas.io.common import get_handle
@@ -28,6 +30,9 @@ from pandas.io.xml import (
     get_data_from_filepath,
     preprocess_data,
 )
+
+if TYPE_CHECKING:
+    from pandas import DataFrame
 
 
 @doc(

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -10,6 +10,7 @@ from collections import abc
 import numbers
 import re
 from typing import (
+    TYPE_CHECKING,
     Iterable,
     Pattern,
     Sequence,
@@ -30,7 +31,6 @@ from pandas.util._decorators import deprecate_nonkeyword_arguments
 from pandas.core.dtypes.common import is_list_like
 
 from pandas.core.construction import create_series_with_explicit_dtype
-from pandas.core.frame import DataFrame
 
 from pandas.io.common import (
     file_exists,
@@ -42,6 +42,9 @@ from pandas.io.common import (
 )
 from pandas.io.formats.printing import pprint_thing
 from pandas.io.parsers import TextParser
+
+if TYPE_CHECKING:
+    from pandas import DataFrame
 
 _IMPORTS = False
 _HAS_BS4 = False

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -9,6 +9,7 @@ import functools
 from io import StringIO
 from itertools import islice
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Generic,
@@ -53,7 +54,6 @@ from pandas import (
     to_datetime,
 )
 from pandas.core.construction import create_series_with_explicit_dtype
-from pandas.core.generic import NDFrame
 from pandas.core.reshape.concat import concat
 from pandas.core.shared_docs import _shared_docs
 
@@ -72,6 +72,9 @@ from pandas.io.json._table_schema import (
     parse_table_schema,
 )
 from pandas.io.parsers.readers import validate_integer
+
+if TYPE_CHECKING:
+    from pandas.core.generic import NDFrame
 
 FrameSeriesStrT = TypeVar("FrameSeriesStrT", bound=Literal["frame", "series"])
 

--- a/pandas/io/parsers/arrow_parser_wrapper.py
+++ b/pandas/io/parsers/arrow_parser_wrapper.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from pandas._typing import ReadBuffer
 from pandas.compat._optional import import_optional_dependency
 
 from pandas.core.dtypes.inference import is_integer
 
-from pandas.core.frame import DataFrame
-
 from pandas.io.parsers.base_parser import ParserBase
+
+if TYPE_CHECKING:
+    from pandas import DataFrame
 
 
 class ArrowParserWrapper(ParserBase):

--- a/pandas/io/parsers/base_parser.py
+++ b/pandas/io/parsers/base_parser.py
@@ -7,6 +7,7 @@ import datetime
 from enum import Enum
 import itertools
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     DefaultDict,
@@ -59,7 +60,6 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.dtypes import CategoricalDtype
 from pandas.core.dtypes.missing import isna
 
-from pandas import DataFrame
 from pandas.core import algorithms
 from pandas.core.arrays import Categorical
 from pandas.core.indexes.api import (
@@ -71,6 +71,9 @@ from pandas.core.series import Series
 from pandas.core.tools import datetimes as tools
 
 from pandas.io.date_converters import generic_parser
+
+if TYPE_CHECKING:
+    from pandas import DataFrame
 
 
 class ParserBase:

--- a/pandas/io/parsers/c_parser_wrapper.py
+++ b/pandas/io/parsers/c_parser_wrapper.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from io import TextIOWrapper
 from typing import (
+    TYPE_CHECKING,
     Hashable,
     Mapping,
     Sequence,
@@ -28,16 +29,18 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.concat import union_categoricals
 from pandas.core.dtypes.dtypes import ExtensionDtype
 
-from pandas import (
-    Index,
-    MultiIndex,
-)
 from pandas.core.indexes.api import ensure_index_from_sequences
 
 from pandas.io.parsers.base_parser import (
     ParserBase,
     is_index_col,
 )
+
+if TYPE_CHECKING:
+    from pandas import (
+        Index,
+        MultiIndex,
+    )
 
 
 class CParserWrapper(ParserBase):

--- a/pandas/io/parsers/python_parser.py
+++ b/pandas/io/parsers/python_parser.py
@@ -10,6 +10,7 @@ import re
 import sys
 from typing import (
     IO,
+    TYPE_CHECKING,
     DefaultDict,
     Hashable,
     Iterator,
@@ -38,15 +39,16 @@ from pandas.util._exceptions import find_stack_level
 from pandas.core.dtypes.common import is_integer
 from pandas.core.dtypes.inference import is_dict_like
 
-from pandas import (
-    Index,
-    MultiIndex,
-)
-
 from pandas.io.parsers.base_parser import (
     ParserBase,
     parser_defaults,
 )
+
+if TYPE_CHECKING:
+    from pandas import (
+        Index,
+        MultiIndex,
+    )
 
 # BOM character (byte order mark)
 # This exists at the beginning of a file to indicate endianness

--- a/pandas/io/spss.py
+++ b/pandas/io/spss.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Sequence
+from typing import (
+    TYPE_CHECKING,
+    Sequence,
+)
 
 from pandas.compat._optional import import_optional_dependency
 
 from pandas.core.dtypes.inference import is_list_like
 
-from pandas.core.api import DataFrame
-
 from pandas.io.common import stringify_path
+
+if TYPE_CHECKING:
+    from pandas import DataFrame
 
 
 def read_spss(

--- a/pandas/io/xml.py
+++ b/pandas/io/xml.py
@@ -34,7 +34,6 @@ from pandas.util._decorators import (
 
 from pandas.core.dtypes.common import is_list_like
 
-from pandas.core.frame import DataFrame
 from pandas.core.shared_docs import _shared_docs
 
 from pandas.io.common import (
@@ -54,6 +53,8 @@ if TYPE_CHECKING:
         _Element,
         _XSLTResultTree,
     )
+
+    from pandas import DataFrame
 
 
 @doc(

--- a/pandas/plotting/_matplotlib/converter.py
+++ b/pandas/plotting/_matplotlib/converter.py
@@ -9,6 +9,7 @@ from datetime import (
 )
 import functools
 from typing import (
+    TYPE_CHECKING,
     Any,
     Final,
     Iterator,
@@ -32,7 +33,6 @@ from pandas._libs.tslibs import (
     to_offset,
 )
 from pandas._libs.tslibs.dtypes import FreqGroup
-from pandas._libs.tslibs.offsets import BaseOffset
 from pandas._typing import F
 
 from pandas.core.dtypes.common import (
@@ -56,6 +56,9 @@ from pandas.core.indexes.period import (
     period_range,
 )
 import pandas.core.tools.datetimes as tools
+
+if TYPE_CHECKING:
+    from pandas._libs.tslibs.offsets import BaseOffset
 
 # constants
 HOURS_PER_DAY: Final = 24.0

--- a/pandas/plotting/_matplotlib/hist.py
+++ b/pandas/plotting/_matplotlib/hist.py
@@ -22,8 +22,6 @@ from pandas.core.dtypes.missing import (
     remove_na_arraylike,
 )
 
-from pandas.core.frame import DataFrame
-
 from pandas.io.formats.printing import pprint_thing
 from pandas.plotting._matplotlib.core import (
     LinePlot,
@@ -43,6 +41,8 @@ from pandas.plotting._matplotlib.tools import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+
+    from pandas import DataFrame
 
 
 class HistPlot(LinePlot):


### PR DESCRIPTION
These are found by flake8-type-checking. There are more cases (all of the _typing imports).

If flake8-type-checking should be run on the CI, it would be good to move all the _typing imports inside TYPE_CHECKING (not sure whether we want to do that).