### PR TITLE
DOC: Updated Resampler.mean docstring to have its own docstring

### DIFF
--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -998,8 +998,6 @@ class Resampler(BaseGroupBy, PandasObject):
         numeric_only : bool, default False
             Include only `float`, `int` or `boolean` data.
 
-            .. versionadded:: 1.5.0
-
         Returns
         -------
         DataFrame or Series

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -984,6 +984,30 @@ class Resampler(BaseGroupBy, PandasObject):
         """
         return self._upsample("asfreq", fill_value=fill_value)
 
+    def mean(
+        self,
+        numeric_only: bool | lib.NoDefault = lib.no_default,
+        *args,
+        **kwargs,
+    ):
+        """
+        Compute mean of groups, excluding missing values.
+
+        Parameters
+        ----------
+        numeric_only : bool, default False
+            Include only `float`, `int` or `boolean` data.
+
+            .. versionadded:: 1.5.0
+
+        Returns
+        -------
+        DataFrame or Series
+            Mean of values within each group.
+        """
+        nv.validate_resampler_func("mean", args, kwargs)
+        return self._downsample("mean", numeric_only=numeric_only)
+
     def std(
         self,
         ddof: int = 1,
@@ -1173,7 +1197,7 @@ def _add_downsample_kernel(
 
 for method in ["sum", "prod", "min", "max", "first", "last"]:
     _add_downsample_kernel(method, ("numeric_only", "min_count"))
-for method in ["mean", "median"]:
+for method in ["median"]:
     _add_downsample_kernel(method, ("numeric_only",))
 for method in ["sem"]:
     _add_downsample_kernel(method, ("ddof", "numeric_only"))


### PR DESCRIPTION
- [x] closes #48803 which belongs to `Contributions welcome` milestone
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.


By default, the `Resampler.mean` docstring is inherited from `GroupBy.mean`. As a result, unsupported parameters 'engine' and 'engine_kwargs' were created in the [API documentation](https://pandas.pydata.org/docs/reference/api/pandas.core.resample.Resampler.aggregate.html).

To do this, I defined the Mean function as a method of Resampler and wrote the docstring of the function itself.

- FYI
  - I think it is unnecessary adding this issue to Whatsnew section, so I left it.
  - I closed [previous PR](https://github.com/pandas-dev/pandas/pull/48902). This one is newly created.