### PR TITLE
"Backport PR #51978 on branch 2.0.x (BUG/API: preserve non-nano in factorize/unique)"

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -764,6 +764,7 @@ Other API changes
 - Division by zero with :class:`ArrowDtype` dtypes returns ``-inf``, ``nan``, or ``inf`` depending on the numerator, instead of raising (:issue:`51541`)
 - Added :func:`pandas.api.types.is_any_real_numeric_dtype` to check for real numeric dtypes (:issue:`51152`)
 - :meth:`~arrays.ArrowExtensionArray.value_counts` now returns data with :class:`ArrowDtype` with ``pyarrow.int64`` type instead of ``"Int64"`` type (:issue:`51462`)
+- :func:`factorize` and :func:`unique` preserve the original dtype when passed numpy timedelta64 or datetime64 with non-nanosecond resolution (:issue:`48670`)
 
 .. note::
 

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -31,7 +31,6 @@ from pandas._libs.tslibs import (
     OutOfBoundsTimedelta,
     Timedelta,
     Timestamp,
-    astype_overflowsafe,
     get_unit_from_dtype,
     is_supported_unit,
 )
@@ -50,8 +49,6 @@ from pandas.errors import (
 )
 
 from pandas.core.dtypes.common import (
-    DT64NS_DTYPE,
-    TD64NS_DTYPE,
     ensure_int8,
     ensure_int16,
     ensure_int32,
@@ -1229,23 +1226,6 @@ def maybe_cast_to_datetime(
             raise
 
         return dta
-
-
-def sanitize_to_nanoseconds(values: np.ndarray, copy: bool = False) -> np.ndarray:
-    """
-    Safely convert non-nanosecond datetime64 or timedelta64 values to nanosecond.
-    """
-    dtype = values.dtype
-    if dtype.kind == "M" and dtype != DT64NS_DTYPE:
-        values = astype_overflowsafe(values, dtype=DT64NS_DTYPE)
-
-    elif dtype.kind == "m" and dtype != TD64NS_DTYPE:
-        values = astype_overflowsafe(values, dtype=TD64NS_DTYPE)
-
-    elif copy:
-        values = values.copy()
-
-    return values
 
 
 def _ensure_nanosecond_dtype(dtype: DtypeObj) -> None:

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -307,7 +307,7 @@ def _convert_and_box_cache(
     """
     from pandas import Series
 
-    result = Series(arg).map(cache_array)
+    result = Series(arg, dtype=cache_array.index.dtype).map(cache_array)
     return _box_as_indexlike(result._values, utc=False, name=name)
 
 

--- a/pandas/tests/indexes/datetimes/methods/test_factorize.py
+++ b/pandas/tests/indexes/datetimes/methods/test_factorize.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from pandas import (
     DatetimeIndex,
@@ -105,3 +106,20 @@ class TestDatetimeIndexFactorize:
         tm.assert_index_equal(res, idx)
         if index_or_series is Index:
             assert res.freq == idx.freq
+
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_factorize_no_freq_non_nano(self, tz_naive_fixture, sort):
+        # GH#51978 case that does not go through the fastpath based on
+        #  non-None freq
+        tz = tz_naive_fixture
+        idx = date_range("2016-11-06", freq="H", periods=5, tz=tz)[[0, 4, 1, 3, 2]]
+        exp_codes, exp_uniques = idx.factorize(sort=sort)
+
+        res_codes, res_uniques = idx.as_unit("s").factorize(sort=sort)
+
+        tm.assert_numpy_array_equal(res_codes, exp_codes)
+        tm.assert_index_equal(res_uniques, exp_uniques.as_unit("s"))
+
+        res_codes, res_uniques = idx.as_unit("s").to_series().factorize(sort=sort)
+        tm.assert_numpy_array_equal(res_codes, exp_codes)
+        tm.assert_index_equal(res_uniques, exp_uniques.as_unit("s"))

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -1657,8 +1657,8 @@ date,time,prn,rxstatus
     datetimes = np.array(["2013-11-03T19:00:00"] * 3, dtype="datetime64[s]")
     expected = DataFrame(
         data={"rxstatus": ["00E80000"] * 3},
-        index=MultiIndex.from_tuples(
-            [(datetimes[0], 126), (datetimes[1], 23), (datetimes[2], 13)],
+        index=MultiIndex.from_arrays(
+            [datetimes, [126, 23, 13]],
             names=["datetime", "prn"],
         ),
     )

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -327,7 +327,7 @@ class TestFactorize:
 
     def test_datetime64_factorize(self, writable):
         # GH35650 Verify whether read-only datetime64 array can be factorized
-        data = np.array([np.datetime64("2020-01-01T00:00:00.000")])
+        data = np.array([np.datetime64("2020-01-01T00:00:00.000")], dtype="M8[ns]")
         data.setflags(write=writable)
         expected_codes = np.array([0], dtype=np.intp)
         expected_uniques = np.array(
@@ -620,13 +620,13 @@ class TestUnique:
     def test_datetime_non_ns(self):
         a = np.array(["2000", "2000", "2001"], dtype="datetime64[s]")
         result = pd.unique(a)
-        expected = np.array(["2000", "2001"], dtype="datetime64[ns]")
+        expected = np.array(["2000", "2001"], dtype="datetime64[s]")
         tm.assert_numpy_array_equal(result, expected)
 
     def test_timedelta_non_ns(self):
         a = np.array(["2000", "2000", "2001"], dtype="timedelta64[s]")
         result = pd.unique(a)
-        expected = np.array([2000000000000, 2001000000000], dtype="timedelta64[ns]")
+        expected = np.array([2000, 2001], dtype="timedelta64[s]")
         tm.assert_numpy_array_equal(result, expected)
 
     def test_timedelta64_dtype_array_returned(self):


### PR DESCRIPTION
* BUG/API: preserve non-nano in factorize/unique

* test

(cherry picked from commit 6a13450cec5996cc14f722069ef9be150f034e03)

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

#51978