### PR TITLE
DOC: Fixing EX01 - Added examples

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -81,8 +81,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.util.hash_array \
         pandas.util.hash_pandas_object \
         pandas_object \
-        pandas.api.indexers.BaseIndexer \
-        pandas.api.indexers.VariableOffsetWindowIndexer \
         pandas.api.extensions.ExtensionDtype \
         pandas.api.extensions.ExtensionArray \
         pandas.arrays.NumpyExtensionArray \

--- a/pandas/core/indexers/objects.py
+++ b/pandas/core/indexers/objects.py
@@ -57,7 +57,7 @@ class BaseIndexer:
     ...         return start, end
     >>> df = pd.DataFrame({"values": range(5)})
     >>> indexer = CustomIndexer(window_size=2)
-    >>> df.rolling(indexer).sum()  # doctest: +SKIP
+    >>> df.rolling(indexer).sum()
         values
     0	1.0
     1	3.0

--- a/pandas/core/indexers/objects.py
+++ b/pandas/core/indexers/objects.py
@@ -41,17 +41,33 @@ window
 
 
 class BaseIndexer:
-    """Base class for window bounds calculations."""
+    """
+    Base class for window bounds calculations.
+
+    Examples
+    --------
+    >>> from pandas.api.indexers import BaseIndexer
+    >>> class CustomIndexer(BaseIndexer):
+    ...     def get_window_bounds(self, num_values, min_periods, center, closed, step):
+    ...         start = np.empty(num_values, dtype=np.int64)
+    ...         end = np.empty(num_values, dtype=np.int64)
+    ...         for i in range(num_values):
+    ...             end[i] = i + self.window_size
+    ...         return start, end
+    >>> df = pd.DataFrame({"values": range(5)})
+    >>> indexer = CustomIndexer(window_size=2)
+    >>> df.rolling(indexer).sum()  # doctest: +SKIP
+        values
+    0	1.0
+    1	3.0
+    2	5.0
+    3	7.0
+    4	4.0
+    """
 
     def __init__(
         self, index_array: np.ndarray | None = None, window_size: int = 0, **kwargs
     ) -> None:
-        """
-        Parameters
-        ----------
-        **kwargs :
-            keyword arguments that will be available when get_window_bounds is called
-        """
         self.index_array = index_array
         self.window_size = window_size
         # Set user defined kwargs as attributes that can be used in get_window_bounds
@@ -127,7 +143,40 @@ class VariableWindowIndexer(BaseIndexer):
 
 
 class VariableOffsetWindowIndexer(BaseIndexer):
-    """Calculate window boundaries based on a non-fixed offset such as a BusinessDay."""
+    """
+    Calculate window boundaries based on a non-fixed offset such as a BusinessDay.
+
+    Examples
+    --------
+    >>> from pandas.api.indexers import VariableOffsetWindowIndexer
+    >>> df = pd.DataFrame(range(10), index=pd.date_range("2020", periods=10))
+    >>> offset = pd.offsets.BDay(1)
+    >>> indexer = VariableOffsetWindowIndexer(index=df.index, offset=offset)
+    >>> df
+                0
+    2020-01-01  0
+    2020-01-02  1
+    2020-01-03  2
+    2020-01-04  3
+    2020-01-05  4
+    2020-01-06  5
+    2020-01-07  6
+    2020-01-08  7
+    2020-01-09  8
+    2020-01-10  9
+    >>> df.rolling(indexer).sum()
+                   0
+    2020-01-01   0.0
+    2020-01-02   1.0
+    2020-01-03   2.0
+    2020-01-04   3.0
+    2020-01-05   7.0
+    2020-01-06  12.0
+    2020-01-07   6.0
+    2020-01-08   7.0
+    2020-01-09   8.0
+    2020-01-10   9.0
+    """
 
     def __init__(
         self,

--- a/pandas/core/indexers/objects.py
+++ b/pandas/core/indexers/objects.py
@@ -52,6 +52,7 @@ class BaseIndexer:
     ...         start = np.empty(num_values, dtype=np.int64)
     ...         end = np.empty(num_values, dtype=np.int64)
     ...         for i in range(num_values):
+    ...             start[i] = i
     ...             end[i] = i + self.window_size
     ...         return start, end
     >>> df = pd.DataFrame({"values": range(5)})


### PR DESCRIPTION
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Towards https://github.com/pandas-dev/pandas/issues/37875

Notes:
On the web there are only 3 custom rolling windows: `BaseIndexer`, `FixedForwardWindowIndexer` and `VariableOffsetWindowIndexer`. But there are more of them in the [code](https://github.com/pandas-dev/pandas/blob/main/pandas/core/indexers/objects.py). Like `ExpandingIndexer` etc.. 

~~Added `# doctest: +SKIP` to the last line of `BaseIndexer` because `validate_docstrings.py` was complaining.~~

I need to do \preview here as I was having a lot of issues with the html file made with Sphinx.

I'll open a separate PR to correct the User Guide on `BaseIndexer`.
