### PR TITLE
FIX `groupby` with column selection not returning tuple when grouping by list of a single element

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -435,6 +435,7 @@ Groupby/resample/rolling
   grouped :class:`Series` or :class:`DataFrame` was a :class:`DatetimeIndex`, :class:`TimedeltaIndex`
   or :class:`PeriodIndex`, and the ``groupby`` method was given a function as its first argument,
   the function operated on the whole index rather than each element of the index. (:issue:`51979`)
+- Bug in :meth:`DataFrame.groupby` when grouping by a list of a single element and selecting columns of the resulting groupby object. The group keys are now tuples. (:issue:`53500`)
 - Bug in :meth:`DataFrameGroupBy.agg` with lists not respecting ``as_index=False`` (:issue:`52849`)
 - Bug in :meth:`DataFrameGroupBy.apply` causing an error to be raised when the input :class:`DataFrame` was subset as a :class:`DataFrame` after groupby (``[['a']]`` and not ``['a']``) and the given callable returned :class:`Series` that were not all indexed the same. (:issue:`52444`)
 - Bug in :meth:`DataFrameGroupBy.apply` raising a ``TypeError`` when selecting multiple columns and providing a function that returns ``np.ndarray`` results (:issue:`18930`)

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -435,7 +435,7 @@ Groupby/resample/rolling
   grouped :class:`Series` or :class:`DataFrame` was a :class:`DatetimeIndex`, :class:`TimedeltaIndex`
   or :class:`PeriodIndex`, and the ``groupby`` method was given a function as its first argument,
   the function operated on the whole index rather than each element of the index. (:issue:`51979`)
-- Bug in :meth:`DataFrame.groupby` when grouping by a list of a single element and selecting columns of the resulting groupby object. The group keys are now tuples. (:issue:`53500`)
+- Bug in :meth:`DataFrame.groupby` with column selection on the resulting groupby object not returning tuples when grouping by a list of a single element. (:issue:`53500`)
 - Bug in :meth:`DataFrameGroupBy.agg` with lists not respecting ``as_index=False`` (:issue:`52849`)
 - Bug in :meth:`DataFrameGroupBy.apply` causing an error to be raised when the input :class:`DataFrame` was subset as a :class:`DataFrame` after groupby (``[['a']]`` and not ``['a']``) and the given callable returned :class:`Series` that were not all indexed the same. (:issue:`52444`)
 - Bug in :meth:`DataFrameGroupBy.apply` raising a ``TypeError`` when selecting multiple columns and providing a function that returns ``np.ndarray`` results (:issue:`18930`)

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -435,7 +435,7 @@ Groupby/resample/rolling
   grouped :class:`Series` or :class:`DataFrame` was a :class:`DatetimeIndex`, :class:`TimedeltaIndex`
   or :class:`PeriodIndex`, and the ``groupby`` method was given a function as its first argument,
   the function operated on the whole index rather than each element of the index. (:issue:`51979`)
-- Bug in :meth:`DataFrame.groupby` with column selection on the resulting groupby object not returning tuples when grouping by a list of a single element. (:issue:`53500`)
+- Bug in :meth:`DataFrame.groupby` with column selection on the resulting groupby object not returning names as tuples when grouping by a list of a single element. (:issue:`53500`)
 - Bug in :meth:`DataFrameGroupBy.agg` with lists not respecting ``as_index=False`` (:issue:`52849`)
 - Bug in :meth:`DataFrameGroupBy.apply` causing an error to be raised when the input :class:`DataFrame` was subset as a :class:`DataFrame` after groupby (``[['a']]`` and not ``['a']``) and the given callable returned :class:`Series` that were not all indexed the same. (:issue:`52444`)
 - Bug in :meth:`DataFrameGroupBy.apply` raising a ``TypeError`` when selecting multiple columns and providing a function that returns ``np.ndarray`` results (:issue:`18930`)

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1952,6 +1952,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                 subset = self.obj[key]
             return SeriesGroupBy(
                 subset,
+                self.keys,
                 level=self.level,
                 grouper=self.grouper,
                 exclusions=self.exclusions,

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1935,7 +1935,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                 subset = self.obj
             return DataFrameGroupBy(
                 subset,
-                self.grouper,
+                self.keys,
                 axis=self.axis,
                 level=self.level,
                 grouper=self.grouper,

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -901,13 +901,8 @@ class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
                 FutureWarning,
                 stacklevel=find_stack_level(),
             )
-        if (
-            isinstance(keys, list)
-            and len(keys) == 1
-            or isinstance(keys, ops.BaseGrouper)
-            and len(keys.names) == 1
-        ):
-            # GH#42795, GH#53500 - if groupby by list of one, still return tuples
+        if isinstance(keys, list) and len(keys) == 1:
+            # GH#42795 - when keys is a list, return tuples even when length is 1
             result = (((key,), group) for key, group in result)
         return result
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -901,8 +901,13 @@ class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
                 FutureWarning,
                 stacklevel=find_stack_level(),
             )
-        if isinstance(keys, list) and len(keys) == 1:
-            # GH#42795 - when keys is a list, return tuples even when length is 1
+        if (
+            isinstance(keys, list)
+            and len(keys) == 1
+            or isinstance(keys, ops.BaseGrouper)
+            and len(keys.names) == 1
+        ):
+            # GH#42795, GH#53500 - if groupby by list of one, still return tuples
             result = (((key,), group) for key, group in result)
         return result
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2722,19 +2722,15 @@ def test_groupby_none_column_name():
     tm.assert_frame_equal(result, expected)
 
 
-def test_single_element_list_grouping():
+@pytest.mark.parametrize("selection", [None, "a", ["a"]])
+def test_single_element_list_grouping(selection):
     # GH#42795, GH#53500
     df = DataFrame({"a": [1, 2], "b": [np.nan, 5], "c": [np.nan, 2]}, index=["x", "y"])
-    grouped = df.groupby(["a"])
+    grouped = df.groupby(["a"]) if selection is None else df.groupby(["a"])[selection]
+    result = [key for key, _ in grouped]
 
-    result0 = [key for key, _ in grouped]
-    result1 = [key for key, _ in grouped["a"]]
-    result2 = [key for key, _ in grouped[["a"]]]
     expected = [(1,), (2,)]
-
-    assert result0 == expected
-    assert result1 == expected
-    assert result2 == expected
+    assert result == expected
 
 
 def test_groupby_string_dtype():

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2723,11 +2723,16 @@ def test_groupby_none_column_name():
 
 
 def test_single_element_list_grouping():
-    # GH 42795
+    # GH#42795, GH#53500
     df = DataFrame({"a": [1, 2], "b": [np.nan, 5], "c": [np.nan, 2]}, index=["x", "y"])
-    result = [key for key, _ in df.groupby(["a"])]
+    grouped = df.groupby(["a"])
+
+    result1 = [key for key, _ in grouped]
+    result2 = [key for key, _ in grouped[["a", "b", "c"]]]
     expected = [(1,), (2,)]
-    assert result == expected
+
+    assert result1 == expected
+    assert result2 == expected
 
 
 def test_groupby_string_dtype():

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2727,10 +2727,12 @@ def test_single_element_list_grouping():
     df = DataFrame({"a": [1, 2], "b": [np.nan, 5], "c": [np.nan, 2]}, index=["x", "y"])
     grouped = df.groupby(["a"])
 
-    result1 = [key for key, _ in grouped]
-    result2 = [key for key, _ in grouped[["a", "b", "c"]]]
+    result0 = [key for key, _ in grouped]
+    result1 = [key for key, _ in grouped["a"]]
+    result2 = [key for key, _ in grouped[["a"]]]
     expected = [(1,), (2,)]
 
+    assert result0 == expected
     assert result1 == expected
     assert result2 == expected
 


### PR DESCRIPTION
- [x] Closes #53500
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests)
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit)
- [x] Added an entry in the latest `doc/source/whatsnew/v2.1.0.rst` file