### PR TITLE
DOC: Add Copy on write whatsnew

### DIFF
--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -290,6 +290,30 @@ and attributes without holding entire tree in memory (:issue:`45442`).
 .. _`lxml's iterparse`: https://lxml.de/3.2/parsing.html#iterparse-and-iterwalk
 .. _`etree's iterparse`: https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.iterparse
 
+.. _whatsnew_150.enhancements.copy_on_write:
+
+Copy on Write
+^^^^^^^^^^^^^
+
+A new feature ``copy_on_write`` was added. Copy on write ensures that
+any DataFrame or Series derived from another in any way always behaves as a copy.
+Copy on write disallows updating any other object than the object the method
+was applied to.
+
+Copy on write can be enabled through:
+
+.. code-block:: python
+
+    pd.set_option("mode.copy_on_write", True)
+    pd.options.mode.copy_on_write = True
+
+Alternatively, copy on write can be enabled locally through:
+
+.. code-block:: python
+
+    with pd.option_context("mode.copy_on_write", True):
+        ...
+
 .. _whatsnew_150.enhancements.other:
 
 Other enhancements

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -295,7 +295,7 @@ and attributes without holding entire tree in memory (:issue:`45442`).
 Copy on Write
 ^^^^^^^^^^^^^
 
-A new feature ``copy_on_write`` was added. Copy on write ensures that
+A new feature ``copy_on_write`` was added (:issue:`46958`). Copy on write ensures that
 any DataFrame or Series derived from another in any way always behaves as a copy.
 Copy on write disallows updating any other object than the object the method
 was applied to.
@@ -313,6 +313,28 @@ Alternatively, copy on write can be enabled locally through:
 
     with pd.option_context("mode.copy_on_write", True):
         ...
+
+Without copy on write, the parent :class:`DataFrame` is updated when updating a child
+:class:`DataFrame` that was derived from this :class:`DataFrame`.
+
+.. ipython:: python
+
+    df = pd.DataFrame({"foo": [1, 2, 3], "bar": 1})
+    view = df["foo"]
+    view.iloc[0]
+    df
+
+With copy on write enabled, df won't be updated anymore:
+
+.. ipython:: python
+
+    with pd.option_context("mode.copy_on_write", True):
+        df = pd.DataFrame({"foo": [1, 2, 3], "bar": 1})
+        view = df["foo"]
+        view.iloc[0]
+        df
+
+A more detailed explanation can be found `here <https://phofl.github.io/cow-introduction.html>`_.
 
 .. _whatsnew_150.enhancements.other:
 

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -1903,6 +1903,7 @@ def using_copy_on_write() -> bool:
     """
     Fixture to check if Copy-on-Write is enabled.
     """
+    pd.options.mode.copy_on_write = True
     return pd.options.mode.copy_on_write and pd.options.mode.data_manager == "block"
 
 

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -1903,7 +1903,6 @@ def using_copy_on_write() -> bool:
     """
     Fixture to check if Copy-on-Write is enabled.
     """
-    pd.options.mode.copy_on_write = True
     return pd.options.mode.copy_on_write and pd.options.mode.data_manager == "block"
 
 


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

cc @mroeschke 

As discussed in the other pr. This is for 1.5, will add another pr for the lazy copy methods.
Do you think it makes sense linking https://phofl.github.io/cow-introduction.html instead of explaining everything in here?
