### PR TITLE
DOC: Fix typo in developer's guide

### DIFF
--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -349,7 +349,7 @@ If using :ref:`mamba <contributing.mamba>`, do::
 If using :ref:`pip <contributing.pip>` , do::
 
     # activate the virtual environment based on your platform
-    pythom -m pip install --upgrade -r requirements-dev.txt
+    python -m pip install --upgrade -r requirements-dev.txt
 
 Tips for a successful pull request
 ==================================


### PR DESCRIPTION
Fix a small typo.
