### PR TITLE
Fix Scorecards GitHub Action

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@v2.0.3
+        uses: ossf/scorecard-action@v2.0.6
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Fixes sudden failure reported in https://github.com/pandas-dev/pandas/issues/48566#issuecomment-1296174657.

Bumps ossf/scorecard-action to v2.0.6, fixing an unexpected breaking change in upstream API.
