### PR TITLE
DOC: Add example for `Series.get()`

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4314,7 +4314,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         2014-02-14          22.0    medium
         2014-02-15          35.0    medium
 
-        >>> df['windspeed'].get('2014-02-13')
+        >>> ser = df['windspeed']
+        >>> ser.get('2014-02-13')
         'high'
 
         If the key isn't found, the default value will be used.
@@ -4322,7 +4323,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         >>> df.get(["temp_celsius", "temp_kelvin"], default="default_value")
         'default_value'
 
-        >>> df['windspeed'].get('2014-02-10', '[unknown]')
+        >>> ser.get('2014-02-10', '[unknown]')
         '[unknown]'
         """
         try:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4314,10 +4314,16 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         2014-02-14          22.0    medium
         2014-02-15          35.0    medium
 
+        >>> df['windspeed'].get('2014-02-13')
+        'high'
+
         If the key isn't found, the default value will be used.
 
         >>> df.get(["temp_celsius", "temp_kelvin"], default="default_value")
         'default_value'
+
+        >>> df['windspeed'].get('2014-02-10', '[unknown]')
+        '[unknown]'
         """
         try:
             return self[key]


### PR DESCRIPTION
Add an example of `Series.get()` to `NDFrame`.

Previously, [the docs for `Series.get()`](https://pandas.pydata.org/docs/reference/api/pandas.Series.get.html) only showed examples for `DataFrame.get()`, confusingly.