### PR TITLE
DEPR: Remove NumericIndex from pandas/io/

### DIFF
--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -24,7 +24,6 @@ from pandas import (
 )
 from pandas.core.api import (
     DataFrame,
-    NumericIndex,
     RangeIndex,
 )
 from pandas.core.shared_docs import _shared_docs
@@ -69,7 +68,7 @@ def to_feather(
     # validate that we have only a default index
     # raise on anything else as we don't serialize the index
 
-    if not (isinstance(df.index, NumericIndex) and df.index.dtype == "int64"):
+    if not df.index.dtype == "int64":
         typ = type(df.index)
         raise ValueError(
             f"feather does not support serializing {typ} "

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -90,7 +90,6 @@ from pandas import (
     concat,
     isna,
 )
-from pandas.core.api import NumericIndex
 from pandas.core.arrays import (
     Categorical,
     DatetimeArray,
@@ -2051,7 +2050,7 @@ class IndexCol:
 
     def convert(
         self, values: np.ndarray, nan_rep, encoding: str, errors: str
-    ) -> tuple[np.ndarray, np.ndarray] | tuple[DatetimeIndex, DatetimeIndex]:
+    ) -> tuple[np.ndarray, np.ndarray] | tuple[Index, Index]:
         """
         Convert the data from this selection to the appropriate pandas type.
         """
@@ -2244,13 +2243,9 @@ class GenericIndexCol(IndexCol):
     def is_indexed(self) -> bool:
         return False
 
-    # error: Return type "Tuple[NumericIndex, NumericIndex]" of "convert"
-    # incompatible with return type "Union[Tuple[ndarray[Any, Any],
-    # ndarray[Any, Any]], Tuple[DatetimeIndex, DatetimeIndex]]" in
-    # supertype "IndexCol"
-    def convert(  # type: ignore[override]
+    def convert(
         self, values: np.ndarray, nan_rep, encoding: str, errors: str
-    ) -> tuple[NumericIndex, NumericIndex]:
+    ) -> tuple[Index, Index]:
         """
         Convert the data from this selection to the appropriate pandas type.
 
@@ -2263,7 +2258,7 @@ class GenericIndexCol(IndexCol):
         """
         assert isinstance(values, np.ndarray), type(values)
 
-        index = NumericIndex(np.arange(len(values)), dtype=np.int64)
+        index = Index(np.arange(len(values), dtype=np.int64))
         return index, index
 
     def set_attr(self) -> None:
@@ -4866,11 +4861,11 @@ def _convert_index(name: str, index: Index, encoding: str, errors: str) -> Index
     atom = DataIndexableCol._get_atom(converted)
 
     if (
-        (isinstance(index, NumericIndex) and is_integer_dtype(index))
+        (isinstance(index.dtype, np.dtype) and is_integer_dtype(index))
         or needs_i8_conversion(index.dtype)
         or is_bool_dtype(index.dtype)
     ):
-        # Includes NumericIndex, RangeIndex, DatetimeIndex, TimedeltaIndex, PeriodIndex,
+        # Includes Index, RangeIndex, DatetimeIndex, TimedeltaIndex, PeriodIndex,
         #  in which case "kind" is "integer", "integer", "datetime64",
         #  "timedelta64", and "integer", respectively.
         return IndexCol(


### PR DESCRIPTION
Removing `NumericIndex` from pandas/io and replaces it with `Index` in preparation for removal of `NumericIndex` from tests/indexes/numeric.py.

Also fixes a typing issue.

xref #42717.