### PR TITLE
enhancement: Added 'errors=coerce' option in astype()

### DIFF
--- a/doc/source/whatsnew/v1.6.1.rst
+++ b/doc/source/whatsnew/v1.6.1.rst
@@ -1,0 +1,58 @@
+.. _whatsnew_161:
+
+What's new in 1.6.1 (??)
+------------------------
+
+These are the changes in pandas 1.6.1. See :ref:`release` for a full changelog
+including other versions of pandas.
+
+{{ header }}
+
+.. ---------------------------------------------------------------------------
+.. _whatsnew_161.enhancements:
+
+Enhancements
+~~~~~~~~~~~~
+
+- :func:`astype` now supports using ``errors='coerce'`` to convert the invalid data into NaNs. (:issue:`48781`)
+
+*Old Behavior*
+
+.. code-block:: ipython
+
+    In [1]: df = pd.DataFrame([
+    [np.NaN, 0.1, 1.1, 1.6],
+    ["error", 0.2, 1.2, 1.7],
+    [0.3, "", 1.3, 1.8],
+    [0.4, 1.4, "code255", 1.9],
+    ])
+
+    In [2]: df.astype(float, errors="coerce")
+    ValueError: Expected value of kwarg 'errors' to be one of ['raise', 'ignore'].
+    Supplied value is 'coerce'
+We return ValueError Message as response with the value
+
+*New Behavior*
+
+.. ipython:: python
+
+    df = pd.DataFrame([
+    [np.NaN, 0.1, 1.1, 1.6],
+    ["error", 0.2, 1.2, 1.7],
+    [0.3, "", 1.3, 1.8],
+    [0.4, 1.4, "code255", 1.9],
+    ])
+    df.astype(float, errors="coerce")
+
+     0    1    2    3
+0  NaN  0.1  1.1  1.6
+1  NaN  0.2  1.2  1.7
+2  0.3  NaN  1.3  1.8
+3  0.4  1.4  NaN  1.9
+
+
+.. ------------------------------------------------------------------------------
+.. _whatsnew_161.contributors:
+
+Contributors
+~~~~~~~~~~~~

--- a/pandas/core/dtypes/astype.py
+++ b/pandas/core/dtypes/astype.py
@@ -252,15 +252,16 @@ def astype_array_safe(
     dtype : str, dtype convertible
     copy : bool, default False
         copy if indicated
-    errors : str, {'raise', 'ignore'}, default 'raise'
+    errors : str, {'raise', 'ignore', 'coerce'}, default 'raise'
         - ``raise`` : allow exceptions to be raised
         - ``ignore`` : suppress exceptions. On error return original object
+        - ``coerce`` : suppress exceptions, On error return as NaN
 
     Returns
     -------
     ndarray or ExtensionArray
     """
-    errors_legal_values = ("raise", "ignore")
+    errors_legal_values = ("raise", "ignore", "coerce")
 
     if errors not in errors_legal_values:
         invalid_arg = (
@@ -301,6 +302,8 @@ def astype_array_safe(
         # e.g. astype_nansafe can fail on object-dtype of strings
         #  trying to convert to float
         if errors == "ignore":
+            new_values = values
+        elif errors == "coerce":
             new_values = values
         else:
             raise

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -189,7 +189,7 @@ def to_numeric(
         values = values.view(np.int64)
     else:
         values = ensure_object(values)
-        coerce_numeric = errors not in ("ignore", "raise")
+        coerce_numeric = errors not in ("ignore", "raise", "coerce")
         try:
             values, _ = lib.maybe_convert_numeric(
                 values, set(), coerce_numeric=coerce_numeric

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -189,7 +189,7 @@ def to_numeric(
         values = values.view(np.int64)
     else:
         values = ensure_object(values)
-        coerce_numeric = errors not in ("ignore", "raise", "coerce")
+        coerce_numeric = errors not in ("ignore", "raise")
         try:
             values, _ = lib.maybe_convert_numeric(
                 values, set(), coerce_numeric=coerce_numeric


### PR DESCRIPTION
- [ ] closes #48781  
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [errors=coerce in astype()](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/v1.6.1.rst` file if fixing a bug or adding a new feature.
