### PR TITLE
BUG: Add note in whatsnew for DataFrame.at behavior change

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -1080,7 +1080,7 @@ Indexing
 - Bug in :meth:`DataFrame.sum` min_count changes dtype if input contains NaNs (:issue:`46947`)
 - Bug in :class:`IntervalTree` that lead to an infinite recursion. (:issue:`46658`)
 - Bug in :class:`PeriodIndex` raising ``AttributeError`` when indexing on ``NA``, rather than putting ``NaT`` in its place. (:issue:`46673`)
--
+- Bug in :meth:`DataFrame.at` would allow the modification of multiple columns (:issue:`48296`)
 
 Missing
 ^^^^^^^

--- a/pandas/tests/indexing/test_at.py
+++ b/pandas/tests/indexing/test_at.py
@@ -6,6 +6,8 @@ from datetime import (
 import numpy as np
 import pytest
 
+from pandas.errors import InvalidIndexError
+
 from pandas import (
     CategoricalDtype,
     CategoricalIndex,
@@ -191,6 +193,12 @@ class TestAtErrors:
 
         with pytest.raises(KeyError, match="^0$"):
             indexer_al(df)["a", 0]
+
+    def test_at_frame_multiple_columns(self):
+        # GH#48296 - at shouldn't modify multiple columns
+        df = DataFrame({"a": [1, 2], "b": [3, 4]})
+        with pytest.raises(InvalidIndexError, match=r"slice\(None, None, None\)"):
+            df.at[5] = [6, 7]
 
     def test_at_getitem_mixed_index_no_fallback(self):
         # GH#19860


### PR DESCRIPTION
- [x] closes #48296 (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

The issue mentioned above is just for tracking the change in behavior in 1.5. I've opened #48323 to track the remaining behavior issue mentioned there.