### PR TITLE
CLN: Ensure that setitem ops don't coerce values

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4760,7 +4760,7 @@ class DataFrame(NDFrame, OpsMixin):
         if isinstance(value, DataFrame) and len(value.columns) > 1:
             raise ValueError(
                 f"Expected a one-dimensional object, got a DataFrame with "
-                f"{len(value.columns)} instead."
+                f"{len(value.columns)} columns instead."
             )
         elif isinstance(value, DataFrame):
             value = value.iloc[:, 0]

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4757,6 +4757,14 @@ class DataFrame(NDFrame, OpsMixin):
         if not isinstance(loc, int):
             raise TypeError("loc must be int")
 
+        if isinstance(value, DataFrame) and len(value.columns) > 1:
+            raise ValueError(
+                f"Expected a one-dimensional object, got a DataFrame with "
+                f"{len(value.columns)} instead."
+            )
+        elif isinstance(value, DataFrame):
+            value = value.iloc[:, 0]
+
         value = self._sanitize_column(value)
         self._mgr.insert(loc, column, value)
 
@@ -4843,11 +4851,9 @@ class DataFrame(NDFrame, OpsMixin):
         """
         self._ensure_valid_index(value)
 
-        # We can get there through isetitem with a DataFrame
-        # or through loc single_block_path
-        if isinstance(value, DataFrame):
-            return _reindex_for_setitem(value, self.index)
-        elif is_dict_like(value):
+        # Using a DataFrame would mean coercing values to one dtype
+        assert not isinstance(value, DataFrame)
+        if is_dict_like(value):
             return _reindex_for_setitem(Series(value), self.index)
 
         if is_list_like(value):

--- a/pandas/tests/frame/indexing/test_insert.py
+++ b/pandas/tests/frame/indexing/test_insert.py
@@ -100,6 +100,6 @@ class TestDataFrameInsert:
         # GH#42403
         df = DataFrame({"col1": [1, 2], "col2": [3, 4]})
 
-        msg = r"Expected a 1D array, got an array with shape \(2, 2\)"
+        msg = "Expected a one-dimensional object, got a DataFrame with 2 instead."
         with pytest.raises(ValueError, match=msg):
             df.insert(1, "newcol", df)

--- a/pandas/tests/frame/indexing/test_insert.py
+++ b/pandas/tests/frame/indexing/test_insert.py
@@ -100,6 +100,8 @@ class TestDataFrameInsert:
         # GH#42403
         df = DataFrame({"col1": [1, 2], "col2": [3, 4]})
 
-        msg = "Expected a one-dimensional object, got a DataFrame with 2 instead."
+        msg = (
+            "Expected a one-dimensional object, got a DataFrame with 2 columns instead."
+        )
         with pytest.raises(ValueError, match=msg):
             df.insert(1, "newcol", df)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

cc @jbrockmendel 

Want to ensure that we don't coerce dtypes accidentally in the future. We shouldn't get here with DataFrames if we can avoid it. Changed the behavior of the single_block case a couple of weeks back.