### PR TITLE
TST: adds test for Series and argwhere interaction

### DIFF
--- a/pandas/tests/series/test_npfuncs.py
+++ b/pandas/tests/series/test_npfuncs.py
@@ -29,7 +29,7 @@ def test_numpy_argwhere(index):
 
     s = Series(range(5), index=index, dtype=np.int64)
 
-    result = np.argwhere(s > 2)
+    result = np.argwhere(s > 2).astype(np.int64)
     expected = np.array([[3], [4]], dtype=np.int64)
 
     tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/series/test_npfuncs.py
+++ b/pandas/tests/series/test_npfuncs.py
@@ -27,7 +27,7 @@ def test_numpy_unique(datetime_series):
 def test_numpy_argwhere(index):
     # GH#35331
 
-    s = Series(range(5), index=index)
+    s = Series(range(5), index=index, dtype=np.int64)
 
     result = np.argwhere(s > 2)
     expected = np.array([[3], [4]], dtype=np.int64)

--- a/pandas/tests/series/test_npfuncs.py
+++ b/pandas/tests/series/test_npfuncs.py
@@ -3,8 +3,10 @@ Tests for np.foo applied to Series, not necessarily ufuncs.
 """
 
 import numpy as np
+import pytest
 
 from pandas import Series
+import pandas._testing as tm
 
 
 class TestPtp:
@@ -19,3 +21,15 @@ class TestPtp:
 def test_numpy_unique(datetime_series):
     # it works!
     np.unique(datetime_series)
+
+
+@pytest.mark.parametrize("index", [["a", "b", "c", "d", "e"], None])
+def test_numpy_argwhere(index):
+    # GH#35331
+
+    s = Series(range(5), index=index)
+
+    result = np.argwhere(s > 2)
+    expected = np.array([[3], [4]])
+
+    tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/series/test_npfuncs.py
+++ b/pandas/tests/series/test_npfuncs.py
@@ -30,6 +30,6 @@ def test_numpy_argwhere(index):
     s = Series(range(5), index=index)
 
     result = np.argwhere(s > 2)
-    expected = np.array([[3], [4]])
+    expected = np.array([[3], [4]], dtype=np.int64)
 
     tm.assert_numpy_array_equal(result, expected)


### PR DESCRIPTION
- [x] closes #35331 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] ~Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.~ N/A
- [ ] ~Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.~ N/A

### Details:
- Adds missing tests mentioned by @mroeschke last week. 
- Dug around briefly in other issues / prs to link the fix to this bug however nothing jumped out. 