### PR TITLE
DOC: Fixed Issue: Typo of DataFrame.iat() in 10 minutes to panda

### DIFF
--- a/doc/source/user_guide/10min.rst
+++ b/doc/source/user_guide/10min.rst
@@ -233,7 +233,7 @@ For getting fast access to a scalar (equivalent to the prior method):
 Selection by position
 ~~~~~~~~~~~~~~~~~~~~~
 
-See more in :ref:`Selection by Position <indexing.integer>` using :meth:`DataFrame.iloc` or :meth:`DataFrame.at`.
+See more in :ref:`Selection by Position <indexing.integer>` using :meth:`DataFrame.iloc` or :meth:`DataFrame.iat`.
 
 Select via the position of the passed integers:
 


### PR DESCRIPTION
- [X] closes #49057
Made single character change to fix description of Selection by Position to refer to `DataFrame.iat()` vs` DataFrame.at()`