### PR TITLE
Backport PR #48736 on branch 1.5.x ( BUG: AttributeError: 'function' object has no attribute 'currentframe')

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1634,8 +1634,8 @@ class SQLDatabase(PandasSQL):
 
     def check_case_sensitive(
         self,
-        name,
-        schema,
+        name: str,
+        schema: str | None,
     ) -> None:
         """
         Checks table name for issues with case-sensitivity.
@@ -1644,10 +1644,10 @@ class SQLDatabase(PandasSQL):
         if not name.isdigit() and not name.islower():
             # check for potentially case sensitivity issues (GH7815)
             # Only check when name is not a number and name is not lower case
-            from sqlalchemy import inspect
+            from sqlalchemy import inspect as sqlalchemy_inspect
 
             with self.connectable.connect() as conn:
-                insp = inspect(conn)
+                insp = sqlalchemy_inspect(conn)
                 table_names = insp.get_table_names(schema=schema or self.meta.schema)
             if name not in table_names:
                 msg = (
@@ -1665,11 +1665,11 @@ class SQLDatabase(PandasSQL):
     def to_sql(
         self,
         frame,
-        name,
+        name: str,
         if_exists: str = "fail",
         index: bool = True,
         index_label=None,
-        schema=None,
+        schema: str | None = None,
         chunksize=None,
         dtype: DtypeArg | None = None,
         method=None,
@@ -1756,9 +1756,9 @@ class SQLDatabase(PandasSQL):
         return self.meta.tables
 
     def has_table(self, name: str, schema: str | None = None):
-        from sqlalchemy import inspect
+        from sqlalchemy import inspect as sqlalchemy_inspect
 
-        insp = inspect(self.connectable)
+        insp = sqlalchemy_inspect(self.connectable)
         return insp.has_table(name, schema or self.meta.schema)
 
     def get_table(self, table_name: str, schema: str | None = None) -> Table:

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1357,10 +1357,17 @@ class TestSQLApi(SQLAlchemyMixIn, _TestSQLApi):
 
     def test_warning_case_insensitive_table_name(self, test_frame1):
         # see gh-7815
-        #
-        # We can't test that this warning is triggered, a the database
-        # configuration would have to be altered. But here we test that
-        # the warning is certainly NOT triggered in a normal case.
+        with tm.assert_produces_warning(
+            UserWarning,
+            match=(
+                r"The provided table name 'TABLE1' is not found exactly as such in "
+                r"the database after writing the table, possibly due to case "
+                r"sensitivity issues. Consider using lower case table names."
+            ),
+        ):
+            sql.SQLDatabase(self.conn).check_case_sensitive("TABLE1", "")
+
+        # Test that the warning is certainly NOT triggered in a normal case.
         with tm.assert_produces_warning(None):
             test_frame1.to_sql("CaseSensitive", self.conn)
 


### PR DESCRIPTION
#48736

the whatsnew was accidentally back ported before
