### PR TITLE
CI/TST: Remove --color=yes for more consistent log output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ exclude = '''
 [tool.pytest.ini_options]
 # sync minversion with pyproject.toml & install.rst
 minversion =  "6.0"
-addopts = "--strict-data-files --strict-markers --strict-config --capture=no --durations=30 --junitxml=test-data.xml --color=yes"
+addopts = "--strict-data-files --strict-markers --strict-config --capture=no --durations=30 --junitxml=test-data.xml"
 xfail_strict = true
 testpaths = "pandas"
 doctest_optionflags = [


### PR DESCRIPTION
While debugging https://github.com/pandas-dev/pandas/pull/48258, I noticed the pytest logs would not correctly render since we've activated `--color=yes`.

Example: https://github.com/pandas-dev/pandas/actions/runs/3025310849/jobs/4867636909
Example wo/ color: https://github.com/pandas-dev/pandas/actions/runs/3026037317/jobs/4869041807

I tried the solutions found in https://github.com/pytest-dev/pytest/issues/7443 but unfortunately they didn't work so removing for now. 
