### PR TITLE
REGR: groupby.count returning string dtype instead of numeric for string input

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -107,6 +107,7 @@ from pandas.core.arrays import (
     IntegerArray,
     SparseArray,
 )
+from pandas.core.arrays.string_ import StringDtype
 from pandas.core.base import (
     PandasObject,
     SelectionMixin,
@@ -2281,7 +2282,9 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                 return IntegerArray(
                     counted[0], mask=np.zeros(counted.shape[1], dtype=np.bool_)
                 )
-            elif isinstance(bvalues, ArrowExtensionArray):
+            elif isinstance(bvalues, ArrowExtensionArray) and not isinstance(
+                bvalues.dtype, StringDtype
+            ):
                 return type(bvalues)._from_sequence(counted[0])
             if is_series:
                 assert counted.ndim == 2

--- a/pandas/tests/groupby/test_counting.py
+++ b/pandas/tests/groupby/test_counting.py
@@ -379,3 +379,14 @@ def test_count_uses_size_on_exception():
     result = df.groupby("grp").count()
     expected = DataFrame({"a": [2, 2]}, index=Index(list("ab"), name="grp"))
     tm.assert_frame_equal(result, expected)
+
+
+def test_count_arrow_string_array(any_string_dtype):
+    # GH#54751
+    pytest.importorskip("pyarrow")
+    df = DataFrame(
+        {"a": [1, 2, 3], "b": Series(["a", "b", "a"], dtype=any_string_dtype)}
+    )
+    result = df.groupby("a").count()
+    expected = DataFrame({"b": 1}, index=Index([1, 2, 3], name="a"))
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #54751 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
