### PR TITLE
TST: add test with freq=2M to increase coverage asfreq

### DIFF
--- a/pandas/tests/indexes/period/methods/test_asfreq.py
+++ b/pandas/tests/indexes/period/methods/test_asfreq.py
@@ -130,7 +130,7 @@ class TestPeriodIndex:
         tm.assert_index_equal(pi1.asfreq("3M"), exp)
         tm.assert_index_equal(pi1.astype("period[3M]"), exp)
 
-    def test_asfreq_with_periodindex(self):
+    def test_asfreq_with_different_n(self):
         ser = Series([1, 2], index=PeriodIndex(["2020-01", "2020-03"], freq="2M"))
         result = ser.asfreq("M")
 

--- a/pandas/tests/indexes/period/methods/test_asfreq.py
+++ b/pandas/tests/indexes/period/methods/test_asfreq.py
@@ -2,6 +2,7 @@ import pytest
 
 from pandas import (
     PeriodIndex,
+    Series,
     period_range,
 )
 import pandas._testing as tm
@@ -128,3 +129,10 @@ class TestPeriodIndex:
         exp = PeriodIndex(["2011-01", "2011-02", "2011-03"], freq="3M")
         tm.assert_index_equal(pi1.asfreq("3M"), exp)
         tm.assert_index_equal(pi1.astype("period[3M]"), exp)
+
+    def test_asfreq_with_periodindex(self):
+        ser = Series([1, 2], index=PeriodIndex(["2020-01", "2020-03"], freq="2M"))
+        result = ser.asfreq("M")
+
+        excepted = Series([1, 2], index=PeriodIndex(["2020-02", "2020-04"], freq="M"))
+        tm.assert_series_equal(result, excepted)


### PR DESCRIPTION
xref #52064

Added a test in which a Series has a PeriodIndex with `freq=2M` to increase coverage `asfreq`. 
The reason: existing tests don't cover a case if the index of a Series is a PeriodIndex with `freq=2M`, then asfreq converts time series to a new one with the frequency `freq=M`.