### PR TITLE
BUG: changing period array formats to specified date formats in `to_csv`

### DIFF
--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -307,7 +307,10 @@ class CSVFormatter:
         df = self.obj.iloc[slicer]
 
         res = df._mgr.to_native_types(**self._number_format)
-        data = [res.iget_values(i) for i in range(len(res.items))]
+        data = [
+            self._change_to_str_date_format(res.iget_values(i))
+            for i in range(len(res.items))
+        ]
 
         ix = self.data_index[slicer]._format_native_types(**self._number_format)
         libwriters.write_csv_rows(
@@ -317,3 +320,15 @@ class CSVFormatter:
             self.cols,
             self.writer,
         )
+
+    def _change_to_str_date_format(self, col: list) -> list:
+        if self.date_format is not None:
+            col = [
+                x
+                if isinstance(x, str)
+                else x.strftime(self.date_format)
+                if notna(x)
+                else ""
+                for x in col
+            ]
+        return col

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -312,6 +312,21 @@ $1$,$2$
         ser = ser.astype("category")
         assert ser.to_csv(index=False, date_format="%Y-%m-%d") == expected
 
+    def test_to_csv_period_to_different_date_format(self):
+        df = DataFrame(
+            data={"period": pd.period_range(start="2000-01-01", periods=5, freq="H")}
+        )
+        expected_rows = [
+            ",period",
+            "0,2000-01-01___00:00:00",
+            "1,2000-01-01___01:00:00",
+            "2,2000-01-01___02:00:00",
+            "3,2000-01-01___03:00:00",
+            "4,2000-01-01___04:00:00",
+        ]
+        expected_ymdhms_hour = tm.convert_rows_list_to_csv_str(expected_rows)
+        assert df.to_csv(date_format="%Y-%m-%d___%H:%M:%S") == expected_ymdhms_hour
+
     def test_to_csv_float_ea_float_format(self):
         # GH#45991
         df = DataFrame({"a": [1.1, 2.02, pd.NA, 6.000006], "b": "c"})


### PR DESCRIPTION
- This is intended to fix #51621
- This issue is that PeriodArrays can not change to the specified `date_format` in `to_csv`.
- The cause is that PeriodArray is established as `NDArrayBackedExtensionBlock` instead of `DatetimeLikeBlock` so that `df._mgr.to_native_types` does not change 'PeriodArray' to desired string format. This fix is added in after `df._mgr.to_native_types` to change `Period` to specified `date_format`.
- One unit test is added.
