### PR TITLE
STYLE enable pylint: ungrouped-imports

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -42,8 +42,12 @@ if not pa_version_under6p0:
     import pyarrow as pa
     import pyarrow.compute as pc
 
-    from pandas.core.arrays.arrow._arrow_utils import fallback_performancewarning
-    from pandas.core.arrays.arrow.dtype import ArrowDtype
+    from pandas.core.arrays.arrow._arrow_utils import (  # pylint: disable=ungrouped-imports # noqa: E501
+        fallback_performancewarning,
+    )
+    from pandas.core.arrays.arrow.dtype import (  # pylint: disable=ungrouped-imports
+        ArrowDtype,
+    )
 
     ARROW_CMP_FUNCS = {
         "eq": pc.equal,

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -43,7 +43,9 @@ if not pa_version_under6p0:
     import pyarrow as pa
     import pyarrow.compute as pc
 
-    from pandas.core.arrays.arrow._arrow_utils import fallback_performancewarning
+    from pandas.core.arrays.arrow._arrow_utils import (  # pylint: disable=ungrouped-imports  # noqa: E501
+        fallback_performancewarning,
+    )
 
 ArrowStringScalarOrNAT = Union[str, libmissing.NAType]
 

--- a/pandas/tests/io/formats/style/test_matplotlib.py
+++ b/pandas/tests/io/formats/style/test_matplotlib.py
@@ -1,16 +1,16 @@
 import numpy as np
 import pytest
 
+pytest.importorskip("matplotlib")
+pytest.importorskip("jinja2")
+
+import matplotlib as mpl
+
 from pandas import (
     DataFrame,
     IndexSlice,
     Series,
 )
-
-pytest.importorskip("matplotlib")
-pytest.importorskip("jinja2")
-
-import matplotlib as mpl
 
 from pandas.io.formats.style import Styler
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ disable = [
   "missing-module-docstring",
   "singleton-comparison",
   "too-many-lines",
-  "ungrouped-imports",
   "unidiomatic-typecheck",
   "unnecessary-dunder-call",
   "unnecessary-lambda-assignment",


### PR DESCRIPTION
Issue #48855. This PR enables pylint type "C" warning: `ungrouped-imports`
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

In two cases out of three, the warning is false-positive.