### PR TITLE
Gitpod docs: added missing line break

### DIFF
--- a/doc/source/development/contributing_gitpod.rst
+++ b/doc/source/development/contributing_gitpod.rst
@@ -145,7 +145,7 @@ docs you need to run the following command in the docs directory::
 
 Alternatively you can build a single page with::
 
-    python make.py html 
+    python make.py html
     python make.py --single development/contributing_gitpod.rst
 
 You have two main options to render the documentation in Gitpod.

--- a/doc/source/development/contributing_gitpod.rst
+++ b/doc/source/development/contributing_gitpod.rst
@@ -145,7 +145,6 @@ docs you need to run the following command in the docs directory::
 
 Alternatively you can build a single page with::
 
-    python make.py html
     python make.py --single development/contributing_gitpod.rst
 
 You have two main options to render the documentation in Gitpod.

--- a/doc/source/development/contributing_gitpod.rst
+++ b/doc/source/development/contributing_gitpod.rst
@@ -145,7 +145,8 @@ docs you need to run the following command in the docs directory::
 
 Alternatively you can build a single page with::
 
-    python make.py html python make.py --single development/contributing_gitpod.rst
+    python make.py html 
+    python make.py --single development/contributing_gitpod.rst
 
 You have two main options to render the documentation in Gitpod.
 


### PR DESCRIPTION
Thanks to the PyLadies Berlin pandas sprint participants who noticed this error 🙇‍♀️ 

CC @phofl 