### PR TITLE
DEPR: move NumericIndexes into base Index, part 1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,10 @@ repos:
         - flake8==5.0.4
         - flake8-bugbear==22.7.1
         - pandas-dev-flaker==0.5.0
+-   repo: https://github.com/pycqa/pylint
+    rev: v2.15.3
+    hooks:
+    -   id: pylint
 -   repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,10 +59,6 @@ repos:
         - flake8==5.0.4
         - flake8-bugbear==22.7.1
         - pandas-dev-flaker==0.5.0
--   repo: https://github.com/pycqa/pylint
-    rev: v2.15.3
-    hooks:
-    -   id: pylint
 -   repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:

--- a/asv_bench/benchmarks/hash_functions.py
+++ b/asv_bench/benchmarks/hash_functions.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 import pandas as pd
+from pandas.core.api import Int64Index, UInt64Index, Float64Index
 
 
 class UniqueForLargePyObjectInts:
@@ -57,7 +58,7 @@ class Unique:
 class NumericSeriesIndexing:
 
     params = [
-        (pd.Int64Index, pd.UInt64Index, pd.Float64Index),
+        (Int64Index, UInt64Index, Float64Index),
         (10**4, 10**5, 5 * 10**5, 10**6, 5 * 10**6),
     ]
     param_names = ["index_dtype", "N"]
@@ -75,7 +76,7 @@ class NumericSeriesIndexing:
 class NumericSeriesIndexingShuffled:
 
     params = [
-        (pd.Int64Index, pd.UInt64Index, pd.Float64Index),
+        (Int64Index, UInt64Index, Float64Index),
         (10**4, 10**5, 5 * 10**5, 10**6, 5 * 10**6),
     ]
     param_names = ["index_dtype", "N"]

--- a/asv_bench/benchmarks/hash_functions.py
+++ b/asv_bench/benchmarks/hash_functions.py
@@ -1,7 +1,11 @@
 import numpy as np
 
 import pandas as pd
-from pandas.core.api import Int64Index, UInt64Index, Float64Index
+from pandas.core.api import (
+    Float64Index,
+    Int64Index,
+    UInt64Index,
+)
 
 
 class UniqueForLargePyObjectInts:

--- a/asv_bench/benchmarks/index_cached_properties.py
+++ b/asv_bench/benchmarks/index_cached_properties.py
@@ -1,5 +1,8 @@
 import pandas as pd
-from pandas.core.api import Float64Index, UInt64Index
+from pandas.core.api import (
+    Float64Index,
+    UInt64Index,
+)
 
 
 class IndexCache:

--- a/asv_bench/benchmarks/index_cached_properties.py
+++ b/asv_bench/benchmarks/index_cached_properties.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from pandas.core.api import Float64Index, UInt64Index
 
 
 class IndexCache:
@@ -40,9 +41,9 @@ class IndexCache:
         elif index_type == "TimedeltaIndex":
             self.idx = pd.TimedeltaIndex(range(N))
         elif index_type == "Float64Index":
-            self.idx = pd.Float64Index(range(N))
+            self.idx = Float64Index(range(N))
         elif index_type == "UInt64Index":
-            self.idx = pd.UInt64Index(range(N))
+            self.idx = UInt64Index(range(N))
         elif index_type == "CategoricalIndex":
             self.idx = pd.CategoricalIndex(range(N), range(N))
         else:

--- a/asv_bench/benchmarks/index_object.py
+++ b/asv_bench/benchmarks/index_object.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from pandas import (
     DatetimeIndex,
-    Float64Index,
     Index,
     IntervalIndex,
     MultiIndex,
@@ -12,6 +11,7 @@ from pandas import (
     Series,
     date_range,
 )
+from pandas.core.api import Float64Index
 
 from .pandas_vb_common import tm
 

--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -12,17 +12,15 @@ import numpy as np
 from pandas import (
     CategoricalIndex,
     DataFrame,
-    Float64Index,
-    Int64Index,
     IntervalIndex,
     MultiIndex,
     Series,
-    UInt64Index,
     concat,
     date_range,
     option_context,
     period_range,
 )
+from pandas.core.api import Float64Index, Int64Index, UInt64Index
 
 from .pandas_vb_common import tm
 

--- a/doc/source/reference/indexing.rst
+++ b/doc/source/reference/indexing.rst
@@ -166,9 +166,6 @@ Numeric Index
    :template: autosummary/class_without_autosummary.rst
 
    RangeIndex
-   Int64Index
-   UInt64Index
-   Float64Index
 
 .. We need this autosummary so that the methods are generated.
 .. Separate block, since they aren't classes.

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -183,38 +183,6 @@ __version__ = v.get("closest-tag", v["version"])
 __git_version__ = v.get("full-revisionid")
 del get_versions, v
 
-# GH 27101
-__deprecated_num_index_names = ["Float64Index", "Int64Index", "UInt64Index"]
-
-
-def __dir__() -> list[str]:
-    # GH43028
-    # Int64Index etc. are deprecated, but we still want them to be available in the dir.
-    # Remove in Pandas 2.0, when we remove Int64Index etc. from the code base.
-    return list(globals().keys()) + __deprecated_num_index_names
-
-
-def __getattr__(name):
-    import warnings
-
-    if name in __deprecated_num_index_names:
-        warnings.warn(
-            f"pandas.{name} is deprecated "
-            "and will be removed from pandas in a future version. "
-            "Use pandas.Index with the appropriate dtype instead.",
-            FutureWarning,
-            stacklevel=2,
-        )
-        from pandas.core.api import Float64Index, Int64Index, UInt64Index
-
-        return {
-            "Float64Index": Float64Index,
-            "Int64Index": Int64Index,
-            "UInt64Index": UInt64Index,
-        }[name]
-
-    raise AttributeError(f"module 'pandas' has no attribute '{name}'")
-
 
 # module level doc-string
 __doc__ = """

--- a/pandas/core/dtypes/generic.py
+++ b/pandas/core/dtypes/generic.py
@@ -13,16 +13,13 @@ if TYPE_CHECKING:
         CategoricalIndex,
         DataFrame,
         DatetimeIndex,
-        Float64Index,
         Index,
-        Int64Index,
         IntervalIndex,
         MultiIndex,
         PeriodIndex,
         RangeIndex,
         Series,
         TimedeltaIndex,
-        UInt64Index,
     )
     from pandas.core.arrays import (
         DatetimeArray,
@@ -31,6 +28,7 @@ if TYPE_CHECKING:
         PeriodArray,
         TimedeltaArray,
     )
+    from pandas.core.api import Float64Index, Int64Index, UInt64Index
     from pandas.core.generic import NDFrame
 
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -11203,7 +11203,7 @@ Parrot 2  Parrot       24.0
             )
         if method == "single":
             # error: Argument "qs" to "quantile" of "BlockManager" has incompatible type
-            # "Index"; expected "Float64Index"
+            # "Index"; expected "NumericIndex"
             res = data._mgr.quantile(
                 qs=q, axis=1, interpolation=interpolation  # type: ignore[arg-type]
             )

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -107,6 +107,7 @@ from pandas.core.dtypes.common import (
     is_scalar,
     is_signed_integer_dtype,
     is_string_dtype,
+    is_unsigned_integer_dtype,
     needs_i8_conversion,
     pandas_dtype,
     validate_all_hashable,

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -13,6 +13,7 @@ from pandas._libs import (
 )
 from pandas._typing import (
     Dtype,
+    DtypeObj,
     npt,
 )
 from pandas.util._decorators import (
@@ -347,7 +348,26 @@ _num_index_shared_docs[
 """
 
 
-class IntegerIndex(NumericIndex):
+class TempBaseIndex(NumericIndex):
+    @classmethod
+    def _dtype_to_subclass(cls, dtype: DtypeObj):
+        if is_integer_dtype(dtype):
+            from pandas.core.api import Int64Index
+
+            return Int64Index
+        elif is_unsigned_integer_dtype(dtype):
+            from pandas.core.api import UInt64Index
+
+            return UInt64Index
+        elif is_float_dtype(dtype):
+            from pandas.core.api import Float64Index
+
+            return Float64Index
+        else:
+            return super()._dtype_to_subclass(dtype)
+
+
+class IntegerIndex(TempBaseIndex):
     """
     This is an abstract class for Int64Index, UInt64Index.
     """
@@ -391,7 +411,7 @@ class UInt64Index(IntegerIndex):
         return libindex.UInt64Engine
 
 
-class Float64Index(NumericIndex):
+class Float64Index(TempBaseIndex):
     _index_descr_args = {
         "klass": "Float64Index",
         "dtype": "float64",

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -75,8 +75,8 @@ class NumericIndex(Index):
     Notes
     -----
     An NumericIndex instance can **only** contain numpy int64/32/16/8, uint64/32/16/8 or
-    float64/32/16 dtype. In particular, ``NumericIndex`` *can not* hold Pandas numeric
-    dtypes (:class:`Int64Dtype`, :class:`Int32Dtype` etc.).
+    float64/32 dtype. In particular, ``NumericIndex`` *can not* hold numpy float16
+    dtype or Pandas numeric dtypes (:class:`Int64Dtype`, :class:`Int32Dtype` etc.).
     """
 
     _typ = "numericindex"
@@ -175,6 +175,10 @@ class NumericIndex(Index):
             raise ValueError("Index data must be 1-dimensional")
 
         subarr = np.asarray(subarr)
+        if subarr.dtype == "float16":
+            # float16 not supported (no indexing engine)
+            subarr = subarr.astype("float32")
+
         return subarr
 
     @classmethod
@@ -199,6 +203,9 @@ class NumericIndex(Index):
             return cls._default_dtype
 
         dtype = pandas_dtype(dtype)
+        if dtype == np.float16:
+            # float16 not supported (no indexing engine)
+            dtype = np.dtype(np.float32)
         assert isinstance(dtype, np.dtype)
 
         if cls._is_backward_compat_public_numeric_index:

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -185,9 +185,9 @@ class RangeIndex(NumericIndex):
     # error: Return type "Type[Int64Index]" of "_constructor" incompatible with return
     # type "Type[RangeIndex]" in supertype "Index"
     @cache_readonly
-    def _constructor(self) -> type[Int64Index]:  # type: ignore[override]
+    def _constructor(self) -> type[NumericIndex]:  # type: ignore[override]
         """return the class to use for construction"""
-        return Int64Index
+        return NumericIndex
 
     # error: Signature of "_data" incompatible with supertype "Index"
     @cache_readonly

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -96,7 +96,7 @@ from pandas.core.internals.blocks import (
 )
 
 if TYPE_CHECKING:
-    from pandas import Float64Index
+    from pandas.core.api import Float64Index
 
 
 T = TypeVar("T", bound="BaseArrayManager")

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -64,8 +64,8 @@ from pandas.core.construction import (
 )
 from pandas.core.indexers import maybe_convert_indices
 from pandas.core.indexes.api import (
-    Float64Index,
     Index,
+    NumericIndex,
     ensure_index,
 )
 from pandas.core.internals.base import (
@@ -1582,7 +1582,7 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
     def quantile(
         self: T,
         *,
-        qs: Float64Index,
+        qs: NumericIndex,
         axis: AxisInt = 0,
         interpolation: QuantileInterpolation = "linear",
     ) -> T:
@@ -1610,7 +1610,7 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         assert axis == 1  # only ever called this way
 
         new_axes = list(self.axes)
-        new_axes[1] = Float64Index(qs)
+        new_axes[1] = Index(qs, dtype=np.float64)
 
         blocks = [
             blk.quantile(axis=axis, qs=qs, interpolation=interpolation)

--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -17,7 +17,6 @@ from pandas.util._decorators import doc
 
 from pandas.core.api import (
     DataFrame,
-    Index,
     RangeIndex,
 )
 from pandas.core.shared_docs import _shared_docs

--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -17,7 +17,7 @@ from pandas.util._decorators import doc
 
 from pandas.core.api import (
     DataFrame,
-    Int64Index,
+    Index,
     RangeIndex,
 )
 from pandas.core.shared_docs import _shared_docs
@@ -62,7 +62,7 @@ def to_feather(
     # validate that we have only a default index
     # raise on anything else as we don't serialize the index
 
-    if not isinstance(df.index, (Int64Index, RangeIndex)):
+    if df.index.dtype != "int64":
         typ = type(df.index)
         raise ValueError(
             f"feather does not support serializing {typ} "

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -55,17 +55,14 @@ class TestPDApi(Base):
         "DatetimeIndex",
         "ExcelFile",
         "ExcelWriter",
-        "Float64Index",
         "Flags",
         "Grouper",
         "HDFStore",
         "Index",
-        "Int64Index",
         "MultiIndex",
         "Period",
         "PeriodIndex",
         "RangeIndex",
-        "UInt64Index",
         "Series",
         "SparseDtype",
         "StringDtype",
@@ -93,7 +90,7 @@ class TestPDApi(Base):
     ]
 
     # these are already deprecated; awaiting removal
-    deprecated_classes: list[str] = ["Float64Index", "Int64Index", "UInt64Index"]
+    deprecated_classes: list[str] = []
 
     # external modules exposed in pandas namespace
     modules: list[str] = []

--- a/pandas/tests/apply/test_series_apply.py
+++ b/pandas/tests/apply/test_series_apply.py
@@ -186,7 +186,7 @@ def test_apply_datetimetz():
     # change dtype
     # GH 14506 : Returned dtype changed from int32 to int64
     result = s.apply(lambda x: x.hour)
-    exp = Series(list(range(24)) + [0], name="XX", dtype=np.int64)
+    exp = Series(list(range(24)) + [0], name="XX", dtype=np.int32)
     tm.assert_series_equal(result, exp)
 
     # not vectorized
@@ -766,7 +766,7 @@ def test_map_datetimetz():
     # change dtype
     # GH 14506 : Returned dtype changed from int32 to int64
     result = s.map(lambda x: x.hour)
-    exp = Series(list(range(24)) + [0], name="XX", dtype=np.int64)
+    exp = Series(list(range(24)) + [0], name="XX", dtype=np.int32)
     tm.assert_series_equal(result, exp)
 
     # not vectorized

--- a/pandas/tests/arrays/sparse/test_accessor.py
+++ b/pandas/tests/arrays/sparse/test_accessor.py
@@ -41,7 +41,12 @@ class TestSeriesAccessor:
         sp_array = scipy.sparse.coo_matrix((data, (row, col)), dtype="int")
         result = pd.Series.sparse.from_coo(sp_array)
 
-        index = pd.MultiIndex.from_arrays([[0, 0, 1, 3], [0, 2, 1, 3]])
+        index = pd.MultiIndex.from_arrays(
+            [
+                np.array([0, 0, 1, 3], dtype=np.int32),
+                np.array([0, 2, 1, 3], dtype=np.int32),
+            ],
+        )
         expected = pd.Series([4, 9, 7, 5], index=index, dtype="Sparse[int]")
         tm.assert_series_equal(result, expected)
 
@@ -212,7 +217,15 @@ class TestFrameAccessor:
 
         A = scipy.sparse.eye(3, format="coo", dtype=dtype)
         result = pd.Series.sparse.from_coo(A, dense_index=dense_index)
-        index = pd.MultiIndex.from_tuples([(0, 0), (1, 1), (2, 2)])
+
+        index_dtype = np.int64 if dense_index else np.int32
+        index = pd.MultiIndex.from_tuples(
+            [
+                np.array([0, 0], dtype=index_dtype),
+                np.array([1, 1], dtype=index_dtype),
+                np.array([2, 2], dtype=index_dtype),
+            ],
+        )
         expected = pd.Series(SparseArray(np.array([1, 1, 1], dtype=dtype)), index=index)
         if dense_index:
             expected = expected.reindex(pd.MultiIndex.from_product(index.levels))

--- a/pandas/tests/base/test_unique.py
+++ b/pandas/tests/base/test_unique.py
@@ -5,12 +5,19 @@ from pandas.core.dtypes.common import is_datetime64tz_dtype
 
 import pandas as pd
 import pandas._testing as tm
-from pandas.core.api import NumericIndex
+from pandas.core.api import (
+    Float64Index,
+    Int64Index,
+    NumericIndex,
+    UInt64Index,
+)
 from pandas.tests.base.common import allow_na_ops
 
 
 def test_unique(index_or_series_obj):
     obj = index_or_series_obj
+    if isinstance(obj, (Int64Index, UInt64Index, Float64Index)):
+        pytest.skip("these indexes will be removed in followup")
     obj = np.repeat(obj, range(1, len(obj) + 1))
     result = obj.unique()
 
@@ -36,6 +43,8 @@ def test_unique(index_or_series_obj):
 @pytest.mark.parametrize("null_obj", [np.nan, None])
 def test_unique_null(null_obj, index_or_series_obj):
     obj = index_or_series_obj
+    if isinstance(obj, (Int64Index, UInt64Index, Float64Index)):
+        pytest.skip("these indexes will be removed in followup")
 
     if not allow_na_ops(obj):
         pytest.skip("type doesn't allow for NA operations")

--- a/pandas/tests/base/test_value_counts.py
+++ b/pandas/tests/base/test_value_counts.py
@@ -24,6 +24,10 @@ from pandas.tests.base.common import allow_na_ops
 def test_value_counts(index_or_series_obj):
     obj = index_or_series_obj
     obj = np.repeat(obj, range(1, len(obj) + 1))
+
+    if obj.dtype == np.float16:
+        pytest.xfail("we don't have Float16Index, so value_counts is problematic")
+
     result = obj.value_counts()
 
     counter = collections.Counter(obj)
@@ -56,6 +60,9 @@ def test_value_counts(index_or_series_obj):
 def test_value_counts_null(null_obj, index_or_series_obj):
     orig = index_or_series_obj
     obj = orig.copy()
+
+    if obj.dtype == np.float16:
+        pytest.xfail("we don't have Float16Index, so value_counts is problematic")
 
     if not allow_na_ops(obj):
         pytest.skip("type doesn't allow for NA operations")

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -736,7 +736,7 @@ class TestDataFrameIndexing:
 
         # positional slicing only via iloc!
         msg = (
-            "cannot do positional indexing on Float64Index with "
+            "cannot do positional indexing on NumericIndex with "
             r"these indexers \[1.0\] of type float"
         )
         with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/frame/methods/test_set_index.py
+++ b/pandas/tests/frame/methods/test_set_index.py
@@ -159,7 +159,7 @@ class TestSetIndex:
         df = DataFrame(
             {"A": [1.1, 2.2, 3.3], "B": [5.0, 6.1, 7.2]}, index=[2010, 2011, 2012]
         )
-        df2 = df.set_index(df.index.astype(np.int32))
+        df2 = df.set_index(df.index.astype(int))
         tm.assert_frame_equal(df, df2)
 
     # A has duplicate values, C does not

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -93,7 +93,7 @@ def test_groupby_nonobject_dtype(mframe, df_mixed_floats):
     result = grouped.sum()
 
     expected = mframe.groupby(key.astype("O")).sum()
-    tm.assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected, check_index_type=False)
 
     # GH 3911, mixed frame non-conversion
     df = df_mixed_floats.copy()
@@ -228,6 +228,7 @@ def test_pass_args_kwargs_duplicate_columns(tsframe, as_index):
         2: tsframe[tsframe.index.month == 2].quantile(0.8),
     }
     expected = DataFrame(ex_data).T
+    expected.index = Index(range(1, 3), dtype=np.int32)
     if not as_index:
         # TODO: try to get this more consistent?
         expected.index = Index(range(2))
@@ -2814,7 +2815,7 @@ def test_groupby_overflow(val, dtype):
     result = df.groupby("a").sum()
     expected = DataFrame(
         {"b": [val * 2]},
-        index=Index([1], name="a", dtype=f"{dtype}64"),
+        index=Index([1], name="a", dtype=f"{dtype}8"),
         dtype=f"{dtype}64",
     )
     tm.assert_frame_equal(result, expected)
@@ -2826,7 +2827,7 @@ def test_groupby_overflow(val, dtype):
     result = df.groupby("a").prod()
     expected = DataFrame(
         {"b": [val * val]},
-        index=Index([1], name="a", dtype=f"{dtype}64"),
+        index=Index([1], name="a", dtype=f"{dtype}8"),
         dtype=f"{dtype}64",
     )
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -311,7 +311,7 @@ def test_transform_datetime_to_numeric():
         lambda x: x.dt.dayofweek - x.dt.dayofweek.min()
     )
 
-    expected = Series([0, 1], name="b")
+    expected = Series([0, 1], dtype=np.int32, name="b")
     tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -835,11 +835,7 @@ class NumericBase(Base):
 
         result = index.insert(0, index[0])
 
-        cls = type(index)
-        if cls is RangeIndex:
-            cls = Int64Index
-
-        expected = cls([index[0]] + list(index), dtype=index.dtype)
+        expected = Index([index[0]] + list(index), dtype=index.dtype)
         tm.assert_index_equal(result, expected, exact=True)
 
     def test_insert_na(self, nulls_fixture, simple_index):
@@ -850,7 +846,7 @@ class NumericBase(Base):
         if na_val is pd.NaT:
             expected = Index([index[0], pd.NaT] + list(index[1:]), dtype=object)
         else:
-            expected = Float64Index([index[0], np.nan] + list(index[1:]))
+            expected = Index([index[0], np.nan] + list(index[1:]))
 
             if index._is_backward_compat_public_numeric_index:
                 # GH#43921 we preserve NumericIndex

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -812,7 +812,7 @@ class TestDateRangeTZ:
 
         dr = date_range("2012-11-02", periods=10, tz=tzstr)
         result = dr.hour
-        expected = pd.Index([0] * 10)
+        expected = pd.Index([0] * 10, dtype="int32")
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("tzstr", ["US/Eastern", "dateutil/US/Eastern"])

--- a/pandas/tests/indexes/datetimes/test_misc.py
+++ b/pandas/tests/indexes/datetimes/test_misc.py
@@ -272,8 +272,9 @@ class TestDatetime64:
 
     def test_nanosecond_field(self):
         dti = DatetimeIndex(np.arange(10))
+        expected = Index(np.arange(10, dtype=np.int32))
 
-        tm.assert_index_equal(dti.nanosecond, Index(np.arange(10, dtype=np.int64)))
+        tm.assert_index_equal(dti.nanosecond, expected)
 
 
 def test_iter_readonly():

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -113,28 +113,28 @@ class TestDatetimeIndexTimezones:
         ts = ["2008-05-12 09:50:00", "2008-12-12 09:50:35", "2009-05-12 09:50:32"]
         tt = DatetimeIndex(ts).tz_localize("US/Eastern")
         ut = tt.tz_convert("UTC")
-        expected = Index([13, 14, 13])
+        expected = Index([13, 14, 13], dtype=np.int32)
         tm.assert_index_equal(ut.hour, expected)
 
         # sorted case UTC -> US/Eastern
         ts = ["2008-05-12 13:50:00", "2008-12-12 14:50:35", "2009-05-12 13:50:32"]
         tt = DatetimeIndex(ts).tz_localize("UTC")
         ut = tt.tz_convert("US/Eastern")
-        expected = Index([9, 9, 9])
+        expected = Index([9, 9, 9], dtype=np.int32)
         tm.assert_index_equal(ut.hour, expected)
 
         # unsorted case US/Eastern -> UTC
         ts = ["2008-05-12 09:50:00", "2008-12-12 09:50:35", "2008-05-12 09:50:32"]
         tt = DatetimeIndex(ts).tz_localize("US/Eastern")
         ut = tt.tz_convert("UTC")
-        expected = Index([13, 14, 13])
+        expected = Index([13, 14, 13], dtype=np.int32)
         tm.assert_index_equal(ut.hour, expected)
 
         # unsorted case UTC -> US/Eastern
         ts = ["2008-05-12 13:50:00", "2008-12-12 14:50:35", "2008-05-12 13:50:32"]
         tt = DatetimeIndex(ts).tz_localize("UTC")
         ut = tt.tz_convert("US/Eastern")
-        expected = Index([9, 9, 9])
+        expected = Index([9, 9, 9], dtype=np.int32)
         tm.assert_index_equal(ut.hour, expected)
 
     @pytest.mark.parametrize("tz", ["US/Eastern", "dateutil/US/Eastern"])
@@ -149,7 +149,7 @@ class TestDatetimeIndexTimezones:
         ]
         tt = DatetimeIndex(ts)
         ut = tt.tz_convert("UTC")
-        expected = Index([13, 14, 13])
+        expected = Index([13, 14, 13], dtype=np.int32)
         tm.assert_index_equal(ut.hour, expected)
 
         # sorted case UTC -> US/Eastern
@@ -160,7 +160,7 @@ class TestDatetimeIndexTimezones:
         ]
         tt = DatetimeIndex(ts)
         ut = tt.tz_convert("US/Eastern")
-        expected = Index([9, 9, 9])
+        expected = Index([9, 9, 9], dtype=np.int32)
         tm.assert_index_equal(ut.hour, expected)
 
         # unsorted case US/Eastern -> UTC
@@ -171,7 +171,7 @@ class TestDatetimeIndexTimezones:
         ]
         tt = DatetimeIndex(ts)
         ut = tt.tz_convert("UTC")
-        expected = Index([13, 14, 13])
+        expected = Index([13, 14, 13], dtype=np.int32)
         tm.assert_index_equal(ut.hour, expected)
 
         # unsorted case UTC -> US/Eastern
@@ -182,7 +182,7 @@ class TestDatetimeIndexTimezones:
         ]
         tt = DatetimeIndex(ts)
         ut = tt.tz_convert("US/Eastern")
-        expected = Index([9, 9, 9])
+        expected = Index([9, 9, 9], dtype=np.int32)
         tm.assert_index_equal(ut.hour, expected)
 
     @pytest.mark.parametrize("freq, n", [("H", 1), ("T", 60), ("S", 3600)])
@@ -194,7 +194,7 @@ class TestDatetimeIndexTimezones:
         idx = idx.tz_convert("Europe/Moscow")
 
         expected = np.repeat(np.array([3, 4, 5]), np.array([n, n, 1]))
-        tm.assert_index_equal(idx.hour, Index(expected))
+        tm.assert_index_equal(idx.hour, Index(expected, dtype=np.int32))
 
     def test_dti_tz_convert_dst(self):
         for freq, n in [("H", 1), ("T", 60), ("S", 3600)]:
@@ -207,7 +207,7 @@ class TestDatetimeIndexTimezones:
                 np.array([18, 19, 20, 21, 22, 23, 0, 1, 3, 4, 5]),
                 np.array([n, n, n, n, n, n, n, n, n, n, 1]),
             )
-            tm.assert_index_equal(idx.hour, Index(expected))
+            tm.assert_index_equal(idx.hour, Index(expected, dtype=np.int32))
 
             idx = date_range(
                 "2014-03-08 18:00", "2014-03-09 05:00", freq=freq, tz="US/Eastern"
@@ -217,7 +217,7 @@ class TestDatetimeIndexTimezones:
                 np.array([23, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
                 np.array([n, n, n, n, n, n, n, n, n, n, 1]),
             )
-            tm.assert_index_equal(idx.hour, Index(expected))
+            tm.assert_index_equal(idx.hour, Index(expected, dtype=np.int32))
 
             # End DST
             idx = date_range(
@@ -228,7 +228,7 @@ class TestDatetimeIndexTimezones:
                 np.array([19, 20, 21, 22, 23, 0, 1, 1, 2, 3, 4]),
                 np.array([n, n, n, n, n, n, n, n, n, n, 1]),
             )
-            tm.assert_index_equal(idx.hour, Index(expected))
+            tm.assert_index_equal(idx.hour, Index(expected, dtype=np.int32))
 
             idx = date_range(
                 "2014-11-01 18:00", "2014-11-02 05:00", freq=freq, tz="US/Eastern"
@@ -238,30 +238,30 @@ class TestDatetimeIndexTimezones:
                 np.array([22, 23, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
                 np.array([n, n, n, n, n, n, n, n, n, n, n, n, 1]),
             )
-            tm.assert_index_equal(idx.hour, Index(expected))
+            tm.assert_index_equal(idx.hour, Index(expected, dtype=np.int32))
 
         # daily
         # Start DST
         idx = date_range("2014-03-08 00:00", "2014-03-09 00:00", freq="D", tz="UTC")
         idx = idx.tz_convert("US/Eastern")
-        tm.assert_index_equal(idx.hour, Index([19, 19]))
+        tm.assert_index_equal(idx.hour, Index([19, 19], dtype=np.int32))
 
         idx = date_range(
             "2014-03-08 00:00", "2014-03-09 00:00", freq="D", tz="US/Eastern"
         )
         idx = idx.tz_convert("UTC")
-        tm.assert_index_equal(idx.hour, Index([5, 5]))
+        tm.assert_index_equal(idx.hour, Index([5, 5], dtype=np.int32))
 
         # End DST
         idx = date_range("2014-11-01 00:00", "2014-11-02 00:00", freq="D", tz="UTC")
         idx = idx.tz_convert("US/Eastern")
-        tm.assert_index_equal(idx.hour, Index([20, 20]))
+        tm.assert_index_equal(idx.hour, Index([20, 20], dtype=np.int32))
 
         idx = date_range(
             "2014-11-01 00:00", "2014-11-02 000:00", freq="D", tz="US/Eastern"
         )
         idx = idx.tz_convert("UTC")
-        tm.assert_index_equal(idx.hour, Index([4, 4]))
+        tm.assert_index_equal(idx.hour, Index([4, 4], dtype=np.int32))
 
     def test_tz_convert_roundtrip(self, tz_aware_fixture):
         tz = tz_aware_fixture
@@ -1134,7 +1134,7 @@ class TestDatetimeIndexTimezones:
             "2011-10-02 00:00", freq="h", periods=10, tz=prefix + "America/Atikokan"
         )
 
-        expected = Index(np.arange(10, dtype=np.int64))
+        expected = Index(np.arange(10, dtype=np.int32))
         tm.assert_index_equal(dr.hour, expected)
 
     @pytest.mark.parametrize("tz", [pytz.timezone("US/Eastern"), gettz("US/Eastern")])

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -10,6 +10,10 @@ from pandas import (
     Series,
 )
 import pandas._testing as tm
+from pandas.api.types import (
+    is_float_dtype,
+    is_unsigned_integer_dtype,
+)
 
 
 @pytest.mark.parametrize("case", [0.5, "xxx"])
@@ -624,7 +628,10 @@ def test_union_duplicates(index, request):
     expected = mi2.sort_values()
     tm.assert_index_equal(result, expected)
 
-    if mi2.levels[0].dtype == np.uint64 and (mi2.get_level_values(0) < 2**63).all():
+    if (
+        is_unsigned_integer_dtype(mi2.levels[0])
+        and (mi2.get_level_values(0) < 2**63).all()
+    ):
         # GH#47294 - union uses lib.fast_zip, converting data to Python integers
         # and loses type information. Result is then unsigned only when values are
         # sufficiently large to require unsigned dtype. This happens only if other
@@ -632,6 +639,13 @@ def test_union_duplicates(index, request):
         expected = expected.set_levels(
             [expected.levels[0].astype(int), expected.levels[1]]
         )
+    elif is_float_dtype(mi2.levels[0]):
+        # mi2 has duplicates witch is a different path than above, Fix that path
+        # to use correct float dtype?
+        expected = expected.set_levels(
+            [expected.levels[0].astype(float), expected.levels[1]]
+        )
+
     result = mi1.union(mi2)
     tm.assert_index_equal(result, expected)
 

--- a/pandas/tests/indexes/numeric/test_astype.py
+++ b/pandas/tests/indexes/numeric/test_astype.py
@@ -67,7 +67,7 @@ class TestAstype:
 
         idx = Float64Index([0, 1.1, 2])
         result = idx.astype(dtype)
-        expected = Index(idx.values.astype(dtype))
+        expected = Float64Index(idx.values.astype(dtype))
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("dtype", ["M8[ns]", "m8[ns]"])

--- a/pandas/tests/indexes/ranges/test_join.py
+++ b/pandas/tests/indexes/ranges/test_join.py
@@ -66,7 +66,7 @@ class TestJoin:
         elidx = np.array([8, 9], dtype=np.intp)
         eridx = np.array([9, 7], dtype=np.intp)
 
-        assert isinstance(res, Int64Index)
+        assert isinstance(res, Index) and res.dtype == np.int64
         tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -218,7 +218,7 @@ class TestRangeIndex(NumericBase):
 
         loc = [0, 3, 5]
         result = idx.delete(loc)
-        expected = Int64Index([1, 2, 4])
+        expected = Index([1, 2, 4])
         tm.assert_index_equal(result, expected, exact=True)
 
         result = idx.delete(loc[::-1])
@@ -536,8 +536,8 @@ class TestRangeIndex(NumericBase):
             ([RI(2), RI(2, 5), RI(5, 8, 4)], RI(0, 6)),
             ([RI(2), RI(3, 5), RI(5, 8, 4)], I64([0, 1, 3, 4, 5])),
             ([RI(-2, 2), RI(2, 5), RI(5, 8, 4)], RI(-2, 6)),
-            ([RI(3), I64([-1, 3, 15])], I64([0, 1, 2, -1, 3, 15])),
-            ([RI(3), F64([-1, 3.1, 15.0])], F64([0, 1, 2, -1, 3.1, 15.0])),
+            ([RI(3), OI([-1, 3, 15])], OI([0, 1, 2, -1, 3, 15])),
+            ([RI(3), OI([-1, 3.1, 15.0])], OI([0, 1, 2, -1, 3.1, 15.0])),
             ([RI(3), OI(["a", None, 14])], OI([0, 1, 2, "a", None, 14])),
             ([RI(3, 1), OI(["a", None, 14])], OI(["a", None, 14])),
         ]

--- a/pandas/tests/indexes/ranges/test_setops.py
+++ b/pandas/tests/indexes/ranges/test_setops.py
@@ -16,16 +16,15 @@ from pandas.core.indexes.api import (
     Index,
     Int64Index,
     RangeIndex,
-    UInt64Index,
 )
 
 
 class TestRangeIndexSetOps:
-    @pytest.mark.parametrize("klass", [RangeIndex, Int64Index, UInt64Index])
-    def test_intersection_mismatched_dtype(self, klass):
+    @pytest.mark.parametrize("dtype", [None, "int64", "uint64"])
+    def test_intersection_mismatched_dtype(self, dtype):
         # check that we cast to float, not object
         index = RangeIndex(start=0, stop=20, step=2, name="foo")
-        index = klass(index)
+        index = Index(index, dtype=dtype)
 
         flt = index.astype(np.float64)
 

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -547,7 +547,7 @@ class TestIndex(Base):
 
     def test_map_tseries_indices_accsr_return_index(self):
         date_index = tm.makeDateIndex(24, freq="h", name="hourly")
-        expected = Int64Index(range(24), name="hourly")
+        expected = Index(range(24), dtype="int32", name="hourly")
         tm.assert_index_equal(expected, date_index.map(lambda x: x.hour), exact=True)
 
     @pytest.mark.parametrize(

--- a/pandas/tests/indexes/test_index_new.py
+++ b/pandas/tests/indexes/test_index_new.py
@@ -10,8 +10,6 @@ from decimal import Decimal
 import numpy as np
 import pytest
 
-from pandas.core.dtypes.common import is_unsigned_integer_dtype
-
 from pandas import (
     NA,
     Categorical,
@@ -31,11 +29,7 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.core.api import (
-    Float64Index,
-    Int64Index,
-    UInt64Index,
-)
+from pandas.core.api import NumericIndex
 
 
 class TestIndexConstructorInference:
@@ -54,12 +48,7 @@ class TestIndexConstructorInference:
     )
     def test_constructor_int_dtype_float(self, dtype):
         # GH#18400
-        if is_unsigned_integer_dtype(dtype):
-            index_type = UInt64Index
-        else:
-            index_type = Int64Index
-
-        expected = index_type([0, 1, 2, 3])
+        expected = NumericIndex([0, 1, 2, 3], dtype=dtype)
         result = Index([0.0, 1.0, 2.0, 3.0], dtype=dtype)
         tm.assert_index_equal(result, expected)
 
@@ -258,7 +247,7 @@ class TestDtypeEnforced:
     )
     def test_constructor_dtypes_to_int64(self, vals):
         index = Index(vals, dtype=int)
-        assert isinstance(index, Int64Index)
+        assert isinstance(index, NumericIndex) and index.dtype == "int64"
 
     @pytest.mark.parametrize(
         "vals",
@@ -272,7 +261,7 @@ class TestDtypeEnforced:
     )
     def test_constructor_dtypes_to_float64(self, vals):
         index = Index(vals, dtype=float)
-        assert isinstance(index, Float64Index)
+        assert isinstance(index, NumericIndex) and index.dtype == "float64"
 
     @pytest.mark.parametrize(
         "vals",

--- a/pandas/tests/indexes/test_numpy_compat.py
+++ b/pandas/tests/indexes/test_numpy_compat.py
@@ -10,10 +10,8 @@ from pandas import (
     isna,
 )
 import pandas._testing as tm
-from pandas.core.api import (
-    Float64Index,
-    NumericIndex,
-)
+from pandas.api.types import is_complex_dtype
+from pandas.core.api import NumericIndex
 from pandas.core.arrays import BooleanArray
 from pandas.core.indexes.datetimelike import DatetimeIndexOpsMixin
 
@@ -81,8 +79,15 @@ def test_numpy_ufuncs_basic(index, func):
 
         tm.assert_index_equal(result, exp)
         if type(index) is not Index or index.dtype == bool:
-            # i.e NumericIndex
-            assert isinstance(result, Float64Index)
+            assert type(result) is NumericIndex
+            if is_complex_dtype(index):
+                assert result.dtype == "complex64"
+            elif index.dtype in ("bool", "int8", "uint8", "float16"):
+                assert result.dtype == "float16"
+            elif index.dtype in ("int16", "uint16", "float32"):
+                assert result.dtype == "float32"
+            else:
+                assert result.dtype == "float64"
         else:
             # e.g. np.exp with Int64 -> Float64
             assert type(result) is Index

--- a/pandas/tests/indexes/test_numpy_compat.py
+++ b/pandas/tests/indexes/test_numpy_compat.py
@@ -82,7 +82,7 @@ def test_numpy_ufuncs_basic(index, func):
             assert type(result) is NumericIndex
             if is_complex_dtype(index):
                 assert result.dtype == "complex64"
-            elif index.dtype in {
+            elif index.dtype in [
                 "bool",
                 "int8",
                 "int16",
@@ -90,7 +90,7 @@ def test_numpy_ufuncs_basic(index, func):
                 "uint16",
                 "float16",
                 "float32",
-            }:
+            ]:
                 assert result.dtype == "float32"
             else:
                 assert result.dtype == "float64"

--- a/pandas/tests/indexes/test_numpy_compat.py
+++ b/pandas/tests/indexes/test_numpy_compat.py
@@ -82,9 +82,15 @@ def test_numpy_ufuncs_basic(index, func):
             assert type(result) is NumericIndex
             if is_complex_dtype(index):
                 assert result.dtype == "complex64"
-            elif index.dtype in ("bool", "int8", "uint8", "float16"):
-                assert result.dtype == "float16"
-            elif index.dtype in ("int16", "uint16", "float32"):
+            elif index.dtype in {
+                "bool",
+                "int8",
+                "int16",
+                "uint8",
+                "uint16",
+                "float16",
+                "float32",
+            }:
                 assert result.dtype == "float32"
             else:
                 assert result.dtype == "float64"

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -14,7 +14,6 @@ from pandas import (
 )
 import pandas._testing as tm
 from pandas.core.arrays import TimedeltaArray
-from pandas.core.indexes.api import Int64Index
 from pandas.tests.indexes.datetimelike import DatetimeLike
 
 randn = np.random.randn
@@ -56,7 +55,7 @@ class TestTimedeltaIndex(DatetimeLike):
 
         f = lambda x: x.days
         result = rng.map(f)
-        exp = Int64Index([f(x) for x in rng])
+        exp = Index([f(x) for x in rng], dtype=np.int32)
         tm.assert_index_equal(result, exp)
 
     def test_pass_TimedeltaIndex_to_index(self):
@@ -70,15 +69,16 @@ class TestTimedeltaIndex(DatetimeLike):
 
     def test_fields(self):
         rng = timedelta_range("1 days, 10:11:12.100123456", periods=2, freq="s")
-        tm.assert_index_equal(rng.days, Index([1, 1], dtype="int64"))
+        tm.assert_index_equal(rng.days, Index([1, 1], dtype=np.int32))
         tm.assert_index_equal(
             rng.seconds,
-            Index([10 * 3600 + 11 * 60 + 12, 10 * 3600 + 11 * 60 + 13], dtype="int64"),
+            Index([10 * 3600 + 11 * 60 + 12, 10 * 3600 + 11 * 60 + 13], dtype=np.int32),
         )
         tm.assert_index_equal(
-            rng.microseconds, Index([100 * 1000 + 123, 100 * 1000 + 123], dtype="int64")
+            rng.microseconds,
+            Index([100 * 1000 + 123, 100 * 1000 + 123], dtype=np.int32),
         )
-        tm.assert_index_equal(rng.nanoseconds, Index([456, 456], dtype="int64"))
+        tm.assert_index_equal(rng.nanoseconds, Index([456, 456], dtype=np.int32))
 
         msg = "'TimedeltaIndex' object has no attribute '{}'"
         with pytest.raises(AttributeError, match=msg.format("hours")):

--- a/pandas/tests/indexing/multiindex/test_partial.py
+++ b/pandas/tests/indexing/multiindex/test_partial.py
@@ -10,10 +10,7 @@ from pandas import (
     to_datetime,
 )
 import pandas._testing as tm
-from pandas.core.api import (
-    Float64Index,
-    Int64Index,
-)
+from pandas.core.api import NumericIndex
 
 
 class TestMultiIndexPartial:
@@ -160,13 +157,14 @@ class TestMultiIndexPartial:
         ser = ymd["A"]
         mi = ser.index
         assert isinstance(mi, MultiIndex)
+        level = mi.levels[0]
         if dtype is int:
-            assert isinstance(mi.levels[0], Int64Index)
+            assert isinstance(level, NumericIndex) and level.dtype == np.int64
         else:
-            assert isinstance(mi.levels[0], Float64Index)
+            assert isinstance(level, NumericIndex) and level.dtype == np.float64
 
-        assert 14 not in mi.levels[0]
-        assert not mi.levels[0]._should_fallback_to_positional
+        assert 14 not in level
+        assert not level._should_fallback_to_positional
         assert not mi._should_fallback_to_positional
 
         with pytest.raises(KeyError, match="14"):

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -437,7 +437,7 @@ class TestLocBaseIndependent:
 
         # raise a KeyError?
         msg = (
-            r"\"None of \[Int64Index\(\[1, 2\], dtype='int64'\)\] are "
+            r"\"None of \[NumericIndex\(\[1, 2\], dtype='int64'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -455,7 +455,7 @@ class TestLocBaseIndependent:
             s.loc[-1]
 
         msg = (
-            r"\"None of \[Int64Index\(\[-1, -2\], dtype='int64'\)\] are "
+            r"\"None of \[NumericIndex\(\[-1, -2\], dtype='int64'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -471,7 +471,7 @@ class TestLocBaseIndependent:
 
         s["a"] = 2
         msg = (
-            r"\"None of \[Int64Index\(\[-2\], dtype='int64'\)\] are "
+            r"\"None of \[NumericIndex\(\[-2\], dtype='int64'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -488,7 +488,7 @@ class TestLocBaseIndependent:
         df = DataFrame([["a"], ["b"]], index=[1, 2], columns=["value"])
 
         msg = (
-            r"\"None of \[Int64Index\(\[3\], dtype='int64'\)\] are "
+            r"\"None of \[NumericIndex\(\[3\], dtype='int64'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -508,7 +508,7 @@ class TestLocBaseIndependent:
         with pytest.raises(
             KeyError,
             match=re.escape(
-                "\"None of [Int64Index([3], dtype='int64')] are in the [index]\""
+                "\"None of [NumericIndex([3], dtype='int64')] are in the [index]\""
             ),
         ):
             s.loc[[3]]
@@ -1218,7 +1218,7 @@ class TestLocBaseIndependent:
         df = DataFrame(columns=["x", "y"])
         df.index = df.index.astype(np.int64)
         msg = (
-            r"None of \[Int64Index\(\[0, 1\], dtype='int64'\)\] "
+            r"None of \[NumericIndex\(\[0, 1\], dtype='int64'\)\] "
             r"are in the \[index\]"
         )
         with pytest.raises(KeyError, match=msg):

--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -403,7 +403,7 @@ class TestPartialSetting:
 
         # raises as nothing is in the index
         msg = (
-            r"\"None of \[Int64Index\(\[3, 3, 3\], dtype='int64'\)\] are "
+            r"\"None of \[NumericIndex\(\[3, 3, 3\], dtype='int64'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -484,7 +484,7 @@ class TestPartialSetting:
 
         # raises as nothing is in the index
         msg = (
-            r"\"None of \[Int64Index\(\[3, 3, 3\], dtype='int64', "
+            r"\"None of \[NumericIndex\(\[3, 3, 3\], dtype='int64', "
             r"name='idx'\)\] are in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):

--- a/pandas/tests/io/pytables/test_put.py
+++ b/pandas/tests/io/pytables/test_put.py
@@ -250,7 +250,7 @@ def test_column_multiindex(setup_path):
     df = DataFrame(np.arange(12).reshape(3, 4), columns=index)
     expected = df.copy()
     if isinstance(expected.index, RangeIndex):
-        expected.index = Int64Index(expected.index)
+        expected.index = Index(expected.index.to_numpy())
 
     with ensure_clean_store(setup_path) as store:
 
@@ -282,7 +282,7 @@ def test_column_multiindex(setup_path):
     df = DataFrame(np.arange(12).reshape(3, 4), columns=Index(list("ABCD"), name="foo"))
     expected = df.copy()
     if isinstance(expected.index, RangeIndex):
-        expected.index = Int64Index(expected.index)
+        expected.index = Index(expected.index.to_numpy())
 
     with ensure_clean_store(setup_path) as store:
 

--- a/pandas/tests/io/pytables/test_put.py
+++ b/pandas/tests/io/pytables/test_put.py
@@ -21,7 +21,6 @@ from pandas import (
     _testing as tm,
     concat,
 )
-from pandas.core.api import Int64Index
 from pandas.tests.io.pytables.common import (
     _maybe_remove,
     ensure_clean_store,

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -831,8 +831,8 @@ class TestParquetPyArrow(Base):
         if partition_col:
             partition_col_type = "category"
 
-            expected_df[partition_col] = expected_df[partition_col].astype(
-                partition_col_type
+            expected_df[partition_col] = (
+                expected_df[partition_col].astype(np.int32).astype(partition_col_type)
             )
 
         check_round_trip(

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -648,7 +648,7 @@ def test_selection_api_validation():
     # non DatetimeIndex
     msg = (
         "Only valid with DatetimeIndex, TimedeltaIndex or PeriodIndex, "
-        "but got an instance of 'Int64Index'"
+        "but got an instance of 'NumericIndex'"
     )
     with pytest.raises(TypeError, match=msg):
         df.resample("2D", level="v")

--- a/pandas/tests/reshape/merge/test_multi.py
+++ b/pandas/tests/reshape/merge/test_multi.py
@@ -441,14 +441,13 @@ class TestMergeMulti:
         if klass is not None:
             on_vector = klass(on_vector)
 
-        expected = DataFrame({"a": [1, 2, 3], "key_1": [2016, 2017, 2018]})
+        exp_years = np.array([2016, 2017, 2018], dtype=np.int32)
+        expected = DataFrame({"a": [1, 2, 3], "key_1": exp_years})
 
         result = df.merge(df, on=["a", on_vector], how="inner")
         tm.assert_frame_equal(result, expected)
 
-        expected = DataFrame(
-            {"key_0": [2016, 2017, 2018], "a_x": [1, 2, 3], "a_y": [1, 2, 3]}
-        )
+        expected = DataFrame({"key_0": exp_years, "a_x": [1, 2, 3], "a_y": [1, 2, 3]})
 
         result = df.merge(df, on=[df.index.year], how="inner")
         tm.assert_frame_equal(result, expected)
@@ -852,14 +851,13 @@ class TestJoinMultiMulti:
         if box is not None:
             on_vector = box(on_vector)
 
-        expected = DataFrame({"a": [1, 2, 3], "key_1": [2016, 2017, 2018]})
+        exp_years = np.array([2016, 2017, 2018], dtype=np.int32)
+        expected = DataFrame({"a": [1, 2, 3], "key_1": exp_years})
 
         result = df.merge(df, on=["a", on_vector], how="inner")
         tm.assert_frame_equal(result, expected)
 
-        expected = DataFrame(
-            {"key_0": [2016, 2017, 2018], "a_x": [1, 2, 3], "a_y": [1, 2, 3]}
-        )
+        expected = DataFrame({"key_0": exp_years, "a_x": [1, 2, 3], "a_y": [1, 2, 3]})
 
         result = df.merge(df, on=[df.index.year], how="inner")
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -411,7 +411,14 @@ class TestPivotTable:
         res = df.pivot_table(index=df.index.month, columns=df.index.day)
 
         exp_columns = MultiIndex.from_tuples([("A", 1), ("A", 2)])
-        exp = DataFrame([[2.5, 4.0], [2.0, np.nan]], index=[1, 2], columns=exp_columns)
+        exp_columns = exp_columns.set_levels(
+            exp_columns.levels[1].astype(np.int32), level=1
+        )
+        exp = DataFrame(
+            [[2.5, 4.0], [2.0, np.nan]],
+            index=Index([1, 2], dtype=np.int32),
+            columns=exp_columns,
+        )
         tm.assert_frame_equal(res, exp)
 
         df = DataFrame(
@@ -424,7 +431,9 @@ class TestPivotTable:
         res = df.pivot_table(index=df.index.month, columns=Grouper(key="dt", freq="M"))
         exp_columns = MultiIndex.from_tuples([("A", pd.Timestamp("2011-01-31"))])
         exp_columns.names = [None, "dt"]
-        exp = DataFrame([3.25, 2.0], index=[1, 2], columns=exp_columns)
+        exp = DataFrame(
+            [3.25, 2.0], index=Index([1, 2], dtype=np.int32), columns=exp_columns
+        )
         tm.assert_frame_equal(res, exp)
 
         res = df.pivot_table(
@@ -1605,7 +1614,7 @@ class TestPivotTable:
         expected = DataFrame(
             {7: [0, 3], 8: [1, 4], 9: [2, 5]},
             index=exp_idx,
-            columns=Index([7, 8, 9], name="dt1"),
+            columns=Index([7, 8, 9], dtype=np.int32, name="dt1"),
         )
         tm.assert_frame_equal(result, expected)
 
@@ -1615,8 +1624,8 @@ class TestPivotTable:
 
         expected = DataFrame(
             {7: [0, 3], 8: [1, 4], 9: [2, 5]},
-            index=Index([1, 2], name="dt2"),
-            columns=Index([7, 8, 9], name="dt1"),
+            index=Index([1, 2], dtype=np.int32, name="dt2"),
+            columns=Index([7, 8, 9], dtype=np.int32, name="dt1"),
         )
         tm.assert_frame_equal(result, expected)
 
@@ -1628,10 +1637,16 @@ class TestPivotTable:
         )
 
         exp_col = MultiIndex.from_arrays(
-            [[7, 7, 8, 8, 9, 9], [1, 2] * 3], names=["dt1", "dt2"]
+            [
+                np.array([7, 7, 8, 8, 9, 9], dtype=np.int32),
+                np.array([1, 2] * 3, dtype=np.int32),
+            ],
+            names=["dt1", "dt2"],
         )
         expected = DataFrame(
-            np.array([[0, 3, 1, 4, 2, 5]], dtype="int64"), index=[2013], columns=exp_col
+            np.array([[0, 3, 1, 4, 2, 5]], dtype="int64"),
+            index=Index([2013], dtype=np.int32),
+            columns=exp_col,
         )
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/reshape/test_util.py
+++ b/pandas/tests/reshape/test_util.py
@@ -23,8 +23,8 @@ class TestCartesianProduct:
         # make sure that the ordering on datetimeindex is consistent
         x = date_range("2000-01-01", periods=2)
         result1, result2 = (Index(y).day for y in cartesian_product([x, x]))
-        expected1 = Index([1, 1, 2, 2])
-        expected2 = Index([1, 2, 1, 2])
+        expected1 = Index([1, 1, 2, 2], dtype=np.int32)
+        expected2 = Index([1, 2, 1, 2], dtype=np.int32)
         tm.assert_index_equal(result1, expected1)
         tm.assert_index_equal(result2, expected2)
 

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -229,14 +229,14 @@ class TestSeriesDatetimeValues:
         dti = date_range("20140204", periods=3, freq="s")
         ser = Series(dti, index=index, name="xxx")
         exp = Series(
-            np.array([2014, 2014, 2014], dtype="int64"), index=index, name="xxx"
+            np.array([2014, 2014, 2014], dtype="int32"), index=index, name="xxx"
         )
         tm.assert_series_equal(ser.dt.year, exp)
 
-        exp = Series(np.array([2, 2, 2], dtype="int64"), index=index, name="xxx")
+        exp = Series(np.array([2, 2, 2], dtype="int32"), index=index, name="xxx")
         tm.assert_series_equal(ser.dt.month, exp)
 
-        exp = Series(np.array([0, 1, 2], dtype="int64"), index=index, name="xxx")
+        exp = Series(np.array([0, 1, 2], dtype="int32"), index=index, name="xxx")
         tm.assert_series_equal(ser.dt.second, exp)
 
         exp = Series([ser[0]] * 3, index=index, name="xxx")
@@ -386,7 +386,7 @@ class TestSeriesDatetimeValues:
         dti = DatetimeIndex(["20171111", "20181212"]).repeat(2)
         ser = Series(pd.Categorical(dti), name="foo")
         result = ser.dt.year
-        expected = Series([2017, 2017, 2018, 2018], name="foo")
+        expected = Series([2017, 2017, 2018, 2018], name="foo", dtype="int32")
         tm.assert_series_equal(result, expected)
 
     def test_dt_tz_localize_categorical(self, tz_aware_fixture):
@@ -749,6 +749,7 @@ class TestSeriesDatetimeValues:
         expected = Series(
             [0, 1, 2, 3, 4],
             index=[2, 6, 7, 8, 11],
+            dtype="int32",
         )
         tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -1159,7 +1159,7 @@ class TestSetitemFloatNDarrayIntoIntegerSeries(SetitemCastingEquivalents):
         return Series(res_values)
 
 
-@pytest.mark.parametrize("val", [512, np.int16(512)])
+@pytest.mark.parametrize("val", [np.int16(512), np.int16(512)])
 class TestSetitemIntoIntegerSeriesNeedsUpcast(SetitemCastingEquivalents):
     @pytest.fixture
     def obj(self):
@@ -1174,7 +1174,7 @@ class TestSetitemIntoIntegerSeriesNeedsUpcast(SetitemCastingEquivalents):
         return Series([1, 512, 3], dtype=np.int16)
 
 
-@pytest.mark.parametrize("val", [2**33 + 1.0, 2**33 + 1.1, 2**62])
+@pytest.mark.parametrize("val", [2**30 + 1.0, 2**33 + 1.1, 2**62])
 class TestSmallIntegerSetitemUpcast(SetitemCastingEquivalents):
     # https://github.com/pandas-dev/pandas/issues/39584#issuecomment-941212124
     @pytest.fixture
@@ -1187,10 +1187,12 @@ class TestSmallIntegerSetitemUpcast(SetitemCastingEquivalents):
 
     @pytest.fixture
     def expected(self, val):
-        if val % 1 != 0:
+        if val > np.iinfo(np.int64).max:
             dtype = "f8"
-        else:
+        elif val > np.iinfo(np.int32).max:
             dtype = "i8"
+        else:
+            dtype = "i4"
         return Series([val, 2, 3], dtype=dtype)
 
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -44,6 +44,11 @@ from pandas import (
 )
 import pandas._testing as tm
 import pandas.core.algorithms as algos
+from pandas.core.api import (
+    Float64Index,
+    Int64Index,
+    UInt64Index,
+)
 from pandas.core.arrays import (
     DatetimeArray,
     TimedeltaArray,
@@ -55,6 +60,8 @@ class TestFactorize:
     @pytest.mark.parametrize("sort", [True, False])
     def test_factorize(self, index_or_series_obj, sort):
         obj = index_or_series_obj
+        if isinstance(obj, (Int64Index, UInt64Index, Float64Index)):
+            pytest.skip("temp. Numeric indexes will soon be removed")
         with tm.maybe_produces_warning(
             PerformanceWarning,
             sort

--- a/pandas/tests/util/test_assert_categorical_equal.py
+++ b/pandas/tests/util/test_assert_categorical_equal.py
@@ -22,8 +22,8 @@ def test_categorical_equal_order_mismatch(check_category_order):
         msg = """Categorical\\.categories are different
 
 Categorical\\.categories values are different \\(100\\.0 %\\)
-\\[left\\]:  Int64Index\\(\\[1, 2, 3, 4\\], dtype='int64'\\)
-\\[right\\]: Int64Index\\(\\[4, 3, 2, 1\\], dtype='int64'\\)"""
+\\[left\\]:  NumericIndex\\(\\[1, 2, 3, 4\\], dtype='int64'\\)
+\\[right\\]: NumericIndex\\(\\[4, 3, 2, 1\\], dtype='int64'\\)"""
         with pytest.raises(AssertionError, match=msg):
             tm.assert_categorical_equal(c1, c2, **kwargs)
     else:
@@ -34,8 +34,8 @@ def test_categorical_equal_categories_mismatch():
     msg = """Categorical\\.categories are different
 
 Categorical\\.categories values are different \\(25\\.0 %\\)
-\\[left\\]:  Int64Index\\(\\[1, 2, 3, 4\\], dtype='int64'\\)
-\\[right\\]: Int64Index\\(\\[1, 2, 3, 5\\], dtype='int64'\\)"""
+\\[left\\]:  NumericIndex\\(\\[1, 2, 3, 4\\], dtype='int64'\\)
+\\[right\\]: NumericIndex\\(\\[1, 2, 3, 5\\], dtype='int64'\\)"""
 
     c1 = Categorical([1, 2, 3, 4])
     c2 = Categorical([1, 2, 3, 5])

--- a/pandas/tests/util/test_assert_index_equal.py
+++ b/pandas/tests/util/test_assert_index_equal.py
@@ -17,7 +17,7 @@ def test_index_equal_levels_mismatch():
     msg = """Index are different
 
 Index levels are different
-\\[left\\]:  1, Int64Index\\(\\[1, 2, 3\\], dtype='int64'\\)
+\\[left\\]:  1, NumericIndex\\(\\[1, 2, 3\\], dtype='int64'\\)
 \\[right\\]: 2, MultiIndex\\(\\[\\('A', 1\\),
             \\('A', 2\\),
             \\('B', 3\\),
@@ -35,8 +35,8 @@ def test_index_equal_values_mismatch(check_exact):
     msg = """MultiIndex level \\[1\\] are different
 
 MultiIndex level \\[1\\] values are different \\(25\\.0 %\\)
-\\[left\\]:  Int64Index\\(\\[2, 2, 3, 4\\], dtype='int64'\\)
-\\[right\\]: Int64Index\\(\\[1, 2, 3, 4\\], dtype='int64'\\)"""
+\\[left\\]:  NumericIndex\\(\\[2, 2, 3, 4\\], dtype='int64'\\)
+\\[right\\]: NumericIndex\\(\\[1, 2, 3, 4\\], dtype='int64'\\)"""
 
     idx1 = MultiIndex.from_tuples([("A", 2), ("A", 2), ("B", 3), ("B", 4)])
     idx2 = MultiIndex.from_tuples([("A", 1), ("A", 2), ("B", 3), ("B", 4)])
@@ -49,8 +49,8 @@ def test_index_equal_length_mismatch(check_exact):
     msg = """Index are different
 
 Index length are different
-\\[left\\]:  3, Int64Index\\(\\[1, 2, 3\\], dtype='int64'\\)
-\\[right\\]: 4, Int64Index\\(\\[1, 2, 3, 4\\], dtype='int64'\\)"""
+\\[left\\]:  3, NumericIndex\\(\\[1, 2, 3\\], dtype='int64'\\)
+\\[right\\]: 4, NumericIndex\\(\\[1, 2, 3, 4\\], dtype='int64'\\)"""
 
     idx1 = Index([1, 2, 3])
     idx2 = Index([1, 2, 3, 4])
@@ -67,22 +67,29 @@ def test_index_equal_class(exact):
     tm.assert_index_equal(idx1, idx2, exact=exact)
 
 
-@pytest.mark.parametrize(
-    "idx_values, msg_str",
-    [
-        [[1, 2, 3.0], "Float64Index\\(\\[1\\.0, 2\\.0, 3\\.0\\], dtype='float64'\\)"],
-        [range(3), "RangeIndex\\(start=0, stop=3, step=1\\)"],
-    ],
-)
-def test_index_equal_class_mismatch(check_exact, idx_values, msg_str):
-    msg = f"""Index are different
+def test_int_float_index_equal_class_mismatch(check_exact):
+    msg = """Index are different
 
-Index classes are different
-\\[left\\]:  Int64Index\\(\\[1, 2, 3\\], dtype='int64'\\)
-\\[right\\]: {msg_str}"""
+Attribute "inferred_type" are different
+\\[left\\]:  integer
+\\[right\\]: floating"""
 
     idx1 = Index([1, 2, 3])
-    idx2 = Index(idx_values)
+    idx2 = Index([1, 2, 3], dtype=np.float64)
+
+    with pytest.raises(AssertionError, match=msg):
+        tm.assert_index_equal(idx1, idx2, exact=True, check_exact=check_exact)
+
+
+def test_range_index_equal_class_mismatch(check_exact):
+    msg = """Index are different
+
+Index classes are different
+\\[left\\]:  NumericIndex\\(\\[1, 2, 3\\], dtype='int64'\\)
+\\[right\\]: """
+
+    idx1 = Index([1, 2, 3])
+    idx2 = RangeIndex(range(3))
 
     with pytest.raises(AssertionError, match=msg):
         tm.assert_index_equal(idx1, idx2, exact=True, check_exact=check_exact)
@@ -96,8 +103,8 @@ def test_index_equal_values_close(check_exact):
         msg = """Index are different
 
 Index values are different \\(33\\.33333 %\\)
-\\[left\\]:  Float64Index\\(\\[1.0, 2.0, 3.0], dtype='float64'\\)
-\\[right\\]: Float64Index\\(\\[1.0, 2.0, 3.0000000001\\], dtype='float64'\\)"""
+\\[left\\]:  NumericIndex\\(\\[1.0, 2.0, 3.0], dtype='float64'\\)
+\\[right\\]: NumericIndex\\(\\[1.0, 2.0, 3.0000000001\\], dtype='float64'\\)"""
 
         with pytest.raises(AssertionError, match=msg):
             tm.assert_index_equal(idx1, idx2, check_exact=check_exact)
@@ -114,8 +121,8 @@ def test_index_equal_values_less_close(check_exact, rtol):
         msg = """Index are different
 
 Index values are different \\(33\\.33333 %\\)
-\\[left\\]:  Float64Index\\(\\[1.0, 2.0, 3.0], dtype='float64'\\)
-\\[right\\]: Float64Index\\(\\[1.0, 2.0, 3.0001\\], dtype='float64'\\)"""
+\\[left\\]:  NumericIndex\\(\\[1.0, 2.0, 3.0], dtype='float64'\\)
+\\[right\\]: NumericIndex\\(\\[1.0, 2.0, 3.0001\\], dtype='float64'\\)"""
 
         with pytest.raises(AssertionError, match=msg):
             tm.assert_index_equal(idx1, idx2, **kwargs)
@@ -131,8 +138,8 @@ def test_index_equal_values_too_far(check_exact, rtol):
     msg = """Index are different
 
 Index values are different \\(33\\.33333 %\\)
-\\[left\\]:  Int64Index\\(\\[1, 2, 3\\], dtype='int64'\\)
-\\[right\\]: Int64Index\\(\\[1, 2, 4\\], dtype='int64'\\)"""
+\\[left\\]:  NumericIndex\\(\\[1, 2, 3\\], dtype='int64'\\)
+\\[right\\]: NumericIndex\\(\\[1, 2, 4\\], dtype='int64'\\)"""
 
     with pytest.raises(AssertionError, match=msg):
         tm.assert_index_equal(idx1, idx2, **kwargs)
@@ -146,8 +153,8 @@ def test_index_equal_value_oder_mismatch(check_exact, rtol, check_order):
     msg = """Index are different
 
 Index values are different \\(66\\.66667 %\\)
-\\[left\\]:  Int64Index\\(\\[1, 2, 3\\], dtype='int64'\\)
-\\[right\\]: Int64Index\\(\\[3, 2, 1\\], dtype='int64'\\)"""
+\\[left\\]:  NumericIndex\\(\\[1, 2, 3\\], dtype='int64'\\)
+\\[right\\]: NumericIndex\\(\\[3, 2, 1\\], dtype='int64'\\)"""
 
     if check_order:
         with pytest.raises(AssertionError, match=msg):
@@ -168,8 +175,8 @@ def test_index_equal_level_values_mismatch(check_exact, rtol):
     msg = """MultiIndex level \\[1\\] are different
 
 MultiIndex level \\[1\\] values are different \\(25\\.0 %\\)
-\\[left\\]:  Int64Index\\(\\[2, 2, 3, 4\\], dtype='int64'\\)
-\\[right\\]: Int64Index\\(\\[1, 2, 3, 4\\], dtype='int64'\\)"""
+\\[left\\]:  NumericIndex\\(\\[2, 2, 3, 4\\], dtype='int64'\\)
+\\[right\\]: NumericIndex\\(\\[1, 2, 3, 4\\], dtype='int64'\\)"""
 
     with pytest.raises(AssertionError, match=msg):
         tm.assert_index_equal(idx1, idx2, **kwargs)
@@ -225,7 +232,7 @@ Index are different
 
 Index classes are different
 \\[left\\]:  RangeIndex\\(start=0, stop=10, step=1\\)
-\\[right\\]: Int64Index\\(\\[0, 1, 2, 3, 4, 5, 6, 7, 8, 9\\], dtype='int64'\\)"""
+\\[right\\]: NumericIndex\\(\\[0, 1, 2, 3, 4, 5, 6, 7, 8, 9\\], dtype='int64'\\)"""
 
     rcat = CategoricalIndex(RangeIndex(10))
     icat = CategoricalIndex(list(range(10)))


### PR DESCRIPTION
A part of the changes in pandas 2.0 will be that the current numeric indexes (Int64Index, Uint64Index & Float64Index) will be removed and their functionality added to the base Index. In addition, the base index should be able to handle all numpy numeric dtypes (int8, int16 tc.), not just the current int64, uint64 & float64.

This PR makes progress towards that. In this PR I:
* remove Int64Index, Uint64Index & Float64Index from the top namespace
* Make instantiation of `Index` with numpy numeric dtypes return a `NumericIndex` with the given dtype rather thanconverting to the old 64 bit only numeric index types, making all numeric dtypes available for indexes.

This is just the first part of the complete changes planned. In follow-ups PRs I will:
* remove Int64Index, Uint64Index & Float64Index from the code base entirely (also internally)
* Move the functionality of `NumericIndex`into the base `Index` and remove `NumericIndex`
* Update docs to reflect the above changes

## Notable changes from this PR:
One notable change from the PR is that because we now have all the numeric dtypes available for indexes, indexes created from DateTimeIndex (day, year etc.) will now be in int32, where previously they were forced to int64 (because that was the only index integer dtype available).

Using int32 is the more correct way, because the underlying `DateTimeArray` returns 32bit arrays. An example of this:

```ipython
>>> import pandas as pd
>>> 
>>> x = pd.date_range(start='1/1/2018', end='1/08/2018')
>>> x.array.day
array([1, 2, 3, 4, 5, 6, 7, 8], dtype=int32)  # 32bit, current and will not be changed in this series of PRs
>>> x.day
Int64Index([1, 2, 3, 4, 5, 6, 7, 8], dtype='int64')  # before this PR
NumericIndex([1, 2, 3, 4, 5, 6, 7, 8], dtype='int32')  # after this PR
Index([1, 2, 3, 4, 5, 6, 7, 8], dtype='int32')  # after follow-up PRs
```

xref #42717, #41272