### PR TITLE
BLD: Drop universal2 wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,7 @@ test-command = "python {project}/ci/test_wheels.py"
 
 [tool.cibuildwheel.macos]
 archs = "x86_64 arm64"
-test-skip = "*_arm64 *_universal2:arm64"
+test-skip = "*_arm64"
 
 [tool.cibuildwheel.windows]
 repair-wheel-command = "python ci/fix_wheels.py {wheel} {dest_dir}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ test-requires = "hypothesis>=6.34.2 pytest>=7.0.0 pytest-xdist>=2.2.0 pytest-asy
 test-command = "python {project}/ci/test_wheels.py"
 
 [tool.cibuildwheel.macos]
-archs = "x86_64 universal2"
+archs = "x86_64 arm64"
 test-skip = "*_arm64 *_universal2:arm64"
 
 [tool.cibuildwheel.windows]


### PR DESCRIPTION
Numpy hasn't provided them anymore for a while, so let's drop them as well to cut down on compilation time and save space on PyPI.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
