### PR TITLE
API: to_datetime allow mixed numeric/datetime with errors=coerce

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -470,7 +470,7 @@ Other API changes
 - Changed behavior of :meth:`Series.quantile` and :meth:`DataFrame.quantile` with :class:`SparseDtype` to retain sparse dtype (:issue:`49583`)
 - When creating a :class:`Series` with a object-dtype :class:`Index` of datetime objects, pandas no longer silently converts the index to a :class:`DatetimeIndex` (:issue:`39307`, :issue:`23598`)
 - :meth:`Series.unique` with dtype "timedelta64[ns]" or "datetime64[ns]" now returns :class:`TimedeltaArray` or :class:`DatetimeArray` instead of ``numpy.ndarray`` (:issue:`49176`)
-- :func:`to_datetime` and :class:`DatetimeIndex` now allow sequences containing both ``datetime`` objects and numeric entries, matching :class:`Series` behavior (:issue:`49037`)
+- :func:`to_datetime` and :class:`DatetimeIndex` now allow sequences containing both ``datetime`` objects and numeric entries, matching :class:`Series` behavior (:issue:`49037`, :issue:`??`)
 - :func:`pandas.api.dtypes.is_string_dtype` now only returns ``True`` for array-likes with ``dtype=object`` when the elements are inferred to be strings (:issue:`15585`)
 - Passing a sequence containing ``datetime`` objects and ``date`` objects to :class:`Series` constructor will return with ``object`` dtype instead of ``datetime64[ns]`` dtype, consistent with :class:`Index` behavior (:issue:`49341`)
 - Passing strings that cannot be parsed as datetimes to :class:`Series` or :class:`DataFrame` with ``dtype="datetime64[ns]"`` will raise instead of silently ignoring the keyword and returning ``object`` dtype (:issue:`24435`)

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -470,7 +470,7 @@ Other API changes
 - Changed behavior of :meth:`Series.quantile` and :meth:`DataFrame.quantile` with :class:`SparseDtype` to retain sparse dtype (:issue:`49583`)
 - When creating a :class:`Series` with a object-dtype :class:`Index` of datetime objects, pandas no longer silently converts the index to a :class:`DatetimeIndex` (:issue:`39307`, :issue:`23598`)
 - :meth:`Series.unique` with dtype "timedelta64[ns]" or "datetime64[ns]" now returns :class:`TimedeltaArray` or :class:`DatetimeArray` instead of ``numpy.ndarray`` (:issue:`49176`)
-- :func:`to_datetime` and :class:`DatetimeIndex` now allow sequences containing both ``datetime`` objects and numeric entries, matching :class:`Series` behavior (:issue:`49037`, :issue:`??`)
+- :func:`to_datetime` and :class:`DatetimeIndex` now allow sequences containing both ``datetime`` objects and numeric entries, matching :class:`Series` behavior (:issue:`49037`, :issue:`50453`)
 - :func:`pandas.api.dtypes.is_string_dtype` now only returns ``True`` for array-likes with ``dtype=object`` when the elements are inferred to be strings (:issue:`15585`)
 - Passing a sequence containing ``datetime`` objects and ``date`` objects to :class:`Series` constructor will return with ``object`` dtype instead of ``datetime64[ns]`` dtype, consistent with :class:`Index` behavior (:issue:`49341`)
 - Passing strings that cannot be parsed as datetimes to :class:`Series` or :class:`DataFrame` with ``dtype="datetime64[ns]"`` will raise instead of silently ignoring the keyword and returning ``object`` dtype (:issue:`24435`)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -1601,16 +1601,16 @@ class TestToDatetimeUnit:
         ],
     )
     def test_unit_mixed(self, cache, exp, arr):
-
+        # pre-2.0 with mixed numeric/datetimes and errors="coerce" the numeric
+        #  entries would be coerced to NaT, was never clear exactly why.
         # mixed integers/datetimes
-        expected = DatetimeIndex(exp)
+        expected = Index([Timestamp(x) for x in arr], dtype="M8[ns]")
         result = to_datetime(arr, errors="coerce", cache=cache)
         tm.assert_index_equal(result, expected)
 
         # GH#49037 pre-2.0 this raised, but it always worked with Series,
         #  was never clear why it was disallowed
         result = to_datetime(arr, errors="raise", cache=cache)
-        expected = Index([Timestamp(x) for x in arr], dtype="M8[ns]")
         tm.assert_index_equal(result, expected)
 
         result = DatetimeIndex(arr)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -1588,19 +1588,13 @@ class TestToDatetimeUnit:
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize(
-        "exp, arr",
+        "arr",
         [
-            [
-                ["2013-01-01", "NaT", "NaT"],
-                [Timestamp("20130101"), 1.434692e18, 1.432766e18],
-            ],
-            [
-                ["NaT", "NaT", "2013-01-01"],
-                [1.434692e18, 1.432766e18, Timestamp("20130101")],
-            ],
+            [Timestamp("20130101"), 1.434692e18, 1.432766e18],
+            [1.434692e18, 1.432766e18, Timestamp("20130101")],
         ],
     )
-    def test_unit_mixed(self, cache, exp, arr):
+    def test_unit_mixed(self, cache, arr):
         # GH#50453 pre-2.0 with mixed numeric/datetimes and errors="coerce"
         #  the numeric entries would be coerced to NaT, was never clear exactly
         #  why.

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -1601,8 +1601,9 @@ class TestToDatetimeUnit:
         ],
     )
     def test_unit_mixed(self, cache, exp, arr):
-        # pre-2.0 with mixed numeric/datetimes and errors="coerce" the numeric
-        #  entries would be coerced to NaT, was never clear exactly why.
+        # GH#50453 pre-2.0 with mixed numeric/datetimes and errors="coerce"
+        #  the numeric entries would be coerced to NaT, was never clear exactly
+        #  why.
         # mixed integers/datetimes
         expected = Index([Timestamp(x) for x in arr], dtype="M8[ns]")
         result = to_datetime(arr, errors="coerce", cache=cache)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
