### PR TITLE
DEV: Improves Error msg when constructing a Timedelta

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -111,7 +111,6 @@ Other enhancements
 - Improve error message when setting :class:`DataFrame` with wrong number of columns through :meth:`DataFrame.isetitem` (:issue:`51701`)
 - Improved error handling when using :meth:`DataFrame.to_json` with incompatible ``index`` and ``orient`` arguments (:issue:`52143`)
 - Improved error message when creating a DataFrame with empty data (0 rows), no index and an incorrect number of columns. (:issue:`52084`)
-- Improved error message when creating a Timedelta from a ambiguous time period (:issue:`54059`)
 - Let :meth:`DataFrame.to_feather` accept a non-default :class:`Index` and non-string column names (:issue:`51787`)
 - Performance improvement in :func:`read_csv` (:issue:`52632`) with ``engine="c"``
 - :meth:`Categorical.from_codes` has gotten a ``validate`` parameter (:issue:`50975`)

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -111,6 +111,7 @@ Other enhancements
 - Improve error message when setting :class:`DataFrame` with wrong number of columns through :meth:`DataFrame.isetitem` (:issue:`51701`)
 - Improved error handling when using :meth:`DataFrame.to_json` with incompatible ``index`` and ``orient`` arguments (:issue:`52143`)
 - Improved error message when creating a DataFrame with empty data (0 rows), no index and an incorrect number of columns. (:issue:`52084`)
+- Improved error message when creating a Timedelta from a ambiguous time period (:issue:`54059`)
 - Let :meth:`DataFrame.to_feather` accept a non-default :class:`Index` and non-string column names (:issue:`51787`)
 - Performance improvement in :func:`read_csv` (:issue:`52632`) with ``engine="c"``
 - :meth:`Categorical.from_codes` has gotten a ``validate`` parameter (:issue:`50975`)

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1843,7 +1843,10 @@ class Timedelta(_Timedelta):
                              NPY_DATETIMEUNIT.NPY_FR_W,
                              NPY_DATETIMEUNIT.NPY_FR_GENERIC]):
                 err = npy_unit_to_abbrev(reso)
-                raise ValueError(f" cannot construct a Timedelta from a unit {err}")
+                raise ValueError(
+                    "Units 'M', 'Y', and 'y' are no longer supported, as they do not "
+                    "represent unambiguous timedelta values durations."
+                    "Allowed unites are 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns'")
 
             new_reso = get_supported_reso(reso)
             if reso != NPY_DATETIMEUNIT.NPY_FR_GENERIC:

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1844,8 +1844,8 @@ class Timedelta(_Timedelta):
                              NPY_DATETIMEUNIT.NPY_FR_GENERIC]):
                 err = npy_unit_to_abbrev(reso)
                 raise ValueError(
-                    "Units 'M', 'Y', and 'y' are no longer supported, as they do not "
-                    "represent unambiguous timedelta values durations."
+                    f"Unit {err} is not supported. "
+                    "Only unambiguous timedelta values durations are supported. "
                     "Allowed units are 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns'")
 
             new_reso = get_supported_reso(reso)

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1846,7 +1846,7 @@ class Timedelta(_Timedelta):
                 raise ValueError(
                     "Units 'M', 'Y', and 'y' are no longer supported, as they do not "
                     "represent unambiguous timedelta values durations."
-                    "Allowed unites are 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns'")
+                    "Allowed units are 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns'")
 
             new_reso = get_supported_reso(reso)
             if reso != NPY_DATETIMEUNIT.NPY_FR_GENERIC:

--- a/pandas/tests/tslibs/test_timedeltas.py
+++ b/pandas/tests/tslibs/test_timedeltas.py
@@ -77,8 +77,8 @@ def test_unsupported_td64_unit_raises(unit):
     # GH 52806
     with pytest.raises(
         ValueError,
-        match="Units 'M', 'Y', and 'y' are no longer supported, as they do not "
-        "represent unambiguous timedelta values durations."
+        match=f"Unit {unit} is not supported. "
+        "Only unambiguous timedelta values durations are supported. "
         "Allowed units are 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns'",
     ):
         Timedelta(np.timedelta64(1, unit))

--- a/pandas/tests/tslibs/test_timedeltas.py
+++ b/pandas/tests/tslibs/test_timedeltas.py
@@ -79,7 +79,7 @@ def test_unsupported_td64_unit_raises(unit):
         ValueError,
         match="Units 'M', 'Y', and 'y' are no longer supported, as they do not "
         "represent unambiguous timedelta values durations."
-        "Allowed unites are 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns'",
+        "Allowed units are 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns'",
     ):
         Timedelta(np.timedelta64(1, unit))
 

--- a/pandas/tests/tslibs/test_timedeltas.py
+++ b/pandas/tests/tslibs/test_timedeltas.py
@@ -76,7 +76,10 @@ def test_delta_to_nanoseconds_td64_MY_raises():
 def test_unsupported_td64_unit_raises(unit):
     # GH 52806
     with pytest.raises(
-        ValueError, match=f"cannot construct a Timedelta from a unit {unit}"
+        ValueError,
+        match="Units 'M', 'Y', and 'y' are no longer supported, as they do not "
+        "represent unambiguous timedelta values durations."
+        "Allowed unites are 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns'",
     ):
         Timedelta(np.timedelta64(1, unit))
 


### PR DESCRIPTION
- [x] closes #54059 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
