### PR TITLE
DEV speed up `pip install -r requirements-dev.txt` by nearly 2000%

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,6 @@ dependencies:
   - pytest-xdist>=1.31
   - psutil
   - pytest-asyncio>=0.17
-  - boto3
   - coverage
 
   # required dependencies
@@ -28,7 +27,6 @@ dependencies:
   - beautifulsoup4
   - blosc
   - brotlipy
-  - botocore
   - bottleneck
   - fastparquet
   - fsspec

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,6 @@ pytest-cov
 pytest-xdist>=1.31
 psutil
 pytest-asyncio>=0.17
-boto3
 coverage
 python-dateutil
 numpy
@@ -17,7 +16,6 @@ pytz
 beautifulsoup4
 blosc
 brotlipy
-botocore
 bottleneck
 fastparquet
 fsspec


### PR DESCRIPTION
- [ ] closes #50239 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

it looks like it may not be necessary to list boto3 and botocore, and they get pulled in anyway by s3fs and moto

EDIT:

yup, this works! and we can stop listing even more unpinned dependencies!

- botocore and boto3 are pulled in by s3fs
- beautifulsoup4 is pulled in by nbsphinx
- coverage is pulled in by pytest-cov
- fsspec is pulled in by s3fs
- gitdb is pulled in by GitPython
- ipykernel is pulled in by ipywidgets
- ipython is pulled in by ipywidgets
- jinja2 is pulled in by moto
- nbformat is pulled in by nbsphinx
- psutil is pulled in by ipywidgets
- pyyaml is pulled in by dask
- requests is pulled in by gcsfs
- sphinx is pulled in by nbsphinx

By removing them, `pip install -r requirements-dev.txt` goes from taking over 54 minutes, to just under 3 minutes!

EDIT2: only removing boto3 and botocore. Timing is still under 3 minutes 🥳 