### PR TITLE
DEPR: Nonkeyword arguments in to_pickle

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -92,7 +92,7 @@ Other API changes
 
 Deprecations
 ~~~~~~~~~~~~
--
+- Deprecated allowing non-keyword arguments in :meth:`DataFrame.to_pickle` except ``path``. (:issue:`54229`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3017,6 +3017,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         )
 
     @final
+    @deprecate_nonkeyword_arguments(
+        version=None, allowed_args=["self", "path"], name="to_pickle"
+    )
     @doc(
         storage_options=_shared_docs["storage_options"],
         compression_options=_shared_docs["compression_options"] % "path",

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3018,7 +3018,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
     @final
     @deprecate_nonkeyword_arguments(
-        version=None, allowed_args=["self", "path"], name="to_pickle"
+        version="3.0", allowed_args=["self", "path"], name="to_pickle"
     )
     @doc(
         storage_options=_shared_docs["storage_options"],

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -460,3 +460,13 @@ class TestNDFrame:
         )
         with tm.assert_produces_warning(FutureWarning, match=msg_warn):
             DataFrame({"col": [False]}).bool()
+
+    def test_drop_pos_args_deprecation_for_to_pickle(self):
+        # GH-54229
+        df = DataFrame({"a": [1, 2, 3]})
+        msg = (
+            r"In a future version of pandas all arguments of to_pickle "
+            r"except for the argument 'path' will be keyword-only"
+        )
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            df.to_pickle("./dummy.pkl", "infer")

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -460,13 +460,3 @@ class TestNDFrame:
         )
         with tm.assert_produces_warning(FutureWarning, match=msg_warn):
             DataFrame({"col": [False]}).bool()
-
-    def test_drop_pos_args_deprecation_for_to_pickle(self):
-        # GH-54229
-        df = DataFrame({"a": [1, 2, 3]})
-        msg = (
-            r"In a future version of pandas all arguments of to_pickle "
-            r"except for the argument 'path' will be keyword-only"
-        )
-        with tm.assert_produces_warning(FutureWarning, match=msg):
-            df.to_pickle("./dummy.pkl", "infer")

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -585,3 +585,15 @@ def test_pickle_frame_v124_unpickle_130(datapath):
 
     expected = pd.DataFrame(index=[], columns=[])
     tm.assert_frame_equal(df, expected)
+
+
+def test_pickle_pos_args_deprecation():
+    # GH-54229
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    msg = (
+        r"Starting with pandas version 3.0 all arguments of to_pickle except for the "
+        r"argument 'path' will be keyword-only."
+    )
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        buffer = io.BytesIO()
+        df.to_pickle(buffer, "infer")


### PR DESCRIPTION
- [x] xref #54229 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.2.0.rst` file if fixing a bug or adding a new feature.
