### PR TITLE
Fix scorecard.yml workflow

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -20,7 +20,7 @@ jobs:
       # Used to receive a badge.
       id-token: write
 
-    if: github.repository == 'pandas-dev/pandas'  # don't run on forks
+    # if: github.repository == 'pandas-dev/pandas'  # don't run on forks
 
     steps:
       - name: "Checkout code"
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.0.3
         with:
           results_file: results.sarif
           results_format: sarif

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -20,7 +20,7 @@ jobs:
       # Used to receive a badge.
       id-token: write
 
-    # if: github.repository == 'pandas-dev/pandas'  # don't run on forks
+    if: github.repository == 'pandas-dev/pandas'  # don't run on forks
 
     steps:
       - name: "Checkout code"


### PR DESCRIPTION
Workflow was added by #48570, but set ossf/scorecard-action to a major version tag (v2). However, that action only has minor version tags. So it is currently broken. Wasn't caught because the `if github.repository` check skipped the action on my fork, and in my hubris I assumed it'd just work. 🤦 

This PR simply sets the action to the current minor version v2.0.3. Has been checked on my fork, can confirm it works!