### PR TITLE
REF: remove usage of `np.product` and `np.cumproduct`

### DIFF
--- a/pandas/core/reshape/util.py
+++ b/pandas/core/reshape/util.py
@@ -41,7 +41,7 @@ def cartesian_product(X) -> list[np.ndarray]:
         return []
 
     lenX = np.fromiter((len(x) for x in X), dtype=np.intp)
-    cumprodX = np.cumproduct(lenX)
+    cumprodX = np.cumprod(lenX)
 
     if np.any(cumprodX < 0):
         raise ValueError("Product space too large to allocate arrays!")
@@ -60,7 +60,7 @@ def cartesian_product(X) -> list[np.ndarray]:
     return [
         tile_compat(
             np.repeat(x, b[i]),
-            np.product(a[i]),  # pyright: ignore[reportGeneralTypeIssues]
+            np.prod(a[i]),  # pyright: ignore[reportGeneralTypeIssues]
         )
         for i, x in enumerate(X)
     ]

--- a/pandas/tests/groupby/test_libgroupby.py
+++ b/pandas/tests/groupby/test_libgroupby.py
@@ -194,7 +194,7 @@ def test_cython_group_transform_cumsum(np_dtype):
 def test_cython_group_transform_cumprod():
     # see gh-4095
     dtype = np.float64
-    pd_op, np_op = group_cumprod, np.cumproduct
+    pd_op, np_op = group_cumprod, np.cumprod
     _check_cython_group_transform_cumulative(pd_op, np_op, dtype)
 
 


### PR DESCRIPTION
These will be deprecated soon, so use the preferred names (`np.prod` and `np.cumprod`) instead.