### PR TITLE
TST: un-xfail clipboard test on mac

### DIFF
--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -4,6 +4,7 @@ from textwrap import dedent
 import numpy as np
 import pytest
 
+from pandas.compat import is_platform_mac
 from pandas.errors import (
     PyperclipException,
     PyperclipWindowsException,
@@ -393,7 +394,7 @@ class TestClipboard:
     @pytest.mark.single_cpu
     @pytest.mark.parametrize("data", ["\U0001f44d...", "Ωœ∑´...", "abcd..."])
     @pytest.mark.xfail(
-        os.environ.get("DISPLAY") is None,
+        os.environ.get("DISPLAY") is None and not is_platform_mac(),
         reason="Cannot be runed if a headless system is not put in place with Xvfb",
         strict=True,
     )


### PR DESCRIPTION
- [x] closes #48721 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
