### PR TITLE
BUG: resolution in datetimelike add/sub timedeltalike scalar

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1275,7 +1275,8 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
 
         # PeriodArray overrides, so we only get here with DTA/TDA
         self = cast("DatetimeArray | TimedeltaArray", self)
-        other = Timedelta(other)._as_unit(self._unit)
+        other = Timedelta(other)
+        self, other = self._ensure_matching_resos(other)
         return self._add_timedeltalike(other)
 
     def _add_timedelta_arraylike(self, other: TimedeltaArray):

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -19,6 +19,7 @@ import pytest
 
 from pandas._libs.tslibs import (
     NaT,
+    Timedelta,
     Timestamp,
     conversion,
     timezones,
@@ -566,6 +567,12 @@ class TestCommon(Base):
             expected = dti._data + off
             result = dta + off
 
+        exp_unit = unit
+        if isinstance(off, Tick) and off._reso > dta._reso:
+            # cast to higher reso like we would with Timedelta scalar
+            exp_unit = Timedelta(off)._unit
+        expected = expected._as_unit(exp_unit)
+
         if len(w):
             # PerformanceWarning was issued bc _apply_array raised, so we
             #  fell back to object dtype, for which the code path does
@@ -576,9 +583,7 @@ class TestCommon(Base):
             )
             request.node.add_marker(mark)
 
-        tm.assert_numpy_array_equal(
-            result._ndarray, expected._ndarray.astype(arr.dtype)
-        )
+        tm.assert_numpy_array_equal(result._ndarray, expected._ndarray)
 
 
 class TestDateOffset(Base):


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the Github issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
