### PR TITLE
BUG: #49889

### DIFF
--- a/pandas/core/interchange/from_dataframe.py
+++ b/pandas/core/interchange/from_dataframe.py
@@ -182,7 +182,7 @@ def categorical_column_to_series(col: Column) -> tuple[pd.Series, Any]:
 
     cat_column = categorical["categories"]
     # for mypy/pyright
-    assert isinstance(cat_column, PandasColumn), "categories must be a PandasColumn"
+    assert isinstance(cat_column, Column), "categories must abide by __dataframe__ protocol API"
     categories = np.array(cat_column._col)
     buffers = col.get_buffers()
 


### PR DESCRIPTION
Fix for issue: BUG: categorical_column_to_series() should not accept only PandasColumn #49889

Relaxed assert statement from `PandasColumn` to `Column` as not only Pandas column could be used here
