### PR TITLE
DOC: simplify pandas footer

### DIFF
--- a/doc/_templates/pandas_footer.html
+++ b/doc/_templates/pandas_footer.html
@@ -1,3 +1,1 @@
-<p class="copyright">
-    &copy {{footer}} 
-</p>
+{{footer}}

--- a/doc/_templates/pandas_footer.html
+++ b/doc/_templates/pandas_footer.html
@@ -1,3 +1,3 @@
 <p class="copyright">
-    &copy {{copyright}} pandas via <a href="https://numfocus.org">NumFOCUS, Inc.</a> Hosted by <a href="https://www.ovhcloud.com">OVHcloud</a>.
+    &copy {{footer}} 
 </p>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -375,11 +375,15 @@ header = f"""\
    import os
    os.chdir(r'{os.path.dirname(os.path.dirname(__file__))}')
 """
+footer = f"""{datetime.now().year}
+pandas via <a href="https://numfocus.org">NumFOCUS, Inc.
+</a> Hosted by <a href="https://www.ovhcloud.com">OVHcloud</a>."""
 
 
 html_context = {
     "redirects": dict(moved_api_pages),
     "header": header,
+    "footer": footer
 }
 
 # If false, no module index is generated.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -375,9 +375,10 @@ header = f"""\
    import os
    os.chdir(r'{os.path.dirname(os.path.dirname(__file__))}')
 """
-footer = f"""{datetime.now().year}
-pandas via <a href="https://numfocus.org">NumFOCUS, Inc.
-</a> Hosted by <a href="https://www.ovhcloud.com">OVHcloud</a>."""
+footer = f"""<p class="copyright">
+    &copy{datetime.now().year}
+    pandas via <a href="https://numfocus.org">NumFOCUS, Inc.</a>
+    Hosted by <a href="https://www.ovhcloud.com">OVHcloud</a>.</p>"""
 
 
 html_context = {


### PR DESCRIPTION
## Description

This pull request addresses issue #51536 by proposing a solution to simplify the pandas theme footer.

The sphinx theme currently requires an extra template to specify the footer content, which limits customization options. 
For the moment there seems to be no way to get rid of the template and set everything in the config file,
However, after research and explorationI have found a potential workaround that allows us to define the footer content directly in the `conf.py` configuration file using the `html_context` setting.


## Proposed Changes

- Updated `conf.py` to define the footer content using the `html_context` setting.
- Modified the `pandas_footer.html` template to render the footer content defined in `conf.py`.

Your feedback and suggestions on this approach are highly appreciated.