### PR TITLE
Backport PR #48176 on branch 1.4.x (REGR: ensure DataFrame.select_dtypes() returns a copy)

### DIFF
--- a/doc/source/whatsnew/v1.4.4.rst
+++ b/doc/source/whatsnew/v1.4.4.rst
@@ -26,6 +26,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.loc` setting a length-1 array like value to a single value in the DataFrame (:issue:`46268`)
 - Fixed regression when slicing with :meth:`DataFrame.loc` with :class:`DateOffset`-index (:issue:`46671`)
 - Fixed regression in setting ``None`` or non-string value into a ``string``-dtype Series using a mask (:issue:`47628`)
+- Fixed regression in :meth:`DataFrame.select_dtypes` returning a view on the original DataFrame (:issue:`48090`)
 - Fixed regression using custom Index subclasses (for example, used in xarray) with :meth:`~DataFrame.reset_index` or :meth:`Index.insert` (:issue:`47071`)
 - Fixed regression in :meth:`DatetimeIndex.intersection` when the :class:`DatetimeIndex` has dates crossing daylight savings time (:issue:`46702`)
 - Fixed regression in :func:`merge` throwing an error when passing a :class:`Series` with a multi-level name (:issue:`47946`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4378,7 +4378,7 @@ class DataFrame(NDFrame, OpsMixin):
 
             return True
 
-        mgr = self._mgr._get_data_subset(predicate).copy(deep=None)
+        mgr = self._mgr._get_data_subset(predicate).copy()
         return type(self)(mgr).__finalize__(self)
 
     def insert(

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4378,7 +4378,7 @@ class DataFrame(NDFrame, OpsMixin):
 
             return True
 
-        mgr = self._mgr._get_data_subset(predicate)
+        mgr = self._mgr._get_data_subset(predicate).copy(deep=None)
         return type(self)(mgr).__finalize__(self)
 
     def insert(

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -456,3 +456,12 @@ class TestSelectDtypes:
         result = df.select_dtypes(include="number")
         expected = DataFrame({"a": [1, 2, 3]})
         tm.assert_frame_equal(result, expected)
+
+    def test_select_dtypes_no_view(self):
+        # https://github.com/pandas-dev/pandas/issues/48090
+        # result of this method is not a view on the original dataframe
+        df = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+        df_orig = df.copy()
+        result = df.select_dtypes(include=["number"])
+        result.iloc[0, 0] = 0
+        tm.assert_frame_equal(df, df_orig)

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -459,7 +459,7 @@ class TestSelectDtypes:
         expected = DataFrame({"a": [1, 2, 3]})
         tm.assert_frame_equal(result, expected)
 
-    @td.skip_array_manager_not_yet_implemented
+    @td.skip_array_manager_invalid_test
     def test_select_dtypes_no_view(self):
         # https://github.com/pandas-dev/pandas/issues/48090
         # result of this method is not a view on the original dataframe

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+import pandas.util._test_decorators as td
+
 from pandas.core.dtypes.dtypes import ExtensionDtype
 
 import pandas as pd
@@ -457,6 +459,7 @@ class TestSelectDtypes:
         expected = DataFrame({"a": [1, 2, 3]})
         tm.assert_frame_equal(result, expected)
 
+    @td.skip_array_manager_not_yet_implemented
     def test_select_dtypes_no_view(self):
         # https://github.com/pandas-dev/pandas/issues/48090
         # result of this method is not a view on the original dataframe


### PR DESCRIPTION
Backport PR #48176