### PR TITLE
add typehint for None pct_change

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10814,7 +10814,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     def pct_change(
         self: NDFrameT,
         periods: int = 1,
-        fill_method: Literal["backfill", "bfill", "pad", "ffill"] = "pad",
+        fill_method: Literal["backfill", "bfill", "pad", "ffill"] | None = "pad",
         limit=None,
         freq=None,
         **kwargs,


### PR DESCRIPTION
- [x ] closes #51269 
- [x ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints)

I've added a typehint for None. It looks like supplying `None` as an argument to `fill_method` is tested for dataframes under `pandas/tests/series/methods`.

Let me know if another test should be written, e.g for dataframes.