### PR TITLE
BUG: loc.setitem raising when expanding empty frame with array value

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -707,6 +707,7 @@ Indexing
 - Bug in :meth:`DataFrame.loc` coercing dtypes when setting values with a list indexer (:issue:`49159`)
 - Bug in :meth:`DataFrame.loc` raising ``ValueError`` with ``bool`` indexer and :class:`MultiIndex` (:issue:`47687`)
 - Bug in :meth:`DataFrame.__setitem__` raising ``ValueError`` when right hand side is :class:`DataFrame` with :class:`MultiIndex` columns (:issue:`49121`)
+- Bug in :meth:`DataFrame.loc` when expanding an empty DataFrame and setting an array-like value (:issue:`49972`)
 - Bug in :meth:`DataFrame.reindex` casting dtype to ``object`` when :class:`DataFrame` has single extension array column when re-indexing ``columns`` and ``index`` (:issue:`48190`)
 - Bug in :func:`~DataFrame.describe` when formatting percentiles in the resulting index showed more decimals than needed (:issue:`46362`)
 - Bug in :meth:`DataFrame.compare` does not recognize differences when comparing ``NA`` with value in nullable dtypes (:issue:`48939`)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1736,7 +1736,9 @@ class _iLocIndexer(_LocationIndexer):
                             arr = extract_array(value, extract_numpy=True)
                             taker = -1 * np.ones(len(self.obj), dtype=np.intp)
                             empty_value = algos.take_nd(arr, taker)
-                            if not isinstance(value, ABCSeries):
+                            if not isinstance(value, ABCSeries) and not isinstance(
+                                indexer[0], dict
+                            ):
                                 # if not Series (in which case we need to align),
                                 #  we can short-circuit
                                 empty_value[indexer[0]] = arr

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -1737,6 +1737,13 @@ class TestLocILocDataFrameCategorical:
 
         assert ser.index.dtype == object
 
+    def test_loc_setitem_empty_frame_expansion(self):
+        # GH#49972
+        result = DataFrame()
+        result.loc[0, 0] = np.asarray([0])
+        expected = DataFrame({0: [0.0]})
+        tm.assert_frame_equal(result, expected)
+
     def test_loc_on_multiindex_one_level(self):
         # GH#45779
         df = DataFrame(


### PR DESCRIPTION
- [x] closes #49972 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
