### PR TITLE
DOC: fix a typo "docstring" -> "docstrings"

### DIFF
--- a/doc/source/development/contributing_codebase.rst
+++ b/doc/source/development/contributing_codebase.rst
@@ -25,7 +25,7 @@ contributing them to the project::
 
 The script validates the doctests, formatting in docstrings, and
 imported modules. It is possible to run the checks independently by using the
-parameters ``docstring``, ``code``, and ``doctests``
+parameters ``docstrings``, ``code``, and ``doctests``
 (e.g. ``./ci/code_checks.sh doctests``).
 
 In addition, because a lot of people use our library, it is important that we


### PR DESCRIPTION
when using the "docstring" parameter I get an error:

```
$ ./ci/code_checks.sh docstring
Unknown command docstring. Usage: ./ci/code_checks.sh [code|doctests|docstrings|single-docs|notebooks]
```