### PR TITLE
DOC: remove reference of NumericIndex in Int64Index docs

### DIFF
--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -313,7 +313,7 @@ _num_index_shared_docs[
     Immutable sequence used for indexing and alignment.
 
     .. deprecated:: 1.4.0
-        In pandas v2.0 %(klass)s will be removed and :class:`NumericIndex` used instead.
+        In pandas v2.0 %(klass)s will be removed and :class:`Index` used instead.
         %(klass)s will remain fully functional for the duration of pandas 1.x.
 
     The basic object storing axis labels for all pandas objects.


### PR DESCRIPTION
Small fix for https://github.com/pandas-dev/pandas/issues/51020#issuecomment-1422820547, in case we end up doing another 1.5.x release to have correct docs.