### PR TITLE
BUG: Have non nano rounding noop return copy

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -2055,7 +2055,7 @@ class TimelikeOps(DatetimeLikeArrayMixin):
         nanos = delta_to_nanoseconds(offset, self._creso)
         if nanos == 0:
             # GH 52761
-            return self
+            return self.copy()
         result_i8 = round_nsint64(values, mode, nanos)
         result = self._maybe_mask_results(result_i8, fill_value=iNaT)
         result = result.view(self._ndarray.dtype)

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -396,6 +396,8 @@ class TestSeriesDatetimeValues:
         result = ser.dt.round(freq)
         tm.assert_series_equal(result, expected)
 
+        assert not np.shares_memory(ser.array._ndarray, result.array._ndarray)
+
     def test_dt_namespace_accessor_categorical(self):
         # GH 19468
         dti = DatetimeIndex(["20171111", "20181212"]).repeat(2)


### PR DESCRIPTION
Addresses https://github.com/pandas-dev/pandas/pull/52841#discussion_r1180466547

Since the original fix was backported to 2.0.1, probably should backport this too (but might be small enough to exclude a whatsnew)