### PR TITLE
TYP: avoid inherit_names for DatetimeIndexOpsMixin

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -110,7 +110,7 @@ def _new_DatetimeIndex(cls, d):
     DatetimeArray,
     wrap=True,
 )
-@inherit_names(["is_normalized", "_resolution_obj"], DatetimeArray, cache=True)
+@inherit_names(["is_normalized"], DatetimeArray, cache=True)
 @inherit_names(
     [
         "tz",
@@ -249,7 +249,6 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         return libindex.DatetimeEngine
 
     _data: DatetimeArray
-    inferred_freq: str | None
     tz: dt.tzinfo | None
 
     # --------------------------------------------------------------------
@@ -293,6 +292,10 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
     def isocalendar(self) -> DataFrame:
         df = self._data.isocalendar()
         return df.set_index(self)
+
+    @cache_readonly
+    def _resolution_obj(self) -> Resolution:
+        return self._data._resolution_obj
 
     # --------------------------------------------------------------------
     # Constructors

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -156,8 +156,7 @@ class PeriodIndex(DatetimeIndexOpsMixin):
         return libindex.PeriodEngine
 
     @cache_readonly
-    # Signature of "_resolution_obj" incompatible with supertype "DatetimeIndexOpsMixin"
-    def _resolution_obj(self) -> Resolution:  # type: ignore[override]
+    def _resolution_obj(self) -> Resolution:
         # for compat with DatetimeIndex
         return self.dtype._resolution_obj
 

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -6,6 +6,7 @@ from pandas._libs import (
     lib,
 )
 from pandas._libs.tslibs import (
+    Resolution,
     Timedelta,
     to_offset,
 )
@@ -111,6 +112,12 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
 
     # Use base class method instead of DatetimeTimedeltaMixin._get_string_slice
     _get_string_slice = Index._get_string_slice
+
+    # error: Signature of "_resolution_obj" incompatible with supertype
+    # "DatetimeIndexOpsMixin"
+    @property
+    def _resolution_obj(self) -> Resolution | None:  # type: ignore[override]
+        return self._data._resolution_obj
 
     # -------------------------------------------------------------------
     # Constructors


### PR DESCRIPTION
new version of #48015


