### PR TITLE
MNT: Mark all `nogil` functions as `noexcept`

### DIFF
--- a/pandas/_libs/algos.pxd
+++ b/pandas/_libs/algos.pxd
@@ -4,7 +4,7 @@ from pandas._libs.dtypes cimport (
 )
 
 
-cdef numeric_t kth_smallest_c(numeric_t* arr, Py_ssize_t k, Py_ssize_t n) nogil
+cdef numeric_t kth_smallest_c(numeric_t* arr, Py_ssize_t k, Py_ssize_t n) noexcept nogil
 
 cdef enum TiebreakEnumType:
     TIEBREAK_AVERAGE

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -259,7 +259,7 @@ def groupsort_indexer(const intp_t[:] index, Py_ssize_t ngroups):
     return indexer.base, counts.base
 
 
-cdef Py_ssize_t swap(numeric_t *a, numeric_t *b) nogil:
+cdef Py_ssize_t swap(numeric_t *a, numeric_t *b) noexcept nogil:
     cdef:
         numeric_t t
 
@@ -270,7 +270,7 @@ cdef Py_ssize_t swap(numeric_t *a, numeric_t *b) nogil:
     return 0
 
 
-cdef numeric_t kth_smallest_c(numeric_t* arr, Py_ssize_t k, Py_ssize_t n) nogil:
+cdef numeric_t kth_smallest_c(numeric_t* arr, Py_ssize_t k, Py_ssize_t n) noexcept nogil:
     """
     See kth_smallest.__doc__. The additional parameter n specifies the maximum
     number of elements considered in arr, needed for compatibility with usage
@@ -1062,7 +1062,7 @@ cdef void rank_sorted_1d(
     # https://github.com/cython/cython/issues/1630, only trailing arguments can
     # currently be omitted for cdef functions, which is why we keep this at the end
     const intp_t[:] labels=None,
-) nogil:
+) noexcept nogil:
     """
     See rank_1d.__doc__. Handles only actual ranking, so sorting and masking should
     be handled in the caller. Note that `out` and `grp_sizes` are modified inplace.

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -270,7 +270,8 @@ cdef Py_ssize_t swap(numeric_t *a, numeric_t *b) noexcept nogil:
     return 0
 
 
-cdef numeric_t kth_smallest_c(numeric_t* arr, Py_ssize_t k, Py_ssize_t n) noexcept nogil:
+cdef numeric_t kth_smallest_c(numeric_t* arr,
+                              Py_ssize_t k, Py_ssize_t n) noexcept nogil:
     """
     See kth_smallest.__doc__. The additional parameter n specifies the maximum
     number of elements considered in arr, needed for compatibility with usage

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -62,7 +62,7 @@ cdef enum InterpolationEnumType:
     INTERPOLATION_MIDPOINT
 
 
-cdef float64_t median_linear_mask(float64_t* a, int n, uint8_t* mask) nogil:
+cdef float64_t median_linear_mask(float64_t* a, int n, uint8_t* mask) noexcept nogil:
     cdef:
         int i, j, na_count = 0
         float64_t* tmp
@@ -99,7 +99,7 @@ cdef float64_t median_linear_mask(float64_t* a, int n, uint8_t* mask) nogil:
     return result
 
 
-cdef float64_t median_linear(float64_t* a, int n) nogil:
+cdef float64_t median_linear(float64_t* a, int n) noexcept nogil:
     cdef:
         int i, j, na_count = 0
         float64_t* tmp
@@ -136,7 +136,7 @@ cdef float64_t median_linear(float64_t* a, int n) nogil:
     return result
 
 
-cdef float64_t calc_median_linear(float64_t* a, int n, int na_count) nogil:
+cdef float64_t calc_median_linear(float64_t* a, int n, int na_count) noexcept nogil:
     cdef:
         float64_t result
 
@@ -1293,7 +1293,7 @@ ctypedef fused numeric_object_complex_t:
     complex128_t
 
 
-cdef bint _treat_as_na(numeric_object_complex_t val, bint is_datetimelike) nogil:
+cdef bint _treat_as_na(numeric_object_complex_t val, bint is_datetimelike) noexcept nogil:
     if numeric_object_complex_t is object:
         # Should never be used, but we need to avoid the `val != val` below
         #  or else cython will raise about gil acquisition.

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -1293,7 +1293,8 @@ ctypedef fused numeric_object_complex_t:
     complex128_t
 
 
-cdef bint _treat_as_na(numeric_object_complex_t val, bint is_datetimelike) noexcept nogil:
+cdef bint _treat_as_na(numeric_object_complex_t val,
+                       bint is_datetimelike) noexcept nogil:
     if numeric_object_complex_t is object:
         # Should never be used, but we need to avoid the `val != val` below
         #  or else cython will raise about gil acquisition.

--- a/pandas/_libs/hashing.pyx
+++ b/pandas/_libs/hashing.pyx
@@ -110,11 +110,11 @@ def hash_object_array(
     return result.base  # .base to retrieve underlying np.ndarray
 
 
-cdef uint64_t _rotl(uint64_t x, uint64_t b) nogil:
+cdef uint64_t _rotl(uint64_t x, uint64_t b) noexcept nogil:
     return (x << b) | (x >> (64 - b))
 
 
-cdef uint64_t u8to64_le(uint8_t* p) nogil:
+cdef uint64_t u8to64_le(uint8_t* p) noexcept nogil:
     return (<uint64_t>p[0] |
             <uint64_t>p[1] << 8 |
             <uint64_t>p[2] << 16 |
@@ -145,7 +145,7 @@ cdef void _sipround(uint64_t* v0, uint64_t* v1,
 
 @cython.cdivision(True)
 cdef uint64_t low_level_siphash(uint8_t* data, size_t datalen,
-                                uint8_t* key) nogil:
+                                uint8_t* key) noexcept nogil:
     cdef uint64_t v0 = 0x736f6d6570736575ULL
     cdef uint64_t v1 = 0x646f72616e646f6dULL
     cdef uint64_t v2 = 0x6c7967656e657261ULL

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -13,7 +13,7 @@ complex_types = ['complex64',
 }}
 
 {{for name in complex_types}}
-cdef kh{{name}}_t to_kh{{name}}_t({{name}}_t val) nogil:
+cdef kh{{name}}_t to_kh{{name}}_t({{name}}_t val) noexcept nogil:
     cdef kh{{name}}_t res
     res.real = val.real
     res.imag = val.imag
@@ -42,7 +42,7 @@ c_types = ['khcomplex128_t',
 
 {{for c_type in c_types}}
 
-cdef bint is_nan_{{c_type}}({{c_type}} val) nogil:
+cdef bint is_nan_{{c_type}}({{c_type}} val) noexcept nogil:
     {{if c_type in {'khcomplex128_t', 'khcomplex64_t'} }}
     return val.real != val.real or val.imag != val.imag
     {{elif c_type in {'float64_t', 'float32_t'} }}
@@ -55,7 +55,7 @@ cdef bint is_nan_{{c_type}}({{c_type}} val) nogil:
 {{if c_type in {'khcomplex128_t', 'khcomplex64_t', 'float64_t', 'float32_t'} }}
 # are_equivalent_{{c_type}} is cimported via khash.pxd
 {{else}}
-cdef bint are_equivalent_{{c_type}}({{c_type}} val1, {{c_type}} val2) nogil:
+cdef bint are_equivalent_{{c_type}}({{c_type}} val1, {{c_type}} val2) noexcept nogil:
     return val1 == val2
 {{endif}}
 
@@ -163,7 +163,7 @@ ctypedef fused vector_data:
     Complex64VectorData
     StringVectorData
 
-cdef bint needs_resize(vector_data *data) nogil:
+cdef bint needs_resize(vector_data *data) noexcept nogil:
     return data.n == data.m
 
 # ----------------------------------------------------------------------

--- a/pandas/_libs/tslibs/ccalendar.pxd
+++ b/pandas/_libs/tslibs/ccalendar.pxd
@@ -6,14 +6,14 @@ from numpy cimport (
 
 ctypedef (int32_t, int32_t, int32_t) iso_calendar_t
 
-cdef int dayofweek(int y, int m, int d) nogil
-cdef bint is_leapyear(int64_t year) nogil
-cpdef int32_t get_days_in_month(int year, Py_ssize_t month) nogil
-cpdef int32_t get_week_of_year(int year, int month, int day) nogil
-cpdef iso_calendar_t get_iso_calendar(int year, int month, int day) nogil
-cpdef int32_t get_day_of_year(int year, int month, int day) nogil
-cpdef int get_lastbday(int year, int month) nogil
-cpdef int get_firstbday(int year, int month) nogil
+cdef int dayofweek(int y, int m, int d) noexcept nogil
+cdef bint is_leapyear(int64_t year) noexcept nogil
+cpdef int32_t get_days_in_month(int year, Py_ssize_t month) noexcept nogil
+cpdef int32_t get_week_of_year(int year, int month, int day) noexcept nogil
+cpdef iso_calendar_t get_iso_calendar(int year, int month, int day) noexcept nogil
+cpdef int32_t get_day_of_year(int year, int month, int day) noexcept nogil
+cpdef int get_lastbday(int year, int month) noexcept nogil
+cpdef int get_firstbday(int year, int month) noexcept nogil
 
 cdef dict c_MONTH_NUMBERS
 

--- a/pandas/_libs/tslibs/ccalendar.pyx
+++ b/pandas/_libs/tslibs/ccalendar.pyx
@@ -53,7 +53,7 @@ weekday_to_int = {int_to_weekday[key]: key for key in int_to_weekday}
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cpdef int32_t get_days_in_month(int year, Py_ssize_t month) nogil:
+cpdef int32_t get_days_in_month(int year, Py_ssize_t month) noexcept nogil:
     """
     Return the number of days in the given month of the given year.
 
@@ -77,7 +77,7 @@ cpdef int32_t get_days_in_month(int year, Py_ssize_t month) nogil:
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.cdivision
-cdef int dayofweek(int y, int m, int d) nogil:
+cdef int dayofweek(int y, int m, int d) noexcept nogil:
     """
     Find the day of week for the date described by the Y/M/D triple y, m, d
     using Sakamoto's method, from wikipedia.
@@ -114,7 +114,7 @@ cdef int dayofweek(int y, int m, int d) nogil:
     return (day + 6) % 7
 
 
-cdef bint is_leapyear(int64_t year) nogil:
+cdef bint is_leapyear(int64_t year) noexcept nogil:
     """
     Returns 1 if the given year is a leap year, 0 otherwise.
 
@@ -132,7 +132,7 @@ cdef bint is_leapyear(int64_t year) nogil:
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cpdef int32_t get_week_of_year(int year, int month, int day) nogil:
+cpdef int32_t get_week_of_year(int year, int month, int day) noexcept nogil:
     """
     Return the ordinal week-of-year for the given day.
 
@@ -155,7 +155,7 @@ cpdef int32_t get_week_of_year(int year, int month, int day) nogil:
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cpdef iso_calendar_t get_iso_calendar(int year, int month, int day) nogil:
+cpdef iso_calendar_t get_iso_calendar(int year, int month, int day) noexcept nogil:
     """
     Return the year, week, and day of year corresponding to ISO 8601
 
@@ -209,7 +209,7 @@ cpdef iso_calendar_t get_iso_calendar(int year, int month, int day) nogil:
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cpdef int32_t get_day_of_year(int year, int month, int day) nogil:
+cpdef int32_t get_day_of_year(int year, int month, int day) noexcept nogil:
     """
     Return the ordinal day-of-year for the given day.
 
@@ -243,7 +243,7 @@ cpdef int32_t get_day_of_year(int year, int month, int day) nogil:
 # ---------------------------------------------------------------------
 # Business Helpers
 
-cpdef int get_lastbday(int year, int month) nogil:
+cpdef int get_lastbday(int year, int month) noexcept nogil:
     """
     Find the last day of the month that is a business day.
 
@@ -264,7 +264,7 @@ cpdef int get_lastbday(int year, int month) nogil:
     return days_in_month - max(((wkday + days_in_month - 1) % 7) - 4, 0)
 
 
-cpdef int get_firstbday(int year, int month) nogil:
+cpdef int get_firstbday(int year, int month) noexcept nogil:
     """
     Find the first day of the month that is a business day.
 

--- a/pandas/_libs/tslibs/dtypes.pxd
+++ b/pandas/_libs/tslibs/dtypes.pxd
@@ -5,7 +5,7 @@ from pandas._libs.tslibs.np_datetime cimport NPY_DATETIMEUNIT
 
 cpdef str npy_unit_to_abbrev(NPY_DATETIMEUNIT unit)
 cpdef NPY_DATETIMEUNIT abbrev_to_npy_unit(str abbrev)
-cdef NPY_DATETIMEUNIT freq_group_code_to_npy_unit(int freq) nogil
+cdef NPY_DATETIMEUNIT freq_group_code_to_npy_unit(int freq) noexcept nogil
 cpdef int64_t periods_per_day(NPY_DATETIMEUNIT reso=*) except? -1
 cpdef int64_t periods_per_second(NPY_DATETIMEUNIT reso) except? -1
 cpdef NPY_DATETIMEUNIT get_supported_reso(NPY_DATETIMEUNIT reso)

--- a/pandas/_libs/tslibs/dtypes.pyx
+++ b/pandas/_libs/tslibs/dtypes.pyx
@@ -380,7 +380,7 @@ cpdef NPY_DATETIMEUNIT abbrev_to_npy_unit(str abbrev):
         raise ValueError(f"Unrecognized unit {abbrev}")
 
 
-cdef NPY_DATETIMEUNIT freq_group_code_to_npy_unit(int freq) nogil:
+cdef NPY_DATETIMEUNIT freq_group_code_to_npy_unit(int freq) noexcept nogil:
     """
     Convert the freq to the corresponding NPY_DATETIMEUNIT to pass
     to npy_datetimestruct_to_datetime.

--- a/pandas/_libs/tslibs/fields.pyx
+++ b/pandas/_libs/tslibs/fields.pyx
@@ -193,7 +193,7 @@ def get_date_name_field(
     return out
 
 
-cdef bint _is_on_month(int month, int compare_month, int modby) nogil:
+cdef bint _is_on_month(int month, int compare_month, int modby) noexcept nogil:
     """
     Analogous to DateOffset.is_on_offset checking for the month part of a date.
     """

--- a/pandas/_libs/tslibs/np_datetime.pxd
+++ b/pandas/_libs/tslibs/np_datetime.pxd
@@ -96,9 +96,9 @@ cdef int64_t pydate_to_dt64(
 )
 cdef void pydate_to_dtstruct(date val, npy_datetimestruct *dts) noexcept
 
-cdef npy_datetime get_datetime64_value(object obj) nogil
-cdef npy_timedelta get_timedelta64_value(object obj) nogil
-cdef NPY_DATETIMEUNIT get_datetime64_unit(object obj) nogil
+cdef npy_datetime get_datetime64_value(object obj) noexcept nogil
+cdef npy_timedelta get_timedelta64_value(object obj) noexcept nogil
+cdef NPY_DATETIMEUNIT get_datetime64_unit(object obj) noexcept nogil
 
 cdef int string_to_dts(
     str val,

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -59,7 +59,7 @@ cdef extern from "src/datetime/pd_datetime.h":
 # ----------------------------------------------------------------------
 # numpy object inspection
 
-cdef npy_datetime get_datetime64_value(object obj) nogil:
+cdef npy_datetime get_datetime64_value(object obj) noexcept nogil:
     """
     returns the int64 value underlying scalar numpy datetime64 object
 
@@ -69,14 +69,14 @@ cdef npy_datetime get_datetime64_value(object obj) nogil:
     return (<PyDatetimeScalarObject*>obj).obval
 
 
-cdef npy_timedelta get_timedelta64_value(object obj) nogil:
+cdef npy_timedelta get_timedelta64_value(object obj) noexcept nogil:
     """
     returns the int64 value underlying scalar numpy timedelta64 object
     """
     return (<PyTimedeltaScalarObject*>obj).obval
 
 
-cdef NPY_DATETIMEUNIT get_datetime64_unit(object obj) nogil:
+cdef NPY_DATETIMEUNIT get_datetime64_unit(object obj) noexcept nogil:
     """
     returns the unit part of the dtype for a numpy datetime64 object.
     """

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -4390,14 +4390,14 @@ cdef datetime _shift_day(datetime other, int days):
     return localize_pydatetime(shifted, tz)
 
 
-cdef int year_add_months(npy_datetimestruct dts, int months) nogil:
+cdef int year_add_months(npy_datetimestruct dts, int months) noexcept nogil:
     """
     New year number after shifting npy_datetimestruct number of months.
     """
     return dts.year + (dts.month + months - 1) // 12
 
 
-cdef int month_add_months(npy_datetimestruct dts, int months) nogil:
+cdef int month_add_months(npy_datetimestruct dts, int months) noexcept nogil:
     """
     New month number after shifting npy_datetimestruct
     number of months.
@@ -4619,7 +4619,7 @@ def shift_month(stamp: datetime, months: int, day_opt: object = None) -> datetim
     return stamp.replace(year=year, month=month, day=day)
 
 
-cdef int get_day_of_month(npy_datetimestruct* dts, str day_opt) nogil:
+cdef int get_day_of_month(npy_datetimestruct* dts, str day_opt) noexcept nogil:
     """
     Find the day in `other`'s month that satisfies a DateOffset's is_on_offset
     policy, as described by the `day_opt` argument.
@@ -4664,7 +4664,7 @@ cdef int get_day_of_month(npy_datetimestruct* dts, str day_opt) nogil:
         return get_lastbday(dts.year, dts.month)
 
 
-cpdef int roll_convention(int other, int n, int compare) nogil:
+cpdef int roll_convention(int other, int n, int compare) noexcept nogil:
     """
     Possibly increment or decrement the number of periods to shift
     based on rollforward/rollbackward conventions.

--- a/pandas/_libs/tslibs/period.pxd
+++ b/pandas/_libs/tslibs/period.pxd
@@ -4,4 +4,4 @@ from .np_datetime cimport npy_datetimestruct
 
 
 cdef bint is_period_object(object obj)
-cdef int64_t get_period_ordinal(npy_datetimestruct *dts, int freq) nogil
+cdef int64_t get_period_ordinal(npy_datetimestruct *dts, int freq) noexcept nogil

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -466,7 +466,8 @@ cdef int64_t asfreq_DTtoA(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return dts_to_year_ordinal(&dts, af_info.to_end)
 
 
-cdef int DtoQ_yq(int64_t ordinal, asfreq_info *af_info, npy_datetimestruct* dts) noexcept nogil:
+cdef int DtoQ_yq(int64_t ordinal, asfreq_info *af_info,
+                 npy_datetimestruct* dts) noexcept nogil:
     cdef:
         int quarter
 
@@ -851,7 +852,8 @@ cdef int64_t get_unix_date(int64_t period_ordinal, int freq) noexcept nogil:
 
 
 @cython.cdivision
-cdef int64_t get_time_nanos(int freq, int64_t unix_date, int64_t ordinal) noexcept nogil:
+cdef int64_t get_time_nanos(int freq, int64_t unix_date,
+                            int64_t ordinal) noexcept nogil:
     """
     Find the number of nanoseconds after midnight on the given unix_date
     that the ordinal represents in the given frequency.

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -121,7 +121,7 @@ ctypedef struct asfreq_info:
     int to_end
     int from_end
 
-ctypedef int64_t (*freq_conv_func)(int64_t, asfreq_info*) nogil
+ctypedef int64_t (*freq_conv_func)(int64_t, asfreq_info*) noexcept nogil
 
 
 cdef extern from *:
@@ -141,19 +141,19 @@ cdef extern from *:
     int64_t daytime_conversion_factor_matrix[7][7]
 
 
-cdef int max_value(int left, int right) nogil:
+cdef int max_value(int left, int right) noexcept nogil:
     if left > right:
         return left
     return right
 
 
-cdef int min_value(int left, int right) nogil:
+cdef int min_value(int left, int right) noexcept nogil:
     if left < right:
         return left
     return right
 
 
-cdef int64_t get_daytime_conversion_factor(int from_index, int to_index) nogil:
+cdef int64_t get_daytime_conversion_factor(int from_index, int to_index) noexcept nogil:
     cdef:
         int row = min_value(from_index, to_index)
         int col = max_value(from_index, to_index)
@@ -166,15 +166,15 @@ cdef int64_t get_daytime_conversion_factor(int from_index, int to_index) nogil:
     return daytime_conversion_factor_matrix[row - 6][col - 6]
 
 
-cdef int64_t nofunc(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t nofunc(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return INT32_MIN
 
 
-cdef int64_t no_op(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t no_op(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return ordinal
 
 
-cdef freq_conv_func get_asfreq_func(int from_freq, int to_freq) nogil:
+cdef freq_conv_func get_asfreq_func(int from_freq, int to_freq) noexcept nogil:
     cdef:
         int from_group = get_freq_group(from_freq)
         int to_group = get_freq_group(to_freq)
@@ -293,12 +293,12 @@ cdef freq_conv_func get_asfreq_func(int from_freq, int to_freq) nogil:
 # --------------------------------------------------------------------
 # Frequency Conversion Helpers
 
-cdef int64_t DtoB_weekday(int64_t unix_date) nogil:
+cdef int64_t DtoB_weekday(int64_t unix_date) noexcept nogil:
     return ((unix_date + 4) // 7) * 5 + ((unix_date + 4) % 7) - 4
 
 
 cdef int64_t DtoB(npy_datetimestruct *dts, int roll_back,
-                  int64_t unix_date) nogil:
+                  int64_t unix_date) noexcept nogil:
     # calculate the current week (counting from 1970-01-01) treating
     # sunday as last day of a week
     cdef:
@@ -316,21 +316,21 @@ cdef int64_t DtoB(npy_datetimestruct *dts, int roll_back,
     return DtoB_weekday(unix_date)
 
 
-cdef int64_t upsample_daytime(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t upsample_daytime(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     if af_info.is_end:
         return (ordinal + 1) * af_info.intraday_conversion_factor - 1
     else:
         return ordinal * af_info.intraday_conversion_factor
 
 
-cdef int64_t downsample_daytime(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t downsample_daytime(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return ordinal // af_info.intraday_conversion_factor
 
 
 cdef int64_t transform_via_day(int64_t ordinal,
                                asfreq_info *af_info,
                                freq_conv_func first_func,
-                               freq_conv_func second_func) nogil:
+                               freq_conv_func second_func) noexcept nogil:
     cdef:
         int64_t result
 
@@ -342,7 +342,7 @@ cdef int64_t transform_via_day(int64_t ordinal,
 # --------------------------------------------------------------------
 # Conversion _to_ Daily Freq
 
-cdef int64_t asfreq_AtoDT(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_AtoDT(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     cdef:
         int64_t unix_date
         npy_datetimestruct dts
@@ -358,7 +358,7 @@ cdef int64_t asfreq_AtoDT(int64_t ordinal, asfreq_info *af_info) nogil:
     return upsample_daytime(unix_date, af_info)
 
 
-cdef int64_t asfreq_QtoDT(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_QtoDT(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     cdef:
         int64_t unix_date
         npy_datetimestruct dts
@@ -374,7 +374,7 @@ cdef int64_t asfreq_QtoDT(int64_t ordinal, asfreq_info *af_info) nogil:
     return upsample_daytime(unix_date, af_info)
 
 
-cdef int64_t asfreq_MtoDT(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_MtoDT(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     cdef:
         int64_t unix_date
         int year, month
@@ -389,7 +389,7 @@ cdef int64_t asfreq_MtoDT(int64_t ordinal, asfreq_info *af_info) nogil:
     return upsample_daytime(unix_date, af_info)
 
 
-cdef int64_t asfreq_WtoDT(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_WtoDT(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     ordinal = (ordinal * 7 + af_info.from_end - 4 +
                (7 - 1) * (af_info.is_end - 1))
     return upsample_daytime(ordinal, af_info)
@@ -398,7 +398,7 @@ cdef int64_t asfreq_WtoDT(int64_t ordinal, asfreq_info *af_info) nogil:
 # --------------------------------------------------------------------
 # Conversion _to_ BusinessDay Freq
 
-cdef int64_t asfreq_AtoB(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_AtoB(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     cdef:
         int roll_back
         npy_datetimestruct dts
@@ -409,7 +409,7 @@ cdef int64_t asfreq_AtoB(int64_t ordinal, asfreq_info *af_info) nogil:
     return DtoB(&dts, roll_back, unix_date)
 
 
-cdef int64_t asfreq_QtoB(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_QtoB(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     cdef:
         int roll_back
         npy_datetimestruct dts
@@ -420,7 +420,7 @@ cdef int64_t asfreq_QtoB(int64_t ordinal, asfreq_info *af_info) nogil:
     return DtoB(&dts, roll_back, unix_date)
 
 
-cdef int64_t asfreq_MtoB(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_MtoB(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     cdef:
         int roll_back
         npy_datetimestruct dts
@@ -431,7 +431,7 @@ cdef int64_t asfreq_MtoB(int64_t ordinal, asfreq_info *af_info) nogil:
     return DtoB(&dts, roll_back, unix_date)
 
 
-cdef int64_t asfreq_WtoB(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_WtoB(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     cdef:
         int roll_back
         npy_datetimestruct dts
@@ -442,7 +442,7 @@ cdef int64_t asfreq_WtoB(int64_t ordinal, asfreq_info *af_info) nogil:
     return DtoB(&dts, roll_back, unix_date)
 
 
-cdef int64_t asfreq_DTtoB(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_DTtoB(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     cdef:
         int roll_back
         npy_datetimestruct dts
@@ -457,7 +457,7 @@ cdef int64_t asfreq_DTtoB(int64_t ordinal, asfreq_info *af_info) nogil:
 # ----------------------------------------------------------------------
 # Conversion _from_ Daily Freq
 
-cdef int64_t asfreq_DTtoA(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_DTtoA(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     cdef:
         npy_datetimestruct dts
 
@@ -466,7 +466,7 @@ cdef int64_t asfreq_DTtoA(int64_t ordinal, asfreq_info *af_info) nogil:
     return dts_to_year_ordinal(&dts, af_info.to_end)
 
 
-cdef int DtoQ_yq(int64_t ordinal, asfreq_info *af_info, npy_datetimestruct* dts) nogil:
+cdef int DtoQ_yq(int64_t ordinal, asfreq_info *af_info, npy_datetimestruct* dts) noexcept nogil:
     cdef:
         int quarter
 
@@ -477,7 +477,7 @@ cdef int DtoQ_yq(int64_t ordinal, asfreq_info *af_info, npy_datetimestruct* dts)
     return quarter
 
 
-cdef int64_t asfreq_DTtoQ(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_DTtoQ(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     cdef:
         int quarter
         npy_datetimestruct dts
@@ -488,7 +488,7 @@ cdef int64_t asfreq_DTtoQ(int64_t ordinal, asfreq_info *af_info) nogil:
     return <int64_t>((dts.year - 1970) * 4 + quarter - 1)
 
 
-cdef int64_t asfreq_DTtoM(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_DTtoM(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     cdef:
         npy_datetimestruct dts
 
@@ -497,42 +497,42 @@ cdef int64_t asfreq_DTtoM(int64_t ordinal, asfreq_info *af_info) nogil:
     return dts_to_month_ordinal(&dts)
 
 
-cdef int64_t asfreq_DTtoW(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_DTtoW(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     ordinal = downsample_daytime(ordinal, af_info)
     return unix_date_to_week(ordinal, af_info.to_end)
 
 
-cdef int64_t unix_date_to_week(int64_t unix_date, int to_end) nogil:
+cdef int64_t unix_date_to_week(int64_t unix_date, int to_end) noexcept nogil:
     return (unix_date + 3 - to_end) // 7 + 1
 
 
 # --------------------------------------------------------------------
 # Conversion _from_ BusinessDay Freq
 
-cdef int64_t asfreq_BtoDT(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_BtoDT(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     ordinal = ((ordinal + 3) // 5) * 7 + (ordinal + 3) % 5 - 3
     return upsample_daytime(ordinal, af_info)
 
 
-cdef int64_t asfreq_BtoA(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_BtoA(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_BtoDT,
                              <freq_conv_func>asfreq_DTtoA)
 
 
-cdef int64_t asfreq_BtoQ(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_BtoQ(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_BtoDT,
                              <freq_conv_func>asfreq_DTtoQ)
 
 
-cdef int64_t asfreq_BtoM(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_BtoM(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_BtoDT,
                              <freq_conv_func>asfreq_DTtoM)
 
 
-cdef int64_t asfreq_BtoW(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_BtoW(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_BtoDT,
                              <freq_conv_func>asfreq_DTtoW)
@@ -541,25 +541,25 @@ cdef int64_t asfreq_BtoW(int64_t ordinal, asfreq_info *af_info) nogil:
 # ----------------------------------------------------------------------
 # Conversion _from_ Annual Freq
 
-cdef int64_t asfreq_AtoA(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_AtoA(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_AtoDT,
                              <freq_conv_func>asfreq_DTtoA)
 
 
-cdef int64_t asfreq_AtoQ(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_AtoQ(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_AtoDT,
                              <freq_conv_func>asfreq_DTtoQ)
 
 
-cdef int64_t asfreq_AtoM(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_AtoM(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_AtoDT,
                              <freq_conv_func>asfreq_DTtoM)
 
 
-cdef int64_t asfreq_AtoW(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_AtoW(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_AtoDT,
                              <freq_conv_func>asfreq_DTtoW)
@@ -568,25 +568,25 @@ cdef int64_t asfreq_AtoW(int64_t ordinal, asfreq_info *af_info) nogil:
 # ----------------------------------------------------------------------
 # Conversion _from_ Quarterly Freq
 
-cdef int64_t asfreq_QtoQ(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_QtoQ(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_QtoDT,
                              <freq_conv_func>asfreq_DTtoQ)
 
 
-cdef int64_t asfreq_QtoA(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_QtoA(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_QtoDT,
                              <freq_conv_func>asfreq_DTtoA)
 
 
-cdef int64_t asfreq_QtoM(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_QtoM(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_QtoDT,
                              <freq_conv_func>asfreq_DTtoM)
 
 
-cdef int64_t asfreq_QtoW(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_QtoW(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_QtoDT,
                              <freq_conv_func>asfreq_DTtoW)
@@ -595,19 +595,19 @@ cdef int64_t asfreq_QtoW(int64_t ordinal, asfreq_info *af_info) nogil:
 # ----------------------------------------------------------------------
 # Conversion _from_ Monthly Freq
 
-cdef int64_t asfreq_MtoA(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_MtoA(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_MtoDT,
                              <freq_conv_func>asfreq_DTtoA)
 
 
-cdef int64_t asfreq_MtoQ(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_MtoQ(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_MtoDT,
                              <freq_conv_func>asfreq_DTtoQ)
 
 
-cdef int64_t asfreq_MtoW(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_MtoW(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_MtoDT,
                              <freq_conv_func>asfreq_DTtoW)
@@ -616,25 +616,25 @@ cdef int64_t asfreq_MtoW(int64_t ordinal, asfreq_info *af_info) nogil:
 # ----------------------------------------------------------------------
 # Conversion _from_ Weekly Freq
 
-cdef int64_t asfreq_WtoA(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_WtoA(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_WtoDT,
                              <freq_conv_func>asfreq_DTtoA)
 
 
-cdef int64_t asfreq_WtoQ(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_WtoQ(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_WtoDT,
                              <freq_conv_func>asfreq_DTtoQ)
 
 
-cdef int64_t asfreq_WtoM(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_WtoM(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_WtoDT,
                              <freq_conv_func>asfreq_DTtoM)
 
 
-cdef int64_t asfreq_WtoW(int64_t ordinal, asfreq_info *af_info) nogil:
+cdef int64_t asfreq_WtoW(int64_t ordinal, asfreq_info *af_info) noexcept nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_WtoDT,
                              <freq_conv_func>asfreq_DTtoW)
@@ -682,12 +682,12 @@ cdef char* c_strftime(npy_datetimestruct *dts, char *fmt):
 # ----------------------------------------------------------------------
 # Conversion between date_info and npy_datetimestruct
 
-cdef int get_freq_group(int freq) nogil:
+cdef int get_freq_group(int freq) noexcept nogil:
     # See also FreqGroup.get_freq_group
     return (freq // 1000) * 1000
 
 
-cdef int get_freq_group_index(int freq) nogil:
+cdef int get_freq_group_index(int freq) noexcept nogil:
     return freq // 1000
 
 
@@ -712,7 +712,7 @@ cdef void adjust_dts_for_qtr(npy_datetimestruct* dts, int to_end) noexcept nogil
 # Find the unix_date (days elapsed since datetime(1970, 1, 1)
 # for the given year/month/day.
 # Assumes GREGORIAN_CALENDAR */
-cdef int64_t unix_date_from_ymd(int year, int month, int day) nogil:
+cdef int64_t unix_date_from_ymd(int year, int month, int day) noexcept nogil:
     # Calculate the absolute date
     cdef:
         npy_datetimestruct dts
@@ -726,12 +726,12 @@ cdef int64_t unix_date_from_ymd(int year, int month, int day) nogil:
     return unix_date
 
 
-cdef int64_t dts_to_month_ordinal(npy_datetimestruct* dts) nogil:
+cdef int64_t dts_to_month_ordinal(npy_datetimestruct* dts) noexcept nogil:
     # AKA: use npy_datetimestruct_to_datetime(NPY_FR_M, &dts)
     return <int64_t>((dts.year - 1970) * 12 + dts.month - 1)
 
 
-cdef int64_t dts_to_year_ordinal(npy_datetimestruct *dts, int to_end) nogil:
+cdef int64_t dts_to_year_ordinal(npy_datetimestruct *dts, int to_end) noexcept nogil:
     cdef:
         int64_t result
 
@@ -742,7 +742,7 @@ cdef int64_t dts_to_year_ordinal(npy_datetimestruct *dts, int to_end) nogil:
         return result
 
 
-cdef int64_t dts_to_qtr_ordinal(npy_datetimestruct* dts, int to_end) nogil:
+cdef int64_t dts_to_qtr_ordinal(npy_datetimestruct* dts, int to_end) noexcept nogil:
     cdef:
         int quarter
 
@@ -751,7 +751,7 @@ cdef int64_t dts_to_qtr_ordinal(npy_datetimestruct* dts, int to_end) nogil:
     return <int64_t>((dts.year - 1970) * 4 + quarter - 1)
 
 
-cdef int get_anchor_month(int freq, int freq_group) nogil:
+cdef int get_anchor_month(int freq, int freq_group) noexcept nogil:
     cdef:
         int fmonth
     fmonth = freq - freq_group
@@ -763,7 +763,7 @@ cdef int get_anchor_month(int freq, int freq_group) nogil:
 # specifically _dont_ use cdvision or else ordinals near -1 are assigned to
 # incorrect dates GH#19643
 @cython.cdivision(False)
-cdef int64_t get_period_ordinal(npy_datetimestruct *dts, int freq) nogil:
+cdef int64_t get_period_ordinal(npy_datetimestruct *dts, int freq) noexcept nogil:
     """
     Generate an ordinal in period space
 
@@ -822,7 +822,7 @@ cdef void get_date_info(int64_t ordinal,
     dts.ps = dts2.ps
 
 
-cdef int64_t get_unix_date(int64_t period_ordinal, int freq) nogil:
+cdef int64_t get_unix_date(int64_t period_ordinal, int freq) noexcept nogil:
     """
     Returns the proleptic Gregorian ordinal of the date, as an integer.
     This corresponds to the number of days since Jan., 1st, 1970 AD.
@@ -851,7 +851,7 @@ cdef int64_t get_unix_date(int64_t period_ordinal, int freq) nogil:
 
 
 @cython.cdivision
-cdef int64_t get_time_nanos(int freq, int64_t unix_date, int64_t ordinal) nogil:
+cdef int64_t get_time_nanos(int freq, int64_t unix_date, int64_t ordinal) noexcept nogil:
     """
     Find the number of nanoseconds after midnight on the given unix_date
     that the ordinal represents in the given frequency.
@@ -936,7 +936,7 @@ cdef int get_yq(int64_t ordinal, int freq, npy_datetimestruct* dts):
     return quarter
 
 
-cdef int month_to_quarter(int month) nogil:
+cdef int month_to_quarter(int month) noexcept nogil:
     return (month - 1) // 3 + 1
 
 
@@ -1024,7 +1024,7 @@ cdef void get_asfreq_info(int from_freq, int to_freq,
 
 
 @cython.cdivision
-cdef int calc_a_year_end(int freq, int group) nogil:
+cdef int calc_a_year_end(int freq, int group) noexcept nogil:
     cdef:
         int result = (freq - group) % 12
     if result == 0:
@@ -1033,7 +1033,7 @@ cdef int calc_a_year_end(int freq, int group) nogil:
         return result
 
 
-cdef int calc_week_end(int freq, int group) nogil:
+cdef int calc_week_end(int freq, int group) noexcept nogil:
     return freq - group
 
 

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -2372,7 +2372,7 @@ Timestamp.daysinmonth = Timestamp.days_in_month
 
 
 @cython.cdivision(False)
-cdef int64_t normalize_i8_stamp(int64_t local_val, int64_t ppd) nogil:
+cdef int64_t normalize_i8_stamp(int64_t local_val, int64_t ppd) noexcept nogil:
     """
     Round the localized nanosecond timestamp down to the previous midnight.
 

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -70,7 +70,7 @@ cdef bint is_monotonic_increasing_start_end_bounds(
 
 cdef float64_t calc_sum(int64_t minp, int64_t nobs, float64_t sum_x,
                         int64_t num_consecutive_same_value, float64_t prev_value
-                        ) nogil:
+                        ) noexcept nogil:
     cdef:
         float64_t result
 
@@ -113,7 +113,7 @@ cdef void add_sum(float64_t val, int64_t *nobs, float64_t *sum_x,
 
 
 cdef void remove_sum(float64_t val, int64_t *nobs, float64_t *sum_x,
-                     float64_t *compensation) nogil:
+                     float64_t *compensation) noexcept nogil:
     """ remove a value from the sum calc using Kahan summation """
 
     cdef:
@@ -189,7 +189,7 @@ def roll_sum(const float64_t[:] values, ndarray[int64_t] start,
 
 cdef float64_t calc_mean(int64_t minp, Py_ssize_t nobs, Py_ssize_t neg_ct,
                          float64_t sum_x, int64_t num_consecutive_same_value,
-                         float64_t prev_value) nogil:
+                         float64_t prev_value) noexcept nogil:
     cdef:
         float64_t result
 
@@ -218,7 +218,7 @@ cdef void add_mean(
     float64_t *compensation,
     int64_t *num_consecutive_same_value,
     float64_t *prev_value
-) nogil:
+) noexcept nogil:
     """ add a value from the mean calc using Kahan summation """
     cdef:
         float64_t y, t
@@ -243,7 +243,7 @@ cdef void add_mean(
 
 
 cdef void remove_mean(float64_t val, Py_ssize_t *nobs, float64_t *sum_x,
-                      Py_ssize_t *neg_ct, float64_t *compensation) nogil:
+                      Py_ssize_t *neg_ct, float64_t *compensation) noexcept nogil:
     """ remove a value from the mean calc using Kahan summation """
     cdef:
         float64_t y, t
@@ -324,7 +324,7 @@ cdef float64_t calc_var(
     float64_t nobs,
     float64_t ssqdm_x,
     int64_t num_consecutive_same_value
-) nogil:
+) noexcept nogil:
     cdef:
         float64_t result
 
@@ -350,7 +350,7 @@ cdef void add_var(
     float64_t *compensation,
     int64_t *num_consecutive_same_value,
     float64_t *prev_value,
-) nogil:
+) noexcept nogil:
     """ add a value from the var calc """
     cdef:
         float64_t delta, prev_mean, y, t
@@ -390,7 +390,7 @@ cdef void remove_var(
     float64_t *mean_x,
     float64_t *ssqdm_x,
     float64_t *compensation
-) nogil:
+) noexcept nogil:
     """ remove a value from the var calc """
     cdef:
         float64_t delta, prev_mean, y, t
@@ -482,7 +482,7 @@ def roll_var(const float64_t[:] values, ndarray[int64_t] start,
 cdef float64_t calc_skew(int64_t minp, int64_t nobs,
                          float64_t x, float64_t xx, float64_t xxx,
                          int64_t num_consecutive_same_value
-                         ) nogil:
+                         ) noexcept nogil:
     cdef:
         float64_t result, dnobs
         float64_t A, B, C, R
@@ -528,7 +528,7 @@ cdef void add_skew(float64_t val, int64_t *nobs,
                    float64_t *compensation_xxx,
                    int64_t *num_consecutive_same_value,
                    float64_t *prev_value,
-                   ) nogil:
+                   ) noexcept nogil:
     """ add a value from the skew calc """
     cdef:
         float64_t y, t
@@ -564,7 +564,7 @@ cdef void remove_skew(float64_t val, int64_t *nobs,
                       float64_t *xxx,
                       float64_t *compensation_x,
                       float64_t *compensation_xx,
-                      float64_t *compensation_xxx) nogil:
+                      float64_t *compensation_xxx) noexcept nogil:
     """ remove a value from the skew calc """
     cdef:
         float64_t y, t
@@ -681,7 +681,7 @@ cdef float64_t calc_kurt(int64_t minp, int64_t nobs,
                          float64_t x, float64_t xx,
                          float64_t xxx, float64_t xxxx,
                          int64_t num_consecutive_same_value,
-                         ) nogil:
+                         ) noexcept nogil:
     cdef:
         float64_t result, dnobs
         float64_t A, B, C, D, R, K
@@ -732,7 +732,7 @@ cdef void add_kurt(float64_t val, int64_t *nobs,
                    float64_t *compensation_xxxx,
                    int64_t *num_consecutive_same_value,
                    float64_t *prev_value
-                   ) nogil:
+                   ) noexcept nogil:
     """ add a value from the kurotic calc """
     cdef:
         float64_t y, t
@@ -773,7 +773,7 @@ cdef void remove_kurt(float64_t val, int64_t *nobs,
                       float64_t *compensation_x,
                       float64_t *compensation_xx,
                       float64_t *compensation_xxx,
-                      float64_t *compensation_xxxx) nogil:
+                      float64_t *compensation_xxxx) noexcept nogil:
     """ remove a value from the kurotic calc """
     cdef:
         float64_t y, t
@@ -992,7 +992,7 @@ def roll_median_c(const float64_t[:] values, ndarray[int64_t] start,
 # https://github.com/pydata/bottleneck
 
 
-cdef float64_t init_mm(float64_t ai, Py_ssize_t *nobs, bint is_max) nogil:
+cdef float64_t init_mm(float64_t ai, Py_ssize_t *nobs, bint is_max) noexcept nogil:
 
     if ai == ai:
         nobs[0] = nobs[0] + 1
@@ -1004,14 +1004,14 @@ cdef float64_t init_mm(float64_t ai, Py_ssize_t *nobs, bint is_max) nogil:
     return ai
 
 
-cdef void remove_mm(float64_t aold, Py_ssize_t *nobs) nogil:
+cdef void remove_mm(float64_t aold, Py_ssize_t *nobs) noexcept nogil:
     """ remove a value from the mm calc """
     if aold == aold:
         nobs[0] = nobs[0] - 1
 
 
 cdef float64_t calc_mm(int64_t minp, Py_ssize_t nobs,
-                       float64_t value) nogil:
+                       float64_t value) noexcept nogil:
     cdef:
         float64_t result
 
@@ -1522,7 +1522,7 @@ cdef float64_t calc_weighted_var(float64_t t,
                                  Py_ssize_t win_n,
                                  unsigned int ddof,
                                  float64_t nobs,
-                                 int64_t minp) nogil:
+                                 int64_t minp) noexcept nogil:
     """
     Calculate weighted variance for a window using West's method.
 
@@ -1573,7 +1573,7 @@ cdef void add_weighted_var(float64_t val,
                            float64_t *t,
                            float64_t *sum_w,
                            float64_t *mean,
-                           float64_t *nobs) nogil:
+                           float64_t *nobs) noexcept nogil:
     """
     Update weighted mean, sum of weights and sum of weighted squared
     differences to include value and weight pair in weighted variance
@@ -1619,7 +1619,7 @@ cdef void remove_weighted_var(float64_t val,
                               float64_t *t,
                               float64_t *sum_w,
                               float64_t *mean,
-                              float64_t *nobs) nogil:
+                              float64_t *nobs) noexcept nogil:
     """
     Update weighted mean, sum of weights and sum of weighted squared
     differences to remove value and weight pair from weighted variance


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This PR marks all `nogil` functions as `noexcept` because:
1. Currently, they are not propagating exception with Cython 0.29.X
2. I found out that several of functions are still checking exception after every call - e.g. https://github.com/pandas-dev/pandas/blob/75daea460b3c2f14ece2c7e10d34ce90b0e52f8a/pandas/_libs/tslibs/ccalendar.pyx#L158
3. Several functions returning `void` were missed in #53144

> **Note**: `nogil` function calls checking the exception after every function call is introducing non-negligible performance degradation - see https://cython.readthedocs.io/en/latest/src/userguide/language_basics.html#error-return-values