### PR TITLE
ENH: use shutil.which() instead of external which(1)

### DIFF
--- a/pandas/io/clipboard/__init__.py
+++ b/pandas/io/clipboard/__init__.py
@@ -31,8 +31,6 @@ This module does not work with PyGObject yet.
 Cygwin is currently not supported.
 
 Security Note: This module runs programs with these names:
-    - which
-    - where
     - pbcopy
     - pbpaste
     - xclip
@@ -59,7 +57,7 @@ from ctypes import (
 )
 import os
 import platform
-from shutil import which
+from shutil import which as _executable_exists
 import subprocess
 import time
 import warnings
@@ -82,23 +80,6 @@ EXCEPT_MSG = """
     """
 
 ENCODING = "utf-8"
-
-try:
-    from shutil import which as _executable_exists
-except ImportError:
-    # The "which" unix command finds where a command is.
-    if platform.system() == "Windows":
-        WHICH_CMD = "where"
-    else:
-        WHICH_CMD = "which"
-
-    def _executable_exists(name):
-        return (
-            subprocess.call(
-                [WHICH_CMD, name], stdout=subprocess.PIPE, stderr=subprocess.PIPE
-            )
-            == 0
-        )
 
 
 class PyperclipTimeoutException(PyperclipException):
@@ -571,7 +552,7 @@ def determine_clipboard():
         return init_windows_clipboard()
 
     if platform.system() == "Linux":
-        if which("wslconfig.exe"):
+        if _executable_exists("wslconfig.exe"):
             return init_wsl_clipboard()
 
     # Setup for the macOS platform:

--- a/pandas/io/clipboard/__init__.py
+++ b/pandas/io/clipboard/__init__.py
@@ -232,7 +232,6 @@ def init_wl_clipboard():
             args.append("--clear")
             subprocess.check_call(args, close_fds=True)
         else:
-            pass
             p = subprocess.Popen(args, stdin=subprocess.PIPE, close_fds=True)
             p.communicate(input=text.encode(ENCODING))
 


### PR DESCRIPTION
Use the `shutil.which()` function to determine whether executables exist rather than calling the external `which(1)` or `where` program. This program is not a part of POSIX base system, and modern Linux distributions are working towards making it completely optional. The builtin `shutil.which()` is available since Python 3.3 and already used in the same file.

This makes it possible to remove the dependency on `sys-apps/which` from Gentoo systems.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
