### PR TITLE
REF: simplify fixtures

### DIFF
--- a/pandas/tests/extension/conftest.py
+++ b/pandas/tests/extension/conftest.py
@@ -26,12 +26,17 @@ def data():
 
 
 @pytest.fixture
-def data_for_twos():
+def data_for_twos(dtype):
     """
     Length-100 array in which all the elements are two.
 
     Call pytest.skip in your fixture if the dtype does not support divmod.
     """
+    if not (dtype._is_numeric or dtype.kind == "m"):
+        # Object-dtypes may want to allow this, but for the most part
+        #  only numeric and timedelta-like dtypes will need to implement this.
+        pytest.skip("Not a numeric dtype")
+
     raise NotImplementedError
 
 
@@ -112,9 +117,9 @@ def na_cmp():
 
 
 @pytest.fixture
-def na_value():
-    """The scalar missing value for this type. Default 'None'"""
-    return None
+def na_value(dtype):
+    """The scalar missing value for this type. Default dtype.na_value"""
+    return dtype.na_value
 
 
 @pytest.fixture

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -57,11 +57,6 @@ def na_cmp():
 
 
 @pytest.fixture
-def na_value():
-    return decimal.Decimal("NaN")
-
-
-@pytest.fixture
 def data_for_grouping():
     b = decimal.Decimal("1.0")
     a = decimal.Decimal("0.0")

--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -53,11 +53,6 @@ def data_missing_for_sorting():
 
 
 @pytest.fixture
-def na_value(dtype):
-    return dtype.na_value
-
-
-@pytest.fixture
 def na_cmp():
     return operator.eq
 
@@ -76,11 +71,6 @@ def data_for_grouping():
             {"c": 2},
         ]
     )
-
-
-@pytest.fixture
-def data_for_twos(dtype):
-    pytest.skip("Not a numeric dtype")
 
 
 class BaseJSON:

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -265,12 +265,6 @@ def data_for_twos(data):
     # TODO: skip otherwise?
 
 
-@pytest.fixture
-def na_value():
-    """The scalar missing value for this type. Default 'None'"""
-    return pd.NA
-
-
 class TestBaseCasting(base.BaseCastingTests):
     def test_astype_str(self, data, request):
         pa_dtype = data.dtype.pyarrow_dtype

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -68,16 +68,6 @@ def data_missing_for_sorting():
 
 
 @pytest.fixture
-def data_for_twos(dtype):
-    pytest.skip("Not a numeric dtype")
-
-
-@pytest.fixture
-def na_value():
-    return np.nan
-
-
-@pytest.fixture
 def data_for_grouping():
     return Categorical(["a", "a", None, None, "b", "b", "a", "c"])
 

--- a/pandas/tests/extension/test_datetime.py
+++ b/pandas/tests/extension/test_datetime.py
@@ -74,21 +74,11 @@ def data_for_grouping(dtype):
 
 
 @pytest.fixture
-def data_for_twos(dtype):
-    pytest.skip("Not a numeric dtype.")
-
-
-@pytest.fixture
 def na_cmp():
     def cmp(a, b):
         return a is pd.NaT and a is b
 
     return cmp
-
-
-@pytest.fixture
-def na_value():
-    return pd.NaT
 
 
 # ----------------------------------------------------------------------------

--- a/pandas/tests/extension/test_interval.py
+++ b/pandas/tests/extension/test_interval.py
@@ -61,11 +61,6 @@ def data_missing_for_sorting():
 
 
 @pytest.fixture
-def na_value():
-    return np.nan
-
-
-@pytest.fixture
 def data_for_grouping():
     a = (0, 1)
     b = (1, 2)

--- a/pandas/tests/extension/test_masked.py
+++ b/pandas/tests/extension/test_masked.py
@@ -141,11 +141,6 @@ def na_cmp():
 
 
 @pytest.fixture
-def na_value():
-    return pd.NA
-
-
-@pytest.fixture
 def data_for_grouping(dtype):
     if dtype.kind == "f":
         b = 0.1

--- a/pandas/tests/extension/test_numpy.py
+++ b/pandas/tests/extension/test_numpy.py
@@ -98,11 +98,6 @@ def data_missing(allow_in_pandas, dtype):
 
 
 @pytest.fixture
-def na_value():
-    return np.nan
-
-
-@pytest.fixture
 def na_cmp():
     def cmp(a, b):
         return np.isnan(a) and np.isnan(b)

--- a/pandas/tests/extension/test_period.py
+++ b/pandas/tests/extension/test_period.py
@@ -22,7 +22,6 @@ from pandas.compat.numpy import np_version_gte1p24
 
 from pandas.core.dtypes.dtypes import PeriodDtype
 
-import pandas as pd
 import pandas._testing as tm
 from pandas.core.arrays import PeriodArray
 from pandas.tests.extension import base
@@ -36,11 +35,6 @@ def dtype(request):
 @pytest.fixture
 def data(dtype):
     return PeriodArray(np.arange(1970, 2070), dtype=dtype)
-
-
-@pytest.fixture
-def data_for_twos(dtype):
-    pytest.skip("Not a numeric dtype")
 
 
 @pytest.fixture
@@ -65,11 +59,6 @@ def data_for_grouping(dtype):
     A = 2017
     C = 2019
     return PeriodArray([B, B, NA, NA, A, A, B, C], dtype=dtype)
-
-
-@pytest.fixture
-def na_value():
-    return pd.NaT
 
 
 class BasePeriodTests:

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -84,11 +84,6 @@ def data_missing_for_sorting(request):
 
 
 @pytest.fixture
-def na_value():
-    return np.nan
-
-
-@pytest.fixture
 def na_cmp():
     return lambda left, right: pd.isna(left) and pd.isna(right)
 

--- a/pandas/tests/extension/test_string.py
+++ b/pandas/tests/extension/test_string.py
@@ -84,11 +84,6 @@ def data_missing_for_sorting(dtype, chunked):
 
 
 @pytest.fixture
-def na_value():
-    return pd.NA
-
-
-@pytest.fixture
 def data_for_grouping(dtype, chunked):
     arr = dtype.construct_array_type()._from_sequence(
         ["B", "B", pd.NA, pd.NA, "A", "A", "B", "C"]


### PR DESCRIPTION
I expect the na_value fixture is unnecessary altogether, saving that for another pass.