### PR TITLE
DOC: add awkward-pandas to ecosystem page

### DIFF
--- a/web/pandas/community/ecosystem.md
+++ b/web/pandas/community/ecosystem.md
@@ -511,8 +511,15 @@ assumptions about your datasets and check that they're *actually* true.
 
 Pandas provides an interface for defining
 [extension types](https://pandas.pydata.org/docs/development/extending.html#extension-types) to extend NumPy's type system.
-The following librariesimplement that interface to provide types not found in NumPy or pandas,
+The following libraries implement that interface to provide types not found in NumPy or pandas,
 which work well with pandas' data containers.
+
+### [awkward-pandas](https://awkward-pandas.readthedocs.io/)
+
+Awkward-pandas provides an extension type for storing [Awkward
+Arrays](https://awkward-array.org/) inside pandas' Series and
+DataFrame. It also provides an accessor to operate on Series that are
+backed by awkward arrays.
 
 ### [cyberpandas](https://cyberpandas.readthedocs.io/en/latest)
 

--- a/web/pandas/community/ecosystem.md
+++ b/web/pandas/community/ecosystem.md
@@ -518,8 +518,8 @@ which work well with pandas' data containers.
 
 Awkward-pandas provides an extension type for storing [Awkward
 Arrays](https://awkward-array.org/) inside pandas' Series and
-DataFrame. It also provides an accessor to operate on Series that are
-backed by awkward arrays.
+DataFrame. It also provides an accessor for using awkward functions
+on Series that are of awkward type.
 
 ### [cyberpandas](https://cyberpandas.readthedocs.io/en/latest)
 
@@ -560,6 +560,7 @@ authors to coordinate on the namespace.
 
   | Library                                                              | Accessor   | Classes               |
   | -------------------------------------------------------------------- | ---------- | --------------------- |
+  | [awkward-pandas](https://awkward-pandas.readthedocs.io/en/latest/)   | `ak`       | `Series`              |
   | [cyberpandas](https://cyberpandas.readthedocs.io/en/latest)          | `ip`       | `Series`              |
   | [pdvega](https://altair-viz.github.io/pdvega/)                       | `vgplot`   | `Series`, `DataFrame` |
   | [pandas-genomics](https://pandas-genomics.readthedocs.io/en/latest/) | `genomics` | `Series`, `DataFrame` |


### PR DESCRIPTION
We'd love to have [awkward-pandas](https://github.com/intake/awkward-pandas) listed on the ecosystem webpage. (I added the package to the existing lists in alphabetical order, would be happy to reorder)

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
