### PR TITLE
REF: implement Dtype.index_class

### DIFF
--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
         type_t,
     )
 
+    from pandas import Index
     from pandas.core.arrays import ExtensionArray
 
     # To parameterize on same ExtensionDtype
@@ -405,6 +406,16 @@ class ExtensionDtype:
         Immutable arrays are expected to raise TypeError on __setitem__ calls.
         """
         return False
+
+    @property
+    def index_class(self) -> type_t[Index]:
+        """
+        The Index subclass to return from Index.__new__ when this dtype is
+        encountered.
+        """
+        from pandas import Index
+
+        return Index
 
 
 class StorageExtensionDtype(ExtensionDtype):

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -15,6 +15,7 @@ import numpy as np
 
 from pandas._libs import missing as libmissing
 from pandas._libs.hashtable import object_hash
+from pandas._libs.properties import cache_readonly
 from pandas.errors import AbstractMethodError
 
 from pandas.core.dtypes.generic import (
@@ -407,7 +408,7 @@ class ExtensionDtype:
         """
         return False
 
-    @property
+    @cache_readonly
     def index_class(self) -> type_t[Index]:
         """
         The Index subclass to return from Index.__new__ when this dtype is

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -81,7 +81,11 @@ if TYPE_CHECKING:
 
     from pandas import (
         Categorical,
+        CategoricalIndex,
+        DatetimeIndex,
         Index,
+        IntervalIndex,
+        PeriodIndex,
     )
     from pandas.core.arrays import (
         BaseMaskedArray,
@@ -671,6 +675,12 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
 
         return find_common_type(non_cat_dtypes)
 
+    @cache_readonly
+    def index_class(self) -> type_t[CategoricalIndex]:
+        from pandas import CategoricalIndex
+
+        return CategoricalIndex
+
 
 @register_extension_dtype
 class DatetimeTZDtype(PandasExtensionDtype):
@@ -911,6 +921,12 @@ class DatetimeTZDtype(PandasExtensionDtype):
         self._tz = state["tz"]
         self._unit = state["unit"]
 
+    @cache_readonly
+    def index_class(self) -> type_t[DatetimeIndex]:
+        from pandas import DatetimeIndex
+
+        return DatetimeIndex
+
 
 @register_extension_dtype
 class PeriodDtype(PeriodDtypeBase, PandasExtensionDtype):
@@ -1120,6 +1136,12 @@ class PeriodDtype(PeriodDtypeBase, PandasExtensionDtype):
         if not results:
             return PeriodArray(np.array([], dtype="int64"), dtype=self, copy=False)
         return PeriodArray._concat_same_type(results)
+
+    @cache_readonly
+    def index_class(self) -> type_t[PeriodIndex]:
+        from pandas import PeriodIndex
+
+        return PeriodIndex
 
 
 @register_extension_dtype
@@ -1383,6 +1405,12 @@ class IntervalDtype(PandasExtensionDtype):
         if common == object:
             return np.dtype(object)
         return IntervalDtype(common, closed=closed)
+
+    @cache_readonly
+    def index_class(self) -> type_t[IntervalIndex]:
+        from pandas import IntervalIndex
+
+        return IntervalIndex
 
 
 class NumpyEADtype(ExtensionDtype):

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -594,24 +594,7 @@ class Index(IndexOpsMixin, PandasObject):
         # Delay import for perf. https://github.com/pandas-dev/pandas/pull/31423
 
         if isinstance(dtype, ExtensionDtype):
-            if isinstance(dtype, DatetimeTZDtype):
-                from pandas import DatetimeIndex
-
-                return DatetimeIndex
-            elif isinstance(dtype, CategoricalDtype):
-                from pandas import CategoricalIndex
-
-                return CategoricalIndex
-            elif isinstance(dtype, IntervalDtype):
-                from pandas import IntervalIndex
-
-                return IntervalIndex
-            elif isinstance(dtype, PeriodDtype):
-                from pandas import PeriodIndex
-
-                return PeriodIndex
-
-            return Index
+            return dtype.index_class
 
         if dtype.kind == "M":
             from pandas import DatetimeIndex


### PR DESCRIPTION
Allows EAs to specify what Index subclass they want to use.  Avoids special-casing pandas-internal EAs.

Small perf improvement

```
In [2]: dti = pd.date_range("2016-01-01", periods=3, tz="UTC")

In [3]: cat = dti.astype("category")

In [4]: %timeit pd.Index(dti)
6.39 µs ± 80 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each) # <- main
5.69 µs ± 368 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)  # <- PR

In [5]: %timeit pd.Index(cat)
6.37 µs ± 112 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)  # <- main
5.8 µs ± 135 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)  # <- PR

```