### PR TITLE
REF: Replace "pyarrow" string storage checks with variable

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -1996,3 +1996,8 @@ def warsaw(request) -> str:
     tzinfo for Europe/Warsaw using pytz, dateutil, or zoneinfo.
     """
     return request.param
+
+
+@pytest.fixture()
+def arrow_string_storage():
+    return ("pyarrow",)

--- a/pandas/tests/arrays/string_/__init__.py
+++ b/pandas/tests/arrays/string_/__init__.py
@@ -1,1 +1,0 @@
-arrow_string_storage = ("pyarrow",)

--- a/pandas/tests/arrays/string_/__init__.py
+++ b/pandas/tests/arrays/string_/__init__.py
@@ -1,0 +1,1 @@
+arrow_string_storage = ("pyarrow",)

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -10,6 +10,7 @@ from pandas.core.dtypes.common import is_dtype_equal
 import pandas as pd
 import pandas._testing as tm
 from pandas.core.arrays.string_arrow import ArrowStringArray
+from pandas.tests.arrays.string_ import arrow_string_storage
 from pandas.util.version import Version
 
 
@@ -116,7 +117,7 @@ def test_add(dtype):
 
 
 def test_add_2d(dtype, request):
-    if dtype.storage == "pyarrow":
+    if dtype.storage in arrow_string_storage:
         reason = "Failed: DID NOT RAISE <class 'ValueError'>"
         mark = pytest.mark.xfail(raises=None, reason=reason)
         request.node.add_marker(mark)
@@ -145,7 +146,7 @@ def test_add_sequence(dtype):
 
 
 def test_mul(dtype, request):
-    if dtype.storage == "pyarrow":
+    if dtype.storage in arrow_string_storage:
         reason = "unsupported operand type(s) for *: 'ArrowStringArray' and 'int'"
         mark = pytest.mark.xfail(raises=NotImplementedError, reason=reason)
         request.node.add_marker(mark)
@@ -370,7 +371,7 @@ def test_min_max(method, skipna, dtype, request):
 @pytest.mark.parametrize("method", ["min", "max"])
 @pytest.mark.parametrize("box", [pd.Series, pd.array])
 def test_min_max_numpy(method, box, dtype, request):
-    if dtype.storage == "pyarrow" and box is pd.array:
+    if dtype.storage in arrow_string_storage and box is pd.array:
         if box is pd.array:
             reason = "'<=' not supported between instances of 'str' and 'NoneType'"
         else:
@@ -397,7 +398,7 @@ def test_fillna_args(dtype, request):
     expected = pd.array(["a", "b"], dtype=dtype)
     tm.assert_extension_array_equal(res, expected)
 
-    if dtype.storage == "pyarrow":
+    if dtype.storage in arrow_string_storage:
         msg = "Invalid value '1' for dtype string"
     else:
         msg = "Cannot set non-string value '1' into a StringArray."
@@ -506,7 +507,7 @@ def test_use_inf_as_na(values, expected, dtype):
 def test_memory_usage(dtype):
     # GH 33963
 
-    if dtype.storage == "pyarrow":
+    if dtype.storage in arrow_string_storage:
         pytest.skip(f"not applicable for {dtype.storage}")
 
     series = pd.Series(["a", "b", "c"], dtype=dtype)

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -10,7 +10,6 @@ from pandas.core.dtypes.common import is_dtype_equal
 import pandas as pd
 import pandas._testing as tm
 from pandas.core.arrays.string_arrow import ArrowStringArray
-from pandas.tests.arrays.string_ import arrow_string_storage
 from pandas.util.version import Version
 
 
@@ -116,7 +115,7 @@ def test_add(dtype):
     tm.assert_series_equal(result, expected)
 
 
-def test_add_2d(dtype, request):
+def test_add_2d(dtype, request, arrow_string_storage):
     if dtype.storage in arrow_string_storage:
         reason = "Failed: DID NOT RAISE <class 'ValueError'>"
         mark = pytest.mark.xfail(raises=None, reason=reason)
@@ -145,7 +144,7 @@ def test_add_sequence(dtype):
     tm.assert_extension_array_equal(result, expected)
 
 
-def test_mul(dtype, request):
+def test_mul(dtype, request, arrow_string_storage):
     if dtype.storage in arrow_string_storage:
         reason = "unsupported operand type(s) for *: 'ArrowStringArray' and 'int'"
         mark = pytest.mark.xfail(raises=NotImplementedError, reason=reason)
@@ -370,7 +369,7 @@ def test_min_max(method, skipna, dtype, request):
 
 @pytest.mark.parametrize("method", ["min", "max"])
 @pytest.mark.parametrize("box", [pd.Series, pd.array])
-def test_min_max_numpy(method, box, dtype, request):
+def test_min_max_numpy(method, box, dtype, request, arrow_string_storage):
     if dtype.storage in arrow_string_storage and box is pd.array:
         if box is pd.array:
             reason = "'<=' not supported between instances of 'str' and 'NoneType'"
@@ -385,7 +384,7 @@ def test_min_max_numpy(method, box, dtype, request):
     assert result == expected
 
 
-def test_fillna_args(dtype, request):
+def test_fillna_args(dtype, request, arrow_string_storage):
     # GH 37987
 
     arr = pd.array(["a", pd.NA], dtype=dtype)
@@ -504,7 +503,7 @@ def test_use_inf_as_na(values, expected, dtype):
             tm.assert_frame_equal(result, expected)
 
 
-def test_memory_usage(dtype):
+def test_memory_usage(dtype, arrow_string_storage):
     # GH 33963
 
     if dtype.storage in arrow_string_storage:

--- a/pandas/tests/arrays/string_/test_string_arrow.py
+++ b/pandas/tests/arrays/string_/test_string_arrow.py
@@ -13,6 +13,7 @@ from pandas.core.arrays.string_ import (
     StringDtype,
 )
 from pandas.core.arrays.string_arrow import ArrowStringArray
+from pandas.tests.arrays.string_ import arrow_string_storage
 
 skip_if_no_pyarrow = pytest.mark.skipif(
     pa_version_under7p0,
@@ -52,7 +53,7 @@ def test_config_bad_storage_raises():
 def test_constructor_not_string_type_raises(array, chunked):
     import pyarrow as pa
 
-    array = pa if array == "pyarrow" else np
+    array = pa if array in arrow_string_storage else np
 
     arr = array.array([1, 2, 3])
     if chunked:

--- a/pandas/tests/arrays/string_/test_string_arrow.py
+++ b/pandas/tests/arrays/string_/test_string_arrow.py
@@ -13,7 +13,6 @@ from pandas.core.arrays.string_ import (
     StringDtype,
 )
 from pandas.core.arrays.string_arrow import ArrowStringArray
-from pandas.tests.arrays.string_ import arrow_string_storage
 
 skip_if_no_pyarrow = pytest.mark.skipif(
     pa_version_under7p0,
@@ -50,7 +49,7 @@ def test_config_bad_storage_raises():
 @skip_if_no_pyarrow
 @pytest.mark.parametrize("chunked", [True, False])
 @pytest.mark.parametrize("array", ["numpy", "pyarrow"])
-def test_constructor_not_string_type_raises(array, chunked):
+def test_constructor_not_string_type_raises(array, chunked, arrow_string_storage):
     import pyarrow as pa
 
     array = pa if array in arrow_string_storage else np

--- a/pandas/tests/extension/test_string.py
+++ b/pandas/tests/extension/test_string.py
@@ -25,6 +25,8 @@ from pandas.core.arrays import ArrowStringArray
 from pandas.core.arrays.string_ import StringDtype
 from pandas.tests.extension import base
 
+arrow_string_storage = ("pyarrow",)
+
 
 def split_array(arr):
     if arr.dtype.storage != "pyarrow":
@@ -104,7 +106,7 @@ class TestDtype(base.BaseDtypeTests):
 
 class TestInterface(base.BaseInterfaceTests):
     def test_view(self, data, request):
-        if data.dtype.storage == "pyarrow":
+        if data.dtype.storage in arrow_string_storage:
             pytest.skip(reason="2D support not implemented for ArrowStringArray")
         super().test_view(data)
 
@@ -117,7 +119,7 @@ class TestConstructors(base.BaseConstructorsTests):
 
 class TestReshaping(base.BaseReshapingTests):
     def test_transpose(self, data, request):
-        if data.dtype.storage == "pyarrow":
+        if data.dtype.storage in arrow_string_storage:
             pytest.skip(reason="2D support not implemented for ArrowStringArray")
         super().test_transpose(data)
 
@@ -128,7 +130,7 @@ class TestGetitem(base.BaseGetitemTests):
 
 class TestSetitem(base.BaseSetitemTests):
     def test_setitem_preserves_views(self, data, request):
-        if data.dtype.storage == "pyarrow":
+        if data.dtype.storage in arrow_string_storage:
             pytest.skip(reason="2D support not implemented for ArrowStringArray")
         super().test_setitem_preserves_views(data)
 

--- a/pandas/tests/extension/test_string.py
+++ b/pandas/tests/extension/test_string.py
@@ -25,8 +25,6 @@ from pandas.core.arrays import ArrowStringArray
 from pandas.core.arrays.string_ import StringDtype
 from pandas.tests.extension import base
 
-arrow_string_storage = ("pyarrow",)
-
 
 def split_array(arr):
     if arr.dtype.storage != "pyarrow":
@@ -105,7 +103,7 @@ class TestDtype(base.BaseDtypeTests):
 
 
 class TestInterface(base.BaseInterfaceTests):
-    def test_view(self, data, request):
+    def test_view(self, data, request, arrow_string_storage):
         if data.dtype.storage in arrow_string_storage:
             pytest.skip(reason="2D support not implemented for ArrowStringArray")
         super().test_view(data)
@@ -118,7 +116,7 @@ class TestConstructors(base.BaseConstructorsTests):
 
 
 class TestReshaping(base.BaseReshapingTests):
-    def test_transpose(self, data, request):
+    def test_transpose(self, data, request, arrow_string_storage):
         if data.dtype.storage in arrow_string_storage:
             pytest.skip(reason="2D support not implemented for ArrowStringArray")
         super().test_transpose(data)
@@ -129,7 +127,7 @@ class TestGetitem(base.BaseGetitemTests):
 
 
 class TestSetitem(base.BaseSetitemTests):
-    def test_setitem_preserves_views(self, data, request):
+    def test_setitem_preserves_views(self, data, request, arrow_string_storage):
         if data.dtype.storage in arrow_string_storage:
             pytest.skip(reason="2D support not implemented for ArrowStringArray")
         super().test_setitem_preserves_views(data)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Precursor to the other pr