### PR TITLE
PERF: Series.to_numpy with float dtype and na_value=np.nan

### DIFF
--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -385,6 +385,9 @@ class ToNumpy:
     def time_to_numpy_copy(self):
         self.ser.to_numpy(copy=True)
 
+    def time_to_numpy_float_with_nan(self):
+        self.ser.to_numpy(dtype="float64", na_value=np.nan)
+
 
 class Replace:
     param_names = ["num_to_replace"]

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -195,6 +195,7 @@ Performance improvements
 - Performance improvement in :meth:`MultiIndex.set_levels` and :meth:`MultiIndex.set_codes` when ``verify_integrity=True`` (:issue:`51873`)
 - Performance improvement in :func:`factorize` for object columns not containing strings (:issue:`51921`)
 - Performance improvement in :class:`Series` reductions (:issue:`52341`)
+- Performance improvement in :meth:`Series.to_numpy` when dtype is a numpy float dtype and ``na_value`` is ``np.nan``(:issue:`52430`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -195,7 +195,7 @@ Performance improvements
 - Performance improvement in :meth:`MultiIndex.set_levels` and :meth:`MultiIndex.set_codes` when ``verify_integrity=True`` (:issue:`51873`)
 - Performance improvement in :func:`factorize` for object columns not containing strings (:issue:`51921`)
 - Performance improvement in :class:`Series` reductions (:issue:`52341`)
-- Performance improvement in :meth:`Series.to_numpy` when dtype is a numpy float dtype and ``na_value`` is ``np.nan``(:issue:`52430`)
+- Performance improvement in :meth:`Series.to_numpy` when dtype is a numpy float dtype and ``na_value`` is ``np.nan`` (:issue:`52430`)
 -
 
 .. ---------------------------------------------------------------------------


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.1.0.rst` file if fixing a bug or adding a new feature.

Avoids filling na values with `np.nan` if the array is already a numpy float dtype. (`DataFrame` has a similar optimization in `BlockManager.as_array`)

```
import pandas as pd
import numpy as np

ser = pd.Series(np.random.randn(10_000_000))

%timeit ser.to_numpy(dtype="float64", na_value=np.nan, copy=False)

# 22.5 ms ± 2.56 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)          -> main
# 1.97 µs ± 24.5 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)   -> PR
```





ASV added:
```
       before           after         ratio
     [3ce07cb4]       [020fb14a]
     <main>           <series-to-numpy-float-nan>
-     1.02±0.02ms      2.12±0.03μs     0.00  series_methods.ToNumpy.time_to_numpy_float_with_nan

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```