### PR TITLE
REF: stricter typing, better naming in parsing.pyx

### DIFF
--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -770,6 +770,15 @@ cdef _array_to_datetime_object(
                 oresult[i] = "NaT"
                 cnp.PyArray_MultiIter_NEXT(mi)
                 continue
+            elif val == "now":
+                oresult[i] = datetime.now()
+                cnp.PyArray_MultiIter_NEXT(mi)
+                continue
+            elif val == "today":
+                oresult[i] = datetime.today()
+                cnp.PyArray_MultiIter_NEXT(mi)
+                continue
+
             try:
                 oresult[i] = parse_datetime_string(val, dayfirst=dayfirst,
                                                    yearfirst=yearfirst)

--- a/pandas/_libs/tslibs/parsing.pyi
+++ b/pandas/_libs/tslibs/parsing.pyi
@@ -2,7 +2,6 @@ from datetime import datetime
 
 import numpy as np
 
-from pandas._libs.tslibs.offsets import BaseOffset
 from pandas._typing import npt
 
 class DateParseError(ValueError): ...
@@ -12,9 +11,9 @@ def parse_datetime_string(
     dayfirst: bool = ...,
     yearfirst: bool = ...,
 ) -> datetime: ...
-def parse_time_string(
-    arg: str,
-    freq: BaseOffset | str | None = ...,
+def parse_datetime_string_with_reso(
+    date_string: str,
+    freq: str | None = ...,
     dayfirst: bool | None = ...,
     yearfirst: bool | None = ...,
 ) -> tuple[datetime, str]: ...

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -88,7 +88,7 @@ from pandas._libs.tslibs.dtypes cimport (
 )
 from pandas._libs.tslibs.parsing cimport quarter_to_myear
 
-from pandas._libs.tslibs.parsing import parse_time_string
+from pandas._libs.tslibs.parsing import parse_datetime_string_with_reso
 
 from pandas._libs.tslibs.nattype cimport (
     NPY_NAT,
@@ -2589,7 +2589,9 @@ class Period(_Period):
 
                 value = str(value)
             value = value.upper()
-            dt, reso = parse_time_string(value, freq)
+
+            freqstr = freq.rule_code if freq is not None else None
+            dt, reso = parse_datetime_string_with_reso(value, freqstr)
             try:
                 ts = Timestamp(value)
             except ValueError:

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -241,7 +241,15 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex):
                 freq = self.freq
         except NotImplementedError:
             freq = getattr(self, "freqstr", getattr(self, "inferred_freq", None))
-        parsed, reso_str = parsing.parse_time_string(label, freq)
+
+        if freq is not None and not isinstance(freq, str):
+            freq = freq.rule_code
+
+        if isinstance(label, np.str_):
+            # GH#45580
+            label = str(label)
+
+        parsed, reso_str = parsing.parse_datetime_string_with_reso(label, freq)
         reso = Resolution.from_attrname(reso_str)
         return parsed, reso
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -242,14 +242,17 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex):
         except NotImplementedError:
             freq = getattr(self, "freqstr", getattr(self, "inferred_freq", None))
 
+        freqstr: str | None
         if freq is not None and not isinstance(freq, str):
-            freq = freq.rule_code
+            freqstr = freq.rule_code
+        else:
+            freqstr = freq
 
         if isinstance(label, np.str_):
             # GH#45580
             label = str(label)
 
-        parsed, reso_str = parsing.parse_datetime_string_with_reso(label, freq)
+        parsed, reso_str = parsing.parse_datetime_string_with_reso(label, freqstr)
         reso = Resolution.from_attrname(reso_str)
         return parsed, reso
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -276,8 +276,9 @@ class TestLocBaseIndependent:
     def test_contains_raise_error_if_period_index_is_in_multi_index(self, msg, key):
         # GH#20684
         """
-        parse_time_string return parameter if type not matched.
-        PeriodIndex.get_loc takes returned value from parse_time_string as a tuple.
+        parse_datetime_string_with_reso return parameter if type not matched.
+        PeriodIndex.get_loc takes returned value from parse_datetime_string_with_reso
+        as a tuple.
         If first argument is Period and a tuple has 3 items,
         process go on not raise exception
         """

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2901,7 +2901,9 @@ class TestDatetimeParsingWrappers:
         # https://github.com/dateutil/dateutil/issues/217
         yearfirst = True
 
-        result1, _ = parsing.parse_time_string(date_str, yearfirst=yearfirst)
+        result1, _ = parsing.parse_datetime_string_with_reso(
+            date_str, yearfirst=yearfirst
+        )
         with tm.assert_produces_warning(warning, match="Could not infer format"):
             result2 = to_datetime(date_str, yearfirst=yearfirst)
             result3 = to_datetime([date_str], yearfirst=yearfirst)
@@ -2937,7 +2939,7 @@ class TestDatetimeParsingWrappers:
 
     def test_parsers_nat(self):
         # Test that each of several string-accepting methods return pd.NaT
-        result1, _ = parsing.parse_time_string("NaT")
+        result1, _ = parsing.parse_datetime_string_with_reso("NaT")
         result2 = to_datetime("NaT")
         result3 = Timestamp("NaT")
         result4 = DatetimeIndex(["NaT"])[0]
@@ -3008,7 +3010,7 @@ class TestDatetimeParsingWrappers:
         dateutil_result = parse(date_str, dayfirst=dayfirst, yearfirst=yearfirst)
         assert dateutil_result == expected
 
-        result1, _ = parsing.parse_time_string(
+        result1, _ = parsing.parse_datetime_string_with_reso(
             date_str, dayfirst=dayfirst, yearfirst=yearfirst
         )
 
@@ -3036,7 +3038,7 @@ class TestDatetimeParsingWrappers:
         # must be the same as dateutil result
         exp_now = parse(date_str)
 
-        result1, _ = parsing.parse_time_string(date_str)
+        result1, _ = parsing.parse_datetime_string_with_reso(date_str)
         with tm.assert_produces_warning(UserWarning, match="Could not infer format"):
             result2 = to_datetime(date_str)
             result3 = to_datetime([date_str])

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -1623,10 +1623,14 @@ class TestToDatetime:
             "2015-03-14T16:15:14.123-08:00",
             "2019-03-04T21:56:32.620-07:00",
             None,
+            "today",
+            "now",
         ]
         ser = Series(vals)
         assert all(ser[i] is vals[i] for i in range(len(vals)))  # GH#40111
 
+        now = Timestamp("now")
+        today = Timestamp("today")
         mixed = to_datetime(ser)
         expected = Series(
             [
@@ -1638,7 +1642,11 @@ class TestToDatetime:
             ],
             dtype=object,
         )
-        tm.assert_series_equal(mixed, expected)
+        tm.assert_series_equal(mixed[:-2], expected)
+        # we'll check mixed[-1] and mixed[-2] match now and today to within
+        # call-timing tolerances
+        assert (now - mixed.iloc[-1]).total_seconds() <= 0.1
+        assert (today - mixed.iloc[-2]).total_seconds() <= 0.1
 
         with pytest.raises(ValueError, match="Tz-aware datetime.datetime"):
             to_datetime(mixed)

--- a/pandas/tests/tslibs/test_parsing.py
+++ b/pandas/tests/tslibs/test_parsing.py
@@ -12,31 +12,31 @@ from pandas._libs.tslibs import (
     parsing,
     strptime,
 )
-from pandas._libs.tslibs.parsing import parse_time_string
+from pandas._libs.tslibs.parsing import parse_datetime_string_with_reso
 import pandas.util._test_decorators as td
 
 import pandas._testing as tm
 
 
-def test_parse_time_string():
-    (parsed, reso) = parse_time_string("4Q1984")
-    (parsed_lower, reso_lower) = parse_time_string("4q1984")
+def test_parse_datetime_string_with_reso():
+    (parsed, reso) = parse_datetime_string_with_reso("4Q1984")
+    (parsed_lower, reso_lower) = parse_datetime_string_with_reso("4q1984")
 
     assert reso == reso_lower
     assert parsed == parsed_lower
 
 
-def test_parse_time_string_nanosecond_reso():
+def test_parse_datetime_string_with_reso_nanosecond_reso():
     # GH#46811
-    parsed, reso = parse_time_string("2022-04-20 09:19:19.123456789")
+    parsed, reso = parse_datetime_string_with_reso("2022-04-20 09:19:19.123456789")
     assert reso == "nanosecond"
 
 
-def test_parse_time_string_invalid_type():
+def test_parse_datetime_string_with_reso_invalid_type():
     # Raise on invalid input, don't just return it
-    msg = "Argument 'arg' has incorrect type (expected str, got tuple)"
+    msg = "Argument 'date_string' has incorrect type (expected str, got tuple)"
     with pytest.raises(TypeError, match=re.escape(msg)):
-        parse_time_string((4, 5))
+        parse_datetime_string_with_reso((4, 5))
 
 
 @pytest.mark.parametrize(
@@ -44,8 +44,8 @@ def test_parse_time_string_invalid_type():
 )
 def test_parse_time_quarter_with_dash(dashed, normal):
     # see gh-9688
-    (parsed_dash, reso_dash) = parse_time_string(dashed)
-    (parsed, reso) = parse_time_string(normal)
+    (parsed_dash, reso_dash) = parse_datetime_string_with_reso(dashed)
+    (parsed, reso) = parse_datetime_string_with_reso(normal)
 
     assert parsed_dash == parsed
     assert reso_dash == reso
@@ -56,7 +56,7 @@ def test_parse_time_quarter_with_dash_error(dashed):
     msg = f"Unknown datetime string format, unable to parse: {dashed}"
 
     with pytest.raises(parsing.DateParseError, match=msg):
-        parse_time_string(dashed)
+        parse_datetime_string_with_reso(dashed)
 
 
 @pytest.mark.parametrize(
@@ -103,7 +103,7 @@ def test_does_not_convert_mixed_integer(date_string, expected):
 )
 def test_parsers_quarterly_with_freq_error(date_str, kwargs, msg):
     with pytest.raises(parsing.DateParseError, match=msg):
-        parsing.parse_time_string(date_str, **kwargs)
+        parsing.parse_datetime_string_with_reso(date_str, **kwargs)
 
 
 @pytest.mark.parametrize(
@@ -115,7 +115,7 @@ def test_parsers_quarterly_with_freq_error(date_str, kwargs, msg):
     ],
 )
 def test_parsers_quarterly_with_freq(date_str, freq, expected):
-    result, _ = parsing.parse_time_string(date_str, freq=freq)
+    result, _ = parsing.parse_datetime_string_with_reso(date_str, freq=freq)
     assert result == expected
 
 
@@ -132,7 +132,7 @@ def test_parsers_quarter_invalid(date_str):
         msg = f"Unknown datetime string format, unable to parse: {date_str}"
 
     with pytest.raises(ValueError, match=msg):
-        parsing.parse_time_string(date_str)
+        parsing.parse_datetime_string_with_reso(date_str)
 
 
 @pytest.mark.parametrize(
@@ -140,7 +140,7 @@ def test_parsers_quarter_invalid(date_str):
     [("201101", datetime(2011, 1, 1, 0, 0)), ("200005", datetime(2000, 5, 1, 0, 0))],
 )
 def test_parsers_month_freq(date_str, expected):
-    result, _ = parsing.parse_time_string(date_str, freq="M")
+    result, _ = parsing.parse_datetime_string_with_reso(date_str, freq="M")
     assert result == expected
 
 
@@ -284,13 +284,13 @@ def test_try_parse_dates():
     tm.assert_numpy_array_equal(result, expected)
 
 
-def test_parse_time_string_check_instance_type_raise_exception():
+def test_parse_datetime_string_with_reso_check_instance_type_raise_exception():
     # issue 20684
-    msg = "Argument 'arg' has incorrect type (expected str, got tuple)"
+    msg = "Argument 'date_string' has incorrect type (expected str, got tuple)"
     with pytest.raises(TypeError, match=re.escape(msg)):
-        parse_time_string((1, 2, 3))
+        parse_datetime_string_with_reso((1, 2, 3))
 
-    result = parse_time_string("2019")
+    result = parse_datetime_string_with_reso("2019")
     expected = (datetime(2019, 1, 1), "year")
     assert result == expected
 


### PR DESCRIPTION
Trying to move towards having fewer different string parsing paths.