### PR TITLE
DOC: Fixed typo in core/groupby/groupby.py - issue #48727

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -204,7 +204,7 @@ _apply_docs = {
     >>> g1 = df.groupby('A', group_keys=False)
     >>> g2 = df.groupby('A', group_keys=True)
 
-    Notice that ``g1`` have ``g2`` have two groups, ``a`` and ``b``, and only
+    Notice that ``g1`` and ``g2`` have two groups, ``a`` and ``b``, and only
     differ in their ``group_keys`` argument. Calling `apply` in various ways,
     we can get different grouping results:
 


### PR DESCRIPTION
- [x] closes #48727 

- [x] Fixed typo on line 207 of pandas/core/groupby/groupby.py  - have -> and


