### PR TITLE
BUG: idxmin and idxmax raising ValueError with all nan row

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -946,7 +946,7 @@ Timedelta
 - Bug in :func:`astype_nansafe` astype("timedelta64[ns]") fails when np.nan is included (:issue:`45798`)
 - Bug in constructing a :class:`Timedelta` with a ``np.timedelta64`` object and a ``unit`` sometimes silently overflowing and returning incorrect results instead of raising ``OutOfBoundsTimedelta`` (:issue:`46827`)
 - Bug in constructing a :class:`Timedelta` from a large integer or float with ``unit="W"`` silently overflowing and returning incorrect results instead of raising ``OutOfBoundsTimedelta`` (:issue:`47268`)
--
+- Bug in :meth:`DataFrame.idxmin` and :meth:`DataFrame.idxmax` raising uncontrolled ``ValueError`` when object contained all ``NaN`` row (:issue:`48123`)
 
 Time Zones
 ^^^^^^^^^^

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -488,6 +488,9 @@ def _nanargminmax(values: np.ndarray, mask: npt.NDArray[np.bool_], func) -> int:
     non_nans = values[~mask]
     non_nan_idx = idx[~mask]
 
+    if len(non_nans) == 0:
+        return -1
+
     return non_nan_idx[func(non_nans)]
 
 

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -1053,6 +1053,36 @@ class TestDataFrameAnalytics:
         expected = Series([4, 3, 4])
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize("func, val", [("idxmin", "a"), ("idxmax", "b")])
+    def test_idxmin_timedelta_all_nan_row(self, func, val):
+        # GH#48123
+        df = DataFrame(
+            {
+                "a": [pd.Timedelta("1 days"), pd.NaT, pd.NaT],
+                "b": [pd.Timedelta("2 days"), pd.Timedelta("2 days"), pd.NaT],
+            },
+        )
+        result = getattr(df, func)(axis=1)
+        expected = Series([val, "b", np.nan])
+        tm.assert_series_equal(result, expected)
+
+        df = DataFrame(
+            {
+                "a": Series([1, pd.NA, pd.NA], dtype="Int64"),
+                "b": Series([2, 2, pd.NA], dtype="Int64"),
+            },
+        )
+        result = getattr(df, func)(axis=1)
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("func, val", [("idxmin", "a"), ("idxmax", "b")])
+    def test_idxmin_timedelta_all_nan_column(self, func, val):
+        # GH#48123
+        df = DataFrame({"a": [pd.Timedelta("1 days"), pd.NaT], "b": pd.NaT})
+        result = getattr(df, func)(axis=0)
+        expected = Series([0.0, np.nan], index=["a", "b"])
+        tm.assert_series_equal(result, expected)
+
     # ----------------------------------------------------------------------
     # Logical reductions
 


### PR DESCRIPTION
- [x] closes #48123 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

The Int64 case was working before too. Just added this for consistency