### PR TITLE
DOC: Typo fix on subset data doc

### DIFF
--- a/doc/source/getting_started/intro_tutorials/03_subset_data.rst
+++ b/doc/source/getting_started/intro_tutorials/03_subset_data.rst
@@ -330,7 +330,7 @@ selection brackets ``[]``.
 
 When selecting specific rows and/or columns with ``loc`` or ``iloc``,
 new values can be assigned to the selected data. For example, to assign
-the name ``anonymous`` to the first 3 elements of the third column:
+the name ``anonymous`` to the first 3 elements of the fourth column:
 
 .. ipython:: python
 

--- a/doc/source/getting_started/intro_tutorials/03_subset_data.rst
+++ b/doc/source/getting_started/intro_tutorials/03_subset_data.rst
@@ -330,7 +330,7 @@ selection brackets ``[]``.
 
 When selecting specific rows and/or columns with ``loc`` or ``iloc``,
 new values can be assigned to the selected data. For example, to assign
-the name ``anonymous`` to the first 3 elements of the fourth column:
+the name ``anonymous`` to the first 3 elements of the third column:
 
 .. ipython:: python
 


### PR DESCRIPTION
- [x] closes #53395
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).