### PR TITLE
REGR: groupby sum causing overflow for int8

### DIFF
--- a/pandas/_libs/groupby.pyi
+++ b/pandas/_libs/groupby.pyi
@@ -51,7 +51,7 @@ def group_any_all(
     skipna: bool,
 ) -> None: ...
 def group_sum(
-    out: np.ndarray,  # complexfloatingintuint_t[:, ::1]
+    out: np.ndarray,  # complexfloatingint64uint64_t[:, ::1]
     counts: np.ndarray,  # int64_t[::1]
     values: np.ndarray,  # ndarray[complexfloatingintuint_t, ndim=2]
     labels: np.ndarray,  # const intp_t[:]

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -293,6 +293,11 @@ class WrappedCythonOp:
 
         if how == "rank":
             out_dtype = "float64"
+        elif how == "sum" and is_integer_dtype(dtype):
+            if dtype.kind == "i":
+                out_dtype = "int64"
+            else:
+                out_dtype = "uint64"
         else:
             if is_numeric_dtype(dtype):
                 out_dtype = f"{dtype.kind}{dtype.itemsize}"

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -296,8 +296,8 @@ class WrappedCythonOp:
 
         if how == "rank":
             out_dtype = "float64"
-        # elif how == "sum" and is_integer_dtype(dtype):
-        #     out_dtype = f"{dtype.kind}8"
+        elif how == "sum" and is_integer_dtype(dtype):
+            out_dtype = f"{dtype.kind}8"
         else:
             if is_numeric_dtype(dtype):
                 out_dtype = f"{dtype.kind}{dtype.itemsize}"

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -183,7 +183,10 @@ class WrappedCythonOp:
                     f"function is not implemented for this dtype: "
                     f"[how->{how},dtype->{dtype_str}]"
                 )
-            elif "object" not in f.__signatures__:
+            elif (
+                "object" not in f.__signatures__
+                and "object|object" not in f.__signatures__
+            ):
                 # raise NotImplementedError here rather than TypeError later
                 raise NotImplementedError(
                     f"function is not implemented for this dtype: "
@@ -293,11 +296,8 @@ class WrappedCythonOp:
 
         if how == "rank":
             out_dtype = "float64"
-        elif how == "sum" and is_integer_dtype(dtype):
-            if dtype.kind == "i":
-                out_dtype = "int64"
-            else:
-                out_dtype = "uint64"
+        # elif how == "sum" and is_integer_dtype(dtype):
+        #     out_dtype = f"{dtype.kind}8"
         else:
             if is_numeric_dtype(dtype):
                 out_dtype = f"{dtype.kind}{dtype.itemsize}"

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2829,3 +2829,11 @@ def test_groupby_sum_support_mask(any_numeric_ea_dtype):
         dtype=any_numeric_ea_dtype,
     )
     tm.assert_frame_equal(result, expected)
+
+
+def test_groupby_sum_int8_overflow():
+    # GH#37493
+    df = DataFrame({"a": [1, 2, 2], "b": [125, 111, 111]}, dtype="int8")
+    result = df.groupby("a").sum()
+    expected = DataFrame({"b": [125, 222]}, index=Index([1, 2], name="a"))
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
This fixes the regression from #48018


BUT: Handling this on the cython level like this is really ugly... and will blow up our wheel size if we introduce this everywhere, but I could not find a way to restrict the compile combinations.

If there is no better way of handling this on the cython level I would propose casting values to int64/uint64 before calling the group_sum function. This would introduce an unnecessary cast and reduce performance, hence why I was looking for a solution on the cython level.


cc @jorisvandenbossche cc @mroeschke 