### PR TITLE
BUG: `MultiIndex` displays incorrectly with a long element

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -369,10 +369,10 @@ I/O
 ^^^
 - :meth:`DataFrame.to_orc` now raising ``ValueError`` when non-default :class:`Index` is given (:issue:`51828`)
 - :meth:`DataFrame.to_sql` now raising ``ValueError`` when the name param is left empty while using SQLAlchemy to connect (:issue:`52675`)
-- Bug in :func:`format_object_summary`, head and tail were not correctly set (:issue:`52960`)
 - Bug in :func:`read_hdf` not properly closing store after a ``IndexError`` is raised (:issue:`52781`)
 - Bug in :func:`read_html`, style elements were read into DataFrames (:issue:`52197`)
 - Bug in :func:`read_html`, tail texts were removed together with elements containing ``display:none`` style (:issue:`51629`)
+- Bug in displaying a :class:`MultiIndex` with a long element (:issue:`52960`)
 
 Period
 ^^^^^^

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -367,10 +367,10 @@ I/O
 ^^^
 - :meth:`DataFrame.to_orc` now raising ``ValueError`` when non-default :class:`Index` is given (:issue:`51828`)
 - :meth:`DataFrame.to_sql` now raising ``ValueError`` when the name param is left empty while using SQLAlchemy to connect (:issue:`52675`)
+- Bug in :func:`format_object_summary`, head and tail were not correctly set (:issue:`52960`)
 - Bug in :func:`read_hdf` not properly closing store after a ``IndexError`` is raised (:issue:`52781`)
 - Bug in :func:`read_html`, style elements were read into DataFrames (:issue:`52197`)
 - Bug in :func:`read_html`, tail texts were removed together with elements containing ``display:none`` style (:issue:`51629`)
--
 
 Period
 ^^^^^^

--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -412,9 +412,11 @@ def format_object_summary(
             # max_space
             max_space = display_width - len(space2)
             value = tail[0]
-            for max_items in reversed(range(1, len(value) + 1)):
-                pprinted_seq = _pprint_seq(value, max_seq_items=max_items)
+            max_items = 1
+            for num_items in reversed(range(1, len(value) + 1)):
+                pprinted_seq = _pprint_seq(value, max_seq_items=num_items)
                 if len(pprinted_seq) < max_space:
+                    max_items = num_items
                     break
             head = [_pprint_seq(x, max_seq_items=max_items) for x in head]
             tail = [_pprint_seq(x, max_seq_items=max_items) for x in tail]

--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -415,9 +415,9 @@ def format_object_summary(
             for max_items in reversed(range(1, len(value) + 1)):
                 pprinted_seq = _pprint_seq(value, max_seq_items=max_items)
                 if len(pprinted_seq) < max_space:
-                    head = [_pprint_seq(x, max_seq_items=max_items) for x in head]
-                    tail = [_pprint_seq(x, max_seq_items=max_items) for x in tail]
                     break
+            head = [_pprint_seq(x, max_seq_items=max_items) for x in head]
+            tail = [_pprint_seq(x, max_seq_items=max_items) for x in tail]
 
         summary = ""
         line = space2

--- a/pandas/tests/io/formats/test_printing.py
+++ b/pandas/tests/io/formats/test_printing.py
@@ -196,3 +196,14 @@ class TestTableSchemaRepr:
             assert formatters[mimetype].enabled
             # smoke test that it works
             ip.instance(config=ip.config).display_formatter.format(cf)
+
+
+def test_multiindex_long_element():
+    # Non-regression test towards GH #52960
+    data = pd.MultiIndex.from_tuples([("c" * 62,)])
+
+    expected = (
+        "MultiIndex([('cccccccccccccccccccccccccccccccccccccccc"
+        "cccccccccccccccccccccc',)],\n           )"
+    )
+    assert str(data) == expected


### PR DESCRIPTION
- [x] Closes #52960
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests)
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit)
- [x] Added an entry in the latest `doc/source/whatsnew/v2.1.0.rst` file

https://github.com/pandas-dev/pandas/blob/721bd7a22efbd1c57f86fd61d6f0e668b79942ae/pandas/io/formats/printing.py#L417-L420
The `if` branch as shown above may never be visited, so `head` and `tail` may not be correctly set. This pull request fixes this problem.