### PR TITLE
WEB: Update list of maintainers and improve inactive maintainers format

### DIFF
--- a/web/pandas/about/team.md
+++ b/web/pandas/about/team.md
@@ -6,10 +6,10 @@ _pandas_ is made with love by more than [2,000 volunteer contributors](https://g
 
 If you want to support pandas development, you can find information in the [donations page](../donate.html).
 
-## Maintainers
+## Active maintainers
 
 <div class="card-group maintainers">
-    {% for person in maintainers.people %}
+    {% for person in maintainers.active_with_github_info %}
         <div class="card">
             <img class="card-img-top" alt="" src="{{ person.avatar_url }}"/>
             <div class="card-body">
@@ -60,10 +60,14 @@ The project governance is available in the [project governance page](governance.
     {% endfor %}
 </ul>
 
-## Emeritus maintainers
+## Inactive maintainers
 
 <ul>
-    {% for person in maintainers.emeritus %}
-        <li>{{ person }}</li>
+    {% for person in maintainers.inactive_with_github_info %}
+        <li>
+            <a href="{{ person.blog or person.html_url }}">
+                {{ person.name or person.login }}
+            </a>
+        </li>
     {% endfor %}
 </ul>

--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -68,13 +68,10 @@ maintainers:
   - wesm
   - jorisvandenbossche
   - TomAugspurger
-  - shoyer
   - jreback
-  - chris-b1
   - sinhrks
   - cpcloud
   - gfyoung
-  - toobaz
   - WillAyd
   - mroeschke
   - jschendel
@@ -93,10 +90,15 @@ maintainers:
   - attack68
   - fangchenli
   - twoertwein
-  emeritus:
-  - Wouter Overmeire
-  - Skipper Seabold
-  - Jeff Tratner
+  - lithomas1
+  - mzeitlin11
+  inactive:
+  - lodagro
+  - jseabold
+  - jtratner
+  - shoyer
+  - chris-b1
+  - toobaz
   coc:
   - Safia Abdalla
   - Tom Augspurger

--- a/web/pandas_web.py
+++ b/web/pandas_web.py
@@ -148,8 +148,9 @@ class Preprocessors:
         Given the active maintainers defined in the yaml file, it fetches
         the GitHub user information for them.
         """
-        repeated = (set(context["maintainers"]["active"])
-                    & set(context["maintainers"]["inactive"]))
+        repeated = set(context["maintainers"]["active"]) & set(
+            context["maintainers"]["inactive"]
+        )
         if repeated:
             raise ValueError(f"Maintainers {repeated} are both active and inactive")
 

--- a/web/pandas_web.py
+++ b/web/pandas_web.py
@@ -148,13 +148,19 @@ class Preprocessors:
         Given the active maintainers defined in the yaml file, it fetches
         the GitHub user information for them.
         """
-        context["maintainers"]["people"] = []
-        for user in context["maintainers"]["active"]:
-            resp = requests.get(f"https://api.github.com/users/{user}")
-            if context["ignore_io_errors"] and resp.status_code == 403:
-                return context
-            resp.raise_for_status()
-            context["maintainers"]["people"].append(resp.json())
+        repeated = (set(context["maintainers"]["active"])
+                    & set(context["maintainers"]["inactive"]))
+        if repeated:
+            raise ValueError(f"Maintainers {repeated} are both active and inactive")
+
+        for kind in ("active", "inactive"):
+            context["maintainers"][f"{kind}_with_github_info"] = []
+            for user in context["maintainers"][kind]:
+                resp = requests.get(f"https://api.github.com/users/{user}")
+                if context["ignore_io_errors"] and resp.status_code == 403:
+                    return context
+                resp.raise_for_status()
+                context["maintainers"][f"{kind}_with_github_info"].append(resp.json())
         return context
 
     @staticmethod


### PR DESCRIPTION
- Adding @lithomas1 and @mzeitlin11 to the maintainers list in the website (sorry it wasn't done when you were promoted)
- Moving @shoyer, @chris-b1 and @toobaz to inactive, renaming the section "Inactive maintainers", and using the same logic to display the names with links as we have for active maintainers
