### PR TITLE
Adding new variables for docstring

### DIFF
--- a/pandas/_libs/tslibs/timestamps.pxd
+++ b/pandas/_libs/tslibs/timestamps.pxd
@@ -22,7 +22,7 @@ cdef _Timestamp create_timestamp_from_ts(int64_t value,
 
 cdef class _Timestamp(ABCTimestamp):
     cdef readonly:
-        int64_t value, nanosecond, year
+        int64_t value, nanosecond, year, _hour
         BaseOffset _freq
         NPY_DATETIMEUNIT _reso
 

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -165,6 +165,7 @@ cdef inline _Timestamp create_timestamp_from_ts(
     ts_base.value = value
     ts_base._freq = freq
     ts_base.year = dts.year
+    ts_base._hour = dts.hour
     ts_base.nanosecond = dts.ps // 1000
     ts_base._reso = reso
 
@@ -2368,6 +2369,13 @@ default 'raise'
                  self.microsecond / 3600.0 / 1e+6 +
                  self.nanosecond / 3600.0 / 1e+9
                  ) / 24.0)
+
+    @property
+    def hour(self):
+        """
+        My hour
+        """
+        return self._hour
 
     def isoweekday(self):
         """


### PR DESCRIPTION
- [ ] closes #48632 
- [ ] ~~[Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature~~
- [ ] ~~All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).~~
- [ ] ~~Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.~~
- [ ] ~~Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.~~

I am creating this PR to get comments on whether this solution is correct or not.

**Solution -** The Timestamp class is inheriting from datetime. Values of `month`, `day`, `hour`, `minute`, `second` and `microsecond` variables are used of that of datetime class. To add the docstring, I am proposing to create one new variable for each. I have added a variable for `hour` as an example.

I don't know whether it will affect performance and memory usage. Do we have some existing mechanism to measure it and then compare with old results?