### PR TITLE
PERF: Improve performance for pyarrow to_numpy with na and na_value

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -891,9 +891,9 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray, BaseStringArrayMethods):
             result[mask] = np.asarray(self[mask]._data)
         elif self._hasna:
             mask = self.isna()
-            result = np.ones((len(self),), dtype=dtype) * na_value
-            result[~mask] = np.asarray(self[~mask]._data, dtype=dtype)
-            return result
+            data = self.copy()
+            data[mask] = na_value
+            return np.asarray(data._data, dtype=dtype)
         else:
             result = np.asarray(self._data, dtype=dtype)
             if copy:

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -889,9 +889,14 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray, BaseStringArrayMethods):
             result = np.empty(len(self), dtype=object)
             mask = ~self.isna()
             result[mask] = np.asarray(self[mask]._data)
+        elif self._hasna:
+            mask = self.isna()
+            result = np.ones((len(self),), dtype=dtype) * na_value
+            result[~mask] = np.asarray(self[~mask]._data, dtype=dtype)
+            return result
         else:
             result = np.asarray(self._data, dtype=dtype)
-            if copy or self._hasna:
+            if copy:
                 result = result.copy()
         if self._hasna:
             result[self.isna()] = na_value

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -11,7 +11,6 @@ from typing import (
     TypeVar,
     cast,
 )
-import warnings
 
 import numpy as np
 
@@ -895,10 +894,7 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray, BaseStringArrayMethods):
             data[self.isna()] = na_value
             return np.asarray(data._data, dtype=dtype)
         else:
-            with warnings.catch_warnings():
-                # int dtype with NA raises Warning
-                warnings.filterwarnings("ignore", category=RuntimeWarning)
-                result = np.asarray(self._data, dtype=dtype)
+            result = np.asarray(self._data, dtype=dtype)
             if copy:
                 result = result.copy()
         if self._hasna:

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -890,9 +890,8 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray, BaseStringArrayMethods):
             mask = ~self.isna()
             result[mask] = np.asarray(self[mask]._data)
         elif self._hasna:
-            mask = self.isna()
             data = self.copy()
-            data[mask] = na_value
+            data[self.isna()] = na_value
             return np.asarray(data._data, dtype=dtype)
         else:
             result = np.asarray(self._data, dtype=dtype)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

saw this in the engine pr, avoids a warning and improves performance:

```
pr
%timeit ser.to_numpy(dtype="int64", na_value=1.5)
1.67 ms ± 11.2 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

main
%timeit ser.to_numpy(dtype="int64", na_value=1.5)
/Users/patrick/PycharmProjects/pandas/pandas/core/arrays/arrow/array.py:893: RuntimeWarning: invalid value encountered in cast
  result = np.asarray(self._data, dtype=dtype)
2.42 ms ± 30.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```