### PR TITLE
DOC: fixes Sphinx parallel build error on `doc/source/whatsnew/v0.24.0.rst`

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -286,6 +286,7 @@ value. (:issue:`17054`)
 
 .. ipython:: python
 
+    from io import StringIO
     result = pd.read_html(StringIO("""
       <table>
         <thead>


### PR DESCRIPTION
- Solves #54782
- Adding `from io import StringIO` in line 289 in `doc/source/whatsnew/v0.24.0.rst` solves Sphinx parallel build error when running `python make.py html` (or just `python make.py --single whatsnew/v0.24.0.rst`)

I'm new here and would like to contribute. Any advice would be very much appreciated! This should fix just a minor issue I came across when trying to build the doc.