### PR TITLE
CI: add warning when not in pandas dev and running stubtest

### DIFF
--- a/scripts/run_stubtest.py
+++ b/scripts/run_stubtest.py
@@ -23,9 +23,9 @@ if not pd_version:
 if "dev" not in pd_version:
     warnings.warn(
         f"stubtest may fail as {pd_version} is not a dev version. "
-        f"Please install a pandas dev version or see <https://github.com/pandas-dev"
-        f"/pandas/blob/main/doc/source/development/contributing_codebase.rst"
-        f"#validating-type-hints> on how to skip the stubtest"
+        f"Please install a pandas dev version or see https://pandas.pydata.org/"
+        f"pandas-docs/stable/development/contributing_codebase.html"
+        f"#validating-type-hints on how to skip the stubtest"
     )
 
 

--- a/scripts/run_stubtest.py
+++ b/scripts/run_stubtest.py
@@ -23,7 +23,9 @@ if not pd_version:
 if "dev" not in pd_version:
     warnings.warn(
         f"stubtest may fail as {pd_version} is not a dev version."
-        f"Please install a pandas dev version or see [] on how to skip the stubtest"
+        f"Please install a pandas dev version or see <https://github.com/pandas-dev"
+        f"/pandas/blob/main/doc/source/development/contributing_codebase.rst> "
+        f"on how to skip the stubtest"
     )
 
 

--- a/scripts/run_stubtest.py
+++ b/scripts/run_stubtest.py
@@ -8,14 +8,23 @@ from mypy import stubtest
 
 import pandas as pd
 
+pd_version = getattr(pd, "__version_", "")
+
 # fail early if pandas is not installed
-if not getattr(pd, "__version__", ""):
+if not pd_version:
     # fail on the CI, soft fail during local development
     warnings.warn("You need to install the development version of pandas")
     if pd.compat.is_ci_environment():
         sys.exit(1)
     else:
         sys.exit(0)
+
+# GH 48260
+if "dev" not in pd_version:
+    warnings.warn(
+        f"stubtest may fail as {pd_version} is not a dev version."
+        f"Please install a pandas dev version or see [] on how to skip the stubtest"
+    )
 
 
 _ALLOWLIST = [  # should be empty

--- a/scripts/run_stubtest.py
+++ b/scripts/run_stubtest.py
@@ -22,10 +22,10 @@ if not pd_version:
 # GH 48260
 if "dev" not in pd_version:
     warnings.warn(
-        f"stubtest may fail as {pd_version} is not a dev version."
+        f"stubtest may fail as {pd_version} is not a dev version. "
         f"Please install a pandas dev version or see <https://github.com/pandas-dev"
-        f"/pandas/blob/main/doc/source/development/contributing_codebase.rst> "
-        f"on how to skip the stubtest"
+        f"/pandas/blob/main/doc/source/development/contributing_codebase.rst"
+        f"#validating-type-hints> on how to skip the stubtest"
     )
 
 

--- a/scripts/run_stubtest.py
+++ b/scripts/run_stubtest.py
@@ -8,7 +8,7 @@ from mypy import stubtest
 
 import pandas as pd
 
-pd_version = getattr(pd, "__version_", "")
+pd_version = getattr(pd, "__version__", "")
 
 # fail early if pandas is not installed
 if not pd_version:


### PR DESCRIPTION
- [x] closes #48260
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).