### PR TITLE
ENH: raise_assert_detail only shows the difference between the columns

### DIFF
--- a/pandas/_libs/testing.pyi
+++ b/pandas/_libs/testing.pyi
@@ -9,4 +9,5 @@ def assert_almost_equal(
     lobj=...,
     robj=...,
     index_values=...,
+    show_diff_only=...,
 ): ...

--- a/pandas/_libs/testing.pyx
+++ b/pandas/_libs/testing.pyx
@@ -52,7 +52,8 @@ cpdef assert_dict_equal(a, b, bint compare_keys=True):
 cpdef assert_almost_equal(a, b,
                           rtol=1.e-5, atol=1.e-8,
                           bint check_dtype=True,
-                          obj=None, lobj=None, robj=None, index_values=None):
+                          obj=None, lobj=None, robj=None, index_values=None,
+                          show_diff_only=False):
     """
     Check that left and right objects are almost equal.
 
@@ -164,7 +165,7 @@ cpdef assert_almost_equal(a, b,
             from pandas._testing import raise_assert_detail
             msg = (f"{obj} values are different "
                    f"({np.round(diff * 100.0 / na, 5)} %)")
-            raise_assert_detail(obj, msg, lobj, robj, index_values=index_values)
+            raise_assert_detail(obj, msg, lobj, robj, index_values=index_values,show_diff_only=show_diff_only)
 
         return True
 

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+
+from numpy import ones
 import pytest
 
 import pandas as pd
@@ -262,6 +265,24 @@ def test_assert_frame_equal_interval_dtype_mismatch():
 
     with pytest.raises(AssertionError, match=msg):
         tm.assert_frame_equal(left, right, check_dtype=True)
+
+
+def test_assert_frame_equal_show_diff_only():
+    msg = (
+        'DataFrame.iloc\\[:, 0\\] \\(column name="a"\\) are different\n\n'
+        'DataFrame.iloc\\[:, 0\\] \\(column name="a"\\) '
+        "values are different \\(0.27397 \\%\\)\n"
+        "            left  right\n1970-12-31   1.0    0.0"
+    )
+    df1 = DataFrame(
+        ones((365, 3)),
+        index=pd.date_range(datetime(1970, 1, 1), datetime(1970, 12, 31)),
+        columns=["a", "b", "c"],
+    )
+    df2 = df1.copy(deep=True)
+    df2.iloc[-1, 0] = 0
+    with pytest.raises(AssertionError, match=msg):
+        tm.assert_frame_equal(df1, df2, show_diff_only=True)
 
 
 @pytest.mark.parametrize("right_dtype", ["Int32", "int64"])

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from numpy import ones
 import pytest
 
@@ -272,11 +270,10 @@ def test_assert_frame_equal_show_diff_only():
         'DataFrame.iloc\\[:, 0\\] \\(column name="a"\\) are different\n\n'
         'DataFrame.iloc\\[:, 0\\] \\(column name="a"\\) '
         "values are different \\(0.27397 \\%\\)\n"
-        "            left  right\n1970-12-31   1.0    0.0"
+        "     left  right\n364   1.0    0.0"
     )
     df1 = DataFrame(
         ones((365, 3)),
-        index=pd.date_range(datetime(1970, 1, 1), datetime(1970, 12, 31)),
         columns=["a", "b", "c"],
     )
     df2 = df1.copy(deep=True)


### PR DESCRIPTION
- [x] closes #47910 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature. The change is super small so I figured it didn't really make sense to add it to the `whatsnew` section but if I should still do this please let me know 

I didn't receive feedback on whether or not it was okay to make this the default behavior but doing so minimizes the code impact and is a reasonable default in my opinion so I'm submitting it like this. If this needs to e changed feel free to let me know. 