### PR TITLE
Docs: Update doc string to not reference deprecated function fillna for ffill

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7368,7 +7368,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         downcast: dict | None | lib.NoDefault = lib.no_default,
     ) -> Self | None:
         """
-        Synonym for :meth:`DataFrame.fillna` with ``method='ffill'``.
+        Fill NA/NaN values by propagating the last valid observation forward
+        to next valid.
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7368,8 +7368,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         downcast: dict | None | lib.NoDefault = lib.no_default,
     ) -> Self | None:
         """
-        Fill NA/NaN values by propagating the last valid observation forward
-        to next valid.
+        Fill NA/NaN values by propagating the last valid observation to next valid.
 
         Returns
         -------


### PR DESCRIPTION
- [x] fix for 1st bullet point on https://github.com/noatamir/pyladies-aug23-sprint/issues/13
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

@noatamir @phofl PyLadies Berlin Aug Sprint
