### PR TITLE
WEB: Removing links to pdf version of the docs from web and docs

### DIFF
--- a/doc/source/index.rst.template
+++ b/doc/source/index.rst.template
@@ -10,7 +10,7 @@ pandas documentation
 
 **Date**: |today| **Version**: |version|
 
-**Download documentation**: `PDF Version <pandas.pdf>`__ | `Zipped HTML <pandas.zip>`__
+**Download documentation**: `Zipped HTML <pandas.zip>`__
 
 **Previous versions**: Documentation of previous pandas versions is available at
 `pandas.pydata.org <https://pandas.pydata.org/>`__.

--- a/web/pandas/index.html
+++ b/web/pandas/index.html
@@ -66,7 +66,6 @@
                         <li><a href="docs/whatsnew/v{{ releases[0].name }}.html">What's new in {{ releases[0].name }}</a></li>
                         <li>Release date:<br/>{{ releases[0].published.strftime("%b %d, %Y") }}</li>
                         <li><a href="{{ base_url}}/docs/">Documentation (web)</a></li>
-                        <li><a href="{{ base_url }}/docs/pandas.pdf">Documentation (pdf)</a></li>
                         <li><a href="{{ releases[0].url }}">Download source code</a></li>
                     </ul>
                 {% endif %}
@@ -100,7 +99,6 @@
                                 {{ release.name }} ({{ release.published.strftime("%b %d, %Y") }})<br/>
                                 <a href="https://pandas.pydata.org/pandas-docs/stable/whatsnew/{{ release.tag }}.html">changelog</a> |
                                 <a href="https://pandas.pydata.org/pandas-docs/version/{{ release.name }}/">docs</a> |
-                                <a href="https://pandas.pydata.org/pandas-docs/version/{{ release.name }}/pandas.pdf">pdf</a> |
                                 <a href="{{ release.url }}">code</a>
                             </li>
                         {% endfor %}
@@ -116,7 +114,6 @@
                                 {{ release.name }} ({{ release.published.strftime("%Y-%m-%d") }})<br/>
                                 <a href="https://pandas.pydata.org/pandas-docs/stable/whatsnew/{{ release.tag }}.html">changelog</a> |
                                 <a href="https://pandas.pydata.org/pandas-docs/version/{{ release.name }}/">docs</a> |
-                                <a href="https://pandas.pydata.org/pandas-docs/version/{{ release.name }}/pandas.pdf">pdf</a> |
                                 <a href="{{ release.url }}">code</a>
                             </li>
                         {% endfor %}


### PR DESCRIPTION
Remove the links to the docs pdf in preparation to not generate it anymore in future releases.