### PR TITLE
PERF: pd.concat with EA-backed indexes

### DIFF
--- a/asv_bench/benchmarks/array.py
+++ b/asv_bench/benchmarks/array.py
@@ -71,3 +71,6 @@ class ArrowStringArray:
 
     def time_setitem_slice(self, multiple_chunks):
         self.array[::10] = "foo"
+
+    def time_tolist(self, multiple_chunks):
+        self.array.tolist()

--- a/asv_bench/benchmarks/join_merge.py
+++ b/asv_bench/benchmarks/join_merge.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from pandas import (
     DataFrame,
+    Index,
     MultiIndex,
     Series,
     array,
@@ -90,6 +91,39 @@ class ConcatDataFrames:
 
     def time_f_ordered(self, axis, ignore_index):
         concat(self.frame_f, axis=axis, ignore_index=ignore_index)
+
+
+class ConcatIndexDtype:
+
+    params = (
+        ["datetime64[ns]", "int64", "Int64", "string[python]", "string[pyarrow]"],
+        [0, 1],
+        [True, False],
+        [True, False],
+    )
+    param_names = ["dtype", "axis", "sort", "is_monotonic"]
+
+    def setup(self, dtype, axis, sort, is_monotonic):
+        N = 10_000
+        if dtype == "datetime64[ns]":
+            vals = date_range("1970-01-01", periods=N)
+        elif dtype in ("int64", "Int64"):
+            vals = np.arange(N, dtype=np.int64)
+        elif dtype in ("string[python]", "string[pyarrow]"):
+            vals = tm.makeStringIndex(N)
+        else:
+            raise NotImplementedError
+
+        idx = Index(vals, dtype=dtype)
+        if is_monotonic:
+            idx = idx.sort_values()
+        else:
+            idx = idx[::-1]
+
+        self.series = [Series(i, idx[i:]) for i in range(5)]
+
+    def time_concat_series(self, dtype, axis, sort, is_monotonic):
+        concat(self.series, axis=axis, sort=sort)
 
 
 class Join:

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -154,6 +154,7 @@ Performance improvements
 - Performance improvement in :func:`merge` and :meth:`DataFrame.join` when joining on a sorted :class:`MultiIndex` (:issue:`48504`)
 - Performance improvement in :meth:`DataFrame.loc` and :meth:`Series.loc` for tuple-based indexing of a :class:`MultiIndex` (:issue:`48384`)
 - Performance improvement for :meth:`MultiIndex.unique` (:issue:`48335`)
+- Performance improvement for :func:`concat` with extension array backed indexes (:issue:`49128`)
 - Performance improvement in :meth:`DataFrame.join` when joining on a subset of a :class:`MultiIndex` (:issue:`48611`)
 - Performance improvement for :meth:`MultiIndex.intersection` (:issue:`48604`)
 - Performance improvement in ``var`` for nullable dtypes (:issue:`48379`).

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1455,8 +1455,7 @@ class ExtensionArray:
         """
         if self.ndim > 1:
             return [x.tolist() for x in self]
-        # faster than list(self)
-        return self.to_numpy(dtype="object").tolist()
+        return list(self)
 
     def delete(self: ExtensionArrayT, loc: PositionalIndexer) -> ExtensionArrayT:
         indexer = np.delete(np.arange(len(self)), loc)

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1456,7 +1456,7 @@ class ExtensionArray:
         if self.ndim > 1:
             return [x.tolist() for x in self]
         # faster than list(self)
-        return self.to_numpy().tolist()
+        return self.to_numpy(dtype="object").tolist()
 
     def delete(self: ExtensionArrayT, loc: PositionalIndexer) -> ExtensionArrayT:
         indexer = np.delete(np.arange(len(self)), loc)

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1455,7 +1455,8 @@ class ExtensionArray:
         """
         if self.ndim > 1:
             return [x.tolist() for x in self]
-        return list(self)
+        # faster than list(self)
+        return self.to_numpy().tolist()
 
     def delete(self: ExtensionArrayT, loc: PositionalIndexer) -> ExtensionArrayT:
         indexer = np.delete(np.arange(len(self)), loc)

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -427,6 +427,15 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
             data = self._data.astype(dtype, copy=copy)
         return data
 
+    @doc(ExtensionArray.tolist)
+    def tolist(self):
+        if self.ndim > 1:
+            return [x.tolist() for x in self]
+        if not self._hasna:
+            # faster than list(self)
+            return list(self._data)
+        return list(self)
+
     @overload
     def astype(self, dtype: npt.DTypeLike, copy: bool = ...) -> np.ndarray:
         ...

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -20,6 +20,7 @@ from pandas._typing import (
 )
 from pandas.compat import pa_version_under1p01
 from pandas.compat.numpy import function as nv
+from pandas.util._decorators import doc
 
 from pandas.core.dtypes.base import (
     ExtensionDtype,
@@ -214,7 +215,11 @@ class BaseStringArray(ExtensionArray):
     Mixin class for StringArray, ArrowStringArray.
     """
 
-    pass
+    @doc(ExtensionArray.tolist)
+    def tolist(self):
+        if self.ndim > 1:
+            return [x.tolist() for x in self]
+        return list(self.to_numpy())
 
 
 class StringArray(BaseStringArray, PandasArray):

--- a/pandas/tests/arrays/masked/test_function.py
+++ b/pandas/tests/arrays/masked/test_function.py
@@ -49,3 +49,9 @@ def test_round(data, numpy_dtype):
         dtype=data.dtype,
     )
     tm.assert_extension_array_equal(result, expected)
+
+
+def test_tolist(data):
+    result = data.tolist()
+    expected = list(data)
+    tm.assert_equal(result, expected)

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -611,3 +611,11 @@ def test_setitem_scalar_with_mask_validation(dtype):
         msg = "Scalar must be NA or str"
     with pytest.raises(ValueError, match=msg):
         ser[mask] = 1
+
+
+def test_tolist(dtype):
+    vals = ["a", "b", "c"]
+    arr = pd.array(vals, dtype=dtype)
+    result = arr.tolist()
+    expected = vals
+    tm.assert_equal(result, expected)


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.0.0.rst` file if fixing a bug or adding a new feature.


Perf improvement for `pd.concat` when objects contain EA-backed indexes. The bottleneck was `EA.tolist`. Still relatively slow vs non-EA, but an improvement. 

```
$ asv continuous -f 1.1 upstream/main ea-tolist -b join_merge.ConcatIndexDtype

       before           after         ratio
     [90b4add7]       [77a21f8d]
     <main>           <ea-tolist>
-      19.4±0.2ms      12.0±0.07ms     0.62  join_merge.ConcatIndexDtype.time_concat_series('Int64', 1, True, False)
-      14.6±0.2ms       6.78±0.2ms     0.46  join_merge.ConcatIndexDtype.time_concat_series('Int64', 1, True, True)
-      14.2±0.2ms       6.57±0.1ms     0.46  join_merge.ConcatIndexDtype.time_concat_series('Int64', 1, False, False)
-      14.1±0.2ms      6.47±0.09ms     0.46  join_merge.ConcatIndexDtype.time_concat_series('Int64', 1, False, True)
-      23.9±0.1ms       10.3±0.1ms     0.43  join_merge.ConcatIndexDtype.time_concat_series('string[python]', 1, True, False)
-      19.7±0.3ms      5.53±0.05ms     0.28  join_merge.ConcatIndexDtype.time_concat_series('string[python]', 1, True, True)
-      19.0±0.2ms      5.16±0.03ms     0.27  join_merge.ConcatIndexDtype.time_concat_series('string[python]', 1, False, True)
-      18.5±0.2ms      4.82±0.03ms     0.26  join_merge.ConcatIndexDtype.time_concat_series('string[python]', 1, False, False)
-         108±1ms       24.5±0.4ms     0.23  join_merge.ConcatIndexDtype.time_concat_series('string[pyarrow]', 1, True, False)
-      98.4±0.6ms       17.0±0.3ms     0.17  join_merge.ConcatIndexDtype.time_concat_series('string[pyarrow]', 1, True, True)
-      97.6±0.8ms       15.9±0.3ms     0.16  join_merge.ConcatIndexDtype.time_concat_series('string[pyarrow]', 1, False, True)
-      99.2±0.5ms       16.0±0.3ms     0.16  join_merge.ConcatIndexDtype.time_concat_series('string[pyarrow]', 1, False, False)
```

```
$ asv continuous -f 1.1 upstream/main ea-tolist -b array.ArrowStringArray

       before           after         ratio
     [90b4add7]       [77a21f8d]
     <main>           <ea-tolist>
-      16.5±0.2ms          399±6μs     0.02  array.ArrowStringArray.time_tolist(True)
-      17.1±0.2ms          404±6μs     0.02  array.ArrowStringArray.time_tolist(False)
```

