### PR TITLE
DOC: point out that only period frequencies are valid for to_period

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1139,9 +1139,9 @@ default 'raise'
 
     def to_period(self, freq=None) -> PeriodArray:
         """
-        Cast to PeriodArray/Index at a particular frequency.
+        Cast to PeriodArray/PeriodIndex at a particular frequency.
 
-        Converts DatetimeArray/Index to PeriodArray/Index.
+        Converts DatetimeArray/Index to PeriodArray/PeriodIndex.
 
         Parameters
         ----------


### PR DESCRIPTION
Updated docs for `to_period`. Point out that only `period` frequencies are valid for `to_period`. For example, offset frequency `'MS'` isn't valid for `to_period`.

```
>>> df = pd.DataFrame({"y": [1, 2]}, `index=pd.to_datetime(["2000-03-31` 00:00:00", "2000-05-31 00:00:00"]))
>>> df.index.to_period("MS")
AttributeError: 'pandas._libs.tslibs.offsets.MonthBegin' object has no attribute '_period_dtype_code'

```
Maybe it would be better to have 2 different tables, for offset aliases and period aliases, instead of this one for [offset aliases](https://pandas.pydata.org/docs/user_guide/timeseries.html#timeseries-offset-aliases)?