### PR TITLE
TYPE: annotate np.dtype

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -125,12 +125,13 @@ RandomState = Union[
 ]
 
 # dtypes
-NpDtype = Union[str, "np.dtype[Any]", type_t[Union[str, complex, bool, object]]]
+# using type: ignore due to incompatible types in assignment
+NpDtype = Union[str, "np.dtype[np.generic]", type_t[Union[str, complex, bool, object]]]  # type: ignore[assignment]
 Dtype = Union["ExtensionDtype", NpDtype]
 AstypeArg = Union["ExtensionDtype", "npt.DTypeLike"]
 # DtypeArg specifies all allowable dtypes in a functions its dtype argument
 DtypeArg = Union[Dtype, Dict[Hashable, Dtype]]
-DtypeObj = Union["np.dtype[Any]", "ExtensionDtype"]
+DtypeObj = Union["np.dtype[np.generic]", "ExtensionDtype"]  # type: ignore[assignment]
 
 # converters
 ConvertersArg = Dict[Hashable, Callable[[Dtype], Dtype]]

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -125,12 +125,12 @@ RandomState = Union[
 ]
 
 # dtypes
-NpDtype = Union[str, np.dtype, type_t[Union[str, complex, bool, object]]]
+NpDtype = Union[str, "np.dtype[Any]", type_t[Union[str, complex, bool, object]]]
 Dtype = Union["ExtensionDtype", NpDtype]
 AstypeArg = Union["ExtensionDtype", "npt.DTypeLike"]
 # DtypeArg specifies all allowable dtypes in a functions its dtype argument
 DtypeArg = Union[Dtype, Dict[Hashable, Dtype]]
-DtypeObj = Union[np.dtype, "ExtensionDtype"]
+DtypeObj = Union["np.dtype[Any]", "ExtensionDtype"]
 
 # converters
 ConvertersArg = Dict[Hashable, Callable[[Dtype], Dtype]]


### PR DESCRIPTION
This PR helps with annotating `np.dtype` for `pandas._typing.NpDtype` and
`pandas._typing.DtypeObj` so that type-checker won't throw `Unknown` errors when
accessing `pd.DataFrame[col].dtype`.

Imo we would like `dtype` to be inferred from `DataFrame`, but `Any` will be sufficient
for now.

- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
