### PR TITLE
BUG: Do not attempt to parse datetime.datetime objects in pd.to_datetime

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -632,6 +632,7 @@ Datetimelike
 - Bug in subtracting a ``datetime`` scalar from :class:`DatetimeIndex` failing to retain the original ``freq`` attribute (:issue:`48818`)
 - Bug in ``pandas.tseries.holiday.Holiday`` where a half-open date interval causes inconsistent return types from :meth:`USFederalHolidayCalendar.holidays` (:issue:`49075`)
 - Bug in rendering :class:`DatetimeIndex` and :class:`Series` and :class:`DataFrame` with timezone-aware dtypes with ``dateutil`` or ``zoneinfo`` timezones near daylight-savings transitions (:issue:`49684`)
+- Bug in :func:`to_datetime` was raising ``ValueError`` when parsing :class:`Timestamp` or ``datetime`` objects with non-ISO8601 ``format`` (:issue:`49298`)
 -
 
 Timedelta

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -318,7 +318,14 @@ def _return_parsed_timezone_results(
     )
     if utc:
         # Convert to the same tz
-        tz_results = np.array([tz_result.tz_convert("utc") for tz_result in tz_results])
+        tz_results = np.array(
+            [
+                tz_result.tz_convert("utc")
+                if tz_result.tzinfo is not None
+                else tz_result.tz_localize("utc")
+                for tz_result in tz_results
+            ]
+        )
 
     return Index(tz_results, name=name)
 
@@ -468,7 +475,9 @@ def _array_strptime_with_fallback(
     Call array_strptime, with fallback behavior depending on 'errors'.
     """
     try:
-        result, timezones = array_strptime(arg, fmt, exact=exact, errors=errors)
+        result, timezones = array_strptime(
+            arg, fmt, exact=exact, errors=errors, utc=utc
+        )
     except OutOfBoundsDatetime:
         if errors == "raise":
             raise
@@ -495,7 +504,7 @@ def _array_strptime_with_fallback(
             # Indicates to the caller to fallback to objects_to_datetime64ns
             return None
     else:
-        if "%Z" in fmt or "%z" in fmt:
+        if any([i is not None for i in timezones]):
             return _return_parsed_timezone_results(result, timezones, utc, name)
 
     return _box_as_indexlike(result, utc=utc, name=name)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -469,6 +469,89 @@ class TestToDatetime:
         expected = to_datetime([d1, d2]).tz_convert(pytz.FixedOffset(-60))
         tm.assert_index_equal(res, expected)
 
+    @pytest.mark.parametrize(
+        "fmt",
+        ["%Y-%d-%m %H:%M:%S%z", "%Y-%m-%d %H:%M:%S%z"],
+        ids=["non-ISO8601 format", "ISO8601 format"],
+    )
+    @pytest.mark.parametrize(
+        "utc, input, expected",
+        [
+            pytest.param(
+                True,
+                ["2000-01-01 01:00:00-08:00", "2000-01-01 02:00:00-08:00"],
+                DatetimeIndex(
+                    ["2000-01-01 09:00:00+00:00", "2000-01-01 10:00:00+00:00"],
+                    dtype="datetime64[ns, UTC]",
+                ),
+                id="all tz-aware, with utc",
+            ),
+            pytest.param(
+                False,
+                ["2000-01-01 01:00:00-08:00", "2000-01-01 02:00:00-08:00"],
+                DatetimeIndex(
+                    ["2000-01-01 01:00:00-08:00", "2000-01-01 02:00:00-08:00"],
+                    tz=pytz.FixedOffset(-480),
+                ),
+                id="all tz-aware, without utc",
+            ),
+            pytest.param(
+                True,
+                ["2000-01-01 01:00:00-08:00", "2000-01-01 02:00:00+00:00"],
+                DatetimeIndex(
+                    ["2000-01-01 09:00:00+00:00", "2000-01-01 02:00:00+00:00"],
+                    dtype="datetime64[ns, UTC]",
+                ),
+                id="all tz-aware, mixed offsets, with utc",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "constructor",
+        [Timestamp, lambda x: Timestamp(x).to_pydatetime()],
+    )
+    def test_to_datetime_mixed_datetime_and_string_with_format(
+        self, fmt, utc, input, expected, constructor
+    ):
+        # https://github.com/pandas-dev/pandas/issues/49298
+        # note: ISO8601 formats go down a fastpath, so we need to check both
+        # a ISO8601 format and a non-ISO8601 one
+        ts1 = constructor(input[0])
+        ts2 = input[1]
+        result = to_datetime([ts1, ts2], format=fmt, utc=utc)
+        tm.assert_index_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "fmt",
+        ["%Y-%d-%m %H:%M:%S%z", "%Y-%m-%d %H:%M:%S%z"],
+        ids=["non-ISO8601 format", "ISO8601 format"],
+    )
+    @pytest.mark.parametrize(
+        "input",
+        [
+            pytest.param(
+                ["2000-01-01 01:00:00-08:00", "2000-01-01 02:00:00-07:00"],
+                id="all tz-aware, mixed timezones, without utc",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "constructor",
+        [Timestamp, lambda x: Timestamp(x).to_pydatetime()],
+    )
+    def test_to_datetime_mixed_datetime_and_string_with_format_raises(
+        self, fmt, input, constructor
+    ):
+        # https://github.com/pandas-dev/pandas/issues/49298
+        # note: ISO8601 formats go down a fastpath, so we need to check both
+        # a ISO8601 format and a non-ISO8601 one
+        ts1 = constructor(input[0])
+        ts2 = constructor(input[1])
+        with pytest.raises(
+            ValueError, match="cannot be converted to datetime64 unless utc=True"
+        ):
+            to_datetime([ts1, ts2], format=fmt, utc=False)
+
     @pytest.mark.parametrize("infer_datetime_format", [True, False])
     def test_to_datetime_np_str(self, infer_datetime_format):
         # GH#32264


### PR DESCRIPTION
- [x] closes #49298 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Granted, there's already a PR open to address this (https://github.com/pandas-dev/pandas/pull/49338), but I'm not sure if it's gone stale. As this is a blocker for PDEP0004, I've taken it forwards, but have taken care to include @aaossa as commit author.
I've fixed it up a bit to handle the objections I had and have re-written the tests

EDIT: looks like aaossa isn't actually showing up as coauthor, I'll try this again