### PR TITLE
DEPR: Deprecate the convert_dtype param in Series.Apply

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -116,6 +116,7 @@ Deprecations
 - Deprecated 'broadcast_axis' keyword in :meth:`Series.align` and :meth:`DataFrame.align`, upcast before calling ``align`` with ``left = DataFrame({col: left for col in right.columns}, index=right.index)`` (:issue:`51856`)
 - Deprecated the 'axis' keyword in :meth:`.GroupBy.idxmax`, :meth:`.GroupBy.idxmin`, :meth:`.GroupBy.fillna`, :meth:`.GroupBy.take`, :meth:`.GroupBy.skew`, :meth:`.GroupBy.rank`, :meth:`.GroupBy.cumprod`, :meth:`.GroupBy.cumsum`, :meth:`.GroupBy.cummax`, :meth:`.GroupBy.cummin`, :meth:`.GroupBy.pct_change`, :meth:`GroupBy.diff`, :meth:`.GroupBy.shift`, and :meth:`DataFrameGroupBy.corrwith`; for ``axis=1`` operate on the underlying :class:`DataFrame` instead (:issue:`50405`, :issue:`51046`)
 - Deprecated :meth:`DataFrame.swapaxes` and :meth:`Series.swapaxes`, use :meth:`DataFrame.transpose` or :meth:`Series.transpose` instead (:issue:`51946`)
+- Deprecated parameter ``convert_type`` in :meth:`Series.apply` (:issue:`52140`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2797,12 +2797,9 @@ def map_infer_mask(ndarray arr, object f, const uint8_t[:] mask, bint convert=Tr
         result[i] = val
 
     if convert:
-        return maybe_convert_objects(result,
-                                     try_float=False,
-                                     convert_datetime=False,
-                                     convert_timedelta=False)
-
-    return result
+        return maybe_convert_objects(result)
+    else:
+        return result
 
 
 @cython.boundscheck(False)
@@ -2845,12 +2842,9 @@ def map_infer(
         result[i] = val
 
     if convert:
-        return maybe_convert_objects(result,
-                                     try_float=False,
-                                     convert_datetime=False,
-                                     convert_timedelta=False)
-
-    return result
+        return maybe_convert_objects(result)
+    else:
+        return result
 
 
 def to_object_array(rows: object, min_width: int = 0) -> ndarray:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4387,7 +4387,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
     def apply(
         self,
         func: AggFuncType,
-        convert_dtype: bool = True,
+        convert_dtype: bool | lib.NoDefault = lib.no_default,
         args: tuple[Any, ...] = (),
         **kwargs,
     ) -> DataFrame | Series:
@@ -4405,6 +4405,10 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             Try to find better dtype for elementwise function results. If
             False, leave as dtype=object. Note that the dtype is always
             preserved for some extension array dtypes, such as Categorical.
+
+            .. deprecated:: 2.1.0
+                The convert_dtype has been deprecated. Do ``ser.astype(object).apply()``
+                instead if you want this functionality.
         args : tuple
             Positional arguments passed to func after the series value.
         **kwargs
@@ -4494,6 +4498,14 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         Helsinki    2.484907
         dtype: float64
         """
+        if convert_dtype is not lib.no_default:
+            warnings.warn(
+                "the convert_dtype parameter is deprecated and will be removed in a "
+                "future version.",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
+            convert_dtype = True
         return SeriesApply(self, func, convert_dtype, args, kwargs).apply()
 
     def _reduce(

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4408,7 +4408,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
             .. deprecated:: 2.1.0
                 The convert_dtype has been deprecated. Do ``ser.astype(object).apply()``
-                instead if you want this functionality.
+                instead if you want ``convert_dtype=False``.
         args : tuple
             Positional arguments passed to func after the series value.
         **kwargs

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4498,14 +4498,15 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         Helsinki    2.484907
         dtype: float64
         """
-        if convert_dtype is not lib.no_default:
+        if convert_dtype is lib.no_default:
+            convert_dtype = True
+        else:
             warnings.warn(
                 "the convert_dtype parameter is deprecated and will be removed in a "
                 "future version.",
                 FutureWarning,
                 stacklevel=find_stack_level(),
             )
-            convert_dtype = True
         return SeriesApply(self, func, convert_dtype, args, kwargs).apply()
 
     def _reduce(

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4503,7 +4503,8 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         else:
             warnings.warn(
                 "the convert_dtype parameter is deprecated and will be removed in a "
-                "future version.",
+                "future version.  Do ``ser.astype(object).apply()`` "
+                "instead if you want ``convert_dtype=False``.",
                 FutureWarning,
                 stacklevel=find_stack_level(),
             )

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1780,7 +1780,7 @@ the string values returned are correct."""
         # Decode strings
         for col, typ in zip(data, self._typlist):
             if type(typ) is int:
-                data[col] = data[col].apply(self._decode, convert_dtype=True)
+                data[col] = data[col].apply(self._decode)
 
         data = self._insert_strls(data)
 

--- a/pandas/tests/apply/test_series_apply.py
+++ b/pandas/tests/apply/test_series_apply.py
@@ -74,14 +74,15 @@ def test_apply_same_length_inference_bug():
     tm.assert_series_equal(result, expected)
 
 
-def test_apply_dont_convert_dtype():
-    s = Series(np.random.randn(10))
+@pytest.mark.parametrize("convert_dtype", [True, False])
+def test_apply_convert_dtype_deprecated(convert_dtype):
+    ser = Series(np.random.randn(10))
 
-    def f(x):
+    def func(x):
         return x if x > 0 else np.nan
 
-    result = s.apply(f, convert_dtype=False)
-    assert result.dtype == object
+    with tm.assert_produces_warning(FutureWarning):
+        ser.apply(func, convert_dtype=convert_dtype)
 
 
 def test_apply_args():


### PR DESCRIPTION
Depreates the `convert_dtype` parameter in `Series.apply`. Also does some minor clean-ups in `lib.pyx`.

Progress towards #52140.