### PR TITLE
BUG: PeriodDtype and IntervalDtype holding references to itself when object is deleted

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -493,7 +493,7 @@ Strings
 Interval
 ^^^^^^^^
 - :meth:`pd.IntervalIndex.get_indexer` and :meth:`pd.IntervalIndex.get_indexer_nonunique` raising if ``target`` is read-only array (:issue:`53703`)
-- Bug in :class:`IntervalDtype` where the object could be kept alive when deleted (:issue:`?`)
+- Bug in :class:`IntervalDtype` where the object could be kept alive when deleted (:issue:`54184`)
 
 Indexing
 ^^^^^^^^
@@ -536,12 +536,12 @@ Period
 - Bug in :class:`PeriodDtype` constructor failing to raise ``TypeError`` when no argument is passed or when ``None`` is passed (:issue:`27388`)
 - Bug in :class:`PeriodDtype` constructor incorrectly returning the same ``normalize`` for different :class:`DateOffset` ``freq`` inputs (:issue:`24121`)
 - Bug in :class:`PeriodDtype` constructor raising ``ValueError`` instead of ``TypeError`` when an invalid type is passed (:issue:`51790`)
+- Bug in :class:`PeriodDtype` where the object could be kept alive when deleted (:issue:`54184`)
 - Bug in :func:`read_csv` not processing empty strings as a null value, with ``engine="pyarrow"`` (:issue:`52087`)
 - Bug in :func:`read_csv` returning ``object`` dtype columns instead of ``float64`` dtype columns with ``engine="pyarrow"`` for columns that are all null with ``engine="pyarrow"`` (:issue:`52087`)
 - Bug in :meth:`Period.now` not accepting the ``freq`` parameter as a keyword argument (:issue:`53369`)
 - Bug in :meth:`arrays.PeriodArray.map` and :meth:`PeriodIndex.map`, where the supplied callable operated array-wise instead of element-wise (:issue:`51977`)
 - Bug in incorrectly allowing construction of :class:`Period` or :class:`PeriodDtype` with :class:`CustomBusinessDay` freq; use :class:`BusinessDay` instead (:issue:`52534`)
-- Bug in :class:`PeriodDtype` where the object could be kept alive when deleted (:issue:`?`)
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -493,7 +493,7 @@ Strings
 Interval
 ^^^^^^^^
 - :meth:`pd.IntervalIndex.get_indexer` and :meth:`pd.IntervalIndex.get_indexer_nonunique` raising if ``target`` is read-only array (:issue:`53703`)
--
+- Bug in :class:`IntervalDtype` where the object could be kept alive when deleted (:issue:`?`)
 
 Indexing
 ^^^^^^^^
@@ -541,6 +541,7 @@ Period
 - Bug in :meth:`Period.now` not accepting the ``freq`` parameter as a keyword argument (:issue:`53369`)
 - Bug in :meth:`arrays.PeriodArray.map` and :meth:`PeriodIndex.map`, where the supplied callable operated array-wise instead of element-wise (:issue:`51977`)
 - Bug in incorrectly allowing construction of :class:`Period` or :class:`PeriodDtype` with :class:`CustomBusinessDay` freq; use :class:`BusinessDay` instead (:issue:`52534`)
+- Bug in :class:`PeriodDtype` where the object could be kept alive when deleted (:issue:`?`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -1154,6 +1154,8 @@ class IntervalDtype(PandasExtensionDtype):
     )
 
     _cache_dtypes: dict[str_type, PandasExtensionDtype] = {}
+    _subtype: None | np.dtype
+    _closed: IntervalClosedType | None
 
     def __init__(self, subtype=None, closed: IntervalClosedType | None = None) -> None:
         from pandas.core.dtypes.common import (
@@ -1223,7 +1225,7 @@ class IntervalDtype(PandasExtensionDtype):
 
     @property
     def closed(self) -> IntervalClosedType:
-        return self._closed
+        return self._closed  # type: ignore[return-value]
 
     @property
     def subtype(self):

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -1155,7 +1155,7 @@ class IntervalDtype(PandasExtensionDtype):
 
     _cache_dtypes: dict[str_type, PandasExtensionDtype] = {}
 
-    def __init__(self, subtype=None, closed: IntervalClosedType | None = None):
+    def __init__(self, subtype=None, closed: IntervalClosedType | None = None) -> None:
         from pandas.core.dtypes.common import (
             is_string_dtype,
             pandas_dtype,

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -1197,17 +1197,17 @@ class IntervalDtype(PandasExtensionDtype):
 
             try:
                 subtype = pandas_dtype(subtype)
-                if CategoricalDtype.is_dtype(subtype) or is_string_dtype(subtype):
-                    # GH 19016
-                    msg = (
-                        "category, object, and string subtypes are not supported "
-                        "for IntervalDtype"
-                    )
-                    raise TypeError(msg)
-                self._subtype = subtype
-                self._closed = closed
             except TypeError as err:
                 raise TypeError("could not construct IntervalDtype") from err
+            if CategoricalDtype.is_dtype(subtype) or is_string_dtype(subtype):
+                # GH 19016
+                msg = (
+                    "category, object, and string subtypes are not supported "
+                    "for IntervalDtype"
+                )
+                raise TypeError(msg)
+            self._subtype = subtype
+            self._closed = closed
 
     @cache_readonly
     def _can_hold_na(self) -> bool:

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -100,7 +100,7 @@ class TestNumpyEADtype:
         ],
     )
     def test_period_dtype(self, dtype):
-        assert com.pandas_dtype(dtype) is PeriodDtype(dtype)
+        assert com.pandas_dtype(dtype) is not PeriodDtype(dtype)
         assert com.pandas_dtype(dtype) == PeriodDtype(dtype)
         assert com.pandas_dtype(dtype) == dtype
 

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -567,6 +567,7 @@ class TestPeriodDtype(Base):
         assert not per_d2.freq.normalize
 
     def test_dont_keep_ref_after_del(self):
+        # GH 54184
         dtype = PeriodDtype("D")
         ref = weakref.ref(dtype)
         del dtype
@@ -840,6 +841,7 @@ class TestIntervalDtype(Base):
             assert not is_interval_dtype(np.float64)
 
     def test_caching(self):
+        # GH 54184: Caching not shown to improve performance
         IntervalDtype.reset_cache()
         dtype = IntervalDtype("int64", "right")
         assert len(IntervalDtype._cache_dtypes) == 0
@@ -864,6 +866,7 @@ class TestIntervalDtype(Base):
         tm.round_trip_pickle(dtype)
 
     def test_dont_keep_ref_after_del(self):
+        # GH 54184
         dtype = IntervalDtype("int64", "right")
         ref = weakref.ref(dtype)
         del dtype

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -1,4 +1,5 @@
 import re
+import weakref
 
 import numpy as np
 import pytest
@@ -412,9 +413,9 @@ class TestPeriodDtype(Base):
         assert dtype == dtype2
         assert dtype2 == dtype
         assert dtype3 == dtype
-        assert dtype is dtype2
-        assert dtype2 is dtype
-        assert dtype3 is dtype
+        assert dtype is not dtype2
+        assert dtype2 is not dtype
+        assert dtype3 is not dtype
         assert hash(dtype) == hash(dtype2)
         assert hash(dtype) == hash(dtype3)
 
@@ -458,13 +459,13 @@ class TestPeriodDtype(Base):
 
     def test_identity(self):
         assert PeriodDtype("period[D]") == PeriodDtype("period[D]")
-        assert PeriodDtype("period[D]") is PeriodDtype("period[D]")
+        assert PeriodDtype("period[D]") is not PeriodDtype("period[D]")
 
         assert PeriodDtype("period[3D]") == PeriodDtype("period[3D]")
-        assert PeriodDtype("period[3D]") is PeriodDtype("period[3D]")
+        assert PeriodDtype("period[3D]") is not PeriodDtype("period[3D]")
 
         assert PeriodDtype("period[1S1U]") == PeriodDtype("period[1000001U]")
-        assert PeriodDtype("period[1S1U]") is PeriodDtype("period[1000001U]")
+        assert PeriodDtype("period[1S1U]") is not PeriodDtype("period[1000001U]")
 
     def test_compat(self, dtype):
         assert not is_datetime64_ns_dtype(dtype)
@@ -565,6 +566,12 @@ class TestPeriodDtype(Base):
         per_d2 = PeriodDtype(pd.offsets.YearEnd(normalize=False))
         assert not per_d2.freq.normalize
 
+    def test_dont_keep_ref_after_del(self):
+        dtype = PeriodDtype("D")
+        ref = weakref.ref(dtype)
+        del dtype
+        assert ref() is None
+
 
 class TestIntervalDtype(Base):
     @pytest.fixture
@@ -581,9 +588,9 @@ class TestIntervalDtype(Base):
         assert dtype == dtype2
         assert dtype2 == dtype
         assert dtype3 == dtype
-        assert dtype is dtype2
-        assert dtype2 is dtype3
-        assert dtype3 is dtype
+        assert dtype is not dtype2
+        assert dtype2 is not dtype3
+        assert dtype3 is not dtype
         assert hash(dtype) == hash(dtype2)
         assert hash(dtype) == hash(dtype3)
 
@@ -593,9 +600,9 @@ class TestIntervalDtype(Base):
         assert dtype2 == dtype1
         assert dtype2 == dtype2
         assert dtype2 == dtype3
-        assert dtype2 is dtype1
+        assert dtype2 is not dtype1
         assert dtype2 is dtype2
-        assert dtype2 is dtype3
+        assert dtype2 is not dtype3
         assert hash(dtype2) == hash(dtype1)
         assert hash(dtype2) == hash(dtype2)
         assert hash(dtype2) == hash(dtype3)
@@ -835,10 +842,10 @@ class TestIntervalDtype(Base):
     def test_caching(self):
         IntervalDtype.reset_cache()
         dtype = IntervalDtype("int64", "right")
-        assert len(IntervalDtype._cache_dtypes) == 1
+        assert len(IntervalDtype._cache_dtypes) == 0
 
         IntervalDtype("interval")
-        assert len(IntervalDtype._cache_dtypes) == 2
+        assert len(IntervalDtype._cache_dtypes) == 0
 
         IntervalDtype.reset_cache()
         tm.round_trip_pickle(dtype)
@@ -855,6 +862,12 @@ class TestIntervalDtype(Base):
         assert dtype._closed is None
 
         tm.round_trip_pickle(dtype)
+
+    def test_dont_keep_ref_after_del(self):
+        dtype = IntervalDtype("int64", "right")
+        ref = weakref.ref(dtype)
+        del dtype
+        assert ref() is None
 
 
 class TestCategoricalDtypeParametrized:


### PR DESCRIPTION
Fixes this issue

```
In [1]: import pandas as pd

In [2]: import weakref

In [3]: pdt = pd.PeriodDtype(freq="D")

In [4]: ref = weakref.ref(pdt)

In [5]: del pdt

In [6]: import gc; gc.collect()
Out[6]: 1119

In [7]: ref()
Out[7]: period[D]

In [8]: idt = pd.IntervalDtype("interval[int64, right]")

In [9]: ref2 = weakref.ref(idt)

In [10]: del idt

In [11]: import gc; gc.collect()
Out[11]: 615

In [12]: ref2()
Out[12]: interval[int64, right]
```

1. For `IntervalDtype` the cache didn't really seem to improve performance now it's not used
2. For `PeriodDtype` just caching the period freq code instead of the created object

```
# PR

In [2]: %timeit pd.IntervalDtype("interval[int64, right]")
11.1 µs ± 13 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [3]: %timeit pd.PeriodDtype(freq="D")
22.2 µs ± 135 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

# main

In [2]: idt = pd.IntervalDtype("interval[int64, right]")

In [3]: %timeit pd.IntervalDtype("interval[int64, right]")
14 µs ± 28.6 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [4]: pdt = pd.PeriodDtype(freq="D")

In [5]: %timeit pd.PeriodDtype(freq="D")
22.2 µs ± 182 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```