### PR TITLE
STYLE/PERF: replace string concatenations with f-strings in core

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1882,7 +1882,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         start = True
         cur_col_len = len(levheader)  # header
         sep_len, sep = (3, " < ") if self.ordered else (2, ", ")
-        linesep = sep.rstrip() + "\n"  # remove whitespace
+        linesep = f"{sep.rstrip()}\n"  # remove whitespace
         for val in category_strs:
             if max_width != 0 and cur_col_len + sep_len + len(val) > max_width:
                 levstring += linesep + (" " * (len(levheader) + 1))
@@ -1893,7 +1893,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
             levstring += val
             start = False
         # replace to simple save space by
-        return levheader + "[" + levstring.replace(" < ... < ", " ... ") + "]"
+        return f"{levheader}[{levstring.replace(' < ... < ', ' ... ')}]"
 
     def _repr_footer(self) -> str:
         info = self._repr_categories_info()

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -1058,7 +1058,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
             data = self.to_numpy("float64", na_value=np.nan)
 
         # median, var, std, skew, kurt, idxmin, idxmax
-        op = getattr(nanops, "nan" + name)
+        op = getattr(nanops, f"nan{name}")
         result = op(data, axis=0, skipna=skipna, mask=mask, **kwargs)
 
         if np.isnan(result):

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -317,11 +317,11 @@ class ArrowStringArray(ArrowExtensionArray, BaseStringArray, ObjectStringArrayMi
         return result
 
     def _str_startswith(self, pat: str, na=None):
-        pat = "^" + re.escape(pat)
+        pat = f"^{re.escape(pat)}"
         return self._str_contains(pat, na=na, regex=True)
 
     def _str_endswith(self, pat: str, na=None):
-        pat = re.escape(pat) + "$"
+        pat = f"{re.escape(pat)}$"
         return self._str_contains(pat, na=na, regex=True)
 
     def _str_replace(
@@ -345,14 +345,14 @@ class ArrowStringArray(ArrowExtensionArray, BaseStringArray, ObjectStringArrayMi
         self, pat: str, case: bool = True, flags: int = 0, na: Scalar | None = None
     ):
         if not pat.startswith("^"):
-            pat = "^" + pat
+            pat = f"^{pat}"
         return self._str_contains(pat, case, flags, na, regex=True)
 
     def _str_fullmatch(
         self, pat, case: bool = True, flags: int = 0, na: Scalar | None = None
     ):
         if not pat.endswith("$") or pat.endswith("//$"):
-            pat = pat + "$"
+            pat = f"{pat}$"
         return self._str_match(pat, case, flags, na)
 
     def _str_isalnum(self):

--- a/pandas/core/computation/expr.py
+++ b/pandas/core/computation/expr.py
@@ -410,7 +410,7 @@ class BaseExprVisitor(ast.NodeVisitor):
                     e.msg = "Python keyword not valid identifier in numexpr query"
                 raise e
 
-        method = "visit_" + type(node).__name__
+        method = f"visit_{type(node).__name__}"
         visitor = getattr(self, method)
         return visitor(node, **kwargs)
 

--- a/pandas/core/computation/parsing.py
+++ b/pandas/core/computation/parsing.py
@@ -59,7 +59,7 @@ def create_valid_python_identifier(name: str) -> str:
     )
 
     name = "".join([special_characters_replacements.get(char, char) for char in name])
-    name = "BACKTICK_QUOTED_STRING_" + name
+    name = f"BACKTICK_QUOTED_STRING_{name}"
 
     if not name.isidentifier():
         raise SyntaxError(f"Could not convert '{name}' to a valid Python identifier.")

--- a/pandas/core/computation/scope.py
+++ b/pandas/core/computation/scope.py
@@ -250,7 +250,7 @@ class Scope:
         variables = itertools.product(scopes, stack)
         for scope, (frame, _, _, _, _, _) in variables:
             try:
-                d = getattr(frame, "f_" + scope)
+                d = getattr(frame, f"f_{scope}")
                 self.scope = DeepChainMap(self.scope.new_child(d))
             finally:
                 # won't remove it, but DECREF it

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -802,7 +802,7 @@ class DatetimeTZDtype(PandasExtensionDtype):
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, str):
             if other.startswith("M8["):
-                other = "datetime64[" + other[3:]
+                other = f"datetime64[{other[3:]}"
             return other == self.name
 
         return (
@@ -1132,7 +1132,7 @@ class IntervalDtype(PandasExtensionDtype):
             )
             raise TypeError(msg)
 
-        key = str(subtype) + str(closed)
+        key = f"{subtype}{closed}"
         try:
             return cls._cache_dtypes[key]
         except KeyError:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1095,7 +1095,7 @@ class DataFrame(NDFrame, OpsMixin):
             # need to escape the <class>, should be the first line.
             val = buf.getvalue().replace("<", r"&lt;", 1)
             val = val.replace(">", r"&gt;", 1)
-            return "<pre>" + val + "</pre>"
+            return f"<pre>{val}</pre>"
 
         if get_option("display.notebook_repr_html"):
             max_rows = get_option("display.max_rows")
@@ -8845,8 +8845,7 @@ Parrot 2  Parrot       24.0
         if not self.columns.is_unique:
             duplicate_cols = self.columns[self.columns.duplicated()].tolist()
             raise ValueError(
-                "DataFrame columns must be unique. "
-                + f"Duplicate columns: {duplicate_cols}"
+                f"DataFrame columns must be unique. Duplicate columns: {duplicate_cols}"
             )
 
         columns: list[Hashable]

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1533,9 +1533,9 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                     with np.errstate(all="ignore"):
                         return func(g, *args, **kwargs)
 
-            elif hasattr(nanops, "nan" + func):
+            elif hasattr(nanops, f"nan{func}"):
                 # TODO: should we wrap this in to e.g. _is_builtin_func?
-                f = getattr(nanops, "nan" + func)
+                f = getattr(nanops, f"nan{func}")
 
             else:
                 raise ValueError(

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -337,7 +337,7 @@ class CategoricalIndex(NDArrayBackedExtensionIndex):
         attrs = [
             (
                 "categories",
-                "[" + ", ".join(self._data._repr_categories()) + "]",
+                f"[{', '.join(self._data._repr_categories())}]",
             ),
             ("ordered", self.ordered),
         ]

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -845,7 +845,7 @@ class IntervalIndex(ExtensionIndex):
     def _format_data(self, name=None) -> str:
         # TODO: integrate with categorical and make generic
         # name argument is unused here; just for compat with base / categorical
-        return self._data._format_data() + "," + self._format_space()
+        return f"{self._data._format_data()},{self._format_space()}"
 
     # --------------------------------------------------------------------
     # Set Operations

--- a/pandas/core/interchange/column.py
+++ b/pandas/core/interchange/column.py
@@ -329,7 +329,7 @@ class PandasColumn(Column):
             return buffer, dtype
 
         try:
-            msg = _NO_VALIDITY_BUFFER[null] + " so does not have a separate mask"
+            msg = f"{_NO_VALIDITY_BUFFER[null]} so does not have a separate mask"
         except KeyError:
             # TODO: implement for other bit/byte masks?
             raise NotImplementedError("See self.describe_null")

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1043,7 +1043,7 @@ def nansem(
 
 
 def _nanminmax(meth, fill_value_typ):
-    @bottleneck_switch(name="nan" + meth)
+    @bottleneck_switch(name=f"nan{meth}")
     @_datetimelike_compat
     def reduction(
         values: np.ndarray,

--- a/pandas/core/ops/docstrings.py
+++ b/pandas/core/ops/docstrings.py
@@ -25,11 +25,11 @@ def make_flex_doc(op_name: str, typ: str) -> str:
     op_desc_op = op_desc["op"]
     assert op_desc_op is not None  # for mypy
     if op_name.startswith("r"):
-        equiv = "other " + op_desc_op + " " + typ
+        equiv = f"other {op_desc_op} {typ}"
     elif op_name == "divmod":
         equiv = f"{op_name}({typ}, other)"
     else:
-        equiv = typ + " " + op_desc_op + " other"
+        equiv = f"{typ} {op_desc_op} other"
 
     if typ == "series":
         base_doc = _flex_doc_SERIES


### PR DESCRIPTION
Doing less concatenations and explicit cast calls in the core is likely to yield some performance improvements (see https://twitter.com/raymondh/status/1205969258800275456).

Split out of https://github.com/pandas-dev/pandas/pull/49229.
Refs https://github.com/pandas-dev/pandas/issues/29547 (a 2019 issue tracking replacing formatting with better alternatives)

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
