### PR TITLE
BUG: Fix mamba can't create environment issue

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,6 @@ dependencies:
   - pytest-cov
   - pytest-xdist>=2.2.0
   - pytest-asyncio>=0.17.0
-  - pytest-localserver>=0.7.1
   - coverage
 
   # required dependencies

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,6 @@ pytest>=7.3.2
 pytest-cov
 pytest-xdist>=2.2.0
 pytest-asyncio>=0.17.0
-pytest-localserver>=0.7.1
 coverage
 python-dateutil
 numpy


### PR DESCRIPTION
- [ ] closes #53978  (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This solution is as @mroeschke suggested to fix environment broken on ARM Mac.
