### PR TITLE
aggregations.pyx: use std:: for signbit() and sqrt().

### DIFF
--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -1,10 +1,7 @@
 # cython: boundscheck=False, wraparound=False, cdivision=True
 
-from libc.math cimport (
-    round,
-    signbit,
-    sqrt,
-)
+from libc.math cimport round
+
 from libcpp.deque cimport deque
 
 from pandas._libs.algos cimport TiebreakEnumType
@@ -18,6 +15,10 @@ from numpy cimport (
     int64_t,
     ndarray,
 )
+
+cdef extern from "<cmath>" namespace "std":
+    int signbit(float64_t) nogil
+    float64_t sqrt(float64_t x) nogil
 
 cnp.import_array()
 


### PR DESCRIPTION
This reintroduces how this was done in pandas 1.3.5. This should fix issue #51047.

- [x] closes #51047
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
