### PR TITLE
Removed indentation in documentation

### DIFF
--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -19,10 +19,10 @@ The following subpackages are public.
 - ``pandas.api.interchange``: DataFrame interchange protocol.
 - ``pandas.api.types``: Datatype classes and functions.
 - ``pandas.api.typing``: Classes that may be necessary for type-hinting.
-    These are classes that are encountered as intermediate results but should not be instantiated
-    directly by users. These classes are not to be confused with classes from the
-    `pandas-stubs <https://github.com/pandas-dev/pandas-stubs>`_ package
-    which has classes in addition to those that occur in pandas for type-hinting.
+  These are classes that are encountered as intermediate results but should not be instantiated
+  directly by users. These classes are not to be confused with classes from the
+  `pandas-stubs <https://github.com/pandas-dev/pandas-stubs>`_ package
+  which has classes in addition to those that occur in pandas for type-hinting.
 
 In addition, public functions in ``pandas.io`` and ``pandas.tseries`` submodules
 are mentioned in the documentation.

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -31,8 +31,7 @@ are mentioned in the documentation.
 
     The ``pandas.core``, ``pandas.compat``, and ``pandas.util`` top-level modules are PRIVATE. Stable functionality in such modules is not guaranteed.
 
-.. If you update this toctree, also update the manual toctree in the
-   main index.rst.template
+.. If you update this toctree, also update the manual toctree in the main index.rst.template
 
 .. toctree::
    :maxdepth: 2

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -10,6 +10,7 @@ This page gives an overview of all public pandas objects, functions and
 methods. All classes and functions exposed in ``pandas.*`` namespace are public.
 
 The following subpackages are public.
+
 - ``pandas.errors``: Custom exception and warnings classes that are raised by pandas.
 - ``pandas.plotting``: Plotting public API.
 - ``pandas.testing``: Functions that are useful for writing tests involving pandas objects.
@@ -17,11 +18,11 @@ The following subpackages are public.
 - ``pandas.api.indexers``: Functions and classes for rolling window indexers.
 - ``pandas.api.interchange``: DataFrame interchange protocol.
 - ``pandas.api.types``: Datatype classes and functions.
-- ``pandas.api.typing``: Classes that may be necessary for type-hinting. These are
-  classes that are encountered as intermediate results but should not be
-  instantiated  directly by users. These classes are not to be confused with
-  classes from the `pandas-stubs <https://github.com/pandas-dev/pandas-stubs>`_
-  package which has classes in addition to those that occur in pandas for type-hinting.
+- ``pandas.api.typing``: Classes that may be necessary for type-hinting.
+    These are classes that are encountered as intermediate results but should not be instantiated
+    directly by users. These classes are not to be confused with classes from the
+    `pandas-stubs <https://github.com/pandas-dev/pandas-stubs>`_ package
+    which has classes in addition to those that occur in pandas for type-hinting.
 
 In addition, public functions in ``pandas.io`` and ``pandas.tseries`` submodules
 are mentioned in the documentation.
@@ -31,7 +32,8 @@ are mentioned in the documentation.
 
     The ``pandas.core``, ``pandas.compat``, and ``pandas.util`` top-level modules are PRIVATE. Stable functionality in such modules is not guaranteed.
 
-.. If you update this toctree, also update the manual toctree in the main index.rst.template
+.. If you update this toctree, also update the manual toctree in the
+.. main index.rst.template
 
 .. toctree::
    :maxdepth: 2

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -10,19 +10,18 @@ This page gives an overview of all public pandas objects, functions and
 methods. All classes and functions exposed in ``pandas.*`` namespace are public.
 
 The following subpackages are public.
-
- - ``pandas.errors``: Custom exception and warnings classes that are raised by pandas.
- - ``pandas.plotting``: Plotting public API.
- - ``pandas.testing``: Functions that are useful for writing tests involving pandas objects.
- - ``pandas.api.extensions``: Functions and classes for extending pandas objects.
- - ``pandas.api.indexers``: Functions and classes for rolling window indexers.
- - ``pandas.api.interchange``: DataFrame interchange protocol.
- - ``pandas.api.types``: Datatype classes and functions.
- - ``pandas.api.typing``: Classes that may be necessary for type-hinting. These are
-   classes that are encountered as intermediate results but should not be
-   instantiated  directly by users. These classes are not to be confused with
-   classes from the `pandas-stubs <https://github.com/pandas-dev/pandas-stubs>`_
-   package which has classes in addition to those that occur in pandas for type-hinting.
+- ``pandas.errors``: Custom exception and warnings classes that are raised by pandas.
+- ``pandas.plotting``: Plotting public API.
+- ``pandas.testing``: Functions that are useful for writing tests involving pandas objects.
+- ``pandas.api.extensions``: Functions and classes for extending pandas objects.
+- ``pandas.api.indexers``: Functions and classes for rolling window indexers.
+- ``pandas.api.interchange``: DataFrame interchange protocol.
+- ``pandas.api.types``: Datatype classes and functions.
+- ``pandas.api.typing``: Classes that may be necessary for type-hinting. These are
+  classes that are encountered as intermediate results but should not be
+  instantiated  directly by users. These classes are not to be confused with
+  classes from the `pandas-stubs <https://github.com/pandas-dev/pandas-stubs>`_
+  package which has classes in addition to those that occur in pandas for type-hinting.
 
 In addition, public functions in ``pandas.io`` and ``pandas.tseries`` submodules
 are mentioned in the documentation.


### PR DESCRIPTION
Removed indentation in documentation
https://github.com/noatamir/scipy-2023-sprint/issues/8

@phofl, @noatamir
