### PR TITLE
PERF: concat_same_type for PeriodDtype

### DIFF
--- a/pandas/_libs/arrays.pyi
+++ b/pandas/_libs/arrays.pyi
@@ -3,7 +3,9 @@ from typing import Sequence
 import numpy as np
 
 from pandas._typing import (
+    AxisInt,
     DtypeObj,
+    Self,
     Shape,
 )
 
@@ -32,3 +34,7 @@ class NDArrayBacked:
     def ravel(self, order=...): ...
     @property
     def T(self): ...
+    @classmethod
+    def _concat_same_type(
+        cls, to_concat: Sequence[Self], axis: AxisInt = ...
+    ) -> Self: ...

--- a/pandas/_libs/arrays.pyx
+++ b/pandas/_libs/arrays.pyx
@@ -182,3 +182,10 @@ cdef class NDArrayBacked:
     def transpose(self, *axes):
         res_values = self._ndarray.transpose(*axes)
         return self._from_backing_data(res_values)
+
+    @classmethod
+    def _concat_same_type(cls, to_concat, axis=0):
+        # NB: We are assuming at this point that dtypes all match
+        new_values = [obj._ndarray for obj in to_concat]
+        new_arr = cnp.PyArray_Concatenate(new_values, axis)
+        return to_concat[0]._from_backing_data(new_arr)

--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -224,13 +224,11 @@ class NDArrayBackedExtensionArray(NDArrayBacked, ExtensionArray):
         to_concat: Sequence[Self],
         axis: AxisInt = 0,
     ) -> Self:
-        dtypes = {str(x.dtype) for x in to_concat}
-        if len(dtypes) != 1:
-            raise ValueError("to_concat must have the same dtype (tz)", dtypes)
+        if not lib.dtypes_all_equal([x.dtype for x in to_concat]):
+            dtypes = {str(x.dtype) for x in to_concat}
+            raise ValueError("to_concat must have the same dtype", dtypes)
 
-        new_values = [x._ndarray for x in to_concat]
-        new_arr = np.concatenate(new_values, axis=axis)
-        return to_concat[0]._from_backing_data(new_arr)
+        return super()._concat_same_type(to_concat, axis=axis)
 
     @doc(ExtensionArray.searchsorted)
     def searchsorted(

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -182,7 +182,11 @@ def _period_dispatch(meth: F) -> F:
     return cast(F, new_meth)
 
 
-class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
+# error: Definition of "_concat_same_type" in base class "NDArrayBacked" is
+# incompatible with definition in base class "ExtensionArray"
+class DatetimeLikeArrayMixin(  # type: ignore[misc]
+    OpsMixin, NDArrayBackedExtensionArray
+):
     """
     Shared Base/Mixin class for DatetimeArray, TimedeltaArray, PeriodArray
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -151,7 +151,9 @@ def _field_accessor(name: str, field: str, docstring: str | None = None):
     return property(f)
 
 
-class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
+# error: Definition of "_concat_same_type" in base class "NDArrayBacked" is
+# incompatible with definition in base class "ExtensionArray"
+class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):  # type: ignore[misc]
     """
     Pandas ExtensionArray for tz-naive or tz-aware datetime data.
 

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -40,7 +40,9 @@ if TYPE_CHECKING:
     )
 
 
-class PandasArray(
+# error: Definition of "_concat_same_type" in base class "NDArrayBacked" is
+# incompatible with definition in base class "ExtensionArray"
+class PandasArray(  # type: ignore[misc]
     OpsMixin,
     NDArrayBackedExtensionArray,
     ObjectStringArrayMixin,

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -109,7 +109,9 @@ def _field_accessor(name: str, docstring: str | None = None):
     return property(f)
 
 
-class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
+# error: Definition of "_concat_same_type" in base class "NDArrayBacked" is
+# incompatible with definition in base class "ExtensionArray"
+class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):  # type: ignore[misc]
     """
     Pandas ExtensionArray for storing Period data.
 
@@ -263,7 +265,10 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
             validate_dtype_freq(scalars.dtype, freq)
             if copy:
                 scalars = scalars.copy()
-            return scalars
+            # error: Incompatible return value type
+            # (got "Union[Sequence[Optional[Period]], Union[Union[ExtensionArray,
+            # ndarray[Any, Any]], Index, Series]]", expected "PeriodArray")
+            return scalars  # type: ignore[return-value]
 
         periods = np.asarray(scalars, dtype=object)
 

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -228,7 +228,9 @@ class BaseStringArray(ExtensionArray):
         return list(self.to_numpy())
 
 
-class StringArray(BaseStringArray, PandasArray):
+# error: Definition of "_concat_same_type" in base class "NDArrayBacked" is
+# incompatible with definition in base class "ExtensionArray"
+class StringArray(BaseStringArray, PandasArray):  # type: ignore[misc]
     """
     Extension array for string data.
 

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -956,12 +956,9 @@ class PeriodDtype(PeriodDtypeBase, PandasExtensionDtype):
         elif isinstance(other, PeriodDtype):
             # For freqs that can be held by a PeriodDtype, this check is
             # equivalent to (and much faster than) self.freq == other.freq
-            sfreq = self.freq
-            ofreq = other.freq
-            return (
-                sfreq.n == ofreq.n
-                and sfreq._period_dtype_code == ofreq._period_dtype_code
-            )
+            sfreq = self._freq
+            ofreq = other._freq
+            return sfreq.n == ofreq.n and self._dtype_code == other._dtype_code
 
         return False
 


### PR DESCRIPTION
xref #23362

```
import numpy as np
import pandas as pd

a = np.random.randint(2000, 2100, size=1000)
b = np.random.randint(2000, 2100, size=1000)

x = pd.core.arrays.period_array(a, freq='B')
y = pd.core.arrays.period_array(b, freq='B')

%timeit x._concat_same_type([x, y])
6.86 µs ± 75.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)  # <- main
4.24 µs ± 109 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)  # <- PR
```