### PR TITLE
Backport PR #49212 on branch 1.5.x (Style concats)

### DIFF
--- a/doc/source/whatsnew/v1.5.3.rst
+++ b/doc/source/whatsnew/v1.5.3.rst
@@ -26,7 +26,7 @@ Fixed regressions
 
 Bug fixes
 ~~~~~~~~~
--
+- Bug when chaining several :meth:`.Styler.concat` calls, only the last styler was concatenated (:issue:`49207`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -316,6 +316,12 @@ class Styler(StylerRenderer):
             inherited from the original Styler and not ``other``.
           - hidden columns and hidden index levels will be inherited from the
             original Styler
+          - ``css`` will be inherited from the original Styler, and the value of
+            keys ``data``, ``row_heading`` and ``row`` will be prepended with
+            ``foot0_``. If more concats are chained, their styles will be prepended
+            with ``foot1_``, ''foot_2'', etc., and if a concatenated style have
+            another concatanated style, the second style will be prepended with
+            ``foot{parent}_foot{child}_``.
 
         A common use case is to concatenate user defined functions with
         ``DataFrame.agg`` or with described statistics via ``DataFrame.describe``.
@@ -367,7 +373,7 @@ class Styler(StylerRenderer):
                 "number of index levels must be same in `other` "
                 "as in `Styler`. See documentation for suggestions."
             )
-        self.concatenated = other
+        self.concatenated.append(other)
         return self
 
     def _repr_html_(self) -> str | None:

--- a/pandas/tests/io/formats/style/test_html.py
+++ b/pandas/tests/io/formats/style/test_html.py
@@ -1,4 +1,7 @@
-from textwrap import dedent
+from textwrap import (
+    dedent,
+    indent,
+)
 
 import numpy as np
 import pytest
@@ -822,18 +825,153 @@ def test_concat(styler):
     other = styler.data.agg(["mean"]).style
     styler.concat(other).set_uuid("X")
     result = styler.to_html()
+    fp = "foot0_"
     expected = dedent(
-        """\
+        f"""\
     <tr>
       <th id="T_X_level0_row1" class="row_heading level0 row1" >b</th>
       <td id="T_X_row1_col0" class="data row1 col0" >2.690000</td>
     </tr>
     <tr>
-      <th id="T_X_level0_foot_row0" class="foot_row_heading level0 foot_row0" >mean</th>
-      <td id="T_X_foot_row0_col0" class="foot_data foot_row0 col0" >2.650000</td>
+      <th id="T_X_level0_{fp}row0" class="{fp}row_heading level0 {fp}row0" >mean</th>
+      <td id="T_X_{fp}row0_col0" class="{fp}data {fp}row0 col0" >2.650000</td>
     </tr>
   </tbody>
 </table>
     """
     )
     assert expected in result
+
+
+def test_concat_recursion(styler):
+    df = styler.data
+    styler1 = styler
+    styler2 = Styler(df.agg(["mean"]), precision=3)
+    styler3 = Styler(df.agg(["mean"]), precision=4)
+    styler1.concat(styler2.concat(styler3)).set_uuid("X")
+    result = styler.to_html()
+    # notice that the second concat (last <tr> of the output html),
+    # there are two `foot_` in the id and class
+    fp1 = "foot0_"
+    fp2 = "foot0_foot0_"
+    expected = dedent(
+        f"""\
+    <tr>
+      <th id="T_X_level0_row1" class="row_heading level0 row1" >b</th>
+      <td id="T_X_row1_col0" class="data row1 col0" >2.690000</td>
+    </tr>
+    <tr>
+      <th id="T_X_level0_{fp1}row0" class="{fp1}row_heading level0 {fp1}row0" >mean</th>
+      <td id="T_X_{fp1}row0_col0" class="{fp1}data {fp1}row0 col0" >2.650</td>
+    </tr>
+    <tr>
+      <th id="T_X_level0_{fp2}row0" class="{fp2}row_heading level0 {fp2}row0" >mean</th>
+      <td id="T_X_{fp2}row0_col0" class="{fp2}data {fp2}row0 col0" >2.6500</td>
+    </tr>
+  </tbody>
+</table>
+    """
+    )
+    assert expected in result
+
+
+def test_concat_chain(styler):
+    df = styler.data
+    styler1 = styler
+    styler2 = Styler(df.agg(["mean"]), precision=3)
+    styler3 = Styler(df.agg(["mean"]), precision=4)
+    styler1.concat(styler2).concat(styler3).set_uuid("X")
+    result = styler.to_html()
+    fp1 = "foot0_"
+    fp2 = "foot1_"
+    expected = dedent(
+        f"""\
+    <tr>
+      <th id="T_X_level0_row1" class="row_heading level0 row1" >b</th>
+      <td id="T_X_row1_col0" class="data row1 col0" >2.690000</td>
+    </tr>
+    <tr>
+      <th id="T_X_level0_{fp1}row0" class="{fp1}row_heading level0 {fp1}row0" >mean</th>
+      <td id="T_X_{fp1}row0_col0" class="{fp1}data {fp1}row0 col0" >2.650</td>
+    </tr>
+    <tr>
+      <th id="T_X_level0_{fp2}row0" class="{fp2}row_heading level0 {fp2}row0" >mean</th>
+      <td id="T_X_{fp2}row0_col0" class="{fp2}data {fp2}row0 col0" >2.6500</td>
+    </tr>
+  </tbody>
+</table>
+    """
+    )
+    assert expected in result
+
+
+def test_concat_combined():
+    def html_lines(foot_prefix: str):
+        assert foot_prefix.endswith("_") or foot_prefix == ""
+        fp = foot_prefix
+        return indent(
+            dedent(
+                f"""\
+        <tr>
+          <th id="T_X_level0_{fp}row0" class="{fp}row_heading level0 {fp}row0" >a</th>
+          <td id="T_X_{fp}row0_col0" class="{fp}data {fp}row0 col0" >2.610000</td>
+        </tr>
+        <tr>
+          <th id="T_X_level0_{fp}row1" class="{fp}row_heading level0 {fp}row1" >b</th>
+          <td id="T_X_{fp}row1_col0" class="{fp}data {fp}row1 col0" >2.690000</td>
+        </tr>
+        """
+            ),
+            prefix=" " * 4,
+        )
+
+    df = DataFrame([[2.61], [2.69]], index=["a", "b"], columns=["A"])
+    s1 = df.style.highlight_max(color="red")
+    s2 = df.style.highlight_max(color="green")
+    s3 = df.style.highlight_max(color="blue")
+    s4 = df.style.highlight_max(color="yellow")
+
+    result = s1.concat(s2).concat(s3.concat(s4)).set_uuid("X").to_html()
+    expected_css = dedent(
+        """\
+        <style type="text/css">
+        #T_X_row1_col0 {
+          background-color: red;
+        }
+        #T_X_foot0_row1_col0 {
+          background-color: green;
+        }
+        #T_X_foot1_row1_col0 {
+          background-color: blue;
+        }
+        #T_X_foot1_foot0_row1_col0 {
+          background-color: yellow;
+        }
+        </style>
+        """
+    )
+    expected_table = (
+        dedent(
+            """\
+            <table id="T_X">
+              <thead>
+                <tr>
+                  <th class="blank level0" >&nbsp;</th>
+                  <th id="T_X_level0_col0" class="col_heading level0 col0" >A</th>
+                </tr>
+              </thead>
+              <tbody>
+            """
+        )
+        + html_lines("")
+        + html_lines("foot0_")
+        + html_lines("foot1_")
+        + html_lines("foot1_foot0_")
+        + dedent(
+            """\
+              </tbody>
+            </table>
+            """
+        )
+    )
+    assert expected_css + expected_table == result

--- a/pandas/tests/io/formats/style/test_to_latex.py
+++ b/pandas/tests/io/formats/style/test_to_latex.py
@@ -1034,6 +1034,26 @@ def test_concat_recursion():
     assert result == expected
 
 
+def test_concat_chain():
+    # tests hidden row recursion and applied styles
+    styler1 = DataFrame([[1], [9]]).style.hide([1]).highlight_min(color="red")
+    styler2 = DataFrame([[9], [2]]).style.hide([0]).highlight_min(color="green")
+    styler3 = DataFrame([[3], [9]]).style.hide([1]).highlight_min(color="blue")
+
+    result = styler1.concat(styler2).concat(styler3).to_latex(convert_css=True)
+    expected = dedent(
+        """\
+    \\begin{tabular}{lr}
+     & 0 \\\\
+    0 & {\\cellcolor{red}} 1 \\\\
+    1 & {\\cellcolor{green}} 2 \\\\
+    0 & {\\cellcolor{blue}} 3 \\\\
+    \\end{tabular}
+    """
+    )
+    assert result == expected
+
+
 @pytest.mark.parametrize(
     "df, expected",
     [

--- a/pandas/tests/io/formats/style/test_to_string.py
+++ b/pandas/tests/io/formats/style/test_to_string.py
@@ -53,3 +53,39 @@ def test_concat(styler):
     """
     )
     assert result == expected
+
+
+def test_concat_recursion(styler):
+    df = styler.data
+    styler1 = styler
+    styler2 = Styler(df.agg(["sum"]), uuid_len=0, precision=3)
+    styler3 = Styler(df.agg(["sum"]), uuid_len=0, precision=4)
+    result = styler1.concat(styler2.concat(styler3)).to_string()
+    expected = dedent(
+        """\
+     A B C
+    0 0 -0.61 ab
+    1 1 -1.22 cd
+    sum 1 -1.830 abcd
+    sum 1 -1.8300 abcd
+    """
+    )
+    assert result == expected
+
+
+def test_concat_chain(styler):
+    df = styler.data
+    styler1 = styler
+    styler2 = Styler(df.agg(["sum"]), uuid_len=0, precision=3)
+    styler3 = Styler(df.agg(["sum"]), uuid_len=0, precision=4)
+    result = styler1.concat(styler2).concat(styler3).to_string()
+    expected = dedent(
+        """\
+     A B C
+    0 0 -0.61 ab
+    1 1 -1.22 cd
+    sum 1 -1.830 abcd
+    sum 1 -1.8300 abcd
+    """
+    )
+    assert result == expected


### PR DESCRIPTION
Backport PR #49212 on branch 1.5.x (Style concats)

- [x] closes  #49207
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v1.5.3.rst` file if fixing a bug or adding a new feature.
