### PR TITLE
REF: avoid catching and re-raising in datetime parsing

### DIFF
--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -980,7 +980,7 @@ class TestBusinessDateRange:
     def test_date_parse_failure(self):
         badly_formed_date = "2007/100/1"
 
-        msg = "could not convert string to Timestamp"
+        msg = "Unknown string format: 2007/100/1"
         with pytest.raises(ValueError, match=msg):
             Timestamp(badly_formed_date)
 

--- a/pandas/tests/io/pytables/test_select.py
+++ b/pandas/tests/io/pytables/test_select.py
@@ -939,7 +939,10 @@ def test_query_compare_column_type(setup_path):
             v = "a"
             for col in ["int", "float", "real_date"]:
                 query = f"{col} {op} v"
-                msg = "could not convert string to "
+                if col == "real_date":
+                    msg = 'Given date string "a" not likely a datetime'
+                else:
+                    msg = "could not convert string to "
                 with pytest.raises(ValueError, match=msg):
                     store.select("test", where=query)
 

--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -429,7 +429,7 @@ class TestTimestampConstructors:
     @pytest.mark.parametrize("z", ["Z0", "Z00"])
     def test_constructor_invalid_Z0_isostring(self, z):
         # GH 8910
-        msg = "could not convert string to Timestamp"
+        msg = f"Unknown string format: 2014-11-02 01:00{z}"
         with pytest.raises(ValueError, match=msg):
             Timestamp(f"2014-11-02 01:00{z}")
 


### PR DESCRIPTION
Broken off from a branch re-using _convert_str_to_tsobject in array_to_datetime cc @MarcoGorelli 