### PR TITLE
BUG: Fix regression when printing backslash in DataFrame.to_string

### DIFF
--- a/doc/source/whatsnew/v2.0.2.rst
+++ b/doc/source/whatsnew/v2.0.2.rst
@@ -14,7 +14,7 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Fixed regression in :meth:`DataFrame.loc` losing :class:`MultiIndex` name when enlarging object (:issue:`53053`)
--
+- Fixed regression in :meth:`DataFrame.to_string` printing a backslash at the end of the first row of data, instead of headers, when the DataFrame doesn't fit the line width (:issue:`53054`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_202.bug_fixes:

--- a/pandas/io/formats/string.py
+++ b/pandas/io/formats/string.py
@@ -135,12 +135,6 @@ class StringFormatter:
         col_bins = _binify(col_widths, lwidth)
         nbins = len(col_bins)
 
-        if self.fmt.is_truncated_vertically:
-            assert self.fmt.max_rows_fitted is not None
-            nrows = self.fmt.max_rows_fitted + 1
-        else:
-            nrows = len(self.frame)
-
         str_lst = []
         start = 0
         for i, end in enumerate(col_bins):
@@ -148,6 +142,7 @@ class StringFormatter:
             if self.fmt.index:
                 row.insert(0, idx)
             if nbins > 1:
+                nrows = len(row[-1])
                 if end <= len(strcols) and i < nbins - 1:
                     row.append([" \\"] + ["  "] * (nrows - 1))
                 else:

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -1446,25 +1446,100 @@ class TestDataFrameFormatting:
         assert df_s == expected
 
     def test_to_string_line_width_no_index(self):
-        # GH 13998, GH 22505, # GH 49230
+        # GH 13998, GH 22505
         df = DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
 
         df_s = df.to_string(line_width=1, index=False)
-        expected = " x   \n 1  \\\n 2   \n 3   \n\n y  \n 4  \n 5  \n 6  "
+        expected = " x  \\\n 1   \n 2   \n 3   \n\n y  \n 4  \n 5  \n 6  "
 
         assert df_s == expected
 
         df = DataFrame({"x": [11, 22, 33], "y": [4, 5, 6]})
 
         df_s = df.to_string(line_width=1, index=False)
-        expected = " x   \n11  \\\n22   \n33   \n\n y  \n 4  \n 5  \n 6  "
+        expected = " x  \\\n11   \n22   \n33   \n\n y  \n 4  \n 5  \n 6  "
 
         assert df_s == expected
 
         df = DataFrame({"x": [11, 22, -33], "y": [4, 5, -6]})
 
         df_s = df.to_string(line_width=1, index=False)
-        expected = "  x   \n 11  \\\n 22   \n-33   \n\n y  \n 4  \n 5  \n-6  "
+        expected = "  x  \\\n 11   \n 22   \n-33   \n\n y  \n 4  \n 5  \n-6  "
+
+        assert df_s == expected
+
+    def test_to_string_line_width_no_header(self):
+        # GH 53054
+        df = DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+
+        df_s = df.to_string(line_width=1, header=False)
+        expected = "0  1  \\\n1  2   \n2  3   \n\n0  4  \n1  5  \n2  6  "
+
+        assert df_s == expected
+
+        df = DataFrame({"x": [11, 22, 33], "y": [4, 5, 6]})
+
+        df_s = df.to_string(line_width=1, header=False)
+        expected = "0  11  \\\n1  22   \n2  33   \n\n0  4  \n1  5  \n2  6  "
+
+        assert df_s == expected
+
+        df = DataFrame({"x": [11, 22, -33], "y": [4, 5, -6]})
+
+        df_s = df.to_string(line_width=1, header=False)
+        expected = "0  11  \\\n1  22   \n2 -33   \n\n0  4  \n1  5  \n2 -6  "
+
+        assert df_s == expected
+
+    def test_to_string_line_width_no_index_no_header(self):
+        # GH 53054
+        df = DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+
+        df_s = df.to_string(line_width=1, index=False, header=False)
+        expected = "1  \\\n2   \n3   \n\n4  \n5  \n6  "
+
+        assert df_s == expected
+
+        df = DataFrame({"x": [11, 22, 33], "y": [4, 5, 6]})
+
+        df_s = df.to_string(line_width=1, index=False, header=False)
+        expected = "11  \\\n22   \n33   \n\n4  \n5  \n6  "
+
+        assert df_s == expected
+
+        df = DataFrame({"x": [11, 22, -33], "y": [4, 5, -6]})
+
+        df_s = df.to_string(line_width=1, index=False, header=False)
+        expected = " 11  \\\n 22   \n-33   \n\n 4  \n 5  \n-6  "
+
+        assert df_s == expected
+
+    def test_to_string_line_width_with_both_index_and_header(self):
+        # GH 53054
+        df = DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+
+        df_s = df.to_string(line_width=1)
+        expected = (
+            "   x  \\\n0  1   \n1  2   \n2  3   \n\n   y  \n0  4  \n1  5  \n2  6  "
+        )
+
+        assert df_s == expected
+
+        df = DataFrame({"x": [11, 22, 33], "y": [4, 5, 6]})
+
+        df_s = df.to_string(line_width=1)
+        expected = (
+            "    x  \\\n0  11   \n1  22   \n2  33   \n\n   y  \n0  4  \n1  5  \n2  6  "
+        )
+
+        assert df_s == expected
+
+        df = DataFrame({"x": [11, 22, -33], "y": [4, 5, -6]})
+
+        df_s = df.to_string(line_width=1)
+        expected = (
+            "    x  \\\n0  11   \n1  22   \n2 -33   \n\n   y  \n0  4  \n1  5  \n2 -6  "
+        )
 
         assert df_s == expected
 


### PR DESCRIPTION
- [x] closes #53054
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
