### PR TITLE
ENH: Implement fastpath for masked indexes in join

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -737,7 +737,7 @@ Performance improvements
 - Performance improvement in :meth:`MultiIndex.putmask` (:issue:`49830`)
 - Performance improvement in :meth:`Index.union` and :meth:`MultiIndex.union` when index contains duplicates (:issue:`48900`)
 - Performance improvement in :meth:`Series.fillna` for extension array dtypes (:issue:`49722`, :issue:`50078`)
-- Performance improvement in :meth:`Index.join`, :meth:`Index.intersection` and :meth:`Index.union` for masked dtypes when :class:`Index` is monotonic (:issue:``)
+- Performance improvement in :meth:`Index.join`, :meth:`Index.intersection` and :meth:`Index.union` for masked dtypes when :class:`Index` is monotonic (:issue:`50310`)
 - Performance improvement for :meth:`Series.value_counts` with nullable dtype (:issue:`48338`)
 - Performance improvement for :class:`Series` constructor passing integer numpy array with nullable dtype (:issue:`48338`)
 - Performance improvement for :class:`DatetimeIndex` constructor passing a list (:issue:`48609`)

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -737,6 +737,7 @@ Performance improvements
 - Performance improvement in :meth:`MultiIndex.putmask` (:issue:`49830`)
 - Performance improvement in :meth:`Index.union` and :meth:`MultiIndex.union` when index contains duplicates (:issue:`48900`)
 - Performance improvement in :meth:`Series.fillna` for extension array dtypes (:issue:`49722`, :issue:`50078`)
+- Performance improvement in :meth:`Index.join`, :meth:`Index.intersection` and :meth:`Index.union` for masked dtypes when :class:`Index` is monotonic (:issue:``)
 - Performance improvement for :meth:`Series.value_counts` with nullable dtype (:issue:`48338`)
 - Performance improvement for :class:`Series` constructor passing integer numpy array with nullable dtype (:issue:`48338`)
 - Performance improvement for :class:`DatetimeIndex` constructor passing a list (:issue:`48609`)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4817,6 +4817,10 @@ class Index(IndexOpsMixin, PandasObject):
         Cast the ndarray returned from one of the libjoin.foo_indexer functions
         back to type(self)._data.
         """
+        if is_extension_array_dtype(self.dtype):
+            if is_numeric_dtype(self.dtype):
+                return type(self.values)(result, np.zeros(result.shape, dtype=np.bool_))
+            return type(self.values)._from_sequence(result)
         return result
 
     @doc(IndexOpsMixin._memory_usage)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4818,10 +4818,8 @@ class Index(IndexOpsMixin, PandasObject):
         Cast the ndarray returned from one of the libjoin.foo_indexer functions
         back to type(self)._data.
         """
-        if is_extension_array_dtype(self.dtype):
-            if is_numeric_dtype(self.dtype):
-                return type(self.values)(result, np.zeros(result.shape, dtype=np.bool_))
-            return type(self.values)._from_sequence(result)
+        if isinstance(self.values, BaseMaskedArray):
+            return type(self.values)(result, np.zeros(result.shape, dtype=np.bool_))
         return result
 
     @doc(IndexOpsMixin._memory_usage)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4805,10 +4805,11 @@ class Index(IndexOpsMixin, PandasObject):
 
     def _get_join_target(self) -> ArrayLike:
         """
-        Get the ndarray or ExtensionArray that we can pass to the IndexEngine
-        constructor.
+        Get the ndarray or ExtensionArray that we can pass to the join
+        functions.
         """
         if isinstance(self._values, BaseMaskedArray):
+            # This is only used if our array is monotonic, so no NAs present
             return self._values._data
         return self._get_engine_target()
 


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

As of right now,  masked indexes go through object even though we only use the join functions when we are monotonic, e.g. no NA present. We can simply use the numpy array to perform the join.

```
       before           after         ratio
     [026a83e0]       [d804bced]
-     5.82±0.02ms      1.38±0.02ms     0.24  index_object.SetOperations.time_operation('monotonic', 'ea_int', 'intersection')
-     4.08±0.03ms         452±10μs     0.11  index_object.SetOperations.time_operation('monotonic', 'ea_int', 'union')
```

This is related to #49420, will make it a bit easier to review since it solves the join changes
