### PR TITLE
PERF: Series(pyarrow-backed).rank

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -734,7 +734,7 @@ Performance improvements
 - Performance improvement in :meth:`MultiIndex.isin` when ``level=None`` (:issue:`48622`, :issue:`49577`)
 - Performance improvement in :meth:`MultiIndex.putmask` (:issue:`49830`)
 - Performance improvement in :meth:`Index.union` and :meth:`MultiIndex.union` when index contains duplicates (:issue:`48900`)
-- Performance improvement in :meth:`Series.rank` for pyarrow-backed dtypes (:issue:`#####`)
+- Performance improvement in :meth:`Series.rank` for pyarrow-backed dtypes (:issue:`50264`)
 - Performance improvement in :meth:`Series.fillna` for extension array dtypes (:issue:`49722`, :issue:`50078`)
 - Performance improvement for :meth:`Series.value_counts` with nullable dtype (:issue:`48338`)
 - Performance improvement for :class:`Series` constructor passing integer numpy array with nullable dtype (:issue:`48338`)

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -734,6 +734,7 @@ Performance improvements
 - Performance improvement in :meth:`MultiIndex.isin` when ``level=None`` (:issue:`48622`, :issue:`49577`)
 - Performance improvement in :meth:`MultiIndex.putmask` (:issue:`49830`)
 - Performance improvement in :meth:`Index.union` and :meth:`MultiIndex.union` when index contains duplicates (:issue:`48900`)
+- Performance improvement in :meth:`Series.rank` for pyarrow-backed dtypes (:issue:`#####`)
 - Performance improvement in :meth:`Series.fillna` for extension array dtypes (:issue:`49722`, :issue:`50078`)
 - Performance improvement for :meth:`Series.value_counts` with nullable dtype (:issue:`48338`)
 - Performance improvement for :class:`Series` constructor passing integer numpy array with nullable dtype (:issue:`48338`)

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -981,7 +981,11 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray):
                 ascending=ascending,
                 pct=pct,
             )
-            result = pa.array(ranked, type=pa.float64(), from_pandas=True)
+            if method != "average" and not pct:
+                pa_type = pa.uint64()
+            else:
+                pa_type = pa.float64()
+            result = pa.array(ranked, type=pa_type, from_pandas=True)
             return type(self)(result)
 
         sort_keys = "ascending" if ascending else "descending"

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -963,7 +963,7 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray):
         """
         See Series.rank.__doc__.
         """
-        if pa_version_under9p0:
+        if pa_version_under9p0 or axis != 0:
             ranked = super()._rank(
                 axis=axis,
                 method=method,
@@ -978,9 +978,6 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray):
                 pa_type = pa.uint64()
             result = pa.array(ranked, type=pa_type, from_pandas=True)
             return type(self)(result)
-
-        if axis != 0:
-            raise NotImplementedError
 
         data = self._data.combine_chunks()
         sort_keys = "ascending" if ascending else "descending"

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -964,7 +964,7 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray):
         See Series.rank.__doc__.
         """
         if pa_version_under9p0:
-            ranked = super().rank(
+            ranked = super()._rank(
                 axis=axis,
                 method=method,
                 na_option=na_option,

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -997,15 +997,15 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray):
             null_placement=null_placement,
             tiebreaker=method,
         )
-        if not pa.types.is_floating(result.type):
-            result = result.cast(pa.float64())
 
         if na_option == "keep":
             mask = pc.is_null(self._data)
-            null = pa.scalar(None, type=self._data.type)
+            null = pa.scalar(None, type=result.type)
             result = pc.if_else(mask, null, result)
 
         if pct:
+            if not pa.types.is_floating(result.type):
+                result = result.cast(pa.float64())
             if method == "dense":
                 divisor = pc.max(result)
             else:

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1576,8 +1576,6 @@ class ExtensionArray:
         if axis != 0:
             raise NotImplementedError
 
-        # TODO: we only have tests that get here with dt64 and td64
-        # TODO: all tests that get here use the defaults for all the kwds
         return rank(
             self,
             axis=axis,

--- a/pandas/tests/series/methods/test_rank.py
+++ b/pandas/tests/series/methods/test_rank.py
@@ -46,8 +46,8 @@ def results(request):
         "int64",
         "Float64",
         "Int64",
-        "float64[pyarrow]",
-        "int64[pyarrow]",
+        pytest.param("float64[pyarrow]", marks=td.skip_if_no("pyarrow")),
+        pytest.param("int64[pyarrow]", marks=td.skip_if_no("pyarrow")),
     ]
 )
 def dtype(request):
@@ -255,7 +255,9 @@ class TestSeriesRank:
             ("object", None, Infinity(), NegInfinity()),
             ("float64", np.nan, np.inf, -np.inf),
             ("Float64", NA, np.inf, -np.inf),
-            ("float64[pyarrow]", NA, np.inf, -np.inf),
+            pytest.param(
+                "float64[pyarrow]", NA, np.inf, -np.inf, marks=td.skip_if_no("pyarrow")
+            ),
         ],
     )
     def test_rank_tie_methods_on_infs_nans(

--- a/pandas/tests/series/methods/test_rank.py
+++ b/pandas/tests/series/methods/test_rank.py
@@ -11,6 +11,7 @@ from pandas._libs.algos import (
 import pandas.util._test_decorators as td
 
 from pandas import (
+    NA,
     NaT,
     Series,
     Timestamp,
@@ -35,6 +36,21 @@ def ser():
     ]
 )
 def results(request):
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        "object",
+        "float64",
+        "int64",
+        "Float64",
+        "Int64",
+        "float64[pyarrow]",
+        "int64[pyarrow]",
+    ]
+)
+def dtype(request):
     return request.param
 
 
@@ -238,13 +254,16 @@ class TestSeriesRank:
         [
             ("object", None, Infinity(), NegInfinity()),
             ("float64", np.nan, np.inf, -np.inf),
+            ("Float64", NA, np.inf, -np.inf),
+            ("float64[pyarrow]", NA, np.inf, -np.inf),
         ],
     )
     def test_rank_tie_methods_on_infs_nans(
         self, method, na_option, ascending, dtype, na_value, pos_inf, neg_inf
     ):
-        chunk = 3
+        exp_dtype = dtype if dtype == "float64[pyarrow]" else "float64"
 
+        chunk = 3
         in_arr = [neg_inf] * chunk + [na_value] * chunk + [pos_inf] * chunk
         iseries = Series(in_arr, dtype=dtype)
         exp_ranks = {
@@ -264,7 +283,7 @@ class TestSeriesRank:
         expected = order if ascending else order[::-1]
         expected = list(chain.from_iterable(expected))
         result = iseries.rank(method=method, na_option=na_option, ascending=ascending)
-        tm.assert_series_equal(result, Series(expected, dtype="float64"))
+        tm.assert_series_equal(result, Series(expected, dtype=exp_dtype))
 
     def test_rank_desc_mix_nans_infs(self):
         # GH 19538
@@ -299,7 +318,6 @@ class TestSeriesRank:
         expected = Series(sprank, index=index).astype("float64")
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.parametrize("dtype", ["O", "f8", "i8"])
     @pytest.mark.parametrize(
         "ser, exp",
         [
@@ -319,7 +337,6 @@ class TestSeriesRank:
         expected = Series(exp).astype(result.dtype)
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.parametrize("dtype", ["O", "f8", "i8"])
     def test_rank_descending(self, ser, results, dtype):
         method, _ = results
         if "i" in dtype:
@@ -365,7 +382,6 @@ class TestSeriesRank:
 # GH15630, pct should be on 100% basis when method='dense'
 
 
-@pytest.mark.parametrize("dtype", ["O", "f8", "i8"])
 @pytest.mark.parametrize(
     "ser, exp",
     [
@@ -387,7 +403,6 @@ def test_rank_dense_pct(dtype, ser, exp):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize("dtype", ["O", "f8", "i8"])
 @pytest.mark.parametrize(
     "ser, exp",
     [
@@ -409,7 +424,6 @@ def test_rank_min_pct(dtype, ser, exp):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize("dtype", ["O", "f8", "i8"])
 @pytest.mark.parametrize(
     "ser, exp",
     [
@@ -431,7 +445,6 @@ def test_rank_max_pct(dtype, ser, exp):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize("dtype", ["O", "f8", "i8"])
 @pytest.mark.parametrize(
     "ser, exp",
     [
@@ -453,7 +466,6 @@ def test_rank_average_pct(dtype, ser, exp):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize("dtype", ["f8", "i8"])
 @pytest.mark.parametrize(
     "ser, exp",
     [

--- a/pandas/tests/series/methods/test_rank.py
+++ b/pandas/tests/series/methods/test_rank.py
@@ -263,7 +263,13 @@ class TestSeriesRank:
     def test_rank_tie_methods_on_infs_nans(
         self, method, na_option, ascending, dtype, na_value, pos_inf, neg_inf
     ):
-        exp_dtype = dtype if dtype == "float64[pyarrow]" else "float64"
+        if dtype == "float64[pyarrow]":
+            if method == "average":
+                exp_dtype = "float64[pyarrow]"
+            else:
+                exp_dtype = "uint64[pyarrow]"
+        else:
+            exp_dtype = "float64"
 
         chunk = 3
         in_arr = [neg_inf] * chunk + [na_value] * chunk + [pos_inf] * chunk

--- a/pandas/tests/series/methods/test_rank.py
+++ b/pandas/tests/series/methods/test_rank.py
@@ -256,7 +256,11 @@ class TestSeriesRank:
             ("float64", np.nan, np.inf, -np.inf),
             ("Float64", NA, np.inf, -np.inf),
             pytest.param(
-                "float64[pyarrow]", NA, np.inf, -np.inf, marks=td.skip_if_no("pyarrow")
+                "float64[pyarrow]",
+                NA,
+                np.inf,
+                -np.inf,
+                marks=td.skip_if_no("pyarrow", min_version="9.0"),
             ),
         ],
     )

--- a/pandas/tests/series/methods/test_rank.py
+++ b/pandas/tests/series/methods/test_rank.py
@@ -260,7 +260,7 @@ class TestSeriesRank:
                 NA,
                 np.inf,
                 -np.inf,
-                marks=td.skip_if_no("pyarrow", min_version="9.0"),
+                marks=td.skip_if_no("pyarrow"),
             ),
         ],
     )


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.0.0.rst` file if fixing a bug or adding a new feature.

Perf improvement in `Series(pyarrow-backed).rank` by using `pyarrow.compute.rank`. All parameter combinations use pyarrow compute functions except for `method="average"` which falls back to `algos.rank`.

```
import pandas as pd 
import numpy as np

ser = pd.Series(np.random.randn(10**6), dtype="float64[pyarrow]")

%timeit ser.rank(method="first")

# 1.41 s ± 10.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)    <- main
# 148 ms ± 1.42 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)  <- PR
```