### PR TITLE
DEPR: remove Int/Uint/Float64Index from pandas/tests/arrays

### DIFF
--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -29,7 +29,6 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 
 
 class TestCategoricalConstructors:
@@ -74,7 +73,7 @@ class TestCategoricalConstructors:
         tm.assert_index_equal(c.categories, expected)
 
         c = Categorical([], categories=[1, 2, 3])
-        expected = Int64Index([1, 2, 3])
+        expected = Index([1, 2, 3], dtype=np.int64)
         tm.assert_index_equal(c.categories, expected)
 
     def test_constructor_empty_boolean(self):

--- a/pandas/tests/arrays/integer/test_dtypes.py
+++ b/pandas/tests/arrays/integer/test_dtypes.py
@@ -62,8 +62,7 @@ def test_astype_nansafe():
 
 @pytest.mark.parametrize("dropna", [True, False])
 def test_construct_index(all_data, dropna):
-    # ensure that we do not coerce to Float64Index, rather
-    # keep as Index
+    # ensure that we do not coerce to different Index dtype or non-index
 
     all_data = all_data[:10]
     if dropna:

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -8,7 +8,6 @@ from pandas._libs.sparse import IntIndex
 import pandas as pd
 from pandas import isna
 import pandas._testing as tm
-from pandas.core.api import Int64Index
 from pandas.core.arrays.sparse import (
     SparseArray,
     SparseDtype,
@@ -469,7 +468,7 @@ def test_dropna(fill_value):
     tm.assert_sp_array_equal(arr.dropna(), exp)
 
     df = pd.DataFrame({"a": [0, 1], "b": arr})
-    expected_df = pd.DataFrame({"a": [1], "b": exp}, index=Int64Index([1]))
+    expected_df = pd.DataFrame({"a": [1], "b": exp}, index=pd.Index([1]))
     tm.assert_equal(df.dropna(), expected_df)
 
 


### PR DESCRIPTION
Extracted from #50479 to make it more manageable.

Progress towards #42717.