### PR TITLE
PERF: ArrowExtensionArray._from_sequence_of_strings(dtype=pa.bool_())

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -104,6 +104,7 @@ Performance improvements
 - Performance improvement in :meth:`~arrays.ArrowExtensionArray.isna` when array has zero nulls or is all nulls (:issue:`51630`)
 - Performance improvement in :meth:`DataFrame.first_valid_index` and :meth:`DataFrame.last_valid_index` for extension array dtypes (:issue:`51549`)
 - Performance improvement in :meth:`DataFrame.clip` and :meth:`Series.clip` (:issue:`51472`)
+- Performance improvement when parsing strings to ``boolean[pyarrow]`` dtype (:issue:`51730`)
 - Performance improvement in :func:`read_parquet` on string columns when using ``use_nullable_dtypes=True`` (:issue:`47345`)
 - Performance improvement in :meth:`read_orc` when reading a remote URI file path. (:issue:`51609`)
 

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -299,9 +299,19 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray, BaseStringArrayMethods):
             # "coerce" to allow "null times" (None) to not raise
             scalars = to_time(strings, errors="coerce")
         elif pa.types.is_boolean(pa_type):
-            from pandas.core.arrays import BooleanArray
-
-            scalars = BooleanArray._from_sequence_of_strings(strings).to_numpy()
+            # pyarrow string->bool casting is case-insensitive:
+            #   "true" or "1" -> True
+            #   "false" or "0" -> False
+            # Note: BooleanArray was previously used to parse these strings
+            #   and allows "1.0" and "0.0". Pyarrow casting does not support
+            #   this, but we allow it here.
+            if isinstance(strings, (pa.Array, pa.ChunkedArray)):
+                scalars = strings
+            else:
+                scalars = pa.array(strings, type=pa.string(), from_pandas=True)
+            scalars = pc.if_else(pc.equal(scalars, "1.0"), "1", scalars)
+            scalars = pc.if_else(pc.equal(scalars, "0.0"), "0", scalars)
+            scalars = scalars.cast(pa.bool_())
         elif (
             pa.types.is_integer(pa_type)
             or pa.types.is_floating(pa_type)

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -2156,3 +2156,21 @@ def test_boolean_reduce_series_all_null(all_boolean_reductions, skipna):
     else:
         expected = pd.NA
     assert result is expected
+
+
+def test_from_sequence_of_strings_boolean():
+    true_strings = ["true", "TRUE", "True", "1", "1.0"]
+    false_strings = ["false", "FALSE", "False", "0", "0.0"]
+    nulls = [None]
+    strings = true_strings + false_strings + nulls
+    bools = (
+        [True] * len(true_strings) + [False] * len(false_strings) + [None] * len(nulls)
+    )
+
+    result = ArrowExtensionArray._from_sequence_of_strings(strings, dtype=pa.bool_())
+    expected = pd.array(bools, dtype="boolean[pyarrow]")
+    tm.assert_extension_array_equal(result, expected)
+
+    strings = ["True", "foo"]
+    with pytest.raises(pa.ArrowInvalid, match="Failed to parse"):
+        ArrowExtensionArray._from_sequence_of_strings(strings, dtype=pa.bool_())


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.1.0.rst` file if fixing a bug or adding a new feature.

`ArrowExtensionArray._from_sequence_of_strings` currently depends on `BooleanArray._from_sequence_of_strings` to parse strings for `boolean[pyarrow]`. This removes the dependency on `BooleanArray` and uses pyarrow casting to accomplish the same thing. I've adding some logic around pyarrow's casting to match existing behavior of `BooleanArray` (assuming we want to maintain existing behavior?)

```
import pyarrow as pa
import numpy as np
from pandas.core.arrays.arrow.array import ArrowExtensionArray

N = 1_000_000
strings_np = np.random.choice(["true", "false", None], N, replace=True)
strings_pa = pa.array(strings_np, type=pa.string())

%timeit ArrowExtensionArray._from_sequence_of_strings(strings_np, dtype=pa.bool_())

# 200 ms ± 4.72 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)    -> main
# 54.5 ms ± 842 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)  -> PR

%timeit ArrowExtensionArray._from_sequence_of_strings(strings_pa, dtype=pa.bool_())

# 298 ms ± 3.45 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)    -> main
# 30.8 ms ± 1.1 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)  -> PR
```