### PR TITLE
BUG: make Series.agg aggregate when possible

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -132,7 +132,7 @@ Now it will always aggregate, when passed an aggregation function:
     ser = pd.Series([1, 2, 3])
     ser.agg(np.sum)
 
-More generally, the result from :meth:`Series.agg` will now always be the same as the single-column result from :meth:`DataFrame.agg`.
+More generally, the result from :meth:`Series.agg` will now always be the same as the single-column result from :meth:`DataFrame.agg` (:issue:'53324').
 
 notable_bug_fix1
 ^^^^^^^^^^^^^^^^

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -108,7 +108,31 @@ Notable bug fixes
 
 These are bug fixes that might have notable behavior changes.
 
-.. _whatsnew_210.notable_bug_fixes.notable_bug_fix1:
+.. _whatsnew_210.notable_bug_fixes.series.agg:
+
+Previously, :meth:`Series.agg` did not necessary aggregate, even if given an aggregation function:
+
+*Previous behavior*:
+
+.. code-block:: ipython
+
+    In [1]: ser = pd.Series([1, 2, 3])
+    In [2]: ser.agg(np.sum)
+    0    1
+    1    2
+    2    3
+    dtype: int64
+
+Now it will always aggregate, when passed an aggregation function:
+
+*New behavior*:
+
+.. ipython:: python
+
+    ser = pd.Series([1, 2, 3])
+    ser.agg(np.sum)
+
+More generally, the result from :meth:`Series.agg` will now always be the same as the single-column result from :meth:`DataFrame.agg`.
 
 notable_bug_fix1
 ^^^^^^^^^^^^^^^^

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -132,7 +132,7 @@ Now it will always aggregate, when passed an aggregation function:
     ser = pd.Series([1, 2, 3])
     ser.agg(np.sum)
 
-More generally, the result from :meth:`Series.agg` will now always be the same as the single-column result from :meth:`DataFrame.agg` (:issue:'53324').
+More generally, the result from :meth:`Series.agg` will now always be the same as the single-column result from :meth:`DataFrame.agg` (:issue:`53324`).
 
 notable_bug_fix1
 ^^^^^^^^^^^^^^^^

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1084,22 +1084,9 @@ class SeriesApply(NDFrameApply):
         result = super().agg()
         if result is None:
             f = self.f
-
             # string, list-like, and dict-like are entirely handled in super
             assert callable(f)
-
-            # try a regular apply, this evaluates lambdas
-            # row-by-row; however if the lambda is expected a Series
-            # expression, e.g.: lambda x: x-x.quantile(0.25)
-            # this will fail, so we can try a vectorized evaluation
-
-            # we cannot FIRST try the vectorized evaluation, because
-            # then .agg and .apply would have different semantics if the
-            # operation is actually defined on the Series, e.g. str
-            try:
-                result = self.obj.apply(f)
-            except (ValueError, AttributeError, TypeError):
-                result = f(self.obj)
+            result = f(self.obj)
 
         return result
 

--- a/pandas/tests/apply/test_series_apply.py
+++ b/pandas/tests/apply/test_series_apply.py
@@ -346,18 +346,6 @@ def test_demo():
     tm.assert_series_equal(result, expected)
 
 
-def test_agg_apply_evaluate_lambdas_the_same(string_series):
-    # test that we are evaluating row-by-row first
-    # before vectorized evaluation
-    result = string_series.apply(lambda x: str(x))
-    expected = string_series.agg(lambda x: str(x))
-    tm.assert_series_equal(result, expected)
-
-    result = string_series.apply(str)
-    expected = string_series.agg(str)
-    tm.assert_series_equal(result, expected)
-
-
 def test_with_nested_series(datetime_series):
     # GH 2316
     # .agg with a reducer and a transform, what to do
@@ -368,11 +356,6 @@ def test_with_nested_series(datetime_series):
             lambda x: Series([x, x**2], index=["x", "x^2"])
         )
     expected = DataFrame({"x": datetime_series, "x^2": datetime_series**2})
-    tm.assert_frame_equal(result, expected)
-
-    with tm.assert_produces_warning(FutureWarning, match=msg):
-        # GH52123
-        result = datetime_series.agg(lambda x: Series([x, x**2], index=["x", "x^2"]))
     tm.assert_frame_equal(result, expected)
 
 


### PR DESCRIPTION
The doc string for `Series.agg` says: `"A passed user-defined-function will be passed a Series for evaluation."` which isn't true currently. In addition `Series.agg` currently will not always aggregate, when given a aggregation function. This PR fixes those issues.

It can be noted that that doc string is correct for `DataFrame.agg`, so this PR aligns the behavior of `Series.agg` and `DataFrame.agg`.

I'm not sure if this is too drastic as a bug fix, or we want it as part of a deprecation process, but just putting this up there, will see where it goes. This will solve parts of #52140. 
