### PR TITLE
BUG: astype('category') on dataframe backed by non-writeable arrays raises ValueError

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -341,6 +341,7 @@ Bug fixes
 
 Categorical
 ^^^^^^^^^^^
+- Bug in :meth:`Series.astype` with ``dtype="category"`` for nullable arrays with read-only null value masks (:issue:`53658`)
 - Bug in :meth:`Series.map` , where the value of the ``na_action`` parameter was not used if the series held a :class:`Categorical` (:issue:`22527`).
 -
 

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -648,7 +648,7 @@ cdef class {{name}}HashTable(HashTable):
             UInt8Vector result_mask
             UInt8VectorData *rmd
             bint use_na_value, use_mask, seen_na = False
-            uint8_t[:] mask_values
+            const uint8_t[:] mask_values
 
         if return_inverse:
             labels = np.empty(n, dtype=np.intp)

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -319,3 +319,12 @@ class Test2DCompat(base.NDArrayBacked2DTests):
 
         res = repr(data.reshape(-1, 1))
         assert res.count("\nCategories") == 1
+
+
+def test_astype_category_readonly_mask_values():
+    # GH 53658
+    df = pd.DataFrame([0, 1, 2], dtype="Int64")
+    df._mgr.arrays[0]._mask.flags["WRITEABLE"] = False
+    result = df.astype("category")
+    expected = pd.DataFrame([0, 1, 2], dtype="Int64").astype("category")
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #53658
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.1.0.rst` file if fixing a bug or adding a new feature.
