### PR TITLE
BUG: displaying string dtypes not showing storage option

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -787,6 +787,7 @@ I/O
 - Improved error message in :func:`read_excel` by including the offending sheet name when an exception is raised while reading a file (:issue:`48706`)
 - Bug when a pickling a subset PyArrow-backed data that would serialize the entire data instead of the subset (:issue:`42600`)
 - Bug in :func:`read_csv` for a single-line csv with fewer columns than ``names`` raised :class:`.errors.ParserError` with ``engine="c"`` (:issue:`47566`)
+- Bug in displaying ``string`` dtypes not showing storage option (:issue:`50099`)
 - Bug in :func:`DataFrame.to_string` with ``header=False`` that printed the index name on the same line as the first row of the data (:issue:`49230`)
 - Fixed memory leak which stemmed from the initialization of the internal JSON module (:issue:`49222`)
 - Fixed issue where :func:`json_normalize` would incorrectly remove leading characters from column names that matched the ``sep`` argument (:issue:`49861`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6473,12 +6473,12 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         2  3  z   <NA>  <NA>    20  200.0
 
         >>> dfn.dtypes
-        a      Int32
-        b     string
-        c    boolean
-        d     string
-        e      Int64
-        f    Float64
+        a             Int32
+        b    string[python]
+        c           boolean
+        d    string[python]
+        e             Int64
+        f           Float64
         dtype: object
 
         Start with a Series of strings and missing data represented by ``np.nan``.

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -89,6 +89,7 @@ from pandas.core.arrays import (
     DatetimeArray,
     TimedeltaArray,
 )
+from pandas.core.arrays.string_ import StringDtype
 from pandas.core.base import PandasObject
 import pandas.core.common as com
 from pandas.core.construction import extract_array
@@ -1395,6 +1396,8 @@ class GenericArrayFormatter:
                 return self.na_rep
             elif isinstance(x, PandasObject):
                 return str(x)
+            elif isinstance(x, StringDtype):
+                return repr(x)
             else:
                 # object dtype
                 return str(formatter(x))

--- a/pandas/tests/io/formats/test_to_string.py
+++ b/pandas/tests/io/formats/test_to_string.py
@@ -338,3 +338,19 @@ def test_to_string_max_rows_zero(data, expected):
     # GH35394
     result = DataFrame(data=data).to_string(max_rows=0)
     assert result == expected
+
+
+def test_to_string_string_dtype():
+    # GH#50099
+    df = DataFrame({"x": ["foo", "bar", "baz"], "y": ["a", "b", "c"], "z": [1, 2, 3]})
+    df = df.astype(
+        {"x": "string[pyarrow]", "y": "string[python]", "z": "int64[pyarrow]"}
+    )
+    result = df.dtypes.to_string()
+    expected = dedent(
+        """\
+        x    string[pyarrow]
+        y     string[python]
+        z     int64[pyarrow]"""
+    )
+    assert result == expected

--- a/pandas/tests/io/formats/test_to_string.py
+++ b/pandas/tests/io/formats/test_to_string.py
@@ -5,7 +5,7 @@ from textwrap import dedent
 import numpy as np
 import pytest
 
-from pandas.compat import pa_version_under6p0
+import pandas.util._test_decorators as td
 
 from pandas import (
     DataFrame,
@@ -342,11 +342,9 @@ def test_to_string_max_rows_zero(data, expected):
     assert result == expected
 
 
+@td.skip_if_no("pyarrow")
 def test_to_string_string_dtype():
     # GH#50099
-    if pa_version_under6p0:
-        pytest.skip()
-
     df = DataFrame({"x": ["foo", "bar", "baz"], "y": ["a", "b", "c"], "z": [1, 2, 3]})
     df = df.astype(
         {"x": "string[pyarrow]", "y": "string[python]", "z": "int64[pyarrow]"}

--- a/pandas/tests/io/formats/test_to_string.py
+++ b/pandas/tests/io/formats/test_to_string.py
@@ -5,6 +5,8 @@ from textwrap import dedent
 import numpy as np
 import pytest
 
+from pandas.compat import pa_version_under6p0
+
 from pandas import (
     DataFrame,
     Series,
@@ -342,6 +344,9 @@ def test_to_string_max_rows_zero(data, expected):
 
 def test_to_string_string_dtype():
     # GH#50099
+    if pa_version_under6p0:
+        pytest.skip()
+
     df = DataFrame({"x": ["foo", "bar", "baz"], "y": ["a", "b", "c"], "z": [1, 2, 3]})
     df = df.astype(
         {"x": "string[pyarrow]", "y": "string[python]", "z": "int64[pyarrow]"}


### PR DESCRIPTION
- [x] closes #50099 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

cc @mroeschke not saying that this is a good fix, but this shows that we have to use repr for the string dtypes in some way. Is there a more general rule to accomplish this?