### PR TITLE
Help Pint-Pandas pass tests when HAS_UNCERTAINTIES is enabled

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1825,7 +1825,7 @@ class _iLocIndexer(_LocationIndexer):
 
         # we need an iterable, with a ndim of at least 1
         # eg. don't pass through np.array(0)
-        if is_list_like_indexer(value) and getattr(value, "ndim", 1) > 0:
+        if is_list_like_indexer(value) and np.iterable(value) and getattr(value, "ndim", 1) > 0:
 
             if isinstance(value, ABCDataFrame):
                 self._setitem_with_indexer_frame_value(indexer, value, name)
@@ -1977,6 +1977,7 @@ class _iLocIndexer(_LocationIndexer):
             pass
         elif (
             is_array_like(value)
+            and getattr(value, "shape", False)
             and len(value.shape) > 0
             and self.obj.shape[0] == value.shape[0]
             and not is_empty_indexer(pi)

--- a/pandas/tests/extension/base/setitem.py
+++ b/pandas/tests/extension/base/setitem.py
@@ -1,6 +1,15 @@
 import numpy as np
 import pytest
 
+try:
+    import uncertainties.unumpy as unp
+    from uncertainties import ufloat, UFloat
+    HAS_UNCERTAINTIES = True
+    _ufloat_nan = ufloat(np.nan, 0)
+except ImportError:
+    unp = np
+    HAS_UNCERTAINTIES = False
+
 from pandas.core.dtypes.dtypes import (
     DatetimeTZDtype,
     IntervalDtype,
@@ -97,7 +106,11 @@ class BaseSetitemTests(BaseExtensionTests):
         assert arr[0] == data[1]
 
     def test_setitem_loc_scalar_mixed(self, data):
-        df = pd.DataFrame({"A": np.arange(len(data)), "B": data})
+        if HAS_UNCERTAINTIES:
+            scalar_data = np.arange(len(data)) + ufloat(0, 0)
+        else:
+            scalar_data = np.arange(len(data))
+        df = pd.DataFrame({"A": scalar_data , "B": data})
         df.loc[0, "B"] = data[1]
         assert df.loc[0, "B"] == data[1]
 
@@ -112,7 +125,11 @@ class BaseSetitemTests(BaseExtensionTests):
         assert df.loc[10, "B"] == data[1]
 
     def test_setitem_iloc_scalar_mixed(self, data):
-        df = pd.DataFrame({"A": np.arange(len(data)), "B": data})
+        if HAS_UNCERTAINTIES:
+            scalar_data = np.arange(len(data)) + ufloat(0, 0)
+        else:
+            scalar_data = np.arange(len(data))
+        df = pd.DataFrame({"A": scalar_data , "B": data})
         df.iloc[0, 1] = data[1]
         assert df.loc[0, "B"] == data[1]
 
@@ -427,7 +444,10 @@ class BaseSetitemTests(BaseExtensionTests):
         # GH#40763
         ser = pd.Series(data, name="data")
 
-        taker = np.arange(len(ser))
+        if HAS_UNCERTAINTIES:
+            taker = np.arange(len(ser)) + ufloat(0, 0)
+        else:
+            taker = np.arange(len(ser))
         taker = np.delete(taker, 1)
 
         expected = ser[taker]


### PR DESCRIPTION
The Pint-Pandas testsuite relies on the Pandas test suite.  In the process of enabling support for uncertainties in Pint-Pandas, I discovered places where the base Pandas test suite needs to follow along.  I will extract the interesting test cases that triggered the need for these patches.

Signed-off-by: MichaelTiemann <72577720+MichaelTiemannOSC@users.noreply.github.com>

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
