### PR TITLE
REGR: Remove groupby's __getattribute__ for nth

### DIFF
--- a/doc/source/whatsnew/v1.5.2.rst
+++ b/doc/source/whatsnew/v1.5.2.rst
@@ -18,6 +18,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.plot` preventing :class:`~matplotlib.colors.Colormap` instance
   from being passed using the ``colormap`` argument if Matplotlib 3.6+ is used (:issue:`49374`)
 - Fixed regression in :func:`date_range` returning an invalid set of periods for ``CustomBusinessDay`` frequency and ``start`` date with timezone (:issue:`49441`)
+- Fixed performance regression in groupby operations (:issue:`49676`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -984,15 +984,6 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             f"'{type(self).__name__}' object has no attribute '{attr}'"
         )
 
-    def __getattribute__(self, attr: str):
-        # Intercept nth to allow both call and index
-        if attr == "nth":
-            return GroupByNthSelector(self)
-        elif attr == "nth_actual":
-            return super().__getattribute__("nth")
-        else:
-            return super().__getattribute__(attr)
-
     @final
     def _op_via_apply(self, name: str, *args, **kwargs):
         """Compute the result of an operation by using GroupBy's apply."""
@@ -2936,13 +2927,10 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         return self._fill("bfill", limit=limit)
 
     @final
+    @property
     @Substitution(name="groupby")
     @Substitution(see_also=_common_see_also)
-    def nth(
-        self,
-        n: PositionalIndexer | tuple,
-        dropna: Literal["any", "all", None] = None,
-    ) -> NDFrameT:
+    def nth(self) -> GroupByNthSelector:
         """
         Take the nth row from each group if n is an int, otherwise a subset of rows.
 
@@ -3030,6 +3018,13 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         Columns: [A, B]
         Index: []
         """
+        return GroupByNthSelector(self)
+
+    def _nth(
+        self,
+        n: PositionalIndexer | tuple,
+        dropna: Literal["any", "all", None] = None,
+    ) -> NDFrameT:
         if not dropna:
             mask = self._make_mask_from_positional_indexer(n)
 

--- a/pandas/core/groupby/indexing.py
+++ b/pandas/core/groupby/indexing.py
@@ -297,7 +297,7 @@ class GroupByNthSelector:
         n: PositionalIndexer | tuple,
         dropna: Literal["any", "all", None] = None,
     ) -> DataFrame | Series:
-        return self.groupby_object.nth_actual(n, dropna)
+        return self.groupby_object._nth(n, dropna)
 
     def __getitem__(self, n: PositionalIndexer | tuple) -> DataFrame | Series:
-        return self.groupby_object.nth_actual(n)
+        return self.groupby_object._nth(n)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

The `__getattribute__` was added in 1.4 by #44688. Also makes stepping through code with a debugger a bit easier

```
       before           after         ratio
     [289f32df]       [ce18b3c6]
     <enforce_numeric_only_resampler~1>       <remove_nth_getattribute>
-      55.8±0.3μs       50.7±0.4μs     0.91  groupby.GroupByMethods.time_dtype_as_field('uint', 'var', 'direct', 1)
-      62.8±0.7μs       57.1±0.7μs     0.91  groupby.GroupByMethods.time_dtype_as_group('uint', 'mean', 'direct', 1)
-        71.4±1μs       64.8±0.6μs     0.91  groupby.GroupByMethods.time_dtype_as_group('int', 'last', 'direct', 1)
-      42.4±0.2μs       38.5±0.2μs     0.91  groupby.GroupByMethods.time_dtype_as_field('object', 'head', 'direct', 5)
-      72.1±0.6μs       65.4±0.8μs     0.91  groupby.GroupByMethods.time_dtype_as_group('float', 'prod', 'direct', 1)
-      72.9±0.3μs       66.1±0.5μs     0.91  groupby.GroupByMethods.time_dtype_as_field('datetime', 'min', 'direct', 1)
-        38.9±1μs      35.3±0.07μs     0.91  groupby.GroupByMethods.time_dtype_as_field('uint', 'head', 'direct', 1)
-        60.3±2μs         54.7±1μs     0.91  groupby.GroupByMethods.time_dtype_as_field('int16', 'mean', 'direct', 1)
-         245±6μs          223±7μs     0.91  groupby.GroupByMethods.time_dtype_as_field('int16', 'count', 'transformation', 1)
-      56.9±0.3μs       51.6±0.2μs     0.91  groupby.GroupByMethods.time_dtype_as_field('datetime', 'all', 'direct', 1)
-        61.9±2μs         56.1±1μs     0.91  groupby.GroupByMethods.time_dtype_as_field('float', 'first', 'direct', 1)
-      40.8±0.4μs       37.0±0.3μs     0.91  groupby.GroupByMethods.time_dtype_as_field('uint', 'head', 'direct', 5)
-      54.7±0.2μs       49.6±0.6μs     0.91  groupby.GroupByMethods.time_dtype_as_field('int16', 'var', 'direct', 1)
-      58.5±0.5μs         53.0±1μs     0.91  groupby.GroupByMethods.time_dtype_as_field('float', 'var', 'direct', 5)
-        60.1±2μs         54.5±1μs     0.91  groupby.GroupByMethods.time_dtype_as_field('int16', 'tail', 'direct', 5)
-         251±1μs          227±4μs     0.91  groupby.GroupByMethods.time_dtype_as_field('int', 'std', 'transformation', 1)
-      39.7±0.5μs       36.0±0.1μs     0.91  groupby.GroupByMethods.time_dtype_as_field('datetime', 'count', 'direct', 5)
-      61.1±0.1μs         55.3±1μs     0.91  groupby.GroupByMethods.time_dtype_as_field('uint', 'tail', 'direct', 5)
-         278±2μs          252±6μs     0.91  groupby.GroupByMethods.time_dtype_as_field('int16', 'mean', 'transformation', 1)
-      71.6±0.3μs       64.8±0.4μs     0.91  groupby.GroupByMethods.time_dtype_as_field('datetime', 'first', 'direct', 1)
-      39.0±0.9μs       35.3±0.3μs     0.90  groupby.GroupByMethods.time_dtype_as_group('int16', 'head', 'direct', 1)
-        38.6±2μs       34.9±0.1μs     0.90  groupby.GroupByMethods.time_dtype_as_group('uint', 'head', 'direct', 1)
-         262±4μs          236±5μs     0.90  groupby.GroupByMethods.time_dtype_as_field('int16', 'any', 'transformation', 1)
-      72.9±0.1μs       65.9±0.1μs     0.90  groupby.GroupByMethods.time_dtype_as_group('int', 'max', 'direct', 1)
-      79.6±0.6μs         71.9±1μs     0.90  groupby.GroupByMethods.time_dtype_as_field('int', 'max', 'direct', 5)
-        72.7±1μs       65.7±0.5μs     0.90  groupby.GroupByMethods.time_dtype_as_group('int', 'first', 'direct', 1)
-      61.6±0.2μs       55.7±0.3μs     0.90  groupby.GroupByMethods.time_dtype_as_field('uint', 'mean', 'direct', 1)
-      55.8±0.5μs       50.3±0.5μs     0.90  groupby.GroupByMethods.time_dtype_as_field('int', 'var', 'direct', 1)
-      51.2±0.6μs       46.2±0.4μs     0.90  groupby.GroupByMethods.time_dtype_as_group('int', 'any', 'direct', 5)
-        77.8±2μs         70.2±2μs     0.90  groupby.GroupByMethods.time_dtype_as_field('int16', 'min', 'direct', 5)
-      72.6±0.3μs       65.5±0.2μs     0.90  groupby.GroupByMethods.time_dtype_as_group('datetime', 'first', 'direct', 1)
-      73.9±0.7μs       66.7±0.5μs     0.90  groupby.GroupByMethods.time_dtype_as_group('int', 'min', 'direct', 1)
-        76.0±2μs         68.5±1μs     0.90  groupby.GroupByMethods.time_dtype_as_field('int16', 'last', 'direct', 5)
-        67.8±1μs       61.2±0.7μs     0.90  groupby.GroupByMethods.time_dtype_as_field('int', 'mean', 'direct', 5)
-      78.7±0.6μs         71.0±2μs     0.90  groupby.GroupByMethods.time_dtype_as_field('int16', 'max', 'direct', 5)
-        40.1±1μs         36.1±1μs     0.90  groupby.GroupByMethods.time_dtype_as_field('int16', 'head', 'direct', 5)
-      39.0±0.5μs       35.1±0.6μs     0.90  groupby.GroupByMethods.time_dtype_as_field('float', 'head', 'direct', 1)
-        74.6±1μs       67.2±0.3μs     0.90  groupby.GroupByMethods.time_dtype_as_group('float', 'sum', 'direct', 1)
-      78.6±0.4μs         70.8±1μs     0.90  groupby.GroupByMethods.time_dtype_as_field('int16', 'first', 'direct', 5)
-      61.2±0.4μs         55.1±2μs     0.90  groupby.GroupByMethods.time_dtype_as_field('int16', 'var', 'direct', 5)
-        38.0±1μs         34.2±1μs     0.90  groupby.GroupByMethods.time_dtype_as_field('int16', 'head', 'direct', 1)
-      89.6±0.5μs         80.7±2μs     0.90  groupby.GroupByMethods.time_dtype_as_field('int16', 'cumcount', 'direct', 1)
-      78.7±0.4μs       70.8±0.6μs     0.90  groupby.GroupByMethods.time_dtype_as_field('int', 'min', 'direct', 5)
-      79.4±0.5μs       71.5±0.2μs     0.90  groupby.GroupByMethods.time_dtype_as_field('uint', 'min', 'direct', 5)
-      73.0±0.7μs       65.6±0.3μs     0.90  groupby.GroupByMethods.time_dtype_as_group('int16', 'sum', 'direct', 1)
-        57.8±1μs         51.9±2μs     0.90  groupby.GroupByMethods.time_dtype_as_field('int16', 'tail', 'direct', 1)
-        32.1±1μs       28.9±0.4μs     0.90  groupby.GroupByMethods.time_dtype_as_group('uint', 'count', 'direct', 1)
-        41.3±1μs       37.2±0.4μs     0.90  groupby.GroupByMethods.time_dtype_as_field('object', 'head', 'direct', 1)
-        58.6±1μs       52.7±0.5μs     0.90  groupby.GroupByMethods.time_dtype_as_field('uint', 'tail', 'direct', 1)
-         249±1μs          224±3μs     0.90  groupby.GroupByMethods.time_dtype_as_field('float', 'std', 'transformation', 1)
-      78.9±0.8μs       70.9±0.4μs     0.90  groupby.GroupByMethods.time_dtype_as_field('uint', 'max', 'direct', 5)
-      31.4±0.6μs       28.2±0.4μs     0.90  groupby.GroupByMethods.time_dtype_as_group('object', 'count', 'direct', 1)
-      71.1±0.6μs         63.9±3μs     0.90  groupby.GroupByMethods.time_dtype_as_field('int', 'max', 'direct', 1)
-      73.8±0.9μs       66.2±0.1μs     0.90  groupby.GroupByMethods.time_dtype_as_group('int', 'sum', 'direct', 1)
-      71.0±0.5μs       63.7±0.5μs     0.90  groupby.GroupByMethods.time_dtype_as_field('int16', 'max', 'direct', 1)
-        39.7±1μs       35.6±0.2μs     0.90  groupby.GroupByMethods.time_dtype_as_group('float', 'head', 'direct', 1)
-      58.9±0.6μs       52.7±0.1μs     0.90  groupby.GroupByMethods.time_dtype_as_group('float', 'tail', 'direct', 1)
-        40.3±1μs       36.1±0.6μs     0.90  groupby.GroupByMethods.time_dtype_as_group('int', 'any', 'direct', 1)
-        44.9±1μs      40.2±0.08μs     0.89  groupby.GroupByMethods.time_dtype_as_field('uint', 'any', 'direct', 5)
-        39.3±1μs       35.2±0.5μs     0.89  groupby.GroupByMethods.time_dtype_as_group('datetime', 'all', 'direct', 1)
-      61.4±0.5μs       54.9±0.4μs     0.89  groupby.GroupByMethods.time_dtype_as_field('object', 'tail', 'direct', 1)
-      67.2±0.6μs       60.1±0.8μs     0.89  groupby.GroupByMethods.time_dtype_as_group('object', 'first', 'direct', 1)
-      71.1±0.8μs       63.5±0.1μs     0.89  groupby.GroupByMethods.time_dtype_as_field('datetime', 'last', 'direct', 1)
-      71.4±0.5μs       63.7±0.5μs     0.89  groupby.GroupByMethods.time_dtype_as_field('uint', 'first', 'direct', 1)
-       249±0.9μs          223±5μs     0.89  groupby.GroupByMethods.time_dtype_as_field('int16', 'std', 'transformation', 1)
-      66.0±0.3μs       58.9±0.6μs     0.89  groupby.GroupByMethods.time_dtype_as_group('object', 'last', 'direct', 1)
-      70.7±0.5μs       63.1±0.9μs     0.89  groupby.GroupByMethods.time_dtype_as_field('float', 'sum', 'direct', 5)
-        37.5±1μs       33.5±0.8μs     0.89  groupby.GroupByMethods.time_dtype_as_field('float', 'count', 'direct', 5)
-        76.7±2μs       68.5±0.5μs     0.89  groupby.GroupByMethods.time_dtype_as_field('int', 'prod', 'direct', 5)
-      69.6±0.3μs         62.0±2μs     0.89  groupby.GroupByMethods.time_dtype_as_field('float', 'last', 'direct', 5)
-      70.6±0.8μs       62.8±0.1μs     0.89  groupby.GroupByMethods.time_dtype_as_field('uint', 'last', 'direct', 1)
-      33.1±0.9μs       29.4±0.2μs     0.89  groupby.GroupByMethods.time_dtype_as_group('float', 'count', 'direct', 1)
-        63.8±1μs         56.7±1μs     0.89  groupby.GroupByMethods.time_dtype_as_field('float', 'max', 'direct', 1)
-      69.5±0.2μs         61.8±2μs     0.89  groupby.GroupByMethods.time_dtype_as_field('float', 'first', 'direct', 5)
-      71.2±0.5μs       63.4±0.5μs     0.89  groupby.GroupByMethods.time_dtype_as_group('int16', 'prod', 'direct', 1)
-      70.6±0.1μs       62.8±0.7μs     0.89  groupby.GroupByMethods.time_dtype_as_field('float', 'min', 'direct', 5)
-      70.6±0.7μs       62.7±0.3μs     0.89  groupby.GroupByMethods.time_dtype_as_field('uint', 'prod', 'direct', 1)
-      52.5±0.5μs         46.6±1μs     0.89  groupby.GroupByMethods.time_dtype_as_field('float', 'var', 'direct', 1)
-      75.6±0.2μs      67.1±0.09μs     0.89  groupby.GroupByMethods.time_dtype_as_field('datetime', 'tail', 'direct', 5)
-      32.6±0.5μs       29.0±0.2μs     0.89  groupby.GroupByMethods.time_dtype_as_field('uint', 'count', 'direct', 1)
-      63.3±0.9μs         56.2±1μs     0.89  groupby.GroupByMethods.time_dtype_as_field('float', 'min', 'direct', 1)
-      70.7±0.6μs         62.8±2μs     0.89  groupby.GroupByMethods.time_dtype_as_field('int', 'first', 'direct', 1)
-      39.1±0.8μs       34.7±0.4μs     0.89  groupby.GroupByMethods.time_dtype_as_group('object', 'any', 'direct', 1)
-      70.1±0.9μs         62.1±2μs     0.89  groupby.GroupByMethods.time_dtype_as_field('int16', 'first', 'direct', 1)
-      39.4±0.2μs       34.9±0.4μs     0.89  groupby.GroupByMethods.time_dtype_as_group('int', 'head', 'direct', 1)
-      61.3±0.9μs         54.2±1μs     0.89  groupby.GroupByMethods.time_dtype_as_field('int', 'tail', 'direct', 5)
-      70.6±0.1μs         62.5±2μs     0.89  groupby.GroupByMethods.time_dtype_as_field('float', 'max', 'direct', 5)
-      69.9±0.8μs       61.9±0.9μs     0.89  groupby.GroupByMethods.time_dtype_as_field('int', 'last', 'direct', 1)
-      32.9±0.3μs       29.1±0.2μs     0.88  groupby.GroupByMethods.time_dtype_as_group('int16', 'count', 'direct', 1)
-      77.3±0.2μs         68.3±1μs     0.88  groupby.GroupByMethods.time_dtype_as_field('int', 'last', 'direct', 5)
-        71.4±2μs         63.1±2μs     0.88  groupby.GroupByMethods.time_dtype_as_field('int', 'min', 'direct', 1)
-        79.9±1μs       70.6±0.5μs     0.88  groupby.GroupByMethods.time_dtype_as_field('int', 'sum', 'direct', 5)
-         163±4μs         144±10μs     0.88  groupby.GroupByMethods.time_dtype_as_field('int', 'quantile', 'direct', 1)
-        61.6±1μs         54.4±2μs     0.88  groupby.GroupByMethods.time_dtype_as_field('int', 'mean', 'direct', 1)
-      59.1±0.8μs       52.2±0.3μs     0.88  groupby.GroupByMethods.time_dtype_as_group('datetime', 'tail', 'direct', 1)
-        39.5±1μs       34.9±0.5μs     0.88  groupby.GroupByMethods.time_dtype_as_field('uint', 'all', 'direct', 1)
-      45.2±0.2μs       39.9±0.2μs     0.88  groupby.GroupByMethods.time_dtype_as_field('uint', 'all', 'direct', 5)
-      69.4±0.4μs         61.2±1μs     0.88  groupby.GroupByMethods.time_dtype_as_field('float', 'prod', 'direct', 5)
-        44.9±1μs       39.6±0.5μs     0.88  groupby.GroupByMethods.time_dtype_as_field('float', 'all', 'direct', 5)
-        39.7±1μs       35.0±0.1μs     0.88  groupby.GroupByMethods.time_dtype_as_group('int', 'all', 'direct', 1)
-      38.3±0.3μs       33.7±0.4μs     0.88  groupby.GroupByMethods.time_dtype_as_field('int16', 'count', 'direct', 5)
-      61.7±0.9μs         54.3±1μs     0.88  groupby.GroupByMethods.time_dtype_as_field('float', 'tail', 'direct', 5)
-         177±3μs         156±10μs     0.88  groupby.GroupByMethods.time_dtype_as_field('int', 'quantile', 'direct', 5)
-      35.0±0.4μs       30.8±0.3μs     0.88  groupby.GroupByMethods.time_dtype_as_field('datetime', 'count', 'direct', 1)
-        39.5±1μs       34.8±0.4μs     0.88  groupby.GroupByMethods.time_dtype_as_group('uint', 'all', 'direct', 1)
-      39.5±0.3μs       34.7±0.6μs     0.88  groupby.GroupByMethods.time_dtype_as_field('int', 'head', 'direct', 1)
-      41.2±0.2μs       36.2±0.9μs     0.88  groupby.GroupByMethods.time_dtype_as_field('float', 'head', 'direct', 5)
-      40.8±0.3μs         35.8±1μs     0.88  groupby.GroupByMethods.time_dtype_as_field('int', 'head', 'direct', 5)
-        59.9±1μs       52.7±0.1μs     0.88  groupby.GroupByMethods.time_dtype_as_group('int', 'tail', 'direct', 1)
-      38.4±0.2μs       33.7±0.2μs     0.88  groupby.GroupByMethods.time_dtype_as_field('uint', 'count', 'direct', 5)
-        62.7±1μs         55.1±1μs     0.88  groupby.GroupByMethods.time_dtype_as_field('float', 'prod', 'direct', 1)
-      56.5±0.4μs       49.5±0.5μs     0.88  groupby.GroupByMethods.time_dtype_as_group('object', 'tail', 'direct', 1)
-      32.9±0.6μs       28.8±0.7μs     0.88  groupby.GroupByMethods.time_dtype_as_field('float', 'count', 'direct', 1)
-      62.0±0.6μs         54.3±1μs     0.88  groupby.GroupByMethods.time_dtype_as_field('float', 'last', 'direct', 1)
-      45.2±0.4μs       39.5±0.3μs     0.87  groupby.GroupByMethods.time_dtype_as_field('int', 'all', 'direct', 5)
-        59.1±2μs         51.6±2μs     0.87  groupby.GroupByMethods.time_dtype_as_field('int', 'tail', 'direct', 1)
-        71.3±1μs         62.3±1μs     0.87  groupby.GroupByMethods.time_dtype_as_field('int', 'prod', 'direct', 1)
-      41.2±0.4μs       36.0±0.1μs     0.87  groupby.GroupByMethods.time_dtype_as_group('uint', 'any', 'direct', 1)
-      33.3±0.3μs       29.1±0.5μs     0.87  groupby.GroupByMethods.time_dtype_as_group('int', 'count', 'direct', 1)
-        50.1±1μs       43.7±0.2μs     0.87  groupby.GroupByMethods.time_dtype_as_field('uint', 'std', 'direct', 5)
-      59.1±0.5μs         51.6±1μs     0.87  groupby.GroupByMethods.time_dtype_as_field('float', 'mean', 'direct', 1)
-      40.8±0.5μs       35.6±0.6μs     0.87  groupby.GroupByMethods.time_dtype_as_group('datetime', 'any', 'direct', 1)
-      38.0±0.8μs         33.1±1μs     0.87  groupby.GroupByMethods.time_dtype_as_field('int', 'count', 'direct', 5)
-      60.5±0.5μs       52.6±0.4μs     0.87  groupby.GroupByMethods.time_dtype_as_group('int16', 'tail', 'direct', 1)
-      40.1±0.7μs         34.9±1μs     0.87  groupby.GroupByMethods.time_dtype_as_field('float', 'any', 'direct', 1)
-      46.0±0.1μs       40.0±0.8μs     0.87  groupby.GroupByMethods.time_dtype_as_field('int', 'any', 'direct', 5)
-      44.5±0.6μs       38.7±0.5μs     0.87  groupby.GroupByMethods.time_dtype_as_field('int16', 'any', 'direct', 5)
-      40.3±0.6μs       35.0±0.5μs     0.87  groupby.GroupByMethods.time_dtype_as_group('float', 'all', 'direct', 1)
-      59.0±0.4μs         51.2±1μs     0.87  groupby.GroupByMethods.time_dtype_as_field('float', 'tail', 'direct', 1)
-      40.3±0.7μs       34.9±0.4μs     0.87  groupby.GroupByMethods.time_dtype_as_group('int16', 'all', 'direct', 1)
-      73.2±0.3μs         63.5±1μs     0.87  groupby.GroupByMethods.time_dtype_as_field('int', 'sum', 'direct', 1)
-      40.6±0.7μs       35.2±0.5μs     0.87  groupby.GroupByMethods.time_dtype_as_group('int16', 'any', 'direct', 1)
-      33.1±0.4μs       28.7±0.9μs     0.87  groupby.GroupByMethods.time_dtype_as_field('int', 'count', 'direct', 1)
-      73.5±0.4μs      63.5±0.05μs     0.86  groupby.GroupByMethods.time_dtype_as_field('uint', 'sum', 'direct', 1)
-      64.7±0.8μs         55.8±2μs     0.86  groupby.GroupByMethods.time_dtype_as_field('float', 'sum', 'direct', 1)
-        39.1±1μs         33.7±1μs     0.86  groupby.GroupByMethods.time_dtype_as_field('int16', 'any', 'direct', 1)
-      45.9±0.6μs       39.5±0.8μs     0.86  groupby.GroupByMethods.time_dtype_as_field('float', 'any', 'direct', 5)
-      41.1±0.5μs       35.4±0.3μs     0.86  groupby.GroupByMethods.time_dtype_as_group('float', 'any', 'direct', 1)
-        46.7±1μs       40.2±0.2μs     0.86  groupby.GroupByMethods.time_dtype_as_group('uint', 'std', 'direct', 1)
-      39.5±0.8μs       33.9±0.2μs     0.86  groupby.GroupByMethods.time_dtype_as_group('object', 'all', 'direct', 1)
-      41.0±0.5μs       35.2±0.4μs     0.86  groupby.GroupByMethods.time_dtype_as_field('uint', 'any', 'direct', 1)
-      47.3±0.7μs       40.5±0.4μs     0.86  groupby.GroupByMethods.time_dtype_as_group('int', 'std', 'direct', 1)
-      40.1±0.1μs         34.3±1μs     0.86  groupby.GroupByMethods.time_dtype_as_field('int', 'any', 'direct', 1)
-      32.7±0.6μs       28.0±0.8μs     0.86  groupby.GroupByMethods.time_dtype_as_field('int16', 'count', 'direct', 1)
-      49.3±0.3μs       42.1±0.3μs     0.85  groupby.GroupByMethods.time_dtype_as_group('float', 'std', 'direct', 1)
-      40.2±0.9μs         34.3±1μs     0.85  groupby.GroupByMethods.time_dtype_as_field('float', 'all', 'direct', 1)
-      39.4±0.1μs       33.6±0.4μs     0.85  groupby.GroupByMethods.time_dtype_as_field('int16', 'all', 'direct', 1)
-      40.7±0.2μs       34.6±0.8μs     0.85  groupby.GroupByMethods.time_dtype_as_field('int', 'all', 'direct', 1)
-      50.7±0.7μs       42.6±0.9μs     0.84  groupby.GroupByMethods.time_dtype_as_field('int', 'std', 'direct', 5)
-      47.4±0.7μs       39.8±0.2μs     0.84  groupby.GroupByMethods.time_dtype_as_group('int16', 'std', 'direct', 1)
-      44.8±0.4μs         37.5±1μs     0.84  groupby.GroupByMethods.time_dtype_as_field('int16', 'all', 'direct', 5)
-      43.4±0.3μs       36.4±0.4μs     0.84  groupby.GroupByMethods.time_dtype_as_field('float', 'std', 'direct', 1)
-      46.0±0.5μs       38.5±0.1μs     0.84  groupby.GroupByMethods.time_dtype_as_field('uint', 'std', 'direct', 1)
-      51.1±0.3μs       42.7±0.2μs     0.83  groupby.GroupByMethods.time_dtype_as_field('int16', 'std', 'direct', 5)
-        45.0±1μs       37.4±0.6μs     0.83  groupby.GroupByMethods.time_dtype_as_field('int16', 'std', 'direct', 1)
-      46.0±0.6μs       38.2±0.4μs     0.83  groupby.GroupByMethods.time_dtype_as_field('int', 'std', 'direct', 1)
-      49.4±0.3μs         40.9±1μs     0.83  groupby.GroupByMethods.time_dtype_as_field('float', 'std', 'direct', 5)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```