### PR TITLE
Backport PR #48246 on branch 1.4.x (REGR: iloc not possible for sparse DataFrame)

### DIFF
--- a/doc/source/whatsnew/v1.4.4.rst
+++ b/doc/source/whatsnew/v1.4.4.rst
@@ -32,7 +32,7 @@ Fixed regressions
 - Fixed regression in :meth:`DatetimeIndex.intersection` when the :class:`DatetimeIndex` has dates crossing daylight savings time (:issue:`46702`)
 - Fixed regression in :func:`merge` throwing an error when passing a :class:`Series` with a multi-level name (:issue:`47946`)
 - Fixed regression in :meth:`DataFrame.eval` creating a copy when updating inplace (:issue:`47449`)
--
+- Fixed regression where getting a row using :meth:`DataFrame.iloc` with :class:`SparseDtype` would raise (:issue:`46406`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -995,11 +995,20 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         dtype = interleaved_dtype([blk.dtype for blk in self.blocks])
 
         n = len(self)
-        if isinstance(dtype, ExtensionDtype):
+
+        # GH#46406
+        immutable_ea = isinstance(dtype, SparseDtype)
+
+        if isinstance(dtype, ExtensionDtype) and not immutable_ea:
             cls = dtype.construct_array_type()
             result = cls._empty((n,), dtype=dtype)
         else:
-            result = np.empty(n, dtype=dtype)
+            # error: Argument "dtype" to "empty" has incompatible type
+            # "Union[Type[object], dtype[Any], ExtensionDtype, None]"; expected
+            # "None"
+            result = np.empty(
+                n, dtype=object if immutable_ea else dtype  # type: ignore[arg-type]
+            )
             result = ensure_wrapped_if_datetimelike(result)
 
         for blk in self.blocks:
@@ -1007,6 +1016,10 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
             # result[blk.mgr_locs] = blk._slice((slice(None), loc))
             for i, rl in enumerate(blk.mgr_locs):
                 result[rl] = blk.iget((i, loc))
+
+        if immutable_ea:
+            dtype = cast(ExtensionDtype, dtype)
+            result = dtype.construct_array_type()._from_sequence(result, dtype=dtype)
 
         return result
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1291,6 +1291,14 @@ class TestLocBaseIndependent:
         expected = Series([1.0, 0.0], dtype=SparseDtype("float64", 0.0))
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize("indexer", ["loc", "iloc"])
+    def test_getitem_single_row_sparse_df(self, indexer):
+        # GH#46406
+        df = DataFrame([[1.0, 0.0, 1.5], [0.0, 2.0, 0.0]], dtype=SparseDtype(float))
+        result = getattr(df, indexer)[0]
+        expected = Series([1.0, 0.0, 1.5], dtype=SparseDtype(float), name=0)
+        tm.assert_series_equal(result, expected)
+
     @pytest.mark.parametrize("key_type", [iter, np.array, Series, Index])
     def test_loc_getitem_iterable(self, float_frame, key_type):
         idx = key_type(["A", "B", "C"])


### PR DESCRIPTION
Backport PR #48246