### PR TITLE
BUG: unstack accessing wrong index level when midx has mixed names

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -263,6 +263,7 @@ Groupby/resample/rolling
 Reshaping
 ^^^^^^^^^
 - Bug in :meth:`DataFrame.pivot_table` raising ``TypeError`` for nullable dtype and ``margins=True`` (:issue:`48681`)
+- Bug in :meth:`DataFrame.unstack` and :meth:`Series.unstack` unstacking wrong level of :class:`MultiIndex` when :class:`MultiIndex` has mixed names (:issue:`48763`)
 - Bug in :meth:`DataFrame.pivot` not respecting ``None`` as column name (:issue:`48293`)
 - Bug in :func:`join` when ``left_on`` or ``right_on`` is or includes a :class:`CategoricalIndex` incorrectly raising ``AttributeError`` (:issue:`48464`)
 -

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -471,6 +471,7 @@ def unstack(obj: Series | DataFrame, level, fill_value=None):
             level = level[0]
 
     if not is_integer(level) and not level == "__placeholder__":
+        # check if level is valid in case of regular index
         obj.index._get_level_number(level)
 
     if isinstance(obj, DataFrame):

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -470,9 +470,8 @@ def unstack(obj: Series | DataFrame, level, fill_value=None):
         else:
             level = level[0]
 
-    # Prioritize integer interpretation (GH #21677):
     if not is_integer(level) and not level == "__placeholder__":
-        level = obj.index._get_level_number(level)
+        obj.index._get_level_number(level)
 
     if isinstance(obj, DataFrame):
         if isinstance(obj.index, MultiIndex):

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -2183,3 +2183,16 @@ Thu,Lunch,Yes,51.51,17"""
         #  be an EA
         expected = df.astype(object).stack("station")
         tm.assert_frame_equal(result, expected)
+
+    def test_unstack_mixed_level_names(self):
+        # GH#48763
+        arrays = [["a", "a"], [1, 2], ["red", "blue"]]
+        idx = MultiIndex.from_arrays(arrays, names=("x", 0, "y"))
+        df = DataFrame({"m": [1, 2]}, index=idx)
+        result = df.unstack("x")
+        expected = DataFrame(
+            [[1], [2]],
+            columns=MultiIndex.from_tuples([("m", "a")], names=[None, "x"]),
+            index=MultiIndex.from_tuples([(1, "red"), (2, "blue")], names=[0, "y"]),
+        )
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/series/methods/test_unstack.py
+++ b/pandas/tests/series/methods/test_unstack.py
@@ -147,3 +147,17 @@ def test_unstack_multi_index_categorical_values():
         index=dti.rename("major"),
     )
     tm.assert_frame_equal(result, expected)
+
+
+def test_unstack_mixed_level_names():
+    # GH#48763
+    arrays = [["a", "a"], [1, 2], ["red", "blue"]]
+    idx = MultiIndex.from_arrays(arrays, names=("x", 0, "y"))
+    ser = Series([1, 2], index=idx)
+    result = ser.unstack("x")
+    expected = DataFrame(
+        [[1], [2]],
+        columns=pd.Index(["a"], name="x"),
+        index=MultiIndex.from_tuples([(1, "red"), (2, "blue")], names=[0, "y"]),
+    )
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #48763 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
