### PR TITLE
PERF: Delay creation of indexer in RangeIndex.sort_values

### DIFF
--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -148,7 +148,7 @@ Performance improvements
 - Performance improvement for :meth:`MultiIndex.intersection` (:issue:`48604`)
 - Performance improvement in ``var`` for nullable dtypes (:issue:`48379`).
 - Performance improvement to :func:`read_sas` with ``blank_missing=True`` (:issue:`48502`)
-- Memory improvement in :meth:`RangeIndex.sort_values` (:issue:`?`)
+- Memory improvement in :meth:`RangeIndex.sort_values` (:issue:`48801`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_160.bug_fixes:

--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -148,7 +148,7 @@ Performance improvements
 - Performance improvement for :meth:`MultiIndex.intersection` (:issue:`48604`)
 - Performance improvement in ``var`` for nullable dtypes (:issue:`48379`).
 - Performance improvement to :func:`read_sas` with ``blank_missing=True`` (:issue:`48502`)
--
+- Memory improvement in :meth:`RangeIndex.sort_values` (:issue:`?`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_160.bug_fixes:

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -554,8 +554,6 @@ class RangeIndex(NumericIndex):
         na_position: str = "last",
         key: Callable | None = None,
     ):
-        sorted_index = self
-        indexer = RangeIndex(range(len(self)))
         if key is not None:
             return super().sort_values(
                 return_indexer=return_indexer,
@@ -565,17 +563,22 @@ class RangeIndex(NumericIndex):
             )
         else:
             sorted_index = self
+            inverse_indexer = False
             if ascending:
                 if self.step < 0:
                     sorted_index = self[::-1]
-                    indexer = indexer[::-1]
+                    inverse_indexer = True
             else:
                 if self.step > 0:
                     sorted_index = self[::-1]
-                    indexer = indexer = indexer[::-1]
+                    inverse_indexer = True
 
         if return_indexer:
-            return sorted_index, indexer
+            if inverse_indexer:
+                rng = range(len(self) + 1, -1, -1)
+            else:
+                rng = range(len(self))
+            return sorted_index, RangeIndex(rng)
         else:
             return sorted_index
 

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -575,7 +575,7 @@ class RangeIndex(NumericIndex):
 
         if return_indexer:
             if inverse_indexer:
-                rng = range(len(self) + 1, -1, -1)
+                rng = range(len(self) - 1, -1, -1)
             else:
                 rng = range(len(self))
             return sorted_index, RangeIndex(rng)


### PR DESCRIPTION
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v1.6.0.rst` file if fixing a bug or adding a new feature.

```
In [2]: ri = pd.RangeIndex(1_000_000)

In [3]: %memit ri.sort_values() # PR
peak memory: 120.22 MiB, increment: 0.10 MiB

In [4]: %memit ri.sort_values() # main
peak memory: 119.88 MiB, increment: 0.17 MiB
```