### PR TITLE
SAS7BDAT parser: Fix page count

### DIFF
--- a/pandas/io/sas/sas7bdat.py
+++ b/pandas/io/sas/sas7bdat.py
@@ -313,7 +313,7 @@ class SAS7BDATReader(ReaderBase, abc.Iterator):
             const.page_size_offset + align1, const.page_size_length
         )
         self._page_count = self._read_int(
-            const.page_count_offset + align1, const.page_count_length
+            const.page_count_offset + align1, self._int_length
         )
 
         self.sas_release_offset = self._read_and_convert_header_text(


### PR DESCRIPTION
While page size is 32 bits (https://github.com/Roche/pyreadstat/blob/e0627c7cf406e4296a9af16036a563719fcba237/src/sas/readstat_sas.c#L245) the page count is word size (https://github.com/Roche/pyreadstat/blob/e0627c7cf406e4296a9af16036a563719fcba237/src/sas/readstat_sas.c#L270-L284).

Unfortunately I don't have a test file that I can share.

- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
