### PR TITLE
BUG: Unexpected KeyError message when using .loc with MultiIndex in a possible edge-case

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2841,6 +2841,8 @@ class MultiIndex(Index):
             #  i.e. do we need _index_as_unique on that level?
             try:
                 return self._engine.get_loc(key)
+            except KeyError as err:
+                raise KeyError(key) from err
             except TypeError:
                 # e.g. test_partial_slicing_with_multiindex partial string slicing
                 loc, _ = self.get_loc_level(key, list(range(self.nlevels)))

--- a/pandas/tests/indexes/multi/test_drop.py
+++ b/pandas/tests/indexes/multi/test_drop.py
@@ -32,16 +32,16 @@ def test_drop(idx):
     tm.assert_index_equal(dropped, expected)
 
     index = MultiIndex.from_tuples([("bar", "two")])
-    with pytest.raises(KeyError, match=r"^15$"):
+    with pytest.raises(KeyError, match=r"^\('bar', 'two'\)$"):
         idx.drop([("bar", "two")])
-    with pytest.raises(KeyError, match=r"^15$"):
+    with pytest.raises(KeyError, match=r"^\('bar', 'two'\)$"):
         idx.drop(index)
     with pytest.raises(KeyError, match=r"^'two'$"):
         idx.drop(["foo", "two"])
 
     # partially correct argument
     mixed_index = MultiIndex.from_tuples([("qux", "one"), ("bar", "two")])
-    with pytest.raises(KeyError, match=r"^15$"):
+    with pytest.raises(KeyError, match=r"^\('bar', 'two'\)$"):
         idx.drop(mixed_index)
 
     # error='ignore'

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -565,7 +565,7 @@ class TestGetLoc:
     def test_get_loc(self, idx):
         assert idx.get_loc(("foo", "two")) == 1
         assert idx.get_loc(("baz", "two")) == 3
-        with pytest.raises(KeyError, match=r"^15$"):
+        with pytest.raises(KeyError, match=r"^\('bar', 'two'\)$"):
             idx.get_loc(("bar", "two"))
         with pytest.raises(KeyError, match=r"^'quux'$"):
             idx.get_loc("quux")

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -420,6 +420,18 @@ class TestMultiIndexLoc:
         )
         tm.assert_frame_equal(res, expected)
 
+    def test_loc_multi_index_key_error(self):
+        df = DataFrame(
+            {
+                (1, 2): ["a", "b", "c"],
+                (1, 3): ["d", "e", "f"],
+                (2, 2): ["g", "h", "i"],
+                (2, 4): ["j", "k", "l"],
+            }
+        )
+        with pytest.raises(KeyError, match=r"(1, 4)"):
+            df.loc[0, (1, 4)]
+
 
 @pytest.mark.parametrize(
     "indexer, pos",

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -421,6 +421,7 @@ class TestMultiIndexLoc:
         tm.assert_frame_equal(res, expected)
 
     def test_loc_multi_index_key_error(self):
+        # GH 51892
         df = DataFrame(
             {
                 (1, 2): ["a", "b", "c"],


### PR DESCRIPTION
- [x] closes #51892
- [ ] [Tests added and passed]
- [x] All [code checks passed]
- [ ] Added [type annotations]
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
