### PR TITLE
TST: add CoW tests for xs() and get()

### DIFF
--- a/pandas/tests/copy_view/util.py
+++ b/pandas/tests/copy_view/util.py
@@ -10,7 +10,7 @@ def get_array(obj, col=None):
     which triggers tracking references / CoW (and we might be testing that
     this is done by some other operation).
     """
-    if isinstance(obj, Series) and (obj is None or obj.name == col):
+    if isinstance(obj, Series) and (col is None or obj.name == col):
         return obj._values
     assert col is not None
     icol = obj.columns.get_loc(col)


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/49473

Adding basic tests for `xs` and `get`. Those rely on indexing methods under the hood, and thus already work correctly for CoW, but adding some basic tests to have independent coverage.