### PR TITLE
TST: add test for apply/reconstruct_func

### DIFF
--- a/pandas/tests/apply/test_frame_apply_relabeling.py
+++ b/pandas/tests/apply/test_frame_apply_relabeling.py
@@ -95,3 +95,11 @@ def test_agg_namedtuple():
         index=pd.Index(["foo", "bar", "cat"]),
     )
     tm.assert_frame_equal(result, expected)
+
+
+def test_reconstruct_func():
+    # GH 28472, test to ensure reconstruct_func isn't moved;
+    # This method is used by other libraries (e.g. dask)
+    result = pd.core.apply.reconstruct_func("min")
+    expected = (False, "min", None, None)
+    tm.assert_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #28472 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Add a test for reconstruct_func to ensure this method isn't moved. It is used by other libraries such as dask.