### PR TITLE
PERF: BooleanArray._from_sequence_of_strings

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -778,6 +778,7 @@ Performance improvements
 - Performance improvement in :meth:`~arrays.ArrowExtensionArray.__setitem__` when key is a null slice (:issue:`50248`)
 - Performance improvement in :class:`~arrays.ArrowExtensionArray` comparison methods when array contains NA (:issue:`50524`)
 - Performance improvement in :meth:`~arrays.ArrowExtensionArray.to_numpy` (:issue:`49973`)
+- Performance improvement when parsing strings to :class:`BooleanDtype` (:issue:`#####`)
 - Performance improvement in :meth:`DataFrame.join` when joining on a subset of a :class:`MultiIndex` (:issue:`48611`)
 - Performance improvement for :meth:`MultiIndex.intersection` (:issue:`48604`)
 - Performance improvement in ``var`` and ``std`` for nullable dtypes (:issue:`48379`).

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -778,7 +778,7 @@ Performance improvements
 - Performance improvement in :meth:`~arrays.ArrowExtensionArray.__setitem__` when key is a null slice (:issue:`50248`)
 - Performance improvement in :class:`~arrays.ArrowExtensionArray` comparison methods when array contains NA (:issue:`50524`)
 - Performance improvement in :meth:`~arrays.ArrowExtensionArray.to_numpy` (:issue:`49973`)
-- Performance improvement when parsing strings to :class:`BooleanDtype` (:issue:`#####`)
+- Performance improvement when parsing strings to :class:`BooleanDtype` (:issue:`50613`)
 - Performance improvement in :meth:`DataFrame.join` when joining on a subset of a :class:`MultiIndex` (:issue:`48611`)
 - Performance improvement for :meth:`MultiIndex.intersection` (:issue:`48604`)
 - Performance improvement in ``var`` and ``std`` for nullable dtypes (:issue:`48379`).

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -321,7 +321,7 @@ class BooleanArray(BaseMaskedArray):
         true_values_union = cls._TRUE_VALUES.union(true_values or [])
         false_values_union = cls._FALSE_VALUES.union(false_values or [])
 
-        def map_string(s):
+        def map_string(s) -> bool:
             if s in true_values_union:
                 return True
             elif s in false_values_union:

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -322,16 +322,16 @@ class BooleanArray(BaseMaskedArray):
         false_values_union = cls._FALSE_VALUES.union(false_values or [])
 
         def map_string(s):
-            if isna(s):
-                return s
-            elif s in true_values_union:
+            if s in true_values_union:
                 return True
             elif s in false_values_union:
                 return False
             else:
                 raise ValueError(f"{s} cannot be cast to bool")
 
-        scalars = [map_string(x) for x in strings]
+        scalars = np.array(strings, dtype=object)
+        mask = isna(scalars)
+        scalars[~mask] = list(map(map_string, scalars[~mask]))
         return cls._from_sequence(scalars, dtype=dtype, copy=copy)
 
     _HANDLED_TYPES = (np.ndarray, numbers.Number, bool, np.bool_)

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -294,12 +294,6 @@ class TestConstructors(base.BaseConstructorsTests):
                     reason=f"pyarrow doesn't support parsing {pa_dtype}",
                 )
             )
-        elif pa.types.is_boolean(pa_dtype):
-            request.node.add_marker(
-                pytest.mark.xfail(
-                    reason="Iterating over ChunkedArray[bool] returns PyArrow scalars.",
-                )
-            )
         elif pa.types.is_timestamp(pa_dtype) and pa_dtype.tz is not None:
             if pa_version_under7p0:
                 request.node.add_marker(


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.0.0.rst` file if fixing a bug or adding a new feature.

Also removes the need to xfail when parsing a pyarrow array of strings.

```
import pandas as pd
import numpy as np
from pandas.core.arrays.boolean import BooleanArray

choices = BooleanArray._TRUE_VALUES.union(BooleanArray._FALSE_VALUES)
choices = np.array(list(choices), dtype=object)
strings = np.random.choice(choices, 10**5, replace=True)

%timeit BooleanArray._from_sequence_of_strings(strings)

# 43.4 ms ± 1.04 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)  -> main
# 21.9 ms ± 120 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)   -> PR