### PR TITLE
BUG: Series([ints], dtype=td[non-nano]) not respecting unit

### DIFF
--- a/doc/source/whatsnew/v2.0.1.rst
+++ b/doc/source/whatsnew/v2.0.1.rst
@@ -20,7 +20,7 @@ Fixed regressions
 
 Bug fixes
 ~~~~~~~~~
--
+- Bug in :class:`Series` constructor when passing ``timedelta64`` dtype with non-nanosecond unit would not respect the unit (:issue:`48312`, :issue:`52457`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_201.other:

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -213,10 +213,12 @@ class TimedeltaArray(dtl.TimelikeOps):
 
     @classmethod
     def _from_sequence(cls, data, *, dtype=None, copy: bool = False) -> Self:
+        unit = None
         if dtype:
             dtype = _validate_td64_dtype(dtype)
+            unit = np.datetime_data(dtype)[0]
 
-        data, inferred_freq = sequence_to_td64ns(data, copy=copy, unit=None)
+        data, inferred_freq = sequence_to_td64ns(data, copy=copy, unit=unit)
         freq, _ = dtl.validate_inferred_freq(None, inferred_freq, False)
         freq = cast("Tick | None", freq)
 

--- a/pandas/tests/indexing/test_scalar.py
+++ b/pandas/tests/indexing/test_scalar.py
@@ -90,7 +90,10 @@ class TestAtAndiAT:
                 Timestamp("2014-02-02"),
             ],
             [
-                Series(["1 days", "2 days"], dtype="timedelta64[ns]"),
+                Series(
+                    [86_400_000_000_000, 2 * 86_400_000_000_000],
+                    dtype="timedelta64[ns]",
+                ),
                 Timedelta("2 days"),
             ],
         ],


### PR DESCRIPTION
- [x] closes #48312 (Replace xxxx with the GitHub issue number)
- [x] closes #52457 (Replace xxxx with the GitHub issue number) 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

I think this should be backported since non-nano support is a new feature in 2.0