### PR TITLE
DEPR: remove NumericIndex.__new__ & ._should_fallback_to_positional

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5689,6 +5689,8 @@ class Index(IndexOpsMixin, PandasObject):
         """
         Should an integer key be treated as positional?
         """
+        if isinstance(self.dtype, np.dtype) and self.dtype.kind in ["i", "u", "f"]:
+            return False
         return not self._holds_integer()
 
     _index_shared_docs[

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -23,11 +23,3 @@ class NumericIndex(Index):
         return super().__new__(
             cls, data=data, dtype=dtype, copy=copy, name=name
         )  # type: ignore[return-value]
-
-    # ----------------------------------------------------------------
-    # Indexing Methods
-
-    @cache_readonly
-    @doc(Index._should_fallback_to_positional)
-    def _should_fallback_to_positional(self) -> bool:
-        return False

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -3,10 +3,6 @@ from __future__ import annotations
 import numpy as np
 
 from pandas._typing import Dtype
-from pandas.util._decorators import (
-    cache_readonly,
-    doc,
-)
 
 from pandas.core.indexes.base import Index
 

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -1,21 +1,7 @@
 from __future__ import annotations
 
-import numpy as np
-
-from pandas._typing import Dtype
-
 from pandas.core.indexes.base import Index
 
 
 class NumericIndex(Index):
-    def __new__(
-        cls, data=None, dtype: Dtype | None = None, copy: bool = False, name=None
-    ) -> NumericIndex:
-        # temporary scaffolding, will be removed soon.
-        if isinstance(data, list) and len(data) == 0:
-            data = np.array([], dtype=np.int64)
-        elif isinstance(data, range):
-            data = np.arange(data.start, data.stop, data.step, dtype=np.int64)
-        return super().__new__(
-            cls, data=data, dtype=dtype, copy=copy, name=name
-        )  # type: ignore[return-value]
+    pass

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -486,7 +486,7 @@ class TestIndex(Base):
     @pytest.mark.parametrize("dtype", [np.int_, np.bool_])
     def test_empty_fancy(self, index, dtype):
         empty_arr = np.array([], dtype=dtype)
-        empty_index = type(index)([])
+        empty_index = type(index)([], dtype=index.dtype)
 
         assert index[[]].identical(empty_index)
         assert index[empty_arr].identical(empty_index)
@@ -500,7 +500,7 @@ class TestIndex(Base):
         # DatetimeIndex is excluded, because it overrides getitem and should
         # be tested separately.
         empty_farr = np.array([], dtype=np.float_)
-        empty_index = type(index)([])
+        empty_index = type(index)([], dtype=index.dtype)
 
         assert index[[]].identical(empty_index)
         # np.ndarray only accepts ndarray of int & bool dtypes, so should Index


### PR DESCRIPTION
Remove `NumericIndex.__new__` & `._should_fallback_to_positional` to Index. Next up is to actually remove `NumericIndex` from the code base (there is various scaffolding around, that I need to remove/alter at the same time).

This move `NumericIndex._should_fallback_to_positional` to `Index` as-is. There is an issue #51053 that should be fixed, I'll take that in a follow-up so I can get `NumericIndex` removed here, without worrying about that.

xref #42717.