### PR TITLE
Backport PR #49579 on Branch 1.5.x (BUG: Behaviour change in 1.5.0 when using Timedelta as Enum data type)

### DIFF
--- a/doc/source/whatsnew/v1.5.2.rst
+++ b/doc/source/whatsnew/v1.5.2.rst
@@ -20,7 +20,7 @@ Fixed regressions
   from being passed using the ``colormap`` argument if Matplotlib 3.6+ is used (:issue:`49374`)
 - Fixed regression in :func:`date_range` returning an invalid set of periods for ``CustomBusinessDay`` frequency and ``start`` date with timezone (:issue:`49441`)
 - Fixed performance regression in groupby operations (:issue:`49676`)
--
+- Fixed regression in :class:`Timedelta` constructor returning object of wrong type when subclassing ``Timedelta`` (:issue:`49579`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_152.bug_fixes:

--- a/pandas/tests/scalar/timedelta/test_constructors.py
+++ b/pandas/tests/scalar/timedelta/test_constructors.py
@@ -402,3 +402,12 @@ def test_string_without_numbers(value):
     )
     with pytest.raises(ValueError, match=msg):
         Timedelta(value)
+
+
+def test_subclass_respected():
+    # GH#49579
+    class MyCustomTimedelta(Timedelta):
+        pass
+
+    td = MyCustomTimedelta("1 minute")
+    assert isinstance(td, MyCustomTimedelta)


### PR DESCRIPTION
#49579