### PR TITLE
DOC: Added links to GitHub tutorials/resources for Forking Workflow in contributing.rst

### DIFF
--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -119,6 +119,21 @@ Some great resources for learning Git:
 * the `NumPy documentation <https://numpy.org/doc/stable/dev/index.html>`_.
 * Matthew Brett's `Pydagogue <https://matthew-brett.github.io/pydagogue/>`_.
 
+Also, the project follows a forking workflow further described on this page whereby contributors
+fork the repository, make changes and then create a pull request. So please be sure to read and
+follow all the instructions in this guide.
+
+If you are new to contributing to projects through forking on GitHub,
+take a look at the `GitHub documentation for contributing to projects <https://docs.github.com/en/get-started/quickstart/contributing-to-projects>`_.
+GitHub provides a quick tutorial using a test repository that may help you become more familiar
+with forking a repository, cloning a fork, creating a feature branch, pushing changes and making pull requests.
+
+Below are some useful resources for learning more about forking and pull requests on GitHub:
+
+* the `GitHub documentation for forking a repo <https://docs.github.com/en/get-started/quickstart/fork-a-repo>`_.
+* the `GitHub documentation for creating a pull request from a fork <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork>`_.
+* the `GitHub documentation for working with forks <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks>`_.
+
 Getting started with Git
 ------------------------
 

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -119,19 +119,20 @@ Some great resources for learning Git:
 * the `NumPy documentation <https://numpy.org/doc/stable/dev/index.html>`_.
 * Matthew Brett's `Pydagogue <https://matthew-brett.github.io/pydagogue/>`_.
 
-Also, the project follows a forking workflow further described on this page whereby contributors
-fork the repository, make changes and then create a pull request. So please be sure to read and
-follow all the instructions in this guide.
+Also, the project follows a forking workflow further described on this page whereby
+contributors fork the repository, make changes and then create a pull request.
+So please be sure to read and follow all the instructions in this guide.
 
 If you are new to contributing to projects through forking on GitHub,
 take a look at the `GitHub documentation for contributing to projects <https://docs.github.com/en/get-started/quickstart/contributing-to-projects>`_.
 GitHub provides a quick tutorial using a test repository that may help you become more familiar
-with forking a repository, cloning a fork, creating a feature branch, pushing changes and making pull requests.
+with forking a repository, cloning a fork, creating a feature branch, pushing changes and
+making pull requests.
 
 Below are some useful resources for learning more about forking and pull requests on GitHub:
 
 * the `GitHub documentation for forking a repo <https://docs.github.com/en/get-started/quickstart/fork-a-repo>`_.
-* the `GitHub documentation for creating a pull request from a fork <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork>`_.
+* the `GitHub documentation for collaborating with pull requests <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests>`_.
 * the `GitHub documentation for working with forks <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks>`_.
 
 Getting started with Git


### PR DESCRIPTION
- [x] closes #53626 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

In the **contributing.rst file**, I have added information/navigation links to the GitHub documentation and tutorials for:
 1) contributing to projects
 2) forking a repo 
 3) collaborating with pull requests 
 4) working with forks

I added the updates to the _'Version control, Git and GitHub'_ section as the updates address GitHub workflows. 

I wanted to provide this information to aid new pandas contributors unsure of GitHub's forking process. I found these resources to be very helpful references when reviewing the contributing guide. Attaching a screenshot below of my local build with the changes (bordered in red). 
<img width="511" alt="contributing rst GitHub tutorial links" src="https://github.com/pandas-dev/pandas/assets/87046544/ce8c04c4-4f98-4a77-a251-58fd10469b71">