### PR TITLE
BUG: DataFrame.agg not returning a reduced result when providing a lambda

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -405,6 +405,7 @@ Plotting
 
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
+- Bug in :meth:`DataFrame.agg` when providing a dict-like or tuple-like renaming argument with a ``lambda`` function (:issue:`41768`)
 - Bug in :meth:`DataFrame.resample` and :meth:`Series.resample` in incorrectly allowing non-fixed ``freq`` when resampling on a :class:`TimedeltaIndex` (:issue:`51896`)
 - Bug in :meth:`DataFrameGroupBy.idxmin`, :meth:`SeriesGroupBy.idxmin`, :meth:`DataFrameGroupBy.idxmax`, :meth:`SeriesGroupBy.idxmax` return wrong dtype when used on empty DataFrameGroupBy or SeriesGroupBy (:issue:`51423`)
 - Bug in weighted rolling aggregations when specifying ``min_periods=0`` (:issue:`51449`)

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -44,6 +44,7 @@ from pandas.core.dtypes.cast import is_nested_object
 from pandas.core.dtypes.common import (
     is_dict_like,
     is_list_like,
+    is_scalar,
     is_sequence,
 )
 from pandas.core.dtypes.dtypes import (
@@ -1100,8 +1101,14 @@ class SeriesApply(NDFrameApply):
             # operation is actually defined on the Series, e.g. str
             try:
                 result = self.obj.apply(f)
+                # GH 41768: Attempt to return a reduced result
+                if not is_scalar(result):
+                    result = f(self.obj)
             except (ValueError, AttributeError, TypeError):
                 result = f(self.obj)
+
+            # TODO: Shouldn't we validate this returns a scalar?
+            # Would fail test_agg_listlike_result, test_agg_transform
 
         return result
 

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1515,3 +1515,24 @@ def test_agg_dist_like_and_nonunique_columns():
     result = df.agg({"A": "count"})
     expected = df["A"].count()
     tm.assert_series_equal(result, expected)
+
+
+def test_agg_lambda_tuple_result_rename():
+    # GH 41768
+    df = DataFrame(
+        [[1, 2, 3], [4, 5, 6], [7, 8, 9], [np.nan, np.nan, np.nan]],
+        columns=["A", "B", "C"],
+    )
+    result = df.agg(z=("C", lambda x: np.mean(x)))
+    expected = DataFrame([6.0], index=["z"], columns=["C"])
+    tm.assert_frame_equal(result, expected)
+
+
+def test_agg_dictlike_lambda():
+    df = DataFrame(
+        [[1, 2, 3], [4, 5, 6], [7, 8, 9], [np.nan, np.nan, np.nan]],
+        columns=["A", "B", "C"],
+    )
+    result = df.agg({"C": lambda x: np.mean(x)})
+    expected = Series([6.0], index=["C"])
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #41768 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
