### PR TITLE
DOC: Update to Documentation - Grammatical Updates and Typo Corrections

### DIFF
--- a/doc/source/index.rst.template
+++ b/doc/source/index.rst.template
@@ -22,9 +22,9 @@ pandas documentation
 `Q&A Support <https://stackoverflow.com/questions/tagged/pandas>`__ |
 `Mailing List <https://groups.google.com/g/pydata>`__
 
-:mod:`pandas` is an open source, BSD-licensed library providing high-performance,
-easy-to-use data structures and data analysis tools for the `Python <https://www.python.org/>`__
-programming language.
+:mod:`Pandas` is a great resource for all data manipulation needs, licensed under BSD, that offers high-performance, user-friendly data structures and analysis tools for `Python <https://www.python.org/>`__
+
+
 
 {% if not single_doc or single_doc == "index.rst" -%}
 .. grid:: 1 2 2 2

--- a/doc/source/index.rst.template
+++ b/doc/source/index.rst.template
@@ -5,7 +5,7 @@
 .. module:: pandas
 
 ********************
-pandas documentation
+Pandas Documentation
 ********************
 
 **Date**: |today| **Version**: |version|


### PR DESCRIPTION
Typo correction and grammatical updates on the "Pandas Documentation" page (https://pandas.pydata.org/docs/). 

Title: 
pandas documentation -> Pandas Documentation
Capitalization of title.

The text below "Useful links":
The word "pandas" is not capitalized. Since it is the first word of a sentence, it must be capitalized. 
Grammatical update to the whole sentence. 

No links were changed.

Before changes:
![before](https://github.com/pandas-dev/pandas/assets/88173271/2cab605e-4e5d-4cbc-b8fb-5cac049d4f90)

After Changes:
![after](https://github.com/pandas-dev/pandas/assets/88173271/80e08d14-cce2-4000-9ec3-6555b66f6063)