### PR TITLE
CI/TST: Ignore flaky BufferedRandom ResourceWarning from matplotlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -433,6 +433,9 @@ filterwarnings = [
   "error::pytest.PytestUnraisableExceptionWarning",
   "ignore:.*ssl.SSLSocket:pytest.PytestUnraisableExceptionWarning",
   "ignore:.*ssl.SSLSocket:ResourceWarning",
+  # GH 44844: Can remove once minimum matplotlib version >= 3.7
+  "ignore:.*FileIO:pytest.PytestUnraisableExceptionWarning",
+  "ignore:.*BufferedRandom:ResourceWarning",
   "ignore::ResourceWarning:asyncio",
   # From plotting doctests
   "ignore:More than 20 figures have been opened:RuntimeWarning",


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/44844