### PR TITLE
 CI_check_correctness_notebooks

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -79,6 +79,10 @@ jobs:
       run: ci/code_checks.sh docstrings
       if: ${{ steps.build.outcome == 'success' && always() }}
 
+    - name: Run check of documentation notebooks
+      run: ci/code_checks.sh notebooks
+      if: ${{ steps.build.outcome == 'success' && always() }}
+
     - name: Use existing environment for type checking
       run: |
         echo $PATH >> $GITHUB_PATH

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -12,7 +12,7 @@
 #   $ ./ci/code_checks.sh doctests      # run doctests
 #   $ ./ci/code_checks.sh docstrings    # validate docstring errors
 #   $ ./ci/code_checks.sh single-docs   # check single-page docs build warning-free
-#   $ ./ci/code_checks.sh notebooks     # check correctness of documentation of notebooks
+#   $ ./ci/code_checks.sh notebooks     # check execution of documentation notebooks
 
 [[ -z "$1" || "$1" == "code" || "$1" == "doctests" || "$1" == "docstrings" || "$1" == "single-docs" || "$1" == "notebooks" ]] || \
     { echo "Unknown command $1. Usage: $0 [code|doctests|docstrings|single-docs|notebooks]"; exit 9999; }

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -12,9 +12,10 @@
 #   $ ./ci/code_checks.sh doctests      # run doctests
 #   $ ./ci/code_checks.sh docstrings    # validate docstring errors
 #   $ ./ci/code_checks.sh single-docs   # check single-page docs build warning-free
+#   $ ./ci/code_checks.sh notebooks     # check correctness of documentation of notebooks
 
-[[ -z "$1" || "$1" == "code" || "$1" == "doctests" || "$1" == "docstrings" || "$1" == "single-docs" ]] || \
-    { echo "Unknown command $1. Usage: $0 [code|doctests|docstrings]"; exit 9999; }
+[[ -z "$1" || "$1" == "code" || "$1" == "doctests" || "$1" == "docstrings" || "$1" == "single-docs" || "$1" == "notebooks" ]] || \
+    { echo "Unknown command $1. Usage: $0 [code|doctests|docstrings|single-docs|notebooks]"; exit 9999; }
 
 BASE_DIR="$(dirname $0)/.."
 RET=0
@@ -80,6 +81,15 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
 
     MSG='Validate docstrings (EX04, GL01, GL02, GL03, GL04, GL05, GL06, GL07, GL09, GL10, PR03, PR04, PR05, PR06, PR08, PR09, PR10, RT01, RT04, RT05, SA02, SA03, SA04, SS01, SS02, SS03, SS04, SS05, SS06)' ; echo $MSG
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=EX04,GL01,GL02,GL03,GL04,GL05,GL06,GL07,GL09,GL10,PR03,PR04,PR05,PR06,PR08,PR09,PR10,RT01,RT04,RT05,SA02,SA03,SA04,SS01,SS02,SS03,SS04,SS05,SS06
+    RET=$(($RET + $?)) ; echo $MSG "DONE"
+
+fi
+
+### DOCUMENTATION NOTEBOOKS ###
+if [[ -z "$CHECK" || "$CHECK" == "notebooks" ]]; then
+
+    MSG='Notebooks' ; echo $MSG
+    jupyter nbconvert --execute $(find doc/source -name '*.ipynb') --to notebook
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
 fi


### PR DESCRIPTION
This PR is related to the PR #49874.
Creating new PR, that checks correctness notebooks, as was discussed with @MarcoGorelli .
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

CI didn't fail when documentation notebook executed with an error. I added new notebooks section in `ci/code_checks.sh` to check if the notebook execution passes.