### PR TITLE
enable pylint for wrong-import-order (#48855)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -19,6 +19,13 @@ import warnings
 
 import jinja2
 from numpydoc.docscrape import NumpyDocString
+import sphinx  # isort:skip
+from sphinx.ext.autodoc import (  # isort:skip
+    AttributeDocumenter,
+    Documenter,
+    MethodDocumenter,
+)
+from sphinx.ext.autosummary import Autosummary  # isort:skip
 from sphinx.ext.autosummary import _import_by_name
 
 logger = logging.getLogger(__name__)
@@ -477,15 +484,6 @@ ipython_execlines = [
 
 # Add custom Documenter to handle attributes/methods of an AccessorProperty
 # eg pandas.Series.str and pandas.Series.dt (see GH9322)
-
-import sphinx  # isort:skip
-from sphinx.ext.autodoc import (  # isort:skip
-    AttributeDocumenter,
-    Documenter,
-    MethodDocumenter,
-)
-from sphinx.ext.autosummary import Autosummary  # isort:skip
-
 
 class AccessorDocumenter(MethodDocumenter):
     """

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 
 import numpy as np
 
+from markupsafe import escape as escape_html  # markupsafe is jinja2 dependency
 from pandas._config import get_option
 
 from pandas._libs import lib
@@ -47,7 +48,6 @@ from pandas.api.types import is_list_like
 import pandas.core.common as com
 
 jinja2 = import_optional_dependency("jinja2", extra="DataFrame.style requires jinja2.")
-from markupsafe import escape as escape_html  # markupsafe is jinja2 dependency
 
 BaseFormatter = Union[str, Callable]
 ExtFormatter = Union[BaseFormatter, Dict[Any, Optional[BaseFormatter]]]

--- a/pandas/tests/io/formats/style/test_matplotlib.py
+++ b/pandas/tests/io/formats/style/test_matplotlib.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import matplotlib as mpl
 
 from pandas import (
     DataFrame,
@@ -9,8 +10,6 @@ from pandas import (
 
 pytest.importorskip("matplotlib")
 pytest.importorskip("jinja2")
-
-import matplotlib as mpl
 
 from pandas.io.formats.style import Styler
 from pandas.plotting._matplotlib.compat import mpl_ge_3_6_0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ disable = [
   "use-implicit-booleaness-not-len",
   "use-sequence-for-iteration",
   "useless-import-alias",
-  "wrong-import-order",
   "wrong-import-position",
 
   # pylint type "R": refactor, for bad code smell


### PR DESCRIPTION
This PR enables pylint C-Type message "wrong-import-order". The warnings from pylint are fixed.
Issue #48855