### PR TITLE
STYLE: fix pylint consider-iterating-dictionary warnings

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -332,7 +332,7 @@ class SeriesGroupBy(GroupBy[Series]):
             from pandas import concat
 
             res_df = concat(
-                results.values(), axis=1, keys=[key.label for key in results.keys()]
+                results.values(), axis=1, keys=[key.label for key in results]
             )
             return res_df
 

--- a/pandas/io/clipboard/__init__.py
+++ b/pandas/io/clipboard/__init__.py
@@ -608,7 +608,7 @@ def set_clipboard(clipboard):
     }
 
     if clipboard not in clipboard_types:
-        allowed_clipboard_types = [repr(_) for _ in clipboard_types.keys()]
+        allowed_clipboard_types = [repr(_) for _ in clipboard_types]
         raise ValueError(
             f"Argument must be one of {', '.join(allowed_clipboard_types)}"
         )

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -2284,7 +2284,7 @@ def _parse_latex_css_conversion(styles: CSSList) -> CSSList:
         if isinstance(value, str) and "--latex" in value:
             # return the style without conversion but drop '--latex'
             latex_styles.append((attribute, value.replace("--latex", "")))
-        if attribute in CONVERTED_ATTRIBUTES.keys():
+        if attribute in CONVERTED_ATTRIBUTES:
             arg = ""
             for x in ["--wrap", "--nowrap", "--lwrap", "--dwrap", "--rwrap"]:
                 if x in str(value):

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1699,7 +1699,7 @@ class TestPivotTable:
         )
         tm.assert_frame_equal(pivot_values_keys, pivot_values_list)
 
-        agg_values_gen = (value for value in aggs.keys())
+        agg_values_gen = (value for value in aggs)
         pivot_values_gen = pivot_table(
             data, index=["A"], values=agg_values_gen, aggfunc=aggs
         )

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -180,7 +180,7 @@ class TestSeriesMisc:
         # GH#9680
         tdi = pd.timedelta_range(start=0, periods=10, freq="1s")
         ser = Series(np.random.normal(size=10), index=tdi)
-        assert "foo" not in ser.__dict__.keys()
+        assert "foo" not in ser.__dict__
         msg = "'Series' object has no attribute 'foo'"
         with pytest.raises(AttributeError, match=msg):
             ser.foo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,6 @@ disable = [
   "used-before-assignment",
 
  # pylint type "C": convention, for programming standard violation
-  "consider-iterating-dictionary",
   "consider-using-f-string",
   "disallowed-name",
   "import-outside-toplevel",


### PR DESCRIPTION
Related to https://github.com/pandas-dev/pandas/issues/48855
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

The `consider-iterating-dictionary` is also removed from the ignored warnings in `pyproject.toml`.
