### PR TITLE
Scipy 2023 sprint: Added type hints

### DIFF
--- a/doc/tmp.csv
+++ b/doc/tmp.csv
@@ -1,0 +1,4 @@
+ID,level,category
+Patient1,123000,x # really unpleasant
+Patient2,23000,y # wouldn't take his medicine
+Patient3,1234018,z # awesome

--- a/doc/tmp.csv
+++ b/doc/tmp.csv
@@ -1,4 +1,0 @@
-ID,level,category
-Patient1,123000,x # really unpleasant
-Patient2,23000,y # wouldn't take his medicine
-Patient3,1234018,z # awesome

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6838,7 +6838,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         return start_slice, end_slice
 
-    def delete(self, loc: int | list[int]) -> Self:
+    def delete(self, loc: int | list[int]) -> Self:  # type: ignore[override]
         """
         Make new Index with passed location(-s) deleted.
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -49,6 +49,7 @@ from pandas._typing import (
     Axes,
     Axis,
     DropKeep,
+    Dtype,
     DtypeObj,
     F,
     IgnoreRaise,
@@ -1033,7 +1034,7 @@ class Index(IndexOpsMixin, PandasObject):
             result._id = self._id
         return result
 
-    def astype(self, dtype, copy: bool = True):
+    def astype(self, dtype: Dtype, copy: bool = True):
         """
         Create an Index with values cast to dtypes.
 
@@ -1228,7 +1229,7 @@ class Index(IndexOpsMixin, PandasObject):
         """
 
     @Appender(_index_shared_docs["repeat"] % _index_doc_kwargs)
-    def repeat(self, repeats, axis=None):
+    def repeat(self, repeats, axis: Axis | None = None):
         repeats = ensure_platform_int(repeats)
         nv.validate_repeat((), {"axis": axis})
         res_values = self._values.repeat(repeats)
@@ -3215,7 +3216,7 @@ class Index(IndexOpsMixin, PandasObject):
         return self, other
 
     @final
-    def union(self, other, sort=None):
+    def union(self, other, sort: bool | None = None):
         """
         Form the union of two Index objects.
 
@@ -3577,7 +3578,7 @@ class Index(IndexOpsMixin, PandasObject):
         return result
 
     @final
-    def difference(self, other, sort=None):
+    def difference(self, other, sort: bool | None = None):
         """
         Return a new Index with elements of index not in `other`.
 
@@ -3661,7 +3662,9 @@ class Index(IndexOpsMixin, PandasObject):
         # We will override for MultiIndex to handle empty results
         return self._wrap_setop_result(other, result)
 
-    def symmetric_difference(self, other, result_name=None, sort=None):
+    def symmetric_difference(
+        self, other, result_name: str = None, sort: bool | None = None
+    ):
         """
         Compute the symmetric difference of two Index objects.
 
@@ -6441,7 +6444,7 @@ class Index(IndexOpsMixin, PandasObject):
             items = [func(x) for x in self]
             return Index(items, name=self.name, tupleize_cols=False)
 
-    def isin(self, values, level=None) -> npt.NDArray[np.bool_]:
+    def isin(self, values, level: str | int = None) -> npt.NDArray[np.bool_]:
         """
         Return a boolean array where the index values are in `values`.
 
@@ -6741,15 +6744,20 @@ class Index(IndexOpsMixin, PandasObject):
             else:
                 return slc
 
-    def slice_locs(self, start=None, end=None, step=None) -> tuple[int, int]:
+    def slice_locs(
+        self,
+        start: IndexLabel | None = None,
+        end: IndexLabel | None = None,
+        step: int | None = None,
+    ) -> tuple[int, int]:
         """
         Compute slice locations for input labels.
 
         Parameters
         ----------
-        start : label, default None
+        start : Label, default None
             If None, defaults to the beginning.
-        end : label, default None
+        end : Label, default None
             If None, defaults to the end.
         step : int, defaults None
             If None, defaults to 1.
@@ -6829,7 +6837,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         return start_slice, end_slice
 
-    def delete(self, loc) -> Self:
+    def delete(self, loc: int | list[int]) -> Self:
         """
         Make new Index with passed location(-s) deleted.
 
@@ -7260,7 +7268,9 @@ class Index(IndexOpsMixin, PandasObject):
             make_invalid_op(opname)(self)
 
     @Appender(IndexOpsMixin.argmin.__doc__)
-    def argmin(self, axis=None, skipna: bool = True, *args, **kwargs) -> int:
+    def argmin(
+        self, axis: Axis | None = None, skipna: bool = True, *args, **kwargs
+    ) -> int:
         nv.validate_argmin(args, kwargs)
         nv.validate_minmax_axis(axis)
 
@@ -7272,7 +7282,9 @@ class Index(IndexOpsMixin, PandasObject):
         return super().argmin(skipna=skipna)
 
     @Appender(IndexOpsMixin.argmax.__doc__)
-    def argmax(self, axis=None, skipna: bool = True, *args, **kwargs) -> int:
+    def argmax(
+        self, axis: Axis | None = None, skipna: bool = True, *args, **kwargs
+    ) -> int:
         nv.validate_argmax(args, kwargs)
         nv.validate_minmax_axis(axis)
 
@@ -7283,14 +7295,14 @@ class Index(IndexOpsMixin, PandasObject):
                 return -1
         return super().argmax(skipna=skipna)
 
-    def min(self, axis=None, skipna: bool = True, *args, **kwargs):
+    def min(self, axis: Axis | None = None, skipna: bool = True, *args, **kwargs):
         """
         Return the minimum value of the Index.
 
         Parameters
         ----------
-        axis : {None}
-            Dummy argument for consistency with Series.
+        axis : int, optional
+            For compatibility with NumPy. Only 0 or None are allowed.
         skipna : bool, default True
             Exclude NA/null values when showing the result.
         *args, **kwargs
@@ -7346,7 +7358,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         return nanops.nanmin(self._values, skipna=skipna)
 
-    def max(self, axis=None, skipna: bool = True, *args, **kwargs):
+    def max(self, axis: Axis | None = None, skipna: bool = True, *args, **kwargs):
         """
         Return the maximum value of the Index.
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -48,6 +48,7 @@ from pandas._typing import (
     ArrayLike,
     Axes,
     Axis,
+    AxisInt,
     DropKeep,
     Dtype,
     DtypeObj,
@@ -3663,7 +3664,7 @@ class Index(IndexOpsMixin, PandasObject):
         return self._wrap_setop_result(other, result)
 
     def symmetric_difference(
-        self, other, result_name: str = None, sort: bool | None = None
+        self, other, result_name: Hashable | None = None, sort: bool | None = None
     ):
         """
         Compute the symmetric difference of two Index objects.
@@ -7295,7 +7296,7 @@ class Index(IndexOpsMixin, PandasObject):
                 return -1
         return super().argmax(skipna=skipna)
 
-    def min(self, axis: Axis | None = None, skipna: bool = True, *args, **kwargs):
+    def min(self, axis: AxisInt | None = None, skipna: bool = True, *args, **kwargs):
         """
         Return the minimum value of the Index.
 
@@ -7358,7 +7359,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         return nanops.nanmin(self._values, skipna=skipna)
 
-    def max(self, axis: Axis | None = None, skipna: bool = True, *args, **kwargs):
+    def max(self, axis: AxisInt | None = None, skipna: bool = True, *args, **kwargs):
         """
         Return the maximum value of the Index.
 

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -855,7 +855,7 @@ class RangeIndex(Index):
 
     # error: Return type "Index" of "delete" incompatible with return type
     #  "RangeIndex" in supertype "Index"
-    def delete(self, loc) -> Index:  # type: ignore[override]
+    def delete(self, loc: int | list[int]) -> Index:  # type: ignore[override]
         # In some cases we can retain RangeIndex, see also
         #  DatetimeTimedeltaMixin._get_delete_Freq
         if is_integer(loc):


### PR DESCRIPTION
Added type hints during the SciPy 2023 sprint.
https://github.com/noatamir/scipy-2023-sprint/issues/5


- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.

@phofl, @noatamir
