### PR TITLE
PERF: avoid accessing has_dropped_na

### DIFF
--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -799,7 +799,14 @@ class BaseGrouper:
         """
         assert kind in ["transform", "aggregate"]
 
-        cy_op = WrappedCythonOp(kind=kind, how=how, has_dropped_na=self.has_dropped_na)
+        # checking self.has_dropped_na is expensive, and it is only needed in
+        #  "transform" cases, so avoid the lookup
+        if kind == "transform":
+            has_dropped_na = self.has_dropped_na
+        else:
+            has_dropped_na = False
+
+        cy_op = WrappedCythonOp(kind=kind, how=how, has_dropped_na=has_dropped_na)
 
         ids, _, _ = self.group_info
         ngroups = self.ngroups


### PR DESCRIPTION
When profiling `q1` in the "pandas_queries" from https://github.com/pola-rs/tpch I found the single check to has_dropped_na took 6.5 seconds, 15% of the total runtime.  Turns out we only need has_dropped_na in transform cases, so this PR just avoids accessing it unless it is necessary.

cc @rhshadrach since I think you introduced has_dropped_na.  This seems like something we should be able to improve upon.  Maybe by checking for -1s at the point where we create the codes rather than after we have them?