### PR TITLE
CI: Automatically upload docs on release

### DIFF
--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -80,7 +80,7 @@ jobs:
 
     - name: Upload prod docs
       run: rsync -az --delete doc/build/html/ docs@${{ secrets.server_ip }}:/usr/share/nginx/pandas/pandas-docs/version/${GITHUB_REF_NAME}
-      if: github.event_name == 'push' && startsWidth(github.ref, 'refs/tags/')
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
 
     - name: Move docs into site directory
       run: mv doc/build/html web/build/docs

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -51,6 +51,9 @@ jobs:
     - name: Build documentation
       run: doc/make.py --warnings-are-errors
 
+    - name: Build documentation zip
+      run: doc/make.py zip_html
+
     - name: Build the interactive terminal
       run: |
         cd web/interactive_terminal

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - 1.4.x
+    tags:
+      - '*'
   pull_request:
     branches:
       - main
@@ -72,6 +74,10 @@ jobs:
     - name: Upload dev docs
       run: rsync -az --delete doc/build/html/ docs@${{ secrets.server_ip }}:/usr/share/nginx/pandas/pandas-docs/dev
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    - name: Upload prod docs
+      run: rsync -az --delete doc/build/html/ docs@${{ secrets.server_ip }}:/usr/share/nginx/pandas/pandas-docs/version/${GITHUB_REF_NAME}
+      if: github.event_name == 'push' && startsWidth(github.ref, 'refs/tags/')
 
     - name: Move docs into site directory
       run: mv doc/build/html web/build/docs


### PR DESCRIPTION
This should make the publishing of the docs automatic one creating and pushing a new tag. My understanding is that versioneer should take care of showing the version correctly in the docs.

I'd merge this before the 1.5 release in few hours, and if there is any problem, we do the publishing manually once more, and we fix the action for the next release. But I don't think it should fail.

The pdf is missing, but I think we're happy to remove it (I'll open a separate PR for it).

If I'm not wrong, for patch releases we upload the new docs, but delete the previous docs of that minor (so, for 1.4.4 we would delete 1.4.3 docs), and we create a symlink for the previous release. If that's the case, this would still be useful, but we should add in a follow up the deleting and the symlinks.

CC: @simonjayhawkins @mroeschke @lithomas1 @jorisvandenbossche 
