### PR TITLE
ENH: maybe_convert_objects add boolean support with NA

### DIFF
--- a/pandas/_libs/lib.pyi
+++ b/pandas/_libs/lib.pyi
@@ -75,7 +75,7 @@ def maybe_convert_objects(
     convert_timedelta: Literal[False] = ...,
     convert_period: Literal[False] = ...,
     convert_interval: Literal[False] = ...,
-    convert_to_nullable_integer: Literal[False] = ...,
+    convert_to_nullable_dtype: Literal[False] = ...,
     dtype_if_all_nat: DtypeObj | None = ...,
 ) -> npt.NDArray[np.object_ | np.number]: ...
 @overload  # both convert_datetime and convert_to_nullable_integer False -> np.ndarray
@@ -88,7 +88,7 @@ def maybe_convert_objects(
     convert_timedelta: bool = ...,
     convert_period: Literal[False] = ...,
     convert_interval: Literal[False] = ...,
-    convert_to_nullable_integer: Literal[False] = ...,
+    convert_to_nullable_dtype: Literal[False] = ...,
     dtype_if_all_nat: DtypeObj | None = ...,
 ) -> np.ndarray: ...
 @overload
@@ -101,7 +101,7 @@ def maybe_convert_objects(
     convert_timedelta: bool = ...,
     convert_period: bool = ...,
     convert_interval: bool = ...,
-    convert_to_nullable_integer: Literal[True] = ...,
+    convert_to_nullable_dtype: Literal[True] = ...,
     dtype_if_all_nat: DtypeObj | None = ...,
 ) -> ArrayLike: ...
 @overload
@@ -114,7 +114,7 @@ def maybe_convert_objects(
     convert_timedelta: bool = ...,
     convert_period: bool = ...,
     convert_interval: bool = ...,
-    convert_to_nullable_integer: bool = ...,
+    convert_to_nullable_dtype: bool = ...,
     dtype_if_all_nat: DtypeObj | None = ...,
 ) -> ArrayLike: ...
 @overload
@@ -127,7 +127,7 @@ def maybe_convert_objects(
     convert_timedelta: bool = ...,
     convert_period: Literal[True] = ...,
     convert_interval: bool = ...,
-    convert_to_nullable_integer: bool = ...,
+    convert_to_nullable_dtype: bool = ...,
     dtype_if_all_nat: DtypeObj | None = ...,
 ) -> ArrayLike: ...
 @overload
@@ -140,7 +140,7 @@ def maybe_convert_objects(
     convert_timedelta: bool = ...,
     convert_period: bool = ...,
     convert_interval: bool = ...,
-    convert_to_nullable_integer: bool = ...,
+    convert_to_nullable_dtype: bool = ...,
     dtype_if_all_nat: DtypeObj | None = ...,
 ) -> ArrayLike: ...
 @overload

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -1315,6 +1315,14 @@ cdef class Seen:
             or self.numeric_ or self.nan_ or self.null_ or self.object_
         )
 
+    @property
+    def is_bool_or_na(self):
+        # i.e. not (anything but bool or missing values)
+        return not (
+            self.datetime_ or self.datetimetz_ or self.nat_ or self.timedelta_
+            or self.period_ or self.interval_ or self.numeric_ or self.object_
+        )
+
 
 cdef object _try_infer_map(object dtype):
     """
@@ -2335,7 +2343,7 @@ def maybe_convert_objects(ndarray[object] objects,
                           bint convert_timedelta=False,
                           bint convert_period=False,
                           bint convert_interval=False,
-                          bint convert_to_nullable_integer=False,
+                          bint convert_to_nullable_dtype=False,
                           object dtype_if_all_nat=None) -> "ArrayLike":
     """
     Type inference function-- convert object array to proper dtype
@@ -2362,9 +2370,9 @@ def maybe_convert_objects(ndarray[object] objects,
     convert_interval : bool, default False
         If an array-like object contains only Interval objects (with matching
         dtypes and closedness) or NaN, whether to convert to IntervalArray.
-    convert_to_nullable_integer : bool, default False
-        If an array-like object contains only integer values (and NaN) is
-        encountered, whether to convert and return an IntegerArray.
+    convert_to_nullable_dtype : bool, default False
+        If an array-like object contains only integer or boolean values (and NaN) is
+        encountered, whether to convert and return an Boolean/IntegerArray.
     dtype_if_all_nat : np.dtype, ExtensionDtype, or None, default None
         Dtype to cast to if we have all-NaT.
 
@@ -2606,6 +2614,9 @@ def maybe_convert_objects(ndarray[object] objects,
         if seen.is_bool:
             # is_bool property rules out everything else
             return bools.view(np.bool_)
+        elif convert_to_nullable_dtype and seen.is_bool_or_na:
+            from pandas.core.arrays import BooleanArray
+            return BooleanArray(bools.view(np.bool_), mask)
         seen.object_ = True
 
     if not seen.object_:
@@ -2617,7 +2628,7 @@ def maybe_convert_objects(ndarray[object] objects,
                 elif seen.float_:
                     result = floats
                 elif seen.int_:
-                    if convert_to_nullable_integer:
+                    if convert_to_nullable_dtype:
                         from pandas.core.arrays import IntegerArray
                         result = IntegerArray(ints, mask)
                     else:

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2454,7 +2454,7 @@ def maybe_convert_objects(ndarray[object] objects,
             seen.int_ = True
             floats[i] = <float64_t>val
             complexes[i] = <double complex>val
-            if not seen.null_ or convert_to_nullable_integer:
+            if not seen.null_ or convert_to_nullable_dtype:
                 seen.saw_int(val)
 
                 if ((seen.uint_ and seen.sint_) or

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -1309,16 +1309,12 @@ cdef class Seen:
     @property
     def is_bool(self):
         # i.e. not (anything but bool)
-        return not (
-            self.datetime_ or self.datetimetz_ or self.timedelta_ or self.nat_
-            or self.period_ or self.interval_
-            or self.numeric_ or self.nan_ or self.null_ or self.object_
-        )
+        return self.is_bool_or_na and not (self.nan_ or self.null_)
 
     @property
     def is_bool_or_na(self):
         # i.e. not (anything but bool or missing values)
-        return not (
+        return self.bool_ and not (
             self.datetime_ or self.datetimetz_ or self.nat_ or self.timedelta_
             or self.period_ or self.interval_ or self.numeric_ or self.object_
         )

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -859,7 +859,7 @@ class TestInference:
     def test_maybe_convert_objects_nullable_integer(self, exp):
         # GH27335
         arr = np.array([2, np.NaN], dtype=object)
-        result = lib.maybe_convert_objects(arr, convert_to_nullable_integer=True)
+        result = lib.maybe_convert_objects(arr, convert_to_nullable_dtype=True)
 
         tm.assert_extension_array_equal(result, exp)
 
@@ -917,6 +917,28 @@ class TestInference:
         exp = np.array([True, False, np.nan], dtype=object)
         out = lib.maybe_convert_objects(ind.values, safe=1)
         tm.assert_numpy_array_equal(out, exp)
+
+    def test_maybe_convert_objects_nullable_boolean(self):
+        # GH
+        arr = np.array([True, False], dtype=object)
+        exp = np.array([True, False])
+        out = lib.maybe_convert_objects(arr, convert_to_nullable_dtype=True)
+        tm.assert_numpy_array_equal(out, exp)
+
+        arr = np.array([True, False, pd.NaT], dtype=object)
+        exp = np.array([True, False, pd.NaT], dtype=object)
+        out = lib.maybe_convert_objects(arr, convert_to_nullable_dtype=True)
+        tm.assert_numpy_array_equal(out, exp)
+
+    @pytest.mark.parametrize("val", [None, np.nan])
+    def test_maybe_convert_objects_nullable_boolean_na(self, val):
+        # GH
+        arr = np.array([True, False, val], dtype=object)
+        exp = BooleanArray(
+            np.array([True, False, False]), np.array([False, False, True])
+        )
+        out = lib.maybe_convert_objects(arr, convert_to_nullable_dtype=True)
+        tm.assert_extension_array_equal(out, exp)
 
     @pytest.mark.parametrize(
         "data0",

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -869,7 +869,7 @@ class TestInference:
     def test_maybe_convert_objects_nullable_none(self, dtype, val):
         # GH#50043
         arr = np.array([val, None, 3], dtype="object")
-        result = lib.maybe_convert_objects(arr, convert_to_nullable_integer=True)
+        result = lib.maybe_convert_objects(arr, convert_to_nullable_dtype=True)
         expected = IntegerArray(
             np.array([val, 0, 3], dtype=dtype), np.array([False, True, False])
         )

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -931,7 +931,7 @@ class TestInference:
         tm.assert_numpy_array_equal(out, exp)
 
     def test_maybe_convert_objects_nullable_boolean(self):
-        # GH
+        # GH50047
         arr = np.array([True, False], dtype=object)
         exp = np.array([True, False])
         out = lib.maybe_convert_objects(arr, convert_to_nullable_dtype=True)
@@ -944,7 +944,7 @@ class TestInference:
 
     @pytest.mark.parametrize("val", [None, np.nan])
     def test_maybe_convert_objects_nullable_boolean_na(self, val):
-        # GH
+        # GH50047
         arr = np.array([True, False, val], dtype=object)
         exp = BooleanArray(
             np.array([True, False, False]), np.array([False, False, True])


### PR DESCRIPTION
This is necessary for read_sql and nullables.

I could not find a usage of ``convert_to_nullable_integer``, so we should be able to repurpose the keyword

