### PR TITLE
Update contributing_docstring.rst

### DIFF
--- a/doc/source/development/contributing_docstring.rst
+++ b/doc/source/development/contributing_docstring.rst
@@ -652,9 +652,9 @@ A simple example could be:
 
             Examples
             --------
-            >>> s = pd.Series(['Ant', 'Bear', 'Cow', 'Dog', 'Falcon',
+            >>> ser = pd.Series(['Ant', 'Bear', 'Cow', 'Dog', 'Falcon',
             ...                'Lion', 'Monkey', 'Rabbit', 'Zebra'])
-            >>> s.head()
+            >>> ser.head()
             0   Ant
             1   Bear
             2   Cow
@@ -664,7 +664,7 @@ A simple example could be:
 
             With the ``n`` parameter, we can change the number of returned rows:
 
-            >>> s.head(n=3)
+            >>> ser.head(n=3)
             0   Ant
             1   Bear
             2   Cow
@@ -695,10 +695,10 @@ and avoiding aliases. Avoid excessive imports, but if needed, imports from
 the standard library go first, followed by third-party libraries (like
 matplotlib).
 
-When illustrating examples with a single ``Series`` use the name ``s``, and if
+When illustrating examples with a single ``Series`` use the name ``Ser``, and if
 illustrating with a single ``DataFrame`` use the name ``df``. For indices,
 ``idx`` is the preferred name. If a set of homogeneous ``Series`` or
-``DataFrame`` is used, name them ``s1``, ``s2``, ``s3``...  or ``df1``,
+``DataFrame`` is used, name them ``ser1``, ``ser2``, ``ser3``...  or ``df1``,
 ``df2``, ``df3``... If the data is not homogeneous, and more than one structure
 is needed, name them with something meaningful, for example ``df_main`` and
 ``df_to_join``.
@@ -731,8 +731,8 @@ positional arguments ``head(3)``.
 
             Examples
             --------
-            >>> s = pd.Series([1, 2, 3])
-            >>> s.mean()
+            >>> ser = pd.Series([1, 2, 3])
+            >>> ser.mean()
             2
             """
             pass
@@ -744,8 +744,8 @@ positional arguments ``head(3)``.
 
             Examples
             --------
-            >>> s = pd.Series([1, np.nan, 3])
-            >>> s.fillna(0)
+            >>> ser = pd.Series([1, np.nan, 3])
+            >>> ser.fillna(0)
             [1, 0, 3]
             """
             pass
@@ -756,10 +756,10 @@ positional arguments ``head(3)``.
 
             Examples
             --------
-            >>> s = pd.Series([380., 370., 24., 26],
+            >>> ser = pd.Series([380., 370., 24., 26],
             ...               name='max_speed',
             ...               index=['falcon', 'falcon', 'parrot', 'parrot'])
-            >>> s.groupby_mean()
+            >>> ser.groupby_mean()
             index
             falcon    375.0
             parrot     25.0
@@ -776,8 +776,8 @@ positional arguments ``head(3)``.
 
             Examples
             --------
-            >>> s = pd.Series('Antelope', 'Lion', 'Zebra', np.nan)
-            >>> s.contains(pattern='a')
+            >>> ser = pd.Series('Antelope', 'Lion', 'Zebra', np.nan)
+            >>> ser.contains(pattern='a')
             0    False
             1    False
             2     True
@@ -789,7 +789,7 @@ positional arguments ``head(3)``.
             With ``case_sensitive`` set to ``False`` we can match ``a`` with both
             ``a`` and ``A``:
 
-            >>> s.contains(pattern='a', case_sensitive=False)
+            >>> ser.contains(pattern='a', case_sensitive=False)
             0     True
             1    False
             2     True
@@ -800,7 +800,7 @@ positional arguments ``head(3)``.
 
             We can fill missing values in the output using the ``na`` parameter:
 
-            >>> s.contains(pattern='a', na=False)
+            >>> ser.contains(pattern='a', na=False)
             0    False
             1    False
             2     True
@@ -884,15 +884,15 @@ be tricky. Here are some attention points:
 * If there is a small part of the result that can vary (e.g. a hash in an object
   representation), you can use ``...`` to represent this part.
 
-  If you want to show that ``s.plot()`` returns a matplotlib AxesSubplot object,
+  If you want to show that ``ser.plot()`` returns a matplotlib AxesSubplot object,
   this will fail the doctest ::
 
-    >>> s.plot()
+    >>> ser.plot()
     <matplotlib.axes._subplots.AxesSubplot at 0x7efd0c0b0690>
 
   However, you can do (notice the comment that needs to be added) ::
 
-    >>> s.plot()  # doctest: +ELLIPSIS
+    >>> ser.plot()  # doctest: +ELLIPSIS
     <matplotlib.axes._subplots.AxesSubplot at ...>
 
 
@@ -920,8 +920,8 @@ plot will be generated automatically when building the documentation.
             .. plot::
                 :context: close-figs
 
-                >>> s = pd.Series([1, 2, 3])
-                >>> s.plot()
+                >>> ser = pd.Series([1, 2, 3])
+                >>> ser.plot()
             """
             pass
 


### PR DESCRIPTION
Change "Convention for examples" to use Series name as 'ser' instead of 's'.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
