### PR TITLE
CI: Use dependabot to update Github Actions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - "CI"
+      - "Dependencies"


### PR DESCRIPTION
Looks like dependabot finally removed enabling by default for forks (https://github.blog/changelog/2022-11-07-dependabot-pull-requests-off-by-default-for-forks/), so it would be nice to use it to keep our Github Actions up to date.

Mirrored off of Numpy's configuration but set the frequency to weekly: https://github.com/numpy/numpy/blob/main/.github/dependabot.yml