### PR TITLE
CI: Pin conda in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN mkdir "$pandas_home" \
 # we just update the base/root one from the 'environment.yml' file instead of creating a new one.
 #
 # Set up environment
-RUN conda install -y mamba
+RUN conda install -y mamba conda=4.13.0
 RUN mamba env update -n base -f "$pandas_home/environment.yml"
 
 # Build C extensions and pandas


### PR DESCRIPTION
- [x] xref #48142

This gets ci green for now, but have to investigate what is wrong here. The first failing build updated conda from 4.13 to 4.14 with the ``conda install mamba``  command, hence the pin there

cc @mroeschke 