### PR TITLE
PERF: avoid exceptions in string.Construction benchmark setup

### DIFF
--- a/asv_bench/benchmarks/strings.py
+++ b/asv_bench/benchmarks/strings.py
@@ -34,7 +34,6 @@ class Construction:
 
         # GH37371. Testing construction of string series/frames from ExtensionArrays
         self.series_cat_arr = Categorical(self.series_arr)
-        self.frame_cat_arr = Categorical(self.frame_arr)
 
     def time_series_construction(self, dtype):
         Series(self.series_arr, dtype=dtype)
@@ -53,12 +52,6 @@ class Construction:
 
     def peakmem_cat_series_construction(self, dtype):
         Series(self.series_cat_arr, dtype=dtype)
-
-    def time_cat_frame_construction(self, dtype):
-        DataFrame(self.frame_cat_arr, dtype=dtype)
-
-    def peakmem_cat_frame_construction(self, dtype):
-        DataFrame(self.frame_cat_arr, dtype=dtype)
 
 
 class Methods(Dtypes):


### PR DESCRIPTION
#37371 added some new benchmarks, along with some new setup code for the new benchmarks. Unfortunately, the new setup code introduced an uncaught exception:

```
>>> import pandas._testing as tm
>>> from pandas import Categorical
>>> series_arr = tm.rands_array(nchars=10, size=10**5)
>>> frame_arr = series_arr.reshape((50_000, 2)).copy()
>>> frame_cat_arr = Categorical(frame_arr)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/nathan/Documents/pandas/pandas/core/arrays/categorical.py", line 399, in __init__
    raise NotImplementedError(
NotImplementedError: > 1 ndim Categorical are not supported at this time
```

This caused asv to skip all the string construction benchmarks since that PR was merged because the setup had an uncaught exception. See e.g. [this benchmark report](https://asv-runner.github.io/asv-collection/pandas/#strings.Construction.time_series_construction).

The fix is just to remove the broken benchmarks.

I built a version of pandas from just after #37371 was merged and verified that the benchmark was broken then. I can't easily verify that the benchmark has been broken the entire time since then but I strongly suspect that's the case.