### PR TITLE
DOC: Fix docs footer

### DIFF
--- a/doc/_templates/pandas_footer.html
+++ b/doc/_templates/pandas_footer.html
@@ -1,0 +1,3 @@
+<p class="copyright">
+    &copy {{copyright}} pandas via <a href="https://numfocus.org">NumFOCUS, Inc.</a> Hosted by <a href="https://www.ovhcloud.com">OVH Cloud</a>.
+</p>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -163,11 +163,8 @@ master_doc = "index"
 
 # General information about the project.
 project = "pandas"
-copyright = (
-    f"{datetime.now().year} "
-    'pandas via <a href="https://numfocus.org">NumFOCUS, Inc.</a> '
-    'Hosted by <a href="https://www.ovhcloud.com">OVH Cloud</a>'
-)
+# We have our custom "pandas_footer.html" template, using copyright for the current year
+copyright = f"{datetime.now().year}"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -243,6 +240,7 @@ elif "rc" in version:
 
 html_theme_options = {
     "external_links": [],
+    "footer_items": ["pandas_footer", "sphinx-version"],
     "github_url": "https://github.com/pandas-dev/pandas",
     "twitter_url": "https://twitter.com/pandas_dev",
     "google_analytics_id": "UA-27880019-2",


### PR DESCRIPTION
Follow up of #48543

Seems like Sphinx escapes html tags in the copyright setting, and links can't be created. Using a template for the new footer. Good news is that with a custom template, we can't now get rid of the `Copyright` word in the footer.
