### PR TITLE
BUG: groupby.var with ArrowDtype(pa.decimal128)

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -798,6 +798,7 @@ Groupby/resample/rolling
 - Bug in :meth:`.SeriesGroupBy.nth` and :meth:`.DataFrameGroupBy.nth` after performing column selection when using ``dropna="any"`` or ``dropna="all"`` would not subset columns (:issue:`53518`)
 - Bug in :meth:`.SeriesGroupBy.nth` and :meth:`.DataFrameGroupBy.nth` raised after performing column selection when using ``dropna="any"`` or ``dropna="all"`` resulted in rows being dropped (:issue:`53518`)
 - Bug in :meth:`.SeriesGroupBy.sum` and :meth:`.DataFrameGroupBy.sum` summing ``np.inf + np.inf`` and ``(-np.inf) + (-np.inf)`` to ``np.nan`` instead of ``np.inf`` and ``-np.inf`` respectively (:issue:`53606`)
+- Bug in :meth:`.SeriesGroupBy.var` and :meth:`.DataFrameGroupBy.var` where the dtype would be ``np.float64`` for data with :class:`ArrowDtype` with ``pyarrow.decimal128`` type (:issue:`54627`)
 - Bug in :meth:`Series.groupby` raising an error when grouped :class:`Series` has a :class:`DatetimeIndex` index and a :class:`Series` with a name that is a month is given to the ``by`` argument (:issue:`48509`)
 
 Reshaping

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -47,6 +47,7 @@ from pandas.core.arrays.base import (
     ExtensionArray,
     ExtensionArraySupportsAnyAll,
 )
+from pandas.core.arrays.floating import Float64Dtype
 from pandas.core.arrays.masked import BaseMaskedArray
 from pandas.core.arrays.string_ import StringDtype
 import pandas.core.common as com
@@ -1942,12 +1943,16 @@ class ArrowExtensionArray(
 
         if pa.types.is_floating(pa_dtype) or pa.types.is_integer(pa_dtype):
             na_value = 1
+            dtype = _arrow_dtype_mapping()[pa_dtype]
         elif pa.types.is_boolean(pa_dtype):
             na_value = True
+            dtype = _arrow_dtype_mapping()[pa_dtype]
+        elif pa.types.is_decimal(pa_dtype):
+            na_value = 1
+            dtype = Float64Dtype()
         else:
             raise NotImplementedError
 
-        dtype = _arrow_dtype_mapping()[pa_dtype]
         mask = self.isna()
         arr = self.to_numpy(dtype=dtype.numpy_dtype, na_value=na_value)
         return dtype.construct_array_type()(arr, mask)

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -2960,6 +2960,24 @@ def test_groupby_count_return_arrow_dtype(data_missing):
     tm.assert_frame_equal(result, expected)
 
 
+def test_groupby_var_decimal_return_arrow_dtype():
+    # GH 54627
+    df = pd.DataFrame(
+        {
+            "A": pd.Series([True, True], dtype="bool[pyarrow]"),
+            "B": pd.Series([123, 12], dtype=ArrowDtype(pa.decimal128(6, 3))),
+        }
+    )
+    result = df.groupby("A").var()
+    expected = pd.DataFrame(
+        [6160.5],
+        index=pd.Index([True], dtype="bool[pyarrow]", name="A"),
+        columns=["B"],
+        dtype="double[pyarrow]",
+    )
+    tm.assert_frame_equal(result, expected)
+
+
 def test_arrowextensiondtype_dataframe_repr():
     # GH 54062
     df = pd.DataFrame(


### PR DESCRIPTION
- [x] closes #54627 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.


I don't think modifying `_arrow_dtype_mapping` is completely correct because I'm not sure we want to do this conversion all the time.
