### PR TITLE
MAINT: small simplification of meson.build following best practices

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,10 +16,8 @@ project(
     ]
 )
 
-py_mod = import('python')
 fs = import('fs')
-py = py_mod.find_installation('python')
-py_dep = py.dependency()
+py = import('python').find_installation()
 tempita = files('generate_pxi.py')
 versioneer = files('generate_version.py')
 

--- a/meson.build
+++ b/meson.build
@@ -6,9 +6,6 @@ project(
     license: 'BSD-3',
     meson_version: '>=1.0.1',
     default_options: [
-        # TODO: investigate, does meson try to compile against debug Python
-        # when buildtype = debug, this seems to be causing problems on CI
-        # where provided Python is not compiled in debug mode
         'buildtype=release',
         # TODO: Reactivate werror, some warnings on Windows
         #'werror=true',

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 project(
     'pandas',
     'c', 'cpp', 'cython',
-    version: run_command(['python', 'generate_version.py', '--print'], check: true).stdout().strip(),
+    version: run_command(['python3', 'generate_version.py', '--print'], check: true).stdout().strip(),
     license: 'BSD-3',
     meson_version: '>=1.0.1',
     default_options: [

--- a/pandas/_libs/window/meson.build
+++ b/pandas/_libs/window/meson.build
@@ -3,7 +3,6 @@ py.extension_module(
     ['aggregations.pyx'],
     cython_args: ['-X always_allow_keywords=true'],
     include_directories: [inc_np, inc_pd],
-    dependencies: [py_dep],
     subdir: 'pandas/_libs/window',
     override_options : ['cython_language=cpp'],
     install: true
@@ -14,7 +13,6 @@ py.extension_module(
     ['indexers.pyx'],
     cython_args: ['-X always_allow_keywords=true'],
     include_directories: [inc_np, inc_pd],
-    dependencies: [py_dep],
     subdir: 'pandas/_libs/window',
     install: true
 )


### PR DESCRIPTION
Just a couple of things I observed having a quick look at `meson.build`.