### PR TITLE
DEV: add gitpod actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,61 @@
+name: Build Base Docker Image
+
+# schedule the base docker build on any change of the environment file in the main branch, or
+# at least once monthly, to catch ubuntu security updates
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'environment.yml'
+  schedule:
+    - cron: "0 0 1 * *" # monthly
+
+jobs:
+  build:
+    name: Build base Docker image
+    runs-on: ubuntu-latest
+    environment: pandas-dev
+    if: "github.repository_owner == 'pandas-dev' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Lint Docker
+        uses: brpaz/hadolint-action@v2
+        with:
+          dockerfile: ./tools/gitpod/Dockerfile
+      - name: Get refs
+        shell: bash
+        run: |
+          export raw_branch=${GITHUB_REF#refs/heads/}
+          echo "::set-output name=branch::${raw_branch//\//-}"
+          echo "::set-output name=date::$(date +'%Y%m%d')"
+          echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+        id: getrefs
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v3
+        with:
+          context: "."
+          file: "./tools/gitpod/Dockerfile"
+          push: ${{ github.event_name != 'pull_request' }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          tags: |
+            pandas/pandas-dev:${{ steps.getrefs.outputs.date }}-${{ steps.getrefs.outputs.branch}}-${{ steps.getrefs.outputs.sha8 }}, pandas/pandas-dev:latest
+      - name: Image digest
+        # Return details of the image build: sha and shell
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/gitpod.yml
+++ b/.github/workflows/gitpod.yml
@@ -1,0 +1,57 @@
+name: Build Gitpod Docker image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build Gitpod Docker image
+    runs-on: ubuntu-latest
+    environment: pandas-dev
+    if: "github.repository_owner == 'pandas-dev' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Lint Docker
+        uses: brpaz/hadolint-action@v2
+        with:
+          dockerfile: ./tools/gitpod/gitpod.Dockerfile
+      - name: Get refs
+        shell: bash
+        run: |
+          export raw_branch=${GITHUB_REF#refs/heads/}
+          echo "::set-output name=branch::${raw_branch//\//-}"
+          echo "::set-output name=date::$(date +'%Y%m%d')"
+          echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+        id: getrefs
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v3
+        with:
+          context: "."
+          file: "./tools/gitpod/gitpod.Dockerfile"
+          push: ${{ github.event_name != 'pull_request' }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          tags: |
+            pandas/pandas-gitpod:${{ steps.getrefs.outputs.date }}-${{ steps.getrefs.outputs.branch}}-${{ steps.getrefs.outputs.sha8 }}, pandas/pandas-gitpod:latest
+      - name: Image digest
+        # Return details of the image build: sha and shell
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
xref #47790

1. Adding an action to create the base docker file. It runs when the `environment.yml` on main is updated, or at least once monthly, to catch Ubuntu security updates
2. Adding an action to create the Gitpod docker file. It runs when main is updated.

Sidenote: I'm going on a few days vacation, and will be back to test the actions next week, so I made this a draft PR for now. If someone with docker/actions experience wants to leave a quick review—awesome. When I'm back, I will be testing it with my private account until I can access a pandas docker hub account.

CC @jorisvandenbossche @mroeschke