### PR TITLE
Fix minor cython warning

### DIFF
--- a/pandas/_libs/writers.pyx
+++ b/pandas/_libs/writers.pyx
@@ -1,4 +1,5 @@
 cimport cython
+from cython cimport Py_ssize_t
 import numpy as np
 
 from cpython cimport (


### PR DESCRIPTION
Fixes 

```
2023-08-26T19:21:26.6203637Z   warning: /home/runner/work/pandas/pandas/pandas/_libs/writers.pyx:123:50: Unknown type declaration 'Py_ssize_t' in annotation, ignoring
2023-08-26T19:21:26.6253780Z   warning: /home/runner/work/pandas/pandas/pandas/_libs/writers.pyx:123:50: Unknown type declaration 'Py_ssize_t' in annotation, ignoring
2023-08-26T19:21:26.6254699Z   warning: /home/runner/work/pandas/pandas/pandas/_libs/writers.pyx:123:50: Unknown type declaration 'Py_ssize_t' in annotation, ignoring
```