### PR TITLE
CLN: Remove unneeded check in BaseMaskedArray.sum

### DIFF
--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -1108,13 +1108,6 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
     ):
         nv.validate_sum((), kwargs)
 
-        # TODO: do this in validate_sum?
-        if "out" in kwargs:
-            # np.sum; test_floating_array_numpy_sum
-            if kwargs["out"] is not None:
-                raise NotImplementedError
-            kwargs.pop("out")
-
         result = masked_reductions.sum(
             self._data,
             self._mask,


### PR DESCRIPTION
The `"out"` kwarg is already checked for in `nv.validate_sum` right above.