### PR TITLE
PERF: Series.corr/Series.cov for EA dtypes

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -196,6 +196,7 @@ Performance improvements
 - Performance improvement in :func:`factorize` for object columns not containing strings (:issue:`51921`)
 - Performance improvement in :class:`Series` reductions (:issue:`52341`)
 - Performance improvement in :meth:`Series.to_numpy` when dtype is a numpy float dtype and ``na_value`` is ``np.nan`` (:issue:`52430`)
+- Performance improvement in :meth:`Series.corr` and :meth:`Series.cov` for extension dtypes (:issue:`52502`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2701,8 +2701,8 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         if len(this) == 0:
             return np.nan
 
-        this_values = np.asarray(this._values)
-        other_values = np.asarray(other._values)
+        this_values = this.to_numpy(dtype=float, na_value=np.nan, copy=False)
+        other_values = other.to_numpy(dtype=float, na_value=np.nan, copy=False)
 
         if method in ["pearson", "spearman", "kendall"] or callable(method):
             return nanops.nancorr(
@@ -2759,8 +2759,8 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         this, other = self.align(other, join="inner", copy=False)
         if len(this) == 0:
             return np.nan
-        this_values = np.asarray(this._values)
-        other_values = np.asarray(other._values)
+        this_values = this.to_numpy(dtype=float, na_value=np.nan, copy=False)
+        other_values = other.to_numpy(dtype=float, na_value=np.nan, copy=False)
         return nanops.nancov(
             this_values, other_values, min_periods=min_periods, ddof=ddof
         )

--- a/pandas/tests/frame/methods/test_cov_corr.py
+++ b/pandas/tests/frame/methods/test_cov_corr.py
@@ -365,8 +365,8 @@ class TestDataFrameCorrWith:
             tm.assert_series_equal(result, expected)
         else:
             with pytest.raises(
-                TypeError,
-                match=r"Could not convert \['a' 'b' 'c' 'd'\] to numeric",
+                ValueError,
+                match="could not convert string to float",
             ):
                 df.corrwith(s, numeric_only=numeric_only)
 


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.1.0.rst` file if fixing a bug or adding a new feature.

```
import pandas as pd
import numpy as np

N = 1_000_000

ser1 = pd.Series(np.random.randn(N), dtype="Float64")
ser2 = pd.Series(np.random.randn(N), dtype="Float64")

%timeit ser1.corr(ser2)

# 849 ms ± 56.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)    -> main
# 33.7 ms ± 320 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)  -> PR

%timeit ser1.cov(ser2)

# 739 ms ± 15.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)    -> main
# 32.9 ms ± 713 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)  -> PR
```


Also, aligns the error raised for non-numeric data with that of `DataFrame.corr` and `DataFrame.cov`.
