### PR TITLE
MAINT: remove `from numpy.math cimport` usages

### DIFF
--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -3,7 +3,10 @@ from cython cimport (
     Py_ssize_t,
     floating,
 )
-from libc.math cimport sqrt
+from libc.math cimport (
+    NAN,
+    sqrt,
+)
 from libc.stdlib cimport (
     free,
     malloc,
@@ -24,7 +27,6 @@ from numpy cimport (
     uint8_t,
     uint64_t,
 )
-from numpy.math cimport NAN
 
 cnp.import_array()
 

--- a/pandas/_libs/reshape.pyx
+++ b/pandas/_libs/reshape.pyx
@@ -9,7 +9,7 @@ from numpy cimport (
 import numpy as np
 
 cimport numpy as cnp
-from numpy.math cimport NAN
+from libc.math cimport NAN
 
 cnp.import_array()
 

--- a/pandas/_libs/sparse.pyx
+++ b/pandas/_libs/sparse.pyx
@@ -3,6 +3,10 @@ cimport cython
 import numpy as np
 
 cimport numpy as cnp
+from libc.math cimport (
+    INFINITY as INF,
+    NAN as NaN,
+)
 from numpy cimport (
     float64_t,
     int8_t,
@@ -10,10 +14,6 @@ from numpy cimport (
     int64_t,
     ndarray,
     uint8_t,
-)
-from numpy.math cimport (
-    INFINITY as INF,
-    NAN as NaN,
 )
 
 cnp.import_array()


### PR DESCRIPTION
These are available from Cython's `libc`, which is cleaner. NumPy would like to get rid of shipping libnpymath, and has also deprecated the (unrelated) `numpy.math` in the Python API. So best to not use it from Cython either.