### PR TITLE
PERF: faster infer_dtype when numpy dtype

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -768,6 +768,7 @@ Performance improvements
 - Performance improvement in :func:`merge` when not merging on the index - the new index will now be :class:`RangeIndex` instead of :class:`Int64Index` (:issue:`49478`)
 - Performance improvement in :meth:`DataFrame.to_dict` and :meth:`Series.to_dict` when using any non-object dtypes (:issue:`46470`)
 - Performance improvement in :func:`read_html` when there are multiple tables (:issue:`49929`)
+- Performance improvement in :func:`pandas.api.types.infer_dtype` when inferring numpy dtypes (:issue:`xxxxx`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_200.bug_fixes:

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -768,7 +768,7 @@ Performance improvements
 - Performance improvement in :func:`merge` when not merging on the index - the new index will now be :class:`RangeIndex` instead of :class:`Int64Index` (:issue:`49478`)
 - Performance improvement in :meth:`DataFrame.to_dict` and :meth:`Series.to_dict` when using any non-object dtypes (:issue:`46470`)
 - Performance improvement in :func:`read_html` when there are multiple tables (:issue:`49929`)
-- Performance improvement in :func:`pandas.api.types.infer_dtype` when inferring numpy dtypes (:issue:`xxxxx`)
+- Performance improvement in :func:`pandas.api.types.infer_dtype` when inferring numpy dtypes (:issue:`50357`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_200.bug_fixes:

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -1331,7 +1331,7 @@ cdef object _try_infer_map(object dtype):
     cdef:
         object val
         str attr
-    for attr in ["name", "kind", "base", "type"]:
+    for attr in ["kind", "name", "base", "type"]:
         val = getattr(dtype, attr, None)
         if val in _TYPE_MAP:
             return _TYPE_MAP[val]


### PR DESCRIPTION
Performance improvement for `infer_dtype` when the array has a numpy dtype:

```python
>>> import numpy as np
>>> import pandas as pd
>>>
>>> arr_np = np.arange(1_000_000)
>>> %timeit pd.api.types.infer_dtype(arr_np)
1.54 µs ± 6.76 ns per loop  # main
196 ns ± 0.348 ns per loop # this PR
>>> arr_pd = pd.array(arr_np, dtype=pd.Int32Dtype()) 
>>> %timeit pd.api.types.infer_dtype(arr_pd)
570 ns ± 0.419 ns per loop  # both main & this PR, no difference
```

## why is this faster?

Apparantly it's faster to access `dtype.kind`than `dtype.name` for numpy dtypes:

```python
>>> %timeit arr_np.dtype.kind
125 ns ± 0.316 ns per loop
>>> %timeit arr_np.dtype.name
1.31 µs ± 7.49 ns per loop
```

So it's better to try `"kind"` before `"name"` in `lib._try_infer_map`.