### PR TITLE
CI: Fix failure due to warning

### DIFF
--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -450,7 +450,9 @@ class TestCommon:
 def test_sort_values_invalid_na_position(index_with_missing, na_position):
     dtype = index_with_missing.dtype
     warning = (
-        PerformanceWarning if dtype == "string" and dtype.storage == "pyarrow" else None
+        PerformanceWarning
+        if dtype.name == "string" and dtype.storage == "pyarrow"
+        else None
     )
     with pytest.raises(ValueError, match=f"invalid na_position: {na_position}"):
         with tm.assert_produces_warning(warning):

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -448,8 +448,13 @@ class TestCommon:
 
 @pytest.mark.parametrize("na_position", [None, "middle"])
 def test_sort_values_invalid_na_position(index_with_missing, na_position):
+    dtype = index_with_missing.dtype
+    warning = (
+        PerformanceWarning if dtype == "string" and dtype.storage == "pyarrow" else None
+    )
     with pytest.raises(ValueError, match=f"invalid na_position: {na_position}"):
-        index_with_missing.sort_values(na_position=na_position)
+        with tm.assert_produces_warning(warning):
+            index_with_missing.sort_values(na_position=na_position)
 
 
 @pytest.mark.parametrize("na_position", ["first", "last"])


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

cc @mroeschke any idea why this wasn't failing before?

https://app.circleci.com/pipelines/github/pandas-dev/pandas/25348/workflows/8a8ef371-75fe-4c4e-b928-33e74b63f1f9/jobs/59312