### PR TITLE
REF: remove axis keyword from PandasArray.pad_or_backfill

### DIFF
--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -233,13 +233,12 @@ class PandasArray(  # type: ignore[misc]
         self,
         *,
         method: FillnaOptions,
-        axis: int,
         limit: int | None,
         limit_area: Literal["inside", "outside"] | None = None,
         copy: bool = True,
     ) -> Self:
         """
-        ffill or bfill
+        ffill or bfill along axis=0.
         """
         if copy:
             out_data = self._ndarray.copy()
@@ -250,7 +249,7 @@ class PandasArray(  # type: ignore[misc]
         missing.pad_or_backfill_inplace(
             out_data,
             method=meth,
-            axis=axis,
+            axis=0,
             limit=limit,
             limit_area=limit_area,
         )

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1366,13 +1366,17 @@ class Block(PandasObject):
 
         # Dispatch to the PandasArray method.
         # We know self.array_values is a PandasArray bc EABlock overrides
-        new_values = cast(PandasArray, self.array_values).pad_or_backfill(
+        vals = cast(PandasArray, self.array_values)
+        if axis == 1:
+            vals = vals.T
+        new_values = vals.pad_or_backfill(
             method=method,
-            axis=axis,
             limit=limit,
             limit_area=limit_area,
             copy=copy,
         )
+        if axis == 1:
+            new_values = new_values.T
 
         data = extract_array(new_values, extract_numpy=True)
 


### PR DESCRIPTION
This will make it easier to share with a soon-to-be-implemented EA.pad_or_backfill