### PR TITLE
BUG: Fix bug in maybe_convert_objects with None and nullable

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2446,7 +2446,7 @@ def maybe_convert_objects(ndarray[object] objects,
             seen.int_ = True
             floats[i] = <float64_t>val
             complexes[i] = <double complex>val
-            if not seen.null_:
+            if not seen.null_ or convert_to_nullable_integer:
                 seen.saw_int(val)
 
                 if ((seen.uint_ and seen.sint_) or
@@ -2616,10 +2616,13 @@ def maybe_convert_objects(ndarray[object] objects,
                     result = complexes
                 elif seen.float_:
                     result = floats
-                elif seen.int_:
+                elif seen.int_ or seen.uint_:
                     if convert_to_nullable_integer:
                         from pandas.core.arrays import IntegerArray
-                        result = IntegerArray(ints, mask)
+                        if seen.uint_:
+                            result = IntegerArray(uints, mask)
+                        else:
+                            result = IntegerArray(ints, mask)
                     else:
                         result = floats
                 elif seen.nan_:

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -867,7 +867,7 @@ class TestInference:
         "dtype, val", [("int64", 1), ("uint64", np.iinfo(np.int64).max + 1)]
     )
     def test_maybe_convert_objects_nullable_none(self, dtype, val):
-        # GH#
+        # GH#50043
         arr = np.array([val, None, 3], dtype="object")
         result = lib.maybe_convert_objects(arr, convert_to_nullable_integer=True)
         expected = IntegerArray(

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -864,6 +864,18 @@ class TestInference:
         tm.assert_extension_array_equal(result, exp)
 
     @pytest.mark.parametrize(
+        "dtype, val", [("int64", 1), ("uint64", np.iinfo(np.int64).max + 1)]
+    )
+    def test_maybe_convert_objects_nullable_none(self, dtype, val):
+        # GH#
+        arr = np.array([val, None, 3], dtype="object")
+        result = lib.maybe_convert_objects(arr, convert_to_nullable_integer=True)
+        expected = IntegerArray(
+            np.array([val, 0, 3], dtype=dtype), np.array([False, True, False])
+        )
+        tm.assert_extension_array_equal(result, expected)
+
+    @pytest.mark.parametrize(
         "convert_to_masked_nullable, exp",
         [
             (True, IntegerArray(np.array([2, 0], dtype="i8"), np.array([False, True]))),


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

I don't think that this is user visible right now. Stumbled on this when working on nullables for read_sql