### PR TITLE
PERF: improve 2D array access / transpose() for masked dtypes

### DIFF
--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -142,6 +142,9 @@ class BooleanDtype(BaseMaskedDtype):
             return BooleanArray._concat_same_type(results)
 
 
+_boolean_dtype = BooleanDtype()
+
+
 def coerce_to_array(
     values, mask=None, copy: bool = False
 ) -> tuple[np.ndarray, np.ndarray]:
@@ -299,7 +302,7 @@ class BooleanArray(BaseMaskedArray):
                 "values should be boolean numpy array. Use "
                 "the 'pd.array' function instead"
             )
-        self._dtype = BooleanDtype()
+        self._dtype = _boolean_dtype
         super().__init__(values, mask, copy=copy)
 
     @property

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -104,6 +104,7 @@ def arrays_to_mgr(
     verify_integrity: bool = True,
     typ: str | None = None,
     consolidate: bool = True,
+    is_1d_ea_only: bool = False,
 ) -> Manager:
     """
     Segregate Series based on type and coerce into matrices.
@@ -127,7 +128,8 @@ def arrays_to_mgr(
 
     else:
         index = ensure_index(index)
-        arrays = [extract_array(x, extract_numpy=True) for x in arrays]
+        if not is_1d_ea_only:
+            arrays = [extract_array(x, extract_numpy=True) for x in arrays]
         # with _from_arrays, the passed arrays should never be Series objects
         refs = [None] * len(arrays)
 
@@ -152,7 +154,7 @@ def arrays_to_mgr(
 
     if typ == "block":
         return create_block_manager_from_column_arrays(
-            arrays, axes, consolidate=consolidate, refs=refs
+            arrays, axes, consolidate, refs=refs, is_1d_ea_only=is_1d_ea_only
         )
     elif typ == "array":
         return ArrayManager(arrays, [index, columns])


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/52016

For `transpose()` or operations that do a transpose under the hood (eg typically operations with axis=1), this is generally expensive if you have extension dtypes. This explores the possibilities to add a fast path for the specific case of a DataFrame with all-masked dtypes.

Using the example dataframe from https://github.com/pandas-dev/pandas/issues/52016, this gives a speed-up 

```python
shape = 250_000, 100
mask = pd.DataFrame(np.random.randint(0, 1, size=shape))

np_mask = mask.astype(bool)
pd_mask = mask.astype(pd.BooleanDtype())

%timeit pd_mask.transpose()
# 9.13 s ± 347 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)   <-- main
# 689 ms ± 28.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)  <-- PR
```


Note there are some various different optimizations added together (that can be splitted, and still needs to be cleaned-up in general). 
The main speed-up comes from calling `BooleanArray(..)` instead of `BooleanArray._from_sequence(..)` (or in general with any other masked array class), because this generic `_from_sequence` has a lot of overhead (that adds up when calling it 250_000 times as in this example). To be able to use the main `__init__`, I added a version of `mgr.as_array()` to return separate data and mask arrays. 

Further, after the arrays are constructed, the BlockManager construction can be optimized by passing `verify_integrity=False` and by knowing that we have all 1D EAs (so no need to do block dtype grouping etc). 
Another tiny optimization is in the BooleanArray(..) to avoid creating a new dtype instance every time (this can easily be split of, we might want to do that generally for all primitive dtypes, and maybe rather in the init of the dtype)