### PR TITLE
POC/DEPR: infer time objects to ArrowDtype[time]

### DIFF
--- a/pandas/_libs/lib.pyi
+++ b/pandas/_libs/lib.pyi
@@ -71,7 +71,6 @@ def map_infer(
     convert: bool = ...,
     ignore_na: bool = ...,
 ) -> np.ndarray: ...
-
 @overload
 def maybe_convert_objects(
     objects: npt.NDArray[np.object_],

--- a/pandas/_libs/lib.pyi
+++ b/pandas/_libs/lib.pyi
@@ -71,6 +71,7 @@ def map_infer(
     convert: bool = ...,
     ignore_na: bool = ...,
 ) -> np.ndarray: ...
+
 @overload
 def maybe_convert_objects(
     objects: npt.NDArray[np.object_],

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2621,7 +2621,7 @@ def maybe_convert_objects(ndarray[object] objects,
                 seen.object_ = True
                 break
         elif PyTime_Check(val):
-            if convert_non_numeric:
+            if convert_non_numeric and val.tzinfo is None:
                 seen.time_ = True
             else:
                 seen.object_ = True
@@ -2692,6 +2692,7 @@ def maybe_convert_objects(ndarray[object] objects,
 
     elif seen.time_:
         if is_time_array(objects):
+            # FIXME: need to ensure this is not timetz
             opt = get_option("future.infer_time")
             if opt is True:
                 import pyarrow as pa

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2621,7 +2621,7 @@ def maybe_convert_objects(ndarray[object] objects,
                 seen.object_ = True
                 break
         elif PyTime_Check(val):
-            if convert_time:
+            if convert_non_numeric:
                 seen.time_ = True
             else:
                 seen.object_ = True
@@ -2696,7 +2696,7 @@ def maybe_convert_objects(ndarray[object] objects,
             if opt is True:
                 import pyarrow as pa
 
-                from pandas.core.arrays.arrow import ArrowDtype
+                from pandas.core.dtypes.dtypes import ArrowDtype
 
                 obj = pa.array(objects)
                 dtype = ArrowDtype(obj.type)

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -146,6 +146,8 @@ def pytest_collection_modifyitems(items, config) -> None:
         ("Series.idxmax", "The behavior of Series.idxmax"),
         ("SeriesGroupBy.idxmin", "The behavior of Series.idxmin"),
         ("SeriesGroupBy.idxmax", "The behavior of Series.idxmax"),
+        ("DatetimeArray.time", "with pyarrow time dtype"),
+        ("DatetimeIndex.time", "with pyarrow time dtype"),
         # Docstring divides by zero to show behavior difference
         ("missing.mask_zero_div_zero", "divide by zero encountered"),
         (

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -134,6 +134,9 @@ def pytest_collection_modifyitems(items, config) -> None:
     # Warnings from doctests that can be ignored; place reason in comment above.
     # Each entry specifies (path, message) - see the ignore_doctest_warning function
     ignored_doctest_warnings = [
+        ("DatetimeProperties.time", "with pyarrow time dtype"),
+        ("DatetimeArray.time", "with pyarrow time dtype"),
+        ("DatetimeIndex.time", "with pyarrow time dtype"),
         ("is_int64_dtype", "is_int64_dtype is deprecated"),
         ("is_interval_dtype", "is_interval_dtype is deprecated"),
         ("is_period_dtype", "is_period_dtype is deprecated"),

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -649,15 +649,7 @@ class ArrowExtensionArray(
         if pc_func is NotImplemented:
             raise NotImplementedError(f"{op.__name__} not implemented.")
 
-        try:
-            result = pc_func(self._pa_array, other)
-        except pa.lib.ArrowNotImplementedError:
-            if op in [operator.add, roperator.radd, operator.sub, roperator.rsub]:
-                # By returning NotImplemented we get standard message with a
-                #  TypeError
-                return NotImplemented
-            raise
-
+        result = pc_func(self._pa_array, other)
         return type(self)(result)
 
     def _logical_method(self, other, op):

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -649,7 +649,15 @@ class ArrowExtensionArray(
         if pc_func is NotImplemented:
             raise NotImplementedError(f"{op.__name__} not implemented.")
 
-        result = pc_func(self._pa_array, other)
+        try:
+            result = pc_func(self._pa_array, other)
+        except pa.lib.ArrowNotImplementedError:
+            if op in [operator.add, roperator.radd, operator.sub, roperator.rsub]:
+                # By returning NotImplemented we get standard message with a
+                #  TypeError
+                return NotImplemented
+            raise
+
         return type(self)(result)
 
     def _logical_method(self, other, op):

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -55,6 +55,7 @@ from pandas.core.dtypes.common import (
     pandas_dtype,
 )
 from pandas.core.dtypes.dtypes import (
+    ArrowDtype,
     DatetimeTZDtype,
     ExtensionDtype,
     PeriodDtype,

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -59,7 +59,6 @@ from pandas.core.dtypes.dtypes import (
     DatetimeTZDtype,
     ExtensionDtype,
     PeriodDtype,
-    ArrowDtype,
 )
 from pandas.core.dtypes.missing import isna
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1387,7 +1387,7 @@ default 'raise'
         if opt is None:
             warnings.warn(
                 f"The behavior of {type(self).__name__}.time is deprecated. "
-                "In a future version, this will an array with pyarrow time "
+                "In a future version, this will return an array with pyarrow time "
                 "dtype instead of object dtype. To opt in to the future behavior, "
                 "set `pd.set_option('future.infer_time', True)`.",
                 FutureWarning,

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -85,7 +85,10 @@ if TYPE_CHECKING:
     )
 
     from pandas import DataFrame
-    from pandas.core.arrays import PeriodArray
+    from pandas.core.arrays import (
+        ArrowExtensionArray,
+        PeriodArray,
+    )
 
 
 def tz_to_dtype(
@@ -1344,7 +1347,7 @@ default 'raise'
         return result
 
     @property
-    def time(self) -> npt.NDArray[np.object_]:
+    def time(self) -> npt.NDArray[np.object_] | ArrowExtensionArray:
         """
         Returns numpy array of :class:`datetime.time` objects.
 

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -889,3 +889,14 @@ with cf.config_prefix("styler"):
         styler_environment,
         validator=is_instance_factory([type(None), str]),
     )
+
+
+with cf.config_prefix("future"):
+    cf.register_option(
+        "future.infer_time",
+        None,
+        "Whether to infer sequence of datetime.time objects as pyarrow time "
+        "dtype, which will be the default in pandas 3.0 "
+        "(at which point this option will be deprecated).",
+        validator=is_one_of_factory([True, False, None]),
+    )

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -51,7 +51,10 @@ from pandas.core.dtypes.common import (
     is_object_dtype,
     pandas_dtype,
 )
-from pandas.core.dtypes.dtypes import NumpyEADtype
+from pandas.core.dtypes.dtypes import (
+    ArrowDtype,
+    NumpyEADtype,
+)
 from pandas.core.dtypes.generic import (
     ABCDataFrame,
     ABCExtensionArray,
@@ -297,7 +300,6 @@ def array(
         PeriodArray,
         TimedeltaArray,
     )
-    from pandas.core.arrays.arrow import ArrowDtype
     from pandas.core.arrays.string_ import StringDtype
 
     if lib.is_scalar(data):

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -844,7 +844,6 @@ def infer_dtype_from_scalar(val) -> tuple[DtypeObj, Any]:
                 import pyarrow as pa
 
                 pa_dtype = pa.time64("us")
-                from pandas.core.arrays.arrow import ArrowDtype
 
                 dtype = ArrowDtype(pa_dtype)
 

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -108,7 +108,9 @@ class Properties(PandasDelegate, PandasObject, NoNewAttributesMixin):
         else:
             index = self._parent.index
         # return the result as a Series
-        result = Series(result, index=index, name=self.name).__finalize__(self._parent)
+        result = Series(
+            result, index=index, name=self.name, dtype=result.dtype
+        ).__finalize__(self._parent)
 
         # setting this object will show a SettingWithCopyWarning/Error
         result._is_copy = (

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -101,8 +101,6 @@ class Properties(PandasDelegate, PandasObject, NoNewAttributesMixin):
         elif not is_list_like(result):
             return result
 
-        result = np.asarray(result)
-
         if self.orig is not None:
             index = self.orig.index
         else:

--- a/pandas/tests/arithmetic/common.py
+++ b/pandas/tests/arithmetic/common.py
@@ -33,7 +33,9 @@ def assert_cannot_add(left, right, msg="cannot add"):
         right + left
 
 
-def assert_invalid_addsub_type(left, right, msg=None):
+def assert_invalid_addsub_type(
+    left, right, msg=None, can_be_not_implemented: bool = False
+):
     """
     Helper to assert that left and right can be neither added nor subtracted.
 
@@ -42,14 +44,23 @@ def assert_invalid_addsub_type(left, right, msg=None):
     left : object
     right : object
     msg : str or None, default None
+    can_be_not_implemented : bool, default False
+        Whether to accept NotImplementedError in addition to TypeError
     """
-    with pytest.raises(TypeError, match=msg):
+
+    errs = TypeError
+    if can_be_not_implemented:
+        # really we are interested in pa.lib.ArrowNotImplementedError, which
+        #  is a subclass of NotImplementedError
+        errs = (TypeError, NotImplementedError)
+
+    with pytest.raises(errs, match=msg):
         left + right
-    with pytest.raises(TypeError, match=msg):
+    with pytest.raises(errs, match=msg):
         right + left
-    with pytest.raises(TypeError, match=msg):
+    with pytest.raises(errs, match=msg):
         left - right
-    with pytest.raises(TypeError, match=msg):
+    with pytest.raises(errs, match=msg):
         right - left
 
 

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1195,7 +1195,7 @@ class TestDatetime64Arithmetic:
         warn_msg = "Pandas type inference with a sequence of `datetime.time` objects"
         warn = None
         if future is True:
-            msgs.append("cannot subtract DatetimeArray from ArrowExtensionArray")
+            msgs.append(r"Function '(add|subtract)_checked' has no kernel")
         elif future is None:
             warn = FutureWarning
 
@@ -1210,7 +1210,7 @@ class TestDatetime64Arithmetic:
             # we aren't testing that here, so ignore.
             warnings.simplefilter("ignore", PerformanceWarning)
 
-            assert_invalid_addsub_type(obj1, obj2, msg=msg)
+            assert_invalid_addsub_type(obj1, obj2, msg=msg, can_be_not_implemented=True)
 
     # -------------------------------------------------------------
     # Other invalid operations

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1171,11 +1171,17 @@ class TestDatetime64Arithmetic:
         "future", [pytest.param(True, marks=td.skip_if_no("pyarrow")), False, None]
     )
     def test_dt64arr_addsub_time_objects_raises(
-        self, box_with_array, tz_naive_fixture, future
+        self, box_with_array, tz_naive_fixture, future, request
     ):
         # https://github.com/pandas-dev/pandas/issues/10329
 
         tz = tz_naive_fixture
+        if str(tz) == "tzlocal()" and future is True:
+            # TODO(GH#53278)
+            mark = pytest.mark.xfail(
+                reason="Incorrectly raises AttributeError instead of TypeError"
+            )
+            request.node.add_marker(mark)
 
         obj1 = date_range("2012-01-01", periods=3, tz=tz)
         obj2 = [time(i, i, i) for i in range(3)]

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1179,7 +1179,9 @@ class TestDatetime64Arithmetic:
         if str(tz) == "tzlocal()" and future is True:
             # TODO(GH#53278)
             mark = pytest.mark.xfail(
-                reason="Incorrectly raises AttributeError instead of TypeError"
+                reason="Incorrectly raises AttributeError instead of TypeError",
+                # some but not all CI builds
+                strict=False,
             )
             request.node.add_marker(mark)
 

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -20,6 +20,7 @@ import pytz
 from pandas._libs.tslibs.conversion import localize_pydatetime
 from pandas._libs.tslibs.offsets import shift_months
 from pandas.errors import PerformanceWarning
+import pandas.util._test_decorators as td
 
 import pandas as pd
 from pandas import (
@@ -1166,7 +1167,9 @@ class TestDatetime64Arithmetic:
         )
         assert_invalid_addsub_type(dtarr, parr, msg)
 
-    @pytest.mark.parametrize("future", [True, False, None])
+    @pytest.mark.parametrize(
+        "future", [pytest.param(True, marks=td.skip_if_no("pyarrow")), False, None]
+    )
     def test_dt64arr_addsub_time_objects_raises(
         self, box_with_array, tz_naive_fixture, future
     ):

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -156,7 +156,7 @@ class TestNonNano:
         dta, dti = dta_dti
 
         warn = None
-        msg = "In a future version, this will an array with pyarrow time dtype"
+        msg = "In a future version, this will return an array with pyarrow time dtype"
         if meth == "time":
             warn = FutureWarning
 

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -155,8 +155,14 @@ class TestNonNano:
     def test_time_date(self, dta_dti, meth):
         dta, dti = dta_dti
 
-        result = getattr(dta, meth)
-        expected = getattr(dti, meth)
+        warn = None
+        msg = "In a future version, this will an array with pyarrow time dtype"
+        if meth == "time":
+            warn = FutureWarning
+
+        with tm.assert_produces_warning(warn, match=msg):
+            result = getattr(dta, meth)
+            expected = getattr(dti, meth)
         tm.assert_numpy_array_equal(result, expected)
 
     def test_format_native_types(self, unit, dtype, dta_dti):

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -1058,7 +1058,7 @@ class TestInference:
 
         with pd.option_context("future.infer_time", future):
             with tm.assert_produces_warning(warn, match=msg):
-                out = lib.maybe_convert_objects(objs, convert_time=True)
+                out = lib.maybe_convert_objects(objs, convert_non_numeric=True)
             with tm.assert_produces_warning(warn, match=msg):
                 ser = Series(objs)
             with tm.assert_produces_warning(warn, match=msg):

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -1038,7 +1038,9 @@ class TestInference:
         )
         tm.assert_extension_array_equal(result, idx._data)
 
-    @pytest.mark.parametrize("future", [True, False, None])
+    @pytest.mark.parametrize(
+        "future", [pytest.param(True, marks=td.skip_if_no("pyarrow")), False, None]
+    )
     def test_maybe_convert_objects_time(self, future):
         ts = Timestamp.now()
         objs = np.array([ts.time()], dtype=object)

--- a/pandas/tests/generic/test_finalize.py
+++ b/pandas/tests/generic/test_finalize.py
@@ -673,7 +673,7 @@ def test_datetime_property(attr):
     s.attrs = {"a": 1}
 
     warn = None
-    msg = "In a future version, this will an array with pyarrow time dtype"
+    msg = "In a future version, this will return an array with pyarrow time dtype"
     if attr == "time":
         warn = FutureWarning
     with tm.assert_produces_warning(warn, match=msg):

--- a/pandas/tests/generic/test_finalize.py
+++ b/pandas/tests/generic/test_finalize.py
@@ -671,7 +671,14 @@ def test_datetime_method(method):
 def test_datetime_property(attr):
     s = pd.Series(pd.date_range("2000", periods=4))
     s.attrs = {"a": 1}
-    result = getattr(s.dt, attr)
+
+    warn = None
+    msg = "In a future version, this will an array with pyarrow time dtype"
+    if attr == "time":
+        warn = FutureWarning
+    with tm.assert_produces_warning(warn, match=msg):
+        result = getattr(s.dt, attr)
+
     assert result.attrs == {"a": 1}
 
 

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -1,6 +1,7 @@
 from datetime import (
     date,
     datetime,
+    time,
 )
 from io import StringIO
 
@@ -836,7 +837,16 @@ def test_apply_datetime_issue(group_column_dtlike):
     #   is a datetime object and the column labels are different from
     #   standard int values in range(len(num_columns))
 
-    df = DataFrame({"a": ["foo"], "b": [group_column_dtlike]})
+    warn = None
+    warn_msg = (
+        "Pandas type inference with a sequence of `datetime.time` "
+        "objects is deprecated"
+    )
+    if isinstance(group_column_dtlike, time):
+        warn = FutureWarning
+
+    with tm.assert_produces_warning(warn, match=warn_msg):
+        df = DataFrame({"a": ["foo"], "b": [group_column_dtlike]})
     result = df.groupby("a").apply(lambda x: Series(["spam"], index=[42]))
 
     expected = DataFrame(

--- a/pandas/tests/indexes/datetimes/test_scalar_compat.py
+++ b/pandas/tests/indexes/datetimes/test_scalar_compat.py
@@ -24,7 +24,9 @@ import pandas._testing as tm
 class TestDatetimeIndexOps:
     def test_dti_time(self):
         rng = date_range("1/1/2000", freq="12min", periods=10)
-        result = pd.Index(rng).time
+        msg = "In a future version, this will an array with pyarrow time dtype"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            result = pd.Index(rng).time
         expected = [t.time() for t in rng]
         assert (result == expected).all()
 

--- a/pandas/tests/indexes/datetimes/test_scalar_compat.py
+++ b/pandas/tests/indexes/datetimes/test_scalar_compat.py
@@ -24,7 +24,7 @@ import pandas._testing as tm
 class TestDatetimeIndexOps:
     def test_dti_time(self):
         rng = date_range("1/1/2000", freq="12min", periods=10)
-        msg = "In a future version, this will an array with pyarrow time dtype"
+        msg = "In a future version, this will return an array with pyarrow time dtype"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             result = pd.Index(rng).time
         expected = [t.time() for t in rng]

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -854,7 +854,7 @@ class TestDatetimeIndexTimezones:
 
         index = DatetimeIndex(["2018-06-04 10:20:30", pd.NaT], dtype=dtype)
 
-        msg = "In a future version, this will an array with pyarrow time dtype"
+        msg = "In a future version, this will return an array with pyarrow time dtype"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             result = index.time
 

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -853,7 +853,10 @@ class TestDatetimeIndexTimezones:
         expected = np.array([time(10, 20, 30), pd.NaT])
 
         index = DatetimeIndex(["2018-06-04 10:20:30", pd.NaT], dtype=dtype)
-        result = index.time
+
+        msg = "In a future version, this will an array with pyarrow time dtype"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            result = index.time
 
         tm.assert_numpy_array_equal(result, expected)
 

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -986,13 +986,17 @@ class TestReaders:
                     time(16, 37, 0, 900000),
                     time(18, 20, 54),
                 ]
-            }
+            },
+            dtype=object,
         )
 
-        actual = pd.read_excel("times_1900" + read_ext, sheet_name="Sheet1")
+        warn_msg = "Pandas type inference with a sequence of `datetime.time` objects"
+        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+            actual = pd.read_excel("times_1900" + read_ext, sheet_name="Sheet1")
         tm.assert_frame_equal(actual, expected)
 
-        actual = pd.read_excel("times_1904" + read_ext, sheet_name="Sheet1")
+        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+            actual = pd.read_excel("times_1904" + read_ext, sheet_name="Sheet1")
         tm.assert_frame_equal(actual, expected)
 
     def test_read_excel_multiindex(self, request, read_ext):

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -479,7 +479,7 @@ KORD,19990127 22:00:00, 21:56:00, -0.5900, 1.7100, 5.1000, 0.0000, 290.0000
     if parser.engine == "pyarrow":
         # https://github.com/pandas-dev/pandas/issues/44231
         # pyarrow 6.0 starts to infer time type
-        msg = "In a future version, this will an array with pyarrow time dtype"
+        msg = "In a future version, this will return an array with pyarrow time dtype"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             expected["X2"] = pd.to_datetime("1970-01-01" + expected["X2"]).dt.time
 

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -479,7 +479,9 @@ KORD,19990127 22:00:00, 21:56:00, -0.5900, 1.7100, 5.1000, 0.0000, 290.0000
     if parser.engine == "pyarrow":
         # https://github.com/pandas-dev/pandas/issues/44231
         # pyarrow 6.0 starts to infer time type
-        expected["X2"] = pd.to_datetime("1970-01-01" + expected["X2"]).dt.time
+        msg = "In a future version, this will an array with pyarrow time dtype"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            expected["X2"] = pd.to_datetime("1970-01-01" + expected["X2"]).dt.time
 
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -3176,15 +3176,17 @@ class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest):
     def test_datetime_time(self, tz_aware):
         # test support for datetime.time, GH #8341
 
-        warn_msg = "Pandas type inference with a sequence of `datetime.time`"
         if not tz_aware:
             tz_times = [time(9, 0, 0), time(9, 1, 30)]
         else:
             tz_dt = date_range("2013-01-01 09:00:00", periods=2, tz="US/Pacific")
-            with tm.assert_produces_warning(FutureWarning, match=warn_msg):
-                tz_times = Series(tz_dt.to_pydatetime()).map(lambda dt: dt.timetz())
+            tz_times = Series(tz_dt.to_pydatetime()).map(lambda dt: dt.timetz())
 
-        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+        warn_msg = "Pandas type inference with a sequence of `datetime.time`"
+        warn = None
+        if not tz_aware:
+            warn = FutureWarning
+        with tm.assert_produces_warning(warn, match=warn_msg):
             df = DataFrame(tz_times, columns=["a"])
 
         assert df.to_sql("test_time", self.conn, index=False) == 2

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -1053,6 +1053,7 @@ class TestTSPlot:
         t = datetime(1, 1, 1, 3, 30, 0)
         deltas = np.random.randint(1, 20, 3).cumsum()
         ts = np.array([(t + timedelta(minutes=int(x))).time() for x in deltas])
+        ts = Index(ts, dtype=object)
         df = DataFrame(
             {"a": np.random.randn(len(ts)), "b": np.random.randn(len(ts))}, index=ts
         )
@@ -1076,7 +1077,10 @@ class TestTSPlot:
     def test_time_change_xlim(self):
         t = datetime(1, 1, 1, 3, 30, 0)
         deltas = np.random.randint(1, 20, 3).cumsum()
-        ts = np.array([(t + timedelta(minutes=int(x))).time() for x in deltas])
+        ts = Index(
+            np.array([(t + timedelta(minutes=int(x))).time() for x in deltas]),
+            dtype=object,
+        )
         df = DataFrame(
             {"a": np.random.randn(len(ts)), "b": np.random.randn(len(ts))}, index=ts
         )
@@ -1118,6 +1122,7 @@ class TestTSPlot:
         t = datetime(1, 1, 1, 3, 30, 0)
         deltas = np.random.randint(1, 20, 3).cumsum()
         ts = np.array([(t + timedelta(microseconds=int(x))).time() for x in deltas])
+        ts = Index(ts, dtype=object)
         df = DataFrame(
             {"a": np.random.randn(len(ts)), "b": np.random.randn(len(ts))}, index=ts
         )

--- a/pandas/tests/series/accessors/test_cat_accessor.py
+++ b/pandas/tests/series/accessors/test_cat_accessor.py
@@ -211,8 +211,12 @@ class TestCatAccessor:
             tm.assert_equal(res, exp)
 
         for attr in attr_names:
-            res = getattr(cat.dt, attr)
-            exp = getattr(ser.dt, attr)
+            with warnings.catch_warnings():
+                if attr == "time":
+                    # deprecated to return pyarrow time dtype
+                    warnings.simplefilter("ignore", FutureWarning)
+                res = getattr(cat.dt, attr)
+                exp = getattr(ser.dt, attr)
 
             tm.assert_equal(res, exp)
 

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -87,7 +87,7 @@ class TestSeriesDatetimeValues:
                     result = result.astype("int64")
             elif not is_list_like(result) or isinstance(result, DataFrame):
                 return result
-            return Series(result, index=ser.index, name=ser.name)
+            return Series(result, index=ser.index, name=ser.name, dtype=result.dtype)
 
         left = getattr(ser.dt, name)
         right = get_expected(ser, name)
@@ -725,7 +725,8 @@ class TestSeriesDatetimeValues:
         )
         ser = Series(dtindex)
         expected = Series(
-            [time(23, 56, tzinfo=tz), time(21, 24, tzinfo=tz), time(22, 14, tzinfo=tz)]
+            [time(23, 56, tzinfo=tz), time(21, 24, tzinfo=tz), time(22, 14, tzinfo=tz)],
+            dtype=object,
         )
         result = ser.dt.timetz
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -91,7 +91,9 @@ class TestSeriesDatetimeValues:
             return Series(result, index=ser.index, name=ser.name, dtype=result.dtype)
 
         if name == "time":
-            msg = "In a future version, this will an array with pyarrow time dtype"
+            msg = (
+                "In a future version, this will return an array with pyarrow time dtype"
+            )
             with tm.assert_produces_warning(FutureWarning, match=msg):
                 left = getattr(ser.dt, name)
                 right = get_expected(ser, name)
@@ -680,7 +682,7 @@ class TestSeriesDatetimeValues:
         )
         tm.assert_series_equal(result, expected)
 
-        msg = "In a future version, this will an array with pyarrow time"
+        msg = "In a future version, this will return an array with pyarrow time"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             result = ser.dt.time
         expected = Series([time(0), time(0), pd.NaT, time(0), time(0)], dtype="object")

--- a/pandas/tests/strings/test_api.py
+++ b/pandas/tests/strings/test_api.py
@@ -31,7 +31,16 @@ def test_api_per_dtype(index_or_series, dtype, any_skipna_inferred_dtype):
     box = index_or_series
     inferred_dtype, values = any_skipna_inferred_dtype
 
-    t = box(values, dtype=dtype)  # explicit dtype to avoid casting
+    warn_msg = (
+        "Pandas type inference with a sequence of `datetime.time` objects "
+        "is deprecated"
+    )
+    warn = None
+    if dtype == "category" and inferred_dtype == "time":
+        warn = FutureWarning
+
+    with tm.assert_produces_warning(warn, match=warn_msg):
+        t = box(values, dtype=dtype)  # explicit dtype to avoid casting
 
     types_passing_constructor = [
         "string",

--- a/pandas/tests/tools/test_to_time.py
+++ b/pandas/tests/tools/test_to_time.py
@@ -61,9 +61,15 @@ class TestToTime:
         with pytest.raises(ValueError, match=msg):
             to_time(arg, format="%I:%M%p", errors="raise")
 
-        tm.assert_series_equal(
-            to_time(Series(arg, name="test")), Series(expected_arr, name="test")
+        warn_msg = (
+            "Pandas type inference with a sequence of `datetime.time` objects "
+            "is deprecated"
         )
+        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+            res_ser = to_time(Series(arg, name="test"))
+        exp_ser = Series(expected_arr, name="test", dtype=object)
+
+        tm.assert_series_equal(res_ser, exp_ser)
 
         res = to_time(np.array(arg))
         assert isinstance(res, list)


### PR DESCRIPTION
xref #52711 this is what I have in mind for how we would deprecate the current inference behavior with a sequence of `datetime.time` objects.  We would allow opting-in to the future behavior with `pd.set_option("future.infer_time", True)`.

I plan to update this PR to also deprecate returning object dtype from the `time` and `timetz` properties in the `.dt` accessor.  Also any relevant cases in the sql code.

If we go down this route, I would follow this with analogous PRs for datetime.date, Decimal, ... 