### PR TITLE
PERF first-non-null

### DIFF
--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -434,7 +434,7 @@ def first_non_null(values: ndarray) -> int:
         if (
             isinstance(val, str)
             and
-            (len(val) == 0 or val in ("now", "today", *nat_strings))
+            (len(val) == 0 or val in nat_strings or val in ("now", "today"))
         ):
             continue
         return i


### PR DESCRIPTION
As intuitied by @jbrockmendel [here](https://github.com/pandas-dev/pandas/pull/50039/files#r1040015439), there was indeed a slight perf hit from #50039

It's negligible compared with the time it'd take to parse the array with `to_datetime`, but still, better to fix it

Timings on my laptop (this is copy-and-pasted from my terminal, I just removed some output from compiling the C extensions)

```console
(pandas-dev) marcogorelli@DESKTOP-U8OKFP3:~/pandas-dev$ git checkout main 
Switched to branch 'main'
Your branch is up-to-date with 'upstream/main'.
(pandas-dev) marcogorelli@DESKTOP-U8OKFP3:~/pandas-dev$ . single-compile-c-extensions.sh 
Compiling pandas/_libs/tslib.pyx because it changed.
[1/1] Cythonizing pandas/_libs/tslib.pyx
/home/marcogorelli/mambaforge/envs/pandas-dev/lib/python3.8/site-packages/setuptools/config/pyprojecttoml.py:108: _BetaConfiguration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
  warnings.warn(msg, _BetaConfiguration)
running build_ext
building 'pandas._libs.tslib' extension
Successfully installed pandas-2.0.0.dev0+858.g7c208c8907
2.0.0.dev0+858.g7c208c8907
(pandas-dev) marcogorelli@DESKTOP-U8OKFP3:~/pandas-dev$ . repl.sh 

In [1]: from pandas._libs.tslib import first_non_null

In [2]: arr = np.array([np.nan, np.nan, np.nan, '2012-01-01'], dtype=object)

In [3]: %%timeit
   ...: first_non_null(arr)
   ...: 
   ...: 
213 ns ± 1.03 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [4]: %%timeit
   ...: first_non_null(arr)
   ...: 
   ...: 
215 ns ± 2.12 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [5]: %%timeit
   ...: first_non_null(arr)
   ...: 
   ...: 
214 ns ± 3.36 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [6]:                                                                                                                                                                 
Do you really want to exit ([y]/n)? y
(pandas-dev) marcogorelli@DESKTOP-U8OKFP3:~/pandas-dev$ git revert 8da8743729
Auto-merging pandas/_libs/tslib.pyx
[main 0427c464b4] Revert "ENH skip 'now' and 'today' when inferring format for array (#50039)"
 2 files changed, 1 insertion(+), 7 deletions(-)
(pandas-dev) marcogorelli@DESKTOP-U8OKFP3:~/pandas-dev$ . single-compile-c-extensions.sh 
Compiling pandas/_libs/tslib.pyx because it changed.
[1/1] Cythonizing pandas/_libs/tslib.pyx
/home/marcogorelli/mambaforge/envs/pandas-dev/lib/python3.8/site-packages/setuptools/config/pyprojecttoml.py:108: _BetaConfiguration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
  warnings.warn(msg, _BetaConfiguration)
running build_ext
building 'pandas._libs.tslib' extension
Successfully installed pandas-2.0.0.dev0+859.g0427c464b4
2.0.0.dev0+859.g0427c464b4
(pandas-dev) marcogorelli@DESKTOP-U8OKFP3:~/pandas-dev$ . repl.sh 

In [1]: from pandas._libs.tslib import first_non_null

In [2]: arr = np.array([np.nan, np.nan, np.nan, '2012-01-01'], dtype=object)

In [3]: %%timeit
   ...: first_non_null(arr)
   ...: 
   ...: 
70.7 ns ± 1.71 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [4]: %%timeit
   ...: first_non_null(arr)
   ...: 
   ...: 
73.3 ns ± 1.31 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [5]: %%timeit
   ...: first_non_null(arr)
   ...: 
   ...: 
73.6 ns ± 3.65 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [6]:                                                                                                                                                                 
Do you really want to exit ([y]/n)? y
(pandas-dev) marcogorelli@DESKTOP-U8OKFP3:~/pandas-dev$ git checkout -
Switched to branch 'first-non-null-perf'
Your branch is up-to-date with 'origin/first-non-null-perf'.
(pandas-dev) marcogorelli@DESKTOP-U8OKFP3:~/pandas-dev$ . single-compile-c-extensions.sh 
Compiling pandas/_libs/tslib.pyx because it changed.
[1/1] Cythonizing pandas/_libs/tslib.pyx
/home/marcogorelli/mambaforge/envs/pandas-dev/lib/python3.8/site-packages/setuptools/config/pyprojecttoml.py:108: _BetaConfiguration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
  warnings.warn(msg, _BetaConfiguration)
running build_ext
building 'pandas._libs.tslib' extension
Successfully installed pandas-2.0.0.dev0+859.gecc8eaaf50
2.0.0.dev0+859.gecc8eaaf50
(pandas-dev) marcogorelli@DESKTOP-U8OKFP3:~/pandas-dev$ . repl.sh 

In [1]: from pandas._libs.tslib import first_non_null

In [2]: arr = np.array([np.nan, np.nan, np.nan, '2012-01-01'], dtype=object)

In [3]: %%timeit
   ...: first_non_null(arr)
   ...: 
   ...: 
75.2 ns ± 2.69 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [4]: %%timeit
   ...: first_non_null(arr)
   ...: 
   ...: 
75.7 ns ± 2.56 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [5]: %%timeit
   ...: first_non_null(arr)
   ...: 
   ...: 
79.8 ns ± 3.22 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [6]:                                                                                                                                                                 
Do you really want to exit ([y]/n)? y
```