### PR TITLE
DOC: Fix the Styler user guide table width issues

### DIFF
--- a/doc/source/_static/css/pandas.css
+++ b/doc/source/_static/css/pandas.css
@@ -5,6 +5,10 @@
   --pst-color-info: 23, 162, 184;
 }
 
+table {
+  width: auto; /* Override fit-content which breaks Styler user guide ipynb */
+}
+
 /* Main index page overview cards */
 
 .intro-card {


### PR DESCRIPTION
Not sure if this has any other unintended consequences. Note that "auto" is the default table width setting in CSS when unspecified. This was the previous setting until 1.5.0 and an update to pydata-sphinx-theme seems to have changed this setting.

Would like to check the rendered output to make sure this affects as expected.

- [x] closes #48644 
