### PR TITLE
TST: don't fail on systems with tzdata backzone enabled

### DIFF
--- a/pandas/tests/tseries/offsets/test_dst.py
+++ b/pandas/tests/tseries/offsets/test_dst.py
@@ -192,7 +192,7 @@ class TestDST:
             Timestamp("1900-01-01"),
             Timestamp("1905-07-01"),
             MonthBegin(66),
-            "Africa/Kinshasa",
+            "Africa/Lagos",
             marks=pytest.mark.xfail(
                 pytz_version < Version("2020.5") or pytz_version == Version("2022.2"),
                 reason="GH#41906: pytz utc transition dates changed",


### PR DESCRIPTION
test_dst.py specifies Africa/Kinshasa but expects a transition date (AmbiguousTimeError) that is actually for Africa/Lagos.  On systems that enable tzdata's backzone file (which Debian and Ubuntu unstable [now do](https://bugs.launchpad.net/bugs/2003797)), these are different, and the test hence fails ([log](https://salsa.debian.org/science-team/pandas/-/jobs/3961090)).

This makes the obvious fix.