### PR TITLE
 BUG: DatetimeIndex with non-nano values and freq='D' throws ValueError

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1897,7 +1897,12 @@ class TimelikeOps(DatetimeLikeArrayMixin):
 
         try:
             on_freq = cls._generate_range(
-                start=index[0], end=None, periods=len(index), freq=freq, **kwargs
+                start=index[0],
+                end=None,
+                periods=len(index),
+                freq=freq,
+                unit=index.unit,
+                **kwargs,
             )
             if not np.array_equal(index.asi8, on_freq.asi8):
                 raise ValueError

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -357,7 +357,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
 
         if inferred_freq is None and freq is not None:
             # this condition precludes `freq_infer`
-            cls._validate_frequency(result, freq, ambiguous=ambiguous, unit=result.unit)
+            cls._validate_frequency(result, freq, ambiguous=ambiguous)
 
         elif freq_infer:
             # Set _freq directly to bypass duplicative _validate_frequency

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -357,7 +357,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
 
         if inferred_freq is None and freq is not None:
             # this condition precludes `freq_infer`
-            cls._validate_frequency(result, freq, ambiguous=ambiguous)
+            cls._validate_frequency(result, freq, ambiguous=ambiguous, unit=result.unit)
 
         elif freq_infer:
             # Set _freq directly to bypass duplicative _validate_frequency

--- a/pandas/tests/frame/methods/test_asfreq.py
+++ b/pandas/tests/frame/methods/test_asfreq.py
@@ -17,6 +17,10 @@ from pandas.tseries import offsets
 
 
 class TestAsFreq:
+    @pytest.fixture(params=["s", "ms", "us", "ns"])
+    def unit(self, request):
+        return request.param
+
     def test_asfreq2(self, frame_or_series):
         ts = frame_or_series(
             [0.0, 1.0, 2.0],
@@ -197,3 +201,11 @@ class TestAsFreq:
 
         result = result.asfreq("D")
         tm.assert_equal(result, expected)
+
+    def test_asfreq_after_normalize(self, unit):
+        # https://github.com/pandas-dev/pandas/issues/50727
+        result = DatetimeIndex(
+            date_range("2000", periods=2).as_unit(unit).normalize(), freq="D"
+        )
+        expected = DatetimeIndex(["2000-01-01", "2000-01-02"], freq="D").as_unit(unit)
+        tm.assert_index_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #50727 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
