### PR TITLE
BUG: PandasArray.astype use astype_nansafe

### DIFF
--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -16,7 +16,12 @@ from pandas._typing import (
 )
 from pandas.compat.numpy import function as nv
 
+from pandas.core.dtypes.astype import astype_array
 from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
+from pandas.core.dtypes.common import (
+    is_dtype_equal,
+    pandas_dtype,
+)
 from pandas.core.dtypes.dtypes import PandasDtype
 from pandas.core.dtypes.missing import isna
 
@@ -184,6 +189,17 @@ class PandasArray(
 
     # ------------------------------------------------------------------------
     # Pandas ExtensionArray Interface
+
+    def astype(self, dtype, copy: bool = True):
+        dtype = pandas_dtype(dtype)
+
+        if is_dtype_equal(dtype, self.dtype):
+            if copy:
+                return self.copy()
+            return self
+
+        result = astype_array(self._ndarray, dtype=dtype, copy=copy)
+        return result
 
     def isna(self) -> np.ndarray:
         return isna(self._ndarray)

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -454,7 +454,8 @@ class StringArray(BaseStringArray, PandasArray):
             values = arr.astype(dtype.numpy_dtype)
             return FloatingArray(values, mask, copy=False)
         elif isinstance(dtype, ExtensionDtype):
-            return super().astype(dtype, copy=copy)
+            # Skip the PandasArray.astype method
+            return ExtensionArray.astype(self, dtype, copy)
         elif np.issubdtype(dtype, np.floating):
             arr = self._ndarray.copy()
             mask = self.isna()

--- a/pandas/tests/extension/test_numpy.py
+++ b/pandas/tests/extension/test_numpy.py
@@ -190,10 +190,7 @@ class BaseNumPyTests:
 
 
 class TestCasting(BaseNumPyTests, base.BaseCastingTests):
-    @skip_nested
-    def test_astype_str(self, data):
-        # ValueError: setting an array element with a sequence
-        super().test_astype_str(data)
+    pass
 
 
 class TestConstructors(BaseNumPyTests, base.BaseConstructorsTests):

--- a/pandas/tests/series/methods/test_astype.py
+++ b/pandas/tests/series/methods/test_astype.py
@@ -352,13 +352,24 @@ class TestAstype:
     def test_astype_float_to_uint_negatives_raise(
         self, float_numpy_dtype, any_unsigned_int_numpy_dtype
     ):
-        # GH#45151
-        # TODO: same for EA float/uint dtypes
+        # GH#45151 We don't cast negative numbers to nonsense values
+        # TODO: same for EA float/uint dtypes, signed integers?
         arr = np.arange(5).astype(float_numpy_dtype) - 3  # includes negatives
         ser = Series(arr)
 
-        with pytest.raises(ValueError, match="losslessly"):
+        msg = "Cannot losslessly cast from .* to .*"
+        with pytest.raises(ValueError, match=msg):
             ser.astype(any_unsigned_int_numpy_dtype)
+
+        with pytest.raises(ValueError, match=msg):
+            ser.to_frame().astype(any_unsigned_int_numpy_dtype)
+
+        with pytest.raises(ValueError, match=msg):
+            # We currently catch and re-raise in Index.astype
+            Index(ser).astype(any_unsigned_int_numpy_dtype)
+
+        with pytest.raises(ValueError, match=msg):
+            ser.array.astype(any_unsigned_int_numpy_dtype)
 
     def test_astype_cast_object_int(self):
         arr = Series(["1", "2", "3", "4"], dtype=object)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
