### PR TITLE
DOC Remove incorrect line from dropna docs

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6164,7 +6164,6 @@ class DataFrame(NDFrame, OpsMixin):
             * 0, or 'index' : Drop rows which contain missing values.
             * 1, or 'columns' : Drop columns which contain missing value.
 
-            Pass tuple or list to drop on multiple axes.
             Only a single axis is allowed.
 
         how : {'any', 'all'}, default 'any'


### PR DESCRIPTION
Remove incorrect line "Pass tuple or list to drop on multiple axes. " from dropna docs, as the ability to drop on multiple axes has been depreciated.
