### PR TITLE
CI make some more hooks manual

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -39,8 +39,8 @@ jobs:
       with:
         extra_args: --verbose --all-files
 
-  docstring_typing_pylint:
-    name: Docstring validation, typing, and pylint
+  docstring_typing_manual_hooks:
+    name: Docstring validation, typing, and other manual pre-commit hooks
     runs-on: ubuntu-22.04
     defaults:
       run:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,17 @@
 minimum_pre_commit_version: 2.15.0
 exclude: ^LICENSES/|\.(html|csv|svg)$
-# reserve "manual" for mypy and pyright
-default_stages: [commit, merge-commit, push, prepare-commit-msg, commit-msg, post-checkout, post-commit, post-merge, post-rewrite]
+# reserve "manual" for relatively slow hooks which we still want to run in CI
+default_stages: [
+    commit,
+    merge-commit,
+    push,
+    prepare-commit-msg,
+    commit-msg,
+    post-checkout,
+    post-commit,
+    post-merge,
+    post-rewrite
+]
 ci:
     autofix_prs: false
 repos:
@@ -34,9 +44,11 @@ repos:
     -   id: debug-statements
     -   id: end-of-file-fixer
         exclude: \.txt$
-        stages: [commit, merge-commit, push, prepare-commit-msg, commit-msg, post-checkout, post-commit, post-merge, post-rewrite]
+        stages: [commit, merge-commit, push, prepare-commit-msg, commit-msg,
+                 post-checkout, post-commit, post-merge, post-rewrite]
     -   id: trailing-whitespace
-        stages: [commit, merge-commit, push, prepare-commit-msg, commit-msg, post-checkout, post-commit, post-merge, post-rewrite]
+        stages: [commit, merge-commit, push, prepare-commit-msg, commit-msg,
+                 post-checkout, post-commit, post-merge, post-rewrite]
 -   repo: https://github.com/cpplint/cpplint
     rev: 1.6.1
     hooks:
@@ -46,7 +58,13 @@ repos:
         # this particular codebase (e.g. src/headers, src/klib). However,
         # we can lint all header files since they aren't "generated" like C files are.
         exclude: ^pandas/_libs/src/(klib|headers)/
-        args: [--quiet, '--extensions=c,h', '--headers=h', --recursive, '--filter=-readability/casting,-runtime/int,-build/include_subdir']
+        args: [
+            --quiet,
+            '--extensions=c,h',
+            '--headers=h',
+            --recursive,
+            '--filter=-readability/casting,-runtime/int,-build/include_subdir'
+        ]
 -   repo: https://github.com/PyCQA/flake8
     rev: 6.0.0
     hooks:
@@ -107,6 +125,7 @@ repos:
     hooks:
     -   id: yesqa
         additional_dependencies: *flake8_dependencies
+        stages: [manual]
 -   repo: local
     hooks:
     # NOTE: we make `black` a local hook because if it's installed from
@@ -214,7 +233,6 @@ repos:
         exclude: ^pandas/tests/extension/base/base\.py
     -   id: pip-to-conda
         name: Generate pip dependency from conda
-        description: This hook checks if the conda environment.yml and requirements-dev.txt are equal
         language: python
         entry: python scripts/generate_pip_deps_from_conda.py
         files: ^(environment.yml|requirements-dev.txt)$
@@ -311,6 +329,7 @@ repos:
         files: ^pandas
         exclude: ^(pandas/tests|pandas/_version.py|pandas/io/clipboard)
         language: python
+        stages: [manual]
         additional_dependencies:
         - autotyping==22.9.0
         - libcst==0.4.7


### PR DESCRIPTION
This was brought up by @jorisvandenbossche in Slack - `autotyping` is the slowest hook, and is really unlikely to fail for most contributions. Shall we just mark it as being in the `manual` hook-stage, so it'll still run on CI but won't slow down people's local development too much?

Similar story for `yesqa`

It may be possible to replace `flake8` with the much faster `ruff`, but that's for a separate PR

---

Durations from CI when running on all files:
```
In [30]: pd.DataFrame(res).astype({'duration': float}).sort_values('duration', ascending=False)
Out[30]:
                               id  duration
38                     autotyping     77.60
9                          flake8     74.46
17                          black     51.33
16                          yesqa     35.31
11                      pyupgrade     21.21
15                    sphinx-lint     13.14
1                         vulture      9.92
3                     cython-lint      6.54
10                          isort      6.14
5                debug-statements      5.08
0                absolufy-imports      4.83
18                     flake8-rst      3.32
8                         cpplint      1.58
2                       codespell      1.55
29          use-io-common-urlopen      1.21
19              unwanted-patterns      1.00
35      validate-errors-locations      0.85
14     rst-inline-touching-normal      0.79
36                     flake8-pyi      0.77
28           use-pd_array-in-core      0.77
13           rst-directive-colons      0.60
4     double-quote-cython-strings      0.52
7             trailing-whitespace      0.33
12                  rst-backticks      0.25
23         np-testing-array-equal      0.24
21            incorrect-backticks      0.20
31            no-return-exception      0.18
20                 cython-casting      0.15
30        no-bool-in-core-generic      0.13
26           sync-flake8-versions      0.12
24             invalid-ea-testing      0.11
22                 seed-check-asv      0.11
37             future-annotations      0.11
33        pg8000-not-installed-CI      0.11
6               end-of-file-fixer      0.10
25                   pip-to-conda      0.09
34  validate-min-versions-in-sync      0.07
27           title-capitalization      0.06
32       pandas-errors-documented      0.05
```