### PR TITLE
BUG: zero-pad shorter years in `Timestamp.isoformat`

### DIFF
--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1015,7 +1015,7 @@ cdef class _Timestamp(ABCTimestamp):
         base_ts = "microseconds" if timespec == "nanoseconds" else timespec
         base = super(_Timestamp, self).isoformat(sep=sep, timespec=base_ts)
         # We need to replace the fake year 1970 with our real year
-        base = f"{self.year}-" + base.split("-", 1)[1]
+        base = f"{self.year:04d}-" + base.split("-", 1)[1]
 
         if self.nanosecond == 0 and timespec != "nanoseconds":
             return base

--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -595,19 +595,16 @@ class TestTimestampConstructors:
         # GH 15829
         msg = "|".join(
             [
-                "Cannot cast 1-01-01 00:00:00 to unit='ns' without overflow",
-                "Out of bounds nanosecond timestamp: 1-01-01 00:00:00",
+                "Cannot cast 0001-01-01 00:00:00 to unit='ns' without overflow",
+                "Out of bounds nanosecond timestamp: 0001-01-01 00:00:00",
             ]
         )
         with pytest.raises(OutOfBoundsDatetime, match=msg):
             Timestamp(arg).as_unit("ns")
 
-        if arg == "0001-01-01":
-            # only the 4-digit year goes through ISO path which gets second reso
-            #  instead of ns reso
-            ts = Timestamp(arg)
-            assert ts.unit == "s"
-            assert ts.year == ts.month == ts.day == 1
+        ts = Timestamp(arg)
+        assert ts.unit == "s"
+        assert ts.year == ts.month == ts.day == 1
 
     def test_min_valid(self):
         # Ensure that Timestamp.min is a valid Timestamp

--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -593,12 +593,7 @@ class TestTimestampConstructors:
     @pytest.mark.parametrize("arg", ["001-01-01", "0001-01-01"])
     def test_out_of_bounds_string_consistency(self, arg):
         # GH 15829
-        msg = "|".join(
-            [
-                "Cannot cast 0001-01-01 00:00:00 to unit='ns' without overflow",
-                "Out of bounds nanosecond timestamp: 0001-01-01 00:00:00",
-            ]
-        )
+        msg = "Cannot cast 0001-01-01 00:00:00 to unit='ns' without overflow"
         with pytest.raises(OutOfBoundsDatetime, match=msg):
             Timestamp(arg).as_unit("ns")
 

--- a/pandas/tests/scalar/timestamp/test_formats.py
+++ b/pandas/tests/scalar/timestamp/test_formats.py
@@ -11,6 +11,15 @@ ts_no_ns = Timestamp(
     second=8,
     microsecond=132263,
 )
+ts_no_ns_year1 = Timestamp(
+    year=1,
+    month=5,
+    day=18,
+    hour=15,
+    minute=17,
+    second=8,
+    microsecond=132263,
+)
 ts_ns = Timestamp(
     year=2019,
     month=5,
@@ -50,6 +59,8 @@ ts_no_us = Timestamp(
         (ts_no_ns, "auto", "2019-05-18T15:17:08.132263"),
         (ts_no_ns, "seconds", "2019-05-18T15:17:08"),
         (ts_no_ns, "nanoseconds", "2019-05-18T15:17:08.132263000"),
+        (ts_no_ns_year1, "seconds", "0001-05-18T15:17:08"),
+        (ts_no_ns_year1, "nanoseconds", "0001-05-18T15:17:08.132263000"),
         (ts_ns, "auto", "2019-05-18T15:17:08.132263123"),
         (ts_ns, "hours", "2019-05-18T15"),
         (ts_ns, "minutes", "2019-05-18T15:17"),


### PR DESCRIPTION
As discussed in #50867, this changes `Timestamp.isoformat` to zero-pad years to 4 digits.

After applying the change, I also had to change a existing test because of the now-changed standard format, but also remove a condition which assumed that `"001-01-01"` and `"0001-01-01"` would result in different objects (not sure, maybe there was a time where the resulting `Timestamp` object would not be equal?). However, on current `main`:
```python
a = pd.Timestamp("001-01-01")
b = pd.Timestamp("0001-01-01")
a == b and a.unit == b.unit
```

cc @spencerkclark

No `whatsnew` entry yet because I was not sure where to put it.

- [x] closes #50867
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] ~Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.~
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
