### PR TITLE
BUG: raise a ParserWarning instead of printing to stderr when on_bad_lines is true

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -577,6 +577,7 @@ I/O
 - Bug in :func:`json_normalize`, fix json_normalize cannot parse metadata fields list type (:issue:`37782`)
 - Bug in :func:`read_csv` where it would error when ``parse_dates`` was set to a list or dictionary with ``engine="pyarrow"`` (:issue:`47961`)
 - Bug in :func:`read_csv`, with ``engine="pyarrow"`` erroring when specifying a ``dtype`` with ``index_col`` (:issue:`53229`)
+- Bug in :func:`read_csv` was just printing to stderr while it should raise a warning when ``on_bad_line="warn"`` is set (:issue:`54296`)
 - Bug in :func:`read_hdf` not properly closing store after a ``IndexError`` is raised (:issue:`52781`)
 - Bug in :func:`read_html`, style elements were read into DataFrames (:issue:`52197`)
 - Bug in :func:`read_html`, tail texts were removed together with elements containing ``display:none`` style (:issue:`51629`)

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -880,9 +880,10 @@ cdef class TextReader:
 
     cdef _check_tokenize_status(self, int status):
         if self.parser.warn_msg != NULL:
-            print(PyUnicode_DecodeUTF8(
+            decoded_warning_message = PyUnicode_DecodeUTF8(
                 self.parser.warn_msg, strlen(self.parser.warn_msg),
-                self.encoding_errors), file=sys.stderr)
+                self.encoding_errors)
+            warnings.warn(decoded_warning_message, ParserWarning, stacklevel=find_stack_level())
             free(self.parser.warn_msg)
             self.parser.warn_msg = NULL
 

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -883,7 +883,8 @@ cdef class TextReader:
             decoded_warning_message = PyUnicode_DecodeUTF8(
                 self.parser.warn_msg, strlen(self.parser.warn_msg),
                 self.encoding_errors)
-            warnings.warn(decoded_warning_message, ParserWarning, stacklevel=find_stack_level())
+            warnings.warn(decoded_warning_message, ParserWarning,
+                          stacklevel=find_stack_level())
             free(self.parser.warn_msg)
             self.parser.warn_msg = NULL
 


### PR DESCRIPTION
Fixes the bug discussed on #54296 
- [x] closes #54296
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature 
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. (**No new arguments/method/functions.**)
- [x] Added an entry in the latest `doc/source/whatsnew/v2.1.0.rst` file if fixing a bug or adding a new feature.

