### PR TITLE
DOC: update docstrings of Interval's attributes

### DIFF
--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -58,6 +58,21 @@ cdef class IntervalMixin:
         -------
         bool
             True if the Interval is closed on the left-side.
+
+        See Also
+        --------
+        Interval.closed_right : Check if the interval is closed on the right side.
+        Interval.open_left : Boolean inverse of closed_left.
+
+        Examples
+        --------
+        >>> iv = pd.Interval(0, 5, closed='left')
+        >>> iv.closed_left
+        True
+
+        >>> iv = pd.Interval(0, 5, closed='right')
+        >>> iv.closed_left
+        False
         """
         return self.closed in ("left", "both")
 
@@ -72,6 +87,21 @@ cdef class IntervalMixin:
         -------
         bool
             True if the Interval is closed on the left-side.
+
+        See Also
+        --------
+        Interval.closed_left : Check if the interval is closed on the left side.
+        Interval.open_right : Boolean inverse of closed_right.
+
+        Examples
+        --------
+        >>> iv = pd.Interval(0, 5, closed='both')
+        >>> iv.closed_right
+        True
+
+        >>> iv = pd.Interval(0, 5, closed='left')
+        >>> iv.closed_right
+        False
         """
         return self.closed in ("right", "both")
 
@@ -86,6 +116,21 @@ cdef class IntervalMixin:
         -------
         bool
             True if the Interval is not closed on the left-side.
+
+        See Also
+        --------
+        Interval.open_right : Check if the interval is open on the right side.
+        Interval.closed_left : Boolean inverse of open_left.
+
+        Examples
+        --------
+        >>> iv = pd.Interval(0, 5, closed='neither')
+        >>> iv.open_left
+        True
+
+        >>> iv = pd.Interval(0, 5, closed='both')
+        >>> iv.open_left
+        False
         """
         return not self.closed_left
 
@@ -100,6 +145,21 @@ cdef class IntervalMixin:
         -------
         bool
             True if the Interval is not closed on the left-side.
+
+        See Also
+        --------
+        Interval.open_left : Check if the interval is open on the left side.
+        Interval.closed_right : Boolean inverse of open_right.
+
+        Examples
+        --------
+        >>> iv = pd.Interval(0, 5, closed='left')
+        >>> iv.open_right
+        True
+
+        >>> iv = pd.Interval(0, 5)
+        >>> iv.open_right
+        False
         """
         return not self.closed_right
 
@@ -124,6 +184,10 @@ cdef class IntervalMixin:
     def length(self):
         """
         Return the length of the Interval.
+
+        See Also
+        --------
+        Interval.is_empty : Indicates if an interval contains no points.
         """
         return self.right - self.left
 
@@ -139,6 +203,10 @@ cdef class IntervalMixin:
             boolean ``ndarray`` positionally indicating if an ``Interval`` in
             an :class:`~arrays.IntervalArray` or :class:`IntervalIndex` is
             empty.
+
+        See Also
+        --------
+        Interval.length : Return the length of the Interval.
 
         Examples
         --------


### PR DESCRIPTION
Added _See Also_ and/or _Examples_ sections in the docstrings of Interval's attributes:

<details><summary>closed_left, output from `validate_docstrings.py`</summary>
<p>

```
﻿﻿﻿################################################################################
################### Docstring (pandas.Interval.closed_left)  ###################
################################################################################

Check if the interval is closed on the left side.

For the meaning of `closed` and `open` see :class:`~pandas.Interval`.

Returns
-------
bool
    True if the Interval is closed on the left-side.

See Also
--------
Interval.closed_right : Check if the interval is closed on the right side.
Interval.open_left : Boolean inverse of closed_left.

Examples
--------
>>> iv = pd.Interval(0, 5, closed='left')
>>> iv.closed_left
True

>>> iv = pd.Interval(0, 5, closed='right')
>>> iv.closed_left
False

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Interval.closed_left" correct. :)
```
</p>
</details>

<details><summary>closed_right, output from `validate_docstrings.py`</summary>
<p>

```
################################################################################
################### Docstring (pandas.Interval.closed_right) ###################
################################################################################

Check if the interval is closed on the right side.

For the meaning of `closed` and `open` see :class:`~pandas.Interval`.

Returns
-------
bool
    True if the Interval is closed on the left-side.

See Also
--------
Interval.closed_left : Check if the interval is closed on the left side.
Interval.open_right : Boolean inverse of closed_right.

Examples
--------
>>> iv = pd.Interval(0, 5, closed='both')
>>> iv.closed_right
True

>>> iv = pd.Interval(0, 5, closed='left')
>>> iv.closed_right
False

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Interval.closed_right" correct. :)
```
</p>
</details>
<details><summary>open_left, output from `validate_docstrings.py`</summary>
<p>

```
################################################################################
#################### Docstring (pandas.Interval.open_left)  ####################
################################################################################

Check if the interval is open on the left side.

For the meaning of `closed` and `open` see :class:`~pandas.Interval`.

Returns
-------
bool
    True if the Interval is not closed on the left-side.

See Also
--------
Interval.open_right : Check if the interval is open on the right side.
Interval.closed_left : Boolean inverse of open_left.

Examples
--------
>>> iv = pd.Interval(0, 5, closed='neither')
>>> iv.open_left
True

>>> iv = pd.Interval(0, 5, closed='both')
>>> iv.open_left
False

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Interval.open_left" correct. :)
 ```
</p>
</details>
<details><summary>open_right, output from `validate_docstrings.py`</summary>
<p>

```
################################################################################
#################### Docstring (pandas.Interval.open_right) ####################
################################################################################

Check if the interval is open on the right side.

For the meaning of `closed` and `open` see :class:`~pandas.Interval`.

Returns
-------
bool
    True if the Interval is not closed on the left-side.

See Also
--------
Interval.open_left : Check if the interval is open on the left side.
Interval.closed_right : Boolean inverse of open_right.

Examples
--------
>>> iv = pd.Interval(0, 5, closed='left')
>>> iv.open_right
True

>>> iv = pd.Interval(0, 5)
>>> iv.open_right
False

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Interval.open_right" correct. :)
```
</p>
</details>
<details><summary>length, output from `validate_docstrings.py`</summary>
<p>

```
################################################################################
###################### Docstring (pandas.Interval.length) ######################
################################################################################

Return the length of the Interval.

See Also
--------
Interval.is_empty : Indicates if an interval contains no points.

################################################################################
################################## Validation ##################################
################################################################################

2 Errors found:
        No extended summary found
        No examples section found
</p>
```
</details>
<details><summary>is_empty, output from `validate_docstrings.py`</summary>
<p>

```
################################################################################
##################### Docstring (pandas.Interval.is_empty) #####################
################################################################################

Indicates if an interval is empty, meaning it contains no points.

Returns
-------
bool or ndarray
    A boolean indicating if a scalar :class:`Interval` is empty, or a
    boolean ``ndarray`` positionally indicating if an ``Interval`` in
    an :class:`~arrays.IntervalArray` or :class:`IntervalIndex` is
    empty.

See Also
--------
Interval.length : Return the length of the Interval.

Examples
--------
An :class:`Interval` that contains points is not empty:

>>> pd.Interval(0, 1, closed='right').is_empty
False

An ``Interval`` that does not contain any points is empty:

>>> pd.Interval(0, 0, closed='right').is_empty
True
>>> pd.Interval(0, 0, closed='left').is_empty
True
>>> pd.Interval(0, 0, closed='neither').is_empty
True

An ``Interval`` that contains a single point is not empty:

>>> pd.Interval(0, 0, closed='both').is_empty
False

An :class:`~arrays.IntervalArray` or :class:`IntervalIndex` returns a
boolean ``ndarray`` positionally indicating if an ``Interval`` is
empty:

>>> ivs = [pd.Interval(0, 0, closed='neither'),
...        pd.Interval(1, 2, closed='neither')]
>>> pd.arrays.IntervalArray(ivs).is_empty
array([ True, False])

Missing values are not considered empty:

>>> ivs = [pd.Interval(0, 0, closed='neither'), np.nan]
>>> pd.IntervalIndex(ivs).is_empty
array([ True, False])

################################################################################
################################## Validation ##################################
################################################################################

1 Errors found:
        No extended summary found
```
</p>
</details>

- [x] xref #15580 #37875
-  ~~[Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature~~ _na_
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- ~~Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.~~ _na_
- ~~Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.~~ _na_
