### PR TITLE
TYP: Axis-related annotations

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -506,7 +506,7 @@ class Apply(metaclass=abc.ABCMeta):
                 ktu._set_names(selected_obj.columns.names)
                 keys_to_use = ktu
 
-            axis = 0 if isinstance(obj, ABCSeries) else 1
+            axis: AxisInt = 0 if isinstance(obj, ABCSeries) else 1
             # error: Key expression in dictionary comprehension has incompatible type
             # "Hashable"; expected type "NDFrame"  [misc]
             result = concat(
@@ -932,7 +932,7 @@ class FrameApply(NDFrameApply):
 
 
 class FrameRowApply(FrameApply):
-    axis = 0
+    axis: AxisInt = 0
 
     def apply_broadcast(self, target: DataFrame) -> DataFrame:
         return super().apply_broadcast(target)
@@ -992,7 +992,7 @@ class FrameRowApply(FrameApply):
 
 
 class FrameColumnApply(FrameApply):
-    axis = 1
+    axis: AxisInt = 1
 
     def apply_broadcast(self, target: DataFrame) -> DataFrame:
         result = super().apply_broadcast(target.T)
@@ -1069,7 +1069,7 @@ class FrameColumnApply(FrameApply):
 
 class SeriesApply(NDFrameApply):
     obj: Series
-    axis = 0
+    axis: AxisInt = 0
 
     def __init__(
         self,
@@ -1199,7 +1199,7 @@ class GroupByApply(Apply):
 
 
 class ResamplerWindowApply(Apply):
-    axis = 0
+    axis: AxisInt = 0
     obj: Resampler | BaseWindow
 
     def __init__(

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7586,7 +7586,7 @@ class DataFrame(NDFrame, OpsMixin):
     # Arithmetic Methods
 
     def _cmp_method(self, other, op):
-        axis = 1  # only relevant for Series other case
+        axis: Literal[1] = 1  # only relevant for Series other case
 
         self, other = ops.align_method_FRAME(self, other, axis, flex=False, level=None)
 
@@ -7598,7 +7598,7 @@ class DataFrame(NDFrame, OpsMixin):
         if ops.should_reindex_frame_op(self, other, op, 1, 1, None, None):
             return ops.frame_arith_method_with_reindex(self, other, op)
 
-        axis = 1  # only relevant for Series other case
+        axis: Literal[1] = 1  # only relevant for Series other case
         other = ops.maybe_prepare_scalar_for_op(other, (self.shape[axis],))
 
         self, other = ops.align_method_FRAME(self, other, axis, flex=True, level=None)
@@ -10657,7 +10657,7 @@ Parrot 2  Parrot       24.0
         if not drop:
             # Find non-matching labels along the given axis
             # and append missing correlations (GH 22375)
-            raxis = 1 if axis == 0 else 0
+            raxis: AxisInt = 1 if axis == 0 else 0
             result_index = this._get_axis(raxis).union(other._get_axis(raxis))
             idx_diff = result_index.difference(correl.index)
 
@@ -11666,7 +11666,7 @@ Parrot 2  Parrot       24.0
         "columns": 1,
     }
     _AXIS_LEN = len(_AXIS_ORDERS)
-    _info_axis_number = 1
+    _info_axis_number: Literal[1] = 1
     _info_axis_name: Literal["columns"] = "columns"
 
     index = properties.AxisProperty(

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -577,7 +577,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
     @final
     @classmethod
-    def _get_block_manager_axis(cls, axis: Axis) -> int:
+    def _get_block_manager_axis(cls, axis: Axis) -> AxisInt:
         """Map the axis to the block_manager axis."""
         axis = cls._get_axis_number(axis)
         ndim = cls._AXIS_LEN
@@ -1705,7 +1705,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         )
 
     @final
-    def _is_label_reference(self, key: Level, axis: int = 0) -> bool_t:
+    def _is_label_reference(self, key: Level, axis: Axis = 0) -> bool_t:
         """
         Test whether a key is a label reference for a given axis.
 
@@ -1725,8 +1725,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         -------
         is_label: bool
         """
-        axis = self._get_axis_number(axis)
-        other_axes = (ax for ax in range(self._AXIS_LEN) if ax != axis)
+        axis_int = self._get_axis_number(axis)
+        other_axes = (ax for ax in range(self._AXIS_LEN) if ax != axis_int)
 
         return (
             key is not None

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1111,7 +1111,7 @@ class _LocIndexer(_LocationIndexer):
     # Key Checks
 
     @doc(_LocationIndexer._validate_key)
-    def _validate_key(self, key, axis: AxisInt):
+    def _validate_key(self, key, axis: Axis):
         # valid for a collection of labels (we check their presence later)
         # slice of labels (where start-end in labels)
         # slice of integers (only if in the labels)

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -21,6 +21,7 @@ import numpy as np
 
 from pandas._typing import (
     Axis,
+    AxisInt,
     HashableT,
 )
 from pandas.util._decorators import (
@@ -636,7 +637,7 @@ class _Concatenator:
             for i in range(ndim)
         ]
 
-    def _get_comb_axis(self, i: int) -> Index:
+    def _get_comb_axis(self, i: AxisInt) -> Index:
         data_axis = self.objs[0]._get_block_manager_axis(i)
         return get_objs_combined_axis(
             self.objs,

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -6228,7 +6228,7 @@ Keep all original rows and also all original values
     # Add index
     _AXIS_ORDERS: list[Literal["index", "columns"]] = ["index"]
     _AXIS_LEN = len(_AXIS_ORDERS)
-    _info_axis_number = 0
+    _info_axis_number: Literal[0] = 0
     _info_axis_name: Literal["index"] = "index"
 
     index = properties.AxisProperty(

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -137,7 +137,7 @@ def _ensure_decoded(s):
     return s
 
 
-def _ensure_encoding(encoding):
+def _ensure_encoding(encoding: str | None) -> str:
     # set the encoding if we need
     if encoding is None:
         encoding = _default_encoding
@@ -543,8 +543,6 @@ class HDFStore:
 
     _handle: File | None
     _mode: str
-    _complevel: int
-    _fletcher32: bool
 
     def __init__(
         self,
@@ -1043,7 +1041,7 @@ class HDFStore:
         _tbls = [x for x in tbls if isinstance(x, Table)]
 
         # axis is the concentration axes
-        axis = list({t.non_index_axes[0][0] for t in _tbls})[0]
+        axis = {t.non_index_axes[0][0] for t in _tbls}.pop()
 
         def func(_start, _stop, _where):
 
@@ -1975,9 +1973,6 @@ class IndexCol:
     is_data_indexable: bool = True
     _info_fields = ["freq", "tz", "index_name"]
 
-    name: str
-    cname: str
-
     def __init__(
         self,
         name: str,
@@ -2310,7 +2305,7 @@ class DataCol(IndexCol):
         values=None,
         kind=None,
         typ=None,
-        cname=None,
+        cname: str | None = None,
         pos=None,
         tz=None,
         ordered=None,
@@ -2622,17 +2617,14 @@ class Fixed:
     format_type: str = "fixed"  # GH#30962 needed by dask
     obj_type: type[DataFrame | Series]
     ndim: int
-    encoding: str
     parent: HDFStore
-    group: Node
-    errors: str
     is_table: bool = False
 
     def __init__(
         self,
         parent: HDFStore,
         group: Node,
-        encoding: str = "UTF-8",
+        encoding: str|None = "UTF-8",
         errors: str = "strict",
     ) -> None:
         assert isinstance(parent, HDFStore), type(parent)
@@ -3306,24 +3298,19 @@ class Table(Fixed):
     levels: int | list[Hashable] = 1
     is_table = True
 
-    index_axes: list[IndexCol]
-    non_index_axes: list[tuple[int, Any]]
-    values_axes: list[DataCol]
-    data_columns: list
     metadata: list
-    info: dict
 
     def __init__(
         self,
         parent: HDFStore,
         group: Node,
-        encoding=None,
+        encoding: str | None = None,
         errors: str = "strict",
-        index_axes=None,
-        non_index_axes=None,
-        values_axes=None,
-        data_columns=None,
-        info=None,
+        index_axes: list[IndexCol] | None = None,
+        non_index_axes: list[tuple[AxisInt, Any]] | None = None,
+        values_axes: list[DataCol] | None = None,
+        data_columns: list | None = None,
+        info: dict | None = None,
         nan_rep=None,
     ) -> None:
         super().__init__(parent, group, encoding=encoding, errors=errors)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2624,7 +2624,7 @@ class Fixed:
         self,
         parent: HDFStore,
         group: Node,
-        encoding: str|None = "UTF-8",
+        encoding: str | None = "UTF-8",
         errors: str = "strict",
     ) -> None:
         assert isinstance(parent, HDFStore), type(parent)


### PR DESCRIPTION
I tried to limit `_typing.AxisInt` to `Literal[0, 1]`. That might be feasible in the future when mypy supports more literal math (e.g., `1 - Literal[0, 1] = Literal[0, 1]`), but would cause too many errors for now.

This PR adds a few Axis-related annotations but does not restrict `AxisInt` to `{0, 1}`.