### PR TITLE
 BUG: fixed json_normalize not working with list records

### DIFF
--- a/pandas/io/json/_normalize.py
+++ b/pandas/io/json/_normalize.py
@@ -531,7 +531,7 @@ def _json_normalize(
             raise ValueError(
                 f"Conflicting metadata name {k}, need distinguishing prefix "
             )
-        result[k] = np.array(v+[[]], dtype=object)[:-1].repeat(lengths)
+        result[k] = np.array(v + [[]], dtype = object)[: - 1].repeat(lengths)
     return result
 
 

--- a/pandas/io/json/_normalize.py
+++ b/pandas/io/json/_normalize.py
@@ -531,7 +531,7 @@ def _json_normalize(
             raise ValueError(
                 f"Conflicting metadata name {k}, need distinguishing prefix "
             )
-        result[k] = np.array(v, dtype=object).repeat(lengths)
+        result[k] = np.array(v+[[]], dtype=object)[:-1].repeat(lengths)
     return result
 
 

--- a/pandas/io/json/_normalize.py
+++ b/pandas/io/json/_normalize.py
@@ -531,7 +531,7 @@ def _json_normalize(
             raise ValueError(
                 f"Conflicting metadata name {k}, need distinguishing prefix "
             )
-        result[k] = np.array(v + [[]], dtype = object)[:-1].repeat(lengths)
+        result[k] = np.array(v + [[]], dtype=object)[:-1].repeat(lengths)
     return result
 
 

--- a/pandas/io/json/_normalize.py
+++ b/pandas/io/json/_normalize.py
@@ -531,7 +531,7 @@ def _json_normalize(
             raise ValueError(
                 f"Conflicting metadata name {k}, need distinguishing prefix "
             )
-        result[k] = np.array(v + [[]], dtype = object)[: - 1].repeat(lengths)
+        result[k] = np.array(v + [[]], dtype = object)[:-1].repeat(lengths)
     return result
 
 


### PR DESCRIPTION
When v is a list like object, numpy tries to create a 2D array if v isn't ragged despite the 'dtype=object'. Solution: add an empty list to make the array ragged and then remove.

- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
