### PR TITLE
TST: Add test_factorize_mixed_values

### DIFF
--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -505,6 +505,32 @@ class TestFactorize:
         tm.assert_numpy_array_equal(uniques, expected_uniques, strict_nan=True)
         tm.assert_numpy_array_equal(codes, expected_codes, strict_nan=True)
 
+    @pytest.mark.parametrize(
+        "data, expected_codes, expected_uniques",
+        [
+            (
+                Index(Categorical(["a", "a", "b"])),
+                np.array([0, 0, 1], dtype=np.intp),
+                CategoricalIndex(["a", "b"], categories=["a", "b"], dtype="category"),
+            ),
+            (
+                Series(Categorical(["a", "a", "b"])),
+                np.array([0, 0, 1], dtype=np.intp),
+                CategoricalIndex(["a", "b"], categories=["a", "b"], dtype="category"),
+            ),
+            (
+                Series(DatetimeIndex(["2017", "2017"], tz="US/Eastern")),
+                np.array([0, 0], dtype=np.intp),
+                DatetimeIndex(["2017"], tz="US/Eastern"),
+            ),
+        ],
+    )
+    def test_factorize_mixed_values(self, data, expected_codes, expected_uniques):
+        # GH 19721
+        codes, uniques = algos.factorize(data)
+        tm.assert_numpy_array_equal(codes, expected_codes)
+        tm.assert_index_equal(uniques, expected_uniques)
+
 
 class TestUnique:
     def test_ints(self):


### PR DESCRIPTION
- [x] closes #19721

It has mentioned some different values for `factorize`. This is the list:
```python
pd.factorize(pd.Categorical(['a', 'a', 'c']))
pd.factorize(pd.Index(pd.Categorical(['a', 'a', 'b'])))
pd.factorize(pd.Series(pd.DatetimeIndex(['2017', '2017'], tz='US/Eastern')))
pd.factorize(pd.Series(pd.Categorical(['a', 'a', 'b'])))
```

For `pd.factorize(pd.Categorical(['a', 'a', 'c']))`, it has been test via [REF/BUG/API: factorizing categorical data](https://github.com/pandas-dev/pandas/pull/19938/files#top) in [pandas/tests/categorical/test_algos.py](https://github.com/pandas-dev/pandas/pull/19938/files#diff-64e79f37f13774c4c44e99497ba9fbdf7b5e459cc4931d95288c1b2eccff4475).

The rest are added here.