### PR TITLE
CLN: Use #pragma once instead of include guards

### DIFF
--- a/pandas/_libs/pd_parser.h
+++ b/pandas/_libs/pd_parser.h
@@ -6,8 +6,7 @@ All rights reserved.
 Distributed under the terms of the BSD Simplified License.
 
 */
-#ifndef PANDAS__LIBS_PD_PARSER_H_
-#define PANDAS__LIBS_PD_PARSER_H_
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -110,4 +109,3 @@ static PandasParser_CAPI *PandasParserAPI = NULL;
 #ifdef __cplusplus
 }
 #endif
-#endif  // PANDAS__LIBS_PD_PARSER_H_

--- a/pandas/_libs/src/headers/portable.h
+++ b/pandas/_libs/src/headers/portable.h
@@ -1,5 +1,4 @@
-#ifndef _PANDAS_PORTABLE_H_
-#define _PANDAS_PORTABLE_H_
+#pragma once
 
 #include <string.h>
 
@@ -14,5 +13,3 @@
 #define isspace_ascii(c) (((c) == ' ') || (((unsigned)(c) - '\t') < 5))
 #define toupper_ascii(c) ((((unsigned)(c) - 'a') < 26) ? ((c) & 0x5f) : (c))
 #define tolower_ascii(c) ((((unsigned)(c) - 'A') < 26) ? ((c) | 0x20) : (c))
-
-#endif

--- a/pandas/_libs/src/inline_helper.h
+++ b/pandas/_libs/src/inline_helper.h
@@ -7,8 +7,7 @@ Distributed under the terms of the BSD Simplified License.
 The full license is in the LICENSE file, distributed with this software.
 */
 
-#ifndef PANDAS__LIBS_SRC_INLINE_HELPER_H_
-#define PANDAS__LIBS_SRC_INLINE_HELPER_H_
+#pragma once
 
 #ifndef PANDAS_INLINE
   #if defined(__clang__)
@@ -23,5 +22,3 @@ The full license is in the LICENSE file, distributed with this software.
     #define PANDAS_INLINE
   #endif  // __GNUC__
 #endif  // PANDAS_INLINE
-
-#endif  // PANDAS__LIBS_SRC_INLINE_HELPER_H_

--- a/pandas/_libs/src/parser/io.h
+++ b/pandas/_libs/src/parser/io.h
@@ -7,8 +7,7 @@ Distributed under the terms of the BSD Simplified License.
 The full license is in the LICENSE file, distributed with this software.
 */
 
-#ifndef PANDAS__LIBS_SRC_PARSER_IO_H_
-#define PANDAS__LIBS_SRC_PARSER_IO_H_
+#pragma once
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
@@ -30,5 +29,3 @@ int del_rd_source(void *src);
 
 void *buffer_rd_bytes(void *source, size_t nbytes, size_t *bytes_read,
                       int *status, const char *encoding_errors);
-
-#endif  // PANDAS__LIBS_SRC_PARSER_IO_H_

--- a/pandas/_libs/src/parser/tokenizer.h
+++ b/pandas/_libs/src/parser/tokenizer.h
@@ -9,8 +9,7 @@ See LICENSE for the license
 
 */
 
-#ifndef PANDAS__LIBS_SRC_PARSER_TOKENIZER_H_
-#define PANDAS__LIBS_SRC_PARSER_TOKENIZER_H_
+#pragma once
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
@@ -232,5 +231,3 @@ double precise_xstrtod(const char *p, char **q, char decimal,
 double round_trip(const char *p, char **q, char decimal, char sci, char tsep,
                   int skip_trailing, int *error, int *maybe_int);
 int to_boolean(const char *item, uint8_t *val);
-
-#endif  // PANDAS__LIBS_SRC_PARSER_TOKENIZER_H_

--- a/pandas/_libs/src/skiplist.h
+++ b/pandas/_libs/src/skiplist.h
@@ -13,8 +13,7 @@ Port of Wes McKinney's Cython version of Raymond Hettinger's original pure
 Python recipe (https://rhettinger.wordpress.com/2010/02/06/lost-knowledge/)
 */
 
-#ifndef PANDAS__LIBS_SRC_SKIPLIST_H_
-#define PANDAS__LIBS_SRC_SKIPLIST_H_
+#pragma once
 
 #include <math.h>
 #include <stdio.h>
@@ -296,5 +295,3 @@ PANDAS_INLINE int skiplist_remove(skiplist_t *skp, double value) {
     --(skp->size);
     return 1;
 }
-
-#endif  // PANDAS__LIBS_SRC_SKIPLIST_H_

--- a/pandas/_libs/src/ujson/lib/ultrajson.h
+++ b/pandas/_libs/src/ujson/lib/ultrajson.h
@@ -49,8 +49,7 @@ tree doesn't have cyclic references.
 
 */
 
-#ifndef PANDAS__LIBS_SRC_UJSON_LIB_ULTRAJSON_H_
-#define PANDAS__LIBS_SRC_UJSON_LIB_ULTRAJSON_H_
+#pragma once
 
 #include <stdio.h>
 #include <wchar.h>
@@ -313,5 +312,3 @@ typedef struct __JSONObjectDecoder {
 EXPORTFUNCTION JSOBJ JSON_DecodeObject(JSONObjectDecoder *dec,
                                        const char *buffer, size_t cbBuffer);
 EXPORTFUNCTION void encode(JSOBJ, JSONObjectEncoder *, const char *, size_t);
-
-#endif  // PANDAS__LIBS_SRC_UJSON_LIB_ULTRAJSON_H_

--- a/pandas/_libs/src/ujson/python/version.h
+++ b/pandas/_libs/src/ujson/python/version.h
@@ -35,9 +35,6 @@ https://www.opensource.apple.com/source/tcl/tcl-14/tcl/license.terms
  * Copyright (c) 1994 Sun Microsystems, Inc.
 */
 
-#ifndef PANDAS__LIBS_SRC_UJSON_PYTHON_VERSION_H_
-#define PANDAS__LIBS_SRC_UJSON_PYTHON_VERSION_H_
+#pragma once
 
 #define UJSON_VERSION "1.33"
-
-#endif  // PANDAS__LIBS_SRC_UJSON_PYTHON_VERSION_H_

--- a/pandas/_libs/tslibs/src/datetime/date_conversions.h
+++ b/pandas/_libs/tslibs/src/datetime/date_conversions.h
@@ -5,8 +5,7 @@ Distributed under the terms of the BSD Simplified License.
 The full license is in the LICENSE file, distributed with this software.
 */
 
-#ifndef PANDAS__LIBS_TSLIBS_SRC_DATETIME_DATE_CONVERSIONS_H_
-#define PANDAS__LIBS_TSLIBS_SRC_DATETIME_DATE_CONVERSIONS_H_
+#pragma once
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
@@ -35,5 +34,3 @@ char *PyDateTimeToIso(PyObject *obj, NPY_DATETIMEUNIT base, size_t *len);
 npy_datetime PyDateTimeToEpoch(PyObject *dt, NPY_DATETIMEUNIT base);
 
 char *int64ToIsoDuration(int64_t value, size_t *len);
-
-#endif  // PANDAS__LIBS_TSLIBS_SRC_DATETIME_DATE_CONVERSIONS_H_

--- a/pandas/_libs/tslibs/src/datetime/np_datetime.h
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime.h
@@ -14,8 +14,7 @@ This file is derived from NumPy 1.7. See NUMPY_LICENSE.txt
 
 */
 
-#ifndef PANDAS__LIBS_TSLIBS_SRC_DATETIME_NP_DATETIME_H_
-#define PANDAS__LIBS_TSLIBS_SRC_DATETIME_NP_DATETIME_H_
+#pragma once
 
 #ifndef NPY_NO_DEPRECATED_API
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
@@ -114,6 +113,3 @@ add_minutes_to_datetimestruct(npy_datetimestruct *dts, int minutes);
  */
 PyArray_DatetimeMetaData get_datetime_metadata_from_dtype(
         PyArray_Descr *dtype);
-
-
-#endif  // PANDAS__LIBS_TSLIBS_SRC_DATETIME_NP_DATETIME_H_

--- a/pandas/_libs/tslibs/src/datetime/np_datetime_strings.h
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime_strings.h
@@ -19,8 +19,7 @@ This file implements string parsing and creation for NumPy datetime.
 
 */
 
-#ifndef PANDAS__LIBS_TSLIBS_SRC_DATETIME_NP_DATETIME_STRINGS_H_
-#define PANDAS__LIBS_TSLIBS_SRC_DATETIME_NP_DATETIME_STRINGS_H_
+#pragma once
 
 #ifndef NPY_NO_DEPRECATED_API
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
@@ -108,4 +107,3 @@ make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
  */
 int make_iso_8601_timedelta(pandas_timedeltastruct *tds, char *outstr,
                             size_t *outlen);
-#endif  // PANDAS__LIBS_TSLIBS_SRC_DATETIME_NP_DATETIME_STRINGS_H_

--- a/pandas/_libs/tslibs/src/datetime/pd_datetime.h
+++ b/pandas/_libs/tslibs/src/datetime/pd_datetime.h
@@ -15,8 +15,7 @@ All rights reserved.
 See NUMPY_LICENSE.txt for the license.
 */
 
-#ifndef PANDAS__LIBS_TSLIBS_SRC_DATETIME_PD_DATETIME_H_
-#define PANDAS__LIBS_TSLIBS_SRC_DATETIME_PD_DATETIME_H_
+#pragma once
 
 #ifndef NPY_NO_DEPRECATED_API
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
@@ -112,4 +111,3 @@ static PandasDateTime_CAPI *PandasDateTimeAPI = NULL;
 #ifdef __cplusplus
 }
 #endif
-#endif  // PANDAS__LIBS_TSLIBS_SRC_DATETIME_PD_DATETIME_H_


### PR DESCRIPTION
Shouldn't make any practical difference, but the include guards are a bit annoying and error prone to update if you move files around.

https://en.wikipedia.org/wiki/Pragma_once