### PR TITLE
BUG/TST Added support for empty dictionary when passed to agg for gro…

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -413,11 +413,19 @@ class Apply(metaclass=abc.ABCMeta):
                 keys_to_use = ktu
 
             axis: AxisInt = 0 if isinstance(obj, ABCSeries) else 1
-            result = concat(
-                {k: results[k] for k in keys_to_use},
-                axis=axis,
-                keys=keys_to_use,
-            )
+
+            # GH 48581 - Adding consistency to empty agg types
+            if not results:
+                # return empty DataFrame if results is empty, following pattern
+                # empty list and tuple
+                from pandas import DataFrame
+
+                result = DataFrame()
+            else:
+                result = concat(
+                    {k: results[k] for k in keys_to_use}, axis=axis, keys=keys_to_use
+                )
+
         elif any(is_ndframe):
             # There is a mix of NDFrames and scalars
             raise ValueError(

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -1443,3 +1443,12 @@ def test_agg_of_mode_list(test, constant):
     expected = expected.set_index(0)
 
     tm.assert_frame_equal(result, expected)
+
+
+def test_empty_container_consistency():
+    df = pd.DataFrame(data={"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    dict_result = df.groupby("a").agg({})
+
+    expected = DataFrame()
+
+    tm.assert_frame_equal(dict_result, expected)

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -1446,7 +1446,7 @@ def test_agg_of_mode_list(test, constant):
 
 
 def test_empty_container_consistency():
-    df = pd.DataFrame(data={"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    df = DataFrame(data={"a": [1, 2], "b": [3, 4], "c": [5, 6]})
     dict_result = df.groupby("a").agg({})
 
     expected = DataFrame()


### PR DESCRIPTION
…upby

This adds consistency across empty containers when passed to agg for groupby. Also added new test to check new functionality works as expected.

- [x] closes #48581
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
