### PR TITLE
STYLE Enable ruff TCH for pandas/core/util/*

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
         RandomState,
         T,
     )
+
     from pandas import Index
 
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -47,7 +47,6 @@ from pandas.core.dtypes.inference import iterable_not_string
 from pandas.core.dtypes.missing import isna
 
 if TYPE_CHECKING:
-    from pandas import Index
     from pandas._typing import (
         AnyArrayLike,
         ArrayLike,
@@ -55,6 +54,7 @@ if TYPE_CHECKING:
         RandomState,
         T,
     )
+    from pandas import Index
 
 
 def flatten(line):

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -30,13 +30,6 @@ import warnings
 import numpy as np
 
 from pandas._libs import lib
-from pandas._typing import (
-    AnyArrayLike,
-    ArrayLike,
-    NpDtype,
-    RandomState,
-    T,
-)
 
 from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
 from pandas.core.dtypes.common import (
@@ -55,6 +48,13 @@ from pandas.core.dtypes.missing import isna
 
 if TYPE_CHECKING:
     from pandas import Index
+    from pandas._typing import (
+        AnyArrayLike,
+        ArrayLike,
+        NpDtype,
+        RandomState,
+        T,
+    )
 
 
 def flatten(line):

--- a/pandas/core/util/hashing.py
+++ b/pandas/core/util/hashing.py
@@ -25,16 +25,16 @@ from pandas.core.dtypes.generic import (
 )
 
 if TYPE_CHECKING:
+    from pandas._typing import (
+        ArrayLike,
+        npt,
+    )
+
     from pandas import (
         DataFrame,
         Index,
         MultiIndex,
         Series,
-    )
-
-    from pandas._typing import (
-        ArrayLike,
-        npt,
     )
 
 

--- a/pandas/core/util/hashing.py
+++ b/pandas/core/util/hashing.py
@@ -14,10 +14,6 @@ from typing import (
 import numpy as np
 
 from pandas._libs.hashing import hash_object_array
-from pandas._typing import (
-    ArrayLike,
-    npt,
-)
 
 from pandas.core.dtypes.common import is_list_like
 from pandas.core.dtypes.generic import (
@@ -34,6 +30,11 @@ if TYPE_CHECKING:
         Index,
         MultiIndex,
         Series,
+    )
+
+    from pandas._typing import (
+        ArrayLike,
+        npt,
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -307,7 +307,6 @@ exclude = [
 "pandas/core/sorting.py" = ["TCH"]
 "pandas/core/construction.py" = ["TCH"]
 "pandas/core/missing.py" = ["TCH"]
-"pandas/core/util/*" = ["TCH"]
 "pandas/core/reshape/*" = ["TCH"]
 "pandas/core/strings/*" = ["TCH"]
 "pandas/core/tools/*" = ["TCH"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -306,7 +306,6 @@ exclude = [
 "pandas/core/ops/*" = ["TCH"]
 "pandas/core/sorting.py" = ["TCH"]
 "pandas/core/construction.py" = ["TCH"]
-"pandas/core/common.py" = ["TCH"]
 "pandas/core/missing.py" = ["TCH"]
 "pandas/core/util/*" = ["TCH"]
 "pandas/core/reshape/*" = ["TCH"]


### PR DESCRIPTION
ref #51740 

This PR will enable ruff TCH for `pandas/core/util/*` and fix associated issues