### PR TITLE
Switch to setup-micromamba

### DIFF
--- a/.github/actions/setup-conda/action.yml
+++ b/.github/actions/setup-conda/action.yml
@@ -13,13 +13,11 @@ runs:
   using: composite
   steps:
     - name: Install ${{ inputs.environment-file }}
-      uses: mamba-org/provision-with-micromamba@v15
+      uses: mamba-org/setup-micromamba@v1
       with:
         environment-file: ${{ inputs.environment-file }}
         environment-name: ${{ inputs.environment-name }}
-        extra-specs: ${{ inputs.extra-specs }}
-        channels: conda-forge
-        channel-priority: 'strict'
+        create-args: ${{ inputs.extra-specs }}
         condarc-file: ci/condarc.yml
         cache-env: true
         cache-downloads: true

--- a/.github/actions/setup-conda/action.yml
+++ b/.github/actions/setup-conda/action.yml
@@ -3,12 +3,6 @@ inputs:
   environment-file:
     description: Conda environment file to use.
     default: environment.yml
-  environment-name:
-    description: Name to use for the Conda environment
-    default: test
-  extra-specs:
-    description: Extra packages to install
-    required: false
 runs:
   using: composite
   steps:
@@ -16,8 +10,7 @@ runs:
       uses: mamba-org/setup-micromamba@v1
       with:
         environment-file: ${{ inputs.environment-file }}
-        environment-name: ${{ inputs.environment-name }}
-        create-args: ${{ inputs.extra-specs }}
+        environment-name: test
         condarc-file: ci/condarc.yml
-        cache-env: true
+        cache-environment: true
         cache-downloads: true

--- a/.github/workflows/package-checks.yml
+++ b/.github/workflows/package-checks.yml
@@ -75,7 +75,7 @@ jobs:
             boa
             conda-verify
           cache-downloads: true
-          cache-env: true
+          cache-environment: true
 
       - name: Build conda package
         run: conda mambabuild ci --no-anaconda-upload --verify --strict-verify --output --output-folder .

--- a/.github/workflows/package-checks.yml
+++ b/.github/workflows/package-checks.yml
@@ -67,15 +67,13 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: mamba-org/provision-with-micromamba@v15
+        uses: mamba-org/setup-micromamba@v1
         with:
-          environment-file: false
           environment-name: recipe-test
-          extra-specs: |
+          extra-specs: >-
             python=${{ matrix.python-version }}
             boa
             conda-verify
-          channels: conda-forge
           cache-downloads: true
           cache-env: true
 


### PR DESCRIPTION
We are deprecating `provision-with-micromamba` and replacing it with https://github.com/mamba-org/setup-micromamba.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
