### PR TITLE
enable pylint: literal-comparison

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,6 @@ disable = [
   "duplicate-code",
   "inconsistent-return-statements",
   "invalid-sequence-index",
-  "literal-comparison",
   "no-else-continue",
   "no-else-raise",
   "no-else-return",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,6 @@ disable = [
   "no-else-continue",
   "no-else-raise",
   "no-else-return",
-  "no-self-use",
   "redefined-argument-from-local",
   "too-few-public-methods",
   "too-many-ancestors",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,6 @@ disable = [
   "cyclic-import",
   "duplicate-code",
   "inconsistent-return-statements",
-  "invalid-sequence-index",
   "no-else-continue",
   "no-else-raise",
   "no-else-return",


### PR DESCRIPTION
Issue #48855. This PR enables pylint type "R" warning: `literal-comparison`.
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).