### PR TITLE
enable pylint: consider-using-sys-exit

### DIFF
--- a/pandas/tests/io/generate_legacy_storage_files.py
+++ b/pandas/tests/io/generate_legacy_storage_files.py
@@ -327,7 +327,7 @@ def write_legacy_file():
     sys.path.insert(0, ".")
 
     if not 3 <= len(sys.argv) <= 4:
-        exit(
+        sys.exit(
             "Specify output directory and storage type: generate_legacy_"
             "storage_files.py <output_dir> <storage_type> "
         )
@@ -338,7 +338,7 @@ def write_legacy_file():
     if storage_type == "pickle":
         write_legacy_pickles(output_dir=output_dir)
     else:
-        exit("storage_type must be one of {'pickle'}")
+        sys.exit("storage_type must be one of {'pickle'}")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,6 @@ disable = [
   "comparison-with-itself",
   "consider-merging-isinstance",
   "consider-using-min-builtin",
-  "consider-using-sys-exit",
   "consider-using-ternary",
   "consider-using-with",
   "cyclic-import",


### PR DESCRIPTION
Issue #48855. This PR enables pylint type "R" warning: `consider-using-sys-exit`.
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).