### PR TITLE
TYP: fix most pylint unpacking-non-sequence errors

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4640,7 +4640,7 @@ class Index(IndexOpsMixin, PandasObject):
         return_indexers: Literal[True],
         sort: bool = ...,
     ) -> tuple[Index, npt.NDArray[np.intp] | None, npt.NDArray[np.intp] | None]:
-        ...
+        raise NotImplementedError
 
     @overload
     def join(
@@ -4652,7 +4652,7 @@ class Index(IndexOpsMixin, PandasObject):
         return_indexers: Literal[False] = ...,
         sort: bool = ...,
     ) -> Index:
-        ...
+        raise NotImplementedError
 
     @overload
     def join(
@@ -4664,7 +4664,7 @@ class Index(IndexOpsMixin, PandasObject):
         return_indexers: bool = ...,
         sort: bool = ...,
     ) -> Index | tuple[Index, npt.NDArray[np.intp] | None, npt.NDArray[np.intp] | None]:
-        ...
+        raise NotImplementedError
 
     @final
     @deprecate_nonkeyword_arguments(version=None, allowed_args=["self", "other"])

--- a/pandas/io/parsers/base_parser.py
+++ b/pandas/io/parsers/base_parser.py
@@ -850,7 +850,7 @@ class ParserBase:
         names: Index,
         data: DataFrame,
     ) -> tuple[Sequence[Hashable] | Index, DataFrame]:
-        ...
+        raise NotImplementedError
 
     @overload
     def _do_date_conversions(
@@ -858,7 +858,7 @@ class ParserBase:
         names: Sequence[Hashable],
         data: Mapping[Hashable, ArrayLike],
     ) -> tuple[Sequence[Hashable], Mapping[Hashable, ArrayLike]]:
-        ...
+        raise NotImplementedError
 
     def _do_date_conversions(
         self,


### PR DESCRIPTION
- Related to https://github.com/pandas-dev/pandas/issues/48855
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This PR fixes most pylint unpacking-non-sequence errors. They were due to pylint not being able to handle `@overload` decorator, see https://github.com/PyCQA/astroid/issues/1015 
Adding `raise NotImplementedError`, as explained in [this stackoverflow question](https://stackoverflow.com/questions/72858185/pylint-false-attempting-to-unpack-a-non-sequence-unpacking-non-sequence) allows pylint to properly handle these methods.

We cannot yet remove the `"unpacking-non-sequence"` line from `pyproject.toml` since there are still two errors I couldn't fix:
```
************* Module pandas.core.reshape.reshape
pandas/core/reshape/reshape.py:161:8: E0633: Attempting to unpack a non-sequence defined at line 139 (unpacking-non-sequence)
pandas/core/reshape/reshape.py:165:8: E0633: Attempting to unpack a non-sequence defined at line 139 (unpacking-non-sequence)
```

Those are due to the `cache_readonly` decorator.
