### PR TITLE
MNT: Add support of Cython 3 master

### DIFF
--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -303,19 +303,19 @@ PandasParser_IMPORT
 # cdef extern'ed declarations seem to leave behind an undefined symbol
 cdef double xstrtod_wrapper(const char *p, char **q, char decimal,
                             char sci, char tsep, int skip_trailing,
-                            int *error, int *maybe_int) nogil:
+                            int *error, int *maybe_int) noexcept nogil:
     return xstrtod(p, q, decimal, sci, tsep, skip_trailing, error, maybe_int)
 
 
 cdef double precise_xstrtod_wrapper(const char *p, char **q, char decimal,
                                     char sci, char tsep, int skip_trailing,
-                                    int *error, int *maybe_int) nogil:
+                                    int *error, int *maybe_int) noexcept nogil:
     return precise_xstrtod(p, q, decimal, sci, tsep, skip_trailing, error, maybe_int)
 
 
 cdef double round_trip_wrapper(const char *p, char **q, char decimal,
                                char sci, char tsep, int skip_trailing,
-                               int *error, int *maybe_int) nogil:
+                               int *error, int *maybe_int) noexcept nogil:
     return round_trip(p, q, decimal, sci, tsep, skip_trailing, error, maybe_int)
 
 


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This PR adds support for Cython 3 master after PR https://github.com/cython/cython/pull/5386. This PR requires Cython >= 0.29.31 or Cython >= 3.0b3. See https://github.com/pandas-dev/pandas/issues/53125#issuecomment-1539086575 for details.
