### PR TITLE
DEPR: start with Deprecation instead of FutureWarning for NDFrame._data

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -506,7 +506,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         warnings.warn(
             f"{type(self).__name__}._data is deprecated and will be removed in "
             "a future version. Use public APIs instead.",
-            FutureWarning,
+            DeprecationWarning,
             stacklevel=find_stack_level(),
         )
         return self._mgr

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -379,6 +379,6 @@ class TestDataFrameMisc:
         df = DataFrame()
         msg = "DataFrame._data is deprecated"
         with tm.assert_produces_warning(
-            FutureWarning, match=msg, check_stacklevel=False
+            DeprecationWarning, match=msg, check_stacklevel=False
         ):
             inspect.getmembers(df)

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -307,7 +307,7 @@ class TestGeneric:
     def test_data_deprecated(self, frame_or_series):
         obj = frame_or_series()
         msg = "(Series|DataFrame)._data is deprecated"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
             mgr = obj._data
         assert mgr is obj._mgr
 

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -172,7 +172,7 @@ class TestSeriesMisc:
         ser = Series(dtype=object)
         msg = "Series._data is deprecated"
         with tm.assert_produces_warning(
-            FutureWarning, match=msg, check_stacklevel=False
+            DeprecationWarning, match=msg, check_stacklevel=False
         ):
             inspect.getmembers(ser)
 


### PR DESCRIPTION
Follow-up on https://github.com/pandas-dev/pandas/pull/52003

Given this is something being used by downstream libraries, and not directly by users, we can start with a DeprecationWarning, which is not visible for users of those libraries.