### PR TITLE
REGR: MultiIndex.join not resorting levels of new index

### DIFF
--- a/doc/source/whatsnew/v2.0.2.rst
+++ b/doc/source/whatsnew/v2.0.2.rst
@@ -14,6 +14,7 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Fixed regression in :meth:`DataFrame.loc` losing :class:`MultiIndex` name when enlarging object (:issue:`53053`)
+- Fixed regression in :meth:`MultiIndex.join` returning levels in wrong order (:issue:`53093`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4907,7 +4907,7 @@ class Index(IndexOpsMixin, PandasObject):
             mask = lidx == -1
             join_idx = self.take(lidx)
             right = other.take(ridx)
-            join_index = join_idx.putmask(mask, right)
+            join_index = join_idx.putmask(mask, right)._sort_levels_monotonic()
             return join_index.set_names(name)  # type: ignore[return-value]
         else:
             name = get_op_result_name(self, other)

--- a/pandas/tests/indexes/multi/test_join.py
+++ b/pandas/tests/indexes/multi/test_join.py
@@ -257,3 +257,15 @@ def test_join_dtypes_all_nan(any_numeric_ea_dtype):
         ]
     )
     tm.assert_index_equal(result, expected)
+
+
+def test_join_index_levels():
+    # GH#53093
+    midx = midx = MultiIndex.from_tuples([("a", "2019-02-01"), ("a", "2019-02-01")])
+    midx2 = MultiIndex.from_tuples([("a", "2019-01-31")])
+    result = midx.join(midx2, how="outer")
+    expected = MultiIndex.from_tuples(
+        [("a", "2019-01-31"), ("a", "2019-02-01"), ("a", "2019-02-01")]
+    )
+    tm.assert_index_equal(result.levels[1], expected.levels[1])
+    tm.assert_index_equal(result, expected)


### PR DESCRIPTION
- [x] closes #53093 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Not resorting causes all kinds of problems when indexing