### PR TITLE
#51826_Fixed bug when np.nan is used as index value with .reindex on …

### DIFF
--- a/pandas/_libs/intervaltree.pxi.in
+++ b/pandas/_libs/intervaltree.pxi.in
@@ -193,7 +193,7 @@ cdef class IntervalTree(IntervalMixin):
 cdef take(ndarray source, ndarray indices):
     """Take the given positions from a 1D ndarray
     """
-    return PyArray_Take(source, indices, 0)
+    return source[indices]
 
 
 cdef sort_values_and_indices(all_values, all_indices, subset):

--- a/pandas/_libs/intervaltree.pxi.in
+++ b/pandas/_libs/intervaltree.pxi.in
@@ -193,13 +193,13 @@ cdef class IntervalTree(IntervalMixin):
 cdef take(ndarray source, ndarray indices):
     """Take the given positions from a 1D ndarray
     """
-    return PyArray_Take(source, indices, np.int64(0))
+    return PyArray_Take(source, indices, 0)
 
 
 cdef sort_values_and_indices(all_values, all_indices, subset):
     indices = take(all_indices, subset)
     values = take(all_values, subset)
-    sorter = PyArray_ArgSort(values, np.int64(0), NPY_QUICKSORT)
+    sorter = PyArray_ArgSort(values, 0, NPY_QUICKSORT)
     sorted_values = take(values, sorter)
     sorted_indices = take(indices, sorter)
     return sorted_values, sorted_indices

--- a/pandas/_libs/intervaltree.pxi.in
+++ b/pandas/_libs/intervaltree.pxi.in
@@ -193,7 +193,7 @@ cdef class IntervalTree(IntervalMixin):
 cdef take(ndarray source, ndarray indices):
     """Take the given positions from a 1D ndarray
     """
-    return source[indices]
+    return PyArray_Take(source, indices, 0)
 
 
 cdef sort_values_and_indices(all_values, all_indices, subset):

--- a/pandas/_libs/intervaltree.pxi.in
+++ b/pandas/_libs/intervaltree.pxi.in
@@ -193,13 +193,13 @@ cdef class IntervalTree(IntervalMixin):
 cdef take(ndarray source, ndarray indices):
     """Take the given positions from a 1D ndarray
     """
-    return PyArray_Take(source, indices, 0)
+    return PyArray_Take(source, indices, np.int64(0))
 
 
 cdef sort_values_and_indices(all_values, all_indices, subset):
     indices = take(all_indices, subset)
     values = take(all_values, subset)
-    sorter = PyArray_ArgSort(values, 0, NPY_QUICKSORT)
+    sorter = PyArray_ArgSort(values, np.int64(0), NPY_QUICKSORT)
     sorted_values = take(values, sorter)
     sorted_indices = take(indices, sorter)
     return sorted_values, sorted_indices

--- a/pandas/_libs/intervaltree.pxi.in
+++ b/pandas/_libs/intervaltree.pxi.in
@@ -391,6 +391,10 @@ cdef class {{dtype_title}}Closed{{closed_title}}IntervalNode(IntervalNode):
         """Recursively query this node and its sub-nodes for intervals that
         overlap with the query point.
         """
+        # GH 51826: ensures nan is handled properly during reindexing
+        if np.isnan(point):
+            return
+
         cdef:
             int64_t[:] indices
             {{dtype}}_t[:] values

--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -184,8 +184,8 @@ class TestIntervalIndexInsideMultiIndex:
     )
     def test_interval_index_reindex_behavior(self, base, expected_result):
         # GH 51826
-        left = np.arange(base, dtype=np.int32)
-        right = np.arange(1, base + 1, dtype=np.int32)
+        left = np.arange(base)
+        right = np.arange(1, base + 1)
         d = Series(range(base), index=IntervalIndex.from_arrays(left, right))
         result = d.reindex(index=[np.nan, 1.0])
         tm.assert_series_equal(result, expected_result)

--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -176,10 +176,10 @@ class TestIntervalIndexInsideMultiIndex:
     @pytest.mark.parametrize(
         "base, expected_result",
         [
-            (10, Series([np.nan, 0.0], index=[np.nan, 1.0], dtype=np.float64)),
-            (100, Series([np.nan, 0.0], index=[np.nan, 1.0], dtype=np.float64)),
-            (101, Series([np.nan, 0.0], index=[np.nan, 1.0], dtype=np.float64)),
-            (1010, Series([np.nan, 0.0], index=[np.nan, 1.0], dtype=np.float64)),
+            (10, Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)),
+            (100, Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)),
+            (101, Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)),
+            (1010, Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)),
         ],
     )
     def test_interval_index_reindex_behavior(self, base, expected_result):

--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -189,4 +189,4 @@ class TestIntervalIndexInsideMultiIndex:
             index=IntervalIndex.from_arrays(range(base), range(1, base + 1)),
         )
         result = d.reindex(index=[np.nan, 1.0])
-        tm.assert_series_equal(result, expected_result)
+        tm.assert_series_equal(result, expected_result, check_dtype=False)

--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -184,11 +184,8 @@ class TestIntervalIndexInsideMultiIndex:
     )
     def test_interval_index_reindex_behavior(self, base, expected_result):
         # GH 51826
-        left = np.arange(base, dtype=np.int64)
-        right = np.arange(1, base + 1, dtype=np.int64)
-        d = Series(
-            range(base),
-            index=IntervalIndex.from_arrays(left, right),
-        )
+        left = np.arange(base, dtype=np.int32)
+        right = np.arange(1, base + 1, dtype=np.int32)
+        d = Series(range(base), index=IntervalIndex.from_arrays(left, right))
         result = d.reindex(index=[np.nan, 1.0])
         tm.assert_series_equal(result, expected_result)

--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -172,3 +172,21 @@ class TestIntervalIndexInsideMultiIndex:
         )
         expected = Series([1, 6, 2, 8, 7], index=expected_index, name="value")
         tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "base, expected_result",
+        [
+            (10, Series([np.nan, 0], index=[np.nan, 1.0], dtype=float)),
+            (100, Series([np.nan, 0], index=[np.nan, 1.0], dtype=float)),
+            (101, Series([np.nan, 0], index=[np.nan, 1.0], dtype=float)),
+            (1010, Series([np.nan, 0], index=[np.nan, 1.0], dtype=float)),
+        ],
+    )
+    def test_interval_index_reindex_behavior(self, base, expected_result):
+        # GH 51826
+        d = Series(
+            range(base),
+            index=IntervalIndex.from_arrays(range(base), range(1, base + 1)),
+        )
+        result = d.reindex(index=[np.nan, 1.0])
+        tm.assert_series_equal(result, expected_result)

--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -176,10 +176,10 @@ class TestIntervalIndexInsideMultiIndex:
     @pytest.mark.parametrize(
         "base, expected_result",
         [
-            (10, Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)),
-            (100, Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)),
-            (101, Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)),
-            (1010, Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)),
+            (10, Series([np.nan, 0.0], index=[np.nan, 1.0], dtype=np.float64)),
+            (100, Series([np.nan, 0.0], index=[np.nan, 1.0], dtype=np.float64)),
+            (101, Series([np.nan, 0.0], index=[np.nan, 1.0], dtype=np.float64)),
+            (1010, Series([np.nan, 0.0], index=[np.nan, 1.0], dtype=np.float64)),
         ],
     )
     def test_interval_index_reindex_behavior(self, base, expected_result):

--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -184,9 +184,11 @@ class TestIntervalIndexInsideMultiIndex:
     )
     def test_interval_index_reindex_behavior(self, base, expected_result):
         # GH 51826
+        left = np.arange(base, dtype=np.int64)
+        right = np.arange(1, base + 1, dtype=np.int64)
         d = Series(
             range(base),
-            index=IntervalIndex.from_arrays(range(base), range(1, base + 1)),
+            index=IntervalIndex.from_arrays(left, right),
         )
         result = d.reindex(index=[np.nan, 1.0])
         tm.assert_series_equal(result, expected_result)

--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -176,10 +176,10 @@ class TestIntervalIndexInsideMultiIndex:
     @pytest.mark.parametrize(
         "base, expected_result",
         [
-            (10, Series([np.nan, 0], index=[np.nan, 1.0], dtype=float)),
-            (100, Series([np.nan, 0], index=[np.nan, 1.0], dtype=float)),
-            (101, Series([np.nan, 0], index=[np.nan, 1.0], dtype=float)),
-            (1010, Series([np.nan, 0], index=[np.nan, 1.0], dtype=float)),
+            (10, Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)),
+            (100, Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)),
+            (101, Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)),
+            (1010, Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)),
         ],
     )
     def test_interval_index_reindex_behavior(self, base, expected_result):
@@ -189,4 +189,4 @@ class TestIntervalIndexInsideMultiIndex:
             index=IntervalIndex.from_arrays(range(base), range(1, base + 1)),
         )
         result = d.reindex(index=[np.nan, 1.0])
-        tm.assert_series_equal(result, expected_result, check_dtype=False)
+        tm.assert_series_equal(result, expected_result)


### PR DESCRIPTION

- [x] closes #51826 
- [x] [Tests added and passed]
- [x] All [code checks passed]

