### PR TITLE
BUG: Restrict Timestamp(nanosecond=...) to [0, 999]

### DIFF
--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -124,7 +124,7 @@ Other API changes
 Deprecations
 ~~~~~~~~~~~~
 -
--
+- Deprecated passing ``nanoseconds`` greater than 999 or less than 0 in :class:`Timestamp` (:issue:`48538`, :issue:`48255`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_160.performance:

--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -116,7 +116,7 @@ See :ref:`install.dependencies` and :ref:`install.optional_dependencies` for mor
 Other API changes
 ^^^^^^^^^^^^^^^^^
 -
--
+- Passing ``nanoseconds`` greater than 999 or less than 0 in :class:`Timestamp` now raises a ``ValueError`` (:issue:`48538`, :issue:`48255`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_160.deprecations:
@@ -124,7 +124,7 @@ Other API changes
 Deprecations
 ~~~~~~~~~~~~
 -
-- Deprecated passing ``nanoseconds`` greater than 999 or less than 0 in :class:`Timestamp` (:issue:`48538`, :issue:`48255`)
+-
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_160.performance:

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1692,7 +1692,18 @@ class Timestamp(_Timestamp):
             )
             # Once this deprecation is enforced, we can do
             #  return Timestamp(ts_input).tz_localize(tzobj)
-        ts = convert_to_tsobject(ts_input, tzobj, unit, 0, 0, nanosecond or 0)
+        if nanosecond is None:
+            nanosecond = 0
+        elif not (999 >= nanosecond >= 0):
+            warnings.warn(
+                "In a future version, nanosecond must be between 0 and 999 inclusive "
+                "and will raise a ValueError otherwise. For nanoseconds > 999, "
+                "please distribute excess nanoseconds to microseconds and "
+                "other components as needed.",
+                FutureWarning,
+                stacklevel=find_stack_level(inspect.currentframe()),
+            )
+        ts = convert_to_tsobject(ts_input, tzobj, unit, 0, 0, nanosecond)
 
         if ts.value == NPY_NAT:
             return NaT

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1692,17 +1692,12 @@ class Timestamp(_Timestamp):
             )
             # Once this deprecation is enforced, we can do
             #  return Timestamp(ts_input).tz_localize(tzobj)
+
         if nanosecond is None:
             nanosecond = 0
         elif not (999 >= nanosecond >= 0):
-            warnings.warn(
-                "In a future version, nanosecond must be between 0 and 999 inclusive "
-                "and will raise a ValueError otherwise. For nanoseconds > 999, "
-                "please distribute excess nanoseconds to microseconds and "
-                "other components as needed.",
-                FutureWarning,
-                stacklevel=find_stack_level(inspect.currentframe()),
-            )
+            raise ValueError("nanosecond must be in 0..999")
+
         ts = convert_to_tsobject(ts_input, tzobj, unit, 0, 0, nanosecond)
 
         if ts.value == NPY_NAT:

--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -677,3 +677,10 @@ def test_constructor_missing_keyword(kwargs):
 
     with pytest.raises(TypeError, match=msg):
         Timestamp(**kwargs)
+
+
+@pytest.mark.parametrize("nano", [-1, 1000])
+def test_timestamp_nano_range_deprecated(nano):
+    # GH 48255
+    with tm.assert_produces_warning(FutureWarning):
+        Timestamp(year=2022, month=1, day=1, nanosecond=nano)

--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -680,7 +680,7 @@ def test_constructor_missing_keyword(kwargs):
 
 
 @pytest.mark.parametrize("nano", [-1, 1000])
-def test_timestamp_nano_range_deprecated(nano):
+def test_timestamp_nano_range(nano):
     # GH 48255
-    with tm.assert_produces_warning(FutureWarning):
+    with pytest.raises(ValueError, match="nanosecond must be in 0..999"):
         Timestamp(year=2022, month=1, day=1, nanosecond=nano)


### PR DESCRIPTION
- [x] closes #48538 (Replace xxxx with the Github issue number)
- [x] closes #48255 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v1.6.0.rst` file if fixing a bug or adding a new feature.
