### PR TITLE
wheel CI: Always use latest minor version of cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -68,7 +68,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.9.0
+        uses: pypa/cibuildwheel@v2
         env:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
 


### PR DESCRIPTION
By removing the exact minor and patch version of the cibuildwheel action, it will always use the latest minor/patch version.

This ensures the latest Python versions are always used to build wheels.

Major version updates will be handled by #49475 for GitHub Actions.