### PR TITLE
CLN: use cache instead of lru_cache for unbound cache

### DIFF
--- a/pandas/core/_numba/executor.py
+++ b/pandas/core/_numba/executor.py
@@ -14,7 +14,7 @@ import numpy as np
 from pandas.compat._optional import import_optional_dependency
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def generate_shared_aggregator(
     func: Callable[..., Scalar],
     nopython: bool,

--- a/pandas/core/array_algos/take.py
+++ b/pandas/core/array_algos/take.py
@@ -285,7 +285,7 @@ def take_2d_multi(
     return out
 
 
-@functools.lru_cache(maxsize=128)
+@functools.lru_cache
 def _get_take_nd_function_cached(
     ndim: int, arr_dtype: np.dtype, out_dtype: np.dtype, axis: AxisInt
 ):

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -586,7 +586,7 @@ def maybe_promote(dtype: np.dtype, fill_value=np.nan):
     return dtype, fill_value
 
 
-@functools.lru_cache(maxsize=128)
+@functools.lru_cache
 def _maybe_promote_cached(dtype, fill_value, fill_value_type):
     # The cached version of _maybe_promote below
     # This also use fill_value_type as (unused) argument to use this in the

--- a/pandas/core/groupby/numba_.py
+++ b/pandas/core/groupby/numba_.py
@@ -61,7 +61,7 @@ def validate_udf(func: Callable) -> None:
         )
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def generate_numba_agg_func(
     func: Callable[..., Scalar],
     nopython: bool,
@@ -121,7 +121,7 @@ def generate_numba_agg_func(
     return group_agg
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def generate_numba_transform_func(
     func: Callable[..., np.ndarray],
     nopython: bool,

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -162,7 +162,7 @@ class WrappedCythonOp:
     # Note: we make this a classmethod and pass kind+how so that caching
     #  works at the class level and not the instance level
     @classmethod
-    @functools.lru_cache(maxsize=None)
+    @functools.cache
     def _get_cython_function(
         cls, kind: str, how: str, dtype: np.dtype, is_numeric: bool
     ):

--- a/pandas/core/window/numba_.py
+++ b/pandas/core/window/numba_.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from pandas._typing import Scalar
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def generate_numba_apply_func(
     func: Callable[..., Scalar],
     nopython: bool,
@@ -77,7 +77,7 @@ def generate_numba_apply_func(
     return roll_apply
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def generate_numba_ewm_func(
     nopython: bool,
     nogil: bool,
@@ -175,7 +175,7 @@ def generate_numba_ewm_func(
     return ewm
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def generate_numba_table_func(
     func: Callable[..., np.ndarray],
     nopython: bool,
@@ -241,7 +241,7 @@ def generate_numba_table_func(
 # This function will no longer be needed once numba supports
 # axis for all np.nan* agg functions
 # https://github.com/numba/numba/issues/1269
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def generate_manual_numpy_nan_agg_with_axis(nan_func):
     if TYPE_CHECKING:
         import numba
@@ -259,7 +259,7 @@ def generate_manual_numpy_nan_agg_with_axis(nan_func):
     return nan_agg_with_axis
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def generate_numba_ewm_table_func(
     nopython: bool,
     nogil: bool,

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -3,10 +3,7 @@ Utilities for conversion to writer-agnostic Excel representation.
 """
 from __future__ import annotations
 
-from functools import (
-    lru_cache,
-    reduce,
-)
+import functools
 import itertools
 import re
 from typing import (
@@ -193,10 +190,10 @@ class CSSToExcelConverter:
             self.inherited = self.compute_css(inherited)
         else:
             self.inherited = None
-        # We should avoid lru_cache on the __call__ method.
+        # We should avoid cache on the __call__ method.
         # Otherwise once the method __call__ has been called
         # garbage collection no longer deletes the instance.
-        self._call_cached = lru_cache(maxsize=None)(self._call_uncached)
+        self._call_cached = functools.cache(self._call_uncached)
 
     compute_css = CSSResolver()
 
@@ -726,7 +723,7 @@ class ExcelFormatter:
             row = [x if x is not None else "" for x in self.df.index.names] + [
                 ""
             ] * len(self.columns)
-            if reduce(lambda x, y: x and y, (x != "" for x in row)):
+            if functools.reduce(lambda x, y: x and y, (x != "" for x in row)):
                 gen2 = (
                     ExcelCell(self.rowcounter, colindex, val, self.header_style)
                     for colindex, val in enumerate(row)


### PR DESCRIPTION
`maxsize=128` is the default value for `lru_cache`.

`maxsize=None` is the equivalent of `cache` after Python 3.9.

