### PR TITLE
STYLE check for ability to remove 'c-extension-no-member' from pylint exclusions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ disable = [
   "W",
   "abstract-class-instantiated",
   "access-member-before-definition",
-  "c-extension-no-member",
   "import-error",
   "invalid-repr-returned",
   "invalid-unary-operand-type",


### PR DESCRIPTION
- [ x] addresses one concern listed in #48855 .

Removed `c-extension-no-member` from `pyproject.toml`, ran the precommit checks in Docker build environment, found no instances of the error.

Looks like `c-extension-no-member` can be removed from the list of pylint exclusions in pyproject.toml
