### PR TITLE
ENH: TimedeltaArray add/sub with non-nano

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1141,6 +1141,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
 
         i8 = self.asi8
         result = checked_add_with_arr(i8, other.value, arr_mask=self._isnan)
+
         dtype = tz_to_dtype(tz=other.tz, unit=self._unit)
         res_values = result.view(f"M8[{self._unit}]")
         return DatetimeArray._simple_new(res_values, dtype=dtype, freq=self.freq)
@@ -1290,12 +1291,19 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         other = ensure_wrapped_if_datetimelike(other)
         other = cast("TimedeltaArray", other)
 
+        if self._reso != other._reso:
+            raise NotImplementedError(
+                f"Addition of {type(self).__name__} with TimedeltaArray with "
+                "mis-matched resolutions is not yet supported."
+            )
+
         self_i8 = self.asi8
         other_i8 = other.asi8
         new_values = checked_add_with_arr(
             self_i8, other_i8, arr_mask=self._isnan, b_mask=other._isnan
         )
-        return type(self)(new_values, dtype=self.dtype)
+        res_values = new_values.view(self._ndarray.dtype)
+        return type(self)._simple_new(res_values, dtype=self.dtype)
 
     @final
     def _add_nat(self):

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1290,6 +1290,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
 
         other = ensure_wrapped_if_datetimelike(other)
         other = cast("TimedeltaArray", other)
+        self = cast("DatetimeArray | TimedeltaArray", self)
 
         if self._reso != other._reso:
             raise NotImplementedError(

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -697,9 +697,10 @@ class TimedeltaArray(dtl.TimelikeOps):
         return res1, res2
 
     def __neg__(self) -> TimedeltaArray:
+        freq = None
         if self.freq is not None:
-            return type(self)(-self._ndarray, freq=-self.freq)
-        return type(self)(-self._ndarray)
+            freq = -self.freq
+        return type(self)._simple_new(-self._ndarray, dtype=self.dtype, freq=freq)
 
     def __pos__(self) -> TimedeltaArray:
         return type(self)(self._ndarray.copy(), freq=self.freq)

--- a/pandas/tests/arrays/test_timedeltas.py
+++ b/pandas/tests/arrays/test_timedeltas.py
@@ -167,6 +167,24 @@ class TestNonNano:
         expected = tda._ndarray / other
         tm.assert_numpy_array_equal(result, expected)
 
+    def test_add_timedeltaarraylike(self, tda):
+        # TODO(2.0): just do `tda_nano = tda.astype("m8[ns]")`
+        tda_nano = TimedeltaArray(tda._ndarray.astype("m8[ns]"))
+
+        msg = "mis-matched resolutions is not yet supported"
+        with pytest.raises(NotImplementedError, match=msg):
+            tda_nano + tda
+        with pytest.raises(NotImplementedError, match=msg):
+            tda + tda_nano
+        with pytest.raises(NotImplementedError, match=msg):
+            tda - tda_nano
+        with pytest.raises(NotImplementedError, match=msg):
+            tda_nano - tda
+
+        result = tda_nano + tda_nano
+        expected = tda_nano * 2
+        tm.assert_extension_array_equal(result, expected)
+
 
 class TestTimedeltaArray:
     @pytest.mark.parametrize("dtype", [int, np.int32, np.int64, "uint32", "uint64"])


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
