### PR TITLE
FIX typo in deprecation message of `deprecate_kwarg` decorator

### DIFF
--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -195,7 +195,7 @@ def deprecate_kwarg(
                 else:
                     new_arg_value = old_arg_value
                     msg = (
-                        f"the {repr(old_arg_name)}' keyword is deprecated, "
+                        f"the {repr(old_arg_name)} keyword is deprecated, "
                         f"use {repr(new_arg_name)} instead."
                     )
 


### PR DESCRIPTION
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v2.1.0.rst`

Previously, the error message looks has an additional quotation mark, which I assume is a **typo**:
```
FutureWarning: the 'quantile'' keyword is deprecated, use 'q' instead.
```
Now it looks like this:
```
FutureWarning: the 'quantile' keyword is deprecated, use 'q' instead.
```

Btw, does this fix need a changelog?