### PR TITLE
DOC: point out the limitation of precision while doing serialization

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2413,7 +2413,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             the default is 'epoch'.
         double_precision : int, default 10
             The number of decimal places to use when encoding
-            floating point values.
+            floating point values. The possible maximal value is 15.
+            Passing double_precision greater than 15 will raise a ValueError.
         force_ascii : bool, default True
             Force encoded string to be ASCII.
         date_unit : str, default 'ms' (milliseconds)


### PR DESCRIPTION
- [x] closes #38437

Updated docstring for `to_json`, pointed out that the maximal possible value for `double_precision` is equal 15.
