### PR TITLE
PERF: MultiIndex.argsort / MultiIndex.sort_values

### DIFF
--- a/asv_bench/benchmarks/multiindex_object.py
+++ b/asv_bench/benchmarks/multiindex_object.py
@@ -176,6 +176,16 @@ class Sortlevel:
         self.mi.sortlevel(1)
 
 
+class SortValues:
+    def setup(self):
+        a = np.tile(np.arange(100), 1000)
+        b = np.tile(np.arange(1000), 100)
+        self.mi = MultiIndex.from_arrays([a, b])
+
+    def time_sort_values(self):
+        self.mi.sort_values()
+
+
 class Values:
     def setup_cache(self):
 

--- a/asv_bench/benchmarks/multiindex_object.py
+++ b/asv_bench/benchmarks/multiindex_object.py
@@ -8,6 +8,7 @@ from pandas import (
     MultiIndex,
     RangeIndex,
     Series,
+    array,
     date_range,
 )
 
@@ -177,12 +178,16 @@ class Sortlevel:
 
 
 class SortValues:
-    def setup(self):
-        a = np.tile(np.arange(100), 1000)
-        b = np.tile(np.arange(1000), 100)
+
+    params = ["int64", "Int64"]
+    param_names = ["dtype"]
+
+    def setup(self, dtype):
+        a = array(np.tile(np.arange(100), 1000), dtype=dtype)
+        b = array(np.tile(np.arange(1000), 100), dtype=dtype)
         self.mi = MultiIndex.from_arrays([a, b])
 
-    def time_sort_values(self):
+    def time_sort_values(self, dtype):
         self.mi.sort_values()
 
 

--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -100,6 +100,7 @@ Deprecations
 
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
+- Performance improvement in :meth:`MultiIndex.argsort` and :meth:`MultiIndex.sort_values` (:issue:`48406`)
 - Performance improvement in :meth:`.GroupBy.mean` and :meth:`.GroupBy.var` for extension array dtypes (:issue:`37493`)
 - Performance improvement for :meth:`MultiIndex.unique` (:issue:`48335`)
 -

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2225,6 +2225,10 @@ class MultiIndex(Index):
             return Index._with_infer(new_tuples)
 
     def argsort(self, *args, **kwargs) -> npt.NDArray[np.intp]:
+        if len(args) == 0 and len(kwargs) == 0:
+            # np.lexsort is significantly faster than self._values.argsort()
+            values = [self._get_level_values(i) for i in reversed(range(self.nlevels))]
+            return np.lexsort(values)
         return self._values.argsort(*args, **kwargs)
 
     @Appender(_index_shared_docs["repeat"] % _index_doc_kwargs)

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -530,11 +530,6 @@ def test_union_duplicates(index, request):
     if index.empty or isinstance(index, (IntervalIndex, CategoricalIndex)):
         # No duplicates in empty indexes
         return
-    if index.dtype.kind == "c":
-        mark = pytest.mark.xfail(
-            reason="sort_values() call raises bc complex objects are not comparable"
-        )
-        request.node.add_marker(mark)
 
     values = index.unique().values.tolist()
     mi1 = MultiIndex.from_arrays([values, [1] * len(values)])


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v1.6.0.rst` file if fixing a bug or adding a new feature.

Perf improvement in `MultiIndex.argsort` and `MultiIndex.sort_values` for the vast majority of cases (where `MultiIndex.argsort` is called without additional passthrough numpy parameters).

Also, an xfail was removed because np.lexsort does not complain about complex dtype arrays whereas np.argsort will complain about an object array of tuples containing complex and non-complex dtypes. 

ASV added:

```
       before           after         ratio
     [fa211d47]       [b2fea756]
     <main>           <perf-multiindex-argsort>
-      81.0±0.9ms       27.9±0.7ms     0.34  multiindex_object.SortValues.time_sort_values('Int64')
-        96.9±2ms       2.00±0.2ms     0.02  multiindex_object.SortValues.time_sort_values('int64')
```



