### PR TITLE
REF: simplify extension reduction tests

### DIFF
--- a/pandas/tests/extension/base/__init__.py
+++ b/pandas/tests/extension/base/__init__.py
@@ -60,6 +60,7 @@ from pandas.tests.extension.base.reduce import (  # noqa: F401
     BaseBooleanReduceTests,
     BaseNoReduceTests,
     BaseNumericReduceTests,
+    BaseReduceTests,
 )
 from pandas.tests.extension.base.reshaping import BaseReshapingTests  # noqa: F401
 from pandas.tests.extension.base.setitem import BaseSetitemTests  # noqa: F401

--- a/pandas/tests/extension/base/reduce.py
+++ b/pandas/tests/extension/base/reduce.py
@@ -14,6 +14,10 @@ class BaseReduceTests(BaseExtensionTests):
     make sense for numeric/boolean operations.
     """
 
+    def _supports_reduction(self, obj, op_name: str) -> bool:
+        # Specify if we expect this reduction to succeed.
+        return False
+
     def check_reduce(self, s, op_name, skipna):
         res_op = getattr(s, op_name)
         exp_op = getattr(s.astype("float64"), op_name)
@@ -25,47 +29,42 @@ class BaseReduceTests(BaseExtensionTests):
             expected = exp_op(skipna=skipna)
         tm.assert_almost_equal(result, expected)
 
+    @pytest.mark.parametrize("skipna", [True, False])
+    def test_reduce_series_boolean(self, data, all_boolean_reductions, skipna):
+        op_name = all_boolean_reductions
+        s = pd.Series(data)
 
-class BaseNoReduceTests(BaseReduceTests):
-    """we don't define any reductions"""
+        if not self._supports_reduction(s, op_name):
+            msg = (
+                "[Cc]annot perform|Categorical is not ordered for operation|"
+                "does not support reduction|"
+            )
+
+            with pytest.raises(TypeError, match=msg):
+                getattr(s, op_name)(skipna=skipna)
+
+        else:
+            self.check_reduce(s, op_name, skipna)
 
     @pytest.mark.parametrize("skipna", [True, False])
     def test_reduce_series_numeric(self, data, all_numeric_reductions, skipna):
         op_name = all_numeric_reductions
         s = pd.Series(data)
 
-        msg = (
-            "[Cc]annot perform|Categorical is not ordered for operation|"
-            "does not support reduction|"
-        )
+        if not self._supports_reduction(s, op_name):
+            msg = (
+                "[Cc]annot perform|Categorical is not ordered for operation|"
+                "does not support reduction|"
+            )
 
-        with pytest.raises(TypeError, match=msg):
-            getattr(s, op_name)(skipna=skipna)
+            with pytest.raises(TypeError, match=msg):
+                getattr(s, op_name)(skipna=skipna)
 
-    @pytest.mark.parametrize("skipna", [True, False])
-    def test_reduce_series_boolean(self, data, all_boolean_reductions, skipna):
-        op_name = all_boolean_reductions
-        s = pd.Series(data)
-
-        msg = (
-            "[Cc]annot perform|Categorical is not ordered for operation|"
-            "does not support reduction|"
-        )
-
-        with pytest.raises(TypeError, match=msg):
-            getattr(s, op_name)(skipna=skipna)
-
-
-class BaseNumericReduceTests(BaseReduceTests):
-    @pytest.mark.parametrize("skipna", [True, False])
-    def test_reduce_series(self, data, all_numeric_reductions, skipna):
-        op_name = all_numeric_reductions
-        s = pd.Series(data)
-
-        # min/max with empty produce numpy warnings
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", RuntimeWarning)
-            self.check_reduce(s, op_name, skipna)
+        else:
+            # min/max with empty produce numpy warnings
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", RuntimeWarning)
+                self.check_reduce(s, op_name, skipna)
 
     @pytest.mark.parametrize("skipna", [True, False])
     def test_reduce_frame(self, data, all_numeric_reductions, skipna):
@@ -74,12 +73,28 @@ class BaseNumericReduceTests(BaseReduceTests):
         if not is_numeric_dtype(s):
             pytest.skip("not numeric dtype")
 
+        if not self._supports_reduction(s, op_name):
+            pytest.skip(f"Reduction {op_name} not supported for this dtype")
+
         self.check_reduce_frame(s, op_name, skipna)
 
 
+# TODO: deprecate BaseNoReduceTests, BaseNumericReduceTests, BaseBooleanReduceTests
+class BaseNoReduceTests(BaseReduceTests):
+    """we don't define any reductions"""
+
+
+class BaseNumericReduceTests(BaseReduceTests):
+    # For backward compatibility only, this only runs the numeric reductions
+    def _supports_reduction(self, obj, op_name: str) -> bool:
+        if op_name in ["any", "all"]:
+            pytest.skip("These are tested in BaseBooleanReduceTests")
+        return True
+
+
 class BaseBooleanReduceTests(BaseReduceTests):
-    @pytest.mark.parametrize("skipna", [True, False])
-    def test_reduce_series(self, data, all_boolean_reductions, skipna):
-        op_name = all_boolean_reductions
-        s = pd.Series(data)
-        self.check_reduce(s, op_name, skipna)
+    # For backward compatibility only, this only runs the numeric reductions
+    def _supports_reduction(self, obj, op_name: str) -> bool:
+        if op_name not in ["any", "all"]:
+            pytest.skip("These are tested in BaseNumericReduceTests")
+        return True

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -146,6 +146,9 @@ class TestMissing(base.BaseMissingTests):
 
 
 class Reduce:
+    def _supports_reduction(self, obj, op_name: str) -> bool:
+        return True
+
     def check_reduce(self, s, op_name, skipna):
         if op_name in ["median", "skew", "kurt", "sem"]:
             msg = r"decimal does not support the .* operation"
@@ -204,11 +207,7 @@ class Reduce:
         tm.assert_series_equal(result, expected)
 
 
-class TestNumericReduce(Reduce, base.BaseNumericReduceTests):
-    pass
-
-
-class TestBooleanReduce(Reduce, base.BaseBooleanReduceTests):
+class TestReduce(Reduce, base.BaseReduceTests):
     pass
 
 

--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -175,7 +175,7 @@ class TestMissing(BaseJSON, base.BaseMissingTests):
 unhashable = pytest.mark.xfail(reason="Unhashable")
 
 
-class TestReduce(base.BaseNoReduceTests):
+class TestReduce(base.BaseReduceTests):
     pass
 
 

--- a/pandas/tests/extension/test_boolean.py
+++ b/pandas/tests/extension/test_boolean.py
@@ -220,7 +220,10 @@ class TestGroupby(base.BaseGroupbyTests):
             tm.assert_frame_equal(result, expected)
 
 
-class TestNumericReduce(base.BaseNumericReduceTests):
+class TestReduce(base.BaseReduceTests):
+    def _supports_reduction(self, obj, op_name: str) -> bool:
+        return True
+
     def check_reduce(self, s, op_name, skipna):
         if op_name == "count":
             result = getattr(s, op_name)()
@@ -259,10 +262,6 @@ class TestNumericReduce(base.BaseNumericReduceTests):
             exp_value = getattr(ser.dropna().astype(cmp_dtype), op_name)()
             expected = pd.array([exp_value], dtype=cmp_dtype)
         tm.assert_extension_array_equal(result, expected)
-
-
-class TestBooleanReduce(base.BaseBooleanReduceTests):
-    pass
 
 
 class TestPrinting(base.BasePrintingTests):

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -152,7 +152,7 @@ class TestMissing(base.BaseMissingTests):
     pass
 
 
-class TestReduce(base.BaseNoReduceTests):
+class TestReduce(base.BaseReduceTests):
     pass
 
 

--- a/pandas/tests/extension/test_interval.py
+++ b/pandas/tests/extension/test_interval.py
@@ -105,7 +105,7 @@ class TestInterface(BaseInterval, base.BaseInterfaceTests):
     pass
 
 
-class TestReduce(base.BaseNoReduceTests):
+class TestReduce(base.BaseReduceTests):
     @pytest.mark.parametrize("skipna", [True, False])
     def test_reduce_series_numeric(self, data, all_numeric_reductions, skipna):
         op_name = all_numeric_reductions

--- a/pandas/tests/extension/test_masked_numeric.py
+++ b/pandas/tests/extension/test_masked_numeric.py
@@ -225,7 +225,12 @@ class TestGroupby(base.BaseGroupbyTests):
     pass
 
 
-class TestNumericReduce(base.BaseNumericReduceTests):
+class TestReduce(base.BaseReduceTests):
+    def _supports_reduction(self, obj, op_name: str) -> bool:
+        if op_name in ["any", "all"]:
+            pytest.skip(reason="Tested in tests/reductions/test_reductions.py")
+        return True
+
     def check_reduce(self, ser: pd.Series, op_name: str, skipna: bool):
         # overwrite to ensure pd.NA is tested instead of np.nan
         # https://github.com/pandas-dev/pandas/issues/30958
@@ -282,11 +287,6 @@ class TestNumericReduce(base.BaseNumericReduceTests):
 
         tm.assert_extension_array_equal(result1, result2)
         tm.assert_extension_array_equal(result2, expected)
-
-
-@pytest.mark.skip(reason="Tested in tests/reductions/test_reductions.py")
-class TestBooleanReduce(base.BaseBooleanReduceTests):
-    pass
 
 
 class TestAccumulation(base.BaseAccumulateTests):

--- a/pandas/tests/extension/test_numpy.py
+++ b/pandas/tests/extension/test_numpy.py
@@ -303,25 +303,27 @@ class TestPrinting(BaseNumPyTests, base.BasePrintingTests):
     pass
 
 
-class TestNumericReduce(BaseNumPyTests, base.BaseNumericReduceTests):
+class TestReduce(BaseNumPyTests, base.BaseReduceTests):
+    def _supports_reduction(self, obj, op_name: str) -> bool:
+        if tm.get_dtype(obj).kind == "O":
+            return op_name in ["sum", "min", "max", "any", "all"]
+        return True
+
     def check_reduce(self, s, op_name, skipna):
-        result = getattr(s, op_name)(skipna=skipna)
+        res_op = getattr(s, op_name)
         # avoid coercing int -> float. Just cast to the actual numpy type.
-        expected = getattr(s.astype(s.dtype._dtype), op_name)(skipna=skipna)
+        exp_op = getattr(s.astype(s.dtype._dtype), op_name)
+        if op_name == "count":
+            result = res_op()
+            expected = exp_op()
+        else:
+            result = res_op(skipna=skipna)
+            expected = exp_op(skipna=skipna)
         tm.assert_almost_equal(result, expected)
 
     @pytest.mark.skip("tests not written yet")
     def check_reduce_frame(self, ser: pd.Series, op_name: str, skipna: bool):
         pass
-
-    @pytest.mark.parametrize("skipna", [True, False])
-    def test_reduce_series(self, data, all_boolean_reductions, skipna):
-        super().test_reduce_series(data, all_boolean_reductions, skipna)
-
-
-@skip_nested
-class TestBooleanReduce(BaseNumPyTests, base.BaseBooleanReduceTests):
-    pass
 
 
 class TestMissing(BaseNumPyTests, base.BaseMissingTests):

--- a/pandas/tests/extension/test_string.py
+++ b/pandas/tests/extension/test_string.py
@@ -168,7 +168,7 @@ class TestMissing(base.BaseMissingTests):
         tm.assert_extension_array_equal(result, data)
 
 
-class TestNoReduce(base.BaseNoReduceTests):
+class TestReduce(base.BaseReduceTests):
     @pytest.mark.parametrize("skipna", [True, False])
     def test_reduce_series_numeric(self, data, all_numeric_reductions, skipna):
         op_name = all_numeric_reductions


### PR DESCRIPTION
- [x] closes #44742 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Will clean up the pyarrow tests usage in a follow-up.

Didn't remove the no-longer-used test classes since downstream projects might be using them.  Are we OK just ripping those out or does that require a deprecation cycle?