### PR TITLE
CLN More float warnings

### DIFF
--- a/pandas/tests/series/methods/test_asof.py
+++ b/pandas/tests/series/methods/test_asof.py
@@ -63,7 +63,8 @@ class TestSeriesAsof:
 
         N = 30
         rng = date_range("1/1/1990", periods=N, freq="53s")
-        ts = Series(np.arange(N), index=rng)
+        # Explicit cast to float avoid implicit cast when setting nan
+        ts = Series(np.arange(N), index=rng, dtype="float")
         ts.iloc[5:10] = np.NaN
         ts.iloc[15:20] = np.NaN
 

--- a/pandas/tests/series/methods/test_interpolate.py
+++ b/pandas/tests/series/methods/test_interpolate.py
@@ -703,7 +703,8 @@ class TestSeriesInterpolateData:
 
     @td.skip_if_no_scipy
     def test_spline_interpolation(self):
-        s = Series(np.arange(10) ** 2)
+        # Explicit cast to float to avoid implicit cast when setting np.nan
+        s = Series(np.arange(10) ** 2, dtype="float")
         s[np.random.randint(0, 9, 3)] = np.nan
         result1 = s.interpolate(method="spline", order=1)
         expected1 = s.interpolate(method="spline", order=1)

--- a/pandas/tests/series/methods/test_rank.py
+++ b/pandas/tests/series/methods/test_rank.py
@@ -92,6 +92,8 @@ class TestSeriesRank:
         iranks = iseries.rank(pct=True)
         tm.assert_series_equal(iranks, exp)
 
+        # Explicit cast to float to avoid implicit cast when setting nan
+        iseries = iseries.astype("float")
         iseries[1] = np.nan
         exp = Series(np.repeat(50.0 / 99.0, 100))
         exp[1] = np.nan
@@ -109,14 +111,16 @@ class TestSeriesRank:
         iranks = iseries.rank(pct=True)
         tm.assert_series_equal(iranks, exp)
 
-        iseries = Series(np.arange(5)) + 1
+        # Explicit cast to float to avoid implicit cast when setting nan
+        iseries = Series(np.arange(5), dtype="float") + 1
         iseries[4] = np.nan
         exp = iseries / 4.0
         iranks = iseries.rank(pct=True)
         tm.assert_series_equal(iranks, exp)
 
         rng = date_range("1/1/1990", periods=5)
-        iseries = Series(np.arange(5), rng) + 1
+        # Explicit cast to float to avoid implicit cast when setting nan
+        iseries = Series(np.arange(5), rng, dtype="float") + 1
         iseries.iloc[4] = np.nan
         exp = iseries / 4.0
         iranks = iseries.rank(pct=True)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -117,7 +117,8 @@ class TestTimeConversionFormats:
         tm.assert_series_equal(result, expected)
 
     def test_to_datetime_format_YYYYMMDD_with_nat(self, cache):
-        ser = Series([19801222, 19801222] + [19810105] * 5)
+        # Explicit cast to float to explicit cast when setting np.nan
+        ser = Series([19801222, 19801222] + [19810105] * 5, dtype="float")
         # with NaT
         expected = Series(
             [Timestamp("19801222"), Timestamp("19801222")] + [Timestamp("19810105")] * 5
@@ -139,7 +140,8 @@ class TestTimeConversionFormats:
 
     def test_to_datetime_format_YYYYMM_with_nat(self, cache):
         # https://github.com/pandas-dev/pandas/issues/50237
-        ser = Series([198012, 198012] + [198101] * 5)
+        # Explicit cast to float to explicit cast when setting np.nan
+        ser = Series([198012, 198012] + [198101] * 5, dtype="float")
         expected = Series(
             [Timestamp("19801201"), Timestamp("19801201")] + [Timestamp("19810101")] * 5
         )


### PR DESCRIPTION
Similar to https://github.com/pandas-dev/pandas/pull/50493

There are places when an implicit cast happens, but it's not the purpose of the test - the cast might as well be done explicitly then

This would help pave the way towards https://github.com/pandas-dev/pandas/pull/50424