### PR TITLE
TST: fix import in test_hash_pandas_object extension test

### DIFF
--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -21,10 +21,10 @@ class BaseMethodsTests(BaseExtensionTests):
     def test_hash_pandas_object(self, data):
         # _hash_pandas_object should return a uint64 ndarray of the same length
         # as the data
+        from pandas.core.util.hashing import _default_hash_key
+
         res = data._hash_pandas_object(
-            encoding="utf-8",
-            hash_key=pd.core.util.hashing._default_hash_key,
-            categorize=False,
+            encoding="utf-8", hash_key=_default_hash_key, categorize=False
         )
         assert res.dtype == np.uint64
         assert res.shape == data.shape


### PR DESCRIPTION
Calling `pd.core.util.hashing._default_hash_key` directly after import of pandas fails with an ImportError, but depending on whether you already did some other operations, the import will succeed. That gives intermittent failures in the test suite (I don't know if it happens in pandas itself, but at least we are seeing it in the geopandas test suite: https://github.com/geopandas/geopandas/issues/2911)