### PR TITLE
CLN/depr: dt.to_pydatetime

### DIFF
--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -334,19 +334,19 @@ class DatetimeProperties(Properties):
         1   2018-03-11
         dtype: datetime64[ns]
 
-        >>> s.dt.to_pydatetime()  # doctest: +SKIP
+        >>> s.dt.to_pydatetime()
         array([datetime.datetime(2018, 3, 10, 0, 0),
                datetime.datetime(2018, 3, 11, 0, 0)], dtype=object)
 
         pandas' nanosecond precision is truncated to microseconds.
 
         >>> s = pd.Series(pd.date_range('20180310', periods=2, freq='ns'))
-        >>> s  # doctest: +SKIP
+        >>> s
         0   2018-03-10 00:00:00.000000000
         1   2018-03-10 00:00:00.000000001
         dtype: datetime64[ns]
 
-        >>> s.dt.to_pydatetime()  # doctest: +SKIP
+        >>> s.dt.to_pydatetime()
         array([datetime.datetime(2018, 3, 10, 0, 0),
                datetime.datetime(2018, 3, 10, 0, 0)], dtype=object)
         """

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -304,6 +304,12 @@ class DatetimeProperties(Properties):
         """
         Return the data as an array of :class:`datetime.datetime` objects.
 
+        .. deprecated:: 2.1.0
+
+            The current behavior of dt.to_pydatetime is deprecated.
+            In a future version this will return a Series containing python
+            datetime objects instead of a ndarray.
+
         Timezone information is retained if present.
 
         .. warning::
@@ -328,19 +334,19 @@ class DatetimeProperties(Properties):
         1   2018-03-11
         dtype: datetime64[ns]
 
-        >>> s.dt.to_pydatetime()
+        >>> s.dt.to_pydatetime()  # doctest: +SKIP
         array([datetime.datetime(2018, 3, 10, 0, 0),
                datetime.datetime(2018, 3, 11, 0, 0)], dtype=object)
 
         pandas' nanosecond precision is truncated to microseconds.
 
         >>> s = pd.Series(pd.date_range('20180310', periods=2, freq='ns'))
-        >>> s
+        >>> s  # doctest: +SKIP
         0   2018-03-10 00:00:00.000000000
         1   2018-03-10 00:00:00.000000001
         dtype: datetime64[ns]
 
-        >>> s.dt.to_pydatetime()
+        >>> s.dt.to_pydatetime()  # doctest: +SKIP
         array([datetime.datetime(2018, 3, 10, 0, 0),
                datetime.datetime(2018, 3, 10, 0, 0)], dtype=object)
         """


### PR DESCRIPTION
Some cleanup related to https://github.com/pandas-dev/pandas/pull/52459. The example code causes warning when running `ci/code_checks.sh`, this suppresses that.