### PR TITLE
Initialize row data frame with list

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -641,7 +641,7 @@ class DataFrame(NDFrame, OpsMixin):
         
             
             
-
+        
         if isinstance(data,list) and columns is not None: 
             nested_list = False
             len_columns = len(columns)
@@ -653,24 +653,24 @@ class DataFrame(NDFrame, OpsMixin):
             if nested_list is not True:
                 if len_columns > 1:
                     if len_columns == len_data:
-                        if len(direction)<2 and len(direction)>2:
-                            print(f'Error: direction has length equal to 2')
-                            exit(1)
+                        if len(direction) is not 2:
+                            raise Exception('Error: direction has length equal to 2')
                         elif direction == ["arrow",None]:
                             if index is None:
                                 index=[0]
                             for i,j in zip(range(len(columns)),range(len(data))):
                                 dict_data[columns[i]] = data[j]   
                             data = dict_data
+                        elif direction[0] == "columns" and index != None:
+                            raise Exception("Error:It's not possible to set index when direction parameter is setted as columns.")
                         elif direction[0] == "columns" and direction[1] != None:
                             if direction[1] not in columns:
-                                print("Error: direction not in columns")
-                                exit(1)
+                                raise Exception("Error: direction not in columns")
                             index_column = direction[1]
                             index = None
                             NaN_list = list()
                             for i in range(len(data)):
-                                NaN_list.append(None)
+                                NaN_list.append(np.nan)
                             for i in columns:
                                 if i == index_column:
                                     dict_data[i] = data
@@ -679,16 +679,13 @@ class DataFrame(NDFrame, OpsMixin):
                             data = dict_data
                            
                         elif direction[0] == "arrow" and direction[1] != None:
-
-                            print(f'Error: direction[1] needs to be None when direction[0] is "arrow"')
-                            exit(1)   
+                            raise Exception('Error: direction[1] needs to be None when direction[0] is "arrow"')
                             
                         elif direction == ["columns",None]:
-                            print(f'Error: When direction[0] is set as "columns", direction[1] requires a column name.')
-                            exit(1) 
+                            raise Exception('Error: When direction[0] is set as "columns", direction[1] requires a column name.')
                         else:
-                            print(f'Error: invalid parameters.')
-                            exit(1) 
+                            raise Exception('Error: invalid parameters.')
+                             
                 
         if isinstance(data, DataFrame):
             data = data._mgr

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -627,6 +627,7 @@ class DataFrame(NDFrame, OpsMixin):
         data=None,
         index: Axes | None = None,
         columns: Axes | None = None,
+        direction: list =["arrow",None], 
         dtype: Dtype | None = None,
         copy: bool | None = None,
     ) -> None:
@@ -635,18 +636,59 @@ class DataFrame(NDFrame, OpsMixin):
             data = {}
         if dtype is not None:
             dtype = self._validate_dtype(dtype)
+        
+
+        
+            
+            
 
         if isinstance(data,list) and columns is not None: 
+            nested_list = False
             len_columns = len(columns)
             len_data = len(data)
-            if index is None:
-                index=[0]
-            if len_columns > 1:
-                if len_columns == len_data:
-                    dict_data = dict()
-                    for i,j in zip(range(len(columns)),range(len(data))):
-                        dict_data[columns[i]] = data[j]   
-                    data = dict_data  
+            dict_data = dict()       
+            for i in data:
+                if type(i) == list:
+                   nested_list = True 
+            if nested_list is not True:
+                if len_columns > 1:
+                    if len_columns == len_data:
+                        if len(direction)<2 and len(direction)>2:
+                            print(f'Error: direction has length equal to 2')
+                            exit(1)
+                        elif direction == ["arrow",None]:
+                            if index is None:
+                                index=[0]
+                            for i,j in zip(range(len(columns)),range(len(data))):
+                                dict_data[columns[i]] = data[j]   
+                            data = dict_data
+                        elif direction[0] == "columns" and direction[1] != None:
+                            if direction[1] not in columns:
+                                print("Error: direction not in columns")
+                                exit(1)
+                            index_column = direction[1]
+                            index = None
+                            NaN_list = list()
+                            for i in range(len(data)):
+                                NaN_list.append(None)
+                            for i in columns:
+                                if i == index_column:
+                                    dict_data[i] = data
+                                    continue
+                                dict_data[i] = NaN_list
+                            data = dict_data
+                           
+                        elif direction[0] == "arrow" and direction[1] != None:
+
+                            print(f'Error: direction[1] needs to be None when direction[0] is "arrow"')
+                            exit(1)   
+                            
+                        elif direction == ["columns",None]:
+                            print(f'Error: When direction[0] is set as "columns", direction[1] requires a column name.')
+                            exit(1) 
+                        else:
+                            print(f'Error: invalid parameters.')
+                            exit(1) 
                 
         if isinstance(data, DataFrame):
             data = data._mgr

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -636,6 +636,18 @@ class DataFrame(NDFrame, OpsMixin):
         if dtype is not None:
             dtype = self._validate_dtype(dtype)
 
+        if isinstance(data,list) and columns is not None: 
+            len_columns = len(columns)
+            len_data = len(data)
+            if index is None:
+                index=[0]
+            if len_columns > 1:
+                if len_columns == len_data:
+                    dict_data = dict()
+                    for i,j in zip(range(len(columns)),range(len(data))):
+                        dict_data[columns[i]] = data[j]   
+                    data = dict_data  
+                
         if isinstance(data, DataFrame):
             data = data._mgr
 

--- a/pandas/tests/frame/constructors/test_from_list.py
+++ b/pandas/tests/frame/constructors/test_from_list.py
@@ -1,0 +1,96 @@
+
+import pytest
+import pandas as pd
+import pandas._testing as tm
+import numpy as np
+
+
+
+class TestFromList:
+     
+    #  passing lists to DataFrame.__init__
+    # related GH#6140
+    def test_start_with_a_List_and_directions_parameter_is_not_setted(self):
+        list_data = [1,2,3,4]
+        list_columns = ["a","b","c","d"]
+        dict = {'a': 1, 'b': 2,'c':3,'d':4}
+        result = pd.DataFrame(data=list_data,columns=list_columns,index=[0])
+        expected  = pd.DataFrame(dict,index=[0])
+        tm.assert_frame_equal(result,expected)
+
+    def test_start_with_a_List_and_directions_parameter_is_not_setted_and_index_parameter_is_not_setted(self):
+        list_data = [1,2,3,4]
+        list_columns = ["a","b","c","d"]
+        dict = {'a': 1, 'b': 2,'c':3,'d':4}
+        result = pd.DataFrame(data=list_data,columns=list_columns)
+        expected  = pd.DataFrame(dict,index=[0])
+        tm.assert_frame_equal(result,expected)
+    
+    
+    def test_direction_parameter_len_higher_then_two_and_direction_setted_as_arrow(self):
+        list_data = [1,2,3,4]
+        list_columns = ["a","b","c","d"]
+        with pytest.raises(Exception):
+            pd.DataFrame(data=list_data,columns=list_columns,index=[0],direction=["arrow",None,"aleatory_variable"])
+           
+    def test_direction_parameter_len_lower_then_two_and_direction_setted_as_arrow(self):
+        list_data = [1,2,3,4]
+        list_columns = ["a","b","c","d"]
+        with pytest.raises(Exception):
+            pd.DataFrame(data=list_data,columns=list_columns,index=[0],direction=["arrow"])
+            
+    
+    def test_direction_parameter_len_higher_then_two_and_direction_setted_as_columns(self):
+        list_data = [1,2,3,4]
+        list_columns = ["a","b","c","d"]
+        with pytest.raises(Exception):
+            pd.DataFrame(data=list_data,columns=list_columns,index=[0],direction=["columns",None,"aleatory_variable"])
+
+    def test_direction_parameter_len_lower_then_two_and_direction_setted_as_columns(self):
+        list_data = [1,2,3,4]
+        list_columns = ["a","b","c","d"]
+        with pytest.raises(Exception):
+            pd.DataFrame(data=list_data,columns=list_columns,index=[0],direction=["columns"])
+
+    
+    def test_direction_parameter_setted_as_arrow_with_second_element_different_from_None(self): 
+        list_data = [1,2,3,4]
+        list_columns = ["a","b","c","d"]
+        with pytest.raises(Exception):
+            pd.DataFrame(data=list_data,columns=list_columns,index=[0],direction=["arrow","Aleatory_variable"])
+
+    def test_create_a_dataframe_when_direction_parameter_is_setted_as_columns(self):
+        list_data = [1,2,3,4]
+        list_columns = ["a","b","c","d"]
+        nan_list = list()
+        for i in range(0,4):
+            nan_list.append(np.nan)
+
+
+        dict = {'a': [1,2,3,4], 'b':nan_list,'c':nan_list,'d':nan_list}
+        result = pd.DataFrame(data=list_data,columns=list_columns,direction=["columns","a"])
+        expected = pd.DataFrame(data=dict, index=[0, 1, 2, 3])
+        tm.assert_frame_equal(result,expected)
+
+
+    def test_direction_parameter_columns_with_second_element_None(self):
+        list_data = [1,2,3,4]
+        list_columns = ["a","b","c","d"]
+        with pytest.raises(Exception):
+            pd.DataFrame(data=list_data,columns=list_columns,index=[0],direction=["columns", None])
+
+
+    def test_direction_parameter_setted_as_columns_and_index_parameter_is_setted(self):
+        list_data = [1,2,3,4]
+        list_columns = ["a","b","c","d"]
+        with pytest.raises(Exception):
+            pd.DataFrame(data=list_data,columns=list_columns,index=[2],direction=["columns","a"])
+
+    def test_invalid_values_in_direction_parameter(self):
+        list_data = [1,2,3,4]
+        list_columns = ["a","b","c","d"]
+        with pytest.raises(Exception):
+            pd.DataFrame(data=list_data,columns=list_columns,index=[2],direction=["Invalid",5])
+    
+
+    


### PR DESCRIPTION
- [X ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- New Feature

It is now possible to initialize a dataframe with a list.

A parameter was also created that allows choosing the direction in which the list will be inserted in the dataframe when initializing it. By column or row.

Here are some examples:

EX1: direction parameter was not set and index parameter was
        list_data = [1,2,3,4]
        list_columns = ["a","b","c","d"]
        result = pd.DataFrame(data=list_data,columns=list_columns,index=[5])

Result:
    a  b  c  d
5  1  2  3  4

EX2: direction parameter set as column 
   
    list_data = ["x","y","z","k"]
    list_columns = ["a","b","c","d"]
   pd.DataFrame(data=list_data,columns=list_columns,direction=["columns","b"])

Result:
      a           b        c     d
0   NaN    NaN     x   NaN
1   NaN    NaN     y   NaN
2   NaN    NaN     z   NaN
3   NaN    NaN     k   NaN

 
