### PR TITLE
BUG: Index.to_numpy returned a referenece to the index' data

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -653,7 +653,7 @@ Indexing
 - Bug in :meth:`DataFrame.loc` coercing dtypes when setting values with a list indexer (:issue:`49159`)
 - Bug in :meth:`DataFrame.__setitem__` raising ``ValueError`` when right hand side is :class:`DataFrame` with :class:`MultiIndex` columns (:issue:`49121`)
 - Bug in :meth:`DataFrame.reindex` casting dtype to ``object`` when :class:`DataFrame` has single extension array column when re-indexing ``columns`` and ``index`` (:issue:`48190`)
-- Bug in :meth:`Index.to_numpy` where the index' underlying data wasn't copied to the new array (:class:`49663`)
+- Bug in :meth:`Index.to_numpy` where the index' underlying data returned writeable (:class:`49663`)
 - Bug in :func:`~DataFrame.describe` when formatting percentiles in the resulting index showed more decimals than needed (:issue:`46362`)
 - Bug in :meth:`DataFrame.compare` does not recognize differences when comparing ``NA`` with value in nullable dtypes (:issue:`48939`)
 -

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -653,6 +653,7 @@ Indexing
 - Bug in :meth:`DataFrame.loc` coercing dtypes when setting values with a list indexer (:issue:`49159`)
 - Bug in :meth:`DataFrame.__setitem__` raising ``ValueError`` when right hand side is :class:`DataFrame` with :class:`MultiIndex` columns (:issue:`49121`)
 - Bug in :meth:`DataFrame.reindex` casting dtype to ``object`` when :class:`DataFrame` has single extension array column when re-indexing ``columns`` and ``index`` (:issue:`48190`)
+- Bug in :meth:`Index.to_numpy` where the index' underlying data wasn't copied to the new array (:class:`49663`)
 - Bug in :func:`~DataFrame.describe` when formatting percentiles in the resulting index showed more decimals than needed (:issue:`46362`)
 - Bug in :meth:`DataFrame.compare` does not recognize differences when comparing ``NA`` with value in nullable dtypes (:issue:`48939`)
 -

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -532,7 +532,7 @@ class IndexOpsMixin(OpsMixin):
 
         result = np.asarray(self._values, dtype=dtype)
         # TODO(GH-24345): Avoid potential double copy
-        if copy or na_value is not lib.no_default:
+        if copy or result is self._values or na_value is not lib.no_default:
             result = result.copy()
             if na_value is not lib.no_default:
                 result[np.asanyarray(self.isna())] = na_value

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -442,7 +442,7 @@ class IndexOpsMixin(OpsMixin):
             another array. Note that ``copy=False`` does not *ensure* that
             ``to_numpy()`` is no-copy. Rather, ``copy=True`` ensure that
             a copy is made, even if not strictly necessary, while ``copy=False`` means
-            that a copy is returned is the underlying data is an ExtensionArray, else
+            that a copy is returned if the underlying data is an ExtensionArray and else
             a non-writeable *view* on the index's underlying data is returned.
         na_value : Any, optional
             The value to use for missing values. The default value depends

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -828,6 +828,12 @@ class NumericBase(Base):
     def test_numeric_compat(self):
         pass  # override Base method
 
+    def test_to_numpy(self, simple_index):
+        # GH49663
+        index = simple_index
+        result = index.to_numpy()
+        assert result is not index._data
+
     def test_insert_non_na(self, simple_index):
         # GH#43921 inserting an element that we know we can hold should
         #  not change dtype or type (except for RangeIndex)


### PR DESCRIPTION
- [X] closes #49663
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

`Index.to_numpy` returned a reference instead of a copy of the underlying data, meaning that is was possible to alter the index' supposedly immutable data:

```ipython
>>> import pandas as pd
>>> idx = pd.Index(["a", "b"])
>>> res = idx.to_numpy()
>>> res[0] = "x"
>>> idx
Index(['x', 'b'], dtype='object')  # main, ups
Index(['a', 'b'], dtype='object')  # this PR
```