### PR TITLE
BUG/PERF: DataFrame.isin lossy data conversion

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -310,6 +310,8 @@ Performance improvements
 - Performance improvement in :meth:`~arrays.ArrowExtensionArray.to_numpy` (:issue:`52525`)
 - Performance improvement when doing various reshaping operations on :class:`arrays.IntegerArrays` & :class:`arrays.FloatingArray` by avoiding doing unnecessary validation (:issue:`53013`)
 - Performance improvement when indexing with pyarrow timestamp and duration dtypes (:issue:`53368`)
+- Performance improvement in :meth:`DataFrame.isin` for extension dtypes (:issue:`#####`)
+-
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_210.bug_fixes:

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -301,6 +301,7 @@ Performance improvements
 - Performance improvement in :class:`Series` reductions (:issue:`52341`)
 - Performance improvement in :func:`concat` when ``axis=1`` and objects have different indexes (:issue:`52541`)
 - Performance improvement in :meth:`.DataFrameGroupBy.groups` (:issue:`53088`)
+- Performance improvement in :meth:`DataFrame.isin` for extension dtypes (:issue:`53514`)
 - Performance improvement in :meth:`DataFrame.loc` when selecting rows and columns (:issue:`53014`)
 - Performance improvement in :meth:`Series.add` for pyarrow string and binary dtypes (:issue:`53150`)
 - Performance improvement in :meth:`Series.corr` and :meth:`Series.cov` for extension dtypes (:issue:`52502`)
@@ -310,7 +311,6 @@ Performance improvements
 - Performance improvement in :meth:`~arrays.ArrowExtensionArray.to_numpy` (:issue:`52525`)
 - Performance improvement when doing various reshaping operations on :class:`arrays.IntegerArrays` & :class:`arrays.FloatingArray` by avoiding doing unnecessary validation (:issue:`53013`)
 - Performance improvement when indexing with pyarrow timestamp and duration dtypes (:issue:`53368`)
-- Performance improvement in :meth:`DataFrame.isin` for extension dtypes (:issue:`#####`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -11731,15 +11731,21 @@ class DataFrame(NDFrame, OpsMixin):
                     "to be passed to DataFrame.isin(), "
                     f"you passed a '{type(values).__name__}'"
                 )
-            # error: Argument 2 to "isin" has incompatible type "Union[Sequence[Any],
-            # Mapping[Any, Any]]"; expected "Union[Union[ExtensionArray,
-            # ndarray[Any, Any]], Index, Series]"
-            res_values = algorithms.isin(
-                self.values.ravel(),
-                values,  # type: ignore[arg-type]
-            )
+
+            def isin_(x):
+                # error: Argument 2 to "isin" has incompatible type "Union[Series,
+                # DataFrame, Sequence[Any], Mapping[Any, Any]]"; expected
+                # "Union[Union[Union[ExtensionArray, ndarray[Any, Any]], Index,
+                # Series], List[Any], range]"
+                result = algorithms.isin(
+                    x.ravel(),
+                    values,  # type: ignore[arg-type]
+                )
+                return result.reshape(x.shape)
+
+            res_values = self._mgr.apply(isin_)
             result = self._constructor(
-                res_values.reshape(self.shape),
+                res_values,
                 self.index,
                 self.columns,
                 copy=False,

--- a/pandas/tests/frame/methods/test_isin.py
+++ b/pandas/tests/frame/methods/test_isin.py
@@ -219,7 +219,7 @@ class TestDataFrameIsIn:
         tm.assert_frame_equal(result, expected)
 
     def test_isin_not_lossy(self):
-        # GH #####
+        # GH 53514
         val = 1666880195890293744
         df = DataFrame({"a": [val], "b": [1.0]})
         result = df.isin([val])

--- a/pandas/tests/frame/methods/test_isin.py
+++ b/pandas/tests/frame/methods/test_isin.py
@@ -217,3 +217,11 @@ class TestDataFrameIsIn:
         result = df.isin(arr)
         expected = DataFrame([True, True, True])
         tm.assert_frame_equal(result, expected)
+
+    def test_isin_not_lossy(self):
+        # GH #####
+        val = 1666880195890293744
+        df = DataFrame({"a": [val], "b": [1.0]})
+        result = df.isin([val])
+        expected = DataFrame({"a": [True], "b": [False]})
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.1.0.rst` file if fixing a bug or adding a new feature.


fixes edge case bug (lossy data conversion):
```
import pandas as pd

val = 1666880195890293744

df = pd.DataFrame({"a": [val], "b": [1.0]})

df.apply(lambda x: x.isin([val]))  # True, False
df.isin([val])                     # False, False 
```


perf (for EA dtypes):
```
import pandas as pd
import numpy as np

data = np.random.randint(0, 1000, (100_000, 2))
df = pd.DataFrame(data, dtype="int64[pyarrow]")

%timeit df.isin([1, 50])

# 25.6 ms ± 1.49 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)  <- main
# 2.1 ms ± 265 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)   <- PR
```