### PR TITLE
DOC: add backticks to docstrings

### DIFF
--- a/pandas/io/xml.py
+++ b/pandas/io/xml.py
@@ -1,5 +1,5 @@
 """
-:mod:`pandas.io.xml` is a module for reading XML.
+:mod:``pandas.io.xml`` is a module for reading XML.
 """
 
 from __future__ import annotations
@@ -66,26 +66,26 @@ class _XMLFrameParser:
 
     Parameters
     ----------
-    path_or_buffer : a valid JSON str, path object or file-like object
+    path_or_buffer : a valid JSON ``str``, path object or file-like object
         Any valid string path is acceptable. The string could be a URL. Valid
         URL schemes include http, ftp, s3, and file.
 
     xpath : str or regex
         The XPath expression to parse required set of nodes for
-        migration to `Data Frame`. `etree` supports limited XPath.
+        migration to :class:`~pandas.DataFrame`. `etree` supports limited XPath.
 
     namespaces : dict
-        The namespaces defined in XML document (`xmlns:namespace='URI')
+        The namespaces defined in XML document (``xmlns:namespace='URI'``)
         as dicts with key being namespace and value the URI.
 
     elems_only : bool
-        Parse only the child elements at the specified `xpath`.
+        Parse only the child elements at the specified ``xpath``.
 
     attrs_only : bool
-        Parse only the attributes at the specified `xpath`.
+        Parse only the attributes at the specified ``xpath``.
 
     names : list
-        Column names for Data Frame of parsed XML data.
+        Column names for :class:`~pandas.DataFrame`of parsed XML data.
 
     dtype : dict
         Data type for data or columns. E.g. {{'a': np.float64,


### PR DESCRIPTION
- [ ] Issue DOC: Inconsistent use of code-style formatting (backticks) in docstrings #53674
- [ ] Issue originally referenced only read_csv and read_excel but open to 
all docstrings to update this formatting for consistency

This PR doesn't address all backsticks needed in pandas/io/xml.py but want to get the ball rolling to see if I'm headed in the right direction. 