### PR TITLE
MAINT: Reflect changes from `numpy` namespace refactor Part 5

### DIFF
--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -285,7 +285,7 @@ def _isna_array(values: ArrayLike, inf_as_na: bool = False):
             # "Union[ndarray[Any, Any], ExtensionArraySupportsAnyAll]", variable has
             # type "ndarray[Any, dtype[bool_]]")
             result = values.isna()  # type: ignore[assignment]
-    elif isinstance(values, np.recarray):
+    elif isinstance(values, np.rec.recarray):
         # GH 48526
         result = _isna_recarray_dtype(values, inf_as_na=inf_as_na)
     elif is_string_or_object_np_dtype(values.dtype):
@@ -332,7 +332,9 @@ def _has_record_inf_value(record_as_array: np.ndarray) -> np.bool_:
     return np.any(is_inf_in_record)
 
 
-def _isna_recarray_dtype(values: np.recarray, inf_as_na: bool) -> npt.NDArray[np.bool_]:
+def _isna_recarray_dtype(
+    values: np.rec.recarray, inf_as_na: bool
+) -> npt.NDArray[np.bool_]:
     result = np.zeros(values.shape, dtype=bool)
     for i, record in enumerate(values):
         record_as_array = np.array(record.tolist())

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2412,7 +2412,7 @@ class DataFrame(NDFrame, OpsMixin):
 
     def to_records(
         self, index: bool = True, column_dtypes=None, index_dtypes=None
-    ) -> np.recarray:
+    ) -> np.rec.recarray:
         """
         Convert DataFrame to a NumPy record array.
 
@@ -2437,7 +2437,7 @@ class DataFrame(NDFrame, OpsMixin):
 
         Returns
         -------
-        numpy.recarray
+        numpy.rec.recarray
             NumPy ndarray with the DataFrame labels as fields and each row
             of the DataFrame as entries.
 
@@ -2445,7 +2445,7 @@ class DataFrame(NDFrame, OpsMixin):
         --------
         DataFrame.from_records: Convert structured or record ndarray
             to DataFrame.
-        numpy.recarray: An ndarray that allows field access using
+        numpy.rec.recarray: An ndarray that allows field access using
             attributes, analogous to typed columns in a
             spreadsheet.
 

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -159,7 +159,7 @@ def arrays_to_mgr(
 
 
 def rec_array_to_mgr(
-    data: np.recarray | np.ndarray,
+    data: np.rec.recarray | np.ndarray,
     index,
     columns,
     dtype: DtypeObj | None,

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -2963,7 +2963,7 @@ supported types."""
         """No-op, future compatibility"""
         return data
 
-    def _prepare_data(self) -> np.recarray:
+    def _prepare_data(self) -> np.rec.recarray:
         data = self.data
         typlist = self.typlist
         convert_dates = self._convert_dates
@@ -2995,7 +2995,7 @@ supported types."""
 
         return data.to_records(index=False, column_dtypes=dtypes)
 
-    def _write_data(self, records: np.recarray) -> None:
+    def _write_data(self, records: np.rec.recarray) -> None:
         self._write_bytes(records.tobytes())
 
     @staticmethod

--- a/pandas/tests/frame/constructors/test_from_records.py
+++ b/pandas/tests/frame/constructors/test_from_records.py
@@ -93,7 +93,7 @@ class TestFromRecords:
                 tup.extend(b.iloc[i].values)
             tuples.append(tuple(tup))
 
-        recarray = np.array(tuples, dtype=dtypes).view(np.recarray)
+        recarray = np.array(tuples, dtype=dtypes).view(np.rec.recarray)
         recarray2 = df.to_records()
         lists = [list(x) for x in tuples]
 

--- a/pandas/tests/frame/methods/test_to_records.py
+++ b/pandas/tests/frame/methods/test_to_records.py
@@ -391,7 +391,7 @@ class TestDataFrameToRecords:
         # see GH#18146
         df = DataFrame({"A": [1, 2], "B": [0.2, 1.5], "C": ["a", "bc"]})
 
-        if not isinstance(expected, np.recarray):
+        if not isinstance(expected, np.rec.recarray):
             with pytest.raises(expected[0], match=expected[1]):
                 df.to_records(**kwargs)
         else:


### PR DESCRIPTION
Hi!
Here's a PR that reflects changes introduced in https://github.com/numpy/numpy/pull/24587. (The only item that needs to be modified in pandas is `np.recarray` access)