### PR TITLE
CLN: Remove deprecated numba functions

### DIFF
--- a/pandas/core/groupby/numba_.py
+++ b/pandas/core/groupby/numba_.py
@@ -92,7 +92,7 @@ def generate_numba_agg_func(
     -------
     Numba function
     """
-    numba_func = jit_user_function(func, nopython, nogil, parallel)
+    numba_func = jit_user_function(func)
     if TYPE_CHECKING:
         import numba
     else:
@@ -152,7 +152,7 @@ def generate_numba_transform_func(
     -------
     Numba function
     """
-    numba_func = jit_user_function(func, nopython, nogil, parallel)
+    numba_func = jit_user_function(func)
     if TYPE_CHECKING:
         import numba
     else:

--- a/pandas/core/window/numba_.py
+++ b/pandas/core/window/numba_.py
@@ -48,7 +48,7 @@ def generate_numba_apply_func(
     -------
     Numba function
     """
-    numba_func = jit_user_function(func, nopython, nogil, parallel)
+    numba_func = jit_user_function(func)
     if TYPE_CHECKING:
         import numba
     else:
@@ -207,7 +207,7 @@ def generate_numba_table_func(
     -------
     Numba function
     """
-    numba_func = jit_user_function(func, nopython, nogil, parallel)
+    numba_func = jit_user_function(func)
     if TYPE_CHECKING:
         import numba
     else:


### PR DESCRIPTION
- [ ] closes #53449 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

The replacement for ``generated_jit`` is ``numba.extending.overload``.

That shouldn't be necessary tho IMO. 
Since the user function is always part of another jitted numba function, we can just mark the function as ``jitable`` and have it inherit the ``nopython``, ``nogil``, etc. of the outer function.