### PR TITLE
xfail EA tests when EA data is unhashable

### DIFF
--- a/pandas/tests/extension/base/groupby.py
+++ b/pandas/tests/extension/base/groupby.py
@@ -111,6 +111,11 @@ class BaseGroupbyTests(BaseExtensionTests):
         tm.assert_series_equal(result, expected)
 
     def test_groupby_extension_transform(self, data_for_grouping):
+        try:
+            hash(data_for_grouping[0])
+        except TypeError as e:
+            pytest.skip(str(e))
+            return
         is_bool = data_for_grouping.dtype._is_boolean
 
         valid = data_for_grouping[~data_for_grouping.isna()]
@@ -129,6 +134,11 @@ class BaseGroupbyTests(BaseExtensionTests):
         tm.assert_series_equal(result, expected)
 
     def test_groupby_extension_apply(self, data_for_grouping, groupby_apply_op):
+        try:
+            hash(data_for_grouping[0])
+        except TypeError as e:
+            pytest.skip(str(e))
+            return
         df = pd.DataFrame({"A": [1, 1, 2, 2, 3, 3, 1, 4], "B": data_for_grouping})
         df.groupby("B", group_keys=False).apply(groupby_apply_op)
         df.groupby("B", group_keys=False).A.apply(groupby_apply_op)

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -238,6 +238,11 @@ class BaseMethodsTests(BaseExtensionTests):
 
     @pytest.mark.parametrize("ascending", [True, False])
     def test_sort_values_frame(self, data_for_sorting, ascending):
+        try:
+            hash(data_for_sorting[0])
+        except TypeError as e:
+            pytest.skip(str(e))
+            return
         df = pd.DataFrame({"A": [1, 2, 1], "B": data_for_sorting})
         result = df.sort_values(["A", "B"])
         expected = pd.DataFrame(
@@ -257,6 +262,11 @@ class BaseMethodsTests(BaseExtensionTests):
         assert result[0] == duplicated[0]
 
     def test_factorize(self, data_for_grouping):
+        try:
+            hash(data_for_grouping[0])
+        except TypeError as e:
+            pytest.skip(str(e))
+            return
         codes, uniques = pd.factorize(data_for_grouping, use_na_sentinel=True)
 
         is_bool = data_for_grouping.dtype._is_boolean
@@ -272,6 +282,11 @@ class BaseMethodsTests(BaseExtensionTests):
         tm.assert_extension_array_equal(uniques, expected_uniques)
 
     def test_factorize_equivalence(self, data_for_grouping):
+        try:
+            hash(data_for_grouping[0])
+        except TypeError as e:
+            pytest.skip(str(e))
+            return
         codes_1, uniques_1 = pd.factorize(data_for_grouping, use_na_sentinel=True)
         codes_2, uniques_2 = data_for_grouping.factorize(use_na_sentinel=True)
 
@@ -480,6 +495,11 @@ class BaseMethodsTests(BaseExtensionTests):
             hash(data)
 
     def test_hash_pandas_object_works(self, data, as_frame):
+        try:
+            hash(data[0])
+        except TypeError as e:
+            pytest.skip(str(e))
+            return
         # https://github.com/pandas-dev/pandas/issues/23066
         data = pd.Series(data)
         if as_frame:

--- a/pandas/tests/extension/base/reshaping.py
+++ b/pandas/tests/extension/base/reshaping.py
@@ -214,6 +214,11 @@ class BaseReshapingTests(BaseExtensionTests):
 
     def test_merge_on_extension_array(self, data):
         # GH 23020
+        try:
+            hash(data[0])
+        except TypeError as e:
+            pytest.skip(str(e))
+            return
         a, b = data[:2]
         key = type(data)._from_sequence([a, b], dtype=data.dtype)
 
@@ -229,6 +234,11 @@ class BaseReshapingTests(BaseExtensionTests):
 
     def test_merge_on_extension_array_duplicates(self, data):
         # GH 23020
+        try:
+            hash(data[0])
+        except TypeError as e:
+            pytest.skip(str(e))
+            return
         a, b = data[:2]
         key = type(data)._from_sequence([a, b, a], dtype=data.dtype)
         df1 = pd.DataFrame({"key": key, "val": [1, 2, 3]})


### PR DESCRIPTION
The `uncertainties` datatype is not hashable.  It's wrapper-style implementation also leads to confusion when testing whether AffineScalarFunc objects are instances of typing.Hashable (`isinstance` says True, but `hash` raises `TypeError`).  These changes skip specific groupby, factorize, and hashing tests but otherwise allow maximal testing of extension arrays without undue interference with the CI/CD system.

In this passes initial review muster, I could create a test case to demonstrate, but that will require lots of extra work to create a test case that fits all the CI/CD rules, but I'd like comments first.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
