### PR TITLE
REF/API: dont alter Grouper in _get_grouper

### DIFF
--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 
 from typing import (
     TYPE_CHECKING,
-    Any,
     Hashable,
     Iterator,
+    cast,
     final,
 )
 
@@ -286,7 +286,7 @@ class Grouper:
 
     def _get_grouper(
         self, obj: NDFrameT, validate: bool = True
-    ) -> tuple[Any, ops.BaseGrouper, NDFrameT]:
+    ) -> tuple[ops.BaseGrouper, NDFrameT]:
         """
         Parameters
         ----------
@@ -296,15 +296,11 @@ class Grouper:
 
         Returns
         -------
-        a tuple of binner, grouper, obj (possibly sorted)
+        a tuple of grouper, obj (possibly sorted)
         """
         self._set_grouper(obj)
-        # error: Value of type variable "NDFrameT" of "get_grouper" cannot be
-        # "Optional[Any]"
-        # error: Incompatible types in assignment (expression has type "BaseGrouper",
-        # variable has type "None")
-        self.grouper, _, self.obj = get_grouper(  # type: ignore[type-var,assignment]
-            self.obj,
+        grouper, _, obj = get_grouper(
+            cast(NDFrameT, self.obj),
             [self.key],
             axis=self.axis,
             level=self.level,
@@ -313,9 +309,7 @@ class Grouper:
             dropna=self.dropna,
         )
 
-        # error: Incompatible return value type (got "Tuple[None, None, None]",
-        # expected "Tuple[Any, BaseGrouper, NDFrameT]")
-        return self.binner, self.grouper, self.obj  # type: ignore[return-value]
+        return grouper, obj
 
     @final
     def _set_grouper(self, obj: NDFrame, sort: bool = False) -> None:
@@ -506,7 +500,7 @@ class Grouping:
             # check again as we have by this point converted these
             # to an actual value (rather than a pd.Grouper)
             assert self.obj is not None  # for mypy
-            _, newgrouper, newobj = self.grouping_vector._get_grouper(
+            newgrouper, newobj = self.grouping_vector._get_grouper(
                 self.obj, validate=False
             )
             self.obj = newobj
@@ -814,7 +808,7 @@ def get_grouper(
 
     # a passed-in Grouper, directly convert
     if isinstance(key, Grouper):
-        binner, grouper, obj = key._get_grouper(obj, validate=False)
+        grouper, obj = key._get_grouper(obj, validate=False)
         if key.key is None:
             return grouper, frozenset(), obj
         else:

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1691,7 +1691,7 @@ class TimeGrouper(Grouper):
     def _get_grouper(self, obj, validate: bool = True):
         # create the resampler and return our binner
         r = self._get_resampler(obj)
-        return r.binner, r.grouper, r.obj
+        return r.grouper, r.obj
 
     def _get_time_bins(self, ax: DatetimeIndex):
         if not isinstance(ax, DatetimeIndex):

--- a/pandas/tests/resample/test_time_grouper.py
+++ b/pandas/tests/resample/test_time_grouper.py
@@ -64,7 +64,7 @@ def test_apply_iteration():
     df = DataFrame({"open": 1, "close": 2}, index=ind)
     tg = Grouper(freq="M")
 
-    _, grouper, _ = tg._get_grouper(df)
+    grouper, _ = tg._get_grouper(df)
 
     # Errors
     grouped = df.groupby(grouper, group_keys=False)


### PR DESCRIPTION
This doesn't break any tests and I haven't concocted any new cases in which it would matter, but the logic is hard enough to disentangle (xref #51134) that I can't promise it won't