### PR TITLE
REGR: properly update DataFrame cache in Series.__setitem__

### DIFF
--- a/doc/source/whatsnew/v1.4.4.rst
+++ b/doc/source/whatsnew/v1.4.4.rst
@@ -26,7 +26,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.loc` setting a length-1 array like value to a single value in the DataFrame (:issue:`46268`)
 - Fixed regression when slicing with :meth:`DataFrame.loc` with :class:`DateOffset`-index (:issue:`46671`)
 - Fixed regression in setting ``None`` or non-string value into a ``string``-dtype Series using a mask (:issue:`47628`)
-- Fixed regression in updating a DataFrame column through :meth:`Series.__setitem__` (:issue:`47172`)
+- Fixed regression in updating a DataFrame column through Series ``__setitem__`` (using chained assignment) not updating column values inplace and using too much memory (:issue:`47172`)
 - Fixed regression in :meth:`DataFrame.select_dtypes` returning a view on the original DataFrame (:issue:`48090`)
 - Fixed regression using custom Index subclasses (for example, used in xarray) with :meth:`~DataFrame.reset_index` or :meth:`Index.insert` (:issue:`47071`)
 - Fixed regression in :meth:`DatetimeIndex.intersection` when the :class:`DatetimeIndex` has dates crossing daylight savings time (:issue:`46702`)

--- a/doc/source/whatsnew/v1.4.4.rst
+++ b/doc/source/whatsnew/v1.4.4.rst
@@ -26,6 +26,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.loc` setting a length-1 array like value to a single value in the DataFrame (:issue:`46268`)
 - Fixed regression when slicing with :meth:`DataFrame.loc` with :class:`DateOffset`-index (:issue:`46671`)
 - Fixed regression in setting ``None`` or non-string value into a ``string``-dtype Series using a mask (:issue:`47628`)
+- Fixed regression in updating a DataFrame column through :meth:`Series.__setitem__` (:issue:`47172`)
 - Fixed regression in :meth:`DataFrame.select_dtypes` returning a view on the original DataFrame (:issue:`48090`)
 - Fixed regression using custom Index subclasses (for example, used in xarray) with :meth:`~DataFrame.reset_index` or :meth:`Index.insert` (:issue:`47071`)
 - Fixed regression in :meth:`DatetimeIndex.intersection` when the :class:`DatetimeIndex` has dates crossing daylight savings time (:issue:`46702`)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1169,7 +1169,7 @@ class Series(base.IndexOpsMixin, NDFrame):
                 self._set_with(key, value)
 
         if cacher_needs_updating:
-            self._maybe_update_cacher()
+            self._maybe_update_cacher(inplace=True)
 
     def _set_with_engine(self, key, value) -> None:
         loc = self.index.get_loc(key)

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -1236,6 +1236,7 @@ class TestDataFrameSetitemCopyViewSemantics:
         df[indexer] = set_value
         tm.assert_frame_equal(view, expected)
 
+    @td.skip_array_manager_invalid_test
     def test_setitem_column_update_inplace(self, using_copy_on_write):
         # https://github.com/pandas-dev/pandas/issues/47172
 

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -1235,3 +1235,20 @@ class TestDataFrameSetitemCopyViewSemantics:
         view = df[:]
         df[indexer] = set_value
         tm.assert_frame_equal(view, expected)
+
+    def test_setitem_column_update_inplace(self, using_copy_on_write):
+        # https://github.com/pandas-dev/pandas/issues/47172
+
+        labels = [f"c{i}" for i in range(10)]
+        df = DataFrame({col: np.zeros(len(labels)) for col in labels}, index=labels)
+        values = df._mgr.blocks[0].values
+
+        for label in df.columns:
+            df[label][label] = 1
+
+        if not using_copy_on_write:
+            # diagonal values all updated
+            assert np.all(values[np.arange(10), np.arange(10)] == 1)
+        else:
+            # original dataframe not updated
+            assert np.all(values[np.arange(10), np.arange(10)] == 0)


### PR DESCRIPTION
Potential fix for https://github.com/pandas-dev/pandas/issues/47172


https://github.com/pandas-dev/pandas/pull/43406 added an `inplace` keyword to `_maybe_update_cacher`, but made the default `False`. While before that PR, the effective behaviour would rather match `True` I think (that PR was meant to make some cases _not_ inplace). 
However, if we are in the case of `Series.__setitem__` needing a cache update, so meaning that this series is a column of a DataFrame and we might need to update that DataFrame, I think we always should try update that DataFrame inplace (we are not in a `DataFrame.__setitem__` case, but rather setting into a column we got with `DataFrame.__getitem__`, so chained assignment, which currently still is expected to work in this case).