### PR TITLE
REF: ensure to apply suffixes before concat step in merge code

### DIFF
--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -764,8 +764,9 @@ class _MergeOperation:
 
         from pandas import concat
 
+        left.columns = llabels
+        right.columns = rlabels
         result = concat([left, right], axis=1, copy=copy)
-        result.columns = llabels.append(rlabels)
         return result
 
     def get_result(self, copy: bool = True) -> DataFrame:


### PR DESCRIPTION
Follow-up on https://github.com/pandas-dev/pandas/pull/48082

I _could_ add a test by writing a small DataFrame subclass that checks for duplicate columns in its constructor, or we could rely on geopandas CI catching this (we do test against pandas main). Either way is fine for me.