### PR TITLE
REF: swap axis before calling Manager.pad_or_backfill

### DIFF
--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -247,7 +247,7 @@ class PandasArray(  # type: ignore[misc]
 
         meth = missing.clean_fill_method(method)
         missing.pad_or_backfill_inplace(
-            out_data,
+            out_data.T,
             method=meth,
             axis=0,
             limit=limit,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6911,7 +6911,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         new_mgr = self._mgr.pad_or_backfill(
             method=method,
-            axis=axis,
+            axis=self._get_block_manager_axis(axis),
             limit=limit,
             inplace=inplace,
             downcast=downcast,
@@ -8027,7 +8027,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
             new_data = obj._mgr.pad_or_backfill(
                 method=method,
-                axis=axis,
+                axis=self._get_block_manager_axis(axis),
                 limit=limit,
                 limit_area=limit_area,
                 inplace=inplace,

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1893,8 +1893,8 @@ class EABackedBlock(Block):
         using_cow: bool = False,
     ) -> list[Block]:
         values = self.values
-        if values.ndim == 2 and axis == 0:
-            # NDArrayBackedExtensionArray.fillna assumes axis=1
+        if values.ndim == 2 and axis == 1:
+            # NDArrayBackedExtensionArray.fillna assumes axis=0
             new_values = values.T.fillna(method=method, limit=limit).T
         else:
             new_values = values.fillna(method=method, limit=limit)

--- a/pandas/tests/extension/base/dim2.py
+++ b/pandas/tests/extension/base/dim2.py
@@ -159,10 +159,26 @@ class Dim2CompatTests(BaseExtensionTests):
         assert arr[0].isna().all()
         assert not arr[1].isna().any()
 
-        result = arr.fillna(method=method)
+        try:
+            result = arr.pad_or_backfill(method=method, limit=None)
+        except AttributeError:
+            result = arr.fillna(method=method, limit=None)
 
         expected = data_missing.fillna(method=method).repeat(2).reshape(2, 2)
         self.assert_extension_array_equal(result, expected)
+
+        # Reverse so that backfill is not a no-op.
+        arr2 = arr[::-1]
+        assert not arr2[0].isna().any()
+        assert arr2[1].isna().all()
+
+        try:
+            result2 = arr2.pad_or_backfill(method=method, limit=None)
+        except AttributeError:
+            result2 = arr2.fillna(method=method, limit=None)
+
+        expected2 = data_missing[::-1].fillna(method=method).repeat(2).reshape(2, 2)
+        self.assert_extension_array_equal(result2, expected2)
 
     @pytest.mark.parametrize("method", ["mean", "median", "var", "std", "sum", "prod"])
     def test_reductions_2d_axis_none(self, data, method):


### PR DESCRIPTION
This was causing some major headaches in trying to implement #53621.  An upcoming PR that implements that will get rid fo the ugly try/except in the dim2 test.