### PR TITLE
Fix bug #50153

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3288,7 +3288,7 @@ class MultiIndex(Index):
             else:
                 indexer &= lvl_indexer
                 if not np.any(indexer) and np.any(lvl_indexer):
-                    raise KeyError(seq)
+                    return np.array([], dtype=np.intp)
 
         # empty indexer
         if indexer is None:


### PR DESCRIPTION
Instead of raising a KeyError in case a key is available in a level but not found with the combination of previous keys an empty array is returned.

- [ ] closes #50153
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
