### PR TITLE
PERF: speed up data frame comparison when shape differs

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1445,6 +1445,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         if not (isinstance(other, type(self)) or isinstance(self, type(other))):
             return False
         other = cast(NDFrame, other)
+        if self.size != other.size:
+            return False
         return self._mgr.equals(other._mgr)
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
- [ ] closes #53945
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Speed up data frame (or series) comparison when shapes are different. A noticeable improvement is observed. The following scripts:
```
>>> import pandas as pd
>>> import time
>>> df = pd.DataFrame({1: range(1000), 2: range(1000)})
>>> other = pd.DataFrame({1: range(1001), 2: range(1001)})
>>> start = time.process_time()
>>> df.equals(other)
False
>>> print(time.process_time() - start)
```
gives `0.00019999999999997797` before changes and ` 0.003806999999999894` after.

