### PR TITLE
BUG: Arithmetic inplace ops not respecting CoW

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -259,6 +259,9 @@ Copy-on-Write improvements
 - :meth:`DataFrame.replace` will now respect the Copy-on-Write mechanism
   when ``inplace=True``.
 
+- Arithmetic operations that can be inplace, e.g. ``ser *= 2`` will now respect the
+  Copy-on-Write mechanism.
+
 Copy-on-Write can be enabled through one of
 
 .. code-block:: python

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11737,7 +11737,11 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             and is_dtype_equal(result.dtype, self.dtype)
         ):
             # GH#36498 this inplace op can _actually_ be inplace.
-            self._mgr.setitem_inplace(slice(None), result._values)
+            # Item "ArrayManager" of "Union[ArrayManager, SingleArrayManager,
+            # BlockManager, SingleBlockManager]" has no attribute "setitem_inplace"
+            self._mgr.setitem_inplace(  # type: ignore[union-attr]
+                slice(None), result._values
+            )
             return self
 
         # Delete cacher

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11735,6 +11735,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             self.ndim == 1
             and result._indexed_same(self)
             and is_dtype_equal(result.dtype, self.dtype)
+            and not (using_copy_on_write() and not self._mgr._has_no_reference(0))
         ):
             # GH#36498 this inplace op can _actually_ be inplace.
             self._values[:] = result._values

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11731,19 +11731,13 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         """
         result = op(self, other)
 
-        # Item "ArrayManager" of "Union[ArrayManager, SingleArrayManager,
-        # BlockManager, SingleBlockManager]" has no attribute "_has_no_reference"
         if (
             self.ndim == 1
             and result._indexed_same(self)
             and is_dtype_equal(result.dtype, self.dtype)
-            and not (
-                using_copy_on_write()
-                and not self._mgr._has_no_reference(0)  # type: ignore[union-attr]
-            )
         ):
             # GH#36498 this inplace op can _actually_ be inplace.
-            self._values[:] = result._values
+            self._mgr.setitem_inplace(slice(None), result._values)
             return self
 
         # Delete cacher

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11731,11 +11731,16 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         """
         result = op(self, other)
 
+        # Item "ArrayManager" of "Union[ArrayManager, SingleArrayManager,
+        # BlockManager, SingleBlockManager]" has no attribute "_has_no_reference"
         if (
             self.ndim == 1
             and result._indexed_same(self)
             and is_dtype_equal(result.dtype, self.dtype)
-            and not (using_copy_on_write() and not self._mgr._has_no_reference(0))
+            and not (
+                using_copy_on_write()
+                and not self._mgr._has_no_reference(0)  # type: ignore[union-attr]
+            )
         ):
             # GH#36498 this inplace op can _actually_ be inplace.
             self._values[:] = result._values

--- a/pandas/tests/copy_view/test_methods.py
+++ b/pandas/tests/copy_view/test_methods.py
@@ -1479,3 +1479,23 @@ def test_xs_multiindex(using_copy_on_write, using_array_manager, key, level, axi
             result.iloc[0, 0] = 0
 
     tm.assert_frame_equal(df, df_orig)
+
+
+def test_inplace_arithmetic_series():
+    ser = Series([1, 2, 3])
+    data = get_array(ser)
+    ser *= 2
+    assert np.shares_memory(get_array(ser), data)
+    tm.assert_numpy_array_equal(data, get_array(ser))
+
+
+def test_inplace_arithmetic_series_with_reference(using_copy_on_write):
+    ser = Series([1, 2, 3])
+    ser_orig = ser.copy()
+    view = ser[:]
+    ser *= 2
+    if using_copy_on_write:
+        assert not np.shares_memory(get_array(ser), get_array(view))
+        tm.assert_series_equal(ser_orig, view)
+    else:
+        assert np.shares_memory(get_array(ser), get_array(view))

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1988,17 +1988,22 @@ def test_arith_list_of_arraylike_raise(to_add):
         to_add + df
 
 
-def test_inplace_arithmetic_series_update():
+def test_inplace_arithmetic_series_update(using_copy_on_write):
     # https://github.com/pandas-dev/pandas/issues/36373
     df = DataFrame({"A": [1, 2, 3]})
+    df_orig = df.copy()
     series = df["A"]
     vals = series._values
 
     series += 1
-    assert series._values is vals
+    if using_copy_on_write:
+        assert series._values is not vals
+        tm.assert_frame_equal(df, df_orig)
+    else:
+        assert series._values is vals
 
-    expected = DataFrame({"A": [2, 3, 4]})
-    tm.assert_frame_equal(df, expected)
+        expected = DataFrame({"A": [2, 3, 4]})
+        tm.assert_frame_equal(df, expected)
 
 
 def test_arithemetic_multiindex_align():

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1105,9 +1105,12 @@ class TestLocBaseIndependent:
         else:
             assert all(sliced_series[:3] == [7, 8, 9])
 
-    @pytest.mark.xfail(reason="accidental fix reverted - GH37497")
-    def test_loc_copy_vs_view(self):
+    def test_loc_copy_vs_view(self, request, using_copy_on_write):
         # GH 15631
+
+        if not using_copy_on_write:
+            mark = pytest.mark.xfail(reason="accidental fix reverted - GH37497")
+            request.node.add_marker(mark)
         x = DataFrame(zip(range(3), range(3)), columns=["a", "b"])
 
         y = x.copy()


### PR DESCRIPTION
- [ ] xref #49473 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

We should add tests for all op-possibilities in a follow up