### PR TITLE
DOC add examples to Timestamp.unit

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -187,7 +187,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.show_versions \
         pandas.test \
         pandas.NaT \
-        pandas.Timestamp.unit \
         pandas.Timestamp.as_unit \
         pandas.Timestamp.ctime \
         pandas.Timestamp.date \

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -236,6 +236,20 @@ cdef class _Timestamp(ABCTimestamp):
     def unit(self) -> str:
         """
         The abbreviation associated with self._creso.
+
+        Examples
+        --------
+        >>> pd.Timestamp("2020-01-01 12:34:56").unit
+        's'
+
+        >>> pd.Timestamp("2020-01-01 12:34:56.123").unit
+        'ms'
+
+        >>> pd.Timestamp("2020-01-01 12:34:56.123456").unit
+        'us'
+
+        >>> pd.Timestamp("2020-01-01 12:34:56.123456789").unit
+        'ns'
         """
         return npy_unit_to_abbrev(self._creso)
 


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/37875

Just an example of how to open such a PR

Before submitting, you should run
```
python scripts/validate_docstrings.py pandas.Timestamp.unit
```
and check that `No examples section found` doesn't appear in the "errors found" section (if other errors appear, it's probably fine for now)

You should then also remove the function you've fixed up to the exclusions in `ci/code_checks.sh` under the EX01 section
