### PR TITLE
STYLE enable pylint: comparison-of-constants

### DIFF
--- a/pandas/tests/io/parser/test_dialect.py
+++ b/pandas/tests/io/parser/test_dialect.py
@@ -97,9 +97,9 @@ def test_dialect_conflict_except_delimiter(all_parsers, custom_dialect, arg, val
 
     # arg=None tests when we pass in the dialect without any other arguments.
     if arg is not None:
-        if "value" == "dialect":  # No conflict --> no warning.
+        if value == "dialect":  # No conflict --> no warning.
             kwds[arg] = dialect_kwargs[arg]
-        elif "value" == "default":  # Default --> no warning.
+        elif value == "default":  # Default --> no warning.
             from pandas.io.parsers.base_parser import parser_defaults
 
             kwds[arg] = parser_defaults[arg]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,6 @@ disable = [
 
   # pylint type "R": refactor, for bad code smell
   "chained-comparison",
-  "comparison-of-constants",
   "comparison-with-itself",
   "consider-merging-isinstance",
   "consider-using-min-builtin",


### PR DESCRIPTION
Issue #48855. This PR enables pylint type "R" warning:` comparison-of-constants`
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).