### PR TITLE
STYLE: fix pylints redefined-outer-name warnings

### DIFF
--- a/pandas/core/dtypes/inference.py
+++ b/pandas/core/dtypes/inference.py
@@ -418,6 +418,7 @@ def is_dataclass(item):
     """
     try:
         import dataclasses as dcs
+
         return dcs.is_dataclass(item) and not isinstance(item, type)
     except ImportError:
         return False

--- a/pandas/core/dtypes/inference.py
+++ b/pandas/core/dtypes/inference.py
@@ -417,8 +417,8 @@ def is_dataclass(item):
 
     """
     try:
-        import dataclasses as dcs
+        import dataclasses
 
-        return dcs.is_dataclass(item) and not isinstance(item, type)
+        return dataclasses.is_dataclass(item) and not isinstance(item, type)
     except ImportError:
         return False

--- a/pandas/core/dtypes/inference.py
+++ b/pandas/core/dtypes/inference.py
@@ -418,7 +418,6 @@ def is_dataclass(item):
     """
     try:
         import dataclasses as dcs
-        
         return dcs.is_dataclass(item) and not isinstance(item, type)
     except ImportError:
         return False

--- a/pandas/core/dtypes/inference.py
+++ b/pandas/core/dtypes/inference.py
@@ -417,8 +417,8 @@ def is_dataclass(item):
 
     """
     try:
-        from dataclasses import is_dataclass
-
-        return is_dataclass(item) and not isinstance(item, type)
+        import dataclasses as dcs
+        
+        return dcs.is_dataclass(item) and not isinstance(item, type)
     except ImportError:
         return False

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6493,9 +6493,9 @@ class DataFrame(NDFrame, OpsMixin):
 
         inplace = validate_bool_kwarg(inplace, "inplace")
         ignore_index = validate_bool_kwarg(ignore_index, "ignore_index")
-        duplicated = self.duplicated(subset, keep=keep)
+        duplicate = self.duplicated(subset, keep=keep)
 
-        result = self[-duplicated]
+        result = self[-duplicate]
         if ignore_index:
             result.index = default_index(len(result))
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6493,9 +6493,8 @@ class DataFrame(NDFrame, OpsMixin):
 
         inplace = validate_bool_kwarg(inplace, "inplace")
         ignore_index = validate_bool_kwarg(ignore_index, "ignore_index")
-        duplicate = self.duplicated(subset, keep=keep)
 
-        result = self[-duplicate]
+        result = self[-self.duplicated(subset, keep=keep)]
         if ignore_index:
             result.index = default_index(len(result))
 


### PR DESCRIPTION
Fixed pylint redefined-outer-name warnings for following 2 files

**1. pandas\core\frame.py
2. pandas\core\dtypes\inference.py**

- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
