### PR TITLE
TST: test UInt64Index in tests/indexes/interval/test_constructors.py

### DIFF
--- a/pandas/tests/indexes/interval/test_constructors.py
+++ b/pandas/tests/indexes/interval/test_constructors.py
@@ -63,7 +63,7 @@ class ConstructorTests:
         result_kwargs = self.get_kwargs_from_breaks(breaks, closed)
         is_uint = is_unsigned_integer_dtype(breaks_dtype)
         if use_dtype or (self._use_dtype_in_test_constructor_uint and is_uint):
-            result_kwargs["dtype"] = IntervalDtype(breaks_dtype)
+            result_kwargs["dtype"] = IntervalDtype(breaks_dtype, closed=closed)
 
         result = constructor(closed=closed, name=name, **result_kwargs)
 


### PR DESCRIPTION
`UInt64Index` wasn't tested previously in the `IntervalIndex` constructor tests, this adds tests for that.

Preparation for fixing an issue in #49560.
