### PR TITLE
CLN: Refactor groupby._make_wrapper

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -550,10 +550,12 @@ class Apply(metaclass=abc.ABCMeta):
         func = getattr(obj, f, None)
         if callable(func):
             sig = inspect.getfullargspec(func)
-            if "axis" in sig.args:
-                self.kwargs["axis"] = self.axis
-            elif self.axis != 0:
+            if self.axis != 0 and (
+                "axis" not in sig.args or f in ("corrwith", "mad", "skew")
+            ):
                 raise ValueError(f"Operation {f} does not support axis=1")
+            elif "axis" in sig.args:
+                self.kwargs["axis"] = self.axis
         return self._try_aggregate_string_function(obj, f, *self.args, **self.kwargs)
 
     def apply_multiple(self) -> DataFrame | Series:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11657,10 +11657,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         setattr(cls, "all", all)
 
-        # error: Argument 1 to "doc" has incompatible type "Optional[str]"; expected
-        # "Union[str, Callable[..., Any]]"
         @doc(
-            NDFrame.mad.__doc__,  # type: ignore[arg-type]
+            NDFrame.mad.__doc__,
             desc="Return the mean absolute deviation of the values "
             "over the requested axis.",
             name1=name1,

--- a/pandas/core/groupby/base.py
+++ b/pandas/core/groupby/base.py
@@ -1,7 +1,5 @@
 """
-Provide basic components for groupby. These definitions
-hold the allowlist of methods that are exposed on the
-SeriesGroupBy and the DataFrameGroupBy objects.
+Provide basic components for groupby.
 """
 from __future__ import annotations
 
@@ -21,36 +19,6 @@ class OutputKey:
 # special case to prevent duplicate plots when catching exceptions when
 # forwarding methods from NDFrames
 plotting_methods = frozenset(["plot", "hist"])
-
-common_apply_allowlist = (
-    frozenset(
-        [
-            "quantile",
-            "fillna",
-            "mad",
-            "take",
-            "idxmax",
-            "idxmin",
-            "tshift",
-            "skew",
-            "corr",
-            "cov",
-            "diff",
-        ]
-    )
-    | plotting_methods
-)
-
-series_apply_allowlist: frozenset[str] = (
-    common_apply_allowlist
-    | frozenset(
-        {"nlargest", "nsmallest", "is_monotonic_increasing", "is_monotonic_decreasing"}
-    )
-) | frozenset(["dtype", "unique"])
-
-dataframe_apply_allowlist: frozenset[str] = common_apply_allowlist | frozenset(
-    ["dtypes", "corrwith"]
-)
 
 # cythonized transformations or canned "agg+broadcast", which do not
 # require postprocessing of the result by transform.

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -17,6 +17,7 @@ from typing import (
     Callable,
     Hashable,
     Iterable,
+    Literal,
     Mapping,
     NamedTuple,
     Sequence,
@@ -35,9 +36,14 @@ from pandas._libs import (
 )
 from pandas._typing import (
     ArrayLike,
+    Axis,
+    FillnaOptions,
+    IndexLabel,
+    Level,
     Manager,
     Manager2D,
     SingleManager,
+    TakeIndexer,
 )
 from pandas.errors import SpecificationError
 from pandas.util._decorators import (
@@ -78,6 +84,7 @@ from pandas.core.frame import DataFrame
 from pandas.core.groupby import base
 from pandas.core.groupby.groupby import (
     GroupBy,
+    GroupByPlot,
     _agg_template,
     _apply_docs,
     _transform_template,
@@ -135,48 +142,7 @@ def generate_property(name: str, klass: type[DataFrame | Series]):
     return property(prop)
 
 
-def pin_allowlisted_properties(
-    klass: type[DataFrame | Series], allowlist: frozenset[str]
-):
-    """
-    Create GroupBy member defs for DataFrame/Series names in a allowlist.
-
-    Parameters
-    ----------
-    klass : DataFrame or Series class
-        class where members are defined.
-    allowlist : frozenset[str]
-        Set of names of klass methods to be constructed
-
-    Returns
-    -------
-    class decorator
-
-    Notes
-    -----
-    Since we don't want to override methods explicitly defined in the
-    base class, any such name is skipped.
-    """
-
-    def pinner(cls):
-        for name in allowlist:
-            if hasattr(cls, name):
-                # don't override anything that was explicitly defined
-                #  in the base class
-                continue
-
-            prop = generate_property(name, klass)
-            setattr(cls, name, prop)
-
-        return cls
-
-    return pinner
-
-
-@pin_allowlisted_properties(Series, base.series_apply_allowlist)
 class SeriesGroupBy(GroupBy[Series]):
-    _apply_allowlist = base.series_apply_allowlist
-
     def _wrap_agged_manager(self, mgr: Manager) -> Series:
         if mgr.ndim == 1:
             mgr = cast(SingleManager, mgr)
@@ -754,8 +720,82 @@ class SeriesGroupBy(GroupBy[Series]):
             out = ensure_int64(out)
         return self.obj._constructor(out, index=mi, name=self.obj.name)
 
-    @doc(Series.nlargest)
-    def nlargest(self, n: int = 5, keep: str = "first") -> Series:
+    @doc(Series.fillna.__doc__)
+    def fillna(
+        self,
+        value: object | ArrayLike | None = None,
+        method: FillnaOptions | None = None,
+        axis: Axis | None = None,
+        inplace: bool = False,
+        limit: int | None = None,
+        downcast: dict | None = None,
+    ) -> Series | None:
+        result = self._op_via_apply(
+            "fillna",
+            value=value,
+            method=method,
+            axis=axis,
+            inplace=inplace,
+            limit=limit,
+            downcast=downcast,
+        )
+        return result
+
+    @doc(Series.take.__doc__)
+    def take(
+        self,
+        indices: TakeIndexer,
+        axis: Axis = 0,
+        is_copy: bool | None = None,
+        **kwargs,
+    ) -> Series:
+        result = self._op_via_apply(
+            "take", indices=indices, axis=axis, is_copy=is_copy, **kwargs
+        )
+        return result
+
+    @doc(Series.skew.__doc__)
+    def skew(
+        self,
+        axis: Axis | lib.NoDefault = lib.no_default,
+        skipna: bool = True,
+        level: Level | None = None,
+        numeric_only: bool | None = None,
+        **kwargs,
+    ) -> Series:
+        result = self._op_via_apply(
+            "skew",
+            axis=axis,
+            skipna=skipna,
+            level=level,
+            numeric_only=numeric_only,
+            **kwargs,
+        )
+        return result
+
+    @doc(Series.mad.__doc__)
+    def mad(
+        self, axis: Axis | None = None, skipna: bool = True, level: Level | None = None
+    ) -> Series:
+        result = self._op_via_apply("mad", axis=axis, skipna=skipna, level=level)
+        return result
+
+    @doc(Series.tshift.__doc__)
+    def tshift(self, periods: int = 1, freq=None) -> Series:
+        result = self._op_via_apply("tshift", periods=periods, freq=freq)
+        return result
+
+    # Decorated property not supported - https://github.com/python/mypy/issues/1362
+    @property  # type: ignore[misc]
+    @doc(Series.plot.__doc__)
+    def plot(self):
+        result = GroupByPlot(self)
+        return result
+
+    @doc(Series.nlargest.__doc__)
+    def nlargest(
+        self, n: int = 5, keep: Literal["first", "last", "all"] = "first"
+    ) -> Series:
         f = partial(Series.nlargest, n=n, keep=keep)
         data = self._obj_with_exclusions
         # Don't change behavior if result index happens to be the same, i.e.
@@ -763,8 +803,10 @@ class SeriesGroupBy(GroupBy[Series]):
         result = self._python_apply_general(f, data, not_indexed_same=True)
         return result
 
-    @doc(Series.nsmallest)
-    def nsmallest(self, n: int = 5, keep: str = "first") -> Series:
+    @doc(Series.nsmallest.__doc__)
+    def nsmallest(
+        self, n: int = 5, keep: Literal["first", "last", "all"] = "first"
+    ) -> Series:
         f = partial(Series.nsmallest, n=n, keep=keep)
         data = self._obj_with_exclusions
         # Don't change behavior if result index happens to be the same, i.e.
@@ -772,11 +814,99 @@ class SeriesGroupBy(GroupBy[Series]):
         result = self._python_apply_general(f, data, not_indexed_same=True)
         return result
 
+    @doc(Series.idxmin.__doc__)
+    def idxmin(self, axis: Axis = 0, skipna: bool = True) -> Series:
+        result = self._op_via_apply("idxmin", axis=axis, skipna=skipna)
+        return result
 
-@pin_allowlisted_properties(DataFrame, base.dataframe_apply_allowlist)
+    @doc(Series.idxmax.__doc__)
+    def idxmax(self, axis: Axis = 0, skipna: bool = True) -> Series:
+        result = self._op_via_apply("idxmax", axis=axis, skipna=skipna)
+        return result
+
+    @doc(Series.corr.__doc__)
+    def corr(
+        self,
+        other: Series,
+        method: Literal["pearson", "kendall", "spearman"]
+        | Callable[[np.ndarray, np.ndarray], float] = "pearson",
+        min_periods: int | None = None,
+    ) -> Series:
+        result = self._op_via_apply(
+            "corr", other=other, method=method, min_periods=min_periods
+        )
+        return result
+
+    @doc(Series.cov.__doc__)
+    def cov(
+        self, other: Series, min_periods: int | None = None, ddof: int | None = 1
+    ) -> Series:
+        result = self._op_via_apply(
+            "cov", other=other, min_periods=min_periods, ddof=ddof
+        )
+        return result
+
+    # Decorated property not supported - https://github.com/python/mypy/issues/1362
+    @property  # type: ignore[misc]
+    @doc(Series.is_monotonic_increasing.__doc__)
+    def is_monotonic_increasing(self) -> Series:
+        result = self._op_via_apply("is_monotonic_increasing")
+        return result
+
+    # Decorated property not supported - https://github.com/python/mypy/issues/1362
+    @property  # type: ignore[misc]
+    @doc(Series.is_monotonic_decreasing.__doc__)
+    def is_monotonic_decreasing(self) -> Series:
+        result = self._op_via_apply("is_monotonic_decreasing")
+        return result
+
+    @doc(Series.hist.__doc__)
+    def hist(
+        self,
+        by=None,
+        ax=None,
+        grid: bool = True,
+        xlabelsize: int | None = None,
+        xrot: float | None = None,
+        ylabelsize: int | None = None,
+        yrot: float | None = None,
+        figsize: tuple[int, int] | None = None,
+        bins: int | Sequence[int] = 10,
+        backend: str | None = None,
+        legend: bool = False,
+        **kwargs,
+    ):
+        result = self._op_via_apply(
+            "hist",
+            by=by,
+            ax=ax,
+            grid=grid,
+            xlabelsize=xlabelsize,
+            xrot=xrot,
+            ylabelsize=ylabelsize,
+            yrot=yrot,
+            figsize=figsize,
+            bins=bins,
+            backend=backend,
+            legend=legend,
+            **kwargs,
+        )
+        return result
+
+    # Decorated property not supported - https://github.com/python/mypy/issues/1362
+    @property  # type: ignore[misc]
+    @doc(Series.dtype.__doc__)
+    def dtype(self) -> Series:
+        result = self._op_via_apply("dtype")
+        return result
+
+    @doc(Series.unique.__doc__)
+    def unique(self) -> Series:
+        result = self._op_via_apply("unique")
+        return result
+
+
 class DataFrameGroupBy(GroupBy[DataFrame]):
-
-    _apply_allowlist = base.dataframe_apply_allowlist
 
     _agg_examples_doc = dedent(
         """
@@ -1910,6 +2040,169 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                 result_frame.columns = columns + [name]
                 result = result_frame
             return result.__finalize__(self.obj, method="value_counts")
+
+    @doc(DataFrame.fillna.__doc__)
+    def fillna(
+        self,
+        value: Hashable | Mapping | Series | DataFrame = None,
+        method: FillnaOptions | None = None,
+        axis: Axis | None = None,
+        inplace: bool = False,
+        limit=None,
+        downcast=None,
+    ) -> DataFrame | None:
+        result = self._op_via_apply(
+            "fillna",
+            value=value,
+            method=method,
+            axis=axis,
+            inplace=inplace,
+            limit=limit,
+            downcast=downcast,
+        )
+        return result
+
+    @doc(DataFrame.take.__doc__)
+    def take(
+        self,
+        indices: TakeIndexer,
+        axis: Axis | None = 0,
+        is_copy: bool | None = None,
+        **kwargs,
+    ) -> DataFrame:
+        result = self._op_via_apply(
+            "take", indices=indices, axis=axis, is_copy=is_copy, **kwargs
+        )
+        return result
+
+    @doc(DataFrame.skew.__doc__)
+    def skew(
+        self,
+        axis: Axis | None | lib.NoDefault = lib.no_default,
+        skipna: bool = True,
+        level: Level | None = None,
+        numeric_only: bool | lib.NoDefault = lib.no_default,
+        **kwargs,
+    ) -> DataFrame:
+        result = self._op_via_apply(
+            "skew",
+            axis=axis,
+            skipna=skipna,
+            level=level,
+            numeric_only=numeric_only,
+            **kwargs,
+        )
+        return result
+
+    @doc(DataFrame.mad.__doc__)
+    def mad(
+        self, axis: Axis | None = None, skipna: bool = True, level: Level | None = None
+    ) -> DataFrame:
+        result = self._op_via_apply("mad", axis=axis, skipna=skipna, level=level)
+        return result
+
+    @doc(DataFrame.tshift.__doc__)
+    def tshift(self, periods: int = 1, freq=None, axis: Axis = 0) -> DataFrame:
+        result = self._op_via_apply("tshift", periods=periods, freq=freq, axis=axis)
+        return result
+
+    @property  # type: ignore[misc]
+    @doc(DataFrame.plot.__doc__)
+    def plot(self) -> GroupByPlot:
+        result = GroupByPlot(self)
+        return result
+
+    @doc(DataFrame.corr.__doc__)
+    def corr(
+        self,
+        method: str | Callable[[np.ndarray, np.ndarray], float] = "pearson",
+        min_periods: int = 1,
+        numeric_only: bool | lib.NoDefault = lib.no_default,
+    ) -> DataFrame:
+        result = self._op_via_apply(
+            "corr", method=method, min_periods=min_periods, numeric_only=numeric_only
+        )
+        return result
+
+    @doc(DataFrame.cov.__doc__)
+    def cov(
+        self,
+        min_periods: int | None = None,
+        ddof: int | None = 1,
+        numeric_only: bool | lib.NoDefault = lib.no_default,
+    ) -> DataFrame:
+        result = self._op_via_apply(
+            "cov", min_periods=min_periods, ddof=ddof, numeric_only=numeric_only
+        )
+        return result
+
+    @doc(DataFrame.hist.__doc__)
+    def hist(
+        self,
+        column: IndexLabel = None,
+        by=None,
+        grid: bool = True,
+        xlabelsize: int | None = None,
+        xrot: float | None = None,
+        ylabelsize: int | None = None,
+        yrot: float | None = None,
+        ax=None,
+        sharex: bool = False,
+        sharey: bool = False,
+        figsize: tuple[int, int] | None = None,
+        layout: tuple[int, int] | None = None,
+        bins: int | Sequence[int] = 10,
+        backend: str | None = None,
+        legend: bool = False,
+        **kwargs,
+    ):
+        result = self._op_via_apply(
+            "hist",
+            column=column,
+            by=by,
+            grid=grid,
+            xlabelsize=xlabelsize,
+            xrot=xrot,
+            ylabelsize=ylabelsize,
+            yrot=yrot,
+            ax=ax,
+            sharex=sharex,
+            sharey=sharey,
+            figsize=figsize,
+            layout=layout,
+            bins=bins,
+            backend=backend,
+            legend=legend,
+            **kwargs,
+        )
+        return result
+
+    # Decorated property not supported - https://github.com/python/mypy/issues/1362
+    @property  # type: ignore[misc]
+    @doc(DataFrame.dtypes.__doc__)
+    def dtypes(self) -> Series:
+        result = self._op_via_apply("dtypes")
+        return result
+
+    @doc(DataFrame.corrwith.__doc__)
+    def corrwith(
+        self,
+        other: DataFrame | Series,
+        axis: Axis = 0,
+        drop: bool = False,
+        method: Literal["pearson", "kendall", "spearman"]
+        | Callable[[np.ndarray, np.ndarray], float] = "pearson",
+        numeric_only: bool | lib.NoDefault = lib.no_default,
+    ) -> DataFrame:
+        result = self._op_via_apply(
+            "corrwith",
+            other=other,
+            axis=axis,
+            drop=drop,
+            method=method,
+            numeric_only=numeric_only,
+        )
+        return result
 
 
 def _wrap_transform_general_frame(

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -989,6 +989,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
 
     @final
     def _op_via_apply(self, name: str, *args, **kwargs):
+        """Compute the result of an operation by using GroupBy's apply."""
         f = getattr(type(self._obj_with_exclusions), name)
         with self._group_selection_context():
             # need to setup the selection

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -212,14 +212,19 @@ def test_aggregate_str_func(tsframe, groupbyfunc):
 
 def test_agg_str_with_kwarg_axis_1_raises(df, reduction_func):
     gb = df.groupby(level=0)
-    if reduction_func in ("idxmax", "idxmin"):
-        error = TypeError
-        msg = "reduction operation '.*' not allowed for this dtype"
+    args = (df,) if reduction_func == "corrwith" else ()
+    if reduction_func == "corrwith":
+        # GH#47723 - corrwith supports axis=1:
+        gb.agg(reduction_func, *args, axis=1)
     else:
-        error = ValueError
-        msg = f"Operation {reduction_func} does not support axis=1"
-    with pytest.raises(error, match=msg):
-        gb.agg(reduction_func, axis=1)
+        if reduction_func in ("idxmax", "idxmin"):
+            error = TypeError
+            msg = "reduction operation '.*' not allowed for this dtype"
+        else:
+            error = ValueError
+            msg = f"Operation {reduction_func} does not support axis=1"
+        with pytest.raises(error, match=msg):
+            gb.agg(reduction_func, *args, axis=1)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -212,19 +212,14 @@ def test_aggregate_str_func(tsframe, groupbyfunc):
 
 def test_agg_str_with_kwarg_axis_1_raises(df, reduction_func):
     gb = df.groupby(level=0)
-    args = (df,) if reduction_func == "corrwith" else ()
-    if reduction_func == "corrwith":
-        # GH#47723 - corrwith supports axis=1:
-        gb.agg(reduction_func, *args, axis=1)
+    if reduction_func in ("idxmax", "idxmin"):
+        error = TypeError
+        msg = "reduction operation '.*' not allowed for this dtype"
     else:
-        if reduction_func in ("idxmax", "idxmin"):
-            error = TypeError
-            msg = "reduction operation '.*' not allowed for this dtype"
-        else:
-            error = ValueError
-            msg = f"Operation {reduction_func} does not support axis=1"
-        with pytest.raises(error, match=msg):
-            gb.agg(reduction_func, *args, axis=1)
+        error = ValueError
+        msg = f"Operation {reduction_func} does not support axis=1"
+    with pytest.raises(error, match=msg):
+        gb.agg(reduction_func, axis=1)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/groupby/test_allowlist.py
+++ b/pandas/tests/groupby/test_allowlist.py
@@ -35,57 +35,6 @@ AGG_FUNCTIONS = [
 ]
 AGG_FUNCTIONS_WITH_SKIPNA = ["skew", "mad"]
 
-df_allowlist = [
-    "quantile",
-    "fillna",
-    "mad",
-    "take",
-    "idxmax",
-    "idxmin",
-    "tshift",
-    "skew",
-    "plot",
-    "hist",
-    "dtypes",
-    "corrwith",
-    "corr",
-    "cov",
-    "diff",
-]
-
-
-@pytest.fixture(params=df_allowlist)
-def df_allowlist_fixture(request):
-    return request.param
-
-
-s_allowlist = [
-    "quantile",
-    "fillna",
-    "mad",
-    "take",
-    "idxmax",
-    "idxmin",
-    "tshift",
-    "skew",
-    "plot",
-    "hist",
-    "dtype",
-    "corr",
-    "cov",
-    "diff",
-    "unique",
-    "nlargest",
-    "nsmallest",
-    "is_monotonic_increasing",
-    "is_monotonic_decreasing",
-]
-
-
-@pytest.fixture(params=s_allowlist)
-def s_allowlist_fixture(request):
-    return request.param
-
 
 @pytest.fixture
 def df():
@@ -111,54 +60,6 @@ def df_letters():
         }
     )
     return df
-
-
-@pytest.mark.parametrize("allowlist", [df_allowlist, s_allowlist])
-def test_groupby_allowlist(df_letters, allowlist):
-    df = df_letters
-    if allowlist == df_allowlist:
-        # dataframe
-        obj = df_letters
-    else:
-        obj = df_letters["floats"]
-
-    gb = obj.groupby(df.letters)
-
-    assert set(allowlist) == set(gb._apply_allowlist)
-
-
-def check_allowlist(obj, df, m):
-    # check the obj for a particular allowlist m
-
-    gb = obj.groupby(df.letters)
-
-    f = getattr(type(gb), m)
-
-    # name
-    try:
-        n = f.__name__
-    except AttributeError:
-        return
-    assert n == m
-
-    # qualname
-    try:
-        n = f.__qualname__
-    except AttributeError:
-        return
-    assert n.endswith(m)
-
-
-def test_groupby_series_allowlist(df_letters, s_allowlist_fixture):
-    m = s_allowlist_fixture
-    df = df_letters
-    check_allowlist(df.letters, df, m)
-
-
-def test_groupby_frame_allowlist(df_letters, df_allowlist_fixture):
-    m = df_allowlist_fixture
-    df = df_letters
-    check_allowlist(df, df, m)
 
 
 @pytest.fixture

--- a/pandas/tests/groupby/test_api_consistency.py
+++ b/pandas/tests/groupby/test_api_consistency.py
@@ -1,0 +1,136 @@
+"""
+Test the consistency of the groupby API, both internally and with other pandas objects.
+"""
+
+import inspect
+
+import pytest
+
+from pandas import (
+    DataFrame,
+    Series,
+)
+from pandas.core.groupby.generic import (
+    DataFrameGroupBy,
+    SeriesGroupBy,
+)
+
+
+def test_frame_consistency(request, groupby_func):
+    # GH#48028
+    if groupby_func in ("first", "last"):
+        msg = "first and last are entirely different between frame and groupby"
+        request.node.add_marker(pytest.mark.xfail(reason=msg))
+    if groupby_func in ("nth", "cumcount", "ngroup"):
+        msg = "DataFrame has no such method"
+        request.node.add_marker(pytest.mark.xfail(reason=msg))
+    if groupby_func in ("size",):
+        msg = "Method is a property"
+        request.node.add_marker(pytest.mark.xfail(reason=msg))
+
+    frame_method = getattr(DataFrame, groupby_func)
+    gb_method = getattr(DataFrameGroupBy, groupby_func)
+    result = set(inspect.signature(gb_method).parameters)
+    expected = set(inspect.signature(frame_method).parameters)
+
+    # Exclude certain arguments from result and expected depending on the operation
+    # Some of these may be purposeful inconsistencies between the APIs
+    exclude_expected, exclude_result = set(), set()
+    if groupby_func in ("any", "all"):
+        exclude_expected = {"kwargs", "bool_only", "level", "axis"}
+    elif groupby_func in ("count",):
+        exclude_expected = {"numeric_only", "level", "axis"}
+    elif groupby_func in ("nunique",):
+        exclude_expected = {"axis"}
+    elif groupby_func in ("max", "min"):
+        exclude_expected = {"axis", "kwargs", "level", "skipna"}
+        exclude_result = {"min_count", "engine", "engine_kwargs"}
+    elif groupby_func in ("mean", "std", "sum", "var"):
+        exclude_expected = {"axis", "kwargs", "level", "skipna"}
+        exclude_result = {"engine", "engine_kwargs"}
+    elif groupby_func in ("median", "prod", "sem"):
+        exclude_expected = {"axis", "kwargs", "level", "skipna"}
+    elif groupby_func in ("backfill", "bfill", "ffill", "pad"):
+        exclude_expected = {"downcast", "inplace", "axis"}
+    elif groupby_func in ("cummax", "cummin"):
+        exclude_expected = {"skipna", "args"}
+        exclude_result = {"numeric_only"}
+    elif groupby_func in ("cumprod", "cumsum"):
+        exclude_expected = {"skipna"}
+    elif groupby_func in ("pct_change",):
+        exclude_expected = {"kwargs"}
+        exclude_result = {"axis"}
+    elif groupby_func in ("rank",):
+        exclude_expected = {"numeric_only"}
+    elif groupby_func in ("quantile",):
+        exclude_expected = {"method", "axis"}
+
+    # Ensure excluded arguments are actually in the signatures
+    assert result & exclude_result == exclude_result
+    assert expected & exclude_expected == exclude_expected
+
+    result -= exclude_result
+    expected -= exclude_expected
+    assert result == expected
+
+
+def test_series_consistency(request, groupby_func):
+    # GH#48028
+    if groupby_func in ("first", "last"):
+        msg = "first and last are entirely different between Series and groupby"
+        request.node.add_marker(pytest.mark.xfail(reason=msg))
+    if groupby_func in ("nth", "cumcount", "ngroup", "corrwith"):
+        msg = "Series has no such method"
+        request.node.add_marker(pytest.mark.xfail(reason=msg))
+    if groupby_func in ("size",):
+        msg = "Method is a property"
+        request.node.add_marker(pytest.mark.xfail(reason=msg))
+
+    series_method = getattr(Series, groupby_func)
+    gb_method = getattr(SeriesGroupBy, groupby_func)
+    result = set(inspect.signature(gb_method).parameters)
+    expected = set(inspect.signature(series_method).parameters)
+
+    # Exclude certain arguments from result and expected depending on the operation
+    # Some of these may be purposeful inconsistencies between the APIs
+    exclude_expected, exclude_result = set(), set()
+    if groupby_func in ("any", "all"):
+        exclude_expected = {"kwargs", "bool_only", "level", "axis"}
+    elif groupby_func in ("count",):
+        exclude_expected = {"level"}
+    elif groupby_func in ("tshift",):
+        exclude_expected = {"axis"}
+    elif groupby_func in ("diff",):
+        exclude_result = {"axis"}
+    elif groupby_func in ("max", "min"):
+        exclude_expected = {"axis", "kwargs", "level", "skipna"}
+        exclude_result = {"min_count", "engine", "engine_kwargs"}
+    elif groupby_func in ("mean", "std", "sum", "var"):
+        exclude_expected = {"axis", "kwargs", "level", "skipna"}
+        exclude_result = {"engine", "engine_kwargs"}
+    elif groupby_func in ("median", "prod", "sem"):
+        exclude_expected = {"axis", "kwargs", "level", "skipna"}
+    elif groupby_func in ("backfill", "bfill", "ffill", "pad"):
+        exclude_expected = {"downcast", "inplace", "axis"}
+    elif groupby_func in ("cummax", "cummin"):
+        exclude_expected = {"skipna", "args"}
+        exclude_result = {"numeric_only"}
+    elif groupby_func in ("cumprod", "cumsum"):
+        exclude_expected = {"skipna"}
+    elif groupby_func in ("pct_change",):
+        exclude_expected = {"kwargs"}
+        exclude_result = {"axis"}
+    elif groupby_func in ("rank",):
+        exclude_expected = {"numeric_only"}
+    elif groupby_func in ("idxmin", "idxmax"):
+        exclude_expected = {"args", "kwargs"}
+    elif groupby_func in ("quantile",):
+        exclude_result = {"numeric_only"}
+
+    # Ensure excluded arguments are actually in the signatures
+    assert result & exclude_result == exclude_result
+    assert expected & exclude_expected == exclude_expected
+
+    result -= exclude_result
+    expected -= exclude_expected
+    assert result == expected

--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -351,7 +351,7 @@ def rewrite_axis_style_signature(
     return decorate
 
 
-def doc(*docstrings: str | Callable, **params) -> Callable[[F], F]:
+def doc(*docstrings: None | str | Callable, **params) -> Callable[[F], F]:
     """
     A decorator take docstring templates, concatenate them and perform string
     substitution on it.
@@ -364,7 +364,7 @@ def doc(*docstrings: str | Callable, **params) -> Callable[[F], F]:
 
     Parameters
     ----------
-    *docstrings : str or callable
+    *docstrings : None, str, or callable
         The string / docstring / docstring template to be appended in order
         after default docstring under callable.
     **params
@@ -378,6 +378,8 @@ def doc(*docstrings: str | Callable, **params) -> Callable[[F], F]:
             docstring_components.append(dedent(decorated.__doc__))
 
         for docstring in docstrings:
+            if docstring is None:
+                continue
             if hasattr(docstring, "_docstring_components"):
                 # error: Item "str" of "Union[str, Callable[..., Any]]" has no attribute
                 # "_docstring_components"
@@ -389,13 +391,19 @@ def doc(*docstrings: str | Callable, **params) -> Callable[[F], F]:
             elif isinstance(docstring, str) or docstring.__doc__:
                 docstring_components.append(docstring)
 
-        # formatting templates and concatenating docstring
+        params_applied = [
+            component.format(**params)
+            if isinstance(component, str) and len(params) > 0
+            else component
+            for component in docstring_components
+        ]
+
         decorated.__doc__ = "".join(
             [
-                component.format(**params)
+                component
                 if isinstance(component, str)
                 else dedent(component.__doc__ or "")
-                for component in docstring_components
+                for component in params_applied
             ]
         )
 


### PR DESCRIPTION
- [x] closes #48028 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Currently keeping the docs the same, plan to make groupby-specific docstrings in the future. Note that most of the SeriesGroupBy docs don't make it into the documentation, I've opened #48399. The only change from a user-perspective here should be that Jupyter / IDEs can now get the correct signature (instead of `*args, **kwargs`).

![image](https://user-images.githubusercontent.com/45562402/188480390-ec9f26c3-ec3d-456d-961b-1843713b8679.png)

![image](https://user-images.githubusercontent.com/45562402/188480951-4e679091-0c7a-402b-8c9e-7e8293f793d1.png)

