### PR TITLE
TYP: keyword-only NDFrame.fillna

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6580,6 +6580,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     def fillna(
         self: NDFrameT,
         value: Hashable | Mapping | Series | DataFrame = None,
+        *,
         method: FillnaOptions | None = None,
         axis: Axis | None = None,
         inplace: bool_t = False,


### PR DESCRIPTION
`DataFrame/Series.fillna` are already keyword-only.


xref https://github.com/pandas-dev/pandas-stubs/pull/474