### PR TITLE
Removing The Show_Source Button from API pages

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -388,7 +388,7 @@ html_use_modindex = True
 # html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-# html_show_sourcelink = True
+# html_show_sourcelink = False
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -388,7 +388,7 @@ html_use_modindex = True
 # html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-# html_show_sourcelink = True
+html_show_sourcelink = False
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the


### PR DESCRIPTION
- [x] closes #48715 

Made the required changes in the conf.py file.
It removes the show_source button from the API pages.

