### PR TITLE
BUG: Bug fix for GH48567

### DIFF
--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -196,6 +196,7 @@ Plotting
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 - Bug in :meth:`DataFrameGroupBy.sample` raises ``ValueError`` when the object is empty (:issue:`48459`)
+- Bug in :meth:`Series.groupby` raises ``ValueError`` when an entry of the index is equal to the name of the index (:issue:`48567`)
 -
 
 Reshaping

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -875,7 +875,7 @@ def get_grouper(
             exclusions.add(gpr.name)
 
         elif is_in_axis(gpr):  # df.groupby('name')
-            if not isinstance(obj, Series) and gpr in obj:
+            if obj.ndim != 1 and gpr in obj:
                 if validate:
                     obj._check_label_or_level_ambiguity(gpr, axis=axis)
                 in_axis, name, gpr = True, gpr, obj[gpr]

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -875,7 +875,7 @@ def get_grouper(
             exclusions.add(gpr.name)
 
         elif is_in_axis(gpr):  # df.groupby('name')
-            if gpr in obj:
+            if not isinstance(obj, Series) and gpr in obj:
                 if validate:
                     obj._check_label_or_level_ambiguity(gpr, axis=axis)
                 in_axis, name, gpr = True, gpr, obj[gpr]

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2907,3 +2907,30 @@ def test_groupby_cumsum_mask(any_numeric_ea_dtype, skipna, val):
         dtype=any_numeric_ea_dtype,
     )
     tm.assert_frame_equal(result, expected)
+
+def test_groupby_index_name_in_index_content():
+    # GH 48567
+    series1 = Series(data=[1.0, 2.0, 3.0, 4.0, 5.0], name='values',
+                     index=Index(['foo', 'foo', 'bar', 'baz', 'blah'],
+                                 name='blah'))
+    result1 = series1.groupby('blah').sum()
+    expected1 = Series(data=[3.0, 4.0, 5.0, 3.0], name='values',
+                       index=Index(['bar', 'baz', 'blah', 'foo'], name='blah'))
+    tm.assert_series_equal(result1, expected1)
+
+    series2 = Series(data=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], name='values',
+                     index=Index(['foo', 'foo', 'bar', 'baz', 'blah', 'blah'],
+                                 name='blah'))
+    result2 = series2.groupby('blah').sum()
+    expected2 = Series(data=[3.0, 4.0, 11.0, 3.0], name='values',
+                       index=Index(['bar', 'baz', 'blah', 'foo'],
+                                      name='blah'))
+    tm.assert_series_equal(result2, expected2)
+
+    result3 = series1.to_frame().groupby('blah').sum()
+    expected3 = expected1.to_frame()
+    tm.assert_frame_equal(result3, expected3)
+
+    result4 = series2.to_frame().groupby('blah').sum()
+    expected4 = expected2.to_frame()
+    tm.assert_frame_equal(result4, expected4)

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2908,29 +2908,33 @@ def test_groupby_cumsum_mask(any_numeric_ea_dtype, skipna, val):
     )
     tm.assert_frame_equal(result, expected)
 
-def test_groupby_index_name_in_index_content():
+
+@pytest.mark.parametrize(
+    "val_in, index, val_out",
+    [
+        (
+            [1.0, 2.0, 3.0, 4.0, 5.0],
+            ["foo", "foo", "bar", "baz", "blah"],
+            [3.0, 4.0, 5.0, 3.0],
+        ),
+        (
+            [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            ["foo", "foo", "bar", "baz", "blah", "blah"],
+            [3.0, 4.0, 11.0, 3.0],
+        ),
+    ],
+)
+def test_groupby_index_name_in_index_content(val_in, index, val_out):
     # GH 48567
-    series1 = Series(data=[1.0, 2.0, 3.0, 4.0, 5.0], name='values',
-                     index=Index(['foo', 'foo', 'bar', 'baz', 'blah'],
-                                 name='blah'))
-    result1 = series1.groupby('blah').sum()
-    expected1 = Series(data=[3.0, 4.0, 5.0, 3.0], name='values',
-                       index=Index(['bar', 'baz', 'blah', 'foo'], name='blah'))
-    tm.assert_series_equal(result1, expected1)
+    series = Series(data=val_in, name="values", index=Index(index, name="blah"))
+    result = series.groupby("blah").sum()
+    expected = Series(
+        data=val_out,
+        name="values",
+        index=Index(["bar", "baz", "blah", "foo"], name="blah"),
+    )
+    tm.assert_series_equal(result, expected)
 
-    series2 = Series(data=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], name='values',
-                     index=Index(['foo', 'foo', 'bar', 'baz', 'blah', 'blah'],
-                                 name='blah'))
-    result2 = series2.groupby('blah').sum()
-    expected2 = Series(data=[3.0, 4.0, 11.0, 3.0], name='values',
-                       index=Index(['bar', 'baz', 'blah', 'foo'],
-                                      name='blah'))
-    tm.assert_series_equal(result2, expected2)
-
-    result3 = series1.to_frame().groupby('blah').sum()
-    expected3 = expected1.to_frame()
-    tm.assert_frame_equal(result3, expected3)
-
-    result4 = series2.to_frame().groupby('blah').sum()
-    expected4 = expected2.to_frame()
-    tm.assert_frame_equal(result4, expected4)
+    result = series.to_frame().groupby("blah").sum()
+    expected = expected.to_frame()
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
Groupby for Series fails if an entry of the index of the Series is equal to the name of the index. Analyzing the bug, I think the following small change would solve the issue:

diff --git a/pandas/core/groupby/grouper.py b/pandas/core/groupby/grouper.py index 5fc713d84e..9281040a79 100644
--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -875,7 +875,7 @@ def get_grouper(
             exclusions.add(gpr.name)

         elif is_in_axis(gpr):  # df.groupby('name')
-            if gpr in obj:
+            if not isinstance(obj, Series) and gpr in obj:
                 if validate:
                     obj._check_label_or_level_ambiguity(gpr, axis=axis)
                 in_axis, name, gpr = True, gpr, obj[gpr]

From my point of view "gpr in obj" does not make sense for series at this point. I think the if-statement is written for dataframes to look if gbr is one of the columns. Skipping the if-statement for series gives the correct results for the examples above. The testsuite for series and groupby runs without errors after the change. I added a test to the test suite at the end of pandas/tests/groupby/test_groupby.py and a comment in the BUG section to doc/source/whatsnew/v1.6.0.rst.

- [x] closes #48567 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
