### PR TITLE
DOC: Adding examples for dtype_backend="pyarrow" for read_json()

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -998,8 +998,7 @@ pass  ``format='mixed'``
 
 .. ipython:: python
 
-   import io
-   data = io.StringIO("date\n12 Jan 2000\n2000-01-13\n")
+   data = StringIO("date\n12 Jan 2000\n2000-01-13\n")
    df = pd.read_csv(data)
    df['date'] = pd.to_datetime(df['date'], format='mixed')
    df
@@ -1008,7 +1007,7 @@ or, if your datetime formats are all ISO8601 (possibly not identically-formatted
 
 .. ipython:: python
 
-   data = io.StringIO("date\n2020-01-01\n2020-01-01 03:00\n")
+   data = StringIO("date\n2020-01-01\n2020-01-01 03:00\n")
    df = pd.read_csv(data)
    df['date'] = pd.to_datetime(df['date'], format='ISO8601')
    df
@@ -2177,7 +2176,9 @@ By setting the ``dtype_backend`` argument you can control the default dtypes use
      '"e":{"0":null,"1":6.0},"f":{"0":null,"1":7.5},"g":{"0":null,"1":true},"h":{"0":null,"1":"a"},'
      '"i":{"0":"12-31-2019","1":"12-31-2019"},"j":{"0":null,"1":null}}'
     )
-    pd.read_json(StringIO(data), dtype_backend="pyarrow")
+    df = pd.read_json(StringIO(data), dtype_backend="pyarrow")
+    df
+    df.dtypes
 
 .. _io.json_normalize:
 

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -998,6 +998,7 @@ pass  ``format='mixed'``
 
 .. ipython:: python
 
+   import io
    data = io.StringIO("date\n12 Jan 2000\n2000-01-13\n")
    df = pd.read_csv(data)
    df['date'] = pd.to_datetime(df['date'], format='mixed')
@@ -2166,6 +2167,17 @@ Dates written in nanoseconds need to be read back in nanoseconds:
    # Or specify that all timestamps are in nanoseconds
    dfju = pd.read_json(json, date_unit="ns")
    dfju
+
+By setting the ``dtype_backend`` argument you can control the default dtypes used for the resulting DataFrame.
+
+.. ipython:: python
+
+    data = (
+     '{"a":{"0":1,"1":3},"b":{"0":2.5,"1":4.5},"c":{"0":true,"1":false},"d":{"0":"a","1":"b"},'
+     '"e":{"0":null,"1":6.0},"f":{"0":null,"1":7.5},"g":{"0":null,"1":true},"h":{"0":null,"1":"a"},'
+     '"i":{"0":"12-31-2019","1":"12-31-2019"},"j":{"0":null,"1":null}}'
+    )
+    pd.read_json(StringIO(data), dtype_backend="pyarrow")
 
 .. _io.json_normalize:
 


### PR DESCRIPTION
Added an example for dtype_backend="pyarrow" for read_json()
- [ ] closes https://github.com/noatamir/pyladies-workshop/issues/2
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
