### PR TITLE
BUG: handle none values in `json.normalize()`

### DIFF
--- a/pandas/io/json/_normalize.py
+++ b/pandas/io/json/_normalize.py
@@ -490,6 +490,8 @@ def json_normalize(
     meta_keys = [sep.join(val) for val in _meta]
 
     def _recursive_extract(data, path, seen_meta, level: int = 0) -> None:
+        if data is None:
+            return
         if isinstance(data, dict):
             data = [data]
         if len(path) > 1:

--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -582,6 +582,29 @@ class TestJSONNormalize:
 
         tm.assert_frame_equal(result, expected)
 
+    def test_column_with_none(self):
+        # 53719
+        data = {
+            "root": [
+                {
+                    "id": 1,
+                    "nested_field": [{"nested_field_id": 1}],
+                },
+                {"id": 2, "nested_field": None},
+            ]
+        }
+        result = json_normalize(
+            data,
+            record_path=["root", "nested_field"],
+        )
+        expected = DataFrame(
+            {
+                "nested_field_id": [1],
+            }
+        )
+
+        tm.assert_frame_equal(result, expected)
+
 
 class TestNestedToRecord:
     def test_flat_stays_flat(self):


### PR DESCRIPTION
This PR fixes the error which is thrown when a field value in `json` is `null` while `json_normalize` it to a `DataFrame`. Implemented tests to validate the change

- [x] closes #53719 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
