### PR TITLE
perf/minor performance improvement in `is_*_dtype` and `get_block_type` methods

### DIFF
--- a/asv_bench/benchmarks/dtypes.py
+++ b/asv_bench/benchmarks/dtypes.py
@@ -9,6 +9,7 @@ from pandas.api.types import (
     is_extension_array_dtype,
     pandas_dtype,
 )
+from pandas.core.internals.blocks import get_block_type
 
 from .pandas_vb_common import (
     datetime_dtypes,
@@ -122,6 +123,24 @@ class CheckDtypes:
 
     def time_is_extension_array_dtype_false(self):
         is_extension_array_dtype(self.np_dtype)
+
+
+class CheckGetBlockType:
+    dtype_instances = {
+        "sparse-ExtensionBlock": pd.SparseDtype(),
+        "CategoricalBlock": pd.CategoricalDtype(),
+        "NDArrayBackedExtensionBlock": pd.PeriodDtype(),
+        "ExtensionBlock": pd.BooleanDtype(),
+        "DatetimeTZBlock": pd.DatetimeTZDtype(tz="UTC"),
+        "DatetimeLikeBlock": np.dtype("M"),
+        "NumericBlock": np.dtype("i"),
+        "ObjectBlock": np.dtype("O"),
+    }
+    params = dtype_instances.keys()
+    param_names = ["case_name"]
+
+    def time_get_block_type(self, case_name):
+        get_block_type(self.dtype_instances[case_name])
 
 
 from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -160,6 +160,7 @@ Performance improvements
 - Performance improvements to :func:`read_sas` (:issue:`47403`, :issue:`47405`, :issue:`47656`, :issue:`48502`)
 - Memory improvement in :meth:`RangeIndex.sort_values` (:issue:`48801`)
 - Performance improvement in :class:`DataFrameGroupBy` and :class:`SeriesGroupBy` when ``by`` is a categorical type and ``sort=False`` (:issue:`48976`)
+- Performance improvement in ``is_*_dtype`` and :func:`get_block_type` methods (:issue:`48212`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_200.bug_fixes:


### PR DESCRIPTION
Improvements:
* use of `classes` in `is_*_dtype` avoid duplicate calls and will use a slightly simpler codepath in `isinstance` when possible
* `get_block_type` has unnecessary assignment removed - benchmarks added

- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] Check performance change with `asv`

`asv continuous -f 1.1 main HEAD -b 'dtypes.CheckGetBlockType|dtypes.CheckDtypes'`:
```
     <main>           <perf/cache-typing>
-        548±40ns          481±2ns     0.88  dtypes.CheckGetBlockType.time_get_block_type('DatetimeLikeBlock')
-        604±30ns          497±3ns     0.82  dtypes.CheckGetBlockType.time_get_block_type('NumericBlock')
-        602±20ns         479±10ns     0.80  dtypes.CheckGetBlockType.time_get_block_type('ExtensionBlock')
-        358±10ns          279±2ns     0.78  dtypes.CheckGetBlockType.time_get_block_type('CategoricalBlock')
-        653±20ns          500±4ns     0.77  dtypes.CheckGetBlockType.time_get_block_type('ObjectBlock')
-        616±20ns          238±3ns     0.39  dtypes.CheckGetBlockType.time_get_block_type('sparse-ExtensionBlock')
SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```

 * _lesson learned:_ some places in the code can use `type(dtype)` instead of `dtype`, so would be reasonably suitable for caching, but it looks like the complexity of that code is sufficiently low that adding caching (particularly via `@lru_cache(n)` which has a fairly costly implementation) causes a slowdown if applied in an untargeted way. Maybe the odd place could benefit from extracting the `isinstance(dtype, str)` branch in `ExtensionDtype.is_dtype` into a method which can be cached internally, but I haven't followed that line of enquiery as performance generally seems good enough with the unfurling in this branch
 * _Trivia:_ the codebase has improved over time as `__isinstance__` overrides have been removed, but prior to that (e.g. 1.1) those were quite slow - this change was originally inspired by finding slowness from those and `cls.construct_from_string(...)`