### PR TITLE
CI: Fix windows failures

### DIFF
--- a/ci/deps/actions-310.yaml
+++ b/ci/deps/actions-310.yaml
@@ -1,4 +1,4 @@
-name: pandas-dev
+name: pandas-dev-test
 channels:
   - conda-forge
 dependencies:
@@ -26,6 +26,7 @@ dependencies:
   - blosc
   - bottleneck
   - brotlipy
+  - cachetools>5.0.0
   - fastparquet
   - fsspec
   - html5lib

--- a/ci/deps/actions-310.yaml
+++ b/ci/deps/actions-310.yaml
@@ -1,4 +1,4 @@
-name: pandas-dev-test
+name: pandas-dev
 channels:
   - conda-forge
 dependencies:

--- a/ci/deps/actions-38.yaml
+++ b/ci/deps/actions-38.yaml
@@ -26,6 +26,7 @@ dependencies:
   - blosc
   - bottleneck
   - brotlipy
+  - cachetools>5.0.0
   - fastparquet
   - fsspec
   - html5lib

--- a/ci/deps/actions-39.yaml
+++ b/ci/deps/actions-39.yaml
@@ -26,6 +26,7 @@ dependencies:
   - blosc
   - bottleneck
   - brotlipy
+  - cachetools>5.0.0
   - fastparquet
   - fsspec
   - html5lib


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This is really odd, lets see if this works.

Looks like xz was upgrade which causes a bunch of weird downgrades in other places