### PR TITLE
PERF: fastpaths in tzconversion

### DIFF
--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -224,6 +224,11 @@ timedelta-like}
     -------
     localized : ndarray[int64_t]
     """
+
+    if tz is None or is_utc(tz) or vals.size == 0:
+        # Fastpath, avoid overhead of creating Localizer
+        return vals.copy()
+
     cdef:
         ndarray[uint8_t, cast=True] ambiguous_array
         Py_ssize_t i, n = vals.shape[0]
@@ -244,8 +249,6 @@ timedelta-like}
         npy_datetimestruct dts
 
     # Vectorized version of DstTzInfo.localize
-    if info.use_utc:
-        return vals.copy()
 
     # silence false-positive compiler warning
     ambiguous_array = np.empty(0, dtype=bool)

--- a/pandas/_libs/tslibs/vectorized.pyx
+++ b/pandas/_libs/tslibs/vectorized.pyx
@@ -54,6 +54,11 @@ def tz_convert_from_utc(ndarray stamps, tzinfo tz, NPY_DATETIMEUNIT reso=NPY_FR_
     -------
     ndarray[int64]
     """
+    if tz is None or is_utc(tz) or stamps.size == 0:
+        # Much faster than going through the "standard" pattern below;
+        #  do this before initializing Localizer.
+        return stamps.copy()
+
     cdef:
         Localizer info = Localizer(tz, creso=reso)
         int64_t utc_val, local_val
@@ -61,10 +66,6 @@ def tz_convert_from_utc(ndarray stamps, tzinfo tz, NPY_DATETIMEUNIT reso=NPY_FR_
 
         ndarray result
         cnp.broadcast mi
-
-    if tz is None or is_utc(tz) or stamps.size == 0:
-        # Much faster than going through the "standard" pattern below
-        return stamps.copy()
 
     result = cnp.PyArray_EMPTY(stamps.ndim, stamps.shape, cnp.NPY_INT64, 0)
     mi = cnp.PyArray_MultiIterNew2(result, stamps)


### PR DESCRIPTION
Should address some asv regressions that happened between 1.4.0 and 1.5.0