### PR TITLE
BUG: resample don't work with non-nanosecond reso

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1031,7 +1031,7 @@ default 'raise'
 
         if self.tz is not None:
             if tz is None:
-                new_dates = tz_convert_from_utc(self.asi8, self.tz)
+                new_dates = tz_convert_from_utc(self.asi8, self.tz, reso=self._creso)
             else:
                 raise TypeError("Already tz-aware, use tz_convert to convert.")
         else:

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -90,7 +90,6 @@ from pandas.tseries.frequencies import (
 )
 from pandas.tseries.offsets import (
     Day,
-    Nano,
     Tick,
 )
 
@@ -1715,7 +1714,7 @@ class TimeGrouper(Grouper):
             name=ax.name,
             ambiguous=True,
             nonexistent="shift_forward",
-        )
+        ).as_unit(ax.unit)
 
         ax_values = ax.asi8
         binner, bin_edges = self._adjust_bin_edges(binner, ax_values)
@@ -1751,7 +1750,7 @@ class TimeGrouper(Grouper):
             if self.closed == "right":
                 # GH 21459, GH 9119: Adjust the bins relative to the wall time
                 bin_edges = binner.tz_localize(None)
-                bin_edges = bin_edges + timedelta(1) - Nano(1)
+                bin_edges = bin_edges + timedelta(1) - Timedelta(1, unit=bin_edges.unit)
                 bin_edges = bin_edges.tz_localize(binner.tz).asi8
             else:
                 bin_edges = binner.asi8

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import copy
-from datetime import timedelta
 from textwrap import dedent
 from typing import (
     TYPE_CHECKING,
@@ -1750,7 +1749,11 @@ class TimeGrouper(Grouper):
             if self.closed == "right":
                 # GH 21459, GH 9119: Adjust the bins relative to the wall time
                 bin_edges = binner.tz_localize(None)
-                bin_edges = bin_edges + timedelta(1) - Timedelta(1, unit=bin_edges.unit)
+                bin_edges = (
+                    bin_edges
+                    + Timedelta(days=1, unit=bin_edges.unit).as_unit(bin_edges.unit)
+                    - Timedelta(1, unit=bin_edges.unit).as_unit(bin_edges.unit)
+                )
                 bin_edges = bin_edges.tz_localize(binner.tz).asi8
             else:
                 bin_edges = binner.asi8

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -1557,12 +1557,12 @@ def test_groupby_with_dst_time_change():
     tm.assert_frame_equal(result, expected)
 
 
-def test_resample_dst_anchor():
+def test_resample_dst_anchor(unit):
     # 5172
-    dti = DatetimeIndex([datetime(2012, 11, 4, 23)], tz="US/Eastern")
+    dti = DatetimeIndex([datetime(2012, 11, 4, 23)], tz="US/Eastern").as_unit(unit)
     df = DataFrame([5], index=dti)
 
-    dti = DatetimeIndex(df.index.normalize(), freq="D")
+    dti = DatetimeIndex(df.index.normalize(), freq="D").as_unit(unit)
     expected = DataFrame([5], index=dti)
     tm.assert_frame_equal(df.resample(rule="D").sum(), expected)
     df.resample(rule="MS").sum()
@@ -1570,11 +1570,15 @@ def test_resample_dst_anchor():
         df.resample(rule="MS").sum(),
         DataFrame(
             [5],
-            index=DatetimeIndex([datetime(2012, 11, 1)], tz="US/Eastern", freq="MS"),
+            index=DatetimeIndex(
+                [datetime(2012, 11, 1)], tz="US/Eastern", freq="MS"
+            ).as_unit(unit),
         ),
     )
 
-    dti = date_range("2013-09-30", "2013-11-02", freq="30Min", tz="Europe/Paris")
+    dti = date_range(
+        "2013-09-30", "2013-11-02", freq="30Min", tz="Europe/Paris"
+    ).as_unit(unit)
     values = range(dti.size)
     df = DataFrame({"a": values, "b": values, "c": values}, index=dti, dtype="int64")
     how = {"a": "min", "b": "max", "c": "count"}
@@ -1587,7 +1591,9 @@ def test_resample_dst_anchor():
                 "b": [47, 383, 719, 1055, 1393, 1586],
                 "c": [48, 336, 336, 336, 338, 193],
             },
-            index=date_range("9/30/2013", "11/4/2013", freq="W-MON", tz="Europe/Paris"),
+            index=date_range(
+                "9/30/2013", "11/4/2013", freq="W-MON", tz="Europe/Paris"
+            ).as_unit(unit),
         ),
         "W-MON Frequency",
     )
@@ -1602,7 +1608,7 @@ def test_resample_dst_anchor():
             },
             index=date_range(
                 "9/30/2013", "11/11/2013", freq="2W-MON", tz="Europe/Paris"
-            ),
+            ).as_unit(unit),
         ),
         "2W-MON Frequency",
     )
@@ -1611,7 +1617,9 @@ def test_resample_dst_anchor():
         df.resample("MS").agg(how)[["a", "b", "c"]],
         DataFrame(
             {"a": [0, 48, 1538], "b": [47, 1537, 1586], "c": [48, 1490, 49]},
-            index=date_range("9/1/2013", "11/1/2013", freq="MS", tz="Europe/Paris"),
+            index=date_range(
+                "9/1/2013", "11/1/2013", freq="MS", tz="Europe/Paris"
+            ).as_unit(unit),
         ),
         "MS Frequency",
     )
@@ -1620,7 +1628,9 @@ def test_resample_dst_anchor():
         df.resample("2MS").agg(how)[["a", "b", "c"]],
         DataFrame(
             {"a": [0, 1538], "b": [1537, 1586], "c": [1538, 49]},
-            index=date_range("9/1/2013", "11/1/2013", freq="2MS", tz="Europe/Paris"),
+            index=date_range(
+                "9/1/2013", "11/1/2013", freq="2MS", tz="Europe/Paris"
+            ).as_unit(unit),
         ),
         "2MS Frequency",
     )
@@ -1636,32 +1646,34 @@ def test_resample_dst_anchor():
                 "b": [1295, 1345, 1393, 1441],
                 "c": [48, 50, 48, 48],
             },
-            index=date_range("10/26/2013", "10/29/2013", freq="D", tz="Europe/Paris"),
+            index=date_range(
+                "10/26/2013", "10/29/2013", freq="D", tz="Europe/Paris"
+            ).as_unit(unit),
         ),
         "D Frequency",
     )
 
 
-def test_downsample_across_dst():
+def test_downsample_across_dst(unit):
     # GH 8531
     tz = pytz.timezone("Europe/Berlin")
     dt = datetime(2014, 10, 26)
-    dates = date_range(tz.localize(dt), periods=4, freq="2H")
+    dates = date_range(tz.localize(dt), periods=4, freq="2H").as_unit(unit)
     result = Series(5, index=dates).resample("H").mean()
     expected = Series(
         [5.0, np.nan] * 3 + [5.0],
-        index=date_range(tz.localize(dt), periods=7, freq="H"),
+        index=date_range(tz.localize(dt), periods=7, freq="H").as_unit(unit),
     )
     tm.assert_series_equal(result, expected)
 
 
-def test_downsample_across_dst_weekly():
+def test_downsample_across_dst_weekly(unit):
     # GH 9119, GH 21459
     df = DataFrame(
         index=DatetimeIndex(
             ["2017-03-25", "2017-03-26", "2017-03-27", "2017-03-28", "2017-03-29"],
             tz="Europe/Amsterdam",
-        ),
+        ).as_unit(unit),
         data=[11, 12, 13, 14, 15],
     )
     result = df.resample("1W").sum()
@@ -1669,28 +1681,32 @@ def test_downsample_across_dst_weekly():
         [23, 42],
         index=DatetimeIndex(
             ["2017-03-26", "2017-04-02"], tz="Europe/Amsterdam", freq="W"
-        ),
+        ).as_unit(unit),
     )
     tm.assert_frame_equal(result, expected)
 
 
-def test_downsample_across_dst_weekly_2():
+def test_downsample_across_dst_weekly_2(unit):
     # GH 9119, GH 21459
-    idx = date_range("2013-04-01", "2013-05-01", tz="Europe/London", freq="H")
+    idx = date_range("2013-04-01", "2013-05-01", tz="Europe/London", freq="H").as_unit(
+        unit
+    )
     s = Series(index=idx, dtype=np.float64)
     result = s.resample("W").mean()
     expected = Series(
-        index=date_range("2013-04-07", freq="W", periods=5, tz="Europe/London"),
+        index=date_range("2013-04-07", freq="W", periods=5, tz="Europe/London").as_unit(
+            unit
+        ),
         dtype=np.float64,
     )
     tm.assert_series_equal(result, expected)
 
 
-def test_downsample_dst_at_midnight():
+def test_downsample_dst_at_midnight(unit):
     # GH 25758
     start = datetime(2018, 11, 3, 12)
     end = datetime(2018, 11, 5, 12)
-    index = date_range(start, end, freq="1H")
+    index = date_range(start, end, freq="1H").as_unit(unit)
     index = index.tz_localize("UTC").tz_convert("America/Havana")
     data = list(range(len(index)))
     dataframe = DataFrame(data, index=index)
@@ -1699,7 +1715,7 @@ def test_downsample_dst_at_midnight():
     dti = date_range("2018-11-03", periods=3).tz_localize(
         "America/Havana", ambiguous=True
     )
-    dti = DatetimeIndex(dti, freq="D")
+    dti = DatetimeIndex(dti, freq="D").as_unit(unit)
     expected = DataFrame([7.5, 28.0, 44.5], index=dti)
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -1114,21 +1114,17 @@ def test_monthly_resample_error(unit):
     ts.resample("M")
 
 
-def test_nanosecond_resample_error(unit):
+def test_nanosecond_resample_error():
     # GH 12307 - Values falls after last bin when
     # Resampling using pd.tseries.offsets.Nano as period
     start = 1443707890427
     exp_start = 1443707890400
-    indx = date_range(start=pd.to_datetime(start), periods=10, freq="100n").as_unit(
-        unit
-    )
+    indx = date_range(start=pd.to_datetime(start), periods=10, freq="100n")
     ts = Series(range(len(indx)), index=indx)
     r = ts.resample(pd.tseries.offsets.Nano(100))
     result = r.agg("mean")
 
-    exp_indx = date_range(
-        start=pd.to_datetime(exp_start), periods=10, freq="100n"
-    ).as_unit(unit)
+    exp_indx = date_range(start=pd.to_datetime(exp_start), periods=10, freq="100n")
     exp = Series(range(len(exp_indx)), index=exp_indx, dtype=float)
 
     tm.assert_series_equal(result, exp)

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -284,7 +284,7 @@ def test_resample_how_callables(unit):
     tm.assert_frame_equal(df_standard, df_class)
 
 
-def test_resample_rounding():
+def test_resample_rounding(unit):
     # GH 8371
     # odd results when rounding is needed
 
@@ -314,43 +314,49 @@ def test_resample_rounding():
         parse_dates={"timestamp": ["date", "time"]},
         index_col="timestamp",
     )
+    df.index = df.index.as_unit(unit)
     df.index.name = None
     result = df.resample("6s").sum()
     expected = DataFrame(
-        {"value": [4, 9, 4, 2]}, index=date_range("2014-11-08", freq="6s", periods=4)
+        {"value": [4, 9, 4, 2]},
+        index=date_range("2014-11-08", freq="6s", periods=4).as_unit(unit),
     )
     tm.assert_frame_equal(result, expected)
 
     result = df.resample("7s").sum()
     expected = DataFrame(
-        {"value": [4, 10, 4, 1]}, index=date_range("2014-11-08", freq="7s", periods=4)
+        {"value": [4, 10, 4, 1]},
+        index=date_range("2014-11-08", freq="7s", periods=4).as_unit(unit),
     )
     tm.assert_frame_equal(result, expected)
 
     result = df.resample("11s").sum()
     expected = DataFrame(
-        {"value": [11, 8]}, index=date_range("2014-11-08", freq="11s", periods=2)
+        {"value": [11, 8]},
+        index=date_range("2014-11-08", freq="11s", periods=2).as_unit(unit),
     )
     tm.assert_frame_equal(result, expected)
 
     result = df.resample("13s").sum()
     expected = DataFrame(
-        {"value": [13, 6]}, index=date_range("2014-11-08", freq="13s", periods=2)
+        {"value": [13, 6]},
+        index=date_range("2014-11-08", freq="13s", periods=2).as_unit(unit),
     )
     tm.assert_frame_equal(result, expected)
 
     result = df.resample("17s").sum()
     expected = DataFrame(
-        {"value": [16, 3]}, index=date_range("2014-11-08", freq="17s", periods=2)
+        {"value": [16, 3]},
+        index=date_range("2014-11-08", freq="17s", periods=2).as_unit(unit),
     )
     tm.assert_frame_equal(result, expected)
 
 
-def test_resample_basic_from_daily():
+def test_resample_basic_from_daily(unit):
     # from daily
     dti = date_range(
         start=datetime(2005, 1, 1), end=datetime(2005, 1, 10), freq="D", name="index"
-    )
+    ).as_unit(unit)
 
     s = Series(np.random.rand(len(dti)), dti)
 
@@ -404,10 +410,10 @@ def test_resample_basic_from_daily():
     assert result.index.name == "index"
 
 
-def test_resample_upsampling_picked_but_not_correct():
+def test_resample_upsampling_picked_but_not_correct(unit):
 
     # Test for issue #3020
-    dates = date_range("01-Jan-2014", "05-Jan-2014", freq="D")
+    dates = date_range("01-Jan-2014", "05-Jan-2014", freq="D").as_unit(unit)
     series = Series(1, index=dates)
 
     result = series.resample("D").mean()
@@ -420,8 +426,10 @@ def test_resample_upsampling_picked_but_not_correct():
     s = Series(
         np.arange(1.0, 6), index=[datetime(1975, 1, i, 12, 0) for i in range(1, 6)]
     )
+    s.index = s.index.as_unit(unit)
     expected = Series(
-        np.arange(1.0, 6), index=date_range("19750101", periods=5, freq="D")
+        np.arange(1.0, 6),
+        index=date_range("19750101", periods=5, freq="D").as_unit(unit),
     )
 
     result = s.resample("D").count()
@@ -434,8 +442,9 @@ def test_resample_upsampling_picked_but_not_correct():
 
 
 @pytest.mark.parametrize("f", ["sum", "mean", "prod", "min", "max", "var"])
-def test_resample_frame_basic_cy_funcs(f):
+def test_resample_frame_basic_cy_funcs(f, unit):
     df = tm.makeTimeDataFrame()
+    df.index = df.index.as_unit(unit)
 
     b = Grouper(freq="M")
     g = df.groupby(b)
@@ -445,23 +454,25 @@ def test_resample_frame_basic_cy_funcs(f):
 
 
 @pytest.mark.parametrize("freq", ["A", "M"])
-def test_resample_frame_basic_M_A(freq):
+def test_resample_frame_basic_M_A(freq, unit):
     df = tm.makeTimeDataFrame()
+    df.index = df.index.as_unit(unit)
     result = df.resample(freq).mean()
     tm.assert_series_equal(result["A"], df["A"].resample(freq).mean())
 
 
 @pytest.mark.parametrize("freq", ["W-WED", "M"])
-def test_resample_frame_basic_kind(freq):
+def test_resample_frame_basic_kind(freq, unit):
     df = tm.makeTimeDataFrame()
+    df.index = df.index.as_unit(unit)
     df.resample(freq, kind="period").mean()
 
 
-def test_resample_upsample():
+def test_resample_upsample(unit):
     # from daily
     dti = date_range(
         start=datetime(2005, 1, 1), end=datetime(2005, 1, 10), freq="D", name="index"
-    )
+    ).as_unit(unit)
 
     s = Series(np.random.rand(len(dti)), dti)
 
@@ -474,7 +485,7 @@ def test_resample_upsample():
     assert result.index.name == "index"
 
 
-def test_resample_how_method():
+def test_resample_how_method(unit):
     # GH9915
     s = Series(
         [11, 22],
@@ -483,6 +494,7 @@ def test_resample_how_method():
             Timestamp("2015-03-31 21:49:52.739000"),
         ],
     )
+    s.index = s.index.as_unit(unit)
     expected = Series(
         [11, np.NaN, np.NaN, np.NaN, np.NaN, np.NaN, 22],
         index=DatetimeIndex(
@@ -498,22 +510,23 @@ def test_resample_how_method():
             freq="10s",
         ),
     )
+    expected.index = expected.index.as_unit(unit)
     tm.assert_series_equal(s.resample("10S").mean(), expected)
 
 
-def test_resample_extra_index_point():
+def test_resample_extra_index_point(unit):
     # GH#9756
-    index = date_range(start="20150101", end="20150331", freq="BM")
+    index = date_range(start="20150101", end="20150331", freq="BM").as_unit(unit)
     expected = DataFrame({"A": Series([21, 41, 63], index=index)})
 
-    index = date_range(start="20150101", end="20150331", freq="B")
+    index = date_range(start="20150101", end="20150331", freq="B").as_unit(unit)
     df = DataFrame({"A": Series(range(len(index)), index=index)}, dtype="int64")
     result = df.resample("BM").last()
     tm.assert_frame_equal(result, expected)
 
 
-def test_upsample_with_limit():
-    rng = date_range("1/1/2000", periods=3, freq="5t")
+def test_upsample_with_limit(unit):
+    rng = date_range("1/1/2000", periods=3, freq="5t").as_unit(unit)
     ts = Series(np.random.randn(len(rng)), rng)
 
     result = ts.resample("t").ffill(limit=2)
@@ -523,9 +536,11 @@ def test_upsample_with_limit():
 
 @pytest.mark.parametrize("freq", ["5D", "10H", "5Min", "10S"])
 @pytest.mark.parametrize("rule", ["Y", "3M", "15D", "30H", "15Min", "30S"])
-def test_nearest_upsample_with_limit(tz_aware_fixture, freq, rule):
+def test_nearest_upsample_with_limit(tz_aware_fixture, freq, rule, unit):
     # GH 33939
-    rng = date_range("1/1/2000", periods=3, freq=freq, tz=tz_aware_fixture)
+    rng = date_range("1/1/2000", periods=3, freq=freq, tz=tz_aware_fixture).as_unit(
+        unit
+    )
     ts = Series(np.random.randn(len(rng)), rng)
 
     result = ts.resample(rule).nearest(limit=2)

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -1114,17 +1114,21 @@ def test_monthly_resample_error(unit):
     ts.resample("M")
 
 
-def test_nanosecond_resample_error():
+def test_nanosecond_resample_error(unit):
     # GH 12307 - Values falls after last bin when
     # Resampling using pd.tseries.offsets.Nano as period
     start = 1443707890427
     exp_start = 1443707890400
-    indx = date_range(start=pd.to_datetime(start), periods=10, freq="100n")
+    indx = date_range(start=pd.to_datetime(start), periods=10, freq="100n").as_unit(
+        unit
+    )
     ts = Series(range(len(indx)), index=indx)
     r = ts.resample(pd.tseries.offsets.Nano(100))
     result = r.agg("mean")
 
-    exp_indx = date_range(start=pd.to_datetime(exp_start), periods=10, freq="100n")
+    exp_indx = date_range(
+        start=pd.to_datetime(exp_start), periods=10, freq="100n"
+    ).as_unit(unit)
     exp = Series(range(len(exp_indx)), index=exp_indx, dtype=float)
 
     tm.assert_series_equal(result, exp)


### PR DESCRIPTION
- [ ] closes #50656  (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Ideally https://github.com/pandas-dev/pandas/pull/50773 would be merged first so I can rebase

Parametrising all these tests over `unit` helped unearth both https://github.com/pandas-dev/pandas/issues/50727 and #50716 so it's probably worthwhile
