### PR TITLE
CLN: remove unused **kwargs from BaseMaskedArray._wrap_reduction_result

### DIFF
--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -1095,9 +1095,8 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
 
         return result
 
-    def _wrap_reduction_result(self, name: str, result, skipna, **kwargs):
+    def _wrap_reduction_result(self, name: str, result, *, skipna, axis):
         if isinstance(result, np.ndarray):
-            axis = kwargs["axis"]
             if skipna:
                 # we only retain mask for all-NA rows/columns
                 mask = self._mask.all(axis=axis)
@@ -1124,9 +1123,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
             min_count=min_count,
             axis=axis,
         )
-        return self._wrap_reduction_result(
-            "sum", result, skipna=skipna, axis=axis, **kwargs
-        )
+        return self._wrap_reduction_result("sum", result, skipna=skipna, axis=axis)
 
     def prod(
         self,
@@ -1144,9 +1141,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
             min_count=min_count,
             axis=axis,
         )
-        return self._wrap_reduction_result(
-            "prod", result, skipna=skipna, axis=axis, **kwargs
-        )
+        return self._wrap_reduction_result("prod", result, skipna=skipna, axis=axis)
 
     def mean(self, *, skipna: bool = True, axis: AxisInt | None = 0, **kwargs):
         nv.validate_mean((), kwargs)
@@ -1156,9 +1151,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
             skipna=skipna,
             axis=axis,
         )
-        return self._wrap_reduction_result(
-            "mean", result, skipna=skipna, axis=axis, **kwargs
-        )
+        return self._wrap_reduction_result("mean", result, skipna=skipna, axis=axis)
 
     def var(
         self, *, skipna: bool = True, axis: AxisInt | None = 0, ddof: int = 1, **kwargs
@@ -1171,9 +1164,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
             axis=axis,
             ddof=ddof,
         )
-        return self._wrap_reduction_result(
-            "var", result, skipna=skipna, axis=axis, **kwargs
-        )
+        return self._wrap_reduction_result("var", result, skipna=skipna, axis=axis)
 
     def std(
         self, *, skipna: bool = True, axis: AxisInt | None = 0, ddof: int = 1, **kwargs
@@ -1186,9 +1177,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
             axis=axis,
             ddof=ddof,
         )
-        return self._wrap_reduction_result(
-            "std", result, skipna=skipna, axis=axis, **kwargs
-        )
+        return self._wrap_reduction_result("std", result, skipna=skipna, axis=axis)
 
     def min(self, *, skipna: bool = True, axis: AxisInt | None = 0, **kwargs):
         nv.validate_min((), kwargs)


### PR DESCRIPTION
The `**kwargs` isn't used.