### PR TITLE
ENH: `ewm()` default to using DatetimeIndex as `times` when `halflife` is a timedelta

### DIFF
--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -367,7 +367,7 @@ class ExponentialMovingWindow(BaseWindow):
             and isinstance(self.halflife, (str, datetime.timedelta, np.timedelta64))
             and isinstance(self.obj.index, DatetimeIndex)
         ):
-            self.times = self.obj.index
+            self.times = self.obj.index.values
         if self.times is not None:
             if not self.adjust:
                 raise NotImplementedError("times is not supported with adjust=False.")


### PR DESCRIPTION
Allow `ewm()` to use a DatetimeIndex as the `times` parameter if it isn't provided and `halflife` is a timedelta convertible.

Before:
```
>>> now = pd.Timestamp.now()
>>> idx = [now + pd.Timedelta(seconds=i) for i in range(1, 4)]
>>> df = pd.DataFrame({'a': [1,2,3]}, index=idx)
>>> df.ewm(halflife=pd.Timedelta(seconds=1)).mean()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/gsiano/.local/lib/python3.10/site-packages/pandas/core/generic.py", line 11743, in ewm
    return ExponentialMovingWindow(
  File "/home/gsiano/.local/lib/python3.10/site-packages/pandas/core/window/ewm.py", line 386, in __init__
    raise ValueError(
ValueError: halflife can only be a timedelta convertible argument if times is not None.
>>> df.ewm(halflife=pd.Timedelta(seconds=1), times=df.index).mean()
                                   a
2023-07-18 10:45:18.007264  1.000000
2023-07-18 10:45:19.007264  1.666667
2023-07-18 10:45:20.007264  2.428571
>>> 
```

After:
```
>>> now = pd.Timestamp.now()
>>> idx = [now + pd.Timedelta(seconds=i) for i in range(1, 4)]
>>> df = pd.DataFrame({'a': [1,2,3]}, index=idx)
>>> df.ewm(halflife=pd.Timedelta(seconds=1)).mean()
                                   a
2023-07-18 10:46:46.589891  1.000000
2023-07-18 10:46:47.589891  1.666667
2023-07-18 10:46:48.589891  2.428571
```

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
