### PR TITLE
PERF: concat(axis=1) for objects with different indexes

### DIFF
--- a/asv_bench/benchmarks/join_merge.py
+++ b/asv_bench/benchmarks/join_merge.py
@@ -73,7 +73,14 @@ class ConcatDataFrames:
 
 class ConcatIndexDtype:
     params = (
-        ["datetime64[ns]", "int64", "Int64", "string[python]", "string[pyarrow]"],
+        [
+            "datetime64[ns]",
+            "int64",
+            "Int64",
+            "int64[pyarrow]",
+            "string[python]",
+            "string[pyarrow]",
+        ],
         ["monotonic", "non_monotonic", "has_na"],
         [0, 1],
         [True, False],
@@ -84,7 +91,7 @@ class ConcatIndexDtype:
         N = 10_000
         if dtype == "datetime64[ns]":
             vals = date_range("1970-01-01", periods=N)
-        elif dtype in ("int64", "Int64"):
+        elif dtype in ("int64", "Int64", "int64[pyarrow]"):
             vals = np.arange(N, dtype=np.int64)
         elif dtype in ("string[python]", "string[pyarrow]"):
             vals = tm.makeStringIndex(N)

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -201,6 +201,7 @@ Performance improvements
 - Performance improvement in :meth:`Series.to_numpy` when dtype is a numpy float dtype and ``na_value`` is ``np.nan`` (:issue:`52430`)
 - Performance improvement in :meth:`Series.corr` and :meth:`Series.cov` for extension dtypes (:issue:`52502`)
 - Performance improvement in :meth:`~arrays.ArrowExtensionArray.to_numpy` (:issue:`52525`)
+- Performance improvement in :func:`concat` when ``axis=1`` and objects have different indexes (:issue:`52541`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -240,7 +240,10 @@ def union_indexes(indexes, sort: bool | None = True) -> Index:
         """
         if all(isinstance(ind, Index) for ind in inds):
             result = inds[0].append(inds[1:]).unique()
-            return result.astype(dtype, copy=False)
+            result = result.astype(dtype, copy=False)
+            if sort:
+                result = result.sort_values()
+            return result
 
         def conv(i):
             if isinstance(i, Index):

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -227,9 +227,7 @@ def union_indexes(indexes, sort: bool | None = True) -> Index:
 
     def _unique_indices(inds, dtype) -> Index:
         """
-        Convert indexes to lists and concatenate them, removing duplicates.
-
-        The final dtype is inferred.
+        Concatenate indices and remove duplicates.
 
         Parameters
         ----------
@@ -240,6 +238,9 @@ def union_indexes(indexes, sort: bool | None = True) -> Index:
         -------
         Index
         """
+        if all(isinstance(ind, Index) for ind in inds):
+            result = inds[0].append(inds[1:]).unique()
+            return result.astype(dtype, copy=False)
 
         def conv(i):
             if isinstance(i, Index):


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.1.0.rst` file if fixing a bug or adding a new feature.

Perf improvement for `concat(objects, axis=1)` when `objects` have different indexes.  

```
> asv continuous -f 1.1 upstream/main perf-concat-axis-1 -b join_merge.ConcatIndexDtype

       before           after         ratio
     [e58d1ba1]       [b8fbc611]
     <main>           <perf-concat-axis-1>
-         121±9μs          109±3μs     0.90  join_merge.ConcatIndexDtype.time_concat_series('Int64', 'has_na', 0, True)
-      2.67±0.2ms      2.40±0.02ms     0.90  join_merge.ConcatIndexDtype.time_concat_series('datetime64[ns]', 'non_monotonic', 1, False)
-     4.84±0.07ms      2.78±0.02ms     0.57  join_merge.ConcatIndexDtype.time_concat_series('Int64', 'non_monotonic', 1, True)
-     4.14±0.03ms      2.25±0.04ms     0.54  join_merge.ConcatIndexDtype.time_concat_series('Int64', 'monotonic', 1, True)
-     4.04±0.03ms      2.18±0.03ms     0.54  join_merge.ConcatIndexDtype.time_concat_series('Int64', 'monotonic', 1, False)
-     5.70±0.05ms       2.82±0.2ms     0.50  join_merge.ConcatIndexDtype.time_concat_series('Int64', 'has_na', 1, True)
-     4.27±0.08ms      2.11±0.03ms     0.49  join_merge.ConcatIndexDtype.time_concat_series('Int64', 'non_monotonic', 1, False)
-     4.76±0.07ms      2.27±0.06ms     0.48  join_merge.ConcatIndexDtype.time_concat_series('int64', 'non_monotonic', 1, True)
-      4.34±0.1ms      2.01±0.03ms     0.46  join_merge.ConcatIndexDtype.time_concat_series('int64', 'monotonic', 1, False)
-     5.21±0.09ms       2.32±0.2ms     0.45  join_merge.ConcatIndexDtype.time_concat_series('Int64', 'has_na', 1, False)
-     4.33±0.03ms      1.93±0.03ms     0.45  join_merge.ConcatIndexDtype.time_concat_series('int64', 'non_monotonic', 1, False)
-      4.59±0.2ms      1.98±0.04ms     0.43  join_merge.ConcatIndexDtype.time_concat_series('int64', 'monotonic', 1, True)
-      20.2±0.2ms       3.94±0.3ms     0.19  join_merge.ConcatIndexDtype.time_concat_series('int64[pyarrow]', 'has_na', 1, True)
-      18.9±0.5ms      2.96±0.04ms     0.16  join_merge.ConcatIndexDtype.time_concat_series('int64[pyarrow]', 'non_monotonic', 1, True)
-      19.0±0.1ms      2.94±0.06ms     0.15  join_merge.ConcatIndexDtype.time_concat_series('int64[pyarrow]', 'has_na', 1, False)
-      18.2±0.1ms       2.67±0.2ms     0.15  join_merge.ConcatIndexDtype.time_concat_series('int64[pyarrow]', 'monotonic', 1, False)
-      18.2±0.1ms      2.38±0.03ms     0.13  join_merge.ConcatIndexDtype.time_concat_series('int64[pyarrow]', 'monotonic', 1, True)
-      18.1±0.1ms      2.28±0.04ms     0.13  join_merge.ConcatIndexDtype.time_concat_series('int64[pyarrow]', 'non_monotonic', 1, False)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```