### PR TITLE
Make `infer_freq` accept `Series` of timezone-aware `Timestamp`s

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -229,7 +229,7 @@ Timedelta
 
 Timezones
 ^^^^^^^^^
--
+- Bug in :func:`infer_freq` that raises ``TypeError`` for ``Series`` of timezone-aware timestamps (:issue:`52456`)
 -
 
 Numeric

--- a/pandas/tests/tseries/frequencies/test_inference.py
+++ b/pandas/tests/tseries/frequencies/test_inference.py
@@ -237,7 +237,7 @@ def test_infer_freq_tz(tz_naive_fixture, expected, dates):
 
 
 def test_infer_freq_tz_series(tz_naive_fixture):
-    # infre_freq should work with both tz-naive and tz-aware series. See gh-52456
+    # infer_freq should work with both tz-naive and tz-aware series. See gh-52456
     tz = tz_naive_fixture
     idx = date_range("2021-01-01", "2021-01-04", tz=tz)
     series = idx.to_series().reset_index(drop=True)

--- a/pandas/tests/tseries/frequencies/test_inference.py
+++ b/pandas/tests/tseries/frequencies/test_inference.py
@@ -236,6 +236,15 @@ def test_infer_freq_tz(tz_naive_fixture, expected, dates):
     assert idx.inferred_freq == expected
 
 
+def test_infer_freq_tz_series(tz_naive_fixture):
+    # infre_freq should work with both tz-naive and tz-aware series. See gh-52456
+    tz = tz_naive_fixture
+    idx = date_range("2021-01-01", "2021-01-04", tz=tz)
+    series = idx.to_series().reset_index(drop=True)
+    inferred_freq = frequencies.infer_freq(series)
+    assert inferred_freq == "D"
+
+
 @pytest.mark.parametrize(
     "date_pair",
     [

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -32,6 +32,7 @@ from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.common import (
     is_datetime64_dtype,
+    is_datetime64tz_dtype,
     is_numeric_dtype,
     is_timedelta64_dtype,
 )
@@ -120,7 +121,7 @@ def infer_freq(
 
     Parameters
     ----------
-    index : DatetimeIndex or TimedeltaIndex
+    index : DatetimeIndex, TimedeltaIndex, Series or array-like
       If passed a Series will use the values of the series (NOT THE INDEX).
 
     Returns
@@ -150,6 +151,7 @@ def infer_freq(
         values = index._values
         if not (
             is_datetime64_dtype(values)
+            or is_datetime64tz_dtype(values)
             or is_timedelta64_dtype(values)
             or values.dtype == object
         ):


### PR DESCRIPTION
- [x] closes #52456
- [x] Fixed `infer_freq`'s documentation making it consistent with type annotation and implementation
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
