### PR TITLE
CLN: Remove pep8speaks

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,4 +1,0 @@
-# File : .pep8speaks.yml
-
-scanner:
-    diff_only: True  # If True, errors caused by only the patch are shown


### PR DESCRIPTION
Looks like this integration hasn't been working since ~October 2022 https://github.com/OrkoHunter/pep8speaks/issues/189. Also don't think it's entirely necessary as it only covers a small fraction of code checks that are done