### PR TITLE
STYLE run autotyping with --no-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -287,5 +287,4 @@ repos:
         language: python
         additional_dependencies:
         - autotyping==22.9.0
-        - black==22.6.0
         - libcst==0.4.7

--- a/scripts/run_autotyping.py
+++ b/scripts/run_autotyping.py
@@ -27,6 +27,7 @@ def main(argv: Sequence[str] | None = None) -> None:
             "autotyping.AutotypeCommand",
             *args.paths,
             "--aggressive",
+            "--no-format",
         ],
         check=True,
     )


### PR DESCRIPTION
autotyping runs `black` on its files as well (!)

we already have a `black` hook though, so we avoid duplicating CPU instructions