### PR TITLE
BUG: __from_arrow__ not respecting explicit dtype

### DIFF
--- a/doc/source/whatsnew/v2.0.1.rst
+++ b/doc/source/whatsnew/v2.0.1.rst
@@ -26,6 +26,7 @@ Bug fixes
 - Bug in :meth:`Series.describe` not returning :class:`ArrowDtype` with ``pyarrow.float64`` type with numeric data (:issue:`52427`)
 - Fixed segfault in :meth:`Series.to_numpy` with ``null[pyarrow]`` dtype (:issue:`52443`)
 - Bug in :func:`pandas.testing.assert_series_equal` where ``check_dtype=False`` would still raise for datetime or timedelta types with different resolutions (:issue:`52449`)
+- Bug in :meth:`ArrowDtype.__from_arrow__` not respecting if dtype is explicitly given (:issue:`52533`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_201.other:

--- a/pandas/core/arrays/arrow/dtype.py
+++ b/pandas/core/arrays/arrow/dtype.py
@@ -27,6 +27,7 @@ from pandas.core.dtypes.dtypes import CategoricalDtypeType
 
 if not pa_version_under7p0:
     import pyarrow as pa
+    import pyarrow.compute as pc
 
 if TYPE_CHECKING:
     from pandas._typing import (
@@ -319,4 +320,5 @@ class ArrowDtype(StorageExtensionDtype):
         Construct IntegerArray/FloatingArray from pyarrow Array/ChunkedArray.
         """
         array_class = self.construct_array_type()
-        return array_class(array)
+        arr = pc.cast(array, self.pyarrow_dtype, safe=True)
+        return array_class(arr)

--- a/pandas/core/arrays/arrow/dtype.py
+++ b/pandas/core/arrays/arrow/dtype.py
@@ -27,7 +27,6 @@ from pandas.core.dtypes.dtypes import CategoricalDtypeType
 
 if not pa_version_under7p0:
     import pyarrow as pa
-    import pyarrow.compute as pc
 
 if TYPE_CHECKING:
     from pandas._typing import (
@@ -320,5 +319,5 @@ class ArrowDtype(StorageExtensionDtype):
         Construct IntegerArray/FloatingArray from pyarrow Array/ChunkedArray.
         """
         array_class = self.construct_array_type()
-        arr = pc.cast(array, self.pyarrow_dtype, safe=True)
+        arr = array.cast(self.pyarrow_dtype, safe=True)
         return array_class(arr)

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -1754,6 +1754,7 @@ def test_from_arrow_respecting_given_dtype():
     tm.assert_series_equal(result, expected)
 
 
+@pytest.mark.skipif(pa_version_under8p0, reason="returns object with 7.0")
 def test_from_arrow_respecting_given_dtype_unsafe():
     array = pa.array([1.5, 2.5], type=pa.float64())
     with pytest.raises(pa.ArrowInvalid, match="Float value 1.5 was truncated"):

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -1754,7 +1754,6 @@ def test_from_arrow_respecting_given_dtype():
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.skipif(pa_version_under8p0, reason="returns object with 7.0")
 def test_from_arrow_respecting_given_dtype_unsafe():
     array = pa.array([1.5, 2.5], type=pa.float64())
     with pytest.raises(pa.ArrowInvalid, match="Float value 1.5 was truncated"):

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -1754,7 +1754,7 @@ def test_from_arrow_respecting_given_dtype():
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.skipif(pa_version_under8p0, reason="returns object with 7.0")
+@pytest.mark.skipif(pa_version_under8p0, reason="doesn't raise with 7")
 def test_from_arrow_respecting_given_dtype_unsafe():
     array = pa.array([1.5, 2.5], type=pa.float64())
     with pytest.raises(pa.ArrowInvalid, match="Float value 1.5 was truncated"):

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -1754,6 +1754,13 @@ def test_from_arrow_respecting_given_dtype():
     tm.assert_series_equal(result, expected)
 
 
+@pytest.mark.skipif(pa_version_under8p0, reason="returns object with 7.0")
+def test_from_arrow_respecting_given_dtype_unsafe():
+    array = pa.array([1.5, 2.5], type=pa.float64())
+    with pytest.raises(pa.ArrowInvalid, match="Float value 1.5 was truncated"):
+        array.to_pandas(types_mapper={pa.float64(): ArrowDtype(pa.int64())}.get)
+
+
 def test_round():
     dtype = "float64[pyarrow]"
 

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -1739,6 +1739,20 @@ def test_setitem_invalid_dtype(data):
         data[:] = fill_value
 
 
+def test_from_arrow_respecting_given_dtype():
+    date_array = pa.array(
+        [pd.Timestamp("2019-12-31"), pd.Timestamp("2019-12-31")], type=pa.date32()
+    )
+    result = date_array.to_pandas(
+        types_mapper={pa.date32(): ArrowDtype(pa.date64())}.get
+    )
+    expected = pd.Series(
+        [pd.Timestamp("2019-12-31"), pd.Timestamp("2019-12-31")],
+        dtype=ArrowDtype(pa.date64()),
+    )
+    tm.assert_series_equal(result, expected)
+
+
 def test_round():
     dtype = "float64[pyarrow]"
 

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -1739,6 +1739,7 @@ def test_setitem_invalid_dtype(data):
         data[:] = fill_value
 
 
+@pytest.mark.skipif(pa_version_under8p0, reason="returns object with 7.0")
 def test_from_arrow_respecting_given_dtype():
     date_array = pa.array(
         [pd.Timestamp("2019-12-31"), pd.Timestamp("2019-12-31")], type=pa.date32()


### PR DESCRIPTION
- [x] closes #52533 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

cc @mroeschke thoughts?