### PR TITLE
add test to check crosstab supports Float64 formats

### DIFF
--- a/pandas/tests/reshape/test_crosstab.py
+++ b/pandas/tests/reshape/test_crosstab.py
@@ -795,6 +795,33 @@ class TestCrosstab:
         expected.index.name = "C"
         tm.assert_frame_equal(result, expected)
 
+    def test_margin_support_Float(self):
+        # GH 50313
+        # use Float64 formats and function aggfunc with margins
+        df = DataFrame(
+            {"A": [1, 2, 2, 1], "B": [3, 3, 4, 5], "C": [-1.0, 10.0, 1.0, 10.0]}
+        )
+        df = df.astype({"C": "Float64"})
+        result = crosstab(
+            df["A"],
+            df["B"],
+            values=df["C"],
+            aggfunc="sum",
+            margins=True,
+        )
+        expected = DataFrame(
+            [
+                [-1.0, pd.NA, 10.0, 9.0],
+                [10.0, 1.0, pd.NA, 11.0],
+                [9.0, 1.0, 10.0, 20.0],
+            ],
+            index=[1, 2, "All"],
+            dtype="Float64",
+        )
+        expected.columns = Index([3, 4, 5, "All"], dtype="object", name="B")
+        expected.index.name = "A"
+        tm.assert_frame_equal(result, expected)
+
 
 @pytest.mark.parametrize("a_dtype", ["category", "int64"])
 @pytest.mark.parametrize("b_dtype", ["category", "int64"])

--- a/pandas/tests/reshape/test_crosstab.py
+++ b/pandas/tests/reshape/test_crosstab.py
@@ -799,9 +799,9 @@ class TestCrosstab:
         # GH 50313
         # use Float64 formats and function aggfunc with margins
         df = DataFrame(
-            {"A": [1, 2, 2, 1], "B": [3, 3, 4, 5], "C": [-1.0, 10.0, 1.0, 10.0]}
+            {"A": [1, 2, 2, 1], "B": [3, 3, 4, 5], "C": [-1.0, 10.0, 1.0, 10.0]},
+            dtype="Float64",
         )
-        df = df.astype({"C": "Float64"})
         result = crosstab(
             df["A"],
             df["B"],
@@ -815,11 +815,10 @@ class TestCrosstab:
                 [10.0, 1.0, pd.NA, 11.0],
                 [9.0, 1.0, 10.0, 20.0],
             ],
-            index=[1, 2, "All"],
+            index=Index([1.0, 2.0, "All"], dtype="object", name="A"),
+            columns=Index([3.0, 4.0, 5.0, "All"], dtype="object", name="B"),
             dtype="Float64",
         )
-        expected.columns = Index([3, 4, 5, "All"], dtype="object", name="B")
-        expected.index.name = "A"
         tm.assert_frame_equal(result, expected)
 
 


### PR DESCRIPTION
- [x] closes #50313
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

A  new test is added. The test validates `crosstab` behavior with `Float64`. I have checked that the problem occurs when `Float64` is used together with `margins=True`. 
The test fails on `1.5.2` and passes on `main`.