### PR TITLE
STYLE enable pylint: fix use-implicit-booleaness-not-comparison warnings

### DIFF
--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -1236,10 +1236,10 @@ def assert_equal(left, right, **kwargs) -> None:
     elif isinstance(left, np.ndarray):
         assert_numpy_array_equal(left, right, **kwargs)
     elif isinstance(left, str):
-        assert kwargs == {}
+        assert not kwargs
         assert left == right
     else:
-        assert kwargs == {}
+        assert not kwargs
         assert_almost_equal(left, right)
 
 

--- a/pandas/io/sas/sas7bdat.py
+++ b/pandas/io/sas/sas7bdat.py
@@ -384,9 +384,7 @@ class SAS7BDATReader(ReaderBase, abc.Iterator):
         is_data_page = self._current_page_type == const.page_data_type
         is_mix_page = self._current_page_type == const.page_mix_type
         return bool(
-            is_data_page
-            or is_mix_page
-            or self._current_page_data_subheader_pointers != []
+            is_data_page or is_mix_page or self._current_page_data_subheader_pointers
         )
 
     def _read_page_header(self) -> None:

--- a/pandas/io/xml.py
+++ b/pandas/io/xml.py
@@ -373,7 +373,7 @@ class _XMLFrameParser:
                     ):
                         del elem.getparent()[0]
 
-        if dicts == []:
+        if not dicts:
             raise ParserError("No result from selected items in iterparse.")
 
         keys = list(dict.fromkeys([k for d in dicts for k in d.keys()]))

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -125,7 +125,7 @@ def test_apply_with_reduce_empty():
     tm.assert_series_equal(result, expected)
 
     # Ensure that x.append hasn't been called
-    assert x == []
+    assert not x
 
 
 @pytest.mark.parametrize("func", ["sum", "prod", "any", "all"])

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -315,7 +315,7 @@ class TestDataFrameMisc:
 
     def test_attrs(self):
         df = DataFrame({"A": [2, 3]})
-        assert df.attrs == {}
+        assert not df.attrs
         df.attrs["version"] = 1
 
         result = df.rename(columns=str)

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -104,7 +104,7 @@ def test_iter_empty(setup_path):
 
     with ensure_clean_store(setup_path) as store:
         # GH 12221
-        assert list(store) == []
+        assert not list(store)
 
 
 def test_repr(setup_path):

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -614,7 +614,7 @@ class TestStata:
         # predates supporting value labels.
         dpath = datapath("io", "data", "stata", "S4_EDUC1.dta")
         with StataReader(dpath) as reader:
-            assert reader.value_labels() == {}
+            assert not reader.value_labels()
 
     def test_date_export_formats(self):
         columns = ["tc", "td", "tw", "tm", "tq", "th", "ty"]

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -162,7 +162,7 @@ class TestSeriesMisc:
 
     def test_attrs(self):
         s = Series([0, 1], name="abc")
-        assert s.attrs == {}
+        assert not s.attrs
         s.attrs["version"] = 1
         result = s + 1
         assert result.attrs == {"version": 1}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ disable = [
   "unidiomatic-typecheck",
   "unnecessary-dunder-call",
   "unnecessary-lambda-assignment",
-  "use-implicit-booleaness-not-comparison",
   "use-implicit-booleaness-not-len",
   "wrong-import-order",
   "wrong-import-position",


### PR DESCRIPTION
Related to [#48855](https://github.com/pandas-dev/pandas/issues/48855). Enables the Pylint type "C" warning `use-implicit-booleaness-not-comparison`

- [] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

