### PR TITLE
TST: Remove fsspec internals from tests

### DIFF
--- a/pandas/tests/io/test_fsspec.py
+++ b/pandas/tests/io/test_fsspec.py
@@ -50,10 +50,8 @@ def test_read_csv(cleared_fs, df1):
 
 
 def test_reasonable_error(monkeypatch, cleared_fs):
-    from fsspec import registry
     from fsspec.registry import known_implementations
 
-    registry.target.clear()
     with pytest.raises(ValueError, match="nosuchprotocol"):
         read_csv("nosuchprotocol://test/test.csv")
     err_msg = "test error message"

--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -22,12 +22,7 @@ from pandas.util import _test_decorators as td
 @pytest.fixture
 def gcs_buffer(monkeypatch):
     """Emulate GCS using a binary buffer."""
-    from fsspec import (
-        AbstractFileSystem,
-        registry,
-    )
-
-    registry.target.clear()  # remove state
+    from fsspec import AbstractFileSystem
 
     gcs_buffer = BytesIO()
     gcs_buffer.close = lambda: True
@@ -55,9 +50,6 @@ def test_to_read_gcs(gcs_buffer, format):
 
     GH 33987
     """
-    from fsspec import registry
-
-    registry.target.clear()  # remove state
 
     df1 = DataFrame(
         {
@@ -132,9 +124,6 @@ def test_to_csv_compression_encoding_gcs(gcs_buffer, compression_only, encoding)
     GH 35677 (to_csv, compression), GH 26124 (to_csv, encoding), and
     GH 32392 (read_csv, encoding)
     """
-    from fsspec import registry
-
-    registry.target.clear()  # remove state
     df = tm.makeDataFrame()
 
     # reference of compressed and encoded file
@@ -174,12 +163,8 @@ def test_to_csv_compression_encoding_gcs(gcs_buffer, compression_only, encoding)
 @td.skip_if_no("gcsfs")
 def test_to_parquet_gcs_new_file(monkeypatch, tmpdir):
     """Regression test for writing to a not-yet-existent GCS Parquet file."""
-    from fsspec import (
-        AbstractFileSystem,
-        registry,
-    )
+    from fsspec import AbstractFileSystem
 
-    registry.target.clear()  # remove state
     df1 = DataFrame(
         {
             "int": [1, 3],

--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -3,6 +3,7 @@ import os
 import tarfile
 import zipfile
 
+import fsspec
 import numpy as np
 import pytest
 
@@ -37,7 +38,8 @@ def gcs_buffer(monkeypatch):
             # needed for pyarrow
             return [{"name": path, "type": "file"}]
 
-    monkeypatch.setattr("gcsfs.GCSFileSystem", MockGCSFileSystem)
+    # Overwrites the default implementation from gcsfs to our mock class
+    fsspec.register_implementation("gs", MockGCSFileSystem, clobber=True)
 
     return gcs_buffer
 

--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -3,7 +3,6 @@ import os
 import tarfile
 import zipfile
 
-import fsspec
 import numpy as np
 import pytest
 
@@ -23,12 +22,12 @@ from pandas.util import _test_decorators as td
 @pytest.fixture
 def gcs_buffer(monkeypatch):
     """Emulate GCS using a binary buffer."""
-    from fsspec import AbstractFileSystem
+    import fsspec
 
     gcs_buffer = BytesIO()
     gcs_buffer.close = lambda: True
 
-    class MockGCSFileSystem(AbstractFileSystem):
+    class MockGCSFileSystem(fsspec.AbstractFileSystem):
         @staticmethod
         def open(*args, **kwargs):
             gcs_buffer.seek(0)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

I don't think clearing the registry does anything. The public registry var is supposed to be immutable, and we were just clearing the internal registry dict. 

However, we didn't remove gcs from the known_implementations dict, so gcs would've technically still been in the registry IIUC this code correctly. 

https://github.com/fsspec/filesystem_spec/blob/0f3ecd8e629043646ab19b1a2b00d895f0553a81/fsspec/registry.py#L206-L209
