### PR TITLE
DOC: removed hypen to fix docs build numpydoc warnings

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -2792,7 +2792,7 @@ cdef class Week(SingleConstructorOffset):
      2nd week of each month.
 
     Examples
-    ---------
+    --------
 
     >>> date_object = pd.Timestamp("2023-01-13")
     >>> date_object


### PR DESCRIPTION
I noticed a few warning in a recent PR. This should fix them. 

Ref:
![Screenshot of docs build warning in CI](https://user-images.githubusercontent.com/6564007/213683432-7a79a34d-4c84-4e52-896a-5e8b73d5af6c.png)

![Screenshot of detailed numpydoc warnings](https://user-images.githubusercontent.com/6564007/213683456-5a01914a-858e-497e-88ea-158a520d48e5.png)
