### PR TITLE
fix warning no-value-for-parameter in pandas/io

### DIFF
--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -1662,7 +1662,7 @@ class ExcelFile:
                     f"only the xls format is supported. Install openpyxl instead."
                 )
             elif ext and ext != "xls":
-                stacklevel = find_stack_level()
+                stacklevel = find_stack_level(inspect.currentframe())
                 warnings.warn(
                     f"Your version of xlrd is {xlrd_version}. In xlrd >= 2.0, "
                     f"only the xls format is supported. Install "


### PR DESCRIPTION
Fixed warning no-value-for-parameter raised by pylint in file pandas/io/excel/_base.py

The warnings raised by pylint while scanning tests are not yet resolved

Signed-off-by: Soumik Dutta <shalearkane@gmail.com>

- [ ] xref #48855 
- [x] All [code checks passed]