### PR TITLE
ENH: Add cumsum to ArrowExtensionArray

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -853,9 +853,9 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray):
         arr = pa.chunked_array(chunks)
         return cls(arr)
 
-    def _accumulate(  # type: ignore[override]
+    def _accumulate(
         self, name: str, *, skipna: bool = True, **kwargs
-    ) -> ArrowExtensionArray:
+    ) -> ArrowExtensionArray | ExtensionArray:
         """
         Return an ExtensionArray performing an accumulation operation.
 

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -853,9 +853,9 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray):
         arr = pa.chunked_array(chunks)
         return cls(arr)
 
-    def _accumulate(
+    def _accumulate(  # type: ignore[override]
         self, name: str, *, skipna: bool = True, **kwargs
-    ) -> ArrowExtensionArrayT:
+    ) -> ArrowExtensionArray:
         """
         Return an ExtensionArray performing an accumulation operation.
 

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -343,6 +343,52 @@ class TestGetitemTests(base.BaseGetitemTests):
         super().test_getitem_scalar(data)
 
 
+class TestBaseAccumulateTests(base.BaseAccumulateTests):
+    def check_accumulate(self, s, op_name, skipna):
+        result = getattr(s, op_name)(skipna=skipna).astype("Float64")
+        expected = getattr(s.astype("Float64"), op_name)(skipna=skipna)
+        self.assert_series_equal(result, expected, check_dtype=False)
+
+    @pytest.mark.parametrize("skipna", [True, False])
+    def test_accumulate_series_raises(
+        self, data, all_numeric_accumulations, skipna, request
+    ):
+        pa_type = data.dtype.pyarrow_dtype
+        if (
+            pa.types.is_integer(pa_type) or pa.types.is_floating(pa_type)
+        ) and all_numeric_accumulations == "cumsum":
+            request.node.add_marker(
+                pytest.mark.xfail(
+                    reason=f"{all_numeric_accumulations} implemented for {pa_type}"
+                )
+            )
+        op_name = all_numeric_accumulations
+        ser = pd.Series(data)
+
+        with pytest.raises(NotImplementedError):
+            getattr(ser, op_name)(skipna=skipna)
+
+    @pytest.mark.parametrize("skipna", [True, False])
+    def test_accumulate_series(self, data, all_numeric_accumulations, skipna, request):
+        pa_type = data.dtype.pyarrow_dtype
+        if all_numeric_accumulations != "cumsum":
+            request.node.add_marker(
+                pytest.mark.xfail(
+                    reason=f"{all_numeric_accumulations} not implemented",
+                    raises=NotImplementedError,
+                )
+            )
+        elif not (pa.types.is_integer(pa_type) or pa.types.is_floating(pa_type)):
+            request.node.add_marker(
+                pytest.mark.xfail(
+                    reason=f"{all_numeric_accumulations} not implemented for {pa_type}"
+                )
+            )
+        op_name = all_numeric_accumulations
+        ser = pd.Series(data)
+        self.check_accumulate(ser, op_name, skipna)
+
+
 class TestBaseNumericReduce(base.BaseNumericReduceTests):
     def check_reduce(self, ser, op_name, skipna):
         pa_dtype = ser.dtype.pyarrow_dtype

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -355,8 +355,10 @@ class TestBaseAccumulateTests(base.BaseAccumulateTests):
     ):
         pa_type = data.dtype.pyarrow_dtype
         if (
-            pa.types.is_integer(pa_type) or pa.types.is_floating(pa_type)
-        ) and all_numeric_accumulations == "cumsum":
+            (pa.types.is_integer(pa_type) or pa.types.is_floating(pa_type))
+            and all_numeric_accumulations == "cumsum"
+            and not pa_version_under9p0
+        ):
             request.node.add_marker(
                 pytest.mark.xfail(
                     reason=f"{all_numeric_accumulations} implemented for {pa_type}"
@@ -371,7 +373,7 @@ class TestBaseAccumulateTests(base.BaseAccumulateTests):
     @pytest.mark.parametrize("skipna", [True, False])
     def test_accumulate_series(self, data, all_numeric_accumulations, skipna, request):
         pa_type = data.dtype.pyarrow_dtype
-        if all_numeric_accumulations != "cumsum":
+        if all_numeric_accumulations != "cumsum" or pa_version_under9p0:
             request.node.add_marker(
                 pytest.mark.xfail(
                     reason=f"{all_numeric_accumulations} not implemented",


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Don't think a whatsnew is needed since `EA._accumulate` was added in 2.0
