### PR TITLE
TST: add test to check dtype after replacing values in categorical Series inplace

### DIFF
--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -395,7 +395,7 @@ class TestSeriesReplace:
         result = pd.Series(data, dtype="category")
         result.replace(to_replace="a", value="b", inplace=True)
         expected = pd.Series(data_exp, dtype="category")
-        tm.assert_index_equal(expected.dtype.categories, result.dtype.categories)
+        tm.assert_series_equal(result, expected)
 
     def test_replace_categorical_single(self):
         # GH 26988

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -387,6 +387,16 @@ class TestSeriesReplace:
             expected = expected.cat.add_categories(2)
         tm.assert_series_equal(expected, result)
 
+    @pytest.mark.parametrize(
+        "data, data_exp", [(["a", "b", "c"], ["b", "b", "c"]), (["a"], ["b"])]
+    )
+    def test_replace_categorical_inplace(self, data, data_exp):
+        # GH 53358
+        result = pd.Series(data, dtype="category")
+        result.replace(to_replace="a", value="b", inplace=True)
+        expected = pd.Series(data_exp, dtype="category")
+        tm.assert_index_equal(expected.dtype.categories, result.dtype.categories)
+
     def test_replace_categorical_single(self):
         # GH 26988
         dti = pd.date_range("2016-01-01", periods=3, tz="US/Pacific")


### PR DESCRIPTION
- [x] closes #53358

- added a test in order to check if the `dtype` is being updated, when we replace values in a categorical Series with `inplace=True`.