### PR TITLE
CI: Use -j1 for python-dev build to avoid flaky build error

### DIFF
--- a/.github/workflows/python-dev.yml
+++ b/.github/workflows/python-dev.yml
@@ -80,9 +80,10 @@ jobs:
         python -m pip install python-dateutil pytz cython hypothesis==6.52.1 pytest>=6.2.5 pytest-xdist pytest-cov pytest-asyncio>=0.17
         python -m pip list
 
+    # GH 47305: Parallel build can cause flaky ImportError from pandas/_libs/tslibs
     - name: Build Pandas
       run: |
-        python setup.py build_ext -q -j2
+        python setup.py build_ext -q -j1
         python -m pip install -e . --no-build-isolation --no-use-pep517
 
     - name: Build Version


### PR DESCRIPTION
xref #47305

e.g. https://github.com/pandas-dev/pandas/runs/8280474438?check_suite_focus=true
