### PR TITLE
DOC: fix EX02 errors in docstrings III

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -579,10 +579,7 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
     MSG='Partially validate docstrings (EX02)' ;  echo $MSG
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=EX02 --ignore_functions \
         pandas.DataFrame.plot.line \
-        pandas.Period.strftime \
-        pandas.Series.floordiv \
         pandas.Series.plot.line \
-        pandas.Series.rfloordiv \
         pandas.Series.sparse.density \
         pandas.Series.sparse.npoints \
         pandas.Series.sparse.sp_values \

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2474,6 +2474,7 @@ cdef class _Period(PeriodMixin):
         Examples
         --------
 
+        >>> from pandas import Period
         >>> a = Period(freq='Q-JUL', year=2006, quarter=1)
         >>> a.strftime('%F-Q%q')
         '2006-Q1'

--- a/pandas/core/ops/docstrings.py
+++ b/pandas/core/ops/docstrings.py
@@ -156,8 +156,8 @@ _floordiv_example_SERIES = (
     + """
 >>> a.floordiv(b, fill_value=0)
 a    1.0
-b    NaN
-c    NaN
+b    inf
+c    inf
 d    0.0
 e    NaN
 dtype: float64


### PR DESCRIPTION
Related to the issue #51236

This PR enables functions:
`pandas.Period.strftime \`
`pandas.Series.floordiv \`
`pandas.Series.rfloordiv \`