### PR TITLE
Speed up StringDtype arrow implementation for merge

### DIFF
--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -90,6 +90,7 @@ from pandas.core.arrays import (
     ExtensionArray,
 )
 from pandas.core.arrays._mixins import NDArrayBackedExtensionArray
+from pandas.core.arrays.string_ import StringDtype
 import pandas.core.common as com
 from pandas.core.construction import (
     ensure_wrapped_if_datetimelike,
@@ -2407,7 +2408,7 @@ def _factorize_keys(
                 or is_string_dtype(lk.dtype)
                 and not sort
             )
-            or (is_string_dtype(lk.dtype) and lk.dtype.storage == "pyarrow")  # type: ignore[attr-defined]  # noqa: E501
+            or (isinstance(lk.dtype, StringDtype) and lk.dtype.storage == "pyarrow")
         ):
             lk, _ = lk._values_for_factorize()
 
@@ -2415,7 +2416,7 @@ def _factorize_keys(
             # "_values_for_factorize"
             rk, _ = rk._values_for_factorize()  # type: ignore[union-attr]
         elif (isinstance(lk.dtype, ArrowDtype) and is_string_dtype(lk.dtype)) or (
-            is_string_dtype(lk.dtype) and lk.dtype.storage == "pyarrow"  # type: ignore[attr-defined]  # noqa: E501
+            isinstance(lk.dtype, StringDtype) and lk.dtype.storage == "pyarrow"
         ):
             import pyarrow as pa
             import pyarrow.compute as pc

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -76,6 +76,7 @@ from pandas.core.dtypes.missing import (
     na_value_for_dtype,
 )
 
+import pandas as pd
 from pandas import (
     ArrowDtype,
     Categorical,
@@ -2407,13 +2408,20 @@ def _factorize_keys(
                 or is_string_dtype(lk.dtype)
                 and not sort
             )
+            or is_string_dtype(lk.dtype)
+            and lk.dtype.storage == "pyarrow"
         ):
             lk, _ = lk._values_for_factorize()
 
             # error: Item "ndarray" of "Union[Any, ndarray]" has no attribute
             # "_values_for_factorize"
             rk, _ = rk._values_for_factorize()  # type: ignore[union-attr]
-        elif isinstance(lk.dtype, ArrowDtype) and is_string_dtype(lk.dtype):
+        elif (
+            isinstance(lk.dtype, ArrowDtype)
+            and is_string_dtype(lk.dtype)
+            or isinstance(lk.dtype, pd.StringDtype)
+            and lk.dtype.storage == "pyarrow"
+        ):
             import pyarrow as pa
             import pyarrow.compute as pc
 

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -2407,7 +2407,7 @@ def _factorize_keys(
                 or is_string_dtype(lk.dtype)
                 and not sort
             )
-            or (is_string_dtype(lk.dtype) and lk.dtype.storage == "pyarrow")
+            or (is_string_dtype(lk.dtype) and lk.dtype.storage == "pyarrow")  # type: ignore[attr-defined]  # noqa: E501
         ):
             lk, _ = lk._values_for_factorize()
 
@@ -2415,7 +2415,7 @@ def _factorize_keys(
             # "_values_for_factorize"
             rk, _ = rk._values_for_factorize()  # type: ignore[union-attr]
         elif (isinstance(lk.dtype, ArrowDtype) and is_string_dtype(lk.dtype)) or (
-            is_string_dtype(lk.dtype) and lk.dtype.storage == "pyarrow"
+            is_string_dtype(lk.dtype) and lk.dtype.storage == "pyarrow"  # type: ignore[attr-defined]  # noqa: E501
         ):
             import pyarrow as pa
             import pyarrow.compute as pc

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -2400,22 +2400,7 @@ def _factorize_keys(
         rk = ensure_int64(rk.codes)
 
     elif isinstance(lk, ExtensionArray) and lk.dtype == rk.dtype:
-        if not isinstance(lk, BaseMaskedArray) and not (
-            # exclude arrow dtypes that would get cast to object
-            isinstance(lk.dtype, ArrowDtype)
-            and (
-                is_numeric_dtype(lk.dtype.numpy_dtype)
-                or is_string_dtype(lk.dtype)
-                and not sort
-            )
-            or (isinstance(lk.dtype, StringDtype) and lk.dtype.storage == "pyarrow")
-        ):
-            lk, _ = lk._values_for_factorize()
-
-            # error: Item "ndarray" of "Union[Any, ndarray]" has no attribute
-            # "_values_for_factorize"
-            rk, _ = rk._values_for_factorize()  # type: ignore[union-attr]
-        elif (isinstance(lk.dtype, ArrowDtype) and is_string_dtype(lk.dtype)) or (
+        if (isinstance(lk.dtype, ArrowDtype) and is_string_dtype(lk.dtype)) or (
             isinstance(lk.dtype, StringDtype) and lk.dtype.storage == "pyarrow"
         ):
             import pyarrow as pa
@@ -2439,6 +2424,21 @@ def _factorize_keys(
             if how == "right":
                 return rlab, llab, count
             return llab, rlab, count
+
+        if not isinstance(lk, BaseMaskedArray) and not (
+            # exclude arrow dtypes that would get cast to object
+            isinstance(lk.dtype, ArrowDtype)
+            and (
+                is_numeric_dtype(lk.dtype.numpy_dtype)
+                or is_string_dtype(lk.dtype)
+                and not sort
+            )
+        ):
+            lk, _ = lk._values_for_factorize()
+
+            # error: Item "ndarray" of "Union[Any, ndarray]" has no attribute
+            # "_values_for_factorize"
+            rk, _ = rk._values_for_factorize()  # type: ignore[union-attr]
 
     if needs_i8_conversion(lk.dtype) and lk.dtype == rk.dtype:
         # GH#23917 TODO: Needs tests for non-matching dtypes

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -76,7 +76,6 @@ from pandas.core.dtypes.missing import (
     na_value_for_dtype,
 )
 
-import pandas as pd
 from pandas import (
     ArrowDtype,
     Categorical,
@@ -2408,19 +2407,15 @@ def _factorize_keys(
                 or is_string_dtype(lk.dtype)
                 and not sort
             )
-            or is_string_dtype(lk.dtype)
-            and lk.dtype.storage == "pyarrow"
+            or (is_string_dtype(lk.dtype) and lk.dtype.storage == "pyarrow")
         ):
             lk, _ = lk._values_for_factorize()
 
             # error: Item "ndarray" of "Union[Any, ndarray]" has no attribute
             # "_values_for_factorize"
             rk, _ = rk._values_for_factorize()  # type: ignore[union-attr]
-        elif (
-            isinstance(lk.dtype, ArrowDtype)
-            and is_string_dtype(lk.dtype)
-            or isinstance(lk.dtype, pd.StringDtype)
-            and lk.dtype.storage == "pyarrow"
+        elif (isinstance(lk.dtype, ArrowDtype) and is_string_dtype(lk.dtype)) or (
+            is_string_dtype(lk.dtype) and lk.dtype.storage == "pyarrow"
         ):
             import pyarrow as pa
             import pyarrow.compute as pc


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

sorry @jbrockmendel :) I promise I'll work on an EA implementation after that string dtype with NumPy semantics