### PR TITLE
BUG: to_timedelta/datetime with numeric ArrowExtensionArray

### DIFF
--- a/doc/source/whatsnew/v2.0.1.rst
+++ b/doc/source/whatsnew/v2.0.1.rst
@@ -20,7 +20,7 @@ Fixed regressions
 
 Bug fixes
 ~~~~~~~~~
--
+- Bug in :func:`to_datetime` and :func:`to_timedelta` when trying to convert numeric data with a :class:`ArrowDtype` (:issue:`52425`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_201.other:

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -127,6 +127,7 @@ from pandas.core.arrays._mixins import (
     NDArrayBackedExtensionArray,
     ravel_compat,
 )
+from pandas.core.arrays.arrow.array import ArrowExtensionArray
 from pandas.core.arrays.base import ExtensionArray
 from pandas.core.arrays.integer import IntegerArray
 import pandas.core.common as com
@@ -2209,10 +2210,14 @@ def ensure_arraylike_for_datetimelike(data, copy: bool, cls_name: str):
     else:
         data = extract_array(data, extract_numpy=True)
 
-    if isinstance(data, IntegerArray):
+    if isinstance(data, IntegerArray) or (
+        isinstance(data, ArrowExtensionArray) and data.dtype.kind in "iu"
+    ):
         data = data.to_numpy("int64", na_value=iNaT)
         copy = False
-    elif not isinstance(data, (np.ndarray, ExtensionArray)):
+    elif not isinstance(data, (np.ndarray, ExtensionArray)) or isinstance(
+        data, ArrowExtensionArray
+    ):
         # GH#24539 e.g. xarray, dask object
         data = np.asarray(data)
 

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -22,7 +22,6 @@ from pandas._libs.tslibs import (
     iNaT,
     parsing,
 )
-from pandas.compat.pyarrow import pa_version_under7p0
 from pandas.errors import (
     OutOfBoundsDatetime,
     OutOfBoundsTimedelta,
@@ -3589,14 +3588,10 @@ def test_ignoring_unknown_tz_deprecated():
     tm.assert_index_equal(res, to_datetime([dtstr[:-5]]))
 
 
-@pytest.mark.skipif(pa_version_under7p0, reason="Requires Pyarrow")
-@pytest.mark.parametrize(
-    "pa_str_dtype",
-    tm.ALL_INT_PYARROW_DTYPES_STR_REPR + tm.FLOAT_PYARROW_DTYPES_STR_REPR,
-)
-def test_from_numeric_arrow_dtype(pa_str_dtype):
+def test_from_numeric_arrow_dtype(any_numeric_ea_dtype):
     # GH 52425
-    ser = Series([1, 2], dtype=pa_str_dtype)
+    pytest.importorskip("pyarrow")
+    ser = Series([1, 2], dtype=f"{any_numeric_ea_dtype.lower()}[pyarrow]")
     result = to_datetime(ser)
     expected = Series([1, 2], dtype="datetime64[ns]")
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -6,7 +6,6 @@ from datetime import (
 import numpy as np
 import pytest
 
-from pandas.compat.pyarrow import pa_version_under7p0
 from pandas.errors import OutOfBoundsTimedelta
 
 import pandas as pd
@@ -290,14 +289,10 @@ class TestTimedeltas:
         tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.skipif(pa_version_under7p0, reason="Requires Pyarrow")
-@pytest.mark.parametrize(
-    "pa_str_dtype",
-    tm.ALL_INT_PYARROW_DTYPES_STR_REPR + tm.FLOAT_PYARROW_DTYPES_STR_REPR,
-)
-def test_from_numeric_arrow_dtype(pa_str_dtype):
+def test_from_numeric_arrow_dtype(any_numeric_ea_dtype):
     # GH 52425
-    ser = Series([1, 2], dtype=pa_str_dtype)
+    pytest.importorskip("pyarrow")
+    ser = Series([1, 2], dtype=f"{any_numeric_ea_dtype.lower()}[pyarrow]")
     result = to_timedelta(ser)
     expected = Series([1, 2], dtype="timedelta64[ns]")
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -6,6 +6,7 @@ from datetime import (
 import numpy as np
 import pytest
 
+from pandas.compat.pyarrow import pa_version_under7p0
 from pandas.errors import OutOfBoundsTimedelta
 
 import pandas as pd
@@ -287,3 +288,16 @@ class TestTimedeltas:
         result = to_timedelta(ser)
         expected = Series([pd.Timedelta(1, unit="ns"), pd.NaT])
         tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.skipif(pa_version_under7p0, reason="Requires Pyarrow")
+@pytest.mark.parametrize(
+    "pa_str_dtype",
+    tm.ALL_INT_PYARROW_DTYPES_STR_REPR + tm.FLOAT_PYARROW_DTYPES_STR_REPR,
+)
+def test_from_numeric_arrow_dtype(pa_str_dtype):
+    # GH 52425
+    ser = Series([1, 2], dtype=pa_str_dtype)
+    result = to_timedelta(ser)
+    expected = Series([1, 2], dtype="timedelta64[ns]")
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #52425 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
