### PR TITLE
DOC: Prepare release notes for 2.0.2

### DIFF
--- a/doc/source/whatsnew/v2.0.2.rst
+++ b/doc/source/whatsnew/v2.0.2.rst
@@ -1,6 +1,6 @@
 .. _whatsnew_202:
 
-What's new in 2.0.2 (May ..., 2023)
+What's new in 2.0.2 (May 26, 2023)
 -----------------------------------
 
 These are the changes in pandas 2.0.2. See :ref:`release` for a full changelog


### PR DESCRIPTION
- xref #52892

Updating the release date of the whatsnew file. This needs to be backported
