### PR TITLE
DOC: More types for groupby's by argument

### DIFF
--- a/pandas/core/shared_docs.py
+++ b/pandas/core/shared_docs.py
@@ -94,7 +94,7 @@ groups.
 
 Parameters
 ----------
-by : mapping, function, label, pd.Grouper or list of labels
+by : mapping, function, label, pd.Grouper or list of such
     Used to determine the groups for the groupby.
     If ``by`` is a function, it's called on each value of the object's
     index. If a dict or Series is passed, the Series or dict VALUES


### PR DESCRIPTION
Added to the typing of the `by` argument in the documentation of the `groupby` functions, to allow lists of functions/mappings/`pd.Grouper` and not just lists of labels.
