### PR TITLE
TST: Add test_ to four tests in test_readlines.py and fix two of them

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -342,4 +342,3 @@ repos:
         exclude: |
             (?x)
             ^pandas/tests/generic/test_generic.py  # GH50380
-            |^pandas/tests/io/json/test_readlines.py  # GH50378

--- a/pandas/tests/io/json/test_readlines.py
+++ b/pandas/tests/io/json/test_readlines.py
@@ -336,7 +336,7 @@ def test_to_json_append_mode(mode_):
         df.to_json(mode=mode_, lines=False, orient="records")
 
 
-def to_json_append_output_consistent_columns():
+def test_to_json_append_output_consistent_columns():
     # GH 35849
     # Testing that resulting output reads in as expected.
     # Testing same columns, new rows
@@ -354,7 +354,7 @@ def to_json_append_output_consistent_columns():
         tm.assert_frame_equal(result, expected)
 
 
-def to_json_append_output_inconsistent_columns():
+def test_to_json_append_output_inconsistent_columns():
     # GH 35849
     # Testing that resulting output reads in as expected.
     # Testing one new column, one old column, new rows
@@ -378,7 +378,7 @@ def to_json_append_output_inconsistent_columns():
         tm.assert_frame_equal(result, expected)
 
 
-def to_json_append_output_different_columns():
+def test_to_json_append_output_different_columns():
     # GH 35849
     # Testing that resulting output reads in as expected.
     # Testing same, differing and new columns
@@ -387,12 +387,13 @@ def to_json_append_output_different_columns():
     df3 = DataFrame({"col2": ["e", "f"], "col3": ["!", "#"]})
     df4 = DataFrame({"col4": [True, False]})
 
+    # Booleans here converted to integers to agree with other data created by "to_json" as JSON converts booleans to integers
     expected = DataFrame(
         {
             "col1": [1, 2, 3, 4, None, None, None, None],
             "col2": ["a", "b", "c", "d", "e", "f", None, None],
             "col3": [None, None, None, None, "!", "#", None, None],
-            "col4": [None, None, None, None, None, None, True, False],
+            "col4": [None, None, None, None, None, None, int(True), int(False)],
         }
     )
     with tm.ensure_clean("test.json") as path:
@@ -407,7 +408,7 @@ def to_json_append_output_different_columns():
         tm.assert_frame_equal(result, expected)
 
 
-def to_json_append_output_different_columns_reordered():
+def test_to_json_append_output_different_columns_reordered():
     # GH 35849
     # Testing that resulting output reads in as expected.
     # Testing specific result column order.
@@ -417,9 +418,10 @@ def to_json_append_output_different_columns_reordered():
     df4 = DataFrame({"col4": [True, False]})
 
     # df4, df3, df2, df1 (in that order)
+    # Booleans here converted to integers to agree with other data created by "to_json" as JSON converts booleans to integers
     expected = DataFrame(
         {
-            "col4": [True, False, None, None, None, None, None, None],
+            "col4": [int(True), int(False), None, None, None, None, None, None],
             "col2": [None, None, "e", "f", "c", "d", "a", "b"],
             "col3": [None, None, "!", "#", None, None, None, None],
             "col1": [None, None, None, None, 3, 4, 1, 2],

--- a/pandas/tests/io/json/test_readlines.py
+++ b/pandas/tests/io/json/test_readlines.py
@@ -387,7 +387,7 @@ def test_to_json_append_output_different_columns():
     df3 = DataFrame({"col2": ["e", "f"], "col3": ["!", "#"]})
     df4 = DataFrame({"col4": [True, False]})
 
-    # Booleans here converted to integers to agree with other data created by "to_json" as JSON converts booleans to integers
+    # Booleans here converted to integers to agree with data created by "to_json"
     expected = DataFrame(
         {
             "col1": [1, 2, 3, 4, None, None, None, None],
@@ -418,7 +418,7 @@ def test_to_json_append_output_different_columns_reordered():
     df4 = DataFrame({"col4": [True, False]})
 
     # df4, df3, df2, df1 (in that order)
-    # Booleans here converted to integers to agree with other data created by "to_json" as JSON converts booleans to integers
+    # Booleans here converted to integers to agree with data created by "to_json"
     expected = DataFrame(
         {
             "col4": [int(True), int(False), None, None, None, None, None, None],

--- a/pandas/tests/io/json/test_readlines.py
+++ b/pandas/tests/io/json/test_readlines.py
@@ -387,15 +387,14 @@ def test_to_json_append_output_different_columns():
     df3 = DataFrame({"col2": ["e", "f"], "col3": ["!", "#"]})
     df4 = DataFrame({"col4": [True, False]})
 
-    # Booleans here converted to integers to agree with data created by "to_json"
     expected = DataFrame(
         {
             "col1": [1, 2, 3, 4, None, None, None, None],
             "col2": ["a", "b", "c", "d", "e", "f", None, None],
             "col3": [None, None, None, None, "!", "#", None, None],
-            "col4": [None, None, None, None, None, None, int(True), int(False)],
+            "col4": [None, None, None, None, None, None, True, False],
         }
-    )
+    ).astype({"col4": "float"})
     with tm.ensure_clean("test.json") as path:
         # Save dataframes to the same file
         df1.to_json(path, mode="a", lines=True, orient="records")
@@ -418,15 +417,14 @@ def test_to_json_append_output_different_columns_reordered():
     df4 = DataFrame({"col4": [True, False]})
 
     # df4, df3, df2, df1 (in that order)
-    # Booleans here converted to integers to agree with data created by "to_json"
     expected = DataFrame(
         {
-            "col4": [int(True), int(False), None, None, None, None, None, None],
+            "col4": [True, False, None, None, None, None, None, None],
             "col2": [None, None, "e", "f", "c", "d", "a", "b"],
             "col3": [None, None, "!", "#", None, None, None, None],
             "col1": [None, None, None, None, 3, 4, 1, 2],
         }
-    )
+    ).astype({"col4": "float"})
     with tm.ensure_clean("test.json") as path:
         # Save dataframes to the same file
         df4.to_json(path, mode="a", lines=True, orient="records")


### PR DESCRIPTION
Four tests in https://github.com/pandas-dev/pandas/blob/main/pandas/tests/io/json/test_readlines.py weren't running because they didn't have `test_` in front of their names, fixed those.

Two of those tests were not passing because the JSON data was turning booleans into 1s and 0s which was conflicting with the booleans in the compared data, so added `int` before all of the booleans in the compared data. Had detailed comments explaining this but shortened them in order to pass Flake8.

- [x] closes #50378
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).