### PR TITLE
TST/CoW: copy-on-write tests for df.head and df.tail

### DIFF
--- a/pandas/tests/copy_view/test_methods.py
+++ b/pandas/tests/copy_view/test_methods.py
@@ -250,3 +250,33 @@ def test_set_index(using_copy_on_write):
     df2.iloc[0, 1] = 0
     assert not np.shares_memory(get_array(df2, "c"), get_array(df, "c"))
     tm.assert_frame_equal(df, df_orig)
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        lambda df: df.head(),
+        lambda df: df.head(2),
+        lambda df: df.tail(),
+        lambda df: df.tail(3),
+    ],
+)
+def test_head_tail(using_copy_on_write, method):
+    df = DataFrame({"a": [1, 1, 1], "b": [0.1, 0.2, 0.3]})
+    df_orig = df.copy()
+    df2 = method(df)
+    df2._mgr._verify_integrity()
+
+    if using_copy_on_write:
+        assert np.shares_memory(get_array(df2, "a"), get_array(df, "a"))
+        assert np.shares_memory(get_array(df2, "b"), get_array(df, "b"))
+
+    # modify df2 to trigger CoW for that block
+    df2.iloc[0, 0] = 0
+    assert np.shares_memory(get_array(df2, "b"), get_array(df, "b"))
+    if using_copy_on_write:
+        assert not np.shares_memory(get_array(df2, "a"), get_array(df, "a"))
+    else:
+        # without CoW enabled, head and tail return views. Mutating df2 also mutates df.
+        df2.iloc[0, 0] = 1
+    tm.assert_frame_equal(df, df_orig)

--- a/pandas/tests/copy_view/test_methods.py
+++ b/pandas/tests/copy_view/test_methods.py
@@ -262,7 +262,7 @@ def test_set_index(using_copy_on_write):
     ],
 )
 def test_head_tail(method, using_copy_on_write):
-    df = DataFrame({"a": [1, 1, 1], "b": [0.1, 0.2, 0.3]})
+    df = DataFrame({"a": [1, 2, 3], "b": [0.1, 0.2, 0.3]})
     df_orig = df.copy()
     df2 = method(df)
     df2._mgr._verify_integrity()

--- a/pandas/tests/copy_view/test_methods.py
+++ b/pandas/tests/copy_view/test_methods.py
@@ -261,7 +261,7 @@ def test_set_index(using_copy_on_write):
         lambda df: df.tail(3),
     ],
 )
-def test_head_tail(using_copy_on_write, method):
+def test_head_tail(method, using_copy_on_write):
     df = DataFrame({"a": [1, 1, 1], "b": [0.1, 0.2, 0.3]})
     df_orig = df.copy()
     df2 = method(df)


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Progress towards #49473
Because `.head()` and `.tail()` use `.iloc` under the hood, copy-on-write is already implemented for them, but this PR adds explicit tests for both methods.