### PR TITLE
Fix a typo in the docstring

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6411,7 +6411,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         By default, ``convert_dtypes`` will attempt to convert a Series (or each
         Series in a DataFrame) to dtypes that support ``pd.NA``. By using the options
         ``convert_string``, ``convert_integer``, ``convert_boolean`` and
-        ``convert_boolean``, it is possible to turn off individual conversions
+        ``convert_floating``, it is possible to turn off individual conversions
         to ``StringDtype``, the integer extension types, ``BooleanDtype``
         or floating extension types, respectively.
 


### PR DESCRIPTION
As you can see, `convert_boolean` is written twice here. Probably, instead of the second one, `convert_floating` was meant.