### PR TITLE
PERF: df.groupby(categorical)

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -531,6 +531,7 @@ Performance improvements
 - Performance improvements to :func:`read_sas` (:issue:`47403`, :issue:`47405`, :issue:`47656`, :issue:`48502`)
 - Memory improvement in :meth:`RangeIndex.sort_values` (:issue:`48801`)
 - Performance improvement in :class:`DataFrameGroupBy` and :class:`SeriesGroupBy` when ``by`` is a categorical type and ``sort=False`` (:issue:`48976`)
+- Performance improvement in :class:`DataFrameGroupBy` and :class:`SeriesGroupBy` when ``by`` is a categorical type and ``observed=False`` (:issue:`49596`)
 - Performance improvement in :func:`merge` when not merging on the index - the new index will now be :class:`RangeIndex` instead of :class:`Int64Index` (:issue:`49478`)
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1019,7 +1019,10 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         remove_unused_categories : Remove categories which are not used.
         set_categories : Set the categories to the specified ones.
         """
-        if set(self.dtype.categories) != set(new_categories):
+        if (
+            len(self.categories) != len(new_categories)
+            or not self.categories.difference(new_categories).empty
+        ):
             raise ValueError(
                 "items in new_categories are not the same as in old categories"
             )


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.0.0.rst` file if fixing a bug or adding a new feature.

Perf improvement in `Categorical.reorder_categories` with user facing performance improvements likely to be `DataFrame.groupby(categorical)`. 

```
import pandas as pd
import pandas._testing as tm

vals = pd.Series(tm.rands_array(10, 10**6), dtype="string")
df = pd.DataFrame({"cat": vals.astype("category")})

%timeit df.groupby("cat").size()

1.21 s ± 4.71 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)     <- main
15.1 ms ± 274 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  <- PR
```


existing ASVs:
```
       before           after         ratio
     [d69e63d7]       [382245ad]
     <main>           <cat-reorder-categories>
-      3.91±0.1ms       3.08±0.1ms     0.79  groupby.Categories.time_groupby_nosort
-     3.54±0.04ms      2.31±0.02ms     0.65  groupby.Categories.time_groupby_extra_cat_nosort
-     3.85±0.05ms       2.39±0.1ms     0.62  groupby.Categories.time_groupby_ordered_nosort
-     2.05±0.01ms          514±6μs     0.25  groupby.Categories.time_groupby_extra_cat_sort
-      2.21±0.1ms          536±4μs     0.24  groupby.Categories.time_groupby_sort
-      2.23±0.1ms         523±30μs     0.23  groupby.Categories.time_groupby_ordered_sort
```