### PR TITLE
BUG: Fix creating DatetimeIndex with BusinessHour Frequency

### DIFF
--- a/doc/source/whatsnew/v1.5.3.rst
+++ b/doc/source/whatsnew/v1.5.3.rst
@@ -30,7 +30,7 @@ Bug fixes
 - Bug in :meth:`.Styler.to_excel` leading to error when unrecognized ``border-style`` (e.g. ``"hair"``) provided to Excel writers (:issue:`48649`)
 - Bug when chaining several :meth:`.Styler.concat` calls, only the last styler was concatenated (:issue:`49207`)
 - Fixed bug when instantiating a :class:`DataFrame` subclass inheriting from ``typing.Generic`` that triggered a ``UserWarning`` on python 3.11 (:issue:`49649`)
-- Fixed bug in :class:`BusinessHour` that could cause creation of `DatetimeIndex` to fail (:issue:`#49835`)
+- Fixed bug in :class:`BusinessHour` that could cause creation of ``DatetimeIndex`` to fail (:issue:`#49835`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_153.other:

--- a/doc/source/whatsnew/v1.5.3.rst
+++ b/doc/source/whatsnew/v1.5.3.rst
@@ -30,7 +30,7 @@ Bug fixes
 - Bug in :meth:`.Styler.to_excel` leading to error when unrecognized ``border-style`` (e.g. ``"hair"``) provided to Excel writers (:issue:`48649`)
 - Bug when chaining several :meth:`.Styler.concat` calls, only the last styler was concatenated (:issue:`49207`)
 - Fixed bug when instantiating a :class:`DataFrame` subclass inheriting from ``typing.Generic`` that triggered a ``UserWarning`` on python 3.11 (:issue:`49649`)
--
+- Fixed bug in :class:`BusinessHour` that could cause creation of `DatetimeIndex` to fail (:issue:`#49835`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_153.other:

--- a/doc/source/whatsnew/v1.5.3.rst
+++ b/doc/source/whatsnew/v1.5.3.rst
@@ -30,7 +30,7 @@ Bug fixes
 - Bug in :meth:`.Styler.to_excel` leading to error when unrecognized ``border-style`` (e.g. ``"hair"``) provided to Excel writers (:issue:`48649`)
 - Bug when chaining several :meth:`.Styler.concat` calls, only the last styler was concatenated (:issue:`49207`)
 - Fixed bug when instantiating a :class:`DataFrame` subclass inheriting from ``typing.Generic`` that triggered a ``UserWarning`` on python 3.11 (:issue:`49649`)
-- Fixed bug in :class:`BusinessHour` that could cause creation of ``DatetimeIndex`` to fail (:issue:`#49835`)
+-
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_153.other:

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -876,7 +876,7 @@ Indexing
 - Bug in :meth:`DataFrame.iloc` raising ``IndexError`` when indexer is a :class:`Series` with numeric extension array dtype (:issue:`49521`)
 - Bug in :func:`~DataFrame.describe` when formatting percentiles in the resulting index showed more decimals than needed (:issue:`46362`)
 - Bug in :meth:`DataFrame.compare` does not recognize differences when comparing ``NA`` with value in nullable dtypes (:issue:`48939`)
--
+- Bug in :class:`BusinessHour` would cause creation of ``DatetimeIndex`` to fail when no opening hour was included in the index (:issue:`#49835`)
 
 Missing
 ^^^^^^^

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -876,7 +876,7 @@ Indexing
 - Bug in :meth:`DataFrame.iloc` raising ``IndexError`` when indexer is a :class:`Series` with numeric extension array dtype (:issue:`49521`)
 - Bug in :func:`~DataFrame.describe` when formatting percentiles in the resulting index showed more decimals than needed (:issue:`46362`)
 - Bug in :meth:`DataFrame.compare` does not recognize differences when comparing ``NA`` with value in nullable dtypes (:issue:`48939`)
-- Bug in :class:`BusinessHour` would cause creation of ``DatetimeIndex`` to fail when no opening hour was included in the index (:issue:`#49835`)
+- Bug in :class:`BusinessHour` would cause creation of :class:`DatetimeIndex` to fail when no opening hour was included in the index (:issue:`#49835`)
 
 Missing
 ^^^^^^^

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -881,7 +881,7 @@ Indexing
 - Bug in :func:`~DataFrame.describe` when formatting percentiles in the resulting index showed more decimals than needed (:issue:`46362`)
 - Bug in :meth:`DataFrame.compare` does not recognize differences when comparing ``NA`` with value in nullable dtypes (:issue:`48939`)
 - Bug in :meth:`DataFrame.isetitem` coercing extension array dtypes in :class:`DataFrame` to object (:issue:`49922`)
-- Bug in :class:`BusinessHour` would cause creation of :class:`DatetimeIndex` to fail when no opening hour was included in the index (:issue:`#49835`)
+- Bug in :class:`BusinessHour` would cause creation of :class:`DatetimeIndex` to fail when no opening hour was included in the index (:issue:`49835`)
 -
 
 Missing

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -1850,7 +1850,7 @@ cdef class BusinessHour(BusinessMixin):
         if self.n == 0:
             is_same_sign = sign > 0
         else: 
-            is_same_sign = self.n * sign >=0
+            is_same_sign = self.n * sign >= 0
 
         if not self.next_bday.is_on_offset(other):
             # today is not business day

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -1849,7 +1849,7 @@ cdef class BusinessHour(BusinessMixin):
 
         if self.n == 0:
             is_same_sign = sign > 0
-        else: 
+        else:
             is_same_sign = self.n * sign >= 0
 
         if not self.next_bday.is_on_offset(other):

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -1847,15 +1847,20 @@ cdef class BusinessHour(BusinessMixin):
         earliest_start = self.start[0]
         latest_start = self.start[-1]
 
+        if self.n == 0:
+            is_same_sign = sign > 0
+        else: 
+            is_same_sign = self.n * sign >=0
+
         if not self.next_bday.is_on_offset(other):
             # today is not business day
             other = other + sign * self.next_bday
-            if self.n * sign >= 0:
+            if is_same_sign:
                 hour, minute = earliest_start.hour, earliest_start.minute
             else:
                 hour, minute = latest_start.hour, latest_start.minute
         else:
-            if self.n * sign >= 0:
+            if is_same_sign:
                 if latest_start < other.time():
                     # current time is after latest starting time in today
                     other = other + sign * self.next_bday

--- a/pandas/tests/tseries/offsets/test_business_hour.py
+++ b/pandas/tests/tseries/offsets/test_business_hour.py
@@ -975,6 +975,10 @@ class TestBusinessHour:
         for idx in [idx1, idx2, idx3]:
             tm.assert_index_equal(idx, expected)
 
+        idx4 = date_range(start="2014-07-01 10:00", freq="BH", periods=1)
+        expected4 = DatetimeIndex(["2014-07-01 10:00"], freq="BH")
+        tm.assert_index_equal(idx4, expected4)
+
     def test_bday_ignores_timedeltas(self):
         idx = date_range("2010/02/01", "2010/02/10", freq="12H")
         t1 = idx + BDay(offset=Timedelta(3, unit="H"))

--- a/pandas/tests/tseries/offsets/test_business_hour.py
+++ b/pandas/tests/tseries/offsets/test_business_hour.py
@@ -231,8 +231,9 @@ class TestBusinessHour:
         assert offset8 + dt == datetime(2014, 7, 1, 11)
         assert offset9 + dt == datetime(2014, 7, 1, 22)
         assert offset10 + dt == datetime(2014, 7, 1, 1)
+        assert dt + 0 * offset1 == dt
 
-    def test_sub(self, dt, offset2, _offset):
+    def test_sub(self, dt, offset1, offset2, _offset):
         off = offset2
         msg = "Cannot subtract datetime from offset"
         with pytest.raises(TypeError, match=msg):
@@ -240,6 +241,8 @@ class TestBusinessHour:
         assert 2 * off - off == off
 
         assert dt - offset2 == dt + _offset(-3)
+
+        assert dt - 0 * offset1 == dt
 
     def testRollback1(
         self,

--- a/pandas/tests/tseries/offsets/test_business_hour.py
+++ b/pandas/tests/tseries/offsets/test_business_hour.py
@@ -231,9 +231,8 @@ class TestBusinessHour:
         assert offset8 + dt == datetime(2014, 7, 1, 11)
         assert offset9 + dt == datetime(2014, 7, 1, 22)
         assert offset10 + dt == datetime(2014, 7, 1, 1)
-        assert dt + 0 * offset1 == dt
 
-    def test_sub(self, dt, offset1, offset2, _offset):
+    def test_sub(self, dt, offset2, _offset):
         off = offset2
         msg = "Cannot subtract datetime from offset"
         with pytest.raises(TypeError, match=msg):
@@ -242,7 +241,11 @@ class TestBusinessHour:
 
         assert dt - offset2 == dt + _offset(-3)
 
+    def test_multiply_by_zero(self, dt, offset1, offset2):
         assert dt - 0 * offset1 == dt
+        assert dt + 0 * offset1 == dt
+        assert dt - 0 * offset2 == dt
+        assert dt + 0 * offset2 == dt
 
     def testRollback1(
         self,
@@ -975,6 +978,8 @@ class TestBusinessHour:
         for idx in [idx1, idx2, idx3]:
             tm.assert_index_equal(idx, expected)
 
+    def test_short_datetimeindex_creation(self):
+        # gh-49835
         idx4 = date_range(start="2014-07-01 10:00", freq="BH", periods=1)
         expected4 = DatetimeIndex(["2014-07-01 10:00"], freq="BH")
         tm.assert_index_equal(idx4, expected4)


### PR DESCRIPTION
DatetimeIndex creating with BusinessHour Frequency would fail whenever the DatetimeIndex did not include a Timestamp that was also an opening time.

The cause of the issue was a bug where adding/subtracting `0 * BusinessHour` gave wrong results:
```python
import pandas as pd
import datetime as dt
dt.datetime(2020,1,1,10) -0 * pd.offsets.BusinessHour()
```
returns `Timestamp('2020-01-02 09:00:00')` rather than the expected `Timestamp('2020-01-01 10:00:00')`

This PR fixes the problem and adds appropriate assertions to the unit-tests

- [x] closes #49835 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
