### PR TITLE
BUG: redirect from meeting to community was incorrect

### DIFF
--- a/doc/redirects.csv
+++ b/doc/redirects.csv
@@ -45,7 +45,7 @@ contributing_docstring,development/contributing_docstring
 developer,development/developer
 extending,development/extending
 internals,development/internals
-meeting,development/community
+development/meeting,community
 
 # api moved function
 reference/api/pandas.io.json.json_normalize,pandas.json_normalize

--- a/doc/redirects.csv
+++ b/doc/redirects.csv
@@ -45,7 +45,7 @@ contributing_docstring,development/contributing_docstring
 developer,development/developer
 extending,development/extending
 internals,development/internals
-development/meeting,development/community
+meeting,development/community
 
 # api moved function
 reference/api/pandas.io.json.json_normalize,pandas.json_normalize


### PR DESCRIPTION
I noticed that the redirect I created had the following bug:
https://pandas.pydata.org/docs/dev/development/development/meeting.html
redirected to:
https://pandas.pydata.org/docs/dev/development/development/community.html
instead of:
https://pandas.pydata.org/docs/dev/development/community.html

After a full local docs build this fix seems to address the problem. Please check me.