### PR TITLE
REF/TYP: stricter typing for Series._slice

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3758,18 +3758,10 @@ class DataFrame(NDFrame, OpsMixin):
 
             elif is_mi and self.columns.is_unique and key in self.columns:
                 return self._getitem_multilevel(key)
+
         # Do we have a slicer (on rows)?
         if isinstance(key, slice):
-            indexer = self.index._convert_slice_indexer(key, kind="getitem")
-            if isinstance(indexer, np.ndarray):
-                # reachable with DatetimeIndex
-                indexer = lib.maybe_indices_to_slice(
-                    indexer.astype(np.intp, copy=False), len(self)
-                )
-                if isinstance(indexer, np.ndarray):
-                    # GH#43223 If we can not convert, use take
-                    return self.take(indexer, axis=0)
-            return self._slice(indexer, axis=0)
+            return self._getitem_slice(key)
 
         # Do we have a (boolean) DataFrame?
         if isinstance(key, DataFrame):


### PR DESCRIPTION
Motivation is that Series._slice surprisingly accepts non-slice inputs.  Changing that required copying the slice-handling code from `DataFrame.__getitem__`, at which point it made sense to share that by implementing `NDFrame._getitem_slice`