### PR TITLE
BUG: ensure to return writable buffer in __dataframe__ interchange for categorical column

### DIFF
--- a/pandas/core/interchange/column.py
+++ b/pandas/core/interchange/column.py
@@ -270,7 +270,7 @@ class PandasColumn(Column):
             buffer = PandasBuffer(self._col.to_numpy(), allow_copy=self._allow_copy)
             dtype = self.dtype
         elif self.dtype[0] == DtypeKind.CATEGORICAL:
-            codes = self._col.values.codes
+            codes = self._col.values._codes
             buffer = PandasBuffer(codes, allow_copy=self._allow_copy)
             dtype = self._dtype_from_pandasdtype(codes.dtype)
         elif self.dtype[0] == DtypeKind.STRING:

--- a/pandas/tests/interchange/test_impl.py
+++ b/pandas/tests/interchange/test_impl.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs import iNaT
+import pandas.util._test_decorators as td
 
 import pandas as pd
 import pandas._testing as tm
@@ -193,3 +194,13 @@ def test_datetime():
     assert col.describe_null == (ColumnNullType.USE_SENTINEL, iNaT)
 
     tm.assert_frame_equal(df, from_dataframe(df.__dataframe__()))
+
+
+@td.skip_if_np_lt("1.23")
+def test_categorical_to_numpy_dlpack():
+    # https://github.com/pandas-dev/pandas/issues/48393
+    df = pd.DataFrame({"A": pd.Categorical["a", "b", "a"]})
+    col = df.__dataframe__().get_column_by_name("A")
+    result = np.from_dlpack(col.get_buffers()["data"][0])
+    expected = np.array([0, 1, 0], dtype="int8")
+    tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/interchange/test_impl.py
+++ b/pandas/tests/interchange/test_impl.py
@@ -199,7 +199,7 @@ def test_datetime():
 @td.skip_if_np_lt("1.23")
 def test_categorical_to_numpy_dlpack():
     # https://github.com/pandas-dev/pandas/issues/48393
-    df = pd.DataFrame({"A": pd.Categorical["a", "b", "a"]})
+    df = pd.DataFrame({"A": pd.Categorical(["a", "b", "a"])})
     col = df.__dataframe__().get_column_by_name("A")
     result = np.from_dlpack(col.get_buffers()["data"][0])
     expected = np.array([0, 1, 0], dtype="int8")


### PR DESCRIPTION
- [x] closes https://github.com/pandas-dev/pandas/issues/48393
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
