### PR TITLE
MNT: Explicitly set cdef functions as noexcept

### DIFF
--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -1360,7 +1360,7 @@ cdef inline void _check_below_mincount(
     int64_t[:, ::1] nobs,
     int64_t min_count,
     mincount_t[:, ::1] resx,
-) nogil:
+) noexcept nogil:
     """
     Check if the number of observations for a group is below min_count,
     and if so set the result for that group to the appropriate NA-like value.

--- a/pandas/_libs/hashing.pyx
+++ b/pandas/_libs/hashing.pyx
@@ -126,7 +126,7 @@ cdef uint64_t u8to64_le(uint8_t* p) nogil:
 
 
 cdef void _sipround(uint64_t* v0, uint64_t* v1,
-                    uint64_t* v2, uint64_t* v3) nogil:
+                    uint64_t* v2, uint64_t* v3) noexcept nogil:
     v0[0] += v1[0]
     v1[0] = _rotl(v1[0], 13)
     v1[0] ^= v0[0]

--- a/pandas/_libs/hashtable.pxd
+++ b/pandas/_libs/hashtable.pxd
@@ -185,5 +185,5 @@ cdef class Int64Vector(Vector):
 
     cdef resize(self)
     cpdef ndarray to_array(self)
-    cdef void append(self, int64_t x)
+    cdef void append(self, int64_t x) noexcept
     cdef extend(self, int64_t[:] x)

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -141,7 +141,7 @@ ctypedef struct {{name}}VectorData:
 @cython.wraparound(False)
 @cython.boundscheck(False)
 cdef void append_data_{{dtype}}({{name}}VectorData *data,
-                                       {{c_type}} x) nogil:
+                                       {{c_type}} x) noexcept nogil:
 
     data.data[data.n] = x
     data.n += 1
@@ -241,7 +241,7 @@ cdef class {{name}}Vector(Vector):
         self.external_view_exists = True
         return self.ao
 
-    cdef void append(self, {{c_type}} x):
+    cdef void append(self, {{c_type}} x) noexcept:
 
         if needs_resize(self.data):
             if self.external_view_exists:
@@ -311,7 +311,7 @@ cdef class StringVector(Vector):
         self.data.m = self.data.n
         return ao
 
-    cdef void append(self, char *x):
+    cdef void append(self, char *x) noexcept:
 
         if needs_resize(self.data):
             self.resize()

--- a/pandas/_libs/join.pyx
+++ b/pandas/_libs/join.pyx
@@ -213,7 +213,7 @@ def full_outer_join(const intp_t[:] left, const intp_t[:] right,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cdef void _get_result_indexer(intp_t[::1] sorter, intp_t[::1] indexer) nogil:
+cdef void _get_result_indexer(intp_t[::1] sorter, intp_t[::1] indexer) noexcept nogil:
     """NOTE: overwrites indexer with the result to avoid allocating another array"""
     cdef:
         Py_ssize_t i, n, idx

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -595,7 +595,7 @@ cdef check_overflows(_TSObject obj, NPY_DATETIMEUNIT reso=NPY_FR_ns):
 # ----------------------------------------------------------------------
 # Localization
 
-cdef void _localize_tso(_TSObject obj, tzinfo tz, NPY_DATETIMEUNIT reso):
+cdef void _localize_tso(_TSObject obj, tzinfo tz, NPY_DATETIMEUNIT reso) noexcept:
     """
     Given the UTC nanosecond timestamp in obj.value, find the wall-clock
     representation of that timestamp in the given timezone.

--- a/pandas/_libs/tslibs/np_datetime.pxd
+++ b/pandas/_libs/tslibs/np_datetime.pxd
@@ -80,7 +80,7 @@ cdef extern from "src/datetime/pd_datetime.h":
         INFER_FORMAT
 
 # You must call this before using the PandasDateTime CAPI functions
-cdef inline void import_pandas_datetime():
+cdef inline void import_pandas_datetime() noexcept:
     PandasDateTime_IMPORT
 
 cdef bint cmp_scalar(int64_t lhs, int64_t rhs, int op) except -1
@@ -90,11 +90,11 @@ cdef check_dts_bounds(npy_datetimestruct *dts, NPY_DATETIMEUNIT unit=?)
 cdef int64_t pydatetime_to_dt64(
     datetime val, npy_datetimestruct *dts, NPY_DATETIMEUNIT reso=?
 )
-cdef void pydatetime_to_dtstruct(datetime dt, npy_datetimestruct *dts)
+cdef void pydatetime_to_dtstruct(datetime dt, npy_datetimestruct *dts) noexcept
 cdef int64_t pydate_to_dt64(
     date val, npy_datetimestruct *dts, NPY_DATETIMEUNIT reso=?
 )
-cdef void pydate_to_dtstruct(date val, npy_datetimestruct *dts)
+cdef void pydate_to_dtstruct(date val, npy_datetimestruct *dts) noexcept
 
 cdef npy_datetime get_datetime64_value(object obj) nogil
 cdef npy_timedelta get_timedelta64_value(object obj) nogil

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -229,7 +229,7 @@ def py_td64_to_tdstruct(int64_t td64, NPY_DATETIMEUNIT unit):
     return tds  # <- returned as a dict to python
 
 
-cdef void pydatetime_to_dtstruct(datetime dt, npy_datetimestruct *dts):
+cdef void pydatetime_to_dtstruct(datetime dt, npy_datetimestruct *dts) noexcept:
     if PyDateTime_CheckExact(dt):
         dts.year = PyDateTime_GET_YEAR(dt)
     else:
@@ -256,7 +256,7 @@ cdef int64_t pydatetime_to_dt64(datetime val,
     return npy_datetimestruct_to_datetime(reso, dts)
 
 
-cdef void pydate_to_dtstruct(date val, npy_datetimestruct *dts):
+cdef void pydate_to_dtstruct(date val, npy_datetimestruct *dts) noexcept:
     dts.year = PyDateTime_GET_YEAR(val)
     dts.month = PyDateTime_GET_MONTH(val)
     dts.day = PyDateTime_GET_DAY(val)

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -1052,7 +1052,7 @@ cdef str _fill_token(token: str, padding: int):
     return token_filled
 
 
-cdef void _maybe_warn_about_dayfirst(format: str, bint dayfirst):
+cdef void _maybe_warn_about_dayfirst(format: str, bint dayfirst) noexcept:
     """Warn if guessed datetime format doesn't respect dayfirst argument."""
     cdef:
         int day_index = format.find("%d")

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -803,7 +803,8 @@ cdef int64_t get_period_ordinal(npy_datetimestruct *dts, int freq) nogil:
     return npy_datetimestruct_to_datetime(unit, dts)
 
 
-cdef void get_date_info(int64_t ordinal, int freq, npy_datetimestruct *dts) noexcept nogil:
+cdef void get_date_info(int64_t ordinal,
+                        int freq, npy_datetimestruct *dts) noexcept nogil:
     cdef:
         int64_t unix_date, nanos
         npy_datetimestruct dts2

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -691,7 +691,7 @@ cdef int get_freq_group_index(int freq) nogil:
     return freq // 1000
 
 
-cdef void adjust_dts_for_month(npy_datetimestruct* dts, int from_end) nogil:
+cdef void adjust_dts_for_month(npy_datetimestruct* dts, int from_end) noexcept nogil:
     if from_end != 12:
         dts.month += from_end
         if dts.month > 12:
@@ -700,7 +700,7 @@ cdef void adjust_dts_for_month(npy_datetimestruct* dts, int from_end) nogil:
             dts.year -= 1
 
 
-cdef void adjust_dts_for_qtr(npy_datetimestruct* dts, int to_end) nogil:
+cdef void adjust_dts_for_qtr(npy_datetimestruct* dts, int to_end) noexcept nogil:
     if to_end != 12:
         dts.month -= to_end
         if dts.month <= 0:
@@ -803,7 +803,7 @@ cdef int64_t get_period_ordinal(npy_datetimestruct *dts, int freq) nogil:
     return npy_datetimestruct_to_datetime(unit, dts)
 
 
-cdef void get_date_info(int64_t ordinal, int freq, npy_datetimestruct *dts) nogil:
+cdef void get_date_info(int64_t ordinal, int freq, npy_datetimestruct *dts) noexcept nogil:
     cdef:
         int64_t unix_date, nanos
         npy_datetimestruct dts2
@@ -985,7 +985,7 @@ def periodarr_to_dt64arr(const int64_t[:] periodarr, int freq):
 
 
 cdef void get_asfreq_info(int from_freq, int to_freq,
-                          bint is_end, asfreq_info *af_info) nogil:
+                          bint is_end, asfreq_info *af_info) noexcept nogil:
     """
     Construct the `asfreq_info` object used to convert an ordinal from
     `from_freq` to `to_freq`.
@@ -1084,7 +1084,7 @@ cdef void _period_asfreq(
     int freq2,
     bint end,
     Py_ssize_t increment=1,
-):
+) noexcept:
     """See period_asfreq.__doc__"""
     cdef:
         Py_ssize_t i

--- a/pandas/_libs/tslibs/util.pxd
+++ b/pandas/_libs/tslibs/util.pxd
@@ -44,14 +44,14 @@ cdef extern from "numpy/npy_common.h":
     int64_t NPY_MIN_INT64
 
 
-cdef inline int64_t get_nat():
+cdef inline int64_t get_nat() noexcept:
     return NPY_MIN_INT64
 
 
 # --------------------------------------------------------------------
 # Type Checking
 
-cdef inline bint is_integer_object(object obj) nogil:
+cdef inline bint is_integer_object(object obj) noexcept nogil:
     """
     Cython equivalent of
 
@@ -73,7 +73,7 @@ cdef inline bint is_integer_object(object obj) nogil:
             and not is_timedelta64_object(obj))
 
 
-cdef inline bint is_float_object(object obj) nogil:
+cdef inline bint is_float_object(object obj) noexcept nogil:
     """
     Cython equivalent of `isinstance(val, (float, np.float_))`
 
@@ -89,7 +89,7 @@ cdef inline bint is_float_object(object obj) nogil:
             (PyObject_TypeCheck(obj, &PyFloatingArrType_Type)))
 
 
-cdef inline bint is_complex_object(object obj) nogil:
+cdef inline bint is_complex_object(object obj) noexcept nogil:
     """
     Cython equivalent of `isinstance(val, (complex, np.complex_))`
 
@@ -105,7 +105,7 @@ cdef inline bint is_complex_object(object obj) nogil:
             PyObject_TypeCheck(obj, &PyComplexFloatingArrType_Type))
 
 
-cdef inline bint is_bool_object(object obj) nogil:
+cdef inline bint is_bool_object(object obj) noexcept nogil:
     """
     Cython equivalent of `isinstance(val, (bool, np.bool_))`
 
@@ -121,11 +121,11 @@ cdef inline bint is_bool_object(object obj) nogil:
             PyObject_TypeCheck(obj, &PyBoolArrType_Type))
 
 
-cdef inline bint is_real_number_object(object obj) nogil:
+cdef inline bint is_real_number_object(object obj) noexcept nogil:
     return is_bool_object(obj) or is_integer_object(obj) or is_float_object(obj)
 
 
-cdef inline bint is_timedelta64_object(object obj) nogil:
+cdef inline bint is_timedelta64_object(object obj) noexcept nogil:
     """
     Cython equivalent of `isinstance(val, np.timedelta64)`
 
@@ -140,7 +140,7 @@ cdef inline bint is_timedelta64_object(object obj) nogil:
     return PyObject_TypeCheck(obj, &PyTimedeltaArrType_Type)
 
 
-cdef inline bint is_datetime64_object(object obj) nogil:
+cdef inline bint is_datetime64_object(object obj) noexcept nogil:
     """
     Cython equivalent of `isinstance(val, np.datetime64)`
 
@@ -155,7 +155,7 @@ cdef inline bint is_datetime64_object(object obj) nogil:
     return PyObject_TypeCheck(obj, &PyDatetimeArrType_Type)
 
 
-cdef inline bint is_array(object val):
+cdef inline bint is_array(object val) noexcept:
     """
     Cython equivalent of `isinstance(val, np.ndarray)`
 
@@ -217,11 +217,11 @@ cdef inline const char* get_c_string(str py_string) except NULL:
     return get_c_string_buf_and_size(py_string, NULL)
 
 
-cdef inline bytes string_encode_locale(str py_string):
+cdef inline bytes string_encode_locale(str py_string) noexcept:
     """As opposed to PyUnicode_Encode, use current system locale to encode."""
     return PyUnicode_EncodeLocale(py_string, NULL)
 
 
-cdef inline object char_to_string_locale(const char* data):
+cdef inline object char_to_string_locale(const char* data) noexcept:
     """As opposed to PyUnicode_FromString, use current system locale to decode."""
     return PyUnicode_DecodeLocale(data, NULL)

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -89,7 +89,7 @@ cdef float64_t calc_sum(int64_t minp, int64_t nobs, float64_t sum_x,
 
 cdef void add_sum(float64_t val, int64_t *nobs, float64_t *sum_x,
                   float64_t *compensation, int64_t *num_consecutive_same_value,
-                  float64_t *prev_value) nogil:
+                  float64_t *prev_value) noexcept nogil:
     """ add a value from the sum calc using Kahan summation """
 
     cdef:


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This PR marks functions returning `void` as `noexcept` to avoid checking an exception after every function call. `inline` functions are marked too to avoid unnecessary overhead. The improvement is only in Cython 3. In Cython 0.29.X `noexcept` keyword is ignored. See https://github.com/pandas-dev/pandas/issues/53125#issuecomment-1539086575 for details.