### PR TITLE
Doc/categorical okexcept

### DIFF
--- a/doc/source/user_guide/categorical.rst
+++ b/doc/source/user_guide/categorical.rst
@@ -443,13 +443,11 @@ meaning and certain operations are possible. If the categorical is unordered, th
 but ``.min()/.max()`` will raise a ``TypeError``.
 
 .. ipython:: python
+    :okexcept:
 
     s = pd.Series(pd.Categorical(["a", "b", "c", "a"], ordered=False))
     s.sort_values(ascending=False)
-    try:
-        s.min()
-    except TypeError as e:
-        print(f"TypeError: {e}")
+    s.min()
     s = s.astype(CategoricalDtype(ordered=True))
     s.sort_values()
     s.min(), s.max()

--- a/doc/source/user_guide/categorical.rst
+++ b/doc/source/user_guide/categorical.rst
@@ -439,15 +439,19 @@ Sorting and order
 .. _categorical.sort:
 
 If categorical data is ordered (``s.cat.ordered == True``), then the order of the categories has a
-meaning and certain operations are possible. If the categorical is unordered, ``.min()/.max()`` will raise a ``TypeError``.
+meaning and certain operations are possible. If the categorical is unordered, the data can still be sorted,
+but ``.min()/.max()`` will raise a ``TypeError``.
 
 .. ipython:: python
 
     s = pd.Series(pd.Categorical(["a", "b", "c", "a"], ordered=False))
-    s.sort_values(inplace=True)
-    s = pd.Series(["a", "b", "c", "a"]).astype(CategoricalDtype(ordered=True))
-    s.sort_values(inplace=True)
-    s
+    s.sort_values(ascending=False)
+    try:
+        s.min()
+    except TypeError as e:
+        print(f"TypeError: {e}")
+    s = s.astype(CategoricalDtype(ordered=True))
+    s.sort_values()
     s.min(), s.max()
 
 You can set categorical data to be ordered by using ``as_ordered()`` or unordered by using ``as_unordered()``. These will by

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -256,7 +256,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
     """
     Represent a categorical variable in classic R / S-plus fashion.
 
-    `Categoricals` can only take on only a limited, and usually fixed, number
+    `Categoricals` can only take on a limited, and usually fixed, number
     of possible values (`categories`). In contrast to statistical categorical
     variables, a `Categorical` might have an order, but numerical operations
     (additions, divisions, ...) are not possible.


### PR DESCRIPTION
This is a variant of #47846 using the `:okexcept:` directive instead of `try/except` [as requested by mroeschke](https://github.com/pandas-dev/pandas/pull/47846#discussion_r929310988).