### PR TITLE
DEPR: remove Int|Uint|Float64Index from conftest & _testing

### DIFF
--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -34,6 +34,7 @@ from pandas.core.dtypes.common import (
     is_float_dtype,
     is_integer_dtype,
     is_sequence,
+    is_signed_integer_dtype,
     is_unsigned_integer_dtype,
     pandas_dtype,
 )
@@ -106,12 +107,7 @@ from pandas._testing.contexts import (
     use_numexpr,
     with_csv_dialect,
 )
-from pandas.core.api import (
-    Float64Index,
-    Int64Index,
-    NumericIndex,
-    UInt64Index,
-)
+from pandas.core.api import NumericIndex
 from pandas.core.arrays import (
     BaseMaskedArray,
     ExtensionArray,
@@ -350,7 +346,7 @@ def makeBoolIndex(k: int = 10, name=None) -> Index:
     return Index([False, True] + [False] * (k - 2), name=name)
 
 
-def makeNumericIndex(k: int = 10, name=None, *, dtype) -> NumericIndex:
+def makeNumericIndex(k: int = 10, *, name=None, dtype: Dtype | None) -> NumericIndex:
     dtype = pandas_dtype(dtype)
     assert isinstance(dtype, np.dtype)
 
@@ -368,23 +364,29 @@ def makeNumericIndex(k: int = 10, name=None, *, dtype) -> NumericIndex:
     return NumericIndex(values, dtype=dtype, name=name)
 
 
-def makeIntIndex(k: int = 10, name=None) -> Int64Index:
-    base_idx = makeNumericIndex(k, name=name, dtype="int64")
-    return Int64Index(base_idx)
+def makeIntIndex(k: int = 10, *, name=None, dtype: Dtype = "int64") -> NumericIndex:
+    dtype = pandas_dtype(dtype)
+    if not is_signed_integer_dtype(dtype):
+        raise TypeError(f"Wrong dtype {dtype}")
+    return makeNumericIndex(k, name=name, dtype=dtype)
 
 
-def makeUIntIndex(k: int = 10, name=None) -> UInt64Index:
-    base_idx = makeNumericIndex(k, name=name, dtype="uint64")
-    return UInt64Index(base_idx)
+def makeUIntIndex(k: int = 10, *, name=None, dtype: Dtype = "uint64") -> NumericIndex:
+    dtype = pandas_dtype(dtype)
+    if not is_unsigned_integer_dtype(dtype):
+        raise TypeError(f"Wrong dtype {dtype}")
+    return makeNumericIndex(k, name=name, dtype=dtype)
 
 
 def makeRangeIndex(k: int = 10, name=None, **kwargs) -> RangeIndex:
     return RangeIndex(0, k, 1, name=name, **kwargs)
 
 
-def makeFloatIndex(k: int = 10, name=None) -> Float64Index:
-    base_idx = makeNumericIndex(k, name=name, dtype="float64")
-    return Float64Index(base_idx)
+def makeFloatIndex(k: int = 10, *, name=None, dtype: Dtype = "float64") -> NumericIndex:
+    dtype = pandas_dtype(dtype)
+    if not is_float_dtype(dtype):
+        raise TypeError(f"Wrong dtype {dtype}")
+    return makeNumericIndex(k, name=name, dtype=dtype)
 
 
 def makeDateIndex(

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -593,24 +593,21 @@ indices_dict = {
     "datetime-tz": tm.makeDateIndex(100, tz="US/Pacific"),
     "period": tm.makePeriodIndex(100),
     "timedelta": tm.makeTimedeltaIndex(100),
-    "int": tm.makeIntIndex(100),
-    "uint": tm.makeUIntIndex(100),
     "range": tm.makeRangeIndex(100),
-    "float": tm.makeFloatIndex(100),
-    "complex64": tm.makeNumericIndex(100, dtype="float64").astype("complex64"),
-    "complex128": tm.makeNumericIndex(100, dtype="float64").astype("complex128"),
-    "num_int64": tm.makeNumericIndex(100, dtype="int64"),
-    "num_int32": tm.makeNumericIndex(100, dtype="int32"),
-    "num_int16": tm.makeNumericIndex(100, dtype="int16"),
-    "num_int8": tm.makeNumericIndex(100, dtype="int8"),
-    "num_uint64": tm.makeNumericIndex(100, dtype="uint64"),
-    "num_uint32": tm.makeNumericIndex(100, dtype="uint32"),
-    "num_uint16": tm.makeNumericIndex(100, dtype="uint16"),
-    "num_uint8": tm.makeNumericIndex(100, dtype="uint8"),
-    "num_float64": tm.makeNumericIndex(100, dtype="float64"),
-    "num_float32": tm.makeNumericIndex(100, dtype="float32"),
+    "int8": tm.makeIntIndex(100, dtype="int8"),
+    "int16": tm.makeIntIndex(100, dtype="int16"),
+    "int32": tm.makeIntIndex(100, dtype="int32"),
+    "int64": tm.makeIntIndex(100, dtype="int64"),
+    "uint8": tm.makeUIntIndex(100, dtype="uint8"),
+    "uint16": tm.makeUIntIndex(100, dtype="uint16"),
+    "uint32": tm.makeUIntIndex(100, dtype="uint32"),
+    "uint64": tm.makeUIntIndex(100, dtype="uint64"),
+    "float32": tm.makeFloatIndex(100, dtype="float32"),
+    "float64": tm.makeFloatIndex(100, dtype="float64"),
     "bool-object": tm.makeBoolIndex(10).astype(object),
     "bool-dtype": Index(np.random.randn(10) < 0),
+    "complex64": tm.makeNumericIndex(100, dtype="float64").astype("complex64"),
+    "complex128": tm.makeNumericIndex(100, dtype="float64").astype("complex128"),
     "categorical": tm.makeCategoricalIndex(100),
     "interval": tm.makeIntervalIndex(100),
     "empty": Index([]),
@@ -670,8 +667,10 @@ index_flat2 = index_flat
         key
         for key, value in indices_dict.items()
         if not (
-            key in ["int", "uint", "range", "empty", "repeats", "bool-dtype"]
-            or key.startswith("num_")
+            key.startswith("int")
+            or key.startswith("uint")
+            or key.startswith("float")
+            or key in ["range", "empty", "repeats", "bool-dtype"]
         )
         and not isinstance(value, MultiIndex)
     ]

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -340,14 +340,17 @@ class TestIndex(Base):
         "index",
         [
             "datetime",
-            "float",
-            "int",
+            "float64",
+            "float32",
+            "int64",
+            "int32",
             "period",
             "range",
             "repeats",
             "timedelta",
             "tuples",
-            "uint",
+            "uint64",
+            "uint32",
         ],
         indirect=True,
     )
@@ -375,7 +378,11 @@ class TestIndex(Base):
             with pytest.raises(TypeError, match=msg):
                 index.view("i8")
 
-    @pytest.mark.parametrize("index", ["int", "range"], indirect=True)
+    @pytest.mark.parametrize(
+        "index",
+        ["int64", "int32", "range"],
+        indirect=True,
+    )
     def test_astype(self, index):
         casted = index.astype("i8")
 
@@ -474,7 +481,11 @@ class TestIndex(Base):
         for i in sl:
             assert i == sl[sl.get_loc(i)]
 
-    @pytest.mark.parametrize("index", ["string", "int", "float"], indirect=True)
+    @pytest.mark.parametrize(
+        "index",
+        ["string", "int64", "int32", "uint64", "uint32", "float64", "float32"],
+        indirect=True,
+    )
     @pytest.mark.parametrize("dtype", [np.int_, np.bool_])
     def test_empty_fancy(self, index, dtype):
         empty_arr = np.array([], dtype=dtype)
@@ -483,7 +494,11 @@ class TestIndex(Base):
         assert index[[]].identical(empty_index)
         assert index[empty_arr].identical(empty_index)
 
-    @pytest.mark.parametrize("index", ["string", "int", "float"], indirect=True)
+    @pytest.mark.parametrize(
+        "index",
+        ["string", "int64", "int32", "uint64", "uint32", "float64", "float32"],
+        indirect=True,
+    )
     def test_empty_fancy_raises(self, index):
         # DatetimeIndex is excluded, because it overrides getitem and should
         # be tested separately.
@@ -638,9 +653,13 @@ class TestIndex(Base):
             ("bool-object", False),
             ("bool-dtype", False),
             ("categorical", False),
-            ("int", True),
+            ("int64", True),
+            ("int32", True),
+            ("uint64", True),
+            ("uint32", True),
             ("datetime", False),
-            ("float", True),
+            ("float64", True),
+            ("float32", True),
         ],
         indirect=["index"],
     )
@@ -654,9 +673,13 @@ class TestIndex(Base):
             ("bool-object", True),
             ("bool-dtype", False),
             ("categorical", False),
-            ("int", False),
+            ("int64", False),
+            ("int32", False),
+            ("uint64", False),
+            ("uint32", False),
             ("datetime", False),
-            ("float", False),
+            ("float64", False),
+            ("float32", False),
         ],
         indirect=["index"],
     )
@@ -700,7 +723,9 @@ class TestIndex(Base):
         index = simple_index
         assert getattr(index, op)() == getattr(index.values, op)()
 
-    @pytest.mark.parametrize("index", ["string", "int", "float"], indirect=True)
+    @pytest.mark.parametrize(
+        "index", ["string", "int64", "int32", "float64", "float32"], indirect=True
+    )
     def test_drop_by_str_label(self, index):
         n = len(index)
         drop = index[list(range(5, 10))]
@@ -713,13 +738,17 @@ class TestIndex(Base):
         expected = index[1:]
         tm.assert_index_equal(dropped, expected)
 
-    @pytest.mark.parametrize("index", ["string", "int", "float"], indirect=True)
+    @pytest.mark.parametrize(
+        "index", ["string", "int64", "int32", "float64", "float32"], indirect=True
+    )
     @pytest.mark.parametrize("keys", [["foo", "bar"], ["1", "bar"]])
     def test_drop_by_str_label_raises_missing_keys(self, index, keys):
         with pytest.raises(KeyError, match=""):
             index.drop(keys)
 
-    @pytest.mark.parametrize("index", ["string", "int", "float"], indirect=True)
+    @pytest.mark.parametrize(
+        "index", ["string", "int64", "int32", "float64", "float32"], indirect=True
+    )
     def test_drop_by_str_label_errors_ignore(self, index):
         n = len(index)
         drop = index[list(range(5, 10))]
@@ -940,7 +969,16 @@ class TestIndex(Base):
 
     @pytest.mark.parametrize(
         "index",
-        ["string", "datetime", "int", "uint", "float"],
+        [
+            "string",
+            "datetime",
+            "int64",
+            "int32",
+            "uint64",
+            "uint32",
+            "float64",
+            "float32",
+        ],
         indirect=True,
     )
     def test_join_self(self, index, join_type):

--- a/pandas/tests/resample/test_time_grouper.py
+++ b/pandas/tests/resample/test_time_grouper.py
@@ -78,17 +78,18 @@ def test_apply_iteration():
 
 
 @pytest.mark.parametrize(
-    "name, func",
+    "func",
     [
-        ("Int64Index", tm.makeIntIndex),
-        ("Index", tm.makeStringIndex),
-        ("Float64Index", tm.makeFloatIndex),
-        ("MultiIndex", lambda m: tm.makeCustomIndex(m, 2)),
+        tm.makeIntIndex,
+        tm.makeStringIndex,
+        tm.makeFloatIndex,
+        (lambda m: tm.makeCustomIndex(m, 2)),
     ],
 )
-def test_fails_on_no_datetime_index(name, func):
+def test_fails_on_no_datetime_index(func):
     n = 2
     index = func(n)
+    name = type(index).__name__
     df = DataFrame({"a": np.random.randn(n)}, index=index)
 
     msg = (

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -31,6 +31,7 @@ from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.common import (
     is_datetime64_dtype,
+    is_numeric_dtype,
     is_period_dtype,
     is_timedelta64_dtype,
 )
@@ -130,10 +131,7 @@ def infer_freq(index) -> str | None:
     """
     from pandas.core.api import (
         DatetimeIndex,
-        Float64Index,
         Index,
-        Int64Index,
-        RangeIndex,
     )
 
     if isinstance(index, ABCSeries):
@@ -164,9 +162,9 @@ def infer_freq(index) -> str | None:
         return inferer.get_freq()
 
     if isinstance(index, Index) and not isinstance(index, DatetimeIndex):
-        if isinstance(index, (Int64Index, Float64Index, RangeIndex)):
+        if is_numeric_dtype(index):
             raise TypeError(
-                f"cannot infer freq from a non-convertible index type {type(index)}"
+                f"cannot infer freq from a non-convertible index with dtype {index.dtype}"
             )
         index = index._values
 

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -164,7 +164,7 @@ def infer_freq(index) -> str | None:
     if isinstance(index, Index) and not isinstance(index, DatetimeIndex):
         if is_numeric_dtype(index):
             raise TypeError(
-                f"cannot infer freq from a non-convertible index with dtype {index.dtype}"
+                f"cannot infer freq from a non-convertible index of dtype {index.dtype}"
             )
         index = index._values
 


### PR DESCRIPTION
Progress towards #42717.

In particular cleans up conftest.py::indices_dict to not use old style indexes and cleans up the `tm.make*Index` functions to not return old style numeric indexes.

I've kept `tm.MakeIntIndex`etc. and just made them tighter versions of `tm.makeNumericIndex` though if they should be deleted that is also fine for me.