### PR TITLE
REF: make pd.Grouper less stateful

### DIFF
--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -279,6 +279,9 @@ class Grouper:
     @final
     @property
     def ax(self) -> Index:
+        assert False
+        # TODO: do we need a deprecation cycle to get rid of this?  can just
+        #  document as a breaking change?
         index = self._gpr_index
         if index is None:
             raise ValueError("_set_grouper must be called before ax is accessed")
@@ -298,9 +301,9 @@ class Grouper:
         -------
         a tuple of grouper, obj (possibly sorted)
         """
-        self._set_grouper(obj)
+        obj, _ = self._set_grouper(obj)
         grouper, _, obj = get_grouper(
-            cast(NDFrameT, self.obj),
+            cast(NDFrameT, obj),
             [self.key],
             axis=self.axis,
             level=self.level,
@@ -312,7 +315,7 @@ class Grouper:
         return grouper, obj
 
     @final
-    def _set_grouper(self, obj: NDFrame, sort: bool = False) -> None:
+    def _set_grouper(self, obj: NDFrame, sort: bool = False):
         """
         given an object and the specifications, setup the internal grouper
         for this particular specification
@@ -382,10 +385,13 @@ class Grouper:
             ax = ax.take(indexer)
             obj = obj.take(indexer, axis=self.axis)
 
-        # error: Incompatible types in assignment (expression has type
-        # "NDFrameT", variable has type "None")
-        self.obj = obj  # type: ignore[assignment]
-        self._gpr_index = ax
+        if type(self) is not Grouper:
+            # i.e. only for TimeGrouper
+            # error: Incompatible types in assignment (expression has type
+            # "NDFrameT", variable has type "None")
+            self.obj = obj  # type: ignore[assignment]
+            self._gpr_index = ax
+        return obj, ax
 
     @final
     @property

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -8,7 +8,6 @@ from typing import (
     TYPE_CHECKING,
     Hashable,
     Iterator,
-    cast,
     final,
 )
 
@@ -302,7 +301,7 @@ class Grouper:
         """
         obj, _ = self._set_grouper(obj)
         grouper, _, obj = get_grouper(
-            cast(NDFrameT, obj),
+            obj,
             [self.key],
             axis=self.axis,
             level=self.level,

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -279,9 +279,8 @@ class Grouper:
     @final
     @property
     def ax(self) -> Index:
-        assert False
-        # TODO: do we need a deprecation cycle to get rid of this?  can just
-        #  document as a breaking change?
+        # TODO: deprecate/remove; this state should not exist, is no longer
+        #  accessed from Resample
         index = self._gpr_index
         if index is None:
             raise ValueError("_set_grouper must be called before ax is accessed")
@@ -387,9 +386,6 @@ class Grouper:
 
         if type(self) is not Grouper:
             # i.e. only for TimeGrouper
-            # error: Incompatible types in assignment (expression has type
-            # "NDFrameT", variable has type "None")
-            self.obj = obj  # type: ignore[assignment]
             self._gpr_index = ax
         return obj, ax
 

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -130,7 +130,7 @@ class Resampler(BaseGroupBy, PandasObject):
     grouper: BinGrouper
     _timegrouper: TimeGrouper
     exclusions: frozenset[Hashable] = frozenset()  # for SelectionMixin compat
-    _internal_names_set = frozenset({"obj", "ax"})
+    _internal_names_set = set({"obj", "ax"})
     # to the groupby descriptor
     _attributes = [
         "freq",
@@ -1190,8 +1190,7 @@ class _GroupByMixin(PandasObject):
         """
         # create a new object to prevent aliasing
         if subset is None:
-            # error: "GotItemMixin" has no attribute "obj"
-            subset = self.obj  # type: ignore[attr-defined]
+            subset = self.obj
 
         # we need to make a shallow copy of ourselves
         # with the same groupby


### PR DESCRIPTION
Grouper.ax is no longer accessed, but since pd.Grouper is in the namespace, removing it would be an API change.  Does anyone mind just ripping it out?