### PR TITLE
DEPR: remove Int/Uint/Float64Index from tests/arithmetic + various

### DIFF
--- a/pandas/tests/arithmetic/conftest.py
+++ b/pandas/tests/arithmetic/conftest.py
@@ -75,7 +75,7 @@ def zero(request):
     --------
     arr = RangeIndex(5)
     arr / zeros
-    Float64Index([nan, inf, inf, inf, inf], dtype='float64')
+    NumericIndex([nan, inf, inf, inf, inf], dtype='float64')
     """
     return request.param
 

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -22,11 +22,7 @@ from pandas import (
 )
 import pandas._testing as tm
 from pandas.core import ops
-from pandas.core.api import (
-    Float64Index,
-    Int64Index,
-    UInt64Index,
-)
+from pandas.core.api import NumericIndex
 from pandas.core.computation import expressions as expr
 from pandas.tests.arithmetic.common import (
     assert_invalid_addsub_type,
@@ -1058,72 +1054,77 @@ class TestAdditionSubtraction:
 
 
 class TestUFuncCompat:
-    @pytest.mark.parametrize(
-        "holder",
-        [Int64Index, UInt64Index, Float64Index, RangeIndex, Series],
-    )
-    def test_ufunc_compat(self, holder):
+    # TODO: add more dtypes
+    @pytest.mark.parametrize("holder", [NumericIndex, RangeIndex, Series])
+    @pytest.mark.parametrize("dtype", [np.int64, np.uint64, np.float64])
+    def test_ufunc_compat(self, holder, dtype):
         box = Series if holder is Series else Index
 
         if holder is RangeIndex:
+            if dtype != np.int64:
+                pytest.skip(f"dtype {dtype} not relevant for RangeIndex")
             idx = RangeIndex(0, 5, name="foo")
         else:
-            idx = holder(np.arange(5, dtype="int64"), name="foo")
+            idx = holder(np.arange(5, dtype=dtype), name="foo")
         result = np.sin(idx)
-        expected = box(np.sin(np.arange(5, dtype="int64")), name="foo")
+        expected = box(np.sin(np.arange(5, dtype=dtype)), name="foo")
         tm.assert_equal(result, expected)
 
-    @pytest.mark.parametrize("holder", [Int64Index, UInt64Index, Float64Index, Series])
-    def test_ufunc_coercions(self, holder):
-        idx = holder([1, 2, 3, 4, 5], name="x")
+    # TODO: add more dtypes
+    @pytest.mark.parametrize("holder", [NumericIndex, Series])
+    @pytest.mark.parametrize("dtype", [np.int64, np.uint64, np.float64])
+    def test_ufunc_coercions(self, holder, dtype):
+        idx = holder([1, 2, 3, 4, 5], dtype=dtype, name="x")
         box = Series if holder is Series else Index
 
         result = np.sqrt(idx)
         assert result.dtype == "f8" and isinstance(result, box)
-        exp = Float64Index(np.sqrt(np.array([1, 2, 3, 4, 5])), name="x")
+        exp = Index(np.sqrt(np.array([1, 2, 3, 4, 5], dtype=np.float64)), name="x")
         exp = tm.box_expected(exp, box)
         tm.assert_equal(result, exp)
 
         result = np.divide(idx, 2.0)
         assert result.dtype == "f8" and isinstance(result, box)
-        exp = Float64Index([0.5, 1.0, 1.5, 2.0, 2.5], name="x")
+        exp = Index([0.5, 1.0, 1.5, 2.0, 2.5], dtype=np.float64, name="x")
         exp = tm.box_expected(exp, box)
         tm.assert_equal(result, exp)
 
         # _evaluate_numeric_binop
         result = idx + 2.0
         assert result.dtype == "f8" and isinstance(result, box)
-        exp = Float64Index([3.0, 4.0, 5.0, 6.0, 7.0], name="x")
+        exp = Index([3.0, 4.0, 5.0, 6.0, 7.0], dtype=np.float64, name="x")
         exp = tm.box_expected(exp, box)
         tm.assert_equal(result, exp)
 
         result = idx - 2.0
         assert result.dtype == "f8" and isinstance(result, box)
-        exp = Float64Index([-1.0, 0.0, 1.0, 2.0, 3.0], name="x")
+        exp = Index([-1.0, 0.0, 1.0, 2.0, 3.0], dtype=np.float64, name="x")
         exp = tm.box_expected(exp, box)
         tm.assert_equal(result, exp)
 
         result = idx * 1.0
         assert result.dtype == "f8" and isinstance(result, box)
-        exp = Float64Index([1.0, 2.0, 3.0, 4.0, 5.0], name="x")
+        exp = Index([1.0, 2.0, 3.0, 4.0, 5.0], dtype=np.float64, name="x")
         exp = tm.box_expected(exp, box)
         tm.assert_equal(result, exp)
 
         result = idx / 2.0
         assert result.dtype == "f8" and isinstance(result, box)
-        exp = Float64Index([0.5, 1.0, 1.5, 2.0, 2.5], name="x")
+        exp = Index([0.5, 1.0, 1.5, 2.0, 2.5], dtype=np.float64, name="x")
         exp = tm.box_expected(exp, box)
         tm.assert_equal(result, exp)
 
-    @pytest.mark.parametrize("holder", [Int64Index, UInt64Index, Float64Index, Series])
-    def test_ufunc_multiple_return_values(self, holder):
-        obj = holder([1, 2, 3], name="x")
+    # TODO: add more dtypes
+    @pytest.mark.parametrize("holder", [NumericIndex, Series])
+    @pytest.mark.parametrize("dtype", [np.int64, np.uint64, np.float64])
+    def test_ufunc_multiple_return_values(self, holder, dtype):
+        obj = holder([1, 2, 3], dtype=dtype, name="x")
         box = Series if holder is Series else Index
 
         result = np.modf(obj)
         assert isinstance(result, tuple)
-        exp1 = Float64Index([0.0, 0.0, 0.0], name="x")
-        exp2 = Float64Index([1.0, 2.0, 3.0], name="x")
+        exp1 = Index([0.0, 0.0, 0.0], dtype=np.float64, name="x")
+        exp2 = Index([1.0, 2.0, 3.0], dtype=np.float64, name="x")
         tm.assert_equal(result[0], tm.box_expected(exp1, box))
         tm.assert_equal(result[1], tm.box_expected(exp2, box))
 
@@ -1241,7 +1242,7 @@ class TestNumericArithmeticUnsorted:
     @pytest.mark.parametrize("scalar", [-1, 1, 2])
     def test_binops_index_scalar(self, op, idx, scalar):
         result = op(idx, scalar)
-        expected = op(Int64Index(idx), scalar)
+        expected = op(Index(idx.to_numpy()), scalar)
         tm.assert_index_equal(result, expected, exact="equiv")
 
     @pytest.mark.parametrize("idx1", [RangeIndex(0, 10, 1), RangeIndex(0, 20, 2)])
@@ -1261,7 +1262,7 @@ class TestNumericArithmeticUnsorted:
         # numpy does not allow powers of negative integers so test separately
         # https://github.com/numpy/numpy/pull/8127
         result = pow(idx, scalar)
-        expected = pow(Int64Index(idx), scalar)
+        expected = pow(Index(idx.to_numpy()), scalar)
         tm.assert_index_equal(result, expected, exact="equiv")
 
     # TODO: divmod?
@@ -1336,17 +1337,18 @@ class TestNumericArithmeticUnsorted:
     @pytest.mark.parametrize(
         "idx, div, expected",
         [
+            # TODO: add more dtypes
             (RangeIndex(0, 1000, 2), 2, RangeIndex(0, 500, 1)),
             (RangeIndex(-99, -201, -3), -3, RangeIndex(33, 67, 1)),
             (
                 RangeIndex(0, 1000, 1),
                 2,
-                Int64Index(RangeIndex(0, 1000, 1)._values) // 2,
+                Index(RangeIndex(0, 1000, 1)._values) // 2,
             ),
             (
                 RangeIndex(0, 100, 1),
                 2.0,
-                Int64Index(RangeIndex(0, 100, 1)._values) // 2.0,
+                Index(RangeIndex(0, 100, 1)._values) // 2.0,
             ),
             (RangeIndex(0), 50, RangeIndex(0)),
             (RangeIndex(2, 4, 2), 3, RangeIndex(0, 1, 1)),

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -137,7 +137,7 @@ def test_agg_apply_corner(ts, tsframe):
     grouped = ts.groupby(ts * np.nan, group_keys=False)
     assert ts.dtype == np.float64
 
-    # groupby float64 values results in Float64Index
+    # groupby float64 values results in a float64 Index
     exp = Series([], dtype=np.float64, index=Index([], dtype=np.float64))
     tm.assert_series_equal(grouped.sum(), exp)
     tm.assert_series_equal(grouped.agg(np.sum), exp)

--- a/pandas/tests/indexes/numeric/test_astype.py
+++ b/pandas/tests/indexes/numeric/test_astype.py
@@ -11,7 +11,7 @@ import pandas._testing as tm
 
 class TestAstype:
     def test_astype_float64_to_uint64(self):
-        # GH#45309 used to incorrectly return Int64Index
+        # GH#45309 used to incorrectly return Index with int64 dtype
         idx = Index([0.0, 5.0, 10.0, 15.0, 20.0], dtype=np.float64)
         result = idx.astype("u8")
         expected = Index([0, 5, 10, 15, 20], dtype=np.uint64)

--- a/pandas/tests/indexes/period/methods/test_astype.py
+++ b/pandas/tests/indexes/period/methods/test_astype.py
@@ -11,7 +11,6 @@ from pandas import (
     period_range,
 )
 import pandas._testing as tm
-from pandas.core.indexes.api import Int64Index
 
 
 class TestPeriodIndexAsType:
@@ -36,7 +35,7 @@ class TestPeriodIndexAsType:
         tm.assert_index_equal(result, expected)
 
         result = idx.astype(np.int64)
-        expected = Int64Index(
+        expected = Index(
             [16937] + [-9223372036854775808] * 3, dtype=np.int64, name="idx"
         )
         tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/period/test_constructors.py
+++ b/pandas/tests/indexes/period/test_constructors.py
@@ -329,7 +329,7 @@ class TestPeriodIndex:
 
         msg = "Should be numpy array of type i8"
         with pytest.raises(AssertionError, match=msg):
-            # Need ndarray, not Int64Index
+            # Need ndarray, not int64 Index
             type(idx._data)._simple_new(Index(idx.asi8), freq=idx.freq)
 
         arr = type(idx._data)._simple_new(idx.asi8, freq=idx.freq)

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -874,7 +874,7 @@ class TestSeriesReductions:
         result = s.idxmax()
         assert result == 4
 
-        # Float64Index
+        # Index with float64 dtype
         # GH#5914
         s = Series([1, 2, 3], [1.1, 2.1, 3.1])
         result = s.idxmax()


### PR DESCRIPTION
Progress towards #42717.

Arithmetic ops with indexes with 8/16/32 bit dtypes is a bit difficult and I'd like like to work on that after removal of Int64Index etc. So there's a follow-up, where more dtypes should be added to the tests in `pandas/tests/arithmetic/`.