### PR TITLE
TST: Use (unused) window parameter of test_freq_window_not_implemented

### DIFF
--- a/pandas/core/indexers/objects.py
+++ b/pandas/core/indexers/objects.py
@@ -208,9 +208,7 @@ class VariableOffsetWindowIndexer(BaseIndexer):
         step: int | None = None,
     ) -> tuple[np.ndarray, np.ndarray]:
         if step is not None:
-            raise NotImplementedError(
-                "step is not supported with variable offset window"
-            )
+            raise NotImplementedError("step not implemented for variable offset window")
         if num_values <= 0:
             return np.empty(0, dtype="int64"), np.empty(0, dtype="int64")
 

--- a/pandas/core/indexers/objects.py
+++ b/pandas/core/indexers/objects.py
@@ -208,7 +208,9 @@ class VariableOffsetWindowIndexer(BaseIndexer):
         step: int | None = None,
     ) -> tuple[np.ndarray, np.ndarray]:
         if step is not None:
-            raise NotImplementedError("step not implemented for variable offset window")
+            raise NotImplementedError(
+                "step is not supported with variable offset window"
+            )
         if num_values <= 0:
             return np.empty(0, dtype="int64"), np.empty(0, dtype="int64")
 

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -99,10 +99,8 @@ def test_freq_window_not_implemented(window):
         np.arange(10),
         index=date_range("2015-12-24", periods=10, freq="D"),
     )
-    with pytest.raises(
-        NotImplementedError, match="step is not supported with frequency windows"
-    ):
-        df.rolling("3D", step=3)
+    with pytest.raises(NotImplementedError, match="^step is not supported with"):
+        df.rolling(window, step=3).sum()
 
 
 @pytest.mark.parametrize("agg", ["cov", "corr"])

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -99,7 +99,9 @@ def test_freq_window_not_implemented(window):
         np.arange(10),
         index=date_range("2015-12-24", periods=10, freq="D"),
     )
-    with pytest.raises(NotImplementedError, match="^step is not supported with"):
+    with pytest.raises(
+        NotImplementedError, match="^step (not implemented|is not supported)"
+    ):
         df.rolling(window, step=3).sum()
 
 


### PR DESCRIPTION
Realized that `window` parameter is unused so this is fixing it. Calling `sum` function as the exception is only raised when a function is called with `VariableOffsetWindowIndexer`. Not sure if I need to add an entry to whatsnew for this

- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
