### PR TITLE
TST: add a test on mixed offsets for read_csv

### DIFF
--- a/pandas/tests/frame/methods/test_to_csv.py
+++ b/pandas/tests/frame/methods/test_to_csv.py
@@ -1310,16 +1310,3 @@ class TestDataFrameToCSV:
         expected_rows = [",a", '0,"[2020-01-01, 2020-01-02]"']
         expected = tm.convert_rows_list_to_csv_str(expected_rows)
         assert result == expected
-
-    def test_from_csv_with_mixed_offsets(self):
-        content = "a\n2020-01-01T00:00:00+01:00\n2020-01-01T00:00:00+00:00"
-        result = read_csv(StringIO(content), parse_dates=["a"])["a"]
-        expected = Series(
-            [
-                Timestamp("2020-01-01 00:00:00+01:00"),
-                Timestamp("2020-01-01 00:00:00+00:00"),
-            ],
-            name="a",
-            index=[0, 1],
-        )
-        tm.assert_series_equal(result, expected)

--- a/pandas/tests/frame/methods/test_to_csv.py
+++ b/pandas/tests/frame/methods/test_to_csv.py
@@ -1310,3 +1310,16 @@ class TestDataFrameToCSV:
         expected_rows = [",a", '0,"[2020-01-01, 2020-01-02]"']
         expected = tm.convert_rows_list_to_csv_str(expected_rows)
         assert result == expected
+
+    def test_from_csv_with_mixed_offsets(self):
+        content = "a\n2020-01-01T00:00:00+01:00\n2020-01-01T00:00:00+00:00"
+        result = read_csv(StringIO(content), parse_dates=["a"])["a"]
+        expected = Series(
+            [
+                Timestamp("2020-01-01 00:00:00+01:00"),
+                Timestamp("2020-01-01 00:00:00+00:00"),
+            ],
+            name="a",
+            index=[0, 1],
+        )
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -2239,9 +2239,11 @@ def test_parse_dates_arrow_engine(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-def test_from_csv_with_mixed_offsets():
-    content = "a\n2020-01-01T00:00:00+01:00\n2020-01-01T00:00:00+00:00"
-    result = read_csv(StringIO(content), parse_dates=["a"])["a"]
+@xfail_pyarrow
+def test_from_csv_with_mixed_offsets(all_parsers):
+    parser = all_parsers
+    data = "a\n2020-01-01T00:00:00+01:00\n2020-01-01T00:00:00+00:00"
+    result = parser.read_csv(StringIO(data), parse_dates=["a"])["a"]
     expected = Series(
         [
             Timestamp("2020-01-01 00:00:00+01:00"),

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -2237,3 +2237,17 @@ def test_parse_dates_arrow_engine(all_parsers):
         }
     )
     tm.assert_frame_equal(result, expected)
+
+
+def test_from_csv_with_mixed_offsets():
+    content = "a\n2020-01-01T00:00:00+01:00\n2020-01-01T00:00:00+00:00"
+    result = read_csv(StringIO(content), parse_dates=["a"])["a"]
+    expected = Series(
+        [
+            Timestamp("2020-01-01 00:00:00+01:00"),
+            Timestamp("2020-01-01 00:00:00+00:00"),
+        ],
+        name="a",
+        index=[0, 1],
+    )
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
xref #54014

added a test on mixed offsets to increase coverage for `read_csv`