### PR TITLE
Return dtype with appropriate resolution in DatetimeTZDtype.base

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -298,6 +298,7 @@ Timedelta
 Timezones
 ^^^^^^^^^
 - Bug in :func:`infer_freq` that raises ``TypeError`` for ``Series`` of timezone-aware timestamps (:issue:`52456`)
+- Bug in :meth:`DatetimeTZDtype.base` that always returns a NumPy dtype with nanosecond resolution (:issue:`52705`)
 -
 
 Numeric

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -676,7 +676,6 @@ class DatetimeTZDtype(PandasExtensionDtype):
     type: type[Timestamp] = Timestamp
     kind: str_type = "M"
     num = 101
-    base = np.dtype("M8[ns]")  # TODO: depend on reso?
     _metadata = ("unit", "tz")
     _match = re.compile(r"(datetime64|M8)\[(?P<unit>.+), (?P<tz>.+)\]")
     _cache_dtypes: dict[str_type, PandasExtensionDtype] = {}
@@ -684,6 +683,10 @@ class DatetimeTZDtype(PandasExtensionDtype):
     @property
     def na_value(self) -> NaTType:
         return NaT
+
+    @cache_readonly
+    def base(self) -> DtypeObj:
+        return np.dtype(f"M8[{self.unit}]")
 
     # error: Signature of "str" incompatible with supertype "PandasExtensionDtype"
     @cache_readonly

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -685,7 +685,7 @@ class DatetimeTZDtype(PandasExtensionDtype):
         return NaT
 
     @cache_readonly
-    def base(self) -> DtypeObj:
+    def base(self) -> DtypeObj:  # type: ignore[override]
         return np.dtype(f"M8[{self.unit}]")
 
     # error: Signature of "str" incompatible with supertype "PandasExtensionDtype"

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -276,6 +276,7 @@ class TestDatetimeTZDtype(Base):
         assert res._creso == NpyDatetimeUnit.NPY_FR_ms.value
         assert res.str == "|M8[ms]"
         assert str(res) == "datetime64[ms, US/Eastern]"
+        assert res.base == np.dtype("M8[ms]")
 
     def test_day_not_supported(self):
         msg = "DatetimeTZDtype only supports s, ms, us, ns units"


### PR DESCRIPTION
- [x] closes https://github.com/pandas-dev/pandas/issues/52705 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
