### PR TITLE
DEPR: deprecate axis keyword in GroupBy methods

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -102,6 +102,7 @@ Deprecations
 - Deprecated passing a :class:`DataFrame` to :meth:`DataFrame.from_records`, use :meth:`DataFrame.set_index` or :meth:`DataFrame.drop` instead (:issue:`51353`)
 - Deprecated accepting slices in :meth:`DataFrame.take`, call ``obj[slicer]`` or pass a sequence of integers instead (:issue:`51539`)
 - Deprecated 'method', 'limit', and 'fill_axis' keywords in :meth:`DataFrame.align` and :meth:`Series.align`, explicitly call ``fillna`` on the alignment results instead (:issue:`51856`)
+- Deprecated the 'axis' keyword in :meth:`.GroupBy.idxmax`, :meth:`.GroupBy.idxmin`, :meth:`.GroupBy.fillna`, :meth:`.GroupBy.take`, :meth:`.GroupBy.skew`, :meth:`.GroupBy.rank`, :meth:`.GroupBy.cumprod`, :meth:`.GroupBy.cumsum`, :meth:`.GroupBy.cummax`, :meth:`.GroupBy.cummin`, :meth:`.GroupBy.pct_change`, :meth:`GroupBy.diff`, :meth:`.GroupBy.shift`, and :meth:`DataFrameGroupBy.corrwith`; for ``axis=1`` operate on the underlying :class:`DataFrame` instead (:issue:`50405`, :issue:`51046`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -814,7 +814,7 @@ class SeriesGroupBy(GroupBy[Series]):
         self,
         value: object | ArrayLike | None = None,
         method: FillnaOptions | None = None,
-        axis: Axis | None = lib.no_default,
+        axis: Axis | None | lib.NoDefault = lib.no_default,
         inplace: bool = False,
         limit: int | None = None,
         downcast: dict | None = None,
@@ -838,6 +838,11 @@ class SeriesGroupBy(GroupBy[Series]):
             ``'bfill'`` will use next valid observation to fill the gap.
         axis : {0 or 'index', 1 or 'columns'}
             Unused, only for compatibility with :meth:`DataFrameGroupBy.fillna`.
+
+            .. deprecated:: 2.1.0
+                For axis=1, operate on the underlying object instead. Otherwise
+                the axis keyword is not necessary.
+
         inplace : bool, default False
             Broken. Do not set to True.
         limit : int, default None
@@ -941,6 +946,11 @@ class SeriesGroupBy(GroupBy[Series]):
             The axis on which to select elements. ``0`` means that we are
             selecting rows, ``1`` means that we are selecting columns.
             For `SeriesGroupBy` this parameter is unused and defaults to 0.
+
+            .. deprecated:: 2.1.0
+                For axis=1, operate on the underlying object instead. Otherwise
+                the axis keyword is not necessary.
+
         **kwargs
             For compatibility with :meth:`numpy.take`. Has no effect on the
             output.
@@ -1015,6 +1025,10 @@ class SeriesGroupBy(GroupBy[Series]):
         axis : {0 or 'index', 1 or 'columns', None}, default 0
             Axis for the function to be applied on.
             This parameter is only for compatibility with DataFrame and is unused.
+
+            .. deprecated:: 2.1.0
+                For axis=1, operate on the underlying object instead. Otherwise
+                the axis keyword is not necessary.
 
         skipna : bool, default True
             Exclude NA/null values when computing the result.
@@ -1943,6 +1957,10 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
             .. versionchanged:: 2.0.0
 
+            .. deprecated:: 2.1.0
+                For axis=1, operate on the underlying object instead. Otherwise
+                the axis keyword is not necessary.
+
         skipna : bool, default True
             Exclude NA/null values. If an entire row/column is NA, the result
             will be NA.
@@ -2033,6 +2051,10 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
             If axis is not provided, grouper's axis is used.
 
             .. versionchanged:: 2.0.0
+
+            .. deprecated:: 2.1.0
+                For axis=1, operate on the underlying object instead. Otherwise
+                the axis keyword is not necessary.
 
         skipna : bool, default True
             Exclude NA/null values. If an entire row/column is NA, the result
@@ -2254,8 +2276,9 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
             :class:`DataFrameGroupBy` ``axis`` argument is ``1``, using ``axis=0``
             or ``axis=1`` here will produce the same results.
 
-            .. deprecated:: 2.0.0
-                Use frame.T.groupby(...) instead.
+            .. deprecated:: 2.1.0
+                For axis=1, operate on the underlying object instead. Otherwise
+                the axis keyword is not necessary.
 
         inplace : bool, default False
             Broken. Do not set to True.
@@ -2380,6 +2403,11 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         axis : {0 or 'index', 1 or 'columns', None}, default 0
             The axis on which to select elements. ``0`` means that we are
             selecting rows, ``1`` means that we are selecting columns.
+
+            .. deprecated:: 2.1.0
+                For axis=1, operate on the underlying object instead. Otherwise
+                the axis keyword is not necessary.
+
         **kwargs
             For compatibility with :meth:`numpy.take`. Has no effect on the
             output.
@@ -2472,6 +2500,10 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
             Specifying ``axis=None`` will apply the aggregation across both axes.
 
             .. versionadded:: 2.0.0
+
+            .. deprecated:: 2.1.0
+                For axis=1, operate on the underlying object instead. Otherwise
+                the axis keyword is not necessary.
 
         skipna : bool, default True
             Exclude NA/null values when computing the result.

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -814,7 +814,7 @@ class SeriesGroupBy(GroupBy[Series]):
         self,
         value: object | ArrayLike | None = None,
         method: FillnaOptions | None = None,
-        axis: Axis | None = None,
+        axis: Axis | None = lib.no_default,
         inplace: bool = False,
         limit: int | None = None,
         downcast: dict | None = None,
@@ -919,7 +919,7 @@ class SeriesGroupBy(GroupBy[Series]):
     def take(
         self,
         indices: TakeIndexer,
-        axis: Axis = 0,
+        axis: Axis | lib.NoDefault = lib.no_default,
         **kwargs,
     ) -> Series:
         """
@@ -1095,12 +1095,16 @@ class SeriesGroupBy(GroupBy[Series]):
         return result
 
     @doc(Series.idxmin.__doc__)
-    def idxmin(self, axis: Axis = 0, skipna: bool = True) -> Series:
+    def idxmin(
+        self, axis: Axis | lib.NoDefault = lib.no_default, skipna: bool = True
+    ) -> Series:
         result = self._op_via_apply("idxmin", axis=axis, skipna=skipna)
         return result.astype(self.obj.index.dtype) if result.empty else result
 
     @doc(Series.idxmax.__doc__)
-    def idxmax(self, axis: Axis = 0, skipna: bool = True) -> Series:
+    def idxmax(
+        self, axis: Axis | lib.NoDefault = lib.no_default, skipna: bool = True
+    ) -> Series:
         result = self._op_via_apply("idxmax", axis=axis, skipna=skipna)
         return result.astype(self.obj.index.dtype) if result.empty else result
 
@@ -1922,7 +1926,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
     def idxmax(
         self,
-        axis: Axis | None = None,
+        axis: Axis | None | lib.NoDefault = lib.no_default,
         skipna: bool = True,
         numeric_only: bool = False,
     ) -> DataFrame:
@@ -1994,7 +1998,12 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         Beef              co2_emissions
         dtype: object
         """
-        if axis is None:
+        if axis is not lib.no_default:
+            if axis is None:
+                axis = self.axis
+            axis = self.obj._get_axis_number(axis)
+            self._deprecate_axis(axis, "idxmax")
+        else:
             axis = self.axis
 
         def func(df):
@@ -2008,7 +2017,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
     def idxmin(
         self,
-        axis: Axis | None = None,
+        axis: Axis | None | lib.NoDefault = lib.no_default,
         skipna: bool = True,
         numeric_only: bool = False,
     ) -> DataFrame:
@@ -2080,7 +2089,12 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         Beef                consumption
         dtype: object
         """
-        if axis is None:
+        if axis is not lib.no_default:
+            if axis is None:
+                axis = self.axis
+            axis = self.obj._get_axis_number(axis)
+            self._deprecate_axis(axis, "idxmin")
+        else:
             axis = self.axis
 
         def func(df):
@@ -2211,7 +2225,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         self,
         value: Hashable | Mapping | Series | DataFrame = None,
         method: FillnaOptions | None = None,
-        axis: Axis | None = None,
+        axis: Axis | None | lib.NoDefault = lib.no_default,
         inplace: bool = False,
         limit=None,
         downcast=None,
@@ -2345,7 +2359,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
     def take(
         self,
         indices: TakeIndexer,
-        axis: Axis | None = 0,
+        axis: Axis | None | lib.NoDefault = lib.no_default,
         **kwargs,
     ) -> DataFrame:
         """
@@ -2598,7 +2612,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
     def corrwith(
         self,
         other: DataFrame | Series,
-        axis: Axis = 0,
+        axis: Axis | lib.NoDefault = lib.no_default,
         drop: bool = False,
         method: CorrelationMethod = "pearson",
         numeric_only: bool = False,

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -3507,6 +3507,10 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         axis : int, default 0
             The axis of the object over which to compute the rank.
 
+            .. deprecated:: 2.1.0
+                For axis=1, operate on the underlying object instead. Otherwise
+                the axis keyword is not necessary.
+
         Returns
         -------
         DataFrame with ranking of values within each group
@@ -3857,6 +3861,11 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             Frequency string.
         axis : axis to shift, default 0
             Shift direction.
+
+            .. deprecated:: 2.1.0
+                For axis=1, operate on the underlying object instead. Otherwise
+                the axis keyword is not necessary.
+
         fill_value : optional
             The scalar value to use for newly introduced missing values.
 
@@ -3911,6 +3920,10 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             Periods to shift for calculating difference, accepts negative values.
         axis : axis to shift, default 0
             Take difference over rows (0) or columns (1).
+
+            .. deprecated:: 2.1.0
+                For axis=1, operate on the underlying object instead. Otherwise
+                the axis keyword is not necessary.
 
         Returns
         -------

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -228,14 +228,18 @@ def test_std_masked_dtype(any_numeric_ea_dtype):
 
 def test_agg_str_with_kwarg_axis_1_raises(df, reduction_func):
     gb = df.groupby(level=0)
+    warn_msg = f"DataFrameGroupBy.{reduction_func} with axis=1 is deprecated"
     if reduction_func in ("idxmax", "idxmin"):
         error = TypeError
         msg = "reduction operation '.*' not allowed for this dtype"
+        warn = FutureWarning
     else:
         error = ValueError
         msg = f"Operation {reduction_func} does not support axis=1"
+        warn = None
     with pytest.raises(error, match=msg):
-        gb.agg(reduction_func, axis=1)
+        with tm.assert_produces_warning(warn, match=warn_msg):
+            gb.agg(reduction_func, axis=1)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -343,10 +343,15 @@ def test_cython_api2():
     tm.assert_frame_equal(result, expected)
 
     # GH 13994
-    result = df.groupby("A").cumsum(axis=1)
+    msg = "DataFrameGroupBy.cumsum with axis=1 is deprecated"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        result = df.groupby("A").cumsum(axis=1)
     expected = df.cumsum(axis=1)
     tm.assert_frame_equal(result, expected)
-    result = df.groupby("A").cumprod(axis=1)
+
+    msg = "DataFrameGroupBy.cumprod with axis=1 is deprecated"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        result = df.groupby("A").cumprod(axis=1)
     expected = df.cumprod(axis=1)
     tm.assert_frame_equal(result, expected)
 
@@ -499,7 +504,9 @@ def test_idxmin_idxmax_axis1():
 
     gb = df.groupby("A")
 
-    res = gb.idxmax(axis=1)
+    warn_msg = "DataFrameGroupBy.idxmax with axis=1 is deprecated"
+    with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+        res = gb.idxmax(axis=1)
 
     alt = df.iloc[:, 1:].idxmax(axis=1)
     indexer = res.index.get_level_values(1)
@@ -511,7 +518,8 @@ def test_idxmin_idxmax_axis1():
 
     msg = "reduction operation 'argmax' not allowed for this dtype"
     with pytest.raises(TypeError, match=msg):
-        gb2.idxmax(axis=1)
+        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+            gb2.idxmax(axis=1)
 
 
 @pytest.mark.parametrize("numeric_only", [True, False, None])
@@ -549,10 +557,16 @@ def test_axis1_numeric_only(request, groupby_func, numeric_only):
         "idxmax",
         "fillna",
     )
+    warn_msg = f"DataFrameGroupBy.{groupby_func} with axis=1 is deprecated"
     if numeric_only is not None and groupby_func in no_args:
         msg = "got an unexpected keyword argument 'numeric_only'"
-        with pytest.raises(TypeError, match=msg):
-            method(*args, **kwargs)
+        if groupby_func in ["cumprod", "cumsum"]:
+            with pytest.raises(TypeError, match=msg):
+                with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+                    method(*args, **kwargs)
+        else:
+            with pytest.raises(TypeError, match=msg):
+                method(*args, **kwargs)
     elif groupby_func not in has_axis:
         msg = "got an unexpected keyword argument 'axis'"
         with pytest.raises(TypeError, match=msg):
@@ -571,9 +585,11 @@ def test_axis1_numeric_only(request, groupby_func, numeric_only):
             "unsupported operand type",
         )
         with pytest.raises(TypeError, match=f"({'|'.join(msgs)})"):
-            method(*args, **kwargs)
+            with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+                method(*args, **kwargs)
     else:
-        result = method(*args, **kwargs)
+        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+            result = method(*args, **kwargs)
 
         df_expected = df.drop(columns="E").T if numeric_only else df.T
         expected = getattr(df_expected, groupby_func)(*args).T
@@ -1599,7 +1615,11 @@ def test_groupby_empty_dataset(dtype, kwargs):
 def test_corrwith_with_1_axis():
     # GH 47723
     df = DataFrame({"a": [1, 1, 2], "b": [3, 7, 4]})
-    result = df.groupby("a").corrwith(df, axis=1)
+    gb = df.groupby("a")
+
+    msg = "DataFrameGroupBy.corrwith with axis=1 is deprecated"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        result = gb.corrwith(df, axis=1)
     index = Index(
         data=[(1, 0), (1, 1), (1, 2), (2, 2), (2, 0), (2, 1)],
         name=("a", None),

--- a/pandas/tests/groupby/test_rank.py
+++ b/pandas/tests/groupby/test_rank.py
@@ -622,7 +622,9 @@ def test_rank_multiindex():
     msg = "DataFrame.groupby with axis=1 is deprecated"
     with tm.assert_produces_warning(FutureWarning, match=msg):
         gb = df.groupby(level=0, axis=1)
-    result = gb.rank(axis=1)
+    msg = "DataFrameGroupBy.rank with axis=1 is deprecated"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        result = gb.rank(axis=1)
 
     expected = concat(
         [
@@ -645,7 +647,9 @@ def test_groupby_axis0_rank_axis1():
     with tm.assert_produces_warning(FutureWarning, match=msg):
         gb = df.groupby(level=0, axis=0)
 
-    res = gb.rank(axis=1)
+    msg = "DataFrameGroupBy.rank with axis=1 is deprecated"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        res = gb.rank(axis=1)
 
     # This should match what we get when "manually" operating group-by-group
     expected = concat([df.loc["a"].rank(axis=1), df.loc["b"].rank(axis=1)], axis=0)
@@ -653,7 +657,9 @@ def test_groupby_axis0_rank_axis1():
 
     # check that we haven't accidentally written a case that coincidentally
     # matches rank(axis=0)
-    alt = gb.rank(axis=0)
+    msg = "The 'axis' keyword in DataFrameGroupBy.rank"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        alt = gb.rank(axis=0)
     assert not alt.equals(expected)
 
 
@@ -669,7 +675,9 @@ def test_groupby_axis0_cummax_axis1():
     with tm.assert_produces_warning(FutureWarning, match=msg):
         gb = df.groupby(level=0, axis=0)
 
-    cmax = gb.cummax(axis=1)
+    msg = "DataFrameGroupBy.cummax with axis=1 is deprecated"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        cmax = gb.cummax(axis=1)
     expected = df[[0, 1]].astype(np.float64)
     expected[2] = expected[1]
     tm.assert_frame_equal(cmax, expected)


### PR DESCRIPTION
- [x] closes #50405 (Replace xxxx with the GitHub issue number)
- [x] closes #51046
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

@rhshadrach can you confirm this closes #50405