### PR TITLE
DEPR: move NumericIndex._convert_tolerance to Index

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3783,13 +3783,13 @@ class Index(IndexOpsMixin, PandasObject):
         elif is_numeric_dtype(self) and not np.issubdtype(tolerance.dtype, np.number):
             if tolerance.ndim > 0:
                 raise ValueError(
-                    f"tolerance argument for {type(self).__name__} must contain "
-                    "numeric elements if it is list type"
+                    f"tolerance argument for {type(self).__name__} with dtype "
+                    f"{self.dtype} must contain numeric elements if it is list type"
                 )
 
             raise ValueError(
-                f"tolerance argument for {type(self).__name__} must be numeric "
-                f"if it is a scalar: {repr(tolerance)}"
+                f"tolerance argument for {type(self).__name__} with dtype {self.dtype} "
+                f"must be numeric if it is a scalar: {repr(tolerance)}"
             )
         return tolerance
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3780,6 +3780,17 @@ class Index(IndexOpsMixin, PandasObject):
         tolerance = np.asarray(tolerance)
         if target.size != tolerance.size and tolerance.size > 1:
             raise ValueError("list-like tolerance size must match target index size")
+        elif is_numeric_dtype(self) and not np.issubdtype(tolerance.dtype, np.number):
+            if tolerance.ndim > 0:
+                raise ValueError(
+                    f"tolerance argument for {type(self).__name__} must contain "
+                    "numeric elements if it is list type"
+                )
+
+            raise ValueError(
+                f"tolerance argument for {type(self).__name__} must be numeric "
+                f"if it is a scalar: {repr(tolerance)}"
+            )
         return tolerance
 
     @final

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -221,22 +221,6 @@ class NumericIndex(Index):
 
     # ----------------------------------------------------------------
 
-    def _convert_tolerance(self, tolerance, target):
-        tolerance = super()._convert_tolerance(tolerance, target)
-
-        if not np.issubdtype(tolerance.dtype, np.number):
-            if tolerance.ndim > 0:
-                raise ValueError(
-                    f"tolerance argument for {type(self).__name__} must contain "
-                    "numeric elements if it is list type"
-                )
-
-            raise ValueError(
-                f"tolerance argument for {type(self).__name__} must be numeric "
-                f"if it is a scalar: {repr(tolerance)}"
-            )
-        return tolerance
-
     @classmethod
     def _assert_safe_casting(cls, data: np.ndarray, subarr: np.ndarray) -> None:
         """


### PR DESCRIPTION
Moves`_convert_tolerance` from `NumericIndex`to `Index` in preparation to remove `NumericIndex` and include numpy int/uint/float64 in the base `Index`.

xref #42717.