### PR TITLE
DOC: add documentation to pandas.core.groupby.SeriesGroupBy.unique

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1224,14 +1224,6 @@ class SeriesGroupBy(GroupBy[Series]):
         Uniques are returned in order of appearance. Hash table-based unique,
         therefore does NOT sort.
 
-        Parameters
-        ----------
-        *docstrings : None, str, or callable
-            The string / docstring / docstring template to be appended in order
-            after default docstring under callable.
-        **params
-            The string which would be used to format docstring template.
-
         Returns
         -------
         ndarray or ExtensionArray
@@ -1248,16 +1240,15 @@ class SeriesGroupBy(GroupBy[Series]):
         Returns the unique values as a NumPy array. In case of an
         extension-array backed Series, a new ExtensionArray of that type with
         just the unique values is returned. This includes
-        ```
-        Categorical
-        Period
-        Datetime with Timezone
-        Datetime without Timezone
-        Timedelta
-        Interval
-        Sparse
-        IntegerNA
-        ```
+
+        - Categorical
+        - Period
+        - Datetime with Timezone
+        - Datetime without Timezone
+        - Timedelta
+        - Interval
+        - Sparse
+        - IntegerNA
 
         See Examples section.
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1221,62 +1221,40 @@ class SeriesGroupBy(GroupBy[Series]):
         """
         Return unique values of Series object.
 
-        Uniques are returned in order of appearance. Hash table-based unique,
+        TODO Uniques are returned in order of appearance. Hash table-based unique,
         therefore does NOT sort.
 
         Returns
         -------
-        ndarray or ExtensionArray
-            The unique values returned as a NumPy array. See Notes.
+        Series
+            TODO The unique values returned as a NumPy array. See Notes.
 
         See Also
         --------
-        Series.drop_duplicates : Return Series with duplicate values removed.
-        unique : Top-level unique method for any 1-d array-like object.
-        Index.unique : Return Index with unique values from an Index object.
-
-        Notes
-        -----
-        Returns the unique values as a NumPy array. In case of an
-        extension-array backed Series, a new ExtensionArray of that type with
-        just the unique values is returned. This includes
-
-        - Categorical
-        - Period
-        - Datetime with Timezone
-        - Datetime without Timezone
-        - Timedelta
-        - Interval
-        - Sparse
-        - IntegerNA
-
-        See Examples section.
+        Series.unique : TODO Return Series with duplicate values removed.
 
         Examples
         --------
-        >>> pd.Series([2, 1, 3, 3], name='A').unique()
-        array([2, 1, 3])
-
-        >>> pd.Series([pd.Timestamp('2016-01-01') for _ in range(3)]).unique()
-        <DatetimeArray>
-        ['2016-01-01 00:00:00']
-        Length: 1, dtype: datetime64[ns]
-
-        >>> pd.Series([pd.Timestamp('2016-01-01', tz='US/Eastern')
-        ...            for _ in range(3)]).unique()
-        <DatetimeArray>
-        ['2016-01-01 00:00:00-05:00']
-        Length: 1, dtype: datetime64[ns, US/Eastern]
-
-        An Categorical will return categories in the order of appearance and with the same dtype.
-
-        >>> pd.Series(pd.Categorical(list('baabc'))).unique()
-        ['b', 'a', 'c']
-        Categories (3, object): ['a', 'b', 'c']
-        >>> pd.Series(pd.Categorical(list('baabc'), categories=list('abc'),
-        ...                          ordered=True)).unique()
-        ['b', 'a', 'c']
-        Categories (3, object): ['a' < 'b' < 'c']
+        >>> df = pd.DataFrame([('Chihuahua', 'dog', 6.1),
+        ...                    ('Beagle', 'dog', 15.2),
+        ...                    ('Chihuahua', 'dog', 6.9),
+        ...                    ('Persian', 'cat', 9.2),
+        ...                    ('Chihuahua', 'dog', 7),
+        ...                    ('Persian', 'cat', 8.8)],
+        ...                   columns=['breed', 'animal', 'height_in'])
+        >>> df
+               breed     animal   height_in
+        0  Chihuahua        dog         6.1
+        1     Beagle        dog        15.2
+        2  Chihuahua        dog         6.9
+        3    Persian        cat         9.2
+        4  Chihuahua        dog         7.0
+        5    Persian        cat         8.8
+        >>> ser = df.groupby('animal')['breed'].unique()
+        animal
+        cat              [Persian]
+        dog    [Chihuahua, Beagle]
+        Name: breed, dtype: object
         """
         result = self._op_via_apply("unique")
         return result

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1251,6 +1251,7 @@ class SeriesGroupBy(GroupBy[Series]):
         4  Chihuahua        dog         7.0
         5    Persian        cat         8.8
         >>> ser = df.groupby('animal')['breed'].unique()
+        >>> ser
         animal
         cat              [Persian]
         dog    [Chihuahua, Beagle]

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1219,19 +1219,19 @@ class SeriesGroupBy(GroupBy[Series]):
 
     def unique(self) -> Series:
         """
-        Return unique values of Series object.
+        Return unique values of GroupedBy Series object.
 
-        TODO Uniques are returned in order of appearance. Hash table-based unique,
-        therefore does NOT sort.
+        It returns unique values for each of the GroupedBy values. Returned in
+        order of appearance. Hash table-based unique, therefore does NOT sort.
 
         Returns
         -------
         Series
-            TODO The unique values returned as a NumPy array. See Notes.
+            Unique values for each of the GroupedBy values.
 
         See Also
         --------
-        Series.unique : TODO Return Series with duplicate values removed.
+        Series.unique : Return unique values of Series object.
 
         Examples
         --------

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1217,8 +1217,76 @@ class SeriesGroupBy(GroupBy[Series]):
     def dtype(self) -> Series:
         return self.apply(lambda ser: ser.dtype)
 
-    @doc(Series.unique.__doc__)
     def unique(self) -> Series:
+        """
+        Return unique values of Series object.
+
+        Uniques are returned in order of appearance. Hash table-based unique,
+        therefore does NOT sort.
+
+        Parameters
+        ----------
+        *docstrings : None, str, or callable
+            The string / docstring / docstring template to be appended in order
+            after default docstring under callable.
+        **params
+            The string which would be used to format docstring template.
+
+        Returns
+        -------
+        ndarray or ExtensionArray
+            The unique values returned as a NumPy array. See Notes.
+
+        See Also
+        --------
+        Series.drop_duplicates : Return Series with duplicate values removed.
+        unique : Top-level unique method for any 1-d array-like object.
+        Index.unique : Return Index with unique values from an Index object.
+
+        Notes
+        -----
+        Returns the unique values as a NumPy array. In case of an
+        extension-array backed Series, a new ExtensionArray of that type with
+        just the unique values is returned. This includes
+        ```
+        Categorical
+        Period
+        Datetime with Timezone
+        Datetime without Timezone
+        Timedelta
+        Interval
+        Sparse
+        IntegerNA
+        ```
+
+        See Examples section.
+
+        Examples
+        --------
+        >>> pd.Series([2, 1, 3, 3], name='A').unique()
+        array([2, 1, 3])
+
+        >>> pd.Series([pd.Timestamp('2016-01-01') for _ in range(3)]).unique()
+        <DatetimeArray>
+        ['2016-01-01 00:00:00']
+        Length: 1, dtype: datetime64[ns]
+
+        >>> pd.Series([pd.Timestamp('2016-01-01', tz='US/Eastern')
+        ...            for _ in range(3)]).unique()
+        <DatetimeArray>
+        ['2016-01-01 00:00:00-05:00']
+        Length: 1, dtype: datetime64[ns, US/Eastern]
+
+        An Categorical will return categories in the order of appearance and with the same dtype.
+
+        >>> pd.Series(pd.Categorical(list('baabc'))).unique()
+        ['b', 'a', 'c']
+        Categories (3, object): ['a', 'b', 'c']
+        >>> pd.Series(pd.Categorical(list('baabc'), categories=list('abc'),
+        ...                          ordered=True)).unique()
+        ['b', 'a', 'c']
+        Categories (3, object): ['a' < 'b' < 'c']
+        """
         result = self._op_via_apply("unique")
         return result
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1219,15 +1219,15 @@ class SeriesGroupBy(GroupBy[Series]):
 
     def unique(self) -> Series:
         """
-        Return unique values of GroupedBy Series object.
+        Return unique values for each group.
 
-        It returns unique values for each of the GroupedBy values. Returned in
+        It returns unique values for each of the grouped values. Returned in
         order of appearance. Hash table-based unique, therefore does NOT sort.
 
         Returns
         -------
         Series
-            Unique values for each of the GroupedBy values.
+            Unique values for each of the grouped values.
 
         See Also
         --------


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

towards https://github.com/noatamir/pyladies-berlin-sprints/issues/13
makes the docstring for `pandas.core.groupby.SeriesGroupBy.unique`

cc: @jorisvandenbossche @marenwestermann 

docs used: [here](https://pandas.pydata.org/docs/dev/reference/api/pandas.core.groupby.SeriesGroupBy.unique.html)