### PR TITLE
Regression tests to cover reset_index issue

### DIFF
--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -773,3 +773,14 @@ def test_errorreset_index_rename(float_frame):
 
     with pytest.raises(IndexError, match="list index out of range"):
         stacked_df.reset_index(names=["new_first"])
+
+
+def test_reset_index_false_index_name():
+    # GH 38147
+    df1 = Series(data=range(5, 10), index=range(0, 5))
+    df1.index.name = False
+    df1.reset_index()
+
+    df2 = DataFrame(data=range(5, 10), index=range(0, 5))
+    df2.index.name = False
+    df2.reset_index()

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -786,5 +786,5 @@ def test_reset_index_false_index_name():
     result_frame = DataFrame(data=range(5, 10), index=range(0, 5))
     result_frame.index.name = False
     result_frame.reset_index()
-    expected_frame = DataFrame(range(5, 10), Index(range(0, 5), name=False))
+    expected_frame = DataFrame(range(5, 10), RangeIndex(range(0, 5), name=False))
     tm.assert_frame_equal(result_frame, expected_frame)

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -776,11 +776,15 @@ def test_errorreset_index_rename(float_frame):
 
 
 def test_reset_index_false_index_name():
-    # GH 38147
-    df1 = Series(data=range(5, 10), index=range(0, 5))
-    df1.index.name = False
-    df1.reset_index()
+    result_series = Series(data=range(5, 10), index=range(0, 5))
+    result_series.index.name = False
+    result_series.reset_index()
+    expected_series = Series(range(5, 10), RangeIndex(range(0, 5), name=False))
+    tm.assert_series_equal(result_series, expected_series)
 
-    df2 = DataFrame(data=range(5, 10), index=range(0, 5))
-    df2.index.name = False
-    df2.reset_index()
+    # GH 38147
+    result_frame = DataFrame(data=range(5, 10), index=range(0, 5))
+    result_frame.index.name = False
+    result_frame.reset_index()
+    expected_frame = DataFrame(range(5, 10), Index(range(0, 5), name=False))
+    tm.assert_frame_equal(result_frame, expected_frame)


### PR DESCRIPTION
- [x] closes #38147
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
