### PR TITLE
TST: Refactor index setops test for xdist stability

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -669,21 +669,6 @@ index_flat2 = index_flat
     params=[
         key
         for key in indices_dict
-        if not isinstance(indices_dict[key], MultiIndex) and indices_dict[key].is_unique
-    ]
-)
-def index_flat_unique(request):
-    """
-    index_flat with uniqueness requirement.
-    """
-    key = request.param
-    return indices_dict[key].copy()
-
-
-@pytest.fixture(
-    params=[
-        key
-        for key in indices_dict
         if not (
             key in ["int", "uint", "range", "empty", "repeats", "bool-dtype"]
             or key.startswith("num_")

--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -317,11 +317,13 @@ class TestSetOps:
             (None, None, None),
         ],
     )
-    def test_corner_union(self, index_flat_unique, fname, sname, expected_name):
+    def test_corner_union(self, index_flat, fname, sname, expected_name):
         # GH#9943, GH#9862
         # Test unions with various name combinations
         # Do not test MultiIndex or repeats
-        index = index_flat_unique
+        if not index_flat.is_unique:
+            pytest.skip("Randomly generated index_flat was not unique.")
+        index = index_flat
 
         # Test copy.union(copy)
         first = index.copy().set_names(fname)
@@ -361,8 +363,10 @@ class TestSetOps:
             (None, None, None),
         ],
     )
-    def test_union_unequal(self, index_flat_unique, fname, sname, expected_name):
-        index = index_flat_unique
+    def test_union_unequal(self, index_flat, fname, sname, expected_name):
+        if not index_flat.is_unique:
+            pytest.skip("Randomly generated index_flat was not unique.")
+        index = index_flat
 
         # test copy.union(subset) - need sort for unicode and string
         first = index.copy().set_names(fname)
@@ -381,10 +385,12 @@ class TestSetOps:
             (None, None, None),
         ],
     )
-    def test_corner_intersect(self, index_flat_unique, fname, sname, expected_name):
+    def test_corner_intersect(self, index_flat, fname, sname, expected_name):
         # GH#35847
         # Test intersections with various name combinations
-        index = index_flat_unique
+        if not index_flat.is_unique:
+            pytest.skip("Randomly generated index_flat was not unique.")
+        index = index_flat
 
         # Test copy.intersection(copy)
         first = index.copy().set_names(fname)
@@ -424,8 +430,10 @@ class TestSetOps:
             (None, None, None),
         ],
     )
-    def test_intersect_unequal(self, index_flat_unique, fname, sname, expected_name):
-        index = index_flat_unique
+    def test_intersect_unequal(self, index_flat, fname, sname, expected_name):
+        if not index_flat.is_unique:
+            pytest.skip("Randomly generated index_flat was not unique.")
+        index = index_flat
 
         # test copy.intersection(subset) - need sort for unicode and string
         first = index.copy().set_names(fname)


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

It appears `pytest-xdist` needs all the workers to collect all the same parameterized tests to run.

Since data is generated randomly, sometimes the `index_flat_unique` fixture could have a different number of indexes between workers based on uniqueness and cause a build to completely fail. It's only used in 4 tests so just moving the filtering logic to the relevant test.
 
Example build failure: https://github.com/pandas-dev/pandas/runs/7735103409?check_suite_focus=true
