### PR TITLE
REF: Move base indexes import in interval array

### DIFF
--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -89,7 +89,6 @@ from pandas.core.construction import (
     extract_array,
 )
 from pandas.core.indexers import check_array_indexer
-from pandas.core.indexes.base import ensure_index
 from pandas.core.ops import (
     invalid_comparison,
     unpack_zerodim_and_defer,
@@ -281,6 +280,9 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             closed = dtype.closed
 
         closed = closed or "right"
+
+        from pandas.core.indexes.base import ensure_index
+
         left = ensure_index(left, copy=copy)
         right = ensure_index(right, copy=copy)
 


### PR DESCRIPTION
cc @jbrockmendel Nice! This will allow us to import BaseMaskedArray top level in base.
