### PR TITLE
TST/BUG: pyarrow test fixtures upcasting dtypes

### DIFF
--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -130,7 +130,7 @@ def data(dtype):
 @pytest.fixture
 def data_missing(data):
     """Length-2 array with [NA, Valid]"""
-    return type(data)._from_sequence([None, data[0]])
+    return type(data)._from_sequence([None, data[0]], dtype=data.dtype)
 
 
 @pytest.fixture(params=["data", "data_missing"])
@@ -213,7 +213,8 @@ def data_for_sorting(data_for_grouping):
     A < B < C
     """
     return type(data_for_grouping)._from_sequence(
-        [data_for_grouping[0], data_for_grouping[7], data_for_grouping[4]]
+        [data_for_grouping[0], data_for_grouping[7], data_for_grouping[4]],
+        dtype=data_for_grouping.dtype,
     )
 
 
@@ -226,7 +227,8 @@ def data_missing_for_sorting(data_for_grouping):
     A < B and NA missing.
     """
     return type(data_for_grouping)._from_sequence(
-        [data_for_grouping[0], data_for_grouping[2], data_for_grouping[4]]
+        [data_for_grouping[0], data_for_grouping[2], data_for_grouping[4]],
+        dtype=data_for_grouping.dtype,
     )
 
 


### PR DESCRIPTION
There are a few test fixtures in `test_arrow.py` that create an array from a subset of another array using `ArrowExtensionArray._from_sequence`. They are not passing the dtype which results in upcasting for smaller dtypes.

```
import pandas as pd

dtype = "int32[pyarrow]"

arr = pd.array([1, 2, 3], dtype=dtype)
arr2 = type(arr)._from_sequence([arr[0], arr[1]])

print(arr2.dtype)  # -> int64[pyarrow]
```