### PR TITLE
BUG: DatetimeIndexResamplerGroupby as_index interaction with .agg()

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -370,6 +370,7 @@ Missing
 MultiIndex
 ^^^^^^^^^^
 - Bug in :meth:`DataFrame.__getitem__` not preserving dtypes for :class:`MultiIndex` partial keys (:issue:`51895`)
+- Bug in :meth:`DatetimeIndexResamplerGroupby.agg({})`, where the aggregatio function wouldn't work if :class:`DatetimeIndexResamplerGroupby` was created from :class:`Groupby` w. ``as_index=False`` (:issue:`52819`)
 - Bug in :meth:`MultiIndex.set_levels` not preserving dtypes for :class:`Categorical` (:issue:`52125`)
 
 I/O

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -659,7 +659,8 @@ class BaseWindow(SelectionMixin):
             return self._resolve_output(out, obj)
 
     def aggregate(self, func, *args, **kwargs):
-        result = ResamplerWindowApply(self, func, args=args, kwargs=kwargs).agg()
+        with com.temp_setattr(self._groupby, "as_index", True):
+            result = ResamplerWindowApply(self, func, args=args, kwargs=kwargs).agg()
         if result is None:
             return self.apply(func, raw=False, args=args, kwargs=kwargs)
         return result

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -659,8 +659,7 @@ class BaseWindow(SelectionMixin):
             return self._resolve_output(out, obj)
 
     def aggregate(self, func, *args, **kwargs):
-        with com.temp_setattr(self._groupby, "as_index", True):
-            result = ResamplerWindowApply(self, func, args=args, kwargs=kwargs).agg()
+        result = ResamplerWindowApply(self, func, args=args, kwargs=kwargs).agg()
         if result is None:
             return self.apply(func, raw=False, args=args, kwargs=kwargs)
         return result

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -659,3 +659,29 @@ def test_groupby_resample_on_index_with_list_of_keys_missing_column():
     )
     with pytest.raises(KeyError, match="Columns not found"):
         df.groupby("group").resample("2D")[["val_not_in_dataframe"]].mean()
+
+
+def test_groupby_resample_agg_dict_works_for_as_index_false():
+    # GH 52397
+    expected = (
+        DataFrame(
+            {"a": np.repeat([0, 1, 2, 3, 4], 2), "b": range(50, 60)},
+            index=date_range(start=Timestamp.now(), freq="1min", periods=10),
+        )
+        .groupby("a", as_index=True)
+        .resample("2min")
+        .min()
+    )
+    expected.drop(columns=["a"], inplace=True)
+
+    result = (
+        DataFrame(
+            {"a": np.repeat([0, 1, 2, 3, 4], 2), "b": range(50, 60)},
+            index=date_range(start=Timestamp.now(), freq="1min", periods=10),
+        )
+        .groupby("a", as_index=False)
+        .resample("2min")
+        .agg({"b": "min"})
+    )
+
+    tm.assert_frame_equal(expected, result)


### PR DESCRIPTION
- [x] closes issue #[52397](https://github.com/pandas-dev/pandas/issues/52397) 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
