### PR TITLE
DOC: Fix formatting issue with DataFrame.info docs

### DIFF
--- a/pandas/io/formats/info.py
+++ b/pandas/io/formats/info.py
@@ -254,7 +254,7 @@ INFO_DOCSTRING = dedent(
     buf : writable buffer, defaults to sys.stdout
         Where to send the output. By default, the output is printed to
         sys.stdout. Pass a writable buffer if you need to further process
-        the output.\
+        the output.
     {max_cols_sub}
     memory_usage : bool, str, optional
         Specifies whether total memory usage of the {klass}


### PR DESCRIPTION
Removed a backslash that was causing the description of the **max_cols** argument from the [DataFrme.info](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.info.html#pandas.DataFrame.info) method to be merged with the description of the **buf** argument.
![image](https://user-images.githubusercontent.com/32521936/213172824-a61ba4d6-6449-4ce2-a6f2-6d16ce62b381.png)


