### PR TITLE
TST: Fix test_constructor_signed_int_overflow_deprecation w/ multiple warnings

### DIFF
--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -740,18 +740,18 @@ class TestSeriesConstructors:
     def test_constructor_signed_int_overflow_deprecation(self):
         # GH#41734 disallow silent overflow
         msg = "Values are too large to be losslessly cast"
-        numpy_warning = DeprecationWarning if is_numpy_dev else None
-        with tm.assert_produces_warning(
-            (FutureWarning, numpy_warning), match=msg, check_stacklevel=False
-        ):
+        warns = (
+            (FutureWarning, DeprecationWarning)
+            if is_numpy_dev or np_version_gte1p24
+            else FutureWarning
+        )
+        with tm.assert_produces_warning(warns, match=msg, check_stacklevel=False):
             ser = Series([1, 200, 923442], dtype="int8")
 
         expected = Series([1, -56, 50], dtype="int8")
         tm.assert_series_equal(ser, expected)
 
-        with tm.assert_produces_warning(
-            (FutureWarning, numpy_warning), match=msg, check_stacklevel=False
-        ):
+        with tm.assert_produces_warning(warns, match=msg, check_stacklevel=False):
             ser = Series([1, 200, 923442], dtype="uint8")
 
         expected = Series([1, 200, 50], dtype="uint8")

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -13,10 +13,7 @@ from pandas._libs import (
     iNaT,
     lib,
 )
-from pandas.compat import (
-    IS64,
-    is_numpy_dev,
-)
+from pandas.compat import is_numpy_dev
 from pandas.compat.numpy import np_version_gte1p24
 import pandas.util._test_decorators as td
 
@@ -736,7 +733,7 @@ class TestSeriesConstructors:
         with pytest.raises(ValueError, match=msg):
             Series(["a", "b", "c"], dtype=float)
 
-    @pytest.mark.xfail(np_version_gte1p24 and not IS64, reason="GH49777")
+    @pytest.mark.xfail(np_version_gte1p24, reason="GH49777")
     def test_constructor_signed_int_overflow_deprecation(self):
         # GH#41734 disallow silent overflow
         msg = "Values are too large to be losslessly cast"

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -733,7 +733,6 @@ class TestSeriesConstructors:
         with pytest.raises(ValueError, match=msg):
             Series(["a", "b", "c"], dtype=float)
 
-    @pytest.mark.xfail(np_version_gte1p24, reason="GH49777")
     def test_constructor_signed_int_overflow_deprecation(self):
         # GH#41734 disallow silent overflow
         msg = "Values are too large to be losslessly cast"


### PR DESCRIPTION
- closes #50710 

Would raise

```
2023-01-07T01:45:49.8230480Z FAILED ../lib/python3.10/site-packages/pandas/tests/series/test_constructors.py::TestSeriesConstructors::test_constructor_signed_int_overflow_deprecation - TypeError: issubclass() arg 2 must be a class, a tuple of classes, or a union
```

because tuple would contain (FutureWarning, None) which is not supported

xref https://github.com/conda-forge/pandas-feedstock/issues/150