### PR TITLE
REGR: NumPy func warning when dropping nuisance in agg, apply, transform

### DIFF
--- a/doc/source/whatsnew/v1.5.3.rst
+++ b/doc/source/whatsnew/v1.5.3.rst
@@ -19,6 +19,7 @@ Fixed regressions
 - Enforced reversion of ``color`` as an alias for ``c`` and ``size`` as an alias for ``s`` in function :meth:`DataFrame.plot.scatter` (:issue:`49732`)
 - Fixed regression in :meth:`SeriesGroupBy.apply` setting a ``name`` attribute on the result if the result was a :class:`DataFrame` (:issue:`49907`)
 - Fixed performance regression in setting with the :meth:`~DataFrame.at` indexer (:issue:`49771`)
+- Fixed regression in the methods ``apply``, ``agg``, and ``transform`` when used with NumPy functions that informed users to supply ``numeric_only=True`` if the operation failed on non-numeric dtypes; such columns must be dropped prior to using these methods (:issue:`50538`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1287,6 +1287,27 @@ def test_nuiscance_columns():
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize("method", ["agg", "apply", "transform"])
+def test_numeric_only_warning_numpy(method):
+    # GH#50538
+    df = DataFrame({"a": [1, 1, 2], "b": list("xyz")})
+    if method == "agg":
+        msg = "The operation <function mean.*failed"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            getattr(df, method)(np.mean)
+        # Ensure users can't pass numeric_only
+        with pytest.raises(TypeError, match="got an unexpected keyword argument"):
+            getattr(df, method)(np.mean, numeric_only=True)
+    elif method == "apply":
+        with pytest.raises(TypeError, match="Could not convert"):
+            getattr(df, method)(np.mean)
+    else:
+        with pytest.raises(ValueError, match="Function did not transform"):
+            msg = "The operation <function mean.*failed"
+            with tm.assert_produces_warning(FutureWarning, match=msg):
+                getattr(df, method)(np.mean)
+
+
 @pytest.mark.parametrize("how", ["agg", "apply"])
 def test_non_callable_aggregates(how):
 

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -1454,3 +1454,15 @@ def test_agg_of_mode_list(test, constant):
     expected = expected.set_index(0)
 
     tm.assert_frame_equal(result, expected)
+
+
+def test_numeric_only_warning_numpy():
+    # GH#50538
+    df = DataFrame({"a": [1, 1, 2], "b": list("xyz"), "c": [3, 4, 5]})
+    gb = df.groupby("a")
+    msg = "The operation <function mean.*failed"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        gb.agg(np.mean)
+    # Ensure users can't pass numeric_only
+    with pytest.raises(TypeError, match="got an unexpected keyword argument"):
+        gb.agg(np.mean, numeric_only=True)

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -1357,3 +1357,16 @@ def test_empty_df(method, op):
     )
 
     tm.assert_series_equal(result, expected)
+
+
+def test_numeric_only_warning_numpy():
+    # GH#50538
+    df = DataFrame({"a": [1, 1, 2], "b": list("xyz"), "c": [3, 4, 5]})
+    gb = df.groupby("a")
+    msg = "The operation <function mean.*failed"
+    # Warning is raised from within NumPy
+    with tm.assert_produces_warning(FutureWarning, match=msg, check_stacklevel=False):
+        gb.apply(np.mean)
+    # Ensure users can't pass numeric_only
+    with pytest.raises(TypeError, match="got an unexpected keyword argument"):
+        gb.apply(np.mean, numeric_only=True)

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -146,7 +146,8 @@ class TestPivotTable:
         df = DataFrame(
             {"rows": ["a", "b", "c"], "cols": ["x", "y", "z"], "values": [1, 2, 3]}
         )
-        msg = "pivot_table dropped a column because it failed to aggregate"
+        # GH#50538
+        msg = "The operation <function sum.*failed"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             rs = df.pivot_table(columns="cols", aggfunc=np.sum)
             xp = df.pivot_table(index="cols", aggfunc=np.sum).T
@@ -907,7 +908,8 @@ class TestPivotTable:
 
         # to help with a buglet
         self.data.columns = [k * 2 for k in self.data.columns]
-        msg = "pivot_table dropped a column because it failed to aggregate"
+        # GH#50538
+        msg = "The operation <function mean.*failed"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             table = self.data.pivot_table(
                 index=["AA", "BB"], margins=True, aggfunc=np.mean
@@ -916,6 +918,7 @@ class TestPivotTable:
             totals = table.loc[("All", ""), value_col]
             assert totals == self.data[value_col].mean()
 
+        msg = "pivot_table dropped a column because it failed to aggregate"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             table = self.data.pivot_table(
                 index=["AA", "BB"], margins=True, aggfunc="mean"
@@ -975,7 +978,11 @@ class TestPivotTable:
             }
         )
 
-        msg = "pivot_table dropped a column because it failed to aggregate"
+        if aggfunc == "sum":
+            msg = "pivot_table dropped a column because it failed to aggregate"
+        else:
+            # GH#50538
+            msg = "The operation <function mean.*failed"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             result = df.pivot_table(columns=columns, margins=True, aggfunc=aggfunc)
         expected = DataFrame(values, index=Index(["D", "E"]), columns=expected_columns)


### PR DESCRIPTION
- [x] closes #50538 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
