### PR TITLE
BUG: indexing empty pyarrow backed object returning corrupt object

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -1247,6 +1247,7 @@ Indexing
 - Bug in :meth:`DataFrame.compare` does not recognize differences when comparing ``NA`` with value in nullable dtypes (:issue:`48939`)
 - Bug in :meth:`Series.rename` with :class:`MultiIndex` losing extension array dtypes (:issue:`21055`)
 - Bug in :meth:`DataFrame.isetitem` coercing extension array dtypes in :class:`DataFrame` to object (:issue:`49922`)
+- Bug in :meth:`Series.__getitem__` returning corrupt object when selecting from an empty pyarrow backed object (:issue:`51734`)
 - Bug in :class:`BusinessHour` would cause creation of :class:`DatetimeIndex` to fail when no opening hour was included in the index (:issue:`49835`)
 
 Missing

--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -252,6 +252,7 @@ if not pa_version_under7p0:
 else:
     FLOAT_PYARROW_DTYPES_STR_REPR = []
     ALL_INT_PYARROW_DTYPES_STR_REPR = []
+    ALL_PYARROW_DTYPES = []
 
 
 EMPTY_STRING_PATTERN = re.compile("^$")

--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -253,7 +253,6 @@ if not pa_version_under7p0:
 else:
     FLOAT_PYARROW_DTYPES_STR_REPR = []
     ALL_INT_PYARROW_DTYPES_STR_REPR = []
-    ALL_PYARROW_DTYPES = []
 
 
 EMPTY_STRING_PATTERN = re.compile("^$")

--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -253,6 +253,7 @@ if not pa_version_under7p0:
 else:
     FLOAT_PYARROW_DTYPES_STR_REPR = []
     ALL_INT_PYARROW_DTYPES_STR_REPR = []
+    ALL_PYARROW_DTYPES = []
 
 
 EMPTY_STRING_PATTERN = re.compile("^$")

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1013,6 +1013,7 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray, BaseStringArrayMethods):
         """
         chunks = [array for ea in to_concat for array in ea._data.iterchunks()]
         if to_concat[0].dtype == "string":
+            # StringDtype has no attrivute pyarrow_dtype
             pa_dtype = pa.string()
         else:
             pa_dtype = to_concat[0].dtype.pyarrow_dtype

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -349,7 +349,7 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray, BaseStringArrayMethods):
                     pa_dtype = pa.string()
                 else:
                     pa_dtype = self._dtype.pyarrow_dtype
-                return type(self)(pa.chunked_array([], type=pa_dtype))
+                return type(self)(pa.array([], type=pa_dtype, from_pandas=True))
             elif is_integer_dtype(item.dtype):
                 return self.take(item)
             elif is_bool_dtype(item.dtype):

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -349,7 +349,7 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray, BaseStringArrayMethods):
                     pa_dtype = pa.string()
                 else:
                     pa_dtype = self._dtype.pyarrow_dtype
-                return type(self)(pa.array([], type=pa_dtype, from_pandas=True))
+                return type(self)(pa.array([], type=pa_dtype))
             elif is_integer_dtype(item.dtype):
                 return self.take(item)
             elif is_bool_dtype(item.dtype):

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -349,7 +349,7 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray, BaseStringArrayMethods):
                     pa_dtype = pa.string()
                 else:
                     pa_dtype = self._dtype.pyarrow_dtype
-                return type(self)(pa.array([], type=pa_dtype))
+                return type(self)(pa.chunked_array([], type=pa_dtype))
             elif is_integer_dtype(item.dtype):
                 return self.take(item)
             elif is_bool_dtype(item.dtype):
@@ -1012,7 +1012,11 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray, BaseStringArrayMethods):
         ArrowExtensionArray
         """
         chunks = [array for ea in to_concat for array in ea._data.iterchunks()]
-        arr = pa.chunked_array(chunks)
+        if to_concat[0].dtype == "string":
+            pa_dtype = pa.string()
+        else:
+            pa_dtype = to_concat[0].dtype.pyarrow_dtype
+        arr = pa.chunked_array(chunks, type=pa_dtype)
         return cls(arr)
 
     def _accumulate(

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -2156,3 +2156,11 @@ def test_boolean_reduce_series_all_null(all_boolean_reductions, skipna):
     else:
         expected = pd.NA
     assert result is expected
+
+
+def test_concat_empty_arrow_backed_series(dtype):
+    # GH#51734
+    ser = pd.Series([], dtype=dtype)
+    expected = ser.copy()
+    result = pd.concat([ser[np.array([], dtype=np.bool_)]])
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/reshape/concat/test_series.py
+++ b/pandas/tests/reshape/concat/test_series.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+import pandas.util._test_decorators as td
+
 from pandas import (
     ArrowDtype,
     DataFrame,
@@ -153,6 +155,7 @@ class TestSeriesConcat:
         result = concat([obj.iloc[::-1]])
         tm.assert_equal(result, obj)
 
+    @td.skip_if_no("pyarrow", min_version="7.0.0")
     @pytest.mark.parametrize("dtype", tm.ALL_PYARROW_DTYPES)
     def test_concat_empty_arrow_backed_series(self, dtype):
         # GH#51734

--- a/pandas/tests/reshape/concat/test_series.py
+++ b/pandas/tests/reshape/concat/test_series.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from pandas import (
+    ArrowDtype,
     DataFrame,
     DatetimeIndex,
     Index,
@@ -151,3 +152,11 @@ class TestSeriesConcat:
         obj = frame_or_series([100])
         result = concat([obj.iloc[::-1]])
         tm.assert_equal(result, obj)
+
+    @pytest.mark.parametrize("dtype", tm.ALL_PYARROW_DTYPES)
+    def test_concat_empty_arrow_backed_series(self, dtype):
+        # GH#51734
+        ser = Series([], dtype=ArrowDtype(dtype))
+        expected = ser.copy()
+        result = concat([ser[np.array([], dtype=np.bool_)]])
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/reshape/concat/test_series.py
+++ b/pandas/tests/reshape/concat/test_series.py
@@ -1,10 +1,7 @@
 import numpy as np
 import pytest
 
-import pandas.util._test_decorators as td
-
 from pandas import (
-    ArrowDtype,
     DataFrame,
     DatetimeIndex,
     Index,
@@ -154,12 +151,3 @@ class TestSeriesConcat:
         obj = frame_or_series([100])
         result = concat([obj.iloc[::-1]])
         tm.assert_equal(result, obj)
-
-    @td.skip_if_no("pyarrow", min_version="7.0.0")
-    @pytest.mark.parametrize("dtype", tm.ALL_PYARROW_DTYPES)
-    def test_concat_empty_arrow_backed_series(self, dtype):
-        # GH#51734
-        ser = Series([], dtype=ArrowDtype(dtype))
-        expected = ser.copy()
-        result = concat([ser[np.array([], dtype=np.bool_)]])
-        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #51734 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

looks like an empty chunked array creates problems later on.