### PR TITLE
WEB: Add robots.txt to disallow docs preview

### DIFF
--- a/web/pandas/robots.txt
+++ b/web/pandas/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /preview/


### PR DESCRIPTION
With the new doc previewer system, we have multiple copies of our web and docs in the `/preview/` path of our domain. I initially added a `robots.txt` file in that directory to be excluded by crawlers, but I double-checked, and seems like crawlers just check for the file in the root. So, it needs to be added here.