### PR TITLE
Add missing pytest-asyncio to test extras

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ test =
     hypothesis>=5.5.3
     pytest>=6.0
     pytest-xdist>=1.31
+    pytest-asyncio>=0.17
 
 [build_ext]
 inplace = True


### PR DESCRIPTION
While testing for #48360 locally I got some errors due to `pytest-asyncio` missing after I did:

```
pip install -e .[test]
```

This should fix it!
