### PR TITLE
POC/REF: remove axes from Managers

### DIFF
--- a/pandas/_libs/properties.pyx
+++ b/pandas/_libs/properties.pyx
@@ -61,9 +61,10 @@ cdef class AxisProperty:
         if obj is None:
             # Only instances have _mgr, not classes
             return self
+        if self.axis == 0:
+            return obj._index
         else:
-            axes = obj._mgr.axes
-        return axes[self.axis]
+            return obj._columns
 
     def __set__(self, obj, value):
         obj._set_axis(self.axis, value)

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -726,7 +726,8 @@ class FrameApply(NDFrameApply):
             with np.errstate(all="ignore"):
                 results = self.obj._mgr.apply("apply", func=self.f)
             # _constructor will retain self.index and self.columns
-            return self.obj._constructor(data=results)
+            axes_dict = self.obj._construct_axes_dict()
+            return self.obj._constructor(data=results, **axes_dict)
 
         # broadcasting
         if self.result_type == "broadcast":

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1002,6 +1002,7 @@ class FrameColumnApply(FrameApply):
         # We create one Series object, and will swap out the data inside
         #  of it.  Kids: don't do this at home.
         ser = self.obj._ixs(0, axis=0)
+        index = ser.index
         mgr = ser._mgr
 
         if is_extension_array_dtype(ser.dtype):
@@ -1013,9 +1014,10 @@ class FrameColumnApply(FrameApply):
 
         else:
             for (arr, name) in zip(values, self.index):
-                # GH#35462 re-pin mgr in case setitem changed it
+                # GH#35462 re-pin mgr, index in case setitem changed it
                 ser._mgr = mgr
                 mgr.set_values(arr)
+                ser._index = index
                 object.__setattr__(ser, "_name", name)
                 yield ser
 

--- a/pandas/core/arraylike.py
+++ b/pandas/core/arraylike.py
@@ -359,11 +359,7 @@ def array_ufunc(self, ufunc: np.ufunc, method: str, *inputs: Any, **kwargs: Any)
         if isinstance(result, BlockManager):
             # we went through BlockManager.apply e.g. np.sqrt
             # TODO: any cases that aren't index/columns-preserving?
-            if self.ndim == 1:
-                reconstruct_kwargs["index"] = self.index
-            else:
-                reconstruct_kwargs["index"] = self.index
-                reconstruct_kwargs["columns"] = self.columns
+            reconstruct_kwargs.update(self._construct_axes_dict())
             result = self._constructor(result, **reconstruct_kwargs, copy=False)
         else:
             # we converted an array, lost our axes

--- a/pandas/core/arraylike.py
+++ b/pandas/core/arraylike.py
@@ -358,6 +358,12 @@ def array_ufunc(self, ufunc: np.ufunc, method: str, *inputs: Any, **kwargs: Any)
             return result
         if isinstance(result, BlockManager):
             # we went through BlockManager.apply e.g. np.sqrt
+            # TODO: any cases that aren't index/columns-preserving?
+            if self.ndim == 1:
+                reconstruct_kwargs["index"] = self.index
+            else:
+                reconstruct_kwargs["index"] = self.index
+                reconstruct_kwargs["columns"] = self.columns
             result = self._constructor(result, **reconstruct_kwargs, copy=False)
         else:
             # we converted an array, lost our axes

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4760,7 +4760,8 @@ class DataFrame(NDFrame, OpsMixin):
                 and not is_bool_dtype(dtype)
             )
 
-        def predicate(dtype: DtypeObj) -> bool:
+        def predicate(arr: ArrayLike) -> bool:
+            dtype = arr.dtype
             if include:
                 if not dtype_predicate(dtype, include):
                     return False
@@ -4771,14 +4772,8 @@ class DataFrame(NDFrame, OpsMixin):
 
             return True
 
-        def arr_predicate(arr: ArrayLike) -> bool:
-            dtype = arr.dtype
-            return predicate(dtype)
-
-        mgr, taker = self._mgr._get_data_subset(arr_predicate).copy(deep=None)
-        # FIXME: get axes without mgr.axes
-        # FIXME: return taker from _get_data_subset, this is really slow
-        #taker = self.dtypes.apply(predicate).values.nonzero()[0]
+        mgr, taker = self._mgr._get_data_subset(predicate)
+        mgr = mgr.copy(deep=None)
         columns = self.columns.take(taker)
         return type(self)(mgr, columns=columns, index=self.index).__finalize__(self)
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -175,6 +175,7 @@ class SeriesGroupBy(GroupBy[Series]):
         else:
             mgr = cast(Manager2D, mgr)
             single = mgr.iget(0)
+        #breakpoint()
         # FIXME: get axes without mgr.axes
         index = single.axes[0]
         ser = self.obj._constructor(single, index=index, name=self.obj.name)
@@ -1329,14 +1330,26 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
         # We could use `mgr.apply` here and not have to set_axis, but
         #  we would have to do shape gymnastics for ArrayManager compat
-        res_mgr = mgr.grouped_reduce(arr_func, ignore_failures=True)
+        res_mgr, taker = mgr.grouped_reduce(arr_func, ignore_failures=True)
         res_mgr.set_axis(1, mgr.axes[1])
 
         if len(res_mgr) < orig_mgr_len:
             warn_dropping_nuisance_columns_deprecated(type(self), how, numeric_only)
 
-        # FIXME: get axes without mgr.axes
-        res_df = self.obj._constructor(res_mgr, index=res_mgr.axes[1], columns=res_mgr.axes[0])
+        columns = mgr.axes[0]
+        index = res_mgr.axes[1]  # FIXME: get index without res_mgr.axes
+        if self.axis == 0:
+            
+            pass#index = self._obj_with_exclusions.index
+            #columns = columns[taker]
+            #breakpoint()
+        else:
+            #columns = self._obj_with_exclusions.index
+            pass#index = self._obj_with_exclusions.columns
+            #breakpoint()
+
+        columns = columns[taker]
+        res_df = self.obj._constructor(res_mgr, index=index, columns=columns)
         if self.axis == 1:
             res_df = res_df.T
         return res_df

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1160,7 +1160,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         for i, (item, sgb) in enumerate(self._iterate_column_groupbys(obj)):
             result[i] = sgb.aggregate(func, *args, **kwargs)
 
-        res_df = self.obj._constructor(result)
+        res_df = self.obj._constructor(result, columns=obj.columns)
         res_df.columns = obj.columns
         return res_df
 
@@ -1335,7 +1335,8 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         if len(res_mgr) < orig_mgr_len:
             warn_dropping_nuisance_columns_deprecated(type(self), how, numeric_only)
 
-        res_df = self.obj._constructor(res_mgr)
+        # FIXME: get axes without mgr.axes
+        res_df = self.obj._constructor(res_mgr, index=res_mgr.axes[1], columns=res_mgr.axes[0])
         if self.axis == 1:
             res_df = res_df.T
         return res_df
@@ -1657,7 +1658,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
             index = Index(range(rows))
             mgr.set_axis(1, index)
             # FIXME: get axes without mgr.axes
-            result = self.obj._constructor(mgr, index=mgr.axes[1], columns=mgr.axes[0])
+            result = self.obj._constructor(mgr, index=index, columns=mgr.axes[0])
 
             self._insert_inaxis_grouper_inplace(result)
             result = result._consolidate()
@@ -1665,7 +1666,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
             index = self.grouper.result_index
             mgr.set_axis(1, index)
             # FIXME: get axes without mgr.axes
-            result = self.obj._constructor(mgr, index=mgr.axes[1], columns=mgr.axes[0])
+            result = self.obj._constructor(mgr, index=index, columns=mgr.axes[0])
 
         if self.axis == 1:
             result = result.T

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1320,7 +1320,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         mgr: Manager2D = self._get_data_to_aggregate()
         orig_mgr_len = len(mgr)
         if numeric_only_bool:
-            mgr = mgr.get_numeric_data(copy=False)
+            mgr = mgr.get_numeric_data(copy=False)[0]
 
         def arr_func(bvalues: ArrayLike) -> ArrayLike:
             return self.grouper._cython_operation(

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -175,7 +175,9 @@ class SeriesGroupBy(GroupBy[Series]):
         else:
             mgr = cast(Manager2D, mgr)
             single = mgr.iget(0)
-        ser = self.obj._constructor(single, name=self.obj.name)
+        # FIXME: get axes without mgr.axes
+        index = single.axes[0]
+        ser = self.obj._constructor(single, index=index, name=self.obj.name)
         # NB: caller is responsible for setting ser.index
         return ser
 
@@ -1654,14 +1656,16 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
             rows = mgr.shape[1] if mgr.shape[0] > 0 else 0
             index = Index(range(rows))
             mgr.set_axis(1, index)
-            result = self.obj._constructor(mgr)
+            # FIXME: get axes without mgr.axes
+            result = self.obj._constructor(mgr, index=mgr.axes[1], columns=mgr.axes[0])
 
             self._insert_inaxis_grouper_inplace(result)
             result = result._consolidate()
         else:
             index = self.grouper.result_index
             mgr.set_axis(1, index)
-            result = self.obj._constructor(mgr)
+            # FIXME: get axes without mgr.axes
+            result = self.obj._constructor(mgr, index=mgr.axes[1], columns=mgr.axes[0])
 
         if self.axis == 1:
             result = result.T

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2906,7 +2906,8 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         mgr = obj._mgr
         res_mgr = mgr.apply(blk_func)
 
-        new_obj = obj._constructor(res_mgr)
+        axes_dict = obj._construct_axes_dict()
+        new_obj = obj._constructor(res_mgr, **axes_dict)
         if isinstance(new_obj, Series):
             new_obj.name = obj.name
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -3864,7 +3864,8 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         if is_ser:
             out = self._wrap_agged_manager(res_mgr)
         else:
-            out = obj._constructor(res_mgr)
+            # FIXME: get axes without mgr.axes
+            out = obj._constructor(res_mgr, index=res_mgr.axes[1], columns=res_mgr.axes[0])
 
         return self._wrap_aggregated_output(out)
 

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -1348,7 +1348,8 @@ class SeriesSplitter(DataSplitter):
     def _chop(self, sdata: Series, slice_obj: slice) -> Series:
         # fastpath equivalent to `sdata.iloc[slice_obj]`
         mgr = sdata._mgr.get_slice(slice_obj)
-        ser = sdata._constructor(mgr, name=sdata.name, fastpath=True)
+        index = sdata.index[slice_obj]
+        ser = sdata._constructor(mgr, index=index, name=sdata.name, fastpath=True)
         return ser.__finalize__(sdata, method="groupby")
 
 
@@ -1360,7 +1361,13 @@ class FrameSplitter(DataSplitter):
         # else:
         #     return sdata.iloc[:, slice_obj]
         mgr = sdata._mgr.get_slice(slice_obj, axis=1 - self.axis)
-        df = sdata._constructor(mgr)
+        if self.axis == 0:
+            index = sdata.index[slice_obj]
+            columns = sdata.columns
+        else:
+            index = sdata.index
+            columns = sdata.columns[slice_obj]
+        df = sdata._constructor(mgr, index=index, columns=columns)
         return df.__finalize__(sdata, method="groupby")
 
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -828,7 +828,9 @@ class Index(IndexOpsMixin, PandasObject):
         result = self._simple_new(self._values, name=self._name)
 
         result._cache = self._cache
+        result._id = self._id
         return result
+        # TODO: preserve _id?
 
     @final
     def _rename(self: _IndexT, name: Hashable) -> _IndexT:

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -485,6 +485,7 @@ class BaseArrayManager(DataManager):
             Whether to copy the blocks
         """
         return self._get_data_subset(is_inferred_bool_dtype)
+        # FIXME: return indexer
 
     def get_numeric_data(self: T, copy: bool = False) -> T:
         """

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -1180,6 +1180,9 @@ class ArrayManager(BaseArrayManager):
 
         return result
 
+    def __len__(self) -> int:
+        return len(self.arrays)
+
 
 class SingleArrayManager(BaseArrayManager, SingleDataManager):
 

--- a/pandas/core/internals/base.py
+++ b/pandas/core/internals/base.py
@@ -45,7 +45,7 @@ class DataManager(PandasObject):
 
     @final
     def __len__(self) -> int:
-        return len(self.items)
+        raise AbstractMethodError(self)
 
     @property
     def ndim(self) -> int:
@@ -159,6 +159,9 @@ class SingleDataManager(DataManager):
     @property
     def ndim(self) -> Literal[1]:
         return 1
+
+    def __len__(self) -> int:
+        return len(self.arrays[0])
 
     @final
     @property

--- a/pandas/core/internals/base.py
+++ b/pandas/core/internals/base.py
@@ -203,7 +203,7 @@ class SingleDataManager(DataManager):
         index = default_index(len(res))
 
         mgr = type(self).from_array(res, index)
-        return mgr
+        return mgr, np.arange(len(res), dtype=np.intp)  # TODO: is taker meaningful here?
 
     @classmethod
     def from_array(cls, arr: ArrayLike, index: Index):

--- a/pandas/core/internals/base.py
+++ b/pandas/core/internals/base.py
@@ -124,8 +124,8 @@ class DataManager(PandasObject):
         self_axes, other_axes = self.axes, other.axes
         if len(self_axes) != len(other_axes):
             return False
-        if not all(ax1.equals(ax2) for ax1, ax2 in zip(self_axes, other_axes)):
-            return False
+        #if not all(ax1.equals(ax2) for ax1, ax2 in zip(self_axes, other_axes)):
+        #    return False
 
         return self._equal_values(other)
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1856,6 +1856,10 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
             self._known_consolidated = True
             self._rebuild_blknos_and_blklocs()
 
+    def __len__(self) -> int:
+        # TODO: cache? would need to invalidate akin to blklocs
+        return sum(x.shape[1] for x in self.blocks)
+
 
 class SingleBlockManager(BaseBlockManager, SingleDataManager):
     """manage a single block with"""

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1937,7 +1937,7 @@ def _take_new_index(
         new_mgr = obj._mgr.reindex_indexer(new_axis=new_index, indexer=indexer, axis=1)
         # error: Incompatible return value type
         # (got "DataFrame", expected "NDFrameT")
-        return obj._constructor(new_mgr)  # type: ignore[return-value]
+        return obj._constructor(new_mgr, index=new_index, columns=obj.columns)  # type: ignore[return-value]
     else:
         raise ValueError("'obj' should be either a Series or a DataFrame")
 

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -621,7 +621,7 @@ class _Concatenator:
                 new_data._consolidate_inplace()
 
             cons = sample._constructor
-            return cons(new_data).__finalize__(self, method="concat")
+            return cons(new_data, index=self.new_axes[1], columns=self.new_axes[0]).__finalize__(self, method="concat")
 
     def _get_result_dim(self) -> int:
         if self._is_series and self.bm_axis == 1:

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -746,7 +746,7 @@ class _MergeOperation:
                 allow_dups=True,
                 use_na_proxy=True,
             )
-            left = left._constructor(lmgr)
+            left = left._constructor(lmgr, index=join_index, columns=left.columns)
         left.index = join_index
 
         if right_indexer is not None:
@@ -759,7 +759,7 @@ class _MergeOperation:
                 allow_dups=True,
                 use_na_proxy=True,
             )
-            right = right._constructor(rmgr)
+            right = right._constructor(rmgr, index=join_index, columns=right.columns)
         right.index = join_index
 
         from pandas import concat

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -500,8 +500,10 @@ def _unstack_frame(obj: DataFrame, level, fill_value=None):
     unstacker = _Unstacker(obj.index, level=level, constructor=obj._constructor)
 
     if not obj._can_fast_transpose:
-        mgr = obj._mgr.unstack(unstacker, fill_value=fill_value)
-        return obj._constructor(mgr)
+        mgr, columns_mask = obj._mgr.unstack(unstacker, fill_value=fill_value)
+        new_columns = unstacker.get_new_columns(obj.columns)
+        new_columns = new_columns[columns_mask]
+        return obj._constructor(mgr, index=unstacker.new_index, columns=new_columns)
     else:
         return unstacker.get_result(
             obj._values, value_columns=obj.columns, fill_value=fill_value

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2360,6 +2360,7 @@ Name: Max Speed, dtype: float64
         result = super().drop_duplicates(keep=keep)
         if inplace:
             self._update_inplace(result)
+            self._index = result.index
             return None
         else:
             return result

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -354,8 +354,11 @@ class Series(base.IndexOpsMixin, NDFrame):
         if isinstance(data, (SingleBlockManager, SingleArrayManager)):
             if index is None:
                 assert False
-            if not index.equals(data.axes[0]):#index is not data.axes[0]:
-                assert False
+            if data.axes[0] is not index:
+                # Adding check to try to avoid segfualt in json tests
+                data.axes = [ensure_index(index)]
+            #if not index.equals(data.axes[0]):#index is not data.axes[0]:
+            #    assert False
 
         if (
             isinstance(data, (SingleBlockManager, SingleArrayManager))

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -714,7 +714,7 @@ class TestBlockManager:
         # we have datetime/tz blocks in mgr
         cons = mgr.consolidate()
         assert cons.nblocks == 4
-        cons = mgr.consolidate().get_numeric_data()
+        cons = mgr.consolidate().get_numeric_data()[0]
         assert cons.nblocks == 1
         assert isinstance(cons.blocks[0].mgr_locs, BlockPlacement)
         tm.assert_numpy_array_equal(
@@ -752,7 +752,7 @@ class TestBlockManager:
         )
         mgr.iset(5, np.array([1, 2, 3], dtype=np.object_))
 
-        numeric = mgr.get_numeric_data()
+        numeric = mgr.get_numeric_data()[0]
         tm.assert_index_equal(numeric.items, Index(["int", "float", "complex", "bool"]))
         tm.assert_almost_equal(
             mgr.iget(mgr.items.get_loc("float")).internal_values(),
@@ -776,7 +776,7 @@ class TestBlockManager:
                 np.array([100.0, 200.0, 300.0]),
             )
 
-        numeric2 = mgr.get_numeric_data(copy=True)
+        numeric2 = mgr.get_numeric_data(copy=True)[0]
         tm.assert_index_equal(numeric.items, Index(["int", "float", "complex", "bool"]))
         numeric2.iset(
             numeric2.items.get_loc("float"),
@@ -804,7 +804,7 @@ class TestBlockManager:
         mgr.iset(6, np.array([True, False, True], dtype=np.object_))
 
         with tm.assert_produces_warning(FutureWarning, match=msg):
-            bools = mgr.get_bool_data()
+            bools = mgr.get_bool_data()[0]
         tm.assert_index_equal(bools.items, Index(["bool", "dt"]))
         tm.assert_almost_equal(
             mgr.iget(mgr.items.get_loc("bool")).internal_values(),
@@ -825,7 +825,7 @@ class TestBlockManager:
 
         # Check sharing
         with tm.assert_produces_warning(FutureWarning, match=msg):
-            bools2 = mgr.get_bool_data(copy=True)
+            bools2 = mgr.get_bool_data(copy=True)[0]
         bools2.iset(0, np.array([False, True, False]))
         if using_copy_on_write:
             tm.assert_numpy_array_equal(

--- a/pandas/tests/series/methods/test_reindex.py
+++ b/pandas/tests/series/methods/test_reindex.py
@@ -22,6 +22,7 @@ import pandas._testing as tm
 def test_reindex(datetime_series, string_series):
     identity = string_series.reindex(string_series.index)
 
+    # TODO: is the comment below still accurate for supported numpies?
     # __array_interface__ is not defined for older numpies
     # and on some pythons
     try:


### PR DESCRIPTION
cc @jorisvandenbossche we've discussed the idea of refactoring the Manager classes to not have the axes.  This is a (not-remotely-working) attempt at de-coupling the NDFrame axes from Manager axes.  Some questions before I spend much more time on this:

1) Am I remembering correctly that you are in principle in favor of this refactor?
2) Thoughts on how to handle the pyarrow usages?
3) Thoughts on cleaner ways to implement this in managably-sized chunks?