### PR TITLE
STYLE Suppressing two instances of pylint W0703 broad-except. 

### DIFF
--- a/pandas/_testing/_io.py
+++ b/pandas/_testing/_io.py
@@ -225,7 +225,7 @@ def network(
             )
         try:
             return t(*args, **kwargs)
-        except Exception as err:
+        except Exception as err: # pylint: disable=broad-except
             errno = getattr(err, "errno", None)
             if not errno and hasattr(errno, "reason"):
                 # error: "Exception" has no attribute "reason"

--- a/pandas/_testing/_io.py
+++ b/pandas/_testing/_io.py
@@ -225,7 +225,7 @@ def network(
             )
         try:
             return t(*args, **kwargs)
-        except Exception as err: # pylint: disable=broad-except
+        except Exception as err:  # pylint: disable=broad-except
             errno = getattr(err, "errno", None)
             if not errno and hasattr(errno, "reason"):
                 # error: "Exception" has no attribute "reason"

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -494,7 +494,7 @@ def maybe_cast_to_extension_array(
 
     try:
         result = cls._from_sequence(obj, dtype=dtype)
-    except Exception: # pylint: disable=broadexcept
+    except Exception:  # pylint: disable=broad-except
         # We can't predict what downstream EA constructors may raise
         result = obj
     return result

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -494,7 +494,7 @@ def maybe_cast_to_extension_array(
 
     try:
         result = cls._from_sequence(obj, dtype=dtype)
-    except Exception:
+    except Exception: # pylint: disable=broadexcept
         # We can't predict what downstream EA constructors may raise
         result = obj
     return result


### PR DESCRIPTION
- [x] partially addresses ability to re-enable pylint checks for `broad-except` from #48855 

34 instances of W0703 were found, this should address 2.    
- Suppressed one warning where there is existing logic to parse returned errors
- Suppressed another warning because downstream constructors could raise any error

Working on appropriate fixes for the rest and the eventual update to `pyproject.toml` -- will submit separate PRs as I go along.