### PR TITLE
adding dtype_backend=pyarrow in documentation

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -492,6 +492,21 @@ Setting ``dtype_backend="numpy_nullable"`` will result in nullable dtypes for ev
 
 .. _io.categorical:
 
+Setting ``dtype_backend="pyarrow"`` will result in pyarrow dtypes.
+
+.. ipython:: python
+
+   data = """a,b,c,d,e,f,g,h,i,j
+   1,2.5,True,a,,,,,12-31-2019,
+   3,4.5,False,b,6,7.5,True,a,12-31-2019,
+   """
+
+   df = pd.read_csv(StringIO(data), dtype_backend="pyarrow", parse_dates=["i"])
+   df
+   df.dtypes
+
+.. _io.categorical:
+
 Specifying categorical dtype
 ''''''''''''''''''''''''''''
 

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -505,8 +505,6 @@ Setting ``dtype_backend="pyarrow"`` will result in pyarrow dtypes.
    df
    df.dtypes
 
-.. _io.categorical:
-
 Specifying categorical dtype
 ''''''''''''''''''''''''''''
 


### PR DESCRIPTION
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Issue took from [here](https://github.com/noatamir/pyladies-aug23-sprint/issues/4)
