### PR TITLE
STYLE Enable Pylint statement import-self

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,6 @@ disable = [
   "fixme",
   "global-statement",
   "global-variable-not-assigned",
-  "import-self",
   "invalid-envvar-default",
   "invalid-overridden-method",
   "keyword-arg-before-vararg",


### PR DESCRIPTION
Issue #48855.  This PR enables the pylint type "W" warning `import-self`.
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).