### PR TITLE
Docs: remove duplicated code example

### DIFF
--- a/doc/source/user_guide/basics.rst
+++ b/doc/source/user_guide/basics.rst
@@ -1213,12 +1213,6 @@ With a DataFrame, you can simultaneously reindex the index and columns:
    df
    df.reindex(index=["c", "f", "b"], columns=["three", "two", "one"])
 
-You may also use ``reindex`` with an ``axis`` keyword:
-
-.. ipython:: python
-
-   df.reindex(["c", "f", "b"], axis="index")
-
 Note that the ``Index`` objects containing the actual axis labels can be
 **shared** between objects. So if we have a Series and a DataFrame, the
 following can be done:


### PR DESCRIPTION
This example snippet can be deleted because it reappears further down (two code snippets below). In other words, the paragraph has two examples covering the `axis` keyword arg where only on is needed.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
