### PR TITLE
DEPR: remove Int/Uint/Float64Index from pandas/tests/indexing & pandas/tests/series

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -133,7 +133,6 @@ from pandas.core.indexers import (
 from pandas.core.indexes.accessors import CombinedDatetimelikeProperties
 from pandas.core.indexes.api import (
     DatetimeIndex,
-    Float64Index,
     Index,
     MultiIndex,
     PeriodIndex,
@@ -2572,7 +2571,8 @@ Name: Max Speed, dtype: float64
 
         if is_list_like(q):
             result.name = self.name
-            return self._constructor(result, index=Float64Index(q), name=self.name)
+            idx = Index(q, dtype=np.float64)
+            return self._constructor(result, index=idx, name=self.name)
         else:
             # scalar
             return result.iloc[0]

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -70,6 +70,7 @@ from pandas.core.dtypes.common import (
     is_datetime64_dtype,
     is_datetime64tz_dtype,
     is_extension_array_dtype,
+    is_integer_dtype,
     is_list_like,
     is_string_dtype,
     is_timedelta64_dtype,
@@ -88,7 +89,7 @@ from pandas import (
     concat,
     isna,
 )
-from pandas.core.api import Int64Index
+from pandas.core.api import NumericIndex
 from pandas.core.arrays import (
     Categorical,
     DatetimeArray,
@@ -2242,13 +2243,13 @@ class GenericIndexCol(IndexCol):
     def is_indexed(self) -> bool:
         return False
 
-    # error: Return type "Tuple[Int64Index, Int64Index]" of "convert"
+    # error: Return type "Tuple[NumericIndex, NumericIndex]" of "convert"
     # incompatible with return type "Union[Tuple[ndarray[Any, Any],
     # ndarray[Any, Any]], Tuple[DatetimeIndex, DatetimeIndex]]" in
     # supertype "IndexCol"
     def convert(  # type: ignore[override]
         self, values: np.ndarray, nan_rep, encoding: str, errors: str
-    ) -> tuple[Int64Index, Int64Index]:
+    ) -> tuple[NumericIndex, NumericIndex]:
         """
         Convert the data from this selection to the appropriate pandas type.
 
@@ -2261,7 +2262,7 @@ class GenericIndexCol(IndexCol):
         """
         assert isinstance(values, np.ndarray), type(values)
 
-        index = Int64Index(np.arange(len(values)))
+        index = NumericIndex(np.arange(len(values)), dtype=np.int64)
         return index, index
 
     def set_attr(self) -> None:
@@ -4864,11 +4865,11 @@ def _convert_index(name: str, index: Index, encoding: str, errors: str) -> Index
     atom = DataIndexableCol._get_atom(converted)
 
     if (
-        isinstance(index, Int64Index)
+        (isinstance(index, NumericIndex) and is_integer_dtype(index))
         or needs_i8_conversion(index.dtype)
         or is_bool_dtype(index.dtype)
     ):
-        # Includes Int64Index, RangeIndex, DatetimeIndex, TimedeltaIndex, PeriodIndex,
+        # Includes NumericIndex, RangeIndex, DatetimeIndex, TimedeltaIndex, PeriodIndex,
         #  in which case "kind" is "integer", "integer", "datetime64",
         #  "timedelta64", and "integer", respectively.
         return IndexCol(

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -28,12 +28,7 @@ from pandas import (
     isna,
 )
 import pandas._testing as tm
-from pandas.core.api import (  # noqa:F401
-    Float64Index,
-    Int64Index,
-    NumericIndex,
-    UInt64Index,
-)
+from pandas.core.api import NumericIndex
 from pandas.core.arrays import BaseMaskedArray
 
 
@@ -322,7 +317,9 @@ class Base:
     def test_repeat(self, simple_index):
         rep = 2
         idx = simple_index.copy()
-        new_index_cls = Int64Index if isinstance(idx, RangeIndex) else idx._constructor
+        new_index_cls = (
+            NumericIndex if isinstance(idx, RangeIndex) else idx._constructor
+        )
         expected = new_index_cls(idx.values.repeat(rep), name=idx.name)
         tm.assert_index_equal(idx.repeat(rep), expected)
 
@@ -505,7 +502,6 @@ class Base:
             # assuming the 2nd to last item is unique in the data
             item = index_a[-2]
             tm.assert_numpy_array_equal(index_a == item, expected3)
-            # For RangeIndex we can convert to Int64Index
             tm.assert_series_equal(series_a == item, Series(expected3))
 
     def test_format(self, simple_index):
@@ -596,7 +592,7 @@ class Base:
         idx = simple_index
 
         result = idx.map(lambda x: x)
-        # For RangeIndex we convert to Int64Index
+        # RangeIndex are equivalent to the similar NumericIndex with int64 dtype
         tm.assert_index_equal(result, idx, exact="equiv")
 
     @pytest.mark.parametrize(
@@ -619,7 +615,7 @@ class Base:
         identity = mapper(idx.values, idx)
 
         result = idx.map(identity)
-        # For RangeIndex we convert to Int64Index
+        # RangeIndex are equivalent to the similar NumericIndex with int64 dtype
         tm.assert_index_equal(result, idx, exact="equiv")
 
         # empty mappable
@@ -910,19 +906,19 @@ class NumericBase(Base):
 
         # float conversions
         arr = np.arange(5, dtype="int64") * 3.2
-        expected = Float64Index(arr)
+        expected = NumericIndex(arr, dtype=np.float64)
         fidx = idx * 3.2
         tm.assert_index_equal(fidx, expected)
         fidx = 3.2 * idx
         tm.assert_index_equal(fidx, expected)
 
         # interops with numpy arrays
-        expected = Float64Index(arr)
+        expected = NumericIndex(arr, dtype=np.float64)
         a = np.zeros(5, dtype="float64")
         result = fidx - a
         tm.assert_index_equal(result, expected)
 
-        expected = Float64Index(-arr)
+        expected = NumericIndex(-arr, dtype=np.float64)
         a = np.zeros(5, dtype="float64")
         result = a - fidx
         tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/conftest.py
+++ b/pandas/tests/indexes/conftest.py
@@ -45,15 +45,15 @@ def listlike_box(request):
 @pytest.fixture(
     params=[
         *tm.ALL_REAL_NUMPY_DTYPES,
-        "datetime64[ns]",
-        "category",
         "object",
+        "category",
+        "datetime64[ns]",
         "timedelta64[ns]",
     ]
 )
-def any_numpy_dtype_for_small_integer_indexes(request):
+def any_numpy_dtype_for_small_pos_integer_indexes(request):
     """
-    Dtypes that can be given to an Index with small integers.
+    Dtypes that can be given to an Index with small positive integers.
 
     This means that for any dtype `x` in the params list, `Index([1, 2, 3], dtype=x)` is
     valid and gives the correct Index (sub-)class.

--- a/pandas/tests/indexes/conftest.py
+++ b/pandas/tests/indexes/conftest.py
@@ -5,6 +5,7 @@ from pandas import (
     Series,
     array,
 )
+import pandas._testing as tm
 
 
 @pytest.fixture(params=[None, False])
@@ -37,5 +38,24 @@ def freq_sample(request):
 def listlike_box(request):
     """
     Types that may be passed as the indexer to searchsorted.
+    """
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        *tm.ALL_REAL_NUMPY_DTYPES,
+        "datetime64[ns]",
+        "category",
+        "object",
+        "timedelta64[ns]",
+    ]
+)
+def any_numpy_dtype_for_small_integer_indexes(request):
+    """
+    Dtypes that can be given to an Index with small integers.
+
+    This means that for any dtype `x` in the params list, `Index([1, 2, 3], dtype=x)` is
+    valid and gives the correct Index (sub-)class.
     """
     return request.param

--- a/pandas/tests/indexes/datetimes/methods/test_astype.py
+++ b/pandas/tests/indexes/datetimes/methods/test_astype.py
@@ -43,11 +43,6 @@ class TestDatetimeIndex:
 
     def test_astype_uint(self):
         arr = date_range("2000", periods=2, name="idx")
-        expected = Index(
-            np.array([946684800000000000, 946771200000000000], dtype="uint64"),
-            name="idx",
-        )
-        tm.assert_index_equal(arr.astype("uint64"), expected)
 
         with pytest.raises(TypeError, match=r"Do obj.astype\('int64'\)"):
             arr.astype("uint64")

--- a/pandas/tests/indexes/datetimes/methods/test_astype.py
+++ b/pandas/tests/indexes/datetimes/methods/test_astype.py
@@ -15,7 +15,6 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 
 
 class TestDatetimeIndex:
@@ -30,7 +29,7 @@ class TestDatetimeIndex:
         tm.assert_index_equal(result, expected)
 
         result = idx.astype(np.int64)
-        expected = Int64Index(
+        expected = Index(
             [1463356800000000000] + [-9223372036854775808] * 3,
             dtype=np.int64,
             name="idx",
@@ -44,6 +43,11 @@ class TestDatetimeIndex:
 
     def test_astype_uint(self):
         arr = date_range("2000", periods=2, name="idx")
+        expected = Index(
+            np.array([946684800000000000, 946771200000000000], dtype="uint64"),
+            name="idx",
+        )
+        tm.assert_index_equal(arr.astype("uint64"), expected)
 
         with pytest.raises(TypeError, match=r"Do obj.astype\('int64'\)"):
             arr.astype("uint64")

--- a/pandas/tests/indexes/datetimes/test_scalar_compat.py
+++ b/pandas/tests/indexes/datetimes/test_scalar_compat.py
@@ -19,7 +19,6 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Float64Index
 
 
 class TestDatetimeIndexOps:
@@ -316,33 +315,33 @@ class TestDateTimeIndexToJulianDate:
         dr = date_range(start=Timestamp("1710-10-01"), periods=5, freq="D")
         r1 = pd.Index([x.to_julian_date() for x in dr])
         r2 = dr.to_julian_date()
-        assert isinstance(r2, Float64Index)
+        assert isinstance(r2, pd.Index) and r2.dtype == np.float64
         tm.assert_index_equal(r1, r2)
 
     def test_2000(self):
         dr = date_range(start=Timestamp("2000-02-27"), periods=5, freq="D")
         r1 = pd.Index([x.to_julian_date() for x in dr])
         r2 = dr.to_julian_date()
-        assert isinstance(r2, Float64Index)
+        assert isinstance(r2, pd.Index) and r2.dtype == np.float64
         tm.assert_index_equal(r1, r2)
 
     def test_hour(self):
         dr = date_range(start=Timestamp("2000-02-27"), periods=5, freq="H")
         r1 = pd.Index([x.to_julian_date() for x in dr])
         r2 = dr.to_julian_date()
-        assert isinstance(r2, Float64Index)
+        assert isinstance(r2, pd.Index) and r2.dtype == np.float64
         tm.assert_index_equal(r1, r2)
 
     def test_minute(self):
         dr = date_range(start=Timestamp("2000-02-27"), periods=5, freq="T")
         r1 = pd.Index([x.to_julian_date() for x in dr])
         r2 = dr.to_julian_date()
-        assert isinstance(r2, Float64Index)
+        assert isinstance(r2, pd.Index) and r2.dtype == np.float64
         tm.assert_index_equal(r1, r2)
 
     def test_second(self):
         dr = date_range(start=Timestamp("2000-02-27"), periods=5, freq="S")
         r1 = pd.Index([x.to_julian_date() for x in dr])
         r2 = dr.to_julian_date()
-        assert isinstance(r2, Float64Index)
+        assert isinstance(r2, pd.Index) and r2.dtype == np.float64
         tm.assert_index_equal(r1, r2)

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -16,7 +16,6 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 
 from pandas.tseries.offsets import (
     BMonthEnd,
@@ -184,7 +183,7 @@ class TestDatetimeIndexSetOps:
         tm.assert_index_equal(df.index, exp)
 
     def test_union_with_DatetimeIndex(self, sort):
-        i1 = Int64Index(np.arange(0, 20, 2))
+        i1 = Index(np.arange(0, 20, 2, dtype=np.int64))
         i2 = date_range(start="2012-01-03 00:00:00", periods=10, freq="D")
         # Works
         i1.union(i2, sort=sort)

--- a/pandas/tests/indexes/interval/test_formats.py
+++ b/pandas/tests/indexes/interval/test_formats.py
@@ -3,6 +3,7 @@ import pytest
 
 from pandas import (
     DataFrame,
+    Index,
     Interval,
     IntervalIndex,
     Series,
@@ -10,7 +11,6 @@ from pandas import (
     Timestamp,
 )
 import pandas._testing as tm
-from pandas.core.api import Float64Index
 
 
 class TestIntervalIndexRendering:
@@ -54,8 +54,8 @@ class TestIntervalIndexRendering:
                 [
                     Interval(left, right)
                     for left, right in zip(
-                        Float64Index([329.973, 345.137], dtype="float64"),
-                        Float64Index([345.137, 360.191], dtype="float64"),
+                        Index([329.973, 345.137], dtype="float64"),
+                        Index([345.137, 360.191], dtype="float64"),
                     )
                 ]
             ),

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -18,7 +18,6 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Float64Index
 import pandas.core.common as com
 
 
@@ -406,7 +405,7 @@ class TestIntervalIndex:
         index = IntervalIndex.from_breaks(breaks)
 
         to_convert = breaks._constructor([pd.NaT] * 3)
-        expected = Float64Index([np.nan] * 3)
+        expected = Index([np.nan] * 3, dtype=np.float64)
         result = index._maybe_convert_i8(to_convert)
         tm.assert_index_equal(result, expected)
 

--- a/pandas/tests/indexes/multi/test_analytics.py
+++ b/pandas/tests/indexes/multi/test_analytics.py
@@ -9,7 +9,6 @@ from pandas import (
     period_range,
 )
 import pandas._testing as tm
-from pandas.core.api import UInt64Index
 
 
 def test_infer_objects(idx):
@@ -196,8 +195,8 @@ def test_map_dictlike(idx, mapper):
 
     identity = mapper(idx.values, idx)
 
-    # we don't infer to UInt64 for a dict
-    if isinstance(idx, UInt64Index) and isinstance(identity, dict):
+    # we don't infer to uint64 dtype for a dict
+    if idx.dtype == np.uint64 and isinstance(identity, dict):
         expected = idx.astype("int64")
     else:
         expected = idx

--- a/pandas/tests/indexes/multi/test_integrity.py
+++ b/pandas/tests/indexes/multi/test_integrity.py
@@ -7,12 +7,12 @@ from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
 
 import pandas as pd
 from pandas import (
+    Index,
     IntervalIndex,
     MultiIndex,
     RangeIndex,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 
 
 def test_labels_dtypes():
@@ -84,8 +84,8 @@ def test_values_multiindex_periodindex():
     idx = MultiIndex.from_arrays([ints, pidx])
     result = idx.values
 
-    outer = Int64Index([x[0] for x in result])
-    tm.assert_index_equal(outer, Int64Index(ints))
+    outer = Index([x[0] for x in result])
+    tm.assert_index_equal(outer, Index(ints, dtype=np.int64))
 
     inner = pd.PeriodIndex([x[1] for x in result])
     tm.assert_index_equal(inner, pidx)
@@ -93,8 +93,8 @@ def test_values_multiindex_periodindex():
     # n_lev > n_lab
     result = idx[:2].values
 
-    outer = Int64Index([x[0] for x in result])
-    tm.assert_index_equal(outer, Int64Index(ints[:2]))
+    outer = Index([x[0] for x in result])
+    tm.assert_index_equal(outer, Index(ints[:2], dtype=np.int64))
 
     inner = pd.PeriodIndex([x[1] for x in result])
     tm.assert_index_equal(inner, pidx[:2])
@@ -246,11 +246,11 @@ def test_rangeindex_fallback_coercion_bug():
     tm.assert_frame_equal(df, expected, check_like=True)
 
     result = df.index.get_level_values("fizz")
-    expected = Int64Index(np.arange(10), name="fizz").repeat(10)
+    expected = Index(np.arange(10, dtype=np.int64), name="fizz").repeat(10)
     tm.assert_index_equal(result, expected)
 
     result = df.index.get_level_values("buzz")
-    expected = Int64Index(np.tile(np.arange(10), 10), name="buzz")
+    expected = Index(np.tile(np.arange(10, dtype=np.int64), 10), name="buzz")
     tm.assert_index_equal(result, expected)
 
 

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -20,10 +20,6 @@ from pandas import (
     period_range,
 )
 import pandas._testing as tm
-from pandas.core.api import (
-    Float64Index,
-    Int64Index,
-)
 
 dti4 = date_range("2016-01-01", periods=4)
 dti = dti4[:-1]
@@ -806,10 +802,10 @@ class TestAsOfLocs:
 
         msg = "must be DatetimeIndex or PeriodIndex"
         with pytest.raises(TypeError, match=msg):
-            pi.asof_locs(Int64Index(pi.asi8), mask)
+            pi.asof_locs(pd.Index(pi.asi8, dtype=np.int64), mask)
 
         with pytest.raises(TypeError, match=msg):
-            pi.asof_locs(Float64Index(pi.asi8), mask)
+            pi.asof_locs(pd.Index(pi.asi8, dtype=np.float64), mask)
 
         with pytest.raises(TypeError, match=msg):
             # TimedeltaIndex

--- a/pandas/tests/indexes/ranges/test_indexing.py
+++ b/pandas/tests/indexes/ranges/test_indexing.py
@@ -1,9 +1,11 @@
 import numpy as np
 import pytest
 
-from pandas import RangeIndex
+from pandas import (
+    Index,
+    RangeIndex,
+)
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 
 
 class TestGetIndexer:
@@ -55,7 +57,7 @@ class TestTake:
         # GH#12631
         idx = RangeIndex(1, 4, name="xxx")
         result = idx.take(np.array([1, 0, -1]))
-        expected = Int64Index([2, 1, 3], name="xxx")
+        expected = Index([2, 1, 3], dtype=np.int64, name="xxx")
         tm.assert_index_equal(result, expected)
 
         # fill_value
@@ -65,7 +67,7 @@ class TestTake:
 
         # allow_fill=False
         result = idx.take(np.array([1, 0, -1]), allow_fill=False, fill_value=True)
-        expected = Int64Index([2, 1, 3], name="xxx")
+        expected = Index([2, 1, 3], dtype=np.int64, name="xxx")
         tm.assert_index_equal(result, expected)
 
         msg = "Unable to fill values because RangeIndex cannot contain NA"
@@ -86,7 +88,7 @@ class TestWhere:
 
         mask = np.array([True, True, False, False, False])
         result = idx.putmask(mask, 10)
-        expected = Int64Index([10, 10, 2, 3, 4], name="test")
+        expected = Index([10, 10, 2, 3, 4], dtype=np.int64, name="test")
         tm.assert_index_equal(result, expected)
 
         result = idx.where(~mask, 10)

--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -15,12 +15,10 @@ from pandas.core.dtypes.cast import find_common_type
 
 from pandas import (
     CategoricalIndex,
-    DatetimeIndex,
     Index,
     MultiIndex,
     RangeIndex,
     Series,
-    TimedeltaIndex,
     Timestamp,
 )
 import pandas._testing as tm
@@ -29,11 +27,6 @@ from pandas.api.types import (
     is_datetime64tz_dtype,
     is_signed_integer_dtype,
     pandas_dtype,
-)
-from pandas.core.api import (
-    Float64Index,
-    Int64Index,
-    UInt64Index,
 )
 
 
@@ -77,7 +70,7 @@ def test_union_different_types(index_flat, index_flat2, request):
         # idx1 = Index(
         # [True, True, True, True, True, True, True, True, False, False], dtype='bool'
         # )
-        # idx2 = Int64Index([0, 0, 1, 1, 2, 2], dtype='int64')
+        # idx2 = Index([0, 0, 1, 1, 2, 2], dtype='int64')
         mark = pytest.mark.xfail(
             reason="GH#44000 True==1", raises=ValueError, strict=False
         )
@@ -567,24 +560,15 @@ def test_intersection_duplicates_all_indexes(index):
     assert idx.intersection(idx_non_unique).is_unique
 
 
-@pytest.mark.parametrize(
-    "cls",
-    [
-        Int64Index,
-        Float64Index,
-        DatetimeIndex,
-        CategoricalIndex,
-        lambda x: CategoricalIndex(x, categories=set(x)),
-        TimedeltaIndex,
-        lambda x: Index(x, dtype=object),
-        UInt64Index,
-    ],
-)
-def test_union_duplicate_index_subsets_of_each_other(cls):
+def test_union_duplicate_index_subsets_of_each_other(
+    any_numpy_dtype_for_small_integer_indexes,
+):
     # GH#31326
-    a = cls([1, 2, 2, 3])
-    b = cls([3, 3, 4])
-    expected = cls([1, 2, 2, 3, 3, 4])
+    dtype = any_numpy_dtype_for_small_integer_indexes
+    a = Index([1, 2, 2, 3], dtype=dtype)
+    b = Index([3, 3, 4], dtype=dtype)
+
+    expected = Index([1, 2, 2, 3, 3, 4], dtype=dtype)
     if isinstance(a, CategoricalIndex):
         expected = Index([1, 2, 2, 3, 3, 4])
     result = a.union(b)
@@ -593,22 +577,14 @@ def test_union_duplicate_index_subsets_of_each_other(cls):
     tm.assert_index_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    "cls",
-    [
-        Int64Index,
-        Float64Index,
-        DatetimeIndex,
-        CategoricalIndex,
-        TimedeltaIndex,
-        lambda x: Index(x, dtype=object),
-    ],
-)
-def test_union_with_duplicate_index_and_non_monotonic(cls):
+def test_union_with_duplicate_index_and_non_monotonic(
+    any_numpy_dtype_for_small_integer_indexes,
+):
     # GH#36289
-    a = cls([1, 0, 0])
-    b = cls([0, 1])
-    expected = cls([0, 0, 1])
+    dtype = any_numpy_dtype_for_small_integer_indexes
+    a = Index([1, 0, 0], dtype=dtype)
+    b = Index([0, 1], dtype=dtype)
+    expected = Index([0, 0, 1], dtype=dtype)
 
     result = a.union(b)
     tm.assert_index_equal(result, expected)
@@ -645,21 +621,16 @@ def test_union_nan_in_both(dup):
     tm.assert_index_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    "cls",
-    [
-        Int64Index,
-        Float64Index,
-        DatetimeIndex,
-        TimedeltaIndex,
-        lambda x: Index(x, dtype=object),
-    ],
-)
-def test_union_with_duplicate_index_not_subset_and_non_monotonic(cls):
+def test_union_with_duplicate_index_not_subset_and_non_monotonic(
+    any_numpy_dtype_for_small_integer_indexes,
+):
     # GH#36289
-    a = cls([1, 0, 2])
-    b = cls([0, 0, 1])
-    expected = cls([0, 0, 1, 2])
+    dtype = any_numpy_dtype_for_small_integer_indexes
+    a = Index([1, 0, 2], dtype=dtype)
+    b = Index([0, 0, 1], dtype=dtype)
+    expected = Index([0, 0, 1, 2], dtype=dtype)
+    if isinstance(a, CategoricalIndex):
+        expected = Index([0, 0, 1, 2])
 
     result = a.union(b)
     tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -561,10 +561,10 @@ def test_intersection_duplicates_all_indexes(index):
 
 
 def test_union_duplicate_index_subsets_of_each_other(
-    any_numpy_dtype_for_small_integer_indexes,
+    any_numpy_dtype_for_small_pos_integer_indexes,
 ):
     # GH#31326
-    dtype = any_numpy_dtype_for_small_integer_indexes
+    dtype = any_numpy_dtype_for_small_pos_integer_indexes
     a = Index([1, 2, 2, 3], dtype=dtype)
     b = Index([3, 3, 4], dtype=dtype)
 
@@ -578,10 +578,10 @@ def test_union_duplicate_index_subsets_of_each_other(
 
 
 def test_union_with_duplicate_index_and_non_monotonic(
-    any_numpy_dtype_for_small_integer_indexes,
+    any_numpy_dtype_for_small_pos_integer_indexes,
 ):
     # GH#36289
-    dtype = any_numpy_dtype_for_small_integer_indexes
+    dtype = any_numpy_dtype_for_small_pos_integer_indexes
     a = Index([1, 0, 0], dtype=dtype)
     b = Index([0, 1], dtype=dtype)
     expected = Index([0, 0, 1], dtype=dtype)
@@ -622,10 +622,10 @@ def test_union_nan_in_both(dup):
 
 
 def test_union_with_duplicate_index_not_subset_and_non_monotonic(
-    any_numpy_dtype_for_small_integer_indexes,
+    any_numpy_dtype_for_small_pos_integer_indexes,
 ):
     # GH#36289
-    dtype = any_numpy_dtype_for_small_integer_indexes
+    dtype = any_numpy_dtype_for_small_pos_integer_indexes
     a = Index([1, 0, 2], dtype=dtype)
     b = Index([0, 0, 1], dtype=dtype)
     expected = Index([0, 0, 1, 2], dtype=dtype)

--- a/pandas/tests/indexes/timedeltas/methods/test_astype.py
+++ b/pandas/tests/indexes/timedeltas/methods/test_astype.py
@@ -53,7 +53,7 @@ class TestTimedeltaIndex:
         )
         tm.assert_index_equal(result, expected)
 
-        result = idx.astype(int)
+        result = idx.astype(np.int64)
         expected = Index(
             [100000000000000] + [-9223372036854775808] * 3, dtype=np.int64, name="idx"
         )

--- a/pandas/tests/indexes/timedeltas/methods/test_astype.py
+++ b/pandas/tests/indexes/timedeltas/methods/test_astype.py
@@ -70,8 +70,6 @@ class TestTimedeltaIndex:
 
     def test_astype_uint(self):
         arr = timedelta_range("1H", periods=2)
-        expected = Index(np.array([3600000000000, 90000000000000], dtype="uint64"))
-        tm.assert_index_equal(arr.astype("uint64"), expected)
 
         with pytest.raises(TypeError, match=r"Do obj.astype\('int64'\)"):
             arr.astype("uint64")

--- a/pandas/tests/indexes/timedeltas/methods/test_astype.py
+++ b/pandas/tests/indexes/timedeltas/methods/test_astype.py
@@ -12,7 +12,6 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 
 
 class TestTimedeltaIndex:
@@ -54,8 +53,8 @@ class TestTimedeltaIndex:
         )
         tm.assert_index_equal(result, expected)
 
-        result = idx.astype(np.int64)
-        expected = Int64Index(
+        result = idx.astype(int)
+        expected = Index(
             [100000000000000] + [-9223372036854775808] * 3, dtype=np.int64, name="idx"
         )
         tm.assert_index_equal(result, expected)
@@ -71,6 +70,8 @@ class TestTimedeltaIndex:
 
     def test_astype_uint(self):
         arr = timedelta_range("1H", periods=2)
+        expected = Index(np.array([3600000000000, 90000000000000], dtype="uint64"))
+        tm.assert_index_equal(arr.astype("uint64"), expected)
 
         with pytest.raises(TypeError, match=r"Do obj.astype\('int64'\)"):
             arr.astype("uint64")

--- a/pandas/tests/indexes/timedeltas/test_setops.py
+++ b/pandas/tests/indexes/timedeltas/test_setops.py
@@ -3,11 +3,11 @@ import pytest
 
 import pandas as pd
 from pandas import (
+    Index,
     TimedeltaIndex,
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 
 from pandas.tseries.offsets import Hour
 
@@ -21,7 +21,7 @@ class TestTimedeltaIndex:
         expected = timedelta_range("1day", periods=7)
         tm.assert_index_equal(result, expected)
 
-        i1 = Int64Index(np.arange(0, 20, 2))
+        i1 = Index(np.arange(0, 20, 2, dtype=np.int64))
         i2 = timedelta_range(start="1 day", periods=10, freq="D")
         i1.union(i2)  # Works
         i2.union(i1)  # Fails with "AttributeError: can't set attribute"

--- a/pandas/tests/indexing/conftest.py
+++ b/pandas/tests/indexing/conftest.py
@@ -3,13 +3,10 @@ import pytest
 
 from pandas import (
     DataFrame,
+    Index,
     MultiIndex,
     Series,
     date_range,
-)
-from pandas.core.api import (
-    Float64Index,
-    UInt64Index,
 )
 
 
@@ -27,15 +24,15 @@ def frame_ints():
 
 @pytest.fixture
 def series_uints():
-    return Series(np.random.rand(4), index=UInt64Index(np.arange(0, 8, 2)))
+    return Series(np.random.rand(4), index=Index(np.arange(0, 8, 2, dtype=np.uint64)))
 
 
 @pytest.fixture
 def frame_uints():
     return DataFrame(
         np.random.randn(4, 4),
-        index=UInt64Index(range(0, 8, 2)),
-        columns=UInt64Index(range(0, 12, 3)),
+        index=Index(range(0, 8, 2), dtype=np.uint64),
+        columns=Index(range(0, 12, 3), dtype=np.uint64),
     )
 
 
@@ -61,15 +58,15 @@ def frame_ts():
 
 @pytest.fixture
 def series_floats():
-    return Series(np.random.rand(4), index=Float64Index(range(0, 8, 2)))
+    return Series(np.random.rand(4), index=Index(range(0, 8, 2), dtype=np.float64))
 
 
 @pytest.fixture
 def frame_floats():
     return DataFrame(
         np.random.randn(4, 4),
-        index=Float64Index(range(0, 8, 2)),
-        columns=Float64Index(range(0, 12, 3)),
+        index=Index(range(0, 8, 2), dtype=np.float64),
+        columns=Index(range(0, 12, 3), dtype=np.float64),
     )
 
 

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -44,16 +44,18 @@ class TestMultiIndexLoc:
         df.loc[("bar", "two"), 1] = 7
         assert df.loc[("bar", "two"), 1] == 7
 
-    def test_loc_getitem_general(self):
-
+    def test_loc_getitem_general(self, any_real_numpy_dtype):
         # GH#2817
+        dtype = any_real_numpy_dtype
         data = {
             "amount": {0: 700, 1: 600, 2: 222, 3: 333, 4: 444},
             "col": {0: 3.5, 1: 3.5, 2: 4.0, 3: 4.0, 4: 4.0},
-            "year": {0: 2012, 1: 2011, 2: 2012, 3: 2012, 4: 2012},
+            "num": {0: 12, 1: 11, 2: 12, 3: 12, 4: 12},
         }
-        df = DataFrame(data).set_index(keys=["col", "year"])
-        key = 4.0, 2012
+        df = DataFrame(data)
+        df = df.astype({"col": dtype, "num": dtype})
+        df = df.set_index(keys=["col", "num"])
+        key = 4.0, 12
 
         # emits a PerformanceWarning, ok
         with tm.assert_produces_warning(PerformanceWarning):
@@ -64,8 +66,10 @@ class TestMultiIndexLoc:
         assert return_value is None
         res = df.loc[key]
 
-        # col has float dtype, result should be Float64Index
-        index = MultiIndex.from_arrays([[4.0] * 3, [2012] * 3], names=["col", "year"])
+        # col has float dtype, result should be float64 Index
+        col_arr = np.array([4.0] * 3, dtype=dtype)
+        year_arr = np.array([12] * 3, dtype=dtype)
+        index = MultiIndex.from_arrays([col_arr, year_arr], names=["col", "num"])
         expected = DataFrame({"amount": [222, 333, 444]}, index=index)
         tm.assert_frame_equal(res, expected)
 

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -16,7 +16,6 @@ from pandas.compat import (
 
 import pandas as pd
 import pandas._testing as tm
-from pandas.core.api import NumericIndex
 
 ###############################################################
 # Index / Series common tests which may trigger dtype coercions
@@ -207,33 +206,39 @@ class TestInsertIndexCoercion(CoercionBase):
     @pytest.mark.parametrize(
         "insert, coerced_val, coerced_dtype",
         [
-            (1, 1, np.int64),
+            (1, 1, None),
             (1.1, 1.1, np.float64),
             (False, False, object),  # GH#36319
             ("x", "x", object),
         ],
     )
-    def test_insert_index_int64(self, insert, coerced_val, coerced_dtype):
-        obj = NumericIndex([1, 2, 3, 4], dtype=np.int64)
-        assert obj.dtype == np.int64
+    def test_insert_int_index(
+        self, any_int_numpy_dtype, insert, coerced_val, coerced_dtype
+    ):
+        dtype = any_int_numpy_dtype
+        obj = pd.Index([1, 2, 3, 4], dtype=dtype)
+        coerced_dtype = coerced_dtype if coerced_dtype is not None else dtype
 
-        exp = pd.Index([1, coerced_val, 2, 3, 4])
+        exp = pd.Index([1, coerced_val, 2, 3, 4], dtype=coerced_dtype)
         self._assert_insert_conversion(obj, insert, exp, coerced_dtype)
 
     @pytest.mark.parametrize(
         "insert, coerced_val, coerced_dtype",
         [
-            (1, 1.0, np.float64),
+            (1, 1.0, None),
             (1.1, 1.1, np.float64),
             (False, False, object),  # GH#36319
             ("x", "x", object),
         ],
     )
-    def test_insert_index_float64(self, insert, coerced_val, coerced_dtype):
-        obj = NumericIndex([1.0, 2.0, 3.0, 4.0], dtype=np.float64)
-        assert obj.dtype == np.float64
+    def test_insert_float_index(
+        self, float_numpy_dtype, insert, coerced_val, coerced_dtype
+    ):
+        dtype = float_numpy_dtype
+        obj = pd.Index([1.0, 2.0, 3.0, 4.0], dtype=dtype)
+        coerced_dtype = coerced_dtype if coerced_dtype is not None else dtype
 
-        exp = pd.Index([1.0, coerced_val, 2.0, 3.0, 4.0])
+        exp = pd.Index([1.0, coerced_val, 2.0, 3.0, 4.0], dtype=coerced_dtype)
         self._assert_insert_conversion(obj, insert, exp, coerced_dtype)
 
     @pytest.mark.parametrize(

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -531,8 +531,9 @@ class TestFloatIndexers:
         result = indexer_sl(s)[[2.5]]
         tm.assert_series_equal(result, Series([1], index=[2.5]))
 
-    def test_float64index_slicing_bug(self):
+    def test_floatindex_slicing_bug(self, float_numpy_dtype):
         # GH 5557, related to slicing a float index
+        dtype = float_numpy_dtype
         ser = {
             256: 2321.0,
             1: 78.0,
@@ -686,6 +687,7 @@ class TestFloatIndexers:
         }
 
         # smoke test for the repr
-        s = Series(ser)
+        s = Series(ser, dtype=dtype)
         result = s.value_counts()
+        assert result.index.dtype == dtype
         str(result)

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -26,7 +26,6 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Float64Index
 from pandas.tests.indexing.common import _mklbl
 from pandas.tests.indexing.test_floats import gen_obj
 
@@ -167,7 +166,7 @@ class TestFancy:
         assert df.loc[np.inf, 0] == 3
 
         result = df.index
-        expected = Float64Index([1, 2, np.inf])
+        expected = Index([1, 2, np.inf], dtype=np.float64)
         tm.assert_index_equal(result, expected)
 
     def test_setitem_dtype_upcast(self):

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -41,7 +41,6 @@ from pandas.api.types import (
     is_bool_dtype,
     is_scalar,
 )
-from pandas.core.api import Float64Index
 from pandas.core.indexing import _one_ellipsis_message
 from pandas.tests.indexing.common import check_indexing_smoketest_or_raises
 
@@ -1377,9 +1376,10 @@ class TestLocBaseIndependent:
         expected.name = val
         tm.assert_series_equal(result, expected)
 
-    def test_loc_setitem_int_label_with_float64index(self):
+    def test_loc_setitem_int_label_with_float_index(self, float_numpy_dtype):
         # note labels are floats
-        ser = Series(["a", "b", "c"], index=[0, 0.5, 1])
+        dtype = float_numpy_dtype
+        ser = Series(["a", "b", "c"], index=Index([0, 0.5, 1], dtype=dtype))
         expected = ser.copy()
 
         ser.loc[1] = "zoo"
@@ -2073,7 +2073,7 @@ class TestLocSetitemWithExpansion:
         df.loc[0, np.inf] = 3
 
         result = df.columns
-        expected = Float64Index([0, 1, np.inf])
+        expected = Index([0, 1, np.inf], dtype=np.float64)
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.filterwarnings("ignore:indexing past lexsort depth")
@@ -2415,13 +2415,14 @@ class TestLabelSlicing:
         s1 = df.loc[52195.1:52198.9]
         assert len(s1) == 3
 
-    def test_loc_getitem_float_slice_float64index(self):
-        ser = Series(np.random.rand(10), index=np.arange(10, 20, dtype=float))
+    def test_loc_getitem_float_slice_floatindex(self, float_numpy_dtype):
+        dtype = float_numpy_dtype
+        ser = Series(np.random.rand(10), index=np.arange(10, 20, dtype=dtype))
 
         assert len(ser.loc[12.0:]) == 8
         assert len(ser.loc[12.5:]) == 7
 
-        idx = np.arange(10, 20, dtype=float)
+        idx = np.arange(10, 20, dtype=dtype)
         idx[2] = 12.2
         ser.index = idx
         assert len(ser.loc[12.0:]) == 8

--- a/pandas/tests/series/indexing/test_get.py
+++ b/pandas/tests/series/indexing/test_get.py
@@ -2,9 +2,11 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas import Series
+from pandas import (
+    Index,
+    Series,
+)
 import pandas._testing as tm
-from pandas.core.api import Float64Index
 
 
 def test_get():
@@ -65,7 +67,7 @@ def test_get():
                 54,
             ]
         ),
-        index=Float64Index(
+        index=Index(
             [
                 25.0,
                 36.0,
@@ -87,7 +89,8 @@ def test_get():
                 1764.0,
                 1849.0,
                 1936.0,
-            ]
+            ],
+            dtype=np.float64,
         ),
     )
 
@@ -110,18 +113,18 @@ def test_get():
     assert result == "Missing"
 
 
-def test_get_nan():
+def test_get_nan(float_numpy_dtype):
     # GH 8569
-    s = Float64Index(range(10)).to_series()
+    s = Index(range(10), dtype=float_numpy_dtype).to_series()
     assert s.get(np.nan) is None
     assert s.get(np.nan, default="Missing") == "Missing"
 
 
-def test_get_nan_multiple():
+def test_get_nan_multiple(float_numpy_dtype):
     # GH 8569
     # ensure that fixing "test_get_nan" above hasn't broken get
     # with multiple elements
-    s = Float64Index(range(10)).to_series()
+    s = Index(range(10), dtype=float_numpy_dtype).to_series()
 
     idx = [2, 30]
     assert s.get(idx) is None

--- a/pandas/tests/series/indexing/test_getitem.py
+++ b/pandas/tests/series/indexing/test_getitem.py
@@ -88,8 +88,9 @@ class TestSeriesGetitemScalars:
         with pytest.raises(KeyError, match="-1"):
             ser[-1]
 
-    def test_getitem_keyerror_with_int64index(self):
-        ser = Series(np.random.randn(6), index=[0, 0, 1, 1, 2, 2])
+    def test_getitem_keyerror_with_integer_index(self, any_int_numpy_dtype):
+        dtype = any_int_numpy_dtype
+        ser = Series(np.random.randn(6), index=Index([0, 0, 1, 1, 2, 2], dtype=dtype))
 
         with pytest.raises(KeyError, match=r"^5$"):
             ser[5]

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -43,7 +43,6 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 from pandas.core.arrays import (
     IntegerArray,
     IntervalArray,
@@ -709,7 +708,7 @@ class TestSeriesConstructors:
             timedelta_range("1 day", periods=3),
             period_range("2012Q1", periods=3, freq="Q"),
             Index(list("abc")),
-            Int64Index([1, 2, 3]),
+            Index([1, 2, 3]),
             RangeIndex(0, 3),
         ],
         ids=lambda x: type(x).__name__,


### PR DESCRIPTION
Extraction of part of #50479. Progress towards #42717.