### PR TITLE
STYLE enable pylint: not-callable

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -134,7 +134,7 @@ class PandasObject(DirNamesMixin):
         """
         memory_usage = getattr(self, "memory_usage", None)
         if memory_usage:
-            mem = memory_usage(deep=True)
+            mem = memory_usage(deep=True)  # pylint: disable=not-callable
             return int(mem if is_scalar(mem) else mem.sum())
 
         # no memory_usage attribute, so fall back to object's 'sizeof'

--- a/pandas/tests/base/test_constructors.py
+++ b/pandas/tests/base/test_constructors.py
@@ -87,7 +87,7 @@ class TestPandasDelegate:
 
         msg = "You cannot access the property prop"
         with pytest.raises(TypeError, match=msg):
-            delegate.prop()
+            delegate.prop
 
     @pytest.mark.skipif(PYPY, reason="not relevant for PyPy")
     def test_memory_usage(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ disable = [
   "no-name-in-module",
   "no-value-for-parameter",
   "not-an-iterable",
-  "not-callable",
   "redundant-keyword-arg",
   "too-many-function-args",
   "undefined-variable",


### PR DESCRIPTION
Issue #48855. This PR enables pylint warning: `not-callable`
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).