### PR TITLE
DOC: add missing periods in JSON section

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -1811,8 +1811,8 @@ Writing JSON
 A ``Series`` or ``DataFrame`` can be converted to a valid JSON string. Use ``to_json``
 with optional parameters:
 
-* ``path_or_buf`` : the pathname or buffer to write the output
-  This can be ``None`` in which case a JSON string is returned
+* ``path_or_buf`` : the pathname or buffer to write the output.
+  This can be ``None`` in which case a JSON string is returned.
 * ``orient`` :
 
   ``Series``:


### PR DESCRIPTION
Hello, I am new here and this is my first contribution (following the advice on how to start contributing from [here](https://blog.afeld.me/contributing-to-pandas-1a68692c4d47)). I just added 2 periods that were missing in the JSON section of the user guide.