### PR TITLE
COMPAT: Workaround invalid PyArrow duration conversion

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -952,6 +952,9 @@ class ArrowExtensionArray(
                 return value
             if isinstance(value, (pa.Scalar, pa.Array, pa.ChunkedArray)):
                 return value
+            if isinstance(value, Timedelta) and value.unit in ("s", "ms"):
+                # Workaround https://github.com/apache/arrow/issues/37291
+                value = value.to_numpy()
             if is_array_like(value):
                 pa_box = pa.array
             else:


### PR DESCRIPTION
- [x] closes #54650 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

I think https://github.com/apache/arrow/pull/37064 caused a `pc.fill_null` code path to accept duration types exposing a pyarrow bug when converting a `pd.Timedelta` to `pa.scalar` https://github.com/apache/arrow/issues/37291
