### PR TITLE
Bug overriden methods of subclasses of styler are not called during rendering #52728

### DIFF
--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -1579,7 +1579,7 @@ class Styler(StylerRenderer):
 
         """
         # GH 40675
-        styler = self.__class__(self.data) 
+        styler = self.__class__(self.data)
         shallow = [  # simple string or boolean immutables
             "hide_index_",
             "hide_columns_",

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -1579,7 +1579,7 @@ class Styler(StylerRenderer):
 
         """
         # GH 40675
-        styler = self.__class__(self.data)
+        styler = self.__class__(self.data) 
         shallow = [  # simple string or boolean immutables
             "hide_index_",
             "hide_columns_",

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -1579,9 +1579,7 @@ class Styler(StylerRenderer):
 
         """
         # GH 40675
-        styler = Styler(
-            self.data,  # populates attributes 'data', 'columns', 'index' as shallow
-        )
+        styler = self.__class__(self.data)
         shallow = [  # simple string or boolean immutables
             "hide_index_",
             "hide_columns_",


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
