### PR TITLE
BUG: date_range with freq="C" (business days) return value changed on 1.5.0

### DIFF
--- a/doc/source/whatsnew/v1.5.2.rst
+++ b/doc/source/whatsnew/v1.5.2.rst
@@ -16,6 +16,7 @@ Fixed regressions
 - Fixed regression in :meth:`Series.replace` raising ``RecursionError`` with numeric dtype and when specifying ``value=None`` (:issue:`45725`)
 - Fixed regression in :meth:`DataFrame.plot` preventing :class:`~matplotlib.colors.Colormap` instance
   from being passed using the ``colormap`` argument if Matplotlib 3.6+ is used (:issue:`49374`)
+- Fixed regression in :func:`date_range` returning an invalid set of periods for ``CustomBusinessDay`` frequency and ``start`` date with timezone (:issue:`49441`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -254,7 +254,9 @@ cdef _to_dt64D(dt):
     if getattr(dt, 'tzinfo', None) is not None:
         # Get the nanosecond timestamp,
         #  equiv `Timestamp(dt).value` or `dt.timestamp() * 10**9`
-        naive = dt.astimezone(None)
+        # The `naive` must be the `dt` naive wall time
+        #  instead of the naive absolute time (GH#49441)
+        naive = dt.replace(tzinfo=None)
         dt = np.datetime64(naive, "D")
     else:
         dt = np.datetime64(dt)

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -1151,6 +1151,24 @@ class TestCustomDateRange:
         expected = DatetimeIndex([start])
         tm.assert_index_equal(result, expected)
 
+    @pytest.mark.parametrize(
+        "start,period,expected",
+        [
+            ("2022-07-23 00:00:00+02:00", 1, ["2022-07-25 00:00:00+02:00"]),
+            ("2022-07-22 00:00:00+02:00", 1, ["2022-07-22 00:00:00+02:00"]),
+            (
+                "2022-07-22 00:00:00+02:00",
+                2,
+                ["2022-07-22 00:00:00+02:00", "2022-07-25 00:00:00+02:00"],
+            ),
+        ],
+    )
+    def test_range_with_timezone_and_custombusinessday(self, start, period, expected):
+        # GH49441
+        result = date_range(start=start, periods=period, freq="C")
+        expected = DatetimeIndex(expected)
+        tm.assert_index_equal(result, expected)
+
 
 def test_date_range_with_custom_holidays():
     # GH 30593


### PR DESCRIPTION
- [ ] closes #49441 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
