### PR TITLE
TYP: Remove use of deprecated mypy option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ warn_no_return = true
 warn_return_any = false # TODO
 warn_unreachable = false # GH#27396
 # Suppressing errors
-show_none_errors = true
 ignore_errors = false
 enable_error_code = "ignore-without-code"
 # Miscellaneous strictness flags


### PR DESCRIPTION
`show_none_errors` is deprecated, see https://github.com/python/mypy/pull/13507