### PR TITLE
CLN avoid some upcasting when its not the purpose of the test

### DIFF
--- a/pandas/tests/frame/methods/test_equals.py
+++ b/pandas/tests/frame/methods/test_equals.py
@@ -36,7 +36,8 @@ class TestEquals:
         df1["start"] = date_range("2000-1-1", periods=10, freq="T")
         df1["end"] = date_range("2000-1-1", periods=10, freq="D")
         df1["diff"] = df1["end"] - df1["start"]
-        df1["bool"] = np.arange(10) % 3 == 0
+        # Explicitly cast to object, to avoid implicit cast when setting np.nan
+        df1["bool"] = (np.arange(10) % 3 == 0).astype(object)
         df1.loc[::2] = np.nan
         df2 = df1.copy()
         assert df1["text"].equals(df2["text"])

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -448,6 +448,7 @@ class TestDataFrameQueryNumExprPandas:
     def test_date_index_query_with_NaT(self):
         engine, parser = self.engine, self.parser
         n = 10
+        # Cast to object to avoid implicit cast when setting entry to pd.NaT below
         df = DataFrame(np.random.randn(n, 3)).astype({0: object})
         df["dates1"] = date_range("1/1/2012", periods=n)
         df["dates3"] = date_range("1/1/2014", periods=n)
@@ -808,6 +809,7 @@ class TestDataFrameQueryNumExprPython(TestDataFrameQueryNumExprPandas):
     def test_date_index_query_with_NaT(self):
         engine, parser = self.engine, self.parser
         n = 10
+        # Cast to object to avoid implicit cast when setting entry to pd.NaT below
         df = DataFrame(np.random.randn(n, 3)).astype({0: object})
         df["dates1"] = date_range("1/1/2012", periods=n)
         df["dates3"] = date_range("1/1/2014", periods=n)

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -448,7 +448,7 @@ class TestDataFrameQueryNumExprPandas:
     def test_date_index_query_with_NaT(self):
         engine, parser = self.engine, self.parser
         n = 10
-        df = DataFrame(np.random.randn(n, 3))
+        df = DataFrame(np.random.randn(n, 3)).astype({0: object})
         df["dates1"] = date_range("1/1/2012", periods=n)
         df["dates3"] = date_range("1/1/2014", periods=n)
         df.iloc[0, 0] = pd.NaT
@@ -808,7 +808,7 @@ class TestDataFrameQueryNumExprPython(TestDataFrameQueryNumExprPandas):
     def test_date_index_query_with_NaT(self):
         engine, parser = self.engine, self.parser
         n = 10
-        df = DataFrame(np.random.randn(n, 3))
+        df = DataFrame(np.random.randn(n, 3)).astype({0: object})
         df["dates1"] = date_range("1/1/2012", periods=n)
         df["dates3"] = date_range("1/1/2014", periods=n)
         df.iloc[0, 0] = pd.NaT

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -448,15 +448,15 @@ class TestDataFrameAnalytics:
     @pytest.mark.parametrize("meth", ["sem", "var", "std"])
     def test_numeric_only_flag(self, meth):
         # GH 9201
-        df1 = DataFrame(np.random.randn(5, 3), columns=["foo", "bar", "baz"]).astype(
-            {"foo": object}
-        )
+        df1 = DataFrame(np.random.randn(5, 3), columns=["foo", "bar", "baz"])
+        # Cast to object to avoid implicit cast when setting entry to "100" below
+        df1 = df1.astype({"foo": object})
         # set one entry to a number in str format
         df1.loc[0, "foo"] = "100"
 
-        df2 = DataFrame(np.random.randn(5, 3), columns=["foo", "bar", "baz"]).astype(
-            {"foo": object}
-        )
+        df2 = DataFrame(np.random.randn(5, 3), columns=["foo", "bar", "baz"])
+        # Cast to object to avoid implicit cast when setting entry to "a" below
+        df2 = df2.astype({"foo": object})
         # set one entry to a non-number str
         df2.loc[0, "foo"] = "a"
 

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -448,11 +448,15 @@ class TestDataFrameAnalytics:
     @pytest.mark.parametrize("meth", ["sem", "var", "std"])
     def test_numeric_only_flag(self, meth):
         # GH 9201
-        df1 = DataFrame(np.random.randn(5, 3), columns=["foo", "bar", "baz"])
+        df1 = DataFrame(np.random.randn(5, 3), columns=["foo", "bar", "baz"]).astype(
+            {"foo": object}
+        )
         # set one entry to a number in str format
         df1.loc[0, "foo"] = "100"
 
-        df2 = DataFrame(np.random.randn(5, 3), columns=["foo", "bar", "baz"])
+        df2 = DataFrame(np.random.randn(5, 3), columns=["foo", "bar", "baz"]).astype(
+            {"foo": object}
+        )
         # set one entry to a non-number str
         df2.loc[0, "foo"] = "a"
 

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -102,7 +102,7 @@ class TestGroupBy:
                 index=date_range(
                     "20130901", "20131205", freq="5D", name="Date", inclusive="left"
                 ),
-            )
+            ).astype({"Buyer": object})
             expected.iloc[0, 0] = "CarlCarlCarl"
             expected.iloc[6, 0] = "CarlCarl"
             expected.iloc[18, 0] = "Joe"

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -102,7 +102,9 @@ class TestGroupBy:
                 index=date_range(
                     "20130901", "20131205", freq="5D", name="Date", inclusive="left"
                 ),
-            ).astype({"Buyer": object})
+            )
+            # Cast to object to avoid implicit cast when setting entry to "CarlCarlCarl"
+            expected = expected.astype({"Buyer": object})
             expected.iloc[0, 0] = "CarlCarlCarl"
             expected.iloc[6, 0] = "CarlCarl"
             expected.iloc[18, 0] = "Joe"

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -16,6 +16,7 @@ class TestSeriesReplace:
         expected = pd.Series([0, 0, None], dtype=object)
         tm.assert_series_equal(result, expected)
 
+        # Cast column 2 to object to avoid implicit cast when setting entry to ""
         df = pd.DataFrame(np.zeros((3, 3))).astype({2: object})
         df.iloc[2, 2] = ""
         result = df.replace("", None)

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -16,7 +16,7 @@ class TestSeriesReplace:
         expected = pd.Series([0, 0, None], dtype=object)
         tm.assert_series_equal(result, expected)
 
-        df = pd.DataFrame(np.zeros((3, 3)))
+        df = pd.DataFrame(np.zeros((3, 3))).astype({2: object})
         df.iloc[2, 2] = ""
         result = df.replace("", None)
         expected = pd.DataFrame(


### PR DESCRIPTION
Generally, tests follow the pattern:
- create input
- do something to it
- check that it matches expected output

There are a few places when, whilst creating the test input, some column is created of some dtype (e.g. 'int'), and then some incompatible type is set (e.g. a string `'foo'`), thus upcasting the column to dtype object. After that, this input is put through the function which the test is meant to test.

Given that the upcasting isn't the purpose of these tests, it'd be cleaner to just create the input right away with object dtype.

The "avoid upcasting to object" part of #50424 does seem uncontroversial, so this would help reduce the diff when a set of PRs to address that will be raised