### PR TITLE
BUG: DTI-datetime_scalar preserve freq

### DIFF
--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -165,7 +165,7 @@ Datetimelike
 ^^^^^^^^^^^^
 - Bug in :func:`pandas.infer_freq`, raising ``TypeError`` when inferred on :class:`RangeIndex` (:issue:`47084`)
 - Bug in :class:`DatetimeIndex` constructor failing to raise when ``tz=None`` is explicitly specified in conjunction with timezone-aware ``dtype`` or data (:issue:`48659`)
-- Bug in subtracting a ``datetime`` scalar from :class:`DatetimeIndex` failing to retain the original ``freq`` attribute (:issue:`?`)
+- Bug in subtracting a ``datetime`` scalar from :class:`DatetimeIndex` failing to retain the original ``freq`` attribute (:issue:`48818`)
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -165,6 +165,7 @@ Datetimelike
 ^^^^^^^^^^^^
 - Bug in :func:`pandas.infer_freq`, raising ``TypeError`` when inferred on :class:`RangeIndex` (:issue:`47084`)
 - Bug in :class:`DatetimeIndex` constructor failing to raise when ``tz=None`` is explicitly specified in conjunction with timezone-aware ``dtype`` or data (:issue:`48659`)
+- Bug in subtracting a ``datetime`` scalar from :class:`DatetimeIndex` failing to retain the original ``freq`` attribute (:issue:`?`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1186,7 +1186,16 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
 
         i8 = self.asi8
         result = checked_add_with_arr(i8, -other.value, arr_mask=self._isnan)
-        return result.view("timedelta64[ns]")
+        res_m8 = result.view(f"timedelta64[{self._unit}]")
+
+        new_freq = None
+        if isinstance(self.freq, Tick):
+            # adding a scalar preserves freq
+            new_freq = self.freq
+
+        from pandas.core.arrays import TimedeltaArray
+
+        return TimedeltaArray._simple_new(res_m8, dtype=res_m8.dtype, freq=new_freq)
 
     @final
     def _sub_datetime_arraylike(self, other):

--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -17,12 +17,33 @@ import pandas._testing as tm
 
 
 class TestDatetimeIndex:
-    def test_sub_datetime_preserves_reso(self, tz_naive_fixture):
+    def test_sub_datetime_preserves_freq(self, tz_naive_fixture):
         # GH#48818
         dti = date_range("2016-01-01", periods=12, tz=tz_naive_fixture)
 
         res = dti - dti[0]
         expected = pd.timedelta_range("0 Days", "11 Days")
+        tm.assert_index_equal(res, expected)
+        assert res.freq == expected.freq
+
+    @pytest.mark.xfail(
+        reason="The inherited freq is incorrect bc dti.freq is incorrect "
+        "https://github.com/pandas-dev/pandas/pull/48818/files#r982793461"
+    )
+    def test_sub_datetime_preserves_freq_across_dst(self):
+        # GH#48818
+        ts = Timestamp("2016-03-11", tz="US/Pacific")
+        dti = date_range(ts, periods=4)
+
+        res = dti - dti[0]
+        expected = pd.TimedeltaIndex(
+            [
+                pd.Timedelta(days=0),
+                pd.Timedelta(days=1),
+                pd.Timedelta(days=2),
+                pd.Timedelta(days=2, hours=23),
+            ]
+        )
         tm.assert_index_equal(res, expected)
         assert res.freq == expected.freq
 

--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -18,6 +18,7 @@ import pandas._testing as tm
 
 class TestDatetimeIndex:
     def test_sub_datetime_preserves_reso(self, tz_naive_fixture):
+        # GH#48818
         dti = date_range("2016-01-01", periods=12, tz=tz_naive_fixture)
 
         res = dti - dti[0]

--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -17,6 +17,14 @@ import pandas._testing as tm
 
 
 class TestDatetimeIndex:
+    def test_sub_datetime_preserves_reso(self, tz_naive_fixture):
+        dti = date_range("2016-01-01", periods=12, tz=tz_naive_fixture)
+
+        res = dti - dti[0]
+        expected = pd.timedelta_range("0 Days", "11 Days")
+        tm.assert_index_equal(res, expected)
+        assert res.freq == expected.freq
+
     def test_time_overflow_for_32bit_machines(self):
         # GH8943.  On some machines NumPy defaults to np.int32 (for example,
         # 32-bit Linux machines).  In the function _generate_regular_range


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
