### PR TITLE
BUG: Fix unintialized strlen when PyUnicode_AsUTF8AndSize fails

### DIFF
--- a/pandas/_libs/src/ujson/lib/ultrajsonenc.c
+++ b/pandas/_libs/src/ujson/lib/ultrajsonenc.c
@@ -1080,11 +1080,11 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name,
 
         case JT_UTF8: {
             value = enc->getStringValue(obj, &tc, &szlen);
-            Buffer_Reserve(enc, RESERVE_STRING(szlen));
             if (enc->errorMsg) {
                 enc->endTypeContext(obj, &tc);
                 return;
             }
+            Buffer_Reserve(enc, RESERVE_STRING(szlen));
             Buffer_AppendCharUnchecked(enc, '\"');
 
             if (enc->forceASCII) {

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -341,7 +341,6 @@ static char *PyUnicodeToUTF8(JSOBJ _obj, JSONTypeContext *tc,
           Set errorMsg(to tell encoder to stop),
           and let Python exception propagate. */
         JSONObjectEncoder *enc = (JSONObjectEncoder *)tc->encoder;
-        *_outLen = 0;
         enc->errorMsg = "Encoding failed.";
     }
     return encoded;

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -341,6 +341,7 @@ static char *PyUnicodeToUTF8(JSOBJ _obj, JSONTypeContext *tc,
           Set errorMsg(to tell encoder to stop),
           and let Python exception propagate. */
         JSONObjectEncoder *enc = (JSONObjectEncoder *)tc->encoder;
+        *_outLen = 0;
         enc->errorMsg = "Encoding failed.";
     }
     return encoded;


### PR DESCRIPTION
- [ ] xref #50324 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Hopefully fixes 32bit builds. 
