### PR TITLE
REF/DEPR: Deprecate AbstractMethodError

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -84,7 +84,7 @@ See :ref:`install.dependencies` and :ref:`install.optional_dependencies` for mor
 
 Other API changes
 ^^^^^^^^^^^^^^^^^
--
+- Many methods that raised :class:`AbstractMethodError` are now decorated with ``@abstractmethod`` (:issue:`48909`)
 -
 
 .. ---------------------------------------------------------------------------
@@ -93,6 +93,7 @@ Other API changes
 Deprecations
 ~~~~~~~~~~~~
 - Deprecated accepting slices in :meth:`DataFrame.take`, call ``obj[slicer]`` or pass a sequence of integers instead (:issue:`51539`)
+- :class:`AbstractMethodError` is deprecated, please use the builtin ``NotImplementedError`` instead (:issue:`48909`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from abc import (
+    ABC,
+    abstractmethod,
+)
 from functools import wraps
 from typing import (
     TYPE_CHECKING,
@@ -29,7 +33,6 @@ from pandas._typing import (
     npt,
     type_t,
 )
-from pandas.errors import AbstractMethodError
 from pandas.util._decorators import doc
 from pandas.util._validators import (
     validate_bool_kwarg,
@@ -94,7 +97,7 @@ def ravel_compat(meth: F) -> F:
     return cast(F, method)
 
 
-class NDArrayBackedExtensionArray(NDArrayBacked, ExtensionArray):
+class NDArrayBackedExtensionArray(NDArrayBacked, ExtensionArray, ABC):
     """
     ExtensionArray that is backed by a single NumPy ndarray.
     """
@@ -113,9 +116,10 @@ class NDArrayBackedExtensionArray(NDArrayBacked, ExtensionArray):
         """
         return x
 
+    @abstractmethod
     def _validate_scalar(self, value):
         # used by NDArrayBackedExtensionIndex.insert
-        raise AbstractMethodError(self)
+        ...
 
     # ------------------------------------------------------------------------
 

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -8,6 +8,10 @@ An interface for extending pandas with custom arrays.
 """
 from __future__ import annotations
 
+from abc import (
+    ABC,
+    abstractmethod,
+)
 import operator
 from typing import (
     TYPE_CHECKING,
@@ -41,7 +45,6 @@ from pandas._typing import (
 )
 from pandas.compat import set_function_name
 from pandas.compat.numpy import function as nv
-from pandas.errors import AbstractMethodError
 from pandas.util._decorators import (
     Appender,
     Substitution,
@@ -258,7 +261,7 @@ class ExtensionArray:
         -------
         ExtensionArray
         """
-        raise AbstractMethodError(cls)
+        raise NotImplementedError
 
     @classmethod
     def _from_sequence_of_strings(
@@ -282,7 +285,7 @@ class ExtensionArray:
         -------
         ExtensionArray
         """
-        raise AbstractMethodError(cls)
+        raise NotImplementedError
 
     @classmethod
     def _from_factorized(cls, values, original):
@@ -301,7 +304,7 @@ class ExtensionArray:
         factorize : Top-level factorize method that dispatches here.
         ExtensionArray.factorize : Encode the extension array as an enumerated type.
         """
-        raise AbstractMethodError(cls)
+        raise NotImplementedError
 
     # ------------------------------------------------------------------------
     # Must be a Sequence
@@ -347,7 +350,7 @@ class ExtensionArray:
         For a boolean mask, return an instance of ``ExtensionArray``, filtered
         to the values where ``item`` is True.
         """
-        raise AbstractMethodError(self)
+        raise NotImplementedError
 
     def __setitem__(self, key, value) -> None:
         """
@@ -402,7 +405,7 @@ class ExtensionArray:
         -------
         length : int
         """
-        raise AbstractMethodError(self)
+        raise NotImplementedError
 
     def __iter__(self) -> Iterator[Any]:
         """
@@ -444,7 +447,7 @@ class ExtensionArray:
         # return NotImplemented (to ensure that those objects are responsible for
         # first unpacking the arrays, and then dispatch the operation to the
         # underlying arrays)
-        raise AbstractMethodError(self)
+        raise NotImplementedError
 
     # error: Signature of "__ne__" incompatible with supertype "object"
     def __ne__(self, other: Any) -> ArrayLike:  # type: ignore[override]
@@ -498,7 +501,7 @@ class ExtensionArray:
         """
         An instance of 'ExtensionDtype'.
         """
-        raise AbstractMethodError(self)
+        raise NotImplementedError
 
     @property
     def shape(self) -> Shape:
@@ -530,7 +533,7 @@ class ExtensionArray:
         """
         # If this is expensive to compute, return an approximate lower bound
         # on the number of bytes needed.
-        raise AbstractMethodError(self)
+        raise NotImplementedError
 
     # ------------------------------------------------------------------------
     # Additional Methods
@@ -611,7 +614,7 @@ class ExtensionArray:
         * `na_values` should implement :func:`ExtensionArray._reduce`
         * ``na_values.any`` and ``na_values.all`` should be implemented
         """
-        raise AbstractMethodError(self)
+        raise NotImplementedError
 
     @property
     def _hasna(self) -> bool:
@@ -1215,7 +1218,7 @@ class ExtensionArray:
         # uses. In this case, your implementation is responsible for casting
         # the user-facing type to the storage type, before using
         # pandas.api.extensions.take
-        raise AbstractMethodError(self)
+        raise NotImplementedError
 
     def copy(self: ExtensionArrayT) -> ExtensionArrayT:
         """
@@ -1225,7 +1228,7 @@ class ExtensionArray:
         -------
         ExtensionArray
         """
-        raise AbstractMethodError(self)
+        raise NotImplementedError
 
     def view(self, dtype: Dtype | None = None) -> ArrayLike:
         """
@@ -1368,7 +1371,7 @@ class ExtensionArray:
         # should allow "easy" concatenation (no upcasting needed), and result
         # in a new ExtensionArray of the same dtype.
         # Note: this strict behaviour is only guaranteed starting with pandas 1.1
-        raise AbstractMethodError(cls)
+        raise NotImplementedError
 
     # The _can_hold_na attribute is set to True so that pandas internals
     # will use the ExtensionDtype.na_value as the NA value in operations
@@ -1686,15 +1689,17 @@ class ExtensionArray:
         return arraylike.default_array_ufunc(self, ufunc, method, *inputs, **kwargs)
 
 
-class ExtensionArraySupportsAnyAll(ExtensionArray):
+class ExtensionArraySupportsAnyAll(ExtensionArray, ABC):
+    @abstractmethod
     def any(self, *, skipna: bool = True) -> bool:
-        raise AbstractMethodError(self)
+        ...
 
+    @abstractmethod
     def all(self, *, skipna: bool = True) -> bool:
-        raise AbstractMethodError(self)
+        ...
 
 
-class ExtensionOpsMixin:
+class ExtensionOpsMixin(ABC):
     """
     A base class for linking the operators to their dunder names.
 
@@ -1706,8 +1711,9 @@ class ExtensionOpsMixin:
     """
 
     @classmethod
+    @abstractmethod
     def _create_arithmetic_method(cls, op):
-        raise AbstractMethodError(cls)
+        ...
 
     @classmethod
     def _add_arithmetic_ops(cls) -> None:
@@ -1731,8 +1737,9 @@ class ExtensionOpsMixin:
         setattr(cls, "__rdivmod__", cls._create_arithmetic_method(roperator.rdivmod))
 
     @classmethod
+    @abstractmethod
     def _create_comparison_method(cls, op):
-        raise AbstractMethodError(cls)
+        ...
 
     @classmethod
     def _add_comparison_ops(cls) -> None:
@@ -1744,8 +1751,9 @@ class ExtensionOpsMixin:
         setattr(cls, "__ge__", cls._create_comparison_method(operator.ge))
 
     @classmethod
+    @abstractmethod
     def _create_logical_method(cls, op):
-        raise AbstractMethodError(cls)
+        ...
 
     @classmethod
     def _add_logical_ops(cls) -> None:

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import abstractmethod
 from datetime import (
     datetime,
     timedelta,
@@ -70,7 +71,6 @@ from pandas._typing import (
 )
 from pandas.compat.numpy import function as nv
 from pandas.errors import (
-    AbstractMethodError,
     InvalidComparison,
     PerformanceWarning,
 )
@@ -205,12 +205,14 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
     def _can_hold_na(self) -> bool:
         return True
 
+    @abstractmethod
     def __init__(
         self, data, dtype: Dtype | None = None, freq=None, copy: bool = False
     ) -> None:
-        raise AbstractMethodError(self)
+        ...
 
     @property
+    @abstractmethod
     def _scalar_type(self) -> type[DatetimeLikeScalar]:
         """
         The scalar associated with this datelike
@@ -219,8 +221,8 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         * DatetimeArray : Timestamp
         * TimedeltaArray : Timedelta
         """
-        raise AbstractMethodError(self)
 
+    @abstractmethod
     def _scalar_from_string(self, value: str) -> DTScalarOrNaT:
         """
         Construct a scalar type from a string.
@@ -239,8 +241,8 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         This should call ``self._check_compatible_with`` before
         unboxing the result.
         """
-        raise AbstractMethodError(self)
 
+    @abstractmethod
     def _unbox_scalar(
         self, value: DTScalarOrNaT
     ) -> np.int64 | np.datetime64 | np.timedelta64:
@@ -261,8 +263,8 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         >>> self._unbox_scalar(Timedelta("10s"))  # doctest: +SKIP
         10000000000
         """
-        raise AbstractMethodError(self)
 
+    @abstractmethod
     def _check_compatible_with(self, other: DTScalarOrNaT) -> None:
         """
         Verify that `self` and `other` are compatible.
@@ -281,15 +283,14 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         ------
         Exception
         """
-        raise AbstractMethodError(self)
 
     # ------------------------------------------------------------------
 
+    @abstractmethod
     def _box_func(self, x):
         """
         box function to get object from internal representation
         """
-        raise AbstractMethodError(self)
 
     def _box_values(self, values) -> np.ndarray:
         """
@@ -319,6 +320,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
     # ----------------------------------------------------------------
     # Rendering Methods
 
+    @abstractmethod
     def _format_native_types(
         self, *, na_rep: str | float = "NaT", date_format=None
     ) -> npt.NDArray[np.object_]:
@@ -329,7 +331,6 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         -------
         ndarray[str]
         """
-        raise AbstractMethodError(self)
 
     def _formatter(self, boxed: bool = False):
         # TODO: Remove Datetime & DatetimeTZ formatters.
@@ -1135,8 +1136,9 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         parr = PeriodArray(i8vals, freq=other.freq)
         return parr + self
 
+    @abstractmethod
     def _add_offset(self, offset):
-        raise AbstractMethodError(self)
+        ...
 
     def _add_timedeltalike_scalar(self, other):
         """
@@ -1855,8 +1857,9 @@ class TimelikeOps(DatetimeLikeArrayMixin):
             type(self)._validate_frequency(self, freq)
 
     @classmethod
+    @abstractmethod
     def _validate_dtype(cls, values, dtype):
-        raise AbstractMethodError(cls)
+        ...
 
     @property
     def freq(self):
@@ -1920,10 +1923,11 @@ class TimelikeOps(DatetimeLikeArrayMixin):
             ) from err
 
     @classmethod
+    @abstractmethod
     def _generate_range(
         cls: type[DatetimeLikeArrayT], start, end, periods, freq, *args, **kwargs
     ) -> DatetimeLikeArrayT:
-        raise AbstractMethodError(cls)
+        ...
 
     # --------------------------------------------------------------
 

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from abc import (
+    ABC,
+    abstractmethod,
+)
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -34,7 +38,6 @@ from pandas._typing import (
     Shape,
     npt,
 )
-from pandas.errors import AbstractMethodError
 from pandas.util._decorators import doc
 from pandas.util._validators import validate_fillna_kwargs
 
@@ -97,7 +100,7 @@ from pandas.compat.numpy import function as nv
 BaseMaskedArrayT = TypeVar("BaseMaskedArrayT", bound="BaseMaskedArray")
 
 
-class BaseMaskedArray(OpsMixin, ExtensionArray):
+class BaseMaskedArray(OpsMixin, ExtensionArray, ABC):
     """
     Base class for masked arrays (which use _data and _mask to store the data).
 
@@ -141,8 +144,9 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
         return cls(values, mask)
 
     @property
+    @abstractmethod
     def dtype(self) -> BaseMaskedDtype:
-        raise AbstractMethodError(self)
+        ...
 
     @overload
     def __getitem__(self, item: ScalarIndexer) -> Any:
@@ -198,10 +202,11 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
         return new_values
 
     @classmethod
+    @abstractmethod
     def _coerce_to_array(
         cls, values, *, dtype: DtypeObj, copy: bool = False
     ) -> tuple[np.ndarray, np.ndarray]:
-        raise AbstractMethodError(cls)
+        ...
 
     def _validate_setitem_value(self, value):
         """

--- a/pandas/core/arrays/numeric.py
+++ b/pandas/core/arrays/numeric.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import abstractmethod
 import numbers
 from typing import (
     TYPE_CHECKING,
@@ -20,7 +21,6 @@ from pandas._typing import (
     DtypeObj,
     npt,
 )
-from pandas.errors import AbstractMethodError
 from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.common import (
@@ -114,8 +114,9 @@ class NumericDtype(BaseMaskedDtype):
             return array_class._concat_same_type(results)
 
     @classmethod
+    @abstractmethod
     def _str_to_dtype_mapping(cls) -> Mapping[str, NumericDtype]:
-        raise AbstractMethodError(cls)
+        ...
 
     @classmethod
     def _standardize_dtype(cls, dtype: NumericDtype | str | np.dtype) -> NumericDtype:
@@ -136,13 +137,13 @@ class NumericDtype(BaseMaskedDtype):
         return dtype
 
     @classmethod
+    @abstractmethod
     def _safe_cast(cls, values: np.ndarray, dtype: np.dtype, copy: bool) -> np.ndarray:
         """
         Safely cast the values to the given dtype.
 
         "safe" in this context means the casting is lossless.
         """
-        raise AbstractMethodError(cls)
 
 
 def _coerce_to_data_and_mask(values, mask, dtype, copy, dtype_cls, default_dtype):

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -4,6 +4,10 @@ Base and utility classes for pandas objects.
 
 from __future__ import annotations
 
+from abc import (
+    ABC,
+    abstractmethod,
+)
 import textwrap
 from typing import (
     TYPE_CHECKING,
@@ -32,7 +36,6 @@ from pandas._typing import (
 )
 from pandas.compat import PYPY
 from pandas.compat.numpy import function as nv
-from pandas.errors import AbstractMethodError
 from pandas.util._decorators import (
     cache_readonly,
     doc,
@@ -176,7 +179,7 @@ class NoNewAttributesMixin:
         object.__setattr__(self, key, value)
 
 
-class SelectionMixin(Generic[NDFrameT]):
+class SelectionMixin(ABC, Generic[NDFrameT]):
     """
     mixin implementing the selection & aggregation interface on a group-like
     object sub-classes need to define: obj, exclusions
@@ -256,15 +259,16 @@ class SelectionMixin(Generic[NDFrameT]):
         subset : object, default None
             subset to act on
         """
-        raise AbstractMethodError(self)
+        raise NotImplementedError
 
+    @abstractmethod
     def aggregate(self, func, *args, **kwargs):
-        raise AbstractMethodError(self)
+        ...
 
     agg = aggregate
 
 
-class IndexOpsMixin(OpsMixin):
+class IndexOpsMixin(ABC, OpsMixin):
     """
     Common ops mixin to support a unified interface / docs for Series / Index
     """
@@ -276,14 +280,16 @@ class IndexOpsMixin(OpsMixin):
     )
 
     @property
+    @abstractmethod
     def dtype(self) -> DtypeObj:
         # must be defined here as a property for mypy
-        raise AbstractMethodError(self)
+        ...
 
     @property
+    @abstractmethod
     def _values(self) -> ExtensionArray | np.ndarray:
         # must be defined here as a property for mypy
-        raise AbstractMethodError(self)
+        ...
 
     @final
     def transpose(self: _T, *args, **kwargs) -> _T:
@@ -331,9 +337,10 @@ class IndexOpsMixin(OpsMixin):
         """
         return self._values.shape
 
+    @abstractmethod
     def __len__(self) -> int:
         # We need this defined here for mypy
-        raise AbstractMethodError(self)
+        ...
 
     @property
     def ndim(self) -> Literal[1]:
@@ -409,6 +416,7 @@ class IndexOpsMixin(OpsMixin):
         return len(self._values)
 
     @property
+    @abstractmethod
     def array(self) -> ExtensionArray:
         """
         The ExtensionArray of the data backing this Series or Index.
@@ -471,7 +479,6 @@ class IndexOpsMixin(OpsMixin):
         ['a', 'b', 'a']
         Categories (2, object): ['a', 'b']
         """
-        raise AbstractMethodError(self)
 
     @final
     def to_numpy(
@@ -1390,9 +1397,9 @@ class IndexOpsMixin(OpsMixin):
 
         return self._construct_result(result, name=res_name)
 
+    @abstractmethod
     def _construct_result(self, result, name):
         """
         Construct an appropriately-wrapped result from the ArrayLike result
         of an arithmetic-like operation.
         """
-        raise AbstractMethodError(self)

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -21,7 +21,6 @@ from pandas._typing import (
     npt,
     type_t,
 )
-from pandas.errors import AbstractMethodError
 
 from pandas.core.dtypes.generic import (
     ABCDataFrame,
@@ -161,7 +160,7 @@ class ExtensionDtype:
         that value is valid (not NA). NA values do not need to be
         instances of `type`.
         """
-        raise AbstractMethodError(self)
+        raise NotImplementedError(self)
 
     @property
     def kind(self) -> str:
@@ -186,7 +185,7 @@ class ExtensionDtype:
 
         Will be used for display in, e.g. ``Series.dtype``
         """
-        raise AbstractMethodError(self)
+        raise NotImplementedError(self)
 
     @property
     def names(self) -> list[str] | None:
@@ -207,7 +206,7 @@ class ExtensionDtype:
         -------
         type
         """
-        raise AbstractMethodError(cls)
+        raise NotImplementedError(cls)
 
     def empty(self, shape: Shape) -> type_t[ExtensionArray]:
         """

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1,6 +1,10 @@
 # pyright: reportPropertyTypeMismatch=false
 from __future__ import annotations
 
+from abc import (
+    ABC,
+    abstractmethod,
+)
 import collections
 import datetime as dt
 from functools import partial
@@ -85,7 +89,6 @@ from pandas._typing import (
 from pandas.compat._optional import import_optional_dependency
 from pandas.compat.numpy import function as nv
 from pandas.errors import (
-    AbstractMethodError,
     InvalidIndexError,
     SettingWithCopyError,
     SettingWithCopyWarning,
@@ -220,7 +223,7 @@ _shared_doc_kwargs = {
 bool_t = bool  # Need alias because NDFrame has def bool:
 
 
-class NDFrame(PandasObject, indexing.IndexingMixin):
+class NDFrame(ABC, PandasObject, indexing.IndexingMixin):
     """
     N-dimensional analogue of DataFrame. Store multi-dimensional in a
     size-mutable, labeled data structure
@@ -467,12 +470,12 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     # Construction
 
     @property
+    @abstractmethod
     def _constructor(self: NDFrameT) -> Callable[..., NDFrameT]:
         """
         Used when a manipulation result has the same dimensions as the
         original.
         """
-        raise AbstractMethodError(self)
 
     # ----------------------------------------------------------------------
     # Internals
@@ -3770,11 +3773,11 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     # ----------------------------------------------------------------------
     # Lookup Caching
 
+    @abstractmethod
     def _reset_cacher(self) -> None:
         """
         Reset the cacher.
         """
-        raise AbstractMethodError(self)
 
     def _maybe_update_cacher(
         self,
@@ -3802,8 +3805,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         if clear:
             self._clear_item_cache()
 
+    @abstractmethod
     def _clear_item_cache(self) -> None:
-        raise AbstractMethodError(self)
+        ...
 
     # ----------------------------------------------------------------------
     # Indexing Methods
@@ -4118,8 +4122,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         result._set_is_copy(self, copy=not result._is_view)
         return result
 
+    @abstractmethod
     def __getitem__(self, item):
-        raise AbstractMethodError(self)
+        ...
 
     def _slice(self: NDFrameT, slobj: slice, axis: Axis = 0) -> NDFrameT:
         """
@@ -4836,6 +4841,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     ) -> NDFrameT | None:
         ...
 
+    @abstractmethod
     def sort_values(
         self: NDFrameT,
         *,
@@ -4988,7 +4994,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         4   96hr     50
         1  128hr     20
         """
-        raise AbstractMethodError(self)
 
     @overload
     def sort_index(
@@ -5389,7 +5394,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         )
 
     def _reindex_multi(self, axes, copy, fill_value):
-        raise AbstractMethodError(self)
+        raise NotImplementedError
 
     @final
     def _reindex_with_indexers(
@@ -6101,13 +6106,14 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     # Internal Interface Methods
 
     @property
+    @abstractmethod
     def values(self):
-        raise AbstractMethodError(self)
+        ...
 
     @property
+    @abstractmethod
     def _values(self) -> ArrayLike:
         """internal implementation"""
-        raise AbstractMethodError(self)
 
     @property
     def dtypes(self):

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1097,11 +1097,10 @@ class GroupBy(BaseGroupBy[NDFrameT]):
 
         return result
 
-    @abstractmethod
     def _indexed_output_to_ndframe(
         self, result: Mapping[base.OutputKey, ArrayLike]
     ) -> Series | DataFrame:
-        ...
+        raise NotImplementedError
 
     @final
     def _maybe_transpose_result(self, result: NDFrameT) -> NDFrameT:

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1097,11 +1097,6 @@ class GroupBy(BaseGroupBy[NDFrameT]):
 
         return result
 
-    def _indexed_output_to_ndframe(
-        self, result: Mapping[base.OutputKey, ArrayLike]
-    ) -> Series | DataFrame:
-        raise NotImplementedError
-
     @final
     def _maybe_transpose_result(self, result: NDFrameT) -> NDFrameT:
         if self.axis == 1:

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -8,6 +8,7 @@ expose these user-facing objects to provide specific functionality.
 """
 from __future__ import annotations
 
+from abc import abstractmethod
 import datetime
 from functools import (
     partial,
@@ -58,10 +59,7 @@ from pandas._typing import (
     npt,
 )
 from pandas.compat.numpy import function as nv
-from pandas.errors import (
-    AbstractMethodError,
-    DataError,
-)
+from pandas.errors import DataError
 from pandas.util._decorators import (
     Appender,
     Substitution,
@@ -1099,10 +1097,11 @@ class GroupBy(BaseGroupBy[NDFrameT]):
 
         return result
 
+    @abstractmethod
     def _indexed_output_to_ndframe(
         self, result: Mapping[base.OutputKey, ArrayLike]
     ) -> Series | DataFrame:
-        raise AbstractMethodError(self)
+        ...
 
     @final
     def _maybe_transpose_result(self, result: NDFrameT) -> NDFrameT:
@@ -1157,6 +1156,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         res = self._maybe_transpose_result(result)  # type: ignore[arg-type]
         return self._reindex_output(res, qs=qs)
 
+    @abstractmethod
     def _wrap_applied_output(
         self,
         data,
@@ -1164,7 +1164,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         not_indexed_same: bool = False,
         is_transform: bool = False,
     ):
-        raise AbstractMethodError(self)
+        ...
 
     # -----------------------------------------------------------------
     # numba
@@ -1503,10 +1503,11 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             out = out.infer_objects(copy=False)
         return out
 
+    @abstractmethod
     def _cython_transform(
         self, how: str, numeric_only: bool = False, axis: AxisInt = 0, **kwargs
     ):
-        raise AbstractMethodError(self)
+        ...
 
     @final
     def _transform(self, func, *args, engine=None, engine_kwargs=None, **kwargs):

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -7,6 +7,10 @@ are contained *in* the SeriesGroupBy and DataFrameGroupBy objects.
 """
 from __future__ import annotations
 
+from abc import (
+    ABC,
+    abstractmethod,
+)
 import collections
 import functools
 from typing import (
@@ -35,7 +39,6 @@ from pandas._typing import (
     Shape,
     npt,
 )
-from pandas.errors import AbstractMethodError
 from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.cast import (
@@ -1200,7 +1203,7 @@ def _is_indexed_like(obj, axes, axis: AxisInt) -> bool:
 # Splitting / application
 
 
-class DataSplitter(Generic[NDFrameT]):
+class DataSplitter(ABC, Generic[NDFrameT]):
     def __init__(
         self,
         data: NDFrameT,
@@ -1242,8 +1245,9 @@ class DataSplitter(Generic[NDFrameT]):
     def _sorted_data(self) -> NDFrameT:
         return self.data.take(self._sort_idx, axis=self.axis)
 
+    @abstractmethod
     def _chop(self, sdata, slice_obj: slice) -> NDFrame:
-        raise AbstractMethodError(self)
+        ...
 
 
 class SeriesSplitter(DataSplitter):

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from abc import (
+    ABC,
+    abstractmethod,
+)
 from contextlib import suppress
 import sys
 from typing import (
@@ -23,7 +27,6 @@ from pandas._typing import (
 )
 from pandas.compat import PYPY
 from pandas.errors import (
-    AbstractMethodError,
     ChainedAssignmentError,
     IndexingError,
     InvalidIndexError,
@@ -661,7 +664,7 @@ class IndexingMixin:
         return _iAtIndexer("iat", self)
 
 
-class _LocationIndexer(NDFrameIndexerBase):
+class _LocationIndexer(ABC, NDFrameIndexerBase):
     _valid_types: str
     axis: AxisInt | None = None
 
@@ -852,6 +855,7 @@ class _LocationIndexer(NDFrameIndexerBase):
         iloc = self if self.name == "iloc" else self.obj.iloc
         iloc._setitem_with_indexer(indexer, value, self.name)
 
+    @abstractmethod
     def _validate_key(self, key, axis: AxisInt):
         """
         Ensure that key is valid for current indexer.
@@ -872,7 +876,6 @@ class _LocationIndexer(NDFrameIndexerBase):
         KeyError
             If the key was not found.
         """
-        raise AbstractMethodError(self)
 
     @final
     def _expand_ellipsis(self, tup: tuple) -> tuple:
@@ -1087,8 +1090,9 @@ class _LocationIndexer(NDFrameIndexerBase):
 
         return obj
 
+    @abstractmethod
     def _convert_to_indexer(self, key, axis: AxisInt):
-        raise AbstractMethodError(self)
+        ...
 
     @final
     def __getitem__(self, key):
@@ -1109,14 +1113,16 @@ class _LocationIndexer(NDFrameIndexerBase):
     def _is_scalar_access(self, key: tuple):
         raise NotImplementedError()
 
+    @abstractmethod
     def _getitem_tuple(self, tup: tuple):
-        raise AbstractMethodError(self)
+        ...
 
     def _getitem_axis(self, key, axis: AxisInt):
         raise NotImplementedError()
 
+    @abstractmethod
     def _has_valid_setitem_indexer(self, indexer) -> bool:
-        raise AbstractMethodError(self)
+        ...
 
     @final
     def _getbool_axis(self, key, axis: AxisInt):
@@ -2348,7 +2354,7 @@ class _iLocIndexer(_LocationIndexer):
         raise ValueError("Incompatible indexer with DataFrame")
 
 
-class _ScalarAccessIndexer(NDFrameIndexerBase):
+class _ScalarAccessIndexer(ABC, NDFrameIndexerBase):
     """
     Access scalars quickly.
     """
@@ -2356,8 +2362,9 @@ class _ScalarAccessIndexer(NDFrameIndexerBase):
     # sub-classes need to set _takeable
     _takeable: bool
 
+    @abstractmethod
     def _convert_key(self, key):
-        raise AbstractMethodError(self)
+        ...
 
     def __getitem__(self, key):
         if not isinstance(key, tuple):

--- a/pandas/core/internals/base.py
+++ b/pandas/core/internals/base.py
@@ -4,6 +4,10 @@ inherit from this class.
 """
 from __future__ import annotations
 
+from abc import (
+    ABC,
+    abstractmethod,
+)
 from typing import (
     Literal,
     TypeVar,
@@ -18,7 +22,6 @@ from pandas._typing import (
     DtypeObj,
     Shape,
 )
-from pandas.errors import AbstractMethodError
 
 from pandas.core.dtypes.cast import (
     find_common_type,
@@ -34,14 +37,15 @@ from pandas.core.indexes.api import (
 T = TypeVar("T", bound="DataManager")
 
 
-class DataManager(PandasObject):
+class DataManager(ABC, PandasObject):
     # TODO share more methods/attributes
 
     axes: list[Index]
 
     @property
+    @abstractmethod
     def items(self) -> Index:
-        raise AbstractMethodError(self)
+        ...
 
     @final
     def __len__(self) -> int:
@@ -72,6 +76,7 @@ class DataManager(PandasObject):
                 f"values have {new_len} elements"
             )
 
+    @abstractmethod
     def reindex_indexer(
         self: T,
         new_axis,
@@ -82,7 +87,7 @@ class DataManager(PandasObject):
         copy: bool = True,
         only_slice: bool = False,
     ) -> T:
-        raise AbstractMethodError(self)
+        ...
 
     @final
     def reindex_axis(
@@ -106,12 +111,12 @@ class DataManager(PandasObject):
             only_slice=only_slice,
         )
 
+    @abstractmethod
     def _equal_values(self: T, other: T) -> bool:
         """
         To be implemented by the subclasses. Only check the column values
         assuming shape and indexes have already been checked.
         """
-        raise AbstractMethodError(self)
 
     @final
     def equals(self, other: object) -> bool:
@@ -129,13 +134,14 @@ class DataManager(PandasObject):
 
         return self._equal_values(other)
 
+    @abstractmethod
     def apply(
         self: T,
         f,
         align_keys: list[str] | None = None,
         **kwargs,
     ) -> T:
-        raise AbstractMethodError(self)
+        ...
 
     @final
     def isna(self: T, func) -> T:
@@ -197,8 +203,9 @@ class SingleDataManager(DataManager):
         return mgr
 
     @classmethod
+    @abstractmethod
     def from_array(cls, arr: ArrayLike, index: Index):
-        raise AbstractMethodError(cls)
+        ...
 
 
 def interleaved_dtype(dtypes: list[DtypeObj]) -> DtypeObj | None:

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from abc import (
+    ABC,
+    abstractmethod,
+)
 from functools import wraps
 import re
 from typing import (
@@ -36,7 +40,6 @@ from pandas._typing import (
     Shape,
     npt,
 )
-from pandas.errors import AbstractMethodError
 from pandas.util._decorators import cache_readonly
 from pandas.util._validators import validate_bool_kwarg
 
@@ -139,7 +142,7 @@ def maybe_split(meth: F) -> F:
     return cast(F, newfunc)
 
 
-class Block(PandasObject):
+class Block(ABC, PandasObject):
     """
     Canonical n-dimensional unit of homogeneous dtype contained in a pandas
     data structure
@@ -1449,26 +1452,27 @@ class Block(PandasObject):
         return new_blocks
 
     @property
+    @abstractmethod
     def is_view(self) -> bool:
         """return a boolean if I am possibly a view"""
-        raise AbstractMethodError(self)
 
     @property
+    @abstractmethod
     def array_values(self) -> ExtensionArray:
         """
         The array that Series.array returns. Always an ExtensionArray.
         """
-        raise AbstractMethodError(self)
 
+    @abstractmethod
     def get_values(self, dtype: DtypeObj | None = None) -> np.ndarray:
         """
         return an internal format, currently just the ndarray
         this is often overridden to handle to_dense like operations
         """
-        raise AbstractMethodError(self)
 
+    @abstractmethod
     def values_for_json(self) -> np.ndarray:
-        raise AbstractMethodError(self)
+        ...
 
 
 class EABackedBlock(Block):

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from abc import (
+    ABC,
+    abstractmethod,
+)
 import copy
 from textwrap import dedent
 from typing import (
@@ -40,7 +44,6 @@ from pandas._typing import (
     npt,
 )
 from pandas.compat.numpy import function as nv
-from pandas.errors import AbstractMethodError
 from pandas.util._decorators import (
     Appender,
     Substitution,
@@ -102,7 +105,7 @@ if TYPE_CHECKING:
 _shared_docs_kwargs: dict[str, str] = {}
 
 
-class Resampler(BaseGroupBy, PandasObject):
+class Resampler(BaseGroupBy, PandasObject, ABC):
     """
     Class for resampling datetimelike data, a groupby-like operation.
     See aggregate, transform, and apply functions on this object.
@@ -219,8 +222,9 @@ class Resampler(BaseGroupBy, PandasObject):
         """
         return obj._consolidate()
 
+    @abstractmethod
     def _get_binner_for_time(self):
-        raise AbstractMethodError(self)
+        ...
 
     @final
     def _get_binner(self):
@@ -372,11 +376,13 @@ class Resampler(BaseGroupBy, PandasObject):
             arg, *args, **kwargs
         )
 
+    @abstractmethod
     def _downsample(self, f, **kwargs):
-        raise AbstractMethodError(self)
+        ...
 
+    @abstractmethod
     def _upsample(self, f, limit=None, fill_value=None):
-        raise AbstractMethodError(self)
+        ...
 
     def _gotitem(self, key, ndim: int, subset=None):
         """

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -4,6 +4,7 @@ Expose public exceptions & warnings
 from __future__ import annotations
 
 import ctypes
+import warnings
 
 from pandas._config.config import OptionError
 
@@ -188,6 +189,14 @@ class AbstractMethodError(NotImplementedError):
     """
 
     def __init__(self, class_instance, methodtype: str = "method") -> None:
+        from pandas.util._exceptions import find_stack_level
+
+        warnings.warn(
+            "`AbstractMethodError` will be removed in a future version. Consider"
+            + " using `NotImplementedError`",
+            FutureWarning,
+            stacklevel=find_stack_level(),
+        )
         types = {"method", "classmethod", "staticmethod", "property"}
         if methodtype not in types:
             raise ValueError(

--- a/pandas/io/formats/xml.py
+++ b/pandas/io/formats/xml.py
@@ -3,6 +3,10 @@
 """
 from __future__ import annotations
 
+from abc import (
+    ABC,
+    abstractmethod,
+)
 import codecs
 import io
 from typing import (
@@ -17,7 +21,6 @@ from pandas._typing import (
     StorageOptions,
     WriteBuffer,
 )
-from pandas.errors import AbstractMethodError
 from pandas.util._decorators import doc
 
 from pandas.core.dtypes.common import is_list_like
@@ -39,7 +42,7 @@ if TYPE_CHECKING:
     storage_options=_shared_docs["storage_options"],
     compression_options=_shared_docs["compression_options"] % "path_or_buffer",
 )
-class BaseXMLFormatter:
+class BaseXMLFormatter(ABC):
     """
     Subclass for formatting data in XML.
 
@@ -143,6 +146,7 @@ class BaseXMLFormatter:
         self.prefix_uri = self.get_prefix_uri()
         self.handle_indexes()
 
+    @abstractmethod
     def build_tree(self) -> bytes:
         """
         Build tree from  data.
@@ -150,7 +154,6 @@ class BaseXMLFormatter:
         This method initializes the root and builds attributes and elements
         with optional namespaces.
         """
-        raise AbstractMethodError(self)
 
     def validate_columns(self) -> None:
         """
@@ -226,6 +229,7 @@ class BaseXMLFormatter:
         if self.elem_cols:
             self.elem_cols = indexes + self.elem_cols
 
+    @abstractmethod
     def get_prefix_uri(self) -> str:
         """
         Get uri of namespace prefix.
@@ -237,8 +241,6 @@ class BaseXMLFormatter:
         KeyError
             *If prefix is not included in namespace dict.
         """
-
-        raise AbstractMethodError(self)
 
     def other_namespaces(self) -> dict:
         """
@@ -288,6 +290,7 @@ class BaseXMLFormatter:
             )
         return f"{self.prefix_uri}{flat_col}"
 
+    @abstractmethod
     def build_elems(self, d: dict[str, Any], elem_row: Any) -> None:
         """
         Create child elements of row.
@@ -295,8 +298,6 @@ class BaseXMLFormatter:
         This method adds child elements using elem_cols to row element and
         works with tuples for multindex or hierarchical columns.
         """
-
-        raise AbstractMethodError(self)
 
     def _build_elems(self, sub_element_cls, d: dict[str, Any], elem_row: Any) -> None:
         if not self.elem_cols:

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -6,6 +6,10 @@ HTML IO.
 
 from __future__ import annotations
 
+from abc import (
+    ABC,
+    abstractmethod,
+)
 from collections import abc
 import numbers
 import re
@@ -27,10 +31,7 @@ from pandas._typing import (
     ReadBuffer,
 )
 from pandas.compat._optional import import_optional_dependency
-from pandas.errors import (
-    AbstractMethodError,
-    EmptyDataError,
-)
+from pandas.errors import EmptyDataError
 
 from pandas.core.dtypes.common import is_list_like
 
@@ -134,7 +135,7 @@ def _read(obj: FilePath | BaseBuffer, encoding: str | None) -> str | bytes:
     return text
 
 
-class _HtmlFrameParser:
+class _HtmlFrameParser(ABC):
     """
     Base class for parsers that parse HTML into DataFrames.
 
@@ -250,6 +251,7 @@ class _HtmlFrameParser:
         # Both lxml and BeautifulSoup have the same implementation:
         return obj.get(attr)
 
+    @abstractmethod
     def _href_getter(self, obj):
         """
         Return a href if the DOM node contains a child <a> or None.
@@ -264,8 +266,8 @@ class _HtmlFrameParser:
         href : str or unicode
             The href from the <a> child of the DOM node.
         """
-        raise AbstractMethodError(self)
 
+    @abstractmethod
     def _text_getter(self, obj):
         """
         Return the text of an individual DOM node.
@@ -280,8 +282,8 @@ class _HtmlFrameParser:
         text : str or unicode
             The text from an individual DOM node.
         """
-        raise AbstractMethodError(self)
 
+    @abstractmethod
     def _parse_td(self, obj):
         """
         Return the td elements from a row element.
@@ -296,8 +298,8 @@ class _HtmlFrameParser:
         list of node-like
             These are the elements of each row, i.e., the columns.
         """
-        raise AbstractMethodError(self)
 
+    @abstractmethod
     def _parse_thead_tr(self, table):
         """
         Return the list of thead row elements from the parsed table element.
@@ -311,8 +313,8 @@ class _HtmlFrameParser:
         list of node-like
             These are the <tr> row elements of a table.
         """
-        raise AbstractMethodError(self)
 
+    @abstractmethod
     def _parse_tbody_tr(self, table):
         """
         Return the list of tbody row elements from the parsed table element.
@@ -330,8 +332,8 @@ class _HtmlFrameParser:
         list of node-like
             These are the <tr> row elements of a table.
         """
-        raise AbstractMethodError(self)
 
+    @abstractmethod
     def _parse_tfoot_tr(self, table):
         """
         Return the list of tfoot row elements from the parsed table element.
@@ -345,8 +347,8 @@ class _HtmlFrameParser:
         list of node-like
             These are the <tr> row elements of a table.
         """
-        raise AbstractMethodError(self)
 
+    @abstractmethod
     def _parse_tables(self, doc, match, attrs):
         """
         Return all tables from the parsed DOM.
@@ -371,8 +373,8 @@ class _HtmlFrameParser:
         list of node-like
             HTML <table> elements to be parsed into raw data.
         """
-        raise AbstractMethodError(self)
 
+    @abstractmethod
     def _equals_tag(self, obj, tag):
         """
         Return whether an individual DOM node matches a tag
@@ -390,8 +392,8 @@ class _HtmlFrameParser:
         boolean
             Whether `obj`'s tag name is `tag`
         """
-        raise AbstractMethodError(self)
 
+    @abstractmethod
     def _build_doc(self):
         """
         Return a tree-like object that can be used to iterate over the DOM.
@@ -401,7 +403,6 @@ class _HtmlFrameParser:
         node-like
             The DOM from which to parse the table element.
         """
-        raise AbstractMethodError(self)
 
     def _parse_thead_tbody_tfoot(self, table_html):
         """
@@ -859,7 +860,7 @@ def _data_to_frame(**kwargs):
         return tp.read()
 
 
-_valid_parsers = {
+_valid_parsers: dict[str | None, type[_HtmlFrameParser]] = {
     "lxml": _LxmlFrameParser,
     None: _LxmlFrameParser,
     "html5lib": _BeautifulSoupHtml5LibFrameParser,

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -44,7 +44,6 @@ from pandas._typing import (
     WriteBuffer,
 )
 from pandas.compat._optional import import_optional_dependency
-from pandas.errors import AbstractMethodError
 from pandas.util._decorators import doc
 
 from pandas.core.dtypes.common import (
@@ -238,8 +237,9 @@ class Writer(ABC):
         self.is_copy = None
         self._format_axes()
 
+    @abstractmethod
     def _format_axes(self):
-        raise AbstractMethodError(self)
+        ...
 
     def write(self) -> str:
         iso_dates = self.date_format == "iso"
@@ -1085,7 +1085,7 @@ class JsonReader(abc.Iterator, Generic[FrameSeriesStrT]):
         self.close()
 
 
-class Parser:
+class Parser(ABC):
     _split_keys: tuple[str, ...]
     _default_orient: str
 
@@ -1153,8 +1153,9 @@ class Parser:
         self._try_convert_types()
         return self.obj
 
+    @abstractmethod
     def _parse(self):
-        raise AbstractMethodError(self)
+        ...
 
     def _convert_axes(self) -> None:
         """
@@ -1172,8 +1173,9 @@ class Parser:
             if result:
                 setattr(self.obj, axis_name, new_axis)
 
+    @abstractmethod
     def _try_convert_types(self):
-        raise AbstractMethodError(self)
+        ...
 
     def _try_convert_data(
         self,
@@ -1293,7 +1295,7 @@ class Parser:
         return data, False
 
     def _try_convert_dates(self):
-        raise AbstractMethodError(self)
+        raise NotImplementedError
 
 
 class SeriesParser(Parser):

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -1,6 +1,10 @@
 """ parquet compat """
 from __future__ import annotations
 
+from abc import (
+    ABC,
+    abstractmethod,
+)
 import io
 import os
 from typing import (
@@ -19,7 +23,6 @@ from pandas._typing import (
     WriteBuffer,
 )
 from pandas.compat._optional import import_optional_dependency
-from pandas.errors import AbstractMethodError
 from pandas.util._decorators import doc
 
 from pandas import (
@@ -114,7 +117,7 @@ def _get_path_or_handle(
     return path_or_handle, handles, fs
 
 
-class BaseImpl:
+class BaseImpl(ABC):
     @staticmethod
     def validate_dataframe(df: DataFrame) -> None:
         if not isinstance(df, DataFrame):
@@ -142,11 +145,13 @@ class BaseImpl:
         if not valid_names:
             raise ValueError("Index level names must be strings")
 
+    @abstractmethod
     def write(self, df: DataFrame, path, compression, **kwargs):
-        raise AbstractMethodError(self)
+        ...
 
+    @abstractmethod
     def read(self, path, columns=None, **kwargs) -> DataFrame:
-        raise AbstractMethodError(self)
+        ...
 
 
 class PyArrowImpl(BaseImpl):

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -37,10 +37,7 @@ from pandas._typing import (
     ReadCsvBuffer,
     StorageOptions,
 )
-from pandas.errors import (
-    AbstractMethodError,
-    ParserWarning,
-)
+from pandas.errors import ParserWarning
 from pandas.util._decorators import Appender
 from pandas.util._exceptions import find_stack_level
 
@@ -1700,7 +1697,7 @@ class TextFileReader(abc.Iterator):
             raise
 
     def _failover_to_python(self) -> None:
-        raise AbstractMethodError(self)
+        raise NotImplementedError
 
     def read(self, nrows: int | None = None) -> DataFrame:
         if self.engine == "pyarrow":

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -41,10 +41,7 @@ from pandas._typing import (
     IndexLabel,
 )
 from pandas.compat._optional import import_optional_dependency
-from pandas.errors import (
-    AbstractMethodError,
-    DatabaseError,
-)
+from pandas.errors import DatabaseError
 from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.common import (
@@ -1460,7 +1457,8 @@ class PandasSQL(PandasObject, ABC):
         pass
 
 
-class BaseEngine:
+class BaseEngine(ABC):
+    @abstractmethod
     def insert_records(
         self,
         table: SQLTable,
@@ -1476,7 +1474,6 @@ class BaseEngine:
         """
         Inserts data into already-prepared table
         """
-        raise AbstractMethodError(self)
 
 
 class SQLAlchemyEngine(BaseEngine):

--- a/pandas/io/xml.py
+++ b/pandas/io/xml.py
@@ -4,6 +4,10 @@
 
 from __future__ import annotations
 
+from abc import (
+    ABC,
+    abstractmethod,
+)
 import io
 from typing import (
     Any,
@@ -26,10 +30,7 @@ from pandas._typing import (
     XMLParsers,
 )
 from pandas.compat._optional import import_optional_dependency
-from pandas.errors import (
-    AbstractMethodError,
-    ParserError,
-)
+from pandas.errors import ParserError
 from pandas.util._decorators import doc
 
 from pandas.core.dtypes.common import is_list_like
@@ -58,7 +59,7 @@ if TYPE_CHECKING:
     storage_options=_shared_docs["storage_options"],
     decompression_options=_shared_docs["decompression_options"] % "path_or_buffer",
 )
-class _XMLFrameParser:
+class _XMLFrameParser(ABC):
     """
     Internal subclass to parse XML into DataFrames.
 
@@ -175,6 +176,7 @@ class _XMLFrameParser:
         self.compression = compression
         self.storage_options = storage_options
 
+    @abstractmethod
     def parse_data(self) -> list[dict[str, str | None]]:
         """
         Parse xml data.
@@ -182,8 +184,6 @@ class _XMLFrameParser:
         This method will call the other internal methods to
         validate xpath, names, parse and return specific nodes.
         """
-
-        raise AbstractMethodError(self)
 
     def _parse_nodes(self, elems: list[Any]) -> list[dict[str, str | None]]:
         """
@@ -389,6 +389,7 @@ class _XMLFrameParser:
 
         return dicts
 
+    @abstractmethod
     def _validate_path(self) -> list[Any]:
         """
         Validate xpath.
@@ -404,8 +405,7 @@ class _XMLFrameParser:
             * If xpah does not return any nodes.
         """
 
-        raise AbstractMethodError(self)
-
+    @abstractmethod
     def _validate_names(self) -> None:
         """
         Validate names.
@@ -418,8 +418,8 @@ class _XMLFrameParser:
         ValueError
             * If value is not a list and less then length of nodes.
         """
-        raise AbstractMethodError(self)
 
+    @abstractmethod
     def _parse_doc(
         self, raw_doc: FilePath | ReadBuffer[bytes] | ReadBuffer[str]
     ) -> Element | etree._Element:
@@ -429,7 +429,6 @@ class _XMLFrameParser:
         This method will parse XML object into tree
         either from string/bytes or file location.
         """
-        raise AbstractMethodError(self)
 
 
 class _EtreeFrameParser(_XMLFrameParser):

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -22,7 +22,6 @@ from pandas._typing import (
     PlottingOrientation,
     npt,
 )
-from pandas.errors import AbstractMethodError
 from pandas.util._decorators import cache_readonly
 from pandas.util._exceptions import find_stack_level
 
@@ -633,8 +632,9 @@ class MPLPlot(ABC):
 
         self.data = numeric_data.apply(self._convert_to_ndarray)
 
+    @abstractmethod
     def _make_plot(self):
-        raise AbstractMethodError(self)
+        ...
 
     def _add_table(self) -> None:
         if self.table is False:

--- a/pandas/tests/extension/decimal/array.py
+++ b/pandas/tests/extension/decimal/array.py
@@ -275,6 +275,10 @@ class DecimalArray(OpsMixin, ExtensionScalarOpsMixin, ExtensionArray):
 
         return value_counts(self.to_numpy(), dropna=dropna)
 
+    @classmethod
+    def _create_logical_method(cls, op):
+        raise NotImplementedError
+
 
 def to_decimal(values, context=None):
     return DecimalArray([decimal.Decimal(x) for x in values], context=context)

--- a/pandas/tests/test_errors.py
+++ b/pandas/tests/test_errors.py
@@ -91,4 +91,4 @@ def test_AbstractMethodError_deprecation():
         + " Consider using `NotImplementedError`"
     )
     with pd._testing.assert_produces_warning(FutureWarning, match=msg):
-        AbstractMethodError(None)
+        AbstractMethodError(None)  # pylint: disable=pointless-exception-statement

--- a/pandas/tests/test_errors.py
+++ b/pandas/tests/test_errors.py
@@ -85,28 +85,10 @@ def test_catch_undefined_variable_error(is_local):
         raise UndefinedVariableError(variable_name, is_local)
 
 
-class Foo:
-    @classmethod
-    def classmethod(cls):
-        raise AbstractMethodError(cls, methodtype="classmethod")
-
-    @property
-    def property(self):
-        raise AbstractMethodError(self, methodtype="property")
-
-    def method(self):
-        raise AbstractMethodError(self)
-
-
-def test_AbstractMethodError_classmethod():
-    xpr = "This classmethod must be defined in the concrete class Foo"
-    with pytest.raises(AbstractMethodError, match=xpr):
-        Foo.classmethod()
-
-    xpr = "This property must be defined in the concrete class Foo"
-    with pytest.raises(AbstractMethodError, match=xpr):
-        Foo().property
-
-    xpr = "This method must be defined in the concrete class Foo"
-    with pytest.raises(AbstractMethodError, match=xpr):
-        Foo().method()
+def test_AbstractMethodError_deprecation():
+    msg = (
+        "`AbstractMethodError` will be removed in a future version."
+        + " Consider using `NotImplementedError`"
+    )
+    with pd._testing.assert_produces_warning(FutureWarning, match=msg):
+        AbstractMethodError(None)

--- a/scripts/pandas_errors_documented.py
+++ b/scripts/pandas_errors_documented.py
@@ -19,7 +19,7 @@ API_PATH = pathlib.Path("doc/source/reference/testing.rst").resolve()
 
 def get_defined_errors(content: str) -> set[str]:
     errors = set()
-    for node in ast.walk(ast.parse(content)):
+    for node in ast.iter_child_nodes(ast.parse(content)):
         if isinstance(node, ast.ClassDef):
             errors.add(node.name)
         elif isinstance(node, ast.ImportFrom) and node.module != "__future__":


### PR DESCRIPTION
closes #48909

Probably would need a whatsnew entry, for people inheriting from those now abstract classes. I'll keep this PR as a draft until I replaced all  cases of `AbstractMethodError` (that are actually implemented).