### PR TITLE
 BUG: non-nano strftime returns wrong results

### DIFF
--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1409,7 +1409,18 @@ class Timestamp(_Timestamp):
         >>> ts.strftime('%Y-%m-%d %X')
         '2020-03-14 15:32:52'
         """
-        return datetime.strftime(self, format)
+        try:
+            _dt = datetime(self.year, self.month, self.day,
+                           self.hour, self.minute, self.second,
+                           self.microsecond, self.tzinfo, fold=self.fold)
+        except ValueError as err:
+            raise NotImplementedError(
+                "strftime not yet supported on Timestamps which "
+                "are outside the range of Python's standard library. "
+                "For now, please call the components you need (such as `.year` "
+                "and `.month`) and construct your string from there."
+            ) from err
+        return _dt.strftime(format)
 
     # Issue 25016.
     @classmethod

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -1104,3 +1104,15 @@ def test_utctimetuple():
     result = ts.utctimetuple()
     expected = time.struct_time((2000, 1, 1, 0, 0, 0, 5, 1, 0))
     assert result == expected
+
+
+def test_negative_dates():
+    # https://github.com/pandas-dev/pandas/issues/50787
+    ts = Timestamp("-2000-01-01")
+    msg = (
+        "^strftime not yet supported on Timestamps which are outside the range of "
+        "Python's standard library. For now, please call the components you need "
+        r"\(such as `.year` and `.month`\) and construct your string from there.$"
+    )
+    with pytest.raises(NotImplementedError, match=msg):
+        ts.strftime("%Y")


### PR DESCRIPTION
- [ ] closes #50787 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
