### PR TITLE
CI: Don't test min pyarrow version with multiple python versions

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         env_file: [actions-38.yaml, actions-39.yaml, actions-310.yaml, actions-311.yaml]
         pattern: ["not single_cpu", "single_cpu"]
-        pyarrow_version: ["7", "8", "9", "10"]
+        pyarrow_version: ["8", "9", "10"]
         include:
           - name: "Downstream Compat"
             env_file: actions-38-downstream_compat.yaml
@@ -80,22 +80,16 @@ jobs:
             error_on_warnings: "0"
         exclude:
           - env_file: actions-38.yaml
-            pyarrow_version: "7"
-          - env_file: actions-38.yaml
             pyarrow_version: "8"
           - env_file: actions-38.yaml
             pyarrow_version: "9"
           - env_file: actions-39.yaml
-            pyarrow_version: "7"
-          - env_file: actions-39.yaml
             pyarrow_version: "8"
           - env_file: actions-39.yaml
             pyarrow_version: "9"
-          - env_file: actions-311.yaml
-            pyarrow_version: "7"
-          - env_file: actions-311.yaml
+          - env_file: actions-310.yaml
             pyarrow_version: "8"
-          - env_file: actions-311.yaml
+          - env_file: actions-310.yaml
             pyarrow_version: "9"
       fail-fast: false
     name: ${{ matrix.name || format('{0} pyarrow={1} {2}', matrix.env_file, matrix.pyarrow_version, matrix.pattern) }}


### PR DESCRIPTION
cc @phofl 

After the minimum pyarrow version was bumped to 7, we shouldn't need to test this over multiple python versions anymore.

Additionally, uses PY3.11 to test multiple pyarrow versions instead of PY3.10