### PR TITLE
CLN: avoid NpyDatetimeUnit in tests

### DIFF
--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -16,7 +16,6 @@ from pandas._libs.tslibs import (
     npy_unit_to_abbrev,
     tz_compare,
 )
-from pandas._libs.tslibs.dtypes import NpyDatetimeUnit
 
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
 
@@ -33,15 +32,6 @@ class TestNonNano:
     def unit(self, request):
         """Fixture returning parametrized time units"""
         return request.param
-
-    @pytest.fixture
-    def reso(self, unit):
-        """Fixture returning datetime resolution for a given time unit"""
-        return {
-            "s": NpyDatetimeUnit.NPY_FR_s.value,
-            "ms": NpyDatetimeUnit.NPY_FR_ms.value,
-            "us": NpyDatetimeUnit.NPY_FR_us.value,
-        }[unit]
 
     @pytest.fixture
     def dtype(self, unit, tz_naive_fixture):
@@ -71,19 +61,19 @@ class TestNonNano:
         dta, dti = dta_dti
         return dta
 
-    def test_non_nano(self, unit, reso, dtype):
+    def test_non_nano(self, unit, dtype):
         arr = np.arange(5, dtype=np.int64).view(f"M8[{unit}]")
         dta = DatetimeArray._simple_new(arr, dtype=dtype)
 
         assert dta.dtype == dtype
-        assert dta[0]._creso == reso
+        assert dta[0].unit == unit
         assert tz_compare(dta.tz, dta[0].tz)
         assert (dta[0] == dta[:1]).all()
 
     @pytest.mark.parametrize(
         "field", DatetimeArray._field_ops + DatetimeArray._bool_ops
     )
-    def test_fields(self, unit, reso, field, dtype, dta_dti):
+    def test_fields(self, unit, field, dtype, dta_dti):
         dta, dti = dta_dti
 
         assert (dti == dta).all()
@@ -166,7 +156,7 @@ class TestNonNano:
         expected = getattr(dti, meth)
         tm.assert_numpy_array_equal(result, expected)
 
-    def test_format_native_types(self, unit, reso, dtype, dta_dti):
+    def test_format_native_types(self, unit, dtype, dta_dti):
         # In this case we should get the same formatted values with our nano
         #  version dti._data as we do with the non-nano dta
         dta, dti = dta_dti

--- a/pandas/tests/arrays/test_timedeltas.py
+++ b/pandas/tests/arrays/test_timedeltas.py
@@ -3,8 +3,6 @@ from datetime import timedelta
 import numpy as np
 import pytest
 
-from pandas._libs.tslibs.dtypes import NpyDatetimeUnit
-
 import pandas as pd
 from pandas import Timedelta
 import pandas._testing as tm
@@ -20,27 +18,16 @@ class TestNonNano:
         return request.param
 
     @pytest.fixture
-    def reso(self, unit):
-        if unit == "s":
-            return NpyDatetimeUnit.NPY_FR_s.value
-        elif unit == "ms":
-            return NpyDatetimeUnit.NPY_FR_ms.value
-        elif unit == "us":
-            return NpyDatetimeUnit.NPY_FR_us.value
-        else:
-            raise NotImplementedError(unit)
-
-    @pytest.fixture
     def tda(self, unit):
         arr = np.arange(5, dtype=np.int64).view(f"m8[{unit}]")
         return TimedeltaArray._simple_new(arr, dtype=arr.dtype)
 
-    def test_non_nano(self, unit, reso):
+    def test_non_nano(self, unit):
         arr = np.arange(5, dtype=np.int64).view(f"m8[{unit}]")
         tda = TimedeltaArray._simple_new(arr, dtype=arr.dtype)
 
         assert tda.dtype == arr.dtype
-        assert tda[0]._creso == reso
+        assert tda[0].unit == unit
 
     @pytest.mark.parametrize("field", TimedeltaArray._field_ops)
     def test_fields(self, tda, field):

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -22,7 +22,6 @@ from pandas._libs.tslibs import (
     iNaT,
     parsing,
 )
-from pandas._libs.tslibs.dtypes import NpyDatetimeUnit
 from pandas.errors import (
     OutOfBoundsDatetime,
     OutOfBoundsTimedelta,
@@ -862,7 +861,7 @@ class TestToDatetime:
         #  as of 2022-09-28, the Timestamp constructor has been updated
         #  to cast to M8[s] but to_datetime has not
         ts = Timestamp(dt)
-        assert ts._creso == NpyDatetimeUnit.NPY_FR_s.value
+        assert ts.unit == "s"
         assert ts.asm8 == dt
 
         msg = "Out of bounds nanosecond timestamp"


### PR DESCRIPTION
Broken off from #50433.