### PR TITLE
DOC: ddof in cov when nans present

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10563,7 +10563,7 @@ class DataFrame(NDFrame, OpsMixin):
         ddof : int, default 1
             Delta degrees of freedom.  The divisor used in calculations
             is ``N - ddof``, where ``N`` represents the number of elements.
-            This argument is applicable only when ``NaN``s are not present
+            This argument is applicable only when ``nan``\s are not present
             in the dataframe.
 
             .. versionadded:: 1.1.0

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10563,7 +10563,8 @@ class DataFrame(NDFrame, OpsMixin):
         ddof : int, default 1
             Delta degrees of freedom.  The divisor used in calculations
             is ``N - ddof``, where ``N`` represents the number of elements.
-            This argument is applicable only when ``nan``s are not present in the dataframe.
+            This argument is applicable only when ``nan``s are not present
+            in the dataframe.
 
             .. versionadded:: 1.1.0
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10563,7 +10563,7 @@ class DataFrame(NDFrame, OpsMixin):
         ddof : int, default 1
             Delta degrees of freedom.  The divisor used in calculations
             is ``N - ddof``, where ``N`` represents the number of elements.
-            This argument is applicable only when ``nan``\s are not present
+            This argument is applicable only when ``nan``\\s are not present
             in the dataframe.
 
             .. versionadded:: 1.1.0

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10563,7 +10563,7 @@ class DataFrame(NDFrame, OpsMixin):
         ddof : int, default 1
             Delta degrees of freedom.  The divisor used in calculations
             is ``N - ddof``, where ``N`` represents the number of elements.
-            This argument is applicable only when ``nan``\\s are not present
+            This argument is applicable only when ``nan``\ s are not present
             in the dataframe.
 
             .. versionadded:: 1.1.0

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10563,6 +10563,7 @@ class DataFrame(NDFrame, OpsMixin):
         ddof : int, default 1
             Delta degrees of freedom.  The divisor used in calculations
             is ``N - ddof``, where ``N`` represents the number of elements.
+            This argument is applicable only when ``nan``s are not present in the dataframe.
 
             .. versionadded:: 1.1.0
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10563,7 +10563,7 @@ class DataFrame(NDFrame, OpsMixin):
         ddof : int, default 1
             Delta degrees of freedom.  The divisor used in calculations
             is ``N - ddof``, where ``N`` represents the number of elements.
-            This argument is applicable only when ``nan``s are not present
+            This argument is applicable only when ``NaN``s are not present
             in the dataframe.
 
             .. versionadded:: 1.1.0

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10563,8 +10563,7 @@ class DataFrame(NDFrame, OpsMixin):
         ddof : int, default 1
             Delta degrees of freedom.  The divisor used in calculations
             is ``N - ddof``, where ``N`` represents the number of elements.
-            This argument is applicable only when ``nan``\ s are not present
-            in the dataframe.
+            This argument is applicable only when no ``nan`` is in the dataframe.
 
             .. versionadded:: 1.1.0
 


### PR DESCRIPTION
- [x] closes #47042
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This PR adds a document about the "``nan``s must not be present in the dataframe" restriction on ddof in pandas.DataFrame.cov.
