### PR TITLE
BUG: set_levels not preserving categorical

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -200,7 +200,7 @@ Missing
 
 MultiIndex
 ^^^^^^^^^^
--
+- Bug in :meth:`MultiIndex.set_levels` not preserving dtypes for :class:`Categorical` (:issue:`52125`)
 -
 
 I/O

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -73,6 +73,7 @@ from pandas.core.dtypes.generic import (
     ABCDatetimeIndex,
     ABCTimedeltaIndex,
 )
+from pandas.core.dtypes.inference import is_array_like
 from pandas.core.dtypes.missing import (
     array_equivalent,
     isna,
@@ -945,7 +946,11 @@ class MultiIndex(Index):
         FrozenList([['a', 'b', 'c'], [1, 2, 3, 4]])
         """
 
-        if is_list_like(levels) and not isinstance(levels, Index):
+        if isinstance(levels, Index):
+            pass
+        elif is_array_like(levels):
+            levels = Index(levels)
+        else:
             levels = list(levels)
 
         level, levels = _require_listlike(level, levels, "Levels")

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -950,7 +950,7 @@ class MultiIndex(Index):
             pass
         elif is_array_like(levels):
             levels = Index(levels)
-        else:
+        elif is_list_like(levels):
             levels = list(levels)
 
         level, levels = _require_listlike(level, levels, "Levels")

--- a/pandas/tests/indexes/multi/test_get_set.py
+++ b/pandas/tests/indexes/multi/test_get_set.py
@@ -367,3 +367,11 @@ def test_set_levels_pos_args_removal():
 
     with pytest.raises(TypeError, match="positional arguments"):
         idx.set_codes([[0, 1], [1, 0]], 0)
+
+
+def test_set_levels_categorical_keep_dtype():
+    # GH#52125
+    midx = MultiIndex.from_arrays([[5, 6]])
+    result = midx.set_levels(levels=pd.Categorical([1, 2]), level=0)
+    expected = MultiIndex.from_arrays([pd.Categorical([1, 2])])
+    tm.assert_index_equal(result, expected)


### PR DESCRIPTION
- [x] closes #52125 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
