### PR TITLE
DOC: clarify pitfalls of NA vs NaN in nullable floats

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7872,6 +7872,14 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         Everything else gets mapped to False values. Characters such as empty
         strings ``''`` or :attr:`numpy.inf` are not considered NA values
         (unless you set ``pandas.options.mode.use_inf_as_na = True``).
+        Note: For :class:`FloatingArray` and float-type
+        :class:`ArrowExtensionArray` the behavior is different, as they
+        use a mask (represented as pd.NA values) to designate missing
+        data but can also hold NaN which will **not** get mapped to True
+        (these values can be detected by :func:`numpy.isnan`).
+        Users may find this behavior unintuitive and want to
+        avoid these dtypes if they prefer to have only one
+        type of missing/NA value.
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7872,14 +7872,12 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         Everything else gets mapped to False values. Characters such as empty
         strings ``''`` or :attr:`numpy.inf` are not considered NA values
         (unless you set ``pandas.options.mode.use_inf_as_na = True``).
-        Note: For :class:`FloatingArray` and float-type
-        :class:`ArrowExtensionArray` the behavior is different, as they
-        use a mask (represented as pd.NA values) to designate missing
-        data but can also hold NaN which will **not** get mapped to True
-        (these values can be detected by :func:`numpy.isnan`).
-        Users may find this behavior unintuitive and want to
-        avoid these dtypes if they prefer to have only one
-        type of missing/NA value.
+
+        Note: For nullable float extension dtypes, i.e.
+        ``Float<...>`` and ``float<...>[pyarrow]``, the behavior is different -
+        missing data is designated by ``pandas.NA`` values while NaN may also be
+        stored but will **not** get mapped to True (these values can be detected
+        by :func:`numpy.isnan`).
 
         Returns
         -------


### PR DESCRIPTION
- [x] stopgap solution addressing  #49818 and such until the discussion in #32265 is resolved 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Following up on my [comment](https://github.com/pandas-dev/pandas/issues/32265#issuecomment-1405543022): since the current behavior easily leads to mistakes when trying to detect missing/NaN data and does not match the docs' described semantics, this PR is trying to update the docs to clarify this edge case so users can avoid the pitfalls.

Notes/questions on PR work: 
* There may be other places to update, but I figure once the language is approved it's easy to add it elsewhere
* Should we link to the issue #32265 discussing what the behavior should be? That would enable users to weigh in with their preferences but might be too detailed/confusing.
* Should the docstring describe this scenario in terms of Arrays or the corresponding dtypes?

Thanks!
