### PR TITLE
TST/CI: Skipif test_complibs

### DIFF
--- a/pandas/tests/io/pytables/test_file_handling.py
+++ b/pandas/tests/io/pytables/test_file_handling.py
@@ -230,11 +230,11 @@ def test_complibs_default_settings_override(tmp_path, setup_path):
 @pytest.mark.parametrize("lvl", range(10))
 @pytest.mark.parametrize("lib", tables.filters.all_complibs)
 @pytest.mark.filterwarnings("ignore:object name is not a valid")
-@pytest.mark.xfail(
+@pytest.mark.skipif(
     not PY311 and is_ci_environment() and is_platform_linux(),
-    reason="producing invalid start bytes",
-    raises=UnicodeDecodeError,
-    strict=False,
+    reason="Segfaulting in a CI environment"
+    # with xfail, would sometimes raise UnicodeDecodeError
+    # invalid state byte
 )
 def test_complibs(tmp_path, lvl, lib):
     # GH14478


### PR DESCRIPTION
Even though this was just xfailed, it appears to also be causing segfault in the CI so just skipping for now e.g. https://github.com/pandas-dev/pandas/actions/runs/5352556089/jobs/9707592733