### PR TITLE
TYP: mypy fix in pandas/io/formats

### DIFF
--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -263,10 +263,7 @@ def enable_data_resource_formatter(enable: bool) -> None:
 
             class TableSchemaFormatter(BaseFormatter):
                 print_method = ObjectName("_repr_data_resource_")
-                # Incompatible types in assignment (expression has type
-                # "Tuple[Type[Dict[Any, Any]]]", base class "BaseFormatter"
-                # defined the type as "Type[str]")
-                _return_type = (dict,)  # type: ignore[assignment]
+                _return_type = (dict,)
 
             # register it:
             formatters[mimetype] = TableSchemaFormatter()


### PR DESCRIPTION
Fixes a mypy error I'm seeing:

```bash
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

pandas/io/formats/printing.py:269: error: Unused "type: ignore" comment
pandas/tests/test_register_accessor.py:16: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
pandas/tests/io/xml/test_xml.py:1127: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
pandas/tests/io/xml/test_xml.py:1306: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
pandas/tests/io/xml/test_to_xml.py:995: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
Found 1 error in 1 file (checked 1397 source files)
```
