### PR TITLE
WEB/CI: Use GITHUB_TOKEN when making Github API calls

### DIFF
--- a/web/pandas_web.py
+++ b/web/pandas_web.py
@@ -43,6 +43,12 @@ import markdown
 import requests
 import yaml
 
+api_token = os.environ.get("GITHUB_TOKEN")
+if api_token is not None:
+    GITHUB_API_HEADERS = {"Authorization": f"Bearer {api_token}"}
+else:
+    GITHUB_API_HEADERS = {}
+
 
 class Preprocessors:
     """
@@ -168,7 +174,9 @@ class Preprocessors:
         for user in (
             context["maintainers"]["active"] + context["maintainers"]["inactive"]
         ):
-            resp = requests.get(f"https://api.github.com/users/{user}")
+            resp = requests.get(
+                f"https://api.github.com/users/{user}", headers=GITHUB_API_HEADERS
+            )
             if resp.status_code == 403:
                 sys.stderr.write(
                     "WARN: GitHub API quota exceeded when fetching maintainers\n"
@@ -199,7 +207,10 @@ class Preprocessors:
         context["releases"] = []
 
         github_repo_url = context["main"]["github_repo_url"]
-        resp = requests.get(f"https://api.github.com/repos/{github_repo_url}/releases")
+        resp = requests.get(
+            f"https://api.github.com/repos/{github_repo_url}/releases",
+            headers=GITHUB_API_HEADERS,
+        )
         if resp.status_code == 403:
             sys.stderr.write("WARN: GitHub API quota exceeded when fetching releases\n")
             resp_bkp = requests.get(context["main"]["production_url"] + "releases.json")
@@ -275,7 +286,8 @@ class Preprocessors:
         github_repo_url = context["main"]["github_repo_url"]
         resp = requests.get(
             "https://api.github.com/search/issues?"
-            f"q=is:pr is:open label:PDEP repo:{github_repo_url}"
+            f"q=is:pr is:open label:PDEP repo:{github_repo_url}",
+            headers=GITHUB_API_HEADERS,
         )
         if resp.status_code == 403:
             sys.stderr.write("WARN: GitHub API quota exceeded when fetching pdeps\n")


### PR DESCRIPTION
Follow up to https://github.com/pandas-dev/pandas/pull/50811, might as well still make authenticated API calls to Github