### PR TITLE
DEPR: parsing to tzlocal

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -611,6 +611,7 @@ Other API changes
 
 Deprecations
 ~~~~~~~~~~~~
+- Deprecated parsing datetime strings with system-local timezone to ``tzlocal``, pass a ``tz`` keyword or explicitly call ``tz_localize`` instead (:issue:`50791`)
 - Deprecated argument ``infer_datetime_format`` in :func:`to_datetime` and :func:`read_csv`, as a strict version of it is now the default (:issue:`48621`)
 - Deprecated :func:`pandas.io.sql.execute` (:issue:`50185`)
 - :meth:`Index.is_boolean` has been deprecated. Use :func:`pandas.api.types.is_bool_dtype` instead (:issue:`50042`)

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -654,14 +654,17 @@ cdef dateutil_parse(
     if not ignoretz:
         if res.tzname and res.tzname in time.tzname:
             # GH#50791
-            assert False, (res.tzname, time.tzname)
-            warnings.warn(
-                "Parsing '{res.tzname}' as tzlocal (dependent on system timezone) "
-                "is deprecated and will raise in a future version. Pass the 'tz' "
-                "keyword or call tz_localize after construction instead",
-                FutureWarning,
-                stacklevel=find_stack_level()
-            )
+            if res.tzname != "UTC":
+                # If the system is localized in UTC (as many CI runs are)
+                #  we get tzlocal, once the deprecation is enforced will get
+                #  timezone.utc, not raise.
+                warnings.warn(
+                    "Parsing '{res.tzname}' as tzlocal (dependent on system timezone) "
+                    "is deprecated and will raise in a future version. Pass the 'tz' "
+                    "keyword or call tz_localize after construction instead",
+                    FutureWarning,
+                    stacklevel=find_stack_level()
+                )
             ret = ret.replace(tzinfo=_dateutil_tzlocal())
         elif res.tzoffset == 0:
             ret = ret.replace(tzinfo=_dateutil_tzutc())

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -654,6 +654,7 @@ cdef dateutil_parse(
     if not ignoretz:
         if res.tzname and res.tzname in time.tzname:
             # GH#50791
+            assert False, (res.tzname, time.tzname)
             warnings.warn(
                 "Parsing '{res.tzname}' as tzlocal (dependent on system timezone) "
                 "is deprecated and will raise in a future version. Pass the 'tz' "

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -653,6 +653,14 @@ cdef dateutil_parse(
         ret = ret + relativedelta.relativedelta(weekday=res.weekday)
     if not ignoretz:
         if res.tzname and res.tzname in time.tzname:
+            # GH#50791
+            warnings.warn(
+                "Parsing '{res.tzname}' as tzlocal (dependent on system timezone) "
+                "is deprecated and will raise in a future version. Pass the 'tz' "
+                "keyword or call tz_localize after construction instead",
+                FutureWarning,
+                stacklevel=find_stack_level()
+            )
             ret = ret.replace(tzinfo=_dateutil_tzlocal())
         elif res.tzoffset == 0:
             ret = ret.replace(tzinfo=_dateutil_tzutc())

--- a/pandas/tests/tslibs/test_array_to_datetime.py
+++ b/pandas/tests/tslibs/test_array_to_datetime.py
@@ -67,12 +67,13 @@ def test_parsing_timezone_offsets(dt_string, expected_tz):
     assert result_tz == timezone(timedelta(minutes=expected_tz))
 
 
-@pytest.mark.filterwarnings("ignore:.*dependent on system timezone.*:FutureWarning")
 def test_parsing_non_iso_timezone_offset():
     dt_string = "01-01-2013T00:00:00.000000000+0000"
     arr = np.array([dt_string], dtype=object)
 
-    result, result_tz = tslib.array_to_datetime(arr)
+    with tm.assert_produces_warning(None):
+        # GH#50949 should not get tzlocal-deprecation warning here
+        result, result_tz = tslib.array_to_datetime(arr)
     expected = np.array([np.datetime64("2013-01-01 00:00:00.000000000")])
 
     tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/tslibs/test_array_to_datetime.py
+++ b/pandas/tests/tslibs/test_array_to_datetime.py
@@ -67,6 +67,7 @@ def test_parsing_timezone_offsets(dt_string, expected_tz):
     assert result_tz == timezone(timedelta(minutes=expected_tz))
 
 
+@pytest.mark.filterwarnings("ignore:.*dependent on system timezone.*:FutureWarning")
 def test_parsing_non_iso_timezone_offset():
     dt_string = "01-01-2013T00:00:00.000000000+0000"
     arr = np.array([dt_string], dtype=object)

--- a/pandas/tests/tslibs/test_parsing.py
+++ b/pandas/tests/tslibs/test_parsing.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import re
 
 from dateutil.parser import parse as du_parse
+from dateutil.tz import tzlocal
 import numpy as np
 import pytest
 
@@ -16,6 +17,22 @@ from pandas._libs.tslibs.parsing import parse_datetime_string_with_reso
 import pandas.util._test_decorators as td
 
 import pandas._testing as tm
+
+
+def test_parsing_tzlocal_deprecated():
+    # GH#50791
+    msg = "Pass the 'tz' keyword or call tz_localize after construction instead"
+    dtstr = "Jan 15 2004 03:00 EST"
+
+    with tm.set_timezone("US/Eastern"):
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            res, _ = parse_datetime_string_with_reso(dtstr)
+
+        assert isinstance(res.tzinfo, tzlocal)
+
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            res = parsing.parse_datetime_string(dtstr)
+        assert isinstance(res.tzinfo, tzlocal)
 
 
 def test_parse_datetime_string_with_reso():

--- a/pandas/tests/tslibs/test_parsing.py
+++ b/pandas/tests/tslibs/test_parsing.py
@@ -19,6 +19,7 @@ import pandas.util._test_decorators as td
 import pandas._testing as tm
 
 
+@td.skip_if_windows
 def test_parsing_tzlocal_deprecated():
     # GH#50791
     msg = "Pass the 'tz' keyword or call tz_localize after construction instead"


### PR DESCRIPTION
- [x] closes #50791 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
