### PR TITLE
DEPR: Remove int64 uint64 float64 index tests

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -90,7 +90,6 @@ from pandas.core.dtypes.common import (
     ensure_platform_int,
     is_bool_dtype,
     is_categorical_dtype,
-    is_complex_dtype,
     is_dtype_equal,
     is_ea_or_datetimelike_dtype,
     is_extension_array_dtype,
@@ -124,7 +123,6 @@ from pandas.core.dtypes.generic import (
     ABCDatetimeIndex,
     ABCMultiIndex,
     ABCPeriodIndex,
-    ABCRangeIndex,
     ABCSeries,
     ABCTimedeltaIndex,
 )

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -21,7 +21,6 @@ from pandas.util._decorators import (
 from pandas.core.dtypes.common import (
     is_categorical_dtype,
     is_scalar,
-    pandas_dtype,
 )
 from pandas.core.dtypes.missing import (
     is_valid_na_for_dtype,
@@ -273,30 +272,6 @@ class CategoricalIndex(NDArrayBackedExtensionIndex):
                 )
 
         return other
-
-    @doc(Index.astype)
-    def astype(self, dtype: Dtype, copy: bool = True) -> Index:
-        from pandas.core.api import NumericIndex
-
-        dtype = pandas_dtype(dtype)
-
-        categories = self.categories
-        # the super method always returns Int64Index, UInt64Index and Float64Index
-        # but if the categories are a NumericIndex with dtype float32, we want to
-        # return an index with the same dtype as self.categories.
-        if categories._is_backward_compat_public_numeric_index:
-            assert isinstance(categories, NumericIndex)  # mypy complaint fix
-            try:
-                categories._validate_dtype(dtype)
-            except ValueError:
-                pass
-            else:
-                new_values = self._data.astype(dtype, copy=copy)
-                # pass copy=False because any copying has been done in the
-                #  _data.astype call above
-                return categories._constructor(new_values, name=self.name, copy=False)
-
-        return super().astype(dtype, copy=copy)
 
     def equals(self, other: object) -> bool:
         """

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -87,7 +87,6 @@ class NumericIndex(Index):
         "numeric type",
     )
     _can_hold_strings = False
-    _is_backward_compat_public_numeric_index: bool = True
 
     _engine_types: dict[np.dtype, type[libindex.IndexEngine]] = {
         np.dtype(np.int8): libindex.Int8Engine,
@@ -214,12 +213,7 @@ class NumericIndex(Index):
             # float16 not supported (no indexing engine)
             raise NotImplementedError("float16 indexes are not supported")
 
-        if cls._is_backward_compat_public_numeric_index:
-            # dtype for NumericIndex
-            return dtype
-        else:
-            # dtype for Int64Index, UInt64Index etc. Needed for backwards compat.
-            return cls._default_dtype
+        return dtype
 
     # ----------------------------------------------------------------
     # Indexing Methods
@@ -415,7 +409,6 @@ class Float64Index(NumericIndex):
     _typ = "float64index"
     _default_dtype = np.dtype(np.float64)
     _dtype_validation_metadata = (is_float_dtype, "float")
-    _is_backward_compat_public_numeric_index: bool = False
 
     @property
     def _engine_type(self) -> type[libindex.Float64Engine]:

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -103,7 +103,6 @@ class RangeIndex(NumericIndex):
     _typ = "rangeindex"
     _dtype_validation_metadata = (is_signed_integer_dtype, "signed integer")
     _range: range
-    _is_backward_compat_public_numeric_index: bool = False
 
     @property
     def _engine_type(self) -> type[libindex.Int64Engine]:

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -848,7 +848,7 @@ class RangeIndex(NumericIndex):
                 # First non-empty index had only one element
                 if rng.start == start:
                     values = np.concatenate([x._values for x in rng_indexes])
-                    result = Int64Index(values)
+                    result = self._constructor(values)
                     return result.rename(name)
 
                 step = rng.start - start
@@ -857,7 +857,9 @@ class RangeIndex(NumericIndex):
                 next_ is not None and rng.start != next_
             )
             if non_consecutive:
-                result = Int64Index(np.concatenate([x._values for x in rng_indexes]))
+                result = self._constructor(
+                    np.concatenate([x._values for x in rng_indexes])
+                )
                 return result.rename(name)
 
             if step is not None:
@@ -905,7 +907,6 @@ class RangeIndex(NumericIndex):
                 "and integer or boolean "
                 "arrays are valid indices"
             )
-        # fall back to Int64Index
         return super().__getitem__(key)
 
     def _getitem_slice(self: RangeIndex, slobj: slice) -> RangeIndex:
@@ -1010,15 +1011,14 @@ class RangeIndex(NumericIndex):
             res_name = ops.get_op_result_name(self, other)
             result = type(self)(rstart, rstop, rstep, name=res_name)
 
-            # for compat with numpy / Int64Index
+            # for compat with numpy / Index with int64 dtype
             # even if we can represent as a RangeIndex, return
-            # as a Float64Index if we have float-like descriptors
+            # as a float64 Index if we have float-like descriptors
             if not all(is_integer(x) for x in [rstart, rstop, rstep]):
                 result = result.astype("float64")
 
             return result
 
         except (ValueError, TypeError, ZeroDivisionError):
-            # Defer to Int64Index implementation
             # test_arithmetic_explicit_conversions
             return super()._arith_method(other, op)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -132,7 +132,6 @@ from pandas.core.indexers import (
 from pandas.core.indexes.accessors import CombinedDatetimelikeProperties
 from pandas.core.indexes.api import (
     DatetimeIndex,
-    Float64Index,
     Index,
     MultiIndex,
     PeriodIndex,
@@ -2569,7 +2568,8 @@ Name: Max Speed, dtype: float64
 
         if is_list_like(q):
             result.name = self.name
-            return self._constructor(result, index=Float64Index(q), name=self.name)
+            idx = Index(q, dtype=np.float64)
+            return self._constructor(result, index=idx, name=self.name)
         else:
             # scalar
             return result.iloc[0]

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -70,6 +70,7 @@ from pandas.core.dtypes.common import (
     is_datetime64_dtype,
     is_datetime64tz_dtype,
     is_extension_array_dtype,
+    is_integer_dtype,
     is_list_like,
     is_string_dtype,
     is_timedelta64_dtype,
@@ -88,7 +89,7 @@ from pandas import (
     concat,
     isna,
 )
-from pandas.core.api import Int64Index
+from pandas.core.api import NumericIndex
 from pandas.core.arrays import (
     Categorical,
     DatetimeArray,
@@ -2240,13 +2241,13 @@ class GenericIndexCol(IndexCol):
     def is_indexed(self) -> bool:
         return False
 
-    # error: Return type "Tuple[Int64Index, Int64Index]" of "convert"
+    # error: Return type "Tuple[NumericIndex, NumericIndex]" of "convert"
     # incompatible with return type "Union[Tuple[ndarray[Any, Any],
     # ndarray[Any, Any]], Tuple[DatetimeIndex, DatetimeIndex]]" in
     # supertype "IndexCol"
     def convert(  # type: ignore[override]
         self, values: np.ndarray, nan_rep, encoding: str, errors: str
-    ) -> tuple[Int64Index, Int64Index]:
+    ) -> tuple[NumericIndex, NumericIndex]:
         """
         Convert the data from this selection to the appropriate pandas type.
 
@@ -2259,7 +2260,7 @@ class GenericIndexCol(IndexCol):
         """
         assert isinstance(values, np.ndarray), type(values)
 
-        index = Int64Index(np.arange(len(values)))
+        index = NumericIndex(np.arange(len(values)), dtype=np.int64)
         return index, index
 
     def set_attr(self) -> None:
@@ -4862,11 +4863,11 @@ def _convert_index(name: str, index: Index, encoding: str, errors: str) -> Index
     atom = DataIndexableCol._get_atom(converted)
 
     if (
-        isinstance(index, Int64Index)
+        (isinstance(index, NumericIndex) and is_integer_dtype(index))
         or needs_i8_conversion(index.dtype)
         or is_bool_dtype(index.dtype)
     ):
-        # Includes Int64Index, RangeIndex, DatetimeIndex, TimedeltaIndex, PeriodIndex,
+        # Includes NumericIndex, RangeIndex, DatetimeIndex, TimedeltaIndex, PeriodIndex,
         #  in which case "kind" is "integer", "integer", "datetime64",
         #  "timedelta64", and "integer", respectively.
         return IndexCol(

--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -29,7 +29,6 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 
 
 class TestCategoricalConstructors:
@@ -74,7 +73,7 @@ class TestCategoricalConstructors:
         tm.assert_index_equal(c.categories, expected)
 
         c = Categorical([], categories=[1, 2, 3])
-        expected = Int64Index([1, 2, 3])
+        expected = Index([1, 2, 3])
         tm.assert_index_equal(c.categories, expected)
 
     def test_constructor_empty_boolean(self):

--- a/pandas/tests/arrays/integer/test_dtypes.py
+++ b/pandas/tests/arrays/integer/test_dtypes.py
@@ -62,8 +62,7 @@ def test_astype_nansafe():
 
 @pytest.mark.parametrize("dropna", [True, False])
 def test_construct_index(all_data, dropna):
-    # ensure that we do not coerce to Float64Index, rather
-    # keep as Index
+    # ensure that we do not coerce to different Index dtype or non-index
 
     all_data = all_data[:10]
     if dropna:

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -8,7 +8,6 @@ from pandas._libs.sparse import IntIndex
 import pandas as pd
 from pandas import isna
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 from pandas.core.arrays.sparse import (
     SparseArray,
     SparseDtype,
@@ -469,7 +468,7 @@ def test_dropna(fill_value):
     tm.assert_sp_array_equal(arr.dropna(), exp)
 
     df = pd.DataFrame({"a": [0, 1], "b": arr})
-    expected_df = pd.DataFrame({"a": [1], "b": exp}, index=Int64Index([1]))
+    expected_df = pd.DataFrame({"a": [1], "b": exp}, index=pd.Index([1]))
     tm.assert_equal(df.dropna(), expected_df)
 
 

--- a/pandas/tests/base/test_unique.py
+++ b/pandas/tests/base/test_unique.py
@@ -5,7 +5,6 @@ from pandas.core.dtypes.common import is_datetime64tz_dtype
 
 import pandas as pd
 import pandas._testing as tm
-from pandas.core.api import NumericIndex
 from pandas.tests.base.common import allow_na_ops
 
 
@@ -19,9 +18,6 @@ def test_unique(index_or_series_obj):
     if isinstance(obj, pd.MultiIndex):
         expected = pd.MultiIndex.from_tuples(unique_values)
         expected.names = obj.names
-        tm.assert_index_equal(result, expected, exact=True)
-    elif isinstance(obj, pd.Index) and obj._is_backward_compat_public_numeric_index:
-        expected = NumericIndex(unique_values, dtype=obj.dtype)
         tm.assert_index_equal(result, expected, exact=True)
     elif isinstance(obj, pd.Index):
         expected = pd.Index(unique_values, dtype=obj.dtype)
@@ -58,10 +54,7 @@ def test_unique_null(null_obj, index_or_series_obj):
     unique_values_not_null = [val for val in unique_values_raw if not pd.isnull(val)]
     unique_values = [null_obj] + unique_values_not_null
 
-    if isinstance(obj, pd.Index) and obj._is_backward_compat_public_numeric_index:
-        expected = NumericIndex(unique_values, dtype=obj.dtype)
-        tm.assert_index_equal(result, expected, exact=True)
-    elif isinstance(obj, pd.Index):
+    if isinstance(obj, pd.Index):
         expected = pd.Index(unique_values, dtype=obj.dtype)
         if is_datetime64tz_dtype(obj.dtype):
             result = result.normalize()

--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -11,6 +11,7 @@ from pandas import (
     CategoricalDtype,
     DataFrame,
     DatetimeTZDtype,
+    Index,
     Interval,
     IntervalDtype,
     NaT,
@@ -22,7 +23,6 @@ from pandas import (
     option_context,
 )
 import pandas._testing as tm
-from pandas.core.api import UInt64Index
 
 
 def _check_cast(df, v):
@@ -372,7 +372,7 @@ class TestAstype:
     )
     def test_astype_column_metadata(self, dtype):
         # GH#19920
-        columns = UInt64Index([100, 200, 300], name="foo")
+        columns = Index([100, 200, 300], dtype=np.uint64, name="foo")
         df = DataFrame(np.arange(15).reshape(5, 3), columns=columns)
         df = df.astype(dtype)
         tm.assert_index_equal(df.columns, columns)
@@ -441,7 +441,7 @@ class TestAstype:
         arr = np.array([[1, 2, 3]], dtype=dtype)
         df = DataFrame(arr)
         ser = df.iloc[:, 0]
-        idx = pd.Index(ser)
+        idx = Index(ser)
         dta = ser._values
 
         if unit in ["ns", "us", "ms", "s"]:
@@ -476,7 +476,7 @@ class TestAstype:
         exp_dta = exp_ser._values
 
         res_index = idx.astype(dtype)
-        exp_index = pd.Index(exp_ser)
+        exp_index = Index(exp_ser)
         assert exp_index.dtype == dtype
         tm.assert_index_equal(res_index, exp_index)
 
@@ -504,7 +504,7 @@ class TestAstype:
         arr = np.array([[1, 2, 3]], dtype=dtype)
         df = DataFrame(arr)
         ser = df.iloc[:, 0]
-        tdi = pd.Index(ser)
+        tdi = Index(ser)
         tda = tdi._values
 
         if unit in ["us", "ms", "s"]:

--- a/pandas/tests/frame/methods/test_truncate.py
+++ b/pandas/tests/frame/methods/test_truncate.py
@@ -5,11 +5,11 @@ import pandas as pd
 from pandas import (
     DataFrame,
     DatetimeIndex,
+    Index,
     Series,
     date_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 
 
 class TestDataFrameTruncate:
@@ -108,13 +108,13 @@ class TestDataFrameTruncate:
         "before, after, indices",
         [(1, 2, [2, 1]), (None, 2, [2, 1, 0]), (1, None, [3, 2, 1])],
     )
-    @pytest.mark.parametrize("klass", [Int64Index, DatetimeIndex])
+    @pytest.mark.parametrize("dtyp", [*tm.ALL_REAL_NUMPY_DTYPES, "datetime64[ns]"])
     def test_truncate_decreasing_index(
-        self, before, after, indices, klass, frame_or_series
+        self, before, after, indices, dtyp, frame_or_series
     ):
         # https://github.com/pandas-dev/pandas/issues/33756
-        idx = klass([3, 2, 1, 0])
-        if klass is DatetimeIndex:
+        idx = Index([3, 2, 1, 0], dtype=dtyp)
+        if isinstance(idx, DatetimeIndex):
             before = pd.Timestamp(before) if before is not None else None
             after = pd.Timestamp(after) if after is not None else None
             indices = [pd.Timestamp(i) for i in indices]

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -624,14 +624,10 @@ class Base:
 
         # empty mappable
         dtype = None
-        if idx._is_backward_compat_public_numeric_index:
-            new_index_cls = NumericIndex
-            if idx.dtype.kind == "f":
-                dtype = idx.dtype
-        else:
-            new_index_cls = Float64Index
+        if idx.dtype.kind == "f":
+            dtype = idx.dtype
 
-        expected = new_index_cls([np.nan] * len(idx), dtype=dtype)
+        expected = Index([np.nan] * len(idx), dtype=dtype)
         result = idx.map(mapper(expected, idx))
         tm.assert_index_equal(result, expected)
 
@@ -887,13 +883,9 @@ class NumericBase(Base):
             expected = Index([index[0], pd.NaT] + list(index[1:]), dtype=object)
         else:
             expected = Index([index[0], np.nan] + list(index[1:]))
-
-            if index._is_backward_compat_public_numeric_index:
-                # GH#43921 we preserve NumericIndex
-                if index.dtype.kind == "f":
-                    expected = NumericIndex(expected, dtype=index.dtype)
-                else:
-                    expected = NumericIndex(expected)
+            # GH#43921 we preserve float dtype
+            if index.dtype.kind == "f":
+                expected = Index(expected, dtype=index.dtype)
 
         result = index.insert(1, na_val)
         tm.assert_index_equal(result, expected, exact=True)

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -28,12 +28,7 @@ from pandas import (
     isna,
 )
 import pandas._testing as tm
-from pandas.core.api import (  # noqa:F401
-    Float64Index,
-    Int64Index,
-    NumericIndex,
-    UInt64Index,
-)
+from pandas.core.api import NumericIndex
 from pandas.core.arrays import BaseMaskedArray
 
 
@@ -322,7 +317,9 @@ class Base:
     def test_repeat(self, simple_index):
         rep = 2
         idx = simple_index.copy()
-        new_index_cls = Int64Index if isinstance(idx, RangeIndex) else idx._constructor
+        new_index_cls = (
+            NumericIndex if isinstance(idx, RangeIndex) else idx._constructor
+        )
         expected = new_index_cls(idx.values.repeat(rep), name=idx.name)
         tm.assert_index_equal(idx.repeat(rep), expected)
 
@@ -505,7 +502,6 @@ class Base:
             # assuming the 2nd to last item is unique in the data
             item = index_a[-2]
             tm.assert_numpy_array_equal(index_a == item, expected3)
-            # For RangeIndex we can convert to Int64Index
             tm.assert_series_equal(series_a == item, Series(expected3))
 
     def test_format(self, simple_index):
@@ -596,7 +592,7 @@ class Base:
         idx = simple_index
 
         result = idx.map(lambda x: x)
-        # For RangeIndex we convert to Int64Index
+        # RangeIndex are equivalent to the similar NumericIndex with int64 dtype
         tm.assert_index_equal(result, idx, exact="equiv")
 
     @pytest.mark.parametrize(
@@ -619,7 +615,7 @@ class Base:
         identity = mapper(idx.values, idx)
 
         result = idx.map(identity)
-        # For RangeIndex we convert to Int64Index
+        # RangeIndex are equivalent to the similar NumericIndex with int64 dtype
         tm.assert_index_equal(result, idx, exact="equiv")
 
         # empty mappable
@@ -901,19 +897,19 @@ class NumericBase(Base):
 
         # float conversions
         arr = np.arange(5, dtype="int64") * 3.2
-        expected = Float64Index(arr)
+        expected = NumericIndex(arr, dtype=np.float64)
         fidx = idx * 3.2
         tm.assert_index_equal(fidx, expected)
         fidx = 3.2 * idx
         tm.assert_index_equal(fidx, expected)
 
         # interops with numpy arrays
-        expected = Float64Index(arr)
+        expected = NumericIndex(arr, dtype=np.float64)
         a = np.zeros(5, dtype="float64")
         result = fidx - a
         tm.assert_index_equal(result, expected)
 
-        expected = Float64Index(-arr)
+        expected = NumericIndex(-arr, dtype=np.float64)
         a = np.zeros(5, dtype="float64")
         result = a - fidx
         tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/conftest.py
+++ b/pandas/tests/indexes/conftest.py
@@ -5,6 +5,7 @@ from pandas import (
     Series,
     array,
 )
+import pandas._testing as tm
 
 
 @pytest.fixture(params=[None, False])
@@ -37,5 +38,24 @@ def freq_sample(request):
 def listlike_box(request):
     """
     Types that may be passed as the indexer to searchsorted.
+    """
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        *tm.ALL_REAL_NUMPY_DTYPES,
+        "datetime64[ns]",
+        "category",
+        "object",
+        "timedelta64[ns]",
+    ]
+)
+def any_numpy_dtype_for_small_integer_indexes(request):
+    """
+    Dtypes that can be given to an Index with small integers.
+
+    This means that for any dtype `x` in the params list, `Index([1, 2, 3], dtype=x)` is
+    valid and gives the correct Index (sub-)class.
     """
     return request.param

--- a/pandas/tests/indexes/datetimes/methods/test_astype.py
+++ b/pandas/tests/indexes/datetimes/methods/test_astype.py
@@ -15,7 +15,6 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 
 
 class TestDatetimeIndex:
@@ -30,7 +29,7 @@ class TestDatetimeIndex:
         tm.assert_index_equal(result, expected)
 
         result = idx.astype(np.int64)
-        expected = Int64Index(
+        expected = Index(
             [1463356800000000000] + [-9223372036854775808] * 3,
             dtype=np.int64,
             name="idx",

--- a/pandas/tests/indexes/datetimes/test_scalar_compat.py
+++ b/pandas/tests/indexes/datetimes/test_scalar_compat.py
@@ -19,7 +19,6 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Float64Index
 
 
 class TestDatetimeIndexOps:
@@ -313,33 +312,33 @@ class TestDateTimeIndexToJulianDate:
         dr = date_range(start=Timestamp("1710-10-01"), periods=5, freq="D")
         r1 = pd.Index([x.to_julian_date() for x in dr])
         r2 = dr.to_julian_date()
-        assert isinstance(r2, Float64Index)
+        assert isinstance(r2, pd.Index) and r2.dtype == np.float64
         tm.assert_index_equal(r1, r2)
 
     def test_2000(self):
         dr = date_range(start=Timestamp("2000-02-27"), periods=5, freq="D")
         r1 = pd.Index([x.to_julian_date() for x in dr])
         r2 = dr.to_julian_date()
-        assert isinstance(r2, Float64Index)
+        assert isinstance(r2, pd.Index) and r2.dtype == np.float64
         tm.assert_index_equal(r1, r2)
 
     def test_hour(self):
         dr = date_range(start=Timestamp("2000-02-27"), periods=5, freq="H")
         r1 = pd.Index([x.to_julian_date() for x in dr])
         r2 = dr.to_julian_date()
-        assert isinstance(r2, Float64Index)
+        assert isinstance(r2, pd.Index) and r2.dtype == np.float64
         tm.assert_index_equal(r1, r2)
 
     def test_minute(self):
         dr = date_range(start=Timestamp("2000-02-27"), periods=5, freq="T")
         r1 = pd.Index([x.to_julian_date() for x in dr])
         r2 = dr.to_julian_date()
-        assert isinstance(r2, Float64Index)
+        assert isinstance(r2, pd.Index) and r2.dtype == np.float64
         tm.assert_index_equal(r1, r2)
 
     def test_second(self):
         dr = date_range(start=Timestamp("2000-02-27"), periods=5, freq="S")
         r1 = pd.Index([x.to_julian_date() for x in dr])
         r2 = dr.to_julian_date()
-        assert isinstance(r2, Float64Index)
+        assert isinstance(r2, pd.Index) and r2.dtype == np.float64
         tm.assert_index_equal(r1, r2)

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -16,7 +16,6 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 
 from pandas.tseries.offsets import (
     BMonthEnd,
@@ -184,7 +183,7 @@ class TestDatetimeIndexSetOps:
         tm.assert_index_equal(df.index, exp)
 
     def test_union_with_DatetimeIndex(self, sort):
-        i1 = Int64Index(np.arange(0, 20, 2))
+        i1 = Index(np.arange(0, 20, 2, dtype=np.int64))
         i2 = date_range(start="2012-01-03 00:00:00", periods=10, freq="D")
         # Works
         i1.union(i2, sort=sort)

--- a/pandas/tests/indexes/interval/test_formats.py
+++ b/pandas/tests/indexes/interval/test_formats.py
@@ -3,6 +3,7 @@ import pytest
 
 from pandas import (
     DataFrame,
+    Index,
     Interval,
     IntervalIndex,
     Series,
@@ -10,7 +11,6 @@ from pandas import (
     Timestamp,
 )
 import pandas._testing as tm
-from pandas.core.api import Float64Index
 
 
 class TestIntervalIndexRendering:
@@ -54,8 +54,8 @@ class TestIntervalIndexRendering:
                 [
                     Interval(left, right)
                     for left, right in zip(
-                        Float64Index([329.973, 345.137], dtype="float64"),
-                        Float64Index([345.137, 360.191], dtype="float64"),
+                        Index([329.973, 345.137], dtype="float64"),
+                        Index([345.137, 360.191], dtype="float64"),
                     )
                 ]
             ),

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -18,7 +18,6 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Float64Index
 import pandas.core.common as com
 
 
@@ -406,7 +405,7 @@ class TestIntervalIndex:
         index = IntervalIndex.from_breaks(breaks)
 
         to_convert = breaks._constructor([pd.NaT] * 3)
-        expected = Float64Index([np.nan] * 3)
+        expected = Index([np.nan] * 3, dtype=np.float64)
         result = index._maybe_convert_i8(to_convert)
         tm.assert_index_equal(result, expected)
 

--- a/pandas/tests/indexes/multi/test_analytics.py
+++ b/pandas/tests/indexes/multi/test_analytics.py
@@ -9,7 +9,6 @@ from pandas import (
     period_range,
 )
 import pandas._testing as tm
-from pandas.core.api import UInt64Index
 
 
 def test_infer_objects(idx):
@@ -196,8 +195,8 @@ def test_map_dictlike(idx, mapper):
 
     identity = mapper(idx.values, idx)
 
-    # we don't infer to UInt64 for a dict
-    if isinstance(idx, UInt64Index) and isinstance(identity, dict):
+    # we don't infer to uint64 dtype for a dict
+    if idx.dtype == np.uint64 and isinstance(identity, dict):
         expected = idx.astype("int64")
     else:
         expected = idx

--- a/pandas/tests/indexes/multi/test_integrity.py
+++ b/pandas/tests/indexes/multi/test_integrity.py
@@ -7,12 +7,12 @@ from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
 
 import pandas as pd
 from pandas import (
+    Index,
     IntervalIndex,
     MultiIndex,
     RangeIndex,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 
 
 def test_labels_dtypes():
@@ -84,8 +84,8 @@ def test_values_multiindex_periodindex():
     idx = MultiIndex.from_arrays([ints, pidx])
     result = idx.values
 
-    outer = Int64Index([x[0] for x in result])
-    tm.assert_index_equal(outer, Int64Index(ints))
+    outer = Index([x[0] for x in result])
+    tm.assert_index_equal(outer, Index(ints, dtype=np.int64))
 
     inner = pd.PeriodIndex([x[1] for x in result])
     tm.assert_index_equal(inner, pidx)
@@ -93,8 +93,8 @@ def test_values_multiindex_periodindex():
     # n_lev > n_lab
     result = idx[:2].values
 
-    outer = Int64Index([x[0] for x in result])
-    tm.assert_index_equal(outer, Int64Index(ints[:2]))
+    outer = Index([x[0] for x in result])
+    tm.assert_index_equal(outer, Index(ints[:2], dtype=np.int64))
 
     inner = pd.PeriodIndex([x[1] for x in result])
     tm.assert_index_equal(inner, pidx[:2])
@@ -246,11 +246,11 @@ def test_rangeindex_fallback_coercion_bug():
     tm.assert_frame_equal(df, expected, check_like=True)
 
     result = df.index.get_level_values("fizz")
-    expected = Int64Index(np.arange(10), name="fizz").repeat(10)
+    expected = Index(np.arange(10, dtype=np.int64), name="fizz").repeat(10)
     tm.assert_index_equal(result, expected)
 
     result = df.index.get_level_values("buzz")
-    expected = Int64Index(np.tile(np.arange(10), 10), name="buzz")
+    expected = Index(np.tile(np.arange(10, dtype=np.int64), 10), name="buzz")
     tm.assert_index_equal(result, expected)
 
 

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -20,10 +20,6 @@ from pandas import (
     period_range,
 )
 import pandas._testing as tm
-from pandas.core.api import (
-    Float64Index,
-    Int64Index,
-)
 
 dti4 = date_range("2016-01-01", periods=4)
 dti = dti4[:-1]
@@ -806,10 +802,10 @@ class TestAsOfLocs:
 
         msg = "must be DatetimeIndex or PeriodIndex"
         with pytest.raises(TypeError, match=msg):
-            pi.asof_locs(Int64Index(pi.asi8), mask)
+            pi.asof_locs(pd.Index(pi.asi8, dtype=np.int64), mask)
 
         with pytest.raises(TypeError, match=msg):
-            pi.asof_locs(Float64Index(pi.asi8), mask)
+            pi.asof_locs(pd.Index(pi.asi8, dtype=np.float64), mask)
 
         with pytest.raises(TypeError, match=msg):
             # TimedeltaIndex

--- a/pandas/tests/indexes/ranges/test_indexing.py
+++ b/pandas/tests/indexes/ranges/test_indexing.py
@@ -1,9 +1,11 @@
 import numpy as np
 import pytest
 
-from pandas import RangeIndex
+from pandas import (
+    Index,
+    RangeIndex,
+)
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 
 
 class TestGetIndexer:
@@ -55,7 +57,7 @@ class TestTake:
         # GH#12631
         idx = RangeIndex(1, 4, name="xxx")
         result = idx.take(np.array([1, 0, -1]))
-        expected = Int64Index([2, 1, 3], name="xxx")
+        expected = Index([2, 1, 3], dtype=np.int64, name="xxx")
         tm.assert_index_equal(result, expected)
 
         # fill_value
@@ -65,7 +67,7 @@ class TestTake:
 
         # allow_fill=False
         result = idx.take(np.array([1, 0, -1]), allow_fill=False, fill_value=True)
-        expected = Int64Index([2, 1, 3], name="xxx")
+        expected = Index([2, 1, 3], dtype=np.int64, name="xxx")
         tm.assert_index_equal(result, expected)
 
         msg = "Unable to fill values because RangeIndex cannot contain NA"
@@ -86,7 +88,7 @@ class TestWhere:
 
         mask = np.array([True, True, False, False, False])
         result = idx.putmask(mask, 10)
-        expected = Int64Index([10, 10, 2, 3, 4], name="test")
+        expected = Index([10, 10, 2, 3, 4], dtype=np.int64, name="test")
         tm.assert_index_equal(result, expected)
 
         result = idx.where(~mask, 10)

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -4,20 +4,15 @@ import pytest
 from pandas.core.dtypes.common import ensure_platform_int
 
 import pandas as pd
-import pandas._testing as tm
-from pandas.core.indexes.api import (
-    Float64Index,
+from pandas import (
     Index,
-    Int64Index,
     RangeIndex,
 )
+import pandas._testing as tm
 from pandas.tests.indexes.common import NumericBase
 
 # aliases to make some tests easier to read
 RI = RangeIndex
-I64 = Int64Index
-F64 = Float64Index
-OI = Index
 
 
 class TestRangeIndex(NumericBase):
@@ -111,7 +106,7 @@ class TestRangeIndex(NumericBase):
         tm.assert_index_equal(idx[0:4], result.insert(0, idx[0]), exact="equiv")
 
         # GH 18295 (test missing)
-        expected = Float64Index([0, np.nan, 1, 2, 3, 4])
+        expected = Index([0, np.nan, 1, 2, 3, 4], dtype=np.float64)
         for na in [np.nan, None, pd.NA]:
             result = RangeIndex(5).insert(1, na)
             tm.assert_index_equal(result, expected)
@@ -379,7 +374,7 @@ class TestRangeIndex(NumericBase):
 
         # memory savings vs int index
         idx = RangeIndex(0, 1000)
-        assert idx.nbytes < Int64Index(idx._values).nbytes / 10
+        assert idx.nbytes < Index(idx._values).nbytes / 10
 
         # constant memory usage
         i2 = RangeIndex(0, 10)
@@ -530,16 +525,16 @@ class TestRangeIndex(NumericBase):
             ([RI(-4, -8), RI(-8, -12)], RI(0, 0)),
             ([RI(-4, -8), RI(3, -4)], RI(0, 0)),
             ([RI(-4, -8), RI(3, 5)], RI(3, 5)),
-            ([RI(-4, -2), RI(3, 5)], I64([-4, -3, 3, 4])),
+            ([RI(-4, -2), RI(3, 5)], Index([-4, -3, 3, 4])),
             ([RI(-2), RI(3, 5)], RI(3, 5)),
-            ([RI(2), RI(2)], I64([0, 1, 0, 1])),
+            ([RI(2), RI(2)], Index([0, 1, 0, 1])),
             ([RI(2), RI(2, 5), RI(5, 8, 4)], RI(0, 6)),
-            ([RI(2), RI(3, 5), RI(5, 8, 4)], I64([0, 1, 3, 4, 5])),
+            ([RI(2), RI(3, 5), RI(5, 8, 4)], Index([0, 1, 3, 4, 5])),
             ([RI(-2, 2), RI(2, 5), RI(5, 8, 4)], RI(-2, 6)),
-            ([RI(3), OI([-1, 3, 15])], OI([0, 1, 2, -1, 3, 15])),
-            ([RI(3), OI([-1, 3.1, 15.0])], OI([0, 1, 2, -1, 3.1, 15.0])),
-            ([RI(3), OI(["a", None, 14])], OI([0, 1, 2, "a", None, 14])),
-            ([RI(3, 1), OI(["a", None, 14])], OI(["a", None, 14])),
+            ([RI(3), Index([-1, 3, 15])], Index([0, 1, 2, -1, 3, 15])),
+            ([RI(3), Index([-1, 3.1, 15.0])], Index([0, 1, 2, -1, 3.1, 15.0])),
+            ([RI(3), Index(["a", None, 14])], Index([0, 1, 2, "a", None, 14])),
+            ([RI(3, 1), Index(["a", None, 14])], Index(["a", None, 14])),
         ]
     )
     def appends(self, request):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -18,6 +18,8 @@ from pandas.errors import (
 )
 from pandas.util._test_decorators import async_mark
 
+from pandas.core.dtypes.common import is_numeric_dtype
+
 import pandas as pd
 from pandas import (
     CategoricalIndex,
@@ -592,12 +594,10 @@ class TestIndex(Base):
         if index.empty:
             # to match proper result coercion for uints
             expected = Index([])
-        elif index._is_backward_compat_public_numeric_index:
+        elif is_numeric_dtype(index.dtype):
             expected = index._constructor(rng, dtype=index.dtype)
         elif type(index) is Index and index.dtype != object:
             # i.e. EA-backed, for now just Nullable
-            expected = Index(rng, dtype=index.dtype)
-        elif index.dtype.kind == "u":
             expected = Index(rng, dtype=index.dtype)
         else:
             expected = Index(rng)

--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -15,12 +15,10 @@ from pandas.core.dtypes.cast import find_common_type
 
 from pandas import (
     CategoricalIndex,
-    DatetimeIndex,
     Index,
     MultiIndex,
     RangeIndex,
     Series,
-    TimedeltaIndex,
     Timestamp,
 )
 import pandas._testing as tm
@@ -29,11 +27,6 @@ from pandas.api.types import (
     is_datetime64tz_dtype,
     is_signed_integer_dtype,
     pandas_dtype,
-)
-from pandas.core.api import (
-    Float64Index,
-    Int64Index,
-    UInt64Index,
 )
 
 
@@ -77,7 +70,7 @@ def test_union_different_types(index_flat, index_flat2, request):
         # idx1 = Index(
         # [True, True, True, True, True, True, True, True, False, False], dtype='bool'
         # )
-        # idx2 = Int64Index([0, 0, 1, 1, 2, 2], dtype='int64')
+        # idx2 = Index([0, 0, 1, 1, 2, 2], dtype='int64')
         mark = pytest.mark.xfail(
             reason="GH#44000 True==1", raises=ValueError, strict=False
         )
@@ -567,24 +560,15 @@ def test_intersection_duplicates_all_indexes(index):
     assert idx.intersection(idx_non_unique).is_unique
 
 
-@pytest.mark.parametrize(
-    "cls",
-    [
-        Int64Index,
-        Float64Index,
-        DatetimeIndex,
-        CategoricalIndex,
-        lambda x: CategoricalIndex(x, categories=set(x)),
-        TimedeltaIndex,
-        lambda x: Index(x, dtype=object),
-        UInt64Index,
-    ],
-)
-def test_union_duplicate_index_subsets_of_each_other(cls):
+def test_union_duplicate_index_subsets_of_each_other(
+    any_numpy_dtype_for_small_integer_indexes,
+):
     # GH#31326
-    a = cls([1, 2, 2, 3])
-    b = cls([3, 3, 4])
-    expected = cls([1, 2, 2, 3, 3, 4])
+    dtype = any_numpy_dtype_for_small_integer_indexes
+    a = Index([1, 2, 2, 3], dtype=dtype)
+    b = Index([3, 3, 4], dtype=dtype)
+
+    expected = Index([1, 2, 2, 3, 3, 4], dtype=dtype)
     if isinstance(a, CategoricalIndex):
         expected = Index([1, 2, 2, 3, 3, 4])
     result = a.union(b)
@@ -593,22 +577,14 @@ def test_union_duplicate_index_subsets_of_each_other(cls):
     tm.assert_index_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    "cls",
-    [
-        Int64Index,
-        Float64Index,
-        DatetimeIndex,
-        CategoricalIndex,
-        TimedeltaIndex,
-        lambda x: Index(x, dtype=object),
-    ],
-)
-def test_union_with_duplicate_index_and_non_monotonic(cls):
+def test_union_with_duplicate_index_and_non_monotonic(
+    any_numpy_dtype_for_small_integer_indexes,
+):
     # GH#36289
-    a = cls([1, 0, 0])
-    b = cls([0, 1])
-    expected = cls([0, 0, 1])
+    dtype = any_numpy_dtype_for_small_integer_indexes
+    a = Index([1, 0, 0], dtype=dtype)
+    b = Index([0, 1], dtype=dtype)
+    expected = Index([0, 0, 1], dtype=dtype)
 
     result = a.union(b)
     tm.assert_index_equal(result, expected)
@@ -645,21 +621,16 @@ def test_union_nan_in_both(dup):
     tm.assert_index_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    "cls",
-    [
-        Int64Index,
-        Float64Index,
-        DatetimeIndex,
-        TimedeltaIndex,
-        lambda x: Index(x, dtype=object),
-    ],
-)
-def test_union_with_duplicate_index_not_subset_and_non_monotonic(cls):
+def test_union_with_duplicate_index_not_subset_and_non_monotonic(
+    any_numpy_dtype_for_small_integer_indexes,
+):
     # GH#36289
-    a = cls([1, 0, 2])
-    b = cls([0, 0, 1])
-    expected = cls([0, 0, 1, 2])
+    dtype = any_numpy_dtype_for_small_integer_indexes
+    a = Index([1, 0, 2], dtype=dtype)
+    b = Index([0, 0, 1], dtype=dtype)
+    expected = Index([0, 0, 1, 2], dtype=dtype)
+    if isinstance(a, CategoricalIndex):
+        expected = Index([0, 0, 1, 2])
 
     result = a.union(b)
     tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/timedeltas/methods/test_astype.py
+++ b/pandas/tests/indexes/timedeltas/methods/test_astype.py
@@ -55,7 +55,7 @@ class TestTimedeltaIndex:
         tm.assert_index_equal(result, expected)
 
         result = idx.astype(np.int64)
-        expected = Int64Index(
+        expected = Index(
             [100000000000000] + [-9223372036854775808] * 3, dtype=np.int64, name="idx"
         )
         tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/timedeltas/methods/test_astype.py
+++ b/pandas/tests/indexes/timedeltas/methods/test_astype.py
@@ -12,7 +12,6 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 
 
 class TestTimedeltaIndex:

--- a/pandas/tests/indexes/timedeltas/test_setops.py
+++ b/pandas/tests/indexes/timedeltas/test_setops.py
@@ -3,11 +3,11 @@ import pytest
 
 import pandas as pd
 from pandas import (
+    Index,
     TimedeltaIndex,
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 
 from pandas.tseries.offsets import Hour
 
@@ -21,7 +21,7 @@ class TestTimedeltaIndex:
         expected = timedelta_range("1day", periods=7)
         tm.assert_index_equal(result, expected)
 
-        i1 = Int64Index(np.arange(0, 20, 2))
+        i1 = Index(np.arange(0, 20, 2, dtype=np.int64))
         i2 = timedelta_range(start="1 day", periods=10, freq="D")
         i1.union(i2)  # Works
         i2.union(i1)  # Fails with "AttributeError: can't set attribute"

--- a/pandas/tests/indexing/conftest.py
+++ b/pandas/tests/indexing/conftest.py
@@ -3,13 +3,10 @@ import pytest
 
 from pandas import (
     DataFrame,
+    Index,
     MultiIndex,
     Series,
     date_range,
-)
-from pandas.core.api import (
-    Float64Index,
-    UInt64Index,
 )
 
 
@@ -27,15 +24,15 @@ def frame_ints():
 
 @pytest.fixture
 def series_uints():
-    return Series(np.random.rand(4), index=UInt64Index(np.arange(0, 8, 2)))
+    return Series(np.random.rand(4), index=Index(np.arange(0, 8, 2, dtype=np.uint64)))
 
 
 @pytest.fixture
 def frame_uints():
     return DataFrame(
         np.random.randn(4, 4),
-        index=UInt64Index(range(0, 8, 2)),
-        columns=UInt64Index(range(0, 12, 3)),
+        index=Index(range(0, 8, 2), dtype=np.uint64),
+        columns=Index(range(0, 12, 3), dtype=np.uint64),
     )
 
 
@@ -61,15 +58,15 @@ def frame_ts():
 
 @pytest.fixture
 def series_floats():
-    return Series(np.random.rand(4), index=Float64Index(range(0, 8, 2)))
+    return Series(np.random.rand(4), index=Index(range(0, 8, 2), dtype=np.float64))
 
 
 @pytest.fixture
 def frame_floats():
     return DataFrame(
         np.random.randn(4, 4),
-        index=Float64Index(range(0, 8, 2)),
-        columns=Float64Index(range(0, 12, 3)),
+        index=Index(range(0, 8, 2), dtype=np.float64),
+        columns=Index(range(0, 12, 3), dtype=np.float64),
     )
 
 

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -44,16 +44,18 @@ class TestMultiIndexLoc:
         df.loc[("bar", "two"), 1] = 7
         assert df.loc[("bar", "two"), 1] == 7
 
-    def test_loc_getitem_general(self):
-
+    def test_loc_getitem_general(self, any_real_numpy_dtype):
         # GH#2817
+        dtype = any_real_numpy_dtype
         data = {
             "amount": {0: 700, 1: 600, 2: 222, 3: 333, 4: 444},
             "col": {0: 3.5, 1: 3.5, 2: 4.0, 3: 4.0, 4: 4.0},
-            "year": {0: 2012, 1: 2011, 2: 2012, 3: 2012, 4: 2012},
+            "num": {0: 12, 1: 11, 2: 12, 3: 12, 4: 12},
         }
-        df = DataFrame(data).set_index(keys=["col", "year"])
-        key = 4.0, 2012
+        df = DataFrame(data)
+        df = df.astype({"col": dtype, "num": dtype})
+        df = df.set_index(keys=["col", "num"])
+        key = 4.0, 12
 
         # emits a PerformanceWarning, ok
         with tm.assert_produces_warning(PerformanceWarning):
@@ -64,8 +66,10 @@ class TestMultiIndexLoc:
         assert return_value is None
         res = df.loc[key]
 
-        # col has float dtype, result should be Float64Index
-        index = MultiIndex.from_arrays([[4.0] * 3, [2012] * 3], names=["col", "year"])
+        # col has float dtype, result should be float64 Index
+        col_arr = np.array([4.0] * 3, dtype=dtype)
+        year_arr = np.array([12] * 3, dtype=dtype)
+        index = MultiIndex.from_arrays([col_arr, year_arr], names=["col", "num"])
         expected = DataFrame({"amount": [222, 333, 444]}, index=index)
         tm.assert_frame_equal(res, expected)
 

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -16,7 +16,6 @@ from pandas.compat import (
 
 import pandas as pd
 import pandas._testing as tm
-from pandas.core.api import NumericIndex
 
 ###############################################################
 # Index / Series common tests which may trigger dtype coercions
@@ -207,33 +206,39 @@ class TestInsertIndexCoercion(CoercionBase):
     @pytest.mark.parametrize(
         "insert, coerced_val, coerced_dtype",
         [
-            (1, 1, np.int64),
+            (1, 1, None),
             (1.1, 1.1, np.float64),
             (False, False, object),  # GH#36319
             ("x", "x", object),
         ],
     )
-    def test_insert_index_int64(self, insert, coerced_val, coerced_dtype):
-        obj = NumericIndex([1, 2, 3, 4], dtype=np.int64)
-        assert obj.dtype == np.int64
+    def test_insert_int_index(
+        self, any_int_numpy_dtype, insert, coerced_val, coerced_dtype
+    ):
+        dtype = any_int_numpy_dtype
+        obj = pd.Index([1, 2, 3, 4], dtype=dtype)
+        coerced_dtype = coerced_dtype if coerced_dtype is not None else dtype
 
-        exp = pd.Index([1, coerced_val, 2, 3, 4])
+        exp = pd.Index([1, coerced_val, 2, 3, 4], dtype=coerced_dtype)
         self._assert_insert_conversion(obj, insert, exp, coerced_dtype)
 
     @pytest.mark.parametrize(
         "insert, coerced_val, coerced_dtype",
         [
-            (1, 1.0, np.float64),
+            (1, 1.0, None),
             (1.1, 1.1, np.float64),
             (False, False, object),  # GH#36319
             ("x", "x", object),
         ],
     )
-    def test_insert_index_float64(self, insert, coerced_val, coerced_dtype):
-        obj = NumericIndex([1.0, 2.0, 3.0, 4.0], dtype=np.float64)
-        assert obj.dtype == np.float64
+    def test_insert_float_index(
+        self, float_numpy_dtype, insert, coerced_val, coerced_dtype
+    ):
+        dtype = float_numpy_dtype
+        obj = pd.Index([1.0, 2.0, 3.0, 4.0], dtype=dtype)
+        coerced_dtype = coerced_dtype if coerced_dtype is not None else dtype
 
-        exp = pd.Index([1.0, coerced_val, 2.0, 3.0, 4.0])
+        exp = pd.Index([1.0, coerced_val, 2.0, 3.0, 4.0], dtype=coerced_dtype)
         self._assert_insert_conversion(obj, insert, exp, coerced_dtype)
 
     @pytest.mark.parametrize(

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -531,8 +531,9 @@ class TestFloatIndexers:
         result = indexer_sl(s)[[2.5]]
         tm.assert_series_equal(result, Series([1], index=[2.5]))
 
-    def test_float64index_slicing_bug(self):
+    def test_floatindex_slicing_bug(self, float_numpy_dtype):
         # GH 5557, related to slicing a float index
+        dtype = float_numpy_dtype
         ser = {
             256: 2321.0,
             1: 78.0,
@@ -686,6 +687,7 @@ class TestFloatIndexers:
         }
 
         # smoke test for the repr
-        s = Series(ser)
+        s = Series(ser, dtype=dtype)
         result = s.value_counts()
+        assert result.index.dtype == dtype
         str(result)

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -26,7 +26,6 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Float64Index
 from pandas.tests.indexing.common import _mklbl
 from pandas.tests.indexing.test_floats import gen_obj
 
@@ -167,7 +166,7 @@ class TestFancy:
         assert df.loc[np.inf, 0] == 3
 
         result = df.index
-        expected = Float64Index([1, 2, np.inf])
+        expected = Index([1, 2, np.inf], dtype=np.float64)
         tm.assert_index_equal(result, expected)
 
     def test_setitem_dtype_upcast(self):

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1377,9 +1377,10 @@ class TestLocBaseIndependent:
         expected.name = val
         tm.assert_series_equal(result, expected)
 
-    def test_loc_setitem_int_label_with_float64index(self):
+    def test_loc_setitem_int_label_with_float_index(self, float_numpy_dtype):
         # note labels are floats
-        ser = Series(["a", "b", "c"], index=[0, 0.5, 1])
+        dtype = float_numpy_dtype
+        ser = Series(["a", "b", "c"], index=Index([0, 0.5, 1], dtype=dtype))
         expected = ser.copy()
 
         ser.loc[1] = "zoo"
@@ -2073,7 +2074,7 @@ class TestLocSetitemWithExpansion:
         df.loc[0, np.inf] = 3
 
         result = df.columns
-        expected = Float64Index([0, 1, np.inf])
+        expected = Index([0, 1, np.inf], dtype=np.float64)
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.filterwarnings("ignore:indexing past lexsort depth")
@@ -2415,13 +2416,14 @@ class TestLabelSlicing:
         s1 = df.loc[52195.1:52198.9]
         assert len(s1) == 3
 
-    def test_loc_getitem_float_slice_float64index(self):
-        ser = Series(np.random.rand(10), index=np.arange(10, 20, dtype=float))
+    def test_loc_getitem_float_slice_floatindex(self, float_numpy_dtype):
+        dtype = float_numpy_dtype
+        ser = Series(np.random.rand(10), index=np.arange(10, 20, dtype=dtype))
 
         assert len(ser.loc[12.0:]) == 8
         assert len(ser.loc[12.5:]) == 7
 
-        idx = np.arange(10, 20, dtype=float)
+        idx = np.arange(10, 20, dtype=dtype)
         idx[2] = 12.2
         ser.index = idx
         assert len(ser.loc[12.0:]) == 8

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -41,7 +41,6 @@ from pandas.api.types import (
     is_bool_dtype,
     is_scalar,
 )
-from pandas.core.api import Float64Index
 from pandas.core.indexing import _one_ellipsis_message
 from pandas.tests.indexing.common import check_indexing_smoketest_or_raises
 

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -15,7 +15,6 @@ from pandas import (
     Timestamp,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 from pandas.core.indexes.datetimes import date_range
 
 test_frame = DataFrame(
@@ -333,7 +332,7 @@ def test_consistency_with_window():
 
     # consistent return values with window
     df = test_frame
-    expected = Int64Index([1, 2, 3], name="A")
+    expected = Index([1, 2, 3], name="A")
     result = df.groupby("A").resample("2s").mean()
     assert result.index.nlevels == 2
     tm.assert_index_equal(result.index.levels[0], expected)

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -20,6 +20,7 @@ from pandas import (
     CategoricalIndex,
     DataFrame,
     DatetimeIndex,
+    Index,
     IntervalIndex,
     MultiIndex,
     PeriodIndex,
@@ -29,11 +30,6 @@ from pandas import (
 )
 import pandas._testing as tm
 from pandas.api.types import CategoricalDtype as CDT
-from pandas.core.api import (
-    Float64Index,
-    Int64Index,
-    UInt64Index,
-)
 from pandas.core.reshape.concat import concat
 from pandas.core.reshape.merge import (
     MergeError,
@@ -1324,8 +1320,13 @@ class TestMerge:
                     ["2001-01-01", "2002-02-02", "2003-03-03", pd.NaT, pd.NaT, pd.NaT]
                 ),
             ),
-            (Float64Index([1, 2, 3]), Float64Index([1, 2, 3, None, None, None])),
-            (Int64Index([1, 2, 3]), Float64Index([1, 2, 3, None, None, None])),
+            *[
+                (
+                    Index([1, 2, 3], dtype=dtyp),
+                    Index([1, 2, 3, None, None, None], dtype=np.float64),
+                )
+                for dtyp in tm.ALL_REAL_NUMPY_DTYPES
+            ],
             (
                 IntervalIndex.from_tuples([(1, 2), (2, 3), (3, 4)]),
                 IntervalIndex.from_tuples(
@@ -2140,17 +2141,19 @@ class TestMergeOnIndexes:
         tm.assert_frame_equal(result, expected)
 
 
+_test_merge_index_types_params = [
+    Index([1, 2], dtype=dtyp, name="index_col") for dtyp in tm.ALL_REAL_NUMPY_DTYPES
+] + [
+    CategoricalIndex(["A", "B"], categories=["A", "B"], name="index_col"),
+    RangeIndex(start=0, stop=2, name="index_col"),
+    DatetimeIndex(["2018-01-01", "2018-01-02"], name="index_col"),
+]
+
+
 @pytest.mark.parametrize(
     "index",
-    [
-        CategoricalIndex(["A", "B"], categories=["A", "B"], name="index_col"),
-        Float64Index([1.0, 2.0], name="index_col"),
-        Int64Index([1, 2], name="index_col"),
-        UInt64Index([1, 2], name="index_col"),
-        RangeIndex(start=0, stop=2, name="index_col"),
-        DatetimeIndex(["2018-01-01", "2018-01-02"], name="index_col"),
-    ],
-    ids=lambda x: type(x).__name__,
+    _test_merge_index_types_params,
+    ids=lambda x: f"{type(x).__name__}[{x.dtype}]",
 )
 def test_merge_index_types(index):
     # gh-20777
@@ -2652,11 +2655,11 @@ def test_merge_duplicate_columns_with_suffix_causing_another_duplicate_raises():
 
 def test_merge_string_float_column_result():
     # GH 13353
-    df1 = DataFrame([[1, 2], [3, 4]], columns=pd.Index(["a", 114.0]))
+    df1 = DataFrame([[1, 2], [3, 4]], columns=Index(["a", 114.0]))
     df2 = DataFrame([[9, 10], [11, 12]], columns=["x", "y"])
     result = merge(df2, df1, how="inner", left_index=True, right_index=True)
     expected = DataFrame(
-        [[9, 10, 1, 2], [11, 12, 3, 4]], columns=pd.Index(["x", "y", "a", 114.0])
+        [[9, 10, 1, 2], [11, 12, 3, 4]], columns=Index(["x", "y", "a", 114.0])
     )
     tm.assert_frame_equal(result, expected)
 
@@ -2712,8 +2715,8 @@ def test_merge_outer_with_NaN(dtype):
 
 def test_merge_different_index_names():
     # GH#45094
-    left = DataFrame({"a": [1]}, index=pd.Index([1], name="c"))
-    right = DataFrame({"a": [1]}, index=pd.Index([1], name="d"))
+    left = DataFrame({"a": [1]}, index=Index([1], name="c"))
+    right = DataFrame({"a": [1]}, index=Index([1], name="d"))
     result = merge(left, right, left_on="c", right_on="d")
     expected = DataFrame({"a_x": [1], "a_y": 1})
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/series/indexing/test_get.py
+++ b/pandas/tests/series/indexing/test_get.py
@@ -2,9 +2,11 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas import Series
+from pandas import (
+    Index,
+    Series,
+)
 import pandas._testing as tm
-from pandas.core.api import Float64Index
 
 
 def test_get():
@@ -65,7 +67,7 @@ def test_get():
                 54,
             ]
         ),
-        index=Float64Index(
+        index=Index(
             [
                 25.0,
                 36.0,
@@ -87,7 +89,8 @@ def test_get():
                 1764.0,
                 1849.0,
                 1936.0,
-            ]
+            ],
+            dtype=np.float64,
         ),
     )
 
@@ -110,18 +113,18 @@ def test_get():
     assert result == "Missing"
 
 
-def test_get_nan():
+def test_get_nan(float_numpy_dtype):
     # GH 8569
-    s = Float64Index(range(10)).to_series()
+    s = Index(range(10), dtype=float_numpy_dtype).to_series()
     assert s.get(np.nan) is None
     assert s.get(np.nan, default="Missing") == "Missing"
 
 
-def test_get_nan_multiple():
+def test_get_nan_multiple(float_numpy_dtype):
     # GH 8569
     # ensure that fixing "test_get_nan" above hasn't broken get
     # with multiple elements
-    s = Float64Index(range(10)).to_series()
+    s = Index(range(10), dtype=float_numpy_dtype).to_series()
 
     idx = [2, 30]
     assert s.get(idx) is None

--- a/pandas/tests/series/indexing/test_getitem.py
+++ b/pandas/tests/series/indexing/test_getitem.py
@@ -88,8 +88,9 @@ class TestSeriesGetitemScalars:
         with pytest.raises(KeyError, match="-1"):
             ser[-1]
 
-    def test_getitem_keyerror_with_int64index(self):
-        ser = Series(np.random.randn(6), index=[0, 0, 1, 1, 2, 2])
+    def test_getitem_keyerror_with_integer_index(self, any_int_numpy_dtype):
+        dtype = any_int_numpy_dtype
+        ser = Series(np.random.randn(6), index=Index([0, 0, 1, 1, 2, 2], dtype=dtype))
 
         with pytest.raises(KeyError, match=r"^5$"):
             ser[5]

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -47,7 +47,6 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 from pandas.core.arrays import (
     IntervalArray,
     period_array,
@@ -712,7 +711,7 @@ class TestSeriesConstructors:
             timedelta_range("1 day", periods=3),
             period_range("2012Q1", periods=3, freq="Q"),
             Index(list("abc")),
-            Int64Index([1, 2, 3]),
+            Index([1, 2, 3]),
             RangeIndex(0, 3),
         ],
         ids=lambda x: type(x).__name__,


### PR DESCRIPTION
This PR updates various tests that currently use Int64Index/UInt64Index/Float64Index to instead use `Index` with the relevant dtype (parametrized dtypes where relevant). Sections of the tests suite are changed in separate commits, so it will be easier to separate them out, if desired. 

This PR's first 3 commits correspond to #50052, which again build on #49560, which builds on #50195. Those 3 PRs are not part of this PR, but should ideally be treated as precursors for this PR, if possible.