### PR TITLE
CI/TST: Mark test_to_read_gcs as single_cpu

### DIFF
--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -44,6 +44,8 @@ def gcs_buffer():
 
 
 @td.skip_if_no("gcsfs")
+# Patches pyarrow; other processes should not pick up change
+@pytest.mark.single_cpu
 @pytest.mark.parametrize("format", ["csv", "json", "parquet", "excel", "markdown"])
 def test_to_read_gcs(gcs_buffer, format, monkeypatch, capsys):
     """


### PR DESCRIPTION
Other tests has been flakily failing in some builds due to this test patching pyarrow: https://pipelines.actions.githubusercontent.com/serviceHosts/e1fa798b-a3de-4f41-9248-cf5942f5881f/_apis/pipelines/1/runs/499248/signedlogcontent/17?urlExpires=2023-06-14T19%3A48%3A38.6327145Z&urlSigningMethod=HMACV1&urlSignature=fJs2bpNPhAAVfqTNUW7HN0Wktd%2F8UYFHuG8BLKeIgb0%3D