### PR TITLE
ENH: DatetimeProperties results seem to be inconsistent since missing milliseconds #49073

### DIFF
--- a/pandas/_libs/tslibs/fields.pyx
+++ b/pandas/_libs/tslibs/fields.pyx
@@ -419,6 +419,17 @@ def get_date_field(
                 out[i] = dts.us
         return out
 
+    elif field == 'ms':
+        with nogil:
+            for i in range(count):
+                if dtindex[i] == NPY_NAT:
+                    out[i] = -1
+                    continue
+
+                pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
+                out[i] = dts.us // 1000
+        return out
+		
     elif field == 'ns':
         with nogil:
             for i in range(count):

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -224,6 +224,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
         "quarter",
         "days_in_month",
         "daysinmonth",
+        "millisecond",
         "microsecond",
         "nanosecond",
     ]
@@ -1475,6 +1476,29 @@ default 'raise'
         dtype: int64
         """,
     )
+    millisecond = _field_accessor(
+        "millisecond",
+        "ms",
+        """
+        The milliseconds of the datetime.
+
+        Examples
+        --------
+        >>> datetime_series = pd.Series(
+        ...     pd.date_range("2000-01-01", periods=3, freq="us")
+        ... )
+        >>> datetime_series
+        0   2000-01-01 00:00:00.000
+        1   2000-01-01 00:00:00.001
+        2   2000-01-01 00:00:00.002
+        dtype: datetime64[ns]
+        >>> datetime_series.dt.millisecond
+        0       0
+        1       1
+        2       2
+        dtype: int64
+        """,
+    )
     microsecond = _field_accessor(
         "microsecond",
         "us",
@@ -1874,6 +1898,7 @@ default 'raise'
                 self.hour
                 + self.minute / 60
                 + self.second / 3600
+                + self.millisecond / 3600 / 10**3
                 + self.microsecond / 3600 / 10**6
                 + self.nanosecond / 3600 / 10**9
             )


### PR DESCRIPTION
- [ X] closes #49073 (Replace xxxx with the GitHub issue number)
- [ X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

I have added the millisecond feature to the Datetime function on Pandas. As it was discussed in the issue, it seemed inconsistent. However, I didn't change how the microseconds were being exhibited (with 6 digits instead of 3), not to break the code.
