### PR TITLE
PERF: skip libjoin fastpath for MultiIndex

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4783,6 +4783,9 @@ class Index(IndexOpsMixin, PandasObject):
         join_idx = self.take(left_idx)
         right = other.take(right_idx)
         join_index = join_idx.putmask(mask, right)
+        if isinstance(join_index, ABCMultiIndex) and how == "outer":
+            # test_join_index_levels
+            join_index = join_index._sort_levels_monotonic()
         return join_index, left_idx, right_idx
 
     @final

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -124,6 +124,7 @@ from pandas.core.dtypes.dtypes import (
 from pandas.core.dtypes.generic import (
     ABCDataFrame,
     ABCDatetimeIndex,
+    ABCIntervalIndex,
     ABCMultiIndex,
     ABCPeriodIndex,
     ABCSeries,
@@ -3492,8 +3493,6 @@ class Index(IndexOpsMixin, PandasObject):
             and other.is_monotonic_increasing
             and self._can_use_libjoin
             and other._can_use_libjoin
-            and not isinstance(self, ABCMultiIndex)
-            and not isinstance(other, ABCMultiIndex)
         ):
             try:
                 res_indexer, indexer, _ = self._inner_indexer(other)
@@ -4632,28 +4631,13 @@ class Index(IndexOpsMixin, PandasObject):
 
         _validate_join_method(how)
 
-        if not self.is_unique and not other.is_unique:
-            return self._join_non_unique(other, how=how, sort=sort)
-        elif not self.is_unique or not other.is_unique:
-            if self.is_monotonic_increasing and other.is_monotonic_increasing:
-                # Note: 2023-08-15 we *do* have tests that get here with
-                #  Categorical, string[python] (can use libjoin)
-                #  and Interval (cannot)
-                if self._can_use_libjoin and other._can_use_libjoin:
-                    # otherwise we will fall through to _join_via_get_indexer
-                    # GH#39133
-                    # go through object dtype for ea till engine is supported properly
-                    return self._join_monotonic(other, how=how)
-            else:
-                return self._join_non_unique(other, how=how, sort=sort)
-        elif (
-            # GH48504: exclude MultiIndex to avoid going through MultiIndex._values
-            self.is_monotonic_increasing
+        if (
+            not isinstance(self.dtype, CategoricalDtype)
+            and self.is_monotonic_increasing
             and other.is_monotonic_increasing
             and self._can_use_libjoin
             and other._can_use_libjoin
-            and not isinstance(self, ABCMultiIndex)
-            and not isinstance(self.dtype, CategoricalDtype)
+            and (self.is_unique or other.is_unique)
         ):
             # Categorical is monotonic if data are ordered as categories, but join can
             #  not handle this in case of not lexicographically monotonic GH#38502
@@ -4662,6 +4646,8 @@ class Index(IndexOpsMixin, PandasObject):
             except TypeError:
                 # object dtype; non-comparable objects
                 pass
+        elif not self.is_unique or not other.is_unique:
+            return self._join_non_unique(other, how=how, sort=sort)
 
         return self._join_via_get_indexer(other, how, sort)
 
@@ -5042,10 +5028,10 @@ class Index(IndexOpsMixin, PandasObject):
                 or isinstance(self._values, (ArrowExtensionArray, BaseMaskedArray))
                 or self.dtype == "string[python]"
             )
-        # For IntervalIndex, the conversion to numpy converts
-        #  to object dtype, which negates the performance benefit of libjoin
-        # TODO: exclude RangeIndex and MultiIndex as these also make copies?
-        return not isinstance(self.dtype, IntervalDtype)
+        # Exclude index types where the conversion to numpy converts to object dtype,
+        #  which negates the performance benefit of libjoin
+        # TODO: exclude RangeIndex? Seems to break test_concat_datetime_timezone
+        return not isinstance(self, (ABCIntervalIndex, ABCMultiIndex))
 
     # --------------------------------------------------------------------
     # Uncategorized Methods
@@ -5180,8 +5166,7 @@ class Index(IndexOpsMixin, PandasObject):
             # present
             return self._values.to_numpy()
 
-        # TODO: exclude ABCRangeIndex, ABCMultiIndex cases here as those create
-        #  copies.
+        # TODO: exclude ABCRangeIndex case here as it copies
         target = self._get_engine_target()
         if not isinstance(target, np.ndarray):
             raise ValueError("_can_use_libjoin should return False.")


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Addresses #54646 for `MultiIndex` but leaves `RangeIndex` as is. The `RangeIndex` case
seems to have a few side effects - I'll add comments separately to #54646 for `RangeIndex`. 


Also, simplifies the logic in `Index.join` which improves perf for a few `MultiIndex` and non-`MultiIndex` cases.


`multiindex_object` benchmarks:

```
       before           after         ratio
-      18.7±0.2ms       16.6±0.4ms     0.89  multiindex_object.SetOperations.time_operation('monotonic', 'ea_int', 'symmetric_difference', False)
-      19.0±0.7ms       16.5±0.2ms     0.87  multiindex_object.SetOperations.time_operation('monotonic', 'int', 'intersection', False)
-       60.6±10ms         49.8±1ms     0.82  multiindex_object.SetOperations.time_operation('monotonic', 'string', 'intersection', None)
-        40.1±1ms       32.2±0.4ms     0.80  multiindex_object.SetOperations.time_operation('monotonic', 'ea_int', 'intersection', None)
```

`join_merge` benchmarks:

```
       before           after         ratio
-      9.98±0.2ms       8.99±0.1ms     0.90  join_merge.ConcatIndexDtype.time_concat_series('Int64', 'has_na', 1, True)
-      12.2±0.3ms      10.5±0.05ms     0.86  join_merge.ConcatIndexDtype.time_concat_series('int64[pyarrow]', 'has_na', 1, True)
-        13.9±2ms       11.8±0.2ms     0.85  join_merge.ConcatIndexDtype.time_concat_series('datetime64[ns]', 'has_na', 1, False)
-        26.3±3ms      22.3±0.05ms     0.85  join_merge.ConcatIndexDtype.time_concat_series('string[python]', 'monotonic', 1, False)
-        6.50±1ms      5.19±0.05ms     0.80  join_merge.ConcatIndexDtype.time_concat_series('datetime64[ns]', 'monotonic', 1, False)
-         133±2ms         51.1±2ms     0.38  join_merge.Align.time_series_align_int64_index
-       105±0.9ms       23.7±0.5ms     0.22  join_merge.Align.time_series_align_left_monotonic
```

