### PR TITLE
PERF: 34% faster Series.to_dict

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1818,7 +1818,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         else:
             # Not an object dtype => all types will be the same so let the default
             # indexer return native python type
-            return into_c((k, v) for k, v in self.items())
+            return into_c(self.items())
 
     def to_frame(self, name: Hashable = lib.no_default) -> DataFrame:
         """


### PR DESCRIPTION
Improve the performance of Series.to_dict() by not including a generator that is not necessary. Local tests showed significant performance improvements.

Note this builds off the changes of #46487 from @RogerThomas