### PR TITLE
ENH: 54714 repeated sampling improvement

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -719,8 +719,7 @@ as a string.
 
     df3 = pd.DataFrame({'col1': [1, 2, 3], 'col2': [2, 3, 4]})
     df3.sample(n=1, axis=1)
-
-Finally, one can also set a seed for ``sample``'s random number generator using the ``random_state`` argument, which will accept either an integer (as a seed) or a NumPy RandomState object.
+One can also set a seed for ``sample``'s random number generator using the ``random_state`` argument, which will accept either an integer (as a seed) or a NumPy RandomState object.
 
 .. ipython:: python
 
@@ -730,6 +729,18 @@ Finally, one can also set a seed for ``sample``'s random number generator using 
     df4.sample(n=2, random_state=2)
     df4.sample(n=2, random_state=2)
 
+Finally, random selection of `n_samples` count of samples each with `n` rows or columns from a Series or DataFrame. Accepts `n_samples` count of different samples, and accepts a specific number of rows/columns to return, or a fraction of rows.
+
+.. ipython:: python
+
+    df5 = pd.Series([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    df5.sample(n=2, n_samples=2)
+
+    # Selecting 3 samples of 4 size with replacement:
+    df5.sample(n=4, n_samples=3, replace = True)
+
+    # Selecting 2 samples of 3 size without replacement:
+    df5.sample(n=3, n_samples=2, replace = False)
 
 
 Setting with enlargement

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -729,7 +729,7 @@ One can also set a seed for ``sample``'s random number generator using the ``ran
     df4.sample(n=2, random_state=2)
     df4.sample(n=2, random_state=2)
 
-Finally, random selection of `n_samples` count of samples each with `n` rows or columns from a Series or DataFrame. Accepts `n_samples` count of different samples, and accepts a specific number of rows/columns to return, or a fraction of rows.
+Finally, random selection of ``n_samples`` count of samples each with ``n`` rows or columns from a Series or DataFrame. Accepts ``n_samples`` count of different samples, and accepts a specific number of rows/columns to return, or a fraction of rows.
 
 .. ipython:: python
 

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -14,6 +14,19 @@ including other versions of pandas.
 Enhancements
 ~~~~~~~~~~~~
 
+.. _whatsnew_210.enhancements.sampling_improvements:
+
+Sample methods in DataFrame and Groupby will now include a ``n_sampling`` parameter
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Addition of ``n_sampling`` parameter to :meth:`DataFrame.sample` and :meth:`Groupby.sample`. (:issue:`54714`)
+
+Currently, there is no way to take repeated samples to create a sampling distribution using pandas alone.
+One would need to create a list comprehension to perform the same, and numpy.random.choice has been preferred for the same,
+as it takes ~700ms compared to the pandas sample method taking ~25s for 1M values.
+
+The new proposed method takes ~ 25ms for the same and performs the task 1000x faster than the current sample feature.
+
 .. _whatsnew_210.enhancements.pyarrow_dependency:
 
 PyArrow will become a required dependency with pandas 3.0

--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -14,6 +14,16 @@ including other versions of pandas.
 Enhancements
 ~~~~~~~~~~~~
 
+Addition of ``n_sampling`` parameter to :meth:`DataFrame.sample` and :meth:`Groupby.sample`. (:issue:`54714`)
+
+Currently, there is no way to take repeated samples to create a sampling distribution using pandas alone.
+One would need to create a list comprehension to perform the same, and numpy.random.choice has been preferred for the same,
+as it takes ~700ms compared to the pandas sample method taking ~25s for 1M values.
+
+The new proposed method takes ~ 25ms for the same and performs the task 1000x faster than the current sample feature.
+
+
+
 .. _whatsnew_220.enhancements.enhancement1:
 
 enhancement1

--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -14,16 +14,6 @@ including other versions of pandas.
 Enhancements
 ~~~~~~~~~~~~
 
-Addition of ``n_sampling`` parameter to :meth:`DataFrame.sample` and :meth:`Groupby.sample`. (:issue:`54714`)
-
-Currently, there is no way to take repeated samples to create a sampling distribution using pandas alone.
-One would need to create a list comprehension to perform the same, and numpy.random.choice has been preferred for the same,
-as it takes ~700ms compared to the pandas sample method taking ~25s for 1M values.
-
-The new proposed method takes ~ 25ms for the same and performs the task 1000x faster than the current sample feature.
-
-
-
 .. _whatsnew_220.enhancements.enhancement1:
 
 enhancement1

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6030,10 +6030,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         if axis is None:
             axis = 0
 
-        #if n_samples is None, set the number of samples to 1
+        # if n_samples is None, set the number of samples to 1
         if n_samples is None:
             n_samples = 1
-        
+
         axis = self._get_axis_number(axis)
         obj_len = self.shape[axis]
 
@@ -6047,18 +6047,22 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         if weights is not None:
             weights = sample.preprocess_weights(self, weights, axis)
-        
-        sampled_indices = sample.sample(obj_len=obj_len,size=size,replace=replace,n_samples=n_samples,weights=weights,random_state=rs)
+
+        sampled_indices = sample.sample(
+            obj_len=obj_len,
+            size=size,
+            replace=replace,
+            n_samples=n_samples,
+            weights=weights,
+            random_state=rs,
+        )
         result = self.take(sampled_indices, axis=axis)
-        
-        if n_samples > 1: 
-            # create a list of sample_no with size repeatations of each in the range of n_samples
+
+        if n_samples > 1:
             sample_no = np.repeat(np.arange(n_samples), size)
-            
-            # reshape the sampled_indices to a 2D array with n_samples rows and size columns
+
             sampled_indices = np.reshape(sampled_indices, (n_samples, size))
-            
-            # add a column to the dataframe with the sample_no
+
             result = result.assign(sample_no=sample_no)
 
         if ignore_index:

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -5541,6 +5541,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         n: int | None = None,
         frac: float | None = None,
         replace: bool = False,
+        n_samples: int | None = None,
         weights: Sequence | Series | None = None,
         random_state: RandomState | None = None,
     ):
@@ -5559,6 +5560,8 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             Fraction of items to return. Cannot be used with `n`.
         replace : bool, default False
             Allow or disallow sampling of the same row more than once.
+        n_samples : int, optional
+            Number of samples to be picked. Each sample will contain `n` rows or `frac` * len(`df`) rows.
         weights : list-like, optional
             Default None results in equal probability weighting.
             If passed a list-like then values must have the same length as
@@ -5628,6 +5631,19 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         5  black  5
         2   blue  2
         0    red  0
+
+        >>> df.groupby("a").sample(
+        ...   n=1, 
+        ...   n_samples = 2, 
+        ...   random_state=1
+        ... )
+                a  b
+        4   black  4
+        5   black  5
+        2    blue  2
+        3    blue  3
+        1     red  1
+        0     red  0
         """  # noqa: E501
         if self._selected_obj.empty:
             # GH48459 prevent ValueError when object is empty
@@ -5656,6 +5672,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                 group_size,
                 size=sample_size,
                 replace=replace,
+                n_samples=n_samples,
                 weights=None if weights is None else weights_arr[grp_indices],
                 random_state=random_state,
             )

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -5633,8 +5633,8 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         0    red  0
 
         >>> df.groupby("a").sample(
-        ...   n=1, 
-        ...   n_samples = 2, 
+        ...   n=1,
+        ...   n_samples = 2,
         ...   random_state=1
         ... )
                 a  b

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -5645,6 +5645,10 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         1     red  1
         0     red  0
         """  # noqa: E501
+        # if n_samples is None, set the number of samples to 1
+        if n_samples is None:
+            n_samples = 1
+
         if self._selected_obj.empty:
             # GH48459 prevent ValueError when object is empty
             return self._selected_obj

--- a/pandas/core/sample.py
+++ b/pandas/core/sample.py
@@ -113,16 +113,16 @@ def process_sampling_size(
 
     return n
 
-
 def sample(
     obj_len: int,
     size: int,
     replace: bool,
+    n_samples: int,
     weights: np.ndarray | None,
     random_state: np.random.RandomState | np.random.Generator,
 ) -> np.ndarray:
     """
-    Randomly sample `size` indices in `np.arange(obj_len)`
+    Randomly sample `size` indices in `np.arange(obj_len)` once or `n_samples` times
 
     Parameters
     ----------
@@ -132,6 +132,8 @@ def sample(
         The number of values to choose
     replace : bool
         Allow or disallow sampling of the same row more than once.
+    n_samples : int
+        Number of samples to pick from the vector space
     weights : np.ndarray[np.float64] or None
         If None, equal probability weighting, otherwise weights according
         to the vector normalized
@@ -140,8 +142,9 @@ def sample(
 
     Returns
     -------
-    np.ndarray[np.intp]
+    np.ndarray[np.intp,np.intp]
     """
+    # GH 54714
     if weights is not None:
         weight_sum = weights.sum()
         if weight_sum != 0:
@@ -149,6 +152,13 @@ def sample(
         else:
             raise ValueError("Invalid weights: weights sum to zero")
 
-    return random_state.choice(obj_len, size=size, replace=replace, p=weights).astype(
+    total_size = size * n_samples
+    
+    return random_state.choice(
+            obj_len, 
+            size=total_size, 
+            replace=replace, 
+            p=weights
+        ).astype(
         np.intp, copy=False
     )

--- a/pandas/core/sample.py
+++ b/pandas/core/sample.py
@@ -113,6 +113,7 @@ def process_sampling_size(
 
     return n
 
+
 def sample(
     obj_len: int,
     size: int,
@@ -153,12 +154,7 @@ def sample(
             raise ValueError("Invalid weights: weights sum to zero")
 
     total_size = size * n_samples
-    
+
     return random_state.choice(
-            obj_len, 
-            size=total_size, 
-            replace=replace, 
-            p=weights
-        ).astype(
-        np.intp, copy=False
-    )
+        obj_len, size=total_size, replace=replace, p=weights
+    ).astype(np.intp, copy=False)

--- a/pandas/core/sample.py
+++ b/pandas/core/sample.py
@@ -145,6 +145,9 @@ def sample(
     -------
     np.ndarray[np.intp,np.intp]
     """
+    if n_samples is None:
+        n_samples = 1
+
     # GH 54714
     if weights is not None:
         weight_sum = weights.sum()

--- a/pandas/tests/groupby/test_sample.py
+++ b/pandas/tests/groupby/test_sample.py
@@ -153,12 +153,13 @@ def test_groupby_sample_with_empty_inputs():
     expected = df
     tm.assert_frame_equal(result, expected)
 
+
 def test_groupby_sample_with_n_samples():
     # GH 54714
     values = [1] * 10 + [2] * 10
     df = DataFrame({"a": values, "b": values, "c": values})
     groupby_df = df.groupby("a")
 
-    result = groupby_df.sample(n_samples = 2)
+    result = groupby_df.sample(n_samples=2)
     expected = df
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/test_sample.py
+++ b/pandas/tests/groupby/test_sample.py
@@ -145,10 +145,20 @@ def test_groupby_sample_with_selections():
 
 
 def test_groupby_sample_with_empty_inputs():
-    # GH48459
+    # GH 48459
     df = DataFrame({"a": [], "b": []})
     groupby_df = df.groupby("a")
 
     result = groupby_df.sample()
+    expected = df
+    tm.assert_frame_equal(result, expected)
+
+def test_groupby_sample_with_n_samples():
+    # GH 54714
+    values = [1] * 10 + [2] * 10
+    df = DataFrame({"a": values, "b": values, "c": values})
+    groupby_df = df.groupby("a")
+
+    result = groupby_df.sample(n_samples = 2)
     expected = df
     tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
This PR contains enhanced functionality for df.sample() and df.groupby().sample(), with the addition of n_samples. 

Currently, there is no way to take repeated samples to create a sampling distribution using pandas alone. Currently, one would need to create a list comprehension to perform the same, and numpy.random.choice has been preferred for the same as it takes ~700ms compared to the pandas sample method taking ~25s for 1M values. 

The new proposed method takes ~ 25ms for the same and performs the task 1000x faster than the current sample feature.

<img width="982" alt="Screenshot 2023-08-27 at 1 40 11 PM" src="https://github.com/pandas-dev/pandas/assets/25490130/206d07e7-0f9d-4e6f-864d-34ea96e5d780">

- [x] closes #54714
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
