### PR TITLE
BUG: dtype from nankurt and nanskew when returning 0

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -346,6 +346,7 @@ Timezones
 Numeric
 ^^^^^^^
 - Bug in :class:`RangeIndex` setting ``step`` incorrectly when being the subtrahend with minuend a numeric value (:issue:`53255`)
+- Bug when calling :meth:`Series.kurt` and :meth:`Series.skew` on numpy data of all zero returning a python type instead of a numpy type (:issue:`xxxxx`)
 - Bug in :meth:`Series.corr` and :meth:`Series.cov` raising ``AttributeError`` for masked dtypes (:issue:`51422`)
 - Bug in :meth:`Series.mean`, :meth:`DataFrame.mean` with object-dtype values containing strings that can be converted to numbers (e.g. "2") returning incorrect numeric results; these now raise ``TypeError`` (:issue:`36703`, :issue:`44008`)
 - Bug in :meth:`DataFrame.corrwith` raising ``NotImplementedError`` for pyarrow-backed dtypes (:issue:`52314`)

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -346,8 +346,8 @@ Timezones
 Numeric
 ^^^^^^^
 - Bug in :class:`RangeIndex` setting ``step`` incorrectly when being the subtrahend with minuend a numeric value (:issue:`53255`)
-- Bug when calling :meth:`Series.kurt` and :meth:`Series.skew` on numpy data of all zero returning a python type instead of a numpy type (:issue:`xxxxx`)
 - Bug in :meth:`Series.corr` and :meth:`Series.cov` raising ``AttributeError`` for masked dtypes (:issue:`51422`)
+- Bug when calling :meth:`Series.kurt` and :meth:`Series.skew` on numpy data of all zero returning a python type instead of a numpy type (:issue:`53482`)
 - Bug in :meth:`Series.mean`, :meth:`DataFrame.mean` with object-dtype values containing strings that can be converted to numbers (e.g. "2") returning incorrect numeric results; these now raise ``TypeError`` (:issue:`36703`, :issue:`44008`)
 - Bug in :meth:`DataFrame.corrwith` raising ``NotImplementedError`` for pyarrow-backed dtypes (:issue:`52314`)
 - Bug in :meth:`DataFrame.size` and :meth:`Series.size` returning 64-bit integer instead of int (:issue:`52897`)

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1267,7 +1267,7 @@ def nanskew(
         result = np.where(m2 == 0, 0, result)
         result[count < 3] = np.nan
     else:
-        result = 0 if m2 == 0 else result
+        result = dtype.type(0) if m2 == 0 else result
         if count < 3:
             return np.nan
 
@@ -1355,7 +1355,7 @@ def nankurt(
         if count < 4:
             return np.nan
         if denominator == 0:
-            return 0
+            return values.dtype.type(0)
 
     with np.errstate(invalid="ignore", divide="ignore"):
         result = numerator / denominator - adj

--- a/pandas/tests/reductions/test_stat_reductions.py
+++ b/pandas/tests/reductions/test_stat_reductions.py
@@ -239,11 +239,13 @@ class TestSeriesStatReductions:
         for i in range(1, min_N + 1):
             s = Series(np.ones(i))
             df = DataFrame(np.ones((i, i)))
+            result = s.skew()
             if i < min_N:
-                assert np.isnan(s.skew())
-                assert np.isnan(df.skew()).all()
+                assert np.isnan(result)
+                assert np.isnan(result).all()
             else:
-                assert 0 == s.skew()
+                assert 0 == result
+                assert isinstance(result, np.float64)
                 assert (df.skew() == 0).all()
 
     @td.skip_if_no_scipy
@@ -262,9 +264,11 @@ class TestSeriesStatReductions:
         for i in range(1, min_N + 1):
             s = Series(np.ones(i))
             df = DataFrame(np.ones((i, i)))
+            result = s.kurt()
             if i < min_N:
-                assert np.isnan(s.kurt())
-                assert np.isnan(df.kurt()).all()
+                assert np.isnan(result)
+                assert np.isnan(result).all()
             else:
-                assert 0 == s.kurt()
+                assert 0 == result
+                assert isinstance(result, np.float64)
                 assert (df.kurt() == 0).all()

--- a/pandas/tests/reductions/test_stat_reductions.py
+++ b/pandas/tests/reductions/test_stat_reductions.py
@@ -245,7 +245,7 @@ class TestSeriesStatReductions:
                 assert np.isnan(result).all()
             else:
                 assert 0 == result
-                assert isinstance(result, np.float64)
+                assert isinstance(result, np.float64)  # GH53482
                 assert (df.skew() == 0).all()
 
     @td.skip_if_no_scipy
@@ -270,5 +270,5 @@ class TestSeriesStatReductions:
                 assert np.isnan(result).all()
             else:
                 assert 0 == result
-                assert isinstance(result, np.float64)
+                assert isinstance(result, np.float64)  # GH53482
                 assert (df.kurt() == 0).all()

--- a/pandas/tests/reductions/test_stat_reductions.py
+++ b/pandas/tests/reductions/test_stat_reductions.py
@@ -239,13 +239,12 @@ class TestSeriesStatReductions:
         for i in range(1, min_N + 1):
             s = Series(np.ones(i))
             df = DataFrame(np.ones((i, i)))
-            result = s.skew()
             if i < min_N:
-                assert np.isnan(result)
-                assert np.isnan(result).all()
+                assert np.isnan(s.skew())
+                assert np.isnan(df.skew()).all()
             else:
-                assert 0 == result
-                assert isinstance(result, np.float64)  # GH53482
+                assert 0 == s.skew()
+                assert isinstance(s.skew(), np.float64)  # GH53482
                 assert (df.skew() == 0).all()
 
     @td.skip_if_no_scipy
@@ -264,11 +263,10 @@ class TestSeriesStatReductions:
         for i in range(1, min_N + 1):
             s = Series(np.ones(i))
             df = DataFrame(np.ones((i, i)))
-            result = s.kurt()
             if i < min_N:
-                assert np.isnan(result)
-                assert np.isnan(result).all()
+                assert np.isnan(s.kurt())
+                assert np.isnan(df.kurt()).all()
             else:
-                assert 0 == result
-                assert isinstance(result, np.float64)  # GH53482
+                assert 0 == s.kurt()
+                assert isinstance(s.kurt(), np.float64)  # GH53482
                 assert (df.kurt() == 0).all()


### PR DESCRIPTION
Fixes a small bug (inconsistent return type). Discovered while working on #52788.