### PR TITLE
BUG: Series read_json tries to convert all column values to dates even when using keep_default_dates=True, if one column has an na value FIX

### DIFF
--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -478,7 +478,7 @@ def read_json(
     typ: Literal["frame", "series"] = "frame",
     dtype: DtypeArg | None = None,
     convert_axes=None,
-    convert_dates: bool | list[str] = True,
+    convert_dates: bool | list[str] = False,
     keep_default_dates: bool = True,
     precise_float: bool = False,
     date_unit: str | None = None,


### PR DESCRIPTION
- [ ] closes #49585 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
