### PR TITLE
ENH: Format `datetime.datetime` and `pd.Timestamp` objects in `pd.to_datetime`

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -49,7 +49,7 @@ Other enhancements
 - Fix ``test`` optional_extra by adding missing test package ``pytest-asyncio`` (:issue:`48361`)
 - :func:`DataFrame.astype` exception message thrown improved to include column name when type conversion is not possible. (:issue:`47571`)
 - :meth:`DataFrame.to_json` now supports a ``mode`` keyword with supported inputs 'w' and 'a'. Defaulting to 'w', 'a' can be used when lines=True and orient='records' to append record oriented json lines to an existing json file. (:issue:`35849`)
-- :func:`to_datetime` now correctly parses ``datetime.datetime`` objects in the input when using the ``format`` argument instead of raising a ``ValueError``. (:issue:`49298`)
+- :func:`to_datetime` now handles ``datetime.datetime`` and :class:`Timestamp` and applies the ``format`` argument on them instead of raising a ``ValueError``. (:issue:`49298`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_200.notable_bug_fixes:

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -49,6 +49,7 @@ Other enhancements
 - Fix ``test`` optional_extra by adding missing test package ``pytest-asyncio`` (:issue:`48361`)
 - :func:`DataFrame.astype` exception message thrown improved to include column name when type conversion is not possible. (:issue:`47571`)
 - :meth:`DataFrame.to_json` now supports a ``mode`` keyword with supported inputs 'w' and 'a'. Defaulting to 'w', 'a' can be used when lines=True and orient='records' to append record oriented json lines to an existing json file. (:issue:`35849`)
+- :func:`to_datetime` now correctly parses ``datetime.datetime`` objects in the input when using the ``format`` argument instead of raising a ``ValueError``. (:issue:`49298`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_200.notable_bug_fixes:

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -49,7 +49,7 @@ Other enhancements
 - Fix ``test`` optional_extra by adding missing test package ``pytest-asyncio`` (:issue:`48361`)
 - :func:`DataFrame.astype` exception message thrown improved to include column name when type conversion is not possible. (:issue:`47571`)
 - :meth:`DataFrame.to_json` now supports a ``mode`` keyword with supported inputs 'w' and 'a'. Defaulting to 'w', 'a' can be used when lines=True and orient='records' to append record oriented json lines to an existing json file. (:issue:`35849`)
-- :func:`to_datetime` now handles ``datetime.datetime`` and :class:`Timestamp` and applies the ``format`` argument on them instead of raising a ``ValueError``. (:issue:`49298`)
+- :func:`to_datetime` now formats ``datetime.datetime`` and :class:`Timestamp` objects to return a format-consistent output instead of raising a ``ValueError``. (:issue:`49298`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_200.notable_bug_fixes:

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -49,7 +49,7 @@ Other enhancements
 - Fix ``test`` optional_extra by adding missing test package ``pytest-asyncio`` (:issue:`48361`)
 - :func:`DataFrame.astype` exception message thrown improved to include column name when type conversion is not possible. (:issue:`47571`)
 - :meth:`DataFrame.to_json` now supports a ``mode`` keyword with supported inputs 'w' and 'a'. Defaulting to 'w', 'a' can be used when lines=True and orient='records' to append record oriented json lines to an existing json file. (:issue:`35849`)
-- :func:`to_datetime` now formats ``datetime.datetime`` and :class:`Timestamp` objects to return a format-consistent output instead of raising a ``ValueError``. (:issue:`49298`)
+- :func:`to_datetime` now skips ``datetime.datetime`` and :class:`Timestamp` objects when passing ``format`` argument instead of raising a ``ValueError``. (:issue:`49298`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_200.notable_bug_fixes:

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -128,6 +128,7 @@ def array_strptime(ndarray[object] values, str fmt, bint exact=True, errors='rai
     result_timezone = np.empty(n, dtype='object')
 
     dts.us = dts.ps = dts.as = 0
+    expect_tz_aware = "%z" in fmt or "%Z" in fmt
 
     for i in range(n):
         val = values[i]
@@ -144,6 +145,10 @@ def array_strptime(ndarray[object] values, str fmt, bint exact=True, errors='rai
             else:
                 iresult[i] = pydatetime_to_dt64(val, &dts)
                 check_dts_bounds(&dts)
+            if val.tzinfo is None and expect_tz_aware:
+                raise ValueError("Cannot mix tz-aware with tz-naive values")
+            elif val.tzinfo is not None and not expect_tz_aware:
+                raise ValueError("Cannot mix tz-aware with tz-naive values")
             result_timezone[i] = val.tzinfo
             continue
         else:

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -134,16 +134,7 @@ def array_strptime(ndarray[object] values, str fmt, bint exact=True, errors='rai
             iresult[i] = NPY_NAT
             continue
         elif isinstance(val, datetime):
-            iresult[i] = _parse_python_datetime_object(val, &dts)
-            try:
-                check_dts_bounds(&dts)
-            except ValueError:
-                if is_coerce:
-                    iresult[i] = NPY_NAT
-                    continue
-                raise
-            result_timezone[i] = val.tzname()
-            continue
+            val = val.strftime(fmt)
         else:
             val = str(val)
 
@@ -543,29 +534,3 @@ cdef tzinfo parse_timezone_directive(str z):
                      (microseconds // 60_000_000))
     total_minutes = -total_minutes if z.startswith("-") else total_minutes
     return pytz.FixedOffset(total_minutes)
-
-cdef int64_t _parse_python_datetime_object(datetime dt, npy_datetimestruct *dts):
-    """
-    Parse a native datetime.datetime object and return a numpy datetime object
-
-    Parameters
-    ----------
-    dt : datetime.datetime instance
-    dts: numpy datetime struct
-
-    Returns
-    -------
-    int64_t
-        the numpy datetime object
-    """
-    dts.year = dt.year
-    dts.month = dt.month
-    dts.day = dt.day
-    dts.hour = dt.hour
-    dts.min = dt.minute
-    dts.sec = dt.second
-    dts.us = dt.microsecond
-    dts.ps = 0  # Not enough precision in datetime objects (https://github.com/python/cpython/issues/59648)
-
-    npy_datetime = npy_datetimestruct_to_datetime(NPY_FR_ns, dts)
-    return npy_datetime

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -2,6 +2,7 @@
 """
 from cpython.datetime cimport (
     date,
+    datetime,
     tzinfo,
 )
 
@@ -129,12 +130,22 @@ def array_strptime(ndarray[object] values, str fmt, bint exact=True, errors='rai
             if val in nat_strings:
                 iresult[i] = NPY_NAT
                 continue
+        elif checknull_with_nat_and_na(val):
+            iresult[i] = NPY_NAT
+            continue
+        elif isinstance(val, datetime):
+            iresult[i] = _parse_python_datetime_object(val, &dts)
+            try:
+                check_dts_bounds(&dts)
+            except ValueError:
+                if is_coerce:
+                    iresult[i] = NPY_NAT
+                    continue
+                raise
+            result_timezone[i] = val.tzname()
+            continue
         else:
-            if checknull_with_nat_and_na(val):
-                iresult[i] = NPY_NAT
-                continue
-            else:
-                val = str(val)
+            val = str(val)
 
         # exact matching
         if exact:
@@ -532,3 +543,29 @@ cdef tzinfo parse_timezone_directive(str z):
                      (microseconds // 60_000_000))
     total_minutes = -total_minutes if z.startswith("-") else total_minutes
     return pytz.FixedOffset(total_minutes)
+
+cdef int64_t _parse_python_datetime_object(datetime dt, npy_datetimestruct *dts):
+    """
+    Parse a native datetime.datetime object and return a numpy datetime object
+
+    Parameters
+    ----------
+    dt : datetime.datetime instance
+    dts: numpy datetime struct
+
+    Returns
+    -------
+    int64_t
+        the numpy datetime object
+    """
+    dts.year = dt.year
+    dts.month = dt.month
+    dts.day = dt.day
+    dts.hour = dt.hour
+    dts.min = dt.minute
+    dts.sec = dt.second
+    dts.us = dt.microsecond
+    dts.ps = 0  # Not enough precision in datetime objects (https://github.com/python/cpython/issues/59648)
+
+    npy_datetime = npy_datetimestruct_to_datetime(NPY_FR_ns, dts)
+    return npy_datetime

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -1,10 +1,13 @@
 """Strptime-related classes and functions.
 """
 from cpython.datetime cimport (
+    PyDateTime_Check,
     date,
-    datetime,
+    import_datetime,
     tzinfo,
 )
+
+import_datetime()
 
 from _thread import allocate_lock as _thread_allocate_lock
 
@@ -133,7 +136,7 @@ def array_strptime(ndarray[object] values, str fmt, bint exact=True, errors='rai
         elif checknull_with_nat_and_na(val):
             iresult[i] = NPY_NAT
             continue
-        elif isinstance(val, datetime):
+        elif PyDateTime_Check(val):
             val = val.strftime(fmt)
         else:
             val = str(val)

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -499,7 +499,7 @@ def _array_strptime_with_fallback(
             # Indicates to the caller to fallback to objects_to_datetime64ns
             return None
     else:
-        if "%Z" in fmt or "%z" in fmt:
+        if any(timezones):
             return _return_parsed_timezone_results(result, timezones, tz, name)
 
     return _box_as_indexlike(result, utc=utc, name=name)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -609,6 +609,56 @@ class TestToDatetime:
         result = to_datetime(arr)
         assert result is arr
 
+    @pytest.mark.parametrize(
+        "init_constructor, end_constructor",
+        [
+            (Index, DatetimeIndex),
+            (list, DatetimeIndex),
+            (np.array, DatetimeIndex),
+            (Series, Series),
+        ],
+    )
+    def test_to_datetime_arraylike_contains_pydatetime(
+        self, init_constructor, end_constructor
+    ):
+        # GH 49298
+        data = ["01/02/01 12:00", datetime(2001, 2, 2, 12, 30)]
+        expected_data = [
+            Timestamp("2001-02-01 12:00:00"),
+            Timestamp("2001-02-02 12:30:00"),
+        ]
+        result = to_datetime(init_constructor(data), format="%d/%m/%y %H:%M")
+        expected = end_constructor(expected_data)
+        tm.assert_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "init_constructor, end_constructor",
+        [
+            (Index, DatetimeIndex),
+            (list, DatetimeIndex),
+            (np.array, DatetimeIndex),
+            (Series, Series),
+        ],
+    )
+    def test_to_datetime_arraylike_contains_pydatetime_utc(
+        self, cache, init_constructor, end_constructor
+    ):
+        # GH 49298
+        dt = datetime(2010, 1, 2, 12, 13, 16)
+        dt = dt.replace(tzinfo=timezone.utc)
+        data = ["20100102 121314", "20100102 121315", dt]
+        expected_data = [
+            Timestamp("2010-01-02 12:13:14", tz="utc"),
+            Timestamp("2010-01-02 12:13:15", tz="utc"),
+            Timestamp("2010-01-02 12:13:16", tz="utc"),
+        ]
+
+        result = to_datetime(
+            init_constructor(data), format="%Y%m%d %H%M%S", utc=True, cache=cache
+        )
+        expected = end_constructor(expected_data)
+        tm.assert_equal(result, expected)
+
     def test_to_datetime_pydatetime(self):
         actual = to_datetime(datetime(2008, 1, 15))
         assert actual == datetime(2008, 1, 15)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -625,25 +625,12 @@ class TestToDatetime:
     )
     def test_to_datetime_preserves_resolution_when_possible(self, data, expected):
         # GH 49298
-        if not isinstance(data, str):
-            result = to_datetime([data])
-            tm.assert_equal(result, DatetimeIndex([data]))
-
+        result = to_datetime([data])
+        tm.assert_equal(result, DatetimeIndex([data]))
         result = to_datetime([data], format="%m/%d/%y %H:%M:%S.%f")
         tm.assert_equal(result, DatetimeIndex([expected]))
 
-    @pytest.mark.parametrize(
-        "init_constructor, end_constructor",
-        [
-            (Index, DatetimeIndex),
-            (list, DatetimeIndex),
-            (np.array, DatetimeIndex),
-            (Series, Series),
-        ],
-    )
-    def test_to_datetime_arraylike_contains_pydatetime_and_timestamp(
-        self, init_constructor, end_constructor
-    ):
+    def test_to_datetime_arraylike_contains_pydatetime_and_timestamp(self):
         # GH 49298
         # Timestamp/datetime have more resolution than str
         case1 = [
@@ -651,14 +638,13 @@ class TestToDatetime:
             datetime(2001, 10, 2, 12, 30, 1, 123456),
             "10/03/01",
         ]
-        result = to_datetime(init_constructor(case1), format="%m/%d/%y")
+        result = to_datetime(case1, format="%m/%d/%y")
         expected_data = [
             Timestamp("2001-10-01"),
             Timestamp("2001-10-02"),
             Timestamp("2001-10-03"),
         ]
-        expected = end_constructor(expected_data)
-        tm.assert_equal(result, expected)
+        tm.assert_equal(result, DatetimeIndex(expected_data))
 
         # Timestamp/datetime have the same resolution than str (nanosecond)
         case2 = [
@@ -666,14 +652,13 @@ class TestToDatetime:
             datetime(2001, 10, 2, 12, 30, 1, 123456),
             "10/03/01 13:00:01.123456789",
         ]
-        result = to_datetime(init_constructor(case2), format="%m/%d/%y %H:%M:%S.%f")
+        result = to_datetime(case2, format="%m/%d/%y %H:%M:%S.%f")
         expected_data = [
             Timestamp("2001-10-01 12:00:01.123456"),
             Timestamp("2001-10-02 12:30:01.123456"),
             Timestamp("2001-10-03 13:00:01.123456789"),
         ]
-        expected = end_constructor(expected_data)
-        tm.assert_equal(result, expected)
+        tm.assert_equal(result, DatetimeIndex(expected_data))
 
         # Timestamp/datetime have less resolution than str
         case3 = [
@@ -681,27 +666,15 @@ class TestToDatetime:
             datetime(2001, 10, 2),
             "10/03/01 12:00:01",
         ]
-        result = to_datetime(init_constructor(case3), format="%m/%d/%y %H:%M:%S")
+        result = to_datetime(case3, format="%m/%d/%y %H:%M:%S")
         expected_data = [
             Timestamp("2001-10-01 00:00:00"),
             Timestamp("2001-10-02 00:00:00"),
             Timestamp("2001-10-03 12:00:01"),
         ]
-        expected = end_constructor(expected_data)
-        tm.assert_equal(result, expected)
+        tm.assert_equal(result, DatetimeIndex(expected_data))
 
-    @pytest.mark.parametrize(
-        "init_constructor, end_constructor",
-        [
-            (Index, DatetimeIndex),
-            (list, DatetimeIndex),
-            (np.array, DatetimeIndex),
-            (Series, Series),
-        ],
-    )
-    def test_to_datetime_arraylike_contains_pydatetime_and_timestamp_utc(
-        self, cache, init_constructor, end_constructor
-    ):
+    def test_to_datetime_arraylike_contains_pydatetime_and_timestamp_utc(self):
         # GH 49298
         dt = datetime(2010, 1, 2, 12, 13, 16)
         dt = dt.replace(tzinfo=timezone.utc)
@@ -715,14 +688,8 @@ class TestToDatetime:
             Timestamp("2010-01-02 12:13:15", tz="utc"),
             Timestamp("2010-01-02 12:13:16", tz="utc"),
         ]
-
-        if init_constructor is Series:
-            input_data = init_constructor(data, dtype="datetime64[ns, UTC]")
-        else:
-            input_data = init_constructor(data)
-        result = to_datetime(input_data, format="%Y%m%d %H%M%S", utc=True, cache=cache)
-        expected = end_constructor(expected_data)
-        tm.assert_equal(result, expected)
+        result = to_datetime(data, format="%Y%m%d %H%M%S", utc=True)
+        tm.assert_equal(result, DatetimeIndex(expected_data))
 
     def test_to_datetime_pydatetime(self):
         actual = to_datetime(datetime(2008, 1, 15))

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -669,6 +669,21 @@ class TestToDatetime:
         result = to_datetime(data, format="%Y%m%d %H%M%S %z", utc=False)
         tm.assert_equal(result, Index(expected_data))
 
+    @pytest.mark.parametrize("value", [datetime(2010, 1, 2, 12, 13, 16), Timestamp("2010-01-02 12:13:17")])
+    def test_to_datetime_includes_tz_dtype_on_pydatetime_and_timestamp(self, value):
+        # GH 49298
+        # No timezone
+        result_no_format = to_datetime([value])
+        result_with_format = to_datetime([value], format="%m-%d-%Y")
+        tm.assert_equal(result_no_format, result_with_format)
+
+        # Localized value
+        america_santiago = pytz.timezone("America/Santiago")
+        result_no_format = to_datetime([america_santiago.localize(value)])
+        result_with_format = to_datetime([america_santiago.localize(value)], format="%m-%d-%Y")
+        tm.assert_equal(result_with_format.dtype.tz, america_santiago)
+        tm.assert_equal(result_no_format, result_with_format)
+
     def test_to_datetime_pydatetime(self):
         actual = to_datetime(datetime(2008, 1, 15))
         assert actual == datetime(2008, 1, 15)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -674,6 +674,22 @@ class TestToDatetime:
         ]
         tm.assert_equal(result, DatetimeIndex(expected_data))
 
+        # Test ISO8601 format
+        case4 = [
+            Timestamp("2001-10-01 13:18:05"),
+            datetime(2001, 10, 2, 13, 18, 5),
+            "2001-10-03T13:18:05",
+            "20011004",
+        ]
+        result = to_datetime(case4)
+        expected_data = [
+            Timestamp("2001-10-01 13:18:05"),
+            Timestamp("2001-10-02 13:18:05"),
+            Timestamp("2001-10-03 13:18:05"),
+            Timestamp("2001-10-04 00:00:00"),
+        ]
+        tm.assert_equal(result, DatetimeIndex(expected_data))
+
     def test_to_datetime_arraylike_contains_pydatetime_and_timestamp_utc(self):
         # GH 49298
         dt = datetime(2010, 1, 2, 12, 13, 16)


### PR DESCRIPTION
- [X] Closes #49298
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

---

**Description of changes**

When passing `datetime.datetime` or `pd.Timestamp` objects to `pd.to_datetime`, while using the `format` argument, a `ValueError` is raised because those object does not match the expected format.

The implemented solution looks for these non-string objects in the `array_strptime` method, and then each object is processed to maintain its contents (which might differ from the expected `format` for strings), and then continuing processing as usual.