### PR TITLE
TST: remove 2D tests irrelevant for pyarrow

### DIFF
--- a/pandas/tests/extension/base/dim2.py
+++ b/pandas/tests/extension/base/dim2.py
@@ -18,6 +18,9 @@ from pandas.tests.extension.base.base import BaseExtensionTests
 
 
 class Dim2CompatTests(BaseExtensionTests):
+    # Note: these are ONLY for ExtensionArray subclasses that support 2D arrays.
+    #  i.e. not for pyarrow-backed EAs.
+
     def test_transpose(self, data):
         arr2d = data.repeat(2).reshape(-1, 2)
         shape = arr2d.shape

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -319,20 +319,6 @@ class TestConstructors(base.BaseConstructorsTests):
         tm.assert_extension_array_equal(result, data)
 
 
-@pytest.mark.xfail(
-    raises=NotImplementedError, reason="pyarrow.ChunkedArray backing is 1D."
-)
-class TestDim2Compat(base.Dim2CompatTests):
-    pass
-
-
-@pytest.mark.xfail(
-    raises=NotImplementedError, reason="pyarrow.ChunkedArray backing is 1D."
-)
-class TestNDArrayBacked2D(base.NDArrayBacked2DTests):
-    pass
-
-
 class TestGetitemTests(base.BaseGetitemTests):
     @pytest.mark.xfail(
         reason=(


### PR DESCRIPTION
Gets rid of 3367 irrelevant xfails cc @mroeschke 