### PR TITLE
Added timeout on request.get() for ensuring that if a recipient serve…

### DIFF
--- a/web/pandas_web.py
+++ b/web/pandas_web.py
@@ -157,7 +157,8 @@ class Preprocessors:
         for kind in ("active", "inactive"):
             context["maintainers"][f"{kind}_with_github_info"] = []
             for user in context["maintainers"][kind]:
-                resp = requests.get(f"https://api.github.com/users/{user}")
+                # OpenRefactory Warning: The 'requests.get' method does not use any 'timeout' threshold which may cause program to hang indefinitely.
+                resp = requests.get(f"https://api.github.com/users/{user}", timeout=100)
                 if context["ignore_io_errors"] and resp.status_code == 403:
                     return context
                 resp.raise_for_status()
@@ -169,7 +170,8 @@ class Preprocessors:
         context["releases"] = []
 
         github_repo_url = context["main"]["github_repo_url"]
-        resp = requests.get(f"https://api.github.com/repos/{github_repo_url}/releases")
+        # OpenRefactory Warning: The 'requests.get' method does not use any 'timeout' threshold which may cause program to hang indefinitely.
+        resp = requests.get(f"https://api.github.com/repos/{github_repo_url}/releases", timeout=100)
         if context["ignore_io_errors"] and resp.status_code == 403:
             return context
         resp.raise_for_status()
@@ -234,9 +236,10 @@ class Preprocessors:
 
         # under discussion
         github_repo_url = context["main"]["github_repo_url"]
+        # OpenRefactory Warning: The 'requests.get' method does not use any 'timeout' threshold which may cause program to hang indefinitely.
         resp = requests.get(
             "https://api.github.com/search/issues?"
-            f"q=is:pr is:open label:PDEP repo:{github_repo_url}"
+            f"q=is:pr is:open label:PDEP repo:{github_repo_url}", timeout=100
         )
         if context["ignore_io_errors"] and resp.status_code == 403:
             return context


### PR DESCRIPTION
We have detected this issue in the `main` branch of `pandas` project on the version with commit hash `f0814b`. This is an instance of an api usage issue.

**Fixes for api usage issues:**
In file: `web/pandas_web.py`, in method `roadmap_pdeps`, `home_add_releases` and `maintainers_add_info` a request is made without a timeout parameter. If the recipient server is unavailable to service the request, [application making the request may stall indefinitely. ](https://docs.python-requests.org/en/master/user/advanced/#timeouts)our intelligent code repair system **iCR** suggested that a timeout value should be specified.

This issue was detected by our **OpenRefactory's Intelligent Code Repair (iCR)**. We are running **iCR** on libraries in the `PyPI` repository to identify issues and fix them. You will get more info at: [pypi.openrefactory.com](https://pypi.openrefactory.com/)
