### PR TITLE
CI: Pin moto image to specific version

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -142,7 +142,7 @@ jobs:
           - 5432:5432
 
       moto:
-        image: motoserver/moto
+        image: motoserver/moto:4.1.4
         env:
           AWS_ACCESS_KEY_ID: foobar_key
           AWS_SECRET_ACCESS_KEY: foobar_secret


### PR DESCRIPTION
Should help fix the failing `single_cpu` builds