### PR TITLE
BUG: pivot_table raising for nullable dtype and margins

### DIFF
--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -239,6 +239,7 @@ Groupby/resample/rolling
 
 Reshaping
 ^^^^^^^^^
+- Bug in :meth:`DataFrame.pivot_table` raising ``TypeError`` for nullable dtype and ``margins=True`` (:issue:`48681`)
 - Bug in :meth:`DataFrame.pivot` not respecting ``None`` as column name (:issue:`48293`)
 - Bug in :func:`join` when ``left_on`` or ``right_on`` is or includes a :class:`CategoricalIndex` incorrectly raising ``AttributeError`` (:issue:`48464`)
 -

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -25,6 +25,7 @@ from pandas.util._decorators import (
 
 from pandas.core.dtypes.cast import maybe_downcast_to_dtype
 from pandas.core.dtypes.common import (
+    is_extension_array_dtype,
     is_integer_dtype,
     is_list_like,
     is_nested_list_like,
@@ -324,6 +325,10 @@ def _add_margins(
     row_names = result.index.names
     # check the result column and leave floats
     for dtype in set(result.dtypes):
+        if is_extension_array_dtype(dtype):
+            # Can hold NA already
+            continue
+
         cols = result.select_dtypes([dtype]).columns
         margin_dummy[cols] = margin_dummy[cols].apply(
             maybe_downcast_to_dtype, args=(dtype,)

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -2183,6 +2183,23 @@ class TestPivotTable:
         )
         tm.assert_frame_equal(result, expected)
 
+    def test_pivot_table_nullable_margins(self):
+        # GH#48681
+        df = DataFrame(
+            {"a": "A", "b": [1, 2], "sales": Series([10, 11], dtype="Int64")}
+        )
+
+        result = df.pivot_table(index="b", columns="a", margins=True, aggfunc="sum")
+        expected = DataFrame(
+            [[10, 10], [11, 11], [21, 21]],
+            index=Index([1, 2, "All"], name="b"),
+            columns=MultiIndex.from_tuples(
+                [("sales", "A"), ("sales", "All")], names=[None, "a"]
+            ),
+            dtype="Int64",
+        )
+        tm.assert_frame_equal(result, expected)
+
     def test_pivot_table_sort_false_with_multiple_values(self):
         df = DataFrame(
             {


### PR DESCRIPTION
- [x] closes #48681 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
