### PR TITLE
BLD: Explicitly state pip as a dependency in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,6 @@
 name: pandas-dev
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - python=3.8
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.8
+  - pip
 
   # test dependencies
   - cython=0.29.32
@@ -127,7 +128,6 @@ dependencies:
 
   # build the interactive terminal
   - jupyterlab >=3.4,<4
-  - pip # Add explicitly to prevent conda/mamba using incorrect pip
   - pip:
       - jupyterlite==0.1.0b10
       - sphinx-toggleprompt

--- a/environment.yml
+++ b/environment.yml
@@ -127,6 +127,7 @@ dependencies:
 
   # build the interactive terminal
   - jupyterlab >=3.4,<4
+  - pip # Add explicitly to prevent conda/mamba using incorrect pip
   - pip:
       - jupyterlite==0.1.0b10
       - sphinx-toggleprompt

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@
 name: pandas-dev
 channels:
   - conda-forge
+  - defaults
 dependencies:
   - python=3.8
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -98,6 +98,7 @@ feedparser
 pyyaml
 requests
 jupyterlab >=3.4,<4
+pip
 jupyterlite==0.1.0b10
 sphinx-toggleprompt
 setuptools>=51.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 # This file is auto-generated from environment.yml, do not modify.
 # See that file for comments about the need/usage of each dependency.
 
+pip
 cython==0.29.32
 pytest>=6.0
 pytest-cov
@@ -98,7 +99,6 @@ feedparser
 pyyaml
 requests
 jupyterlab >=3.4,<4
-pip
 jupyterlite==0.1.0b10
 sphinx-toggleprompt
 setuptools>=51.0.0


### PR DESCRIPTION
- [x] closes #48026 
- [x] All code checks passed [here](https://github.com/pandas-dev/pandas/actions/runs/2898960589)
- [x] Explicitly add pip as a dependency in environment.yml to prevent using incorrect version of pip