### PR TITLE
PDEP-13: Deprecate the apply method on Series and DataFrame and make the agg and transform methods operate on series data

### DIFF
--- a/web/pandas/pdeps/0013-standardize-apply.md
+++ b/web/pandas/pdeps/0013-standardize-apply.md
@@ -1,4 +1,4 @@
-# PDEP-13: Deprecate the apply method on Series & DataFrame and make the agg and transform methods operate on series data
+# PDEP-13: Deprecate the apply method on Series and DataFrame and make the agg and transform methods operate on series data
 
 - Created: 24 August 2023
 - Status: Under discussion
@@ -8,27 +8,29 @@
 
 ## Abstract
 
-The `apply`, `transform` and `agg` methods have very complex behavior because they in some cases operate on elements in series, in some cases on series and sometimes try one first, and it that fails, falls back to try the other. There is not a logical system how these behaviors are arranged and it can therefore be difficult for users to understand these methods.
+The `apply`, `transform` and `agg` methods have very complex behavior when given callables because they in some cases operate on elements in series, in some cases on series and sometimes try one first, and it that fails, falls back to try the other. There is not a logical system how these behaviors are arranged and it can therefore be difficult for users to understand these methods.
 
 It is proposed that `apply`, `transform` and `agg` in the future will work as follows:
 
-1. the `agg` & `transform` methods of `Series`, `DataFrame` & `groupby` will always operate series-wise and never element-wise
-2. `Series.apply` & `DataFrame.apply` will be deprecated.
-3. `groupby.apply` will not be deprecated (because it behaves differently than `Series.apply` & `DataFrame.apply`)
+1. the `agg` and `transform` methods of `Series`, `DataFrame` and `groupby` will always operate series-wise and never element-wise
+2. `Series.apply` and `DataFrame.apply` will be deprecated.
+3. The current behavior when supplying string to the methods will not be changed.
+4. `groupby.apply` will not be deprecated (because it behaves differently than `Series.apply` and `DataFrame.apply`)
 
 The above changes means that the future behavior, when users want to apply arbitrary callables in pandas, can be described as follows:
 
 1. When users want to operate on single elements in a `Series` or `DataFrame`, they should use `Series.map` and `DataFrame.map` respectively.
 2. When users want to aggregate a `Series`, columns/rows of a `DataFrame` or groups in `groupby` objects, they should use `Series.agg`, `DataFrame.agg` and `groupby.agg` respectively.
 3. When users want to transform a `Series`, columns/rows of a `DataFrame` or groups in `groupby` objects, they should use `Series.transform`, `DataFrame.transform` and `groupby.transform` respectively.
+4. Functions that are not applicable for  `map`, `agg` nor `transform` are considered relatively rare and in the future users should call these functions directly rather than use the `apply` method.
 
-The use of `Series.apply` &  `DataFrame.apply` will after the proposed change in almost all cases be replaced by `map`, `agg` or `transform`. In the very few cases where `Series.apply` &  `DataFrame.apply` cannot be substituted by `map`, `agg` or `transform`, it is proposed that it will be accepted that users will have to find alternative ways to apply the functions, i.e. typically apply the functions manually and possibly concatenating the results.
+The use of `Series.apply` and  `DataFrame.apply` will after the proposed change in almost all cases be replaced by `map`, `agg` or `transform`. In the very few cases where `Series.apply` and  `DataFrame.apply` cannot be substituted by `map`, `agg` or `transform`, it is proposed that it will be accepted that users will have to find alternative ways to apply the functions, i.e. typically apply the functions manually and possibly concatenating the results.
 
 ## Motivation
 
-The current behavior of `apply`, `agg` & `transform` is very complex and therefore difficult to understand for non-expert users. The difficulty is especially that the methods sometimes apply callables on elements of series/dataframes, sometimes on Series or columns/rows of Dataframes and sometimes try element-wise operation and if that fails, falls back to series-wise operations.
+The current behavior of `apply`, `agg` and `transform` is very complex and therefore difficult to understand for non-expert users. The difficulty is especially that the methods sometimes apply callables on elements of series/dataframes, sometimes on Series or columns/rows of Dataframes and sometimes try element-wise operation and if that fails, falls back to series-wise operations.
 
-Below is an overview of the current behavior in table form when giving callables to `agg`, `transform` & `apply`. As an example on how to read the tables, when a non-ufunc callable is given to `Series.agg`, `Series.agg` will first try to apply the callable to each element in the series, and if that fails, will fall back to call the series using the callable.
+Below is an overview of the current behavior in table form when giving callables to `agg`, `transform` and `apply`. As an example on how to read the tables, when a non-ufunc callable is given to `Series.agg`, `Series.agg` will first try to apply the callable to each element in the series, and if that fails, will fall back to call the series using the callable.
 
 (The description may not be 100 % accurate because of various special cases in the current implementation, but will give a good understanding of the current behavior).
 
@@ -100,9 +102,9 @@ It can also have great effect on performance, even when the result is correct. F
 
 The reason for the great performance difference is that `df.transform(func)` operates on series data, which is fast, while `df.transform(func_list)` will attempt elementwise operation first, and if that works (which is does here), will be much slower than series operations.
 
-In addition to the above effects of the current implementation of `agg`/`transform` & `apply`, see [#52140](https://github.com/pandas-dev/pandas/issues/52140) for more examples of the unexpected effects of how `apply` is implemented.
+In addition to the above effects of the current implementation of `agg`/`transform` and `apply`, see [#52140](https://github.com/pandas-dev/pandas/issues/52140) for more examples of the unexpected effects of how `apply` is implemented.
 
-It can also be noted that `Series.apply` & `DataFrame.apply` could almost always be replaced with calls to `agg`, `transform` & `map`, if `agg` & `transform` were to always operate on series data. For some examples, see the table below for alternatives using `apply(func)`:
+It can also be noted that `Series.apply` and `DataFrame.apply` could almost always be replaced with calls to `agg`, `transform` or `map`, if `agg` and `transform` were to always operate on series data. For some examples, see the table below for alternatives using `apply(func)`:
 
 | func                    | Series     | DataFrame   |
 |:--------------------|:-----------|:------------|
@@ -112,40 +114,45 @@ It can also be noted that `Series.apply` & `DataFrame.apply` could almost always
 
 So, for example, `ser.apply(lambda x: str(x))` can be replaced with `ser.map(lambda x: str(x))` while `df.apply([lambda x: x.sum()])` can be replaced with `df.agg([lambda x: x.sum()])`.
 
-Overall, because of their flexibility, `Series.apply` & `DataFrame.apply` are considered unnecessarily complex, and it would be clearer for users to use `.map`, `.agg` or `.transform`, as appropriate in the given situation.
+Overall, because of their flexibility, `Series.apply` and `DataFrame.apply` are considered unnecessarily complex, and it would be clearer for users to use `.map`, `.agg` or `.transform`, as appropriate in the given situation.
 
 ## Proposal
 
-With the above in mind, it is proposed that in the future:
+With the above in mind, it is proposed that in the future `apply`, `transform` and `agg` will work as follows:
 
-It is proposed that `apply`, `transform` and `agg` in the future will work as follows:
-
-1. the `agg` & `transform` methods of `Series`, `DataFrame` & `groupby` will always operate series-wise and never element-wise
-2. `Series.apply` & `DataFrame.apply` will be deprecated.
-3. `groupby.apply` will not be deprecated (because it behaves differently than `Series.apply` & `DataFrame.apply`)
+1. the `agg` and `transform` methods of `Series`, `DataFrame` and `groupby` will always operate series-wise and never element-wise
+2. `Series.apply` and `DataFrame.apply` will be deprecated.
+3. `groupby.apply` will not be deprecated (because it behaves differently than `Series.apply` and `DataFrame.apply`)
 
 The above changes means that the future behavior, when users want to apply arbitrary callables in pandas, can be described as follows:
 
 1. When users want to operate on single elements in a `Series` or `DataFrame`, they should use `Series.map` and `DataFrame.map` respectively.
 2. When users want to aggregate a `Series`, columns/rows of a `DataFrame` or groups in `groupby` objects, they should use `Series.agg`, `DataFrame.agg` and `groupby.agg` respectively.
 3. When users want to transform a `Series`, columns/rows of a `DataFrame` or groups in `groupby` objects, they should use `Series.transform`, `DataFrame.transform` and `groupby.transform` respectively.
+4. Functions that are not applicable for  `map`, `agg` nor `transform` are considered relatively rare and in the future users should call these functions directly rather than use the `apply` method.
 
-The use of `Series.apply` &  `DataFrame.apply` will after the proposed change in almost all cases be replaced by `map`, `agg` or `transform`. In the very few cases where `Series.apply` &  `DataFrame.apply` cannot be substituted by `map`, `agg` or `transform`, it is proposed that it will be accepted that users will have to find alternative ways to apply the functions, i.e. typically apply the functions manually and possibly concatenating the results.
+The use of `Series.apply` and  `DataFrame.apply` will after the proposed change in almost all cases be replaced by `map`, `agg` or `transform`. In the very few cases where `Series.apply` and  `DataFrame.apply` cannot be substituted by `map`, `agg` or `transform`, it is proposed that it will be accepted that users will have to find alternative ways to apply the functions, i.e. typically apply the functions manually and possibly concatenating the results.
 
-It can be noted that `groupby.agg`, `groupby.transform` & `groupby.apply` are not proposed changed in this PDEP, because `groupby.agg`, `groupby.transform` already behave as desired and `groupby.apply` behaves differently than `Series.apply` & `DataFrame.apply`. Likewise, the behavior when given ufuncs will remain unchanged, because the behavior is already as intended in all cases.
+It can be noted that the behavior of `groupby.agg`, `groupby.transform` and `groupby.apply` are not proposed changed in this PDEP, because `groupby.agg`, `groupby.transform` already behave as desired and `groupby.apply` behaves differently than `Series.apply` and `DataFrame.apply`. Likewise, the behavior when given ufuncs (e.g. `np.sqrt`) and string input (e.g. `"sqrt"`) will remain unchanged, because the behavior is already as intended in all cases.
 
 ## Deprecation process
 
-To change the current behavior, it will have to be deprecated. This will be done by in v2.2:
+To change the current behavior, it will have to be deprecated. However, `Series.apply` and `DataFrame.apply` are very widely used methods, so will be deprecated very gradually:
 
-1. Deprecate `Series.apply` & `DataFrame.apply`.
-2. Add a `series_ops_only` with type `bool | lib.NoDefault` parameter to `agg` & `transform` methods of `Series` & `DataFrame`. When `series_ops_only` is set to False, `agg` & `transform` will behave as they do currently. When set to True, `agg` & `transform` will never operate on elements, but always on Series. When set to `no_default`, `agg` & `transform` will behave as `series_ops_only=False`, but will emit a FutureWarning the current behavior will be reoved in the future.
+This means that in v2.2:
+
+1. Calls to `Series.apply` and `DataFrame.apply`will emit a `DeprecationWarning` with an appropriate deprecation message.
+2. A `series_ops_only` with type `bool | lib.NoDefault` parameter will be added to the `agg` and `transform` methods of `Series` and `DataFrame`. When `series_ops_only` is set to False, `agg` and `transform` will behave as they do currently. When set to True, `agg` and `transform` will never operate on elements, but always on Series. When set to `no_default`, `agg` and `transform` will behave as `series_ops_only=False`, but will emit a FutureWarning the current behavior will be reoved in the future.
 
 In Pandas v3.0:
-1. `Series.apply` & `DataFrame.apply` will be removed from the code base (question: or added to `_hidden_attrs`?).
-1. The `agg` & `transform` will always operate on series/columns/rows data and the `series_ops_only` parameter will have no effect and be deprecated and removed in v4.0 (it must be kept in v3.x in order to facilitate the switch from v2.x to v3.0).
+1. Calls to `Series.apply` and `DataFrame.apply` will emit a `FutureWarning` and emit an appropriate deprecation message.
+2. The `agg` and `transform` will always operate on series/columns/rows data and the `series_ops_only` parameter will have no effect and be deprecated.
+
+In Pandas v4.0:
+1. `Series.apply` and `DataFrame.apply` will be removed from the code base.
+2. The `series_ops_only` parameter of agg` and `transform` will be removed from the code base.
 
 ## PDEP History
 
-- 24 august 2023: Initial version (proposed to change `Series.apply` & `DataFrame.apply` to always operate on series/columns/rows)
-- 17. september 2023: version 2 (renamed and proposing to deprecate `Series.apply` & `DataFrame.apply` and make `agg`/`transform` always operate on series/columns/rows)
+- 24 august 2023: Initial version (proposed to change `Series.apply` and `DataFrame.apply` to always operate on series/columns/rows)
+- 17. september 2023: version 2 (renamed and proposing to deprecate `Series.apply` and `DataFrame.apply` and make `agg`/`transform` always operate on series/columns/rows)

--- a/web/pandas/pdeps/0013-standardize-apply.md
+++ b/web/pandas/pdeps/0013-standardize-apply.md
@@ -231,7 +231,7 @@ dtype: int64
 
 Users would expect these two to give the same result.
 
-This PDEP proposes that callables will be applies to the whole `Series`, so in the future we will have:
+This PDEP proposes that callables will be applied to the whole `Series`, so in the future we will have:
 
 ```python
 >>> small_ser.agg(np.sum)

--- a/web/pandas/pdeps/0013-standardize-apply.md
+++ b/web/pandas/pdeps/0013-standardize-apply.md
@@ -109,9 +109,10 @@ It can also be noted that `Series.apply` & `DataFrame.apply` could almost always
 | lambda x: str(x)    | .map       | .map        |
 | lambda x: x + 1     | .transform | .transform  |
 | [lambda x: x.sum()] | .agg       | .agg        |
-``
 
-Because of their flexibility, `Series.apply` & `DataFrame.apply` are considered unnecessarily complex, and it would be better to direct users to use `.map`, `.agg` or `.transform`, as appropriate in the given situation.
+So, for example, `ser.apply(lambda x: str(x))` can be replaced with `ser.map(lambda x: str(x))` while `df.apply([lambda x: x.sum()])` can be replaced with `df.agg([lambda x: x.sum()])`.
+
+Overall, because of their flexibility, `Series.apply` & `DataFrame.apply` are considered unnecessarily complex, and it would be clearer for users to use `.map`, `.agg` or `.transform`, as appropriate in the given situation.
 
 ## Proposal
 

--- a/web/pandas/pdeps/0013-standardize-apply.md
+++ b/web/pandas/pdeps/0013-standardize-apply.md
@@ -144,7 +144,7 @@ In Pandas v3.0:
 1. `Series.apply` & `DataFrame.apply` will be removed from the code base (question: or added to `_hidden_attrs`?).
 1. The `agg` & `transform` will always operate on series/columns/rows data and the `series_ops_only` parameter will have no effect and be deprecated and removed in v4.0 (it must be kept in v3.x in order to facilitate the switch from v2.x to v3.0).
 
-## PDEP-13 History
+## PDEP History
 
 - 24 august 2023: Initial version (proposed to change `Series.apply` & `DataFrame.apply` to always operate on series/columns/rows)
 - 17. september 2023: version 2 (renamed and proposing to deprecate `Series.apply` & `DataFrame.apply` and make `agg`/`transform` always operate on series/columns/rows)

--- a/web/pandas/pdeps/0013-standardize-apply.md
+++ b/web/pandas/pdeps/0013-standardize-apply.md
@@ -163,7 +163,7 @@ Note also that `.pipe` operates on the `Series` while `apply`currently operates 
 
 This PDEP proposes that callables will be applies to the whole `Series`, so we in the future `Series.apply` will be as fast as `Series.pipe`.
 
-### 4. ufuncs in `Series.apply` vs. noral functions
+### 4. ufuncs in `Series.apply` vs. normal functions
 
 Performance-wise, ufuncs are fine in `Series.apply`, but non-ufunc functions are not:
 
@@ -289,7 +289,7 @@ This PDEP proposes that the result from giving list-likes and dict-likes to `Ser
 With the above in mind, it is proposed that:
 
 1. When given a callable, `Series.apply` always operate on the series. I.e. let `series.apply(func)` be similar to `func(series)` + the needed additional functionality.
-2. When given a list-like or dict-like, `Series.apply` will apply each element of the list-like/dict-like to the series. I.e. `series.apply(func_list)` wil be similar to `[series.apply(func) for func in func_list]` + the needed additional functionality
+2. When given a list-like or dict-like, `Series.apply` will apply each element of the list-like/dict-like to the series. I.e. `series.apply(func_list)` will be similar to `[series.apply(func) for func in func_list]` + the needed additional functionality
 3. The changes made to `Series.apply`will propagate to `Series.agg` and `Series.transform` as needed.
 
 The difference between `Series.apply()` & `Series.map()` will then be that:

--- a/web/pandas/pdeps/0013-standardize-apply.md
+++ b/web/pandas/pdeps/0013-standardize-apply.md
@@ -142,7 +142,7 @@ To change the current behavior, it will have to be deprecated. However, `Series.
 This means that in v2.2:
 
 1. Calls to `Series.apply` and `DataFrame.apply`will emit a `DeprecationWarning` with an appropriate deprecation message.
-2. A `series_ops_only` with type `bool | lib.NoDefault` parameter will be added to the `agg` and `transform` methods of `Series` and `DataFrame`. When `series_ops_only` is set to False, `agg` and `transform` will behave as they do currently. When set to True, `agg` and `transform` will never operate on elements, but always on Series. When set to `no_default`, `agg` and `transform` will behave as `series_ops_only=False`, but will emit a FutureWarning the current behavior will be reoved in the future.
+2. A `series_ops_only` argument with type `bool | lib.NoDefault` parameter will be added to the `agg` and `transform` methods of `Series` and `DataFrame` with a default value of `lib.NoDefault`. When `series_ops_only` is set to `False`, `agg` and `transform` will behave as they do currently. When set to `True`, `agg` and `transform` will never operate on elements, but always on Series. When set to `no_default`, `agg` and `transform` will behave as `series_ops_only=False`, but will emit a `DeprecationWarning`, the current behavior will be removed in the future.
 
 In Pandas v3.0:
 1. Calls to `Series.apply` and `DataFrame.apply` will emit a `FutureWarning` and emit an appropriate deprecation message.

--- a/web/pandas/pdeps/0013-standardize-apply.md
+++ b/web/pandas/pdeps/0013-standardize-apply.md
@@ -8,7 +8,7 @@
 
 ## Abstract
 
-Currently, giving a input to `Series.apply` is treated differently depending on the type of the input:
+Currently, giving an input to `Series.apply` is treated differently depending on the type of the input:
 
 * if the input is a numpy `ufunc`, `series.apply(func)` is equivalent to `func(series)`, i.e. similar to `series.pipe(func)`.
 * if the input is a callable, but not a numpy `ufunc`, `series.apply(func)` is similar to `Series([func(val) for val in series], index=series.index)`, i.e. similar to `series.map(func)`

--- a/web/pandas/pdeps/0013-standardize-apply.md
+++ b/web/pandas/pdeps/0013-standardize-apply.md
@@ -1,0 +1,333 @@
+# PDEP-13: Make the Series.apply method operate Series-wise
+
+- Created: 24 August 2023
+- Status: Under discussion
+- Discussion: [#52140](https://github.com/pandas-dev/pandas/issues/52509)
+- Author: [Terji Petersen](https://github.com/topper-123)
+- Revision: 1
+
+## Abstract
+
+Currently, giving a input to `Series.apply` is treated differently depending on the type of the input:
+
+* if the input is a numpy `ufunc`, `series.apply(func)` is equivalent to `func(series)`, i.e. similar to `series.pipe(func)`.
+* if the input is a callable, but not a numpy `ufunc`, `series.apply(func)` is similar to `Series([func(val) for val in series], index=series.index)`, i.e. similar to `series.map(func)`
+* if the input is a list-like or dict-like, `series.apply(func)` is equivalent to `series.agg(func)` (which is subtly different than `series.apply`)
+
+In contrast, `DataFrame.apply` has a consistent behavior:
+
+* if the input is a callable, `df.apply(func)` always calls each columns in the DataFrame, so is similar to `func(col) for _, col in
+df.items()` + wrapping functionality
+* if the input is a list-like or dict-like, `df.apply` call each item in the list/dict and wraps the result as needed. So for example if the input is a list, `df.apply(func_list)` is equivalent to `[df.apply(func) for func in func_list]` + wrapping functionality
+
+This PDEP proposes that:
+
+- The current complex current behavior of `Series.apply` will be deprecated in Pandas 2.2.
+- Single callables given to the `.apply` methods of `Series` will in Pandas 3.0 always be called on the whole `Series`, so `series.apply(func)` will become similar to `func(series)`,
+- Lists or dicts of callables given to the `Series.apply` will in Pandas 3.0 always call `Series.apply` on each element of the list/dict
+
+In short, this PDEP proposes changing `Series.apply` to be more similar to how `DataFrame.apply` works on single dataframe columns, i.e. operate on the whole series. If a user wants to map a callable to each element of a Series, they should be directed to use `Series.map` instead of using `Series.apply`.
+
+## Motivation
+
+`Series.apply` is currently a very complex method, whose behaviour will differ depending on the nature of its input.
+
+`Series.apply` & `Series.map` currently often behave very similar, but differently enough for it to be confusing when it's a good idea to use one over the other and especially when `Series.apply` is a bad idea to use.
+
+Also, calling `Series.apply` currently gives a different result than the per-column result from calling `DataFrame.apply`, which can be confusing for users who expect `Series.apply` to be the `Series` version of `DataFrame.apply`, similar to how `Series.agg` is the `Series` version of `DataFrame.agg`. For example, currently some functions may work fine with `DataFrame.apply`, but may fail, be very slow when given to `Series.apply` or give a different result than the per-column result from `DataFrame.apply`.
+
+### Similarities and differences between `Series.apply` and `Series.map`
+
+The similarity between the methods is especially that they both fall back to use `Series._map_values` and there use `algorithms.map_array` or `ExtensionArray.map` as relevant.
+
+The differences are many, but each one is relative minor:
+
+1. `Series.map` has a `na_action` parameter, which `Series.apply` doesn't
+2. `Series.apply` can take advantage of numpy ufuncs, which `Series.map` can't
+3. `Series.apply` can take `args` and `**kwargs`, which `Series.map` can't
+4. `Series.apply` is more general and can take a string, e.g. `"sum"`, or lists or dicts of inputs which `Series.map` can't.
+5. when given a numpy ufunc, the ufunc will be called on the whole Series, when given to `Series.apply` and on each element of the series, if given to `Series.map`.
+
+In addition, `Series.apply` has some functionality, which `Series.map` does not, but which has already been deprecated:
+
+6. `Series.apply` has a `convert_dtype` parameter, which has been deprecated (deprecated in pandas 2.1, see [GH52257](https://github.com/pandas-dev/pandas/pull/52257))
+7. `Series.apply` will return a Dataframe, if its result is a list of Series (deprecated in pandas 2.1, see [GH52123]()https://github.com/pandas-dev/pandas/pull/52123)).
+
+### Similarities and differences between `Series.apply` and `DataFrame.apply`
+
+`Series.apply` and `DataFrame.apply` are similar when given numpy ufuncs as inputs, but when given non-ufuncs as inputs, `Series.apply` and `DataFrame.apply` will behave differently, because `series.apply(func)` will be similar to `series.map(func)` while `Dataframe.apply(func)` will call the input on each column series and combine the result.
+
+If given a list-like or dict-like, `Series.apply` will behave similar to `Series.agg`, while `DataFrame.apply` will call each element in the list-like/dict-like on each column and combine the results.
+
+Also `DataFrame.apply` has some parameters (`raw` and `result_type`) which are relevant for a 2D DataFrame, but may not be relevant for `Series.apply`, because `Series` is a 1D structure.
+
+## Examples of problems with the current way `Series.apply` works
+
+The above similarities and many minor differences makes for confusing and too complex rules for when its a good idea to use `Series.apply` over `Series.map` to do operations, and vica versa, and for when a callable will work well with `Series.apply` versus `DataFrame.apply`. Some examples will show some examples below.
+
+First some setup:
+
+```python
+>>> import numpy as np
+>>> import pandas as pd
+>>>
+>>> small_ser = pd.Series([1, 2, 3])
+>>> large_ser = pd.Series(range(100_000))
+```
+
+### 1: string vs numpy funcs in `Series.apply`
+
+```python
+>>> small_ser.apply("sum")
+6
+>>> small_ser.apply(np.sum)
+0    1
+1    2
+2    3
+dtype: int64
+```
+
+It will surprise users that these two give different results. Also, anyone using the second pattern is probably making a mistake.
+
+Note that giving `np.sum` to `DataFrame.apply` aggregates properly:
+
+```python
+>>> pd.DataFrame(small_ser).apply(np.sum)
+0    6
+dtype: int64
+```
+
+This PDEP proposes that callables will be applies to the whole `Series`, so we in the future will have:
+
+```python
+>>> small_ser.apply(np.sum)
+6
+```
+
+### 2 Callables vs. list/dict of callables
+
+Giving functions and lists/dicts of functions will give different results:
+
+```python
+>>> small_ser.apply(np.sum)
+0    1
+1    2
+2    3
+dtype: int64
+>>> small_ser.apply([np.sum])
+sum    6
+dtype: int64
+```
+
+Also with non-numpy callables:
+
+```python
+>>> small_ser.apply(lambda x: x.sum())
+AttributeError: 'int' object has no attribute 'sum'
+>>> small_ser.apply([lambda x: x.sum()])
+<lambda>    6
+dtype: int64
+```
+
+In both cases above the difference is that `Series.apply` operates element-wise, if given a callable, but series-wise if given a list/dict of callables.
+
+This PDEP proposes that callables will be applies to the whole `Series`, so we in the future will have:
+
+```python
+>>> small_ser.apply(lambda x: x.sum())
+6
+>>> small_ser.apply([lambda x: x.sum()])
+<lambda>    6
+dtype: int64
+```
+
+### 3. Functions in `Series.apply`
+
+The `Series.apply` doc string have examples with using lambdas, but using lambdas in `Series.apply` is often a bad practices because of bad performance:
+
+```python
+>>> %timeit large_ser.apply(lambda x: x + 1)
+24.1 ms ± 88.8 µs per loop
+```
+
+Currently, `Series` does not have a method that makes a callable operate on a series' data. Instead users need to use `Series.pipe` for that operation in order for the operation to be efficient:
+
+```python
+>>> %timeit large_ser.pipe(lambda x: x + 1)
+44 µs ± 363 ns per loop
+```
+
+(The reason for the above performance differences is that apply gets called on each single element, while `pipe` calls `x.__add__(1)`, which operates on the whole array).
+
+Note also that `.pipe` operates on the `Series` while `apply`currently operates on each element in the data, so there is some differences that may have some consequence in some cases.
+
+This PDEP proposes that callables will be applies to the whole `Series`, so we in the future `Series.apply` will be as fast as `Series.pipe`.
+
+### 4. ufuncs in `Series.apply` vs. noral functions
+
+Performance-wise, ufuncs are fine in `Series.apply`, but non-ufunc functions are not:
+
+```python
+>>> %timeit large_ser.apply(np.sqrt)
+71.6 µs ± 1.17 µs per loop
+>>> %timeit large_ser.apply(lambda x:np.sqrt(x))
+63.6 ms ± 1.03 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
+```
+
+It is difficult to understand why ufuncs are fast in `apply`, while other callables are slow in `apply` (answer: it's because ufuncs operate on the whole Series, while other callables operate elementwise).
+
+This PDEP proposes that callables will be applies to the whole `Series`, so we in the future non-ufunc functions in `Series.apply` will be as fast as ufuncs.
+
+### 5. callables in `Series.apply` is slow, callables in `DataFrame.apply` is fast
+
+Above it was shown that using (non-ufunc) callables in `Series.apply` is bad performance-wise. OTOH using them in `DataFrame.apply` is fine:
+
+```python
+>>> %timeit large_ser.apply(lambda x: x + 1)
+24.3 ms ± 24 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
+>>> %timeit pd.DataFrame(large_ser).apply(lambda x: x + 1)
+160 µs +- 1.17 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+```
+
+Having callables being fast to use in the `DataFrame.apply` method, but slow in `Series.apply` is confusing for users.
+
+This PDEP proposes that callables will be applies to the whole `Series`, so we in the future `Series.apply` will be as fast as `DataFrame.apply` already is.
+
+### 6. callables in `Series.apply` may fail, while callables in `DataFrame.apply` do not and vica versa
+
+```python
+>>> ser.apply(lambda x: x.sum())
+AttributeError: 'int' object has no attribute 'sum'
+>>> pd.DataFrame(ser).apply(lambda x: x.sum())
+0    6
+dtype: int64
+```
+
+Having callables fail when used in `Series.apply`, but work in `DataFrame.Apply` or vica versa is confusing for users.
+
+This PDEP proposes that callables will be applies to the whole `Series`, so callables given to `Series.apply` will work the same as when given to `DataFrame.apply`, so in the future we will have that:
+
+```python
+>>> ser.apply(lambda x: x.sum())
+6
+>>> pd.DataFrame(ser).apply(lambda x: x.sum())
+0    6
+dtype: int64
+```
+
+### 7.  `Series.apply` vs. `Series.agg`
+
+The doc string for `Series.agg` says about the method's `func` parameter: "If a function, must ... work when passed ... to Series.apply". But compare these:
+
+```python
+>>> small_ser.agg(np.sum)
+6
+>>> small_ser.apply(np.sum)
+0    1
+1    2
+2    3
+dtype: int64
+```
+
+Users would expect these two to give the same result.
+
+This PDEP proposes that callables will be applies to the whole `Series`, so in the future we will have:
+
+```python
+>>> small_ser.agg(np.sum)
+6
+>>> small_ser.apply(np.sum)
+6
+```
+
+### 8. dictlikes vs. listlikes in `Series.apply`
+
+Giving a *list* of transforming arguments to `Series.apply` returns a `DataFrame`:
+
+```python
+>>> small_ser.apply(["sqrt", np.abs])
+       sqrt  absolute
+0  1.000000         1
+1  1.414214         2
+2  1.732051         3
+```
+
+But giving a *dict* of transforming arguments returns a `Series` with a `MultiIndex`:
+
+```python
+>>> small_ser.apply({"sqrt" :"sqrt", "abs" : np.abs})
+sqrt  0    1.000000
+      1    1.414214
+      2    1.732051
+abs   0    1.000000
+      1    2.000000
+      2    3.000000
+dtype: float64
+```
+
+These two should give same-shaped output for consistency. Using `Series.transform` instead of `Series.apply`, it returns a `DataFrame` in both cases and I think the dictlike example above should return a `DataFrame` similar to the listlike example.
+
+Minor additional info: listlikes and dictlikes of aggregation arguments do behave the same, so this is only a problem with dictlikes of transforming arguments when using `apply`.
+
+This PDEP proposes that the result from giving list-likes and dict-likes to `Series.apply` will have the same shape as when given list-likes currently:
+
+```python
+>>> small_ser.apply(["sqrt", np.abs])
+       sqrt  absolute
+0  1.000000         1
+1  1.414214         2
+2  1.732051         3
+>>> small_ser.apply({"sqrt" :"sqrt", "abs" : np.abs})
+       sqrt  absolute
+0  1.000000         1
+1  1.414214         2
+2  1.732051         3
+```
+
+## Proposal
+
+With the above in mind, it is proposed that:
+
+1. When given a callable, `Series.apply` always operate on the series. I.e. let `series.apply(func)` be similar to `func(series)` + the needed additional functionality.
+2. When given a list-like or dict-like, `Series.apply` will apply each element of the list-like/dict-like to the series. I.e. `series.apply(func_list)` wil be similar to `[series.apply(func) for func in func_list]` + the needed additional functionality
+3. The changes made to `Series.apply`will propagate to `Series.agg` and `Series.transform` as needed.
+
+The difference between `Series.apply()` & `Series.map()` will then be that:
+
+* `Series.apply()` makes the passed-in callable operate on the series, similarly to how `(DataFrame|SeriesGroupby|DataFrameGroupBy).apply` operate on series. This is very fast and can do almost anything,
+* `Series.map()` makes the passed-in callable operate on each series data elements individually. This is very flexible, but can be very slow, so should only be used if `Series.apply` can't do it.
+
+so, this API change will help make Pandas `Series.(apply|map)` API  clearer without losing functionality and let their functionality  be explainable in a simple manner, which would be a win for Pandas.
+
+The result from the above change will be that `Series.apply` will operate similar to how `DataFrame.apply` works already per column, similar to how `Series.map` operates similar to how `DataFrame.map` works per column. This will give better coherence between same-named methods on `DataFrames` and `Series`.
+
+## Deprecation process
+
+To change the behavior to the current behavior will have to be deprecated. This can be done by adding a `by_row` parameter to `Series.apply`, which means, when `by_rows=False`, that `Series.apply` will not operate elementwise but Series-wise.
+
+So we will have in pandas v2.2:
+
+```python
+>>> def apply(self, ..., by_row: bool | NoDefault=no_default, ...):
+    if by_row is no_default:
+        warn("The by_row parameter will be set to False in the future")
+        by_row = True
+    ...
+```
+
+In pandas v3.0 the signature will change to:
+
+```python
+>>> def apply(self, ..., by_row: NoDefault=no_default, ...):
+    if by_row is not no_default:
+        warn("Do not use the by_row parameter, it will be removed in the future")
+    ...
+```
+
+I.e. the `by_row` parameter will be needed in the signature in v3.0 in order be backward compatible with v2.x, but will have no effect.
+
+In Pandas v4.0, the `by_row` parameter will be removed.
+
+## PDEP-13 History
+
+- 24 august 2023: Initial version

--- a/web/pandas/pdeps/0013-standardize-apply.md
+++ b/web/pandas/pdeps/0013-standardize-apply.md
@@ -1,4 +1,4 @@
-# PDEP-13: Deprecate the apply method on Series & DataFrame in favor of series-based operations using the agg and transform methods
+# PDEP-13: Deprecate the apply method on Series & DataFrame and make the agg and transform methods operate on series data
 
 - Created: 24 August 2023
 - Status: Under discussion

--- a/web/pandas/pdeps/0013-standardize-apply.md
+++ b/web/pandas/pdeps/0013-standardize-apply.md
@@ -205,7 +205,7 @@ dtype: int64
 
 Having callables fail when used in `Series.apply`, but work in `DataFrame.Apply` or vica versa is confusing for users.
 
-This PDEP proposes that callables will be applies to the whole `Series`, so callables given to `Series.apply` will work the same as when given to `DataFrame.apply`, so in the future we will have that:
+This PDEP proposes that callables will be applied to the whole `Series`, so callables given to `Series.apply` will work the same as when given to `DataFrame.apply`, so in the future we will have that:
 
 ```python
 >>> ser.apply(lambda x: x.sum())


### PR DESCRIPTION
There has been some demand for a PDEP regarding changes to `Series.apply` proposed in #52140, for example https://github.com/pandas-dev/pandas/issues/52140#issuecomment-1684879389.

I've made a proposal in this PR.

@MarcoGorelli , if you want to add/change to the proposal I'm fine with that, especially regarding styles/formats that are used for PDEPs and I've missed.

EDIT 17/09-2023: I've made a version 2 of the PDEP.