### PR TITLE
PERF: MultiIndex.size

### DIFF
--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -133,6 +133,7 @@ Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 - Performance improvement in :meth:`.DataFrameGroupBy.median` and :meth:`.SeriesGroupBy.median` and :meth:`.GroupBy.cumprod` for nullable dtypes (:issue:`37493`)
 - Performance improvement in :meth:`MultiIndex.argsort` and :meth:`MultiIndex.sort_values` (:issue:`48406`)
+- Performance improvement in :meth:`MultiIndex.size` (:issue:`48723`)
 - Performance improvement in :meth:`MultiIndex.union` without missing values and without duplicates (:issue:`48505`)
 - Performance improvement in :meth:`.DataFrameGroupBy.mean`, :meth:`.SeriesGroupBy.mean`, :meth:`.DataFrameGroupBy.var`, and :meth:`.SeriesGroupBy.var` for extension array dtypes (:issue:`37493`)
 - Performance improvement in :meth:`MultiIndex.isin` when ``level=None`` (:issue:`48622`)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -786,6 +786,14 @@ class MultiIndex(Index):
     def __len__(self) -> int:
         return len(self.codes[0])
 
+    @property
+    def size(self) -> int:
+        """
+        Return the number of elements in the underlying data.
+        """
+        # override Index.size to avoid materializing _values
+        return len(self)
+
     # --------------------------------------------------------------------
     # Levels Methods
 


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v1.6.0.rst` file if fixing a bug or adding a new feature.


Improvement comes from avoiding MultiIndex._values

```
import pandas as pd
import numpy as np

mi = pd.MultiIndex.from_product(
    [
        pd.date_range('1970-01-01', periods=1000),
        np.arange(1000),
    ]
)

%timeit mi.copy().size
```

```
111 ms ± 9.11 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)       <- main
17.7 µs ± 1.1 µs per loop (mean ± std. dev. of 7 runs, 100,000 loops each)  <- PR
```

At least one existing asv shows improvement (there may be others):

```
 before           after         ratio
     [cda0f6be]       [8395c77a]
     <main>           <multiindex-size>
-      25.1±0.4ms         18.3±1ms     0.73  multiindex_object.SetOperations.time_operation('non_monotonic', 'string', 'symmetric_difference')
-      24.8±0.4ms         16.7±2ms     0.68  multiindex_object.SetOperations.time_operation('monotonic', 'ea_int', 'symmetric_difference')
-      24.4±0.8ms       15.8±0.3ms     0.65  multiindex_object.SetOperations.time_operation('monotonic', 'string', 'symmetric_difference')
-      25.3±0.4ms         16.4±1ms     0.65  multiindex_object.SetOperations.time_operation('non_monotonic', 'ea_int', 'symmetric_difference')
-      23.9±0.4ms       13.5±0.2ms     0.57  multiindex_object.SetOperations.time_operation('non_monotonic', 'datetime', 'symmetric_difference')
-      23.0±0.6ms         12.1±2ms     0.53  multiindex_object.SetOperations.time_operation('non_monotonic', 'int', 'symmetric_difference')
-        25.1±1ms       13.0±0.6ms     0.52  multiindex_object.SetOperations.time_operation('monotonic', 'datetime', 'symmetric_difference')
-      23.0±0.4ms       11.2±0.6ms     0.49  multiindex_object.SetOperations.time_operation('monotonic', 'int', 'symmetric_difference')
```
