### PR TITLE
Backport PR #49377 on branch 1.5.x (BUG: Fix passing Colormap instance to plot methods with mpl >= 3.6)

### DIFF
--- a/doc/source/whatsnew/v1.5.2.rst
+++ b/doc/source/whatsnew/v1.5.2.rst
@@ -14,6 +14,8 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Fixed regression in :meth:`Series.replace` raising ``RecursionError`` with numeric dtype and when specifying ``value=None`` (:issue:`45725`)
+- Fixed regression in :meth:`DataFrame.plot` preventing :class:`~matplotlib.colors.Colormap` instance
+  from being passed using the ``colormap`` argument if Matplotlib 3.6+ is used (:issue:`49374`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -3927,7 +3927,15 @@ def _background_gradient(
         rng = smax - smin
         # extend lower / upper bounds, compresses color range
         norm = mpl.colors.Normalize(smin - (rng * low), smax + (rng * high))
-        rgbas = plt.cm.get_cmap(cmap)(norm(gmap))
+        from pandas.plotting._matplotlib.compat import mpl_ge_3_6_0
+
+        if mpl_ge_3_6_0():
+            if cmap is None:
+                rgbas = mpl.colormaps[mpl.rcParams["image.cmap"]](norm(gmap))
+            else:
+                rgbas = mpl.colormaps.get_cmap(cmap)(norm(gmap))
+        else:
+            rgbas = plt.cm.get_cmap(cmap)(norm(gmap))
 
         def relative_luminance(rgba) -> float:
             """

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -1222,7 +1222,7 @@ class ScatterPlot(PlanePlot):
 
         if self.colormap is not None:
             if mpl_ge_3_6_0():
-                cmap = mpl.colormaps[self.colormap]
+                cmap = mpl.colormaps.get_cmap(self.colormap)
             else:
                 cmap = self.plt.cm.get_cmap(self.colormap)
         else:
@@ -1302,7 +1302,7 @@ class HexBinPlot(PlanePlot):
         # pandas uses colormap, matplotlib uses cmap.
         cmap = self.colormap or "BuGn"
         if mpl_ge_3_6_0():
-            cmap = mpl.colormaps[cmap]
+            cmap = mpl.colormaps.get_cmap(cmap)
         else:
             cmap = self.plt.cm.get_cmap(cmap)
         cb = self.kwds.pop("colorbar", True)

--- a/pandas/tests/io/formats/style/test_matplotlib.py
+++ b/pandas/tests/io/formats/style/test_matplotlib.py
@@ -284,3 +284,17 @@ def test_bar_color_raises(df):
     msg = "`color` and `cmap` cannot both be given"
     with pytest.raises(ValueError, match=msg):
         df.style.bar(color="something", cmap="something else").to_html()
+
+
+@pytest.mark.parametrize(
+    "plot_method",
+    ["scatter", "hexbin"],
+)
+def test_pass_colormap_instance(df, plot_method):
+    # https://github.com/pandas-dev/pandas/issues/49374
+    cmap = mpl.colors.ListedColormap([[1, 1, 1], [0, 0, 0]])
+    df["c"] = df.A + df.B
+    kwargs = dict(x="A", y="B", c="c", colormap=cmap)
+    if plot_method == "hexbin":
+        kwargs["C"] = kwargs.pop("c")
+    getattr(df.plot, plot_method)(**kwargs)


### PR DESCRIPTION
Backport of #49377 to 1.5.x

- [x] closes #49374
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
