### PR TITLE
CI temporarily pin numpy

### DIFF
--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -41,7 +41,7 @@
     // pip (with all the conda available packages installed first,
     // followed by the pip installed packages).
     "matrix": {
-        "numpy": [],
+        "numpy": ["1.23.5"],  // https://github.com/pandas-dev/pandas/pull/50356
         "Cython": ["0.29.32"],
         "matplotlib": [],
         "sqlalchemy": [],

--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -41,7 +41,7 @@
     // pip (with all the conda available packages installed first,
     // followed by the pip installed packages).
     "matrix": {
-        "numpy": [],
+        "numpy<": ["1.24"],
         "Cython": ["0.29.32"],
         "matplotlib": [],
         "sqlalchemy": [],

--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -41,7 +41,7 @@
     // pip (with all the conda available packages installed first,
     // followed by the pip installed packages).
     "matrix": {
-        "numpy<": ["1.24"],
+        "numpy": [],
         "Cython": ["0.29.32"],
         "matplotlib": [],
         "sqlalchemy": [],

--- a/ci/deps/actions-310-numpydev.yaml
+++ b/ci/deps/actions-310-numpydev.yaml
@@ -22,5 +22,5 @@ dependencies:
     - "cython"
     - "--extra-index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple"
     - "--pre"
-    - "numpy"
+    - "numpy<1.24"
     - "scipy"

--- a/ci/deps/actions-310.yaml
+++ b/ci/deps/actions-310.yaml
@@ -18,7 +18,7 @@ dependencies:
 
   # required dependencies
   - python-dateutil
-  - numpy
+  - numpy<1.24
   - pytz
 
   # optional dependencies

--- a/ci/deps/actions-38-downstream_compat.yaml
+++ b/ci/deps/actions-38-downstream_compat.yaml
@@ -19,7 +19,7 @@ dependencies:
 
   # required dependencies
   - python-dateutil
-  - numpy
+  - numpy<1.24
   - pytz
 
   # optional dependencies

--- a/ci/deps/actions-38.yaml
+++ b/ci/deps/actions-38.yaml
@@ -18,7 +18,7 @@ dependencies:
 
   # required dependencies
   - python-dateutil
-  - numpy
+  - numpy<1.24
   - pytz
 
   # optional dependencies

--- a/ci/deps/actions-39.yaml
+++ b/ci/deps/actions-39.yaml
@@ -18,7 +18,7 @@ dependencies:
 
   # required dependencies
   - python-dateutil
-  - numpy
+  - numpy<1.24
   - pytz
 
   # optional dependencies

--- a/ci/deps/actions-pypy-38.yaml
+++ b/ci/deps/actions-pypy-38.yaml
@@ -19,6 +19,6 @@ dependencies:
   - hypothesis>=5.5.3
 
   # required
-  - numpy
+  - numpy<1.24
   - python-dateutil
   - pytz

--- a/ci/deps/circle-38-arm64.yaml
+++ b/ci/deps/circle-38-arm64.yaml
@@ -18,7 +18,7 @@ dependencies:
 
   # required dependencies
   - python-dateutil
-  - numpy
+  - numpy<1.24
   - pytz
 
   # optional dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
 
   # required dependencies
   - python-dateutil
-  - numpy
+  - numpy<1.24
   - pytz
 
   # optional dependencies

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ psutil
 pytest-asyncio>=0.17
 coverage
 python-dateutil
-numpy
+numpy<1.24
 pytz
 beautifulsoup4
 blosc


### PR DESCRIPTION
Looks like numba is failing with the latest numpy release https://github.com/numba/numba/issues/8615

Let's temporarily pin numpy to get CI green, and then lift the pin once it's solved in numba?