### PR TITLE
CI set LD_PRELOAD in circleci job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,9 @@ jobs:
     steps:
       - checkout
       - run: .circleci/setup_env.sh
-      - run: |
-          PATH=$HOME/miniconda3/envs/pandas-dev/bin:$HOME/miniconda3/condabin:$PATH \\
-          LD_PRELOAD=$HOME/miniconda3/envs/pandas-dev/lib/libgomp.so.1:$LD_PRELOAD \\
+      - run: >
+          PATH=$HOME/miniconda3/envs/pandas-dev/bin:$HOME/miniconda3/condabin:$PATH
+          LD_PRELOAD=$HOME/miniconda3/envs/pandas-dev/lib/libgomp.so.1:$LD_PRELOAD
           ci/run_tests.sh
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,10 @@ jobs:
     steps:
       - checkout
       - run: .circleci/setup_env.sh
-      - run: PATH=$HOME/miniconda3/envs/pandas-dev/bin:$HOME/miniconda3/condabin:$PATH ci/run_tests.sh
+      - run: |
+          PATH=$HOME/miniconda3/envs/pandas-dev/bin:$HOME/miniconda3/condabin:$PATH \\
+          LD_PRELOAD=$HOME/miniconda3/envs/pandas-dev/lib/libgomp.so.1:$LD_PRELOAD \\
+          ci/run_tests.sh
 
 workflows:
   test:


### PR DESCRIPTION
circle CI job is failing, let's see if this fixes anything

```python-traceback
=================================== FAILURES ===================================
______________________________ test_scikit_learn _______________________________
[gw2] linux -- Python 3.8.15 /home/circleci/miniconda3/envs/pandas-dev/bin/python3.8

    def test_scikit_learn():
    
>       sklearn = import_module("sklearn")  # noqa:F841

pandas/tests/test_downstream.py:158: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
pandas/tests/test_downstream.py:27: in import_module
    return importlib.import_module(name)
../miniconda3/envs/pandas-dev/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1014: in _gcd_import
    ???
<frozen importlib._bootstrap>:991: in _find_and_load
    ???
<frozen importlib._bootstrap>:975: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:671: in _load_unlocked
    ???
<frozen importlib._bootstrap_external>:843: in exec_module
    ???
<frozen importlib._bootstrap>:219: in _call_with_frames_removed
    ???
../miniconda3/envs/pandas-dev/lib/python3.8/site-packages/sklearn/__init__.py:83: in <module>
    from .utils._show_versions import show_versions
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    """
    Utility methods to print system info for debugging
    
    adapted from :func:`pandas.show_versions`
    """
    # License: BSD 3 clause
    
    import platform
    import sys
    from ..utils.fixes import threadpool_info
    from .. import __version__
    
    
>   from ._openmp_helpers import _openmp_parallelism_enabled
E   ImportError: /home/circleci/miniconda3/envs/pandas-dev/lib/python3.8/site-packages/sklearn/utils/../../../../libgomp.so.1: cannot allocate memory in static TLS block

../miniconda3/envs/pandas-dev/lib/python3.8/site-packages/sklearn/utils/_show_versions.py:14: ImportError
```