### PR TITLE
Fixed import error message when extensions not built

### DIFF
--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -28,7 +28,7 @@ except ImportError as _err:  # pragma: no cover
     raise ImportError(
         f"C extension: {_module} not built. If you want to import "
         "pandas from the source directory, you may need to run "
-        "'python setup.py build_ext --force' to build the C extensions first."
+        "'python setup.py build_ext' to build the C extensions first."
     ) from _err
 
 from pandas._config import (

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -18,11 +18,9 @@ if _missing_dependencies:  # pragma: no cover
     )
 del _hard_dependencies, _dependency, _missing_dependencies
 
-# numpy compat
-from pandas.compat import is_numpy_dev as _is_numpy_dev  # pyright: ignore # noqa:F401
-
 try:
-    from pandas._libs import hashtable as _hashtable, lib as _lib, tslib as _tslib
+    # numpy compat
+    pass  # pyright: ignore # noqa:F401
 except ImportError as _err:  # pragma: no cover
     _module = _err.name
     raise ImportError(
@@ -30,8 +28,6 @@ except ImportError as _err:  # pragma: no cover
         "pandas from the source directory, you may need to run "
         "'python setup.py build_ext --force' to build the C extensions first."
     ) from _err
-else:
-    del _tslib, _lib, _hashtable
 
 from pandas._config import (
     get_option,

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -20,7 +20,9 @@ del _hard_dependencies, _dependency, _missing_dependencies
 
 try:
     # numpy compat
-    pass  # pyright: ignore # noqa:F401
+    from pandas.compat import (
+        is_numpy_dev as _is_numpy_dev,  # pyright: ignore # noqa:F401
+    )
 except ImportError as _err:  # pragma: no cover
     _module = _err.name
     raise ImportError(


### PR DESCRIPTION
From a quick glance at the newcomers slack channel this is the question people ask about most often. It looks like pandas.compat indirectly imports the _libs folder via util._dectorators grabbing `cache_readonly`, so our try...except never gets the chance to run.

It would be nice to add a test for this, not sure the cleanest way how