### PR TITLE
ENH: Use circular weakref to delay copy in setitem

### DIFF
--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1375,7 +1375,7 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
             new_mgr = col_mgr.setitem((idx,), value)
             self.iset(loc, new_mgr._block.values, inplace=True)
 
-    def insert(self, loc: int, item: Hashable, value: ArrayLike) -> None:
+    def insert(self, loc: int, item: Hashable, value: ArrayLike, ref=None) -> None:
         """
         Insert item at selected position.
 
@@ -1384,6 +1384,8 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         loc : int
         item : hashable
         value : np.ndarray or ExtensionArray
+        ref: weakref.ref or None
+            A weakref pointing to the Block that owns the value or None
         """
         # insert to the axis; this could possibly raise a TypeError
         new_axis = self.items.insert(loc, item)
@@ -1410,9 +1412,13 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
 
         self.axes[0] = new_axis
         self.blocks += (block,)
-        # TODO(CoW) do we always "own" the passed `value`?
-        if self.refs is not None:
-            self.refs += [None]
+
+        if ref:
+            if self.refs is not None:
+                self.refs.append(ref)
+            else:
+                self.refs = [None] * (len(self.blocks) - 1)
+                self.refs += ref
 
         self._known_consolidated = False
 


### PR DESCRIPTION
- [ ] xref #48998 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This PR uses a circular weakref between the added block in the DataFrame and the original block from the Series, when doing setitem in a DataFrame with a Series (haven't fixed other cases yet, wanted to get feedback on whether I'm on the right track).

With this way, whoever modifies the data first will have to copy the data, and we can delay the copy in ``__setitem__``.
