### PR TITLE
REF: remove numeric arg from NDFrame._convert

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6318,8 +6318,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     @final
     def _convert(
         self: NDFrameT,
+        *,
         datetime: bool_t = False,
-        numeric: bool_t = False,
         timedelta: bool_t = False,
     ) -> NDFrameT:
         """
@@ -6329,9 +6329,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         ----------
         datetime : bool, default False
             If True, convert to date where possible.
-        numeric : bool, default False
-            If True, attempt to convert to numbers (including strings), with
-            unconvertible values becoming NaN.
         timedelta : bool, default False
             If True, convert to timedelta where possible.
 
@@ -6340,12 +6337,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         converted : same as input object
         """
         validate_bool_kwarg(datetime, "datetime")
-        validate_bool_kwarg(numeric, "numeric")
         validate_bool_kwarg(timedelta, "timedelta")
         return self._constructor(
             self._mgr.convert(
                 datetime=datetime,
-                numeric=numeric,
                 timedelta=timedelta,
                 copy=True,
             )
@@ -6390,11 +6385,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         A    int64
         dtype: object
         """
-        # numeric=False necessary to only soft convert;
-        # python objects will still be converted to
-        # native numpy numeric types
         return self._constructor(
-            self._mgr.convert(datetime=True, numeric=False, timedelta=True, copy=True)
+            self._mgr.convert(datetime=True, timedelta=True, copy=True)
         ).__finalize__(self, method="infer_objects")
 
     @final

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -377,9 +377,9 @@ class BaseArrayManager(DataManager):
 
     def convert(
         self: T,
+        *,
         copy: bool = True,
         datetime: bool = True,
-        numeric: bool = True,
         timedelta: bool = True,
     ) -> T:
         def _convert(arr):
@@ -389,7 +389,6 @@ class BaseArrayManager(DataManager):
                 return soft_convert_objects(
                     arr,
                     datetime=datetime,
-                    numeric=numeric,
                     timedelta=timedelta,
                     copy=copy,
                 )

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -429,9 +429,7 @@ class Block(PandasObject):
             #  but ATM it breaks too much existing code.
             # split and convert the blocks
 
-            return extend_blocks(
-                [blk.convert(datetime=True, numeric=False) for blk in blocks]
-            )
+            return extend_blocks([blk.convert(datetime=True) for blk in blocks])
 
         if downcast is None:
             return blocks
@@ -451,9 +449,9 @@ class Block(PandasObject):
 
     def convert(
         self,
+        *,
         copy: bool = True,
         datetime: bool = True,
-        numeric: bool = True,
         timedelta: bool = True,
     ) -> list[Block]:
         """
@@ -570,7 +568,7 @@ class Block(PandasObject):
             if not (self.is_object and value is None):
                 # if the user *explicitly* gave None, we keep None, otherwise
                 #  may downcast to NaN
-                blocks = blk.convert(numeric=False, copy=False)
+                blocks = blk.convert(copy=False)
             else:
                 blocks = [blk]
             return blocks
@@ -642,7 +640,7 @@ class Block(PandasObject):
         replace_regex(new_values, rx, value, mask)
 
         block = self.make_block(new_values)
-        return block.convert(numeric=False, copy=False)
+        return block.convert(copy=False)
 
     @final
     def replace_list(
@@ -712,9 +710,7 @@ class Block(PandasObject):
                 )
                 if convert and blk.is_object and not all(x is None for x in dest_list):
                     # GH#44498 avoid unwanted cast-back
-                    result = extend_blocks(
-                        [b.convert(numeric=False, copy=True) for b in result]
-                    )
+                    result = extend_blocks([b.convert(copy=True) for b in result])
                 new_rb.extend(result)
             rb = new_rb
         return rb
@@ -1969,9 +1965,9 @@ class ObjectBlock(NumpyBlock):
     @maybe_split
     def convert(
         self,
+        *,
         copy: bool = True,
         datetime: bool = True,
-        numeric: bool = True,
         timedelta: bool = True,
     ) -> list[Block]:
         """
@@ -1987,7 +1983,6 @@ class ObjectBlock(NumpyBlock):
         res_values = soft_convert_objects(
             values,
             datetime=datetime,
-            numeric=numeric,
             timedelta=timedelta,
             copy=copy,
         )

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -443,16 +443,15 @@ class BaseBlockManager(DataManager):
 
     def convert(
         self: T,
+        *,
         copy: bool = True,
         datetime: bool = True,
-        numeric: bool = True,
         timedelta: bool = True,
     ) -> T:
         return self.apply(
             "convert",
             copy=copy,
             datetime=datetime,
-            numeric=numeric,
             timedelta=timedelta,
         )
 

--- a/pandas/tests/frame/methods/test_convert.py
+++ b/pandas/tests/frame/methods/test_convert.py
@@ -1,10 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas import (
-    DataFrame,
-    Series,
-)
+from pandas import DataFrame
 import pandas._testing as tm
 
 
@@ -21,17 +18,11 @@ class TestConvert:
         float_string_frame["I"] = "1"
 
         # add in some items that will be nan
-        length = len(float_string_frame)
         float_string_frame["J"] = "1."
         float_string_frame["K"] = "1"
         float_string_frame.loc[float_string_frame.index[0:5], ["J", "K"]] = "garbled"
-        converted = float_string_frame._convert(datetime=True, numeric=True)
-        assert converted["H"].dtype == "float64"
-        assert converted["I"].dtype == "int64"
-        assert converted["J"].dtype == "float64"
-        assert converted["K"].dtype == "float64"
-        assert len(converted["J"].dropna()) == length - 5
-        assert len(converted["K"].dropna()) == length - 5
+        converted = float_string_frame._convert(datetime=True)
+        tm.assert_frame_equal(converted, float_string_frame)
 
         # via astype
         converted = float_string_frame.copy()
@@ -44,14 +35,6 @@ class TestConvert:
         converted = float_string_frame.copy()
         with pytest.raises(ValueError, match="invalid literal"):
             converted["H"].astype("int32")
-
-    def test_convert_mixed_single_column(self):
-        # GH#4119, not converting a mixed type (e.g.floats and object)
-        # mixed in a single column
-        df = DataFrame({"s": Series([1, "na", 3, 4])})
-        result = df._convert(datetime=True, numeric=True)
-        expected = DataFrame({"s": Series([1, np.nan, 3, 4])})
-        tm.assert_frame_equal(result, expected)
 
     def test_convert_objects_no_conversion(self):
         mixed1 = DataFrame({"a": [1, 2, 3], "b": [4.0, 5, 6], "c": ["x", "y", "z"]})

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -557,14 +557,6 @@ class TestFancy:
         )
         tm.assert_frame_equal(df, expected)
 
-        df = df_orig.copy()
-        with tm.assert_produces_warning(FutureWarning, match=msg):
-            df.iloc[:, 0:2] = df.iloc[:, 0:2]._convert(datetime=True, numeric=True)
-        expected = DataFrame(
-            [[1, 2, "3", ".4", 5, 6.0, "foo"]], columns=list("ABCDEFG")
-        )
-        tm.assert_frame_equal(df, expected)
-
         # GH5702 (loc)
         df = df_orig.copy()
         with tm.assert_produces_warning(FutureWarning, match=msg):

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -599,9 +599,9 @@ class TestBlockManager:
         mgr.iset(0, np.array(["1"] * N, dtype=np.object_))
         mgr.iset(1, np.array(["2."] * N, dtype=np.object_))
         mgr.iset(2, np.array(["foo."] * N, dtype=np.object_))
-        new_mgr = mgr.convert(numeric=True)
-        assert new_mgr.iget(0).dtype == np.int64
-        assert new_mgr.iget(1).dtype == np.float64
+        new_mgr = mgr.convert()
+        assert new_mgr.iget(0).dtype == np.object_
+        assert new_mgr.iget(1).dtype == np.object_
         assert new_mgr.iget(2).dtype == np.object_
         assert new_mgr.iget(3).dtype == np.int64
         assert new_mgr.iget(4).dtype == np.float64
@@ -612,9 +612,9 @@ class TestBlockManager:
         mgr.iset(0, np.array(["1"] * N, dtype=np.object_))
         mgr.iset(1, np.array(["2."] * N, dtype=np.object_))
         mgr.iset(2, np.array(["foo."] * N, dtype=np.object_))
-        new_mgr = mgr.convert(numeric=True)
-        assert new_mgr.iget(0).dtype == np.int64
-        assert new_mgr.iget(1).dtype == np.float64
+        new_mgr = mgr.convert()
+        assert new_mgr.iget(0).dtype == np.object_
+        assert new_mgr.iget(1).dtype == np.object_
         assert new_mgr.iget(2).dtype == np.object_
         assert new_mgr.iget(3).dtype == np.int32
         assert new_mgr.iget(4).dtype == np.bool_

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -627,7 +627,7 @@ class TestReadHtml:
         ]
         dfnew = df.applymap(try_remove_ws).replace(old, new)
         gtnew = ground_truth.applymap(try_remove_ws)
-        converted = dfnew._convert(datetime=True, numeric=True)
+        converted = dfnew._convert(datetime=True)
         date_cols = ["Closing Date", "Updated Date"]
         converted[date_cols] = converted[date_cols].apply(to_datetime)
         tm.assert_frame_equal(converted, gtnew)

--- a/pandas/tests/series/methods/test_convert.py
+++ b/pandas/tests/series/methods/test_convert.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-import numpy as np
 import pytest
 
 from pandas import (
@@ -19,36 +18,27 @@ class TestConvert:
         # Test coercion with mixed types
         ser = Series(["a", "3.1415", dt, td])
 
-        results = ser._convert(numeric=True)
-        expected = Series([np.nan, 3.1415, np.nan, np.nan])
-        tm.assert_series_equal(results, expected)
-
         # Test standard conversion returns original
         results = ser._convert(datetime=True)
         tm.assert_series_equal(results, ser)
-        results = ser._convert(numeric=True)
-        expected = Series([np.nan, 3.1415, np.nan, np.nan])
-        tm.assert_series_equal(results, expected)
+
         results = ser._convert(timedelta=True)
         tm.assert_series_equal(results, ser)
 
     def test_convert_numeric_strings_with_other_true_args(self):
         # test pass-through and non-conversion when other types selected
         ser = Series(["1.0", "2.0", "3.0"])
-        results = ser._convert(datetime=True, numeric=True, timedelta=True)
-        expected = Series([1.0, 2.0, 3.0])
-        tm.assert_series_equal(results, expected)
-        results = ser._convert(True, False, True)
+        results = ser._convert(datetime=True, timedelta=True)
         tm.assert_series_equal(results, ser)
 
     def test_convert_datetime_objects(self):
         ser = Series(
             [datetime(2001, 1, 1, 0, 0), datetime(2001, 1, 1, 0, 0)], dtype="O"
         )
-        results = ser._convert(datetime=True, numeric=True, timedelta=True)
+        results = ser._convert(datetime=True, timedelta=True)
         expected = Series([datetime(2001, 1, 1, 0, 0), datetime(2001, 1, 1, 0, 0)])
         tm.assert_series_equal(results, expected)
-        results = ser._convert(datetime=False, numeric=True, timedelta=True)
+        results = ser._convert(datetime=False, timedelta=True)
         tm.assert_series_equal(results, ser)
 
     def test_convert_datetime64(self):
@@ -74,45 +64,11 @@ class TestConvert:
     def test_convert_timedeltas(self):
         td = datetime(2001, 1, 1, 0, 0) - datetime(2000, 1, 1, 0, 0)
         ser = Series([td, td], dtype="O")
-        results = ser._convert(datetime=True, numeric=True, timedelta=True)
+        results = ser._convert(datetime=True, timedelta=True)
         expected = Series([td, td])
         tm.assert_series_equal(results, expected)
-        results = ser._convert(True, True, False)
+        results = ser._convert(datetime=True, timedelta=False)
         tm.assert_series_equal(results, ser)
-
-    def test_convert_numeric_strings(self):
-        ser = Series([1.0, 2, 3], index=["a", "b", "c"])
-        result = ser._convert(numeric=True)
-        tm.assert_series_equal(result, ser)
-
-        # force numeric conversion
-        res = ser.copy().astype("O")
-        res["a"] = "1"
-        result = res._convert(numeric=True)
-        tm.assert_series_equal(result, ser)
-
-        res = ser.copy().astype("O")
-        res["a"] = "1."
-        result = res._convert(numeric=True)
-        tm.assert_series_equal(result, ser)
-
-        res = ser.copy().astype("O")
-        res["a"] = "garbled"
-        result = res._convert(numeric=True)
-        expected = ser.copy()
-        expected["a"] = np.nan
-        tm.assert_series_equal(result, expected)
-
-    def test_convert_mixed_type_noop(self):
-        # GH 4119, not converting a mixed type (e.g.floats and object)
-        ser = Series([1, "na", 3, 4])
-        result = ser._convert(datetime=True, numeric=True)
-        expected = Series([1, np.nan, 3, 4])
-        tm.assert_series_equal(result, expected)
-
-        ser = Series([1, "", 3, 4])
-        result = ser._convert(datetime=True, numeric=True)
-        tm.assert_series_equal(result, expected)
 
     def test_convert_preserve_non_object(self):
         # preserve if non-object
@@ -122,18 +78,17 @@ class TestConvert:
 
     def test_convert_no_arg_error(self):
         ser = Series(["1.0", "2"])
-        msg = r"At least one of datetime, numeric or timedelta must be True\."
+        msg = r"At least one of datetime or timedelta must be True\."
         with pytest.raises(ValueError, match=msg):
             ser._convert()
 
     def test_convert_preserve_bool(self):
         ser = Series([1, True, 3, 5], dtype=object)
-        res = ser._convert(datetime=True, numeric=True)
-        expected = Series([1, 1, 3, 5], dtype="i8")
-        tm.assert_series_equal(res, expected)
+        res = ser._convert(datetime=True)
+        tm.assert_series_equal(res, ser)
 
     def test_convert_preserve_all_bool(self):
         ser = Series([False, True, False, False], dtype=object)
-        res = ser._convert(datetime=True, numeric=True)
+        res = ser._convert(datetime=True)
         expected = Series([False, True, False, False], dtype=bool)
         tm.assert_series_equal(res, expected)


### PR DESCRIPTION
Moving towards getting rid of _convert and soft_convert_objects and just using infer_objects and maybe_infer_objects