### PR TITLE
TST: xfail `test_rolling_var_numerical_issues` on Mac

### DIFF
--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -9,7 +9,6 @@ import pytest
 from pandas.compat import (
     IS64,
     is_platform_arm,
-    is_platform_mac,
     is_platform_power,
 )
 
@@ -1189,7 +1188,7 @@ def test_rolling_sem(frame_or_series):
 
 
 @pytest.mark.xfail(
-    (is_platform_arm() and not is_platform_mac()) or is_platform_power(),
+    is_platform_arm() or is_platform_power(),
     reason="GH 38921",
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] related to #38921. *Does not close the issue*. Test is failing on M2 chip.
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit). *Getting the same warnings on main and this branch on my local machine, so I think it is good.*
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. *No new functionality.*
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature. *Change to testing only.*

---

Related to discussion starting from [this comment](https://github.com/pandas-dev/pandas/issues/38921#issuecomment-1586318796) on #38921. The test fails on with the Mac M2 chip, so this PR removes the exclusion of Mac from the xfail marker. Mac was previously excluded because the test passes on M1.