### PR TITLE
CLN: fix and move using_copy_on_write() helper out of internals

### DIFF
--- a/pandas/_config/__init__.py
+++ b/pandas/_config/__init__.py
@@ -14,10 +14,12 @@ __all__ = [
     "describe_option",
     "option_context",
     "options",
+    "using_copy_on_write",
 ]
 from pandas._config import config
 from pandas._config import dates  # pyright: ignore # noqa:F401
 from pandas._config.config import (
+    _global_config,
     describe_option,
     get_option,
     option_context,
@@ -26,3 +28,8 @@ from pandas._config.config import (
     set_option,
 )
 from pandas._config.display import detect_console_encoding
+
+
+def using_copy_on_write():
+    _mode_options = _global_config["mode"]
+    return _mode_options["copy_on_write"] and _mode_options["data_manager"] == "block"

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -29,7 +29,10 @@ import weakref
 
 import numpy as np
 
-from pandas._config import config
+from pandas._config import (
+    config,
+    using_copy_on_write,
+)
 
 from pandas._libs import lib
 from pandas._libs.tslibs import (
@@ -158,7 +161,6 @@ from pandas.core.internals import (
     SingleArrayManager,
 )
 from pandas.core.internals.construction import mgr_to_mgr
-from pandas.core.internals.managers import using_copy_on_write
 from pandas.core.methods.describe import describe_ndframe
 from pandas.core.missing import (
     clean_fill_method,
@@ -4023,10 +4025,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         df.iloc[0:5]['group'] = 'a'
 
         """
-        if (
-            config.get_option("mode.copy_on_write")
-            and config.get_option("mode.data_manager") == "block"
-        ):
+        if using_copy_on_write():
             return
 
         # return early if the check is not needed

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -15,7 +15,7 @@ import weakref
 
 import numpy as np
 
-from pandas._config import config
+from pandas._config import using_copy_on_write
 
 from pandas._libs import (
     algos as libalgos,
@@ -2362,10 +2362,3 @@ def _preprocess_slice_or_indexer(
         if not allow_fill:
             indexer = maybe_convert_indices(indexer, length)
         return "fancy", indexer, len(indexer)
-
-
-_mode_options = config._global_config["mode"]
-
-
-def using_copy_on_write():
-    return _mode_options["copy_on_write"]

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -22,7 +22,10 @@ import weakref
 
 import numpy as np
 
-from pandas._config import get_option
+from pandas._config import (
+    get_option,
+    using_copy_on_write,
+)
 
 from pandas._libs import (
     lib,
@@ -1263,10 +1266,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             # for CoW, we never want to update the parent DataFrame cache
             # if the Series changed, and always pop the cached item
             elif (
-                not (
-                    get_option("mode.copy_on_write")
-                    and get_option("mode.data_manager") == "block"
-                )
+                not using_copy_on_write()
                 and len(self) == len(ref)
                 and self.name in ref.columns
             ):

--- a/scripts/validate_unwanted_patterns.py
+++ b/scripts/validate_unwanted_patterns.py
@@ -52,6 +52,7 @@ PRIVATE_IMPORTS_TO_IGNORE: Set[str] = {
     "_test_decorators",
     "__version__",  # check np.__version__ in compat.numpy.function
     "_arrow_dtype_mapping",
+    "_global_config",
 }
 
 


### PR DESCRIPTION
I initially added this helper function just to the BlockManager internals in https://github.com/pandas-dev/pandas/pull/49771, but since then it seems we also started to use it outside of the internals. Which I think is a good change for a check that we will have to do often on the short term (it makes it more convenient to do this check, see the improvement in the diff where I changed existing `get_option(..)` calls). 
But, 1) the current function was only meant for internal usage and was incorrect for usage outside of the BlockManager (it also needs to check for the manager option) -> fixed that, and 2) moved it outside of the internals, so we don't have to import it from the internals in other parts of pandas.