### PR TITLE
PERF: Reuse codes when grouping on a MultiIndex

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -100,7 +100,7 @@ Deprecations
 
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
-- Performance improvement :class:`DataFrameGroupBy` and :class:`SeriesGroupby` when grouping on index levels of a :class:`MultiIndex` (:issue:`??`)
+- Performance improvement :class:`DataFrameGroupBy` and :class:`SeriesGroupby` when grouping on index levels of a :class:`MultiIndex` (:issue:`54529`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -100,7 +100,7 @@ Deprecations
 
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
-- Performance improvement :class:`DataFrameGroupBy` and :class:`SeriesGroupby` when grouping on index levels of a :class:`MultiIndex` (:issue:`54529`)
+- Performance improvement in :class:`DataFrameGroupBy` and :class:`SeriesGroupby` when grouping on index levels of a :class:`MultiIndex` (:issue:`54529`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -100,7 +100,7 @@ Deprecations
 
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
--
+- Performance improvement :class:`DataFrameGroupBy` and :class:`SeriesGroupby` when grouping on index levels of a :class:`MultiIndex` (:issue:`??`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -549,6 +549,18 @@ class Grouping:
         self._dropna = dropna
         self._uniques = uniques
 
+        if in_axis and sort and dropna and isinstance(index, MultiIndex):
+            try:
+                lev = index._get_level_number(level)
+            except (ValueError, IndexError, KeyError):
+                pass
+            else:
+                level = index.levels[lev]
+                from pandas import RangeIndex
+
+                if level.is_monotonic_increasing and not isinstance(level, RangeIndex):
+                    self._cache = {"_codes_and_uniques": (index.codes[lev], level)}
+
         # we have a single grouper which may be a myriad of things,
         # some of which are dependent on the passing in level
 


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

When we create a Grouping using a level of a MultiIndex, in certain cases we can use the codes and uniques from the MultiIndex instead of computing them via factorize.

ASVs to come.