### PR TITLE
BUG: safe_sort losing MultiIndex dtypes

### DIFF
--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -11,6 +11,7 @@ from pandas.compat import (
 )
 
 from pandas import (
+    NA,
     DataFrame,
     MultiIndex,
     Series,
@@ -510,3 +511,15 @@ def test_mixed_str_nan():
     result = safe_sort(values)
     expected = np.array([np.nan, "a", "b", "b"], dtype=object)
     tm.assert_numpy_array_equal(result, expected)
+
+
+def test_safe_sort_multiindex():
+    # GH#48412
+    arr1 = Series([2, 1, NA, NA], dtype="Int64")
+    arr2 = [2, 1, 3, 3]
+    midx = MultiIndex.from_arrays([arr1, arr2])
+    result = safe_sort(midx)
+    expected = MultiIndex.from_arrays(
+        [Series([1, 2, NA, NA], dtype="Int64"), [1, 2, 3, 3]]
+    )
+    tm.assert_index_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

I don't think that this is user visible. This is a precursor for improving ea support in MultiIndex operations