### PR TITLE
BUG: doc string error

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -332,7 +332,7 @@ class Index(IndexOpsMixin, PandasObject):
     Index(['a', 'b', 'c'], dtype='object')
 
     >>> pd.Index([1, 2, 3], dtype="uint8")
-    NumericIndex([1, 2, 3], dtype='uint8')
+    Index([1, 2, 3], dtype='uint8')
     """
 
     # To hand over control to subclasses


### PR DESCRIPTION
An error is occurring in `ci/code_checks.sh docstrings` because of a missing rebase:

```
Error: /home/runner/work/pandas/pandas/pandas/core/indexes/base.py:285:EX02:pandas.Index:Examples do not pass tests:
**********************************************************************
Line 49, in pandas.Index
Failed example:
    pd.Index([1, 2, 3], dtype="uint8")
Expected:
    NumericIndex([1, 2, 3], dtype='uint8')
Got:
    Index([1, 2, 3], dtype='uint8')
```

This fixes that.

xref #42717.