### PR TITLE
Adding to the function docs that groupby.transform() function parameter can be a string

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -399,7 +399,7 @@ filled with the transformed values.
 
 Parameters
 ----------
-f : function
+f : function, str
     Function to apply to each group. See the Notes section below for requirements.
 
     Can also accept a Numba JIT function with


### PR DESCRIPTION
Docs change: Adding to the function docs that groupby.transform() function parameter can be a string

- [ ] closes #49961 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
