### PR TITLE
DOC: Provide examples of using read_parquet #49739

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -90,7 +90,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.NaT \
         pandas.read_feather \
         pandas.DataFrame.to_feather \
-        pandas.read_parquet \
         pandas.read_orc \
         pandas.read_sas \
         pandas.read_spss \

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -563,7 +563,6 @@ def read_parquet(
 
     Examples
     --------
-    >>> import pandas as pd
     >>> original_df = pd.DataFrame(
     ...     {{"foo": range(5), "bar": range(5, 10)}}
     ...    )
@@ -612,7 +611,6 @@ def read_parquet(
         foo  bar
     0    3    8
     1    4    9
-
     """
 
     impl = get_engine(engine)

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -588,7 +588,7 @@ def read_parquet(
     True
     >>> restored_bar = pd.read_parquet(BytesIO(df_parquet_bytes), columns=["bar"])
     >>> restored_bar
-    bar
+        bar
     0    5
     1    6
     2    7

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -556,7 +556,64 @@ def read_parquet(
     Returns
     -------
     DataFrame
+
+    See Also
+    --------
+    DataFrame.to_parquet : Create a parquet object that serializes a DataFrame.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> original_df = pd.DataFrame(
+    ...     {{"foo": range(5), "bar": range(5, 10)}}
+    ...    )
+    >>> original_df
+       foo  bar
+    0    0    5
+    1    1    6
+    2    2    7
+    3    3    8
+    4    4    9
+    >>> df_parquet_bytes = original_df.to_parquet()
+    >>> from io import BytesIO
+    >>> restored_df =  pd.read_parquet(BytesIO(df_parquet_bytes))
+    >>> restored_df
+       foo  bar
+    0    0    5
+    1    1    6
+    2    2    7
+    3    3    8
+    4    4    9
+    >>> restored_df.equals(original_df)
+    True
+    >>> restored_bar = pd.read_parquet(BytesIO(df_parquet_bytes), columns=["bar"])
+    bar
+    0    5
+    1    6
+    2    7
+    3    8
+    4    9
+    >>> restored_bar.equals(original_df[['bar']])
+    True
+
+    The function uses `kwargs` that are passed directly to the engine.
+    In the following example, we use the `filters` argument of the pyarrow
+    engine to filter the rows of the DataFrame.
+
+    Since `pyarrow` is the default engine, we can omit the `engine` argument.
+    Note that the `filters` argument is implemented by the `pyarrow` engine,
+    which can benefit from multithreading and also potentially be more
+    economical in terms of memory.
+
+    >>> sel = [("bar", ">", 2)]
+    >>> restored_part = pd.read_parquet(BytesIO(df_parquet_bytes), filters=sel)
+    >>> restored_part
+        foo  bar
+    0    3    8
+    1    4    9
+
     """
+
     impl = get_engine(engine)
 
     if use_nullable_dtypes is not lib.no_default:

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -576,7 +576,7 @@ def read_parquet(
     4    4    9
     >>> df_parquet_bytes = original_df.to_parquet()
     >>> from io import BytesIO
-    >>> restored_df =  pd.read_parquet(BytesIO(df_parquet_bytes))
+    >>> restored_df = pd.read_parquet(BytesIO(df_parquet_bytes))
     >>> restored_df
        foo  bar
     0    0    5
@@ -606,7 +606,7 @@ def read_parquet(
     which can benefit from multithreading and also potentially be more
     economical in terms of memory.
 
-    >>> sel = [("bar", ">", 2)]
+    >>> sel = [("foo", ">", 2)]
     >>> restored_part = pd.read_parquet(BytesIO(df_parquet_bytes), filters=sel)
     >>> restored_part
         foo  bar

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -587,6 +587,7 @@ def read_parquet(
     >>> restored_df.equals(original_df)
     True
     >>> restored_bar = pd.read_parquet(BytesIO(df_parquet_bytes), columns=["bar"])
+    >>> restored_bar
     bar
     0    5
     1    6


### PR DESCRIPTION
- [x] closes #xDOC: Provide examples of using read_parquet #49739
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

@noatamir  @phofl SciPy 2023 sprint
