### PR TITLE
API: ensure IntervalIndex.left/right are 64bit if numeric, part II

### DIFF
--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -46,7 +46,10 @@ from pandas.compat.numpy import function as nv
 from pandas.errors import IntCastingNaNError
 from pandas.util._decorators import Appender
 
-from pandas.core.dtypes.cast import LossySetitemError
+from pandas.core.dtypes.cast import (
+    LossySetitemError,
+    maybe_upcast_numeric_to_64bit,
+)
 from pandas.core.dtypes.common import (
     is_categorical_dtype,
     is_dtype_equal,
@@ -1787,5 +1790,6 @@ def _maybe_convert_platform_interval(values) -> ArrayLike:
         values = extract_array(values, extract_numpy=True)
 
     if not hasattr(values, "dtype"):
-        return np.asarray(values)
+        values = np.asarray(values)
+        values = maybe_upcast_numeric_to_64bit(values)
     return values

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -46,10 +46,7 @@ from pandas.compat.numpy import function as nv
 from pandas.errors import IntCastingNaNError
 from pandas.util._decorators import Appender
 
-from pandas.core.dtypes.cast import (
-    LossySetitemError,
-    maybe_upcast_numeric_to_64bit,
-)
+from pandas.core.dtypes.cast import LossySetitemError
 from pandas.core.dtypes.common import (
     is_categorical_dtype,
     is_dtype_equal,
@@ -1791,5 +1788,6 @@ def _maybe_convert_platform_interval(values) -> ArrayLike:
 
     if not hasattr(values, "dtype"):
         values = np.asarray(values)
-        values = maybe_upcast_numeric_to_64bit(values)
+        if is_integer_dtype(values) and values.dtype != np.int64:
+            values = values.astype(np.int64)
     return values

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -35,6 +35,7 @@ from pandas._typing import (
     ArrayLike,
     Dtype,
     DtypeObj,
+    NumpyIndexT,
     Scalar,
     npt,
 )
@@ -52,6 +53,7 @@ from pandas.core.dtypes.common import (
     ensure_int64,
     ensure_object,
     ensure_str,
+    is_array_like,
     is_bool,
     is_bool_dtype,
     is_complex,
@@ -65,6 +67,7 @@ from pandas.core.dtypes.common import (
     is_numeric_dtype,
     is_object_dtype,
     is_scalar,
+    is_signed_integer_dtype,
     is_string_dtype,
     is_timedelta64_dtype,
     is_unsigned_integer_dtype,
@@ -410,6 +413,34 @@ def maybe_downcast_numeric(
             return new_result
 
     return result
+
+
+def maybe_upcast_numeric_to_64bit(arr: NumpyIndexT) -> NumpyIndexT:
+    """
+    If array is a int/uint/float bit size lower than 64 bit, upcast it to 64 bit.
+
+    Parameters
+    ----------
+    arr : ndarray or ExtensionArray
+
+    Returns
+    -------
+    ndarray or ExtensionArray
+    """
+
+    if not is_array_like(arr):
+        return arr
+    dtype = arr.dtype
+    if not np.issubclass_(dtype.type, np.number):
+        return arr
+    elif is_signed_integer_dtype(dtype) and dtype != np.int64:
+        return arr.astype(np.int64)
+    elif is_unsigned_integer_dtype(dtype) and dtype != np.uint64:
+        return arr.astype(np.uint64)
+    elif is_float_dtype(dtype) and dtype != np.float64:
+        return arr.astype(np.float64)
+    else:
+        return arr
 
 
 def maybe_cast_pointwise_result(

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -427,9 +427,7 @@ def maybe_upcast_numeric_to_64bit(arr: NumpyIndexT) -> NumpyIndexT:
     ndarray or ExtensionArray
     """
     dtype = arr.dtype
-    if not np.issubclass_(dtype.type, np.number):
-        return arr
-    elif is_signed_integer_dtype(dtype) and dtype != np.int64:
+    if is_signed_integer_dtype(dtype) and dtype != np.int64:
         return arr.astype(np.int64)
     elif is_unsigned_integer_dtype(dtype) and dtype != np.uint64:
         return arr.astype(np.uint64)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -53,7 +53,6 @@ from pandas.core.dtypes.common import (
     ensure_int64,
     ensure_object,
     ensure_str,
-    is_array_like,
     is_bool,
     is_bool_dtype,
     is_complex,
@@ -427,9 +426,6 @@ def maybe_upcast_numeric_to_64bit(arr: NumpyIndexT) -> NumpyIndexT:
     -------
     ndarray or ExtensionArray
     """
-
-    if not is_array_like(arr):
-        return arr
     dtype = arr.dtype
     if not np.issubclass_(dtype.type, np.number):
         return arr

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -18,7 +18,10 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Float64Index
+from pandas.core.api import (
+    Float64Index,
+    NumericIndex,
+)
 import pandas.core.common as com
 
 
@@ -435,9 +438,12 @@ class TestIntervalIndex:
         index = IntervalIndex.from_breaks(breaks)
         key = make_key(breaks)
 
-        # no conversion occurs for numeric
         result = index._maybe_convert_i8(key)
-        assert result is key
+        if not isinstance(result, NumericIndex):
+            assert result is key
+        else:
+            expected = NumericIndex(key)
+            tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize(
         "breaks1, breaks2",

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -414,13 +414,18 @@ class TestIntervalIndex:
         result = index._maybe_convert_i8(to_convert)
         tm.assert_index_equal(result, expected)
 
-    def test_maybe_convert_i8_numeric(self, any_real_numpy_dtype):
+    @pytest.mark.parametrize(
+        "make_key", [lambda breaks: breaks, list],
+        ids=["lambda", "list"],
+    )
+    def test_maybe_convert_i8_numeric(self, make_key, any_real_numpy_dtype):
         # GH 20636
         breaks = np.arange(5, dtype=any_real_numpy_dtype)
         index = IntervalIndex.from_breaks(breaks)
+        key = make_key(breaks)
 
-        result = index._maybe_convert_i8(breaks)
-        expected = Index(breaks)
+        result = index._maybe_convert_i8(key)
+        expected = Index(key)
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize(

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -415,7 +415,8 @@ class TestIntervalIndex:
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize(
-        "make_key", [lambda breaks: breaks, list],
+        "make_key",
+        [lambda breaks: breaks, list],
         ids=["lambda", "list"],
     )
     def test_maybe_convert_i8_numeric(self, make_key, any_real_numpy_dtype):

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -18,10 +18,7 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.core.api import (
-    Float64Index,
-    NumericIndex,
-)
+from pandas.core.api import Float64Index
 import pandas.core.common as com
 
 
@@ -417,33 +414,33 @@ class TestIntervalIndex:
         result = index._maybe_convert_i8(to_convert)
         tm.assert_index_equal(result, expected)
 
-    @pytest.mark.parametrize(
-        "breaks",
-        [np.arange(5, dtype="int64"), np.arange(5, dtype="float64")],
-        ids=lambda x: str(x.dtype),
-    )
+    def test_maybe_convert_i8_numeric(self, any_real_numpy_dtype):
+        # GH 20636
+        breaks = np.arange(5, dtype=any_real_numpy_dtype)
+        index = IntervalIndex.from_breaks(breaks)
+
+        result = index._maybe_convert_i8(breaks)
+        expected = Index(breaks)
+        tm.assert_index_equal(result, expected)
+
     @pytest.mark.parametrize(
         "make_key",
         [
             IntervalIndex.from_breaks,
             lambda breaks: Interval(breaks[0], breaks[1]),
-            lambda breaks: breaks,
             lambda breaks: breaks[0],
-            list,
         ],
-        ids=["IntervalIndex", "Interval", "Index", "scalar", "list"],
+        ids=["IntervalIndex", "Interval", "scalar"],
     )
-    def test_maybe_convert_i8_numeric(self, breaks, make_key):
+    def test_maybe_convert_i8_numeric_identical(self, make_key, any_real_numpy_dtype):
         # GH 20636
+        breaks = np.arange(5, dtype=any_real_numpy_dtype)
         index = IntervalIndex.from_breaks(breaks)
         key = make_key(breaks)
 
+        # test if _maybe_convert_i8 won't change key if an Interval or IntervalIndex
         result = index._maybe_convert_i8(key)
-        if not isinstance(result, NumericIndex):
-            assert result is key
-        else:
-            expected = NumericIndex(key)
-            tm.assert_index_equal(result, expected)
+        assert result is key
 
     @pytest.mark.parametrize(
         "breaks1, breaks2",


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Follow-up to #50130. It turned out that `IntervalArray.from_array` could get around the 64bit requirement, so we fix that by moving `maybe_convert_numeric_to_64bit` and  and using it in the `IntervalArray` constructor also. 

Also return the 64bit index in `IntervalIndex._maybe_convert_i8`, previously we returned `original`, which was the  not-64bit-converted one...(this changes a test, but it’s just for an internal method).