### PR TITLE
BUG: Series.quantile emitting RuntimeWarning for all NA case

### DIFF
--- a/doc/source/whatsnew/v1.5.3.rst
+++ b/doc/source/whatsnew/v1.5.3.rst
@@ -28,6 +28,7 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 - Bug in :meth:`.Styler.to_excel` leading to error when unrecognized ``border-style`` (e.g. ``"hair"``) provided to Excel writers (:issue:`48649`)
+- Bug in :meth:`Series.quantile` emitting warning from NumPy when :class:`Series` has only ``NA`` values (:issue:`50681`)
 - Bug when chaining several :meth:`.Styler.concat` calls, only the last styler was concatenated (:issue:`49207`)
 - Fixed bug when instantiating a :class:`DataFrame` subclass inheriting from ``typing.Generic`` that triggered a ``UserWarning`` on python 3.11 (:issue:`49649`)
 -

--- a/pandas/core/array_algos/quantile.py
+++ b/pandas/core/array_algos/quantile.py
@@ -204,8 +204,10 @@ def _nanpercentile(
             result = np.array(result, copy=False).T
             if (
                 result.dtype != values.dtype
+                and not mask.all()
                 and (result == result.astype(values.dtype, copy=False)).all()
             ):
+                # mask.all() will never get cast back to int
                 # e.g. values id integer dtype and result is floating dtype,
                 #  only cast back to integer dtype if result values are all-integer.
                 result = result.astype(values.dtype, copy=False)

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -1039,6 +1039,11 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
                 raise NotImplementedError
             if self.isna().all():
                 out_mask = np.ones(res.shape, dtype=bool)
+
+                if is_integer_dtype(self.dtype):
+                    # We try to maintain int dtype if possible for not all-na case
+                    # as well
+                    res = np.zeros(res.shape, dtype=self.dtype.numpy_dtype)
             else:
                 out_mask = np.zeros(res.shape, dtype=bool)
         else:

--- a/pandas/tests/frame/methods/test_quantile.py
+++ b/pandas/tests/frame/methods/test_quantile.py
@@ -897,11 +897,6 @@ class TestQuantileExtensionDtype:
         qs = [0.5, 0, 1]
         result = self.compute_quantile(obj, qs)
 
-        if np_version_under1p21 and index.dtype == "timedelta64[ns]":
-            msg = "failed on Numpy 1.20.3; TypeError: data type 'Int64' not understood"
-            mark = pytest.mark.xfail(reason=msg, raises=TypeError)
-            request.node.add_marker(mark)
-
         expected = index.take([-1, -1, -1], allow_fill=True, fill_value=index._na_value)
         expected = Series(expected, index=qs, name="A")
         expected = type(obj)(expected)

--- a/pandas/tests/frame/methods/test_quantile.py
+++ b/pandas/tests/frame/methods/test_quantile.py
@@ -904,8 +904,6 @@ class TestQuantileExtensionDtype:
 
         expected = index.take([-1, -1, -1], allow_fill=True, fill_value=index._na_value)
         expected = Series(expected, index=qs, name="A")
-        if expected.dtype == "Int64":
-            expected = expected.astype("Float64")
         expected = type(obj)(expected)
         tm.assert_equal(result, expected)
 

--- a/pandas/tests/series/methods/test_quantile.py
+++ b/pandas/tests/series/methods/test_quantile.py
@@ -225,3 +225,18 @@ class TestSeriesQuantile:
         if dtype == "Int64":
             expected = expected.astype("Float64")
         tm.assert_series_equal(result, expected)
+
+    def test_quantile_all_na(self, any_int_ea_dtype):
+        # GH#50681
+        ser = Series([pd.NA, pd.NA], dtype=any_int_ea_dtype)
+        with tm.assert_produces_warning(None):
+            result = ser.quantile([0.1, 0.5])
+        expected = Series([pd.NA, pd.NA], dtype=any_int_ea_dtype, index=[0.1, 0.5])
+        tm.assert_series_equal(result, expected)
+
+    def test_quantile_dtype_size(self, any_int_ea_dtype):
+        # GH#50681
+        ser = Series([pd.NA, pd.NA, 1], dtype=any_int_ea_dtype)
+        result = ser.quantile([0.1, 0.5])
+        expected = Series([1, 1], dtype=any_int_ea_dtype, index=[0.1, 0.5])
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #50681 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

I am not totally sure that we should backport since technically this also fixes a bug. 

Edit: Could probably avoid the bug fix I guess