### PR TITLE
Fixes NonExistentTimeError when resampling weekly 

### DIFF
--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -13,6 +13,7 @@ from typing import (
 import warnings
 
 import numpy as np
+from pytz import NonExistentTimeError
 
 from pandas._libs import lib
 from pandas._libs.tslibs import (
@@ -2494,6 +2495,17 @@ def _get_timestamp_range_edges(
             first = first.tz_localize(index_tz)
             last = last.tz_localize(index_tz)
     else:
+        # Added to handle non-existent times when localizing to
+        # time-zones with negative time-zone difference
+        try:
+            first = first.tz_localize(None)
+        except NonExistentTimeError:
+            first = first.tz_localize(None, nonexistent="shift_forward")
+
+        try:
+            last = last.tz_localize(None)
+        except NonExistentTimeError:
+            last = last.tz_localize(None, nonexistent="shift_forward")
         if isinstance(origin, Timestamp):
             first = origin
 

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from textwrap import dedent
 
 import numpy as np
@@ -696,3 +697,19 @@ def test_groupby_resample_kind(kind):
     )
     expected = Series([1, 3, 2, 4], index=expected_index, name="value")
     tm.assert_series_equal(result, expected)
+
+
+def test_resample_dataframe_with_negative_timezone_difference():
+    df = DataFrame({"ts": [datetime(2005, 10, 9, 21)], "values": [10.0]})
+    df["ts"] = df["ts"].dt.tz_localize("Chile/Continental")
+    result = df.resample("W-Mon", on="ts", closed="left", label="left").sum()
+    expected = DataFrame(
+        {
+            "values": {
+                Timestamp("2005-10-03 00:00:00-0400", tz="Chile/Continental"): 10.0
+            }
+        }
+    )
+    expected.index.name = "ts"
+    expected.index.freq = "W-Mon"
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #53666 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) 
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
