### PR TITLE
ENH: dont guess %Y/%m

### DIFF
--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -1013,12 +1013,15 @@ def guess_datetime_format(dt_str: str, bint dayfirst=False) -> str | None:
                 found_attrs.update(attrs)
                 break
 
-    # Only consider it a valid guess if we have a year, month and day,
-    # unless it's %Y or %Y-%m which conform with ISO8601. Note that we don't
-    # make an exception for %Y%m because it's explicitly not considered ISO8601.
+    # Only consider it a valid guess if we have a year, month and day.
+    # We make exceptions for %Y and %Y-%m (only with the `-` separator)
+    # as they conform with ISO8601.
     if (
         len({'year', 'month', 'day'} & found_attrs) != 3
-        and format_guess not in (['%Y'], ['%Y', None, '%m'])
+        and format_guess != ['%Y']
+        and not (
+            format_guess == ['%Y', None, '%m'] and tokens[1] == '-'
+        )
     ):
         return None
 

--- a/pandas/tests/tslibs/test_parsing.py
+++ b/pandas/tests/tslibs/test_parsing.py
@@ -149,7 +149,6 @@ def test_parsers_month_freq(date_str, expected):
         ("2011-12-30", "%Y-%m-%d"),
         ("2011", "%Y"),
         ("2011-01", "%Y-%m"),
-        ("2011/01", "%Y/%m"),
         ("30-12-2011", "%d-%m-%Y"),
         ("2011-12-30 00:00:00", "%Y-%m-%d %H:%M:%S"),
         ("2011-12-30T00:00:00", "%Y-%m-%dT%H:%M:%S"),
@@ -218,6 +217,7 @@ def test_guess_datetime_format_with_locale_specific_formats(string, fmt):
         "51a",
         "13/2019",
         "202001",  # YYYYMM isn't ISO8601
+        "2020/01",  # YYYY/MM isn't ISO8601 either
     ],
 )
 def test_guess_datetime_format_invalid_inputs(invalid_dt):


### PR DESCRIPTION
Follow-up from https://github.com/pandas-dev/pandas/pull/49389

Guess "year month", but only if it's "%Y-%m" as that's ISO8601 compliant