### PR TITLE
TST: catch some test warnings

### DIFF
--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1583,7 +1583,7 @@ def test_apply_on_empty_dataframe():
     # GH 39111
     df = DataFrame({"a": [1, 2], "b": [3, 0]})
     result = df.head(0).apply(lambda x: max(x["a"], x["b"]), axis=1)
-    expected = Series([])
+    expected = Series([], dtype=np.float64)
     tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/series/methods/test_fillna.py
+++ b/pandas/tests/series/methods/test_fillna.py
@@ -152,14 +152,16 @@ class TestSeriesFillNA:
         tm.assert_series_equal(result, expected)
 
         # where (we ignore the errors=)
-        result = ser.where(
-            [True, False], Timestamp("20130101", tz="US/Eastern"), errors="ignore"
-        )
+        with tm.assert_produces_warning(FutureWarning, match="the 'errors' keyword"):
+            result = ser.where(
+                [True, False], Timestamp("20130101", tz="US/Eastern"), errors="ignore"
+            )
         tm.assert_series_equal(result, expected)
 
-        result = ser.where(
-            [True, False], Timestamp("20130101", tz="US/Eastern"), errors="ignore"
-        )
+        with tm.assert_produces_warning(FutureWarning, match="the 'errors' keyword"):
+            result = ser.where(
+                [True, False], Timestamp("20130101", tz="US/Eastern"), errors="ignore"
+            )
         tm.assert_series_equal(result, expected)
 
         # with a non-datetime

--- a/pandas/tests/series/test_ufunc.py
+++ b/pandas/tests/series/test_ufunc.py
@@ -434,11 +434,11 @@ def test_object_dtype_ok():
 
 def test_outer():
     # https://github.com/pandas-dev/pandas/issues/27186
-    s = pd.Series([1, 2, 3])
-    o = np.array([1, 2, 3])
+    ser = pd.Series([1, 2, 3])
+    obj = np.array([1, 2, 3])
 
     with pytest.raises(NotImplementedError, match=tm.EMPTY_STRING_PATTERN):
-        np.subtract.outer(s, o)
+        np.subtract.outer(ser, obj)
 
 
 def test_np_matmul():
@@ -446,7 +446,10 @@ def test_np_matmul():
     df1 = pd.DataFrame(data=[[-1, 1, 10]])
     df2 = pd.DataFrame(data=[-1, 1, 10])
     expected_result = pd.DataFrame(data=[102])
+
+    with tm.assert_produces_warning(FutureWarning, match="on non-aligned"):
+        result = np.matmul(df1, df2)
     tm.assert_frame_equal(
         expected_result,
-        np.matmul(df1, df2),
+        result,
     )

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -184,10 +184,12 @@ def test_series_equal_index_mismatch(check_index):
 
 
 def test_series_invalid_param_combination():
+    left = Series(dtype=object)
+    right = Series(dtype=object)
     with pytest.raises(
         ValueError, match="check_like must be False if check_index is False"
     ):
-        tm.assert_series_equal(Series(), Series(), check_index=False, check_like=True)
+        tm.assert_series_equal(left, right, check_index=False, check_like=True)
 
 
 def test_series_equal_length_mismatch(rtol):

--- a/pandas/tests/window/moments/test_moments_consistency_ewm.py
+++ b/pandas/tests/window/moments/test_moments_consistency_ewm.py
@@ -220,9 +220,10 @@ def test_ewm_consistency_series_cov_corr(
 
     # check that corr(x, y) == cov(x, y) / (std(x) *
     # std(y))
-    corr_x_y = series_data.ewm(
-        com=com, min_periods=min_periods, adjust=adjust, ignore_na=ignore_na
-    ).corr(series_data, bias=bias)
+    with tm.assert_produces_warning(FutureWarning, match="Passing additional kwargs"):
+        corr_x_y = series_data.ewm(
+            com=com, min_periods=min_periods, adjust=adjust, ignore_na=ignore_na
+        ).corr(series_data, bias=bias)
     std_x = series_data.ewm(
         com=com, min_periods=min_periods, adjust=adjust, ignore_na=ignore_na
     ).std(bias=bias)


### PR DESCRIPTION
I get a hundred and change warnings locally when I run the test suite, am surprised the npdev build isn't failing on these.  This gets a handful of them.