### PR TITLE
BUG: Fix failing hash function for certain non-ns resolution `Timedelta`s

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -393,9 +393,9 @@ Timedelta
 - :meth:`TimedeltaIndex.map` with ``na_action="ignore"`` now works as expected (:issue:`51644`)
 - Bug in :class:`TimedeltaIndex` division or multiplication leading to ``.freq`` of "0 Days" instead of ``None`` (:issue:`51575`)
 - Bug in :class:`Timedelta` with Numpy timedelta64 objects not properly raising ``ValueError`` (:issue:`52806`)
+- Bug in :meth:`Timedelta.__hash__`, raising an ``OutOfBoundsTimedelta`` on certain large values of second resolution (:issue:`54037`)
 - Bug in :meth:`Timedelta.round` with values close to the implementation bounds returning incorrect results instead of raising ``OutOfBoundsTimedelta`` (:issue:`51494`)
 - Bug in :meth:`arrays.TimedeltaArray.map` and :meth:`TimedeltaIndex.map`, where the supplied callable operated array-wise instead of element-wise (:issue:`51977`)
-- Bug in :meth:`Timedelta.__hash__`, raising an ``OutOfBoundsTimedelta`` on certain large values of second resolution (:issue:`54037`)
 -
 
 Timezones

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -395,6 +395,7 @@ Timedelta
 - Bug in :class:`Timedelta` with Numpy timedelta64 objects not properly raising ``ValueError`` (:issue:`52806`)
 - Bug in :meth:`Timedelta.round` with values close to the implementation bounds returning incorrect results instead of raising ``OutOfBoundsTimedelta`` (:issue:`51494`)
 - Bug in :meth:`arrays.TimedeltaArray.map` and :meth:`TimedeltaIndex.map`, where the supplied callable operated array-wise instead of element-wise (:issue:`51977`)
+- Bug in :meth:`Timedelta.__hash__`, raising an ``OutOfBoundsTimedelta`` on certain large values of second resolution (:issue:`54037`)
 -
 
 Timezones

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1156,7 +1156,7 @@ cdef class _Timedelta(timedelta):
             #  resolution.
             try:
                 obj = (<_Timedelta>self)._as_creso(<NPY_DATETIMEUNIT>(self._creso + 1))
-            except OverflowError:
+            except OutOfBoundsTimedelta:
                 # Doesn't fit, so we're off the hook
                 return hash(self._value)
             else:

--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -305,6 +305,11 @@ class TestNonNano:
         assert result == expected
         assert result._creso == expected._creso
 
+    def test_hash(self) -> None:
+        second_resolution_max = Timedelta(0).as_unit("s").max
+
+        assert hash(second_resolution_max)
+
 
 def test_timedelta_class_min_max_resolution():
     # when accessed on the class (as opposed to an instance), we default

--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -306,9 +306,10 @@ class TestNonNano:
         assert result._creso == expected._creso
 
     def test_hash(self) -> None:
+        # GH#54037
         second_resolution_max = Timedelta(0).as_unit("s").max
 
-        assert hash(second_resolution_max) == 42
+        assert hash(second_resolution_max)
 
 
 def test_timedelta_class_min_max_resolution():

--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -308,7 +308,7 @@ class TestNonNano:
     def test_hash(self) -> None:
         second_resolution_max = Timedelta(0).as_unit("s").max
 
-        assert hash(second_resolution_max)
+        assert hash(second_resolution_max) == 42
 
 
 def test_timedelta_class_min_max_resolution():


### PR DESCRIPTION
I noticed that hashing certain large `pd.Timedelta`s resultet in an `OutOfBoundsTimedelta` exception, which shouldn't happen.

In the hash implementation there is seems to be an attempt at catching this error, as the offending line is wrapped in a `try` clause, but, the `except` clause catches an `OverflowError` instead. The call that raises `OutOfBoundsTimedelta` does so when itself catches an `OverflowError`, so my interpretation is that the intention was for the hash implementation to catch the `OutOfBoundsTimedelta`. My changes reflect this. I've also added a test reproducing the issue.

- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
