### PR TITLE
REGR: get_loc for ExtensionEngine not returning bool indexer for na

### DIFF
--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -1061,7 +1061,7 @@ cdef class ExtensionEngine(SharedEngine):
 
     cdef ndarray _get_bool_indexer(self, val):
         if checknull(val):
-            return self.values.isna().view("uint8")
+            return self.values.isna()
 
         try:
             return self.values == val

--- a/pandas/tests/indexes/test_indexing.py
+++ b/pandas/tests/indexes/test_indexing.py
@@ -223,7 +223,7 @@ class TestGetLoc:
             index.get_loc(x for x in range(5))
 
     def test_get_loc_masked_duplicated_na(self):
-        # GH#
+        # GH#48411
         idx = Index([1, 2, NA, NA], dtype="Int64")
         result = idx.get_loc(NA)
         expected = np.array([False, False, True, True])
@@ -262,7 +262,7 @@ class TestGetIndexer:
         assert indexer.dtype == np.intp
 
     def test_get_indexer_masked_duplicated_na(self):
-        # GH#
+        # GH#48411
         idx = Index([1, 2, NA, NA], dtype="Int64")
         result = idx.get_indexer_for(Index([1, NA], dtype="Int64"))
         expected = np.array([0, 2, 3])

--- a/pandas/tests/indexes/test_indexing.py
+++ b/pandas/tests/indexes/test_indexing.py
@@ -265,7 +265,7 @@ class TestGetIndexer:
         # GH#48411
         idx = Index([1, 2, NA, NA], dtype="Int64")
         result = idx.get_indexer_for(Index([1, NA], dtype="Int64"))
-        expected = np.array([0, 2, 3])
+        expected = np.array([0, 2, 3], dtype="int64")
         tm.assert_numpy_array_equal(result, expected)
 
 

--- a/pandas/tests/indexes/test_indexing.py
+++ b/pandas/tests/indexes/test_indexing.py
@@ -20,6 +20,7 @@ import pytest
 from pandas.errors import InvalidIndexError
 
 from pandas import (
+    NA,
     DatetimeIndex,
     Index,
     IntervalIndex,
@@ -221,6 +222,13 @@ class TestGetLoc:
             # MultiIndex specifically checks for generator; others for scalar
             index.get_loc(x for x in range(5))
 
+    def test_get_loc_masked_duplicated_na(self):
+        # GH#
+        idx = Index([1, 2, NA, NA], dtype="Int64")
+        result = idx.get_loc(NA)
+        expected = np.array([False, False, True, True])
+        tm.assert_numpy_array_equal(result, expected)
+
 
 class TestGetIndexer:
     def test_get_indexer_base(self, index):
@@ -252,6 +260,13 @@ class TestGetIndexer:
         indexer, _ = index.get_indexer_non_unique(index[0:2])
         assert isinstance(indexer, np.ndarray)
         assert indexer.dtype == np.intp
+
+    def test_get_indexer_masked_duplicated_na(self):
+        # GH#
+        idx = Index([1, 2, NA, NA], dtype="Int64")
+        result = idx.get_indexer_for(Index([1, NA], dtype="Int64"))
+        expected = np.array([0, 2, 3])
+        tm.assert_numpy_array_equal(result, expected)
 
 
 class TestConvertSliceIndexer:

--- a/pandas/tests/indexes/test_indexing.py
+++ b/pandas/tests/indexes/test_indexing.py
@@ -265,7 +265,7 @@ class TestGetIndexer:
         # GH#48411
         idx = Index([1, 2, NA, NA], dtype="Int64")
         result = idx.get_indexer_for(Index([1, NA], dtype="Int64"))
-        expected = np.array([0, 2, 3], dtype="int64")
+        expected = np.array([0, 2, 3], dtype=result.dtype)
         tm.assert_numpy_array_equal(result, expected)
 
 


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Stumbled across this when working on something else.

ExtensionEngine was new in 1.5, so no whatsnew. But should backport to 1.5
