### PR TITLE
CLN: Replace incorrect GH#5667 with GH#5567

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1257,7 +1257,7 @@ class _LocIndexer(_LocationIndexer):
         return self._getitem_tuple_same_dim(tup)
 
     def _get_label(self, label, axis: int):
-        # GH#5667 this will fail if the label is not present in the axis.
+        # GH#5567 this will fail if the label is not present in the axis.
         return self.obj.xs(label, axis=axis)
 
     def _handle_lowerdim_multi_index_axis0(self, tup: tuple):


### PR DESCRIPTION
Hello!

*The checklist is not applicable here*

### Pull request overview
* Replacing `GH#5667` ina comment with `GH#5567`.

### Details
The PR #6364 closes the issue #5567, but the comment this PR introduces in `indexing.py` incorrectly refers to 5<ins>6</ins>67 instead. This code was later moved, cleaned up, etc., but the reference to the incorrect 5667 stuck around.

* Tom Aarsen