### PR TITLE
REF: dont rely on Grouper.ax

### DIFF
--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -329,6 +329,12 @@ class Grouper:
         obj : Series or DataFrame
         sort : bool, default False
             whether the resulting grouper should be sorted
+        gpr_index : Index or None, default None
+
+        Returns
+        -------
+        NDFrame
+        Index
         """
         assert obj is not None
 

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1192,8 +1192,7 @@ class _GroupByMixin(PandasObject):
         """
         # create a new object to prevent aliasing
         if subset is None:
-            # error: "GotItemMixin" has no attribute "obj"
-            subset = self.obj  # type: ignore[attr-defined]
+            subset = self.obj
 
         # we need to make a shallow copy of ourselves
         # with the same groupby

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -130,6 +130,7 @@ class Resampler(BaseGroupBy, PandasObject):
     grouper: BinGrouper
     _timegrouper: TimeGrouper
     exclusions: frozenset[Hashable] = frozenset()  # for SelectionMixin compat
+    _internal_names_set = set({"obj", "ax"})
 
     # to the groupby descriptor
     _attributes = [
@@ -150,6 +151,7 @@ class Resampler(BaseGroupBy, PandasObject):
         axis: Axis = 0,
         kind=None,
         *,
+        gpr_index: Index,
         group_keys: bool | lib.NoDefault = lib.no_default,
         selection=None,
     ) -> None:
@@ -163,7 +165,9 @@ class Resampler(BaseGroupBy, PandasObject):
         self.group_keys = group_keys
         self.as_index = True
 
-        self._timegrouper._set_grouper(self._convert_obj(obj), sort=True)
+        self.obj, self.ax = self._timegrouper._set_grouper(
+            self._convert_obj(obj), sort=True, gpr_index=gpr_index
+        )
         self.binner, self.grouper = self._get_binner()
         self._selection = selection
         if self._timegrouper.key is not None:
@@ -191,19 +195,6 @@ class Resampler(BaseGroupBy, PandasObject):
             return self[attr]
 
         return object.__getattribute__(self, attr)
-
-    # error: Signature of "obj" incompatible with supertype "BaseGroupBy"
-    @property
-    def obj(self) -> NDFrame:  # type: ignore[override]
-        # error: Incompatible return value type (got "Optional[Any]",
-        # expected "NDFrameT")
-        return self._timegrouper.obj  # type: ignore[return-value]
-
-    @property
-    def ax(self):
-        # we can infer that this is a PeriodIndex/DatetimeIndex/TimedeltaIndex,
-        #  but skipping annotating bc the overrides overwhelming
-        return self._timegrouper.ax
 
     @property
     def _from_selection(self) -> bool:
@@ -1161,6 +1152,9 @@ class _GroupByMixin(PandasObject):
         self._groupby = groupby
         self._timegrouper = copy.copy(parent._timegrouper)
 
+        self.ax = parent.ax
+        self.obj = parent.obj
+
     @no_type_check
     def _apply(self, f, *args, **kwargs):
         """
@@ -1169,7 +1163,7 @@ class _GroupByMixin(PandasObject):
         """
 
         def func(x):
-            x = self._resampler_cls(x, groupby=self._timegrouper)
+            x = self._resampler_cls(x, groupby=self._timegrouper, gpr_index=self.ax)
 
             if isinstance(f, str):
                 return getattr(x, f)(**kwargs)
@@ -1660,20 +1654,33 @@ class TimeGrouper(Grouper):
         TypeError if incompatible axis
 
         """
-        self._set_grouper(obj)
+        _, ax = self._set_grouper(obj, gpr_index=None)
 
-        ax = self.ax
         if isinstance(ax, DatetimeIndex):
             return DatetimeIndexResampler(
-                obj, groupby=self, kind=kind, axis=self.axis, group_keys=self.group_keys
+                obj,
+                groupby=self,
+                kind=kind,
+                axis=self.axis,
+                group_keys=self.group_keys,
+                gpr_index=ax,
             )
         elif isinstance(ax, PeriodIndex) or kind == "period":
             return PeriodIndexResampler(
-                obj, groupby=self, kind=kind, axis=self.axis, group_keys=self.group_keys
+                obj,
+                groupby=self,
+                kind=kind,
+                axis=self.axis,
+                group_keys=self.group_keys,
+                gpr_index=ax,
             )
         elif isinstance(ax, TimedeltaIndex):
             return TimedeltaIndexResampler(
-                obj, groupby=self, axis=self.axis, group_keys=self.group_keys
+                obj,
+                groupby=self,
+                axis=self.axis,
+                group_keys=self.group_keys,
+                gpr_index=ax,
             )
 
         raise TypeError(


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

After this we an deprecate Grouper.ax