### PR TITLE
DOC: Update doc version dropdown for pandas 2.0

### DIFF
--- a/web/pandas/versions.json
+++ b/web/pandas/versions.json
@@ -5,9 +5,14 @@
         "url": "/docs/dev/"
     },
     {
-        "name": "1.5 (stable)",
+        "name": "2.0 (stable)",
         "version": "docs",
         "url": "/docs/"
+    },
+    {
+        "name": "1.4",
+        "version": "pandas-docs/version/1.5",
+        "url": "/pandas-docs/version/1.5/"
     },
     {
         "name": "1.4",

--- a/web/pandas/versions.json
+++ b/web/pandas/versions.json
@@ -10,7 +10,7 @@
         "url": "/docs/"
     },
     {
-        "name": "1.4",
+        "name": "1.5",
         "version": "pandas-docs/version/1.5",
         "url": "/pandas-docs/version/1.5/"
     },


### PR DESCRIPTION
After this release I think we can start removing older versions from the drop down. I'd probably leave 5 versions at most. Thoughts?