### PR TITLE
Use ccache

### DIFF
--- a/.github/actions/build_pandas/action.yml
+++ b/.github/actions/build_pandas/action.yml
@@ -26,4 +26,4 @@ runs:
         fi
       shell: bash -el {0}
       env:
-        SCCACHE_GHA_ENABLED: true
+        SCCACHE_GHA_ENABLED: "true"

--- a/.github/actions/build_pandas/action.yml
+++ b/.github/actions/build_pandas/action.yml
@@ -14,24 +14,8 @@ runs:
         micromamba list
       shell: bash -el {0}
 
-    - name: Make ccache-action key
-      id: ccache-action-key
-      run: |
-        key="${{ runner.os }}--${{ runner.arch }}--${{ github.workflow }}"
-        # Date: Daily invalidation of all ccaches as an extra safety measure.
-        key="$key--$(/bin/date -u '+%Y%m%d')"
-        # Python version: Separate caches for each Python version. This reduces the number of cache misses.
-        key="$key--$(python -V)"
-        # Cache version: Bump this number to manually invalidate the cache.
-        key="$key--0"
-
-        echo "key=$key" >> $GITHUB_OUTPUT
-      shell: bash
     - name: Use sccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        variant: sccache
-        key: ${{ steps.ccache-action-key.outputs.key }}
+      uses: https://github.com/Mozilla-Actions/sccache-action
 
     - name: Build Pandas
       run: |
@@ -41,3 +25,5 @@ runs:
           pip install . --no-build-isolation -v
         fi
       shell: bash -el {0}
+      env:
+        SCCACHE_GHA_ENABLED: true

--- a/.github/actions/build_pandas/action.yml
+++ b/.github/actions/build_pandas/action.yml
@@ -15,7 +15,7 @@ runs:
       shell: bash -el {0}
 
     - name: Use sccache
-      uses: https://github.com/Mozilla-Actions/sccache-action
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: Build Pandas
       run: |

--- a/.github/actions/build_pandas/action.yml
+++ b/.github/actions/build_pandas/action.yml
@@ -14,6 +14,25 @@ runs:
         micromamba list
       shell: bash -el {0}
 
+    - name: Make ccache-action key
+      id: ccache-action-key
+      run: |
+        key="${{ runner.os }}--${{ runner.arch }}--${{ github.workflow }}"
+        # Date: Daily invalidation of all ccaches as an extra safety measure.
+        key="$key--$(/bin/date -u '+%Y%m%d')"
+        # Python version: Separate caches for each Python version. This reduces the number of cache misses.
+        key="$key--$(python -V)"
+        # Cache version: Bump this number to manually invalidate the cache.
+        key="$key--0"
+
+        echo "key=$key" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Use sccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        variant: sccache
+        key: ${{ steps.ccache-action-key.outputs.key }}
+
     - name: Build Pandas
       run: |
         if [[ ${{ inputs.editable }} == "true" ]]; then


### PR DESCRIPTION
Supersedes #47360

Meson autodetects and autouses ccache so this PR turns out to be very simple.

Shaves off ~ 5 min

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
