### PR TITLE
STYLE enable pylint: undefined-variable

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -84,7 +84,7 @@ class DocBuilder:
 
         elif single_doc.startswith("pandas."):
             try:
-                obj = pandas  # noqa: F821
+                obj = pandas  # pylint: disable=undefined-variable  # noqa: F821
                 for name in single_doc.split("."):
                     obj = getattr(obj, name)
             except AttributeError as err:

--- a/pandas/io/clipboard/__init__.py
+++ b/pandas/io/clipboard/__init__.py
@@ -124,6 +124,12 @@ def init_osx_pbcopy_clipboard():
 
 
 def init_osx_pyobjc_clipboard():
+    try:
+        import AppKit
+        import Foundation  # check if pyobjc is installed
+    except ImportError:
+        return init_osx_pbcopy_clipboard()
+
     def copy_osx_pyobjc(text):
         """Copy string argument to clipboard"""
         text = _stringifyText(text)  # Converts non-str values to str.
@@ -512,7 +518,7 @@ def determine_clipboard():
     Determine the OS/platform and set the copy() and paste() functions
     accordingly.
     """
-    global Foundation, AppKit, qtpy, PyQt4, PyQt5
+    global qtpy, PyQt4, PyQt5
 
     # Setup for the CYGWIN platform:
     if (
@@ -539,13 +545,7 @@ def determine_clipboard():
 
     # Setup for the macOS platform:
     if os.name == "mac" or platform.system() == "Darwin":
-        try:
-            import AppKit
-            import Foundation  # check if pyobjc is installed
-        except ImportError:
-            return init_osx_pbcopy_clipboard()
-        else:
-            return init_osx_pyobjc_clipboard()
+        return init_osx_pyobjc_clipboard()
 
     # Setup for the LINUX platform:
     if HAS_DISPLAY:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,6 @@ disable = [
   "abstract-class-instantiated",
   "redundant-keyword-arg",
   "no-value-for-parameter",
-  "undefined-variable",
   "unpacking-non-sequence",
 
  # pylint type "C": convention, for programming standard violation


### PR DESCRIPTION
Issue #48855. This PR enables pylint warning: `undefined-variable`
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).