### PR TITLE
BUG `date_range` with end, periods, and freq failing

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -315,6 +315,7 @@ Datetimelike
 ^^^^^^^^^^^^
 - :meth:`DatetimeIndex.map` with ``na_action="ignore"`` now works as expected. (:issue:`51644`)
 - Bug in :func:`date_range` when ``freq`` was a :class:`DateOffset` with ``nanoseconds`` (:issue:`46877`)
+- Bug in :func:`date_range` when using ``periods``, ``freq``, and one of ``start`` or ``end`` (:issue:`53293`)
 - Bug in :meth:`Timestamp.round` with values close to the implementation bounds returning incorrect results instead of raising ``OutOfBoundsDatetime`` (:issue:`51494`)
 - Bug in :meth:`arrays.DatetimeArray.map` and :meth:`DatetimeIndex.map`, where the supplied callable operated array-wise instead of element-wise (:issue:`51977`)
 - Bug in constructing a :class:`Series` or :class:`DataFrame` from a datetime or timedelta scalar always inferring nanosecond resolution instead of inferring from the input (:issue:`52212`)

--- a/pandas/core/arrays/_ranges.py
+++ b/pandas/core/arrays/_ranges.py
@@ -74,10 +74,10 @@ def generate_regular_range(
         e = b + (iend - b) // stride * stride + stride // 2 + 1
     elif istart is not None and periods is not None:
         b = istart
-        e = _generate_range_overflow_safe(b, periods, stride, side="start")
+        e = int(_generate_range_overflow_safe(b, periods, stride, side="start"))
     elif iend is not None and periods is not None:
         e = iend + stride
-        b = _generate_range_overflow_safe(e, periods, stride, side="end")
+        b = int(_generate_range_overflow_safe(e, periods, stride, side="end"))
     else:
         raise ValueError(
             "at least 'start' or 'end' should be specified if a 'period' is given."


### PR DESCRIPTION
- [x] Closes #53293
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests)
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit)
- [x] Added an entry in the latest `doc/source/whatsnew/v2.1.0.rst`

I think this does not need a changelog entry (though I have added one for now), since this bug seems to be introduced just two weeks ago and does not exist in any prior versions of pandas. Please let me know if I should remove the changelog entry.
