### PR TITLE
Issue 21932: Added Regression Test for index of pivot_table on empty table

### DIFF
--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -2606,5 +2606,3 @@ class TestPivot:
 
         expected = pd.Index([], dtype="object", name="b")
         tm.assert_index_equal(pivot.columns, expected)
-
-

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -2602,8 +2602,7 @@ class TestPivot:
     def test_pivot_table_empty_dataframe_correct_index(self):
         # GH 21932
         df = DataFrame([], columns=["a", "b", "value"])
-        pivot = df.pivot_table(index="a", columns="b", values="value", 
-        aggfunc="count") 
+        pivot = df.pivot_table(index="a", columns="b", values="value", aggfunc="count")
 
         expected = pd.Index([], dtype="object", name="b")
         tm.assert_index_equal(pivot.columns, expected)

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -2604,5 +2604,5 @@ class TestPivot:
         df = DataFrame([], columns=["a", "b", "value"])
         pivot = df.pivot_table(index="a", columns="b", values="value", aggfunc="count")
 
-        expected = pd.Index([], dtype="object", name="b")
+        expected = Index([], dtype="object", name="b")
         tm.assert_index_equal(pivot.columns, expected)

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -2598,3 +2598,14 @@ class TestPivot:
         expected = df.copy(deep=True)
         df.pivot(index="one", columns="two", values="three")
         tm.assert_frame_equal(df, expected)
+
+    def test_pivot_table_empty_dataframe_correct_index(self):
+    # GH 21932
+        df = DataFrame([], columns=['a', 'b', 'value'])
+        pivot = df.pivot_table(index='a', columns='b', values='value', 
+        aggfunc='count') 
+
+        expected = pd.Index([], dtype='object', name='b')
+        tm.assert_index_equal(pivot.columns, expected)
+
+

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -2600,12 +2600,12 @@ class TestPivot:
         tm.assert_frame_equal(df, expected)
 
     def test_pivot_table_empty_dataframe_correct_index(self):
-    # GH 21932
-        df = DataFrame([], columns=['a', 'b', 'value'])
-        pivot = df.pivot_table(index='a', columns='b', values='value', 
-        aggfunc='count') 
+        # GH 21932
+        df = DataFrame([], columns=["a", "b", "value"])
+        pivot = df.pivot_table(index="a", columns="b", values="value", 
+        aggfunc="count") 
 
-        expected = pd.Index([], dtype='object', name='b')
+        expected = pd.Index([], dtype="object", name="b")
         tm.assert_index_equal(pivot.columns, expected)
 
 


### PR DESCRIPTION
- [x] closes #21932 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature


@phofl, @noatamir, @jorisvandenbossche and @marcogorelli 

