### PR TITLE
TYP: add missing `py.typed` marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,6 @@ dist
 *.egg-info
 .eggs
 .pypirc
-# type checkers
-pandas/py.typed
 
 # tox testing tool
 .tox


### PR DESCRIPTION
I'd like to use `mypy` to check type hint in my project. But it's failed with following error (apache/iceberg#6254)
![image](https://user-images.githubusercontent.com/6848311/203572069-1bd0d889-e081-447a-b43a-a95a494d29e1.png)

`pandas` seem support for type hint already, however, because of missing [`py.typed` marker](https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports), `mypy` can't analyze this package and report the error.