### PR TITLE
TST: update exception messages for lxml tests

### DIFF
--- a/pandas/tests/io/xml/test_to_xml.py
+++ b/pandas/tests/io/xml/test_to_xml.py
@@ -1037,9 +1037,16 @@ def test_stylesheet_wrong_path():
 def test_empty_string_stylesheet(val):
     from lxml.etree import XMLSyntaxError
 
-    with pytest.raises(
-        XMLSyntaxError, match=("Document is empty|Start tag expected, '<' not found")
-    ):
+    msg = "|".join(
+        [
+            "Document is empty",
+            "Start tag expected, '<' not found",
+            # Seen on Mac with lxml 4.9.1
+            r"None \(line 0\)",
+        ]
+    )
+
+    with pytest.raises(XMLSyntaxError, match=msg):
         geom_df.to_xml(stylesheet=val)
 
 

--- a/pandas/tests/io/xml/test_xml.py
+++ b/pandas/tests/io/xml/test_xml.py
@@ -471,7 +471,14 @@ def test_file_handle_close(datapath, parser):
 def test_empty_string_lxml(val):
     from lxml.etree import XMLSyntaxError
 
-    with pytest.raises(XMLSyntaxError, match="Document is empty"):
+    msg = "|".join(
+        [
+            "Document is empty",
+            # Seen on Mac with lxml 4.91
+            r"None \(line 0\)",
+        ]
+    )
+    with pytest.raises(XMLSyntaxError, match=msg):
         read_xml(val, parser="lxml")
 
 


### PR DESCRIPTION
These have been failing locally since I upgraded lxml.