### PR TITLE
 BUG: AttributeError: 'function' object has no attribute 'currentframe' 

### DIFF
--- a/doc/source/whatsnew/v1.5.1.rst
+++ b/doc/source/whatsnew/v1.5.1.rst
@@ -17,7 +17,7 @@ Fixed regressions
 - Fixed Regression in :meth:`DataFrame.loc` when setting values as a :class:`DataFrame` with all ``True`` indexer (:issue:`48701`)
 - Regression in :func:`.read_csv` causing an ``EmptyDataError`` when using an UTF-8 file handle that was already read from (:issue:`48646`)
 - Fixed performance regression in :func:`factorize` when ``na_sentinel`` is not ``None`` and ``sort=False`` (:issue:`48620`)
--
+- Fixed regression in :meth:`SQLDatabase.check_case_sensitive` causing an ``AttributeError`` when table name can't be found (:issue:`48733`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.5.1.rst
+++ b/doc/source/whatsnew/v1.5.1.rst
@@ -17,7 +17,7 @@ Fixed regressions
 - Fixed Regression in :meth:`DataFrame.loc` when setting values as a :class:`DataFrame` with all ``True`` indexer (:issue:`48701`)
 - Regression in :func:`.read_csv` causing an ``EmptyDataError`` when using an UTF-8 file handle that was already read from (:issue:`48646`)
 - Fixed performance regression in :func:`factorize` when ``na_sentinel`` is not ``None`` and ``sort=False`` (:issue:`48620`)
-- Fixed regression in :meth:`SQLDatabase.check_case_sensitive` causing an ``AttributeError`` when table name can't be found (:issue:`48733`)
+- Fixed regression causing an ``AttributeError`` during warning emitted if the provided table name in :meth:`DataFrame.to_sql` and the table name actually used in the database do not match (:issue:`48733`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1645,10 +1645,10 @@ class SQLDatabase(PandasSQL):
         if not name.isdigit() and not name.islower():
             # check for potentially case sensitivity issues (GH7815)
             # Only check when name is not a number and name is not lower case
-            from sqlalchemy import inspect
+            sqlalchemy = import_optional_dependency("sqlalchemy", errors="ignore")
 
             with self.connectable.connect() as conn:
-                insp = inspect(conn)
+                insp = sqlalchemy.inspect(conn)
                 table_names = insp.get_table_names(schema=schema or self.meta.schema)
             if name not in table_names:
                 msg = (
@@ -1757,9 +1757,9 @@ class SQLDatabase(PandasSQL):
         return self.meta.tables
 
     def has_table(self, name: str, schema: str | None = None):
-        from sqlalchemy import inspect
+        sqlalchemy = import_optional_dependency("sqlalchemy", errors="ignore")
 
-        insp = inspect(self.connectable)
+        insp = sqlalchemy.inspect(self.connectable)
         return insp.has_table(name, schema or self.meta.schema)
 
     def get_table(self, table_name: str, schema: str | None = None) -> Table:

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1635,8 +1635,8 @@ class SQLDatabase(PandasSQL):
 
     def check_case_sensitive(
         self,
-        name,
-        schema,
+        name: str,
+        schema: str | None,
     ) -> None:
         """
         Checks table name for issues with case-sensitivity.
@@ -1666,11 +1666,11 @@ class SQLDatabase(PandasSQL):
     def to_sql(
         self,
         frame,
-        name,
+        name: str,
         if_exists: Literal["fail", "replace", "append"] = "fail",
         index: bool = True,
         index_label=None,
-        schema=None,
+        schema: str | None = None,
         chunksize=None,
         dtype: DtypeArg | None = None,
         method=None,

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1645,10 +1645,10 @@ class SQLDatabase(PandasSQL):
         if not name.isdigit() and not name.islower():
             # check for potentially case sensitivity issues (GH7815)
             # Only check when name is not a number and name is not lower case
-            sqlalchemy = import_optional_dependency("sqlalchemy", errors="ignore")
+            from sqlalchemy import inspect as sqlalchemy_inspect
 
             with self.connectable.connect() as conn:
-                insp = sqlalchemy.inspect(conn)
+                insp = sqlalchemy_inspect(conn)
                 table_names = insp.get_table_names(schema=schema or self.meta.schema)
             if name not in table_names:
                 msg = (
@@ -1757,9 +1757,9 @@ class SQLDatabase(PandasSQL):
         return self.meta.tables
 
     def has_table(self, name: str, schema: str | None = None):
-        sqlalchemy = import_optional_dependency("sqlalchemy", errors="ignore")
+        from sqlalchemy import inspect as sqlalchemy_inspect
 
-        insp = sqlalchemy.inspect(self.connectable)
+        insp = sqlalchemy_inspect(self.connectable)
         return insp.has_table(name, schema or self.meta.schema)
 
     def get_table(self, table_name: str, schema: str | None = None) -> Table:

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1357,10 +1357,17 @@ class TestSQLApi(SQLAlchemyMixIn, _TestSQLApi):
 
     def test_warning_case_insensitive_table_name(self, test_frame1):
         # see gh-7815
-        #
-        # We can't test that this warning is triggered, a the database
-        # configuration would have to be altered. But here we test that
-        # the warning is certainly NOT triggered in a normal case.
+        with tm.assert_produces_warning(
+            UserWarning,
+            match=(
+                r"The provided table name 'TABLE1' is not found exactly as such in "
+                r"the database after writing the table, possibly due to case "
+                r"sensitivity issues. Consider using lower case table names."
+            ),
+        ):
+            sql.SQLDatabase(self.conn).check_case_sensitive("TABLE1", "")
+
+        # Test that the warning is certainly NOT triggered in a normal case.
         with tm.assert_produces_warning(None):
             test_frame1.to_sql("CaseSensitive", self.conn)
 


### PR DESCRIPTION
- [x] closes #48733  (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Note how `pylint` would've caught this:
```
$ pylint pandas/io/sql.py | grep 'inspect'
pandas/io/sql.py:1648:12: W0621: Redefining name 'inspect' from outer scope (line 15) (redefined-outer-name)
pandas/io/sql.py:1648:12: C0415: Import outside toplevel (sqlalchemy.inspect) (import-outside-toplevel)
pandas/io/sql.py:1663:48: E1101: Function 'inspect' has no 'currentframe' member (no-member)
pandas/io/sql.py:1760:8: W0621: Redefining name 'inspect' from outer scope (line 15) (redefined-outer-name)
pandas/io/sql.py:1760:8: C0415: Import outside toplevel (sqlalchemy.inspect) (import-outside-toplevel)
```

We should add that to CI