### PR TITLE
Added test case to lock in behaviour

### DIFF
--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -212,6 +212,7 @@ Sparse
 ExtensionArray
 ^^^^^^^^^^^^^^
 - Bug in :meth:`Series.mean` overflowing unnecessarily with nullable integers (:issue:`48378`)
+- Loss of dtype information when concatenating EA with empty EA of same type (:issue:`48510`)
 -
 
 Styler

--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -212,7 +212,7 @@ Sparse
 ExtensionArray
 ^^^^^^^^^^^^^^
 - Bug in :meth:`Series.mean` overflowing unnecessarily with nullable integers (:issue:`48378`)
-- Loss of dtype information when concatenating EA with empty EA of same type (:issue:`48510`)
+- When concatenating DataFrame containing an empty ExtensionArray Series with another DataFrame with an ExtensionArray of the same type, the resulting dtype turned into object (:issue:`48510`)
 -
 
 Styler

--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -212,7 +212,7 @@ Sparse
 ExtensionArray
 ^^^^^^^^^^^^^^
 - Bug in :meth:`Series.mean` overflowing unnecessarily with nullable integers (:issue:`48378`)
-- When concatenating DataFrame containing an empty ExtensionArray Series with another DataFrame with an ExtensionArray of the same type, the resulting dtype turned into object (:issue:`48510`)
+- Bug when concatenating an empty DataFrame with an ExtensionDtype to another DataFrame with the same ExtensionDtype, the resulting dtype turned into object (:issue:`48510`)
 -
 
 Styler

--- a/pandas/tests/extension/test_integer.py
+++ b/pandas/tests/extension/test_integer.py
@@ -234,14 +234,3 @@ class TestParsing(base.BaseParsingTests):
 
 class Test2DCompat(base.Dim2CompatTests):
     pass
-
-
-def test_concat_to_empty_ea():
-    """`concat` to an empty EA should maintain type EA information."""
-    df_empty = pd.DataFrame({"a": pd.array([], dtype=pd.Int64Dtype())})
-
-    df_new = pd.DataFrame({"a": pd.array([1, 2, 3], dtype=pd.Int64Dtype())})
-
-    result = pd.concat([df_empty, df_new])
-
-    assert result["a"].dtype == df_empty["a"].dtype == df_new["a"].dtype

--- a/pandas/tests/extension/test_integer.py
+++ b/pandas/tests/extension/test_integer.py
@@ -234,3 +234,14 @@ class TestParsing(base.BaseParsingTests):
 
 class Test2DCompat(base.Dim2CompatTests):
     pass
+
+
+def test_concat_to_empty_ea():
+    """`concat` to an empty EA should maintain type EA information."""
+    df_empty = pd.DataFrame({"a": pd.array([], dtype=pd.Int64Dtype())})
+
+    df_new = pd.DataFrame({"a": pd.array([1, 2, 3], dtype=pd.Int64Dtype())})
+
+    result = pd.concat([df_empty, df_new])
+
+    assert result["a"].dtype == df_empty["a"].dtype == df_new["a"].dtype

--- a/pandas/tests/reshape/concat/test_empty.py
+++ b/pandas/tests/reshape/concat/test_empty.py
@@ -284,3 +284,11 @@ class TestEmptyConcat:
         result = concat([df1[:0], df2[:0]])
         assert result["a"].dtype == np.int64
         assert result["b"].dtype == np.object_
+
+    def test_concat_to_empty_ea(self):
+        """48510 `concat` to an empty EA should maintain type EA dtype."""
+        df_empty = pd.DataFrame({"a": pd.array([], dtype=pd.Int64Dtype())})
+        df_new = pd.DataFrame({"a": pd.array([1, 2, 3], dtype=pd.Int64Dtype())})
+        expected = df_new.copy()
+        result = pd.concat([df_empty, df_new])
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/reshape/concat/test_empty.py
+++ b/pandas/tests/reshape/concat/test_empty.py
@@ -287,8 +287,8 @@ class TestEmptyConcat:
 
     def test_concat_to_empty_ea(self):
         """48510 `concat` to an empty EA should maintain type EA dtype."""
-        df_empty = pd.DataFrame({"a": pd.array([], dtype=pd.Int64Dtype())})
-        df_new = pd.DataFrame({"a": pd.array([1, 2, 3], dtype=pd.Int64Dtype())})
+        df_empty = DataFrame({"a": pd.array([], dtype=pd.Int64Dtype())})
+        df_new = DataFrame({"a": pd.array([1, 2, 3], dtype=pd.Int64Dtype())})
         expected = df_new.copy()
-        result = pd.concat([df_empty, df_new])
+        result = concat([df_empty, df_new])
         tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
* In previous versions, concatenating to empty EA was resetting type information to np.object

- [x] closes #48510  (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

I wasn't sure which issue to reference since it was resolved as part of something else, so I took this one for which I only really added a test case (not the actual fix). @mroeschke would you like me to reference another issue instead (or remove this from whatsnew entirely)?