### PR TITLE
REGR: Raise on invalid colormap for scatter plot

### DIFF
--- a/doc/source/whatsnew/v1.5.1.rst
+++ b/doc/source/whatsnew/v1.5.1.rst
@@ -16,6 +16,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Fixed Regression in :meth:`DataFrame.loc` when setting values as a :class:`DataFrame` with all ``True`` indexer (:issue:`48701`)
 - Regression in :func:`.read_csv` causing an ``EmptyDataError`` when using an UTF-8 file handle that was already read from (:issue:`48646`)
+- Fixed regression in :meth:`DataFrame.plot` ignoring invalid ``colormap`` for ``kind="scatter"`` (:issue:`48726`)
 - Fixed performance regression in :func:`factorize` when ``na_sentinel`` is not ``None`` and ``sort=False`` (:issue:`48620`)
 -
 

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -1231,16 +1231,22 @@ class ScatterPlot(PlanePlot):
         else:
             c_values = c
 
-        # cmap is only used if c_values are integers, otherwise UserWarning
-        if is_integer_dtype(c_values):
-            # pandas uses colormap, matplotlib uses cmap.
-            cmap = self.colormap or "Greys"
+        if self.colormap is not None:
             if mpl_ge_3_6_0():
-                cmap = mpl.colormaps[cmap]
+                cmap = mpl.colormaps[self.colormap]
             else:
-                cmap = self.plt.cm.get_cmap(cmap)
+                cmap = self.plt.cm.get_cmap(self.colormap)
         else:
-            cmap = None
+            # cmap is only used if c_values are integers, otherwise UserWarning
+            if is_integer_dtype(c_values):
+                # pandas uses colormap, matplotlib uses cmap.
+                cmap = "Greys"
+                if mpl_ge_3_6_0():
+                    cmap = mpl.colormaps[cmap]
+                else:
+                    cmap = self.plt.cm.get_cmap(cmap)
+            else:
+                cmap = None
 
         if color_by_categorical:
             from matplotlib import colors

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -1681,6 +1681,12 @@ class TestDataFramePlots(TestPlotBase):
         self._check_has_errorbars(ax, xerr=0, yerr=1)
         _check_errorbar_color(ax.containers, "green", has_err="has_yerr")
 
+    def test_scatter_unknown_colormap(self):
+        # GH#48726
+        df = DataFrame({"a": [1, 2, 3], "b": 4})
+        with pytest.raises(ValueError, match="'unknown' is not a valid value for name"):
+            df.plot(x="a", y="b", colormap="unknown", kind="scatter")
+
     def test_sharex_and_ax(self):
         # https://github.com/pandas-dev/pandas/issues/9737 using gridspec,
         # the axis in fig.get_axis() are sorted differently than pandas

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -1684,7 +1684,7 @@ class TestDataFramePlots(TestPlotBase):
     def test_scatter_unknown_colormap(self):
         # GH#48726
         df = DataFrame({"a": [1, 2, 3], "b": 4})
-        with pytest.raises(ValueError, match="'unknown' is not a valid value for name"):
+        with pytest.raises((ValueError, KeyError), match="'unknown' is not a"):
             df.plot(x="a", y="b", colormap="unknown", kind="scatter")
 
     def test_sharex_and_ax(self):


### PR DESCRIPTION
- [x] closes #48726 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
