### PR TITLE
BUG: pd.replace changes dtype when using a dict to replace values even when there are no matches

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -546,6 +546,7 @@ Other
 - Bug in :func:`assert_almost_equal` now throwing assertion error for two unequal sets (:issue:`51727`)
 - Bug in :func:`assert_frame_equal` checks category dtypes even when asked not to check index type (:issue:`52126`)
 - Bug in :meth:`DataFrame.reindex` with a ``fill_value`` that should be inferred with a :class:`ExtensionDtype` incorrectly inferring ``object`` dtype (:issue:`52586`)
+- Bug in :meth:`DataFrame.replace` changing column dtypes even when no replacements are made (:issue:`53539`)
 - Bug in :meth:`DataFrame.shift` and :meth:`Series.shift` when passing both "freq" and "fill_value" silently ignoring "fill_value" instead of raising ``ValueError`` (:issue:`53832`)
 - Bug in :meth:`DataFrame.shift` with ``axis=1`` on a :class:`DataFrame` with a single :class:`ExtensionDtype` column giving incorrect results (:issue:`53832`)
 - Bug in :meth:`Series.align`, :meth:`DataFrame.align`, :meth:`Series.reindex`, :meth:`DataFrame.reindex`, :meth:`Series.interpolate`, :meth:`DataFrame.interpolate`, incorrectly failing to raise with method="asfreq" (:issue:`53620`)

--- a/pandas/core/array_algos/replace.py
+++ b/pandas/core/array_algos/replace.py
@@ -23,6 +23,7 @@ from pandas.core.dtypes.missing import isna
 if TYPE_CHECKING:
     from pandas._typing import (
         ArrayLike,
+        NDFrame,
         Scalar,
         npt,
     )
@@ -150,3 +151,20 @@ def replace_regex(
         values[:] = f(values)
     else:
         values[mask] = f(values[mask])
+
+
+def keep_original_dtypes(result: NDFrame, original: NDFrame) -> NDFrame:
+    """
+    Keep same data types as the original input if no replacements have been made.
+
+    Parameters
+    ----------
+    result: NDFrame
+    original: NDFrame
+    """
+    # Perform operation only if input is a dataframe, not a series
+    if hasattr(original, "columns"):
+        for col in original.columns:
+            if result[col].astype(str).equals(original[col].astype(str)):
+                result[col] = result[col].astype(original[col].dtypes)
+    return result

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1515,6 +1515,12 @@ class TestDataFrameReplace:
         result = ser.replace("nil", "anything else")
         tm.assert_frame_equal(expected, result)
 
+    def test_replace_no_replacements_dtypes(self):
+        # GH 53539
+        df = DataFrame({"a": [1, 2], "b": [3, 4]}, dtype="object")
+        res = df.replace({5: 0})
+        tm.assert_frame_equal(df, res)
+
 
 class TestDataFrameReplaceRegex:
     @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] closes #53539 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
