### PR TITLE
CI: catch warnings in ci

### DIFF
--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -1332,7 +1332,7 @@ class TestDataFrameQueryBacktickQuoting:
         # GH#50261
         df = DataFrame({"a": Series([1, 2], dtype=dtype)})
         ref = {2}  # noqa:F841
-        warning = RuntimeWarning if dtype == "Int64" else None
+        warning = RuntimeWarning if dtype == "Int64" and NUMEXPR_INSTALLED else None
         with tm.assert_produces_warning(warning):
             result = df.query("a in @ref")
         expected = DataFrame({"a": Series([2], dtype=dtype, index=[1])})

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -1332,7 +1332,9 @@ class TestDataFrameQueryBacktickQuoting:
         # GH#50261
         df = DataFrame({"a": Series([1, 2], dtype=dtype)})
         ref = {2}  # noqa:F841
-        result = df.query("a in @ref")
+        warning = RuntimeWarning if dtype != "int64" else None
+        with tm.assert_produces_warning(warning):
+            result = df.query("a in @ref")
         expected = DataFrame({"a": Series([2], dtype=dtype, index=[1])})
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -1332,7 +1332,7 @@ class TestDataFrameQueryBacktickQuoting:
         # GH#50261
         df = DataFrame({"a": Series([1, 2], dtype=dtype)})
         ref = {2}  # noqa:F841
-        warning = RuntimeWarning if dtype != "int64" else None
+        warning = RuntimeWarning if dtype == "Int64" else None
         with tm.assert_produces_warning(warning):
             result = df.query("a in @ref")
         expected = DataFrame({"a": Series([2], dtype=dtype, index=[1])})

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -38,6 +38,7 @@ from pandas.core.computation import expressions as expr
 def switch_numexpr_min_elements(request):
     _MIN_ELEMENTS = expr._MIN_ELEMENTS
     expr._MIN_ELEMENTS = request.param
+    print("hello")
     yield request.param
     expr._MIN_ELEMENTS = _MIN_ELEMENTS
 
@@ -349,15 +350,16 @@ class TestSeriesArithmetic:
         result = [1, None, val] + ser
         tm.assert_series_equal(result, expected)
 
-    def test_add_list_to_masked_array_boolean(self):
+    def test_add_list_to_masked_array_boolean(self, request):
         # GH#22962
+        warning = UserWarning if request.node.callspec.id == "numexpr" else None
         ser = Series([True, None, False], dtype="boolean")
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(warning):
             result = ser + [True, None, True]
         expected = Series([True, None, True], dtype="boolean")
         tm.assert_series_equal(result, expected)
 
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(warning):
             result = [True, None, True] + ser
         tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -352,11 +352,13 @@ class TestSeriesArithmetic:
     def test_add_list_to_masked_array_boolean(self):
         # GH#22962
         ser = Series([True, None, False], dtype="boolean")
-        result = ser + [True, None, True]
+        with tm.assert_produces_warning(UserWarning):
+            result = ser + [True, None, True]
         expected = Series([True, None, True], dtype="boolean")
         tm.assert_series_equal(result, expected)
 
-        result = [True, None, True] + ser
+        with tm.assert_produces_warning(UserWarning):
+            result = [True, None, True] + ser
         tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -32,6 +32,7 @@ from pandas.core import (
     ops,
 )
 from pandas.core.computation import expressions as expr
+from pandas.core.computation.check import NUMEXPR_INSTALLED
 
 
 @pytest.fixture(autouse=True, params=[0, 1000000], ids=["numexpr", "python"])
@@ -352,7 +353,11 @@ class TestSeriesArithmetic:
 
     def test_add_list_to_masked_array_boolean(self, request):
         # GH#22962
-        warning = UserWarning if request.node.callspec.id == "numexpr" else None
+        warning = (
+            UserWarning
+            if request.node.callspec.id == "numexpr" and NUMEXPR_INSTALLED
+            else None
+        )
         ser = Series([True, None, False], dtype="boolean")
         with tm.assert_produces_warning(warning):
             result = ser + [True, None, True]


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

let's backport this to get rid of the warnings on the 2.0.x branch as well