### PR TITLE
TST: use `with` where possible instead of manual `close`

### DIFF
--- a/pandas/tests/io/parser/test_encoding.py
+++ b/pandas/tests/io/parser/test_encoding.py
@@ -66,13 +66,9 @@ A,B,C
         with open(path, "wb") as f:
             f.write(bytes_data)
 
-        bytes_buffer = BytesIO(data.encode(utf8))
-        bytes_buffer = TextIOWrapper(bytes_buffer, encoding=utf8)
-
-        result = parser.read_csv(path, encoding=encoding, **kwargs)
-        expected = parser.read_csv(bytes_buffer, encoding=utf8, **kwargs)
-
-        bytes_buffer.close()
+        with TextIOWrapper(BytesIO(data.encode(utf8)), encoding=utf8) as bytes_buffer:
+            result = parser.read_csv(path, encoding=encoding, **kwargs)
+            expected = parser.read_csv(bytes_buffer, encoding=utf8, **kwargs)
         tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/io/pytables/test_file_handling.py
+++ b/pandas/tests/io/pytables/test_file_handling.py
@@ -41,9 +41,8 @@ def test_mode(setup_path, tmp_path, mode):
             HDFStore(path, mode=mode)
 
     else:
-        store = HDFStore(path, mode=mode)
-        assert store._handle.mode == mode
-        store.close()
+        with HDFStore(path, mode=mode) as store:
+            assert store._handle.mode == mode
 
     path = tmp_path / setup_path
 
@@ -253,16 +252,14 @@ def test_complibs(tmp_path, setup_path):
         result = read_hdf(tmpfile, gname)
         tm.assert_frame_equal(result, df)
 
-        # Open file and check metadata
-        # for correct amount of compression
-        h5table = tables.open_file(tmpfile, mode="r")
-        for node in h5table.walk_nodes(where="/" + gname, classname="Leaf"):
-            assert node.filters.complevel == lvl
-            if lvl == 0:
-                assert node.filters.complib is None
-            else:
-                assert node.filters.complib == lib
-        h5table.close()
+        # Open file and check metadata for correct amount of compression
+        with tables.open_file(tmpfile, mode="r") as h5table:
+            for node in h5table.walk_nodes(where="/" + gname, classname="Leaf"):
+                assert node.filters.complevel == lvl
+                if lvl == 0:
+                    assert node.filters.complib is None
+                else:
+                    assert node.filters.complib == lib
 
 
 @pytest.mark.skipif(

--- a/pandas/tests/io/pytables/test_select.py
+++ b/pandas/tests/io/pytables/test_select.py
@@ -682,10 +682,9 @@ def test_frame_select_complex2(tmp_path):
 
     # scope with list like
     l0 = selection.index.tolist()  # noqa:F841
-    store = HDFStore(hh)
-    result = store.select("df", where="l1=l0")
-    tm.assert_frame_equal(result, expected)
-    store.close()
+    with HDFStore(hh) as store:
+        result = store.select("df", where="l1=l0")
+        tm.assert_frame_equal(result, expected)
 
     result = read_hdf(hh, "df", where="l1=l0")
     tm.assert_frame_equal(result, expected)
@@ -705,21 +704,18 @@ def test_frame_select_complex2(tmp_path):
     tm.assert_frame_equal(result, expected)
 
     # scope with index
-    store = HDFStore(hh)
+    with HDFStore(hh) as store:
+        result = store.select("df", where="l1=index")
+        tm.assert_frame_equal(result, expected)
 
-    result = store.select("df", where="l1=index")
-    tm.assert_frame_equal(result, expected)
+        result = store.select("df", where="l1=selection.index")
+        tm.assert_frame_equal(result, expected)
 
-    result = store.select("df", where="l1=selection.index")
-    tm.assert_frame_equal(result, expected)
+        result = store.select("df", where="l1=selection.index.tolist()")
+        tm.assert_frame_equal(result, expected)
 
-    result = store.select("df", where="l1=selection.index.tolist()")
-    tm.assert_frame_equal(result, expected)
-
-    result = store.select("df", where="l1=list(selection.index)")
-    tm.assert_frame_equal(result, expected)
-
-    store.close()
+        result = store.select("df", where="l1=list(selection.index)")
+        tm.assert_frame_equal(result, expected)
 
 
 def test_invalid_filtering(setup_path):

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -917,9 +917,8 @@ def test_copy():
         df = tm.makeDataFrame()
 
         with tm.ensure_clean() as path:
-            st = HDFStore(path)
-            st.append("df", df, data_columns=["A"])
-            st.close()
+            with HDFStore(path) as st:
+                st.append("df", df, data_columns=["A"])
             do_copy(f=path)
             do_copy(f=path, propindexes=False)
 

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -118,11 +118,11 @@ bar2,12,13,14,15
                 assert os.path.expanduser(filename) == handles.handle.name
 
     def test_get_handle_with_buffer(self):
-        input_buffer = StringIO()
-        with icom.get_handle(input_buffer, "r") as handles:
-            assert handles.handle == input_buffer
-        assert not input_buffer.closed
-        input_buffer.close()
+        with StringIO() as input_buffer:
+            with icom.get_handle(input_buffer, "r") as handles:
+                assert handles.handle == input_buffer
+            assert not input_buffer.closed
+        assert input_buffer.closed
 
     # Test that BytesIOWrapper(get_handle) returns correct amount of bytes every time
     def test_bytesiowrapper_returns_correct_bytes(self):

--- a/pandas/tests/io/test_compression.py
+++ b/pandas/tests/io/test_compression.py
@@ -282,18 +282,17 @@ def test_bzip_compression_level(obj, method):
 )
 def test_empty_archive_zip(suffix, archive):
     with tm.ensure_clean(filename=suffix) as path:
-        file = archive(path, "w")
-        file.close()
+        with archive(path, "w"):
+            pass
         with pytest.raises(ValueError, match="Zero files found"):
             pd.read_csv(path)
 
 
 def test_ambiguous_archive_zip():
     with tm.ensure_clean(filename=".zip") as path:
-        file = zipfile.ZipFile(path, "w")
-        file.writestr("a.csv", "foo,bar")
-        file.writestr("b.csv", "foo,bar")
-        file.close()
+        with zipfile.ZipFile(path, "w") as file:
+            file.writestr("a.csv", "foo,bar")
+            file.writestr("b.csv", "foo,bar")
         with pytest.raises(ValueError, match="Multiple files found in ZIP file"):
             pd.read_csv(path)
 

--- a/pandas/tests/io/test_fsspec.py
+++ b/pandas/tests/io/test_fsspec.py
@@ -95,22 +95,18 @@ def test_to_csv_fsspec_object(cleared_fs, binary_mode, df1):
 
     path = "memory://test/test.csv"
     mode = "wb" if binary_mode else "w"
-    fsspec_object = fsspec.open(path, mode=mode).open()
-
-    df1.to_csv(fsspec_object, index=True)
-    assert not fsspec_object.closed
-    fsspec_object.close()
+    with fsspec.open(path, mode=mode).open() as fsspec_object:
+        df1.to_csv(fsspec_object, index=True)
+        assert not fsspec_object.closed
 
     mode = mode.replace("w", "r")
-    fsspec_object = fsspec.open(path, mode=mode).open()
-
-    df2 = read_csv(
-        fsspec_object,
-        parse_dates=["dt"],
-        index_col=0,
-    )
-    assert not fsspec_object.closed
-    fsspec_object.close()
+    with fsspec.open(path, mode=mode) as fsspec_object:
+        df2 = read_csv(
+            fsspec_object,
+            parse_dates=["dt"],
+            index_col=0,
+        )
+        assert not fsspec_object.closed
 
     tm.assert_frame_equal(df1, df2)
 

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -600,9 +600,8 @@ class TestStata:
         # Test that value_labels() returns an empty dict if the file format
         # predates supporting value labels.
         dpath = datapath("io", "data", "stata", "S4_EDUC1.dta")
-        reader = StataReader(dpath)
-        assert reader.value_labels() == {}
-        reader.close()
+        with StataReader(dpath) as reader:
+            assert reader.value_labels() == {}
 
     def test_date_export_formats(self):
         columns = ["tc", "td", "tw", "tm", "tq", "th", "ty"]
@@ -1108,29 +1107,26 @@ class TestStata:
                 convert_categoricals=convert_categoricals,
                 convert_dates=convert_dates,
             )
-        itr = read_stata(
+        with read_stata(
             fname,
             iterator=True,
             convert_categoricals=convert_categoricals,
             convert_dates=convert_dates,
-        )
-
-        pos = 0
-        for j in range(5):
-            with warnings.catch_warnings(record=True):
-                warnings.simplefilter("always")
-                try:
-                    chunk = itr.read(chunksize)
-                except StopIteration:
-                    break
-            from_frame = parsed.iloc[pos : pos + chunksize, :].copy()
-            from_frame = self._convert_categorical(from_frame)
-            tm.assert_frame_equal(
-                from_frame, chunk, check_dtype=False, check_datetimelike_compat=True
-            )
-
-            pos += chunksize
-        itr.close()
+        ) as itr:
+            pos = 0
+            for j in range(5):
+                with warnings.catch_warnings(record=True):
+                    warnings.simplefilter("always")
+                    try:
+                        chunk = itr.read(chunksize)
+                    except StopIteration:
+                        break
+                from_frame = parsed.iloc[pos : pos + chunksize, :].copy()
+                from_frame = self._convert_categorical(from_frame)
+                tm.assert_frame_equal(
+                    from_frame, chunk, check_dtype=False, check_datetimelike_compat=True
+                )
+                pos += chunksize
 
     @staticmethod
     def _convert_categorical(from_frame: DataFrame) -> DataFrame:
@@ -1206,28 +1202,26 @@ class TestStata:
             )
 
         # Compare to what we get when reading by chunk
-        itr = read_stata(
+        with read_stata(
             fname,
             iterator=True,
             convert_dates=convert_dates,
             convert_categoricals=convert_categoricals,
-        )
-        pos = 0
-        for j in range(5):
-            with warnings.catch_warnings(record=True):
-                warnings.simplefilter("always")
-                try:
-                    chunk = itr.read(chunksize)
-                except StopIteration:
-                    break
-            from_frame = parsed.iloc[pos : pos + chunksize, :].copy()
-            from_frame = self._convert_categorical(from_frame)
-            tm.assert_frame_equal(
-                from_frame, chunk, check_dtype=False, check_datetimelike_compat=True
-            )
-
-            pos += chunksize
-        itr.close()
+        ) as itr:
+            pos = 0
+            for j in range(5):
+                with warnings.catch_warnings(record=True):
+                    warnings.simplefilter("always")
+                    try:
+                        chunk = itr.read(chunksize)
+                    except StopIteration:
+                        break
+                from_frame = parsed.iloc[pos : pos + chunksize, :].copy()
+                from_frame = self._convert_categorical(from_frame)
+                tm.assert_frame_equal(
+                    from_frame, chunk, check_dtype=False, check_datetimelike_compat=True
+                )
+                pos += chunksize
 
     def test_read_chunks_columns(self, datapath):
         fname = datapath("io", "data", "stata", "stata3_117.dta")
@@ -1820,9 +1814,9 @@ the string values returned are correct."""
                 data["β"].replace(value_labels["β"]).astype("category").cat.as_ordered()
             )
             tm.assert_frame_equal(data, reread_encoded)
-            reader = StataReader(path)
-            assert reader.data_label == data_label
-            assert reader.variable_labels() == variable_labels
+            with StataReader(path) as reader:
+                assert reader.data_label == data_label
+                assert reader.variable_labels() == variable_labels
 
             data.to_stata(path, version=version, write_index=False)
             reread_to_stata = read_stata(path)
@@ -1922,11 +1916,11 @@ def test_chunked_categorical(version):
     df.index.name = "index"
     with tm.ensure_clean() as path:
         df.to_stata(path, version=version)
-        reader = StataReader(path, chunksize=2, order_categoricals=False)
-        for i, block in enumerate(reader):
-            block = block.set_index("index")
-            assert "cats" in block
-            tm.assert_series_equal(block.cats, df.cats.iloc[2 * i : 2 * (i + 1)])
+        with StataReader(path, chunksize=2, order_categoricals=False) as reader:
+            for i, block in enumerate(reader):
+                block = block.set_index("index")
+                assert "cats" in block
+                tm.assert_series_equal(block.cats, df.cats.iloc[2 * i : 2 * (i + 1)])
 
 
 def test_chunked_categorical_partial(datapath):
@@ -1952,7 +1946,8 @@ def test_chunked_categorical_partial(datapath):
 def test_iterator_errors(datapath, chunksize):
     dta_file = datapath("io", "data", "stata", "stata-dta-partially-labeled.dta")
     with pytest.raises(ValueError, match="chunksize must be a positive"):
-        StataReader(dta_file, chunksize=chunksize)
+        with StataReader(dta_file, chunksize=chunksize):
+            pass
 
 
 def test_iterator_value_labels():
@@ -2051,9 +2046,9 @@ def test_non_categorical_value_labels():
         writer = StataWriter(path, data, value_labels=value_labels)
         writer.write_file()
 
-        reader = StataReader(path)
-        reader_value_labels = reader.value_labels()
-        assert reader_value_labels == expected
+        with StataReader(path) as reader:
+            reader_value_labels = reader.value_labels()
+            assert reader_value_labels == expected
 
         msg = "Can't create value labels for notY, it wasn't found in the dataset."
         with pytest.raises(KeyError, match=msg):
@@ -2101,9 +2096,9 @@ def test_non_categorical_value_label_name_conversion():
         with tm.assert_produces_warning(InvalidColumnName):
             data.to_stata(path, value_labels=value_labels)
 
-        reader = StataReader(path)
-        reader_value_labels = reader.value_labels()
-        assert reader_value_labels == expected
+        with StataReader(path) as reader:
+            reader_value_labels = reader.value_labels()
+            assert reader_value_labels == expected
 
 
 def test_non_categorical_value_label_convert_categoricals_error():
@@ -2122,8 +2117,8 @@ def test_non_categorical_value_label_convert_categoricals_error():
     with tm.ensure_clean() as path:
         data.to_stata(path, value_labels=value_labels)
 
-        reader = StataReader(path, convert_categoricals=False)
-        reader_value_labels = reader.value_labels()
+        with StataReader(path, convert_categoricals=False) as reader:
+            reader_value_labels = reader.value_labels()
         assert reader_value_labels == value_labels
 
         col = "repeated_labels"


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the Github issue number)
  - Nothing to close – just noticed these while working on #48922.
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
  - Only tests changed. 
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
  - Nothing changed.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
  - Not done (not required)