### PR TITLE
STYLE: Enable Pylint warning redundant-keyword-arg

### DIFF
--- a/pandas/_testing/_io.py
+++ b/pandas/_testing/_io.py
@@ -225,7 +225,7 @@ def network(
             )
         try:
             return t(*args, **kwargs)
-        except Exception as err:  # pylint: disable=broad-except
+        except Exception as err:
             errno = getattr(err, "errno", None)
             if not errno and hasattr(errno, "reason"):
                 # error: "Exception" has no attribute "reason"

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -485,7 +485,7 @@ def maybe_cast_to_extension_array(
 
     try:
         result = cls._from_sequence(obj, dtype=dtype)
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         # We can't predict what downstream EA constructors may raise
         result = obj
     return result

--- a/pandas/tests/frame/methods/test_rename.py
+++ b/pandas/tests/frame/methods/test_rename.py
@@ -334,7 +334,7 @@ class TestRename:
 
         # Duplicates
         with pytest.raises(TypeError, match="multiple values"):
-            df.rename(id, mapper=id)  # pylint: disable=redundant-keyword-arg
+            df.rename(id, mapper=id)
 
     def test_rename_positional_raises(self):
         # GH 29136

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -1113,7 +1113,7 @@ class TestReadHtml:
     @pytest.mark.slow
     def test_fallback_success(self, datapath):
         banklist_data = datapath("io", "data", "html", "banklist.html")
-        # pylint: disable-next=redundant-keyword-arg
+
         self.read_html(banklist_data, match=".*Water.*", flavor=["lxml", "html5lib"])
 
     def test_to_html_timestamp(self):

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -1113,9 +1113,8 @@ class TestReadHtml:
     @pytest.mark.slow
     def test_fallback_success(self, datapath):
         banklist_data = datapath("io", "data", "html", "banklist.html")
-        self.read_html(
-            banklist_data, match=".*Water.*", flavor=["lxml", "html5lib"]
-        )  # pylint: disable=redundant-keyword-arg
+        # pylint: disable-next=redundant-keyword-arg
+        self.read_html(banklist_data, match=".*Water.*", flavor=["lxml", "html5lib"])
 
     def test_to_html_timestamp(self):
         rng = date_range("2000-01-01", periods=10)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,7 +230,6 @@ disable = [
 
  # misc
   "abstract-class-instantiated",
-  "redundant-keyword-arg",
   "no-value-for-parameter",
   "undefined-variable",
   "unpacking-non-sequence",


### PR DESCRIPTION
Enables the Pylint warning `redundant-keyword-arg`.

- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
