### PR TITLE
DEPR: use DeprecationWarning for Categorical fastpath deprecation

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -381,7 +381,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
             warnings.warn(
                 "The 'fastpath' keyword in Categorical is deprecated and will "
                 "be removed in a future version. Use Categorical.from_codes instead",
-                FutureWarning,
+                DeprecationWarning,
                 stacklevel=find_stack_level(),
             )
         else:

--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -36,7 +36,7 @@ class TestCategoricalConstructors:
         codes = np.array([1, 2, 3])
         dtype = CategoricalDtype(categories=["a", "b", "c", "d"], ordered=False)
         msg = "The 'fastpath' keyword in Categorical is deprecated"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
             Categorical(codes, dtype=dtype, fastpath=True)
 
     def test_categorical_from_cat_and_dtype_str_preserve_ordered(self):


### PR DESCRIPTION
Follow-up on https://github.com/pandas-dev/pandas/pull/52472, changing the warning type. I expect this fastpath to be used in libraries (at least pyarrow did), and first using DeprecationWarning avoids that users see this warning if it's not coming from their own code (i.e. avoids warnings they can't do anything about).