### PR TITLE
TST: increase coverage of asfreq

### DIFF
--- a/pandas/tests/frame/methods/test_asfreq.py
+++ b/pandas/tests/frame/methods/test_asfreq.py
@@ -211,3 +211,12 @@ class TestAsFreq:
         )
         expected = DatetimeIndex(["2000-01-01", "2000-01-02"], freq="D").as_unit(unit)
         tm.assert_index_equal(result, expected)
+
+    def test_asfreq_2M(self, frame_or_series):
+        index = date_range("1/1/2000", periods=6, freq="M")
+        df = DataFrame({"s": Series([0.0, 1.0, 2.0, 3.0, 4.0, 5.0], index=index)})
+        expected = df.asfreq(freq="2M")
+
+        index = date_range("1/1/2000", periods=3, freq="2M")
+        result = DataFrame({"s": Series([0.0, 2.0, 4.0], index=index)})
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/methods/test_asfreq.py
+++ b/pandas/tests/frame/methods/test_asfreq.py
@@ -212,7 +212,7 @@ class TestAsFreq:
         expected = DatetimeIndex(["2000-01-01", "2000-01-02"], freq="D").as_unit(unit)
         tm.assert_index_equal(result, expected)
 
-    def test_asfreq_2M(self, frame_or_series):
+    def test_asfreq_2M(self):
         index = date_range("1/1/2000", periods=6, freq="M")
         df = DataFrame({"s": Series([0.0, 1.0, 2.0, 3.0, 4.0, 5.0], index=index)})
         expected = df.asfreq(freq="2M")


### PR DESCRIPTION
In order to  increase coverage of `asfreq` a test is added, in which we pass `freq = '2M'` to `asfreq`. There's no test which has a number with the frequency yet.