### PR TITLE
BUG: 54445 interferes with EAs that support complex128

### DIFF
--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -992,7 +992,7 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         except TypeError:
             if isinstance(dtype, ExtensionDtype) and not immutable_ea:
                 values = [v[loc] for v in self.arrays]
-                result = cls._from_sequence(values, dtype)
+                result = cls._from_sequence(values, dtype=dtype)
             else:
                 raise TypeError
 


### PR DESCRIPTION
When a loc indexer goes to create a fresh array to hold values from an Extension Array, it makes the array allocation based on the na_value of the EA, but that na_value may be smaller than the size of the things that the EA can hold (such as complex128).  Note that np.nan is itself a legitimate complex128 value.

If the allocated array cannot hold the values from the block manager, and if the EA is not immutable, it will try a second strategy of allocating an array based on the dtype of the values of the blocks.  If the blocks hold complex numbers, the array will be properly sized.

This should close #54445.

- [x] closes #54445
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
