### PR TITLE
REGR: describe raising when result contains NA

### DIFF
--- a/doc/source/whatsnew/v1.5.1.rst
+++ b/doc/source/whatsnew/v1.5.1.rst
@@ -72,6 +72,7 @@ Fixed regressions
 - Fixed Regression in :meth:`Series.__setitem__` casting ``None`` to ``NaN`` for object dtype (:issue:`48665`)
 - Fixed Regression in :meth:`DataFrame.loc` when setting values as a :class:`DataFrame` with all ``True`` indexer (:issue:`48701`)
 - Regression in :func:`.read_csv` causing an ``EmptyDataError`` when using an UTF-8 file handle that was already read from (:issue:`48646`)
+- Fixed regression in :meth:`DataFrame.describe` raising ``TypeError`` when result contains ``NA`` (:issue:`48778`)
 - Fixed regression in :meth:`DataFrame.plot` ignoring invalid ``colormap`` for ``kind="scatter"`` (:issue:`48726`)
 - Fixed performance regression in :func:`factorize` when ``na_sentinel`` is not ``None`` and ``sort=False`` (:issue:`48620`)
 -

--- a/pandas/core/describe.py
+++ b/pandas/core/describe.py
@@ -24,6 +24,7 @@ import numpy as np
 
 from pandas._libs.tslibs import Timestamp
 from pandas._typing import (
+    DtypeObj,
     NDFrameT,
     npt,
 )
@@ -244,10 +245,11 @@ def describe_numeric_1d(series: Series, percentiles: Sequence[float]) -> Series:
         + [series.max()]
     )
     # GH#48340 - always return float on non-complex numeric data
+    dtype: DtypeObj | None
     if is_extension_array_dtype(series):
         dtype = pd.Float64Dtype()
     elif is_numeric_dtype(series) and not is_complex_dtype(series):
-        dtype = float
+        dtype = np.dtype("float")
     else:
         dtype = None
     return Series(d, index=stat_index, name=series.name, dtype=dtype)

--- a/pandas/core/describe.py
+++ b/pandas/core/describe.py
@@ -34,10 +34,12 @@ from pandas.core.dtypes.common import (
     is_bool_dtype,
     is_complex_dtype,
     is_datetime64_any_dtype,
+    is_extension_array_dtype,
     is_numeric_dtype,
     is_timedelta64_dtype,
 )
 
+import pandas as pd
 from pandas.core.reshape.concat import concat
 
 from pandas.io.formats.format import format_percentiles
@@ -242,7 +244,12 @@ def describe_numeric_1d(series: Series, percentiles: Sequence[float]) -> Series:
         + [series.max()]
     )
     # GH#48340 - always return float on non-complex numeric data
-    dtype = float if is_numeric_dtype(series) and not is_complex_dtype(series) else None
+    if is_extension_array_dtype(series):
+        dtype = pd.Float64Dtype()
+    elif is_numeric_dtype(series) and not is_complex_dtype(series):
+        dtype = float
+    else:
+        dtype = None
     return Series(d, index=stat_index, name=series.name, dtype=dtype)
 
 

--- a/pandas/tests/frame/methods/test_describe.py
+++ b/pandas/tests/frame/methods/test_describe.py
@@ -397,3 +397,15 @@ class TestDataFrameDescribe:
         ser = df.iloc[:, 0].describe()
         expected = pd.concat([ser, ser, ser], keys=df.columns, axis=1)
         tm.assert_frame_equal(result, expected)
+
+    def test_ea_with_na(self, any_numeric_ea_dtype):
+        # GH#48778
+
+        df = DataFrame({"a": [1, pd.NA, pd.NA], "b": pd.NA}, dtype=any_numeric_ea_dtype)
+        result = df.describe()
+        expected = DataFrame(
+            {"a": [1.0, 1.0, pd.NA] + [1.0] * 5, "b": [0.0] + [pd.NA] * 7},
+            index=["count", "mean", "std", "min", "25%", "50%", "75%", "max"],
+            dtype="Float64",
+        )
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/series/methods/test_describe.py
+++ b/pandas/tests/series/methods/test_describe.py
@@ -1,6 +1,9 @@
 import numpy as np
 
-from pandas.core.dtypes.common import is_complex_dtype
+from pandas.core.dtypes.common import (
+    is_complex_dtype,
+    is_extension_array_dtype,
+)
 
 from pandas import (
     Period,
@@ -154,6 +157,11 @@ class TestSeriesDescribe:
 
     def test_numeric_result_dtype(self, any_numeric_dtype):
         # GH#48340 - describe should always return float on non-complex numeric input
+        if is_extension_array_dtype(any_numeric_dtype):
+            dtype = "Float64"
+        else:
+            dtype = "complex128" if is_complex_dtype(any_numeric_dtype) else None
+
         ser = Series([0, 1], dtype=any_numeric_dtype)
         result = ser.describe()
         expected = Series(
@@ -168,6 +176,6 @@ class TestSeriesDescribe:
                 1.0,
             ],
             index=["count", "mean", "std", "min", "25%", "50%", "75%", "max"],
-            dtype="complex128" if is_complex_dtype(ser) else None,
+            dtype=dtype,
         )
         tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #48778 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

We should keep the masked dtypes when we are getting them as input, otherwise we either end up with object or with these TypeErrors as soon as a NA is introduced

cc @rhshadrach are you ok with this?