### PR TITLE
BUG: Tuple subclasses should work as tuple in `df.iloc[key]`

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1085,7 +1085,7 @@ class _LocationIndexer(NDFrameIndexerBase):
     @final
     def __getitem__(self, key):
         check_dict_or_set_indexers(key)
-        if type(key) is tuple:
+        if isinstance(key, tuple):
             key = tuple(list(x) if is_iterator(x) else x for x in key)
             key = tuple(com.apply_if_callable(x, self.obj) for x in key)
             if self._is_scalar_access(key):

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -1402,6 +1402,25 @@ class TestDataFrameIndexing:
         )
         tm.assert_frame_equal(result, expected)
 
+    def test_iloc_named_tuple_for_midx(self):
+        # GH#48188
+        df = DataFrame(
+            index=MultiIndex.from_product(
+                [["A", "B"], ["a", "b", "c"]], names=["first", "second"]
+            ),
+            columns=["one", "two", "three", "four"],
+        )
+        indexer_tuple = namedtuple("Indexer", df.index.names)
+        idxr = indexer_tuple(first=[1, 2], second=[2, 3])
+        result = df.iloc[idxr]
+        expected = DataFrame(
+            index=MultiIndex.from_tuples(
+                [("A", "b"), ("A", "c")], names=["first", "second"]
+            ),
+            columns=["three", "four"],
+        )
+        tm.assert_frame_equal(result, expected)
+
     @pytest.mark.parametrize("indexer", [["a"], "a"])
     @pytest.mark.parametrize("col", [{}, {"b": 1}])
     def test_set_2d_casting_date_to_int(self, col, indexer):


### PR DESCRIPTION
- Closes #48188
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

---

This patch makes tuple subclasses behave the same as tuple in `df.iloc[key]` and `df.loc[key]`.  All but one of the tests pass.  The failing test (`indexing/test_loc.py::TestLocBaseIndependent::test_loc_getitem_index_namedtuple`) raises an exception on `df.loc[key]` (not `.iloc`).  I've opened issue #50597 where I suggest deprecating the behavior in that test.  This patch would enforce that deprecation in addition to closing #48188.

I'm opening this as is WIP but please comment.  I have doubts on whether I'm on the right track with this.
