### PR TITLE
STYLE enable pylint: invalid-envvar-default

### DIFF
--- a/pandas/io/clipboard/__init__.py
+++ b/pandas/io/clipboard/__init__.py
@@ -69,7 +69,7 @@ from pandas.util._exceptions import find_stack_level
 # `import PyQt4` sys.exit()s if DISPLAY is not in the environment.
 # Thus, we need to detect the presence of $DISPLAY manually
 # and not load PyQt4 if it is absent.
-HAS_DISPLAY = os.getenv("DISPLAY", False)
+HAS_DISPLAY = os.getenv("DISPLAY")
 
 EXCEPT_MSG = """
     Pyperclip could not find a copy/paste mechanism for your system.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,6 @@ disable = [
   "expression-not-assigned",
   "fixme",
   "global-statement",
-  "invalid-envvar-default",
   "invalid-overridden-method",
   "keyword-arg-before-vararg",
   "non-parent-init-called",


### PR DESCRIPTION
Issue #48855. This PR enables pylint type "W" warning: `invalid-envvar-default`
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).