### PR TITLE
BUG: Setting frame into df with dup cols loses dtypes

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -361,7 +361,7 @@ Interval
 
 Indexing
 ^^^^^^^^
--
+- Bug in :meth:`DataFrame.__setitem__` losing dtype when setting a :class:`DataFrame` into duplicated columns (:issue:`53143`)
 -
 
 Missing

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4107,9 +4107,8 @@ class DataFrame(NDFrame, OpsMixin):
                 locs = [loc]
             else:
                 locs = loc.nonzero()[0]
-            for idx, loc in enumerate(locs):
-                self.isetitem(loc, value.iloc[:, idx])
-            return
+
+            return self.isetitem(locs, value)
 
         if len(value.columns) != 1:
             raise ValueError(

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4101,6 +4101,7 @@ class DataFrame(NDFrame, OpsMixin):
                 self[cols] = value[value.columns[0]]
                 return
 
+            locs: np.ndarray | list
             if isinstance(loc, slice):
                 locs = np.arange(loc.start, loc.stop, loc.step)
             elif is_scalar(loc):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4101,9 +4101,14 @@ class DataFrame(NDFrame, OpsMixin):
                 self[cols] = value[value.columns[0]]
                 return
 
-            # now align rows
-            arraylike, _ = _reindex_for_setitem(value, self.index)
-            self._set_item_mgr(key, arraylike)
+            if isinstance(loc, slice):
+                locs = np.arange(loc.start, loc.stop, loc.step)
+            elif is_scalar(loc):
+                locs = [loc]
+            else:
+                locs = loc.nonzero()[0]
+            for idx, loc in enumerate(locs):
+                self.isetitem(loc, value.iloc[:, idx])
             return
 
         if len(value.columns) != 1:

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -1283,3 +1283,19 @@ class TestDataFrameSetitemCopyViewSemantics:
 
         expected = DataFrame({"a": [2, 1, 1]}, dtype=dtype)
         tm.assert_frame_equal(df, expected)
+
+    def test_setitem_frame_dup_cols_dtype(self):
+        # GH#53143
+        df = DataFrame([[1, 2, 3, 4], [4, 5, 6, 7]], columns=["a", "b", "a", "c"])
+        rhs = DataFrame([[0, 1.5], [2, 2.5]], columns=["a", "a"])
+        df["a"] = rhs
+        expected = DataFrame(
+            [[0, 2, 1.5, 4], [2, 5, 2.5, 7]], columns=["a", "b", "a", "c"]
+        )
+        tm.assert_frame_equal(df, expected)
+
+        df = DataFrame([[1, 2, 3], [4, 5, 6]], columns=["a", "a", "b"])
+        rhs = DataFrame([[0, 1.5], [2, 2.5]], columns=["a", "a"])
+        df["a"] = rhs
+        expected = DataFrame([[0, 1.5, 3], [2, 2.5, 6]], columns=["a", "a", "b"])
+        tm.assert_frame_equal(df, expected)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
