### PR TITLE
STYLE enable pylint: global-variable-not-assigned

### DIFF
--- a/pandas/_config/config.py
+++ b/pandas/_config/config.py
@@ -767,7 +767,7 @@ def config_prefix(prefix) -> Generator[None, None, None]:
     # Note: reset_option relies on set_option, and on key directly
     # it does not fit in to this monkey-patching scheme
 
-    global register_option, get_option, set_option, reset_option
+    global register_option, get_option, set_option
 
     def wrap(func: F) -> F:
         def inner(key: str, *args, **kwds):

--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -271,7 +271,6 @@ def set_test_mode(v: bool = True) -> None:
 
 
 def _store_test_result(used_numexpr: bool) -> None:
-    global _TEST_RESULT
     if used_numexpr:
         _TEST_RESULT.append(used_numexpr)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,6 @@ disable = [
   "expression-not-assigned",
   "fixme",
   "global-statement",
-  "global-variable-not-assigned",
   "invalid-envvar-default",
   "invalid-overridden-method",
   "keyword-arg-before-vararg",


### PR DESCRIPTION
Issue #48855. This PR enables pylint type "W" warning:` global-variable-not-assigned`
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).