### PR TITLE
TYP: resolve mypy errors in core/arrays/_ranges.py

### DIFF
--- a/pandas/core/arrays/_ranges.py
+++ b/pandas/core/arrays/_ranges.py
@@ -54,6 +54,8 @@ def generate_regular_range(
     iend = end._value if end is not None else None
     freq.nanos  # raises if non-fixed frequency
     td = Timedelta(freq)
+    b: int | np.int64 | np.uint64
+    e: int | np.int64 | np.uint64
     try:
         td = td.as_unit(  # pyright: ignore[reportGeneralTypeIssues]
             unit, round_ok=False
@@ -196,11 +198,11 @@ def _generate_range_overflow_safe_signed(
             #  exceed implementation bounds, but when passing the result to
             #  np.arange will get a result slightly within the bounds
 
-            result = np.uint64(endpoint) + np.uint64(addend)
+            uresult = np.uint64(endpoint) + np.uint64(addend)
             i64max = np.uint64(i8max)
-            assert result > i64max
-            if result <= i64max + np.uint64(stride):
-                return result
+            assert uresult > i64max
+            if uresult <= i64max + np.uint64(stride):
+                return uresult
 
     raise OutOfBoundsDatetime(
         f"Cannot generate range with {side}={endpoint} and periods={periods}"

--- a/pandas/core/arrays/_ranges.py
+++ b/pandas/core/arrays/_ranges.py
@@ -96,7 +96,7 @@ def generate_regular_range(
 
 def _generate_range_overflow_safe(
     endpoint: int, periods: int, stride: int, side: str = "start"
-) -> np.int64:
+) -> np.int64 | np.uint64:
     """
     Calculate the second endpoint for passing to np.arange, checking
     to avoid an integer overflow.  Catch OverflowError and re-raise
@@ -115,7 +115,7 @@ def _generate_range_overflow_safe(
 
     Returns
     -------
-    other_end : int
+    other_end : np.int64 | np.uint64
 
     Raises
     ------
@@ -163,7 +163,7 @@ def _generate_range_overflow_safe(
 
 def _generate_range_overflow_safe_signed(
     endpoint: int, periods: int, stride: int, side: str
-) -> np.int64:
+) -> np.int64 | np.uint64:
     """
     A special case for _generate_range_overflow_safe where `periods * stride`
     can be calculated without overflowing int64 bounds.

--- a/pandas/core/arrays/_ranges.py
+++ b/pandas/core/arrays/_ranges.py
@@ -200,7 +200,7 @@ def _generate_range_overflow_safe_signed(
             i64max = np.uint64(i8max)
             assert result > i64max
             if result <= i64max + np.uint64(stride):
-                result
+                return result
 
     raise OutOfBoundsDatetime(
         f"Cannot generate range with {side}={endpoint} and periods={periods}"

--- a/pandas/core/arrays/_ranges.py
+++ b/pandas/core/arrays/_ranges.py
@@ -181,9 +181,7 @@ def _generate_range_overflow_safe_signed(
                 # Putting this into a DatetimeArray/TimedeltaArray
                 #  would incorrectly be interpreted as NaT
                 raise OverflowError
-            # error: Incompatible return value type (got "signedinteger[_64Bit]",
-            # expected "int")
-            return result  # type: ignore[return-value]
+            return int(result)
         except (FloatingPointError, OverflowError):
             # with endpoint negative and addend positive we risk
             #  FloatingPointError; with reversed signed we risk OverflowError
@@ -204,9 +202,7 @@ def _generate_range_overflow_safe_signed(
             i64max = np.uint64(i8max)
             assert result > i64max
             if result <= i64max + np.uint64(stride):
-                # error: Incompatible return value type (got "unsignedinteger", expected
-                # "int")
-                return result  # type: ignore[return-value]
+                return int(result)
 
     raise OutOfBoundsDatetime(
         f"Cannot generate range with {side}={endpoint} and periods={periods}"


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/37715

- casted the return types in the `_generate_range_overflow_safe_signed` function to `int` to match the function signature
