### PR TITLE
enable pylint:useless-return

### DIFF
--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -304,7 +304,6 @@ class NDArrayBackedExtensionArray(NDArrayBacked, ExtensionArray):
         # (for now) when self.ndim == 2, we assume axis=0
         func = missing.get_fill_func(method, ndim=self.ndim)
         func(self._ndarray.T, limit=limit, mask=mask.T)
-        return
 
     @doc(ExtensionArray.fillna)
     def fillna(

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1556,7 +1556,6 @@ class ExtensionArray:
         func(npvalues, limit=limit, mask=mask.copy())
         new_values = self._from_sequence(npvalues, dtype=self.dtype)
         self[mask] = new_values[mask]
-        return
 
     def _rank(
         self,

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -258,7 +258,6 @@ def interpolate_array_2d(
             fill_value=fill_value,
             **kwargs,
         )
-    return
 
 
 def _interpolate_2d_with_fill(
@@ -341,7 +340,6 @@ def _interpolate_2d_with_fill(
     # Sequence[Sequence[Sequence[_SupportsArray[dtype[<nothing>]]]]],
     # Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[<nothing>]]]]]]]]"
     np.apply_along_axis(func, axis, data)  # type: ignore[arg-type]
-    return
 
 
 def _index_to_interp_indices(index: Index, method: str) -> np.ndarray:
@@ -761,8 +759,6 @@ def _interpolate_with_limit_area(
             invalid[:first] = invalid[last + 1 :] = False
 
         values[invalid] = np.nan
-
-    return
 
 
 def interpolate_2d(

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -148,10 +148,9 @@ def test_group_apply_once_per_group(df, group_names):
         names.append(group.name)
         return 0
 
-    def f_none(group):  # pylint: disable= "useless-return"
+    def f_none(group):
         # GH10519, GH12155, GH21417
         names.append(group.name)
-        return None
 
     def f_constant_df(group):
         # GH2936, GH20084

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -148,7 +148,7 @@ def test_group_apply_once_per_group(df, group_names):
         names.append(group.name)
         return 0
 
-    def f_none(group):
+    def f_none(group):  # pylint: disable= "useless-return"
         # GH10519, GH12155, GH21417
         names.append(group.name)
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,6 @@ disable = [
   "unnecessary-list-index-lookup",
   "use-a-generator",
   "useless-option-value",
-  "useless-return",
 
   # pylint type "W": warning, for python specific problems
   "abstract-method",


### PR DESCRIPTION
Issue #48855. This PR enables pylint type "R" warning:  "useless-return". 
In one place (https://github.com/natmokval/pandas/blob/da3025ae6dec3fed73df0cf1d1bbc5ef0d816695/pandas/tests/groupby/test_apply.py#L151) the warning is disabled to match the style of surrounding functions. 

- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).