### PR TITLE
DEV: enable liveserver for docs on gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -32,6 +32,7 @@ vscode:
     - yzhang.markdown-all-in-one
     - eamodio.gitlens
     - lextudio.restructuredtext
+    - ritwickdey.liveserver
     # add or remove what you think is generally useful to most contributors
     # avoid adding too many. they each open a pop-up window
 


### PR DESCRIPTION
Another follow-up for https://github.com/pandas-dev/pandas/issues/47790