### PR TITLE
DOC: Update Benchmark Link #49871

### DIFF
--- a/doc/source/development/maintaining.rst
+++ b/doc/source/development/maintaining.rst
@@ -318,7 +318,7 @@ Benchmark machine
 -----------------
 
 The team currently owns dedicated hardware for hosting a website for pandas' ASV performance benchmark. The results
-are published to http://pandas.pydata.org/speed/pandas/
+are published to https://asv-runner.github.io/asv-collection/pandas/
 
 Configuration
 `````````````


### PR DESCRIPTION

- [ ] Updated the broken benchmark-machine link in  `doc/source/development/maintaining.rst` file fixing a bug #49871.
