### PR TITLE
API / BUG: copy non-Index arrays in Index construction to avoid data corruption

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -464,7 +464,7 @@ class Index(IndexOpsMixin, PandasObject):
         cls,
         data=None,
         dtype=None,
-        copy: bool = False,
+        copy: bool | None = None,
         name=None,
         tupleize_cols: bool = True,
     ) -> Index:
@@ -476,6 +476,12 @@ class Index(IndexOpsMixin, PandasObject):
             dtype = pandas_dtype(dtype)
 
         data_dtype = getattr(data, "dtype", None)
+
+        if copy is None:
+            if isinstance(data, Index):
+                copy = False
+            else:
+                copy = True
 
         # range
         if isinstance(data, (range, RangeIndex)):
@@ -7051,7 +7057,7 @@ def ensure_index_from_sequences(sequences, names=None) -> Index:
         return MultiIndex.from_arrays(sequences, names=names)
 
 
-def ensure_index(index_like: Axes, copy: bool = False) -> Index:
+def ensure_index(index_like: Axes, copy: bool | None = None) -> Index:
     """
     Ensure that we have an index from some index-like object.
 
@@ -7059,7 +7065,8 @@ def ensure_index(index_like: Axes, copy: bool = False) -> Index:
     ----------
     index_like : sequence
         An Index or other sequence
-    copy : bool, default False
+    copy : bool, optional
+        By default copy if the passed object is not yet an Index object.
 
     Returns
     -------
@@ -7083,9 +7090,12 @@ def ensure_index(index_like: Axes, copy: bool = False) -> Index:
            )
     """
     if isinstance(index_like, Index):
-        if copy:
+        if copy is True:
             index_like = index_like.copy()
         return index_like
+
+    if copy is None:
+        copy = True
 
     if isinstance(index_like, ABCSeries):
         name = index_like.name

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6720,7 +6720,7 @@ class Index(IndexOpsMixin, PandasObject):
         )
         if copy and res_values is values:
             return self.copy()
-        return Index(res_values, name=self.name)
+        return Index(res_values, name=self.name, copy=False)
 
     # --------------------------------------------------------------------
     # Generated Arithmetic, Comparison, and Unary Methods

--- a/pandas/tests/copy_view/test_indexes.py
+++ b/pandas/tests/copy_view/test_indexes.py
@@ -1,0 +1,44 @@
+from pandas import (
+    DataFrame,
+    Index,
+    Series,
+)
+import pandas._testing as tm
+
+
+def test_index_constructor():
+    ser = Series([1, 2, 3])
+    idx = Index(ser)
+    # assert not np.shares_memory(idx.values, get_array(ser))
+    ser.iloc[0] = 0
+    tm.assert_index_equal(idx, Index([1, 2, 3]))
+
+
+def test_series_constructor():
+    ser = Series([1, 2, 3])
+    ser2 = Series(ser, index=ser)
+    ser2.iloc[0] = 0
+    tm.assert_index_equal(ser2.index, Index([1, 2, 3]))
+
+
+def test_dataframe_constructor():
+    ser = Series([1, 2, 3])
+    df = DataFrame({"a": ser}, index=ser)
+    ser.iloc[0] = 0
+    tm.assert_index_equal(df.index, Index([1, 2, 3]))
+    df.iloc[0, 0] = 10
+    tm.assert_index_equal(df.index, Index([1, 2, 3]))
+
+
+def test_dataframe_set_index_inplace():
+    df = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [0.1, 0.2, 0.3]})
+    df.set_index("a", drop=False, inplace=True)
+    df.iloc[0, 0] = 0
+    tm.assert_index_equal(df.index, Index([1, 2, 3], name="a"))
+
+
+def test_index_attribute_assignment():
+    ser = Series([1, 2, 3])
+    ser.index = ser
+    ser.iloc[0] = 10
+    tm.assert_index_equal(ser.index, Index([1, 2, 3]))

--- a/pandas/tests/reductions/test_stat_reductions.py
+++ b/pandas/tests/reductions/test_stat_reductions.py
@@ -77,6 +77,7 @@ class TestDatetimeLikeStatReductions:
         assert result == expected
 
         tdarr[0] = pd.NaT
+        obj = box(tdarr)
         assert obj.mean(skipna=False) is pd.NaT
 
         result2 = obj.mean(skipna=True)


### PR DESCRIPTION
Would close https://github.com/pandas-dev/pandas/issues/34364 and https://github.com/pandas-dev/pandas/issues/42934

The idea here is that since the Index is assumed to be immutable and caches things like the hashtable, we should avoid that a user can actually mutate those values through normal pandas functionality by making a copy when creating an Index from array-like data. 
I made the exception for an object that is already an Index (since this is immutable, you can't mutate this through normal pandas functionality, and typically this will already made a copy when first being created). This should avoid too many copies on repeated `ensure_index` calls.

Still need to add more tests (covering the segfault case), docs, and do the same in the Index subclasses' `__new__`, in case we want something like this.


- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
