### PR TITLE
STYLE improve `validate-docstrings` ergonomics

### DIFF
--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1005,11 +1005,11 @@ class Window(BaseWindow):
     Rolling sum with a window span of 2 seconds.
 
     >>> df_time = pd.DataFrame({'B': [0, 1, 2, np.nan, 4]},
-    ...                        index = [pd.Timestamp('20130101 09:00:00'),
-    ...                                 pd.Timestamp('20130101 09:00:02'),
-    ...                                 pd.Timestamp('20130101 09:00:03'),
-    ...                                 pd.Timestamp('20130101 09:00:05'),
-    ...                                 pd.Timestamp('20130101 09:00:06')])
+    ...                        index=[pd.Timestamp('20130101 09:00:00'),
+    ...                               pd.Timestamp('20130101 09:00:02'),
+    ...                               pd.Timestamp('20130101 09:00:03'),
+    ...                               pd.Timestamp('20130101 09:00:05'),
+    ...                               pd.Timestamp('20130101 09:00:06')])
 
     >>> df_time
                            B

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -1770,16 +1770,16 @@ class Styler(StylerRenderer):
         Using ``subset`` to restrict application to a single column or multiple columns
 
         >>> df.style.apply(highlight_max, color='red', subset="A")
-        ...  # doctest: +SKIP
+        ... # doctest: +SKIP
         >>> df.style.apply(highlight_max, color='red', subset=["A", "B"])
-        ...  # doctest: +SKIP
+        ... # doctest: +SKIP
 
         Using a 2d input to ``subset`` to select rows in addition to columns
 
-        >>> df.style.apply(highlight_max, color='red', subset=([0,1,2], slice(None)))
-        ...  # doctest: +SKIP
-        >>> df.style.apply(highlight_max, color='red', subset=(slice(0,5,2), "A"))
-        ...  # doctest: +SKIP
+        >>> df.style.apply(highlight_max, color='red', subset=([0, 1, 2], slice(None)))
+        ... # doctest: +SKIP
+        >>> df.style.apply(highlight_max, color='red', subset=(slice(0, 5, 2), "A"))
+        ... # doctest: +SKIP
 
         Using a function which returns a Series / DataFrame of unequal length but
         containing valid index labels

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -157,13 +157,16 @@ class TestValidator:
             (
                 "BadDocstrings",
                 "unused_import",
-                ("flake8 error: F401 'pandas as pdf' imported but unused",),
+                (
+                    "flake8 error: line 1, col 1: F401 'pandas as pdf' "
+                    "imported but unused",
+                ),
             ),
             (
                 "BadDocstrings",
                 "missing_whitespace_around_arithmetic_operator",
                 (
-                    "flake8 error: "
+                    "flake8 error: line 1, col 2: "
                     "E226 missing whitespace around arithmetic operator",
                 ),
             ),
@@ -172,12 +175,15 @@ class TestValidator:
                 "indentation_is_not_a_multiple_of_four",
                 # with flake8 3.9.0, the message ends with four spaces,
                 #  whereas in earlier versions, it ended with "four"
-                ("flake8 error: E111 indentation is not a multiple of 4",),
+                (
+                    "flake8 error: line 2, col 3: E111 indentation is not a "
+                    "multiple of 4",
+                ),
             ),
             (
                 "BadDocstrings",
                 "missing_whitespace_after_comma",
-                ("flake8 error: E231 missing whitespace after ',' (3 times)",),
+                ("flake8 error: line 1, col 33: E231 missing whitespace after ','",),
             ),
             (
                 "BadDocstrings",

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,8 @@ max-line-length = 88
 ignore =
     # space before : (needed for how black formats slicing)
     E203,
+    # expected n blank lines
+    E3,
     # line break before binary operator
     W503,
     # line break after binary operator


### PR DESCRIPTION
Before opening an issue for EX03 errors, I just wanted to improve the usability of `validate_docstrings`

Currently it's kind of hard to tell which lines need to change, especially if there's a long docstring.

Now, here's what it shows for `python scripts/validate_docstrings.py pandas.Series.describe`:
```python
################################################################################
################################## Validation ##################################
################################################################################

3 Errors found for `pandas.Series.describe`:
        flake8 error: line 11, col 54: E231 missing whitespace after ','
        flake8 error: line 11, col 58: E231 missing whitespace after ','
        flake8 error: line 14, col 19: E124 closing bracket does not match visual indentation
```

From trying it out locally, this makes it much easier to tell what needs changing