### PR TITLE
ENH: Add to_pydatetime for ArrowExtensionArray

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -2090,6 +2090,9 @@ class ArrowExtensionArray(
     ):
         return self._round_temporally("round", freq, ambiguous, nonexistent)
 
+    def _dt_to_pydatetime(self):
+        return np.array(self._data.to_pylist(), dtype=object)
+
     def _dt_tz_localize(
         self,
         tz,

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -209,6 +209,9 @@ class ArrowTemporalProperties(PandasDelegate, PandasObject, NoNewAttributesMixin
 
         return result
 
+    def to_pydatetime(self):
+        return cast(ArrowExtensionArray, self._parent.array)._dt_to_pydatetime()
+
     def isocalendar(self):
         from pandas import DataFrame
 

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -2248,6 +2248,19 @@ def test_dt_ceil_year_floor(freq, method):
     tm.assert_series_equal(result, expected)
 
 
+def test_dt_to_pydatetime():
+    # GH 51859
+    data = [datetime(2022, 1, 1), datetime(2023, 1, 1)]
+    ser = pd.Series(data, dtype=ArrowDtype(pa.timestamp("ns")))
+
+    result = ser.dt.to_pydatetime()
+    expected = np.array(data, dtype=object)
+    tm.assert_numpy_array_equal(result, expected)
+
+    expected = ser.astype("datetime64[ns]").dt.to_pydatetime()
+    tm.assert_numpy_array_equal(result, expected)
+
+
 def test_dt_tz_localize_unsupported_tz_options():
     ser = pd.Series(
         [datetime(year=2023, month=1, day=2, hour=3), None],


### PR DESCRIPTION
- [x] closes #51859 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
