### PR TITLE
DOC: fix EX02 errors in docstrings

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -583,14 +583,11 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.api.types.is_signed_integer_dtype \
         pandas.api.types.is_sparse \
         pandas.api.types.is_string_dtype \
-        pandas.api.types.is_timedelta64_dtype \
-        pandas.api.types.is_timedelta64_ns_dtype \
         pandas.api.types.is_unsigned_integer_dtype \
         pandas.io.formats.style.Styler.concat \
         pandas.io.formats.style.Styler.export \
         pandas.io.formats.style.Styler.set_td_classes \
         pandas.io.formats.style.Styler.use \
-        pandas.io.json.build_table_schema \
         pandas.plotting.andrews_curves \
         pandas.plotting.autocorrelation_plot \
         pandas.plotting.lag_plot \

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -363,6 +363,7 @@ def is_timedelta64_dtype(arr_or_dtype) -> bool:
 
     Examples
     --------
+    >>> from pandas.core.dtypes.common import is_timedelta64_dtype
     >>> is_timedelta64_dtype(object)
     False
     >>> is_timedelta64_dtype(np.timedelta64)
@@ -972,6 +973,7 @@ def is_timedelta64_ns_dtype(arr_or_dtype) -> bool:
 
     Examples
     --------
+    >>> from pandas.core.dtypes.common import is_timedelta64_ns_dtype
     >>> is_timedelta64_ns_dtype(np.dtype('m8[ns]'))
     True
     >>> is_timedelta64_ns_dtype(np.dtype('m8[ps]'))  # Wrong frequency

--- a/pandas/io/json/_table_schema.py
+++ b/pandas/io/json/_table_schema.py
@@ -265,6 +265,7 @@ def build_table_schema(
 
     Examples
     --------
+    >>> from pandas.io.json._table_schema import build_table_schema
     >>> df = pd.DataFrame(
     ...     {'A': [1, 2, 3],
     ...      'B': ['a', 'b', 'c'],


### PR DESCRIPTION
Related to the issue #51236

This PR enables functions:
`pandas.io.json.build_table_schema`
`pandas.api.types.is_timedelta64_dtype`
`pandas.api.types.is_timedelta64_ns_dtype`