### PR TITLE
DOC: Update documentation for date_range(), bdate_range(), and interval_range() to include timedelta as a possible data type for the freq parameter

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -966,7 +966,7 @@ def date_range(
         Right bound for generating dates.
     periods : int, optional
         Number of periods to generate.
-    freq : str or DateOffset, default 'D'
+    freq : str, datetime.timedelta, or DateOffset, default 'D'
         Frequency strings can have multiples, e.g. '5H'. See
         :ref:`here <timeseries.offset_aliases>` for a list of
         frequency aliases.
@@ -1163,7 +1163,7 @@ def bdate_range(
         Right bound for generating dates.
     periods : int, default None
         Number of periods to generate.
-    freq : str or DateOffset, default 'B' (business daily)
+    freq : str, datetime.timedelta, or DateOffset, default 'B' (business daily)
         Frequency strings can have multiples, e.g. '5H'.
     tz : str or None
         Time zone name for returning localized DatetimeIndex, for example

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -969,7 +969,7 @@ def interval_range(
         Right bound for generating intervals.
     periods : int, default None
         Number of periods to generate.
-    freq : numeric, str, or DateOffset, default None
+    freq : numeric, str, datetime.timedelta, or DateOffset, default None
         The length of each interval. Must be consistent with the type of start
         and end, e.g. 2 for numeric, or '5H' for datetime-like.  Default is 1
         for numeric and 'D' for datetime-like.

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -432,6 +432,13 @@ class TestDateRanges:
         rng = date_range("2014-07-04 09:00", "2014-07-08 16:00", freq="BH")
         tm.assert_index_equal(idx, rng)
 
+    def test_date_range_timedelta(self):
+        start = "2020-01-01"
+        end = "2020-01-11"
+        rng1 = date_range(start, end, freq="3D")
+        rng2 = date_range(start, end, freq=timedelta(days=3))
+        tm.assert_index_equal(rng1, rng2)
+
     def test_range_misspecified(self):
         # GH #1095
         msg = (


### PR DESCRIPTION
- [X] closes https://github.com/pandas-dev/pandas/issues/48460

This PR simply documents behavior that was already allowed, and was already properly documented on the underlying function `to_offset()`.

```
In [1]: import pandas as pd                                                                                                                                                          

In [2]: from datetime import date, timedelta                                                                                                                                         

In [3]: start = date(2022, 1, 1)                                                                                                                                                     

In [4]: end = date(2022, 1, 11)                                                                                                                                                      

In [5]: pd.date_range(start, end, freq=timedelta(days=2))                                                                                                                            
Out[5]: 
DatetimeIndex(['2022-01-01', '2022-01-03', '2022-01-05', '2022-01-07',
               '2022-01-09', '2022-01-11'],
              dtype='datetime64[ns]', freq='2D')

In [6]: pd.bdate_range(start, end, freq=timedelta(days=2))                                                                                                                           
Out[6]: 
DatetimeIndex(['2022-01-01', '2022-01-03', '2022-01-05', '2022-01-07',
               '2022-01-09', '2022-01-11'],
              dtype='datetime64[ns]', freq='2D')

In [7]: start = pd.Timestamp(start)                                                                                                                                  

In [8]: end = pd.Timestamp(end)                                                                                                                                     

In [9]: pd.interval_range(start, end, freq=timedelta(days=2))                                                                                                       
Out[9]: IntervalIndex([(2022-01-01, 2022-01-03], (2022-01-03, 2022-01-05], (2022-01-05, 2022-01-07], (2022-01-07, 2022-01-09], (2022-01-09, 2022-01-11]], dtype='interval[datetime64[ns], right]')
```