### PR TITLE
API: Change Timestamp/Timedelta arithmetic to match numpy

### DIFF
--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -433,6 +433,7 @@ cdef class _Timestamp(ABCTimestamp):
                     # TODO: deprecate allowing this?  We only get here
                     #  with test_timedelta_add_timestamp_interval
                     other = np.timedelta64(other.view("i8"), "ns")
+                    other_reso = NPY_DATETIMEUNIT.NPY_FR_ns
                 elif (
                     other_reso == NPY_DATETIMEUNIT.NPY_FR_Y or other_reso == NPY_DATETIMEUNIT.NPY_FR_M
                 ):
@@ -440,6 +441,8 @@ cdef class _Timestamp(ABCTimestamp):
                     #  corresponding DateOffsets?
                     # TODO: no tests get here
                     other = ensure_td64ns(other)
+                    other_reso = NPY_DATETIMEUNIT.NPY_FR_ns
+
                 if other_reso > NPY_DATETIMEUNIT.NPY_FR_ns:
                     # TODO: no tests
                     other = ensure_td64ns(other)

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -440,23 +440,23 @@ cdef class _Timestamp(ABCTimestamp):
                     #  corresponding DateOffsets?
                     # TODO: no tests get here
                     other = ensure_td64ns(other)
+                if other_reso > NPY_DATETIMEUNIT.NPY_FR_ns:
+                    # TODO: no tests
+                    other = ensure_td64ns(other)
+                if other_reso > self._reso:
+                    # Following numpy, we cast to the higher resolution
+                    # test_sub_timedelta64_mismatched_reso
+                    self = (<_Timestamp>self)._as_reso(other_reso)
+
 
             if isinstance(other, _Timedelta):
                 # TODO: share this with __sub__, Timedelta.__add__
-                # We allow silent casting to the lower resolution if and only
-                #  if it is lossless.  See also Timestamp.__sub__
-                #  and Timedelta.__add__
-                try:
-                    if self._reso < other._reso:
-                        other = (<_Timedelta>other)._as_reso(self._reso, round_ok=False)
-                    elif self._reso > other._reso:
-                        self = (<_Timestamp>self)._as_reso(other._reso, round_ok=False)
-                except ValueError as err:
-                    raise ValueError(
-                        "Timestamp addition with mismatched resolutions is not "
-                        "allowed when casting to the lower resolution would require "
-                        "lossy rounding."
-                    ) from err
+                # Matching numpy, we cast to the higher resolution. Unlike numpy,
+                #  we raise instead of silently overflowing during this casting.
+                if self._reso < other._reso:
+                    self = (<_Timestamp>self)._as_reso(other._reso, round_ok=True)
+                elif self._reso > other._reso:
+                    other = (<_Timedelta>other)._as_reso(self._reso, round_ok=True)
 
             try:
                 nanos = delta_to_nanoseconds(
@@ -464,12 +464,6 @@ cdef class _Timestamp(ABCTimestamp):
                 )
             except OutOfBoundsTimedelta:
                 raise
-            except ValueError as err:
-                raise ValueError(
-                    "Addition between Timestamp and Timedelta with mismatched "
-                    "resolutions is not allowed when casting to the lower "
-                    "resolution would require lossy rounding."
-                ) from err
 
             try:
                 new_value = self.value + nanos
@@ -556,19 +550,12 @@ cdef class _Timestamp(ABCTimestamp):
                     "Cannot subtract tz-naive and tz-aware datetime-like objects."
                 )
 
-            # We allow silent casting to the lower resolution if and only
-            #  if it is lossless.
-            try:
-                if self._reso < other._reso:
-                    other = (<_Timestamp>other)._as_reso(self._reso, round_ok=False)
-                elif self._reso > other._reso:
-                    self = (<_Timestamp>self)._as_reso(other._reso, round_ok=False)
-            except ValueError as err:
-                raise ValueError(
-                    "Timestamp subtraction with mismatched resolutions is not "
-                    "allowed when casting to the lower resolution would require "
-                    "lossy rounding."
-                ) from err
+            # Matching numpy, we cast to the higher resolution. Unlike numpy,
+            #  we raise instead of silently overflowing during this casting.
+            if self._reso < other._reso:
+                self = (<_Timestamp>self)._as_reso(other._reso, round_ok=False)
+            elif self._reso > other._reso:
+                other = (<_Timestamp>other)._as_reso(self._reso, round_ok=False)
 
             # scalar Timestamp/datetime - Timestamp/datetime -> yields a
             # Timedelta

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -18,7 +18,10 @@ from pytz import (
     utc,
 )
 
-from pandas._libs.tslibs.dtypes import NpyDatetimeUnit
+from pandas._libs.tslibs.dtypes import (
+    NpyDatetimeUnit,
+    npy_unit_to_abbrev,
+)
 from pandas._libs.tslibs.timezones import (
     dateutil_gettz as gettz,
     get_timezone,
@@ -884,22 +887,29 @@ class TestNonNano:
     )
     def test_addsub_timedeltalike_non_nano(self, dt64, ts, td):
 
+        if isinstance(td, Timedelta):
+            # td._reso is ns
+            exp_reso = td._reso
+        else:
+            # effective td._reso is s
+            exp_reso = ts._reso
+
         result = ts - td
         expected = Timestamp(dt64) - td
         assert isinstance(result, Timestamp)
-        assert result._reso == ts._reso
+        assert result._reso == exp_reso
         assert result == expected
 
         result = ts + td
         expected = Timestamp(dt64) + td
         assert isinstance(result, Timestamp)
-        assert result._reso == ts._reso
+        assert result._reso == exp_reso
         assert result == expected
 
         result = td + ts
         expected = td + Timestamp(dt64)
         assert isinstance(result, Timestamp)
-        assert result._reso == ts._reso
+        assert result._reso == exp_reso
         assert result == expected
 
     def test_addsub_offset(self, ts_tz):
@@ -944,27 +954,35 @@ class TestNonNano:
         result = ts - other
         assert isinstance(result, Timedelta)
         assert result.value == 0
-        assert result._reso == min(ts._reso, other._reso)
+        assert result._reso == max(ts._reso, other._reso)
 
         result = other - ts
         assert isinstance(result, Timedelta)
         assert result.value == 0
-        assert result._reso == min(ts._reso, other._reso)
+        assert result._reso == max(ts._reso, other._reso)
 
-        msg = "Timestamp subtraction with mismatched resolutions"
         if ts._reso < other._reso:
             # Case where rounding is lossy
             other2 = other + Timedelta._from_value_and_reso(1, other._reso)
-            with pytest.raises(ValueError, match=msg):
-                ts - other2
-            with pytest.raises(ValueError, match=msg):
-                other2 - ts
+            exp = ts._as_unit(npy_unit_to_abbrev(other._reso)) - other2
+
+            res = ts - other2
+            assert res == exp
+            assert res._reso == max(ts._reso, other._reso)
+
+            res = other2 - ts
+            assert res == -exp
+            assert res._reso == max(ts._reso, other._reso)
         else:
             ts2 = ts + Timedelta._from_value_and_reso(1, ts._reso)
-            with pytest.raises(ValueError, match=msg):
-                ts2 - other
-            with pytest.raises(ValueError, match=msg):
-                other - ts2
+            exp = ts2 - other._as_unit(npy_unit_to_abbrev(ts2._reso))
+
+            res = ts2 - other
+            assert res == exp
+            assert res._reso == max(ts._reso, other._reso)
+            res = other - ts2
+            assert res == -exp
+            assert res._reso == max(ts._reso, other._reso)
 
     def test_sub_timedeltalike_mismatched_reso(self, ts_tz):
         # case with non-lossy rounding
@@ -984,32 +1002,41 @@ class TestNonNano:
         result = ts + other
         assert isinstance(result, Timestamp)
         assert result == ts
-        assert result._reso == min(ts._reso, other._reso)
+        assert result._reso == max(ts._reso, other._reso)
 
         result = other + ts
         assert isinstance(result, Timestamp)
         assert result == ts
-        assert result._reso == min(ts._reso, other._reso)
+        assert result._reso == max(ts._reso, other._reso)
 
-        msg = "Timestamp addition with mismatched resolutions"
         if ts._reso < other._reso:
             # Case where rounding is lossy
             other2 = other + Timedelta._from_value_and_reso(1, other._reso)
-            with pytest.raises(ValueError, match=msg):
-                ts + other2
-            with pytest.raises(ValueError, match=msg):
-                other2 + ts
+            exp = ts._as_unit(npy_unit_to_abbrev(other._reso)) + other2
+            res = ts + other2
+            assert res == exp
+            assert res._reso == max(ts._reso, other._reso)
+            res = other2 + ts
+            assert res == exp
+            assert res._reso == max(ts._reso, other._reso)
         else:
             ts2 = ts + Timedelta._from_value_and_reso(1, ts._reso)
-            with pytest.raises(ValueError, match=msg):
-                ts2 + other
-            with pytest.raises(ValueError, match=msg):
-                other + ts2
+            exp = ts2 + other._as_unit(npy_unit_to_abbrev(ts2._reso))
 
-        msg = "Addition between Timestamp and Timedelta with mismatched resolutions"
-        with pytest.raises(ValueError, match=msg):
-            # With a mismatched td64 as opposed to Timedelta
-            ts + np.timedelta64(1, "ns")
+            res = ts2 + other
+            assert res == exp
+            assert res._reso == max(ts._reso, other._reso)
+            res = other + ts2
+            assert res == exp
+            assert res._reso == max(ts._reso, other._reso)
+
+    def test_sub_timedelta64_mismatched_reso(self, ts_tz):
+        ts = ts_tz
+
+        res = ts + np.timedelta64(1, "ns")
+        exp = ts._as_unit("ns") + np.timedelta64(1, "ns")
+        assert exp == res
+        assert exp._reso == NpyDatetimeUnit.NPY_FR_ns.value
 
     def test_min(self, ts):
         assert ts.min <= ts


### PR DESCRIPTION
cc @mroeschke as discussed.  Will do analogous DTA/TDA cases in followup.