### PR TITLE
BUG: CSV C engine raises an error on single line CSV with no header w…

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -252,7 +252,7 @@ MultiIndex
 I/O
 ^^^
 - Bug in :func:`read_sas` caused fragmentation of :class:`DataFrame` and raised :class:`.errors.PerformanceWarning` (:issue:`48595`)
-- Bug in :func:`read_csv` for a single-line csv with fewer columns than :parameter:`names` raised :class:`.errors.ParserError` r ``engine="c"`` (:issue:`47566`)
+- Bug in :func:`read_csv` for a single-line csv with fewer columns than ``names`` raised :class:`.errors.ParserError` with ``engine="c"`` (:issue:`47566`)
 -
 
 Period

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -252,6 +252,7 @@ MultiIndex
 I/O
 ^^^
 - Bug in :func:`read_sas` caused fragmentation of :class:`DataFrame` and raised :class:`.errors.PerformanceWarning` (:issue:`48595`)
+- Bug in :func:`read_csv` for a single-line csv with fewer columns than :parameter:`names` raised :class:`.errors.ParserError` r ``engine="c"`` (:issue:`47566`)
 -
 
 Period

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -744,6 +744,8 @@ cdef class TextReader:
         elif self.names is not None:
             # Names passed
             if self.parser.lines < 1:
+                if not self.has_usecols:
+                    self.parser.expected_fields = len(self.names)
                 self._tokenize_rows(1)
 
             header = [self.names]
@@ -756,6 +758,7 @@ cdef class TextReader:
             # Enforce this unless usecols
             if not self.has_usecols:
                 self.parser.expected_fields = max(field_count, len(self.names))
+
         else:
             # No header passed nor to be found in the file
             if self.parser.lines < 1:

--- a/pandas/tests/io/parser/common/test_common_basic.py
+++ b/pandas/tests/io/parser/common/test_common_basic.py
@@ -919,6 +919,26 @@ def test_malformed_second_line(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
+@xfail_pyarrow
+def test_short_single_line(all_parsers):
+    parser = all_parsers
+    columns = ["a", "b", "c"]
+    data = "1,2"
+    result = parser.read_csv(StringIO(data), header=None, names=columns)
+    expected = DataFrame({"a": [1], "b": [2], "c": [np.nan]})
+    tm.assert_frame_equal(result, expected)
+
+
+@xfail_pyarrow
+def test_short_multi_line(all_parsers):
+    parser = all_parsers
+    columns = ["a", "b", "c"]
+    data = "1,2\n1,2"
+    result = parser.read_csv(StringIO(data), header=None, names=columns)
+    expected = DataFrame({"a": [1, 1], "b": [2, 2], "c": [np.nan, np.nan]})
+    tm.assert_frame_equal(result, expected)
+
+
 def test_read_table_posargs_deprecation(all_parsers):
     # https://github.com/pandas-dev/pandas/issues/41485
     data = StringIO("a\tb\n1\t2")

--- a/pandas/tests/io/parser/common/test_common_basic.py
+++ b/pandas/tests/io/parser/common/test_common_basic.py
@@ -921,6 +921,7 @@ def test_malformed_second_line(all_parsers):
 
 @xfail_pyarrow
 def test_short_single_line(all_parsers):
+    # GH 47566
     parser = all_parsers
     columns = ["a", "b", "c"]
     data = "1,2"
@@ -931,6 +932,7 @@ def test_short_single_line(all_parsers):
 
 @xfail_pyarrow
 def test_short_multi_line(all_parsers):
+    # GH 47566
     parser = all_parsers
     columns = ["a", "b", "c"]
     data = "1,2\n1,2"


### PR DESCRIPTION
…hen passing extra names (#47566)

* Expect the provided number of columns when the names property is set

* Add tests to demonstrate handling of files with a single row with fewer columns.

- [x] closes #47566 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
