### PR TITLE
BUG: Fix NameError in tab complete warning test

### DIFF
--- a/pandas/tests/arrays/categorical/test_warnings.py
+++ b/pandas/tests/arrays/categorical/test_warnings.py
@@ -12,7 +12,7 @@ class TestCategoricalWarnings:
         pytest.importorskip("IPython", minversion="6.0.0")
         from IPython.core.completer import provisionalcompleter
 
-        code = "import pandas as pd; c = Categorical([])"
+        code = "import pandas as pd; c = pd.Categorical([])"
         await ip.run_code(code)
 
         # GH 31324 newer jedi version raises Deprecation warning;


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.


I was running the unit tests locally and noticed this:
<img width="1049" alt="image" src="https://user-images.githubusercontent.com/122238526/219918687-6005cb1e-b3ac-4fc0-ad48-85be36014135.png">

From what I can tell, this is a problem with the test.

With this pull request, the test now passes without throwing this NameError:
<img width="1030" alt="image" src="https://user-images.githubusercontent.com/122238526/219919331-5a7f58b6-7f1e-4a0f-b9a7-4dadaa9d28f8.png">


