### PR TITLE
DEPR: Move Numericindex._convert_slice_indexer & ._maybe_cast_slice_bound

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6291,11 +6291,9 @@ class Index(IndexOpsMixin, PandasObject):
         """
 
         # We are a plain index here (sub-class override this method if they
-        # wish to have special treatment for floats/ints, e.g. NumericIndex and
-        # datetimelike Indexes
-        # Special case numeric EA Indexes, since they are not handled by NumericIndex
+        # wish to have special treatment for floats/ints, e.g. datetimelike Indexes
 
-        if is_extension_array_dtype(self.dtype) and is_numeric_dtype(self.dtype):
+        if is_numeric_dtype(self.dtype):
             return self._maybe_cast_indexer(label)
 
         # reject them, if index does not contain label

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3985,7 +3985,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         # TODO(GH#50617): once Series.__[gs]etitem__ is removed we should be able
         #  to simplify this.
-        if is_float_dtype(self.dtype):
+        if isinstance(self.dtype, np.dtype) and is_float_dtype(self.dtype):
             # We always treat __getitem__ slicing as label-based
             # translate to locations
             return self.slice_indexer(start, stop, step)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3983,6 +3983,13 @@ class Index(IndexOpsMixin, PandasObject):
         # potentially cast the bounds to integers
         start, stop, step = key.start, key.stop, key.step
 
+        # TODO(GH#50617): once Series.__[gs]etitem__ is removed we should be able
+        #  to simplify this.
+        if is_float_dtype(self.dtype):
+            # We always treat __getitem__ slicing as label-based
+            # translate to locations
+            return self.slice_indexer(start, stop, step)
+
         # figure out if this is a positional indexer
         def is_int(v):
             return v is None or is_integer(v)

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -12,7 +12,6 @@ from pandas.util._decorators import (
 
 from pandas.core.dtypes.common import (
     is_dtype_equal,
-    is_float_dtype,
     is_integer_dtype,
     is_numeric_dtype,
     is_scalar,
@@ -169,19 +168,6 @@ class NumericIndex(Index):
     @doc(Index._should_fallback_to_positional)
     def _should_fallback_to_positional(self) -> bool:
         return False
-
-    @doc(Index._convert_slice_indexer)
-    def _convert_slice_indexer(self, key: slice, kind: str):
-        # TODO(GH#50617): once Series.__[gs]etitem__ is removed we should be able
-        #  to simplify this.
-        if is_float_dtype(self.dtype):
-            assert kind in ["loc", "getitem"]
-
-            # We always treat __getitem__ slicing as label-based
-            # translate to locations
-            return self.slice_indexer(key.start, key.stop, key.step)
-
-        return super()._convert_slice_indexer(key, kind=kind)
 
     @doc(Index._maybe_cast_slice_bound)
     def _maybe_cast_slice_bound(self, label, side: str):

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -169,11 +169,6 @@ class NumericIndex(Index):
     def _should_fallback_to_positional(self) -> bool:
         return False
 
-    @doc(Index._maybe_cast_slice_bound)
-    def _maybe_cast_slice_bound(self, label, side: str):
-        # we will try to coerce to integers
-        return self._maybe_cast_indexer(label)
-
     # ----------------------------------------------------------------
 
     @classmethod


### PR DESCRIPTION
Moves`_convert_slice_indexer` & `_maybe_cast_slice_bound` from `NumericIndex`to `Index` in preparation to remove `NumericIndex` and include numpy int/uint/float64 in the base `Index`.

Each commit contains one method moving each, could be easier to view each method separately in the commit. 

xref #42717.