### PR TITLE
PERF: #48212 Cache the results of get_block_type (1.1.x)

### DIFF
--- a/doc/source/whatsnew/v1.1.6.rst
+++ b/doc/source/whatsnew/v1.1.6.rst
@@ -1,0 +1,26 @@
+.. _whatsnew_116:
+
+What's new in 1.1.6 (XXX XX, XXXX)
+---------------------------------------
+
+These are the changes in pandas 1.1.6. See :ref:`release` for a full changelog
+including other versions of pandas.
+
+{{ header }}
+
+.. ---------------------------------------------------------------------------
+
+.. _whatsnew_116.regressions:
+
+Fixed regressions
+~~~~~~~~~~~~~~~~~
+- Fixed performance regression in the creation of blocks (:issue:`48212`)
+
+.. ---------------------------------------------------------------------------
+
+.. _whatsnew_116.contributors:
+
+Contributors
+~~~~~~~~~~~~
+
+.. contributors:: v1.1.5..v1.1.6|HEAD


### PR DESCRIPTION
This gave a ~5% performance boost. It looks like things started to slow down in this area after 0.19.2 with more costly type checking.

As mentioned on #48212, I'm upgrading a large codebase and 1.1.x is the limit I can get to without significant changes (upgrading of codebase, libraries, and environments/machines), so this is a great stepping stone. I'd appreciate if this would get accepted as a patch release for it, I'm happy to go through the other 1.x branches to apply the change once a pattern is confirmed.

It looks like the automated CI run doesn't like trying to run on/for 1.1.x, so I'll have a run when I swap machines, but imagine I'll have to make a branch based on master sooner rather than later to get confidence from CI.

- [ ] ~closes #48212 (Replace xxxx with the Github issue number)~ - not closing as targeting a 1.1.x
- [ ] ~[Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature~
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] ~Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.~
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
