### PR TITLE
TEST: Add test to check safe cast between UInt32 and np.uint32

### DIFF
--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -1195,7 +1195,7 @@ def test_multi_column_dtype_assignment():
     tm.assert_frame_equal(df, expected)
 
 
-def test_safe_cast(self):
+def test_safe_cast():
     dfr = pd.DataFrame({"col1": np.random.randint(0, 100, size=100)})
     with pytest.raises(TypeError, match=r"cannot safely cast non-equivalent"):
         (dfr / 10).astype("UInt32").dtypes

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -1193,3 +1193,9 @@ def test_multi_column_dtype_assignment():
 
     df["b"] = 0
     tm.assert_frame_equal(df, expected)
+
+
+def test_safe_cast(self):
+    dfr = pd.DataFrame({"col1": np.random.randint(0, 100, size=100)})
+    with pytest.raises(TypeError, match=r"cannot safely cast non-equivalent"):
+        (dfr / 10).astype("UInt32").dtypes


### PR DESCRIPTION
PR from the SciPy 2023 Sprint session. @noatamir @phofl 

I implemented a test to check that the casting from `float` type to `UInt32` pandas type raises an error.

This should be raising an error, as it is expected that Pandas types do not allow for casting to types that would remove information.