### PR TITLE
WEB/DOC: Fix typo in OVH name

### DIFF
--- a/doc/_templates/pandas_footer.html
+++ b/doc/_templates/pandas_footer.html
@@ -1,3 +1,3 @@
 <p class="copyright">
-    &copy {{copyright}} pandas via <a href="https://numfocus.org">NumFOCUS, Inc.</a> Hosted by <a href="https://www.ovhcloud.com">OVH Cloud</a>.
+    &copy {{copyright}} pandas via <a href="https://numfocus.org">NumFOCUS, Inc.</a> Hosted by <a href="https://www.ovhcloud.com">OVHcloud</a>.
 </p>

--- a/web/pandas/_templates/layout.html
+++ b/web/pandas/_templates/layout.html
@@ -91,7 +91,7 @@
                 </li>
             </ul>
             <p>
-                &copy; {{ current_year }} pandas via <a href="https://numfocus.org">NumFOCUS, Inc.</a> Hosted by <a href="https://www.ovhcloud.com">OVH Cloud</a>.
+                &copy; {{ current_year }} pandas via <a href="https://numfocus.org">NumFOCUS, Inc.</a> Hosted by <a href="https://www.ovhcloud.com">OVHcloud</a>.
             </p>
         </footer>
         


### PR DESCRIPTION
In #48557 and #48556, when adding the mention in the footer to OVH, I mistakenly used `OVH Cloud` instead of the name they use `OVHcloud`. Fixing it here.