### PR TITLE
TST: Remove type-hint from test

### DIFF
--- a/pandas/tests/frame/methods/test_shift.py
+++ b/pandas/tests/frame/methods/test_shift.py
@@ -692,7 +692,7 @@ class TestDataFrameShift:
         shifts = [0, 1, 2]
 
         df = DataFrame(data)
-        s: Series = df["a"]
+        s = df["a"]
         tm.assert_frame_equal(s.shift(shifts), df.shift(shifts))
 
     def test_shift_with_iterable_freq_and_fill_value(self):


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Followup to #54115. Having this type-hint makes mypy display

> pandas/tests/frame/methods/test_shift.py:695: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]