### PR TITLE
WIP/CI: Build docs with single job

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -302,7 +302,7 @@ def main():
         "command", nargs="?", default="html", help=f"command to run: {joined}"
     )
     argparser.add_argument(
-        "--num-jobs", default="0", help="number of jobs used by sphinx-build"
+        "--num-jobs", default="1", help="number of jobs used by sphinx-build"
     )
     argparser.add_argument(
         "--no-api", default=False, help="omit api and autosummary", action="store_true"

--- a/doc/make.py
+++ b/doc/make.py
@@ -302,7 +302,7 @@ def main():
         "command", nargs="?", default="html", help=f"command to run: {joined}"
     )
     argparser.add_argument(
-        "--num-jobs", default="auto", help="number of jobs used by sphinx-build"
+        "--num-jobs", default="0", help="number of jobs used by sphinx-build"
     )
     argparser.add_argument(
         "--no-api", default=False, help="omit api and autosummary", action="store_true"


### PR DESCRIPTION
The docs build in the CI is taking more than one hour, which seems too much. Based on the logs the time is spent in `waiting for workers...`, which doesn't provide much information. Running in a single job here to see if the logs provide more information on where the time is spent, and see if the job does need to take so long, or if there is any particular step responsible for most of the time.