### PR TITLE
WIP: dtype._is_valid_na_for_dtype

### DIFF
--- a/pandas/core/arrays/arrow/dtype.py
+++ b/pandas/core/arrays/arrow/dtype.py
@@ -4,6 +4,7 @@ import re
 
 import numpy as np
 
+from pandas._libs import missing as libmissing
 from pandas._typing import (
     TYPE_CHECKING,
     DtypeObj,
@@ -208,6 +209,9 @@ class ArrowDtype(StorageExtensionDtype):
             return type(self)(pa_dtype)
         except NotImplementedError:
             return None
+
+    def _is_valid_na_for_dtype(self, value) -> bool:
+        return value is None or value is libmissing.NA
 
     def __from_arrow__(self, array: pa.Array | pa.ChunkedArray):
         """

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -425,7 +425,7 @@ class ExtensionArray:
         if is_scalar(item) and isna(item):
             if not self._can_hold_na:
                 return False
-            elif item is self.dtype.na_value or isinstance(item, self.dtype.type):
+            elif self.dtype._is_valid_na_for_dtype(item):
                 return self._hasna
             else:
                 return False

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -61,9 +61,11 @@ class ExtensionDtype:
     * _is_numeric
     * _is_boolean
     * _get_common_dtype
+    * _is_valid_na_for_dtype
 
     The `na_value` class attribute can be used to set the default NA value
-    for this type. :attr:`numpy.nan` is used by default.
+    for this type. :attr:`numpy.nan` is used by default. What other NA values
+    are accepted can be fine-tuned by overriding ``_is_valid_na_for_dtype``.
 
     ExtensionDtypes are required to be hashable. The base class provides
     a default implementation, which relies on the ``_metadata`` class
@@ -389,6 +391,26 @@ class ExtensionDtype:
         Can arrays of this dtype hold NA values?
         """
         return True
+
+    def _is_valid_na_for_dtype(self, value) -> bool:
+        """
+        Should we treat this value as interchangeable with self.na_value?
+
+        Use cases include:
+
+        - series[key] = value
+        - series.replace(other, value)
+        - value in index
+
+        If ``value`` is a valid na for this dtype, ``self.na_value`` will be used
+        in its place for the purpose of this operations.
+
+        Notes
+        -----
+        The base class implementation considers any scalar recognized by pd.isna
+        to be equivalent.
+        """
+        return libmissing.checknull(value)
 
 
 class StorageExtensionDtype(ExtensionDtype):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -35,7 +35,10 @@ from pandas._config import (
     using_copy_on_write,
 )
 
-from pandas._libs import lib
+from pandas._libs import (
+    lib,
+    missing as libmissing,
+)
 from pandas._libs.lib import is_range_indexer
 from pandas._libs.tslibs import (
     Period,
@@ -8012,7 +8015,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 result = result.where(subset, lower, axis=None, inplace=False)
 
         if np.any(mask):
-            result[mask] = np.nan
+            result[mask] = libmissing.NA
 
         if inplace:
             return self._update_inplace(result)

--- a/pandas/tests/extension/test_integer.py
+++ b/pandas/tests/extension/test_integer.py
@@ -135,7 +135,7 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
             expected = self._combine(s, other, op)
 
             if op_name in ("__rtruediv__", "__truediv__", "__div__"):
-                expected = expected.fillna(np.nan).astype("Float64")
+                expected = expected.fillna(pd.NA).astype("Float64")
             else:
                 # combine method result in 'biggest' (int64) dtype
                 expected = expected.astype(sdtype)

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -193,7 +193,7 @@ class TestSeriesConvertDtypes:
         # Test that it is a copy
         copy = series.copy(deep=True)
 
-        result[result.notna()] = np.nan
+        result[result.notna()] = None
 
         # Make sure original not changed
         tm.assert_series_equal(series, copy)


### PR DESCRIPTION
Some dtypes (pyarrow/nullable mostly) need to treat NaN (and maybe None) differently from pd.NA.  Motivating bug (which this PR does not address):

```
arr = pd.array(range(5)) / 0

>>> np.nan in arr  # <- wrong
False
```

What this does fix is `arr[2] = np.nan` now sets NaN instead of pd.NA.  Setting np.nan into an IntegerArray/BooleanArray raises.  (None still casts to pd.NA).

This breaks a bunch of tests.  I'd like feedback before I go track those down.  cc @jorisvandenbossche 

Tangentially related #27825
