### PR TITLE
BUG/PERF: MultiIndex.difference losing EA dtype

### DIFF
--- a/asv_bench/benchmarks/multiindex_object.py
+++ b/asv_bench/benchmarks/multiindex_object.py
@@ -268,7 +268,11 @@ class SetOperations:
         if index_structure == "non_monotonic":
             data = {k: mi[::-1] for k, mi in data.items()}
 
-        data = {k: {"left": mi, "right": mi[:-1]} for k, mi in data.items()}
+        # left and right each have values not in the other
+        for k, mi in data.items():
+            n = len(mi) // 10
+            data[k] = {"left": mi[:-n], "right": mi[n:]}
+
         self.left = data[dtype]["left"]
         self.right = data[dtype]["right"]
 

--- a/asv_bench/benchmarks/multiindex_object.py
+++ b/asv_bench/benchmarks/multiindex_object.py
@@ -238,7 +238,7 @@ class SetOperations:
     params = [
         ("monotonic", "non_monotonic"),
         ("datetime", "int", "string", "ea_int"),
-        ("intersection", "union", "symmetric_difference"),
+        ("intersection", "union", "difference", "symmetric_difference"),
     ]
     param_names = ["index_structure", "dtype", "method"]
 

--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -144,6 +144,7 @@ Performance improvements
 - Performance improvement for :meth:`MultiIndex.unique` (:issue:`48335`)
 - Performance improvement in :meth:`DataFrame.join` when joining on a subset of a :class:`MultiIndex` (:issue:`48611`)
 - Performance improvement for :meth:`MultiIndex.intersection` (:issue:`48604`)
+- Performance improvement for :meth:`MultiIndex.difference` (:issue:`48722`)
 - Performance improvement in ``var`` for nullable dtypes (:issue:`48379`).
 - Performance improvement to :func:`read_sas` with ``blank_missing=True`` (:issue:`48502`)
 -
@@ -211,10 +212,11 @@ MultiIndex
 ^^^^^^^^^^
 - Bug in :class:`MultiIndex.set_levels` raising ``IndexError`` when setting empty level (:issue:`48636`)
 - Bug in :meth:`MultiIndex.unique` losing extension array dtype (:issue:`48335`)
-- Bug in :meth:`MultiIndex.intersection` losing extension array (:issue:`48604`)
+- Bug in :meth:`MultiIndex.intersection` losing extension array dtype (:issue:`48604`)
 - Bug in :meth:`MultiIndex.union` losing extension array (:issue:`48498`, :issue:`48505`)
 - Bug in :meth:`MultiIndex.append` not checking names for equality (:issue:`48288`)
-- Bug in :meth:`MultiIndex.symmetric_difference` losing extension array (:issue:`48607`)
+- Bug in :meth:`MultiIndex.difference` losing extension array dtype (:issue:`48722`)
+- Bug in :meth:`MultiIndex.symmetric_difference` losing extension array dtype (:issue:`48607`)
 -
 
 I/O

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3677,7 +3677,7 @@ class Index(IndexOpsMixin, PandasObject):
         return self._wrap_difference_result(other, result)
 
     def _difference(self, other, sort):
-        # overridden by RangeIndex
+        # overridden by MultiIndex, RangeIndex
 
         this = self.unique()
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -4013,7 +4013,7 @@ def _require_listlike(level, arr, arrname: str):
     return level, arr
 
 
-def _maybe_try_sort(result, sort):
+def _maybe_try_sort(result: MultiIndex, sort) -> MultiIndex:
     if sort is None:
         try:
             result = result.sort_values()

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -216,7 +216,10 @@ def test_difference_sort_incomparable():
 
     other = MultiIndex.from_product([[3, pd.Timestamp("2000"), 4], ["c", "d"]])
     # sort=None, the default
-    msg = "sort order is undefined for incomparable objects"
+    msg = (
+        "The values in the array are unorderable. "
+        "Pass `sort=False` to suppress this warning."
+    )
     with tm.assert_produces_warning(RuntimeWarning, match=msg):
         result = idx.difference(other)
     tm.assert_index_equal(result, idx)

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -649,3 +649,16 @@ def test_intersection_keep_ea_dtypes(val, any_numeric_ea_dtype):
     result = midx.intersection(midx2)
     expected = MultiIndex.from_arrays([Series([2], dtype=any_numeric_ea_dtype), [1]])
     tm.assert_index_equal(result, expected)
+
+
+@pytest.mark.parametrize("val", [pd.NA, 100])
+def test_difference_keep_ea_dtypes(val, any_numeric_ea_dtype):
+    midx = MultiIndex.from_arrays(
+        [Series([1, 2], dtype=any_numeric_ea_dtype), [2, 1]], names=["a", None]
+    )
+    midx2 = MultiIndex.from_arrays(
+        [Series([1, 2, val], dtype=any_numeric_ea_dtype), [1, 1, 3]]
+    )
+    result = midx.difference(midx2)
+    expected = MultiIndex.from_arrays([Series([1], dtype=any_numeric_ea_dtype), [2]])
+    tm.assert_index_equal(result, expected)


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v1.6.0.rst` file if fixing a bug or adding a new feature.

Maintains EA dtypes and improves perf:

```
       before           after         ratio
     [71fc89cd]       [19e9ae76]
     <main>           <mi-difference>
-      29.0±0.8ms       16.7±0.9ms     0.58  multiindex_object.SetOperations.time_operation('monotonic', 'string', 'difference')
-      30.4±0.4ms       15.7±0.1ms     0.52  multiindex_object.SetOperations.time_operation('non_monotonic', 'string', 'difference')
-      26.7±0.7ms       13.0±0.5ms     0.49  multiindex_object.SetOperations.time_operation('monotonic', 'ea_int', 'difference')
-      30.1±0.3ms       13.3±0.1ms     0.44  multiindex_object.SetOperations.time_operation('non_monotonic', 'ea_int', 'difference')
-      25.1±0.5ms       8.87±0.2ms     0.35  multiindex_object.SetOperations.time_operation('monotonic', 'int', 'difference')
-      27.7±0.3ms       9.58±0.3ms     0.35  multiindex_object.SetOperations.time_operation('monotonic', 'datetime', 'difference')
-      27.5±0.4ms       9.13±0.3ms     0.33  multiindex_object.SetOperations.time_operation('non_monotonic', 'int', 'difference')
-      33.4±0.2ms       10.4±0.4ms     0.31  multiindex_object.SetOperations.time_operation('non_monotonic', 'datetime', 'difference')
```