### PR TITLE
DEPR: Remove NumericIndex from tests/indexes/numeric.py

### DIFF
--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -929,15 +929,13 @@ class NumericBase(Base):
         result = a - fidx
         tm.assert_index_equal(result, expected)
 
-    def test_invalid_dtype(self, invalid_dtype):
-        # GH 29539
-        dtype = invalid_dtype
-        msg = rf"Incorrect `dtype` passed: expected \w+(?: \w+)?, received {dtype}"
-        with pytest.raises(ValueError, match=msg):
-            self._index_cls([1, 2, 3], dtype=dtype)
-
     @pytest.mark.parametrize("complex_dtype", [np.complex64, np.complex128])
     def test_astype_to_complex(self, complex_dtype, simple_index):
         result = simple_index.astype(complex_dtype)
 
         assert type(result) is Index and result.dtype == complex_dtype
+
+    def test_cast_string(self, dtype):
+        result = self._index_cls(["0", "1", "2"], dtype=dtype)
+        expected = self._index_cls([0, 1, 2], dtype=dtype)
+        tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/numeric/test_numeric.py
+++ b/pandas/tests/indexes/numeric/test_numeric.py
@@ -1,27 +1,20 @@
 import numpy as np
 import pytest
 
-from pandas._libs.tslibs import Timestamp
-
 import pandas as pd
 from pandas import (
     Index,
     Series,
 )
 import pandas._testing as tm
-from pandas.core.indexes.api import NumericIndex
 from pandas.tests.indexes.common import NumericBase
 
 
 class TestFloatNumericIndex(NumericBase):
-    _index_cls = NumericIndex
+    _index_cls = Index
 
     @pytest.fixture(params=[np.float64, np.float32])
     def dtype(self, request):
-        return request.param
-
-    @pytest.fixture(params=["category", "datetime64", "object"])
-    def invalid_dtype(self, request):
         return request.param
 
     @pytest.fixture
@@ -50,11 +43,9 @@ class TestFloatNumericIndex(NumericBase):
         return self._index_cls([0.0, 2.5, 5.0, 7.5, 10.0], dtype=dtype)
 
     def test_repr_roundtrip(self, index):
-        tm.assert_index_equal(eval(repr(index)), index, exact=True)
+        from pandas.core.api import NumericIndex  # noqa: F401
 
-    def check_is_index(self, idx):
-        assert isinstance(idx, Index)
-        assert not isinstance(idx, self._index_cls)
+        tm.assert_index_equal(eval(repr(index)), index, exact=True)
 
     def check_coerce(self, a, b, is_float_index=True):
         assert a.equals(b)
@@ -62,7 +53,7 @@ class TestFloatNumericIndex(NumericBase):
         if is_float_index:
             assert isinstance(b, self._index_cls)
         else:
-            self.check_is_index(b)
+            assert type(b) is Index
 
     def test_constructor_from_list_no_dtype(self):
         index = self._index_cls([1.5, 2.5, 3.5])
@@ -110,7 +101,6 @@ class TestFloatNumericIndex(NumericBase):
     def test_constructor_invalid(self):
         index_cls = self._index_cls
         cls_name = index_cls.__name__
-
         # invalid
         msg = (
             rf"{cls_name}\(\.\.\.\) must be called with a collection of "
@@ -118,13 +108,6 @@ class TestFloatNumericIndex(NumericBase):
         )
         with pytest.raises(TypeError, match=msg):
             index_cls(0.0)
-
-        msg = f"data is not compatible with {index_cls.__name__}"
-        with pytest.raises(ValueError, match=msg):
-            index_cls(["a", "b", 0.0])
-
-        with pytest.raises(ValueError, match=msg):
-            index_cls([Timestamp("20130101")])
 
     def test_constructor_coerce(self, mixed_index, float_index):
 
@@ -254,6 +237,8 @@ class TestFloatNumericIndex(NumericBase):
 
 
 class NumericInt(NumericBase):
+    _index_cls = Index
+
     def test_is_monotonic(self):
         index_cls = self._index_cls
 
@@ -317,18 +302,13 @@ class NumericInt(NumericBase):
 
         assert not index.astype(dtype=object).identical(index.astype(dtype=dtype))
 
-    def test_cant_or_shouldnt_cast(self):
-        msg = f"data is not compatible with {self._index_cls.__name__}"
+    def test_cant_or_shouldnt_cast(self, dtype):
+        msg = r"invalid literal for int\(\) with base 10: 'foo'"
 
         # can't
         data = ["foo", "bar", "baz"]
         with pytest.raises(ValueError, match=msg):
-            self._index_cls(data)
-
-        # shouldn't
-        data = ["0", "1", "2"]
-        with pytest.raises(ValueError, match=msg):
-            self._index_cls(data)
+            self._index_cls(data, dtype=dtype)
 
     def test_view_index(self, simple_index):
         index = simple_index
@@ -341,14 +321,8 @@ class NumericInt(NumericBase):
 
 
 class TestIntNumericIndex(NumericInt):
-    _index_cls = NumericIndex
-
     @pytest.fixture(params=[np.int64, np.int32, np.int16, np.int8])
     def dtype(self, request):
-        return request.param
-
-    @pytest.fixture(params=["category", "datetime64", "object"])
-    def invalid_dtype(self, request):
         return request.param
 
     @pytest.fixture
@@ -427,7 +401,8 @@ class TestIntNumericIndex(NumericInt):
 
         # preventing casting
         arr = np.array([1, "2", 3, "4"], dtype=object)
-        with pytest.raises(TypeError, match="casting"):
+        msg = "Trying to coerce float values to integers"
+        with pytest.raises(ValueError, match=msg):
             index_cls(arr, dtype=dtype)
 
     def test_constructor_coercion_signed_to_unsigned(
@@ -468,7 +443,7 @@ class TestIntNumericIndex(NumericInt):
 class TestFloat16Index:
     # float 16 indexes not supported
     # GH 49535
-    _index_cls = NumericIndex
+    _index_cls = Index
 
     def test_constructor(self):
         index_cls = self._index_cls
@@ -504,15 +479,8 @@ class TestFloat16Index:
 
 
 class TestUIntNumericIndex(NumericInt):
-
-    _index_cls = NumericIndex
-
     @pytest.fixture(params=[np.uint64])
     def dtype(self, request):
-        return request.param
-
-    @pytest.fixture(params=["category", "datetime64", "object"])
-    def invalid_dtype(self, request):
         return request.param
 
     @pytest.fixture
@@ -583,8 +551,8 @@ def test_map_dtype_inference_unsigned_to_signed():
 
 def test_map_dtype_inference_overflows():
     # GH#44609 case where we have to upcast
-    idx = NumericIndex(np.array([1, 2, 3], dtype=np.int8))
+    idx = Index(np.array([1, 2, 3], dtype=np.int8))
     result = idx.map(lambda x: x * 1000)
     # TODO: we could plausibly try to infer down to int16 here
-    expected = NumericIndex([1000, 2000, 3000], dtype=np.int64)
+    expected = Index([1000, 2000, 3000], dtype=np.int64)
     tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -29,7 +29,7 @@ class TestRangeIndex(NumericBase):
         return request.param
 
     @pytest.fixture
-    def simple_index(self) -> Index:
+    def simple_index(self):
         return self._index_cls(start=0, stop=20, step=2)
 
     @pytest.fixture(
@@ -612,3 +612,6 @@ class TestRangeIndex(NumericBase):
         result = values.sort_values(key=lambda x: x.map(sort_order))
         expected = Index([4, 8, 6, 0, 2], dtype="int64")
         tm.assert_index_equal(result, expected, check_exact=True)
+
+    def test_cast_string(self, dtype):
+        pytest.skip("casting of strings not relevant for RangeIndex")


### PR DESCRIPTION
Removing `NumericIndex` from tests/indexes/numeric.py and replaces it with `Index` in preparation for removal of `NumericIndex` from tests/indexes/numeric.py.

xref #42717.