### PR TITLE
TYP: annotate functions that always error with NoReturn

### DIFF
--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -15,6 +15,7 @@ from typing import (
     Generic,
     Hashable,
     Iterator,
+    NoReturn,
     Sequence,
     final,
 )
@@ -1243,7 +1244,7 @@ class BinGrouper(BaseGrouper):
         ping = grouper.Grouping(lev, lev, in_axis=False, level=None)
         return [ping]
 
-    def _aggregate_series_fast(self, obj: Series, func: Callable) -> np.ndarray:
+    def _aggregate_series_fast(self, obj: Series, func: Callable) -> NoReturn:
         # -> np.ndarray[object]
         raise NotImplementedError(
             "This should not be reached; use _aggregate_series_pure_python"

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -12,6 +12,7 @@ from typing import (
     Hashable,
     Iterable,
     Literal,
+    NoReturn,
     Sequence,
     TypeVar,
     cast,
@@ -3166,7 +3167,7 @@ class Index(IndexOpsMixin, PandasObject):
         return self.symmetric_difference(other)
 
     @final
-    def __nonzero__(self):
+    def __nonzero__(self) -> NoReturn:
         raise ValueError(
             f"The truth value of a {type(self).__name__} is ambiguous. "
             "Use a.empty, a.bool(), a.item(), a.any() or a.all()."

--- a/pandas/core/indexes/frozen.py
+++ b/pandas/core/indexes/frozen.py
@@ -8,7 +8,10 @@ These are used for:
 """
 from __future__ import annotations
 
-from typing import Any
+from typing import (
+    Any,
+    NoReturn,
+)
 
 from pandas.core.base import PandasObject
 
@@ -93,7 +96,7 @@ class FrozenList(PandasObject, list):
     def __hash__(self) -> int:  # type: ignore[override]
         return hash(tuple(self))
 
-    def _disabled(self, *args, **kwargs):
+    def _disabled(self, *args, **kwargs) -> NoReturn:
         """
         This method will not function because object is immutable.
         """


### PR DESCRIPTION
There are more non-abstract functions that also error. Most of them should probably be abstract functions. I ignored those functions.