### PR TITLE
CLN explicit float casts in tests

### DIFF
--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1936,15 +1936,19 @@ def test_dataframe_blockwise_slicelike():
     # GH#34367
     arr = np.random.randint(0, 1000, (100, 10))
     df1 = DataFrame(arr)
-    df2 = df1.copy()
+    # Explicit cast to float to avoid implicit cast when setting nan
+    df2 = df1.copy().astype({1: "float", 3: "float", 7: "float"})
     df2.iloc[0, [1, 3, 7]] = np.nan
 
-    df3 = df1.copy()
+    # Explicit cast to float to avoid implicit cast when setting nan
+    df3 = df1.copy().astype({5: "float"})
     df3.iloc[0, [5]] = np.nan
 
-    df4 = df1.copy()
+    # Explicit cast to float to avoid implicit cast when setting nan
+    df4 = df1.copy().astype({2: "float", 3: "float", 4: "float"})
     df4.iloc[0, np.arange(2, 5)] = np.nan
-    df5 = df1.copy()
+    # Explicit cast to float to avoid implicit cast when setting nan
+    df5 = df1.copy().astype({4: "float", 5: "float", 6: "float"})
     df5.iloc[0, np.arange(4, 7)] = np.nan
 
     for left, right in [(df1, df2), (df2, df3), (df4, df5)]:

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -826,6 +826,8 @@ def test_cummin(dtypes_for_minmax):
     tm.assert_frame_equal(result, expected, check_exact=True)
 
     # Test nan in some values
+    # Explicit cast to float to avoid implicit cast when setting nan
+    base_df = base_df.astype({"B": "float"})
     base_df.loc[[0, 2, 4, 6], "B"] = np.nan
     expected = DataFrame({"B": [np.nan, 4, np.nan, 2, np.nan, 3, np.nan, 1]})
     result = base_df.groupby("A").cummin()
@@ -891,6 +893,8 @@ def test_cummax(dtypes_for_minmax):
     tm.assert_frame_equal(result, expected)
 
     # Test nan in some values
+    # Explicit cast to float to avoid implicit cast when setting nan
+    base_df = base_df.astype({"B": "float"})
     base_df.loc[[0, 2, 4, 6], "B"] = np.nan
     expected = DataFrame({"B": [np.nan, 4, np.nan, 4, np.nan, 3, np.nan, 3]})
     result = base_df.groupby("A").cummax()

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -193,7 +193,8 @@ class TestDataFrameFormatting:
     )
     def test_show_counts(self, row, columns, show_counts, result):
 
-        df = DataFrame(1, columns=range(10), index=range(10))
+        # Explicit cast to float to avoid implicit cast when setting nan
+        df = DataFrame(1, columns=range(10), index=range(10)).astype({1: "float"})
         df.iloc[1, 1] = np.nan
 
         with option_context(

--- a/pandas/tests/resample/test_base.py
+++ b/pandas/tests/resample/test_base.py
@@ -68,7 +68,8 @@ def test_asfreq_fill_value(series, create_index):
     expected = ser.reindex(new_index)
     tm.assert_series_equal(result, expected)
 
-    frame = ser.to_frame("value")
+    # Explicit cast to float to avoid implicit cast when setting None
+    frame = ser.astype("float").to_frame("value")
     frame.iloc[1] = None
     result = frame.resample("1H").asfreq(fill_value=4.0)
     new_index = create_index(frame.index[0], frame.index[-1], freq="1H")

--- a/pandas/tests/reshape/merge/test_multi.py
+++ b/pandas/tests/reshape/merge/test_multi.py
@@ -123,7 +123,8 @@ class TestMergeMulti:
 
         lc = list(map(chr, np.arange(ord("a"), ord("z") + 1)))
         left = DataFrame(np.random.choice(lc, (5000, 2)), columns=["1st", "3rd"])
-        left.insert(1, "2nd", np.random.randint(0, 1000, len(left)))
+        # Explicit cast to float to avoid implicit cast when setting nan
+        left.insert(1, "2nd", np.random.randint(0, 1000, len(left)).astype("float"))
 
         i = np.random.permutation(len(left))
         right = left.iloc[i].copy()

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -433,6 +433,8 @@ def test_closed_uneven():
 def test_closed_min_max_minp(func, closed, expected):
     # see gh-21704
     ser = Series(data=np.arange(10), index=date_range("2000", periods=10))
+    # Explicit cast to float to avoid implicit cast when setting nan
+    ser = ser.astype("float")
     ser[ser.index[-3:]] = np.nan
     result = getattr(ser.rolling("3D", min_periods=2, closed=closed), func)()
     expected = Series(expected, index=ser.index)

--- a/pandas/tests/window/test_timeseries_window.py
+++ b/pandas/tests/window/test_timeseries_window.py
@@ -579,7 +579,8 @@ class TestRollingTS:
     def test_freqs_ops(self, freq, op, result_data):
         # GH 21096
         index = date_range(start="2018-1-1 01:00:00", freq=f"1{freq}", periods=10)
-        s = Series(data=0, index=index)
+        # Explicit cast to float to avoid implicit cast when setting nan
+        s = Series(data=0, index=index, dtype="float")
         s.iloc[1] = np.nan
         s.iloc[-1] = 2
         result = getattr(s.rolling(window=f"10{freq}"), op)()


### PR DESCRIPTION
Similar to https://github.com/pandas-dev/pandas/pull/50493

There are places when an implicit cast happens, but it's not the purpose of the test - the cast might as well be done explicitly then

This would help pave the way towards https://github.com/pandas-dev/pandas/pull/50424

---

I expect this to be the last precursor PR, after this one I'll raise a draft PR to try enforcing PDEP6 in some cases (note that merging would only take place _after_ 2.0 is released)