### PR TITLE
Revert "PERF: faster corrwith method for pearson and spearman correlation when other is a Series and axis = 0 (column-wise) (#46174)"

### DIFF
--- a/doc/source/whatsnew/v1.5.1.rst
+++ b/doc/source/whatsnew/v1.5.1.rst
@@ -88,6 +88,7 @@ Fixed regressions
 - Fixed regression in :meth:`Series.groupby` and :meth:`DataFrame.groupby` when the grouper is a nullable data type (e.g. :class:`Int64`) or a PyArrow-backed string array, contains null values, and ``dropna=False`` (:issue:`48794`)
 - Fixed regression in :meth:`DataFrame.to_parquet` raising when file name was specified as ``bytes`` (:issue:`48944`)
 - Fixed regression in :class:`ExcelWriter` where the ``book`` attribute could no longer be set; however setting this attribute is now deprecated and this ability will be removed in a future version of pandas (:issue:`48780`)
+- Fixed regression in :meth:`DataFrame.corrwith` when computing correlation on tied data with ``method="spearman"`` (:issue:`48826`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/tests/frame/methods/test_cov_corr.py
+++ b/pandas/tests/frame/methods/test_cov_corr.py
@@ -410,6 +410,7 @@ class TestDataFrameCorrWith:
         expected = Series(np.ones(len(result)))
         tm.assert_series_equal(result, expected)
 
+    @td.skip_if_no_scipy
     def test_corrwith_spearman_with_tied_data(self):
         # GH#48826
         df1 = DataFrame(

--- a/pandas/tests/frame/methods/test_cov_corr.py
+++ b/pandas/tests/frame/methods/test_cov_corr.py
@@ -411,7 +411,7 @@ class TestDataFrameCorrWith:
         tm.assert_series_equal(result, expected)
 
     def test_corrwith_spearman_with_tied_data(self):
-        # GH#21925
+        # GH#48826
         df = DataFrame(
             {
                 "A": [2, 5, 8, 9],

--- a/pandas/tests/frame/methods/test_cov_corr.py
+++ b/pandas/tests/frame/methods/test_cov_corr.py
@@ -424,3 +424,11 @@ class TestDataFrameCorrWith:
         result = (df1 + 1).corrwith(df2.B, method="spearman")
         expected = Series([0.0, 1.0, 0.0], index=["A", "B", "C"])
         tm.assert_series_equal(result, expected)
+
+        df_bool = DataFrame(
+            {"A": [True, True, False, False], "B": [True, False, False, True]}
+        )
+        ser_bool = Series([True, True, False, True])
+        result = df_bool.corrwith(ser_bool)
+        expected = Series([0.57735, 0.57735], index=["A", "B"])
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/frame/methods/test_cov_corr.py
+++ b/pandas/tests/frame/methods/test_cov_corr.py
@@ -412,30 +412,14 @@ class TestDataFrameCorrWith:
 
     def test_corrwith_spearman_with_tied_data(self):
         # GH#48826
-        df = DataFrame(
+        df1 = DataFrame(
             {
-                "A": [2, 5, 8, 9],
-                "B": [2, np.nan, 8, 9],
-                "C": Series([2, np.nan, 8, 9], dtype="Int64"),
-                "D": [0, 1, 1, 0],
-                "E": [0, np.nan, 1, 0],
-                "F": Series([0, np.nan, 1, 0], dtype="Float64"),
-                "G": [False, True, True, False],
-                "H": Series([False, pd.NA, True, False], dtype="boolean"),
-            },
+                "A": [1, np.nan, 7, 8],
+                "B": [False, True, True, False],
+                "C": [10, 4, 9, 3],
+            }
         )
-        ser_list = [
-            Series([0, 1, 1, 0]),
-            Series([0.0, 1.0, 1.0, 0.0]),
-            Series([False, True, True, False]),
-            Series([0, pd.NA, 1, 0], dtype="Int64"),
-            Series([0, pd.NA, 1, 0], dtype="Float64"),
-            Series([False, pd.NA, True, False], dtype="boolean"),
-        ]
-        expected = Series(
-            [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
-            index=["A", "B", "C", "D", "E", "F", "G", "H"],
-        )
-        for ser in ser_list:
-            result = df.corrwith(ser, method="spearman", numeric_only=False)
-            tm.assert_series_equal(result, expected)
+        df2 = df1[["B", "C"]]
+        result = (df1 + 1).corrwith(df2.B, method="spearman")
+        expected = Series([0.0, 1.0, 0.0], index=["A", "B", "C"])
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #48826 (Replace xxxx with the GitHub issue number)
- [x] closes #49141
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Reverting for now - I've a test fix and whatsnew note from https://github.com/pandas-dev/pandas/pull/49032 , but have reverted the change and added the issue as a test so we can go ahead with 1.5.1. A fixed version of the performance improvement can go into 2.0.0