### PR TITLE
DOC: Update footer and include OVH

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -163,7 +163,9 @@ master_doc = "index"
 
 # General information about the project.
 project = "pandas"
-copyright = f"2008-{datetime.now().year}, the pandas development team"
+copyright = (f'{datetime.now().year} '
+             'pandas via <a href="https://numfocus.org">NumFOCUS, Inc.</a> '
+             'Hosted by <a href="https://www.ovhcloud.com">OVH Cloud</a>')
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -163,9 +163,11 @@ master_doc = "index"
 
 # General information about the project.
 project = "pandas"
-copyright = (f'{datetime.now().year} '
-             'pandas via <a href="https://numfocus.org">NumFOCUS, Inc.</a> '
-             'Hosted by <a href="https://www.ovhcloud.com">OVH Cloud</a>')
+copyright = (
+    f"{datetime.now().year} "
+    'pandas via <a href="https://numfocus.org">NumFOCUS, Inc.</a> '
+    'Hosted by <a href="https://www.ovhcloud.com">OVH Cloud</a>'
+)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
- [X] xref #48012

The OVH agreement for the new hosting has been signed, adding an OVH mention to the documentation footer for 1.5, and standardizing to the agreed footer.

Note that Sphinx poor design doesn't provide a way to have the footer we want (it forces the footer to start with `© Copyright`), without creating our own template, which I'm not doing here. We can check later if this can be [addressed in the sphinx theme](https://github.com/pydata/pydata-sphinx-theme/issues/42#issuecomment-1246579580), we want to create a custom template, or if we're happy to let Sphinx force content in our footer.