### PR TITLE
change test such that it passes in headless mode (instead of xpass)

### DIFF
--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -391,6 +391,7 @@ class TestClipboard:
         self.check_round_trip_frame(df, encoding=enc)
 
     @pytest.mark.parametrize("data", ["\U0001f44d...", "Ωœ∑´...", "abcd..."])
+    @pytest.mark.single_cpu
     @pytest.mark.xfail(
         os.environ.get("DISPLAY") is None,
         reason="Cannot be runed if a headless system is not put in place with Xvfb",

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -390,8 +390,8 @@ class TestClipboard:
     def test_round_trip_valid_encodings(self, enc, df):
         self.check_round_trip_frame(df, encoding=enc)
 
-    @pytest.mark.parametrize("data", ["\U0001f44d...", "Ωœ∑´...", "abcd..."])
     @pytest.mark.single_cpu
+    @pytest.mark.parametrize("data", ["\U0001f44d...", "Ωœ∑´...", "abcd..."])
     @pytest.mark.xfail(
         os.environ.get("DISPLAY") is None,
         reason="Cannot be runed if a headless system is not put in place with Xvfb",

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -1,5 +1,5 @@
-from textwrap import dedent
 import os
+from textwrap import dedent
 
 import numpy as np
 import pytest
@@ -392,8 +392,8 @@ class TestClipboard:
 
     @pytest.mark.parametrize("data", ["\U0001f44d...", "Ωœ∑´...", "abcd..."])
     @pytest.mark.xfail(
-        os.environ.get('DISPLAY') is None, 
-        reason="Cannot be runned if a headless system is not put in place with ",
+        os.environ.get("DISPLAY") is None,
+        reason="Cannot be runed if a headless system is not put in place with Xvfb",
         strict=True,
     )
     def test_raw_roundtrip(self, data):

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -1,4 +1,5 @@
 from textwrap import dedent
+import os
 
 import numpy as np
 import pytest
@@ -391,9 +392,9 @@ class TestClipboard:
 
     @pytest.mark.parametrize("data", ["\U0001f44d...", "Ωœ∑´...", "abcd..."])
     @pytest.mark.xfail(
-        reason="Flaky test in multi-process CI environment: GH 44584",
-        raises=AssertionError,
-        strict=False,
+        os.environ.get('DISPLAY') is None, 
+        reason="Cannot be runned if a headless system is not put in place with ",
+        strict=True,
     )
     def test_raw_roundtrip(self, data):
         # PR #25040 wide unicode wasn't copied correctly on PY3 on windows


### PR DESCRIPTION
…and xpass in non-headless mode (instead of error).

- [ ] closes #48483 
- [ ] [Tests *modified* and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests). 
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
