### PR TITLE
DOC: updated docstring for deprecation of axis=1 in groupby

### DIFF
--- a/pandas/core/shared_docs.py
+++ b/pandas/core/shared_docs.py
@@ -113,6 +113,13 @@ by : mapping, function, label, pd.Grouper or list of such
 axis : {0 or 'index', 1 or 'columns'}, default 0
     Split along rows (0) or columns (1). For `Series` this parameter
     is unused and defaults to 0.
+
+    .. deprecated:: 2.1.0
+
+        This now defaults to 0 for both `DataFrame` and `Series`.
+        DataFrame.groupby with axis=1 is deprecated. Do
+        Instead, do `frame.T.groupby(...)` without axis.
+
 level : int, level name, or sequence of such, default None
     If the axis is a MultiIndex (hierarchical), group by a particular
     level or levels. Do not specify both ``by`` and ``level``.

--- a/pandas/core/shared_docs.py
+++ b/pandas/core/shared_docs.py
@@ -116,9 +116,8 @@ axis : {0 or 'index', 1 or 'columns'}, default 0
 
     .. deprecated:: 2.1.0
 
-        This now defaults to 0 for both `DataFrame` and `Series`.
-        DataFrame.groupby with axis=1 is deprecated. Do
-        Instead, do `frame.T.groupby(...)` without axis.
+        Will be removed and behave like axis=0 in a future version.
+        For ``axis=1``, do ``frame.T.groupby(...)`` instead.
 
 level : int, level name, or sequence of such, default None
     If the axis is a MultiIndex (hierarchical), group by a particular


### PR DESCRIPTION
- [x] closes #54873
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
