### PR TITLE
CI/WEB: Adding cache for maintainers' github info

### DIFF
--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -46,6 +46,12 @@ jobs:
     - name: Build Pandas
       uses: ./.github/actions/build_pandas
 
+    - name: Set up maintainers cache
+      uses: actions/cache@v3
+      with:
+        path: maintainers.json
+        key: maintainers
+
     - name: Build website
       run: python web/pandas_web.py web/pandas --target-path=web/build
 

--- a/web/pandas_web.py
+++ b/web/pandas_web.py
@@ -27,6 +27,7 @@ import argparse
 import collections
 import datetime
 import importlib
+import json
 import operator
 import os
 import pathlib
@@ -163,6 +164,18 @@ class Preprocessors:
         Given the active maintainers defined in the yaml file, it fetches
         the GitHub user information for them.
         """
+        timestamp = time.time()
+
+        cache_file = pathlib.Path("maintainers.json")
+        if cache_file.is_file():
+            with open(cache_file) as f:
+                context["maintainers"] = json.load(f)
+            # refresh cache after 1 hour
+            if (timestamp - context["maintainers"]["timestamp"]) < 3_600:
+                return context
+
+        context["maintainers"]["timestamp"] = timestamp
+
         repeated = set(context["maintainers"]["active"]) & set(
             context["maintainers"]["inactive"]
         )
@@ -179,6 +192,10 @@ class Preprocessors:
                     return context
                 resp.raise_for_status()
                 context["maintainers"][f"{kind}_with_github_info"].append(resp.json())
+
+        with open(cache_file, "w") as f:
+            json.dump(context["maintainers"], f)
+
         return context
 
     @staticmethod


### PR DESCRIPTION
I've seen some CI failures recently caused by hitting github API quota when building the website. The website requests from github the info of maintainers to show names and photos in https://pandas.pydata.org/about/team.html (also the releases in the home, but that's a single request not affecting the quota much).

Feels like in the past every github worker was independent and had its own quota, but now seems like running jobs too quickly hits the quota. In this PR I add a cache to reuse the maintainers info for one hour (the time it takes the quota to reset), which should avoid those failures.