### PR TITLE
BUG: iterparse on `read_xml` ignores repeated elements

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -1304,6 +1304,7 @@ I/O
 - Bug in :meth:`DataFrame.to_dict` not converting ``NA`` to ``None`` (:issue:`50795`)
 - Bug in :meth:`DataFrame.to_json` where it would segfault when failing to encode a string (:issue:`50307`)
 - Bug in :func:`read_xml` where file-like objects failed when iterparse is used (:issue:`50641`)
+- Bug in :func:`read_xml` ignored repeated elements when iterparse is used (:issue:`51183`)
 
 Period
 ^^^^^^

--- a/pandas/io/xml.py
+++ b/pandas/io/xml.py
@@ -337,6 +337,10 @@ class _XMLFrameParser:
                 "local disk and not as compressed files or online sources."
             )
 
+        iterparse_repeats = len(self.iterparse[row_node]) != len(
+            set(self.iterparse[row_node])
+        )
+
         for event, elem in iterparse(self.path_or_buffer, events=("start", "end")):
             curr_elem = elem.tag.split("}")[1] if "}" in elem.tag else elem.tag
 
@@ -345,12 +349,13 @@ class _XMLFrameParser:
                     row = {}
 
             if row is not None:
-                if self.names:
+                if self.names and iterparse_repeats:
                     for col, nm in zip(self.iterparse[row_node], self.names):
                         if curr_elem == col:
                             elem_val = elem.text.strip() if elem.text else None
-                            if row.get(nm) != elem_val and nm not in row:
+                            if elem_val not in row.values() and nm not in row:
                                 row[nm] = elem_val
+
                         if col in elem.attrib:
                             if elem.attrib[col] not in row.values() and nm not in row:
                                 row[nm] = elem.attrib[col]

--- a/pandas/tests/io/xml/test_xml.py
+++ b/pandas/tests/io/xml/test_xml.py
@@ -948,6 +948,55 @@ def test_repeat_values_new_names(parser):
     tm.assert_frame_equal(df_iter, df_expected)
 
 
+def test_repeat_elements(parser):
+    xml = """\
+<shapes>
+  <shape>
+    <value item="name">circle</value>
+    <value item="family">ellipse</value>
+    <value item="degrees">360</value>
+    <value item="sides">0</value>
+  </shape>
+  <shape>
+    <value item="name">triangle</value>
+    <value item="family">polygon</value>
+    <value item="degrees">180</value>
+    <value item="sides">3</value>
+  </shape>
+  <shape>
+    <value item="name">square</value>
+    <value item="family">polygon</value>
+    <value item="degrees">360</value>
+    <value item="sides">4</value>
+  </shape>
+</shapes>"""
+    df_xpath = read_xml(
+        xml,
+        xpath=".//shape",
+        parser=parser,
+        names=["name", "family", "degrees", "sides"],
+    )
+
+    df_iter = read_xml_iterparse(
+        xml,
+        parser=parser,
+        iterparse={"shape": ["value", "value", "value", "value"]},
+        names=["name", "family", "degrees", "sides"],
+    )
+
+    df_expected = DataFrame(
+        {
+            "name": ["circle", "triangle", "square"],
+            "family": ["ellipse", "polygon", "polygon"],
+            "degrees": [360, 180, 360],
+            "sides": [0, 3, 4],
+        }
+    )
+
+    tm.assert_frame_equal(df_xpath, df_expected)
+    tm.assert_frame_equal(df_iter, df_expected)
+
+
 def test_names_option_wrong_length(datapath, parser):
     filename = datapath("io", "data", "xml", "books.xml")
 


### PR DESCRIPTION
- [X] closes #51183
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/v2.0.0.rst` file if fixing a bug or adding a new feature.
