### PR TITLE
API: NumericIndex([1 2, 3]).dtype should be int64 on 32-bit systems

### DIFF
--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -618,7 +618,7 @@ def sanitize_array(
     else:
         _sanitize_non_ordered(data)
         # materialize e.g. generators, convert e.g. tuples, abc.ValueView
-        data = list(data)
+        data = list(data) if not isinstance(data, list) else data
 
         if len(data) == 0 and dtype is None:
             # We default to float64, matching numpy

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -618,7 +618,7 @@ def sanitize_array(
     else:
         _sanitize_non_ordered(data)
         # materialize e.g. generators, convert e.g. tuples, abc.ValueView
-        data = list(data) if not isinstance(data, list) else data
+        data = list(data)
 
         if len(data) == 0 and dtype is None:
             # We default to float64, matching numpy

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4962,14 +4962,6 @@ class Index(IndexOpsMixin, PandasObject):
             f"kind, {repr(data)} was passed"
         )
 
-    @final
-    @classmethod
-    def _string_data_error(cls, data):
-        raise TypeError(
-            "String dtype not supported, you may need "
-            "to explicitly cast to a numeric type"
-        )
-
     def _validate_fill_value(self, value):
         """
         Check if the value can be inserted into our array without casting,

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -145,13 +145,11 @@ class NumericIndex(Index):
                 data = list(data)
 
             orig = data
-            if isinstance(data, (list, tuple)) and dtype is None:
+            if isinstance(data, (list, tuple)):
                 if len(data):
                     data = sanitize_array(data, index=None)
                 else:
                     data = np.array([], dtype=np.int64)
-            else:
-                data = np.asarray(data, dtype=dtype)
 
             if dtype is None and data.dtype.kind == "f":
                 if cls is UInt64Index and (data >= 0).all():
@@ -203,7 +201,8 @@ class NumericIndex(Index):
             return cls._default_dtype
 
         dtype = pandas_dtype(dtype)
-        assert isinstance(dtype, np.dtype)
+        if not isinstance(dtype, np.dtype):
+            raise TypeError(f"{dtype} not a numpy type")
 
         if cls._is_backward_compat_public_numeric_index:
             # dtype for NumericIndex

--- a/pandas/tests/indexes/numeric/test_numeric.py
+++ b/pandas/tests/indexes/numeric/test_numeric.py
@@ -64,6 +64,10 @@ class TestFloatNumericIndex(NumericBase):
         else:
             self.check_is_index(b)
 
+    def test_constructor_from_list_no_dtype(self):
+        index = self._index_cls([1.5, 2.5, 3.5])
+        assert index.dtype == np.float64
+
     def test_constructor(self, dtype):
         index_cls = self._index_cls
 
@@ -115,17 +119,10 @@ class TestFloatNumericIndex(NumericBase):
         with pytest.raises(TypeError, match=msg):
             index_cls(0.0)
 
-        # 2021-02-1 we get ValueError in numpy 1.20, but not on all builds
-        msg = "|".join(
-            [
-                "String dtype not supported, you may need to explicitly cast ",
-                "could not convert string to float: 'a'",
-            ]
-        )
-        with pytest.raises((TypeError, ValueError), match=msg):
+        msg = f"data is not compatible with {index_cls.__name__}"
+        with pytest.raises(ValueError, match=msg):
             index_cls(["a", "b", 0.0])
 
-        msg = f"data is not compatible with {index_cls.__name__}"
         with pytest.raises(ValueError, match=msg):
             index_cls([Timestamp("20130101")])
 
@@ -327,18 +324,16 @@ class NumericInt(NumericBase):
         assert not index.astype(dtype=object).identical(index.astype(dtype=dtype))
 
     def test_cant_or_shouldnt_cast(self):
-        msg = (
-            "String dtype not supported, "
-            "you may need to explicitly cast to a numeric type"
-        )
+        msg = f"data is not compatible with {self._index_cls.__name__}"
+
         # can't
         data = ["foo", "bar", "baz"]
-        with pytest.raises(TypeError, match=msg):
+        with pytest.raises(ValueError, match=msg):
             self._index_cls(data)
 
         # shouldn't
         data = ["0", "1", "2"]
-        with pytest.raises(TypeError, match=msg):
+        with pytest.raises(ValueError, match=msg):
             self._index_cls(data)
 
     def test_view_index(self, simple_index):
@@ -371,6 +366,10 @@ class TestIntNumericIndex(NumericInt):
     )
     def index(self, request, dtype):
         return self._index_cls(request.param, dtype=dtype)
+
+    def test_constructor_from_list_no_dtype(self):
+        index = self._index_cls([1, 2, 3])
+        assert index.dtype == np.int64
 
     def test_constructor(self, dtype):
         index_cls = self._index_cls


### PR DESCRIPTION
- [x] closes #49813
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
