### PR TITLE
DOC: add closed and dtype in TimedeltaIndex parameters

### DIFF
--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -60,6 +60,11 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
         One of pandas date offset strings or corresponding objects. The string
         'infer' can be passed in order to set the frequency of the index as the
         inferred frequency upon creation.
+    closed : str, default None
+        Make the interval closed with respect to the given frequency to
+        the 'left', 'right', or both sides (None).
+    dtype : numpy.dtype or None, default dtype('<m8[ns]')
+        If None, dtype will be inferred.
     copy  : bool
         Make a copy of input ndarray.
     name : object


### PR DESCRIPTION
- [x] closes #49153 
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
