### PR TITLE
CI: Fix weekly cache cleanup job

### DIFF
--- a/.github/workflows/cache-cleanup-weekly.yml
+++ b/.github/workflows/cache-cleanup-weekly.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'pandas-dev'
+    permissions:
+      actions: write
     steps:
       - name: Clean Cache
         run: |


### PR DESCRIPTION
It appears this job didn't fully clear all the GHA caches. I think setting the correct permissions should do the trick