### PR TITLE
TST: add a test with freq=1MS to increase coverage of shift

### DIFF
--- a/pandas/tests/frame/methods/test_shift.py
+++ b/pandas/tests/frame/methods/test_shift.py
@@ -656,3 +656,12 @@ class TestDataFrameShift:
 
         shifted2 = df.shift(-6, axis=1, fill_value=None)
         tm.assert_frame_equal(shifted2, expected)
+
+    def test_shift_with_offsets_freq(self):
+        df = DataFrame({"x": [1, 2, 3]}, index=date_range("2000", periods=3))
+        shifted = df.shift(freq="1MS")
+        expected = DataFrame(
+            {"x": [1, 2, 3]},
+            index=date_range(start="02/01/2000", end="02/01/2000", periods=3),
+        )
+        tm.assert_frame_equal(shifted, expected)


### PR DESCRIPTION
xref #52064

Added a test with `freq=1MS` to increase coverage of `shift`. The reason: existing tests don't cover a case if the index of a DataFrame is a `DatetimeIndex`.