### PR TITLE
improved description of mamba section

### DIFF
--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -79,7 +79,7 @@ Step 2: create an isolated environment
 Before we begin, please:
 
 * Make sure that you have :any:`cloned the repository <contributing.forking>`
-* ``cd`` to the pandas source directory
+* ``cd`` to the pandas source directory you just created with the clone command
 
 .. _contributing.mamba:
 


### PR DESCRIPTION

Fixed the mamba section, at the line that says “cd to the pandas source directory” add: " you just created with the clone command." under the DOC: Update the development environment guide. 

