### PR TITLE
TST: add the parameter MonthEnd(2) to 2 tests with freq= 2M

### DIFF
--- a/pandas/tests/arrays/period/test_constructors.py
+++ b/pandas/tests/arrays/period/test_constructors.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs import iNaT
+from pandas._libs.tslibs.offsets import MonthEnd
 from pandas._libs.tslibs.period import IncompatibleFrequency
 
 import pandas as pd
@@ -56,12 +57,13 @@ def test_from_datetime64_freq_changes():
     tm.assert_period_array_equal(result, expected)
 
 
-def test_from_datetime64_freq_2M():
+@pytest.mark.parametrize("freq", ["2M", MonthEnd(2)])
+def test_from_datetime64_freq_2M(freq):
     arr = np.array(
         ["2020-01-01T00:00:00", "2020-01-02T00:00:00"], dtype="datetime64[ns]"
     )
-    result = PeriodArray._from_datetime64(arr, "2M")
-    expected = period_array(["2020-01", "2020-01"], freq="2M")
+    result = PeriodArray._from_datetime64(arr, freq)
+    expected = period_array(["2020-01", "2020-01"], freq=freq)
     tm.assert_period_array_equal(result, expected)
 
 

--- a/pandas/tests/frame/methods/test_asfreq.py
+++ b/pandas/tests/frame/methods/test_asfreq.py
@@ -3,6 +3,8 @@ from datetime import datetime
 import numpy as np
 import pytest
 
+from pandas._libs.tslibs.offsets import MonthEnd
+
 from pandas import (
     DataFrame,
     DatetimeIndex,
@@ -212,11 +214,18 @@ class TestAsFreq:
         expected = DatetimeIndex(["2000-01-01", "2000-01-02"], freq="D").as_unit(unit)
         tm.assert_index_equal(result, expected)
 
-    def test_asfreq_2M(self):
-        index = date_range("1/1/2000", periods=6, freq="M")
+    @pytest.mark.parametrize(
+        "freq, freq_half",
+        [
+            ("2M", "M"),
+            (MonthEnd(2), MonthEnd(1)),
+        ],
+    )
+    def test_asfreq_2M(self, freq, freq_half):
+        index = date_range("1/1/2000", periods=6, freq=freq_half)
         df = DataFrame({"s": Series([0.0, 1.0, 2.0, 3.0, 4.0, 5.0], index=index)})
-        expected = df.asfreq(freq="2M")
+        expected = df.asfreq(freq=freq)
 
-        index = date_range("1/1/2000", periods=3, freq="2M")
+        index = date_range("1/1/2000", periods=3, freq=freq)
         result = DataFrame({"s": Series([0.0, 2.0, 4.0], index=index)})
         tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
xref #52064

added parametrization to 2 tests in which we pass `freq = '2M'`  to check if they work correctly not only with str, but with offsets (`MonthEnd(2)`) as well.