### PR TITLE
REF: implement BaseOpsUtil._cast_pointwise_result

### DIFF
--- a/pandas/tests/extension/base/ops.py
+++ b/pandas/tests/extension/base/ops.py
@@ -29,6 +29,12 @@ class BaseOpsUtil(BaseExtensionTests):
 
         self._check_op(ser, op, other, op_name, exc)
 
+    # Subclasses are not expected to need to override _check_op or _combine.
+    #  Ideally any relevant overriding can be done in _cast_pointwise_result,
+    #  get_op_from_name, and the specification of `exc`. If you find a use
+    #  case that still requires overriding _check_op or _combine, please let
+    #  us know at github.com/pandas-dev/pandas/issues
+    @final
     def _combine(self, obj, other, op):
         if isinstance(obj, pd.DataFrame):
             if len(obj.columns) != 1:
@@ -38,11 +44,7 @@ class BaseOpsUtil(BaseExtensionTests):
             expected = obj.combine(other, op)
         return expected
 
-    # Subclasses are not expected to need to override _check_op. Ideally any
-    #  relevant overriding can be done in _cast_pointwise_result, get_op_from_name,
-    #  and the specification of `exc`. If you find a use case that still requires
-    #  overriding _check_op, please let us know at
-    #  github.com/pandas-dev/pandas/issues
+    # see comment on _combine
     @final
     def _check_op(
         self, ser: pd.Series, op, other, op_name: str, exc=NotImplementedError

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -873,11 +873,11 @@ class TestBaseArithmeticOps(base.BaseArithmeticOpsTests):
 
         return tm.get_op_from_name(op_name)
 
-    def _combine(self, obj, other, op):
+    def _cast_pointwise_result(self, op_name: str, obj, other, pointwise_result):
         # BaseOpsUtil._combine can upcast expected dtype
         # (because it generates expected on python scalars)
         # while ArrowExtensionArray maintains original type
-        expected = base.BaseArithmeticOpsTests._combine(self, obj, other, op)
+        expected = pointwise_result
 
         was_frame = False
         if isinstance(expected, pd.DataFrame):
@@ -895,7 +895,7 @@ class TestBaseArithmeticOps(base.BaseArithmeticOpsTests):
                 pa.types.is_floating(orig_pa_type)
                 or (
                     pa.types.is_integer(orig_pa_type)
-                    and op.__name__ not in ["truediv", "rtruediv"]
+                    and op_name not in ["__truediv__", "__rtruediv__"]
                 )
                 or pa.types.is_duration(orig_pa_type)
                 or pa.types.is_timestamp(orig_pa_type)
@@ -906,7 +906,7 @@ class TestBaseArithmeticOps(base.BaseArithmeticOpsTests):
                 #  ArrowExtensionArray does not upcast
                 return expected
         elif not (
-            (op is operator.floordiv and pa.types.is_integer(orig_pa_type))
+            (op_name == "__floordiv__" and pa.types.is_integer(orig_pa_type))
             or pa.types.is_duration(orig_pa_type)
             or pa.types.is_timestamp(orig_pa_type)
             or pa.types.is_date(orig_pa_type)
@@ -943,14 +943,14 @@ class TestBaseArithmeticOps(base.BaseArithmeticOpsTests):
         ):
             # decimal precision can resize in the result type depending on data
             # just compare the float values
-            alt = op(obj, other)
+            alt = getattr(obj, op_name)(other)
             alt_dtype = tm.get_dtype(alt)
             assert isinstance(alt_dtype, ArrowDtype)
-            if op is operator.pow and isinstance(other, Decimal):
+            if op_name == "__pow__" and isinstance(other, Decimal):
                 # TODO: would it make more sense to retain Decimal here?
                 alt_dtype = ArrowDtype(pa.float64())
             elif (
-                op is operator.pow
+                op_name == "__pow__"
                 and isinstance(other, pd.Series)
                 and other.dtype == original_dtype
             ):

--- a/pandas/tests/extension/test_masked_numeric.py
+++ b/pandas/tests/extension/test_masked_numeric.py
@@ -146,45 +146,20 @@ class TestDtype(base.BaseDtypeTests):
 
 
 class TestArithmeticOps(base.BaseArithmeticOpsTests):
-    def _check_op(self, s, op, other, op_name, exc=NotImplementedError):
-        if exc is None:
-            sdtype = tm.get_dtype(s)
+    def _cast_pointwise_result(self, op_name: str, obj, other, pointwise_result):
+        sdtype = tm.get_dtype(obj)
+        expected = pointwise_result
 
-            if hasattr(other, "dtype") and isinstance(other.dtype, np.dtype):
-                if sdtype.kind == "f":
-                    if other.dtype.kind == "f":
-                        # other is np.float64 and would therefore always result
-                        # in upcasting, so keeping other as same numpy_dtype
-                        other = other.astype(sdtype.numpy_dtype)
-
-                else:
-                    # i.e. sdtype.kind in "iu""
-                    if other.dtype.kind in "iu" and sdtype.is_unsigned_integer:
-                        # TODO: comment below is inaccurate; other can be int8
-                        #  int16, ...
-                        #  and the trouble is that e.g. if s is UInt8 and other
-                        #  is int8, then result is UInt16
-                        # other is np.int64 and would therefore always result in
-                        # upcasting, so keeping other as same numpy_dtype
-                        other = other.astype(sdtype.numpy_dtype)
-
-            result = op(s, other)
-            expected = self._combine(s, other, op)
-
-            if sdtype.kind in "iu":
-                if op_name in ("__rtruediv__", "__truediv__", "__div__"):
-                    expected = expected.fillna(np.nan).astype("Float64")
-                else:
-                    # combine method result in 'biggest' (int64) dtype
-                    expected = expected.astype(sdtype)
+        if sdtype.kind in "iu":
+            if op_name in ("__rtruediv__", "__truediv__", "__div__"):
+                expected = expected.fillna(np.nan).astype("Float64")
             else:
-                # combine method result in 'biggest' (float64) dtype
+                # combine method result in 'biggest' (int64) dtype
                 expected = expected.astype(sdtype)
-
-            tm.assert_equal(result, expected)
         else:
-            with pytest.raises(exc):
-                op(s, other)
+            # combine method result in 'biggest' (float64) dtype
+            expected = expected.astype(sdtype)
+        return expected
 
     def check_opname(self, ser: pd.Series, op_name: str, other, exc=None):
         # overwriting to indicate ops don't raise an error
@@ -195,17 +170,8 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
 
 
 class TestComparisonOps(base.BaseComparisonOpsTests):
-    def _check_op(
-        self, ser: pd.Series, op, other, op_name: str, exc=NotImplementedError
-    ):
-        if exc is None:
-            result = op(ser, other)
-            # Override to do the astype to boolean
-            expected = ser.combine(other, op).astype("boolean")
-            tm.assert_series_equal(result, expected)
-        else:
-            with pytest.raises(exc):
-                op(ser, other)
+    def _cast_pointwise_result(self, op_name: str, obj, other, pointwise_result):
+        return pointwise_result.astype("boolean")
 
     def check_opname(self, ser: pd.Series, op_name: str, other, exc=None):
         super().check_opname(ser, op_name, other, exc=None)


### PR DESCRIPTION
Along with #54365 this goes most of the way towards getting rid of the most egregious patterns in the extension arithmetic tests.