### PR TITLE
Add fillna_method 'pad' extension array tests

### DIFF
--- a/pandas/tests/extension/base/missing.py
+++ b/pandas/tests/extension/base/missing.py
@@ -117,7 +117,7 @@ class BaseMissingTests(BaseExtensionTests):
     def test_fillna_series_method(self, data_missing, fillna_method):
         fill_value = data_missing[1]
 
-        if fillna_method == "ffill":
+        if fillna_method in {"pad", "ffill"}:
             data_missing = data_missing[::-1]
 
         result = pd.Series(data_missing).fillna(method=fillna_method)

--- a/pandas/tests/extension/conftest.py
+++ b/pandas/tests/extension/conftest.py
@@ -169,10 +169,10 @@ def use_numpy(request):
     return request.param
 
 
-@pytest.fixture(params=["ffill", "bfill"])
+@pytest.fixture(params=["bfill", "pad", "ffill"])
 def fillna_method(request):
     """
-    Parametrized fixture giving method parameters 'ffill' and 'bfill' for
+    Parametrized fixture giving method parameters 'bfill', 'pad', and 'ffill' for
     Series.fillna(method=<method>) testing.
     """
     return request.param


### PR DESCRIPTION
Should we also be adding `'backfill'`?

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
