### PR TITLE
DOC: Fix docstring for `pandas.util._decorators.doc`

### DIFF
--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -339,7 +339,7 @@ def deprecate_nonkeyword_arguments(
 
 def doc(*docstrings: None | str | Callable, **params) -> Callable[[F], F]:
     """
-    A decorator take docstring templates, concatenate them and perform string
+    A decorator to take docstring templates, concatenate them and perform string
     substitution on it.
 
     This decorator will add a variable "_docstring_components" to the wrapped

--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -340,7 +340,7 @@ def deprecate_nonkeyword_arguments(
 def doc(*docstrings: None | str | Callable, **params) -> Callable[[F], F]:
     """
     A decorator to take docstring templates, concatenate them and perform string
-    substitution on it.
+    substitution on them.
 
     This decorator will add a variable "_docstring_components" to the wrapped
     callable to keep track the original docstring template for potential usage.


### PR DESCRIPTION
Trivial PR to fix something I noticed while reading pandas source code. I think most of the below checks don't apply.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
