### PR TITLE
CLN use pd.Timestamp for single element in converter

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -253,7 +253,7 @@ Period
 
 Plotting
 ^^^^^^^^
--
+- ``ax.set_xlim`` was sometimes raising ``UserWarning`` which users couldn't address due to ``set_xlim`` not accepting parsing arguments - the converter now uses :func:`Timestamp` instead (:issue:`49148`)
 -
 
 Groupby/resample/rolling

--- a/pandas/plotting/_matplotlib/converter.py
+++ b/pandas/plotting/_matplotlib/converter.py
@@ -153,8 +153,6 @@ def _to_ordinalf(tm: pydt.time) -> float:
 def time2num(d):
     if isinstance(d, str):
         parsed = Timestamp(d)
-        if not isinstance(parsed, datetime):
-            raise ValueError(f"Could not parse time {d}")
         return _to_ordinalf(parsed.time())
     if isinstance(d, pydt.time):
         return _to_ordinalf(d)

--- a/pandas/plotting/_matplotlib/converter.py
+++ b/pandas/plotting/_matplotlib/converter.py
@@ -152,7 +152,7 @@ def _to_ordinalf(tm: pydt.time) -> float:
 
 def time2num(d):
     if isinstance(d, str):
-        parsed = tools.to_datetime(d)
+        parsed = Timestamp(d)
         if not isinstance(parsed, datetime):
             raise ValueError(f"Could not parse time {d}")
         return _to_ordinalf(parsed.time())


### PR DESCRIPTION
Only a single element is being parsed, and there's no way for a user to pass any options (like `dayfirst`) through `ax.set_xlim`, so might as well use `pd.Timestamp`.

Otherwise with https://github.com/pandas-dev/pandas/pull/49024 users might get a warning they wouldn't be able to do anything about

Example of test that hits this: `pytest pandas/tests/plotting/test_datetimelike.py -k test_time_change_xlim`