### PR TITLE
BUG: period_range gives incorrect output 

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -518,6 +518,7 @@ Other
 - Bug in :meth:`Series.align`, :meth:`DataFrame.align`, :meth:`Series.reindex`, :meth:`DataFrame.reindex`, :meth:`Series.interpolate`, :meth:`DataFrame.interpolate`, incorrectly failing to raise with method="asfreq" (:issue:`53620`)
 - Bug in :meth:`Series.map` when giving a callable to an empty series, the returned series had ``object`` dtype. It now keeps the original dtype (:issue:`52384`)
 - Bug in :meth:`Series.memory_usage` when ``deep=True`` throw an error with Series of objects and the returned value is incorrect, as it does not take into account GC corrections (:issue:`51858`)
+- Bug in :meth:`period_range` the default behavior when freq was not passed as an argument was incorrect(:issue:`53687`)
 - Fixed incorrect ``__name__`` attribute of ``pandas._libs.json`` (:issue:`52898`)
 -
 

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -1175,6 +1175,7 @@ def _get_ordinal_range(start, end, periods, freq, mult: int = 1):
             freq = end.freq
         else:  # pragma: no cover
             raise ValueError("Could not infer freq from start/end")
+        mult = freq.n
 
     if periods is not None:
         periods = periods * mult

--- a/pandas/tests/indexes/period/test_constructors.py
+++ b/pandas/tests/indexes/period/test_constructors.py
@@ -137,6 +137,13 @@ class TestPeriodIndex:
         exp = period_range("2007-01", periods=10, freq="M")
         tm.assert_index_equal(result, exp)
 
+    def test_constructor_with_without_freq(self):
+        # GH53687
+        start = Period("2002-01-01 00:00", freq="30T")
+        exp = period_range(start=start, periods=5, freq=start.freq)
+        result = period_range(start=start, periods=5)
+        tm.assert_index_equal(exp, result)
+
     def test_constructor_fromarraylike(self):
         idx = period_range("2007-01", periods=20, freq="M")
 


### PR DESCRIPTION
- [x] closes #53687
- [x] [Tests added and passed]
- [x] All [code checks passed]
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file
