### PR TITLE
TST: Add non-regression test for GH-33828

### DIFF
--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -1251,3 +1251,19 @@ class TestDataFrameSetitemCopyViewSemantics:
                     df[label][label] = 1
             # original dataframe not updated
             assert np.all(values[np.arange(10), np.arange(10)] == 0)
+
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            "int64",
+            "Int64",
+        ],
+    )
+    def test_setitem_iloc_with_numpy_array(self, dtype):
+        # GH-33828
+        df = DataFrame({"a": np.ones(3)}, dtype=dtype)
+        df.iloc[np.array([0]), np.array([0])] = np.array([[2]])
+
+        expected = DataFrame({"a": [2, 1, 1]}, dtype=dtype)
+
+        tm.assert_frame_equal(df, expected)

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -1252,18 +1252,11 @@ class TestDataFrameSetitemCopyViewSemantics:
             # original dataframe not updated
             assert np.all(values[np.arange(10), np.arange(10)] == 0)
 
-    @pytest.mark.parametrize(
-        "dtype",
-        [
-            "int64",
-            "Int64",
-        ],
-    )
+    @pytest.mark.parametrize("dtype", ["int64", "Int64"])
     def test_setitem_iloc_with_numpy_array(self, dtype):
         # GH-33828
         df = DataFrame({"a": np.ones(3)}, dtype=dtype)
         df.iloc[np.array([0]), np.array([0])] = np.array([[2]])
 
         expected = DataFrame({"a": [2, 1, 1]}, dtype=dtype)
-
         tm.assert_frame_equal(df, expected)


### PR DESCRIPTION
- [X] closes #33828
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
