### PR TITLE
DOC: fix EX02 errors in docstrings

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -569,14 +569,11 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=EX02 --ignore_functions \
         pandas.DataFrame.plot.line \
         pandas.Series.plot.line \
-        pandas.api.types.infer_dtype \
         pandas.api.types.is_datetime64_any_dtype \
         pandas.api.types.is_datetime64_ns_dtype \
         pandas.api.types.is_datetime64tz_dtype \
         pandas.api.types.is_integer_dtype \
-        pandas.api.types.is_sparse \
         pandas.api.types.is_string_dtype \
-        pandas.api.types.is_unsigned_integer_dtype \
         pandas.plotting.andrews_curves \
         pandas.plotting.autocorrelation_plot \
         pandas.plotting.lag_plot \

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -1420,7 +1420,7 @@ def infer_dtype(value: object, skipna: bool = True) -> str:
 
     Examples
     --------
-    >>> import datetime
+    >>> from pandas.api.types import infer_dtype
     >>> infer_dtype(['foo', 'bar'])
     'string'
 
@@ -1445,6 +1445,7 @@ def infer_dtype(value: object, skipna: bool = True) -> str:
     >>> infer_dtype(['a', 1])
     'mixed-integer'
 
+    >>> from decimal import Decimal
     >>> infer_dtype([Decimal(1), Decimal(2.0)])
     'decimal'
 
@@ -1457,6 +1458,7 @@ def infer_dtype(value: object, skipna: bool = True) -> str:
     >>> infer_dtype([pd.Timestamp('20130101')])
     'datetime'
 
+    >>> import datetime
     >>> infer_dtype([datetime.date(2013, 1, 1)])
     'date'
 

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -207,6 +207,7 @@ def is_sparse(arr) -> bool:
     --------
     Returns `True` if the parameter is a 1-D pandas sparse array.
 
+    >>> from pandas.api.types import is_sparse
     >>> is_sparse(pd.arrays.SparseArray([0, 0, 1, 0]))
     True
     >>> is_sparse(pd.Series(pd.arrays.SparseArray([0, 0, 1, 0])))
@@ -785,6 +786,7 @@ def is_unsigned_integer_dtype(arr_or_dtype) -> bool:
 
     Examples
     --------
+    >>> from pandas.api.types import is_unsigned_integer_dtype
     >>> is_unsigned_integer_dtype(str)
     False
     >>> is_unsigned_integer_dtype(int)  # signed

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -330,9 +330,9 @@ class Styler(StylerRenderer):
         A common use case is adding totals rows, or otherwise, via methods calculated
         in ``DataFrame.agg``.
 
-        >>> df = pd.DataFrame([[4, 6], [1, 9], [3, 4], [5, 5], [9,6]],
-        ...                columns=["Mike", "Jim"],
-        ...                index=["Mon", "Tue", "Wed", "Thurs", "Fri"])
+        >>> df = pd.DataFrame([[4, 6], [1, 9], [3, 4], [5, 5], [9, 6]],
+        ...                   columns=["Mike", "Jim"],
+        ...                   index=["Mon", "Tue", "Wed", "Thurs", "Fri"])
         >>> styler = df.style.concat(df.agg(["sum"]).style)  # doctest: +SKIP
 
         .. figure:: ../../_static/style/footer_simple.png
@@ -358,7 +358,7 @@ class Styler(StylerRenderer):
         to extend the index in ``other``, with placeholder levels.
 
         >>> df = pd.DataFrame([[1], [2]],
-        ...             index=pd.MultiIndex.from_product([[0], [1, 2]]))
+        ...                   index=pd.MultiIndex.from_product([[0], [1, 2]]))
         >>> descriptors = df.agg(["sum"])
         >>> descriptors.index = pd.MultiIndex.from_product([[""], descriptors.index])
         >>> df.style.concat(descriptors.style)  # doctest: +SKIP


### PR DESCRIPTION
Related to issue #51236

This PR enables functions:
`pandas.api.types.infer_dtype`
`pandas.api.types.is_sparse`
`pandas.api.types.is_unsigned_integer_dtype`

EX03 errors appeared in the pr #51529 were fixed.