### PR TITLE
DEPR: Enforce deprecation of mad and tshift

### DIFF
--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -35,7 +35,6 @@ method_blocklist = {
         "pct_change",
         "min",
         "var",
-        "mad",
         "describe",
         "std",
         "quantile",
@@ -52,7 +51,6 @@ method_blocklist = {
         "cummax",
         "pct_change",
         "var",
-        "mad",
         "describe",
         "std",
     },
@@ -437,7 +435,6 @@ class GroupByMethods:
             "first",
             "head",
             "last",
-            "mad",
             "max",
             "min",
             "median",
@@ -483,7 +480,7 @@ class GroupByMethods:
 
         if method == "describe":
             ngroups = 20
-        elif method in ["mad", "skew"]:
+        elif method == "skew":
             ngroups = 100
         else:
             ngroups = 1000

--- a/asv_bench/benchmarks/stat_ops.py
+++ b/asv_bench/benchmarks/stat_ops.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import pandas as pd
 
-ops = ["mean", "sum", "median", "std", "skew", "kurt", "mad", "prod", "sem", "var"]
+ops = ["mean", "sum", "median", "std", "skew", "kurt", "prod", "sem", "var"]
 
 
 class FrameOps:
@@ -11,9 +11,6 @@ class FrameOps:
     param_names = ["op", "dtype", "axis"]
 
     def setup(self, op, dtype, axis):
-        if op == "mad" and dtype == "Int64":
-            # GH-33036, GH#33600
-            raise NotImplementedError
         values = np.random.randn(100000, 4)
         if dtype == "Int64":
             values = values.astype(int)

--- a/doc/redirects.csv
+++ b/doc/redirects.csv
@@ -186,7 +186,6 @@ generated/pandas.core.groupby.DataFrameGroupBy.filter,../reference/api/pandas.co
 generated/pandas.core.groupby.DataFrameGroupBy.hist,../reference/api/pandas.core.groupby.DataFrameGroupBy.hist
 generated/pandas.core.groupby.DataFrameGroupBy.idxmax,../reference/api/pandas.core.groupby.DataFrameGroupBy.idxmax
 generated/pandas.core.groupby.DataFrameGroupBy.idxmin,../reference/api/pandas.core.groupby.DataFrameGroupBy.idxmin
-generated/pandas.core.groupby.DataFrameGroupBy.mad,../reference/api/pandas.core.groupby.DataFrameGroupBy.mad
 generated/pandas.core.groupby.DataFrameGroupBy.pct_change,../reference/api/pandas.core.groupby.DataFrameGroupBy.pct_change
 generated/pandas.core.groupby.DataFrameGroupBy.plot,../reference/api/pandas.core.groupby.DataFrameGroupBy.plot
 generated/pandas.core.groupby.DataFrameGroupBy.quantile,../reference/api/pandas.core.groupby.DataFrameGroupBy.quantile
@@ -196,7 +195,6 @@ generated/pandas.core.groupby.DataFrameGroupBy.shift,../reference/api/pandas.cor
 generated/pandas.core.groupby.DataFrameGroupBy.size,../reference/api/pandas.core.groupby.DataFrameGroupBy.size
 generated/pandas.core.groupby.DataFrameGroupBy.skew,../reference/api/pandas.core.groupby.DataFrameGroupBy.skew
 generated/pandas.core.groupby.DataFrameGroupBy.take,../reference/api/pandas.core.groupby.DataFrameGroupBy.take
-generated/pandas.core.groupby.DataFrameGroupBy.tshift,../reference/api/pandas.core.groupby.DataFrameGroupBy.tshift
 generated/pandas.core.groupby.GroupBy.agg,../reference/api/pandas.core.groupby.GroupBy.agg
 generated/pandas.core.groupby.GroupBy.aggregate,../reference/api/pandas.core.groupby.GroupBy.aggregate
 generated/pandas.core.groupby.GroupBy.all,../reference/api/pandas.core.groupby.GroupBy.all
@@ -415,7 +413,6 @@ generated/pandas.DataFrame.le,../reference/api/pandas.DataFrame.le
 generated/pandas.DataFrame.loc,../reference/api/pandas.DataFrame.loc
 generated/pandas.DataFrame.lookup,../reference/api/pandas.DataFrame.lookup
 generated/pandas.DataFrame.lt,../reference/api/pandas.DataFrame.lt
-generated/pandas.DataFrame.mad,../reference/api/pandas.DataFrame.mad
 generated/pandas.DataFrame.mask,../reference/api/pandas.DataFrame.mask
 generated/pandas.DataFrame.max,../reference/api/pandas.DataFrame.max
 generated/pandas.DataFrame.mean,../reference/api/pandas.DataFrame.mean
@@ -528,7 +525,6 @@ generated/pandas.DataFrame.transform,../reference/api/pandas.DataFrame.transform
 generated/pandas.DataFrame.transpose,../reference/api/pandas.DataFrame.transpose
 generated/pandas.DataFrame.truediv,../reference/api/pandas.DataFrame.truediv
 generated/pandas.DataFrame.truncate,../reference/api/pandas.DataFrame.truncate
-generated/pandas.DataFrame.tshift,../reference/api/pandas.DataFrame.tshift
 generated/pandas.DataFrame.tz_convert,../reference/api/pandas.DataFrame.tz_convert
 generated/pandas.DataFrame.tz_localize,../reference/api/pandas.DataFrame.tz_localize
 generated/pandas.DataFrame.unstack,../reference/api/pandas.DataFrame.unstack
@@ -1097,7 +1093,6 @@ generated/pandas.Series.last_valid_index,../reference/api/pandas.Series.last_val
 generated/pandas.Series.le,../reference/api/pandas.Series.le
 generated/pandas.Series.loc,../reference/api/pandas.Series.loc
 generated/pandas.Series.lt,../reference/api/pandas.Series.lt
-generated/pandas.Series.mad,../reference/api/pandas.Series.mad
 generated/pandas.Series.map,../reference/api/pandas.Series.map
 generated/pandas.Series.mask,../reference/api/pandas.Series.mask
 generated/pandas.Series.max,../reference/api/pandas.Series.max
@@ -1266,7 +1261,6 @@ generated/pandas.Series.transform,../reference/api/pandas.Series.transform
 generated/pandas.Series.transpose,../reference/api/pandas.Series.transpose
 generated/pandas.Series.truediv,../reference/api/pandas.Series.truediv
 generated/pandas.Series.truncate,../reference/api/pandas.Series.truncate
-generated/pandas.Series.tshift,../reference/api/pandas.Series.tshift
 generated/pandas.Series.tz_convert,../reference/api/pandas.Series.tz_convert
 generated/pandas.Series.tz_localize,../reference/api/pandas.Series.tz_localize
 generated/pandas.Series.unique,../reference/api/pandas.Series.unique

--- a/doc/source/reference/frame.rst
+++ b/doc/source/reference/frame.rst
@@ -151,7 +151,6 @@ Computations / descriptive stats
    DataFrame.eval
    DataFrame.kurt
    DataFrame.kurtosis
-   DataFrame.mad
    DataFrame.max
    DataFrame.mean
    DataFrame.median
@@ -268,7 +267,6 @@ Time Series-related
    DataFrame.asof
    DataFrame.shift
    DataFrame.slice_shift
-   DataFrame.tshift
    DataFrame.first_valid_index
    DataFrame.last_valid_index
    DataFrame.resample

--- a/doc/source/reference/groupby.rst
+++ b/doc/source/reference/groupby.rst
@@ -84,7 +84,6 @@ Function application
    DataFrameGroupBy.idxmax
    DataFrameGroupBy.idxmin
    DataFrameGroupBy.last
-   DataFrameGroupBy.mad
    DataFrameGroupBy.max
    DataFrameGroupBy.mean
    DataFrameGroupBy.median
@@ -108,7 +107,6 @@ Function application
    DataFrameGroupBy.var
    DataFrameGroupBy.tail
    DataFrameGroupBy.take
-   DataFrameGroupBy.tshift
    DataFrameGroupBy.value_counts
 
 ``SeriesGroupBy`` computations / descriptive stats
@@ -138,7 +136,6 @@ Function application
    SeriesGroupBy.idxmin
    SeriesGroupBy.is_monotonic_increasing
    SeriesGroupBy.is_monotonic_decreasing
-   SeriesGroupBy.mad
    SeriesGroupBy.max
    SeriesGroupBy.mean
    SeriesGroupBy.median
@@ -165,7 +162,6 @@ Function application
    SeriesGroupBy.var
    SeriesGroupBy.tail
    SeriesGroupBy.take
-   SeriesGroupBy.tshift
    SeriesGroupBy.value_counts
 
 Plotting and visualization

--- a/doc/source/reference/series.rst
+++ b/doc/source/reference/series.rst
@@ -148,7 +148,6 @@ Computations / descriptive stats
    Series.diff
    Series.factorize
    Series.kurt
-   Series.mad
    Series.max
    Series.mean
    Series.median
@@ -269,7 +268,6 @@ Time Series-related
    Series.tz_localize
    Series.at_time
    Series.between_time
-   Series.tshift
    Series.slice_shift
 
 Accessors

--- a/doc/source/user_guide/basics.rst
+++ b/doc/source/user_guide/basics.rst
@@ -556,7 +556,6 @@ optional ``level`` parameter which applies only if the object has a
     ``count``, Number of non-NA observations
     ``sum``, Sum of values
     ``mean``, Mean of values
-    ``mad``, Mean absolute deviation
     ``median``, Arithmetic median of values
     ``min``, Minimum
     ``max``, Maximum

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -196,7 +196,8 @@ Removal of prior version deprecations/changes
 - Removed ``pandas.SparseSeries`` and ``pandas.SparseDataFrame`` (:issue:`30642`)
 - Enforced disallowing a string column label into ``times`` in :meth:`DataFrame.ewm` (:issue:`43265`)
 - Enforced :meth:`Rolling.count` with ``min_periods=None`` to default to the size of the window (:issue:`31302`)
--
+- Removed the deprecated method ``mad`` from pandas classes (:issue:`11787`)
+- Removed the deprecated method ``tshift`` from pandas classes (:issue:`11631`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_200.performance:

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -280,7 +280,7 @@ ColspaceArgType = Union[
 ]
 
 # Arguments for fillna()
-FillnaOptions = Literal["backfill", "bfill", "ffill"]
+FillnaOptions = Literal["backfill", "bfill", "ffill", "pad"]
 
 # internals
 Manager = Union[

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -280,7 +280,7 @@ ColspaceArgType = Union[
 ]
 
 # Arguments for fillna()
-FillnaOptions = Literal["backfill", "bfill", "ffill", "pad"]
+FillnaOptions = Literal["backfill", "bfill", "ffill"]
 
 # internals
 Manager = Union[

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -557,7 +557,7 @@ class Apply(metaclass=abc.ABCMeta):
             sig = inspect.getfullargspec(func)
             arg_names = (*sig.args, *sig.kwonlyargs)
             if self.axis != 0 and (
-                "axis" not in arg_names or f in ("corrwith", "mad", "skew")
+                "axis" not in arg_names or f in ("corrwith", "skew")
             ):
                 raise ValueError(f"Operation {f} does not support axis=1")
             elif "axis" in arg_names:

--- a/pandas/core/groupby/base.py
+++ b/pandas/core/groupby/base.py
@@ -36,7 +36,6 @@ reduction_kernels = frozenset(
         "idxmax",
         "idxmin",
         "last",
-        "mad",
         "max",
         "mean",
         "median",
@@ -86,7 +85,6 @@ transformation_kernels = frozenset(
         "pct_change",
         "rank",
         "shift",
-        "tshift",
     ]
 )
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -880,18 +880,6 @@ class SeriesGroupBy(GroupBy[Series]):
         )
         return result
 
-    @doc(Series.mad.__doc__)
-    def mad(
-        self, axis: Axis | None = None, skipna: bool = True, level: Level | None = None
-    ) -> Series:
-        result = self._op_via_apply("mad", axis=axis, skipna=skipna, level=level)
-        return result
-
-    @doc(Series.tshift.__doc__)
-    def tshift(self, periods: int = 1, freq=None) -> Series:
-        result = self._op_via_apply("tshift", periods=periods, freq=freq)
-        return result
-
     @property
     @doc(Series.plot.__doc__)
     def plot(self):
@@ -2273,18 +2261,6 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
             numeric_only=numeric_only,
             **kwargs,
         )
-        return result
-
-    @doc(DataFrame.mad.__doc__)
-    def mad(
-        self, axis: Axis | None = None, skipna: bool = True, level: Level | None = None
-    ) -> DataFrame:
-        result = self._op_via_apply("mad", axis=axis, skipna=skipna, level=level)
-        return result
-
-    @doc(DataFrame.tshift.__doc__)
-    def tshift(self, periods: int = 1, freq=None, axis: Axis = 0) -> DataFrame:
-        result = self._op_via_apply("tshift", periods=periods, freq=freq, axis=axis)
         return result
 
     @property

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -3877,8 +3877,6 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         See Also
         --------
         Index.shift : Shift values of Index.
-        tshift : Shift the time index, using the index’s frequency
-            if available.
         """
         if freq is not None or axis != 0:
             f = lambda x: x.shift(periods, freq, axis, fill_value)

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -789,7 +789,6 @@ class BaseGrouper:
             result_values.append(res)
         # getattr pattern for __name__ is needed for functools.partial objects
         if len(group_keys) == 0 and getattr(f, "__name__", None) in [
-            "mad",
             "skew",
             "sum",
             "prod",

--- a/pandas/tests/apply/common.py
+++ b/pandas/tests/apply/common.py
@@ -1,10 +1,7 @@
 from pandas.core.groupby.base import transformation_kernels
 
-# tshift only works on time index and is deprecated
 # There is no Series.cumcount or DataFrame.cumcount
 series_transform_kernels = [
-    x for x in sorted(transformation_kernels) if x not in ["tshift", "cumcount"]
+    x for x in sorted(transformation_kernels) if x != "cumcount"
 ]
-frame_transform_kernels = [
-    x for x in sorted(transformation_kernels) if x not in ["tshift", "cumcount"]
-]
+frame_transform_kernels = [x for x in sorted(transformation_kernels) if x != "cumcount"]

--- a/pandas/tests/apply/test_frame_transform.py
+++ b/pandas/tests/apply/test_frame_transform.py
@@ -147,17 +147,14 @@ def test_transform_bad_dtype(op, frame_or_series, request):
     obj = DataFrame({"A": 3 * [object]})  # DataFrame that will fail on most transforms
     obj = tm.get_obj(obj, frame_or_series)
 
-    # tshift is deprecated
-    warn = None if op != "tshift" else FutureWarning
-    with tm.assert_produces_warning(warn):
-        with pytest.raises(TypeError, match="unsupported operand|not supported"):
-            obj.transform(op)
-        with pytest.raises(TypeError, match="Transform function failed"):
-            obj.transform([op])
-        with pytest.raises(TypeError, match="Transform function failed"):
-            obj.transform({"A": op})
-        with pytest.raises(TypeError, match="Transform function failed"):
-            obj.transform({"A": [op]})
+    with pytest.raises(TypeError, match="unsupported operand|not supported"):
+        obj.transform(op)
+    with pytest.raises(TypeError, match="Transform function failed"):
+        obj.transform([op])
+    with pytest.raises(TypeError, match="Transform function failed"):
+        obj.transform({"A": op})
+    with pytest.raises(TypeError, match="Transform function failed"):
+        obj.transform({"A": [op]})
 
 
 @pytest.mark.parametrize("op", frame_kernels_raise)

--- a/pandas/tests/arrays/categorical/test_operators.py
+++ b/pandas/tests/arrays/categorical/test_operators.py
@@ -374,8 +374,6 @@ class TestCategoricalOps:
             with pytest.raises(TypeError, match=msg):
                 getattr(s, op)(numeric_only=False)
 
-        # mad technically works because it takes always the numeric data
-
     def test_numeric_like_ops_series(self):
         # numpy ops
         s = Series(Categorical([1, 2, 3, 4]))

--- a/pandas/tests/frame/conftest.py
+++ b/pandas/tests/frame/conftest.py
@@ -277,7 +277,6 @@ def frame_of_index_cols():
         "sem",
         "var",
         "std",
-        "mad",
     ]
 )
 def reduction_functions(request):

--- a/pandas/tests/frame/methods/test_shift.py
+++ b/pandas/tests/frame/methods/test_shift.py
@@ -447,64 +447,6 @@ class TestDataFrameShift:
 
         tm.assert_frame_equal(result, expected)
 
-    @pytest.mark.filterwarnings("ignore:tshift is deprecated:FutureWarning")
-    def test_tshift(self, datetime_frame, frame_or_series):
-        # TODO(2.0): remove this test when tshift deprecation is enforced
-
-        # PeriodIndex
-        ps = tm.makePeriodFrame()
-        ps = tm.get_obj(ps, frame_or_series)
-        shifted = ps.tshift(1)
-        unshifted = shifted.tshift(-1)
-
-        tm.assert_equal(unshifted, ps)
-
-        shifted2 = ps.tshift(freq="B")
-        tm.assert_equal(shifted, shifted2)
-
-        shifted3 = ps.tshift(freq=offsets.BDay())
-        tm.assert_equal(shifted, shifted3)
-
-        msg = "Given freq M does not match PeriodIndex freq B"
-        with pytest.raises(ValueError, match=msg):
-            ps.tshift(freq="M")
-
-        # DatetimeIndex
-        dtobj = tm.get_obj(datetime_frame, frame_or_series)
-        shifted = dtobj.tshift(1)
-        unshifted = shifted.tshift(-1)
-
-        tm.assert_equal(dtobj, unshifted)
-
-        shifted2 = dtobj.tshift(freq=dtobj.index.freq)
-        tm.assert_equal(shifted, shifted2)
-
-        inferred_ts = DataFrame(
-            datetime_frame.values,
-            Index(np.asarray(datetime_frame.index)),
-            columns=datetime_frame.columns,
-        )
-        inferred_ts = tm.get_obj(inferred_ts, frame_or_series)
-        shifted = inferred_ts.tshift(1)
-
-        expected = dtobj.tshift(1)
-        expected.index = expected.index._with_freq(None)
-        tm.assert_equal(shifted, expected)
-
-        unshifted = shifted.tshift(-1)
-        tm.assert_equal(unshifted, inferred_ts)
-
-        no_freq = dtobj.iloc[[0, 5, 7]]
-        msg = "Freq was not set in the index hence cannot be inferred"
-        with pytest.raises(ValueError, match=msg):
-            no_freq.tshift()
-
-    def test_tshift_deprecated(self, datetime_frame, frame_or_series):
-        # GH#11631
-        dtobj = tm.get_obj(datetime_frame, frame_or_series)
-        with tm.assert_produces_warning(FutureWarning):
-            dtobj.tshift()
-
     def test_period_index_frame_shift_with_freq(self, frame_or_series):
         ps = tm.makePeriodFrame()
         ps = tm.get_obj(ps, frame_or_series)

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -69,7 +69,6 @@ def assert_stat_op_calc(
     skipna_alternative : function, default None
         NaN-safe version of alternative
     """
-    warn = FutureWarning if opname == "mad" else None
     f = getattr(frame, opname)
 
     if check_dates:
@@ -91,9 +90,8 @@ def assert_stat_op_calc(
             return alternative(x.values)
 
         skipna_wrapper = tm._make_skipna_wrapper(alternative, skipna_alternative)
-        with tm.assert_produces_warning(warn, match="The 'mad' method is deprecated"):
-            result0 = f(axis=0, skipna=False)
-            result1 = f(axis=1, skipna=False)
+        result0 = f(axis=0, skipna=False)
+        result1 = f(axis=1, skipna=False)
         tm.assert_series_equal(
             result0, frame.apply(wrapper), check_dtype=check_dtype, rtol=rtol, atol=atol
         )
@@ -106,9 +104,8 @@ def assert_stat_op_calc(
     else:
         skipna_wrapper = alternative
 
-    with tm.assert_produces_warning(warn, match="The 'mad' method is deprecated"):
-        result0 = f(axis=0)
-        result1 = f(axis=1)
+    result0 = f(axis=0)
+    result1 = f(axis=1)
     tm.assert_series_equal(
         result0,
         frame.apply(skipna_wrapper),
@@ -130,18 +127,14 @@ def assert_stat_op_calc(
         assert lcd_dtype == result1.dtype
 
     # bad axis
-    with tm.assert_produces_warning(warn, match="The 'mad' method is deprecated"):
-        with pytest.raises(ValueError, match="No axis named 2"):
-            f(axis=2)
+    with pytest.raises(ValueError, match="No axis named 2"):
+        f(axis=2)
 
     # all NA case
     if has_skipna:
         all_na = frame * np.NaN
-        with tm.assert_produces_warning(
-            warn, match="The 'mad' method is deprecated", raise_on_extra_warnings=False
-        ):
-            r0 = getattr(all_na, opname)(axis=0)
-            r1 = getattr(all_na, opname)(axis=1)
+        r0 = getattr(all_na, opname)(axis=0)
+        r1 = getattr(all_na, opname)(axis=1)
         if opname in ["sum", "prod"]:
             unit = 1 if opname == "prod" else 0  # result for empty sum/prod
             expected = Series(unit, index=r0.index, dtype=r0.dtype)
@@ -167,7 +160,6 @@ class TestDataFrameAnalytics:
             "min",
             "max",
             "nunique",
-            "mad",
             "var",
             "std",
             "sem",
@@ -176,13 +168,9 @@ class TestDataFrameAnalytics:
         ],
     )
     def test_stat_op_api_float_string_frame(self, float_string_frame, axis, opname):
-        warn = FutureWarning if opname == "mad" else None
-        with tm.assert_produces_warning(
-            warn, match="The 'mad' method is deprecated", raise_on_extra_warnings=False
-        ):
-            getattr(float_string_frame, opname)(axis=axis)
-            if opname not in ("nunique", "mad"):
-                getattr(float_string_frame, opname)(axis=axis, numeric_only=True)
+        getattr(float_string_frame, opname)(axis=axis)
+        if opname != "nunique":
+            getattr(float_string_frame, opname)(axis=axis, numeric_only=True)
 
     @pytest.mark.filterwarnings("ignore:Dropping of nuisance:FutureWarning")
     @pytest.mark.parametrize("axis", [0, 1])
@@ -212,9 +200,6 @@ class TestDataFrameAnalytics:
 
         def nunique(s):
             return len(algorithms.unique1d(s.dropna()))
-
-        def mad(x):
-            return np.abs(x - x.mean()).mean()
 
         def var(x):
             return np.var(x, ddof=1)
@@ -253,7 +238,6 @@ class TestDataFrameAnalytics:
             "product", np.prod, float_frame_with_na, skipna_alternative=np.nanprod
         )
 
-        assert_stat_op_calc("mad", mad, float_frame_with_na)
         assert_stat_op_calc("var", var, float_frame_with_na)
         assert_stat_op_calc("std", std, float_frame_with_na)
         assert_stat_op_calc("sem", sem, float_frame_with_na)
@@ -1490,14 +1474,6 @@ class TestDataFrameReductions:
         expected = Series(data=[False, True])
         tm.assert_series_equal(result, expected)
 
-    def test_reductions_deprecation_skipna_none(self, frame_or_series):
-        # GH#44580
-        obj = frame_or_series([1, 2, 3])
-        with tm.assert_produces_warning(
-            FutureWarning, match="skipna", raise_on_extra_warnings=False
-        ):
-            obj.mad(skipna=None)
-
     def test_reductions_deprecation_level_argument(
         self, frame_or_series, reduction_functions
     ):
@@ -1515,8 +1491,6 @@ class TestDataFrameReductions:
             request.node.add_marker(
                 pytest.mark.xfail(reason="Count does not accept skipna")
             )
-        elif reduction_functions == "mad":
-            pytest.skip("Mad is deprecated: GH#11787")
         obj = frame_or_series([1, 2, 3])
         msg = 'For argument "skipna" expected type bool, received type NoneType.'
         with pytest.raises(ValueError, match=msg):
@@ -1715,68 +1689,6 @@ def test_minmax_extensionarray(method, numeric_only):
     expected = Series(
         [getattr(int64_info, method)], index=Index(["Int64"], dtype="object")
     )
-    tm.assert_series_equal(result, expected)
-
-
-def test_mad_nullable_integer(any_signed_int_ea_dtype):
-    # GH#33036
-    df = DataFrame(np.random.randn(100, 4).astype(np.int64))
-    df2 = df.astype(any_signed_int_ea_dtype)
-
-    with tm.assert_produces_warning(
-        FutureWarning, match="The 'mad' method is deprecated"
-    ):
-        result = df2.mad()
-        expected = df.mad()
-    tm.assert_series_equal(result, expected)
-
-    with tm.assert_produces_warning(
-        FutureWarning, match="The 'mad' method is deprecated"
-    ):
-        result = df2.mad(axis=1)
-        expected = df.mad(axis=1)
-    tm.assert_series_equal(result, expected)
-
-    # case with NAs present
-    df2.iloc[::2, 1] = pd.NA
-
-    with tm.assert_produces_warning(
-        FutureWarning, match="The 'mad' method is deprecated"
-    ):
-        result = df2.mad()
-        expected = df.mad()
-        expected[1] = df.iloc[1::2, 1].mad()
-    tm.assert_series_equal(result, expected)
-
-    with tm.assert_produces_warning(
-        FutureWarning, match="The 'mad' method is deprecated"
-    ):
-        result = df2.mad(axis=1)
-        expected = df.mad(axis=1)
-        expected[::2] = df.T.loc[[0, 2, 3], ::2].mad()
-    tm.assert_series_equal(result, expected)
-
-
-@pytest.mark.xfail(reason="GH#42895 caused by lack of 2D EA")
-def test_mad_nullable_integer_all_na(any_signed_int_ea_dtype):
-    # GH#33036
-    df = DataFrame(np.random.randn(100, 4).astype(np.int64))
-    df2 = df.astype(any_signed_int_ea_dtype)
-
-    # case with all-NA row/column
-    msg = "will attempt to set the values inplace instead"
-    with tm.assert_produces_warning(FutureWarning, match=msg):
-        df2.iloc[:, 1] = pd.NA  # FIXME(GH#44199): this doesn't operate in-place
-        df2.iloc[:, 1] = pd.array([pd.NA] * len(df2), dtype=any_signed_int_ea_dtype)
-
-    with tm.assert_produces_warning(
-        FutureWarning, match="The 'mad' method is deprecated"
-    ):
-        result = df2.mad()
-        expected = df.mad()
-
-    expected[1] = pd.NA
-    expected = expected.astype("Float64")
     tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/generic/test_finalize.py
+++ b/pandas/tests/generic/test_finalize.py
@@ -395,22 +395,6 @@ _all_methods = [
     (pd.DataFrame, frame_data, operator.methodcaller("where", np.array([[True]]))),
     (pd.Series, ([1, 2],), operator.methodcaller("mask", np.array([True, False]))),
     (pd.DataFrame, frame_data, operator.methodcaller("mask", np.array([[True]]))),
-    pytest.param(
-        (
-            pd.Series,
-            (1, pd.date_range("2000", periods=4)),
-            operator.methodcaller("tshift"),
-        ),
-        marks=pytest.mark.filterwarnings("ignore::FutureWarning"),
-    ),
-    pytest.param(
-        (
-            pd.DataFrame,
-            ({"A": [1, 1, 1, 1]}, pd.date_range("2000", periods=4)),
-            operator.methodcaller("tshift"),
-        ),
-        marks=pytest.mark.filterwarnings("ignore::FutureWarning"),
-    ),
     (pd.Series, ([1, 2],), operator.methodcaller("truncate", before=0)),
     (pd.DataFrame, frame_data, operator.methodcaller("truncate", before=0)),
     (

--- a/pandas/tests/groupby/__init__.py
+++ b/pandas/tests/groupby/__init__.py
@@ -22,6 +22,4 @@ def get_groupby_method_args(name, obj):
         return (0.5,)
     if name == "corrwith":
         return (obj,)
-    if name == "tshift":
-        return (0, 0)
     return ()

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -1348,13 +1348,11 @@ def test_groupby_aggregate_directory(reduction_func):
     # GH#32793
     if reduction_func in ["corrwith", "nth"]:
         return None
-    warn = FutureWarning if reduction_func == "mad" else None
 
     obj = DataFrame([[0, 1], [0, np.nan]])
 
-    with tm.assert_produces_warning(warn, match="The 'mad' method is deprecated"):
-        result_reduced_series = obj.groupby(0).agg(reduction_func)
-        result_reduced_frame = obj.groupby(0).agg({1: reduction_func})
+    result_reduced_series = obj.groupby(0).agg(reduction_func)
+    result_reduced_frame = obj.groupby(0).agg({1: reduction_func})
 
     if reduction_func in ["size", "ngroup"]:
         # names are different: None / 1

--- a/pandas/tests/groupby/test_api_consistency.py
+++ b/pandas/tests/groupby/test_api_consistency.py
@@ -98,8 +98,6 @@ def test_series_consistency(request, groupby_func):
         exclude_expected = {"kwargs", "bool_only", "level", "axis"}
     elif groupby_func in ("count",):
         exclude_expected = {"level"}
-    elif groupby_func in ("tshift",):
-        exclude_expected = {"axis"}
     elif groupby_func in ("diff",):
         exclude_result = {"axis"}
     elif groupby_func in ("max", "min"):

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -1048,8 +1048,6 @@ def test_apply_with_timezones_aware():
 def test_apply_is_unchanged_when_other_methods_are_called_first(reduction_func):
     # GH #34656
     # GH #34271
-    warn = FutureWarning if reduction_func == "mad" else None
-
     df = DataFrame(
         {
             "a": [99, 99, 99, 88, 88, 88],
@@ -1071,8 +1069,7 @@ def test_apply_is_unchanged_when_other_methods_are_called_first(reduction_func):
     # Check output when another method is called before .apply()
     grp = df.groupby(by="a")
     args = get_groupby_method_args(reduction_func, df)
-    with tm.assert_produces_warning(warn, match="The 'mad' method is deprecated"):
-        _ = getattr(grp, reduction_func)(*args)
+    _ = getattr(grp, reduction_func)(*args)
     result = grp.apply(sum)
     tm.assert_frame_equal(result, expected)
 
@@ -1338,7 +1335,6 @@ def test_result_name_when_one_group(name):
     [
         ("apply", lambda gb: gb.values[-1]),
         ("apply", lambda gb: gb["b"].iloc[0]),
-        ("agg", "mad"),
         ("agg", "skew"),
         ("agg", "prod"),
         ("agg", "sum"),

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -49,7 +49,6 @@ _results_for_groupbys_with_missing_categories = {
     "idxmax": np.NaN,
     "idxmin": np.NaN,
     "last": np.NaN,
-    "mad": np.NaN,
     "max": np.NaN,
     "mean": np.NaN,
     "median": np.NaN,
@@ -1365,7 +1364,6 @@ def test_series_groupby_on_2_categoricals_unobserved(reduction_func, observed, r
             reason="TODO: implemented SeriesGroupBy.corrwith. See GH 32293"
         )
         request.node.add_marker(mark)
-    warn = FutureWarning if reduction_func == "mad" else None
 
     df = DataFrame(
         {
@@ -1380,8 +1378,7 @@ def test_series_groupby_on_2_categoricals_unobserved(reduction_func, observed, r
 
     series_groupby = df.groupby(["cat_1", "cat_2"], observed=observed)["value"]
     agg = getattr(series_groupby, reduction_func)
-    with tm.assert_produces_warning(warn, match="The 'mad' method is deprecated"):
-        result = agg(*args)
+    result = agg(*args)
 
     assert len(result) == expected_length
 
@@ -1400,7 +1397,6 @@ def test_series_groupby_on_2_categoricals_unobserved_zeroes_or_nans(
             reason="TODO: implemented SeriesGroupBy.corrwith. See GH 32293"
         )
         request.node.add_marker(mark)
-    warn = FutureWarning if reduction_func == "mad" else None
 
     df = DataFrame(
         {
@@ -1414,8 +1410,7 @@ def test_series_groupby_on_2_categoricals_unobserved_zeroes_or_nans(
 
     series_groupby = df.groupby(["cat_1", "cat_2"], observed=False)["value"]
     agg = getattr(series_groupby, reduction_func)
-    with tm.assert_produces_warning(warn, match="The 'mad' method is deprecated"):
-        result = agg(*args)
+    result = agg(*args)
 
     zero_or_nan = _results_for_groupbys_with_missing_categories[reduction_func]
 
@@ -1438,7 +1433,6 @@ def test_dataframe_groupby_on_2_categoricals_when_observed_is_true(reduction_fun
     # does not return the categories that are not in df when observed=True
     if reduction_func == "ngroup":
         pytest.skip("ngroup does not return the Categories on the index")
-    warn = FutureWarning if reduction_func == "mad" else None
 
     df = DataFrame(
         {
@@ -1452,8 +1446,7 @@ def test_dataframe_groupby_on_2_categoricals_when_observed_is_true(reduction_fun
     df_grp = df.groupby(["cat_1", "cat_2"], observed=True)
 
     args = get_groupby_method_args(reduction_func, df)
-    with tm.assert_produces_warning(warn, match="The 'mad' method is deprecated"):
-        res = getattr(df_grp, reduction_func)(*args)
+    res = getattr(df_grp, reduction_func)(*args)
 
     for cat in unobserved_cats:
         assert cat not in res.index
@@ -1470,7 +1463,6 @@ def test_dataframe_groupby_on_2_categoricals_when_observed_is_false(
 
     if reduction_func == "ngroup":
         pytest.skip("ngroup does not return the Categories on the index")
-    warn = FutureWarning if reduction_func == "mad" else None
 
     df = DataFrame(
         {
@@ -1484,8 +1476,7 @@ def test_dataframe_groupby_on_2_categoricals_when_observed_is_false(
     df_grp = df.groupby(["cat_1", "cat_2"], observed=observed)
 
     args = get_groupby_method_args(reduction_func, df)
-    with tm.assert_produces_warning(warn, match="The 'mad' method is deprecated"):
-        res = getattr(df_grp, reduction_func)(*args)
+    res = getattr(df_grp, reduction_func)(*args)
 
     expected = _results_for_groupbys_with_missing_categories[reduction_func]
 

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -323,23 +323,6 @@ class TestGroupByNonCythonPaths:
             result = gb.idxmin()
         tm.assert_frame_equal(result, expected)
 
-    def test_mad(self, gb, gni):
-        # mad
-        expected = DataFrame([[0], [np.nan]], columns=["B"], index=[1, 3])
-        expected.index.name = "A"
-        with tm.assert_produces_warning(
-            FutureWarning, match="The 'mad' method is deprecated"
-        ):
-            result = gb.mad()
-        tm.assert_frame_equal(result, expected)
-
-        expected = DataFrame([[1, 0.0], [3, np.nan]], columns=["A", "B"], index=[0, 1])
-        with tm.assert_produces_warning(
-            FutureWarning, match="The 'mad' method is deprecated"
-        ):
-            result = gni.mad()
-        tm.assert_frame_equal(result, expected)
-
     def test_describe(self, df, gb, gni):
         # describe
         expected_index = Index([1, 3], name="A")
@@ -560,8 +543,6 @@ def test_idxmin_idxmax_axis1():
 def test_axis1_numeric_only(request, groupby_func, numeric_only):
     if groupby_func in ("idxmax", "idxmin"):
         pytest.skip("idxmax and idx_min tested in test_idxmin_idxmax_axis1")
-    if groupby_func in ("mad", "tshift"):
-        pytest.skip("mad and tshift are deprecated")
     if groupby_func in ("corrwith", "skew"):
         msg = "GH#47723 groupby.corrwith and skew do not correctly implement axis=1"
         request.node.add_marker(pytest.mark.xfail(reason=msg))
@@ -1460,7 +1441,7 @@ def test_deprecate_numeric_only(
 @pytest.mark.parametrize("dtype", [bool, int, float, object])
 def test_deprecate_numeric_only_series(dtype, groupby_func, request):
     # GH#46560
-    if groupby_func in ("backfill", "mad", "pad", "tshift"):
+    if groupby_func in ("backfill", "pad"):
         pytest.skip("method is deprecated")
     elif groupby_func == "corrwith":
         msg = "corrwith is not implemented on SeriesGroupBy"

--- a/pandas/tests/groupby/test_groupby_subclass.py
+++ b/pandas/tests/groupby/test_groupby_subclass.py
@@ -20,7 +20,6 @@ from pandas.tests.groupby import get_groupby_method_args
         tm.SubclassedSeries(np.arange(0, 10), name="A"),
     ],
 )
-@pytest.mark.filterwarnings("ignore:tshift is deprecated:FutureWarning")
 def test_groupby_preserves_subclass(obj, groupby_func):
     # GH28330 -- preserve subclass through groupby operations
 
@@ -28,7 +27,6 @@ def test_groupby_preserves_subclass(obj, groupby_func):
         pytest.skip(f"Not applicable for Series and {groupby_func}")
     # TODO(2.0) Remove after pad/backfill deprecation enforced
     groupby_func = maybe_normalize_deprecated_kernels(groupby_func)
-    warn = FutureWarning if groupby_func in ("mad", "tshift") else None
 
     grouped = obj.groupby(np.arange(0, 10))
 
@@ -37,9 +35,8 @@ def test_groupby_preserves_subclass(obj, groupby_func):
 
     args = get_groupby_method_args(groupby_func, obj)
 
-    with tm.assert_produces_warning(warn, match="is deprecated"):
-        result1 = getattr(grouped, groupby_func)(*args)
-        result2 = grouped.agg(groupby_func, *args)
+    result1 = getattr(grouped, groupby_func)(*args)
+    result2 = grouped.agg(groupby_func, *args)
 
     # Reduction or transformation kernels should preserve type
     slices = {"ngroup", "cumcount", "size"}


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
