### PR TITLE
DEPR: remove some more Int/UInt/Float64Index from tests

### DIFF
--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -26,11 +26,7 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.core.api import (
-    Float64Index,
-    Int64Index,
-    UInt64Index,
-)
+from pandas.core.api import NumericIndex
 from pandas.tests.arithmetic.common import (
     assert_invalid_addsub_type,
     assert_invalid_comparison,
@@ -492,10 +488,10 @@ class TestTimedelta64ArithmeticUnsorted:
         # random indexes
         msg = "Addition/subtraction of integers and integer-arrays"
         with pytest.raises(TypeError, match=msg):
-            tdi + Int64Index([1, 2, 3])
+            tdi + NumericIndex([1, 2, 3], dtype=np.int64)
 
         # this is a union!
-        # pytest.raises(TypeError, lambda : Int64Index([1,2,3]) + tdi)
+        # pytest.raises(TypeError, lambda : Index([1,2,3]) + tdi)
 
         result = tdi + dti  # name will be reset
         expected = DatetimeIndex(["20130102", NaT, "20130105"])
@@ -1508,9 +1504,9 @@ class TestTimedeltaArraylikeMulDivOps:
         "other",
         [
             np.arange(1, 11),
-            Int64Index(range(1, 11)),
-            UInt64Index(range(1, 11)),
-            Float64Index(range(1, 11)),
+            NumericIndex(np.arange(1, 11), np.int64),
+            NumericIndex(range(1, 11), np.uint64),
+            NumericIndex(range(1, 11), np.float64),
             pd.RangeIndex(1, 11),
         ],
         ids=lambda x: type(x).__name__,
@@ -1594,7 +1590,7 @@ class TestTimedeltaArraylikeMulDivOps:
         xbox = np.ndarray if box is pd.array else box
 
         rng = timedelta_range("1 days", "10 days", name="foo")
-        expected = Float64Index((np.arange(10) + 1) * 12, name="foo")
+        expected = NumericIndex((np.arange(10) + 1) * 12, dtype=np.float64, name="foo")
 
         rng = tm.box_expected(rng, box)
         expected = tm.box_expected(expected, xbox)
@@ -1634,7 +1630,7 @@ class TestTimedeltaArraylikeMulDivOps:
         xbox = np.ndarray if box is pd.array else box
 
         rng = TimedeltaIndex(["1 days", NaT, "2 days"], name="foo")
-        expected = Float64Index([12, np.nan, 24], name="foo")
+        expected = NumericIndex([12, np.nan, 24], dtype=np.float64, name="foo")
 
         rng = tm.box_expected(rng, box)
         expected = tm.box_expected(expected, xbox)
@@ -1652,7 +1648,7 @@ class TestTimedeltaArraylikeMulDivOps:
         xbox = np.ndarray if box is pd.array else box
 
         rng = TimedeltaIndex(["1 days", NaT, "2 days"])
-        expected = Float64Index([12, np.nan, 24])
+        expected = NumericIndex([12, np.nan, 24], dtype=np.float64)
 
         rng = tm.box_expected(rng, box)
         expected = tm.box_expected(expected, xbox)

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -1829,7 +1829,6 @@ class TestNumberScalar:
         assert is_timedelta64_ns_dtype(tdi)
         assert is_timedelta64_ns_dtype(tdi.astype("timedelta64[ns]"))
 
-        # Conversion to Int64Index:
         assert not is_timedelta64_ns_dtype(Index([], dtype=np.float64))
         assert not is_timedelta64_ns_dtype(Index([], dtype=np.int64))
 

--- a/pandas/tests/dtypes/test_missing.py
+++ b/pandas/tests/dtypes/test_missing.py
@@ -33,13 +33,14 @@ from pandas.core.dtypes.missing import (
 import pandas as pd
 from pandas import (
     DatetimeIndex,
+    Index,
     NaT,
     Series,
     TimedeltaIndex,
     date_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Float64Index
+from pandas.core.api import NumericIndex
 
 fix_now = pd.Timestamp("2021-01-01")
 fix_utcnow = pd.Timestamp("2021-01-01", tz="UTC")
@@ -355,7 +356,7 @@ class TestIsNA:
         tm.assert_series_equal(result, ~expected)
 
         # index
-        idx = pd.Index(arr)
+        idx = Index(arr)
         expected = np.array([False, True])
         result = isna(idx)
         tm.assert_numpy_array_equal(result, expected)
@@ -404,10 +405,10 @@ def test_array_equivalent(dtype_equal):
         np.array(["a", "b", "c", "d"]), np.array(["e", "e"]), dtype_equal=dtype_equal
     )
     assert array_equivalent(
-        Float64Index([0, np.nan]), Float64Index([0, np.nan]), dtype_equal=dtype_equal
+        NumericIndex([0, np.nan]), NumericIndex([0, np.nan]), dtype_equal=dtype_equal
     )
     assert not array_equivalent(
-        Float64Index([0, np.nan]), Float64Index([1, np.nan]), dtype_equal=dtype_equal
+        NumericIndex([0, np.nan]), NumericIndex([1, np.nan]), dtype_equal=dtype_equal
     )
     assert array_equivalent(
         DatetimeIndex([0, np.nan]), DatetimeIndex([0, np.nan]), dtype_equal=dtype_equal
@@ -559,15 +560,15 @@ def test_array_equivalent_nested():
 
 def test_array_equivalent_index_with_tuples():
     # GH#48446
-    idx1 = pd.Index(np.array([(pd.NA, 4), (1, 1)], dtype="object"))
-    idx2 = pd.Index(np.array([(1, 1), (pd.NA, 4)], dtype="object"))
+    idx1 = Index(np.array([(pd.NA, 4), (1, 1)], dtype="object"))
+    idx2 = Index(np.array([(1, 1), (pd.NA, 4)], dtype="object"))
     assert not array_equivalent(idx1, idx2)
     assert not idx1.equals(idx2)
     assert not array_equivalent(idx2, idx1)
     assert not idx2.equals(idx1)
 
-    idx1 = pd.Index(np.array([(4, pd.NA), (1, 1)], dtype="object"))
-    idx2 = pd.Index(np.array([(1, 1), (4, pd.NA)], dtype="object"))
+    idx1 = Index(np.array([(4, pd.NA), (1, 1)], dtype="object"))
+    idx2 = Index(np.array([(1, 1), (4, pd.NA)], dtype="object"))
     assert not array_equivalent(idx1, idx2)
     assert not idx1.equals(idx2)
     assert not array_equivalent(idx2, idx1)

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -55,7 +55,6 @@ from pandas.arrays import (
     SparseArray,
     TimedeltaArray,
 )
-from pandas.core.api import Int64Index
 
 MIXED_FLOAT_DTYPES = ["float16", "float32", "float64"]
 MIXED_INT_DTYPES = [
@@ -626,7 +625,7 @@ class TestDataFrameConstructors:
         df = DataFrame([[1]], columns=[[1]], index=[1, 2])
         expected = DataFrame(
             [1, 1],
-            index=Int64Index([1, 2], dtype="int64"),
+            index=Index([1, 2], dtype="int64"),
             columns=MultiIndex(levels=[[1]], codes=[[0]]),
         )
         tm.assert_frame_equal(df, expected)

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -16,7 +16,6 @@ from pandas import (
     bdate_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 from pandas.tests.groupby import get_groupby_method_args
 
 
@@ -799,11 +798,9 @@ def test_apply_with_mixed_types():
 
 def test_func_returns_object():
     # GH 28652
-    df = DataFrame({"a": [1, 2]}, index=Int64Index([1, 2]))
+    df = DataFrame({"a": [1, 2]}, index=Index([1, 2]))
     result = df.groupby("a").apply(lambda g: g.index)
-    expected = Series(
-        [Int64Index([1]), Int64Index([2])], index=Int64Index([1, 2], name="a")
-    )
+    expected = Series([Index([1]), Index([2])], index=Index([1, 2], name="a"))
 
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -688,7 +688,7 @@ class TestGrouping:
             (
                 "agg",
                 Series(
-                    namqe=2, dtype=np.float64, index=Index([], dtype=np.float64, name=1)
+                    name=2, dtype=np.float64, index=Index([], dtype=np.float64, name=1)
                 ),
             ),
             (

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -14,10 +14,6 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
-from pandas.core.api import (
-    Float64Index,
-    Int64Index,
-)
 from pandas.core.groupby.grouper import Grouping
 
 # selection
@@ -691,11 +687,15 @@ class TestGrouping:
             ),
             (
                 "agg",
-                Series(name=2, dtype=np.float64, index=Float64Index([], name=1)),
+                Series(
+                    namqe=2, dtype=np.float64, index=Index([], dtype=np.float64, name=1)
+                ),
             ),
             (
                 "apply",
-                Series(name=2, dtype=np.float64, index=Float64Index([], name=1)),
+                Series(
+                    name=2, dtype=np.float64, index=Index([], dtype=np.float64, name=1)
+                ),
             ),
         ],
     )
@@ -759,7 +759,9 @@ class TestGrouping:
         empty = df[df.value < 0]
         result = empty.groupby("id").sum()
         expected = DataFrame(
-            dtype="float64", columns=["value"], index=Int64Index([], name="id")
+            dtype="float64",
+            columns=["value"],
+            index=Index([], dtype=np.int64, name="id"),
         )
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/groupby/test_min_max.py
+++ b/pandas/tests/groupby/test_min_max.py
@@ -10,7 +10,6 @@ from pandas import (
     Series,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 
 
 def test_max_min_non_numeric():
@@ -123,7 +122,7 @@ def test_groupby_aggregate_period_column(func):
     df = DataFrame({"a": groups, "b": periods})
 
     result = getattr(df.groupby("a")["b"], func)()
-    idx = Int64Index([1, 2], name="a")
+    idx = Index([1, 2], name="a")
     expected = Series(periods, index=idx, name="b")
 
     tm.assert_series_equal(result, expected)
@@ -137,7 +136,7 @@ def test_groupby_aggregate_period_frame(func):
     df = DataFrame({"a": groups, "b": periods})
 
     result = getattr(df.groupby("a"), func)()
-    idx = Int64Index([1, 2], name="a")
+    idx = Index([1, 2], name="a")
     expected = DataFrame({"b": periods}, index=idx)
 
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/test_pipe.py
+++ b/pandas/tests/groupby/test_pipe.py
@@ -6,7 +6,7 @@ from pandas import (
     Index,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
+from pandas.core.api import NumericIndex
 
 
 def test_pipe():
@@ -76,6 +76,6 @@ def test_pipe_args():
     ser = pd.Series([1, 1, 2, 2, 3, 3])
     result = ser.groupby(ser).pipe(lambda grp: grp.sum() * grp.count())
 
-    expected = pd.Series([4, 8, 12], index=Int64Index([1, 2, 3]))
+    expected = pd.Series([4, 8, 12], index=NumericIndex([1, 2, 3], dtype=np.int64))
 
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -32,12 +32,7 @@ from pandas import (
     period_range,
 )
 import pandas._testing as tm
-from pandas.core.api import (
-    Float64Index,
-    Int64Index,
-    NumericIndex,
-    UInt64Index,
-)
+from pandas.core.api import NumericIndex
 from pandas.core.indexes.api import (
     Index,
     MultiIndex,
@@ -194,14 +189,14 @@ class TestIndex(Base):
     def test_constructor_int_dtype_nan(self):
         # see gh-15187
         data = [np.nan]
-        expected = Float64Index(data)
+        expected = NumericIndex(data, dtype=np.float64)
         result = Index(data, dtype="float")
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize(
         "klass,dtype,na_val",
         [
-            (Float64Index, np.float64, np.nan),
+            (NumericIndex, np.float64, np.nan),
             (DatetimeIndex, "datetime64[ns]", pd.NaT),
         ],
     )
@@ -309,9 +304,7 @@ class TestIndex(Base):
         "klass",
         [
             Index,
-            Float64Index,
-            Int64Index,
-            UInt64Index,
+            NumericIndex,
             CategoricalIndex,
             DatetimeIndex,
             TimedeltaIndex,
@@ -561,7 +554,7 @@ class TestIndex(Base):
 
     def test_map_tseries_indices_accsr_return_index(self):
         date_index = tm.makeDateIndex(24, freq="h", name="hourly")
-        expected = Int64Index(range(24), name="hourly")
+        expected = Index(list(range(24)), dtype=np.int64, name="hourly")
         tm.assert_index_equal(expected, date_index.map(lambda x: x.hour), exact=True)
 
     @pytest.mark.parametrize(
@@ -875,17 +868,17 @@ class TestIndex(Base):
     def test_isin_nan_common_float64(self, nulls_fixture):
 
         if nulls_fixture is pd.NaT or nulls_fixture is pd.NA:
-            # Check 1) that we cannot construct a Float64Index with this value
+            # Check 1) that we cannot construct a float64 Index with this value
             #  and 2) that with an NaN we do not have .isin(nulls_fixture)
-            msg = "data is not compatible with Float64Index"
+            msg = "data is not compatible with NumericIndex"
             with pytest.raises(ValueError, match=msg):
-                Float64Index([1.0, nulls_fixture])
+                NumericIndex([1.0, nulls_fixture], dtype=np.float64)
 
-            idx = Float64Index([1.0, np.nan])
+            idx = NumericIndex([1.0, np.nan], dtype=np.float64)
             assert not idx.isin([nulls_fixture]).any()
             return
 
-        idx = Float64Index([1.0, nulls_fixture])
+        idx = NumericIndex([1.0, nulls_fixture], dtype=np.float64)
         res = idx.isin([np.nan])
         tm.assert_numpy_array_equal(res, np.array([False, True]))
 
@@ -898,8 +891,8 @@ class TestIndex(Base):
         "index",
         [
             Index(["qux", "baz", "foo", "bar"]),
-            # Float64Index overrides isin, so must be checked separately
-            Float64Index([1.0, 2.0, 3.0, 4.0]),
+            # float64 Index overrides isin, so must be checked separately
+            NumericIndex([1.0, 2.0, 3.0, 4.0], dtype=np.float64),
         ],
     )
     def test_isin_level_kwarg(self, level, index):
@@ -1068,7 +1061,7 @@ class TestIndex(Base):
             result = left_index.join(right_index, how="outer")
 
         # right_index in this case because DatetimeIndex has join precedence
-        # over Int64Index
+        # over int64 Index
         with tm.assert_produces_warning(RuntimeWarning):
             expected = right_index.astype(object).union(left_index.astype(object))
 
@@ -1138,8 +1131,6 @@ class TestIndex(Base):
     @pytest.mark.parametrize(
         "labels,dtype",
         [
-            (Int64Index([]), np.int64),
-            (Float64Index([]), np.float64),
             (DatetimeIndex([]), np.datetime64),
         ],
     )
@@ -1148,10 +1139,19 @@ class TestIndex(Base):
         index = Index(list("abc"))
         assert index.reindex(labels)[0].dtype.type == dtype
 
+    def test_reindex_doesnt_preserve_type_if_target_is_empty_index_numeric(
+        self, any_real_numpy_dtype
+    ):
+        # GH7774
+        dtype = any_real_numpy_dtype
+        index = Index(list("abc"))
+        labels = NumericIndex([], dtype=dtype)
+        assert index.reindex(labels)[0].dtype.type == dtype
+
     def test_reindex_no_type_preserve_target_empty_mi(self):
         index = Index(list("abc"))
         result = index.reindex(
-            MultiIndex([Int64Index([]), Float64Index([])], [[], []])
+            MultiIndex([Index([], np.int64), Index([], np.float64)], [[], []])
         )[0]
         assert result.levels[0].dtype.type == np.int64
         assert result.levels[1].dtype.type == np.float64
@@ -1541,7 +1541,7 @@ def test_deprecated_fastpath():
         Index(np.array(["a", "b"], dtype=object), name="test", fastpath=True)
 
     with pytest.raises(TypeError, match=msg):
-        Int64Index(np.array([1, 2, 3], dtype="int64"), name="test", fastpath=True)
+        Index(np.array([1, 2, 3], dtype="int64"), name="test", fastpath=True)
 
     with pytest.raises(TypeError, match=msg):
         RangeIndex(0, 5, 2, name="test", fastpath=True)
@@ -1562,40 +1562,31 @@ def test_shape_of_invalid_index():
         idx[:, None]
 
 
-def test_validate_1d_input():
+@pytest.mark.parametrize("dtype", [None, np.int64, np.uint64, np.float64])
+def test_validate_1d_input(dtype):
     # GH#27125 check that we do not have >1-dimensional input
     msg = "Index data must be 1-dimensional"
 
     arr = np.arange(8).reshape(2, 2, 2)
     with pytest.raises(ValueError, match=msg):
-        Index(arr)
-
-    with pytest.raises(ValueError, match=msg):
-        Float64Index(arr.astype(np.float64))
-
-    with pytest.raises(ValueError, match=msg):
-        Int64Index(arr.astype(np.int64))
-
-    with pytest.raises(ValueError, match=msg):
-        UInt64Index(arr.astype(np.uint64))
+        Index(arr, dtype=dtype)
 
     df = DataFrame(arr.reshape(4, 2))
     with pytest.raises(ValueError, match=msg):
-        Index(df)
+        Index(df, dtype=dtype)
 
-    # GH#13601 trying to assign a multi-dimensional array to an index is not
-    #  allowed
+    # GH#13601 trying to assign a multi-dimensional array to an index is not allowed
     ser = Series(0, range(4))
     with pytest.raises(ValueError, match=msg):
-        ser.index = np.array([[2, 3]] * 4)
+        ser.index = np.array([[2, 3]] * 4, dtype=dtype)
 
 
 @pytest.mark.parametrize(
     "klass, extra_kwargs",
     [
         [Index, {}],
-        [Int64Index, {}],
-        [Float64Index, {}],
+        [lambda x: NumericIndex(x, np.int64), {}],
+        [lambda x: NumericIndex(x, np.float64), {}],
         [DatetimeIndex, {}],
         [TimedeltaIndex, {}],
         [NumericIndex, {}],

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1146,7 +1146,7 @@ class TestIndex(Base):
         dtype = any_real_numpy_dtype
         index = Index(list("abc"))
         labels = NumericIndex([], dtype=dtype)
-        assert index.reindex(labels)[0].dtype.type == dtype
+        assert index.reindex(labels)[0].dtype == dtype
 
     def test_reindex_no_type_preserve_target_empty_mi(self):
         index = Index(list("abc"))

--- a/pandas/tests/indexes/test_index_new.py
+++ b/pandas/tests/indexes/test_index_new.py
@@ -288,7 +288,7 @@ class TestDtypeEnforced:
             np.array([1.0, 2.0, 3.0], dtype=float),
         ],
     )
-    def test_constructor_dtypes_to_int64(self, vals, any_int_numpy_dtype):
+    def test_constructor_dtypes_to_int(self, vals, any_int_numpy_dtype):
         dtype = any_int_numpy_dtype
         index = NumericIndex(vals, dtype=dtype)
         assert index.dtype == dtype
@@ -303,9 +303,10 @@ class TestDtypeEnforced:
             np.array([1.0, 2.0, 3.0], dtype=float),
         ],
     )
-    def test_constructor_dtypes_to_float64(self, vals):
-        index = NumericIndex(vals, dtype=float)
-        assert index.dtype == np.float64
+    def test_constructor_dtypes_to_float(self, vals, float_numpy_dtype):
+        dtype = float_numpy_dtype
+        index = NumericIndex(vals, dtype=dtype)
+        assert index.dtype == dtype
 
     @pytest.mark.parametrize(
         "vals",

--- a/pandas/tests/indexes/test_index_new.py
+++ b/pandas/tests/indexes/test_index_new.py
@@ -288,9 +288,10 @@ class TestDtypeEnforced:
             np.array([1.0, 2.0, 3.0], dtype=float),
         ],
     )
-    def test_constructor_dtypes_to_int64(self, vals):
-        index = NumericIndex(vals, dtype=int)
-        assert index.dtype == np.int64
+    def test_constructor_dtypes_to_int64(self, vals, any_int_numpy_dtype):
+        dtype = any_int_numpy_dtype
+        index = NumericIndex(vals, dtype=dtype)
+        assert index.dtype == dtype
 
     @pytest.mark.parametrize(
         "vals",

--- a/pandas/tests/indexes/test_index_new.py
+++ b/pandas/tests/indexes/test_index_new.py
@@ -31,11 +31,7 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.core.api import (
-    Float64Index,
-    Int64Index,
-    UInt64Index,
-)
+from pandas.core.api import NumericIndex
 
 
 class TestIndexConstructorInference:
@@ -91,11 +87,11 @@ class TestIndexConstructorInference:
     def test_constructor_int_dtype_float(self, dtype):
         # GH#18400
         if is_unsigned_integer_dtype(dtype):
-            index_type = UInt64Index
+            expected_dtype = np.uint64
         else:
-            index_type = Int64Index
+            expected_dtype = np.int64
 
-        expected = index_type([0, 1, 2, 3])
+        expected = NumericIndex([0, 1, 2, 3], dtype=expected_dtype)
         result = Index([0.0, 1.0, 2.0, 3.0], dtype=dtype)
         tm.assert_index_equal(result, expected)
 
@@ -293,8 +289,8 @@ class TestDtypeEnforced:
         ],
     )
     def test_constructor_dtypes_to_int64(self, vals):
-        index = Index(vals, dtype=int)
-        assert isinstance(index, Int64Index)
+        index = NumericIndex(vals, dtype=int)
+        assert index.dtype == np.int64
 
     @pytest.mark.parametrize(
         "vals",
@@ -307,8 +303,8 @@ class TestDtypeEnforced:
         ],
     )
     def test_constructor_dtypes_to_float64(self, vals):
-        index = Index(vals, dtype=float)
-        assert isinstance(index, Float64Index)
+        index = NumericIndex(vals, dtype=float)
+        assert index.dtype == np.float64
 
     @pytest.mark.parametrize(
         "vals",

--- a/pandas/tests/indexes/test_indexing.py
+++ b/pandas/tests/indexes/test_indexing.py
@@ -19,6 +19,8 @@ import pytest
 
 from pandas.errors import InvalidIndexError
 
+from pandas.core.dtypes.common import is_float_dtype
+
 from pandas import (
     NA,
     DatetimeIndex,
@@ -31,11 +33,7 @@ from pandas import (
     TimedeltaIndex,
 )
 import pandas._testing as tm
-from pandas.core.api import (
-    Float64Index,
-    Int64Index,
-    UInt64Index,
-)
+from pandas.core.api import NumericIndex
 
 
 class TestTake:
@@ -114,12 +112,12 @@ class TestContains:
             (Index([0, 1, 2, np.nan]), 4),
             (Index([0, 1, 2, np.inf]), np.nan),
             (Index([0, 1, 2, np.nan]), np.inf),
-            # Checking if np.inf in Int64Index should not cause an OverflowError
+            # Checking if np.inf in int64 Index should not cause an OverflowError
             # Related to GH 16957
-            (Int64Index([0, 1, 2]), np.inf),
-            (Int64Index([0, 1, 2]), np.nan),
-            (UInt64Index([0, 1, 2]), np.inf),
-            (UInt64Index([0, 1, 2]), np.nan),
+            (Index([0, 1, 2], dtype=np.int64), np.inf),
+            (Index([0, 1, 2], dtype=np.int64), np.nan),
+            (Index([0, 1, 2], dtype=np.uint64), np.inf),
+            (Index([0, 1, 2], dtype=np.uint64), np.nan),
         ],
     )
     def test_index_not_contains(self, index, val):
@@ -139,20 +137,20 @@ class TestContains:
         # GH#19860
         assert val not in index
 
-    def test_contains_with_float_index(self):
+    def test_contains_with_float_index(self, any_real_numpy_dtype):
         # GH#22085
-        integer_index = Int64Index([0, 1, 2, 3])
-        uinteger_index = UInt64Index([0, 1, 2, 3])
-        float_index = Float64Index([0.1, 1.1, 2.2, 3.3])
+        dtype = any_real_numpy_dtype
+        data = [0, 1, 2, 3] if not is_float_dtype(dtype) else [0.1, 1.1, 2.2, 3.3]
+        index = NumericIndex(data, dtype=dtype)
 
-        for index in (integer_index, uinteger_index):
+        if not is_float_dtype(index.dtype):
             assert 1.1 not in index
             assert 1.0 in index
             assert 1 in index
-
-        assert 1.1 in float_index
-        assert 1.0 not in float_index
-        assert 1 not in float_index
+        else:
+            assert 1.1 in index
+            assert 1.0 not in index
+            assert 1 not in index
 
     def test_contains_requires_hashable_raises(self, index):
         if isinstance(index, MultiIndex):

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -16,10 +16,7 @@ from pandas.compat import (
 
 import pandas as pd
 import pandas._testing as tm
-from pandas.core.api import (
-    Float64Index,
-    Int64Index,
-)
+from pandas.core.api import NumericIndex
 
 ###############################################################
 # Index / Series common tests which may trigger dtype coercions
@@ -217,7 +214,7 @@ class TestInsertIndexCoercion(CoercionBase):
         ],
     )
     def test_insert_index_int64(self, insert, coerced_val, coerced_dtype):
-        obj = Int64Index([1, 2, 3, 4])
+        obj = NumericIndex([1, 2, 3, 4], dtype=np.int64)
         assert obj.dtype == np.int64
 
         exp = pd.Index([1, coerced_val, 2, 3, 4])
@@ -233,7 +230,7 @@ class TestInsertIndexCoercion(CoercionBase):
         ],
     )
     def test_insert_index_float64(self, insert, coerced_val, coerced_dtype):
-        obj = Float64Index([1.0, 2.0, 3.0, 4.0])
+        obj = NumericIndex([1.0, 2.0, 3.0, 4.0], dtype=np.float64)
         assert obj.dtype == np.float64
 
         exp = pd.Index([1.0, coerced_val, 2.0, 3.0, 4.0])

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -261,9 +261,9 @@ class TestFloatIndexers:
         # oob indicates if we are out of bounds
         # of positional indexing
         for index, oob in [
-            (NumericIndex(np.arange(5, np.int64)), False),
+            (NumericIndex(np.arange(5, dtype=np.int64)), False),
             (RangeIndex(5), False),
-            (NumericIndex(np.arange(5, np.int64)) + 10, True),
+            (NumericIndex(np.arange(5, dtype=np.int64) + 10), True),
         ]:
 
             # s is an in-range index

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -8,10 +8,7 @@ from pandas import (
     Series,
 )
 import pandas._testing as tm
-from pandas.core.api import (
-    Float64Index,
-    Int64Index,
-)
+from pandas.core.api import NumericIndex
 
 
 def gen_obj(klass, index):
@@ -264,9 +261,9 @@ class TestFloatIndexers:
         # oob indicates if we are out of bounds
         # of positional indexing
         for index, oob in [
-            (Int64Index(range(5)), False),
+            (NumericIndex(np.arange(5, np.int64)), False),
             (RangeIndex(5), False),
-            (Int64Index(range(5)) + 10, True),
+            (NumericIndex(np.arange(5, np.int64)) + 10, True),
         ]:
 
             # s is an in-range index
@@ -496,7 +493,7 @@ class TestFloatIndexers:
 
         # fancy floats/integers create the correct entry (as nan)
         # fancy tests
-        expected = Series([2, 0], index=Float64Index([5.0, 0.0]))
+        expected = Series([2, 0], index=Index([5.0, 0.0], dtype=np.float64))
         for fancy_idx in [[5.0, 0.0], np.array([5.0, 0.0])]:  # float
             tm.assert_series_equal(indexer_sl(s)[fancy_idx], expected)
 

--- a/pandas/tests/io/pytables/test_put.py
+++ b/pandas/tests/io/pytables/test_put.py
@@ -21,7 +21,7 @@ from pandas import (
     _testing as tm,
     concat,
 )
-from pandas.core.api import Int64Index
+from pandas.core.api import NumericIndex
 from pandas.tests.io.pytables.common import (
     _maybe_remove,
     ensure_clean_store,
@@ -250,7 +250,7 @@ def test_column_multiindex(setup_path):
     df = DataFrame(np.arange(12).reshape(3, 4), columns=index)
     expected = df.copy()
     if isinstance(expected.index, RangeIndex):
-        expected.index = Int64Index(expected.index)
+        expected.index = NumericIndex(expected.index, dtype=np.int64)
 
     with ensure_clean_store(setup_path) as store:
 
@@ -282,7 +282,7 @@ def test_column_multiindex(setup_path):
     df = DataFrame(np.arange(12).reshape(3, 4), columns=Index(list("ABCD"), name="foo"))
     expected = df.copy()
     if isinstance(expected.index, RangeIndex):
-        expected.index = Int64Index(expected.index)
+        expected.index = NumericIndex(expected.index, dtype=np.int64)
 
     with ensure_clean_store(setup_path) as store:
 

--- a/pandas/tests/io/pytables/test_put.py
+++ b/pandas/tests/io/pytables/test_put.py
@@ -21,7 +21,6 @@ from pandas import (
     _testing as tm,
     concat,
 )
-from pandas.core.api import NumericIndex
 from pandas.tests.io.pytables.common import (
     _maybe_remove,
     ensure_clean_store,
@@ -248,9 +247,7 @@ def test_column_multiindex(setup_path):
         [("A", "a"), ("A", "b"), ("B", "a"), ("B", "b")], names=["first", "second"]
     )
     df = DataFrame(np.arange(12).reshape(3, 4), columns=index)
-    expected = df.copy()
-    if isinstance(expected.index, RangeIndex):
-        expected.index = NumericIndex(expected.index, dtype=np.int64)
+    expected = df.set_axis(df.index.to_numpy())
 
     with ensure_clean_store(setup_path) as store:
 
@@ -280,9 +277,7 @@ def test_column_multiindex(setup_path):
 
     # non_index_axes name
     df = DataFrame(np.arange(12).reshape(3, 4), columns=Index(list("ABCD"), name="foo"))
-    expected = df.copy()
-    if isinstance(expected.index, RangeIndex):
-        expected.index = NumericIndex(expected.index, dtype=np.int64)
+    expected = df.set_axis(df.index.to_numpy())
 
     with ensure_clean_store(setup_path) as store:
 

--- a/pandas/tests/io/pytables/test_put.py
+++ b/pandas/tests/io/pytables/test_put.py
@@ -16,7 +16,6 @@ from pandas import (
     HDFStore,
     Index,
     MultiIndex,
-    RangeIndex,
     Series,
     _testing as tm,
     concat,

--- a/pandas/tests/series/test_ufunc.py
+++ b/pandas/tests/series/test_ufunc.py
@@ -286,7 +286,7 @@ class TestNumpyReductions:
                 expected = obj.prod(numeric_only=False)
                 tm.assert_series_equal(result, expected)
             elif box is pd.Index:
-                # Int64Index, Index has no 'prod'
+                # Index has no 'prod'
                 expected = obj._values.prod()
                 assert result == expected
             else:
@@ -317,7 +317,7 @@ class TestNumpyReductions:
                 expected = obj.sum(numeric_only=False)
                 tm.assert_series_equal(result, expected)
             elif box is pd.Index:
-                # Int64Index, Index has no 'sum'
+                # Index has no 'sum'
                 expected = obj._values.sum()
                 assert result == expected
             else:

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -39,7 +39,6 @@ def df():
     return DataFrame({"A": [1, 2, 3]})
 
 
-@pytest.mark.filterwarnings("ignore:.*64Index is deprecated:FutureWarning")
 def test_dask(df):
 
     # dask sets "compute.use_numexpr" to False, so catch the current value
@@ -59,7 +58,6 @@ def test_dask(df):
         pd.set_option("compute.use_numexpr", olduse)
 
 
-@pytest.mark.filterwarnings("ignore:.*64Index is deprecated:FutureWarning")
 @pytest.mark.filterwarnings("ignore:The __array_wrap__:DeprecationWarning")
 def test_dask_ufunc():
     # At the time of dask 2022.01.0, dask is still directly using __array_wrap__
@@ -158,7 +156,6 @@ def test_oo_optimized_datetime_index_unpickle():
 @tm.network
 # Cython import warning
 @pytest.mark.filterwarnings("ignore:can't:ImportWarning")
-@pytest.mark.filterwarnings("ignore:.*64Index is deprecated:FutureWarning")
 @pytest.mark.filterwarnings(
     # patsy needs to update their imports
     "ignore:Using or importing the ABCs from 'collections:DeprecationWarning"


### PR DESCRIPTION
Progress towards #42717, one easy step at a time... 

There are still some places that have these indexes, but maybe easier taking these things in steps.