### PR TITLE
WEB: Sort and fix link to under discussions PDEPs

### DIFF
--- a/web/pandas_web.py
+++ b/web/pandas_web.py
@@ -301,9 +301,9 @@ class Preprocessors:
         with open(pathlib.Path(context["target_path"]) / "pdeps.json", "w") as f:
             json.dump(pdeps, f)
 
-        for pdep in pdeps["items"]:
+        for pdep in sorted(pdeps["items"], key=operator.itemgetter("title")):
             context["pdeps"]["Under discussion"].append(
-                {"title": pdep["title"], "url": pdep["url"]}
+                {"title": pdep["title"], "url": pdep["html_url"]}
             )
 
         return context


### PR DESCRIPTION
The links to the under discussion PDEPs in https://pandas.pydata.org/about/roadmap.html point to the API page, not the html page, fixing. Also, sorting the list by title.