### PR TITLE
DOC: add examples to get_indexer_non_unique

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5557,6 +5557,25 @@ class Index(IndexOpsMixin, PandasObject):
         missing : np.ndarray[np.intp]
             An indexer into the target of the values not found.
             These correspond to the -1 in the indexer array.
+
+        Examples
+        --------
+        >>> index = pd.Index(['c', 'b', 'a', 'b', 'b'])
+        >>> index.get_indexer_non_unique(['f', 'b', 's'])
+        (array([-1,  1,  3,  4, -1]), array([0, 2]))
+
+        >>> index = pd.Index(['c', 'b', 'a', 'b', 'b'])
+        >>> index.get_indexer_non_unique(['b', 'b'])
+        (array([1, 3, 4, 1, 3, 4]), array([], dtype=int64))
+
+        >>> index = pd.Index(['c', 'b', 'a', 'b', 'b'])
+        >>> index.get_indexer_non_unique(['q', 'r', 't'])
+        (array([-1, -1, -1]), array([0, 1, 2]))
+
+        Notice that the return value is a tuple contains two items.
+        The first item is an array of locations in ``index`` and ``x``
+        is marked by -1, as it is not in ``index``. The second item
+        is a mask for new index given the current index.
         """
 
     @Appender(_index_shared_docs["get_indexer_non_unique"] % _index_doc_kwargs)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5564,23 +5564,25 @@ class Index(IndexOpsMixin, PandasObject):
         >>> index.get_indexer_non_unique(['b', 'b'])
         (array([1, 3, 4, 1, 3, 4]), array([], dtype=int64))
 
-        In the example below there are no matched values. For this reason,
-        the returned ``indexer`` contains only integers equal to -1.
-        It demonstrates no index at these positions that match the corresponding
-        ``target`` values. The mask [0, 1, 2] in the return value shows that the first,
-        second, and third elements are missing.
+        In the example below there are no matched values.
 
         >>> index = pd.Index(['c', 'b', 'a', 'b', 'b'])
         >>> index.get_indexer_non_unique(['q', 'r', 't'])
         (array([-1, -1, -1]), array([0, 1, 2]))
 
+        For this reason, the returned ``indexer`` contains only integers equal to -1.
+        It demonstrates no index at these positions that match the corresponding
+        ``target`` values. The mask [0, 1, 2] in the return value shows that the first,
+        second, and third elements are missing.
+
+        Notice that the return value is a tuple contains two items. In the example
+        below the first item is an array of locations in ``index``. The second
+        item is a mask shows that the first and third elements are missing.
+
         >>> index = pd.Index(['c', 'b', 'a', 'b', 'b'])
         >>> index.get_indexer_non_unique(['f', 'b', 's'])
         (array([-1,  1,  3,  4, -1]), array([0, 2]))
 
-        Notice that the return value is a tuple contains two items. In the example
-        above the first item is an array of locations in ``index``. The second
-        item is a mask shows that the first and third elements are missing.
         """
 
     @Appender(_index_shared_docs["get_indexer_non_unique"] % _index_doc_kwargs)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5561,21 +5561,26 @@ class Index(IndexOpsMixin, PandasObject):
         Examples
         --------
         >>> index = pd.Index(['c', 'b', 'a', 'b', 'b'])
-        >>> index.get_indexer_non_unique(['f', 'b', 's'])
-        (array([-1,  1,  3,  4, -1]), array([0, 2]))
-
-        >>> index = pd.Index(['c', 'b', 'a', 'b', 'b'])
         >>> index.get_indexer_non_unique(['b', 'b'])
         (array([1, 3, 4, 1, 3, 4]), array([], dtype=int64))
+
+        In the example below there are no matched values. For this reason,
+        the returned ``indexer`` contains only integers equal to -1.
+        It demonstrates no index at these positions that match the corresponding
+        ``target`` values. The mask [0, 1, 2] in the return value shows that the first,
+        second, and third elements are missing.
 
         >>> index = pd.Index(['c', 'b', 'a', 'b', 'b'])
         >>> index.get_indexer_non_unique(['q', 'r', 't'])
         (array([-1, -1, -1]), array([0, 1, 2]))
 
-        Notice that the return value is a tuple contains two items.
-        The first item is an array of locations in ``index`` and ``x``
-        is marked by -1, as it is not in ``index``. The second item
-        is a mask for new index given the current index.
+        >>> index = pd.Index(['c', 'b', 'a', 'b', 'b'])
+        >>> index.get_indexer_non_unique(['f', 'b', 's'])
+        (array([-1,  1,  3,  4, -1]), array([0, 2]))
+
+        Notice that the return value is a tuple contains two items. In the example
+        above the first item is an array of locations in ``index``. The second
+        item is a mask shows that the first and third elements are missing.
         """
 
     @Appender(_index_shared_docs["get_indexer_non_unique"] % _index_doc_kwargs)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5571,9 +5571,9 @@ class Index(IndexOpsMixin, PandasObject):
         (array([-1, -1, -1]), array([0, 1, 2]))
 
         For this reason, the returned ``indexer`` contains only integers equal to -1.
-        It demonstrates no index at these positions that match the corresponding
-        ``target`` values. The mask [0, 1, 2] in the return value shows that the first,
-        second, and third elements are missing.
+        It demonstrates that there's no match between the index and the ``target``
+        values at these positions. The mask [0, 1, 2] in the return value shows that
+        the first, second, and third elements are missing.
 
         Notice that the return value is a tuple contains two items. In the example
         below the first item is an array of locations in ``index``. The second

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5582,7 +5582,6 @@ class Index(IndexOpsMixin, PandasObject):
         >>> index = pd.Index(['c', 'b', 'a', 'b', 'b'])
         >>> index.get_indexer_non_unique(['f', 'b', 's'])
         (array([-1,  1,  3,  4, -1]), array([0, 2]))
-
         """
 
     @Appender(_index_shared_docs["get_indexer_non_unique"] % _index_doc_kwargs)


### PR DESCRIPTION
- [X] closes #50132
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Updated docstring for `Index.get_indexer_non_unique`. Added examples to clarify `Index.get_indexer_non_unique` behavior.