### PR TITLE
PERF: ffill/bfill with non-numpy dtypes

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -342,6 +342,7 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.loc` when selecting rows and columns (:issue:`53014`)
 - Performance improvement in :meth:`Series.add` for pyarrow string and binary dtypes (:issue:`53150`)
 - Performance improvement in :meth:`Series.corr` and :meth:`Series.cov` for extension dtypes (:issue:`52502`)
+- Performance improvement in :meth:`Series.ffill`, :meth:`Series.bfill`, :meth:`DataFrame.ffill`, :meth:`DataFrame.bfill` with pyarrow dtypes (:issue:`53950`)
 - Performance improvement in :meth:`Series.str.get_dummies` for pyarrow-backed strings (:issue:`53655`)
 - Performance improvement in :meth:`Series.str.get` for pyarrow-backed strings (:issue:`53152`)
 - Performance improvement in :meth:`Series.str.split` with ``expand=True`` for pyarrow-backed strings (:issue:`53585`)
@@ -350,7 +351,6 @@ Performance improvements
 - Performance improvement in :meth:`~arrays.ArrowExtensionArray.to_numpy` (:issue:`52525`)
 - Performance improvement when doing various reshaping operations on :class:`arrays.IntegerArrays` & :class:`arrays.FloatingArray` by avoiding doing unnecessary validation (:issue:`53013`)
 - Performance improvement when indexing with pyarrow timestamp and duration dtypes (:issue:`53368`)
-- Performance improvement in :meth:`Series.ffill`, :meth:`Series.bfill`, :meth:`DataFrame.ffill`, :meth:`DataFrame.bfill` with pyarrow dtypes (:issue:`??`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -350,6 +350,7 @@ Performance improvements
 - Performance improvement in :meth:`~arrays.ArrowExtensionArray.to_numpy` (:issue:`52525`)
 - Performance improvement when doing various reshaping operations on :class:`arrays.IntegerArrays` & :class:`arrays.FloatingArray` by avoiding doing unnecessary validation (:issue:`53013`)
 - Performance improvement when indexing with pyarrow timestamp and duration dtypes (:issue:`53368`)
+- Performance improvement in :meth:`Series.ffill`, :meth:`Series.bfill`, :meth:`DataFrame.ffill`, :meth:`DataFrame.bfill` with pyarrow dtypes (:issue:`??`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/_libs/algos.pyi
+++ b/pandas/_libs/algos.pyi
@@ -60,6 +60,10 @@ def nancorr_spearman(
 # ----------------------------------------------------------------------
 
 def validate_limit(nobs: int | None, limit=...) -> int: ...
+def get_fill_indexer(
+    mask: npt.NDArray[np.bool_],
+    limit: int | None = None,
+) -> npt.NDArray[np.intp]: ...
 def pad(
     old: np.ndarray,  # ndarray[numeric_object_t]
     new: np.ndarray,  # ndarray[numeric_object_t]

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -525,6 +525,42 @@ def validate_limit(nobs: int | None, limit=None) -> int:
     return lim
 
 
+# TODO: overlap with libgroupby.group_fillna_indexer?
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def get_fill_indexer(const uint8_t[:] mask, limit=None):
+    """
+    Find an indexer to use for ffill to `take` on the array being filled.
+    """
+    cdef:
+        ndarray[intp_t, ndim=1] indexer
+        Py_ssize_t i, N = len(mask), last_valid
+        int lim
+
+        # fill_count is the number of consecutive NAs we have seen.
+        #  If it exceeds the given limit, we stop padding.
+        int fill_count = 0
+
+    lim = validate_limit(N, limit)
+    indexer = np.empty(N, dtype=np.intp)
+
+    last_valid = -1  # haven't yet seen anything non-NA
+
+    for i in range(N):
+        if not mask[i]:
+            indexer[i] = i
+            last_valid = i
+            fill_count = 0
+        else:
+            if fill_count < lim:
+                indexer[i] = last_valid
+            else:
+                indexer[i] = -1
+            fill_count += 1
+
+    return indexer
+
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def pad(

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -67,8 +67,6 @@ if not pa_version_under7p0:
 
     from pandas.core.dtypes.dtypes import ArrowDtype
 
-    from pandas.core.arrays.arrow._arrow_utils import fallback_performancewarning
-
     ARROW_CMP_FUNCS = {
         "eq": pc.equal,
         "ne": pc.not_equal,
@@ -918,7 +916,6 @@ class ArrowExtensionArray(
             return super().fillna(value=value, method=method, limit=limit)
 
         if method is not None:
-            fallback_performancewarning()
             return super().fillna(value=value, method=method, limit=limit)
 
         if isinstance(value, (np.ndarray, ExtensionArray)):

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -829,12 +829,13 @@ class ExtensionArray:
             if method is not None:
                 meth = missing.clean_fill_method(method)
 
+                npmask = np.asarray(mask)
                 if meth == "pad":
-                    indexer = libalgos.get_fill_indexer(mask, limit=limit)
+                    indexer = libalgos.get_fill_indexer(npmask, limit=limit)
                     return self.take(indexer, allow_fill=True)
                 else:
                     # i.e. meth == "backfill"
-                    indexer = libalgos.get_fill_indexer(mask[::-1], limit=limit)[::-1]
+                    indexer = libalgos.get_fill_indexer(npmask[::-1], limit=limit)[::-1]
                     return self[::-1].take(indexer, allow_fill=True)
             else:
                 # fill with value

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -23,7 +23,10 @@ from typing import (
 
 import numpy as np
 
-from pandas._libs import lib
+from pandas._libs import (
+    algos as libalgos,
+    lib,
+)
 from pandas.compat import set_function_name
 from pandas.compat.numpy import function as nv
 from pandas.errors import AbstractMethodError
@@ -824,10 +827,15 @@ class ExtensionArray:
 
         if mask.any():
             if method is not None:
-                func = missing.get_fill_func(method)
-                npvalues = self.astype(object)
-                func(npvalues, limit=limit, mask=mask)
-                new_values = self._from_sequence(npvalues, dtype=self.dtype)
+                meth = missing.clean_fill_method(method)
+
+                if meth == "pad":
+                    indexer = libalgos.get_fill_indexer(mask, limit=limit)
+                    return self.take(indexer, allow_fill=True)
+                else:
+                    # i.e. meth == "backfill"
+                    indexer = libalgos.get_fill_indexer(mask[::-1], limit=limit)[::-1]
+                    return self[::-1].take(indexer, allow_fill=True)
             else:
                 # fill with value
                 new_values = self.copy()

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -38,7 +38,6 @@ from pandas.compat import (
     pa_version_under9p0,
     pa_version_under11p0,
 )
-from pandas.errors import PerformanceWarning
 
 from pandas.core.dtypes.dtypes import (
     ArrowDtype,
@@ -697,12 +696,6 @@ class TestBaseMissing(base.BaseMissingTests):
         result = data.fillna(method="backfill")
         assert result is not data
         self.assert_extension_array_equal(result, data)
-
-    def test_fillna_series_method(self, data_missing, fillna_method):
-        with tm.maybe_produces_warning(
-            PerformanceWarning, fillna_method is not None, check_stacklevel=False
-        ):
-            super().test_fillna_series_method(data_missing, fillna_method)
 
 
 class TestBasePrinting(base.BasePrintingTests):

--- a/pandas/tests/extension/test_string.py
+++ b/pandas/tests/extension/test_string.py
@@ -18,10 +18,7 @@ import string
 import numpy as np
 import pytest
 
-from pandas.errors import PerformanceWarning
-
 import pandas as pd
-import pandas._testing as tm
 from pandas.api.types import is_string_dtype
 from pandas.core.arrays import ArrowStringArray
 from pandas.core.arrays.string_ import StringDtype
@@ -168,14 +165,6 @@ class TestMissing(base.BaseMissingTests):
         result = data.fillna(method="backfill")
         assert result is not data
         self.assert_extension_array_equal(result, data)
-
-    def test_fillna_series_method(self, data_missing, fillna_method):
-        with tm.maybe_produces_warning(
-            PerformanceWarning,
-            fillna_method is not None and data_missing.dtype.storage == "pyarrow",
-            check_stacklevel=False,
-        ):
-            super().test_fillna_series_method(data_missing, fillna_method)
 
 
 class TestNoReduce(base.BaseNoReduceTests):


### PR DESCRIPTION
Implement ffill/bfill in terms of 'take', avoiding an object cast.

```
ser = pd.Series(range(10**5), dtype="int64[pyarrow]")
ser[5000] = pd.NA

%timeit ser.ffill()
609 µs ± 25.9 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)  # <- branch
5.49 ms ± 158 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  # <- main
```

Some of the perf difference is likely due to no longer issuing a PerformanceWarning.