### PR TITLE
DEPR: Nonkeyword arguments in to_latex

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -92,7 +92,7 @@ Other API changes
 
 Deprecations
 ~~~~~~~~~~~~
--
+- Deprecated allowing non-keyword arguments in :meth:`DataFrame.to_pickle` except ``buf``. (:issue:`54229`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -92,7 +92,7 @@ Other API changes
 
 Deprecations
 ~~~~~~~~~~~~
-- Deprecated allowing non-keyword arguments in :meth:`DataFrame.to_pickle` except ``buf``. (:issue:`54229`)
+- Deprecated allowing non-keyword arguments in :meth:`DataFrame.to_latex` except ``buf``. (:issue:`54229`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3301,7 +3301,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
     @final
     @deprecate_nonkeyword_arguments(
-        version=None, allowed_args=["self", "buf"], name="to_latex"
+        version="3.0", allowed_args=["self", "buf"], name="to_latex"
     )
     def to_latex(
         self,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3300,6 +3300,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         ...
 
     @final
+    @deprecate_nonkeyword_arguments(
+        version=None, allowed_args=["self", "buf"], name="to_latex"
+    )
     def to_latex(
         self,
         buf: FilePath | WriteBuffer[str] | None = None,

--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -187,6 +187,22 @@ class TestToLatex:
         )
         assert result == expected
 
+    def test_to_latex_pos_args_deprecation(self):
+        # GH-54229
+        df = DataFrame(
+            {
+                "name": ["Raphael", "Donatello"],
+                "age": [26, 45],
+                "height": [181.23, 177.65],
+            }
+        )
+        msg = (
+            r"Starting with pandas version 3.0 all arguments of to_latex except for "
+            r"the argument 'buf' will be keyword-only."
+        )
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            df.to_latex(None, None)
+
 
 class TestToLatexLongtable:
     def test_to_latex_empty_longtable(self):


### PR DESCRIPTION
- [x] xref #54229 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.2.0.rst` file if fixing a bug or adding a new feature.
