### PR TITLE
DOC: Fix dangling hyphens.

### DIFF
--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -377,8 +377,8 @@ aggregations for step functions defined over real numbers, datetime and timedelt
 
 xarray brings the labeled data power of pandas to the physical sciences by
 providing N-dimensional variants of the core pandas data structures. It aims to
-provide a pandas-like and pandas-compatible toolkit for analytics on multi-
-dimensional arrays, rather than the tabular data for which pandas excels.
+provide a pandas-like and pandas-compatible toolkit for analytics on
+multi-dimensional arrays, rather than the tabular data for which pandas excels.
 
 
 .. _ecosystem.io:

--- a/doc/source/user_guide/integer_na.rst
+++ b/doc/source/user_guide/integer_na.rst
@@ -58,8 +58,8 @@ with the dtype.
 .. warning::
 
    Currently :meth:`pandas.array` and :meth:`pandas.Series` use different
-   rules for dtype inference. :meth:`pandas.array` will infer a nullable-
-   integer dtype
+   rules for dtype inference. :meth:`pandas.array` will infer a
+   nullable-integer dtype
 
    .. ipython:: python
 


### PR DESCRIPTION
Dangling hyphens gets rendered with a space, see screenshot:

![Screenshot 2023-03-10 at 21-46-19 pandas ecosystem — pandas 1 5 3 documentation](https://user-images.githubusercontent.com/239510/224425105-e9cef4ea-2aac-4e99-bb80-ea164947453f.png)

It's currently been added sphinx-lint side in https://github.com/sphinx-contrib/sphinx-lint/pull/56.