### PR TITLE
BUG: Add numpy_nullable support to arrow csv parser

### DIFF
--- a/pandas/io/parsers/arrow_parser_wrapper.py
+++ b/pandas/io/parsers/arrow_parser_wrapper.py
@@ -9,6 +9,7 @@ from pandas.core.dtypes.inference import is_integer
 import pandas as pd
 from pandas import DataFrame
 
+from pandas.io._util import _arrow_dtype_mapping
 from pandas.io.parsers.base_parser import ParserBase
 
 if TYPE_CHECKING:
@@ -151,6 +152,8 @@ class ArrowParserWrapper(ParserBase):
         )
         if self.kwds["dtype_backend"] == "pyarrow":
             frame = table.to_pandas(types_mapper=pd.ArrowDtype)
+        elif self.kwds["dtype_backend"] == "numpy_nullable":
+            frame = table.to_pandas(types_mapper=_arrow_dtype_mapping().get)
         else:
             frame = table.to_pandas()
         return self._finalize_pandas_output(frame)

--- a/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
+++ b/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
@@ -402,7 +402,6 @@ def test_dtypes_defaultdict_invalid(all_parsers):
         parser.read_csv(StringIO(data), dtype=dtype)
 
 
-@pytest.mark.usefixtures("pyarrow_xfail")
 def test_dtype_backend(all_parsers):
     # GH#36712
 
@@ -424,9 +423,13 @@ def test_dtype_backend(all_parsers):
             "e": pd.Series([pd.NA, 6], dtype="Int64"),
             "f": pd.Series([pd.NA, 7.5], dtype="Float64"),
             "g": pd.Series([pd.NA, True], dtype="boolean"),
-            "h": pd.Series([pd.NA, "a"], dtype="string"),
+            "h": pd.Series(
+                [pd.NA if parser.engine != "pyarrow" else "", "a"], dtype="string"
+            ),
             "i": pd.Series([Timestamp("2019-12-31")] * 2),
-            "j": pd.Series([pd.NA, pd.NA], dtype="Int64"),
+            "j": pd.Series(
+                [pd.NA, pd.NA], dtype="Int64" if parser.engine != "pyarrow" else object
+            ),
         }
     )
     tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #51852 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
