### PR TITLE
BUG: handle duplicated columns when using `read_sql` (#44421)

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -900,6 +900,7 @@ I/O
 - Fixed memory leak which stemmed from the initialization of the internal JSON module (:issue:`49222`)
 - Fixed issue where :func:`json_normalize` would incorrectly remove leading characters from column names that matched the ``sep`` argument (:issue:`49861`)
 - Bug in :meth:`DataFrame.to_json` where it would segfault when failing to encode a string (:issue:`50307`)
+- Bug in :func:`read_sql` ignoring duplicated columns, fixed by adding a suffix on duplicated columns (:issue:`44421`)
 
 Period
 ^^^^^^

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -147,16 +147,27 @@ def _convert_arrays_to_dataframe(
     use_nullable_dtypes: bool = False,
 ) -> DataFrame:
     content = lib.to_object_array_tuples(data)
-    arrays = convert_object_array(
+    if arrays := convert_object_array(
         list(content.T),
         dtype=None,
         coerce_float=coerce_float,
         use_nullable_dtypes=use_nullable_dtypes,
-    )
-    if arrays:
-        return DataFrame(dict(zip(columns, arrays)))
+    ):
+        return DataFrame(
+            np.array(arrays).T, columns=_suffix_on_duplicated(list(columns))
+        )
     else:
         return DataFrame(columns=columns)
+
+
+def _suffix_on_duplicated(lst: list[Any]) -> list[Any]:
+    """
+    Add suffix on items that are duplicated
+    """
+    return [
+        f"{value}_{lst[:index].count(value)}" if lst.count(value) > 1 else value
+        for index, value in enumerate(lst, 1)
+    ]
 
 
 def _wrap_result(


### PR DESCRIPTION
- [X] closes #44421 
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Hello everyone,

This is my first PR on this project, so don't hesitate to be picky.
I've normally fixed the issue found in the issue #44421, it was a simple error due to duplicated columns names.

I tried to respect the rules for PR, but if I missed something, feel free to comment ;)
Have a good day!