### PR TITLE
DOC: remove private parameters from method/constructor signatures

### DIFF
--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -29,7 +29,7 @@ class SeriesConstructor:
         Series(data=None, index=self.idx)
 
     def time_constructor_fastpath(self):
-        Series(self.array, index=self.idx2, name="name", fastpath=True)
+        Series(self.array, index=self.idx2, name="name", _fastpath=True)
 
 
 class ToFrame:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -14,6 +14,7 @@ import importlib
 import inspect
 import logging
 import os
+import re
 import sys
 import warnings
 
@@ -765,6 +766,19 @@ def process_business_alias_docstrings(app, what, name, obj, options, lines):
         lines[:] = []
 
 
+def process_signature(app, what, name, obj, options, signature, return_annotation):
+    """
+    Remove all the private (starting with underscore) parameters from the signature
+    of class constructors and other functions.
+    """
+    if signature:
+        # matches parameters starting with underscore `_`
+        pattern = r",[\s\t]*_[a-zA-Z0-9_:\s=]*"
+
+        signature_without_private_args = re.sub(pattern, "", signature)
+        return (signature_without_private_args, return_annotation)
+
+
 suppress_warnings = [
     # We "overwrite" autosummary with our PandasAutosummary, but
     # still want the regular autosummary setup to run. So we just
@@ -795,6 +809,7 @@ def setup(app):
     app.connect("autodoc-process-docstring", remove_flags_docstring)
     app.connect("autodoc-process-docstring", process_class_docstrings)
     app.connect("autodoc-process-docstring", process_business_alias_docstrings)
+    app.connect("autodoc-process-signature", process_signature)
     app.add_autodocumenter(AccessorDocumenter)
     app.add_autodocumenter(AccessorAttributeDocumenter)
     app.add_autodocumenter(AccessorMethodDocumenter)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4277,7 +4277,7 @@ class DataFrame(NDFrame, OpsMixin):
         name = self.columns[loc]
         klass = self._constructor_sliced
         # We get index=self.index bc values is a SingleDataManager
-        return klass(values, name=name, fastpath=True).__finalize__(self)
+        return klass(values, name=name, _fastpath=True).__finalize__(self)
 
     # ----------------------------------------------------------------------
     # Lookup Caching
@@ -4924,7 +4924,7 @@ class DataFrame(NDFrame, OpsMixin):
     def _series(self):
         return {
             item: Series(
-                self._mgr.iget(idx), index=self.index, name=item, fastpath=True
+                self._mgr.iget(idx), index=self.index, name=item, _fastpath=True
             )
             for idx, item in enumerate(self.columns)
         }

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -1274,7 +1274,7 @@ class SeriesSplitter(DataSplitter):
     def _chop(self, sdata: Series, slice_obj: slice) -> Series:
         # fastpath equivalent to `sdata.iloc[slice_obj]`
         mgr = sdata._mgr.get_slice(slice_obj)
-        ser = sdata._constructor(mgr, name=sdata.name, fastpath=True)
+        ser = sdata._constructor(mgr, name=sdata.name, _fastpath=True)
         return ser.__finalize__(sdata, method="groupby")
 
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -377,7 +377,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         dtype: Dtype | None = None,
         name=None,
         copy: bool = False,
-        fastpath: bool = False,
+        _fastpath: bool = False,
     ) -> None:
         if (
             isinstance(data, (SingleBlockManager, SingleArrayManager))
@@ -387,7 +387,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         ):
             # GH#33357 called with just the SingleBlockManager
             NDFrame.__init__(self, data)
-            if fastpath:
+            if _fastpath:
                 # e.g. from _box_col_values, skip validation of name
                 object.__setattr__(self, "_name", name)
             else:
@@ -395,7 +395,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             return
 
         # we are called internally, so short-circuit
-        if fastpath:
+        if _fastpath:
             # data is a ndarray, index is defined
             if not isinstance(data, (SingleBlockManager, SingleArrayManager)):
                 manager = get_option("mode.data_manager")


### PR DESCRIPTION
- [x] closes #52028
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.


The documentation (e.g. for Series constructor) contain the parameters which are used only internally (fastpath in case of Series). Now if a parameter is private and prefixed with an underscore `_` it will not be part of the signature in the output.
