### PR TITLE
DOC: Escape backslash in read_clipboard docstring

### DIFF
--- a/pandas/io/clipboards.py
+++ b/pandas/io/clipboards.py
@@ -30,8 +30,8 @@ def read_clipboard(
 
     Parameters
     ----------
-    sep : str, default '\s+'
-        A string or regex delimiter. The default of '\s+' denotes
+    sep : str, default '\\s+'
+        A string or regex delimiter. The default of '\\s+' denotes
         one or more whitespace characters.
 
     dtype_backend : {"numpy_nullable", "pyarrow"}, defaults to NumPy backed DataFrames


### PR DESCRIPTION
- [x] closes #51868
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
