### PR TITLE
enable pylint wildcard-import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,8 +185,7 @@ disable = [
   "unused-wildcard-import",
   "using-constant-test",
   "useless-else-on-loop",
-  "useless-parent-delegation",
-  "wildcard-import"
+  "useless-parent-delegation"
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Issue #48855. This PR enables pylint type "W" warning: `wildcard-import`.
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).