### PR TITLE
ENH skip 'now' and 'today' when inferring format for array

### DIFF
--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -431,7 +431,11 @@ def first_non_null(values: ndarray) -> int:
         val = values[i]
         if checknull_with_nat_and_na(val):
             continue
-        if isinstance(val, str) and (len(val) == 0 or val in nat_strings):
+        if (
+            isinstance(val, str)
+            and
+            (len(val) == 0 or val in ("now", "today", *nat_strings))
+        ):
             continue
         return i
     else:

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2318,6 +2318,8 @@ class TestGuessDatetimeFormat:
             ["", "2011-12-30 00:00:00.000000"],
             ["NaT", "2011-12-30 00:00:00.000000"],
             ["2011-12-30 00:00:00.000000", "random_string"],
+            ["now", "2011-12-30 00:00:00.000000"],
+            ["today", "2011-12-30 00:00:00.000000"],
         ],
     )
     def test_guess_datetime_format_for_array(self, test_list):


### PR DESCRIPTION
breaking this off from https://github.com/pandas-dev/pandas/pull/49024/files

haven't added a whatsnew note as it's not user facing (yet! but it will make a difference after PDEP4)