### PR TITLE
DOC: re-phrase web README.md ENG

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -5,8 +5,8 @@ containing the settings to build the website. The website is generated with the
 command `./pandas_web.py pandas`. See `./pandas_web.py --help` and the header of
 the script for more information and options.
 
-After building the website, to navigate it, it is needed to access the web using
-an http server (a not open the local files with the browser, since the links and
+After building the website, the web must be accessed using
+an http server to allow navigation of the website (it is not possible to open the local files with the browser, since the links and
 the image sources are absolute to where they are served from). The easiest way
 to run an http server locally is to run `python -m http.server` from the
 `web/build/` directory.

--- a/web/README.md
+++ b/web/README.md
@@ -5,8 +5,7 @@ containing the settings to build the website. The website is generated with the
 command `./pandas_web.py pandas`. See `./pandas_web.py --help` and the header of
 the script for more information and options.
 
-After building the website, the web must be accessed using
-an http server to allow navigation of the website (it is not possible to open the local files with the browser, since the links and
+After building the website, a local http server is needed to access the built website (it is not possible to open the local files with the browser, since the links and
 the image sources are absolute to where they are served from). The easiest way
 to run an http server locally is to run `python -m http.server` from the
 `web/build/` directory.


### PR DESCRIPTION
Basic rephrasing of the web README.md for improved legibility 
- "to navigate it " -> "to allow navigation of the website " ("it" is ambiguous here, "website" leaves no question as to which entity the instructions refer to.
- "it is needed" -> "must"
- "a not open" -> "it is not possible to open " (perhaps a typo here initially, sentence lengthened for improved legibility)



