### PR TITLE
DEV: update gitpod to give user cache write permissions (fix pre-commit)

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,7 +14,6 @@ tasks:
       git pull --unshallow  # need to force this else the prebuild fails
       git fetch --tags
       python setup.py build_ext -j 4
-      python -m pip install -e . --no-build-isolation
       echo "🛠 Completed rebuilding Pandas!! 🛠 "
       echo "✨ Pre-build complete! You can close this terminal ✨ "
 

--- a/gitpod/gitpod.Dockerfile
+++ b/gitpod/gitpod.Dockerfile
@@ -34,6 +34,7 @@ WORKDIR ${WORKSPACE}
 # Build pandas to populate the cache used by ccache
 RUN git config --global --add safe.directory /workspace/pandas
 RUN conda activate ${CONDA_ENV} && \
+    python -m pip install -e . --no-build-isolation && \
     python setup.py build_ext --inplace && \
     ccache -s
 
@@ -43,4 +44,5 @@ RUN rm -rf ${WORKSPACE}
 
 # -----------------------------------------------------------------------------
 # Always return to non privileged user
+RUN chown -R gitpod:gitpod /home/gitpod/.cache/
 USER gitpod


### PR DESCRIPTION
Currently installing pre-commit hooks gives a permission error, this fixes that. 

In addition, I moved the `pip install` from the gitpod custom build commands to the docker image, so this is done in advance