### PR TITLE
DOC: Fixed documentation for pivot_table margins (#48916)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8604,12 +8604,15 @@ Parrot 2  Parrot       24.0
             hierarchical columns whose top level are the function names
             (inferred from the function objects themselves)
             If dict is passed, the key is column to aggregate and value
-            is function or list of functions.
+            is function or list of functions. If margin = ``True``,
+            aggfunc will be used to calculate the partial aggregates.
         fill_value : scalar, default None
             Value to replace missing values with (in the resulting pivot table,
             after aggregation).
         margins : bool, default False
-            Add all row / columns (e.g. for subtotal / grand totals).
+            If ``margins=True``, special ``All`` columns and rows
+            will be added with partial group aggregates across the categories
+            on the rows and columns.
         dropna : bool, default True
             Do not include columns whose entries are all NaN. If True,
             rows with a NaN value in any column will be omitted before

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8604,7 +8604,7 @@ Parrot 2  Parrot       24.0
             hierarchical columns whose top level are the function names
             (inferred from the function objects themselves)
             If dict is passed, the key is column to aggregate and value
-            is function or list of functions. If margin = ``True``,
+            is function or list of functions. If ``margin=True``,
             aggfunc will be used to calculate the partial aggregates.
         fill_value : scalar, default None
             Value to replace missing values with (in the resulting pivot table,


### PR DESCRIPTION
The documentation for the margins parameter of pivot_table was incorrect. It said that the parameter added rows and columns, but it actually passed them to aggfunc. I used the documentation from the user guide to replace the old documentation, as well as added a sentence to the documentation for aggfunc that explained its role in calculating margins.

- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
