### PR TITLE
DOC: reverted directive for SAS logo white

### DIFF
--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -607,10 +607,6 @@ the pandas-equivalent operations compared to software you already know:
     ---
     :card: + comparison-card-sas
     :img-top: ../_static/logo_sas.svg
-     :class: only-light
-
-    :img-top: ../_static/logo_sas_white.svg
-     :class: only-dark
 
     The `SAS <https://en.wikipedia.org/wiki/SAS_(software)>`__ statistical software suite
     also provides the ``data set`` corresponding to the pandas ``DataFrame``.


### PR DESCRIPTION
This pull requrest is related to #48790. These changes revert the directive, that don't work as expected and causes a code leak on the web page, to use a different image depending on the theme used:
- [logo_sas.svg](https://github.com/pandas-dev/pandas/blob/main/doc/source/_static/logo_sas.svg) for light theme;
- [logo_sas_white.svg](https://github.com/pandas-dev/pandas/blob/main/doc/source/_static/logo_sas_white.svg) for dark theme.

I can't figured out how to solve it, so I restored a previous version of the file (see Commits tab) and I will open an issue about this problem.
