### PR TITLE
Revert addition of 'None' to default na_values of the parser

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -1149,7 +1149,7 @@ To completely override the default values that are recognized as missing, specif
 .. _io.navaluesconst:
 
 The default ``NaN`` recognized values are ``['-1.#IND', '1.#QNAN', '1.#IND', '-1.#QNAN', '#N/A N/A', '#N/A', 'N/A',
-'n/a', 'NA', '<NA>', '#NA', 'NULL', 'null', 'NaN', '-NaN', 'nan', '-nan', 'None', '']``.
+'n/a', 'NA', '<NA>', '#NA', 'NULL', 'null', 'NaN', '-NaN', 'nan', '-nan', '']``.
 
 Let us consider some examples:
 

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1410,7 +1410,6 @@ STR_NA_VALUES = {
     "nan",
     "-nan",
     "",
-    "None",
 }
 _NA_VALUES = _ensure_encoded(list(STR_NA_VALUES))
 

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -113,7 +113,6 @@ def test_default_na_values(all_parsers):
         "-nan",
         "#N/A N/A",
         "",
-        "None",
     }
     assert _NA_VALUES == STR_NA_VALUES
 

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -178,6 +178,7 @@ class TestReadHtml:
                 "b": Series([1, 2, 3], dtype="Int64"),
                 "c": Series([1.5, np.nan, 2.5], dtype="Float64"),
                 "d": Series([1.5, 2.0, 2.5], dtype="Float64"),
+                # "e": Series([True, False, None], dtype="boolean"),
                 "e": [True, False, None],
                 "f": [True, False, True],
                 "g": ["a", "b", "c"],


### PR DESCRIPTION
Running the tests for https://github.com/pandas-dev/pandas/issues/52493

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
