### PR TITLE
DEP: Enforce deprecation of squeeze in read_excel

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -922,6 +922,7 @@ Removal of prior version deprecations/changes
 - Removed argument ``is_copy`` from :meth:`DataFrame.take` and :meth:`Series.take` (:issue:`30615`)
 - Removed argument ``kind`` from :meth:`Index.get_slice_bound`, :meth:`Index.slice_indexer` and :meth:`Index.slice_locs` (:issue:`41378`)
 - Removed arguments ``prefix``, ``squeeze``, ``error_bad_lines`` and ``warn_bad_lines`` from :func:`read_csv` (:issue:`40413`, :issue:`43427`)
+- Removed arguments ``squeeze`` from :func:`read_excel` (:issue:`43427`)
 - Removed argument ``datetime_is_numeric`` from :meth:`DataFrame.describe` and :meth:`Series.describe` as datetime data will always be summarized as numeric data (:issue:`34798`)
 - Disallow passing list ``key`` to :meth:`Series.xs` and :meth:`DataFrame.xs`, pass a tuple instead (:issue:`41789`)
 - Disallow subclass-specific keywords (e.g. "freq", "tz", "names", "closed") in the :class:`Index` constructor (:issue:`38597`)

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -885,11 +885,10 @@ class BaseExcelReader(metaclass=abc.ABCMeta):
 
                 output[asheetname] = parser.read(nrows=nrows)
 
-                if isinstance(output[asheetname], DataFrame):
-                    if header_names:
-                        output[asheetname].columns = output[
-                            asheetname
-                        ].columns.set_names(header_names)
+                if header_names:
+                    output[asheetname].columns = output[asheetname].columns.set_names(
+                        header_names
+                    )
 
             except EmptyDataError:
                 # No Data, return an empty DataFrame

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -140,12 +140,6 @@ usecols : str, list-like, or callable, default None
       column if the callable returns ``True``.
 
     Returns a subset of the columns according to behavior above.
-squeeze : bool, default False
-    If the parsed data only contains one column then return a Series.
-
-    .. deprecated:: 1.4.0
-       Append ``.squeeze("columns")`` to the call to ``read_excel`` to squeeze
-       the data.
 dtype : Type name or dict of column -> type, default None
     Data type for data or columns. E.g. {{'a': np.float64, 'b': np.int32}}
     Use `object` to preserve data as stored in Excel and not interpret dtype.
@@ -383,7 +377,6 @@ def read_excel(
     | Sequence[str]
     | Callable[[str], bool]
     | None = ...,
-    squeeze: bool | None = ...,
     dtype: DtypeArg | None = ...,
     engine: Literal["xlrd", "openpyxl", "odf", "pyxlsb"] | None = ...,
     converters: dict[str, Callable] | dict[int, Callable] | None = ...,
@@ -423,7 +416,6 @@ def read_excel(
     | Sequence[str]
     | Callable[[str], bool]
     | None = ...,
-    squeeze: bool | None = ...,
     dtype: DtypeArg | None = ...,
     engine: Literal["xlrd", "openpyxl", "odf", "pyxlsb"] | None = ...,
     converters: dict[str, Callable] | dict[int, Callable] | None = ...,
@@ -463,7 +455,6 @@ def read_excel(
     | Sequence[str]
     | Callable[[str], bool]
     | None = None,
-    squeeze: bool | None = None,
     dtype: DtypeArg | None = None,
     engine: Literal["xlrd", "openpyxl", "odf", "pyxlsb"] | None = None,
     converters: dict[str, Callable] | dict[int, Callable] | None = None,
@@ -508,7 +499,6 @@ def read_excel(
             names=names,
             index_col=index_col,
             usecols=usecols,
-            squeeze=squeeze,
             dtype=dtype,
             converters=converters,
             true_values=true_values,
@@ -716,7 +706,6 @@ class BaseExcelReader(metaclass=abc.ABCMeta):
         names=None,
         index_col: int | Sequence[int] | None = None,
         usecols=None,
-        squeeze: bool | None = None,
         dtype: DtypeArg | None = None,
         true_values: Iterable[Hashable] | None = None,
         false_values: Iterable[Hashable] | None = None,
@@ -875,7 +864,6 @@ class BaseExcelReader(metaclass=abc.ABCMeta):
                     header=header,
                     index_col=index_col,
                     has_index_names=has_index_names,
-                    squeeze=squeeze,
                     dtype=dtype,
                     true_values=true_values,
                     false_values=false_values,
@@ -897,7 +885,7 @@ class BaseExcelReader(metaclass=abc.ABCMeta):
 
                 output[asheetname] = parser.read(nrows=nrows)
 
-                if not squeeze or isinstance(output[asheetname], DataFrame):
+                if isinstance(output[asheetname], DataFrame):
                     if header_names:
                         output[asheetname].columns = output[
                             asheetname
@@ -1545,7 +1533,6 @@ class ExcelFile:
         names=None,
         index_col: int | Sequence[int] | None = None,
         usecols=None,
-        squeeze: bool | None = None,
         converters=None,
         true_values: Iterable[Hashable] | None = None,
         false_values: Iterable[Hashable] | None = None,
@@ -1578,7 +1565,6 @@ class ExcelFile:
             names=names,
             index_col=index_col,
             usecols=usecols,
-            squeeze=squeeze,
             converters=converters,
             true_values=true_values,
             false_values=false_values,


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

looks like we missed a deprecation.

cc @MarcoGorelli for a quick look?