### PR TITLE
Fix UserWarning in DataFrame.plot.scatter when invoked with c="b"

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -547,6 +547,7 @@ Period
 Plotting
 ^^^^^^^^
 - Bug in :meth:`Series.plot` when invoked with ``color=None`` (:issue:`51953`)
+- Fixed UserWarning in :meth:`DataFrame.plot.scatter` when invoked with ``c="b"`` (:issue:`53908`)
 -
 
 Groupby/resample/rolling

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -1235,11 +1235,12 @@ class ScatterPlot(PlanePlot):
 
         if self.colormap is not None:
             cmap = mpl.colormaps.get_cmap(self.colormap)
-        # cmap is only used if c_values are integers, otherwise UserWarning
-        elif is_integer_dtype(c_values):
+        # cmap is only used if c_values are integers, otherwise UserWarning.
+        # GH-53908: additionally call isinstance() because is_integer_dtype
+        # returns True for "b" (meaning "blue" and not int8 in this context)
+        elif not isinstance(c_values, str) and is_integer_dtype(c_values):
             # pandas uses colormap, matplotlib uses cmap.
-            cmap = "Greys"
-            cmap = mpl.colormaps[cmap]
+            cmap = mpl.colormaps["Greys"]
         else:
             cmap = None
 

--- a/pandas/tests/plotting/frame/test_frame_color.py
+++ b/pandas/tests/plotting/frame/test_frame_color.py
@@ -216,7 +216,8 @@ class TestDataFrameColor:
         # GH-53908. Do not raise UserWarning: No data for colormapping
         # provided via 'c'. Parameters 'cmap' will be ignored
         df = DataFrame({"x": [1, 2, 3], "y": [1, 2, 3]})
-        df.plot.scatter(x="x", y="y", c="b")
+        with tm.assert_produces_warning(None):
+            df.plot.scatter(x="x", y="y", c="b")
 
     def test_scatter_colors_default(self):
         df = DataFrame({"a": [1, 2, 3], "b": [1, 2, 3], "c": [1, 2, 3]})

--- a/pandas/tests/plotting/frame/test_frame_color.py
+++ b/pandas/tests/plotting/frame/test_frame_color.py
@@ -212,6 +212,12 @@ class TestDataFrameColor:
         with pytest.raises(TypeError, match="Specify exactly one of `c` and `color`"):
             df.plot.scatter(x="a", y="b", c="c", color="green")
 
+    def test_scatter_colors_not_raising_warnings(self):
+        # GH-53908. Do not raise UserWarning: No data for colormapping
+        # provided via 'c'. Parameters 'cmap' will be ignored
+        df = DataFrame({"x": [1, 2, 3], "y": [1, 2, 3]})
+        df.plot.scatter(x="x", y="y", c="b")
+
     def test_scatter_colors_default(self):
         df = DataFrame({"a": [1, 2, 3], "b": [1, 2, 3], "c": [1, 2, 3]})
         default_colors = _unpack_cycler(mpl.pyplot.rcParams)


### PR DESCRIPTION
- [x] closes #53908
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
