### PR TITLE
REGR: fix Series construction from dict for subclasses

### DIFF
--- a/doc/source/whatsnew/v2.0.1.rst
+++ b/doc/source/whatsnew/v2.0.1.rst
@@ -13,7 +13,7 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
--
+- Fixed regression for subclassed Series when constructing from a dictionary (:issue:`52445`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_201.bug_fixes:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -561,12 +561,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             keys, values = (), []
 
         # Input is now list-like, so rely on "standard" construction:
-
-        s = self._constructor(
-            values,
-            index=keys,
-            dtype=dtype,
-        )
+        s = Series(values, index=keys, dtype=dtype)
 
         # Now we just make sure the order is respected, if any
         if data and index is not None:

--- a/pandas/tests/series/test_subclass.py
+++ b/pandas/tests/series/test_subclass.py
@@ -58,3 +58,21 @@ class TestSeriesSubclassing:
         s2 = tm.SubclassedSeries([1, 2, 3])
         assert s1.equals(s2)
         assert s2.equals(s1)
+
+
+class SubclassedSeries(pd.Series):
+    @property
+    def _constructor(self):
+        def _new(*args, **kwargs):
+            # some constructor logic that accesses the Series' name
+            if self.name == "test":
+                return pd.Series(*args, **kwargs)
+            return SubclassedSeries(*args, **kwargs)
+
+        return _new
+
+
+def test_constructor_from_dict():
+    # https://github.com/pandas-dev/pandas/issues/52445
+    result = SubclassedSeries({"a": 1, "b": 2, "c": 3})
+    assert isinstance(result, SubclassedSeries)


### PR DESCRIPTION
- [ ] closes #52445
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
