### PR TITLE
TST: Determine groupby-transform not convert back type

### DIFF
--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -1050,7 +1050,7 @@ def test_groupby_transform_dtype():
     # GH 22243
     df = DataFrame({"a": [1], "val": [1.35]})
 
-    result = df["val"].transform(lambda x: x.map("+{}".format))
+    result = df["val"].transform(lambda x: x.map(lambda y: f"+{y}"))
     expected1 = Series(["+1.35"], name="val", dtype="object")
     tm.assert_series_equal(result, expected1)
 

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -1049,11 +1049,9 @@ def test_groupby_transform_with_datetimes(func, values):
 def test_groupby_transform_dtype():
     # GH 22243
     df = DataFrame({"a": [1], "val": [1.35]})
-    result = df.groupby("a")["val"].transform(lambda x: f"+{x}").dtype
-    original = df["val"].dtype
-    expected = df["val"].transform(lambda x: f"+{x}").dtype
-    assert result != original
-    assert result == expected
+    result = df.groupby("a")["val"].transform(lambda x: x.map(lambda y: f"+{y}"))
+    expected = Series(["+1.35"], name="val", dtype="object")
+    tm.assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize("func", ["cumsum", "cumprod", "cummin", "cummax"])

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -1049,9 +1049,9 @@ def test_groupby_transform_with_datetimes(func, values):
 def test_groupby_transform_dtype():
     # GH 22243
     df = DataFrame({"a": [1], "val": [1.35]})
-    result = df.groupby("a")["val"].transform(lambda x: x.map("+{}".format)).dtype
+    result = df.groupby("a")["val"].transform(lambda x: f"+{x}").dtype
     original = df["val"].dtype
-    expected = df["val"].transform(lambda x: x.map("+{}".format)).dtype
+    expected = df["val"].transform(lambda x: f"+{x}").dtype
     assert result != original
     assert result == expected
 

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -1046,6 +1046,16 @@ def test_groupby_transform_with_datetimes(func, values):
     tm.assert_series_equal(result, expected)
 
 
+def test_groupby_transform_dtype():
+    # GH 22243
+    df = DataFrame({"a": [1], "val": [1.35]})
+    result = df.groupby("a")["val"].transform(lambda x: x.map("+{}".format)).dtype
+    original = df["val"].dtype
+    expected = df["val"].transform(lambda x: x.map("+{}".format)).dtype
+    assert result != original
+    assert result == expected
+
+
 @pytest.mark.parametrize("func", ["cumsum", "cumprod", "cummin", "cummax"])
 def test_transform_absent_categories(func):
     # GH 16771

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -1049,9 +1049,21 @@ def test_groupby_transform_with_datetimes(func, values):
 def test_groupby_transform_dtype():
     # GH 22243
     df = DataFrame({"a": [1], "val": [1.35]})
+
+    result = df["val"].transform(lambda x: x.map("+{}".format))
+    expected1 = Series(["+1.35"], name="val", dtype="object")
+    tm.assert_series_equal(result, expected1)
+
     result = df.groupby("a")["val"].transform(lambda x: x.map(lambda y: f"+{y}"))
-    expected = Series(["+1.35"], name="val", dtype="object")
-    tm.assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected1)
+
+    result = df.groupby("a")["val"].transform(lambda x: x.map(lambda y: f"+({y})"))
+    expected2 = Series(["+(1.35)"], name="val", dtype="object")
+    tm.assert_series_equal(result, expected2)
+
+    df["val"] = df["val"].astype(object)
+    result = df.groupby("a")["val"].transform(lambda x: x.map(lambda y: f"+{y}"))
+    tm.assert_series_equal(result, expected1)
 
 
 @pytest.mark.parametrize("func", ["cumsum", "cumprod", "cummin", "cummax"])


### PR DESCRIPTION
- [x] closes #22243 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
