### PR TITLE
DOC: remove unnecessary note about EA values_for_factorize from 2.0.3 whatsnew

### DIFF
--- a/doc/source/whatsnew/v2.0.3.rst
+++ b/doc/source/whatsnew/v2.0.3.rst
@@ -16,7 +16,6 @@ Fixed regressions
 - Bug in :meth:`Timestamp.weekday`` was returning incorrect results before ``'0000-02-29'`` (:issue:`53738`)
 - Fixed performance regression in merging on datetime-like columns (:issue:`53231`)
 - Fixed regression when :meth:`DataFrame.to_string` creates extra space for string dtypes (:issue:`52690`)
-- For external ExtensionArray implementations, restored the default use of ``_values_for_factorize`` for hashing arrays (:issue:`53475`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_203.bug_fixes:


### PR DESCRIPTION
See https://github.com/pandas-dev/pandas/pull/53475#issuecomment-1611999192