### PR TITLE
ENH: Improve performance for idxmin and idxmax

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -870,6 +870,7 @@ Performance improvements
 - Performance improvement in :func:`read_html` when there are multiple tables (:issue:`49929`)
 - Performance improvement in :func:`to_datetime` when using ``'%Y%m%d'`` format (:issue:`17410`)
 - Performance improvement in :func:`to_datetime` when format is given or can be inferred (:issue:`50465`)
+- Performance improvement in :meth:`Series.idxmax` and :meth:`Series.idxmin` for nullable dtypes (:issue:`1`)
 - Performance improvement in :func:`read_csv` when passing :func:`to_datetime` lambda-function to ``date_parser`` and inputs have mixed timezone offsetes (:issue:`35296`)
 - Performance improvement in :meth:`.SeriesGroupBy.value_counts` with categorical dtype (:issue:`46202`)
 - Fixed a reference leak in :func:`read_hdf` (:issue:`37441`)

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -36,7 +36,10 @@ from pandas._typing import (
 )
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import doc
-from pandas.util._validators import validate_fillna_kwargs
+from pandas.util._validators import (
+    validate_bool_kwarg,
+    validate_fillna_kwargs,
+)
 
 from pandas.core.dtypes.base import ExtensionDtype
 from pandas.core.dtypes.common import (
@@ -83,6 +86,7 @@ from pandas.core.arrays import ExtensionArray
 from pandas.core.construction import ensure_wrapped_if_datetimelike
 from pandas.core.indexers import check_array_indexer
 from pandas.core.ops import invalid_comparison
+from pandas.core.sorting import nargminmax
 
 if TYPE_CHECKING:
     from pandas import Series
@@ -1377,6 +1381,54 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
                 return result
             else:
                 return self.dtype.na_value
+
+    def argmin(self, skipna: bool = True) -> int:
+        """
+        Return the index of minimum value.
+
+        In case of multiple occurrences of the minimum value, the index
+        corresponding to the first occurrence is returned.
+
+        Parameters
+        ----------
+        skipna : bool, default True
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        BaseMaskedArray.argmax
+        """
+        validate_bool_kwarg(skipna, "skipna")
+        if not skipna and self._hasna:
+            raise NotImplementedError
+        return nargminmax(self, "argmin", mask=self._mask)
+
+    def argmax(self, skipna: bool = True) -> int:
+        """
+        Return the index of maximum value.
+
+        In case of multiple occurrences of the maximum value, the index
+        corresponding to the first occurrence is returned.
+
+        Parameters
+        ----------
+        skipna : bool, default True
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        BaseMaskedArray.argmin
+        """
+        validate_bool_kwarg(skipna, "skipna")
+        if not skipna and self._hasna:
+            raise NotImplementedError
+        return nargminmax(self, "argmax", self._mask)
 
     def _accumulate(
         self, name: str, *, skipna: bool = True, **kwargs

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -442,7 +442,12 @@ def nargsort(
     return ensure_platform_int(indexer)
 
 
-def nargminmax(values: ExtensionArray, method: str, axis: AxisInt = 0):
+def nargminmax(
+    values: ExtensionArray,
+    method: str,
+    axis: AxisInt = 0,
+    mask: npt.NDArray[np.bool_] | None = None,
+):
     """
     Implementation of np.argmin/argmax but for ExtensionArray and which
     handles missing values.
@@ -452,6 +457,7 @@ def nargminmax(values: ExtensionArray, method: str, axis: AxisInt = 0):
     values : ExtensionArray
     method : {"argmax", "argmin"}
     axis : int, default 0
+    mask : npt.NDArray[np.bool_], optional
 
     Returns
     -------
@@ -460,7 +466,8 @@ def nargminmax(values: ExtensionArray, method: str, axis: AxisInt = 0):
     assert method in {"argmax", "argmin"}
     func = np.argmax if method == "argmax" else np.argmin
 
-    mask = np.asarray(isna(values))
+    if mask is None:
+        mask = np.asarray(isna(values))
     arr_values = values._values_for_argsort()
 
     if arr_values.ndim > 1:


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.


This avoids re-computing the mask in the nargminmax algorithm