### PR TITLE
DOC: Fixing EX01 - Added examples

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -66,9 +66,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.Series.backfill \
         pandas.Series.pad \
         pandas.Series.hist \
-        pandas.errors.AccessorRegistrationWarning \
-        pandas.errors.AttributeConflictWarning \
-        pandas.errors.DataError \
         pandas.errors.IncompatibilityWarning \
         pandas.errors.InvalidComparison \
         pandas.errors.IntCastingNaNError \

--- a/doc/source/reference/testing.rst
+++ b/doc/source/reference/testing.rst
@@ -25,7 +25,6 @@ Exceptions and warnings
    :toctree: api/
 
    errors.AbstractMethodError
-   errors.AccessorRegistrationWarning
    errors.AttributeConflictWarning
    errors.CategoricalConversionWarning
    errors.ChainedAssignmentError

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -184,12 +184,6 @@ class MergeError(ValueError):
     """
 
 
-class AccessorRegistrationWarning(Warning):
-    """
-    Warning for attribute conflicts in accessor registration.
-    """
-
-
 class AbstractMethodError(NotImplementedError):
     """
     Raise this error instead of NotImplementedError for abstract methods.
@@ -281,6 +275,13 @@ class DataError(Exception):
 
     For example, calling ``ohlc`` on a non-numerical column or a function
     on a rolling window.
+
+    Examples
+    --------
+    >>> ser = pd.Series(['a', 'b', 'c'])
+    >>> ser.rolling(2).sum()
+    Traceback (most recent call last):
+    DataError: No numeric types to aggregate
     """
 
 
@@ -552,6 +553,17 @@ class AttributeConflictWarning(Warning):
     Occurs when attempting to append an index with a different
     name than the existing index on an HDFStore or attempting to append an index with a
     different frequency than the existing index on an HDFStore.
+
+    Examples
+    --------
+    >>> idx1 = pd.Index(['a', 'b'], name='name1')
+    >>> df1 = pd.DataFrame([[1, 2], [3, 4]], index=idx1)
+    >>> df1.to_hdf('file', 'data', 'w', append=True)  # doctest: +SKIP
+    >>> idx2 = pd.Index(['c', 'd'], name='name2')
+    >>> df2 = pd.DataFrame([[5, 6], [7, 8]], index=idx2)
+    >>> df2.to_hdf('file', 'data', 'a', append=True)  # doctest: +SKIP
+    AttributeConflictWarning: the [index_name] attribute of the existing index is
+    [name1] which conflicts with the new [name2]...
     """
 
 
@@ -644,7 +656,6 @@ class InvalidComparison(Exception):
 
 __all__ = [
     "AbstractMethodError",
-    "AccessorRegistrationWarning",
     "AttributeConflictWarning",
     "CategoricalConversionWarning",
     "ClosedFileError",


### PR DESCRIPTION
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Towards https://github.com/pandas-dev/pandas/issues/37875

Note: `pandas.errors.AccessorRegistrationWarning` definition was supposed to be removed.
The warning was [removed](https://github.com/pandas-dev/pandas/pull/18827/commits/a308a2e29286c03c71e3566a881629d996b4821c) but definition left.
(Explanation courtesy of @MarcoGorelli)