### PR TITLE
BUG: Allow tz-aware Datetime SQL columns to be passed to parse_dates kwarg.

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1121,6 +1121,9 @@ class SQLTable(PandasObject):
             try:
                 df_col = self.frame[col_name]
 
+                # the type the dataframe column should have
+                col_type = self._get_dtype(sql_col.type)
+
                 # Handle date parsing upfront; don't try to convert columns
                 # twice
                 if col_name in parse_dates:
@@ -1128,11 +1131,12 @@ class SQLTable(PandasObject):
                         fmt = parse_dates[col_name]
                     except TypeError:
                         fmt = None
-                    self.frame[col_name] = _handle_date_column(df_col, format=fmt)
+                    # Convert tz-aware Datetime SQL columns to UTC
+                    utc = col_type is DatetimeTZDtype
+                    self.frame[col_name] = _handle_date_column(
+                        df_col, format=fmt, utc=utc
+                    )
                     continue
-
-                # the type the dataframe column should have
-                col_type = self._get_dtype(sql_col.type)
 
                 if (
                     col_type is datetime

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1781,7 +1781,7 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
                 )
 
         # GH11216
-        df = read_sql_query("select * from types", self.conn)
+        df = read_sql_table("types", self.conn)
         if not hasattr(df, "DateColWithTz"):
             request.node.add_marker(
                 pytest.mark.xfail(reason="no column with datetime with time zone")
@@ -1793,9 +1793,7 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
         col = df.DateColWithTz
         assert is_datetime64tz_dtype(col.dtype)
 
-        df = read_sql_query(
-            "select * from types", self.conn, parse_dates=["DateColWithTz"]
-        )
+        df = read_sql_table("types", self.conn, parse_dates=["DateColWithTz"])
         if not hasattr(df, "DateColWithTz"):
             request.node.add_marker(
                 pytest.mark.xfail(reason="no column with datetime with time zone")
@@ -1806,7 +1804,7 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
         check(df.DateColWithTz)
 
         df = concat(
-            list(read_sql_query("select * from types", self.conn, chunksize=1)),
+            list(read_sql_table("types", self.conn, chunksize=1)),
             ignore_index=True,
         )
         col = df.DateColWithTz


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This PR is related to existing tests which fail for me on the main branch, but they pass after making these changes.
```
FAILED pandas/tests/io/test_sql.py::TestPostgreSQLAlchemy::test_datetime_with_timezone - AssertionError: assert False
FAILED pandas/tests/io/test_sql.py::TestPostgreSQLAlchemyConn::test_datetime_with_timezone - AssertionError: assert False
```

Both tests fail here:
```
        # this is parsed on Travis (linux), but not on macosx for some reason
        # even with the same versions of psycopg2 & sqlalchemy, possibly a
        # Postgresql server version difference
        col = df.DateColWithTz
>       assert is_datetime64tz_dtype(col.dtype)
E       AssertionError: assert False
E        +  where False = is_datetime64tz_dtype(dtype('O'))
E        +    where dtype('O') = 0    2000-01-01 00:00:00-08:00\n1    2000-06-01 00:00:00-07:00\nName: DateColWithTz, dtype: object.dtype

pandas\tests\io\test_sql.py:1794: AssertionError
```