### PR TITLE
Deprecate positional arguments for read_hdf and to_hdf

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -825,7 +825,7 @@ Other Deprecations
 - Deprecated passing arguments as positional in :meth:`DataFrame.any` and :meth:`Series.any` (:issue:`44802`)
 - Deprecated the ``closed`` argument in :meth:`interval_range` in favor of ``inclusive`` argument; In a future version passing ``closed`` will raise (:issue:`40245`)
 - Deprecated the methods :meth:`DataFrame.mad`, :meth:`Series.mad`, and the corresponding groupby methods (:issue:`11787`)
-- Deprecated positional arguments to :meth:`DataFrame.to_hdf`, :func:`to_hdf` and :func:`read_hdf` except for ``path_or_buf`` and ``key``, use keyword-only arguments instead of positional arguments (:issue:`47423`)
+- Deprecated positional arguments to :meth:`DataFrame.to_hdf` and :func:`read_hdf` except for ``path_or_buf`` and ``key``, use keyword-only arguments instead of positional arguments (:issue:`47423`)
 - Deprecated positional arguments to :meth:`Index.join` except for ``other``, use keyword-only arguments instead of positional arguments (:issue:`46518`)
 - Deprecated positional arguments to :meth:`StringMethods.rsplit` and :meth:`StringMethods.split` except for ``pat``, use keyword-only arguments instead of positional arguments (:issue:`47423`)
 - Deprecated indexing on a timezone-naive :class:`DatetimeIndex` using a string representing a timezone-aware datetime (:issue:`46903`, :issue:`36148`)

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -825,6 +825,7 @@ Other Deprecations
 - Deprecated passing arguments as positional in :meth:`DataFrame.any` and :meth:`Series.any` (:issue:`44802`)
 - Deprecated the ``closed`` argument in :meth:`interval_range` in favor of ``inclusive`` argument; In a future version passing ``closed`` will raise (:issue:`40245`)
 - Deprecated the methods :meth:`DataFrame.mad`, :meth:`Series.mad`, and the corresponding groupby methods (:issue:`11787`)
+- Deprecated positional arguments to :meth:`DataFrame.to_hdf`, :func:`to_hdf` and :func:`read_hdf` except for ``path_or_buf`` and ``key``, use keyword-only arguments instead of positional arguments (:issue:`47423`)
 - Deprecated positional arguments to :meth:`Index.join` except for ``other``, use keyword-only arguments instead of positional arguments (:issue:`46518`)
 - Deprecated positional arguments to :meth:`StringMethods.rsplit` and :meth:`StringMethods.split` except for ``pat``, use keyword-only arguments instead of positional arguments (:issue:`47423`)
 - Deprecated indexing on a timezone-naive :class:`DatetimeIndex` using a string representing a timezone-aware datetime (:issue:`46903`, :issue:`36148`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2646,6 +2646,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             storage_options=storage_options,
         )
 
+    @deprecate_nonkeyword_arguments(
+        version=None, allowed_args=["self", "path_or_buf", "key"]
+    )
     @final
     def to_hdf(
         self,

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -58,7 +58,10 @@ from pandas.errors import (
     PerformanceWarning,
     PossibleDataLossError,
 )
-from pandas.util._decorators import cache_readonly
+from pandas.util._decorators import (
+    cache_readonly,
+    deprecate_nonkeyword_arguments,
+)
 from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.common import (
@@ -247,6 +250,9 @@ def _tables():
 # interface to/from ###
 
 
+@deprecate_nonkeyword_arguments(
+    version=None, allowed_args=["path_or_buf", "key", "value"]
+)
 def to_hdf(
     path_or_buf: FilePath | HDFStore,
     key: str,
@@ -303,6 +309,7 @@ def to_hdf(
         f(path_or_buf)
 
 
+@deprecate_nonkeyword_arguments(version=None, allowed_args=["path_or_buf", "key"])
 def read_hdf(
     path_or_buf: FilePath | HDFStore,
     key=None,


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
