### PR TITLE
TYP/TST: tests/mypy complaints failing locally

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -3129,6 +3129,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         dropped = self.obj.dropna(how=dropna, axis=self.axis)
 
         # get a new grouper for our dropped obj
+        grouper: np.ndarray | Index | ops.BaseGrouper
         if self.keys is None and self.level is None:
             # we don't have the grouper info available
             # (e.g. we have selected out

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -4,7 +4,10 @@ from textwrap import dedent
 import numpy as np
 import pytest
 
-from pandas.compat import is_ci_environment
+from pandas.compat import (
+    is_ci_environment,
+    is_platform_mac,
+)
 from pandas.errors import (
     PyperclipException,
     PyperclipWindowsException,
@@ -401,7 +404,8 @@ class TestClipboard:
     @pytest.mark.single_cpu
     @pytest.mark.parametrize("data", ["\U0001f44d...", "Ωœ∑´...", "abcd..."])
     @pytest.mark.xfail(
-        os.environ.get("DISPLAY") is None or is_ci_environment(),
+        (os.environ.get("DISPLAY") is None and not is_platform_mac())
+        or is_ci_environment(),
         reason="Cannot pass if a headless system is not put in place with Xvfb",
         strict=not is_ci_environment(),  # Flaky failures in the CI
     )

--- a/pandas/tests/io/xml/test_to_xml.py
+++ b/pandas/tests/io/xml/test_to_xml.py
@@ -991,7 +991,9 @@ def test_stylesheet_file_like(datapath, mode):
 def test_stylesheet_io(datapath, mode):
     xsl_path = datapath("io", "data", "xml", "row_field_output.xsl")
 
-    xsl_obj: BytesIO | StringIO
+    # note: By default the bodies of untyped functions are not checked,
+    # consider using --check-untyped-defs
+    xsl_obj: BytesIO | StringIO  # type: ignore[annotation-unchecked]
 
     with open(xsl_path, mode) as f:
         if mode == "rb":

--- a/pandas/tests/io/xml/test_xml.py
+++ b/pandas/tests/io/xml/test_xml.py
@@ -1170,7 +1170,9 @@ def test_stylesheet_io(datapath, mode):
     kml = datapath("io", "data", "xml", "cta_rail_lines.kml")
     xsl = datapath("io", "data", "xml", "flatten_doc.xsl")
 
-    xsl_obj: BytesIO | StringIO
+    # note: By default the bodies of untyped functions are not checked,
+    # consider using --check-untyped-defs
+    xsl_obj: BytesIO | StringIO  # type: ignore[annotation-unchecked]
 
     with open(xsl, mode) as f:
         if mode == "rb":
@@ -1349,7 +1351,9 @@ def test_stylesheet_file_close(datapath, mode):
     kml = datapath("io", "data", "xml", "cta_rail_lines.kml")
     xsl = datapath("io", "data", "xml", "flatten_doc.xsl")
 
-    xsl_obj: BytesIO | StringIO
+    # note: By default the bodies of untyped functions are not checked,
+    # consider using --check-untyped-defs
+    xsl_obj: BytesIO | StringIO  # type: ignore[annotation-unchecked]
 
     with open(xsl, mode) as f:
         if mode == "rb":

--- a/pandas/tests/test_register_accessor.py
+++ b/pandas/tests/test_register_accessor.py
@@ -13,7 +13,9 @@ def test_dirname_mixin():
 
     class X(accessor.DirNamesMixin):
         x = 1
-        y: int
+        # note: By default the bodies of untyped functions are not checked,
+        # consider using --check-untyped-defs
+        y: int  # type: ignore[annotation-unchecked]
 
         def __init__(self) -> None:
             self.z = 3

--- a/pandas/tests/test_register_accessor.py
+++ b/pandas/tests/test_register_accessor.py
@@ -8,14 +8,12 @@ import pandas._testing as tm
 from pandas.core import accessor
 
 
-def test_dirname_mixin():
+def test_dirname_mixin() -> None:
     # GH37173
 
     class X(accessor.DirNamesMixin):
         x = 1
-        # note: By default the bodies of untyped functions are not checked,
-        # consider using --check-untyped-defs
-        y: int  # type: ignore[annotation-unchecked]
+        y: int
 
         def __init__(self) -> None:
             self.z = 3


### PR DESCRIPTION
This un-xfails-on-mac a test that is passing locally.  Also suppresses some mypy complaints.  I'm still complaints:

```
pandas/io/formats/printing.py:266: error: Incompatible types in assignment (expression has type "Tuple[Type[Dict[Any, Any]]]", base class "BaseFormatter" defined the type as "Type[str]")  [assignment]
pandas/core/dtypes/dtypes.py:865: error: Incompatible types in assignment (expression has type "Callable[[PeriodDtypeBase], int]", base class "PandasExtensionDtype" defined the type as "Callable[[PandasExtensionDtype], int]")  [assignment]
```

that I haven't found a solution for