### PR TITLE
Truncate table option for to sql

### DIFF
--- a/doc/source/whatsnew/v1.5.3.rst
+++ b/doc/source/whatsnew/v1.5.3.rst
@@ -32,7 +32,7 @@ Bug fixes
 
 Other
 ~~~~~
-- Added ``"truncate"`` option to ``if_exists`` argument in :meth:`DataFrame.to_sql` to truncate the existing table (:issue:`37210`)
+- 
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.5.3.rst
+++ b/doc/source/whatsnew/v1.5.3.rst
@@ -32,7 +32,7 @@ Bug fixes
 
 Other
 ~~~~~
--
+- Added ``"truncate"`` option to ``if_exists`` argument in :meth:`DataFrame.to_sql` to truncate the existing table (:issue:`37210`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -83,7 +83,7 @@ Other enhancements
 - :func:`timedelta_range` now supports a ``unit`` keyword ("s", "ms", "us", or "ns") to specify the desired resolution of the output index (:issue:`49824`)
 - :meth:`DataFrame.to_json` now supports a ``mode`` keyword with supported inputs 'w' and 'a'. Defaulting to 'w', 'a' can be used when lines=True and orient='records' to append record oriented json lines to an existing json file. (:issue:`35849`)
 - Added ``name`` parameter to :meth:`IntervalIndex.from_breaks`, :meth:`IntervalIndex.from_arrays` and :meth:`IntervalIndex.from_tuples` (:issue:`48911`)
--
+- Added ``"truncate"`` option to ``if_exists`` argument in :meth:`DataFrame.to_sql` to truncate the existing table (:issue:`37210`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_200.notable_bug_fixes:

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -2266,8 +2266,7 @@ class SQLiteDatabase(PandasSQL):
         self.execute(drop_sql)
 
     def trunc_table(self, name: str, schema: str | None = None) -> None:
-        trunc_sql = f"DELETE FROM {_get_valid_sqlite_name(name)}"
-        self.execute(trunc_sql)
+        raise NotImplementedError("TRUNCATE not implemented on database")
 
     def _create_sql_schema(
         self,

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1841,10 +1841,7 @@ class SQLDatabase(PandasSQL):
         schema = schema or self.meta.schema
         if self.has_table(table_name, schema):
             self.meta.reflect(bind=self.con, only=[table_name], schema=schema)
-            if schema:
-                self.execute(f"TRUNCATE FROM {schema}.{table_name}")
-            else:
-                self.execute(f"DELETE FROM {table_name}")
+            self.execute(f"TRUNCATE FROM {schema}.{table_name}")
             self.meta.clear()
 
     def _create_sql_schema(
@@ -2269,7 +2266,7 @@ class SQLiteDatabase(PandasSQL):
         self.execute(drop_sql)
 
     def trunc_table(self, name: str, schema: str | None = None) -> None:
-        trunc_sql = f"TRUNCATE TABLE {_get_valid_sqlite_name(name)}"
+        trunc_sql = f"DELETE FROM {_get_valid_sqlite_name(name)}"
         self.execute(trunc_sql)
 
     def _create_sql_schema(

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1842,8 +1842,9 @@ class SQLDatabase(PandasSQL):
         if self.has_table(table_name, schema):
             self.meta.reflect(bind=self.con, only=[table_name], schema=schema)
             if schema:
-                schema = schema + "."
-            self.execute(f"DELETE FROM {schema or ''}{table_name}")
+                self.execute(f"TRUNCATE FROM {schema}.{table_name}")
+            else:
+                self.execute(f"DELETE FROM {table_name}")
             self.meta.clear()
 
     def _create_sql_schema(

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1841,7 +1841,7 @@ class SQLDatabase(PandasSQL):
         schema = schema or self.meta.schema
         if self.has_table(table_name, schema):
             self.meta.reflect(bind=self.con, only=[table_name], schema=schema)
-            self.execute(f"TRUNCATE FROM {schema}.{table_name}")
+            self.execute(f"TRUNCATE TABLE {schema}.{table_name}")
             self.meta.clear()
 
     def _create_sql_schema(

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1838,7 +1838,6 @@ class SQLDatabase(PandasSQL):
             self.get_table(table_name, schema).drop(bind=self.con)
             self.meta.clear()
 
-   
     def trunc_table(self, table_name: str, schema: str | None = None) -> None:
         schema = schema or self.meta.schema
         if self.has_table(table_name, schema):

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1842,7 +1842,7 @@ class SQLDatabase(PandasSQL):
         if self.has_table(table_name, schema):
             self.meta.reflect(bind=self.con, only=[table_name], schema=schema)
             if schema:
-                schema=schema+'.'
+                schema = schema + "."
             self.execute(f"DELETE FROM {schema or ''}{table_name}")
             self.meta.clear()
 

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -857,7 +857,6 @@ class SQLTable(PandasObject):
                 self._execute_create()
             elif self.if_exists == "truncate":
                 self.pd_sql.trunc_table(self.name, self.schema)
-                self._execute_create()
             elif self.if_exists == "append":
                 pass
             else:
@@ -1842,8 +1841,9 @@ class SQLDatabase(PandasSQL):
         schema = schema or self.meta.schema
         if self.has_table(table_name, schema):
             self.meta.reflect(bind=self.con, only=[table_name], schema=schema)
-            # self.execute(f"TRUNCATE TABLE {schema}.{table_name};") -- true truncate
-            self.get_table(table_name, schema).delete(bind=self.con)
+            if schema:
+                schema=schema+'.'
+            self.execute(f"DELETE FROM {schema or ''}{table_name}")
             self.meta.clear()
 
     def _create_sql_schema(

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -913,6 +913,20 @@ class _TestSQLApi(PandasSQLTest):
 
         assert num_rows == num_entries
 
+    def test_to_sql_truncate_no_table(self, test_frame1):
+        #  creates new table if table doesn't exist
+        sql.to_sql(test_frame1, "test_frame_new", self.conn, if_exists="truncate")
+        assert sql.has_table("test_frame_new")
+        
+    def test_to_sql_truncate_new_columns(self, test_frame1, test_frame3):
+        sql.to_sql(test_frame3, "test_frame3", self.conn, if_exists='fail')
+        # truncate and attempt to add more columns
+        msg = "table test_frame3 has no column named C"
+        with pytest.raises(Exception, match=msg):
+            sql.to_sql(test_frame1, "test_frame3", self.conn, if_exists='truncate')
+        
+        
+
     def test_to_sql_append(self, test_frame1):
         assert sql.to_sql(test_frame1, "test_frame4", self.conn, if_exists="fail") == 4
 

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -917,15 +917,20 @@ class _TestSQLApi(PandasSQLTest):
         #  creates new table if table doesn't exist
         sql.to_sql(test_frame1, "test_frame_new", self.conn, if_exists="truncate")
         assert sql.has_table("test_frame_new")
-        
+
     def test_to_sql_truncate_new_columns(self, test_frame1, test_frame3):
-        sql.to_sql(test_frame3, "test_frame3", self.conn, if_exists='fail')
+        sql.to_sql(test_frame3, "test_frame3", self.conn, if_exists="fail")
         # truncate and attempt to add more columns
         msg = "table test_frame3 has no column named C"
         with pytest.raises(Exception, match=msg):
-            sql.to_sql(test_frame1, "test_frame3", self.conn, if_exists='truncate')
-        
-        
+            sql.to_sql(test_frame1, "test_frame3", self.conn, if_exists="truncate")
+
+    def test_sqlite_truncate_raises(self, test_frame1):
+        msg = "TRUNCATE not implemented on database"
+        with pytest.raises(NotImplementedError, match=msg):
+            sql.to_sql(
+                test_frame1, "test_frame3", self.conn, if_exists="truncate"
+            )
 
     def test_to_sql_append(self, test_frame1):
         assert sql.to_sql(test_frame1, "test_frame4", self.conn, if_exists="fail") == 4

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -902,6 +902,17 @@ class _TestSQLApi(PandasSQLTest):
 
         assert num_rows == num_entries
 
+    def test_to_sql_truncate(self, test_frame1):
+        sql.to_sql(test_frame1, "test_frame3", self.conn, if_exists="fail")
+        # Add to table again
+        sql.to_sql(test_frame1, "test_frame3", self.conn, if_exists="truncate")
+        assert sql.has_table("test_frame3", self.conn)
+
+        num_entries = len(test_frame1)
+        num_rows = count_rows(self.conn, "test_frame3")
+
+        assert num_rows == num_entries
+
     def test_to_sql_append(self, test_frame1):
         assert sql.to_sql(test_frame1, "test_frame4", self.conn, if_exists="fail") == 4
 


### PR DESCRIPTION
- [X] closes #37210 - in order to reload a table but not drop it to avoid CASCADE-ing
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/v1.5.3.rst` file if fixing a bug or adding a new feature.
