### PR TITLE
DOC: add source link to properties

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -653,12 +653,20 @@ def linkcode_resolve(domain, info):
     try:
         fn = inspect.getsourcefile(inspect.unwrap(obj))
     except TypeError:
-        fn = None
+        try:  # property
+            fn = inspect.getsourcefile(inspect.unwrap(obj.fget))
+        except (AttributeError, TypeError):
+            fn = None
     if not fn:
         return None
 
     try:
         source, lineno = inspect.getsourcelines(obj)
+    except TypeError:
+        try:  # property
+            source, lineno = inspect.getsourcelines(obj.fget)
+        except (AttributeError, TypeError):
+            lineno = None
     except OSError:
         lineno = None
 


### PR DESCRIPTION
The current version of `linkcode_resolve` is unable to handle properties and ignore them. Hence there are no links to the source code for properties unlike for everything else. This add support to properties I did in https://github.com/geopandas/geopandas/pull/2526#issuecomment-1212926545 which is based on pandas code, so I thought it is worth contributing the enhancement back.