### PR TITLE
STYLE enable pylint: 48855-useless-import-alias

### DIFF
--- a/pandas/tests/io/pytables/test_file_handling.py
+++ b/pandas/tests/io/pytables/test_file_handling.py
@@ -22,7 +22,7 @@ from pandas.tests.io.pytables.common import (
     tables,
 )
 
-from pandas.io import pytables as pytables
+from pandas.io import pytables
 from pandas.io.pytables import Term
 
 pytestmark = pytest.mark.single_cpu

--- a/pandas/tests/strings/conftest.py
+++ b/pandas/tests/strings/conftest.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from pandas import Series
-from pandas.core import strings as strings
+from pandas.core import strings
 
 _any_string_method = [
     ("cat", (), {"sep": ","}),

--- a/pandas/tests/strings/test_api.py
+++ b/pandas/tests/strings/test_api.py
@@ -8,7 +8,7 @@ from pandas import (
     _testing as tm,
     get_option,
 )
-from pandas.core import strings as strings
+from pandas.core import strings
 
 
 def test_api(any_string_dtype):

--- a/pandas/tests/tseries/offsets/test_business_day.py
+++ b/pandas/tests/tseries/offsets/test_business_day.py
@@ -28,7 +28,7 @@ from pandas.tests.tseries.offsets.common import (
     assert_offset_equal,
 )
 
-from pandas.tseries import offsets as offsets
+from pandas.tseries import offsets
 
 
 @pytest.fixture

--- a/pandas/tests/tseries/offsets/test_custom_business_month.py
+++ b/pandas/tests/tseries/offsets/test_custom_business_month.py
@@ -31,7 +31,7 @@ from pandas.tests.tseries.offsets.common import (
 )
 from pandas.tests.tseries.offsets.test_offsets import _ApplyCases
 
-from pandas.tseries import offsets as offsets
+from pandas.tseries import offsets
 from pandas.tseries.holiday import USFederalHolidayCalendar
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ disable = [
   "unneeded-not",
   "use-implicit-booleaness-not-comparison",
   "use-implicit-booleaness-not-len",
-  "useless-import-alias",
   "wrong-import-order",
   "wrong-import-position",
 


### PR DESCRIPTION
Issue #48855. This PR enables pylint type "C" warning: `useless-import-alias`
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).