### PR TITLE
TST: Move xfail to its own test

### DIFF
--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2426,14 +2426,6 @@ def test_group_on_two_row_multiindex_returns_one_tuple_key():
         (DataFrame, "group_keys", False),
         (DataFrame, "observed", True),
         (DataFrame, "dropna", False),
-        pytest.param(
-            Series,
-            "axis",
-            1,
-            marks=pytest.mark.xfail(
-                reason="GH 35443: Attribute currently not passed on to series"
-            ),
-        ),
         (Series, "level", "a"),
         (Series, "as_index", False),
         (Series, "sort", False),

--- a/pandas/tests/groupby/test_raises.py
+++ b/pandas/tests/groupby/test_raises.py
@@ -176,3 +176,11 @@ def test_groupby_raises_datetime_udf(how):
 
     with pytest.raises(TypeError, match="Test error message"):
         getattr(gb, how)(func)
+
+
+def test_subsetting_columns_axis_1_raises():
+    # GH 35443
+    df = DataFrame({"a": [1], "b": [2], "c": [3]})
+    gb = df.groupby("a", axis=1)
+    with pytest.raises(ValueError, match="Cannot subset columns when using axis=1"):
+        gb["b"]


### PR DESCRIPTION
- [x] closes #35443 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
