### PR TITLE
DOC: Remove storage options from doc of Styler.to_excel

### DIFF
--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -442,7 +442,7 @@ class Styler(StylerRenderer):
     @doc(
         NDFrame.to_excel,
         klass="Styler",
-        storage_options=_shared_docs["storage_options"],
+        storage_options="",
     )
     def to_excel(
         self,


### PR DESCRIPTION
Remove parameter from doc string that is not in function.  `Styler.to_excel` only supports `storage_options` in 1.5.x+

The PR is only for the 1.4.x branch.