### PR TITLE
CLN: Remove overloads made redundant by deprecation

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -841,17 +841,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         return type(self)(codes, dtype=dtype, fastpath=True)
 
     @overload
-    def set_ordered(
-        self, value, *, inplace: NoDefault | Literal[False] = ...
-    ) -> Categorical:
-        ...
-
-    @overload
-    def set_ordered(self, value, *, inplace: Literal[True]) -> None:
-        ...
-
-    @overload
-    def set_ordered(self, value, *, inplace: bool) -> Categorical | None:
+    def set_ordered(self, value) -> Categorical:
         ...
 
     @deprecate_nonkeyword_arguments(version=None, allowed_args=["self", "value"])
@@ -893,11 +883,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         return None
 
     @overload
-    def as_ordered(self, *, inplace: NoDefault | Literal[False] = ...) -> Categorical:
-        ...
-
-    @overload
-    def as_ordered(self, *, inplace: Literal[True]) -> None:
+    def as_ordered(self) -> Categorical:
         ...
 
     @deprecate_nonkeyword_arguments(version=None, allowed_args=["self"])
@@ -923,11 +909,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         return self.set_ordered(True, inplace=inplace)
 
     @overload
-    def as_unordered(self, *, inplace: NoDefault | Literal[False] = ...) -> Categorical:
-        ...
-
-    @overload
-    def as_unordered(self, *, inplace: Literal[True]) -> None:
+    def as_unordered(self) -> Categorical:
         ...
 
     @deprecate_nonkeyword_arguments(version=None, allowed_args=["self"])


### PR DESCRIPTION
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.


Not 100% sure what the policy is on type annotation in pandas when there is a deprecation that makes overloads redundant, assuming the deprecated path isn't taken. 

xref pandas-dev/pandas-stubs#317
