### PR TITLE
BUG: df_empty.convert_dtypes() with pyarrow backend

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -137,15 +137,17 @@ def to_pyarrow_type(
     Convert dtype to a pyarrow type instance.
     """
     if isinstance(dtype, ArrowDtype):
-        pa_dtype = dtype.pyarrow_dtype
+        return dtype.pyarrow_dtype
     elif isinstance(dtype, pa.DataType):
-        pa_dtype = dtype
+        return dtype
     elif dtype:
-        # Accepts python types too
-        pa_dtype = pa.from_numpy_dtype(dtype)
-    else:
-        pa_dtype = None
-    return pa_dtype
+        try:
+            # Accepts python types too
+            # Doesn't handle all numpy types
+            return pa.from_numpy_dtype(dtype)
+        except pa.ArrowNotImplementedError:
+            pass
+    return None
 
 
 class ArrowExtensionArray(OpsMixin, ExtensionArray):

--- a/pandas/tests/frame/methods/test_convert_dtypes.py
+++ b/pandas/tests/frame/methods/test_convert_dtypes.py
@@ -120,3 +120,10 @@ class TestConvertDtypes:
             }
         )
         tm.assert_frame_equal(result, expected)
+
+    def test_pyarrow_dtype_empty_object(self):
+        # GH 50970
+        expected = pd.DataFrame(columns=[0])
+        with pd.option_context("mode.dtype_backend", "pyarrow"):
+            result = expected.convert_dtypes()
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/methods/test_convert_dtypes.py
+++ b/pandas/tests/frame/methods/test_convert_dtypes.py
@@ -123,6 +123,7 @@ class TestConvertDtypes:
 
     def test_pyarrow_dtype_empty_object(self):
         # GH 50970
+        pytest.importorskip("pyarrow")
         expected = pd.DataFrame(columns=[0])
         with pd.option_context("mode.dtype_backend", "pyarrow"):
             result = expected.convert_dtypes()


### PR DESCRIPTION
- [x] closes #50970 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.

Doesn't need a whatsnew since this will be a new feature in 2.0
