### PR TITLE
DOC: fix EX02 errors in docstrings

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -593,8 +593,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.api.types.is_datetime64_dtype \
         pandas.api.types.is_datetime64_ns_dtype \
         pandas.api.types.is_datetime64tz_dtype \
-        pandas.api.types.is_float_dtype \
-        pandas.api.types.is_int64_dtype \
         pandas.api.types.is_integer_dtype \
         pandas.api.types.is_interval_dtype \
         pandas.api.types.is_numeric_dtype \

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -832,6 +832,7 @@ def is_int64_dtype(arr_or_dtype) -> bool:
 
     Examples
     --------
+    >>> from pandas.api.types import is_int64_dtype
     >>> is_int64_dtype(str)
     False
     >>> is_int64_dtype(np.int32)
@@ -1216,6 +1217,7 @@ def is_float_dtype(arr_or_dtype) -> bool:
 
     Examples
     --------
+    >>> from pandas.api.types import is_float_dtype
     >>> is_float_dtype(str)
     False
     >>> is_float_dtype(int)


### PR DESCRIPTION
- Related to issue #51236

This PR enables functions:
`pandas.api.types.is_float_dtype`
`pandas.api.types.is_int64_dtype`