### PR TITLE
CI: remove test cases which would have globbed pandas.tests

### DIFF
--- a/scripts/tests/test_check_test_naming.py
+++ b/scripts/tests/test_check_test_naming.py
@@ -17,18 +17,7 @@ from scripts.check_test_naming import main
             1,
         ),
         ("def test_foo(): pass\n", "", 0),
-        (
-            "class TestFoo:\n    def foo(): pass\n",
-            "t.py:2:4 found test function which does not start with 'test'\n",
-            1,
-        ),
         ("class TestFoo:\n    def test_foo(): pass\n", "", 0),
-        (
-            "class Foo:\n    def foo(): pass\n",
-            "t.py:1:0 found test class which does not start with 'Test'\n"
-            "t.py:2:4 found test function which does not start with 'test'\n",
-            1,
-        ),
         (
             "def foo():\n    pass\ndef test_foo():\n    foo()\n",
             "",


### PR DESCRIPTION
This came up here https://github.com/pandas-dev/pandas/pull/54365#issuecomment-1664639342

I've removed the test cases which would've ended up triggering globbing of pandas/tests, this should remove the noise observed in that PR