### PR TITLE
TST: add test with freq=2M for period_array from datetime64

### DIFF
--- a/pandas/tests/arrays/period/test_constructors.py
+++ b/pandas/tests/arrays/period/test_constructors.py
@@ -56,6 +56,15 @@ def test_from_datetime64_freq_changes():
     tm.assert_period_array_equal(result, expected)
 
 
+def test_from_datetime64_freq_2M():
+    arr = np.array(
+        ["2020-01-01T00:00:00", "2020-01-02T00:00:00"], dtype="datetime64[ns]"
+    )
+    result = PeriodArray._from_datetime64(arr, "2M")
+    expected = period_array(["2020-01", "2020-01"], freq="2M")
+    tm.assert_period_array_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     "data, freq, msg",
     [


### PR DESCRIPTION
xref #52064

added a test in `pandas/tests/arrays/period/test_constructors.py`, which covers a case `freq='2M'` for period_array from datetime64. The reason: existing tests were all for `"freq='M'"`,  rather then for `"freq='2M'"`.