### PR TITLE
CLN: Replace confusing brackets with backticks

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -470,12 +470,12 @@ def isin(comps: ListLike, values: ListLike) -> npt.NDArray[np.bool_]:
     if not is_list_like(comps):
         raise TypeError(
             "only list-like objects are allowed to be passed "
-            f"to isin(), you passed a [{type(comps).__name__}]"
+            f"to isin(), you passed a `{type(comps).__name__}`"
         )
     if not is_list_like(values):
         raise TypeError(
             "only list-like objects are allowed to be passed "
-            f"to isin(), you passed a [{type(values).__name__}]"
+            f"to isin(), you passed a `{type(values).__name__}`"
         )
 
     if not isinstance(values, (ABCIndex, ABCSeries, ABCExtensionArray, np.ndarray)):

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2581,7 +2581,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
             values_type = type(values).__name__
             raise TypeError(
                 "only list-like objects are allowed to be passed "
-                f"to isin(), you passed a [{values_type}]"
+                f"to isin(), you passed a `{values_type}`"
             )
         values = sanitize_array(values, None, None)
         null_mask = np.asarray(isna(values))

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -158,7 +158,7 @@ class TestEval:
             [
                 r"only list-like( or dict-like)? objects are allowed to be "
                 r"passed to (DataFrame\.)?isin\(\), you passed a "
-                r"(\[|')bool(\]|')",
+                r"(`|')bool(`|')",
                 "argument of type 'bool' is not iterable",
             ]
         )
@@ -203,7 +203,7 @@ class TestEval:
             [
                 r"only list-like( or dict-like)? objects are allowed to be "
                 r"passed to (DataFrame\.)?isin\(\), you passed a "
-                r"(\[|')float(\]|')",
+                r"(`|')float(`|')",
                 "argument of type 'float' is not iterable",
             ]
         )

--- a/pandas/tests/series/methods/test_isin.py
+++ b/pandas/tests/series/methods/test_isin.py
@@ -34,7 +34,7 @@ class TestSeriesIsIn:
         s = Series(["A", "B", "C", "a", "B", "B", "A", "C"])
         msg = (
             r"only list-like objects are allowed to be passed to isin\(\), "
-            r"you passed a \[str\]"
+            r"you passed a `str`"
         )
         with pytest.raises(TypeError, match=msg):
             s.isin("a")

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -888,7 +888,7 @@ class TestIsin:
     def test_invalid(self):
         msg = (
             r"only list-like objects are allowed to be passed to isin\(\), "
-            r"you passed a \[int\]"
+            r"you passed a `int`"
         )
         with pytest.raises(TypeError, match=msg):
             algos.isin(1, 1)


### PR DESCRIPTION
There are some errors which read like:

> only list-like objects are allowed to be passed to isin(), you
> passed a [str]

(note how the type `str` is enclosed in square brackets)

This is potentially confusing, since some languages use notation like `[TYPE]` to denote a list of TYPE objects. So the user could read the error message saying they can't use `[str]`, but intepret `[str]` to mean "a list of str objects".

This commit removes the possibility of confusion by using backticks instead of square brackets.