### PR TITLE
Removed gitter from contributing_environment.rst

### DIFF
--- a/doc/source/development/community.rst
+++ b/doc/source/development/community.rst
@@ -100,6 +100,8 @@ The pandas mailing list `pandas-dev@python.org <mailto://pandas-dev@python
 conversations and to engages people in the wider community who might not
 be active on the issue tracker but we would like to include in discussions.
 
+.. _community.slack:
+
 Community slack
 ---------------
 

--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -95,7 +95,8 @@ installed (or you wish to install a newer version) you can install a compiler
 For other Linux distributions, consult your favorite search engine for
 compiler installation instructions.
 
-Let us know if you have any difficulties by opening an issue or reaching out on `Gitter <https://gitter.im/pydata/pandas/>`_.
+Let us know if you have any difficulties by opening an issue or reaching out on our contributor
+community :ref:`Slack <community.slack>`.
 
 .. _contributing.mamba:
 


### PR DESCRIPTION
Replaced gitter with the contributor community slack and linked to community.rst, for the instruction to join the slack


