### PR TITLE
Added an edge case handler and a test case for Series.first("#M")

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -260,6 +260,7 @@ Styler
 
 Other
 ^^^^^
+- Bug in :func:`Series.first` ``first`` not returning all the timestamps of the last day of a month when parameter is month-based (:issue:`51285`)
 - Bug in :func:`assert_almost_equal` now throwing assertion error for two unequal sets (:issue:`51727`)
 - Bug in :meth:`Series.memory_usage` when ``deep=True`` throw an error with Series of objects and the returned value is incorrect, as it does not take into account GC corrections (:issue:`51858`)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -189,6 +189,11 @@ from pandas.io.formats.format import (
 )
 from pandas.io.formats.printing import pprint_thing
 
+from pandas.tseries.offsets import (
+    Day,
+    MonthEnd,
+)
+
 if TYPE_CHECKING:
     from pandas._libs.tslibs import BaseOffset
 
@@ -9071,6 +9076,14 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         # Tick-like, e.g. 3 weeks
         if isinstance(offset, Tick) and end_date in self.index:
+            end = self.index.searchsorted(end_date, side="left")
+            return self.iloc[:end]
+
+        # if original offset is "#M", MonthEnd only includes 
+        # the first timestamp of the last day of the month
+        # however, first() should return the rest timestamps of the day as well
+        if isinstance(offset, MonthEnd):
+            end_date = end_date.date() + Day()
             end = self.index.searchsorted(end_date, side="left")
             return self.iloc[:end]
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -188,7 +188,6 @@ from pandas.io.formats.format import (
     DataFrameRenderer,
 )
 from pandas.io.formats.printing import pprint_thing
-
 from pandas.tseries.offsets import (
     Day,
     MonthEnd,
@@ -9079,7 +9078,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             end = self.index.searchsorted(end_date, side="left")
             return self.iloc[:end]
 
-        # if original offset is "#M", MonthEnd only includes 
+        # if original offset is "#M", MonthEnd only includes
         # the first timestamp of the last day of the month
         # however, first() should return the rest timestamps of the day as well
         if isinstance(offset, MonthEnd):

--- a/pandas/tests/frame/methods/test_first_and_last.py
+++ b/pandas/tests/frame/methods/test_first_and_last.py
@@ -96,11 +96,13 @@ class TestFirst:
         tm.assert_frame_equal(df, result)
         assert df is not result
 
-    @pytest.mark.parametrize("start, periods, freq", [("2018-02-01", 3000, '1H')])
+    @pytest.mark.parametrize("start, periods, freq", [("2018-02-01", 3000, "1H")])
     def test_first_with_offsets_in_month(self, frame_or_series, start, periods, freq):
         # GH#51285
-        x = frame_or_series([1] * periods, index=bdate_range(start, periods=periods, freq=freq))
-        result = x.first('1M')
+        x = frame_or_series(
+            [1] * periods, index=bdate_range(start, periods=periods, freq=freq)
+        )
+        result = x.first("1M")
         expected = frame_or_series(
             [1] * 672, index=bdate_range(start, periods=672, freq=freq)
         )

--- a/pandas/tests/frame/methods/test_first_and_last.py
+++ b/pandas/tests/frame/methods/test_first_and_last.py
@@ -95,3 +95,13 @@ class TestFirst:
         result = getattr(df, func)(offset=1)
         tm.assert_frame_equal(df, result)
         assert df is not result
+
+    @pytest.mark.parametrize("start, periods, freq", [("2018-02-01", 3000, '1H')])
+    def test_first_with_offsets_in_month(self, frame_or_series, start, periods, freq):
+        # GH#51285
+        x = frame_or_series([1] * periods, index=bdate_range(start, periods=periods, freq=freq))
+        result = x.first('1M')
+        expected = frame_or_series(
+            [1] * 672, index=bdate_range(start, periods=672, freq=freq)
+        )
+        tm.assert_equal(result, expected)


### PR DESCRIPTION
- [x] closes #51285
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

As described in the above issue, first("1M") does not include timestamps of the last day of a month that are beyond "00:00:00". The problem happens to "2M", "3M", etc., where MonthEnd is being used.

To fix it, I added an if-statement in first() to check whether the offset variable is an instance of MonthEnd. If it is, the end date will be adjusted one day forward, and the returned range will end till the last timestamp before the end date.

I also added a test case in test_first_and_last.py and passed it.