### PR TITLE
BUG: idxmax and idxmin raising for all na ea series

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -1256,6 +1256,7 @@ Missing
 - Bug in :meth:`DataFrame.update` with ``overwrite=False`` raising ``TypeError`` when ``self`` has column with ``NaT`` values and column not present in ``other`` (:issue:`16713`)
 - Bug in :meth:`Series.replace` raising ``RecursionError`` when replacing value in object-dtype :class:`Series` containing ``NA`` (:issue:`47480`)
 - Bug in :meth:`Series.replace` raising ``RecursionError`` when replacing value in numeric :class:`Series` with ``NA`` (:issue:`50758`)
+- Bug in :meth:`Series.idxmin` and :meth:`Series.idxmax` raising ``ValueError`` for all ``NA`` with extension array dtype (:issue:`51276`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -461,6 +461,8 @@ def nargminmax(values: ExtensionArray, method: str, axis: AxisInt = 0):
     func = np.argmax if method == "argmax" else np.argmin
 
     mask = np.asarray(isna(values))
+    if mask.all():
+        return -1
     arr_values = values._values_for_argsort()
 
     if arr_values.ndim > 1:

--- a/pandas/tests/series/methods/test_argsort.py
+++ b/pandas/tests/series/methods/test_argsort.py
@@ -65,3 +65,10 @@ class TestSeriesArgsort:
     def test_argsort_preserve_name(self, datetime_series):
         result = datetime_series.argsort()
         assert result.name == datetime_series.name
+
+    @pytest.mark.parametrize("func", ["idxmin", "idxmax"])
+    def test_idxmin_idxmax_all_na(self, any_numeric_ea_and_arrow_dtype, func):
+        # GH#51276
+        ser = Series([None, None], dtype=any_numeric_ea_and_arrow_dtype)
+        result = getattr(ser, func)()
+        assert result is np.nan


### PR DESCRIPTION
- [x] closes #51276 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Not sure if NA or NaN makes more sense. I think we have a couple of ops where we return nan even for ea dtypes when the result is a scalar