### PR TITLE
add extra test case in the test_constructor_str_infer_reso

### DIFF
--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -58,6 +58,12 @@ class TestTimestampConstructors:
         ts = Timestamp("2016 June 3 15:25:01.345")
         assert ts.unit == "ms"
 
+        ts = Timestamp("300-01-01")
+        assert ts.unit == "s"
+
+        ts = Timestamp("300 June 1:30:01.300")
+        assert ts.unit == "ms"
+
     def test_constructor_from_iso8601_str_with_offset_reso(self):
         # GH#49737
         ts = Timestamp("2016-01-01 04:05:06-01:00")


### PR DESCRIPTION
- [x] closes #51025
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

An extra test case is added to `test_constructor_str_infer_reso`  to check `Timestamp('300-01-01')`.

I suggest doing a parametrization for this test.