### PR TITLE
DOC: fix an example which raised a KeyError in v0.11.0.rst

### DIFF
--- a/doc/source/whatsnew/v0.11.0.rst
+++ b/doc/source/whatsnew/v0.11.0.rst
@@ -367,15 +367,27 @@ Enhancements
 
   - You can now select with a string from a DataFrame with a datelike index, in a similar way to a Series (:issue:`3070`)
 
-    .. ipython:: python
-       :okexcept:
+    .. code-block:: ipython
 
-        idx = pd.date_range("2001-10-1", periods=5, freq='M')
-        ts = pd.Series(np.random.rand(len(idx)), index=idx)
-        ts['2001']
+     In [30]: idx = pd.date_range("2001-10-1", periods=5, freq='M')
 
-        df = pd.DataFrame({'A': ts})
-        df['2001']
+     In [31]: ts = pd.Series(np.random.rand(len(idx)), index=idx)
+
+     In [32]: ts['2001']
+     Out[32]:
+     2001-10-31    0.117967
+     2001-11-30    0.702184
+     2001-12-31    0.414034
+     Freq: M, dtype: float64
+
+     In [33]: df = pd.DataFrame({'A': ts})
+
+     In [34]: df['2001']
+     Out[34]:
+                        A
+     2001-10-31  0.117967
+     2001-11-30  0.702184
+     2001-12-31  0.414034
 
   - ``Squeeze`` to possibly remove length 1 dimensions from an object.
 


### PR DESCRIPTION
Fix an example in doc/source/whatsnew/v0.11.0.rst, which raises a KeyError (see https://pandas.pydata.org/docs/whatsnew/v0.11.0.html#enhancements)