### PR TITLE
TST: avoid mutating DataFrame.values in tests (use iloc instead)

### DIFF
--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -796,7 +796,7 @@ def _create_missing_idx(nrows, ncols, density: float, random_state=None):
 def makeMissingDataframe(density: float = 0.9, random_state=None) -> DataFrame:
     df = makeDataFrame()
     i, j = _create_missing_idx(*df.shape, density=density, random_state=random_state)
-    df.values[i, j] = np.nan
+    df.iloc[i, j] = np.nan
     return df
 
 

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -620,7 +620,7 @@ class TestDataFrameIndexing:
             for idx in f.index[::5]:
                 i = f.index.get_loc(idx)
                 val = np.random.randn()
-                expected.values[i, j] = val
+                expected.iloc[i, j] = val
 
                 ix[idx, col] = val
                 tm.assert_frame_equal(f, expected)

--- a/pandas/tests/frame/methods/test_cov_corr.py
+++ b/pandas/tests/frame/methods/test_cov_corr.py
@@ -218,9 +218,8 @@ class TestDataFrameCorr:
         _ = df.corr(numeric_only=True)
 
         if using_copy_on_write:
-            # TODO(CoW) we should disallow this, so `df` doesn't get updated
-            ser.values[0] = 99
-            assert df.loc[0, "A"] == 99
+            ser.iloc[0] = 99
+            assert df.loc[0, "A"] == 0
         else:
             # Check that the corr didn't break link between ser and df
             ser.values[0] = 99

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -550,8 +550,9 @@ class TestFillNA:
         tm.assert_frame_equal(result, expected)
 
     def test_fillna_columns(self):
-        df = DataFrame(np.random.randn(10, 10))
-        df.values[:, ::2] = np.nan
+        arr = np.random.randn(10, 10)
+        arr[:, ::2] = np.nan
+        df = DataFrame(arr)
 
         result = df.fillna(method="ffill", axis=1)
         expected = df.T.fillna(method="pad").T

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2102,13 +2102,14 @@ class TestDataFrameConstructors:
 
     def test_constructor_ndarray_copy(self, float_frame, using_array_manager):
         if not using_array_manager:
-            df = DataFrame(float_frame.values)
+            arr = float_frame.values.copy()
+            df = DataFrame(arr)
 
-            float_frame.values[5] = 5
+            arr[5] = 5
             assert (df.values[5] == 5).all()
 
-            df = DataFrame(float_frame.values, copy=True)
-            float_frame.values[6] = 6
+            df = DataFrame(arr, copy=True)
+            arr[6] = 6
             assert not (df.values[6] == 6).all()
         else:
             arr = float_frame.values.copy()

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -356,8 +356,9 @@ def test_cython_api2():
 
 
 def test_cython_median():
-    df = DataFrame(np.random.randn(1000))
-    df.values[::2] = np.nan
+    arr = np.random.randn(1000)
+    arr[::2] = np.nan
+    df = DataFrame(arr)
 
     labels = np.random.randint(0, 50, size=1000).astype(float)
     labels[::17] = np.nan

--- a/pandas/tests/indexing/multiindex/test_slice.py
+++ b/pandas/tests/indexing/multiindex/test_slice.py
@@ -750,7 +750,7 @@ class TestMultiIndexSlicers:
 
         exp = ymd["A"].copy()
         s[5:] = 0
-        exp.values[5:] = 0
+        exp.iloc[5:] = 0
         tm.assert_numpy_array_equal(s.values, exp.values)
 
         result = ymd[5:]

--- a/pandas/tests/io/pytables/test_round_trip.py
+++ b/pandas/tests/io/pytables/test_round_trip.py
@@ -372,8 +372,8 @@ def test_frame(compression, setup_path):
     df = tm.makeDataFrame()
 
     # put in some random NAs
-    df.values[0, 0] = np.nan
-    df.values[5, 3] = np.nan
+    df.iloc[0, 0] = np.nan
+    df.iloc[5, 3] = np.nan
 
     _check_roundtrip_table(
         df, tm.assert_frame_equal, path=setup_path, compression=compression

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -899,7 +899,7 @@ class TestSetitemTimedelta64IntoNumeric(SetitemCastingEquivalents):
         arr = np.arange(5).astype(dtype)
         ser = Series(arr)
         ser = ser.astype(object)
-        ser.values[0] = np.timedelta64(4, "ns")
+        ser.iloc[0] = np.timedelta64(4, "ns")
         return ser
 
     @pytest.fixture

--- a/pandas/tests/series/methods/test_fillna.py
+++ b/pandas/tests/series/methods/test_fillna.py
@@ -32,7 +32,7 @@ class TestSeriesFillNA:
         filled2 = series.fillna(value=series.values[2])
 
         expected = series.copy()
-        expected.values[3] = expected.values[2]
+        expected.iloc[3] = expected.iloc[2]
 
         tm.assert_series_equal(filled, expected)
         tm.assert_series_equal(filled2, expected)


### PR DESCRIPTION
This is splitting off some "usefully anyway" test changes from https://github.com/pandas-dev/pandas/pull/51082

We have several places internally where we mutate the `df.values[..] = ..` directly, while this is certainly a discouraged pattern (also only work if you have a single block), and often easily avoided by using `df.iloc[..] = ..` or mutating the array before creating the DataFrame, instead.