### PR TITLE
REF: simplify Series.apply

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1690,8 +1690,7 @@ def map_array(
         mapping correspondence.
     convert : bool, default True
         Try to find better dtype for elementwise function results. If
-        False, leave as dtype=object. Note that the dtype is always
-        preserved for some extension array dtypes, such as Categorical.
+        False, leave as dtype=object.
 
     Returns
     -------

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1673,7 +1673,10 @@ def union_with_duplicates(
 
 
 def map_array(
-    arr: ArrayLike, mapper, na_action: Literal["ignore"] | None = None
+    arr: ArrayLike,
+    mapper,
+    na_action: Literal["ignore"] | None = None,
+    convert: bool = True,
 ) -> np.ndarray | ExtensionArray | Index:
     """
     Map values using an input mapping or function.
@@ -1685,6 +1688,10 @@ def map_array(
     na_action : {None, 'ignore'}, default None
         If 'ignore', propagate NA values, without passing them to the
         mapping correspondence.
+    convert : bool, default True
+        Try to find better dtype for elementwise function results. If
+        False, leave as dtype=object. Note that the dtype is always
+        preserved for some extension array dtypes, such as Categorical.
 
     Returns
     -------
@@ -1739,6 +1746,8 @@ def map_array(
     # we must convert to python types
     values = arr.astype(object, copy=False)
     if na_action is None:
-        return lib.map_infer(values, mapper)
+        return lib.map_infer(values, mapper, convert=convert)
     else:
-        return lib.map_infer_mask(values, mapper, isna(values).view(np.uint8))
+        return lib.map_infer_mask(
+            values, mapper, mask=isna(values).view(np.uint8), convert=convert
+        )

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -865,7 +865,7 @@ class IndexOpsMixin(OpsMixin):
         return func(skipna=skipna, **kwds)
 
     @final
-    def _map_values(self, mapper, na_action=None):
+    def _map_values(self, mapper, na_action=None, convert: bool = True):
         """
         An internal function that maps values using the input
         correspondence (which can be a dict, Series, or function).
@@ -877,6 +877,10 @@ class IndexOpsMixin(OpsMixin):
         na_action : {None, 'ignore'}
             If 'ignore', propagate NA values, without passing them to the
             mapping function
+        convert : bool, default True
+            Try to find better dtype for elementwise function results. If
+            False, leave as dtype=object. Note that the dtype is always
+            preserved for some extension array dtypes, such as Categorical.
 
         Returns
         -------
@@ -894,7 +898,7 @@ class IndexOpsMixin(OpsMixin):
         # "Union[IndexOpsMixin, ExtensionArray, ndarray[Any, Any]]";
         # expected "Union[ExtensionArray, ndarray[Any, Any]]"
         return algorithms.map_array(
-            arr, mapper, na_action=na_action  # type: ignore[arg-type]
+            arr, mapper, na_action=na_action, convert=convert  # type: ignore[arg-type]
         )
 
     @final


### PR DESCRIPTION
Simplify Series.apply by using `Series._map_values` instead of having custom mapping functionality.