### PR TITLE
CLN/DOC: DataFrame.count remove references to "level"

### DIFF
--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -512,19 +512,10 @@ class Count:
         self.df_mixed = self.df.copy()
         self.df_mixed["foo"] = "bar"
 
-        self.df.index = MultiIndex.from_arrays([self.df.index, self.df.index])
-        self.df.columns = MultiIndex.from_arrays([self.df.columns, self.df.columns])
-        self.df_mixed.index = MultiIndex.from_arrays(
-            [self.df_mixed.index, self.df_mixed.index]
-        )
-        self.df_mixed.columns = MultiIndex.from_arrays(
-            [self.df_mixed.columns, self.df_mixed.columns]
-        )
-
-    def time_count_level_multi(self, axis):
+    def time_count(self, axis):
         self.df.count(axis=axis)
 
-    def time_count_level_mixed_dtypes_multi(self, axis):
+    def time_count_mixed_dtypes(self, axis):
         self.df_mixed.count(axis=axis)
 
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10991,9 +10991,8 @@ class DataFrame(NDFrame, OpsMixin):
 
         Returns
         -------
-        Series or DataFrame
+        Series
             For each column/row the number of non-NA/null entries.
-            If `level` is specified returns a `DataFrame`.
 
         See Also
         --------
@@ -11051,7 +11050,7 @@ class DataFrame(NDFrame, OpsMixin):
         else:
             result = notna(frame).sum(axis=axis)
 
-        return result.astype("int64").__finalize__(self, method="count")
+        return result.astype("int64", copy=False).__finalize__(self, method="count")
 
     def _reduce(
         self,


### PR DESCRIPTION
1. Removed mention of `level` in `DataFrame.count` docstring as it has been deprecated and removed.
2. Removed "level" from `frame_methods.Count` benchmark name and the `MultiIndex` since it was only relevant when using `level`.

