### PR TITLE
ENH: Deprecate literal json string input to read_json

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -2028,10 +2028,7 @@ Reading a JSON string to pandas object can take a number of parameters.
 The parser will try to parse a ``DataFrame`` if ``typ`` is not supplied or
 is ``None``. To explicitly force ``Series`` parsing, pass ``typ=series``
 
-* ``filepath_or_buffer`` : a **VALID** JSON string or file handle / StringIO. The string could be
-  a URL. Valid URL schemes include http, ftp, S3, and file. For file URLs, a host
-  is expected. For instance, a local file could be
-  file ://localhost/path/to/table.json
+* ``filepath_or_buffer`` : a **VALID** file handle or StringIO object.
 * ``typ``    : type of object to recover (series or frame), default 'frame'
 * ``orient`` :
 
@@ -2106,12 +2103,6 @@ preserve string-like numbers (e.g. '1', '2') in an axes.
    * bool columns will be converted to ``integer`` on reconstruction
 
    Thus there are times where you may want to specify specific dtypes via the ``dtype`` keyword argument.
-
-Reading from a JSON string:
-
-.. ipython:: python
-
-   pd.read_json(json)
 
 Reading from a file:
 

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -266,6 +266,7 @@ Deprecations
 - Deprecated allowing ``downcast`` keyword other than ``None``, ``False``, "infer", or a dict with these as values in :meth:`Series.fillna`, :meth:`DataFrame.fillna` (:issue:`40988`)
 - Deprecated allowing arbitrary ``fill_value`` in :class:`SparseDtype`, in a future version the ``fill_value`` will need to be compatible with the ``dtype.subtype``, either a scalar that can be held by that subtype or ``NaN`` for integer or bool subtypes (:issue:`23124`)
 - Deprecated constructing :class:`SparseArray` from scalar data, pass a sequence instead (:issue:`53039`)
+- Deprecated literal json input to :func:`read_json`. Moving forward the method only accepts file-like objects (:issue:`52271`)
 - Deprecated positional indexing on :class:`Series` with :meth:`Series.__getitem__` and :meth:`Series.__setitem__`, in a future version ``ser[item]`` will *always* interpret ``item`` as a label, not a position (:issue:`50617`)
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -266,7 +266,7 @@ Deprecations
 - Deprecated allowing ``downcast`` keyword other than ``None``, ``False``, "infer", or a dict with these as values in :meth:`Series.fillna`, :meth:`DataFrame.fillna` (:issue:`40988`)
 - Deprecated allowing arbitrary ``fill_value`` in :class:`SparseDtype`, in a future version the ``fill_value`` will need to be compatible with the ``dtype.subtype``, either a scalar that can be held by that subtype or ``NaN`` for integer or bool subtypes (:issue:`23124`)
 - Deprecated constructing :class:`SparseArray` from scalar data, pass a sequence instead (:issue:`53039`)
-- Deprecated literal json input to :func:`read_json`. Moving forward the method only accepts file-like objects (:issue:`52271`)
+- Deprecated literal json input to :func:`read_json`. Moving forward the method only accepts file-like objects (:issue:`53330`)
 - Deprecated positional indexing on :class:`Series` with :meth:`Series.__getitem__` and :meth:`Series.__setitem__`, in a future version ``ser[item]`` will *always* interpret ``item`` as a label, not a position (:issue:`50617`)
 
 .. ---------------------------------------------------------------------------

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -493,7 +493,7 @@ def read_json(
     decompression_options=_shared_docs["decompression_options"] % "path_or_buf",
 )
 def read_json(
-    path_or_buf: FilePath | ReadBuffer[str] | ReadBuffer[bytes],
+    path_or_buf: ReadBuffer[str] | ReadBuffer[bytes],
     *,
     orient: str | None = None,
     typ: Literal["frame", "series"] = "frame",

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -860,7 +860,9 @@ class JsonReader(abc.Iterator, Generic[FrameSeriesStrT]):
                 )
             self.data = filepath_or_buffer
         elif self.engine == "ujson":
+            self.handles = get_handle(filepath_or_buffer, "r")
             self.data = self._preprocess_data(filepath_or_buffer)
+            self.close()
 
     def _preprocess_data(self, data):
         """


### PR DESCRIPTION
- [X] closes #52271 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
