### PR TITLE
DOC: fix inconsistencies in `read_csv` docstring type descriptions

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -111,7 +111,7 @@ sep : str, default {_default_sep}
     to ignoring quoted data. Regex example: ``'\r\t'``.
 delimiter : str, optional
     Alias for ``sep``.
-header : int, list of int, None, default 'infer'
+header : int, Sequence of int, 'infer' or None, default 'infer'
     Row number(s) to use as the column names, and the start of the
     data.  Default behavior is to infer the column names: if no ``names``
     are passed the behavior is identical to ``header=0`` and column
@@ -125,11 +125,11 @@ header : int, list of int, None, default 'infer'
     parameter ignores commented lines and empty lines if
     ``skip_blank_lines=True``, so ``header=0`` denotes the first line of
     data rather than the first line of the file.
-names : array-like, optional
+names : Sequence of Hashable, optional
     List of column names to use. If the file contains a header row,
     then you should explicitly pass ``header=0`` to override the column names.
     Duplicates in this list are not allowed.
-index_col : int, str, sequence of int / str, or False, optional
+index_col : Hashable, Sequence of Hashable or False, optional
   Column(s) to use as the row labels of the :class:`~pandas.DataFrame`, either given as
   string name or column index. If a sequence of ``int`` / ``str`` is given, a
   :class:`~pandas.MultiIndex` is used.
@@ -137,7 +137,7 @@ index_col : int, str, sequence of int / str, or False, optional
   Note: ``index_col=False`` can be used to force ``pandas`` to *not* use the first
   column as the index, e.g. when you have a malformed file with delimiters at
   the end of each line.
-usecols : list-like or callable, optional
+usecols : list of Hashable or Callable, optional
     Return a subset of the columns. If list-like, all elements must either
     be positional (i.e. integer indices into the document columns) or strings
     that correspond to column names provided either by the user in ``names`` or
@@ -156,7 +156,7 @@ usecols : list-like or callable, optional
     example of a valid callable argument would be ``lambda x: x.upper() in
     ['AAA', 'BBB', 'DDD']``. Using this parameter results in much faster
     parsing time and lower memory usage.
-dtype : Type name or dict of column -> type, optional
+dtype : dtype or dict of {{Hashable : dtype}}, optional
     Data type for data or columns. E.g., ``{{'a': np.float64, 'b': np.int32,
     'c': 'Int64'}}``
     Use ``str`` or ``object`` together with suitable ``na_values`` settings
@@ -176,18 +176,18 @@ engine : {{'c', 'python', 'pyarrow'}}, optional
 
     .. versionadded:: 1.4.0
 
-        The "pyarrow" engine was added as an *experimental* engine, and some features
+        The 'pyarrow' engine was added as an *experimental* engine, and some features
         are unsupported, or may not work correctly, with this engine.
-converters : dict, optional
+converters : dict of {{Hashable : Callable}}, optional
     ``dict`` of functions for converting values in certain columns. Keys can either
     be integers or column labels.
 true_values : list, optional
-    Values to consider as ``True`` in addition to case-insensitive variants of "True".
+    Values to consider as ``True`` in addition to case-insensitive variants of 'True'.
 false_values : list, optional
-    Values to consider as ``False`` in addition to case-insensitive variants of "False".
+    Values to consider as ``False`` in addition to case-insensitive variants of 'False'.
 skipinitialspace : bool, default False
     Skip spaces after delimiter.
-skiprows : list-like, int or callable, optional
+skiprows : int, list of int or Callable, optional
     Line numbers to skip (0-indexed) or number of lines to skip (``int``)
     at the start of the file.
 
@@ -198,7 +198,8 @@ skipfooter : int, default 0
     Number of lines at bottom of file to skip (Unsupported with ``engine='c'``).
 nrows : int, optional
     Number of rows of file to read. Useful for reading pieces of large files.
-na_values : scalar, str, list-like, or dict, optional
+na_values : Hashable, Iterable of Hashable or dict of {{Hashable : Iterable of \
+Hashable}}, optional
     Additional strings to recognize as ``NA``/``NaN``. If ``dict`` passed, specific
     per-column ``NA`` values.  By default the following values are interpreted as
     ``NaN``: '"""
@@ -258,7 +259,7 @@ infer_datetime_format : bool, default False
 keep_date_col : bool, default False
     If ``True`` and ``parse_dates`` specifies combining multiple columns then
     keep the original columns.
-date_parser : function, optional
+date_parser : Callable, optional
     Function to use for converting a sequence of string columns to an array of
     ``datetime`` instances. The default uses ``dateutil.parser.parser`` to do the
     conversion. ``pandas`` will try to call ``date_parser`` in three different ways,
@@ -305,16 +306,16 @@ chunksize : int, optional
 
     .. versionchanged:: 1.4.0 Zstandard support.
 
-thousands : str, optional
+thousands : str (length 1), optional
     Thousands separator.
-decimal : str, default '.'
+decimal : str (length 1), default '.'
     Character to recognize as decimal point (e.g. use ',' for European data).
 lineterminator : str (length 1), optional
     Character to break file into lines. Only valid with C parser.
 quotechar : str (length 1), optional
     The character used to denote the start and end of a quoted item. Quoted
     items can include the ``delimiter`` and it will be ignored.
-quoting : int or csv.QUOTE_* instance, default 0
+quoting : int or csv.QUOTE_* instance, default 0 (i.e., csv.QUOTE_MINIMAL)
     Control field quoting behavior per ``csv.QUOTE_*`` constants. Use one of
     ``QUOTE_MINIMAL`` (0), ``QUOTE_ALL`` (1), ``QUOTE_NONNUMERIC`` (2) or
     ``QUOTE_NONE`` (3).
@@ -324,7 +325,7 @@ doublequote : bool, default True
    field as a single ``quotechar`` element.
 escapechar : str (length 1), optional
     One-character string used to escape other characters.
-comment : str, optional
+comment : str (length 1), optional
     Indicates remainder of line should not be parsed. If found at the beginning
     of a line, the line will be ignored altogether. This parameter must be a
     single character. Like empty lines (as long as ``skip_blank_lines=True``),
@@ -332,23 +333,24 @@ comment : str, optional
     ``skiprows``. For example, if ``comment='#'``, parsing
     ``#empty\\na,b,c\\n1,2,3`` with ``header=0`` will result in ``'a,b,c'`` being
     treated as the header.
-encoding : str, optional, default "utf-8"
+encoding : str, optional, default 'utf-8'
     Encoding to use for UTF when reading/writing (ex. ``'utf-8'``). `List of Python
     standard encodings
     <https://docs.python.org/3/library/codecs.html#standard-encodings>`_ .
 
     .. versionchanged:: 1.2
 
-       When ``encoding`` is ``None``, ``errors="replace"`` is passed to
-       ``open()``. Otherwise, ``errors="strict"`` is passed to ``open()``.
-       This behavior was previously only the case for ``engine="python"``.
+       When ``encoding`` is ``None``, ``errors='replace'`` is passed to
+       ``open()``. Otherwise, ``errors='strict'`` is passed to ``open()``.
+       This behavior was previously only the case for ``engine='python'``.
 
     .. versionchanged:: 1.3.0
 
        ``encoding_errors`` is a new argument. ``encoding`` has no longer an
        influence on how encoding errors are handled.
 
-encoding_errors : str, optional, default "strict"
+encoding_errors : str, optional, default 'strict'
+    # TODO: figure out what None means
     How encoding errors are treated. `List of possible values
     <https://docs.python.org/3/library/codecs.html#error-handlers>`_ .
 
@@ -360,7 +362,8 @@ dialect : str or csv.Dialect, optional
     ``skipinitialspace``, ``quotechar``, and ``quoting``. If it is necessary to
     override values, a ``ParserWarning`` will be issued. See ``csv.Dialect``
     documentation for more details.
-on_bad_lines : {{'error', 'warn', 'skip'}} or callable, default 'error'
+on_bad_lines : {{'error', 'warn', 'skip'}} or Callable, default 'error'
+    # TODO: confirm that callable should be added to type hint
     Specifies what to do upon encountering a bad line (a line with too many fields).
     Allowed values are :
 
@@ -378,7 +381,7 @@ on_bad_lines : {{'error', 'warn', 'skip'}} or callable, default 'error'
           If the function returns ``None``, the bad line will be ignored.
           If the function returns a new ``list`` of strings with more elements than
           expected, a ``ParserWarning`` will be emitted while dropping extra elements.
-          Only supported when ``engine="python"``
+          Only supported when ``engine='python'``
 
 delim_whitespace : bool, default False
     Specifies whether or not whitespace (e.g. ``' '`` or ``'\\t'``) will be
@@ -396,7 +399,8 @@ memory_map : bool, default False
     If a filepath is provided for ``filepath_or_buffer``, map the file object
     directly onto memory and access the data directly from there. Using this
     option can improve performance because there is no longer any I/O overhead.
-float_precision : str, optional
+float_precision : {{'high', 'legacy', 'round_trip'}}, optional
+    # TODO: figure out why type hint is missing 'round_trip'
     Specifies which converter the C engine should use for floating-point
     values. The options are ``None`` or ``'high'`` for the ordinary converter,
     ``'legacy'`` for the original lower precision ``pandas`` converter, and
@@ -408,11 +412,12 @@ float_precision : str, optional
 
     .. versionadded:: 1.2
 
-dtype_backend : {{"numpy_nullable", "pyarrow"}}, defaults to NumPy backed DataFrame
+dtype_backend : {{'numpy_nullable', 'pyarrow'}}, defaults to NumPy backed DataFrame
+    # TODO: confirm that default can be 'numpy_nullable'
     Which ``dtype_backend`` to use, e.g. whether a :class:`~pandas.DataFrame` should
     have NumPy arrays, nullable ``dtypes`` are used for all ``dtypes`` that have a
-    nullable implementation when ``"numpy_nullable"`` is set, pyarrow is used for all
-    dtypes if ``"pyarrow"`` is set.
+    nullable implementation when ``'numpy_nullable'`` is set, pyarrow is used for all
+    dtypes if ``'pyarrow'`` is set.
 
     The ``dtype_backends`` are still experimential.
 

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -200,8 +200,7 @@ skipfooter : int, default 0
     Number of lines at bottom of file to skip (Unsupported with ``engine='c'``).
 nrows : int, optional
     Number of rows of file to read. Useful for reading pieces of large files.
-na_values : Hashable, Iterable of Hashable or dict of {{Hashable : Iterable of \
-Hashable}}, optional
+na_values : Hashable, Iterable of Hashable or dict of {{Hashable : Iterable}}, optional
     Additional strings to recognize as ``NA``/``NaN``. If ``dict`` passed, specific
     per-column ``NA`` values.  By default the following values are interpreted as
     ``NaN``: '"""
@@ -230,7 +229,7 @@ verbose : bool, default False
     Indicate number of ``NA`` values placed in non-numeric columns.
 skip_blank_lines : bool, default True
     If ``True``, skip over blank lines rather than interpreting as ``NaN`` values.
-parse_dates : bool or list of int or names or list of lists or dict, \
+parse_dates : bool, list of Hashable, list of lists or dict of {{Hashable : list}}, \
 default False
     The behavior is as follows:
 


### PR DESCRIPTION
- [x] closes #53763
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).