### PR TITLE
STYLE: fix pylint consider-using-dict-items warnings

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -653,7 +653,7 @@ index_fixture2 = index
 
 @pytest.fixture(
     params=[
-        key for key in indices_dict if not isinstance(indices_dict[key], MultiIndex)
+        key for key, value in indices_dict.items() if not isinstance(value, MultiIndex)
     ]
 )
 def index_flat(request):
@@ -671,12 +671,12 @@ index_flat2 = index_flat
 @pytest.fixture(
     params=[
         key
-        for key in indices_dict
+        for key, value in indices_dict.items()
         if not (
             key in ["int", "uint", "range", "empty", "repeats", "bool-dtype"]
             or key.startswith("num_")
         )
-        and not isinstance(indices_dict[key], MultiIndex)
+        and not isinstance(value, MultiIndex)
     ]
 )
 def index_with_missing(request):

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -1646,9 +1646,8 @@ class TextFileReader(abc.Iterator):
 
         validate_header_arg(options["header"])
 
-        for arg in _deprecated_defaults.keys():
+        for arg, depr_default in _deprecated_defaults.items():
             parser_default = _c_parser_defaults.get(arg, parser_defaults[arg])
-            depr_default = _deprecated_defaults[arg]
             if result.get(arg, depr_default) != depr_default.default_value:
                 msg = (
                     f"The {arg} argument has been deprecated and will be "

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1853,8 +1853,8 @@ the string values returned are correct."""
             replacements[colname] = replacement
 
         if replacements:
-            for col in replacements:
-                data[col] = replacements[col]
+            for col, value in replacements.items():
+                data[col] = value
         return data
 
     def _insert_strls(self, data: DataFrame) -> DataFrame:

--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -301,7 +301,7 @@ class TestAstype:
         d = {"A": list("abbc"), "B": list("bccd"), "C": list("cdde")}
         df = DataFrame(d)
         result = df.astype(dtype)
-        expected = DataFrame({k: Categorical(d[k], dtype=dtype) for k in d})
+        expected = DataFrame({k: Categorical(v, dtype=dtype) for k, v in d.items()})
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize("cls", [CategoricalDtype, DatetimeTZDtype, IntervalDtype])

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -1827,11 +1827,11 @@ class TestDataFramePlots(TestPlotBase):
         # force a garbage collection
         gc.collect()
         msg = "weakly-referenced object no longer exists"
-        for key in results:
+        for result_value in results.values():
             # check that every plot was collected
             with pytest.raises(ReferenceError, match=msg):
                 # need to actually access something to get an error
-                results[key].lines
+                result_value.lines
 
     def test_df_gridspec_patterns(self):
         # GH 10819

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,6 @@ disable = [
 
  # pylint type "C": convention, for programming standard violation
   "consider-iterating-dictionary",
-  "consider-using-dict-items",
   "consider-using-f-string",
   "disallowed-name",
   "import-outside-toplevel",


### PR DESCRIPTION
Related to https://github.com/pandas-dev/pandas/issues/48855
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

`consider-using-dict-items` is also removed from the ignored warnings in `pyproject.toml`.
