### PR TITLE
BUG: DataFrame reductions losing EA dtypes

### DIFF
--- a/pandas/core/array_algos/masked_reductions.py
+++ b/pandas/core/array_algos/masked_reductions.py
@@ -155,7 +155,7 @@ def mean(
     skipna: bool = True,
     axis: AxisInt | None = None,
 ):
-    if not values.size or mask.all():
+    if (not values.size or mask.all()) and (values.ndim == 1 or axis is None):
         return libmissing.NA
     return _reductions(np.mean, values=values, mask=mask, skipna=skipna, axis=axis)
 
@@ -168,7 +168,7 @@ def var(
     axis: AxisInt | None = None,
     ddof: int = 1,
 ):
-    if not values.size or mask.all():
+    if (not values.size or mask.all()) and (values.ndim == 1 or axis is None):
         return libmissing.NA
 
     return _reductions(
@@ -184,7 +184,7 @@ def std(
     axis: AxisInt | None = None,
     ddof: int = 1,
 ):
-    if not values.size or mask.all():
+    if (not values.size or mask.all()) and (values.ndim == 1 or axis is None):
         return libmissing.NA
 
     return _reductions(

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1222,6 +1222,7 @@ class ArrowExtensionArray(
         ------
         TypeError : subclass does not define reductions
         """
+        keepdims = kwargs.pop("keepdims", False)
         pa_type = self._pa_array.type
 
         data_to_reduce = self._pa_array
@@ -1289,6 +1290,12 @@ class ArrowExtensionArray(
                 f"upgrading pyarrow."
             )
             raise TypeError(msg) from err
+
+        if keepdims:
+            # TODO: is there a way to do this without .as_py()
+            result = pa.array([result.as_py()], type=result.type)
+            return type(self)(result)
+
         if pc.is_null(result).as_py():
             return self.dtype.na_value
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2049,6 +2049,11 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         -------
         min : the minimum of this `Categorical`, NA value if empty
         """
+        keepdims = kwargs.pop("keepdims", False)
+        if keepdims:
+            result = self.min(skipna=skipna, **kwargs)
+            return type(self)([result], dtype=self.dtype)
+
         nv.validate_minmax_axis(kwargs.get("axis", 0))
         nv.validate_min((), kwargs)
         self.check_for_ordered("min")
@@ -2081,6 +2086,11 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         -------
         max : the maximum of this `Categorical`, NA if array is empty
         """
+        keepdims = kwargs.pop("keepdims", False)
+        if keepdims:
+            result = self.max(skipna=skipna, **kwargs)
+            return type(self)([result], dtype=self.dtype)
+
         nv.validate_minmax_axis(kwargs.get("axis", 0))
         nv.validate_max((), kwargs)
         self.check_for_ordered("max")

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10912,9 +10912,10 @@ class DataFrame(NDFrame, OpsMixin):
             if isinstance(values, ExtensionArray):
                 if not is_1d_only_ea_dtype(values.dtype):
                     if is_am:
-                        return values.reshape(1, -1)._reduce(
-                            name, axis=1, skipna=skipna, **kwds
-                        )
+                        # error: "ExtensionArray" has no attribute "reshape";
+                        #  maybe "shape"?
+                        vals2d = values.reshape(1, -1)  # type: ignore[attr-defined]
+                        return vals2d._reduce(name, axis=1, skipna=skipna, **kwds)
                     else:
                         return values._reduce(name, axis=1, skipna=skipna, **kwds)
 

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -980,13 +980,17 @@ class ArrayManager(BaseArrayManager):
         for i, arr in enumerate(self.arrays):
             res = func(arr, axis=0)
 
-            # TODO NaT doesn't preserve dtype, so we need to ensure to create
-            # a timedelta result array if original was timedelta
-            # what if datetime results in timedelta? (eg std)
-            dtype = arr.dtype if res is NaT else None
-            result_arrays.append(
-                sanitize_array([res], None, dtype=dtype)  # type: ignore[arg-type]
-            )
+            if isinstance(res, (np.ndarray, ExtensionArray)):
+                # keepdims worked!
+                result_arrays.append(res)
+            else:
+                # TODO NaT doesn't preserve dtype, so we need to ensure to create
+                # a timedelta result array if original was timedelta
+                # what if datetime results in timedelta? (eg std)
+                dtype = arr.dtype if res is NaT else None
+                result_arrays.append(
+                    sanitize_array([res], None, dtype=dtype)  # type: ignore[arg-type]
+                )
 
         index = Index._simple_new(np.array([None], dtype=object))  # placeholder
         columns = self.items

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -976,7 +976,7 @@ class ArrayManager(BaseArrayManager):
         -------
         ArrayManager
         """
-        result_arrays: list[np.ndarray] = []
+        result_arrays: list[ArrayLike] = []
         for i, arr in enumerate(self.arrays):
             res = func(arr, axis=0)
 
@@ -988,16 +988,12 @@ class ArrayManager(BaseArrayManager):
                 # a timedelta result array if original was timedelta
                 # what if datetime results in timedelta? (eg std)
                 dtype = arr.dtype if res is NaT else None
-                result_arrays.append(
-                    sanitize_array([res], None, dtype=dtype)  # type: ignore[arg-type]
-                )
+                result_arrays.append(sanitize_array([res], None, dtype=dtype))
 
         index = Index._simple_new(np.array([None], dtype=object))  # placeholder
         columns = self.items
 
-        # error: Argument 1 to "ArrayManager" has incompatible type "List[ndarray]";
-        # expected "List[Union[ndarray, ExtensionArray]]"
-        new_mgr = type(self)(result_arrays, [index, columns])  # type: ignore[arg-type]
+        new_mgr = type(self)(result_arrays, [index, columns])
         return new_mgr
 
     def operate_blockwise(self, other: ArrayManager, array_op) -> ArrayManager:

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -339,7 +339,11 @@ class Block(PandasObject):
 
         if self.values.ndim == 1:
             # TODO(EA2D): special case not needed with 2D EAs
-            res_values = np.array([[result]])
+            if isinstance(result, (np.ndarray, ExtensionArray)):
+                # keepdims=True worked
+                res_values = result
+            else:
+                res_values = np.array([[result]])
         else:
             res_values = result.reshape(-1, 1)
 

--- a/pandas/tests/arrays/categorical/test_analytics.py
+++ b/pandas/tests/arrays/categorical/test_analytics.py
@@ -124,7 +124,7 @@ class TestCategoricalAnalytics:
         with pytest.raises(TypeError, match=re.escape(msg)):
             method(cat)
 
-    @pytest.mark.parametrize("kwarg", ["axis", "out", "keepdims"])
+    @pytest.mark.parametrize("kwarg", ["axis", "out"])
     @pytest.mark.parametrize("method", ["min", "max"])
     def test_numpy_min_max_unsupported_kwargs_raises(self, method, kwarg):
         cat = Categorical(["a", "b", "c", "b"], ordered=True)


### PR DESCRIPTION
- [x] closes #51446 (Replace xxxx with the GitHub issue number)
- [x] closes #42895
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

In the absence of 2D EAs, we need reductions to sometimes pretend the EA is 2D.  Enter "keepdims" adapted from numpy reductions.

This is still pretty ugly. I'm open to ideas to clean it up.

cc @rhshadrach any other particular cases need testing?