### PR TITLE
REF: remove _time_shift

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -70,7 +70,6 @@ from pandas.compat.numpy import function as nv
 from pandas.errors import (
     AbstractMethodError,
     InvalidComparison,
-    NullFrequencyError,
     PerformanceWarning,
 )
 from pandas.util._decorators import (
@@ -1359,44 +1358,6 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         result = cast(np.ndarray, extract_array(ext_arr, extract_numpy=True))
         result = result.reshape(self.shape)
         return result
-
-    def _time_shift(
-        self: DatetimeLikeArrayT, periods: int, freq=None
-    ) -> DatetimeLikeArrayT:
-        """
-        Shift each value by `periods`.
-
-        Note this is different from ExtensionArray.shift, which
-        shifts the *position* of each element, padding the end with
-        missing values.
-
-        Parameters
-        ----------
-        periods : int
-            Number of periods to shift by.
-        freq : pandas.DateOffset, pandas.Timedelta, or str
-            Frequency increment to shift by.
-        """
-        if freq is not None and freq != self.freq:
-            if isinstance(freq, str):
-                freq = to_offset(freq)
-            offset = periods * freq
-            return self + offset
-
-        if periods == 0 or len(self) == 0:
-            # GH#14811 empty case
-            return self.copy()
-
-        if self.freq is None:
-            raise NullFrequencyError("Cannot shift with no freq")
-
-        start = self[0] + periods * self.freq
-        end = self[-1] + periods * self.freq
-
-        # Note: in the DatetimeTZ case, _generate_range will infer the
-        #  appropriate timezone from `start` and `end`, so tz does not need
-        #  to be passed explicitly.
-        return self._generate_range(start=start, end=end, periods=None, freq=self.freq)
 
     @unpack_zerodim_and_defer("__add__")
     def __add__(self, other):

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -538,28 +538,6 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
 
     # --------------------------------------------------------------------
 
-    def _time_shift(self, periods: int, freq=None) -> PeriodArray:
-        """
-        Shift each value by `periods`.
-
-        Note this is different from ExtensionArray.shift, which
-        shifts the *position* of each element, padding the end with
-        missing values.
-
-        Parameters
-        ----------
-        periods : int
-            Number of periods to shift by.
-        freq : pandas.DateOffset, pandas.Timedelta, or str
-            Frequency increment to shift by.
-        """
-        if freq is not None:
-            raise TypeError(
-                "`freq` argument is not supported for "
-                f"{type(self).__name__}._time_shift"
-            )
-        return self + periods
-
     def _box_func(self, x) -> Period | NaTType:
         return Period._from_ordinal(ordinal=x, freq=self.freq)
 
@@ -726,8 +704,7 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
         self, other: np.ndarray | int, op: Callable[[Any, Any], Any]
     ) -> PeriodArray:
         """
-        Add or subtract array of integers; equivalent to applying
-        `_time_shift` pointwise.
+        Add or subtract array of integers.
 
         Parameters
         ----------

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -481,6 +481,14 @@ class PeriodIndex(DatetimeIndexOpsMixin):
         iv = Period(parsed, freq=reso.attr_abbrev)
         return (iv.asfreq(self.freq, how="start"), iv.asfreq(self.freq, how="end"))
 
+    @doc(DatetimeIndexOpsMixin.shift)
+    def shift(self, periods: int = 1, freq=None):
+        if freq is not None:
+            raise TypeError(
+                f"`freq` argument is not supported for {type(self).__name__}.shift"
+            )
+        return self + periods
+
 
 def period_range(
     start=None, end=None, periods: int | None = None, freq=None, name=None

--- a/pandas/tests/indexes/period/methods/test_shift.py
+++ b/pandas/tests/indexes/period/methods/test_shift.py
@@ -66,7 +66,7 @@ class TestPeriodIndexShift:
         # GH#9903
         idx = PeriodIndex([], name="xxx", freq="H")
 
-        msg = "`freq` argument is not supported for PeriodArray._time_shift"
+        msg = "`freq` argument is not supported for PeriodIndex.shift"
         with pytest.raises(TypeError, match=msg):
             # period shift doesn't accept freq
             idx.shift(1, freq="H")


### PR DESCRIPTION
One of a number of steps to getting `freq` out of DTA/TDA.

Only user-facing change is a slightly-improved exception message for PeriodIndex.shift