### PR TITLE
TST: dt.total_seconds() stores float with appending 0.00000000000001 fix

### DIFF
--- a/pandas/tests/arrays/test_timedeltas.py
+++ b/pandas/tests/arrays/test_timedeltas.py
@@ -69,9 +69,9 @@ class TestNonNano:
 
     def test_timedelta_array_total_seconds(self):
         # GH34290
-        expected = pd.Timedelta("2 min").total_seconds()
+        expected = Timedelta("2 min").total_seconds()
 
-        result = pd.array([pd.Timedelta("2 min")]).total_seconds()[0]
+        result = pd.array([Timedelta("2 min")]).total_seconds()[0]
         assert result == expected
 
     @pytest.mark.parametrize(

--- a/pandas/tests/arrays/test_timedeltas.py
+++ b/pandas/tests/arrays/test_timedeltas.py
@@ -1,7 +1,4 @@
-from datetime import (
-    datetime,
-    timedelta,
-)
+from datetime import timedelta
 
 import numpy as np
 import pytest
@@ -70,28 +67,11 @@ class TestNonNano:
         expected = tda_nano.total_seconds()
         tm.assert_numpy_array_equal(result, expected)
 
-    def test_series_total_seconds(self):
+    def test_timedelta_array_total_seconds(self):
         # GH34290
-        expected = float(15)
-        out = pd.Series(
-            [pd.Timestamp("2022-03-16 08:32:26"), pd.Timestamp("2022-03-16 08:32:41")]
-        )
+        expected = pd.Timedelta("2 min").total_seconds()
 
-        result = (out - out.iloc[0]).dt.total_seconds()[1]
-        assert result == expected
-
-    def test_dateframe_total_seconds(self):
-        # GH34290
-        expected = float(120)
-        data = {"start": datetime(2020, 1, 1, 12), "end": datetime(2020, 1, 1, 12, 2)}
-        df = pd.DataFrame(data, index=[0])
-
-        # try to parse to pd.to_datetime
-        df["end"] = pd.to_datetime(df["end"])
-        df["start"] = pd.to_datetime(df["start"])
-
-        result = (df["end"] - df["start"]).dt.total_seconds().values[0]
-
+        result = pd.array([pd.Timedelta("2 min")]).total_seconds()[0]
         assert result == expected
 
     @pytest.mark.parametrize(

--- a/pandas/tests/arrays/test_timedeltas.py
+++ b/pandas/tests/arrays/test_timedeltas.py
@@ -1,4 +1,7 @@
-from datetime import timedelta
+from datetime import (
+    datetime,
+    timedelta,
+)
 
 import numpy as np
 import pytest
@@ -66,6 +69,30 @@ class TestNonNano:
         result = tda.total_seconds()
         expected = tda_nano.total_seconds()
         tm.assert_numpy_array_equal(result, expected)
+
+    def test_series_total_seconds(self):
+        # GH34290
+        expected = float(15)
+        out = pd.Series(
+            [pd.Timestamp("2022-03-16 08:32:26"), pd.Timestamp("2022-03-16 08:32:41")]
+        )
+
+        result = (out - out.iloc[0]).dt.total_seconds()[1]
+        assert result == expected
+
+    def test_dateframe_total_seconds(self):
+        # GH34290
+        expected = float(120)
+        data = {"start": datetime(2020, 1, 1, 12), "end": datetime(2020, 1, 1, 12, 2)}
+        df = pd.DataFrame(data, index=[0])
+
+        # try to parse to pd.to_datetime
+        df["end"] = pd.to_datetime(df["end"])
+        df["start"] = pd.to_datetime(df["start"])
+
+        result = (df["end"] - df["start"]).dt.total_seconds().values[0]
+
+        assert result == expected
 
     @pytest.mark.parametrize(
         "nat", [np.datetime64("NaT", "ns"), np.datetime64("NaT", "us")]


### PR DESCRIPTION
- [x] closes #34290 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
