### PR TITLE
TST: mark copy_view test_switch_options test as single_cpu

### DIFF
--- a/pandas/tests/copy_view/test_internals.py
+++ b/pandas/tests/copy_view/test_internals.py
@@ -65,6 +65,7 @@ def test_clear_parent(using_copy_on_write):
     assert subset._mgr.parent is None
 
 
+@pytest.mark.single_cpu
 @td.skip_array_manager_invalid_test
 def test_switch_options():
     # ensure we can switch the value of the option within one session


### PR DESCRIPTION
While backporting https://github.com/pandas-dev/pandas/pull/49771 in https://github.com/pandas-dev/pandas/pull/50128, I had to mark the test to not run in parallel to get it passing. This was not needed on the main branch, but since this can depend on the exact order and presence of other tests, seems safer to apply this to the main branch as well.