### PR TITLE
CI: Don't run cron for forks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
+    if: github.repository_owner == 'pandas-dev'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -11,6 +11,7 @@ jobs:
   stale:
     permissions:
       pull-requests: write
+    if: github.repository_owner == 'pandas-dev'
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/stale@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,7 +37,7 @@ jobs:
   build_wheels:
     name: Build wheel for ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
     if: >-
-      github.event_name == 'schedule' ||
+      (github.event_name == 'schedule' && github.repository_owner == 'pandas-dev') ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
       contains(github.event.pull_request.labels.*.name, 'Build')) ||


### PR DESCRIPTION
- [n/a] closes #xxxx (Replace xxxx with the GitHub issue number)
- [n/a] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [n/a] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [n/a?] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

The codeql and stale-pr workflows run on a cron:

```yml
on:
  schedule:
    # every day at midnight
    - cron: "0 0 * * *"
```

As does the wheels workflow:

```yml
on:
  schedule:
  #        ┌───────────── minute (0 - 59)
  #        │  ┌───────────── hour (0 - 23)
  #        │  │ ┌───────────── day of the month (1 - 31)
  #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
  #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
  #        │  │ │ │ │
  - cron: "27 3 */1 * *"
```

These are useful for the upstream https://github.com/pandas-dev/pandas repo but unnecessary for contributors' forks:

<img width="997" alt="image" src="https://user-images.githubusercontent.com/1324225/236686019-f97c10e6-9fcd-4de4-920e-42a837f6f497.png">

They also trigger emails when they fail on the fork:

<img width="712" alt="image" src="https://user-images.githubusercontent.com/1324225/236686197-c2b4e3cd-eb68-4f02-bb31-8c7b3cb2629f.png">

Similar to autoupdate-pre-commit-config, let's only run the schedule for upstream:

https://github.com/pandas-dev/pandas/blob/956b8008e90845093f57c581c97b15297c72090a/.github/workflows/autoupdate-pre-commit-config.yml#L16
