### PR TITLE
Add mixed int string entry.

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -619,6 +619,7 @@ indices_dict = {
     "tuples": MultiIndex.from_tuples(zip(["foo", "bar", "baz"], [1, 2, 3])),
     "mi-with-dt64tz-level": _create_mi_with_dt64tz_level(),
     "multi": _create_multiindex(),
+    "mixed-int-string": Index([0, "a", 1, "b", 2, "c"]),
     "repeats": Index([0, 0, 1, 1, 2, 2]),
     "nullable_int": Index(np.arange(100), dtype="Int64"),
     "nullable_uint": Index(np.arange(100), dtype="UInt16"),

--- a/pandas/tests/base/test_value_counts.py
+++ b/pandas/tests/base/test_value_counts.py
@@ -23,9 +23,13 @@ def test_value_counts(index_or_series_obj):
     obj = index_or_series_obj
     obj = np.repeat(obj, range(1, len(obj) + 1))
     result = obj.value_counts()
+    present_types = set([type(i) for i in obj])
 
     counter = collections.Counter(obj)
     expected = Series(dict(counter.most_common()), dtype=np.int64, name="count")
+
+    if len(present_types) > 1:
+        pytest.skip("Test doesn't make sense on data with different index types.")
 
     if obj.dtype != np.float16:
         expected.index = expected.index.astype(obj.dtype)
@@ -33,6 +37,7 @@ def test_value_counts(index_or_series_obj):
         with pytest.raises(NotImplementedError, match="float16 indexes are not "):
             expected.index.astype(obj.dtype)
         return
+
     if isinstance(expected.index, MultiIndex):
         expected.index.names = obj.names
     else:
@@ -57,11 +62,14 @@ def test_value_counts(index_or_series_obj):
 def test_value_counts_null(null_obj, index_or_series_obj):
     orig = index_or_series_obj
     obj = orig.copy()
+    present_types = set([type(i) for i in obj])
 
     if not allow_na_ops(obj):
         pytest.skip("type doesn't allow for NA operations")
     elif len(obj) < 1:
         pytest.skip("Test doesn't make sense on empty data")
+    elif len(present_types) > 1:
+        pytest.skip("Test doesn't make sense on data with different index types.")
     elif isinstance(orig, MultiIndex):
         pytest.skip(f"MultiIndex can't hold '{null_obj}'")
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -71,7 +71,10 @@ class TestFactorize:
             expected_uniques = expected_uniques.astype(object)
 
         if sort:
-            expected_uniques = expected_uniques.sort_values()
+            try:
+                expected_uniques = expected_uniques.sort_values()
+            except TypeError:
+                pytest.xfail("dtypes not suitable for sorting.")
 
         # construct an integer ndarray so that
         # `expected_uniques.take(expected_codes)` is equal to `obj`


### PR DESCRIPTION
- [X] closes #54072 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This is in reference to #54072. Currently running tests have been failing due to memory requirements on local machine. 
As suggested by @noatamir @phofl during SciPy 2023 opening as a draft to have it run tests. 
