### PR TITLE
refactor grouper __iter__

### DIFF
--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -996,9 +996,6 @@ class BinGrouper(BaseGrouper):
         }
         return result
 
-    def __iter__(self) -> Iterator[Hashable]:
-        return iter(self.groupings[0].grouping_vector)
-
     @property
     def nkeys(self) -> int:
         # still matches len(self.groupings), but we can hard-code


### PR DESCRIPTION
- [x] closes #52468 
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Removed the `__iter__` overload that was introduced in #51414. The logic accessing the `grouping_vector` for was introduced #53088