### PR TITLE
CI: Remove 32 bit testing

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -205,41 +205,6 @@ jobs:
       - name: Test
         uses: ./.github/actions/run-tests
 
-  Linux-32-bit:
-    runs-on: ubuntu-22.04
-    container:
-      image: quay.io/pypa/manylinux2014_i686
-      options: --platform linux/386
-    steps:
-      - name: Checkout pandas Repo
-        # actions/checkout does not work since it requires node
-        run: |
-          git config --global --add safe.directory $PWD
-
-          if [ $GITHUB_EVENT_NAME != pull_request ]; then
-              git clone --recursive --branch=$GITHUB_REF_NAME https://github.com/${GITHUB_REPOSITORY}.git $GITHUB_WORKSPACE
-              git reset --hard $GITHUB_SHA
-          else
-              git clone --recursive https://github.com/${GITHUB_REPOSITORY}.git $GITHUB_WORKSPACE
-              git fetch origin $GITHUB_REF:my_ref_name
-              git checkout $GITHUB_BASE_REF
-              git -c user.email="you@example.com" merge --no-commit my_ref_name
-          fi
-      - name: Build environment and Run Tests
-        run: |
-          /opt/python/cp39-cp39/bin/python -m venv ~/virtualenvs/pandas-dev
-          . ~/virtualenvs/pandas-dev/bin/activate
-          python -m pip install -U pip wheel setuptools meson[ninja]==1.0.1 meson-python==0.13.1
-          python -m pip install --no-cache-dir versioneer[toml] cython numpy python-dateutil pytz pytest>=7.0.0 pytest-xdist>=2.2.0 pytest-asyncio>=0.17 hypothesis>=6.46.1
-          python -m pip install --no-cache-dir --no-build-isolation -e .
-          python -m pip list --no-cache-dir
-          export PANDAS_CI=1
-          python -m pytest -m 'not slow and not network and not clipboard and not single_cpu' pandas --junitxml=test-data.xml
-    concurrency:
-      # https://github.community/t/concurrecy-not-work-for-push/183068/7
-      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-32bit
-      cancel-in-progress: true
-
   Linux-Musl:
     runs-on: ubuntu-22.04
     container:


### PR DESCRIPTION
- [ ] closes #28842 (Replace xxxx with the GitHub issue number)
- [ ] closes #44453 (Replace xxxx with the GitHub issue number)
- [ ] closes #46360 (Replace xxxx with the GitHub issue number)

With the meson build PR, we dropped windows 32 bit wheels. Additionally, other pydata libraries are also starting to remove 32 bit wheel support https://discuss.python.org/t/dropping-32-bit-packages/5476/9. Since we don't ship these wheels anymore, I am not sure if we should continue to test this specifically. 

