### PR TITLE
TST: add numexpr fixture

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -1267,7 +1267,8 @@ def use_numexpr(request):
     _min_elements = expr._MIN_ELEMENTS
 
     expr.set_use_numexpr(request.param)
-    expr._MIN_ELEMENTS = 0 if request.param else 1_000_000
+    if request.param:
+        expr._MIN_ELEMENTS = 0
     yield request.param
 
     expr.set_use_numexpr(use_numexpr)

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -1253,6 +1253,27 @@ def utc_fixture(request):
 utc_fixture2 = utc_fixture
 
 
+@pytest.fixture(params=[True, False], ids=["numexpr", "python"])
+def use_numexpr(request):
+    """
+    If True always use numexpr for evaluations, else never.
+    """
+    from pandas.core.computation import expressions as expr
+
+    if request.param and not expr.NUMEXPR_INSTALLED:
+        pytest.skip("numexpr not installed")
+
+    use_numexpr = expr.USE_NUMEXPR
+    _min_elements = expr._MIN_ELEMENTS
+
+    expr.USE_NUMEXPR = request.param
+    expr._MIN_ELEMENTS = 0 if request.param else 1_000_000
+    yield request.param
+
+    expr.USE_NUMEXPR = use_numexpr
+    expr._MIN_ELEMENTS = _min_elements
+
+
 # ----------------------------------------------------------------
 # Dtypes
 # ----------------------------------------------------------------

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -1266,11 +1266,11 @@ def use_numexpr(request):
     use_numexpr = expr.USE_NUMEXPR
     _min_elements = expr._MIN_ELEMENTS
 
-    expr.USE_NUMEXPR = request.param
+    expr.set_use_numexpr(request.param)
     expr._MIN_ELEMENTS = 0 if request.param else 1_000_000
     yield request.param
 
-    expr.USE_NUMEXPR = use_numexpr
+    expr.set_use_numexpr(use_numexpr)
     expr._MIN_ELEMENTS = _min_elements
 
 

--- a/pandas/tests/arithmetic/conftest.py
+++ b/pandas/tests/arithmetic/conftest.py
@@ -9,22 +9,10 @@ from pandas.core.api import (
     Int64Index,
     UInt64Index,
 )
-from pandas.core.computation import expressions as expr
-
-
-@pytest.fixture(autouse=True, params=[0, 1000000], ids=["numexpr", "python"])
-def switch_numexpr_min_elements(request):
-    _MIN_ELEMENTS = expr._MIN_ELEMENTS
-    expr._MIN_ELEMENTS = request.param
-    yield request.param
-    expr._MIN_ELEMENTS = _MIN_ELEMENTS
-
 
 # ------------------------------------------------------------------
 
-# doctest with +SKIP for one fixture fails during setup with
-# 'DoctestItem' object has no attribute 'callspec'
-# due to switch_numexpr_min_elements fixture
+
 @pytest.fixture(params=[1, np.array(1, dtype=np.int64)])
 def one(request):
     """
@@ -61,9 +49,6 @@ zeros.extend([np.array(-0.0, dtype=np.float64)])
 zeros.extend([0, 0.0, -0.0])
 
 
-# doctest with +SKIP for zero fixture fails during setup with
-# 'DoctestItem' object has no attribute 'callspec'
-# due to switch_numexpr_min_elements fixture
 @pytest.fixture(params=zeros)
 def zero(request):
     """

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -27,7 +27,6 @@ from pandas.core.api import (
     Int64Index,
     UInt64Index,
 )
-from pandas.core.computation import expressions as expr
 from pandas.tests.arithmetic.common import (
     assert_invalid_addsub_type,
     assert_invalid_comparison,
@@ -392,7 +391,7 @@ class TestDivisionByZero:
     @pytest.mark.parametrize("dtype1", [np.int64, np.float64, np.uint64])
     def test_ser_div_ser(
         self,
-        switch_numexpr_min_elements,
+        use_numexpr,
         dtype1,
         any_real_numpy_dtype,
     ):
@@ -412,7 +411,7 @@ class TestDivisionByZero:
         if first.dtype == "int64" and second.dtype == "float32":
             # when using numexpr, the casting rules are slightly different
             # and int64/float32 combo results in float32 instead of float64
-            if expr.USE_NUMEXPR and switch_numexpr_min_elements == 0:
+            if use_numexpr:
                 expected = expected.astype("float32")
 
         result = first / second

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -29,15 +29,6 @@ from pandas.core import (
     nanops,
     ops,
 )
-from pandas.core.computation import expressions as expr
-
-
-@pytest.fixture(autouse=True, params=[0, 1000000], ids=["numexpr", "python"])
-def switch_numexpr_min_elements(request):
-    _MIN_ELEMENTS = expr._MIN_ELEMENTS
-    expr._MIN_ELEMENTS = request.param
-    yield request.param
-    expr._MIN_ELEMENTS = _MIN_ELEMENTS
 
 
 def _permute(obj):


### PR DESCRIPTION
Adds a `use_numexpr` fixture to `conftest.py`, deletes 3 `switch_numexpr_min_elements` and simplifies numexpr tests.