### PR TITLE
CI: Add bot to track deprecation prs

### DIFF
--- a/.github/workflows/deprecation-tracking-bot.yml
+++ b/.github/workflows/deprecation-tracking-bot.yml
@@ -1,0 +1,31 @@
+name: Deprecations Bot
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      [closed]
+
+
+permissions:
+  contents: read
+
+jobs:
+  deprecation_update:
+    permissions:
+      issues: write
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'Deprecate') && github.event.pull_request.merged == true
+    runs-on: ubuntu-22.04
+    env:
+      DEPRECATION_TRACKER_ISSUE: 50578
+    steps:
+    - name: Checkout
+      run: |
+        echo "Adding deprecation PR number to deprecation tracking issue"
+        export PR=${{ github.event.pull_request.number }}
+        BODY=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/issues/${DEPRECATION_TRACKER_ISSUE} |
+          python3 -c "import sys, json, os; x = {'body': json.load(sys.stdin)['body']}; pr = os.environ['PR']; x['body'] += f'\n- [ ] #{pr}'; print(json.dumps(x))")
+        echo ${BODY}
+        curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -X PATCH -d "${BODY}" https://api.github.com/repos/${{ github.repository }}/issues/${DEPRECATION_TRACKER_ISSUE}


### PR DESCRIPTION
We tend to forget to register deprecation prs in our deprecation log. This bot aims to solve this. Every time a PR with the label Deprecate is merged, it adds a new entry to the deprecation log.

In a future version I'd like to add the option to also check enforced deprecations automatically.

One TODO is how to handle PRs where we enforce deprecations:
- We could create a new label that does not affect the bot
- Add a switch to the bot when we start enforcing deprecations

We could get race conditions in theory, but it is not very likely, so would address if it becomes a problem.

Tried this in my repo and worked reliably

Pinging everyone who is regularly merging prs, hope I did not forget anyone