### PR TITLE
CLN Dont upcast where unnecessary (PDEP6 precursor)

### DIFF
--- a/doc/source/user_guide/cookbook.rst
+++ b/doc/source/user_guide/cookbook.rst
@@ -125,7 +125,7 @@ Building criteria
 
 .. ipython:: python
 
-   df.loc[(df["BBB"] > 25) | (df["CCC"] >= 75), "AAA"] = 0.1
+   df.loc[(df["BBB"] > 25) | (df["CCC"] >= 75), "AAA"] = 999
    df
 
 `Select rows with data closest to certain value using argsort

--- a/doc/source/user_guide/missing_data.rst
+++ b/doc/source/user_guide/missing_data.rst
@@ -123,7 +123,7 @@ the missing value type chosen:
 
 .. ipython:: python
 
-   s = pd.Series([1, 2, 3])
+   s = pd.Series([1., 2., 3.])
    s.loc[0] = None
    s
 

--- a/doc/source/whatsnew/v0.15.0.rst
+++ b/doc/source/whatsnew/v0.15.0.rst
@@ -748,7 +748,7 @@ Other notable API changes:
 
   .. ipython:: python
 
-     s = pd.Series([1, 2, 3])
+     s = pd.Series([1., 2., 3.])
      s.loc[0] = None
      s
 

--- a/doc/source/whatsnew/v0.17.0.rst
+++ b/doc/source/whatsnew/v0.17.0.rst
@@ -738,7 +738,7 @@ Boolean comparisons of a ``Series`` vs ``None`` will now be equivalent to compar
 
 .. ipython:: python
 
-   s = pd.Series(range(3))
+   s = pd.Series(range(3), dtype="float")
    s.iloc[1] = None
    s
 

--- a/pandas/_testing/contexts.py
+++ b/pandas/_testing/contexts.py
@@ -205,18 +205,24 @@ def use_numexpr(use, min_elements=None) -> Generator[None, None, None]:
         set_option("compute.use_numexpr", olduse)
 
 
-def raises_chained_assignment_error():
-    if PYPY:
+def raises_chained_assignment_error(extra_warnings=(), extra_match=()):
+    from pandas._testing import assert_produces_warning
+
+    if PYPY and not extra_warnings:
         from contextlib import nullcontext
 
         return nullcontext()
-    else:
-        from pandas._testing import assert_produces_warning
-
+    elif PYPY and extra_warnings:
         return assert_produces_warning(
-            ChainedAssignmentError,
-            match=(
-                "A value is trying to be set on a copy of a DataFrame or Series "
-                "through chained assignment"
-            ),
+            extra_warnings,
+            match="|".join(extra_match),
+        )
+    else:
+        match = (
+            "A value is trying to be set on a copy of a DataFrame or Series "
+            "through chained assignment"
+        )
+        return assert_produces_warning(
+            (ChainedAssignmentError, *extra_warnings),
+            match="|".join((match, *extra_match)),
         )

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7894,7 +7894,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         Take all columns into consideration
 
-        >>> df = pd.DataFrame({'a': [10, 20, 30, 40, 50],
+        >>> df = pd.DataFrame({'a': [10., 20., 30., 40., 50.],
         ...                    'b': [None, None, None, None, 500]},
         ...                   index=pd.DatetimeIndex(['2018-02-27 09:01:00',
         ...                                           '2018-02-27 09:02:00',
@@ -7912,9 +7912,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         >>> df.asof(pd.DatetimeIndex(['2018-02-27 09:03:30',
         ...                           '2018-02-27 09:04:30']),
         ...         subset=['a'])
-                              a   b
-        2018-02-27 09:03:30  30 NaN
-        2018-02-27 09:04:30  40 NaN
+                                a   b
+        2018-02-27 09:03:30  30.0 NaN
+        2018-02-27 09:04:30  40.0 NaN
         """
         if isinstance(where, str):
             where = Timestamp(where)

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -184,7 +184,8 @@ def test_inconsistent_return_type():
     msg = "DataFrameGroupBy.apply operated on the grouping columns"
     with tm.assert_produces_warning(FutureWarning, match=msg):
         result = df.groupby("A").apply(f_2)[["B"]]
-    e = expected.copy()
+    # Explicit cast to float to avoid implicit cast when setting nan
+    e = expected.copy().astype({"B": "float"})
     e.loc["Pony"] = np.nan
     tm.assert_frame_equal(result, e)
 

--- a/pandas/tests/groupby/test_nunique.py
+++ b/pandas/tests/groupby/test_nunique.py
@@ -51,6 +51,7 @@ def test_series_groupby_nunique(n, m, sort, dropna):
     check_nunique(frame, ["jim"])
     check_nunique(frame, ["jim", "joe"])
 
+    frame = frame.astype({"julie": float})  # Explicit cast to avoid implicit cast below
     frame.loc[1::17, "jim"] = None
     frame.loc[3::37, "joe"] = None
     frame.loc[7::19, "julie"] = None


### PR DESCRIPTION
precursor to https://github.com/pandas-dev/pandas/pull/50626/files, trying to reduce the diff

there's some example / tests in which upcasting from int to float happens, but where it's not the purpose of what's being shown / tested. similar to https://github.com/pandas-dev/pandas/pull/50493