### PR TITLE
DOC: include defaults into docs for true_values and false_values

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -195,9 +195,9 @@ converters : dict, optional
     Dict of functions for converting values in certain columns. Keys can either
     be integers or column labels.
 true_values : list, optional
-    Values to consider as True.
+    Values to consider as True in addition to case-insensitive variants of "True".
 false_values : list, optional
-    Values to consider as False.
+    Values to consider as False in addition to case-insensitive variants of "False".
 skipinitialspace : bool, default False
     Skip spaces after delimiter.
 skiprows : list-like, int or callable, optional


### PR DESCRIPTION
- [X] closes #48487 

## Motivation
This PR touches only one docstring, so no other checks are necessary. As outlined in #48487, when we call `pd.read_csv`, we eventually go to `_libs/ops.pyx`, where there are [defaults](https://github.com/pandas-dev/pandas/blob/ca60aab7340d9989d9428e11a51467658190bb6b/pandas/_libs/ops.pyx#L257) for `true_values` and `false_values`:
```python
    # the defaults
    true_vals = {'True', 'TRUE', 'true'}
    false_vals = {'False', 'FALSE', 'false'}

    if true_values is not None:
        true_vals = true_vals | set(true_values)

    if false_values is not None:
        false_vals = false_vals | set(false_values)
```
In addition, there appears to be a `str.lower()` or `str.upper()` call somewhere, although I can't find it, because `trUe` is treated as true-like too. We should outline this in the docstring, so that it's not a surprise to our users.

## Definition of done
- [X] mention the default values for `true_values` and `false_values` in the docstring for `pd.read_csv`