### PR TITLE
 enable pylint: no-self-use

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,6 @@ disable = [
   "no-else-continue",
   "no-else-raise",
   "no-else-return",
-  "no-self-use",
   "redefined-argument-from-local",
   "too-few-public-methods",
   "too-many-ancestors",


### PR DESCRIPTION
Issue #48855. This PR enables pylint type "R" warning: `no-self-use`.
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
