### PR TITLE
CI: Set back the schedule

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,8 +14,8 @@ name: Wheel builder
 
 on:
   schedule:
-  # 8:50 UTC every day
-  - cron: "50 8 * * *"
+  # 3:27 UTC every day
+  - cron: "27 3 * * *"
   push:
   pull_request:
     types: [labeled, opened, synchronize, reopened]


### PR DESCRIPTION
The wheel builds didn't trigger in time.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
