### PR TITLE
Function signature53071

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -3653,7 +3653,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
     @Substitution(name="groupby")
     @Appender(_common_see_also)
     def cumprod(
-        self, axis: Axis | lib.NoDefault = lib.no_default, *args, **kwargs
+        self, axis: Axis | lib.NoDefault = lib.no_default, numeric_only: bool = False, *args, **kwargs
     ) -> NDFrameT:
         """
         Cumulative product for each group.
@@ -3662,7 +3662,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         -------
         Series or DataFrame
         """
-        nv.validate_groupby_func("cumprod", args, kwargs, ["numeric_only", "skipna"])
+        nv.validate_groupby_func("cumprod", args, kwargs, ["skipna"])
         if axis is not lib.no_default:
             axis = self.obj._get_axis_number(axis)
             self._deprecate_axis(axis, "cumprod")
@@ -3673,13 +3673,13 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             f = lambda x: x.cumprod(axis=axis, **kwargs)
             return self._python_apply_general(f, self._selected_obj, is_transform=True)
 
-        return self._cython_transform("cumprod", **kwargs)
+        return self._cython_transform("cumprod", numeric_only=numeric_only, **kwargs)
 
     @final
     @Substitution(name="groupby")
     @Appender(_common_see_also)
     def cumsum(
-        self, axis: Axis | lib.NoDefault = lib.no_default, *args, **kwargs
+        self, axis: Axis | lib.NoDefault = lib.no_default, numeric_only: bool = False, *args, **kwargs
     ) -> NDFrameT:
         """
         Cumulative sum for each group.
@@ -3688,7 +3688,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         -------
         Series or DataFrame
         """
-        nv.validate_groupby_func("cumsum", args, kwargs, ["numeric_only", "skipna"])
+        nv.validate_groupby_func("cumsum", args, kwargs, ["skipna"])
         if axis is not lib.no_default:
             axis = self.obj._get_axis_number(axis)
             self._deprecate_axis(axis, "cumsum")
@@ -3699,7 +3699,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             f = lambda x: x.cumsum(axis=axis, **kwargs)
             return self._python_apply_general(f, self._selected_obj, is_transform=True)
 
-        return self._cython_transform("cumsum", **kwargs)
+        return self._cython_transform("cumsum", numeric_only=numeric_only, **kwargs)
 
     @final
     @Substitution(name="groupby")

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -57,7 +57,6 @@ from pandas._typing import (
     T,
     npt,
 )
-from pandas.compat.numpy import function as nv
 from pandas.errors import (
     AbstractMethodError,
     DataError,
@@ -3657,17 +3656,23 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         axis: Axis | lib.NoDefault = lib.no_default,
         numeric_only: bool = False,
         skipna: bool = True,
-        *args,
-        **kwargs,
     ) -> NDFrameT:
         """
         Cumulative product for each group.
+
+        Parameters
+        ----------
+        axis : int, default 0
+            The axis to apply the cumulative product along.
+        skipna : bool, default True
+            Exclude NA/null values when computing the result.
+        numeric_only : bool, default False
+            Include only float, int, boolean columns.
 
         Returns
         -------
         Series or DataFrame
         """
-        nv.validate_groupby_func("cumprod", args, kwargs, [])
         if axis is not lib.no_default:
             axis = self.obj._get_axis_number(axis)
             self._deprecate_axis(axis, "cumprod")
@@ -3675,11 +3680,11 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             axis = 0
 
         if axis != 0:
-            f = lambda x: x.cumprod(axis=axis, skipna=skipna, **kwargs)
+            f = lambda x: x.cumprod(axis=axis, skipna=skipna, numeric_only=numeric_only)
             return self._python_apply_general(f, self._selected_obj, is_transform=True)
 
         return self._cython_transform(
-            "cumprod", numeric_only=numeric_only, skipna=skipna, **kwargs
+            "cumprod", numeric_only=numeric_only, skipna=skipna
         )
 
     @final
@@ -3690,17 +3695,23 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         axis: Axis | lib.NoDefault = lib.no_default,
         numeric_only: bool = False,
         skipna: bool = True,
-        *args,
-        **kwargs,
     ) -> NDFrameT:
         """
         Cumulative sum for each group.
+
+        Parameters
+        ----------
+        axis : int, default 0
+            The axis to apply the cumulative sum along.
+        skipna : bool, default True
+            Exclude NA/null values when computing the result.
+        numeric_only : bool, default False
+            Include only float, int, boolean columns.
 
         Returns
         -------
         Series or DataFrame
         """
-        nv.validate_groupby_func("cumsum", args, kwargs, [])
         if axis is not lib.no_default:
             axis = self.obj._get_axis_number(axis)
             self._deprecate_axis(axis, "cumsum")
@@ -3708,11 +3719,11 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             axis = 0
 
         if axis != 0:
-            f = lambda x: x.cumsum(axis=axis, skipna=skipna, **kwargs)
+            f = lambda x: x.cumsum(axis=axis, skipna=skipna, numeric_only=numeric_only)
             return self._python_apply_general(f, self._selected_obj, is_transform=True)
 
         return self._cython_transform(
-            "cumsum", numeric_only=numeric_only, skipna=skipna, **kwargs
+            "cumsum", numeric_only=numeric_only, skipna=skipna
         )
 
     @final

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -3653,7 +3653,12 @@ class GroupBy(BaseGroupBy[NDFrameT]):
     @Substitution(name="groupby")
     @Appender(_common_see_also)
     def cumprod(
-        self, axis: Axis | lib.NoDefault = lib.no_default, numeric_only: bool = False, *args, **kwargs
+        self,
+        axis: Axis | lib.NoDefault = lib.no_default,
+        numeric_only: bool = False,
+        skipna: bool = True,
+        *args,
+        **kwargs,
     ) -> NDFrameT:
         """
         Cumulative product for each group.
@@ -3662,7 +3667,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         -------
         Series or DataFrame
         """
-        nv.validate_groupby_func("cumprod", args, kwargs, ["skipna"])
+        nv.validate_groupby_func("cumprod", args, kwargs, [])
         if axis is not lib.no_default:
             axis = self.obj._get_axis_number(axis)
             self._deprecate_axis(axis, "cumprod")
@@ -3670,16 +3675,23 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             axis = 0
 
         if axis != 0:
-            f = lambda x: x.cumprod(axis=axis, **kwargs)
+            f = lambda x: x.cumprod(axis=axis, skipna=skipna, **kwargs)
             return self._python_apply_general(f, self._selected_obj, is_transform=True)
 
-        return self._cython_transform("cumprod", numeric_only=numeric_only, **kwargs)
+        return self._cython_transform(
+            "cumprod", numeric_only=numeric_only, skipna=skipna, **kwargs
+        )
 
     @final
     @Substitution(name="groupby")
     @Appender(_common_see_also)
     def cumsum(
-        self, axis: Axis | lib.NoDefault = lib.no_default, numeric_only: bool = False, *args, **kwargs
+        self,
+        axis: Axis | lib.NoDefault = lib.no_default,
+        numeric_only: bool = False,
+        skipna: bool = True,
+        *args,
+        **kwargs,
     ) -> NDFrameT:
         """
         Cumulative sum for each group.
@@ -3688,7 +3700,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         -------
         Series or DataFrame
         """
-        nv.validate_groupby_func("cumsum", args, kwargs, ["skipna"])
+        nv.validate_groupby_func("cumsum", args, kwargs, [])
         if axis is not lib.no_default:
             axis = self.obj._get_axis_number(axis)
             self._deprecate_axis(axis, "cumsum")
@@ -3696,10 +3708,12 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             axis = 0
 
         if axis != 0:
-            f = lambda x: x.cumsum(axis=axis, **kwargs)
+            f = lambda x: x.cumsum(axis=axis, skipna=skipna, **kwargs)
             return self._python_apply_general(f, self._selected_obj, is_transform=True)
 
-        return self._cython_transform("cumsum", numeric_only=numeric_only, **kwargs)
+        return self._cython_transform(
+            "cumsum", numeric_only=numeric_only, skipna=skipna, **kwargs
+        )
 
     @final
     @Substitution(name="groupby")


### PR DESCRIPTION
- [x] closes #53071  (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Previously, the skipna and numeric_only parameters could only be passed via the *args or **kwargs parameters, which could make the function signatures less clear and confusing for users. With these changes, the new parameters are included in the function signature and in the calls to the cumprod and cumsum methods inside the functions.