### PR TITLE
TST: Make get_array smarter to work for masked arrays

### DIFF
--- a/pandas/tests/copy_view/test_util.py
+++ b/pandas/tests/copy_view/test_util.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+from pandas import DataFrame
+from pandas.tests.copy_view.util import get_array
+
+
+def test_get_array_numpy():
+    df = DataFrame({"a": [1, 2, 3]})
+    assert np.shares_memory(get_array(df, "a"), get_array(df, "a"))
+
+
+def test_get_array_masked():
+    df = DataFrame({"a": [1, 2, 3]}, dtype="Int64")
+    assert np.shares_memory(get_array(df, "a"), get_array(df, "a"))

--- a/pandas/tests/copy_view/util.py
+++ b/pandas/tests/copy_view/util.py
@@ -1,3 +1,6 @@
+from pandas.core.arrays import BaseMaskedArray
+
+
 def get_array(df, col):
     """
     Helper method to get array for a DataFrame column.
@@ -8,4 +11,7 @@ def get_array(df, col):
     """
     icol = df.columns.get_loc(col)
     assert isinstance(icol, int)
-    return df._get_column_array(icol)
+    arr = df._get_column_array(icol)
+    if isinstance(arr, BaseMaskedArray):
+        return arr._data
+    return arr


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This should work ootb when testing with masked arrays