### PR TITLE
REF/TYP: avoid need for NDFrameTb

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -131,9 +131,6 @@ Timezone = Union[str, tzinfo]
 # Series is passed into a function, a Series is always returned and if a DataFrame is
 # passed in, a DataFrame is always returned.
 NDFrameT = TypeVar("NDFrameT", bound="NDFrame")
-# same as NDFrameT, needed when binding two pairs of parameters to potentially
-# separate NDFrame-subclasses (see NDFrame.align)
-NDFrameTb = TypeVar("NDFrameTb", bound="NDFrame")
 
 NumpyIndexT = TypeVar("NumpyIndexT", np.ndarray, "Index")
 

--- a/pandas/tests/frame/methods/test_align.py
+++ b/pandas/tests/frame/methods/test_align.py
@@ -101,6 +101,7 @@ class TestDataFrameAlign:
         with pytest.raises(ValueError, match=msg):
             float_frame.align(af.iloc[0, :3], join="inner", axis=2)
 
+    def test_align_frame_with_series(self, float_frame):
         # align dataframe to series with broadcast or not
         idx = float_frame.index
         s = Series(range(len(idx)), index=idx)
@@ -118,6 +119,7 @@ class TestDataFrameAlign:
         )
         tm.assert_frame_equal(right, expected)
 
+    def test_align_series_condition(self):
         # see gh-9558
         df = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
         result = df[df["a"] == 2]


### PR DESCRIPTION
We have a method align_as_utc that implemented at the module-level instead of as a method, requiring some annotation gymnastics.  This refactors so that it is only used in one place instead of two, then inlines the function inside `align`.