### PR TITLE
WARN: Avoid FutureWarnings in tests

### DIFF
--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -777,6 +777,6 @@ def test_fillna_nonconsolidated_frame():
         ],
         columns=["i1", "i2", "i3", "f1"],
     )
-    df_nonconsol = df.pivot("i1", "i2")
+    df_nonconsol = df.pivot(index="i1", columns="i2")
     result = df_nonconsol.fillna(0)
     assert result.isna().sum().sum() == 0

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -136,7 +136,8 @@ class TestDataFrameUpdate:
     def test_update_datetime_tz(self):
         # GH 25807
         result = DataFrame([pd.Timestamp("2019", tz="UTC")])
-        result.update(result)
+        with tm.assert_produces_warning(FutureWarning):
+            result.update(result)
         expected = DataFrame([pd.Timestamp("2019", tz="UTC")])
         tm.assert_frame_equal(result, expected)
 


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Would like to backport, otherwise we have to deal with this on the 1.5.x branch