### PR TITLE
Index fallbacks with Intervals 

### DIFF
--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -784,7 +784,7 @@ class IntervalIndex(ExtensionIndex):
         #  positional in this case
         # error: Item "ExtensionDtype"/"dtype[Any]" of "Union[dtype[Any],
         # ExtensionDtype]" has no attribute "subtype"
-        return self.dtype.subtype.kind in ["m", "M"]  # type: ignore[union-attr]
+        return self.dtype.subtype.kind in ["m", "M", "i", "f"]  # type: ignore[union-attr]
 
     def _maybe_cast_slice_bound(self, label, side: str, kind=lib.no_default):
         self._deprecated_arg(kind, "kind", "_maybe_cast_slice_bound")

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -784,7 +784,8 @@ class IntervalIndex(ExtensionIndex):
         #  positional in this case
         # error: Item "ExtensionDtype"/"dtype[Any]" of "Union[dtype[Any],
         # ExtensionDtype]" has no attribute "subtype"
-        return self.dtype.subtype.kind in ["m", "M", "i", "f"]  # type: ignore[union-attr]
+        fallback_dtypes = ["m", "M", "i", "f"]
+        return self.dtype.subtype.kind in fallback_dtypes  # type: ignore[union-attr]
 
     def _maybe_cast_slice_bound(self, label, side: str, kind=lib.no_default):
         self._deprecated_arg(kind, "kind", "_maybe_cast_slice_bound")

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -784,7 +784,7 @@ class IntervalIndex(ExtensionIndex):
         #  positional in this case
         # error: Item "ExtensionDtype"/"dtype[Any]" of "Union[dtype[Any],
         # ExtensionDtype]" has no attribute "subtype"
-        fallback_dtypes = ["m", "M", "i", "f"]
+        fallback_dtypes: list[str] = ["m", "M", "i", "f"]
         return self.dtype.subtype.kind in fallback_dtypes  # type: ignore[union-attr]
 
     def _maybe_cast_slice_bound(self, label, side: str, kind=lib.no_default):

--- a/pandas/tests/series/indexing/test_getitem.py
+++ b/pandas/tests/series/indexing/test_getitem.py
@@ -207,6 +207,18 @@ class TestSeriesGetitemScalars:
         result = ser[0]
         assert result == 1
 
+    def test_getitem_integer_with_intervalindex(self):
+        # GH#27437
+        cat_index = pd.CategoricalIndex(
+            pd.interval_range(start=0, end=4, periods=2), ordered=True
+        )
+        ser = Series([[1, 2], [3, 4]], index=cat_index)
+
+        assert ser[0] == [1, 2]
+        assert ser[1] == [3, 4]
+        assert ser.loc[0] == [1, 2]
+        assert ser.loc[1] == [3, 4]
+
 
 class TestSeriesGetitemSlices:
     def test_getitem_partial_str_slice_with_datetimeindex(self):


### PR DESCRIPTION
- [X] closes #27437 (Replace xxxx with the Github issue number)
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

# Summary

Looks to fix #27437 where the integer index should fallback to positional. I identified that the private method `_should_fallback_to_positional` returned the expression `return self.dtype.subtype.kind in ["m", "M"]` which was missing the `numpy.dtype.kind` for single integers and floats as expressed [here](https://numpy.org/doc/stable/reference/generated/numpy.dtype.kind.html). 

However, extending the list with `["i", "f"]` caused the character count to exceed 88, hence extracting this out in the previous line and storing as a variable to reference.

Tests are also included which aims to mimic the example given in the issue where the `series` is constructed with a `CategoricalIndex` with intervals.

Also, this is my first time contributing to the project so would appreciate feedback 👍  

**Edit**

There are a couple things I need to fix

- [ ] Remove `.loc[index]` from unittest as this wasn't the desired property
- [ ] Investigate why other tests are failing