### PR TITLE
ENH: Add Index.filter() method

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -314,7 +314,7 @@ Other enhancements
 - Added new argument ``engine`` to :func:`read_json` to support parsing JSON with pyarrow by specifying ``engine="pyarrow"`` (:issue:`48893`)
 - Added support for SQLAlchemy 2.0 (:issue:`40686`)
 - :class:`Index` set operations :meth:`Index.union`, :meth:`Index.intersection`, :meth:`Index.difference`, and :meth:`Index.symmetric_difference` now support ``sort=True``, which will always return a sorted result, unlike the default ``sort=None`` which does not sort in some cases (:issue:`25151`)
--
+- Added :meth:`Index.filter` that allows filtering on :class:`Index` to create a new :class:`Index` object
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_200.notable_bug_fixes:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5473,6 +5473,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         --------
         DataFrame.loc : Access a group of rows and columns
             by label(s) or a boolean array.
+        Index.filter : Create a subset of the index according to the specified index
+            labels.
 
         Notes
         -----

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1285,6 +1285,34 @@ class TestIndex(Base):
         result = index.sortlevel(ascending=False)
         tm.assert_index_equal(result[0], expected)
 
+    @pytest.mark.parametrize(
+        "dtype",
+        ["object", pd.StringDtype()],
+    )
+    def test_filter_string(self, dtype):
+        idx = Index(["cat", "dog", "bat", "bird"], dtype=dtype)
+        result = idx.filter(["cat", "dog"])
+        expected = Index(["cat", "dog"], dtype=dtype)
+        tm.assert_index_equal(result, expected)
+
+        result = idx.filter(like="at")
+        expected = Index(["cat", "bat"], dtype=dtype)
+        tm.assert_index_equal(result, expected)
+
+        result = idx.filter(regex=r"b.*")
+        expected = Index(["bat", "bird"], dtype=dtype)
+        tm.assert_index_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "dtype",
+        ["int", pd.Int64Dtype()],
+    )
+    def test_filter_int(self, dtype):
+        idx = Index([1, 2, 3, 4, 5], dtype=dtype)
+        result = idx.filter(range(2, 4))
+        expected = Index([2, 3], dtype=dtype)
+        tm.assert_index_equal(result, expected)
+
 
 class TestMixedIntIndex(Base):
     # Mostly the tests from common.py for which the results differ


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
  - New feature - no issue
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
  - `pandas\pandas\tests\indexes\test_base.py:TestIndex.test_filter_string()`
  - `pandas\pandas\tests\indexes\test_base.py:TestIndex.test_filter_int()`
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.0.0.rst` file if fixing a bug or adding a new feature.

This is similar to `DataFrame.filter()`, except it returns an `Index` object, and avoids any under-the-hood things that might be happening with `DataFrame.filter()` in terms of views/copies of the `DataFrame`.   Some examples where this would be useful (and helpful when doing type checking).

- Instead of `df.columns = [x for x in otherdf.columns if "at" in x]`, you can do `df.columns = otherdf.columns.filter(like="at")`
- Instead of `df.drop(columns=[x for x in df.columns if x.startswith("b")]`, you can do `df.drop(columns=df.columns.filter(regex=r"b.*")`
- Instead of `df.set_index([x for x in df.columns if x.endswith("z")])`, you can do `df.set_index(df.columns.filter(r".*z$"))`

