### PR TITLE
CI: Fix directory name for published prod docs

### DIFF
--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -81,7 +81,7 @@ jobs:
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     - name: Upload prod docs
-      run: rsync -az --delete doc/build/html/ docs@${{ secrets.server_ip }}:/usr/share/nginx/pandas/pandas-docs/version/${GITHUB_REF_NAME}
+      run: rsync -az --delete doc/build/html/ docs@${{ secrets.server_ip }}:/usr/share/nginx/pandas/pandas-docs/version/${GITHUB_REF_NAME:1}
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
 
     - name: Move docs into site directory


### PR DESCRIPTION
- [X] xref #48211 

The job to publish the docs to our production server when a new tag is created worked mostly fine for the 1.5.0 release. The only thing is that the tag name is `v1.5.0`, while the docs had to be published to the `1.5.0` directory (without the heading `v`). Fixing this here, so docs are published to the right directory.