### PR TITLE
make more comparisons work across dataframes of different manager types

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7453,7 +7453,8 @@ class DataFrame(NDFrame, OpsMixin):
             #  fails in cases with empty columns reached via
             #  _frame_arith_method_with_reindex
 
-            # TODO operate_blockwise expects a manager of the same type
+            if type(self._mgr) is not type(right._mgr):
+                raise ValueError("Expected DataFrames have managers of the same type.")
             with np.errstate(all="ignore"):
                 bm = self._mgr.operate_blockwise(
                     # error: Argument 1 to "operate_blockwise" of "ArrayManager" has

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7453,8 +7453,11 @@ class DataFrame(NDFrame, OpsMixin):
             #  fails in cases with empty columns reached via
             #  _frame_arith_method_with_reindex
 
-            if type(self._mgr) is not type(right._mgr):
-                raise ValueError("Expected DataFrames have managers of the same type.")
+            if isinstance(self._mgr, BlockManager) and isinstance(
+                right._mgr, ArrayManager
+            ):
+                raise ValueError("BlockManager -> ArrayManager operators don't work.")
+
             with np.errstate(all="ignore"):
                 bm = self._mgr.operate_blockwise(
                     # error: Argument 1 to "operate_blockwise" of "ArrayManager" has

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7453,11 +7453,6 @@ class DataFrame(NDFrame, OpsMixin):
             #  fails in cases with empty columns reached via
             #  _frame_arith_method_with_reindex
 
-            if isinstance(self._mgr, BlockManager) and isinstance(
-                right._mgr, ArrayManager
-            ):
-                raise ValueError("BlockManager -> ArrayManager operators don't work.")
-
             with np.errstate(all="ignore"):
                 bm = self._mgr.operate_blockwise(
                     # error: Argument 1 to "operate_blockwise" of "ArrayManager" has

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1403,8 +1403,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         if not (isinstance(other, type(self)) or isinstance(self, type(other))):
             return False
         other = cast(NDFrame, other)
-
-        # TODO: make this work with ArrayManager
+        
         return self._mgr.equals(other._mgr)
 
     # -------------------------------------------------------------------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1403,6 +1403,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         if not (isinstance(other, type(self)) or isinstance(self, type(other))):
             return False
         other = cast(NDFrame, other)
+
+        # TODO: make this work with ArrayManager
         return self._mgr.equals(other._mgr)
 
     # -------------------------------------------------------------------------

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -694,14 +694,7 @@ class BaseArrayManager(DataManager):
         Used in .equals defined in base class. Only check the column values
         assuming shape and indexes have already been checked.
         """
-        from pandas.core.internals.construction import mgr_to_mgr
 
-        # If not ArrayManager, implies that `other` is of type BlockManager
-        if not isinstance(other, ArrayManager):
-            # Because BlockManager exposes it's array in a list of multi-column NDArray
-            # but ArrayManager exposes arrays as a list of single-column NDArray.
-            # Therefore, we have to flatten BlockManager's array list
-            other = mgr_to_mgr(other, "array", copy=False)
 
         for left, right in zip(self.arrays, other.arrays):
             if not array_equals(left, right):
@@ -1051,9 +1044,9 @@ class ArrayManager(BaseArrayManager):
         """
         Apply array_op blockwise with another (aligned) BlockManager.
         """
-        from pandas.core.internals.construction import mgr_to_mgr
 
         if not isinstance(other, ArrayManager):
+            from pandas.core.internals.construction import mgr_to_mgr
             other = mgr_to_mgr(other, "array")
 
         result_arrays = [

--- a/pandas/core/internals/base.py
+++ b/pandas/core/internals/base.py
@@ -119,13 +119,6 @@ class DataManager(PandasObject):
         """
         Implementation for DataFrame.equals
         """
-        # prevent circular import
-        from pandas.core.internals import (
-            ArrayManager,
-            BlockManager,
-        )
-        from pandas.core.internals.construction import mgr_to_mgr
-
         if not isinstance(other, DataManager):
             return False
 
@@ -135,8 +128,17 @@ class DataManager(PandasObject):
         if not all(ax1.equals(ax2) for ax1, ax2 in zip(self_axes, other_axes)):
             return False
 
-        if isinstance(self, BlockManager) and isinstance(other, ArrayManager):
-            other = mgr_to_mgr(other, "block", copy=False)
+        if type(self) is not type(other):
+            from pandas.core.internals import (
+                ArrayManager,
+                BlockManager,
+            )
+            from pandas.core.internals.construction import mgr_to_mgr
+            if isinstance(self, BlockManager) and isinstance(other, ArrayManager):
+                other = mgr_to_mgr(other, "block", copy=False)
+            else:
+                # Here, we know self is ArrayManager so we convert other to array too
+                other = mgr_to_mgr(other, "array", copy=False)
         return self._equal_values(other)
 
     def apply(

--- a/pandas/core/internals/base.py
+++ b/pandas/core/internals/base.py
@@ -119,6 +119,12 @@ class DataManager(PandasObject):
         """
         Implementation for DataFrame.equals
         """
+        # prevent circular import
+        from pandas.core.internals import (
+            ArrayManager,
+            BlockManager,
+        )
+
         if not isinstance(other, DataManager):
             return False
 
@@ -128,6 +134,8 @@ class DataManager(PandasObject):
         if not all(ax1.equals(ax2) for ax1, ax2 in zip(self_axes, other_axes)):
             return False
 
+        if isinstance(self, BlockManager) and isinstance(other, ArrayManager):
+            raise ValueError("BlockManager -> ArrayManager operators don't work.")
         return self._equal_values(other)
 
     def apply(

--- a/pandas/core/internals/base.py
+++ b/pandas/core/internals/base.py
@@ -124,6 +124,7 @@ class DataManager(PandasObject):
             ArrayManager,
             BlockManager,
         )
+        from pandas.core.internals.construction import mgr_to_mgr
 
         if not isinstance(other, DataManager):
             return False
@@ -135,7 +136,7 @@ class DataManager(PandasObject):
             return False
 
         if isinstance(self, BlockManager) and isinstance(other, ArrayManager):
-            raise ValueError("BlockManager -> ArrayManager operators don't work.")
+            other = mgr_to_mgr(other, "block", copy=False)
         return self._equal_values(other)
 
     def apply(

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1571,11 +1571,10 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         """
         Apply array_op blockwise with another (aligned) BlockManager.
         """
-        from pandas.core.internals.construction import mgr_to_mgr
 
         if isinstance(other, ArrayManager):
-            # set copy = False? Is it guaranteed that array_op is immutable?
-            other = mgr_to_mgr(other, "block")
+            from pandas.core.internals.construction import mgr_to_mgr
+            other = mgr_to_mgr(other, "block", copy = False)
 
         return operate_blockwise(self, other, array_op)
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -68,6 +68,7 @@ from pandas.core.indexes.api import (
     Index,
     ensure_index,
 )
+from pandas.core.internals import ArrayManager
 from pandas.core.internals.base import (
     DataManager,
     SingleDataManager,
@@ -1570,6 +1571,9 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         """
         Apply array_op blockwise with another (aligned) BlockManager.
         """
+        if isinstance(other, ArrayManager):
+            raise ValueError("BlockManager -> ArrayManager operators don't work.")
+
         return operate_blockwise(self, other, array_op)
 
     def _equal_values(self: BlockManager, other: BlockManager) -> bool:

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1571,8 +1571,11 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         """
         Apply array_op blockwise with another (aligned) BlockManager.
         """
+        from pandas.core.internals.construction import mgr_to_mgr
+
         if isinstance(other, ArrayManager):
-            raise ValueError("BlockManager -> ArrayManager operators don't work.")
+            # set copy = False? Is it guaranteed that array_op is immutable?
+            other = mgr_to_mgr(other, "block")
 
         return operate_blockwise(self, other, array_op)
 

--- a/pandas/tests/internals/test_managers.py
+++ b/pandas/tests/internals/test_managers.py
@@ -22,15 +22,24 @@ def test_equality_comparison_different_dataframe_managers():
     with pd.option_context("mode.data_manager", "block"):
         df_block = pd.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]})
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="BlockManager -> ArrayManager operators don't work."
+    ):
         # Cannot compare two dataframes of different manager types using ==
-        _a = df_array == df_block
-    with pytest.raises(ValueError):
-        # Cannot compare two dataframes of different manager types using ==
-        _a = df_block == df_array
+        df_block == df_array
+    with pytest.raises(
+        ValueError, match="BlockManager -> ArrayManager operators don't work."
+    ):
+        df_block.equals(df_array)
 
     assert df_array.equals(df_block)
     assert df_array.equals(df_array1)
+
+    # Test that most comparison operators work
+    assert (df_array == df_block).all().all()
+    assert (df_array >= df_block).all().all()
+    assert not (df_array > df_block).any().any()
+    assert not (df_array < df_block).any().any()
 
     # TODO: this direction doesn't work right now
     # assert df_block.equals(df_array)

--- a/pandas/tests/internals/test_managers.py
+++ b/pandas/tests/internals/test_managers.py
@@ -1,7 +1,6 @@
 """
 Testing interaction between the different managers (BlockManager, ArrayManager)
 """
-import pytest
 
 from pandas.core.dtypes.missing import array_equivalent
 
@@ -22,18 +21,12 @@ def test_equality_comparison_different_dataframe_managers():
     with pd.option_context("mode.data_manager", "block"):
         df_block = pd.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]})
 
-    with pytest.raises(
-        ValueError, match="BlockManager -> ArrayManager operators don't work."
-    ):
-        # Cannot compare two dataframes of different manager types using ==
-        df_block == df_array
-    with pytest.raises(
-        ValueError, match="BlockManager -> ArrayManager operators don't work."
-    ):
-        df_block.equals(df_array)
+    assert (df_block == df_array).equals(df_array == df_block)
+    assert df_block.equals(df_array)
 
     assert df_array.equals(df_block)
     assert df_array.equals(df_array1)
+    assert df_block.equals(df_array)
 
     # Test that most comparison operators work
     assert (df_array == df_block).all().all()
@@ -41,8 +34,8 @@ def test_equality_comparison_different_dataframe_managers():
     assert not (df_array > df_block).any().any()
     assert not (df_array < df_block).any().any()
 
-    # TODO: this direction doesn't work right now
-    # assert df_block.equals(df_array)
+    assert (df_block + df_array).equals(df_array + df_block)
+    assert (df_array + df_array).equals(df_block + df_block)
 
 
 def test_dataframe_creation():

--- a/pandas/tests/internals/test_managers.py
+++ b/pandas/tests/internals/test_managers.py
@@ -1,6 +1,8 @@
 """
 Testing interaction between the different managers (BlockManager, ArrayManager)
 """
+import pytest
+
 from pandas.core.dtypes.missing import array_equivalent
 
 import pandas as pd
@@ -11,6 +13,27 @@ from pandas.core.internals import (
     SingleArrayManager,
     SingleBlockManager,
 )
+
+
+def test_equality_comparison_different_dataframe_managers():
+    with pd.option_context("mode.data_manager", "array"):
+        df_array = pd.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]})
+        df_array1 = df_array.copy()
+    with pd.option_context("mode.data_manager", "block"):
+        df_block = pd.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]})
+
+    with pytest.raises(ValueError):
+        # Cannot compare two dataframes of different manager types using ==
+        _a = df_array == df_block
+    with pytest.raises(ValueError):
+        # Cannot compare two dataframes of different manager types using ==
+        _a = df_block == df_array
+
+    assert df_array.equals(df_block)
+    assert df_array.equals(df_array1)
+
+    # TODO: this direction doesn't work right now
+    # assert df_block.equals(df_array)
 
 
 def test_dataframe_creation():


### PR DESCRIPTION
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This PR fixes issues with binary operators and `.equals` across two DataFrames with different managers (one with BlockManager, one with ArrayManager). 

1. When comparing using ` df (BlockManager) == df (ArrayManager)`, there would be a cryptic `AttributeError: 'ArrayManager' object has no attribute '_slice_take_blocks_ax0'`. Instead, we raise a ValueError exception that this comparison cannot be done.


2. Comparing using `df (ArrayManager) == df (BlockManager)` and `df (ArrayManager).equals( df(BlockManager) )` now works. It did not work before because BlockManager.arrays returns a nested list, whereas ArrayManager.arrays returns a flat list. Now, we flatten BlockManager.arrays which makes the comparisons work.


## Summary

Before, ArrayManager <-> BlockManager comparisons and operations did not work at all and would give cryptic error messages. 

Now, ArrayManager -> BlockManager operations work. BlockManager -> ArrayManager operations don't work but give a helpful `ValueError`.