### PR TITLE
API: ensure IntervalIndex.left/right are 64bit if numeric

### DIFF
--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -572,7 +572,7 @@ class IntervalIndex(ExtensionIndex):
     def _maybe_convert_numeric_to_64bit(self, idx: Index) -> Index:
         # IntervalTree only supports 64 bit numpy array
         dtype = idx.dtype
-        if np.issubclass_(idx.dtype.type, np.number):
+        if np.issubclass_(dtype.type, np.number):
             return idx
         elif is_signed_integer_dtype(dtype) and dtype != np.int64:
             return idx.astype(np.int64)

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -59,6 +59,8 @@ from pandas.core.dtypes.common import (
     is_number,
     is_object_dtype,
     is_scalar,
+    is_signed_integer_dtype,
+    is_unsigned_integer_dtype,
 )
 from pandas.core.dtypes.dtypes import IntervalDtype
 from pandas.core.dtypes.missing import is_valid_na_for_dtype
@@ -521,6 +523,7 @@ class IntervalIndex(ExtensionIndex):
         original = key
         if is_list_like(key):
             key = ensure_index(key)
+            key = self._maybe_convert_numeric_to_64bit(key)
 
         if not self._needs_i8_conversion(key):
             return original
@@ -565,6 +568,20 @@ class IntervalIndex(ExtensionIndex):
             )
 
         return key_i8
+
+    def _maybe_convert_numeric_to_64bit(self, idx: Index) -> Index:
+        # IntervalTree only supports 64 bit numpy array
+        dtype = idx.dtype
+        if np.issubclass_(idx.dtype.type, np.number):
+            return idx
+        elif is_signed_integer_dtype(dtype) and dtype != np.int64:
+            return idx.astype(np.int64)
+        elif is_unsigned_integer_dtype(dtype) and dtype != np.uint64:
+            return idx.astype(np.uint64)
+        elif is_float_dtype(dtype) and dtype != np.float64:
+            return idx.astype(np.float64)
+        else:
+            return idx
 
     def _searchsorted_monotonic(self, label, side: Literal["left", "right"] = "left"):
         if not self.is_non_overlapping_monotonic:


### PR DESCRIPTION
Extracted part for #49560, slightly altered.

`IntervalIndex` depends on `IntervalTree` which only accepts 64-bit int/uint/floats. This ensures that numpy numeric arrays in `IntervalTree` will always be 64-bit.

A question is if we should have non-64bit `IntervalTree`s. I've considered that that is maybe a different question than #49650, and  I could write an issue about it and someone could take it in a follow-up, possibly before 2.0?

This PR changes nothing  functionality-wise, but is needed when `Index` can have non-64bit indexes after #49650.