### PR TITLE
CLN: Remove None check in attrs property lookup

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -381,8 +381,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         >>> df.attrs
         {'A': [10, 20, 30]}
         """
-        if self._attrs is None:
-            self._attrs = {}
         return self._attrs
 
     @attrs.setter
@@ -2126,6 +2124,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             typ = state.get("_typ")
             if typ is not None:
                 attrs = state.get("_attrs", {})
+                if attrs is None:  # should not happen, but better be on the safe side
+                    attrs = {}
                 object.__setattr__(self, "_attrs", attrs)
                 flags = state.get("_flags", {"allows_duplicate_labels": True})
                 object.__setattr__(self, "_flags", Flags(self, **flags))


### PR DESCRIPTION
`self._attrs` is always initialized to an empty dict per https://github.com/pandas-dev/pandas/blob/c93e8034a13d3dbe2358b1b2f868a0d54d1034a7/pandas/core/generic.py#L275

The attribute `_attrs` is only witten to in two other places

a) in the attrs.setter property (which enforces dict as well)
b) in `__setstate__`, which takes whatever the state is:
   https://github.com/pandas-dev/pandas/blob/c93e8034a13d3dbe2358b1b2f868a0d54d1034a7/pandas/core/generic.py#L2129
   AFAICS (including code history) I do not see a reason that this could be None.
   But if we wanted to be very defensive, we should do the dict enforcing here.

