### PR TITLE
DOC: add examples to offsets classes: FY5253, FY5253Quarter

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -3567,6 +3567,10 @@ cdef class FY5253(FY5253Mixin):
     >>> ts = pd.Timestamp(2022, 1, 1)
     >>> ts + pd.offsets.FY5253()
     Timestamp('2022-01-31 00:00:00')
+
+    >>> ts = pd.Timestamp(2022, 1, 1)
+    >>> ts + pd.offsets.FY5253(startingMonth=1, weekday=3, variation="nearest")
+    Timestamp('2022-02-03 00:00:00')
     """
 
     _prefix = "RE"
@@ -3750,6 +3754,11 @@ cdef class FY5253Quarter(FY5253Mixin):
     >>> ts = pd.Timestamp(2022, 1, 1)
     >>> ts + pd.offsets.FY5253Quarter()
     Timestamp('2022-01-31 00:00:00')
+
+    >>> ts = pd.Timestamp(2022, 1, 1)
+    >>> ts + pd.offsets.FY5253Quarter(weekday=5, startingMonth=12, variation="last",
+    ...                               qtr_with_extra_week=4)
+    Timestamp('2022-03-26 00:00:00')
     """
 
     _prefix = "REQ"

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -3541,6 +3541,8 @@ cdef class FY5253(FY5253Mixin):
     ----------
     n : int
         The number of fiscal years represented.
+    normalize : bool, default False
+        Normalize start/end dates to midnight before generating date range.
     weekday : int {0, 1, ..., 6}, default 0
         A specific integer for the day of the week.
 
@@ -3742,6 +3744,8 @@ cdef class FY5253Quarter(FY5253Mixin):
     ----------
     n : int
         The number of business quarters represented.
+    normalize : bool, default False
+        Normalize start/end dates to midnight before generating date range.
     weekday : int {0, 1, ..., 6}, default 0
         A specific integer for the day of the week.
 

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -3540,6 +3540,7 @@ cdef class FY5253(FY5253Mixin):
     Parameters
     ----------
     n : int
+        The number of fiscal years represented.
     weekday : int {0, 1, ..., 6}, default 0
         A specific integer for the day of the week.
 
@@ -3562,15 +3563,31 @@ cdef class FY5253(FY5253Mixin):
         - "nearest" means year end is **weekday** closest to last day of month in year.
         - "last" means year end is final **weekday** of the final month in fiscal year.
 
+    See Also
+    --------
+    :class:`~pandas.tseries.offsets.DateOffset` : Standard kind of date increment.
+
     Examples
     --------
+    In the example below the default parameters give the next 52-53 week fiscal year.
+
     >>> ts = pd.Timestamp(2022, 1, 1)
     >>> ts + pd.offsets.FY5253()
     Timestamp('2022-01-31 00:00:00')
 
+    By the parameter ``startingMonth`` we can specify
+    the month in which fiscal years end.
+
     >>> ts = pd.Timestamp(2022, 1, 1)
-    >>> ts + pd.offsets.FY5253(startingMonth=1, weekday=3, variation="nearest")
-    Timestamp('2022-02-03 00:00:00')
+    >>> ts + pd.offsets.FY5253(startingMonth=3)
+    Timestamp('2022-03-28 00:00:00')
+
+    52-53 week fiscal year can be specified by
+    ``weekday`` and ``variation`` parameters.
+
+    >>> ts = pd.Timestamp(2022, 1, 1)
+    >>> ts + pd.offsets.FY5253(weekday=5, startingMonth=12, variation="last")
+    Timestamp('2022-12-31 00:00:00')
     """
 
     _prefix = "RE"
@@ -3724,6 +3741,7 @@ cdef class FY5253Quarter(FY5253Mixin):
     Parameters
     ----------
     n : int
+        The number of business quarters represented.
     weekday : int {0, 1, ..., 6}, default 0
         A specific integer for the day of the week.
 
@@ -3749,16 +3767,32 @@ cdef class FY5253Quarter(FY5253Mixin):
         - "nearest" means year end is **weekday** closest to last day of month in year.
         - "last" means year end is final **weekday** of the final month in fiscal year.
 
+    See Also
+    --------
+    :class:`~pandas.tseries.offsets.DateOffset` : Standard kind of date increment.
+
     Examples
     --------
+    In the example below the default parameters give
+    the next business quarter for 52-53 week fiscal year.
+
     >>> ts = pd.Timestamp(2022, 1, 1)
     >>> ts + pd.offsets.FY5253Quarter()
     Timestamp('2022-01-31 00:00:00')
 
+    By the parameter ``startingMonth`` we can specify
+    the month in which fiscal years end.
+
     >>> ts = pd.Timestamp(2022, 1, 1)
-    >>> ts + pd.offsets.FY5253Quarter(weekday=5, startingMonth=12, variation="last",
-    ...                               qtr_with_extra_week=4)
-    Timestamp('2022-03-26 00:00:00')
+    >>> ts + pd.offsets.FY5253Quarter(startingMonth=3)
+    Timestamp('2022-03-28 00:00:00')
+
+    Business quarters for 52-53 week fiscal year can be specified by
+    ``weekday`` and ``variation`` parameters.
+
+    >>> ts = pd.Timestamp(2022, 1, 1)
+    >>> ts + pd.offsets.FY5253Quarter(weekday=5, startingMonth=12, variation="last")
+    Timestamp('2022-04-02 00:00:00')
     """
 
     _prefix = "REQ"


### PR DESCRIPTION
xref #52431
added examples, see also section, and missing parameters to offsets classes `FY5253,` `FY5253Quarter`
