### PR TITLE
STYLE: fix pylint unneeded-not warnings

### DIFF
--- a/pandas/core/arrays/arrow/extension_types.py
+++ b/pandas/core/arrays/arrow/extension_types.py
@@ -36,7 +36,7 @@ class ArrowPeriodType(pyarrow.ExtensionType):
             return NotImplemented
 
     def __ne__(self, other) -> bool:
-        return not self.__eq__(other)
+        return not self == other
 
     def __hash__(self) -> int:
         return hash((str(self), self.freq))
@@ -95,7 +95,7 @@ class ArrowIntervalType(pyarrow.ExtensionType):
             return NotImplemented
 
     def __ne__(self, other) -> bool:
-        return not self.__eq__(other)
+        return not self == other
 
     def __hash__(self) -> int:
         return hash((str(self), str(self.subtype), self.closed))

--- a/pandas/core/arrays/arrow/extension_types.py
+++ b/pandas/core/arrays/arrow/extension_types.py
@@ -35,6 +35,9 @@ class ArrowPeriodType(pyarrow.ExtensionType):
         else:
             return NotImplemented
 
+    def __ne__(self, other) -> bool:
+        return not self.__eq__(other)
+
     def __hash__(self) -> int:
         return hash((str(self), self.freq))
 
@@ -90,6 +93,9 @@ class ArrowIntervalType(pyarrow.ExtensionType):
             )
         else:
             return NotImplemented
+
+    def __ne__(self, other) -> bool:
+        return not self.__eq__(other)
 
     def __hash__(self) -> int:
         return hash((str(self), str(self.subtype), self.closed))

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -98,7 +98,7 @@ class StylerRenderer:
         self.data: DataFrame = data
         self.index: Index = data.index
         self.columns: Index = data.columns
-        if not isinstance(uuid_len, int) or not uuid_len >= 0:
+        if not isinstance(uuid_len, int) or uuid_len < 0:
             raise TypeError("``uuid_len`` must be an integer in range [0, 32].")
         self.uuid = uuid or uuid4().hex[: min(32, uuid_len)]
         self.uuid_len = len(self.uuid)

--- a/pandas/tests/arrays/interval/test_interval.py
+++ b/pandas/tests/arrays/interval/test_interval.py
@@ -256,9 +256,9 @@ def test_arrow_extension_type():
 
     assert p1.closed == "left"
     assert p1 == p2
-    assert not p1 == p3
+    assert p1 != p3
     assert hash(p1) == hash(p2)
-    assert not hash(p1) == hash(p3)
+    assert hash(p1) != hash(p3)
 
 
 @pyarrow_skip

--- a/pandas/tests/arrays/interval/test_interval.py
+++ b/pandas/tests/arrays/interval/test_interval.py
@@ -256,7 +256,7 @@ def test_arrow_extension_type():
 
     assert p1.closed == "left"
     assert p1 == p2
-    assert p1 != p3
+    assert not p1 == p3  # pylint: disable=unneeded-not
     assert hash(p1) == hash(p2)
     assert hash(p1) != hash(p3)
 

--- a/pandas/tests/arrays/interval/test_interval.py
+++ b/pandas/tests/arrays/interval/test_interval.py
@@ -256,7 +256,7 @@ def test_arrow_extension_type():
 
     assert p1.closed == "left"
     assert p1 == p2
-    assert not p1 == p3  # pylint: disable=unneeded-not
+    assert p1 != p3
     assert hash(p1) == hash(p2)
     assert hash(p1) != hash(p3)
 

--- a/pandas/tests/arrays/period/test_arrow_compat.py
+++ b/pandas/tests/arrays/period/test_arrow_compat.py
@@ -21,9 +21,9 @@ def test_arrow_extension_type():
 
     assert p1.freq == "D"
     assert p1 == p2
-    assert not p1 == p3
+    assert p1 != p3
     assert hash(p1) == hash(p2)
-    assert not hash(p1) == hash(p3)
+    assert hash(p1) != hash(p3)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/arrays/period/test_arrow_compat.py
+++ b/pandas/tests/arrays/period/test_arrow_compat.py
@@ -21,7 +21,7 @@ def test_arrow_extension_type():
 
     assert p1.freq == "D"
     assert p1 == p2
-    assert not p1 == p3  # pylint: disable=unneeded-not
+    assert p1 != p3
     assert hash(p1) == hash(p2)
     assert hash(p1) != hash(p3)
 

--- a/pandas/tests/arrays/period/test_arrow_compat.py
+++ b/pandas/tests/arrays/period/test_arrow_compat.py
@@ -21,7 +21,7 @@ def test_arrow_extension_type():
 
     assert p1.freq == "D"
     assert p1 == p2
-    assert p1 != p3
+    assert not p1 == p3  # pylint: disable=unneeded-not
     assert hash(p1) == hash(p2)
     assert hash(p1) != hash(p3)
 

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -800,7 +800,7 @@ class TestContains:
     def test_large_mi_contains(self):
         # GH#10645
         result = MultiIndex.from_arrays([range(10**6), range(10**6)])
-        assert not (10**6, 0) in result
+        assert (10**6, 0) not in result
 
 
 def test_timestamp_multiindex_indexer():

--- a/pandas/tests/scalar/timedelta/test_arithmetic.py
+++ b/pandas/tests/scalar/timedelta/test_arithmetic.py
@@ -1114,5 +1114,5 @@ def test_ops_error_str():
         with pytest.raises(TypeError, match=msg):
             left > right
 
-        assert not left == right
+        assert not left == right  # pylint: disable=unneeded-not
         assert left != right

--- a/pandas/tests/scalar/timestamp/test_comparisons.py
+++ b/pandas/tests/scalar/timestamp/test_comparisons.py
@@ -310,5 +310,5 @@ def test_rich_comparison_with_unsupported_type():
     for left, right in [(inf, timestamp), (timestamp, inf)]:
         assert left > right or left < right
         assert left >= right or left <= right
-        assert not left == right
+        assert not left == right  # pylint: disable=unneeded-not
         assert left != right

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,6 @@ disable = [
   "unidiomatic-typecheck",
   "unnecessary-dunder-call",
   "unnecessary-lambda-assignment",
-  "unneeded-not",
   "use-implicit-booleaness-not-comparison",
   "use-implicit-booleaness-not-len",
   "use-sequence-for-iteration",


### PR DESCRIPTION
Related to https://github.com/pandas-dev/pandas/issues/48855
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

I added `# pylint: disable=unneeded-not` for tests where the intention was clearly to test the `not` operator.