### PR TITLE
BUG: pd.offsets.MonthEnd() delevers wrong month

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -2477,7 +2477,6 @@ cdef class MonthEnd(MonthOffset):
     """
     DateOffset of one month end.
 
-     
     Parameters
     ----------
     n : int, default 1
@@ -2506,7 +2505,7 @@ cdef class MonthEnd(MonthOffset):
     
     >>> ts = pd.Timestamp(2022, 1, 31)
     >>> ts + pd.offsets.MonthEnd(n=0)
-    Timestamp('2022-01-31 00:00:00') 
+    Timestamp('2022-01-31 00:00:00')
     
     When ``n`` is set to 1 (default) it will be moved to the following month:
     
@@ -2514,7 +2513,7 @@ cdef class MonthEnd(MonthOffset):
     >>> ts + pd.offsets.MonthEnd(n=1)
     Timestamp('2022-02-28 00:00:00')
     
-      When ``n`` is set to 2, method offsets one additional month. And again depends whether given date is on on anchor point:
+    When ``n`` is set to 2, method offsets one additional month. And again depends whether given date is on on anchor point:
     
     >>> ts = pd.Timestamp(2022, 1, 1)
     >>> ts + pd.offsets.MonthEnd(n=2)

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -2476,12 +2476,42 @@ cdef class MonthOffset(SingleConstructorOffset):
 cdef class MonthEnd(MonthOffset):
     """
     DateOffset of one month end.
+    
+    When parameter n=0, always offset to the end of month.
+    
+    When parameter n=1, depend on the given date:
+        a) Given date is on an anchor point (last day of the month) -> offset to the end of the following month
+        b) Given date is not on an anchor point -> offset to the end of the same month
+   
+    
+    Parameters
+    ----------
+    n : int, default 1
+        
 
     Examples
     --------
     >>> ts = pd.Timestamp(2022, 1, 1)
-    >>> ts + pd.offsets.MonthEnd()
+    >>> ts + pd.offsets.MonthEnd(n=1)
     Timestamp('2022-01-31 00:00:00')
+    
+    >>> ts = pd.Timestamp(2022, 1, 31)
+    >>> ts + pd.offsets.MonthEnd(n=0)
+    Timestamp('2022-01-31 00:00:00')
+    
+    
+    >>> ts = pd.Timestamp(2022, 1, 31)
+    >>> ts + pd.offsets.MonthEnd(n=1)
+    Timestamp('2022-02-28 00:00:00')
+    
+    
+    >>> ts = pd.Timestamp(2022, 1, 31)
+    >>> ts + pd.offsets.MonthEnd(n=2)
+    Timestamp('2022-03-31 00:00:00')
+    
+    >>> ts = pd.Timestamp(2022, 1, 31)
+    >>> ts + pd.offsets.MonthEnd(n=-1)
+    Timestamp('2021-12-31 00:00:00')
     """
     _period_dtype_code = PeriodDtypeCode.M
     _prefix = "M"

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -2476,34 +2476,55 @@ cdef class MonthOffset(SingleConstructorOffset):
 cdef class MonthEnd(MonthOffset):
     """
     DateOffset of one month end.
-    
-    When parameter n=0, always offset to the end of month.
-    
-    When parameter n=1, depend on the given date:
-        a) Given date is on an anchor point (last day of the month) -> offset to the end of the following month.
-        b) Given date is not on an anchor point -> offset to the end of the same month.
-        
+
+     
     Parameters
     ----------
     n : int, default 1
+        n = 0 -> offset to the end of month.
+        n = 1 -> depend on the given date:
+            a) Given date is on an anchor point (last day of the month) -> offset to the end of the following month.
+            b) Given date is not on an anchor point -> offset to the end of the same month.
     
     Examples
     --------
+    Offset to the end of the month:
+    
     >>> ts = pd.Timestamp(2022, 1, 1)
-    >>> ts + pd.offsets.MonthEnd(n=1)
+    >>> ts + pd.offsets.MonthEnd()
     Timestamp('2022-01-31 00:00:00')
+    
+    However be careful, if given date is the last day of a month, method offsets to the end of the following month:
+    
+    >>> ts = pd.Timestamp(2022, 1, 31)
+    >>> ts + pd.offsets.MonthEnd()
+    Timestamp('2022-02-28 00:00:00')
+    
+    With the ``n`` parameter, we can control logic of offset.
+    
+    See below, when ``n`` is set to 0, offset is always made the end of the current month:
     
     >>> ts = pd.Timestamp(2022, 1, 31)
     >>> ts + pd.offsets.MonthEnd(n=0)
     Timestamp('2022-01-31 00:00:00') 
     
+    When ``n`` is set to 1 (default) it will be moved to the following month:
+    
     >>> ts = pd.Timestamp(2022, 1, 31)
     >>> ts + pd.offsets.MonthEnd(n=1)
+    Timestamp('2022-02-28 00:00:00')
+    
+      When ``n`` is set to 2, method offsets one additional month. And again depends whether given date is on on anchor point:
+    
+    >>> ts = pd.Timestamp(2022, 1, 1)
+    >>> ts + pd.offsets.MonthEnd(n=2)
     Timestamp('2022-02-28 00:00:00')
     
     >>> ts = pd.Timestamp(2022, 1, 31)
     >>> ts + pd.offsets.MonthEnd(n=2)
     Timestamp('2022-03-31 00:00:00')
+    
+    Also we can use negative ``n`` to find end of previous months:
     
     >>> ts = pd.Timestamp(2022, 1, 31)
     >>> ts + pd.offsets.MonthEnd(n=-1)

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -2501,7 +2501,7 @@ cdef class MonthEnd(MonthOffset):
     
     With the ``n`` parameter, we can control logic of offset.
     
-    See below, when ``n`` is set to 0, offset is always made the end of the current month:
+    See below, when ``n`` is set to 0, offset is always made to the end of the current month:
     
     >>> ts = pd.Timestamp(2022, 1, 31)
     >>> ts + pd.offsets.MonthEnd(n=0)

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -2513,7 +2513,7 @@ cdef class MonthEnd(MonthOffset):
     >>> ts + pd.offsets.MonthEnd(n=1)
     Timestamp('2022-02-28 00:00:00')
     
-    When ``n`` is set to 2, method offsets one additional month. And again depends whether given date is on on anchor point:
+    When ``n`` is set to 2, method offsets one additional month. And again depends whether given date is on an anchor point:
     
     >>> ts = pd.Timestamp(2022, 1, 1)
     >>> ts + pd.offsets.MonthEnd(n=2)

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -2480,15 +2480,13 @@ cdef class MonthEnd(MonthOffset):
     When parameter n=0, always offset to the end of month.
     
     When parameter n=1, depend on the given date:
-        a) Given date is on an anchor point (last day of the month) -> offset to the end of the following month
-        b) Given date is not on an anchor point -> offset to the end of the same month
-   
-    
+        a) Given date is on an anchor point (last day of the month) -> offset to the end of the following month.
+        b) Given date is not on an anchor point -> offset to the end of the same month.
+        
     Parameters
     ----------
     n : int, default 1
-        
-
+    
     Examples
     --------
     >>> ts = pd.Timestamp(2022, 1, 1)
@@ -2497,13 +2495,11 @@ cdef class MonthEnd(MonthOffset):
     
     >>> ts = pd.Timestamp(2022, 1, 31)
     >>> ts + pd.offsets.MonthEnd(n=0)
-    Timestamp('2022-01-31 00:00:00')
-    
+    Timestamp('2022-01-31 00:00:00') 
     
     >>> ts = pd.Timestamp(2022, 1, 31)
     >>> ts + pd.offsets.MonthEnd(n=1)
     Timestamp('2022-02-28 00:00:00')
-    
     
     >>> ts = pd.Timestamp(2022, 1, 31)
     >>> ts + pd.offsets.MonthEnd(n=2)


### PR DESCRIPTION
[DOC] - Added more examples and explanation regarding MonthEnd method.

- [ ] closes #48779
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.


