### PR TITLE
CI: replace flake8-pyi with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         types_or: [python, pyi]
         additional_dependencies: [black==23.1.0]
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.255
+    rev: v0.0.259
     hooks:
     -   id: ruff
         args: [--exit-non-zero-on-fix]
@@ -392,14 +392,6 @@ repos:
         files: ^pandas/
         exclude: ^(pandas/_libs/|pandas/tests/|pandas/errors/__init__.py$|pandas/_version.py)
         types: [python]
-    -   id: flake8-pyi
-        name: flake8-pyi
-        entry: flake8 --extend-ignore=E301,E302,E305,E701,E704
-        types: [pyi]
-        language: python
-        additional_dependencies:
-        - flake8==5.0.4
-        - flake8-pyi==22.8.1
     -   id: future-annotations
         name: import annotations from __future__
         entry: 'from __future__ import annotations'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,6 +215,8 @@ select = [
   "PLE", "PLR", "PLW",
   # misc lints
   "PIE",
+  # flake8-pyi
+  "PYI",
   # tidy imports
   "TID",
   # implicit string concatenation
@@ -266,6 +268,14 @@ ignore = [
   "PLR0915",
   # Global statements are discouraged
   "PLW0603",
+  # Docstrings should not be included in stubs
+  "PYI021",
+  # Use typing_extensions.TypeAlias for type aliases
+  # "PYI026",  # not yet implemented
+  # Use "collections.abc.*" instead of "typing.*" (PEP 585 syntax)
+  # "PYI027",  # not yet implemented
+  # while int | float can be shortened to float, the former is more explicit
+  # "PYI041",  # not yet implemented
 
   # Additional checks that don't pass yet
   # Within an except clause, raise exceptions with ...
@@ -281,6 +291,8 @@ exclude = [
   "doc/build/*.py",
   "doc/temp/*.py",
   ".eggs/*.py",
+  # vendored files
+  "pandas/util/version/*",
   "versioneer.py",
   # exclude asv benchmark environments from linting
   "env",
@@ -292,8 +304,9 @@ exclude = [
 # to be enabled gradually
 "pandas/core/*" = ["PLR5501", "PLW2901"]
 "pandas/io/*" = ["PLW2901"]
-"pandas/tests/*" = ["PLW2901"]
+"pandas/tests/*" = ["B028", "PLW2901"]
 "pandas/plotting/*" = ["PLW2901"]
+"scripts/*" = ["B028"]
 # Keep this one enabled
 "pandas/_typing.py" = ["TCH"]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 88
 # Although ruff is now the main linter for style checks, this section
-# is still needed for validate_docstrings.py and flake8-pyi
+# is still needed for validate_docstrings.py
 ignore =
     # space before : (needed for how black formats slicing)
     E203,
@@ -12,17 +12,7 @@ ignore =
     # module level import not at top of file
     E402,
     # do not assign a lambda expression, use a def
-    E731,
-    # found modulo formatter (incorrect picks up mod operations)
-    Y002,
-    # Docstrings should not be included in stubs
-    Y021,
-    # Use typing_extensions.TypeAlias for type aliases
-    Y026,
-    # Use "collections.abc.*" instead of "typing.*" (PEP 585 syntax)
-    Y027,
-    # while int | float can be shortened to float, the former is more explicit
-    Y041
+    E731
 exclude =
     doc/sphinxext/*.py,
     doc/build/*.py,


### PR DESCRIPTION
Not all rules are covered by ruff but, from my point of view, the important ones are covered.