### PR TITLE
STYLE #49656: fixed redefined-outer-name linting issue to format.py 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,8 +79,6 @@ repos:
             |^pandas/util/_test_decorators\.py  # keep excluded
             |^pandas/_version\.py  # keep excluded
             |^pandas/conftest\.py  # keep excluded
-            |^pandas/core/tools/datetimes\.py
-            |^pandas/io/formats/format\.py
             |^pandas/core/generic\.py
         args: [--disable=all, --enable=redefined-outer-name]
         stages: [manual]

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -356,14 +356,12 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         -------
         bool
         """
-        from pandas.io.formats.format import is_dates_only_
+        from pandas.io.formats.format import is_dates_only
 
         # error: Argument 1 to "is_dates_only" has incompatible type
         # "Union[ExtensionArray, ndarray]"; expected "Union[ndarray,
         # DatetimeArray, Index, DatetimeIndex]"
-        return self.tz is None and is_dates_only_(
-            self._values
-        )  # type: ignore[arg-type]
+        return self.tz is None and is_dates_only(self._values)  # type: ignore[arg-type]
 
     def __reduce__(self):
         d = {"data": self._data, "name": self.name}
@@ -386,7 +384,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
     def _formatter_func(self):
         from pandas.io.formats.format import get_format_datetime64
 
-        formatter = get_format_datetime64(is_dates_only=self._is_dates_only)
+        formatter = get_format_datetime64(is_dates_only_=self._is_dates_only)
         return lambda x: f"'{formatter(x)}'"
 
     # --------------------------------------------------------------------

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -356,12 +356,14 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         -------
         bool
         """
-        from pandas.io.formats.format import is_dates_only
+        from pandas.io.formats.format import is_dates_only_
 
         # error: Argument 1 to "is_dates_only" has incompatible type
         # "Union[ExtensionArray, ndarray]"; expected "Union[ndarray,
         # DatetimeArray, Index, DatetimeIndex]"
-        return self.tz is None and is_dates_only(self._values)  # type: ignore[arg-type]
+        return self.tz is None and is_dates_only_(
+            self._values
+        )  # type: ignore[arg-type]
 
     def __reduce__(self):
         d = {"data": self._data, "name": self.name}
@@ -384,7 +386,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
     def _formatter_func(self):
         from pandas.io.formats.format import get_format_datetime64
 
-        formatter = get_format_datetime64(is_dates_only_result=self._is_dates_only)
+        formatter = get_format_datetime64(is_dates_only=self._is_dates_only)
         return lambda x: f"'{formatter(x)}'"
 
     # --------------------------------------------------------------------

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -384,7 +384,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
     def _formatter_func(self):
         from pandas.io.formats.format import get_format_datetime64
 
-        formatter = get_format_datetime64(is_dates_only=self._is_dates_only)
+        formatter = get_format_datetime64(is_dates_only_result=self._is_dates_only)
         return lambda x: f"'{formatter(x)}'"
 
     # --------------------------------------------------------------------

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -108,7 +108,6 @@ from pandas.io.common import (
 )
 from pandas.io.formats.printing import (
     adjoin,
-    justify,
     pprint_thing,
 )
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1742,7 +1742,7 @@ def format_percentiles(
     return [i + "%" for i in out]
 
 
-def is_dates_only(values: np.ndarray | DatetimeArray | Index | DatetimeIndex) -> bool:
+def is_dates_only_(values: np.ndarray | DatetimeArray | Index | DatetimeIndex) -> bool:
     # return a boolean if we are only dates (and don't have a timezone)
     if not isinstance(values, Index):
         values = values.ravel()
@@ -1792,12 +1792,12 @@ def _format_datetime64_dateonly(
 
 
 def get_format_datetime64(
-    is_dates_only_result: bool, nat_rep: str = "NaT", date_format: str | None = None
+    is_dates_only: bool, nat_rep: str = "NaT", date_format: str | None = None
 ) -> Callable:
     """Return a formatter callable taking a datetime64 as input and providing
     a string as output"""
 
-    if is_dates_only_result:
+    if is_dates_only:
         return lambda x: _format_datetime64_dateonly(
             x, nat_rep=nat_rep, date_format=date_format
         )
@@ -1814,7 +1814,7 @@ def get_format_datetime64_from_values(
         #  only accepts 1D values
         values = values.ravel()
 
-    ido = is_dates_only(values)
+    ido = is_dates_only_(values)
     if ido:
         # Only dates and no timezone: provide a default format
         return date_format or "%Y-%m-%d"
@@ -1825,7 +1825,7 @@ class Datetime64TZFormatter(Datetime64Formatter):
     def _format_strings(self) -> list[str]:
         """we by definition have a TZ"""
         values = self.values.astype(object)
-        ido = is_dates_only(values)
+        ido = is_dates_only_(values)
         formatter = self.formatter or get_format_datetime64(
             ido, date_format=self.date_format
         )

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -9,7 +9,7 @@ from csv import (
     QUOTE_NONE,
     QUOTE_NONNUMERIC,
 )
-import decimal
+from decimal import Decimal
 from functools import partial
 from io import StringIO
 import math
@@ -2071,12 +2071,12 @@ class EngFormatter:
 
         @return: engineering formatted string
         """
-        dnum = decimal.Decimal(str(num))
+        dnum = Decimal(str(num))
 
-        if decimal.Decimal.is_nan(dnum):
+        if Decimal.is_nan(dnum):
             return "NaN"
 
-        if decimal.Decimal.is_infinite(dnum):
+        if Decimal.is_infinite(dnum):
             return "inf"
 
         sign = 1
@@ -2086,9 +2086,9 @@ class EngFormatter:
             dnum = -dnum
 
         if dnum != 0:
-            pow10 = decimal.Decimal(int(math.floor(dnum.log10() / 3) * 3))
+            pow10 = Decimal(int(math.floor(dnum.log10() / 3) * 3))
         else:
-            pow10 = decimal.Decimal(0)
+            pow10 = Decimal(0)
 
         pow10 = pow10.min(max(self.ENG_PREFIXES.keys()))
         pow10 = pow10.max(min(self.ENG_PREFIXES.keys()))

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1794,12 +1794,12 @@ def _format_datetime64_dateonly(
 
 
 def get_format_datetime64(
-    is_dates_only: bool, nat_rep: str = "NaT", date_format: str | None = None
+    is_dates_only_result: bool, nat_rep: str = "NaT", date_format: str | None = None
 ) -> Callable:
     """Return a formatter callable taking a datetime64 as input and providing
     a string as output"""
 
-    if is_dates_only:
+    if is_dates_only_result:
         return lambda x: _format_datetime64_dateonly(
             x, nat_rep=nat_rep, date_format=date_format
         )

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -106,11 +106,7 @@ from pandas.io.common import (
     check_parent_directory,
     stringify_path,
 )
-from pandas.io.formats.printing import (
-    adjoin,
-    justify as jst,
-    pprint_thing,
-)
+from pandas.io.formats import printing
 
 if TYPE_CHECKING:
     from pandas import (
@@ -339,7 +335,7 @@ class SeriesFormatter:
             if footer:
                 footer += ", "
 
-            series_name = pprint_thing(name, escape_chars=("\t", "\r", "\n"))
+            series_name = printing.pprint_thing(name, escape_chars=("\t", "\r", "\n"))
             footer += f"Name: {series_name}"
 
         if self.length is True or (
@@ -354,7 +350,7 @@ class SeriesFormatter:
             if dtype_name:
                 if footer:
                     footer += ", "
-                footer += f"dtype: {pprint_thing(dtype_name)}"
+                footer += f"dtype: {printing.pprint_thing(dtype_name)}"
 
         # level infos are added to the end and in a new line, like it is done
         # for Categoricals
@@ -433,10 +429,12 @@ class TextAdjustment:
         return len(text)
 
     def justify(self, texts: Any, max_len: int, mode: str = "right") -> list[str]:
-        return jst(texts, max_len, mode=mode)
+        return printing.justify(texts, max_len, mode=mode)
 
     def adjoin(self, space: int, *lists, **kwargs) -> str:
-        return adjoin(space, *lists, strlen=self.len, justfunc=self.justify, **kwargs)
+        return printing.adjoin(
+            space, *lists, strlen=self.len, justfunc=self.justify, **kwargs
+        )
 
 
 class EastAsianTextAdjustment(TextAdjustment):
@@ -1375,7 +1373,7 @@ class GenericArrayFormatter:
         else:
             quote_strings = self.quoting is not None and self.quoting != QUOTE_NONE
             formatter = partial(
-                pprint_thing,
+                printing.pprint_thing,
                 escape_chars=("\t", "\r", "\n"),
                 quote_strings=quote_strings,
             )

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1742,7 +1742,7 @@ def format_percentiles(
     return [i + "%" for i in out]
 
 
-def is_dates_only_(values: np.ndarray | DatetimeArray | Index | DatetimeIndex) -> bool:
+def is_dates_only(values: np.ndarray | DatetimeArray | Index | DatetimeIndex) -> bool:
     # return a boolean if we are only dates (and don't have a timezone)
     if not isinstance(values, Index):
         values = values.ravel()
@@ -1792,12 +1792,12 @@ def _format_datetime64_dateonly(
 
 
 def get_format_datetime64(
-    is_dates_only: bool, nat_rep: str = "NaT", date_format: str | None = None
+    is_dates_only_: bool, nat_rep: str = "NaT", date_format: str | None = None
 ) -> Callable:
     """Return a formatter callable taking a datetime64 as input and providing
     a string as output"""
 
-    if is_dates_only:
+    if is_dates_only_:
         return lambda x: _format_datetime64_dateonly(
             x, nat_rep=nat_rep, date_format=date_format
         )
@@ -1814,7 +1814,7 @@ def get_format_datetime64_from_values(
         #  only accepts 1D values
         values = values.ravel()
 
-    ido = is_dates_only_(values)
+    ido = is_dates_only(values)
     if ido:
         # Only dates and no timezone: provide a default format
         return date_format or "%Y-%m-%d"
@@ -1825,7 +1825,7 @@ class Datetime64TZFormatter(Datetime64Formatter):
     def _format_strings(self) -> list[str]:
         """we by definition have a TZ"""
         values = self.values.astype(object)
-        ido = is_dates_only_(values)
+        ido = is_dates_only(values)
         formatter = self.formatter or get_format_datetime64(
             ido, date_format=self.date_format
         )

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -108,6 +108,7 @@ from pandas.io.common import (
 )
 from pandas.io.formats.printing import (
     adjoin,
+    justify as jst,
     pprint_thing,
 )
 
@@ -432,7 +433,7 @@ class TextAdjustment:
         return len(text)
 
     def justify(self, texts: Any, max_len: int, mode: str = "right") -> list[str]:
-        return justify(texts, max_len, mode=mode)
+        return jst(texts, max_len, mode=mode)
 
     def adjoin(self, space: int, *lists, **kwargs) -> str:
         return adjoin(space, *lists, strlen=self.len, justfunc=self.justify, **kwargs)


### PR DESCRIPTION
Fixed redefined-outer-name issue in:
- pandas/io/formats/format.py

redefined-outer-name t issues raised for:
- justify function (import from pandas.io.formats.printing)
- decimal (changed to from decimal import Decimal) 
- is_dates_only parameter conflict with function name 
- updated get_format_datetime64 function with renamed parameter

- passed related tests in pytest pandas
- running:  pylint --disable=all --enable=redefined-outer-name pandas/io/
-- > Results in 10.00/10 rating

