### PR TITLE
CI: Require s3fs greater than minumum version in builds

### DIFF
--- a/ci/deps/actions-310.yaml
+++ b/ci/deps/actions-310.yaml
@@ -19,6 +19,7 @@ dependencies:
   - pytz
 
   # optional dependencies
+  - aiobotocore<2.0.0
   - beautifulsoup4
   - blosc
   - bottleneck

--- a/ci/deps/actions-310.yaml
+++ b/ci/deps/actions-310.yaml
@@ -43,7 +43,7 @@ dependencies:
   - pyreadstat
   - python-snappy
   - pyxlsb
-  - s3fs
+  - s3fs>=2021.05.0
   - scipy
   - sqlalchemy
   - tabulate

--- a/ci/deps/actions-38-downstream_compat.yaml
+++ b/ci/deps/actions-38-downstream_compat.yaml
@@ -44,7 +44,7 @@ dependencies:
   - pytables
   - python-snappy
   - pyxlsb
-  - s3fs
+  - s3fs>=2021.05.0
   - scipy
   - sqlalchemy
   - tabulate

--- a/ci/deps/actions-38.yaml
+++ b/ci/deps/actions-38.yaml
@@ -43,7 +43,7 @@ dependencies:
   - pytables
   - python-snappy
   - pyxlsb
-  - s3fs
+  - s3fs>=2021.05.0
   - scipy
   - sqlalchemy
   - tabulate

--- a/ci/deps/actions-38.yaml
+++ b/ci/deps/actions-38.yaml
@@ -19,6 +19,7 @@ dependencies:
   - pytz
 
   # optional dependencies
+  - aiobotocore<2.0.0
   - beautifulsoup4
   - blosc
   - bottleneck

--- a/ci/deps/actions-39.yaml
+++ b/ci/deps/actions-39.yaml
@@ -43,7 +43,7 @@ dependencies:
   - pytables
   - python-snappy
   - pyxlsb
-  - s3fs
+  - s3fs>=2021.05.0
   - scipy
   - sqlalchemy
   - tabulate

--- a/ci/deps/actions-39.yaml
+++ b/ci/deps/actions-39.yaml
@@ -19,6 +19,7 @@ dependencies:
   - pytz
 
   # optional dependencies
+  - aiobotocore<2.0.0
   - beautifulsoup4
   - blosc
   - bottleneck

--- a/ci/deps/circle-38-arm64.yaml
+++ b/ci/deps/circle-38-arm64.yaml
@@ -44,7 +44,7 @@ dependencies:
   - pytables
   - python-snappy
   - pyxlsb
-  - s3fs
+  - s3fs>=2021.05.0
   - scipy
   - sqlalchemy
   - tabulate

--- a/ci/deps/circle-38-arm64.yaml
+++ b/ci/deps/circle-38-arm64.yaml
@@ -19,6 +19,7 @@ dependencies:
   - pytz
 
   # optional dependencies
+  - aiobotocore<2.0.0
   - beautifulsoup4
   - blosc
   - bottleneck

--- a/environment.yml
+++ b/environment.yml
@@ -45,7 +45,7 @@ dependencies:
   - pytables
   - python-snappy
   - pyxlsb
-  - s3fs
+  - s3fs>=2021.05.0
   - scipy
   - sqlalchemy
   - tabulate

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -36,7 +36,7 @@ pyreadstat
 tables
 python-snappy
 pyxlsb
-s3fs
+s3fs>=2021.05.0
 scipy
 sqlalchemy
 tabulate


### PR DESCRIPTION
- [x] xref  #48271 (Replace xxxx with the Github issue number)

Our minimum version of s3fs is not compatible with aiobotocore >= 2.0, so have to pin to lower than 2.0 till we bump s3fs 
