### PR TITLE
TYP: Add typing.overload signatures to DataFrame.drop_duplicates.

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6383,6 +6383,39 @@ class DataFrame(NDFrame, OpsMixin):
         self._update_inplace(result)
         return None
 
+    @overload
+    def drop_duplicates(
+        self,
+        subset: Hashable | Sequence[Hashable] | None = ...,
+        *,
+        keep: DropKeep = ...,
+        inplace: Literal[True],
+        ignore_index: bool = ...,
+    ) -> None:
+      ...
+
+    @overload
+    def drop_duplicates(
+        self,
+        subset: Hashable | Sequence[Hashable] | None = ...,
+        *,
+        keep: DropKeep = ...,
+        inplace: Literal[False] = ...,
+        ignore_index: bool = ...,
+    ) -> DataFrame:
+      ...
+
+    @overload
+    def drop_duplicates(
+        self,
+        subset: Hashable | Sequence[Hashable] | None = ...,
+        *,
+        keep: DropKeep = ...,
+        inplace: bool = ...,
+        ignore_index: bool = ...,
+    ) -> DataFrame | None:
+      ...
+
     def drop_duplicates(
         self,
         subset: Hashable | Sequence[Hashable] | None = None,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6392,7 +6392,7 @@ class DataFrame(NDFrame, OpsMixin):
         inplace: Literal[True],
         ignore_index: bool = ...,
     ) -> None:
-      ...
+        ...
 
     @overload
     def drop_duplicates(
@@ -6403,7 +6403,7 @@ class DataFrame(NDFrame, OpsMixin):
         inplace: Literal[False] = ...,
         ignore_index: bool = ...,
     ) -> DataFrame:
-      ...
+        ...
 
     @overload
     def drop_duplicates(
@@ -6414,7 +6414,7 @@ class DataFrame(NDFrame, OpsMixin):
         inplace: bool = ...,
         ignore_index: bool = ...,
     ) -> DataFrame | None:
-      ...
+        ...
 
     def drop_duplicates(
         self,


### PR DESCRIPTION
This adds overloads so that a type checker can determine whether drop_duplicates returns DataFrame or None based on the value of the `inplace` argument.

The motivation for this is that we're using a type checker that looks at the pandas source code for type information. I realize that we should be using the stubs instead, but this will unblock us in the meantime and seems like an improvement to the type annotations anyway.