### PR TITLE
DOC: mention tz_convert(None) and tz_localize(None) for dataframe or series

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10137,8 +10137,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         """
         Convert tz-aware axis to target time zone.
 
-        To convert to UTC and get a tz-naive axis, pass tz=None.
-
         Parameters
         ----------
         tz : str or tzinfo object or None
@@ -10207,9 +10205,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         This operation localizes the Index. To localize the values in a
         timezone-naive Series, use :meth:`Series.dt.tz_localize`.
-
-        This method can also used to do the inverse -- to get a tz-naive index
-        from a time zone aware index, pass tz=None.
 
         Parameters
         ----------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10140,7 +10140,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         Parameters
         ----------
         tz : str or tzinfo object or None
-            Time zone to convert index to. Passing ``None`` will convert to
+            Target time zone. Passing ``None`` will convert to
             UTC and remove the timezone information.
         axis : the axis to convert
         level : int, str, default None
@@ -10169,7 +10169,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         2018-09-15 07:30:00+08:00    1
         dtype: int64
 
-        Convert to UTC and get a tz-naive index:
+        Pass None to convert to UTC and get a tz-naive index:
 
         >>> s = pd.Series([1],
         ...     index=pd.DatetimeIndex(['2018-09-15 01:30:00+02:00']))
@@ -10227,7 +10227,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         Parameters
         ----------
         tz : str or tzinfo or None
-            Time zone to convert the index to. pass ``None`` will remove the
+            Time zone to localize. Passing ``None`` will remove the
             time zone information and preserve local time.
         axis : the axis to localize
         level : int, str, default None
@@ -10284,7 +10284,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         2018-09-15 01:30:00+02:00    1
         dtype: int64
 
-        Convert to tz-naive index and preserve local time:
+        Pass None to convert to tz-naive index and preserve local time:
 
         >>> s = pd.Series([1],
         ...     index=pd.DatetimeIndex(['2018-09-15 01:30:00+02:00']))

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10137,9 +10137,13 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         """
         Convert tz-aware axis to target time zone.
 
+        To convert to UTC and get a tz-naive axis, pass tz=None.
+
         Parameters
         ----------
-        tz : str or tzinfo object
+        tz : str or tzinfo object or None
+            Time zone to convert index to. Passing ``None`` will convert to
+            UTC and remove the timezone information.
         axis : the axis to convert
         level : int, str, default None
             If axis is a MultiIndex, convert a specific level. Otherwise
@@ -10204,9 +10208,14 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         This operation localizes the Index. To localize the values in a
         timezone-naive Series, use :meth:`Series.dt.tz_localize`.
 
+        This method can also used to do the inverse -- to get a tz-naive index
+        from a time zone aware index, pass tz=None.
+
         Parameters
         ----------
-        tz : str or tzinfo
+        tz : str or tzinfo or None
+            Time zone to convert the index to. pass ``None`` will remove the
+            time zone information and preserve local time.
         axis : the axis to localize
         level : int, str, default None
             If axis ia a MultiIndex, localize a specific level. Otherwise

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10158,6 +10158,24 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         ------
         TypeError
             If the axis is tz-naive.
+
+        Examples
+        --------
+        Change to another time zone:
+
+        >>> s = pd.Series([1],
+        ...     index=pd.DatetimeIndex(['2018-09-15 01:30:00+02:00']))
+        >>> s.tz_convert('Asia/Shanghai')
+        2018-09-15 07:30:00+08:00    1
+        dtype: int64
+
+        Convert to UTC and get a tz-naive index:
+
+        >>> s = pd.Series([1],
+        ...     index=pd.DatetimeIndex(['2018-09-15 01:30:00+02:00']))
+        >>> s.tz_convert(None)
+        2018-09-14 23:30:00    1
+        dtype: int64
         """
         axis = self._get_axis_number(axis)
         ax = self._get_axis(axis)
@@ -10264,6 +10282,14 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         ...               index=pd.DatetimeIndex(['2018-09-15 01:30:00']))
         >>> s.tz_localize('CET')
         2018-09-15 01:30:00+02:00    1
+        dtype: int64
+
+        Convert to tz-naive index and preserve local time:
+
+        >>> s = pd.Series([1],
+        ...     index=pd.DatetimeIndex(['2018-09-15 01:30:00+02:00']))
+        >>> s.tz_localize(None)
+        2018-09-15 01:30:00    1
         dtype: int64
 
         Be careful with DST changes. When there is sequential data, pandas


### PR DESCRIPTION
DOC: mention tz_convert(None) and tz_localize(None) for dataframe or series
---

I found the functionality to convert tz-aware axis to tz-naive axis is documented in DatatimeIndex but not documented in DataFrame or Series. Add more documentation to mention this feature.

[pandas.DatetimeIndex.tz_convert](https://pandas.pydata.org/docs/reference/api/pandas.DatetimeIndex.tz_convert.html)
[pandas.DatetimeIndex.tz_localize](https://pandas.pydata.org/docs/reference/api/pandas.DatetimeIndex.tz_localize.html)

