### PR TITLE
CI: include tests in coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -184,7 +184,6 @@ ignore-regex = https://([\w/\.])+
 [coverage:run]
 branch = True
 omit =
-    */tests/*
     pandas/_typing.py
     pandas/_version.py
 plugins = Cython.Coverage


### PR DESCRIPTION
It's hard to tell whether all tests are being executed in CI - can we add not omit them from the coverage report, so this'll be easier?