### PR TITLE
Bump matplotlib min_ver to 3.6.1 (from 3.6.0)

### DIFF
--- a/ci/deps/actions-38-minimum_versions.yaml
+++ b/ci/deps/actions-38-minimum_versions.yaml
@@ -32,7 +32,7 @@ dependencies:
   - gcsfs=2021.07.0
   - jinja2=3.0.0
   - lxml=4.6.3
-  - matplotlib=3.6.0
+  - matplotlib=3.6.1
   - numba=0.53.1
   - numexpr=2.7.3
   - odfpy=1.4.1

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -310,7 +310,7 @@ Can be managed as optional_extra with ``pandas[plot, output_formatting]``, depen
 ========================= ================== ================== =============================================================
 Dependency                Minimum Version    optional_extra     Notes
 ========================= ================== ================== =============================================================
-matplotlib                3.6.0              plot               Plotting library
+matplotlib                3.6.1              plot               Plotting library
 Jinja2                    3.0.0              output_formatting  Conditional formatting with DataFrame.style
 tabulate                  0.8.9              output_formatting  Printing in Markdown-friendly format (see `tabulate`_)
 ========================= ================== ================== =============================================================

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -124,7 +124,7 @@ Optional libraries below the lowest tested version may still work, but are not c
 +=================+=================+=========+
 | pyarrow         | 6.0.0           |    X    |
 +-----------------+-----------------+---------+
-| matplotlib      | 3.6.0           |    X    |
+| matplotlib      | 3.6.1           |    X    |
 +-----------------+-----------------+---------+
 | fastparquet     | 0.6.3           |    X    |
 +-----------------+-----------------+---------+

--- a/pandas/compat/_optional.py
+++ b/pandas/compat/_optional.py
@@ -23,7 +23,7 @@ VERSIONS = {
     "gcsfs": "2021.07.0",
     "jinja2": "3.0.0",
     "lxml.etree": "4.6.3",
-    "matplotlib": "3.6.0",
+    "matplotlib": "3.6.1",
     "numba": "0.53.1",
     "numexpr": "2.7.3",
     "odfpy": "1.4.1",


### PR DESCRIPTION
- [ ] closes #49498 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

I think this will fix the minimum-versions build.