### PR TITLE
REF: GroupBy.ops don't depend on mutation status

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1790,7 +1790,6 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                 sort=self.sort,
                 group_keys=self.group_keys,
                 observed=self.observed,
-                mutated=self.mutated,
                 dropna=self.dropna,
             )
         elif ndim == 1:

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -620,7 +620,6 @@ class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
         "group_keys",
         "keys",
         "level",
-        "mutated",
         "obj",
         "observed",
         "sort",
@@ -900,7 +899,6 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         sort: bool = True,
         group_keys: bool | lib.NoDefault = True,
         observed: bool = False,
-        mutated: bool = False,
         dropna: bool = True,
     ) -> None:
 
@@ -919,7 +917,6 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         self.sort = sort
         self.group_keys = group_keys
         self.observed = observed
-        self.mutated = mutated
         self.dropna = dropna
 
         if grouper is None:
@@ -930,7 +927,6 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                 level=level,
                 sort=sort,
                 observed=observed,
-                mutated=self.mutated,
                 dropna=self.dropna,
             )
 
@@ -3113,7 +3109,6 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                 axis=self.axis,
                 level=self.level,
                 sort=self.sort,
-                mutated=self.mutated,
             )
 
         grb = dropped.groupby(
@@ -4263,7 +4258,6 @@ def get_groupby(
     sort: bool = True,
     group_keys: bool | lib.NoDefault = True,
     observed: bool = False,
-    mutated: bool = False,
     dropna: bool = True,
 ) -> GroupBy:
 
@@ -4291,7 +4285,6 @@ def get_groupby(
         sort=sort,
         group_keys=group_keys,
         observed=observed,
-        mutated=mutated,
         dropna=dropna,
     )
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1487,7 +1487,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         """
         values, mutated = self.grouper.apply(f, data, self.axis)
         if not_indexed_same is None:
-            not_indexed_same = mutated or self.mutated
+            not_indexed_same = mutated
 
         return self._wrap_applied_output(
             data,

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -738,7 +738,6 @@ def get_grouper(
     level=None,
     sort: bool = True,
     observed: bool = False,
-    mutated: bool = False,
     validate: bool = True,
     dropna: bool = True,
 ) -> tuple[ops.BaseGrouper, frozenset[Hashable], NDFrameT]:
@@ -957,9 +956,7 @@ def get_grouper(
         groupings.append(Grouping(Index([], dtype="int"), np.array([], dtype=np.intp)))
 
     # create the internals grouper
-    grouper = ops.BaseGrouper(
-        group_axis, groupings, sort=sort, mutated=mutated, dropna=dropna
-    )
+    grouper = ops.BaseGrouper(group_axis, groupings, sort=sort, dropna=dropna)
     return grouper, frozenset(exclusions), obj
 
 

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -678,7 +678,6 @@ class BaseGrouper:
     sort : bool, default True
         whether this grouper will give sorted result or not
     group_keys : bool, default True
-    mutated : bool, default False
     indexer : np.ndarray[np.intp], optional
         the indexer created by Grouper
         some groupers (TimeGrouper) will sort its axis and its
@@ -694,7 +693,6 @@ class BaseGrouper:
         groupings: Sequence[grouper.Grouping],
         sort: bool = True,
         group_keys: bool = True,
-        mutated: bool = False,
         indexer: npt.NDArray[np.intp] | None = None,
         dropna: bool = True,
     ) -> None:
@@ -704,7 +702,6 @@ class BaseGrouper:
         self._groupings: list[grouper.Grouping] = list(groupings)
         self._sort = sort
         self.group_keys = group_keys
-        self.mutated = mutated
         self.indexer = indexer
         self.dropna = dropna
 
@@ -772,7 +769,7 @@ class BaseGrouper:
     def apply(
         self, f: Callable, data: DataFrame | Series, axis: AxisInt = 0
     ) -> tuple[list, bool]:
-        mutated = self.mutated
+        mutated = False
         splitter = self._get_splitter(data, axis=axis)
         group_keys = self.group_keys_seq
         result_values = []
@@ -1061,7 +1058,6 @@ class BinGrouper(BaseGrouper):
     ----------
     bins : the split index of binlabels to group the item of axis
     binlabels : the label list
-    mutated : bool, default False
     indexer : np.ndarray[np.intp]
 
     Examples
@@ -1084,18 +1080,15 @@ class BinGrouper(BaseGrouper):
 
     bins: npt.NDArray[np.int64]
     binlabels: Index
-    mutated: bool
 
     def __init__(
         self,
         bins,
         binlabels,
-        mutated: bool = False,
         indexer=None,
     ) -> None:
         self.bins = ensure_int64(bins)
         self.binlabels = ensure_index(binlabels)
-        self.mutated = mutated
         self.indexer = indexer
 
         # These lengths must match, otherwise we could call agg_series

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1168,8 +1168,6 @@ class _GroupByMixin(PandasObject):
         self.key = key
 
         self._groupby = groupby
-        self._groupby.mutated = True
-        self._groupby.grouper.mutated = True
         self.groupby = copy.copy(parent.groupby)
 
     @no_type_check

--- a/pandas/tests/window/test_groupby.py
+++ b/pandas/tests/window/test_groupby.py
@@ -46,20 +46,15 @@ def roll_frame():
 
 
 class TestRolling:
-    def test_mutated(self, roll_frame):
+    def test_groupby_unsupported_argument(self, roll_frame):
 
         msg = r"groupby\(\) got an unexpected keyword argument 'foo'"
         with pytest.raises(TypeError, match=msg):
             roll_frame.groupby("A", foo=1)
 
-        g = roll_frame.groupby("A")
-        assert not g.mutated
-        g = get_groupby(roll_frame, by="A", mutated=True)
-        assert g.mutated
-
     def test_getitem(self, roll_frame):
         g = roll_frame.groupby("A")
-        g_mutated = get_groupby(roll_frame, by="A", mutated=True)
+        g_mutated = get_groupby(roll_frame, by="A")
 
         expected = g_mutated.B.apply(lambda x: x.rolling(2).mean())
 
@@ -80,7 +75,7 @@ class TestRolling:
         # GH 13174
         g = roll_frame.groupby("A")
         r = g.rolling(2, min_periods=0)
-        g_mutated = get_groupby(roll_frame, by="A", mutated=True)
+        g_mutated = get_groupby(roll_frame, by="A")
         expected = g_mutated.B.apply(lambda x: x.rolling(2, min_periods=0).count())
 
         result = r.B.count()
@@ -789,8 +784,6 @@ class TestRolling:
         _ = g.rolling(window=4)
         result = g.apply(lambda x: x.rolling(4).sum()).index
         tm.assert_index_equal(result, expected)
-        assert not g.mutated
-        assert not g.grouper.mutated
 
     @pytest.mark.parametrize(
         ("window", "min_periods", "closed", "expected"),


### PR DESCRIPTION
`self.mutated` is only used in one place (see one-line edit in first commit) and removing that doesn't break anything.  Conceivably could change some behavior but until we have an example I don't think it is even worth documenting as an API change.

Might be leftover from the old libreduction path?

cc @jreback for the deep cut into the history