### PR TITLE
DEPR: deprecated nonkeyword arguments in to_excel

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -134,6 +134,7 @@ Deprecations
 - Deprecated allowing non-keyword arguments in :meth:`DataFrame.to_clipboard`. (:issue:`54229`)
 - Deprecated allowing non-keyword arguments in :meth:`DataFrame.to_csv` except ``path_or_buf``. (:issue:`54229`)
 - Deprecated allowing non-keyword arguments in :meth:`DataFrame.to_dict`. (:issue:`54229`)
+- Deprecated allowing non-keyword arguments in :meth:`DataFrame.to_excel` except ``excel_writer``. (:issue:`54229`)
 - Deprecated allowing non-keyword arguments in :meth:`DataFrame.to_hdf` except ``path_or_buf``. (:issue:`54229`)
 - Deprecated allowing non-keyword arguments in :meth:`DataFrame.to_html` except ``buf``. (:issue:`54229`)
 - Deprecated allowing non-keyword arguments in :meth:`DataFrame.to_json` except ``path_or_buf``. (:issue:`54229`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2187,6 +2187,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     # I/O Methods
 
     @final
+    @deprecate_nonkeyword_arguments(
+        version="3.0", allowed_args=["self", "excel_writer"], name="to_excel"
+    )
     @doc(
         klass="object",
         storage_options=_shared_docs["storage_options"],

--- a/pandas/tests/io/excel/test_openpyxl.py
+++ b/pandas/tests/io/excel/test_openpyxl.py
@@ -241,7 +241,7 @@ def test_if_sheet_exists_raises(ext, if_sheet_exists, msg):
     df = DataFrame({"fruit": ["pear"]})
     with tm.ensure_clean(ext) as f:
         with pytest.raises(ValueError, match=re.escape(msg)):
-            df.to_excel(f, "foo", engine="openpyxl")
+            df.to_excel(f, sheet_name="foo", engine="openpyxl")
             with ExcelWriter(
                 f, engine="openpyxl", mode="a", if_sheet_exists=if_sheet_exists
             ) as writer:

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -591,7 +591,7 @@ class TestReaders:
             }
         )
         with tm.ensure_clean(read_ext) as file_path:
-            df.to_excel(file_path, "test", index=False)
+            df.to_excel(file_path, sheet_name="test", index=False)
             result = pd.read_excel(
                 file_path, sheet_name="test", dtype_backend=dtype_backend
             )
@@ -623,7 +623,7 @@ class TestReaders:
 
         df = DataFrame({"a": [np.nan, 1.0], "b": [2.5, np.nan]})
         with tm.ensure_clean(read_ext) as file_path:
-            df.to_excel(file_path, "test", index=False)
+            df.to_excel(file_path, sheet_name="test", index=False)
             result = pd.read_excel(
                 file_path,
                 sheet_name="test",
@@ -647,7 +647,7 @@ class TestReaders:
                 }
             )
             with tm.ensure_clean(read_ext) as file_path:
-                df.to_excel(file_path, "test", index=False)
+                df.to_excel(file_path, sheet_name="test", index=False)
                 result = pd.read_excel(
                     file_path, sheet_name="test", dtype_backend="numpy_nullable"
                 )

--- a/pandas/tests/io/formats/test_to_excel.py
+++ b/pandas/tests/io/formats/test_to_excel.py
@@ -2,12 +2,17 @@
 
 ExcelFormatter is tested implicitly in pandas/tests/io/excel
 """
+import io
 import string
 
 import pytest
 
 from pandas.errors import CSSWarning
 
+from pandas import (
+    DataFrame,
+    ExcelWriter,
+)
 import pandas._testing as tm
 
 from pandas.io.formats.excel import (
@@ -427,3 +432,16 @@ def test_css_excel_cell_cache(styles, cache_hits, cache_misses):
 
     assert cache_info.hits == cache_hits
     assert cache_info.misses == cache_misses
+
+
+def test_to_excel_pos_args_deprecation():
+    # GH-54229
+    df = DataFrame({"a": [1, 2, 3]})
+    msg = (
+        r"Starting with pandas version 3.0 all arguments of to_excel except for the "
+        r"argument 'excel_writer' will be keyword-only."
+    )
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        buf = io.BytesIO()
+        writer = ExcelWriter(buf)
+        df.to_excel(writer, "Sheet_name_1")

--- a/pandas/tests/io/formats/test_to_excel.py
+++ b/pandas/tests/io/formats/test_to_excel.py
@@ -2,17 +2,12 @@
 
 ExcelFormatter is tested implicitly in pandas/tests/io/excel
 """
-import io
 import string
 
 import pytest
 
 from pandas.errors import CSSWarning
 
-from pandas import (
-    DataFrame,
-    ExcelWriter,
-)
 import pandas._testing as tm
 
 from pandas.io.formats.excel import (
@@ -432,16 +427,3 @@ def test_css_excel_cell_cache(styles, cache_hits, cache_misses):
 
     assert cache_info.hits == cache_hits
     assert cache_info.misses == cache_misses
-
-
-def test_to_excel_pos_args_deprecation():
-    # GH-54229
-    df = DataFrame({"a": [1, 2, 3]})
-    msg = (
-        r"Starting with pandas version 3.0 all arguments of to_excel except for the "
-        r"argument 'excel_writer' will be keyword-only."
-    )
-    with tm.assert_produces_warning(FutureWarning, match=msg):
-        buf = io.BytesIO()
-        writer = ExcelWriter(buf)
-        df.to_excel(writer, "Sheet_name_1")


### PR DESCRIPTION
- [x] closes #54229 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v2.2.0.rst` file if fixing a bug or adding a new feature.
