### PR TITLE
CI: Restrict asv to 0.5.1 or higher

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -69,7 +69,7 @@ dependencies:
   - flask
 
   # benchmarks
-  - asv
+  - asv>=0.5.1
 
   # The compiler packages are meta-packages and install the correct compiler (activation) packages on the respective platforms.
   - c-compiler

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -52,7 +52,7 @@ dask
 seaborn
 moto
 flask
-asv
+asv>=0.5.1
 black==22.10.0
 cpplint
 flake8==6.0.0


### PR DESCRIPTION
This helps us to get rid of the aiobotocore pin. Also, 0.5.0 fails during pip install, so shouldn't use it anyway