### PR TITLE
BUG/CoW: is_range_indexer can't handle very large arrays

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -396,7 +396,7 @@ Indexing
 ^^^^^^^^
 - Bug in :meth:`DataFrame.__setitem__` losing dtype when setting a :class:`DataFrame` into duplicated columns (:issue:`53143`)
 - Bug in :meth:`DataFrame.__setitem__` with a boolean mask and :meth:`DataFrame.putmask` with mixed non-numeric dtypes and a value other than ``NaN`` incorrectly raising ``TypeError`` (:issue:`53291`)
--
+- Bug in indexing methods (e.g. :meth:`DataFrame.__getitem__`) where taking the entire :class:`DataFrame`/:class:`Series` would raise an ``OverflowError`` when Copy on Write was enabled and the length of the array was over the maximum size a 32-bit integer can hold (:issue:`53616`)
 
 Missing
 ^^^^^^^

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -668,7 +668,7 @@ ctypedef fused int6432_t:
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def is_range_indexer(ndarray[int6432_t, ndim=1] left, int n) -> bool:
+def is_range_indexer(ndarray[int6432_t, ndim=1] left, Py_ssize_t n) -> bool:
     """
     Perform an element by element comparison on 1-d integer arrays, meant for indexer
     comparisons

--- a/pandas/tests/libs/test_lib.py
+++ b/pandas/tests/libs/test_lib.py
@@ -249,6 +249,13 @@ class TestIndexing:
         assert lib.is_range_indexer(left, 100)
 
     @pytest.mark.parametrize("dtype", ["int64", "int32"])
+    def test_is_range_indexer_big_n(self, dtype):
+        # GH53616
+        left = np.arange(0, 100, dtype=dtype)
+
+        assert not lib.is_range_indexer(left, 2**31)
+
+    @pytest.mark.parametrize("dtype", ["int64", "int32"])
     def test_is_range_indexer_not_equal(self, dtype):
         # GH#50592
         left = np.array([1, 2], dtype=dtype)

--- a/pandas/tests/libs/test_lib.py
+++ b/pandas/tests/libs/test_lib.py
@@ -6,6 +6,7 @@ from pandas._libs import (
     lib,
     writers as libwriters,
 )
+from pandas.compat import IS64
 
 from pandas import Index
 import pandas._testing as tm
@@ -248,6 +249,11 @@ class TestIndexing:
         left = np.arange(0, 100, dtype=dtype)
         assert lib.is_range_indexer(left, 100)
 
+    @pytest.mark.skipif(
+        not IS64,
+        reason="2**31 is too big for Py_ssize_t on 32-bit. "
+        "It doesn't matter though since you cannot create an array that long on 32-bit",
+    )
     @pytest.mark.parametrize("dtype", ["int64", "int32"])
     def test_is_range_indexer_big_n(self, dtype):
         # GH53616


### PR DESCRIPTION
- [ ] closes #53616 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

I don't have enough RAM to test that this actually works.

(But the test raises ``OverflowError`` before, and doesn't raise after).