### PR TITLE
BUG: Series.str.split(expand=True) for ArrowDtype(pa.string())

### DIFF
--- a/doc/source/whatsnew/v2.0.3.rst
+++ b/doc/source/whatsnew/v2.0.3.rst
@@ -22,6 +22,8 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 - Bug in :func:`read_csv` when defining ``dtype`` with ``bool[pyarrow]`` for the ``"c"`` and ``"python"`` engines (:issue:`53390`)
+- Bug in :meth:`Series.str.split` and :meth:`Series.str.rsplit` with ``expand=True`` for :class:`ArrowDtype` with ``pyarrow.string`` (:issue:`53532`)
+-
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_203.other:

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -275,22 +275,40 @@ class StringMethods(NoNewAttributesMixin):
             if isinstance(result.dtype, ArrowDtype):
                 import pyarrow as pa
 
+                from pandas.compat import pa_version_under11p0
+
                 from pandas.core.arrays.arrow.array import ArrowExtensionArray
 
-                max_len = pa.compute.max(
-                    result._pa_array.combine_chunks().value_lengths()
-                ).as_py()
-                if result.isna().any():
+                value_lengths = result._pa_array.combine_chunks().value_lengths()
+                max_len = pa.compute.max(value_lengths).as_py()
+                min_len = pa.compute.min(value_lengths).as_py()
+                if result._hasna:
                     # ArrowExtensionArray.fillna doesn't work for list scalars
                     result._pa_array = result._pa_array.fill_null([None] * max_len)
+                if min_len < max_len:
+                    # append nulls to each scalar list element up to max_len
+                    if not pa_version_under11p0:
+                        result._pa_array = pa.compute.list_slice(
+                            result._pa_array,
+                            start=0,
+                            stop=max_len,
+                            return_fixed_size_list=True,
+                        )
+                    else:
+                        all_null = np.full(max_len, fill_value=None, dtype=object)
+                        values = result.to_numpy()
+                        new_values = []
+                        for row in values:
+                            if len(row) < max_len:
+                                nulls = all_null[: max_len - len(row)]
+                                row = np.append(row, nulls)
+                            new_values.append(row)
+                        pa_type = result._pa_array.type
+                        result._pa_array = pa.array(new_values, type=pa_type)
                 if name is not None:
                     labels = name
                 else:
                     labels = range(max_len)
-                # append nulls to each scalar list element up to max_len
-                result._pa_array = pa.compute.list_slice(
-                    result._pa_array, start=0, stop=max_len, return_fixed_size_list=True
-                )
                 result = {
                     label: ArrowExtensionArray(pa.array(res))
                     for label, res in zip(labels, (zip(*result.tolist())))

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -287,6 +287,10 @@ class StringMethods(NoNewAttributesMixin):
                     labels = name
                 else:
                     labels = range(max_len)
+                # append nulls to each scalar list element up to max_len
+                result._pa_array = pa.compute.list_slice(
+                    result._pa_array, start=0, stop=max_len, return_fixed_size_list=True
+                )
                 result = {
                     label: ArrowExtensionArray(pa.array(res))
                     for label, res in zip(labels, (zip(*result.tolist())))

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -284,15 +284,19 @@ class StringMethods(NoNewAttributesMixin):
                 min_len = pa.compute.min(value_lengths).as_py()
                 if result._hasna:
                     # ArrowExtensionArray.fillna doesn't work for list scalars
-                    result._pa_array = result._pa_array.fill_null([None] * max_len)
+                    result = ArrowExtensionArray(
+                        result._pa_array.fill_null([None] * max_len)
+                    )
                 if min_len < max_len:
                     # append nulls to each scalar list element up to max_len
                     if not pa_version_under11p0:
-                        result._pa_array = pa.compute.list_slice(
-                            result._pa_array,
-                            start=0,
-                            stop=max_len,
-                            return_fixed_size_list=True,
+                        result = ArrowExtensionArray(
+                            pa.compute.list_slice(
+                                result._pa_array,
+                                start=0,
+                                stop=max_len,
+                                return_fixed_size_list=True,
+                            )
                         )
                     else:
                         all_null = np.full(max_len, fill_value=None, dtype=object)
@@ -304,7 +308,7 @@ class StringMethods(NoNewAttributesMixin):
                                 row = np.append(row, nulls)
                             new_values.append(row)
                         pa_type = result._pa_array.type
-                        result._pa_array = pa.array(new_values, type=pa_type)
+                        result = ArrowExtensionArray(pa.array(new_values, type=pa_type))
                 if name is not None:
                     labels = name
                 else:

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -2286,6 +2286,15 @@ def test_str_split():
     )
     tm.assert_frame_equal(result, expected)
 
+    result = ser.str.split("1", expand=True)
+    expected = pd.DataFrame(
+        {
+            0: ArrowExtensionArray(pa.array(["a", "a2cbcb", None])),
+            1: ArrowExtensionArray(pa.array(["cbcb", None, None])),
+        }
+    )
+    tm.assert_frame_equal(result, expected)
+
 
 def test_str_rsplit():
     # GH 52401
@@ -2307,6 +2316,15 @@ def test_str_rsplit():
         {
             0: ArrowExtensionArray(pa.array(["a1cb", "a2cb", None])),
             1: ArrowExtensionArray(pa.array(["b", "b", None])),
+        }
+    )
+    tm.assert_frame_equal(result, expected)
+
+    result = ser.str.rsplit("1", expand=True)
+    expected = pd.DataFrame(
+        {
+            0: ArrowExtensionArray(pa.array(["a", "a2cbcb", None])),
+            1: ArrowExtensionArray(pa.array(["cbcb", None, None])),
         }
     )
     tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.0.3.rst` file if fixing a bug or adding a new feature.

main:
```
In [1]: import pandas as pd

In [2]: import pyarrow as pa

In [3]: ser = pd.Series(["a", "a|b", "a|b|c"], dtype=pd.ArrowDtype(pa.string()))

In [4]: ser.str.split("|", expand=True)
Out[4]: 
   0
0  a
1  a
2  a
```

PR:
```
Out[4]: 
   0     1     2
0  a  <NA>  <NA>
1  a     b  <NA>
2  a     b     c
```
