### PR TITLE
CLN: clean IntervalArray._simple_new

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -44,6 +44,10 @@ if TYPE_CHECKING:
     from pandas.core.dtypes.dtypes import ExtensionDtype
 
     from pandas import Interval
+    from pandas.arrays import (
+        DatetimeArray,
+        TimedeltaArray,
+    )
     from pandas.core.arrays.base import ExtensionArray
     from pandas.core.frame import DataFrame
     from pandas.core.generic import NDFrame
@@ -88,6 +92,7 @@ HashableT = TypeVar("HashableT", bound=Hashable)
 
 ArrayLike = Union["ExtensionArray", np.ndarray]
 AnyArrayLike = Union[ArrayLike, "Index", "Series"]
+TimeArrayLike = Union["DatetimeArray", "TimedeltaArray"]
 
 # scalars
 

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -213,8 +213,8 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         return 1
 
     # To make mypy recognize the fields
-    _left: np.ndarray
-    _right: np.ndarray
+    _left: ArrayLike
+    _right: ArrayLike
     _dtype: IntervalDtype
 
     # ---------------------------------------------------------------------
@@ -714,7 +714,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             if is_scalar(left) and isna(left):
                 return self._fill_value
             return Interval(left, right, self.closed)
-        if np.ndim(left) > 1:
+        if np.ndim(left) > 1:  # type: ignore[arg-type]
             # GH#30588 multi-dimensional indexer disallowed
             raise ValueError("multi-dimensional indexing not allowed")
         return self._shallow_copy(left, right)
@@ -1456,15 +1456,15 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         # at a point when both sides of intervals are included
         if self.closed == "both":
             return bool(
-                (self._right[:-1] < self._left[1:]).all()
-                or (self._left[:-1] > self._right[1:]).all()
+                (self._right[:-1] < self._left[1:]).all()  # type: ignore[operator]
+                or (self._left[:-1] > self._right[1:]).all()  # type: ignore[operator]
             )
 
         # non-strict inequality when closed != 'both'; at least one side is
         # not included in the intervals, so equality does not imply overlapping
         return bool(
-            (self._right[:-1] <= self._left[1:]).all()
-            or (self._left[:-1] >= self._right[1:]).all()
+            (self._right[:-1] <= self._left[1:]).all()  # type: ignore[operator]
+            or (self._left[:-1] >= self._right[1:]).all()  # type: ignore[operator]
         )
 
     # ---------------------------------------------------------------------
@@ -1574,9 +1574,11 @@ class IntervalArray(IntervalMixin, ExtensionArray):
 
         if isinstance(self._left, np.ndarray):
             np.putmask(self._left, mask, value_left)
+            assert isinstance(self._right, np.ndarray)
             np.putmask(self._right, mask, value_right)
         else:
             self._left._putmask(mask, value_left)
+            assert isinstance(self._right, ExtensionArray)
             self._right._putmask(mask, value_right)
 
     def insert(self: IntervalArrayT, loc: int, item: Interval) -> IntervalArrayT:
@@ -1603,10 +1605,12 @@ class IntervalArray(IntervalMixin, ExtensionArray):
 
     def delete(self: IntervalArrayT, loc) -> IntervalArrayT:
         if isinstance(self._left, np.ndarray):
-            new_left = np.delete(self._left, loc)
-            new_right = np.delete(self._right, loc)
+            new_left: ArrayLike = np.delete(self._left, loc)
+            assert isinstance(self._right, np.ndarray)
+            new_right: ArrayLike = np.delete(self._right, loc)
         else:
             new_left = self._left.delete(loc)
+            assert isinstance(self._right, ExtensionArray)
             new_right = self._right.delete(loc)
         return self._shallow_copy(left=new_left, right=new_right)
 
@@ -1724,17 +1728,13 @@ class IntervalArray(IntervalMixin, ExtensionArray):
 
         dtype = self._left.dtype
         if needs_i8_conversion(dtype):
-            # error: "Type[ndarray[Any, Any]]" has no attribute "_from_sequence"
-            new_left = type(self._left)._from_sequence(  # type: ignore[attr-defined]
-                nc[:, 0], dtype=dtype
-            )
-            # error: "Type[ndarray[Any, Any]]" has no attribute "_from_sequence"
-            new_right = type(self._right)._from_sequence(  # type: ignore[attr-defined]
-                nc[:, 1], dtype=dtype
-            )
+            assert isinstance(self._left, ExtensionArray)
+            new_left = type(self._left)._from_sequence(nc[:, 0], dtype=dtype)
+            assert isinstance(self._right, ExtensionArray)
+            new_right = type(self._right)._from_sequence(nc[:, 1], dtype=dtype)
         else:
-            new_left = nc[:, 0].view(dtype)
-            new_right = nc[:, 1].view(dtype)
+            new_left = nc[:, 0].view(dtype)  # type: ignore[arg-type]
+            new_right = nc[:, 1].view(dtype)  # type: ignore[arg-type]
         return self._shallow_copy(left=new_left, right=new_right)
 
     def unique(self) -> IntervalArray:

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -79,12 +79,12 @@ from pandas.core.algorithms import (
     unique,
     value_counts,
 )
-from pandas.core.arrays.datetimes import DatetimeArray
-from pandas.core.arrays.timedeltas import TimedeltaArray
 from pandas.core.arrays.base import (
     ExtensionArray,
     _extension_array_shared_docs,
 )
+from pandas.core.arrays.datetimes import DatetimeArray
+from pandas.core.arrays.timedeltas import TimedeltaArray
 import pandas.core.common as com
 from pandas.core.construction import (
     array as pd_array,


### PR DESCRIPTION
There is a lot of code in `IntervalArray._simple_new`. I suggest moving all the code there that checks that the input data is correct into its own method (`_ensure_simple_new_inputs`), so we have a better split between building the ÌntervalArray` and checking that its inputs are correct.

This PR changes no functionality.