### PR TITLE
fix Series.apply(..., by_row)

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -397,7 +397,7 @@ class Apply(metaclass=abc.ABCMeta):
 
         obj = self.obj
         func = cast(AggFuncTypeDict, self.func)
-        kwargs = {}
+        kwargs: dict[str, Any] = {}
         if isinstance(self, SeriesApply) and op_name == "apply":
             kwargs = {**kwargs, "by_row": self.by_row}
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4503,7 +4503,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         convert_dtype: bool | lib.NoDefault = lib.no_default,
         args: tuple[Any, ...] = (),
         *,
-        by_row: bool = True,
+        by_row: bool | lib.NoDefault = lib.no_default,
         **kwargs,
     ) -> DataFrame | Series:
         """
@@ -4531,7 +4531,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
                 instead if you want ``convert_dtype=False``.
         args : tuple
             Positional arguments passed to func after the series value.
-        by_row : bool, default True
+        by_row : bool, optional
             If False, the func will be passed the whole Series at once.
             If True, will func will be passed each element of the Series, like
             Series.map (backward compatible).


### PR DESCRIPTION
Fixes https://github.com/pandas-dev/pandas/pull/53400#discussion_r1223790606 by making the `by_row` param take `no_default` as its default parameter.
