### PR TITLE
CI: Don't run tests when web folder is updated

### DIFF
--- a/.github/workflows/macos-windows.yml
+++ b/.github/workflows/macos-windows.yml
@@ -13,6 +13,7 @@ on:
       - 1.5.x
     paths-ignore:
       - "doc/**"
+      - "web/**"
 
 env:
   PANDAS_CI: 1

--- a/.github/workflows/python-dev.yml
+++ b/.github/workflows/python-dev.yml
@@ -33,6 +33,7 @@ on:
       - None
     paths-ignore:
       - "doc/**"
+      - "web/**"
 
 env:
   PYTEST_WORKERS: "auto"

--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -14,6 +14,7 @@ on:
     types: [labeled, opened, synchronize, reopened]
     paths-ignore:
       - "doc/**"
+      - "web/**"
 
 permissions:
   contents: read

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,6 +13,7 @@ on:
       - 1.5.x
     paths-ignore:
       - "doc/**"
+      - "web/**"
 
 env:
   PANDAS_CI: 1


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Saw this when fixing the redirects, doesn't make much sense when only modifying the web folder