### PR TITLE
Parquet metadata persistence of DataFrame.attrs

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -176,8 +176,8 @@ Other enhancements
 - Performance improvement in :func:`concat` with homogeneous ``np.float64`` or ``np.float32`` dtypes (:issue:`52685`)
 - Performance improvement in :meth:`DataFrame.filter` when ``items`` is given (:issue:`52941`)
 - Reductions :meth:`Series.argmax`, :meth:`Series.argmin`, :meth:`Series.idxmax`, :meth:`Series.idxmin`, :meth:`Index.argmax`, :meth:`Index.argmin`, :meth:`DataFrame.idxmax`, :meth:`DataFrame.idxmin` are now supported for object-dtype objects (:issue:`4279`, :issue:`18021`, :issue:`40685`, :issue:`43697`)
+- Added ``PANDAS_ATTRS`` to :attr:`Schema.metadata` in :class:`PyArrowImpl` for parquet metadata persistence using pyarrow engine (:issue:`54346`)
 - Performance improvement in :meth:`GroupBy.quantile` (:issue:`51722`)
--
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_210.notable_bug_fixes:

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -176,7 +176,7 @@ Other enhancements
 - Performance improvement in :func:`concat` with homogeneous ``np.float64`` or ``np.float32`` dtypes (:issue:`52685`)
 - Performance improvement in :meth:`DataFrame.filter` when ``items`` is given (:issue:`52941`)
 - Reductions :meth:`Series.argmax`, :meth:`Series.argmin`, :meth:`Series.idxmax`, :meth:`Series.idxmin`, :meth:`Index.argmax`, :meth:`Index.argmin`, :meth:`DataFrame.idxmax`, :meth:`DataFrame.idxmin` are now supported for object-dtype objects (:issue:`4279`, :issue:`18021`, :issue:`40685`, :issue:`43697`)
-- Added ``PANDAS_ATTRS`` to :attr:`Schema.metadata` in :class:`PyArrowImpl` for parquet metadata persistence using pyarrow engine (:issue:`54346`)
+- :meth:`DataFrame.to_parquet` and :func:`read_parquet` will now write and read ``attrs`` respectively (:issue:`54346`)
 - Performance improvement in :meth:`GroupBy.quantile` (:issue:`51722`)
 
 .. ---------------------------------------------------------------------------

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -1,7 +1,9 @@
 """ parquet compat """
 from __future__ import annotations
 
+import ast
 import io
+import json
 import os
 from typing import (
     TYPE_CHECKING,
@@ -184,6 +186,11 @@ class PyArrowImpl(BaseImpl):
 
         table = self.api.Table.from_pandas(df, **from_pandas_kwargs)
 
+        df_metadata = {"df.attrs": json.dumps(df.attrs)}
+        existing_metadata = table.schema.metadata
+        merged_metadata = {**existing_metadata, **df_metadata}
+        table = table.replace_schema_metadata(merged_metadata)
+
         path_or_handle, handles, filesystem = _get_path_or_handle(
             path,
             filesystem,
@@ -263,6 +270,10 @@ class PyArrowImpl(BaseImpl):
 
             if manager == "array":
                 result = result._as_manager("array", copy=False)
+
+            result.attrs = ast.literal_eval(
+                pa_table.schema.metadata[b"df.attrs"].decode("utf-8")
+            )
             return result
         finally:
             if handles is not None:

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -1,7 +1,6 @@
 """ parquet compat """
 from __future__ import annotations
 
-import ast
 import io
 import json
 import os
@@ -186,7 +185,7 @@ class PyArrowImpl(BaseImpl):
 
         table = self.api.Table.from_pandas(df, **from_pandas_kwargs)
 
-        df_metadata = {"df.attrs": json.dumps(df.attrs)}
+        df_metadata = {"PANDAS_ATTRS": json.dumps(df.attrs)}
         existing_metadata = table.schema.metadata
         merged_metadata = {**existing_metadata, **df_metadata}
         table = table.replace_schema_metadata(merged_metadata)
@@ -272,9 +271,9 @@ class PyArrowImpl(BaseImpl):
                 result = result._as_manager("array", copy=False)
 
             if pa_table.schema.metadata:
-                if b"df.attrs" in pa_table.schema.metadata:
-                    df_metadata = pa_table.schema.metadata[b"df.attrs"]
-                    result.attrs = ast.literal_eval(df_metadata.decode("utf-8"))
+                if b"PANDAS_ATTRS" in pa_table.schema.metadata:
+                    df_metadata = pa_table.schema.metadata[b"PANDAS_ATTRS"]
+                    result.attrs = json.loads(df_metadata)
             return result
         finally:
             if handles is not None:

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -185,10 +185,11 @@ class PyArrowImpl(BaseImpl):
 
         table = self.api.Table.from_pandas(df, **from_pandas_kwargs)
 
-        df_metadata = {"PANDAS_ATTRS": json.dumps(df.attrs)}
-        existing_metadata = table.schema.metadata
-        merged_metadata = {**existing_metadata, **df_metadata}
-        table = table.replace_schema_metadata(merged_metadata)
+        if df.attrs:
+            df_metadata = {"PANDAS_ATTRS": json.dumps(df.attrs)}
+            existing_metadata = table.schema.metadata
+            merged_metadata = {**existing_metadata, **df_metadata}
+            table = table.replace_schema_metadata(merged_metadata)
 
         path_or_handle, handles, filesystem = _get_path_or_handle(
             path,

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -271,9 +271,10 @@ class PyArrowImpl(BaseImpl):
             if manager == "array":
                 result = result._as_manager("array", copy=False)
 
-            result.attrs = ast.literal_eval(
-                pa_table.schema.metadata[b"df.attrs"].decode("utf-8")
-            )
+            if pa_table.schema.metadata:
+                if b"df.attrs" in pa_table.schema.metadata:
+                    df_metadata = pa_table.schema.metadata[b"df.attrs"]
+                    result.attrs = ast.literal_eval(df_metadata.decode("utf-8"))
             return result
         finally:
             if handles is not None:

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -1068,7 +1068,7 @@ class TestParquetPyArrow(Base):
     def test_df_attrs_persistence(self, tmp_path, pa):
         path = tmp_path / "test_df_metadata.p"
         df = pd.DataFrame(data={1: [1]})
-        df.attrs = {"Test attribute": 1}
+        df.attrs = {"test_attribute": 1}
         df.to_parquet(path, engine=pa)
         new_df = read_parquet(path, engine=pa)
         assert new_df.attrs == df.attrs

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -1065,6 +1065,14 @@ class TestParquetPyArrow(Base):
         df = pd.DataFrame(index=pd.Index(["a", "b", "c"], name="custom name"))
         check_round_trip(df, pa)
 
+    def test_df_attrs_persistence(self, tmp_path, pa):
+        path = tmp_path / "test_df_metadata.p"
+        df = pd.DataFrame(data={1: [1]})
+        df.attrs = {"Test attribute": 1}
+        df.to_parquet(path, engine=pa)
+        new_df = read_parquet(path, engine=pa)
+        assert new_df.attrs == df.attrs
+
 
 class TestParquetFastParquet(Base):
     def test_basic(self, fp, df_full):
@@ -1191,14 +1199,6 @@ class TestParquetFastParquet(Base):
 
         actual_partition_cols = fastparquet.ParquetFile(str(tmp_path), False).cats
         assert len(actual_partition_cols) == 2
-
-    def test_df_attrs_persistence(self, tmp_path):
-        path = tmp_path / "test_df_metadata.p"
-        df = pd.DataFrame(data={1: [1]})
-        df.attrs = {"Test attribute": 1}
-        df.to_parquet(path)
-        new_df = read_parquet(path)
-        assert new_df.attrs == df.attrs
 
     def test_error_on_using_partition_cols_and_partition_on(
         self, tmp_path, fp, df_full

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -1192,6 +1192,14 @@ class TestParquetFastParquet(Base):
         actual_partition_cols = fastparquet.ParquetFile(str(tmp_path), False).cats
         assert len(actual_partition_cols) == 2
 
+    def test_df_attrs_persistence(self, tmp_path):
+        path = tmp_path / "test_df_metadata.p"
+        df = pd.DataFrame(data={1: [1]})
+        df.attrs = {"Test attribute": 1}
+        df.to_parquet(path)
+        new_df = read_parquet(path)
+        assert new_df.attrs == df.attrs
+
     def test_error_on_using_partition_cols_and_partition_on(
         self, tmp_path, fp, df_full
     ):


### PR DESCRIPTION
- [x] closes #https://github.com/pandas-dev/pandas/issues/54321
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests)
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

DataFrame.attrs seems to not be attached to pyarrow schema metadata as it is experimental. Added it to the pyarrow table (schema.metadata) so it persists when the parquet file is read back. One issue I am facing is DataFrame.attrs dictionary can't have int as keys as encoding it for pyarrow converts it to string, but not sure if this is a problem.
