### PR TITLE
BUG: preserve dtype for right/outer merge of datetime with different resolutions

### DIFF
--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -994,6 +994,14 @@ class _MergeOperation:
                 else:
                     key_col = Index(lvals).where(~mask_left, rvals)
                     result_dtype = find_common_type([lvals.dtype, rvals.dtype])
+                    if (
+                        lvals.dtype.kind == "M"
+                        and rvals.dtype.kind == "M"
+                        and result_dtype.kind == "O"
+                    ):
+                        # TODO(non-nano) Workaround for common_type not dealing
+                        # with different resolutions
+                        result_dtype = key_col.dtype
 
                 if result._is_label_reference(name):
                     result[name] = result._constructor_sliced(


### PR DESCRIPTION
Follow-up on https://github.com/pandas-dev/pandas/pull/53213, fixing one more corner case for the right/outer joins making the key column object dtype.

Expanded the test added in that PR to test the different join types. 
The whatsnew added in https://github.com/pandas-dev/pandas/pull/53213 should also already cover this.