### PR TITLE
DEPR: deprecated nonkeyword arguments in to_markdown

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -92,8 +92,8 @@ Other API changes
 
 Deprecations
 ~~~~~~~~~~~~
+- Deprecated allowing non-keyword arguments in :meth:`DataFrame.to_markdown` except ``buf``. (:issue:`54229`)
 - Deprecated allowing non-keyword arguments in :meth:`DataFrame.to_pickle` except ``path``. (:issue:`54229`)
--
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_220.performance:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -64,6 +64,7 @@ from pandas.errors import (
 from pandas.util._decorators import (
     Appender,
     Substitution,
+    deprecate_nonkeyword_arguments,
     doc,
 )
 from pandas.util._exceptions import find_stack_level
@@ -2796,6 +2797,9 @@ class DataFrame(NDFrame, OpsMixin):
 
         to_feather(self, path, **kwargs)
 
+    @deprecate_nonkeyword_arguments(
+        version="3.0", allowed_args=["self", "buf"], name="to_markdown"
+    )
     @doc(
         Series.to_markdown,
         klass=_shared_doc_kwargs["klass"],

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1871,7 +1871,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         {examples}
         """
         return self.to_frame().to_markdown(
-            buf, mode, index, storage_options=storage_options, **kwargs
+            buf, mode=mode, index=index, storage_options=storage_options, **kwargs
         )
 
     # ----------------------------------------------------------------------

--- a/pandas/tests/io/formats/test_to_markdown.py
+++ b/pandas/tests/io/formats/test_to_markdown.py
@@ -1,8 +1,12 @@
-from io import StringIO
+from io import (
+    BytesIO,
+    StringIO,
+)
 
 import pytest
 
 import pandas as pd
+import pandas._testing as tm
 
 pytest.importorskip("tabulate")
 
@@ -88,3 +92,15 @@ def test_showindex_disallowed_in_kwargs():
     df = pd.DataFrame([1, 2, 3])
     with pytest.raises(ValueError, match="Pass 'index' instead of 'showindex"):
         df.to_markdown(index=True, showindex=True)
+
+
+def test_markdown_pos_args_deprecatation():
+    # GH-54229
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    msg = (
+        r"Starting with pandas version 3.0 all arguments of to_markdown except for the "
+        r"argument 'buf' will be keyword-only."
+    )
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        buffer = BytesIO()
+        df.to_markdown(buffer, "grid")


### PR DESCRIPTION
- [x] xref #54229 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v2.2.0.rst` file if fixing a bug or adding a new feature.
