### PR TITLE
PERF: groupby iteration

### DIFF
--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -1308,7 +1308,7 @@ class FrameSplitter(DataSplitter):
         df = sdata._constructor(mgr)
         return df.__finalize__(sdata, method="groupby")
 
-    def _chop_fast(self, sdata: Series, slice_obj: slice) -> Series:
+    def _chop_fast(self, sdata: DataFrame, slice_obj: slice) -> DataFrame:
         # _chop specialized to cast with _can_fast_construct
         mgr = sdata._mgr.get_slice(slice_obj, axis=1 - self.axis)
         df = DataFrame(mgr)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Lookups on ._constructor and __finalize__ calls add up when iterating over many groups.  This does a pre-iteration check to see if we can skip those lookups/calls.

Using the example from #46505

```
import string
import random

import pandas as pd
import numpy as np
from time import time

rows = 500000
temp = np.random.randint(10**6, size=(rows, 3))
symbols = string.ascii_uppercase + string.digits
string_col = [''.join(random.choices(symbols, k=16)) for _ in range(rows)]
res = np.concatenate((temp, np.array([string_col]).T), axis=1)

df = pd.DataFrame(res)

def _format(x):
    vals = x.values
    if len(vals) > 2:
        return '-'.join(map(str, vals[:-1]))
    return np.nan


gb = df.groupby(3, sort=False)
func = {"col1": (2, _format), "col2": (1, _format)}
%prun -s cumtime gb.agg(**func)
```

On main this takes 31.655s of which 21.520 are in `_chop` and 8.357 are in `__finalize__`.  In this PR this takes 20.328s of which 11.237 are in `_chop_fast`.  (still slower than 1.3.5 which was 6.553s

There's a reasonable argument to be made that having separate paths for subclasses is not ideal, which I'll leave to @jorisvandenbossche to make if he's interested.