### PR TITLE
PERF: get_block_type

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -106,7 +106,6 @@ from pandas.core.arrays import (
     PeriodArray,
     TimedeltaArray,
 )
-from pandas.core.arrays.sparse import SparseDtype
 from pandas.core.base import PandasObject
 import pandas.core.common as com
 from pandas.core.computation import expressions
@@ -2341,10 +2340,7 @@ def get_block_type(dtype: DtypeObj) -> type[Block]:
     -------
     cls : class, subclass of Block
     """
-    if isinstance(dtype, SparseDtype):
-        # Need this first(ish) so that Sparse[datetime] is sparse
-        return ExtensionBlock
-    elif isinstance(dtype, DatetimeTZDtype):
+    if isinstance(dtype, DatetimeTZDtype):
         return DatetimeTZBlock
     elif isinstance(dtype, PeriodDtype):
         return NDArrayBackedExtensionBlock
@@ -2355,9 +2351,9 @@ def get_block_type(dtype: DtypeObj) -> type[Block]:
     # We use kind checks because it is much more performant
     #  than is_foo_dtype
     kind = dtype.kind
-    if kind in ["M", "m"]:
+    if kind in "Mm":
         return DatetimeLikeBlock
-    elif kind in ["f", "c", "i", "u", "b"]:
+    elif kind in "fciub":
         return NumericBlock
 
     return ObjectBlock

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2329,7 +2329,7 @@ def maybe_coerce_values(values: ArrayLike) -> ArrayLike:
     return values
 
 
-def get_block_type(dtype: DtypeObj):
+def get_block_type(dtype: DtypeObj) -> type[Block]:
     """
     Find the appropriate Block subclass to use for the given values and dtype.
 
@@ -2341,30 +2341,26 @@ def get_block_type(dtype: DtypeObj):
     -------
     cls : class, subclass of Block
     """
+    if isinstance(dtype, SparseDtype):
+        # Need this first(ish) so that Sparse[datetime] is sparse
+        return ExtensionBlock
+    elif isinstance(dtype, DatetimeTZDtype):
+        return DatetimeTZBlock
+    elif isinstance(dtype, PeriodDtype):
+        return NDArrayBackedExtensionBlock
+    elif isinstance(dtype, ExtensionDtype):
+        # Note: need to be sure PandasArray is unwrapped before we get here
+        return ExtensionBlock
+
     # We use kind checks because it is much more performant
     #  than is_foo_dtype
     kind = dtype.kind
-
-    cls: type[Block]
-
-    if isinstance(dtype, SparseDtype):
-        # Need this first(ish) so that Sparse[datetime] is sparse
-        cls = ExtensionBlock
-    elif isinstance(dtype, DatetimeTZDtype):
-        cls = DatetimeTZBlock
-    elif isinstance(dtype, PeriodDtype):
-        cls = NDArrayBackedExtensionBlock
-    elif isinstance(dtype, ExtensionDtype):
-        # Note: need to be sure PandasArray is unwrapped before we get here
-        cls = ExtensionBlock
-
-    elif kind in ["M", "m"]:
-        cls = DatetimeLikeBlock
+    if kind in ["M", "m"]:
+        return DatetimeLikeBlock
     elif kind in ["f", "c", "i", "u", "b"]:
-        cls = NumericBlock
-    else:
-        cls = ObjectBlock
-    return cls
+        return NumericBlock
+
+    return ObjectBlock
 
 
 def new_block_2d(


### PR DESCRIPTION
- [x] closes #48212
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

cc @jbrockmendel - this may partly close #48212, however, I suspect the OP was referring to non-EA's given the old version of pandas. 

Performance improvement is mostly for EA's where the `.kind` call can be a bottleneck.

```
import pyarrow as pa
import pandas as pd
from pandas.core.internals.blocks import get_block_type

%timeit get_block_type(pd.ArrowDtype(pa.float64()))
# 3.51 µs ± 440 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)    <- main
# 740 ns ± 5.19 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)  <- PR

%timeit get_block_type(pd.Float64Dtype())
# 1.3 µs ± 23.2 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)  <- main
# 289 ns ± 2.3 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)   <- PR
```