### PR TITLE
DOC: Final clean up of release notes for 2.0.2

### DIFF
--- a/doc/source/whatsnew/v2.0.2.rst
+++ b/doc/source/whatsnew/v2.0.2.rst
@@ -39,7 +39,6 @@ Bug fixes
 - Bug in :meth:`Series.rename` not making a lazy copy when Copy-on-Write is enabled when a scalar is passed to it (:issue:`52450`)
 - Bug in :meth:`pd.array` raising for ``NumPy`` array and ``pa.large_string`` or ``pa.large_binary`` (:issue:`52590`)
 - Bug in :meth:`DataFrame.__getitem__` not preserving dtypes for :class:`MultiIndex` partial keys (:issue:`51895`)
--
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_202.other:


### PR DESCRIPTION
For some reason there was an empty bullet point in the release notes that is removed in main, but wasn't backported to 2.0.x.

Removing it here, and then we're ready to release, CI is green now for 2.0.x.