### PR TITLE
PERF: Improve performance with copy=True and different dtype

### DIFF
--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -17,6 +17,7 @@ from numpy import ma
 
 from pandas._libs import lib
 
+from pandas.core.dtypes.astype import astype_is_view
 from pandas.core.dtypes.cast import (
     construct_1d_arraylike_from_scalar,
     dict_compat,
@@ -293,6 +294,11 @@ def ndarray_to_mgr(
 
     elif isinstance(values, (np.ndarray, ExtensionArray, ABCSeries, Index)):
         # drop subclass info
+        _copy = (
+            copy_on_sanitize
+            if (dtype is None or astype_is_view(values.dtype, dtype))
+            else False
+        )
         values = np.array(values, copy=copy_on_sanitize)
         values = _ensure_2d(values)
 

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -299,7 +299,7 @@ def ndarray_to_mgr(
             if (dtype is None or astype_is_view(values.dtype, dtype))
             else False
         )
-        values = np.array(values, copy=copy_on_sanitize)
+        values = np.array(values, copy=_copy)
         values = _ensure_2d(values)
 
     else:


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This cuts runtime roughly in half when dtype is different than the dtype from values

```
# main
%timeit DataFrame(arr, dtype="int32", copy=True)
6.01 ms ± 37.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# pr
%timeit DataFrame(arr, dtype="int32", copy=True)
3.54 ms ± 25.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```