### PR TITLE
BUG: Adding a columns to a Frame with RangeIndex columns using a non-scalar key

### DIFF
--- a/doc/source/whatsnew/v2.0.1.rst
+++ b/doc/source/whatsnew/v2.0.1.rst
@@ -20,7 +20,7 @@ Fixed regressions
 - Fixed regression in :meth:`MultiIndex.isin` raising ``TypeError`` for ``Generator`` (:issue:`52568`)
 - Fixed regression in :meth:`Series.describe` showing ``RuntimeWarning`` for extension dtype :class:`Series` with one element (:issue:`52515`)
 - Fixed regression in :meth:`SeriesGroupBy.agg` failing when grouping with categorical data, multiple groupings, ``as_index=False``, and a list of aggregations (:issue:`52760`)
-- Fixed regression when adding a new column in a :class:`DataFrame` when the :attr:`DataFrame.columns` was a :class:`RangeIndex` and the new key was hashable but not a scalar (:issue:`52652`)
+- Fixed regression when adding a new column to a :class:`DataFrame` when the :attr:`DataFrame.columns` was a :class:`RangeIndex` and the new key was hashable but not a scalar (:issue:`52652`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_201.bug_fixes:
@@ -56,7 +56,7 @@ Other
 - :class:`Series` created from empty dicts had :attr:`~Series.index`  of dtype ``object``. It is now a :class:`RangeIndex` (:issue:`52404`)
 - Implemented :meth:`Series.str.split` and :meth:`Series.str.rsplit` for :class:`ArrowDtype` with ``pyarrow.string`` (:issue:`52401`)
 - Implemented most ``str`` accessor methods for :class:`ArrowDtype` with ``pyarrow.string`` (:issue:`52401`)
-- Supplying a non-integer hashable key that tests ``False`` in :func:`api.types.is_scalar` now raises a ``KeyError`` for :class:`RangeIndex`, like :class:`Index` does. Previously it raises an ``InvalidIndexError`` (:issue:`52652`).
+- Supplying a non-integer hashable key that tests ``False`` in :func:`api.types.is_scalar` now raises a ``KeyError`` for :meth:`RangeIndex.get_loc`, like it does for :meth:`Index.get_loc`. Previously it raised an ``InvalidIndexError`` (:issue:`52652`).
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_201.contributors:

--- a/doc/source/whatsnew/v2.0.1.rst
+++ b/doc/source/whatsnew/v2.0.1.rst
@@ -20,6 +20,7 @@ Fixed regressions
 - Fixed regression in :meth:`MultiIndex.isin` raising ``TypeError`` for ``Generator`` (:issue:`52568`)
 - Fixed regression in :meth:`Series.describe` showing ``RuntimeWarning`` for extension dtype :class:`Series` with one element (:issue:`52515`)
 - Fixed regression in :meth:`SeriesGroupBy.agg` failing when grouping with categorical data, multiple groupings, ``as_index=False``, and a list of aggregations (:issue:`52760`)
+- Fixed regression when adding a new column in a :class:`DataFrame` when the :attr:`DataFrame.columns` was a :class:`RangeIndex` and the new key was hashable but not a scalar (:issue:`52652`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_201.bug_fixes:
@@ -55,6 +56,7 @@ Other
 - :class:`Series` created from empty dicts had :attr:`~Series.index`  of dtype ``object``. It is now a :class:`RangeIndex` (:issue:`52404`)
 - Implemented :meth:`Series.str.split` and :meth:`Series.str.rsplit` for :class:`ArrowDtype` with ``pyarrow.string`` (:issue:`52401`)
 - Implemented most ``str`` accessor methods for :class:`ArrowDtype` with ``pyarrow.string`` (:issue:`52401`)
+- Supplying a non-integer hashable key that tests ``False`` in :func:`api.types.is_scalar` now raises a ``KeyError`` for :class:`RangeIndex`, like :class:`Index` does. Previously it raises an ``InvalidIndexError`` (:issue:`52652`).
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_201.contributors:

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -347,6 +347,8 @@ class RangeIndex(Index):
                 return self._range.index(new_key)
             except ValueError as err:
                 raise KeyError(key) from err
+        if isinstance(key, Hashable):
+            raise KeyError(key)
         self._check_indexing_error(key)
         raise KeyError(key)
 

--- a/pandas/tests/indexes/test_indexing.py
+++ b/pandas/tests/indexes/test_indexing.py
@@ -19,7 +19,10 @@ import pytest
 
 from pandas.errors import InvalidIndexError
 
-from pandas.core.dtypes.common import is_float_dtype
+from pandas.core.dtypes.common import (
+    is_float_dtype,
+    is_scalar,
+)
 
 from pandas import (
     NA,
@@ -29,7 +32,6 @@ from pandas import (
     MultiIndex,
     NaT,
     PeriodIndex,
-    RangeIndex,
     TimedeltaIndex,
 )
 import pandas._testing as tm
@@ -179,6 +181,32 @@ class TestGetLoc:
         with pytest.raises((TypeError, InvalidIndexError), match="slice"):
             index.get_loc(slice(0, 1))
 
+    def test_get_loc_non_scalar_hashable(self, index):
+        # GHXXXXX
+        from enum import Enum
+
+        class E(Enum):
+            X1 = "x1"
+
+        assert not is_scalar(E.X1)
+
+        exc = KeyError
+        msg = "<E.X1: 'x1'>"
+        if isinstance(
+            index,
+            (
+                DatetimeIndex,
+                TimedeltaIndex,
+                PeriodIndex,
+                IntervalIndex,
+            ),
+        ):
+            # TODO: make these more consistent?
+            exc = InvalidIndexError
+            msg = "E.X1"
+        with pytest.raises(exc, match=msg):
+            index.get_loc(E.X1)
+
     def test_get_loc_generator(self, index):
         exc = KeyError
         if isinstance(
@@ -187,7 +215,6 @@ class TestGetLoc:
                 DatetimeIndex,
                 TimedeltaIndex,
                 PeriodIndex,
-                RangeIndex,
                 IntervalIndex,
                 MultiIndex,
             ),

--- a/pandas/tests/indexes/test_indexing.py
+++ b/pandas/tests/indexes/test_indexing.py
@@ -182,7 +182,7 @@ class TestGetLoc:
             index.get_loc(slice(0, 1))
 
     def test_get_loc_non_scalar_hashable(self, index):
-        # GHXXXXX
+        # GH52877
         from enum import Enum
 
         class E(Enum):


### PR DESCRIPTION
- [X] closes #52652
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
