### PR TITLE
Replace deprecated BadZipfile with BadZipFile

### DIFF
--- a/pandas/tests/io/parser/test_compression.py
+++ b/pandas/tests/io/parser/test_compression.py
@@ -85,7 +85,7 @@ def test_zip_error_invalid_zip(parser_and_data):
 
     with tm.ensure_clean() as path:
         with open(path, "rb") as f:
-            with pytest.raises(zipfile.BadZipfile, match="File is not a zip file"):
+            with pytest.raises(zipfile.BadZipFile, match="File is not a zip file"):
                 parser.read_csv(f, compression="zip")
 
 


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

---

`BadZipfile` (with a small `f`) has been deprecated since Python 3.2, use `BadZipFile` (big `F`) instead, added in 3.2.

* https://docs.python.org/3/library/zipfile.html#zipfile.BadZipfile
* https://github.com/python/cpython/issues/86437

Does this need a news entry?