### PR TITLE
DOC: Fix version switcher in old docs

### DIFF
--- a/web/pandas/versions.json
+++ b/web/pandas/versions.json
@@ -2,36 +2,31 @@
     {
         "name": "dev",
         "version": "dev",
-        "url": "/docs/dev/"
+        "url": "https://pandas.pydata.org/docs/dev/"
     },
     {
         "name": "1.4 (stable)",
         "version": "1.4 (stable)",
-        "url": "/docs/"
-    },
-    {
-        "name": "1.4",
-        "version": "1.4",
-        "url": "/pandas-docs/version/1.4/"
+        "url": "https://pandas.pydata.org/docs/"
     },
     {
         "name": "1.3",
         "version": "1.3",
-        "url": "/pandas-docs/version/1.3/"
+        "url": "https://pandas.pydata.org/pandas-docs/version/1.3/"
     },
     {
         "name": "1.2",
         "version": "1.2",
-        "url": "/pandas-docs/version/1.2/"
+        "url": "https://pandas.pydata.org/pandas-docs/version/1.2/"
     },
     {
         "name": "1.1",
         "version": "1.1",
-        "url": "/pandas-docs/version/1.1/"
+        "url": "https://pandas.pydata.org/pandas-docs/version/1.1/"
     },
     {
         "name": "1.0",
         "version": "1.0",
-        "url": "/pandas-docs/version/1.0/"
+        "url": "https://pandas.pydata.org/pandas-docs/version/1.0/"
     }
 ]

--- a/web/pandas/versions.json
+++ b/web/pandas/versions.json
@@ -5,9 +5,14 @@
         "url": "https://pandas.pydata.org/docs/dev/"
     },
     {
-        "name": "1.4 (stable)",
-        "version": "1.4 (stable)",
+        "name": "1.5 (stable)",
+        "version": "1.5 (stable)",
         "url": "https://pandas.pydata.org/docs/"
+    },
+    {
+        "name": "1.4",
+        "version": "1.4",
+        "url": "https://pandas.pydata.org/pandas-docs/version/1.4/"
     },
     {
         "name": "1.3",


### PR DESCRIPTION
- [X] xref #48285

Fixing the version switcher in old versions of the documentation.

I'm also removing here the duplicated 1.4 link in the version switcher.
