### PR TITLE
DEPR: deprecated nonkeyword arguments in to_stata

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2616,7 +2616,7 @@ class DataFrame(NDFrame, OpsMixin):
         compression_options=_shared_docs["compression_options"] % "path",
     )
     @deprecate_nonkeyword_arguments(
-        version=None, allowed_args=["self", "path"], name="to_stata"
+        version="3.0", allowed_args=["self", "path"], name="to_stata"
     )
     def to_stata(
         self,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -64,6 +64,7 @@ from pandas.errors import (
 from pandas.util._decorators import (
     Appender,
     Substitution,
+    deprecate_nonkeyword_arguments,
     doc,
 )
 from pandas.util._exceptions import find_stack_level
@@ -2613,6 +2614,9 @@ class DataFrame(NDFrame, OpsMixin):
     @doc(
         storage_options=_shared_docs["storage_options"],
         compression_options=_shared_docs["compression_options"] % "path",
+    )
+    @deprecate_nonkeyword_arguments(
+        version=None, allowed_args=["self", "path"], name="to_stata"
     )
     def to_stata(
         self,


### PR DESCRIPTION
- [ ] xref #54229 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/v2.2.0.rst` file if fixing a bug or adding a new feature.
