### PR TITLE
test_map: use data_missing to exercise na_action

### DIFF
--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -95,9 +95,9 @@ class BaseMethodsTests(BaseExtensionTests):
         assert isinstance(result, pd.Series)
 
     @pytest.mark.parametrize("na_action", [None, "ignore"])
-    def test_map(self, data, na_action):
-        result = data.map(lambda x: x, na_action=na_action)
-        expected = data.to_numpy()
+    def test_map(self, data_missing, na_action):
+        result = data_missing.map(lambda x: x, na_action=na_action)
+        expected = data_missing.to_numpy()
         tm.assert_numpy_array_equal(result, expected)
 
     def test_argsort(self, data_for_sorting):


### PR DESCRIPTION
Change `data` to `data_missing` to exercise the `na_action` parameter.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
