### PR TITLE
PERF: Fix performance regression in get_loc of IntervalIndex

### DIFF
--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -662,9 +662,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             msg = "left side of interval must be <= right side"
             raise ValueError(msg)
 
-    def _shallow_copy(
-        self: IntervalArrayT, left, right, verify_integrity: bool = True
-    ) -> IntervalArrayT:
+    def _shallow_copy(self: IntervalArrayT, left, right) -> IntervalArrayT:
         """
         Return a new IntervalArray with the replacement attributes
 
@@ -677,8 +675,6 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         """
         dtype = IntervalDtype(left.dtype, closed=self.closed)
         left, right, dtype = self._ensure_simple_new_inputs(left, right, dtype=dtype)
-        if verify_integrity:
-            self._validate(left, right, dtype=dtype)
 
         return self._simple_new(left, right, dtype=dtype)
 

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -730,7 +730,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         if np.ndim(left) > 1:
             # GH#30588 multi-dimensional indexer disallowed
             raise ValueError("multi-dimensional indexing not allowed")
-        return self._shallow_copy(left, right, verify_integrity=False)
+        return self._simple_new(left, right, dtype=self.dtype)
 
     def __setitem__(self, key, value) -> None:
         value_left, value_right = self._validate_setitem_value(value)

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -726,7 +726,11 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         if np.ndim(left) > 1:
             # GH#30588 multi-dimensional indexer disallowed
             raise ValueError("multi-dimensional indexing not allowed")
-        return self._simple_new(left, right, dtype=self.dtype)
+        # Argument 2 to "_simple_new" of "IntervalArray" has incompatible type
+        # "Union[Period, Timestamp, Timedelta, NaTType, DatetimeArray, TimedeltaArray,
+        # ndarray[Any, Any]]"; expected "Union[Union[DatetimeArray, TimedeltaArray],
+        # ndarray[Any, Any]]"
+        return self._simple_new(left, right, dtype=self.dtype)  # type: ignore[arg-type]
 
     def __setitem__(self, key, value) -> None:
         value_left, value_right = self._validate_setitem_value(value)

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -662,7 +662,9 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             msg = "left side of interval must be <= right side"
             raise ValueError(msg)
 
-    def _shallow_copy(self: IntervalArrayT, left, right) -> IntervalArrayT:
+    def _shallow_copy(
+        self: IntervalArrayT, left, right, verify_integrity: bool = True
+    ) -> IntervalArrayT:
         """
         Return a new IntervalArray with the replacement attributes
 
@@ -675,7 +677,8 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         """
         dtype = IntervalDtype(left.dtype, closed=self.closed)
         left, right, dtype = self._ensure_simple_new_inputs(left, right, dtype=dtype)
-        self._validate(left, right, dtype=dtype)
+        if verify_integrity:
+            self._validate(left, right, dtype=dtype)
 
         return self._simple_new(left, right, dtype=dtype)
 
@@ -727,7 +730,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         if np.ndim(left) > 1:
             # GH#30588 multi-dimensional indexer disallowed
             raise ValueError("multi-dimensional indexing not allowed")
-        return self._shallow_copy(left, right)
+        return self._shallow_copy(left, right, verify_integrity=False)
 
     def __setitem__(self, key, value) -> None:
         value_left, value_right = self._validate_setitem_value(value)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.


caused in https://github.com/pandas-dev/pandas/commit/184e1674

No need to call validate here

https://asv-runner.github.io/asv-collection/pandas/#indexing.IntervalIndexing.time_loc_list