### PR TITLE
TYP: Fix typing issues, mainly Something => IndexLabel

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6956,7 +6956,7 @@ class DataFrame(NDFrame, OpsMixin):
 
     def value_counts(
         self,
-        subset: Sequence[Hashable] | None = None,
+        subset: IndexLabel | None = None,
         normalize: bool = False,
         sort: bool = True,
         ascending: bool = False,
@@ -7080,8 +7080,8 @@ class DataFrame(NDFrame, OpsMixin):
         if normalize:
             counts /= counts.sum()
 
-        # Force MultiIndex for single column
-        if is_list_like(subset) and len(subset) == 1:
+        # Force MultiIndex for a list_like subset with a single column
+        if is_list_like(subset) and len(subset) == 1:  # type: ignore[arg-type]
             counts.index = MultiIndex.from_arrays(
                 [counts.index], names=[counts.index.name]
             )
@@ -8991,7 +8991,7 @@ class DataFrame(NDFrame, OpsMixin):
             sort=sort,
         )
 
-    def stack(self, level: Level = -1, dropna: bool = True, sort: bool = True):
+    def stack(self, level: IndexLabel = -1, dropna: bool = True, sort: bool = True):
         """
         Stack the prescribed level(s) from columns to index.
 
@@ -9296,7 +9296,7 @@ class DataFrame(NDFrame, OpsMixin):
 
         return result.__finalize__(self, method="explode")
 
-    def unstack(self, level: Level = -1, fill_value=None, sort: bool = True):
+    def unstack(self, level: IndexLabel = -1, fill_value=None, sort: bool = True):
         """
         Pivot a level of the (necessarily hierarchical) index labels.
 


### PR DESCRIPTION
Several typing annotations in Pandas are not correct. This patch tries to fix some of them.

The internal names in Pandas are not straight forward. An `IndexLabel` is used for one or multiple columns.

 * `value_counts` also works for a single column
 * `stack`/`unstack` can work with multiple levels at the same time

I have the feeling that there might be more such problems in the code. There are also some incorrect annotations in pandas-stubs mainly related to one/multiple index levels (refer to https://github.com/pandas-dev/pandas-stubs/issues/703 - even though I haven't had time for a PR over there)