### PR TITLE
CI: continue-on-error: true for scorecard action

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -14,6 +14,7 @@ jobs:
   analysis:
     name: Scorecards analysis
     runs-on: ubuntu-22.04
+    continue-on-error: true
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write


### PR DESCRIPTION
This job on main is currently failing with a 500 error 

```
 2022/12/14 18:00:45 error processing signature: http response 500, status: 500 Internal Server Error, error: {"code":500,"message":"something went wrong and we are looking into it."}
```

I am doubtful this is entirely actionable on our side (or if it ever will be), and it masks if there are actual failures on main so just letting this job "pass" even if there are these issues