### PR TITLE
Fixed unexpected np.nan value with reindex on pd.series with pd.Inter…

### DIFF
--- a/pandas/_libs/intervaltree.pxi.in
+++ b/pandas/_libs/intervaltree.pxi.in
@@ -391,6 +391,11 @@ cdef class {{dtype_title}}Closed{{closed_title}}IntervalNode(IntervalNode):
         """Recursively query this node and its sub-nodes for intervals that
         overlap with the query point.
         """
+
+        # GH 51826: ensures nan is handled properly during reindexing
+        if np.isnan(point):
+            return
+
         cdef:
             int64_t[:] indices
             {{dtype}}_t[:] values

--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from pandas.compat import IS64
+
 import pandas as pd
 from pandas import (
     DataFrame,
@@ -173,15 +175,18 @@ class TestIntervalIndexInsideMultiIndex:
         expected = Series([1, 6, 2, 8, 7], index=expected_index, name="value")
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.xfail(not IS64, reason="GH 23440")
     @pytest.mark.parametrize(
         "base",
-        [10, 100, 101, 1010],
+        [101, 1010],
     )
     def test_reindex_behavior_with_interval_index(self, base):
         # GH 51826
-        left = np.arange(base)
-        right = np.arange(1, base + 1)
-        ser = Series(range(base), index=IntervalIndex.from_arrays(left, right))
-        expected_result = Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)
+
+        ser = Series(
+            range(base),
+            index=IntervalIndex.from_arrays(range(base), range(1, base + 1)),
+        )
+        expected_result = Series([np.nan, 0], index=[np.nan, 1.0], dtype=float)
         result = ser.reindex(index=[np.nan, 1.0])
         tm.assert_series_equal(result, expected_result)

--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -172,3 +172,20 @@ class TestIntervalIndexInsideMultiIndex:
         )
         expected = Series([1, 6, 2, 8, 7], index=expected_index, name="value")
         tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "base, expected_result",
+        [
+            (10, Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)),
+            (100, Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)),
+            (101, Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)),
+            (1010, Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)),
+        ],
+    )
+    def test_reindex_behavior_with_interval_index(self, base, expected_result):
+        # GH 51826
+        left = np.arange(base)
+        right = np.arange(1, base + 1)
+        d = Series(range(base), index=IntervalIndex.from_arrays(left, right))
+        result = d.reindex(index=[np.nan, 1.0])
+        tm.assert_series_equal(result, expected_result)

--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -174,18 +174,14 @@ class TestIntervalIndexInsideMultiIndex:
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize(
-        "base, expected_result",
-        [
-            (10, Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)),
-            (100, Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)),
-            (101, Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)),
-            (1010, Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)),
-        ],
+        "base",
+        [10, 100, 101, 1010],
     )
-    def test_reindex_behavior_with_interval_index(self, base, expected_result):
+    def test_reindex_behavior_with_interval_index(self, base):
         # GH 51826
         left = np.arange(base)
         right = np.arange(1, base + 1)
-        d = Series(range(base), index=IntervalIndex.from_arrays(left, right))
-        result = d.reindex(index=[np.nan, 1.0])
+        ser = Series(range(base), index=IntervalIndex.from_arrays(left, right))
+        expected_result = Series([np.nan, 0], index=[np.nan, 1.0], dtype=np.float64)
+        result = ser.reindex(index=[np.nan, 1.0])
         tm.assert_series_equal(result, expected_result)


### PR DESCRIPTION
- [x] closes #51826
- [x] [Tests added and passed]
- [x] All [code checks passed]

The test added in this issue is failing on Linux-32-bit. This is caused by another issue as discussed in #23440. The description of the the error is also described below in the comments. The test is marked xfail for 32-bit system in this PR.   