### PR TITLE
STYLE: fix pylint redefined-outer-name warnings

### DIFF
--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -77,7 +77,7 @@ def deprecate(
     if alternative.__doc__:
         if alternative.__doc__.count("\n") < 3:
             raise AssertionError(doc_error_msg)
-        empty1, summary, empty2, doc = alternative.__doc__.split("\n", 3)
+        empty1, summary, empty2, doc_string = alternative.__doc__.split("\n", 3)
         if empty1 or empty2 and not summary:
             raise AssertionError(doc_error_msg)
         wrapper.__doc__ = dedent(
@@ -87,7 +87,7 @@ def deprecate(
         .. deprecated:: {version}
             {msg}
 
-        {dedent(doc)}"""
+        {dedent(doc_string)}"""
         )
     # error: Incompatible return value type (got "Callable[[VarArg(Any), KwArg(Any)],
     # Callable[...,Any]]", expected "Callable[[F], F]")

--- a/pandas/util/_doctools.py
+++ b/pandas/util/_doctools.py
@@ -166,9 +166,8 @@ class TablePlotter:
         ax.set_title(title, size=self.font_size)
         ax.axis("off")
 
-
-if __name__ == "__main__":
-    import matplotlib.pyplot as pyplot
+def main():
+    import matplotlib.pyplot as plt
 
     p = TablePlotter()
 
@@ -176,14 +175,14 @@ if __name__ == "__main__":
     df2 = pd.DataFrame({"A": [10, 12], "C": [30, 32]})
 
     p.plot([df1, df2], pd.concat([df1, df2]), labels=["df1", "df2"], vertical=True)
-    pyplot.show()
+    plt.show()
 
     df3 = pd.DataFrame({"X": [10, 12], "Z": [30, 32]})
 
     p.plot(
         [df1, df3], pd.concat([df1, df3], axis=1), labels=["df1", "df2"], vertical=False
     )
-    pyplot.show()
+    plt.show()
 
     idx = pd.MultiIndex.from_tuples(
         [(1, "A"), (1, "B"), (1, "C"), (2, "A"), (2, "B"), (2, "C")]
@@ -192,4 +191,7 @@ if __name__ == "__main__":
     df3 = pd.DataFrame({"v1": [1, 2, 3, 4, 5, 6], "v2": [5, 6, 7, 8, 9, 10]}, index=idx)
     df3.columns = column
     p.plot(df3, df3, labels=["df3"])
-    pyplot.show()
+    plt.show()
+
+if __name__ == "__main__":
+    main()

--- a/pandas/util/_doctools.py
+++ b/pandas/util/_doctools.py
@@ -168,7 +168,7 @@ class TablePlotter:
 
 
 if __name__ == "__main__":
-    import matplotlib.pyplot as plt
+    import matplotlib.pyplot as pyplot
 
     p = TablePlotter()
 
@@ -176,20 +176,20 @@ if __name__ == "__main__":
     df2 = pd.DataFrame({"A": [10, 12], "C": [30, 32]})
 
     p.plot([df1, df2], pd.concat([df1, df2]), labels=["df1", "df2"], vertical=True)
-    plt.show()
+    pyplot.show()
 
     df3 = pd.DataFrame({"X": [10, 12], "Z": [30, 32]})
 
     p.plot(
         [df1, df3], pd.concat([df1, df3], axis=1), labels=["df1", "df2"], vertical=False
     )
-    plt.show()
+    pyplot.show()
 
     idx = pd.MultiIndex.from_tuples(
         [(1, "A"), (1, "B"), (1, "C"), (2, "A"), (2, "B"), (2, "C")]
     )
-    col = pd.MultiIndex.from_tuples([(1, "A"), (1, "B")])
+    column = pd.MultiIndex.from_tuples([(1, "A"), (1, "B")])
     df3 = pd.DataFrame({"v1": [1, 2, 3, 4, 5, 6], "v2": [5, 6, 7, 8, 9, 10]}, index=idx)
-    df3.columns = col
+    df3.columns = column
     p.plot(df3, df3, labels=["df3"])
-    plt.show()
+    pyplot.show()

--- a/pandas/util/_doctools.py
+++ b/pandas/util/_doctools.py
@@ -166,7 +166,8 @@ class TablePlotter:
         ax.set_title(title, size=self.font_size)
         ax.axis("off")
 
-def main():
+
+def main() -> None:
     import matplotlib.pyplot as plt
 
     p = TablePlotter()
@@ -192,6 +193,7 @@ def main():
     df3.columns = column
     p.plot(df3, df3, labels=["df3"])
     plt.show()
+
 
 if __name__ == "__main__":
     main()

--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -295,11 +295,11 @@ def file_leak_context() -> Generator[None, None, None]:
 def async_mark():
     try:
         import_optional_dependency("pytest_asyncio")
-        async_mark = pytest.mark.asyncio
+        asyncio_mark = pytest.mark.asyncio
     except ImportError:
-        async_mark = pytest.mark.skip(reason="Missing dependency pytest-asyncio")
+        asyncio_mark = pytest.mark.skip(reason="Missing dependency pytest-asyncio")
 
-    return async_mark
+    return asyncio_mark
 
 
 def mark_array_manager_not_yet_implemented(request) -> None:

--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -295,11 +295,11 @@ def file_leak_context() -> Generator[None, None, None]:
 def async_mark():
     try:
         import_optional_dependency("pytest_asyncio")
-        asyncio_mark = pytest.mark.asyncio
+        async_mark = pytest.mark.asyncio
     except ImportError:
-        asyncio_mark = pytest.mark.skip(reason="Missing dependency pytest-asyncio")
+        async_mark = pytest.mark.skip(reason="Missing dependency pytest-asyncio")
 
-    return asyncio_mark
+    return async_mark
 
 
 def mark_array_manager_not_yet_implemented(request) -> None:


### PR DESCRIPTION
Fixed `redefined-outer-name` linting issue in the following files (Towards #49656)
- `pandas/util/_decorators.py`
- `pandas/util/_doctools.py`
- `pandas/util/_test_decorators.py`