### PR TITLE
WARN improve some warnings introduced in PDEP4

### DIFF
--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -1005,7 +1005,8 @@ cdef void _maybe_warn_about_dayfirst(format: str, bint dayfirst):
             )
         if (day_index < month_index) and not dayfirst:
             warnings.warn(
-                f"Parsing dates in {format} format when dayfirst=False was specified. "
+                f"Parsing dates in {format} format when dayfirst=False (the default) "
+                "was specified. "
                 "Pass `dayfirst=True` or specify a format to silence this warning.",
                 UserWarning,
                 stacklevel=find_stack_level(),

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -139,7 +139,7 @@ def _guess_datetime_format_for_array(arr, dayfirst: bool | None = False) -> str 
                 return guessed_format
             warnings.warn(
                 "Could not infer format, so each element will be parsed "
-                "individually by `dateutil`. To ensure parsing is "
+                "individually, falling back to `dateutil`. To ensure parsing is "
                 "consistent and as-expected, please specify a format.",
                 UserWarning,
                 stacklevel=find_stack_level(),

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -2052,7 +2052,7 @@ def test_parse_dot_separated_dates(all_parsers):
             name="a",
         )
         warn = UserWarning
-    msg = "when dayfirst=False was specified"
+    msg = r"when dayfirst=False \(the default\) was specified"
     result = parser.read_csv_check_warnings(
         warn, msg, StringIO(data), parse_dates=True, index_col=0
     )

--- a/pandas/tests/tslibs/test_parsing.py
+++ b/pandas/tests/tslibs/test_parsing.py
@@ -262,7 +262,8 @@ def test_guess_datetime_format_wrong_type_inputs(invalid_type_dt):
 def test_guess_datetime_format_no_padding(string, fmt, dayfirst, warning):
     # see gh-11142
     msg = (
-        f"Parsing dates in {fmt} format when dayfirst=False was specified. "
+        rf"Parsing dates in {fmt} format when dayfirst=False \(the default\) "
+        "was specified. "
         "Pass `dayfirst=True` or specify a format to silence this warning."
     )
     with tm.assert_produces_warning(warning, match=msg):


### PR DESCRIPTION
`dayfirst=False` is the default, so it may be confusing to see "when dayfirst=False was specified" if the user didn't specify anything