### PR TITLE
CLN: Use exclusions in determination of _selected_obj

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1020,7 +1020,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         ):
             return
 
-        groupers = [g.name for g in grp.groupings if g.level is None and g.in_axis]
+        groupers = self.exclusions
 
         if len(groupers):
             # GH12839 clear selected obj cache when group selection changes


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Toward #46944.

Currently we use whether a grouping is in-axis or not to determine if it should make it into `_selected_obj`. This is almost the same as using `exclusions`, except for a TimeGrouper. Here, the grouping data may arise from a column and hence should be excluded, however the grouping data is not the column itself but rather derived from the column, so it is not technically in-axis. Such columns should not make it into `_selected_obj`, so we should prefer using excluded directly rather than in-axis.

This does not change the behavior of Resampler because Resampler is a subclass of BaseGroupBy which does not have the selection context.