### PR TITLE
BUG: mask/where raising for mixed dtype frame and no other

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6078,8 +6078,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     def _check_inplace_setting(self, value) -> bool_t:
         """check whether we allow in-place setting with this type of value"""
         if self._is_mixed_type and not self._mgr.is_numeric_mixed_type:
-            # allow an actual np.nan thru
-            if is_float(value) and np.isnan(value):
+            # allow an actual np.nan through
+            if is_float(value) and np.isnan(value) or value is lib.no_default:
                 return True
 
             raise TypeError(

--- a/pandas/tests/frame/indexing/test_mask.py
+++ b/pandas/tests/frame/indexing/test_mask.py
@@ -141,3 +141,12 @@ def test_mask_return_dtype():
     excepted = Series([1.0, 0.0, 1.0, 0.0], dtype=ser.dtype)
     result = ser.mask(cond, other)
     tm.assert_series_equal(result, excepted)
+
+
+def test_mask_inplace_no_other():
+    # GH#51685
+    df = DataFrame({"a": [1, 2], "b": ["x", "y"]})
+    cond = DataFrame({"a": [True, False], "b": [False, True]})
+    df.mask(cond, inplace=True)
+    expected = DataFrame({"a": [np.nan, 2], "b": ["x", np.nan]})
+    tm.assert_frame_equal(df, expected)

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -1025,3 +1025,12 @@ def test_where_int_overflow(replacement):
     expected = DataFrame([[1.0, 2e25, "nine"], [replacement, 0.1, replacement]])
 
     tm.assert_frame_equal(result, expected)
+
+
+def test_where_inplace_no_other():
+    # GH#51685
+    df = DataFrame({"a": [1, 2], "b": ["x", "y"]})
+    cond = DataFrame({"a": [True, False], "b": [False, True]})
+    df.where(cond, inplace=True)
+    expected = DataFrame({"a": [1, np.nan], "b": [np.nan, "y"]})
+    tm.assert_frame_equal(df, expected)


### PR DESCRIPTION
- [x] closes #51685 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

cc @jbrockmendel @mroeschke 

Based on the commits causing the error, I don't think this was ever intended to raise?