### PR TITLE
FIX: Reject any non-array, non-ns datetimes and timedeltas

### DIFF
--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1578,6 +1578,14 @@ class TestSeriesConstructors:
         expected = Series(date_range("20130101 00:00:01", periods=3, freq="s"))
         tm.assert_series_equal(ser, expected)
 
+        # try to construct from a sequence asking for non-ns timedelta64
+        with pytest.raises(TypeError, match=r"Only \[ns\] granularity"):
+            Series([1000000, 200000, 3000000], dtype="timedelta64[s]")
+
+        # try to construct from a sequence asking for non-ns datetime64
+        with pytest.raises(TypeError, match=r"Only \[ns\] granularity"):
+            Series([1000000, 200000, 3000000], dtype="datetime64[s]")
+
     @pytest.mark.parametrize(
         "index",
         [

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1650,8 +1650,8 @@ class TestSeriesConstructors:
     @pytest.mark.parametrize(
         "dtype,msg",
         [
-            ("m8[ps]", "Only \[ns\] granularity is supported"),
-            ("M8[ps]", "Only \[ns\] granularity is supported"),
+            (r"m8[ps]", r"Only \[ns\] granularity is supported"),
+            (r"M8[ps]", r"Only \[ns\] granularity is supported"),
         ],
     )
     def test_constructor_generic_timestamp_bad_frequency(self, dtype, msg):

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1579,11 +1579,11 @@ class TestSeriesConstructors:
         tm.assert_series_equal(ser, expected)
 
         # try to construct from a sequence asking for non-ns timedelta64
-        with pytest.raises(TypeError, match=r"Only \[ns\] granularity"):
+        with pytest.raises(TypeError, match=r"Only \[ns\] granularity is supported"):
             Series([1000000, 200000, 3000000], dtype="timedelta64[s]")
 
         # try to construct from a sequence asking for non-ns datetime64
-        with pytest.raises(TypeError, match=r"Only \[ns\] granularity"):
+        with pytest.raises(TypeError, match=r"Only \[ns\] granularity is supported"):
             Series([1000000, 200000, 3000000], dtype="datetime64[s]")
 
     @pytest.mark.parametrize(
@@ -1650,8 +1650,8 @@ class TestSeriesConstructors:
     @pytest.mark.parametrize(
         "dtype,msg",
         [
-            ("m8[ps]", "cannot convert timedeltalike"),
-            ("M8[ps]", "cannot convert datetimelike"),
+            ("m8[ps]", "Only \[ns\] granularity is supported"),
+            ("M8[ps]", "Only \[ns\] granularity is supported"),
         ],
     )
     def test_constructor_generic_timestamp_bad_frequency(self, dtype, msg):
@@ -1892,22 +1892,6 @@ class TestSeriesConstructors:
         # GH#35465
         result = Series([1000000, 200000, 3000000], dtype="timedelta64[ns]")
         expected = Series(pd.to_timedelta([1000000, 200000, 3000000], unit="ns"))
-        tm.assert_series_equal(result, expected)
-
-    def test_constructor_dtype_timedelta_ns_s(self):
-        # GH#35465
-        result = Series([1000000, 200000, 3000000], dtype="timedelta64[ns]")
-        expected = Series([1000000, 200000, 3000000], dtype="timedelta64[s]")
-        tm.assert_series_equal(result, expected)
-
-    def test_constructor_dtype_timedelta_ns_s_astype_int64(self):
-        # GH#35465
-        result = Series([1000000, 200000, 3000000], dtype="timedelta64[ns]").astype(
-            "int64"
-        )
-        expected = Series([1000000, 200000, 3000000], dtype="timedelta64[s]").astype(
-            "int64"
-        )
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.filterwarnings(


### PR DESCRIPTION
Done at euroSciPy2022! Fixes #48312.

On suggestion of @jorisvandenbossche, we opted to raise an error instead of converting to `[ns]` in order to make it easier in the future to add support for other granularity levels.

co-author: @kislovskiy

- [x] closes #48312
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
