### PR TITLE
DOC: Add mention that mangle_dupe_cols is deprecated in user guide

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -629,27 +629,7 @@ distinguish between them so as to prevent overwriting data:
 
 There is no more duplicate data because ``mangle_dupe_cols=True`` by default,
 which modifies a series of duplicate columns 'X', ..., 'X' to become
-'X', 'X.1', ..., 'X.N'.  If ``mangle_dupe_cols=False``, duplicate data can
-arise:
-
-.. code-block:: ipython
-
-   In [2]: data = 'a,b,a\n0,1,2\n3,4,5'
-   In [3]: pd.read_csv(StringIO(data), mangle_dupe_cols=False)
-   Out[3]:
-      a  b  a
-   0  2  1  2
-   1  5  4  5
-
-To prevent users from encountering this problem with duplicate data, a ``ValueError``
-exception is raised if ``mangle_dupe_cols != True``:
-
-.. code-block:: ipython
-
-   In [2]: data = 'a,b,a\n0,1,2\n3,4,5'
-   In [3]: pd.read_csv(StringIO(data), mangle_dupe_cols=False)
-   ...
-   ValueError: Setting mangle_dupe_cols=False is not supported yet
+'X', 'X.1', ..., 'X.N'.
 
 .. _io.usecols:
 

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -179,6 +179,10 @@ mangle_dupe_cols : boolean, default ``True``
   Passing in ``False`` will cause data to be overwritten if there are duplicate
   names in the columns.
 
+  .. deprecated:: 1.5.0
+     The argument was never implemented, and a new argument where the
+     renaming pattern can be specified will be added instead.
+
 General parsing configuration
 +++++++++++++++++++++++++++++
 
@@ -610,6 +614,10 @@ If the header is in a row other than the first, pass the row number to
 
 Duplicate names parsing
 '''''''''''''''''''''''
+
+  .. deprecated:: 1.5.0
+     ``mangle_dupe_cols`` was never implemented, and a new argument where the
+     renaming pattern can be specified will be added instead.
 
 If the file or header contains duplicate names, pandas will by default
 distinguish between them so as to prevent overwriting data:


### PR DESCRIPTION
cc @datapythonista 
