### PR TITLE
DOC Change slack invitation from email to link

### DIFF
--- a/doc/source/development/community.rst
+++ b/doc/source/development/community.rst
@@ -111,9 +111,11 @@ contributing to pandas. The slack is a private space, specifically meant for
 people who are hesitant to bring up their questions or ideas on a large public
 mailing list or GitHub.
 
-If this sounds like the right place for you, you are welcome to join! Email us
-at `slack@pandas.pydata.org <mailto://slack@pandas.pydata.org>`_ and let us
-know that you read and agree to our `Code of Conduct <https://pandas.pydata.org/community/coc.html>`_
-😉 to get an invite. And please remember that slack is not meant to replace the
-mailing list or issue tracker - all important announcements and conversations
-should still happen there.
+If this sounds like the right place for you, you are welcome to join using
+`this link <https://join.slack.com/t/pandas-dev-community/shared_invite/zt-1e2qgy1r6-PLCN8UOLEUAYoLdAsaJilw>`_!
+Please remember to follow our `Code of Conduct <https://pandas.pydata.org/community/coc.html>`_,
+and be aware that our admins are monitoring for irrelevant messages and will remove folks who use
+our
+slack for spam, advertisements and messages not related to the pandas contributing community. And
+please remember that slack is not meant to replace the mailing list or issue tracker - all important
+announcements and conversations should still happen there.


### PR DESCRIPTION
Simplified the slack invitation process after discussion with @rhshadrach and @MarcoGorelli.

The current email process is maintenance heavy and until now, we received very little spam. We want to try letting people join themselves and see if spam increases or not.

Local build looked correct.