### PR TITLE
PERF: Fix performance regression in read_csv when converting datetimes

### DIFF
--- a/pandas/io/parsers/base_parser.py
+++ b/pandas/io/parsers/base_parser.py
@@ -60,7 +60,10 @@ from pandas.core.dtypes.dtypes import (
 )
 from pandas.core.dtypes.missing import isna
 
-from pandas import StringDtype
+from pandas import (
+    DatetimeIndex,
+    StringDtype,
+)
 from pandas.core import algorithms
 from pandas.core.arrays import (
     ArrowExtensionArray,
@@ -1116,14 +1119,19 @@ def _make_date_converter(
                 date_format.get(col) if isinstance(date_format, dict) else date_format
             )
 
-            return tools.to_datetime(
+            result = tools.to_datetime(
                 ensure_object(strs),
                 format=date_fmt,
                 utc=False,
                 dayfirst=dayfirst,
                 errors="ignore",
                 cache=cache_dates,
-            )._values
+            )
+            if isinstance(result, DatetimeIndex):
+                # Item "ExtensionArray" of "Union[ExtensionArray, ndarray[Any, Any]]"
+                # has no attribute "_ndarray"
+                return result._values._ndarray  # type: ignore[union-attr]
+            return result._values
         else:
             try:
                 result = tools.to_datetime(

--- a/pandas/io/parsers/base_parser.py
+++ b/pandas/io/parsers/base_parser.py
@@ -1128,9 +1128,9 @@ def _make_date_converter(
                 cache=cache_dates,
             )
             if isinstance(result, DatetimeIndex):
-                # Item "ExtensionArray" of "Union[ExtensionArray, ndarray[Any, Any]]"
-                # has no attribute "_ndarray"
-                return result._values._ndarray  # type: ignore[union-attr]
+                arr = result.to_numpy()
+                arr.flags.writeable = True
+                return arr
             return result._values
         else:
             try:


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

the read-only pr changed this to _values which returns a DatetimeArray instead of a ndarray, which caused a performance regression 

https://asv-runner.github.io/asv-collection/pandas/#io.csv.ReadCSVConcatDatetime.time_read_csv