### PR TITLE
REF: reso->creso in TSObject

### DIFF
--- a/pandas/_libs/tslibs/conversion.pxd
+++ b/pandas/_libs/tslibs/conversion.pxd
@@ -20,9 +20,9 @@ cdef class _TSObject:
         int64_t value               # numpy dt64
         tzinfo tzinfo
         bint fold
-        NPY_DATETIMEUNIT reso
+        NPY_DATETIMEUNIT creso
 
-    cdef void ensure_reso(self, NPY_DATETIMEUNIT reso)
+    cdef void ensure_reso(self, NPY_DATETIMEUNIT creso)
 
 
 cdef _TSObject convert_to_tsobject(object ts, tzinfo tz, str unit,

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -205,16 +205,16 @@ cdef class _TSObject:
     #    int64_t value               # numpy dt64
     #    tzinfo tzinfo
     #    bint fold
-    #    NPY_DATETIMEUNIT reso
+    #    NPY_DATETIMEUNIT creso
 
     def __cinit__(self):
         # GH 25057. As per PEP 495, set fold to 0 by default
         self.fold = 0
-        self.reso = NPY_FR_ns  # default value
+        self.creso = NPY_FR_ns  # default value
 
-    cdef void ensure_reso(self, NPY_DATETIMEUNIT reso):
-        if self.reso != reso:
-            self.value = convert_reso(self.value, self.reso, reso, False)
+    cdef void ensure_reso(self, NPY_DATETIMEUNIT creso):
+        if self.creso != creso:
+            self.value = convert_reso(self.value, self.creso, creso, False)
 
 
 cdef _TSObject convert_to_tsobject(object ts, tzinfo tz, str unit,
@@ -246,7 +246,7 @@ cdef _TSObject convert_to_tsobject(object ts, tzinfo tz, str unit,
         obj.value = NPY_NAT
     elif is_datetime64_object(ts):
         reso = get_supported_reso(get_datetime64_unit(ts))
-        obj.reso = reso
+        obj.creso = reso
         obj.value = get_datetime64_nanos(ts, reso)
         if obj.value != NPY_NAT:
             pandas_datetime_to_datetimestruct(obj.value, reso, &obj.dts)
@@ -305,7 +305,7 @@ cdef _TSObject convert_to_tsobject(object ts, tzinfo tz, str unit,
         raise TypeError(f'Cannot convert input [{ts}] of type {type(ts)} to '
                         f'Timestamp')
 
-    maybe_localize_tso(obj, tz, obj.reso)
+    maybe_localize_tso(obj, tz, obj.creso)
     return obj
 
 

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -279,7 +279,7 @@ cdef class _Timestamp(ABCTimestamp):
             )
 
         obj.value = value
-        obj.reso = reso
+        obj.creso = reso
         pandas_datetime_to_datetimestruct(value, reso, &obj.dts)
         maybe_localize_tso(obj, tz, reso)
 
@@ -1675,7 +1675,7 @@ class Timestamp(_Timestamp):
             if not is_offset_object(freq):
                 freq = to_offset(freq)
 
-        return create_timestamp_from_ts(ts.value, ts.dts, ts.tzinfo, freq, ts.fold, ts.reso)
+        return create_timestamp_from_ts(ts.value, ts.dts, ts.tzinfo, freq, ts.fold, ts.creso)
 
     def _round(self, freq, mode, ambiguous='raise', nonexistent='raise'):
         cdef:


### PR DESCRIPTION
Based on the call on Wednesday I'm planning to make a reso keyword in Timestamp/Timedelta constructors, and change _as_unit to as_reso.  In preparation for that, I'm changing usages of reso to creso, and will be changing the existing _as_reso to _as_creso.