### PR TITLE
DEPR: move NumericIndex._format_native_types to Index

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1296,6 +1296,7 @@ class Index(IndexOpsMixin, PandasObject):
         na_rep: str_t = "",
         decimal: str = ".",
         float_format=None,
+        date_format=None,
         quoting=None,
     ) -> npt.NDArray[np.object_]:
         """

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1294,7 +1294,7 @@ class Index(IndexOpsMixin, PandasObject):
         self,
         *,
         na_rep: str_t = "",
-        decimal: str = ".",
+        decimal: str_t = ".",
         float_format=None,
         date_format=None,
         quoting=None,

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1291,11 +1291,29 @@ class Index(IndexOpsMixin, PandasObject):
         return header + result
 
     def _format_native_types(
-        self, *, na_rep: str_t = "", quoting=None, **kwargs
+        self,
+        *,
+        na_rep: str_t = "",
+        decimal: str = ".",
+        float_format=None,
+        quoting=None,
     ) -> npt.NDArray[np.object_]:
         """
         Actually format specific types of the index.
         """
+        from pandas.io.formats.format import FloatArrayFormatter
+
+        if is_float_dtype(self.dtype) and not is_extension_array_dtype(self.dtype):
+            formatter = FloatArrayFormatter(
+                self._values,
+                na_rep=na_rep,
+                float_format=float_format,
+                decimal=decimal,
+                quoting=quoting,
+                fixed_width=False,
+            )
+            return formatter.get_result_as_array()
+
         mask = isna(self)
         if not self.is_object() and not quoting:
             values = np.asarray(self).astype(str)

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -5,10 +5,7 @@ from typing import Callable
 import numpy as np
 
 from pandas._libs import index as libindex
-from pandas._typing import (
-    Dtype,
-    npt,
-)
+from pandas._typing import Dtype
 from pandas.util._decorators import (
     cache_readonly,
     doc,
@@ -251,33 +248,3 @@ class NumericIndex(Index):
         if is_integer_dtype(subarr.dtype):
             if not np.array_equal(data, subarr):
                 raise TypeError("Unsafe NumPy casting, you must explicitly cast")
-
-    def _format_native_types(
-        self,
-        *,
-        na_rep: str = "",
-        float_format=None,
-        decimal: str = ".",
-        quoting=None,
-        **kwargs,
-    ) -> npt.NDArray[np.object_]:
-        from pandas.io.formats.format import FloatArrayFormatter
-
-        if is_float_dtype(self.dtype):
-            formatter = FloatArrayFormatter(
-                self._values,
-                na_rep=na_rep,
-                float_format=float_format,
-                decimal=decimal,
-                quoting=quoting,
-                fixed_width=False,
-            )
-            return formatter.get_result_as_array()
-
-        return super()._format_native_types(
-            na_rep=na_rep,
-            float_format=float_format,
-            decimal=decimal,
-            quoting=quoting,
-            **kwargs,
-        )


### PR DESCRIPTION
This starts moving functionality from `NumericIndex`to `Index` in preparation to remove `NumericIndex` and include numpy int/uint/float64 in the base `Index`.

Also removes the `**kwargs`, as that wasn't used in the method.

I'm doing one method per PR, figuring that is easier to review. I could add ore per PR if you want.

xref #42717.