### PR TITLE
Fix build warning for use of `strdup` in ultrajson

### DIFF
--- a/pandas/_libs/src/headers/portable.h
+++ b/pandas/_libs/src/headers/portable.h
@@ -1,8 +1,16 @@
 #ifndef _PANDAS_PORTABLE_H_
 #define _PANDAS_PORTABLE_H_
 
+// To get `strdup` from strings.h
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 600
+#endif
+
+#include <string.h>
+
 #if defined(_MSC_VER)
 #define strcasecmp( s1, s2 ) _stricmp( s1, s2 )
+#define strdup _strdup
 #endif
 
 // GH-23516 - works around locale perf issues

--- a/pandas/_libs/src/ujson/lib/ultrajson.h
+++ b/pandas/_libs/src/ujson/lib/ultrajson.h
@@ -54,6 +54,7 @@ tree doesn't have cyclic references.
 
 #include <stdio.h>
 #include <wchar.h>
+#include "../../headers/portable.h"
 
 // Don't output any extra whitespaces when encoding
 #define JSON_NO_EXTRA_WHITESPACE


### PR DESCRIPTION
When building with `-std=c99` (I was having a look at @lithomas1's `meson-poc` branch) on Linux this gives a warning:

```
[2/3] Compiling C object pandas/_libs/json.cpython-310-x86_64-linux-gnu.so.p/src_ujson_lib_ultrajsonenc.c.o
../pandas/_libs/src/ujson/lib/ultrajsonenc.c: In function 'JSON_EncodeObject':
../pandas/_libs/src/ujson/lib/ultrajsonenc.c:1180:18: warning: implicit declaration of function 'strdup'; did you mean 'strcmp'? [-Wimplicit-function-declaration]
 1180 |         locale = strdup(locale);
      |                  ^~~~~~
      |                  strcmp
../pandas/_libs/src/ujson/lib/ultrajsonenc.c:1180:16: warning: assignment to 'char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
 1180 |         locale = strdup(locale);
```

And for the MSVC builds in CI the warnings look like:
```
building 'pandas._libs.json' extension
creating build\temp.win-amd64-cpython-310\Release\pandas\_libs\src\ujson
creating build\temp.win-amd64-cpython-310\Release\pandas\_libs\src\ujson\lib
creating build\temp.win-amd64-cpython-310\Release\pandas\_libs\src\ujson\python
"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.33.31629\bin\HostX86\x64\cl.exe" /c /nologo /O2 /W3 /GL /DNDEBUG /MD -DNPY_NO_DEPRECATED_API=0 -Ipandas/_libs/src/ujson/python -Ipandas/_libs/src/ujson/lib -Ipandas/_libs/src/datetime -IC:\Users\runneradmin\micromamba\envs\test\lib\site-packages\numpy\core\include -IC:\Users\runneradmin\micromamba\envs\test\include -IC:\Users\runneradmin\micromamba\envs\test\Include "-IC:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.33.31629\include" "-IC:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.33.31629\ATLMFC\include" "-IC:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\VS\include" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\um" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\shared" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\winrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\cppwinrt" "-IC:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\include\um" /Tcpandas/_libs/src/ujson/lib/ultrajsondec.c /Fobuild\temp.win-amd64-cpython-310\Release\pandas/_libs/src/ujson/lib/ultrajsondec.obj -D_GNU_SOURCE
ultrajsondec.c
pandas/_libs/src/ujson/lib/ultrajsondec.c(1178): warning C4996: 'strdup': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _strdup. See online help for details.
```

I considered avoiding the code duplication by putting this block in a shared file, but the two files touched here already have quite a bit of duplicated code, so that's best left alone.