### PR TITLE
test: Add test for loc assignment changes datetime dtype

### DIFF
--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -29,6 +29,7 @@ from pandas import (
     date_range,
     isna,
     notna,
+    to_datetime,
 )
 import pandas._testing as tm
 
@@ -1453,6 +1454,32 @@ class TestDataFrameIndexing:
             {"c": [1, 2]}, index=Index([True, False], name="b", dtype=dtype)
         )
         tm.assert_frame_equal(result, expected)
+
+    @pytest.mark.parametrize("utc", [False, True])
+    @pytest.mark.parametrize("column_label_array", [False, True])
+    def test_loc_datetime_assignment_dtype_does_not_change(
+        self, utc, column_label_array
+    ):
+        # GH#49837
+        df = DataFrame(
+            {
+                "date": to_datetime(
+                    [datetime(2022, 1, 20), datetime(2022, 1, 22)], utc=utc
+                ),
+                "update": [True, False],
+            }
+        )
+        expected = df.copy(deep=True)
+
+        update_df = df[df["update"]]
+
+        column = "date"
+        if column_label_array:
+            column = [column]
+
+        df.loc[df["update"], column] = update_df["date"]
+
+        tm.assert_frame_equal(df, expected)
 
 
 class TestDataFrameIndexingUInt64:

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -1456,10 +1456,8 @@ class TestDataFrameIndexing:
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize("utc", [False, True])
-    @pytest.mark.parametrize("column_label_array", [False, True])
-    def test_loc_datetime_assignment_dtype_does_not_change(
-        self, utc, column_label_array
-    ):
+    @pytest.mark.parametrize("indexer", ["date", ["date"]])
+    def test_loc_datetime_assignment_dtype_does_not_change(self, utc, indexer):
         # GH#49837
         df = DataFrame(
             {
@@ -1473,11 +1471,7 @@ class TestDataFrameIndexing:
 
         update_df = df[df["update"]]
 
-        column = "date"
-        if column_label_array:
-            column = [column]
-
-        df.loc[df["update"], column] = update_df["date"]
+        df.loc[df["update"], indexer] = update_df["date"]
 
         tm.assert_frame_equal(df, expected)
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -5,6 +5,7 @@ from datetime import (
     datetime,
     time,
     timedelta,
+    timezone,
 )
 import re
 
@@ -2969,6 +2970,27 @@ def test_loc_periodindex_3_levels():
     )
     mi_series = mi_series.set_index(["ONE", "TWO"], append=True)["VALUES"]
     assert mi_series.loc[(p_index[0], "A", "B")] == 1.0
+
+
+@pytest.mark.parametrize("utc", [False, True])
+def test_loc_datetime_assignment_dtype_does_not_change(utc):
+    # GH#49837
+    df = pd.DataFrame(
+        {
+            # Checking with and without UTC as the original bug didn't occur with utc=True
+            "date": pd.to_datetime(
+                [datetime(2022, 1, 20), datetime(2022, 1, 22)], utc=utc
+            ),
+            "update": [True, False],
+        }
+    )
+    # We don't expect the dataframe to be changes at all
+    expected = df.copy(deep=True)
+
+    update_df = df[df["update"]]
+    df.loc[df["update"], ["date"]] = update_df["date"])
+
+    tm.assert_frame_equal(df, expected)
 
 
 class TestLocSeries:

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -2971,28 +2971,6 @@ def test_loc_periodindex_3_levels():
     assert mi_series.loc[(p_index[0], "A", "B")] == 1.0
 
 
-@pytest.mark.parametrize("utc", [False, True])
-def test_loc_datetime_assignment_dtype_does_not_change(utc):
-    # GH#49837
-    df = DataFrame(
-        {
-            # Checking with and without UTC as the original bug didn't occur
-            # for utc=True
-            "date": to_datetime(
-                [datetime(2022, 1, 20), datetime(2022, 1, 22)], utc=utc
-            ),
-            "update": [True, False],
-        }
-    )
-    # We don't expect the dataframe to be changes at all
-    expected = df.copy(deep=True)
-
-    update_df = df[df["update"]]
-    df.loc[df["update"], ["date"]] = update_df["date"]
-
-    tm.assert_frame_equal(df, expected)
-
-
 class TestLocSeries:
     @pytest.mark.parametrize("val,expected", [(2**63 - 1, 3), (2**63, 4)])
     def test_loc_uint64(self, val, expected):

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -2974,10 +2974,11 @@ def test_loc_periodindex_3_levels():
 @pytest.mark.parametrize("utc", [False, True])
 def test_loc_datetime_assignment_dtype_does_not_change(utc):
     # GH#49837
-    df = pd.DataFrame(
+    df = DataFrame(
         {
-            # Checking with and without UTC as the original bug didn't occur with utc=True
-            "date": pd.to_datetime(
+            # Checking with and without UTC as the original bug didn't occur
+            # for utc=True
+            "date": to_datetime(
                 [datetime(2022, 1, 20), datetime(2022, 1, 22)], utc=utc
             ),
             "update": [True, False],
@@ -2987,7 +2988,7 @@ def test_loc_datetime_assignment_dtype_does_not_change(utc):
     expected = df.copy(deep=True)
 
     update_df = df[df["update"]]
-    df.loc[df["update"], ["date"]] = update_df["date"])
+    df.loc[df["update"], ["date"]] = update_df["date"]
 
     tm.assert_frame_equal(df, expected)
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -5,7 +5,6 @@ from datetime import (
     datetime,
     time,
     timedelta,
-    timezone,
 )
 import re
 


### PR DESCRIPTION
- [x] closes #49837
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
