### PR TITLE
DEV: Update .gitpod.yml to build inplace

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,7 +13,7 @@ tasks:
       conda activate pandas-dev
       git pull --unshallow  # need to force this else the prebuild fails
       git fetch --tags
-      python setup.py build_ext -j 4
+      python setup.py build_ext --inplace -j 4
       echo "🛠 Completed rebuilding Pandas!! 🛠 "
       echo "✨ Pre-build complete! You can close this terminal ✨ "
 


### PR DESCRIPTION
Because of the change in https://github.com/pandas-dev/pandas/commit/de0753e4932d1b4951bc8275610ec4b0b9bdc1e1, we were not actually rebuilding the latest fetched pandas inplace. 

Going to directly merge this since we are using this in a workshop.