### PR TITLE
DEPR: Enforce disallowing 2 positional args in DataFrame.reindex

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -627,6 +627,7 @@ Removal of prior version deprecations/changes
 - Disallow passing non-keyword arguments to :meth:`DataFrame.replace`, :meth:`Series.replace` except for ``to_replace`` and ``value`` (:issue:`47587`)
 - Disallow passing non-keyword arguments to :meth:`DataFrame.sort_values` except for ``by`` (:issue:`41505`)
 - Disallow passing non-keyword arguments to :meth:`Series.sort_values` (:issue:`41505`)
+- Disallow passing 2 non-keyword arguments to :meth:`DataFrame.reindex` (:issue:`17966`)
 - Disallow :meth:`Index.reindex` with non-unique :class:`Index` objects (:issue:`42568`)
 - Disallowed constructing :class:`Categorical` with scalar ``data`` (:issue:`38433`)
 - Disallowed constructing :class:`CategoricalIndex` without passing ``data`` (:issue:`38944`)

--- a/pandas/tests/frame/methods/test_reindex.py
+++ b/pandas/tests/frame/methods/test_reindex.py
@@ -840,14 +840,12 @@ class TestDataFrameSelectReindex:
         result = df.reindex([0, 1, 3], axis="index")
         tm.assert_frame_equal(result, expected)
 
-    def test_reindex_positional_warns(self):
+    def test_reindex_positional_raises(self):
         # https://github.com/pandas-dev/pandas/issues/12392
+        # Enforced in 2.0
         df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-        expected = DataFrame({"A": [1.0, 2], "B": [4.0, 5], "C": [np.nan, np.nan]})
-        with tm.assert_produces_warning(FutureWarning):
-            result = df.reindex([0, 1], ["A", "B", "C"])
-
-        tm.assert_frame_equal(result, expected)
+        with pytest.raises(TypeError, match=r".* is ambiguous."):
+            df.reindex([0, 1], ["A", "B", "C"])
 
     def test_reindex_axis_style_raises(self):
         # https://github.com/pandas-dev/pandas/issues/12392
@@ -914,9 +912,7 @@ class TestDataFrameSelectReindex:
         for res in [res2, res3]:
             tm.assert_frame_equal(res1, res)
 
-        with tm.assert_produces_warning(FutureWarning) as m:
-            res1 = df.reindex(["b", "a"], ["e", "d"])
-        assert "reindex" in str(m[0].message)
+        res1 = df.reindex(index=["b", "a"], columns=["e", "d"])
         res2 = df.reindex(columns=["e", "d"], index=["b", "a"])
         res3 = df.reindex(labels=["b", "a"], axis=0).reindex(labels=["e", "d"], axis=1)
         for res in [res2, res3]:

--- a/pandas/util/_validators.py
+++ b/pandas/util/_validators.py
@@ -11,11 +11,8 @@ from typing import (
     TypeVar,
     overload,
 )
-import warnings
 
 import numpy as np
-
-from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.common import (
     is_bool,
@@ -348,15 +345,10 @@ def validate_axis_style_args(
             raise TypeError(msg)
 
         msg = (
-            f"Interpreting call\n\t'.{method_name}(a, b)' as "
-            f"\n\t'.{method_name}(index=a, columns=b)'.\nUse named "
-            "arguments to remove any ambiguity. In the future, using "
-            "positional arguments for 'index' or 'columns' will raise "
-            "a 'TypeError'."
+            f"'.{method_name}(a, b)' is ambiguous. Use named keyword arguments"
+            "for 'index' or 'columns'."
         )
-        warnings.warn(msg, FutureWarning, stacklevel=find_stack_level())
-        out[data._get_axis_name(0)] = args[0]
-        out[data._get_axis_name(1)] = args[1]
+        raise TypeError(msg)
     else:
         msg = f"Cannot specify all of '{arg_name}', 'index', 'columns'."
         raise TypeError(msg)

--- a/pandas/util/_validators.py
+++ b/pandas/util/_validators.py
@@ -294,11 +294,6 @@ def validate_axis_style_args(
     >>> validate_axis_style_args(df, (str.upper,), {'columns': id},
     ...                          'mapper', 'rename')
     {'columns': <built-in function id>, 'index': <method 'upper' of 'str' objects>}
-
-    This emits a warning
-    >>> validate_axis_style_args(df, (str.upper, id), {},
-    ...                          'mapper', 'rename')
-    {'index': <method 'upper' of 'str' objects>, 'columns': <built-in function id>}
     """
     # TODO: Change to keyword-only args and remove all this
 


### PR DESCRIPTION
Introduced in #17966