### PR TITLE
TST/DOC: clarify warning message for inplace methods with CoW

### DIFF
--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -395,12 +395,13 @@ _chained_assignment_msg = (
 
 _chained_assignment_method_msg = (
     "A value is trying to be set on a copy of a DataFrame or Series "
-    "through chained assignment.\n"
-    "When using the Copy-on-Write mode, such chained assignment never works "
+    "through chained assignment using an inplace method.\n"
+    "When using the Copy-on-Write mode, such inplace method never works "
     "to update the original DataFrame or Series, because the intermediate "
     "object on which we are setting values always behaves as a copy.\n\n"
-    "Try using 'df.method({col: value}, inplace=True)' instead, to perform "
-    "the operation inplace.\n\n"
+    "For example, when doing 'df[col].method(value, inplace=True)', try "
+    "using 'df.method({col: value}, inplace=True)' instead, to perform "
+    "the operation inplace on the original object.\n\n"
 )
 
 

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.errors import ChainedAssignmentError
 import pandas.util._test_decorators as td
 
 from pandas import (
@@ -51,7 +50,7 @@ class TestFillNA:
         df = DataFrame(arr, copy=False)
 
         if using_copy_on_write:
-            with tm.assert_produces_warning(ChainedAssignmentError):
+            with tm.raises_chained_assignment_error():
                 df[0].fillna(-1, inplace=True)
             assert np.isnan(arr[:, 0]).all()
         else:

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -7,10 +7,7 @@ import itertools
 import numpy as np
 import pytest
 
-from pandas.errors import (
-    ChainedAssignmentError,
-    PerformanceWarning,
-)
+from pandas.errors import PerformanceWarning
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -414,7 +411,7 @@ def test_update_inplace_sets_valid_block_values(using_copy_on_write):
 
     # inplace update of a single column
     if using_copy_on_write:
-        with tm.assert_produces_warning(ChainedAssignmentError):
+        with tm.raises_chained_assignment_error():
             df["a"].fillna(1, inplace=True)
     else:
         df["a"].fillna(1, inplace=True)

--- a/pandas/tests/indexing/multiindex/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/multiindex/test_chaining_and_caching.py
@@ -1,10 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas.errors import (
-    ChainedAssignmentError,
-    SettingWithCopyError,
-)
+from pandas.errors import SettingWithCopyError
 import pandas.util._test_decorators as td
 
 from pandas import (
@@ -33,7 +30,7 @@ def test_detect_chained_assignment(using_copy_on_write):
     zed = DataFrame(events, index=["a", "b"], columns=multiind)
 
     if using_copy_on_write:
-        with tm.assert_produces_warning(ChainedAssignmentError):
+        with tm.raises_chained_assignment_error():
             zed["eyes"]["right"].fillna(value=555, inplace=True)
     else:
         msg = "A value is trying to be set on a copy of a slice from a DataFrame"


### PR DESCRIPTION
Small follow-up on https://github.com/pandas-dev/pandas/pull/53779