### PR TITLE
DOC: Document default value for options.display.max_cols when not running in terminal

### DIFF
--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -131,11 +131,11 @@ pc_max_cols_doc = """
     a summary view. 'None' value means unlimited.
 
     In case python/IPython is running in a terminal and `large_repr`
-    equals 'truncate' this can be set to 0 and pandas will auto-detect
+    equals 'truncate' this can be set to 0 or None and pandas will auto-detect
     the width of the terminal and print a truncated object which fits
     the screen width. The IPython notebook, IPython qtconsole, or IDLE
     do not run in a terminal and hence it is not possible to do
-    correct auto-detection.
+    correct auto-detection and defaults to 20.
 """
 
 pc_max_categories_doc = """


### PR DESCRIPTION
`display.max_cols` has a default value of 20 when not running in a terminal such as Jupyter Notebook.

This was a little confusing as the documentation for the default parameters generated in [Pandas User Guide - Available Options](https://pandas.pydata.org/docs/user_guide/options.html#available-options) are [environment specific](https://github.com/pandas-dev/pandas/blob/e493323d93e6a3447f0adfded493b80a42f4fec4/pandas/core/config_init.py#L412-L415) and 0 for when terminal is detected, but this was not noted in the current description.
