### PR TITLE
DEPR: deprecate using some params as positional in (DataFrame|Series).apply

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -284,6 +284,8 @@ Deprecations
 - Deprecated option "mode.use_inf_as_na", convert inf entries to ``NaN`` before instead (:issue:`51684`)
 - Deprecated positional indexing on :class:`Series` with :meth:`Series.__getitem__` and :meth:`Series.__setitem__`, in a future version ``ser[item]`` will *always* interpret ``item`` as a label, not a position (:issue:`50617`)
 - Deprecated the "method" and "limit" keywords on :meth:`Series.fillna`, :meth:`DataFrame.fillna`, :meth:`SeriesGroupBy.fillna`, :meth:`DataFrameGroupBy.fillna`, and :meth:`Resampler.fillna`, use ``obj.bfill()`` or ``obj.ffill()`` instead (:issue:`53394`)
+- Deprecated allowing non-keyword arguments other than `func` in :meth:`Series.apply` (:issue:`xxxxx`)
+- Deprecated allowing non-keyword arguments other than `func` and ``axis`` in :meth:`DataFrame.apply` (:issue:`xxxxx`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -284,8 +284,8 @@ Deprecations
 - Deprecated option "mode.use_inf_as_na", convert inf entries to ``NaN`` before instead (:issue:`51684`)
 - Deprecated positional indexing on :class:`Series` with :meth:`Series.__getitem__` and :meth:`Series.__setitem__`, in a future version ``ser[item]`` will *always* interpret ``item`` as a label, not a position (:issue:`50617`)
 - Deprecated the "method" and "limit" keywords on :meth:`Series.fillna`, :meth:`DataFrame.fillna`, :meth:`SeriesGroupBy.fillna`, :meth:`DataFrameGroupBy.fillna`, and :meth:`Resampler.fillna`, use ``obj.bfill()`` or ``obj.ffill()`` instead (:issue:`53394`)
-- Deprecated allowing non-keyword arguments other than `func` in :meth:`Series.apply` (:issue:`xxxxx`)
-- Deprecated allowing non-keyword arguments other than `func` and ``axis`` in :meth:`DataFrame.apply` (:issue:`xxxxx`)
+- Deprecated allowing non-keyword arguments other than `func` in :meth:`Series.apply` (:issue:`53592`)
+- Deprecated allowing non-keyword arguments other than `func` and ``axis`` in :meth:`DataFrame.apply` (:issue:`53592`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -279,13 +279,13 @@ Deprecations
 - Deprecated :meth:`Series.first` and :meth:`DataFrame.first` (please create a mask and filter using ``.loc`` instead) (:issue:`45908`)
 - Deprecated allowing ``downcast`` keyword other than ``None``, ``False``, "infer", or a dict with these as values in :meth:`Series.fillna`, :meth:`DataFrame.fillna` (:issue:`40988`)
 - Deprecated allowing arbitrary ``fill_value`` in :class:`SparseDtype`, in a future version the ``fill_value`` will need to be compatible with the ``dtype.subtype``, either a scalar that can be held by that subtype or ``NaN`` for integer or bool subtypes (:issue:`23124`)
+- Deprecated allowing non-keyword arguments other than ``func`` and ``axis`` in :meth:`DataFrame.apply` (:issue:`53592`)
+- Deprecated allowing non-keyword arguments other than ``func`` in :meth:`Series.apply` (:issue:`53592`)
 - Deprecated behavior of :func:`assert_series_equal` and :func:`assert_frame_equal` considering NA-like values (e.g. ``NaN`` vs ``None`` as equivalent) (:issue:`52081`)
 - Deprecated constructing :class:`SparseArray` from scalar data, pass a sequence instead (:issue:`53039`)
 - Deprecated option "mode.use_inf_as_na", convert inf entries to ``NaN`` before instead (:issue:`51684`)
 - Deprecated positional indexing on :class:`Series` with :meth:`Series.__getitem__` and :meth:`Series.__setitem__`, in a future version ``ser[item]`` will *always* interpret ``item`` as a label, not a position (:issue:`50617`)
 - Deprecated the "method" and "limit" keywords on :meth:`Series.fillna`, :meth:`DataFrame.fillna`, :meth:`SeriesGroupBy.fillna`, :meth:`DataFrameGroupBy.fillna`, and :meth:`Resampler.fillna`, use ``obj.bfill()`` or ``obj.ffill()`` instead (:issue:`53394`)
-- Deprecated allowing non-keyword arguments other than `func` in :meth:`Series.apply` (:issue:`53592`)
-- Deprecated allowing non-keyword arguments other than `func` and ``axis`` in :meth:`DataFrame.apply` (:issue:`53592`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -112,9 +112,9 @@ class Apply(metaclass=abc.ABCMeta):
         self,
         obj: AggObjType,
         func: AggFuncType,
+        *,
         raw: bool,
         result_type: str | None,
-        *,
         args,
         kwargs,
     ) -> None:

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -79,6 +79,7 @@ def frame_apply(
     obj: DataFrame,
     func: AggFuncType,
     axis: Axis = 0,
+    *,
     raw: bool = False,
     result_type: str | None = None,
     args=None,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9619,6 +9619,11 @@ class DataFrame(NDFrame, OpsMixin):
         is inferred from the return type of the applied function. Otherwise,
         it depends on the `result_type` argument.
 
+        .. versionchanged:: 2.1.0
+
+            Supplying other arguments than ``func`` and ``axis`` as positional arguments
+            has been deprecated.
+
         Parameters
         ----------
         func : function
@@ -9659,10 +9664,6 @@ class DataFrame(NDFrame, OpsMixin):
         **kwargs
             Additional keyword arguments to pass as keywords arguments to
             `func`.
-
-        .. versionchanged:: 2.1.0
-            Supplying other arguments than `func` and `axis` as a positional argument
-            has been deprecated.
 
         Returns
         -------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -66,6 +66,7 @@ from pandas.errors import (
 from pandas.util._decorators import (
     Appender,
     Substitution,
+    deprecate_nonkeyword_arguments,
     doc,
 )
 from pandas.util._exceptions import find_stack_level
@@ -9597,6 +9598,9 @@ class DataFrame(NDFrame, OpsMixin):
         assert isinstance(result, DataFrame)
         return result
 
+    @deprecate_nonkeyword_arguments(
+        version="2.1", allowed_args=["self", "func", "axis"]
+    )
     def apply(
         self,
         func: AggFuncType,
@@ -9655,6 +9659,10 @@ class DataFrame(NDFrame, OpsMixin):
         **kwargs
             Additional keyword arguments to pass as keywords arguments to
             `func`.
+
+        .. versionchanged:: 2.1.0
+            Supplying other arguments than `func` and `axis` as a positional argument
+            has been deprecated.
 
         Returns
         -------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -46,6 +46,7 @@ from pandas.errors import (
 from pandas.util._decorators import (
     Appender,
     Substitution,
+    deprecate_nonkeyword_arguments,
     doc,
 )
 from pandas.util._exceptions import find_stack_level
@@ -4497,6 +4498,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         result = SeriesApply(self, func=func, args=args, kwargs=kwargs).transform()
         return result
 
+    @deprecate_nonkeyword_arguments(version="2.1", allowed_args=["self", "func"])
     def apply(
         self,
         func: AggFuncType,
@@ -4516,6 +4518,10 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         Can be ufunc (a NumPy function that applies to the entire Series)
         or a Python function that only works on single values.
+
+        .. versionchanged:: 2.1.0
+            Supplying other arguments than `func` as a positional argument has been
+            deprecated.
 
         Parameters
         ----------

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1534,6 +1534,7 @@ def test_agg_dist_like_and_nonunique_columns():
 
 
 def test_deprecate_positional_params():
+    # GH53592
     df = DataFrame({"x": [1, 2, 3]})
     msg = (
         "Starting with pandas version 2.1 all arguments of DataFrame.apply except for "

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1540,5 +1540,5 @@ def test_deprecate_positional_params():
         "Starting with pandas version 2.1 all arguments of DataFrame.apply except for "
         "the arguments 'func' and 'axis' will be keyword-only."
     )
-    with pytest.raises(FutureWarning, match=msg):
+    with tm.assert_produces_warning(FutureWarning, match=msg):
         df.apply("sum", 0, True)

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1531,3 +1531,13 @@ def test_agg_dist_like_and_nonunique_columns():
     result = df.agg({"A": "count"})
     expected = df["A"].count()
     tm.assert_series_equal(result, expected)
+
+
+def test_deprecate_positional_params():
+    df = DataFrame({"x": [1, 2, 3]})
+    msg = (
+        "Starting with pandas version 2.1 all arguments of DataFrame.apply except for "
+        "the arguments 'func' and 'axis' will be keyword-only."
+    )
+    with pytest.raises(FutureWarning, match=msg):
+        df.apply("sum", 0, True)

--- a/pandas/tests/apply/test_series_apply.py
+++ b/pandas/tests/apply/test_series_apply.py
@@ -676,3 +676,27 @@ def test_apply_type():
     result = s.apply(type)
     expected = Series([int, str, type], index=["a", "b", "c"])
     tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "func, by_row, error, msg",
+    [
+        [lambda x: x.sum(), True, AttributeError, "object has no attribute 'sum'"],
+        [lambda x: int(x), False, TypeError, "cannot convert the series"],
+    ],
+)
+def test_series_apply_by_row_raises(func, by_row, error, msg):
+    # GH53400
+    ser = Series([1, 2, 3])
+    with pytest.raises(error, match=msg):
+        ser.apply(func, by_row=by_row)
+
+
+def test_deprecate_positional_params():
+    ser = Series([1, 2, 3])
+    msg = (
+        "Starting with pandas version 2.1 all arguments of Series.apply except "
+        "for the argument 'func' will be keyword-only."
+    )
+    with pytest.raises(FutureWarning, match=msg):
+        ser.apply("sum", True)

--- a/pandas/tests/apply/test_series_apply.py
+++ b/pandas/tests/apply/test_series_apply.py
@@ -693,6 +693,7 @@ def test_series_apply_by_row_raises(func, by_row, error, msg):
 
 
 def test_deprecate_positional_params():
+    # GH53592
     ser = Series([1, 2, 3])
     msg = (
         "Starting with pandas version 2.1 all arguments of Series.apply except "

--- a/pandas/tests/apply/test_series_apply.py
+++ b/pandas/tests/apply/test_series_apply.py
@@ -685,5 +685,5 @@ def test_deprecate_positional_params():
         "Starting with pandas version 2.1 all arguments of Series.apply except "
         "for the argument 'func' will be keyword-only."
     )
-    with pytest.raises(FutureWarning, match=msg):
+    with tm.assert_produces_warning(FutureWarning, match=msg):
         ser.apply("sum", True)

--- a/pandas/tests/apply/test_series_apply.py
+++ b/pandas/tests/apply/test_series_apply.py
@@ -678,20 +678,6 @@ def test_apply_type():
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    "func, by_row, error, msg",
-    [
-        [lambda x: x.sum(), True, AttributeError, "object has no attribute 'sum'"],
-        [lambda x: int(x), False, TypeError, "cannot convert the series"],
-    ],
-)
-def test_series_apply_by_row_raises(func, by_row, error, msg):
-    # GH53400
-    ser = Series([1, 2, 3])
-    with pytest.raises(error, match=msg):
-        ser.apply(func, by_row=by_row)
-
-
 def test_deprecate_positional_params():
     # GH53592
     ser = Series([1, 2, 3])

--- a/pandas/tests/apply/test_str.py
+++ b/pandas/tests/apply/test_str.py
@@ -30,10 +30,10 @@ from pandas.tests.apply.common import (
 )
 @pytest.mark.parametrize("how", ["agg", "apply"])
 def test_apply_with_string_funcs(request, float_frame, func, args, kwds, how):
-    if len(args) > 1 and how == "agg":
+    if len(args) > 1:
         request.node.add_marker(
             pytest.mark.xfail(
-                raises=TypeError,
+                raises=TypeError if how == "agg" else FutureWarning,
                 reason="agg/apply signature mismatch - agg passes 2nd "
                 "argument to func",
             )


### PR DESCRIPTION
Deprecate allowing using `raw`, `result_type` etc. as positional parameters in `DataFrame.apply` & `Series.apply`, i.e. requiring them to be keyword-only in the future.

EDIT: updated for intent.