### PR TITLE
BLD: Update Gitpod to use docker installation flow and pip/meson for setup 

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,10 +11,10 @@ tasks:
     init: |
       mkdir -p .vscode
       cp gitpod/settings.json .vscode/settings.json
-      conda activate pandas-dev
       git fetch --tags
       python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true
       pre-commit install
+      echo "✨ Pre-build complete! You can close this terminal ✨ "
 
 # --------------------------------------------------------
 # exposing ports for liveserve

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,7 +3,8 @@
 # https://www.gitpod.io/docs/config-start-tasks/#configuring-the-terminal
 # -------------------------------------------------------------------------
 
-# assuming we use dockerhub: name of the docker user, docker image, tag, e.g. https://hub.docker.com/r/pandas/pandas-gitpod/tags
+# images for gitpod pandas are in https://hub.docker.com/r/pandas/pandas-gitpod/tags
+# we're using the Dockerfile in the base of the repo
 image:
   file: Dockerfile
 tasks:
@@ -37,17 +38,18 @@ vscode:
 
 # --------------------------------------------------------
 # using prebuilds for the container
-# With this configuration the prebuild will happen on push to main
+# With this configuration the prebuild will happen on push to main, branches,
+# pull requests, and pull requests from forks
 github:
   prebuilds:
     # enable for main/default branch
     main: true
     # enable for other branches (defaults to false)
-    branches: false
+    branches: true
     # enable for pull requests coming from this repo (defaults to true)
-    pullRequests: false
+    pullRequests: true
     # enable for pull requests coming from forks (defaults to false)
-    pullRequestsFromForks: false
+    pullRequestsFromForks: true
     # add a check to pull requests (defaults to true)
     addCheck: false
     # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,6 +15,8 @@ tasks:
       git fetch --tags
       python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true
       pre-commit install
+    command: |
+      python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true
       echo "✨ Pre-build complete! You can close this terminal ✨ "
 
 # --------------------------------------------------------

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,8 +15,6 @@ tasks:
       git fetch --tags
       python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true
       pre-commit install
-    command: |
-      python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true
       echo "✨ Pre-build complete! You can close this terminal ✨ "
 
 # --------------------------------------------------------

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -30,7 +30,6 @@ vscode:
     - ms-python.python
     - yzhang.markdown-all-in-one
     - eamodio.gitlens
-    - swyddfa.esbonio
     - lextudio.restructuredtext
     - ritwickdey.liveserver
     # add or remove what you think is generally useful to most contributors

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -29,6 +29,7 @@ vscode:
     - ms-python.python
     - yzhang.markdown-all-in-one
     - eamodio.gitlens
+    - swyddfa.esbonio
     - lextudio.restructuredtext
     - ritwickdey.liveserver
     # add or remove what you think is generally useful to most contributors

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -46,11 +46,11 @@ github:
     # enable for main/default branch
     main: true
     # enable for other branches (defaults to false)
-    branches: true
+    branches: false
     # enable for pull requests coming from this repo (defaults to true)
     pullRequests: true
     # enable for pull requests coming from forks (defaults to false)
-    pullRequestsFromForks: true
+    pullRequestsFromForks: false
     # add a check to pull requests (defaults to true)
     addCheck: false
     # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -48,7 +48,7 @@ github:
     # enable for other branches (defaults to false)
     branches: false
     # enable for pull requests coming from this repo (defaults to true)
-    pullRequests: true
+    pullRequests: false
     # enable for pull requests coming from forks (defaults to false)
     pullRequestsFromForks: false
     # add a check to pull requests (defaults to true)

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -39,8 +39,7 @@ vscode:
 
 # --------------------------------------------------------
 # using prebuilds for the container
-# With this configuration the prebuild will happen on push to main, branches,
-# pull requests, and pull requests from forks
+# With this configuration the prebuild will happen on push to main
 github:
   prebuilds:
     # enable for main/default branch

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,8 +15,9 @@ tasks:
       git fetch --tags
       python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true
       pre-commit install
+    command: |
+      python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true
       echo "✨ Pre-build complete! You can close this terminal ✨ "
-    command: python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true
 
 # --------------------------------------------------------
 # exposing ports for liveserve

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -38,7 +38,7 @@ vscode:
     # avoid adding too many. they each open a pop-up window
 
 # --------------------------------------------------------
-# using prebuilds for the container
+# Using prebuilds for the container
 # With this configuration the prebuild will happen on push to main
 github:
   prebuilds:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,6 +15,7 @@ tasks:
       python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true
       pre-commit install
       echo "✨ Pre-build complete! You can close this terminal ✨ "
+    command: python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true
 
 # --------------------------------------------------------
 # exposing ports for liveserve

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,7 +4,7 @@
 # -------------------------------------------------------------------------
 
 # assuming we use dockerhub: name of the docker user, docker image, tag, e.g. https://hub.docker.com/r/pandas/pandas-gitpod/tags
-image: 
+image:
   file: Dockerfile
 tasks:
   - name: Prepare development environment

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,7 +13,7 @@ tasks:
       conda activate pandas-dev
       git pull --unshallow  # need to force this else the prebuild fails
       git fetch --tags
-      python setup.py build_ext --inplace -j 4
+      python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true
       echo "🛠 Completed rebuilding Pandas!! 🛠 "
       pre-commit install
       echo "✨ Pre-build complete! You can close this terminal ✨ "

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,7 +4,8 @@
 # -------------------------------------------------------------------------
 
 # assuming we use dockerhub: name of the docker user, docker image, tag, e.g. https://hub.docker.com/r/pandas/pandas-gitpod/tags
-image: pandas/pandas-gitpod:latest
+image: 
+  file: gitpod/Dockerfile
 tasks:
   - name: Prepare development environment
     init: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,12 +12,8 @@ tasks:
       mkdir -p .vscode
       cp gitpod/settings.json .vscode/settings.json
       conda activate pandas-dev
-      git pull --unshallow  # need to force this else the prebuild fails
       git fetch --tags
       python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true
-      echo "🛠 Completed rebuilding Pandas!! 🛠 "
-      pre-commit install
-      echo "✨ Pre-build complete! You can close this terminal ✨ "
 
 # --------------------------------------------------------
 # exposing ports for liveserve

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,7 +5,7 @@
 
 # assuming we use dockerhub: name of the docker user, docker image, tag, e.g. https://hub.docker.com/r/pandas/pandas-gitpod/tags
 image: 
-  file: gitpod/Dockerfile
+  file: Dockerfile
 tasks:
   - name: Prepare development environment
     init: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,6 +14,7 @@ tasks:
       conda activate pandas-dev
       git fetch --tags
       python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true
+      pre-commit install
 
 # --------------------------------------------------------
 # exposing ports for liveserve

--- a/gitpod/Dockerfile
+++ b/gitpod/Dockerfile
@@ -27,7 +27,7 @@
 # OS/ARCH: linux/amd64
 FROM gitpod/workspace-base:latest
 
-ARG MAMBAFORGE_VERSION="22.9.0-1"
+ARG MAMBAFORGE_VERSION="23.1.0-3"
 ARG CONDA_ENV=pandas-dev
 ARG PANDAS_HOME="/home/pandas"
 

--- a/gitpod/settings.json
+++ b/gitpod/settings.json
@@ -1,6 +1,5 @@
 {
-    "restructuredtext.updateOnTextChanged": "true",
-    "restructuredtext.updateDelay": 300,
+    "esbonio.server.pythonPath": "/usr/local/bin/python"
     "restructuredtext.linter.disabledLinters": ["doc8","rst-lint", "rstcheck"],
-    "python.defaultInterpreterPath": "/home/gitpod/mambaforge3/envs/pandas-dev/bin/python"
+    "python.defaultInterpreterPath": "/usr/local/bin/python"
 }

--- a/gitpod/settings.json
+++ b/gitpod/settings.json
@@ -1,5 +1,5 @@
 {
-    "esbonio.server.pythonPath": "/usr/local/bin/python"
+    "esbonio.server.pythonPath": "/usr/local/bin/python",
     "restructuredtext.linter.disabledLinters": ["doc8","rst-lint", "rstcheck"],
     "python.defaultInterpreterPath": "/usr/local/bin/python"
 }


### PR DESCRIPTION
- [x] closes #53685 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature | it is not a feature/bug
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. | no new functions
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature. | not a feature/bug

The docker images on Dockerhub that are used with Gitpod are outdated by like 6 months, which is causing the build to fail in Gitpod (because the docker images are using python 3.8.16). 

This is the original repo in gitpod with the issue (using the latest commit):
https://gitpod.io#https://github.com/pandas-dev/pandas/commit/457690995ccbfc5b8eee80a0818d62070d078bcf

```
(pandas-dev) gitpod > /workspace/pandas $ python -i
Python 3.8.16 | packaged by conda-forge | (default, Feb  1 2023, 16:01:55) 
[GCC 11.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pandas
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/workspace/pandas/pandas/__init__.py", line 46, in <module>
    from pandas.core.api import (
  File "/workspace/pandas/pandas/core/api.py", line 47, in <module>
    from pandas.core.groupby import (
  File "/workspace/pandas/pandas/core/groupby/__init__.py", line 1, in <module>
    from pandas.core.groupby.generic import (
  File "/workspace/pandas/pandas/core/groupby/generic.py", line 70, in <module>
    from pandas.core.frame import DataFrame
  File "/workspace/pandas/pandas/core/frame.py", line 137, in <module>
    from pandas.core.generic import (
  File "/workspace/pandas/pandas/core/generic.py", line 191, in <module>
    from pandas.core.window import (
  File "/workspace/pandas/pandas/core/window/__init__.py", line 1, in <module>
    from pandas.core.window.ewm import (
  File "/workspace/pandas/pandas/core/window/ewm.py", line 41, in <module>
    from pandas.core.window.numba_ import (
  File "/workspace/pandas/pandas/core/window/numba_.py", line 20, in <module>
    @functools.cache
AttributeError: module 'functools' has no attribute 'cache'
```

I've made a couple changes to fix this and other errors related to the Gitpod build. This is what it looks like with the changes:
https://gitpod.io#https://github.com/pandas-dev/pandas/pull/54046

```
gitpod@theuerc-pandas-5ztda316yrs:/workspace/pandas$ python -i
Python 3.10.8 (main, Dec  6 2022, 14:13:21) [GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pandas
+ /usr/local/bin/ninja
[1/1] Generating write_version_file with a custom command
>>> pandas.DataFrame({'test': 'testing'}, index=[0])
      test
0  testing
```

**The Bigger Changes**

I'm following the updated [development environment creation](https://pandas.pydata.org/docs/dev/development/contributing_environment.html) instructions for these changes, but with the docker option instead of the mamba option (as mamba requires version pinning and causes other issues that can make it hard to maintain). 

- Update setup to use pip/meson.
- Add a duplicate line in `command` to resolve a small issue with pip when prebuilding with pip/meson. Strangely this prebuild issue is not present on all of the branches I was testing on.
- Build the Gitpod image from the Dockerfile in the base of the repo instead of pulling the image from Dockerhub, so that it will always stay current with the rest of the repo.
   - Gitpod will build and install all of the dependencies inside the image, and then reuse the image after that. If there are any changes to the Dockerfile, it will rebuild the image automatically. 
   - This would automate the process of having to manually update the Docker image on Dockerhub every 3-6 months to get Gitpod working again. The image will rebuild itself when Gitpod detects a difference in the Dockerfile. [source](https://www.gitpod.io/blog/docker-in-gitpod)
 <img width="865" alt="Screen Shot 2023-07-07 at 3 18 33 PM" src="https://github.com/pandas-dev/pandas/assets/60138157/f119b1c3-72b1-46fc-97d0-d037c16935d5">

**The Smaller Changes**

- Update `gitpod/Dockerfile` to use the latest version of conda (though the mamba flow wouldn't be used at all anymore). 
- Remove intermediary echo statements
- Remove legacy plugin settings that were causing errors.

**Next Steps and Other Considerations** 

I tried to do the minimal changes to get everything working again, but it seems like the `gitpod/` folder could be gotten rid of completely. Only `.gitpod.yml`, `Dockerfile`, and `gitpod/settings.json` are needed for Gitpod (could change `gitpod/settings.json > settings.json`). 

`gitpod/Dockerfile`, `gitpod/gitpod.Dockerfile`, and `gitpod/workspace_config` are customizations for the Gitpod workspace, but they have to be continually updated over time for them to work. Otherwise they just cause errors after a few months (like they're doing in the repo right now).

Enabling prebuilds for branches/forks/pull-requests would be cool in the future. It would allow for instantly opening/running pull requests in a web browser. Prebuilds save about 3 minutes of time each time Gitpod is booted up. I wasn't sure if there would be cost associated with it so I didn't enable autoprebuilds for those options in the .gitpod.yml file. Right now prebuilds have to be done manually since they are only enabled for `main`. 