### PR TITLE
BUG: allow DataFrame[mask]=value with mixed non-numeric dtypes

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -264,6 +264,7 @@ Deprecations
 - Deprecated allowing ``downcast`` keyword other than ``None``, ``False``, "infer", or a dict with these as values in :meth:`Series.fillna`, :meth:`DataFrame.fillna` (:issue:`40988`)
 - Deprecated allowing arbitrary ``fill_value`` in :class:`SparseDtype`, in a future version the ``fill_value`` will need to be compatible with the ``dtype.subtype``, either a scalar that can be held by that subtype or ``NaN`` for integer or bool subtypes (:issue:`23124`)
 - Deprecated constructing :class:`SparseArray` from scalar data, pass a sequence instead (:issue:`53039`)
+- Deprecated behavior of :meth:`DataFrame.__setitem__` with a boolean mask and :meth:`DataFrame.putmask` with mixed non-numeric dtypes and a value other than ``NaN``, in a future version this will be allowed instead of raising ``TypeError`` (:issue:`??`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -264,7 +264,6 @@ Deprecations
 - Deprecated allowing ``downcast`` keyword other than ``None``, ``False``, "infer", or a dict with these as values in :meth:`Series.fillna`, :meth:`DataFrame.fillna` (:issue:`40988`)
 - Deprecated allowing arbitrary ``fill_value`` in :class:`SparseDtype`, in a future version the ``fill_value`` will need to be compatible with the ``dtype.subtype``, either a scalar that can be held by that subtype or ``NaN`` for integer or bool subtypes (:issue:`23124`)
 - Deprecated constructing :class:`SparseArray` from scalar data, pass a sequence instead (:issue:`53039`)
-- Deprecated behavior of :meth:`DataFrame.__setitem__` with a boolean mask and :meth:`DataFrame.putmask` with mixed non-numeric dtypes and a value other than ``NaN``, in a future version this will be allowed instead of raising ``TypeError`` (:issue:`??`)
 -
 
 .. ---------------------------------------------------------------------------
@@ -371,6 +370,7 @@ Interval
 Indexing
 ^^^^^^^^
 - Bug in :meth:`DataFrame.__setitem__` losing dtype when setting a :class:`DataFrame` into duplicated columns (:issue:`53143`)
+- Bug in :meth:`DataFrame.__setitem__` with a boolean mask and :meth:`DataFrame.putmask` with mixed non-numeric dtypes and a value other than ``NaN`` incorrectly raising ``TypeError`` (:issue:`53291`)
 -
 
 Missing

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4074,7 +4074,6 @@ class DataFrame(NDFrame, OpsMixin):
                 "Must pass DataFrame or 2-d ndarray with boolean values only"
             )
 
-        self._check_inplace_setting(value)
         self._check_setitem_copy()
         self._where(-key, value, inplace=True)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -114,7 +114,6 @@ from pandas.core.dtypes.common import (
     is_bool_dtype,
     is_dict_like,
     is_extension_array_dtype,
-    is_float,
     is_list_like,
     is_number,
     is_numeric_dtype,
@@ -6202,34 +6201,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         return self.dtypes.nunique() > 1
 
     @final
-    def _check_inplace_setting(self, value) -> bool_t:
-        """check whether we allow in-place setting with this type of value"""
-        if self._is_mixed_type and not self._mgr.is_numeric_mixed_type:
-            # allow an actual np.nan through
-            if (is_float(value) and np.isnan(value)) or value is lib.no_default:
-                return True
-
-            # Deprecate raising introduced in GH#7657, as the original
-            #  inconsistency no longer appears to exist.
-            # TODO(3.0): once this is enforced, is_numeric_mixed_type can
-            #  be removed.
-            warnings.warn(
-                "DataFrame.__setitem__ with a boolean mask and "
-                "DataFrame.putmask with mixed non-numeric "
-                "dtypes and a value other than NaN behavior is deprecated. In a "
-                "future version this will be allowed.",
-                FutureWarning,
-                stacklevel=find_stack_level(),
-            )
-
-            raise TypeError(
-                "Cannot do inplace boolean setting on "
-                "mixed-types with a non np.nan value"
-            )
-
-        return True
-
-    @final
     def _get_numeric_data(self) -> Self:
         return self._constructor(self._mgr.get_numeric_data()).__finalize__(self)
 
@@ -10049,7 +10020,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             # we may have different type blocks come out of putmask, so
             # reconstruct the block manager
 
-            self._check_inplace_setting(other)
             new_data = self._mgr.putmask(mask=cond, new=other, align=align)
             result = self._constructor(new_data)
             return self._update_inplace(result)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6209,6 +6209,19 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             if (is_float(value) and np.isnan(value)) or value is lib.no_default:
                 return True
 
+            # Deprecate raising introduced in GH#7657, as the original
+            #  inconsistency no longer appears to exist.
+            # TODO(3.0): once this is enforced, is_numeric_mixed_type can
+            #  be removed.
+            warnings.warn(
+                "DataFrame.__setitem__ with a boolean mask and "
+                "DataFrame.putmask with mixed non-numeric "
+                "dtypes and a value other than NaN behavior is deprecated. In a "
+                "future version this will be allowed.",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
+
             raise TypeError(
                 "Cannot do inplace boolean setting on "
                 "mixed-types with a non np.nan value"

--- a/pandas/core/internals/array_manager.py
+++ b/pandas/core/internals/array_manager.py
@@ -444,10 +444,6 @@ class BaseArrayManager(DataManager):
         return True
 
     @property
-    def is_numeric_mixed_type(self) -> bool:
-        return all(is_numeric_dtype(t) for t in self.get_dtypes())
-
-    @property
     def any_extension_types(self) -> bool:
         """Whether any of the blocks in this manager are extension blocks"""
         return False  # any(block.is_extension for block in self.blocks)

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -515,10 +515,6 @@ class BaseBlockManager(DataManager):
         return self.apply("to_native_types", **kwargs)
 
     @property
-    def is_numeric_mixed_type(self) -> bool:
-        return all(block.is_numeric for block in self.blocks)
-
-    @property
     def any_extension_types(self) -> bool:
         """Whether any of the blocks in this manager are extension blocks"""
         return any(block.is_extension for block in self.blocks)

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -401,28 +401,23 @@ class TestDataFrameIndexingWhere:
                 {"A": np.nan, "B": "Test", "C": np.nan},
             ]
         )
-        warn_msg = (
-            "DataFrame.__setitem__ with a boolean mask and "
-            "DataFrame.putmask with mixed non-numeric"
-        )
-        msg = "boolean setting on mixed-type"
+
+        orig = df.copy()
 
         mask = ~isna(df)
-        with pytest.raises(TypeError, match=msg):
-            with tm.assert_produces_warning(FutureWarning, match=warn_msg):
-                df.where(mask, None, inplace=True)
+        df.where(mask, None, inplace=True)
+        expected = DataFrame(
+            {
+                "A": [1.0, np.nan],
+                "B": [None, "Test"],
+                "C": ["Test", None],
+            }
+        )
+        tm.assert_frame_equal(df, expected)
 
-        with pytest.raises(TypeError, match=msg):
-            with tm.assert_produces_warning(FutureWarning, match=warn_msg):
-                df.where(mask, 3, inplace=True)
-
-        with pytest.raises(TypeError, match=msg):
-            with tm.assert_produces_warning(FutureWarning, match=warn_msg):
-                df[mask] = None
-
-        with pytest.raises(TypeError, match=msg):
-            with tm.assert_produces_warning(FutureWarning, match=warn_msg):
-                df[mask] = 3
+        df = orig.copy()
+        df[~mask] = None
+        tm.assert_frame_equal(df, expected)
 
     def test_where_empty_df_and_empty_cond_having_non_bool_dtypes(self):
         # see gh-21947

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -401,10 +401,28 @@ class TestDataFrameIndexingWhere:
                 {"A": np.nan, "B": "Test", "C": np.nan},
             ]
         )
+        warn_msg = (
+            "DataFrame.__setitem__ with a boolean mask and "
+            "DataFrame.putmask with mixed non-numeric"
+        )
         msg = "boolean setting on mixed-type"
 
+        mask = ~isna(df)
         with pytest.raises(TypeError, match=msg):
-            df.where(~isna(df), None, inplace=True)
+            with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+                df.where(mask, None, inplace=True)
+
+        with pytest.raises(TypeError, match=msg):
+            with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+                df.where(mask, 3, inplace=True)
+
+        with pytest.raises(TypeError, match=msg):
+            with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+                df[mask] = None
+
+        with pytest.raises(TypeError, match=msg):
+            with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+                df[mask] = 3
 
     def test_where_empty_df_and_empty_cond_having_non_bool_dtypes(self):
         # see gh-21947


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Looks like this check was implemented to avoid some inconsistency, but I can no longer find what that inconsistency was.