### PR TITLE
DEPR: remove Int64Index, UInt64Index, Float64Index from tests.indexes.numeric

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,11 +59,6 @@ repos:
         - flake8==5.0.4
         - flake8-bugbear==22.7.1
         - pandas-dev-flaker==0.5.0
--   repo: https://github.com/pycqa/pylint
-    rev: v2.15.5
-    hooks:
-    -   id: pylint
-        stages: [manual]
 -   repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,11 @@ repos:
         - flake8==5.0.4
         - flake8-bugbear==22.7.1
         - pandas-dev-flaker==0.5.0
+-   repo: https://github.com/pycqa/pylint
+    rev: v2.15.5
+    hooks:
+    -   id: pylint
+        stages: [manual]
 -   repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -818,6 +818,19 @@ class NumericBase(Base):
         key = idx[0]
         assert idx._can_hold_identifiers_and_holds_name(key) is False
 
+    def test_view(self, dtype):
+        index_cls = self._index_cls
+
+        idx = index_cls([], dtype=dtype, name="Foo")
+        idx_view = idx.view()
+        assert idx_view.name == "Foo"
+
+        idx_view = idx.view(dtype)
+        tm.assert_index_equal(idx, index_cls(idx_view, name="Foo"), exact=True)
+
+        idx_view = idx.view(index_cls)
+        tm.assert_index_equal(idx, index_cls(idx_view, name="Foo"), exact=True)
+
     def test_format(self, simple_index):
         # GH35439
         idx = simple_index

--- a/pandas/tests/indexes/numeric/test_astype.py
+++ b/pandas/tests/indexes/numeric/test_astype.py
@@ -7,72 +7,67 @@ from pandas.core.dtypes.common import pandas_dtype
 
 from pandas import Index
 import pandas._testing as tm
-from pandas.core.indexes.api import (
-    Float64Index,
-    Int64Index,
-    UInt64Index,
-)
 
 
 class TestAstype:
     def test_astype_float64_to_uint64(self):
         # GH#45309 used to incorrectly return Int64Index
-        idx = Float64Index([0.0, 5.0, 10.0, 15.0, 20.0])
+        idx = Index([0.0, 5.0, 10.0, 15.0, 20.0], dtype=np.float64)
         result = idx.astype("u8")
-        expected = UInt64Index([0, 5, 10, 15, 20])
-        tm.assert_index_equal(result, expected)
+        expected = Index([0, 5, 10, 15, 20], dtype=np.uint64)
+        tm.assert_index_equal(result, expected, exact=True)
 
         idx_with_negatives = idx - 10
         with pytest.raises(ValueError, match="losslessly"):
             idx_with_negatives.astype(np.uint64)
 
     def test_astype_float64_to_object(self):
-        float_index = Float64Index([0.0, 2.5, 5.0, 7.5, 10.0])
+        float_index = Index([0.0, 2.5, 5.0, 7.5, 10.0], dtype=np.float64)
         result = float_index.astype(object)
         assert result.equals(float_index)
         assert float_index.equals(result)
-        assert isinstance(result, Index) and not isinstance(result, Float64Index)
+        assert isinstance(result, Index) and result.dtype == object
 
     def test_astype_float64_mixed_to_object(self):
         # mixed int-float
-        idx = Float64Index([1.5, 2, 3, 4, 5])
+        idx = Index([1.5, 2, 3, 4, 5], dtype=np.float64)
         idx.name = "foo"
         result = idx.astype(object)
         assert result.equals(idx)
         assert idx.equals(result)
-        assert isinstance(result, Index) and not isinstance(result, Float64Index)
+        assert isinstance(result, Index) and result.dtype == object
 
     @pytest.mark.parametrize("dtype", ["int16", "int32", "int64"])
     def test_astype_float64_to_int_dtype(self, dtype):
         # GH#12881
         # a float astype int
-        idx = Float64Index([0, 1, 2])
+        idx = Index([0, 1, 2], dtype=np.float64)
         result = idx.astype(dtype)
-        expected = Int64Index([0, 1, 2])
-        tm.assert_index_equal(result, expected)
+        expected = Index([0, 1, 2], dtype=np.int64)
+        tm.assert_index_equal(result, expected, exact=True)
 
-        idx = Float64Index([0, 1.1, 2])
+        idx = Index([0, 1.1, 2], dtype=np.float64)
         result = idx.astype(dtype)
-        expected = Int64Index([0, 1, 2])
-        tm.assert_index_equal(result, expected)
+        expected = Index([0, 1, 2], dtype=dtype)
+        tm.assert_index_equal(result, expected, exact=True)
 
     @pytest.mark.parametrize("dtype", ["float32", "float64"])
     def test_astype_float64_to_float_dtype(self, dtype):
         # GH#12881
         # a float astype int
-        idx = Float64Index([0, 1, 2])
+        idx = Index([0, 1, 2], dtype=np.float64)
         result = idx.astype(dtype)
         expected = idx
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
-        idx = Float64Index([0, 1.1, 2])
+        idx = Index([0, 1.1, 2], dtype=np.float64)
         result = idx.astype(dtype)
         expected = Index(idx.values.astype(dtype))
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     @pytest.mark.parametrize("dtype", ["M8[ns]", "m8[ns]"])
     def test_cannot_cast_to_datetimelike(self, dtype):
-        idx = Float64Index([0, 1.1, 2])
+        idx = Index([0, 1.1, 2], dtype=np.float64)
 
         msg = (
             f"Cannot convert Float64Index to dtype {pandas_dtype(dtype)}; "
@@ -85,7 +80,7 @@ class TestAstype:
     @pytest.mark.parametrize("non_finite", [np.inf, np.nan])
     def test_cannot_cast_inf_to_int(self, non_finite, dtype):
         # GH#13149
-        idx = Float64Index([1, 2, non_finite])
+        idx = Index([1, 2, non_finite], dtype=np.float64)
 
         msg = r"Cannot convert non-finite values \(NA or inf\) to integer"
         with pytest.raises(ValueError, match=msg):
@@ -94,6 +89,6 @@ class TestAstype:
     def test_astype_from_object(self):
         index = Index([1.0, np.nan, 0.2], dtype="object")
         result = index.astype(float)
-        expected = Float64Index([1.0, np.nan, 0.2])
+        expected = Index([1.0, np.nan, 0.2], dtype=np.float64)
         assert result.dtype == expected.dtype
         tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/numeric/test_indexing.py
+++ b/pandas/tests/indexes/numeric/test_indexing.py
@@ -10,18 +10,13 @@ from pandas import (
     Timestamp,
 )
 import pandas._testing as tm
-from pandas.core.indexes.api import (
-    Float64Index,
-    Int64Index,
-    UInt64Index,
-)
 
 
 @pytest.fixture
 def index_large():
-    # large values used in UInt64Index tests where no compat needed with Int64/Float64
+    # large values used in Index[uint64] tests where no compat needed with Int64/Float64
     large = [2**63, 2**63 + 10, 2**63 + 15, 2**63 + 20, 2**63 + 25]
-    return UInt64Index(large)
+    return Index(large, dtype=np.uint64)
 
 
 class TestGetLoc:
@@ -86,7 +81,7 @@ class TestGetLoc:
 
     @pytest.mark.filterwarnings("ignore:Passing method:FutureWarning")
     def test_get_loc_float64(self):
-        idx = Float64Index([0.0, 1.0, 2.0])
+        idx = Index([0.0, 1.0, 2.0], dtype=np.float64)
         for method in [None, "pad", "backfill", "nearest"]:
             assert idx.get_loc(1, method) == 1
             if method is not None:
@@ -119,11 +114,11 @@ class TestGetLoc:
             idx.get_loc(1.4, method="nearest", tolerance=np.array([1, 2]))
 
     def test_get_loc_na(self):
-        idx = Float64Index([np.nan, 1, 2])
+        idx = Index([np.nan, 1, 2], dtype=np.float64)
         assert idx.get_loc(1) == 1
         assert idx.get_loc(np.nan) == 0
 
-        idx = Float64Index([np.nan, 1, np.nan])
+        idx = Index([np.nan, 1, np.nan], dtype=np.float64)
         assert idx.get_loc(1) == 1
 
         # representable by slice [0:2:2]
@@ -131,7 +126,7 @@ class TestGetLoc:
         with pytest.raises(KeyError, match=msg):
             idx.slice_locs(np.nan)
         # not representable by slice
-        idx = Float64Index([np.nan, 1, np.nan, np.nan])
+        idx = Index([np.nan, 1, np.nan, np.nan], dtype=np.float64)
         assert idx.get_loc(1) == 1
         msg = "'Cannot get left slice bound for non-unique label: nan"
         with pytest.raises(KeyError, match=msg):
@@ -139,7 +134,7 @@ class TestGetLoc:
 
     def test_get_loc_missing_nan(self):
         # GH#8569
-        idx = Float64Index([1, 2])
+        idx = Index([1, 2], dtype=np.float64)
         assert idx.get_loc(1) == 0
         with pytest.raises(KeyError, match=r"^3$"):
             idx.get_loc(3)
@@ -285,14 +280,12 @@ class TestGetIndexer:
         actual = index.get_indexer([0.2, 1.8, 8.5], method=method)
         tm.assert_numpy_array_equal(actual, np.array(expected, dtype=np.intp))
 
-    @pytest.mark.parametrize(
-        "idx_class", [Int64Index, RangeIndex, Float64Index, UInt64Index]
-    )
+    @pytest.mark.parametrize("idx_dtype", [np.int64, np.float64, np.uint64])
     @pytest.mark.parametrize("method", ["get_indexer", "get_indexer_non_unique"])
-    def test_get_indexer_numeric_index_boolean_target(self, method, idx_class):
+    def test_get_indexer_numeric_index_boolean_target(self, method, idx_dtype):
         # GH 16877
 
-        numeric_index = idx_class(RangeIndex(4))
+        numeric_index = Index(RangeIndex(4), dtype=idx_dtype)
         other = Index([True, False, True])
 
         result = getattr(numeric_index, method)(other)
@@ -336,7 +329,7 @@ class TestGetIndexer:
         tm.assert_numpy_array_equal(res, expected)
 
     def test_get_indexer_float64(self):
-        idx = Float64Index([0.0, 1.0, 2.0])
+        idx = Index([0.0, 1.0, 2.0], dtype=np.float64)
         tm.assert_numpy_array_equal(
             idx.get_indexer(idx), np.array([0, 1, 2], dtype=np.intp)
         )
@@ -354,39 +347,39 @@ class TestGetIndexer:
 
     def test_get_indexer_nan(self):
         # GH#7820
-        result = Float64Index([1, 2, np.nan]).get_indexer([np.nan])
+        result = Index([1, 2, np.nan], dtype=np.float64).get_indexer([np.nan])
         expected = np.array([2], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
 
     def test_get_indexer_int64(self):
-        index = Int64Index(range(0, 20, 2))
-        target = Int64Index(np.arange(10))
+        index = Index(range(0, 20, 2), dtype=np.int64)
+        target = Index(np.arange(10), dtype=np.int64)
         indexer = index.get_indexer(target)
         expected = np.array([0, -1, 1, -1, 2, -1, 3, -1, 4, -1], dtype=np.intp)
         tm.assert_numpy_array_equal(indexer, expected)
 
-        target = Int64Index(np.arange(10))
+        target = Index(np.arange(10), dtype=np.int64)
         indexer = index.get_indexer(target, method="pad")
         expected = np.array([0, 0, 1, 1, 2, 2, 3, 3, 4, 4], dtype=np.intp)
         tm.assert_numpy_array_equal(indexer, expected)
 
-        target = Int64Index(np.arange(10))
+        target = Index(np.arange(10), dtype=np.int64)
         indexer = index.get_indexer(target, method="backfill")
         expected = np.array([0, 1, 1, 2, 2, 3, 3, 4, 4, 5], dtype=np.intp)
         tm.assert_numpy_array_equal(indexer, expected)
 
     def test_get_indexer_uint64(self, index_large):
-        target = UInt64Index(np.arange(10).astype("uint64") * 5 + 2**63)
+        target = Index(np.arange(10).astype("uint64") * 5 + 2**63)
         indexer = index_large.get_indexer(target)
         expected = np.array([0, -1, 1, 2, 3, 4, -1, -1, -1, -1], dtype=np.intp)
         tm.assert_numpy_array_equal(indexer, expected)
 
-        target = UInt64Index(np.arange(10).astype("uint64") * 5 + 2**63)
+        target = Index(np.arange(10).astype("uint64") * 5 + 2**63)
         indexer = index_large.get_indexer(target, method="pad")
         expected = np.array([0, 0, 1, 2, 3, 4, 4, 4, 4, 4], dtype=np.intp)
         tm.assert_numpy_array_equal(indexer, expected)
 
-        target = UInt64Index(np.arange(10).astype("uint64") * 5 + 2**63)
+        target = Index(np.arange(10).astype("uint64") * 5 + 2**63)
         indexer = index_large.get_indexer(target, method="backfill")
         expected = np.array([0, 1, 1, 2, 3, 4, -1, -1, -1, -1], dtype=np.intp)
         tm.assert_numpy_array_equal(indexer, expected)
@@ -396,9 +389,9 @@ class TestWhere:
     @pytest.mark.parametrize(
         "index",
         [
-            Float64Index(np.arange(5, dtype="float64")),
-            Int64Index(range(0, 20, 2)),
-            UInt64Index(np.arange(5, dtype="uint64")),
+            Index(np.arange(5, dtype="float64")),
+            Index(range(0, 20, 2), dtype=np.int64),
+            Index(np.arange(5, dtype="uint64")),
         ],
     )
     def test_where(self, listlike_box, index):
@@ -407,16 +400,16 @@ class TestWhere:
         result = index.where(listlike_box(cond))
 
         cond = [False] + [True] * (len(index) - 1)
-        expected = Float64Index([index._na_value] + index[1:].tolist())
+        expected = Index([index._na_value] + index[1:].tolist(), dtype=np.float64)
         result = index.where(listlike_box(cond))
         tm.assert_index_equal(result, expected)
 
     def test_where_uint64(self):
-        idx = UInt64Index([0, 6, 2])
+        idx = Index([0, 6, 2], dtype=np.uint64)
         mask = np.array([False, True, False])
         other = np.array([1], dtype=np.int64)
 
-        expected = UInt64Index([1, 6, 1])
+        expected = Index([1, 6, 1], dtype=np.uint64)
 
         result = idx.where(mask, other)
         tm.assert_index_equal(result, expected)
@@ -437,27 +430,27 @@ class TestWhere:
 
 
 class TestTake:
-    @pytest.mark.parametrize("klass", [Float64Index, Int64Index, UInt64Index])
-    def test_take_preserve_name(self, klass):
-        index = klass([1, 2, 3, 4], name="foo")
+    @pytest.mark.parametrize("idx_dtype", [np.float64, np.int64, np.uint64])
+    def test_take_preserve_name(self, idx_dtype):
+        index = Index([1, 2, 3, 4], dtype=idx_dtype, name="foo")
         taken = index.take([3, 0, 1])
         assert index.name == taken.name
 
     def test_take_fill_value_float64(self):
         # GH 12631
-        idx = Float64Index([1.0, 2.0, 3.0], name="xxx")
+        idx = Index([1.0, 2.0, 3.0], name="xxx", dtype=np.float64)
         result = idx.take(np.array([1, 0, -1]))
-        expected = Float64Index([2.0, 1.0, 3.0], name="xxx")
+        expected = Index([2.0, 1.0, 3.0], dtype=np.float64, name="xxx")
         tm.assert_index_equal(result, expected)
 
         # fill_value
         result = idx.take(np.array([1, 0, -1]), fill_value=True)
-        expected = Float64Index([2.0, 1.0, np.nan], name="xxx")
+        expected = Index([2.0, 1.0, np.nan], dtype=np.float64, name="xxx")
         tm.assert_index_equal(result, expected)
 
         # allow_fill=False
         result = idx.take(np.array([1, 0, -1]), allow_fill=False, fill_value=True)
-        expected = Float64Index([2.0, 1.0, 3.0], name="xxx")
+        expected = Index([2.0, 1.0, 3.0], dtype=np.float64, name="xxx")
         tm.assert_index_equal(result, expected)
 
         msg = (
@@ -473,15 +466,15 @@ class TestTake:
         with pytest.raises(IndexError, match=msg):
             idx.take(np.array([1, -5]))
 
-    @pytest.mark.parametrize("klass", [Int64Index, UInt64Index])
-    def test_take_fill_value_ints(self, klass):
+    @pytest.mark.parametrize("dtype", [np.int64, np.uint64])
+    def test_take_fill_value_ints(self, dtype):
         # see gh-12631
-        idx = klass([1, 2, 3], name="xxx")
+        idx = Index([1, 2, 3], dtype=dtype, name="xxx")
         result = idx.take(np.array([1, 0, -1]))
-        expected = klass([2, 1, 3], name="xxx")
+        expected = Index([2, 1, 3], dtype=dtype, name="xxx")
         tm.assert_index_equal(result, expected)
 
-        name = klass.__name__
+        name = type(idx).__name__
         msg = f"Unable to fill values because {name} cannot contain NA"
 
         # fill_value=True
@@ -490,7 +483,7 @@ class TestTake:
 
         # allow_fill=False
         result = idx.take(np.array([1, 0, -1]), allow_fill=False, fill_value=True)
-        expected = klass([2, 1, 3], name="xxx")
+        expected = Index([2, 1, 3], dtype=dtype, name="xxx")
         tm.assert_index_equal(result, expected)
 
         with pytest.raises(ValueError, match=msg):
@@ -504,18 +497,18 @@ class TestTake:
 
 
 class TestContains:
-    @pytest.mark.parametrize("klass", [Float64Index, Int64Index, UInt64Index])
-    def test_contains_none(self, klass):
+    @pytest.mark.parametrize("dtype", [np.float64, np.int64, np.uint64])
+    def test_contains_none(self, dtype):
         # GH#35788 should return False, not raise TypeError
-        index = klass([0, 1, 2, 3, 4])
+        index = Index([0, 1, 2, 3, 4], dtype=dtype)
         assert None not in index
 
     def test_contains_float64_nans(self):
-        index = Float64Index([1.0, 2.0, np.nan])
+        index = Index([1.0, 2.0, np.nan], dtype=np.float64)
         assert np.nan in index
 
     def test_contains_float64_not_nans(self):
-        index = Float64Index([1.0, 2.0, np.nan])
+        index = Index([1.0, 2.0, np.nan], dtype=np.float64)
         assert 1.0 in index
 
 

--- a/pandas/tests/indexes/numeric/test_indexing.py
+++ b/pandas/tests/indexes/numeric/test_indexing.py
@@ -280,12 +280,16 @@ class TestGetIndexer:
         actual = index.get_indexer([0.2, 1.8, 8.5], method=method)
         tm.assert_numpy_array_equal(actual, np.array(expected, dtype=np.intp))
 
-    @pytest.mark.parametrize("idx_dtype", [np.int64, np.float64, np.uint64])
+    @pytest.mark.parametrize("idx_dtype", ["int64", "float64", "uint64", "range"])
     @pytest.mark.parametrize("method", ["get_indexer", "get_indexer_non_unique"])
     def test_get_indexer_numeric_index_boolean_target(self, method, idx_dtype):
         # GH 16877
 
-        numeric_index = Index(RangeIndex(4), dtype=idx_dtype)
+        if idx_dtype == "range":
+            numeric_index = RangeIndex(4)
+        else:
+            numeric_index = Index(np.arange(4, dtype=idx_dtype))
+
         other = Index([True, False, True])
 
         result = getattr(numeric_index, method)(other)

--- a/pandas/tests/indexes/numeric/test_join.py
+++ b/pandas/tests/indexes/numeric/test_join.py
@@ -2,11 +2,7 @@ import numpy as np
 import pytest
 
 import pandas._testing as tm
-from pandas.core.indexes.api import (
-    Index,
-    Int64Index,
-    UInt64Index,
-)
+from pandas.core.indexes.api import Index
 
 
 class TestJoinInt64Index:
@@ -25,9 +21,9 @@ class TestJoinInt64Index:
         tm.assert_numpy_array_equal(ridx, exp_ridx)
 
     def test_join_inner(self):
-        index = Int64Index(range(0, 20, 2))
-        other = Int64Index([7, 12, 25, 1, 2, 5])
-        other_mono = Int64Index([1, 2, 5, 7, 12, 25])
+        index = Index(range(0, 20, 2), dtype=np.int64)
+        other = Index([7, 12, 25, 1, 2, 5], dtype=np.int64)
+        other_mono = Index([1, 2, 5, 7, 12, 25], dtype=np.int64)
 
         # not monotonic
         res, lidx, ridx = index.join(other, how="inner", return_indexers=True)
@@ -38,11 +34,11 @@ class TestJoinInt64Index:
         lidx = lidx.take(ind)
         ridx = ridx.take(ind)
 
-        eres = Int64Index([2, 12])
+        eres = Index([2, 12], dtype=np.int64)
         elidx = np.array([1, 6], dtype=np.intp)
         eridx = np.array([4, 1], dtype=np.intp)
 
-        assert isinstance(res, Int64Index)
+        assert isinstance(res, Index) and res.dtype == np.int64
         tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
@@ -55,22 +51,22 @@ class TestJoinInt64Index:
 
         elidx = np.array([1, 6], dtype=np.intp)
         eridx = np.array([1, 4], dtype=np.intp)
-        assert isinstance(res, Int64Index)
+        assert isinstance(res, Index) and res.dtype == np.int64
         tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
     def test_join_left(self):
-        index = Int64Index(range(0, 20, 2))
-        other = Int64Index([7, 12, 25, 1, 2, 5])
-        other_mono = Int64Index([1, 2, 5, 7, 12, 25])
+        index = Index(range(0, 20, 2), dtype=np.int64)
+        other = Index([7, 12, 25, 1, 2, 5], dtype=np.int64)
+        other_mono = Index([1, 2, 5, 7, 12, 25], dtype=np.int64)
 
         # not monotonic
         res, lidx, ridx = index.join(other, how="left", return_indexers=True)
         eres = index
         eridx = np.array([-1, 4, -1, -1, -1, -1, 1, -1, -1, -1], dtype=np.intp)
 
-        assert isinstance(res, Int64Index)
+        assert isinstance(res, Index) and res.dtype == np.int64
         tm.assert_index_equal(res, eres)
         assert lidx is None
         tm.assert_numpy_array_equal(ridx, eridx)
@@ -78,7 +74,7 @@ class TestJoinInt64Index:
         # monotonic
         res, lidx, ridx = index.join(other_mono, how="left", return_indexers=True)
         eridx = np.array([-1, 1, -1, -1, -1, -1, 4, -1, -1, -1], dtype=np.intp)
-        assert isinstance(res, Int64Index)
+        assert isinstance(res, Index) and res.dtype == np.int64
         tm.assert_index_equal(res, eres)
         assert lidx is None
         tm.assert_numpy_array_equal(ridx, eridx)
@@ -95,16 +91,16 @@ class TestJoinInt64Index:
         tm.assert_numpy_array_equal(ridx, eridx)
 
     def test_join_right(self):
-        index = Int64Index(range(0, 20, 2))
-        other = Int64Index([7, 12, 25, 1, 2, 5])
-        other_mono = Int64Index([1, 2, 5, 7, 12, 25])
+        index = Index(range(0, 20, 2), dtype=np.int64)
+        other = Index([7, 12, 25, 1, 2, 5], dtype=np.int64)
+        other_mono = Index([1, 2, 5, 7, 12, 25], dtype=np.int64)
 
         # not monotonic
         res, lidx, ridx = index.join(other, how="right", return_indexers=True)
         eres = other
         elidx = np.array([-1, 6, -1, -1, 1, -1], dtype=np.intp)
 
-        assert isinstance(other, Int64Index)
+        assert isinstance(other, Index) and other.dtype == np.int64
         tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         assert ridx is None
@@ -113,7 +109,7 @@ class TestJoinInt64Index:
         res, lidx, ridx = index.join(other_mono, how="right", return_indexers=True)
         eres = other_mono
         elidx = np.array([-1, 1, -1, -1, 6, -1], dtype=np.intp)
-        assert isinstance(other, Int64Index)
+        assert isinstance(other, Index) and other.dtype == np.int64
         tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         assert ridx is None
@@ -130,7 +126,7 @@ class TestJoinInt64Index:
         tm.assert_numpy_array_equal(ridx, eridx)
 
     def test_join_non_int_index(self):
-        index = Int64Index(range(0, 20, 2))
+        index = Index(range(0, 20, 2), dtype=np.int64)
         other = Index([3, 6, 7, 8, 10], dtype=object)
 
         outer = index.join(other, how="outer")
@@ -158,9 +154,9 @@ class TestJoinInt64Index:
         tm.assert_index_equal(right2, index.astype(object))
 
     def test_join_outer(self):
-        index = Int64Index(range(0, 20, 2))
-        other = Int64Index([7, 12, 25, 1, 2, 5])
-        other_mono = Int64Index([1, 2, 5, 7, 12, 25])
+        index = Index(range(0, 20, 2), dtype=np.int64)
+        other = Index([7, 12, 25, 1, 2, 5], dtype=np.int64)
+        other_mono = Index([1, 2, 5, 7, 12, 25], dtype=np.int64)
 
         # not monotonic
         # guarantee of sortedness
@@ -168,13 +164,13 @@ class TestJoinInt64Index:
         noidx_res = index.join(other, how="outer")
         tm.assert_index_equal(res, noidx_res)
 
-        eres = Int64Index([0, 1, 2, 4, 5, 6, 7, 8, 10, 12, 14, 16, 18, 25])
+        eres = Index([0, 1, 2, 4, 5, 6, 7, 8, 10, 12, 14, 16, 18, 25], dtype=np.int64)
         elidx = np.array([0, -1, 1, 2, -1, 3, -1, 4, 5, 6, 7, 8, 9, -1], dtype=np.intp)
         eridx = np.array(
             [-1, 3, 4, -1, 5, -1, 0, -1, -1, 1, -1, -1, -1, 2], dtype=np.intp
         )
 
-        assert isinstance(res, Int64Index)
+        assert isinstance(res, Index) and res.dtype == np.int64
         tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
@@ -188,7 +184,7 @@ class TestJoinInt64Index:
         eridx = np.array(
             [-1, 0, 1, -1, 2, -1, 3, -1, -1, 4, -1, -1, -1, 5], dtype=np.intp
         )
-        assert isinstance(res, Int64Index)
+        assert isinstance(res, Index) and res.dtype == np.int64
         tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
@@ -197,15 +193,13 @@ class TestJoinInt64Index:
 class TestJoinUInt64Index:
     @pytest.fixture
     def index_large(self):
-        # large values used in TestUInt64Index where no compat needed with Int64/Float64
+        # large values used in TestUInt64Index where no compat needed with int64/float64
         large = [2**63, 2**63 + 10, 2**63 + 15, 2**63 + 20, 2**63 + 25]
-        return UInt64Index(large)
+        return Index(large, dtype=np.uint64)
 
     def test_join_inner(self, index_large):
-        other = UInt64Index(2**63 + np.array([7, 12, 25, 1, 2, 10], dtype="uint64"))
-        other_mono = UInt64Index(
-            2**63 + np.array([1, 2, 7, 10, 12, 25], dtype="uint64")
-        )
+        other = Index(2**63 + np.array([7, 12, 25, 1, 2, 10], dtype="uint64"))
+        other_mono = Index(2**63 + np.array([1, 2, 7, 10, 12, 25], dtype="uint64"))
 
         # not monotonic
         res, lidx, ridx = index_large.join(other, how="inner", return_indexers=True)
@@ -216,11 +210,11 @@ class TestJoinUInt64Index:
         lidx = lidx.take(ind)
         ridx = ridx.take(ind)
 
-        eres = UInt64Index(2**63 + np.array([10, 25], dtype="uint64"))
+        eres = Index(2**63 + np.array([10, 25], dtype="uint64"))
         elidx = np.array([1, 4], dtype=np.intp)
         eridx = np.array([5, 2], dtype=np.intp)
 
-        assert isinstance(res, UInt64Index)
+        assert isinstance(res, Index) and res.dtype == np.uint64
         tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
@@ -236,23 +230,21 @@ class TestJoinUInt64Index:
         elidx = np.array([1, 4], dtype=np.intp)
         eridx = np.array([3, 5], dtype=np.intp)
 
-        assert isinstance(res, UInt64Index)
+        assert isinstance(res, Index) and res.dtype == np.uint64
         tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
     def test_join_left(self, index_large):
-        other = UInt64Index(2**63 + np.array([7, 12, 25, 1, 2, 10], dtype="uint64"))
-        other_mono = UInt64Index(
-            2**63 + np.array([1, 2, 7, 10, 12, 25], dtype="uint64")
-        )
+        other = Index(2**63 + np.array([7, 12, 25, 1, 2, 10], dtype="uint64"))
+        other_mono = Index(2**63 + np.array([1, 2, 7, 10, 12, 25], dtype="uint64"))
 
         # not monotonic
         res, lidx, ridx = index_large.join(other, how="left", return_indexers=True)
         eres = index_large
         eridx = np.array([-1, 5, -1, -1, 2], dtype=np.intp)
 
-        assert isinstance(res, UInt64Index)
+        assert isinstance(res, Index) and res.dtype == np.uint64
         tm.assert_index_equal(res, eres)
         assert lidx is None
         tm.assert_numpy_array_equal(ridx, eridx)
@@ -261,18 +253,18 @@ class TestJoinUInt64Index:
         res, lidx, ridx = index_large.join(other_mono, how="left", return_indexers=True)
         eridx = np.array([-1, 3, -1, -1, 5], dtype=np.intp)
 
-        assert isinstance(res, UInt64Index)
+        assert isinstance(res, Index) and res.dtype == np.uint64
         tm.assert_index_equal(res, eres)
         assert lidx is None
         tm.assert_numpy_array_equal(ridx, eridx)
 
         # non-unique
-        idx = UInt64Index(2**63 + np.array([1, 1, 2, 5], dtype="uint64"))
-        idx2 = UInt64Index(2**63 + np.array([1, 2, 5, 7, 9], dtype="uint64"))
+        idx = Index(2**63 + np.array([1, 1, 2, 5], dtype="uint64"))
+        idx2 = Index(2**63 + np.array([1, 2, 5, 7, 9], dtype="uint64"))
         res, lidx, ridx = idx2.join(idx, how="left", return_indexers=True)
 
         # 1 is in idx2, so it should be x2
-        eres = UInt64Index(2**63 + np.array([1, 1, 2, 5, 7, 9], dtype="uint64"))
+        eres = Index(2**63 + np.array([1, 1, 2, 5, 7, 9], dtype="uint64"))
         eridx = np.array([0, 1, 2, 3, -1, -1], dtype=np.intp)
         elidx = np.array([0, 0, 1, 2, 3, 4], dtype=np.intp)
 
@@ -281,10 +273,8 @@ class TestJoinUInt64Index:
         tm.assert_numpy_array_equal(ridx, eridx)
 
     def test_join_right(self, index_large):
-        other = UInt64Index(2**63 + np.array([7, 12, 25, 1, 2, 10], dtype="uint64"))
-        other_mono = UInt64Index(
-            2**63 + np.array([1, 2, 7, 10, 12, 25], dtype="uint64")
-        )
+        other = Index(2**63 + np.array([7, 12, 25, 1, 2, 10], dtype="uint64"))
+        other_mono = Index(2**63 + np.array([1, 2, 7, 10, 12, 25], dtype="uint64"))
 
         # not monotonic
         res, lidx, ridx = index_large.join(other, how="right", return_indexers=True)
@@ -292,7 +282,7 @@ class TestJoinUInt64Index:
         elidx = np.array([-1, -1, 4, -1, -1, 1], dtype=np.intp)
 
         tm.assert_numpy_array_equal(lidx, elidx)
-        assert isinstance(other, UInt64Index)
+        assert isinstance(other, Index) and other.dtype == np.uint64
         tm.assert_index_equal(res, eres)
         assert ridx is None
 
@@ -303,18 +293,18 @@ class TestJoinUInt64Index:
         eres = other_mono
         elidx = np.array([-1, -1, -1, 1, -1, 4], dtype=np.intp)
 
-        assert isinstance(other, UInt64Index)
+        assert isinstance(other, Index) and other.dtype == np.uint64
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_index_equal(res, eres)
         assert ridx is None
 
         # non-unique
-        idx = UInt64Index(2**63 + np.array([1, 1, 2, 5], dtype="uint64"))
-        idx2 = UInt64Index(2**63 + np.array([1, 2, 5, 7, 9], dtype="uint64"))
+        idx = Index(2**63 + np.array([1, 1, 2, 5], dtype="uint64"))
+        idx2 = Index(2**63 + np.array([1, 2, 5, 7, 9], dtype="uint64"))
         res, lidx, ridx = idx.join(idx2, how="right", return_indexers=True)
 
         # 1 is in idx2, so it should be x2
-        eres = UInt64Index(2**63 + np.array([1, 1, 2, 5, 7, 9], dtype="uint64"))
+        eres = Index(2**63 + np.array([1, 1, 2, 5, 7, 9], dtype="uint64"))
         elidx = np.array([0, 1, 2, 3, -1, -1], dtype=np.intp)
         eridx = np.array([0, 0, 1, 2, 3, 4], dtype=np.intp)
 
@@ -354,10 +344,8 @@ class TestJoinUInt64Index:
         tm.assert_index_equal(right2, index_large.astype(object))
 
     def test_join_outer(self, index_large):
-        other = UInt64Index(2**63 + np.array([7, 12, 25, 1, 2, 10], dtype="uint64"))
-        other_mono = UInt64Index(
-            2**63 + np.array([1, 2, 7, 10, 12, 25], dtype="uint64")
-        )
+        other = Index(2**63 + np.array([7, 12, 25, 1, 2, 10], dtype="uint64"))
+        other_mono = Index(2**63 + np.array([1, 2, 7, 10, 12, 25], dtype="uint64"))
 
         # not monotonic
         # guarantee of sortedness
@@ -365,13 +353,13 @@ class TestJoinUInt64Index:
         noidx_res = index_large.join(other, how="outer")
         tm.assert_index_equal(res, noidx_res)
 
-        eres = UInt64Index(
+        eres = Index(
             2**63 + np.array([0, 1, 2, 7, 10, 12, 15, 20, 25], dtype="uint64")
         )
         elidx = np.array([0, -1, -1, -1, 1, -1, 2, 3, 4], dtype=np.intp)
         eridx = np.array([-1, 3, 4, 0, 5, 1, -1, -1, 2], dtype=np.intp)
 
-        assert isinstance(res, UInt64Index)
+        assert isinstance(res, Index) and res.dtype == np.uint64
         tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
@@ -386,7 +374,7 @@ class TestJoinUInt64Index:
         elidx = np.array([0, -1, -1, -1, 1, -1, 2, 3, 4], dtype=np.intp)
         eridx = np.array([-1, 0, 1, 2, 3, 4, -1, -1, 5], dtype=np.intp)
 
-        assert isinstance(res, UInt64Index)
+        assert isinstance(res, Index) and res.dtype == np.uint64
         tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)

--- a/pandas/tests/indexes/numeric/test_numeric.py
+++ b/pandas/tests/indexes/numeric/test_numeric.py
@@ -9,12 +9,7 @@ from pandas import (
     Series,
 )
 import pandas._testing as tm
-from pandas.core.indexes.api import (
-    Float64Index,
-    Int64Index,
-    NumericIndex,
-    UInt64Index,
-)
+from pandas.core.indexes.api import NumericIndex
 from pandas.tests.indexes.common import NumericBase
 
 
@@ -185,7 +180,7 @@ class TestFloatNumericIndex(NumericBase):
     @pytest.mark.parametrize(
         "other",
         (
-            Int64Index([1, 2]),
+            Index([1, 2], dtype=np.int64),
             Index([1.0, 2.0], dtype=object),
             Index([1, 2], dtype=object),
         ),
@@ -259,62 +254,15 @@ class TestFloatNumericIndex(NumericBase):
         tm.assert_index_equal(idx.fillna(0.1), exp, exact=True)
 
         # downcast
-        exact = True if index_cls is Int64Index else "equiv"
         exp = index_cls([1.0, 2.0, 3.0], name="x")
-        tm.assert_index_equal(idx.fillna(2), exp, exact=exact)
+        tm.assert_index_equal(idx.fillna(2), exp)
 
         # object
         exp = Index([1.0, "obj", 3.0], name="x")
         tm.assert_index_equal(idx.fillna("obj"), exp, exact=True)
 
 
-class TestFloat64Index(TestFloatNumericIndex):
-    _index_cls = Float64Index
-
-    @pytest.fixture
-    def dtype(self, request):
-        return np.float64
-
-    @pytest.fixture(
-        params=["int64", "uint64", "object", "category", "datetime64"],
-    )
-    def invalid_dtype(self, request):
-        return request.param
-
-    def test_constructor_from_base_index(self, dtype):
-        index_cls = self._index_cls
-
-        result = Index(np.array([np.nan], dtype=dtype))
-        assert isinstance(result, index_cls)
-        assert result.dtype == dtype
-        assert pd.isna(result.values).all()
-
-    def test_constructor_32bit(self, dtype):
-        index_cls = self._index_cls
-
-        index = index_cls(np.array([1.0, 2, 3, 4, 5]), dtype=np.float32)
-        assert isinstance(index, index_cls)
-        assert index.dtype == np.float64
-
-        index = index_cls(np.array([1, 2, 3, 4, 5]), dtype=np.float32)
-        assert isinstance(index, index_cls)
-        assert index.dtype == np.float64
-
-
 class NumericInt(NumericBase):
-    def test_view(self, dtype):
-        index_cls = self._index_cls
-
-        idx = index_cls([], dtype=dtype, name="Foo")
-        idx_view = idx.view()
-        assert idx_view.name == "Foo"
-
-        idx_view = idx.view(dtype)
-        tm.assert_index_equal(idx, index_cls(idx_view, name="Foo"), exact=True)
-
-        idx_view = idx.view(index_cls)
-        tm.assert_index_equal(idx, index_cls(idx_view, name="Foo"), exact=True)
-
     def test_is_monotonic(self):
         index_cls = self._index_cls
 
@@ -448,17 +396,15 @@ class TestIntNumericIndex(NumericInt):
         assert new_index[0] != val
 
         if dtype == np.int64:
-            exact = "equiv" if index_cls != Int64Index else True
-
             # pass list, coerce fine
             index = index_cls([-5, 0, 1, 2], dtype=dtype)
             expected = Index([-5, 0, 1, 2], dtype=dtype)
-            tm.assert_index_equal(index, expected, exact=exact)
+            tm.assert_index_equal(index, expected)
 
             # from iterable
             index = index_cls(iter([-5, 0, 1, 2]), dtype=dtype)
             expected = index_cls([-5, 0, 1, 2], dtype=dtype)
-            tm.assert_index_equal(index, expected, exact=exact)
+            tm.assert_index_equal(index, expected, exact=True)
 
             # interpret list-like
             expected = index_cls([5, 0], dtype=dtype)
@@ -468,7 +414,7 @@ class TestIntNumericIndex(NumericInt):
                     cls(np.array([5, 0]), dtype=dtype),
                     cls(Series([5, 0]), dtype=dtype),
                 ]:
-                    tm.assert_index_equal(idx, expected, exact=exact)
+                    tm.assert_index_equal(idx, expected)
 
     def test_constructor_corner(self, dtype):
         index_cls = self._index_cls
@@ -484,8 +430,7 @@ class TestIntNumericIndex(NumericInt):
             #  ndarray of numbers, matching Series behavior
             assert without_dtype.dtype == object
 
-            exact = True if index_cls is Int64Index else "equiv"
-            tm.assert_index_equal(index, without_dtype.astype(np.int64), exact=exact)
+            tm.assert_index_equal(index, without_dtype.astype(np.int64))
 
         # preventing casting
         arr = np.array([1, "2", 3, "4"], dtype=object)
@@ -507,15 +452,15 @@ class TestIntNumericIndex(NumericInt):
         # GH#47475
         scalar = np.dtype(any_signed_int_numpy_dtype).type(1)
         result = Index([scalar])
-        expected = Int64Index([1])
-        tm.assert_index_equal(result, expected)
+        expected = Index([1], dtype=np.int64)
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_constructor_np_unsigned(self, any_unsigned_int_numpy_dtype):
         # GH#47475
         scalar = np.dtype(any_unsigned_int_numpy_dtype).type(1)
         result = Index([scalar])
-        expected = UInt64Index([1])
-        tm.assert_index_equal(result, expected)
+        expected = Index([1], dtype=np.uint64)
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_coerce_list(self):
         # coerce things
@@ -525,31 +470,6 @@ class TestIntNumericIndex(NumericInt):
         # but not if explicit dtype passed
         arr = Index([1, 2, 3, 4], dtype=object)
         assert type(arr) is Index
-
-
-class TestInt64Index(TestIntNumericIndex):
-    _index_cls = Int64Index
-
-    @pytest.fixture
-    def dtype(self):
-        return np.int64
-
-    @pytest.fixture(
-        params=["float64", "uint64", "object", "category", "datetime64"],
-    )
-    def invalid_dtype(self, request):
-        return request.param
-
-    def test_constructor_32bit(self, dtype):
-        index_cls = self._index_cls
-
-        index = index_cls(np.array([1, 2, 3, 4, 5]), dtype=np.int32)
-        assert isinstance(index, index_cls)
-        assert index.dtype == np.int64
-
-        index = index_cls(np.array([1, 2, 3, 4, 5]), dtype=np.int32)
-        assert isinstance(index, index_cls)
-        assert index.dtype == np.int64
 
 
 class TestUIntNumericIndex(NumericInt):
@@ -580,64 +500,6 @@ class TestUIntNumericIndex(NumericInt):
         return self._index_cls(request.param, dtype=np.uint64)
 
 
-class TestUInt64Index(TestUIntNumericIndex):
-
-    _index_cls = UInt64Index
-
-    @pytest.fixture
-    def dtype(self):
-        return np.uint64
-
-    @pytest.fixture(
-        params=["int64", "float64", "object", "category", "datetime64"],
-    )
-    def invalid_dtype(self, request):
-        return request.param
-
-    def test_constructor(self, dtype):
-        index_cls = self._index_cls
-        exact = True if index_cls is UInt64Index else "equiv"
-
-        idx = index_cls([1, 2, 3])
-        res = Index([1, 2, 3], dtype=dtype)
-        tm.assert_index_equal(res, idx, exact=exact)
-
-        idx = index_cls([1, 2**63])
-        res = Index([1, 2**63], dtype=dtype)
-        tm.assert_index_equal(res, idx, exact=exact)
-
-        idx = index_cls([1, 2**63])
-        res = Index([1, 2**63])
-        tm.assert_index_equal(res, idx, exact=exact)
-
-        idx = Index([-1, 2**63], dtype=object)
-        res = Index(np.array([-1, 2**63], dtype=object))
-        tm.assert_index_equal(res, idx, exact=exact)
-
-        # https://github.com/pandas-dev/pandas/issues/29526
-        idx = index_cls([1, 2**63 + 1], dtype=dtype)
-        res = Index([1, 2**63 + 1], dtype=dtype)
-        tm.assert_index_equal(res, idx, exact=exact)
-
-    def test_constructor_does_not_cast_to_float(self):
-        # https://github.com/numpy/numpy/issues/19146
-        values = [0, np.iinfo(np.uint64).max]
-
-        result = UInt64Index(values)
-        assert list(result) == values
-
-    def test_constructor_32bit(self, dtype):
-        index_cls = self._index_cls
-
-        index = index_cls(np.array([1, 2, 3, 4, 5]), dtype=np.uint32)
-        assert isinstance(index, index_cls)
-        assert index.dtype == np.uint64
-
-        index = index_cls(np.array([1, 2, 3, 4, 5]), dtype=np.uint32)
-        assert isinstance(index, index_cls)
-        assert index.dtype == np.uint64
-
-
 @pytest.mark.parametrize(
     "box",
     [list, lambda x: np.array(x, dtype=object), lambda x: Index(x, dtype=object)],
@@ -659,7 +521,7 @@ def test_uint_index_does_not_convert_to_float64(box):
 
     result = series.loc[box([7606741985629028552, 17876870360202815256])]
 
-    expected = UInt64Index(
+    expected = Index(
         [7606741985629028552, 17876870360202815256, 17876870360202815256],
         dtype="uint64",
     )
@@ -682,9 +544,9 @@ def test_float64_index_equals():
 
 def test_map_dtype_inference_unsigned_to_signed():
     # GH#44609 cases where we don't retain dtype
-    idx = UInt64Index([1, 2, 3])
+    idx = Index([1, 2, 3], dtype=np.uint64)
     result = idx.map(lambda x: -x)
-    expected = Int64Index([-1, -2, -3])
+    expected = Index([-1, -2, -3], dtype=np.int64)
     tm.assert_index_equal(result, expected)
 
 

--- a/pandas/tests/indexes/numeric/test_setops.py
+++ b/pandas/tests/indexes/numeric/test_setops.py
@@ -8,19 +8,16 @@ import pytest
 
 import pandas._testing as tm
 from pandas.core.indexes.api import (
-    Float64Index,
     Index,
-    Int64Index,
     RangeIndex,
-    UInt64Index,
 )
 
 
 @pytest.fixture
 def index_large():
-    # large values used in TestUInt64Index where no compat needed with Int64/Float64
+    # large values used in TestUInt64Index where no compat needed with int64/float64
     large = [2**63, 2**63 + 10, 2**63 + 15, 2**63 + 20, 2**63 + 25]
-    return UInt64Index(large)
+    return Index(large, dtype=np.uint64)
 
 
 class TestSetOps:
@@ -40,7 +37,7 @@ class TestSetOps:
         tm.assert_index_equal(result, expected)
 
     def test_intersection(self):
-        index = Int64Index(range(5))
+        index = Index(range(5), dtype=np.int64)
 
         other = Index([1, 2, 3, 4, 5])
         result = index.intersection(other)
@@ -58,8 +55,8 @@ class TestSetOps:
         # https://github.com/pandas-dev/pandas/issues/26778
         # [u]int | float -> float
         index = Index([0, 2, 3], dtype=dtype)
-        other = Float64Index([0.5, 1.5])
-        expected = Float64Index([0.0, 0.5, 1.5, 2.0, 3.0])
+        other = Index([0.5, 1.5], dtype=np.float64)
+        expected = Index([0.0, 0.5, 1.5, 2.0, 3.0], dtype=np.float64)
         result = index.union(other)
         tm.assert_index_equal(result, expected)
 
@@ -69,9 +66,9 @@ class TestSetOps:
     def test_range_float_union_dtype(self):
         # https://github.com/pandas-dev/pandas/issues/26778
         index = RangeIndex(start=0, stop=3)
-        other = Float64Index([0.5, 1.5])
+        other = Index([0.5, 1.5], dtype=np.float64)
         result = index.union(other)
-        expected = Float64Index([0.0, 0.5, 1, 1.5, 2.0])
+        expected = Index([0.0, 0.5, 1, 1.5, 2.0], dtype=np.float64)
         tm.assert_index_equal(result, expected)
 
         result = other.union(index)


### PR DESCRIPTION
Progress towards #42717. Other locations will follow.

There are tests in here that probably should be parametrized when `Index` will be able to return non-64 bit dtypes. I'll do that in followups, after `Index` returns a `NumericIndex`.