### PR TITLE
BUG: Groupby.filter with pd.NA

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -562,7 +562,7 @@ class SeriesGroupBy(GroupBy[Series]):
         # Interpret np.nan as False.
         def true_and_notna(x) -> bool:
             b = wrapper(x)
-            return b and notna(b)
+            return notna(b) and b
 
         try:
             indices = [
@@ -1717,7 +1717,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
             # interpret the result of the filter
             if is_bool(res) or (is_scalar(res) and isna(res)):
-                if res and notna(res):
+                if notna(res) and res:
                     indices.append(self._get_index(name))
             else:
                 # non scalars aren't allowed

--- a/pandas/tests/groupby/test_filters.py
+++ b/pandas/tests/groupby/test_filters.py
@@ -172,6 +172,20 @@ def test_filter_nan_is_false():
     tm.assert_series_equal(g_s.filter(f), s[[]])
 
 
+def test_filter_pdna_is_false():
+    # in particular, dont raise in filter trying to call bool(pd.NA)
+    df = DataFrame({"A": np.arange(8), "B": list("aabbbbcc"), "C": np.arange(8)})
+    ser = df["B"]
+    g_df = df.groupby(df["B"])
+    g_s = ser.groupby(ser)
+
+    func = lambda x: pd.NA
+    res = g_df.filter(func)
+    tm.assert_frame_equal(res, df.loc[[]])
+    res = g_s.filter(func)
+    tm.assert_series_equal(res, ser[[]])
+
+
 def test_filter_against_workaround():
     np.random.seed(0)
     # Series of ints


### PR DESCRIPTION
@Dr-Irv this is an example of the kind of bug that I have in mind when I said in the Categorical issue that getting pd.NA is a PITA.   We've had 3 years to track them down and we're still finding places where having it unexpectedly causes bugs.  Users will have this long tail until the end of time.