### PR TITLE
CI: Remove workflows on 1.5.x branch

### DIFF
--- a/.github/workflows/32-bit-linux.yml
+++ b/.github/workflows/32-bit-linux.yml
@@ -5,12 +5,10 @@ on:
     branches:
       - main
       - 2.0.x
-      - 1.5.x
   pull_request:
     branches:
       - main
       - 2.0.x
-      - 1.5.x
     paths-ignore:
       - "doc/**"
 

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -5,12 +5,10 @@ on:
     branches:
       - main
       - 2.0.x
-      - 1.5.x
   pull_request:
     branches:
       - main
       - 2.0.x
-      - 1.5.x
 
 env:
   ENV_FILE: environment.yml

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -5,14 +5,12 @@ on:
     branches:
       - main
       - 2.0.x
-      - 1.5.x
     tags:
       - '*'
   pull_request:
     branches:
       - main
       - 2.0.x
-      - 1.5.x
 
 env:
   ENV_FILE: environment.yml

--- a/.github/workflows/macos-windows.yml
+++ b/.github/workflows/macos-windows.yml
@@ -5,12 +5,10 @@ on:
     branches:
       - main
       - 2.0.x
-      - 1.5.x
   pull_request:
     branches:
       - main
       - 2.0.x
-      - 1.5.x
     paths-ignore:
       - "doc/**"
       - "web/**"

--- a/.github/workflows/package-checks.yml
+++ b/.github/workflows/package-checks.yml
@@ -5,12 +5,10 @@ on:
     branches:
       - main
       - 2.0.x
-      - 1.5.x
   pull_request:
     branches:
       - main
       - 2.0.x
-      - 1.5.x
     types: [ labeled, opened, synchronize, reopened ]
 
 permissions:

--- a/.github/workflows/python-dev.yml
+++ b/.github/workflows/python-dev.yml
@@ -23,13 +23,13 @@ name: Python Dev
 on:
   push:
     branches:
-#      - main
-#      - 1.5.x
+      - main
+      - 2.0.x
       - None
   pull_request:
     branches:
-#      - main
-#      - 1.5.x
+      - main
+      - 2.0.x
       - None
     paths-ignore:
       - "doc/**"
@@ -47,7 +47,7 @@ permissions:
 
 jobs:
   build:
-    # if: false # Uncomment this to freeze the workflow, comment it to unfreeze
+    if: false # Uncomment this to freeze the workflow, comment it to unfreeze
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -5,12 +5,10 @@ on:
     branches:
       - main
       - 2.0.x
-      - 1.5.x
   pull_request:
     branches:
       - main
       - 2.0.x
-      - 1.5.x
     types: [labeled, opened, synchronize, reopened]
     paths-ignore:
       - "doc/**"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -5,12 +5,10 @@ on:
     branches:
       - main
       - 2.0.x
-      - 1.5.x
   pull_request:
     branches:
       - main
       - 2.0.x
-      - 1.5.x
     paths-ignore:
       - "doc/**"
       - "web/**"


### PR DESCRIPTION
Additionally freezes the `python-dev` workflow by using `if: False` instead of commenting out branches