### PR TITLE
WEB/DOC: use Plausible for analytics (using Scientific Python server)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -240,7 +240,10 @@ html_theme_options = {
     "footer_start": ["pandas_footer", "sphinx-version"],
     "github_url": "https://github.com/pandas-dev/pandas",
     "twitter_url": "https://twitter.com/pandas_dev",
-    "analytics": {"google_analytics_id": "G-5RE31C1RNW"},
+    "analytics": {
+        "plausible_analytics_domain": "pandas.pydata.org",
+        "plausible_analytics_url": "https://views.scientific-python.org/js/script.js",
+    },
     "logo": {"image_dark": "https://pandas.pydata.org/static/img/pandas_white.svg"},
     "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],
     "switcher": {

--- a/web/pandas/_templates/layout.html
+++ b/web/pandas/_templates/layout.html
@@ -1,13 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <script async="async" src="https://www.googletagmanager.com/gtag/js?id=G-5RE31C1RNW"></script>
-        <script>
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){ dataLayer.push(arguments); }
-            gtag('js', new Date());
-            gtag('config', 'G-5RE31C1RNW');
-        </script>
+        <script defer data-domain="pandas.pydata.org" src="https://views.scientific-python.org/js/script.js"></script>
         <title>pandas - Python Data Analysis Library</title>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">


### PR DESCRIPTION
This proposes to switch from our current usage of Google Analytics to Plausible.

(currently it fully switches, but could also first add it in addition so we have both for some time)

Plausible is a privacy-friendly and open source alternative for Google Analytics (https://plausible.io/). 
The server we are using here is a self-hosted one by the Scientific Python team (using one from plausible.io costs some money). But the disclaimer I got from @stefanv is that it's a small server without professional sysadmin support and is currently not automatically backed up (but we could set up a cron job to query the data and dump them somewhere). I think, given that this is also being used by other projects (numpy, scipy, scikit-learn, ..), that this is fine, and if there come up problems, we will be able to look for solutions together.

The main advantage is that privacy-friendly (not collecting data for a big corporation ..). I think our current usage of Google Analytics is actually not correct (I assume we should have a pop-up to ask for permission). 
The consequence of that is that Plausible cannot track "unique visitors" over time (only per day), for example per month (https://plausible.io/data-policy#how-we-count-unique-users-without-cookies).