### PR TITLE
REGR: TextIOWrapper raising an error in read_csv

### DIFF
--- a/doc/source/whatsnew/v1.5.1.rst
+++ b/doc/source/whatsnew/v1.5.1.rst
@@ -14,7 +14,7 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
--
+- Regression in :func:`.read_csv` causing an ``EmptyDataError`` when using an UTF-8 file handle that was already read from (:issue:`48646`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/io/parsers/c_parser_wrapper.py
+++ b/pandas/io/parsers/c_parser_wrapper.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections import defaultdict
 import inspect
-from io import TextIOWrapper
 from typing import (
     TYPE_CHECKING,
     Hashable,
@@ -66,19 +65,6 @@ class CParserWrapper(ParserBase):
 
         # Have to pass int, would break tests using TextReader directly otherwise :(
         kwds["on_bad_lines"] = self.on_bad_lines.value
-
-        # c-engine can cope with utf-8 bytes. Remove TextIOWrapper when its errors
-        # policy is the same as the one given to read_csv
-        if (
-            isinstance(src, TextIOWrapper)
-            and src.encoding == "utf-8"
-            and (src.errors or "strict") == kwds["encoding_errors"]
-            and src.seekable()
-            and src.tell() == src.buffer.tell()
-        ):
-            # error: Incompatible types in assignment (expression has type "BinaryIO",
-            # variable has type "ReadCsvBuffer[str]")
-            src = src.buffer  # type: ignore[assignment]
 
         for key in (
             "storage_options",

--- a/pandas/io/parsers/c_parser_wrapper.py
+++ b/pandas/io/parsers/c_parser_wrapper.py
@@ -73,7 +73,8 @@ class CParserWrapper(ParserBase):
             isinstance(src, TextIOWrapper)
             and src.encoding == "utf-8"
             and (src.errors or "strict") == kwds["encoding_errors"]
-            and (not src.seekable() or src.tell() == src.buffer.tell())
+            and src.seekable()
+            and src.tell() == src.buffer.tell()
         ):
             # error: Incompatible types in assignment (expression has type "BinaryIO",
             # variable has type "ReadCsvBuffer[str]")

--- a/pandas/io/parsers/c_parser_wrapper.py
+++ b/pandas/io/parsers/c_parser_wrapper.py
@@ -74,6 +74,9 @@ class CParserWrapper(ParserBase):
             and src.encoding == "utf-8"
             and (src.errors or "strict") == kwds["encoding_errors"]
         ):
+            # the internal buffer TextIOWrapper.buffer might have read ahead, make sure
+            # to first go back where TextIOWrapper is
+            src.seek(src.tell())
             # error: Incompatible types in assignment (expression has type "BinaryIO",
             # variable has type "ReadCsvBuffer[str]")
             src = src.buffer  # type: ignore[assignment]

--- a/pandas/io/parsers/c_parser_wrapper.py
+++ b/pandas/io/parsers/c_parser_wrapper.py
@@ -73,10 +73,8 @@ class CParserWrapper(ParserBase):
             isinstance(src, TextIOWrapper)
             and src.encoding == "utf-8"
             and (src.errors or "strict") == kwds["encoding_errors"]
+            and (not src.seekable() or src.tell() == src.buffer.tell())
         ):
-            # the internal buffer TextIOWrapper.buffer might have read ahead, make sure
-            # to first go back where TextIOWrapper is
-            src.seek(src.tell())
             # error: Incompatible types in assignment (expression has type "BinaryIO",
             # variable has type "ReadCsvBuffer[str]")
             src = src.buffer  # type: ignore[assignment]

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -60,6 +60,7 @@ from pandas.core.shared_docs import _shared_docs
 from pandas.io.common import (
     IOHandles,
     get_handle,
+    stringify_path,
     validate_header_arg,
 )
 from pandas.io.parsers.arrow_parser_wrapper import ArrowParserWrapper
@@ -1727,6 +1728,16 @@ class TextFileReader(abc.Iterator):
             if engine == "pyarrow":
                 is_text = False
                 mode = "rb"
+            elif (
+                engine == "c"
+                and self.options.get("encoding", "utf-8") == "utf-8"
+                and isinstance(stringify_path(f), str)
+            ):
+                # c engine can decode utf-8 bytes, adding TextIOWrapper makes
+                # the c-engine especially for memory_map=True far slower
+                is_text = False
+                if "b" not in mode:
+                    mode += "b"
             self.handles = get_handle(
                 f,
                 mode,

--- a/pandas/tests/io/parser/common/test_common_basic.py
+++ b/pandas/tests/io/parser/common/test_common_basic.py
@@ -937,7 +937,7 @@ def test_read_seek(all_parsers):
     content = "nkey,value\ntables,rectangular\n"
     with tm.ensure_clean() as path:
         Path(path).write_text(prefix + content)
-        with open(path, mode="r") as file:
+        with open(path, encoding="utf-8") as file:
             file.readline()
             actual = parser.read_csv(file)
         expected = parser.read_csv(StringIO(content))

--- a/pandas/tests/io/parser/common/test_common_basic.py
+++ b/pandas/tests/io/parser/common/test_common_basic.py
@@ -928,3 +928,17 @@ def test_read_table_posargs_deprecation(all_parsers):
         "except for the argument 'filepath_or_buffer' will be keyword-only"
     )
     parser.read_table_check_warnings(FutureWarning, msg, data, " ")
+
+
+def test_read_seek(all_parsers):
+    # GH48646
+    parser = all_parsers
+    prefix = "### DATA\n"
+    content = "nkey,value\ntables,rectangular\n"
+    with tm.ensure_clean() as path:
+        Path(path).write_text(prefix + content)
+        with open(path, mode="r") as file:
+            file.readline()
+            actual = parser.read_csv(file)
+        expected = parser.read_csv(StringIO(content))
+    tm.assert_frame_equal(actual, expected)


### PR DESCRIPTION
- [x] closes #48646
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

If `TextIOWrapper.buffer` has some more unexpected surprises, it might be worth not to use this shortcut (use src instead of src.buffer). Or only have this shortcut when pandas opens the file (edit: I went for this approach).