### PR TITLE
BUG: still emitting unnecessary FutureWarning in DataFrame.sort_values with sparse columns

### DIFF
--- a/doc/source/whatsnew/v1.5.1.rst
+++ b/doc/source/whatsnew/v1.5.1.rst
@@ -84,6 +84,7 @@ Bug fixes
 ~~~~~~~~~
 - Bug in :meth:`DataFrame.to_hdf` raising ``AssertionError`` with boolean index (:issue:`48667`)
 - Bug in :meth:`DataFrame.pivot_table` raising unexpected ``FutureWarning`` when setting datetime column as index (:issue:`48683`)
+- Stopped emitting unnecessary ``FutureWarning`` in :meth:`DataFrame.sort_values` with boolean sparse columns (:issue:`48784`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.5.1.rst
+++ b/doc/source/whatsnew/v1.5.1.rst
@@ -88,7 +88,7 @@ Bug fixes
 - Bug in :meth:`DataFrame.to_hdf` raising ``AssertionError`` with boolean index (:issue:`48667`)
 - Bug in :func:`assert_index_equal` for extension arrays with non matching ``NA`` raising ``ValueError`` (:issue:`48608`)
 - Bug in :meth:`DataFrame.pivot_table` raising unexpected ``FutureWarning`` when setting datetime column as index (:issue:`48683`)
-- Stopped emitting unnecessary ``FutureWarning`` in :meth:`DataFrame.sort_values` with boolean sparse columns (:issue:`48784`)
+- Bug in :meth:`DataFrame.sort_values` emitting unnecessary ``FutureWarning`` when called on :class:`DataFrame` with boolean sparse columns (:issue:`48784`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -344,7 +344,9 @@ def lexsort_indexer(
         with warnings.catch_warnings():
             # TODO(2.0): unnecessary once deprecation is enforced
             # GH#45618 don't issue warning user can't do anything about
-            warnings.filterwarnings("ignore", ".*SparseArray.*", category=FutureWarning)
+            warnings.filterwarnings(
+                "ignore", ".*(SparseArray|SparseDtype).*", category=FutureWarning
+            )
 
             cat = Categorical(k, ordered=True)
 

--- a/pandas/tests/frame/methods/test_sort_values.py
+++ b/pandas/tests/frame/methods/test_sort_values.py
@@ -15,11 +15,12 @@ import pandas._testing as tm
 
 
 class TestDataFrameSortValues:
-    def test_sort_values_sparse_no_warning(self):
+    @pytest.mark.parametrize("dtype", [np.uint8, bool])
+    def test_sort_values_sparse_no_warning(self, dtype):
         # GH#45618
         # TODO(2.0): test will be unnecessary
         ser = pd.Series(Categorical(["a", "b", "a"], categories=["a", "b", "c"]))
-        df = pd.get_dummies(ser, sparse=True)
+        df = pd.get_dummies(ser, dtype=dtype, sparse=True)
 
         with tm.assert_produces_warning(None):
             # No warnings about constructing Index from SparseArray


### PR DESCRIPTION
- [x] closes #48784 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
