### PR TITLE
PERF: ArrowExtensionArray._from_sequence

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -251,7 +251,7 @@ class ArrowExtensionArray(
             except pa.ArrowInvalid:
                 # GH50430: let pyarrow infer type, then cast
                 scalars = pa.array(scalars, from_pandas=True)
-        if pa_dtype:
+        if pa_dtype and scalars.type != pa_dtype:
             scalars = scalars.cast(pa_dtype)
         return cls(scalars)
 


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Avoid an unnecessary cast in `ArrowExtensionArray._from_sequence`. 

Noticed the time spent there when transposing and arrow-backed dataframe:

```
import pandas as pd
import numpy as np
import pyarrow as pa

data = np.random.randn(10_000, 10)
dtype = pd.ArrowDtype(pa.float64())
df = pd.DataFrame(data, dtype=dtype)

%timeit df.T

# 254 ms ± 14.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)    <- main
# 169 ms ± 3.69 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)  <- PR
```
