### PR TITLE
CLN: consistent use of rval within left_join_indexer_unique (minor cleanup)

### DIFF
--- a/pandas/_libs/join.pyx
+++ b/pandas/_libs/join.pyx
@@ -298,7 +298,7 @@ def left_join_indexer_unique(
             indexer[i] = j
             i += 1
 
-        if left[i] == right[j]:
+        if left[i] == rval:
             indexer[i] = j
             i += 1
             while i < nleft - 1 and left[i] == rval:


### PR DESCRIPTION
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Very minor cleanup. Replacing `right[j]` with `rval` to be consistent with code above and below the line in question. (`rval = right[j]`) 