### PR TITLE
BUG: replace with inplace not respecting cow

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -247,6 +247,9 @@ Copy-on-Write improvements
   can never update the original Series or DataFrame. Therefore, an informative
   error is raised to the user instead of silently doing nothing (:issue:`49467`)
 
+- :meth:`DataFrame.replace` will now respect the Copy-on-Write mechanism
+  when ``inplace=True``.
+
 Copy-on-Write can be enabled through one of
 
 .. code-block:: python

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -473,6 +473,7 @@ class BaseBlockManager(DataManager):
             dest_list=dest_list,
             inplace=inplace,
             regex=regex,
+            using_cow=using_copy_on_write(),
         )
         bm._consolidate_inplace()
         return bm

--- a/pandas/tests/copy_view/test_replace.py
+++ b/pandas/tests/copy_view/test_replace.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+from pandas import (
+    Categorical,
+    DataFrame,
+)
+import pandas._testing as tm
+from pandas.tests.copy_view.util import get_array
+
+
+def test_replace_categorical_inplace_reference(using_copy_on_write):
+    df = DataFrame({"a": Categorical([1, 2, 3])})
+    df_orig = df.copy()
+    arr_a = get_array(df, "a")
+    view = df[:]  # noqa
+    df.replace(to_replace=[1], value=2, inplace=True)
+
+    if using_copy_on_write:
+        assert not np.shares_memory(get_array(df, "a").codes, arr_a.codes)
+        assert df._mgr._has_no_reference(0)
+        assert view._mgr._has_no_reference(0)
+        tm.assert_frame_equal(view, df_orig)
+    else:
+        assert np.shares_memory(get_array(df, "a").codes, arr_a.codes)
+
+
+def test_replace_inplace_reference(using_copy_on_write):
+    df = DataFrame({"a": [1.5, 2, 3]})
+    arr_a = get_array(df, "a")
+    view = df[:]  # noqa
+    df.replace(to_replace=[1.5], value=15.5, inplace=True)
+
+    if using_copy_on_write:
+        assert not np.shares_memory(get_array(df, "a"), arr_a)
+        assert df._mgr._has_no_reference(0)
+        assert view._mgr._has_no_reference(0)
+    else:
+        assert np.shares_memory(get_array(df, "a"), arr_a)


### PR DESCRIPTION
- [x] closes #51277 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.


This is a short term change that we should get in for the rc to avoid updating multiple object. Will optimise after the other replace pr is merged.