### PR TITLE
WEB: Fix redirect of blog posts

### DIFF
--- a/web/pandas/community/blog/index.html
+++ b/web/pandas/community/blog/index.html
@@ -4,10 +4,10 @@
     {% for post in blog.posts %}
         <div class="card">
             <div class="card-body">
-                <h5 class="card-title"><a href="{{ base_url }}{{post.link }}" target="_blank">{{ post.title }}</a></h5>
+                <h5 class="card-title"><a href="{{post.link }}" target="_blank">{{ post.title }}</a></h5>
                 <h6 class="card-subtitle text-muted small mb-4">Source: {{ post.feed }} | Author: {{ post.author }} | Published: {{ post.published.strftime("%b %d, %Y") }}</h6>
                 <div class="card-text mb-2">{{ post.summary }}</div>
-                <a class="card-link small" href="{{ base_url }}{{post.link }}" target="_blank">Read more</a>
+                <a class="card-link small" href="{{post.link }}" target="_blank">Read more</a>
             </div>
         </div>
     {% endfor %}


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

@datapythonista 

I think https://github.com/pandas-dev/pandas/pull/50897 broke the blog-redirects. This works locally.