### PR TITLE
DEPR: make Series.agg aggregate when possible

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -114,10 +114,47 @@ Notable bug fixes
 
 These are bug fixes that might have notable behavior changes.
 
-.. _whatsnew_210.notable_bug_fixes.notable_bug_fix1:
+.. _whatsnew_210.notable_bug_fixes.series_agg:
 
-notable_bug_fix1
-^^^^^^^^^^^^^^^^
+User defined functions in Series.agg will always be passed the whole :class:`Series` for evaluation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Previously, :meth:`Series.agg` would attempt to apply user-defined functions on each element first and only if that failed would it apply user-defined function to the whole :class:`Series`. This would mean it in some cases didn't aggregate when given an aggregation function, and that the result for :meth:`Series.agg` could be different than the single-column result from :meth:`DataFrame.agg`:
+
+*Previous behavior*:
+
+.. code-block:: ipython
+
+    In [1]: ser = pd.Series([1, 2, 3])
+    In [2]: ser.agg(lambda x: np.sum(x, where=True))
+    Out[2]:
+    0    1
+    1    2
+    2    3
+    dtype: int64
+    In [3]: ser.agg(type)
+    Out[3]:
+    0    <class 'int'>
+    1    <class 'int'>
+    2    <class 'int'>
+    dtype: object
+    In [3]: df = ser.to_frame()
+    In [4]: df.agg(type)[0]
+    pandas.core.series.Series
+
+Now user-defined functions in :meth:`Series.agg` will always be passed the whole :class:`Series` for evaluation:
+
+*New behavior*:
+
+.. ipython:: python
+
+    ser = pd.Series([1, 2, 3])
+    ser.agg(lambda x: np.sum(x, where=True))  # fails, as it should
+    ser.agg(type)
+    ser.agg(type) == ser.to_frame().agg(type)[0]
+
+More generally, the result from :meth:`Series.agg` will now always be the same as the single-column result from :meth:`DataFrame.agg` (:issue:`53324`).
+
 
 .. _whatsnew_210.notable_bug_fixes.notable_bug_fix2:
 

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -147,13 +147,14 @@ Now user-defined functions in :meth:`Series.agg` will always be passed the whole
 *New behavior*:
 
 .. ipython:: python
+   :okexcept:
 
-    ser = pd.Series([1, 2, 3])
-    ser.agg(lambda x: np.sum(x, where=True))  # fails, as it should
-    ser.agg(type)
-    ser.agg(type) == ser.to_frame().agg(type)[0]
+   ser = pd.Series([1, 2, 3])
+   ser.agg(lambda x: np.sum(x, where=True))  # fails, as it should
+   ser.agg(type)
+   ser.agg(type) == ser.to_frame().agg(type)[0]
 
-More generally, the result from :meth:`Series.agg` will now always be the same as the single-column result from :meth:`DataFrame.agg` (:issue:`53324`).
+More generally, the result from :meth:`Series.agg` will now always be the same as the single-column result from :meth:`DataFrame.agg` (:issue:`53325`).
 
 
 .. _whatsnew_210.notable_bug_fixes.notable_bug_fix2:

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -114,48 +114,10 @@ Notable bug fixes
 
 These are bug fixes that might have notable behavior changes.
 
-.. _whatsnew_210.notable_bug_fixes.series_agg:
+.. _whatsnew_210.notable_bug_fixes.notable_bug_fix1:
 
-User defined functions in Series.agg will always be passed the whole :class:`Series` for evaluation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Previously, :meth:`Series.agg` would attempt to apply user-defined functions on each element first and only if that failed would it apply user-defined function to the whole :class:`Series`. This would mean it in some cases didn't aggregate when given an aggregation function, and that the result for :meth:`Series.agg` could be different than the single-column result from :meth:`DataFrame.agg`:
-
-*Previous behavior*:
-
-.. code-block:: ipython
-
-    In [1]: ser = pd.Series([1, 2, 3])
-    In [2]: ser.agg(lambda x: np.sum(x, where=True))
-    Out[2]:
-    0    1
-    1    2
-    2    3
-    dtype: int64
-    In [3]: ser.agg(type)
-    Out[3]:
-    0    <class 'int'>
-    1    <class 'int'>
-    2    <class 'int'>
-    dtype: object
-    In [3]: df = ser.to_frame()
-    In [4]: df.agg(type)[0]
-    pandas.core.series.Series
-
-Now user-defined functions in :meth:`Series.agg` will always be passed the whole :class:`Series` for evaluation:
-
-*New behavior*:
-
-.. ipython:: python
-   :okexcept:
-
-   ser = pd.Series([1, 2, 3])
-   ser.agg(lambda x: np.sum(x, where=True))  # fails, as it should
-   ser.agg(type)
-   ser.agg(type) == ser.to_frame().agg(type)[0]
-
-More generally, the result from :meth:`Series.agg` will now always be the same as the single-column result from :meth:`DataFrame.agg` (:issue:`53325`).
-
+notable_bug_fix1
+^^^^^^^^^^^^^^^^
 
 .. _whatsnew_210.notable_bug_fixes.notable_bug_fix2:
 
@@ -273,6 +235,8 @@ Deprecations
 - Deprecated ``axis=1`` in :meth:`DataFrame.groupby` and in :class:`Grouper` constructor, do ``frame.T.groupby(...)`` instead (:issue:`51203`)
 - Deprecated accepting slices in :meth:`DataFrame.take`, call ``obj[slicer]`` or pass a sequence of integers instead (:issue:`51539`)
 - Deprecated explicit support for subclassing :class:`Index` (:issue:`45289`)
+- Deprecated making functions given to :meth:`Series.agg` attempt to operate on each element in the :class:`Series` and only operate on the whole :class:`Series` if the elementwise operations failed. In the future, functions given to :meth:`Series.agg` will always operate on the whole :class:`Series` only. To keep the current behavior, use :meth:`Series.transform` instead. (:issue:`53325`)
+- Deprecated making the functions in a list of functions given to :meth:`DataFrame.agg` attempt to operate on each element in the :class:`DataFrame` and only operate on the columns of the :class:`DataFrame` if the elementwise operations failed. To keep the current behavior, use :meth:`DataFrame.transform` instead. (:issue:`53325`)
 - Deprecated passing a :class:`DataFrame` to :meth:`DataFrame.from_records`, use :meth:`DataFrame.set_index` or :meth:`DataFrame.drop` instead (:issue:`51353`)
 - Deprecated silently dropping unrecognized timezones when parsing strings to datetimes (:issue:`18702`)
 - Deprecated the ``axis`` keyword in :meth:`DataFrame.ewm`, :meth:`Series.ewm`, :meth:`DataFrame.rolling`, :meth:`Series.rolling`, :meth:`DataFrame.expanding`, :meth:`Series.expanding` (:issue:`51778`)

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1130,13 +1130,10 @@ class SeriesApply(NDFrameApply):
             # GH53325: The setup below is just to keep current behavior while emitting a
             # deprecation message. In the future this will all be replaced with a simple
             # `result = f(self.obj)`.
-            if isinstance(func, np.ufunc):
-                with np.errstate(all="ignore"):
-                    return func(obj)
             try:
-                result = obj.apply(func)
+                result = obj.apply(func, args=self.args, **self.kwargs)
             except (ValueError, AttributeError, TypeError):
-                result = func(self.obj)
+                result = func(obj, *self.args, **self.kwargs)
             else:
                 msg = (
                     f"using {func} in {type(obj).__name__}.agg cannot aggregate and "

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -324,6 +324,8 @@ class Apply(metaclass=abc.ABCMeta):
         is_groupby = isinstance(obj, (DataFrameGroupBy, SeriesGroupBy))
 
         is_ser_or_df = isinstance(obj, (ABCDataFrame, ABCSeries))
+        this_args = [self.axis, *self.args] if is_ser_or_df else self.args
+
         context_manager: ContextManager
         if is_groupby:
             # When as_index=False, we combine all results using indices
@@ -342,7 +344,6 @@ class Apply(metaclass=abc.ABCMeta):
             if selected_obj.ndim == 1:
                 for a in func:
                     colg = obj._gotitem(selected_obj.name, ndim=1, subset=selected_obj)
-                    this_args = [self.axis, *self.args] if is_ser_or_df else self.args
                     new_res = getattr(colg, op_name)(a, *this_args, **kwargs)
                     results.append(new_res)
 
@@ -354,7 +355,6 @@ class Apply(metaclass=abc.ABCMeta):
                 indices = []
                 for index, col in enumerate(selected_obj):
                     colg = obj._gotitem(col, ndim=1, subset=selected_obj.iloc[:, index])
-                    this_args = [self.axis, *self.args] if is_ser_or_df else self.args
                     new_res = getattr(colg, op_name)(func, *this_args, **kwargs)
                     results.append(new_res)
                     indices.append(index)

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -323,6 +323,7 @@ class Apply(metaclass=abc.ABCMeta):
 
         is_groupby = isinstance(obj, (DataFrameGroupBy, SeriesGroupBy))
 
+        is_ser_or_df = isinstance(obj, (ABCDataFrame, ABCSeries))
         context_manager: ContextManager
         if is_groupby:
             # When as_index=False, we combine all results using indices
@@ -341,8 +342,8 @@ class Apply(metaclass=abc.ABCMeta):
             if selected_obj.ndim == 1:
                 for a in func:
                     colg = obj._gotitem(selected_obj.name, ndim=1, subset=selected_obj)
-                    args = [self.axis, *self.args] if include_axis(colg) else self.args
-                    new_res = getattr(colg, op_name)(a, *args, **kwargs)
+                    this_args = [self.axis, *self.args] if is_ser_or_df else self.args
+                    new_res = getattr(colg, op_name)(a, *this_args, **kwargs)
                     results.append(new_res)
 
                     # make sure we find a good name
@@ -353,8 +354,8 @@ class Apply(metaclass=abc.ABCMeta):
                 indices = []
                 for index, col in enumerate(selected_obj):
                     colg = obj._gotitem(col, ndim=1, subset=selected_obj.iloc[:, index])
-                    args = [self.axis, *self.args] if include_axis(colg) else self.args
-                    new_res = getattr(colg, op_name)(func, *args, **kwargs)
+                    this_args = [self.axis, *self.args] if is_ser_or_df else self.args
+                    new_res = getattr(colg, op_name)(func, *this_args, **kwargs)
                     results.append(new_res)
                     indices.append(index)
                 keys = selected_obj.columns.take(indices)

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1121,23 +1121,28 @@ class SeriesApply(NDFrameApply):
     def agg(self):
         result = super().agg()
         if result is None:
+            obj = self.obj
             func = self.func
-
             # string, list-like, and dict-like are entirely handled in super
             assert callable(func)
 
-            # try a regular apply, this evaluates lambdas
-            # row-by-row; however if the lambda is expected a Series
-            # expression, e.g.: lambda x: x-x.quantile(0.25)
-            # this will fail, so we can try a vectorized evaluation
-
-            # we cannot FIRST try the vectorized evaluation, because
-            # then .agg and .apply would have different semantics if the
-            # operation is actually defined on the Series, e.g. str
+            # GH53325: The setup below is just to keep current behavior while emitting a
+            # deprecation message. In the future this will all be replaced with a simple
+            # `result = f(self.obj)`.
+            if isinstance(func, np.ufunc):
+                with np.errstate(all="ignore"):
+                    return func(obj)
             try:
-                result = self.obj.apply(func, args=self.args, **self.kwargs)
+                result = obj.apply(func)
             except (ValueError, AttributeError, TypeError):
-                result = func(self.obj, *self.args, **self.kwargs)
+                result = func(self.obj)
+            else:
+                msg = (
+                    f"using {func} in {type(obj).__name__}.agg cannot aggregate and "
+                    f"has been deprecated. Use {type(obj).__name__}.transform to "
+                    f"keep behavior unchanged."
+                )
+                warnings.warn(msg, FutureWarning, stacklevel=find_stack_level())
 
         return result
 

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1128,7 +1128,7 @@ class SeriesApply(NDFrameApply):
 
             # GH53325: The setup below is just to keep current behavior while emitting a
             # deprecation message. In the future this will all be replaced with a simple
-            # `result = f(self.obj)`.
+            # `result = f(self.obj, *self.args, **self.kwargs)`.
             try:
                 result = obj.apply(func, args=self.args, **self.kwargs)
             except (ValueError, AttributeError, TypeError):

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -323,9 +323,6 @@ class Apply(metaclass=abc.ABCMeta):
 
         is_groupby = isinstance(obj, (DataFrameGroupBy, SeriesGroupBy))
 
-        is_ser_or_df = isinstance(obj, (ABCDataFrame, ABCSeries))
-        this_args = [self.axis, *self.args] if is_ser_or_df else self.args
-
         context_manager: ContextManager
         if is_groupby:
             # When as_index=False, we combine all results using indices
@@ -344,7 +341,8 @@ class Apply(metaclass=abc.ABCMeta):
             if selected_obj.ndim == 1:
                 for a in func:
                     colg = obj._gotitem(selected_obj.name, ndim=1, subset=selected_obj)
-                    new_res = getattr(colg, op_name)(a, *this_args, **kwargs)
+                    args = [self.axis, *self.args] if include_axis(colg) else self.args
+                    new_res = getattr(colg, op_name)(a, *args, **kwargs)
                     results.append(new_res)
 
                     # make sure we find a good name
@@ -355,7 +353,8 @@ class Apply(metaclass=abc.ABCMeta):
                 indices = []
                 for index, col in enumerate(selected_obj):
                     colg = obj._gotitem(col, ndim=1, subset=selected_obj.iloc[:, index])
-                    new_res = getattr(colg, op_name)(func, *this_args, **kwargs)
+                    args = [self.axis, *self.args] if include_axis(colg) else self.args
+                    new_res = getattr(colg, op_name)(func, *args, **kwargs)
                     results.append(new_res)
                     indices.append(index)
                 keys = selected_obj.columns.take(indices)

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1497,7 +1497,7 @@ def test_agg_mapping_func_deprecated():
 
     with tm.assert_produces_warning(FutureWarning, match=msg):
         result = df.agg([foo1, foo2], 0, 3, c=4)
-    expected = pd.DataFrame(
+    expected = DataFrame(
         [[8, 8], [9, 9], [10, 10]], columns=[["x", "x"], ["foo1", "foo2"]]
     )
     tm.assert_frame_equal(result, expected)
@@ -1505,7 +1505,7 @@ def test_agg_mapping_func_deprecated():
     # TODO: the result below is wrong, should be fixed (GH53325)
     with tm.assert_produces_warning(FutureWarning, match=msg):
         result = df.agg({"x": foo1}, 0, 3, c=4)
-    expected = pd.DataFrame([2, 3, 4], columns=["x"])
+    expected = DataFrame([2, 3, 4], columns=["x"])
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1489,12 +1489,24 @@ def test_agg_mapping_func_deprecated():
         return x + b + c
 
     # single func already takes the vectorized path
-    df.agg(foo1, 0, 3, c=4)
+    result = df.agg(foo1, 0, 3, c=4)
+    expected = df + 7
+    tm.assert_frame_equal(result, expected)
+
     msg = "using .+ in Series.agg cannot aggregate and"
+
     with tm.assert_produces_warning(FutureWarning, match=msg):
-        df.agg([foo1, foo2], 0, 3, c=4)
-        with tm.assert_produces_warning(FutureWarning, match=msg):
-            df.agg({"x": foo1}, 0, 3, c=4)
+        result = df.agg([foo1, foo2], 0, 3, c=4)
+    expected = pd.DataFrame(
+        [[8, 8], [9, 9], [10, 10]], columns=[["x", "x"], ["foo1", "foo2"]]
+    )
+    tm.assert_frame_equal(result, expected)
+
+    # TODO: the result below is wrong, should be fixed (GH53325)
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        result = df.agg({"x": foo1}, 0, 3, c=4)
+    expected = pd.DataFrame([2, 3, 4], columns=["x"])
+    tm.assert_frame_equal(result, expected)
 
 
 def test_agg_std():

--- a/pandas/tests/apply/test_frame_transform.py
+++ b/pandas/tests/apply/test_frame_transform.py
@@ -66,6 +66,28 @@ def test_transform_empty_listlike(float_frame, ops, frame_or_series):
         obj.transform(ops)
 
 
+def test_transform_listlike_func_with_args():
+    # GH 50624
+    df = DataFrame({"x": [1, 2, 3]})
+
+    def foo1(x, a=1, c=0):
+        return x + a + c
+
+    def foo2(x, b=2, c=0):
+        return x + b + c
+
+    msg = r"foo1\(\) got an unexpected keyword argument 'b'"
+    with pytest.raises(TypeError, match=msg):
+        df.transform([foo1, foo2], 0, 3, b=3, c=4)
+
+    result = df.transform([foo1, foo2], 0, 3, c=4)
+    expected = DataFrame(
+        [[8, 8], [9, 9], [10, 10]],
+        columns=MultiIndex.from_tuples([("x", "foo1"), ("x", "foo2")]),
+    )
+    tm.assert_frame_equal(result, expected)
+
+
 @pytest.mark.parametrize("box", [dict, Series])
 def test_transform_dictlike(axis, float_frame, box):
     # GH 35964

--- a/pandas/tests/apply/test_invalid_arg.py
+++ b/pandas/tests/apply/test_invalid_arg.py
@@ -8,6 +8,7 @@
 
 from itertools import chain
 import re
+import warnings
 
 import numpy as np
 import pytest
@@ -307,7 +308,10 @@ def test_transform_and_agg_err_series(string_series, func, msg):
     # we are trying to transform with an aggregator
     with pytest.raises(ValueError, match=msg):
         with np.errstate(all="ignore"):
-            string_series.agg(func)
+            # GH53325
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", FutureWarning)
+                string_series.agg(func)
 
 
 @pytest.mark.parametrize("func", [["max", "min"], ["max", "sqrt"]])

--- a/pandas/tests/apply/test_series_apply.py
+++ b/pandas/tests/apply/test_series_apply.py
@@ -398,13 +398,14 @@ def test_agg_evaluate_lambdas(string_series):
     assert isinstance(result, Series) and len(result) == len(string_series)
 
 
-def test_with_nested_series(datetime_series):
+@pytest.mark.parametrize("op_name", ["agg", "apply"])
+def test_with_nested_series(datetime_series, op_name):
     # GH 2316
     # .agg with a reducer and a transform, what to do
     msg = "Returning a DataFrame from Series.apply when the supplied function"
     with tm.assert_produces_warning(FutureWarning, match=msg):
         # GH52123
-        result = datetime_series.apply(
+        result = getattr(datetime_series, op_name)(
             lambda x: Series([x, x**2], index=["x", "x^2"])
         )
     expected = DataFrame({"x": datetime_series, "x^2": datetime_series**2})

--- a/pandas/tests/apply/test_series_apply.py
+++ b/pandas/tests/apply/test_series_apply.py
@@ -391,6 +391,16 @@ def test_apply_map_evaluate_lambdas_the_same(string_series, func, by_row):
         assert result == str(string_series)
 
 
+def test_agg_evaluate_lambdas(string_series):
+    expected = Series
+
+    result = string_series.agg(lambda x: type(x))
+    assert result is expected
+
+    result = string_series.agg(type)
+    assert result is expected
+
+
 def test_with_nested_series(datetime_series):
     # GH 2316
     # .agg with a reducer and a transform, what to do
@@ -401,11 +411,6 @@ def test_with_nested_series(datetime_series):
             lambda x: Series([x, x**2], index=["x", "x^2"])
         )
     expected = DataFrame({"x": datetime_series, "x^2": datetime_series**2})
-    tm.assert_frame_equal(result, expected)
-
-    with tm.assert_produces_warning(FutureWarning, match=msg):
-        # GH52123
-        result = datetime_series.agg(lambda x: Series([x, x**2], index=["x", "x^2"]))
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/apply/test_series_apply.py
+++ b/pandas/tests/apply/test_series_apply.py
@@ -392,6 +392,7 @@ def test_apply_map_evaluate_lambdas_the_same(string_series, func, by_row):
 
 
 def test_agg_evaluate_lambdas(string_series):
+    # GH53325
     expected = Series
 
     result = string_series.agg(lambda x: type(x))


### PR DESCRIPTION
The doc string for `Series.agg` says: `"A passed user-defined-function will be passed a Series for evaluation."` which isn't true currently. In addition, `Series.agg` currently will not always aggregate, when given a aggregation function. This PR fixes those issues.

It can be noted that both the behavior and that doc string are correct for `DataFrame.agg`, so this PR aligns the behavior of `Series.agg` and `DataFrame.agg`.

I'm not sure if this is too drastic as a bug fix, or we want it as part of a deprecation process, but just putting this up there, will see where it goes.

EDIT: In the new version the old behavior is deprecated rather than just removed. 