### PR TITLE
BUG: Change FutureWarning to DeprecationWarning for inplace setitem with DataFrame.(i)loc

### DIFF
--- a/doc/source/whatsnew/v1.5.3.rst
+++ b/doc/source/whatsnew/v1.5.3.rst
@@ -48,7 +48,7 @@ Other
     as pandas works toward compatibility with SQLAlchemy 2.0.
 
 - Reverted deprecation (:issue:`45324`) of behavior of :meth:`Series.__getitem__` and :meth:`Series.__setitem__` slicing with an integer :class:`Index`; this will remain positional (:issue:`49612`)
-- A ``FutureWarning`` raised when attempting to set values inplace with `:meth:`DataFrame.loc` or `:meth:`DataFrame.loc`` has been changed to a ``DeprecationWarning`` (:issue:`48673`)
+- A ``FutureWarning`` raised when attempting to set values inplace with :meth:`DataFrame.loc` or :meth:`DataFrame.loc` has been changed to a ``DeprecationWarning`` (:issue:`48673`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.5.3.rst
+++ b/doc/source/whatsnew/v1.5.3.rst
@@ -33,6 +33,7 @@ Bug fixes
 - Bug when chaining several :meth:`.Styler.concat` calls, only the last styler was concatenated (:issue:`49207`)
 - Fixed bug when instantiating a :class:`DataFrame` subclass inheriting from ``typing.Generic`` that triggered a ``UserWarning`` on python 3.11 (:issue:`49649`)
 - Bug in :func:`pandas.testing.assert_series_equal` (and equivalent ``assert_`` functions) when having nested data and using numpy >= 1.25 (:issue:`50360`)
+- Bug in :meth:`DataFrame.loc` leading to unwanted `FutureWarning` (:issue:`48673`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.5.3.rst
+++ b/doc/source/whatsnew/v1.5.3.rst
@@ -33,7 +33,6 @@ Bug fixes
 - Bug when chaining several :meth:`.Styler.concat` calls, only the last styler was concatenated (:issue:`49207`)
 - Fixed bug when instantiating a :class:`DataFrame` subclass inheriting from ``typing.Generic`` that triggered a ``UserWarning`` on python 3.11 (:issue:`49649`)
 - Bug in :func:`pandas.testing.assert_series_equal` (and equivalent ``assert_`` functions) when having nested data and using numpy >= 1.25 (:issue:`50360`)
-- Bug in :meth:`DataFrame.loc` leading to unwanted `FutureWarning` (:issue:`48673`)
 -
 
 .. ---------------------------------------------------------------------------
@@ -49,6 +48,7 @@ Other
     as pandas works toward compatibility with SQLAlchemy 2.0.
 
 - Reverted deprecation (:issue:`45324`) of behavior of :meth:`Series.__getitem__` and :meth:`Series.__setitem__` slicing with an integer :class:`Index`; this will remain positional (:issue:`49612`)
+- A ``FutureWarning`` raised when attempting to set values inplace with `:meth:`DataFrame.loc` or `:meth:`DataFrame.loc`` has been changed to a ``DeprecationWarning`` (:issue:`48673`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2031,7 +2031,6 @@ class _iLocIndexer(_LocationIndexer):
                 )
                 # TODO: how to get future behavior?
                 # TODO: what if we got here indirectly via loc?
-                pass
         return
 
     def _setitem_single_block(self, indexer, value, name: str):

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2026,11 +2026,12 @@ class _iLocIndexer(_LocationIndexer):
                     "array. To retain the old behavior, use either "
                     "`df[df.columns[i]] = newvals` or, if columns are non-unique, "
                     "`df.isetitem(i, newvals)`",
-                    FutureWarning,
+                    DeprecationWarning,
                     stacklevel=find_stack_level(),
                 )
                 # TODO: how to get future behavior?
                 # TODO: what if we got here indirectly via loc?
+                pass
         return
 
     def _setitem_single_block(self, indexer, value, name: str):

--- a/pandas/tests/extension/base/setitem.py
+++ b/pandas/tests/extension/base/setitem.py
@@ -400,7 +400,7 @@ class BaseSetitemTests(BaseExtensionTests):
         warn = None
         if has_can_hold_element and not isinstance(data.dtype, PandasDtype):
             # PandasDtype excluded because it isn't *really* supported.
-            warn = FutureWarning
+            warn = DeprecationWarning
 
         with tm.assert_produces_warning(warn, match=msg):
             df.iloc[:] = df

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -785,7 +785,7 @@ class TestDataFrameIndexing:
         assert len(result) == 5
 
         cp = df.copy()
-        warn = FutureWarning if using_array_manager else None
+        warn = DeprecationWarning if using_array_manager else None
         msg = "will attempt to set the values inplace"
         with tm.assert_produces_warning(warn, match=msg):
             cp.loc[1.0:5.0] = 0

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -408,7 +408,7 @@ class TestDataFrameSetItem:
 
     def test_setitem_frame_duplicate_columns(self, using_array_manager):
         # GH#15695
-        warn = FutureWarning if using_array_manager else None
+        warn = DeprecationWarning if using_array_manager else None
         msg = "will attempt to set the values inplace"
 
         cols = ["A", "B", "C"] * 2

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -384,7 +384,7 @@ class TestDataFrameIndexingWhere:
         expected = df.copy()
         expected.loc[[0, 1], "A"] = np.nan
 
-        warn = FutureWarning if using_array_manager else None
+        warn = DeprecationWarning if using_array_manager else None
         msg = "will attempt to set the values inplace"
         with tm.assert_produces_warning(warn, match=msg):
             expected.loc[:, "C"] = np.nan
@@ -571,7 +571,7 @@ class TestDataFrameIndexingWhere:
 
         d2 = df.copy().drop(1, axis=1)
         expected = df.copy()
-        warn = FutureWarning if using_array_manager else None
+        warn = DeprecationWarning if using_array_manager else None
         msg = "will attempt to set the values inplace"
         with tm.assert_produces_warning(warn, match=msg):
             expected.loc[:, 1] = np.nan

--- a/pandas/tests/frame/methods/test_dropna.py
+++ b/pandas/tests/frame/methods/test_dropna.py
@@ -221,7 +221,7 @@ class TestDataFrameMissingData:
         df.iloc[0, 0] = np.nan
         df.iloc[1, 1] = np.nan
         msg = "will attempt to set the values inplace instead"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
             df.iloc[:, 3] = np.nan
         expected = df.dropna(subset=["A", "B", "C"], how="all")
         expected.columns = ["A", "A", "B", "C"]

--- a/pandas/tests/frame/methods/test_rename.py
+++ b/pandas/tests/frame/methods/test_rename.py
@@ -178,7 +178,9 @@ class TestRename:
 
         # TODO(CoW) this also shouldn't warn in case of CoW, but the heuristic
         # checking if the array shares memory doesn't work if CoW happened
-        with tm.assert_produces_warning(FutureWarning if using_copy_on_write else None):
+        with tm.assert_produces_warning(
+            DeprecationWarning if using_copy_on_write else None
+        ):
             # This loc setitem already happens inplace, so no warning
             #  that this will change in the future
             renamed.loc[:, "foo"] = 1.0

--- a/pandas/tests/frame/methods/test_shift.py
+++ b/pandas/tests/frame/methods/test_shift.py
@@ -372,7 +372,7 @@ class TestDataFrameShift:
 
         warn = None
         if using_array_manager:
-            warn = FutureWarning
+            warn = DeprecationWarning
 
         shifted = []
         for columns in column_lists:

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2604,7 +2604,9 @@ class TestDataFrameConstructors:
 
         # FIXME(GH#35417): until GH#35417, iloc.setitem into EA values does not preserve
         #  view, so we have to check in the other direction
-        with tm.assert_produces_warning(DeprecationWarning, match="will attempt to set"):
+        with tm.assert_produces_warning(
+            DeprecationWarning, match="will attempt to set"
+        ):
             df.iloc[:, 2] = pd.array([45, 46], dtype=c.dtype)
         assert df.dtypes.iloc[2] == c.dtype
         if not copy and not using_copy_on_write:

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2604,7 +2604,7 @@ class TestDataFrameConstructors:
 
         # FIXME(GH#35417): until GH#35417, iloc.setitem into EA values does not preserve
         #  view, so we have to check in the other direction
-        with tm.assert_produces_warning(FutureWarning, match="will attempt to set"):
+        with tm.assert_produces_warning(DeprecationWarning, match="will attempt to set"):
             df.iloc[:, 2] = pd.array([45, 46], dtype=c.dtype)
         assert df.dtypes.iloc[2] == c.dtype
         if not copy and not using_copy_on_write:

--- a/pandas/tests/frame/test_nonunique_indexes.py
+++ b/pandas/tests/frame/test_nonunique_indexes.py
@@ -323,7 +323,9 @@ class TestDataFrameNonuniqueIndexes:
     def test_set_value_by_index(self, using_array_manager):
         # See gh-12344
         warn = (
-            FutureWarning if using_array_manager and not is_platform_windows() else None
+            DeprecationWarning
+            if using_array_manager and not is_platform_windows()
+            else None
         )
         msg = "will attempt to set the values inplace"
 

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -23,7 +23,7 @@ from pandas.core.reshape import reshape as reshape_lib
 
 class TestDataFrameReshape:
     def test_stack_unstack(self, float_frame, using_array_manager):
-        warn = FutureWarning if using_array_manager else None
+        warn = DeprecationWarning if using_array_manager else None
         msg = "will attempt to set the values inplace"
 
         df = float_frame.copy()

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -541,9 +541,9 @@ def test_loc_setitem_single_column_slice():
     )
     expected = df.copy()
     msg = "will attempt to set the values inplace instead"
-    with tm.assert_produces_warning(FutureWarning, match=msg):
+    with tm.assert_produces_warning(DeprecationWarning, match=msg):
         df.loc[:, "B"] = np.arange(4)
-    with tm.assert_produces_warning(FutureWarning, match=msg):
+    with tm.assert_produces_warning(DeprecationWarning, match=msg):
         expected.iloc[:, 2] = np.arange(4)
     tm.assert_frame_equal(df, expected)
 

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -84,7 +84,7 @@ class TestiLocBaseIndependent:
         overwrite = isinstance(key, slice) and key == slice(None)
         warn = None
         if overwrite:
-            warn = FutureWarning
+            warn = DeprecationWarning
         msg = "will attempt to set the values inplace instead"
         with tm.assert_produces_warning(warn, match=msg):
             indexer(df)[key, 0] = cat
@@ -108,7 +108,7 @@ class TestiLocBaseIndependent:
         frame = DataFrame({0: np.array([0, 1, 2], dtype=object), 1: range(3)})
         df = frame.copy()
         orig_vals = df.values
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
             indexer(df)[key, 0] = cat
         expected = DataFrame({0: cat, 1: range(3)})
         tm.assert_frame_equal(df, expected)
@@ -904,7 +904,7 @@ class TestiLocBaseIndependent:
 
         # This should modify our original values in-place
         msg = "will attempt to set the values inplace instead"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
             df.iloc[:, 0] = cat[::-1]
 
         if not using_copy_on_write:
@@ -1314,7 +1314,7 @@ class TestILocSetItemDuplicateColumns:
         # GH#22035
         df = DataFrame([[init_value, "str", "str2"]], columns=["a", "b", "b"])
         msg = "will attempt to set the values inplace instead"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
             df.iloc[:, 0] = df.iloc[:, 0].astype(dtypes)
 
         expected_df = DataFrame(

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -550,7 +550,7 @@ class TestFancy:
 
         df = df_orig.copy()
         msg = "will attempt to set the values inplace instead"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
             df.iloc[:, 0:2] = df.iloc[:, 0:2].astype(np.int64)
         expected = DataFrame(
             [[1, 2, "3", ".4", 5, 6.0, "foo"]], columns=list("ABCDEFG")
@@ -558,7 +558,7 @@ class TestFancy:
         tm.assert_frame_equal(df, expected)
 
         df = df_orig.copy()
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
             df.iloc[:, 0:2] = df.iloc[:, 0:2]._convert(datetime=True, numeric=True)
         expected = DataFrame(
             [[1, 2, "3", ".4", 5, 6.0, "foo"]], columns=list("ABCDEFG")
@@ -567,7 +567,7 @@ class TestFancy:
 
         # GH5702 (loc)
         df = df_orig.copy()
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
             df.loc[:, "A"] = df.loc[:, "A"].astype(np.int64)
         expected = DataFrame(
             [[1, "2", "3", ".4", 5, 6.0, "foo"]], columns=list("ABCDEFG")
@@ -575,7 +575,7 @@ class TestFancy:
         tm.assert_frame_equal(df, expected)
 
         df = df_orig.copy()
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
             df.loc[:, ["B", "C"]] = df.loc[:, ["B", "C"]].astype(np.int64)
         expected = DataFrame(
             [["1", 2, 3, ".4", 5, 6.0, "foo"]], columns=list("ABCDEFG")
@@ -586,13 +586,13 @@ class TestFancy:
         # full replacements / no nans
         df = DataFrame({"A": [1.0, 2.0, 3.0, 4.0]})
         msg = "will attempt to set the values inplace instead"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
             df.iloc[:, 0] = df["A"].astype(np.int64)
         expected = DataFrame({"A": [1, 2, 3, 4]})
         tm.assert_frame_equal(df, expected)
 
         df = DataFrame({"A": [1.0, 2.0, 3.0, 4.0]})
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
             df.loc[:, "A"] = df["A"].astype(np.int64)
         expected = DataFrame({"A": [1, 2, 3, 4]})
         tm.assert_frame_equal(df, expected)

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -3211,3 +3211,11 @@ class TestLocSeries:
         index = pd.period_range(start="2000", periods=20, freq="B")
         series = Series(range(20), index=index)
         assert series.loc["2000-01-14"] == 9
+
+    def test_deprecation_warnings_raised_loc(self):
+        # GH#48673
+        with tm.assert_produces_warning(DeprecationWarning):
+            values = np.arange(4).reshape(2, 2)
+            df = DataFrame(values, columns=["a", "b"])
+            new = np.array([10, 11]).astype(np.int16)
+            df.loc[:, "a"] = new

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -368,7 +368,7 @@ class TestLocBaseIndependent:
         df = DataFrame({"id": ["A"], "a": [1.2], "b": [0.0], "c": [-2.5]})
         cols = ["a", "b", "c"]
         msg = "will attempt to set the values inplace instead"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
             df.loc[:, cols] = df.loc[:, cols].astype("float32")
 
         expected = DataFrame(
@@ -633,11 +633,11 @@ class TestLocBaseIndependent:
         df = DataFrame(values, index=mi, columns=cols)
 
         msg = "will attempt to set the values inplace instead"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
             df.loc[:, ("Respondent", "StartDate")] = to_datetime(
                 df.loc[:, ("Respondent", "StartDate")]
             )
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
             df.loc[:, ("Respondent", "EndDate")] = to_datetime(
                 df.loc[:, ("Respondent", "EndDate")]
             )
@@ -720,7 +720,7 @@ class TestLocBaseIndependent:
         df = DataFrame(index=[3, 5, 4], columns=["A", "B"], dtype=float)
         df["B"] = "string"
         msg = "will attempt to set the values inplace instead"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
             df.loc[[4, 3, 5], "A"] = np.array([1, 2, 3], dtype="int64")
         ser = Series([2, 3, 1], index=[3, 5, 4], dtype="int64")
         expected = DataFrame({"A": ser})
@@ -732,7 +732,7 @@ class TestLocBaseIndependent:
         df = DataFrame(index=[1, 2, 3], columns=["A", "B"], dtype=float)
         df["B"] = "string"
         msg = "will attempt to set the values inplace instead"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
             df.loc[slice(3, 0, -1), "A"] = np.array([1, 2, 3], dtype="int64")
         expected = DataFrame({"A": [3, 2, 1], "B": "string"}, index=[1, 2, 3])
         tm.assert_frame_equal(df, expected)
@@ -909,7 +909,7 @@ class TestLocBaseIndependent:
 
         warn = None
         if isinstance(index[0], slice) and index[0] == slice(None):
-            warn = FutureWarning
+            warn = DeprecationWarning
 
         msg = "will attempt to set the values inplace instead"
         with tm.assert_produces_warning(warn, match=msg):
@@ -1425,7 +1425,7 @@ class TestLocBaseIndependent:
         categories = Categorical(df["Alpha"], categories=["a", "b", "c"])
 
         msg = "will attempt to set the values inplace instead"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
             df.loc[:, "Alpha"] = categories
 
         result = df["Alpha"]

--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -312,7 +312,7 @@ class TestPartialSetting:
         df = df_orig.copy()
         df["B"] = df["B"].astype(np.float64)
         msg = "will attempt to set the values inplace instead"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
             df.loc[:, "B"] = df.loc[:, "A"]
         tm.assert_frame_equal(df, expected)
 


### PR DESCRIPTION
- [X] closes #48673 
- [X] [Tests added and passed](
- [ ] Added [type annotations]
- [ ] All [code checks passed].
- [X] Added an entry in the latest `doc/source/whatsnew/v1.5.3.rst` file.
