### PR TITLE
BUG: read_parquet from public parquet file with AWS credentials in environment gives OSError

### DIFF
--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -277,7 +277,6 @@ class PyArrowImpl(BaseImpl):
             mode="rb",
         )
         try:
-            # print(filesystem.access_key)
             pa_table = self.api.parquet.read_table(
                 path_or_handle,
                 columns=columns,
@@ -295,9 +294,6 @@ class PyArrowImpl(BaseImpl):
                     df_metadata = pa_table.schema.metadata[b"PANDAS_ATTRS"]
                     result.attrs = json.loads(df_metadata)
             return result
-        except OSError as error:
-            print(f"{error}")
-            # print(f"{filesystem.region}")
         finally:
             if handles is not None:
                 handles.close()


### PR DESCRIPTION
- [x] closes #53701
- [ ] [Tests added and passed]
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Added retry mechanism so public parquet files from s3 can be read regardless of valid or invalid credentials.