### PR TITLE
BUG: SeriesGroupBy.nunique raises when grouping with an empty categrorical

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -773,6 +773,7 @@ Groupby/resample/rolling
 - Bug in :meth:`.DataFrameGroupBy.describe` would describe the group keys (:issue:`49256`)
 - Bug in :meth:`.SeriesGroupBy.describe` with ``as_index=False`` would have the incorrect shape (:issue:`49256`)
 - Bug in :class:`.DataFrameGroupBy` and :class:`.SeriesGroupBy` with ``dropna=False`` would drop NA values when the grouper was categorical (:issue:`36327`)
+- Bug in :meth:`.SeriesGroupBy.nunique` would incorrectly raise when the grouper was an empty categorical and ``observed=True`` (:issue:`21334`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -585,7 +585,9 @@ class SeriesGroupBy(GroupBy[Series]):
         # we might have duplications among the bins
         if len(res) != len(ri):
             res, out = np.zeros(len(ri), dtype=out.dtype), res
-            res[ids[idx]] = out
+            if len(ids) > 0:
+                # GH#21334s
+                res[ids[idx]] = out
 
         result = self.obj._constructor(res, index=ri, name=self.obj.name)
         return self._reindex_output(result, fill_value=0)

--- a/pandas/tests/groupby/test_nunique.py
+++ b/pandas/tests/groupby/test_nunique.py
@@ -191,7 +191,7 @@ def test_empty_categorical(observed):
     gb = ser.groupby(ser, observed=observed)
     result = gb.nunique()
     if observed:
-        expected = Series([], index=cat[:0], dtype=int)
+        expected = Series([], index=cat[:0], dtype="int64")
     else:
-        expected = Series([0], index=cat)
+        expected = Series([0], index=cat, dtype="int64")
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/groupby/test_nunique.py
+++ b/pandas/tests/groupby/test_nunique.py
@@ -182,3 +182,16 @@ def test_nunique_transform_with_datetime():
     result = df.groupby([0, 0, 1])["date"].transform("nunique")
     expected = Series([2, 2, 1], name="date")
     tm.assert_series_equal(result, expected)
+
+
+def test_empty_categorical(observed):
+    # GH#21334
+    cat = Series([1]).astype("category")
+    ser = cat[:0]
+    gb = ser.groupby(ser, observed=observed)
+    result = gb.nunique()
+    if observed:
+        expected = Series([], index=cat[:0], dtype=int)
+    else:
+        expected = Series([0], index=cat)
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #21334 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
