### PR TITLE
ENH: Improve ref-tracking for group keys

### DIFF
--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -11,7 +11,6 @@ from typing import (
     final,
 )
 import warnings
-import weakref
 
 import numpy as np
 
@@ -952,8 +951,14 @@ def get_grouper(
             except (AttributeError, KeyError, IndexError, InvalidIndexError):
                 return False
             if isinstance(gpr, Series) and isinstance(obj_gpr_column, Series):
-                ref = weakref.ref(obj_gpr_column._mgr.blocks[0])
-                return ref in gpr._mgr.blocks[0].refs.referenced_blocks
+                # Item "SingleArrayManager" of "Union[SingleArrayManager,
+                # SingleBlockManager]" has no attribute "references_same_values"
+                # Argument 1 to "references_same_values" of "BaseBlockManager" has
+                # incompatible type "Union[SingleArrayManager, SingleBlockManager]";
+                # expected "BaseBlockManager
+                return gpr._mgr.references_same_values(  # type: ignore[union-attr]
+                    obj_gpr_column._mgr, 0  # type: ignore[arg-type]
+                )
             return False
         try:
             return gpr is obj[gpr.name]

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -944,8 +944,8 @@ def get_grouper(
         if not hasattr(gpr, "name"):
             return False
         if using_copy_on_write():
-            # For the CoW case, we need an equality check as the identity check
-            # no longer works (each Series from column access is a new object)
+            # For the CoW case, we check the references to determine if the
+            # series is part of the object
             try:
                 obj_gpr_column = obj[gpr.name]
             except (KeyError, IndexError, InvalidIndexError):

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -948,14 +948,9 @@ def get_grouper(
             # no longer works (each Series from column access is a new object)
             try:
                 obj_gpr_column = obj[gpr.name]
-            except (AttributeError, KeyError, IndexError, InvalidIndexError):
+            except (KeyError, IndexError, InvalidIndexError):
                 return False
             if isinstance(gpr, Series) and isinstance(obj_gpr_column, Series):
-                # Item "SingleArrayManager" of "Union[SingleArrayManager,
-                # SingleBlockManager]" has no attribute "references_same_values"
-                # Argument 1 to "references_same_values" of "BaseBlockManager" has
-                # incompatible type "Union[SingleArrayManager, SingleBlockManager]";
-                # expected "BaseBlockManager
                 return gpr._mgr.references_same_values(  # type: ignore[union-attr]
                     obj_gpr_column._mgr, 0  # type: ignore[arg-type]
                 )

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -951,8 +951,10 @@ def get_grouper(
                 obj_gpr_column = obj[gpr.name]
             except (AttributeError, KeyError, IndexError, InvalidIndexError):
                 return False
-            ref = weakref.ref(obj_gpr_column._mgr.blocks[0])
-            return ref in gpr._mgr.blocks[0].refs.referenced_blocks
+            if isinstance(gpr, Series) and isinstance(obj_gpr_column, Series):
+                ref = weakref.ref(obj_gpr_column._mgr.blocks[0])
+                return ref in gpr._mgr.blocks[0].refs.referenced_blocks
+            return False
         try:
             return gpr is obj[gpr.name]
         except (KeyError, IndexError, InvalidIndexError):

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -11,6 +11,7 @@ from typing import (
     final,
 )
 import warnings
+import weakref
 
 import numpy as np
 
@@ -947,9 +948,11 @@ def get_grouper(
             # For the CoW case, we need an equality check as the identity check
             # no longer works (each Series from column access is a new object)
             try:
-                return gpr.equals(obj[gpr.name])
+                obj_gpr_column = obj[gpr.name]
             except (AttributeError, KeyError, IndexError, InvalidIndexError):
                 return False
+            ref = weakref.ref(obj_gpr_column._mgr.blocks[0])
+            return ref in gpr._mgr.blocks[0].refs.referenced_blocks
         try:
             return gpr is obj[gpr.name]
         except (KeyError, IndexError, InvalidIndexError):

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -11,6 +11,7 @@ from typing import (
     cast,
 )
 import warnings
+import weakref
 
 import numpy as np
 
@@ -246,6 +247,14 @@ class BaseBlockManager(DataManager):
         Returns True if the block has no references.
         """
         return not self.blocks[blkno].refs.has_reference()
+
+    def references_same_values(self, mgr: BaseBlockManager, blkno: int) -> bool:
+        """
+        Checks if two blocks from two different block managers reference the
+        same underlying values.
+        """
+        ref = weakref.ref(self.blocks[blkno])
+        return ref in mgr.blocks[blkno].refs.referenced_blocks
 
     def get_dtypes(self):
         dtypes = np.array([blk.dtype for blk in self.blocks])


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

cc @jorisvandenbossche 

Follow-up on https://github.com/pandas-dev/pandas/pull/49450

The equals check causes failures in Dask. I think we are better off moving to reference checking anyway. If you are ok with the general logic here, I'd refactor this check down to the Manager level.