### PR TITLE
DEPR: enforce deprecation of slice_shift

### DIFF
--- a/doc/redirects.csv
+++ b/doc/redirects.csv
@@ -484,7 +484,6 @@ generated/pandas.DataFrame.shape,../reference/api/pandas.DataFrame.shape
 generated/pandas.DataFrame.shift,../reference/api/pandas.DataFrame.shift
 generated/pandas.DataFrame.size,../reference/api/pandas.DataFrame.size
 generated/pandas.DataFrame.skew,../reference/api/pandas.DataFrame.skew
-generated/pandas.DataFrame.slice_shift,../reference/api/pandas.DataFrame.slice_shift
 generated/pandas.DataFrame.sort_index,../reference/api/pandas.DataFrame.sort_index
 generated/pandas.DataFrame.sort_values,../reference/api/pandas.DataFrame.sort_values
 generated/pandas.DataFrame.squeeze,../reference/api/pandas.DataFrame.squeeze
@@ -1166,7 +1165,6 @@ generated/pandas.Series.shape,../reference/api/pandas.Series.shape
 generated/pandas.Series.shift,../reference/api/pandas.Series.shift
 generated/pandas.Series.size,../reference/api/pandas.Series.size
 generated/pandas.Series.skew,../reference/api/pandas.Series.skew
-generated/pandas.Series.slice_shift,../reference/api/pandas.Series.slice_shift
 generated/pandas.Series.sort_index,../reference/api/pandas.Series.sort_index
 generated/pandas.Series.sort_values,../reference/api/pandas.Series.sort_values
 generated/pandas.Series.sparse.density,../reference/api/pandas.Series.sparse.density

--- a/doc/source/reference/frame.rst
+++ b/doc/source/reference/frame.rst
@@ -266,7 +266,6 @@ Time Series-related
    DataFrame.asfreq
    DataFrame.asof
    DataFrame.shift
-   DataFrame.slice_shift
    DataFrame.first_valid_index
    DataFrame.last_valid_index
    DataFrame.resample

--- a/doc/source/reference/series.rst
+++ b/doc/source/reference/series.rst
@@ -268,7 +268,6 @@ Time Series-related
    Series.tz_localize
    Series.at_time
    Series.between_time
-   Series.slice_shift
 
 Accessors
 ---------

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -192,6 +192,7 @@ Removal of prior version deprecations/changes
 - Removed the ``numeric_only`` keyword from :meth:`Categorical.min` and :meth:`Categorical.max` in favor of ``skipna`` (:issue:`48821`)
 - Removed :func:`is_extension_type` in favor of :func:`is_extension_array_dtype` (:issue:`29457`)
 - Removed :meth:`Index.get_value` and :meth:`Index.set_value` (:issue:`33907`, :issue:`28621`)
+- Removed :meth:`Series.slice_shift` and :meth:`DataFrame.slice_shift` (:issue:`37601`)
 - Remove :meth:`DataFrameGroupBy.pad` and :meth:`DataFrameGroupBy.backfill` (:issue:`45076`)
 - Remove ``numpy`` argument from :func:`read_json` (:issue:`30636`)
 - Removed the ``center`` keyword in :meth:`DataFrame.expanding` (:issue:`20647`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10219,57 +10219,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         result = self.set_axis(new_ax, axis=axis)
         return result.__finalize__(self, method="shift")
 
-    @final
-    def slice_shift(self: NDFrameT, periods: int = 1, axis: Axis = 0) -> NDFrameT:
-        """
-        Equivalent to `shift` without copying data.
-
-        .. deprecated:: 1.2.0
-            slice_shift is deprecated,
-            use DataFrame/Series.shift instead.
-
-        The shifted data will not include the dropped periods and the
-        shifted axis will be smaller than the original.
-
-        Parameters
-        ----------
-        periods : int
-            Number of periods to move, can be positive or negative.
-        axis : {0 or 'index', 1 or 'columns', None}, default 0
-            For `Series` this parameter is unused and defaults to 0.
-
-        Returns
-        -------
-        shifted : same type as caller
-
-        Notes
-        -----
-        While the `slice_shift` is faster than `shift`, you may pay for it
-        later during alignment.
-        """
-
-        msg = (
-            "The 'slice_shift' method is deprecated "
-            "and will be removed in a future version. "
-            "You can use DataFrame/Series.shift instead."
-        )
-        warnings.warn(msg, FutureWarning, stacklevel=find_stack_level())
-
-        if periods == 0:
-            return self
-
-        if periods > 0:
-            vslicer = slice(None, -periods)
-            islicer = slice(periods, None)
-        else:
-            vslicer = slice(-periods, None)
-            islicer = slice(None, periods)
-
-        new_obj = self._slice(vslicer, axis=axis)
-        shifted_axis = self._get_axis(axis)[islicer]
-        new_obj = new_obj.set_axis(shifted_axis, axis=axis, copy=False)
-        return new_obj.__finalize__(self, method="slice_shift")
-
     def truncate(
         self: NDFrameT,
         before=None,

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -462,11 +462,3 @@ class TestNDFrame:
         assert obj.flags is obj.flags
         obj2 = obj.copy()
         assert obj2.flags is not obj.flags
-
-    def test_slice_shift_deprecated(self, frame_or_series):
-        # GH 37601
-        obj = DataFrame({"A": [1, 2, 3, 4]})
-        obj = tm.get_obj(obj, frame_or_series)
-
-        with tm.assert_produces_warning(FutureWarning):
-            obj.slice_shift()


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.0.0.rst` file if fixing a bug or adding a new feature.

Deprecation introduced in #37601