### PR TITLE
REF: stricter calls to array_equivalent

### DIFF
--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -174,7 +174,7 @@ class NDArrayBackedExtensionArray(NDArrayBacked, ExtensionArray):
             return False
         if not is_dtype_equal(self.dtype, other.dtype):
             return False
-        return bool(array_equivalent(self._ndarray, other._ndarray))
+        return bool(array_equivalent(self._ndarray, other._ndarray, dtype_equal=True))
 
     @classmethod
     def _from_factorized(cls, values, original):

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -1026,7 +1026,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
 
         left = self._data[~self._mask]
         right = other._data[~other._mask]
-        return array_equivalent(left, right, dtype_equal=True)
+        return array_equivalent(left, right, strict_nan=True, dtype_equal=True)
 
     def _quantile(
         self, qs: npt.NDArray[np.float64], interpolation: str

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2223,7 +2223,9 @@ class IndexCol:
             if (
                 new_metadata is not None
                 and cur_metadata is not None
-                and not array_equivalent(new_metadata, cur_metadata)
+                and not array_equivalent(
+                    new_metadata, cur_metadata, strict_nan=True, dtype_equal=True
+                )
             ):
                 raise ValueError(
                     "cannot append a categorical with "
@@ -3855,10 +3857,18 @@ class Table(Fixed):
         if table_exists:
             indexer = len(new_non_index_axes)  # i.e. 0
             exist_axis = self.non_index_axes[indexer][1]
-            if not array_equivalent(np.array(append_axis), np.array(exist_axis)):
+            if not array_equivalent(
+                np.array(append_axis),
+                np.array(exist_axis),
+                strict_nan=True,
+                dtype_equal=True,
+            ):
                 # ahah! -> reindex
                 if array_equivalent(
-                    np.array(sorted(append_axis)), np.array(sorted(exist_axis))
+                    np.array(sorted(append_axis)),
+                    np.array(sorted(exist_axis)),
+                    strict_nan=True,
+                    dtype_equal=True,
                 ):
                     append_axis = exist_axis
 


### PR DESCRIPTION
Doesn't actually change anything in the affected cases, just makes the strictness explicit.