### PR TITLE
PERF: remove categories

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -73,7 +73,6 @@ from pandas.core.dtypes.generic import (
 from pandas.core.dtypes.missing import (
     is_valid_na_for_dtype,
     isna,
-    notna,
 )
 
 from pandas.core import (
@@ -1135,14 +1134,17 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         [NaN, 'c', 'b', 'c', NaN]
         Categories (2, object): ['b', 'c']
         """
+        from pandas import Index
+
         if not is_list_like(removals):
             removals = [removals]
 
-        removals = {x for x in set(removals) if notna(x)}
+        removals = Index(removals).dropna().unique()
         new_categories = self.dtype.categories.difference(removals)
         not_included = removals.difference(self.dtype.categories)
 
         if len(not_included) != 0:
+            not_included = set(not_included)
             raise ValueError(f"removals must all be in old categories: {not_included}")
 
         return self.set_categories(new_categories, ordered=self.ordered, rename=False)

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1139,7 +1139,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         if not is_list_like(removals):
             removals = [removals]
 
-        removals = Index(removals).dropna().unique()
+        removals = Index(removals).unique().dropna()
         new_categories = self.dtype.categories.difference(removals)
         not_included = removals.difference(self.dtype.categories)
 


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.

cc @phofl, per https://github.com/pandas-dev/pandas/pull/50857#issuecomment-1426898195

I dont think we should revert #50857 as that fixed a few bugs. I think this gets most of the perf back though.

No whatsnew as this was a slowdown on main only. 

```
from asv_bench.benchmarks.categoricals import RemoveCategories

b = RemoveCategories()
b.setup()

%timeit b.time_remove_categories()

# 66.4 ms ± 1.92 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)  <- main
# 45.2 ms ± 1.57 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)  <- PR
```