### PR TITLE
TST: Testing that no warnings are emitted and that inplace fillna produces the correct result (GH48480)

### DIFF
--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -780,3 +780,16 @@ def test_fillna_nonconsolidated_frame():
     df_nonconsol = df.pivot(index="i1", columns="i2")
     result = df_nonconsol.fillna(0)
     assert result.isna().sum().sum() == 0
+
+
+def test_fillna_nones_inplace():
+    # GH 48480
+    df = DataFrame(
+        [[None, None], [None, None]],
+        columns=["A", "B"],
+    )
+    with tm.assert_produces_warning(False):
+        df.fillna(value={"A": 1, "B": 2}, inplace=True)
+
+    expected = DataFrame([[1, 2], [1, 2]], columns=["A", "B"])
+    tm.assert_frame_equal(df, expected)


### PR DESCRIPTION
- [x] closes #48480
- [x] [Tests added and passed]
- [x] All [code checks passed]

In GH48480 it was stated that using fillna in-place on a dataframe with Nones emits a future warning. The issue was already resolved as also stated in the issue, so I included a test which tests on an example that no warning is emitted and that the result is correct.