### PR TITLE
ASV: update Fillna benchmarks for method parameter deprecation

### DIFF
--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -388,7 +388,6 @@ class Isnull:
 class Fillna:
     params = (
         [True, False],
-        ["pad", "bfill"],
         [
             "float64",
             "float32",
@@ -400,9 +399,9 @@ class Fillna:
             "timedelta64[ns]",
         ],
     )
-    param_names = ["inplace", "method", "dtype"]
+    param_names = ["inplace", "dtype"]
 
-    def setup(self, inplace, method, dtype):
+    def setup(self, inplace, dtype):
         N, M = 10000, 100
         if dtype in ("datetime64[ns]", "datetime64[ns, tz]", "timedelta64[ns]"):
             data = {
@@ -420,9 +419,16 @@ class Fillna:
             if dtype == "Int64":
                 values = values.round()
             self.df = DataFrame(values, dtype=dtype)
+        self.fill_values = self.df.iloc[self.df.first_valid_index()].to_dict()
 
-    def time_frame_fillna(self, inplace, method, dtype):
-        self.df.fillna(inplace=inplace, method=method)
+    def time_fillna(self, inplace, dtype):
+        self.df.fillna(value=self.fill_values, inplace=inplace)
+
+    def time_ffill(self, inplace, dtype):
+        self.df.ffill(inplace=inplace)
+
+    def time_bfill(self, inplace, dtype):
+        self.df.bfill(inplace=inplace)
 
 
 class Dropna:

--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -423,7 +423,7 @@ class Shift:
         self.df.groupby("g").shift(fill_value=99)
 
 
-class FillNA:
+class Fillna:
     def setup(self):
         N = 100
         self.df = DataFrame(
@@ -431,16 +431,16 @@ class FillNA:
         ).set_index("group")
 
     def time_df_ffill(self):
-        self.df.groupby("group").fillna(method="ffill")
+        self.df.groupby("group").ffill()
 
     def time_df_bfill(self):
-        self.df.groupby("group").fillna(method="bfill")
+        self.df.groupby("group").bfill()
 
     def time_srs_ffill(self):
-        self.df.groupby("group")["value"].fillna(method="ffill")
+        self.df.groupby("group")["value"].ffill()
 
     def time_srs_bfill(self):
-        self.df.groupby("group")["value"].fillna(method="bfill")
+        self.df.groupby("group")["value"].bfill()
 
 
 class GroupByMethods:

--- a/asv_bench/benchmarks/reindex.py
+++ b/asv_bench/benchmarks/reindex.py
@@ -66,24 +66,6 @@ class ReindexMethod:
         self.ts.reindex(self.idx, method=method)
 
 
-class Fillna:
-    params = ["pad", "backfill"]
-    param_names = ["method"]
-
-    def setup(self, method):
-        N = 100000
-        self.idx = date_range("1/1/2000", periods=N, freq="1min")
-        ts = Series(np.random.randn(N), index=self.idx)[::2]
-        self.ts_reindexed = ts.reindex(self.idx)
-        self.ts_float32 = self.ts_reindexed.astype("float32")
-
-    def time_reindexed(self, method):
-        self.ts_reindexed.fillna(method=method)
-
-    def time_float_32(self, method):
-        self.ts_float32.fillna(method=method)
-
-
 class LevelAlign:
     def setup(self):
         self.index = MultiIndex(

--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -81,6 +81,7 @@ class Fillna:
     params = [
         [
             "datetime64[ns]",
+            "float32",
             "float64",
             "Float64",
             "Int64",
@@ -88,11 +89,10 @@ class Fillna:
             "string",
             "string[pyarrow]",
         ],
-        [None, "pad", "backfill"],
     ]
-    param_names = ["dtype", "method"]
+    param_names = ["dtype"]
 
-    def setup(self, dtype, method):
+    def setup(self, dtype):
         N = 10**6
         if dtype == "datetime64[ns]":
             data = date_range("2000-01-01", freq="S", periods=N)
@@ -114,9 +114,14 @@ class Fillna:
         self.ser = ser
         self.fill_value = fill_value
 
-    def time_fillna(self, dtype, method):
-        value = self.fill_value if method is None else None
-        self.ser.fillna(value=value, method=method)
+    def time_fillna(self, dtype):
+        self.ser.fillna(value=self.fill_value)
+
+    def time_ffill(self, dtype):
+        self.ser.ffill()
+
+    def time_bfill(self, dtype):
+        self.ser.bfill()
 
 
 class SearchSorted:


### PR DESCRIPTION
Updates various `Fillna` benchmarks to not use `method` as `method` has been deprecated in favor of `DataFrame.ffill` and `DataFrame.bfill`. 

Also, removed `reindex.Fillna` ASV as it was just a subset of `series_methods.Fillna`. 
