### PR TITLE
BUG: misleading message when using to_datetime with format='%V %a'

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -786,6 +786,7 @@ Datetimelike
 - Bug in :func:`to_datetime` was raising ``ValueError`` when parsing :class:`Timestamp`, ``datetime.datetime``, ``datetime.date``, or ``np.datetime64`` objects when non-ISO8601 ``format`` was passed (:issue:`49298`, :issue:`50036`)
 - Bug in :func:`to_datetime` was raising ``ValueError`` when parsing empty string and non-ISO8601 format was passed. Now, empty strings will be parsed as :class:`NaT`, for compatibility with how is done for ISO8601 formats (:issue:`50251`)
 - Bug in :class:`Timestamp` was showing ``UserWarning``, which was not actionable by users, when parsing non-ISO8601 delimited date strings (:issue:`50232`)
+- Bug in :func:`to_datetime` was showing misleading ``ValueError`` when parsing dates with format containing ISO week directive and ISO weekday directive (:issue:`50308`)
 -
 
 Timedelta

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -129,7 +129,6 @@ def array_strptime(
             "%V" not in fmt
             or not (
                 "%A" in fmt
-                or "%A" in fmt
                 or "%a" in fmt
                 or "%w" in fmt
                 or "%u" in fmt
@@ -138,7 +137,7 @@ def array_strptime(
             raise ValueError("ISO year directive '%G' must be used with "
                              "the ISO week directive '%V' and a weekday "
                              "directive '%A', '%a', '%w', or '%u'.")
-        elif ("%V" in fmt and "%Y" in fmt):
+        elif "%V" in fmt and "%Y" in fmt:
             raise ValueError("ISO week directive '%V' is incompatible with "
                              "the year directive '%Y'. Use the ISO year "
                              "'%G' instead.")
@@ -146,7 +145,6 @@ def array_strptime(
             "%G" not in fmt
             or not (
                 "%A" in fmt
-                or "%A" in fmt
                 or "%a" in fmt
                 or "%w" in fmt
                 or "%u" in fmt

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -121,6 +121,40 @@ def array_strptime(
                 raise ValueError("Cannot use '%W' or '%U' without day and year")
         elif "%Z" in fmt and "%z" in fmt:
             raise ValueError("Cannot parse both %Z and %z")
+        elif "%j" in fmt and "%G" in fmt:
+            raise ValueError("Day of the year directive '%j' is not "
+                             "compatible with ISO year directive '%G'. "
+                             "Use '%Y' instead.")
+        elif "%G" in fmt and (
+            "%V" not in fmt
+            or not (
+                "%A" in fmt
+                or "%A" in fmt
+                or "%a" in fmt
+                or "%w" in fmt
+                or "%u" in fmt
+            )
+        ):
+            raise ValueError("ISO year directive '%G' must be used with "
+                             "the ISO week directive '%V' and a weekday "
+                             "directive '%A', '%a', '%w', or '%u'.")
+        elif ("%V" in fmt and "%Y" in fmt):
+            raise ValueError("ISO week directive '%V' is incompatible with "
+                             "the year directive '%Y'. Use the ISO year "
+                             "'%G' instead.")
+        elif "%V" in fmt and (
+            "%G" not in fmt
+            or not (
+                "%A" in fmt
+                or "%A" in fmt
+                or "%a" in fmt
+                or "%w" in fmt
+                or "%u" in fmt
+            )
+        ):
+            raise ValueError("ISO week directive '%V' must be used with "
+                             "the ISO year directive '%G' and a weekday "
+                             "directive '%A', '%a', '%w', or '%u'.")
 
     global _TimeRE_cache, _regex_cache
     with _cache_lock:
@@ -327,26 +361,6 @@ def array_strptime(
             elif parse_code == 22:
                 weekday = int(found_dict["u"])
                 weekday -= 1
-
-        # don't assume default values for ISO week/year
-        if iso_year != -1:
-            if iso_week == -1 or weekday == -1:
-                raise ValueError("ISO year directive '%G' must be used with "
-                                 "the ISO week directive '%V' and a weekday "
-                                 "directive '%A', '%a', '%w', or '%u'.")
-            if julian != -1:
-                raise ValueError("Day of the year directive '%j' is not "
-                                 "compatible with ISO year directive '%G'. "
-                                 "Use '%Y' instead.")
-        elif year != -1 and week_of_year == -1 and iso_week != -1:
-            if weekday == -1:
-                raise ValueError("ISO week directive '%V' must be used with "
-                                 "the ISO year directive '%G' and a weekday "
-                                 "directive '%A', '%a', '%w', or '%u'.")
-            else:
-                raise ValueError("ISO week directive '%V' is incompatible with "
-                                 "the year directive '%Y'. Use the ISO year "
-                                 "'%G' instead.")
 
         # If we know the wk of the year and what day of that wk, we can figure
         # out the Julian day of the year.

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -629,8 +629,8 @@ class TestToDatetime:
         "msg, s, _format",
         [
             [
-                "ISO week directive '%V' must be used with the ISO year directive "
-                "'%G' and a weekday directive '%A', '%a', '%w', or '%u'.",
+                "ISO week directive '%V' is incompatible with the year directive "
+                "'%Y'. Use the ISO year '%G' instead.",
                 "1999 50",
                 "%Y %V",
             ],
@@ -705,6 +705,36 @@ class TestToDatetime:
                 "'%G' and a weekday directive '%A', '%a', '%w', or '%u'.",
                 "20",
                 "%V",
+            ],
+            [
+                "ISO week directive '%V' must be used with the ISO year directive "
+                "'%G' and a weekday directive '%A', '%a', '%w', or '%u'.",
+                "1999 51 Sunday",
+                "%V %A",
+            ],
+            [
+                "ISO week directive '%V' must be used with the ISO year directive "
+                "'%G' and a weekday directive '%A', '%a', '%w', or '%u'.",
+                "1999 51 Sun",
+                "%V %a",
+            ],
+            [
+                "ISO week directive '%V' must be used with the ISO year directive "
+                "'%G' and a weekday directive '%A', '%a', '%w', or '%u'.",
+                "1999 51 1",
+                "%V %w",
+            ],
+            [
+                "ISO week directive '%V' must be used with the ISO year directive "
+                "'%G' and a weekday directive '%A', '%a', '%w', or '%u'.",
+                "1999 51 1",
+                "%V %u",
+            ],
+            [
+                "Day of the year directive '%j' is not compatible with ISO year "
+                "directive '%G'. Use '%Y' instead.",
+                "1999 50",
+                "%G %j",
             ],
         ],
     )

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -736,10 +736,16 @@ class TestToDatetime:
                 "1999 50",
                 "%G %j",
             ],
+            [
+                "ISO week directive '%V' must be used with the ISO year directive "
+                "'%G' and a weekday directive '%A', '%a', '%w', or '%u'.",
+                "20 Monday",
+                "%V %A",
+            ],
         ],
     )
     def test_error_iso_week_year(self, msg, s, _format):
-        # See GH#16607
+        # See GH#16607, #50308
         # This test checks for errors thrown when giving the wrong format
         # However, as discussed on PR#25541, overriding the locale
         # causes a different error to be thrown due to the format being


### PR DESCRIPTION
- [ ] closes #50308 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Good call @mroeschke to factor this out! I think it's simpler like this, and it helped find some untested code, and other code where the message was misleading

---

Performance is unaffected:

On this branch:
```python
In [1]: format = '%Y-%d-%m %H:%M:%S%z'

In [2]: dates = pd.date_range('1900', '2000').tz_localize('+01:00').strftime(format).tolist()

In [3]: %%timeit
   ...: pd.to_datetime(dates, format=format)
   ...: 
   ...: 
234 ms ± 470 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

upstream/main (after having recompiled):
```python
In [1]: format = '%Y-%d-%m %H:%M:%S%z'

In [2]: dates = pd.date_range('1900', '2000').tz_localize('+01:00').strftime(format).tolist()

In [3]: %%timeit
   ...: pd.to_datetime(dates, format=format)
   ...: 
   ...: 
234 ms ± 885 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```