### PR TITLE
STYLE: Enable Pylint useless-parent-delegation warning

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -836,9 +836,6 @@ class FrameApply(NDFrameApply):
 class FrameRowApply(FrameApply):
     axis: AxisInt = 0
 
-    def apply_broadcast(self, target: DataFrame) -> DataFrame:
-        return super().apply_broadcast(target)
-
     @property
     def series_generator(self):
         return (self.obj._ixs(i, axis=1) for i in range(len(self.columns)))

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -514,7 +514,8 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
     def view(self, dtype: Dtype | None = ...) -> ArrayLike:
         ...
 
-    def view(self, dtype: Dtype | None = None) -> ArrayLike:  # pylint: disable=useless-parent-delegation
+    # pylint: disable-next=useless-parent-delegation
+    def view(self, dtype: Dtype | None = None) -> ArrayLike:
         # we need to explicitly call super() method as long as the `@overload`s
         #  are present in this file.
         return super().view(dtype)

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -514,7 +514,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
     def view(self, dtype: Dtype | None = ...) -> ArrayLike:
         ...
 
-    def view(self, dtype: Dtype | None = None) -> ArrayLike:
+    def view(self, dtype: Dtype | None = None) -> ArrayLike:  # pylint: disable=useless-parent-delegation
         # we need to explicitly call super() method as long as the `@overload`s
         #  are present in this file.
         return super().view(dtype)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2625,6 +2625,7 @@ class MultiIndex(Index):
             label = (label,)
         return self._partial_tup_index(label, side=side)
 
+    # pylint: disable-next=useless-parent-delegation
     def slice_locs(self, start=None, end=None, step=None) -> tuple[int, int]:
         """
         For an ordered MultiIndex, compute the slice locations for input

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2036,7 +2036,7 @@ Name: Max Speed, dtype: float64
             res_values, index=range(len(res_values)), name=self.name
         )
 
-    def unique(self) -> ArrayLike:
+    def unique(self) -> ArrayLike:  # pylint: disable=useless-parent-delegation
         """
         Return unique values of Series object.
 

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -158,8 +158,7 @@ class TestCasting(base.BaseCastingTests):
 
 
 class TestGroupby(base.BaseGroupbyTests):
-    def test_groupby_agg_extension(self, data_for_grouping):
-        super().test_groupby_agg_extension(data_for_grouping)
+    pass
 
 
 class TestSetitem(base.BaseSetitemTests):

--- a/pandas/tests/extension/test_numpy.py
+++ b/pandas/tests/extension/test_numpy.py
@@ -236,6 +236,7 @@ class TestGetitem(BaseNumPyTests, base.BaseGetitemTests):
 
 
 class TestGroupby(BaseNumPyTests, base.BaseGroupbyTests):
+    @skip_nested
     def test_groupby_extension_apply(self, data_for_grouping, groupby_apply_op):
         super().test_groupby_extension_apply(data_for_grouping, groupby_apply_op)
 
@@ -403,6 +404,7 @@ class TestSetitem(BaseNumPyTests, base.BaseSetitemTests):
     def test_setitem_mask(self, data, mask, box_in_series):
         super().test_setitem_mask(data, mask, box_in_series)
 
+    @skip_nested
     def test_setitem_mask_raises(self, data, box_in_series):
         super().test_setitem_mask_raises(data, box_in_series)
 

--- a/pandas/tests/extension/test_numpy.py
+++ b/pandas/tests/extension/test_numpy.py
@@ -236,7 +236,7 @@ class TestGetitem(BaseNumPyTests, base.BaseGetitemTests):
 
 
 class TestGroupby(BaseNumPyTests, base.BaseGroupbyTests):
-    @skip_nested
+    # pylint: disable-next=useless-parent-delegation
     def test_groupby_extension_apply(self, data_for_grouping, groupby_apply_op):
         super().test_groupby_extension_apply(data_for_grouping, groupby_apply_op)
 
@@ -404,7 +404,7 @@ class TestSetitem(BaseNumPyTests, base.BaseSetitemTests):
     def test_setitem_mask(self, data, mask, box_in_series):
         super().test_setitem_mask(data, mask, box_in_series)
 
-    @skip_nested
+    # pylint: disable-next=useless-parent-delegation
     def test_setitem_mask_raises(self, data, box_in_series):
         super().test_setitem_mask_raises(data, box_in_series)
 

--- a/pandas/tests/extension/test_numpy.py
+++ b/pandas/tests/extension/test_numpy.py
@@ -236,9 +236,7 @@ class TestGetitem(BaseNumPyTests, base.BaseGetitemTests):
 
 
 class TestGroupby(BaseNumPyTests, base.BaseGroupbyTests):
-    # pylint: disable-next=useless-parent-delegation
-    def test_groupby_extension_apply(self, data_for_grouping, groupby_apply_op):
-        super().test_groupby_extension_apply(data_for_grouping, groupby_apply_op)
+    pass
 
 
 class TestInterface(BaseNumPyTests, base.BaseInterfaceTests):
@@ -403,10 +401,6 @@ class TestSetitem(BaseNumPyTests, base.BaseSetitemTests):
     )
     def test_setitem_mask(self, data, mask, box_in_series):
         super().test_setitem_mask(data, mask, box_in_series)
-
-    # pylint: disable-next=useless-parent-delegation
-    def test_setitem_mask_raises(self, data, box_in_series):
-        super().test_setitem_mask_raises(data, box_in_series)
 
     @skip_nested
     @pytest.mark.parametrize(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,8 +158,7 @@ disable = [
   "unused-argument",
   "unused-import",
   "unused-variable",
-  "using-constant-test",
-  "useless-parent-delegation"
+  "using-constant-test"
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Associated with #48855.  Enables the Pylint type "W" warning `useless-parent-delegation`.

I have questions about the changes that I made to `test_decimal.py` and `test_numpy.py`.  I'll elaborate in comments below.

- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
