### PR TITLE
API: Use lowest precision floating type found in reindex with columns

### DIFF
--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -812,11 +812,10 @@ class BaseBlockManager(DataManager):
         for blkno, mgr_locs in libinternals.get_blkno_placements(blknos, group=group):
             if blkno == -1:
                 # If we've got here, fill_value was not lib.no_default
-
                 blocks.append(
                     self._make_na_block(
                         placement=mgr_locs,
-                        fill_value=fill_value,
+                        fill_value=None if use_na_proxy else fill_value,
                         use_na_proxy=use_na_proxy,
                     )
                 )

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -748,6 +748,7 @@ def _stack_multi_columns(
             chunk = this.loc[:, this.columns[loc]]
             chunk.columns = level_vals_nan.take(chunk.columns.codes[-1])
             value_slice = chunk.reindex(columns=level_vals_used).values
+
         else:
             if frame._is_homogeneous_type and is_extension_array_dtype(
                 frame.dtypes.iloc[0]

--- a/pandas/tests/frame/methods/test_reindex.py
+++ b/pandas/tests/frame/methods/test_reindex.py
@@ -1237,3 +1237,34 @@ class TestDataFrameSelectReindex:
         result = df.reindex(index=index_res)
         expected = DataFrame(index=index_exp)
         tm.assert_frame_equal(result, expected)
+
+    def test_reindex_doesnt_upcast_nans(self):
+        df = DataFrame(
+            {
+                "a": np.array([1, 2, 3], dtype="float64"),
+                "b": np.array([4, 5, 6], dtype="float32"),
+            }
+        )
+        expected = DataFrame(
+            {
+                "a": np.array([1, 2, np.nan], dtype="float64"),
+                "b": np.array([4, 5, np.nan], dtype="float32"),
+            },
+            index=[0, 1, 4],
+        )
+        res = df.reindex([0, 1, 4])
+        tm.assert_frame_equal(res, expected)
+
+    def test_reindex_nans_matches_dtype(self):
+        # Test that reindexing to make a column that doesn't exist
+        # produces NaNs matching float column dtypes
+        # GH 51059
+        df = DataFrame({"a": np.array([1, 2, 3], dtype="float32")})
+        expected = DataFrame(
+            {
+                "a": np.array([1, 2, 3], dtype="float32"),
+                "d": np.array([np.nan, np.nan, np.nan], dtype="float32"),
+            }
+        )
+        res = df.reindex(columns=["a", "d"])
+        tm.assert_frame_equal(res, expected)

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -1467,6 +1467,19 @@ class TestStackUnstackMultiLevel:
         expected = ymd.unstack(0).stack(0)
         tm.assert_equal(result, expected)
 
+    def test_stack_nans_doesnt_upcast_float(self):
+        # GH 51059
+        df = DataFrame({("n1", "q1"): [1], ("n2", "q2"): [2]}, dtype="float32")
+        res = df.stack(level=0)
+        exp = DataFrame(
+            {
+                "q1": np.array([1.0, np.nan], dtype="float32"),
+                "q2": np.array([np.nan, 2.0], dtype="float32"),
+            },
+            index=MultiIndex.from_product([[0], ["n1", "n2"]]),
+        )
+        tm.assert_frame_equal(res, exp)
+
     @pytest.mark.parametrize(
         "idx, columns, exp_idx",
         [


### PR DESCRIPTION
- [ ] closes #51059 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

The problem there was that the ``.values`` call here
https://github.com/pandas-dev/pandas/blob/a131266c8ab7c83f73331b5be5ea49d9a628f075/pandas/core/reshape/reshape.py#L746
upcasts the values, so the float32 will become float64.

I had to modify reindex in order to make this possible, since I don't think you can easily tell whether an all-nan col was there before or was created because of re-indexing. 
   - I guess could modify stack, but then I'd be duplicating reindex logic.
