### PR TITLE
DEPS: Test numba on PY 3.11

### DIFF
--- a/ci/deps/actions-311.yaml
+++ b/ci/deps/actions-311.yaml
@@ -35,7 +35,7 @@ dependencies:
   - jinja2>=3.1.2
   - lxml>=4.8.0
   - matplotlib>=3.6.1
-  # - numba>=0.55.2 not compatible with 3.11
+  - numba>=0.55.2
   - numexpr>=2.8.0
   - odfpy>=1.4.1
   - qtpy>=2.2.0


### PR DESCRIPTION
Appears numba 0.57 which supports Python 3.11 IIRC is now available so it should be safe to enable testing: https://anaconda.org/conda-forge/numba