### PR TITLE
DOC: Update interpolation docstring

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7254,8 +7254,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
               values of the index.  Both 'polynomial' and 'spline' require that
               you also specify an `order` (int), e.g.
               ``df.interpolate(method='polynomial', order=5)``. Note that,
-              `slinear` method in Pandas refers to the Scipy first order `spline` instead
-              of Pandas first order `spline`.
+              `slinear` method in Pandas refers to the Scipy first order `spline`
+              instead of Pandas first order `spline`.
             * 'krogh', 'piecewise_polynomial', 'spline', 'pchip', 'akima',
               'cubicspline': Wrappers around the SciPy interpolation methods of
               similar names. See `Notes`.

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7247,12 +7247,15 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
               given length of interval.
             * 'index', 'values': use the actual numerical values of the index.
             * 'pad': Fill in NaNs using existing values.
-            * 'nearest', 'zero', 'slinear', 'quadratic', 'cubic', 'spline',
+            * 'nearest', 'zero', 'slinear', 'quadratic', 'cubic',
               'barycentric', 'polynomial': Passed to
-              `scipy.interpolate.interp1d`. These methods use the numerical
+              `scipy.interpolate.interp1d`, whereas 'spline' is assed to
+              `scipy.interpolate.UnivariateSpline`. These methods use the numerical
               values of the index.  Both 'polynomial' and 'spline' require that
               you also specify an `order` (int), e.g.
-              ``df.interpolate(method='polynomial', order=5)``.
+              ``df.interpolate(method='polynomial', order=5)``. Note that, Scipy
+              `slinear` method refers to the Scipy first order spline instead
+              of Pandas first order spline.
             * 'krogh', 'piecewise_polynomial', 'spline', 'pchip', 'akima',
               'cubicspline': Wrappers around the SciPy interpolation methods of
               similar names. See `Notes`.

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7249,13 +7249,13 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             * 'pad': Fill in NaNs using existing values.
             * 'nearest', 'zero', 'slinear', 'quadratic', 'cubic',
               'barycentric', 'polynomial': Passed to
-              `scipy.interpolate.interp1d`, whereas 'spline' is assed to
+              `scipy.interpolate.interp1d`, whereas 'spline' is passed to
               `scipy.interpolate.UnivariateSpline`. These methods use the numerical
               values of the index.  Both 'polynomial' and 'spline' require that
               you also specify an `order` (int), e.g.
-              ``df.interpolate(method='polynomial', order=5)``. Note that, Scipy
-              `slinear` method refers to the Scipy first order spline instead
-              of Pandas first order spline.
+              ``df.interpolate(method='polynomial', order=5)``. Note that,
+              `slinear` method in Pandas refers to the Scipy first order `spline` instead
+              of Pandas first order `spline`.
             * 'krogh', 'piecewise_polynomial', 'spline', 'pchip', 'akima',
               'cubicspline': Wrappers around the SciPy interpolation methods of
               similar names. See `Notes`.


### PR DESCRIPTION
DOC: Update interpolation docstring to highlight slinear and spline differences between pandas and scipy.

# Scipy vs Pandas interpolation documentation missmatching

We can find information in [Pandas documentation](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.interpolate.html) that, Pandas interpolation module on both - Series and on DataFrames, pases input data to Scipy `scipy.interpolate.interp1d` method. We can read about method paramter:

`'nearest’, ‘zero’, ‘slinear’, ‘quadratic’, ‘cubic’, ‘spline’, ‘barycentric’, ‘polynomial’: Passed to scipy.interpolate.interp1d. These methods use the numerical values of the index. Both ‘polynomial’ and ‘spline’ require that you also specify an order (int), e.g. df.interpolate(method='polynomial', order=5).`

Thus, user might think that Pandas, uses methods of `scipy.interpolate.interp1d` to all interpolation methods. But as it shown in below code, this is true for `slinear` and not for `spline`. This is also visible in the `pandas.core.missing._interpolate_scipy_wrapper` function definition, where we can find that `spline`in fact uses `interpolate.UnivariateSpline` to predict gaps in the data. 

This might confuse end user because in [scipy.interpolate.interp1d](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html#scipy.interpolate.interp1d) documentation might be found that `slinear` method refer to a spline interpolation of first orger. At the same time, end user can read in [pandas.Series.interpolate](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.interpolate.html) that `spline` require that you also specify an order (int), e.g 1, as in this work. 

Summarizing: 
1. Pandas `slinear` refers to Scipy `slinear`, but Scipy `slinear` refers to first order `spline` method with order 1, which is defined separatley in Pandas.
2. `pandas.core.missing._interpolate_scipy_wrapper` points that Pandas does not use for interpolation `scipy.interpolate.interp1d` for `spline` as for `slinear`. Pandas uses `interpolate.UnivariateSpline` for `spline` interpolation, what is not pointed in the [pandas.Series.interpolate](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.interpolate.html) documentation.
3. Scipy slinear and linear give the same results.
4. Pandas slinear gives the same results as Scipy slinear
5. Pandas slinear does not gives the same results as Pandas first order spline, to which Scipy slinear refers to.

Proposed solution:
1. Update the docstring of interpolation method.

Workspace - Jupyter notebook used to highlight the differences between Scipy and Pandas interpolation methods:
[interpolation_comparison.zip](https://github.com/pandas-dev/pandas/files/9997625/interpolation_comparison.zip)

Visualization of differences between Scipy and Pandas interpolations. 
![pandas_int
[case_2_comparison.csv](https://github.com/pandas-dev/pandas/files/9997621/case_2_comparison.csv)
erpolation](https://user-images.githubusercontent.com/98959490/201530317-35bc99a1-3c3f-496d-a657-9e43d11bd962.png)
![scipy_interpolation](https://user-images.githubusercontent.com/98959490/201530320-3ee27d17-9bdd-48dc-8434-3b18e69dd768.png)

CSV files with plot data.
[case_1_comparison.csv](https://github.com/pandas-dev/pandas/files/9997622/case_1_comparison.csv)
[case_2_comparison.csv](https://github.com/pandas-dev/pandas/files/9997623/case_2_comparison.csv)