### PR TITLE
DOC: Add `pip install odfpy` for io.rst

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -3833,14 +3833,13 @@ OpenDocument Spreadsheets
 The io methods for `Excel files`_ also support reading and writing OpenDocument spreadsheets
 using the `odfpy <https://pypi.org/project/odfpy/>`__ module. The semantics and features for reading and writing
 OpenDocument spreadsheets match what can be done for `Excel files`_ using
-``engine='odf'``.
+``engine='odf'``. The optional dependency 'odfpy' needs to be installed.
 
 The :func:`~pandas.read_excel` method can read OpenDocument spreadsheets
 
 .. code-block:: python
 
    # Returns a DataFrame
-   # package 'odfpy' is required
    pd.read_excel("path_to_file.ods", engine="odf")
 
 .. versionadded:: 1.1.0

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -3833,13 +3833,14 @@ OpenDocument Spreadsheets
 The io methods for `Excel files`_ also support reading and writing OpenDocument spreadsheets
 using the `odfpy <https://pypi.org/project/odfpy/>`__ module. The semantics and features for reading and writing
 OpenDocument spreadsheets match what can be done for `Excel files`_ using
-``engine='odf'``. ``pip install odfpy`` may be required, if is not already installed.
+``engine='odf'``.
 
 The :func:`~pandas.read_excel` method can read OpenDocument spreadsheets
 
 .. code-block:: python
 
    # Returns a DataFrame
+   # package 'odfpy' is required
    pd.read_excel("path_to_file.ods", engine="odf")
 
 .. versionadded:: 1.1.0

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -3833,7 +3833,7 @@ OpenDocument Spreadsheets
 The io methods for `Excel files`_ also support reading and writing OpenDocument spreadsheets
 using the `odfpy <https://pypi.org/project/odfpy/>`__ module. The semantics and features for reading and writing
 OpenDocument spreadsheets match what can be done for `Excel files`_ using
-``engine='odf'``.
+``engine='odf'``. ``pip install odfpy`` may be required, if is not already installed.
 
 The :func:`~pandas.read_excel` method can read OpenDocument spreadsheets
 


### PR DESCRIPTION
Fixes #50487

- [x] closes #50487

Perhaps because of my misunderstanding, adding 'pip install' here may not be consistent with the previous docs style. Because there is no direct instruction in the previous docs how to install the engine manually.
