### PR TITLE
BUG: overriden methods of subclasses of Styler are not called during …

### DIFF
--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -1553,7 +1553,7 @@ class Styler(StylerRenderer):
                     self.ctx_index[(i, j)].extend(css_list)
                 else:
                     self.ctx_columns[(j, i)].extend(css_list)
-
+    @classmethod
     def _copy(cls, self, deepcopy: bool = False) -> Styler:
         """
         Copies a Styler, allowing for deepcopy or shallow copy

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -1554,7 +1554,7 @@ class Styler(StylerRenderer):
                 else:
                     self.ctx_columns[(j, i)].extend(css_list)
 
-    def _copy(self, deepcopy: bool = False) -> Styler:
+    def _copy(cls, self, deepcopy: bool = False) -> Styler:
         """
         Copies a Styler, allowing for deepcopy or shallow copy
 
@@ -1579,9 +1579,7 @@ class Styler(StylerRenderer):
 
         """
         # GH 40675
-        styler = Styler(
-            self.data,  # populates attributes 'data', 'columns', 'index' as shallow
-        )
+        styler = cls(self.data)
         shallow = [  # simple string or boolean immutables
             "hide_index_",
             "hide_columns_",
@@ -1624,10 +1622,10 @@ class Styler(StylerRenderer):
         return styler
 
     def __copy__(self) -> Styler:
-        return self._copy(deepcopy=False)
+        return self._copy(self.__class__, deepcopy=False)
 
     def __deepcopy__(self, memo) -> Styler:
-        return self._copy(deepcopy=True)
+        return self._copy(self.__class__, deepcopy=True)
 
     def clear(self) -> None:
         """


### PR DESCRIPTION
…rendering #52728

BUG: overriden methods of subclasses of Styler are not called during rendering #52728

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `pandas/io/format/style.py` file if fixing a bug or adding a new feature.
