### PR TITLE
TST .drop() doesn't parse strings for DatetimeIndex

### DIFF
--- a/pandas/tests/frame/methods/test_drop.py
+++ b/pandas/tests/frame/methods/test_drop.py
@@ -535,3 +535,22 @@ class TestDataFrameDrop:
             {"a": [1], "b": 100}, dtype=any_numeric_ea_dtype
         ).set_index(idx)
         tm.assert_frame_equal(result, expected)
+
+    def test_drop_parse_strings_datetime_index(self):
+        # GH #5355
+        df = DataFrame(
+            {
+                "a": [1, 2],
+                "b": [1, 2]
+            },
+            index=[pd.Timestamp('2000-01-03'), pd.Timestamp('2000-01-04')]
+        )
+        result = df.drop('2000-01-03', axis=0)
+        expected = DataFrame(
+            {
+                "a": [2],
+                "b": [2]
+            },
+            index=[pd.Timestamp('2000-01-04')]
+        )
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/methods/test_drop.py
+++ b/pandas/tests/frame/methods/test_drop.py
@@ -539,18 +539,9 @@ class TestDataFrameDrop:
     def test_drop_parse_strings_datetime_index(self):
         # GH #5355
         df = DataFrame(
-            {
-                "a": [1, 2],
-                "b": [1, 2]
-            },
-            index=[pd.Timestamp('2000-01-03'), pd.Timestamp('2000-01-04')]
+            {"a": [1, 2], "b": [1, 2]},
+            index=[Timestamp("2000-01-03"), Timestamp("2000-01-04")],
         )
-        result = df.drop('2000-01-03', axis=0)
-        expected = DataFrame(
-            {
-                "a": [2],
-                "b": [2]
-            },
-            index=[pd.Timestamp('2000-01-04')]
-        )
+        result = df.drop("2000-01-03", axis=0)
+        expected = DataFrame({"a": [2], "b": [2]}, index=[Timestamp("2000-01-04")])
         tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [X] closes https://github.com/pandas-dev/pandas/issues/5355
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).