### PR TITLE
CLN/ASV: reduce size of join_merge.JoinIndex

### DIFF
--- a/asv_bench/benchmarks/join_merge.py
+++ b/asv_bench/benchmarks/join_merge.py
@@ -171,12 +171,12 @@ class Join:
 
 class JoinIndex:
     def setup(self):
-        N = 50000
+        N = 5000
         self.left = DataFrame(
-            np.random.randint(1, N / 500, (N, 2)), columns=["jim", "joe"]
+            np.random.randint(1, N / 50, (N, 2)), columns=["jim", "joe"]
         )
         self.right = DataFrame(
-            np.random.randint(1, N / 500, (N, 2)), columns=["jolie", "jolia"]
+            np.random.randint(1, N / 50, (N, 2)), columns=["jolie", "jolia"]
         ).set_index("jolie")
 
     def time_left_outer_join_index(self):


### PR DESCRIPTION
The existing `join_merge.JoinIndex.time_left_outer_join_index` ASV joins two frames with indexes containing lots of duplicates resulting in a large result (~25m rows). This is resulting in long (and inconsistent?) run times (700-3000 ms):

<img width="304" alt="Screen Shot 2023-07-16 at 12 36 34 PM" src="https://github.com/pandas-dev/pandas/assets/8519523/fd0fbd49-581b-4680-978c-3fb71a7b1560">

This PR reduces the size of the frames being joined such that the result is ~250,000 rows and the runtime is < 20ms. 
