### PR TITLE
CLN: MultiIndex._values remove special casing for Timestamp.freq

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -732,23 +732,13 @@ class MultiIndex(Index):
                 vals = cast("CategoricalIndex", vals)
                 vals = vals._data._internal_get_values()
 
-            is_dti = isinstance(vals, ABCDatetimeIndex)
-
-            if is_dti:
-                # TODO: this can be removed after Timestamp.freq is removed
-                # The astype(object) below does not remove the freq from
-                # the underlying Timestamps so we remove it here to match
-                # the behavior of self._get_level_values
-                vals = algos.take_nd(vals, codes, fill_value=index._na_value)
-
             if isinstance(vals.dtype, ExtensionDtype) or isinstance(
                 vals, (ABCDatetimeIndex, ABCTimedeltaIndex)
             ):
                 vals = vals.astype(object)
 
             vals = np.array(vals, copy=False)
-            if not is_dti:
-                vals = algos.take_nd(vals, codes, fill_value=index._na_value)
+            vals = algos.take_nd(vals, codes, fill_value=index._na_value)
             values.append(vals)
 
         arr = lib.fast_zip(values)


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.

Following removal of deprecated `Timestamp.freq` in #49365, we can remove the special casing in `MultiIndex._values`.