### PR TITLE
BUG: DataFrame.to_html(na_rep="-") with non-scalar data

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -1322,6 +1322,7 @@ I/O
 - Bug in :func:`read_csv` unnecessarily overflowing for extension array dtype when containing ``NA`` (:issue:`32134`)
 - Bug in :meth:`DataFrame.to_dict` not converting ``NA`` to ``None`` (:issue:`50795`)
 - Bug in :meth:`DataFrame.to_json` where it would segfault when failing to encode a string (:issue:`50307`)
+- Bug in :meth:`DataFrame.to_html` with `na_rep` set when the :class:`DataFrame` contains non-scalar data (:issue:`47103`)
 - Bug in :func:`read_xml` where file-like objects failed when iterparse is used (:issue:`50641`)
 - Bug in :func:`read_xml` ignored repeated elements when iterparse is used (:issue:`51183`)
 

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -1322,7 +1322,7 @@ I/O
 - Bug in :func:`read_csv` unnecessarily overflowing for extension array dtype when containing ``NA`` (:issue:`32134`)
 - Bug in :meth:`DataFrame.to_dict` not converting ``NA`` to ``None`` (:issue:`50795`)
 - Bug in :meth:`DataFrame.to_json` where it would segfault when failing to encode a string (:issue:`50307`)
-- Bug in :meth:`DataFrame.to_html` with `na_rep` set when the :class:`DataFrame` contains non-scalar data (:issue:`47103`)
+- Bug in :meth:`DataFrame.to_html` with ``na_rep`` set when the :class:`DataFrame` contains non-scalar data (:issue:`47103`)
 - Bug in :func:`read_xml` where file-like objects failed when iterparse is used (:issue:`50641`)
 - Bug in :func:`read_xml` ignored repeated elements when iterparse is used (:issue:`51183`)
 

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -1814,7 +1814,7 @@ def _maybe_wrap_formatter(
     if na_rep is None:
         return func_3
     else:
-        return lambda x: na_rep if isna(x) else func_3(x)
+        return lambda x: na_rep if (isna(x) is True) else func_3(x)
 
 
 def non_reducing_slice(slice_: Subset):

--- a/pandas/tests/io/formats/data/html/gh47103_expected_output.html
+++ b/pandas/tests/io/formats/data/html/gh47103_expected_output.html
@@ -1,0 +1,18 @@
+<style type="text/css">
+</style>
+<table id="T_test">
+  <thead>
+    <tr>
+      <th class="blank level0" >&nbsp;</th>
+      <th id="T_test_level0_col0" class="col_heading level0 col0" >a</th>
+      <th id="T_test_level0_col1" class="col_heading level0 col1" >b</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th id="T_test_level0_row0" class="row_heading level0 row0" >0</th>
+      <td id="T_test_row0_col0" class="data row0 col0" >1</td>
+      <td id="T_test_row0_col1" class="data row0 col1" >[1, 2, 3]</td>
+    </tr>
+  </tbody>
+</table>

--- a/pandas/tests/io/formats/data/html/gh47103_expected_output.html
+++ b/pandas/tests/io/formats/data/html/gh47103_expected_output.html
@@ -1,18 +1,16 @@
-<style type="text/css">
-</style>
-<table id="T_test">
+<table border="1" class="dataframe">
   <thead>
-    <tr>
-      <th class="blank level0" >&nbsp;</th>
-      <th id="T_test_level0_col0" class="col_heading level0 col0" >a</th>
-      <th id="T_test_level0_col1" class="col_heading level0 col1" >b</th>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>a</th>
+      <th>b</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <th id="T_test_level0_row0" class="row_heading level0 row0" >0</th>
-      <td id="T_test_row0_col0" class="data row0 col0" >1</td>
-      <td id="T_test_row0_col1" class="data row0 col1" >[1, 2, 3]</td>
+      <th>0</th>
+      <td>1</td>
+      <td>[1, 2, 3]</td>
     </tr>
   </tbody>
 </table>

--- a/pandas/tests/io/formats/style/test_html.py
+++ b/pandas/tests/io/formats/style/test_html.py
@@ -976,3 +976,32 @@ def test_concat_combined():
         )
     )
     assert expected_css + expected_table == result
+
+
+def test_to_html_na_rep_non_scalar_data(datapath):
+    # GH47103
+    df = DataFrame([dict(a=1, b=[1, 2, 3], c=np.nan)])
+    result = df.style.format(na_rep="-").to_html(table_uuid="test")
+    expected = """\
+<style type="text/css">
+</style>
+<table id="T_test">
+  <thead>
+    <tr>
+      <th class="blank level0" >&nbsp;</th>
+      <th id="T_test_level0_col0" class="col_heading level0 col0" >a</th>
+      <th id="T_test_level0_col1" class="col_heading level0 col1" >b</th>
+      <th id="T_test_level0_col2" class="col_heading level0 col2" >c</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th id="T_test_level0_row0" class="row_heading level0 row0" >0</th>
+      <td id="T_test_row0_col0" class="data row0 col0" >1</td>
+      <td id="T_test_row0_col1" class="data row0 col1" >[1, 2, 3]</td>
+      <td id="T_test_row0_col2" class="data row0 col2" >-</td>
+    </tr>
+  </tbody>
+</table>
+"""
+    assert result == expected

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -886,7 +886,7 @@ def test_to_html_na_rep_non_scalar_data(datapath):
     # GH47103
     df = DataFrame([dict(a=1, b=[1, 2, 3])])
     result = df.to_html(na_rep="-")
-    expected = expected_html(datapath, "gh47103_expected_output") + "\n"
+    expected = expected_html(datapath, "gh47103_expected_output")
     assert result == expected
 
 

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -882,6 +882,14 @@ def test_to_html_na_rep_and_float_format(na_rep, datapath):
     assert result == expected
 
 
+def test_to_html_na_rep_non_scalar_data(datapath):
+    # GH47103
+    df = pd.DataFrame([dict(a=1, b=[1, 2, 3])])
+    result = df.style.format(na_rep="-").to_html(table_uuid="test")
+    expected = expected_html(datapath, "gh47103_expected_output") + "\n"
+    assert result == expected
+
+
 def test_to_html_float_format_object_col(datapath):
     # GH#40024
     df = DataFrame(data={"x": [1000.0, "test"]})

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -884,8 +884,8 @@ def test_to_html_na_rep_and_float_format(na_rep, datapath):
 
 def test_to_html_na_rep_non_scalar_data(datapath):
     # GH47103
-    df = pd.DataFrame([dict(a=1, b=[1, 2, 3])])
-    result = df.style.format(na_rep="-").to_html(table_uuid="test")
+    df = DataFrame([dict(a=1, b=[1, 2, 3])])
+    result = df.to_html(na_rep="-")
     expected = expected_html(datapath, "gh47103_expected_output") + "\n"
     assert result == expected
 


### PR DESCRIPTION
- [x] closes #47103
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
