### PR TITLE
DOC: improve the string repr of "no_default" in the signature of methods

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2722,6 +2722,9 @@ class _NoDefault(Enum):
     def __repr__(self) -> str:
         return "<no_default>"
 
+    def __str__(self) -> str:
+        return "<no_default>"
+
 
 # Note: no_default is exported to the public API in pandas.api.extensions
 no_default = _NoDefault.no_default  # Sentinel indicating the default value.


### PR DESCRIPTION
- [x] closes https://github.com/noatamir/pyladies-berlin-sprints/issues/20

> For example in https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.dropna.html, the signature shows "how=_NoDefault.no_default". This could be improved to the shorter / less noisy "how=<no_default>", by adding a __str__ method to this object (https://github.com/pandas-dev/pandas/blob/7e5a95cda77d2665d5bec2f4154bf72f041ac36b/pandas/_libs/lib.pyx#L2671-L2678)

@phofl and @noatamir