### PR TITLE
Fix deprecation warning on Python 3.12

### DIFF
--- a/pandas/core/computation/expr.py
+++ b/pandas/core/computation/expr.py
@@ -550,7 +550,7 @@ class BaseExprVisitor(ast.NodeVisitor):
         return self.const_type(node.n, self.env)
 
     def visit_Constant(self, node, **kwargs) -> Term:
-        return self.const_type(node.n, self.env)
+        return self.const_type(node.value, self.env)
 
     def visit_Str(self, node, **kwargs):
         name = self.env.add_tmp(node.s)


### PR DESCRIPTION
`Constant.n` is now deprecated for removal in 3.14; it appears that `Constant.value` has existed since at least 3.9.

- [n/a] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [n/a] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
