### PR TITLE
BUG: setitem with object type inserting Series maintains Series

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -726,6 +726,7 @@ Indexing
 - Bug in :meth:`DataFrame.__setitem__` losing dtype when setting a :class:`DataFrame` into duplicated columns (:issue:`53143`)
 - Bug in :meth:`DataFrame.__setitem__` with a boolean mask and :meth:`DataFrame.putmask` with mixed non-numeric dtypes and a value other than ``NaN`` incorrectly raising ``TypeError`` (:issue:`53291`)
 - Bug in :meth:`DataFrame.iloc` when using ``nan`` as the only element (:issue:`52234`)
+- Bug in :meth:`Series.loc` casting :class:`Series` to ``np.dnarray`` when assigning :class:`Series` at predefined index of ``object`` dtype :class:`Series` (:issue:`48933`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1133,6 +1133,9 @@ class Block(PandasObject, libinternals.Block):
         check_setitem_lengths(indexer, value, values)
 
         value = extract_array(value, extract_numpy=True)
+        if self.dtype != _dtype_obj:
+            # GH48933: extract_array would convert a pd.Series value to np.ndarray
+            value = extract_array(value, extract_numpy=True)
         try:
             casted = np_can_hold_element(values.dtype, value)
         except LossySetitemError:

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1132,7 +1132,6 @@ class Block(PandasObject, libinternals.Block):
         # length checking
         check_setitem_lengths(indexer, value, values)
 
-        value = extract_array(value, extract_numpy=True)
         if self.dtype != _dtype_obj:
             # GH48933: extract_array would convert a pd.Series value to np.ndarray
             value = extract_array(value, extract_numpy=True)

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -1132,3 +1132,19 @@ def test_scalar_setitem_series_with_nested_value_length1(value, indexer_sli):
         assert (ser.loc[0] == value).all()
     else:
         assert ser.loc[0] == value
+
+
+def test_object_dtype_series_set_series_element():
+    # GH 48933
+    s1 = Series(dtype="O", index=["a", "b"])
+
+    s1["a"] = Series()
+    s1.loc["b"] = Series()
+
+    tm.assert_series_equal(s1.loc["a"], Series())
+    tm.assert_series_equal(s1.loc["b"], Series())
+
+    s2 = Series(dtype="O", index=["a", "b"])
+
+    s2.iloc[1] = Series()
+    tm.assert_series_equal(s2.iloc[1], Series())


### PR DESCRIPTION
- [x] closes #48933 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
