### PR TITLE
TYP: Better numeric test types

### DIFF
--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -27,6 +27,7 @@ from pandas._config.localization import (
 from pandas._typing import (
     Dtype,
     Frequency,
+    NpDtype,
 )
 from pandas.compat import pa_version_under6p0
 
@@ -124,12 +125,13 @@ if TYPE_CHECKING:
 _N = 30
 _K = 4
 
-UNSIGNED_INT_NUMPY_DTYPES: list[Dtype] = ["uint8", "uint16", "uint32", "uint64"]
+UNSIGNED_INT_NUMPY_DTYPES: list[NpDtype] = ["uint8", "uint16", "uint32", "uint64"]
 UNSIGNED_INT_EA_DTYPES: list[Dtype] = ["UInt8", "UInt16", "UInt32", "UInt64"]
-SIGNED_INT_NUMPY_DTYPES: list[Dtype] = [int, "int8", "int16", "int32", "int64"]
+SIGNED_INT_NUMPY_DTYPES: list[NpDtype] = [int, "int8", "int16", "int32", "int64"]
 SIGNED_INT_EA_DTYPES: list[Dtype] = ["Int8", "Int16", "Int32", "Int64"]
 ALL_INT_NUMPY_DTYPES = UNSIGNED_INT_NUMPY_DTYPES + SIGNED_INT_NUMPY_DTYPES
 ALL_INT_EA_DTYPES = UNSIGNED_INT_EA_DTYPES + SIGNED_INT_EA_DTYPES
+ALL_INT_DTYPES: list[Dtype] = [*ALL_INT_NUMPY_DTYPES, *ALL_INT_EA_DTYPES]
 
 FLOAT_NUMPY_DTYPES: list[Dtype] = [float, "float32", "float64"]
 FLOAT_EA_DTYPES: list[Dtype] = ["Float32", "Float64"]

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -1486,7 +1486,7 @@ def any_int_ea_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=tm.ALL_INT_NUMPY_DTYPES + tm.ALL_INT_EA_DTYPES)
+@pytest.fixture(params=tm.ALL_INT_DTYPES)
 def any_int_dtype(request):
     """
     Parameterized fixture for any nullable integer dtype.

--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -263,10 +263,7 @@ def enable_data_resource_formatter(enable: bool) -> None:
 
             class TableSchemaFormatter(BaseFormatter):
                 print_method = ObjectName("_repr_data_resource_")
-                # Incompatible types in assignment (expression has type
-                # "Tuple[Type[Dict[Any, Any]]]", base class "BaseFormatter"
-                # defined the type as "Type[str]")
-                _return_type = (dict,)  # type: ignore[assignment]
+                _return_type = (dict,)
 
             # register it:
             formatters[mimetype] = TableSchemaFormatter()

--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -263,7 +263,10 @@ def enable_data_resource_formatter(enable: bool) -> None:
 
             class TableSchemaFormatter(BaseFormatter):
                 print_method = ObjectName("_repr_data_resource_")
-                _return_type = (dict,)
+                # Incompatible types in assignment (expression has type
+                # "Tuple[Type[Dict[Any, Any]]]", base class "BaseFormatter"
+                # defined the type as "Type[str]")
+                _return_type = (dict,)  # type: ignore[assignment]
 
             # register it:
             formatters[mimetype] = TableSchemaFormatter()


### PR DESCRIPTION
Currently we have that:
* UNSIGNED_INT_NUMPY_DTYPES
* SIGNED_INT_NUMPY_DTYPES
* ALL_INT_NUMPY_DTYPES

have dtype `list[Dtype]`. This is a too broad dtype, and the better dtype for these objects is `list[NpDtype]`.

Extracted from newest version of #49560.