### PR TITLE
CLN: avoid upcasting in tests where unnecessary (PDEP-6 precursor)

### DIFF
--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -328,15 +328,14 @@ class TestDataFrameIndexingWhere:
         )
 
         expected = DataFrame(
-            {"a": [np.nan, np.nan, 3.0, 4.0], "b": [4.0, 3.0, np.nan, np.nan]},
-            dtype="float64",
-        )
+            {"a": [-1, -1, 3, 4], "b": [4.0, 3.0, -1, -1]},
+        ).astype({"a": any_signed_int_numpy_dtype, "b": "float64"})
 
-        result = df.where(df > 2, np.nan)
+        result = df.where(df > 2, -1)
         tm.assert_frame_equal(result, expected)
 
         result = df.copy()
-        return_value = result.where(result > 2, np.nan, inplace=True)
+        return_value = result.where(result > 2, -1, inplace=True)
         assert return_value is None
         tm.assert_frame_equal(result, expected)
 
@@ -1028,7 +1027,7 @@ def test_where_int_overflow(replacement):
 
 def test_where_inplace_no_other():
     # GH#51685
-    df = DataFrame({"a": [1, 2], "b": ["x", "y"]})
+    df = DataFrame({"a": [1.0, 2.0], "b": ["x", "y"]})
     cond = DataFrame({"a": [True, False], "b": [False, True]})
     df.where(cond, inplace=True)
     expected = DataFrame({"a": [1, np.nan], "b": [np.nan, "y"]})

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -436,7 +436,9 @@ class TestFancy:
                 "col1": list(range(6)),
                 "col2": list(range(6, 12)),
             }
-        )
+        ).astype(
+            {"col2": "float64"}
+        )  # set float64 to avoid upcast when setting nan
         df.iloc[1, 0] = np.nan
         df2 = df.copy()
 

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -429,6 +429,7 @@ class TestFancy:
 
     def test_multi_assign(self):
         # GH 3626, an assignment of a sub-df to a df
+        # set float64 to avoid upcast when setting nan
         df = DataFrame(
             {
                 "FC": ["a", "b", "a", "b", "a", "b"],
@@ -436,9 +437,7 @@ class TestFancy:
                 "col1": list(range(6)),
                 "col2": list(range(6, 12)),
             }
-        ).astype(
-            {"col2": "float64"}
-        )  # set float64 to avoid upcast when setting nan
+        ).astype({"col2": "float64"})
         df.iloc[1, 0] = np.nan
         df2 = df.copy()
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -863,7 +863,8 @@ class TestLocBaseIndependent:
         # assigning like "df.loc[0, ['A']] = ['Z']" should be evaluated
         # elementwisely, not using "setter('A', ['Z'])".
 
-        df = DataFrame([[1, 2], [3, 4]], columns=["A", "B"])
+        # Set object dtype to avoid upcast when setting 'Z'
+        df = DataFrame([[1, 2], [3, 4]], columns=["A", "B"]).astype({"A": object})
         df.loc[0, indexer] = value
         result = df.loc[0, "A"]
 
@@ -1524,7 +1525,8 @@ class TestLocBaseIndependent:
 
     def test_loc_setitem_2d_to_1d_raises(self):
         data = np.random.randn(2, 2)
-        ser = Series(range(2))
+        # float64 dtype to avoid upcast when trying to set float data
+        ser = Series(range(2), dtype="float64")
 
         msg = "|".join(
             [

--- a/pandas/tests/interchange/test_impl.py
+++ b/pandas/tests/interchange/test_impl.py
@@ -171,7 +171,7 @@ def test_missing_from_masked():
         {
             "x": np.array([1.0, 2.0, 3.0, 4.0, 0.0]),
             "y": np.array([1.5, 2.5, 3.5, 4.5, 0]),
-            "z": np.array([True, False, True, True, True]),
+            "z": np.array([1.0, 0.0, 1.0, 1.0, 1.0]),
         }
     )
 

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -61,7 +61,8 @@ class TestSetitemDT64Values:
 
     def test_setitem_with_string_index(self):
         # GH#23451
-        ser = Series([1, 2, 3], index=["Date", "b", "other"])
+        # Set object dtype to avoid upcast when setting date.today()
+        ser = Series([1, 2, 3], index=["Date", "b", "other"], dtype=object)
         ser["Date"] = date.today()
         assert ser.Date == date.today()
         assert ser["Date"] == date.today()
@@ -459,7 +460,8 @@ class TestSetitemCallable:
         # GH#13299
         inc = lambda x: x + 1
 
-        ser = Series([1, 2, -1, 4])
+        # set object dtype to avoid upcast when setting inc
+        ser = Series([1, 2, -1, 4], dtype=object)
         ser[ser < 0] = inc
 
         expected = Series([1, 2, inc, 4])


### PR DESCRIPTION
another precursor to PDEP6, similar to https://github.com/pandas-dev/pandas/pull/52957

turns out there were even more of these which could be factored upon further inspection