### PR TITLE
DOC: Fix typo in sed command in the release instructions

### DIFF
--- a/doc/source/development/maintaining.rst
+++ b/doc/source/development/maintaining.rst
@@ -458,8 +458,8 @@ which will be triggered when the tag is pushed.
     git checkout master
     git pull --ff-only upstream master
     git checkout -B RLS-<version>
-    sed -i 's/BUILD_COMMIT: "v.*/BUILD_COMMIT: "'<version>'"/' azure/windows.yml azure/posix.yml
-    sed -i 's/BUILD_COMMIT="v.*/BUILD_COMMIT="'<version>'"/' .travis.yml
+    sed -i 's/BUILD_COMMIT: "v.*/BUILD_COMMIT: "'v<version>'"/' azure/windows.yml azure/posix.yml
+    sed -i 's/BUILD_COMMIT="v.*/BUILD_COMMIT="'v<version>'"/' .travis.yml
     git commit -am "RLS <version>"
     git push -u origin RLS-<version>
 


### PR DESCRIPTION
The `BUILD_COMMIT` in the MacPython CI is the tag name (e.g. `v1.5.3`) and not the version name (e.g. `1.5.3`). The release instructions have it wrong, fixing it here.