### PR TITLE
ENH: Update numpy exceptions imports

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -45,6 +45,8 @@ from pandas.core.dtypes.generic import (
 )
 from pandas.core.dtypes.inference import iterable_not_string
 
+from pandas.util.version import Version
+
 if TYPE_CHECKING:
     from pandas._typing import (
         AnyArrayLike,
@@ -236,7 +238,8 @@ def asarray_tuplesafe(values: Iterable, dtype: NpDtype | None = None) -> ArrayLi
     try:
         with warnings.catch_warnings():
             # Can remove warning filter once NumPy 1.24 is min version
-            warnings.simplefilter("ignore", np.VisibleDeprecationWarning)
+            if Version(np.__version__) < Version("1.24.0"):
+                warnings.simplefilter("ignore", np.VisibleDeprecationWarning)
             result = np.asarray(values, dtype=dtype)
     except ValueError:
         # Using try/except since it's more performant than checking is_list_like

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -32,6 +32,7 @@ import warnings
 import numpy as np
 
 from pandas._libs import lib
+from pandas.compat.numpy import np_version_gte1p24
 
 from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
 from pandas.core.dtypes.common import (
@@ -44,8 +45,6 @@ from pandas.core.dtypes.generic import (
     ABCSeries,
 )
 from pandas.core.dtypes.inference import iterable_not_string
-
-from pandas.util.version import Version
 
 if TYPE_CHECKING:
     from pandas._typing import (
@@ -238,7 +237,7 @@ def asarray_tuplesafe(values: Iterable, dtype: NpDtype | None = None) -> ArrayLi
     try:
         with warnings.catch_warnings():
             # Can remove warning filter once NumPy 1.24 is min version
-            if Version(np.__version__) < Version("1.24.0"):
+            if not np_version_gte1p24:
                 warnings.simplefilter("ignore", np.VisibleDeprecationWarning)
             result = np.asarray(values, dtype=dtype)
     except ValueError:

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -27,6 +27,7 @@ from pandas import (
     RangeIndex,
 )
 import pandas._testing as tm
+from pandas.util.version import Version
 
 
 class TestCommon:
@@ -389,7 +390,10 @@ class TestCommon:
         warn = None
         if index.dtype.kind == "c" and dtype in ["float64", "int64", "uint64"]:
             # imaginary components discarded
-            warn = np.ComplexWarning
+            if Version(np.__version__) >= Version("1.25.0"):
+                warn = np.exceptions.ComplexWarning
+            else:
+                warn = np.ComplexWarning
 
         is_pyarrow_str = str(index.dtype) == "string[pyarrow]" and dtype == "category"
         try:

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -13,6 +13,7 @@ import numpy as np
 import pytest
 
 from pandas.compat import IS64
+from pandas.compat.numpy import np_version_gte1p25
 
 from pandas.core.dtypes.common import (
     is_integer_dtype,
@@ -27,7 +28,6 @@ from pandas import (
     RangeIndex,
 )
 import pandas._testing as tm
-from pandas.util.version import Version
 
 
 class TestCommon:
@@ -390,7 +390,7 @@ class TestCommon:
         warn = None
         if index.dtype.kind == "c" and dtype in ["float64", "int64", "uint64"]:
             # imaginary components discarded
-            if Version(np.__version__) >= Version("1.25.0"):
+            if np_version_gte1p25:
                 warn = np.exceptions.ComplexWarning
             else:
                 warn = np.ComplexWarning


### PR DESCRIPTION
Due to NumPy's main namespace being changed in https://github.com/numpy/numpy/pull/24316, here I update warning imports.

- [ ] closes #xxxx
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
