### PR TITLE
DOC: point out that only period aliases are valid for the method asfreq in period.pyx

### DIFF
--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1917,7 +1917,8 @@ cdef class _Period(PeriodMixin):
         Parameters
         ----------
         freq : str, BaseOffset
-            The desired frequency.
+            The desired frequency. If passing a `str`, it needs to be a
+            valid :ref:`period alias <timeseries.period_aliases>`.
         how : {'E', 'S', 'end', 'start'}, default 'end'
             Start or end of the timespan.
 


### PR DESCRIPTION
related to pr #52064
Updated docstring for the method `asfreq` in period.pyx. Point out that only period aliases are valid for `asfreq`.