### PR TITLE
DOCS: improving "to_excel" function description. Explained more about engines

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2196,7 +2196,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         startcol : int, default 0
             Upper left cell column to dump data frame.
         engine : str, optional
-            Write engine to use, 'openpyxl' or 'xlsxwriter'. First install them (via pip). If only one is installed, Pandas defaults to that one. If both are installed, default is 'xlsxwriter' (faster and makes a smaller file).
+            Write engine to use, 'openpyxl' or 'xlsxwriter'. 
+            If both are installed, default is 'xlsxwriter' (usually faster and makes a smaller file).
+            Otherwise use 'openpyxl'.
+            
         merge_cells : bool, default True
             Write MultiIndex and Hierarchical Rows as merged cells.
         inf_rep : str, default 'inf'

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2196,7 +2196,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         startcol : int, default 0
             Upper left cell column to dump data frame.
         engine : str, optional
-            Write engine to use, 'openpyxl' or 'xlsxwriter'. Install them (via pip). Default is 'xlswriter' unless ONLY 'openpyxl' is installed. 
+            Write engine to use, 'openpyxl' or 'xlsxwriter'. First install them (via pip). If only one is installed, Pandas defaults to that one. If both are installed, default is 'xlsxwriter' (faster and makes a smaller file).
         merge_cells : bool, default True
             Write MultiIndex and Hierarchical Rows as merged cells.
         inf_rep : str, default 'inf'

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2198,7 +2198,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         engine : str, optional
             Write engine to use, 'openpyxl' or 'xlsxwriter'. 
             If both are installed, defaults to 'xlsxwriter' 
-            (usually faster and makes a smaller file).
+            (faster and makes a smaller file).
             Otherwise 'openpyxl' is used 
             (supports xlsm/xltx/xltm/xlsx formats).
         merge_cells : bool, default True

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2199,7 +2199,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             Write engine to use, 'openpyxl' or 'xlsxwriter'. 
             If both are installed, default is 'xlsxwriter' (usually faster and makes a smaller file).
             Otherwise use 'openpyxl'.
-            
         merge_cells : bool, default True
             Write MultiIndex and Hierarchical Rows as merged cells.
         inf_rep : str, default 'inf'

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2197,8 +2197,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             Upper left cell column to dump data frame.
         engine : str, optional
             Write engine to use, 'openpyxl' or 'xlsxwriter'. 
-            If both are installed, default is 'xlsxwriter' (usually faster and makes a smaller file).
-            Otherwise use 'openpyxl'.
+            If both are installed, defaults to 'xlsxwriter' (usually faster and makes a smaller file).
+            Otherwise 'openpyxl' is used (supports xlsx/xlsm/xltx/xltm formats).
         merge_cells : bool, default True
             Write MultiIndex and Hierarchical Rows as merged cells.
         inf_rep : str, default 'inf'

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2197,8 +2197,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             Upper left cell column to dump data frame.
         engine : str, optional
             Write engine to use, 'openpyxl' or 'xlsxwriter'. 
-            If both are installed, defaults to 'xlsxwriter' (usually faster and makes a smaller file).
-            Otherwise 'openpyxl' is used (supports xlsx/xlsm/xltx/xltm formats).
+            If both are installed, defaults to 'xlsxwriter' 
+            (usually faster and makes a smaller file).
+            Otherwise 'openpyxl' is used 
+            (supports xlsx/xlsm/xltx/xltm formats).
         merge_cells : bool, default True
             Write MultiIndex and Hierarchical Rows as merged cells.
         inf_rep : str, default 'inf'

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2196,10 +2196,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         startcol : int, default 0
             Upper left cell column to dump data frame.
         engine : str, optional
-            Write engine to use, 'openpyxl' or 'xlsxwriter'. You can also set this
-            via the options ``io.excel.xlsx.writer`` or
-            ``io.excel.xlsm.writer``.
-
+            Write engine to use, 'openpyxl' or 'xlsxwriter'. Install them (via pip). Default is 'xlswriter' unless ONLY 'openpyxl' is installed. 
         merge_cells : bool, default True
             Write MultiIndex and Hierarchical Rows as merged cells.
         inf_rep : str, default 'inf'

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2200,7 +2200,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             If both are installed, defaults to 'xlsxwriter' 
             (usually faster and makes a smaller file).
             Otherwise 'openpyxl' is used 
-            (supports xlsx/xlsm/xltx/xltm formats).
+            (supports xlsm/xltx/xltm/xlsx formats).
         merge_cells : bool, default True
             Write MultiIndex and Hierarchical Rows as merged cells.
         inf_rep : str, default 'inf'


### PR DESCRIPTION
The basic description looked a bit confusing and did not explain why one engine should be used over the other. Also it didn't mention that both need to be installed and which was the default option.  I had 'openpyxl' installed in a previous project, and every time the file was 2x the normal size compared to using 'xlsxwriter' or opening and closing in Excel directly (manually). 