### PR TITLE
BUG: Missing date formatting parameters

### DIFF
--- a/pandas/io/excel/_openpyxl.py
+++ b/pandas/io/excel/_openpyxl.py
@@ -60,6 +60,8 @@ class OpenpyxlWriter(ExcelWriter):
 
         super().__init__(
             path,
+            date_format=date_format,
+            datetime_format=datetime_format,
             mode=mode,
             storage_options=storage_options,
             if_sheet_exists=if_sheet_exists,


### PR DESCRIPTION
Missing parameters from __init__() in super().init() causes excelwriter using openpyxl as engine to ignore date formatting.