### PR TITLE
48779-doc-MonthEnd

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -2410,19 +2410,23 @@ cdef class MonthOffset(SingleConstructorOffset):
 
 cdef class MonthEnd(MonthOffset):
     """
-    DateOffset of one month end. MonthEnd goes to the next date which is an end
-    of the month.
-    To get the end of the current month pass the parameter n equals 0: MonthEnd(0).
+    DateOffset of one month end.
+
+    MonthEnd goes to the next date which is an end of the month.
+    To get the end of the current month pass the parameter n equals 0.
 
     Examples
     --------
     >>> ts = pd.Timestamp(2022, 1, 30)
     >>> ts + pd.offsets.MonthEnd()
     Timestamp('2022-01-31 00:00:00')
-
     >>> ts = pd.Timestamp(2022, 1, 31)
     >>> ts + pd.offsets.MonthEnd()
     Timestamp('2022-02-28 00:00:00')
+    If you want to get the end of the current month pass the parameter n equals 0:
+    >>> ts = pd.Timestamp(2022, 1, 31)
+    >>> ts + pd.offsets.MonthEnd(0)
+    Timestamp('2022-01-31 00:00:00')
     """
     _period_dtype_code = PeriodDtypeCode.M
     _prefix = "M"

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -2410,13 +2410,19 @@ cdef class MonthOffset(SingleConstructorOffset):
 
 cdef class MonthEnd(MonthOffset):
     """
-    DateOffset of one month end.
+    DateOffset of one month end. MonthEnd goes to the next date which is an end
+    of the month.
+    To get the end of the current month pass the parameter n equals 0: MonthEnd(0).
 
     Examples
     --------
-    >>> ts = pd.Timestamp(2022, 1, 1)
+    >>> ts = pd.Timestamp(2022, 1, 30)
     >>> ts + pd.offsets.MonthEnd()
     Timestamp('2022-01-31 00:00:00')
+
+    >>> ts = pd.Timestamp(2022, 1, 31)
+    >>> ts + pd.offsets.MonthEnd()
+    Timestamp('2022-02-28 00:00:00')
     """
     _period_dtype_code = PeriodDtypeCode.M
     _prefix = "M"

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -2415,15 +2415,22 @@ cdef class MonthEnd(MonthOffset):
     MonthEnd goes to the next date which is an end of the month.
     To get the end of the current month pass the parameter n equals 0.
 
+    See Also
+    --------
+    :class:`~pandas.tseries.offsets.DateOffset` : Standard kind of date increment.
+
     Examples
     --------
     >>> ts = pd.Timestamp(2022, 1, 30)
     >>> ts + pd.offsets.MonthEnd()
     Timestamp('2022-01-31 00:00:00')
+
     >>> ts = pd.Timestamp(2022, 1, 31)
     >>> ts + pd.offsets.MonthEnd()
     Timestamp('2022-02-28 00:00:00')
+
     If you want to get the end of the current month pass the parameter n equals 0:
+
     >>> ts = pd.Timestamp(2022, 1, 31)
     >>> ts + pd.offsets.MonthEnd(0)
     Timestamp('2022-01-31 00:00:00')


### PR DESCRIPTION
- [x] closes #48779
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
As proposed by @MarcoGorelli I updated docs for `MonthEnd` and added one more example to highlight “the last day of the month” behavior.

I checked that build of documentation shows the new description.