### PR TITLE
BUG: groupby with empty object, categorical grouper, and dropna=False fails

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -972,6 +972,7 @@ Groupby/resample/rolling
 - Bug in :meth:`.DataFrameGrouBy.value_counts` would raise when used with a :class:`.TimeGrouper` (:issue:`50486`)
 - Bug in :meth:`Resampler.size` caused a wide :class:`DataFrame` to be returned instead of a :class:`Series` with :class:`MultiIndex` (:issue:`46826`)
 - Bug in :meth:`.DataFrameGroupBy.transform` and :meth:`.SeriesGroupBy.transform` would raise incorrectly when grouper had ``axis=1`` for ``"idxmin"`` and ``"idxmax"`` arguments (:issue:`45986`)
+- Bug in :class:`.DataFrameGroupBy` would raise when used with an empty DataFrame, categorical grouper, and ``dropna=False`` (:issue:`50634`)
 -
 
 Reshaping

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -649,7 +649,7 @@ class Grouping:
                 uniques = Categorical.from_codes(
                     np.append(uniques.codes, [-1]), uniques.categories
                 )
-            else:
+            elif len(codes) > 0:
                 # Need to determine proper placement of NA value when not sorting
                 cat = self.grouping_vector
                 na_idx = (cat.codes < 0).argmax()

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1870,7 +1870,9 @@ def test_pivot_table_values_key_error():
 @pytest.mark.parametrize(
     "op", ["idxmax", "idxmin", "min", "max", "sum", "prod", "skew"]
 )
-def test_empty_groupby(columns, keys, values, method, op, request, using_array_manager):
+def test_empty_groupby(
+    columns, keys, values, method, op, request, using_array_manager, dropna
+):
     # GH8093 & GH26411
     override_dtype = None
 
@@ -1930,7 +1932,7 @@ def test_empty_groupby(columns, keys, values, method, op, request, using_array_m
 
     df = df.iloc[:0]
 
-    gb = df.groupby(keys, group_keys=False)[columns]
+    gb = df.groupby(keys, group_keys=False, dropna=dropna)[columns]
 
     def get_result(**kwargs):
         if method == "attr":
@@ -2037,7 +2039,6 @@ def test_empty_groupby(columns, keys, values, method, op, request, using_array_m
                 lev = Categorical([0], dtype=values.dtype)
                 ci = Index(lev, name=keys[0])
                 expected = DataFrame([], columns=[], index=ci)
-            # expected = df.set_index(keys)[columns]
 
             tm.assert_equal(result, expected)
             return


### PR DESCRIPTION
- [x] closes #50634 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
