### PR TITLE
Add new `df.select()` method, plus tests and docs

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -356,6 +356,18 @@ Accessing via label slices:
 
    df1.loc['d':, 'A':'C']
 
+For accessing only a single column:
+
+.. ipython:: python
+
+   df1.select('A')
+
+Or for accessing a list of columns:
+
+.. ipython:: python
+
+   df1.select(['A', 'B'])
+
 For getting a cross section using a label (equivalent to ``df.xs('a')``):
 
 .. ipython:: python

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -108,6 +108,7 @@ Other enhancements
 - Many read/to_* functions, such as :meth:`DataFrame.to_pickle` and :func:`read_csv`, support forwarding compression arguments to lzma.LZMAFile (:issue:`52979`)
 - Performance improvement in :func:`concat` with homogeneous ``np.float64`` or ``np.float32`` dtypes (:issue:`52685`)
 - Performance improvement in :meth:`DataFrame.filter` when ``items`` is given (:issue:`52941`)
+- Added :meth:`DataFrame.select` as pass-through method for purely column based indexer on DataFrames.
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_210.notable_bug_fixes:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -687,7 +687,7 @@ class IndexingMixin:
         """
         Select one or multiple columns from a DataFrame.
 
-        ``.select()`` is a pass-thru method, which utilises ``.loc[]`` to
+        ``.select()`` is a pass-through method, which utilises ``.loc[]`` to
             only retrieve the selected columns from the DataFrame.
         The equivalent call to this function would be: ``DataFrame.loc[:,columns]``.
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -176,6 +176,7 @@ class IndexingMixin:
         --------
         DataFrame.iat : Fast integer location scalar accessor.
         DataFrame.loc : Purely label-location based indexer for selection by label.
+        DataFrame.select : Purely column based indexer for selection by label.
         Series.iloc : Purely integer-location based indexing for
                        selection by position.
 
@@ -325,6 +326,7 @@ class IndexingMixin:
         DataFrame.iloc : Access group of rows and columns by integer position(s).
         DataFrame.xs : Returns a cross-section (row(s) or column(s)) from the
             Series/DataFrame.
+        DataFrame.select : Purely column based indexer for selection by label.
         Series.loc : Access group of values using labels.
 
         Examples
@@ -593,6 +595,7 @@ class IndexingMixin:
         DataFrame.loc : Access a group of rows and columns by label(s).
         DataFrame.iloc : Access a group of rows and columns by integer
             position(s).
+        DataFrame.select : Purely column based indexer for selection by label.
         Series.at : Access a single value by label.
         Series.iat : Access a single value by integer position.
         Series.loc : Access a group of rows by label(s).
@@ -650,6 +653,7 @@ class IndexingMixin:
         DataFrame.at : Access a single value for a row/column label pair.
         DataFrame.loc : Access a group of rows and columns by label(s).
         DataFrame.iloc : Access a group of rows and columns by integer position(s).
+        DataFrame.select : Purely column based indexer for selection by label.
 
         Examples
         --------
@@ -678,6 +682,78 @@ class IndexingMixin:
         2
         """
         return _iAtIndexer("iat", self)
+
+    def select(self, columns: str | list):
+        """
+        Select one or multiple columns from a DataFrame.
+
+        ``.select()`` is a pass-thru method, which utilises ``.loc[]`` to
+            only retrieve the selected columns from the DataFrame.
+        The equivalent call to this function would be: ``DataFrame.loc[:,columns]``.
+
+          .. note:: All calls to this function will return a DataFrame.
+
+          .. versionadded:: 2.1.0
+
+        Raises
+        ------
+        KeyError
+            If any items are not found.
+        IndexingError
+            If an indexed key is passed and its index is unalignable to the frame index.
+
+        Returns
+        -------
+        DataFrame
+            DataFrame containing only the selected columns.
+
+        See Also
+        --------
+        DataFrame.loc : Purely label-location based indexer for selection by label.
+        DataFrame.iloc : Access group of rows and columns by integer position(s).
+        DataFrame.at : Access a single value for a row/column label pair.
+        DataFrame.xs : Returns a cross-section (row(s) or column(s)) from the
+            Series/DataFrame.
+
+        Examples
+        --------
+        **Getting values**
+
+        >>> mydict = [{'a': 1, 'b': 2, 'c': 3, 'd': 4},
+        ...           {'a': 100, 'b': 200, 'c': 300, 'd': 400},
+        ...           {'a': 1000, 'b': 2000, 'c': 3000, 'd': 4000 }]
+        >>> df = pd.DataFrame(mydict)
+        >>> df
+              a     b     c     d
+        0     1     2     3     4
+        1   100   200   300   400
+        2  1000  2000  3000  4000
+
+        A single column.
+
+        >>> type(df.select('a'))
+        <class 'pandas.core.frame.DataFrame'>
+        >>> df.select('a')
+              a
+        0     1
+        1   100
+        2  1000
+        >>> df.select(['a'])
+              a
+        0     1
+        1   100
+        2  1000
+
+        A list of columns.
+
+        >>> type(df.select['a', 'b'])
+              a     b
+        0     1     2
+        1   100   200
+        2  1000  2000
+        """
+        columns = columns if isinstance(columns, list) else [columns]
+        return self.loc[:, columns]
 
 
 class _LocationIndexer(NDFrameIndexerBase):

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -2729,13 +2729,13 @@ class TestLocListlike:
 
 class TestSelect:
     @property
-    def df() -> pd.DataFrame:
+    def df() -> DataFrame:
         mydict = [
             {"a": 1, "b": 2, "c": 3, "d": 4},
             {"a": 100, "b": 200, "c": 300, "d": 400},
             {"a": 1000, "b": 2000, "c": 3000, "d": 4000},
         ]
-        return pd.DataFrame(mydict)
+        return DataFrame(mydict)
 
     def test_select_single_column(self):
         expected = self.df.loc[:, ["a"]]

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -2727,6 +2727,32 @@ class TestLocListlike:
         tm.assert_frame_equal(result, expected)
 
 
+class TestSelect:
+    @property
+    def df() -> pd.DataFrame:
+        mydict = [
+            {"a": 1, "b": 2, "c": 3, "d": 4},
+            {"a": 100, "b": 200, "c": 300, "d": 400},
+            {"a": 1000, "b": 2000, "c": 3000, "d": 4000},
+        ]
+        return pd.DataFrame(mydict)
+
+    def test_select_single_column(self):
+        expected = self.df.loc[:, ["a"]]
+        result = self.df.select("a")
+        tm.assert_frame_equal(result, expected)
+
+    def test_select_single_column_as_list(self):
+        expected = self.df.loc[:, ["a"]]
+        result = self.df.select(["a"])
+        tm.assert_frame_equal(result, expected)
+
+    def test_select_list_of_columns(self):
+        expected = self.df.loc[:, ["a", "b", "c"]]
+        result = self.df.select(["a", "b", "c"])
+        tm.assert_frame_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     "columns, column_key, expected_columns",
     [


### PR DESCRIPTION
- [x] No issues to close
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.1.0.rst` file if fixing a bug or adding a new feature.

The existing [`DataFrame.loc`][docs-pandas-DataFrame.loc] method works just fine. However, the naming convention is inconsistent with other languages and packages.

- SQL source has the name [`SELECT`][docs-sql-SELECT]
- PySpark has the method [`DataFrame.select`][docs-pyspark-DataFrame.select]
- PyPolars has the method [`DataFrame.select`][docs-polars-DataFrame.select]

By adding this `pandas.DataFrame.select()` method, we will be bringing the naming convention in line with other languages and packages.

Under-the-hood, this new method is not implementing any new logic or functionality. It's only a pass-through method to the `DataFrame.loc` method.

The equivalent of running: `df.select('column')`
Is the same as running: `df.loc[:, ['column'])`

All docs and tests have been added and are passing.

[docs-pandas-DataFrame.loc]: https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.loc.html
[docs-sql-SELECT]: https://en.wikipedia.org/wiki/Select_(SQL)
[docs-pyspark-DataFrame.select]: https://spark.apache.org/docs/3.1.1/api/python/reference/api/pyspark.sql.DataFrame.select.html
[docs-polars-DataFrame.select]: https://pola-rs.github.io/polars/py-polars/html/reference/dataframe/api/polars.DataFrame.select.html