### PR TITLE
BUG: fixed issue where Index was being accessed with DatetimeIndex attribute

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -178,6 +178,37 @@ the appropriate rows. Also, when ``n`` is larger than the group, no rows instead
 .. ipython:: python
 
     gb.nth(n=3, dropna="any")
+    
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In previous versions, an error occured if the :meth:`dates` method is ran for a date range 
+outside of the holiday's start_date/end_date. The problem arised because the method
+tried to access a DateTimeIndex attribute on an Index object (:issue:`49925`).
+
+*Old Behavior*
+
+.. code-block:: ipython
+
+    In [1]: from pandas import Timestamp as T
+    In [2]: from pandas.tseries.holiday import Holiday, next_monday
+    In [3]: hol = Holiday("Dec 25", month=12, day=25, observance=next_monday, days_of_week=(5, 6), end_date=T("2013-01-01"))
+    In [4]: hol.dates(pd.Timestamp("2020-01-01"), pd.Timestamp("2023-01-01"))
+    Out[5]: Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File "C:\Users\marco\anaconda3\envs\pandas\Lib\site-packages\pandas\tseries\holiday.py", line 274, in dates
+    np.in1d(holiday_dates.dayofweek, self.days_of_week)
+            ^^^^^^^^^^^^^^^^^^^^^^^
+AttributeError: 'Index' object has no attribute 'dayofweek'
+
+*New Behavior*
+
+.. code-block:: python
+
+    In [1]: from pandas import Timestamp as T
+    In [2]: from pandas.tseries.holiday import Holiday, next_monday
+    In [3]: hol = Holiday("Dec 25", month=12, day=25, observance=next_monday, days_of_week=(5, 6), end_date=T("2013-01-01"))
+    In [4]: hol.dates(pd.Timestamp("2020-01-01"), pd.Timestamp("2023-01-01"))
+    Out[5]: DatetimeIndex([], dtype='datetime64[ns]', freq='D')
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_200.api_breaking:

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -198,7 +198,7 @@ tried to access a DateTimeIndex attribute on an Index object (:issue:`49925`).
   File "C:\Users\marco\anaconda3\envs\pandas\Lib\site-packages\pandas\tseries\holiday.py", line 274, in dates
     np.in1d(holiday_dates.dayofweek, self.days_of_week)
             ^^^^^^^^^^^^^^^^^^^^^^^
-            AttributeError: 'Index' object has no attribute 'dayofweek'
+ AttributeError: 'Index' object has no attribute 'dayofweek'
 
 *New Behavior*
 

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -198,7 +198,7 @@ tried to access a DateTimeIndex attribute on an Index object (:issue:`49925`).
   File "C:\Users\marco\anaconda3\envs\pandas\Lib\site-packages\pandas\tseries\holiday.py", line 274, in dates
     np.in1d(holiday_dates.dayofweek, self.days_of_week)
             ^^^^^^^^^^^^^^^^^^^^^^^
-AttributeError: 'Index' object has no attribute 'dayofweek'
+            AttributeError: 'Index' object has no attribute 'dayofweek'
 
 *New Behavior*
 

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -179,10 +179,6 @@ the appropriate rows. Also, when ``n`` is larger than the group, no rows instead
 
     gb.nth(n=3, dropna="any")
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-In previous versions, an error occurred if the :meth:`dates` method is ran for a date range.
-
 .. ---------------------------------------------------------------------------
 .. _whatsnew_200.api_breaking:
 
@@ -721,7 +717,7 @@ Timezones
 ^^^^^^^^^
 - Bug in :meth:`Series.astype` and :meth:`DataFrame.astype` with object-dtype containing multiple timezone-aware ``datetime`` objects with heterogeneous timezones to a :class:`DatetimeTZDtype` incorrectly raising (:issue:`32581`)
 - Bug in :func:`to_datetime` was failing to parse date strings with timezone name when ``format`` was specified with ``%Z`` (:issue:`49748`)
--
+- Bug in :meth:`dates` was trying to access an DatetimeIndex attribute on an Index object when holiday landed outside of date range provided (:issue:`49925`)
 
 Numeric
 ^^^^^^^

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -181,7 +181,7 @@ the appropriate rows. Also, when ``n`` is larger than the group, no rows instead
     
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In previous versions, an error occured if the :meth:`dates` method is ran for a date range.
+In previous versions, an error occurred if the :meth:`dates` method is ran for a date range.
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_200.api_breaking:

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -178,7 +178,7 @@ the appropriate rows. Also, when ``n`` is larger than the group, no rows instead
 .. ipython:: python
 
     gb.nth(n=3, dropna="any")
-    
+
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In previous versions, an error occurred if the :meth:`dates` method is ran for a date range.

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -179,36 +179,9 @@ the appropriate rows. Also, when ``n`` is larger than the group, no rows instead
 
     gb.nth(n=3, dropna="any")
     
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In previous versions, an error occured if the :meth:`dates` method is ran for a date range 
-outside of the holiday's start_date/end_date. The problem arised because the method
-tried to access a DateTimeIndex attribute on an Index object (:issue:`49925`).
-
-*Old Behavior*
-
-.. code-block:: ipython
-
-    In [1]: from pandas import Timestamp as T
-    In [2]: from pandas.tseries.holiday import Holiday, next_monday
-    In [3]: hol = Holiday("Dec 25", month=12, day=25, observance=next_monday, days_of_week=(5, 6), end_date=T("2013-01-01"))
-    In [4]: hol.dates(pd.Timestamp("2020-01-01"), pd.Timestamp("2023-01-01"))
-    Out[5]: Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
-  File "C:\Users\marco\anaconda3\envs\pandas\Lib\site-packages\pandas\tseries\holiday.py", line 274, in dates
-    np.in1d(holiday_dates.dayofweek, self.days_of_week)
-            ^^^^^^^^^^^^^^^^^^^^^^^
- AttributeError: 'Index' object has no attribute 'dayofweek'
-
-*New Behavior*
-
-.. code-block:: python
-
-    In [1]: from pandas import Timestamp as T
-    In [2]: from pandas.tseries.holiday import Holiday, next_monday
-    In [3]: hol = Holiday("Dec 25", month=12, day=25, observance=next_monday, days_of_week=(5, 6), end_date=T("2013-01-01"))
-    In [4]: hol.dates(pd.Timestamp("2020-01-01"), pd.Timestamp("2023-01-01"))
-    Out[5]: DatetimeIndex([], dtype='datetime64[ns]', freq='D')
+In previous versions, an error occured if the :meth:`dates` method is ran for a date range.
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_200.api_breaking:

--- a/pandas/tests/tseries/holiday/test_holiday.py
+++ b/pandas/tests/tseries/holiday/test_holiday.py
@@ -193,6 +193,13 @@ def test_holidays_within_dates(holiday, start, expected):
         holiday.dates(utc.localize(Timestamp(start)), utc.localize(Timestamp(start)))
     ) == [utc.localize(dt) for dt in expected]
 
+    
+def test_holidays_outside_dates():
+    hol = Holiday("Dec 25", month=12, day=25, observance=next_monday, days_of_week=(5, 6),
+                  end_date=Timestamp("2013-01-01"))
+    expected = hol.dates(Timestamp("2010-01-01"), Timestamp("2023-01-01"))
+    assert(isinstance(hol.dates(Timestamp("2020-01-01"), Timestamp("2023-01-01")), type(expected)))
+    
 
 @pytest.mark.parametrize(
     "transform", [lambda x: x.strftime("%Y-%m-%d"), lambda x: Timestamp(x)]

--- a/pandas/tests/tseries/holiday/test_holiday.py
+++ b/pandas/tests/tseries/holiday/test_holiday.py
@@ -193,13 +193,21 @@ def test_holidays_within_dates(holiday, start, expected):
         holiday.dates(utc.localize(Timestamp(start)), utc.localize(Timestamp(start)))
     ) == [utc.localize(dt) for dt in expected]
 
-    
+
 def test_holidays_outside_dates():
-    hol = Holiday("Dec 25", month=12, day=25, observance=next_monday, days_of_week=(5, 6),
-                  end_date=Timestamp("2013-01-01"))
+    hol = Holiday(
+        "Dec 25",
+        month=12,
+        day=25,
+        observance=next_monday,
+        days_of_week=(5, 6),
+        end_date=Timestamp("2013-01-01"),
+    )
     expected = hol.dates(Timestamp("2010-01-01"), Timestamp("2023-01-01"))
-    assert(isinstance(hol.dates(Timestamp("2020-01-01"), Timestamp("2023-01-01")), type(expected)))
-    
+    assert isinstance(
+        hol.dates(Timestamp("2020-01-01"), Timestamp("2023-01-01")), type(expected)
+    )
+
 
 @pytest.mark.parametrize(
     "transform", [lambda x: x.strftime("%Y-%m-%d"), lambda x: Timestamp(x)]

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -275,7 +275,7 @@ class Holiday:
                     np.in1d(holiday_dates.dayofweek, self.days_of_week)
                 ]
             else:
-                holiday_dates = date_range(start_date, end_date)
+                holiday_dates = date_range(start=start_date, end=end_date)
 
         if self.start_date is not None:
             filter_start_date = max(

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -270,9 +270,12 @@ class Holiday:
         dates = self._reference_dates(start_date, end_date)
         holiday_dates = self._apply_rule(dates)
         if self.days_of_week is not None:
-            holiday_dates = holiday_dates[
-                np.in1d(holiday_dates.dayofweek, self.days_of_week)
-            ]
+            if len(holiday_dates) != 0:
+                holiday_dates = holiday_dates[
+                    np.in1d(holiday_dates.dayofweek, self.days_of_week)
+                ]
+            else:
+                holiday_dates = date_range(start_date, end_date)
 
         if self.start_date is not None:
             filter_start_date = max(


### PR DESCRIPTION
- [x] Closes #49925 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Changes: updated the dates method in pandas/tseries/holiday.py to include a check to prevent the DatetimeIndex attribute
from being accessed by an Index object.  The bug occurs if the holidays land outside the provided date range which results in an empty DatetimeIndex object being converted to an Index object. The updated dates method now checks if the object contains elements before allowing access to a DatetimeIndex attribute because such an object will be of type Index. Furthermore, the Index object is converted back into a DatetimeIndex object. A test was added to pandas/tests/tseries/holiday/test_holiday.py to ensure that the intended behavior is occurring. 
