### PR TITLE
STYLE Enable Pylint statement use-sequence-for-iteration

### DIFF
--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -537,7 +537,7 @@ class TestIntervalIndex:
         result = index.isin(other.tolist())
         tm.assert_numpy_array_equal(result, expected)
 
-        for other_closed in {"right", "left", "both", "neither"}:
+        for other_closed in ["right", "left", "both", "neither"]:
             other = self.create_index(closed=other_closed)
             expected = np.repeat(closed == other_closed, len(index))
             result = index.isin(other)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ disable = [
   "unneeded-not",
   "use-implicit-booleaness-not-comparison",
   "use-implicit-booleaness-not-len",
-  "use-sequence-for-iteration",
   "useless-import-alias",
   "wrong-import-order",
   "wrong-import-position",


### PR DESCRIPTION
Associated with Issue #48855.  This PR enables the pylint type "C" warning `use-sequence-for-iteration`.
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
