### PR TITLE
Revert "CLN: Remove read_orc dtype checking (#51604)"

### DIFF
--- a/pandas/io/orc.py
+++ b/pandas/io/orc.py
@@ -21,6 +21,13 @@ from pandas._typing import (
 )
 from pandas.compat._optional import import_optional_dependency
 
+from pandas.core.dtypes.common import (
+    is_categorical_dtype,
+    is_interval_dtype,
+    is_period_dtype,
+    is_unsigned_integer_dtype,
+)
+
 from pandas.core.arrays import ArrowExtensionArray
 from pandas.core.frame import DataFrame
 
@@ -201,10 +208,22 @@ def to_orc(
     if engine_kwargs is None:
         engine_kwargs = {}
 
+    # If unsupported dtypes are found raise NotImplementedError
+    # In Pyarrow 9.0.0 this check will no longer be needed
+    for dtype in df.dtypes:
+        if (
+            is_categorical_dtype(dtype)
+            or is_interval_dtype(dtype)
+            or is_period_dtype(dtype)
+            or is_unsigned_integer_dtype(dtype)
+        ):
+            raise NotImplementedError(
+                "The dtype of one or more columns is not supported yet."
+            )
+
     if engine != "pyarrow":
         raise ValueError("engine must be 'pyarrow'")
     engine = import_optional_dependency(engine, min_version="7.0.0")
-    pa = import_optional_dependency("pyarrow")
     orc = import_optional_dependency("pyarrow.orc")
 
     was_none = path is None
@@ -219,7 +238,7 @@ def to_orc(
                 handles.handle,
                 **engine_kwargs,
             )
-        except (TypeError, pa.ArrowNotImplementedError) as e:
+        except TypeError as e:
             raise NotImplementedError(
                 "The dtype of one or more columns is not supported yet."
             ) from e

--- a/pandas/io/orc.py
+++ b/pandas/io/orc.py
@@ -226,6 +226,7 @@ def to_orc(
     if engine != "pyarrow":
         raise ValueError("engine must be 'pyarrow'")
     engine = import_optional_dependency(engine, min_version="7.0.0")
+    pa = import_optional_dependency("pyarrow")
     orc = import_optional_dependency("pyarrow.orc")
 
     was_none = path is None
@@ -240,7 +241,7 @@ def to_orc(
                 handles.handle,
                 **engine_kwargs,
             )
-        except TypeError as e:
+        except (TypeError, pa.ArrowNotImplementedError) as e:
             raise NotImplementedError(
                 "The dtype of one or more columns is not supported yet."
             ) from e

--- a/pandas/io/orc.py
+++ b/pandas/io/orc.py
@@ -19,6 +19,7 @@ from pandas._typing import (
     ReadBuffer,
     WriteBuffer,
 )
+from pandas.compat import pa_version_under8p0
 from pandas.compat._optional import import_optional_dependency
 
 from pandas.core.dtypes.common import (
@@ -209,17 +210,18 @@ def to_orc(
         engine_kwargs = {}
 
     # If unsupported dtypes are found raise NotImplementedError
-    # In Pyarrow 9.0.0 this check will no longer be needed
-    for dtype in df.dtypes:
-        if (
-            is_categorical_dtype(dtype)
-            or is_interval_dtype(dtype)
-            or is_period_dtype(dtype)
-            or is_unsigned_integer_dtype(dtype)
-        ):
-            raise NotImplementedError(
-                "The dtype of one or more columns is not supported yet."
-            )
+    # In Pyarrow 8.0.0 this check will no longer be needed
+    if pa_version_under8p0:
+        for dtype in df.dtypes:
+            if (
+                is_categorical_dtype(dtype)
+                or is_interval_dtype(dtype)
+                or is_period_dtype(dtype)
+                or is_unsigned_integer_dtype(dtype)
+            ):
+                raise NotImplementedError(
+                    "The dtype of one or more columns is not supported yet."
+                )
 
     if engine != "pyarrow":
         raise ValueError("engine must be 'pyarrow'")

--- a/pandas/tests/io/test_orc.py
+++ b/pandas/tests/io/test_orc.py
@@ -301,10 +301,7 @@ def test_orc_roundtrip_bytesio():
 def test_orc_writer_dtypes_not_supported(df_not_supported):
     # GH44554
     # PyArrow gained ORC write support with the current argument order
-    msg = (
-        "The dtype of one or more columns is not supported yet.|"
-        "Unknown or unsupported Arrow type"
-    )
+    msg = "The dtype of one or more columns is not supported yet."
     with pytest.raises(NotImplementedError, match=msg):
         df_not_supported.to_orc()
 

--- a/pandas/tests/io/test_orc.py
+++ b/pandas/tests/io/test_orc.py
@@ -301,7 +301,10 @@ def test_orc_roundtrip_bytesio():
 def test_orc_writer_dtypes_not_supported(df_not_supported):
     # GH44554
     # PyArrow gained ORC write support with the current argument order
-    msg = "The dtype of one or more columns is not supported yet."
+    msg = (
+        "The dtype of one or more columns is not supported yet.|"
+        "Unknown or unsupported Arrow type"
+    )
     with pytest.raises(NotImplementedError, match=msg):
         df_not_supported.to_orc()
 


### PR DESCRIPTION
This reverts commit b69bd0755d654c0dba42042df7b2251918274327.

- [x] closes #51733 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Looks like timeouts started after this commit. Checking if this would fix it before looking closer