### PR TITLE
Backport PR #52518 on branch 2.0.x (WARN: std and var showing RuntimeWarning for ea dtype with one element

### DIFF
--- a/doc/source/whatsnew/v2.0.1.rst
+++ b/doc/source/whatsnew/v2.0.1.rst
@@ -14,6 +14,7 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Fixed regression for subclassed Series when constructing from a dictionary (:issue:`52445`)
+- Fixed regression in :meth:`Series.describe` showing ``RuntimeWarning`` for extension dtype :class:`Series` with one element (:issue:`52515`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_201.bug_fixes:

--- a/pandas/core/array_algos/masked_reductions.py
+++ b/pandas/core/array_algos/masked_reductions.py
@@ -5,6 +5,7 @@ for missing values.
 from __future__ import annotations
 
 from typing import Callable
+import warnings
 
 import numpy as np
 
@@ -166,9 +167,11 @@ def var(
     if not values.size or mask.all():
         return libmissing.NA
 
-    return _reductions(
-        np.var, values=values, mask=mask, skipna=skipna, axis=axis, ddof=ddof
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        return _reductions(
+            np.var, values=values, mask=mask, skipna=skipna, axis=axis, ddof=ddof
+        )
 
 
 def std(
@@ -182,6 +185,8 @@ def std(
     if not values.size or mask.all():
         return libmissing.NA
 
-    return _reductions(
-        np.std, values=values, mask=mask, skipna=skipna, axis=axis, ddof=ddof
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        return _reductions(
+            np.std, values=values, mask=mask, skipna=skipna, axis=axis, ddof=ddof
+        )

--- a/pandas/tests/extension/base/dim2.py
+++ b/pandas/tests/extension/base/dim2.py
@@ -12,7 +12,6 @@ from pandas.core.dtypes.common import (
 )
 
 import pandas as pd
-import pandas._testing as tm
 from pandas.core.arrays.integer import INT_STR_TO_DTYPE
 from pandas.tests.extension.base.base import BaseExtensionTests
 
@@ -200,12 +199,7 @@ class Dim2CompatTests(BaseExtensionTests):
             kwargs["ddof"] = 0
 
         try:
-            if method in ["mean", "var", "std"] and hasattr(data, "_mask"):
-                # Empty slices produced by the mask cause RuntimeWarnings by numpy
-                with tm.assert_produces_warning(RuntimeWarning, check_stacklevel=False):
-                    result = getattr(arr2d, method)(axis=0, **kwargs)
-            else:
-                result = getattr(arr2d, method)(axis=0, **kwargs)
+            result = getattr(arr2d, method)(axis=0, **kwargs)
         except Exception as err:
             try:
                 getattr(data, method)()

--- a/pandas/tests/frame/methods/test_describe.py
+++ b/pandas/tests/frame/methods/test_describe.py
@@ -388,9 +388,7 @@ class TestDataFrameDescribe:
         # GH#48778
 
         df = DataFrame({"a": [1, pd.NA, pd.NA], "b": pd.NA}, dtype=any_numeric_ea_dtype)
-        # Warning from numpy for taking std of single element
-        with tm.assert_produces_warning(RuntimeWarning, check_stacklevel=False):
-            result = df.describe()
+        result = df.describe()
         expected = DataFrame(
             {"a": [1.0, 1.0, pd.NA] + [1.0] * 5, "b": [0.0] + [pd.NA] * 7},
             index=["count", "mean", "std", "min", "25%", "50%", "75%", "max"],

--- a/pandas/tests/series/methods/test_describe.py
+++ b/pandas/tests/series/methods/test_describe.py
@@ -9,6 +9,7 @@ from pandas.core.dtypes.common import (
 )
 
 from pandas import (
+    NA,
     Period,
     Series,
     Timedelta,
@@ -185,5 +186,17 @@ class TestSeriesDescribe:
             ],
             index=["count", "mean", "std", "min", "25%", "50%", "75%", "max"],
             dtype=dtype,
+        )
+        tm.assert_series_equal(result, expected)
+
+    def test_describe_one_element_ea(self):
+        # GH#52515
+        ser = Series([0.0], dtype="Float64")
+        with tm.assert_produces_warning(None):
+            result = ser.describe()
+        expected = Series(
+            [1, 0, NA, 0, 0, 0, 0, 0],
+            dtype="Float64",
+            index=["count", "mean", "std", "min", "25%", "50%", "75%", "max"],
         )
         tm.assert_series_equal(result, expected)


### PR DESCRIPTION
#52518