### PR TITLE
BUG: MultiIndex.symmetric_difference not keeping ea dtype

### DIFF
--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -178,6 +178,7 @@ MultiIndex
 - Bug in :meth:`MultiIndex.unique` losing extension array dtype (:issue:`48335`)
 - Bug in :meth:`MultiIndex.union` losing extension array (:issue:`48498`, :issue:`48505`)
 - Bug in :meth:`MultiIndex.append` not checking names for equality (:issue:`48288`)
+- Bug in :meth:`MultiIndex.symmetric_difference` losing extension array (:issue:`50000`)
 -
 
 I/O

--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -178,7 +178,7 @@ MultiIndex
 - Bug in :meth:`MultiIndex.unique` losing extension array dtype (:issue:`48335`)
 - Bug in :meth:`MultiIndex.union` losing extension array (:issue:`48498`, :issue:`48505`)
 - Bug in :meth:`MultiIndex.append` not checking names for equality (:issue:`48288`)
-- Bug in :meth:`MultiIndex.symmetric_difference` losing extension array (:issue:`50000`)
+- Bug in :meth:`MultiIndex.symmetric_difference` losing extension array (:issue:`48607`)
 -
 
 I/O

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3711,31 +3711,23 @@ class Index(IndexOpsMixin, PandasObject):
         left_indexer = np.setdiff1d(
             np.arange(this.size), common_indexer, assume_unique=True
         )
-        left_diff = this._values.take(left_indexer)
+        left_diff = this.take(left_indexer)
 
         # {other} minus {this}
         right_indexer = (indexer == -1).nonzero()[0]
-        right_diff = other._values.take(right_indexer)
+        right_diff = other.take(right_indexer)
 
-        res_values = concat_compat([left_diff, right_diff])
-        res_values = _maybe_try_sort(res_values, sort)
+        res_values = left_diff.append(right_diff)
+        result = _maybe_try_sort(res_values, sort)
 
-        # pass dtype so we retain object dtype
-        result = Index(res_values, name=result_name, dtype=res_values.dtype)
-
-        if self._is_multi:
-            self = cast("MultiIndex", self)
+        if not self._is_multi:
+            return Index(result, name=result_name, dtype=res_values.dtype)
+        else:
+            left_diff = cast("MultiIndex", left_diff)
             if len(result) == 0:
-                # On equal symmetric_difference MultiIndexes the difference is empty.
-                # Therefore, an empty MultiIndex is returned GH#13490
-                return type(self)(
-                    levels=[[] for _ in range(self.nlevels)],
-                    codes=[[] for _ in range(self.nlevels)],
-                    names=result.name,
-                )
-            return type(self).from_tuples(result, names=result.name)
-
-        return result
+                # result might be an Index, if other was an Index
+                return left_diff.remove_unused_levels().set_names(result_name)
+            return result.set_names(result_name)
 
     @final
     def _assert_can_do_setop(self, other) -> bool:

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -442,7 +442,7 @@ def test_setops_disallow_true(method):
 
 @pytest.mark.parametrize("val", [pd.NA, 5])
 def test_symmetric_difference_keeping_ea_dtype(any_numeric_ea_dtype, val):
-    # GH#
+    # GH#48607
     midx = MultiIndex.from_arrays(
         [Series([1, 2], dtype=any_numeric_ea_dtype), [2, 1]], names=["a", None]
     )

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -440,6 +440,22 @@ def test_setops_disallow_true(method):
         getattr(idx1, method)(idx2, sort=True)
 
 
+@pytest.mark.parametrize("val", [pd.NA, 5])
+def test_symmetric_difference_keeping_ea_dtype(any_numeric_ea_dtype, val):
+    # GH#
+    midx = MultiIndex.from_arrays(
+        [Series([1, 2], dtype=any_numeric_ea_dtype), [2, 1]], names=["a", None]
+    )
+    midx2 = MultiIndex.from_arrays(
+        [Series([1, 2, val], dtype=any_numeric_ea_dtype), [1, 1, 3]]
+    )
+    result = midx.symmetric_difference(midx2)
+    expected = MultiIndex.from_arrays(
+        [Series([1, 1, val], dtype=any_numeric_ea_dtype), [1, 2, 3]]
+    )
+    tm.assert_index_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     ("tuples", "exp_tuples"),
     [


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.


```
       before           after         ratio
     [b5632fb3]       [811faf6b]
     <deprecation_notes~1>       <sym_diff>
-     16.0±0.09ms      11.0±0.08ms     0.69  multiindex_object.SetOperations.time_operation('monotonic', 'string', 'symmetric_difference')
-      16.4±0.4ms       10.9±0.1ms     0.66  multiindex_object.SetOperations.time_operation('non_monotonic', 'string', 'symmetric_difference')
-      15.2±0.4ms       9.78±0.2ms     0.64  multiindex_object.SetOperations.time_operation('non_monotonic', 'int', 'symmetric_difference')
-      15.8±0.1ms       10.1±0.2ms     0.64  multiindex_object.SetOperations.time_operation('non_monotonic', 'datetime', 'symmetric_difference')
-      15.1±0.1ms      9.40±0.08ms     0.62  multiindex_object.SetOperations.time_operation('monotonic', 'int', 'symmetric_difference')
-      15.8±0.1ms      9.79±0.04ms     0.62  multiindex_object.SetOperations.time_operation('monotonic', 'datetime', 'symmetric_difference')
```