### PR TITLE
PERF: Calculate mask in interpolate only once

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11643,7 +11643,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         -------
         idx_first_valid : type of index
         """
-        idxpos = find_valid_index(self._values, how=how, is_valid=isna(self._values))
+        idxpos = find_valid_index(self._values, how=how, is_valid=~isna(self._values))
         if idxpos is None:
             return None
         return self.index[idxpos]

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11643,7 +11643,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         -------
         idx_first_valid : type of index
         """
-        idxpos = find_valid_index(self._values, how=how)
+        idxpos = find_valid_index(self._values, how=how, is_valid=isna(self._values))
         if idxpos is None:
             return None
         return self.index[idxpos]

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -170,7 +170,7 @@ def clean_interp_method(method: str, index: Index, **kwargs) -> str:
     return method
 
 
-def find_valid_index(values, *, how: str) -> int | None:
+def find_valid_index(values, *, how: str, is_valid: np.ndarray) -> int | None:
     """
     Retrieves the index of the first valid value.
 
@@ -179,6 +179,8 @@ def find_valid_index(values, *, how: str) -> int | None:
     values : ndarray or ExtensionArray
     how : {'first', 'last'}
         Use this parameter to change between the first or last valid index.
+    is_valid: np.ndarray
+        Mask to find na_values.
 
     Returns
     -------
@@ -188,8 +190,6 @@ def find_valid_index(values, *, how: str) -> int | None:
 
     if len(values) == 0:  # early stop
         return None
-
-    is_valid = ~isna(values)
 
     if values.ndim == 2:
         is_valid = is_valid.any(axis=1)  # reduce axis 1
@@ -400,12 +400,12 @@ def _interpolate_1d(
     # These are sets of index pointers to invalid values... i.e. {0, 1, etc...
     all_nans = set(np.flatnonzero(invalid))
 
-    first_valid_index = find_valid_index(yvalues, how="first")
+    first_valid_index = find_valid_index(yvalues, how="first", is_valid=valid)
     if first_valid_index is None:  # no nan found in start
         first_valid_index = 0
     start_nans = set(range(first_valid_index))
 
-    last_valid_index = find_valid_index(yvalues, how="last")
+    last_valid_index = find_valid_index(yvalues, how="last", is_valid=valid)
     if last_valid_index is None:  # no nan found in end
         last_valid_index = len(yvalues)
     end_nans = set(range(1 + last_valid_index, len(valid)))
@@ -738,12 +738,13 @@ def _interpolate_with_limit_area(
     """
 
     invalid = isna(values)
+    is_valid = ~invalid
 
     if not invalid.all():
-        first = find_valid_index(values, how="first")
+        first = find_valid_index(values, how="first", is_valid=is_valid)
         if first is None:
             first = 0
-        last = find_valid_index(values, how="last")
+        last = find_valid_index(values, how="last", is_valid=is_valid)
         if last is None:
             last = len(values)
 

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -170,7 +170,9 @@ def clean_interp_method(method: str, index: Index, **kwargs) -> str:
     return method
 
 
-def find_valid_index(values, *, how: str, is_valid: np.ndarray) -> int | None:
+def find_valid_index(
+    values, *, how: str, is_valid: npt.NDArray[np.bool_]
+) -> int | None:
     """
     Retrieves the index of the first valid value.
 
@@ -204,7 +206,9 @@ def find_valid_index(values, *, how: str, is_valid: np.ndarray) -> int | None:
 
     if not chk_notna:
         return None
-    return idxpos
+    # Incompatible return value type (got "signedinteger[Any]",
+    # expected "Optional[int]")
+    return idxpos  # type: ignore[return-value]
 
 
 def interpolate_array_2d(


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Gives us an easy 10% speedup

```
PR: 15.4 ms ± 266 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
Main: 17 ms ± 69.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```