### PR TITLE
Backport PR #52075 on branch 2.0.x (BUG: Arrow setitem segfaults when len > 145 000)

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1618,6 +1618,10 @@ class ArrowExtensionArray(
                 indices = pa.array(indices, type=pa.int64())
                 replacements = replacements.take(indices)
             return cls._if_else(mask, replacements, values)
+        if isinstance(values, pa.ChunkedArray) and pa.types.is_boolean(values.type):
+            # GH#52059 replace_with_mask segfaults for chunked array
+            # https://github.com/apache/arrow/issues/34634
+            values = values.combine_chunks()
         try:
             return pc.replace_with_mask(values, mask, replacements)
         except pa.ArrowNotImplementedError:

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -2333,3 +2333,12 @@ def test_series_from_string_array(dtype):
     ser = pd.Series(arr, dtype=dtype)
     expected = pd.Series(ArrowExtensionArray(arr), dtype=dtype)
     tm.assert_series_equal(ser, expected)
+
+
+def test_setitem_boolean_replace_with_mask_segfault():
+    # GH#52059
+    N = 145_000
+    arr = ArrowExtensionArray(pa.chunked_array([np.ones((N,), dtype=np.bool_)]))
+    expected = arr.copy()
+    arr[np.zeros((N,), dtype=np.bool_)] = False
+    assert arr._pa_array == expected._pa_array

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -2341,4 +2341,4 @@ def test_setitem_boolean_replace_with_mask_segfault():
     arr = ArrowExtensionArray(pa.chunked_array([np.ones((N,), dtype=np.bool_)]))
     expected = arr.copy()
     arr[np.zeros((N,), dtype=np.bool_)] = False
-    assert arr._pa_array == expected._pa_array
+    assert arr._data == expected._data


### PR DESCRIPTION
* BUG: Arrow setitem segfaults when len > 145 000

* Add gh ref

* Address review

* Restrict to bool type

(cherry picked from commit 10000db023208c1db0bba6a7d819bfe87dc49908)

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
