### PR TITLE
DOC: Simplify pandas theme footer

### DIFF
--- a/doc/source/_static/css/pandas.css
+++ b/doc/source/_static/css/pandas.css
@@ -36,17 +36,6 @@ table {
   padding: 2.5rem 0rem 0.5rem 0rem;
 }
 
-.intro-card .card-footer {
-  border: none;
-  background-color: transparent;
-}
-
-.intro-card .card-footer p.card-text{
-  max-width: 220px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
 .card, .card img {
   background-color: transparent !important;
 }

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -240,7 +240,7 @@ elif "rc" in version:
 
 html_theme_options = {
     "external_links": [],
-    "footer_items": ["pandas_footer", "sphinx-version"],
+    "footer_start": ["pandas_footer", "sphinx-version"],
     "github_url": "https://github.com/pandas-dev/pandas",
     "twitter_url": "https://twitter.com/pandas_dev",
     "google_analytics_id": "UA-27880019-2",

--- a/environment.yml
+++ b/environment.yml
@@ -87,7 +87,7 @@ dependencies:
   - gitdb
   - natsort  # DataFrame.sort_values doctest
   - numpydoc
-  - pydata-sphinx-theme<0.11
+  - pydata-sphinx-theme>=0.13.0
   - pytest-cython  # doctest
   - sphinx
   - sphinx-panels

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -62,7 +62,7 @@ gitpython
 gitdb
 natsort
 numpydoc
-pydata-sphinx-theme<0.11
+pydata-sphinx-theme>=0.13.0
 pytest-cython
 sphinx
 sphinx-panels


### PR DESCRIPTION
This pr is related to issue #51536.  The next changes were made:

1. Changed a version of `pydata-sphinx-theme` in environment.yml from less than 0.11 to 0.13.0
2. Updated my environment by running mamba env update -n pandas-dev --file environment.yml
3. In conf.py I changed `html_theme_options`. Now  "footer_start" is used instead of "footer_items”
4. In doc/source/_static/css/pandas.css where we override some aspects of `pydata-sphinx-theme` I removed `card-footer`
5. After cleaning and rebuilding documentation there is no footer in our html.

