### PR TITLE
WEB: Update to `jupyterlite==0.1.0b12`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -129,5 +129,5 @@ dependencies:
   # build the interactive terminal
   - jupyterlab >=3.4,<4
   - pip:
-      - jupyterlite==0.1.0b10
+      - jupyterlite==0.1.0b12
       - sphinx-toggleprompt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -99,6 +99,6 @@ feedparser
 pyyaml
 requests
 jupyterlab >=3.4,<4
-jupyterlite==0.1.0b10
+jupyterlite==0.1.0b12
 sphinx-toggleprompt
 setuptools>=51.0.0


### PR DESCRIPTION
Update to the latest `jupyterlite` release to bring some more bug fixes and improvements.

This should help fix an issue with the current repl failing to load

- [x] ~closes #xxxx (Replace xxxx with the Github issue number)~
- [x] ~[Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature~
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] ~Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.~
- [x] ~Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.~
