### PR TITLE
BUG: DTA.isin with mismatched resos

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -867,6 +867,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
                 return isin(self.astype(object), values)
 
         if self.dtype.kind in ["m", "M"]:
+            self = cast("DatetimeArray | TimedeltaArray", self)
             values = values._as_unit(self._unit)
 
         try:

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -866,6 +866,9 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
             except ValueError:
                 return isin(self.astype(object), values)
 
+        if self.dtype.kind in ["m", "M"]:
+            values = values._as_unit(self._unit)
+
         try:
             self._check_compatible_with(values)
         except (TypeError, ValueError):

--- a/pandas/tests/series/methods/test_isin.py
+++ b/pandas/tests/series/methods/test_isin.py
@@ -53,15 +53,22 @@ class TestSeriesIsIn:
         result = ser.isin(day_values)
         tm.assert_series_equal(result, expected)
 
-        s_values = day_values.astype("M8[s]")
-        dta = type(ser._values)._simple_new(s_values, dtype=s_values.dtype)
+        dta = ser[:2]._values.astype("M8[s]")
         result = ser.isin(dta)
         tm.assert_series_equal(result, expected)
 
-        # FIXME(2.0): DTA._from_sequence incorrectly treats Timestamp[s].value
-        #  as nanoseconds.
-        # result = ser.isin(list(dta))
-        # tm.assert_series_equal(result, expected)
+    @pytest.mark.xfail(
+        reason="DTA._from_sequence incorrectly treats Timestamp[s].value as "
+        "nanoseconds."
+    )
+    def test_isin_datetimelike_mismatched_reso_list(self):
+        expected = Series([True, True, False, False, False])
+
+        ser = Series(date_range("jan-01-2013", "jan-05-2013"))
+
+        dta = ser[:2]._values.astype("M8[s]")
+        result = ser.isin(list(dta))
+        tm.assert_series_equal(result, expected)
 
     def test_isin_with_i8(self):
         # GH#5021

--- a/pandas/tests/series/methods/test_isin.py
+++ b/pandas/tests/series/methods/test_isin.py
@@ -43,6 +43,26 @@ class TestSeriesIsIn:
         with pytest.raises(TypeError, match=msg):
             s.isin("aaa")
 
+    def test_isin_datetimelike_mismatched_reso(self):
+        expected = Series([True, True, False, False, False])
+
+        ser = Series(date_range("jan-01-2013", "jan-05-2013"))
+
+        # fails on dtype conversion in the first place
+        day_values = np.asarray(ser[0:2].values).astype("datetime64[D]")
+        result = ser.isin(day_values)
+        tm.assert_series_equal(result, expected)
+
+        s_values = day_values.astype("M8[s]")
+        dta = type(ser._values)._simple_new(s_values, dtype=s_values.dtype)
+        result = ser.isin(dta)
+        tm.assert_series_equal(result, expected)
+
+        # FIXME(2.0): DTA._from_sequence incorrectly treats Timestamp[s].value
+        #  as nanoseconds.
+        # result = ser.isin(list(dta))
+        # tm.assert_series_equal(result, expected)
+
     def test_isin_with_i8(self):
         # GH#5021
 
@@ -56,10 +76,6 @@ class TestSeriesIsIn:
         tm.assert_series_equal(result, expected)
 
         result = s.isin(s[0:2].values)
-        tm.assert_series_equal(result, expected)
-
-        # fails on dtype conversion in the first place
-        result = s.isin(np.asarray(s[0:2].values).astype("datetime64[D]"))
         tm.assert_series_equal(result, expected)
 
         result = s.isin([s[1]])


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Also trims a bit off of the upcoming DTA._from_sequence non-nano PR