### PR TITLE
DOC: Add small userguide example on how to use arrow dtype backend in read_parquet

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -5334,7 +5334,7 @@ By setting the ``dtype_backend`` argument you can control the default dtypes use
 
 .. note::
 
-   Note that this is not support for ``fastparquet``.
+   Note that this is not supported for ``fastparquet``.
 
 
 Read only certain columns of a parquet file.

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -5323,6 +5323,20 @@ Read from a parquet file.
 
    result.dtypes
 
+By setting the ``dtype_backend`` argument you can control the default dtypes used for the resulting DataFrame.
+
+.. ipython:: python
+   :okwarning:
+
+   result = pd.read_parquet("example_pa.parquet", engine="pyarrow", dtype_backend="pyarrow")
+
+   result.dtypes
+
+.. note::
+
+   Note that this is not support for ``fastparquet``.
+
+
 Read only certain columns of a parquet file.
 
 .. ipython:: python


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
