### PR TITLE
BUG: masked mean unnecessarily overflowing

### DIFF
--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -199,7 +199,7 @@ Sparse
 
 ExtensionArray
 ^^^^^^^^^^^^^^
--
+- Bug in :meth:`Series.mean` overflowing unnecessarily with nullable integers (:issue:`40000`)
 -
 
 Styler

--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -199,7 +199,7 @@ Sparse
 
 ExtensionArray
 ^^^^^^^^^^^^^^
-- Bug in :meth:`Series.mean` overflowing unnecessarily with nullable integers (:issue:`40000`)
+- Bug in :meth:`Series.mean` overflowing unnecessarily with nullable integers (:issue:`48378`)
 -
 
 Styler

--- a/pandas/core/array_algos/masked_reductions.py
+++ b/pandas/core/array_algos/masked_reductions.py
@@ -14,7 +14,7 @@ from pandas._typing import npt
 from pandas.core.nanops import check_below_min_count
 
 
-def _sumprodmean(
+def _reductions(
     func: Callable,
     values: np.ndarray,
     mask: npt.NDArray[np.bool_],
@@ -63,7 +63,7 @@ def sum(
     min_count: int = 0,
     axis: int | None = None,
 ):
-    return _sumprodmean(
+    return _reductions(
         np.sum, values=values, mask=mask, skipna=skipna, min_count=min_count, axis=axis
     )
 
@@ -76,7 +76,7 @@ def prod(
     min_count: int = 0,
     axis: int | None = None,
 ):
-    return _sumprodmean(
+    return _reductions(
         np.prod, values=values, mask=mask, skipna=skipna, min_count=min_count, axis=axis
     )
 
@@ -146,4 +146,4 @@ def mean(
     skipna: bool = True,
     axis: int | None = None,
 ):
-    return _sumprodmean(np.mean, values=values, mask=mask, skipna=skipna, axis=axis)
+    return _reductions(np.mean, values=values, mask=mask, skipna=skipna, axis=axis)

--- a/pandas/core/array_algos/masked_reductions.py
+++ b/pandas/core/array_algos/masked_reductions.py
@@ -14,7 +14,7 @@ from pandas._typing import npt
 from pandas.core.nanops import check_below_min_count
 
 
-def _sumprod(
+def _sumprodmean(
     func: Callable,
     values: np.ndarray,
     mask: npt.NDArray[np.bool_],
@@ -24,7 +24,7 @@ def _sumprod(
     axis: int | None = None,
 ):
     """
-    Sum or product for 1D masked array.
+    Sum, mean or product for 1D masked array.
 
     Parameters
     ----------
@@ -63,7 +63,7 @@ def sum(
     min_count: int = 0,
     axis: int | None = None,
 ):
-    return _sumprod(
+    return _sumprodmean(
         np.sum, values=values, mask=mask, skipna=skipna, min_count=min_count, axis=axis
     )
 
@@ -76,7 +76,7 @@ def prod(
     min_count: int = 0,
     axis: int | None = None,
 ):
-    return _sumprod(
+    return _sumprodmean(
         np.prod, values=values, mask=mask, skipna=skipna, min_count=min_count, axis=axis
     )
 
@@ -141,9 +141,4 @@ def max(
 
 # TODO: axis kwarg
 def mean(values: np.ndarray, mask: npt.NDArray[np.bool_], skipna: bool = True):
-    if not values.size or mask.all():
-        return libmissing.NA
-    _sum = _sumprod(np.sum, values=values, mask=mask, skipna=skipna)
-    count = np.count_nonzero(~mask)
-    mean_value = _sum / count
-    return mean_value
+    return _sumprodmean(np.mean, values=values, mask=mask, skipna=skipna)

--- a/pandas/core/array_algos/masked_reductions.py
+++ b/pandas/core/array_algos/masked_reductions.py
@@ -146,4 +146,6 @@ def mean(
     skipna: bool = True,
     axis: int | None = None,
 ):
+    if not values.size or mask.all():
+        return libmissing.NA
     return _reductions(np.mean, values=values, mask=mask, skipna=skipna, axis=axis)

--- a/pandas/core/array_algos/masked_reductions.py
+++ b/pandas/core/array_algos/masked_reductions.py
@@ -139,6 +139,11 @@ def max(
     return _minmax(np.max, values=values, mask=mask, skipna=skipna, axis=axis)
 
 
-# TODO: axis kwarg
-def mean(values: np.ndarray, mask: npt.NDArray[np.bool_], skipna: bool = True):
-    return _sumprodmean(np.mean, values=values, mask=mask, skipna=skipna)
+def mean(
+    values: np.ndarray,
+    mask: npt.NDArray[np.bool_],
+    *,
+    skipna: bool = True,
+    axis: int | None = None,
+):
+    return _sumprodmean(np.mean, values=values, mask=mask, skipna=skipna, axis=axis)

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -1036,16 +1036,11 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
     # Reductions
 
     def _reduce(self, name: str, *, skipna: bool = True, **kwargs):
-        if name in {"any", "all", "min", "max", "sum", "prod"}:
+        if name in {"any", "all", "min", "max", "sum", "prod", "mean"}:
             return getattr(self, name)(skipna=skipna, **kwargs)
 
         data = self._data
         mask = self._mask
-
-        if name in {"mean"}:
-            op = getattr(masked_reductions, name)
-            result = op(data, mask, skipna=skipna, **kwargs)
-            return result
 
         # coerce to a nan-aware float if needed
         # (we explicitly use NaN within reductions)
@@ -1105,6 +1100,18 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
         )
         return self._wrap_reduction_result(
             "prod", result, skipna=skipna, axis=axis, **kwargs
+        )
+
+    def mean(self, *, skipna=True, axis: int | None = 0, **kwargs):
+        nv.validate_mean((), kwargs)
+        result = masked_reductions.mean(
+            self._data,
+            self._mask,
+            skipna=skipna,
+            axis=axis,
+        )
+        return self._wrap_reduction_result(
+            "mean", result, skipna=skipna, axis=axis, **kwargs
         )
 
     def min(self, *, skipna=True, axis: int | None = 0, **kwargs):

--- a/pandas/tests/extension/base/dim2.py
+++ b/pandas/tests/extension/base/dim2.py
@@ -7,6 +7,7 @@ import pytest
 from pandas._libs.missing import is_matching_na
 
 import pandas as pd
+import pandas._testing as tm
 from pandas.core.arrays.integer import INT_STR_TO_DTYPE
 from pandas.tests.extension.base.base import BaseExtensionTests
 
@@ -191,7 +192,11 @@ class Dim2CompatTests(BaseExtensionTests):
             kwargs["ddof"] = 0
 
         try:
-            result = getattr(arr2d, method)(axis=0, **kwargs)
+            if method == "mean":
+                with tm.assert_produces_warning(RuntimeWarning, check_stacklevel=False):
+                    result = getattr(arr2d, method)(axis=0, **kwargs)
+            else:
+                result = getattr(arr2d, method)(axis=0, **kwargs)
         except Exception as err:
             try:
                 getattr(data, method)()
@@ -212,7 +217,7 @@ class Dim2CompatTests(BaseExtensionTests):
                 # i.e. dtype.kind == "u"
                 return INT_STR_TO_DTYPE[np.dtype(np.uint).name]
 
-        if method in ["mean", "median", "sum", "prod"]:
+        if method in ["median", "sum", "prod"]:
             # std and var are not dtype-preserving
             expected = data
             if method in ["sum", "prod"] and data.dtype.kind in "iub":
@@ -229,6 +234,9 @@ class Dim2CompatTests(BaseExtensionTests):
             self.assert_extension_array_equal(result, expected)
         elif method == "std":
             self.assert_extension_array_equal(result, data - data)
+        elif method == "mean":
+            expected = data.astype("Float64")
+            self.assert_extension_array_equal(result, expected)
         # punt on method == "var"
 
     @pytest.mark.parametrize("method", ["mean", "median", "var", "std", "sum", "prod"])

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -775,6 +775,18 @@ class TestSeriesReductions:
             result = s.max(skipna=False)
             assert np.allclose(float(result), v[-1])
 
+    def test_mean_masked_overflow(self):
+        # GH#48378
+        val = 100_000_000_000_000_000
+        n_elements = 100
+        na = np.array([val] * n_elements)
+        ser = Series([val] * n_elements, dtype="Int64")
+
+        result_numpy = np.mean(na)
+        result_masked = ser.mean()
+        assert result_masked - result_numpy == 0
+        assert result_masked == 1e17
+
     @pytest.mark.parametrize("dtype", ("m8[ns]", "m8[ns]", "M8[ns]", "M8[ns, UTC]"))
     @pytest.mark.parametrize("skipna", [True, False])
     def test_empty_timeseries_reductions_return_nat(self, dtype, skipna):

--- a/pandas/tests/series/test_reductions.py
+++ b/pandas/tests/series/test_reductions.py
@@ -141,16 +141,3 @@ def test_validate_stat_keepdims():
     )
     with pytest.raises(ValueError, match=msg):
         np.sum(ser, keepdims=True)
-
-
-def test_mean_masked_overflow():
-    # GH#48378
-    val = 100_000_000_000_000_000
-    n_elements = 100
-    na = np.array([val] * n_elements)
-    ser = Series([val] * n_elements, dtype="Int64")
-
-    result_numpy = np.mean(na)
-    result_masked = ser.mean()
-    assert result_masked - result_numpy == 0
-    assert result_masked == 1e17

--- a/pandas/tests/series/test_reductions.py
+++ b/pandas/tests/series/test_reductions.py
@@ -144,7 +144,7 @@ def test_validate_stat_keepdims():
 
 
 def test_mean_masked_overflow():
-    # GH#
+    # GH#48378
     val = 100_000_000_000_000_000
     n_elements = 100
     na = np.array([val] * n_elements)

--- a/pandas/tests/series/test_reductions.py
+++ b/pandas/tests/series/test_reductions.py
@@ -141,3 +141,16 @@ def test_validate_stat_keepdims():
     )
     with pytest.raises(ValueError, match=msg):
         np.sum(ser, keepdims=True)
+
+
+def test_mean_masked_overflow():
+    # GH#
+    val = 100_000_000_000_000_000
+    n_elements = 100
+    na = np.array([val] * n_elements)
+    ser = Series([val] * n_elements, dtype="Int64")
+
+    result_numpy = np.mean(na)
+    result_masked = ser.mean()
+    assert result_masked - result_numpy == 0
+    assert result_masked == 1e17


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Do we want to add mean to the Masked Array interface (I would say yes, but want to check anyway)? This would simplify things a bit.

cc @jorisvandenbossche 