### PR TITLE
DEPR: Move NumericIndex doc string + some minor stuff

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -288,6 +288,11 @@ class Index(IndexOpsMixin, PandasObject):
 
     The basic object storing axis labels for all pandas objects.
 
+    .. versionchanged:: 2.0.0
+
+       Index can hold all numpy numeric dtypes (except float16). Previously only
+       int64/uint64/float64 dtypes were accepted.
+
     Parameters
     ----------
     data : array-like (1-dimensional)
@@ -315,7 +320,8 @@ class Index(IndexOpsMixin, PandasObject):
 
     Notes
     -----
-    An Index instance can **only** contain hashable objects
+    An Index instance can **only** contain hashable objects.
+    An Index instance *can not* hold numpy float16 dtype.
 
     Examples
     --------
@@ -324,6 +330,9 @@ class Index(IndexOpsMixin, PandasObject):
 
     >>> pd.Index(list('abc'))
     Index(['a', 'b', 'c'], dtype='object')
+
+    >>> pd.Index([1, 2, 3], dtype="uint8")
+    NumericIndex([1, 2, 3], dtype='uint8')
     """
 
     # To hand over control to subclasses
@@ -400,7 +409,10 @@ class Index(IndexOpsMixin, PandasObject):
     _no_setting_name: bool = False
     _comparables: list[str] = ["name"]
     _attributes: list[str] = ["name"]
-    _can_hold_strings: bool = True
+
+    @cache_readonly
+    def _can_hold_strings(self):
+        return not is_numeric_dtype(self)
 
     _engine_types: dict[np.dtype | ExtensionDtype, type[libindex.IndexEngine]] = {
         np.dtype(np.int8): libindex.Int8Engine,

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -411,7 +411,7 @@ class Index(IndexOpsMixin, PandasObject):
     _attributes: list[str] = ["name"]
 
     @cache_readonly
-    def _can_hold_strings(self):
+    def _can_hold_strings(self) -> bool:
         return not is_numeric_dtype(self)
 
     _engine_types: dict[np.dtype | ExtensionDtype, type[libindex.IndexEngine]] = {

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -12,46 +12,6 @@ from pandas.core.indexes.base import Index
 
 
 class NumericIndex(Index):
-    """
-    Immutable numeric sequence used for indexing and alignment.
-
-    The basic object storing axis labels for all pandas objects.
-    NumericIndex is a special case of `Index` with purely numpy int/uint/float labels.
-
-    .. versionadded:: 1.4.0
-
-    Parameters
-    ----------
-    data : array-like (1-dimensional)
-    dtype : NumPy dtype (default: None)
-    copy : bool
-        Make a copy of input ndarray.
-    name : object
-        Name to be stored in the index.
-
-    Attributes
-    ----------
-    None
-
-    Methods
-    -------
-    None
-
-    See Also
-    --------
-    Index : The base pandas Index type.
-
-    Notes
-    -----
-    An NumericIndex instance can **only** contain numpy int64/32/16/8, uint64/32/16/8 or
-    float64/32 dtype. In particular, ``NumericIndex`` *can not* hold numpy float16
-    dtype or Pandas numeric dtypes (:class:`Int64Dtype`, :class:`Int32Dtype` etc.).
-    """
-
-    _typ = "numericindex"
-    _default_dtype: np.dtype | None = None
-    _can_hold_strings = False
-
     def __new__(
         cls, data=None, dtype: Dtype | None = None, copy: bool = False, name=None
     ) -> NumericIndex:


### PR DESCRIPTION
Moves doc string  of `NumericIndex` to `Index`. Also moves `_can_hold_strings` attribute and removes  `NumericIndex._default_dtype`, & `NumericIndex._typ`.

xref #42717.
