### PR TITLE
DEPR: Enforce deprecation of silent dropping of nuisance columns in agg_list_like

### DIFF
--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -310,7 +310,7 @@ class AggFunctions:
         df.groupby(["key1", "key2"]).agg([sum, min, max])
 
     def time_different_python_functions_singlecol(self, df):
-        df.groupby("key1").agg([sum, min, max])
+        df.groupby("key1")[["value1", "value2", "value3"]].agg([sum, min, max])
 
 
 class GroupStrings:

--- a/doc/source/user_guide/basics.rst
+++ b/doc/source/user_guide/basics.rst
@@ -1039,34 +1039,6 @@ not noted for a particular column will be ``NaN``:
 
    tsdf.agg({"A": ["mean", "min"], "B": "sum"})
 
-.. _basics.aggregation.mixed_string:
-
-Mixed dtypes
-++++++++++++
-
-.. deprecated:: 1.4.0
-   Attempting to determine which columns cannot be aggregated and silently dropping them from the results is deprecated and will be removed in a future version. If any porition of the columns or operations provided fail, the call to ``.agg`` will raise.
-
-When presented with mixed dtypes that cannot aggregate, ``.agg`` will only take the valid
-aggregations. This is similar to how ``.groupby.agg`` works.
-
-.. ipython:: python
-
-   mdf = pd.DataFrame(
-       {
-           "A": [1, 2, 3],
-           "B": [1.0, 2.0, 3.0],
-           "C": ["foo", "bar", "baz"],
-           "D": pd.date_range("20130101", periods=3),
-       }
-   )
-   mdf.dtypes
-
-.. ipython:: python
-   :okwarning:
-
-   mdf.agg(["min", "sum"])
-
 .. _basics.aggregation.custom_describe:
 
 Custom describe

--- a/doc/source/user_guide/groupby.rst
+++ b/doc/source/user_guide/groupby.rst
@@ -1007,7 +1007,7 @@ functions:
 .. ipython:: python
    :okwarning:
 
-   grouped = df.groupby("A")
+   grouped = df.groupby("A")[["C", "D"]]
    grouped.agg(lambda x: x.std())
 
 But, it's rather verbose and can be untidy if you need to pass additional

--- a/doc/source/whatsnew/v0.20.0.rst
+++ b/doc/source/whatsnew/v0.20.0.rst
@@ -104,10 +104,13 @@ aggregations. This is similar to how groupby ``.agg()`` works. (:issue:`15015`)
                       'D': pd.date_range('20130101', periods=3)})
    df.dtypes
 
-.. ipython:: python
-   :okwarning:
+.. code-block:: python
 
-   df.agg(['min', 'sum'])
+   In [10]: df.agg(['min', 'sum'])
+   Out[10]:
+        A    B          C          D
+   min  1  1.0        bar 2013-01-01
+   sum  6  6.0  foobarbaz        NaT
 
 .. _whatsnew_0200.enhancements.dataio_dtype:
 

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -275,7 +275,7 @@ Removal of prior version deprecations/changes
 - Changed behavior of :class:`Index` constructor when passed a ``SparseArray`` or ``SparseDtype`` to retain that dtype instead of casting to ``numpy.ndarray`` (:issue:`43930`)
 - Removed the deprecated ``base`` and ``loffset`` arguments from :meth:`pandas.DataFrame.resample`, :meth:`pandas.Series.resample` and :class:`pandas.Grouper`. Use ``offset`` or ``origin`` instead (:issue:`31809`)
 - Changed behavior of :meth:`DataFrame.any` and :meth:`DataFrame.all` with ``bool_only=True``; object-dtype columns with all-bool values will no longer be included, manually cast to ``bool`` dtype first (:issue:`46188`)
--
+- Change behavior of :meth:`DataFrame.apply` with list-like so that any partial failure will raise an error (:issue:`43740`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_200.performance:

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -443,10 +443,8 @@ class Apply(metaclass=abc.ABCMeta):
                 keys_to_use = ktu
 
             axis: AxisInt = 0 if isinstance(obj, ABCSeries) else 1
-            # error: Key expression in dictionary comprehension has incompatible type
-            # "Hashable"; expected type "NDFrame"  [misc]
             result = concat(
-                {k: results[k] for k in keys_to_use},  # type: ignore[misc]
+                {k: results[k] for k in keys_to_use},
                 axis=axis,
                 keys=keys_to_use,
             )

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -417,7 +417,7 @@ class Apply(metaclass=abc.ABCMeta):
 
             axis: AxisInt = 0 if isinstance(obj, ABCSeries) else 1
             result = concat(
-                {k: results[k] for k in keys_to_use},
+                {k: results[k] for k in keys_to_use},  # type: ignore[misc]
                 axis=axis,
                 keys=keys_to_use,
             )

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1141,7 +1141,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                     result = gba.agg()
 
                 except ValueError as err:
-                    if "no results" not in str(err):
+                    if "No objects to concatenate" not in str(err):
                         # raised directly by _aggregate_multiple_funcs
                         raise
                     result = self._aggregate_frame(func)

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1142,7 +1142,6 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
                 except ValueError as err:
                     if "No objects to concatenate" not in str(err):
-                        # raised directly by _aggregate_multiple_funcs
                         raise
                     result = self._aggregate_frame(func)
 

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1141,7 +1141,35 @@ def test_agg_with_name_as_column_name():
     tm.assert_series_equal(result, expected)
 
 
-def test_agg_multiple_mixed_no_warning():
+def test_agg_multiple_mixed():
+    # GH 20909
+    mdf = DataFrame(
+        {
+            "A": [1, 2, 3],
+            "B": [1.0, 2.0, 3.0],
+            "C": ["foo", "bar", "baz"],
+        }
+    )
+    expected = DataFrame(
+        {
+            "A": [1, 6],
+            "B": [1.0, 6.0],
+            "C": ["bar", "foobarbaz"],
+        },
+        index=["min", "sum"],
+    )
+    # sorted index
+    result = mdf.agg(["min", "sum"])
+    tm.assert_frame_equal(result, expected)
+
+    result = mdf[["C", "B", "A"]].agg(["sum", "min"])
+    # GH40420: the result of .agg should have an index that is sorted
+    # according to the arguments provided to agg.
+    expected = expected[["C", "B", "A"]].reindex(["sum", "min"])
+    tm.assert_frame_equal(result, expected)
+
+
+def test_agg_multiple_mixed_raises():
     # GH 20909
     mdf = DataFrame(
         {
@@ -1151,32 +1179,15 @@ def test_agg_multiple_mixed_no_warning():
             "D": date_range("20130101", periods=3),
         }
     )
-    expected = DataFrame(
-        {
-            "A": [1, 6],
-            "B": [1.0, 6.0],
-            "C": ["bar", "foobarbaz"],
-            "D": [Timestamp("2013-01-01"), pd.NaT],
-        },
-        index=["min", "sum"],
-    )
+
     # sorted index
-    with tm.assert_produces_warning(
-        FutureWarning, match=r"\['D'\] did not aggregate successfully"
-    ):
-        result = mdf.agg(["min", "sum"])
+    # TODO: GH#49399 will fix error message
+    msg = "DataFrame constructor called with"
+    with pytest.raises(TypeError, match=msg):
+        mdf.agg(["min", "sum"])
 
-    tm.assert_frame_equal(result, expected)
-
-    with tm.assert_produces_warning(
-        FutureWarning, match=r"\['D'\] did not aggregate successfully"
-    ):
-        result = mdf[["D", "C", "B", "A"]].agg(["sum", "min"])
-
-    # GH40420: the result of .agg should have an index that is sorted
-    # according to the arguments provided to agg.
-    expected = expected[["D", "C", "B", "A"]].reindex(["sum", "min"])
-    tm.assert_frame_equal(result, expected)
+    with pytest.raises(TypeError, match=msg):
+        mdf[["D", "C", "B", "A"]].agg(["sum", "min"])
 
 
 def test_agg_reduce(axis, float_frame):
@@ -1277,14 +1288,10 @@ def test_nuiscance_columns():
     expected = Series([6, 6.0, "foobarbaz"], index=["A", "B", "C"])
     tm.assert_series_equal(result, expected)
 
-    with tm.assert_produces_warning(
-        FutureWarning, match=r"\['D'\] did not aggregate successfully"
-    ):
-        result = df.agg(["sum"])
-    expected = DataFrame(
-        [[6, 6.0, "foobarbaz"]], index=["sum"], columns=["A", "B", "C"]
-    )
-    tm.assert_frame_equal(result, expected)
+    # TODO: GH#49399 will fix error message
+    msg = "DataFrame constructor called with"
+    with pytest.raises(TypeError, match=msg):
+        df.agg(["sum"])
 
 
 @pytest.mark.parametrize("how", ["agg", "apply"])
@@ -1499,27 +1506,23 @@ def test_aggregation_func_column_order():
     # according to the arguments provided to agg.
     df = DataFrame(
         [
-            ("1", 1, 0, 0),
-            ("2", 2, 0, 0),
-            ("3", 3, 0, 0),
-            ("4", 4, 5, 4),
-            ("5", 5, 6, 6),
-            ("6", 6, 7, 7),
+            (1, 0, 0),
+            (2, 0, 0),
+            (3, 0, 0),
+            (4, 5, 4),
+            (5, 6, 6),
+            (6, 7, 7),
         ],
-        columns=("item", "att1", "att2", "att3"),
+        columns=("att1", "att2", "att3"),
     )
 
     def foo(s):
         return s.sum() / 2
 
     aggs = ["sum", foo, "count", "min"]
-    with tm.assert_produces_warning(
-        FutureWarning, match=r"\['item'\] did not aggregate successfully"
-    ):
-        result = df.agg(aggs)
+    result = df.agg(aggs)
     expected = DataFrame(
         {
-            "item": ["123456", np.nan, 6, "1"],
             "att1": [21.0, 10.5, 6.0, 1.0],
             "att2": [18.0, 9.0, 6.0, 0.0],
             "att3": [17.0, 8.5, 6.0, 0.0],

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -383,21 +383,18 @@ def test_agg_multiple_functions_same_name_with_ohlc_present():
 
 def test_multiple_functions_tuples_and_non_tuples(df):
     # #1359
+    # Columns B and C would cause partial failure
+    df = df.drop(columns=["B", "C"])
+
     funcs = [("foo", "mean"), "std"]
     ex_funcs = [("foo", "mean"), ("std", "std")]
 
-    result = df.groupby("A")["C"].agg(funcs)
-    expected = df.groupby("A")["C"].agg(ex_funcs)
+    result = df.groupby("A")["D"].agg(funcs)
+    expected = df.groupby("A")["D"].agg(ex_funcs)
     tm.assert_frame_equal(result, expected)
 
-    with tm.assert_produces_warning(
-        FutureWarning, match=r"\['B'\] did not aggregate successfully"
-    ):
-        result = df.groupby("A").agg(funcs)
-    with tm.assert_produces_warning(
-        FutureWarning, match=r"\['B'\] did not aggregate successfully"
-    ):
-        expected = df.groupby("A").agg(ex_funcs)
+    result = df.groupby("A").agg(funcs)
+    expected = df.groupby("A").agg(ex_funcs)
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/groupby/aggregate/test_other.py
+++ b/pandas/tests/groupby/aggregate/test_other.py
@@ -25,10 +25,8 @@ import pandas._testing as tm
 from pandas.io.formats.printing import pprint_thing
 
 
-def test_agg_api():
-    # GH 6337
-    # https://stackoverflow.com/questions/21706030/pandas-groupby-agg-function-column-dtype-error
-    # different api for agg when passed custom function with mixed frame
+def test_agg_partial_failure_raises():
+    # GH#43741
 
     df = DataFrame(
         {
@@ -43,19 +41,11 @@ def test_agg_api():
     def peak_to_peak(arr):
         return arr.max() - arr.min()
 
-    with tm.assert_produces_warning(
-        FutureWarning,
-        match=r"\['key2'\] did not aggregate successfully",
-    ):
-        expected = grouped.agg([peak_to_peak])
-    expected.columns = ["data1", "data2"]
+    with pytest.raises(TypeError, match="unsupported operand type"):
+        grouped.agg([peak_to_peak])
 
-    with tm.assert_produces_warning(
-        FutureWarning,
-        match=r"\['key2'\] did not aggregate successfully",
-    ):
-        result = grouped.agg(peak_to_peak)
-    tm.assert_frame_equal(result, expected)
+    with pytest.raises(TypeError, match="unsupported operand type"):
+        grouped.agg(peak_to_peak)
 
 
 def test_agg_datetimes_mixed():

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -407,14 +407,14 @@ def test_agg():
     expected.columns = pd.MultiIndex.from_product([["A", "B"], ["mean", "std"]])
     for t in cases:
         # In case 2, "date" is an index and a column, so agg still tries to agg
-        warn = FutureWarning if t == cases[2] else None
-        with tm.assert_produces_warning(
-            warn,
-            match=r"\['date'\] did not aggregate successfully",
-        ):
-            # .var on dt64 column raises and is dropped
+        if t == cases[2]:
+            # .var on dt64 column raises
+            msg = "Cannot cast DatetimeArray to dtype float64"
+            with pytest.raises(TypeError, match=msg):
+                t.aggregate([np.mean, np.std])
+        else:
             result = t.aggregate([np.mean, np.std])
-        tm.assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
     expected = pd.concat([a_mean, b_std], axis=1)
     for t in cases:


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

It seemed to me we'd lose test coverage with some of the tests if we just were tested these ops raised. So I split some into testing without the nuisance columns and with them.
