### PR TITLE
ERR: improve setitem error message for DatetimeArray

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -625,15 +625,19 @@ class DatetimeLikeArrayMixin(  # type: ignore[misc]
         -------
         str
         """
+        if hasattr(value, "dtype") and getattr(value, "ndim", 0) > 0:
+            msg_got = f"{value.dtype} array"
+        else:
+            msg_got = f"'{type(value).__name__}'"
         if allow_listlike:
             msg = (
                 f"value should be a '{self._scalar_type.__name__}', 'NaT', "
-                f"or array of those. Got '{type(value).__name__}' instead."
+                f"or array of those. Got {msg_got} instead."
             )
         else:
             msg = (
                 f"value should be a '{self._scalar_type.__name__}' or 'NaT'. "
-                f"Got '{type(value).__name__}' instead."
+                f"Got {msg_got} instead."
             )
         return msg
 

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -324,19 +324,12 @@ class SharedTests:
         ):
             arr.searchsorted("foo")
 
-        if string_storage == "python":
-            arr_type = "StringArray"
-        elif string_storage == "pyarrow":
-            arr_type = "ArrowStringArray"
-        else:
-            arr_type = "ArrowStringArrayNumpySemantics"
-
         with pd.option_context("string_storage", string_storage):
             with pytest.raises(
                 TypeError,
                 match=re.escape(
                     f"value should be a '{arr1d._scalar_type.__name__}', 'NaT', "
-                    f"or array of those. Got '{arr_type}' instead."
+                    "or array of those. Got string array instead."
                 ),
             ):
                 arr.searchsorted([str(arr[1]), "baz"])


### PR DESCRIPTION
This is a small detail, but currently we see this kind of error message:

```python
>>> ser = pd.Series(pd.arrays.DatetimeArray(np.arange(10, dtype="i8") * 24 * 3600 * 10**9))
>>> ser.searchsorted(["foo", "baz"])
TypeError: value should be a 'Timestamp', 'NaT', or array of those. Got 'StringArray' instead.
>>> ser.searchsorted(np.array([1, 2, 3]))
TypeError: value should be a 'Timestamp', 'NaT', or array of those. Got 'IntegerArray' instead.
>>> pd.options.mode.string_storage = "pyarrow_numpy"
>>> ser.searchsorted(["foo", "baz"])
TypeError: value should be a 'Timestamp', 'NaT', or array of those. Got 'ArrowStringArrayNumpySemantics' instead.
```
(and same error message is used for the array's `__setitem__`)

I personally don't like that the error message uses the array class names (those are not exactly private, but still not something users typically have to work with directly), and I think in general we should try to write our messages in a more generic, user-friendly way (what the user wants to know here is that they provided data of a wrong data type).

With this small PR, the above message become the following, respectively:

```
TypeError: value should be a 'Timestamp', 'NaT', or array of those. Got string array instead.
TypeError: value should be a 'Timestamp', 'NaT', or array of those. Got Int64 array instead.
TypeError: value should be a 'Timestamp', 'NaT', or array of those. Got string array instead.
```

(and as a bonus, the testing actually became easier)