### PR TITLE
DOC: fix EX02 errors in docstrings II

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -589,15 +589,12 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.Timestamp.fromtimestamp \
         pandas.api.types.infer_dtype \
         pandas.api.types.is_datetime64_any_dtype \
-        pandas.api.types.is_datetime64_dtype \
         pandas.api.types.is_datetime64_ns_dtype \
         pandas.api.types.is_datetime64tz_dtype \
         pandas.api.types.is_float_dtype \
         pandas.api.types.is_int64_dtype \
         pandas.api.types.is_integer_dtype \
         pandas.api.types.is_interval_dtype \
-        pandas.api.types.is_numeric_dtype \
-        pandas.api.types.is_object_dtype \
         pandas.api.types.is_period_dtype \
         pandas.api.types.is_signed_integer_dtype \
         pandas.api.types.is_sparse \

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -170,6 +170,7 @@ def is_object_dtype(arr_or_dtype) -> bool:
 
     Examples
     --------
+    >>> from pandas.api.types import is_object_dtype
     >>> is_object_dtype(object)
     True
     >>> is_object_dtype(int)
@@ -286,6 +287,7 @@ def is_datetime64_dtype(arr_or_dtype) -> bool:
 
     Examples
     --------
+    >>> from pandas.api.types import is_datetime64_dtype
     >>> is_datetime64_dtype(object)
     False
     >>> is_datetime64_dtype(np.datetime64)
@@ -1135,6 +1137,7 @@ def is_numeric_dtype(arr_or_dtype) -> bool:
 
     Examples
     --------
+    >>> from pandas.api.types import is_numeric_dtype
     >>> is_numeric_dtype(str)
     False
     >>> is_numeric_dtype(int)


### PR DESCRIPTION
Related to issue #51236

This PR enables functions:
`pandas.api.types.is_object_dtype`
`pandas.api.types.is_numeric_dtype`
`pandas.api.types.is_datetime64_dtype`