### PR TITLE
DEPR: infer bytes to bytes[pyarrow]

### DIFF
--- a/pandas/_libs/lib.pyi
+++ b/pandas/_libs/lib.pyi
@@ -71,7 +71,6 @@ def map_infer(
     convert: bool = ...,
     ignore_na: bool = ...,
 ) -> np.ndarray: ...
-
 @overload
 def maybe_convert_objects(
     objects: npt.NDArray[np.object_],

--- a/pandas/_libs/lib.pyi
+++ b/pandas/_libs/lib.pyi
@@ -71,6 +71,7 @@ def map_infer(
     convert: bool = ...,
     ignore_na: bool = ...,
 ) -> np.ndarray: ...
+
 @overload
 def maybe_convert_objects(
     objects: npt.NDArray[np.object_],

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2589,7 +2589,7 @@ def maybe_convert_objects(ndarray[object] objects,
                 seen.object_ = True
                 break
         elif PyTime_Check(val):
-            if convert_time:
+            if convert_non_numeric:
                 seen.time_ = True
             else:
                 seen.object_ = True
@@ -2664,7 +2664,7 @@ def maybe_convert_objects(ndarray[object] objects,
             if opt is True:
                 import pyarrow as pa
 
-                from pandas.core.arrays.arrow import ArrowDtype
+                from pandas.core.dtypes.dtypes import ArrowDtype
 
                 obj = pa.array(objects)
                 dtype = ArrowDtype(obj.type)

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -6,6 +6,7 @@ from typing import (
     Literal,
     _GenericAlias,
 )
+import warnings
 
 cimport cython
 from cpython.datetime cimport (
@@ -98,6 +99,8 @@ cdef extern from "pandas/parser/pd_parser.h":
     void PandasParser_IMPORT()
 
 PandasParser_IMPORT
+
+from pandas._config import get_option
 
 from pandas._libs cimport util
 from pandas._libs.util cimport (
@@ -1267,6 +1270,7 @@ cdef class Seen:
         bint datetimetz_      # seen_datetimetz
         bint period_          # seen_period
         bint interval_        # seen_interval
+        bint time_
 
     def __cinit__(self, bint coerce_numeric=False):
         """
@@ -1293,6 +1297,7 @@ cdef class Seen:
         self.datetimetz_ = False
         self.period_ = False
         self.interval_ = False
+        self.time_ = False
         self.coerce_numeric = coerce_numeric
 
     cdef bint check_uint64_conflict(self) except -1:
@@ -2583,6 +2588,12 @@ def maybe_convert_objects(ndarray[object] objects,
             else:
                 seen.object_ = True
                 break
+        elif PyTime_Check(val):
+            if convert_time:
+                seen.time_ = True
+            else:
+                seen.object_ = True
+            break
         else:
             seen.object_ = True
             break
@@ -2647,7 +2658,36 @@ def maybe_convert_objects(ndarray[object] objects,
 
         seen.object_ = True
 
-    elif seen.nat_:
+    elif seen.time_:
+        if is_time_array(objects):
+            opt = get_option("future.infer_time")
+            if opt is True:
+                import pyarrow as pa
+
+                from pandas.core.arrays.arrow import ArrowDtype
+
+                obj = pa.array(objects)
+                dtype = ArrowDtype(obj.type)
+                return dtype.construct_array_type()(obj)
+            elif opt is False:
+                # explicitly set to keep the old behavior and avoid the warning
+                pass
+            else:
+                from pandas.util._exceptions import find_stack_level
+                warnings.warn(
+                    "Pandas type inference with a sequence of `datetime.time` "
+                    "objects is deprecated. In a future version, this will give "
+                    "time32[pyarrow] dtype, which will require pyarrow to be "
+                    "installed. To opt in to the new behavior immediately set "
+                    "`pd.set_option('future.infer_time', True)`. To keep the "
+                    "old behavior pass `dtype=object`.",
+                    FutureWarning,
+                    stacklevel=find_stack_level(),
+                )
+
+        seen.object_ = True
+
+    if seen.nat_:
         if not seen.object_ and not seen.numeric_ and not seen.bool_:
             # all NaT, None, or nan (at least one NaT)
             # see GH#49340 for discussion of desired behavior

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2589,7 +2589,7 @@ def maybe_convert_objects(ndarray[object] objects,
                 seen.object_ = True
                 break
         elif PyTime_Check(val):
-            if convert_non_numeric:
+            if convert_non_numeric and val.tzinfo is None:
                 seen.time_ = True
             else:
                 seen.object_ = True
@@ -2660,6 +2660,7 @@ def maybe_convert_objects(ndarray[object] objects,
 
     elif seen.time_:
         if is_time_array(objects):
+            # FIXME: need to ensure this is not timetz
             opt = get_option("future.infer_time")
             if opt is True:
                 import pyarrow as pa

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2660,6 +2660,7 @@ def maybe_convert_objects(ndarray[object] objects,
 
     elif seen.time_:
         if is_time_array(objects):
+            # FIXME: need to ensure this is not timetz
             opt = get_option("future.infer_time")
             if opt is True:
                 import pyarrow as pa

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2660,7 +2660,6 @@ def maybe_convert_objects(ndarray[object] objects,
 
     elif seen.time_:
         if is_time_array(objects):
-            # FIXME: need to ensure this is not timetz
             opt = get_option("future.infer_time")
             if opt is True:
                 import pyarrow as pa

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -129,6 +129,9 @@ def pytest_collection_modifyitems(items, config) -> None:
     # Warnings from doctests that can be ignored; place reason in comment above.
     # Each entry specifies (path, message) - see the ignore_doctest_warning function
     ignored_doctest_warnings = [
+        ("DatetimeProperties.time", "with pyarrow time dtype"),
+        ("DatetimeArray.time", "with pyarrow time dtype"),
+        ("DatetimeIndex.time", "with pyarrow time dtype"),
         ("is_int64_dtype", "is_int64_dtype is deprecated"),
         ("is_interval_dtype", "is_interval_dtype is deprecated"),
         ("is_period_dtype", "is_period_dtype is deprecated"),

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -137,6 +137,8 @@ def pytest_collection_modifyitems(items, config) -> None:
         ("is_sparse", "is_sparse is deprecated"),
         ("NDFrame.replace", "The 'method' keyword"),
         ("NDFrame.replace", "Series.replace without 'value'"),
+        ("DatetimeArray.time", "with pyarrow time dtype"),
+        ("DatetimeIndex.time", "with pyarrow time dtype"),
         # Docstring divides by zero to show behavior difference
         ("missing.mask_zero_div_zero", "divide by zero encountered"),
         (

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -651,15 +651,7 @@ class ArrowExtensionArray(
         if pc_func is NotImplemented:
             raise NotImplementedError(f"{op.__name__} not implemented.")
 
-        try:
-            result = pc_func(self._pa_array, other)
-        except pa.lib.ArrowNotImplementedError:
-            if op in [operator.add, roperator.radd, operator.sub, roperator.rsub]:
-                # By returning NotImplemented we get standard message with a
-                #  TypeError
-                return NotImplemented
-            raise
-
+        result = pc_func(self._pa_array, other)
         return type(self)(result)
 
     def _logical_method(self, other, op):

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -651,7 +651,15 @@ class ArrowExtensionArray(
         if pc_func is NotImplemented:
             raise NotImplementedError(f"{op.__name__} not implemented.")
 
-        result = pc_func(self._pa_array, other)
+        try:
+            result = pc_func(self._pa_array, other)
+        except pa.lib.ArrowNotImplementedError:
+            if op in [operator.add, roperator.radd, operator.sub, roperator.rsub]:
+                # By returning NotImplemented we get standard message with a
+                #  TypeError
+                return NotImplemented
+            raise
+
         return type(self)(result)
 
     def _logical_method(self, other, op):

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -61,6 +61,7 @@ from pandas.core.dtypes.dtypes import (
     DatetimeTZDtype,
     ExtensionDtype,
     PeriodDtype,
+    ArrowDtype,
 )
 from pandas.core.dtypes.missing import isna
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -57,6 +57,7 @@ from pandas.core.dtypes.common import (
     pandas_dtype,
 )
 from pandas.core.dtypes.dtypes import (
+    ArrowDtype,
     DatetimeTZDtype,
     ExtensionDtype,
     PeriodDtype,

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -85,7 +85,10 @@ if TYPE_CHECKING:
     )
 
     from pandas import DataFrame
-    from pandas.core.arrays import PeriodArray
+    from pandas.core.arrays import (
+        ArrowExtensionArray,
+        PeriodArray,
+    )
 
 _midnight = time(0, 0)
 
@@ -1338,7 +1341,7 @@ default 'raise'
         return result
 
     @property
-    def time(self) -> npt.NDArray[np.object_]:
+    def time(self) -> npt.NDArray[np.object_] | ArrowExtensionArray:
         """
         Returns numpy array of :class:`datetime.time` objects.
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -61,7 +61,6 @@ from pandas.core.dtypes.dtypes import (
     DatetimeTZDtype,
     ExtensionDtype,
     PeriodDtype,
-    ArrowDtype,
 )
 from pandas.core.dtypes.missing import isna
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -15,6 +15,8 @@ import warnings
 
 import numpy as np
 
+from pandas._config import get_option
+
 from pandas._libs import (
     lib,
     tslib,
@@ -58,6 +60,7 @@ from pandas.core.dtypes.dtypes import (
     DatetimeTZDtype,
     ExtensionDtype,
     PeriodDtype,
+    ArrowDtype,
 )
 from pandas.core.dtypes.missing import isna
 
@@ -1368,7 +1371,30 @@ default 'raise'
         # keeping their timezone and not using UTC
         timestamps = self._local_timestamps()
 
-        return ints_to_pydatetime(timestamps, box="time", reso=self._creso)
+        result = ints_to_pydatetime(timestamps, box="time", reso=self._creso)
+
+        opt = get_option("future.infer_time")
+        if opt is None:
+            warnings.warn(
+                f"The behavior of {type(self).__name__}.time is deprecated. "
+                "In a future version, this will an array with pyarrow time "
+                "dtype instead of object dtype. To opt in to the future behavior, "
+                "set `pd.set_option('future.infer_time', True)`.",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
+        elif opt is True:
+            # TODO: optimize this to avoid going through ints_to_pydatetime
+            import pyarrow as pa
+
+            pa_type = pa.time64(self.unit)
+            result[self.isna()] = None
+            obj = pa.array(result, type=pa_type)
+            dtype = ArrowDtype(obj.type)
+            out = dtype.construct_array_type()(obj)
+            return out
+
+        return result
 
     @property
     def timetz(self) -> npt.NDArray[np.object_]:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1381,7 +1381,7 @@ default 'raise'
         if opt is None:
             warnings.warn(
                 f"The behavior of {type(self).__name__}.time is deprecated. "
-                "In a future version, this will an array with pyarrow time "
+                "In a future version, this will return an array with pyarrow time "
                 "dtype instead of object dtype. To opt in to the future behavior, "
                 "set `pd.set_option('future.infer_time', True)`.",
                 FutureWarning,

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -889,3 +889,14 @@ with cf.config_prefix("styler"):
         styler_environment,
         validator=is_instance_factory([type(None), str]),
     )
+
+
+with cf.config_prefix("future"):
+    cf.register_option(
+        "future.infer_time",
+        None,
+        "Whether to infer sequence of datetime.time objects as pyarrow time "
+        "dtype, which will be the default in pandas 3.0 "
+        "(at which point this option will be deprecated).",
+        validator=is_one_of_factory([True, False, None]),
+    )

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -893,6 +893,14 @@ with cf.config_prefix("styler"):
 
 with cf.config_prefix("future"):
     cf.register_option(
+        "future.infer_bytes",
+        None,
+        "Whether to infer sequence of bytes objects as pyarrow bytes "
+        "dtype, which will be the default in pandas 3.0 "
+        "(at which point this option will be deprecated).",
+        validator=is_one_of_factory([True, False, None]),
+    )
+    cf.register_option(
         "future.infer_time",
         None,
         "Whether to infer sequence of datetime.time objects as pyarrow time "

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -900,3 +900,12 @@ with cf.config_prefix("future"):
         "(at which point this option will be deprecated).",
         validator=is_one_of_factory([True, False, None]),
     )
+
+    cf.register_option(
+        "future.infer_date",
+        None,
+        "Whether to infer sequence of datetime.date objects as pyarrow date "
+        "dtype, which will be the default in pandas 3.0 "
+        "(at which point this option will be deprecated).",
+        validator=is_one_of_factory([True, False, None]),
+    )

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -392,6 +392,30 @@ def array(
                     stacklevel=find_stack_level(),
                 )
 
+        elif inferred_dtype == "date":
+            opt = get_option("future.infer_date")
+
+            if opt is True:
+                import pyarrow as pa
+
+                obj = pa.array(data)
+                dtype = ArrowDtype(obj.type)
+                return dtype.construct_array_type()(obj)
+            elif opt is False:
+                # explicitly set to keep the old behavior and avoid the warning
+                pass
+            else:
+                warnings.warn(
+                    "Pandas type inference with a sequence of `datetime.date` "
+                    "objects is deprecated. In a future version, this will give "
+                    "date32[pyarrow] dtype, which will require pyarrow to be "
+                    "installed. To opt in to the new behavior immediately set "
+                    "`pd.set_option('future.infer_time', True)`. To keep the "
+                    "old behavior pass `dtype=object`.",
+                    FutureWarning,
+                    stacklevel=find_stack_level(),
+                )
+
     # Pandas overrides NumPy for
     #   1. datetime64[ns,us,ms,s]
     #   2. timedelta64[ns,us,ms,s]

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -51,7 +51,7 @@ from pandas.core.dtypes.common import (
     is_object_dtype,
     pandas_dtype,
 )
-from pandas.core.dtypes.dtypes import PandasDtype
+from pandas.core.dtypes.dtypes import PandasDtype, ArrowDtype
 from pandas.core.dtypes.generic import (
     ABCDataFrame,
     ABCExtensionArray,
@@ -297,7 +297,6 @@ def array(
         PeriodArray,
         TimedeltaArray,
     )
-    from pandas.core.arrays.arrow import ArrowDtype
     from pandas.core.arrays.string_ import StringDtype
 
     if lib.is_scalar(data):

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -14,9 +14,12 @@ from typing import (
     cast,
     overload,
 )
+import warnings
 
 import numpy as np
 from numpy import ma
+
+from pandas._config import get_option
 
 from pandas._libs import lib
 from pandas._libs.tslibs import (
@@ -31,6 +34,7 @@ from pandas._typing import (
     DtypeObj,
     T,
 )
+from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.base import ExtensionDtype
 from pandas.core.dtypes.cast import (
@@ -293,6 +297,7 @@ def array(
         PeriodArray,
         TimedeltaArray,
     )
+    from pandas.core.arrays.arrow import ArrowDtype
     from pandas.core.arrays.string_ import StringDtype
 
     if lib.is_scalar(data):
@@ -359,6 +364,30 @@ def array(
 
         elif inferred_dtype == "boolean":
             return BooleanArray._from_sequence(data, copy=copy)
+
+        elif inferred_dtype == "time":
+            opt = get_option("future.infer_time")
+
+            if opt is True:
+                import pyarrow as pa
+
+                obj = pa.array(data)
+                dtype = ArrowDtype(obj.type)
+                return dtype.construct_array_type()(obj)
+            elif opt is False:
+                # explicitly set to keep the old behavior and avoid the warning
+                pass
+            else:
+                warnings.warn(
+                    "Pandas type inference with a sequence of `datetime.time` "
+                    "objects is deprecated. In a future version, this will give "
+                    "time32[pyarrow] dtype, which will require pyarrow to be "
+                    "installed. To opt in to the new behavior immediately set "
+                    "`pd.set_option('future.infer_time', True)`. To keep the "
+                    "old behavior pass `dtype=object`.",
+                    FutureWarning,
+                    stacklevel=find_stack_level(),
+                )
 
     # Pandas overrides NumPy for
     #   1. datetime64[ns,us,ms,s]

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -300,7 +300,6 @@ def array(
         PeriodArray,
         TimedeltaArray,
     )
-    from pandas.core.arrays.arrow import ArrowDtype
     from pandas.core.arrays.string_ import StringDtype
 
     if lib.is_scalar(data):

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -51,7 +51,10 @@ from pandas.core.dtypes.common import (
     is_object_dtype,
     pandas_dtype,
 )
-from pandas.core.dtypes.dtypes import PandasDtype, ArrowDtype
+from pandas.core.dtypes.dtypes import (
+    ArrowDtype,
+    PandasDtype,
+)
 from pandas.core.dtypes.generic import (
     ABCDataFrame,
     ABCExtensionArray,

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -415,6 +415,30 @@ def array(
                     stacklevel=find_stack_level(),
                 )
 
+        elif inferred_dtype == "bytes":
+            opt = get_option("future.infer_bytes")
+
+            if opt is True:
+                import pyarrow as pa
+
+                obj = pa.array(data)
+                dtype = ArrowDtype(obj.type)
+                return dtype.construct_array_type()(obj)
+            elif opt is False:
+                # explicitly set to keep the old behavior and avoid the warning
+                pass
+            else:
+                warnings.warn(
+                    "Pandas type inference with a sequence of `bytes` "
+                    "objects is deprecated. In a future version, this will give "
+                    "bytes[pyarrow] dtype, which will require pyarrow to be "
+                    "installed. To opt in to the new behavior immediately set "
+                    "`pd.set_option('future.infer_bytes', True)`. To keep the "
+                    "old behavior pass `dtype=object`.",
+                    FutureWarning,
+                    stacklevel=find_stack_level(),
+                )
+
     # Pandas overrides NumPy for
     #   1. datetime64[ns,us,ms,s]
     #   2. timedelta64[ns,us,ms,s]

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -300,6 +300,7 @@ def array(
         PeriodArray,
         TimedeltaArray,
     )
+    from pandas.core.arrays.arrow import ArrowDtype
     from pandas.core.arrays.string_ import StringDtype
 
     if lib.is_scalar(data):

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -843,6 +843,29 @@ def infer_dtype_from_scalar(val) -> tuple[DtypeObj, Any]:
                 pa_dtype = pa.time64("us")
                 dtype = ArrowDtype(pa_dtype)
 
+    elif isinstance(val, dt.time):
+        if val.tzinfo is None:
+            # pyarrow doesn't have a dtype for timetz.
+            opt = get_option("future.infer_time")
+            if opt is None:
+                warnings.warn(
+                    "Pandas type inference with a `datetime.time` "
+                    "object is deprecated. In a future version, this will give "
+                    "time32[pyarrow] dtype, which will require pyarrow to be "
+                    "installed. To opt in to the new behavior immediately set "
+                    "`pd.set_option('future.infer_time', True)`. To keep the "
+                    "old behavior pass `dtype=object`.",
+                    FutureWarning,
+                    stacklevel=find_stack_level(),
+                )
+            elif opt is True:
+                import pyarrow as pa
+
+                pa_dtype = pa.time64("us")
+                from pandas.core.arrays.arrow import ArrowDtype
+
+                dtype = ArrowDtype(pa_dtype)
+
     elif is_bool(val):
         dtype = np.dtype(np.bool_)
 

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -860,7 +860,25 @@ def infer_dtype_from_scalar(val) -> tuple[DtypeObj, Any]:
             import pyarrow as pa
 
             pa_dtype = pa.date32()
+            dtype = ArrowDtype(pa_dtype)
 
+    elif isinstance(val, bytes):
+        opt = get_option("future.infer_bytes")
+        if opt is None:
+            warnings.warn(
+                "Pandas type inference with a `bytes` "
+                "object is deprecated. In a future version, this will give "
+                "bytes[pyarrow] dtype, which will require pyarrow to be "
+                "installed. To opt in to the new behavior immediately set "
+                "`pd.set_option('future.infer_bytes', True)`. To keep the "
+                "old behavior pass `dtype=object`.",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
+        elif opt is True:
+            import pyarrow as pa
+
+            pa_dtype = pa.binary()
             dtype = ArrowDtype(pa_dtype)
 
     elif is_bool(val):

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -841,7 +841,6 @@ def infer_dtype_from_scalar(val) -> tuple[DtypeObj, Any]:
                 import pyarrow as pa
 
                 pa_dtype = pa.time64("us")
-                from pandas.core.arrays.arrow import ArrowDtype
 
                 dtype = ArrowDtype(pa_dtype)
 

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -841,7 +841,6 @@ def infer_dtype_from_scalar(val) -> tuple[DtypeObj, Any]:
                 import pyarrow as pa
 
                 pa_dtype = pa.time64("us")
-
                 dtype = ArrowDtype(pa_dtype)
 
     elif is_bool(val):

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -20,6 +20,8 @@ import warnings
 
 import numpy as np
 
+from pandas._config import get_option
+
 from pandas._libs import lib
 from pandas._libs.missing import (
     NA,
@@ -40,6 +42,7 @@ from pandas.errors import (
     IntCastingNaNError,
     LossySetitemError,
 )
+from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.common import (
     ensure_int8,
@@ -818,6 +821,29 @@ def infer_dtype_from_scalar(val) -> tuple[DtypeObj, Any]:
             else:
                 val = val.asm8
             dtype = val.dtype
+
+    elif isinstance(val, dt.time):
+        if val.tzinfo is None:
+            # pyarrow doesn't have a dtype for timetz.
+            opt = get_option("future.infer_time")
+            if opt is None:
+                warnings.warn(
+                    "Pandas type inference with a `datetime.time` "
+                    "object is deprecated. In a future version, this will give "
+                    "time32[pyarrow] dtype, which will require pyarrow to be "
+                    "installed. To opt in to the new behavior immediately set "
+                    "`pd.set_option('future.infer_time', True)`. To keep the "
+                    "old behavior pass `dtype=object`.",
+                    FutureWarning,
+                    stacklevel=find_stack_level(),
+                )
+            elif opt is True:
+                import pyarrow as pa
+
+                pa_dtype = pa.time64("us")
+                from pandas.core.arrays.arrow import ArrowDtype
+
+                dtype = ArrowDtype(pa_dtype)
 
     elif is_bool(val):
         dtype = np.dtype(np.bool_)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -843,28 +843,25 @@ def infer_dtype_from_scalar(val) -> tuple[DtypeObj, Any]:
                 pa_dtype = pa.time64("us")
                 dtype = ArrowDtype(pa_dtype)
 
-    elif isinstance(val, dt.time):
-        if val.tzinfo is None:
-            # pyarrow doesn't have a dtype for timetz.
-            opt = get_option("future.infer_time")
-            if opt is None:
-                warnings.warn(
-                    "Pandas type inference with a `datetime.time` "
-                    "object is deprecated. In a future version, this will give "
-                    "time32[pyarrow] dtype, which will require pyarrow to be "
-                    "installed. To opt in to the new behavior immediately set "
-                    "`pd.set_option('future.infer_time', True)`. To keep the "
-                    "old behavior pass `dtype=object`.",
-                    FutureWarning,
-                    stacklevel=find_stack_level(),
-                )
-            elif opt is True:
-                import pyarrow as pa
+    elif isinstance(val, dt.date):
+        opt = get_option("future.infer_date")
+        if opt is None:
+            warnings.warn(
+                "Pandas type inference with a `datetime.date` "
+                "object is deprecated. In a future version, this will give "
+                "date32[pyarrow] dtype, which will require pyarrow to be "
+                "installed. To opt in to the new behavior immediately set "
+                "`pd.set_option('future.infer_date', True)`. To keep the "
+                "old behavior pass `dtype=object`.",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
+        elif opt is True:
+            import pyarrow as pa
 
-                pa_dtype = pa.time64("us")
-                from pandas.core.arrays.arrow import ArrowDtype
+            pa_dtype = pa.date32()
 
-                dtype = ArrowDtype(pa_dtype)
+            dtype = ArrowDtype(pa_dtype)
 
     elif is_bool(val):
         dtype = np.dtype(np.bool_)

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -108,7 +108,9 @@ class Properties(PandasDelegate, PandasObject, NoNewAttributesMixin):
         else:
             index = self._parent.index
         # return the result as a Series
-        result = Series(result, index=index, name=self.name).__finalize__(self._parent)
+        result = Series(
+            result, index=index, name=self.name, dtype=result.dtype
+        ).__finalize__(self._parent)
 
         # setting this object will show a SettingWithCopyWarning/Error
         result._is_copy = (

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -101,8 +101,6 @@ class Properties(PandasDelegate, PandasObject, NoNewAttributesMixin):
         elif not is_list_like(result):
             return result
 
-        result = np.asarray(result)
-
         if self.orig is not None:
             index = self.orig.index
         else:

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1967,7 +1967,13 @@ class StringMethods(NoNewAttributesMixin):
             f = lambda x: decoder(x, errors)[0]
         arr = self._data.array
         # assert isinstance(arr, (StringArray,))
-        result = arr._str_map(f)
+
+        if isinstance(arr.dtype, ArrowDtype):
+            # TODO: is there a performant way to do this?
+            res_values = arr.map(f)
+            result = type(arr)._from_sequence(res_values)
+        else:
+            result = arr._str_map(f)
         return self._wrap_result(result)
 
     @forbid_nonstring_types(["bytes"])

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -5066,7 +5066,16 @@ def _unconvert_string_array(
         dtype = f"U{itemsize}"
 
         if isinstance(data[0], bytes):
-            data = Series(data, copy=False).str.decode(encoding, errors=errors)._values
+            with warnings.catch_warnings():
+                # Deprecation about inferring bytes to bytes[pyarrow] dtype
+                # TODO: try to avoid this altogether
+                warnings.filterwarnings("ignore", category=FutureWarning)
+
+                data = (
+                    Series(data, copy=False).str.decode(encoding, errors=errors)._values
+                ).astype(object, copy=False)
+                # TODO: if we have pyarrow str instead of object here to begin
+                #  with, can we avoid object dtype cast here?
         else:
             data = data.astype(dtype, copy=False).astype(object, copy=False)
 

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -2910,7 +2910,13 @@ supported types."""
         for i, col in enumerate(data):
             typ = typlist[i]
             if typ <= self._max_string_length:
-                data[col] = data[col].fillna("").apply(_pad_bytes, args=(typ,))
+                with warnings.catch_warnings():
+                    # deprecated behavior with sequence of bytes, will infer
+                    #  to bytes[pyarrow]
+                    # TODO: can we avoid this altogether
+                    warnings.filterwarnings("ignore", category=FutureWarning)
+
+                    data[col] = data[col].fillna("").apply(_pad_bytes, args=(typ,))
                 stype = f"S{typ}"
                 dtypes[col] = stype
                 data[col] = data[col].astype(stype)

--- a/pandas/tests/arithmetic/common.py
+++ b/pandas/tests/arithmetic/common.py
@@ -33,7 +33,9 @@ def assert_cannot_add(left, right, msg="cannot add"):
         right + left
 
 
-def assert_invalid_addsub_type(left, right, msg=None):
+def assert_invalid_addsub_type(
+    left, right, msg=None, can_be_not_implemented: bool = False
+):
     """
     Helper to assert that left and right can be neither added nor subtracted.
 
@@ -42,14 +44,23 @@ def assert_invalid_addsub_type(left, right, msg=None):
     left : object
     right : object
     msg : str or None, default None
+    can_be_not_implemented : bool, default False
+        Whether to accept NotImplementedError in addition to TypeError
     """
-    with pytest.raises(TypeError, match=msg):
+
+    errs = TypeError
+    if can_be_not_implemented:
+        # really we are interested in pa.lib.ArrowNotImplementedError, which
+        #  is a subclass of NotImplementedError
+        errs = (TypeError, NotImplementedError)
+
+    with pytest.raises(errs, match=msg):
         left + right
-    with pytest.raises(TypeError, match=msg):
+    with pytest.raises(errs, match=msg):
         right + left
-    with pytest.raises(TypeError, match=msg):
+    with pytest.raises(errs, match=msg):
         left - right
-    with pytest.raises(TypeError, match=msg):
+    with pytest.raises(errs, match=msg):
         right - left
 
 

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1195,7 +1195,7 @@ class TestDatetime64Arithmetic:
         warn_msg = "Pandas type inference with a sequence of `datetime.time` objects"
         warn = None
         if future is True:
-            msgs.append("cannot subtract DatetimeArray from ArrowExtensionArray")
+            msgs.append(r"Function '(add|subtract)_checked' has no kernel")
         elif future is None:
             warn = FutureWarning
 
@@ -1210,7 +1210,7 @@ class TestDatetime64Arithmetic:
             # we aren't testing that here, so ignore.
             warnings.simplefilter("ignore", PerformanceWarning)
 
-            assert_invalid_addsub_type(obj1, obj2, msg=msg)
+            assert_invalid_addsub_type(obj1, obj2, msg=msg, can_be_not_implemented=True)
 
     # -------------------------------------------------------------
     # Other invalid operations

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1171,11 +1171,17 @@ class TestDatetime64Arithmetic:
         "future", [pytest.param(True, marks=td.skip_if_no("pyarrow")), False, None]
     )
     def test_dt64arr_addsub_time_objects_raises(
-        self, box_with_array, tz_naive_fixture, future
+        self, box_with_array, tz_naive_fixture, future, request
     ):
         # https://github.com/pandas-dev/pandas/issues/10329
 
         tz = tz_naive_fixture
+        if str(tz) == "tzlocal()" and future is True:
+            # TODO(GH#53278)
+            mark = pytest.mark.xfail(
+                reason="Incorrectly raises AttributeError instead of TypeError"
+            )
+            request.node.add_marker(mark)
 
         obj1 = date_range("2012-01-01", periods=3, tz=tz)
         obj2 = [time(i, i, i) for i in range(3)]

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1179,7 +1179,9 @@ class TestDatetime64Arithmetic:
         if str(tz) == "tzlocal()" and future is True:
             # TODO(GH#53278)
             mark = pytest.mark.xfail(
-                reason="Incorrectly raises AttributeError instead of TypeError"
+                reason="Incorrectly raises AttributeError instead of TypeError",
+                # some but not all CI builds
+                strict=False,
             )
             request.node.add_marker(mark)
 

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -20,6 +20,7 @@ import pytz
 from pandas._libs.tslibs.conversion import localize_pydatetime
 from pandas._libs.tslibs.offsets import shift_months
 from pandas.errors import PerformanceWarning
+import pandas.util._test_decorators as td
 
 import pandas as pd
 from pandas import (
@@ -1166,7 +1167,9 @@ class TestDatetime64Arithmetic:
         )
         assert_invalid_addsub_type(dtarr, parr, msg)
 
-    @pytest.mark.parametrize("future", [True, False, None])
+    @pytest.mark.parametrize(
+        "future", [pytest.param(True, marks=td.skip_if_no("pyarrow")), False, None]
+    )
     def test_dt64arr_addsub_time_objects_raises(
         self, box_with_array, tz_naive_fixture, future
     ):

--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -369,7 +369,12 @@ class TestCategoricalConstructors:
         # we dont cast date objects to timestamps, matching Index constructor
         v = date.today()
 
-        cat = Categorical([v, v])
+        msg = (
+            "Pandas type inference with a sequence of `datetime.date` "
+            "objects is deprecated"
+        )
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            cat = Categorical([v, v])
         assert cat.categories.dtype == object
         assert type(cat.categories[0]) is date
 

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -156,7 +156,7 @@ class TestNonNano:
         dta, dti = dta_dti
 
         warn = None
-        msg = "In a future version, this will an array with pyarrow time dtype"
+        msg = "In a future version, this will return an array with pyarrow time dtype"
         if meth == "time":
             warn = FutureWarning
 

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -155,8 +155,14 @@ class TestNonNano:
     def test_time_date(self, dta_dti, meth):
         dta, dti = dta_dti
 
-        result = getattr(dta, meth)
-        expected = getattr(dti, meth)
+        warn = None
+        msg = "In a future version, this will an array with pyarrow time dtype"
+        if meth == "time":
+            warn = FutureWarning
+
+        with tm.assert_produces_warning(warn, match=msg):
+            result = getattr(dta, meth)
+            expected = getattr(dti, meth)
         tm.assert_numpy_array_equal(result, expected)
 
     def test_format_native_types(self, unit, dtype, dta_dti):

--- a/pandas/tests/dtypes/cast/test_infer_dtype.py
+++ b/pandas/tests/dtypes/cast/test_infer_dtype.py
@@ -163,7 +163,14 @@ def test_infer_dtype_from_scalar_errors():
     ],
 )
 def test_infer_dtype_from_scalar(value, expected):
-    dtype, _ = infer_dtype_from_scalar(value)
+    msg = "type inference with a `bytes` object is deprecated"
+    warn = None
+    if isinstance(value, bytes):
+        warn = FutureWarning
+
+    with tm.assert_produces_warning(warn, match=msg):
+        dtype, _ = infer_dtype_from_scalar(value)
+
     assert is_dtype_equal(dtype, expected)
 
     with pytest.raises(TypeError, match="must be list-like"):

--- a/pandas/tests/dtypes/cast/test_infer_dtype.py
+++ b/pandas/tests/dtypes/cast/test_infer_dtype.py
@@ -23,6 +23,7 @@ from pandas import (
     Timestamp,
     date_range,
 )
+import pandas._testing as tm
 
 
 def test_infer_dtype_from_int_scalar(any_int_numpy_dtype):
@@ -102,7 +103,9 @@ def test_infer_dtype_from_period(freq):
 
 def test_infer_dtype_misc():
     dt = date(2000, 1, 1)
-    dtype, val = infer_dtype_from_scalar(dt)
+    msg = "type inference with a `datetime.date` object"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        dtype, val = infer_dtype_from_scalar(dt)
     assert dtype == np.object_
 
     ts = Timestamp(1, tz="US/Eastern")

--- a/pandas/tests/dtypes/cast/test_promote.py
+++ b/pandas/tests/dtypes/cast/test_promote.py
@@ -16,6 +16,7 @@ from pandas.core.dtypes.dtypes import DatetimeTZDtype
 from pandas.core.dtypes.missing import isna
 
 import pandas as pd
+import pandas._testing as tm
 
 
 def _check_promote(dtype, fill_value, expected_dtype, exp_val_for_scalar=None):
@@ -354,12 +355,21 @@ def test_maybe_promote_any_with_datetime64(any_numpy_dtype, fill_value):
         expected_dtype = np.dtype(object)
         exp_val_for_scalar = fill_value
 
+    msg = "type inference with a `datetime.date` object"
+    warn = None
+    if type(fill_value) is datetime.date and any_numpy_dtype in [
+        "datetime64[ns]",
+        "timedelta64[ns]",
+    ]:
+        warn = FutureWarning
+
     if type(fill_value) is datetime.date and dtype.kind == "M":
         # Casting date to dt64 is deprecated, in 2.0 enforced to cast to object
         expected_dtype = np.dtype(object)
         exp_val_for_scalar = fill_value
 
-    _check_promote(dtype, fill_value, expected_dtype, exp_val_for_scalar)
+    with tm.assert_produces_warning(warn, match=msg):
+        _check_promote(dtype, fill_value, expected_dtype, exp_val_for_scalar)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/dtypes/cast/test_promote.py
+++ b/pandas/tests/dtypes/cast/test_promote.py
@@ -311,7 +311,13 @@ def test_maybe_promote_any_with_bytes(any_numpy_dtype):
     # output is not a generic bytes, but corresponds to expected_dtype
     exp_val_for_scalar = np.array([fill_value], dtype=expected_dtype)[0]
 
-    _check_promote(dtype, fill_value, expected_dtype, exp_val_for_scalar)
+    msg = "type inference with a `bytes` object"
+    warn = None
+    if any_numpy_dtype in ["timedelta64[ns]", "datetime64[ns]"]:
+        warn = FutureWarning
+
+    with tm.assert_produces_warning(warn, match=msg):
+        _check_promote(dtype, fill_value, expected_dtype, exp_val_for_scalar)
 
 
 def test_maybe_promote_datetime64_with_any(datetime64_dtype, any_numpy_dtype):
@@ -330,7 +336,13 @@ def test_maybe_promote_datetime64_with_any(datetime64_dtype, any_numpy_dtype):
         expected_dtype = np.dtype(object)
         exp_val_for_scalar = fill_value
 
-    _check_promote(dtype, fill_value, expected_dtype, exp_val_for_scalar)
+    msg = "type inference with a `bytes` object is deprecated"
+    warn = None
+    if any_numpy_dtype is bytes and datetime64_dtype == "datetime64[ns]":
+        warn = FutureWarning
+
+    with tm.assert_produces_warning(warn, match=msg):
+        _check_promote(dtype, fill_value, expected_dtype, exp_val_for_scalar)
 
 
 @pytest.mark.parametrize(
@@ -413,7 +425,13 @@ def test_maybe_promote_timedelta64_with_any(timedelta64_dtype, any_numpy_dtype):
         expected_dtype = np.dtype(object)
         exp_val_for_scalar = fill_value
 
-    _check_promote(dtype, fill_value, expected_dtype, exp_val_for_scalar)
+    msg = "type inference with a `bytes` object is deprecated"
+    warn = None
+    if any_numpy_dtype is bytes and timedelta64_dtype == "timedelta64[ns]":
+        warn = FutureWarning
+
+    with tm.assert_produces_warning(warn, match=msg):
+        _check_promote(dtype, fill_value, expected_dtype, exp_val_for_scalar)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -1037,7 +1037,9 @@ class TestInference:
         )
         tm.assert_extension_array_equal(result, idx._data)
 
-    @pytest.mark.parametrize("future", [True, False, None])
+    @pytest.mark.parametrize(
+        "future", [pytest.param(True, marks=td.skip_if_no("pyarrow")), False, None]
+    )
     def test_maybe_convert_objects_time(self, future):
         ts = Timestamp.now()
         objs = np.array([ts.time()], dtype=object)

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -1037,6 +1037,56 @@ class TestInference:
         )
         tm.assert_extension_array_equal(result, idx._data)
 
+    @pytest.mark.parametrize("future", [True, False, None])
+    def test_maybe_convert_objects_time(self, future):
+        ts = Timestamp.now()
+        objs = np.array([ts.time()], dtype=object)
+
+        msg = "Pandas type inference with a sequence of `datetime.time` objects"
+        warn = None
+        if future is True:
+            pa = pytest.importorskip("pyarrow")
+            dtype = pd.ArrowDtype(pa.time64("us"))
+            exp = dtype.construct_array_type()._from_sequence(objs, dtype=dtype)
+        else:
+            if future is None:
+                warn = FutureWarning
+            exp = objs
+
+        with pd.option_context("future.infer_time", future):
+            with tm.assert_produces_warning(warn, match=msg):
+                out = lib.maybe_convert_objects(objs, convert_time=True)
+            with tm.assert_produces_warning(warn, match=msg):
+                ser = Series(objs)
+            with tm.assert_produces_warning(warn, match=msg):
+                ser2 = Series(list(objs))
+            with tm.assert_produces_warning(warn, match=msg):
+                df = DataFrame(objs)
+            with tm.assert_produces_warning(warn, match=msg):
+                df2 = DataFrame(list(objs))
+            with tm.assert_produces_warning(warn, match=msg):
+                idx = Index(objs)
+            with tm.assert_produces_warning(warn, match=msg):
+                idx2 = Index(list(objs))
+            with tm.assert_produces_warning(warn, match=msg):
+                arr = pd.array(objs)
+            with tm.assert_produces_warning(warn, match=msg):
+                arr2 = pd.array(list(objs))
+
+        tm.assert_equal(out, exp)
+        if future:
+            tm.assert_equal(arr, exp)
+            tm.assert_equal(arr2, exp)
+        else:
+            tm.assert_equal(arr, pd.core.arrays.PandasArray(exp))
+            tm.assert_equal(arr2, pd.core.arrays.PandasArray(exp))
+        tm.assert_series_equal(ser, Series(exp, dtype=exp.dtype))
+        tm.assert_series_equal(ser2, Series(exp, dtype=exp.dtype))
+        tm.assert_frame_equal(df, DataFrame(exp, dtype=exp.dtype))
+        tm.assert_frame_equal(df2, DataFrame(exp, dtype=exp.dtype))
+        tm.assert_index_equal(idx, Index(exp, dtype=exp.dtype))
+        tm.assert_index_equal(idx2, Index(exp, dtype=exp.dtype))
+
 
 class TestTypeInference:
     # Dummy class used for testing with Python objects

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -1564,7 +1564,7 @@ class TestTypeInference:
 
     def test_date(self):
         dates = [date(2012, 1, day) for day in range(1, 20)]
-        index = Index(dates)
+        index = Index(dates, dtype=object)
         assert index.inferred_type == "date"
 
         dates = [date(2012, 1, day) for day in range(1, 20)] + [np.nan]

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -1057,7 +1057,7 @@ class TestInference:
 
         with pd.option_context("future.infer_time", future):
             with tm.assert_produces_warning(warn, match=msg):
-                out = lib.maybe_convert_objects(objs, convert_time=True)
+                out = lib.maybe_convert_objects(objs, convert_non_numeric=True)
             with tm.assert_produces_warning(warn, match=msg):
                 ser = Series(objs)
             with tm.assert_produces_warning(warn, match=msg):

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -716,6 +716,28 @@ class TestBaseReshaping(base.BaseReshapingTests):
     def test_transpose(self, data):
         super().test_transpose(data)
 
+    @pytest.mark.parametrize(
+        "columns",
+        [
+            ["A", "B"],
+            pd.MultiIndex.from_tuples(
+                [("A", "a"), ("A", "b")], names=["outer", "inner"]
+            ),
+        ],
+    )
+    def test_stack(self, data, columns):
+        warn = None
+        warn_msg = "Pandas type inference with a sequence of `datetime.time` objects"
+
+        pa_dtype = data.dtype.pyarrow_dtype
+        if pa.types.is_time(pa_dtype):
+            # FIXME: need to avoid doing inference when calling frame._constructor
+            #  in _stack_multi_columns
+            warn = FutureWarning
+
+        with tm.assert_produces_warning(warn, match=warn_msg, check_stacklevel=False):
+            super().test_stack(data, columns)
+
 
 class TestBaseSetitem(base.BaseSetitemTests):
     @pytest.mark.xfail(
@@ -778,6 +800,18 @@ class TestBaseUnaryOps(base.BaseUnaryOpsTests):
 
 
 class TestBaseMethods(base.BaseMethodsTests):
+    def test_hash_pandas_object_works(self, data, as_frame):
+        pa_dtype = data.dtype.pyarrow_dtype
+        warn_msg = "Pandas type inference with a sequence of `datetime.time`"
+        warn = None
+        if pa.types.is_time(pa_dtype):
+            # TODO(#48964) This warning will be avoided by implementing
+            #  ArrowExtensionArray.hash_pandas_object
+            warn = FutureWarning
+
+        with tm.assert_produces_warning(warn, match=warn_msg, check_stacklevel=False):
+            super().test_hash_pandas_object_works(data, as_frame)
+
     @pytest.mark.parametrize("periods", [1, -2])
     def test_diff(self, data, periods, request):
         pa_dtype = data.dtype.pyarrow_dtype

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -741,6 +741,9 @@ class TestBaseReshaping(base.BaseReshapingTests):
             warn_msg = (
                 "Pandas type inference with a sequence of `datetime.date` objects"
             )
+        if pa.types.is_binary(pa_dtype):
+            warn = FutureWarning
+            warn_msg = "Pandas type inference with a sequence of `bytes` objects"
 
         with tm.assert_produces_warning(warn, match=warn_msg, check_stacklevel=False):
             super().test_stack(data, columns)
@@ -814,6 +817,9 @@ class TestBaseMethods(base.BaseMethodsTests):
         if pa.types.is_time(pa_dtype) or pa.types.is_date(pa_dtype):
             # TODO(#48964) This warning will be avoided by implementing
             #  ArrowExtensionArray.hash_pandas_object
+            warn = FutureWarning
+        elif pa.types.is_binary(pa_dtype):
+            warn_msg = "Pandas type inference with a sequence of `bytes`"
             warn = FutureWarning
 
         with tm.assert_produces_warning(warn, match=warn_msg, check_stacklevel=False):

--- a/pandas/tests/frame/methods/test_asfreq.py
+++ b/pandas/tests/frame/methods/test_asfreq.py
@@ -186,7 +186,12 @@ class TestAsFreq:
         ts = frame_or_series(np.random.randn(20), index=rng)
 
         ts2 = ts.copy()
-        ts2.index = [x.date() for x in ts2.index]
+        msg = (
+            "Pandas type inference with a sequence of `datetime.date` "
+            "objects is deprecated"
+        )
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            ts2.index = [x.date() for x in ts2.index]
 
         result = ts2.asfreq("4H", method="ffill")
         expected = ts.asfreq("4H", method="ffill")

--- a/pandas/tests/frame/methods/test_filter.py
+++ b/pandas/tests/frame/methods/test_filter.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+import pandas.util._test_decorators as td
+
 import pandas as pd
 from pandas import DataFrame
 import pandas._testing as tm
@@ -112,11 +114,18 @@ class TestDataFrameFilter:
         tm.assert_frame_equal(df.filter(like=name), expected)
         tm.assert_frame_equal(df.filter(regex=name), expected)
 
+    @pytest.mark.parametrize(
+        "future", [pytest.param(True, marks=td.skip_if_no("pyarrow")), False, None]
+    )
     @pytest.mark.parametrize("name", ["a", "a"])
-    def test_filter_bytestring(self, name):
+    def test_filter_bytestring(self, name, future):
         # GH13101
-        df = DataFrame({b"a": [1, 2], b"b": [3, 4]})
-        expected = DataFrame({b"a": [1, 2]})
+        warn = FutureWarning if future is None else None
+        msg = "type inference with a sequence of `bytes` objects"
+        with tm.assert_produces_warning(warn, match=msg):
+            with pd.option_context("future.infer_bytes", future):
+                df = DataFrame({b"a": [1, 2], b"b": [3, 4]})
+                expected = DataFrame({b"a": [1, 2]})
 
         tm.assert_frame_equal(df.filter(like=name), expected)
         tm.assert_frame_equal(df.filter(regex=name), expected)

--- a/pandas/tests/frame/methods/test_join.py
+++ b/pandas/tests/frame/methods/test_join.py
@@ -510,16 +510,26 @@ class TestDataFrameJoin:
         # GH 33692
         date = pd.Timestamp(2000, 1, 1).date()
 
-        df1_index = MultiIndex.from_tuples([(0, date)], names=["index_0", "date"])
+        msg = (
+            "Pandas type inference with a sequence of `datetime.date` "
+            "objects is deprecated"
+        )
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            df1_index = MultiIndex.from_tuples([(0, date)], names=["index_0", "date"])
         df1 = DataFrame({"col1": [0]}, index=df1_index)
-        df2_index = MultiIndex.from_tuples([(0, date)], names=["index_0", "date"])
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            df2_index = MultiIndex.from_tuples([(0, date)], names=["index_0", "date"])
         df2 = DataFrame({"col2": [0]}, index=df2_index)
-        df3_index = MultiIndex.from_tuples([(0, date)], names=["index_0", "date"])
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            df3_index = MultiIndex.from_tuples([(0, date)], names=["index_0", "date"])
         df3 = DataFrame({"col3": [0]}, index=df3_index)
 
         result = df1.join([df2, df3])
 
-        expected_index = MultiIndex.from_tuples([(0, date)], names=["index_0", "date"])
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            expected_index = MultiIndex.from_tuples(
+                [(0, date)], names=["index_0", "date"]
+            )
         expected = DataFrame(
             {"col1": [0], "col2": [0], "col3": [0]}, index=expected_index
         )

--- a/pandas/tests/frame/methods/test_reindex.py
+++ b/pandas/tests/frame/methods/test_reindex.py
@@ -200,7 +200,9 @@ class TestDataFrameSelectReindex:
         ts = df.iloc[0, 0]
         fv = ts.date()
 
-        res = df.reindex(index=range(4), columns=["A", "B", "C"], fill_value=fv)
+        msg = "type inference with a sequence of `datetime.date` objects is deprecated"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            res = df.reindex(index=range(4), columns=["A", "B", "C"], fill_value=fv)
 
         expected = DataFrame(
             {"A": df["A"].tolist() + [fv], "B": df["B"].tolist() + [fv], "C": [fv] * 4},

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1895,7 +1895,12 @@ class TestDataFrameConstructors:
         datetimes = [ts.to_pydatetime() for ts in ind]
         dates = [ts.date() for ts in ind]
         df = DataFrame(datetimes, columns=["datetimes"])
-        df["dates"] = dates
+        msg = (
+            "Pandas type inference with a sequence of `datetime.date` "
+            "objects is deprecated"
+        )
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            df["dates"] = dates
         result = df.dtypes
         expected = Series(
             [np.dtype("datetime64[ns]"), np.dtype("object")],
@@ -2361,7 +2366,12 @@ class TestDataFrameConstructors:
         # GH 10863
         v = date.today()
         tup = v, v
-        result = DataFrame({tup: Series(range(3), index=range(3))}, columns=[tup])
+        msg = (
+            "Pandas type inference with a sequence of `datetime.date` "
+            "objects is deprecated"
+        )
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            result = DataFrame({tup: Series(range(3), index=range(3))}, columns=[tup])
         expected = DataFrame([0, 1, 2], columns=Index(Series([tup])))
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -3154,6 +3154,40 @@ class TestFromScalar:
         with pytest.raises(err, match=msg):
             constructor(ts, dtype="M8[ns]")
 
+    @pytest.mark.parametrize(
+        "future", [pytest.param(True, marks=td.skip_if_no("pyarrow")), False, None]
+    )
+    def test_from_pytime(self, constructor, box, frame_or_series, future):
+        item = Timestamp("2023-05-04 08:53").time()
+
+        warn = None
+        if box is list or (box is dict and frame_or_series is Series):
+            msg = (
+                "Pandas type inference with a sequence of `datetime.time` "
+                "objects is deprecated"
+            )
+        else:
+            msg = "Pandas type inference with a `datetime.time` object is deprecated"
+        exp_dtype = np.dtype(object)
+        if future is None:
+            warn = FutureWarning
+        elif future is True:
+            import pyarrow as pa
+
+            pa_type = pa.time64("us")
+            exp_dtype = pd.ArrowDtype(pa_type)
+
+        with pd.option_context("future.infer_time", future):
+            with tm.assert_produces_warning(warn, match=msg):
+                result = constructor(item)
+        dtype = tm.get_dtype(result)
+        assert dtype == exp_dtype
+
+        aware = Timestamp("2023-05-04 08:53", tz="US/Pacific").timetz()
+        result2 = constructor(aware)
+        dtype = tm.get_dtype(result2)
+        assert dtype == np.dtype(object)
+
 
 # TODO: better location for this test?
 class TestAllowNonNano:

--- a/pandas/tests/generic/test_finalize.py
+++ b/pandas/tests/generic/test_finalize.py
@@ -673,7 +673,7 @@ def test_datetime_property(attr):
     s.attrs = {"a": 1}
 
     warn = None
-    msg = "In a future version, this will an array with pyarrow time dtype"
+    msg = "In a future version, this will return an array with pyarrow time dtype"
     if attr == "time":
         warn = FutureWarning
     with tm.assert_produces_warning(warn, match=msg):

--- a/pandas/tests/generic/test_finalize.py
+++ b/pandas/tests/generic/test_finalize.py
@@ -671,7 +671,14 @@ def test_datetime_method(method):
 def test_datetime_property(attr):
     s = pd.Series(pd.date_range("2000", periods=4))
     s.attrs = {"a": 1}
-    result = getattr(s.dt, attr)
+
+    warn = None
+    msg = "In a future version, this will an array with pyarrow time dtype"
+    if attr == "time":
+        warn = FutureWarning
+    with tm.assert_produces_warning(warn, match=msg):
+        result = getattr(s.dt, attr)
+
     assert result.attrs == {"a": 1}
 
 

--- a/pandas/tests/groupby/aggregate/test_other.py
+++ b/pandas/tests/groupby/aggregate/test_other.py
@@ -68,19 +68,22 @@ def test_agg_datetimes_mixed():
         for row in data
     ]
 
-    df2 = DataFrame(
-        {
-            "key": [x[0] for x in data],
-            "date": [x[1] for x in data],
-            "value": [x[2] for x in data],
-        }
-    )
+    msg = "Pandas type inference with a sequence of `datetime.date` objects"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        df2 = DataFrame(
+            {
+                "key": [x[0] for x in data],
+                "date": [x[1] for x in data],
+                "value": [x[2] for x in data],
+            }
+        )
 
     df1["weights"] = df1["value"] / df1["value"].sum()
     gb1 = df1.groupby("date").aggregate(np.sum)
 
     df2["weights"] = df1["value"] / df1["value"].sum()
-    gb2 = df2.groupby("date").aggregate(np.sum)
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        gb2 = df2.groupby("date").aggregate(np.sum)
 
     assert len(gb1) == len(gb2)
 
@@ -367,22 +370,25 @@ def test_agg_consistency():
     def P1(a):
         return np.percentile(a.dropna(), q=1)
 
-    df = DataFrame(
-        {
-            "col1": [1, 2, 3, 4],
-            "col2": [10, 25, 26, 31],
-            "date": [
-                dt.date(2013, 2, 10),
-                dt.date(2013, 2, 10),
-                dt.date(2013, 2, 11),
-                dt.date(2013, 2, 11),
-            ],
-        }
-    )
+    msg = "Pandas type inference with a sequence of `datetime.date` objects"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        df = DataFrame(
+            {
+                "col1": [1, 2, 3, 4],
+                "col2": [10, 25, 26, 31],
+                "date": [
+                    dt.date(2013, 2, 10),
+                    dt.date(2013, 2, 10),
+                    dt.date(2013, 2, 11),
+                    dt.date(2013, 2, 11),
+                ],
+            }
+        )
 
     g = df.groupby("date")
 
-    expected = g.agg([P1])
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        expected = g.agg([P1])
     expected.columns = expected.columns.levels[0]
 
     result = g.agg(P1)

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -1,6 +1,7 @@
 from datetime import (
     date,
     datetime,
+    time,
 )
 from io import StringIO
 
@@ -836,7 +837,16 @@ def test_apply_datetime_issue(group_column_dtlike):
     #   is a datetime object and the column labels are different from
     #   standard int values in range(len(num_columns))
 
-    df = DataFrame({"a": ["foo"], "b": [group_column_dtlike]})
+    warn = None
+    warn_msg = (
+        "Pandas type inference with a sequence of `datetime.time` "
+        "objects is deprecated"
+    )
+    if isinstance(group_column_dtlike, time):
+        warn = FutureWarning
+
+    with tm.assert_produces_warning(warn, match=warn_msg):
+        df = DataFrame({"a": ["foo"], "b": [group_column_dtlike]})
     result = df.groupby("a").apply(lambda x: Series(["spam"], index=[42]))
 
     expected = DataFrame(

--- a/pandas/tests/groupby/test_min_max.py
+++ b/pandas/tests/groupby/test_min_max.py
@@ -67,13 +67,16 @@ def test_min_date_with_nans():
     ).dt.date
     df = DataFrame({"a": [np.nan, "1", np.nan], "b": [0, 1, 1], "c": dates})
 
-    result = df.groupby("b", as_index=False)["c"].min()["c"]
+    msg = "Pandas type inference with a sequence of `datetime.date` objects"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        result = df.groupby("b", as_index=False)["c"].min()["c"]
     expected = pd.to_datetime(
         Series(["2019-05-09", "2019-05-09"], name="c"), format="%Y-%m-%d"
     ).dt.date
     tm.assert_series_equal(result, expected)
 
-    result = df.groupby("b")["c"].min()
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        result = df.groupby("b")["c"].min()
     expected.index.name = "b"
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/groupby/test_nunique.py
+++ b/pandas/tests/groupby/test_nunique.py
@@ -156,7 +156,12 @@ def test_nunique_with_timegrouper():
 )
 def test_nunique_with_NaT(key, data, dropna, expected):
     # GH 27951
-    df = DataFrame({"key": key, "data": data})
+    msg = "Pandas type inference with a sequence of `datetime.date` objects"
+    warn = None
+    if type(data[0]) is dt.date:
+        warn = FutureWarning
+    with tm.assert_produces_warning(warn, match=msg):
+        df = DataFrame({"key": key, "data": data})
     result = df.groupby(["key"])["data"].nunique(dropna=dropna)
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/indexes/categorical/test_astype.py
+++ b/pandas/tests/indexes/categorical/test_astype.py
@@ -78,12 +78,15 @@ class TestAstype:
         # astype to categorical and back should preserve date objects
         v = date.today()
 
-        obj = Index([v, v])
+        msg = "Pandas type inference with a sequence of `datetime.date` objects"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            obj = Index([v, v])
         assert obj.dtype == object
         if box:
             obj = obj.array
 
-        cat = obj.astype("category")
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            cat = obj.astype("category")
 
         rtrip = cat.astype(object)
         assert rtrip.dtype == object

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -513,7 +513,9 @@ class TestGetIndexer:
     def test_get_indexer_date_objs(self):
         rng = date_range("1/1/2000", periods=20)
 
-        result = rng.get_indexer(rng.map(lambda x: x.date()))
+        msg = "Pandas type inference with a sequence of `datetime.date` objects"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            result = rng.get_indexer(rng.map(lambda x: x.date()))
         expected = rng.get_indexer(rng)
         tm.assert_numpy_array_equal(result, expected)
 
@@ -568,7 +570,9 @@ class TestGetIndexer:
     def test_get_indexer_mixed_dtypes(self, target):
         # https://github.com/pandas-dev/pandas/issues/33741
         values = DatetimeIndex([Timestamp("2020-01-01"), Timestamp("2020-01-02")])
-        result = values.get_indexer(target)
+        msg = "Pandas type inference with a sequence of `datetime.date` objects"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            result = values.get_indexer(target)
         expected = np.array([0, 1], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
 
@@ -583,7 +587,9 @@ class TestGetIndexer:
     def test_get_indexer_out_of_bounds_date(self, target, positions):
         values = DatetimeIndex([Timestamp("2020-01-01"), Timestamp("2020-01-02")])
 
-        result = values.get_indexer(target)
+        msg = "Pandas type inference with a sequence of `datetime.date` objects"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            result = values.get_indexer(target)
         expected = np.array(positions, dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
 

--- a/pandas/tests/indexes/datetimes/test_scalar_compat.py
+++ b/pandas/tests/indexes/datetimes/test_scalar_compat.py
@@ -24,7 +24,9 @@ import pandas._testing as tm
 class TestDatetimeIndexOps:
     def test_dti_time(self):
         rng = date_range("1/1/2000", freq="12min", periods=10)
-        result = pd.Index(rng).time
+        msg = "In a future version, this will an array with pyarrow time dtype"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            result = pd.Index(rng).time
         expected = [t.time() for t in rng]
         assert (result == expected).all()
 

--- a/pandas/tests/indexes/datetimes/test_scalar_compat.py
+++ b/pandas/tests/indexes/datetimes/test_scalar_compat.py
@@ -24,7 +24,7 @@ import pandas._testing as tm
 class TestDatetimeIndexOps:
     def test_dti_time(self):
         rng = date_range("1/1/2000", freq="12min", periods=10)
-        msg = "In a future version, this will an array with pyarrow time dtype"
+        msg = "In a future version, this will return an array with pyarrow time dtype"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             result = pd.Index(rng).time
         expected = [t.time() for t in rng]

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -854,7 +854,7 @@ class TestDatetimeIndexTimezones:
 
         index = DatetimeIndex(["2018-06-04 10:20:30", pd.NaT], dtype=dtype)
 
-        msg = "In a future version, this will an array with pyarrow time dtype"
+        msg = "In a future version, this will return an array with pyarrow time dtype"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             result = index.time
 

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -853,7 +853,10 @@ class TestDatetimeIndexTimezones:
         expected = np.array([time(10, 20, 30), pd.NaT])
 
         index = DatetimeIndex(["2018-06-04 10:20:30", pd.NaT], dtype=dtype)
-        result = index.time
+
+        msg = "In a future version, this will an array with pyarrow time dtype"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            result = index.time
 
         tm.assert_numpy_array_equal(result, expected)
 

--- a/pandas/tests/indexes/multi/test_constructors.py
+++ b/pandas/tests/indexes/multi/test_constructors.py
@@ -801,7 +801,9 @@ def test_datetimeindex():
 
     # but NOT date objects, matching Index behavior
     date4 = date.today()
-    index = MultiIndex.from_product([[date4], [date2]])
+    msg = "Pandas type inference with a sequence of `datetime.date` objects"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        index = MultiIndex.from_product([[date4], [date2]])
     assert not isinstance(index.levels[0], pd.DatetimeIndex)
     assert isinstance(index.levels[1], pd.DatetimeIndex)
 
@@ -829,23 +831,27 @@ def test_constructor_with_tz():
 
 def test_multiindex_inference_consistency():
     # check that inference behavior matches the base class
-
+    msg = "Pandas type inference with a sequence of `datetime.date` objects"
     v = date.today()
 
     arr = [v, v]
 
-    idx = Index(arr)
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        idx = Index(arr)
     assert idx.dtype == object
 
-    mi = MultiIndex.from_arrays([arr])
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        mi = MultiIndex.from_arrays([arr])
     lev = mi.levels[0]
     assert lev.dtype == object
 
-    mi = MultiIndex.from_product([arr])
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        mi = MultiIndex.from_product([arr])
     lev = mi.levels[0]
     assert lev.dtype == object
 
-    mi = MultiIndex.from_tuples([(x,) for x in arr])
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        mi = MultiIndex.from_tuples([(x,) for x in arr])
     lev = mi.levels[0]
     assert lev.dtype == object
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1443,7 +1443,10 @@ class TestLocBaseIndependent:
         df.loc[0:1, "c"] = np.datetime64("2008-08-08")
         assert Timestamp("2008-08-08") == df.loc[0, "c"]
         assert Timestamp("2008-08-08") == df.loc[1, "c"]
-        df.loc[2, "c"] = date(2005, 5, 5)
+
+        warn_msg = "type inference with a `datetime.date` object"
+        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+            df.loc[2, "c"] = date(2005, 5, 5)
         assert Timestamp("2005-05-05").date() == df.loc[2, "c"]
 
     @pytest.mark.parametrize("idxer", ["var", ["var"]])

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -993,13 +993,17 @@ class TestReaders:
                     time(16, 37, 0, 900000),
                     time(18, 20, 54),
                 ]
-            }
+            },
+            dtype=object,
         )
 
-        actual = pd.read_excel("times_1900" + read_ext, sheet_name="Sheet1")
+        warn_msg = "Pandas type inference with a sequence of `datetime.time` objects"
+        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+            actual = pd.read_excel("times_1900" + read_ext, sheet_name="Sheet1")
         tm.assert_frame_equal(actual, expected)
 
-        actual = pd.read_excel("times_1904" + read_ext, sheet_name="Sheet1")
+        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+            actual = pd.read_excel("times_1904" + read_ext, sheet_name="Sheet1")
         tm.assert_frame_equal(actual, expected)
 
     def test_read_excel_multiindex(self, request, read_ext):

--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -633,7 +633,7 @@ class TestExcelWriter:
 
         tsf = tsframe.copy()
 
-        tsf.index = [x.date() for x in tsframe.index]
+        tsf.index = Index([x.date() for x in tsframe.index], dtype=object)
         tsf.to_excel(path, "test1", merge_cells=merge_cells)
 
         with ExcelFile(path) as reader:

--- a/pandas/tests/io/formats/test_to_string.py
+++ b/pandas/tests/io/formats/test_to_string.py
@@ -13,6 +13,7 @@ from pandas import (
     option_context,
     to_datetime,
 )
+import pandas._testing as tm
 
 
 def test_repr_embedded_ndarray():
@@ -172,10 +173,13 @@ def test_to_string_unicode_columns(float_frame):
 
 
 def test_to_string_utf8_columns():
+    msg = "type inference with a sequence of `bytes` objects"
+
     n = "\u05d0".encode()
 
     with option_context("display.max_rows", 1):
-        df = DataFrame([1, 2], columns=[n])
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            df = DataFrame([1, 2], columns=[n])
         repr(df)
 
 

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -836,7 +836,13 @@ class TestPandasContainer:
         if as_object:
             data.append("a")
 
-        ser = Series(data, index=data)
+        msg = "Pandas type inference with a sequence of `datetime.date` objects"
+        warn = None
+        if date_typ is datetime.date and not as_object:
+            warn = FutureWarning
+
+        with tm.assert_produces_warning(warn, match=msg):
+            ser = Series(data, index=data)
         result = ser.to_json(date_format=date_format)
 
         if date_format == "epoch":

--- a/pandas/tests/io/parser/dtypes/test_categorical.py
+++ b/pandas/tests/io/parser/dtypes/test_categorical.py
@@ -264,7 +264,14 @@ def test_categorical_coerces_timestamp(all_parsers):
     data = "b\n2014-01-01\n2014-01-01"
     expected = DataFrame({"b": Categorical([Timestamp("2014")] * 2)})
 
-    result = parser.read_csv(StringIO(data), dtype=dtype)
+    msg = (
+        "Pandas type inference with a sequence of `datetime.date` objects is deprecated"
+    )
+    warn = None
+    if parser.engine == "pyarrow":
+        warn = FutureWarning
+    with tm.assert_produces_warning(warn, match=msg, check_stacklevel=False):
+        result = parser.read_csv(StringIO(data), dtype=dtype)
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -479,7 +479,7 @@ KORD,19990127 22:00:00, 21:56:00, -0.5900, 1.7100, 5.1000, 0.0000, 290.0000
     if parser.engine == "pyarrow":
         # https://github.com/pandas-dev/pandas/issues/44231
         # pyarrow 6.0 starts to infer time type
-        msg = "In a future version, this will an array with pyarrow time dtype"
+        msg = "In a future version, this will return an array with pyarrow time dtype"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             expected["X2"] = pd.to_datetime("1970-01-01" + expected["X2"]).dt.time
 

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -479,7 +479,9 @@ KORD,19990127 22:00:00, 21:56:00, -0.5900, 1.7100, 5.1000, 0.0000, 290.0000
     if parser.engine == "pyarrow":
         # https://github.com/pandas-dev/pandas/issues/44231
         # pyarrow 6.0 starts to infer time type
-        expected["X2"] = pd.to_datetime("1970-01-01" + expected["X2"]).dt.time
+        msg = "In a future version, this will an array with pyarrow time dtype"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            expected["X2"] = pd.to_datetime("1970-01-01" + expected["X2"]).dt.time
 
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -1621,10 +1621,12 @@ def test_generic(all_parsers):
         parse_dates={"ym": [0, 1]},
         date_parser=parse_function,
     )
-    expected = DataFrame(
-        [[date(2001, 1, 1), 10, 10.0], [date(2001, 2, 1), 1, 11.0]],
-        columns=["ym", "day", "a"],
-    )
+    msg = "Pandas type inference with a sequence of `datetime.date` objects"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        expected = DataFrame(
+            [[date(2001, 1, 1), 10, 10.0], [date(2001, 2, 1), 1, 11.0]],
+            columns=["ym", "day", "a"],
+        )
     expected["ym"] = expected["ym"].astype("datetime64[ns]")
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/io/pytables/test_errors.py
+++ b/pandas/tests/io/pytables/test_errors.py
@@ -56,13 +56,15 @@ def test_table_index_incompatible_dtypes(setup_path):
 
 
 def test_unimplemented_dtypes_table_columns(setup_path):
+    warn_msg = "type inference with a `datetime.date` object"
     with ensure_clean_store(setup_path) as store:
         dtypes = [("date", datetime.date(2001, 1, 2))]
 
         # currently not supported dtypes ####
         for n, f in dtypes:
             df = tm.makeDataFrame()
-            df[n] = f
+            with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+                df[n] = f
             msg = re.escape(f"[{n}] is not implemented as a table column")
             with pytest.raises(TypeError, match=msg):
                 store.append(f"df1_{n}", df)
@@ -71,7 +73,8 @@ def test_unimplemented_dtypes_table_columns(setup_path):
     df = tm.makeDataFrame()
     df["obj1"] = "foo"
     df["obj2"] = "bar"
-    df["datetime1"] = datetime.date(2001, 1, 2)
+    with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+        df["datetime1"] = datetime.date(2001, 1, 2)
     df = df._consolidate()
 
     with ensure_clean_store(setup_path) as store:

--- a/pandas/tests/io/pytables/test_round_trip.py
+++ b/pandas/tests/io/pytables/test_round_trip.py
@@ -407,6 +407,7 @@ def test_empty_series(dtype, setup_path):
 
 def test_can_serialize_dates(setup_path):
     rng = [x.date() for x in bdate_range("1/1/2000", "1/30/2000")]
+    rng = Index(rng, dtype=object)
     frame = DataFrame(np.random.randn(len(rng), 4), index=rng)
 
     _check_roundtrip(frame, tm.assert_frame_equal, path=setup_path)

--- a/pandas/tests/io/pytables/test_timezones.py
+++ b/pandas/tests/io/pytables/test_timezones.py
@@ -277,10 +277,12 @@ def test_store_timezone(setup_path):
     # issue storing datetime.date with a timezone as it resets when read
     # back in a new timezone
 
+    today = date(2013, 9, 10)
+    idx = pd.Index([today, today, today], dtype=object)
+
     # original method
     with ensure_clean_store(setup_path) as store:
-        today = date(2013, 9, 10)
-        df = DataFrame([1, 2, 3], index=[today, today, today])
+        df = DataFrame([1, 2, 3], index=idx)
         store["obj1"] = df
         result = store["obj1"]
         tm.assert_frame_equal(result, df)
@@ -288,8 +290,7 @@ def test_store_timezone(setup_path):
     # with tz setting
     with ensure_clean_store(setup_path) as store:
         with tm.set_timezone("EST5EDT"):
-            today = date(2013, 9, 10)
-            df = DataFrame([1, 2, 3], index=[today, today, today])
+            df = DataFrame([1, 2, 3], index=idx)
             store["obj1"] = df
 
         with tm.set_timezone("CST6CDT"):

--- a/pandas/tests/io/test_orc.py
+++ b/pandas/tests/io/test_orc.py
@@ -153,7 +153,9 @@ def test_orc_reader_date_low(dirpath):
             dtype="object",
         ),
     }
-    expected = pd.DataFrame.from_dict(data)
+    msg = "Pandas type inference with a sequence of `datetime.date` objects"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        expected = pd.DataFrame.from_dict(data)
 
     inputfile = os.path.join(dirpath, "TestOrcFile.testDate1900.orc")
     got = read_orc(inputfile).iloc[:10]
@@ -194,7 +196,9 @@ def test_orc_reader_date_high(dirpath):
             dtype="object",
         ),
     }
-    expected = pd.DataFrame.from_dict(data)
+    msg = "Pandas type inference with a sequence of `datetime.date` objects"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        expected = pd.DataFrame.from_dict(data)
 
     inputfile = os.path.join(dirpath, "TestOrcFile.testDate2038.orc")
     got = read_orc(inputfile).iloc[:10]

--- a/pandas/tests/io/test_orc.py
+++ b/pandas/tests/io/test_orc.py
@@ -82,7 +82,8 @@ def test_orc_reader_basic(dirpath):
         "long1": np.array([9223372036854775807, 9223372036854775807], dtype="int64"),
         "float1": np.array([1.0, 2.0], dtype="float32"),
         "double1": np.array([-15.0, -5.0], dtype="float64"),
-        "bytes1": np.array([b"\x00\x01\x02\x03\x04", b""], dtype="object"),
+        # TODO: same thing with bytes[pyarrow]
+        "bytes1": pd.Series([b"\x00\x01\x02\x03\x04", b""], dtype="object"),
         "string1": np.array(["hi", "bye"], dtype="object"),
     }
     expected = pd.DataFrame.from_dict(data)
@@ -259,7 +260,8 @@ def test_orc_roundtrip_file(dirpath):
         "long1": np.array([9223372036854775807, 9223372036854775807], dtype="int64"),
         "float1": np.array([1.0, 2.0], dtype="float32"),
         "double1": np.array([-15.0, -5.0], dtype="float64"),
-        "bytes1": np.array([b"\x00\x01\x02\x03\x04", b""], dtype="object"),
+        # TODO: same thing with bytes[pyarrow] dtype
+        "bytes1": pd.Series([b"\x00\x01\x02\x03\x04", b""], dtype="object"),
         "string1": np.array(["hi", "bye"], dtype="object"),
     }
     expected = pd.DataFrame.from_dict(data)
@@ -283,7 +285,8 @@ def test_orc_roundtrip_bytesio():
         "long1": np.array([9223372036854775807, 9223372036854775807], dtype="int64"),
         "float1": np.array([1.0, 2.0], dtype="float32"),
         "double1": np.array([-15.0, -5.0], dtype="float64"),
-        "bytes1": np.array([b"\x00\x01\x02\x03\x04", b""], dtype="object"),
+        # TODO: same thing with bytes[pyarrow] dtype
+        "bytes1": pd.Series([b"\x00\x01\x02\x03\x04", b""], dtype="object"),
         "string1": np.array(["hi", "bye"], dtype="object"),
     }
     expected = pd.DataFrame.from_dict(data)

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -122,7 +122,8 @@ def df_full():
             "string": list("abc"),
             "string_with_nan": ["a", np.nan, "c"],
             "string_with_none": ["a", None, "c"],
-            "bytes": [b"foo", b"bar", b"baz"],
+            # TODO: same thing with bytes[pyarrow] here
+            "bytes": pd.Series([b"foo", b"bar", b"baz"], dtype=object),
             "unicode": ["foo", "bar", "baz"],
             "int": list(range(1, 4)),
             "uint": np.arange(3, 6).astype("u1"),
@@ -1054,7 +1055,7 @@ class TestParquetPyArrow(Base):
         check_round_trip(df, pa)
 
         # bytes
-        df.columns = [b"foo", b"bar"]
+        df.columns = pd.Index([b"foo", b"bar"], dtype=object)
         with pytest.raises(NotImplementedError, match="|S3"):
             # Bytes fails on read_parquet
             check_round_trip(df, pa)
@@ -1093,7 +1094,7 @@ class TestParquetFastParquet(Base):
         self.check_error_on_write(df, fp, err, msg)
 
         # bytes
-        df.columns = [b"foo", b"bar"]
+        df.columns = pd.Index([b"foo", b"bar"], dtype=object)
         self.check_error_on_write(df, fp, err, msg)
 
         # python object

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -2239,9 +2239,12 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
 
     def test_datetime_date(self):
         # test support for datetime.date
-        df = DataFrame([date(2014, 1, 1), date(2014, 1, 2)], columns=["a"])
+        msg = "Pandas type inference with a sequence of `datetime.date` objects"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            df = DataFrame([date(2014, 1, 1), date(2014, 1, 2)], columns=["a"])
         assert df.to_sql("test_date", self.conn, index=False) == 2
-        res = read_sql_table("test_date", self.conn)
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            res = read_sql_table("test_date", self.conn)
         result = res["a"]
         expected = to_datetime(df["a"])
         # comes back as datetime64
@@ -3099,7 +3102,9 @@ class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest):
 
     def test_datetime_date(self):
         # test support for datetime.date
-        df = DataFrame([date(2014, 1, 1), date(2014, 1, 2)], columns=["a"])
+        msg = "Pandas type inference with a sequence of `datetime.date` objects"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            df = DataFrame([date(2014, 1, 1), date(2014, 1, 2)], columns=["a"])
         assert df.to_sql("test_date", self.conn, index=False) == 2
         res = read_sql_query("SELECT * FROM test_date", self.conn)
         if self.flavor == "sqlite":
@@ -3112,7 +3117,7 @@ class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest):
     def test_datetime_time(self, tz_aware):
         # test support for datetime.time, GH #8341
 
-        warn_msg = "Pandas type inference with a sequence of `datetime.time`"
+        warn_msg = "Pandas type inference with a sequence of `datetime.time` objects"
         if not tz_aware:
             tz_times = [time(9, 0, 0), time(9, 1, 30)]
             warn = FutureWarning

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -3112,16 +3112,15 @@ class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest):
     def test_datetime_time(self, tz_aware):
         # test support for datetime.time, GH #8341
 
+        warn_msg = "Pandas type inference with a sequence of `datetime.time`"
         if not tz_aware:
             tz_times = [time(9, 0, 0), time(9, 1, 30)]
+            warn = FutureWarning
         else:
             tz_dt = date_range("2013-01-01 09:00:00", periods=2, tz="US/Pacific")
             tz_times = Series(tz_dt.to_pydatetime()).map(lambda dt: dt.timetz())
+            warn = None
 
-        warn_msg = "Pandas type inference with a sequence of `datetime.time`"
-        warn = None
-        if not tz_aware:
-            warn = FutureWarning
         with tm.assert_produces_warning(warn, match=warn_msg):
             df = DataFrame(tz_times, columns=["a"])
 

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -2249,9 +2249,14 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
 
     def test_datetime_time(self, sqlite_buildin):
         # test support for datetime.time
-        df = DataFrame([time(9, 0, 0), time(9, 1, 30)], columns=["a"])
+
+        warn_msg = "Pandas type inference with a sequence of `datetime.time`"
+        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+            df = DataFrame([time(9, 0, 0), time(9, 1, 30)], columns=["a"])
         assert df.to_sql("test_time", self.conn, index=False) == 2
-        res = read_sql_table("test_time", self.conn)
+
+        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+            res = read_sql_table("test_time", self.conn)
         tm.assert_frame_equal(res, df)
 
         # GH8341
@@ -2267,7 +2272,9 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
             res = sql.read_sql_query("SELECT * FROM test_time3", self.conn)
             ref = df.map(lambda _: _.strftime("%H:%M:%S.%f"))
             tm.assert_frame_equal(ref, res)
-        res = sql.read_sql_table("test_time3", self.conn)
+
+        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+            res = sql.read_sql_table("test_time3", self.conn)
         tm.assert_frame_equal(df, res)
 
     def test_mixed_dtype_insert(self):
@@ -3104,13 +3111,17 @@ class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest):
     @pytest.mark.parametrize("tz_aware", [False, True])
     def test_datetime_time(self, tz_aware):
         # test support for datetime.time, GH #8341
+
+        warn_msg = "Pandas type inference with a sequence of `datetime.time`"
         if not tz_aware:
             tz_times = [time(9, 0, 0), time(9, 1, 30)]
         else:
             tz_dt = date_range("2013-01-01 09:00:00", periods=2, tz="US/Pacific")
-            tz_times = Series(tz_dt.to_pydatetime()).map(lambda dt: dt.timetz())
+            with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+                tz_times = Series(tz_dt.to_pydatetime()).map(lambda dt: dt.timetz())
 
-        df = DataFrame(tz_times, columns=["a"])
+        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+            df = DataFrame(tz_times, columns=["a"])
 
         assert df.to_sql("test_time", self.conn, index=False) == 2
         res = read_sql_query("SELECT * FROM test_time", self.conn)

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -3112,15 +3112,17 @@ class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest):
     def test_datetime_time(self, tz_aware):
         # test support for datetime.time, GH #8341
 
-        warn_msg = "Pandas type inference with a sequence of `datetime.time`"
         if not tz_aware:
             tz_times = [time(9, 0, 0), time(9, 1, 30)]
         else:
             tz_dt = date_range("2013-01-01 09:00:00", periods=2, tz="US/Pacific")
-            with tm.assert_produces_warning(FutureWarning, match=warn_msg):
-                tz_times = Series(tz_dt.to_pydatetime()).map(lambda dt: dt.timetz())
+            tz_times = Series(tz_dt.to_pydatetime()).map(lambda dt: dt.timetz())
 
-        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+        warn_msg = "Pandas type inference with a sequence of `datetime.time`"
+        warn = None
+        if not tz_aware:
+            warn = FutureWarning
+        with tm.assert_produces_warning(warn, match=warn_msg):
             df = DataFrame(tz_times, columns=["a"])
 
         assert df.to_sql("test_time", self.conn, index=False) == 2

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -1230,9 +1230,12 @@ class TestDataFramePlots:
         assert result[expected][0].get_color() == "C1"
 
     def test_unordered_ts(self):
+        idx = pd.Index(
+            [date(2012, 10, 1), date(2012, 9, 1), date(2012, 8, 1)], dtype=object
+        )
         df = DataFrame(
             np.array([3.0, 2.0, 1.0]),
-            index=[date(2012, 10, 1), date(2012, 9, 1), date(2012, 8, 1)],
+            index=idx,
             columns=["test"],
         )
         ax = df.plot()

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -673,11 +673,25 @@ class TestDataFramePlots:
     def test_raise_error_on_datetime_time_data(self):
         # GH 8113, datetime.time type is not supported by matplotlib in scatter
         df = DataFrame(np.random.randn(10), columns=["a"])
-        df["dtime"] = date_range(start="2014-01-01", freq="h", periods=10).time
+        warn_msg = (
+            "Pandas type inference with a sequence of `datetime.time` "
+            "objects is deprecated"
+        )
+
+        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+            df["dtime"] = date_range(start="2014-01-01", freq="h", periods=10).time
+
         msg = "must be a string or a (real )?number, not 'datetime.time'"
 
         with pytest.raises(TypeError, match=msg):
-            df.plot(kind="scatter", x="dtime", y="a")
+            with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+                # warns bc it calls infer_objects inside df.plot
+                df.plot(kind="scatter", x="dtime", y="a")
+
+        with pd.option_context("future.infer_time", True):
+            with pytest.raises(TypeError, match=msg):
+                with tm.assert_produces_warning(None):
+                    df.plot(kind="scatter", x="dtime", y="a")
 
     def test_scatterplot_datetime_data(self):
         # GH 30391

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -1008,6 +1008,7 @@ class TestTSPlot:
         t = datetime(1, 1, 1, 3, 30, 0)
         deltas = np.random.randint(1, 20, 3).cumsum()
         ts = np.array([(t + timedelta(minutes=int(x))).time() for x in deltas])
+        ts = Index(ts, dtype=object)
         df = DataFrame(
             {"a": np.random.randn(len(ts)), "b": np.random.randn(len(ts))}, index=ts
         )
@@ -1031,7 +1032,10 @@ class TestTSPlot:
     def test_time_change_xlim(self):
         t = datetime(1, 1, 1, 3, 30, 0)
         deltas = np.random.randint(1, 20, 3).cumsum()
-        ts = np.array([(t + timedelta(minutes=int(x))).time() for x in deltas])
+        ts = Index(
+            np.array([(t + timedelta(minutes=int(x))).time() for x in deltas]),
+            dtype=object,
+        )
         df = DataFrame(
             {"a": np.random.randn(len(ts)), "b": np.random.randn(len(ts))}, index=ts
         )
@@ -1073,6 +1077,7 @@ class TestTSPlot:
         t = datetime(1, 1, 1, 3, 30, 0)
         deltas = np.random.randint(1, 20, 3).cumsum()
         ts = np.array([(t + timedelta(microseconds=int(x))).time() for x in deltas])
+        ts = Index(ts, dtype=object)
         df = DataFrame(
             {"a": np.random.randn(len(ts)), "b": np.random.randn(len(ts))}, index=ts
         )

--- a/pandas/tests/reshape/concat/test_datetimes.py
+++ b/pandas/tests/reshape/concat/test_datetimes.py
@@ -131,34 +131,43 @@ class TestDatetimeConcat:
             dtype="object",
         )
 
-        s = Series(
-            ["a", "b"],
-            index=MultiIndex.from_arrays(
+        msg = "Pandas type inference with a sequence of `datetime.date` objects"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            # TODO: should this be not-inferring since we already specified
+            # object dtype?
+            mi = MultiIndex.from_arrays(
                 [
                     [1, 2],
                     idx[:-1],
                 ],
                 names=["first", "second"],
-            ),
-        )
-        s2 = Series(
+            )
+        s = Series(
             ["a", "b"],
-            index=MultiIndex.from_arrays(
+            index=mi,
+        )
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            mi2 = MultiIndex.from_arrays(
                 [[1, 2], idx[::2]],
                 names=["first", "second"],
-            ),
+            )
+        s2 = Series(
+            ["a", "b"],
+            index=mi2,
         )
-        mi = MultiIndex.from_arrays(
-            [[1, 2, 2], idx],
-            names=["first", "second"],
-        )
-        assert mi.levels[1].dtype == object
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            mi3 = MultiIndex.from_arrays(
+                [[1, 2, 2], idx],
+                names=["first", "second"],
+            )
+        assert mi3.levels[1].dtype == object
 
         expected = DataFrame(
             [["a", "a"], ["b", np.nan], [np.nan, "b"]],
-            index=mi,
+            index=mi3,
         )
-        result = concat([s, s2], axis=1)
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            result = concat([s, s2], axis=1)
         tm.assert_frame_equal(result, expected)
 
     def test_concat_NaT_series(self):

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2036,31 +2036,42 @@ class TestMergeCategorical:
         # GH 16900
         # dates should not be coerced to ints
 
-        df = DataFrame(
-            [[date(2001, 1, 1), 1.1], [date(2001, 1, 2), 1.3]], columns=["date", "num2"]
+        msg = (
+            "Pandas type inference with a sequence of `datetime.date` "
+            "objects is deprecated"
         )
-        df["date"] = df["date"].astype("category")
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            df = DataFrame(
+                [[date(2001, 1, 1), 1.1], [date(2001, 1, 2), 1.3]],
+                columns=["date", "num2"],
+            )
+            df["date"] = df["date"].astype("category")
 
-        df2 = DataFrame(
-            [[date(2001, 1, 1), 1.3], [date(2001, 1, 3), 1.4]], columns=["date", "num4"]
-        )
-        df2["date"] = df2["date"].astype("category")
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            df2 = DataFrame(
+                [[date(2001, 1, 1), 1.3], [date(2001, 1, 3), 1.4]],
+                columns=["date", "num4"],
+            )
+            df2["date"] = df2["date"].astype("category")
 
-        expected_outer = DataFrame(
-            [
-                [pd.Timestamp("2001-01-01").date(), 1.1, 1.3],
-                [pd.Timestamp("2001-01-02").date(), 1.3, np.nan],
-                [pd.Timestamp("2001-01-03").date(), np.nan, 1.4],
-            ],
-            columns=["date", "num2", "num4"],
-        )
-        result_outer = merge(df, df2, how="outer", on=["date"])
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            expected_outer = DataFrame(
+                [
+                    [pd.Timestamp("2001-01-01").date(), 1.1, 1.3],
+                    [pd.Timestamp("2001-01-02").date(), 1.3, np.nan],
+                    [pd.Timestamp("2001-01-03").date(), np.nan, 1.4],
+                ],
+                columns=["date", "num2", "num4"],
+            )
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            result_outer = merge(df, df2, how="outer", on=["date"])
         tm.assert_frame_equal(result_outer, expected_outer)
 
-        expected_inner = DataFrame(
-            [[pd.Timestamp("2001-01-01").date(), 1.1, 1.3]],
-            columns=["date", "num2", "num4"],
-        )
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            expected_inner = DataFrame(
+                [[pd.Timestamp("2001-01-01").date(), 1.1, 1.3]],
+                columns=["date", "num2", "num4"],
+            )
         result_inner = merge(df, df2, how="inner", on=["date"])
         tm.assert_frame_equal(result_inner, expected_inner)
 

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1087,11 +1087,15 @@ class TestPivotTable:
                 [1.0],
             )
         )
-        df = DataFrame(data)
-        table = df.pivot_table(values=4, index=[0, 1, 3], columns=[2])
+        msg = "type inference with a sequence of `datetime.date` objects is deprecated"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            df = DataFrame(data)
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            table = df.pivot_table(values=4, index=[0, 1, 3], columns=[2])
 
         df2 = df.rename(columns=str)
-        table2 = df2.pivot_table(values="4", index=["0", "1", "3"], columns=["2"])
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            table2 = df2.pivot_table(values="4", index=["0", "1", "3"], columns=["2"])
 
         tm.assert_frame_equal(table, table2, check_names=False)
 

--- a/pandas/tests/series/accessors/test_cat_accessor.py
+++ b/pandas/tests/series/accessors/test_cat_accessor.py
@@ -212,8 +212,12 @@ class TestCatAccessor:
             tm.assert_equal(res, exp)
 
         for attr in attr_names:
-            res = getattr(cat.dt, attr)
-            exp = getattr(ser.dt, attr)
+            with warnings.catch_warnings():
+                if attr == "time":
+                    # deprecated to return pyarrow time dtype
+                    warnings.simplefilter("ignore", FutureWarning)
+                res = getattr(cat.dt, attr)
+                exp = getattr(ser.dt, attr)
 
             tm.assert_equal(res, exp)
 

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -87,7 +87,7 @@ class TestSeriesDatetimeValues:
                     result = result.astype("int64")
             elif not is_list_like(result) or isinstance(result, DataFrame):
                 return result
-            return Series(result, index=ser.index, name=ser.name)
+            return Series(result, index=ser.index, name=ser.name, dtype=result.dtype)
 
         left = getattr(ser.dt, name)
         right = get_expected(ser, name)
@@ -725,7 +725,8 @@ class TestSeriesDatetimeValues:
         )
         ser = Series(dtindex)
         expected = Series(
-            [time(23, 56, tzinfo=tz), time(21, 24, tzinfo=tz), time(22, 14, tzinfo=tz)]
+            [time(23, 56, tzinfo=tz), time(21, 24, tzinfo=tz), time(22, 14, tzinfo=tz)],
+            dtype=object,
         )
         result = ser.dt.timetz
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -91,7 +91,9 @@ class TestSeriesDatetimeValues:
             return Series(result, index=ser.index, name=ser.name, dtype=result.dtype)
 
         if name == "time":
-            msg = "In a future version, this will an array with pyarrow time dtype"
+            msg = (
+                "In a future version, this will return an array with pyarrow time dtype"
+            )
             with tm.assert_produces_warning(FutureWarning, match=msg):
                 left = getattr(ser.dt, name)
                 right = get_expected(ser, name)
@@ -680,7 +682,7 @@ class TestSeriesDatetimeValues:
         )
         tm.assert_series_equal(result, expected)
 
-        msg = "In a future version, this will an array with pyarrow time"
+        msg = "In a future version, this will return an array with pyarrow time"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             result = ser.dt.time
         expected = Series([time(0), time(0), pd.NaT, time(0), time(0)], dtype="object")

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -744,9 +744,18 @@ class TestSeriesDatetimeValues:
             tz="US/Eastern",
         )
         ser = Series(rng)
-        expected = Series([date(2014, 4, 4), date(2014, 7, 18), date(2015, 11, 22)])
+
+        warn_msg = (
+            "Pandas type inference with a sequence of `datetime.date` objects "
+            "is deprecated"
+        )
+        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+            expected = Series([date(2014, 4, 4), date(2014, 7, 18), date(2015, 11, 22)])
         tm.assert_series_equal(ser.dt.date, expected)
-        tm.assert_series_equal(ser.apply(lambda x: x.date()), expected)
+
+        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+            res = ser.apply(lambda x: x.date())
+        tm.assert_series_equal(res, expected)
 
     def test_dt_timetz_accessor(self, tz_naive_fixture):
         # GH21358

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -91,9 +91,7 @@ class TestSeriesDatetimeValues:
             return Series(result, index=ser.index, name=ser.name, dtype=result.dtype)
 
         if name == "time":
-            msg = (
-                "In a future version, this will return an array with pyarrow time dtype"
-            )
+            msg = "In a future version, this will an array with pyarrow time dtype"
             with tm.assert_produces_warning(FutureWarning, match=msg):
                 left = getattr(ser.dt, name)
                 right = get_expected(ser, name)

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -101,7 +101,6 @@ class TestSeriesDatetimeValues:
             left = getattr(ser.dt, name)
             right = get_expected(ser, name)
 
-
         if not (is_list_like(left) and is_list_like(right)):
             assert left == right
         elif isinstance(left, DataFrame):

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -101,6 +101,7 @@ class TestSeriesDatetimeValues:
             left = getattr(ser.dt, name)
             right = get_expected(ser, name)
 
+
         if not (is_list_like(left) and is_list_like(right)):
             assert left == right
         elif isinstance(left, DataFrame):

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -91,7 +91,9 @@ class TestSeriesDatetimeValues:
             return Series(result, index=ser.index, name=ser.name, dtype=result.dtype)
 
         if name == "time":
-            msg = "In a future version, this will an array with pyarrow time dtype"
+            msg = (
+                "In a future version, this will return an array with pyarrow time dtype"
+            )
             with tm.assert_produces_warning(FutureWarning, match=msg):
                 left = getattr(ser.dt, name)
                 right = get_expected(ser, name)

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -219,9 +219,8 @@ class TestSeriesArithmetic:
         tm.assert_series_equal(result, expected)
 
     def test_add_na_handling(self):
-        ser = Series(
-            [Decimal("1.3"), Decimal("2.3")], index=[date(2012, 1, 1), date(2012, 1, 2)]
-        )
+        index = Index([date(2012, 1, 1), date(2012, 1, 2)], dtype=object)
+        ser = Series([Decimal("1.3"), Decimal("2.3")], index=index)
 
         result = ser + ser.shift(1)
         result2 = ser.shift(1) + ser
@@ -761,7 +760,13 @@ class TestTimeSeriesArithmetic:
 
         ts_slice = ts[5:]
         ts2 = ts_slice.copy()
-        ts2.index = [x.date() for x in ts2.index]
+
+        warn_msg = (
+            "Pandas type inference with a sequence of `datetime.date` objects "
+            "is deprecated"
+        )
+        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+            ts2.index = [x.date() for x in ts2.index]
 
         result = ts + ts2
         result2 = ts2 + ts

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1043,7 +1043,12 @@ class TestSeriesConstructors:
 
         # leave datetime.date alone
         dates2 = np.array([d.date() for d in dates.to_pydatetime()], dtype=object)
-        series1 = Series(dates2, dates)
+        warn_msg = (
+            "Pandas type inference with a sequence of `datetime.date` objects "
+            "is deprecated"
+        )
+        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+            series1 = Series(dates2, dates)
         tm.assert_numpy_array_equal(series1.values, dates2)
         assert series1.dtype == object
 

--- a/pandas/tests/strings/test_api.py
+++ b/pandas/tests/strings/test_api.py
@@ -31,7 +31,16 @@ def test_api_per_dtype(index_or_series, dtype, any_skipna_inferred_dtype):
     box = index_or_series
     inferred_dtype, values = any_skipna_inferred_dtype
 
-    t = box(values, dtype=dtype)  # explicit dtype to avoid casting
+    warn_msg = (
+        "Pandas type inference with a sequence of `datetime.time` objects "
+        "is deprecated"
+    )
+    warn = None
+    if dtype == "category" and inferred_dtype == "time":
+        warn = FutureWarning
+
+    with tm.assert_produces_warning(warn, match=warn_msg):
+        t = box(values, dtype=dtype)  # explicit dtype to avoid casting
 
     types_passing_constructor = [
         "string",

--- a/pandas/tests/strings/test_api.py
+++ b/pandas/tests/strings/test_api.py
@@ -38,6 +38,12 @@ def test_api_per_dtype(index_or_series, dtype, any_skipna_inferred_dtype):
     warn = None
     if dtype == "category" and inferred_dtype == "time":
         warn = FutureWarning
+    if dtype == "category" and inferred_dtype == "date":
+        warn = FutureWarning
+        warn_msg = (
+            "Pandas type inference with a sequence of `datetime.date` objects "
+            "is deprecated"
+        )
 
     with tm.assert_produces_warning(warn, match=warn_msg):
         t = box(values, dtype=dtype)  # explicit dtype to avoid casting

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -269,13 +269,18 @@ class TestMultiLevel:
         tm.assert_series_equal(result, expected)
 
     def test_datetime_object_multiindex(self):
+        msg = (
+            "Pandas type inference with a sequence of `datetime.date` "
+            "objects is deprecated"
+        )
         data_dic = {
             (0, datetime.date(2018, 3, 3)): {"A": 1, "B": 10},
             (0, datetime.date(2018, 3, 4)): {"A": 2, "B": 11},
             (1, datetime.date(2018, 3, 3)): {"A": 3, "B": 12},
             (1, datetime.date(2018, 3, 4)): {"A": 4, "B": 13},
         }
-        result = DataFrame.from_dict(data_dic, orient="index")
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            result = DataFrame.from_dict(data_dic, orient="index")
         data = {"A": [1, 2, 3, 4], "B": [10, 11, 12, 13]}
         index = [
             [0, 0, 1, 1],
@@ -286,7 +291,8 @@ class TestMultiLevel:
                 datetime.date(2018, 3, 4),
             ],
         ]
-        expected = DataFrame(data=data, index=index)
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            expected = DataFrame(data=data, index=index)
 
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/tools/test_to_time.py
+++ b/pandas/tests/tools/test_to_time.py
@@ -61,9 +61,15 @@ class TestToTime:
         with pytest.raises(ValueError, match=msg):
             to_time(arg, format="%I:%M%p", errors="raise")
 
-        tm.assert_series_equal(
-            to_time(Series(arg, name="test")), Series(expected_arr, name="test")
+        warn_msg = (
+            "Pandas type inference with a sequence of `datetime.time` objects "
+            "is deprecated"
         )
+        with tm.assert_produces_warning(FutureWarning, match=warn_msg):
+            res_ser = to_time(Series(arg, name="test"))
+        exp_ser = Series(expected_arr, name="test", dtype=object)
+
+        tm.assert_series_equal(res_ser, exp_ser)
 
         res = to_time(np.array(arg))
         assert isinstance(res, list)


### PR DESCRIPTION
Sits on top of #53025 and #53165.

Inferring bytes causes a few failures that need to be worked out before this is merged.

- [ ] in the string accessors there is a workaround for _str_map, used for .decode
- [ ] test_to_hdf_errors afils with "UnicodeEncodeError: 'utf-8' codec can't encode character '\ud800' in position 0: surrogates not allowed"
- [ ] 3 of the SAS tests fail bc "expected" is constructed with `objects.astype('string[pyarrow]')` which isn't what we get with `bytes_pyarrow.str.decode(...)`
- [ ] similar failure for test_decode_errors_kwarg
- [ ] test_astype_unicode fails with UnicodeDecodeError
