### PR TITLE
 CLN: avoid upcasting in tests where unnecessary (PDEP-6 precursor)

### DIFF
--- a/pandas/tests/indexing/test_at.py
+++ b/pandas/tests/indexing/test_at.py
@@ -114,9 +114,10 @@ class TestAtSetItem:
 
     @pytest.mark.parametrize("row", (Timestamp("2019-01-01"), "2019-01-01"))
     def test_at_datetime_index(self, row):
+        # Set float64 dtype to avoid upcast when setting .5
         df = DataFrame(
             data=[[1] * 2], index=DatetimeIndex(data=["2019-01-01", "2019-01-02"])
-        )
+        ).astype({0: "float64"})
         expected = DataFrame(
             data=[[0.5, 1], [1.0, 1]],
             index=DatetimeIndex(data=["2019-01-01", "2019-01-02"]),

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -719,7 +719,8 @@ class TestiLocBaseIndependent:
         # assigning like "df.iloc[0, [0]] = ['Z']" should be evaluated
         # elementwisely, not using "setter('A', ['Z'])".
 
-        df = DataFrame([[1, 2], [3, 4]], columns=["A", "B"])
+        # Set object type to avoid upcast when setting "Z"
+        df = DataFrame([[1, 2], [3, 4]], columns=["A", "B"]).astype({"A": object})
         df.iloc[0, indexer] = value
         result = df.iloc[0, 0]
 

--- a/pandas/tests/indexing/test_scalar.py
+++ b/pandas/tests/indexing/test_scalar.py
@@ -202,7 +202,7 @@ class TestAtAndiAT:
 
     def test_iat_setter_incompatible_assignment(self):
         # GH 23236
-        result = DataFrame({"a": [0, 1], "b": [4, 5]})
+        result = DataFrame({"a": [0.0, 1.0], "b": [4, 5]})
         result.iat[0, 0] = None
         expected = DataFrame({"a": [None, 1], "b": [4, 5]})
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/interchange/test_impl.py
+++ b/pandas/tests/interchange/test_impl.py
@@ -157,7 +157,7 @@ def test_dataframe(data):
 def test_missing_from_masked():
     df = pd.DataFrame(
         {
-            "x": np.array([1, 2, 3, 4, 0]),
+            "x": np.array([1.0, 2.0, 3.0, 4.0, 0.0]),
             "y": np.array([1.5, 2.5, 3.5, 4.5, 0]),
             "z": np.array([True, False, True, True, True]),
         }

--- a/pandas/tests/reshape/test_from_dummies.py
+++ b/pandas/tests/reshape/test_from_dummies.py
@@ -163,6 +163,8 @@ def test_error_with_prefix_default_category_dict_not_complete(
 
 
 def test_error_with_prefix_contains_nan(dummies_basic):
+    # Set float64 dtype to avoid upcast when setting np.nan
+    dummies_basic["col2_c"] = dummies_basic["col2_c"].astype("float64")
     dummies_basic.loc[2, "col2_c"] = np.nan
     with pytest.raises(
         ValueError, match=r"Dummy DataFrame contains NA value in column: 'col2_c'"
@@ -171,6 +173,8 @@ def test_error_with_prefix_contains_nan(dummies_basic):
 
 
 def test_error_with_prefix_contains_non_dummies(dummies_basic):
+    # Set object dtype to avoid upcast when setting "str"
+    dummies_basic["col2_c"] = dummies_basic["col2_c"].astype(object)
     dummies_basic.loc[2, "col2_c"] = "str"
     with pytest.raises(TypeError, match=r"Passed DataFrame contains non-dummy data"):
         from_dummies(dummies_basic, sep="_")

--- a/pandas/tests/series/methods/test_update.py
+++ b/pandas/tests/series/methods/test_update.py
@@ -25,6 +25,8 @@ class TestUpdate:
         # GH 3217
         df = DataFrame([{"a": 1}, {"a": 3, "b": 2}])
         df["c"] = np.nan
+        # Cast to object to avoid upcast when setting "foo"
+        df["c"] = df["c"].astype(object)
         df_orig = df.copy()
 
         df["c"].update(Series(["foo"], index=[0]))

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -91,7 +91,8 @@ class TestSeriesMissingData:
 
 def test_hasnans_uncached_for_series():
     # GH#19700
-    idx = Index([0, 1])
+    # set float64 dtype to avoid upcast when setting nan
+    idx = Index([0, 1], dtype="float64")
     assert idx.hasnans is False
     assert "hasnans" in idx._cache
     ser = idx.to_series()


### PR DESCRIPTION
another precursor to PDEP6, similar to https://github.com/pandas-dev/pandas/pull/52957

getting there...I think most of the remaining ones are when the test explicitly checks for upcasting behaviour, and so probably can't be changed right now