### PR TITLE
ENH: Add copy-on-write to `DataFrame.drop`

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4483,6 +4483,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             indexer,
             axis=bm_axis,
             allow_dups=True,
+            copy=None,
             only_slice=only_slice,
         )
         result = self._constructor(new_mgr)

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -546,7 +546,7 @@ class BaseArrayManager(DataManager):
         axis: AxisInt,
         fill_value=None,
         allow_dups: bool = False,
-        copy: bool = True,
+        copy: bool | None = True,
         # ignored keywords
         only_slice: bool = False,
         # ArrayManager specific keywords
@@ -570,7 +570,7 @@ class BaseArrayManager(DataManager):
         axis: AxisInt,
         fill_value=None,
         allow_dups: bool = False,
-        copy: bool = True,
+        copy: bool | None = True,
         use_na_proxy: bool = False,
     ) -> T:
         """

--- a/pandas/tests/copy_view/test_methods.py
+++ b/pandas/tests/copy_view/test_methods.py
@@ -52,6 +52,24 @@ def test_copy_shallow(using_copy_on_write):
 # DataFrame methods returning new DataFrame using shallow copy
 
 
+def test_drop_on_column(using_copy_on_write):
+    df = DataFrame(
+        {"a": [1, 2, 3], "b": [4, 5, 6], "c": [0.1, 0.2, 0.3]}, index=[10, 11, 12]
+    )
+    df_orig = df.copy()
+    df2 = df.drop(columns="a")
+    df2._mgr._verify_integrity()
+
+    if using_copy_on_write:
+        assert np.shares_memory(get_array(df2, "b"), get_array(df, "b"))
+        assert np.shares_memory(get_array(df2, "c"), get_array(df, "c"))
+    df2.iloc[0, 0] = 0
+    assert not np.shares_memory(get_array(df2, "b"), get_array(df, "b"))
+    if using_copy_on_write:
+        assert np.shares_memory(get_array(df2, "c"), get_array(df, "c"))
+    tm.assert_frame_equal(df, df_orig)
+
+
 def test_reset_index(using_copy_on_write):
     # Case: resetting the index (i.e. adding a new column) + mutating the
     # resulting dataframe
@@ -61,7 +79,6 @@ def test_reset_index(using_copy_on_write):
     df_orig = df.copy()
     df2 = df.reset_index()
     df2._mgr._verify_integrity()
-
     if using_copy_on_write:
         # still shares memory (df2 is a shallow copy)
         assert np.shares_memory(get_array(df2, "b"), get_array(df, "b"))

--- a/pandas/tests/copy_view/test_methods.py
+++ b/pandas/tests/copy_view/test_methods.py
@@ -52,24 +52,6 @@ def test_copy_shallow(using_copy_on_write):
 # DataFrame methods returning new DataFrame using shallow copy
 
 
-def test_drop_on_column(using_copy_on_write):
-    df = DataFrame(
-        {"a": [1, 2, 3], "b": [4, 5, 6], "c": [0.1, 0.2, 0.3]}, index=[10, 11, 12]
-    )
-    df_orig = df.copy()
-    df2 = df.drop(columns="a")
-    df2._mgr._verify_integrity()
-
-    if using_copy_on_write:
-        assert np.shares_memory(get_array(df2, "b"), get_array(df, "b"))
-        assert np.shares_memory(get_array(df2, "c"), get_array(df, "c"))
-    df2.iloc[0, 0] = 0
-    assert not np.shares_memory(get_array(df2, "b"), get_array(df, "b"))
-    if using_copy_on_write:
-        assert np.shares_memory(get_array(df2, "c"), get_array(df, "c"))
-    tm.assert_frame_equal(df, df_orig)
-
-
 def test_reset_index(using_copy_on_write):
     # Case: resetting the index (i.e. adding a new column) + mutating the
     # resulting dataframe
@@ -145,6 +127,25 @@ def test_reindex_columns(using_copy_on_write):
     # mutating df2 triggers a copy-on-write for that column
     df2.iloc[0, 0] = 0
     assert not np.shares_memory(get_array(df2, "a"), get_array(df, "a"))
+    if using_copy_on_write:
+        assert np.shares_memory(get_array(df2, "c"), get_array(df, "c"))
+    tm.assert_frame_equal(df, df_orig)
+
+
+def test_drop_on_column(using_copy_on_write):
+    df = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [0.1, 0.2, 0.3]})
+    df_orig = df.copy()
+    df2 = df.drop(columns="a")
+    df2._mgr._verify_integrity()
+
+    if using_copy_on_write:
+        assert np.shares_memory(get_array(df2, "b"), get_array(df, "b"))
+        assert np.shares_memory(get_array(df2, "c"), get_array(df, "c"))
+    else:
+        assert not np.shares_memory(get_array(df2, "b"), get_array(df, "b"))
+        assert not np.shares_memory(get_array(df2, "c"), get_array(df, "c"))
+    df2.iloc[0, 0] = 0
+    assert not np.shares_memory(get_array(df2, "b"), get_array(df, "b"))
     if using_copy_on_write:
         assert np.shares_memory(get_array(df2, "c"), get_array(df, "c"))
     tm.assert_frame_equal(df, df_orig)

--- a/pandas/tests/copy_view/test_methods.py
+++ b/pandas/tests/copy_view/test_methods.py
@@ -79,6 +79,7 @@ def test_reset_index(using_copy_on_write):
     df_orig = df.copy()
     df2 = df.reset_index()
     df2._mgr._verify_integrity()
+
     if using_copy_on_write:
         # still shares memory (df2 is a shallow copy)
         assert np.shares_memory(get_array(df2, "b"), get_array(df, "b"))


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Progress towards #49473 
Add copy-on-write support to `df.drop`.

Not sure if the test is checking the correct behavior. It was passing even before I set `copy=None`, but `BlockManager.reindex_indexer()` has `copy=True` by default. So my assumption is that there's an error in the test itself.

Also test only tries dropping a column. Wasn't sure how to write a test for dropping a row since there's no `get_array` equivalent for that.

@jorisvandenbossche Please advise when you have a moment.