### PR TITLE
DEPR: inplace arg in Categorical.remove_unused_categories

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -190,6 +190,7 @@ Removal of prior version deprecations/changes
 - Removed argument ``tz`` from :meth:`Period.to_timestamp`, use ``obj.to_timestamp(...).tz_localize(tz)`` instead (:issue:`34522`)
 - Removed argument ``is_copy`` from :meth:`DataFrame.take` and :meth:`Series.take` (:issue:`30615`)
 - Removed argument ``kind`` from :meth:`Index.get_slice_bound`, :meth:`Index.slice_indexer` and :meth:`Index.slice_locs` (:issue:`41378`)
+- Removed argument ``inplace`` from :meth:`Categorical.remove_unused_categories` (:issue:`37918`)
 - Disallow passing non-round floats to :class:`Timestamp` with ``unit="M"`` or ``unit="Y"`` (:issue:`47266`)
 - Remove keywords ``convert_float`` and ``mangle_dupe_cols`` from :func:`read_excel` (:issue:`41176`)
 - Disallow passing non-keyword arguments to :func:`read_excel` except ``io`` and ``sheet_name`` (:issue:`34418`)

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1393,35 +1393,14 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
                 new_categories, ordered=self.ordered, rename=False, inplace=inplace
             )
 
-    @overload
-    def remove_unused_categories(
-        self, *, inplace: Literal[False] | NoDefault = ...
-    ) -> Categorical:
-        ...
-
-    @overload
-    def remove_unused_categories(self, *, inplace: Literal[True]) -> None:
-        ...
-
-    @deprecate_nonkeyword_arguments(version=None, allowed_args=["self"])
-    def remove_unused_categories(
-        self, inplace: bool | NoDefault = no_default
-    ) -> Categorical | None:
+    def remove_unused_categories(self) -> Categorical:
         """
         Remove categories which are not used.
 
-        Parameters
-        ----------
-        inplace : bool, default False
-           Whether or not to drop unused categories inplace or return a copy of
-           this categorical with unused categories dropped.
-
-           .. deprecated:: 1.2.0
-
         Returns
         -------
-        cat : Categorical or None
-            Categorical with unused categories dropped or None if ``inplace=True``.
+        cat : Categorical
+            Categorical with unused categories dropped.
 
         See Also
         --------
@@ -1448,33 +1427,20 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         ['a', 'c', 'a', 'c', 'c']
         Categories (2, object): ['a', 'c']
         """
-        if inplace is not no_default:
-            warn(
-                "The `inplace` parameter in pandas.Categorical."
-                "remove_unused_categories is deprecated and "
-                "will be removed in a future version.",
-                FutureWarning,
-                stacklevel=find_stack_level(),
-            )
-        else:
-            inplace = False
-
-        inplace = validate_bool_kwarg(inplace, "inplace")
-        cat = self if inplace else self.copy()
-        idx, inv = np.unique(cat._codes, return_inverse=True)
+        idx, inv = np.unique(self._codes, return_inverse=True)
 
         if idx.size != 0 and idx[0] == -1:  # na sentinel
             idx, inv = idx[1:], inv - 1
 
-        new_categories = cat.dtype.categories.take(idx)
+        new_categories = self.dtype.categories.take(idx)
         new_dtype = CategoricalDtype._from_fastpath(
             new_categories, ordered=self.ordered
         )
         new_codes = coerce_indexer_dtype(inv, new_dtype.categories)
+
+        cat = self.copy()
         NDArrayBacked.__init__(cat, new_codes, new_dtype)
-        if not inplace:
-            return cat
-        return None
+        return cat
 
     # ------------------------------------------------------------------
 

--- a/pandas/tests/arrays/categorical/test_analytics.py
+++ b/pandas/tests/arrays/categorical/test_analytics.py
@@ -364,11 +364,6 @@ class TestCategoricalAnalytics:
                 cat.remove_categories(removals=["D", "E", "F"], inplace=value)
 
         with pytest.raises(ValueError, match=msg):
-            with tm.assert_produces_warning(FutureWarning):
-                # issue #37643 inplace kwarg deprecated
-                cat.remove_unused_categories(inplace=value)
-
-        with pytest.raises(ValueError, match=msg):
             cat.sort_values(inplace=value)
 
     def test_quantile_empty(self):

--- a/pandas/tests/arrays/categorical/test_api.py
+++ b/pandas/tests/arrays/categorical/test_api.py
@@ -422,13 +422,6 @@ class TestCategoricalAPI:
         tm.assert_index_equal(res.categories, exp_categories_dropped)
         tm.assert_index_equal(c.categories, exp_categories_all)
 
-        with tm.assert_produces_warning(FutureWarning):
-            # issue #37643 inplace kwarg deprecated
-            res = c.remove_unused_categories(inplace=True)
-
-        tm.assert_index_equal(c.categories, exp_categories_dropped)
-        assert res is None
-
         # with NaN values (GH11599)
         c = Categorical(["a", "b", "c", np.nan], categories=["a", "b", "c", "d", "e"])
         res = c.remove_unused_categories()

--- a/pandas/tests/series/accessors/test_cat_accessor.py
+++ b/pandas/tests/series/accessors/test_cat_accessor.py
@@ -78,17 +78,6 @@ class TestCatAccessor:
         with pytest.raises(AttributeError, match="You cannot add any new attribute"):
             cat.cat.xlabel = "a"
 
-    def test_cat_accessor_updates_on_inplace(self):
-        ser = Series(list("abc")).astype("category")
-        return_value = ser.drop(0, inplace=True)
-        assert return_value is None
-
-        with tm.assert_produces_warning(FutureWarning):
-            return_value = ser.cat.remove_unused_categories(inplace=True)
-
-        assert return_value is None
-        assert len(ser.cat.categories) == 2
-
     def test_categorical_delegations(self):
 
         # invalid accessor


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.0.0.rst` file if fixing a bug or adding a new feature.

deprecation introduced in #37918