### PR TITLE
DEPR: unused keywords in DTI/TDI construtors

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -232,8 +232,8 @@ Deprecations
 - Deprecated :func:`is_int64_dtype`, check ``dtype == np.dtype(np.int64)`` instead (:issue:`52564`)
 - Deprecated :func:`is_interval_dtype`, check ``isinstance(dtype, pd.IntervalDtype)`` instead (:issue:`52607`)
 - Deprecated :func:`is_datetime64tz_dtype`, check ``isinstance(dtype, pd.DatetimeTZDtype)`` instead (:issue:`52607`)
-- Deprecated unused "closed" and "normalize" keywords in the :class:`DatetimeIndex` constructor (:issue:`??`)
-- Deprecated unused "closed" keyword in the :class:`TimedeltaIndex` constructor (:issue:`??`)
+- Deprecated unused "closed" and "normalize" keywords in the :class:`DatetimeIndex` constructor (:issue:`52628`)
+- Deprecated unused "closed" keyword in the :class:`TimedeltaIndex` constructor (:issue:`52628`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -232,6 +232,8 @@ Deprecations
 - Deprecated :func:`is_int64_dtype`, check ``dtype == np.dtype(np.int64)`` instead (:issue:`52564`)
 - Deprecated :func:`is_interval_dtype`, check ``isinstance(dtype, pd.IntervalDtype)`` instead (:issue:`52607`)
 - Deprecated :func:`is_datetime64tz_dtype`, check ``isinstance(dtype, pd.DatetimeTZDtype)`` instead (:issue:`52607`)
+- Deprecated unused "closed" and "normalize" keywords in the :class:`DatetimeIndex` constructor (:issue:`??`)
+- Deprecated unused "closed" keyword in the :class:`TimedeltaIndex` constructor (:issue:`??`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -29,6 +29,7 @@ from pandas.util._decorators import (
     cache_readonly,
     doc,
 )
+from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.common import (
     is_datetime64_dtype,
@@ -152,9 +153,15 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         Set the Timezone of the data.
     normalize : bool, default False
         Normalize start/end dates to midnight before generating date range.
+
+        .. deprecated:: 2.1.0
+
     closed : {'left', 'right'}, optional
         Set whether to include `start` and `end` that are on the
         boundary. The default includes boundary points on either end.
+
+        .. deprecated:: 2.1.0
+
     ambiguous : 'infer', bool-ndarray, 'NaT', default 'raise'
         When clocks moved backward due to DST, ambiguous times may arise.
         For example in Central European Time (UTC+01), when going from 03:00
@@ -310,8 +317,8 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         data=None,
         freq: Frequency | lib.NoDefault = lib.no_default,
         tz=lib.no_default,
-        normalize: bool = False,
-        closed=None,
+        normalize: bool | lib.NoDefault = lib.no_default,
+        closed=lib.no_default,
         ambiguous: TimeAmbiguous = "raise",
         dayfirst: bool = False,
         yearfirst: bool = False,
@@ -319,6 +326,21 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         copy: bool = False,
         name: Hashable = None,
     ) -> Self:
+        if closed is not lib.no_default:
+            warnings.warn(
+                f"The 'closed' keyword in {cls.__name__} construction is "
+                "deprecated and will be removed in a future version.",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
+        if normalize is not lib.no_default:
+            warnings.warn(
+                f"The 'normalize' keyword in {cls.__name__} construction is "
+                "deprecated and will be removed in a future version.",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
+
         if is_scalar(data):
             cls._raise_scalar_data_error(data)
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -327,6 +327,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         name: Hashable = None,
     ) -> Self:
         if closed is not lib.no_default:
+            # GH#52628
             warnings.warn(
                 f"The 'closed' keyword in {cls.__name__} construction is "
                 "deprecated and will be removed in a future version.",
@@ -334,6 +335,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
                 stacklevel=find_stack_level(),
             )
         if normalize is not lib.no_default:
+            # GH#52628
             warnings.warn(
                 f"The 'normalize' keyword in {cls.__name__} construction is "
                 "deprecated and will be removed in a future version.",

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -143,6 +143,7 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
         name=None,
     ):
         if closed is not lib.no_default:
+            # GH#52628
             warnings.warn(
                 f"The 'closed' keyword in {cls.__name__} construction is "
                 "deprecated and will be removed in a future version.",

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+import warnings
 
 from pandas._libs import (
     index as libindex,
@@ -12,6 +13,7 @@ from pandas._libs.tslibs import (
     Timedelta,
     to_offset,
 )
+from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.common import (
     is_dtype_equal,
@@ -67,6 +69,9 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
         One of pandas date offset strings or corresponding objects. The string
         'infer' can be passed in order to set the frequency of the index as the
         inferred frequency upon creation.
+    dtype : numpy.dtype or str, default None
+        Valid NumPy dtypes are timedelta64[ns]’, timedelta64[us]’,
+        timedelta64[ms]’, and timedelta64[s]’.
     copy  : bool
         Make a copy of input ndarray.
     name : object
@@ -132,11 +137,19 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
         data=None,
         unit=None,
         freq=lib.no_default,
-        closed=None,
+        closed=lib.no_default,
         dtype=None,
         copy: bool = False,
         name=None,
     ):
+        if closed is not lib.no_default:
+            warnings.warn(
+                f"The 'closed' keyword in {cls.__name__} construction is "
+                "deprecated and will be removed in a future version.",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
+
         name = maybe_extract_name(name, data, cls)
 
         if is_scalar(data):

--- a/pandas/tests/indexes/datetimes/test_constructors.py
+++ b/pandas/tests/indexes/datetimes/test_constructors.py
@@ -34,11 +34,13 @@ from pandas.core.arrays import (
 
 class TestDatetimeIndex:
     def test_closed_deprecated(self):
+        # GH#52628
         msg = "The 'closed' keyword"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             DatetimeIndex([], closed=True)
 
     def test_normalize_deprecated(self):
+        # GH#52628
         msg = "The 'normalize' keyword"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             DatetimeIndex([], normalize=True)

--- a/pandas/tests/indexes/datetimes/test_constructors.py
+++ b/pandas/tests/indexes/datetimes/test_constructors.py
@@ -33,6 +33,16 @@ from pandas.core.arrays import (
 
 
 class TestDatetimeIndex:
+    def test_closed_deprecated(self):
+        msg = "The 'closed' keyword"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            DatetimeIndex([], closed=True)
+
+    def test_normalize_deprecated(self):
+        msg = "The 'normalize' keyword"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            DatetimeIndex([], normalize=True)
+
     def test_from_dt64_unsupported_unit(self):
         # GH#49292
         val = np.datetime64(1, "D")

--- a/pandas/tests/indexes/timedeltas/test_constructors.py
+++ b/pandas/tests/indexes/timedeltas/test_constructors.py
@@ -18,6 +18,11 @@ from pandas.core.arrays.timedeltas import (
 
 
 class TestTimedeltaIndex:
+    def test_closed_deprecated(self):
+        msg = "The 'closed' keyword"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            TimedeltaIndex([], closed=True)
+
     def test_array_of_dt64_nat_raises(self):
         # GH#39462
         nat = np.datetime64("NaT", "ns")

--- a/pandas/tests/indexes/timedeltas/test_constructors.py
+++ b/pandas/tests/indexes/timedeltas/test_constructors.py
@@ -19,6 +19,7 @@ from pandas.core.arrays.timedeltas import (
 
 class TestTimedeltaIndex:
     def test_closed_deprecated(self):
+        # GH#52628
         msg = "The 'closed' keyword"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             TimedeltaIndex([], closed=True)


### PR DESCRIPTION
- [x] closes #49153 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
