### PR TITLE
REF: de-duplicate test_direct_arith_with_ndframe_returns_not_implemented

### DIFF
--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -269,6 +269,26 @@ else:
 EMPTY_STRING_PATTERN = re.compile("^$")
 
 
+arithmetic_dunder_methods = [
+    "__add__",
+    "__radd__",
+    "__sub__",
+    "__rsub__",
+    "__mul__",
+    "__rmul__",
+    "__floordiv__",
+    "__rfloordiv__",
+    "__truediv__",
+    "__rtruediv__",
+    "__pow__",
+    "__rpow__",
+    "__mod__",
+    "__rmod__",
+]
+
+comparison_dunder_methods = ["__eq__", "__ne__", "__le__", "__lt__", "__ge__", "__gt__"]
+
+
 def reset_display_options() -> None:
     """
     Reset the display options for printing and representing objects.

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -974,25 +974,9 @@ def ea_scalar_and_dtype(request):
 # ----------------------------------------------------------------
 # Operators & Operations
 # ----------------------------------------------------------------
-_all_arithmetic_operators = [
-    "__add__",
-    "__radd__",
-    "__sub__",
-    "__rsub__",
-    "__mul__",
-    "__rmul__",
-    "__floordiv__",
-    "__rfloordiv__",
-    "__truediv__",
-    "__rtruediv__",
-    "__pow__",
-    "__rpow__",
-    "__mod__",
-    "__rmod__",
-]
 
 
-@pytest.fixture(params=_all_arithmetic_operators)
+@pytest.fixture(params=tm.arithmetic_dunder_methods)
 def all_arithmetic_operators(request):
     """
     Fixture for dunder names for common arithmetic operations.

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -157,6 +157,11 @@ if TYPE_CHECKING:
 DTScalarOrNaT = Union[DatetimeLikeScalar, NaTType]
 
 
+def _make_unpacked_invalid_op(op_name: str):
+    op = make_invalid_op(op_name)
+    return unpack_zerodim_and_defer(op_name)(op)
+
+
 def _period_dispatch(meth: F) -> F:
     """
     For PeriodArray methods, dispatch to DatetimeArray and re-wrap the results
@@ -979,18 +984,18 @@ class DatetimeLikeArrayMixin(  # type: ignore[misc]
 
     # pow is invalid for all three subclasses; TimedeltaArray will override
     #  the multiplication and division ops
-    __pow__ = make_invalid_op("__pow__")
-    __rpow__ = make_invalid_op("__rpow__")
-    __mul__ = make_invalid_op("__mul__")
-    __rmul__ = make_invalid_op("__rmul__")
-    __truediv__ = make_invalid_op("__truediv__")
-    __rtruediv__ = make_invalid_op("__rtruediv__")
-    __floordiv__ = make_invalid_op("__floordiv__")
-    __rfloordiv__ = make_invalid_op("__rfloordiv__")
-    __mod__ = make_invalid_op("__mod__")
-    __rmod__ = make_invalid_op("__rmod__")
-    __divmod__ = make_invalid_op("__divmod__")
-    __rdivmod__ = make_invalid_op("__rdivmod__")
+    __pow__ = _make_unpacked_invalid_op("__pow__")
+    __rpow__ = _make_unpacked_invalid_op("__rpow__")
+    __mul__ = _make_unpacked_invalid_op("__mul__")
+    __rmul__ = _make_unpacked_invalid_op("__rmul__")
+    __truediv__ = _make_unpacked_invalid_op("__truediv__")
+    __rtruediv__ = _make_unpacked_invalid_op("__rtruediv__")
+    __floordiv__ = _make_unpacked_invalid_op("__floordiv__")
+    __rfloordiv__ = _make_unpacked_invalid_op("__rfloordiv__")
+    __mod__ = _make_unpacked_invalid_op("__mod__")
+    __rmod__ = _make_unpacked_invalid_op("__rmod__")
+    __divmod__ = _make_unpacked_invalid_op("__divmod__")
+    __rdivmod__ = _make_unpacked_invalid_op("__rdivmod__")
 
     @final
     def _get_i8_values_and_mask(

--- a/pandas/tests/extension/base/ops.py
+++ b/pandas/tests/extension/base/ops.py
@@ -167,19 +167,24 @@ class BaseArithmeticOpsTests(BaseOpsUtil):
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("box", [pd.Series, pd.DataFrame, pd.Index])
-    def test_direct_arith_with_ndframe_returns_not_implemented(self, data, box):
+    @pytest.mark.parametrize(
+        "op_name",
+        [
+            x
+            for x in tm.arithmetic_dunder_methods + tm.comparison_dunder_methods
+            if not x.startswith("__r")
+        ],
+    )
+    def test_direct_arith_with_ndframe_returns_not_implemented(
+        self, data, box, op_name
+    ):
         # EAs should return NotImplemented for ops with Series/DataFrame/Index
         # Pandas takes care of unboxing the series and calling the EA's op.
         other = box(data)
 
-        op_names = tm.arithmetic_dunder_methods + tm.comparison_dunder_methods
-        op_names = [x for x in op_names if not x.startswith("__r")]
-        for op_name in op_names:
-            # We use a loop here instead of fixture to avoid overhead from
-            #  re-creating 'data' many times.
-            if hasattr(data, op_name):
-                result = getattr(data, op_name)(other)
-                assert result is NotImplemented
+        if hasattr(data, op_name):
+            result = getattr(data, op_name)(other)
+            assert result is NotImplemented
 
 
 class BaseComparisonOpsTests(BaseOpsUtil):

--- a/pandas/tests/extension/test_period.py
+++ b/pandas/tests/extension/test_period.py
@@ -131,17 +131,6 @@ class TestArithmeticOps(BasePeriodTests, base.BaseArithmeticOpsTests):
         with pytest.raises(TypeError, match=msg):
             s + data
 
-    def test_direct_arith_with_ndframe_returns_not_implemented(
-        self, data, frame_or_series
-    ):
-        # Override to use __sub__ instead of __add__
-        other = pd.Series(data)
-        if frame_or_series is pd.DataFrame:
-            other = other.to_frame()
-
-        result = data.__sub__(other)
-        assert result is NotImplemented
-
 
 class TestCasting(BasePeriodTests, base.BaseCastingTests):
     pass


### PR DESCRIPTION
Also extends it to test for Index and all the arithmetic/comparison methods instead of just `__add__`.  Uses a loop inside the test bc im leaning towards trying to slow the expansion of the test suite, but not super-opposed to parametrizing if reviewers have strong opinions.
