### PR TITLE
BUG: assert_frame_equal still checks category dtypes even when asked not to check index type

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -259,6 +259,7 @@ Other
 ^^^^^
 - Bug in :func:`assert_almost_equal` now throwing assertion error for two unequal sets (:issue:`51727`)
 - Bug in :meth:`Series.memory_usage` when ``deep=True`` throw an error with Series of objects and the returned value is incorrect, as it does not take into account GC corrections (:issue:`51858`)
+- Bug in :func:`assert_frame_equal` checks category dtypes even when asked not to check index type (:issue:`52126`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -294,6 +294,7 @@ def assert_index_equal(
                 exact=exact,
                 check_names=check_names,
                 check_exact=check_exact,
+                check_categorical=check_categorical,
                 rtol=rtol,
                 atol=atol,
                 obj=lobj,

--- a/pandas/tests/util/test_assert_index_equal.py
+++ b/pandas/tests/util/test_assert_index_equal.py
@@ -298,3 +298,16 @@ def test_assert_ea_index_equal_non_matching_na(check_names, check_categorical):
         tm.assert_index_equal(
             idx1, idx2, check_names=check_names, check_categorical=check_categorical
         )
+
+
+@pytest.mark.parametrize("check_categorical", [True, False])
+def test_assert_multi_index_dtype_check_categorical(check_categorical):
+    idx1 = MultiIndex.from_arrays([Categorical(np.array([1, 2], dtype=np.uint64))])
+    idx2 = MultiIndex.from_arrays([Categorical(np.array([1, 2], dtype=np.int64))])
+    if check_categorical:
+        with pytest.raises(
+            AssertionError, match=r"^MultiIndex level \[0\] are different"
+        ):
+            tm.assert_index_equal(idx1, idx2, check_categorical=check_categorical)
+    else:
+        tm.assert_index_equal(idx1, idx2, check_categorical=check_categorical)

--- a/pandas/tests/util/test_assert_index_equal.py
+++ b/pandas/tests/util/test_assert_index_equal.py
@@ -302,6 +302,7 @@ def test_assert_ea_index_equal_non_matching_na(check_names, check_categorical):
 
 @pytest.mark.parametrize("check_categorical", [True, False])
 def test_assert_multi_index_dtype_check_categorical(check_categorical):
+    # GH#52126
     idx1 = MultiIndex.from_arrays([Categorical(np.array([1, 2], dtype=np.uint64))])
     idx2 = MultiIndex.from_arrays([Categorical(np.array([1, 2], dtype=np.int64))])
     if check_categorical:


### PR DESCRIPTION
- [x] closes #52126
- [ ] [Tests added and passed]
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
