### PR TITLE
TST/CI: Follow up fix test_write_fspath_all

### DIFF
--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -361,7 +361,7 @@ Look,a snake,🐍"""
             writer(string, **writer_kwargs)
             writer(mypath, **writer_kwargs)
             with open(string, "rb") as f_str, open(fspath, "rb") as f_path:
-                if writer == "to_excel":
+                if writer_name == "to_excel":
                     # binary representation of excel contains time creation
                     # data that causes flaky CI failures
                     result = pd.read_excel(f_str, **writer_kwargs)


### PR DESCRIPTION
Follow up to https://github.com/pandas-dev/pandas/pull/49509, was not hitting the more stable `pd.read_excel` path