### PR TITLE
BUG: DataFrameGroupBy.value_counts fails with a TimeGrouper

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -932,6 +932,7 @@ Groupby/resample/rolling
 - Bug in :class:`.DataFrameGroupBy` and :class:`.SeriesGroupBy` with ``dropna=False`` would drop NA values when the grouper was categorical (:issue:`36327`)
 - Bug in :meth:`.SeriesGroupBy.nunique` would incorrectly raise when the grouper was an empty categorical and ``observed=True`` (:issue:`21334`)
 - Bug in :meth:`.SeriesGroupBy.nth` would raise when grouper contained NA values after subsetting from a :class:`DataFrameGroupBy` (:issue:`26454`)
+- Bug in :meth:`.DataFrameGrouBy.value_counts` would raise when used with a :class:`.TimeGrouper` (:issue:`50486`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -663,6 +663,7 @@ class Grouping:
 
     @cache_readonly
     def _codes_and_uniques(self) -> tuple[npt.NDArray[np.signedinteger], ArrayLike]:
+        uniques: ArrayLike
         if self._passed_categorical:
             # we make a CategoricalIndex out of the cat grouper
             # preserving the categories / ordered attributes;
@@ -707,11 +708,7 @@ class Grouping:
         elif isinstance(self.grouping_vector, ops.BaseGrouper):
             # we have a list of groupers
             codes = self.grouping_vector.codes_info
-            # error: Incompatible types in assignment (expression has type "Union
-            # [ExtensionArray, ndarray[Any, Any]]", variable has type "Categorical")
-            uniques = (
-                self.grouping_vector.result_index._values  # type: ignore[assignment]
-            )
+            uniques = self.grouping_vector.result_index._values
         elif self._uniques is not None:
             # GH#50486 Code grouping_vector using _uniques; allows
             # including uniques that are not present in grouping_vector.

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -1214,7 +1214,9 @@ class BinGrouper(BaseGrouper):
     @property
     def groupings(self) -> list[grouper.Grouping]:
         lev = self.binlabels
-        ping = grouper.Grouping(lev, lev, in_axis=False, level=None)
+        codes = self.group_info[0]
+        labels = lev.take(codes)
+        ping = grouper.Grouping(labels, labels, in_axis=False, level=None, uniques=lev)
         return [ping]
 
     def _aggregate_series_fast(self, obj: Series, func: Callable) -> NoReturn:

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -1217,7 +1217,7 @@ class BinGrouper(BaseGrouper):
         codes = self.group_info[0]
         labels = lev.take(codes)
         ping = grouper.Grouping(
-            labels, labels, in_axis=False, level=None, uniques=lev.values
+            labels, labels, in_axis=False, level=None, uniques=lev._values
         )
         return [ping]
 

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -1216,7 +1216,9 @@ class BinGrouper(BaseGrouper):
         lev = self.binlabels
         codes = self.group_info[0]
         labels = lev.take(codes)
-        ping = grouper.Grouping(labels, labels, in_axis=False, level=None, uniques=lev)
+        ping = grouper.Grouping(
+            labels, labels, in_axis=False, level=None, uniques=lev.values
+        )
         return [ping]
 
     def _aggregate_series_fast(self, obj: Series, func: Callable) -> NoReturn:

--- a/pandas/tests/groupby/test_frame_value_counts.py
+++ b/pandas/tests/groupby/test_frame_value_counts.py
@@ -4,9 +4,11 @@ import pytest
 from pandas import (
     CategoricalIndex,
     DataFrame,
+    Grouper,
     Index,
     MultiIndex,
     Series,
+    to_datetime,
 )
 import pandas._testing as tm
 
@@ -780,4 +782,35 @@ def test_subset_duplicate_columns():
             [[0, 1], ["x", "y"], ["x", "y"]], names=[None, "c2", "c2"]
         ),
     )
+    tm.assert_series_equal(result, expected)
+
+
+def test_value_counts_time_grouper():
+    # GH#50486
+    df = DataFrame(
+        {
+            "Timestamp": [
+                1565083561,
+                1565083561 + 86400,
+                1565083561 + 86500,
+                1565083561 + 86400 * 2,
+                1565083561 + 86400 * 3,
+                1565083561 + 86500 * 3,
+                1565083561 + 86400 * 4,
+            ],
+            "Food": ["apple", "apple", "banana", "banana", "orange", "orange", "pear"],
+        }
+    ).drop([3])
+
+    df["Datetime"] = to_datetime(df["Timestamp"].apply(lambda t: str(t)), unit="s")
+    gb = df.groupby(Grouper(freq="1D", key="Datetime"))
+    result = gb.value_counts()
+    dates = to_datetime(["2019-08-06", "2019-08-07", "2019-08-09", "2019-08-10"])
+    timestamps = df["Timestamp"].unique()
+    index = MultiIndex(
+        levels=[dates, timestamps, ["apple", "banana", "orange", "pear"]],
+        codes=[[0, 1, 1, 2, 2, 3], range(6), [0, 0, 1, 2, 2, 3]],
+        names=["Datetime", "Timestamp", "Food"],
+    )
+    expected = Series(1, index=index)
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/groupby/test_frame_value_counts.py
+++ b/pandas/tests/groupby/test_frame_value_counts.py
@@ -785,7 +785,8 @@ def test_subset_duplicate_columns():
     tm.assert_series_equal(result, expected)
 
 
-def test_value_counts_time_grouper():
+@pytest.mark.parametrize("utc", [True, False])
+def test_value_counts_time_grouper(utc):
     # GH#50486
     df = DataFrame(
         {
@@ -802,10 +803,14 @@ def test_value_counts_time_grouper():
         }
     ).drop([3])
 
-    df["Datetime"] = to_datetime(df["Timestamp"].apply(lambda t: str(t)), unit="s")
+    df["Datetime"] = to_datetime(
+        df["Timestamp"].apply(lambda t: str(t)), utc=utc, unit="s"
+    )
     gb = df.groupby(Grouper(freq="1D", key="Datetime"))
     result = gb.value_counts()
-    dates = to_datetime(["2019-08-06", "2019-08-07", "2019-08-09", "2019-08-10"])
+    dates = to_datetime(
+        ["2019-08-06", "2019-08-07", "2019-08-09", "2019-08-10"], utc=utc
+    )
     timestamps = df["Timestamp"].unique()
     index = MultiIndex(
         levels=[dates, timestamps, ["apple", "banana", "orange", "pear"]],

--- a/pandas/tests/groupby/test_value_counts.py
+++ b/pandas/tests/groupby/test_value_counts.py
@@ -114,7 +114,8 @@ def test_series_groupby_value_counts(
     tm.assert_series_equal(left.sort_index(), right.sort_index())
 
 
-def test_series_groupby_value_counts_with_grouper():
+@pytest.mark.parametrize("utc", [True, False])
+def test_series_groupby_value_counts_with_grouper(utc):
     # GH28479
     df = DataFrame(
         {
@@ -131,7 +132,9 @@ def test_series_groupby_value_counts_with_grouper():
         }
     ).drop([3])
 
-    df["Datetime"] = to_datetime(df["Timestamp"].apply(lambda t: str(t)), unit="s")
+    df["Datetime"] = to_datetime(
+        df["Timestamp"].apply(lambda t: str(t)), utc=utc, unit="s"
+    )
     dfg = df.groupby(Grouper(freq="1D", key="Datetime"))
 
     # have to sort on index because of unstable sort on values xref GH9212


### PR DESCRIPTION
- [x] closes #50486 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Unlike other Groupings, BinGrouper was creating its Grouping based on the labels that were to be in the result. Thus the `Grouping.grouping_vector` length did not in general match the input object, which then fails when combing with other Groupings that do match the input object.

In order to include empty groups, e.g. the 2nd group below

```
df = pd.DataFrame(
    {
        "datetime": to_datetime(["2022-01-01", "2022-01-03"]),
        "values": [2, 3],
    }
)
gb = df.groupby(pd.Grouper(freq="1D", key="datetime"))
print(gb.sum())
#             values
# datetime          
# 2022-01-01       2
# 2022-01-02       0
# 2022-01-03       3
```

added a `uniques` argument to Grouping and then rely on Categorical to encode the groups including those that are missing.