### PR TITLE
ENH: Don't fragment manager if convert is no-op

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -484,6 +484,7 @@ class Block(PandasObject):
                 Block.convert, copy=copy, using_cow=using_cow
             )
             if all(blk.dtype.kind == "O" for blk in blocks):
+                # Avoid fragmenting the block if convert is a no-op
                 if using_cow:
                     return [self.copy(deep=False)]
                 return [self.copy()] if copy else [self]

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -480,7 +480,14 @@ class Block(PandasObject):
             return [self.copy()] if copy else [self]
 
         if self.ndim != 1 and self.shape[0] != 1:
-            return self.split_and_operate(Block.convert, copy=copy, using_cow=using_cow)
+            blocks = self.split_and_operate(
+                Block.convert, copy=copy, using_cow=using_cow
+            )
+            if all(blk.dtype.kind == "O" for blk in blocks):
+                if using_cow:
+                    return [self.copy(deep=False)]
+                return [self.copy()] if copy else [self]
+            return blocks
 
         values = self.values
         if values.ndim == 2:

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1594,7 +1594,7 @@ class TestDataFrameReplaceRegex:
         tm.assert_frame_equal(result, expected)
 
     def test_replace_object_splitting(self):
-        # GH#
+        # GH#53977
         df = DataFrame({"a": ["a"], "b": "b"})
         assert len(df._mgr.blocks) == 1
         df.replace(to_replace=r"^\s*$", value="", inplace=True, regex=True)

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1592,3 +1592,10 @@ class TestDataFrameReplaceRegex:
 
         result = df.replace(to_replace=[".", "def"], value=["_", None])
         tm.assert_frame_equal(result, expected)
+
+    def test_replace_object_splitting(self):
+        # GH#
+        df = DataFrame({"a": ["a"], "b": "b"})
+        assert len(df._mgr.blocks) == 1
+        df.replace(to_replace=r"^\s*$", value="", inplace=True, regex=True)
+        assert len(df._mgr.blocks) == 1


### PR DESCRIPTION
- [x] closes #53853 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

cc @jbrockmendel thoughts here? This isn't ideal but since this is probably the code path that's taken 99% of the time this might make sense?