### PR TITLE
STYLE enable pylint: typevar-name-incorrect-variance

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -188,8 +188,8 @@ AggObjType = Union[
 PythonFuncType = Callable[[Any], Any]
 
 # filenames and file-like-objects
-AnyStr_cov = TypeVar("AnyStr_cov", str, bytes, covariant=True)
-AnyStr_con = TypeVar("AnyStr_con", str, bytes, contravariant=True)
+AnyStr_co = TypeVar("AnyStr_co", str, bytes, covariant=True)
+AnyStr_contra = TypeVar("AnyStr_contra", str, bytes, contravariant=True)
 
 
 class BaseBuffer(Protocol):
@@ -212,14 +212,14 @@ class BaseBuffer(Protocol):
         ...
 
 
-class ReadBuffer(BaseBuffer, Protocol[AnyStr_cov]):
-    def read(self, __n: int = ...) -> AnyStr_cov:
+class ReadBuffer(BaseBuffer, Protocol[AnyStr_co]):
+    def read(self, __n: int = ...) -> AnyStr_co:
         # for BytesIOWrapper, gzip.GzipFile, bz2.BZ2File
         ...
 
 
-class WriteBuffer(BaseBuffer, Protocol[AnyStr_con]):
-    def write(self, __b: AnyStr_con) -> Any:
+class WriteBuffer(BaseBuffer, Protocol[AnyStr_contra]):
+    def write(self, __b: AnyStr_contra) -> Any:
         # for gzip.GzipFile, bz2.BZ2File
         ...
 
@@ -238,8 +238,8 @@ class WriteExcelBuffer(WriteBuffer[bytes], Protocol):
         ...
 
 
-class ReadCsvBuffer(ReadBuffer[AnyStr_cov], Protocol):
-    def __iter__(self) -> Iterator[AnyStr_cov]:
+class ReadCsvBuffer(ReadBuffer[AnyStr_co], Protocol):
+    def __iter__(self) -> Iterator[AnyStr_co]:
         # for engine=python
         ...
 
@@ -247,7 +247,7 @@ class ReadCsvBuffer(ReadBuffer[AnyStr_cov], Protocol):
         # for _MMapWrapper
         ...
 
-    def readline(self) -> AnyStr_cov:
+    def readline(self) -> AnyStr_co:
         # for engine=python
         ...
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ disable = [
   "missing-module-docstring",
   "singleton-comparison",
   "too-many-lines",
-  "typevar-name-incorrect-variance",
   "ungrouped-imports",
   "unidiomatic-typecheck",
   "unnecessary-dunder-call",


### PR DESCRIPTION
Issue #48855. This PR enables pylint type "C" warning: `typevar-name-incorrect-variance`
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).