### PR TITLE
STYLE enable pylint: confusing-with-statement

### DIFF
--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -284,7 +284,8 @@ class TestCompression:
 
         if compression not in ["zip", "tar"]:
             with open(src_path, "rb") as fh:
-                f.write(fh.read())
+                with f:
+                    f.write(fh.read())
 
     def test_write_explicit(self, compression, get_random_path):
         base = get_random_path
@@ -351,9 +352,8 @@ class TestCompression:
             self.compress_file(p1, p2, compression=compression)
 
             # read compressed file
-            if os.path.getsize(p2) > 0:
-                df2 = pd.read_pickle(p2, compression=compression)
-                tm.assert_frame_equal(df, df2)
+            df2 = pd.read_pickle(p2, compression=compression)
+            tm.assert_frame_equal(df, df2)
 
     def test_read_infer(self, compression_ext, get_random_path):
         base = get_random_path
@@ -371,9 +371,8 @@ class TestCompression:
             self.compress_file(p1, p2, compression=compression)
 
             # read compressed file by inferred compression method
-            if os.path.getsize(p2) > 0:
-                df2 = pd.read_pickle(p2)
-                tm.assert_frame_equal(df, df2)
+            df2 = pd.read_pickle(p2)
+            tm.assert_frame_equal(df, df2)
 
 
 # ---------------------

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -283,7 +283,7 @@ class TestCompression:
             raise ValueError(msg)
 
         if compression not in ["zip", "tar"]:
-            with open(src_path, "rb") as fh, f:
+            with open(src_path, "rb") as fh:
                 f.write(fh.read())
 
     def test_write_explicit(self, compression, get_random_path):
@@ -351,9 +351,9 @@ class TestCompression:
             self.compress_file(p1, p2, compression=compression)
 
             # read compressed file
-            df2 = pd.read_pickle(p2, compression=compression)
-
-            tm.assert_frame_equal(df, df2)
+            if os.path.getsize(p2) > 0:
+                df2 = pd.read_pickle(p2, compression=compression)
+                tm.assert_frame_equal(df, df2)
 
     def test_read_infer(self, compression_ext, get_random_path):
         base = get_random_path
@@ -371,9 +371,9 @@ class TestCompression:
             self.compress_file(p1, p2, compression=compression)
 
             # read compressed file by inferred compression method
-            df2 = pd.read_pickle(p2)
-
-            tm.assert_frame_equal(df, df2)
+            if os.path.getsize(p2) > 0:
+                df2 = pd.read_pickle(p2)
+                tm.assert_frame_equal(df, df2)
 
 
 # ---------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,6 @@ disable = [
   "attribute-defined-outside-init",
   "broad-except",
   "comparison-with-callable",
-  "confusing-with-statement",
   "dangerous-default-value",
   "deprecated-module",
   "eval-used",


### PR DESCRIPTION
Issue #48855. This PR enables pylint type "W" warning: `confusing-with-statement`
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

After fixing the warning `confusing-with-statement` running `pandas/tests/io/test_pickle.py` raises an error `EOFError: Ran out of input`. To handle this error I check if the size of the file is not zero. Maybe there is a better way to deal with the test?