### PR TITLE
STYLE rename fixtures and enable redefined-outer-name on tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -303,6 +303,12 @@ repos:
         files: ^pandas/
         exclude: ^(pandas/_libs/|pandas/tests/|pandas/errors/__init__.py$|pandas/_version.py)
         types: [python]
+    -   id: rename-test-fixtures
+        name: Rename test fixtures
+        entry: python -m scripts.rename_test_fixtures
+        language: python
+        files: ^pandas/
+        types: [python]
     -   id: flake8-pyi
         name: flake8-pyi
         entry: flake8 --extend-ignore=E301,E302,E305,E701,E704

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -235,8 +235,8 @@ for name in "QuarterBegin QuarterEnd BQuarterBegin BQuarterEnd".split():
     )
 
 
-@pytest.fixture
-def add_doctest_imports(doctest_namespace) -> None:
+@pytest.fixture(name="add_doctest_imports")
+def fixture_add_doctest_imports(doctest_namespace) -> None:
     """
     Make `np` and `pd` names available for doctests.
     """
@@ -247,8 +247,8 @@ def add_doctest_imports(doctest_namespace) -> None:
 # ----------------------------------------------------------------
 # Autouse fixtures
 # ----------------------------------------------------------------
-@pytest.fixture(autouse=True)
-def configure_tests() -> None:
+@pytest.fixture(name="configure_tests", autouse=True)
+def fixture_configure_tests() -> None:
     """
     Configure settings for all tests and test modules.
     """
@@ -258,8 +258,10 @@ def configure_tests() -> None:
 # ----------------------------------------------------------------
 # Common arguments
 # ----------------------------------------------------------------
-@pytest.fixture(params=[0, 1, "index", "columns"], ids=lambda x: f"axis={repr(x)}")
-def axis(request):
+@pytest.fixture(
+    name="axis", params=[0, 1, "index", "columns"], ids=lambda x: f"axis={repr(x)}"
+)
+def fixture_axis(request):
     """
     Fixture for returning the axis numbers of a DataFrame.
     """
@@ -269,16 +271,16 @@ def axis(request):
 axis_frame = axis
 
 
-@pytest.fixture(params=[1, "columns"], ids=lambda x: f"axis={repr(x)}")
-def axis_1(request):
+@pytest.fixture(name="axis_1", params=[1, "columns"], ids=lambda x: f"axis={repr(x)}")
+def fixture_axis_1(request):
     """
     Fixture for returning aliases of axis 1 of a DataFrame.
     """
     return request.param
 
 
-@pytest.fixture(params=[True, False, None])
-def observed(request):
+@pytest.fixture(name="observed", params=[True, False, None])
+def fixture_observed(request):
     """
     Pass in the observed keyword to groupby for [True, False]
     This indicates whether categoricals should return values for
@@ -290,16 +292,16 @@ def observed(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False, None])
-def ordered(request):
+@pytest.fixture(name="ordered", params=[True, False, None])
+def fixture_ordered(request):
     """
     Boolean 'ordered' parameter for Categorical.
     """
     return request.param
 
 
-@pytest.fixture(params=["first", "last", False])
-def keep(request):
+@pytest.fixture(name="keep", params=["first", "last", False])
+def fixture_keep(request):
     """
     Valid values for the 'keep' parameter used in
     .duplicated or .drop_duplicates
@@ -307,24 +309,26 @@ def keep(request):
     return request.param
 
 
-@pytest.fixture(params=["both", "neither", "left", "right"])
-def inclusive_endpoints_fixture(request):
+@pytest.fixture(
+    name="inclusive_endpoints_fixture", params=["both", "neither", "left", "right"]
+)
+def fixture_inclusive_endpoints_fixture(request):
     """
     Fixture for trying all interval 'inclusive' parameters.
     """
     return request.param
 
 
-@pytest.fixture(params=["left", "right", "both", "neither"])
-def closed(request):
+@pytest.fixture(name="closed", params=["left", "right", "both", "neither"])
+def fixture_closed(request):
     """
     Fixture for trying all interval closed parameters.
     """
     return request.param
 
 
-@pytest.fixture(params=["left", "right", "both", "neither"])
-def other_closed(request):
+@pytest.fixture(name="other_closed", params=["left", "right", "both", "neither"])
+def fixture_other_closed(request):
     """
     Secondary closed fixture to allow parametrizing over all pairs of closed.
     """
@@ -332,6 +336,7 @@ def other_closed(request):
 
 
 @pytest.fixture(
+    name="compression",
     params=[
         None,
         "gzip",
@@ -340,9 +345,9 @@ def other_closed(request):
         "xz",
         "tar",
         pytest.param("zstd", marks=td.skip_if_no("zstandard")),
-    ]
+    ],
 )
-def compression(request):
+def fixture_compression(request):
     """
     Fixture for trying common compression types in compression tests.
     """
@@ -350,6 +355,7 @@ def compression(request):
 
 
 @pytest.fixture(
+    name="compression_only",
     params=[
         "gzip",
         "bz2",
@@ -357,9 +363,9 @@ def compression(request):
         "xz",
         "tar",
         pytest.param("zstd", marks=td.skip_if_no("zstandard")),
-    ]
+    ],
 )
-def compression_only(request):
+def fixture_compression_only(request):
     """
     Fixture for trying common compression types in compression tests excluding
     uncompressed case.
@@ -367,24 +373,24 @@ def compression_only(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def writable(request):
+@pytest.fixture(name="writable", params=[True, False])
+def fixture_writable(request):
     """
     Fixture that an array is writable.
     """
     return request.param
 
 
-@pytest.fixture(params=["inner", "outer", "left", "right"])
-def join_type(request):
+@pytest.fixture(name="join_type", params=["inner", "outer", "left", "right"])
+def fixture_join_type(request):
     """
     Fixture for trying all types of join operations.
     """
     return request.param
 
 
-@pytest.fixture(params=["nlargest", "nsmallest"])
-def nselect_method(request):
+@pytest.fixture(name="nselect_method", params=["nlargest", "nsmallest"])
+def fixture_nselect_method(request):
     """
     Fixture for trying all nselect methods.
     """
@@ -394,8 +400,10 @@ def nselect_method(request):
 # ----------------------------------------------------------------
 # Missing values & co.
 # ----------------------------------------------------------------
-@pytest.fixture(params=tm.NULL_OBJECTS, ids=lambda x: type(x).__name__)
-def nulls_fixture(request):
+@pytest.fixture(
+    name="nulls_fixture", params=tm.NULL_OBJECTS, ids=lambda x: type(x).__name__
+)
+def fixture_nulls_fixture(request):
     """
     Fixture for each null type in pandas.
     """
@@ -405,8 +413,8 @@ def nulls_fixture(request):
 nulls_fixture2 = nulls_fixture  # Generate cartesian product of nulls_fixture
 
 
-@pytest.fixture(params=[None, np.nan, pd.NaT])
-def unique_nulls_fixture(request):
+@pytest.fixture(name="unique_nulls_fixture", params=[None, np.nan, pd.NaT])
+def fixture_unique_nulls_fixture(request):
     """
     Fixture for each null type in pandas, each null type exactly once.
     """
@@ -417,8 +425,10 @@ def unique_nulls_fixture(request):
 unique_nulls_fixture2 = unique_nulls_fixture
 
 
-@pytest.fixture(params=tm.NP_NAT_OBJECTS, ids=lambda x: type(x).__name__)
-def np_nat_fixture(request):
+@pytest.fixture(
+    name="np_nat_fixture", params=tm.NP_NAT_OBJECTS, ids=lambda x: type(x).__name__
+)
+def fixture_np_nat_fixture(request):
     """
     Fixture for each NaT type in numpy.
     """
@@ -434,16 +444,16 @@ np_nat_fixture2 = np_nat_fixture
 # ----------------------------------------------------------------
 
 
-@pytest.fixture(params=[DataFrame, Series])
-def frame_or_series(request):
+@pytest.fixture(name="frame_or_series", params=[DataFrame, Series])
+def fixture_frame_or_series(request):
     """
     Fixture to parametrize over DataFrame and Series.
     """
     return request.param
 
 
-@pytest.fixture(params=[Index, Series], ids=["index", "series"])
-def index_or_series(request):
+@pytest.fixture(name="index_or_series", params=[Index, Series], ids=["index", "series"])
+def fixture_index_or_series(request):
     """
     Fixture to parametrize over Index and Series, made necessary by a mypy
     bug, giving an error:
@@ -459,16 +469,24 @@ def index_or_series(request):
 index_or_series2 = index_or_series
 
 
-@pytest.fixture(params=[Index, Series, pd.array], ids=["index", "series", "array"])
-def index_or_series_or_array(request):
+@pytest.fixture(
+    name="index_or_series_or_array",
+    params=[Index, Series, pd.array],
+    ids=["index", "series", "array"],
+)
+def fixture_index_or_series_or_array(request):
     """
     Fixture to parametrize over Index, Series, and ExtensionArray
     """
     return request.param
 
 
-@pytest.fixture(params=[Index, Series, DataFrame, pd.array], ids=lambda x: x.__name__)
-def box_with_array(request):
+@pytest.fixture(
+    name="box_with_array",
+    params=[Index, Series, DataFrame, pd.array],
+    ids=lambda x: x.__name__,
+)
+def fixture_box_with_array(request):
     """
     Fixture to test behavior for Index, Series, DataFrame, and pandas Array
     classes
@@ -479,8 +497,8 @@ def box_with_array(request):
 box_with_array2 = box_with_array
 
 
-@pytest.fixture
-def dict_subclass():
+@pytest.fixture(name="dict_subclass")
+def fixture_dict_subclass():
     """
     Fixture for a dictionary subclass.
     """
@@ -492,8 +510,8 @@ def dict_subclass():
     return TestSubDict
 
 
-@pytest.fixture
-def non_dict_mapping_subclass():
+@pytest.fixture(name="non_dict_mapping_subclass")
+def fixture_non_dict_mapping_subclass():
     """
     Fixture for a non-mapping dictionary subclass.
     """
@@ -517,8 +535,8 @@ def non_dict_mapping_subclass():
 # ----------------------------------------------------------------
 # Indices
 # ----------------------------------------------------------------
-@pytest.fixture
-def multiindex_year_month_day_dataframe_random_data():
+@pytest.fixture(name="multiindex_year_month_day_dataframe_random_data")
+def fixture_multiindex_year_month_day_dataframe_random_data():
     """
     DataFrame with 3 level MultiIndex (year, month, day) covering
     first 100 business days from 2000-01-01 with random data
@@ -531,8 +549,8 @@ def multiindex_year_month_day_dataframe_random_data():
     return ymd
 
 
-@pytest.fixture
-def lexsorted_two_level_string_multiindex() -> MultiIndex:
+@pytest.fixture(name="lexsorted_two_level_string_multiindex")
+def fixture_lexsorted_two_level_string_multiindex() -> MultiIndex:
     """
     2-level MultiIndex, lexsorted, with string names.
     """
@@ -543,8 +561,8 @@ def lexsorted_two_level_string_multiindex() -> MultiIndex:
     )
 
 
-@pytest.fixture
-def multiindex_dataframe_random_data(
+@pytest.fixture(name="multiindex_dataframe_random_data")
+def fixture_multiindex_dataframe_random_data(
     lexsorted_two_level_string_multiindex,
 ) -> DataFrame:
     """DataFrame with 2 level MultiIndex with random data"""
@@ -624,8 +642,8 @@ if has_pyarrow:
     indices_dict["string-pyarrow"] = idx
 
 
-@pytest.fixture(params=indices_dict.keys())
-def index(request):
+@pytest.fixture(name="index", params=indices_dict.keys())
+def fixture_index(request):
     """
     Fixture for many "simple" kinds of indices.
 
@@ -644,11 +662,12 @@ index_fixture2 = index
 
 
 @pytest.fixture(
+    name="index_flat",
     params=[
         key for key, value in indices_dict.items() if not isinstance(value, MultiIndex)
-    ]
+    ],
 )
-def index_flat(request):
+def fixture_index_flat(request):
     """
     index fixture, but excluding MultiIndex cases.
     """
@@ -661,6 +680,7 @@ index_flat2 = index_flat
 
 
 @pytest.fixture(
+    name="index_with_missing",
     params=[
         key
         for key, value in indices_dict.items()
@@ -671,9 +691,9 @@ index_flat2 = index_flat
             or key in ["range", "empty", "repeats", "bool-dtype"]
         )
         and not isinstance(value, MultiIndex)
-    ]
+    ],
 )
-def index_with_missing(request):
+def fixture_index_with_missing(request):
     """
     Fixture for indices with missing values.
 
@@ -702,8 +722,8 @@ def index_with_missing(request):
 # ----------------------------------------------------------------
 # Series'
 # ----------------------------------------------------------------
-@pytest.fixture
-def string_series() -> Series:
+@pytest.fixture(name="string_series")
+def fixture_string_series() -> Series:
     """
     Fixture for Series of floats with Index of unique strings
     """
@@ -712,8 +732,8 @@ def string_series() -> Series:
     return s
 
 
-@pytest.fixture
-def object_series() -> Series:
+@pytest.fixture(name="object_series")
+def fixture_object_series() -> Series:
     """
     Fixture for Series of dtype object with Index of unique strings
     """
@@ -722,8 +742,8 @@ def object_series() -> Series:
     return s
 
 
-@pytest.fixture
-def datetime_series() -> Series:
+@pytest.fixture(name="datetime_series")
+def fixture_datetime_series() -> Series:
     """
     Fixture for Series of floats with DatetimeIndex
     """
@@ -745,16 +765,16 @@ _series = {
 }
 
 
-@pytest.fixture
-def series_with_simple_index(index) -> Series:
+@pytest.fixture(name="series_with_simple_index")
+def fixture_series_with_simple_index(index) -> Series:
     """
     Fixture for tests on series with changing types of indices.
     """
     return _create_series(index)
 
 
-@pytest.fixture
-def series_with_multilevel_index() -> Series:
+@pytest.fixture(name="series_with_multilevel_index")
+def fixture_series_with_multilevel_index() -> Series:
     """
     Fixture with a Series with a 2-level MultiIndex.
     """
@@ -779,8 +799,8 @@ _narrow_series = {
 _index_or_series_objs = {**indices_dict, **_series, **_narrow_series}
 
 
-@pytest.fixture(params=_index_or_series_objs.keys())
-def index_or_series_obj(request):
+@pytest.fixture(name="index_or_series_obj", params=_index_or_series_objs.keys())
+def fixture_index_or_series_obj(request):
     """
     Fixture for tests on indexes, series and series with a narrow dtype
     copy to avoid mutation, e.g. setting .name
@@ -791,8 +811,8 @@ def index_or_series_obj(request):
 # ----------------------------------------------------------------
 # DataFrames
 # ----------------------------------------------------------------
-@pytest.fixture
-def int_frame() -> DataFrame:
+@pytest.fixture(name="int_frame")
+def fixture_int_frame() -> DataFrame:
     """
     Fixture for DataFrame of ints with index of unique strings
 
@@ -820,8 +840,8 @@ def int_frame() -> DataFrame:
     return DataFrame(tm.getSeriesData()).astype("int64")
 
 
-@pytest.fixture
-def datetime_frame() -> DataFrame:
+@pytest.fixture(name="datetime_frame")
+def fixture_datetime_frame() -> DataFrame:
     """
     Fixture for DataFrame of floats with DatetimeIndex
 
@@ -849,8 +869,8 @@ def datetime_frame() -> DataFrame:
     return DataFrame(tm.getTimeSeriesData())
 
 
-@pytest.fixture
-def float_frame() -> DataFrame:
+@pytest.fixture(name="float_frame")
+def fixture_float_frame() -> DataFrame:
     """
     Fixture for DataFrame of floats with index of unique strings
 
@@ -878,8 +898,8 @@ def float_frame() -> DataFrame:
     return DataFrame(tm.getSeriesData())
 
 
-@pytest.fixture
-def mixed_type_frame() -> DataFrame:
+@pytest.fixture(name="mixed_type_frame")
+def fixture_mixed_type_frame() -> DataFrame:
     """
     Fixture for DataFrame of float/int/string columns with RangeIndex
     Columns are ['a', 'b', 'c', 'float32', 'int32'].
@@ -896,8 +916,8 @@ def mixed_type_frame() -> DataFrame:
     )
 
 
-@pytest.fixture
-def rand_series_with_duplicate_datetimeindex() -> Series:
+@pytest.fixture(name="rand_series_with_duplicate_datetimeindex")
+def fixture_rand_series_with_duplicate_datetimeindex() -> Series:
     """
     Fixture for Series with a DatetimeIndex that has duplicates.
     """
@@ -921,6 +941,7 @@ def rand_series_with_duplicate_datetimeindex() -> Series:
 # Scalars
 # ----------------------------------------------------------------
 @pytest.fixture(
+    name="ea_scalar_and_dtype",
     params=[
         (Interval(left=0, right=5), IntervalDtype("int64", "right")),
         (Interval(left=0.1, right=0.5), IntervalDtype("float64", "right")),
@@ -931,9 +952,9 @@ def rand_series_with_duplicate_datetimeindex() -> Series:
             DatetimeTZDtype(tz="US/Eastern"),
         ),
         (Timedelta(seconds=500), "timedelta64[ns]"),
-    ]
+    ],
 )
-def ea_scalar_and_dtype(request):
+def fixture_ea_scalar_and_dtype(request):
     return request.param
 
 
@@ -958,8 +979,8 @@ _all_arithmetic_operators = [
 ]
 
 
-@pytest.fixture(params=_all_arithmetic_operators)
-def all_arithmetic_operators(request):
+@pytest.fixture(name="all_arithmetic_operators", params=_all_arithmetic_operators)
+def fixture_all_arithmetic_operators(request):
     """
     Fixture for dunder names for common arithmetic operations.
     """
@@ -967,6 +988,7 @@ def all_arithmetic_operators(request):
 
 
 @pytest.fixture(
+    name="all_binary_operators",
     params=[
         operator.add,
         ops.radd,
@@ -994,9 +1016,9 @@ def all_arithmetic_operators(request):
         ops.rxor,
         operator.or_,
         ops.ror_,
-    ]
+    ],
 )
-def all_binary_operators(request):
+def fixture_all_binary_operators(request):
     """
     Fixture for operator and roperator arithmetic, comparison, and logical ops.
     """
@@ -1004,6 +1026,7 @@ def all_binary_operators(request):
 
 
 @pytest.fixture(
+    name="all_arithmetic_functions",
     params=[
         operator.add,
         ops.radd,
@@ -1019,9 +1042,9 @@ def all_binary_operators(request):
         ops.rmod,
         operator.pow,
         ops.rpow,
-    ]
+    ],
 )
-def all_arithmetic_functions(request):
+def fixture_all_arithmetic_functions(request):
     """
     Fixture for operator and roperator arithmetic functions.
 
@@ -1049,8 +1072,8 @@ _all_numeric_reductions = [
 ]
 
 
-@pytest.fixture(params=_all_numeric_reductions)
-def all_numeric_reductions(request):
+@pytest.fixture(name="all_numeric_reductions", params=_all_numeric_reductions)
+def fixture_all_numeric_reductions(request):
     """
     Fixture for numeric reduction names.
     """
@@ -1060,8 +1083,8 @@ def all_numeric_reductions(request):
 _all_boolean_reductions = ["all", "any"]
 
 
-@pytest.fixture(params=_all_boolean_reductions)
-def all_boolean_reductions(request):
+@pytest.fixture(name="all_boolean_reductions", params=_all_boolean_reductions)
+def fixture_all_boolean_reductions(request):
     """
     Fixture for boolean reduction names.
     """
@@ -1071,8 +1094,8 @@ def all_boolean_reductions(request):
 _all_reductions = _all_numeric_reductions + _all_boolean_reductions
 
 
-@pytest.fixture(params=_all_reductions)
-def all_reductions(request):
+@pytest.fixture(name="all_reductions", params=_all_reductions)
+def fixture_all_reductions(request):
     """
     Fixture for all (boolean + numeric) reduction names.
     """
@@ -1080,6 +1103,7 @@ def all_reductions(request):
 
 
 @pytest.fixture(
+    name="comparison_op",
     params=[
         operator.eq,
         operator.ne,
@@ -1087,17 +1111,19 @@ def all_reductions(request):
         operator.ge,
         operator.lt,
         operator.le,
-    ]
+    ],
 )
-def comparison_op(request):
+def fixture_comparison_op(request):
     """
     Fixture for operator module comparison functions.
     """
     return request.param
 
 
-@pytest.fixture(params=["__le__", "__lt__", "__ge__", "__gt__"])
-def compare_operators_no_eq_ne(request):
+@pytest.fixture(
+    name="compare_operators_no_eq_ne", params=["__le__", "__lt__", "__ge__", "__gt__"]
+)
+def fixture_compare_operators_no_eq_ne(request):
     """
     Fixture for dunder names for compare operations except == and !=
 
@@ -1110,9 +1136,10 @@ def compare_operators_no_eq_ne(request):
 
 
 @pytest.fixture(
-    params=["__and__", "__rand__", "__or__", "__ror__", "__xor__", "__rxor__"]
+    name="all_logical_operators",
+    params=["__and__", "__rand__", "__or__", "__ror__", "__xor__", "__rxor__"],
 )
-def all_logical_operators(request):
+def fixture_all_logical_operators(request):
     """
     Fixture for dunder names for common logical operations
 
@@ -1126,8 +1153,8 @@ def all_logical_operators(request):
 _all_numeric_accumulations = ["cumsum", "cumprod", "cummin", "cummax"]
 
 
-@pytest.fixture(params=_all_numeric_accumulations)
-def all_numeric_accumulations(request):
+@pytest.fixture(name="all_numeric_accumulations", params=_all_numeric_accumulations)
+def fixture_all_numeric_accumulations(request):
     """
     Fixture for numeric accumulation names
     """
@@ -1137,16 +1164,16 @@ def all_numeric_accumulations(request):
 # ----------------------------------------------------------------
 # Data sets/files
 # ----------------------------------------------------------------
-@pytest.fixture
-def strict_data_files(pytestconfig):
+@pytest.fixture(name="strict_data_files")
+def fixture_strict_data_files(pytestconfig):
     """
     Returns the configuration for the test setting `--strict-data-files`.
     """
     return pytestconfig.getoption("--strict-data-files")
 
 
-@pytest.fixture
-def datapath(strict_data_files: str) -> Callable[..., str]:
+@pytest.fixture(name="datapath")
+def fixture_datapath(strict_data_files: str) -> Callable[..., str]:
     """
     Get the path to a data file.
 
@@ -1179,8 +1206,8 @@ def datapath(strict_data_files: str) -> Callable[..., str]:
     return deco
 
 
-@pytest.fixture
-def iris(datapath) -> DataFrame:
+@pytest.fixture(name="iris")
+def fixture_iris(datapath) -> DataFrame:
     """
     The iris dataset as a DataFrame.
     """
@@ -1216,8 +1243,8 @@ TIMEZONE_IDS = [repr(i) for i in TIMEZONES]
 
 
 @td.parametrize_fixture_doc(str(TIMEZONE_IDS))
-@pytest.fixture(params=TIMEZONES, ids=TIMEZONE_IDS)
-def tz_naive_fixture(request):
+@pytest.fixture(name="tz_naive_fixture", params=TIMEZONES, ids=TIMEZONE_IDS)
+def fixture_tz_naive_fixture(request):
     """
     Fixture for trying timezones including default (None): {0}
     """
@@ -1225,8 +1252,8 @@ def tz_naive_fixture(request):
 
 
 @td.parametrize_fixture_doc(str(TIMEZONE_IDS[1:]))
-@pytest.fixture(params=TIMEZONES[1:], ids=TIMEZONE_IDS[1:])
-def tz_aware_fixture(request):
+@pytest.fixture(name="tz_aware_fixture", params=TIMEZONES[1:], ids=TIMEZONE_IDS[1:])
+def fixture_tz_aware_fixture(request):
     """
     Fixture for trying explicit timezones: {0}
     """
@@ -1242,8 +1269,8 @@ if zoneinfo is not None:
     _UTCS.append(zoneinfo.ZoneInfo("UTC"))
 
 
-@pytest.fixture(params=_UTCS)
-def utc_fixture(request):
+@pytest.fixture(name="utc_fixture", params=_UTCS)
+def fixture_utc_fixture(request):
     """
     Fixture to provide variants of UTC timezone strings and tzinfo objects.
     """
@@ -1256,8 +1283,8 @@ utc_fixture2 = utc_fixture
 # ----------------------------------------------------------------
 # Dtypes
 # ----------------------------------------------------------------
-@pytest.fixture(params=tm.STRING_DTYPES)
-def string_dtype(request):
+@pytest.fixture(name="string_dtype", params=tm.STRING_DTYPES)
+def fixture_string_dtype(request):
     """
     Parametrized fixture for string dtypes.
 
@@ -1269,12 +1296,13 @@ def string_dtype(request):
 
 
 @pytest.fixture(
+    name="nullable_string_dtype",
     params=[
         "string[python]",
         pytest.param("string[pyarrow]", marks=td.skip_if_no("pyarrow")),
-    ]
+    ],
 )
-def nullable_string_dtype(request):
+def fixture_nullable_string_dtype(request):
     """
     Parametrized fixture for string dtypes.
 
@@ -1285,12 +1313,13 @@ def nullable_string_dtype(request):
 
 
 @pytest.fixture(
+    name="string_storage",
     params=[
         "python",
         pytest.param("pyarrow", marks=td.skip_if_no("pyarrow")),
-    ]
+    ],
 )
-def string_storage(request):
+def fixture_string_storage(request):
     """
     Parametrized fixture for pd.options.mode.string_storage.
 
@@ -1304,8 +1333,8 @@ def string_storage(request):
 string_storage2 = string_storage
 
 
-@pytest.fixture(params=tm.BYTES_DTYPES)
-def bytes_dtype(request):
+@pytest.fixture(name="bytes_dtype", params=tm.BYTES_DTYPES)
+def fixture_bytes_dtype(request):
     """
     Parametrized fixture for bytes dtypes.
 
@@ -1315,8 +1344,8 @@ def bytes_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=tm.OBJECT_DTYPES)
-def object_dtype(request):
+@pytest.fixture(name="object_dtype", params=tm.OBJECT_DTYPES)
+def fixture_object_dtype(request):
     """
     Parametrized fixture for object dtypes.
 
@@ -1327,13 +1356,14 @@ def object_dtype(request):
 
 
 @pytest.fixture(
+    name="any_string_dtype",
     params=[
         "object",
         "string[python]",
         pytest.param("string[pyarrow]", marks=td.skip_if_no("pyarrow")),
-    ]
+    ],
 )
-def any_string_dtype(request):
+def fixture_any_string_dtype(request):
     """
     Parametrized fixture for string dtypes.
     * 'object'
@@ -1343,8 +1373,8 @@ def any_string_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=tm.DATETIME64_DTYPES)
-def datetime64_dtype(request):
+@pytest.fixture(name="datetime64_dtype", params=tm.DATETIME64_DTYPES)
+def fixture_datetime64_dtype(request):
     """
     Parametrized fixture for datetime64 dtypes.
 
@@ -1354,8 +1384,8 @@ def datetime64_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=tm.TIMEDELTA64_DTYPES)
-def timedelta64_dtype(request):
+@pytest.fixture(name="timedelta64_dtype", params=tm.TIMEDELTA64_DTYPES)
+def fixture_timedelta64_dtype(request):
     """
     Parametrized fixture for timedelta64 dtypes.
 
@@ -1365,8 +1395,8 @@ def timedelta64_dtype(request):
     return request.param
 
 
-@pytest.fixture
-def fixed_now_ts() -> Timestamp:
+@pytest.fixture(name="fixed_now_ts")
+def fixture_fixed_now_ts() -> Timestamp:
     """
     Fixture emits fixed Timestamp.now()
     """
@@ -1375,8 +1405,8 @@ def fixed_now_ts() -> Timestamp:
     )
 
 
-@pytest.fixture(params=tm.FLOAT_NUMPY_DTYPES)
-def float_numpy_dtype(request):
+@pytest.fixture(name="float_numpy_dtype", params=tm.FLOAT_NUMPY_DTYPES)
+def fixture_float_numpy_dtype(request):
     """
     Parameterized fixture for float dtypes.
 
@@ -1387,8 +1417,8 @@ def float_numpy_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=tm.FLOAT_EA_DTYPES)
-def float_ea_dtype(request):
+@pytest.fixture(name="float_ea_dtype", params=tm.FLOAT_EA_DTYPES)
+def fixture_float_ea_dtype(request):
     """
     Parameterized fixture for float dtypes.
 
@@ -1398,8 +1428,10 @@ def float_ea_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=tm.FLOAT_NUMPY_DTYPES + tm.FLOAT_EA_DTYPES)
-def any_float_dtype(request):
+@pytest.fixture(
+    name="any_float_dtype", params=tm.FLOAT_NUMPY_DTYPES + tm.FLOAT_EA_DTYPES
+)
+def fixture_any_float_dtype(request):
     """
     Parameterized fixture for float dtypes.
 
@@ -1412,8 +1444,8 @@ def any_float_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=tm.COMPLEX_DTYPES)
-def complex_dtype(request):
+@pytest.fixture(name="complex_dtype", params=tm.COMPLEX_DTYPES)
+def fixture_complex_dtype(request):
     """
     Parameterized fixture for complex dtypes.
 
@@ -1424,8 +1456,8 @@ def complex_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=tm.SIGNED_INT_NUMPY_DTYPES)
-def any_signed_int_numpy_dtype(request):
+@pytest.fixture(name="any_signed_int_numpy_dtype", params=tm.SIGNED_INT_NUMPY_DTYPES)
+def fixture_any_signed_int_numpy_dtype(request):
     """
     Parameterized fixture for signed integer dtypes.
 
@@ -1438,8 +1470,10 @@ def any_signed_int_numpy_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=tm.UNSIGNED_INT_NUMPY_DTYPES)
-def any_unsigned_int_numpy_dtype(request):
+@pytest.fixture(
+    name="any_unsigned_int_numpy_dtype", params=tm.UNSIGNED_INT_NUMPY_DTYPES
+)
+def fixture_any_unsigned_int_numpy_dtype(request):
     """
     Parameterized fixture for unsigned integer dtypes.
 
@@ -1451,8 +1485,8 @@ def any_unsigned_int_numpy_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=tm.ALL_INT_NUMPY_DTYPES)
-def any_int_numpy_dtype(request):
+@pytest.fixture(name="any_int_numpy_dtype", params=tm.ALL_INT_NUMPY_DTYPES)
+def fixture_any_int_numpy_dtype(request):
     """
     Parameterized fixture for any integer dtype.
 
@@ -1469,8 +1503,8 @@ def any_int_numpy_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=tm.ALL_INT_EA_DTYPES)
-def any_int_ea_dtype(request):
+@pytest.fixture(name="any_int_ea_dtype", params=tm.ALL_INT_EA_DTYPES)
+def fixture_any_int_ea_dtype(request):
     """
     Parameterized fixture for any nullable integer dtype.
 
@@ -1486,8 +1520,10 @@ def any_int_ea_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=tm.ALL_INT_NUMPY_DTYPES + tm.ALL_INT_EA_DTYPES)
-def any_int_dtype(request):
+@pytest.fixture(
+    name="any_int_dtype", params=tm.ALL_INT_NUMPY_DTYPES + tm.ALL_INT_EA_DTYPES
+)
+def fixture_any_int_dtype(request):
     """
     Parameterized fixture for any nullable integer dtype.
 
@@ -1512,8 +1548,10 @@ def any_int_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=tm.ALL_INT_EA_DTYPES + tm.FLOAT_EA_DTYPES)
-def any_numeric_ea_dtype(request):
+@pytest.fixture(
+    name="any_numeric_ea_dtype", params=tm.ALL_INT_EA_DTYPES + tm.FLOAT_EA_DTYPES
+)
+def fixture_any_numeric_ea_dtype(request):
     """
     Parameterized fixture for any nullable integer dtype and
     any float ea dtypes.
@@ -1532,8 +1570,8 @@ def any_numeric_ea_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=tm.SIGNED_INT_EA_DTYPES)
-def any_signed_int_ea_dtype(request):
+@pytest.fixture(name="any_signed_int_ea_dtype", params=tm.SIGNED_INT_EA_DTYPES)
+def fixture_any_signed_int_ea_dtype(request):
     """
     Parameterized fixture for any signed nullable integer dtype.
 
@@ -1545,8 +1583,8 @@ def any_signed_int_ea_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=tm.ALL_REAL_NUMPY_DTYPES)
-def any_real_numpy_dtype(request):
+@pytest.fixture(name="any_real_numpy_dtype", params=tm.ALL_REAL_NUMPY_DTYPES)
+def fixture_any_real_numpy_dtype(request):
     """
     Parameterized fixture for any (purely) real numeric dtype.
 
@@ -1567,9 +1605,10 @@ def any_real_numpy_dtype(request):
 
 
 @pytest.fixture(
-    params=tm.ALL_REAL_NUMPY_DTYPES + tm.ALL_INT_EA_DTYPES + tm.FLOAT_EA_DTYPES
+    name="any_real_numeric_dtype",
+    params=tm.ALL_REAL_NUMPY_DTYPES + tm.ALL_INT_EA_DTYPES + tm.FLOAT_EA_DTYPES,
 )
-def any_real_numeric_dtype(request):
+def fixture_any_real_numeric_dtype(request):
     """
     Parameterized fixture for any (purely) real numeric dtype.
 
@@ -1591,8 +1630,8 @@ def any_real_numeric_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=tm.ALL_NUMPY_DTYPES)
-def any_numpy_dtype(request):
+@pytest.fixture(name="any_numpy_dtype", params=tm.ALL_NUMPY_DTYPES)
+def fixture_any_numpy_dtype(request):
     """
     Parameterized fixture for all numpy dtypes.
 
@@ -1629,12 +1668,13 @@ def any_numpy_dtype(request):
 
 
 @pytest.fixture(
+    name="any_numeric_dtype",
     params=tm.ALL_REAL_NUMPY_DTYPES
     + tm.COMPLEX_DTYPES
     + tm.ALL_INT_EA_DTYPES
-    + tm.FLOAT_EA_DTYPES
+    + tm.FLOAT_EA_DTYPES,
 )
-def any_numeric_dtype(request):
+def fixture_any_numeric_dtype(request):
     """
     Parameterized fixture for all numeric dtypes.
 
@@ -1698,8 +1738,10 @@ _any_skipna_inferred_dtype = [
 ids, _ = zip(*_any_skipna_inferred_dtype)  # use inferred type as fixture-id
 
 
-@pytest.fixture(params=_any_skipna_inferred_dtype, ids=ids)
-def any_skipna_inferred_dtype(request):
+@pytest.fixture(
+    name="any_skipna_inferred_dtype", params=_any_skipna_inferred_dtype, ids=ids
+)
+def fixture_any_skipna_inferred_dtype(request):
     """
     Fixture for all inferred dtypes from _libs.lib.infer_dtype
 
@@ -1749,8 +1791,8 @@ def any_skipna_inferred_dtype(request):
 # ----------------------------------------------------------------
 # Misc
 # ----------------------------------------------------------------
-@pytest.fixture
-def ip():
+@pytest.fixture(name="ip")
+def fixture_ip():
     """
     Get an instance of IPython.InteractiveShell.
 
@@ -1768,8 +1810,10 @@ def ip():
     return InteractiveShell(config=c)
 
 
-@pytest.fixture(params=["bsr", "coo", "csc", "csr", "dia", "dok", "lil"])
-def spmatrix(request):
+@pytest.fixture(
+    name="spmatrix", params=["bsr", "coo", "csc", "csr", "dia", "dok", "lil"]
+)
+def fixture_spmatrix(request):
     """
     Yields scipy sparse matrix classes.
     """
@@ -1779,21 +1823,22 @@ def spmatrix(request):
 
 
 @pytest.fixture(
+    name="tick_classes",
     params=[
         getattr(pd.offsets, o)
         for o in pd.offsets.__all__
         if issubclass(getattr(pd.offsets, o), pd.offsets.Tick) and o != "Tick"
-    ]
+    ],
 )
-def tick_classes(request):
+def fixture_tick_classes(request):
     """
     Fixture for Tick based datetime offsets available for a time series.
     """
     return request.param
 
 
-@pytest.fixture(params=[None, lambda x: x])
-def sort_by_key(request):
+@pytest.fixture(name="sort_by_key", params=[None, lambda x: x])
+def fixture_sort_by_key(request):
     """
     Simple fixture for testing keys in sorting methods.
     Tests None (no key) and the identity key.
@@ -1801,8 +1846,8 @@ def sort_by_key(request):
     return request.param
 
 
-@pytest.fixture()
-def fsspectest():
+@pytest.fixture(name="fsspectest")
+def fixture_fsspectest():
     pytest.importorskip("fsspec")
     from fsspec import register_implementation
     from fsspec.implementations.memory import MemoryFileSystem
@@ -1824,6 +1869,7 @@ def fsspectest():
 
 
 @pytest.fixture(
+    name="names",
     params=[
         ("foo", None, None),
         ("Egon", "Venkman", None),
@@ -1833,73 +1879,73 @@ def fsspectest():
         (np.nan, pd.NaT, None),
         (np.nan, pd.NA, None),
         (pd.NA, pd.NA, pd.NA),
-    ]
+    ],
 )
-def names(request):
+def fixture_names(request):
     """
     A 3-tuple of names, the first two for operands, the last for a result.
     """
     return request.param
 
 
-@pytest.fixture(params=[tm.setitem, tm.loc, tm.iloc])
-def indexer_sli(request):
+@pytest.fixture(name="indexer_sli", params=[tm.setitem, tm.loc, tm.iloc])
+def fixture_indexer_sli(request):
     """
     Parametrize over __setitem__, loc.__setitem__, iloc.__setitem__
     """
     return request.param
 
 
-@pytest.fixture(params=[tm.loc, tm.iloc])
-def indexer_li(request):
+@pytest.fixture(name="indexer_li", params=[tm.loc, tm.iloc])
+def fixture_indexer_li(request):
     """
     Parametrize over loc.__getitem__, iloc.__getitem__
     """
     return request.param
 
 
-@pytest.fixture(params=[tm.setitem, tm.iloc])
-def indexer_si(request):
+@pytest.fixture(name="indexer_si", params=[tm.setitem, tm.iloc])
+def fixture_indexer_si(request):
     """
     Parametrize over __setitem__, iloc.__setitem__
     """
     return request.param
 
 
-@pytest.fixture(params=[tm.setitem, tm.loc])
-def indexer_sl(request):
+@pytest.fixture(name="indexer_sl", params=[tm.setitem, tm.loc])
+def fixture_indexer_sl(request):
     """
     Parametrize over __setitem__, loc.__setitem__
     """
     return request.param
 
 
-@pytest.fixture(params=[tm.at, tm.loc])
-def indexer_al(request):
+@pytest.fixture(name="indexer_al", params=[tm.at, tm.loc])
+def fixture_indexer_al(request):
     """
     Parametrize over at.__setitem__, loc.__setitem__
     """
     return request.param
 
 
-@pytest.fixture(params=[tm.iat, tm.iloc])
-def indexer_ial(request):
+@pytest.fixture(name="indexer_ial", params=[tm.iat, tm.iloc])
+def fixture_indexer_ial(request):
     """
     Parametrize over iat.__setitem__, iloc.__setitem__
     """
     return request.param
 
 
-@pytest.fixture
-def using_array_manager():
+@pytest.fixture(name="using_array_manager")
+def fixture_using_array_manager():
     """
     Fixture to check if the array manager is being used.
     """
     return pd.options.mode.data_manager == "array"
 
 
-@pytest.fixture
-def using_copy_on_write() -> bool:
+@pytest.fixture(name="using_copy_on_write")
+def fixture_using_copy_on_write() -> bool:
     """
     Fixture to check if Copy-on-Write is enabled.
     """
@@ -1911,8 +1957,8 @@ if zoneinfo is not None:
     warsaws.append(zoneinfo.ZoneInfo("Europe/Warsaw"))
 
 
-@pytest.fixture(params=warsaws)
-def warsaw(request):
+@pytest.fixture(name="warsaw", params=warsaws)
+def fixture_warsaw(request):
     """
     tzinfo for Europe/Warsaw using pytz, dateutil, or zoneinfo.
     """

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -268,7 +268,9 @@ def fixture_axis(request):
     return request.param
 
 
-axis_frame = axis
+@pytest.fixture(name="axis_frame")
+def fixture_axis_frame(axis):
+    yield axis
 
 
 @pytest.fixture(name="axis_1", params=[1, "columns"], ids=lambda x: f"axis={repr(x)}")
@@ -410,7 +412,10 @@ def fixture_nulls_fixture(request):
     return request.param
 
 
-nulls_fixture2 = nulls_fixture  # Generate cartesian product of nulls_fixture
+@pytest.fixture(name="nulls_fixture2")
+def fixture_nulls_fixture2(nulls_fixture):
+    # Generate cartesian product of nulls_fixture
+    yield nulls_fixture
 
 
 @pytest.fixture(name="unique_nulls_fixture", params=[None, np.nan, pd.NaT])
@@ -421,8 +426,10 @@ def fixture_unique_nulls_fixture(request):
     return request.param
 
 
-# Generate cartesian product of unique_nulls_fixture:
-unique_nulls_fixture2 = unique_nulls_fixture
+@pytest.fixture(name="unique_nulls_fixture2")
+def fixture_unique_nulls_fixture2(unique_nulls_fixture):
+    # Generate cartesian product of unique_nulls_fixture
+    yield unique_nulls_fixture
 
 
 @pytest.fixture(
@@ -435,8 +442,10 @@ def fixture_np_nat_fixture(request):
     return request.param
 
 
-# Generate cartesian product of np_nat_fixture:
-np_nat_fixture2 = np_nat_fixture
+@pytest.fixture(name="np_nat_fixture2")
+def fixture_np_nat_fixture2(np_nat_fixture):
+    # Generate cartesian product of np_nat_fixture
+    yield np_nat_fixture
 
 
 # ----------------------------------------------------------------
@@ -465,8 +474,10 @@ def fixture_index_or_series(request):
     return request.param
 
 
-# Generate cartesian product of index_or_series fixture:
-index_or_series2 = index_or_series
+@pytest.fixture(name="index_or_series2")
+def fixture_index_or_series2(index_or_series):
+    # Generate cartesian product of index_or_series
+    yield index_or_series
 
 
 @pytest.fixture(
@@ -494,7 +505,10 @@ def fixture_box_with_array(request):
     return request.param
 
 
-box_with_array2 = box_with_array
+@pytest.fixture(name="box_with_array2")
+def fixture_box_with_array2(box_with_array):
+    # Generate cartesian product of box_with_array
+    yield box_with_array
 
 
 @pytest.fixture(name="dict_subclass")
@@ -658,7 +672,10 @@ def fixture_index(request):
 
 
 # Needed to generate cartesian product of indices
-index_fixture2 = index
+@pytest.fixture(name="index_fixture2")
+def fixture_index_fixture2(index):
+    # Generate cartesian product of index
+    yield index
 
 
 @pytest.fixture(
@@ -675,8 +692,10 @@ def fixture_index_flat(request):
     return indices_dict[key].copy()
 
 
-# Alias so we can test with cartesian product of index_flat
-index_flat2 = index_flat
+@pytest.fixture(name="index_flat2")
+def fixture_index_flat2(index_flat):
+    # Alias so we can test with cartesian product of index_flat
+    yield index_flat
 
 
 @pytest.fixture(
@@ -1260,8 +1279,10 @@ def fixture_tz_aware_fixture(request):
     return request.param
 
 
-# Generate cartesian product of tz_aware_fixture:
-tz_aware_fixture2 = tz_aware_fixture
+@pytest.fixture(name="tz_aware_fixture2")
+def fixture_tz_aware_fixture2(tz_aware_fixture):
+    # Generate cartesian product of tz_aware_fixture:
+    yield tz_aware_fixture
 
 
 _UTCS = ["utc", "dateutil/UTC", utc, tzutc(), timezone.utc]
@@ -1277,7 +1298,10 @@ def fixture_utc_fixture(request):
     return request.param
 
 
-utc_fixture2 = utc_fixture
+@pytest.fixture(name="utc_fixture2")
+def fixture_utc_fixture2(utc_fixture):
+    # Generate cartesian product of utc_fixture
+    yield utc_fixture
 
 
 # ----------------------------------------------------------------
@@ -1330,7 +1354,10 @@ def fixture_string_storage(request):
 
 
 # Alias so we can test with cartesian product of string_storage
-string_storage2 = string_storage
+@pytest.fixture(name="string_storage2")
+def fixture_string_storage2(string_storage):
+    # Generate cartesian product of string_storage:
+    yield string_storage
 
 
 @pytest.fixture(name="bytes_dtype", params=tm.BYTES_DTYPES)

--- a/pandas/tests/apply/conftest.py
+++ b/pandas/tests/apply/conftest.py
@@ -4,8 +4,8 @@ import pytest
 from pandas import DataFrame
 
 
-@pytest.fixture
-def int_frame_const_col():
+@pytest.fixture(name="int_frame_const_col")
+def fixture_int_frame_const_col():
     """
     Fixture for DataFrame of ints which are constant per column
 

--- a/pandas/tests/arithmetic/conftest.py
+++ b/pandas/tests/arithmetic/conftest.py
@@ -12,8 +12,13 @@ from pandas.core.api import (
 from pandas.core.computation import expressions as expr
 
 
-@pytest.fixture(autouse=True, params=[0, 1000000], ids=["numexpr", "python"])
-def switch_numexpr_min_elements(request):
+@pytest.fixture(
+    name="switch_numexpr_min_elements",
+    autouse=True,
+    params=[0, 1000000],
+    ids=["numexpr", "python"],
+)
+def fixture_switch_numexpr_min_elements(request):
     _MIN_ELEMENTS = expr._MIN_ELEMENTS
     expr._MIN_ELEMENTS = request.param
     yield request.param
@@ -25,8 +30,8 @@ def switch_numexpr_min_elements(request):
 # doctest with +SKIP for one fixture fails during setup with
 # 'DoctestItem' object has no attribute 'callspec'
 # due to switch_numexpr_min_elements fixture
-@pytest.fixture(params=[1, np.array(1, dtype=np.int64)])
-def one(request):
+@pytest.fixture(name="one", params=[1, np.array(1, dtype=np.int64)])
+def fixture_one(request):
     """
     Several variants of integer value 1. The zero-dim integer array
     behaves like an integer.
@@ -64,8 +69,8 @@ zeros.extend([0, 0.0, -0.0])
 # doctest with +SKIP for zero fixture fails during setup with
 # 'DoctestItem' object has no attribute 'callspec'
 # due to switch_numexpr_min_elements fixture
-@pytest.fixture(params=zeros)
-def zero(request):
+@pytest.fixture(name="zero", params=zeros)
+def fixture_zero(request):
     """
     Several types of scalar zeros and length 5 vectors of zeros.
 
@@ -89,6 +94,7 @@ def zero(request):
 
 
 @pytest.fixture(
+    name="numeric_idx",
     params=[
         Float64Index(np.arange(5, dtype="float64")),
         Int64Index(np.arange(5, dtype="int64")),
@@ -97,7 +103,7 @@ def zero(request):
     ],
     ids=lambda x: type(x).__name__,
 )
-def numeric_idx(request):
+def fixture_numeric_idx(request):
     """
     Several types of numeric-dtypes Index objects
     """
@@ -109,6 +115,7 @@ def numeric_idx(request):
 
 
 @pytest.fixture(
+    name="scalar_td",
     params=[
         pd.Timedelta("10m7s").to_pytimedelta(),
         pd.Timedelta("10m7s"),
@@ -116,7 +123,7 @@ def numeric_idx(request):
     ],
     ids=lambda x: type(x).__name__,
 )
-def scalar_td(request):
+def fixture_scalar_td(request):
     """
     Several variants of Timedelta scalars representing 10 minutes and 7 seconds.
     """
@@ -124,6 +131,7 @@ def scalar_td(request):
 
 
 @pytest.fixture(
+    name="three_days",
     params=[
         pd.offsets.Day(3),
         pd.offsets.Hour(72),
@@ -134,7 +142,7 @@ def scalar_td(request):
     ],
     ids=lambda x: type(x).__name__,
 )
-def three_days(request):
+def fixture_three_days(request):
     """
     Several timedelta-like and DateOffset objects that each represent
     a 3-day timedelta
@@ -143,6 +151,7 @@ def three_days(request):
 
 
 @pytest.fixture(
+    name="two_hours",
     params=[
         pd.offsets.Hour(2),
         pd.offsets.Minute(120),
@@ -153,7 +162,7 @@ def three_days(request):
     ],
     ids=lambda x: type(x).__name__,
 )
-def two_hours(request):
+def fixture_two_hours(request):
     """
     Several timedelta-like and DateOffset objects that each represent
     a 2-hour timedelta
@@ -169,14 +178,15 @@ _common_mismatch = [
 
 
 @pytest.fixture(
+    name="not_hourly",
     params=[
         pd.Timedelta(minutes=30).to_pytimedelta(),
         np.timedelta64(30, "s"),
         pd.Timedelta(seconds=30),
     ]
-    + _common_mismatch
+    + _common_mismatch,
 )
-def not_hourly(request):
+def fixture_not_hourly(request):
     """
     Several timedelta-like and DateOffset instances that are _not_
     compatible with Hourly frequencies.
@@ -185,14 +195,15 @@ def not_hourly(request):
 
 
 @pytest.fixture(
+    name="not_daily",
     params=[
         np.timedelta64(4, "h"),
         pd.Timedelta(hours=23).to_pytimedelta(),
         pd.Timedelta("23:00:00"),
     ]
-    + _common_mismatch
+    + _common_mismatch,
 )
-def not_daily(request):
+def fixture_not_daily(request):
     """
     Several timedelta-like and DateOffset instances that are _not_
     compatible with Daily frequencies.
@@ -201,14 +212,15 @@ def not_daily(request):
 
 
 @pytest.fixture(
+    name="mismatched_freq",
     params=[
         np.timedelta64(365, "D"),
         pd.Timedelta(days=365).to_pytimedelta(),
         pd.Timedelta(days=365),
     ]
-    + _common_mismatch
+    + _common_mismatch,
 )
-def mismatched_freq(request):
+def fixture_mismatched_freq(request):
     """
     Several timedelta-like and DateOffset instances that are _not_
     compatible with Monthly or Annual frequencies.
@@ -220,9 +232,11 @@ def mismatched_freq(request):
 
 
 @pytest.fixture(
-    params=[pd.Index, pd.Series, tm.to_array, np.array, list], ids=lambda x: x.__name__
+    name="box_1d_array",
+    params=[pd.Index, pd.Series, tm.to_array, np.array, list],
+    ids=lambda x: x.__name__,
 )
-def box_1d_array(request):
+def fixture_box_1d_array(request):
     """
     Fixture to test behavior for Index, Series, tm.to_array, numpy Array and list
     classes

--- a/pandas/tests/arithmetic/test_interval.py
+++ b/pandas/tests/arithmetic/test_interval.py
@@ -28,6 +28,7 @@ from pandas.tests.arithmetic.common import get_upcast_box
 
 
 @pytest.fixture(
+    name="left_right_dtypes",
     params=[
         (Index([0, 2, 4, 4]), Index([1, 3, 5, 8])),
         (Index([0.0, 1.0, 2.0, np.nan]), Index([1.0, 2.0, 3.0, np.nan])),
@@ -46,15 +47,15 @@ from pandas.tests.arithmetic.common import get_upcast_box
     ],
     ids=lambda x: str(x[0].dtype),
 )
-def left_right_dtypes(request):
+def fixture_left_right_dtypes(request):
     """
     Fixture for building an IntervalArray from various dtypes
     """
     return request.param
 
 
-@pytest.fixture
-def interval_array(left_right_dtypes):
+@pytest.fixture(name="interval_array")
+def fixture_interval_array(left_right_dtypes):
     """
     Fixture to generate an IntervalArray of various dtypes containing NA if possible
     """
@@ -75,11 +76,12 @@ def create_series_categorical_intervals(left, right, closed="right"):
 
 
 class TestComparison:
-    @pytest.fixture(params=[operator.eq, operator.ne])
-    def op(self, request):
+    @pytest.fixture(name="op", params=[operator.eq, operator.ne])
+    def fixture_op(self, request):
         return request.param
 
     @pytest.fixture(
+        name="interval_constructor",
         params=[
             IntervalArray.from_arrays,
             IntervalIndex.from_arrays,
@@ -95,7 +97,7 @@ class TestComparison:
             "Series[Categorical[Interval]]",
         ],
     )
-    def interval_constructor(self, request):
+    def fixture_interval_constructor(self, request):
         """
         Fixture for all pandas native interval constructors.
         To be used as the LHS of IntervalArray comparisons.

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -34,8 +34,8 @@ from pandas.tests.arithmetic.common import (
 )
 
 
-@pytest.fixture(params=[Index, Series, tm.to_array])
-def box_pandas_1d_array(request):
+@pytest.fixture(name="box_pandas_1d_array", params=[Index, Series, tm.to_array])
+def fixture_box_pandas_1d_array(request):
     """
     Fixture to test behavior for Index, Series and tm.to_array classes
     """

--- a/pandas/tests/arrays/boolean/test_arithmetic.py
+++ b/pandas/tests/arrays/boolean/test_arithmetic.py
@@ -7,8 +7,8 @@ import pandas as pd
 import pandas._testing as tm
 
 
-@pytest.fixture
-def data():
+@pytest.fixture(name="data")
+def fixture_data():
     """Fixture returning boolean array with valid and missing values."""
     return pd.array(
         [True, False] * 4 + [np.nan] + [True, False] * 44 + [np.nan] + [True, False],
@@ -16,14 +16,14 @@ def data():
     )
 
 
-@pytest.fixture
-def left_array():
+@pytest.fixture(name="left_array")
+def fixture_left_array():
     """Fixture returning boolean array with valid and missing values."""
     return pd.array([True] * 3 + [False] * 3 + [None] * 3, dtype="boolean")
 
 
-@pytest.fixture
-def right_array():
+@pytest.fixture(name="right_array")
+def fixture_right_array():
     """Fixture returning boolean array with valid and missing values."""
     return pd.array([True, False, None] * 3, dtype="boolean")
 

--- a/pandas/tests/arrays/boolean/test_comparison.py
+++ b/pandas/tests/arrays/boolean/test_comparison.py
@@ -7,8 +7,8 @@ from pandas.arrays import BooleanArray
 from pandas.tests.arrays.masked_shared import ComparisonOps
 
 
-@pytest.fixture
-def data():
+@pytest.fixture(name="data")
+def fixture_data():
     """Fixture returning boolean array with valid and missing data"""
     return pd.array(
         [True, False] * 4 + [np.nan] + [True, False] * 44 + [np.nan] + [True, False],
@@ -16,8 +16,8 @@ def data():
     )
 
 
-@pytest.fixture
-def dtype():
+@pytest.fixture(name="dtype")
+def fixture_dtype():
     """Fixture returning BooleanDtype"""
     return pd.BooleanDtype()
 

--- a/pandas/tests/arrays/boolean/test_reduction.py
+++ b/pandas/tests/arrays/boolean/test_reduction.py
@@ -4,8 +4,8 @@ import pytest
 import pandas as pd
 
 
-@pytest.fixture
-def data():
+@pytest.fixture(name="data")
+def fixture_data():
     """Fixture returning boolean array, with valid and missing values."""
     return pd.array(
         [True, False] * 4 + [np.nan] + [True, False] * 44 + [np.nan] + [True, False],

--- a/pandas/tests/arrays/categorical/conftest.py
+++ b/pandas/tests/arrays/categorical/conftest.py
@@ -3,13 +3,13 @@ import pytest
 from pandas import Categorical
 
 
-@pytest.fixture(params=[True, False])
-def allow_fill(request):
+@pytest.fixture(name="allow_fill", params=[True, False])
+def fixture_allow_fill(request):
     """Boolean 'allow_fill' parameter for Categorical.take"""
     return request.param
 
 
-@pytest.fixture
-def factor():
+@pytest.fixture(name="factor")
+def fixture_factor():
     """Fixture returning  a Categorical object"""
     return Categorical(["a", "b", "b", "a", "a", "c", "c", "c"], ordered=True)

--- a/pandas/tests/arrays/categorical/test_indexing.py
+++ b/pandas/tests/arrays/categorical/test_indexing.py
@@ -357,8 +357,8 @@ def test_mask_with_boolean_na_treated_as_false(index):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.fixture
-def non_coercible_categorical(monkeypatch):
+@pytest.fixture(name="non_coercible_categorical")
+def fixture_non_coercible_categorical(monkeypatch):
     """
     Monkeypatch Categorical.__array__ to ensure no implicit conversion.
 

--- a/pandas/tests/arrays/datetimes/test_reductions.py
+++ b/pandas/tests/arrays/datetimes/test_reductions.py
@@ -10,8 +10,8 @@ from pandas.core.arrays import DatetimeArray
 
 
 class TestReductions:
-    @pytest.fixture
-    def arr1d(self, tz_naive_fixture):
+    @pytest.fixture(name="arr1d")
+    def fixture_arr1d(self, tz_naive_fixture):
         """Fixture returning DatetimeArray with parametrized timezones"""
         tz = tz_naive_fixture
         dtype = DatetimeTZDtype(tz=tz) if tz is not None else np.dtype("M8[ns]")

--- a/pandas/tests/arrays/floating/conftest.py
+++ b/pandas/tests/arrays/floating/conftest.py
@@ -8,14 +8,14 @@ from pandas.core.arrays.floating import (
 )
 
 
-@pytest.fixture(params=[Float32Dtype, Float64Dtype])
-def dtype(request):
+@pytest.fixture(name="dtype", params=[Float32Dtype, Float64Dtype])
+def fixture_dtype(request):
     """Parametrized fixture returning a float 'dtype'"""
     return request.param()
 
 
-@pytest.fixture
-def data(dtype):
+@pytest.fixture(name="data")
+def fixture_data(dtype):
     """Fixture returning 'data' array according to parametrized float 'dtype'"""
     return pd.array(
         list(np.arange(0.1, 0.9, 0.1))
@@ -27,8 +27,8 @@ def data(dtype):
     )
 
 
-@pytest.fixture
-def data_missing(dtype):
+@pytest.fixture(name="data_missing")
+def fixture_data_missing(dtype):
     """
     Fixture returning array with missing data according to parametrized float
     'dtype'.
@@ -36,8 +36,8 @@ def data_missing(dtype):
     return pd.array([np.nan, 0.1], dtype=dtype)
 
 
-@pytest.fixture(params=["data", "data_missing"])
-def all_data(request, data, data_missing):
+@pytest.fixture(name="all_data", params=["data", "data_missing"])
+def fixture_all_data(request, data, data_missing):
     """Parametrized fixture returning 'data' or 'data_missing' float arrays.
 
     Used to test dtype conversion with and without missing values.

--- a/pandas/tests/arrays/integer/conftest.py
+++ b/pandas/tests/arrays/integer/conftest.py
@@ -15,6 +15,7 @@ from pandas.core.arrays.integer import (
 
 
 @pytest.fixture(
+    name="dtype",
     params=[
         Int8Dtype,
         Int16Dtype,
@@ -24,15 +25,15 @@ from pandas.core.arrays.integer import (
         UInt16Dtype,
         UInt32Dtype,
         UInt64Dtype,
-    ]
+    ],
 )
-def dtype(request):
+def fixture_dtype(request):
     """Parametrized fixture returning integer 'dtype'"""
     return request.param()
 
 
-@pytest.fixture
-def data(dtype):
+@pytest.fixture(name="data")
+def fixture_data(dtype):
     """
     Fixture returning 'data' array with valid and missing values according to
     parametrized integer 'dtype'.
@@ -45,8 +46,8 @@ def data(dtype):
     )
 
 
-@pytest.fixture
-def data_missing(dtype):
+@pytest.fixture(name="data_missing")
+def fixture_data_missing(dtype):
     """
     Fixture returning array with exactly one NaN and one valid integer,
     according to parametrized integer 'dtype'.
@@ -56,8 +57,8 @@ def data_missing(dtype):
     return pd.array([np.nan, 1], dtype=dtype)
 
 
-@pytest.fixture(params=["data", "data_missing"])
-def all_data(request, data, data_missing):
+@pytest.fixture(name="all_data", params=["data", "data_missing"])
+def fixture_all_data(request, data, data_missing):
     """Parametrized fixture returning 'data' or 'data_missing' integer arrays.
 
     Used to test dtype conversion with and without missing values.

--- a/pandas/tests/arrays/integer/test_construction.py
+++ b/pandas/tests/arrays/integer/test_construction.py
@@ -12,8 +12,8 @@ from pandas.core.arrays.integer import (
 )
 
 
-@pytest.fixture(params=[pd.array, IntegerArray._from_sequence])
-def constructor(request):
+@pytest.fixture(name="constructor", params=[pd.array, IntegerArray._from_sequence])
+def fixture_constructor(request):
     """Fixture returning parametrized IntegerArray from given sequence.
 
     Used to test dtype conversions.

--- a/pandas/tests/arrays/interval/test_interval.py
+++ b/pandas/tests/arrays/interval/test_interval.py
@@ -18,6 +18,7 @@ from pandas.core.arrays import IntervalArray
 
 
 @pytest.fixture(
+    name="left_right_dtypes",
     params=[
         (Index([0, 2, 4]), Index([1, 3, 5])),
         (Index([0.0, 1.0, 2.0]), Index([1.0, 2.0, 3.0])),
@@ -30,7 +31,7 @@ from pandas.core.arrays import IntervalArray
     ],
     ids=lambda x: str(x[0].dtype),
 )
-def left_right_dtypes(request):
+def fixture_left_right_dtypes(request):
     """
     Fixture for building an IntervalArray from various dtypes
     """

--- a/pandas/tests/arrays/interval/test_ops.py
+++ b/pandas/tests/arrays/interval/test_ops.py
@@ -12,8 +12,8 @@ import pandas._testing as tm
 from pandas.core.arrays import IntervalArray
 
 
-@pytest.fixture(params=[IntervalArray, IntervalIndex])
-def constructor(request):
+@pytest.fixture(name="constructor", params=[IntervalArray, IntervalIndex])
+def fixture_constructor(request):
     """
     Fixture for testing both interval container classes.
     """
@@ -21,6 +21,7 @@ def constructor(request):
 
 
 @pytest.fixture(
+    name="start_shift",
     params=[
         (Timedelta("0 days"), Timedelta("1 day")),
         (Timestamp("2018-01-01"), Timedelta("1 day")),
@@ -28,7 +29,7 @@ def constructor(request):
     ],
     ids=lambda x: type(x[0]).__name__,
 )
-def start_shift(request):
+def fixture_start_shift(request):
     """
     Fixture for generating intervals of different types from a start value
     and a shift value that can be added to start to generate an endpoint.

--- a/pandas/tests/arrays/masked/test_arithmetic.py
+++ b/pandas/tests/arrays/masked/test_arithmetic.py
@@ -19,8 +19,10 @@ arrays += [pd.array([True, False, True, None], dtype="boolean")]
 scalars += [False]
 
 
-@pytest.fixture(params=zip(arrays, scalars), ids=[a.dtype.name for a in arrays])
-def data(request):
+@pytest.fixture(
+    name="data", params=zip(arrays, scalars), ids=[a.dtype.name for a in arrays]
+)
+def fixture_data(request):
     """Fixture returning parametrized (array, scalar) tuple.
 
     Used to test equivalence of scalars, numpy arrays with array ops, and the

--- a/pandas/tests/arrays/masked/test_arrow_compat.py
+++ b/pandas/tests/arrays/masked/test_arrow_compat.py
@@ -13,8 +13,8 @@ arrays += [pd.array([0.1, 0.2, 0.3, None], dtype=dtype) for dtype in tm.FLOAT_EA
 arrays += [pd.array([True, False, True, None], dtype="boolean")]
 
 
-@pytest.fixture(params=arrays, ids=[a.dtype.name for a in arrays])
-def data(request):
+@pytest.fixture(name="data", params=arrays, ids=[a.dtype.name for a in arrays])
+def fixture_data(request):
     """
     Fixture returning parametrized array from given dtype, including integer,
     float and boolean
@@ -103,8 +103,8 @@ def test_arrow_sliced(data):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.fixture
-def np_dtype_to_arrays(any_real_numpy_dtype):
+@pytest.fixture(name="np_dtype_to_arrays")
+def fixture_np_dtype_to_arrays(any_real_numpy_dtype):
     """
     Fixture returning actual and expected dtype, pandas and numpy arrays and
     mask from a given numpy dtype

--- a/pandas/tests/arrays/masked/test_function.py
+++ b/pandas/tests/arrays/masked/test_function.py
@@ -12,8 +12,8 @@ arrays += [
 ]
 
 
-@pytest.fixture(params=arrays, ids=[a.dtype.name for a in arrays])
-def data(request):
+@pytest.fixture(name="data", params=arrays, ids=[a.dtype.name for a in arrays])
+def fixture_data(request):
     """
     Fixture returning parametrized 'data' array with different integer and
     floating point types
@@ -21,8 +21,8 @@ def data(request):
     return request.param
 
 
-@pytest.fixture()
-def numpy_dtype(data):
+@pytest.fixture(name="numpy_dtype")
+def fixture_numpy_dtype(data):
     """
     Fixture returning numpy dtype from 'data' input array.
     """

--- a/pandas/tests/arrays/numpy_/test_numpy.py
+++ b/pandas/tests/arrays/numpy_/test_numpy.py
@@ -13,6 +13,7 @@ from pandas.arrays import PandasArray
 
 
 @pytest.fixture(
+    name="any_numpy_array",
     params=[
         np.array(["a", "b"], dtype=object),
         np.array([0, 1], dtype=float),
@@ -21,9 +22,9 @@ from pandas.arrays import PandasArray
         np.array([True, False], dtype=bool),
         np.array([0, 1], dtype="datetime64[ns]"),
         np.array([0, 1], dtype="timedelta64[ns]"),
-    ]
+    ],
 )
-def any_numpy_array(request):
+def fixture_any_numpy_array(request):
     """
     Parametrized fixture for NumPy arrays with different dtypes.
 

--- a/pandas/tests/arrays/sparse/test_arithmetics.py
+++ b/pandas/tests/arrays/sparse/test_arithmetics.py
@@ -11,14 +11,14 @@ from pandas.core.arrays.sparse import (
 )
 
 
-@pytest.fixture(params=["integer", "block"])
-def kind(request):
+@pytest.fixture(name="kind", params=["integer", "block"])
+def fixture_kind(request):
     """kind kwarg to pass to SparseArray"""
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def mix(request):
+@pytest.fixture(name="mix", params=[True, False])
+def fixture_mix(request):
     """
     Fixture returning True or False, determining whether to operate
     op(sparse, dense) instead of op(sparse, sparse)

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -15,20 +15,20 @@ from pandas.core.arrays.sparse import (
 )
 
 
-@pytest.fixture
-def arr_data():
+@pytest.fixture(name="arr_data")
+def fixture_arr_data():
     """Fixture returning numpy array with valid and missing entries"""
     return np.array([np.nan, np.nan, 1, 2, 3, np.nan, 4, 5, np.nan, 6])
 
 
-@pytest.fixture
-def arr(arr_data):
+@pytest.fixture(name="arr")
+def fixture_arr(arr_data):
     """Fixture returning SparseArray from 'arr_data'"""
     return SparseArray(arr_data)
 
 
-@pytest.fixture
-def zarr():
+@pytest.fixture(name="zarr")
+def fixture_zarr():
     """Fixture returning SparseArray with integer entries and 'fill_value=0'"""
     return SparseArray([0, 0, 1, 2, 3, 0, 4, 5, 0, 6], fill_value=0)
 

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -15,14 +15,14 @@ import pandas._testing as tm
 from pandas.core.arrays.string_arrow import ArrowStringArray
 
 
-@pytest.fixture
-def dtype(string_storage):
+@pytest.fixture(name="dtype")
+def fixture_dtype(string_storage):
     """Fixture giving StringDtype from parametrized 'string_storage'"""
     return pd.StringDtype(storage=string_storage)
 
 
-@pytest.fixture
-def cls(dtype):
+@pytest.fixture(name="cls")
+def fixture_cls(dtype):
     """Fixture giving array type from parametrized 'dtype'"""
     return dtype.construct_array_type()
 

--- a/pandas/tests/arrays/test_array.py
+++ b/pandas/tests/arrays/test_array.py
@@ -396,8 +396,8 @@ def test_array_unboxes(index_or_series):
     tm.assert_equal(result, expected)
 
 
-@pytest.fixture
-def registry_without_decimal():
+@pytest.fixture(name="registry_without_decimal")
+def fixture_registry_without_decimal():
     """Fixture yielding 'registry' with no DecimalDtype entries"""
     idx = registry.dtypes.index(DecimalDtype)
     registry.dtypes.pop(idx)

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -31,14 +31,14 @@ from pandas.core.arrays.timedeltas import sequence_to_td64ns
 
 
 # TODO: more freq variants
-@pytest.fixture(params=["D", "B", "W", "M", "Q", "Y"])
-def freqstr(request):
+@pytest.fixture(name="freqstr", params=["D", "B", "W", "M", "Q", "Y"])
+def fixture_freqstr(request):
     """Fixture returning parametrized frequency in string format."""
     return request.param
 
 
-@pytest.fixture
-def period_index(freqstr):
+@pytest.fixture(name="period_index")
+def fixture_period_index(freqstr):
     """
     A fixture to provide PeriodIndex objects with different frequencies.
 
@@ -51,8 +51,8 @@ def period_index(freqstr):
     return pi
 
 
-@pytest.fixture
-def datetime_index(freqstr):
+@pytest.fixture(name="datetime_index")
+def fixture_datetime_index(freqstr):
     """
     A fixture to provide DatetimeIndex objects with different frequencies.
 
@@ -65,8 +65,8 @@ def datetime_index(freqstr):
     return dti
 
 
-@pytest.fixture
-def timedelta_index():
+@pytest.fixture(name="timedelta_index")
+def fixture_timedelta_index():
     """
     A fixture to provide TimedeltaIndex objects with different frequencies.
      Most TimedeltaArray behavior is already tested in TimedeltaIndex tests,
@@ -80,8 +80,8 @@ def timedelta_index():
 class SharedTests:
     index_cls: type[DatetimeIndex | PeriodIndex | TimedeltaIndex]
 
-    @pytest.fixture
-    def arr1d(self):
+    @pytest.fixture(name="arr1d")
+    def fixture_arr1d(self):
         """Fixture returning DatetimeArray with daily frequency."""
         data = np.arange(10, dtype="i8") * 24 * 3600 * 10**9
         arr = self.array_cls(data, freq="D")
@@ -602,8 +602,8 @@ class TestDatetimeArray(SharedTests):
     scalar_type = Timestamp
     example_dtype = "M8[ns]"
 
-    @pytest.fixture
-    def arr1d(self, tz_naive_fixture, freqstr):
+    @pytest.fixture(name="arr1d")
+    def fixture_arr1d(self, tz_naive_fixture, freqstr):
         """
         Fixture returning DatetimeArray with parametrized frequency and
         timezones
@@ -1009,8 +1009,8 @@ class TestPeriodArray(SharedTests):
     scalar_type = Period
     example_dtype = PeriodIndex([], freq="W").dtype
 
-    @pytest.fixture
-    def arr1d(self, period_index):
+    @pytest.fixture(name="arr1d")
+    def fixture_arr1d(self, period_index):
         """
         Fixture returning DatetimeArray from parametrized PeriodIndex objects
         """
@@ -1327,14 +1327,15 @@ def test_from_pandas_array(dtype):
 
 
 @pytest.fixture(
+    name="array_likes",
     params=[
         "memoryview",
         "array",
         pytest.param("dask", marks=td.skip_if_no("dask.array")),
         pytest.param("xarray", marks=td.skip_if_no("xarray")),
-    ]
+    ],
 )
-def array_likes(request):
+def fixture_array_likes(request):
     """
     Fixture giving a numpy array and a parametrized 'data' object, which can
     be a memoryview, array, dask or xarray object created from the numpy array.

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -28,21 +28,21 @@ from pandas.core.arrays import (
 
 
 class TestNonNano:
-    @pytest.fixture(params=["s", "ms", "us"])
-    def unit(self, request):
+    @pytest.fixture(name="unit", params=["s", "ms", "us"])
+    def fixture_unit(self, request):
         """Fixture returning parametrized time units"""
         return request.param
 
-    @pytest.fixture
-    def dtype(self, unit, tz_naive_fixture):
+    @pytest.fixture(name="dtype")
+    def fixture_dtype(self, unit, tz_naive_fixture):
         tz = tz_naive_fixture
         if tz is None:
             return np.dtype(f"datetime64[{unit}]")
         else:
             return DatetimeTZDtype(unit=unit, tz=tz)
 
-    @pytest.fixture
-    def dta_dti(self, unit, dtype):
+    @pytest.fixture(name="dta_dti")
+    def fixture_dta_dti(self, unit, dtype):
         tz = getattr(dtype, "tz", None)
 
         dti = pd.date_range("2016-01-01", periods=55, freq="D", tz=tz)
@@ -56,8 +56,8 @@ class TestNonNano:
         dta = DatetimeArray._simple_new(arr, dtype=dtype)
         return dta, dti
 
-    @pytest.fixture
-    def dta(self, dta_dti):
+    @pytest.fixture(name="dta")
+    def fixture_dta(self, dta_dti):
         dta, dti = dta_dti
         return dta
 

--- a/pandas/tests/arrays/test_timedeltas.py
+++ b/pandas/tests/arrays/test_timedeltas.py
@@ -13,12 +13,12 @@ from pandas.core.arrays import (
 
 
 class TestNonNano:
-    @pytest.fixture(params=["s", "ms", "us"])
-    def unit(self, request):
+    @pytest.fixture(name="unit", params=["s", "ms", "us"])
+    def fixture_unit(self, request):
         return request.param
 
-    @pytest.fixture
-    def tda(self, unit):
+    @pytest.fixture(name="tda")
+    def fixture_tda(self, unit):
         arr = np.arange(5, dtype=np.int64).view(f"m8[{unit}]")
         return TimedeltaArray._simple_new(arr, dtype=arr.dtype)
 

--- a/pandas/tests/base/test_constructors.py
+++ b/pandas/tests/base/test_constructors.py
@@ -29,6 +29,7 @@ def series_via_frame_from_scalar(x, **kwargs):
 
 
 @pytest.fixture(
+    name="constructor",
     params=[
         Series,
         series_via_frame_from_dict,
@@ -37,7 +38,7 @@ def series_via_frame_from_scalar(x, **kwargs):
     ],
     ids=["Series", "DataFrame-dict", "DataFrame-array", "Index"],
 )
-def constructor(request):
+def fixture_constructor(request):
     return request.param
 
 

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -115,8 +115,14 @@ def fixture_lhs(request):
     return opts[request.param]
 
 
-rhs = lhs
-midhs = lhs
+@pytest.fixture(name="rhs")
+def fixture_rhs(lhs):
+    yield lhs
+
+
+@pytest.fixture(name="midhs")
+def fixture_midhs(lhs):
+    yield lhs
 
 
 class TestEval:
@@ -1054,7 +1060,7 @@ class TestOperations:
     def test_simple_bool_ops(self, rhs, lhs, op):
         ex = f"{lhs} {op} {rhs}"
 
-        if parser == "python" and op in ["and", "or"]:
+        if fixture_parser == "python" and op in ["and", "or"]:
             msg = "'BoolOp' nodes are not implemented"
             with pytest.raises(NotImplementedError, match=msg):
                 self.eval(ex)
@@ -1070,7 +1076,7 @@ class TestOperations:
     def test_bool_ops_with_constants(self, rhs, lhs, op):
         ex = f"{lhs} {op} {rhs}"
 
-        if parser == "python" and op in ["and", "or"]:
+        if fixture_parser == "python" and op in ["and", "or"]:
             msg = "'BoolOp' nodes are not implemented"
             with pytest.raises(NotImplementedError, match=msg):
                 self.eval(ex)

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -55,6 +55,7 @@ from pandas.core.computation.scope import DEFAULT_GLOBALS
 
 
 @pytest.fixture(
+    name="engine",
     params=(
         pytest.param(
             engine,
@@ -68,14 +69,14 @@ from pandas.core.computation.scope import DEFAULT_GLOBALS
             ],
         )
         for engine in ENGINES
-    )
+    ),
 )
-def engine(request):
+def fixture_engine(request):
     return request.param
 
 
-@pytest.fixture(params=expr.PARSERS)
-def parser(request):
+@pytest.fixture(name="parser", params=expr.PARSERS)
+def fixture_parser(request):
     return request.param
 
 
@@ -95,10 +96,11 @@ def _eval_single_bin(lhs, cmp1, rhs, engine):
 
 # TODO: using range(5) here is a kludge
 @pytest.fixture(
+    name="lhs",
     params=list(range(5)),
     ids=["DataFrame", "Series", "SeriesNaN", "DataFrameNaN", "float"],
 )
-def lhs(request):
+def fixture_lhs(request):
 
     nan_df1 = DataFrame(np.random.rand(10, 5))
     nan_df1[nan_df1 > 0.5] = np.nan

--- a/pandas/tests/config/test_config.py
+++ b/pandas/tests/config/test_config.py
@@ -9,8 +9,8 @@ import pandas as pd
 
 
 class TestConfig:
-    @pytest.fixture(autouse=True)
-    def clean_config(self, monkeypatch):
+    @pytest.fixture(name="clean_config", autouse=True)
+    def fixture_clean_config(self, monkeypatch):
         with monkeypatch.context() as m:
             m.setattr(cf, "_global_config", {})
             m.setattr(cf, "options", cf.DictWrapper(cf._global_config))

--- a/pandas/tests/dtypes/cast/test_infer_dtype.py
+++ b/pandas/tests/dtypes/cast/test_infer_dtype.py
@@ -25,8 +25,8 @@ from pandas import (
 )
 
 
-@pytest.fixture(params=[True, False])
-def pandas_dtype(request):
+@pytest.fixture(name="pandas_dtype", params=[True, False])
+def fixture_pandas_dtype(request):
     return request.param
 
 

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -80,8 +80,8 @@ class Base:
 
 
 class TestCategoricalDtype(Base):
-    @pytest.fixture
-    def dtype(self):
+    @pytest.fixture(name="dtype")
+    def fixture_dtype(self):
         """
         Class level fixture of dtype for TestCategoricalDtype
         """
@@ -223,8 +223,8 @@ class TestCategoricalDtype(Base):
 
 
 class TestDatetimeTZDtype(Base):
-    @pytest.fixture
-    def dtype(self):
+    @pytest.fixture(name="dtype")
+    def fixture_dtype(self):
         """
         Class level fixture of dtype for TestDatetimeTZDtype
         """
@@ -383,8 +383,8 @@ class TestDatetimeTZDtype(Base):
 
 
 class TestPeriodDtype(Base):
-    @pytest.fixture
-    def dtype(self):
+    @pytest.fixture(name="dtype")
+    def fixture_dtype(self):
         """
         Class level fixture of dtype for TestPeriodDtype
         """
@@ -532,8 +532,8 @@ class TestPeriodDtype(Base):
 
 
 class TestIntervalDtype(Base):
-    @pytest.fixture
-    def dtype(self):
+    @pytest.fixture(name="dtype")
+    def fixture_dtype(self):
         """
         Class level fixture of dtype for TestIntervalDtype
         """

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -76,8 +76,8 @@ from pandas.core.arrays import (
 )
 
 
-@pytest.fixture(params=[True, False], ids=str)
-def coerce(request):
+@pytest.fixture(name="coerce", params=[True, False], ids=str)
+def fixture_coerce(request):
     return request.param
 
 
@@ -187,8 +187,8 @@ ll_params = [
 objs, expected, ids = zip(*ll_params)
 
 
-@pytest.fixture(params=zip(objs, expected), ids=ids)
-def maybe_list_like(request):
+@pytest.fixture(name="maybe_list_like", params=zip(objs, expected), ids=ids)
+def fixture_maybe_list_like(request):
     return request.param
 
 

--- a/pandas/tests/extension/base/setitem.py
+++ b/pandas/tests/extension/base/setitem.py
@@ -8,6 +8,7 @@ from pandas.tests.extension.base.base import BaseExtensionTests
 
 class BaseSetitemTests(BaseExtensionTests):
     @pytest.fixture(
+        name="full_indexer",
         params=[
             lambda x: x.index,
             lambda x: list(x.index),
@@ -27,7 +28,7 @@ class BaseSetitemTests(BaseExtensionTests):
             "mask",
         ],
     )
-    def full_indexer(self, request):
+    def fixture_full_indexer(self, request):
         """
         Fixture for an indexer to pass to obj.loc to get/set the full length of the
         object.

--- a/pandas/tests/extension/conftest.py
+++ b/pandas/tests/extension/conftest.py
@@ -5,14 +5,14 @@ import pytest
 from pandas import Series
 
 
-@pytest.fixture
-def dtype():
+@pytest.fixture(name="dtype")
+def fixture_dtype():
     """A fixture providing the ExtensionDtype to validate."""
     raise NotImplementedError
 
 
-@pytest.fixture
-def data():
+@pytest.fixture(name="data")
+def fixture_data():
     """
     Length-100 array for this type.
 
@@ -22,20 +22,20 @@ def data():
     raise NotImplementedError
 
 
-@pytest.fixture
-def data_for_twos():
+@pytest.fixture(name="data_for_twos")
+def fixture_data_for_twos():
     """Length-100 array in which all the elements are two."""
     raise NotImplementedError
 
 
-@pytest.fixture
-def data_missing():
+@pytest.fixture(name="data_missing")
+def fixture_data_missing():
     """Length-2 array with [NA, Valid]"""
     raise NotImplementedError
 
 
-@pytest.fixture(params=["data", "data_missing"])
-def all_data(request, data, data_missing):
+@pytest.fixture(name="all_data", params=["data", "data_missing"])
+def fixture_all_data(request, data, data_missing):
     """Parametrized fixture giving 'data' and 'data_missing'"""
     if request.param == "data":
         return data
@@ -43,8 +43,8 @@ def all_data(request, data, data_missing):
         return data_missing
 
 
-@pytest.fixture
-def data_repeated(data):
+@pytest.fixture(name="data_repeated")
+def fixture_data_repeated(data):
     """
     Generate many datasets.
 
@@ -66,8 +66,8 @@ def data_repeated(data):
     return gen
 
 
-@pytest.fixture
-def data_for_sorting():
+@pytest.fixture(name="data_for_sorting")
+def fixture_data_for_sorting():
     """
     Length-3 array with a known sort order.
 
@@ -77,8 +77,8 @@ def data_for_sorting():
     raise NotImplementedError
 
 
-@pytest.fixture
-def data_missing_for_sorting():
+@pytest.fixture(name="data_missing_for_sorting")
+def fixture_data_missing_for_sorting():
     """
     Length-3 array with a known sort order.
 
@@ -88,8 +88,8 @@ def data_missing_for_sorting():
     raise NotImplementedError
 
 
-@pytest.fixture
-def na_cmp():
+@pytest.fixture(name="na_cmp")
+def fixture_na_cmp():
     """
     Binary operator for comparing NA values.
 
@@ -101,14 +101,14 @@ def na_cmp():
     return operator.is_
 
 
-@pytest.fixture
-def na_value():
+@pytest.fixture(name="na_value")
+def fixture_na_value():
     """The scalar missing value for this type. Default 'None'"""
     return None
 
 
-@pytest.fixture
-def data_for_grouping():
+@pytest.fixture(name="data_for_grouping")
+def fixture_data_for_grouping():
     """
     Data for factorization, grouping, and unique tests.
 
@@ -119,13 +119,14 @@ def data_for_grouping():
     raise NotImplementedError
 
 
-@pytest.fixture(params=[True, False])
-def box_in_series(request):
+@pytest.fixture(name="box_in_series", params=[True, False])
+def fixture_box_in_series(request):
     """Whether to box the data in a Series"""
     return request.param
 
 
 @pytest.fixture(
+    name="groupby_apply_op",
     params=[
         lambda x: 1,
         lambda x: [1] * len(x),
@@ -134,31 +135,31 @@ def box_in_series(request):
     ],
     ids=["scalar", "list", "series", "object"],
 )
-def groupby_apply_op(request):
+def fixture_groupby_apply_op(request):
     """
     Functions to test groupby.apply().
     """
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def as_frame(request):
+@pytest.fixture(name="as_frame", params=[True, False])
+def fixture_as_frame(request):
     """
     Boolean fixture to support Series and Series.to_frame() comparison testing.
     """
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def as_series(request):
+@pytest.fixture(name="as_series", params=[True, False])
+def fixture_as_series(request):
     """
     Boolean fixture to support arr and Series(arr) comparison testing.
     """
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def use_numpy(request):
+@pytest.fixture(name="use_numpy", params=[True, False])
+def fixture_use_numpy(request):
     """
     Boolean fixture to support comparison testing of ExtensionDtype array
     and numpy array.
@@ -166,8 +167,8 @@ def use_numpy(request):
     return request.param
 
 
-@pytest.fixture(params=["ffill", "bfill"])
-def fillna_method(request):
+@pytest.fixture(name="fillna_method", params=["ffill", "bfill"])
+def fixture_fillna_method(request):
     """
     Parametrized fixture giving method parameters 'ffill' and 'bfill' for
     Series.fillna(method=<method>) testing.
@@ -175,16 +176,16 @@ def fillna_method(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def as_array(request):
+@pytest.fixture(name="as_array", params=[True, False])
+def fixture_as_array(request):
     """
     Boolean fixture to support ExtensionDtype _from_sequence method testing.
     """
     return request.param
 
 
-@pytest.fixture
-def invalid_scalar(data):
+@pytest.fixture(name="invalid_scalar")
+def fixture_invalid_scalar(data):
     """
     A scalar that *cannot* be held by this ExtensionArray.
 

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -16,52 +16,52 @@ from pandas.tests.extension.decimal.array import (
 )
 
 
-@pytest.fixture
-def dtype():
+@pytest.fixture(name="dtype")
+def fixture_dtype():
     return DecimalDtype()
 
 
-@pytest.fixture
-def data():
+@pytest.fixture(name="data")
+def fixture_data():
     return DecimalArray(make_data())
 
 
-@pytest.fixture
-def data_for_twos():
+@pytest.fixture(name="data_for_twos")
+def fixture_data_for_twos():
     return DecimalArray([decimal.Decimal(2) for _ in range(100)])
 
 
-@pytest.fixture
-def data_missing():
+@pytest.fixture(name="data_missing")
+def fixture_data_missing():
     return DecimalArray([decimal.Decimal("NaN"), decimal.Decimal(1)])
 
 
-@pytest.fixture
-def data_for_sorting():
+@pytest.fixture(name="data_for_sorting")
+def fixture_data_for_sorting():
     return DecimalArray(
         [decimal.Decimal("1"), decimal.Decimal("2"), decimal.Decimal("0")]
     )
 
 
-@pytest.fixture
-def data_missing_for_sorting():
+@pytest.fixture(name="data_missing_for_sorting")
+def fixture_data_missing_for_sorting():
     return DecimalArray(
         [decimal.Decimal("1"), decimal.Decimal("NaN"), decimal.Decimal("0")]
     )
 
 
-@pytest.fixture
-def na_cmp():
+@pytest.fixture(name="na_cmp")
+def fixture_na_cmp():
     return lambda x, y: x.is_nan() and y.is_nan()
 
 
-@pytest.fixture
-def na_value():
+@pytest.fixture(name="na_value")
+def fixture_na_value():
     return decimal.Decimal("NaN")
 
 
-@pytest.fixture
-def data_for_grouping():
+@pytest.fixture(name="data_for_grouping")
+def fixture_data_for_grouping():
     b = decimal.Decimal("1.0")
     a = decimal.Decimal("0.0")
     c = decimal.Decimal("2.0")

--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -14,13 +14,13 @@ from pandas.tests.extension.json.array import (
 )
 
 
-@pytest.fixture
-def dtype():
+@pytest.fixture(name="dtype")
+def fixture_dtype():
     return JSONDtype()
 
 
-@pytest.fixture
-def data():
+@pytest.fixture(name="data")
+def fixture_data():
     """Length-100 PeriodArray for semantics test."""
     data = make_data()
 
@@ -36,34 +36,34 @@ def data():
     return JSONArray(data)
 
 
-@pytest.fixture
-def data_missing():
+@pytest.fixture(name="data_missing")
+def fixture_data_missing():
     """Length 2 array with [NA, Valid]"""
     return JSONArray([{}, {"a": 10}])
 
 
-@pytest.fixture
-def data_for_sorting():
+@pytest.fixture(name="data_for_sorting")
+def fixture_data_for_sorting():
     return JSONArray([{"b": 1}, {"c": 4}, {"a": 2, "c": 3}])
 
 
-@pytest.fixture
-def data_missing_for_sorting():
+@pytest.fixture(name="data_missing_for_sorting")
+def fixture_data_missing_for_sorting():
     return JSONArray([{"b": 1}, {}, {"a": 4}])
 
 
-@pytest.fixture
-def na_value(dtype):
+@pytest.fixture(name="na_value")
+def fixture_na_value(dtype):
     return dtype.na_value
 
 
-@pytest.fixture
-def na_cmp():
+@pytest.fixture(name="na_cmp")
+def fixture_na_cmp():
     return operator.eq
 
 
-@pytest.fixture
-def data_for_grouping():
+@pytest.fixture(name="data_for_grouping")
+def fixture_data_for_grouping():
     return JSONArray(
         [
             {"b": 1},

--- a/pandas/tests/extension/list/test_list.py
+++ b/pandas/tests/extension/list/test_list.py
@@ -8,13 +8,13 @@ from pandas.tests.extension.list.array import (
 )
 
 
-@pytest.fixture
-def dtype():
+@pytest.fixture(name="dtype")
+def fixture_dtype():
     return ListDtype()
 
 
-@pytest.fixture
-def data():
+@pytest.fixture(name="data")
+def fixture_data():
     """Length-100 ListArray for semantics test."""
     data = make_data()
 

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -51,13 +51,13 @@ pytestmark = pytest.mark.filterwarnings(
 )
 
 
-@pytest.fixture(params=tm.ALL_PYARROW_DTYPES, ids=str)
-def dtype(request):
+@pytest.fixture(name="dtype", params=tm.ALL_PYARROW_DTYPES, ids=str)
+def fixture_dtype(request):
     return ArrowDtype(pyarrow_dtype=request.param)
 
 
-@pytest.fixture
-def data(dtype):
+@pytest.fixture(name="data")
+def fixture_data(dtype):
     pa_dtype = dtype.pyarrow_dtype
     if pa.types.is_boolean(pa_dtype):
         data = [True, False] * 4 + [None] + [True, False] * 44 + [None] + [True, False]
@@ -108,14 +108,14 @@ def data(dtype):
     return pd.array(data, dtype=dtype)
 
 
-@pytest.fixture
-def data_missing(data):
+@pytest.fixture(name="data_missing")
+def fixture_data_missing(data):
     """Length-2 array with [NA, Valid]"""
     return type(data)._from_sequence([None, data[0]])
 
 
-@pytest.fixture(params=["data", "data_missing"])
-def all_data(request, data, data_missing):
+@pytest.fixture(name="all_data", params=["data", "data_missing"])
+def fixture_all_data(request, data, data_missing):
     """Parametrized fixture returning 'data' or 'data_missing' integer arrays.
 
     Used to test dtype conversion with and without missing values.
@@ -126,8 +126,8 @@ def all_data(request, data, data_missing):
         return data_missing
 
 
-@pytest.fixture
-def data_for_grouping(dtype):
+@pytest.fixture(name="data_for_grouping")
+def fixture_data_for_grouping(dtype):
     """
     Data for factorization, grouping, and unique tests.
 
@@ -181,8 +181,8 @@ def data_for_grouping(dtype):
     return pd.array([B, B, None, None, A, A, B, C], dtype=dtype)
 
 
-@pytest.fixture
-def data_for_sorting(data_for_grouping):
+@pytest.fixture(name="data_for_sorting")
+def fixture_data_for_sorting(data_for_grouping):
     """
     Length-3 array with a known sort order.
 
@@ -194,8 +194,8 @@ def data_for_sorting(data_for_grouping):
     )
 
 
-@pytest.fixture
-def data_missing_for_sorting(data_for_grouping):
+@pytest.fixture(name="data_missing_for_sorting")
+def fixture_data_missing_for_sorting(data_for_grouping):
     """
     Length-3 array with a known sort order.
 
@@ -207,8 +207,8 @@ def data_missing_for_sorting(data_for_grouping):
     )
 
 
-@pytest.fixture
-def data_for_twos(data):
+@pytest.fixture(name="data_for_twos")
+def fixture_data_for_twos(data):
     """Length-100 array in which all the elements are two."""
     pa_dtype = data.dtype.pyarrow_dtype
     if pa.types.is_integer(pa_dtype) or pa.types.is_floating(pa_dtype):
@@ -217,8 +217,8 @@ def data_for_twos(data):
     return data
 
 
-@pytest.fixture
-def na_value():
+@pytest.fixture(name="na_value")
+def fixture_na_value():
     """The scalar missing value for this type. Default 'None'"""
     return pd.NA
 

--- a/pandas/tests/extension/test_boolean.py
+++ b/pandas/tests/extension/test_boolean.py
@@ -28,49 +28,49 @@ def make_data():
     return [True, False] * 4 + [np.nan] + [True, False] * 44 + [np.nan] + [True, False]
 
 
-@pytest.fixture
-def dtype():
+@pytest.fixture(name="dtype")
+def fixture_dtype():
     return BooleanDtype()
 
 
-@pytest.fixture
-def data(dtype):
+@pytest.fixture(name="data")
+def fixture_data(dtype):
     return pd.array(make_data(), dtype=dtype)
 
 
-@pytest.fixture
-def data_for_twos(dtype):
+@pytest.fixture(name="data_for_twos")
+def fixture_data_for_twos(dtype):
     return pd.array(np.ones(100), dtype=dtype)
 
 
-@pytest.fixture
-def data_missing(dtype):
+@pytest.fixture(name="data_missing")
+def fixture_data_missing(dtype):
     return pd.array([np.nan, True], dtype=dtype)
 
 
-@pytest.fixture
-def data_for_sorting(dtype):
+@pytest.fixture(name="data_for_sorting")
+def fixture_data_for_sorting(dtype):
     return pd.array([True, True, False], dtype=dtype)
 
 
-@pytest.fixture
-def data_missing_for_sorting(dtype):
+@pytest.fixture(name="data_missing_for_sorting")
+def fixture_data_missing_for_sorting(dtype):
     return pd.array([True, np.nan, False], dtype=dtype)
 
 
-@pytest.fixture
-def na_cmp():
+@pytest.fixture(name="na_cmp")
+def fixture_na_cmp():
     # we are pd.NA
     return lambda x, y: x is pd.NA and y is pd.NA
 
 
-@pytest.fixture
-def na_value():
+@pytest.fixture(name="na_value")
+def fixture_na_value():
     return pd.NA
 
 
-@pytest.fixture
-def data_for_grouping(dtype):
+@pytest.fixture(name="data_for_grouping")
+def fixture_data_for_grouping(dtype):
     b = True
     a = False
     na = np.nan

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -40,13 +40,13 @@ def make_data():
     return values
 
 
-@pytest.fixture
-def dtype():
+@pytest.fixture(name="dtype")
+def fixture_dtype():
     return CategoricalDtype()
 
 
-@pytest.fixture
-def data():
+@pytest.fixture(name="data")
+def fixture_data():
     """Length-100 array for this type.
 
     * data[0] and data[1] should both be non missing
@@ -55,29 +55,29 @@ def data():
     return Categorical(make_data())
 
 
-@pytest.fixture
-def data_missing():
+@pytest.fixture(name="data_missing")
+def fixture_data_missing():
     """Length 2 array with [NA, Valid]"""
     return Categorical([np.nan, "A"])
 
 
-@pytest.fixture
-def data_for_sorting():
+@pytest.fixture(name="data_for_sorting")
+def fixture_data_for_sorting():
     return Categorical(["A", "B", "C"], categories=["C", "A", "B"], ordered=True)
 
 
-@pytest.fixture
-def data_missing_for_sorting():
+@pytest.fixture(name="data_missing_for_sorting")
+def fixture_data_missing_for_sorting():
     return Categorical(["A", None, "B"], categories=["B", "A"], ordered=True)
 
 
-@pytest.fixture
-def na_value():
+@pytest.fixture(name="na_value")
+def fixture_na_value():
     return np.nan
 
 
-@pytest.fixture
-def data_for_grouping():
+@pytest.fixture(name="data_for_grouping")
+def fixture_data_for_grouping():
     return Categorical(["a", "a", None, None, "b", "b", "a", "c"])
 
 

--- a/pandas/tests/extension/test_datetime.py
+++ b/pandas/tests/extension/test_datetime.py
@@ -23,41 +23,41 @@ from pandas.core.arrays import DatetimeArray
 from pandas.tests.extension import base
 
 
-@pytest.fixture(params=["US/Central"])
-def dtype(request):
+@pytest.fixture(name="dtype", params=["US/Central"])
+def fixture_dtype(request):
     return DatetimeTZDtype(unit="ns", tz=request.param)
 
 
-@pytest.fixture
-def data(dtype):
+@pytest.fixture(name="data")
+def fixture_data(dtype):
     data = DatetimeArray(pd.date_range("2000", periods=100, tz=dtype.tz), dtype=dtype)
     return data
 
 
-@pytest.fixture
-def data_missing(dtype):
+@pytest.fixture(name="data_missing")
+def fixture_data_missing(dtype):
     return DatetimeArray(
         np.array(["NaT", "2000-01-01"], dtype="datetime64[ns]"), dtype=dtype
     )
 
 
-@pytest.fixture
-def data_for_sorting(dtype):
+@pytest.fixture(name="data_for_sorting")
+def fixture_data_for_sorting(dtype):
     a = pd.Timestamp("2000-01-01")
     b = pd.Timestamp("2000-01-02")
     c = pd.Timestamp("2000-01-03")
     return DatetimeArray(np.array([b, c, a], dtype="datetime64[ns]"), dtype=dtype)
 
 
-@pytest.fixture
-def data_missing_for_sorting(dtype):
+@pytest.fixture(name="data_missing_for_sorting")
+def fixture_data_missing_for_sorting(dtype):
     a = pd.Timestamp("2000-01-01")
     b = pd.Timestamp("2000-01-02")
     return DatetimeArray(np.array([b, "NaT", a], dtype="datetime64[ns]"), dtype=dtype)
 
 
-@pytest.fixture
-def data_for_grouping(dtype):
+@pytest.fixture(name="data_for_grouping")
+def fixture_data_for_grouping(dtype):
     """
     Expected to be like [B, B, NA, NA, A, A, B, C]
 
@@ -72,16 +72,16 @@ def data_for_grouping(dtype):
     )
 
 
-@pytest.fixture
-def na_cmp():
+@pytest.fixture(name="na_cmp")
+def fixture_na_cmp():
     def cmp(a, b):
         return a is pd.NaT and a is b
 
     return cmp
 
 
-@pytest.fixture
-def na_value():
+@pytest.fixture(name="na_value")
+def fixture_na_value():
     return pd.NaT
 
 

--- a/pandas/tests/extension/test_extension.py
+++ b/pandas/tests/extension/test_extension.py
@@ -12,8 +12,8 @@ class MyEA(ExtensionArray):
         self._values = values
 
 
-@pytest.fixture
-def data():
+@pytest.fixture(name="data")
+def fixture_data():
     arr = np.arange(10)
     return MyEA(arr)
 

--- a/pandas/tests/extension/test_external_block.py
+++ b/pandas/tests/extension/test_external_block.py
@@ -21,8 +21,8 @@ class CustomBlock(ExtensionBlock):
         return False
 
 
-@pytest.fixture
-def df():
+@pytest.fixture(name="df")
+def fixture_df():
     df1 = pd.DataFrame({"a": [1, 2, 3]})
     blocks = df1._mgr.blocks
     values = np.arange(3, dtype="int64")

--- a/pandas/tests/extension/test_floating.py
+++ b/pandas/tests/extension/test_floating.py
@@ -38,49 +38,49 @@ def make_data():
     )
 
 
-@pytest.fixture(params=[Float32Dtype, Float64Dtype])
-def dtype(request):
+@pytest.fixture(name="dtype", params=[Float32Dtype, Float64Dtype])
+def fixture_dtype(request):
     return request.param()
 
 
-@pytest.fixture
-def data(dtype):
+@pytest.fixture(name="data")
+def fixture_data(dtype):
     return pd.array(make_data(), dtype=dtype)
 
 
-@pytest.fixture
-def data_for_twos(dtype):
+@pytest.fixture(name="data_for_twos")
+def fixture_data_for_twos(dtype):
     return pd.array(np.ones(100) * 2, dtype=dtype)
 
 
-@pytest.fixture
-def data_missing(dtype):
+@pytest.fixture(name="data_missing")
+def fixture_data_missing(dtype):
     return pd.array([pd.NA, 0.1], dtype=dtype)
 
 
-@pytest.fixture
-def data_for_sorting(dtype):
+@pytest.fixture(name="data_for_sorting")
+def fixture_data_for_sorting(dtype):
     return pd.array([0.1, 0.2, 0.0], dtype=dtype)
 
 
-@pytest.fixture
-def data_missing_for_sorting(dtype):
+@pytest.fixture(name="data_missing_for_sorting")
+def fixture_data_missing_for_sorting(dtype):
     return pd.array([0.1, pd.NA, 0.0], dtype=dtype)
 
 
-@pytest.fixture
-def na_cmp():
+@pytest.fixture(name="na_cmp")
+def fixture_na_cmp():
     # we are pd.NA
     return lambda x, y: x is pd.NA and y is pd.NA
 
 
-@pytest.fixture
-def na_value():
+@pytest.fixture(name="na_value")
+def fixture_na_value():
     return pd.NA
 
 
-@pytest.fixture
-def data_for_grouping(dtype):
+@pytest.fixture(name="data_for_grouping")
+def fixture_data_for_grouping(dtype):
     b = 0.1
     a = 0.0
     c = 0.2

--- a/pandas/tests/extension/test_integer.py
+++ b/pandas/tests/extension/test_integer.py
@@ -45,6 +45,7 @@ def make_data():
 
 
 @pytest.fixture(
+    name="dtype",
     params=[
         Int8Dtype,
         Int16Dtype,
@@ -54,50 +55,50 @@ def make_data():
         UInt16Dtype,
         UInt32Dtype,
         UInt64Dtype,
-    ]
+    ],
 )
-def dtype(request):
+def fixture_dtype(request):
     return request.param()
 
 
-@pytest.fixture
-def data(dtype):
+@pytest.fixture(name="data")
+def fixture_data(dtype):
     return pd.array(make_data(), dtype=dtype)
 
 
-@pytest.fixture
-def data_for_twos(dtype):
+@pytest.fixture(name="data_for_twos")
+def fixture_data_for_twos(dtype):
     return pd.array(np.ones(100) * 2, dtype=dtype)
 
 
-@pytest.fixture
-def data_missing(dtype):
+@pytest.fixture(name="data_missing")
+def fixture_data_missing(dtype):
     return pd.array([pd.NA, 1], dtype=dtype)
 
 
-@pytest.fixture
-def data_for_sorting(dtype):
+@pytest.fixture(name="data_for_sorting")
+def fixture_data_for_sorting(dtype):
     return pd.array([1, 2, 0], dtype=dtype)
 
 
-@pytest.fixture
-def data_missing_for_sorting(dtype):
+@pytest.fixture(name="data_missing_for_sorting")
+def fixture_data_missing_for_sorting(dtype):
     return pd.array([1, pd.NA, 0], dtype=dtype)
 
 
-@pytest.fixture
-def na_cmp():
+@pytest.fixture(name="na_cmp")
+def fixture_na_cmp():
     # we are pd.NA
     return lambda x, y: x is pd.NA and y is pd.NA
 
 
-@pytest.fixture
-def na_value():
+@pytest.fixture(name="na_value")
+def fixture_na_value():
     return pd.NA
 
 
-@pytest.fixture
-def data_for_grouping(dtype):
+@pytest.fixture(name="data_for_grouping")
+def fixture_data_for_grouping(dtype):
     b = 1
     a = 0
     c = 2

--- a/pandas/tests/extension/test_interval.py
+++ b/pandas/tests/extension/test_interval.py
@@ -33,40 +33,40 @@ def make_data():
     return [Interval(left, right) for left, right in zip(left_array, right_array)]
 
 
-@pytest.fixture
-def dtype():
+@pytest.fixture(name="dtype")
+def fixture_dtype():
     return IntervalDtype()
 
 
-@pytest.fixture
-def data():
+@pytest.fixture(name="data")
+def fixture_data():
     """Length-100 PeriodArray for semantics test."""
     return IntervalArray(make_data())
 
 
-@pytest.fixture
-def data_missing():
+@pytest.fixture(name="data_missing")
+def fixture_data_missing():
     """Length 2 array with [NA, Valid]"""
     return IntervalArray.from_tuples([None, (0, 1)])
 
 
-@pytest.fixture
-def data_for_sorting():
+@pytest.fixture(name="data_for_sorting")
+def fixture_data_for_sorting():
     return IntervalArray.from_tuples([(1, 2), (2, 3), (0, 1)])
 
 
-@pytest.fixture
-def data_missing_for_sorting():
+@pytest.fixture(name="data_missing_for_sorting")
+def fixture_data_missing_for_sorting():
     return IntervalArray.from_tuples([(1, 2), None, (0, 1)])
 
 
-@pytest.fixture
-def na_value():
+@pytest.fixture(name="na_value")
+def fixture_na_value():
     return np.nan
 
 
-@pytest.fixture
-def data_for_grouping():
+@pytest.fixture(name="data_for_grouping")
+def fixture_data_for_grouping():
     a = (0, 1)
     b = (1, 2)
     c = (2, 3)

--- a/pandas/tests/extension/test_numpy.py
+++ b/pandas/tests/extension/test_numpy.py
@@ -57,13 +57,13 @@ def _assert_attr_equal(attr: str, left, right, obj: str = "Attributes"):
     orig_assert_attr_equal(attr, left, right, obj)
 
 
-@pytest.fixture(params=["float", "object"])
-def dtype(request):
+@pytest.fixture(name="dtype", params=["float", "object"])
+def fixture_dtype(request):
     return PandasDtype(np.dtype(request.param))
 
 
-@pytest.fixture
-def allow_in_pandas(monkeypatch):
+@pytest.fixture(name="allow_in_pandas")
+def fixture_allow_in_pandas(monkeypatch):
     """
     A monkeypatch to tells pandas to let us in.
 
@@ -86,35 +86,35 @@ def allow_in_pandas(monkeypatch):
         yield
 
 
-@pytest.fixture
-def data(allow_in_pandas, dtype):
+@pytest.fixture(name="data")
+def fixture_data(allow_in_pandas, dtype):
     if dtype.numpy_dtype == "object":
         return pd.Series([(i,) for i in range(100)]).array
     return PandasArray(np.arange(1, 101, dtype=dtype._dtype))
 
 
-@pytest.fixture
-def data_missing(allow_in_pandas, dtype):
+@pytest.fixture(name="data_missing")
+def fixture_data_missing(allow_in_pandas, dtype):
     if dtype.numpy_dtype == "object":
         return PandasArray(np.array([np.nan, (1,)], dtype=object))
     return PandasArray(np.array([np.nan, 1.0]))
 
 
-@pytest.fixture
-def na_value():
+@pytest.fixture(name="na_value")
+def fixture_na_value():
     return np.nan
 
 
-@pytest.fixture
-def na_cmp():
+@pytest.fixture(name="na_cmp")
+def fixture_na_cmp():
     def cmp(a, b):
         return np.isnan(a) and np.isnan(b)
 
     return cmp
 
 
-@pytest.fixture
-def data_for_sorting(allow_in_pandas, dtype):
+@pytest.fixture(name="data_for_sorting")
+def fixture_data_for_sorting(allow_in_pandas, dtype):
     """Length-3 array with a known sort order.
 
     This should be three items [B, C, A] with
@@ -127,8 +127,8 @@ def data_for_sorting(allow_in_pandas, dtype):
     return PandasArray(np.array([1, 2, 0]))
 
 
-@pytest.fixture
-def data_missing_for_sorting(allow_in_pandas, dtype):
+@pytest.fixture(name="data_missing_for_sorting")
+def fixture_data_missing_for_sorting(allow_in_pandas, dtype):
     """Length-3 array with a known sort order.
 
     This should be three items [B, NA, A] with
@@ -139,8 +139,8 @@ def data_missing_for_sorting(allow_in_pandas, dtype):
     return PandasArray(np.array([1, np.nan, 0]))
 
 
-@pytest.fixture
-def data_for_grouping(allow_in_pandas, dtype):
+@pytest.fixture(name="data_for_grouping")
+def fixture_data_for_grouping(allow_in_pandas, dtype):
     """Data for factorization, grouping, and unique tests.
 
     Expected to be like [B, B, NA, NA, A, A, B, C]
@@ -156,8 +156,8 @@ def data_for_grouping(allow_in_pandas, dtype):
     )
 
 
-@pytest.fixture
-def skip_numpy_object(dtype, request):
+@pytest.fixture(name="skip_numpy_object")
+def fixture_skip_numpy_object(dtype, request):
     """
     Tests for PandasArray with nested data. Users typically won't create
     these objects via `pd.array`, but they can show up through `.array`

--- a/pandas/tests/extension/test_period.py
+++ b/pandas/tests/extension/test_period.py
@@ -25,38 +25,38 @@ from pandas.core.arrays import PeriodArray
 from pandas.tests.extension import base
 
 
-@pytest.fixture(params=["D", "2D"])
-def dtype(request):
+@pytest.fixture(name="dtype", params=["D", "2D"])
+def fixture_dtype(request):
     return PeriodDtype(freq=request.param)
 
 
-@pytest.fixture
-def data(dtype):
+@pytest.fixture(name="data")
+def fixture_data(dtype):
     return PeriodArray(np.arange(1970, 2070), freq=dtype.freq)
 
 
-@pytest.fixture
-def data_for_twos(dtype):
+@pytest.fixture(name="data_for_twos")
+def fixture_data_for_twos(dtype):
     return PeriodArray(np.ones(100) * 2, freq=dtype.freq)
 
 
-@pytest.fixture
-def data_for_sorting(dtype):
+@pytest.fixture(name="data_for_sorting")
+def fixture_data_for_sorting(dtype):
     return PeriodArray([2018, 2019, 2017], freq=dtype.freq)
 
 
-@pytest.fixture
-def data_missing(dtype):
+@pytest.fixture(name="data_missing")
+def fixture_data_missing(dtype):
     return PeriodArray([iNaT, 2017], freq=dtype.freq)
 
 
-@pytest.fixture
-def data_missing_for_sorting(dtype):
+@pytest.fixture(name="data_missing_for_sorting")
+def fixture_data_missing_for_sorting(dtype):
     return PeriodArray([2018, iNaT, 2017], freq=dtype.freq)
 
 
-@pytest.fixture
-def data_for_grouping(dtype):
+@pytest.fixture(name="data_for_grouping")
+def fixture_data_for_grouping(dtype):
     B = 2018
     NA = iNaT
     A = 2017
@@ -64,8 +64,8 @@ def data_for_grouping(dtype):
     return PeriodArray([B, B, NA, NA, A, A, B, C], freq=dtype.freq)
 
 
-@pytest.fixture
-def na_value():
+@pytest.fixture(name="na_value")
+def fixture_na_value():
     return pd.NaT
 
 

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -38,31 +38,31 @@ def make_data(fill_value):
     return data
 
 
-@pytest.fixture
-def dtype():
+@pytest.fixture(name="dtype")
+def fixture_dtype():
     return SparseDtype()
 
 
-@pytest.fixture(params=[0, np.nan])
-def data(request):
+@pytest.fixture(name="data", params=[0, np.nan])
+def fixture_data(request):
     """Length-100 PeriodArray for semantics test."""
     res = SparseArray(make_data(request.param), fill_value=request.param)
     return res
 
 
-@pytest.fixture
-def data_for_twos():
+@pytest.fixture(name="data_for_twos")
+def fixture_data_for_twos():
     return SparseArray(np.ones(100) * 2)
 
 
-@pytest.fixture(params=[0, np.nan])
-def data_missing(request):
+@pytest.fixture(name="data_missing", params=[0, np.nan])
+def fixture_data_missing(request):
     """Length 2 array with [NA, Valid]"""
     return SparseArray([np.nan, 1], fill_value=request.param)
 
 
-@pytest.fixture(params=[0, np.nan])
-def data_repeated(request):
+@pytest.fixture(name="data_repeated", params=[0, np.nan])
+def fixture_data_repeated(request):
     """Return different versions of data for count times"""
 
     def gen(count):
@@ -72,33 +72,33 @@ def data_repeated(request):
     yield gen
 
 
-@pytest.fixture(params=[0, np.nan])
-def data_for_sorting(request):
+@pytest.fixture(name="data_for_sorting", params=[0, np.nan])
+def fixture_data_for_sorting(request):
     return SparseArray([2, 3, 1], fill_value=request.param)
 
 
-@pytest.fixture(params=[0, np.nan])
-def data_missing_for_sorting(request):
+@pytest.fixture(name="data_missing_for_sorting", params=[0, np.nan])
+def fixture_data_missing_for_sorting(request):
     return SparseArray([2, np.nan, 1], fill_value=request.param)
 
 
-@pytest.fixture
-def na_value():
+@pytest.fixture(name="na_value")
+def fixture_na_value():
     return np.nan
 
 
-@pytest.fixture
-def na_cmp():
+@pytest.fixture(name="na_cmp")
+def fixture_na_cmp():
     return lambda left, right: pd.isna(left) and pd.isna(right)
 
 
-@pytest.fixture(params=[0, np.nan])
-def data_for_grouping(request):
+@pytest.fixture(name="data_for_grouping", params=[0, np.nan])
+def fixture_data_for_grouping(request):
     return SparseArray([1, 1, np.nan, np.nan, 2, 2, 1, 3], fill_value=request.param)
 
 
-@pytest.fixture(params=[0, np.nan])
-def data_for_compare(request):
+@pytest.fixture(name="data_for_compare", params=[0, np.nan])
+def fixture_data_for_compare(request):
     return SparseArray([0, 0, np.nan, -2, -1, 4, 2, 3, 0, 0], fill_value=request.param)
 
 

--- a/pandas/tests/extension/test_string.py
+++ b/pandas/tests/extension/test_string.py
@@ -50,18 +50,18 @@ def split_array(arr):
     return _split_array(arr)
 
 
-@pytest.fixture(params=[True, False])
-def chunked(request):
+@pytest.fixture(name="chunked", params=[True, False])
+def fixture_chunked(request):
     return request.param
 
 
-@pytest.fixture
-def dtype(string_storage):
+@pytest.fixture(name="dtype")
+def fixture_dtype(string_storage):
     return StringDtype(storage=string_storage)
 
 
-@pytest.fixture
-def data(dtype, chunked):
+@pytest.fixture(name="data")
+def fixture_data(dtype, chunked):
     strings = np.random.choice(list(string.ascii_letters), size=100)
     while strings[0] == strings[1]:
         strings = np.random.choice(list(string.ascii_letters), size=100)
@@ -70,32 +70,32 @@ def data(dtype, chunked):
     return split_array(arr) if chunked else arr
 
 
-@pytest.fixture
-def data_missing(dtype, chunked):
+@pytest.fixture(name="data_missing")
+def fixture_data_missing(dtype, chunked):
     """Length 2 array with [NA, Valid]"""
     arr = dtype.construct_array_type()._from_sequence([pd.NA, "A"])
     return split_array(arr) if chunked else arr
 
 
-@pytest.fixture
-def data_for_sorting(dtype, chunked):
+@pytest.fixture(name="data_for_sorting")
+def fixture_data_for_sorting(dtype, chunked):
     arr = dtype.construct_array_type()._from_sequence(["B", "C", "A"])
     return split_array(arr) if chunked else arr
 
 
-@pytest.fixture
-def data_missing_for_sorting(dtype, chunked):
+@pytest.fixture(name="data_missing_for_sorting")
+def fixture_data_missing_for_sorting(dtype, chunked):
     arr = dtype.construct_array_type()._from_sequence(["B", pd.NA, "A"])
     return split_array(arr) if chunked else arr
 
 
-@pytest.fixture
-def na_value():
+@pytest.fixture(name="na_value")
+def fixture_na_value():
     return pd.NA
 
 
-@pytest.fixture
-def data_for_grouping(dtype, chunked):
+@pytest.fixture(name="data_for_grouping")
+def fixture_data_for_grouping(dtype, chunked):
     arr = dtype.construct_array_type()._from_sequence(
         ["B", "B", pd.NA, pd.NA, "A", "A", "B", "C"]
     )
@@ -413,8 +413,8 @@ class TestGroupBy(base.BaseGroupbyTests):
 
 
 class Test2DCompat(base.Dim2CompatTests):
-    @pytest.fixture(autouse=True)
-    def arrow_not_supported(self, data, request):
+    @pytest.fixture(name="arrow_not_supported", autouse=True)
+    def fixture_arrow_not_supported(self, data, request):
         if isinstance(data, ArrowStringArray):
             mark = pytest.mark.xfail(
                 reason="2D support not implemented for ArrowStringArray"

--- a/pandas/tests/frame/conftest.py
+++ b/pandas/tests/frame/conftest.py
@@ -9,8 +9,8 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.fixture
-def float_frame_with_na():
+@pytest.fixture(name="float_frame_with_na")
+def fixture_float_frame_with_na():
     """
     Fixture for DataFrame of floats with index of unique strings
 
@@ -42,8 +42,8 @@ def float_frame_with_na():
     return df
 
 
-@pytest.fixture
-def bool_frame_with_na():
+@pytest.fixture(name="bool_frame_with_na")
+def fixture_bool_frame_with_na():
     """
     Fixture for DataFrame of booleans with index of unique strings
 
@@ -81,8 +81,8 @@ def bool_frame_with_na():
     return df
 
 
-@pytest.fixture
-def float_string_frame():
+@pytest.fixture(name="float_string_frame")
+def fixture_float_string_frame():
     """
     Fixture for DataFrame of floats and strings with index of unique strings
 
@@ -112,8 +112,8 @@ def float_string_frame():
     return df
 
 
-@pytest.fixture
-def mixed_float_frame():
+@pytest.fixture(name="mixed_float_frame")
+def fixture_mixed_float_frame():
     """
     Fixture for DataFrame of different float types with index of unique strings
 
@@ -146,8 +146,8 @@ def mixed_float_frame():
     return df
 
 
-@pytest.fixture
-def mixed_int_frame():
+@pytest.fixture(name="mixed_int_frame")
+def fixture_mixed_int_frame():
     """
     Fixture for DataFrame of different int types with index of unique strings
 
@@ -180,8 +180,8 @@ def mixed_int_frame():
     return df
 
 
-@pytest.fixture
-def timezone_frame():
+@pytest.fixture(name="timezone_frame")
+def fixture_timezone_frame():
     """
     Fixture for DataFrame of date_range Series with different time zones
 
@@ -204,8 +204,8 @@ def timezone_frame():
     return df
 
 
-@pytest.fixture
-def uint64_frame():
+@pytest.fixture(name="uint64_frame")
+def fixture_uint64_frame():
     """
     Fixture for DataFrame with uint64 values
 
@@ -216,8 +216,8 @@ def uint64_frame():
     )
 
 
-@pytest.fixture
-def simple_frame():
+@pytest.fixture(name="simple_frame")
+def fixture_simple_frame():
     """
     Fixture for simple 3x3 DataFrame
 
@@ -233,8 +233,8 @@ def simple_frame():
     return DataFrame(arr, columns=["one", "two", "three"], index=["a", "b", "c"])
 
 
-@pytest.fixture
-def frame_of_index_cols():
+@pytest.fixture(name="frame_of_index_cols")
+def fixture_frame_of_index_cols():
     """
     Fixture for DataFrame of columns that can be used for indexing
 

--- a/pandas/tests/frame/indexing/test_getitem.py
+++ b/pandas/tests/frame/indexing/test_getitem.py
@@ -344,8 +344,8 @@ class TestGetitemBooleanMask:
         expected = DataFrame(exdict).rename(columns={2: 0, 3: 1})
         tm.assert_frame_equal(result, expected)
 
-    @pytest.fixture
-    def df_dup_cols(self):
+    @pytest.fixture(name="df_dup_cols")
+    def fixture_df_dup_cols(self):
         dups = ["A", "A", "C", "D"]
         df = DataFrame(np.arange(12).reshape(3, 4), columns=dups, dtype="float64")
         return df

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -1576,16 +1576,16 @@ msg2 = "Cannot set a Categorical with another, without identical categories"
 
 
 class TestLocILocDataFrameCategorical:
-    @pytest.fixture
-    def orig(self):
+    @pytest.fixture(name="orig")
+    def fixture_orig(self):
         cats = Categorical(["a", "a", "a", "a", "a", "a", "a"], categories=["a", "b"])
         idx = Index(["h", "i", "j", "k", "l", "m", "n"])
         values = [1, 1, 1, 1, 1, 1, 1]
         orig = DataFrame({"cats": cats, "values": values}, index=idx)
         return orig
 
-    @pytest.fixture
-    def exp_single_row(self):
+    @pytest.fixture(name="exp_single_row")
+    def fixture_exp_single_row(self):
         # The expected values if we change a single row
         cats1 = Categorical(["a", "a", "b", "a", "a", "a", "a"], categories=["a", "b"])
         idx1 = Index(["h", "i", "j", "k", "l", "m", "n"])
@@ -1593,8 +1593,8 @@ class TestLocILocDataFrameCategorical:
         exp_single_row = DataFrame({"cats": cats1, "values": values1}, index=idx1)
         return exp_single_row
 
-    @pytest.fixture
-    def exp_multi_row(self):
+    @pytest.fixture(name="exp_multi_row")
+    def fixture_exp_multi_row(self):
         # assign multiple rows (mixed values) (-> array) -> exp_multi_row
         # changed multiple rows
         cats2 = Categorical(["a", "a", "b", "b", "a", "a", "a"], categories=["a", "b"])
@@ -1603,8 +1603,8 @@ class TestLocILocDataFrameCategorical:
         exp_multi_row = DataFrame({"cats": cats2, "values": values2}, index=idx2)
         return exp_multi_row
 
-    @pytest.fixture
-    def exp_parts_cats_col(self):
+    @pytest.fixture(name="exp_parts_cats_col")
+    def fixture_exp_parts_cats_col(self):
         # changed part of the cats column
         cats3 = Categorical(["a", "a", "b", "b", "a", "a", "a"], categories=["a", "b"])
         idx3 = Index(["h", "i", "j", "k", "l", "m", "n"])
@@ -1612,8 +1612,8 @@ class TestLocILocDataFrameCategorical:
         exp_parts_cats_col = DataFrame({"cats": cats3, "values": values3}, index=idx3)
         return exp_parts_cats_col
 
-    @pytest.fixture
-    def exp_single_cats_value(self):
+    @pytest.fixture(name="exp_single_cats_value")
+    def fixture_exp_single_cats_value(self):
         # changed single value in cats col
         cats4 = Categorical(["a", "a", "b", "a", "a", "a", "a"], categories=["a", "b"])
         idx4 = Index(["h", "i", "j", "k", "l", "m", "n"])

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -750,14 +750,14 @@ class TestDataFrameSetItem:
 
 
 class TestSetitemTZAwareValues:
-    @pytest.fixture
-    def idx(self):
+    @pytest.fixture(name="idx")
+    def fixture_idx(self):
         naive = DatetimeIndex(["2013-1-1 13:00", "2013-1-2 14:00"], name="B")
         idx = naive.tz_localize("US/Pacific")
         return idx
 
-    @pytest.fixture
-    def expected(self, idx):
+    @pytest.fixture(name="expected")
+    def fixture_expected(self, idx):
         expected = Series(np.array(idx.tolist(), dtype="object"), name="B")
         assert expected.dtype == idx.dtype
         return expected

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -21,8 +21,12 @@ import pandas._testing as tm
 from pandas._testing._hypothesis import OPTIONAL_ONE_OF_ALL
 
 
-@pytest.fixture(params=["default", "float_string", "mixed_float", "mixed_int"])
-def where_frame(request, float_string_frame, mixed_float_frame, mixed_int_frame):
+@pytest.fixture(
+    name="where_frame", params=["default", "float_string", "mixed_float", "mixed_int"]
+)
+def fixture_where_frame(
+    request, float_string_frame, mixed_float_frame, mixed_int_frame
+):
     if request.param == "default":
         return DataFrame(np.random.randn(5, 3), columns=["A", "B", "C"])
     if request.param == "float_string":

--- a/pandas/tests/frame/indexing/test_xs.py
+++ b/pandas/tests/frame/indexing/test_xs.py
@@ -18,8 +18,8 @@ import pandas._testing as tm
 from pandas.tseries.offsets import BDay
 
 
-@pytest.fixture
-def four_level_index_dataframe():
+@pytest.fixture(name="four_level_index_dataframe")
+def fixture_four_level_index_dataframe():
     arr = np.array(
         [
             [-0.5109, -2.3358, -0.4645, 0.05076, 0.364],

--- a/pandas/tests/frame/methods/test_asof.py
+++ b/pandas/tests/frame/methods/test_asof.py
@@ -15,8 +15,8 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.fixture
-def date_range_frame():
+@pytest.fixture(name="date_range_frame")
+def fixture_date_range_frame():
     """
     Fixture for DataFrame of ints with date_range index
 

--- a/pandas/tests/frame/methods/test_dot.py
+++ b/pandas/tests/frame/methods/test_dot.py
@@ -9,19 +9,19 @@ import pandas._testing as tm
 
 
 class DotSharedTests:
-    @pytest.fixture
-    def obj(self):
+    @pytest.fixture(name="obj")
+    def fixture_obj(self):
         raise NotImplementedError
 
-    @pytest.fixture
-    def other(self) -> DataFrame:
+    @pytest.fixture(name="other")
+    def fixture_other(self) -> DataFrame:
         """
         other is a DataFrame that is indexed so that obj.dot(other) is valid
         """
         raise NotImplementedError
 
-    @pytest.fixture
-    def expected(self, obj, other) -> DataFrame:
+    @pytest.fixture(name="expected")
+    def fixture_expected(self, obj, other) -> DataFrame:
         """
         The expected result of obj.dot(other)
         """
@@ -81,18 +81,18 @@ class DotSharedTests:
 
 
 class TestSeriesDot(DotSharedTests):
-    @pytest.fixture
-    def obj(self):
+    @pytest.fixture(name="obj")
+    def fixture_obj(self):
         return Series(np.random.randn(4), index=["p", "q", "r", "s"])
 
-    @pytest.fixture
-    def other(self):
+    @pytest.fixture(name="other")
+    def fixture_other(self):
         return DataFrame(
             np.random.randn(3, 4), index=["1", "2", "3"], columns=["p", "q", "r", "s"]
         ).T
 
-    @pytest.fixture
-    def expected(self, obj, other):
+    @pytest.fixture(name="expected")
+    def fixture_expected(self, obj, other):
         return Series(np.dot(obj.values, other.values), index=other.columns)
 
     @classmethod
@@ -104,20 +104,20 @@ class TestSeriesDot(DotSharedTests):
 
 
 class TestDataFrameDot(DotSharedTests):
-    @pytest.fixture
-    def obj(self):
+    @pytest.fixture(name="obj")
+    def fixture_obj(self):
         return DataFrame(
             np.random.randn(3, 4), index=["a", "b", "c"], columns=["p", "q", "r", "s"]
         )
 
-    @pytest.fixture
-    def other(self):
+    @pytest.fixture(name="other")
+    def fixture_other(self):
         return DataFrame(
             np.random.randn(4, 2), index=["p", "q", "r", "s"], columns=["1", "2"]
         )
 
-    @pytest.fixture
-    def expected(self, obj, other):
+    @pytest.fixture(name="expected")
+    def fixture_expected(self, obj, other):
         return DataFrame(
             np.dot(obj.values, other.values), index=obj.index, columns=other.columns
         )

--- a/pandas/tests/frame/methods/test_join.py
+++ b/pandas/tests/frame/methods/test_join.py
@@ -17,8 +17,8 @@ import pandas._testing as tm
 from pandas.core.reshape.concat import concat
 
 
-@pytest.fixture
-def frame_with_period_index():
+@pytest.fixture(name="frame_with_period_index")
+def fixture_frame_with_period_index():
     return DataFrame(
         data=np.arange(20).reshape(4, 5),
         columns=list("abcde"),
@@ -26,26 +26,26 @@ def frame_with_period_index():
     )
 
 
-@pytest.fixture
-def left():
+@pytest.fixture(name="left")
+def fixture_left():
     return DataFrame({"a": [20, 10, 0]}, index=[2, 1, 0])
 
 
-@pytest.fixture
-def right():
+@pytest.fixture(name="right")
+def fixture_right():
     return DataFrame({"b": [300, 100, 200]}, index=[3, 1, 2])
 
 
-@pytest.fixture
-def left_no_dup():
+@pytest.fixture(name="left_no_dup")
+def fixture_left_no_dup():
     return DataFrame(
         {"a": ["a", "b", "c", "d"], "b": ["cat", "dog", "weasel", "horse"]},
         index=range(4),
     )
 
 
-@pytest.fixture
-def right_no_dup():
+@pytest.fixture(name="right_no_dup")
+def fixture_right_no_dup():
     return DataFrame(
         {
             "a": ["a", "b", "c", "d", "e"],
@@ -55,15 +55,15 @@ def right_no_dup():
     ).set_index("a")
 
 
-@pytest.fixture
-def left_w_dups(left_no_dup):
+@pytest.fixture(name="left_w_dups")
+def fixture_left_w_dups(left_no_dup):
     return concat(
         [left_no_dup, DataFrame({"a": ["a"], "b": ["cow"]}, index=[3])], sort=True
     )
 
 
-@pytest.fixture
-def right_w_dups(right_no_dup):
+@pytest.fixture(name="right_w_dups")
+def fixture_right_w_dups(right_no_dup):
     return concat(
         [right_no_dup, DataFrame({"a": ["e"], "c": ["moo"]}, index=[3])]
     ).set_index("a")

--- a/pandas/tests/frame/methods/test_nlargest.py
+++ b/pandas/tests/frame/methods/test_nlargest.py
@@ -11,16 +11,16 @@ import pandas as pd
 import pandas._testing as tm
 
 
-@pytest.fixture
-def df_duplicates():
+@pytest.fixture(name="df_duplicates")
+def fixture_df_duplicates():
     return pd.DataFrame(
         {"a": [1, 2, 3, 4, 4], "b": [1, 1, 1, 1, 1], "c": [0, 1, 2, 5, 4]},
         index=[0, 0, 1, 1, 1],
     )
 
 
-@pytest.fixture
-def df_strings():
+@pytest.fixture(name="df_strings")
+def fixture_df_strings():
     return pd.DataFrame(
         {
             "a": np.random.permutation(10),
@@ -30,8 +30,8 @@ def df_strings():
     )
 
 
-@pytest.fixture
-def df_main_dtypes():
+@pytest.fixture(name="df_main_dtypes")
+def fixture_df_main_dtypes():
     return pd.DataFrame(
         {
             "group": [1, 1, 2],

--- a/pandas/tests/frame/methods/test_quantile.py
+++ b/pandas/tests/frame/methods/test_quantile.py
@@ -17,9 +17,11 @@ import pandas._testing as tm
 
 
 @pytest.fixture(
-    params=[["linear", "single"], ["nearest", "table"]], ids=lambda x: "-".join(x)
+    name="interp_method",
+    params=[["linear", "single"], ["nearest", "table"]],
+    ids=lambda x: "-".join(x),
 )
-def interp_method(request):
+def fixture_interp_method(request):
     """(interpolation, method) arguments for quantile"""
     return request.param
 
@@ -795,6 +797,7 @@ class TestQuantileExtensionDtype:
     # TODO: empty case?
 
     @pytest.fixture(
+        name="index",
         params=[
             pytest.param(
                 pd.IntervalIndex.from_breaks(range(10)),
@@ -808,14 +811,14 @@ class TestQuantileExtensionDtype:
         ],
         ids=lambda x: str(x.dtype),
     )
-    def index(self, request):
+    def fixture_index(self, request):
         # NB: not actually an Index object
         idx = request.param
         idx.name = "A"
         return idx
 
-    @pytest.fixture
-    def obj(self, index, frame_or_series):
+    @pytest.fixture(name="obj")
+    def fixture_obj(self, index, frame_or_series):
         # bc index is not always an Index (yet), we need to re-patch .name
         obj = frame_or_series(index).copy()
 

--- a/pandas/tests/frame/methods/test_rank.py
+++ b/pandas/tests/frame/methods/test_rank.py
@@ -31,8 +31,8 @@ class TestRank:
         "dense": np.array([1, 3, 4, 2, np.nan, 2, 1, 5, np.nan, 3]),
     }
 
-    @pytest.fixture(params=["average", "min", "max", "first", "dense"])
-    def method(self, request):
+    @pytest.fixture(name="method", params=["average", "min", "max", "first", "dense"])
+    def fixture_method(self, request):
         """
         Fixture for trying all rank methods
         """

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -17,13 +17,13 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.fixture
-def mix_ab() -> dict[str, list[int | str]]:
+@pytest.fixture(name="mix_ab")
+def fixture_mix_ab() -> dict[str, list[int | str]]:
     return {"a": list(range(4)), "b": list("ab..")}
 
 
-@pytest.fixture
-def mix_abc() -> dict[str, list[float | str]]:
+@pytest.fixture(name="mix_abc")
+def fixture_mix_abc() -> dict[str, list[float | str]]:
     return {"a": list(range(4)), "b": list("ab.."), "c": ["a", "b", np.nan, "d"]}
 
 

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -27,8 +27,8 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.fixture()
-def multiindex_df():
+@pytest.fixture(name="multiindex_df")
+def fixture_multiindex_df():
     levels = [["A", ""], ["B", "b"]]
     return DataFrame([[0, 2], [1, 3]], columns=MultiIndex.from_tuples(levels))
 

--- a/pandas/tests/frame/methods/test_sample.py
+++ b/pandas/tests/frame/methods/test_sample.py
@@ -11,8 +11,8 @@ import pandas.core.common as com
 
 
 class TestSample:
-    @pytest.fixture
-    def obj(self, frame_or_series):
+    @pytest.fixture(name="obj")
+    def fixture_obj(self, frame_or_series):
         if frame_or_series is Series:
             arr = np.random.randn(10)
         else:

--- a/pandas/tests/frame/methods/test_set_axis.py
+++ b/pandas/tests/frame/methods/test_set_axis.py
@@ -9,8 +9,8 @@ import pandas._testing as tm
 
 
 class SharedSetAxisTests:
-    @pytest.fixture
-    def obj(self):
+    @pytest.fixture(name="obj")
+    def fixture_obj(self):
         raise NotImplementedError("Implemented by subclasses")
 
     def test_set_axis(self, obj):
@@ -127,8 +127,8 @@ class SharedSetAxisTests:
 
 
 class TestDataFrameSetAxis(SharedSetAxisTests):
-    @pytest.fixture
-    def obj(self):
+    @pytest.fixture(name="obj")
+    def fixture_obj(self):
         df = DataFrame(
             {"A": [1.1, 2.2, 3.3], "B": [5.0, 6.1, 7.2], "C": [4.4, 5.5, 6.6]},
             index=[2010, 2011, 2012],
@@ -137,7 +137,7 @@ class TestDataFrameSetAxis(SharedSetAxisTests):
 
 
 class TestSeriesSetAxis(SharedSetAxisTests):
-    @pytest.fixture
-    def obj(self):
+    @pytest.fixture(name="obj")
+    def fixture_obj(self):
         ser = Series(np.arange(4), index=[1, 3, 5, 7], dtype="int64")
         return ser

--- a/pandas/tests/frame/methods/test_sort_values.py
+++ b/pandas/tests/frame/methods/test_sort_values.py
@@ -780,8 +780,8 @@ class TestDataFrameSortKey:  # test key sorting (issue 27237)
         tm.assert_frame_equal(result, expected)
 
 
-@pytest.fixture
-def df_none():
+@pytest.fixture(name="df_none")
+def fixture_df_none():
     return DataFrame(
         {
             "outer": ["a", "a", "a", "b", "b", "b"],
@@ -792,13 +792,14 @@ def df_none():
     )
 
 
-@pytest.fixture(params=[["outer"], ["outer", "inner"]])
-def df_idx(request, df_none):
+@pytest.fixture(name="df_idx", params=[["outer"], ["outer", "inner"]])
+def fixture_df_idx(request, df_none):
     levels = request.param
     return df_none.set_index(levels)
 
 
 @pytest.fixture(
+    name="sort_names",
     params=[
         "inner",  # index level
         ["outer"],  # list of index level
@@ -808,14 +809,14 @@ def df_idx(request, df_none):
         [("B", 5), "outer"],  # index level and column
         ["A", ("B", 5)],  # Two columns
         ["inner", "outer"],  # two index levels and column
-    ]
+    ],
 )
-def sort_names(request):
+def fixture_sort_names(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def ascending(request):
+@pytest.fixture(name="ascending", params=[True, False])
+def fixture_ascending(request):
     return request.param
 
 

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -33,8 +33,13 @@ from pandas.tests.frame.common import (
 )
 
 
-@pytest.fixture(autouse=True, params=[0, 1000000], ids=["numexpr", "python"])
-def switch_numexpr_min_elements(request):
+@pytest.fixture(
+    name="switch_numexpr_min_elements",
+    autouse=True,
+    params=[0, 1000000],
+    ids=["numexpr", "python"],
+)
+def fixture_switch_numexpr_min_elements(request):
     _MIN_ELEMENTS = expr._MIN_ELEMENTS
     expr._MIN_ELEMENTS = request.param
     yield request.param

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2964,12 +2964,12 @@ def get1(obj):  # TODO: make a helper in tm?
 
 
 class TestFromScalar:
-    @pytest.fixture(params=[list, dict, None])
-    def box(self, request):
+    @pytest.fixture(name="box", params=[list, dict, None])
+    def fixture_box(self, request):
         return request.param
 
-    @pytest.fixture
-    def constructor(self, frame_or_series, box):
+    @pytest.fixture(name="constructor")
+    def fixture_constructor(self, frame_or_series, box):
 
         extra = {"index": range(2)}
         if frame_or_series is DataFrame:
@@ -3119,12 +3119,12 @@ class TestAllowNonNano:
     # Until 2.0, we do not preserve non-nano dt64/td64 when passed as ndarray,
     #  but do preserve it when passed as DTA/TDA
 
-    @pytest.fixture(params=[True, False])
-    def as_td(self, request):
+    @pytest.fixture(name="as_td", params=[True, False])
+    def fixture_as_td(self, request):
         return request.param
 
-    @pytest.fixture
-    def arr(self, as_td):
+    @pytest.fixture(name="arr")
+    def fixture_arr(self, as_td):
         values = np.arange(5).astype(np.int64).view("M8[s]")
         if as_td:
             values = values - values[0]

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -18,15 +18,17 @@ import pandas._testing as tm
 from pandas.core.computation.check import NUMEXPR_INSTALLED
 
 
-@pytest.fixture(params=["python", "pandas"], ids=lambda x: x)
-def parser(request):
+@pytest.fixture(name="parser", params=["python", "pandas"], ids=lambda x: x)
+def fixture_parser(request):
     return request.param
 
 
 @pytest.fixture(
-    params=["python", pytest.param("numexpr", marks=td.skip_if_no_ne)], ids=lambda x: x
+    name="engine",
+    params=["python", pytest.param("numexpr", marks=td.skip_if_no_ne)],
+    ids=lambda x: x,
 )
-def engine(request):
+def fixture_engine(request):
     return request.param
 
 
@@ -36,16 +38,16 @@ def skip_if_no_pandas_parser(parser):
 
 
 class TestCompat:
-    @pytest.fixture
-    def df(self):
+    @pytest.fixture(name="df")
+    def fixture_df(self):
         return DataFrame({"A": [1, 2, 3]})
 
-    @pytest.fixture
-    def expected1(self, df):
+    @pytest.fixture(name="expected1")
+    def fixture_expected1(self, df):
         return df[df.A > 0]
 
-    @pytest.fixture
-    def expected2(self, df):
+    @pytest.fixture(name="expected2")
+    def fixture_expected2(self, df):
         return df.A + 1
 
     def test_query_default(self, df, expected1, expected2):
@@ -1090,8 +1092,8 @@ class TestDataFrameQueryStrings:
 
 
 class TestDataFrameEvalWithFrame:
-    @pytest.fixture
-    def frame(self):
+    @pytest.fixture(name="frame")
+    def fixture_frame(self):
         return DataFrame(np.random.randn(10, 3), columns=list("abc"))
 
     def test_simple_expr(self, frame, parser, engine):
@@ -1114,8 +1116,8 @@ class TestDataFrameEvalWithFrame:
 
 
 class TestDataFrameQueryBacktickQuoting:
-    @pytest.fixture
-    def df(self):
+    @pytest.fixture(name="df")
+    def fixture_df(self):
         """
         Yields a dataframe with strings that may or may not need escaping
         by backticks. The last two columns cannot be escaped by backticks

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -13,8 +13,8 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.fixture()
-def gpd_style_subclass_df():
+@pytest.fixture(name="gpd_style_subclass_df")
+def fixture_gpd_style_subclass_df():
     class SubclassedDataFrame(DataFrame):
         @property
         def _constructor(self):

--- a/pandas/tests/frame/test_validate.py
+++ b/pandas/tests/frame/test_validate.py
@@ -3,8 +3,8 @@ import pytest
 from pandas.core.frame import DataFrame
 
 
-@pytest.fixture
-def dataframe():
+@pytest.fixture(name="dataframe")
+def fixture_dataframe():
     return DataFrame({"a": [1, 2], "b": [3, 4]})
 
 

--- a/pandas/tests/generic/test_finalize.py
+++ b/pandas/tests/generic/test_finalize.py
@@ -445,8 +445,8 @@ def idfn(x):
         return str(x)
 
 
-@pytest.fixture(params=_all_methods, ids=lambda x: idfn(x[-1]))
-def ndframe_method(request):
+@pytest.fixture(name="ndframe_method", params=_all_methods, ids=lambda x: idfn(x[-1]))
+def fixture_ndframe_method(request):
     """
     An NDFrame method returning an NDFrame.
     """

--- a/pandas/tests/generic/test_label_or_level_utils.py
+++ b/pandas/tests/generic/test_label_or_level_utils.py
@@ -7,14 +7,14 @@ import pandas as pd
 
 # Fixtures
 # ========
-@pytest.fixture
-def df():
+@pytest.fixture(name="df")
+def fixture_df():
     """DataFrame with columns 'L1', 'L2', and 'L3'"""
     return pd.DataFrame({"L1": [1, 2, 3], "L2": [11, 12, 13], "L3": ["A", "B", "C"]})
 
 
-@pytest.fixture(params=[[], ["L1"], ["L1", "L2"], ["L1", "L2", "L3"]])
-def df_levels(request, df):
+@pytest.fixture(name="df_levels", params=[[], ["L1"], ["L1", "L2"], ["L1", "L2", "L3"]])
+def fixture_df_levels(request, df):
     """DataFrame with columns or index levels 'L1', 'L2', and 'L3'"""
     levels = request.param
 
@@ -24,8 +24,8 @@ def df_levels(request, df):
     return df
 
 
-@pytest.fixture
-def df_ambig(df):
+@pytest.fixture(name="df_ambig")
+def fixture_df_ambig(df):
     """DataFrame with levels 'L1' and 'L2' and labels 'L1' and 'L3'"""
     df = df.set_index(["L1", "L2"])
 
@@ -34,8 +34,8 @@ def df_ambig(df):
     return df
 
 
-@pytest.fixture
-def df_duplabels(df):
+@pytest.fixture(name="df_duplabels")
+def fixture_df_duplabels(df):
     """DataFrame with level 'L1' and labels 'L2', 'L3', and 'L2'"""
     df = df.set_index(["L1"])
     df = pd.concat([df, df["L2"]], axis=1)

--- a/pandas/tests/generic/test_to_xarray.py
+++ b/pandas/tests/generic/test_to_xarray.py
@@ -15,8 +15,8 @@ import pandas._testing as tm
 
 @td.skip_if_no("xarray")
 class TestDataFrameToXArray:
-    @pytest.fixture
-    def df(self):
+    @pytest.fixture(name="df")
+    def fixture_df(self):
         return DataFrame(
             {
                 "a": list("abc"),

--- a/pandas/tests/groupby/conftest.py
+++ b/pandas/tests/groupby/conftest.py
@@ -9,33 +9,33 @@ from pandas.core.groupby.base import (
 )
 
 
-@pytest.fixture(params=[True, False])
-def sort(request):
+@pytest.fixture(name="sort", params=[True, False])
+def fixture_sort(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def as_index(request):
+@pytest.fixture(name="as_index", params=[True, False])
+def fixture_as_index(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def dropna(request):
+@pytest.fixture(name="dropna", params=[True, False])
+def fixture_dropna(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def observed(request):
+@pytest.fixture(name="observed", params=[True, False])
+def fixture_observed(request):
     return request.param
 
 
-@pytest.fixture
-def mframe(multiindex_dataframe_random_data):
+@pytest.fixture(name="mframe")
+def fixture_mframe(multiindex_dataframe_random_data):
     return multiindex_dataframe_random_data
 
 
-@pytest.fixture
-def df():
+@pytest.fixture(name="df")
+def fixture_df():
     return DataFrame(
         {
             "A": ["foo", "bar", "foo", "bar", "foo", "bar", "foo", "foo"],
@@ -46,23 +46,23 @@ def df():
     )
 
 
-@pytest.fixture
-def ts():
+@pytest.fixture(name="ts")
+def fixture_ts():
     return tm.makeTimeSeries()
 
 
-@pytest.fixture
-def tsd():
+@pytest.fixture(name="tsd")
+def fixture_tsd():
     return tm.getTimeSeriesData()
 
 
-@pytest.fixture
-def tsframe(tsd):
+@pytest.fixture(name="tsframe")
+def fixture_tsframe(tsd):
     return DataFrame(tsd)
 
 
-@pytest.fixture
-def df_mixed_floats():
+@pytest.fixture(name="df_mixed_floats")
+def fixture_df_mixed_floats():
     return DataFrame(
         {
             "A": ["foo", "bar", "foo", "bar", "foo", "bar", "foo", "foo"],
@@ -73,8 +73,8 @@ def df_mixed_floats():
     )
 
 
-@pytest.fixture
-def three_group():
+@pytest.fixture(name="three_group")
+def fixture_three_group():
     return DataFrame(
         {
             "A": [
@@ -123,8 +123,8 @@ def three_group():
     )
 
 
-@pytest.fixture()
-def slice_test_df():
+@pytest.fixture(name="slice_test_df")
+def fixture_slice_test_df():
     data = [
         [0, "a", "a0_at_0"],
         [1, "b", "b0_at_1"],
@@ -139,33 +139,36 @@ def slice_test_df():
     return df.set_index("Index")
 
 
-@pytest.fixture()
-def slice_test_grouped(slice_test_df):
+@pytest.fixture(name="slice_test_grouped")
+def fixture_slice_test_grouped(slice_test_df):
     return slice_test_df.groupby("Group", as_index=False)
 
 
-@pytest.fixture(params=sorted(reduction_kernels))
-def reduction_func(request):
+@pytest.fixture(name="reduction_func", params=sorted(reduction_kernels))
+def fixture_reduction_func(request):
     """
     yields the string names of all groupby reduction functions, one at a time.
     """
     return request.param
 
 
-@pytest.fixture(params=sorted(transformation_kernels))
-def transformation_func(request):
+@pytest.fixture(name="transformation_func", params=sorted(transformation_kernels))
+def fixture_transformation_func(request):
     """yields the string names of all groupby transformation functions."""
     return request.param
 
 
-@pytest.fixture(params=sorted(reduction_kernels) + sorted(transformation_kernels))
-def groupby_func(request):
+@pytest.fixture(
+    name="groupby_func",
+    params=sorted(reduction_kernels) + sorted(transformation_kernels),
+)
+def fixture_groupby_func(request):
     """yields both aggregation and transformation functions."""
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def parallel(request):
+@pytest.fixture(name="parallel", params=[True, False])
+def fixture_parallel(request):
     """parallel keyword argument for numba.jit"""
     return request.param
 
@@ -174,19 +177,20 @@ def parallel(request):
 # https://github.com/pandas-dev/pandas/pull/41971#issuecomment-860607472
 
 
-@pytest.fixture(params=[False])
-def nogil(request):
+@pytest.fixture(name="nogil", params=[False])
+def fixture_nogil(request):
     """nogil keyword argument for numba.jit"""
     return request.param
 
 
-@pytest.fixture(params=[True])
-def nopython(request):
+@pytest.fixture(name="nopython", params=[True])
+def fixture_nopython(request):
     """nopython keyword argument for numba.jit"""
     return request.param
 
 
 @pytest.fixture(
+    name="numba_supported_reductions",
     params=[
         ("mean", {}),
         ("var", {"ddof": 1}),
@@ -199,6 +203,6 @@ def nopython(request):
     ],
     ids=["mean", "var_1", "var_0", "std_1", "std_0", "sum", "min", "max"],
 )
-def numba_supported_reductions(request):
+def fixture_numba_supported_reductions(request):
     """reductions supported with engine='numba'"""
     return request.param

--- a/pandas/tests/groupby/test_allowlist.py
+++ b/pandas/tests/groupby/test_allowlist.py
@@ -35,8 +35,8 @@ AGG_FUNCTIONS = [
 AGG_FUNCTIONS_WITH_SKIPNA = ["skew"]
 
 
-@pytest.fixture
-def df():
+@pytest.fixture(name="df")
+def fixture_df():
     return DataFrame(
         {
             "A": ["foo", "bar", "foo", "bar", "foo", "bar", "foo", "foo"],
@@ -47,8 +47,8 @@ def df():
     )
 
 
-@pytest.fixture
-def df_letters():
+@pytest.fixture(name="df_letters")
+def fixture_df_letters():
     letters = np.array(list(ascii_lowercase))
     N = 10
     random_letters = letters.take(np.random.randint(0, 26, N))
@@ -61,8 +61,8 @@ def df_letters():
     return df
 
 
-@pytest.fixture
-def raw_frame():
+@pytest.fixture(name="raw_frame")
+def fixture_raw_frame():
     return DataFrame([0])
 
 

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1186,8 +1186,8 @@ def test_shift(fill_value):
     tm.assert_equal(res, expected)
 
 
-@pytest.fixture
-def df_cat(df):
+@pytest.fixture(name="df_cat")
+def fixture_df_cat(df):
     """
     DataFrame with multiple categorical columns and a column of integers.
     Shortened so as not to contain all possible combinations of categories.

--- a/pandas/tests/groupby/test_frame_value_counts.py
+++ b/pandas/tests/groupby/test_frame_value_counts.py
@@ -13,8 +13,8 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.fixture
-def education_df():
+@pytest.fixture(name="education_df")
+def fixture_education_df():
     return DataFrame(
         {
             "gender": ["male", "male", "female", "male", "female", "male"],
@@ -169,8 +169,8 @@ def test_compound(
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.fixture
-def animals_df():
+@pytest.fixture(name="animals_df")
+def fixture_animals_df():
     return DataFrame(
         {"key": [1, 1, 1, 1], "num_legs": [2, 4, 4, 6], "num_wings": [2, 0, 0, 0]},
         index=["falcon", "dog", "cat", "ant"],
@@ -209,8 +209,8 @@ def test_data_frame_value_counts(
     tm.assert_series_equal(result_frame_groupby, expected)
 
 
-@pytest.fixture
-def nulls_df():
+@pytest.fixture(name="nulls_df")
+def fixture_nulls_df():
     n = np.nan
     return DataFrame(
         {
@@ -249,8 +249,8 @@ def test_dropna_combinations(
     tm.assert_series_equal(result, expected)
 
 
-@pytest.fixture
-def names_with_nulls_df(nulls_fixture):
+@pytest.fixture(name="names_with_nulls_df")
+def fixture_names_with_nulls_df(nulls_fixture):
     return DataFrame(
         {
             "key": [1, 1, 1, 1],

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -23,10 +23,11 @@ from pandas.util import _test_decorators as td
 
 
 @pytest.fixture(
+    name="dtypes_for_minmax",
     params=[np.int32, np.int64, np.float32, np.float64, "Int64", "Float64"],
     ids=["np.int32", "np.int64", "np.float32", "np.float64", "Int64", "Float64"],
 )
-def dtypes_for_minmax(request):
+def fixture_dtypes_for_minmax(request):
     """
     Fixture of dtypes with min and max values used for testing
     cummin and cummax
@@ -107,8 +108,8 @@ def test_builtins_apply(keys, f):
 class TestNumericOnly:
     # make sure that we are passing thru kwargs to our agg functions
 
-    @pytest.fixture
-    def df(self):
+    @pytest.fixture(name="df")
+    def fixture_df(self):
         # GH3668
         # GH5724
         df = DataFrame(
@@ -297,21 +298,21 @@ class TestGroupByNonCythonPaths:
     # GH#5610 non-cython calls should not include the grouper
     # Tests for code not expected to go through cython paths.
 
-    @pytest.fixture
-    def df(self):
+    @pytest.fixture(name="df")
+    def fixture_df(self):
         df = DataFrame(
             [[1, 2, "foo"], [1, np.nan, "bar"], [3, np.nan, "baz"]],
             columns=["A", "B", "C"],
         )
         return df
 
-    @pytest.fixture
-    def gb(self, df):
+    @pytest.fixture(name="gb")
+    def fixture_gb(self, df):
         gb = df.groupby("A")
         return gb
 
-    @pytest.fixture
-    def gni(self, df):
+    @pytest.fixture(name="gni")
+    def fixture_gni(self, df):
         gni = df.groupby("A", as_index=False)
         return gni
 

--- a/pandas/tests/groupby/test_index_as_string.py
+++ b/pandas/tests/groupby/test_index_as_string.py
@@ -5,8 +5,8 @@ import pandas as pd
 import pandas._testing as tm
 
 
-@pytest.fixture(params=[["inner"], ["inner", "outer"]])
-def frame(request):
+@pytest.fixture(name="frame", params=[["inner"], ["inner", "outer"]])
+def fixture_frame(request):
     levels = request.param
     df = pd.DataFrame(
         {
@@ -22,8 +22,8 @@ def frame(request):
     return df
 
 
-@pytest.fixture()
-def series():
+@pytest.fixture(name="series")
+def fixture_series():
     df = pd.DataFrame(
         {
             "outer": ["a", "a", "a", "b", "b", "b"],

--- a/pandas/tests/groupby/test_indexing.py
+++ b/pandas/tests/groupby/test_indexing.py
@@ -120,8 +120,8 @@ def test_doc_examples():
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.fixture()
-def multiindex_data():
+@pytest.fixture(name="multiindex_data")
+def fixture_multiindex_data():
     ndates = 100
     nitems = 20
     dates = pd.date_range("20130101", periods=ndates, freq="D")
@@ -272,8 +272,8 @@ def test_step(step):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.fixture()
-def column_group_df():
+@pytest.fixture(name="column_group_df")
+def fixture_column_group_df():
     return pd.DataFrame(
         [[0, 1, 2, 3, 4, 5, 6], [0, 0, 1, 0, 1, 0, 2]],
         columns=["A", "B", "C", "D", "E", "F", "G"],

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -25,8 +25,8 @@ from pandas.core.groupby.grouper import Grouper
 from pandas.core.groupby.ops import BinGrouper
 
 
-@pytest.fixture
-def frame_for_truncated_bingrouper():
+@pytest.fixture(name="frame_for_truncated_bingrouper")
+def fixture_frame_for_truncated_bingrouper():
     """
     DataFrame used by groupby_with_truncated_bingrouper, made into
     a separate fixture for easier re-use in
@@ -48,8 +48,8 @@ def frame_for_truncated_bingrouper():
     return df
 
 
-@pytest.fixture
-def groupby_with_truncated_bingrouper(frame_for_truncated_bingrouper):
+@pytest.fixture(name="groupby_with_truncated_bingrouper")
+def fixture_groupby_with_truncated_bingrouper(frame_for_truncated_bingrouper):
     """
     GroupBy object such that gb.grouper is a BinGrouper and
     len(gb.grouper.result_index) < len(gb.grouper.group_keys_seq)

--- a/pandas/tests/indexes/categorical/test_append.py
+++ b/pandas/tests/indexes/categorical/test_append.py
@@ -8,8 +8,8 @@ import pandas._testing as tm
 
 
 class TestAppend:
-    @pytest.fixture
-    def ci(self):
+    @pytest.fixture(name="ci")
+    def fixture_ci(self):
         categories = list("cab")
         return CategoricalIndex(list("aabbca"), categories=categories, ordered=False)
 

--- a/pandas/tests/indexes/categorical/test_category.py
+++ b/pandas/tests/indexes/categorical/test_category.py
@@ -20,12 +20,12 @@ from pandas.tests.indexes.common import Base
 class TestCategoricalIndex(Base):
     _index_cls = CategoricalIndex
 
-    @pytest.fixture
-    def simple_index(self) -> CategoricalIndex:
+    @pytest.fixture(name="simple_index")
+    def fixture_simple_index(self) -> CategoricalIndex:
         return self._index_cls(list("aabbca"), categories=list("cab"), ordered=False)
 
-    @pytest.fixture
-    def index(self):
+    @pytest.fixture(name="index")
+    def fixture_index(self):
         return tm.makeCategoricalIndex(100)
 
     def create_index(self, *, categories=None, ordered=False):

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -44,8 +44,8 @@ class Base:
 
     _index_cls: type[Index]
 
-    @pytest.fixture
-    def simple_index(self):
+    @pytest.fixture(name="simple_index")
+    def fixture_simple_index(self):
         raise NotImplementedError("Method not implemented")
 
     def create_index(self) -> Index:

--- a/pandas/tests/indexes/conftest.py
+++ b/pandas/tests/indexes/conftest.py
@@ -7,8 +7,8 @@ from pandas import (
 )
 
 
-@pytest.fixture(params=[None, False])
-def sort(request):
+@pytest.fixture(name="sort", params=[None, False])
+def fixture_sort(request):
     """
     Valid values for the 'sort' parameter used in the Index
     setops methods (intersection, union, etc.)
@@ -24,8 +24,11 @@ def sort(request):
     return request.param
 
 
-@pytest.fixture(params=["D", "3D", "-3D", "H", "2H", "-2H", "T", "2T", "S", "-3S"])
-def freq_sample(request):
+@pytest.fixture(
+    name="freq_sample",
+    params=["D", "3D", "-3D", "H", "2H", "-2H", "T", "2T", "S", "-3S"],
+)
+def fixture_freq_sample(request):
     """
     Valid values for 'freq' parameter used to create date_range and
     timedelta_range..
@@ -33,8 +36,8 @@ def freq_sample(request):
     return request.param
 
 
-@pytest.fixture(params=[list, tuple, np.array, array, Series])
-def listlike_box(request):
+@pytest.fixture(name="listlike_box", params=[list, tuple, np.array, array, Series])
+def fixture_listlike_box(request):
     """
     Types that may be passed as the indexer to searchsorted.
     """

--- a/pandas/tests/indexes/datetimelike_/test_drop_duplicates.py
+++ b/pandas/tests/indexes/datetimelike_/test_drop_duplicates.py
@@ -59,22 +59,22 @@ class DropDuplicates:
 
 
 class TestDropDuplicatesPeriodIndex(DropDuplicates):
-    @pytest.fixture(params=["D", "3D", "H", "2H", "T", "2T", "S", "3S"])
-    def freq(self, request):
+    @pytest.fixture(name="freq", params=["D", "3D", "H", "2H", "T", "2T", "S", "3S"])
+    def fixture_freq(self, request):
         return request.param
 
-    @pytest.fixture
-    def idx(self, freq):
+    @pytest.fixture(name="idx")
+    def fixture_idx(self, freq):
         return period_range("2011-01-01", periods=10, freq=freq, name="idx")
 
 
 class TestDropDuplicatesDatetimeIndex(DropDuplicates):
-    @pytest.fixture
-    def idx(self, freq_sample):
+    @pytest.fixture(name="idx")
+    def fixture_idx(self, freq_sample):
         return date_range("2011-01-01", freq=freq_sample, periods=10, name="idx")
 
 
 class TestDropDuplicatesTimedeltaIndex(DropDuplicates):
-    @pytest.fixture
-    def idx(self, freq_sample):
+    @pytest.fixture(name="idx")
+    def fixture_idx(self, freq_sample):
         return timedelta_range("1 day", periods=10, freq=freq_sample, name="idx")

--- a/pandas/tests/indexes/datetimelike_/test_equals.py
+++ b/pandas/tests/indexes/datetimelike_/test_equals.py
@@ -50,8 +50,8 @@ class EqualsTests:
 
 
 class TestPeriodIndexEquals(EqualsTests):
-    @pytest.fixture
-    def index(self):
+    @pytest.fixture(name="index")
+    def fixture_index(self):
         return period_range("2013-01-01", periods=5, freq="D")
 
     # TODO: de-duplicate with other test_equals2 methods
@@ -89,8 +89,8 @@ class TestPeriodIndexEquals(EqualsTests):
 
 
 class TestDatetimeIndexEquals(EqualsTests):
-    @pytest.fixture
-    def index(self):
+    @pytest.fixture(name="index")
+    def fixture_index(self):
         return date_range("2013-01-01", periods=5)
 
     def test_equals2(self):
@@ -141,8 +141,8 @@ class TestDatetimeIndexEquals(EqualsTests):
 
 
 class TestTimedeltaIndexEquals(EqualsTests):
-    @pytest.fixture
-    def index(self):
+    @pytest.fixture(name="index")
+    def fixture_index(self):
         return tm.makeTimedeltaIndex(10)
 
     def test_equals2(self):

--- a/pandas/tests/indexes/datetimelike_/test_nat.py
+++ b/pandas/tests/indexes/datetimelike_/test_nat.py
@@ -35,19 +35,19 @@ class NATests:
 
 
 class TestDatetimeIndexNA(NATests):
-    @pytest.fixture
-    def index_without_na(self, tz_naive_fixture):
+    @pytest.fixture(name="index_without_na")
+    def fixture_index_without_na(self, tz_naive_fixture):
         tz = tz_naive_fixture
         return DatetimeIndex(["2011-01-01", "2011-01-02"], tz=tz)
 
 
 class TestTimedeltaIndexNA(NATests):
-    @pytest.fixture
-    def index_without_na(self):
+    @pytest.fixture(name="index_without_na")
+    def fixture_index_without_na(self):
         return TimedeltaIndex(["1 days", "2 days"])
 
 
 class TestPeriodIndexNA(NATests):
-    @pytest.fixture
-    def index_without_na(self):
+    @pytest.fixture(name="index_without_na")
+    def fixture_index_without_na(self):
         return PeriodIndex(["2011-01-01", "2011-01-02"], freq="D")

--- a/pandas/tests/indexes/datetimelike_/test_sort_values.py
+++ b/pandas/tests/indexes/datetimelike_/test_sort_values.py
@@ -40,8 +40,10 @@ def check_freq_nonmonotonic(ordered, orig):
 
 
 class TestSortValues:
-    @pytest.fixture(params=[DatetimeIndex, TimedeltaIndex, PeriodIndex])
-    def non_monotonic_idx(self, request):
+    @pytest.fixture(
+        name="non_monotonic_idx", params=[DatetimeIndex, TimedeltaIndex, PeriodIndex]
+    )
+    def fixture_non_monotonic_idx(self, request):
         if request.param is DatetimeIndex:
             return DatetimeIndex(["2000-01-04", "2000-01-01", "2000-01-02"])
         elif request.param is PeriodIndex:

--- a/pandas/tests/indexes/datetimes/test_datetimelike.py
+++ b/pandas/tests/indexes/datetimes/test_datetimelike.py
@@ -12,15 +12,16 @@ from pandas.tests.indexes.datetimelike import DatetimeLike
 class TestDatetimeIndex(DatetimeLike):
     _index_cls = DatetimeIndex
 
-    @pytest.fixture
-    def simple_index(self) -> DatetimeIndex:
+    @pytest.fixture(name="simple_index")
+    def fixture_simple_index(self) -> DatetimeIndex:
         return date_range("20130101", periods=5)
 
     @pytest.fixture(
+        name="index",
         params=[tm.makeDateIndex(10), date_range("20130110", periods=10, freq="-1D")],
         ids=["index_inc", "index_dec"],
     )
-    def index(self, request):
+    def fixture_index(self, request):
         return request.param
 
     def test_format(self, simple_index):

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -51,8 +51,8 @@ class TestDatetimeIndexOps:
 
 @pytest.mark.parametrize("freq", ["B", "C"])
 class TestBusinessDatetimeIndex:
-    @pytest.fixture
-    def rng(self, freq):
+    @pytest.fixture(name="rng")
+    def fixture_rng(self, freq):
         return bdate_range(START, END, freq=freq)
 
     def test_comparison(self, rng):

--- a/pandas/tests/indexes/interval/test_astype.py
+++ b/pandas/tests/indexes/interval/test_astype.py
@@ -85,8 +85,8 @@ class TestIntSubtype(AstypeTests):
         IntervalIndex.from_breaks(np.arange(100, dtype="uint64"), closed="left"),
     ]
 
-    @pytest.fixture(params=indexes)
-    def index(self, request):
+    @pytest.fixture(name="index", params=indexes)
+    def fixture_index(self, request):
         return request.param
 
     @pytest.mark.parametrize(
@@ -139,8 +139,8 @@ class TestFloatSubtype(AstypeTests):
         ),
     ]
 
-    @pytest.fixture(params=indexes)
-    def index(self, request):
+    @pytest.fixture(name="index", params=indexes)
+    def fixture_index(self, request):
         return request.param
 
     @pytest.mark.parametrize("subtype", ["int64", "uint64"])
@@ -198,8 +198,8 @@ class TestDatetimelikeSubtype(AstypeTests):
         interval_range(Timedelta("0 days"), periods=10).insert(2, NaT),
     ]
 
-    @pytest.fixture(params=indexes)
-    def index(self, request):
+    @pytest.fixture(name="index", params=indexes)
+    def fixture_index(self, request):
         return request.param
 
     @pytest.mark.parametrize("subtype", ["int64", "uint64"])

--- a/pandas/tests/indexes/interval/test_base.py
+++ b/pandas/tests/indexes/interval/test_base.py
@@ -14,12 +14,12 @@ class TestBase(Base):
 
     _index_cls = IntervalIndex
 
-    @pytest.fixture
-    def simple_index(self) -> IntervalIndex:
+    @pytest.fixture(name="simple_index")
+    def fixture_simple_index(self) -> IntervalIndex:
         return self._index_cls.from_breaks(range(11), closed="right")
 
-    @pytest.fixture
-    def index(self):
+    @pytest.fixture(name="index")
+    def fixture_index(self):
         return tm.makeIntervalIndex(10)
 
     def create_index(self, *, closed="right"):

--- a/pandas/tests/indexes/interval/test_constructors.py
+++ b/pandas/tests/indexes/interval/test_constructors.py
@@ -26,8 +26,8 @@ from pandas.core.arrays import IntervalArray
 import pandas.core.common as com
 
 
-@pytest.fixture(params=[None, "foo"])
-def name(request):
+@pytest.fixture(name="name", params=[None, "foo"])
+def fixture_name(request):
     return request.param
 
 
@@ -207,8 +207,8 @@ class ConstructorTests:
 class TestFromArrays(ConstructorTests):
     """Tests specific to IntervalIndex.from_arrays"""
 
-    @pytest.fixture
-    def constructor(self):
+    @pytest.fixture(name="constructor")
+    def fixture_constructor(self):
         return IntervalIndex.from_arrays
 
     def get_kwargs_from_breaks(self, breaks, closed="right"):
@@ -256,8 +256,8 @@ class TestFromArrays(ConstructorTests):
 class TestFromBreaks(ConstructorTests):
     """Tests specific to IntervalIndex.from_breaks"""
 
-    @pytest.fixture
-    def constructor(self):
+    @pytest.fixture(name="constructor")
+    def fixture_constructor(self):
         return IntervalIndex.from_breaks
 
     def get_kwargs_from_breaks(self, breaks, closed="right"):
@@ -294,8 +294,8 @@ class TestFromBreaks(ConstructorTests):
 class TestFromTuples(ConstructorTests):
     """Tests specific to IntervalIndex.from_tuples"""
 
-    @pytest.fixture
-    def constructor(self):
+    @pytest.fixture(name="constructor")
+    def fixture_constructor(self):
         return IntervalIndex.from_tuples
 
     def get_kwargs_from_breaks(self, breaks, closed="right"):
@@ -342,15 +342,16 @@ class TestClassConstructors(ConstructorTests):
     """Tests specific to the IntervalIndex/Index constructors"""
 
     @pytest.fixture(
+        name="klass",
         params=[IntervalIndex, partial(Index, dtype="interval")],
         ids=["IntervalIndex", "Index"],
     )
-    def klass(self, request):
+    def fixture_klass(self, request):
         # We use a separate fixture here to include Index.__new__ with dtype kwarg
         return request.param
 
-    @pytest.fixture
-    def constructor(self):
+    @pytest.fixture(name="constructor")
+    def fixture_constructor(self):
         return IntervalIndex
 
     def get_kwargs_from_breaks(self, breaks, closed="right"):

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -22,8 +22,8 @@ from pandas.core.api import Float64Index
 import pandas.core.common as com
 
 
-@pytest.fixture(params=[None, "foo"])
-def name(request):
+@pytest.fixture(name="name", params=[None, "foo"])
+def fixture_name(request):
     return request.param
 
 

--- a/pandas/tests/indexes/interval/test_interval_range.py
+++ b/pandas/tests/indexes/interval/test_interval_range.py
@@ -20,8 +20,8 @@ import pandas._testing as tm
 from pandas.tseries.offsets import Day
 
 
-@pytest.fixture(params=[None, "foo"])
-def name(request):
+@pytest.fixture(name="name", params=[None, "foo"])
+def fixture_name(request):
     return request.param
 
 

--- a/pandas/tests/indexes/interval/test_interval_tree.py
+++ b/pandas/tests/indexes/interval/test_interval_tree.py
@@ -18,13 +18,13 @@ def skipif_32bit(param):
     return pytest.param(param, marks=marks)
 
 
-@pytest.fixture(params=["int64", "float64", "uint64"])
-def dtype(request):
+@pytest.fixture(name="dtype", params=["int64", "float64", "uint64"])
+def fixture_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=[skipif_32bit(1), skipif_32bit(2), 10])
-def leaf_size(request):
+@pytest.fixture(name="leaf_size", params=[skipif_32bit(1), skipif_32bit(2), 10])
+def fixture_leaf_size(request):
     """
     Fixture to specify IntervalTree leaf_size parameter; to be used with the
     tree fixture.
@@ -33,14 +33,15 @@ def leaf_size(request):
 
 
 @pytest.fixture(
+    name="tree",
     params=[
         np.arange(5, dtype="int64"),
         np.arange(5, dtype="uint64"),
         np.arange(5, dtype="float64"),
         np.array([0, 1, 2, 3, 4, np.nan], dtype="float64"),
-    ]
+    ],
 )
-def tree(request, leaf_size):
+def fixture_tree(request, leaf_size):
     left = request.param
     return IntervalTree(left, left + 2, leaf_size=leaf_size)
 

--- a/pandas/tests/indexes/interval/test_join.py
+++ b/pandas/tests/indexes/interval/test_join.py
@@ -8,13 +8,13 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.fixture
-def range_index():
+@pytest.fixture(name="range_index")
+def fixture_range_index():
     return RangeIndex(3, name="range_index")
 
 
-@pytest.fixture
-def interval_index():
+@pytest.fixture(name="interval_index")
+def fixture_interval_index():
     return IntervalIndex.from_tuples(
         [(0.0, 1.0), (1.0, 2.0), (1.5, 2.5)], name="interval_index"
     )

--- a/pandas/tests/indexes/multi/conftest.py
+++ b/pandas/tests/indexes/multi/conftest.py
@@ -9,8 +9,8 @@ from pandas import (
 
 
 # Note: identical the "multi" entry in the top-level "index" fixture
-@pytest.fixture
-def idx():
+@pytest.fixture(name="idx")
+def fixture_idx():
     # a MultiIndex used to test the general functionality of the
     # general functionality of this object
     major_axis = Index(["foo", "bar", "baz", "qux"])
@@ -28,8 +28,8 @@ def idx():
     return mi
 
 
-@pytest.fixture
-def idx_dup():
+@pytest.fixture(name="idx_dup")
+def fixture_idx_dup():
     # compare tests/indexes/multi/conftest.py
     major_axis = Index(["foo", "bar", "baz", "qux"])
     minor_axis = Index(["one", "two"])
@@ -46,15 +46,15 @@ def idx_dup():
     return mi
 
 
-@pytest.fixture
-def index_names():
+@pytest.fixture(name="index_names")
+def fixture_index_names():
     # names that match those in the idx fixture for testing equality of
     # names assigned to the idx
     return ["first", "second"]
 
 
-@pytest.fixture
-def narrow_multi_index():
+@pytest.fixture(name="narrow_multi_index")
+def fixture_narrow_multi_index():
     """
     Return a MultiIndex that is narrower than the display (<80 characters).
     """
@@ -64,8 +64,8 @@ def narrow_multi_index():
     return MultiIndex.from_arrays([ci, ci.codes + 9, dti], names=["a", "b", "dti"])
 
 
-@pytest.fixture
-def wide_multi_index():
+@pytest.fixture(name="wide_multi_index")
+def fixture_wide_multi_index():
     """
     Return a MultiIndex that is wider than the display (>80 characters).
     """

--- a/pandas/tests/indexes/multi/test_partial_indexing.py
+++ b/pandas/tests/indexes/multi/test_partial_indexing.py
@@ -10,8 +10,8 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.fixture
-def df():
+@pytest.fixture(name="df")
+def fixture_df():
     #                        c1
     # 2016-01-01 00:00:00 a   0
     #                     b   1

--- a/pandas/tests/indexes/numeric/test_indexing.py
+++ b/pandas/tests/indexes/numeric/test_indexing.py
@@ -12,8 +12,8 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.fixture
-def index_large():
+@pytest.fixture(name="index_large")
+def fixture_index_large():
     # large values used in Index[uint64] tests where no compat needed with Int64/Float64
     large = [2**63, 2**63 + 10, 2**63 + 15, 2**63 + 20, 2**63 + 25]
     return Index(large, dtype=np.uint64)

--- a/pandas/tests/indexes/numeric/test_join.py
+++ b/pandas/tests/indexes/numeric/test_join.py
@@ -191,8 +191,8 @@ class TestJoinInt64Index:
 
 
 class TestJoinUInt64Index:
-    @pytest.fixture
-    def index_large(self):
+    @pytest.fixture(name="index_large")
+    def fixture_index_large(self):
         # large values used in TestUInt64Index where no compat needed with int64/float64
         large = [2**63, 2**63 + 10, 2**63 + 15, 2**63 + 20, 2**63 + 25]
         return Index(large, dtype=np.uint64)

--- a/pandas/tests/indexes/numeric/test_numeric.py
+++ b/pandas/tests/indexes/numeric/test_numeric.py
@@ -16,20 +16,21 @@ from pandas.tests.indexes.common import NumericBase
 class TestFloatNumericIndex(NumericBase):
     _index_cls = NumericIndex
 
-    @pytest.fixture(params=[np.float64, np.float32])
-    def dtype(self, request):
+    @pytest.fixture(name="dtype", params=[np.float64, np.float32])
+    def fixture_dtype(self, request):
         return request.param
 
-    @pytest.fixture(params=["category", "datetime64", "object"])
-    def invalid_dtype(self, request):
+    @pytest.fixture(name="invalid_dtype", params=["category", "datetime64", "object"])
+    def fixture_invalid_dtype(self, request):
         return request.param
 
-    @pytest.fixture
-    def simple_index(self, dtype):
+    @pytest.fixture(name="simple_index")
+    def fixture_simple_index(self, dtype):
         values = np.arange(5, dtype=dtype)
         return self._index_cls(values)
 
     @pytest.fixture(
+        name="index",
         params=[
             [1.5, 2, 3, 4, 5],
             [0.0, 2.5, 5.0, 7.5, 10.0],
@@ -38,15 +39,15 @@ class TestFloatNumericIndex(NumericBase):
         ],
         ids=["mixed", "float", "mixed_dec", "float_dec"],
     )
-    def index(self, request, dtype):
+    def fixture_index(self, request, dtype):
         return self._index_cls(request.param, dtype=dtype)
 
-    @pytest.fixture
-    def mixed_index(self, dtype):
+    @pytest.fixture(name="mixed_index")
+    def fixture_mixed_index(self, dtype):
         return self._index_cls([1.5, 2, 3, 4, 5], dtype=dtype)
 
-    @pytest.fixture
-    def float_index(self, dtype):
+    @pytest.fixture(name="float_index")
+    def fixture_float_index(self, dtype):
         return self._index_cls([0.0, 2.5, 5.0, 7.5, 10.0], dtype=dtype)
 
     def test_repr_roundtrip(self, index):
@@ -349,22 +350,24 @@ class NumericInt(NumericBase):
 class TestIntNumericIndex(NumericInt):
     _index_cls = NumericIndex
 
-    @pytest.fixture(params=[np.int64, np.int32, np.int16, np.int8])
-    def dtype(self, request):
+    @pytest.fixture(name="dtype", params=[np.int64, np.int32, np.int16, np.int8])
+    def fixture_dtype(self, request):
         return request.param
 
-    @pytest.fixture(params=["category", "datetime64", "object"])
-    def invalid_dtype(self, request):
+    @pytest.fixture(name="invalid_dtype", params=["category", "datetime64", "object"])
+    def fixture_invalid_dtype(self, request):
         return request.param
 
-    @pytest.fixture
-    def simple_index(self, dtype):
+    @pytest.fixture(name="simple_index")
+    def fixture_simple_index(self, dtype):
         return self._index_cls(range(0, 20, 2), dtype=dtype)
 
     @pytest.fixture(
-        params=[range(0, 20, 2), range(19, -1, -1)], ids=["index_inc", "index_dec"]
+        name="index",
+        params=[range(0, 20, 2), range(19, -1, -1)],
+        ids=["index_inc", "index_dec"],
     )
-    def index(self, request, dtype):
+    def fixture_index(self, request, dtype):
         return self._index_cls(request.param, dtype=dtype)
 
     def test_constructor_from_list_no_dtype(self):
@@ -513,27 +516,28 @@ class TestUIntNumericIndex(NumericInt):
 
     _index_cls = NumericIndex
 
-    @pytest.fixture(params=[np.uint64])
-    def dtype(self, request):
+    @pytest.fixture(name="dtype", params=[np.uint64])
+    def fixture_dtype(self, request):
         return request.param
 
-    @pytest.fixture(params=["category", "datetime64", "object"])
-    def invalid_dtype(self, request):
+    @pytest.fixture(name="invalid_dtype", params=["category", "datetime64", "object"])
+    def fixture_invalid_dtype(self, request):
         return request.param
 
-    @pytest.fixture
-    def simple_index(self, dtype):
+    @pytest.fixture(name="simple_index")
+    def fixture_simple_index(self, dtype):
         # compat with shared Int64/Float64 tests
         return self._index_cls(np.arange(5, dtype=dtype))
 
     @pytest.fixture(
+        name="index",
         params=[
             [2**63, 2**63 + 10, 2**63 + 15, 2**63 + 20, 2**63 + 25],
             [2**63 + 25, 2**63 + 20, 2**63 + 15, 2**63 + 10, 2**63],
         ],
         ids=["index_inc", "index_dec"],
     )
-    def index(self, request):
+    def fixture_index(self, request):
         return self._index_cls(request.param, dtype=np.uint64)
 
 

--- a/pandas/tests/indexes/numeric/test_setops.py
+++ b/pandas/tests/indexes/numeric/test_setops.py
@@ -13,8 +13,8 @@ from pandas.core.indexes.api import (
 )
 
 
-@pytest.fixture
-def index_large():
+@pytest.fixture(name="index_large")
+def fixture_index_large():
     # large values used in TestUInt64Index where no compat needed with int64/float64
     large = [2**63, 2**63 + 10, 2**63 + 15, 2**63 + 20, 2**63 + 25]
     return Index(large, dtype=np.uint64)

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -31,6 +31,7 @@ rng = pd.Index(range(3))
 
 
 @pytest.fixture(
+    name="non_comparable_idx",
     params=[
         dti,
         dti.tz_localize("UTC"),
@@ -41,9 +42,9 @@ rng = pd.Index(range(3))
         pd.Index([2.0, 3.0, 4.0]),
         pd.Index([4, 5, 6], dtype="u8"),
         pd.IntervalIndex.from_breaks(dti4),
-    ]
+    ],
 )
-def non_comparable_idx(request):
+def fixture_non_comparable_idx(request):
     # All have length 3
     return request.param
 

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -20,18 +20,19 @@ from pandas.tests.indexes.datetimelike import DatetimeLike
 class TestPeriodIndex(DatetimeLike):
     _index_cls = PeriodIndex
 
-    @pytest.fixture
-    def simple_index(self) -> Index:
+    @pytest.fixture(name="simple_index")
+    def fixture_simple_index(self) -> Index:
         return period_range("20130101", periods=5, freq="D")
 
     @pytest.fixture(
+        name="index",
         params=[
             tm.makePeriodIndex(10),
             period_range("20130101", periods=10, freq="D")[::-1],
         ],
         ids=["index_inc", "index_dec"],
     )
-    def index(self, request):
+    def fixture_index(self, request):
         return request.param
 
     def test_where(self):

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -23,28 +23,30 @@ OI = Index
 class TestRangeIndex(NumericBase):
     _index_cls = RangeIndex
 
-    @pytest.fixture
-    def dtype(self):
+    @pytest.fixture(name="dtype")
+    def fixture_dtype(self):
         return np.int64
 
     @pytest.fixture(
+        name="invalid_dtype",
         params=["uint64", "float64", "category", "datetime64", "object"],
     )
-    def invalid_dtype(self, request):
+    def fixture_invalid_dtype(self, request):
         return request.param
 
-    @pytest.fixture
-    def simple_index(self) -> Index:
+    @pytest.fixture(name="simple_index")
+    def fixture_simple_index(self) -> Index:
         return self._index_cls(start=0, stop=20, step=2)
 
     @pytest.fixture(
+        name="index",
         params=[
             RangeIndex(start=0, stop=20, step=2, name="foo"),
             RangeIndex(start=18, stop=-1, step=-2, name="bar"),
         ],
         ids=["index_inc", "index_dec"],
     )
-    def index(self, request):
+    def fixture_index(self, request):
         return request.param
 
     def test_constructor_unwraps_index(self, dtype):
@@ -520,6 +522,7 @@ class TestRangeIndex(NumericBase):
         assert len(index) == 0
 
     @pytest.fixture(
+        name="appends",
         params=[
             ([RI(1, 12, 5)], RI(1, 12, 5)),
             ([RI(0, 6, 4)], RI(0, 6, 4)),
@@ -540,9 +543,9 @@ class TestRangeIndex(NumericBase):
             ([RI(3), F64([-1, 3.1, 15.0])], F64([0, 1, 2, -1, 3.1, 15.0])),
             ([RI(3), OI(["a", None, 14])], OI([0, 1, 2, "a", None, 14])),
             ([RI(3, 1), OI(["a", None, 14])], OI(["a", None, 14])),
-        ]
+        ],
     )
-    def appends(self, request):
+    def fixture_appends(self, request):
         """Inputs and expected outputs for RangeIndex.append test"""
         return request.param
 

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -46,8 +46,8 @@ from pandas.tests.indexes.common import Base
 class TestIndex(Base):
     _index_cls = Index
 
-    @pytest.fixture
-    def simple_index(self) -> Index:
+    @pytest.fixture(name="simple_index")
+    def fixture_simple_index(self) -> Index:
         return self._index_cls(list("abcde"))
 
     def test_can_hold_identifiers(self, simple_index):
@@ -1286,12 +1286,12 @@ class TestMixedIntIndex(Base):
     # (GH 13514)
     _index_cls = Index
 
-    @pytest.fixture
-    def simple_index(self) -> Index:
+    @pytest.fixture(name="simple_index")
+    def fixture_simple_index(self) -> Index:
         return self._index_cls([0, "a", 1, "b", 2, "c"])
 
-    @pytest.fixture(params=[[0, "a", 1, "b", 2, "c"]], ids=["mixedIndex"])
-    def index(self, request):
+    @pytest.fixture(name="index", params=[[0, "a", 1, "b", 2, "c"]], ids=["mixedIndex"])
+    def fixture_index(self, request):
         return Index(request.param)
 
     def test_argsort(self, simple_index):

--- a/pandas/tests/indexes/test_engines.py
+++ b/pandas/tests/indexes/test_engines.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 
 @pytest.fixture(
+    name="numeric_indexing_engine_type_and_dtype",
     params=[
         (libindex.Int64Engine, np.int64),
         (libindex.Int32Engine, np.int32),
@@ -23,7 +24,7 @@ import pandas as pd
     ],
     ids=lambda x: x[0].__name__,
 )
-def numeric_indexing_engine_type_and_dtype(request):
+def fixture_numeric_indexing_engine_type_and_dtype(request):
     return request.param
 
 

--- a/pandas/tests/indexes/test_frozen.py
+++ b/pandas/tests/indexes/test_frozen.py
@@ -5,18 +5,18 @@ import pytest
 from pandas.core.indexes.frozen import FrozenList
 
 
-@pytest.fixture
-def lst():
+@pytest.fixture(name="lst")
+def fixture_lst():
     return [1, 2, 3, 4, 5]
 
 
-@pytest.fixture
-def container(lst):
+@pytest.fixture(name="container")
+def fixture_container(lst):
     return FrozenList(lst)
 
 
-@pytest.fixture
-def unicode_container():
+@pytest.fixture(name="unicode_container")
+def fixture_unicode_container():
     return FrozenList(["\u05d0", "\u05d1", "c"])
 
 

--- a/pandas/tests/indexes/timedeltas/test_indexing.py
+++ b/pandas/tests/indexes/timedeltas/test_indexing.py
@@ -274,12 +274,12 @@ class TestTake:
 
 
 class TestMaybeCastSliceBound:
-    @pytest.fixture(params=["increasing", "decreasing", None])
-    def monotonic(self, request):
+    @pytest.fixture(name="monotonic", params=["increasing", "decreasing", None])
+    def fixture_monotonic(self, request):
         return request.param
 
-    @pytest.fixture
-    def tdi(self, monotonic):
+    @pytest.fixture(name="tdi")
+    def fixture_tdi(self, monotonic):
         tdi = timedelta_range("1 Day", periods=10)
         if monotonic == "decreasing":
             tdi = tdi[::-1]

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -23,16 +23,16 @@ randn = np.random.randn
 class TestTimedeltaIndex(DatetimeLike):
     _index_cls = TimedeltaIndex
 
-    @pytest.fixture
-    def simple_index(self) -> TimedeltaIndex:
+    @pytest.fixture(name="simple_index")
+    def fixture_simple_index(self) -> TimedeltaIndex:
         index = pd.to_timedelta(range(5), unit="d")._with_freq("infer")
         assert index.freq == "D"
         ret = index + pd.offsets.Hour(1)
         assert ret.freq == "D"
         return ret
 
-    @pytest.fixture
-    def index(self):
+    @pytest.fixture(name="index")
+    def fixture_index(self):
         return tm.makeTimedeltaIndex(10)
 
     def test_numeric_compat(self):

--- a/pandas/tests/indexing/conftest.py
+++ b/pandas/tests/indexing/conftest.py
@@ -13,25 +13,25 @@ from pandas.core.api import (
 )
 
 
-@pytest.fixture
-def series_ints():
+@pytest.fixture(name="series_ints")
+def fixture_series_ints():
     return Series(np.random.rand(4), index=np.arange(0, 8, 2))
 
 
-@pytest.fixture
-def frame_ints():
+@pytest.fixture(name="frame_ints")
+def fixture_frame_ints():
     return DataFrame(
         np.random.randn(4, 4), index=np.arange(0, 8, 2), columns=np.arange(0, 12, 3)
     )
 
 
-@pytest.fixture
-def series_uints():
+@pytest.fixture(name="series_uints")
+def fixture_series_uints():
     return Series(np.random.rand(4), index=UInt64Index(np.arange(0, 8, 2)))
 
 
-@pytest.fixture
-def frame_uints():
+@pytest.fixture(name="frame_uints")
+def fixture_frame_uints():
     return DataFrame(
         np.random.randn(4, 4),
         index=UInt64Index(range(0, 8, 2)),
@@ -39,33 +39,33 @@ def frame_uints():
     )
 
 
-@pytest.fixture
-def series_labels():
+@pytest.fixture(name="series_labels")
+def fixture_series_labels():
     return Series(np.random.randn(4), index=list("abcd"))
 
 
-@pytest.fixture
-def frame_labels():
+@pytest.fixture(name="frame_labels")
+def fixture_frame_labels():
     return DataFrame(np.random.randn(4, 4), index=list("abcd"), columns=list("ABCD"))
 
 
-@pytest.fixture
-def series_ts():
+@pytest.fixture(name="series_ts")
+def fixture_series_ts():
     return Series(np.random.randn(4), index=date_range("20130101", periods=4))
 
 
-@pytest.fixture
-def frame_ts():
+@pytest.fixture(name="frame_ts")
+def fixture_frame_ts():
     return DataFrame(np.random.randn(4, 4), index=date_range("20130101", periods=4))
 
 
-@pytest.fixture
-def series_floats():
+@pytest.fixture(name="series_floats")
+def fixture_series_floats():
     return Series(np.random.rand(4), index=Float64Index(range(0, 8, 2)))
 
 
-@pytest.fixture
-def frame_floats():
+@pytest.fixture(name="frame_floats")
+def fixture_frame_floats():
     return DataFrame(
         np.random.randn(4, 4),
         index=Float64Index(range(0, 8, 2)),
@@ -73,28 +73,28 @@ def frame_floats():
     )
 
 
-@pytest.fixture
-def series_mixed():
+@pytest.fixture(name="series_mixed")
+def fixture_series_mixed():
     return Series(np.random.randn(4), index=[2, 4, "null", 8])
 
 
-@pytest.fixture
-def frame_mixed():
+@pytest.fixture(name="frame_mixed")
+def fixture_frame_mixed():
     return DataFrame(np.random.randn(4, 4), index=[2, 4, "null", 8])
 
 
-@pytest.fixture
-def frame_empty():
+@pytest.fixture(name="frame_empty")
+def fixture_frame_empty():
     return DataFrame()
 
 
-@pytest.fixture
-def series_empty():
+@pytest.fixture(name="series_empty")
+def fixture_series_empty():
     return Series(dtype=object)
 
 
-@pytest.fixture
-def frame_multi():
+@pytest.fixture(name="frame_multi")
+def fixture_frame_multi():
     return DataFrame(
         np.random.randn(4, 4),
         index=MultiIndex.from_product([[1, 2], [3, 4]]),
@@ -102,6 +102,6 @@ def frame_multi():
     )
 
 
-@pytest.fixture
-def series_multi():
+@pytest.fixture(name="series_multi")
+def fixture_series_multi():
     return Series(np.random.rand(4), index=MultiIndex.from_product([[1, 2], [3, 4]]))

--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -11,8 +11,8 @@ import pandas._testing as tm
 
 
 class TestIntervalIndex:
-    @pytest.fixture
-    def series_with_interval_index(self):
+    @pytest.fixture(name="series_with_interval_index")
+    def fixture_series_with_interval_index(self):
         return Series(np.arange(5), IntervalIndex.from_breaks(np.arange(6)))
 
     def test_getitem_with_scalar(self, series_with_interval_index, indexer_sl):

--- a/pandas/tests/indexing/interval/test_interval_new.py
+++ b/pandas/tests/indexing/interval/test_interval_new.py
@@ -15,8 +15,8 @@ import pandas._testing as tm
 
 
 class TestIntervalIndex:
-    @pytest.fixture
-    def series_with_interval_index(self):
+    @pytest.fixture(name="series_with_interval_index")
+    def fixture_series_with_interval_index(self):
         return Series(np.arange(5), IntervalIndex.from_breaks(np.arange(6)))
 
     def test_loc_with_interval(self, series_with_interval_index, indexer_sl):

--- a/pandas/tests/indexing/multiindex/test_getitem.py
+++ b/pandas/tests/indexing/multiindex/test_getitem.py
@@ -315,8 +315,8 @@ def test_frame_getitem_nan_cols_multiindex(
 # ----------------------------------------------------------------------------
 
 
-@pytest.fixture
-def dataframe_with_duplicate_index():
+@pytest.fixture(name="dataframe_with_duplicate_index")
+def fixture_dataframe_with_duplicate_index():
     """Fixture for DataFrame used in tests for gh-4145 and gh-4146"""
     data = [["a", "d", "e", "c", "f", "b"], [1, 4, 5, 3, 6, 2], [1, 4, 5, 3, 6, 2]]
     index = ["h1", "h3", "h5"]

--- a/pandas/tests/indexing/multiindex/test_iloc.py
+++ b/pandas/tests/indexing/multiindex/test_iloc.py
@@ -9,8 +9,8 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.fixture
-def simple_multiindex_dataframe():
+@pytest.fixture(name="simple_multiindex_dataframe")
+def fixture_simple_multiindex_dataframe():
     """
     Factory function to create simple 3 x 3 dataframe with
     both columns and row MultiIndex using supplied data or

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -16,16 +16,16 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.fixture
-def single_level_multiindex():
+@pytest.fixture(name="single_level_multiindex")
+def fixture_single_level_multiindex():
     """single level MultiIndex"""
     return MultiIndex(
         levels=[["foo", "bar", "baz", "qux"]], codes=[[0, 1, 2, 3]], names=["first"]
     )
 
 
-@pytest.fixture
-def frame_random_data_integer_multi_index():
+@pytest.fixture(name="frame_random_data_integer_multi_index")
+def fixture_frame_random_data_integer_multi_index():
     levels = [[0, 1], [0, 1, 2]]
     codes = [[0, 0, 0, 1, 1, 1], [0, 1, 2, 0, 1, 2]]
     index = MultiIndex(levels=levels, codes=codes)

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -20,8 +20,8 @@ import pandas._testing as tm
 from pandas.api.types import CategoricalDtype as CDT
 
 
-@pytest.fixture
-def df():
+@pytest.fixture(name="df")
+def fixture_df():
     return DataFrame(
         {
             "A": np.arange(6, dtype="int64"),
@@ -30,8 +30,8 @@ def df():
     )
 
 
-@pytest.fixture
-def df2():
+@pytest.fixture(name="df2")
+def fixture_df2():
     return DataFrame(
         {
             "A": np.arange(6, dtype="int64"),

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -23,8 +23,8 @@ from pandas.core.api import NumericIndex
 ###############################################################
 
 
-@pytest.fixture(autouse=True, scope="class")
-def check_comprehensiveness(request):
+@pytest.fixture(name="check_comprehensiveness", autouse=True, scope="class")
+def fixture_check_comprehensiveness(request):
     # Iterate over combination of dtype, method and klass
     # and ensure that each are contained within a collected test
     cls = request.cls
@@ -767,11 +767,12 @@ class TestReplaceSeriesCoercion(CoercionBase):
 
     rep["timedelta64[ns]"] = [pd.Timedelta("1 day"), pd.Timedelta("2 day")]
 
-    @pytest.fixture(params=["dict", "series"])
-    def how(self, request):
+    @pytest.fixture(name="how", params=["dict", "series"])
+    def fixture_how(self, request):
         return request.param
 
     @pytest.fixture(
+        name="from_key",
         params=[
             "object",
             "int64",
@@ -782,12 +783,13 @@ class TestReplaceSeriesCoercion(CoercionBase):
             "datetime64[ns, UTC]",
             "datetime64[ns, US/Eastern]",
             "timedelta64[ns]",
-        ]
+        ],
     )
-    def from_key(self, request):
+    def fixture_from_key(self, request):
         return request.param
 
     @pytest.fixture(
+        name="to_key",
         params=[
             "object",
             "int64",
@@ -811,11 +813,11 @@ class TestReplaceSeriesCoercion(CoercionBase):
             "timedelta64",
         ],
     )
-    def to_key(self, request):
+    def fixture_to_key(self, request):
         return request.param
 
-    @pytest.fixture
-    def replacer(self, how, from_key, to_key):
+    @pytest.fixture(name="replacer")
+    def fixture_replacer(self, how, from_key, to_key):
         """
         Object we will pass to `Series.replace`
         """

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -556,8 +556,8 @@ class TestLocBaseIndependent:
         tm.assert_series_equal(result, expected)
         assert result.dtype == object
 
-    @pytest.fixture
-    def frame_for_consistency(self):
+    @pytest.fixture(name="frame_for_consistency")
+    def fixture_frame_for_consistency(self):
         return DataFrame(
             {
                 "date": date_range("2000-01-01", "2000-01-5"),
@@ -1635,13 +1635,13 @@ class TestLocBaseIndependent:
 
 
 class TestLocWithEllipsis:
-    @pytest.fixture(params=[tm.loc, tm.iloc])
-    def indexer(self, request):
+    @pytest.fixture(name="indexer", params=[tm.loc, tm.iloc])
+    def fixture_indexer(self, request):
         # Test iloc while we're here
         return request.param
 
-    @pytest.fixture
-    def obj(self, series_with_simple_index, frame_or_series):
+    @pytest.fixture(name="obj")
+    def fixture_obj(self, series_with_simple_index, frame_or_series):
         obj = series_with_simple_index
         if frame_or_series is not Series:
             obj = obj.to_frame()

--- a/pandas/tests/interchange/conftest.py
+++ b/pandas/tests/interchange/conftest.py
@@ -3,8 +3,8 @@ import pytest
 import pandas as pd
 
 
-@pytest.fixture
-def df_from_dict():
+@pytest.fixture(name="df_from_dict")
+def fixture_df_from_dict():
     def maker(dct, is_categorical=False):
         df = pd.DataFrame(dct)
         return df.astype("category") if is_categorical else df

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -47,16 +47,16 @@ from pandas.core.internals.blocks import (
 pytestmark = td.skip_array_manager_invalid_test
 
 
-@pytest.fixture(params=[new_block, make_block])
-def block_maker(request):
+@pytest.fixture(name="block_maker", params=[new_block, make_block])
+def fixture_block_maker(request):
     """
     Fixture to test both the internal new_block and pseudo-public make_block.
     """
     return request.param
 
 
-@pytest.fixture
-def mgr():
+@pytest.fixture(name="mgr")
+def fixture_mgr():
     return create_mgr(
         "a: f8; b: object; c: f8; d: object; e: f8;"
         "f: bool; g: i8; h: complex; i: datetime-1; j: datetime-2;"
@@ -243,8 +243,8 @@ def create_mgr(descr, item_shape=None):
     )
 
 
-@pytest.fixture
-def fblock():
+@pytest.fixture(name="fblock")
+def fixture_fblock():
     return create_block("float", [0, 2, 4])
 
 
@@ -1218,6 +1218,7 @@ class TestBlockPlacement:
 
 class TestCanHoldElement:
     @pytest.fixture(
+        name="element",
         params=[
             lambda x: x,
             lambda x: x.to_series(),
@@ -1227,9 +1228,9 @@ class TestCanHoldElement:
             lambda x: np.asarray(x),
             lambda x: x[0],
             lambda x: x[:0],
-        ]
+        ],
     )
-    def element(self, request):
+    def fixture_element(self, request):
         """
         Functions that take an Index and return an element that should have
         blk._can_hold_element(element) for a Block with this index's dtype.

--- a/pandas/tests/io/conftest.py
+++ b/pandas/tests/io/conftest.py
@@ -18,31 +18,31 @@ import pandas._testing as tm
 from pandas.io.parsers import read_csv
 
 
-@pytest.fixture
-def tips_file(datapath):
+@pytest.fixture(name="tips_file")
+def fixture_tips_file(datapath):
     """Path to the tips dataset"""
     return datapath("io", "data", "csv", "tips.csv")
 
 
-@pytest.fixture
-def jsonl_file(datapath):
+@pytest.fixture(name="jsonl_file")
+def fixture_jsonl_file(datapath):
     """Path to a JSONL dataset"""
     return datapath("io", "parser", "data", "items.jsonl")
 
 
-@pytest.fixture
-def salaries_table(datapath):
+@pytest.fixture(name="salaries_table")
+def fixture_salaries_table(datapath):
     """DataFrame with the salaries dataset"""
     return read_csv(datapath("io", "parser", "data", "salaries.csv"), sep="\t")
 
 
-@pytest.fixture
-def feather_file(datapath):
+@pytest.fixture(name="feather_file")
+def fixture_feather_file(datapath):
     return datapath("io", "data", "feather", "feather-0_3_1.feather")
 
 
-@pytest.fixture
-def s3so(worker_id):
+@pytest.fixture(name="s3so")
+def fixture_s3so(worker_id):
     if is_ci_environment():
         url = "http://localhost:5000/"
     else:
@@ -51,8 +51,8 @@ def s3so(worker_id):
     return {"client_kwargs": {"endpoint_url": url}}
 
 
-@pytest.fixture(scope="session")
-def s3_base(worker_id):
+@pytest.fixture(name="s3_base", scope="session")
+def fixture_s3_base(worker_id):
     """
     Fixture for mocking S3 interaction.
 
@@ -115,8 +115,8 @@ def s3_base(worker_id):
                 proc.terminate()
 
 
-@pytest.fixture
-def s3_resource(s3_base, tips_file, jsonl_file, feather_file):
+@pytest.fixture(name="s3_resource")
+def fixture_s3_resource(s3_base, tips_file, jsonl_file, feather_file):
     """
     Sets up S3 bucket with contents
 
@@ -204,11 +204,11 @@ _compression_formats_params = [
 ]
 
 
-@pytest.fixture(params=_compression_formats_params[1:])
-def compression_format(request):
+@pytest.fixture(name="compression_format", params=_compression_formats_params[1:])
+def fixture_compression_format(request):
     return request.param
 
 
-@pytest.fixture(params=_compression_formats_params)
-def compression_ext(request):
+@pytest.fixture(name="compression_ext", params=_compression_formats_params)
+def fixture_compression_ext(request):
     return request.param[0]

--- a/pandas/tests/io/excel/conftest.py
+++ b/pandas/tests/io/excel/conftest.py
@@ -8,26 +8,26 @@ import pandas._testing as tm
 from pandas.io.parsers import read_csv
 
 
-@pytest.fixture
-def frame(float_frame):
+@pytest.fixture(name="frame")
+def fixture_frame(float_frame):
     """
     Returns the first ten items in fixture "float_frame".
     """
     return float_frame[:10]
 
 
-@pytest.fixture
-def tsframe():
+@pytest.fixture(name="tsframe")
+def fixture_tsframe():
     return tm.makeTimeDataFrame()[:5]
 
 
-@pytest.fixture(params=[True, False])
-def merge_cells(request):
+@pytest.fixture(name="merge_cells", params=[True, False])
+def fixture_merge_cells(request):
     return request.param
 
 
-@pytest.fixture
-def df_ref(datapath):
+@pytest.fixture(name="df_ref")
+def fixture_df_ref(datapath):
     """
     Obtain the reference data from read_csv with the Python engine.
     """
@@ -36,8 +36,8 @@ def df_ref(datapath):
     return df_ref
 
 
-@pytest.fixture(params=[".xls", ".xlsx", ".xlsm", ".ods", ".xlsb"])
-def read_ext(request):
+@pytest.fixture(name="read_ext", params=[".xls", ".xlsx", ".xlsm", ".ods", ".xlsb"])
+def fixture_read_ext(request):
     """
     Valid extensions for reading Excel files.
     """
@@ -45,8 +45,8 @@ def read_ext(request):
 
 
 # Checking for file leaks can hang on Windows CI
-@pytest.fixture(autouse=not is_platform_windows())
-def check_for_file_leaks():
+@pytest.fixture(name="check_for_file_leaks", autouse=not is_platform_windows())
+def fixture_check_for_file_leaks():
     """
     Fixture to run around every test to ensure that we are not leaking files.
 

--- a/pandas/tests/io/excel/test_odf.py
+++ b/pandas/tests/io/excel/test_odf.py
@@ -9,8 +9,8 @@ import pandas._testing as tm
 pytest.importorskip("odf")
 
 
-@pytest.fixture(autouse=True)
-def cd_and_set_engine(monkeypatch, datapath):
+@pytest.fixture(name="cd_and_set_engine", autouse=True)
+def fixture_cd_and_set_engine(monkeypatch, datapath):
     func = functools.partial(pd.read_excel, engine="odf")
     monkeypatch.setattr(pd, "read_excel", func)
     monkeypatch.chdir(datapath("io", "data", "excel"))

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -87,6 +87,7 @@ def _transfer_marks(engine, read_ext):
 
 
 @pytest.fixture(
+    name="engine_and_read_ext",
     params=[
         _transfer_marks(eng, ext)
         for eng in engine_params
@@ -95,28 +96,28 @@ def _transfer_marks(engine, read_ext):
     ],
     ids=str,
 )
-def engine_and_read_ext(request):
+def fixture_engine_and_read_ext(request):
     """
     Fixture for Excel reader engine and read_ext, only including valid pairs.
     """
     return request.param
 
 
-@pytest.fixture
-def engine(engine_and_read_ext):
+@pytest.fixture(name="engine")
+def fixture_engine(engine_and_read_ext):
     engine, read_ext = engine_and_read_ext
     return engine
 
 
-@pytest.fixture
-def read_ext(engine_and_read_ext):
+@pytest.fixture(name="read_ext")
+def fixture_read_ext(engine_and_read_ext):
     engine, read_ext = engine_and_read_ext
     return read_ext
 
 
 class TestReaders:
-    @pytest.fixture(autouse=True)
-    def cd_and_set_engine(self, engine, datapath, monkeypatch):
+    @pytest.fixture(name="cd_and_set_engine", autouse=True)
+    def fixture_cd_and_set_engine(self, engine, datapath, monkeypatch):
         """
         Change directory and set engine for read_excel calls.
         """
@@ -1416,8 +1417,8 @@ class TestReaders:
 
 
 class TestExcelFileRead:
-    @pytest.fixture(autouse=True)
-    def cd_and_set_engine(self, engine, datapath, monkeypatch):
+    @pytest.fixture(name="cd_and_set_engine", autouse=True)
+    def fixture_cd_and_set_engine(self, engine, datapath, monkeypatch):
         """
         Change directory and set engine for ExcelFile objects.
         """

--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -32,8 +32,8 @@ from pandas.io.excel import (
 from pandas.io.excel._util import _writers
 
 
-@pytest.fixture
-def path(ext):
+@pytest.fixture(name="path")
+def fixture_path(ext):
     """
     Fixture to open file for use in each test case.
     """
@@ -41,8 +41,8 @@ def path(ext):
         yield file_path
 
 
-@pytest.fixture
-def set_engine(engine, ext):
+@pytest.fixture(name="set_engine")
+def fixture_set_engine(engine, ext):
     """
     Fixture to set engine for use in each test case.
 

--- a/pandas/tests/io/excel/test_xlrd.py
+++ b/pandas/tests/io/excel/test_xlrd.py
@@ -13,8 +13,8 @@ xlrd = pytest.importorskip("xlrd")
 exts = [".xls"]
 
 
-@pytest.fixture(params=exts)
-def read_ext_xlrd(request):
+@pytest.fixture(name="read_ext_xlrd", params=exts)
+def fixture_read_ext_xlrd(request):
     """
     Valid extensions for reading Excel files with xlrd.
 

--- a/pandas/tests/io/formats/style/test_bar.py
+++ b/pandas/tests/io/formats/style/test_bar.py
@@ -36,18 +36,18 @@ def bar_from_to(x, y, color="#d65f5f"):
     )
 
 
-@pytest.fixture
-def df_pos():
+@pytest.fixture(name="df_pos")
+def fixture_df_pos():
     return DataFrame([[1], [2], [3]])
 
 
-@pytest.fixture
-def df_neg():
+@pytest.fixture(name="df_neg")
+def fixture_df_neg():
     return DataFrame([[-1], [-2], [-3]])
 
 
-@pytest.fixture
-def df_mix():
+@pytest.fixture(name="df_mix")
+def fixture_df_mix():
     return DataFrame([[-3], [1], [2]])
 
 

--- a/pandas/tests/io/formats/style/test_exceptions.py
+++ b/pandas/tests/io/formats/style/test_exceptions.py
@@ -10,8 +10,8 @@ from pandas import (
 from pandas.io.formats.style import Styler
 
 
-@pytest.fixture
-def df():
+@pytest.fixture(name="df")
+def fixture_df():
     return DataFrame(
         data=[[0, -0.609], [1, -1.228]],
         columns=["A", "B"],
@@ -19,8 +19,8 @@ def df():
     )
 
 
-@pytest.fixture
-def styler(df):
+@pytest.fixture(name="styler")
+def fixture_styler(df):
     return Styler(df, uuid_len=0)
 
 

--- a/pandas/tests/io/formats/style/test_format.py
+++ b/pandas/tests/io/formats/style/test_format.py
@@ -16,8 +16,8 @@ from pandas.io.formats.style import Styler
 from pandas.io.formats.style_render import _str_escape
 
 
-@pytest.fixture
-def df():
+@pytest.fixture(name="df")
+def fixture_df():
     return DataFrame(
         data=[[0, -0.609], [1, -1.228]],
         columns=["A", "B"],
@@ -25,13 +25,13 @@ def df():
     )
 
 
-@pytest.fixture
-def styler(df):
+@pytest.fixture(name="styler")
+def fixture_styler(df):
     return Styler(df, uuid_len=0)
 
 
-@pytest.fixture
-def df_multi():
+@pytest.fixture(name="df_multi")
+def fixture_df_multi():
     return DataFrame(
         data=np.arange(16).reshape(4, 4),
         columns=MultiIndex.from_product([["A", "B"], ["a", "b"]]),
@@ -39,8 +39,8 @@ def df_multi():
     )
 
 
-@pytest.fixture
-def styler_multi(df_multi):
+@pytest.fixture(name="styler_multi")
+def fixture_styler_multi(df_multi):
     return Styler(df_multi, uuid_len=0)
 
 

--- a/pandas/tests/io/formats/style/test_highlight.py
+++ b/pandas/tests/io/formats/style/test_highlight.py
@@ -12,16 +12,16 @@ pytest.importorskip("jinja2")
 from pandas.io.formats.style import Styler
 
 
-@pytest.fixture(params=[(None, "float64"), (NA, "Int64")])
-def df(request):
+@pytest.fixture(name="df", params=[(None, "float64"), (NA, "Int64")])
+def fixture_df(request):
     # GH 45804
     return DataFrame(
         {"A": [0, np.nan, 10], "B": [1, request.param[0], 2]}, dtype=request.param[1]
     )
 
 
-@pytest.fixture
-def styler(df):
+@pytest.fixture(name="styler")
+def fixture_styler(df):
     return Styler(df, uuid_len=0)
 
 

--- a/pandas/tests/io/formats/style/test_html.py
+++ b/pandas/tests/io/formats/style/test_html.py
@@ -19,24 +19,24 @@ loader = jinja2.PackageLoader("pandas", "io/formats/templates")
 env = jinja2.Environment(loader=loader, trim_blocks=True)
 
 
-@pytest.fixture
-def styler():
+@pytest.fixture(name="styler")
+def fixture_styler():
     return Styler(DataFrame([[2.61], [2.69]], index=["a", "b"], columns=["A"]))
 
 
-@pytest.fixture
-def styler_mi():
+@pytest.fixture(name="styler_mi")
+def fixture_styler_mi():
     midx = MultiIndex.from_product([["a", "b"], ["c", "d"]])
     return Styler(DataFrame(np.arange(16).reshape(4, 4), index=midx, columns=midx))
 
 
-@pytest.fixture
-def tpl_style():
+@pytest.fixture(name="tpl_style")
+def fixture_tpl_style():
     return env.get_template("html_style.tpl")
 
 
-@pytest.fixture
-def tpl_table():
+@pytest.fixture(name="tpl_table")
+def fixture_tpl_table():
     return env.get_template("html_table.tpl")
 
 

--- a/pandas/tests/io/formats/style/test_matplotlib.py
+++ b/pandas/tests/io/formats/style/test_matplotlib.py
@@ -15,23 +15,23 @@ import matplotlib as mpl
 from pandas.io.formats.style import Styler
 
 
-@pytest.fixture
-def df():
+@pytest.fixture(name="df")
+def fixture_df():
     return DataFrame([[1, 2], [2, 4]], columns=["A", "B"])
 
 
-@pytest.fixture
-def styler(df):
+@pytest.fixture(name="styler")
+def fixture_styler(df):
     return Styler(df, uuid_len=0)
 
 
-@pytest.fixture
-def df_blank():
+@pytest.fixture(name="df_blank")
+def fixture_df_blank():
     return DataFrame([[0, 0], [0, 0]], columns=["A", "B"], index=["X", "Y"])
 
 
-@pytest.fixture
-def styler_blank(df_blank):
+@pytest.fixture(name="styler_blank")
+def fixture_styler_blank(df_blank):
     return Styler(df_blank, uuid_len=0)
 
 

--- a/pandas/tests/io/formats/style/test_non_unique.py
+++ b/pandas/tests/io/formats/style/test_non_unique.py
@@ -12,8 +12,8 @@ pytest.importorskip("jinja2")
 from pandas.io.formats.style import Styler
 
 
-@pytest.fixture
-def df():
+@pytest.fixture(name="df")
+def fixture_df():
     return DataFrame(
         [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
         index=["i", "j", "j"],
@@ -22,8 +22,8 @@ def df():
     )
 
 
-@pytest.fixture
-def styler(df):
+@pytest.fixture(name="styler")
+def fixture_styler(df):
     return Styler(df, uuid_len=0)
 
 

--- a/pandas/tests/io/formats/style/test_style.py
+++ b/pandas/tests/io/formats/style/test_style.py
@@ -27,8 +27,8 @@ from pandas.io.formats.style_render import (
 )
 
 
-@pytest.fixture
-def mi_df():
+@pytest.fixture(name="mi_df")
+def fixture_mi_df():
     return DataFrame(
         [[1, 2], [3, 4]],
         index=MultiIndex.from_product([["i0"], ["i1_a", "i1_b"]]),
@@ -37,13 +37,13 @@ def mi_df():
     )
 
 
-@pytest.fixture
-def mi_styler(mi_df):
+@pytest.fixture(name="mi_styler")
+def fixture_mi_styler(mi_df):
     return Styler(mi_df, uuid_len=0)
 
 
-@pytest.fixture
-def mi_styler_comp(mi_styler):
+@pytest.fixture(name="mi_styler_comp")
+def fixture_mi_styler_comp(mi_styler):
     # comprehensively add features to mi_styler
     mi_styler = mi_styler._copy(deepcopy=True)
     mi_styler.css = {**mi_styler.css, **{"row": "ROW", "col": "COL"}}
@@ -80,20 +80,20 @@ def mi_styler_comp(mi_styler):
     return mi_styler
 
 
-@pytest.fixture
-def blank_value():
+@pytest.fixture(name="blank_value")
+def fixture_blank_value():
     return "&nbsp;"
 
 
-@pytest.fixture
-def df():
+@pytest.fixture(name="df")
+def fixture_df():
     np.random.seed(24)
     df = DataFrame({"A": [0, 1], "B": np.random.randn(2)})
     return df
 
 
-@pytest.fixture
-def styler(df):
+@pytest.fixture(name="styler")
+def fixture_styler(df):
     np.random.seed(24)
     df = DataFrame({"A": [0, 1], "B": np.random.randn(2)})
     return Styler(df)

--- a/pandas/tests/io/formats/style/test_to_latex.py
+++ b/pandas/tests/io/formats/style/test_to_latex.py
@@ -20,20 +20,20 @@ from pandas.io.formats.style_render import (
 )
 
 
-@pytest.fixture
-def df():
+@pytest.fixture(name="df")
+def fixture_df():
     return DataFrame({"A": [0, 1], "B": [-0.61, -1.22], "C": ["ab", "cd"]})
 
 
-@pytest.fixture
-def df_ext():
+@pytest.fixture(name="df_ext")
+def fixture_df_ext():
     return DataFrame(
         {"A": [0, 1, 2], "B": [-0.61, -1.22, -2.22], "C": ["ab", "cd", "de"]}
     )
 
 
-@pytest.fixture
-def styler(df):
+@pytest.fixture(name="styler")
+def fixture_styler(df):
     return Styler(df, uuid_len=0, precision=2)
 
 

--- a/pandas/tests/io/formats/style/test_to_string.py
+++ b/pandas/tests/io/formats/style/test_to_string.py
@@ -8,13 +8,13 @@ pytest.importorskip("jinja2")
 from pandas.io.formats.style import Styler
 
 
-@pytest.fixture
-def df():
+@pytest.fixture(name="df")
+def fixture_df():
     return DataFrame({"A": [0, 1], "B": [-0.61, -1.22], "C": ["ab", "cd"]})
 
 
-@pytest.fixture
-def styler(df):
+@pytest.fixture(name="styler")
+def fixture_styler(df):
     return Styler(df, uuid_len=0, precision=2)
 
 

--- a/pandas/tests/io/formats/style/test_tooltip.py
+++ b/pandas/tests/io/formats/style/test_tooltip.py
@@ -7,8 +7,8 @@ pytest.importorskip("jinja2")
 from pandas.io.formats.style import Styler
 
 
-@pytest.fixture
-def df():
+@pytest.fixture(name="df")
+def fixture_df():
     return DataFrame(
         data=[[0, 1, 2], [3, 4, 5], [6, 7, 8]],
         columns=["A", "B", "C"],
@@ -16,8 +16,8 @@ def df():
     )
 
 
-@pytest.fixture
-def styler(df):
+@pytest.fixture(name="styler")
+def fixture_styler(df):
     return Styler(df, uuid_len=0)
 
 

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -58,16 +58,16 @@ def get_local_am_pm():
     return am_local, pm_local
 
 
-@pytest.fixture(params=["string", "pathlike", "buffer"])
-def filepath_or_buffer_id(request):
+@pytest.fixture(name="filepath_or_buffer_id", params=["string", "pathlike", "buffer"])
+def fixture_filepath_or_buffer_id(request):
     """
     A fixture yielding test ids for filepath_or_buffer testing.
     """
     return request.param
 
 
-@pytest.fixture
-def filepath_or_buffer(filepath_or_buffer_id, tmp_path):
+@pytest.fixture(name="filepath_or_buffer")
+def fixture_filepath_or_buffer(filepath_or_buffer_id, tmp_path):
     """
     A fixture yielding a string representing a filepath, a path-like object
     and a StringIO buffer. Also checks that buffer is not closed.
@@ -84,8 +84,8 @@ def filepath_or_buffer(filepath_or_buffer_id, tmp_path):
             yield str(tmp_path / "foo")
 
 
-@pytest.fixture
-def assert_filepath_or_buffer_equals(
+@pytest.fixture(name="assert_filepath_or_buffer_equals")
+def fixture_assert_filepath_or_buffer_equals(
     filepath_or_buffer, filepath_or_buffer_id, encoding
 ):
     """

--- a/pandas/tests/io/formats/test_info.py
+++ b/pandas/tests/io/formats/test_info.py
@@ -23,8 +23,8 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.fixture
-def duplicate_columns_frame():
+@pytest.fixture(name="duplicate_columns_frame")
+def fixture_duplicate_columns_frame():
     """Dataframe with duplicate column names."""
     return DataFrame(np.random.randn(1500, 4), columns=["a", "a", "b", "b"])
 

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -49,8 +49,8 @@ def expected_html(datapath, name):
     return html.rstrip()
 
 
-@pytest.fixture(params=["mixed", "empty"])
-def biggie_df_fixture(request):
+@pytest.fixture(name="biggie_df_fixture", params=["mixed", "empty"])
+def fixture_biggie_df_fixture(request):
     """Fixture for a big mixed Dataframe and an empty Dataframe"""
     if request.param == "mixed":
         df = DataFrame(
@@ -65,8 +65,8 @@ def biggie_df_fixture(request):
         return df
 
 
-@pytest.fixture(params=fmt._VALID_JUSTIFY_PARAMETERS)
-def justify(request):
+@pytest.fixture(name="justify", params=fmt._VALID_JUSTIFY_PARAMETERS)
+def fixture_justify(request):
     return request.param
 
 
@@ -453,8 +453,8 @@ def test_to_html_invalid_justify(justify):
 
 
 class TestHTMLIndex:
-    @pytest.fixture
-    def df(self):
+    @pytest.fixture(name="df")
+    def fixture_df(self):
         index = ["foo", "bar", "baz"]
         df = DataFrame(
             {"A": [1, 2, 3], "B": [1.2, 3.4, 5.6], "C": ["one", "two", np.nan]},
@@ -463,8 +463,8 @@ class TestHTMLIndex:
         )
         return df
 
-    @pytest.fixture
-    def expected_without_index(self, datapath):
+    @pytest.fixture(name="expected_without_index")
+    def fixture_expected_without_index(self, datapath):
         return expected_html(datapath, "index_2")
 
     def test_to_html_flat_index_without_name(

--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -32,8 +32,8 @@ def _dedent(string):
     return dedent(string).lstrip()
 
 
-@pytest.fixture
-def df_short():
+@pytest.fixture(name="df_short")
+def fixture_df_short():
     """Short dataframe for testing table/tabular/longtable LaTeX env."""
     return DataFrame({"a": [1, 2], "b": ["b1", "b2"]})
 
@@ -432,28 +432,28 @@ class TestToLatexBold:
 
 
 class TestToLatexCaptionLabel:
-    @pytest.fixture
-    def caption_table(self):
+    @pytest.fixture(name="caption_table")
+    def fixture_caption_table(self):
         """Caption for table/tabular LaTeX environment."""
         return "a table in a \\texttt{table/tabular} environment"
 
-    @pytest.fixture
-    def short_caption(self):
+    @pytest.fixture(name="short_caption")
+    def fixture_short_caption(self):
         """Short caption for testing \\caption[short_caption]{full_caption}."""
         return "a table"
 
-    @pytest.fixture
-    def label_table(self):
+    @pytest.fixture(name="label_table")
+    def fixture_label_table(self):
         """Label for table/tabular LaTeX environment."""
         return "tab:table_tabular"
 
-    @pytest.fixture
-    def caption_longtable(self):
+    @pytest.fixture(name="caption_longtable")
+    def fixture_caption_longtable(self):
         """Caption for longtable LaTeX environment."""
         return "a table in a \\texttt{longtable} environment"
 
-    @pytest.fixture
-    def label_longtable(self):
+    @pytest.fixture(name="label_longtable")
+    def fixture_label_longtable(self):
         """Label for longtable LaTeX environment."""
         return "tab:longtable"
 
@@ -767,8 +767,8 @@ class TestToLatexCaptionLabel:
 
 
 class TestToLatexEscape:
-    @pytest.fixture
-    def df_with_symbols(self):
+    @pytest.fixture(name="df_with_symbols")
+    def fixture_df_with_symbols(self):
         """Dataframe with special characters for testing chars escaping."""
         a = "a"
         b = "b"
@@ -1021,8 +1021,8 @@ class TestToLatexFormatters:
 
 
 class TestToLatexMultiindex:
-    @pytest.fixture
-    def multiindex_frame(self):
+    @pytest.fixture(name="multiindex_frame")
+    def fixture_multiindex_frame(self):
         """Multiindex dataframe for testing multirow LaTeX macros."""
         yield DataFrame.from_dict(
             {
@@ -1034,8 +1034,8 @@ class TestToLatexMultiindex:
             }
         ).T
 
-    @pytest.fixture
-    def multicolumn_frame(self):
+    @pytest.fixture(name="multicolumn_frame")
+    def fixture_multicolumn_frame(self):
         """Multicolumn dataframe for testing multicolumn LaTeX macros."""
         yield DataFrame(
             {
@@ -1436,12 +1436,12 @@ class TestToLatexMultiindex:
 
 
 class TestTableBuilder:
-    @pytest.fixture
-    def dataframe(self):
+    @pytest.fixture(name="dataframe")
+    def fixture_dataframe(self):
         return DataFrame({"a": [1, 2], "b": ["b1", "b2"]})
 
-    @pytest.fixture
-    def table_builder(self, dataframe):
+    @pytest.fixture(name="table_builder")
+    def fixture_table_builder(self, dataframe):
         return RegularTableBuilder(formatter=DataFrameFormatter(dataframe))
 
     def test_create_row_iterator(self, table_builder):

--- a/pandas/tests/io/json/conftest.py
+++ b/pandas/tests/io/json/conftest.py
@@ -1,8 +1,10 @@
 import pytest
 
 
-@pytest.fixture(params=["split", "records", "index", "columns", "values"])
-def orient(request):
+@pytest.fixture(
+    name="orient", params=["split", "records", "index", "columns", "values"]
+)
+def fixture_orient(request):
     """
     Fixture for orients excluding the table format.
     """

--- a/pandas/tests/io/json/test_json_table_schema.py
+++ b/pandas/tests/io/json/test_json_table_schema.py
@@ -24,8 +24,8 @@ from pandas.io.json._table_schema import (
 )
 
 
-@pytest.fixture
-def df_schema():
+@pytest.fixture(name="df_schema")
+def fixture_df_schema():
     return DataFrame(
         {
             "A": [1, 2, 3, 4],
@@ -37,8 +37,8 @@ def df_schema():
     )
 
 
-@pytest.fixture
-def df_table():
+@pytest.fixture(name="df_table")
+def fixture_df_table():
     return DataFrame(
         {
             "A": [1, 2, 3, 4],

--- a/pandas/tests/io/json/test_json_table_schema_ext_dtype.py
+++ b/pandas/tests/io/json/test_json_table_schema_ext_dtype.py
@@ -115,24 +115,24 @@ class TestTableSchemaType:
 
 
 class TestTableOrient:
-    @pytest.fixture
-    def da(self):
+    @pytest.fixture(name="da")
+    def fixture_da(self):
         return DateArray([dt.date(2021, 10, 10)])
 
-    @pytest.fixture
-    def dc(self):
+    @pytest.fixture(name="dc")
+    def fixture_dc(self):
         return DecimalArray([decimal.Decimal(10)])
 
-    @pytest.fixture
-    def sa(self):
+    @pytest.fixture(name="sa")
+    def fixture_sa(self):
         return array(["pandas"], dtype="string")
 
-    @pytest.fixture
-    def ia(self):
+    @pytest.fixture(name="ia")
+    def fixture_ia(self):
         return array([10], dtype="Int64")
 
-    @pytest.fixture
-    def df(self, da, dc, sa, ia):
+    @pytest.fixture(name="df")
+    def fixture_df(self, da, dc, sa, ia):
         return DataFrame(
             {
                 "A": da,

--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -14,8 +14,8 @@ import pandas._testing as tm
 from pandas.io.json._normalize import nested_to_record
 
 
-@pytest.fixture
-def deep_nested():
+@pytest.fixture(name="deep_nested")
+def fixture_deep_nested():
     # deeply nested data
     return [
         {
@@ -53,8 +53,8 @@ def deep_nested():
     ]
 
 
-@pytest.fixture
-def state_data():
+@pytest.fixture(name="state_data")
+def fixture_state_data():
     return [
         {
             "counties": [
@@ -78,8 +78,8 @@ def state_data():
     ]
 
 
-@pytest.fixture
-def author_missing_data():
+@pytest.fixture(name="author_missing_data")
+def fixture_author_missing_data():
     return [
         {"info": None},
         {
@@ -89,8 +89,8 @@ def author_missing_data():
     ]
 
 
-@pytest.fixture
-def missing_metadata():
+@pytest.fixture(name="missing_metadata")
+def fixture_missing_metadata():
     return [
         {
             "name": "Alice",
@@ -120,8 +120,8 @@ def missing_metadata():
     ]
 
 
-@pytest.fixture
-def max_level_test_input_data():
+@pytest.fixture(name="max_level_test_input_data")
+def fixture_max_level_test_input_data():
     """
     input data to test json_normalize with max_level param
     """

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -35,8 +35,8 @@ def assert_json_roundtrip_equal(result, expected, orient):
     "ignore:an integer is required (got type float)*:DeprecationWarning"
 )
 class TestPandasContainer:
-    @pytest.fixture
-    def categorical_frame(self):
+    @pytest.fixture(name="categorical_frame")
+    def fixture_categorical_frame(self):
         _seriesd = tm.getSeriesData()
 
         _cat_frame = DataFrame(_seriesd)
@@ -47,8 +47,8 @@ class TestPandasContainer:
         _cat_frame["sort"] = np.arange(len(_cat_frame), dtype="int64")
         return _cat_frame
 
-    @pytest.fixture
-    def datetime_series(self):
+    @pytest.fixture(name="datetime_series")
+    def fixture_datetime_series(self):
         # Same as usual datetime_series, but with index freq set to None,
         #  since that doesn't round-trip, see GH#33711
         ser = tm.makeTimeSeries()
@@ -56,8 +56,8 @@ class TestPandasContainer:
         ser.index = ser.index._with_freq(None)
         return ser
 
-    @pytest.fixture
-    def datetime_frame(self):
+    @pytest.fixture(name="datetime_frame")
+    def fixture_datetime_frame(self):
         # Same as usual datetime_frame, but with index freq set to None,
         #  since that doesn't round-trip, see GH#33711
         df = DataFrame(tm.getTimeSeriesData())

--- a/pandas/tests/io/json/test_readlines.py
+++ b/pandas/tests/io/json/test_readlines.py
@@ -14,8 +14,8 @@ import pandas._testing as tm
 from pandas.io.json._json import JsonReader
 
 
-@pytest.fixture
-def lines_json_df():
+@pytest.fixture(name="lines_json_df")
+def fixture_lines_json_df():
     df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
     return df.to_json(lines=True, orient="records")
 

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -46,9 +46,10 @@ def _clean_dict(d):
 
 
 @pytest.fixture(
-    params=[None, "split", "records", "values", "index"]  # Column indexed by default.
+    name="orient",
+    params=[None, "split", "records", "values", "index"],  # Column indexed by default.
 )
-def orient(request):
+def fixture_orient(request):
     return request.param
 
 

--- a/pandas/tests/io/parser/conftest.py
+++ b/pandas/tests/io/parser/conftest.py
@@ -76,16 +76,16 @@ class PyArrowParser(BaseParser):
     float_precision_choices = [None]
 
 
-@pytest.fixture
-def csv_dir_path(datapath):
+@pytest.fixture(name="csv_dir_path")
+def fixture_csv_dir_path(datapath):
     """
     The directory path to the data files needed for parser tests.
     """
     return datapath("io", "parser", "data")
 
 
-@pytest.fixture
-def csv1(datapath):
+@pytest.fixture(name="csv1")
+def fixture_csv1(datapath):
     """
     The path to the data file "test1.csv" needed for parser tests.
     """
@@ -110,8 +110,8 @@ _pyarrow_parsers_ids = ["pyarrow"]
 _all_parser_ids = [*_c_parser_ids, *_py_parser_ids, *_pyarrow_parsers_ids]
 
 
-@pytest.fixture(params=_all_parsers, ids=_all_parser_ids)
-def all_parsers(request):
+@pytest.fixture(name="all_parsers", params=_all_parsers, ids=_all_parser_ids)
+def fixture_all_parsers(request):
     """
     Fixture all of the CSV parsers.
     """
@@ -126,24 +126,26 @@ def all_parsers(request):
     return parser
 
 
-@pytest.fixture(params=_c_parsers_only, ids=_c_parser_ids)
-def c_parser_only(request):
+@pytest.fixture(name="c_parser_only", params=_c_parsers_only, ids=_c_parser_ids)
+def fixture_c_parser_only(request):
     """
     Fixture all of the CSV parsers using the C engine.
     """
     return request.param()
 
 
-@pytest.fixture(params=_py_parsers_only, ids=_py_parser_ids)
-def python_parser_only(request):
+@pytest.fixture(name="python_parser_only", params=_py_parsers_only, ids=_py_parser_ids)
+def fixture_python_parser_only(request):
     """
     Fixture all of the CSV parsers using the Python engine.
     """
     return request.param()
 
 
-@pytest.fixture(params=_pyarrow_parsers_only, ids=_pyarrow_parsers_ids)
-def pyarrow_parser_only(request):
+@pytest.fixture(
+    name="pyarrow_parser_only", params=_pyarrow_parsers_only, ids=_pyarrow_parsers_ids
+)
+def fixture_pyarrow_parser_only(request):
     """
     Fixture all of the CSV parsers using the Pyarrow engine.
     """
@@ -172,10 +174,11 @@ def _get_all_parser_float_precision_combinations():
 
 
 @pytest.fixture(
+    name="all_parsers_all_precisions",
     params=_get_all_parser_float_precision_combinations()["params"],
     ids=_get_all_parser_float_precision_combinations()["ids"],
 )
-def all_parsers_all_precisions(request):
+def fixture_all_parsers_all_precisions(request):
     """
     Fixture for all allowable combinations of parser
     and float precision
@@ -193,16 +196,16 @@ _encoding_fmts = [
 ]
 
 
-@pytest.fixture(params=_utf_values)
-def utf_value(request):
+@pytest.fixture(name="utf_value", params=_utf_values)
+def fixture_utf_value(request):
     """
     Fixture for all possible integer values for a UTF encoding.
     """
     return request.param
 
 
-@pytest.fixture(params=_encoding_fmts)
-def encoding_fmt(request):
+@pytest.fixture(name="encoding_fmt", params=_encoding_fmts)
+def fixture_encoding_fmt(request):
     """
     Fixture for all possible string formats of a UTF encoding.
     """
@@ -210,6 +213,7 @@ def encoding_fmt(request):
 
 
 @pytest.fixture(
+    name="numeric_decimal",
     params=[
         ("-1,0", -1.0),
         ("-1,2e0", -1.2),
@@ -254,9 +258,9 @@ def encoding_fmt(request):
         ("1a_2,1", "1a_2,1"),
         ("1,2E-1", 0.12),
         ("1,2E1", 12.0),
-    ]
+    ],
 )
-def numeric_decimal(request):
+def fixture_numeric_decimal(request):
     """
     Fixture for all numeric formats which should get recognized. The first entry
     represents the value to read while the second represents the expected result.
@@ -264,8 +268,8 @@ def numeric_decimal(request):
     return request.param
 
 
-@pytest.fixture
-def pyarrow_xfail(request):
+@pytest.fixture(name="pyarrow_xfail")
+def fixture_pyarrow_xfail(request):
     """
     Fixture that xfails a test if the engine is pyarrow.
     """
@@ -281,8 +285,8 @@ def pyarrow_xfail(request):
         request.node.add_marker(mark)
 
 
-@pytest.fixture
-def pyarrow_skip(request):
+@pytest.fixture(name="pyarrow_skip")
+def fixture_pyarrow_skip(request):
     """
     Fixture that skips a test if the engine is pyarrow.
     """

--- a/pandas/tests/io/parser/test_compression.py
+++ b/pandas/tests/io/parser/test_compression.py
@@ -17,13 +17,13 @@ from pandas.tests.io.test_compression import _compression_to_extension
 skip_pyarrow = pytest.mark.usefixtures("pyarrow_skip")
 
 
-@pytest.fixture(params=[True, False])
-def buffer(request):
+@pytest.fixture(name="buffer", params=[True, False])
+def fixture_buffer(request):
     return request.param
 
 
-@pytest.fixture
-def parser_and_data(all_parsers, csv1):
+@pytest.fixture(name="parser_and_data")
+def fixture_parser_and_data(all_parsers, csv1):
     parser = all_parsers
 
     with open(csv1, "rb") as f:

--- a/pandas/tests/io/parser/test_dialect.py
+++ b/pandas/tests/io/parser/test_dialect.py
@@ -16,8 +16,8 @@ import pandas._testing as tm
 pytestmark = pytest.mark.usefixtures("pyarrow_skip")
 
 
-@pytest.fixture
-def custom_dialect():
+@pytest.fixture(name="custom_dialect")
+def fixture_custom_dialect():
     dialect_name = "weird"
     dialect_kwargs = {
         "doublequote": False,

--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -72,8 +72,8 @@ def test_url_encoding_csv():
     assert df.loc[15, 1] == "Á köldum klaka (Cold Fever) (1994)"
 
 
-@pytest.fixture
-def tips_df(datapath):
+@pytest.fixture(name="tips_df")
+def fixture_tips_df(datapath):
     """DataFrame with the tips dataset."""
     return read_csv(datapath("io", "data", "csv", "tips.csv"))
 

--- a/pandas/tests/io/parser/test_textreader.py
+++ b/pandas/tests/io/parser/test_textreader.py
@@ -24,8 +24,8 @@ from pandas.io.parsers.c_parser_wrapper import ensure_dtype_objs
 
 
 class TestTextReader:
-    @pytest.fixture
-    def csv_path(self, datapath):
+    @pytest.fixture(name="csv_path")
+    def fixture_csv_path(self, datapath):
         return datapath("io", "data", "csv", "test1.csv")
 
     def test_file_handle(self, csv_path):

--- a/pandas/tests/io/parser/test_unsupported.py
+++ b/pandas/tests/io/parser/test_unsupported.py
@@ -25,8 +25,10 @@ from pandas.io.parsers import read_csv
 import pandas.io.parsers.readers as parsers
 
 
-@pytest.fixture(params=["python", "python-fwf"], ids=lambda val: val)
-def python_engine(request):
+@pytest.fixture(
+    name="python_engine", params=["python", "python-fwf"], ids=lambda val: val
+)
+def fixture_python_engine(request):
     return request.param
 
 

--- a/pandas/tests/io/pytables/conftest.py
+++ b/pandas/tests/io/pytables/conftest.py
@@ -3,7 +3,7 @@ import uuid
 import pytest
 
 
-@pytest.fixture
-def setup_path():
+@pytest.fixture(name="setup_path")
+def fixture_setup_path():
     """Fixture for setup path"""
     return f"tmp.__{uuid.uuid4()}__.h5"

--- a/pandas/tests/io/pytables/test_compat.py
+++ b/pandas/tests/io/pytables/test_compat.py
@@ -6,8 +6,8 @@ import pandas._testing as tm
 tables = pytest.importorskip("tables")
 
 
-@pytest.fixture
-def pytables_hdf5_file(tmp_path):
+@pytest.fixture(name="pytables_hdf5_file")
+def fixture_pytables_hdf5_file(tmp_path):
     """
     Use PyTables to create a simple HDF5 file.
     """

--- a/pandas/tests/io/sas/test_sas7bdat.py
+++ b/pandas/tests/io/sas/test_sas7bdat.py
@@ -15,13 +15,13 @@ import pandas as pd
 import pandas._testing as tm
 
 
-@pytest.fixture
-def dirpath(datapath):
+@pytest.fixture(name="dirpath")
+def fixture_dirpath(datapath):
     return datapath("io", "sas", "data")
 
 
-@pytest.fixture(params=[(1, range(1, 16)), (2, [16])])
-def data_test_ix(request, dirpath):
+@pytest.fixture(name="data_test_ix", params=[(1, range(1, 16)), (2, [16])])
+def fixture_data_test_ix(request, dirpath):
     i, test_ix = request.param
     fname = os.path.join(dirpath, f"test_sas7bdat_{i}.csv")
     df = pd.read_csv(fname)

--- a/pandas/tests/io/sas/test_xport.py
+++ b/pandas/tests/io/sas/test_xport.py
@@ -21,29 +21,29 @@ def numeric_as_float(data):
 
 
 class TestXport:
-    @pytest.fixture(autouse=True)
-    def setup_method(self):
+    @pytest.fixture(name="setup_method", autouse=True)
+    def fixture_setup_method(self):
         with td.file_leak_context():
             yield
 
-    @pytest.fixture
-    def file01(self, datapath):
+    @pytest.fixture(name="file01")
+    def fixture_file01(self, datapath):
         return datapath("io", "sas", "data", "DEMO_G.xpt")
 
-    @pytest.fixture
-    def file02(self, datapath):
+    @pytest.fixture(name="file02")
+    def fixture_file02(self, datapath):
         return datapath("io", "sas", "data", "SSHSV1_A.xpt")
 
-    @pytest.fixture
-    def file03(self, datapath):
+    @pytest.fixture(name="file03")
+    def fixture_file03(self, datapath):
         return datapath("io", "sas", "data", "DRXFCD_G.xpt")
 
-    @pytest.fixture
-    def file04(self, datapath):
+    @pytest.fixture(name="file04")
+    def fixture_file04(self, datapath):
         return datapath("io", "sas", "data", "paxraw_d_short.xpt")
 
-    @pytest.fixture
-    def file05(self, datapath):
+    @pytest.fixture(name="file05")
+    def fixture_file05(self, datapath):
         return datapath("io", "sas", "data", "DEMO_PUF.cpt")
 
     @pytest.mark.slow

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -35,6 +35,7 @@ def build_kwargs(sep, excel):
 
 
 @pytest.fixture(
+    name="df",
     params=[
         "delims",
         "utf8",
@@ -46,9 +47,9 @@ def build_kwargs(sep, excel):
         "mixed",
         "float",
         "int",
-    ]
+    ],
 )
-def df(request):
+def fixture_df(request):
     data_type = request.param
 
     if data_type == "delims":
@@ -119,8 +120,8 @@ def df(request):
         raise ValueError
 
 
-@pytest.fixture
-def mock_ctypes(monkeypatch):
+@pytest.fixture(name="mock_ctypes")
+def fixture_mock_ctypes(monkeypatch):
     """
     Mocks WinError to help with testing the clipboard.
     """
@@ -194,8 +195,8 @@ def test_stringify_text(text):
             _stringifyText(text)
 
 
-@pytest.fixture
-def mock_clipboard(monkeypatch, request):
+@pytest.fixture(name="mock_clipboard")
+def fixture_mock_clipboard(monkeypatch, request):
     """Fixture mocking clipboard IO.
 
     This mocks pandas.io.clipboard.clipboard_get and

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -396,8 +396,8 @@ Look,a snake,🐍"""
         tm.assert_frame_equal(result, expected)
 
 
-@pytest.fixture
-def mmap_file(datapath):
+@pytest.fixture(name="mmap_file")
+def fixture_mmap_file(datapath):
     return datapath("io", "data", "csv", "test_mmap.csv")
 
 

--- a/pandas/tests/io/test_fsspec.py
+++ b/pandas/tests/io/test_fsspec.py
@@ -19,8 +19,8 @@ import pandas._testing as tm
 from pandas.util import _test_decorators as td
 
 
-@pytest.fixture
-def df1():
+@pytest.fixture(name="df1")
+def fixture_df1():
     return DataFrame(
         {
             "int": [1, 3],
@@ -31,8 +31,8 @@ def df1():
     )
 
 
-@pytest.fixture
-def cleared_fs():
+@pytest.fixture(name="cleared_fs")
+def fixture_cleared_fs():
     fsspec = pytest.importorskip("fsspec")
 
     memfs = fsspec.filesystem("memory")

--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -19,8 +19,8 @@ from pandas.tests.io.test_compression import _compression_to_extension
 from pandas.util import _test_decorators as td
 
 
-@pytest.fixture
-def gcs_buffer(monkeypatch):
+@pytest.fixture(name="gcs_buffer")
+def fixture_gcs_buffer(monkeypatch):
     """Emulate GCS using a binary buffer."""
     from fsspec import (
         AbstractFileSystem,

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -40,14 +40,15 @@ from pandas.io.html import read_html
 
 
 @pytest.fixture(
+    name="html_encoding_file",
     params=[
         "chinese_utf-16.html",
         "chinese_utf-32.html",
         "chinese_utf-8.html",
         "letz_latin1.html",
-    ]
+    ],
 )
-def html_encoding_file(request, datapath):
+def fixture_html_encoding_file(request, datapath):
     """Parametrized fixture for HTML encoding test filenames."""
     return datapath("io", "data", "html_encoding", request.param)
 
@@ -109,16 +110,16 @@ def test_same_ordering(datapath):
     ],
 )
 class TestReadHtml:
-    @pytest.fixture
-    def spam_data(self, datapath):
+    @pytest.fixture(name="spam_data")
+    def fixture_spam_data(self, datapath):
         return datapath("io", "data", "html", "spam.html")
 
-    @pytest.fixture
-    def banklist_data(self, datapath):
+    @pytest.fixture(name="banklist_data")
+    def fixture_banklist_data(self, datapath):
         return datapath("io", "data", "html", "banklist.html")
 
-    @pytest.fixture(autouse=True)
-    def set_defaults(self, flavor):
+    @pytest.fixture(name="set_defaults", autouse=True)
+    def fixture_set_defaults(self, flavor):
         self.read_html = partial(read_html, flavor=flavor)
         yield
 

--- a/pandas/tests/io/test_orc.py
+++ b/pandas/tests/io/test_orc.py
@@ -17,8 +17,8 @@ pytest.importorskip("pyarrow.orc")
 import pyarrow as pa
 
 
-@pytest.fixture
-def dirpath(datapath):
+@pytest.fixture(name="dirpath")
+def fixture_dirpath(datapath):
     return datapath("io", "data", "orc")
 
 

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -57,6 +57,7 @@ except ImportError:
 
 # setup engines & skips
 @pytest.fixture(
+    name="engine",
     params=[
         pytest.param(
             "fastparquet",
@@ -71,21 +72,21 @@ except ImportError:
                 not _HAVE_PYARROW, reason="pyarrow is not installed"
             ),
         ),
-    ]
+    ],
 )
-def engine(request):
+def fixture_engine(request):
     return request.param
 
 
-@pytest.fixture
-def pa():
+@pytest.fixture(name="pa")
+def fixture_pa():
     if not _HAVE_PYARROW:
         pytest.skip("pyarrow is not installed")
     return "pyarrow"
 
 
-@pytest.fixture
-def fp():
+@pytest.fixture(name="fp")
+def fixture_fp():
     if not _HAVE_FASTPARQUET:
         pytest.skip("fastparquet is not installed")
     elif get_option("mode.data_manager") == "array":
@@ -93,13 +94,13 @@ def fp():
     return "fastparquet"
 
 
-@pytest.fixture
-def df_compat():
+@pytest.fixture(name="df_compat")
+def fixture_df_compat():
     return pd.DataFrame({"A": [1, 2, 3], "B": "foo"})
 
 
-@pytest.fixture
-def df_cross_compat():
+@pytest.fixture(name="df_cross_compat")
+def fixture_df_cross_compat():
     df = pd.DataFrame(
         {
             "a": list("abc"),
@@ -116,8 +117,8 @@ def df_cross_compat():
     return df
 
 
-@pytest.fixture
-def df_full():
+@pytest.fixture(name="df_full")
+def fixture_df_full():
     return pd.DataFrame(
         {
             "string": list("abc"),
@@ -141,6 +142,7 @@ def df_full():
 
 
 @pytest.fixture(
+    name="timezone_aware_date_list",
     params=[
         datetime.datetime.now(datetime.timezone.utc),
         datetime.datetime.now(datetime.timezone.min),
@@ -149,9 +151,9 @@ def df_full():
         datetime.datetime.strptime("2019-01-04T16:41:24+0215", "%Y-%m-%dT%H:%M:%S%z"),
         datetime.datetime.strptime("2019-01-04T16:41:24-0200", "%Y-%m-%dT%H:%M:%S%z"),
         datetime.datetime.strptime("2019-01-04T16:41:24-0215", "%Y-%m-%dT%H:%M:%S%z"),
-    ]
+    ],
 )
-def timezone_aware_date_list(request):
+def fixture_timezone_aware_date_list(request):
     return request.param
 
 

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -56,8 +56,8 @@ from pandas.tseries.offsets import (
 )
 
 
-@pytest.fixture(scope="module")
-def current_pickle_data():
+@pytest.fixture(name="current_pickle_data", scope="module")
+def fixture_current_pickle_data():
     # our current version pickle data
     from pandas.tests.io.generate_legacy_storage_files import create_pickle_data
 
@@ -89,8 +89,8 @@ legacy_dirname = os.path.join(os.path.dirname(__file__), "data", "legacy_pickle"
 files = glob.glob(os.path.join(legacy_dirname, "*", "*.pickle"))
 
 
-@pytest.fixture(params=files)
-def legacy_pickle(request, datapath):
+@pytest.fixture(name="legacy_pickle", params=files)
+def fixture_legacy_pickle(request, datapath):
     return datapath(request.param)
 
 
@@ -248,8 +248,8 @@ def test_pickle_path_localpath():
 # ---------------------
 
 
-@pytest.fixture
-def get_random_path():
+@pytest.fixture(name="get_random_path")
+def fixture_get_random_path():
     return f"__{uuid.uuid4()}__.pickle"
 
 

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -280,14 +280,14 @@ def count_rows(conn, table_name: str):
     return result.fetchone()[0]
 
 
-@pytest.fixture
-def iris_path(datapath):
+@pytest.fixture(name="iris_path")
+def fixture_iris_path(datapath):
     iris_path = datapath("io", "data", "csv", "iris.csv")
     return Path(iris_path)
 
 
-@pytest.fixture
-def types_data():
+@pytest.fixture(name="types_data")
+def fixture_types_data():
     return [
         {
             "TextCol": "first",
@@ -316,8 +316,8 @@ def types_data():
     ]
 
 
-@pytest.fixture
-def types_data_frame(types_data):
+@pytest.fixture(name="types_data_frame")
+def fixture_types_data_frame(types_data):
     dtypes = {
         "TextCol": "str",
         "DateCol": "str",
@@ -333,8 +333,8 @@ def types_data_frame(types_data):
     return df[dtypes.keys()].astype(dtypes)
 
 
-@pytest.fixture
-def test_frame1():
+@pytest.fixture(name="test_frame1")
+def fixture_test_frame1():
     columns = ["index", "A", "B", "C", "D"]
     data = [
         (
@@ -369,8 +369,8 @@ def test_frame1():
     return DataFrame(data, columns=columns)
 
 
-@pytest.fixture
-def test_frame3():
+@pytest.fixture(name="test_frame3")
+def fixture_test_frame3():
     columns = ["index", "A", "B"]
     data = [
         ("2000-01-03 00:00:00", 2**31 - 1, -1.987670),
@@ -381,8 +381,8 @@ def test_frame3():
     return DataFrame(data, columns=columns)
 
 
-@pytest.fixture
-def mysql_pymysql_engine(iris_path, types_data):
+@pytest.fixture(name="mysql_pymysql_engine")
+def fixture_mysql_pymysql_engine(iris_path, types_data):
     sqlalchemy = pytest.importorskip("sqlalchemy")
     pymysql = pytest.importorskip("pymysql")
     engine = sqlalchemy.create_engine(
@@ -404,13 +404,13 @@ def mysql_pymysql_engine(iris_path, types_data):
     engine.dispose()
 
 
-@pytest.fixture
-def mysql_pymysql_conn(mysql_pymysql_engine):
+@pytest.fixture(name="mysql_pymysql_conn")
+def fixture_mysql_pymysql_conn(mysql_pymysql_engine):
     yield mysql_pymysql_engine.connect()
 
 
-@pytest.fixture
-def postgresql_psycopg2_engine(iris_path, types_data):
+@pytest.fixture(name="postgresql_psycopg2_engine")
+def fixture_postgresql_psycopg2_engine(iris_path, types_data):
     sqlalchemy = pytest.importorskip("sqlalchemy")
     pytest.importorskip("psycopg2")
     engine = sqlalchemy.create_engine(
@@ -429,44 +429,44 @@ def postgresql_psycopg2_engine(iris_path, types_data):
     engine.dispose()
 
 
-@pytest.fixture
-def postgresql_psycopg2_conn(postgresql_psycopg2_engine):
+@pytest.fixture(name="postgresql_psycopg2_conn")
+def fixture_postgresql_psycopg2_conn(postgresql_psycopg2_engine):
     yield postgresql_psycopg2_engine.connect()
 
 
-@pytest.fixture
-def sqlite_engine():
+@pytest.fixture(name="sqlite_engine")
+def fixture_sqlite_engine():
     sqlalchemy = pytest.importorskip("sqlalchemy")
     engine = sqlalchemy.create_engine("sqlite://")
     yield engine
     engine.dispose()
 
 
-@pytest.fixture
-def sqlite_conn(sqlite_engine):
+@pytest.fixture(name="sqlite_conn")
+def fixture_sqlite_conn(sqlite_engine):
     yield sqlite_engine.connect()
 
 
-@pytest.fixture
-def sqlite_iris_engine(sqlite_engine, iris_path):
+@pytest.fixture(name="sqlite_iris_engine")
+def fixture_sqlite_iris_engine(sqlite_engine, iris_path):
     create_and_load_iris(sqlite_engine, iris_path, "sqlite")
     return sqlite_engine
 
 
-@pytest.fixture
-def sqlite_iris_conn(sqlite_iris_engine):
+@pytest.fixture(name="sqlite_iris_conn")
+def fixture_sqlite_iris_conn(sqlite_iris_engine):
     yield sqlite_iris_engine.connect()
 
 
-@pytest.fixture
-def sqlite_buildin():
+@pytest.fixture(name="sqlite_buildin")
+def fixture_sqlite_buildin():
     with contextlib.closing(sqlite3.connect(":memory:")) as closing_conn:
         with closing_conn as conn:
             yield conn
 
 
-@pytest.fixture
-def sqlite_buildin_iris(sqlite_buildin, iris_path):
+@pytest.fixture(name="sqlite_buildin_iris")
+def fixture_sqlite_buildin_iris(sqlite_buildin, iris_path):
     create_and_load_iris_sqlite3(sqlite_buildin, iris_path)
     return sqlite_buildin
 
@@ -866,8 +866,8 @@ class _TestSQLApi(PandasSQLTest):
     flavor = "sqlite"
     mode: str
 
-    @pytest.fixture(autouse=True)
-    def setup_method(self, iris_path, types_data):
+    @pytest.fixture(name="setup_method", autouse=True)
+    def fixture_setup_method(self, iris_path, types_data):
         self.conn = self.connect()
         if not isinstance(self.conn, sqlite3.Connection):
             self.conn.begin()
@@ -1612,8 +1612,8 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
         cls.setup_driver()
         cls.setup_engine()
 
-    @pytest.fixture(autouse=True)
-    def setup_method(self, iris_path, types_data):
+    @pytest.fixture(name="setup_method", autouse=True)
+    def fixture_setup_method(self, iris_path, types_data):
         try:
             self.conn = self.engine.connect()
             self.conn.begin()
@@ -2623,8 +2623,8 @@ class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest):
 
     flavor = "sqlite"
 
-    @pytest.fixture(autouse=True)
-    def setup_method(self, iris_path, types_data):
+    @pytest.fixture(name="setup_method", autouse=True)
+    def fixture_setup_method(self, iris_path, types_data):
         self.conn = self.connect()
         self.load_iris_data(iris_path)
         self.load_types_data(types_data)

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -36,8 +36,8 @@ from pandas.io.stata import (
 )
 
 
-@pytest.fixture
-def mixed_frame():
+@pytest.fixture(name="mixed_frame")
+def fixture_mixed_frame():
     return DataFrame(
         {
             "a": [1, 2, 3, 4],
@@ -47,8 +47,8 @@ def mixed_frame():
     )
 
 
-@pytest.fixture
-def parsed_114(datapath):
+@pytest.fixture(name="parsed_114")
+def fixture_parsed_114(datapath):
     dta14_114 = datapath("io", "data", "stata", "stata5_114.dta")
     parsed_114 = read_stata(dta14_114, convert_dates=True)
     parsed_114.index.name = "index"

--- a/pandas/tests/io/test_user_agent.py
+++ b/pandas/tests/io/test_user_agent.py
@@ -206,8 +206,8 @@ def process_server(responder, port):
     server.server_close()
 
 
-@pytest.fixture
-def responder(request):
+@pytest.fixture(name="responder")
+def fixture_responder(request):
     """
     Fixture that starts a local http server in a separate process on localhost
     and returns the port.

--- a/pandas/tests/io/xml/test_to_xml.py
+++ b/pandas/tests/io/xml/test_to_xml.py
@@ -150,13 +150,15 @@ def equalize_decl(doc):
     return doc
 
 
-@pytest.fixture(params=["rb", "r"])
-def mode(request):
+@pytest.fixture(name="mode", params=["rb", "r"])
+def fixture_mode(request):
     return request.param
 
 
-@pytest.fixture(params=[pytest.param("lxml", marks=td.skip_if_no("lxml")), "etree"])
-def parser(request):
+@pytest.fixture(
+    name="parser", params=[pytest.param("lxml", marks=td.skip_if_no("lxml")), "etree"]
+)
+def fixture_parser(request):
     return request.param
 
 

--- a/pandas/tests/io/xml/test_xml.py
+++ b/pandas/tests/io/xml/test_xml.py
@@ -237,13 +237,15 @@ df_kml = DataFrame(
 )
 
 
-@pytest.fixture(params=["rb", "r"])
-def mode(request):
+@pytest.fixture(name="mode", params=["rb", "r"])
+def fixture_mode(request):
     return request.param
 
 
-@pytest.fixture(params=[pytest.param("lxml", marks=td.skip_if_no("lxml")), "etree"])
-def parser(request):
+@pytest.fixture(
+    name="parser", params=[pytest.param("lxml", marks=td.skip_if_no("lxml")), "etree"]
+)
+def fixture_parser(request):
     return request.param
 
 

--- a/pandas/tests/io/xml/test_xml_dtypes.py
+++ b/pandas/tests/io/xml/test_xml_dtypes.py
@@ -15,15 +15,18 @@ import pandas._testing as tm
 from pandas.io.xml import read_xml
 
 
-@pytest.fixture(params=[pytest.param("lxml", marks=td.skip_if_no("lxml")), "etree"])
-def parser(request):
+@pytest.fixture(
+    name="parser", params=[pytest.param("lxml", marks=td.skip_if_no("lxml")), "etree"]
+)
+def fixture_parser(request):
     return request.param
 
 
 @pytest.fixture(
-    params=[None, {"book": ["category", "title", "author", "year", "price"]}]
+    name="iterparse",
+    params=[None, {"book": ["category", "title", "author", "year", "price"]}],
 )
-def iterparse(request):
+def fixture_iterparse(request):
     return request.param
 
 

--- a/pandas/tests/plotting/conftest.py
+++ b/pandas/tests/plotting/conftest.py
@@ -8,8 +8,8 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.fixture
-def hist_df():
+@pytest.fixture(name="hist_df")
+def fixture_hist_df():
     n = 100
     with tm.RNGContext(42):
         gender = np.random.choice(["Male", "Female"], size=n)

--- a/pandas/tests/plotting/frame/test_hist_box_by.py
+++ b/pandas/tests/plotting/frame/test_hist_box_by.py
@@ -13,8 +13,8 @@ from pandas.tests.plotting.common import (
 )
 
 
-@pytest.fixture
-def hist_df():
+@pytest.fixture(name="hist_df")
+def fixture_hist_df():
     np.random.seed(0)
     df = DataFrame(np.random.randn(30, 2), columns=["A", "B"])
     df["C"] = np.random.choice(["a", "b", "c"], 30)

--- a/pandas/tests/plotting/test_backend.py
+++ b/pandas/tests/plotting/test_backend.py
@@ -11,8 +11,8 @@ dummy_backend = types.ModuleType("pandas_dummy_backend")
 setattr(dummy_backend, "plot", lambda *args, **kwargs: "used_dummy")
 
 
-@pytest.fixture
-def restore_backend():
+@pytest.fixture(name="restore_backend")
+def fixture_restore_backend():
     """Restore the plotting backend to matplotlib"""
     with pandas.option_context("plotting.backend", "matplotlib"):
         yield

--- a/pandas/tests/plotting/test_converter.py
+++ b/pandas/tests/plotting/test_converter.py
@@ -152,8 +152,8 @@ class TestRegistration:
 
 
 class TestDateTimeConverter:
-    @pytest.fixture
-    def dtc(self):
+    @pytest.fixture(name="dtc")
+    def fixture_dtc(self):
         return converter.DatetimeConverter()
 
     def test_convert_accepts_unicode(self, dtc):
@@ -283,12 +283,12 @@ class TestDateTimeConverter:
 
 
 class TestPeriodConverter:
-    @pytest.fixture
-    def pc(self):
+    @pytest.fixture(name="pc")
+    def fixture_pc(self):
         return converter.PeriodConverter()
 
-    @pytest.fixture
-    def axis(self):
+    @pytest.fixture(name="axis")
+    def fixture_axis(self):
         class Axis:
             pass
 

--- a/pandas/tests/plotting/test_hist_method.py
+++ b/pandas/tests/plotting/test_hist_method.py
@@ -19,8 +19,8 @@ from pandas.tests.plotting.common import (
 )
 
 
-@pytest.fixture
-def ts():
+@pytest.fixture(name="ts")
+def fixture_ts():
     return tm.makeTimeSeries(name="ts")
 
 

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -21,18 +21,18 @@ from pandas.tests.plotting.common import (
 )
 
 
-@pytest.fixture
-def ts():
+@pytest.fixture(name="ts")
+def fixture_ts():
     return tm.makeTimeSeries(name="ts")
 
 
-@pytest.fixture
-def series():
+@pytest.fixture(name="series")
+def fixture_series():
     return tm.makeStringSeries(name="series")
 
 
-@pytest.fixture
-def iseries():
+@pytest.fixture(name="iseries")
+def fixture_iseries():
     return tm.makePeriodSeries(name="iseries")
 
 

--- a/pandas/tests/resample/conftest.py
+++ b/pandas/tests/resample/conftest.py
@@ -31,20 +31,20 @@ series_methods = ["nunique"]
 resample_methods = downsample_methods + upsample_methods + series_methods
 
 
-@pytest.fixture(params=downsample_methods)
-def downsample_method(request):
+@pytest.fixture(name="downsample_method", params=downsample_methods)
+def fixture_downsample_method(request):
     """Fixture for parametrization of Grouper downsample methods."""
     return request.param
 
 
-@pytest.fixture(params=resample_methods)
-def resample_method(request):
+@pytest.fixture(name="resample_method", params=resample_methods)
+def fixture_resample_method(request):
     """Fixture for parametrization of Grouper resample methods."""
     return request.param
 
 
-@pytest.fixture
-def simple_date_range_series():
+@pytest.fixture(name="simple_date_range_series")
+def fixture_simple_date_range_series():
     """
     Series with date range index and random data for test purposes.
     """
@@ -56,8 +56,8 @@ def simple_date_range_series():
     return _simple_date_range_series
 
 
-@pytest.fixture
-def simple_period_range_series():
+@pytest.fixture(name="simple_period_range_series")
+def fixture_simple_period_range_series():
     """
     Series with period range index and random data for test purposes.
     """
@@ -69,32 +69,32 @@ def simple_period_range_series():
     return _simple_period_range_series
 
 
-@pytest.fixture
-def _index_start():
+@pytest.fixture(name="_index_start")
+def fixture__index_start():
     """Fixture for parametrization of index, series and frame."""
     return datetime(2005, 1, 1)
 
 
-@pytest.fixture
-def _index_end():
+@pytest.fixture(name="_index_end")
+def fixture__index_end():
     """Fixture for parametrization of index, series and frame."""
     return datetime(2005, 1, 10)
 
 
-@pytest.fixture
-def _index_freq():
+@pytest.fixture(name="_index_freq")
+def fixture__index_freq():
     """Fixture for parametrization of index, series and frame."""
     return "D"
 
 
-@pytest.fixture
-def _index_name():
+@pytest.fixture(name="_index_name")
+def fixture__index_name():
     """Fixture for parametrization of index, series and frame."""
     return None
 
 
-@pytest.fixture
-def index(_index_factory, _index_start, _index_end, _index_freq, _index_name):
+@pytest.fixture(name="index")
+def fixture_index(_index_factory, _index_start, _index_end, _index_freq, _index_name):
     """
     Fixture for parametrization of date_range, period_range and
     timedelta_range indexes
@@ -102,8 +102,8 @@ def index(_index_factory, _index_start, _index_end, _index_freq, _index_name):
     return _index_factory(_index_start, _index_end, freq=_index_freq, name=_index_name)
 
 
-@pytest.fixture
-def _static_values(index):
+@pytest.fixture(name="_static_values")
+def fixture__static_values(index):
     """
     Fixture for parametrization of values used in parametrization of
     Series and DataFrames with date_range, period_range and
@@ -112,8 +112,8 @@ def _static_values(index):
     return np.arange(len(index))
 
 
-@pytest.fixture
-def _series_name():
+@pytest.fixture(name="_series_name")
+def fixture__series_name():
     """
     Fixture for parametrization of Series name for Series used with
     date_range, period_range and timedelta_range indexes
@@ -121,8 +121,8 @@ def _series_name():
     return None
 
 
-@pytest.fixture
-def series(index, _series_name, _static_values):
+@pytest.fixture(name="series")
+def fixture_series(index, _series_name, _static_values):
     """
     Fixture for parametrization of Series with date_range, period_range and
     timedelta_range indexes
@@ -130,8 +130,8 @@ def series(index, _series_name, _static_values):
     return Series(_static_values, index=index, name=_series_name)
 
 
-@pytest.fixture
-def empty_series_dti(series):
+@pytest.fixture(name="empty_series_dti")
+def fixture_empty_series_dti(series):
     """
     Fixture for parametrization of empty Series with date_range,
     period_range and timedelta_range indexes
@@ -139,8 +139,8 @@ def empty_series_dti(series):
     return series[:0]
 
 
-@pytest.fixture
-def frame(index, _series_name, _static_values):
+@pytest.fixture(name="frame")
+def fixture_frame(index, _series_name, _static_values):
     """
     Fixture for parametrization of DataFrame with date_range, period_range
     and timedelta_range indexes
@@ -149,8 +149,8 @@ def frame(index, _series_name, _static_values):
     return DataFrame({"value": _static_values}, index=index)
 
 
-@pytest.fixture
-def empty_frame_dti(series):
+@pytest.fixture(name="empty_frame_dti")
+def fixture_empty_frame_dti(series):
     """
     Fixture for parametrization of empty DataFrame with date_range,
     period_range and timedelta_range indexes
@@ -159,8 +159,8 @@ def empty_frame_dti(series):
     return DataFrame(index=index)
 
 
-@pytest.fixture
-def series_and_frame(frame_or_series, series, frame):
+@pytest.fixture(name="series_and_frame")
+def fixture_series_and_frame(frame_or_series, series, frame):
     """
     Fixture for parametrization of Series and DataFrame with date_range,
     period_range and timedelta_range indexes

--- a/pandas/tests/resample/test_base.py
+++ b/pandas/tests/resample/test_base.py
@@ -33,8 +33,8 @@ all_ts = pytest.mark.parametrize(
 )
 
 
-@pytest.fixture
-def create_index(_index_factory):
+@pytest.fixture(name="create_index")
+def fixture_create_index(_index_factory):
     def _create_index(*args, **kwargs):
         """return the _index_factory created using the args, kwargs"""
         return _index_factory(*args, **kwargs)

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -36,18 +36,18 @@ from pandas.tseries import offsets
 from pandas.tseries.offsets import Minute
 
 
-@pytest.fixture()
-def _index_factory():
+@pytest.fixture(name="_index_factory")
+def fixture__index_factory():
     return date_range
 
 
-@pytest.fixture
-def _index_freq():
+@pytest.fixture(name="_index_freq")
+def fixture__index_freq():
     return "Min"
 
 
-@pytest.fixture
-def _static_values(index):
+@pytest.fixture(name="_static_values")
+def fixture__static_values(index):
     return np.random.rand(len(index))
 
 

--- a/pandas/tests/resample/test_period_index.py
+++ b/pandas/tests/resample/test_period_index.py
@@ -30,13 +30,13 @@ from pandas.core.resample import _get_period_range_edges
 from pandas.tseries import offsets
 
 
-@pytest.fixture()
-def _index_factory():
+@pytest.fixture(name="_index_factory")
+def fixture__index_factory():
     return period_range
 
 
-@pytest.fixture
-def _series_name():
+@pytest.fixture(name="_series_name")
+def fixture__series_name():
     return "pi"
 
 

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -20,8 +20,8 @@ test_series = Series(np.random.rand(len(dti)), dti)
 _test_frame = DataFrame({"A": test_series, "B": test_series, "C": np.arange(len(dti))})
 
 
-@pytest.fixture
-def test_frame():
+@pytest.fixture(name="test_frame")
+def fixture_test_frame():
     return _test_frame.copy()
 
 

--- a/pandas/tests/reshape/concat/conftest.py
+++ b/pandas/tests/reshape/concat/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.fixture(params=[True, False])
-def sort(request):
+@pytest.fixture(name="sort", params=[True, False])
+def fixture_sort(request):
     """Boolean sort keyword for concat and DataFrame.append."""
     return request.param

--- a/pandas/tests/reshape/concat/test_append_common.py
+++ b/pandas/tests/reshape/concat/test_append_common.py
@@ -53,7 +53,9 @@ class TestConcatAppendCommon:
         key = request.param
         return key, data_dict[key]
 
-    item2 = item
+    @pytest.fixture(name="item2")
+    def fixture_item2(self, item):
+        yield item
 
     def test_dtypes(self, item, index_or_series):
         # to confirm test case covers intended dtypes

--- a/pandas/tests/reshape/concat/test_append_common.py
+++ b/pandas/tests/reshape/concat/test_append_common.py
@@ -48,8 +48,8 @@ class TestConcatAppendCommon:
     Test common dtype coercion rules between concat and append.
     """
 
-    @pytest.fixture(params=sorted(data_dict.keys()))
-    def item(self, request):
+    @pytest.fixture(name="item", params=sorted(data_dict.keys()))
+    def fixture_item(self, request):
         key = request.param
         return key, data_dict[key]
 

--- a/pandas/tests/reshape/merge/test_join.py
+++ b/pandas/tests/reshape/merge/test_join.py
@@ -28,8 +28,8 @@ def get_test_data(ngroups=8, n=50):
 
 class TestJoin:
     # aggregate multiple columns
-    @pytest.fixture
-    def df(self):
+    @pytest.fixture(name="df")
+    def fixture_df(self):
         df = DataFrame(
             {
                 "key1": get_test_data(),
@@ -43,8 +43,8 @@ class TestJoin:
         df = df[df["key2"] > 1]
         return df
 
-    @pytest.fixture
-    def df2(self):
+    @pytest.fixture(name="df2")
+    def fixture_df2(self):
         return DataFrame(
             {
                 "key1": get_test_data(n=10),
@@ -53,8 +53,8 @@ class TestJoin:
             }
         )
 
-    @pytest.fixture
-    def target_source(self):
+    @pytest.fixture(name="target_source")
+    def fixture_target_source(self):
         index, data = tm.getMixedTypeDict()
         target = DataFrame(data, index=index)
 

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -73,8 +73,8 @@ def get_series_na():
     ]
 
 
-@pytest.fixture(params=get_series(), ids=lambda x: x.dtype.name)
-def series_of_dtype(request):
+@pytest.fixture(name="series_of_dtype", params=get_series(), ids=lambda x: x.dtype.name)
+def fixture_series_of_dtype(request):
     """
     A parametrized fixture returning a variety of Series of different
     dtypes
@@ -82,8 +82,10 @@ def series_of_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=get_series(), ids=lambda x: x.dtype.name)
-def series_of_dtype2(request):
+@pytest.fixture(
+    name="series_of_dtype2", params=get_series(), ids=lambda x: x.dtype.name
+)
+def fixture_series_of_dtype2(request):
     """
     A duplicate of the series_of_dtype fixture, so that it can be used
     twice by a single function
@@ -91,8 +93,10 @@ def series_of_dtype2(request):
     return request.param
 
 
-@pytest.fixture(params=get_series_na(), ids=lambda x: x.dtype.name)
-def series_of_dtype_all_na(request):
+@pytest.fixture(
+    name="series_of_dtype_all_na", params=get_series_na(), ids=lambda x: x.dtype.name
+)
+def fixture_series_of_dtype_all_na(request):
     """
     A parametrized fixture returning a variety of Series with all NA
     values
@@ -100,8 +104,8 @@ def series_of_dtype_all_na(request):
     return request.param
 
 
-@pytest.fixture
-def dfs_for_indicator():
+@pytest.fixture(name="dfs_for_indicator")
+def fixture_dfs_for_indicator():
     df1 = DataFrame({"col1": [0, 1], "col_conflict": [1, 2], "col_left": ["a", "b"]})
     df2 = DataFrame(
         {
@@ -114,8 +118,8 @@ def dfs_for_indicator():
 
 
 class TestMerge:
-    @pytest.fixture
-    def df(self):
+    @pytest.fixture(name="df")
+    def fixture_df(self):
         df = DataFrame(
             {
                 "key1": get_test_data(),
@@ -129,8 +133,8 @@ class TestMerge:
         df = df[df["key2"] > 1]
         return df
 
-    @pytest.fixture
-    def df2(self):
+    @pytest.fixture(name="df2")
+    def fixture_df2(self):
         return DataFrame(
             {
                 "key1": get_test_data(n=10),
@@ -139,14 +143,14 @@ class TestMerge:
             }
         )
 
-    @pytest.fixture
-    def left(self):
+    @pytest.fixture(name="left")
+    def fixture_left(self):
         return DataFrame(
             {"key": ["a", "b", "c", "d", "e", "e", "a"], "v1": np.random.randn(7)}
         )
 
-    @pytest.fixture
-    def right(self):
+    @pytest.fixture(name="right")
+    def fixture_right(self):
         return DataFrame({"v2": np.random.randn(4)}, index=["d", "b", "c", "a"])
 
     def test_merge_inner_join_empty(self):
@@ -1783,8 +1787,8 @@ class TestMergeDtypes:
         tm.assert_frame_equal(result, expected)
 
 
-@pytest.fixture
-def left():
+@pytest.fixture(name="left")
+def fixture_left():
     np.random.seed(1234)
     return DataFrame(
         {
@@ -1796,8 +1800,8 @@ def left():
     )
 
 
-@pytest.fixture
-def right():
+@pytest.fixture(name="right")
+def fixture_right():
     np.random.seed(1234)
     return DataFrame(
         {"X": Series(["foo", "bar"]).astype(CDT(["foo", "bar"])), "Z": [1, 2]}
@@ -2076,13 +2080,13 @@ class TestMergeCategorical:
         tm.assert_frame_equal(result, expected)
 
 
-@pytest.fixture
-def left_df():
+@pytest.fixture(name="left_df")
+def fixture_left_df():
     return DataFrame({"a": [20, 10, 0]}, index=[2, 1, 0])
 
 
-@pytest.fixture
-def right_df():
+@pytest.fixture(name="right_df")
+def fixture_right_df():
     return DataFrame({"b": [300, 100, 200]}, index=[3, 1, 2])
 
 

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -27,28 +27,28 @@ class TestAsOfMerge:
         x.time = to_datetime(x.time)
         return x
 
-    @pytest.fixture
-    def trades(self, datapath):
+    @pytest.fixture(name="trades")
+    def fixture_trades(self, datapath):
         return self.read_data(datapath, "trades.csv")
 
-    @pytest.fixture
-    def quotes(self, datapath):
+    @pytest.fixture(name="quotes")
+    def fixture_quotes(self, datapath):
         return self.read_data(datapath, "quotes.csv", dedupe=True)
 
-    @pytest.fixture
-    def asof(self, datapath):
+    @pytest.fixture(name="asof")
+    def fixture_asof(self, datapath):
         return self.read_data(datapath, "asof.csv")
 
-    @pytest.fixture
-    def tolerance(self, datapath):
+    @pytest.fixture(name="tolerance")
+    def fixture_tolerance(self, datapath):
         return self.read_data(datapath, "tolerance.csv")
 
-    @pytest.fixture
-    def allow_exact_matches(self, datapath):
+    @pytest.fixture(name="allow_exact_matches")
+    def fixture_allow_exact_matches(self, datapath):
         return self.read_data(datapath, "allow_exact_matches.csv")
 
-    @pytest.fixture
-    def allow_exact_matches_and_tolerance(self, datapath):
+    @pytest.fixture(name="allow_exact_matches_and_tolerance")
+    def fixture_allow_exact_matches_and_tolerance(self, datapath):
         return self.read_data(datapath, "allow_exact_matches_and_tolerance.csv")
 
     def test_examples1(self):

--- a/pandas/tests/reshape/merge/test_merge_index_as_string.py
+++ b/pandas/tests/reshape/merge/test_merge_index_as_string.py
@@ -5,8 +5,8 @@ from pandas import DataFrame
 import pandas._testing as tm
 
 
-@pytest.fixture
-def df1():
+@pytest.fixture(name="df1")
+def fixture_df1():
     return DataFrame(
         {
             "outer": [1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4],
@@ -16,8 +16,8 @@ def df1():
     )
 
 
-@pytest.fixture
-def df2():
+@pytest.fixture(name="df2")
+def fixture_df2():
     return DataFrame(
         {
             "outer": [1, 1, 1, 1, 1, 1, 2, 2, 3, 3, 3, 3],
@@ -27,8 +27,8 @@ def df2():
     )
 
 
-@pytest.fixture(params=[[], ["outer"], ["outer", "inner"]])
-def left_df(request, df1):
+@pytest.fixture(name="left_df", params=[[], ["outer"], ["outer", "inner"]])
+def fixture_left_df(request, df1):
     """Construct left test DataFrame with specified levels
     (any of 'outer', 'inner', and 'v1')
     """
@@ -39,8 +39,8 @@ def left_df(request, df1):
     return df1
 
 
-@pytest.fixture(params=[[], ["outer"], ["outer", "inner"]])
-def right_df(request, df2):
+@pytest.fixture(name="right_df", params=[[], ["outer"], ["outer", "inner"]])
+def fixture_right_df(request, df2):
     """Construct right test DataFrame with specified levels
     (any of 'outer', 'inner', and 'v2')
     """

--- a/pandas/tests/reshape/merge/test_merge_ordered.py
+++ b/pandas/tests/reshape/merge/test_merge_ordered.py
@@ -9,13 +9,13 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.fixture
-def left():
+@pytest.fixture(name="left")
+def fixture_left():
     return DataFrame({"key": ["a", "c", "e"], "lvalue": [1, 2.0, 3]})
 
 
-@pytest.fixture
-def right():
+@pytest.fixture(name="right")
+def fixture_right():
     return DataFrame({"key": ["b", "c", "d", "f"], "rvalue": [1, 2, 3.0, 4]})
 
 

--- a/pandas/tests/reshape/merge/test_multi.py
+++ b/pandas/tests/reshape/merge/test_multi.py
@@ -14,8 +14,8 @@ from pandas.core.reshape.concat import concat
 from pandas.core.reshape.merge import merge
 
 
-@pytest.fixture
-def left():
+@pytest.fixture(name="left")
+def fixture_left():
     """left dataframe (not multi-indexed) for multi-index join tests"""
     # a little relevant example with NAs
     key1 = ["bar", "bar", "bar", "foo", "foo", "baz", "baz", "qux", "qux", "snap"]
@@ -25,8 +25,8 @@ def left():
     return DataFrame({"key1": key1, "key2": key2, "data": data})
 
 
-@pytest.fixture
-def right(multiindex_dataframe_random_data):
+@pytest.fixture(name="right")
+def fixture_right(multiindex_dataframe_random_data):
     """right dataframe (multi-indexed) for multi-index join tests"""
     df = multiindex_dataframe_random_data
     df.index.names = ["key1", "key2"]
@@ -35,8 +35,8 @@ def right(multiindex_dataframe_random_data):
     return df
 
 
-@pytest.fixture
-def left_multi():
+@pytest.fixture(name="left_multi")
+def fixture_left_multi():
     return DataFrame(
         {
             "Origin": ["A", "A", "B", "B", "C"],
@@ -49,8 +49,8 @@ def left_multi():
     ).set_index(["Origin", "Destination", "Period", "TripPurp"])
 
 
-@pytest.fixture
-def right_multi():
+@pytest.fixture(name="right_multi")
+def fixture_right_multi():
     return DataFrame(
         {
             "Origin": ["A", "A", "B", "B", "C", "C", "E"],
@@ -63,13 +63,13 @@ def right_multi():
     ).set_index(["Origin", "Destination", "Period", "LinkType"])
 
 
-@pytest.fixture
-def on_cols_multi():
+@pytest.fixture(name="on_cols_multi")
+def fixture_on_cols_multi():
     return ["Origin", "Destination", "Period"]
 
 
-@pytest.fixture
-def idx_cols_multi():
+@pytest.fixture(name="idx_cols_multi")
+def fixture_idx_cols_multi():
     return ["Origin", "Destination", "Period", "TripPurp", "LinkType"]
 
 
@@ -500,8 +500,8 @@ class TestMergeMulti:
         tm.assert_frame_equal(results_merge, expected)
         tm.assert_frame_equal(results_join, expected)
 
-    @pytest.fixture
-    def household(self):
+    @pytest.fixture(name="household")
+    def fixture_household(self):
         household = DataFrame(
             {
                 "household_id": [1, 2, 3],
@@ -512,8 +512,8 @@ class TestMergeMulti:
         ).set_index("household_id")
         return household
 
-    @pytest.fixture
-    def portfolio(self):
+    @pytest.fixture(name="portfolio")
+    def fixture_portfolio(self):
         portfolio = DataFrame(
             {
                 "household_id": [1, 2, 2, 3, 3, 3, 4],
@@ -541,8 +541,8 @@ class TestMergeMulti:
         ).set_index(["household_id", "asset_id"])
         return portfolio
 
-    @pytest.fixture
-    def expected(self):
+    @pytest.fixture(name="expected")
+    def fixture_expected(self):
         expected = (
             DataFrame(
                 {

--- a/pandas/tests/reshape/test_crosstab.py
+++ b/pandas/tests/reshape/test_crosstab.py
@@ -15,8 +15,8 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.fixture
-def df():
+@pytest.fixture(name="df")
+def fixture_df():
     df = DataFrame(
         {
             "A": [

--- a/pandas/tests/reshape/test_from_dummies.py
+++ b/pandas/tests/reshape/test_from_dummies.py
@@ -10,8 +10,8 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.fixture
-def dummies_basic():
+@pytest.fixture(name="dummies_basic")
+def fixture_dummies_basic():
     return DataFrame(
         {
             "col1_a": [1, 0, 1],
@@ -23,8 +23,8 @@ def dummies_basic():
     )
 
 
-@pytest.fixture
-def dummies_with_unassigned():
+@pytest.fixture(name="dummies_with_unassigned")
+def fixture_dummies_with_unassigned():
     return DataFrame(
         {
             "col1_a": [1, 0, 0],

--- a/pandas/tests/reshape/test_get_dummies.py
+++ b/pandas/tests/reshape/test_get_dummies.py
@@ -21,16 +21,16 @@ from pandas.core.arrays.sparse import (
 
 
 class TestGetDummies:
-    @pytest.fixture
-    def df(self):
+    @pytest.fixture(name="df")
+    def fixture_df(self):
         return DataFrame({"A": ["a", "b", "a"], "B": ["b", "b", "c"], "C": [1, 2, 3]})
 
-    @pytest.fixture(params=["uint8", "i8", np.float64, bool, None])
-    def dtype(self, request):
+    @pytest.fixture(name="dtype", params=["uint8", "i8", np.float64, bool, None])
+    def fixture_dtype(self, request):
         return np.dtype(request.param)
 
-    @pytest.fixture(params=["dense", "sparse"])
-    def sparse(self, request):
+    @pytest.fixture(name="sparse", params=["dense", "sparse"])
+    def fixture_sparse(self, request):
         # params are strings to simplify reading test results,
         # e.g. TestGetDummies::test_basic[uint8-sparse] instead of [uint8-True]
         return request.param == "sparse"

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -13,16 +13,16 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.fixture
-def df():
+@pytest.fixture(name="df")
+def fixture_df():
     res = tm.makeTimeDataFrame()[:10]
     res["id1"] = (res["A"] > 0).astype(np.int64)
     res["id2"] = (res["B"] > 0).astype(np.int64)
     return res
 
 
-@pytest.fixture
-def df1():
+@pytest.fixture(name="df1")
+def fixture_df1():
     res = DataFrame(
         [
             [1.067683, -1.110463, 0.20867],
@@ -35,13 +35,13 @@ def df1():
     return res
 
 
-@pytest.fixture
-def var_name():
+@pytest.fixture(name="var_name")
+def fixture_var_name():
     return "var"
 
 
-@pytest.fixture
-def value_name():
+@pytest.fixture(name="value_name")
+def fixture_value_name():
     return "val"
 
 

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -27,20 +27,22 @@ from pandas.core.reshape import reshape as reshape_lib
 from pandas.core.reshape.pivot import pivot_table
 
 
-@pytest.fixture(params=[True, False])
-def dropna(request):
+@pytest.fixture(name="dropna", params=[True, False])
+def fixture_dropna(request):
     return request.param
 
 
-@pytest.fixture(params=[([0] * 4, [1] * 4), (range(0, 3), range(1, 4))])
-def interval_values(request, closed):
+@pytest.fixture(
+    name="interval_values", params=[([0] * 4, [1] * 4), (range(0, 3), range(1, 4))]
+)
+def fixture_interval_values(request, closed):
     left, right = request.param
     return Categorical(pd.IntervalIndex.from_arrays(left, right, closed))
 
 
 class TestPivotTable:
-    @pytest.fixture
-    def data(self):
+    @pytest.fixture(name="data")
+    def fixture_data(self):
         return DataFrame(
             {
                 "A": [

--- a/pandas/tests/scalar/interval/test_interval.py
+++ b/pandas/tests/scalar/interval/test_interval.py
@@ -11,8 +11,8 @@ import pandas._testing as tm
 import pandas.core.common as com
 
 
-@pytest.fixture
-def interval():
+@pytest.fixture(name="interval")
+def fixture_interval():
     return Interval(0, 1)
 
 

--- a/pandas/tests/scalar/interval/test_ops.py
+++ b/pandas/tests/scalar/interval/test_ops.py
@@ -9,6 +9,7 @@ from pandas import (
 
 
 @pytest.fixture(
+    name="start_shift",
     params=[
         (Timedelta("0 days"), Timedelta("1 day")),
         (Timestamp("2018-01-01"), Timedelta("1 day")),
@@ -16,7 +17,7 @@ from pandas import (
     ],
     ids=lambda x: type(x[0]).__name__,
 )
-def start_shift(request):
+def fixture_start_shift(request):
     """
     Fixture for generating intervals of types from a start value and a shift
     value that can be added to start to generate an endpoint

--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -100,18 +100,18 @@ class TestAsUnit:
 
 
 class TestNonNano:
-    @pytest.fixture(params=["s", "ms", "us"])
-    def unit_str(self, request):
+    @pytest.fixture(name="unit_str", params=["s", "ms", "us"])
+    def fixture_unit_str(self, request):
         return request.param
 
-    @pytest.fixture
-    def unit(self, unit_str):
+    @pytest.fixture(name="unit")
+    def fixture_unit(self, unit_str):
         # 7, 8, 9 correspond to second, millisecond, and microsecond, respectively
         attr = f"NPY_FR_{unit_str}"
         return getattr(NpyDatetimeUnit, attr).value
 
-    @pytest.fixture
-    def val(self, unit):
+    @pytest.fixture(name="val")
+    def fixture_val(self, unit):
         # microsecond that would be just out of bounds for nano
         us = 9223372800000000
         if unit == NpyDatetimeUnit.NPY_FR_us.value:
@@ -122,8 +122,8 @@ class TestNonNano:
             value = us // 1_000_000
         return value
 
-    @pytest.fixture
-    def td(self, unit, val):
+    @pytest.fixture(name="td")
+    def fixture_td(self, unit, val):
         return Timedelta._from_value_and_reso(val, unit)
 
     def test_from_value_and_reso(self, unit, val):

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -646,22 +646,22 @@ def test_dt_subclass_add_timedelta(lh, rh):
 
 
 class TestNonNano:
-    @pytest.fixture(params=["s", "ms", "us"])
-    def reso(self, request):
+    @pytest.fixture(name="reso", params=["s", "ms", "us"])
+    def fixture_reso(self, request):
         return request.param
 
-    @pytest.fixture
-    def dt64(self, reso):
+    @pytest.fixture(name="dt64")
+    def fixture_dt64(self, reso):
         # cases that are in-bounds for nanosecond, so we can compare against
         #  the existing implementation.
         return np.datetime64("2016-01-01", reso)
 
-    @pytest.fixture
-    def ts(self, dt64):
+    @pytest.fixture(name="ts")
+    def fixture_ts(self, dt64):
         return Timestamp._from_dt64(dt64)
 
-    @pytest.fixture
-    def ts_tz(self, ts, tz_aware_fixture):
+    @pytest.fixture(name="ts_tz")
+    def fixture_ts_tz(self, ts, tz_aware_fixture):
         tz = maybe_get_tz(tz_aware_fixture)
         return Timestamp._from_value_and_reso(ts.value, ts._creso, tz)
 

--- a/pandas/tests/series/methods/test_drop_duplicates.py
+++ b/pandas/tests/series/methods/test_drop_duplicates.py
@@ -71,13 +71,21 @@ def test_drop_duplicates_no_duplicates(any_numpy_dtype, keep, values):
 
 class TestSeriesDropDuplicates:
     @pytest.fixture(
-        params=["int_", "uint", "float_", "unicode_", "timedelta64[h]", "datetime64[D]"]
+        name="dtype",
+        params=[
+            "int_",
+            "uint",
+            "float_",
+            "unicode_",
+            "timedelta64[h]",
+            "datetime64[D]",
+        ],
     )
-    def dtype(self, request):
+    def fixture_dtype(self, request):
         return request.param
 
-    @pytest.fixture
-    def cat_series_unused_category(self, dtype, ordered):
+    @pytest.fixture(name="cat_series_unused_category")
+    def fixture_cat_series_unused_category(self, dtype, ordered):
         # Test case 1
         cat_array = np.array([1, 2, 3, 4, 5], dtype=np.dtype(dtype))
 
@@ -138,8 +146,8 @@ class TestSeriesDropDuplicates:
         assert return_value is None
         tm.assert_series_equal(sc, tc1[~expected])
 
-    @pytest.fixture
-    def cat_series(self, dtype, ordered):
+    @pytest.fixture(name="cat_series")
+    def fixture_cat_series(self, dtype, ordered):
         # no unused categories, unlike cat_series_unused_category
         cat_array = np.array([1, 2, 3, 4, 5], dtype=np.dtype(dtype))
 

--- a/pandas/tests/series/methods/test_interpolate.py
+++ b/pandas/tests/series/methods/test_interpolate.py
@@ -15,6 +15,7 @@ import pandas._testing as tm
 
 
 @pytest.fixture(
+    name="nontemporal_method",
     params=[
         "linear",
         "index",
@@ -33,9 +34,9 @@ import pandas._testing as tm
         "pchip",
         "akima",
         "cubicspline",
-    ]
+    ],
 )
-def nontemporal_method(request):
+def fixture_nontemporal_method(request):
     """Fixture that returns an (method name, required kwargs) pair.
 
     This fixture does not include method 'time' as a parameterization; that
@@ -48,6 +49,7 @@ def nontemporal_method(request):
 
 
 @pytest.fixture(
+    name="interp_methods_ind",
     params=[
         "linear",
         "slinear",
@@ -63,9 +65,9 @@ def nontemporal_method(request):
         "pchip",
         "akima",
         "cubicspline",
-    ]
+    ],
 )
-def interp_methods_ind(request):
+def fixture_interp_methods_ind(request):
     """Fixture that returns a (method name, required kwargs) pair to
     be tested for various Index types.
 

--- a/pandas/tests/series/methods/test_nlargest.py
+++ b/pandas/tests/series/methods/test_nlargest.py
@@ -28,8 +28,8 @@ main_dtypes = [
 ]
 
 
-@pytest.fixture
-def s_main_dtypes():
+@pytest.fixture(name="s_main_dtypes")
+def fixture_s_main_dtypes():
     """
     A DataFrame with many dtypes
 
@@ -68,8 +68,8 @@ def s_main_dtypes():
     return df
 
 
-@pytest.fixture(params=main_dtypes)
-def s_main_dtypes_split(request, s_main_dtypes):
+@pytest.fixture(name="s_main_dtypes_split", params=main_dtypes)
+def fixture_s_main_dtypes_split(request, s_main_dtypes):
     """Each series in s_main_dtypes."""
     return s_main_dtypes[request.param]
 

--- a/pandas/tests/series/methods/test_rank.py
+++ b/pandas/tests/series/methods/test_rank.py
@@ -21,25 +21,27 @@ import pandas._testing as tm
 from pandas.api.types import CategoricalDtype
 
 
-@pytest.fixture
-def ser():
+@pytest.fixture(name="ser")
+def fixture_ser():
     return Series([1, 3, 4, 2, np.nan, 2, 1, 5, np.nan, 3])
 
 
 @pytest.fixture(
+    name="results",
     params=[
         ["average", np.array([1.5, 5.5, 7.0, 3.5, np.nan, 3.5, 1.5, 8.0, np.nan, 5.5])],
         ["min", np.array([1, 5, 7, 3, np.nan, 3, 1, 8, np.nan, 5])],
         ["max", np.array([2, 6, 7, 4, np.nan, 4, 2, 8, np.nan, 6])],
         ["first", np.array([1, 5, 7, 3, np.nan, 4, 2, 8, np.nan, 6])],
         ["dense", np.array([1, 3, 4, 2, np.nan, 2, 1, 5, np.nan, 3])],
-    ]
+    ],
 )
-def results(request):
+def fixture_results(request):
     return request.param
 
 
 @pytest.fixture(
+    name="dtype",
     params=[
         "object",
         "float64",
@@ -48,9 +50,9 @@ def results(request):
         "Int64",
         pytest.param("float64[pyarrow]", marks=td.skip_if_no("pyarrow")),
         pytest.param("int64[pyarrow]", marks=td.skip_if_no("pyarrow")),
-    ]
+    ],
 )
-def dtype(request):
+def fixture_dtype(request):
     return request.param
 
 

--- a/pandas/tests/series/methods/test_sort_index.py
+++ b/pandas/tests/series/methods/test_sort_index.py
@@ -12,8 +12,10 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.fixture(params=["quicksort", "mergesort", "heapsort", "stable"])
-def sort_kind(request):
+@pytest.fixture(
+    name="sort_kind", params=["quicksort", "mergesort", "heapsort", "stable"]
+)
+def fixture_sort_kind(request):
     return request.param
 
 

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -32,8 +32,13 @@ from pandas.core import (
 from pandas.core.computation import expressions as expr
 
 
-@pytest.fixture(autouse=True, params=[0, 1000000], ids=["numexpr", "python"])
-def switch_numexpr_min_elements(request):
+@pytest.fixture(
+    name="switch_numexpr_min_elements",
+    autouse=True,
+    params=[0, 1000000],
+    ids=["numexpr", "python"],
+)
+def fixture_switch_numexpr_min_elements(request):
     _MIN_ELEMENTS = expr._MIN_ELEMENTS
     expr._MIN_ELEMENTS = request.param
     yield request.param

--- a/pandas/tests/series/test_ufunc.py
+++ b/pandas/tests/series/test_ufunc.py
@@ -14,8 +14,8 @@ SPARSE = [True, False]
 SPARSE_IDS = ["sparse", "dense"]
 
 
-@pytest.fixture
-def arrays_for_binary_ufunc():
+@pytest.fixture(name="arrays_for_binary_ufunc")
+def fixture_arrays_for_binary_ufunc():
     """
     A pair of random, length-100 integer-dtype arrays, that are mostly 0.
     """
@@ -248,6 +248,7 @@ def test_object_series_ok():
 
 
 @pytest.fixture(
+    name="values_for_np_reduce",
     params=[
         pd.array([1, 3, 2], dtype=np.int64),
         pd.array([1, 3, 2], dtype="Int64"),
@@ -261,7 +262,7 @@ def test_object_series_ok():
     ],
     ids=lambda x: str(x.dtype),
 )
-def values_for_np_reduce(request):
+def fixture_values_for_np_reduce(request):
     # min/max tests assume that these are monotonic increasing
     return request.param
 

--- a/pandas/tests/strings/conftest.py
+++ b/pandas/tests/strings/conftest.py
@@ -97,8 +97,8 @@ missing_methods = {
 assert not missing_methods
 
 
-@pytest.fixture(params=_any_string_method, ids=ids)
-def any_string_method(request):
+@pytest.fixture(name="any_string_method", params=_any_string_method, ids=ids)
+def fixture_any_string_method(request):
     """
     Fixture for all public methods of `StringMethods`
 
@@ -138,8 +138,12 @@ _any_allowed_skipna_inferred_dtype = [
 ids, _ = zip(*_any_allowed_skipna_inferred_dtype)  # use inferred type as id
 
 
-@pytest.fixture(params=_any_allowed_skipna_inferred_dtype, ids=ids)
-def any_allowed_skipna_inferred_dtype(request):
+@pytest.fixture(
+    name="any_allowed_skipna_inferred_dtype",
+    params=_any_allowed_skipna_inferred_dtype,
+    ids=ids,
+)
+def fixture_any_allowed_skipna_inferred_dtype(request):
     """
     Fixture for all (inferred) dtypes allowed in StringMethods.__init__
 

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -34,8 +34,8 @@ def import_module(name):
         pytest.skip(f"skipping as {name} not available")
 
 
-@pytest.fixture
-def df():
+@pytest.fixture(name="df")
+def fixture_df():
     return DataFrame({"A": [1, 2, 3]})
 
 

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -15,18 +15,18 @@ from pandas.core.api import (
 from pandas.core.computation import expressions as expr
 
 
-@pytest.fixture
-def _frame():
+@pytest.fixture(name="_frame")
+def fixture__frame():
     return DataFrame(np.random.randn(10001, 4), columns=list("ABCD"), dtype="float64")
 
 
-@pytest.fixture
-def _frame2():
+@pytest.fixture(name="_frame2")
+def fixture__frame2():
     return DataFrame(np.random.randn(100, 4), columns=list("ABCD"), dtype="float64")
 
 
-@pytest.fixture
-def _mixed(_frame):
+@pytest.fixture(name="_mixed")
+def fixture__mixed(_frame):
     return DataFrame(
         {
             "A": _frame["A"].copy(),
@@ -37,8 +37,8 @@ def _mixed(_frame):
     )
 
 
-@pytest.fixture
-def _mixed2(_frame2):
+@pytest.fixture(name="_mixed2")
+def fixture__mixed2(_frame2):
     return DataFrame(
         {
             "A": _frame2["A"].copy(),
@@ -49,50 +49,50 @@ def _mixed2(_frame2):
     )
 
 
-@pytest.fixture
-def _integer():
+@pytest.fixture(name="_integer")
+def fixture__integer():
     return DataFrame(
         np.random.randint(1, 100, size=(10001, 4)), columns=list("ABCD"), dtype="int64"
     )
 
 
-@pytest.fixture
-def _integer_randint(_integer):
+@pytest.fixture(name="_integer_randint")
+def fixture__integer_randint(_integer):
     # randint to get a case with zeros
     return _integer * np.random.randint(0, 2, size=np.shape(_integer))
 
 
-@pytest.fixture
-def _integer2():
+@pytest.fixture(name="_integer2")
+def fixture__integer2():
     return DataFrame(
         np.random.randint(1, 100, size=(101, 4)), columns=list("ABCD"), dtype="int64"
     )
 
 
-@pytest.fixture
-def _array(_frame):
+@pytest.fixture(name="_array")
+def fixture__array(_frame):
     return _frame["A"].values.copy()
 
 
-@pytest.fixture
-def _array2(_frame2):
+@pytest.fixture(name="_array2")
+def fixture__array2(_frame2):
     return _frame2["A"].values.copy()
 
 
-@pytest.fixture
-def _array_mixed(_mixed):
+@pytest.fixture(name="_array_mixed")
+def fixture__array_mixed(_mixed):
     return _mixed["D"].values.copy()
 
 
-@pytest.fixture
-def _array_mixed2(_mixed2):
+@pytest.fixture(name="_array_mixed2")
+def fixture__array_mixed2(_mixed2):
     return _mixed2["D"].values.copy()
 
 
 @pytest.mark.skipif(not expr.USE_NUMEXPR, reason="not using numexpr")
 class TestExpressions:
-    @pytest.fixture(autouse=True)
-    def save_min_elements(self):
+    @pytest.fixture(name="save_min_elements", autouse=True)
+    def fixture_save_min_elements(self):
         min_elements = expr._MIN_ELEMENTS
         yield
         expr._MIN_ELEMENTS = min_elements

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -21,118 +21,118 @@ from pandas.core.arrays import DatetimeArray
 use_bn = nanops._USE_BOTTLENECK
 
 
-@pytest.fixture(params=[True, False])
-def skipna(request):
+@pytest.fixture(name="skipna", params=[True, False])
+def fixture_skipna(request):
     """
     Fixture to pass skipna to nanops functions.
     """
     return request.param
 
 
-@pytest.fixture
-def disable_bottleneck(monkeypatch):
+@pytest.fixture(name="disable_bottleneck")
+def fixture_disable_bottleneck(monkeypatch):
     with monkeypatch.context() as m:
         m.setattr(nanops, "_USE_BOTTLENECK", False)
         yield
 
 
-@pytest.fixture
-def arr_shape():
+@pytest.fixture(name="arr_shape")
+def fixture_arr_shape():
     return 11, 7
 
 
-@pytest.fixture
-def arr_float(arr_shape):
+@pytest.fixture(name="arr_float")
+def fixture_arr_float(arr_shape):
     np.random.seed(11235)
     return np.random.randn(*arr_shape)
 
 
-@pytest.fixture
-def arr_complex(arr_float):
+@pytest.fixture(name="arr_complex")
+def fixture_arr_complex(arr_float):
     return arr_float + arr_float * 1j
 
 
-@pytest.fixture
-def arr_int(arr_shape):
+@pytest.fixture(name="arr_int")
+def fixture_arr_int(arr_shape):
     np.random.seed(11235)
     return np.random.randint(-10, 10, arr_shape)
 
 
-@pytest.fixture
-def arr_bool(arr_shape):
+@pytest.fixture(name="arr_bool")
+def fixture_arr_bool(arr_shape):
     np.random.seed(11235)
     return np.random.randint(0, 2, arr_shape) == 0
 
 
-@pytest.fixture
-def arr_str(arr_float):
+@pytest.fixture(name="arr_str")
+def fixture_arr_str(arr_float):
     return np.abs(arr_float).astype("S")
 
 
-@pytest.fixture
-def arr_utf(arr_float):
+@pytest.fixture(name="arr_utf")
+def fixture_arr_utf(arr_float):
     return np.abs(arr_float).astype("U")
 
 
-@pytest.fixture
-def arr_date(arr_shape):
+@pytest.fixture(name="arr_date")
+def fixture_arr_date(arr_shape):
     np.random.seed(11235)
     return np.random.randint(0, 20000, arr_shape).astype("M8[ns]")
 
 
-@pytest.fixture
-def arr_tdelta(arr_shape):
+@pytest.fixture(name="arr_tdelta")
+def fixture_arr_tdelta(arr_shape):
     np.random.seed(11235)
     return np.random.randint(0, 20000, arr_shape).astype("m8[ns]")
 
 
-@pytest.fixture
-def arr_nan(arr_shape):
+@pytest.fixture(name="arr_nan")
+def fixture_arr_nan(arr_shape):
     return np.tile(np.nan, arr_shape)
 
 
-@pytest.fixture
-def arr_float_nan(arr_float, arr_nan):
+@pytest.fixture(name="arr_float_nan")
+def fixture_arr_float_nan(arr_float, arr_nan):
     return np.vstack([arr_float, arr_nan])
 
 
-@pytest.fixture
-def arr_nan_float1(arr_nan, arr_float):
+@pytest.fixture(name="arr_nan_float1")
+def fixture_arr_nan_float1(arr_nan, arr_float):
     return np.vstack([arr_nan, arr_float])
 
 
-@pytest.fixture
-def arr_nan_nan(arr_nan):
+@pytest.fixture(name="arr_nan_nan")
+def fixture_arr_nan_nan(arr_nan):
     return np.vstack([arr_nan, arr_nan])
 
 
-@pytest.fixture
-def arr_inf(arr_float):
+@pytest.fixture(name="arr_inf")
+def fixture_arr_inf(arr_float):
     return arr_float * np.inf
 
 
-@pytest.fixture
-def arr_float_inf(arr_float, arr_inf):
+@pytest.fixture(name="arr_float_inf")
+def fixture_arr_float_inf(arr_float, arr_inf):
     return np.vstack([arr_float, arr_inf])
 
 
-@pytest.fixture
-def arr_nan_inf(arr_nan, arr_inf):
+@pytest.fixture(name="arr_nan_inf")
+def fixture_arr_nan_inf(arr_nan, arr_inf):
     return np.vstack([arr_nan, arr_inf])
 
 
-@pytest.fixture
-def arr_float_nan_inf(arr_float, arr_nan, arr_inf):
+@pytest.fixture(name="arr_float_nan_inf")
+def fixture_arr_float_nan_inf(arr_float, arr_nan, arr_inf):
     return np.vstack([arr_float, arr_nan, arr_inf])
 
 
-@pytest.fixture
-def arr_nan_nan_inf(arr_nan, arr_inf):
+@pytest.fixture(name="arr_nan_nan_inf")
+def fixture_arr_nan_nan_inf(arr_nan, arr_inf):
     return np.vstack([arr_nan, arr_nan, arr_inf])
 
 
-@pytest.fixture
-def arr_obj(
+@pytest.fixture(name="arr_obj")
+def fixture_arr_obj(
     arr_float, arr_int, arr_bool, arr_complex, arr_str, arr_utf, arr_date, arr_tdelta
 ):
     return np.vstack(
@@ -149,52 +149,52 @@ def arr_obj(
     )
 
 
-@pytest.fixture
-def arr_nan_nanj(arr_nan):
+@pytest.fixture(name="arr_nan_nanj")
+def fixture_arr_nan_nanj(arr_nan):
     with np.errstate(invalid="ignore"):
         return arr_nan + arr_nan * 1j
 
 
-@pytest.fixture
-def arr_complex_nan(arr_complex, arr_nan_nanj):
+@pytest.fixture(name="arr_complex_nan")
+def fixture_arr_complex_nan(arr_complex, arr_nan_nanj):
     with np.errstate(invalid="ignore"):
         return np.vstack([arr_complex, arr_nan_nanj])
 
 
-@pytest.fixture
-def arr_nan_infj(arr_inf):
+@pytest.fixture(name="arr_nan_infj")
+def fixture_arr_nan_infj(arr_inf):
     with np.errstate(invalid="ignore"):
         return arr_inf * 1j
 
 
-@pytest.fixture
-def arr_complex_nan_infj(arr_complex, arr_nan_infj):
+@pytest.fixture(name="arr_complex_nan_infj")
+def fixture_arr_complex_nan_infj(arr_complex, arr_nan_infj):
     with np.errstate(invalid="ignore"):
         return np.vstack([arr_complex, arr_nan_infj])
 
 
-@pytest.fixture
-def arr_float_1d(arr_float):
+@pytest.fixture(name="arr_float_1d")
+def fixture_arr_float_1d(arr_float):
     return arr_float[:, 0]
 
 
-@pytest.fixture
-def arr_nan_1d(arr_nan):
+@pytest.fixture(name="arr_nan_1d")
+def fixture_arr_nan_1d(arr_nan):
     return arr_nan[:, 0]
 
 
-@pytest.fixture
-def arr_float_nan_1d(arr_float_nan):
+@pytest.fixture(name="arr_float_nan_1d")
+def fixture_arr_float_nan_1d(arr_float_nan):
     return arr_float_nan[:, 0]
 
 
-@pytest.fixture
-def arr_float1_nan_1d(arr_float1_nan):
+@pytest.fixture(name="arr_float1_nan_1d")
+def fixture_arr_float1_nan_1d(arr_float1_nan):
     return arr_float1_nan[:, 0]
 
 
-@pytest.fixture
-def arr_nan_float1_1d(arr_nan_float1):
+@pytest.fixture(name="arr_nan_float1_1d")
+def fixture_arr_nan_float1_1d(arr_nan_float1):
     return arr_nan_float1[:, 0]
 
 
@@ -938,12 +938,12 @@ class TestNanvarFixedValues:
 
     # xref GH10242
     # Samples from a normal distribution.
-    @pytest.fixture
-    def variance(self):
+    @pytest.fixture(name="variance")
+    def fixture_variance(self):
         return 3.0
 
-    @pytest.fixture
-    def samples(self, variance):
+    @pytest.fixture(name="samples")
+    def fixture_samples(self, variance):
         return self.prng.normal(scale=variance**0.5, size=100000)
 
     def test_nanvar_all_finite(self, samples, variance):
@@ -1056,12 +1056,12 @@ class TestNanskewFixedValues:
 
     # xref GH 11974
     # Test data + skewness value (computed with scipy.stats.skew)
-    @pytest.fixture
-    def samples(self):
+    @pytest.fixture(name="samples")
+    def fixture_samples(self):
         return np.sin(np.linspace(0, 1, 200))
 
-    @pytest.fixture
-    def actual_skew(self):
+    @pytest.fixture(name="actual_skew")
+    def fixture_actual_skew(self):
         return -0.1875895205961754
 
     @pytest.mark.parametrize("val", [3075.2, 3075.3, 3075.5])
@@ -1108,12 +1108,12 @@ class TestNankurtFixedValues:
 
     # xref GH 11974
     # Test data + kurtosis value (computed with scipy.stats.kurtosis)
-    @pytest.fixture
-    def samples(self):
+    @pytest.fixture(name="samples")
+    def fixture_samples(self):
         return np.sin(np.linspace(0, 1, 200))
 
-    @pytest.fixture
-    def actual_kurt(self):
+    @pytest.fixture(name="actual_kurt")
+    def fixture_actual_kurt(self):
         return -1.2058303433799713
 
     @pytest.mark.parametrize("val", [3075.2, 3075.3, 3075.5])

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -31,8 +31,8 @@ from pandas.core.sorting import (
 )
 
 
-@pytest.fixture
-def left_right():
+@pytest.fixture(name="left_right")
+def fixture_left_right():
     low, high, n = -1 << 10, 1 << 10, 1 << 20
     left = DataFrame(np.random.randint(low, high, (n, 7)), columns=list("ABCDEFG"))
     left["left"] = left.sum(axis=1)

--- a/pandas/tests/test_take.py
+++ b/pandas/tests/test_take.py
@@ -11,6 +11,7 @@ import pandas.core.algorithms as algos
 
 
 @pytest.fixture(
+    name="dtype_fill_out_dtype",
     params=[
         (np.int8, np.int16(127), np.int8),
         (np.int8, np.int16(128), np.int16),
@@ -34,9 +35,9 @@ import pandas.core.algorithms as algos
         (np.bool_, 3.0 + 4.0j, np.object_),
         (np.bool_, True, np.bool_),
         (np.bool_, "", np.object_),
-    ]
+    ],
 )
-def dtype_fill_out_dtype(request):
+def fixture_dtype_fill_out_dtype(request):
     return request.param
 
 

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -49,8 +49,8 @@ from pandas.core.tools.datetimes import start_caching_at
 from pandas.util.version import Version
 
 
-@pytest.fixture(params=[True, False])
-def cache(request):
+@pytest.fixture(name="cache", params=[True, False])
+def fixture_cache(request):
     """
     cache keyword to pass to to_datetime.
     """
@@ -1901,8 +1901,8 @@ class TestToDatetimeUnit:
 
 
 class TestToDatetimeDataFrame:
-    @pytest.fixture
-    def df(self):
+    @pytest.fixture(name="df")
+    def fixture_df(self):
         return DataFrame(
             {
                 "year": [2015, 2016],
@@ -3058,8 +3058,8 @@ class TestDatetimeParsingWrappers:
         assert dt_string_repr == repr(dt_time)
 
 
-@pytest.fixture(params=["D", "s", "ms", "us", "ns"])
-def units(request):
+@pytest.fixture(name="units", params=["D", "s", "ms", "us", "ns"])
+def fixture_units(request):
     """Day and some time units.
 
     * D
@@ -3071,19 +3071,21 @@ def units(request):
     return request.param
 
 
-@pytest.fixture
-def epoch_1960():
+@pytest.fixture(name="epoch_1960")
+def fixture_epoch_1960():
     """Timestamp at 1960-01-01."""
     return Timestamp("1960-01-01")
 
 
-@pytest.fixture
-def units_from_epochs():
+@pytest.fixture(name="units_from_epochs")
+def fixture_units_from_epochs():
     return list(range(5))
 
 
-@pytest.fixture(params=["timestamp", "pydatetime", "datetime64", "str_1960"])
-def epochs(epoch_1960, request):
+@pytest.fixture(
+    name="epochs", params=["timestamp", "pydatetime", "datetime64", "str_1960"]
+)
+def fixture_epochs(epoch_1960, request):
     """Timestamp at 1960-01-01 in various forms.
 
     * Timestamp
@@ -3102,8 +3104,8 @@ def epochs(epoch_1960, request):
         return str(epoch_1960)
 
 
-@pytest.fixture
-def julian_dates():
+@pytest.fixture(name="julian_dates")
+def fixture_julian_dates():
     return date_range("2014-1-1", periods=10).to_julian_date().values
 
 

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -16,39 +16,40 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.fixture(params=[None, "ignore", "raise", "coerce"])
-def errors(request):
+@pytest.fixture(name="errors", params=[None, "ignore", "raise", "coerce"])
+def fixture_errors(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def signed(request):
+@pytest.fixture(name="signed", params=[True, False])
+def fixture_signed(request):
     return request.param
 
 
-@pytest.fixture(params=[lambda x: x, str], ids=["identity", "str"])
-def transform(request):
+@pytest.fixture(name="transform", params=[lambda x: x, str], ids=["identity", "str"])
+def fixture_transform(request):
     return request.param
 
 
-@pytest.fixture(params=[47393996303418497800, 100000000000000000000])
-def large_val(request):
+@pytest.fixture(name="large_val", params=[47393996303418497800, 100000000000000000000])
+def fixture_large_val(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def multiple_elts(request):
+@pytest.fixture(name="multiple_elts", params=[True, False])
+def fixture_multiple_elts(request):
     return request.param
 
 
 @pytest.fixture(
+    name="transform_assert_equal",
     params=[
         (lambda x: Index(x, name="idx"), tm.assert_index_equal),
         (lambda x: Series(x, name="ser"), tm.assert_series_equal),
         (lambda x: np.array(Index(x).values), tm.assert_numpy_array_equal),
-    ]
+    ],
 )
-def transform_assert_equal(request):
+def fixture_transform_assert_equal(request):
     return request.param
 
 

--- a/pandas/tests/tseries/frequencies/test_inference.py
+++ b/pandas/tests/tseries/frequencies/test_inference.py
@@ -36,6 +36,7 @@ from pandas.tseries import (
 
 
 @pytest.fixture(
+    name="base_delta_code_pair",
     params=[
         (timedelta(1), "D"),
         (timedelta(hours=1), "H"),
@@ -44,9 +45,9 @@ from pandas.tseries import (
         (np.timedelta64(1, "ns"), "N"),
         (timedelta(microseconds=1), "U"),
         (timedelta(microseconds=1000), "L"),
-    ]
+    ],
 )
-def base_delta_code_pair(request):
+def fixture_base_delta_code_pair(request):
     return request.param
 
 

--- a/pandas/tests/tseries/offsets/conftest.py
+++ b/pandas/tests/tseries/offsets/conftest.py
@@ -9,11 +9,12 @@ from pandas.tseries import offsets
 
 
 @pytest.fixture(
+    name="offset_types",
     params=[
         getattr(offsets, o) for o in offsets.__all__ if o not in ("Tick", "BaseOffset")
-    ]
+    ],
 )
-def offset_types(request):
+def fixture_offset_types(request):
     """
     Fixture for all the datetime offsets available for a time series.
     """
@@ -21,21 +22,22 @@ def offset_types(request):
 
 
 @pytest.fixture(
+    name="month_classes",
     params=[
         getattr(offsets, o)
         for o in offsets.__all__
         if issubclass(getattr(offsets, o), MonthOffset) and o != "MonthOffset"
-    ]
+    ],
 )
-def month_classes(request):
+def fixture_month_classes(request):
     """
     Fixture for month based datetime offsets available for a time series.
     """
     return request.param
 
 
-@pytest.fixture
-def dt():
+@pytest.fixture(name="dt")
+def fixture_dt():
     """
     Fixture for common Timestamp.
     """

--- a/pandas/tests/tseries/offsets/test_business_day.py
+++ b/pandas/tests/tseries/offsets/test_business_day.py
@@ -31,23 +31,23 @@ from pandas.tests.tseries.offsets.common import (
 from pandas.tseries import offsets
 
 
-@pytest.fixture
-def dt():
+@pytest.fixture(name="dt")
+def fixture_dt():
     return datetime(2008, 1, 1)
 
 
-@pytest.fixture
-def _offset():
+@pytest.fixture(name="_offset")
+def fixture__offset():
     return BDay
 
 
-@pytest.fixture
-def offset(_offset):
+@pytest.fixture(name="offset")
+def fixture_offset(_offset):
     return _offset()
 
 
-@pytest.fixture
-def offset2(_offset):
+@pytest.fixture(name="offset2")
+def fixture_offset2(_offset):
     return _offset(2)
 
 

--- a/pandas/tests/tseries/offsets/test_business_hour.py
+++ b/pandas/tests/tseries/offsets/test_business_hour.py
@@ -28,63 +28,63 @@ from pandas import (
 from pandas.tests.tseries.offsets.common import assert_offset_equal
 
 
-@pytest.fixture
-def dt():
+@pytest.fixture(name="dt")
+def fixture_dt():
     return datetime(2014, 7, 1, 10, 00)
 
 
-@pytest.fixture
-def _offset():
+@pytest.fixture(name="_offset")
+def fixture__offset():
     return BusinessHour
 
 
-@pytest.fixture
-def offset1():
+@pytest.fixture(name="offset1")
+def fixture_offset1():
     return BusinessHour()
 
 
-@pytest.fixture
-def offset2():
+@pytest.fixture(name="offset2")
+def fixture_offset2():
     return BusinessHour(n=3)
 
 
-@pytest.fixture
-def offset3():
+@pytest.fixture(name="offset3")
+def fixture_offset3():
     return BusinessHour(n=-1)
 
 
-@pytest.fixture
-def offset4():
+@pytest.fixture(name="offset4")
+def fixture_offset4():
     return BusinessHour(n=-4)
 
 
-@pytest.fixture
-def offset5():
+@pytest.fixture(name="offset5")
+def fixture_offset5():
     return BusinessHour(start=dt_time(11, 0), end=dt_time(14, 30))
 
 
-@pytest.fixture
-def offset6():
+@pytest.fixture(name="offset6")
+def fixture_offset6():
     return BusinessHour(start="20:00", end="05:00")
 
 
-@pytest.fixture
-def offset7():
+@pytest.fixture(name="offset7")
+def fixture_offset7():
     return BusinessHour(n=-2, start=dt_time(21, 30), end=dt_time(6, 30))
 
 
-@pytest.fixture
-def offset8():
+@pytest.fixture(name="offset8")
+def fixture_offset8():
     return BusinessHour(start=["09:00", "13:00"], end=["12:00", "17:00"])
 
 
-@pytest.fixture
-def offset9():
+@pytest.fixture(name="offset9")
+def fixture_offset9():
     return BusinessHour(n=3, start=["09:00", "22:00"], end=["13:00", "03:00"])
 
 
-@pytest.fixture
-def offset10():
+@pytest.fixture(name="offset10")
+def fixture_offset10():
     return BusinessHour(n=-1, start=["23:00", "13:00"], end=["02:00", "17:00"])
 
 

--- a/pandas/tests/tseries/offsets/test_common.py
+++ b/pandas/tests/tseries/offsets/test_common.py
@@ -74,6 +74,7 @@ def _get_offset(klass, value=1, normalize=False):
 
 
 @pytest.fixture(
+    name="_offset",
     params=[
         BDay,
         BusinessHour,
@@ -100,14 +101,14 @@ def _get_offset(klass, value=1, normalize=False):
         FY5253,
         FY5253Quarter,
         DateOffset,
-    ]
+    ],
 )
-def _offset(request):
+def fixture__offset(request):
     return request.param
 
 
-@pytest.fixture
-def dt(_offset):
+@pytest.fixture(name="dt")
+def fixture_dt(_offset):
     if _offset in (CBMonthBegin, CBMonthEnd, BDay):
         return Timestamp(2008, 1, 1)
     elif _offset is (CustomBusinessHour, BusinessHour):

--- a/pandas/tests/tseries/offsets/test_custom_business_day.py
+++ b/pandas/tests/tseries/offsets/test_custom_business_day.py
@@ -20,13 +20,13 @@ from pandas.tests.tseries.offsets.common import assert_offset_equal
 from pandas.tseries.holiday import USFederalHolidayCalendar
 
 
-@pytest.fixture
-def offset():
+@pytest.fixture(name="offset")
+def fixture_offset():
     return CDay()
 
 
-@pytest.fixture
-def offset2():
+@pytest.fixture(name="offset2")
+def fixture_offset2():
     return CDay(2)
 
 

--- a/pandas/tests/tseries/offsets/test_custom_business_hour.py
+++ b/pandas/tests/tseries/offsets/test_custom_business_hour.py
@@ -25,13 +25,13 @@ from pandas.tseries.holiday import USFederalHolidayCalendar
 holidays = ["2014-06-27", datetime(2014, 6, 30), np.datetime64("2014-07-02")]
 
 
-@pytest.fixture
-def dt():
+@pytest.fixture(name="dt")
+def fixture_dt():
     return datetime(2014, 7, 1, 10, 00)
 
 
-@pytest.fixture
-def _offset():
+@pytest.fixture(name="_offset")
+def fixture__offset():
     return CustomBusinessHour
 
 
@@ -40,13 +40,13 @@ def _offset():
 #  6/22  23  24  25  26  27  28
 #    29  30 7/1   2   3   4   5
 #     6   7   8   9  10  11  12
-@pytest.fixture
-def offset1():
+@pytest.fixture(name="offset1")
+def fixture_offset1():
     return CustomBusinessHour(weekmask="Tue Wed Thu Fri")
 
 
-@pytest.fixture
-def offset2():
+@pytest.fixture(name="offset2")
+def fixture_offset2():
     return CustomBusinessHour(holidays=holidays)
 
 

--- a/pandas/tests/tseries/offsets/test_custom_business_month.py
+++ b/pandas/tests/tseries/offsets/test_custom_business_month.py
@@ -35,8 +35,8 @@ from pandas.tseries import offsets
 from pandas.tseries.holiday import USFederalHolidayCalendar
 
 
-@pytest.fixture
-def dt():
+@pytest.fixture(name="dt")
+def fixture_dt():
     return datetime(2008, 1, 1)
 
 
@@ -67,16 +67,16 @@ class TestCommonCBM:
 
 
 class TestCustomBusinessMonthBegin:
-    @pytest.fixture
-    def _offset(self):
+    @pytest.fixture(name="_offset")
+    def fixture__offset(self):
         return CBMonthBegin
 
-    @pytest.fixture
-    def offset(self):
+    @pytest.fixture(name="offset")
+    def fixture_offset(self):
         return CBMonthBegin()
 
-    @pytest.fixture
-    def offset2(self):
+    @pytest.fixture(name="offset2")
+    def fixture_offset2(self):
         return CBMonthBegin(2)
 
     def test_different_normalize_equals(self, _offset):
@@ -265,16 +265,16 @@ class TestCustomBusinessMonthBegin:
 
 
 class TestCustomBusinessMonthEnd:
-    @pytest.fixture
-    def _offset(self):
+    @pytest.fixture(name="_offset")
+    def fixture__offset(self):
         return CBMonthEnd
 
-    @pytest.fixture
-    def offset(self):
+    @pytest.fixture(name="offset")
+    def fixture_offset(self):
         return CBMonthEnd()
 
-    @pytest.fixture
-    def offset2(self):
+    @pytest.fixture(name="offset2")
+    def fixture_offset2(self):
         return CBMonthEnd(2)
 
     def test_different_normalize_equals(self, _offset):

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -109,13 +109,13 @@ def _create_offset(klass, value=1, normalize=False):
     return klass
 
 
-@pytest.fixture
-def dt():
+@pytest.fixture(name="dt")
+def fixture_dt():
     return Timestamp(datetime(2008, 1, 2))
 
 
-@pytest.fixture
-def expecteds():
+@pytest.fixture(name="expecteds")
+def fixture_expecteds():
     # executed value created by _create_offset
     # are applied to 2011/01/01 09:00 (Saturday)
     # used for .apply and .rollforward

--- a/pandas/tests/tslibs/test_fields.py
+++ b/pandas/tests/tslibs/test_fields.py
@@ -6,8 +6,8 @@ from pandas._libs.tslibs import fields
 import pandas._testing as tm
 
 
-@pytest.fixture
-def dtindex():
+@pytest.fixture(name="dtindex")
+def fixture_dtindex():
     dtindex = np.arange(5, dtype=np.int64) * 10**9 * 3600 * 24 * 32
     dtindex.flags.writeable = False
     return dtindex

--- a/pandas/tests/tslibs/test_liboffsets.py
+++ b/pandas/tests/tslibs/test_liboffsets.py
@@ -15,8 +15,10 @@ from pandas._libs.tslibs.offsets import roll_qtrday
 from pandas import Timestamp
 
 
-@pytest.fixture(params=["start", "end", "business_start", "business_end"])
-def day_opt(request):
+@pytest.fixture(
+    name="day_opt", params=["start", "end", "business_start", "business_end"]
+)
+def fixture_day_opt(request):
     return request.param
 
 

--- a/pandas/tests/tslibs/test_timezones.py
+++ b/pandas/tests/tslibs/test_timezones.py
@@ -75,12 +75,13 @@ def test_tz_compare_utc(utc_fixture, utc_fixture2):
 
 
 @pytest.fixture(
+    name="infer_setup",
     params=[
         (pytz.timezone("US/Eastern"), lambda tz, x: tz.localize(x)),
         (dateutil.tz.gettz("US/Eastern"), lambda tz, x: x.replace(tzinfo=tz)),
-    ]
+    ],
 )
-def infer_setup(request):
+def fixture_infer_setup(request):
     eastern, localize = request.param
 
     start_naive = datetime(2001, 1, 1)

--- a/pandas/tests/util/conftest.py
+++ b/pandas/tests/util/conftest.py
@@ -1,26 +1,26 @@
 import pytest
 
 
-@pytest.fixture(params=[True, False])
-def check_dtype(request):
+@pytest.fixture(name="check_dtype", params=[True, False])
+def fixture_check_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def check_exact(request):
+@pytest.fixture(name="check_exact", params=[True, False])
+def fixture_check_exact(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def check_index_type(request):
+@pytest.fixture(name="check_index_type", params=[True, False])
+def fixture_check_index_type(request):
     return request.param
 
 
-@pytest.fixture(params=[0.5e-3, 0.5e-5])
-def rtol(request):
+@pytest.fixture(name="rtol", params=[0.5e-3, 0.5e-5])
+def fixture_rtol(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def check_categorical(request):
+@pytest.fixture(name="check_categorical", params=[True, False])
+def fixture_check_categorical(request):
     return request.param

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -5,13 +5,13 @@ from pandas import DataFrame
 import pandas._testing as tm
 
 
-@pytest.fixture(params=[True, False])
-def by_blocks_fixture(request):
+@pytest.fixture(name="by_blocks_fixture", params=[True, False])
+def fixture_by_blocks_fixture(request):
     return request.param
 
 
-@pytest.fixture(params=["DataFrame", "Series"])
-def obj_fixture(request):
+@pytest.fixture(name="obj_fixture", params=["DataFrame", "Series"])
+def fixture_obj_fixture(request):
     return request.param
 
 

--- a/pandas/tests/util/test_assert_produces_warning.py
+++ b/pandas/tests/util/test_assert_produces_warning.py
@@ -14,6 +14,7 @@ import pandas._testing as tm
 
 
 @pytest.fixture(
+    name="category",
     params=[
         RuntimeWarning,
         ResourceWarning,
@@ -24,7 +25,7 @@ import pandas._testing as tm
         DtypeWarning,
     ],
 )
-def category(request):
+def fixture_category(request):
     """
     Return unique warning.
 
@@ -34,6 +35,7 @@ def category(request):
 
 
 @pytest.fixture(
+    name="pair_different_warnings",
     params=[
         (RuntimeWarning, UserWarning),
         (UserWarning, FutureWarning),
@@ -46,7 +48,7 @@ def category(request):
     ],
     ids=lambda x: type(x).__name__,
 )
-def pair_different_warnings(request):
+def fixture_pair_different_warnings(request):
     """
     Return pair or different warnings.
 

--- a/pandas/tests/util/test_hashing.py
+++ b/pandas/tests/util/test_hashing.py
@@ -17,6 +17,7 @@ from pandas.util import (
 
 
 @pytest.fixture(
+    name="series",
     params=[
         Series([1, 2, 3] * 3, dtype="int32"),
         Series([None, 2.5, 3.5] * 3, dtype="float32"),
@@ -26,14 +27,14 @@ from pandas.util import (
         Series(pd.date_range("20130101", periods=9)),
         Series(pd.date_range("20130101", periods=9, tz="US/Eastern")),
         Series(pd.timedelta_range("2000", periods=9)),
-    ]
+    ],
 )
-def series(request):
+def fixture_series(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def index(request):
+@pytest.fixture(name="index", params=[True, False])
+def fixture_index(request):
     return request.param
 
 

--- a/pandas/tests/window/conftest.py
+++ b/pandas/tests/window/conftest.py
@@ -15,13 +15,14 @@ from pandas import (
 )
 
 
-@pytest.fixture(params=[True, False])
-def raw(request):
+@pytest.fixture(name="raw", params=[True, False])
+def fixture_raw(request):
     """raw keyword argument for rolling.apply"""
     return request.param
 
 
 @pytest.fixture(
+    name="arithmetic_win_operators",
     params=[
         "sum",
         "mean",
@@ -34,24 +35,24 @@ def raw(request):
         "skew",
         "count",
         "sem",
-    ]
+    ],
 )
-def arithmetic_win_operators(request):
+def fixture_arithmetic_win_operators(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def center(request):
+@pytest.fixture(name="center", params=[True, False])
+def fixture_center(request):
     return request.param
 
 
-@pytest.fixture(params=[None, 1])
-def min_periods(request):
+@pytest.fixture(name="min_periods", params=[None, 1])
+def fixture_min_periods(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def parallel(request):
+@pytest.fixture(name="parallel", params=[True, False])
+def fixture_parallel(request):
     """parallel keyword argument for numba.jit"""
     return request.param
 
@@ -60,62 +61,69 @@ def parallel(request):
 # https://github.com/pandas-dev/pandas/pull/41971#issuecomment-860607472
 
 
-@pytest.fixture(params=[False])
-def nogil(request):
+@pytest.fixture(name="nogil", params=[False])
+def fixture_nogil(request):
     """nogil keyword argument for numba.jit"""
     return request.param
 
 
-@pytest.fixture(params=[True])
-def nopython(request):
+@pytest.fixture(name="nopython", params=[True])
+def fixture_nopython(request):
     """nopython keyword argument for numba.jit"""
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def adjust(request):
+@pytest.fixture(name="adjust", params=[True, False])
+def fixture_adjust(request):
     """adjust keyword argument for ewm"""
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def ignore_na(request):
+@pytest.fixture(name="ignore_na", params=[True, False])
+def fixture_ignore_na(request):
     """ignore_na keyword argument for ewm"""
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def numeric_only(request):
+@pytest.fixture(name="numeric_only", params=[True, False])
+def fixture_numeric_only(request):
     """numeric_only keyword argument"""
     return request.param
 
 
-@pytest.fixture(params=[pytest.param("numba", marks=td.skip_if_no("numba")), "cython"])
-def engine(request):
+@pytest.fixture(
+    name="engine",
+    params=[pytest.param("numba", marks=td.skip_if_no("numba")), "cython"],
+)
+def fixture_engine(request):
     """engine keyword argument for rolling.apply"""
     return request.param
 
 
 @pytest.fixture(
+    name="engine_and_raw",
     params=[
         pytest.param(("numba", True), marks=td.skip_if_no("numba")),
         ("cython", True),
         ("cython", False),
-    ]
+    ],
 )
-def engine_and_raw(request):
+def fixture_engine_and_raw(request):
     """engine and raw keyword arguments for rolling.apply"""
     return request.param
 
 
-@pytest.fixture(params=["1 day", timedelta(days=1), np.timedelta64(1, "D")])
-def halflife_with_times(request):
+@pytest.fixture(
+    name="halflife_with_times",
+    params=["1 day", timedelta(days=1), np.timedelta64(1, "D")],
+)
+def fixture_halflife_with_times(request):
     """Halflife argument for EWM when times is specified."""
     return request.param
 
 
-@pytest.fixture
-def series():
+@pytest.fixture(name="series")
+def fixture_series():
     """Make mocked series as fixture."""
     arr = np.random.randn(100)
     locs = np.arange(20, 40)
@@ -124,8 +132,8 @@ def series():
     return series
 
 
-@pytest.fixture
-def frame():
+@pytest.fixture(name="frame")
+def fixture_frame():
     """Make mocked frame as fixture."""
     return DataFrame(
         np.random.randn(100, 10),
@@ -134,7 +142,7 @@ def frame():
     )
 
 
-@pytest.fixture(params=[None, 1, 2, 5, 10])
-def step(request):
+@pytest.fixture(name="step", params=[None, 1, 2, 5, 10])
+def fixture_step(request):
     """step keyword argument for rolling window operations."""
     return request.param

--- a/pandas/tests/window/moments/conftest.py
+++ b/pandas/tests/window/moments/conftest.py
@@ -36,23 +36,26 @@ def is_constant(x):
 
 
 @pytest.fixture(
+    name="consistent_data",
     params=(
         obj
         for obj in itertools.chain(create_series(), create_dataframes())
         if is_constant(obj)
     ),
 )
-def consistent_data(request):
+def fixture_consistent_data(request):
     return request.param
 
 
-@pytest.fixture(params=create_series())
-def series_data(request):
+@pytest.fixture(name="series_data", params=create_series())
+def fixture_series_data(request):
     return request.param
 
 
-@pytest.fixture(params=itertools.chain(create_series(), create_dataframes()))
-def all_data(request):
+@pytest.fixture(
+    name="all_data", params=itertools.chain(create_series(), create_dataframes())
+)
+def fixture_all_data(request):
     """
     Test:
         - Empty Series / DataFrame
@@ -67,6 +70,6 @@ def all_data(request):
     return request.param
 
 
-@pytest.fixture(params=[0, 2])
-def min_periods(request):
+@pytest.fixture(name="min_periods", params=[0, 2])
+def fixture_min_periods(request):
     return request.param

--- a/pandas/tests/window/moments/test_moments_consistency_rolling.py
+++ b/pandas/tests/window/moments/test_moments_consistency_rolling.py
@@ -13,8 +13,8 @@ def all_na(x):
     return x.isnull().all().all()
 
 
-@pytest.fixture(params=[(1, 0), (5, 1)])
-def rolling_consistency_cases(request):
+@pytest.fixture(name="rolling_consistency_cases", params=[(1, 0), (5, 1)])
+def fixture_rolling_consistency_cases(request):
     """window, min_periods"""
     return request.param
 

--- a/pandas/tests/window/test_cython_aggregations.py
+++ b/pandas/tests/window/test_cython_aggregations.py
@@ -67,9 +67,11 @@ _rolling_aggregations = _get_rolling_aggregations()
 
 
 @pytest.fixture(
-    params=_rolling_aggregations["params"], ids=_rolling_aggregations["ids"]
+    name="rolling_aggregation",
+    params=_rolling_aggregations["params"],
+    ids=_rolling_aggregations["ids"],
 )
-def rolling_aggregation(request):
+def fixture_rolling_aggregation(request):
     """Make a rolling aggregation function as fixture."""
     return request.param
 

--- a/pandas/tests/window/test_dtypes.py
+++ b/pandas/tests/window/test_dtypes.py
@@ -26,6 +26,7 @@ def get_dtype(dtype, coerce_int=None):
 
 
 @pytest.fixture(
+    name="dtypes",
     params=[
         "object",
         "category",
@@ -43,9 +44,9 @@ def get_dtype(dtype, coerce_int=None):
         "m8[ns]",
         "M8[ns]",
         "datetime64[ns, UTC]",
-    ]
+    ],
 )
-def dtypes(request):
+def fixture_dtypes(request):
     """Dtypes for window tests"""
     return request.param
 

--- a/pandas/tests/window/test_groupby.py
+++ b/pandas/tests/window/test_groupby.py
@@ -15,8 +15,8 @@ from pandas.api.indexers import BaseIndexer
 from pandas.core.groupby.groupby import get_groupby
 
 
-@pytest.fixture
-def times_frame():
+@pytest.fixture(name="times_frame")
+def fixture_times_frame():
     """Frame for testing times argument in EWM groupby."""
     return DataFrame(
         {
@@ -40,8 +40,8 @@ def times_frame():
     )
 
 
-@pytest.fixture
-def roll_frame():
+@pytest.fixture(name="roll_frame")
+def fixture_roll_frame():
     return DataFrame({"A": [1] * 20 + [2] * 12 + [3] * 8, "B": np.arange(40)})
 
 
@@ -1003,8 +1003,8 @@ class TestRolling:
 
 
 class TestExpanding:
-    @pytest.fixture
-    def frame(self):
+    @pytest.fixture(name="frame")
+    def fixture_frame(self):
         return DataFrame({"A": [1] * 20 + [2] * 12 + [3] * 8, "B": np.arange(40)})
 
     @pytest.mark.parametrize(

--- a/pandas/tests/window/test_numba.py
+++ b/pandas/tests/window/test_numba.py
@@ -26,13 +26,14 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.fixture(params=["single", "table"])
-def method(request):
+@pytest.fixture(name="method", params=["single", "table"])
+def fixture_method(request):
     """method keyword in rolling/expanding/ewm constructor"""
     return request.param
 
 
 @pytest.fixture(
+    name="arithmetic_numba_supported_operators",
     params=[
         ["sum", {}],
         ["mean", {}],
@@ -43,9 +44,9 @@ def method(request):
         ["var", {"ddof": 0}],
         ["std", {}],
         ["std", {"ddof": 0}],
-    ]
+    ],
 )
-def arithmetic_numba_supported_operators(request):
+def fixture_arithmetic_numba_supported_operators(request):
     return request.param
 
 

--- a/pandas/tests/window/test_pairwise.py
+++ b/pandas/tests/window/test_pairwise.py
@@ -15,6 +15,7 @@ from pandas.core.algorithms import safe_sort
 
 
 @pytest.fixture(
+    name="pairwise_frames",
     params=[
         DataFrame([[2, 4], [1, 2], [5, 2], [8, 1]], columns=[1, 0]),
         DataFrame([[2, 4], [1, 2], [5, 2], [8, 1]], columns=[1, 1]),
@@ -25,21 +26,21 @@ from pandas.core.algorithms import safe_sort
         DataFrame([[2.0, 4.0], [1.0, 2.0], [5.0, 2.0], [8.0, 1.0]], columns=[1, 0.0]),
         DataFrame([[2, 4.0], [1, 2.0], [5, 2.0], [8, 1.0]], columns=[0, 1.0]),
         DataFrame([[2, 4], [1, 2], [5, 2], [8, 1.0]], columns=[1.0, "X"]),
-    ]
+    ],
 )
-def pairwise_frames(request):
+def fixture_pairwise_frames(request):
     """Pairwise frames test_pairwise"""
     return request.param
 
 
-@pytest.fixture
-def pairwise_target_frame():
+@pytest.fixture(name="pairwise_target_frame")
+def fixture_pairwise_target_frame():
     """Pairwise target frame for test_pairwise"""
     return DataFrame([[2, 4], [1, 2], [5, 2], [8, 1]], columns=[0, 1])
 
 
-@pytest.fixture
-def pairwise_other_frame():
+@pytest.fixture(name="pairwise_other_frame")
+def fixture_pairwise_other_frame():
     """Pairwise other frame for test_pairwise"""
     return DataFrame(
         [[None, 1, 1], [None, 1, 2], [None, 3, 2], [None, 8, 1]],

--- a/pandas/tests/window/test_timeseries_window.py
+++ b/pandas/tests/window/test_timeseries_window.py
@@ -15,15 +15,15 @@ import pandas._testing as tm
 from pandas.tseries import offsets
 
 
-@pytest.fixture
-def regular():
+@pytest.fixture(name="regular")
+def fixture_regular():
     return DataFrame(
         {"A": date_range("20130101", periods=5, freq="s"), "B": range(5)}
     ).set_index("A")
 
 
-@pytest.fixture
-def ragged():
+@pytest.fixture(name="ragged")
+def fixture_ragged():
     df = DataFrame({"B": range(5)})
     df.index = [
         Timestamp("20130101 09:00:00"),

--- a/pandas/tests/window/test_win_type.py
+++ b/pandas/tests/window/test_win_type.py
@@ -15,6 +15,7 @@ from pandas.api.indexers import BaseIndexer
 
 
 @pytest.fixture(
+    name="win_types",
     params=[
         "triang",
         "blackman",
@@ -24,14 +25,17 @@ from pandas.api.indexers import BaseIndexer
         "blackmanharris",
         "nuttall",
         "barthann",
-    ]
+    ],
 )
-def win_types(request):
+def fixture_win_types(request):
     return request.param
 
 
-@pytest.fixture(params=["kaiser", "gaussian", "general_gaussian", "exponential"])
-def win_types_special(request):
+@pytest.fixture(
+    name="win_types_special",
+    params=["kaiser", "gaussian", "general_gaussian", "exponential"],
+)
+def fixture_win_types_special(request):
     return request.param
 
 

--- a/scripts/rename_test_fixtures.py
+++ b/scripts/rename_test_fixtures.py
@@ -1,0 +1,160 @@
+"""
+Ensure that test fixtures have a `name` argument.
+
+This is to ensure that pylint's redefined-outer-name does not
+report tests which use fixtures, see PyCQA/pylint#1535.
+
+You can run this in pre-commit::
+
+    pre-commit run rename-test-fixtures --all-files
+
+or by passing filenames manually::
+
+    python -m scripts.rename_test_fixtures <file_1> <file_2> ... <file_n>
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+from ast import NodeVisitor
+import re
+import sys
+from typing import NamedTuple
+
+
+class Offset(NamedTuple):
+    lineno: int
+    col_offset: int
+    name: str
+    new_name: str | None
+
+
+class FixtureVisitor(NodeVisitor):
+    def __init__(self, file) -> None:
+        self.file = file
+        self.fixture_attributes: list[Offset] = []
+        self.fixture_calls: list[Offset] = []
+        self.func_defs: list[Offset] = []
+        self.misnamed_test: list[Offset] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        for decorator in node.decorator_list:
+            if (
+                isinstance(decorator, ast.Attribute)
+                and isinstance(decorator.value, ast.Name)
+                and decorator.value.id == "pytest"
+                and decorator.attr == "fixture"
+            ):
+                self.fixture_attributes.append(
+                    Offset(decorator.lineno, decorator.col_offset, node.name, None)
+                )
+                self.func_defs.append(
+                    Offset(
+                        node.lineno, node.col_offset, node.name, f"fixture_{node.name}"
+                    )
+                )
+            elif (
+                isinstance(decorator, ast.Call)
+                and isinstance(decorator.func, ast.Attribute)
+                and isinstance(decorator.func.value, ast.Name)
+                and decorator.func.value.id == "pytest"
+                and decorator.func.attr == "fixture"
+            ):
+                if not any(keyword.arg == "name" for keyword in decorator.keywords):
+                    self.fixture_calls.append(
+                        Offset(decorator.lineno, decorator.col_offset, node.name, None)
+                    )
+                    self.func_defs.append(
+                        Offset(
+                            node.lineno,
+                            node.col_offset,
+                            node.name,
+                            f"fixture_{node.name}",
+                        )
+                    )
+                for keyword in decorator.keywords:
+                    if (
+                        (keyword.arg == "name")
+                        and isinstance(keyword.value, ast.Constant)
+                        and (f"fixture_{keyword.value.value}" != node.name)
+                    ):
+                        self.misnamed_test.append(
+                            Offset(
+                                node.lineno,
+                                node.col_offset,
+                                node.name,
+                                f"fixture_{keyword.value.value}",
+                            )
+                        )
+        self.generic_visit(node)
+
+
+def main(content: str, file: str) -> str | None:
+    """
+    Rename fixture so it can be used with pylint's redefined-outer-name.
+
+    If there is a fixture which doesn't have `name=`, then it is rewritten.
+    If no rewrite is necessary, then `None` is returned.
+    """
+    lines = content.splitlines(keepends=True)
+    tree = ast.parse(content)
+    visitor = FixtureVisitor(file)
+    visitor.visit(tree)
+
+    ret = 0
+    for lineno, col_offset, name, new_name in visitor.func_defs:
+        line = lines[lineno - 1]
+        subbed = re.sub(rf"^def {name}", f"def {new_name}", line[col_offset:])
+        lines[lineno - 1] = line[:col_offset] + subbed
+        print(f"{file}:{lineno}:{col_offset}: renamed {name} to {new_name}")
+        ret |= 1
+    for lineno, col_offset, name, _ in visitor.fixture_calls:
+        line = lines[lineno - 1]
+        # If there are existing arguments, e.g. `pytest.fixture(autouse=True)`
+        subbed = re.sub(
+            r"^pytest\.fixture\(([^\)])",
+            f'pytest.fixture(name="{name}", \\1',
+            line[col_offset:],
+        )
+        # If there are no existing arguments, e.g. `pytest.fixture()`
+        subbed = re.sub(
+            r"^pytest\.fixture\(\)", f'pytest.fixture(name="{name}")', subbed
+        )
+        lines[lineno - 1] = line[:col_offset] + subbed
+        ret |= 1
+    for lineno, col_offset, name, _ in visitor.fixture_attributes:
+        line = lines[lineno - 1]
+        subbed = re.sub(
+            r"^pytest\.fixture", f'pytest.fixture(name="{name}")', line[col_offset:]
+        )
+        lines[lineno - 1] = line[:col_offset] + subbed
+        ret |= 1
+    for lineno, col_offset, name, new_name in visitor.misnamed_test:
+        line = lines[lineno - 1]
+        subbed = re.sub(rf"^def {name}", f"def {new_name}", line[col_offset:])
+        lines[lineno - 1] = line[:col_offset] + subbed
+        print(f"{file}:{lineno}:{col_offset}: renamed {name} to {new_name}")
+        ret |= 1
+
+    if ret:
+        new_content = "".join(lines)
+        return new_content
+    return None
+
+
+if __name__ == "__main__":  # pragma: no cover
+    parser = argparse.ArgumentParser()
+    parser.add_argument("paths", nargs="*")
+    args = parser.parse_args()
+
+    ret = 0
+    for file in args.paths:
+        with open(file, encoding="utf-8") as fd:
+            content = fd.read()
+        new_content = main(content, file)
+        if new_content is not None:
+            with open(file, "w", encoding="utf-8") as fd:
+                fd.write(new_content)
+            ret |= 1
+
+    sys.exit(ret)

--- a/scripts/tests/test_rename_test_fixtures.py
+++ b/scripts/tests/test_rename_test_fixtures.py
@@ -1,0 +1,40 @@
+import pytest
+
+from scripts.rename_test_fixtures import main
+
+
+@pytest.mark.parametrize(
+    "src, expected",
+    [
+        pytest.param(
+            "@pytest.fixture\ndef foo():\n    pass",
+            '@pytest.fixture(name="foo")\ndef fixture_foo():\n    pass',
+            id="attribute",
+        ),
+        pytest.param(
+            "@pytest.fixture()\ndef foo():\n    pass",
+            '@pytest.fixture(name="foo")\ndef fixture_foo():\n    pass',
+            id="call with no arguments",
+        ),
+        pytest.param(
+            "@pytest.fixture(autouse=True)\ndef foo():\n    pass",
+            '@pytest.fixture(name="foo", autouse=True)\n'
+            "def fixture_foo():\n"
+            "    pass",
+            id="call with arguments",
+        ),
+        pytest.param(
+            '@pytest.fixture(name="foo")\ndef foo():\n    pass',
+            '@pytest.fixture(name="foo")\ndef fixture_foo():\n    pass',
+            id="already renamed",
+        ),
+        pytest.param(
+            '@pytest.fixture(name="foo")\ndef fixture_foo():\n    pass',
+            None,
+            id="already renamed",
+        ),
+    ],
+)
+def test_rename_test_fixtures(src, expected):
+    result = main(src, "t.py")
+    assert result == expected


### PR DESCRIPTION
- [ ] closes #50553 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This changes a lot of files, but it's all automated

The only manual thing I did was to rename fixtures that are created just for cartesian products, as in `conftest.py`:

```diff
-axis_frame = axis
+@pytest.fixture(name="axis_frame")
+def fixture_axis_frame(fixture_axis):
+    yield fixture_axis
```

I've split this into 3 separate commits:
1. add the script / pre-commit hook
2. run the pre-commit hook on all files
3. make a handful of manual adjustments

The vast majority of changes here are automated and driven by the script (which is 100% tested)

This is what the pytest docs recommend doing https://docs.pytest.org/en/stable/reference/reference.html#pytest-fixture :

> If a fixture is used in the same module in which it is defined, the function name of the fixture will be shadowed by the function arg that requests the fixture; one way to resolve this is to name the decorated function fixture_<fixturename> and then use @pytest.fixture(name='<fixturename>').


EDIT
----

This only needs doing in files where fixtures are both defined and used...that'll probably reduce the size of the diff. I'll do that, please ignore for now