### PR TITLE
PERF: DataFrame.values for pyarrow-backed numeric types

### DIFF
--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -50,6 +50,7 @@ from pandas.core.dtypes.missing import (
 
 import pandas.core.algorithms as algos
 from pandas.core.arrays._mixins import NDArrayBackedExtensionArray
+from pandas.core.arrays.arrow import ArrowDtype
 from pandas.core.arrays.sparse import SparseDtype
 import pandas.core.common as com
 from pandas.core.construction import (
@@ -1769,6 +1770,13 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         if isinstance(dtype, SparseDtype):
             dtype = dtype.subtype
             dtype = cast(np.dtype, dtype)
+        elif (
+            isinstance(dtype, ArrowDtype)
+            and dtype.numpy_dtype is not None
+            and dtype.numpy_dtype.kind in "fciub"
+            and all(blk.dtype == dtype and not blk.values._hasna for blk in self.blocks)
+        ):
+            dtype = dtype.numpy_dtype
         elif isinstance(dtype, ExtensionDtype):
             dtype = np.dtype("object")
         elif is_dtype_equal(dtype, str):


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Perf improvement for `DataFrame.values` when backed by a _single pyarrow numeric dtype without any nulls_. I realize this is a narrow use case, so happy to close this PR if it isn't worth special casing. The current slowness is due to `DataFrame.values` always casting to `object` dtype for EA-backed frames. Unfortunately, a single null anywhere in the dataframe misses this optimization since `pd.NA` is used as the null representation in the `ndarray`.

```
import pandas as pd
import numpy as np

data = np.random.randn(100_000, 20)
df = pd.DataFrame(data, dtype="float64[pyarrow]")

%timeit df.values

# 98.7 ms ± 11.8 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)   <- main
# 3.56 ms ± 96.2 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  <- PR
```