### PR TITLE
API: stop silently ignoring parsing failures with dtype=dt64

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -141,6 +141,7 @@ Other API changes
 - The ``other`` argument in :meth:`DataFrame.mask` and :meth:`Series.mask` now defaults to ``no_default`` instead of ``np.nan`` consistent with :meth:`DataFrame.where` and :meth:`Series.where`. Entries will be filled with the corresponding NULL value (``np.nan`` for numpy dtypes, ``pd.NA`` for extension dtypes). (:issue:`49111`)
 - When creating a :class:`Series` with a object-dtype :class:`Index` of datetime objects, pandas no longer silently converts the index to a :class:`DatetimeIndex` (:issue:`39307`, :issue:`23598`)
 - :meth:`Series.unique` with dtype "timedelta64[ns]" or "datetime64[ns]" now returns :class:`TimedeltaArray` or :class:`DatetimeArray` instead of ``numpy.ndarray`` (:issue:`49176`)
+- Passing strings that cannot be parsed as datetimes to :class:`Series` or :class:`DataFrame` with ``dtype="datetime64[ns]"`` will raise instead of silently ignoring the keyword and returning ``object`` dtype (:issue:`24435`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -20,7 +20,6 @@ from typing import (
 )
 import warnings
 
-from dateutil.parser import ParserError
 import numpy as np
 
 from pandas._libs import lib
@@ -1339,28 +1338,21 @@ def maybe_cast_to_datetime(
             if value.size or not is_dtype_equal(value.dtype, dtype):
                 _disallow_mismatched_datetimelike(value, dtype)
 
-                try:
-                    dta = sequence_to_datetimes(value)
-                    # GH 25843: Remove tz information since the dtype
-                    # didn't specify one
+                dta = sequence_to_datetimes(value)
+                # GH 25843: Remove tz information since the dtype
+                # didn't specify one
 
-                    if dta.tz is not None:
-                        raise ValueError(
-                            "Cannot convert timezone-aware data to "
-                            "timezone-naive dtype. Use "
-                            "pd.Series(values).dt.tz_localize(None) instead."
-                        )
+                if dta.tz is not None:
+                    raise ValueError(
+                        "Cannot convert timezone-aware data to "
+                        "timezone-naive dtype. Use "
+                        "pd.Series(values).dt.tz_localize(None) instead."
+                    )
 
-                    # TODO(2.0): Do this astype in sequence_to_datetimes to
-                    #  avoid potential extra copy?
-                    dta = dta.astype(dtype, copy=False)
-                    value = dta
-
-                except OutOfBoundsDatetime:
-                    raise
-                except ParserError:
-                    # Note: this is dateutil's ParserError, not ours.
-                    pass
+                # TODO(2.0): Do this astype in sequence_to_datetimes to
+                #  avoid potential extra copy?
+                dta = dta.astype(dtype, copy=False)
+                value = dta
 
         elif getattr(vdtype, "kind", None) in ["m", "M"]:
             # we are already datetimelike and want to coerce to non-datetimelike;

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -16,7 +16,6 @@ from pandas import (
     DataFrame,
     Series,
     Timestamp,
-    compat,
     date_range,
     option_context,
 )
@@ -266,8 +265,8 @@ class TestDataFrameBlockInternals:
             f("float64")
 
         # 10822
-        # invalid error message on dt inference
-        if not compat.is_platform_windows():
+        msg = "Unknown string format: aa present at position 0"
+        with pytest.raises(ValueError, match=msg):
             f("M8[ns]")
 
     def test_pickle(self, float_string_frame, timezone_frame):

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -52,6 +52,16 @@ from pandas.core.internals.blocks import NumericBlock
 
 
 class TestSeriesConstructors:
+    def test_unparseable_strings_with_dt64_dtype(self):
+        # pre-2.0 these would be silently ignored and come back with object dtype
+        vals = ["aa"]
+        msg = "Unknown string format: aa present at position 0"
+        with pytest.raises(ValueError, match=msg):
+            Series(vals, dtype="datetime64[ns]")
+
+        with pytest.raises(ValueError, match=msg):
+            Series(np.array(vals, dtype=object), dtype="datetime64[ns]")
+
     @pytest.mark.parametrize(
         "constructor,check_index_type",
         [


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

It's a bit ambiguous whether to call this a deprecation-enforcement or API change.  In 1.3.0 we have

```
- Deprecated behavior of :class:`DataFrame` constructor when a ``dtype`` is passed and the data cannot be cast to that dtype. In a future version, this will raise instead of being silently ignored (:issue:`24435`)
```

but the PR that did that deprecation added that warning in a different code path, so we don't currently issue a warning for this case.  (and the whatsnew didn't say anything about Series).