### PR TITLE
BUG: respect allow_copy=False in interchange.from_dataframe

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -684,6 +684,7 @@ Other
 - Bug in :class:`DataFrame` and :class:`Series` raising for data of complex dtype when ``NaN`` values are present (:issue:`53627`)
 - Bug in :class:`DatetimeIndex` where ``repr`` of index passed with time does not print time is midnight and non-day based freq(:issue:`53470`)
 - Bug in :class:`FloatingArray.__contains__` with ``NaN`` item incorrectly returning ``False`` when ``NaN`` values are present (:issue:`52840`)
+- Bug in :func:`api.interchange.from_dataframe` was not respecting ``allow_copy`` argument (:issue:`54322`)
 - Bug in :func:`api.interchange.from_dataframe` when converting an empty DataFrame object (:issue:`53155`)
 - Bug in :func:`assert_almost_equal` now throwing assertion error for two unequal sets (:issue:`51727`)
 - Bug in :func:`assert_frame_equal` checks category dtypes even when asked not to check index type (:issue:`52126`)

--- a/pandas/core/interchange/from_dataframe.py
+++ b/pandas/core/interchange/from_dataframe.py
@@ -67,7 +67,9 @@ def from_dataframe(df, allow_copy: bool = True) -> pd.DataFrame:
     if not hasattr(df, "__dataframe__"):
         raise ValueError("`df` does not support __dataframe__")
 
-    return _from_dataframe(df.__dataframe__(allow_copy=allow_copy))
+    return _from_dataframe(
+        df.__dataframe__(allow_copy=allow_copy), allow_copy=allow_copy
+    )
 
 
 def _from_dataframe(df: DataFrameXchg, allow_copy: bool = True):
@@ -451,10 +453,9 @@ def buffer_to_ndarray(
         data_pointer = ctypes.cast(
             buffer.ptr + (offset * bit_width // 8), ctypes.POINTER(ctypes_type)
         )
-        return np.ctypeslib.as_array(
-            data_pointer,
-            shape=(length,),
-        )
+        if length > 0:
+            return np.ctypeslib.as_array(data_pointer, shape=(length,))
+        return np.array([], dtype=ctypes_type)
 
 
 def set_nulls(

--- a/pandas/tests/interchange/test_impl.py
+++ b/pandas/tests/interchange/test_impl.py
@@ -286,6 +286,19 @@ def test_empty_pyarrow(data):
     tm.assert_frame_equal(result, expected)
 
 
+def test_multi_chunk_pyarrow() -> None:
+    pa = pytest.importorskip("pyarrow", "11.0.0")
+    n_legs = pa.chunked_array([[2, 2, 4], [4, 5, 100]])
+    names = ["n_legs"]
+    table = pa.table([n_legs], names=names)
+    with pytest.raises(
+        RuntimeError,
+        match="To join chunks a copy is required which is "
+        "forbidden by allow_copy=False",
+    ):
+        pd.api.interchange.from_dataframe(table, allow_copy=False)
+
+
 @pytest.mark.parametrize("tz", ["UTC", "US/Pacific"])
 @pytest.mark.parametrize("unit", ["s", "ms", "us", "ns"])
 def test_datetimetzdtype(tz, unit):


### PR DESCRIPTION
On `main`, the following doesn't raise:
```python
import pyarrow as pa
import pyarrow.compute as pc

n_legs = pa.chunked_array([[2, 2, 4], [4, 5, 100]])
names = ["n_legs"]
table = pa.table([n_legs], names=names)

pd.api.interchange.from_dataframe(table, allow_copy=False)
```