### PR TITLE
allow type to be specified in argument of tolist()

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -307,7 +307,7 @@ Other enhancements
 - Added new argument ``dtype`` to :func:`read_sql` to be consistent with :func:`read_sql_query` (:issue:`50797`)
 - Added new argument ``engine`` to :func:`read_json` to support parsing JSON with pyarrow by specifying ``engine="pyarrow"`` (:issue:`48893`)
 - Added support for SQLAlchemy 2.0 (:issue:`40686`)
--
+- Added new argument ``scalar_type`` to :meth:`Index.tolist` to allow a specification for typing purposes of the elements of the returned list.
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_200.notable_bug_fixes:

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -28,6 +28,7 @@ from pandas._typing import (
     IndexLabel,
     NDFrameT,
     Shape,
+    T as Ttolist,
     npt,
 )
 from pandas.compat import PYPY
@@ -735,13 +736,34 @@ class IndexOpsMixin(OpsMixin):
                 delegate, skipna=skipna
             )
 
-    def tolist(self):
+    # The overloads are done this way due to a mypy issue. See
+    # https://github.com/python/mypy/issues/3737#issuecomment-465355737
+    @overload
+    def tolist(self) -> list[Any]:
+        ...
+
+    @overload
+    def tolist(self, scalar_type: type[Ttolist]) -> list[Ttolist]:
+        ...
+
+    def tolist(self, scalar_type=Any) -> list[Any]:
         """
         Return a list of the values.
 
         These are each a scalar type, which is a Python scalar
         (for str, int, float) or a pandas scalar
         (for Timestamp/Timedelta/Interval/Period)
+        or a tuple (for MultiIndex)
+
+        For type checking purposes, the type of the returned elements of the
+        list may be specified.  For example ``index.tolist(str)`` will appear
+        to a type checker as ``list[str]``.  However, the returned type of
+        each element will be the actual type of the elements in the values.
+
+        Parameters
+        ----------
+        scalar_type : type, default Any
+            Returned type of elements in the list.
 
         Returns
         -------
@@ -763,6 +785,7 @@ class IndexOpsMixin(OpsMixin):
         These are each a scalar type, which is a Python scalar
         (for str, int, float) or a pandas scalar
         (for Timestamp/Timedelta/Interval/Period)
+        or a tuple (for MultiIndex)
 
         Returns
         -------

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import (
     Any,
     Hashable,
+    overload,
 )
 
 import numpy as np
@@ -11,6 +12,7 @@ from pandas._libs import index as libindex
 from pandas._typing import (
     Dtype,
     DtypeObj,
+    T as Ttolist,
     npt,
 )
 from pandas.util._decorators import (
@@ -52,7 +54,6 @@ _index_doc_kwargs.update({"target_klass": "CategoricalIndex"})
 @inherit_names(
     [
         "argsort",
-        "tolist",
         "codes",
         "categories",
         "ordered",
@@ -327,6 +328,19 @@ class CategoricalIndex(NDArrayBackedExtensionIndex):
         return header + result
 
     # --------------------------------------------------------------------
+
+    # The overloads are done this way due to a mypy issue. See
+    # https://github.com/python/mypy/issues/3737#issuecomment-465355737
+    @overload
+    def tolist(self) -> list[Any]:
+        ...
+
+    @overload
+    def tolist(self, scalar_type: type[Ttolist]) -> list[Ttolist]:
+        ...
+
+    def tolist(self, scalar_type=Any) -> list[Any]:
+        return self._data.tolist()
 
     @property
     def inferred_type(self) -> str:

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -385,8 +385,9 @@ class RangeIndex(Index):
         return False
 
     # --------------------------------------------------------------------
-
-    def tolist(self) -> list[int]:
+    # error: Signature of "tolist" incompatible with supertype
+    # "IndexOpsMixin"  [override]
+    def tolist(self, scalar_type: type = int) -> list[int]:  # type: ignore[override]
         return list(self._range)
 
     @doc(Index.__iter__)

--- a/pandas/tests/indexes/test_any_index.py
+++ b/pandas/tests/indexes/test_any_index.py
@@ -95,6 +95,8 @@ class TestConversion:
 
     def test_tolist_matches_list(self, index):
         assert index.tolist() == list(index)
+        if len(index) > 0:
+            assert index.tolist(type(index[0])) == list(index)
 
 
 class TestRoundTrips:


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)  
  - no corresponding issue
- [x] [Tests added and passed]
  - modified `tests/indexes/test_any_index.py:TestConversion.test_tolist_matches_list()`
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.0.0.rst` file if fixing a bug or adding a new feature.


I'm not sure how people will feel about this idea.

The idea here is that if you do something like `y = [x for x in df.index if x.startswith("a")]`, right now, the type of `x` cannot be inferred.  That means that the expression `x.startswith("a")` isn't type checked. 

But, with this PR, if you do `y = [x for x in df.index.tolist(str) if x.startswith("a")]` then  the expression `x.startswith("a")` will be type checked.  Not only that, the type checker can infer that `y` will be `list[str]` in this example.

Furthermore, if you wrote  `y = [x for x in df.index.tolist(int) if x.startswith("a")]`, then the type checker would catch that you can't call `startswith()` on an `int`.

Note that the new argument to `tolist()` is optional.  The argument is ignored in the `tolist()` method.  It is only used to change the type of the result.  It does not convert the type of the values in the list.  This is only there for convenience with typing.

If this PR is accepted for 2.0, then a corresponding change will also be made to `pandas-stubs` once 2.0 is released.
