### PR TITLE
CLN: Don't intercept NotImplementedError in _cython_transform

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1362,8 +1362,9 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                 arr_func, ignore_failures=numeric_only is lib.no_default
             )
         except NotImplementedError as err:
-            # For NotImplementedError, args[0] is the error message
-            raise TypeError(err.args[0]) from err
+            # For NotImplementedError, args[0] is the error message when available
+            msg = err.args[0] if len(err.args) > 0 else ""
+            raise TypeError(msg) from err
         res_mgr.set_axis(1, mgr.axes[1])
 
         if len(res_mgr) < orig_mgr_len:

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1357,14 +1357,9 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
         # We could use `mgr.apply` here and not have to set_axis, but
         #  we would have to do shape gymnastics for ArrayManager compat
-        try:
-            res_mgr = mgr.grouped_reduce(
-                arr_func, ignore_failures=numeric_only is lib.no_default
-            )
-        except NotImplementedError as err:
-            # For NotImplementedError, args[0] is the error message when available
-            msg = err.args[0] if len(err.args) > 0 else ""
-            raise TypeError(msg) from err
+        res_mgr = mgr.grouped_reduce(
+            arr_func, ignore_failures=numeric_only is lib.no_default
+        )
         res_mgr.set_axis(1, mgr.axes[1])
 
         if len(res_mgr) < orig_mgr_len:

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -250,6 +250,10 @@ class TestNumericOnly:
     def _check(self, df, method, expected_columns, expected_columns_numeric):
         gb = df.groupby("group")
 
+        # object dtypes for transformations are not implemented in Cython and
+        # have no Python fallback
+        exception = NotImplementedError if method.startswith("cum") else TypeError
+
         if method in ("min", "max", "cummin", "cummax"):
             # The methods default to numeric_only=False and raise TypeError
             msg = "|".join(
@@ -258,7 +262,7 @@ class TestNumericOnly:
                     "function is not implemented for this dtype",
                 ]
             )
-            with pytest.raises(TypeError, match=msg):
+            with pytest.raises(exception, match=msg):
                 getattr(gb, method)()
         else:
             result = getattr(gb, method)()
@@ -274,7 +278,7 @@ class TestNumericOnly:
                     "function is not implemented for this dtype",
                 ]
             )
-            with pytest.raises(TypeError, match=msg):
+            with pytest.raises(exception, match=msg):
                 getattr(gb, method)(numeric_only=False)
         else:
             result = getattr(gb, method)(numeric_only=False)
@@ -1411,6 +1415,11 @@ def test_deprecate_numeric_only(
     elif has_arg or kernel in ("idxmax", "idxmin"):
         assert numeric_only is not True
         # kernels that are successful on any dtype were above; this will fail
+
+        # object dtypes for transformations are not implemented in Cython and
+        # have no Python fallback
+        exception = NotImplementedError if kernel.startswith("cum") else TypeError
+
         msg = "|".join(
             [
                 "not allowed for this dtype",
@@ -1422,7 +1431,7 @@ def test_deprecate_numeric_only(
                 "function is not implemented for this dtype",
             ]
         )
-        with pytest.raises(TypeError, match=msg):
+        with pytest.raises(exception, match=msg):
             method(*args, **kwargs)
     elif not has_arg and numeric_only is not lib.no_default:
         with pytest.raises(


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Ref: https://github.com/pandas-dev/pandas/pull/49665#discussion_r1024528347

The one place in groupby where there is `raise NotImplementedError` is in `_reconstruct_ea_result`. This is not hit by tests.

cc @jbrockmendel