### PR TITLE
TST: to_numeric(large_float, downcast=float) isn't lossy

### DIFF
--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -799,3 +799,11 @@ def test_to_numeric_scientific_notation():
     result = to_numeric("1.7e+308")
     expected = np.float64(1.7e308)
     assert result == expected
+
+
+@pytest.mark.parametrize("val", [9876543210.0, 2.0**128])
+def test_to_numeric_large_float_not_downcast_to_float_32(val):
+    # GH 19729
+    expected = Series([val])
+    result = to_numeric(expected, downcast="float")
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #19729 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Fixed by https://github.com/pandas-dev/pandas/pull/43710 but adding an additional test.

