### PR TITLE
issue 48855 enable pylint unnecessary-pass

### DIFF
--- a/pandas/core/computation/engines.py
+++ b/pandas/core/computation/engines.py
@@ -102,7 +102,6 @@ class AbstractEngine(metaclass=abc.ABCMeta):
         -----
         Must be implemented by subclasses.
         """
-        pass
 
 
 class NumExprEngine(AbstractEngine):

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -116,8 +116,6 @@ class CategoricalDtypeType(type):
     the type of CategoricalDtype, this metaclass determines subclass ability
     """
 
-    pass
-
 
 @register_extension_dtype
 class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3610,7 +3610,6 @@ class MultiIndex(Index):
                         RuntimeWarning,
                         stacklevel=find_stack_level(),
                     )
-                    pass
             return result
 
     def _is_comparable_dtype(self, dtype: DtypeObj) -> bool:

--- a/pandas/core/interchange/dataframe_protocol.py
+++ b/pandas/core/interchange/dataframe_protocol.py
@@ -134,7 +134,6 @@ class Buffer(ABC):
         """
         Buffer size in bytes.
         """
-        pass
 
     @property
     @abstractmethod
@@ -142,7 +141,6 @@ class Buffer(ABC):
         """
         Pointer to start of the buffer as an integer.
         """
-        pass
 
     @abstractmethod
     def __dlpack__(self):
@@ -166,7 +164,6 @@ class Buffer(ABC):
         Uses device type codes matching DLPack.
         Note: must be implemented even if ``__dlpack__`` is not.
         """
-        pass
 
 
 class Column(ABC):
@@ -222,7 +219,6 @@ class Column(ABC):
         Corresponds to DataFrame.num_rows() if column is a single chunk;
         equal to size of this current chunk otherwise.
         """
-        pass
 
     @property
     @abstractmethod
@@ -234,7 +230,6 @@ class Column(ABC):
         equal size M (only the last chunk may be shorter),
         ``offset = n * M``, ``n = 0 .. N-1``.
         """
-        pass
 
     @property
     @abstractmethod
@@ -266,7 +261,6 @@ class Column(ABC):
             - Data types not included: complex, Arrow-style null, binary, decimal,
               and nested (list, struct, map, union) dtypes.
         """
-        pass
 
     @property
     @abstractmethod
@@ -289,7 +283,6 @@ class Column(ABC):
 
         TBD: are there any other in-memory representations that are needed?
         """
-        pass
 
     @property
     @abstractmethod
@@ -302,7 +295,6 @@ class Column(ABC):
         mask or a byte mask, the value (0 or 1) indicating a missing value. None
         otherwise.
         """
-        pass
 
     @property
     @abstractmethod
@@ -312,7 +304,6 @@ class Column(ABC):
 
         Note: Arrow uses -1 to indicate "unknown", but None seems cleaner.
         """
-        pass
 
     @property
     @abstractmethod
@@ -320,14 +311,12 @@ class Column(ABC):
         """
         The metadata for the column. See `DataFrame.metadata` for more details.
         """
-        pass
 
     @abstractmethod
     def num_chunks(self) -> int:
         """
         Return the number of chunks the column consists of.
         """
-        pass
 
     @abstractmethod
     def get_chunks(self, n_chunks: int | None = None) -> Iterable[Column]:
@@ -336,7 +325,6 @@ class Column(ABC):
 
         See `DataFrame.get_chunks` for details on ``n_chunks``.
         """
-        pass
 
     @abstractmethod
     def get_buffers(self) -> ColumnBuffers:
@@ -360,7 +348,6 @@ class Column(ABC):
                          if the data buffer does not have an associated offsets
                          buffer.
         """
-        pass
 
 
 #    def get_children(self) -> Iterable[Column]:
@@ -391,7 +378,6 @@ class DataFrame(ABC):
     @abstractmethod
     def __dataframe__(self, nan_as_null: bool = False, allow_copy: bool = True):
         """Construct a new interchange object, potentially changing the parameters."""
-        pass
 
     @property
     @abstractmethod
@@ -405,14 +391,12 @@ class DataFrame(ABC):
         entries, please add name the keys with the name of the library
         followed by a period and the desired name, e.g, ``pandas.indexcol``.
         """
-        pass
 
     @abstractmethod
     def num_columns(self) -> int:
         """
         Return the number of columns in the DataFrame.
         """
-        pass
 
     @abstractmethod
     def num_rows(self) -> int | None:
@@ -422,56 +406,48 @@ class DataFrame(ABC):
         """
         Return the number of rows in the DataFrame, if available.
         """
-        pass
 
     @abstractmethod
     def num_chunks(self) -> int:
         """
         Return the number of chunks the DataFrame consists of.
         """
-        pass
 
     @abstractmethod
     def column_names(self) -> Iterable[str]:
         """
         Return an iterator yielding the column names.
         """
-        pass
 
     @abstractmethod
     def get_column(self, i: int) -> Column:
         """
         Return the column at the indicated position.
         """
-        pass
 
     @abstractmethod
     def get_column_by_name(self, name: str) -> Column:
         """
         Return the column whose name is the indicated name.
         """
-        pass
 
     @abstractmethod
     def get_columns(self) -> Iterable[Column]:
         """
         Return an iterator yielding the columns.
         """
-        pass
 
     @abstractmethod
     def select_columns(self, indices: Sequence[int]) -> DataFrame:
         """
         Create a new DataFrame by selecting a subset of columns by index.
         """
-        pass
 
     @abstractmethod
     def select_columns_by_name(self, names: Sequence[str]) -> DataFrame:
         """
         Create a new DataFrame by selecting a subset of columns by name.
         """
-        pass
 
     @abstractmethod
     def get_chunks(self, n_chunks: int | None = None) -> Iterable[DataFrame]:
@@ -483,4 +459,3 @@ class DataFrame(ABC):
         ``self.num_chunks()``, meaning the producer must subdivide each chunk
         before yielding it.
         """
-        pass

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -1142,7 +1142,6 @@ class ExcelWriter(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def sheets(self) -> dict[str, Any]:
         """Mapping of sheet names to sheet objects."""
-        pass
 
     @property
     @abc.abstractmethod
@@ -1152,7 +1151,6 @@ class ExcelWriter(metaclass=abc.ABCMeta):
 
         This attribute can be used to access engine-specific features.
         """
-        pass
 
     @book.setter
     @abc.abstractmethod
@@ -1160,7 +1158,6 @@ class ExcelWriter(metaclass=abc.ABCMeta):
         """
         Set book instance. Class type will depend on the engine used.
         """
-        pass
 
     def write_cells(
         self,
@@ -1212,7 +1209,6 @@ class ExcelWriter(metaclass=abc.ABCMeta):
         freeze_panes: int tuple of length 2
             contains the bottom-most row and right-most column to freeze
         """
-        pass
 
     def save(self) -> None:
         """
@@ -1228,7 +1224,6 @@ class ExcelWriter(metaclass=abc.ABCMeta):
         """
         Save workbook to disk.
         """
-        pass
 
     def __init__(
         self,

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -249,7 +249,6 @@ class Writer(ABC):
     @abstractmethod
     def obj_to_write(self) -> NDFrame | Mapping[IndexLabel, Any]:
         """Object to write in JSON format."""
-        pass
 
 
 class SeriesWriter(Writer):

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2593,8 +2593,6 @@ class DataIndexableCol(DataCol):
 class GenericDataIndexableCol(DataIndexableCol):
     """represent a generic pytables data column"""
 
-    pass
-
 
 class Fixed:
     """
@@ -2701,11 +2699,9 @@ class Fixed:
 
     def set_attrs(self) -> None:
         """set our object attributes"""
-        pass
 
     def get_attrs(self) -> None:
         """get our object attributes"""
-        pass
 
     @property
     def storable(self):
@@ -2728,7 +2724,6 @@ class Fixed:
 
     def validate_version(self, where=None) -> None:
         """are we trying to operate on an old version?"""
-        pass
 
     def infer_axes(self) -> bool:
         """

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -2417,7 +2417,6 @@ class StataWriter(StataParser):
 
     def _update_strl_names(self) -> None:
         """No-op, forward compatibility"""
-        pass
 
     def _validate_variable_name(self, name: str) -> str:
         """
@@ -2701,19 +2700,15 @@ supported types."""
 
     def _write_map(self) -> None:
         """No-op, future compatibility"""
-        pass
 
     def _write_file_close_tag(self) -> None:
         """No-op, future compatibility"""
-        pass
 
     def _write_characteristics(self) -> None:
         """No-op, future compatibility"""
-        pass
 
     def _write_strls(self) -> None:
         """No-op, future compatibility"""
-        pass
 
     def _write_expansion_fields(self) -> None:
         """Write 5 zeros for expansion fields"""
@@ -3438,7 +3433,6 @@ class StataWriter117(StataWriter):
 
     def _write_expansion_fields(self) -> None:
         """No-op in dta 117+"""
-        pass
 
     def _write_value_labels(self) -> None:
         self._update_map("value_labels")

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -668,7 +668,6 @@ class MPLPlot(ABC):
 
     def _post_plot_logic(self, ax, data) -> None:
         """Post process for each axes. Overridden in child classes"""
-        pass
 
     def _adorn_subplots(self):
         """Common post process unrelated to data"""

--- a/pandas/tests/base/test_constructors.py
+++ b/pandas/tests/base/test_constructors.py
@@ -56,7 +56,6 @@ class TestPandasDelegate:
 
         def bar(self, *args, **kwargs):
             """a test bar method"""
-            pass
 
     class Delegate(PandasDelegate, PandasObject):
         def __init__(self, obj) -> None:

--- a/pandas/tests/indexes/interval/test_constructors.py
+++ b/pandas/tests/indexes/interval/test_constructors.py
@@ -377,7 +377,6 @@ class TestClassConstructors(ConstructorTests):
         override the base class implementation since errors are handled
         differently; checks unnecessary since caught at the Interval level
         """
-        pass
 
     def test_constructor_string(self):
         # GH23013

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -423,11 +423,9 @@ class TestUltraJSONTests:
 
         class O2:
             member = 0
-            pass
 
         class O1:
             member = 0
-            pass
 
         decoded_input = O1()
         decoded_input.member = O2()

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -1673,7 +1673,6 @@ def _helper_hypothesis_delimited_date(call, date_string, **kwargs):
         result = call(date_string, **kwargs)
     except ValueError as er:
         msg = str(er)
-        pass
     return msg, result
 
 

--- a/pandas/tests/util/test_deprecate.py
+++ b/pandas/tests/util/test_deprecate.py
@@ -34,7 +34,6 @@ def new_func_with_deprecation():
 
     This is the extended summary. The deprecate directive goes before this.
     """
-    pass
 
 
 def test_deprecate_ok():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,6 @@ disable = [
   "try-except-raise",
   "undefined-loop-variable",
   "unnecessary-lambda",
-  "unnecessary-pass",
   "unspecified-encoding",
   "unused-argument",
   "unused-import",

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -23,7 +23,6 @@ class BadDocstrings:
         pandas.Series.rename : Alter Series index labels or name.
         DataFrame.head : The first `n` rows of the caller object.
         """
-        pass
 
     def redundant_import(self, foo=None, bar=None):
         """
@@ -45,7 +44,6 @@ class BadDocstrings:
         >>> df.all(bool_only=True)
         Series([], dtype: bool)
         """
-        pass
 
     def unused_import(self):
         """
@@ -54,7 +52,6 @@ class BadDocstrings:
         >>> import pandas as pdf
         >>> df = pd.DataFrame(np.ones((3, 3)), columns=('a', 'b', 'c'))
         """
-        pass
 
     def missing_whitespace_around_arithmetic_operator(self):
         """
@@ -63,7 +60,6 @@ class BadDocstrings:
         >>> 2+5
         7
         """
-        pass
 
     def indentation_is_not_a_multiple_of_four(self):
         """
@@ -72,7 +68,6 @@ class BadDocstrings:
         >>> if 2 + 5:
         ...   pass
         """
-        pass
 
     def missing_whitespace_after_comma(self):
         """
@@ -80,13 +75,11 @@ class BadDocstrings:
         --------
         >>> df = pd.DataFrame(np.ones((3,3)),columns=('a','b', 'c'))
         """
-        pass
 
     def write_array_like_with_hyphen_not_underscore(self):
         """
         In docstrings, use array-like over array_like
         """
-        pass
 
     def leftover_files(self):
         """
@@ -95,7 +88,6 @@ class BadDocstrings:
         >>> import pathlib
         >>> pathlib.Path("foo.txt").touch()
         """
-        pass
 
 
 class TestValidator:


### PR DESCRIPTION
Issue #48855. This PR enables pylint type "W" warning: `unnecessary-pass`.
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).