### PR TITLE
PERF: Series.fillna for pyarrow-backed dtypes 

### DIFF
--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -79,6 +79,48 @@ class Dropna:
         self.s.dropna()
 
 
+class Fillna:
+
+    params = [
+        [
+            "datetime64[ns]",
+            "float64",
+            "Int64",
+            "int64[pyarrow]",
+            "string",
+            "string[pyarrow]",
+        ],
+        [None, "pad", "backfill"],
+    ]
+    param_names = ["dtype", "method"]
+
+    def setup(self, dtype, method):
+        N = 10**6
+        if dtype == "datetime64[ns]":
+            data = date_range("2000-01-01", freq="S", periods=N)
+            na_value = NaT
+        elif dtype == "float64":
+            data = np.random.randn(N)
+            na_value = np.nan
+        elif dtype in ("Int64", "int64[pyarrow]"):
+            data = np.arange(N)
+            na_value = NA
+        elif dtype in ("string", "string[pyarrow]"):
+            data = tm.rands_array(5, N)
+            na_value = NA
+        else:
+            raise NotImplementedError
+        fill_value = data[0]
+        ser = Series(data, dtype=dtype)
+        ser[::2] = na_value
+        self.ser = ser
+        self.fill_value = fill_value
+
+    def time_fillna(self, dtype, method):
+        value = self.fill_value if method is None else None
+        self.ser.fillna(value=value, method=method)
+
+
 class SearchSorted:
 
     goal_time = 0.2

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -573,6 +573,7 @@ Performance improvements
 - Performance improvement in :meth:`.DataFrameGroupBy.mean`, :meth:`.SeriesGroupBy.mean`, :meth:`.DataFrameGroupBy.var`, and :meth:`.SeriesGroupBy.var` for extension array dtypes (:issue:`37493`)
 - Performance improvement in :meth:`MultiIndex.isin` when ``level=None`` (:issue:`48622`, :issue:`49577`)
 - Performance improvement in :meth:`Index.union` and :meth:`MultiIndex.union` when index contains duplicates (:issue:`48900`)
+- Performance improvement in :meth:`Series.fillna` for pyarrow-backed dtypes (:issue:`49722`)
 - Performance improvement for :meth:`Series.value_counts` with nullable dtype (:issue:`48338`)
 - Performance improvement for :class:`Series` constructor passing integer numpy array with nullable dtype (:issue:`48338`)
 - Performance improvement for :class:`DatetimeIndex` constructor passing a list (:issue:`48609`)

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -535,31 +535,35 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray):
 
         value, method = validate_fillna_kwargs(value, method)
 
-        if isinstance(self._data.type, pa.DurationType):
-            # pyarrow complains about duration types:
-            #   ArrowNotImplementedError: Function 'coalesce' has no kernel
+        try:
+            if method is None and limit is None:
+                if is_array_like(value):
+                    val = cast(ArrayLike, value)
+                    if len(val) != len(self):
+                        raise ValueError(
+                            f"Length of 'value' does not match. Got ({len(val)}) "
+                            f" expected {len(self)}"
+                        )
+                    if not isinstance(val, (pa.Array, pa.ChunkedArray)):
+                        val = pa.array(val, type=self._data.type, from_pandas=True)
+                else:
+                    val = pa.scalar(value, type=self._data.type, from_pandas=True)
+                return type(self)(pc.fill_null(self._data, fill_value=val))
+
+            elif method == "pad" and limit is None and not pa_version_under7p0:
+                return type(self)(pc.fill_null_forward(self._data))
+
+            elif method == "backfill" and limit is None and not pa_version_under7p0:
+                return type(self)(pc.fill_null_backward(self._data))
+
+        except (pa.ArrowInvalid, pa.ArrowTypeError):
+            raise TypeError(f"Invalid value '{str(value)}' for dtype {self.dtype}")
+        except pa.ArrowNotImplementedError:
+            # ArrowNotImplementedError: Function 'coalesce' has no kernel
             #   matching input types (duration[ns], duration[ns])
+            # TODO: remove this except case if/when pyarrow implements a
+            #   kernel for duration types.
             pass
-
-        elif method is None and limit is None:
-            if is_array_like(value):
-                value = cast(ArrayLike, value)
-                if len(value) != len(self):
-                    raise ValueError(
-                        f"Length of 'value' does not match. Got ({len(value)}) "
-                        f" expected {len(self)}"
-                    )
-                if not isinstance(value, (pa.Array, pa.ChunkedArray)):
-                    value = pa.array(value, type=self._data.type, from_pandas=True)
-            else:
-                value = pa.scalar(value, type=self._data.type, from_pandas=True)
-            return type(self)(pc.fill_null(self._data, fill_value=value))
-
-        elif method == "pad" and limit is None and not pa_version_under7p0:
-            return type(self)(pc.fill_null_forward(self._data))
-
-        elif method == "backfill" and limit is None and not pa_version_under7p0:
-            return type(self)(pc.fill_null_backward(self._data))
 
         return super().fillna(value=value, method=method, limit=limit)
 

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -632,6 +632,18 @@ class TestBaseMissing(base.BaseMissingTests):
     def test_dropna_array(self, data_missing):
         super().test_dropna_array(data_missing)
 
+    def test_fillna_no_op_returns_copy(self, data):
+        with tm.maybe_produces_warning(
+            PerformanceWarning, pa_version_under7p0, check_stacklevel=False
+        ):
+            super().test_fillna_no_op_returns_copy(data)
+
+    def test_fillna_series_method(self, data_missing, fillna_method):
+        with tm.maybe_produces_warning(
+            PerformanceWarning, pa_version_under7p0, check_stacklevel=False
+        ):
+            super().test_fillna_series_method(data_missing, fillna_method)
+
 
 class TestBasePrinting(base.BasePrintingTests):
     pass

--- a/pandas/tests/extension/test_string.py
+++ b/pandas/tests/extension/test_string.py
@@ -168,6 +168,22 @@ class TestMissing(base.BaseMissingTests):
         expected = data_missing[[1]]
         self.assert_extension_array_equal(result, expected)
 
+    def test_fillna_no_op_returns_copy(self, data):
+        with tm.maybe_produces_warning(
+            PerformanceWarning,
+            pa_version_under7p0 and data.dtype.storage == "pyarrow",
+            check_stacklevel=False,
+        ):
+            super().test_fillna_no_op_returns_copy(data)
+
+    def test_fillna_series_method(self, data_missing, fillna_method):
+        with tm.maybe_produces_warning(
+            PerformanceWarning,
+            pa_version_under7p0 and data_missing.dtype.storage == "pyarrow",
+            check_stacklevel=False,
+        ):
+            super().test_fillna_series_method(data_missing, fillna_method)
+
 
 class TestNoReduce(base.BaseNoReduceTests):
     @pytest.mark.parametrize("skipna", [True, False])


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.0.0.rst` file if fixing a bug or adding a new feature.

Perf improvement in `Series.fillna` for pyarrow-backed dtypes.

 ```
       before           after         ratio
     [86f18282]       [34319599]
     <main>           <arrow-ea-fillna>
-        98.6±1ms       18.7±0.4ms     0.19  series_methods.Fillna.time_fillna('string[pyarrow]', 'backfill')
-        99.2±1ms       17.6±0.2ms     0.18  series_methods.Fillna.time_fillna('string[pyarrow]', 'pad')
-       1.86±0.1s      3.86±0.03ms     0.00  series_methods.Fillna.time_fillna('int64[pyarrow]', 'backfill')
-      1.89±0.07s      3.01±0.03ms     0.00  series_methods.Fillna.time_fillna('int64[pyarrow]', 'pad')

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```