### PR TITLE
REF: move ExtensionIndex.map to be part of DatetimeLikeArrayMixin.map

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -881,10 +881,8 @@ class IndexOpsMixin(OpsMixin):
         """
         arr = extract_array(self, extract_numpy=True, extract_range=True)
 
-        if is_extension_array_dtype(arr.dtype):
-            # Item "IndexOpsMixin" of "Union[IndexOpsMixin, ExtensionArray,
-            # ndarray[Any, Any]]" has no attribute "map"
-            return arr.map(mapper, na_action=na_action)  # type: ignore[union-attr]
+        if isinstance(arr, ExtensionArray):
+            return arr.map(mapper, na_action=na_action)
 
         # Argument 1 to "map_array" has incompatible type
         # "Union[IndexOpsMixin, ExtensionArray, ndarray[Any, Any]]";

--- a/pandas/core/indexes/extension.py
+++ b/pandas/core/indexes/extension.py
@@ -9,18 +9,15 @@ from typing import (
     TypeVar,
 )
 
-import numpy as np
-
-from pandas.util._decorators import (
-    cache_readonly,
-    doc,
-)
+from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.generic import ABCDataFrame
 
 from pandas.core.indexes.base import Index
 
 if TYPE_CHECKING:
+    import numpy as np
+
     from pandas._typing import (
         ArrayLike,
         npt,
@@ -153,23 +150,6 @@ class ExtensionIndex(Index):
         Convert value to be insertable to underlying array.
         """
         return self._data._validate_setitem_value(value)
-
-    @doc(Index.map)
-    def map(self, mapper, na_action=None):
-        # Try to run function on index first, and then on elements of index
-        # Especially important for group-by functionality
-        try:
-            result = mapper(self)
-
-            # Try to use this result if we can
-            if isinstance(result, np.ndarray):
-                result = Index(result)
-
-            if not isinstance(result, Index):
-                raise TypeError("The map function must return an Index object")
-            return result
-        except Exception:
-            return self.astype(object).map(mapper)
 
     @cache_readonly
     def _isnan(self) -> npt.NDArray[np.bool_]:


### PR DESCRIPTION
Follow-up to #51809.

`ExtensionIndex.map` is only used by the datetime-like indexes (`DatetimeIndex.map` etc.) and contains no index-specific functionality, so shouldn't be an index method.

By moving this method to `DatetimeLikeArrayMixin.map` we simplify the code paths quite a bit when dealing with `DatetimeArray.map` etc. In the next PR I will make  `na_action="ignore"` work as expected and close #51644. 