### PR TITLE
Improve error message about duplicate columns in df.explode

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8939,7 +8939,11 @@ Parrot 2  Parrot       24.0
         3    4  1    e
         """
         if not self.columns.is_unique:
-            raise ValueError("columns must be unique")
+            duplicate_cols = self.columns[self.columns.duplicated()].tolist()
+            raise ValueError(
+                "data frame columns must be unique. "
+                + f"Duplicate columns: {duplicate_cols}"
+            )
 
         columns: list[Hashable]
         if is_scalar(column) or isinstance(column, tuple):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8941,7 +8941,7 @@ Parrot 2  Parrot       24.0
         if not self.columns.is_unique:
             duplicate_cols = self.columns[self.columns.duplicated()].tolist()
             raise ValueError(
-                "data frame columns must be unique. "
+                "DataFrame columns must be unique. "
                 + f"Duplicate columns: {duplicate_cols}"
             )
 

--- a/pandas/tests/frame/methods/test_explode.py
+++ b/pandas/tests/frame/methods/test_explode.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import pytest
 
@@ -18,7 +20,10 @@ def test_error():
         df.explode(list("AA"))
 
     df.columns = list("AA")
-    with pytest.raises(ValueError, match="columns must be unique"):
+    with pytest.raises(
+        ValueError,
+        match=re.escape("data frame columns must be unique. Duplicate columns: ['A']"),
+    ):
         df.explode("A")
 
 

--- a/pandas/tests/frame/methods/test_explode.py
+++ b/pandas/tests/frame/methods/test_explode.py
@@ -22,7 +22,7 @@ def test_error():
     df.columns = list("AA")
     with pytest.raises(
         ValueError,
-        match=re.escape("data frame columns must be unique. Duplicate columns: ['A']"),
+        match=re.escape("DataFrame columns must be unique. Duplicate columns: ['A']"),
     ):
         df.explode("A")
 


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This is an attempt to improve the error message happening when exploding a column in a data frame with duplicate columns. 

As a newbie with pandas, it was really confusing to me why this happens – I was looking for a key inside the exploded column that would cause a duplicate. Eventually, I had to go to the source code to understand that it was not related. 

If listing the duplicate columns is too much/not a standard practice, I would vote for changing it at least to something like `data frame columns must be unique`.

