### PR TITLE
DOC Set sort default to no_default, note that it may differ in other libraries

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8385,7 +8385,7 @@ Parrot 2  Parrot       24.0
         axis: Axis = 0,
         level: IndexLabel | None = None,
         as_index: bool = True,
-        sort: bool = True,
+        sort: bool | lib.NoDefault = no_default,
         group_keys: bool | lib.NoDefault = no_default,
         squeeze: bool | lib.NoDefault = no_default,
         observed: bool = False,
@@ -8393,6 +8393,10 @@ Parrot 2  Parrot       24.0
     ) -> DataFrameGroupBy:
         from pandas.core.groupby.generic import DataFrameGroupBy
 
+        if sort is no_default:
+            # no_default is just there to signal to users that
+            # the default may differ across DataFrame libraries
+            sort = True
         if squeeze is not no_default:
             warnings.warn(
                 (
@@ -9838,7 +9842,7 @@ Parrot 2  Parrot       24.0
         how: str = "left",
         lsuffix: str = "",
         rsuffix: str = "",
-        sort: bool = False,
+        sort: bool | lib.NoDefault = lib.no_default,
         validate: str | None = None,
     ) -> DataFrame:
         """
@@ -9994,6 +9998,10 @@ Parrot 2  Parrot       24.0
         4  K0  A4   B0
         5  K1  A5   B1
         """
+        if sort is no_default:
+            # no_default is just there to signal to users that
+            # the default may differ across DataFrame libraries
+            sort = False
         return self._join_compat(
             other,
             on=on,

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2060,7 +2060,7 @@ Name: Max Speed, dtype: float64
         axis: Axis = 0,
         level: Level = None,
         as_index: bool = True,
-        sort: bool = True,
+        sort: bool | lib.NoDefault = no_default,
         group_keys: bool | lib.NoDefault = no_default,
         squeeze: bool | lib.NoDefault = no_default,
         observed: bool = False,
@@ -2068,6 +2068,10 @@ Name: Max Speed, dtype: float64
     ) -> SeriesGroupBy:
         from pandas.core.groupby.generic import SeriesGroupBy
 
+        if sort is no_default:
+            # no_default is just there to signal to users that
+            # the default may differ across DataFrame libraries
+            sort = True
         if squeeze is not no_default:
             warnings.warn(
                 (


### PR DESCRIPTION
This comes out of  Consortium for Python Data API Standards working group meetings - the idea is that there are other DataFrame libraries with a similar API to pandas, and it'd be good to standardise where possible.

For methods which use hash-based methods (e.g. that call `factorize`), then to sort or not to sort can vary across libraries. For example, for `DataFrame.groupby`, in vaex the default is `sort=False`, whilst in pandas it's `sort=True`.

From the minutes of the 31 March 2022 meeting:

> 
> Ashwin: so the change would be to change to the sort argument to None in pandas.
> 
> Jeff: in pandas, we don't allow None as a default value. If not passed, we default to boolean.
> 
> Ashwin: yeah, my proposal is making None the default. Should not change default behavior.
> 
> Jeff: sounds reasonable to me.

Also, from the [pandas standardisation document](https://docs.google.com/document/d/1PIFF0JhPEn9SLK1dagS11lTzPg1DCcuvam7GYE8jK88):

> Decision: make sort=None with a note not to rely on ordering unless sort=True is specified by the user.
> We changed our minds on this; pandas may stay with sort=True, others may recommend sort=False.

It's hard to tell exactly what's required here, so I figured I'd just open a PR with what I think is being asked and we can drive the conversation forwards from here. The docs already mention "Get better performance by turning this off."