### PR TITLE
CLN explicit casts to float to avoid implicit casts

### DIFF
--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -550,7 +550,8 @@ class TestDataFrameIndexingWhere:
 
         # DataFrame vs DataFrame
         d1 = df.copy().drop(1, axis=0)
-        expected = df.copy()
+        # Explicit cast to avoid implicit cast when setting value to np.nan
+        expected = df.copy().astype("float")
         expected.loc[1, :] = np.nan
 
         result = df.where(mask, d1)
@@ -669,7 +670,8 @@ class TestDataFrameIndexingWhere:
         df["b"] = df["b"].astype("category")
 
         result = df.where(df["a"] > 0)
-        expected = df.copy()
+        # Explicitly cast to 'float' to avoid implicit cast when setting np.nan
+        expected = df.copy().astype({"a": "float"})
         expected.loc[0, :] = np.nan
 
         tm.assert_equal(result, expected)

--- a/pandas/tests/frame/methods/test_asfreq.py
+++ b/pandas/tests/frame/methods/test_asfreq.py
@@ -159,7 +159,8 @@ class TestAsFreq:
 
         # setup
         rng = date_range("1/1/2016", periods=10, freq="2S")
-        ts = Series(np.arange(len(rng)), index=rng)
+        # Explicit cast to 'float' to avoid implicit cast when setting None
+        ts = Series(np.arange(len(rng)), index=rng, dtype="float")
         df = DataFrame({"one": ts})
 
         # insert pre-existing missing value

--- a/pandas/tests/frame/methods/test_asof.py
+++ b/pandas/tests/frame/methods/test_asof.py
@@ -29,7 +29,8 @@ def date_range_frame():
 
 class TestFrameAsof:
     def test_basic(self, date_range_frame):
-        df = date_range_frame
+        # Explicitly cast to float to avoid implicit cast when setting np.nan
+        df = date_range_frame.astype({"A": "float"})
         N = 50
         df.loc[df.index[15:30], "A"] = np.nan
         dates = date_range("1/1/1990", periods=N * 3, freq="25s")
@@ -50,7 +51,8 @@ class TestFrameAsof:
 
     def test_subset(self, date_range_frame):
         N = 10
-        df = date_range_frame.iloc[:N].copy()
+        # explicitly cast to float to avoid implicit upcast when setting to np.nan
+        df = date_range_frame.iloc[:N].copy().astype({"A": "float"})
         df.loc[df.index[4:8], "A"] = np.nan
         dates = date_range("1/1/1990", periods=N * 3, freq="25s")
 
@@ -163,7 +165,7 @@ class TestFrameAsof:
     def test_is_copy(self, date_range_frame):
         # GH-27357, GH-30784: ensure the result of asof is an actual copy and
         # doesn't track the parent dataframe / doesn't give SettingWithCopy warnings
-        df = date_range_frame
+        df = date_range_frame.astype({"A": "float"})
         N = 50
         df.loc[df.index[15:30], "A"] = np.nan
         dates = date_range("1/1/1990", periods=N * 3, freq="25s")

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -857,6 +857,8 @@ class TestDataFrameReshape:
     def test_unstack_nan_index2(self):
         # GH7403
         df = DataFrame({"A": list("aaaabbbb"), "B": range(8), "C": range(8)})
+        # Explicit cast to avoid implicit cast when setting to np.NaN
+        df = df.astype({"B": "float"})
         df.iloc[3, 1] = np.NaN
         left = df.set_index(["A", "B"]).unstack(0)
 
@@ -874,6 +876,8 @@ class TestDataFrameReshape:
         tm.assert_frame_equal(left, right)
 
         df = DataFrame({"A": list("aaaabbbb"), "B": list(range(4)) * 2, "C": range(8)})
+        # Explicit cast to avoid implicit cast when setting to np.NaN
+        df = df.astype({"B": "float"})
         df.iloc[2, 1] = np.NaN
         left = df.set_index(["A", "B"]).unstack(0)
 
@@ -886,6 +890,8 @@ class TestDataFrameReshape:
         tm.assert_frame_equal(left, right)
 
         df = DataFrame({"A": list("aaaabbbb"), "B": list(range(4)) * 2, "C": range(8)})
+        # Explicit cast to avoid implicit cast when setting to np.NaN
+        df = df.astype({"B": "float"})
         df.iloc[3, 1] = np.NaN
         left = df.set_index(["A", "B"]).unstack(0)
 

--- a/pandas/tests/groupby/test_value_counts.py
+++ b/pandas/tests/groupby/test_value_counts.py
@@ -54,10 +54,10 @@ def seed_df(seed_nans, n, m):
             "3rd": np.random.randint(1, m + 1, n),
         }
     )
-    # Explicitly cast to float to avoid implicit cast when setting nan
-    frame["3rd"] = frame["3rd"].astype("float")
 
     if seed_nans:
+        # Explicitly cast to float to avoid implicit cast when setting nan
+        frame["3rd"] = frame["3rd"].astype("float")
         frame.loc[1::11, "1st"] = np.nan
         frame.loc[3::17, "2nd"] = np.nan
         frame.loc[7::19, "3rd"] = np.nan

--- a/pandas/tests/groupby/test_value_counts.py
+++ b/pandas/tests/groupby/test_value_counts.py
@@ -54,6 +54,8 @@ def seed_df(seed_nans, n, m):
             "3rd": np.random.randint(1, m + 1, n),
         }
     )
+    # Explicitly cast to float to avoid implicit cast when setting nan
+    frame["3rd"] = frame["3rd"].astype("float")
 
     if seed_nans:
         frame.loc[1::11, "1st"] = np.nan


### PR DESCRIPTION
Similar to #50493 

There are places when an implicit cast happens, but it's not the purpose of the test - the cast might as well be done explicitly then

This would help pave the way towards [PDEP6](https://github.com/pandas-dev/pandas/pull/50424)