### PR TITLE
ENH: Support ffill/bfill on IntervalArray

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -132,7 +132,7 @@ to ``na_action=None``, like for all the other array types.
 
 Other enhancements
 ^^^^^^^^^^^^^^^^^^
-- :meth:`Series.ffill` and :meth:`Series.bfill` are now supported for objects with :class:`IntervalDtype` (:issue:`??`)
+- :meth:`Series.ffill` and :meth:`Series.bfill` are now supported for objects with :class:`IntervalDtype` (:issue:`54247`)
 - :meth:`Categorical.map` and :meth:`CategoricalIndex.map` now have a ``na_action`` parameter.
   :meth:`Categorical.map` implicitly had a default value of ``"ignore"`` for ``na_action``. This has formally been deprecated and will be changed to ``None`` in the future.
   Also notice that :meth:`Series.map` has default ``na_action=None`` and calls to series with categorical data will now use ``na_action=None`` unless explicitly set otherwise (:issue:`44279`)

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -132,6 +132,7 @@ to ``na_action=None``, like for all the other array types.
 
 Other enhancements
 ^^^^^^^^^^^^^^^^^^
+- :meth:`Series.ffill` and :meth:`Series.bfill` are now supported for objects with :class:`IntervalDtype` (:issue:`??`)
 - :meth:`Categorical.map` and :meth:`CategoricalIndex.map` now have a ``na_action`` parameter.
   :meth:`Categorical.map` implicitly had a default value of ``"ignore"`` for ``na_action``. This has formally been deprecated and will be changed to ``None`` in the future.
   Also notice that :meth:`Series.map` has default ``na_action=None`` and calls to series with categorical data will now use ``na_action=None`` unless explicitly set otherwise (:issue:`44279`)

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -917,9 +917,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         filled : IntervalArray with NA/NaN filled
         """
         if method is not None:
-            raise TypeError("Filling by method is not supported for IntervalArray.")
-        if limit is not None:
-            raise TypeError("limit is not supported for IntervalArray.")
+            return super().fillna(value=value, method=method, limit=limit)
 
         value_left, value_right = self._validate_scalar(value)
 

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -78,7 +78,6 @@ from pandas.core.indexers import (
     check_array_indexer,
     unpack_tuple_and_ellipses,
 )
-from pandas.core.missing import pad_or_backfill_inplace
 from pandas.core.nanops import check_below_min_count
 
 from pandas.io.formats import printing
@@ -757,21 +756,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
             raise ValueError("Must specify one of 'method' or 'value'.")
 
         if method is not None:
-            msg = "fillna with 'method' requires high memory usage."
-            warnings.warn(
-                msg,
-                PerformanceWarning,
-                stacklevel=find_stack_level(),
-            )
-            new_values = np.asarray(self)
-            # pad_or_backfill_inplace modifies new_values inplace
-            # error: Argument "method" to "pad_or_backfill_inplace" has incompatible
-            # type "Literal['backfill', 'bfill', 'ffill', 'pad']"; expected
-            # "Literal['pad', 'backfill']"
-            pad_or_backfill_inplace(
-                new_values, method=method, limit=limit  # type: ignore[arg-type]
-            )
-            return type(self)(new_values, fill_value=self.fill_value)
+            return super().fillna(method=method, limit=limit)
 
         else:
             new_values = np.where(isna(self.sp_values), value, self.sp_values)

--- a/pandas/tests/extension/test_interval.py
+++ b/pandas/tests/extension/test_interval.py
@@ -134,32 +134,6 @@ class TestMethods(BaseInterval, base.BaseMethodsTests):
 
 
 class TestMissing(BaseInterval, base.BaseMissingTests):
-    # Index.fillna only accepts scalar `value`, so we have to xfail all
-    # non-scalar fill tests.
-    unsupported_fill = pytest.mark.xfail(
-        reason="Unsupported fillna option for Interval."
-    )
-
-    @unsupported_fill
-    def test_fillna_limit_pad(self):
-        super().test_fillna_limit_pad()
-
-    @unsupported_fill
-    def test_fillna_series_method(self):
-        super().test_fillna_series_method()
-
-    @unsupported_fill
-    def test_fillna_limit_backfill(self):
-        super().test_fillna_limit_backfill()
-
-    @unsupported_fill
-    def test_fillna_no_op_returns_copy(self):
-        super().test_fillna_no_op_returns_copy()
-
-    @unsupported_fill
-    def test_fillna_series(self):
-        super().test_fillna_series()
-
     def test_fillna_non_scalar_raises(self, data_missing):
         msg = "can only insert Interval objects and NA into an IntervalArray"
         with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -223,11 +223,6 @@ class TestMissing(BaseSparseTests, base.BaseMissingTests):
         expected = SparseArray([False, False], fill_value=False, dtype=expected_dtype)
         self.assert_equal(sarr.isna(), expected)
 
-    def test_fillna_limit_pad(self, data_missing):
-        warns = (PerformanceWarning, FutureWarning)
-        with tm.assert_produces_warning(warns, check_stacklevel=False):
-            super().test_fillna_limit_pad(data_missing)
-
     def test_fillna_limit_backfill(self, data_missing):
         warns = (PerformanceWarning, FutureWarning)
         with tm.assert_produces_warning(warns, check_stacklevel=False):
@@ -238,12 +233,7 @@ class TestMissing(BaseSparseTests, base.BaseMissingTests):
             request.node.add_marker(
                 pytest.mark.xfail(reason="returns array with different fill value")
             )
-        with tm.assert_produces_warning(PerformanceWarning, check_stacklevel=False):
-            super().test_fillna_no_op_returns_copy(data)
-
-    def test_fillna_series_method(self, data_missing, fillna_method):
-        with tm.assert_produces_warning(PerformanceWarning, check_stacklevel=False):
-            super().test_fillna_series_method(data_missing, fillna_method)
+        super().test_fillna_no_op_returns_copy(data)
 
     @pytest.mark.xfail(reason="Unsupported")
     def test_fillna_series(self):


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Also avoids the need for a PerformanceWarning for SparseArray.