### PR TITLE
STYLE enable pylint: overridden-final-method

### DIFF
--- a/pandas/tests/extension/test_external_block.py
+++ b/pandas/tests/extension/test_external_block.py
@@ -17,7 +17,7 @@ class CustomBlock(ExtensionBlock):
 
     # Cannot override final attribute "_can_hold_na"
     @property  # type: ignore[misc]
-    def _can_hold_na(self) -> bool:
+    def _can_hold_na(self) -> bool:  # pylint: disable=overridden-final-method
         return False
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,6 @@ disable = [
   "invalid-overridden-method",
   "keyword-arg-before-vararg",
   "non-parent-init-called",
-  "overridden-final-method",
   "pointless-statement",
   "pointless-string-statement",
   "possibly-unused-variable",


### PR DESCRIPTION
Issue #48855. This PR enables pylint type "W" warning: `overridden-final-method`
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

The only occurrence of the warning is in `test_external_block.py`. I think it was made on purpose and disabled the warning on this line.