### PR TITLE
DEPS: Unpin openpyxl in CI

### DIFF
--- a/ci/deps/actions-310.yaml
+++ b/ci/deps/actions-310.yaml
@@ -39,7 +39,7 @@ dependencies:
   - numexpr>=2.8.0
   - odfpy>=1.4.1
   - qtpy>=2.2.0
-  - openpyxl<3.1.1, >=3.0.10
+  - openpyxl>=3.0.10
   - pandas-gbq>=0.17.5
   - psycopg2>=2.9.3
   - pyarrow>=7.0.0

--- a/ci/deps/actions-311.yaml
+++ b/ci/deps/actions-311.yaml
@@ -39,7 +39,7 @@ dependencies:
   - numexpr>=2.8.0
   - odfpy>=1.4.1
   - qtpy>=2.2.0
-  - openpyxl<3.1.1, >=3.0.10
+  - openpyxl>=3.0.10
   - pandas-gbq>=0.17.5
   - psycopg2>=2.9.3
   - pyarrow>=7.0.0

--- a/ci/deps/actions-39-downstream_compat.yaml
+++ b/ci/deps/actions-39-downstream_compat.yaml
@@ -40,7 +40,7 @@ dependencies:
   - numexpr>=2.8.0
   - odfpy>=1.4.1
   - qtpy>=2.2.0
-  - openpyxl<3.1.1, >=3.0.10
+  - openpyxl>=3.0.10
   - pandas-gbq>=0.17.5
   - psycopg2>=2.9.3
   - pyarrow>=7.0.0

--- a/ci/deps/actions-39.yaml
+++ b/ci/deps/actions-39.yaml
@@ -39,7 +39,7 @@ dependencies:
   - numexpr>=2.8.0
   - odfpy>=1.4.1
   - qtpy>=2.2.0
-  - openpyxl<3.1.1, >=3.0.10
+  - openpyxl>=3.0.10
   - pandas-gbq>=0.17.5
   - psycopg2>=2.9.3
   - pyarrow>=7.0.0

--- a/ci/deps/circle-39-arm64.yaml
+++ b/ci/deps/circle-39-arm64.yaml
@@ -39,7 +39,7 @@ dependencies:
   - numexpr>=2.8.0
   - odfpy>=1.4.1
   - qtpy>=2.2.0
-  - openpyxl<3.1.1, >=3.0.10
+  - openpyxl>=3.0.10
   - pandas-gbq>=0.17.5
   - psycopg2>=2.9.3
   - pyarrow>=7.0.0


### PR DESCRIPTION
- [ ] closes #51392 (Replace xxxx with the GitHub issue number)

Fixed in 3.1.2 and looks to have packages on conda forge


