### PR TITLE
PERF cache find_stack_level

### DIFF
--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -1,3 +1,4 @@
+import inspect
 import numbers
 from operator import (
     le,
@@ -45,6 +46,7 @@ cnp.import_array()
 import warnings
 
 from pandas._libs import lib
+
 from pandas._libs cimport util
 from pandas._libs.hashtable cimport Int64Vector
 from pandas._libs.tslibs.timedeltas cimport _Timedelta
@@ -394,7 +396,7 @@ cdef class Interval(IntervalMixin):
         warnings.warn(
             "Attribute `closed` is deprecated in favor of `inclusive`.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.inclusive
 

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from typing import (
     Literal,
     cast,
@@ -112,7 +113,7 @@ def assert_almost_equal(
             "is deprecated and will be removed in a future version. "
             "You can stop passing 'check_less_precise' to silence this warning.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         rtol = atol = _get_tol_from_less_precise(check_less_precise)
 
@@ -339,7 +340,7 @@ def assert_index_equal(
             "is deprecated and will be removed in a future version. "
             "You can stop passing 'check_less_precise' to silence this warning.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         rtol = atol = _get_tol_from_less_precise(check_less_precise)
 
@@ -815,7 +816,7 @@ def assert_extension_array_equal(
             "is deprecated and will be removed in a future version. "
             "You can stop passing 'check_less_precise' to silence this warning.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         rtol = atol = _get_tol_from_less_precise(check_less_precise)
 
@@ -970,7 +971,7 @@ def assert_series_equal(
             "is deprecated and will be removed in a future version. "
             "You can stop passing 'check_less_precise' to silence this warning.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         rtol = atol = _get_tol_from_less_precise(check_less_precise)
 
@@ -1263,7 +1264,7 @@ def assert_frame_equal(
             "is deprecated and will be removed in a future version. "
             "You can stop passing 'check_less_precise' to silence this warning.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         rtol = atol = _get_tol_from_less_precise(check_less_precise)
 

--- a/pandas/core/accessor.py
+++ b/pandas/core/accessor.py
@@ -6,6 +6,7 @@ that can be mixed into or pinned onto other pandas classes.
 """
 from __future__ import annotations
 
+import inspect
 import warnings
 
 from pandas.util._decorators import doc
@@ -268,7 +269,7 @@ def _register_accessor(name, cls):
                 f"{repr(name)} for type {repr(cls)} is overriding a preexisting "
                 f"attribute with the same name.",
                 UserWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         setattr(cls, name, CachedAccessor(name, accessor))
         cls._accessors.add(name)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -836,7 +836,9 @@ def resolve_na_sentinel(
                 "Specify `use_na_sentinel=True` to use the sentinel value -1, and "
                 "`use_na_sentinel=False` to encode NaN values."
             )
-        warnings.warn(msg, FutureWarning, stacklevel=find_stack_level())
+        warnings.warn(
+            msg, FutureWarning, stacklevel=find_stack_level(inspect.currentframe())
+        )
         result = na_sentinel
     return result
 
@@ -1658,7 +1660,7 @@ def diff(arr, n: int, axis: int = 0):
                 "dtype lost in 'diff()'. In the future this will raise a "
                 "TypeError. Convert to a suitable dtype prior to calling 'diff'.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             arr = np.asarray(arr)
             dtype = arr.dtype

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -291,7 +291,7 @@ class Apply(metaclass=abc.ABCMeta):
                 f"raised, this will raise in a future version of pandas. "
                 f"Drop these columns/ops to avoid this warning.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         return concat(results, axis=1)
 
@@ -423,7 +423,7 @@ class Apply(metaclass=abc.ABCMeta):
             warnings.warn(
                 depr_nuisance_columns_msg.format(failed_names),
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         try:

--- a/pandas/core/arraylike.py
+++ b/pandas/core/arraylike.py
@@ -6,6 +6,7 @@ Methods that can be shared by many array-like classes or subclasses:
 """
 from __future__ import annotations
 
+import inspect
 import operator
 from typing import Any
 import warnings
@@ -220,7 +221,7 @@ def _maybe_fallback(ufunc: np.ufunc, method: str, *inputs: Any, **kwargs: Any):
                 "or align manually (eg 'df1, df2 = df1.align(df2)') before passing to "
                 "the ufunc to obtain the future behaviour and silence this warning.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
             # keep the first dataframe of the inputs, other DataFrame/Series is
@@ -348,7 +349,9 @@ def array_ufunc(self, ufunc: np.ufunc, method: str, *inputs: Any, **kwargs: Any)
                         "to an array with '.to_numpy()' first."
                     )
                     warnings.warn(
-                        msg.format(ufunc), FutureWarning, stacklevel=find_stack_level()
+                        msg.format(ufunc),
+                        FutureWarning,
+                        stacklevel=find_stack_level(inspect.currentframe()),
                     )
                     return result
                 raise NotImplementedError

--- a/pandas/core/arrays/arrow/_arrow_utils.py
+++ b/pandas/core/arrays/arrow/_arrow_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import json
 import warnings
 
@@ -22,7 +23,9 @@ def fallback_performancewarning(version: str | None = None) -> None:
     msg = "Falling back on a non-pyarrow code path which may decrease performance."
     if version is not None:
         msg += f" Upgrade to pyarrow >={version} to possibly suppress this warning."
-    warnings.warn(msg, PerformanceWarning, stacklevel=find_stack_level())
+    warnings.warn(
+        msg, PerformanceWarning, stacklevel=find_stack_level(inspect.currentframe())
+    )
 
 
 def pyarrow_array_to_numpy_and_mask(
@@ -133,7 +136,7 @@ class ArrowIntervalType(pyarrow.ExtensionType):
         warnings.warn(
             "Attribute `closed` is deprecated in favor of `inclusive`.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self._inclusive
 

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -476,7 +476,7 @@ class ExtensionArray:
                 f"instead.  Add this argument to `{name}.factorize` to be compatible "
                 f"with future versions of pandas and silence this warning.",
                 DeprecationWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
     def to_numpy(

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from csv import QUOTE_NONNUMERIC
 from functools import partial
+import inspect
 import operator
 from shutil import get_terminal_size
 from typing import (
@@ -394,7 +395,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
                 "Allowing scalars in the Categorical constructor is deprecated "
                 "and will raise in a future version.  Use `[value]` instead",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             values = [values]
 
@@ -749,7 +750,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
             "Setting categories in-place is deprecated and will raise in a "
             "future version. Use rename_categories instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
 
         self._set_categories(categories)
@@ -873,7 +874,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
                 "a future version. setting ordered-ness on categories will always "
                 "return a new Categorical object.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         else:
             inplace = False
@@ -1125,7 +1126,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
                 "a future version. Removing unused categories will always "
                 "return a new Categorical object.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         else:
             inplace = False
@@ -1189,7 +1190,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
                 "a future version. Reordering categories will always "
                 "return a new Categorical object.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         else:
             inplace = False
@@ -1273,7 +1274,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
                 "a future version. Removing unused categories will always "
                 "return a new Categorical object.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         else:
             inplace = False
@@ -1349,7 +1350,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
                 "a future version. Removing unused categories will always "
                 "return a new Categorical object.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         else:
             inplace = False
@@ -1437,7 +1438,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
                 "remove_unused_categories is deprecated and "
                 "will be removed in a future version.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         else:
             inplace = False
@@ -2046,7 +2047,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
             "Categorical.to_dense is deprecated and will be removed in "
             "a future version.  Use np.asarray(cat) instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return np.asarray(self)
 
@@ -2063,7 +2064,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
             "Setting the codes on a Categorical is deprecated and will raise in "
             "a future version. Create a new Categorical object instead",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )  # GH#40606
         NDArrayBacked.__init__(self, value, self.dtype)
 
@@ -2088,7 +2089,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         warn(
             "Categorical.take_nd is deprecated, use Categorical.take instead",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.take(indexer, allow_fill=allow_fill, fill_value=fill_value)
 
@@ -2381,7 +2382,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
             "Categorical.mode is deprecated and will be removed in a future version. "
             "Use Series.mode instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self._mode(dropna=dropna)
 
@@ -2524,7 +2525,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
             "Categorical.is_dtype_equal is deprecated and will be removed "
             "in a future version",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         try:
             return self._categories_match_up_to_permutation(other)
@@ -2648,7 +2649,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
             "Categorical.replace is deprecated and will be removed in a future "
             "version. Use Series.replace directly instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self._replace(to_replace=to_replace, value=value, inplace=inplace)
 

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -4,6 +4,7 @@ from datetime import (
     datetime,
     timedelta,
 )
+import inspect
 import operator
 from typing import (
     TYPE_CHECKING,
@@ -469,7 +470,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
                         "exactly the specified dtype instead of uint64, and will "
                         "raise if that conversion overflows.",
                         FutureWarning,
-                        stacklevel=find_stack_level(),
+                        stacklevel=find_stack_level(inspect.currentframe()),
                     )
                 elif (self.asi8 < 0).any():
                     # GH#45034
@@ -479,7 +480,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
                         "raise if the conversion overflows, as it did in this "
                         "case with negative int64 values.",
                         FutureWarning,
-                        stacklevel=find_stack_level(),
+                        stacklevel=find_stack_level(inspect.currentframe()),
                     )
             elif dtype != np.int64:
                 # GH#45034
@@ -489,7 +490,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
                     "exactly the specified dtype instead of int64, and will "
                     "raise if that conversion overflows.",
                     FutureWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
 
             if copy:
@@ -628,7 +629,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
                 FutureWarning,
                 # There is no way to hard-code the level since this might be
                 #  reached directly or called from the Index or Block method
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             fill_value = new_fill
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -6,6 +6,7 @@ from datetime import (
     timedelta,
     tzinfo,
 )
+import inspect
 from typing import (
     TYPE_CHECKING,
     Literal,
@@ -473,7 +474,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                     "timezone. To retain the old behavior, explicitly cast to "
                     "object dtype before the operation.",
                     FutureWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
                 raise ValueError(f"Timezones don't match. '{self.tz}' != '{other.tz}'")
 
@@ -1139,7 +1140,7 @@ default 'raise'
             "Use `dtindex - dtindex.to_period(freq).to_timestamp()` instead.",
             FutureWarning,
             # stacklevel chosen to be correct for when called from DatetimeIndex
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         from pandas.core.arrays.timedeltas import TimedeltaArray
 
@@ -1341,7 +1342,7 @@ default 'raise'
             "weekofyear and return an Index, you may call "
             "pd.Int64Index(idx.isocalendar().week)",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         week_series = self.isocalendar().week
         if week_series.hasnans:
@@ -2238,7 +2239,7 @@ def maybe_convert_dtype(data, copy: bool, tz: tzinfo | None = None):
                 "before passing the data to pandas. To get the future behavior, "
                 "first cast to 'int64'.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
     elif is_timedelta64_dtype(data.dtype) or is_bool_dtype(data.dtype):

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import operator
 from operator import (
     le,
@@ -1380,7 +1381,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         warnings.warn(
             "Attribute `closed` is deprecated in favor of `inclusive`.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.dtype.inclusive
 
@@ -1432,7 +1433,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             "set_closed is deprecated and will be removed in a future version. "
             "Use set_inclusive instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.set_inclusive(closed)
 

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -4,6 +4,7 @@ SparseArray data structure
 from __future__ import annotations
 
 from collections import abc
+import inspect
 import numbers
 import operator
 from typing import (
@@ -414,7 +415,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
                 "to construct an array with the desired repeats of the "
                 "scalar value instead.\n\n",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         if index is not None and not is_scalar(data):
@@ -493,7 +494,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
                         "loses timezone information. Cast to object before "
                         "sparse to retain timezone information.",
                         UserWarning,
-                        stacklevel=find_stack_level(),
+                        stacklevel=find_stack_level(inspect.currentframe()),
                     )
                     data = np.asarray(data, dtype="datetime64[ns]")
                     if fill_value is NaT:
@@ -1182,7 +1183,9 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
     ) -> npt.NDArray[np.intp] | np.intp:
 
         msg = "searchsorted requires high memory usage."
-        warnings.warn(msg, PerformanceWarning, stacklevel=find_stack_level())
+        warnings.warn(
+            msg, PerformanceWarning, stacklevel=find_stack_level(inspect.currentframe())
+        )
         if not is_scalar(v):
             v = np.asarray(v)
         v = np.asarray(v)
@@ -1322,7 +1325,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
                 "array with the requested dtype. To retain the old behavior, use "
                 "`obj.astype(SparseDtype(dtype))`",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         dtype = self.dtype.update_dtype(dtype)

--- a/pandas/core/arrays/sparse/dtype.py
+++ b/pandas/core/arrays/sparse/dtype.py
@@ -1,6 +1,7 @@
 """Sparse Dtype"""
 from __future__ import annotations
 
+import inspect
 import re
 from typing import (
     TYPE_CHECKING,
@@ -409,7 +410,7 @@ class SparseDtype(ExtensionDtype):
                 f"values: '{fill_values}'. Picking the first and "
                 "converting the rest.",
                 PerformanceWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         np_dtypes = [x.subtype if isinstance(x, SparseDtype) else x for x in dtypes]

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -4,6 +4,7 @@ Base and utility classes for pandas objects.
 
 from __future__ import annotations
 
+import inspect
 import textwrap
 from typing import (
     TYPE_CHECKING,
@@ -1064,7 +1065,7 @@ class IndexOpsMixin(OpsMixin):
             "is_monotonic is deprecated and will be removed in a future version. "
             "Use is_monotonic_increasing instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.is_monotonic_increasing
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -169,7 +169,7 @@ def cast_scalar_indexer(val, warn_float: bool = False):
                 "Indexing with a float is deprecated, and will raise an IndexError "
                 "in pandas 2.0. You can manually convert to an integer key instead.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         return int(val)
     return val
@@ -697,4 +697,6 @@ def deprecate_numeric_only_default(
         "this warning."
     )
 
-    warnings.warn(msg, FutureWarning, stacklevel=find_stack_level())
+    warnings.warn(
+        msg, FutureWarning, stacklevel=find_stack_level(inspect.currentframe())
+    )

--- a/pandas/core/computation/align.py
+++ b/pandas/core/computation/align.py
@@ -7,6 +7,7 @@ from functools import (
     partial,
     wraps,
 )
+import inspect
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -131,7 +132,9 @@ def _align_core(terms):
                         f"by more than {ordm:.4g}; performance may suffer."
                     )
                     warnings.warn(
-                        w, category=PerformanceWarning, stacklevel=find_stack_level()
+                        w,
+                        category=PerformanceWarning,
+                        stacklevel=find_stack_level(inspect.currentframe()),
                     )
 
                 f = partial(ti.reindex, reindexer, axis=axis, copy=False)

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -3,6 +3,7 @@ Top level ``eval`` module.
 """
 from __future__ import annotations
 
+import inspect
 import tokenize
 from typing import TYPE_CHECKING
 import warnings
@@ -311,7 +312,7 @@ def eval(
                 "will be removed in a future version."
             ),
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
 
     exprs: list[str | BinOp]

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -11,6 +11,7 @@ module is imported, register them here rather than in the module.
 """
 from __future__ import annotations
 
+import inspect
 import os
 from typing import Callable
 import warnings
@@ -370,7 +371,7 @@ with cf.config_prefix("display"):
             "in a future version. Use df.to_string(col_space=...) "
             "instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
 
     cf.register_option("column_space", 12, validator=is_int, cb=_deprecate_column_space)
@@ -397,7 +398,7 @@ with cf.config_prefix("display"):
                 "will not be supported in future version. Instead, use None "
                 "to not limit the column width.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
     cf.register_option(

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -6,6 +6,7 @@ These should not depend on core.internals.
 """
 from __future__ import annotations
 
+import inspect
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -568,7 +569,7 @@ def sanitize_array(
                     "passed dtype. To retain the old behavior, call Series(arr) or "
                     "DataFrame(arr) without passing a dtype.",
                     FutureWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
                 subarr = np.array(data, copy=copy)
             except ValueError:
@@ -580,7 +581,7 @@ def sanitize_array(
                         "if they cannot be cast losslessly (matching Series behavior). "
                         "To retain the old behavior, use DataFrame(data).astype(dtype)",
                         FutureWarning,
-                        stacklevel=find_stack_level(),
+                        stacklevel=find_stack_level(inspect.currentframe()),
                     )
                     # GH#40110 until the deprecation is enforced, we _dont_
                     #  ignore the dtype for DataFrame, and _do_ cast even though
@@ -852,7 +853,7 @@ def _try_cast(
                 "passed to 'DataFrame', either all columns will be cast to that "
                 "dtype, or a TypeError will be raised.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             subarr = np.array(arr, dtype=object, copy=copy)
     return subarr

--- a/pandas/core/describe.py
+++ b/pandas/core/describe.py
@@ -9,6 +9,7 @@ from abc import (
     ABC,
     abstractmethod,
 )
+import inspect
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -373,7 +374,7 @@ def select_describe_func(
                 "version of pandas. Specify `datetime_is_numeric=True` to "
                 "silence this warning and adopt the future behavior now.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             return describe_timestamp_as_categorical_1d
     elif is_timedelta64_dtype(data.dtype):

--- a/pandas/core/dtypes/astype.py
+++ b/pandas/core/dtypes/astype.py
@@ -371,7 +371,7 @@ def astype_dt64_to_dt64tz(
             "timezone-aware dtype is deprecated and will raise in a "
             "future version.  Use ser.dt.tz_localize instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
 
         # GH#33401 this doesn't match DatetimeArray.astype, which
@@ -387,7 +387,7 @@ def astype_dt64_to_dt64tz(
                 "timezone-aware dtype is deprecated and will raise in a "
                 "future version.  Use obj.tz_localize instead.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
             return values.tz_localize(dtype.tz)
@@ -407,7 +407,7 @@ def astype_dt64_to_dt64tz(
                 "future version.  Use obj.tz_localize(None) or "
                 "obj.tz_convert('UTC').tz_localize(None) instead",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
             result = values.tz_convert("UTC").tz_localize(None)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -10,6 +10,7 @@ from datetime import (
     timedelta,
 )
 import functools
+import inspect
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -624,7 +625,7 @@ def _maybe_promote(dtype: np.dtype, fill_value=np.nan):
                     "dtype is deprecated. In a future version, this will be cast "
                     "to object dtype. Pass `fill_value=Timestamp(date_obj)` instead.",
                     FutureWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
                 return dtype, fv
         elif isinstance(fill_value, str):
@@ -1277,7 +1278,7 @@ def maybe_infer_to_datetimelike(
             "and will be removed in a future version. To retain the old behavior "
             f"explicitly pass Series(data, dtype={value.dtype})",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
     return value
 
@@ -1336,7 +1337,7 @@ def maybe_cast_to_datetime(
                                 "`pd.Series(values).dt.tz_localize(None)` "
                                 "instead.",
                                 FutureWarning,
-                                stacklevel=find_stack_level(),
+                                stacklevel=find_stack_level(inspect.currentframe()),
                             )
                             # equiv: dta.view(dtype)
                             # Note: NOT equivalent to dta.astype(dtype)
@@ -1376,7 +1377,7 @@ def maybe_cast_to_datetime(
                                     ".tz_localize('UTC').tz_convert(dtype.tz) "
                                     "or pd.Series(data.view('int64'), dtype=dtype)",
                                     FutureWarning,
-                                    stacklevel=find_stack_level(),
+                                    stacklevel=find_stack_level(inspect.currentframe()),
                                 )
 
                             value = dta.tz_localize("UTC").tz_convert(dtype.tz)
@@ -1745,7 +1746,7 @@ def _maybe_unbox_datetimelike_tz_deprecation(value: Scalar, dtype: DtypeObj):
                 "`pd.Series(values).dt.tz_localize(None)` "
                 "instead.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             new_value = value.tz_localize(None)
             return _maybe_unbox_datetimelike(new_value, dtype)
@@ -1863,7 +1864,7 @@ def maybe_cast_to_integer_array(
             "In a future version this will raise OverflowError. To retain the "
             f"old behavior, use pd.Series(values).astype({dtype})",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return casted
 
@@ -1874,7 +1875,7 @@ def maybe_cast_to_integer_array(
             f"dtype={dtype} is deprecated and will raise in a future version. "
             "Use values.view(dtype) instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return casted
 

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -3,6 +3,7 @@ Common type operations.
 """
 from __future__ import annotations
 
+import inspect
 from typing import (
     Any,
     Callable,
@@ -307,7 +308,7 @@ def is_categorical(arr) -> bool:
         "is_categorical is deprecated and will be removed in a future version. "
         "Use is_categorical_dtype instead.",
         FutureWarning,
-        stacklevel=find_stack_level(),
+        stacklevel=find_stack_level(inspect.currentframe()),
     )
     return isinstance(arr, ABCCategorical) or is_categorical_dtype(arr)
 
@@ -1386,7 +1387,7 @@ def is_extension_type(arr) -> bool:
         "'is_extension_type' is deprecated and will be removed in a future "
         "version.  Use 'is_extension_array_dtype' instead.",
         FutureWarning,
-        stacklevel=find_stack_level(),
+        stacklevel=find_stack_level(inspect.currentframe()),
     )
 
     if is_categorical_dtype(arr):

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -3,6 +3,7 @@ Utility functions related to concat.
 """
 from __future__ import annotations
 
+import inspect
 from typing import (
     TYPE_CHECKING,
     cast,
@@ -152,7 +153,7 @@ def concat_compat(to_concat, axis: int = 0, ea_compat_axis: bool = False):
             "(instead of coercing bools to numeric values). To retain the old "
             "behavior, explicitly cast bool-dtype arrays to numeric dtype.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
     return result
 

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -3,6 +3,7 @@ Define extension dtypes.
 """
 from __future__ import annotations
 
+import inspect
 import re
 from typing import (
     TYPE_CHECKING,
@@ -1194,7 +1195,7 @@ class IntervalDtype(PandasExtensionDtype):
         warnings.warn(
             "Attribute `closed` is deprecated in favor of `inclusive`.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self._inclusive
 

--- a/pandas/core/dtypes/inference.py
+++ b/pandas/core/dtypes/inference.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import abc
+import inspect
 from numbers import Number
 import re
 from typing import Pattern
@@ -459,7 +460,7 @@ def is_inferred_bool_dtype(arr: ArrayLike) -> bool:
                 "will not be included in reductions with bool_only=True. "
                 "Explicitly cast to bool dtype instead.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         return result
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -14,6 +14,7 @@ import collections
 from collections import abc
 import datetime
 import functools
+import inspect
 from io import StringIO
 import itertools
 from textwrap import dedent
@@ -673,7 +674,7 @@ class DataFrame(NDFrame, OpsMixin):
                     "removed in a future version.  Pass "
                     "{name: data[name] for name in data.dtype.names} instead.",
                     FutureWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
 
             # a masked array
@@ -1324,7 +1325,7 @@ class DataFrame(NDFrame, OpsMixin):
             "iteritems is deprecated and will be removed in a future version. "
             "Use .items instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         yield from self.items()
 
@@ -1909,7 +1910,7 @@ class DataFrame(NDFrame, OpsMixin):
             warnings.warn(
                 "DataFrame columns are not unique, some columns will be omitted.",
                 UserWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         # GH16122
         into_c = com.standardize_mapping(into)
@@ -1930,7 +1931,7 @@ class DataFrame(NDFrame, OpsMixin):
                 "will be used in a future version. Use one of the above "
                 "to silence this warning.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
             if orient.startswith("d"):
@@ -2773,7 +2774,7 @@ class DataFrame(NDFrame, OpsMixin):
                 "'showindex' is deprecated. Only 'index' will be used "
                 "in a future version. Use 'index' to silence this warning.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         kwargs.setdefault("headers", "keys")
@@ -3387,7 +3388,7 @@ class DataFrame(NDFrame, OpsMixin):
             warnings.warn(
                 "null_counts is deprecated. Use show_counts instead",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             show_counts = null_counts
         info = DataFrameInfo(
@@ -3772,7 +3773,7 @@ class DataFrame(NDFrame, OpsMixin):
             warnings.warn(
                 "Boolean Series key will be reindexed to match DataFrame index.",
                 UserWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         elif len(key) != len(self.index):
             raise ValueError(
@@ -4862,7 +4863,9 @@ class DataFrame(NDFrame, OpsMixin):
             "You can use DataFrame.melt and DataFrame.loc "
             "as a substitute."
         )
-        warnings.warn(msg, FutureWarning, stacklevel=find_stack_level())
+        warnings.warn(
+            msg, FutureWarning, stacklevel=find_stack_level(inspect.currentframe())
+        )
 
         n = len(row_labels)
         if n != len(col_labels):
@@ -8364,7 +8367,7 @@ Parrot 2  Parrot       24.0
                     "will be removed in a future version."
                 ),
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         else:
             squeeze = False
@@ -9735,7 +9738,7 @@ Parrot 2  Parrot       24.0
             "and will be removed from pandas in a future version. "
             "Use pandas.concat instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
 
         return self._append(other, ignore_index, verify_integrity, sort)
@@ -10701,7 +10704,7 @@ Parrot 2  Parrot       24.0
                 "deprecated and will be removed in a future version. Use groupby "
                 "instead. df.count(level=1) should use df.groupby(level=1).count().",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             res = self._count_level(level, axis=axis, numeric_only=numeric_only)
             return res.__finalize__(self, method="count")
@@ -10803,7 +10806,7 @@ Parrot 2  Parrot       24.0
                     "will include datetime64 and datetime64tz columns in a "
                     "future version.",
                     FutureWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
                 # Non-copy equivalent to
                 #  dt64_cols = self.dtypes.apply(is_datetime64_any_dtype)
@@ -10904,7 +10907,7 @@ Parrot 2  Parrot       24.0
                 "version this will raise TypeError.  Select only valid "
                 "columns before calling the reduction.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         if hasattr(result, "dtype"):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5,6 +5,7 @@ import collections
 from datetime import timedelta
 import functools
 import gc
+import inspect
 import json
 import operator
 import pickle
@@ -493,7 +494,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         warnings.warn(
             "_AXIS_NUMBERS has been deprecated.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return {"index": 0}
 
@@ -3375,7 +3376,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             "to use `DataFrame.style.to_latex` which also contains additional "
             "functionality."
         )
-        warnings.warn(msg, FutureWarning, stacklevel=find_stack_level())
+        warnings.warn(
+            msg, FutureWarning, stacklevel=find_stack_level(inspect.currentframe())
+        )
 
         # Get defaults from the pandas config
         if self.ndim == 1:
@@ -3804,7 +3807,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 "is_copy is deprecated and will be removed in a future version. "
                 "'take' always returns a copy, so there is no need to specify this.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         nv.validate_take((), kwargs)
@@ -3960,7 +3963,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 "Passing lists as key for xs is deprecated and will be removed in a "
                 "future version. Pass key as a tuple instead.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         if level is not None:
@@ -4145,7 +4148,11 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         if value == "raise":
             raise SettingWithCopyError(t)
         elif value == "warn":
-            warnings.warn(t, SettingWithCopyWarning, stacklevel=find_stack_level())
+            warnings.warn(
+                t,
+                SettingWithCopyWarning,
+                stacklevel=find_stack_level(inspect.currentframe()),
+            )
 
     def __delitem__(self, key) -> None:
         """
@@ -5883,7 +5890,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                         "created via a new attribute name - see "
                         "https://pandas.pydata.org/pandas-docs/"
                         "stable/indexing.html#attribute-access",
-                        stacklevel=find_stack_level(),
+                        stacklevel=find_stack_level(inspect.currentframe()),
                     )
                 object.__setattr__(self, name, value)
 
@@ -8262,7 +8269,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 "`include_start` and `include_end` are deprecated in "
                 "favour of `inclusive`.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             left = True if include_start is lib.no_default else include_start
             right = True if include_end is lib.no_default else include_end
@@ -8978,7 +8985,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 "and will raise in a future version. Pass either 'True' or "
                 "'False'. 'False' will be the default.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             warned = True
         elif numeric_only is lib.no_default:
@@ -9034,7 +9041,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                         "is deprecated; in a future version this will raise TypeError. "
                         "Select only valid columns before calling rank.",
                         FutureWarning,
-                        stacklevel=find_stack_level(),
+                        stacklevel=find_stack_level(inspect.currentframe()),
                     )
 
         if numeric_only:
@@ -9045,7 +9052,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                     f"{self.dtype} is deprecated and will raise a TypeError in a "
                     "future version of pandas",
                     category=FutureWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
             data = self._get_numeric_data()
         else:
@@ -9816,7 +9823,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 "try_cast keyword is deprecated and will be removed in a "
                 "future version.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         return self._where(cond, other, inplace, axis, level)
@@ -9894,7 +9901,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 "try_cast keyword is deprecated and will be removed in a "
                 "future version.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         # see gh-21891
@@ -10089,7 +10096,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             "and will be removed in a future version. "
             "You can use DataFrame/Series.shift instead."
         )
-        warnings.warn(msg, FutureWarning, stacklevel=find_stack_level())
+        warnings.warn(
+            msg, FutureWarning, stacklevel=find_stack_level(inspect.currentframe())
+        )
 
         if periods == 0:
             return self
@@ -10142,7 +10151,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 "Please use shift instead."
             ),
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
 
         if freq is None:
@@ -10975,7 +10984,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 "deprecated and will be removed in a future version. Use groupby "
                 "instead. df.any(level=1) should use df.groupby(level=1).any()",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             if bool_only is not None:
                 raise NotImplementedError(
@@ -11109,7 +11118,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 "deprecated and will be removed in a future version. Use groupby "
                 "instead. df.var(level=1) should use df.groupby(level=1).var().",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             return self._agg_by_level(
                 name, axis=axis, level=level, skipna=skipna, ddof=ddof
@@ -11183,7 +11192,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 f"scalar {name} over the entire DataFrame. To retain the old "
                 f"behavior, use 'frame.{name}(axis=0)' or just 'frame.{name}()'",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         if axis is lib.no_default:
             axis = None
@@ -11196,7 +11205,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 "deprecated and will be removed in a future version. Use groupby "
                 "instead. df.median(level=1) should use df.groupby(level=1).median().",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             return self._agg_by_level(
                 name, axis=axis, level=level, skipna=skipna, numeric_only=numeric_only
@@ -11320,7 +11329,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 "deprecated and will be removed in a future version. Use groupby "
                 "instead. df.sum(level=1) should use df.groupby(level=1).sum().",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             return self._agg_by_level(
                 name,
@@ -11408,7 +11417,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             "The 'mad' method is deprecated and will be removed in a future version. "
             "To compute the same result, you may do `(df - df.mean()).abs().mean()`."
         )
-        warnings.warn(msg, FutureWarning, stacklevel=find_stack_level())
+        warnings.warn(
+            msg, FutureWarning, stacklevel=find_stack_level(inspect.currentframe())
+        )
 
         if not is_bool(skipna):
             warnings.warn(
@@ -11416,7 +11427,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 "version. Pass True instead. Only boolean values will be allowed "
                 "in the future.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             skipna = True
         if axis is None:
@@ -11427,7 +11438,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 "deprecated and will be removed in a future version. Use groupby "
                 "instead. df.mad(level=1) should use df.groupby(level=1).mad()",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             return self._agg_by_level("mad", axis=axis, level=level, skipna=skipna)
 
@@ -11874,7 +11885,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             warnings.warn(
                 "The `center` argument on `expanding` will be removed in the future.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         else:
             center = False

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from collections import abc
 from functools import partial
+import inspect
 from textwrap import dedent
 from typing import (
     TYPE_CHECKING,
@@ -1235,7 +1236,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                 "`.to_numpy()` to the result in the transform function to keep "
                 "the current behavior and silence this warning.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         concat_index = obj.columns if self.axis == 0 else obj.index
@@ -1405,7 +1406,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                 "Indexing with multiple keys (implicitly converted to a tuple "
                 "of keys) will be deprecated, use a list instead.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         return super().__getitem__(key)
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -833,7 +833,7 @@ class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
                     "to avoid this warning."
                 ),
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         return self.grouper.get_iterator(self._selected_obj, axis=self.axis)
 
@@ -1357,7 +1357,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                 f"numeric_only={numeric_only} and dtype {self.obj.dtype}. This will "
                 "raise a TypeError in a future version of pandas",
                 category=FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             raise NotImplementedError(
                 f"{type(self).__name__}.{how} does not implement numeric_only"
@@ -1619,7 +1619,9 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                 "To adopt the future behavior and silence this warning, use "
                 "\n\n\t>>> .groupby(..., group_keys=True)"
             )
-            warnings.warn(msg, FutureWarning, stacklevel=find_stack_level())
+            warnings.warn(
+                msg, FutureWarning, stacklevel=find_stack_level(inspect.currentframe())
+            )
             # We want to behave as if `self.group_keys=False` when reconstructing
             # the object. However, we don't want to mutate the stateful GroupBy
             # object, so we just override it.
@@ -2940,7 +2942,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             "pad is deprecated and will be removed in a future version. "
             "Use ffill instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.ffill(limit=limit)
 
@@ -2976,7 +2978,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             "backfill is deprecated and will be removed in a future version. "
             "Use bfill instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.bfill(limit=limit)
 
@@ -4362,7 +4364,7 @@ def warn_dropping_nuisance_columns_deprecated(cls, how: str, numeric_only) -> No
             f"Before calling .{how}, select only columns which "
             "should be valid for the function.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
     elif numeric_only is lib.no_default:
         warnings.warn(
@@ -4372,5 +4374,5 @@ def warn_dropping_nuisance_columns_deprecated(cls, how: str, numeric_only) -> No
             f"Either specify numeric_only or select only columns which "
             "should be valid for the function.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -4,6 +4,7 @@ split-apply-combine paradigm.
 """
 from __future__ import annotations
 
+import inspect
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -981,7 +982,7 @@ def _check_deprecated_resample_kwargs(kwargs, origin):
             "\nbecomes:\n"
             '\n>>> df.resample(freq="3s", offset="2s")\n',
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
     if kwargs.get("loffset", None) is not None:
         warnings.warn(
@@ -992,5 +993,5 @@ def _check_deprecated_resample_kwargs(kwargs, origin):
             '\n>>> df = df.resample(freq="3s").mean()'
             '\n>>> df.index = df.index.to_timestamp() + to_offset("8H")\n',
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1,6 +1,7 @@
 # pyright: reportUnusedImport = false
 from __future__ import annotations
 
+import inspect
 import warnings
 
 from pandas.util._exceptions import find_stack_level
@@ -31,7 +32,7 @@ warnings.warn(
     "pandas.core.index is deprecated and will be removed in a future version. "
     "The public classes are available in the top-level namespace.",
     FutureWarning,
-    stacklevel=find_stack_level(),
+    stacklevel=find_stack_level(inspect.currentframe()),
 )
 
 __all__: list[str] = []

--- a/pandas/core/indexers/utils.py
+++ b/pandas/core/indexers/utils.py
@@ -3,6 +3,7 @@ Low-dependency indexing utilities.
 """
 from __future__ import annotations
 
+import inspect
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -348,7 +349,7 @@ def deprecate_ndim_indexing(result, stacklevel: int = 3) -> None:
             "is deprecated and will be removed in a future "
             "version.  Convert to a numpy array before indexing instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
 
 
@@ -372,7 +373,7 @@ def unpack_1tuple(tup):
                 "slice is deprecated and will raise in a future "
                 "version.  Pass a tuple instead.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         return tup[0]

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -3,6 +3,7 @@ datetimelike delegation
 """
 from __future__ import annotations
 
+import inspect
 from typing import TYPE_CHECKING
 import warnings
 
@@ -291,7 +292,7 @@ class DatetimeProperties(Properties):
             "Series.dt.weekofyear and Series.dt.week have been deprecated. "
             "Please use Series.dt.isocalendar().week instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         week_series = self.isocalendar().week
         week_series.name = self.name

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 import functools
+import inspect
 from itertools import zip_longest
 import operator
 from typing import (
@@ -437,7 +438,7 @@ class Index(IndexOpsMixin, PandasObject):
                 "'tupleize_cols' is deprecated and will raise TypeError in a "
                 "future version.  Use the specific Index subclass directly instead.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         from pandas.core.arrays import PandasArray
@@ -615,7 +616,7 @@ class Index(IndexOpsMixin, PandasObject):
                     "dense numpy ndarray. To retain the old behavior, use "
                     "pd.Index(arr.to_numpy()) instead",
                     FutureWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
                 return cls._dtype_to_subclass(dtype.subtype)
 
@@ -683,7 +684,7 @@ class Index(IndexOpsMixin, PandasObject):
         warnings.warn(
             "Index.asi8 is deprecated and will be removed in a future version.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return None
 
@@ -797,7 +798,7 @@ class Index(IndexOpsMixin, PandasObject):
             "The Index._get_attributes_dict method is deprecated, and will be "
             "removed in a future version",
             DeprecationWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return {k: getattr(self, k, None) for k in self._attributes}
 
@@ -1000,7 +1001,7 @@ class Index(IndexOpsMixin, PandasObject):
             "Index.ravel returning ndarray is deprecated; in a future version "
             "this will return a view on self.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         if needs_i8_conversion(self.dtype):
             # Item "ndarray[Any, Any]" of "Union[ExtensionArray, ndarray[Any, Any]]"
@@ -1295,7 +1296,7 @@ class Index(IndexOpsMixin, PandasObject):
                 "parameter names is deprecated and will be removed in a future "
                 "version. Use the name parameter instead.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         name = self._validate_names(name=name, names=names, deep=deep)[0]
@@ -1310,7 +1311,7 @@ class Index(IndexOpsMixin, PandasObject):
                 "parameter dtype is deprecated and will be removed in a future "
                 "version. Use the astype method instead.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             new_index = new_index.astype(dtype)
         return new_index
@@ -1502,7 +1503,7 @@ class Index(IndexOpsMixin, PandasObject):
             "The 'to_native_types' method is deprecated and will be removed in "
             "a future version. Use 'astype(str)' instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         values = self
         if slicer is not None:
@@ -1703,7 +1704,7 @@ class Index(IndexOpsMixin, PandasObject):
                 "the future `None` will be used as the name of the resulting "
                 "DataFrame column.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             name = lib.no_default
 
@@ -2289,7 +2290,7 @@ class Index(IndexOpsMixin, PandasObject):
             "is_monotonic is deprecated and will be removed in a future version. "
             "Use is_monotonic_increasing instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.is_monotonic_increasing
 
@@ -2714,7 +2715,7 @@ class Index(IndexOpsMixin, PandasObject):
             "Index.is_mixed is deprecated and will be removed in a future version. "
             "Check index.inferred_type directly instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.inferred_type in ["mixed"]
 
@@ -2759,7 +2760,7 @@ class Index(IndexOpsMixin, PandasObject):
             "Index.is_all_dates is deprecated, will be removed in a future version. "
             "check index.inferred_type instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self._is_all_dates
 
@@ -3140,7 +3141,7 @@ class Index(IndexOpsMixin, PandasObject):
             "in the future this will be a logical operation matching "
             "Series.__and__.  Use index.intersection(other) instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.intersection(other)
 
@@ -3151,7 +3152,7 @@ class Index(IndexOpsMixin, PandasObject):
             "in the future this will be a logical operation matching "
             "Series.__or__.  Use index.union(other) instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.union(other)
 
@@ -3162,7 +3163,7 @@ class Index(IndexOpsMixin, PandasObject):
             "in the future this will be a logical operation matching "
             "Series.__xor__.  Use index.symmetric_difference(other) instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.symmetric_difference(other)
 
@@ -3218,7 +3219,7 @@ class Index(IndexOpsMixin, PandasObject):
                 "object dtype. To retain the old behavior, "
                 f"use `index.astype(object).{setop}(other)`",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
     @final
@@ -3794,7 +3795,7 @@ class Index(IndexOpsMixin, PandasObject):
             "and will raise in a future version. Use "
             "index.get_indexer([item], method=...) instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
 
         if is_scalar(key) and isna(key) and not self.hasnans:
@@ -4258,7 +4259,7 @@ class Index(IndexOpsMixin, PandasObject):
                         "lookups. To retain the old behavior, use `series.iloc[i:j]`. "
                         "To get the future behavior, use `series.loc[i:j]`.",
                         FutureWarning,
-                        stacklevel=find_stack_level(),
+                        stacklevel=find_stack_level(inspect.currentframe()),
                     )
             if self.is_integer() or is_index_slice:
                 # Note: these checks are redundant if we know is_index_slice
@@ -4292,7 +4293,7 @@ class Index(IndexOpsMixin, PandasObject):
                     "and will raise TypeError in a future version.  "
                     "Use .loc with labels or .iloc with positions instead.",
                     FutureWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
             indexer = key
         else:
@@ -4443,7 +4444,7 @@ class Index(IndexOpsMixin, PandasObject):
                         "reindexing with a non-unique Index is deprecated and "
                         "will raise in a future version.",
                         FutureWarning,
-                        stacklevel=find_stack_level(),
+                        stacklevel=find_stack_level(inspect.currentframe()),
                     )
 
         target = self._wrap_reindex_result(target, indexer, preserve_names)
@@ -5257,7 +5258,7 @@ class Index(IndexOpsMixin, PandasObject):
             "Index.is_type_compatible is deprecated and will be removed in a "
             "future version.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return kind == self.inferred_type
 
@@ -5904,7 +5905,7 @@ class Index(IndexOpsMixin, PandasObject):
             "get_value is deprecated and will be removed in a future version. "
             "Use Series[key] instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
 
         self._check_indexing_error(key)
@@ -5972,7 +5973,7 @@ class Index(IndexOpsMixin, PandasObject):
                 "will be removed in a future version."
             ),
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         loc = self._engine.get_loc(key)
         if not can_hold_element(arr, value):
@@ -7238,7 +7239,7 @@ class Index(IndexOpsMixin, PandasObject):
                 f"'{name}' argument in {methodname} is deprecated "
                 "and will be removed in a future version.  Do not pass it.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
 
@@ -7492,6 +7493,6 @@ def _maybe_try_sort(result, sort):
             warnings.warn(
                 f"{err}, sort order is undefined for incomparable objects.",
                 RuntimeWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
     return result

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from typing import (
     Any,
     Hashable,
@@ -224,7 +225,7 @@ class CategoricalIndex(NDArrayBackedExtensionIndex):
                 "deprecated and will raise in a future version. "
                 "Use CategoricalIndex([], ...) instead.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             data = []
 
@@ -419,7 +420,7 @@ class CategoricalIndex(NDArrayBackedExtensionIndex):
                     "reindexing with a non-unique Index is deprecated and will "
                     "raise in a future version.",
                     FutureWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
 
         new_target: Index
@@ -495,7 +496,7 @@ class CategoricalIndex(NDArrayBackedExtensionIndex):
             "CategoricalIndex.take_nd is deprecated, use CategoricalIndex.take "
             "instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.take(*args, **kwargs)
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -4,6 +4,7 @@ Base and utility classes for tseries type pandas objects.
 from __future__ import annotations
 
 from datetime import datetime
+import inspect
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -393,7 +394,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin):
             f"{type(self).__name__}.is_type_compatible is deprecated and will be "
             "removed in a future version.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return kind in self._data._infer_matches
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -7,6 +7,7 @@ from datetime import (
     timedelta,
     tzinfo,
 )
+import inspect
 import operator
 from typing import (
     TYPE_CHECKING,
@@ -423,7 +424,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
             "DatetimeIndex.union_many is deprecated and will be removed in "
             "a future version. Use obj.union instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
 
         this = self
@@ -547,7 +548,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
                     "is deprecated and will be removed in a future version. "
                     "You can stop passing 'keep_tz' to silence this warning.",
                     FutureWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
             else:
                 warnings.warn(
@@ -557,7 +558,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
                     "can do 'idx.tz_convert(None)' before calling "
                     "'to_series'.",
                     FutureWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
         else:
             keep_tz = True
@@ -660,7 +661,9 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
                     "raise KeyError in a future version. "
                     "Use a timezone-aware object instead."
                 )
-            warnings.warn(msg, FutureWarning, stacklevel=find_stack_level())
+            warnings.warn(
+                msg, FutureWarning, stacklevel=find_stack_level(inspect.currentframe())
+            )
 
     def get_loc(self, key, method=None, tolerance=None):
         """
@@ -809,7 +812,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
                 "with non-existing keys is deprecated and will raise a "
                 "KeyError in a future Version.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         indexer = mask.nonzero()[0][::step]
         if len(indexer) == len(self):
@@ -1089,7 +1092,7 @@ def date_range(
         warnings.warn(
             "Argument `closed` is deprecated in favor of `inclusive`.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         if closed is None:
             inclusive = "both"

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1,6 +1,7 @@
 """ define the IntervalIndex """
 from __future__ import annotations
 
+import inspect
 from operator import (
     le,
     lt,
@@ -242,7 +243,7 @@ class IntervalIndex(ExtensionIndex):
         warnings.warn(
             "Attribute `closed` is deprecated in favor of `inclusive`.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.inclusive
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from functools import wraps
+import inspect
 from sys import getsizeof
 from typing import (
     TYPE_CHECKING,
@@ -923,7 +924,7 @@ class MultiIndex(Index):
             warnings.warn(
                 "inplace is deprecated and will be removed in a future version.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         else:
             inplace = False
@@ -1084,7 +1085,7 @@ class MultiIndex(Index):
             warnings.warn(
                 "inplace is deprecated and will be removed in a future version.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         else:
             inplace = False
@@ -1197,7 +1198,7 @@ class MultiIndex(Index):
                 "parameter levels is deprecated and will be removed in a future "
                 "version. Use the set_levels method instead.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             keep_id = False
         if codes is not None:
@@ -1205,7 +1206,7 @@ class MultiIndex(Index):
                 "parameter codes is deprecated and will be removed in a future "
                 "version. Use the set_codes method instead.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             keep_id = False
 
@@ -1237,7 +1238,7 @@ class MultiIndex(Index):
                 "parameter dtype is deprecated and will be removed in a future "
                 "version. Use the astype method instead.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             new_index = new_index.astype(dtype)
         return new_index
@@ -1800,7 +1801,7 @@ class MultiIndex(Index):
                 "the future `None` will be used as the name of the resulting "
                 "DataFrame column.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             name = lib.no_default
 
@@ -1869,7 +1870,7 @@ class MultiIndex(Index):
             "MultiIndex.is_lexsorted is deprecated as a public function, "
             "users should use MultiIndex.is_monotonic_increasing instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self._is_lexsorted()
 
@@ -1913,7 +1914,7 @@ class MultiIndex(Index):
             "MultiIndex.is_lexsorted is deprecated as a public function, "
             "users should use MultiIndex.is_monotonic_increasing instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self._lexsort_depth
 
@@ -2279,7 +2280,7 @@ class MultiIndex(Index):
                             "dropping on a non-lexsorted multi-index "
                             "without a level parameter may impact performance.",
                             PerformanceWarning,
-                            stacklevel=find_stack_level(),
+                            stacklevel=find_stack_level(inspect.currentframe()),
                         )
                     loc = loc.nonzero()[0]
                     inds.extend(loc)
@@ -2955,7 +2956,7 @@ class MultiIndex(Index):
         warnings.warn(
             "indexing past lexsort depth may impact performance.",
             PerformanceWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
 
         loc = np.arange(start, stop, dtype=np.intp)
@@ -3394,7 +3395,7 @@ class MultiIndex(Index):
                                 # TODO: how to handle IntervalIndex level?
                                 #  (no test cases)
                                 FutureWarning,
-                                stacklevel=find_stack_level(),
+                                stacklevel=find_stack_level(inspect.currentframe()),
                             )
                             continue
                         else:

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from typing import (
     Callable,
     Hashable,
@@ -360,7 +361,7 @@ class IntegerIndex(NumericIndex):
         warnings.warn(
             "Index.asi8 is deprecated and will be removed in a future version.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self._values.view(self._default_dtype)
 

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -4,6 +4,7 @@ from datetime import (
     datetime,
     timedelta,
 )
+import inspect
 from typing import Hashable
 import warnings
 
@@ -366,7 +367,7 @@ class PeriodIndex(DatetimeIndexOpsMixin):
                 "will be removed in a future version. "
                 "Use index.to_timestamp(how=how) instead.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         else:
             how = "start"

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+import inspect
 import operator
 from sys import getsizeof
 from typing import (
@@ -263,7 +264,7 @@ class RangeIndex(NumericIndex):
         warnings.warn(
             self._deprecation_message.format("_start", "start"),
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.start
 
@@ -286,7 +287,7 @@ class RangeIndex(NumericIndex):
         warnings.warn(
             self._deprecation_message.format("_stop", "stop"),
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.stop
 
@@ -310,7 +311,7 @@ class RangeIndex(NumericIndex):
         warnings.warn(
             self._deprecation_message.format("_step", "step"),
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.step
 
@@ -471,7 +472,7 @@ class RangeIndex(NumericIndex):
                 "parameter dtype is deprecated and will be removed in a future "
                 "version. Use the astype method instead.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             new_index = new_index.astype(dtype)
         return new_index

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextlib import suppress
+import inspect
 from typing import (
     TYPE_CHECKING,
     Hashable,
@@ -1497,7 +1498,7 @@ class _iLocIndexer(_LocationIndexer):
                 "a future version.\n"
                 "consider using .loc with a DataFrame indexer for automatic alignment.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         if not isinstance(indexer, tuple):
@@ -2026,7 +2027,7 @@ class _iLocIndexer(_LocationIndexer):
                     "`df[df.columns[i]] = newvals` or, if columns are non-unique, "
                     "`df.isetitem(i, newvals)`",
                     FutureWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
                 # TODO: how to get future behavior?
                 # TODO: what if we got here indirectly via loc?
@@ -2502,7 +2503,7 @@ def convert_to_index_sliceable(obj: DataFrame, key):
                     "and will be removed in a future version. Use `frame.loc[string]` "
                     "instead.",
                     FutureWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
                 return res
             except (KeyError, ValueError, NotImplementedError):
@@ -2656,7 +2657,7 @@ def check_deprecated_indexers(key) -> None:
             "Passing a set as an indexer is deprecated and will raise in "
             "a future version. Use a list instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
     if (
         isinstance(key, dict)
@@ -2667,5 +2668,5 @@ def check_deprecated_indexers(key) -> None:
             "Passing a dict as an indexer is deprecated and will raise in "
             "a future version. Use a list instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )

--- a/pandas/core/internals/__init__.py
+++ b/pandas/core/internals/__init__.py
@@ -41,6 +41,7 @@ __all__ = [
 
 
 def __getattr__(name: str):
+    import inspect
     import warnings
 
     from pandas.util._exceptions import find_stack_level
@@ -50,7 +51,7 @@ def __getattr__(name: str):
             "CategoricalBlock is deprecated and will be removed in a future version. "
             "Use ExtensionBlock instead.",
             DeprecationWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         from pandas.core.internals.blocks import CategoricalBlock
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from functools import wraps
+import inspect
 import re
 from typing import (
     TYPE_CHECKING,
@@ -181,7 +182,7 @@ class Block(PandasObject):
             "future version.  Use isinstance(block.values, Categorical) "
             "instead. See https://github.com/pandas-dev/pandas/issues/40226",
             DeprecationWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return isinstance(self.values, Categorical)
 
@@ -252,7 +253,7 @@ class Block(PandasObject):
                     "already been cast to DatetimeArray and TimedeltaArray, "
                     "respectively.",
                     DeprecationWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
             values = new_values
 
@@ -1564,7 +1565,7 @@ class EABackedBlock(Block):
                     "(usually object) instead of raising, matching the "
                     "behavior of other dtypes.",
                     FutureWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
                 raise
             else:

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -5,6 +5,7 @@ constructors before passing them to a BlockManager.
 from __future__ import annotations
 
 from collections import abc
+import inspect
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -844,7 +845,7 @@ def to_arrays(
             "To retain the old behavior, pass as a dictionary "
             "DataFrame({col: categorical, ..})",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         if columns is None:
             columns = default_index(len(data))

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import itertools
 from typing import (
     Any,
@@ -909,7 +910,7 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
                         "will assume that a DatetimeTZBlock with block.ndim==2 "
                         "has block.values.ndim == 2.",
                         DeprecationWarning,
-                        stacklevel=find_stack_level(),
+                        stacklevel=find_stack_level(inspect.currentframe()),
                     )
 
                     # error: Incompatible types in assignment (expression has type
@@ -1248,7 +1249,7 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
                 "Consider joining all columns at once using pd.concat(axis=1) "
                 "instead. To get a de-fragmented frame, use `newframe = frame.copy()`",
                 PerformanceWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
     def _insert_update_mgr_locs(self, loc) -> None:
@@ -1707,7 +1708,7 @@ class SingleBlockManager(BaseBlockManager, SingleDataManager):
                 "The `fastpath` keyword is deprecated and will be removed "
                 "in a future version.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         self.axes = [axis]

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -5,6 +5,7 @@ This is not a public API.
 """
 from __future__ import annotations
 
+import inspect
 import operator
 from typing import TYPE_CHECKING
 import warnings
@@ -301,7 +302,7 @@ def align_method_FRAME(
                     "Do `left, right = left.align(right, axis=1, copy=False)` "
                     "before e.g. `left == right`",
                     FutureWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
 
         left, right = left.align(

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 from datetime import timedelta
+import inspect
 from textwrap import dedent
 from typing import (
     TYPE_CHECKING,
@@ -549,7 +550,7 @@ class Resampler(BaseGroupBy, PandasObject):
             "pad is deprecated and will be removed in a future version. "
             "Use ffill instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.ffill(limit=limit)
 
@@ -722,7 +723,7 @@ class Resampler(BaseGroupBy, PandasObject):
             "backfill is deprecated and will be removed in a future version. "
             "Use bfill instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.bfill(limit=limit)
 

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -4,6 +4,7 @@ Concat routines.
 from __future__ import annotations
 
 from collections import abc
+import inspect
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -552,7 +553,7 @@ class _Concatenator:
                 "Passing non boolean values for sort is deprecated and "
                 "will error in a future version!",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         self.sort = sort
 

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import re
 from typing import TYPE_CHECKING
 import warnings
@@ -59,7 +60,7 @@ def melt(
             "In the future this will raise an error, please set the 'value_name' "
             "parameter of DataFrame.melt to a unique name.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
 
     if id_vars is not None:

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -7,6 +7,7 @@ import copy
 import datetime
 from functools import partial
 import hashlib
+import inspect
 import string
 from typing import (
     TYPE_CHECKING,
@@ -678,7 +679,9 @@ class _MergeOperation:
             )
             # stacklevel chosen to be correct when this is reached via pd.merge
             # (and not DataFrame.join)
-            warnings.warn(msg, FutureWarning, stacklevel=find_stack_level())
+            warnings.warn(
+                msg, FutureWarning, stacklevel=find_stack_level(inspect.currentframe())
+            )
 
         self._validate_specification()
 
@@ -2369,7 +2372,7 @@ def _items_overlap_with_suffix(
             "unexpected results. Provide 'suffixes' as a tuple instead. In the "
             "future a 'TypeError' will be raised.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
 
     to_rename = left.intersection(right)
@@ -2419,7 +2422,7 @@ def _items_overlap_with_suffix(
             f"Passing 'suffixes' which cause duplicate columns {set(dups)} in the "
             f"result is deprecated and will raise a MergeError in a future version.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
 
     return llabels, rlabels

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3,6 +3,7 @@ Data structure for 1-dimensional cross-sectional and time series data
 """
 from __future__ import annotations
 
+import inspect
 from textwrap import dedent
 from typing import (
     IO,
@@ -389,7 +390,7 @@ class Series(base.IndexOpsMixin, NDFrame):
                     "of 'float64' in a future version. Specify a dtype explicitly "
                     "to silence this warning.",
                     FutureWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
                 # uncomment the line below when removing the FutureWarning
                 # dtype = np.dtype(object)
@@ -916,7 +917,7 @@ class Series(base.IndexOpsMixin, NDFrame):
                 "is_copy is deprecated and will be removed in a future version. "
                 "'take' always returns a copy, so there is no need to specify this.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         nv.validate_take((), kwargs)
 
@@ -1047,7 +1048,9 @@ class Series(base.IndexOpsMixin, NDFrame):
             #  see tests.series.timeseries.test_mpl_compat_hack
             # the asarray is needed to avoid returning a 2D DatetimeArray
             result = np.asarray(self._values[key])
-            deprecate_ndim_indexing(result, stacklevel=find_stack_level())
+            deprecate_ndim_indexing(
+                result, stacklevel=find_stack_level(inspect.currentframe())
+            )
             return result
 
         if not isinstance(self.index, MultiIndex):
@@ -1111,7 +1114,7 @@ class Series(base.IndexOpsMixin, NDFrame):
                         "Series. Use `series.iloc[an_int] = val` to treat the "
                         "key as positional.",
                         FutureWarning,
-                        stacklevel=find_stack_level(),
+                        stacklevel=find_stack_level(inspect.currentframe()),
                     )
                 # can't use _mgr.setitem_inplace yet bc could have *both*
                 #  KeyError and then ValueError, xref GH#45070
@@ -1797,7 +1800,7 @@ class Series(base.IndexOpsMixin, NDFrame):
             "iteritems is deprecated and will be removed in a future version. "
             "Use .items instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.items()
 
@@ -1880,7 +1883,7 @@ class Series(base.IndexOpsMixin, NDFrame):
                 "the future `None` will be used as the name of the resulting "
                 "DataFrame column.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             name = lib.no_default
 
@@ -2018,7 +2021,7 @@ Name: Max Speed, dtype: float64
                     "will be removed in a future version."
                 ),
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         else:
             squeeze = False
@@ -2078,7 +2081,7 @@ Name: Max Speed, dtype: float64
                 "deprecated and will be removed in a future version. Use groupby "
                 "instead. ser.count(level=1) should use ser.groupby(level=1).count().",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             if not isinstance(self.index, MultiIndex):
                 raise ValueError("Series.count level is only valid with a MultiIndex")
@@ -3076,7 +3079,7 @@ Name: Max Speed, dtype: float64
             "and will be removed from pandas in a future version. "
             "Use pandas.concat instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
 
         return self._append(to_append, ignore_index, verify_integrity)
@@ -4733,7 +4736,7 @@ Keep all original rows and also all original values
                     f"Calling Series.{name} with {kwd_name}={numeric_only} and "
                     f"dtype {self.dtype} will raise a TypeError in the future",
                     FutureWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
                 raise NotImplementedError(
                     f"Series.{name} does not implement {kwd_name}."
@@ -5611,7 +5614,7 @@ Keep all original rows and also all original values
                 "Boolean inputs to the `inclusive` argument are deprecated in "
                 "favour of `both` or `neither`.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             if inclusive:
                 inclusive = "both"

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import codecs
 from functools import wraps
+import inspect
 import re
 from typing import (
     TYPE_CHECKING,
@@ -242,7 +243,7 @@ class StringMethods(NoNewAttributesMixin):
         warnings.warn(
             "Columnar iteration over characters will be deprecated in future releases.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         i = 0
         g = self.get(i)
@@ -1244,7 +1245,7 @@ class StringMethods(NoNewAttributesMixin):
                 "This pattern is interpreted as a regular expression, and has "
                 "match groups. To actually get the groups, use str.extract.",
                 UserWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         result = self._data.array._str_contains(pat, case, flags, na, regex)
@@ -1456,7 +1457,11 @@ class StringMethods(NoNewAttributesMixin):
                         " In addition, single character regular expressions will "
                         "*not* be treated as literal strings when regex=True."
                     )
-                warnings.warn(msg, FutureWarning, stacklevel=find_stack_level())
+                warnings.warn(
+                    msg,
+                    FutureWarning,
+                    stacklevel=find_stack_level(inspect.currentframe()),
+                )
 
         # Check whether repl is valid (GH 13438, GH 15055)
         if not (isinstance(repl, str) or callable(repl)):

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import abc
 from datetime import datetime
 from functools import partial
+import inspect
 from itertools import islice
 from typing import (
     TYPE_CHECKING,
@@ -1284,7 +1285,7 @@ def to_time(arg, format=None, infer_time_format=False, errors="raise"):
         "`to_time` has been moved, should be imported from pandas.core.tools.times. "
         "This alias will be removed in a future version.",
         FutureWarning,
-        stacklevel=find_stack_level(),
+        stacklevel=find_stack_level(inspect.currentframe()),
     )
     from pandas.core.tools.times import to_time
 

--- a/pandas/core/window/common.py
+++ b/pandas/core/window/common.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+import inspect
 from typing import cast
 import warnings
 
@@ -203,5 +204,5 @@ def maybe_warn_args_and_kwargs(cls, kernel: str, args, kwargs) -> None:
             "no impact on the result and is deprecated. This will "
             "raise a TypeError in a future version of pandas.",
             category=FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 from functools import partial
+import inspect
 from textwrap import dedent
 from typing import (
     TYPE_CHECKING,
@@ -391,7 +392,7 @@ class ExponentialMovingWindow(BaseWindow):
                         "into times instead."
                     ),
                     FutureWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
                 # self.times cannot be str anymore
                 self.times = cast("Series", self._selected_obj[self.times])
@@ -683,7 +684,7 @@ class ExponentialMovingWindow(BaseWindow):
                 "Use std instead."
             ),
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.std(bias, *args, **kwargs)
 

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -171,7 +171,7 @@ class BaseWindow(SelectionMixin):
                 "win_type will no longer return 'freq' in a future version. "
                 "Check the type of self.window instead.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             return "freq"
         return self._win_type
@@ -181,7 +181,7 @@ class BaseWindow(SelectionMixin):
         warnings.warn(
             "is_datetimelike is deprecated and will be removed in a future version.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self._win_freq_i8 is not None
 
@@ -189,7 +189,7 @@ class BaseWindow(SelectionMixin):
         warnings.warn(
             "validate is deprecated and will be removed in a future version.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self._validate()
 
@@ -549,7 +549,7 @@ class BaseWindow(SelectionMixin):
                 "Select only valid columns before calling the operation. "
                 f"Dropped columns were {dropped}",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         return self._resolve_output(df, obj)
@@ -1967,7 +1967,7 @@ class Rolling(RollingAndExpandingMixin):
                     "Specify min_periods=0 instead."
                 ),
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             self.min_periods = 0
             result = super().count()

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -10,6 +10,7 @@ import codecs
 import dataclasses
 import functools
 import gzip
+import inspect
 from io import (
     BufferedIOBase,
     BytesIO,
@@ -322,7 +323,7 @@ def _get_filepath_or_buffer(
         warnings.warn(
             "compression has no effect when passing a non-binary object as input.",
             RuntimeWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         compression_method = None
 

--- a/pandas/io/date_converters.py
+++ b/pandas/io/date_converters.py
@@ -1,6 +1,7 @@
 """This module is designed for community supported date conversion functions"""
 from __future__ import annotations
 
+import inspect
 import warnings
 
 import numpy as np
@@ -22,7 +23,7 @@ def parse_date_time(date_col, time_col) -> npt.NDArray[np.object_]:
         Use pd.to_datetime(date_col + " " + time_col).to_pydatetime() instead to get a Numpy array.
 """,  # noqa: E501
         FutureWarning,
-        stacklevel=find_stack_level(),
+        stacklevel=find_stack_level(inspect.currentframe()),
     )
     date_col = _maybe_cast(date_col)
     time_col = _maybe_cast(time_col)
@@ -42,7 +43,7 @@ def parse_date_fields(year_col, month_col, day_col) -> npt.NDArray[np.object_]:
         np.array([s.to_pydatetime() for s in ser]) instead to get a Numpy array.
 """,  # noqa: E501
         FutureWarning,
-        stacklevel=find_stack_level(),
+        stacklevel=find_stack_level(inspect.currentframe()),
     )
 
     year_col = _maybe_cast(year_col)
@@ -69,7 +70,7 @@ def parse_all_fields(
         np.array([s.to_pydatetime() for s in ser]) instead to get a Numpy array.
 """,  # noqa: E501
         FutureWarning,
-        stacklevel=find_stack_level(),
+        stacklevel=find_stack_level(inspect.currentframe()),
     )
 
     year_col = _maybe_cast(year_col)
@@ -95,7 +96,7 @@ def generic_parser(parse_func, *cols) -> np.ndarray:
         Use pd.to_datetime instead.
 """,
         FutureWarning,
-        stacklevel=find_stack_level(),
+        stacklevel=find_stack_level(inspect.currentframe()),
     )
 
     N = _check_columns(cols)

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 import datetime
 from functools import partial
+import inspect
 from io import BytesIO
 import os
 from textwrap import fill
@@ -719,7 +720,7 @@ class BaseExcelReader(metaclass=abc.ABCMeta):
             warnings.warn(
                 "convert_float is deprecated and will be removed in a future version.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         validate_header_arg(header)
@@ -1122,7 +1123,7 @@ class ExcelWriter(metaclass=abc.ABCMeta):
             warnings.warn(
                 "Use of **kwargs is deprecated, use engine_kwargs instead.",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         # only switch class if generic(ExcelWriter)
@@ -1156,7 +1157,7 @@ class ExcelWriter(metaclass=abc.ABCMeta):
                         "deprecated and will also raise a warning, it can "
                         "be globally set and the warning suppressed.",
                         FutureWarning,
-                        stacklevel=find_stack_level(),
+                        stacklevel=find_stack_level(inspect.currentframe()),
                     )
 
             # for mypy
@@ -1326,7 +1327,7 @@ class ExcelWriter(metaclass=abc.ABCMeta):
             f"{attr} is not part of the public API, usage can give in unexpected "
             "results and will be removed in a future version",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
 
     @property

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 import copy
 from functools import partial
+import inspect
 import operator
 from typing import (
     Any,
@@ -443,7 +444,7 @@ class Styler(StylerRenderer):
         warnings.warn(
             "this method is deprecated in favour of `Styler.to_html()`",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         if sparse_index is None:
             sparse_index = get_option("styler.sparse.index")
@@ -2123,7 +2124,7 @@ class Styler(StylerRenderer):
         warnings.warn(
             "this method is deprecated in favour of `Styler.applymap()`",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
 
         if other is None:
@@ -2155,7 +2156,7 @@ class Styler(StylerRenderer):
         warnings.warn(
             "this method is deprecated in favour of `Styler.format(precision=..)`",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         self.precision = precision
         return self.format(precision=precision, na_rep=self.na_rep)
@@ -2667,7 +2668,7 @@ class Styler(StylerRenderer):
         warnings.warn(
             "this method is deprecated in favour of `Styler.format(na_rep=..)`",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         self.na_rep = na_rep
         return self.format(na_rep=na_rep, precision=self.precision)
@@ -2721,7 +2722,7 @@ class Styler(StylerRenderer):
         warnings.warn(
             'this method is deprecated in favour of `Styler.hide(axis="index")`',
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.hide(axis="index", level=level, subset=subset, names=names)
 
@@ -2774,7 +2775,7 @@ class Styler(StylerRenderer):
         warnings.warn(
             'this method is deprecated in favour of `Styler.hide(axis="columns")`',
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         return self.hide(axis="columns", level=level, subset=subset, names=names)
 
@@ -3381,7 +3382,7 @@ class Styler(StylerRenderer):
             warnings.warn(
                 "`null_color` is deprecated: use `color` instead",
                 FutureWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         if color is None and null_color == lib.no_default:

--- a/pandas/io/parsers/base_parser.py
+++ b/pandas/io/parsers/base_parser.py
@@ -5,6 +5,7 @@ from copy import copy
 import csv
 import datetime
 from enum import Enum
+import inspect
 import itertools
 from typing import (
     TYPE_CHECKING,
@@ -559,7 +560,7 @@ class ParserBase:
                             f"for column {c} - only the converter will be used."
                         ),
                         ParserWarning,
-                        stacklevel=find_stack_level(),
+                        stacklevel=find_stack_level(inspect.currentframe()),
                     )
 
                 try:
@@ -857,7 +858,7 @@ class ParserBase:
                 "Length of header or names does not match length of data. This leads "
                 "to a loss of data with index_col=False.",
                 ParserWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
     @overload

--- a/pandas/io/parsers/c_parser_wrapper.py
+++ b/pandas/io/parsers/c_parser_wrapper.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+import inspect
 from io import TextIOWrapper
 from typing import (
     TYPE_CHECKING,
@@ -421,7 +422,11 @@ def _concatenate_chunks(chunks: list[dict[int, ArrayLike]]) -> dict:
                 f"Specify dtype option on import or set low_memory=False."
             ]
         )
-        warnings.warn(warning_message, DtypeWarning, stacklevel=find_stack_level())
+        warnings.warn(
+            warning_message,
+            DtypeWarning,
+            stacklevel=find_stack_level(inspect.currentframe()),
+        )
     return result
 
 

--- a/pandas/io/parsers/python_parser.py
+++ b/pandas/io/parsers/python_parser.py
@@ -5,6 +5,7 @@ from collections import (
     defaultdict,
 )
 import csv
+import inspect
 from io import StringIO
 import re
 import sys
@@ -599,7 +600,7 @@ class PythonParser(ParserBase):
                         "Defining usecols with out of bounds indices is deprecated "
                         "and will raise a ParserError in a future version.",
                         FutureWarning,
-                        stacklevel=find_stack_level(),
+                        stacklevel=find_stack_level(inspect.currentframe()),
                     )
                 col_indices = self.usecols
 

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from collections import abc
 import csv
+import inspect
 import sys
 from textwrap import fill
 from typing import (
@@ -1609,7 +1610,7 @@ class TextFileReader(abc.Iterator):
                     "engine='python'."
                 ),
                 ParserWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
 
         index_col = options["index_col"]
@@ -1628,7 +1629,11 @@ class TextFileReader(abc.Iterator):
                     f"The {arg} argument has been deprecated and will be "
                     f"removed in a future version. {depr_default.msg}\n\n"
                 )
-                warnings.warn(msg, FutureWarning, stacklevel=find_stack_level())
+                warnings.warn(
+                    msg,
+                    FutureWarning,
+                    stacklevel=find_stack_level(inspect.currentframe()),
+                )
             else:
                 result[arg] = parser_default
 
@@ -2203,7 +2208,9 @@ def _merge_with_dialect_properties(
 
         if conflict_msgs:
             warnings.warn(
-                "\n\n".join(conflict_msgs), ParserWarning, stacklevel=find_stack_level()
+                "\n\n".join(conflict_msgs),
+                ParserWarning,
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
         kwds[param] = dialect_val
     return kwds

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -10,6 +10,7 @@ from datetime import (
     date,
     tzinfo,
 )
+import inspect
 import itertools
 import os
 import re
@@ -686,7 +687,7 @@ class HDFStore:
             "iteritems is deprecated and will be removed in a future version. "
             "Use .items instead.",
             FutureWarning,
-            stacklevel=find_stack_level(),
+            stacklevel=find_stack_level(inspect.currentframe()),
         )
         yield from self.items()
 
@@ -2195,7 +2196,9 @@ class IndexCol:
                 if key in ["freq", "index_name"]:
                     ws = attribute_conflict_doc % (key, existing_value, value)
                     warnings.warn(
-                        ws, AttributeConflictWarning, stacklevel=find_stack_level()
+                        ws,
+                        AttributeConflictWarning,
+                        stacklevel=find_stack_level(inspect.currentframe()),
                     )
 
                     # reset
@@ -3093,7 +3096,11 @@ class GenericFixed(Fixed):
                 pass
             else:
                 ws = performance_doc % (inferred_type, key, items)
-                warnings.warn(ws, PerformanceWarning, stacklevel=find_stack_level())
+                warnings.warn(
+                    ws,
+                    PerformanceWarning,
+                    stacklevel=find_stack_level(inspect.currentframe()),
+                )
 
             vlarr = self._handle.create_vlarray(self.group, key, _tables().ObjectAtom())
             vlarr.append(value)

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -12,6 +12,7 @@ from datetime import (
     time,
 )
 from functools import partial
+import inspect
 import re
 from typing import (
     TYPE_CHECKING,
@@ -1193,7 +1194,7 @@ class SQLTable(PandasObject):
                 "the 'timedelta' type is not supported, and will be "
                 "written as integer values (ns frequency) to the database.",
                 UserWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             return BigInteger
         elif col_type == "floating":
@@ -1962,7 +1963,7 @@ class SQLiteTable(SQLTable):
                 "the 'timedelta' type is not supported, and will be "
                 "written as integer values (ns frequency) to the database.",
                 UserWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             col_type = "integer"
 

--- a/pandas/plotting/_matplotlib/tools.py
+++ b/pandas/plotting/_matplotlib/tools.py
@@ -1,6 +1,7 @@
 # being a bit too dynamic
 from __future__ import annotations
 
+import inspect
 from math import ceil
 from typing import (
     TYPE_CHECKING,
@@ -239,7 +240,7 @@ def create_subplots(
                     "When passing multiple axes, sharex and sharey "
                     "are ignored. These settings must be specified when creating axes.",
                     UserWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
             if ax.size == naxes:
                 fig = ax.flat[0].get_figure()
@@ -262,7 +263,7 @@ def create_subplots(
                 "To output multiple subplots, the figure containing "
                 "the passed axes is being cleared.",
                 UserWarning,
-                stacklevel=find_stack_level(),
+                stacklevel=find_stack_level(inspect.currentframe()),
             )
             fig.clear()
 

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import warnings
 
 import numpy as np
@@ -116,7 +117,7 @@ def get_offset(name: str) -> BaseOffset:
         "get_offset is deprecated and will be removed in a future version, "
         "use to_offset instead.",
         FutureWarning,
-        stacklevel=find_stack_level(),
+        stacklevel=find_stack_level(inspect.currentframe()),
     )
     return _get_offset(name)
 

--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -312,7 +312,7 @@ def deprecate_nonkeyword_arguments(
                 warnings.warn(
                     msg.format(arguments=arguments),
                     FutureWarning,
-                    stacklevel=find_stack_level(),
+                    stacklevel=find_stack_level(inspect.currentframe()),
                 )
             return func(*args, **kwargs)
 

--- a/pandas/util/_exceptions.py
+++ b/pandas/util/_exceptions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import functools
 import inspect
 import os
 from typing import Iterator
@@ -25,10 +26,16 @@ def rewrite_exception(old_name: str, new_name: str) -> Iterator[None]:
         raise
 
 
-def find_stack_level() -> int:
+@functools.lru_cache
+def find_stack_level(frame) -> int:
     """
     Find the first place in the stack that is not inside pandas
     (tests notwithstanding).
+
+    ``frame`` should be passed as ``inspect.currentframe()`` by the
+    calling function.
+
+    https://stackoverflow.com/questions/17407119/python-inspect-stack-is-slow
     """
 
     import pandas as pd
@@ -36,9 +43,7 @@ def find_stack_level() -> int:
     pkg_dir = os.path.dirname(pd.__file__)
     test_dir = os.path.join(pkg_dir, "tests")
 
-    # https://stackoverflow.com/questions/17407119/python-inspect-stack-is-slow
-    frame = inspect.currentframe()
-    n = 0
+    n = 1
     while frame:
         fname = inspect.getfile(frame)
         if fname.startswith(pkg_dir) and not fname.startswith(test_dir):

--- a/pandas/util/_validators.py
+++ b/pandas/util/_validators.py
@@ -4,6 +4,7 @@ for validating data or function arguments
 """
 from __future__ import annotations
 
+import inspect
 from typing import (
     Any,
     Iterable,
@@ -355,7 +356,9 @@ def validate_axis_style_args(
             "positional arguments for 'index' or 'columns' will raise "
             "a 'TypeError'."
         )
-        warnings.warn(msg, FutureWarning, stacklevel=find_stack_level())
+        warnings.warn(
+            msg, FutureWarning, stacklevel=find_stack_level(inspect.currentframe())
+        )
         out[data._get_axis_name(0)] = args[0]
         out[data._get_axis_name(1)] = args[1]
     else:

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1,3 +1,4 @@
+import inspect
 import warnings
 
 from pandas.util._exceptions import find_stack_level
@@ -10,5 +11,5 @@ warnings.warn(
         "public API at pandas.testing instead."
     ),
     FutureWarning,
-    stacklevel=find_stack_level(),
+    stacklevel=find_stack_level(inspect.currentframe()),
 )


### PR DESCRIPTION
This would be a precursor to #47998 and #47828. If repeatedly calling `find_stack_level`, then performance takes a hit

Demo of impact: if we run the file
```python
import cProfile
import pstats, cProfile

import re
import pandas as pd

data = pd.date_range('1990', '2000').strftime('%d/%m/%Y').tolist()

def fun():
    pd.to_datetime(data, dayfirst=False)

cProfile.runctx("fun()", globals(), locals(), "Profile.prof")

s = pstats.Stats("Profile.prof")
s.strip_dirs().sort_stats("time").print_stats()
```


On main:
```
#         1199 function calls (1187 primitive calls) in 0.046 seconds
#
#   Ordered by: internal time
#
#   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
#        1    0.034    0.034    0.035    0.035 {built-in method pandas._libs.tslib.array_to_datetime}
#      262    0.001    0.000    0.001    0.000 {built-in method builtins.isinstance}
#      2/1    0.000    0.000    0.006    0.006 series.py:342(__init__)
#        2    0.000    0.000    0.000    0.000 {built-in method numpy.array}
#        1    0.000    0.000    0.046    0.046 {built-in method builtins.exec}
#        1    0.000    0.000    0.001    0.001 sre_parse.py:493(_parse)
#        1    0.000    0.000    0.046    0.046 datetimes.py:702(to_datetime)
#      2/1    0.000    0.000    0.000    0.000 sre_compile.py:71(_compile)
#      2/1    0.000    0.000    0.001    0.001 base.py:431(__new__)
#        2    0.000    0.000    0.000    0.000 {pandas._libs.lib.maybe_convert_objects}
```

Using find_stack_level in
https://github.com/pandas-dev/pandas/blob/6db95e79297a4dcefff53ca151324949b0c956c3/pandas/_libs/tslibs/parsing.pyx#L217
and
https://github.com/pandas-dev/pandas/blob/6db95e79297a4dcefff53ca151324949b0c956c3/pandas/_libs/tslibs/parsing.pyx#L225
```
#         224611 function calls (224599 primitive calls) in 0.582 seconds
#
#   Ordered by: internal time
#
#   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
#    11060    0.106    0.000    0.342    0.000 inspect.py:655(getfile)
#    82106    0.081    0.000    0.082    0.000 {built-in method builtins.isinstance}
#     2212    0.063    0.000    0.517    0.000 _exceptions.py:30(find_stack_level)
#        1    0.045    0.045    0.572    0.572 {built-in method pandas._libs.tslib.array_to_datetime}
#    22128    0.027    0.000    0.027    0.000 {method 'startswith' of 'str' objects}
#    11060    0.023    0.000    0.035    0.000 inspect.py:64(ismodule)
#    11060    0.023    0.000    0.034    0.000 inspect.py:81(ismethod)
#    11060    0.023    0.000    0.033    0.000 inspect.py:261(iscode)
#    11060    0.023    0.000    0.034    0.000 inspect.py:237(istraceback)
#    11060    0.023    0.000    0.034    0.000 inspect.py:159(isfunction)
```

Using find_stack_level in the same places as above, but with caching (as in this branch):
```
#         7916 function calls (7904 primitive calls) in 0.065 seconds
#
#   Ordered by: internal time
#
#   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
#        1    0.031    0.031    0.056    0.056 {built-in method pandas._libs.tslib.array_to_datetime}
#     2212    0.018    0.000    0.024    0.000 inspect.py:1546(currentframe)
#     2231    0.003    0.000    0.003    0.000 {built-in method builtins.hasattr}
#     2212    0.003    0.000    0.003    0.000 {built-in method sys._getframe}
#      292    0.001    0.000    0.001    0.000 {built-in method builtins.isinstance}
#        1    0.000    0.000    0.065    0.065 {built-in method builtins.exec}
#      2/1    0.000    0.000    0.005    0.005 series.py:342(__init__)
#        1    0.000    0.000    0.001    0.001 sre_parse.py:493(_parse)
#        2    0.000    0.000    0.000    0.000 {built-in method numpy.array}
#    49/41    0.000    0.000    0.000    0.000 {built-in method builtins.len}
```