### PR TITLE
CLN validate some Py_* Functions in C Extensions check for NULL

### DIFF
--- a/pandas/_libs/src/parser/io.c
+++ b/pandas/_libs/src/parser/io.c
@@ -66,6 +66,9 @@ void *buffer_rd_bytes(void *source, size_t nbytes, size_t *bytes_read,
     args = Py_BuildValue("(i)", nbytes);
 
     func = PyObject_GetAttrString(src->obj, "read");
+    if (func == NULL) {
+        return NULL;
+    }
 
     /* TODO: does this release the GIL? */
     result = PyObject_CallObject(func, args);

--- a/pandas/_libs/src/ujson/python/JSONtoObj.c
+++ b/pandas/_libs/src/ujson/python/JSONtoObj.c
@@ -108,6 +108,9 @@ JSOBJ Object_npyNewArray(void *prv, void *_decoder) {
     if (decoder->curdim <= 0) {
         // start of array - initialise the context buffer
         npyarr = decoder->npyarr = PyObject_Malloc(sizeof(NpyArrContext));
+        if (npyarr == NULL) {
+            return NULL;
+        }
         decoder->npyarr_addr = npyarr;
 
         if (!npyarr) {
@@ -119,6 +122,9 @@ JSOBJ Object_npyNewArray(void *prv, void *_decoder) {
         npyarr->labels[0] = npyarr->labels[1] = NULL;
 
         npyarr->shape.ptr = PyObject_Malloc(sizeof(npy_intp) * NPY_MAXDIMS);
+        if (npyarr->shape.ptr == NULL) {
+            return NULL;
+        }
         npyarr->shape.len = 1;
         npyarr->ret = NULL;
 

--- a/pandas/_libs/src/ujson/python/date_conversions.c
+++ b/pandas/_libs/src/ujson/python/date_conversions.c
@@ -90,6 +90,10 @@ char *PyDateTimeToIso(PyObject *obj, NPY_DATETIMEUNIT base,
 
     *len = (size_t)get_datetime_iso_8601_strlen(0, base);
     char *result = PyObject_Malloc(*len);
+    if (result == NULL) {
+        PyErr_NoMemory();
+        return NULL;
+    }
     // Check to see if PyDateTime has a timezone.
     // Don't convert to UTC if it doesn't.
     int is_tz_aware = 0;

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -149,6 +149,9 @@ static TypeContext *createTypeContext(void) {
     TypeContext *pc;
 
     pc = PyObject_Malloc(sizeof(TypeContext));
+    if (pc == NULL) {
+        return NULL;
+    }
     if (!pc) {
         PyErr_NoMemory();
         return NULL;
@@ -183,11 +186,17 @@ static PyObject *get_values(PyObject *obj) {
         //  without going through and object array of Timestamps.
         if (PyObject_HasAttrString(obj, "tz")) {
             PyObject *tz = PyObject_GetAttrString(obj, "tz");
+            if (tz == NULL) {
+                return NULL;
+            }
             if (tz != Py_None) {
                 // Go through object array if we have dt64tz, since tz info will
                 // be lost if values is used directly.
                 Py_DECREF(tz);
                 values = PyObject_CallMethod(obj, "__array__", NULL);
+                if (values == NULL) {
+                    return NULL;
+                }
                 return values;
             }
             Py_DECREF(tz);
@@ -211,10 +220,19 @@ static PyObject *get_values(PyObject *obj) {
 
     if (values == NULL) {
         PyObject *typeRepr = PyObject_Repr((PyObject *)Py_TYPE(obj));
+        if (typeRepr == NULL) {
+            return NULL;
+        }
         PyObject *repr;
         if (PyObject_HasAttrString(obj, "dtype")) {
             PyObject *dtype = PyObject_GetAttrString(obj, "dtype");
+            if (dtype == NULL) {
+                return NULL;
+            }
             repr = PyObject_Repr(dtype);
+            if (repr == NULL) {
+                return NULL;
+            }
             Py_DECREF(dtype);
         } else {
             repr = PyUnicode_FromString("<unknown dtype>");
@@ -233,12 +251,18 @@ static PyObject *get_values(PyObject *obj) {
 
 static PyObject *get_sub_attr(PyObject *obj, char *attr, char *subAttr) {
     PyObject *tmp = PyObject_GetAttrString(obj, attr);
+    if (tmp == NULL) {
+        return NULL;
+    }
     PyObject *ret;
 
     if (tmp == 0) {
         return 0;
     }
     ret = PyObject_GetAttrString(tmp, subAttr);
+    if (ret == NULL) {
+        return ret;
+    }
     Py_DECREF(tmp);
 
     return ret;


### PR DESCRIPTION
xref #49756

@WillAyd is this what you had in mind?

In cases like

https://github.com/pandas-dev/pandas/blob/3a1a8b3c6bc94a3036e45d75adf33adc5b35c697/pandas/_libs/src/ujson/python/objToJSON.c#L902-L906

which return `void`, how should `NULL` be handled?