### PR TITLE
REGR: Revert GH51335

### DIFF
--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -777,7 +777,7 @@ Other API changes
 - The levels of the index of the :class:`Series` returned from ``Series.sparse.from_coo`` now always have dtype ``int32``. Previously they had dtype ``int64`` (:issue:`50926`)
 - :func:`to_datetime` with ``unit`` of either "Y" or "M" will now raise if a sequence contains a non-round ``float`` value, matching the ``Timestamp`` behavior (:issue:`50301`)
 - The methods :meth:`Series.round`, :meth:`DataFrame.__invert__`, :meth:`Series.__invert__`, :meth:`DataFrame.swapaxes`, :meth:`DataFrame.first`, :meth:`DataFrame.last`, :meth:`Series.first`, :meth:`Series.last` and :meth:`DataFrame.align` will now always return new objects (:issue:`51032`)
-- :class:`DataFrame` and :class:`DataFrameGroupBy` aggregations (e.g. "sum") with object-dtype columns no longer infer non-object dtypes for their results, explicitly call ``result.infer_objects(copy=False)`` on the result to obtain the old behavior (:issue:`51205`, :issue:`49603`)
+- :class:`DataFrameGroupBy` aggregations (e.g. "sum") with object-dtype columns no longer infer non-object dtypes for their results, explicitly call ``result.infer_objects(copy=False)`` on the result to obtain the old behavior (:issue:`51205`, :issue:`49603`)
 - Division by zero with :class:`ArrowDtype` dtypes returns ``-inf``, ``nan``, or ``inf`` depending on the numerator, instead of raising (:issue:`51541`)
 - Added :func:`pandas.api.types.is_any_real_numeric_dtype` to check for real numeric dtypes (:issue:`51152`)
 - :meth:`~arrays.ArrowExtensionArray.value_counts` now returns data with :class:`ArrowDtype` with ``pyarrow.int64`` type instead of ``"Int64"`` type (:issue:`51462`)
@@ -1204,11 +1204,11 @@ Numeric
 ^^^^^^^
 - Bug in :meth:`DataFrame.add` cannot apply ufunc when inputs contain mixed DataFrame type and Series type (:issue:`39853`)
 - Bug in arithmetic operations on :class:`Series` not propagating mask when combining masked dtypes and numpy dtypes (:issue:`45810`, :issue:`42630`)
+- Bug in DataFrame reduction methods (e.g. :meth:`DataFrame.sum`) with object dtype, ``axis=1`` and ``numeric_only=False`` would not be coerced to float (:issue:`49551`)
 - Bug in :meth:`DataFrame.sem` and :meth:`Series.sem` where an erroneous ``TypeError`` would always raise when using data backed by an :class:`ArrowDtype` (:issue:`49759`)
 - Bug in :meth:`Series.__add__` casting to object for list and masked :class:`Series` (:issue:`22962`)
 - Bug in :meth:`~arrays.ArrowExtensionArray.mode` where ``dropna=False`` was not respected when there was ``NA`` values (:issue:`50982`)
 - Bug in :meth:`DataFrame.query` with ``engine="numexpr"`` and column names are ``min`` or ``max`` would raise a ``TypeError`` (:issue:`50937`)
-- Bug in :meth:`DataFrame.min` and :meth:`DataFrame.max` with tz-aware data containing ``pd.NaT`` and ``axis=1`` would return incorrect results (:issue:`51242`)
 
 Conversion
 ^^^^^^^^^^

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -102,6 +102,7 @@ from pandas.core.dtypes.common import (
     is_integer_dtype,
     is_iterator,
     is_list_like,
+    is_object_dtype,
     is_scalar,
     is_sequence,
     needs_i8_conversion,
@@ -10925,44 +10926,93 @@ class DataFrame(NDFrame, OpsMixin):
                 data = self._get_bool_data()
             return data
 
-        # Case with EAs see GH#35881
-        df = self
-        if numeric_only:
-            df = _get_data()
+        if numeric_only or axis == 0:
+            # For numeric_only non-None and axis non-None, we know
+            #  which blocks to use and no try/except is needed.
+            #  For numeric_only=None only the case with axis==0 and no object
+            #  dtypes are unambiguous can be handled with BlockManager.reduce
+            # Case with EAs see GH#35881
+            df = self
+            if numeric_only:
+                df = _get_data()
+            if axis == 1:
+                df = df.T
+                axis = 0
+
+            # After possibly _get_data and transposing, we are now in the
+            #  simple case where we can use BlockManager.reduce
+            res = df._mgr.reduce(blk_func)
+            out = df._constructor(res).iloc[0]
+            if out_dtype is not None:
+                out = out.astype(out_dtype)
+            if axis == 0 and len(self) == 0 and name in ["sum", "prod"]:
+                # Even if we are object dtype, follow numpy and return
+                #  float64, see test_apply_funcs_over_empty
+                out = out.astype(np.float64)
+
+            return out
+
+        assert not numeric_only and axis in (1, None)
+
+        data = self
+        values = data.values
+        result = func(values)
+
+        if hasattr(result, "dtype"):
+            if filter_type == "bool" and notna(result).all():
+                result = result.astype(np.bool_)
+            elif filter_type is None and is_object_dtype(result.dtype):
+                try:
+                    result = result.astype(np.float64)
+                except (ValueError, TypeError):
+                    # try to coerce to the original dtypes item by item if we can
+                    pass
+
         if axis is None:
-            return func(df.values)
-        elif axis == 1:
-            if len(df.index) == 0:
-                # Taking a transpose would result in no columns, losing the dtype.
-                # In the empty case, reducing along axis 0 or 1 gives the same
-                # result dtype, so reduce with axis=0 and ignore values
-                result = df._reduce(
-                    op,
-                    name,
-                    axis=0,
-                    skipna=skipna,
-                    numeric_only=False,
-                    filter_type=filter_type,
-                    **kwds,
-                ).iloc[:0]
-                result.index = df.index
-                return result
-            df = df.T
+            return result
 
-        # After possibly _get_data and transposing, we are now in the
-        #  simple case where we can use BlockManager.reduce
-        res = df._mgr.reduce(blk_func)
-        out = df._constructor(res).iloc[0]
-        if out_dtype is not None:
-            out = out.astype(out_dtype)
-        elif (df._mgr.get_dtypes() == object).any():
-            out = out.astype(object)
-        elif len(self) == 0 and name in ("sum", "prod"):
-            # Even if we are object dtype, follow numpy and return
-            #  float64, see test_apply_funcs_over_empty
-            out = out.astype(np.float64)
+        labels = self._get_agg_axis(axis)
+        result = self._constructor_sliced(result, index=labels)
+        return result
 
-        return out
+        # # Case with EAs see GH#35881
+        # df = self
+        # if numeric_only:
+        #     df = _get_data()
+        # if axis is None:
+        #     return func(df.values)
+        # elif axis == 1:
+        #     if len(df.index) == 0:
+        #         # Taking a transpose would result in no columns, losing the dtype.
+        #         # In the empty case, reducing along axis 0 or 1 gives the same
+        #         # result dtype, so reduce with axis=0 and ignore values
+        #         result = df._reduce(
+        #             op,
+        #             name,
+        #             axis=0,
+        #             skipna=skipna,
+        #             numeric_only=False,
+        #             filter_type=filter_type,
+        #             **kwds,
+        #         ).iloc[:0]
+        #         result.index = df.index
+        #         return result
+        #     df = df.T
+        #
+        # # After possibly _get_data and transposing, we are now in the
+        # #  simple case where we can use BlockManager.reduce
+        # res = df._mgr.reduce(blk_func)
+        # out = df._constructor(res).iloc[0]
+        # if out_dtype is not None:
+        #     out = out.astype(out_dtype)
+        # elif (df._mgr.get_dtypes() == object).any():
+        #     out = out.astype(object)
+        # elif len(self) == 0 and name in ("sum", "prod"):
+        #     # Even if we are object dtype, follow numpy and return
+        #     #  float64, see test_apply_funcs_over_empty
+        #     out = out.astype(np.float64)
+        #
+        # return out
 
     def _reduce_axis1(self, name: str, func, skipna: bool) -> Series:
         """

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10975,45 +10975,6 @@ class DataFrame(NDFrame, OpsMixin):
         result = self._constructor_sliced(result, index=labels)
         return result
 
-        # # Case with EAs see GH#35881
-        # df = self
-        # if numeric_only:
-        #     df = _get_data()
-        # if axis is None:
-        #     return func(df.values)
-        # elif axis == 1:
-        #     if len(df.index) == 0:
-        #         # Taking a transpose would result in no columns, losing the dtype.
-        #         # In the empty case, reducing along axis 0 or 1 gives the same
-        #         # result dtype, so reduce with axis=0 and ignore values
-        #         result = df._reduce(
-        #             op,
-        #             name,
-        #             axis=0,
-        #             skipna=skipna,
-        #             numeric_only=False,
-        #             filter_type=filter_type,
-        #             **kwds,
-        #         ).iloc[:0]
-        #         result.index = df.index
-        #         return result
-        #     df = df.T
-        #
-        # # After possibly _get_data and transposing, we are now in the
-        # #  simple case where we can use BlockManager.reduce
-        # res = df._mgr.reduce(blk_func)
-        # out = df._constructor(res).iloc[0]
-        # if out_dtype is not None:
-        #     out = out.astype(out_dtype)
-        # elif (df._mgr.get_dtypes() == object).any():
-        #     out = out.astype(object)
-        # elif len(self) == 0 and name in ("sum", "prod"):
-        #     # Even if we are object dtype, follow numpy and return
-        #     #  float64, see test_apply_funcs_over_empty
-        #     out = out.astype(np.float64)
-        #
-        # return out
-
     def _reduce_axis1(self, name: str, func, skipna: bool) -> Series:
         """
         Special case for _reduce to try to avoid a potentially-expensive transpose.

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -317,9 +317,15 @@ class TestDataFrameAnalytics:
             DataFrame({0: [np.nan, 2], 1: [np.nan, 3], 2: [np.nan, 4]}, dtype=object),
         ],
     )
-    def test_stat_operators_attempt_obj_array(self, method, df, axis, request):
+    def test_stat_operators_attempt_obj_array(
+        self, method, df, axis, request, using_array_manager
+    ):
         # GH#676
-        if axis in (1, "columns") or method not in ("sum", "prod", "min", "max"):
+        if (
+            axis in (1, "columns")
+            or method not in ("sum", "prod", "min", "max")
+            or using_array_manager
+        ):
             request.node.add_marker(pytest.mark.xfail(reason="Revert of GH#51335"))
         assert df.values.dtype == np.object_
         result = getattr(df, method)(axis=axis)


### PR DESCRIPTION
Ref: https://github.com/pandas-dev/pandas/pull/51955#issuecomment-1478685300

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

@jbrockmendel - this only reverts the change to `_reduce`, but leaves other changes untouched. Would you prefer to revert all of #51335?