### PR TITLE
BUG: IntervalIndex.get_indexer raising for read only array

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -400,7 +400,7 @@ Strings
 
 Interval
 ^^^^^^^^
--
+- :meth:`pd.IntervalIndex.get_indexer` and :meth:`pd.IntervalIndex.get_indexer_nonunique` raising if ``target`` is read-only array (:issue:`53703`)
 -
 
 Indexing

--- a/pandas/_libs/intervaltree.pxi.in
+++ b/pandas/_libs/intervaltree.pxi.in
@@ -125,7 +125,7 @@ cdef class IntervalTree(IntervalMixin):
         sort_order = self.left_sorter
         return is_monotonic(sort_order, False)[0]
 
-    def get_indexer(self, scalar_t[:] target) -> np.ndarray:
+    def get_indexer(self, ndarray[scalar_t, ndim=1] target) -> np.ndarray:
         """Return the positions corresponding to unique intervals that overlap
         with the given array of scalar targets.
         """
@@ -153,7 +153,7 @@ cdef class IntervalTree(IntervalMixin):
             old_len = result.data.n
         return result.to_array().astype('intp')
 
-    def get_indexer_non_unique(self, scalar_t[:] target):
+    def get_indexer_non_unique(self, ndarray[scalar_t, ndim=1] target):
         """Return the positions corresponding to intervals that overlap with
         the given array of scalar targets. Non-unique positions are repeated.
         """

--- a/pandas/tests/indexes/interval/test_indexing.py
+++ b/pandas/tests/indexes/interval/test_indexing.py
@@ -430,10 +430,9 @@ class TestGetIndexer:
         arr.flags.writeable = False
         result = idx.get_indexer(arr)
         expected = np.array([0, 1])
-        tm.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected, check_dtype=False)
 
         result = idx.get_indexer_non_unique(arr)[0]
-        expected = np.array([0, 1])
         tm.assert_numpy_array_equal(result, expected, check_dtype=False)
 
 

--- a/pandas/tests/indexes/interval/test_indexing.py
+++ b/pandas/tests/indexes/interval/test_indexing.py
@@ -424,6 +424,18 @@ class TestGetIndexer:
         expected = np.array([-1, -1, -1], dtype=np.intp)
         tm.assert_numpy_array_equal(actual, expected)
 
+    def test_get_indexer_read_only(self):
+        idx = interval_range(start=0, end=5)
+        arr = np.array([1, 2])
+        arr.flags.writeable = False
+        result = idx.get_indexer(arr)
+        expected = np.array([0, 1])
+        tm.assert_numpy_array_equal(result, expected)
+
+        result = idx.get_indexer_non_unique(arr)[0]
+        expected = np.array([0, 1])
+        tm.assert_numpy_array_equal(result, expected)
+
 
 class TestSliceLocs:
     def test_slice_locs_with_interval(self):

--- a/pandas/tests/indexes/interval/test_indexing.py
+++ b/pandas/tests/indexes/interval/test_indexing.py
@@ -434,7 +434,7 @@ class TestGetIndexer:
 
         result = idx.get_indexer_non_unique(arr)[0]
         expected = np.array([0, 1])
-        tm.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected, check_dtype=False)
 
 
 class TestSliceLocs:


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
