### PR TITLE
STYLE enable pylint's redefined-outer-name

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -5,8 +5,8 @@ Routines for casting.
 from __future__ import annotations
 
 from datetime import (
-    datetime,
-    timedelta,
+    datetime as datetime_func,
+    timedelta as timedelta_func,
 )
 import functools
 from typing import (
@@ -73,7 +73,7 @@ from pandas.core.dtypes.common import (
     is_string_dtype,
     is_timedelta64_dtype,
     is_unsigned_integer_dtype,
-    pandas_dtype,
+    pandas_dtype as pandas_dtype_func,
 )
 from pandas.core.dtypes.dtypes import (
     CategoricalDtype,
@@ -170,9 +170,9 @@ def maybe_box_datetimelike(value: Scalar, dtype: Dtype | None = None) -> Scalar:
     """
     if dtype == _dtype_obj:
         pass
-    elif isinstance(value, (np.datetime64, datetime)):
+    elif isinstance(value, (np.datetime64, datetime_func)):
         value = Timestamp(value)
-    elif isinstance(value, (np.timedelta64, timedelta)):
+    elif isinstance(value, (np.timedelta64, timedelta_func)):
         value = Timedelta(value)
 
     return value
@@ -761,7 +761,7 @@ def infer_dtype_from_scalar(val, pandas_dtype: bool = False) -> tuple[DtypeObj, 
 
         dtype = _dtype_obj
 
-    elif isinstance(val, (np.datetime64, datetime)):
+    elif isinstance(val, (np.datetime64, datetime_func)):
         try:
             val = Timestamp(val)
         except OutOfBoundsDatetime:
@@ -781,7 +781,7 @@ def infer_dtype_from_scalar(val, pandas_dtype: bool = False) -> tuple[DtypeObj, 
                 # return datetimetz as object
                 return _dtype_obj, val
 
-    elif isinstance(val, (np.timedelta64, timedelta)):
+    elif isinstance(val, (np.timedelta64, timedelta_func)):
         try:
             val = Timedelta(val)
         except (OutOfBoundsTimedelta, OverflowError):
@@ -1096,10 +1096,10 @@ def convert_dtypes(
             if not convert_string or inferred_dtype == "bytes":
                 return input_array.dtype
             else:
-                return pandas_dtype("string")
+                return pandas_dtype_func("string")
 
         if convert_integer:
-            target_int_dtype = pandas_dtype("Int64")
+            target_int_dtype = pandas_dtype_func("Int64")
 
             if is_integer_dtype(input_array.dtype):
                 from pandas.core.arrays.integer import INT_STR_TO_DTYPE
@@ -1128,7 +1128,7 @@ def convert_dtypes(
                 from pandas.core.arrays.floating import FLOAT_STR_TO_DTYPE
 
                 inferred_float_dtype: DtypeObj = FLOAT_STR_TO_DTYPE.get(
-                    input_array.dtype.name, pandas_dtype("Float64")
+                    input_array.dtype.name, pandas_dtype_func("Float64")
                 )
                 # if we could also convert to integer, check if all floats
                 # are actually integers
@@ -1136,7 +1136,7 @@ def convert_dtypes(
                     # TODO: de-dup with maybe_cast_to_integer_array?
                     arr = input_array[notna(input_array)]
                     if (arr.astype(int) == arr).all():
-                        inferred_dtype = pandas_dtype("Int64")
+                        inferred_dtype = pandas_dtype_func("Int64")
                     else:
                         inferred_dtype = inferred_float_dtype
                 else:
@@ -1146,13 +1146,13 @@ def convert_dtypes(
                 and is_object_dtype(input_array.dtype)
                 and inferred_dtype == "mixed-integer-float"
             ):
-                inferred_dtype = pandas_dtype("Float64")
+                inferred_dtype = pandas_dtype_func("Float64")
 
         if convert_boolean:
             if is_bool_dtype(input_array.dtype):
-                inferred_dtype = pandas_dtype("boolean")
+                inferred_dtype = pandas_dtype_func("boolean")
             elif isinstance(inferred_dtype, str) and inferred_dtype == "boolean":
-                inferred_dtype = pandas_dtype("boolean")
+                inferred_dtype = pandas_dtype_func("boolean")
 
         if isinstance(inferred_dtype, str):
             # If we couldn't do anything else, then we retain the dtype
@@ -1578,7 +1578,7 @@ def construct_1d_arraylike_from_scalar(
 def _maybe_box_and_unbox_datetimelike(value: Scalar, dtype: DtypeObj):
     # Caller is responsible for checking dtype.kind in ["m", "M"]
 
-    if isinstance(value, datetime):
+    if isinstance(value, datetime_func):
         # we dont want to box dt64, in particular datetime64("NaT")
         value = maybe_box_datetimelike(value, dtype)
 

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -3,11 +3,7 @@ Routines for casting.
 """
 
 from __future__ import annotations
-
-from datetime import (
-    datetime as datetime_func,
-    timedelta as timedelta_func,
-)
+import datetime as dt
 import functools
 from typing import (
     TYPE_CHECKING,
@@ -170,9 +166,9 @@ def maybe_box_datetimelike(value: Scalar, dtype: Dtype | None = None) -> Scalar:
     """
     if dtype == _dtype_obj:
         pass
-    elif isinstance(value, (np.datetime64, datetime_func)):
+    elif isinstance(value, (np.datetime64, dt.datetime)):
         value = Timestamp(value)
-    elif isinstance(value, (np.timedelta64, timedelta_func)):
+    elif isinstance(value, (np.timedelta64, dt.timedelta)):
         value = Timedelta(value)
 
     return value
@@ -761,7 +757,7 @@ def infer_dtype_from_scalar(val, pandas_dtype: bool = False) -> tuple[DtypeObj, 
 
         dtype = _dtype_obj
 
-    elif isinstance(val, (np.datetime64, datetime_func)):
+    elif isinstance(val, (np.datetime64, dt.datetime)):
         try:
             val = Timestamp(val)
         except OutOfBoundsDatetime:
@@ -781,7 +777,7 @@ def infer_dtype_from_scalar(val, pandas_dtype: bool = False) -> tuple[DtypeObj, 
                 # return datetimetz as object
                 return _dtype_obj, val
 
-    elif isinstance(val, (np.timedelta64, timedelta_func)):
+    elif isinstance(val, (np.timedelta64, dt.timedelta)):
         try:
             val = Timedelta(val)
         except (OutOfBoundsTimedelta, OverflowError):
@@ -1578,7 +1574,7 @@ def construct_1d_arraylike_from_scalar(
 def _maybe_box_and_unbox_datetimelike(value: Scalar, dtype: DtypeObj):
     # Caller is responsible for checking dtype.kind in ["m", "M"]
 
-    if isinstance(value, datetime_func):
+    if isinstance(value, dt.datetime):
         # we dont want to box dt64, in particular datetime64("NaT")
         value = maybe_box_datetimelike(value, dtype)
 

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -3,6 +3,7 @@ Routines for casting.
 """
 
 from __future__ import annotations
+
 import datetime as dt
 import functools
 from typing import (

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -17,13 +17,14 @@ import pytz
 from pandas._libs import missing as libmissing
 from pandas._libs.interval import Interval
 from pandas._libs.properties import cache_readonly
+from pandas._libs.tslibs.dtypes import NpyDatetimeUnit
+from pandas._libs.tslibs.dtypes import PeriodDtypeBase
 from pandas._libs.tslibs import (
     BaseOffset,
     NaT,
     NaTType,
     Period,
     Timestamp,
-    dtypes,
     timezones,
     to_offset,
     tz_compare,
@@ -716,10 +717,10 @@ class DatetimeTZDtype(PandasExtensionDtype):
         The NPY_DATETIMEUNIT corresponding to this dtype's resolution.
         """
         reso = {
-            "s": dtypes.NpyDatetimeUnit.NPY_FR_s,
-            "ms": dtypes.NpyDatetimeUnit.NPY_FR_ms,
-            "us": dtypes.NpyDatetimeUnit.NPY_FR_us,
-            "ns": dtypes.NpyDatetimeUnit.NPY_FR_ns,
+            "s": NpyDatetimeUnit.NPY_FR_s,
+            "ms": NpyDatetimeUnit.NPY_FR_ms,
+            "us": NpyDatetimeUnit.NPY_FR_us,
+            "ns": NpyDatetimeUnit.NPY_FR_ns,
         }[self.unit]
         return reso.value
 
@@ -820,7 +821,7 @@ class DatetimeTZDtype(PandasExtensionDtype):
 
 
 @register_extension_dtype
-class PeriodDtype(dtypes.PeriodDtypeBase, PandasExtensionDtype):
+class PeriodDtype(PeriodDtypeBase, PandasExtensionDtype):
     """
     An ExtensionDtype for Period data.
 
@@ -869,7 +870,7 @@ class PeriodDtype(dtypes.PeriodDtypeBase, PandasExtensionDtype):
         elif freq is None:
             # empty constructor for pickle compat
             # -10_000 corresponds to PeriodDtypeCode.UNDEFINED
-            u = dtypes.PeriodDtypeBase.__new__(cls, -10_000)
+            u = PeriodDtypeBase.__new__(cls, -10_000)
             u._freq = None
             return u
 
@@ -880,7 +881,7 @@ class PeriodDtype(dtypes.PeriodDtypeBase, PandasExtensionDtype):
             return cls._cache_dtypes[freq.freqstr]
         except KeyError:
             dtype_code = freq._period_dtype_code
-            u = dtypes.PeriodDtypeBase.__new__(cls, dtype_code)
+            u = PeriodDtypeBase.__new__(cls, dtype_code)
             u._freq = freq
             cls._cache_dtypes[freq.freqstr] = u
             return u

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -17,8 +17,6 @@ import pytz
 from pandas._libs import missing as libmissing
 from pandas._libs.interval import Interval
 from pandas._libs.properties import cache_readonly
-from pandas._libs.tslibs.dtypes import NpyDatetimeUnit
-from pandas._libs.tslibs.dtypes import PeriodDtypeBase
 from pandas._libs.tslibs import (
     BaseOffset,
     NaT,
@@ -28,6 +26,10 @@ from pandas._libs.tslibs import (
     timezones,
     to_offset,
     tz_compare,
+)
+from pandas._libs.tslibs.dtypes import (
+    NpyDatetimeUnit,
+    PeriodDtypeBase,
 )
 from pandas._typing import (
     Dtype,

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -134,8 +134,8 @@ from pandas.core.dtypes.missing import (
     is_valid_na_for_dtype,
     isna,
 )
-from pandas.core.missing import clean_reindex_fill_method
 from pandas.core import (
+    missing as missing_func,
     arraylike,
     ops,
 )
@@ -3649,7 +3649,7 @@ class Index(IndexOpsMixin, PandasObject):
         limit: int | None = None,
         tolerance=None,
     ) -> npt.NDArray[np.intp]:
-        method = clean_reindex_fill_method(method)
+        method = missing_func.clean_reindex_fill_method(method)
         orig_target = target
         target = self._maybe_cast_listlike_indexer(target)
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -134,7 +134,7 @@ from pandas.core.dtypes.missing import (
     is_valid_na_for_dtype,
     isna,
 )
-from pandas.core.missing import clean_reindex_fill_method
+
 from pandas.core import (
     arraylike,
     ops,
@@ -162,6 +162,7 @@ from pandas.core.construction import (
 )
 from pandas.core.indexers import disallow_ndim_indexing
 from pandas.core.indexes.frozen import FrozenList
+from pandas.core.missing import clean_reindex_fill_method
 from pandas.core.ops import get_op_result_name
 from pandas.core.ops.invalid import make_invalid_op
 from pandas.core.sorting import (

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -134,8 +134,8 @@ from pandas.core.dtypes.missing import (
     is_valid_na_for_dtype,
     isna,
 )
+from pandas.core.missing import clean_reindex_fill_method
 from pandas.core import (
-    missing as missing_func,
     arraylike,
     ops,
 )
@@ -3649,7 +3649,7 @@ class Index(IndexOpsMixin, PandasObject):
         limit: int | None = None,
         tolerance=None,
     ) -> npt.NDArray[np.intp]:
-        method = missing_func.clean_reindex_fill_method(method)
+        method = clean_reindex_fill_method(method)
         orig_target = target
         target = self._maybe_cast_listlike_indexer(target)
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -134,10 +134,9 @@ from pandas.core.dtypes.missing import (
     is_valid_na_for_dtype,
     isna,
 )
-
+from pandas.core.missing import clean_reindex_fill_method
 from pandas.core import (
     arraylike,
-    missing,
     ops,
 )
 from pandas.core.accessor import CachedAccessor
@@ -3650,7 +3649,7 @@ class Index(IndexOpsMixin, PandasObject):
         limit: int | None = None,
         tolerance=None,
     ) -> npt.NDArray[np.intp]:
-        method = missing.clean_reindex_fill_method(method)
+        method = clean_reindex_fill_method(method)
         orig_target = target
         target = self._maybe_cast_listlike_indexer(target)
 


### PR DESCRIPTION
Fixed warnings for the following files :-
- pandas/core/dtypes/cast.py
- pandas/core/dtypes/dtypes.py
- pandas/core/indexes/base.py