### PR TITLE
BUG: Series.describe treating pyarrow timestamps/timedeltas as categorical

### DIFF
--- a/doc/source/whatsnew/v2.0.2.rst
+++ b/doc/source/whatsnew/v2.0.2.rst
@@ -23,8 +23,8 @@ Bug fixes
 - Bug in :func:`api.interchange.from_dataframe` was returning :class:`DataFrame`'s of incorrect sizes when called on slices (:issue:`52824`)
 - Bug in :func:`api.interchange.from_dataframe` was unnecessarily raising on bitmasks (:issue:`49888`)
 - Bug in :meth:`DataFrame.convert_dtypes` ignores ``convert_*`` keywords when set to False ``dtype_backend="pyarrow"`` (:issue:`52872`)
+- Bug in :meth:`Series.describe` treating pyarrow-backed timestamps and timedeltas as categorical data (:issue:`53001`)
 - Bug in :meth:`pd.array` raising for ``NumPy`` array and ``pa.large_string`` or ``pa.large_binary`` (:issue:`52590`)
-- Bug in :meth:`Series.describe` treating pyarrow-backed timestamps and timedeltas as categorical data (:issue:`#####`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v2.0.2.rst
+++ b/doc/source/whatsnew/v2.0.2.rst
@@ -24,6 +24,7 @@ Bug fixes
 - Bug in :func:`api.interchange.from_dataframe` was unnecessarily raising on bitmasks (:issue:`49888`)
 - Bug in :meth:`DataFrame.convert_dtypes` ignores ``convert_*`` keywords when set to False ``dtype_backend="pyarrow"`` (:issue:`52872`)
 - Bug in :meth:`pd.array` raising for ``NumPy`` array and ``pa.large_string`` or ``pa.large_binary`` (:issue:`52590`)
+- Bug in :meth:`Series.describe` treating pyarrow-backed timestamps and timedeltas as categorical data (:issue:`#####`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/methods/describe.py
+++ b/pandas/core/methods/describe.py
@@ -19,7 +19,6 @@ from typing import (
 
 import numpy as np
 
-from pandas._libs import lib
 from pandas._libs.tslibs import Timestamp
 from pandas._typing import (
     DtypeObj,
@@ -232,9 +231,13 @@ def describe_numeric_1d(series: Series, percentiles: Sequence[float]) -> Series:
     dtype: DtypeObj | None
     if isinstance(series.dtype, ExtensionDtype):
         if isinstance(series.dtype, ArrowDtype):
-            import pyarrow as pa
+            if series.dtype.kind == "m":
+                # GH#####: describe timedeltas with object dtype
+                dtype = None
+            else:
+                import pyarrow as pa
 
-            dtype = ArrowDtype(pa.float64())
+                dtype = ArrowDtype(pa.float64())
         else:
             dtype = Float64Dtype()
     elif series.dtype.kind in "iufb":
@@ -363,9 +366,9 @@ def select_describe_func(
         return describe_categorical_1d
     elif is_numeric_dtype(data):
         return describe_numeric_1d
-    elif lib.is_np_dtype(data.dtype, "M") or isinstance(data.dtype, DatetimeTZDtype):
+    elif data.dtype.kind == "M" or isinstance(data.dtype, DatetimeTZDtype):
         return describe_timestamp_1d
-    elif lib.is_np_dtype(data.dtype, "m"):
+    elif data.dtype.kind == "m":
         return describe_numeric_1d
     else:
         return describe_categorical_1d

--- a/pandas/core/methods/describe.py
+++ b/pandas/core/methods/describe.py
@@ -232,7 +232,7 @@ def describe_numeric_1d(series: Series, percentiles: Sequence[float]) -> Series:
     if isinstance(series.dtype, ExtensionDtype):
         if isinstance(series.dtype, ArrowDtype):
             if series.dtype.kind == "m":
-                # GH#####: describe timedeltas with object dtype
+                # GH53001: describe timedeltas with object dtype
                 dtype = None
             else:
                 import pyarrow as pa

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -2844,7 +2844,7 @@ def test_describe_numeric_data(pa_type):
 
 @pytest.mark.parametrize("pa_type", tm.TIMEDELTA_PYARROW_DTYPES)
 def test_describe_timedelta_data(pa_type):
-    # GH#####
+    # GH53001
     data = pd.Series(range(1, 10), dtype=ArrowDtype(pa_type))
     result = data.describe()
     expected = pd.Series(
@@ -2857,7 +2857,7 @@ def test_describe_timedelta_data(pa_type):
 
 @pytest.mark.parametrize("pa_type", tm.DATETIME_PYARROW_DTYPES)
 def test_describe_datetime_data(pa_type):
-    # GH#####
+    # GH53001
     data = pd.Series(range(1, 10), dtype=ArrowDtype(pa_type))
     result = data.describe()
     expected = pd.Series(

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -2842,6 +2842,35 @@ def test_describe_numeric_data(pa_type):
     tm.assert_series_equal(result, expected)
 
 
+@pytest.mark.parametrize("pa_type", tm.TIMEDELTA_PYARROW_DTYPES)
+def test_describe_timedelta_data(pa_type):
+    # GH#####
+    data = pd.Series(range(1, 10), dtype=ArrowDtype(pa_type))
+    result = data.describe()
+    expected = pd.Series(
+        [9] + pd.to_timedelta([5, 2, 1, 3, 5, 7, 9], unit=pa_type.unit).tolist(),
+        dtype=object,
+        index=["count", "mean", "std", "min", "25%", "50%", "75%", "max"],
+    )
+    tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("pa_type", tm.DATETIME_PYARROW_DTYPES)
+def test_describe_datetime_data(pa_type):
+    # GH#####
+    data = pd.Series(range(1, 10), dtype=ArrowDtype(pa_type))
+    result = data.describe()
+    expected = pd.Series(
+        [9, 5, 1, 3, 5, 7, 9],
+        dtype=object,
+        index=["count", "mean", "min", "25%", "50%", "75%", "max"],
+    )
+    for k, v in expected.items():
+        if k != "count":
+            expected[k] = pd.Timestamp(v, tz=pa_type.tz, unit=pa_type.unit)
+    tm.assert_series_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     "pa_type", tm.DATETIME_PYARROW_DTYPES + tm.TIMEDELTA_PYARROW_DTYPES
 )

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -2861,13 +2861,14 @@ def test_describe_datetime_data(pa_type):
     data = pd.Series(range(1, 10), dtype=ArrowDtype(pa_type))
     result = data.describe()
     expected = pd.Series(
-        [9, 5, 1, 3, 5, 7, 9],
+        [9]
+        + [
+            pd.Timestamp(v, tz=pa_type.tz, unit=pa_type.unit)
+            for v in [5, 1, 3, 5, 7, 9]
+        ],
         dtype=object,
         index=["count", "mean", "min", "25%", "50%", "75%", "max"],
     )
-    for k, v in expected.items():
-        if k != "count":
-            expected[k] = pd.Timestamp(v, tz=pa_type.tz, unit=pa_type.unit)
     tm.assert_series_equal(result, expected)
 
 


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.0.2.rst` file if fixing a bug or adding a new feature.


Fixes the following such that pyarrow-backed timestamps and timedeltas are described in the same way numpy-backed timestamps and timedeltas are described. 

Current behavior:

```
In [1]: import pandas as pd

In [2]: df_numpy = pd.DataFrame({
   ...:     "datetime": pd.to_datetime(range(10)),
   ...:     "timedelta": pd.to_timedelta(range(10)),
   ...:     "numeric": range(10),
   ...: })

In [3]: df_pyarrow = df_numpy.convert_dtypes(dtype_backend="pyarrow")

In [4]: df_numpy.describe()
Out[4]: 
                            datetime                  timedelta   numeric
count                             10                         10  10.00000
mean   1970-01-01 00:00:00.000000004  0 days 00:00:00.000000004   4.50000
min              1970-01-01 00:00:00            0 days 00:00:00   0.00000
25%    1970-01-01 00:00:00.000000002  0 days 00:00:00.000000002   2.25000
50%    1970-01-01 00:00:00.000000004  0 days 00:00:00.000000004   4.50000
75%    1970-01-01 00:00:00.000000006  0 days 00:00:00.000000006   6.75000
max    1970-01-01 00:00:00.000000009  0 days 00:00:00.000000009   9.00000
std                              NaN  0 days 00:00:00.000000003   3.02765

In [5]: df_pyarrow.describe()
Out[5]: 
                   datetime        timedelta  numeric
count                    10               10     10.0
unique                   10               10     <NA>
top     1970-01-01 00:00:00  0 days 00:00:00     <NA>
freq                      1                1     <NA>
mean                    NaN              NaN      4.5
std                     NaN              NaN  3.02765
min                     NaN              NaN      0.0
25%                     NaN              NaN     2.25
50%                     NaN              NaN      4.5
75%                     NaN              NaN     6.75
max                     NaN              NaN      9.0
```

New behavior:

```
In [4]: df_pyarrow.describe()
Out[4]: 
                            datetime                  timedelta   numeric
count                             10                         10  10.00000
mean   1970-01-01 00:00:00.000000004  0 days 00:00:00.000000004   4.50000
min              1970-01-01 00:00:00            0 days 00:00:00   0.00000
25%    1970-01-01 00:00:00.000000002  0 days 00:00:00.000000002   2.25000
50%    1970-01-01 00:00:00.000000004  0 days 00:00:00.000000004   4.50000
75%    1970-01-01 00:00:00.000000006  0 days 00:00:00.000000006   6.75000
max    1970-01-01 00:00:00.000000009  0 days 00:00:00.000000009   9.00000
std                              NaN  0 days 00:00:00.000000003   3.02765
```