### PR TITLE
ENH/CoW: use lazy copy on replace method

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7213,6 +7213,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         if inplace:
             return self._update_inplace(result)
         else:
+            # GH 49473 Use "lazy copy" with Copy-on-Write
+            result = self.copy(deep=None)
             return result.__finalize__(self, method="replace")
 
     def interpolate(


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
This PR is part of an effort to implement the Copy-on-Write implementation mentioned in #49473. More detail in this proposal https://docs.google.com/document/d/1ZCQ9mx3LBMy-nhwRl33_jgcvWo9IWdEfxDNQ2thyTb0/edit / with discussions in https://github.com/pandas-dev/pandas/issues/36195