### PR TITLE
WEB: Update link to datapythonista blog url

### DIFF
--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -62,7 +62,7 @@ blog:
   - https://wesmckinney.com/feeds/pandas.atom.xml
   - https://tomaugspurger.github.io/feed
   - https://jorisvandenbossche.github.io/feeds/pandas.atom.xml
-  - https://datapythonista.github.io/blog/feeds/pandas.atom.xml
+  - https://datapythonista.me/blog/feeds/pandas.atom.xml
   - https://numfocus.org/tag/pandas/feed/
 maintainers:
   active:


### PR DESCRIPTION
The domain of my blog changed long ago, but seems like it wasn't updated in the pandas blog aggregator configuration. Updating it here.