### PR TITLE
Clean up autosummary usage

### DIFF
--- a/doc/_templates/autosummary/class.rst
+++ b/doc/_templates/autosummary/class.rst
@@ -1,33 +1,32 @@
-{% extends "!autosummary/class.rst" %}
+{{ fullname | escape | underline}}
 
-{% block methods %}
-{% if methods %}
+.. currentmodule:: {{ module }}
 
-..
-   HACK -- the point here is that we don't want this to appear in the output, but the autosummary should still generate the pages.
+.. autoclass:: {{ objname }}
+
+   {% block methods %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
    .. autosummary::
-      :toctree:
-      {% for item in all_methods %}
-      {%- if not item.startswith('_') or item in ['__call__'] %}
-      {{ name }}.{{ item }}
-      {%- endif -%}
-      {%- endfor %}
+   {% for item in attributes %}
+      {% if item in members and not item.startswith('_') %}
+        ~{{ name }}.{{ item }}
+      {% endif %}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
 
-{% endif %}
-{% endblock %}
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
 
-{% block attributes %}
-{% if attributes %}
-
-..
-   HACK -- the point here is that we don't want this to appear in the output, but the autosummary should still generate the pages.
    .. autosummary::
-      :toctree:
-      {% for item in all_attributes %}
-      {%- if not item.startswith('_') %}
-      {{ name }}.{{ item }}
-      {%- endif -%}
-      {%- endfor %}
-
-{% endif %}
-{% endblock %}
+   {% for item in methods %}
+      {% if item in members and (not item.startswith('_') or item in ['__call__']) %}
+        ~{{ name }}.{{ item }}
+      {% endif %}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -130,6 +130,8 @@ autosummary_generate = True if include_api else ["index"]
 autodoc_typehints = "none"
 
 # numpydoc
+numpydoc_show_class_members = False
+numpydoc_show_inherited_class_members = False
 numpydoc_attributes_as_param_list = False
 
 # matplotlib plot directive

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -76,7 +76,6 @@ exclude_patterns = [
     # to ensure that include files (partial pages) aren't built, exclude them
     # https://github.com/sphinx-doc/sphinx/issues/1965#issuecomment-124732907
     "**/includes/**",
-    "**/api/pandas.Series.dt.rst",
 ]
 try:
     import nbconvert

--- a/doc/source/reference/series.rst
+++ b/doc/source/reference/series.rst
@@ -273,6 +273,19 @@ pandas provides dtype-specific methods under various accessors.
 These are separate namespaces within :class:`Series` that only apply
 to specific data types.
 
+.. autosummary::
+    :toctree: api/
+    :nosignatures:
+    :template: autosummary/accessor.rst
+
+    Series.str
+    Series.cat
+    Series.dt
+    Series.sparse
+    DataFrame.sparse
+    Index.str
+
+
 =========================== =================================
 Data Type                   Accessor
 =========================== =================================
@@ -457,22 +470,6 @@ strings and apply several methods to it. These can be accessed like
    Series.str.isnumeric
    Series.str.isdecimal
    Series.str.get_dummies
-
-..
-    The following is needed to ensure the generated pages are created with the
-    correct template (otherwise they would be created in the Series/Index class page)
-
-..
-    .. autosummary::
-       :toctree: api/
-       :template: autosummary/accessor.rst
-
-       Series.str
-       Series.cat
-       Series.dt
-       Series.sparse
-       DataFrame.sparse
-       Index.str
 
 .. _api.series.cat:
 


### PR DESCRIPTION
This PR stops numpydoc from producing the summary tables for a class's methods and attributes, preferring to instead rely on autosummary. This approach allows using a class.rst template that isn't relying on hacks to get autosummary to still generate stub pages. In a follow-up PR we can look into removing more of those hacks throughout the code base, this PR is just scoped to resolve the issues with the main class.rst template.

- [x] closes #54454 
- [x] closes https://github.com/pandas-dev/pandas/issues/52937
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
