### PR TITLE
DOC: Add docstring for DataFrame.T property

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3577,6 +3577,10 @@ class DataFrame(NDFrame, OpsMixin):
         DataFrame
             The transposed DataFrame.
 
+        See Also
+        --------
+        DataFrame.transpose : Transpose index and columns.
+
         Examples
         --------
         >>> df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
@@ -3589,11 +3593,6 @@ class DataFrame(NDFrame, OpsMixin):
               0  1
         col1  1  2
         col2  3  4
-
-
-        See Also
-        --------
-        DataFrame.transpose : Transpose index and columns.
         """
         return self.transpose()
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3569,6 +3569,32 @@ class DataFrame(NDFrame, OpsMixin):
 
     @property
     def T(self) -> DataFrame:
+        """
+        The transpose of the DataFrame.
+
+        Returns
+        -------
+        DataFrame
+            The transposed DataFrame.
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
+        >>> df
+           col1  col2
+        0     1     3
+        1     2     4
+
+        >>> df.T
+              0  1
+        col1  1  2
+        col2  3  4
+
+
+        See Also
+        --------
+        DataFrame.transpose : Transpose index and columns.
+        """
         return self.transpose()
 
     # ----------------------------------------------------------------------


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.



**Before this change:**
The `T` property of a DataFrame is named in the docs but is not linked to any documentation:

(Screenshot below taken from https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.html)

<img width="1346" alt="image" src="https://user-images.githubusercontent.com/122238526/212579272-bc583d1a-bd0d-471e-972f-c6d10d81667e.png">



**After this change**
The `T` property is linked to documentation (it now appears as the top property alphabetically, I guess because it's a capital 'T').

<img width="1258" alt="image" src="https://user-images.githubusercontent.com/122238526/212579535-b4f9c4d7-2bfb-49af-bb3b-1e3f0e675df0.png">


And if you click on it you see this new page.  As you can see, it links through to the existing `DataFrame.transpose` docs. I put in one simple example here.
<img width="1277" alt="image" src="https://user-images.githubusercontent.com/122238526/212579665-cdca6ebd-9a99-4d16-ace6-979ad85a7dbc.png">




