### PR TITLE
REGR: MultiIndex.append raising for overlapping IntervalIndex levels

### DIFF
--- a/doc/source/whatsnew/v2.1.1.rst
+++ b/doc/source/whatsnew/v2.1.1.rst
@@ -17,6 +17,7 @@ Fixed regressions
 - Fixed regression in :func:`read_csv` when ``usecols`` is given and ``dtypes`` is a dict for ``engine="python"`` (:issue:`54868`)
 - Fixed regression in :meth:`.GroupBy.get_group` raising for ``axis=1`` (:issue:`54858`)
 - Fixed regression in :meth:`DataFrame.__setitem__` raising ``AssertionError`` when setting a :class:`Series` with a partial :class:`MultiIndex` (:issue:`54875`)
+- Fixed regression in :meth:`MultiIndex.append` raising when appending overlapping :class:`IntervalIndex` levels (:issue:`54934`)
 - Fixed regression in :meth:`Series.value_counts` raising for numeric data if ``bins`` was specified (:issue:`54857`)
 - Fixed regression when comparing a :class:`Series` with ``datetime64`` dtype with ``None`` (:issue:`54870`)
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2947,9 +2947,11 @@ def recode_for_categories(
             return codes.copy()
         return codes
 
-    indexer = coerce_indexer_dtype(
-        new_categories.get_indexer(old_categories), new_categories
-    )
+    if new_categories._index_as_unique:
+        indexer = new_categories.get_indexer(old_categories)
+    else:
+        indexer = new_categories.get_indexer_non_unique(old_categories)[0]
+    indexer = coerce_indexer_dtype(indexer, new_categories)
     new_codes = take_nd(indexer, codes, fill_value=-1)
     return new_codes
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2947,11 +2947,9 @@ def recode_for_categories(
             return codes.copy()
         return codes
 
-    if new_categories._index_as_unique:
-        indexer = new_categories.get_indexer(old_categories)
-    else:
-        indexer = new_categories.get_indexer_non_unique(old_categories)[0]
-    indexer = coerce_indexer_dtype(indexer, new_categories)
+    indexer = coerce_indexer_dtype(
+        new_categories.get_indexer_for(old_categories), new_categories
+    )
     new_codes = take_nd(indexer, codes, fill_value=-1)
     return new_codes
 

--- a/pandas/tests/indexes/multi/test_reshape.py
+++ b/pandas/tests/indexes/multi/test_reshape.py
@@ -169,6 +169,28 @@ def test_append_names_dont_match():
     tm.assert_index_equal(result, expected)
 
 
+def test_append_overlapping_interval_levels():
+    # GH 54934
+    ivl1 = pd.IntervalIndex.from_breaks([0.0, 1.0, 2.0])
+    ivl2 = pd.IntervalIndex.from_breaks([0.5, 1.5, 2.5])
+    mi1 = MultiIndex.from_product([ivl1, ivl1])
+    mi2 = MultiIndex.from_product([ivl2, ivl2])
+    result = mi1.append(mi2)
+    expected = MultiIndex.from_tuples(
+        [
+            (pd.Interval(0.0, 1.0), pd.Interval(0.0, 1.0)),
+            (pd.Interval(0.0, 1.0), pd.Interval(1.0, 2.0)),
+            (pd.Interval(1.0, 2.0), pd.Interval(0.0, 1.0)),
+            (pd.Interval(1.0, 2.0), pd.Interval(1.0, 2.0)),
+            (pd.Interval(0.5, 1.5), pd.Interval(0.5, 1.5)),
+            (pd.Interval(0.5, 1.5), pd.Interval(1.5, 2.5)),
+            (pd.Interval(1.5, 2.5), pd.Interval(0.5, 1.5)),
+            (pd.Interval(1.5, 2.5), pd.Interval(1.5, 2.5)),
+        ]
+    )
+    tm.assert_index_equal(result, expected)
+
+
 def test_repeat():
     reps = 2
     numbers = [1, 2, 3]


### PR DESCRIPTION
- [x] closes #54934
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.1.1.rst` file if fixing a bug or adding a new feature.
