### PR TITLE
WARN unnecessary "can't infer datetime format" for out-of-bounds datetimes

### DIFF
--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -73,7 +73,7 @@ from pandas._libs.tslibs.np_datetime cimport (
     string_to_dts,
 )
 
-from pandas._libs.tslibs.strptime import array_strptime
+from pandas._libs.tslibs.strptime import TimeRE
 
 from pandas._libs.tslibs.util cimport (
     get_c_string_buf_and_size,
@@ -992,9 +992,7 @@ def guess_datetime_format(dt_str: str, bint dayfirst=False) -> str | None:
 
     guessed_format = "".join(output_format)
 
-    try:
-        array_strptime(np.asarray([dt_str], dtype=object), guessed_format)
-    except ValueError:
+    if TimeRE().compile(guessed_format).match(dt_str) is None:
         # Doesn't parse, so this can't be the correct format.
         return None
     # rebuild string, capturing any inferred padding

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -1383,7 +1383,7 @@ class TestToDatetime:
             with pytest.raises(ValueError, match=msg):
                 to_datetime(value, errors="raise", format=format)
         else:
-            msg = "^Out of bounds .*, at position 0"
+            msg = f"^Out of bounds .*, at position 0. {PARSING_ERR_MSG}"
             with pytest.raises(OutOfBoundsDatetime, match=msg):
                 to_datetime(value, errors="raise", format=format)
 

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -1372,12 +1372,10 @@ class TestToDatetime:
     )
     def test_datetime_outofbounds_scalar(self, value, format, warning):
         # GH24763
-        with tm.assert_produces_warning(warning, match="Could not infer format"):
-            res = to_datetime(value, errors="ignore", format=format)
+        res = to_datetime(value, errors="ignore", format=format)
         assert res == value
 
-        with tm.assert_produces_warning(warning, match="Could not infer format"):
-            res = to_datetime(value, errors="coerce", format=format)
+        res = to_datetime(value, errors="coerce", format=format)
         assert res is NaT
 
         if format is not None:
@@ -1385,10 +1383,8 @@ class TestToDatetime:
             with pytest.raises(ValueError, match=msg):
                 to_datetime(value, errors="raise", format=format)
         else:
-            msg = "^Out of bounds .*, at position 0$"
-            with pytest.raises(
-                OutOfBoundsDatetime, match=msg
-            ), tm.assert_produces_warning(warning, match="Could not infer format"):
+            msg = "^Out of bounds .*, at position 0"
+            with pytest.raises(OutOfBoundsDatetime, match=msg):
                 to_datetime(value, errors="raise", format=format)
 
     @pytest.mark.parametrize("values", [["a"], ["00:01:99"], ["a", "b", "99:00:00"]])
@@ -2217,10 +2213,7 @@ class TestToDatetimeMisc:
 
         msg = "^Out of bounds nanosecond timestamp: .*, at position 0"
         with pytest.raises(OutOfBoundsDatetime, match=msg):
-            with tm.assert_produces_warning(
-                UserWarning, match="Could not infer format"
-            ):
-                to_datetime(arr)
+            to_datetime(arr)
 
     @pytest.mark.parametrize(
         "arg, exp_str",
@@ -3335,8 +3328,7 @@ class TestOrigin:
         # see gh-23830
         msg = r"^Out of bounds nanosecond timestamp: 2417-10-10 00:00:00, at position 0"
         with pytest.raises(OutOfBoundsDatetime, match=msg):
-            with tm.assert_produces_warning(warning, match="Could not infer format"):
-                to_datetime("2417-10-10 00:00:00", format=format)
+            to_datetime("2417-10-10 00:00:00", format=format)
 
     @pytest.mark.parametrize(
         "arg, origin, expected_str",


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
