### PR TITLE
DOC: Add ignore_functions option to validate_docstrings.py

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -83,7 +83,9 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=EX04,GL01,GL02,GL03,GL04,GL05,GL06,GL07,GL09,GL10,PR03,PR04,PR05,PR06,PR08,PR09,PR10,RT01,RT04,RT05,SA02,SA03,SA04,SS01,SS02,SS03,SS04,SS05,SS06
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
+    MSG='Partially validate docstrings (RT02)' ; echo $MSG
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=RT02 --ignore_functions=pandas.Series.align,pandas.Series.dt.total_seconds,pandas.Series.cat.rename_categories,pandas.Series.cat.reorder_categories,pandas.Series.cat.add_categories,pandas.Series.cat.remove_categories,pandas.Series.cat.remove_unused_categories,pandas.Index.all,pandas.Index.any,pandas.CategoricalIndex.rename_categories,pandas.CategoricalIndex.reorder_categories,pandas.CategoricalIndex.add_categories,pandas.CategoricalIndex.remove_categories,pandas.CategoricalIndex.remove_unused_categories,pandas.MultiIndex.drop,pandas.DatetimeIndex.to_pydatetime,pandas.TimedeltaIndex.to_pytimedelta,pandas.core.groupby.SeriesGroupBy.apply,pandas.core.groupby.DataFrameGroupBy.apply,pandas.io.formats.style.Styler.export,pandas.api.extensions.ExtensionArray.astype,pandas.api.extensions.ExtensionArray.dropna,pandas.api.extensions.ExtensionArray.isna,pandas.api.extensions.ExtensionArray.repeat,pandas.api.extensions.ExtensionArray.unique,pandas.DataFrame.align
+    RET=$(($RET + $?)) ; echo $MSG "DONE"
 
 fi
 

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -83,6 +83,8 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=EX04,GL01,GL02,GL03,GL04,GL05,GL06,GL07,GL09,GL10,PR03,PR04,PR05,PR06,PR08,PR09,PR10,RT01,RT04,RT05,SA02,SA03,SA04,SS01,SS02,SS03,SS04,SS05,SS06
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
+    $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=RT02 --ignore_functions=pandas.Series.align,pandas.Series.dt.total_seconds,pandas.Series.cat.rename_categories,pandas.Series.cat.reorder_categories,pandas.Series.cat.add_categories,pandas.Series.cat.remove_categories,pandas.Series.cat.remove_unused_categories,pandas.Index.all,pandas.Index.any,pandas.CategoricalIndex.rename_categories,pandas.CategoricalIndex.reorder_categories,pandas.CategoricalIndex.add_categories,pandas.CategoricalIndex.remove_categories,pandas.CategoricalIndex.remove_unused_categories,pandas.MultiIndex.drop,pandas.DatetimeIndex.to_pydatetime,pandas.TimedeltaIndex.to_pytimedelta,pandas.core.groupby.SeriesGroupBy.apply,pandas.core.groupby.DataFrameGroupBy.apply,pandas.io.formats.style.Styler.export,pandas.api.extensions.ExtensionArray.astype,pandas.api.extensions.ExtensionArray.dropna,pandas.api.extensions.ExtensionArray.isna,pandas.api.extensions.ExtensionArray.repeat,pandas.api.extensions.ExtensionArray.unique,pandas.DataFrame.align
+
 fi
 
 ### DOCUMENTATION NOTEBOOKS ###

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -84,7 +84,33 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
     MSG='Partially validate docstrings (RT02)' ; echo $MSG
-    $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=RT02 --ignore_functions=pandas.Series.align,pandas.Series.dt.total_seconds,pandas.Series.cat.rename_categories,pandas.Series.cat.reorder_categories,pandas.Series.cat.add_categories,pandas.Series.cat.remove_categories,pandas.Series.cat.remove_unused_categories,pandas.Index.all,pandas.Index.any,pandas.CategoricalIndex.rename_categories,pandas.CategoricalIndex.reorder_categories,pandas.CategoricalIndex.add_categories,pandas.CategoricalIndex.remove_categories,pandas.CategoricalIndex.remove_unused_categories,pandas.MultiIndex.drop,pandas.DatetimeIndex.to_pydatetime,pandas.TimedeltaIndex.to_pytimedelta,pandas.core.groupby.SeriesGroupBy.apply,pandas.core.groupby.DataFrameGroupBy.apply,pandas.io.formats.style.Styler.export,pandas.api.extensions.ExtensionArray.astype,pandas.api.extensions.ExtensionArray.dropna,pandas.api.extensions.ExtensionArray.isna,pandas.api.extensions.ExtensionArray.repeat,pandas.api.extensions.ExtensionArray.unique,pandas.DataFrame.align
+    $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=RT02 --ignore_functions \
+    	    pandas.Series.align \
+	    pandas.Series.dt.total_seconds \
+	    pandas.Series.cat.rename_categories \
+	    pandas.Series.cat.reorder_categories \
+	    pandas.Series.cat.add_categories \
+	    pandas.Series.cat.remove_categories \
+	    pandas.Series.cat.remove_unused_categories \
+	    pandas.Index.all \
+	    pandas.Index.any \
+	    pandas.CategoricalIndex.rename_categories \
+	    pandas.CategoricalIndex.reorder_categories \
+	    pandas.CategoricalIndex.add_categories \
+	    pandas.CategoricalIndex.remove_categories \
+	    pandas.CategoricalIndex.remove_unused_categories \
+	    pandas.MultiIndex.drop \
+	    pandas.DatetimeIndex.to_pydatetime \
+	    pandas.TimedeltaIndex.to_pytimedelta \
+	    pandas.core.groupby.SeriesGroupBy.apply \
+	    pandas.core.groupby.DataFrameGroupBy.apply \
+	    pandas.io.formats.style.Styler.export \
+	    pandas.api.extensions.ExtensionArray.astype \
+	    pandas.api.extensions.ExtensionArray.dropna \
+	    pandas.api.extensions.ExtensionArray.isna \
+	    pandas.api.extensions.ExtensionArray.repeat \
+	    pandas.api.extensions.ExtensionArray.unique \
+	    pandas.DataFrame.align
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
 fi

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -339,6 +339,7 @@ class TestMainFunction:
             errors=[],
             output_format="default",
             ignore_deprecated=False,
+            ignore_functions=None,
         )
         assert exit_status == 0
 
@@ -346,7 +347,7 @@ class TestMainFunction:
         monkeypatch.setattr(
             validate_docstrings,
             "validate_all",
-            lambda prefix, ignore_deprecated=False: {
+            lambda prefix, ignore_deprecated=False, ignore_functions=None: {
                 "docstring1": {
                     "errors": [
                         ("ER01", "err desc"),
@@ -369,6 +370,7 @@ class TestMainFunction:
             errors=[],
             output_format="default",
             ignore_deprecated=False,
+            ignore_functions=None,
         )
         assert exit_status == 5
 
@@ -376,7 +378,7 @@ class TestMainFunction:
         monkeypatch.setattr(
             validate_docstrings,
             "validate_all",
-            lambda prefix, ignore_deprecated=False: {
+            lambda prefix, ignore_deprecated=False, ignore_functions=None: {
                 "docstring1": {"errors": [], "warnings": [("WN01", "warn desc")]},
                 "docstring2": {"errors": []},
             },
@@ -387,6 +389,7 @@ class TestMainFunction:
             errors=[],
             output_format="default",
             ignore_deprecated=False,
+            ignore_functions=None,
         )
         assert exit_status == 0
 
@@ -395,7 +398,7 @@ class TestMainFunction:
         monkeypatch.setattr(
             validate_docstrings,
             "validate_all",
-            lambda prefix, ignore_deprecated=False: {
+            lambda prefix, ignore_deprecated=False, ignore_functions=None: {
                 "docstring1": {
                     "errors": [
                         ("ER01", "err desc"),
@@ -412,6 +415,7 @@ class TestMainFunction:
             errors=[],
             output_format="json",
             ignore_deprecated=False,
+            ignore_functions=None,
         )
         assert exit_status == 0
 
@@ -419,7 +423,7 @@ class TestMainFunction:
         monkeypatch.setattr(
             validate_docstrings,
             "validate_all",
-            lambda prefix, ignore_deprecated=False: {
+            lambda prefix, ignore_deprecated=False, ignore_functions=None: {
                 "Series.foo": {
                     "errors": [
                         ("ER01", "err desc"),
@@ -447,6 +451,7 @@ class TestMainFunction:
             errors=["ER01"],
             output_format="default",
             ignore_deprecated=False,
+            ignore_functions=None,
         )
         assert exit_status == 3
 
@@ -456,5 +461,6 @@ class TestMainFunction:
             errors=["ER03"],
             output_format="default",
             ignore_deprecated=False,
+            ignore_functions=None,
         )
         assert exit_status == 1

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -199,6 +199,25 @@ class TestValidator:
                 self._import_path(klass="BadDocstrings", func="leftover_files")
             )
 
+    def test_validate_all_ignore_functions(self, monkeypatch):
+        monkeypatch.setattr(
+            validate_docstrings,
+            "get_all_api_items",
+            lambda: [
+                (
+                    "pandas.DataFrame.align",
+                    "func",
+                    "current_section",
+                    "current_subsection",
+                )
+            ],
+        )
+        result = validate_docstrings.validate_all(
+            prefix=None,
+            ignore_functions=["pandas.DataFrame.align"],
+        )
+        assert len(result) == 0
+
     def test_validate_all_ignore_deprecated(self, monkeypatch):
         monkeypatch.setattr(
             validate_docstrings,

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -209,14 +209,21 @@ class TestValidator:
                     "func",
                     "current_section",
                     "current_subsection",
-                )
+                ),
+                (
+                    "pandas.Index.all",
+                    "func",
+                    "current_section",
+                    "current_subsection",
+                ),
             ],
         )
         result = validate_docstrings.validate_all(
             prefix=None,
             ignore_functions=["pandas.DataFrame.align"],
         )
-        assert len(result) == 0
+        assert len(result) == 1
+        assert "pandas.Index.all" in result
 
     def test_validate_all_ignore_deprecated(self, monkeypatch):
         monkeypatch.setattr(

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -321,9 +321,7 @@ def validate_all(prefix, ignore_deprecated=False, ignore_functions=None):
 
     ignore_functions = set(ignore_functions or [])
 
-    api_items = get_all_api_items()
-
-    for func_name, _, section, subsection in api_items:
+    for func_name, _, section, subsection in get_all_api_items():
         if func_name in ignore_functions:
             continue
         if prefix and not func_name.startswith(prefix):
@@ -352,11 +350,9 @@ def validate_all(prefix, ignore_deprecated=False, ignore_functions=None):
 def get_all_api_items():
     base_path = pathlib.Path(__file__).parent.parent
     api_doc_fnames = pathlib.Path(base_path, "doc", "source", "reference")
-    api_items = []
     for api_doc_fname in api_doc_fnames.glob("*.rst"):
         with open(api_doc_fname) as f:
-            api_items += list(get_api_items(f))
-    return api_items
+            yield from get_api_items(f)
 
 
 def print_validate_all_results(

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -319,10 +319,7 @@ def validate_all(prefix, ignore_deprecated=False, ignore_functions=None):
     result = {}
     seen = {}
 
-    if ignore_functions is None:
-        ignore_functions = {}
-    else:
-        ignore_functions = set(ignore_functions)
+    ignore_functions = set(ignore_functions or [])
 
     base_path = pathlib.Path(__file__).parent.parent
     api_doc_fnames = pathlib.Path(base_path, "doc", "source", "reference")
@@ -332,9 +329,9 @@ def validate_all(prefix, ignore_deprecated=False, ignore_functions=None):
             api_items += list(get_api_items(f))
 
     for func_name, _, section, subsection in api_items:
-        if (
-            prefix and not func_name.startswith(prefix)
-        ) or func_name in ignore_functions:
+        if func_name in ignore_functions:
+            continue
+        if prefix and not func_name.startswith(prefix):
             continue
         doc_info = pandas_validate(func_name)
         if ignore_deprecated and doc_info["deprecated"]:
@@ -482,7 +479,7 @@ if __name__ == "__main__":
         "--ignore_functions",
         default=None,
         help="function or method to not validate "
-        "(e.g. Pandas.DataFrame.head). "
+        "(e.g. pandas.DataFrame.head). "
         "Inverse of the `function` argument.",
     )
 

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -321,12 +321,7 @@ def validate_all(prefix, ignore_deprecated=False, ignore_functions=None):
 
     ignore_functions = set(ignore_functions or [])
 
-    base_path = pathlib.Path(__file__).parent.parent
-    api_doc_fnames = pathlib.Path(base_path, "doc", "source", "reference")
-    api_items = []
-    for api_doc_fname in api_doc_fnames.glob("*.rst"):
-        with open(api_doc_fname) as f:
-            api_items += list(get_api_items(f))
+    api_items = get_all_api_items()
 
     for func_name, _, section, subsection in api_items:
         if func_name in ignore_functions:
@@ -352,6 +347,16 @@ def validate_all(prefix, ignore_deprecated=False, ignore_functions=None):
         seen[shared_code_key] = func_name
 
     return result
+
+
+def get_all_api_items():
+    base_path = pathlib.Path(__file__).parent.parent
+    api_doc_fnames = pathlib.Path(base_path, "doc", "source", "reference")
+    api_items = []
+    for api_doc_fname in api_doc_fnames.glob("*.rst"):
+        with open(api_doc_fname) as f:
+            api_items += list(get_api_items(f))
+    return api_items
 
 
 def print_validate_all_results(
@@ -477,7 +482,7 @@ if __name__ == "__main__":
     )
     argparser.add_argument(
         "--ignore_functions",
-        default=None,
+        nargs="*",
         help="function or method to not validate "
         "(e.g. pandas.DataFrame.head). "
         "Inverse of the `function` argument.",
@@ -491,6 +496,6 @@ if __name__ == "__main__":
             args.errors.split(",") if args.errors else None,
             args.format,
             args.ignore_deprecated,
-            args.ignore_functions.split(",") if args.ignore_functions else None,
+            args.ignore_functions,
         )
     )


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Following @MarcoGorelli [comment](https://github.com/pandas-dev/pandas/issues/49968#issuecomment-1333467996), this PR adds an option to `validate_docstrings.py` to ignore functions. This allows to ignore the remaining `RT02` errors, described in https://github.com/pandas-dev/pandas/issues/49968,  in `ci/code_checks.sh`. This will also be useful for other documentation-related errors that required multiple fixes.
