### PR TITLE
ENH/CoW: use lazy copy in set_index method

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5855,7 +5855,8 @@ class DataFrame(NDFrame, OpsMixin):
         if inplace:
             frame = self
         else:
-            frame = self.copy()
+            # GH 49473 Use "lazy copy" with Copy-on-Write
+            frame = self.copy(deep=None)
 
         arrays = []
         names: list[Hashable] = []

--- a/pandas/tests/copy_view/test_methods.py
+++ b/pandas/tests/copy_view/test_methods.py
@@ -218,16 +218,16 @@ def test_chained_methods(request, method, idx, using_copy_on_write):
 
 def test_set_index(using_copy_on_write):
     # GH 49473
-    df = DataFrame(
-        {
-            "month": [1, 4, 7, 10],
-            "year": [2012, 2014, 2013, 2014],
-            "sale": [55, 40, 84, 31],
-        }
-    )
-    df2 = df.set_index("month")
+    df = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [0.1, 0.2, 0.3]})
+    df_orig = df.copy()
+    df2 = df.set_index("a")
 
     if using_copy_on_write:
-        assert np.shares_memory(get_array(df2, "year"), get_array(df, "year"))
+        assert np.shares_memory(get_array(df2, "b"), get_array(df, "b"))
     else:
-        assert not np.shares_memory(get_array(df2, "year"), get_array(df, "year"))
+        assert not np.shares_memory(get_array(df2, "b"), get_array(df, "b"))
+
+    # mutating df2 triggers a copy-on-write for that column / block 
+    df2.iloc[0, 1] = 0 
+    assert not np.shares_memory(get_array(df2, "c"), get_array(df, "c"))
+    tm.assert_frame_equal(df, df_orig) 

--- a/pandas/tests/copy_view/test_methods.py
+++ b/pandas/tests/copy_view/test_methods.py
@@ -227,7 +227,7 @@ def test_set_index(using_copy_on_write):
     else:
         assert not np.shares_memory(get_array(df2, "b"), get_array(df, "b"))
 
-    # mutating df2 triggers a copy-on-write for that column / block 
-    df2.iloc[0, 1] = 0 
+    # mutating df2 triggers a copy-on-write for that column / block
+    df2.iloc[0, 1] = 0
     assert not np.shares_memory(get_array(df2, "c"), get_array(df, "c"))
-    tm.assert_frame_equal(df, df_orig) 
+    tm.assert_frame_equal(df, df_orig)

--- a/pandas/tests/copy_view/test_methods.py
+++ b/pandas/tests/copy_view/test_methods.py
@@ -214,3 +214,20 @@ def test_chained_methods(request, method, idx, using_copy_on_write):
     df.iloc[0, 0] = 0
     if not df2_is_view:
         tm.assert_frame_equal(df2.iloc[:, idx:], df_orig)
+
+
+def test_set_index(using_copy_on_write):
+    # GH 49473
+    df = DataFrame(
+        {
+            "month": [1, 4, 7, 10],
+            "year": [2012, 2014, 2013, 2014],
+            "sale": [55, 40, 84, 31],
+        }
+    )
+    df2 = df.set_index("month")
+
+    if using_copy_on_write:
+        assert np.shares_memory(get_array(df2, "year"), get_array(df, "year"))
+    else:
+        assert not np.shares_memory(get_array(df2, "year"), get_array(df, "year"))


### PR DESCRIPTION
Copy-on-Write in `set_index`
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
This PR is part of an effort to implement the Copy-on-Write implementation mentioned in #49473. More detail in this proposal https://docs.google.com/document/d/1ZCQ9mx3LBMy-nhwRl33_jgcvWo9IWdEfxDNQ2thyTb0/edit / with discussions in https://github.com/pandas-dev/pandas/issues/36195