### PR TITLE
DOC: Fix typos and standardize spelling of "GitHub"  and "macOS"

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -68,5 +68,5 @@ body:
     attributes:
       label: Additional Context
       description: >
-        Please provide any relevant Github issues, code examples or references that help describe and support
+        Please provide any relevant GitHub issues, code examples or references that help describe and support
         the feature request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-- [ ] closes #xxxx (Replace xxxx with the Github issue number)
+- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
 - [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
 - [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
 - [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.

--- a/.github/workflows/macos-windows.yml
+++ b/.github/workflows/macos-windows.yml
@@ -1,4 +1,4 @@
-name: Windows-MacOS
+name: Windows-macOS
 
 on:
   push:

--- a/.github/workflows/python-dev.yml
+++ b/.github/workflows/python-dev.yml
@@ -3,7 +3,7 @@
 #
 # In general, this file will remain frozen(present, but not running) until:
 #    - The next unreleased Python version has released beta 1
-#      - This version should be available on Github Actions.
+#      - This version should be available on GitHub Actions.
 #    - Our required build/runtime dependencies(numpy, pytz, Cython, python-dateutil)
 #      support that unreleased Python version.
 #    To unfreeze, comment out the ``if: false`` condition, and make sure you update

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,7 +44,7 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        # Github Actions doesn't support pairing matrix values together, let's improvise
+        # GitHub Actions doesn't support pairing matrix values together, let's improvise
         # https://github.com/github/feedback/discussions/7835#discussioncomment-1769026
         buildplat:
         - [ubuntu-20.04, manylinux_x86_64]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -251,7 +251,7 @@ repos:
         files: ^(ci/deps/actions-.*-minimum_versions\.yaml|pandas/compat/_optional\.py)$
     -   id: validate-errors-locations
         name: Validate errors locations
-        description: Validate errors are in approriate locations.
+        description: Validate errors are in appropriate locations.
         entry: python scripts/validate_exception_location.py
         language: python
         files: ^pandas/

--- a/doc/source/development/contributing_codebase.rst
+++ b/doc/source/development/contributing_codebase.rst
@@ -651,7 +651,7 @@ Example
 ^^^^^^^
 
 Here is an example of a self-contained set of tests in a file ``pandas/tests/test_cool_feature.py``
-that illustrate multiple features that we like to use. Please remember to add the Github Issue Number
+that illustrate multiple features that we like to use. Please remember to add the GitHub Issue Number
 as a comment to a new test.
 
 .. code-block:: python

--- a/doc/source/development/maintaining.rst
+++ b/doc/source/development/maintaining.rst
@@ -210,15 +210,15 @@ pandas supports point releases (e.g. ``1.4.3``) that aim to:
 
   * e.g. If a feature worked in ``1.2`` and stopped working since ``1.3``, a fix can be applied in ``1.4.3``.
 
-Since pandas minor releases are based on Github branches (e.g. point release of ``1.4`` are based off the ``1.4.x`` branch),
+Since pandas minor releases are based on GitHub branches (e.g. point release of ``1.4`` are based off the ``1.4.x`` branch),
 "backporting" means merging a pull request fix to the ``main`` branch and correct minor branch associated with the next point release.
 
-By default, if a pull request is assigned to the next point release milestone within the Github interface,
+By default, if a pull request is assigned to the next point release milestone within the GitHub interface,
 the backporting process should happen automatically by the ``@meeseeksdev`` bot once the pull request is merged.
 A new pull request will be made backporting the pull request to the correct version branch.
 Sometimes due to merge conflicts, a manual pull request will need to be made addressing the code conflict.
 
-If the bot does not automatically start the backporting process, you can also write a Github comment in the merged pull request
+If the bot does not automatically start the backporting process, you can also write a GitHub comment in the merged pull request
 to trigger the backport::
 
     @meeseeksdev backport version-branch
@@ -271,14 +271,14 @@ being helpful on the issue tracker.
 The required steps for adding a maintainer are:
 
 1. Contact the contributor and ask their interest to join.
-2. Add the contributor to the appropriate `Github Team <https://github.com/orgs/pandas-dev/teams>`_ if accepted the invitation.
+2. Add the contributor to the appropriate `GitHub Team <https://github.com/orgs/pandas-dev/teams>`_ if accepted the invitation.
 
   * ``pandas-core`` is for core team members
   * ``pandas-triage`` is for pandas triage members
 
 3. Add the contributor to the pandas Google group.
-4. Create a pull request to add the contributor's Github handle to ``pandas-dev/pandas/web/pandas/config.yml``.
-5. Create a pull request to add the contributor's name/Github handle to the `governance document <https://github.com/pandas-dev/pandas-governance/blob/master/people.md>`_.
+4. Create a pull request to add the contributor's GitHub handle to ``pandas-dev/pandas/web/pandas/config.yml``.
+5. Create a pull request to add the contributor's name/GitHub handle to the `governance document <https://github.com/pandas-dev/pandas-governance/blob/master/people.md>`_.
 
 The current list of core-team members is at
 https://github.com/pandas-dev/pandas-governance/blob/master/people.md
@@ -328,7 +328,7 @@ The machine can be configured with the `Ansible <http://docs.ansible.com/ansible
 Publishing
 ``````````
 
-The results are published to another Github repository, https://github.com/tomaugspurger/asv-collection.
+The results are published to another GitHub repository, https://github.com/tomaugspurger/asv-collection.
 Finally, we have a cron job on our docs server to pull from https://github.com/tomaugspurger/asv-collection, to serve them from ``/speed``.
 Ask Tom or Joris for access to the webserver.
 

--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -19,7 +19,7 @@ development to remain focused around it's original requirements.
 This is an inexhaustive list of projects that build on pandas in order to provide
 tools in the PyData space. For a list of projects that depend on pandas,
 see the
-`Github network dependents for pandas <https://github.com/pandas-dev/pandas/network/dependents>`_
+`GitHub network dependents for pandas <https://github.com/pandas-dev/pandas/network/dependents>`_
 or `search pypi for pandas <https://pypi.org/search/?q=pandas>`_.
 
 We'd like to make it easier for users to find these projects, if you know of other
@@ -599,4 +599,4 @@ Install pandas-stubs to enable basic type coverage of pandas API.
 
 Learn more by reading through :issue:`14468`, :issue:`26766`, :issue:`28142`.
 
-See installation and usage instructions on the `github page <https://github.com/pandas-dev/pandas-stubs>`__.
+See installation and usage instructions on the `GitHub page <https://github.com/pandas-dev/pandas-stubs>`__.

--- a/doc/source/getting_started/overview.rst
+++ b/doc/source/getting_started/overview.rst
@@ -133,7 +133,7 @@ untouched. In general we like to **favor immutability** where sensible.
 Getting support
 ---------------
 
-The first stop for pandas issues and ideas is the `Github Issue Tracker
+The first stop for pandas issues and ideas is the `GitHub Issue Tracker
 <https://github.com/pandas-dev/pandas/issues>`__. If you have a general question,
 pandas community experts can answer through `Stack Overflow
 <https://stackoverflow.com/questions/tagged/pandas>`__.

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -654,7 +654,7 @@ Deprecations
     In the next major version release, 2.0, several larger API changes are being considered without a formal deprecation such as
     making the standard library `zoneinfo <https://docs.python.org/3/library/zoneinfo.html>`_ the default timezone implementation instead of ``pytz``,
     having the :class:`Index` support all data types instead of having multiple subclasses (:class:`CategoricalIndex`, :class:`Int64Index`, etc.), and more.
-    The changes under consideration are logged in `this Github issue <https://github.com/pandas-dev/pandas/issues/44823>`_, and any
+    The changes under consideration are logged in `this GitHub issue <https://github.com/pandas-dev/pandas/issues/44823>`_, and any
     feedback or concerns are welcome.
 
 .. _whatsnew_150.deprecations.int_slicing_series:

--- a/doc/sphinxext/announce.py
+++ b/doc/sphinxext/announce.py
@@ -3,7 +3,7 @@
 Script to generate contributor and pull request lists
 
 This script generates contributor and pull request lists for release
-announcements using Github v3 protocol. Use requires an authentication token in
+announcements using GitHub v3 protocol. Use requires an authentication token in
 order to have sufficient bandwidth, you can get one following the directions at
 `<https://help.github.com/articles/creating-an-access-token-for-command-line-use/>_
 Don't add any scope, as the default is read access to public information. The
@@ -112,7 +112,7 @@ def get_pull_requests(repo, revision_range):
     issues = re.findall("^.*\\(\\#(\\d+)\\)$", commits, re.M)
     prnums.extend(int(s) for s in issues)
 
-    # get PR data from github repo
+    # get PR data from GitHub repo
     prnums.sort()
     prs = [repo.get_pull(n) for n in prnums]
     return prs

--- a/pandas/_version.py
+++ b/pandas/_version.py
@@ -1,5 +1,5 @@
 # This file helps to compute a version number in source trees obtained from
-# git-archive tarball (such as those provided by githubs download-from-tag
+# git-archive tarball (such as those provided by GitHub's download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
 # directories (produced by setup.py build) will contain a much shorter file
 # that just contains the computed version number.

--- a/pandas/core/internals/api.py
+++ b/pandas/core/internals/api.py
@@ -83,7 +83,7 @@ def make_block(
 
 def maybe_infer_ndim(values, placement: BlockPlacement, ndim: int | None) -> int:
     """
-    If `ndim` is not provided, infer it from placment and values.
+    If `ndim` is not provided, infer it from placement and values.
     """
     if ndim is None:
         # GH#38134 Block constructor now assumes ndim is not None

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -418,7 +418,7 @@ def _interpolate_1d(
 
     # For example if limit_direction='forward' then preserve_nans will
     # contain indices of NaNs at the beginning of the series, and NaNs that
-    # are more than'limit' away from the prior non-NaN.
+    # are more than 'limit' away from the prior non-NaN.
 
     # set preserve_nans based on direction using _interp_limit
     preserve_nans: list | set

--- a/pandas/io/clipboard/__init__.py
+++ b/pandas/io/clipboard/__init__.py
@@ -538,7 +538,7 @@ def determine_clipboard():
         if which("wslconfig.exe"):
             return init_wsl_clipboard()
 
-    # Setup for the MAC OS X platform:
+    # Setup for the macOS platform:
     if os.name == "mac" or platform.system() == "Darwin":
         try:
             import AppKit
@@ -587,7 +587,7 @@ def set_clipboard(clipboard):
     the copy() and paste() functions interact with the operating system to
     implement the copy/paste feature. The clipboard parameter must be one of:
         - pbcopy
-        - pyobjc (default on Mac OS X)
+        - pyobjc (default on macOS)
         - qt
         - xclip
         - xsel

--- a/pandas/io/clipboard/__init__.py
+++ b/pandas/io/clipboard/__init__.py
@@ -587,7 +587,7 @@ def set_clipboard(clipboard):
     the copy() and paste() functions interact with the operating system to
     implement the copy/paste feature. The clipboard parameter must be one of:
         - pbcopy
-        - pbobjc (default on Mac OS X)
+        - pyobjc (default on Mac OS X)
         - qt
         - xclip
         - xsel

--- a/pandas/tests/extension/json/array.py
+++ b/pandas/tests/extension/json/array.py
@@ -203,7 +203,7 @@ class JSONArray(ExtensionArray):
                 return self.copy()
             return self
         elif isinstance(dtype, StringDtype):
-            value = self.astype(str)  # numpy doesn'y like nested dicts
+            value = self.astype(str)  # numpy doesn't like nested dicts
             return dtype.construct_array_type()._from_sequence(value, copy=False)
 
         return np.array([dict(x) for x in self], dtype=dtype, copy=copy)

--- a/pandas/tests/io/conftest.py
+++ b/pandas/tests/io/conftest.py
@@ -71,7 +71,7 @@ def s3_base(worker_id):
             if is_platform_arm() or is_platform_mac() or is_platform_windows():
                 # NOT RUN on Windows/macOS/ARM, only Ubuntu
                 # - subprocess in CI can cause timeouts
-                # - Github Actions do not support
+                # - GitHub Actions do not support
                 #   container services for the above OSs
                 # - CircleCI will probably hit the Docker rate pull limit
                 pytest.skip(

--- a/pandas/tests/io/conftest.py
+++ b/pandas/tests/io/conftest.py
@@ -69,14 +69,14 @@ def s3_base(worker_id):
         os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "foobar_secret")
         if is_ci_environment():
             if is_platform_arm() or is_platform_mac() or is_platform_windows():
-                # NOT RUN on Windows/MacOS/ARM, only Ubuntu
+                # NOT RUN on Windows/macOS/ARM, only Ubuntu
                 # - subprocess in CI can cause timeouts
                 # - Github Actions do not support
                 #   container services for the above OSs
                 # - CircleCI will probably hit the Docker rate pull limit
                 pytest.skip(
                     "S3 tests do not have a corresponding service in "
-                    "Windows, MacOS or ARM platforms"
+                    "Windows, macOS or ARM platforms"
                 )
             else:
                 yield "http://localhost:5000"

--- a/pandas/tests/io/sas/test_sas7bdat.py
+++ b/pandas/tests/io/sas/test_sas7bdat.py
@@ -96,7 +96,7 @@ class TestSAS7BDAT:
     @pytest.mark.parametrize("chunksize", (3, 5, 10, 11))
     @pytest.mark.parametrize("k", range(1, 17))
     def test_iterator_loop(self, dirpath, k, chunksize):
-        # GitHub issue #13654
+        # github #13654
         fname = os.path.join(dirpath, f"test{k}.sas7bdat")
         with pd.read_sas(fname, chunksize=chunksize, encoding="utf-8") as rdr:
             y = 0
@@ -105,7 +105,7 @@ class TestSAS7BDAT:
         assert y == rdr.row_count
 
     def test_iterator_read_too_much(self, dirpath):
-        # GitHub issue #14734
+        # github #14734
         fname = os.path.join(dirpath, "test1.sas7bdat")
         with pd.read_sas(
             fname, format="sas7bdat", iterator=True, encoding="utf-8"

--- a/pandas/tests/io/sas/test_sas7bdat.py
+++ b/pandas/tests/io/sas/test_sas7bdat.py
@@ -96,7 +96,7 @@ class TestSAS7BDAT:
     @pytest.mark.parametrize("chunksize", (3, 5, 10, 11))
     @pytest.mark.parametrize("k", range(1, 17))
     def test_iterator_loop(self, dirpath, k, chunksize):
-        # github #13654
+        # GitHub issue #13654
         fname = os.path.join(dirpath, f"test{k}.sas7bdat")
         with pd.read_sas(fname, chunksize=chunksize, encoding="utf-8") as rdr:
             y = 0
@@ -105,7 +105,7 @@ class TestSAS7BDAT:
         assert y == rdr.row_count
 
     def test_iterator_read_too_much(self, dirpath):
-        # github #14734
+        # GitHub issue #14734
         fname = os.path.join(dirpath, "test1.sas7bdat")
         with pd.read_sas(
             fname, format="sas7bdat", iterator=True, encoding="utf-8"

--- a/pandas/tests/window/test_numba.py
+++ b/pandas/tests/window/test_numba.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.skipif(
     is_ci_environment() and (is_platform_windows() or is_platform_mac()),
     reason="On GHA CI, Windows can fail with "
     "'Windows fatal exception: stack overflow' "
-    "and MacOS can timeout",
+    "and macOS can timeout",
 )
 
 

--- a/pandas/tests/window/test_online.py
+++ b/pandas/tests/window/test_online.py
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.skipif(
     is_ci_environment() and (is_platform_windows() or is_platform_mac()),
     reason="On GHA CI, Windows can fail with "
     "'Windows fatal exception: stack overflow' "
-    "and MacOS can timeout",
+    "and macOS can timeout",
 )
 
 

--- a/pandas/tests/window/test_win_type.py
+++ b/pandas/tests/window/test_win_type.py
@@ -684,7 +684,7 @@ def test_cmov_window_special_linear_range(win_types_special, step):
 
 @td.skip_if_no_scipy
 def test_weighted_var_big_window_no_segfault(win_types, center):
-    # Github Issue #46772
+    # GitHub Issue #46772
     x = Series(0)
     result = x.rolling(window=16, center=center, win_type=win_types).var()
     expected = Series(np.NaN)

--- a/versioneer.py
+++ b/versioneer.py
@@ -33,7 +33,7 @@ Source trees come from a variety of places:
 
 * a version-control system checkout (mostly used by developers)
 * a nightly tarball, produced by build automation
-* a snapshot tarball, produced by a web-based VCS browser, like github's
+* a snapshot tarball, produced by a web-based VCS browser, like GitHub's
   "tarball from tag" feature
 * a release tarball, produced by "setup.py sdist", distributed through PyPI
 
@@ -161,7 +161,7 @@ which may help identify what went wrong).
 ## Known Limitations
 
 Some situations are known to cause problems for Versioneer. This details the
-most significant ones. More can be found on Github
+most significant ones. More can be found on GitHub
 [issues page](https://github.com/python-versioneer/python-versioneer/issues).
 
 ### Subprojects
@@ -421,7 +421,7 @@ LONG_VERSION_PY[
     "git"
 ] = r'''
 # This file helps to compute a version number in source trees obtained from
-# git-archive tarball (such as those provided by githubs download-from-tag
+# git-archive tarball (such as those provided by GitHub's download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
 # directories (produced by setup.py build) will contain a much shorter file
 # that just contains the computed version number.
@@ -1466,7 +1466,7 @@ def get_versions(verbose=False):
     # extract version from first of: _version.py, VCS command (e.g. 'git
     # describe'), parentdir. This is meant to work for developers using a
     # source checkout, for users of a tarball created by 'setup.py sdist',
-    # and for users of a tarball/zipball created by 'git archive' or github's
+    # and for users of a tarball/zipball created by 'git archive' or GitHub's
     # download-from-tag feature or the equivalent in other VCSes.
 
     get_keywords_f = handlers.get("get_keywords")

--- a/web/pandas/community/ecosystem.md
+++ b/web/pandas/community/ecosystem.md
@@ -411,8 +411,8 @@ It prescibes an opinionated paradigm, that ensures all code is:
 * unit testable
 * integration testing friendly
 * documentation friendly
-* transformation logic is reuseable, as it is decoupled from the context of where it is used.
-* integrateable with runtime data quality checks.
+* transformation logic is reusable, as it is decoupled from the context of where it is used.
+* integratable with runtime data quality checks.
 
 This helps one to scale your pandas code base, at the same time, keeping maintenance costs low.
 

--- a/web/pandas/community/ecosystem.md
+++ b/web/pandas/community/ecosystem.md
@@ -399,7 +399,7 @@ Install pandas-stubs to enable basic type coverage of pandas API.
 Learn more by reading through these issues [14468](https://github.com/pandas-dev/pandas/issues/14468),
 [26766](https://github.com/pandas-dev/pandas/issues/26766), [28142](https://github.com/pandas-dev/pandas/issues/28142).
 
-See installation and usage instructions on the [github page](https://github.com/VirtusLab/pandas-stubs).
+See installation and usage instructions on the [GitHub page](https://github.com/VirtusLab/pandas-stubs).
 
 ### [Hamilton](https://github.com/stitchfix/hamilton)
 

--- a/web/pandas/getting_started.md
+++ b/web/pandas/getting_started.md
@@ -29,7 +29,7 @@ the [advanced installation page]({{ base_url}}/docs/getting_started/install.html
     Detailed instructions on how to install Anaconda can be found in the
     [Anaconda documentation](https://docs.anaconda.com/anaconda/install/).
 
-2. In the Anaconda prompt (or terminal in Linux or MacOS), start JupyterLab:
+2. In the Anaconda prompt (or terminal in Linux or macOS), start JupyterLab:
 
     <img class="img-fluid" alt="" src="{{ base_url }}/static/img/install/anaconda_prompt.png"/>
 

--- a/web/pandas_web.py
+++ b/web/pandas_web.py
@@ -395,7 +395,7 @@ if __name__ == "__main__":
         action="store_true",
         help="do not fail if errors happen when fetching "
         "data from http sources, and those fail "
-        "(mostly useful to allow github quota errors "
+        "(mostly useful to allow GitHub quota errors "
         "when running the script locally)",
     )
     args = parser.parse_args()

--- a/web/pandas_web.py
+++ b/web/pandas_web.py
@@ -338,7 +338,7 @@ def main(
     Copy every file in the source directory to the target directory.
 
     For ``.md`` and ``.html`` files, render them with the context
-    before copyings them. ``.md`` files are transformed to HTML.
+    before copying them. ``.md`` files are transformed to HTML.
     """
     config_fname = os.path.join(source_path, "config.yml")
 


### PR DESCRIPTION
## Proposed changes

1. Fix some typos. They were found with:

   ```shell
   brew install aspell
   
   find . -type f -exec cat '{}' \; |
     aspell -a |
     grep -v '*' |
     sed '/^$/d' |
     cut -d ' ' -f 2 |
     sort -u
   ```

   The output was visually inspected to find the typos.

3. Standardize spelling of "GitHub". The official spelling of "GitHub" can be seen in the title of page <https://github.com/>.
4. Standardize spelling of "macOS". The Apple operating system was called "Mac OS X" in versions 10.0-10.7, then "OS X" in versions 10.8-10.11, and finally "macOS" since version 10.12, released in 2016 (<https://en.wikipedia.org/wiki/MacOS#Release_history>).

## Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
