### PR TITLE
CLN: some cleanups in Series.apply & related

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -25,6 +25,7 @@ import numpy as np
 
 from pandas._config import option_context
 
+from pandas._libs import lib
 from pandas._typing import (
     AggFuncType,
     AggFuncTypeBase,
@@ -110,6 +111,7 @@ class Apply(metaclass=abc.ABCMeta):
         func,
         raw: bool,
         result_type: str | None,
+        *,
         args,
         kwargs,
     ) -> None:
@@ -1037,10 +1039,21 @@ class SeriesApply(NDFrameApply):
         self,
         obj: Series,
         func: AggFuncType,
-        convert_dtype: bool,
+        *,
+        convert_dtype: bool | lib.NoDefault = lib.no_default,
         args,
         kwargs,
     ) -> None:
+        if convert_dtype is lib.no_default:
+            convert_dtype = True
+        else:
+            warnings.warn(
+                "the convert_dtype parameter is deprecated and will be removed in a "
+                "future version.  Do ``ser.astype(object).apply()`` "
+                "instead if you want ``convert_dtype=False``.",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
         self.convert_dtype = convert_dtype
 
         super().__init__(
@@ -1143,6 +1156,7 @@ class GroupByApply(Apply):
         self,
         obj: GroupBy[NDFrameT],
         func: AggFuncType,
+        *,
         args,
         kwargs,
     ) -> None:
@@ -1172,6 +1186,7 @@ class ResamplerWindowApply(Apply):
         self,
         obj: Resampler | BaseWindow,
         func: AggFuncType,
+        *,
         args,
         kwargs,
     ) -> None:

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1329,7 +1329,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         relabeling, func, columns, order = reconstruct_func(func, **kwargs)
         func = maybe_mangle_lambdas(func)
 
-        op = GroupByApply(self, func, args, kwargs)
+        op = GroupByApply(self, func, args=args, kwargs=kwargs)
         result = op.agg()
         if not is_dict_like(func) and result is not None:
             return result

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4365,7 +4365,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         if func is None:
             func = dict(kwargs.items())
 
-        op = SeriesApply(self, func, convert_dtype=False, args=args, kwargs=kwargs)
+        op = SeriesApply(self, func, args=args, kwargs=kwargs)
         result = op.agg()
         return result
 
@@ -4381,9 +4381,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
     ) -> DataFrame | Series:
         # Validate axis argument
         self._get_axis_number(axis)
-        result = SeriesApply(
-            self, func=func, convert_dtype=True, args=args, kwargs=kwargs
-        ).transform()
+        result = SeriesApply(self, func=func, args=args, kwargs=kwargs).transform()
         return result
 
     def apply(
@@ -4505,17 +4503,9 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         Helsinki    2.484907
         dtype: float64
         """
-        if convert_dtype is lib.no_default:
-            convert_dtype = True
-        else:
-            warnings.warn(
-                "the convert_dtype parameter is deprecated and will be removed in a "
-                "future version.  Do ``ser.astype(object).apply()`` "
-                "instead if you want ``convert_dtype=False``.",
-                FutureWarning,
-                stacklevel=find_stack_level(),
-            )
-        return SeriesApply(self, func, convert_dtype, args, kwargs).apply()
+        return SeriesApply(
+            self, func, convert_dtype=convert_dtype, args=args, kwargs=kwargs
+        ).apply()
 
     def _reindex_indexer(
         self,


### PR DESCRIPTION
Some cleanups:

* Move the `convert_dtype` warning from `Series.apply` to `SeriesApply`
* Add `*, ` to force use use of keywords
* Set the default for `convert_dtype` in `SeriesApply` to `no_default`
* Drop setting `convert_dtype` internally in `Series.agg`  & `Series.transform` (these are noops, i.e. have no effect)
