### PR TITLE
PERF: DataFrame reductions with axis=None and EA dtypes

### DIFF
--- a/asv_bench/benchmarks/stat_ops.py
+++ b/asv_bench/benchmarks/stat_ops.py
@@ -6,7 +6,7 @@ ops = ["mean", "sum", "median", "std", "skew", "kurt", "prod", "sem", "var"]
 
 
 class FrameOps:
-    params = [ops, ["float", "int", "Int64"], [0, 1]]
+    params = [ops, ["float", "int", "Int64"], [0, 1, None]]
     param_names = ["op", "dtype", "axis"]
 
     def setup(self, op, dtype, axis):

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -446,6 +446,7 @@ Performance improvements
 - Performance improvement in :func:`concat` (:issue:`52291`, :issue:`52290`)
 - :class:`Period`'s default formatter (`period_format`) is now significantly (~twice) faster. This improves performance of ``str(Period)``, ``repr(Period)``, and :meth:`Period.strftime(fmt=None)`, as well as ``PeriodArray.strftime(fmt=None)``, ``PeriodIndex.strftime(fmt=None)`` and ``PeriodIndex.format(fmt=None)``. Finally, ``to_csv`` operations involving :class:`PeriodArray` or :class:`PeriodIndex` with default ``date_format`` are also significantly accelerated. (:issue:`51459`)
 - Performance improvement accessing :attr:`arrays.IntegerArrays.dtype` & :attr:`arrays.FloatingArray.dtype` (:issue:`52998`)
+- Performance improvement in :class:`DataFrame` reductions with ``axis=None`` and extension dtypes (:issue:`54308`)
 - Performance improvement in :class:`MultiIndex` and multi-column operations (e.g. :meth:`DataFrame.sort_values`, :meth:`DataFrame.groupby`, :meth:`Series.unstack`) when index/column values are already sorted (:issue:`53806`)
 - Performance improvement in :class:`Series` reductions (:issue:`52341`)
 - Performance improvement in :func:`concat` when ``axis=1`` and objects have different indexes (:issue:`52541`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -106,6 +106,7 @@ from pandas.core.dtypes.common import (
     needs_i8_conversion,
     pandas_dtype,
 )
+from pandas.core.dtypes.concat import concat_compat
 from pandas.core.dtypes.dtypes import (
     ArrowDtype,
     BaseMaskedDtype,
@@ -11064,6 +11065,11 @@ class DataFrame(NDFrame, OpsMixin):
         if numeric_only:
             df = _get_data()
         if axis is None:
+            dtype = find_common_type([arr.dtype for arr in df._mgr.arrays])
+            if isinstance(dtype, ExtensionDtype):
+                df = df.astype(dtype, copy=False)
+                arr = concat_compat(list(df._iter_column_arrays()))
+                return arr._reduce(name, skipna=skipna, keepdims=False, **kwds)
             return func(df.values)
         elif axis == 1:
             if len(df.index) == 0:

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -1884,10 +1884,7 @@ def test_reduction_axis_none_returns_scalar(method, numeric_only, dtype):
         tm.assert_almost_equal(result, expected)
     else:
         expected = getattr(np, method)(np_arr, axis=None)
-        if dtype == "float64":
-            assert result == expected
-        else:
-            tm.assert_almost_equal(result, expected)
+        assert result == expected
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -1868,13 +1868,14 @@ def test_prod_sum_min_count_mixed_object():
 
 @pytest.mark.parametrize("method", ["min", "max", "mean", "median", "skew", "kurt"])
 @pytest.mark.parametrize("numeric_only", [True, False])
-def test_reduction_axis_none_returns_scalar(method, numeric_only):
+@pytest.mark.parametrize("dtype", ["float64", "Float64"])
+def test_reduction_axis_none_returns_scalar(method, numeric_only, dtype):
     # GH#21597 As of 2.0, axis=None reduces over all axes.
 
-    df = DataFrame(np.random.randn(4, 4))
+    df = DataFrame(np.random.randn(4, 4), dtype=dtype)
 
     result = getattr(df, method)(axis=None, numeric_only=numeric_only)
-    np_arr = df.to_numpy()
+    np_arr = df.to_numpy(dtype=np.float64)
     if method in {"skew", "kurt"}:
         comp_mod = pytest.importorskip("scipy.stats")
         if method == "kurt":
@@ -1883,7 +1884,10 @@ def test_reduction_axis_none_returns_scalar(method, numeric_only):
         tm.assert_almost_equal(result, expected)
     else:
         expected = getattr(np, method)(np_arr, axis=None)
-        assert result == expected
+        if dtype == "float64":
+            assert result == expected
+        else:
+            tm.assert_almost_equal(result, expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.1.0.rst` file if fixing a bug or adding a new feature.

```
import pandas as pd
import numpy as np

df = pd.DataFrame(np.random.randn(1000, 1000), dtype="float64[pyarrow]")

%timeit df.min(axis=None)

316 ms ± 52.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)     <- main
196 ms ± 13.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)     <- this PR
22.9 ms ± 1.32 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)  <- this PR + #54299 (pending PR)
```


Existing ASV:

```
       before           after         ratio
     [aefede93]       [bf708351]
     <main>           <perf-ea-axis-none-reductions>
-      8.83±0.7ms       7.03±0.3ms     0.80  stat_ops.FrameOps.time_op('std', 'Int64', None)
-        99.6±4ms       13.7±0.3ms     0.14  stat_ops.FrameOps.time_op('skew', 'Int64', None)
-        96.7±4ms       13.2±0.3ms     0.14  stat_ops.FrameOps.time_op('kurt', 'Int64', None)
-        107±10ms       12.9±0.3ms     0.12  stat_ops.FrameOps.time_op('median', 'Int64', None)
-        63.9±2ms       6.01±0.8ms     0.09  stat_ops.FrameOps.time_op('mean', 'Int64', None)
```