### PR TITLE
BUG: checking for value type when parquet is partitioned

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -533,13 +533,13 @@ Sparse
 
 ExtensionArray
 ^^^^^^^^^^^^^^
+- Bug in :class:`ArrowStringArray` constructor raises value error on dictionary on values with string type (:issue:`54074`)
 - Bug in :class:`DataFrame` constructor not copying :class:`Series` with extension dtype when given in dict (:issue:`53744`)
 - Bug in :class:`~arrays.ArrowExtensionArray` converting pandas non-nanosecond temporal objects from non-zero values to zero values (:issue:`53171`)
 - Bug in :meth:`Series.quantile` for pyarrow temporal types raising ArrowInvalid (:issue:`52678`)
 - Bug in :meth:`Series.rank` returning wrong order for small values with ``Float64`` dtype (:issue:`52471`)
 - Bug in :meth:`~arrays.ArrowExtensionArray.__iter__` and :meth:`~arrays.ArrowExtensionArray.__getitem__` returning python datetime and timedelta objects for non-nano dtypes (:issue:`53326`)
 - Bug where the ``__from_arrow__`` method of masked ExtensionDtypes(e.g. :class:`Float64Dtype`, :class:`BooleanDtype`) would not accept pyarrow arrays of type ``pyarrow.null()`` (:issue:`52223`)
--
 
 Styler
 ^^^^^^

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -533,7 +533,7 @@ Sparse
 
 ExtensionArray
 ^^^^^^^^^^^^^^
-- Bug in :class:`ArrowStringArray` constructor raises value error on dictionary on values with string type (:issue:`54074`)
+- Bug in :class:`ArrowStringArray` constructor raises ``ValueError`` with dictionary types of strings (:issue:`54074`)
 - Bug in :class:`DataFrame` constructor not copying :class:`Series` with extension dtype when given in dict (:issue:`53744`)
 - Bug in :class:`~arrays.ArrowExtensionArray` converting pandas non-nanosecond temporal objects from non-zero values to zero values (:issue:`53171`)
 - Bug in :meth:`Series.quantile` for pyarrow temporal types raising ArrowInvalid (:issue:`52678`)

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -118,7 +118,10 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
         super().__init__(values)
         self._dtype = StringDtype(storage="pyarrow")
 
-        if not pa.types.is_string(self._pa_array.type):
+        if not pa.types.is_string(self._pa_array.type) and not (
+            pa.types.is_dictionary(self._pa_array.type)
+            and pa.types.is_string(self._pa_array.type.value_type)
+        ):
             raise ValueError(
                 "ArrowStringArray requires a PyArrow (chunked) array of string type"
             )

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -183,7 +183,6 @@ class PyArrowImpl(BaseImpl):
             from_pandas_kwargs["preserve_index"] = index
 
         table = self.api.Table.from_pandas(df, **from_pandas_kwargs)
-
         path_or_handle, handles, filesystem = _get_path_or_handle(
             path,
             filesystem,

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -183,6 +183,7 @@ class PyArrowImpl(BaseImpl):
             from_pandas_kwargs["preserve_index"] = index
 
         table = self.api.Table.from_pandas(df, **from_pandas_kwargs)
+
         path_or_handle, handles, filesystem = _get_path_or_handle(
             path,
             filesystem,

--- a/pandas/tests/arrays/string_/test_string_arrow.py
+++ b/pandas/tests/arrays/string_/test_string_arrow.py
@@ -70,6 +70,24 @@ def test_constructor_not_string_type_raises(array, chunked):
 
 
 @skip_if_no_pyarrow
+@pytest.mark.parametrize("chunked", [True, False])
+def test_constructor_not_string_type_value_dictionary_raises(chunked):
+    import pyarrow as pa
+
+    array = pa
+
+    arr = array.array([1, 2, 3], array.dictionary(array.int32(), array.int32()))
+    if chunked:
+        arr = pa.chunked_array(arr)
+
+    msg = re.escape(
+        "ArrowStringArray requires a PyArrow (chunked) array of string type"
+    )
+    with pytest.raises(ValueError, match=msg):
+        ArrowStringArray(arr)
+
+
+@skip_if_no_pyarrow
 def test_from_sequence_wrong_dtype_raises():
     with pd.option_context("string_storage", "python"):
         ArrowStringArray._from_sequence(["a", None, "c"], dtype="string")

--- a/pandas/tests/arrays/string_/test_string_arrow.py
+++ b/pandas/tests/arrays/string_/test_string_arrow.py
@@ -69,14 +69,11 @@ def test_constructor_not_string_type_raises(array, chunked):
         ArrowStringArray(arr)
 
 
-@skip_if_no_pyarrow
 @pytest.mark.parametrize("chunked", [True, False])
 def test_constructor_not_string_type_value_dictionary_raises(chunked):
-    import pyarrow as pa
+    pa = pytest.importorskip("pyarrow")
 
-    array = pa
-
-    arr = array.array([1, 2, 3], array.dictionary(array.int32(), array.int32()))
+    arr = pa.array([1, 2, 3], pa.dictionary(pa.int32(), pa.int32()))
     if chunked:
         arr = pa.chunked_array(arr)
 

--- a/pandas/tests/arrays/string_/test_string_arrow.py
+++ b/pandas/tests/arrays/string_/test_string_arrow.py
@@ -84,6 +84,18 @@ def test_constructor_not_string_type_value_dictionary_raises(chunked):
         ArrowStringArray(arr)
 
 
+@pytest.mark.parametrize("chunked", [True, False])
+def test_constructor_valid_string_type_value_dictionary(chunked):
+    pa = pytest.importorskip("pyarrow")
+
+    arr = pa.array(["1", "2", "3"], pa.dictionary(pa.int32(), pa.utf8()))
+    if chunked:
+        arr = pa.chunked_array(arr)
+
+    arr = ArrowStringArray(arr)
+    assert pa.types.is_string(arr._pa_array.type.value_type)
+
+
 @skip_if_no_pyarrow
 def test_from_sequence_wrong_dtype_raises():
     with pd.option_context("string_storage", "python"):


### PR DESCRIPTION
- [ ] closes #53951 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x]  Added an entry in the latest doc/source/whatsnew/vX.X.X.rst file if fixing a bug or adding a new feature.

Instead of checking pyarrow array's type to be string, it could be a dictionary of values with string type when partitioned. Performed checks for both cases.
