### PR TITLE
BUG: MultiIndex.set_levels raising when setting empty level

### DIFF
--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -175,6 +175,7 @@ Missing
 
 MultiIndex
 ^^^^^^^^^^
+- Bug in :class:`MultiIndex.set_levels` raising ``IndexError`` when setting empty level (:issue:`48636`)
 - Bug in :meth:`MultiIndex.unique` losing extension array dtype (:issue:`48335`)
 - Bug in :meth:`MultiIndex.union` losing extension array (:issue:`48498`, :issue:`48505`)
 - Bug in :meth:`MultiIndex.append` not checking names for equality (:issue:`48288`)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -4003,7 +4003,7 @@ def _require_listlike(level, arr, arrname: str):
     if level is not None and not is_list_like(level):
         if not is_list_like(arr):
             raise TypeError(f"{arrname} must be list-like")
-        if is_list_like(arr[0]):
+        if len(arr) > 0 and is_list_like(arr[0]):
             raise TypeError(f"{arrname} must be list-like")
         level = [level]
         arr = [arr]

--- a/pandas/tests/indexes/multi/test_get_set.py
+++ b/pandas/tests/indexes/multi/test_get_set.py
@@ -476,6 +476,14 @@ def test_set_levels_pos_args_deprecation():
     tm.assert_index_equal(result, expected)
 
 
+def test_set_empty_level():
+    # GH#48636
+    midx = MultiIndex.from_arrays([[]], names=["A"])
+    result = midx.set_levels(pd.DatetimeIndex([]), level=0)
+    expected = MultiIndex.from_arrays([pd.DatetimeIndex([])], names=["A"])
+    tm.assert_index_equal(result, expected)
+
+
 def test_set_codes_pos_args_depreciation(idx):
     # https://github.com/pandas-dev/pandas/issues/41485
     msg = (


### PR DESCRIPTION
- [x] closes #48636 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
