### PR TITLE
CLN avoid more test warnings

### DIFF
--- a/pandas/tests/frame/methods/test_describe.py
+++ b/pandas/tests/frame/methods/test_describe.py
@@ -388,7 +388,9 @@ class TestDataFrameDescribe:
         # GH#48778
 
         df = DataFrame({"a": [1, pd.NA, pd.NA], "b": pd.NA}, dtype=any_numeric_ea_dtype)
-        result = df.describe()
+        # Warning from numpy for taking std of single element
+        with tm.assert_produces_warning(RuntimeWarning, check_stacklevel=False):
+            result = df.describe()
         expected = DataFrame(
             {"a": [1.0, 1.0, pd.NA] + [1.0] * 5, "b": [0.0] + [pd.NA] * 7},
             index=["count", "mean", "std", "min", "25%", "50%", "75%", "max"],

--- a/pandas/tests/frame/methods/test_shift.py
+++ b/pandas/tests/frame/methods/test_shift.py
@@ -397,6 +397,13 @@ class TestDataFrameShift:
         result = df3.shift(2, axis=1)
 
         expected = df3.take([-1, -1, 0, 1, 2], axis=1)
+        # Explicit cast to float to avoid implicit cast when setting nan.
+        # Column names aren't unique, so directly calling `expected.astype` won't work.
+        expected = expected.pipe(
+            lambda df: df.set_axis(range(df.shape[1]), axis=1)
+            .astype({0: "float", 1: "float"})
+            .set_axis(df.columns, axis=1)
+        )
         expected.iloc[:, :2] = np.nan
         expected.columns = df3.columns
 
@@ -410,6 +417,13 @@ class TestDataFrameShift:
         result = df3.shift(-2, axis=1)
 
         expected = df3.take([2, 3, 4, -1, -1], axis=1)
+        # Explicit cast to float to avoid implicit cast when setting nan.
+        # Column names aren't unique, so directly calling `expected.astype` won't work.
+        expected = expected.pipe(
+            lambda df: df.set_axis(range(df.shape[1]), axis=1)
+            .astype({3: "float", 4: "float"})
+            .set_axis(df.columns, axis=1)
+        )
         expected.iloc[:, -2:] = np.nan
         expected.columns = df3.columns
 


### PR DESCRIPTION
Similar to https://github.com/pandas-dev/pandas/pull/50493

There are places when an implicit cast happens, but it's not the purpose of the test - the cast might as well be done explicitly then

This would help pave the way towards https://github.com/pandas-dev/pandas/pull/50424

---

I expect this to be the last precursor PR, after this one I'll raise a draft PR to try enforcing PDEP6 in some cases (note that merging would only take place _after_ 2.0 is released)