### PR TITLE
Backport PR #51741 on branch 2.0.x (BUG: indexing empty pyarrow backed object returning corrupt object)

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -1247,6 +1247,7 @@ Indexing
 - Bug in :meth:`DataFrame.compare` does not recognize differences when comparing ``NA`` with value in nullable dtypes (:issue:`48939`)
 - Bug in :meth:`Series.rename` with :class:`MultiIndex` losing extension array dtypes (:issue:`21055`)
 - Bug in :meth:`DataFrame.isetitem` coercing extension array dtypes in :class:`DataFrame` to object (:issue:`49922`)
+- Bug in :meth:`Series.__getitem__` returning corrupt object when selecting from an empty pyarrow backed object (:issue:`51734`)
 - Bug in :class:`BusinessHour` would cause creation of :class:`DatetimeIndex` to fail when no opening hour was included in the index (:issue:`49835`)
 
 Missing

--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -252,6 +252,7 @@ if not pa_version_under7p0:
 else:
     FLOAT_PYARROW_DTYPES_STR_REPR = []
     ALL_INT_PYARROW_DTYPES_STR_REPR = []
+    ALL_PYARROW_DTYPES = []
 
 
 EMPTY_STRING_PATTERN = re.compile("^$")

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1010,7 +1010,12 @@ class ArrowExtensionArray(OpsMixin, ExtensionArray, BaseStringArrayMethods):
         ArrowExtensionArray
         """
         chunks = [array for ea in to_concat for array in ea._data.iterchunks()]
-        arr = pa.chunked_array(chunks)
+        if to_concat[0].dtype == "string":
+            # StringDtype has no attrivute pyarrow_dtype
+            pa_dtype = pa.string()
+        else:
+            pa_dtype = to_concat[0].dtype.pyarrow_dtype
+        arr = pa.chunked_array(chunks, type=pa_dtype)
         return cls(arr)
 
     def _accumulate(

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -2300,36 +2300,6 @@ def test_dt_tz_localize(unit):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize("skipna", [True, False])
-def test_boolean_reduce_series_all_null(all_boolean_reductions, skipna):
-    # GH51624
-    ser = pd.Series([None], dtype="float64[pyarrow]")
-    result = getattr(ser, all_boolean_reductions)(skipna=skipna)
-    if skipna:
-        expected = all_boolean_reductions == "all"
-    else:
-        expected = pd.NA
-    assert result is expected
-
-
-def test_from_sequence_of_strings_boolean():
-    true_strings = ["true", "TRUE", "True", "1", "1.0"]
-    false_strings = ["false", "FALSE", "False", "0", "0.0"]
-    nulls = [None]
-    strings = true_strings + false_strings + nulls
-    bools = (
-        [True] * len(true_strings) + [False] * len(false_strings) + [None] * len(nulls)
-    )
-
-    result = ArrowExtensionArray._from_sequence_of_strings(strings, dtype=pa.bool_())
-    expected = pd.array(bools, dtype="boolean[pyarrow]")
-    tm.assert_extension_array_equal(result, expected)
-
-    strings = ["True", "foo"]
-    with pytest.raises(pa.ArrowInvalid, match="Failed to parse"):
-        ArrowExtensionArray._from_sequence_of_strings(strings, dtype=pa.bool_())
-
-
 def test_concat_empty_arrow_backed_series(dtype):
     # GH#51734
     ser = pd.Series([], dtype=dtype)


### PR DESCRIPTION
#51741
