### PR TITLE
Make the conversion from dtype to subclass just a little faster

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -106,7 +106,6 @@ from pandas.core.dtypes.common import (
     is_scalar,
     is_signed_integer_dtype,
     is_string_dtype,
-    is_unsigned_integer_dtype,
     needs_i8_conversion,
     pandas_dtype,
     validate_all_hashable,
@@ -591,20 +590,20 @@ class Index(IndexOpsMixin, PandasObject):
 
             return TimedeltaIndex
 
-        elif is_float_dtype(dtype):
+        elif dtype.kind == "f":
             from pandas.core.api import Float64Index
 
             return Float64Index
-        elif is_unsigned_integer_dtype(dtype):
+        elif dtype.kind == "u":
             from pandas.core.api import UInt64Index
 
             return UInt64Index
-        elif is_signed_integer_dtype(dtype):
+        elif dtype.kind == "i":
             from pandas.core.api import Int64Index
 
             return Int64Index
 
-        elif dtype == _dtype_obj:
+        elif dtype.kind == "O":
             # NB: assuming away MultiIndex
             return Index
 


### PR DESCRIPTION
Calling `is_float_dtype` is a really "safe" way to take an array or a dtype and know if it is a subclass.

But I don't think you need to do that. Checking the `kind` should be enough. I get about 5-10% faster on the benchmarks shown. Mostly reducing 12us to 11.5 us. I think it is real.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
