### PR TITLE
DOC: Fix column alignment in df.mul docstring

### DIFF
--- a/pandas/core/ops/docstrings.py
+++ b/pandas/core/ops/docstrings.py
@@ -559,16 +559,16 @@ rectangle       3      359
 Multiply a dictionary by axis.
 
 >>> df.mul({{'angles': 0, 'degrees': 2}})
-            angles	degrees
-circle	         0	    720
-triangle	     0	    360
-rectangle	     0	    720
+            angles  degrees
+circle           0      720
+triangle         0      360
+rectangle        0      720
 
 >>> df.mul({{'circle': 0, 'triangle': 2, 'rectangle': 3}}, axis='index')
-            angles	degrees
-circle		     0	      0
-triangle	     6	    360
-rectangle	    12	   1080
+            angles  degrees
+circle           0        0
+triangle         6      360
+rectangle       12     1080
 
 Multiply a DataFrame of different shape with operator version.
 


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Found an alignment issue in the documentation that was due to a few tabs being in there. Changing them to spaces fixes the issue.



**Before this pull request:**
(Screenshot taken from https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.add.html)
<img width="856" alt="image" src="https://user-images.githubusercontent.com/122238526/211251882-8bebd9f1-17bd-41f9-93bb-14e81620981a.png">




**After this pull request:**
(Screenshot taken from docs built locally)
<img width="849" alt="image" src="https://user-images.githubusercontent.com/122238526/211251773-35d73066-5537-4b74-9f6e-d8e750bfcfb4.png">


