### PR TITLE
Update default value for `copy` parameter of `DataFrame.tz_convert` method

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10611,7 +10611,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     @final
     @doc(klass=_shared_doc_kwargs["klass"])
     def tz_convert(
-        self, tz, axis: Axis = 0, level=None, copy: bool_t | None = None
+        self, tz, axis: Axis = 0, level=None, copy: bool_t | None = True
     ) -> Self:
         """
         Convert tz-aware axis to target time zone.

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10696,7 +10696,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         tz,
         axis: Axis = 0,
         level=None,
-        copy: bool_t | None = None,
+        copy: bool_t | None = True,
         ambiguous: TimeAmbiguous = "raise",
         nonexistent: TimeNonexistent = "raise",
     ) -> Self:


### PR DESCRIPTION
The default value is in accordance with the method's [documentation](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.tz_convert.html).

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
