### PR TITLE
BUG: to_numpy for PandasArray does not handle na_value

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -931,7 +931,7 @@ ExtensionArray
 - Bug in :meth:`Series.mean` overflowing unnecessarily with nullable integers (:issue:`48378`)
 - Bug in :meth:`Series.tolist` for nullable dtypes returning numpy scalars instead of python scalars (:issue:`49890`)
 - Bug when concatenating an empty DataFrame with an ExtensionDtype to another DataFrame with the same ExtensionDtype, the resulting dtype turned into object (:issue:`48510`)
--
+- Bug in :meth:`array.PandasArray.to_numpy` raising with ``NA`` value when ``na_value`` is specified (:issue:`40638`)
 
 Styler
 ^^^^^^

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -389,13 +389,17 @@ class PandasArray(
         copy: bool = False,
         na_value: object = lib.no_default,
     ) -> np.ndarray:
-        result = np.asarray(self._ndarray, dtype=dtype)
+        mask = self.isna()
+        if na_value is not lib.no_default and mask.any():
+            result = self._ndarray.copy()
+            result[mask] = na_value
+        else:
+            result = self._ndarray
 
-        if (copy or na_value is not lib.no_default) and result is self._ndarray:
+        result = np.asarray(result, dtype=dtype)
+
+        if copy and result is self._ndarray:
             result = result.copy()
-
-        if na_value is not lib.no_default:
-            result[self.isna()] = na_value
 
         return result
 

--- a/pandas/tests/arrays/test_array.py
+++ b/pandas/tests/arrays/test_array.py
@@ -413,3 +413,11 @@ def test_array_not_registered(registry_without_decimal):
     result = pd.array(data, dtype=DecimalDtype)
     expected = DecimalArray._from_sequence(data)
     tm.assert_equal(result, expected)
+
+
+def test_array_to_numpy_na():
+    # GH#40638
+    arr = pd.array([pd.NA, 1], dtype="string")
+    result = arr.to_numpy(na_value=True, dtype=bool)
+    expected = np.array([True, True])
+    tm.assert_numpy_array_equal(result, expected)


### PR DESCRIPTION
- [x] closes #40638 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
