### PR TITLE
CI: Don't rebuild pandas before running tests

### DIFF
--- a/.github/actions/build_pandas/action.yml
+++ b/.github/actions/build_pandas/action.yml
@@ -14,6 +14,13 @@ runs:
         micromamba list
       shell: bash -el {0}
 
+    - name: Uninstall existing Pandas installation
+      run: |
+        if pip list | grep -q ^pandas; then
+          pip uninstall -y pandas || true
+        fi
+      shell: bash -el {0}
+
     - name: Build Pandas
       run: |
         if [[ ${{ inputs.editable }} == "true" ]]; then


### PR DESCRIPTION
It appears some unit test jobs are rebuilding pandas before running `pytest`. Meson might be rebuilding pandas because an optional dependency installed pandas before the initial build, so trying to uninstall pandas before the initial build

cc @lithomas1 