### PR TITLE
Update default value for `fill_value` parameter of `Series.reindex` method

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4821,7 +4821,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         method: ReindexMethod | None = None,
         copy: bool | None = None,
         level: Level | None = None,
-        fill_value: Scalar | None = None,
+        fill_value: Scalar | None = np.nan,
         limit: int | None = None,
         tolerance=None,
     ) -> Series:


### PR DESCRIPTION
The default value is in accordance with the method's [documentation](https://pandas.pydata.org/docs/reference/api/pandas.Series.reindex.html).

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
