### PR TITLE
ENH: MultiIndex.intersection now keeping EA dtypes

### DIFF
--- a/asv_bench/benchmarks/index_object.py
+++ b/asv_bench/benchmarks/index_object.py
@@ -19,12 +19,13 @@ from .pandas_vb_common import tm
 class SetOperations:
 
     params = (
+        ["monotonic", "non_monotonic"],
         ["datetime", "date_string", "int", "strings", "ea_int"],
         ["intersection", "union", "symmetric_difference"],
     )
-    param_names = ["dtype", "method"]
+    param_names = ["index_structure", "dtype", "method"]
 
-    def setup(self, dtype, method):
+    def setup(self, index_structure, dtype, method):
         N = 10**5
         dates_left = date_range("1/1/2000", periods=N, freq="T")
         fmt = "%Y-%m-%d %H:%M:%S"
@@ -32,17 +33,24 @@ class SetOperations:
         int_left = Index(np.arange(N))
         ea_int_left = Index(np.arange(N), dtype="Int64")
         str_left = tm.makeStringIndex(N)
+
         data = {
-            "datetime": {"left": dates_left, "right": dates_left[:-1]},
-            "date_string": {"left": date_str_left, "right": date_str_left[:-1]},
-            "int": {"left": int_left, "right": int_left[:-1]},
-            "strings": {"left": str_left, "right": str_left[:-1]},
-            "ea_int": {"left": ea_int_left, "right": ea_int_left[:-1]},
+            "datetime": dates_left,
+            "date_string": date_str_left,
+            "int": int_left,
+            "strings": str_left,
+            "ea_int": ea_int_left,
         }
+
+        if index_structure == "non_monotonic":
+            data = {k: mi[::-1] for k, mi in data.items()}
+
+        data = {k: {"left": idx, "right": idx[:-1]} for k, idx in data.items()}
+
         self.left = data[dtype]["left"]
         self.right = data[dtype]["right"]
 
-    def time_operation(self, dtype, method):
+    def time_operation(self, index_structure, dtype, method):
         getattr(self.left, method)(self.right)
 
 

--- a/asv_bench/benchmarks/index_object.py
+++ b/asv_bench/benchmarks/index_object.py
@@ -19,7 +19,7 @@ from .pandas_vb_common import tm
 class SetOperations:
 
     params = (
-        ["datetime", "date_string", "int", "strings"],
+        ["datetime", "date_string", "int", "strings", "ea_int"],
         ["intersection", "union", "symmetric_difference"],
     )
     param_names = ["dtype", "method"]
@@ -30,12 +30,14 @@ class SetOperations:
         fmt = "%Y-%m-%d %H:%M:%S"
         date_str_left = Index(dates_left.strftime(fmt))
         int_left = Index(np.arange(N))
+        ea_int_left = Index(np.arange(N), dtype="Int64")
         str_left = tm.makeStringIndex(N)
         data = {
             "datetime": {"left": dates_left, "right": dates_left[:-1]},
             "date_string": {"left": date_str_left, "right": date_str_left[:-1]},
             "int": {"left": int_left, "right": int_left[:-1]},
             "strings": {"left": str_left, "right": str_left[:-1]},
+            "ea_int": {"left": ea_int_left, "right": ea_int_left[:-1]},
         }
         self.left = data[dtype]["left"]
         self.right = data[dtype]["right"]

--- a/asv_bench/benchmarks/multiindex_object.py
+++ b/asv_bench/benchmarks/multiindex_object.py
@@ -237,7 +237,7 @@ class SetOperations:
 
     params = [
         ("monotonic", "non_monotonic"),
-        ("datetime", "int", "string", "Int"),
+        ("datetime", "int", "string", "ea_int"),
         ("intersection", "union", "symmetric_difference"),
     ]
     param_names = ["index_structure", "dtype", "method"]
@@ -262,7 +262,7 @@ class SetOperations:
             "datetime": dates_left,
             "int": int_left,
             "string": str_left,
-            "Int": ea_int_left,
+            "ea_int": ea_int_left,
         }
 
         if index_structure == "non_monotonic":

--- a/asv_bench/benchmarks/multiindex_object.py
+++ b/asv_bench/benchmarks/multiindex_object.py
@@ -237,7 +237,7 @@ class SetOperations:
 
     params = [
         ("monotonic", "non_monotonic"),
-        ("datetime", "int", "string"),
+        ("datetime", "int", "string", "Int"),
         ("intersection", "union", "symmetric_difference"),
     ]
     param_names = ["index_structure", "dtype", "method"]
@@ -255,10 +255,14 @@ class SetOperations:
         level2 = tm.makeStringIndex(N // 1000).values
         str_left = MultiIndex.from_product([level1, level2])
 
+        level2 = range(N // 1000)
+        ea_int_left = MultiIndex.from_product([level1, Series(level2, dtype="Int64")])
+
         data = {
             "datetime": dates_left,
             "int": int_left,
             "string": str_left,
+            "Int": ea_int_left,
         }
 
         if index_structure == "non_monotonic":

--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -111,6 +111,7 @@ Performance improvements
 - Performance improvement for :class:`Series` constructor passing integer numpy array with nullable dtype (:issue:`48338`)
 - Performance improvement in :meth:`DataFrame.loc` and :meth:`Series.loc` for tuple-based indexing of a :class:`MultiIndex` (:issue:`48384`)
 - Performance improvement for :meth:`MultiIndex.unique` (:issue:`48335`)
+- Performance improvement for :meth:`MultiIndex.intersection` (:issue:`50000`)
 - Performance improvement in ``var`` for nullable dtypes (:issue:`48379`).
 - Performance improvement to :func:`read_sas` with ``blank_missing=True`` (:issue:`48502`)
 -
@@ -176,6 +177,7 @@ Missing
 MultiIndex
 ^^^^^^^^^^
 - Bug in :meth:`MultiIndex.unique` losing extension array dtype (:issue:`48335`)
+- Bug in :meth:`MultiIndex.intersection` losing extension array (:issue:`50000`)
 - Bug in :meth:`MultiIndex.union` losing extension array (:issue:`48498`, :issue:`48505`)
 - Bug in :meth:`MultiIndex.append` not checking names for equality (:issue:`48288`)
 -

--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -111,7 +111,7 @@ Performance improvements
 - Performance improvement for :class:`Series` constructor passing integer numpy array with nullable dtype (:issue:`48338`)
 - Performance improvement in :meth:`DataFrame.loc` and :meth:`Series.loc` for tuple-based indexing of a :class:`MultiIndex` (:issue:`48384`)
 - Performance improvement for :meth:`MultiIndex.unique` (:issue:`48335`)
-- Performance improvement for :meth:`MultiIndex.intersection` (:issue:`50000`)
+- Performance improvement for :meth:`MultiIndex.intersection` (:issue:`48604`)
 - Performance improvement in ``var`` for nullable dtypes (:issue:`48379`).
 - Performance improvement to :func:`read_sas` with ``blank_missing=True`` (:issue:`48502`)
 -
@@ -177,7 +177,7 @@ Missing
 MultiIndex
 ^^^^^^^^^^
 - Bug in :meth:`MultiIndex.unique` losing extension array dtype (:issue:`48335`)
-- Bug in :meth:`MultiIndex.intersection` losing extension array (:issue:`50000`)
+- Bug in :meth:`MultiIndex.intersection` losing extension array (:issue:`48604`)
 - Bug in :meth:`MultiIndex.union` losing extension array (:issue:`48498`, :issue:`48505`)
 - Bug in :meth:`MultiIndex.append` not checking names for equality (:issue:`48288`)
 -

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3556,7 +3556,9 @@ class Index(IndexOpsMixin, PandasObject):
         return self._wrap_setop_result(other, result)
 
     @final
-    def _intersection_via_get_indexer(self, other: Index, sort) -> ArrayLike:
+    def _intersection_via_get_indexer(
+        self, other: Index, sort
+    ) -> ArrayLike | MultiIndex:
         """
         Find the intersection of two Indexes using get_indexer.
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3532,18 +3532,17 @@ class Index(IndexOpsMixin, PandasObject):
             and self._can_use_libjoin
         ):
             try:
-                indexer = self._inner_indexer(other)[1]
+                res_indexer, indexer, _ = self._inner_indexer(other)
             except TypeError:
                 # non-comparable; should only be for object dtype
                 pass
             else:
-                result = self.take(indexer)
                 # TODO: algos.unique1d should preserve DTA/TDA
-                if is_numeric_dtype(result):
-                    res = algos.unique1d(result)
+                if self.is_numeric():
+                    res = algos.unique1d(res_indexer)
                 else:
+                    result = self.take(indexer)
                     res = result.drop_duplicates()
-                # return res
                 return ensure_wrapped_if_datetimelike(res)
 
         res_values = self._intersection_via_get_indexer(other, sort=sort)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3539,6 +3539,8 @@ class Index(IndexOpsMixin, PandasObject):
             else:
                 # TODO: algos.unique1d should preserve DTA/TDA
                 if self.is_numeric():
+                    # This is faster, because Index.unique() checks for uniqueness
+                    # before calculating the unique values.
                     res = algos.unique1d(res_indexer)
                 else:
                     result = self.take(indexer)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3539,7 +3539,11 @@ class Index(IndexOpsMixin, PandasObject):
             else:
                 result = self.take(indexer)
                 # TODO: algos.unique1d should preserve DTA/TDA
-                res = result.unique()
+                if is_numeric_dtype(result):
+                    res = algos.unique1d(result)
+                else:
+                    res = result.drop_duplicates()
+                # return res
                 return ensure_wrapped_if_datetimelike(res)
 
         res_values = self._intersection_via_get_indexer(other, sort=sort)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3557,7 +3557,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     @final
     def _intersection_via_get_indexer(
-        self, other: Index, sort
+        self, other: Index | MultiIndex, sort
     ) -> ArrayLike | MultiIndex:
         """
         Find the intersection of two Indexes using get_indexer.

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3719,16 +3719,7 @@ class MultiIndex(Index):
 
     def _wrap_intersection_result(self, other, result) -> MultiIndex:
         _, result_names = self._convert_can_do_setop(other)
-
-        if len(result) == 0:
-            return MultiIndex(
-                levels=self.levels,
-                codes=[[]] * self.nlevels,
-                names=result_names,
-                verify_integrity=False,
-            )
-        else:
-            return MultiIndex.from_arrays(zip(*result), sortorder=0, names=result_names)
+        return result.set_names(result_names)
 
     def _wrap_difference_result(self, other, result) -> MultiIndex:
         _, result_names = self._convert_can_do_setop(other)

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -620,7 +620,7 @@ def test_intersection_lexsort_depth(levels1, levels2, codes1, codes2, names):
 
 @pytest.mark.parametrize("val", [pd.NA, 100])
 def test_intersection_keep_ea_dtypes(val, any_numeric_ea_dtype):
-    # GH#
+    # GH#48604
     midx = MultiIndex.from_arrays(
         [Series([1, 2], dtype=any_numeric_ea_dtype), [2, 1]], names=["a", None]
     )

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -616,3 +616,17 @@ def test_intersection_lexsort_depth(levels1, levels2, codes1, codes2, names):
 
     with tm.assert_produces_warning(FutureWarning, match="MultiIndex.lexsort_depth"):
         assert mi_int.lexsort_depth == 2
+
+
+@pytest.mark.parametrize("val", [pd.NA, 100])
+def test_intersection_keep_ea_dtypes(val, any_numeric_ea_dtype):
+    # GH#
+    midx = MultiIndex.from_arrays(
+        [Series([1, 2], dtype=any_numeric_ea_dtype), [2, 1]], names=["a", None]
+    )
+    midx2 = MultiIndex.from_arrays(
+        [Series([1, 2, val], dtype=any_numeric_ea_dtype), [1, 1, 3]]
+    )
+    result = midx.intersection(midx2)
+    expected = MultiIndex.from_arrays([Series([2], dtype=any_numeric_ea_dtype), [1]])
+    tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -509,7 +509,7 @@ def test_intersection_with_missing_values_on_both_sides(nulls_fixture):
     mi1 = MultiIndex.from_arrays([[3, nulls_fixture, 4, nulls_fixture], [1, 2, 4, 2]])
     mi2 = MultiIndex.from_arrays([[3, nulls_fixture, 3], [1, 2, 4]])
     result = mi1.intersection(mi2)
-    expected = MultiIndex.from_arrays([[3.0, nulls_fixture], [1, 2]])
+    expected = MultiIndex.from_arrays([[3, nulls_fixture], [1, 2]])
     tm.assert_index_equal(result, expected)
 
 
@@ -615,4 +615,4 @@ def test_intersection_lexsort_depth(levels1, levels2, codes1, codes2, names):
     mi_int = mi1.intersection(mi2)
 
     with tm.assert_produces_warning(FutureWarning, match="MultiIndex.lexsort_depth"):
-        assert mi_int.lexsort_depth == 0
+        assert mi_int.lexsort_depth == 2


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Nice performance boost

```
       before           after         ratio
     [b5632fb3]       [ed481f4f]
     <intersection~4>       <intersection>
-      8.81±0.2ms      7.49±0.08ms     0.85  index_object.SetOperations.time_operation('non_monotonic', 'strings', 'symmetric_difference')
-      16.5±0.2ms      12.2±0.05ms     0.74  index_object.SetOperations.time_operation('monotonic', 'date_string', 'intersection')
-      49.7±0.7ms       20.7±0.3ms     0.42  multiindex_object.SetOperations.time_operation('monotonic', 'ea_int', 'intersection')
-      49.9±0.3ms       19.9±0.3ms     0.40  multiindex_object.SetOperations.time_operation('monotonic', 'int', 'intersection')
-         119±1ms       33.2±0.3ms     0.28  multiindex_object.SetOperations.time_operation('monotonic', 'datetime', 'intersection')
-      31.7±0.1ms      4.98±0.05ms     0.16  multiindex_object.SetOperations.time_operation('non_monotonic', 'string', 'intersection')
-      31.8±0.4ms       4.83±0.2ms     0.15  multiindex_object.SetOperations.time_operation('monotonic', 'string', 'intersection')
-      35.5±0.2ms      4.62±0.01ms     0.13  multiindex_object.SetOperations.time_operation('non_monotonic', 'ea_int', 'intersection')
-      34.6±0.4ms       3.35±0.1ms     0.10  multiindex_object.SetOperations.time_operation('non_monotonic', 'int', 'intersection')
-      73.4±0.8ms       3.42±0.1ms     0.05  multiindex_object.SetOperations.time_operation('non_monotonic', 'datetime', 'intersection')
```