### PR TITLE
ENH: Allow to assign/create custom body_style and header_style property to an instance of ExcelFormatter used in method df.to_excel()

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -3881,6 +3881,19 @@ The look and feel of Excel worksheets created from pandas can be modified using 
 * ``float_format`` : Format string for floating point numbers (default ``None``).
 * ``freeze_panes`` : A tuple of two integers representing the bottommost row and rightmost column to freeze. Each of these parameters is one-based, so (1, 1) will freeze the first row and first column (default ``None``).
 
+The styling and formatting of a worksheet's header and body can be easily customized using CSS by passing a dictionary object to
+``pd.io.formats.excel.ExcelFormatter.header_style`` and ``pd.io.formats.excel.ExcelFormatter.body_style``.
+
+.. code-block:: python
+
+    # Set Excel worksheet header and body style
+    >>> df = pd.DataFrame([{"A": 1, "B": 2, "C": 3}, {"A": 1, "B": 2, "C": 3}])
+    >>> pd.io.formats.excel.ExcelFormatter.header_style = {"font": {"bold": True},}
+    >>> pd.io.formats.excel.ExcelFormatter.body_style = {
+    ... "font": {"bold": True},"alignment": {"horizontal": "center", "vertical": "top"},
+    ... }
+    >>> df.to_excel("path_to_file.xlsx", "Sheet1", index=False)
+
 Using the `Xlsxwriter`_ engine provides many options for controlling the
 format of an Excel worksheet created with the ``to_excel`` method.  Excellent examples can be found in the
 `Xlsxwriter`_ documentation here: https://xlsxwriter.readthedocs.io/working_with_pandas.html

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -119,6 +119,7 @@ Other enhancements
 - Many read/to_* functions, such as :meth:`DataFrame.to_pickle` and :func:`read_csv`, support forwarding compression arguments to lzma.LZMAFile (:issue:`52979`)
 - Performance improvement in :func:`concat` with homogeneous ``np.float64`` or ``np.float32`` dtypes (:issue:`52685`)
 - Performance improvement in :meth:`DataFrame.filter` when ``items`` is given (:issue:`52941`)
+- Made `ExcelFormatter.header_style` a class attribute instead of a property. Default styles for :meth:`DataFrameGroupby.to_excel` are set to None. (:issue:`52369`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -116,10 +116,10 @@ Other enhancements
 - Added a new parameter ``by_row`` to :meth:`Series.apply` and :meth:`DataFrame.apply`. When set to ``False`` the supplied callables will always operate on the whole Series or DataFrame (:issue:`53400`, :issue:`53601`).
 - Groupby aggregations (such as :meth:`DataFrameGroupby.sum`) now can preserve the dtype of the input instead of casting to ``float64`` (:issue:`44952`)
 - Improved error message when :meth:`DataFrameGroupBy.agg` failed (:issue:`52930`)
+- Made :attr:`ExcelFormatter.header_style` a class attribute instead of a property. Default styles for :meth:`DataFrame.to_excel` are set to None. (:issue:`52369`)
 - Many read/to_* functions, such as :meth:`DataFrame.to_pickle` and :func:`read_csv`, support forwarding compression arguments to lzma.LZMAFile (:issue:`52979`)
 - Performance improvement in :func:`concat` with homogeneous ``np.float64`` or ``np.float32`` dtypes (:issue:`52685`)
 - Performance improvement in :meth:`DataFrame.filter` when ``items`` is given (:issue:`52941`)
-- Made `ExcelFormatter.header_style` a class attribute instead of a property. Default styles for :meth:`DataFrameGroupby.to_excel` are set to None. (:issue:`52369`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -883,7 +883,7 @@ class ExcelFormatter:
                     row=self.rowcounter + i,
                     col=colidx + coloffset,
                     val=val,
-                    style=None,
+                    style=self.body_style,
                     css_styles=getattr(self.styler, "ctx", None),
                     css_row=i,
                     css_col=colidx,

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -585,7 +585,7 @@ class ExcelFormatter:
         return self._header_style
 
     @header_style.setter
-    def header_style(self, val):
+    def header_style(self, val) -> None:
         if isinstance(val, dict):
             self._header_style = val
 
@@ -594,7 +594,7 @@ class ExcelFormatter:
         return self._body_style
 
     @body_style.setter
-    def body_style(self, val):
+    def body_style(self, val) -> None:
         if isinstance(val, dict):
             self._body_style = val
 

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -577,8 +577,8 @@ class ExcelFormatter:
         self.header = header
         self.merge_cells = merge_cells
         self.inf_rep = inf_rep
-        self._header_style = None
-        self._body_style = None
+        self._header_style = dict[str] | None
+        self._body_style = dict[str] | None
 
     @property
     def header_style(self):

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -577,8 +577,8 @@ class ExcelFormatter:
         self.header = header
         self.merge_cells = merge_cells
         self.inf_rep = inf_rep
-        self._header_style = {}
-        self._body_style = {}
+        self._header_styledict[str, Any] = None
+        self._body_styledict[str, Any] = None
 
     @property
     def header_style(self):

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -585,7 +585,7 @@ class ExcelFormatter:
         return self._header_style
 
     @header_style.setter
-    def set_header_style(self, val):
+    def header_style(self, val):
         if not isinstance(val, dict):
             return None
         else:
@@ -597,7 +597,7 @@ class ExcelFormatter:
         return self._body_style
 
     @body_style.setter
-    def set_body_style(self, val):
+    def body_style(self, val):
         if not isinstance(val, dict):
             return None
         else:

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -577,8 +577,8 @@ class ExcelFormatter:
         self.header = header
         self.merge_cells = merge_cells
         self.inf_rep = inf_rep
-        self._header_style = dict[str] | None
-        self._body_style = dict[str] | None
+        self._header_style = {}
+        self._body_style = {}
 
     @property
     def header_style(self):

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -580,13 +580,6 @@ class ExcelFormatter:
         self.header_style = None
         self.body_style = None
 
-    def set_header_style(self, style):
-        if not isinstance(style, dict):
-            self.header_style = None
-        else:
-            self.header_style = style
-        return self.header_style
-
     def _format_value(self, val):
         if is_scalar(val) and missing.isna(val):
             val = self.na_rep

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -577,8 +577,8 @@ class ExcelFormatter:
         self.header = header
         self.merge_cells = merge_cells
         self.inf_rep = inf_rep
-        self._header_styledict[str, Any] = None
-        self._body_styledict[str, Any] = None
+        self._header_style: dict[str, Any] | None = None
+        self._body_style: dict[str, Any] | None = None
 
     @property
     def header_style(self):
@@ -586,11 +586,8 @@ class ExcelFormatter:
 
     @header_style.setter
     def header_style(self, val):
-        if not isinstance(val, dict):
-            return None
-        else:
+        if isinstance(val, dict):
             self._header_style = val
-            return self._header_style
 
     @property
     def body_style(self):
@@ -598,11 +595,8 @@ class ExcelFormatter:
 
     @body_style.setter
     def body_style(self, val):
-        if not isinstance(val, dict):
-            return None
-        else:
+        if isinstance(val, dict):
             self._body_style = val
-            return self._body_style
 
     def _format_value(self, val):
         if is_scalar(val) and missing.isna(val):

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -577,8 +577,32 @@ class ExcelFormatter:
         self.header = header
         self.merge_cells = merge_cells
         self.inf_rep = inf_rep
-        self.header_style = None
-        self.body_style = None
+        self._header_style = None
+        self._body_style = None
+
+    @property
+    def header_style(self):
+        return self._header_style
+
+    @header_style.setter
+    def set_header_style(self, val):
+        if not isinstance(val, dict):
+            return None
+        else:
+            self._header_style = val
+            return self._header_style
+
+    @property
+    def body_style(self):
+        return self._body_style
+
+    @body_style.setter
+    def set_body_style(self, val):
+        if not isinstance(val, dict):
+            return None
+        else:
+            self._body_style = val
+            return self._body_style
 
     def _format_value(self, val):
         if is_scalar(val) and missing.isna(val):

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -577,19 +577,15 @@ class ExcelFormatter:
         self.header = header
         self.merge_cells = merge_cells
         self.inf_rep = inf_rep
+        self.header_style = None
+        self.body_style = None
 
-    @property
-    def header_style(self) -> dict[str, dict[str, str | bool]]:
-        return {
-            "font": {"bold": True},
-            "borders": {
-                "top": "thin",
-                "right": "thin",
-                "bottom": "thin",
-                "left": "thin",
-            },
-            "alignment": {"horizontal": "center", "vertical": "top"},
-        }
+    def set_header_style(self, style):
+        if not isinstance(style, dict):
+            self.header_style = None
+        else:
+            self.header_style = style
+        return self.header_style
 
     def _format_value(self, val):
         if is_scalar(val) and missing.isna(val):

--- a/pandas/tests/io/excel/test_style.py
+++ b/pandas/tests/io/excel/test_style.py
@@ -30,6 +30,31 @@ def assert_equal_cell_styles(cell1, cell2):
     assert cell1.number_format == cell2.number_format
     assert cell1.protection.__dict__ == cell2.protection.__dict__
 
+def test_styler_to_excel_set_instance():
+    style = {
+            "font": {"bold": True},
+            "borders": {
+                "top": "thin",
+                "right": "thin",
+                "bottom": "thin",
+                "left": "thin",
+            },
+            "alignment": {"horizontal": "center", "vertical": "top"},
+        }
+
+    df = DataFrame([{'A': 1, 'B': 2, 'C': 3}, {'A': 1, 'B': 2, 'C': 3}])
+    fmt = ExcelFormatter(df)
+
+    # Check default value
+    assert fmt.header_style == None
+
+    # Check updated value
+    header_style = fmt.set_body_style(style)
+    assert header_style == style
+
+    # Check value for invalid input
+    header_style = fmt.set_body_style('abcd')
+    assert header_style == None
 
 @pytest.mark.parametrize(
     "engine",
@@ -252,6 +277,24 @@ def test_styler_to_excel_border_style(engine, border_style):
         else:
             assert u_cell is None or u_cell != expected
             assert s_cell == expected
+
+def test_styler_change_values():
+    openpyxl = pytest.importorskip("openpyxl")
+    font1 = {"font": {"color": {"rgb": "111222"}}}
+    font2 = {"font": {"color": {"rgb": "000222"}}}
+
+
+    df = DataFrame(np.random.randn(1, 1))
+    with tm.ensure_clean(".xlsx") as path:
+        with ExcelWriter(path, engine="openpyxl") as writer:
+            fil = ExcelFormatter(df)
+            fil.set_body_style(font1)
+            fil.write(writer, sheet_name="custom")
+
+        with contextlib.closing(openpyxl.load_workbook(path)) as wb:
+            assert wb["custom"].cell(2, 2).font.color.value == "00111222"
+
+
 
 
 def test_styler_custom_converter():

--- a/pandas/tests/io/excel/test_style.py
+++ b/pandas/tests/io/excel/test_style.py
@@ -15,7 +15,7 @@ import pandas._testing as tm
 from pandas.io.excel import ExcelWriter
 from pandas.io.formats.excel import ExcelFormatter
 
-#pytest.importorskip("jinja2")
+# pytest.importorskip("jinja2")
 # jinja2 is currently required for Styler.__init__(). Technically Styler.to_excel
 # could compute styles and render to excel without jinja2, since there is no
 # 'template' file, but this needs the import error to delayed until render time.
@@ -257,24 +257,24 @@ def test_styler_to_excel_border_style(engine, border_style):
 def test_styler_default_values():
     openpyxl = pytest.importorskip("openpyxl")
 
-    df = DataFrame([{'A': 1, 'B': 2, 'C': 3}, {'A': 1, 'B': 2, 'C': 3}])
+    df = DataFrame([{"A": 1, "B": 2, "C": 3}, {"A": 1, "B": 2, "C": 3}])
     with tm.ensure_clean(".xlsx") as path:
         with ExcelWriter(path, engine="openpyxl") as writer:
-            df.to_excel(writer, sheet_name='custom')
+            df.to_excel(writer, sheet_name="custom")
 
         with contextlib.closing(openpyxl.load_workbook(path)) as wb:
             # Check font, spacing, indentation
             assert wb["custom"].cell(1, 1).font.color.value == 1
-            assert wb["custom"].cell(1, 1).alignment.horizontal == None
-            assert wb["custom"].cell(1, 1).alignment.vertical == None
+            assert wb["custom"].cell(1, 1).alignment.horizontal is None
+            assert wb["custom"].cell(1, 1).alignment.vertical is None
             assert wb["custom"].cell(1, 1).alignment.indent == 0.0
 
             # Check border
-            x = wb["custom"].cell(1, 1).border
-            assert wb["custom"].cell(1, 1).border.bottom.color == None
-            assert wb["custom"].cell(1, 1).border.top.color == None
-            assert wb["custom"].cell(1, 1).border.left.color == None
-            assert wb["custom"].cell(1, 1).border.right.color == None
+            wb["custom"].cell(1, 1).border
+            assert wb["custom"].cell(1, 1).border.bottom.color is None
+            assert wb["custom"].cell(1, 1).border.top.color is None
+            assert wb["custom"].cell(1, 1).border.left.color is None
+            assert wb["custom"].cell(1, 1).border.right.color is None
 
 
 def test_styler_custom_converter():

--- a/pandas/tests/io/excel/test_style.py
+++ b/pandas/tests/io/excel/test_style.py
@@ -30,31 +30,33 @@ def assert_equal_cell_styles(cell1, cell2):
     assert cell1.number_format == cell2.number_format
     assert cell1.protection.__dict__ == cell2.protection.__dict__
 
+
 def test_styler_to_excel_set_instance():
     style = {
-            "font": {"bold": True},
-            "borders": {
-                "top": "thin",
-                "right": "thin",
-                "bottom": "thin",
-                "left": "thin",
-            },
-            "alignment": {"horizontal": "center", "vertical": "top"},
-        }
+        "font": {"bold": True},
+        "borders": {
+            "top": "thin",
+            "right": "thin",
+            "bottom": "thin",
+            "left": "thin",
+        },
+        "alignment": {"horizontal": "center", "vertical": "top"},
+    }
 
-    df = DataFrame([{'A': 1, 'B': 2, 'C': 3}, {'A': 1, 'B': 2, 'C': 3}])
+    df = DataFrame([{"A": 1, "B": 2, "C": 3}, {"A": 1, "B": 2, "C": 3}])
     fmt = ExcelFormatter(df)
 
     # Check default value
-    assert fmt.header_style == None
+    assert fmt.header_style is None
 
     # Check updated value
     header_style = fmt.set_body_style(style)
     assert header_style == style
 
     # Check value for invalid input
-    header_style = fmt.set_body_style('abcd')
-    assert header_style == None
+    header_style = fmt.set_body_style("abcd")
+    assert header_style is None
+
 
 @pytest.mark.parametrize(
     "engine",
@@ -278,11 +280,10 @@ def test_styler_to_excel_border_style(engine, border_style):
             assert u_cell is None or u_cell != expected
             assert s_cell == expected
 
+
 def test_styler_change_values():
     openpyxl = pytest.importorskip("openpyxl")
     font1 = {"font": {"color": {"rgb": "111222"}}}
-    font2 = {"font": {"color": {"rgb": "000222"}}}
-
 
     df = DataFrame(np.random.randn(1, 1))
     with tm.ensure_clean(".xlsx") as path:
@@ -293,8 +294,6 @@ def test_styler_change_values():
 
         with contextlib.closing(openpyxl.load_workbook(path)) as wb:
             assert wb["custom"].cell(2, 2).font.color.value == "00111222"
-
-
 
 
 def test_styler_custom_converter():


### PR DESCRIPTION
- [X] closes #52369 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
