### PR TITLE
STYLE: Enable ruff TCH on pandas/core/indexers and more 

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -32,18 +32,6 @@ from pandas._libs import (
     lib,
     reduction as libreduction,
 )
-from pandas._typing import (
-    ArrayLike,
-    Axis,
-    AxisInt,
-    CorrelationMethod,
-    FillnaOptions,
-    IndexLabel,
-    Manager,
-    Manager2D,
-    SingleManager,
-    TakeIndexer,
-)
 from pandas.errors import SpecificationError
 from pandas.util._decorators import (
     Appender,
@@ -96,6 +84,19 @@ from pandas.core.util.numba_ import maybe_use_numba
 from pandas.plotting import boxplot_frame_groupby
 
 if TYPE_CHECKING:
+    from pandas._typing import (
+        ArrayLike,
+        Axis,
+        AxisInt,
+        CorrelationMethod,
+        FillnaOptions,
+        IndexLabel,
+        Manager,
+        Manager2D,
+        SingleManager,
+        TakeIndexer,
+    )
+
     from pandas import Categorical
     from pandas.core.generic import NDFrame
 

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -17,12 +17,6 @@ import numpy as np
 from pandas._config import using_copy_on_write
 
 from pandas._libs import lib
-from pandas._typing import (
-    ArrayLike,
-    Axis,
-    NDFrameT,
-    npt,
-)
 from pandas.errors import InvalidIndexError
 from pandas.util._decorators import cache_readonly
 from pandas.util._exceptions import find_stack_level
@@ -52,6 +46,13 @@ from pandas.core.series import Series
 from pandas.io.formats.printing import pprint_thing
 
 if TYPE_CHECKING:
+    from pandas._typing import (
+        ArrayLike,
+        Axis,
+        NDFrameT,
+        npt,
+    )
+
     from pandas.core.generic import NDFrame
 
 

--- a/pandas/core/groupby/indexing.py
+++ b/pandas/core/groupby/indexing.py
@@ -9,7 +9,6 @@ from typing import (
 
 import numpy as np
 
-from pandas._typing import PositionalIndexer
 from pandas.util._decorators import (
     cache_readonly,
     doc,
@@ -21,6 +20,8 @@ from pandas.core.dtypes.common import (
 )
 
 if TYPE_CHECKING:
+    from pandas._typing import PositionalIndexer
+
     from pandas import (
         DataFrame,
         Series,

--- a/pandas/core/groupby/numba_.py
+++ b/pandas/core/groupby/numba_.py
@@ -11,13 +11,15 @@ from typing import (
 
 import numpy as np
 
-from pandas._typing import Scalar
 from pandas.compat._optional import import_optional_dependency
 
 from pandas.core.util.numba_ import (
     NumbaUtilError,
     jit_user_function,
 )
+
+if TYPE_CHECKING:
+    from pandas._typing import Scalar
 
 
 def validate_udf(func: Callable) -> None:

--- a/pandas/core/indexers/utils.py
+++ b/pandas/core/indexers/utils.py
@@ -10,8 +10,6 @@ from typing import (
 
 import numpy as np
 
-from pandas._typing import AnyArrayLike
-
 from pandas.core.dtypes.common import (
     is_array_like,
     is_bool_dtype,
@@ -26,6 +24,8 @@ from pandas.core.dtypes.generic import (
 )
 
 if TYPE_CHECKING:
+    from pandas._typing import AnyArrayLike
+
     from pandas.core.frame import DataFrame
     from pandas.core.indexes.base import Index
 

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import textwrap
-from typing import cast
+from typing import (
+    TYPE_CHECKING,
+    cast,
+)
 
 import numpy as np
 
@@ -9,7 +12,6 @@ from pandas._libs import (
     NaT,
     lib,
 )
-from pandas._typing import Axis
 from pandas.errors import InvalidIndexError
 
 from pandas.core.dtypes.cast import find_common_type
@@ -30,6 +32,8 @@ from pandas.core.indexes.period import PeriodIndex
 from pandas.core.indexes.range import RangeIndex
 from pandas.core.indexes.timedeltas import TimedeltaIndex
 
+if TYPE_CHECKING:
+    from pandas._typing import Axis
 _sort_msg = textwrap.dedent(
     """\
 Sorting because non-concatenation axis is not aligned. A future version

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import (
+    TYPE_CHECKING,
     Any,
     Hashable,
 )
@@ -8,11 +9,6 @@ from typing import (
 import numpy as np
 
 from pandas._libs import index as libindex
-from pandas._typing import (
-    Dtype,
-    DtypeObj,
-    npt,
-)
 from pandas.util._decorators import (
     cache_readonly,
     doc,
@@ -45,6 +41,12 @@ from pandas.core.indexes.extension import (
 
 from pandas.io.formats.printing import pprint_thing
 
+if TYPE_CHECKING:
+    from pandas._typing import (
+        Dtype,
+        DtypeObj,
+        npt,
+    )
 _index_doc_kwargs: dict[str, str] = dict(ibase._index_doc_kwargs)
 _index_doc_kwargs.update({"target_klass": "CategoricalIndex"})
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -7,7 +7,6 @@ from abc import (
     ABC,
     abstractmethod,
 )
-from datetime import datetime
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -31,10 +30,6 @@ from pandas._libs.tslibs import (
     Tick,
     parsing,
     to_offset,
-)
-from pandas._typing import (
-    Axis,
-    npt,
 )
 from pandas.compat.numpy import function as nv
 from pandas.errors import NullFrequencyError
@@ -70,6 +65,13 @@ from pandas.core.indexes.range import RangeIndex
 from pandas.core.tools.timedeltas import to_timedelta
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
+    from pandas._typing import (
+        Axis,
+        npt,
+    )
+
     from pandas import CategoricalIndex
 
 _index_doc_kwargs = dict(ibase._index_doc_kwargs)

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -25,15 +25,6 @@ from pandas._libs.tslibs import (
     to_offset,
 )
 from pandas._libs.tslibs.offsets import prefix_mapping
-from pandas._typing import (
-    Dtype,
-    DtypeObj,
-    Frequency,
-    IntervalClosedType,
-    TimeAmbiguous,
-    TimeNonexistent,
-    npt,
-)
 from pandas.util._decorators import (
     cache_readonly,
     doc,
@@ -60,6 +51,16 @@ from pandas.core.indexes.extension import inherit_names
 from pandas.core.tools.times import to_time
 
 if TYPE_CHECKING:
+    from pandas._typing import (
+        Dtype,
+        DtypeObj,
+        Frequency,
+        IntervalClosedType,
+        TimeAmbiguous,
+        TimeNonexistent,
+        npt,
+    )
+
     from pandas.core.api import (
         DataFrame,
         PeriodIndex,

--- a/pandas/core/indexes/extension.py
+++ b/pandas/core/indexes/extension.py
@@ -11,10 +11,6 @@ from typing import (
 
 import numpy as np
 
-from pandas._typing import (
-    ArrayLike,
-    npt,
-)
 from pandas.util._decorators import (
     cache_readonly,
     doc,
@@ -25,6 +21,11 @@ from pandas.core.dtypes.generic import ABCDataFrame
 from pandas.core.indexes.base import Index
 
 if TYPE_CHECKING:
+    from pandas._typing import (
+        ArrayLike,
+        npt,
+    )
+
     from pandas.core.arrays import IntervalArray
     from pandas.core.arrays._mixins import NDArrayBackedExtensionArray
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -7,6 +7,7 @@ from operator import (
 )
 import textwrap
 from typing import (
+    TYPE_CHECKING,
     Any,
     Hashable,
     Literal,
@@ -25,12 +26,6 @@ from pandas._libs.tslibs import (
     Timedelta,
     Timestamp,
     to_offset,
-)
-from pandas._typing import (
-    Dtype,
-    DtypeObj,
-    IntervalClosedType,
-    npt,
 )
 from pandas.errors import InvalidIndexError
 from pandas.util._decorators import (
@@ -92,6 +87,13 @@ from pandas.core.indexes.timedeltas import (
     timedelta_range,
 )
 
+if TYPE_CHECKING:
+    from pandas._typing import (
+        Dtype,
+        DtypeObj,
+        IntervalClosedType,
+        npt,
+    )
 _index_doc_kwargs = dict(ibase._index_doc_kwargs)
 
 _index_doc_kwargs.update(

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -4,7 +4,10 @@ from datetime import (
     datetime,
     timedelta,
 )
-from typing import Hashable
+from typing import (
+    TYPE_CHECKING,
+    Hashable,
+)
 
 import numpy as np
 
@@ -15,11 +18,6 @@ from pandas._libs.tslibs import (
     Period,
     Resolution,
     Tick,
-)
-from pandas._typing import (
-    Dtype,
-    DtypeObj,
-    npt,
 )
 from pandas.util._decorators import (
     cache_readonly,
@@ -46,6 +44,12 @@ from pandas.core.indexes.datetimes import (
 )
 from pandas.core.indexes.extension import inherit_names
 
+if TYPE_CHECKING:
+    from pandas._typing import (
+        Dtype,
+        DtypeObj,
+        npt,
+    )
 _index_doc_kwargs = dict(ibase._index_doc_kwargs)
 _index_doc_kwargs.update({"target_klass": "PeriodIndex or list of Periods"})
 _shared_doc_kwargs = {

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import operator
 from sys import getsizeof
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Hashable,
@@ -20,10 +21,6 @@ from pandas._libs import (
 )
 from pandas._libs.algos import unique_deltas
 from pandas._libs.lib import no_default
-from pandas._typing import (
-    Dtype,
-    npt,
-)
 from pandas.compat.numpy import function as nv
 from pandas.util._decorators import (
     cache_readonly,
@@ -51,6 +48,11 @@ from pandas.core.indexes.base import (
 )
 from pandas.core.ops.common import unpack_zerodim_and_defer
 
+if TYPE_CHECKING:
+    from pandas._typing import (
+        Dtype,
+        npt,
+    )
 _empty_range = range(0)
 
 

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -1,6 +1,8 @@
 """ implement the TimedeltaIndex """
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from pandas._libs import (
     index as libindex,
     lib,
@@ -10,7 +12,6 @@ from pandas._libs.tslibs import (
     Timedelta,
     to_offset,
 )
-from pandas._typing import DtypeObj
 
 from pandas.core.dtypes.common import (
     is_dtype_equal,
@@ -27,6 +28,9 @@ from pandas.core.indexes.base import (
 )
 from pandas.core.indexes.datetimelike import DatetimeTimedeltaMixin
 from pandas.core.indexes.extension import inherit_names
+
+if TYPE_CHECKING:
+    from pandas._typing import DtypeObj
 
 
 @inherit_names(

--- a/pandas/core/internals/api.py
+++ b/pandas/core/internals/api.py
@@ -8,10 +8,11 @@ authors
 """
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 from pandas._libs.internals import BlockPlacement
-from pandas._typing import Dtype
 
 from pandas.core.dtypes.common import (
     is_datetime64tz_dtype,
@@ -31,6 +32,9 @@ from pandas.core.internals.blocks import (
     get_block_type,
     maybe_coerce_values,
 )
+
+if TYPE_CHECKING:
+    from pandas._typing import Dtype
 
 
 def make_block(

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -4,6 +4,7 @@ Experimental manager based on storing a collection of 1D arrays
 from __future__ import annotations
 
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Hashable,
@@ -17,13 +18,6 @@ from pandas._libs import (
     NaT,
     algos as libalgos,
     lib,
-)
-from pandas._typing import (
-    ArrayLike,
-    AxisInt,
-    DtypeObj,
-    QuantileInterpolation,
-    npt,
 )
 from pandas.util._validators import validate_bool_kwarg
 
@@ -93,6 +87,14 @@ from pandas.core.internals.blocks import (
     to_native_types,
 )
 
+if TYPE_CHECKING:
+    from pandas._typing import (
+        ArrayLike,
+        AxisInt,
+        DtypeObj,
+        QuantileInterpolation,
+        npt,
+    )
 T = TypeVar("T", bound="BaseArrayManager")
 
 

--- a/pandas/core/internals/base.py
+++ b/pandas/core/internals/base.py
@@ -5,6 +5,7 @@ inherit from this class.
 from __future__ import annotations
 
 from typing import (
+    TYPE_CHECKING,
     Literal,
     TypeVar,
     final,
@@ -12,12 +13,6 @@ from typing import (
 
 import numpy as np
 
-from pandas._typing import (
-    ArrayLike,
-    AxisInt,
-    DtypeObj,
-    Shape,
-)
 from pandas.errors import AbstractMethodError
 
 from pandas.core.dtypes.cast import (
@@ -31,6 +26,13 @@ from pandas.core.indexes.api import (
     default_index,
 )
 
+if TYPE_CHECKING:
+    from pandas._typing import (
+        ArrayLike,
+        AxisInt,
+        DtypeObj,
+        Shape,
+    )
 T = TypeVar("T", bound="DataManager")
 
 

--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -15,13 +15,6 @@ from pandas._libs import (
     internals as libinternals,
 )
 from pandas._libs.missing import NA
-from pandas._typing import (
-    ArrayLike,
-    AxisInt,
-    DtypeObj,
-    Manager,
-    Shape,
-)
 from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.astype import astype_array
@@ -64,6 +57,14 @@ from pandas.core.internals.blocks import (
 from pandas.core.internals.managers import BlockManager
 
 if TYPE_CHECKING:
+    from pandas._typing import (
+        ArrayLike,
+        AxisInt,
+        DtypeObj,
+        Manager,
+        Shape,
+    )
+
     from pandas import Index
     from pandas.core.internals.blocks import Block
 

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from collections import abc
 from typing import (
+    TYPE_CHECKING,
     Any,
     Hashable,
     Sequence,
@@ -15,12 +16,6 @@ import numpy as np
 from numpy import ma
 
 from pandas._libs import lib
-from pandas._typing import (
-    ArrayLike,
-    DtypeObj,
-    Manager,
-    npt,
-)
 
 from pandas.core.dtypes.cast import (
     construct_1d_arraylike_from_scalar,
@@ -89,6 +84,13 @@ from pandas.core.internals.managers import (
     create_block_manager_from_column_arrays,
 )
 
+if TYPE_CHECKING:
+    from pandas._typing import (
+        ArrayLike,
+        DtypeObj,
+        Manager,
+        npt,
+    )
 # ---------------------------------------------------------------------
 # BlockManager Interface
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Hashable,
@@ -23,15 +24,6 @@ from pandas._libs import (
     lib,
 )
 from pandas._libs.internals import BlockPlacement
-from pandas._typing import (
-    ArrayLike,
-    AxisInt,
-    DtypeObj,
-    QuantileInterpolation,
-    Shape,
-    npt,
-    type_t,
-)
 from pandas.errors import PerformanceWarning
 from pandas.util._decorators import cache_readonly
 from pandas.util._exceptions import find_stack_level
@@ -86,6 +78,16 @@ from pandas.core.internals.ops import (
     operate_blockwise,
 )
 
+if TYPE_CHECKING:
+    from pandas._typing import (
+        ArrayLike,
+        AxisInt,
+        DtypeObj,
+        QuantileInterpolation,
+        Shape,
+        npt,
+        type_t,
+    )
 T = TypeVar("T", bound="BaseBlockManager")
 
 

--- a/pandas/core/internals/ops.py
+++ b/pandas/core/internals/ops.py
@@ -6,10 +6,9 @@ from typing import (
     NamedTuple,
 )
 
-from pandas._typing import ArrayLike
-
 if TYPE_CHECKING:
     from pandas._libs.internals import BlockPlacement
+    from pandas._typing import ArrayLike
 
     from pandas.core.internals.blocks import Block
     from pandas.core.internals.managers import BlockManager

--- a/pandas/core/methods/selectn.py
+++ b/pandas/core/methods/selectn.py
@@ -15,10 +15,6 @@ from typing import (
 import numpy as np
 
 from pandas._libs import algos as libalgos
-from pandas._typing import (
-    DtypeObj,
-    IndexLabel,
-)
 
 from pandas.core.dtypes.common import (
     is_bool_dtype,
@@ -31,6 +27,11 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.dtypes import BaseMaskedDtype
 
 if TYPE_CHECKING:
+    from pandas._typing import (
+        DtypeObj,
+        IndexLabel,
+    )
+
     from pandas import (
         DataFrame,
         Series,

--- a/pandas/core/methods/to_dict.py
+++ b/pandas/core/methods/to_dict.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import (
+    TYPE_CHECKING,
+    Literal,
+)
 import warnings
 
 from pandas.util._exceptions import find_stack_level
@@ -11,8 +14,10 @@ from pandas.core.dtypes.common import (
     is_object_dtype,
 )
 
-from pandas import DataFrame
 from pandas.core import common as com
+
+if TYPE_CHECKING:
+    from pandas import DataFrame
 
 
 def to_dict(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -293,11 +293,6 @@ exclude = [
 # TCH to be enabled gradually
 "pandas/core/arrays/*" = ["TCH"]
 "pandas/core/io/*" = ["TCH"]
-"pandas/core/indexers/*" = ["TCH"]
-"pandas/core/indexes/*" = ["TCH"]
-"pandas/core/internals/*" = ["TCH"]
-"pandas/core/groupby/*" = ["TCH"]
-"pandas/core/methods/*" = ["TCH"]
 "pandas/core/array_algos/*" = ["TCH"]
 "pandas/core/dtypes/*" = ["TCH"]
 "pandas/core/generic.py" = ["TCH"]


### PR DESCRIPTION
xref #51740, for 
```
"pandas/core/indexers/*" 
"pandas/core/indexes/*"
"pandas/core/internals/*" 
"pandas/core/groupby/*"
"pandas/core/methods/*"
```