### PR TITLE
DEPR: Remove df.info(null_counts=)

### DIFF
--- a/doc/source/user_guide/options.rst
+++ b/doc/source/user_guide/options.rst
@@ -249,7 +249,7 @@ displayed when calling :meth:`~pandas.DataFrame.info`.
 ``display.max_info_rows``: :meth:`~pandas.DataFrame.info` will usually show null-counts for each column.
 For a large :class:`DataFrame`, this can be quite slow. ``max_info_rows`` and ``max_info_cols``
 limit this null check to the specified rows and columns respectively. The :meth:`~pandas.DataFrame.info`
-keyword argument ``null_counts=True`` will override this.
+keyword argument ``show_counts=True`` will override this.
 
 .. ipython:: python
 

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -181,6 +181,7 @@ Removal of prior version deprecations/changes
 - Removed deprecated :meth:`.Styler.where` (:issue:`49397`)
 - Removed deprecated :meth:`.Styler.render` (:issue:`49397`)
 - Removed deprecated argument ``null_color`` in :meth:`.Styler.highlight_null` (:issue:`49397`)
+- Removed deprecated ``null_counts`` argument in :meth:`DataFrame.info`. Use ``show_counts`` instead (:issue:`37999`)
 - Enforced deprecation disallowing passing a timezone-aware :class:`Timestamp` and ``dtype="datetime64[ns]"`` to :class:`Series` or :class:`DataFrame` constructors (:issue:`41555`)
 - Enforced deprecation disallowing passing a sequence of timezone-aware values and ``dtype="datetime64[ns]"`` to to :class:`Series` or :class:`DataFrame` constructors (:issue:`41555`)
 - Enforced deprecation disallowing unit-less "datetime64" dtype in :meth:`Series.astype` and :meth:`DataFrame.astype` (:issue:`47844`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3398,17 +3398,7 @@ class DataFrame(NDFrame, OpsMixin):
         max_cols: int | None = None,
         memory_usage: bool | str | None = None,
         show_counts: bool | None = None,
-        null_counts: bool | None = None,
     ) -> None:
-        if null_counts is not None:
-            if show_counts is not None:
-                raise ValueError("null_counts used with show_counts. Use show_counts.")
-            warnings.warn(
-                "null_counts is deprecated. Use show_counts instead",
-                FutureWarning,
-                stacklevel=find_stack_level(),
-            )
-            show_counts = null_counts
         info = DataFrameInfo(
             data=self,
             memory_usage=memory_usage,

--- a/pandas/io/formats/info.py
+++ b/pandas/io/formats/info.py
@@ -52,13 +52,6 @@ show_counts_sub = dedent(
         shows the counts, and False never shows the counts."""
 )
 
-null_counts_sub = dedent(
-    """
-    null_counts : bool, optional
-        .. deprecated:: 1.2.0
-            Use show_counts instead."""
-)
-
 
 frame_examples_sub = dedent(
     """\
@@ -159,7 +152,6 @@ frame_sub_kwargs = {
     "type_sub": " and columns",
     "max_cols_sub": frame_max_cols_sub,
     "show_counts_sub": show_counts_sub,
-    "null_counts_sub": null_counts_sub,
     "examples_sub": frame_examples_sub,
     "see_also_sub": frame_see_also_sub,
     "version_added_sub": "",
@@ -240,7 +232,6 @@ series_sub_kwargs = {
     "type_sub": "",
     "max_cols_sub": "",
     "show_counts_sub": show_counts_sub,
-    "null_counts_sub": "",
     "examples_sub": series_examples_sub,
     "see_also_sub": series_see_also_sub,
     "version_added_sub": "\n.. versionadded:: 1.4.0\n",
@@ -280,7 +271,7 @@ INFO_DOCSTRING = dedent(
         at the cost of computational resources. See the
         :ref:`Frequently Asked Questions <df-memory-usage>` for more
         details.
-    {show_counts_sub}{null_counts_sub}
+    {show_counts_sub}
 
     Returns
     -------

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -209,20 +209,6 @@ class TestDataFrameFormatting:
                 df.info(buf=buf, show_counts=show_counts)
                 assert ("non-null" in buf.getvalue()) is result
 
-    def test_show_null_counts_deprecation(self):
-        # GH37999
-        df = DataFrame(1, columns=range(10), index=range(10))
-        with tm.assert_produces_warning(
-            FutureWarning, match="null_counts is deprecated.+"
-        ):
-            buf = StringIO()
-            df.info(buf=buf, null_counts=True)
-            assert "non-null" in buf.getvalue()
-
-        # GH37999
-        with pytest.raises(ValueError, match=r"null_counts used with show_counts.+"):
-            df.info(null_counts=True, show_counts=True)
-
     def test_repr_truncation(self):
         max_len = 20
         with option_context("display.max_colwidth", max_len):


### PR DESCRIPTION
Introduced in https://github.com/pandas-dev/pandas/pull/37999
