### PR TITLE
CI: Pin pandas-gbq above 0.15 to get rid of warnings on 2.0.x

### DIFF
--- a/ci/deps/circle-310-arm64.yaml
+++ b/ci/deps/circle-310-arm64.yaml
@@ -38,7 +38,7 @@ dependencies:
   - numexpr
   - openpyxl<3.1.1
   - odfpy
-  - pandas-gbq
+  - pandas-gbq>=0.15.0
   - psycopg2
   - pyarrow>=7.0.0
   - pymysql


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Gets the CircleCI build to green.