### PR TITLE
Optimizing the code for autotyping

### DIFF
--- a/scripts/run_autotyping.py
+++ b/scripts/run_autotyping.py
@@ -14,10 +14,8 @@ from typing import Sequence
 
 def main(argv: Sequence[str] | None = None) -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("paths", nargs="*")
+    parser.add_argument("paths", nargs="*", default=[])
     args = parser.parse_args(argv)
-    if not args.paths:
-        sys.exit(0)
     output = subprocess.run(
         [
             "python",
@@ -29,10 +27,11 @@ def main(argv: Sequence[str] | None = None) -> None:
             "--aggressive",
             "--no-format",
         ],
-        check=True,
+        capture_output=True,
     )
     sys.exit(output.returncode)
 
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
1) Use argparse's default argument instead of checking if not args.paths 
2) Use subprocess.run()'s capture_output argument instead of check=True to capture the output of the command 
3) Use sys.exit(output.returncode) directly instead of checking the return code

- [ ] closes #52067 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
