### PR TITLE
TST: crosstab margins with ordered categorical column

### DIFF
--- a/pandas/tests/reshape/test_crosstab.py
+++ b/pandas/tests/reshape/test_crosstab.py
@@ -818,6 +818,27 @@ class TestCrosstab:
         )
         tm.assert_frame_equal(result, expected)
 
+    def test_margin_with_ordered_categorical_column(self):
+        # GH 25278
+        df = DataFrame(
+            {
+                "First": ["B", "B", "C", "A", "B", "C"],
+                "Second": ["C", "B", "B", "B", "C", "A"],
+            }
+        )
+        df["First"] = df["First"].astype(CategoricalDtype(ordered=True))
+        customized_categories_order = ["C", "A", "B"]
+        df["First"] = df["First"].cat.reorder_categories(customized_categories_order)
+        result = crosstab(df["First"], df["Second"], margins=True)
+
+        expected_index = Index(["C", "A", "B", "All"], name="First")
+        expected_columns = Index(["A", "B", "C", "All"], name="Second")
+        expected_data = [[1, 1, 0, 2], [0, 1, 0, 1], [0, 1, 2, 3], [1, 3, 2, 6]]
+        expected = DataFrame(
+            expected_data, index=expected_index, columns=expected_columns
+        )
+        tm.assert_frame_equal(result, expected)
+
 
 @pytest.mark.parametrize("a_dtype", ["category", "int64"])
 @pytest.mark.parametrize("b_dtype", ["category", "int64"])


### PR DESCRIPTION
- [x] closes #25278
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
