### PR TITLE
CI: linting check to ensure `lib.NoDefault` is only used for typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -340,7 +340,7 @@ repos:
         entry: python scripts/validate_unwanted_patterns.py --validation-type="strings_with_wrong_placed_whitespace"
         types_or: [python, cython]
     -   id: unwanted-patterns-nodefault-not-used-for-typing
-        name: Check for pandas._libs.lib.NoDefault not used for typing
+        name: Check for `pandas._libs.lib.NoDefault` not used for typing
         language: python
         entry: python scripts/validate_unwanted_patterns.py --validation-type="nodefault_not_used_for_typing"
         types_or: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -343,7 +343,7 @@ repos:
         name: Check for `pandas._libs.lib.NoDefault` not used for typing
         language: python
         entry: python scripts/validate_unwanted_patterns.py --validation-type="nodefault_not_used_for_typing"
-        types_or: [python]
+        types: [python]
     -   id: use-pd_array-in-core
         name: Import pandas.array as pd_array in core
         language: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -340,7 +340,7 @@ repos:
         entry: python scripts/validate_unwanted_patterns.py --validation-type="strings_with_wrong_placed_whitespace"
         types_or: [python, cython]
     -   id: unwanted-patterns-nodefault-not-used-for-typing
-        name: Check for `pandas._libs.lib.NoDefault` not used for typing
+        name: Check that `pandas._libs.lib.NoDefault` is only used for typing
         language: python
         entry: python scripts/validate_unwanted_patterns.py --validation-type="nodefault_not_used_for_typing"
         types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -339,10 +339,10 @@ repos:
         language: python
         entry: python scripts/validate_unwanted_patterns.py --validation-type="strings_with_wrong_placed_whitespace"
         types_or: [python, cython]
-    -   id: unwanted-patterns-nodefault-not-used-for-typing
-        name: Check that `pandas._libs.lib.NoDefault` is only used for typing
+    -   id: unwanted-patterns-nodefault-used-not-only-for-typing
+        name: Check that `pandas._libs.lib.NoDefault` is used only for typing
         language: python
-        entry: python scripts/validate_unwanted_patterns.py --validation-type="nodefault_not_used_for_typing"
+        entry: python scripts/validate_unwanted_patterns.py --validation-type="nodefault_used_not_only_for_typing"
         types: [python]
     -   id: use-pd_array-in-core
         name: Import pandas.array as pd_array in core

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -339,6 +339,11 @@ repos:
         language: python
         entry: python scripts/validate_unwanted_patterns.py --validation-type="strings_with_wrong_placed_whitespace"
         types_or: [python, cython]
+    -   id: unwanted-patterns-nodefault-not-used-for-typing
+        name: Check for pandas._libs.lib.NoDefault not used for typing
+        language: python
+        entry: python scripts/validate_unwanted_patterns.py --validation-type="nodefault_not_used_for_typing"
+        types_or: [python]
     -   id: use-pd_array-in-core
         name: Import pandas.array as pd_array in core
         language: python

--- a/scripts/tests/test_validate_unwanted_patterns.py
+++ b/scripts/tests/test_validate_unwanted_patterns.py
@@ -377,7 +377,7 @@ class TestStringsWithWrongPlacedWhitespace:
         assert result == expected
 
 
-class TestNoDefaultNotUsedForTyping:
+class TestNoDefaultUsedNotOnlyForTyping:
     @pytest.mark.parametrize(
         "data",
         [
@@ -401,9 +401,9 @@ b: lib.NoDefault = lib.no_default
             ),
         ],
     )
-    def test_nodefault_not_used_for_typing(self, data):
+    def test_nodefault_used_not_only_for_typing(self, data):
         fd = io.StringIO(data.strip())
-        result = list(validate_unwanted_patterns.nodefault_not_used_for_typing(fd))
+        result = list(validate_unwanted_patterns.nodefault_used_not_only_for_typing(fd))
         assert result == []
 
     @pytest.mark.parametrize(
@@ -440,7 +440,7 @@ if a is NoDefault:
             ),
         ],
     )
-    def test_nodefault_not_used_for_typing_raises(self, data, expected):
+    def test_nodefault_used_not_only_for_typing_raises(self, data, expected):
         fd = io.StringIO(data.strip())
-        result = list(validate_unwanted_patterns.nodefault_not_used_for_typing(fd))
+        result = list(validate_unwanted_patterns.nodefault_used_not_only_for_typing(fd))
         assert result == expected

--- a/scripts/tests/test_validate_unwanted_patterns.py
+++ b/scripts/tests/test_validate_unwanted_patterns.py
@@ -375,3 +375,72 @@ class TestStringsWithWrongPlacedWhitespace:
             validate_unwanted_patterns.strings_with_wrong_placed_whitespace(fd)
         )
         assert result == expected
+
+
+class TestNoDefaultNotUsedForTyping:
+    @pytest.mark.parametrize(
+        "data",
+        [
+            (
+                """
+def f(
+    a: int | NoDefault,
+    b: float | lib.NoDefault = 0.1,
+    c: pandas._libs.lib.NoDefault = lib.no_default,
+) -> lib.NoDefault | None:
+    pass
+"""
+            ),
+            (
+                """
+# var = lib.NoDefault
+# the above is incorrect
+a: NoDefault | int
+b: lib.NoDefault = lib.no_default
+"""
+            ),
+        ],
+    )
+    def test_nodefault_not_used_for_typing(self, data):
+        fd = io.StringIO(data.strip())
+        result = list(validate_unwanted_patterns.nodefault_not_used_for_typing(fd))
+        assert result == []
+
+    @pytest.mark.parametrize(
+        "data, expected",
+        [
+            (
+                (
+                    """
+def f(
+    a = lib.NoDefault,
+    b: Any
+        = pandas._libs.lib.NoDefault,
+):
+    pass
+"""
+                ),
+                [
+                    (2, "NoDefault is not used for typing"),
+                    (4, "NoDefault is not used for typing"),
+                ],
+            ),
+            (
+                (
+                    """
+a: Any = lib.NoDefault
+if a is NoDefault:
+    pass
+"""
+                ),
+                [
+                    (1, "NoDefault is not used for typing"),
+                    (2, "NoDefault is not used for typing"),
+                ],
+            ),
+        ],
+    )
+    def test_nodefault_not_used_for_typing_raises(self, data, expected):
+        fd = io.StringIO(data.strip())
+        result = list(validate_unwanted_patterns.nodefault_not_used_for_typing(fd))
+        assert result == expected

--- a/scripts/tests/test_validate_unwanted_patterns.py
+++ b/scripts/tests/test_validate_unwanted_patterns.py
@@ -421,8 +421,8 @@ def f(
 """
                 ),
                 [
-                    (2, "NoDefault is not used for typing"),
-                    (4, "NoDefault is not used for typing"),
+                    (2, "NoDefault is used not only for typing"),
+                    (4, "NoDefault is used not only for typing"),
                 ],
             ),
             (
@@ -434,8 +434,8 @@ if a is NoDefault:
 """
                 ),
                 [
-                    (1, "NoDefault is not used for typing"),
-                    (2, "NoDefault is not used for typing"),
+                    (1, "NoDefault is used not only for typing"),
+                    (2, "NoDefault is used not only for typing"),
                 ],
             ),
         ],

--- a/scripts/validate_unwanted_patterns.py
+++ b/scripts/validate_unwanted_patterns.py
@@ -364,39 +364,39 @@ def nodefault_not_used_for_typing(file_obj: IO[str]) -> Iterable[Tuple[int, str]
     Yields
     ------
     line_number : int
-        Line number of unconcatenated string.
+        Line number of misused lib.NoDefault.
     msg : str
         Explanation of the error.
     """
     contents = file_obj.read()
     tree = ast.parse(contents)
-    for node in ast.walk(tree):
-        for child in ast.iter_child_nodes(node):
-            child.parent = node
+    in_annotation = False
+    nodes: List[tuple[bool, ast.AST]] = [(in_annotation, tree)]
 
-    def child_of(node, types):
-        """Check if any ancestor of the node has the specified type.
-
-        Parameters
-        ----------
-        node : AST
-            A node in the AST.
-        types : tuple of classes
-            The types as in `ininstance(xxx, types)`.
-        """
-        curnode = getattr(node, "parent", None)
-        while curnode is not None:
-            if isinstance(curnode, types):
-                return True
-            curnode = getattr(curnode, "parent", None)
-        return False
-
-    for node in ast.walk(tree):
-        if (isinstance(node, ast.Name) and node.id == "NoDefault") or (
-            isinstance(node, ast.Attribute) and node.attr == "NoDefault"
+    while nodes:
+        in_annotation, node = nodes.pop()
+        if not in_annotation and (
+            isinstance(node, ast.Name)  # Case `NoDefault`
+            and node.id == "NoDefault"
+            or isinstance(node, ast.Attribute)  # Cases e.g. `lib.NoDefault`
+            and node.attr == "NoDefault"
         ):
-            if not child_of(node, (ast.AnnAssign, ast.arg)):
-                yield (node.lineno, "NoDefault is not used for typing")
+            yield (node.lineno, "NoDefault is not used for typing")
+
+        # This part is adapted from
+        # https://github.com/asottile/pyupgrade/blob/5495a248f2165941c5d3b82ac3226ba7ad1fa59d/pyupgrade/_data.py#L70-L113
+        for name in reversed(node._fields):
+            value = getattr(node, name)
+            if name in {"annotation", "returns"}:
+                next_in_annotation = True
+            else:
+                next_in_annotation = in_annotation
+            if isinstance(value, ast.AST):
+                nodes.append((next_in_annotation, value))
+            elif isinstance(value, list):
+                for value in reversed(value):
+                    if isinstance(value, ast.AST):
+                        nodes.append((next_in_annotation, value))
 
 
 def main(
@@ -460,7 +460,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--format",
         "-f",
-        default="{source_path}:{line_number}:{msg}",
+        default="{source_path}:{line_number}: {msg}",
         help="Output format of the error message.",
     )
     parser.add_argument(

--- a/scripts/validate_unwanted_patterns.py
+++ b/scripts/validate_unwanted_patterns.py
@@ -353,7 +353,7 @@ def strings_with_wrong_placed_whitespace(
                 )
 
 
-def nodefault_not_used_for_typing(file_obj: IO[str]) -> Iterable[Tuple[int, str]]:
+def nodefault_used_not_only_for_typing(file_obj: IO[str]) -> Iterable[Tuple[int, str]]:
     """Test case where pandas._libs.lib.NoDefault is not used for typing.
 
     Parameters
@@ -381,7 +381,7 @@ def nodefault_not_used_for_typing(file_obj: IO[str]) -> Iterable[Tuple[int, str]
             or isinstance(node, ast.Attribute)  # Cases e.g. `lib.NoDefault`
             and node.attr == "NoDefault"
         ):
-            yield (node.lineno, "NoDefault is not used for typing")
+            yield (node.lineno, "NoDefault is used not only for typing")
 
         # This part is adapted from
         # https://github.com/asottile/pyupgrade/blob/5495a248f2165941c5d3b82ac3226ba7ad1fa59d/pyupgrade/_data.py#L70-L113
@@ -451,7 +451,7 @@ if __name__ == "__main__":
         "private_function_across_module",
         "private_import_across_module",
         "strings_with_wrong_placed_whitespace",
-        "nodefault_not_used_for_typing",
+        "nodefault_used_not_only_for_typing",
     ]
 
     parser = argparse.ArgumentParser(description="Unwanted patterns checker.")


### PR DESCRIPTION
- [x] See https://github.com/pandas-dev/pandas/pull/53877#issuecomment-1609917156
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit)
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions

In this PR, I added a pre-commit hook to check that `pandas._libs.lib.NoDefault` is used only for typing. This is invoked by #53877. Before that PR, this new hook correctly catches all misused `NoDefault`:

<details>
<p></p>

```
(pandas-dev) D:\>pre-commit run unwanted-patterns-nodefault-not-used-for-typing --all-files
Check for pandas._libs.lib.NoDefault not used for typing.......................Failed   
- hook id: unwanted-patterns-nodefault-not-used-for-typing
- exit code: 1

pandas/tests/reshape/test_pivot_multilevel.py:38:NoDefault is not used for typing       
pandas/tests/reshape/test_pivot_multilevel.py:75:NoDefault is not used for typing       
pandas/core/frame.py:8831:NoDefault is not used for typing
pandas/core/frame.py:8831:NoDefault is not used for typing
pandas/core/reshape/pivot.py:514:NoDefault is not used for typing
pandas/core/reshape/pivot.py:515:NoDefault is not used for typing
pandas/core/reshape/pivot.py:529:NoDefault is not used for typing
pandas/core/reshape/pivot.py:525:NoDefault is not used for typing
pandas/core/reshape/pivot.py:530:NoDefault is not used for typing
pandas/core/reshape/pivot.py:535:NoDefault is not used for typing
pandas/core/reshape/pivot.py:542:NoDefault is not used for typing
pandas/core/reshape/pivot.py:572:NoDefault is not used for typing
```

</details>

After that PR, the check passes normally:

<details>
<p></p>

```
(pandas-dev) D:\>pre-commit run unwanted-patterns-nodefault-not-used-for-typing --all-files
Check for pandas._libs.lib.NoDefault not used for typing.......................Passed
```

</details>

In fact I don't work with ASTs very often so not sure if this check covers all possibilties. Please let me know if any modification is needed. (The runtime is a bit long but seems acceptable, approximately 10s to check all files.)
