### PR TITLE
BUG: convert_dtypes not converting with pd.NA and object dtype

### DIFF
--- a/doc/source/whatsnew/v1.6.0.rst
+++ b/doc/source/whatsnew/v1.6.0.rst
@@ -186,6 +186,7 @@ Conversion
 ^^^^^^^^^^
 - Bug in constructing :class:`Series` with ``int64`` dtype from a string list raising instead of casting (:issue:`44923`)
 - Bug in :meth:`DataFrame.eval` incorrectly raising an ``AttributeError`` when there are negative values in function call (:issue:`46471`)
+- Bug in :meth:`Series.convert_dtypes` not converting dtype to nullable dtype when :class:`Series` contains ``NA`` and has dtype ``object`` (:issue:`48791`)
 - Bug where any :class:`ExtensionDtype` subclass with ``kind="M"`` would be interpreted as a timezone type (:issue:`34986`)
 -
 

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1083,6 +1083,7 @@ def convert_dtypes(
     convert_integer: bool = True,
     convert_boolean: bool = True,
     convert_floating: bool = True,
+    infer_objects: bool = False,
 ) -> DtypeObj:
     """
     Convert objects to best possible type, and optionally,
@@ -1139,6 +1140,12 @@ def convert_dtypes(
                     inferred_dtype = target_int_dtype
                 else:
                     inferred_dtype = input_array.dtype
+            elif (
+                infer_objects
+                and is_object_dtype(input_array.dtype)
+                and inferred_dtype == "integer"
+            ):
+                inferred_dtype = target_int_dtype
 
         if convert_floating:
             if not is_integer_dtype(input_array.dtype) and is_numeric_dtype(
@@ -1160,6 +1167,12 @@ def convert_dtypes(
                         inferred_dtype = inferred_float_dtype
                 else:
                     inferred_dtype = inferred_float_dtype
+            elif (
+                infer_objects
+                and is_object_dtype(input_array.dtype)
+                and inferred_dtype == "mixed-integer-float"
+            ):
+                inferred_dtype = pandas_dtype("Float64")
 
         if convert_boolean:
             if is_bool_dtype(input_array.dtype):

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1103,7 +1103,7 @@ def convert_dtypes(
         If `convert_integer` is also True, preference will be give to integer
         dtypes if the floats can be faithfully casted to integers.
     infer_objects : bool, defaults False
-        Whether to also infert objects to float/int if possible. Is only hit if the
+        Whether to also infer objects to float/int if possible. Is only hit if the
         object array contains pd.NA.
 
     Returns

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1102,6 +1102,9 @@ def convert_dtypes(
         Whether, if possible, conversion can be done to floating extension types.
         If `convert_integer` is also True, preference will be give to integer
         dtypes if the floats can be faithfully casted to integers.
+    infer_objects : bool, defaults False
+        Whether to also infert objects to float/int if possible. Is only hit if the
+        object array contains pd.NA.
 
     Returns
     -------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -5704,6 +5704,7 @@ Keep all original rows and also all original values
                 convert_integer,
                 convert_boolean,
                 convert_floating,
+                infer_objects,
             )
             result = input_series.astype(inferred_dtype)
         else:

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -229,3 +229,23 @@ class TestSeriesConvertDtypes:
         result = df.convert_dtypes()
         expected = df
         tm.assert_frame_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "infer_objects, dtype", [(True, "Int64"), (False, "object")]
+    )
+    def test_convert_dtype_object_with_na(self, infer_objects, dtype):
+        # GH#48791
+        ser = pd.Series([1, pd.NA])
+        result = ser.convert_dtypes(infer_objects=infer_objects)
+        expected = pd.Series([1, pd.NA], dtype=dtype)
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "infer_objects, dtype", [(True, "Float64"), (False, "object")]
+    )
+    def test_convert_dtype_object_with_na_float(self, infer_objects, dtype):
+        # GH#48791
+        ser = pd.Series([1.5, pd.NA])
+        result = ser.convert_dtypes(infer_objects=infer_objects)
+        expected = pd.Series([1.5, pd.NA], dtype=dtype)
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #48791 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

I think these conversion rules make more sense