### PR TITLE
DOC: update contributing to pandas documentation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,5 @@
 - [ ] closes #xxxx (Replace xxxx with the Github issue number)
+- [ ] xref #xxxx (Replace xxxx with the Github issue number)
 - [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
 - [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
 - [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,4 @@
 - [ ] closes #xxxx (Replace xxxx with the Github issue number)
-- [ ] xref #xxxx (Replace xxxx with the Github issue number)
 - [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
 - [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
 - [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -194,30 +194,17 @@ Doing 'git status' again should give something like::
     #       modified:   /relative/path/to/file-you-added.py
     #
 
-Finally, commit your changes to your local repository with an explanatory message. pandas
-uses a convention for commit message prefixes and layout.  Here are
-some common prefixes along with general guidelines for when to use them:
+Finally, commit your changes to your local repository with an explanatory commit
+message of ``< 80`` chars::
 
-* ENH: Enhancement, new functionality
-* BUG: Bug fix
-* DOC: Additions/updates to documentation
-* TST: Additions/updates to tests
-* BLD: Updates to the build process/scripts
-* PERF: Performance improvement
-* TYP: Type annotations
-* CLN: Code cleanup
+    git commit -m "your commit message goes here"
 
-The following defines how a commit message should be structured.  Please reference the
-relevant GitHub issues in your commit message using GH1234 or #1234.  Either style
-is fine, but the former is generally preferred:
+Alternatively, you can just type ``git commit`` which opens an editor and use the
+following commit message structure:
 
 * a subject line with ``< 80`` chars.
 * One blank line.
 * Optionally, a commit message body.
-
-Now you can commit your changes in your local repository::
-
-    git commit -m
 
 .. _contributing.push-code:
 
@@ -262,16 +249,28 @@ double check your branch changes against the branch it was based on:
 Finally, make the pull request
 ------------------------------
 
-If everything looks good, you are ready to make a pull request.  A pull request is how
+If everything looks good, you are ready to make a pull request. A pull request is how
 code from a local repository becomes available to the GitHub community and can be looked
-at and eventually merged into the main version.  This pull request and its associated
+at and eventually merged into the main version. This pull request and its associated
 changes will eventually be committed to the main branch and available in the next
-release.  To submit a pull request:
+release. To submit a pull request:
 
 #. Navigate to your repository on GitHub
-#. Click on the ``Pull Request`` button
+#. Click on the ``Compare & pull request`` button
 #. You can then click on ``Commits`` and ``Files Changed`` to make sure everything looks
    okay one last time
+#. Write a descriptive title that inlcudes prefixes. pandas uses a convention for title
+   prefixes. Here are some common ones along with general guidelines for when to use them:
+
+    * ENH: Enhancement, new functionality
+    * BUG: Bug fix
+    * DOC: Additions/updates to documentation
+    * TST: Additions/updates to tests
+    * BLD: Updates to the build process/scripts
+    * PERF: Performance improvement
+    * TYP: Type annotations
+    * CLN: Code cleanup
+
 #. Write a description of your changes in the ``Preview Discussion`` tab
 #. Click ``Send Pull Request``.
 

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -195,16 +195,9 @@ Doing 'git status' again should give something like::
     #
 
 Finally, commit your changes to your local repository with an explanatory commit
-message of ``< 80`` chars::
+message::
 
     git commit -m "your commit message goes here"
-
-Alternatively, you can just type ``git commit`` which opens an editor and use the
-following commit message structure:
-
-* a subject line with ``< 80`` chars.
-* One blank line.
-* Optionally, a commit message body.
 
 .. _contributing.push-code:
 

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -252,7 +252,7 @@ release. To submit a pull request:
 #. Click on the ``Compare & pull request`` button
 #. You can then click on ``Commits`` and ``Files Changed`` to make sure everything looks
    okay one last time
-#. Write a descriptive title that inlcudes prefixes. pandas uses a convention for title
+#. Write a descriptive title that includes prefixes. pandas uses a convention for title
    prefixes. Here are some common ones along with general guidelines for when to use them:
 
     * ENH: Enhancement, new functionality


### PR DESCRIPTION
- [x] closes #48035
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

I removed the part in the [Committing your code](https://pandas.pydata.org/docs/development/contributing.html#id9) section where it is said that commit messages should include the number of the GitHub issue the commit is contributing towards. I updated the pull request template to include cross references so that it's more clear how people should make use of referencing GitHub issues.

I fixed the code snippet `git commit -m` which causes an error and updated the documentation to include both commit message versions, the one line commit message and the more detailed commit message that can be done with an editor. Let me know if you would like to keep both versions or would like further changes.

Additionally, I moved the section about the prefixes to the [Finally, make the pull request](https://pandas.pydata.org/docs/development/contributing.html#id12) section of the documentation. Let me know if the prefixes need to be updated. 
