### PR TITLE
PERF: ArrowDtype.__eq__

### DIFF
--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -2113,12 +2113,6 @@ class ArrowDtype(StorageExtensionDtype):
         """
         A string identifying the data type.
         """
-        # try:
-        #     return self._cache_dtype_names[self.pyarrow_dtype]
-        # except KeyError:
-        #     name = f"{str(self.pyarrow_dtype)}[{self.storage}]"
-        #     self._cache_dtype_names[self.pyarrow_dtype] = name
-        #     return name
         return f"{str(self.pyarrow_dtype)}[{self.storage}]"
 
     @cache_readonly

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -2046,6 +2046,15 @@ class ArrowDtype(StorageExtensionDtype):
     def __repr__(self) -> str:
         return self.name
 
+    def __hash__(self) -> int:
+        # make myself hashable
+        return hash(str(self))
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, type(self)):
+            return super().__eq__(other)
+        return self.pyarrow_dtype == other.pyarrow_dtype
+
     @property
     def type(self):
         """
@@ -2104,6 +2113,12 @@ class ArrowDtype(StorageExtensionDtype):
         """
         A string identifying the data type.
         """
+        # try:
+        #     return self._cache_dtype_names[self.pyarrow_dtype]
+        # except KeyError:
+        #     name = f"{str(self.pyarrow_dtype)}[{self.storage}]"
+        #     self._cache_dtype_names[self.pyarrow_dtype] = name
+        #     return name
         return f"{str(self.pyarrow_dtype)}[{self.storage}]"
 
     @cache_readonly


### PR DESCRIPTION
Micro-perf improvement:

```
import pandas as pd
import pyarrow as pa

a = pd.ArrowDtype(pa.float64())
b = pd.ArrowDtype(pa.float64())

%timeit a == b

# 2.86 µs ± 214 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)   -> main
# 473 ns ± 15.2 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each) -> PR
```
