### PR TITLE
enable pylint: invalid-sequence-index

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,6 @@ disable = [
   "cyclic-import",
   "duplicate-code",
   "inconsistent-return-statements",
-  "invalid-sequence-index",
   "literal-comparison",
   "no-else-continue",
   "no-else-raise",


### PR DESCRIPTION
Issue #48855. This PR enables pylint type "R" warning: `invalid-sequence-index`.
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).