### PR TITLE
BUG: DataFrame.corrwith raising for pyarrow-backed dtypes

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -181,6 +181,7 @@ Timezones
 Numeric
 ^^^^^^^
 - Bug in :meth:`Series.corr` and :meth:`Series.cov` raising ``AttributeError`` for masked dtypes (:issue:`51422`)
+- Bug in :meth:`DataFrame.corrwith` raising ``NotImplementedError`` for pyarrow-backed dtypes (:issue:`52314`)
 -
 
 Conversion

--- a/pandas/core/internals/ops.py
+++ b/pandas/core/internals/ops.py
@@ -6,6 +6,8 @@ from typing import (
     NamedTuple,
 )
 
+from pandas.core.dtypes.common import is_1d_only_ea_dtype
+
 if TYPE_CHECKING:
     from pandas._libs.internals import BlockPlacement
     from pandas._typing import ArrayLike
@@ -60,7 +62,12 @@ def operate_blockwise(
     res_blks: list[Block] = []
     for lvals, rvals, locs, left_ea, right_ea, rblk in _iter_block_pairs(left, right):
         res_values = array_op(lvals, rvals)
-        if left_ea and not right_ea and hasattr(res_values, "reshape"):
+        if (
+            left_ea
+            and not right_ea
+            and hasattr(res_values, "reshape")
+            and not is_1d_only_ea_dtype(res_values.dtype)
+        ):
             res_values = res_values.reshape(1, -1)
         nbs = rblk._split_op_result(res_values)
 

--- a/pandas/tests/frame/methods/test_cov_corr.py
+++ b/pandas/tests/frame/methods/test_cov_corr.py
@@ -274,7 +274,17 @@ class TestDataFrameCorr:
 
 
 class TestDataFrameCorrWith:
-    def test_corrwith(self, datetime_frame):
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            "float64",
+            "Float64",
+            pytest.param("float64[pyarrow]", marks=td.skip_if_no("pyarrow")),
+        ],
+    )
+    def test_corrwith(self, datetime_frame, dtype):
+        datetime_frame = datetime_frame.astype(dtype)
+
         a = datetime_frame
         noise = Series(np.random.randn(len(a)), index=a.index)
 


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.1.0.rst` file if fixing a bug or adding a new feature.


Fixes the following:

```
import pandas as pd
import numpy as np

data = np.random.randn(100, 10)
df = pd.DataFrame(data, dtype="float64[pyarrow]")

df.corrwith(df)
```

```
NotImplementedError: <class 'pandas.core.arrays.arrow.array.ArrowExtensionArray'> does not support reshape as backed by a 1D pyarrow.ChunkedArray.
```