### PR TITLE
CLN: MultiIndex.drop_duplicates

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3864,10 +3864,6 @@ class MultiIndex(Index):
 
     rename = set_names
 
-    @deprecate_nonkeyword_arguments(version=None, allowed_args=["self"])
-    def drop_duplicates(self, keep: str | bool = "first") -> MultiIndex:
-        return super().drop_duplicates(keep=keep)
-
     # ---------------------------------------------------------------
     # Arithmetic/Numeric Methods - Disabled
 

--- a/pandas/tests/indexes/multi/test_duplicates.py
+++ b/pandas/tests/indexes/multi/test_duplicates.py
@@ -332,7 +332,7 @@ def test_multi_drop_duplicates_pos_args_deprecation():
     idx = MultiIndex.from_arrays([[1, 2, 3, 1], [1, 2, 3, 1]])
     msg = (
         "In a future version of pandas all arguments of "
-        "MultiIndex.drop_duplicates will be keyword-only"
+        "Index.drop_duplicates will be keyword-only"
     )
     with tm.assert_produces_warning(FutureWarning, match=msg):
         result = idx.drop_duplicates("last")


### PR DESCRIPTION
I think there is no reason why `MultiIndex` overwrites `drop_duplicates` from `Index`:

- Both implementations do exactly the same
- Both implementations have exactly the same type annotations
- `MultiIndex.drop_duplicates` does not have a doc-string

There are a few more methods (`set_names`, `rename`) but in those cases, the annotations might actually be different.