### PR TITLE
CI: Reduce duplicate pyarrow version testing

### DIFF
--- a/.github/workflows/macos-windows.yml
+++ b/.github/workflows/macos-windows.yml
@@ -53,7 +53,7 @@ jobs:
       uses: ./.github/actions/setup-conda
       with:
         environment-file: ci/deps/${{ matrix.env_file }}
-        pyarrow-version: ${{ matrix.os == 'macos-latest' && '6' || '' }}
+        pyarrow-version: ${{ matrix.os == 'macos-latest' && '9' || '' }}
 
     - name: Build Pandas
       uses: ./.github/actions/build_pandas

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -79,13 +79,17 @@ jobs:
             test_args: "-W error::DeprecationWarning:numpy -W error::FutureWarning:numpy"
         exclude:
           - env_file: actions-39.yaml
-            pyarrow_version: "6"
+            pyarrow_version: "7"
           - env_file: actions-39.yaml
+            pyarrow_version: "8"
+          - env_file: actions-39.yaml
+            pyarrow_version: "9"
+          - env_file: actions-310.yaml
             pyarrow_version: "7"
           - env_file: actions-310.yaml
-            pyarrow_version: "6"
+            pyarrow_version: "8"
           - env_file: actions-310.yaml
-            pyarrow_version: "7"
+            pyarrow_version: "9"
       fail-fast: false
     name: ${{ matrix.name || format('{0} pyarrow={1} {2}', matrix.env_file, matrix.pyarrow_version, matrix.pattern) }}
     env:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -78,17 +78,17 @@ jobs:
             pattern: "not slow and not network and not single_cpu"
             test_args: "-W error::DeprecationWarning:numpy -W error::FutureWarning:numpy"
         exclude:
-          - env_file: actions-39.yaml
+          - env_file: actions-38.yaml
             pyarrow_version: "7"
-          - env_file: actions-39.yaml
+          - env_file: actions-38.yaml
             pyarrow_version: "8"
-          - env_file: actions-39.yaml
+          - env_file: actions-38.yaml
             pyarrow_version: "9"
-          - env_file: actions-310.yaml
+          - env_file: actions-39.yaml
             pyarrow_version: "7"
-          - env_file: actions-310.yaml
+          - env_file: actions-39.yaml
             pyarrow_version: "8"
-          - env_file: actions-310.yaml
+          - env_file: actions-39.yaml
             pyarrow_version: "9"
       fail-fast: false
     name: ${{ matrix.name || format('{0} pyarrow={1} {2}', matrix.env_file, matrix.pyarrow_version, matrix.pattern) }}


### PR DESCRIPTION
We probably don't need to be testing multiple permutations of pyarrow version & Python version in the CI. Instead:

* PY310 builds will test pyarrow version 6 - 10
* PY38 & 39 builds will test pyarrow = 10
