### PR TITLE
remove Int/Uint/Float64Index from pandas/tests/frame

### DIFF
--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -11,6 +11,7 @@ from pandas import (
     CategoricalDtype,
     DataFrame,
     DatetimeTZDtype,
+    Index,
     Interval,
     IntervalDtype,
     NaT,
@@ -22,7 +23,6 @@ from pandas import (
     option_context,
 )
 import pandas._testing as tm
-from pandas.core.api import UInt64Index
 
 
 def _check_cast(df, v):
@@ -372,7 +372,7 @@ class TestAstype:
     )
     def test_astype_column_metadata(self, dtype):
         # GH#19920
-        columns = UInt64Index([100, 200, 300], name="foo")
+        columns = Index([100, 200, 300], dtype=np.uint64, name="foo")
         df = DataFrame(np.arange(15).reshape(5, 3), columns=columns)
         df = df.astype(dtype)
         tm.assert_index_equal(df.columns, columns)
@@ -441,7 +441,7 @@ class TestAstype:
         arr = np.array([[1, 2, 3]], dtype=dtype)
         df = DataFrame(arr)
         ser = df.iloc[:, 0]
-        idx = pd.Index(ser)
+        idx = Index(ser)
         dta = ser._values
 
         if unit in ["ns", "us", "ms", "s"]:
@@ -476,7 +476,7 @@ class TestAstype:
         exp_dta = exp_ser._values
 
         res_index = idx.astype(dtype)
-        exp_index = pd.Index(exp_ser)
+        exp_index = Index(exp_ser)
         assert exp_index.dtype == dtype
         tm.assert_index_equal(res_index, exp_index)
 
@@ -504,7 +504,7 @@ class TestAstype:
         arr = np.array([[1, 2, 3]], dtype=dtype)
         df = DataFrame(arr)
         ser = df.iloc[:, 0]
-        tdi = pd.Index(ser)
+        tdi = Index(ser)
         tda = tdi._values
 
         if unit in ["us", "ms", "s"]:

--- a/pandas/tests/frame/methods/test_truncate.py
+++ b/pandas/tests/frame/methods/test_truncate.py
@@ -5,11 +5,11 @@ import pandas as pd
 from pandas import (
     DataFrame,
     DatetimeIndex,
+    Index,
     Series,
     date_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 
 
 class TestDataFrameTruncate:
@@ -108,13 +108,13 @@ class TestDataFrameTruncate:
         "before, after, indices",
         [(1, 2, [2, 1]), (None, 2, [2, 1, 0]), (1, None, [3, 2, 1])],
     )
-    @pytest.mark.parametrize("klass", [Int64Index, DatetimeIndex])
+    @pytest.mark.parametrize("dtyp", [*tm.ALL_REAL_NUMPY_DTYPES, "datetime64[ns]"])
     def test_truncate_decreasing_index(
-        self, before, after, indices, klass, frame_or_series
+        self, before, after, indices, dtyp, frame_or_series
     ):
         # https://github.com/pandas-dev/pandas/issues/33756
-        idx = klass([3, 2, 1, 0])
-        if klass is DatetimeIndex:
+        idx = Index([3, 2, 1, 0], dtype=dtyp)
+        if isinstance(idx, DatetimeIndex):
             before = pd.Timestamp(before) if before is not None else None
             after = pd.Timestamp(after) if after is not None else None
             indices = [pd.Timestamp(i) for i in indices]


### PR DESCRIPTION
Extracted from #50479 to make it more manageable.

Progress towards #42717.