### PR TITLE
CLN/FIX/PERF: Don't buffer entire Stata file into memory

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -6033,6 +6033,14 @@ values will have ``object`` data type.
    ``int64`` for all integer types and ``float64`` for floating point data.  By default,
    the Stata data types are preserved when importing.
 
+.. note::
+
+   All :class:`~pandas.io.stata.StataReader` objects, whether created by :func:`~pandas.read_stata`
+   (when using ``iterator=True`` or ``chunksize``) or instantiated by hand, must be used as context
+   managers (e.g. the ``with`` statement).
+   While the :meth:`~pandas.io.stata.StataReader.close` method is available, its use is unsupported.
+   It is not part of the public API and will be removed in with future without warning.
+
 .. ipython:: python
    :suppress:
 

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -857,6 +857,7 @@ Deprecations
 - Deprecated :meth:`Series.backfill` in favor of :meth:`Series.bfill` (:issue:`33396`)
 - Deprecated :meth:`DataFrame.pad` in favor of :meth:`DataFrame.ffill` (:issue:`33396`)
 - Deprecated :meth:`DataFrame.backfill` in favor of :meth:`DataFrame.bfill` (:issue:`33396`)
+- Deprecated :meth:`~pandas.io.stata.StataReader.close`. Use :class:`~pandas.io.stata.StataReader` as a context manager instead (:issue:`49228`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_200.prior_deprecations:

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -1163,6 +1163,8 @@ Performance improvements
 - Fixed a reference leak in :func:`read_hdf` (:issue:`37441`)
 - Fixed a memory leak in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing datetimes and timedeltas (:issue:`40443`)
 - Decreased memory usage in many :class:`DataFrameGroupBy` methods (:issue:`51090`)
+- Memory improvement in :class:`StataReader` when reading seekable files (:issue:`48922`)
+
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_200.bug_fixes:

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1233,7 +1233,7 @@ class StataReader(StataParser, abc.Iterator):
             "will be removed in a future version without notice. "
             "Using StataReader as a context manager is the only supported method.",
             FutureWarning,
-            stacklevel=2,
+            stacklevel=find_stack_level(),
         )
         if self._close_file:
             self._close_file()

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1706,7 +1706,6 @@ the string values returned are correct."""
         if (self._nobs == 0) and (nrows is None):
             self._can_read_value_labels = True
             self._data_read = True
-            self.close()
             return DataFrame(columns=self._varlist)
 
         # Handle options
@@ -1743,7 +1742,6 @@ the string values returned are correct."""
             # we are reading the file incrementally
             if convert_categoricals:
                 self._read_value_labels()
-            self.close()
             raise StopIteration
         offset = self._lines_read * dtype.itemsize
         self._path_or_buf.seek(self._data_location + offset)
@@ -1776,11 +1774,7 @@ the string values returned are correct."""
             data.index = Index(rng)  # set attr instead of set_index to avoid copy
 
         if columns is not None:
-            try:
-                data = self._do_select_columns(data, columns)
-            except ValueError:
-                self.close()
-                raise
+            data = self._do_select_columns(data, columns)
 
         # Decode strings
         for col, typ in zip(data, self._typlist):
@@ -1819,13 +1813,9 @@ the string values returned are correct."""
             cols = np.where([any_startswith(x) for x in self._fmtlist])[0]
             for i in cols:
                 col = data.columns[i]
-                try:
-                    data[col] = _stata_elapsed_date_to_datetime_vec(
-                        data[col], self._fmtlist[i]
-                    )
-                except ValueError:
-                    self.close()
-                    raise
+                data[col] = _stata_elapsed_date_to_datetime_vec(
+                    data[col], self._fmtlist[i]
+                )
 
         if convert_categoricals and self._format_version > 108:
             data = self._do_convert_categoricals(

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -183,10 +183,10 @@ Read a Stata dta file in 10,000 line chunks:
 >>> df = pd.DataFrame(values, columns=["i"])  # doctest: +SKIP
 >>> df.to_stata('filename.dta')  # doctest: +SKIP
 
->>> itr = pd.read_stata('filename.dta', chunksize=10000)  # doctest: +SKIP
->>> for chunk in itr:
-...    # Operate on a single chunk, e.g., chunk.mean()
-...    pass  # doctest: +SKIP
+>>> with pd.read_stata('filename.dta', chunksize=10000) as itr: # doctest: +SKIP
+>>>     for chunk in itr:
+...         # Operate on a single chunk, e.g., chunk.mean()
+...         pass  # doctest: +SKIP
 """
 
 _read_method_doc = f"""\

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1496,9 +1496,9 @@ class StataReader(StataParser, abc.Iterator):
         for i, typ in enumerate(self.typlist):
             if typ in self.NUMPY_TYPE_MAP:
                 typ = cast(str, typ)  # only strs in NUMPY_TYPE_MAP
-                dtypes.append(("s" + str(i), self.byteorder + self.NUMPY_TYPE_MAP[typ]))
+                dtypes.append((f"s{i}", f"{self.byteorder}{self.NUMPY_TYPE_MAP[typ]}"))
             else:
-                dtypes.append(("s" + str(i), "S" + str(typ)))
+                dtypes.append((f"s{i}", f"S{typ}"))
         self._dtype = np.dtype(dtypes)
 
         return self._dtype
@@ -1566,10 +1566,10 @@ the string values returned are correct."""
             n = self._read_uint32()
             txtlen = self._read_uint32()
             off = np.frombuffer(
-                self.path_or_buf.read(4 * n), dtype=self.byteorder + "i4", count=n
+                self.path_or_buf.read(4 * n), dtype=f"{self.byteorder}i4", count=n
             )
             val = np.frombuffer(
-                self.path_or_buf.read(4 * n), dtype=self.byteorder + "i4", count=n
+                self.path_or_buf.read(4 * n), dtype=f"{self.byteorder}i4", count=n
             )
             ii = np.argsort(off)
             off = off[ii]

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -736,10 +736,8 @@ class TestStata:
             original.to_stata(path, write_index=False)
 
             with StataReader(path) as sr:
-                typlist = sr.typlist
-                variables = sr.varlist
-                formats = sr.fmtlist
-                for variable, fmt, typ in zip(variables, formats, typlist):
+                sr._ensure_open()  # The `_*list` variables are initialized here
+                for variable, fmt, typ in zip(sr._varlist, sr._fmtlist, sr._typlist):
                     assert int(variable[1:]) == int(fmt[1:-1])
                     assert int(variable[1:]) == typ
 


### PR DESCRIPTION
Fixes #48700
Closes #48922 (supersedes it)
Refs pandas-dev/pandas#9245
Refs pandas-dev/pandas#37639
Regressed in 6d1541e1782a7b94797d5432922e64a97934cfa4

- [x] closes #48700
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
  - [x] The existing tests for e.g. roundtripping zstandard-compressed Stata files test this code path.
  - [x] Added a test that checks e.g. a fp or BytesIO passed in is the same object the reader reads. 
  - [x] Added a test that ensures a warning is raised if StataReader isn't being used as a context manager. 
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

---

This PR is a reworking of my earlier #48922, following @bashtage's suggestions. Unfortunately I couldn't quite make it fit in about 15 lines.

Compared to that PR, StataReader required some refactoring to have it behave as it has done before (see the discussion in the other PR) while also making it possible for it to raise a warning when data is being read without a `with` block being in use. (This does not take into account an user having code that doesn't use `with`, but that calls `.close()` by hand.)

The main refactoring is that all of the internal state of the reader object is now `_private`, and public bits are accessed via properties; this allows us to make sure the data is actually read when requested, even without reading happening in `__init__`. (Accessing those properties when the StataReader hasn't been `__enter__`ed will thus also raise a ResourceWarning.) As a bonus, the properties are now well-typed. Previously, e.g. `reader.time_stamp` had to rely on inference...

While renaming those properties, I noticed there was a bunch of repeated `struct.unpack(...read...)[0]` code that would have been `black` reformatted into very unwieldy lines following the addition of the underscores, so I decided to refactor the repeated code into smaller reading utility functions.

Finally, there's basically the same fix I made in #48922 – if the underlying stream is seekable, we can use it directly.

I also added a commit that removes the implicit automatic closing of the underlying stream, since it shouldn't be necessary anymore. If that should be removed from this PR, let me know.