### PR TITLE
DOC: Example missing in pandas.DataFrame.to_html #44945

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3133,35 +3133,29 @@ class DataFrame(NDFrame, OpsMixin):
 
         Examples
         --------
-        >>> df = pd.DataFrame({'ID': ['XYZ', 'ABC'],
-            'Department': ['HR', 'Admin'],
-            'Job Title': ['Title1', 'Title2']})
-        >>> print(df.to_html())
-        <table border="1" class="dataframe">
-        <thead>
-            <tr style="text-align: right;">
-            <th></th>
-            <th>ID</th>
-            <th>Department</th>
-            <th>Job Title</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-            <th>0</th>
-            <td>XYZ</td>
-            <td>HR</td>
-            <td>Title1</td>
-            </tr>
-            <tr>
-            <th>1</th>
-            <td>ABC</td>
-            <td>Admin</td>
-            <td>Title2</td>
-            </tr>
-        </tbody>
-        </table>
-
+        >>> df = pd.DataFrame(data={'col1': [1, 2], 'col2': [4, 3]})
+        >>> html_string = '''<table border="1" class="dataframe">
+        ...   <thead>
+        ...     <tr style="text-align: right;">
+        ...       <th></th>
+        ...       <th>col1</th>
+        ...       <th>col2</th>
+        ...     </tr>
+        ...   </thead>
+        ...   <tbody>
+        ...     <tr>
+        ...       <th>0</th>
+        ...       <td>1</td>
+        ...       <td>4</td>
+        ...     </tr>
+        ...     <tr>
+        ...       <th>1</th>
+        ...       <td>2</td>
+        ...       <td>3</td>
+        ...     </tr>
+        ...   </tbody>
+        ... </table>'''
+        >>> assert html_string == df.to_html()
         """
         if justify is not None and justify not in fmt._VALID_JUSTIFY_PARAMETERS:
             raise ValueError("Invalid value for justify parameter")

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3133,8 +3133,35 @@ class DataFrame(NDFrame, OpsMixin):
 
         Examples
         --------
-        >>> df = pd.DataFrame([[1, 2], [3, 4]], columns=['A', 'B'])
-        >>> df.to_html()  # doctest: +SKIP
+        >>> df = pd.DataFrame({'ID': ['XYZ', 'ABC'],
+            'Department': ['HR', 'Admin'],
+            'Job Title': ['Title1', 'Title2']})
+        >>> print(df.to_html())
+        <table border="1" class="dataframe">
+        <thead>
+            <tr style="text-align: right;">
+            <th></th>
+            <th>ID</th>
+            <th>Department</th>
+            <th>Job Title</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+            <th>0</th>
+            <td>XYZ</td>
+            <td>HR</td>
+            <td>Title1</td>
+            </tr>
+            <tr>
+            <th>1</th>
+            <td>ABC</td>
+            <td>Admin</td>
+            <td>Title2</td>
+            </tr>
+        </tbody>
+        </table>
+
         """
         if justify is not None and justify not in fmt._VALID_JUSTIFY_PARAMETERS:
             raise ValueError("Invalid value for justify parameter")


### PR DESCRIPTION
- [x] closes DOC: Example missing in pandas.DataFrame.to_html #44945
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Uses the suggestion in the issue report as an example.

@noatamir  @phofl  SciPy 2023 sprint
