### PR TITLE
DOC: Typo on the close argument of pandas.DataFrame.rolling

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2771,7 +2771,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
 
             If ``'left'``, the last point in the window is excluded from calculations.
 
-            If ``'both'``, the no points in the window are excluded from calculations.
+            If ``'both'``, no points in the window are excluded from calculations.
 
             If ``'neither'``, the first and last points in the window are excluded
             from calculations.


### PR DESCRIPTION
The documentation "close" argument of pandas.DataFrame.rolling for option "both" had an extra "the", it is removed here.
