### PR TITLE
CI/DEPS: Use np.prod in tests for np deprecation

### DIFF
--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -1842,7 +1842,7 @@ def test_resample_apply_product(duplicates, unit):
     if duplicates:
         df.columns = ["A", "A"]
 
-    result = df.resample("Q").apply(np.product)
+    result = df.resample("Q").apply(np.prod)
     expected = DataFrame(
         np.array([[0, 24], [60, 210], [336, 720], [990, 1716]], dtype=np.int64),
         index=DatetimeIndex(


### PR DESCRIPTION
Failing on the numpy dev build due to a deprecation https://github.com/pandas-dev/pandas/actions/runs/4380199790/jobs/7667001150

https://github.com/numpy/numpy/pull/23314