### PR TITLE
REF change to_datetime -> Timestamp for in odf reader

### DIFF
--- a/pandas/io/excel/_odfreader.py
+++ b/pandas/io/excel/_odfreader.py
@@ -213,9 +213,9 @@ class ODFReader(BaseExcelReader):
             return float(cell_value)
         elif cell_type == "date":
             cell_value = cell.attributes.get((OFFICENS, "date-value"))
-            return pd.to_datetime(cell_value)
+            return pd.Timestamp(cell_value)
         elif cell_type == "time":
-            stamp = pd.to_datetime(str(cell))
+            stamp = pd.Timestamp(str(cell))
             # cast needed here because Scalar doesn't include datetime.time
             return cast(Scalar, stamp.time())
         else:


### PR DESCRIPTION
Broken off from https://github.com/pandas-dev/pandas/pull/49024

Users wouldn't have the option to pass arguments to `to_datetime` here anyway, so might as well use `Timestamp` and avoid warnings related to `to_datetime` (like to pass `format` to ensure consistent parsing)