### PR TITLE
ENH: Implement DataFrame.from_pyarrow and DataFrame.to_pyarrow

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -281,7 +281,7 @@ Other enhancements
 - Added new argument ``engine`` to :func:`read_json` to support parsing JSON with pyarrow by specifying ``engine="pyarrow"`` (:issue:`48893`)
 - Added support for SQLAlchemy 2.0 (:issue:`40686`)
 - :class:`Index` set operations :meth:`Index.union`, :meth:`Index.intersection`, :meth:`Index.difference`, and :meth:`Index.symmetric_difference` now support ``sort=True``, which will always return a sorted result, unlike the default ``sort=None`` which does not sort in some cases (:issue:`25151`)
-- :class:`DataFrame` constructor supports PyArrow tables as input (:issue:`51760`)
+- Added methods :meth:`DataFrame.from_pyarrow` and :meth:`DataFrame.to_pyarrow` to convert data from and to PyArrow tables (:issue:`51760`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_200.notable_bug_fixes:

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -281,6 +281,7 @@ Other enhancements
 - Added new argument ``engine`` to :func:`read_json` to support parsing JSON with pyarrow by specifying ``engine="pyarrow"`` (:issue:`48893`)
 - Added support for SQLAlchemy 2.0 (:issue:`40686`)
 - :class:`Index` set operations :meth:`Index.union`, :meth:`Index.intersection`, :meth:`Index.difference`, and :meth:`Index.symmetric_difference` now support ``sort=True``, which will always return a sorted result, unlike the default ``sort=None`` which does not sort in some cases (:issue:`25151`)
+- :class:`DataFrame` constructor supports PyArrow tables as input (:issue:`51760`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_200.notable_bug_fixes:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -171,6 +171,7 @@ from pandas.core.arrays import (
     PeriodArray,
     TimedeltaArray,
 )
+from pandas.core.arrays.arrow import ArrowDtype, ArrowExtensionArray
 from pandas.core.arrays.sparse import SparseFrameAccessor
 from pandas.core.construction import (
     ensure_wrapped_if_datetimelike,
@@ -664,6 +665,17 @@ class DataFrame(NDFrame, OpsMixin):
                 # GH#33357 fastpath
                 NDFrame.__init__(self, data)
                 return
+
+        try:
+            import pyarrow as pa
+        except ImportError:
+            pass
+        else:
+            if isinstance(data, pa.Table):
+                data = {
+                    name: ArrowExtensionArray(array)
+                    for name, array in zip(data.column_names, data.columns)
+                }
 
         manager = get_option("mode.data_manager")
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -171,10 +171,7 @@ from pandas.core.arrays import (
     PeriodArray,
     TimedeltaArray,
 )
-from pandas.core.arrays.arrow import (
-    ArrowDtype,
-    ArrowExtensionArray,
-)
+from pandas.core.arrays.arrow import ArrowDtype
 from pandas.core.arrays.sparse import SparseFrameAccessor
 from pandas.core.construction import (
     ensure_wrapped_if_datetimelike,

--- a/pandas/tests/frame/constructors/test_pyarrow.py
+++ b/pandas/tests/frame/constructors/test_pyarrow.py
@@ -1,0 +1,92 @@
+import pytest
+
+from pandas import (
+    NA,
+    DataFrame,
+    Series,
+)
+from pandas.core.arrays.arrow import ArrowDtype
+
+pa = pytest.importorskip("pyarrow", minversion="7.0.0")
+import pandas._testing as tm
+
+
+@pytest.fixture(scope="module")
+def sample_dataframe_numpy_backend():
+    return DataFrame(
+        {
+            "u8": Series([1, 2, 3, NA], dtype="UInt8"),
+            "f64": Series([float("NaN"), 1.0, 2.0, 3.0], dtype="float64"),
+            "s": Series(["foo", "bar", None, "foobar"], dtype="object"),
+        }
+    )
+
+
+@pytest.fixture(scope="module")
+def sample_dataframe_pyarrow_backend():
+    return DataFrame(
+        {
+            "u8": Series([1, 2, 3, NA], dtype="uint8[pyarrow]"),
+            "f64": Series([NA, 1.0, 2.0, 3.0], dtype="float64[pyarrow]"),
+            "s": Series(["foo", "bar", NA, "foobar"], dtype="string[pyarrow]"),
+        }
+    )
+
+
+@pytest.fixture(scope="module")
+def sample_pyarrow_table():
+    return pa.table(
+        [
+            pa.array([1, 2, 3, None], type=pa.uint8()),
+            pa.array([None, 1.0, 2.0, 3.0], type=pa.float64()),
+            pa.array(["foo", "bar", None, "foobar"], type=pa.string()),
+        ],
+        names=["u8", "f64", "s"],
+    )
+
+
+class TestPyArrow:
+    @pytest.mark.parametrize(
+        "column,dtype", [("u8", pa.uint8()), ("f64", pa.float64()), ("s", pa.string())]
+    )
+    def test_from_pyarrow_uses_right_pandas_types(
+        self, sample_pyarrow_table, column, dtype
+    ):
+        result = DataFrame.from_pyarrow(sample_pyarrow_table)
+        assert result[column].dtype == ArrowDtype(dtype)
+
+    @pytest.mark.parametrize("column", ["u8", "f64", "s"])
+    def test_from_pyarrow_keeps_correct_data(self, sample_pyarrow_table, column):
+        result = DataFrame.from_pyarrow(sample_pyarrow_table)
+        assert result[column]._data.array._data == sample_pyarrow_table[column]
+
+    @pytest.mark.parametrize("column", ["u8", "f64", "s"])
+    def test_from_pyarrow_does_not_copy_memory(self, sample_pyarrow_table, column):
+        result = DataFrame.from_pyarrow(sample_pyarrow_table)
+
+        result_buffers = result[column]._data.array._data.chunks[0].buffers()
+        expected_buffers = sample_pyarrow_table[column].chunks[0].buffers()
+
+        for result_buffer, expected_buffer in zip(result_buffers, expected_buffers):
+            if result_buffer is None and expected_buffer is None:
+                continue
+            assert result_buffer.address == expected_buffer.address
+            assert result_buffer.size == expected_buffer.size
+
+    def test_to_pyarrow_numpy_backend(
+        self, sample_dataframe_numpy_backend, sample_pyarrow_table
+    ):
+        result = sample_dataframe_numpy_backend.to_pyarrow()
+        assert result == sample_pyarrow_table
+
+    def test_to_pyarrow_pyarrow_backend(
+        self, sample_dataframe_pyarrow_backend, sample_pyarrow_table
+    ):
+        result = sample_dataframe_pyarrow_backend.to_pyarrow()
+        assert result == sample_pyarrow_table
+
+    def test_pyarrow_roundtrip(
+        self, sample_dataframe_numpy_backend, sample_dataframe_pyarrow_backend
+    ):
+        result = DataFrame.from_pyarrow(sample_dataframe_numpy_backend.to_pyarrow())
+        tm.assert_frame_equal(result, sample_dataframe_pyarrow_backend)

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -20,7 +20,6 @@ import warnings
 import numpy as np
 from numpy import ma
 from numpy.ma import mrecords
-import pyarrow as pa
 import pytest
 import pytz
 
@@ -2341,30 +2340,6 @@ class TestDataFrameConstructors:
         expected = DataFrame(Series(extension_arr))
         result = DataFrame(extension_arr)
         tm.assert_frame_equal(result, expected)
-
-    @pytest.mark.parametrize(
-        "data,dtype",
-        [
-            ([1, 2, 3], pa.uint8()),
-            ([1.0, 2.0, 3.0], pa.float64()),
-            (["foo", "bar", "foobar"], pa.string()),
-        ],
-    )
-    def test_constructor_with_pyarrow_table(self, data, dtype):
-        array = pa.array(data, type=dtype)
-        table = pa.table([array], names=["col"])
-        result = DataFrame(table)
-        assert isinstance(result["col"].dtype, ArrowDtype)
-        result_array = result["col"]._data.array._data.chunks[0]
-        assert result_array == array
-
-        for result_buffer, expected_buffer in zip(
-            result_array.buffers(), array.buffers()
-        ):
-            if result_buffer is None and expected_buffer is None:
-                continue
-            assert result_buffer.address == expected_buffer.address
-            assert result_buffer.size == expected_buffer.size
 
     def test_datetime_date_tuple_columns_from_dict(self):
         # GH 10863

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -60,7 +60,6 @@ from pandas.arrays import (
     SparseArray,
     TimedeltaArray,
 )
-from pandas.core.arrays.arrow import ArrowDtype
 
 MIXED_FLOAT_DTYPES = ["float16", "float32", "float64"]
 MIXED_INT_DTYPES = [


### PR DESCRIPTION
- [X] closes #51760

A mention in the docs is missing, and I guess we can add `pyarrow.Table` to the type annotations of what `DataFrame` accepts, but this should be mostly done otherwise.