### PR TITLE
DOC: Removed parenthesis from .loc,.iloc,.at,.iat

### DIFF
--- a/doc/source/user_guide/10min.rst
+++ b/doc/source/user_guide/10min.rst
@@ -167,8 +167,8 @@ Selection
 
    While standard Python / NumPy expressions for selecting and setting are
    intuitive and come in handy for interactive work, for production code, we
-   recommend the optimized pandas data access methods, :meth:`DataFrame.at`, :meth:`DataFrame.iat`,
-   :meth:`DataFrame.loc` and :meth:`DataFrame.iloc`.
+   recommend the optimized pandas data access methods, :attr:`DataFrame.at`, :attr:`DataFrame.iat`,
+   :attr:`DataFrame.loc` and :attr:`DataFrame.iloc`.
 
 See the indexing documentation :ref:`Indexing and Selecting Data <indexing>` and :ref:`MultiIndex / Advanced Indexing <advanced>`.
 

--- a/doc/source/user_guide/10min.rst
+++ b/doc/source/user_guide/10min.rst
@@ -192,7 +192,7 @@ Selecting via ``[]`` (``__getitem__``), which slices the rows:
 Selection by label
 ~~~~~~~~~~~~~~~~~~
 
-See more in :ref:`Selection by Label <indexing.label>` using :meth:`DataFrame.loc` or :meth:`DataFrame.at`.
+See more in :ref:`Selection by Label <indexing.label>` using :attr:`DataFrame.loc` or :attr:`DataFrame.at`.
 
 For getting a cross section using a label:
 
@@ -233,7 +233,7 @@ For getting fast access to a scalar (equivalent to the prior method):
 Selection by position
 ~~~~~~~~~~~~~~~~~~~~~
 
-See more in :ref:`Selection by Position <indexing.integer>` using :meth:`DataFrame.iloc` or :meth:`DataFrame.iat`.
+See more in :ref:`Selection by Position <indexing.integer>` using :attr:`DataFrame.iloc` or :attr:`DataFrame.iat`.
 
 Select via the position of the passed integers:
 


### PR DESCRIPTION
- [ ] closes #49254 
- Removed parenthesis from **.loc**, **.iloc**, **.at**, **.iat** under `Selection`, `Selection by Label` and `Selection by Position`.
