### PR TITLE
STYLE: fix pylint self-assigning-variable warnings

### DIFF
--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -877,7 +877,7 @@ def assert_series_equal(
         )
 
     if check_like:
-        left, right = left.reindex_like(right), right
+        left = left.reindex_like(right)
 
     if check_freq and isinstance(left.index, (DatetimeIndex, TimedeltaIndex)):
         lidx = left.index
@@ -1159,7 +1159,7 @@ def assert_frame_equal(
     )
 
     if check_like:
-        left, right = left.reindex_like(right), right
+        left = left.reindex_like(right)
 
     # compare by blocks
     if by_blocks:

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -446,7 +446,6 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin):
             new_freq = self.freq
         elif isinstance(res_i8, RangeIndex):
             new_freq = to_offset(Timedelta(res_i8.step))
-            res_i8 = res_i8
 
         # TODO(GH#41493): we cannot just do
         #  type(self._data)(res_i8.values, dtype=self.dtype, freq=new_freq)

--- a/pandas/tests/indexes/multi/test_reindex.py
+++ b/pandas/tests/indexes/multi/test_reindex.py
@@ -90,7 +90,6 @@ def test_reindex_lvl_preserves_type_if_target_is_empty_list_or_array():
 
 
 def test_reindex_base(idx):
-    idx = idx
     expected = np.arange(idx.size, dtype=np.intp)
 
     actual = idx.get_indexer(idx)

--- a/pandas/tests/indexes/multi/test_take.py
+++ b/pandas/tests/indexes/multi/test_take.py
@@ -18,7 +18,6 @@ def test_take(idx):
 
 
 def test_take_invalid_kwargs(idx):
-    idx = idx
     indices = [1, 2]
 
     msg = r"take\(\) got an unexpected keyword argument 'foo'"

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -210,7 +210,6 @@ class TestAsOfMerge:
     def test_basic_right_index(self, trades, asof, quotes):
 
         expected = asof
-        trades = trades
         quotes = quotes.set_index("time")
 
         result = merge_asof(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,6 @@ disable = [
   "raise-missing-from",
   "redefined-builtin",
   "redefined-outer-name",
-  "self-assigning-variable",
   "self-cls-assignment",
   "signature-differs",
   "super-init-not-called",


### PR DESCRIPTION
Related to https://github.com/pandas-dev/pandas/issues/48855
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.