### PR TITLE
STYLE enable pylint: non-parent-init-called

### DIFF
--- a/pandas/plotting/_matplotlib/boxplot.py
+++ b/pandas/plotting/_matplotlib/boxplot.py
@@ -58,7 +58,7 @@ class BoxPlot(LinePlot):
             raise ValueError("return_type must be {None, 'axes', 'dict', 'both'}")
 
         self.return_type = return_type
-        MPLPlot.__init__(self, data, **kwargs)
+        MPLPlot.__init__(self, data, **kwargs)  # pylint: disable=non-parent-init-called
 
     def _args_adjust(self) -> None:
         if self.subplots:

--- a/pandas/plotting/_matplotlib/boxplot.py
+++ b/pandas/plotting/_matplotlib/boxplot.py
@@ -53,11 +53,11 @@ class BoxPlot(LinePlot):
         lines: dict[str, list[Line2D]]
 
     def __init__(self, data, return_type: str = "axes", **kwargs) -> None:
-        # Do not call LinePlot.__init__ which may fill nan
         if return_type not in self._valid_return_types:
             raise ValueError("return_type must be {None, 'axes', 'dict', 'both'}")
 
         self.return_type = return_type
+        # Do not call LinePlot.__init__ which may fill nan
         MPLPlot.__init__(self, data, **kwargs)  # pylint: disable=non-parent-init-called
 
     def _args_adjust(self) -> None:

--- a/pandas/plotting/_matplotlib/hist.py
+++ b/pandas/plotting/_matplotlib/hist.py
@@ -60,7 +60,7 @@ class HistPlot(LinePlot):
         self.bins = bins  # use mpl default
         self.bottom = bottom
         # Do not call LinePlot.__init__ which may fill nan
-        MPLPlot.__init__(self, data, **kwargs)
+        MPLPlot.__init__(self, data, **kwargs)  # pylint: disable=non-parent-init-called
 
     def _args_adjust(self) -> None:
         # calculate bin number separately in different subplots
@@ -192,7 +192,7 @@ class KdePlot(HistPlot):
         return "vertical"
 
     def __init__(self, data, bw_method=None, ind=None, **kwargs) -> None:
-        MPLPlot.__init__(self, data, **kwargs)
+        MPLPlot.__init__(self, data, **kwargs)  # pylint: disable=non-parent-init-called
         self.bw_method = bw_method
         self.ind = ind
 

--- a/pandas/plotting/_matplotlib/hist.py
+++ b/pandas/plotting/_matplotlib/hist.py
@@ -192,6 +192,7 @@ class KdePlot(HistPlot):
         return "vertical"
 
     def __init__(self, data, bw_method=None, ind=None, **kwargs) -> None:
+        # Do not call LinePlot.__init__ which may fill nan
         MPLPlot.__init__(self, data, **kwargs)  # pylint: disable=non-parent-init-called
         self.bw_method = bw_method
         self.ind = ind

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,6 @@ disable = [
   "global-statement",
   "invalid-overridden-method",
   "keyword-arg-before-vararg",
-  "non-parent-init-called",
   "overridden-final-method",
   "pointless-statement",
   "pointless-string-statement",


### PR DESCRIPTION
Issue #48855. This PR enables pylint type "W" warning: `non-parent-init-called`
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).