### PR TITLE
`DataFrame.dictmap` - apply multiple column transforms simultaneously via a dict and `DataFrame.map`

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9879,9 +9879,9 @@ class DataFrame(NDFrame, OpsMixin):
         >>> df.dictmap({'x': lambda x: x ** 2,
                         'z': lambda z: 1 - z/2})
            x  y    z
-        0  1  3 -2.0
-        1  4  4 -2.5
-        2  9  5 -3.0
+        0  1  3 -2.5
+        1  4  4 -3.0
+        2  9  5 -3.5
 
         """
         from pandas.core.reshape.concat import concat

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9879,9 +9879,9 @@ class DataFrame(NDFrame, OpsMixin):
         >>> df.dictmap({'x': lambda x: x ** 2,
                         'z': lambda z: 1 - z/2})
            x  y    z
-        0  1  3 -2.5
-        1  4  4 -3.0
-        2  9  5 -3.5
+        0  1  4 -2.5
+        1  4  5 -3.0
+        2  9  6 -3.5
 
         """
         from pandas.core.reshape.concat import concat

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9870,7 +9870,7 @@ class DataFrame(NDFrame, OpsMixin):
         >>> d = pd.DataFrame([[1,4,7],
         ...                   [2,5,8],
         ...                   [3,6,9]],
-        ...                   columns=['x', 'y', 'z']
+        ...                   columns=['x', 'y', 'z'])
         >>> df
            x  y  z
         0  1  4  7

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9843,6 +9843,56 @@ class DataFrame(NDFrame, OpsMixin):
 
         return self.apply(infer).__finalize__(self, "map")
 
+    def dictmap(
+        self, mapdict: Dict[str, Callable], **kwargs
+    ) -> pd.DataFrame:
+        """
+        Applies a dict of column names and column mapping functions on
+        matching columns in the ``self``` dataframe, while preserving non-matching
+        columns.
+
+        Parameters
+        ----------
+        mapdict : dict
+            A dict keyed by column name, values are column mapping functions;
+            the column names in the keys should match a subset of columns in
+            the ``self`` datafame. The column mapping functions should be
+            applicable on values in a column using ``map``.
+        **kwargs
+            Additional keyword arguments that could be passed to this method,
+            but not supported in this implementation.
+
+        Returns
+        -------
+        DataFrame
+            Transformed DataFrame.
+
+        Examples
+        --------
+        >>> d = pd.DataFrame([[1,4,7],
+        ...                   [2,5,8],
+        ...                   [3,6,9]],
+        ...                   columns=['x', 'y', 'z']
+        >>> df
+           x  y  z
+        0  1  4  7
+        1  2  5  8
+        2  3  6  9
+        >>> df.dictmap({'x': lambda x: x ** 2,
+                        'z': lambda z: 1 - z/2})
+           x  y    z
+        0  1  3 -2.0
+        1  4  4 -2.5
+        2  9  5 -3.0
+
+        """
+        return pd.concat(
+            [self[col].map(mapdict[col]) if col in mapdict
+             else self[col]
+             for col in self.columns],
+            axis=1
+        )
+
     def applymap(
         self, func: PythonFuncType, na_action: NaAction | None = None, **kwargs
     ) -> DataFrame:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9843,9 +9843,7 @@ class DataFrame(NDFrame, OpsMixin):
 
         return self.apply(infer).__finalize__(self, "map")
 
-    def dictmap(
-        self, mapdict: Dict[str, Callable], **kwargs
-    ) -> pd.DataFrame:
+    def dictmap(self, mapdict: dict[str, Callable], **kwargs) -> DataFrame:
         """
         Applies a dict of column names and column mapping functions on
         matching columns in the ``self``` dataframe, while preserving non-matching
@@ -9886,11 +9884,14 @@ class DataFrame(NDFrame, OpsMixin):
         2  9  5 -3.0
 
         """
-        return pd.concat(
-            [self[col].map(mapdict[col]) if col in mapdict
-             else self[col]
-             for col in self.columns],
-            axis=1
+        from pandas.core.reshape.concat import concat
+
+        return concat(
+            [
+                self[col].map(mapdict[col]) if col in mapdict else self[col]
+                for col in self.columns
+            ],
+            axis=1,
         )
 
     def applymap(

--- a/pandas/tests/frame/methods/test_dictmap.py
+++ b/pandas/tests/frame/methods/test_dictmap.py
@@ -1,23 +1,8 @@
-from datetime import datetime
-
-import numpy as np
-import pytest
-
-import pandas as pd
-from pandas import (
-    DataFrame,
-    Series,
-    Timestamp,
-    date_range,
-)
+from pandas import DataFrame
 import pandas._testing as tm
 
 
 def test_dictmap():
-    df = DataFrame([[1, 4, 7],
-                    [2, 5, 8],
-                    [3, 6, 9]],
-                   columns=['x', 'y', 'z'])
-    result = df.dictmap({'x': lambda x: x ** 2,
-                         'z': lambda z: 1 - z/2})
+    df = DataFrame([[1, 4, 7], [2, 5, 8], [3, 6, 9]], columns=["x", "y", "z"])
+    result = df.dictmap({"x": lambda x: x**2, "z": lambda z: 1 - z / 2})
     tm.assert_frame_equal(result, df)

--- a/pandas/tests/frame/methods/test_dictmap.py
+++ b/pandas/tests/frame/methods/test_dictmap.py
@@ -4,5 +4,6 @@ import pandas._testing as tm
 
 def test_dictmap():
     df = DataFrame([[1, 4, 7], [2, 5, 8], [3, 6, 9]], columns=["x", "y", "z"])
-    result = df.dictmap({"x": lambda x: x**2, "z": lambda z: 1 - z / 2})
-    tm.assert_frame_equal(result, df)
+    result = df.dictmap({"x": lambda x: x ** 2, "z": lambda z: 1 - z / 2})
+    expected = DataFrame([[1, 4, -2.5], [4, 5, -3.0], [9, 6, -3.5]], columns=["x", "y", "z"])
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/methods/test_dictmap.py
+++ b/pandas/tests/frame/methods/test_dictmap.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+import pandas as pd
+from pandas import (
+    DataFrame,
+    Series,
+    Timestamp,
+    date_range,
+)
+import pandas._testing as tm
+
+
+def test_dictmap():
+    df = DataFrame([[1, 4, 7],
+                    [2, 5, 8],
+                    [3, 6, 9]],
+                   columns=['x', 'y', 'z'])
+    result = df.dictmap({'x': lambda x: x ** 2,
+                         'z': lambda z: 1 - z/2})
+    tm.assert_frame_equal(result, df)

--- a/pandas/tests/frame/methods/test_dictmap.py
+++ b/pandas/tests/frame/methods/test_dictmap.py
@@ -4,6 +4,8 @@ import pandas._testing as tm
 
 def test_dictmap():
     df = DataFrame([[1, 4, 7], [2, 5, 8], [3, 6, 9]], columns=["x", "y", "z"])
-    result = df.dictmap({"x": lambda x: x ** 2, "z": lambda z: 1 - z / 2})
-    expected = DataFrame([[1, 4, -2.5], [4, 5, -3.0], [9, 6, -3.5]], columns=["x", "y", "z"])
+    result = df.dictmap({"x": lambda x: x**2, "z": lambda z: 1 - z / 2})
+    expected = DataFrame(
+        [[1, 4, -2.5], [4, 5, -3.0], [9, 6, -3.5]], columns=["x", "y", "z"]
+    )
     tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
Adds a `dictmap` instance method to `DataFrame`, that allows callers to apply multiple column transforms simultaneously via a dict of column names and transform functions.

The specified columns are keyed in the dict passed to the method, and the values are the associated transforms. 

The transforms are applied via `DataFrame.map`, while the columns are concatenated along the columns axis.

The row index is unchanged, and the output has the same shape as before.

Example below:
```
>>> d = pd.DataFrame([[1,4,7],
...                   [2,5,8],
...                   [3,6,9]],
...                   columns=['x', 'y', 'z']
>>> df
   x  y  z
0  1  4  7
1  2  5  8
2  3  6  9
>>> df.dictmap({'x': lambda x: x ** 2,
                'z': lambda z: 1 - z/2})
   x  y    z
0  1  4 -2.5
1  4  5 -3.0
2  9  6 -3.5
```
