### PR TITLE
Fix some little-endian assumptions in the tests

### DIFF
--- a/pandas/tests/arrays/floating/test_arithmetic.py
+++ b/pandas/tests/arrays/floating/test_arithmetic.py
@@ -162,7 +162,10 @@ def test_error_invalid_values(data, all_arithmetic_operators):
             "not all arguments converted during string formatting",
             "can't multiply sequence by non-int of type 'float'",
             "ufunc 'subtract' cannot use operands with types dtype",
-            r"ufunc 'add' cannot use operands with types dtype\('<M8\[ns\]'\)",
+            (
+                "ufunc 'add' cannot use operands with types "
+                rf"dtype\('{tm.ENDIAN}M8\[ns\]'\)"
+            ),
             r"ufunc 'add' cannot use operands with types dtype\('float\d{2}'\)",
             "cannot subtract DatetimeArray from ndarray",
         ]

--- a/pandas/tests/frame/methods/test_to_records.py
+++ b/pandas/tests/frame/methods/test_to_records.py
@@ -96,7 +96,13 @@ class TestDataFrameToRecords:
             + [np.asarray(df.iloc[:, i]) for i in range(3)],
             dtype={
                 "names": ["A", "level_1", "0", "1", "2"],
-                "formats": ["O", "O", "<f8", "<f8", "<f8"],
+                "formats": [
+                    "O",
+                    "O",
+                    f"{tm.ENDIAN}f8",
+                    f"{tm.ENDIAN}f8",
+                    f"{tm.ENDIAN}f8",
+                ],
             },
         )
         tm.assert_numpy_array_equal(result, expected)
@@ -123,7 +129,11 @@ class TestDataFrameToRecords:
                 ("2022-01-01", "2022-01-01", "2022-01-01"),
                 ("2022-01-02", "2022-01-02", "2022-01-02"),
             ],
-            dtype=[("1", "<M8[ns]"), ("2", "<M8[ns]"), ("3", "<M8[ns]")],
+            dtype=[
+                ("1", f"{tm.ENDIAN}M8[ns]"),
+                ("2", f"{tm.ENDIAN}M8[ns]"),
+                ("3", f"{tm.ENDIAN}M8[ns]"),
+            ],
         )
 
         result = df.to_records(index=False)

--- a/pandas/tests/scalar/timedelta/test_arithmetic.py
+++ b/pandas/tests/scalar/timedelta/test_arithmetic.py
@@ -435,7 +435,7 @@ class TestTimedeltaMultiplicationDivision:
 
         msg = (
             "ufunc '?multiply'? cannot use operands with types "
-            r"dtype\('<m8\[ns\]'\) and dtype\('<m8\[ns\]'\)"
+            rf"dtype\('{tm.ENDIAN}m8\[ns\]'\) and dtype\('{tm.ENDIAN}m8\[ns\]'\)"
         )
         with pytest.raises(TypeError, match=msg):
             td * other


### PR DESCRIPTION
See previous [PR#46681](https://github.com/pandas-dev/pandas/pull/46681).

- [ ] closes #xxxx **N/A**
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature **N/A, fixes some existing test failures on s390x**
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. **N/A**
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature. **N/A**
