### PR TITLE
enable pylint unused-wildcard-import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,6 @@ disable = [
   "unused-argument",
   "unused-import",
   "unused-variable",
-  "unused-wildcard-import",
   "using-constant-test",
   "useless-else-on-loop",
   "useless-parent-delegation",


### PR DESCRIPTION
Issue #48855. This PR enables pylint type "W" warning: `unused-wildcard-import`.
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).