### PR TITLE
DOC: fix closed and dtype arguments of TimedeltaIndex

### DIFF
--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -65,6 +65,14 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
         Make a copy of input ndarray.
     name : object
         Name to be stored in the index.
+    dtype : numpy.dtype
+         Currently, only ``numpy.dtype("timedelta64[ns]")`` is accepted.
+
+         .. warning::
+
+           A future version of pandas will change dtype to be an instance
+           of an ``ExtensionDtype`` subclass, not a ``numpy.dtype``.
+           See :class:`pandas.arrays.TimedeltaArray`.
 
     Attributes
     ----------
@@ -120,7 +128,6 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
         data=None,
         unit=None,
         freq=lib.no_default,
-        closed=None,
         dtype=None,
         copy: bool = False,
         name=None,

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -66,7 +66,7 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
     name : object
         Name to be stored in the index.
     dtype : numpy.dtype
-         Currently, only ``numpy.dtype("timedelta64[ns]")`` is accepted.
+        Currently, only ``numpy.dtype("timedelta64[ns]")`` is accepted.
 
          .. warning::
 


### PR DESCRIPTION
- [X] closes #49153 
- ~~[Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature~~
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
-  ~~Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.~~
- ~~Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.~~

1. **closed**: removed unused argument (xref #49167). It was already deprecated in version 0.24.0. (See https://github.com/TomAugspurger/pandas/blob/4d0fce26a87f7c6d74b77743fbcf96dd9c3cc338/pandas/core/indexes/timedeltas.py#L82)

2. **dtype**: add dtype parameter in docstring and add warning as indicated in [TimedeltaArray](https://pandas.pydata.org/docs/dev/reference/api/pandas.arrays.TimedeltaArray.html), since the argument is used to construct a TimedeltaArray.