### PR TITLE
TST: remove redundant catch_warnings

### DIFF
--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -47,12 +47,7 @@ def period_index(freqstr):
     the PeriodIndex behavior.
     """
     # TODO: non-monotone indexes; NaTs, different start dates
-    with warnings.catch_warnings():
-        # suppress deprecation of Period[B]
-        warnings.filterwarnings(
-            "ignore", message="Period with BDay freq", category=FutureWarning
-        )
-        pi = pd.period_range(start=Timestamp("2000-01-01"), periods=100, freq=freqstr)
+    pi = pd.period_range(start=Timestamp("2000-01-01"), periods=100, freq=freqstr)
     return pi
 
 

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import re
-import warnings
 
 import numpy as np
 import pytest


### PR DESCRIPTION
xref #52064
removed redundant catch_warnings in pandas/tests/arrays/test_datetimelike.py