### PR TITLE
GH49560 without GH50195 (DEPR: Remove int64 uint64 float64 index part 1)

### DIFF
--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -27,6 +27,7 @@ from pandas._config.localization import (
 from pandas._typing import (
     Dtype,
     Frequency,
+    NpDtype,
 )
 from pandas.compat import pa_version_under6p0
 
@@ -124,12 +125,13 @@ if TYPE_CHECKING:
 _N = 30
 _K = 4
 
-UNSIGNED_INT_NUMPY_DTYPES: list[Dtype] = ["uint8", "uint16", "uint32", "uint64"]
+UNSIGNED_INT_NUMPY_DTYPES: list[NpDtype] = ["uint8", "uint16", "uint32", "uint64"]
 UNSIGNED_INT_EA_DTYPES: list[Dtype] = ["UInt8", "UInt16", "UInt32", "UInt64"]
-SIGNED_INT_NUMPY_DTYPES: list[Dtype] = [int, "int8", "int16", "int32", "int64"]
+SIGNED_INT_NUMPY_DTYPES: list[NpDtype] = [int, "int8", "int16", "int32", "int64"]
 SIGNED_INT_EA_DTYPES: list[Dtype] = ["Int8", "Int16", "Int32", "Int64"]
 ALL_INT_NUMPY_DTYPES = UNSIGNED_INT_NUMPY_DTYPES + SIGNED_INT_NUMPY_DTYPES
 ALL_INT_EA_DTYPES = UNSIGNED_INT_EA_DTYPES + SIGNED_INT_EA_DTYPES
+ALL_INT_DTYPES: list[Dtype] = [*ALL_INT_NUMPY_DTYPES, *ALL_INT_EA_DTYPES]
 
 FLOAT_NUMPY_DTYPES: list[Dtype] = [float, "float32", "float64"]
 FLOAT_EA_DTYPES: list[Dtype] = ["Float32", "Float64"]

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -1486,7 +1486,7 @@ def any_int_ea_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=tm.ALL_INT_NUMPY_DTYPES + tm.ALL_INT_EA_DTYPES)
+@pytest.fixture(params=tm.ALL_INT_DTYPES)
 def any_int_dtype(request):
     """
     Parameterized fixture for any nullable integer dtype.

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1385,7 +1385,7 @@ default 'raise'
         0    2000
         1    2001
         2    2002
-        dtype: int64
+        dtype: int32
         """,
     )
     month = _field_accessor(
@@ -1408,7 +1408,7 @@ default 'raise'
         0    1
         1    2
         2    3
-        dtype: int64
+        dtype: int32
         """,
     )
     day = _field_accessor(
@@ -1431,7 +1431,7 @@ default 'raise'
         0    1
         1    2
         2    3
-        dtype: int64
+        dtype: int32
         """,
     )
     hour = _field_accessor(
@@ -1454,7 +1454,7 @@ default 'raise'
         0    0
         1    1
         2    2
-        dtype: int64
+        dtype: int32
         """,
     )
     minute = _field_accessor(
@@ -1477,7 +1477,7 @@ default 'raise'
         0    0
         1    1
         2    2
-        dtype: int64
+        dtype: int32
         """,
     )
     second = _field_accessor(
@@ -1500,7 +1500,7 @@ default 'raise'
         0    0
         1    1
         2    2
-        dtype: int64
+        dtype: int32
         """,
     )
     microsecond = _field_accessor(
@@ -1523,7 +1523,7 @@ default 'raise'
         0       0
         1       1
         2       2
-        dtype: int64
+        dtype: int32
         """,
     )
     nanosecond = _field_accessor(
@@ -1546,7 +1546,7 @@ default 'raise'
         0       0
         1       1
         2       2
-        dtype: int64
+        dtype: int32
         """,
     )
     _dayofweek_doc = """
@@ -1581,7 +1581,7 @@ default 'raise'
     2017-01-06    4
     2017-01-07    5
     2017-01-08    6
-    Freq: D, dtype: int64
+    Freq: D, dtype: int32
     """
     day_of_week = _field_accessor("day_of_week", "dow", _dayofweek_doc)
     dayofweek = day_of_week

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -771,7 +771,7 @@ class TimedeltaArray(dtl.TimelikeOps):
                        dtype='timedelta64[ns]', freq=None)
 
         >>> idx.total_seconds()
-        Float64Index([0.0, 86400.0, 172800.0, 259200.0, 345600.0],
+        NumericIndex([0.0, 86400.0, 172800.0, 259200.0, 345600.0],
                      dtype='float64')
         """
         pps = periods_per_second(self._creso)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6095,7 +6095,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         0    1
         1    2
         dtype: category
-        Categories (2, int64): [1, 2]
+        Categories (2, int32): [1, 2]
 
         Convert to ordered categorical type with custom ordering:
 

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -161,7 +161,7 @@ class DatetimeProperties(Properties):
     0    0
     1    1
     2    2
-    dtype: int64
+    dtype: int32
 
     >>> hours_series = pd.Series(pd.date_range("2000-01-01", periods=3, freq="h"))
     >>> hours_series
@@ -173,7 +173,7 @@ class DatetimeProperties(Properties):
     0    0
     1    1
     2    2
-    dtype: int64
+    dtype: int32
 
     >>> quarters_series = pd.Series(pd.date_range("2000-01-01", periods=3, freq="q"))
     >>> quarters_series
@@ -185,7 +185,7 @@ class DatetimeProperties(Properties):
     0    1
     1    2
     2    3
-    dtype: int64
+    dtype: int32
 
     Returns a Series indexed like the original Series.
     Raises TypeError if the Series does not contain datetimelike values.
@@ -303,7 +303,7 @@ class TimedeltaProperties(Properties):
     0    1
     1    2
     2    3
-    dtype: int64
+    dtype: int32
     """
 
     def to_pytimedelta(self) -> np.ndarray:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -106,6 +106,7 @@ from pandas.core.dtypes.common import (
     is_scalar,
     is_signed_integer_dtype,
     is_string_dtype,
+    is_unsigned_integer_dtype,
     needs_i8_conversion,
     pandas_dtype,
     validate_all_hashable,
@@ -307,7 +308,7 @@ class Index(IndexOpsMixin, PandasObject):
     Examples
     --------
     >>> pd.Index([1, 2, 3])
-    Int64Index([1, 2, 3], dtype='int64')
+    NumericIndex([1, 2, 3], dtype='int64')
 
     >>> pd.Index(list('abc'))
     Index(['a', 'b', 'c'], dtype='object')
@@ -528,7 +529,7 @@ class Index(IndexOpsMixin, PandasObject):
             data = data.copy()
         return data
 
-    @final
+    # @final (temporary off until merge NumericIndex into Index
     @classmethod
     def _dtype_to_subclass(cls, dtype: DtypeObj):
         # Delay import for perf. https://github.com/pandas-dev/pandas/pull/31423
@@ -563,18 +564,10 @@ class Index(IndexOpsMixin, PandasObject):
 
             return TimedeltaIndex
 
-        elif dtype.kind == "f":
-            from pandas.core.api import Float64Index
+        elif dtype.kind in ["i", "f", "u"]:
+            from pandas.core.api import NumericIndex
 
-            return Float64Index
-        elif dtype.kind == "u":
-            from pandas.core.api import UInt64Index
-
-            return UInt64Index
-        elif dtype.kind == "i":
-            from pandas.core.api import Int64Index
-
-            return Int64Index
+            return NumericIndex
 
         elif dtype.kind == "O":
             # NB: assuming away MultiIndex
@@ -1002,18 +995,34 @@ class Index(IndexOpsMixin, PandasObject):
                 new_values = astype_array(values, dtype=dtype, copy=copy)
 
         # pass copy=False because any copying will be done in the astype above
-        if self._is_backward_compat_public_numeric_index:
-            # this block is needed so e.g. NumericIndex[int8].astype("int32") returns
-            # NumericIndex[int32] and not Int64Index with dtype int64.
+        if not self._is_backward_compat_public_numeric_index and not isinstance(
+            self, ABCRangeIndex
+        ):
+            # this block is needed so e.g. Int64Index.astype("int32") returns
+            # Int64Index and not a NumericIndex with dtype int32.
             # When Int64Index etc. are removed from the code base, removed this also.
             if (
                 isinstance(dtype, np.dtype)
                 and is_numeric_dtype(dtype)
                 and not is_complex_dtype(dtype)
             ):
-                return self._constructor(
-                    new_values, name=self.name, dtype=dtype, copy=False
+                from pandas.core.api import (
+                    Float64Index,
+                    Int64Index,
+                    UInt64Index,
                 )
+
+                klass: type[Index]
+                if is_signed_integer_dtype(dtype):
+                    klass = Int64Index
+                elif is_unsigned_integer_dtype(dtype):
+                    klass = UInt64Index
+                elif is_float_dtype(dtype):
+                    klass = Float64Index
+                else:
+                    klass = Index
+                return klass(new_values, name=self.name, dtype=dtype, copy=False)
+
         return Index(new_values, name=self.name, dtype=new_values.dtype, copy=False)
 
     _index_shared_docs[
@@ -1712,9 +1721,9 @@ class Index(IndexOpsMixin, PandasObject):
         --------
         >>> idx = pd.Index([1, 2, 3, 4])
         >>> idx
-        Int64Index([1, 2, 3, 4], dtype='int64')
+        NumericIndex([1, 2, 3, 4], dtype='int64')
         >>> idx.set_names('quarter')
-        Int64Index([1, 2, 3, 4], dtype='int64', name='quarter')
+        NumericIndex([1, 2, 3, 4], dtype='int64', name='quarter')
 
         >>> idx = pd.MultiIndex.from_product([['python', 'cobra'],
         ...                                   [2018, 2019]])
@@ -2000,7 +2009,7 @@ class Index(IndexOpsMixin, PandasObject):
                    names=['x', 'y'])
 
         >>> mi.droplevel(['x', 'y'])
-        Int64Index([5, 6], dtype='int64', name='z')
+        NumericIndex([5, 6], dtype='int64', name='z')
         """
         if not isinstance(level, (tuple, list)):
             level = [level]
@@ -2579,7 +2588,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         >>> idx = pd.Index([5.2, 6.0, np.NaN])
         >>> idx
-        Float64Index([5.2, 6.0, nan], dtype='float64')
+        NumericIndex([5.2, 6.0, nan], dtype='float64')
         >>> idx.isna()
         array([False, False,  True])
 
@@ -2636,7 +2645,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         >>> idx = pd.Index([5.2, 6.0, np.NaN])
         >>> idx
-        Float64Index([5.2, 6.0, nan], dtype='float64')
+        NumericIndex([5.2, 6.0, nan], dtype='float64')
         >>> idx.notna()
         array([ True,  True, False])
 
@@ -2947,7 +2956,7 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx1 = pd.Index([1, 2, 3, 4])
         >>> idx2 = pd.Index([3, 4, 5, 6])
         >>> idx1.union(idx2)
-        Int64Index([1, 2, 3, 4, 5, 6], dtype='int64')
+        NumericIndex([1, 2, 3, 4, 5, 6], dtype='int64')
 
         Union mismatched dtypes
 
@@ -3139,7 +3148,7 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx1 = pd.Index([1, 2, 3, 4])
         >>> idx2 = pd.Index([3, 4, 5, 6])
         >>> idx1.intersection(idx2)
-        Int64Index([3, 4], dtype='int64')
+        NumericIndex([3, 4], dtype='int64')
         """
         self._validate_sort_keyword(sort)
         self._assert_can_do_setop(other)
@@ -3286,9 +3295,9 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx1 = pd.Index([2, 1, 3, 4])
         >>> idx2 = pd.Index([3, 4, 5, 6])
         >>> idx1.difference(idx2)
-        Int64Index([1, 2], dtype='int64')
+        NumericIndex([1, 2], dtype='int64')
         >>> idx1.difference(idx2, sort=False)
-        Int64Index([2, 1], dtype='int64')
+        NumericIndex([2, 1], dtype='int64')
         """
         self._validate_sort_keyword(sort)
         self._assert_can_do_setop(other)
@@ -3369,7 +3378,7 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx1 = pd.Index([1, 2, 3, 4])
         >>> idx2 = pd.Index([2, 3, 4, 5])
         >>> idx1.symmetric_difference(idx2)
-        Int64Index([1, 5], dtype='int64')
+        NumericIndex([1, 5], dtype='int64')
         """
         self._validate_sort_keyword(sort)
         self._assert_can_do_setop(other)
@@ -4912,7 +4921,7 @@ class Index(IndexOpsMixin, PandasObject):
         --------
         >>> idx = pd.Index([1, 2, 3, 4])
         >>> idx
-        Int64Index([1, 2, 3, 4], dtype='int64')
+        NumericIndex([1, 2, 3, 4], dtype='int64')
 
         >>> 2 in idx
         True
@@ -5063,6 +5072,7 @@ class Index(IndexOpsMixin, PandasObject):
         if self.dtype != object and is_valid_na_for_dtype(value, self.dtype):
             # e.g. None -> np.nan, see also Block._standardize_fill_value
             value = self._na_value
+
         try:
             converted = self._validate_fill_value(value)
         except (LossySetitemError, ValueError, TypeError) as err:
@@ -5109,7 +5119,7 @@ class Index(IndexOpsMixin, PandasObject):
         --------
         >>> idx1 = pd.Index([1, 2, 3])
         >>> idx1
-        Int64Index([1, 2, 3], dtype='int64')
+        NumericIndex([1, 2, 3], dtype='int64')
         >>> idx1.equals(pd.Index([1, 2, 3]))
         True
 
@@ -5126,10 +5136,10 @@ class Index(IndexOpsMixin, PandasObject):
 
         >>> ascending_idx = pd.Index([1, 2, 3])
         >>> ascending_idx
-        Int64Index([1, 2, 3], dtype='int64')
+        NumericIndex([1, 2, 3], dtype='int64')
         >>> descending_idx = pd.Index([3, 2, 1])
         >>> descending_idx
-        Int64Index([3, 2, 1], dtype='int64')
+        NumericIndex([3, 2, 1], dtype='int64')
         >>> ascending_idx.equals(descending_idx)
         False
 
@@ -5137,10 +5147,10 @@ class Index(IndexOpsMixin, PandasObject):
 
         >>> int64_idx = pd.Index([1, 2, 3], dtype='int64')
         >>> int64_idx
-        Int64Index([1, 2, 3], dtype='int64')
+        NumericIndex([1, 2, 3], dtype='int64')
         >>> uint64_idx = pd.Index([1, 2, 3], dtype='uint64')
         >>> uint64_idx
-        UInt64Index([1, 2, 3], dtype='uint64')
+        NumericIndex([1, 2, 3], dtype='uint64')
         >>> int64_idx.equals(uint64_idx)
         True
         """
@@ -5363,18 +5373,18 @@ class Index(IndexOpsMixin, PandasObject):
         --------
         >>> idx = pd.Index([10, 100, 1, 1000])
         >>> idx
-        Int64Index([10, 100, 1, 1000], dtype='int64')
+        NumericIndex([10, 100, 1, 1000], dtype='int64')
 
         Sort values in ascending order (default behavior).
 
         >>> idx.sort_values()
-        Int64Index([1, 10, 100, 1000], dtype='int64')
+        NumericIndex([1, 10, 100, 1000], dtype='int64')
 
         Sort values in descending order, and also get the indices `idx` was
         sorted by.
 
         >>> idx.sort_values(ascending=False, return_indexer=True)
-        (Int64Index([1000, 100, 10, 1], dtype='int64'), array([3, 1, 0, 2]))
+        (NumericIndex([1000, 100, 10, 1], dtype='int64'), array([3, 1, 0, 2]))
         """
         idx = ensure_key_mapped(self, key)
 
@@ -5956,13 +5966,6 @@ class Index(IndexOpsMixin, PandasObject):
                 new_values, self.dtype, same_dtype=same_dtype
             )
 
-        if self._is_backward_compat_public_numeric_index and is_numeric_dtype(
-            new_values.dtype
-        ):
-            return self._constructor(
-                new_values, dtype=dtype, copy=False, name=self.name
-            )
-
         return Index._with_infer(new_values, dtype=dtype, copy=False, name=self.name)
 
     # TODO: De-duplicate with map, xref GH#32349
@@ -6030,7 +6033,7 @@ class Index(IndexOpsMixin, PandasObject):
         --------
         >>> idx = pd.Index([1,2,3])
         >>> idx
-        Int64Index([1, 2, 3], dtype='int64')
+        NumericIndex([1, 2, 3], dtype='int64')
 
         Check whether each index value in a list of values.
 
@@ -6834,7 +6837,7 @@ def ensure_index_from_sequences(sequences, names=None) -> Index:
     Examples
     --------
     >>> ensure_index_from_sequences([[1, 2, 3]], names=["name"])
-    Int64Index([1, 2, 3], dtype='int64', name='name')
+    NumericIndex([1, 2, 3], dtype='int64', name='name')
 
     >>> ensure_index_from_sequences([["a", "a"], ["a", "b"]], names=["L1", "L2"])
     MultiIndex([('a', 'a'),

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -530,7 +530,7 @@ class Index(IndexOpsMixin, PandasObject):
             data = data.copy()
         return data
 
-    # @final (temporary off until merge NumericIndex into Index
+    @final
     @classmethod
     def _dtype_to_subclass(cls, dtype: DtypeObj):
         # Delay import for perf. https://github.com/pandas-dev/pandas/pull/31423

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -79,7 +79,7 @@ from pandas.core.dtypes.cast import (
     can_hold_element,
     common_dtype_categorical_compat,
     ensure_dtype_can_hold_na,
-    find_common_type,
+    find_result_type,
     infer_dtype_from,
     maybe_cast_pointwise_result,
     np_can_hold_element,
@@ -124,6 +124,7 @@ from pandas.core.dtypes.generic import (
     ABCDatetimeIndex,
     ABCMultiIndex,
     ABCPeriodIndex,
+    ABCRangeIndex,
     ABCSeries,
     ABCTimedeltaIndex,
 )
@@ -5860,7 +5861,7 @@ class Index(IndexOpsMixin, PandasObject):
             ):
                 return _dtype_obj
 
-        dtype = find_common_type([self.dtype, target_dtype])
+        dtype = find_result_type(self._values, target)
         dtype = common_dtype_categorical_compat([self, target], dtype)
         return dtype
 

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -13,6 +13,7 @@ from pandas._libs import (
 )
 from pandas._typing import (
     Dtype,
+    DtypeObj,
     npt,
 )
 from pandas.util._decorators import (
@@ -361,7 +362,20 @@ _num_index_shared_docs[
 """
 
 
-class IntegerIndex(NumericIndex):
+class TempBaseIndex(NumericIndex):
+    @classmethod
+    def _dtype_to_subclass(cls, dtype: DtypeObj):
+        if is_integer_dtype(dtype):
+            return Int64Index
+        elif is_unsigned_integer_dtype(dtype):
+            return UInt64Index
+        elif is_float_dtype(dtype):
+            return Float64Index
+        else:
+            return super()._dtype_to_subclass(dtype)
+
+
+class IntegerIndex(TempBaseIndex):
     """
     This is an abstract class for Int64Index, UInt64Index.
     """
@@ -405,7 +419,7 @@ class UInt64Index(IntegerIndex):
         return libindex.UInt64Engine
 
 
-class Float64Index(NumericIndex):
+class Float64Index(TempBaseIndex):
     _index_descr_args = {
         "klass": "Float64Index",
         "dtype": "float64",

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -13,7 +13,6 @@ from pandas._libs import (
 )
 from pandas._typing import (
     Dtype,
-    DtypeObj,
     npt,
 )
 from pandas.util._decorators import (
@@ -362,20 +361,7 @@ _num_index_shared_docs[
 """
 
 
-class TempBaseIndex(NumericIndex):
-    @classmethod
-    def _dtype_to_subclass(cls, dtype: DtypeObj):
-        if is_integer_dtype(dtype):
-            return Int64Index
-        elif is_unsigned_integer_dtype(dtype):
-            return UInt64Index
-        elif is_float_dtype(dtype):
-            return Float64Index
-        else:
-            return super()._dtype_to_subclass(dtype)
-
-
-class IntegerIndex(TempBaseIndex):
+class IntegerIndex(NumericIndex):
     """
     This is an abstract class for Int64Index, UInt64Index.
     """
@@ -419,7 +405,7 @@ class UInt64Index(IntegerIndex):
         return libindex.UInt64Engine
 
 
-class Float64Index(TempBaseIndex):
+class Float64Index(NumericIndex):
     _index_descr_args = {
         "klass": "Float64Index",
         "dtype": "float64",

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -189,9 +189,9 @@ class RangeIndex(NumericIndex):
     # error: Return type "Type[Int64Index]" of "_constructor" incompatible with return
     # type "Type[RangeIndex]" in supertype "Index"
     @cache_readonly
-    def _constructor(self) -> type[Int64Index]:  # type: ignore[override]
+    def _constructor(self) -> type[NumericIndex]:  # type: ignore[override]
         """return the class to use for construction"""
-        return Int64Index
+        return NumericIndex
 
     # error: Signature of "_data" incompatible with supertype "Index"
     @cache_readonly

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -108,10 +108,7 @@ from pandas.core.construction import (
 from pandas.core.indexers import check_setitem_lengths
 
 if TYPE_CHECKING:
-    from pandas.core.api import (
-        Float64Index,
-        Index,
-    )
+    from pandas.core.api import Index
     from pandas.core.arrays._mixins import NDArrayBackedExtensionArray
 
 # comparison is faster than is_object_dtype
@@ -1281,7 +1278,7 @@ class Block(PandasObject):
     @final
     def quantile(
         self,
-        qs: Float64Index,
+        qs: Index,  # with dtype float64
         interpolation: QuantileInterpolation = "linear",
         axis: AxisInt = 0,
     ) -> Block:

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -64,7 +64,6 @@ from pandas.core.construction import (
 )
 from pandas.core.indexers import maybe_convert_indices
 from pandas.core.indexes.api import (
-    Float64Index,
     Index,
     ensure_index,
 )
@@ -1534,7 +1533,7 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
     def quantile(
         self: T,
         *,
-        qs: Float64Index,
+        qs: Index,  # with dtype float 64
         axis: AxisInt = 0,
         interpolation: QuantileInterpolation = "linear",
     ) -> T:
@@ -1562,7 +1561,7 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         assert axis == 1  # only ever called this way
 
         new_axes = list(self.axes)
-        new_axes[1] = Float64Index(qs)
+        new_axes[1] = Index(qs, dtype=np.float64)
 
         blocks = [
             blk.quantile(axis=axis, qs=qs, interpolation=interpolation)

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -2247,7 +2247,7 @@ class StringMethods(NoNewAttributesMixin):
         This is also available on Index
 
         >>> pd.Index(['A', 'A', 'Aaba', 'cat']).str.count('a')
-        Int64Index([0, 0, 2, 1], dtype='int64')
+        NumericIndex([0, 0, 2, 1], dtype='int64')
         """
         result = self._data.array._str_count(pat, flags)
         return self._wrap_result(result, returns_string=False)

--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -17,7 +17,7 @@ from pandas.util._decorators import doc
 
 from pandas.core.api import (
     DataFrame,
-    Int64Index,
+    NumericIndex,
     RangeIndex,
 )
 from pandas.core.shared_docs import _shared_docs
@@ -62,7 +62,7 @@ def to_feather(
     # validate that we have only a default index
     # raise on anything else as we don't serialize the index
 
-    if not isinstance(df.index, (Int64Index, RangeIndex)):
+    if not (isinstance(df.index, NumericIndex) and df.index.dtype == "int64"):
         typ = type(df.index)
         raise ValueError(
             f"feather does not support serializing {typ} "

--- a/pandas/io/formats/info.py
+++ b/pandas/io/formats/info.py
@@ -165,7 +165,7 @@ series_examples_sub = dedent(
     >>> s = pd.Series(text_values, index=int_values)
     >>> s.info()
     <class 'pandas.core.series.Series'>
-    Int64Index: 5 entries, 1 to 5
+    NumericIndex: 5 entries, 1 to 5
     Series name: None
     Non-Null Count  Dtype
     --------------  -----
@@ -177,7 +177,7 @@ series_examples_sub = dedent(
 
     >>> s.info(verbose=False)
     <class 'pandas.core.series.Series'>
-    Int64Index: 5 entries, 1 to 5
+    NumericIndex: 5 entries, 1 to 5
     dtypes: object(1)
     memory usage: 80.0+ bytes
 

--- a/pandas/tests/apply/test_series_apply.py
+++ b/pandas/tests/apply/test_series_apply.py
@@ -186,7 +186,7 @@ def test_apply_datetimetz():
     # change dtype
     # GH 14506 : Returned dtype changed from int32 to int64
     result = s.apply(lambda x: x.hour)
-    exp = Series(list(range(24)) + [0], name="XX", dtype=np.int64)
+    exp = Series(list(range(24)) + [0], name="XX", dtype=np.int32)
     tm.assert_series_equal(result, exp)
 
     # not vectorized
@@ -764,7 +764,7 @@ def test_map_datetimetz():
     # change dtype
     # GH 14506 : Returned dtype changed from int32 to int64
     result = s.map(lambda x: x.hour)
-    exp = Series(list(range(24)) + [0], name="XX", dtype=np.int64)
+    exp = Series(list(range(24)) + [0], name="XX", dtype=np.int32)
     tm.assert_series_equal(result, exp)
 
     # not vectorized

--- a/pandas/tests/arrays/categorical/test_repr.py
+++ b/pandas/tests/arrays/categorical/test_repr.py
@@ -111,7 +111,7 @@ Categories (5, int64): [1, 2, 3, 4, 5]"""
 
         assert repr(c) == exp
 
-        c = Categorical(np.arange(20))
+        c = Categorical(np.arange(20, dtype=np.int64))
         exp = """[0, 1, 2, 3, 4, ..., 15, 16, 17, 18, 19]
 Length: 20
 Categories (20, int64): [0, 1, 2, 3, ..., 16, 17, 18, 19]"""
@@ -138,7 +138,7 @@ Categories (5, int64): [1 < 2 < 3 < 4 < 5]"""
 
         assert repr(c) == exp
 
-        c = Categorical(np.arange(20), ordered=True)
+        c = Categorical(np.arange(20, dtype=np.int64), ordered=True)
         exp = """[0, 1, 2, 3, 4, ..., 15, 16, 17, 18, 19]
 Length: 20
 Categories (20, int64): [0 < 1 < 2 < 3 ... 16 < 17 < 18 < 19]"""
@@ -380,7 +380,7 @@ Categories (20, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
         exp = """CategoricalIndex([1, 2, 3], categories=[1, 2, 3], ordered=False, dtype='category')"""  # noqa:E501
         assert repr(idx) == exp
 
-        i = CategoricalIndex(Categorical(np.arange(10)))
+        i = CategoricalIndex(Categorical(np.arange(10, dtype=np.int64)))
         exp = """CategoricalIndex([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], categories=[0, 1, 2, 3, ..., 6, 7, 8, 9], ordered=False, dtype='category')"""  # noqa:E501
         assert repr(i) == exp
 
@@ -389,7 +389,7 @@ Categories (20, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
         exp = """CategoricalIndex([1, 2, 3], categories=[1, 2, 3], ordered=True, dtype='category')"""  # noqa:E501
         assert repr(i) == exp
 
-        i = CategoricalIndex(Categorical(np.arange(10), ordered=True))
+        i = CategoricalIndex(Categorical(np.arange(10, dtype=np.int64), ordered=True))
         exp = """CategoricalIndex([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], categories=[0, 1, 2, 3, ..., 6, 7, 8, 9], ordered=True, dtype='category')"""  # noqa:E501
         assert repr(i) == exp
 

--- a/pandas/tests/arrays/interval/test_interval.py
+++ b/pandas/tests/arrays/interval/test_interval.py
@@ -287,7 +287,7 @@ def test_arrow_array():
     with pytest.raises(TypeError, match="Not supported to convert IntervalArray"):
         pa.array(intervals, type="float64")
 
-    with pytest.raises(TypeError, match="different 'subtype'|to convert IntervalArray"):
+    with pytest.raises(TypeError, match="Not supported to convert IntervalArray"):
         pa.array(intervals, type=ArrowIntervalType(pa.float64(), "left"))
 
 

--- a/pandas/tests/arrays/sparse/test_accessor.py
+++ b/pandas/tests/arrays/sparse/test_accessor.py
@@ -41,7 +41,12 @@ class TestSeriesAccessor:
         sp_array = scipy.sparse.coo_matrix((data, (row, col)), dtype="int")
         result = pd.Series.sparse.from_coo(sp_array)
 
-        index = pd.MultiIndex.from_arrays([[0, 0, 1, 3], [0, 2, 1, 3]])
+        index = pd.MultiIndex.from_arrays(
+            [
+                np.array([0, 0, 1, 3], dtype=np.int32),
+                np.array([0, 2, 1, 3], dtype=np.int32),
+            ],
+        )
         expected = pd.Series([4, 9, 7, 5], index=index, dtype="Sparse[int]")
         tm.assert_series_equal(result, expected)
 
@@ -212,7 +217,15 @@ class TestFrameAccessor:
 
         A = scipy.sparse.eye(3, format="coo", dtype=dtype)
         result = pd.Series.sparse.from_coo(A, dense_index=dense_index)
-        index = pd.MultiIndex.from_tuples([(0, 0), (1, 1), (2, 2)])
+
+        index_dtype = np.int64 if dense_index else np.int32
+        index = pd.MultiIndex.from_tuples(
+            [
+                np.array([0, 0], dtype=index_dtype),
+                np.array([1, 1], dtype=index_dtype),
+                np.array([2, 2], dtype=index_dtype),
+            ],
+        )
         expected = pd.Series(SparseArray(np.array([1, 1, 1], dtype=dtype)), index=index)
         if dense_index:
             expected = expected.reindex(pd.MultiIndex.from_product(index.levels))

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -445,7 +445,8 @@ def test_groupby_agg_ea_method(monkeypatch):
     result = df.groupby("id")["decimals"].agg(lambda x: x.values.my_sum())
     tm.assert_series_equal(result, expected, check_names=False)
     s = pd.Series(DecimalArray(data))
-    result = s.groupby(np.array([0, 0, 0, 1, 1])).agg(lambda x: x.values.my_sum())
+    grouper = np.array([0, 0, 0, 1, 1], dtype=np.int64)
+    result = s.groupby(grouper).agg(lambda x: x.values.my_sum())
     tm.assert_series_equal(result, expected, check_names=False)
 
 

--- a/pandas/tests/frame/constructors/test_from_dict.py
+++ b/pandas/tests/frame/constructors/test_from_dict.py
@@ -85,7 +85,7 @@ class TestFromDict:
         expected = DataFrame.from_dict(sdict, orient="index")
         tm.assert_frame_equal(result, expected.reindex(result.index))
 
-        result2 = DataFrame(data, index=np.arange(6))
+        result2 = DataFrame(data, index=np.arange(6, dtype=np.int64))
         tm.assert_frame_equal(result, result2)
 
         result = DataFrame([Series(dtype=object)])

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -737,7 +737,7 @@ class TestDataFrameIndexing:
 
         # positional slicing only via iloc!
         msg = (
-            "cannot do positional indexing on Float64Index with "
+            "cannot do positional indexing on NumericIndex with "
             r"these indexers \[1.0\] of type float"
         )
         with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -642,7 +642,8 @@ class TestDataFrameIndexingWhere:
     @pytest.mark.parametrize("kwargs", [{}, {"other": None}])
     def test_df_where_with_category(self, kwargs):
         # GH#16979
-        df = DataFrame(np.arange(2 * 3).reshape(2, 3), columns=list("ABC"))
+        data = np.arange(2 * 3, dtype=np.int64).reshape(2, 3)
+        df = DataFrame(data, columns=list("ABC"))
         mask = np.array([[True, False, False], [False, False, True]])
 
         # change type to category

--- a/pandas/tests/frame/methods/test_set_index.py
+++ b/pandas/tests/frame/methods/test_set_index.py
@@ -159,7 +159,7 @@ class TestSetIndex:
         df = DataFrame(
             {"A": [1.1, 2.2, 3.3], "B": [5.0, 6.1, 7.2]}, index=[2010, 2011, 2012]
         )
-        df2 = df.set_index(df.index.astype(np.int32))
+        df2 = df.set_index(df.index.astype(np.int64))
         tm.assert_frame_equal(df, df2)
 
     # A has duplicate values, C does not

--- a/pandas/tests/frame/methods/test_set_index.py
+++ b/pandas/tests/frame/methods/test_set_index.py
@@ -154,14 +154,6 @@ class TestSetIndex:
         # Check equality
         tm.assert_index_equal(df.set_index([df.index, idx2]).index, mi2)
 
-    def test_set_index_cast(self):
-        # issue casting an index then set_index
-        df = DataFrame(
-            {"A": [1.1, 2.2, 3.3], "B": [5.0, 6.1, 7.2]}, index=[2010, 2011, 2012]
-        )
-        df2 = df.set_index(df.index.astype(np.int64))
-        tm.assert_frame_equal(df, df2)
-
     # A has duplicate values, C does not
     @pytest.mark.parametrize("keys", ["A", "C", ["A", "B"], ("tuple", "as", "label")])
     @pytest.mark.parametrize("inplace", [True, False])

--- a/pandas/tests/frame/methods/test_to_csv.py
+++ b/pandas/tests/frame/methods/test_to_csv.py
@@ -62,8 +62,8 @@ class TestDataFrameToCSV:
             # corner case
             dm = DataFrame(
                 {
-                    "s1": Series(range(3), index=np.arange(3)),
-                    "s2": Series(range(2), index=np.arange(2)),
+                    "s1": Series(range(3), index=np.arange(3, dtype=np.int64)),
+                    "s2": Series(range(2), index=np.arange(2, dtype=np.int64)),
                 }
             )
             dm.to_csv(path)
@@ -388,7 +388,7 @@ class TestDataFrameToCSV:
 
     @pytest.mark.slow
     def test_to_csv_empty(self):
-        df = DataFrame(index=np.arange(10))
+        df = DataFrame(index=np.arange(10, dtype=np.int64))
         result, expected = self._return_result_expected(df, 1000)
         tm.assert_frame_equal(result, expected, check_column_type=False)
 
@@ -486,7 +486,7 @@ class TestDataFrameToCSV:
 
         frame = float_frame
         old_index = frame.index
-        arrays = np.arange(len(old_index) * 2).reshape(2, -1)
+        arrays = np.arange(len(old_index) * 2, dtype=np.int64).reshape(2, -1)
         new_index = MultiIndex.from_arrays(arrays, names=["first", "second"])
         frame.index = new_index
 
@@ -510,7 +510,7 @@ class TestDataFrameToCSV:
             # try multiindex with dates
             tsframe = datetime_frame
             old_index = tsframe.index
-            new_index = [old_index, np.arange(len(old_index))]
+            new_index = [old_index, np.arange(len(old_index), dtype=np.int64)]
             tsframe.index = MultiIndex.from_arrays(new_index)
 
             tsframe.to_csv(path, index_label=["time", "foo"])

--- a/pandas/tests/frame/methods/test_value_counts.py
+++ b/pandas/tests/frame/methods/test_value_counts.py
@@ -88,7 +88,7 @@ def test_data_frame_value_counts_empty():
     df_no_cols = pd.DataFrame()
 
     result = df_no_cols.value_counts()
-    expected = pd.Series([], dtype=np.int64)
+    expected = pd.Series([], dtype=np.int64, index=np.array([], dtype=np.intp))
 
     tm.assert_series_equal(result, expected)
 
@@ -97,7 +97,7 @@ def test_data_frame_value_counts_empty_normalize():
     df_no_cols = pd.DataFrame()
 
     result = df_no_cols.value_counts(normalize=True)
-    expected = pd.Series([], dtype=np.float64)
+    expected = pd.Series([], dtype=np.float64, index=np.array([], dtype=np.intp))
 
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -583,7 +583,7 @@ class TestDataFrameAnalytics:
     def test_mode_empty_df(self):
         df = DataFrame([], columns=["a", "b"])
         result = df.mode()
-        expected = DataFrame([], columns=["a", "b"], index=Index([], dtype=int))
+        expected = DataFrame([], columns=["a", "b"], index=Index([], dtype=np.int64))
         tm.assert_frame_equal(result, expected)
 
     def test_operators_timedelta64(self):

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -673,7 +673,8 @@ def test_agg_split_object_part_datetime():
             "D": ["b"],
             "E": [pd.Timestamp("2000")],
             "F": [1],
-        }
+        },
+        index=np.array([0]),
     )
     tm.assert_frame_equal(result, expected)
 
@@ -684,7 +685,7 @@ class TestNamedAggregationSeries:
         gr = df.groupby([0, 0, 1, 1])
         result = gr.agg(a="sum", b="min")
         expected = DataFrame(
-            {"a": [3, 7], "b": [1, 3]}, columns=["a", "b"], index=[0, 1]
+            {"a": [3, 7], "b": [1, 3]}, columns=["a", "b"], index=np.array([0, 1])
         )
         tm.assert_frame_equal(result, expected)
 
@@ -706,13 +707,13 @@ class TestNamedAggregationSeries:
         # GH28426
         gr = Series([1, 2, 3]).groupby([0, 0, 1])
         grouped = gr.agg(a="sum", b="sum")
-        expected = DataFrame({"a": [3, 3], "b": [3, 3]})
+        expected = DataFrame({"a": [3, 3], "b": [3, 3]}, index=np.array([0, 1]))
         tm.assert_frame_equal(expected, grouped)
 
     def test_mangled(self):
         gr = Series([1, 2, 3]).groupby([0, 0, 1])
         result = gr.agg(a=lambda x: 0, b=lambda x: 1)
-        expected = DataFrame({"a": [0, 0], "b": [1, 1]})
+        expected = DataFrame({"a": [0, 0], "b": [1, 1]}, index=np.array([0, 1]))
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize(
@@ -1013,8 +1014,7 @@ def test_multiindex_custom_func(func):
         (1, 4): {0: 4.0, 1: 7.0},
         (2, 3): {0: 2.0, 1: 1.0},
     }
-    expected = DataFrame(expected_dict)
-    expected.columns = df.columns
+    expected = DataFrame(expected_dict, index=np.array([0, 1]), columns=df.columns)
     tm.assert_frame_equal(result, expected)
 
 
@@ -1096,7 +1096,8 @@ class TestLambdaMangling:
     def test_mangle_series_groupby(self):
         gr = Series([1, 2, 3, 4]).groupby([0, 0, 1, 1])
         result = gr.agg([lambda x: 0, lambda x: 1])
-        expected = DataFrame({"<lambda_0>": [0, 0], "<lambda_1>": [1, 1]})
+        exp_data = {"<lambda_0>": [0, 0], "<lambda_1>": [1, 1]}
+        expected = DataFrame(exp_data, index=np.array([0, 1]))
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.xfail(reason="GH-26611. kwargs for multi-agg.")
@@ -1384,7 +1385,7 @@ def test_groupby_aggregate_directory(reduction_func):
 def test_group_mean_timedelta_nat():
     # GH43132
     data = Series(["1 day", "3 days", "NaT"], dtype="timedelta64[ns]")
-    expected = Series(["2 days"], dtype="timedelta64[ns]")
+    expected = Series(["2 days"], dtype="timedelta64[ns]", index=np.array([0]))
 
     result = data.groupby([0, 0, 0]).mean()
 
@@ -1407,7 +1408,7 @@ def test_group_mean_timedelta_nat():
 def test_group_mean_datetime64_nat(input_data, expected_output):
     # GH43132
     data = to_datetime(Series(input_data))
-    expected = to_datetime(Series(expected_output))
+    expected = to_datetime(Series(expected_output, index=np.array([0])))
 
     result = data.groupby([0, 0, 0]).mean()
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/groupby/aggregate/test_cython.py
+++ b/pandas/tests/groupby/aggregate/test_cython.py
@@ -212,7 +212,7 @@ def test_cython_agg_empty_buckets_nanops(observed):
     # GH-18869 can't call nanops on empty groups, so hardcode expected
     # for these
     df = DataFrame([11, 12, 13], columns=["a"])
-    grps = np.arange(0, 25, 5, dtype=np.intp)
+    grps = np.arange(0, 25, 5, dtype=np.int_)
     # add / sum
     result = df.groupby(pd.cut(df["a"], grps), observed=observed)._cython_agg_general(
         "sum", alt=None, numeric_only=True

--- a/pandas/tests/groupby/aggregate/test_cython.py
+++ b/pandas/tests/groupby/aggregate/test_cython.py
@@ -212,7 +212,7 @@ def test_cython_agg_empty_buckets_nanops(observed):
     # GH-18869 can't call nanops on empty groups, so hardcode expected
     # for these
     df = DataFrame([11, 12, 13], columns=["a"])
-    grps = np.arange(0, 25, 5, dtype=np.int_)
+    grps = np.arange(0, 25, 5, dtype=np.intp)
     # add / sum
     result = df.groupby(pd.cut(df["a"], grps), observed=observed)._cython_agg_general(
         "sum", alt=None, numeric_only=True

--- a/pandas/tests/groupby/aggregate/test_cython.py
+++ b/pandas/tests/groupby/aggregate/test_cython.py
@@ -212,12 +212,12 @@ def test_cython_agg_empty_buckets_nanops(observed):
     # GH-18869 can't call nanops on empty groups, so hardcode expected
     # for these
     df = DataFrame([11, 12, 13], columns=["a"])
-    grps = range(0, 25, 5)
+    grps = np.arange(0, 25, 5, dtype=np.int_)
     # add / sum
     result = df.groupby(pd.cut(df["a"], grps), observed=observed)._cython_agg_general(
         "sum", alt=None, numeric_only=True
     )
-    intervals = pd.interval_range(0, 20, freq=5)
+    intervals = pd.IntervalIndex.from_breaks(np.arange(0, 21, 5))
     expected = DataFrame(
         {"a": [0, 0, 36, 0]},
         index=pd.CategoricalIndex(intervals, name="a", ordered=True),

--- a/pandas/tests/groupby/test_any_all.py
+++ b/pandas/tests/groupby/test_any_all.py
@@ -68,7 +68,7 @@ def test_bool_aggs_dup_column_labels(bool_agg_func):
     grp_by = df.groupby([0])
     result = getattr(grp_by, bool_agg_func)()
 
-    expected = df
+    expected = df.set_axis(np.array([0]))
     tm.assert_frame_equal(result, expected)
 
 
@@ -92,7 +92,7 @@ def test_masked_kleene_logic(bool_agg_func, skipna, data):
     # The result should match aggregating on the whole series. Correctness
     # there is verified in test_reductions.py::test_any_all_boolean_kleene_logic
     expected_data = getattr(ser, bool_agg_func)(skipna=skipna)
-    expected = Series(expected_data, dtype="boolean")
+    expected = Series(expected_data, index=np.array([0]), dtype="boolean")
 
     result = ser.groupby([0, 0, 0]).agg(bool_agg_func, skipna=skipna)
     tm.assert_series_equal(result, expected)
@@ -135,7 +135,7 @@ def test_masked_mixed_types(dtype1, dtype2, exp_col1, exp_col2):
     )
     result = df.groupby([1, 1]).agg("all", skipna=False)
 
-    expected = DataFrame({"col1": exp_col1, "col2": exp_col2}, index=[1])
+    expected = DataFrame({"col1": exp_col1, "col2": exp_col2}, index=np.array([1]))
     tm.assert_frame_equal(result, expected)
 
 
@@ -148,7 +148,7 @@ def test_masked_bool_aggs_skipna(bool_agg_func, dtype, skipna, frame_or_series):
     expected_res = True
     if not skipna and bool_agg_func == "all":
         expected_res = pd.NA
-    expected = frame_or_series([expected_res], index=[1], dtype="boolean")
+    expected = frame_or_series([expected_res], index=np.array([1]), dtype="boolean")
 
     result = obj.groupby([1, 1]).agg(bool_agg_func, skipna=skipna)
     tm.assert_equal(result, expected)
@@ -167,7 +167,7 @@ def test_object_type_missing_vals(bool_agg_func, data, expected_res, frame_or_se
     # GH#37501
     obj = frame_or_series(data, dtype=object)
     result = obj.groupby([1] * len(data)).agg(bool_agg_func)
-    expected = frame_or_series([expected_res], index=[1], dtype="bool")
+    expected = frame_or_series([expected_res], index=np.array([1]), dtype="bool")
     tm.assert_equal(result, expected)
 
 

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1507,7 +1507,7 @@ def test_groupby_agg_categorical_columns(func, expected_values):
 
 def test_groupby_agg_non_numeric():
     df = DataFrame({"A": Categorical(["a", "a", "b"], categories=["a", "b", "c"])})
-    expected = DataFrame({"A": [2, 1]}, index=[1, 2])
+    expected = DataFrame({"A": [2, 1]}, index=np.array([1, 2]))
 
     result = df.groupby([1, 2, 1]).agg(Series.nunique)
     tm.assert_frame_equal(result, expected)
@@ -1538,9 +1538,7 @@ def test_read_only_category_no_sort():
     df = DataFrame(
         {"a": [1, 3, 5, 7], "b": Categorical([1, 1, 2, 2], categories=Index(cats))}
     )
-    expected = DataFrame(
-        data={"a": [2.0, 6.0]}, index=CategoricalIndex([1, 2], name="b")
-    )
+    expected = DataFrame(data={"a": [2.0, 6.0]}, index=CategoricalIndex(cats, name="b"))
     result = df.groupby("b", sort=False).mean()
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/groupby/test_filters.py
+++ b/pandas/tests/groupby/test_filters.py
@@ -232,7 +232,7 @@ def test_filter_using_len():
     actual = grouped.filter(lambda x: len(x) > 2)
     expected = DataFrame(
         {"A": np.arange(2, 6), "B": list("bbbb"), "C": np.arange(2, 6)},
-        index=np.arange(2, 6),
+        index=np.arange(2, 6, dtype=np.int64),
     )
     tm.assert_frame_equal(actual, expected)
 
@@ -244,7 +244,7 @@ def test_filter_using_len():
     s = df["B"]
     grouped = s.groupby(s)
     actual = grouped.filter(lambda x: len(x) > 2)
-    expected = Series(4 * ["b"], index=np.arange(2, 6), name="B")
+    expected = Series(4 * ["b"], index=np.arange(2, 6, dtype=np.int64), name="B")
     tm.assert_series_equal(actual, expected)
 
     actual = grouped.filter(lambda x: len(x) > 4)

--- a/pandas/tests/groupby/test_frame_value_counts.py
+++ b/pandas/tests/groupby/test_frame_value_counts.py
@@ -674,7 +674,7 @@ def test_mixed_groupings(normalize, expected_label, expected_values):
     result = gp.value_counts(sort=True, normalize=normalize)
     expected = DataFrame(
         {
-            "level_0": [4, 4, 5],
+            "level_0": np.array([4, 4, 5]),
             "A": [1, 1, 2],
             "level_2": [8, 8, 7],
             "B": [1, 3, 2],
@@ -697,7 +697,8 @@ def test_column_label_duplicates(test, columns, expected_names, as_index):
     # Test for duplicate input column labels and generated duplicate labels
     df = DataFrame([[1, 3, 5, 7, 9], [2, 4, 6, 8, 10]], columns=columns)
     expected_data = [(1, 0, 7, 3, 5, 9), (2, 1, 8, 4, 6, 10)]
-    result = df.groupby(["a", [0, 1], "d"], as_index=as_index).value_counts()
+    keys = ["a", np.array([0, 1], dtype=np.int64), "d"]
+    result = df.groupby(keys, as_index=as_index).value_counts()
     if as_index:
         expected = Series(
             data=(1, 1),
@@ -736,7 +737,7 @@ def test_result_label_duplicates(normalize, expected_label):
 def test_ambiguous_grouping():
     # Test that groupby is not confused by groupings length equal to row count
     df = DataFrame({"a": [1, 1]})
-    gb = df.groupby([1, 1])
+    gb = df.groupby(np.array([1, 1], dtype=np.int64))
     result = gb.value_counts()
     expected = Series([2], index=MultiIndex.from_tuples([[1, 1]], names=[None, "a"]))
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -778,7 +778,7 @@ def test_nlargest_and_smallest_noop(data, groups, method):
     if method == "nlargest":
         data = list(reversed(data))
     ser = Series(data, name="a")
-    result = getattr(ser.groupby(groups), method)(n=2)
+    result = getattr(ser.groupby(np.array(groups, dtype=np.int64)), method)(n=2)
     expected = Series(data, index=MultiIndex.from_arrays([groups, ser.index]), name="a")
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -768,7 +768,15 @@ def test_nsmallest():
 
 @pytest.mark.parametrize(
     "data, groups",
-    [([0, 1, 2, 3], [0, 0, 1, 1]), ([0], [0])],
+    [
+        ([0, 1, 2, 3], [0, 0, 1, 1]),
+        ([0], [0]),
+        *[
+            (np.array(data, dtype=dtyp), np.array(groups, dtype=dtyp))
+            for data, groups in [([0, 1, 2, 3], [0, 0, 1, 1]), ([0], [0])]
+            for dtyp in tm.ALL_INT_NUMPY_DTYPES
+        ],
+    ],
 )
 @pytest.mark.parametrize("method", ["nlargest", "nsmallest"])
 def test_nlargest_and_smallest_noop(data, groups, method):
@@ -778,8 +786,9 @@ def test_nlargest_and_smallest_noop(data, groups, method):
     if method == "nlargest":
         data = list(reversed(data))
     ser = Series(data, name="a")
-    result = getattr(ser.groupby(np.array(groups, dtype=np.int64)), method)(n=2)
-    expected = Series(data, index=MultiIndex.from_arrays([groups, ser.index]), name="a")
+    result = getattr(ser.groupby(groups), method)(n=2)
+    expidx = np.array(groups, dtype=np.intp) if isinstance(groups, list) else groups
+    expected = Series(data, index=MultiIndex.from_arrays([expidx, ser.index]), name="a")
     tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -92,7 +92,9 @@ def test_groupby_nonobject_dtype(mframe, df_mixed_floats):
     result = grouped.sum()
 
     expected = mframe.groupby(key.astype("O")).sum()
-    tm.assert_frame_equal(result, expected)
+    assert result.index.dtype == np.int8
+    assert expected.index.dtype == np.int64
+    tm.assert_frame_equal(result, expected, check_index_type=False)
 
     # GH 3911, mixed frame non-conversion
     df = df_mixed_floats.copy()
@@ -227,6 +229,7 @@ def test_pass_args_kwargs_duplicate_columns(tsframe, as_index):
         2: tsframe[tsframe.index.month == 2].quantile(0.8),
     }
     expected = DataFrame(ex_data).T
+    expected.index = expected.index.astype(np.int32)
     if not as_index:
         # TODO: try to get this more consistent?
         expected.index = Index(range(2))
@@ -795,7 +798,7 @@ def test_groupby_as_index_cython(df):
         data.groupby(["A"]).mean()
     expected = data.groupby(["A"]).mean(numeric_only=True)
     expected.insert(0, "A", expected.index)
-    expected.index = np.arange(len(expected))
+    expected.index = RangeIndex(len(expected))
     tm.assert_frame_equal(result, expected)
 
     # multi-key
@@ -806,7 +809,7 @@ def test_groupby_as_index_cython(df):
     arrays = list(zip(*expected.index.values))
     expected.insert(0, "A", arrays[0])
     expected.insert(1, "B", arrays[1])
-    expected.index = np.arange(len(expected))
+    expected.index = RangeIndex(len(expected))
     tm.assert_frame_equal(result, expected)
 
 
@@ -1016,8 +1019,12 @@ def test_groupby_level_mapper(mframe):
     result0 = mframe.groupby(mapper0, level=0).sum()
     result1 = mframe.groupby(mapper1, level=1).sum()
 
-    mapped_level0 = np.array([mapper0.get(x) for x in deleveled["first"]])
-    mapped_level1 = np.array([mapper1.get(x) for x in deleveled["second"]])
+    mapped_level0 = np.array(
+        [mapper0.get(x) for x in deleveled["first"]], dtype=np.int64
+    )
+    mapped_level1 = np.array(
+        [mapper1.get(x) for x in deleveled["second"]], dtype=np.int64
+    )
     expected0 = mframe.groupby(mapped_level0).sum()
     expected1 = mframe.groupby(mapped_level1).sum()
     expected0.index.name, expected1.index.name = "first", "second"
@@ -2468,7 +2475,7 @@ def test_groupby_duplicate_columns():
     ).astype(object)
     df.columns = ["A", "B", "B"]
     result = df.groupby([0, 0, 0, 0]).min()
-    expected = DataFrame([["e", "a", 1]], columns=["A", "B", "B"])
+    expected = DataFrame([["e", "a", 1]], index=np.array([0]), columns=["A", "B", "B"])
     tm.assert_frame_equal(result, expected)
 
 
@@ -2769,7 +2776,7 @@ def test_groupby_overflow(val, dtype):
     result = df.groupby("a").sum()
     expected = DataFrame(
         {"b": [val * 2]},
-        index=Index([1], name="a", dtype=f"{dtype}64"),
+        index=Index([1], name="a", dtype=f"{dtype}8"),
         dtype=f"{dtype}64",
     )
     tm.assert_frame_equal(result, expected)
@@ -2781,7 +2788,7 @@ def test_groupby_overflow(val, dtype):
     result = df.groupby("a").prod()
     expected = DataFrame(
         {"b": [val * val]},
-        index=Index([1], name="a", dtype=f"{dtype}64"),
+        index=Index([1], name="a", dtype=f"{dtype}8"),
         dtype=f"{dtype}64",
     )
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -403,8 +403,9 @@ class TestGrouping:
 
         result = s.groupby(mapping).mean()
         result2 = s.groupby(mapping).agg(np.mean)
-        expected = s.groupby([0, 0, 1, 1]).mean()
-        expected2 = s.groupby([0, 0, 1, 1]).mean()
+        exp_key = np.array([0, 0, 1, 1], dtype=np.int64)
+        expected = s.groupby(exp_key).mean()
+        expected2 = s.groupby(exp_key).mean()
         tm.assert_series_equal(result, expected)
         tm.assert_series_equal(result, result2)
         tm.assert_series_equal(result, expected2)
@@ -692,7 +693,8 @@ class TestGrouping:
         gr = s.groupby([])
 
         result = gr.mean()
-        tm.assert_series_equal(result, s)
+        expected = s.set_axis(Index([], dtype=np.intp))
+        tm.assert_series_equal(result, expected)
 
         # check group properties
         assert len(gr.grouper.groupings) == 1

--- a/pandas/tests/groupby/test_min_max.py
+++ b/pandas/tests/groupby/test_min_max.py
@@ -81,7 +81,8 @@ def test_min_date_with_nans():
 def test_max_inat():
     # GH#40767 dont interpret iNaT as NaN
     ser = Series([1, iNaT])
-    gb = ser.groupby([1, 1])
+    key = np.array([1, 1], dtype=np.int64)
+    gb = ser.groupby(key)
 
     result = gb.max(min_count=2)
     expected = Series({1: 1}, dtype=np.int64)
@@ -107,6 +108,7 @@ def test_max_inat_not_all_na():
 
     # Note: in converting to float64, the iNaT + 1 maps to iNaT, i.e. is lossy
     expected = Series({1: np.nan, 2: np.nan, 3: iNaT + 1})
+    expected.index = expected.index.astype(np.int_)
     tm.assert_series_equal(result, expected, check_exact=True)
 
 

--- a/pandas/tests/groupby/test_min_max.py
+++ b/pandas/tests/groupby/test_min_max.py
@@ -108,7 +108,7 @@ def test_max_inat_not_all_na():
 
     # Note: in converting to float64, the iNaT + 1 maps to iNaT, i.e. is lossy
     expected = Series({1: np.nan, 2: np.nan, 3: iNaT + 1})
-    expected.index = expected.index.astype(np.int_)
+    expected.index = expected.index.astype(np.intp)
     tm.assert_series_equal(result, expected, check_exact=True)
 
 

--- a/pandas/tests/groupby/test_min_max.py
+++ b/pandas/tests/groupby/test_min_max.py
@@ -108,7 +108,7 @@ def test_max_inat_not_all_na():
 
     # Note: in converting to float64, the iNaT + 1 maps to iNaT, i.e. is lossy
     expected = Series({1: np.nan, 2: np.nan, 3: iNaT + 1})
-    expected.index = expected.index.astype(np.intp)
+    expected.index = expected.index.astype(np.int_)
     tm.assert_series_equal(result, expected, check_exact=True)
 
 

--- a/pandas/tests/groupby/test_nunique.py
+++ b/pandas/tests/groupby/test_nunique.py
@@ -172,7 +172,7 @@ def test_nunique_preserves_column_level_names():
     # GH 23222
     test = DataFrame([1, 2, 2], columns=pd.Index(["A"], name="level_0"))
     result = test.groupby([0, 0, 0]).nunique()
-    expected = DataFrame([2], index=np.array([0], dtype=np.int_), columns=test.columns)
+    expected = DataFrame([2], index=np.array([0], dtype=np.intp), columns=test.columns)
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/groupby/test_nunique.py
+++ b/pandas/tests/groupby/test_nunique.py
@@ -172,7 +172,7 @@ def test_nunique_preserves_column_level_names():
     # GH 23222
     test = DataFrame([1, 2, 2], columns=pd.Index(["A"], name="level_0"))
     result = test.groupby([0, 0, 0]).nunique()
-    expected = DataFrame([2], index=np.array([0], dtype=np.intp), columns=test.columns)
+    expected = DataFrame([2], index=np.array([0], dtype=np.int_), columns=test.columns)
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/groupby/test_nunique.py
+++ b/pandas/tests/groupby/test_nunique.py
@@ -172,7 +172,7 @@ def test_nunique_preserves_column_level_names():
     # GH 23222
     test = DataFrame([1, 2, 2], columns=pd.Index(["A"], name="level_0"))
     result = test.groupby([0, 0, 0]).nunique()
-    expected = DataFrame([2], columns=test.columns)
+    expected = DataFrame([2], index=np.array([0], dtype=np.int_), columns=test.columns)
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/groupby/test_size.py
+++ b/pandas/tests/groupby/test_size.py
@@ -36,6 +36,9 @@ def test_size_axis_1(df, axis_1, by, sort, dropna):
     expected = Series(counts, dtype="int64")
     if sort:
         expected = expected.sort_index()
+    if tm.is_integer_dtype(expected.index) and not any(x is None for x in by):
+        expected.index = expected.index.astype(np.int_)
+
     grouped = df.groupby(by=by, axis=axis_1, sort=sort, dropna=dropna)
     result = grouped.size()
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/groupby/test_size.py
+++ b/pandas/tests/groupby/test_size.py
@@ -37,7 +37,7 @@ def test_size_axis_1(df, axis_1, by, sort, dropna):
     if sort:
         expected = expected.sort_index()
     if tm.is_integer_dtype(expected.index) and not any(x is None for x in by):
-        expected.index = expected.index.astype(np.int_)
+        expected.index = expected.index.astype(np.intp)
 
     grouped = df.groupby(by=by, axis=axis_1, sort=sort, dropna=dropna)
     result = grouped.size()

--- a/pandas/tests/groupby/test_size.py
+++ b/pandas/tests/groupby/test_size.py
@@ -37,7 +37,7 @@ def test_size_axis_1(df, axis_1, by, sort, dropna):
     if sort:
         expected = expected.sort_index()
     if tm.is_integer_dtype(expected.index) and not any(x is None for x in by):
-        expected.index = expected.index.astype(np.intp)
+        expected.index = expected.index.astype(np.int_)
 
     grouped = df.groupby(by=by, axis=axis_1, sort=sort, dropna=dropna)
     result = grouped.size()

--- a/pandas/tests/groupby/test_value_counts.py
+++ b/pandas/tests/groupby/test_value_counts.py
@@ -182,7 +182,7 @@ def test_series_groupby_value_counts_on_categorical():
         data=[1, 0],
         index=MultiIndex.from_arrays(
             [
-                [0, 0],
+                np.array([0, 0]),
                 CategoricalIndex(
                     ["a", "b"], categories=["a", "b"], ordered=False, dtype="category"
                 ),

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -305,7 +305,7 @@ def test_transform_datetime_to_numeric():
         lambda x: x.dt.dayofweek - x.dt.dayofweek.min()
     )
 
-    expected = Series([0, 1], name="b")
+    expected = Series([0, 1], dtype=np.int32, name="b")
     tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -848,11 +848,7 @@ class NumericBase(Base):
 
         result = index.insert(0, index[0])
 
-        cls = type(index)
-        if cls is RangeIndex:
-            cls = Int64Index
-
-        expected = cls([index[0]] + list(index), dtype=index.dtype)
+        expected = Index([index[0]] + list(index), dtype=index.dtype)
         tm.assert_index_equal(result, expected, exact=True)
 
     def test_insert_na(self, nulls_fixture, simple_index):
@@ -863,7 +859,7 @@ class NumericBase(Base):
         if na_val is pd.NaT:
             expected = Index([index[0], pd.NaT] + list(index[1:]), dtype=object)
         else:
-            expected = Float64Index([index[0], np.nan] + list(index[1:]))
+            expected = Index([index[0], np.nan] + list(index[1:]))
 
             if index._is_backward_compat_public_numeric_index:
                 # GH#43921 we preserve NumericIndex

--- a/pandas/tests/indexes/datetimelike_/test_drop_duplicates.py
+++ b/pandas/tests/indexes/datetimelike_/test_drop_duplicates.py
@@ -35,12 +35,20 @@ class DropDuplicates:
     @pytest.mark.parametrize(
         "keep, expected, index",
         [
-            ("first", np.concatenate(([False] * 10, [True] * 5)), np.arange(0, 10)),
-            ("last", np.concatenate(([True] * 5, [False] * 10)), np.arange(5, 15)),
+            (
+                "first",
+                np.concatenate(([False] * 10, [True] * 5)),
+                np.arange(0, 10, dtype=np.int64),
+            ),
+            (
+                "last",
+                np.concatenate(([True] * 5, [False] * 10)),
+                np.arange(5, 15, dtype=np.int64),
+            ),
             (
                 False,
                 np.concatenate(([True] * 5, [False] * 5, [True] * 5)),
-                np.arange(5, 10),
+                np.arange(5, 10, dtype=np.int64),
             ),
         ],
     )
@@ -55,7 +63,8 @@ class DropDuplicates:
         tm.assert_index_equal(result, expected)
 
         result = Series(idx).drop_duplicates(keep=keep)
-        tm.assert_series_equal(result, Series(expected, index=index))
+        expected = Series(expected, index=index)
+        tm.assert_series_equal(result, expected)
 
 
 class TestDropDuplicatesPeriodIndex(DropDuplicates):

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -812,7 +812,7 @@ class TestDateRangeTZ:
 
         dr = date_range("2012-11-02", periods=10, tz=tzstr)
         result = dr.hour
-        expected = pd.Index([0] * 10)
+        expected = pd.Index([0] * 10, dtype="int32")
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("tzstr", ["US/Eastern", "dateutil/US/Eastern"])

--- a/pandas/tests/indexes/datetimes/test_misc.py
+++ b/pandas/tests/indexes/datetimes/test_misc.py
@@ -281,8 +281,9 @@ class TestDatetime64:
 
     def test_nanosecond_field(self):
         dti = DatetimeIndex(np.arange(10))
+        expected = Index(np.arange(10, dtype=np.int32))
 
-        tm.assert_index_equal(dti.nanosecond, Index(np.arange(10, dtype=np.int64)))
+        tm.assert_index_equal(dti.nanosecond, expected)
 
 
 def test_iter_readonly():

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -119,28 +119,28 @@ class TestDatetimeIndexTimezones:
         ts = ["2008-05-12 09:50:00", "2008-12-12 09:50:35", "2009-05-12 09:50:32"]
         tt = DatetimeIndex(ts).tz_localize("US/Eastern")
         ut = tt.tz_convert("UTC")
-        expected = Index([13, 14, 13])
+        expected = Index([13, 14, 13], dtype=np.int32)
         tm.assert_index_equal(ut.hour, expected)
 
         # sorted case UTC -> US/Eastern
         ts = ["2008-05-12 13:50:00", "2008-12-12 14:50:35", "2009-05-12 13:50:32"]
         tt = DatetimeIndex(ts).tz_localize("UTC")
         ut = tt.tz_convert("US/Eastern")
-        expected = Index([9, 9, 9])
+        expected = Index([9, 9, 9], dtype=np.int32)
         tm.assert_index_equal(ut.hour, expected)
 
         # unsorted case US/Eastern -> UTC
         ts = ["2008-05-12 09:50:00", "2008-12-12 09:50:35", "2008-05-12 09:50:32"]
         tt = DatetimeIndex(ts).tz_localize("US/Eastern")
         ut = tt.tz_convert("UTC")
-        expected = Index([13, 14, 13])
+        expected = Index([13, 14, 13], dtype=np.int32)
         tm.assert_index_equal(ut.hour, expected)
 
         # unsorted case UTC -> US/Eastern
         ts = ["2008-05-12 13:50:00", "2008-12-12 14:50:35", "2008-05-12 13:50:32"]
         tt = DatetimeIndex(ts).tz_localize("UTC")
         ut = tt.tz_convert("US/Eastern")
-        expected = Index([9, 9, 9])
+        expected = Index([9, 9, 9], dtype=np.int32)
         tm.assert_index_equal(ut.hour, expected)
 
     @pytest.mark.parametrize("tz", ["US/Eastern", "dateutil/US/Eastern"])
@@ -155,7 +155,7 @@ class TestDatetimeIndexTimezones:
         ]
         tt = DatetimeIndex(ts)
         ut = tt.tz_convert("UTC")
-        expected = Index([13, 14, 13])
+        expected = Index([13, 14, 13], dtype=np.int32)
         tm.assert_index_equal(ut.hour, expected)
 
         # sorted case UTC -> US/Eastern
@@ -166,7 +166,7 @@ class TestDatetimeIndexTimezones:
         ]
         tt = DatetimeIndex(ts)
         ut = tt.tz_convert("US/Eastern")
-        expected = Index([9, 9, 9])
+        expected = Index([9, 9, 9], dtype=np.int32)
         tm.assert_index_equal(ut.hour, expected)
 
         # unsorted case US/Eastern -> UTC
@@ -177,7 +177,7 @@ class TestDatetimeIndexTimezones:
         ]
         tt = DatetimeIndex(ts)
         ut = tt.tz_convert("UTC")
-        expected = Index([13, 14, 13])
+        expected = Index([13, 14, 13], dtype=np.int32)
         tm.assert_index_equal(ut.hour, expected)
 
         # unsorted case UTC -> US/Eastern
@@ -188,7 +188,7 @@ class TestDatetimeIndexTimezones:
         ]
         tt = DatetimeIndex(ts)
         ut = tt.tz_convert("US/Eastern")
-        expected = Index([9, 9, 9])
+        expected = Index([9, 9, 9], dtype=np.int32)
         tm.assert_index_equal(ut.hour, expected)
 
     @pytest.mark.parametrize("freq, n", [("H", 1), ("T", 60), ("S", 3600)])
@@ -200,7 +200,7 @@ class TestDatetimeIndexTimezones:
         idx = idx.tz_convert("Europe/Moscow")
 
         expected = np.repeat(np.array([3, 4, 5]), np.array([n, n, 1]))
-        tm.assert_index_equal(idx.hour, Index(expected))
+        tm.assert_index_equal(idx.hour, Index(expected, dtype=np.int32))
 
     def test_dti_tz_convert_dst(self):
         for freq, n in [("H", 1), ("T", 60), ("S", 3600)]:
@@ -213,7 +213,7 @@ class TestDatetimeIndexTimezones:
                 np.array([18, 19, 20, 21, 22, 23, 0, 1, 3, 4, 5]),
                 np.array([n, n, n, n, n, n, n, n, n, n, 1]),
             )
-            tm.assert_index_equal(idx.hour, Index(expected))
+            tm.assert_index_equal(idx.hour, Index(expected, dtype=np.int32))
 
             idx = date_range(
                 "2014-03-08 18:00", "2014-03-09 05:00", freq=freq, tz="US/Eastern"
@@ -223,7 +223,7 @@ class TestDatetimeIndexTimezones:
                 np.array([23, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
                 np.array([n, n, n, n, n, n, n, n, n, n, 1]),
             )
-            tm.assert_index_equal(idx.hour, Index(expected))
+            tm.assert_index_equal(idx.hour, Index(expected, dtype=np.int32))
 
             # End DST
             idx = date_range(
@@ -234,7 +234,7 @@ class TestDatetimeIndexTimezones:
                 np.array([19, 20, 21, 22, 23, 0, 1, 1, 2, 3, 4]),
                 np.array([n, n, n, n, n, n, n, n, n, n, 1]),
             )
-            tm.assert_index_equal(idx.hour, Index(expected))
+            tm.assert_index_equal(idx.hour, Index(expected, dtype=np.int32))
 
             idx = date_range(
                 "2014-11-01 18:00", "2014-11-02 05:00", freq=freq, tz="US/Eastern"
@@ -244,30 +244,30 @@ class TestDatetimeIndexTimezones:
                 np.array([22, 23, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
                 np.array([n, n, n, n, n, n, n, n, n, n, n, n, 1]),
             )
-            tm.assert_index_equal(idx.hour, Index(expected))
+            tm.assert_index_equal(idx.hour, Index(expected, dtype=np.int32))
 
         # daily
         # Start DST
         idx = date_range("2014-03-08 00:00", "2014-03-09 00:00", freq="D", tz="UTC")
         idx = idx.tz_convert("US/Eastern")
-        tm.assert_index_equal(idx.hour, Index([19, 19]))
+        tm.assert_index_equal(idx.hour, Index([19, 19], dtype=np.int32))
 
         idx = date_range(
             "2014-03-08 00:00", "2014-03-09 00:00", freq="D", tz="US/Eastern"
         )
         idx = idx.tz_convert("UTC")
-        tm.assert_index_equal(idx.hour, Index([5, 5]))
+        tm.assert_index_equal(idx.hour, Index([5, 5], dtype=np.int32))
 
         # End DST
         idx = date_range("2014-11-01 00:00", "2014-11-02 00:00", freq="D", tz="UTC")
         idx = idx.tz_convert("US/Eastern")
-        tm.assert_index_equal(idx.hour, Index([20, 20]))
+        tm.assert_index_equal(idx.hour, Index([20, 20], dtype=np.int32))
 
         idx = date_range(
             "2014-11-01 00:00", "2014-11-02 000:00", freq="D", tz="US/Eastern"
         )
         idx = idx.tz_convert("UTC")
-        tm.assert_index_equal(idx.hour, Index([4, 4]))
+        tm.assert_index_equal(idx.hour, Index([4, 4], dtype=np.int32))
 
     def test_tz_convert_roundtrip(self, tz_aware_fixture):
         tz = tz_aware_fixture
@@ -1125,7 +1125,7 @@ class TestDatetimeIndexTimezones:
             "2011-10-02 00:00", freq="h", periods=10, tz=prefix + "America/Atikokan"
         )
 
-        expected = Index(np.arange(10, dtype=np.int64))
+        expected = Index(np.arange(10, dtype=np.int32))
         tm.assert_index_equal(dr.hour, expected)
 
     @pytest.mark.parametrize("tz", [pytz.timezone("US/Eastern"), gettz("US/Eastern")])

--- a/pandas/tests/indexes/interval/test_constructors.py
+++ b/pandas/tests/indexes/interval/test_constructors.py
@@ -18,7 +18,6 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.api.types import is_unsigned_integer_dtype
 from pandas.core.api import NumericIndex
 from pandas.core.arrays import IntervalArray
 import pandas.core.common as com
@@ -321,12 +320,6 @@ class TuplesClassConstructorTests(ConstructorTests):
 class TestFromTuples(TuplesClassConstructorTests):
     """Tests specific to IntervalIndex.from_tuples"""
 
-    def _skip_test_constructor(self, dtype):
-        if is_unsigned_integer_dtype(dtype):
-            return True, "tuples don't have a dtype"
-        else:
-            return False, ""
-
     @pytest.fixture
     def constructor(self):
         return IntervalIndex.from_tuples
@@ -373,14 +366,6 @@ class TestFromTuples(TuplesClassConstructorTests):
 
 class TestClassConstructors(TuplesClassConstructorTests):
     """Tests specific to the IntervalIndex/Index constructors"""
-
-    def _skip_test_constructor(self, dtype):
-        # get_kwargs_from_breaks in TestFromTuples and TestClassconstructors just return
-        # tuples of ints, so IntervalIndex can't know the original dtype
-        if is_unsigned_integer_dtype(dtype):
-            return True, "tuples don't have a dtype"
-        else:
-            return False, ""
 
     @pytest.fixture(
         params=[IntervalIndex, partial(Index, dtype="interval")],

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -47,9 +47,9 @@ class TestIntervalIndex:
         assert index.size == 10
         assert index.shape == (10,)
 
-        tm.assert_index_equal(index.left, Index(np.arange(10)))
-        tm.assert_index_equal(index.right, Index(np.arange(1, 11)))
-        tm.assert_index_equal(index.mid, Index(np.arange(0.5, 10.5)))
+        tm.assert_index_equal(index.left, Index(np.arange(10, dtype=np.int64)))
+        tm.assert_index_equal(index.right, Index(np.arange(1, 11, dtype=np.int64)))
+        tm.assert_index_equal(index.mid, Index(np.arange(0.5, 10.5, dtype=np.float64)))
 
         assert index.closed == closed
 
@@ -160,7 +160,8 @@ class TestIntervalIndex:
         )
 
     def test_delete(self, closed):
-        expected = IntervalIndex.from_breaks(np.arange(1, 11), closed=closed)
+        breaks = np.arange(1, 11, dtype=np.int64)
+        expected = IntervalIndex.from_breaks(breaks, closed=closed)
         result = self.create_index(closed=closed).delete(0)
         tm.assert_index_equal(result, expected)
 

--- a/pandas/tests/indexes/interval/test_interval_range.py
+++ b/pandas/tests/indexes/interval/test_interval_range.py
@@ -29,7 +29,8 @@ class TestIntervalRange:
     @pytest.mark.parametrize("freq, periods", [(1, 100), (2.5, 40), (5, 20), (25, 4)])
     def test_constructor_numeric(self, closed, name, freq, periods):
         start, end = 0, 100
-        breaks = np.arange(101, step=freq)
+        dtype = np.int64 if is_integer(freq) else np.float64
+        breaks = np.arange(101, step=freq, dtype=dtype)
         expected = IntervalIndex.from_breaks(breaks, name=name, closed=closed)
 
         # defined from start/end/freq

--- a/pandas/tests/indexes/numeric/test_astype.py
+++ b/pandas/tests/indexes/numeric/test_astype.py
@@ -43,7 +43,7 @@ class TestAstype:
         # a float astype int
         idx = Index([0, 1, 2], dtype=np.float64)
         result = idx.astype(dtype)
-        expected = Index([0, 1, 2], dtype=np.int64)
+        expected = Index([0, 1, 2], dtype=dtype)
         tm.assert_index_equal(result, expected, exact=True)
 
         idx = Index([0, 1.1, 2], dtype=np.float64)
@@ -57,13 +57,7 @@ class TestAstype:
         # a float astype int
         idx = Index([0, 1, 2], dtype=np.float64)
         result = idx.astype(dtype)
-        expected = idx
-        tm.assert_index_equal(result, expected, exact=True)
-
-        idx = Index([0, 1.1, 2], dtype=np.float64)
-        result = idx.astype(dtype)
-        expected = Index(idx.values.astype(dtype))
-        tm.assert_index_equal(result, expected, exact=True)
+        assert isinstance(result, Index) and result.dtype == dtype
 
     @pytest.mark.parametrize("dtype", ["M8[ns]", "m8[ns]"])
     def test_astype_float_to_datetimelike(self, dtype):

--- a/pandas/tests/indexes/numeric/test_numeric.py
+++ b/pandas/tests/indexes/numeric/test_numeric.py
@@ -151,12 +151,6 @@ class TestFloatNumericIndex(NumericBase):
         with pytest.raises(ValueError, match=msg):
             Index([1, 2, 3.5], dtype=any_int_numpy_dtype)
 
-    def test_type_coercion_valid(self, float_numpy_dtype):
-        # There is no Float32Index, so we always
-        # generate Float64Index.
-        idx = Index([1, 2, 3.5], dtype=float_numpy_dtype)
-        tm.assert_index_equal(idx, Index([1, 2, 3.5]), exact=True)
-
     def test_equals_numeric(self):
         index_cls = self._index_cls
 
@@ -451,14 +445,14 @@ class TestIntNumericIndex(NumericInt):
         # GH#47475
         scalar = np.dtype(any_signed_int_numpy_dtype).type(1)
         result = Index([scalar])
-        expected = Index([1], dtype=np.int64)
+        expected = Index([1], dtype=any_signed_int_numpy_dtype)
         tm.assert_index_equal(result, expected, exact=True)
 
     def test_constructor_np_unsigned(self, any_unsigned_int_numpy_dtype):
         # GH#47475
         scalar = np.dtype(any_unsigned_int_numpy_dtype).type(1)
         result = Index([scalar])
-        expected = Index([1], dtype=np.uint64)
+        expected = Index([1], dtype=any_unsigned_int_numpy_dtype)
         tm.assert_index_equal(result, expected, exact=True)
 
     def test_coerce_list(self):

--- a/pandas/tests/indexes/ranges/test_join.py
+++ b/pandas/tests/indexes/ranges/test_join.py
@@ -66,7 +66,7 @@ class TestJoin:
         elidx = np.array([8, 9], dtype=np.intp)
         eridx = np.array([9, 7], dtype=np.intp)
 
-        assert isinstance(res, Int64Index)
+        assert isinstance(res, Index) and res.dtype == np.int64
         tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -218,7 +218,7 @@ class TestRangeIndex(NumericBase):
 
         loc = [0, 3, 5]
         result = idx.delete(loc)
-        expected = Int64Index([1, 2, 4])
+        expected = Index([1, 2, 4])
         tm.assert_index_equal(result, expected, exact=True)
 
         result = idx.delete(loc[::-1])
@@ -473,17 +473,17 @@ class TestRangeIndex(NumericBase):
 
         # positive slice values
         index_slice = index[7:10:2]
-        expected = Index(np.array([14, 18]), name="foo")
+        expected = Index([14, 18], name="foo")
         tm.assert_index_equal(index_slice, expected, exact="equiv")
 
         # negative slice values
         index_slice = index[-1:-5:-2]
-        expected = Index(np.array([18, 14]), name="foo")
+        expected = Index([18, 14], name="foo")
         tm.assert_index_equal(index_slice, expected, exact="equiv")
 
         # stop overshoot
         index_slice = index[2:100:4]
-        expected = Index(np.array([4, 12]), name="foo")
+        expected = Index([4, 12], name="foo")
         tm.assert_index_equal(index_slice, expected, exact="equiv")
 
         # reverse
@@ -492,7 +492,7 @@ class TestRangeIndex(NumericBase):
         tm.assert_index_equal(index_slice, expected, exact="equiv")
 
         index_slice = index[-8::-1]
-        expected = Index(np.array([4, 2, 0]), name="foo")
+        expected = Index([4, 2, 0], name="foo")
         tm.assert_index_equal(index_slice, expected, exact="equiv")
 
         index_slice = index[-40::-1]
@@ -536,8 +536,8 @@ class TestRangeIndex(NumericBase):
             ([RI(2), RI(2, 5), RI(5, 8, 4)], RI(0, 6)),
             ([RI(2), RI(3, 5), RI(5, 8, 4)], I64([0, 1, 3, 4, 5])),
             ([RI(-2, 2), RI(2, 5), RI(5, 8, 4)], RI(-2, 6)),
-            ([RI(3), I64([-1, 3, 15])], I64([0, 1, 2, -1, 3, 15])),
-            ([RI(3), F64([-1, 3.1, 15.0])], F64([0, 1, 2, -1, 3.1, 15.0])),
+            ([RI(3), OI([-1, 3, 15])], OI([0, 1, 2, -1, 3, 15])),
+            ([RI(3), OI([-1, 3.1, 15.0])], OI([0, 1, 2, -1, 3.1, 15.0])),
             ([RI(3), OI(["a", None, 14])], OI([0, 1, 2, "a", None, 14])),
             ([RI(3, 1), OI(["a", None, 14])], OI(["a", None, 14])),
         ]

--- a/pandas/tests/indexes/ranges/test_setops.py
+++ b/pandas/tests/indexes/ranges/test_setops.py
@@ -16,16 +16,15 @@ from pandas.core.indexes.api import (
     Index,
     Int64Index,
     RangeIndex,
-    UInt64Index,
 )
 
 
 class TestRangeIndexSetOps:
-    @pytest.mark.parametrize("klass", [RangeIndex, Int64Index, UInt64Index])
-    def test_intersection_mismatched_dtype(self, klass):
+    @pytest.mark.parametrize("dtype", [None, "int64", "uint64"])
+    def test_intersection_mismatched_dtype(self, dtype):
         # check that we cast to float, not object
         index = RangeIndex(start=0, stop=20, step=2, name="foo")
-        index = klass(index)
+        index = Index(index, dtype=dtype)
 
         flt = index.astype(np.float64)
 

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -554,7 +554,7 @@ class TestIndex(Base):
 
     def test_map_tseries_indices_accsr_return_index(self):
         date_index = tm.makeDateIndex(24, freq="h", name="hourly")
-        expected = Index(list(range(24)), dtype=np.int64, name="hourly")
+        expected = Index(range(24), dtype="int32", name="hourly")
         tm.assert_index_equal(expected, date_index.map(lambda x: x.hour), exact=True)
 
     @pytest.mark.parametrize(
@@ -587,7 +587,7 @@ class TestIndex(Base):
             # Cannot map duplicated index
             return
 
-        rng = np.arange(len(index), 0, -1)
+        rng = np.arange(len(index), 0, -1, dtype=np.int64)
 
         if index.empty:
             # to match proper result coercion for uints

--- a/pandas/tests/indexes/test_index_new.py
+++ b/pandas/tests/indexes/test_index_new.py
@@ -10,8 +10,6 @@ from decimal import Decimal
 import numpy as np
 import pytest
 
-from pandas.core.dtypes.common import is_unsigned_integer_dtype
-
 from pandas import (
     NA,
     Categorical,
@@ -86,12 +84,7 @@ class TestIndexConstructorInference:
     )
     def test_constructor_int_dtype_float(self, dtype):
         # GH#18400
-        if is_unsigned_integer_dtype(dtype):
-            expected_dtype = np.uint64
-        else:
-            expected_dtype = np.int64
-
-        expected = NumericIndex([0, 1, 2, 3], dtype=expected_dtype)
+        expected = NumericIndex([0, 1, 2, 3], dtype=dtype)
         result = Index([0.0, 1.0, 2.0, 3.0], dtype=dtype)
         tm.assert_index_equal(result, expected)
 

--- a/pandas/tests/indexes/test_numpy_compat.py
+++ b/pandas/tests/indexes/test_numpy_compat.py
@@ -10,10 +10,8 @@ from pandas import (
     isna,
 )
 import pandas._testing as tm
-from pandas.core.api import (
-    Float64Index,
-    NumericIndex,
-)
+from pandas.api.types import is_complex_dtype
+from pandas.core.api import NumericIndex
 from pandas.core.arrays import BooleanArray
 from pandas.core.indexes.datetimelike import DatetimeIndexOpsMixin
 
@@ -84,8 +82,18 @@ def test_numpy_ufuncs_basic(index, func):
 
         tm.assert_index_equal(result, exp)
         if type(index) is not Index or index.dtype == bool:
-            # i.e NumericIndex
-            assert isinstance(result, Float64Index)
+            assert type(result) is NumericIndex
+            if is_complex_dtype(index):
+                assert result.dtype == "complex64"
+            elif index.dtype in ["bool", "int8", "uint8"]:
+                # TODO: find out when index.dtype is float16 vs float32 (platform issue)
+                assert result.dtype in ["float16", "float32"]
+            elif index.dtype in ["float16"]:
+                assert result.dtype == "float16"
+            elif index.dtype in ["int16", "uint16", "float32"]:
+                assert result.dtype == "float32"
+            else:
+                assert result.dtype == "float64"
         else:
             # e.g. np.exp with Int64 -> Float64
             assert type(result) is Index

--- a/pandas/tests/indexes/test_numpy_compat.py
+++ b/pandas/tests/indexes/test_numpy_compat.py
@@ -86,10 +86,7 @@ def test_numpy_ufuncs_basic(index, func):
             if is_complex_dtype(index):
                 assert result.dtype == "complex64"
             elif index.dtype in ["bool", "int8", "uint8"]:
-                # TODO: find out when index.dtype is float16 vs float32 (platform issue)
                 assert result.dtype in ["float16", "float32"]
-            elif index.dtype in ["float16"]:
-                assert result.dtype == "float16"
             elif index.dtype in ["int16", "uint16", "float32"]:
                 assert result.dtype == "float32"
             else:

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -14,7 +14,6 @@ from pandas import (
 )
 import pandas._testing as tm
 from pandas.core.arrays import TimedeltaArray
-from pandas.core.indexes.api import Int64Index
 from pandas.tests.indexes.datetimelike import DatetimeLike
 
 randn = np.random.randn
@@ -56,7 +55,7 @@ class TestTimedeltaIndex(DatetimeLike):
 
         f = lambda x: x.days
         result = rng.map(f)
-        exp = Int64Index([f(x) for x in rng])
+        exp = Index([f(x) for x in rng], dtype=np.int32)
         tm.assert_index_equal(result, exp)
 
     def test_pass_TimedeltaIndex_to_index(self):
@@ -70,15 +69,16 @@ class TestTimedeltaIndex(DatetimeLike):
 
     def test_fields(self):
         rng = timedelta_range("1 days, 10:11:12.100123456", periods=2, freq="s")
-        tm.assert_index_equal(rng.days, Index([1, 1], dtype="int64"))
+        tm.assert_index_equal(rng.days, Index([1, 1], dtype=np.int32))
         tm.assert_index_equal(
             rng.seconds,
-            Index([10 * 3600 + 11 * 60 + 12, 10 * 3600 + 11 * 60 + 13], dtype="int64"),
+            Index([10 * 3600 + 11 * 60 + 12, 10 * 3600 + 11 * 60 + 13], dtype=np.int32),
         )
         tm.assert_index_equal(
-            rng.microseconds, Index([100 * 1000 + 123, 100 * 1000 + 123], dtype="int64")
+            rng.microseconds,
+            Index([100 * 1000 + 123, 100 * 1000 + 123], dtype=np.int32),
         )
-        tm.assert_index_equal(rng.nanoseconds, Index([456, 456], dtype="int64"))
+        tm.assert_index_equal(rng.nanoseconds, Index([456, 456], dtype=np.int32))
 
         msg = "'TimedeltaIndex' object has no attribute '{}'"
         with pytest.raises(AttributeError, match=msg.format("hours")):

--- a/pandas/tests/indexing/multiindex/test_partial.py
+++ b/pandas/tests/indexing/multiindex/test_partial.py
@@ -10,10 +10,6 @@ from pandas import (
     to_datetime,
 )
 import pandas._testing as tm
-from pandas.core.api import (
-    Float64Index,
-    Int64Index,
-)
 
 
 class TestMultiIndexPartial:
@@ -160,9 +156,9 @@ class TestMultiIndexPartial:
         mi = ser.index
         assert isinstance(mi, MultiIndex)
         if dtype is int:
-            assert isinstance(mi.levels[0], Int64Index)
+            assert mi.levels[0].dtype == np.int_
         else:
-            assert isinstance(mi.levels[0], Float64Index)
+            assert mi.levels[0].dtype == np.float64
 
         assert 14 not in mi.levels[0]
         assert not mi.levels[0]._should_fallback_to_positional

--- a/pandas/tests/indexing/multiindex/test_partial.py
+++ b/pandas/tests/indexing/multiindex/test_partial.py
@@ -156,7 +156,7 @@ class TestMultiIndexPartial:
         mi = ser.index
         assert isinstance(mi, MultiIndex)
         if dtype is int:
-            assert mi.levels[0].dtype == np.int_
+            assert mi.levels[0].dtype == np.intpq
         else:
             assert mi.levels[0].dtype == np.float64
 

--- a/pandas/tests/indexing/multiindex/test_partial.py
+++ b/pandas/tests/indexing/multiindex/test_partial.py
@@ -156,7 +156,7 @@ class TestMultiIndexPartial:
         mi = ser.index
         assert isinstance(mi, MultiIndex)
         if dtype is int:
-            assert mi.levels[0].dtype == np.intpq
+            assert mi.levels[0].dtype == np.intp
         else:
             assert mi.levels[0].dtype == np.float64
 

--- a/pandas/tests/indexing/multiindex/test_partial.py
+++ b/pandas/tests/indexing/multiindex/test_partial.py
@@ -156,7 +156,7 @@ class TestMultiIndexPartial:
         mi = ser.index
         assert isinstance(mi, MultiIndex)
         if dtype is int:
-            assert mi.levels[0].dtype == np.intp
+            assert mi.levels[0].dtype == np.int_
         else:
             assert mi.levels[0].dtype == np.float64
 

--- a/pandas/tests/indexing/multiindex/test_slice.py
+++ b/pandas/tests/indexing/multiindex/test_slice.py
@@ -729,7 +729,7 @@ class TestMultiIndexSlicers:
     def test_multiindex_slice_first_level(self):
         # GH 12697
         freq = ["a", "b", "c", "d"]
-        idx = MultiIndex.from_product([freq, np.arange(500)])
+        idx = MultiIndex.from_product([freq, range(500)])
         df = DataFrame(list(range(2000)), index=idx, columns=["Test"])
         df_slice = df.loc[pd.IndexSlice[:, 30:70], :]
         result = df_slice.loc["a"]

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -41,7 +41,7 @@ class TestFancy:
         # GH5508
 
         # len of indexer vs length of the 1d ndarray
-        df = DataFrame(index=Index(np.arange(1, 11)))
+        df = DataFrame(index=Index(np.arange(1, 11), dtype=np.int64))
         df["foo"] = np.zeros(10, dtype=np.float64)
         df["bar"] = np.zeros(10, dtype=complex)
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -436,7 +436,7 @@ class TestLocBaseIndependent:
         )
 
         msg = (
-            rf"\"None of \[NumericIndex\(\[1, 2\], dtype='{np.int_().dtype}'\)\] are "
+            rf"\"None of \[NumericIndex\(\[1, 2\], dtype='{np.intp().dtype}'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -454,7 +454,7 @@ class TestLocBaseIndependent:
             s.loc[-1]
 
         msg = (
-            rf"\"None of \[NumericIndex\(\[-1, -2\], dtype='{np.int_().dtype}'\)\] are "
+            rf"\"None of \[NumericIndex\(\[-1, -2\], dtype='{np.intp().dtype}'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -470,7 +470,7 @@ class TestLocBaseIndependent:
 
         s["a"] = 2
         msg = (
-            rf"\"None of \[NumericIndex\(\[-2\], dtype='{np.int_().dtype}'\)\] are "
+            rf"\"None of \[NumericIndex\(\[-2\], dtype='{np.intp().dtype}'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -487,7 +487,7 @@ class TestLocBaseIndependent:
         df = DataFrame([["a"], ["b"]], index=[1, 2], columns=["value"])
 
         msg = (
-            rf"\"None of \[NumericIndex\(\[3\], dtype='{np.int_().dtype}'\)\] are "
+            rf"\"None of \[NumericIndex\(\[3\], dtype='{np.intp().dtype}'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -505,7 +505,7 @@ class TestLocBaseIndependent:
         s.loc[[2]]
 
         msg = (
-            f"\"None of [NumericIndex([3], dtype='{np.int_().dtype}')] "
+            f"\"None of [NumericIndex([3], dtype='{np.intp().dtype}')] "
             'are in the [index]"'
         )
         with pytest.raises(KeyError, match=re.escape(msg)):
@@ -1195,7 +1195,7 @@ class TestLocBaseIndependent:
         df = DataFrame(columns=["x", "y"])
         df.index = df.index.astype(np.int64)
         msg = (
-            rf"None of \[NumericIndex\(\[0, 1\], dtype='{np.int_().dtype}'\)\] "
+            rf"None of \[NumericIndex\(\[0, 1\], dtype='{np.intp().dtype}'\)\] "
             r"are in the \[index\]"
         )
         with pytest.raises(KeyError, match=msg):

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -436,7 +436,7 @@ class TestLocBaseIndependent:
         )
 
         msg = (
-            rf"\"None of \[NumericIndex\(\[1, 2\], dtype='{np.intp().dtype}'\)\] are "
+            rf"\"None of \[NumericIndex\(\[1, 2\], dtype='{np.int_().dtype}'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -454,7 +454,7 @@ class TestLocBaseIndependent:
             s.loc[-1]
 
         msg = (
-            rf"\"None of \[NumericIndex\(\[-1, -2\], dtype='{np.intp().dtype}'\)\] are "
+            rf"\"None of \[NumericIndex\(\[-1, -2\], dtype='{np.int_().dtype}'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -470,7 +470,7 @@ class TestLocBaseIndependent:
 
         s["a"] = 2
         msg = (
-            rf"\"None of \[NumericIndex\(\[-2\], dtype='{np.intp().dtype}'\)\] are "
+            rf"\"None of \[NumericIndex\(\[-2\], dtype='{np.int_().dtype}'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -487,7 +487,7 @@ class TestLocBaseIndependent:
         df = DataFrame([["a"], ["b"]], index=[1, 2], columns=["value"])
 
         msg = (
-            rf"\"None of \[NumericIndex\(\[3\], dtype='{np.intp().dtype}'\)\] are "
+            rf"\"None of \[NumericIndex\(\[3\], dtype='{np.int_().dtype}'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -505,7 +505,7 @@ class TestLocBaseIndependent:
         s.loc[[2]]
 
         msg = (
-            f"\"None of [NumericIndex([3], dtype='{np.intp().dtype}')] "
+            f"\"None of [NumericIndex([3], dtype='{np.int_().dtype}')] "
             'are in the [index]"'
         )
         with pytest.raises(KeyError, match=re.escape(msg)):
@@ -1195,7 +1195,7 @@ class TestLocBaseIndependent:
         df = DataFrame(columns=["x", "y"])
         df.index = df.index.astype(np.int64)
         msg = (
-            rf"None of \[NumericIndex\(\[0, 1\], dtype='{np.intp().dtype}'\)\] "
+            rf"None of \[NumericIndex\(\[0, 1\], dtype='{np.int_().dtype}'\)\] "
             r"are in the \[index\]"
         )
         with pytest.raises(KeyError, match=msg):

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -436,7 +436,7 @@ class TestLocBaseIndependent:
         )
 
         msg = (
-            r"\"None of \[Int64Index\(\[1, 2\], dtype='int64'\)\] are "
+            rf"\"None of \[NumericIndex\(\[1, 2\], dtype='{np.int_().dtype}'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -454,7 +454,7 @@ class TestLocBaseIndependent:
             s.loc[-1]
 
         msg = (
-            r"\"None of \[Int64Index\(\[-1, -2\], dtype='int64'\)\] are "
+            rf"\"None of \[NumericIndex\(\[-1, -2\], dtype='{np.int_().dtype}'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -470,7 +470,7 @@ class TestLocBaseIndependent:
 
         s["a"] = 2
         msg = (
-            r"\"None of \[Int64Index\(\[-2\], dtype='int64'\)\] are "
+            rf"\"None of \[NumericIndex\(\[-2\], dtype='{np.int_().dtype}'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -487,7 +487,7 @@ class TestLocBaseIndependent:
         df = DataFrame([["a"], ["b"]], index=[1, 2], columns=["value"])
 
         msg = (
-            r"\"None of \[Int64Index\(\[3\], dtype='int64'\)\] are "
+            rf"\"None of \[NumericIndex\(\[3\], dtype='{np.int_().dtype}'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -504,12 +504,11 @@ class TestLocBaseIndependent:
 
         s.loc[[2]]
 
-        with pytest.raises(
-            KeyError,
-            match=re.escape(
-                "\"None of [Int64Index([3], dtype='int64')] are in the [index]\""
-            ),
-        ):
+        msg = (
+            f"\"None of [NumericIndex([3], dtype='{np.int_().dtype}')] "
+            'are in the [index]"'
+        )
+        with pytest.raises(KeyError, match=re.escape(msg)):
             s.loc[[3]]
 
         # a non-match and a match
@@ -1196,7 +1195,7 @@ class TestLocBaseIndependent:
         df = DataFrame(columns=["x", "y"])
         df.index = df.index.astype(np.int64)
         msg = (
-            r"None of \[Int64Index\(\[0, 1\], dtype='int64'\)\] "
+            rf"None of \[NumericIndex\(\[0, 1\], dtype='{np.int_().dtype}'\)\] "
             r"are in the \[index\]"
         )
         with pytest.raises(KeyError, match=msg):

--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -403,8 +403,8 @@ class TestPartialSetting:
 
         # raises as nothing is in the index
         msg = (
-            r"\"None of \[Int64Index\(\[3, 3, 3\], dtype='int64'\)\] are "
-            r"in the \[index\]\""
+            rf"\"None of \[NumericIndex\(\[3, 3, 3\], dtype='{np.int_().dtype}'\)\] "
+            r"are in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
             ser.loc[[3, 3, 3]]
@@ -484,7 +484,7 @@ class TestPartialSetting:
 
         # raises as nothing is in the index
         msg = (
-            r"\"None of \[Int64Index\(\[3, 3, 3\], dtype='int64', "
+            rf"\"None of \[NumericIndex\(\[3, 3, 3\], dtype='{np.int_().dtype}', "
             r"name='idx'\)\] are in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):

--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -403,7 +403,7 @@ class TestPartialSetting:
 
         # raises as nothing is in the index
         msg = (
-            rf"\"None of \[NumericIndex\(\[3, 3, 3\], dtype='{np.int_().dtype}'\)\] "
+            rf"\"None of \[NumericIndex\(\[3, 3, 3\], dtype='{np.intp().dtype}'\)\] "
             r"are in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -484,7 +484,7 @@ class TestPartialSetting:
 
         # raises as nothing is in the index
         msg = (
-            rf"\"None of \[NumericIndex\(\[3, 3, 3\], dtype='{np.int_().dtype}', "
+            rf"\"None of \[NumericIndex\(\[3, 3, 3\], dtype='{np.intp().dtype}', "
             r"name='idx'\)\] are in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):

--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -403,7 +403,7 @@ class TestPartialSetting:
 
         # raises as nothing is in the index
         msg = (
-            rf"\"None of \[NumericIndex\(\[3, 3, 3\], dtype='{np.intp().dtype}'\)\] "
+            rf"\"None of \[NumericIndex\(\[3, 3, 3\], dtype='{np.int_().dtype}'\)\] "
             r"are in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -484,7 +484,7 @@ class TestPartialSetting:
 
         # raises as nothing is in the index
         msg = (
-            rf"\"None of \[NumericIndex\(\[3, 3, 3\], dtype='{np.intp().dtype}', "
+            rf"\"None of \[NumericIndex\(\[3, 3, 3\], dtype='{np.int_().dtype}', "
             r"name='idx'\)\] are in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):

--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -737,7 +737,7 @@ class TestExcelWriter:
         tm.assert_frame_equal(xp, rs.to_period("M"))
 
     def test_to_excel_multiindex(self, merge_cells, frame, path):
-        arrays = np.arange(len(frame.index) * 2).reshape(2, -1)
+        arrays = np.arange(len(frame.index) * 2, dtype=np.int64).reshape(2, -1)
         new_index = MultiIndex.from_arrays(arrays, names=["first", "second"])
         frame.index = new_index
 
@@ -763,7 +763,7 @@ class TestExcelWriter:
     # sure they are handled correctly for either setting of
     # merge_cells
     def test_to_excel_multiindex_cols(self, merge_cells, frame, path):
-        arrays = np.arange(len(frame.index) * 2).reshape(2, -1)
+        arrays = np.arange(len(frame.index) * 2, dtype=np.int64).reshape(2, -1)
         new_index = MultiIndex.from_arrays(arrays, names=["first", "second"])
         frame.index = new_index
 
@@ -786,7 +786,7 @@ class TestExcelWriter:
 
     def test_to_excel_multiindex_dates(self, merge_cells, tsframe, path):
         # try multiindex with dates
-        new_index = [tsframe.index, np.arange(len(tsframe.index))]
+        new_index = [tsframe.index, np.arange(len(tsframe.index), dtype=np.int64)]
         tsframe.index = MultiIndex.from_arrays(new_index)
 
         tsframe.index.names = ["time", "foo"]

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -1328,7 +1328,6 @@ class TestDataFrameFormatting:
         # big mixed
         biggie = DataFrame(
             {"A": np.random.randn(200), "B": tm.makeStringIndex(200)},
-            index=np.arange(200),
         )
 
         biggie.loc[:20, "A"] = np.nan

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -399,12 +399,12 @@ class TestPandasContainer:
             left = read_json(inp, orient=orient, convert_axes=False)
             tm.assert_frame_equal(left, right)
 
-        right.index = np.arange(len(df))
+        right.index = pd.RangeIndex(len(df))
         inp = df.to_json(orient="records")
         left = read_json(inp, orient="records", convert_axes=False)
         tm.assert_frame_equal(left, right)
 
-        right.columns = np.arange(df.shape[1])
+        right.columns = pd.RangeIndex(df.shape[1])
         inp = df.to_json(orient="values")
         left = read_json(inp, orient="values", convert_axes=False)
         tm.assert_frame_equal(left, right)

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -829,6 +829,7 @@ class TestParquetPyArrow(Base):
 
         # GH #35791
         if partition_col:
+            expected_df = expected_df.astype(dict.fromkeys(partition_col, np.int32))
             partition_col_type = "category"
 
             expected_df[partition_col] = expected_df[partition_col].astype(

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -2842,7 +2842,7 @@ class TestXSQLite:
 
         frame["txt"] = ["a"] * len(frame)
         frame2 = frame.copy()
-        new_idx = Index(np.arange(len(frame2))) + 10
+        new_idx = Index(np.arange(len(frame2)), dtype=np.int64) + 10
         frame2["Idx"] = new_idx.copy()
         assert (
             sql.to_sql(frame2, name="test_table2", con=sqlite_buildin, index=False)

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -299,7 +299,10 @@ class TestStata:
         with tm.ensure_clean() as path:
             original.to_stata(path, convert_dates=None)
             written_and_read_again = self.read_dta(path)
-            tm.assert_frame_equal(written_and_read_again.set_index("index"), original)
+
+        expected = original.copy()
+        expected.index = expected.index.astype(np.int32)
+        tm.assert_frame_equal(written_and_read_again.set_index("index"), expected)
 
     def test_write_dta6(self, datapath):
         original = self.read_csv(datapath("io", "data", "stata", "stata3.csv"))
@@ -392,7 +395,10 @@ class TestStata:
                 original.to_stata(path, convert_dates=None)
 
             written_and_read_again = self.read_dta(path)
-            tm.assert_frame_equal(written_and_read_again.set_index("index"), formatted)
+
+        expected = formatted.copy()
+        expected.index = expected.index.astype(np.int32)
+        tm.assert_frame_equal(written_and_read_again.set_index("index"), expected)
 
     @pytest.mark.parametrize("version", [114, 117, 118, 119, None])
     def test_read_write_dta12(self, version):
@@ -429,7 +435,10 @@ class TestStata:
                 assert len(w) == 1
 
             written_and_read_again = self.read_dta(path)
-            tm.assert_frame_equal(written_and_read_again.set_index("index"), formatted)
+
+        expected = formatted.copy()
+        expected.index = expected.index.astype(np.int32)
+        tm.assert_frame_equal(written_and_read_again.set_index("index"), expected)
 
     def test_read_write_dta13(self):
         s1 = Series(2**9, dtype=np.int16)
@@ -444,7 +453,10 @@ class TestStata:
         with tm.ensure_clean() as path:
             original.to_stata(path)
             written_and_read_again = self.read_dta(path)
-            tm.assert_frame_equal(written_and_read_again.set_index("index"), formatted)
+
+        expected = formatted.copy()
+        expected.index = expected.index.astype(np.int32)
+        tm.assert_frame_equal(written_and_read_again.set_index("index"), expected)
 
     @pytest.mark.parametrize("version", [114, 117, 118, 119, None])
     @pytest.mark.parametrize(
@@ -461,7 +473,9 @@ class TestStata:
             parsed_114.to_stata(path, convert_dates={"date_td": "td"}, version=version)
             written_and_read_again = self.read_dta(path)
 
-        tm.assert_frame_equal(written_and_read_again.set_index("index"), parsed_114)
+        expected = parsed_114.copy()
+        expected.index = expected.index.astype(np.int32)
+        tm.assert_frame_equal(written_and_read_again.set_index("index"), expected)
 
     @pytest.mark.parametrize(
         "file", ["stata6_113", "stata6_114", "stata6_115", "stata6_117"]
@@ -516,11 +530,15 @@ class TestStata:
                 original.to_stata(path)
 
             written_and_read_again = self.read_dta(path)
-            written_and_read_again = written_and_read_again.set_index("index")
-            columns = list(written_and_read_again.columns)
-            convert_col_name = lambda x: int(x[1])
-            written_and_read_again.columns = map(convert_col_name, columns)
-            tm.assert_frame_equal(original, written_and_read_again)
+
+        written_and_read_again = written_and_read_again.set_index("index")
+        columns = list(written_and_read_again.columns)
+        convert_col_name = lambda x: int(x[1])
+        written_and_read_again.columns = map(convert_col_name, columns)
+
+        expected = original.copy()
+        expected.index = expected.index.astype(np.int32)
+        tm.assert_frame_equal(expected, written_and_read_again)
 
     @pytest.mark.parametrize("version", [114, 117, 118, 119, None])
     def test_nan_to_missing_value(self, version):
@@ -530,11 +548,15 @@ class TestStata:
         s2[1::2] = np.nan
         original = DataFrame({"s1": s1, "s2": s2})
         original.index.name = "index"
+
         with tm.ensure_clean() as path:
             original.to_stata(path, version=version)
             written_and_read_again = self.read_dta(path)
-            written_and_read_again = written_and_read_again.set_index("index")
-            tm.assert_frame_equal(written_and_read_again, original)
+
+        written_and_read_again = written_and_read_again.set_index("index")
+        expected = original.copy()
+        expected.index = expected.index.astype(np.int32)
+        tm.assert_frame_equal(written_and_read_again, expected)
 
     def test_no_index(self):
         columns = ["x", "y"]
@@ -554,7 +576,10 @@ class TestStata:
         with tm.ensure_clean() as path:
             original.to_stata(path)
             written_and_read_again = self.read_dta(path)
-            tm.assert_frame_equal(written_and_read_again.set_index("index"), original)
+
+        expected = original.copy()
+        expected.index = expected.index.astype(np.int32)
+        tm.assert_frame_equal(written_and_read_again.set_index("index"), expected)
 
     def test_large_value_conversion(self):
         s0 = Series([1, 99], dtype=np.int8)
@@ -568,11 +593,13 @@ class TestStata:
                 original.to_stata(path)
 
             written_and_read_again = self.read_dta(path)
-            modified = original.copy()
-            modified["s1"] = Series(modified["s1"], dtype=np.int16)
-            modified["s2"] = Series(modified["s2"], dtype=np.int32)
-            modified["s3"] = Series(modified["s3"], dtype=np.float64)
-            tm.assert_frame_equal(written_and_read_again.set_index("index"), modified)
+
+        modified = original.copy()
+        modified["s1"] = Series(modified["s1"], dtype=np.int16)
+        modified["s2"] = Series(modified["s2"], dtype=np.int32)
+        modified["s3"] = Series(modified["s3"], dtype=np.float64)
+        modified.index = original.index.astype(np.int32)
+        tm.assert_frame_equal(written_and_read_again.set_index("index"), modified)
 
     def test_dates_invalid_column(self):
         original = DataFrame([datetime(2006, 11, 19, 23, 13, 20)])
@@ -582,9 +609,11 @@ class TestStata:
                 original.to_stata(path, convert_dates={0: "tc"})
 
             written_and_read_again = self.read_dta(path)
-            modified = original.copy()
-            modified.columns = ["_0"]
-            tm.assert_frame_equal(written_and_read_again.set_index("index"), modified)
+
+        modified = original.copy()
+        modified.columns = ["_0"]
+        modified.index = original.index.astype(np.int32)
+        tm.assert_frame_equal(written_and_read_again.set_index("index"), modified)
 
     def test_105(self, datapath):
         # Data obtained from:
@@ -625,21 +654,32 @@ class TestStata:
             datetime(2006, 1, 1),
         ]  # Year
 
-        expected = DataFrame([expected_values], columns=columns)
-        expected.index.name = "index"
+        expected = DataFrame(
+            [expected_values],
+            index=pd.Index([0], dtype=np.int32, name="index"),
+            columns=columns,
+        )
+
         with tm.ensure_clean() as path:
             original.to_stata(path, convert_dates=conversions)
             written_and_read_again = self.read_dta(path)
-            tm.assert_frame_equal(written_and_read_again.set_index("index"), expected)
+
+        tm.assert_frame_equal(written_and_read_again.set_index("index"), expected)
 
     def test_write_missing_strings(self):
         original = DataFrame([["1"], [None]], columns=["foo"])
-        expected = DataFrame([["1"], [""]], columns=["foo"])
-        expected.index.name = "index"
+
+        expected = DataFrame(
+            [["1"], [""]],
+            index=pd.Index([0, 1], dtype=np.int32, name="index"),
+            columns=["foo"],
+        )
+
         with tm.ensure_clean() as path:
             original.to_stata(path)
             written_and_read_again = self.read_dta(path)
-            tm.assert_frame_equal(written_and_read_again.set_index("index"), expected)
+
+        tm.assert_frame_equal(written_and_read_again.set_index("index"), expected)
 
     @pytest.mark.parametrize("version", [114, 117, 118, 119, None])
     @pytest.mark.parametrize("byteorder", [">", "<"])
@@ -657,6 +697,7 @@ class TestStata:
         )
         original.index.name = "index"
         expected = original.copy()
+        expected.index = original.index.astype(np.int32)
         expected_types = (
             np.int8,
             np.int8,
@@ -672,8 +713,9 @@ class TestStata:
         with tm.ensure_clean() as path:
             original.to_stata(path, byteorder=byteorder, version=version)
             written_and_read_again = self.read_dta(path)
-            written_and_read_again = written_and_read_again.set_index("index")
-            tm.assert_frame_equal(written_and_read_again, expected)
+
+        written_and_read_again = written_and_read_again.set_index("index")
+        tm.assert_frame_equal(written_and_read_again, expected)
 
     def test_variable_labels(self, datapath):
         with StataReader(datapath("io", "data", "stata", "stata7_115.dta")) as rdr:
@@ -824,11 +866,12 @@ class TestStata:
             expected.index.name = "index"
             expected.to_stata(path, convert_dates=date_conversion)
             written_and_read_again = self.read_dta(path)
-            tm.assert_frame_equal(
-                written_and_read_again.set_index("index"),
-                expected,
-                check_datetimelike_compat=True,
-            )
+
+        tm.assert_frame_equal(
+            written_and_read_again.set_index("index"),
+            expected.set_index(expected.index.astype(np.int32)),
+            check_datetimelike_compat=True,
+        )
 
     def test_dtype_conversion(self, datapath):
         expected = self.read_csv(datapath("io", "data", "stata", "stata6.csv"))
@@ -942,7 +985,7 @@ class TestStata:
         original = pd.concat(
             [original[col].astype("category") for col in original], axis=1
         )
-        expected.index.name = "index"
+        expected.index = expected.index.set_names("index").astype(np.int32)
 
         expected["incompletely_labeled"] = expected["incompletely_labeled"].apply(str)
         expected["unlabeled"] = expected["unlabeled"].apply(str)
@@ -961,8 +1004,9 @@ class TestStata:
         with tm.ensure_clean() as path:
             original.to_stata(path, version=version)
             written_and_read_again = self.read_dta(path)
-            res = written_and_read_again.set_index("index")
-            tm.assert_frame_equal(res, expected)
+
+        res = written_and_read_again.set_index("index")
+        tm.assert_frame_equal(res, expected)
 
     def test_categorical_warnings_and_errors(self):
         # Warning for non-string labels
@@ -1006,15 +1050,17 @@ class TestStata:
         with tm.ensure_clean() as path:
             original.to_stata(path, version=version)
             written_and_read_again = self.read_dta(path)
-            res = written_and_read_again.set_index("index")
 
-            expected = original.copy()
-            for col in expected:
-                cat = expected[col]._values
-                new_cats = cat.remove_unused_categories().categories
-                cat = cat.set_categories(new_cats, ordered=True)
-                expected[col] = cat
-            tm.assert_frame_equal(res, expected)
+        res = written_and_read_again.set_index("index")
+
+        expected = original.copy()
+        for col in expected:
+            cat = expected[col]._values
+            new_cats = cat.remove_unused_categories().categories
+            cat = cat.set_categories(new_cats, ordered=True)
+            expected[col] = cat
+        expected.index = expected.index.astype(np.int32)
+        tm.assert_frame_equal(res, expected)
 
     @pytest.mark.parametrize("file", ["stata10_115", "stata10_117"])
     def test_categorical_order(self, file, datapath):
@@ -1462,8 +1508,11 @@ The repeated labels are:\n-+\nwolof
         with tm.ensure_clean() as path:
             original.to_stata(path)
             reread = read_stata(path)
-            original["ColumnTooBig"] = original["ColumnTooBig"].astype(np.float64)
-            tm.assert_frame_equal(original, reread.set_index("index"))
+
+        original["ColumnTooBig"] = original["ColumnTooBig"].astype(np.float64)
+        expected = original.copy()
+        expected.index = expected.index.astype(np.int32)
+        tm.assert_frame_equal(reread.set_index("index"), expected)
 
     @pytest.mark.parametrize("infval", [np.inf, -np.inf])
     def test_inf(self, infval):
@@ -1891,7 +1940,10 @@ def test_compression(compression, version, use_dict, infer):
         elif compression is None:
             fp = path
         reread = read_stata(fp, index_col="index")
-        tm.assert_frame_equal(reread, df)
+
+    expected = df.copy()
+    expected.index = expected.index.astype(np.int32)
+    tm.assert_frame_equal(reread, expected)
 
 
 @pytest.mark.parametrize("method", ["zip", "infer"])
@@ -1912,20 +1964,29 @@ def test_compression_dict(method, file_ext):
         else:
             fp = path
         reread = read_stata(fp, index_col="index")
-        tm.assert_frame_equal(reread, df)
+
+    expected = df.copy()
+    expected.index = expected.index.astype(np.int32)
+    tm.assert_frame_equal(reread, expected)
 
 
 @pytest.mark.parametrize("version", [114, 117, 118, 119, None])
 def test_chunked_categorical(version):
     df = DataFrame({"cats": Series(["a", "b", "a", "b", "c"], dtype="category")})
     df.index.name = "index"
+
+    expected = df.copy()
+    expected.index = expected.index.astype(np.int32)
+
     with tm.ensure_clean() as path:
         df.to_stata(path, version=version)
         with StataReader(path, chunksize=2, order_categoricals=False) as reader:
             for i, block in enumerate(reader):
                 block = block.set_index("index")
                 assert "cats" in block
-                tm.assert_series_equal(block.cats, df.cats.iloc[2 * i : 2 * (i + 1)])
+                tm.assert_series_equal(
+                    block.cats, expected.cats.iloc[2 * i : 2 * (i + 1)]
+                )
 
 
 def test_chunked_categorical_partial(datapath):

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -646,7 +646,7 @@ def test_selection_api_validation():
     # non DatetimeIndex
     msg = (
         "Only valid with DatetimeIndex, TimedeltaIndex or PeriodIndex, "
-        "but got an instance of 'Int64Index'"
+        "but got an instance of 'NumericIndex'"
     )
     with pytest.raises(TypeError, match=msg):
         df.resample("2D", level="v")

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -316,7 +316,7 @@ def test_resample_groupby_with_label():
     result = df.groupby("col0").resample("1W", label="left").sum()
 
     mi = [
-        np.array([0, 0, 1, 2]),
+        np.array([0, 0, 1, 2], dtype=np.int64),
         pd.to_datetime(
             np.array(["1999-12-26", "2000-01-02", "2000-01-02", "2000-01-02"])
         ),

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -355,7 +355,7 @@ class TestMerge:
         lkey = np.array([1])
         rkey = np.array([2])
         df = merge(df1, df2, left_on=lkey, right_on=rkey, how="outer")
-        assert df["key_0"].dtype == "int64"
+        assert df["key_0"].dtype == "int_"
 
     def test_handle_join_key_pass_array(self):
         left = DataFrame(
@@ -379,9 +379,8 @@ class TestMerge:
         rkey = np.array([1, 1, 2, 3, 4, 5])
 
         merged = merge(left, right, left_on=lkey, right_on=rkey, how="outer")
-        tm.assert_series_equal(
-            merged["key_0"], Series([1, 1, 1, 1, 2, 2, 3, 4, 5], name="key_0")
-        )
+        expected = Series([1, 1, 1, 1, 2, 2, 3, 4, 5], dtype=np.int_, name="key_0")
+        tm.assert_series_equal(merged["key_0"], expected)
 
         left = DataFrame({"value": np.arange(3)})
         right = DataFrame({"rvalue": np.arange(6)})
@@ -2469,7 +2468,7 @@ def test_categorical_non_unique_monotonic(n_categories):
     df2 = DataFrame(
         [[6]],
         columns=["value"],
-        index=CategoricalIndex([0], categories=np.arange(n_categories)),
+        index=CategoricalIndex([0], categories=list(range(n_categories))),
     )
 
     result = merge(df1, df2, how="left", left_index=True, right_index=True)

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -355,7 +355,7 @@ class TestMerge:
         lkey = np.array([1])
         rkey = np.array([2])
         df = merge(df1, df2, left_on=lkey, right_on=rkey, how="outer")
-        assert df["key_0"].dtype == np.intp
+        assert df["key_0"].dtype == np.int_
 
     def test_handle_join_key_pass_array(self):
         left = DataFrame(
@@ -379,7 +379,7 @@ class TestMerge:
         rkey = np.array([1, 1, 2, 3, 4, 5])
 
         merged = merge(left, right, left_on=lkey, right_on=rkey, how="outer")
-        expected = Series([1, 1, 1, 1, 2, 2, 3, 4, 5], dtype=np.intp, name="key_0")
+        expected = Series([1, 1, 1, 1, 2, 2, 3, 4, 5], dtype=np.int_, name="key_0")
         tm.assert_series_equal(merged["key_0"], expected)
 
         left = DataFrame({"value": np.arange(3)})

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -355,7 +355,7 @@ class TestMerge:
         lkey = np.array([1])
         rkey = np.array([2])
         df = merge(df1, df2, left_on=lkey, right_on=rkey, how="outer")
-        assert df["key_0"].dtype == "int_"
+        assert df["key_0"].dtype == np.intp
 
     def test_handle_join_key_pass_array(self):
         left = DataFrame(
@@ -379,7 +379,7 @@ class TestMerge:
         rkey = np.array([1, 1, 2, 3, 4, 5])
 
         merged = merge(left, right, left_on=lkey, right_on=rkey, how="outer")
-        expected = Series([1, 1, 1, 1, 2, 2, 3, 4, 5], dtype=np.int_, name="key_0")
+        expected = Series([1, 1, 1, 1, 2, 2, 3, 4, 5], dtype=np.intp, name="key_0")
         tm.assert_series_equal(merged["key_0"], expected)
 
         left = DataFrame({"value": np.arange(3)})

--- a/pandas/tests/reshape/merge/test_multi.py
+++ b/pandas/tests/reshape/merge/test_multi.py
@@ -6,6 +6,7 @@ from pandas import (
     DataFrame,
     Index,
     MultiIndex,
+    RangeIndex,
     Series,
     Timestamp,
 )
@@ -118,7 +119,7 @@ class TestMergeMulti:
 
             out = merge(left, right.reset_index(), on=icols, sort=sort, how="left")
 
-            res.index = np.arange(len(res))
+            res.index = RangeIndex(len(res))
             tm.assert_frame_equal(out, res)
 
         lc = list(map(chr, np.arange(ord("a"), ord("z") + 1)))
@@ -370,7 +371,7 @@ class TestMergeMulti:
 
         # GH7331 - maintain left frame order in left merge
         result = merge(left, right.reset_index(), how="left", on="tag")
-        expected.index = np.arange(len(expected))
+        expected.index = RangeIndex(len(expected))
         tm.assert_frame_equal(result, expected)
 
     def test_left_merge_na_buglet(self):
@@ -441,14 +442,13 @@ class TestMergeMulti:
         if klass is not None:
             on_vector = klass(on_vector)
 
-        expected = DataFrame({"a": [1, 2, 3], "key_1": [2016, 2017, 2018]})
+        exp_years = np.array([2016, 2017, 2018], dtype=np.int32)
+        expected = DataFrame({"a": [1, 2, 3], "key_1": exp_years})
 
         result = df.merge(df, on=["a", on_vector], how="inner")
         tm.assert_frame_equal(result, expected)
 
-        expected = DataFrame(
-            {"key_0": [2016, 2017, 2018], "a_x": [1, 2, 3], "a_y": [1, 2, 3]}
-        )
+        expected = DataFrame({"key_0": exp_years, "a_x": [1, 2, 3], "a_y": [1, 2, 3]})
 
         result = df.merge(df, on=[df.index.year], how="inner")
         tm.assert_frame_equal(result, expected)
@@ -852,14 +852,13 @@ class TestJoinMultiMulti:
         if box is not None:
             on_vector = box(on_vector)
 
-        expected = DataFrame({"a": [1, 2, 3], "key_1": [2016, 2017, 2018]})
+        exp_years = np.array([2016, 2017, 2018], dtype=np.int32)
+        expected = DataFrame({"a": [1, 2, 3], "key_1": exp_years})
 
         result = df.merge(df, on=["a", on_vector], how="inner")
         tm.assert_frame_equal(result, expected)
 
-        expected = DataFrame(
-            {"key_0": [2016, 2017, 2018], "a_x": [1, 2, 3], "a_y": [1, 2, 3]}
-        )
+        expected = DataFrame({"key_0": exp_years, "a_x": [1, 2, 3], "a_y": [1, 2, 3]})
 
         result = df.merge(df, on=[df.index.year], how="inner")
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/reshape/test_crosstab.py
+++ b/pandas/tests/reshape/test_crosstab.py
@@ -112,7 +112,7 @@ class TestCrosstab:
         # GH 17005
         a = Series([0, 1, 1], index=["a", "b", "c"])
         b = Series([3, 4, 3, 4, 3], index=["a", "b", "c", "d", "f"])
-        c = np.array([3, 4, 3])
+        c = np.array([3, 4, 3], dtype=np.int64)
 
         expected = DataFrame(
             [[1, 0], [1, 1]],

--- a/pandas/tests/reshape/test_cut.py
+++ b/pandas/tests/reshape/test_cut.py
@@ -87,7 +87,9 @@ def test_bins_from_interval_index_doc_example():
     # Make sure we preserve the bins.
     ages = np.array([10, 15, 13, 12, 23, 25, 28, 59, 60])
     c = cut(ages, bins=[0, 18, 35, 70])
-    expected = IntervalIndex.from_tuples([(0, 18), (18, 35), (35, 70)])
+    expected = IntervalIndex.from_arrays(
+        left=np.array([0, 18, 35]), right=np.array([18, 35, 70])
+    )
     tm.assert_index_equal(c.categories, expected)
 
     result = cut([25, 20, 50], bins=c.categories)

--- a/pandas/tests/reshape/test_get_dummies.py
+++ b/pandas/tests/reshape/test_get_dummies.py
@@ -11,6 +11,7 @@ from pandas import (
     Categorical,
     CategoricalIndex,
     DataFrame,
+    RangeIndex,
     Series,
     get_dummies,
 )
@@ -471,7 +472,7 @@ class TestGetDummies:
         s_series = Series(s_list)
         s_series_index = Series(s_list, list("ABC"))
 
-        expected = DataFrame(index=np.arange(3))
+        expected = DataFrame(index=RangeIndex(3))
 
         result = get_dummies(s_list, drop_first=True, sparse=sparse)
         tm.assert_frame_equal(result, expected)
@@ -504,7 +505,7 @@ class TestGetDummies:
         res_just_na = get_dummies(
             [np.nan], dummy_na=True, drop_first=True, sparse=sparse
         )
-        exp_just_na = DataFrame(index=np.arange(1))
+        exp_just_na = DataFrame(index=RangeIndex(1))
         tm.assert_frame_equal(res_just_na, exp_just_na)
 
     def test_dataframe_dummies_drop_first(self, df, sparse):

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -831,7 +831,7 @@ class TestWideToLong:
             "A": [],
             "B": [],
         }
-        expected = DataFrame(exp_data).astype({"year": "int"})
+        expected = DataFrame(exp_data).astype({"year": np.int64})
         expected = expected.set_index(["id", "year"])[
             ["X", "A2010", "A2011", "B2010", "A", "B"]
         ]
@@ -894,7 +894,7 @@ class TestWideToLong:
             "A": [],
             "B": [],
         }
-        expected = DataFrame(exp_data).astype({"year": "int"})
+        expected = DataFrame(exp_data).astype({"year": np.int64})
 
         expected = expected.set_index(["id", "year"])
         expected.index = expected.index.set_levels([0, 1], level=0)

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -409,7 +409,14 @@ class TestPivotTable:
         res = df.pivot_table(index=df.index.month, columns=df.index.day)
 
         exp_columns = MultiIndex.from_tuples([("A", 1), ("A", 2)])
-        exp = DataFrame([[2.5, 4.0], [2.0, np.nan]], index=[1, 2], columns=exp_columns)
+        exp_columns = exp_columns.set_levels(
+            exp_columns.levels[1].astype(np.int32), level=1
+        )
+        exp = DataFrame(
+            [[2.5, 4.0], [2.0, np.nan]],
+            index=Index([1, 2], dtype=np.int32),
+            columns=exp_columns,
+        )
         tm.assert_frame_equal(res, exp)
 
         df = DataFrame(
@@ -422,7 +429,9 @@ class TestPivotTable:
         res = df.pivot_table(index=df.index.month, columns=Grouper(key="dt", freq="M"))
         exp_columns = MultiIndex.from_tuples([("A", pd.Timestamp("2011-01-31"))])
         exp_columns.names = [None, "dt"]
-        exp = DataFrame([3.25, 2.0], index=[1, 2], columns=exp_columns)
+        exp = DataFrame(
+            [3.25, 2.0], index=Index([1, 2], dtype=np.int32), columns=exp_columns
+        )
         tm.assert_frame_equal(res, exp)
 
         res = df.pivot_table(
@@ -1614,7 +1623,7 @@ class TestPivotTable:
         expected = DataFrame(
             {7: [0, 3], 8: [1, 4], 9: [2, 5]},
             index=exp_idx,
-            columns=Index([7, 8, 9], name="dt1"),
+            columns=Index([7, 8, 9], dtype=np.int32, name="dt1"),
         )
         tm.assert_frame_equal(result, expected)
 
@@ -1624,8 +1633,8 @@ class TestPivotTable:
 
         expected = DataFrame(
             {7: [0, 3], 8: [1, 4], 9: [2, 5]},
-            index=Index([1, 2], name="dt2"),
-            columns=Index([7, 8, 9], name="dt1"),
+            index=Index([1, 2], dtype=np.int32, name="dt2"),
+            columns=Index([7, 8, 9], dtype=np.int32, name="dt1"),
         )
         tm.assert_frame_equal(result, expected)
 
@@ -1637,10 +1646,16 @@ class TestPivotTable:
         )
 
         exp_col = MultiIndex.from_arrays(
-            [[7, 7, 8, 8, 9, 9], [1, 2] * 3], names=["dt1", "dt2"]
+            [
+                np.array([7, 7, 8, 8, 9, 9], dtype=np.int32),
+                np.array([1, 2] * 3, dtype=np.int32),
+            ],
+            names=["dt1", "dt2"],
         )
         expected = DataFrame(
-            np.array([[0, 3, 1, 4, 2, 5]], dtype="int64"), index=[2013], columns=exp_col
+            np.array([[0, 3, 1, 4, 2, 5]], dtype="int64"),
+            index=Index([2013], dtype=np.int32),
+            columns=exp_col,
         )
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/reshape/test_util.py
+++ b/pandas/tests/reshape/test_util.py
@@ -23,8 +23,8 @@ class TestCartesianProduct:
         # make sure that the ordering on datetimeindex is consistent
         x = date_range("2000-01-01", periods=2)
         result1, result2 = (Index(y).day for y in cartesian_product([x, x]))
-        expected1 = Index([1, 1, 2, 2])
-        expected2 = Index([1, 2, 1, 2])
+        expected1 = Index([1, 1, 2, 2], dtype=np.int32)
+        expected2 = Index([1, 2, 1, 2], dtype=np.int32)
         tm.assert_index_equal(result1, expected1)
         tm.assert_index_equal(result2, expected2)
 

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -229,14 +229,14 @@ class TestSeriesDatetimeValues:
         dti = date_range("20140204", periods=3, freq="s")
         ser = Series(dti, index=index, name="xxx")
         exp = Series(
-            np.array([2014, 2014, 2014], dtype="int64"), index=index, name="xxx"
+            np.array([2014, 2014, 2014], dtype="int32"), index=index, name="xxx"
         )
         tm.assert_series_equal(ser.dt.year, exp)
 
-        exp = Series(np.array([2, 2, 2], dtype="int64"), index=index, name="xxx")
+        exp = Series(np.array([2, 2, 2], dtype="int32"), index=index, name="xxx")
         tm.assert_series_equal(ser.dt.month, exp)
 
-        exp = Series(np.array([0, 1, 2], dtype="int64"), index=index, name="xxx")
+        exp = Series(np.array([0, 1, 2], dtype="int32"), index=index, name="xxx")
         tm.assert_series_equal(ser.dt.second, exp)
 
         exp = Series([ser[0]] * 3, index=index, name="xxx")
@@ -386,7 +386,7 @@ class TestSeriesDatetimeValues:
         dti = DatetimeIndex(["20171111", "20181212"]).repeat(2)
         ser = Series(pd.Categorical(dti), name="foo")
         result = ser.dt.year
-        expected = Series([2017, 2017, 2018, 2018], name="foo")
+        expected = Series([2017, 2017, 2018, 2018], dtype="int32", name="foo")
         tm.assert_series_equal(result, expected)
 
     def test_dt_tz_localize_categorical(self, tz_aware_fixture):
@@ -741,6 +741,7 @@ class TestSeriesDatetimeValues:
         result = dt_series.dt.hour
         expected = Series(
             [0, 1, 2, 3, 4],
+            dtype="int32",
             index=[2, 6, 7, 8, 11],
         )
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -793,7 +793,8 @@ class SetitemCastingEquivalents:
         mask[key] = True
 
         res = Index(obj).where(~mask, val)
-        tm.assert_index_equal(res, Index(expected, dtype=expected.dtype))
+        expected_idx = Index(expected, dtype=expected.dtype)
+        tm.assert_index_equal(res, expected_idx)
 
     def test_index_putmask(self, obj, key, expected, val):
         mask = np.zeros(obj.shape, dtype=bool)
@@ -1153,7 +1154,7 @@ class TestSetitemFloatNDarrayIntoIntegerSeries(SetitemCastingEquivalents):
         return Series(res_values)
 
 
-@pytest.mark.parametrize("val", [np.int16(512), np.int16(512)])
+@pytest.mark.parametrize("val", [512, np.int16(512)])
 class TestSetitemIntoIntegerSeriesNeedsUpcast(SetitemCastingEquivalents):
     @pytest.fixture
     def obj(self):
@@ -1168,7 +1169,7 @@ class TestSetitemIntoIntegerSeriesNeedsUpcast(SetitemCastingEquivalents):
         return Series([1, 512, 3], dtype=np.int16)
 
 
-@pytest.mark.parametrize("val", [2**30 + 1.0, 2**33 + 1.1, 2**62])
+@pytest.mark.parametrize("val", [2**33 + 1.0, 2**33 + 1.1, 2**62])
 class TestSmallIntegerSetitemUpcast(SetitemCastingEquivalents):
     # https://github.com/pandas-dev/pandas/issues/39584#issuecomment-941212124
     @pytest.fixture
@@ -1181,12 +1182,10 @@ class TestSmallIntegerSetitemUpcast(SetitemCastingEquivalents):
 
     @pytest.fixture
     def expected(self, val):
-        if val > np.iinfo(np.int64).max:
+        if val % 1 != 0:
             dtype = "f8"
-        elif val > np.iinfo(np.int32).max:
-            dtype = "i8"
         else:
-            dtype = "i4"
+            dtype = "i8"
         return Series([val, 2, 3], dtype=dtype)
 
 

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -1153,7 +1153,7 @@ class TestSetitemFloatNDarrayIntoIntegerSeries(SetitemCastingEquivalents):
         return Series(res_values)
 
 
-@pytest.mark.parametrize("val", [512, np.int16(512)])
+@pytest.mark.parametrize("val", [np.int16(512), np.int16(512)])
 class TestSetitemIntoIntegerSeriesNeedsUpcast(SetitemCastingEquivalents):
     @pytest.fixture
     def obj(self):
@@ -1168,7 +1168,7 @@ class TestSetitemIntoIntegerSeriesNeedsUpcast(SetitemCastingEquivalents):
         return Series([1, 512, 3], dtype=np.int16)
 
 
-@pytest.mark.parametrize("val", [2**33 + 1.0, 2**33 + 1.1, 2**62])
+@pytest.mark.parametrize("val", [2**30 + 1.0, 2**33 + 1.1, 2**62])
 class TestSmallIntegerSetitemUpcast(SetitemCastingEquivalents):
     # https://github.com/pandas-dev/pandas/issues/39584#issuecomment-941212124
     @pytest.fixture
@@ -1181,10 +1181,12 @@ class TestSmallIntegerSetitemUpcast(SetitemCastingEquivalents):
 
     @pytest.fixture
     def expected(self, val):
-        if val % 1 != 0:
+        if val > np.iinfo(np.int64).max:
             dtype = "f8"
-        else:
+        elif val > np.iinfo(np.int32).max:
             dtype = "i8"
+        else:
+            dtype = "i4"
         return Series([val, 2, 3], dtype=dtype)
 
 

--- a/pandas/tests/series/methods/test_reindex.py
+++ b/pandas/tests/series/methods/test_reindex.py
@@ -126,7 +126,7 @@ def test_reindex_pad():
     reindexed2 = s2.reindex(s.index, method="ffill")
     tm.assert_series_equal(reindexed, reindexed2)
 
-    expected = Series([0, 0, 2, 2, 4, 4, 6, 6, 8, 8], index=np.arange(10))
+    expected = Series([0, 0, 2, 2, 4, 4, 6, 6, 8, 8])
     tm.assert_series_equal(reindexed, expected)
 
     # GH4604

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1214,7 +1214,7 @@ class TestSeriesConstructors:
         # construction from interval & array of intervals
         intervals = interval_constructor.from_breaks(np.arange(3), closed="right")
         result = Series(intervals)
-        assert result.dtype == f"interval[int64, right]"
+        assert result.dtype == "interval[int64, right]"
         tm.assert_index_equal(Index(result.values), Index(intervals))
 
     @pytest.mark.parametrize(

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1214,7 +1214,7 @@ class TestSeriesConstructors:
         # construction from interval & array of intervals
         intervals = interval_constructor.from_breaks(np.arange(3), closed="right")
         result = Series(intervals)
-        assert result.dtype == "interval[int64, right]"
+        assert result.dtype == f"interval[int64, right]"
         tm.assert_index_equal(Index(result.values), Index(intervals))
 
     @pytest.mark.parametrize(

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -322,7 +322,7 @@ Categories (3, int64): [1, 2, 3]"""
         assert repr(s) == exp
 
         s = Series(Categorical(np.arange(10)))
-        exp = """0    0
+        exp = f"""0    0
 1    1
 2    2
 3    3
@@ -333,7 +333,7 @@ Categories (3, int64): [1, 2, 3]"""
 8    8
 9    9
 dtype: category
-Categories (10, int64): [0, 1, 2, 3, ..., 6, 7, 8, 9]"""
+Categories (10, {np.int_().dtype}): [0, 1, 2, 3, ..., 6, 7, 8, 9]"""
 
         assert repr(s) == exp
 
@@ -348,7 +348,7 @@ Categories (3, int64): [1 < 2 < 3]"""
         assert repr(s) == exp
 
         s = Series(Categorical(np.arange(10), ordered=True))
-        exp = """0    0
+        exp = f"""0    0
 1    1
 2    2
 3    3
@@ -359,7 +359,7 @@ Categories (3, int64): [1 < 2 < 3]"""
 8    8
 9    9
 dtype: category
-Categories (10, int64): [0 < 1 < 2 < 3 ... 6 < 7 < 8 < 9]"""
+Categories (10, {np.int_().dtype}): [0 < 1 < 2 < 3 ... 6 < 7 < 8 < 9]"""
 
         assert repr(s) == exp
 

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -333,7 +333,7 @@ Categories (3, int64): [1, 2, 3]"""
 8    8
 9    9
 dtype: category
-Categories (10, {np.intp().dtype}): [0, 1, 2, 3, ..., 6, 7, 8, 9]"""
+Categories (10, {np.int_().dtype}): [0, 1, 2, 3, ..., 6, 7, 8, 9]"""
 
         assert repr(s) == exp
 
@@ -359,7 +359,7 @@ Categories (3, int64): [1 < 2 < 3]"""
 8    8
 9    9
 dtype: category
-Categories (10, {np.intp().dtype}): [0 < 1 < 2 < 3 ... 6 < 7 < 8 < 9]"""
+Categories (10, {np.int_().dtype}): [0 < 1 < 2 < 3 ... 6 < 7 < 8 < 9]"""
 
         assert repr(s) == exp
 

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -333,7 +333,7 @@ Categories (3, int64): [1, 2, 3]"""
 8    8
 9    9
 dtype: category
-Categories (10, {np.int_().dtype}): [0, 1, 2, 3, ..., 6, 7, 8, 9]"""
+Categories (10, {np.intp().dtype}): [0, 1, 2, 3, ..., 6, 7, 8, 9]"""
 
         assert repr(s) == exp
 
@@ -359,7 +359,7 @@ Categories (3, int64): [1 < 2 < 3]"""
 8    8
 9    9
 dtype: category
-Categories (10, {np.int_().dtype}): [0 < 1 < 2 < 3 ... 6 < 7 < 8 < 9]"""
+Categories (10, {np.intp().dtype}): [0 < 1 < 2 < 3 ... 6 < 7 < 8 < 9]"""
 
         assert repr(s) == exp
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -1776,7 +1776,7 @@ class TestTseriesUtil:
 
         # corner case
         old = Index([5, 10])
-        new = Index(np.arange(5))
+        new = Index(np.arange(5, dtype=np.int64))
         filler = libalgos.pad["int64_t"](old.values, new.values)
         expect_filler = np.array([-1, -1, -1, -1, -1], dtype=np.intp)
         tm.assert_numpy_array_equal(filler, expect_filler)

--- a/pandas/tests/util/test_assert_categorical_equal.py
+++ b/pandas/tests/util/test_assert_categorical_equal.py
@@ -22,8 +22,8 @@ def test_categorical_equal_order_mismatch(check_category_order):
         msg = """Categorical\\.categories are different
 
 Categorical\\.categories values are different \\(100\\.0 %\\)
-\\[left\\]:  Int64Index\\(\\[1, 2, 3, 4\\], dtype='int64'\\)
-\\[right\\]: Int64Index\\(\\[4, 3, 2, 1\\], dtype='int64'\\)"""
+\\[left\\]:  NumericIndex\\(\\[1, 2, 3, 4]\\, dtype='int64'\\)
+\\[right\\]: NumericIndex\\(\\[4, 3, 2, 1\\], dtype='int64'\\)"""
         with pytest.raises(AssertionError, match=msg):
             tm.assert_categorical_equal(c1, c2, **kwargs)
     else:
@@ -34,8 +34,8 @@ def test_categorical_equal_categories_mismatch():
     msg = """Categorical\\.categories are different
 
 Categorical\\.categories values are different \\(25\\.0 %\\)
-\\[left\\]:  Int64Index\\(\\[1, 2, 3, 4\\], dtype='int64'\\)
-\\[right\\]: Int64Index\\(\\[1, 2, 3, 5\\], dtype='int64'\\)"""
+\\[left\\]:  NumericIndex\\(\\[1, 2, 3, 4\\], dtype='int64'\\)
+\\[right\\]: NumericIndex\\(\\[1, 2, 3, 5\\], dtype='int64'\\)"""
 
     c1 = Categorical([1, 2, 3, 4])
     c2 = Categorical([1, 2, 3, 5])

--- a/pandas/tests/util/test_assert_categorical_equal.py
+++ b/pandas/tests/util/test_assert_categorical_equal.py
@@ -22,7 +22,7 @@ def test_categorical_equal_order_mismatch(check_category_order):
         msg = """Categorical\\.categories are different
 
 Categorical\\.categories values are different \\(100\\.0 %\\)
-\\[left\\]:  NumericIndex\\(\\[1, 2, 3, 4]\\, dtype='int64'\\)
+\\[left\\]:  NumericIndex\\(\\[1, 2, 3, 4\\], dtype='int64'\\)
 \\[right\\]: NumericIndex\\(\\[4, 3, 2, 1\\], dtype='int64'\\)"""
         with pytest.raises(AssertionError, match=msg):
             tm.assert_categorical_equal(c1, c2, **kwargs)

--- a/pandas/tests/util/test_assert_index_equal.py
+++ b/pandas/tests/util/test_assert_index_equal.py
@@ -17,7 +17,7 @@ def test_index_equal_levels_mismatch():
     msg = """Index are different
 
 Index levels are different
-\\[left\\]:  1, Int64Index\\(\\[1, 2, 3\\], dtype='int64'\\)
+\\[left\\]:  1, NumericIndex\\(\\[1, 2, 3\\], dtype='int64'\\)
 \\[right\\]: 2, MultiIndex\\(\\[\\('A', 1\\),
             \\('A', 2\\),
             \\('B', 3\\),
@@ -35,8 +35,8 @@ def test_index_equal_values_mismatch(check_exact):
     msg = """MultiIndex level \\[1\\] are different
 
 MultiIndex level \\[1\\] values are different \\(25\\.0 %\\)
-\\[left\\]:  Int64Index\\(\\[2, 2, 3, 4\\], dtype='int64'\\)
-\\[right\\]: Int64Index\\(\\[1, 2, 3, 4\\], dtype='int64'\\)"""
+\\[left\\]:  NumericIndex\\(\\[2, 2, 3, 4\\], dtype='int64'\\)
+\\[right\\]: NumericIndex\\(\\[1, 2, 3, 4\\], dtype='int64'\\)"""
 
     idx1 = MultiIndex.from_tuples([("A", 2), ("A", 2), ("B", 3), ("B", 4)])
     idx2 = MultiIndex.from_tuples([("A", 1), ("A", 2), ("B", 3), ("B", 4)])
@@ -49,8 +49,8 @@ def test_index_equal_length_mismatch(check_exact):
     msg = """Index are different
 
 Index length are different
-\\[left\\]:  3, Int64Index\\(\\[1, 2, 3\\], dtype='int64'\\)
-\\[right\\]: 4, Int64Index\\(\\[1, 2, 3, 4\\], dtype='int64'\\)"""
+\\[left\\]:  3, NumericIndex\\(\\[1, 2, 3\\], dtype='int64'\\)
+\\[right\\]: 4, NumericIndex\\(\\[1, 2, 3, 4\\], dtype='int64'\\)"""
 
     idx1 = Index([1, 2, 3])
     idx2 = Index([1, 2, 3, 4])
@@ -67,22 +67,29 @@ def test_index_equal_class(exact):
     tm.assert_index_equal(idx1, idx2, exact=exact)
 
 
-@pytest.mark.parametrize(
-    "idx_values, msg_str",
-    [
-        [[1, 2, 3.0], "Float64Index\\(\\[1\\.0, 2\\.0, 3\\.0\\], dtype='float64'\\)"],
-        [range(3), "RangeIndex\\(start=0, stop=3, step=1\\)"],
-    ],
-)
-def test_index_equal_class_mismatch(check_exact, idx_values, msg_str):
-    msg = f"""Index are different
+def test_int_float_index_equal_class_mismatch(check_exact):
+    msg = """Index are different
 
-Index classes are different
-\\[left\\]:  Int64Index\\(\\[1, 2, 3\\], dtype='int64'\\)
-\\[right\\]: {msg_str}"""
+Attribute "inferred_type" are different
+\\[left\\]:  integer
+\\[right\\]: floating"""
 
     idx1 = Index([1, 2, 3])
-    idx2 = Index(idx_values)
+    idx2 = Index([1, 2, 3], dtype=np.float64)
+
+    with pytest.raises(AssertionError, match=msg):
+        tm.assert_index_equal(idx1, idx2, exact=True, check_exact=check_exact)
+
+
+def test_range_index_equal_class_mismatch(check_exact):
+    msg = """Index are different
+
+Index classes are different
+\\[left\\]:  NumericIndex\\(\\[1, 2, 3\\], dtype='int64'\\)
+\\[right\\]: """
+
+    idx1 = Index([1, 2, 3])
+    idx2 = RangeIndex(range(3))
 
     with pytest.raises(AssertionError, match=msg):
         tm.assert_index_equal(idx1, idx2, exact=True, check_exact=check_exact)
@@ -96,8 +103,8 @@ def test_index_equal_values_close(check_exact):
         msg = """Index are different
 
 Index values are different \\(33\\.33333 %\\)
-\\[left\\]:  Float64Index\\(\\[1.0, 2.0, 3.0], dtype='float64'\\)
-\\[right\\]: Float64Index\\(\\[1.0, 2.0, 3.0000000001\\], dtype='float64'\\)"""
+\\[left\\]:  NumericIndex\\(\\[1.0, 2.0, 3.0], dtype='float64'\\)
+\\[right\\]: NumericIndex\\(\\[1.0, 2.0, 3.0000000001\\], dtype='float64'\\)"""
 
         with pytest.raises(AssertionError, match=msg):
             tm.assert_index_equal(idx1, idx2, check_exact=check_exact)
@@ -114,8 +121,8 @@ def test_index_equal_values_less_close(check_exact, rtol):
         msg = """Index are different
 
 Index values are different \\(33\\.33333 %\\)
-\\[left\\]:  Float64Index\\(\\[1.0, 2.0, 3.0], dtype='float64'\\)
-\\[right\\]: Float64Index\\(\\[1.0, 2.0, 3.0001\\], dtype='float64'\\)"""
+\\[left\\]:  NumericIndex\\(\\[1.0, 2.0, 3.0], dtype='float64'\\)
+\\[right\\]: NumericIndex\\(\\[1.0, 2.0, 3.0001\\], dtype='float64'\\)"""
 
         with pytest.raises(AssertionError, match=msg):
             tm.assert_index_equal(idx1, idx2, **kwargs)
@@ -131,8 +138,8 @@ def test_index_equal_values_too_far(check_exact, rtol):
     msg = """Index are different
 
 Index values are different \\(33\\.33333 %\\)
-\\[left\\]:  Int64Index\\(\\[1, 2, 3\\], dtype='int64'\\)
-\\[right\\]: Int64Index\\(\\[1, 2, 4\\], dtype='int64'\\)"""
+\\[left\\]:  NumericIndex\\(\\[1, 2, 3\\], dtype='int64'\\)
+\\[right\\]: NumericIndex\\(\\[1, 2, 4\\], dtype='int64'\\)"""
 
     with pytest.raises(AssertionError, match=msg):
         tm.assert_index_equal(idx1, idx2, **kwargs)
@@ -146,8 +153,8 @@ def test_index_equal_value_oder_mismatch(check_exact, rtol, check_order):
     msg = """Index are different
 
 Index values are different \\(66\\.66667 %\\)
-\\[left\\]:  Int64Index\\(\\[1, 2, 3\\], dtype='int64'\\)
-\\[right\\]: Int64Index\\(\\[3, 2, 1\\], dtype='int64'\\)"""
+\\[left\\]:  NumericIndex\\(\\[1, 2, 3\\], dtype='int64'\\)
+\\[right\\]: NumericIndex\\(\\[3, 2, 1\\], dtype='int64'\\)"""
 
     if check_order:
         with pytest.raises(AssertionError, match=msg):
@@ -168,8 +175,8 @@ def test_index_equal_level_values_mismatch(check_exact, rtol):
     msg = """MultiIndex level \\[1\\] are different
 
 MultiIndex level \\[1\\] values are different \\(25\\.0 %\\)
-\\[left\\]:  Int64Index\\(\\[2, 2, 3, 4\\], dtype='int64'\\)
-\\[right\\]: Int64Index\\(\\[1, 2, 3, 4\\], dtype='int64'\\)"""
+\\[left\\]:  NumericIndex\\(\\[2, 2, 3, 4\\], dtype='int64'\\)
+\\[right\\]: NumericIndex\\(\\[1, 2, 3, 4\\], dtype='int64'\\)"""
 
     with pytest.raises(AssertionError, match=msg):
         tm.assert_index_equal(idx1, idx2, **kwargs)
@@ -225,7 +232,7 @@ Index are different
 
 Index classes are different
 \\[left\\]:  RangeIndex\\(start=0, stop=10, step=1\\)
-\\[right\\]: Int64Index\\(\\[0, 1, 2, 3, 4, 5, 6, 7, 8, 9\\], dtype='int64'\\)"""
+\\[right\\]: NumericIndex\\(\\[0, 1, 2, 3, 4, 5, 6, 7, 8, 9\\], dtype='int64'\\)"""
 
     rcat = CategoricalIndex(RangeIndex(10))
     icat = CategoricalIndex(list(range(10)))

--- a/pandas/tests/window/conftest.py
+++ b/pandas/tests/window/conftest.py
@@ -130,7 +130,6 @@ def frame():
     return DataFrame(
         np.random.randn(100, 10),
         index=bdate_range(datetime(2009, 1, 1), periods=100),
-        columns=np.arange(10),
     )
 
 

--- a/pandas/tests/window/test_groupby.py
+++ b/pandas/tests/window/test_groupby.py
@@ -897,10 +897,11 @@ class TestRolling:
         )
         tm.assert_frame_equal(result, expected)
 
-    def test_nan_and_zero_endpoints(self):
+    def test_nan_and_zero_endpoints(self, any_int_numpy_dtype):
         # https://github.com/twosigma/pandas/issues/53
+        dtype = np.dtype(any_int_numpy_dtype).type
         size = 1000
-        idx = np.repeat(0, size)
+        idx = np.repeat(dtype(0), size)
         idx[-1] = 1
 
         val = 5e25
@@ -919,7 +920,10 @@ class TestRolling:
             arr,
             name="adl2",
             index=MultiIndex.from_arrays(
-                [[0] * 999 + [1], [0] * 999 + [1]], names=["index", "index"]
+                [
+                    Index([0] * 999 + [1], dtype=dtype, name="index"),
+                    Index([0] * 999 + [1], dtype=dtype, name="index"),
+                ],
             ),
         )
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/window/test_groupby.py
+++ b/pandas/tests/window/test_groupby.py
@@ -919,10 +919,7 @@ class TestRolling:
             arr,
             name="adl2",
             index=MultiIndex.from_arrays(
-                [
-                    Index([0] * 999 + [1], dtype=np.int_, name="index"),
-                    Index([0] * 999 + [1], dtype=np.int_, name="index"),
-                ],
+                [[0] * 999 + [1], [0] * 999 + [1]], names=["index", "index"]
             ),
         )
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/window/test_groupby.py
+++ b/pandas/tests/window/test_groupby.py
@@ -811,7 +811,7 @@ class TestRolling:
         expected_result = DataFrame(
             np.array(expected, dtype="float64"),
             index=MultiIndex(
-                levels=[[1, 2], [0, 1, 2, 3, 4, 5, 6, 7]],
+                levels=[np.array([1, 2]), [0, 1, 2, 3, 4, 5, 6, 7]],
                 codes=[[0, 0, 0, 0, 1, 1, 1, 1], [0, 2, 4, 6, 1, 3, 5, 7]],
             ),
         )
@@ -919,7 +919,10 @@ class TestRolling:
             arr,
             name="adl2",
             index=MultiIndex.from_arrays(
-                [[0] * 999 + [1], [0] * 999 + [1]], names=["index", "index"]
+                [
+                    Index([0] * 999 + [1], dtype=np.int_, name="index"),
+                    Index([0] * 999 + [1], dtype=np.int_, name="index"),
+                ],
             ),
         )
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/window/test_pairwise.py
+++ b/pandas/tests/window/test_pairwise.py
@@ -99,7 +99,6 @@ def test_flex_binary_frame(method, frame):
     exp = DataFrame(
         {k: getattr(frame[k].rolling(window=10), method)(frame2[k]) for k in frame}
     )
-    exp.columns = exp.columns.astype(np.int_)
     tm.assert_frame_equal(res3, exp)
 
 

--- a/pandas/tests/window/test_pairwise.py
+++ b/pandas/tests/window/test_pairwise.py
@@ -99,6 +99,7 @@ def test_flex_binary_frame(method, frame):
     exp = DataFrame(
         {k: getattr(frame[k].rolling(window=10), method)(frame2[k]) for k in frame}
     )
+    exp.columns = exp.columns.astype(np.int_)
     tm.assert_frame_equal(res3, exp)
 
 
@@ -429,7 +430,11 @@ class TestPairwise:
         expected = DataFrame(
             np.nan,
             index=MultiIndex.from_arrays(
-                [np.repeat(np.arange(5), 2), ["M", "N"] * 5, ["P", "Q"] * 5],
+                [
+                    np.repeat(np.arange(5, dtype=np.int64), 2),
+                    ["M", "N"] * 5,
+                    ["P", "Q"] * 5,
+                ],
                 names=[None, "a", "b"],
             ),
             columns=columns,


### PR DESCRIPTION
This is #49560, but without #50195, as a draft.

Locally, It looks like #49560 doesn't need #50195 to pass the tests, so I'm trying if the same is true in the github CI.

 @jbrockmendel