### PR TITLE
DEPR: move NumericIndex._engine_type and .inferred_type to Index

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2560,15 +2560,14 @@ class Index(IndexOpsMixin, PandasObject):
         """
         Return a string of the type inferred from the values.
         """
-        try:  # fastpath numeric indexes
+        if isinstance(self.dtype, np.dtype) and self.dtype.kind in "iufc":  # fastpath
             return {
                 "i": "integer",
                 "u": "integer",
                 "f": "floating",
                 "c": "complex",
             }[self.dtype.kind]
-        except KeyError:
-            return lib.infer_dtype(self._values, skipna=False)
+        return lib.infer_dtype(self._values, skipna=False)
 
     @cache_readonly
     @final

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2555,26 +2555,12 @@ class Index(IndexOpsMixin, PandasObject):
         )
         return self._holds_integer()
 
-    def _inferred_type(self) -> str_t:
-        """
-        Return a string of the type inferred from the values.
-        """
-        try:  # fastpath numeric indexes
-            return {
-                "i": "integer",
-                "u": "integer",
-                "f": "floating",
-                "c": "complex",
-            }[self.dtype.kind]
-        except KeyError:
-            return lib.infer_dtype(self._values, skipna=False)
-
     @cache_readonly
     def inferred_type(self) -> str_t:
         """
         Return a string of the type inferred from the values.
         """
-        try:
+        try:  # fastpath numeric indexes
             return {
                 "i": "integer",
                 "u": "integer",

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -386,11 +386,26 @@ class Index(IndexOpsMixin, PandasObject):
     _attributes: list[str] = ["name"]
     _can_hold_strings: bool = True
 
+    _engine_types: dict[np.dtype | ExtensionDtype, type[libindex.IndexEngine]] = {
+        np.dtype(np.int8): libindex.Int8Engine,
+        np.dtype(np.int16): libindex.Int16Engine,
+        np.dtype(np.int32): libindex.Int32Engine,
+        np.dtype(np.int64): libindex.Int64Engine,
+        np.dtype(np.uint8): libindex.UInt8Engine,
+        np.dtype(np.uint16): libindex.UInt16Engine,
+        np.dtype(np.uint32): libindex.UInt32Engine,
+        np.dtype(np.uint64): libindex.UInt64Engine,
+        np.dtype(np.float32): libindex.Float32Engine,
+        np.dtype(np.float64): libindex.Float64Engine,
+        np.dtype(np.complex64): libindex.Complex64Engine,
+        np.dtype(np.complex128): libindex.Complex128Engine,
+    }
+
     @property
     def _engine_type(
         self,
     ) -> type[libindex.IndexEngine] | type[libindex.ExtensionEngine]:
-        return libindex.ObjectEngine
+        return self._engine_types.get(self.dtype, libindex.ObjectEngine)
 
     # whether we support partial string indexing. Overridden
     # in DatetimeIndex and PeriodIndex
@@ -2540,12 +2555,34 @@ class Index(IndexOpsMixin, PandasObject):
         )
         return self._holds_integer()
 
+    def _inferred_type(self) -> str_t:
+        """
+        Return a string of the type inferred from the values.
+        """
+        try:  # fastpath numeric indexes
+            return {
+                "i": "integer",
+                "u": "integer",
+                "f": "floating",
+                "c": "complex",
+            }[self.dtype.kind]
+        except KeyError:
+            return lib.infer_dtype(self._values, skipna=False)
+
     @cache_readonly
     def inferred_type(self) -> str_t:
         """
         Return a string of the type inferred from the values.
         """
-        return lib.infer_dtype(self._values, skipna=False)
+        try:
+            return {
+                "i": "integer",
+                "u": "integer",
+                "f": "floating",
+                "c": "complex",
+            }[self.dtype.kind]
+        except KeyError:
+            return lib.infer_dtype(self._values, skipna=False)
 
     @cache_readonly
     @final

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -4,7 +4,6 @@ from typing import Callable
 
 import numpy as np
 
-from pandas._libs import index as libindex
 from pandas._typing import Dtype
 from pandas.util._decorators import (
     cache_readonly,
@@ -73,36 +72,6 @@ class NumericIndex(Index):
         "numeric type",
     )
     _can_hold_strings = False
-
-    _engine_types: dict[np.dtype, type[libindex.IndexEngine]] = {
-        np.dtype(np.int8): libindex.Int8Engine,
-        np.dtype(np.int16): libindex.Int16Engine,
-        np.dtype(np.int32): libindex.Int32Engine,
-        np.dtype(np.int64): libindex.Int64Engine,
-        np.dtype(np.uint8): libindex.UInt8Engine,
-        np.dtype(np.uint16): libindex.UInt16Engine,
-        np.dtype(np.uint32): libindex.UInt32Engine,
-        np.dtype(np.uint64): libindex.UInt64Engine,
-        np.dtype(np.float32): libindex.Float32Engine,
-        np.dtype(np.float64): libindex.Float64Engine,
-        np.dtype(np.complex64): libindex.Complex64Engine,
-        np.dtype(np.complex128): libindex.Complex128Engine,
-    }
-
-    @property
-    def _engine_type(self) -> type[libindex.IndexEngine]:
-        # error: Invalid index type "Union[dtype[Any], ExtensionDtype]" for
-        # "Dict[dtype[Any], Type[IndexEngine]]"; expected type "dtype[Any]"
-        return self._engine_types[self.dtype]  # type: ignore[index]
-
-    @cache_readonly
-    def inferred_type(self) -> str:
-        return {
-            "i": "integer",
-            "u": "integer",
-            "f": "floating",
-            "c": "complex",
-        }[self.dtype.kind]
 
     def __new__(
         cls, data=None, dtype: Dtype | None = None, copy: bool = False, name=None


### PR DESCRIPTION
Moves`_engine_type` & `inferred_type` from `NumericIndex`to `Index` in preparation to remove `NumericIndex` and include numpy int/uint/float64 in the base `Index`.

xref #42717.