### PR TITLE
BUG: info raising when use_numba is set

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -162,6 +162,7 @@ Numeric
 Conversion
 ^^^^^^^^^^
 - Bug in :meth:`ArrowDtype.numpy_dtype` returning nanosecond units for non-nanosecond ``pyarrow.timestamp`` and ``pyarrow.duration`` types (:issue:`51800`)
+- Bug in :meth:`DataFrame.info` raising  ``ValueError`` when ``use_numba`` is set (:issue:`51922`)
 -
 
 Strings

--- a/pandas/io/formats/info.py
+++ b/pandas/io/formats/info.py
@@ -14,6 +14,8 @@ from typing import (
     Sequence,
 )
 
+import numpy as np
+
 from pandas._config import get_option
 
 from pandas.io.formats import format as fmt
@@ -1097,4 +1099,4 @@ def _get_dataframe_dtype_counts(df: DataFrame) -> Mapping[str, int]:
     Create mapping between datatypes and their number of occurrences.
     """
     # groupby dtype.name to collect e.g. Categorical columns
-    return df.dtypes.value_counts().groupby(lambda x: x.name).sum()
+    return df.dtypes.value_counts().groupby(lambda x: x.name).sum().astype(np.intp)

--- a/pandas/tests/io/formats/test_info.py
+++ b/pandas/tests/io/formats/test_info.py
@@ -11,6 +11,7 @@ from pandas.compat import (
     IS64,
     PYPY,
 )
+import pandas.util._test_decorators as td
 
 from pandas import (
     CategoricalIndex,
@@ -501,3 +502,19 @@ def test_memory_usage_empty_no_warning():
         result = df.memory_usage()
     expected = Series(16 if IS64 else 8, index=["Index"])
     tm.assert_series_equal(result, expected)
+
+
+@td.skip_if_no("numba")
+def test_info_compute_numba():
+    # GH#51922
+    df = DataFrame([[1, 2], [3, 4]])
+
+    with option_context("compute.use_numba", True):
+        buf = StringIO()
+        df.info()
+        result = buf.getvalue()
+
+    buf = StringIO()
+    df.info()
+    expected = buf.getvalue()
+    assert result == expected


### PR DESCRIPTION
- [x] closes #51922 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Alternative would be to reimplement sum for numba to return int when int input is given