### PR TITLE
BUG: repr aligning left for string dtype columns

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -717,6 +717,7 @@ Conversion
 Strings
 ^^^^^^^
 - Bug in :meth:`Series.str` that did not raise a  ``TypeError`` when iterated (:issue:`54173`)
+- Bug in ``repr`` for :class:`DataFrame`` with string-dtype columns (:issue:`54797`)
 
 Interval
 ^^^^^^^^

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1395,6 +1395,8 @@ class Index(IndexOpsMixin, PandasObject):
         from pandas.io.formats.format import format_array
 
         values = self._values
+        if is_string_dtype(values.dtype):
+            values = np.asarray(values)
 
         if is_object_dtype(values.dtype):
             values = cast(np.ndarray, values)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1395,11 +1395,9 @@ class Index(IndexOpsMixin, PandasObject):
         from pandas.io.formats.format import format_array
 
         values = self._values
-        if is_string_dtype(values.dtype):
-            values = np.asarray(values)
 
-        if is_object_dtype(values.dtype):
-            values = cast(np.ndarray, values)
+        if is_object_dtype(values.dtype) or is_string_dtype(values.dtype):
+            values = np.asarray(values)
             values = lib.maybe_convert_objects(values, safe=True)
 
             result = [pprint_thing(x, escape_chars=("\t", "\r", "\n")) for x in values]

--- a/pandas/tests/frame/test_repr_info.py
+++ b/pandas/tests/frame/test_repr_info.py
@@ -455,3 +455,14 @@ NaT   4"""
 0  0.12  1.00
 1  1.12  2.00"""
         assert result == expected
+
+    def test_repr_ea_columns(self, any_string_dtype):
+        # GH#54797
+        pytest.importorskip("pyarrow")
+        df = DataFrame({"long_column_name": [1, 2, 3], "col2": [4, 5, 6]})
+        df.columns = df.columns.astype(any_string_dtype)
+        expected = """   long_column_name  col2
+0                 1     4
+1                 2     5
+2                 3     6"""
+        assert repr(df) == expected


### PR DESCRIPTION
- [ ] closes #54797 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

cc @jorisvandenbossche this is a bit hacky, but changing format_array breaks index-related stuff. Don't feel comfortable to do this now, can be a follow up (we are casting to object anyway, so this does not impact performance)