### PR TITLE
disable bad-super-call checking

### DIFF
--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -151,6 +151,9 @@ class TestDataFrame:
 
 # formerly in Generic but only test DataFrame
 class TestDataFrame2:
+    # disable pylint bad-super-call warning emitted due to super(type[, obj]) calls
+    # pylint: disable=E1003
+
     @pytest.mark.parametrize("value", [1, "True", [1, 2, 3], 5.0])
     def test_validate_bool_args(self, value):
         df = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})


### PR DESCRIPTION
because super(Dataframe, df) is valid is this class

Signed-off-by: Soumik Dutta <shalearkane@gmail.com>

- [X] closes #48855 
