### PR TITLE
TST: add test for nested OrderedDict in constructor

### DIFF
--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1396,6 +1396,7 @@ class TestDataFrameConstructors:
         tm.assert_frame_equal(result, expected)
 
     def test_constructor_ordered_dict_nested_preserve_order(self):
+        # see gh-18166
         nested1 = OrderedDict([("b", 1), ("a", 2)])
         nested2 = OrderedDict([("b", 2), ("a", 5)])
         data = OrderedDict([("col2", nested1), ("col1", nested2)])

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1395,6 +1395,15 @@ class TestDataFrameConstructors:
         expected = DataFrame(index=[0])
         tm.assert_frame_equal(result, expected)
 
+    def test_constructor_ordered_dict_nested_preserve_order(self):
+        nested1 = OrderedDict([("b", 1), ("a", 2)])
+        nested2 = OrderedDict([("b", 2), ("a", 5)])
+        data = OrderedDict([("col2", nested1), ("col1", nested2)])
+        result = DataFrame(data)
+        data = {"col2": [1, 2], "col1": [2, 5]}
+        expected = DataFrame(data=data, index=["b", "a"])
+        tm.assert_frame_equal(result, expected)
+
     @pytest.mark.parametrize("dict_type", [dict, OrderedDict])
     def test_constructor_ordered_dict_preserve_order(self, dict_type):
         # see gh-13304


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.


closes #18166