### PR TITLE
DOC: Adjust build command for building with meson

### DIFF
--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -223,7 +223,10 @@ Because the meson build system is newer, you may find bugs/minor issues as it ma
 To compile pandas with meson, run::
 
    # Build and install pandas
-   python -m pip install -ve . --no-build-isolation
+   # By default, this will print verbose output
+   # showing the "rebuild" taking place on import (see section below for explanation)
+   # If you do not want to see this, omit everything after --no-build-isolation
+   python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true
 
 **Build options**
 


### PR DESCRIPTION
Change default command to show verbose output, as discussed during the dev call.

Otherwise, it might be confusing for users when the import hangs and their CPU goes to 100% during the rebuild step.

cc @ngoldbaum
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
