### PR TITLE
DOC: Mark contributors.py as not parallel safe

### DIFF
--- a/doc/sphinxext/contributors.py
+++ b/doc/sphinxext/contributors.py
@@ -54,4 +54,4 @@ class ContributorsDirective(Directive):
 def setup(app):
     app.add_directive("contributors", ContributorsDirective)
 
-    return {"version": "0.1", "parallel_read_safe": True, "parallel_write_safe": True}
+    return {"version": "0.1", "parallel_read_safe": False, "parallel_write_safe": False}


### PR DESCRIPTION
Looks like the doc build has been timing out recently. From the logs it appears to get stuck around the whatsnew files.