### PR TITLE
REF: Remove side-effects from importing Styler

### DIFF
--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -41,9 +41,6 @@ from pandas.core.generic import NDFrame
 from pandas.core.shared_docs import _shared_docs
 
 from pandas.io.formats.format import save_to_buffer
-
-jinja2 = import_optional_dependency("jinja2", extra="DataFrame.style requires jinja2.")
-
 from pandas.io.formats.style_render import (
     CSSProperties,
     CSSStyles,
@@ -75,21 +72,17 @@ if TYPE_CHECKING:
 
     from pandas import ExcelWriter
 
-try:
-    import matplotlib as mpl
-    import matplotlib.pyplot as plt
-
-    has_mpl = True
-except ImportError:
-    has_mpl = False
-
 
 @contextmanager
 def _mpl(func: Callable) -> Generator[tuple[Any, Any], None, None]:
-    if has_mpl:
-        yield plt, mpl
-    else:
+    try:
+        import matplotlib as mpl
+        import matplotlib.pyplot as plt
+
+    except ImportError:
         raise ImportError(f"{func.__name__} requires matplotlib.")
+
+    yield plt, mpl
 
 
 ####
@@ -3424,6 +3417,10 @@ class Styler(StylerRenderer):
             Has the correct ``env``,``template_html``, ``template_html_table`` and
             ``template_html_style`` class attributes set.
         """
+        jinja2 = import_optional_dependency(
+            "jinja2", extra="DataFrame.style requires jinja2."
+        )
+
         loader = jinja2.ChoiceLoader([jinja2.FileSystemLoader(searchpath), cls.loader])
 
         # mypy doesn't like dynamically-defined classes

--- a/pandas/tests/io/formats/style/test_format.py
+++ b/pandas/tests/io/formats/style/test_format.py
@@ -12,6 +12,8 @@ from pandas import (
 )
 
 pytest.importorskip("jinja2")
+import markupsafe
+
 from pandas.io.formats.style import Styler
 from pandas.io.formats.style_render import _str_escape
 
@@ -408,12 +410,12 @@ def test_format_decimal(formatter, thousands, precision, func, col):
 def test_str_escape_error():
     msg = "`escape` only permitted in {'html', 'latex', 'latex-math'}, got "
     with pytest.raises(ValueError, match=msg):
-        _str_escape("text", "bad_escape")
+        _str_escape("text", "bad_escape", markupsafe)
 
     with pytest.raises(ValueError, match=msg):
-        _str_escape("text", [])
+        _str_escape("text", [], markupsafe)
 
-    _str_escape(2.00, "bad_escape")  # OK since dtype is float
+    _str_escape(2.00, "bad_escape", markupsafe)  # OK since dtype is float
 
 
 def test_format_options():

--- a/pandas/tests/io/formats/style/test_style.py
+++ b/pandas/tests/io/formats/style/test_style.py
@@ -1,6 +1,8 @@
 import contextlib
 import copy
 import re
+import subprocess
+import sys
 from textwrap import dedent
 
 import numpy as np
@@ -97,6 +99,23 @@ def styler(df):
     np.random.seed(24)
     df = DataFrame({"A": [0, 1], "B": np.random.randn(2)})
     return Styler(df)
+
+
+def test_import_styler_no_side_effects():
+    # Check that Matplotlib converters are properly reset (see issue #27481)
+    code = (
+        "import matplotlib.units as units; "
+        "import matplotlib.dates as mdates; "
+        "n_conv = len(units.registry); "
+        "import pandas as pd; "
+        "from pandas.io.formats.style import Styler; "
+        "assert len(units.registry) == n_conv; "
+        # Ensure jinja2 was not imported
+        "import sys; "
+        "assert 'jinja2' not in sys.modules; "
+    )
+    call = [sys.executable, "-c", code]
+    subprocess.check_output(call)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/io/formats/style/test_style.py
+++ b/pandas/tests/io/formats/style/test_style.py
@@ -102,7 +102,7 @@ def styler(df):
 
 
 def test_import_styler_no_side_effects():
-    # Check that Matplotlib converters are properly reset (see issue #27481)
+    # GH#52995
     code = (
         "import matplotlib.units as units; "
         "import matplotlib.dates as mdates; "


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

I initially pursued this because I thought it was necessary for #27522, but realize now Styler isn't defined in core. However it would be necessary for #52994 if we decide to go that route.

The "cached classmethods" are a bit of a hack. It works because when you set e.g. `StylerRenderer.template_string = some_value`, you're just overwriting the entire property with the value. Still looking for a better way to do this.