### PR TITLE
Corrected pd.merge indicator type hint

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10100,7 +10100,7 @@ Parrot 2  Parrot       24.0
         sort: bool = False,
         suffixes: Suffixes = ("_x", "_y"),
         copy: bool = True,
-        indicator: bool = False,
+        indicator: str | bool = False,
         validate: str | None = None,
     ) -> DataFrame:
         from pandas.core.reshape.merge import merge

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -644,7 +644,7 @@ class _MergeOperation:
         right_index: bool = False,
         sort: bool = True,
         suffixes: Suffixes = ("_x", "_y"),
-        indicator: bool = False,
+        indicator: str | bool = False,
         validate: str | None = None,
     ) -> None:
         _left = _validate_operand(left)

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -107,7 +107,7 @@ def merge(
     sort: bool = False,
     suffixes: Suffixes = ("_x", "_y"),
     copy: bool = True,
-    indicator: bool = False,
+    indicator: str | bool = False,
     validate: str | None = None,
 ) -> DataFrame:
     op = _MergeOperation(

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -625,7 +625,7 @@ class _MergeOperation:
     sort: bool
     suffixes: Suffixes
     copy: bool
-    indicator: bool
+    indicator: str | bool
     validate: str | None
     join_names: list[Hashable]
     right_join_keys: list[AnyArrayLike]


### PR DESCRIPTION
The argument "indicator" in [merge ](https://pandas.pydata.org/docs/reference/api/pandas.merge.html ) should be "str | bool" instead of just string.

- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.