### PR TITLE
BLD: improvements to meson.build files

### DIFF
--- a/generate_version.py
+++ b/generate_version.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Note: This file has to live next to setup.py or versioneer will not work
 import argparse
 import os

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 project(
     'pandas',
     'c', 'cpp', 'cython',
-    version: run_command(['python', 'generate_version.py', '--print'], check: true).stdout().strip(),
+    version: run_command(['generate_version.py', '--print'], check: true).stdout().strip(),
     license: 'BSD-3',
     meson_version: '>=1.0.1',
     default_options: [

--- a/meson.build
+++ b/meson.build
@@ -7,14 +7,12 @@ project(
     meson_version: '>=1.0.1',
     default_options: [
         'buildtype=release',
-        # TODO: Reactivate werror, some warnings on Windows
-        #'werror=true',
         'c_std=c99'
     ]
 )
 
 fs = import('fs')
-py = import('python').find_installation()
+py = import('python').find_installation(pure: false)
 tempita = files('generate_pxi.py')
 versioneer = files('generate_version.py')
 
@@ -30,7 +28,7 @@ add_project_arguments('-DNPY_TARGET_VERSION=NPY_1_21_API_VERSION', language : 'c
 
 
 if fs.exists('_version_meson.py')
-    py.install_sources('_version_meson.py', pure: false, subdir: 'pandas')
+    py.install_sources('_version_meson.py', subdir: 'pandas')
 else
     custom_target('write_version_file',
         output: '_version_meson.py',
@@ -40,11 +38,15 @@ else
         build_by_default: true,
         build_always_stale: true,
         install: true,
-        install_dir: py.get_install_dir(pure: false) / 'pandas'
+        install_dir: py.get_install_dir() / 'pandas'
     )
     meson.add_dist_script(py, versioneer, '-o', '_version_meson.py')
 endif
 
 # Needed by pandas.test() when it looks for the pytest ini options
-py.install_sources('pyproject.toml', pure: false, subdir: 'pandas')
+py.install_sources(
+    'pyproject.toml',
+    subdir: 'pandas'
+)
+
 subdir('pandas')

--- a/pandas/_libs/meson.build
+++ b/pandas/_libs/meson.build
@@ -113,8 +113,9 @@ foreach ext_name, ext_dict : libs_sources
     )
 endforeach
 
-py.install_sources('__init__.py',
-                    pure: false,
-                    subdir: 'pandas/_libs')
+py.install_sources(
+    '__init__.py',
+    subdir: 'pandas/_libs'
+)
 
 subdir('window')

--- a/pandas/_libs/tslibs/meson.build
+++ b/pandas/_libs/tslibs/meson.build
@@ -31,6 +31,7 @@ foreach ext_name, ext_dict : tslibs_sources
     )
 endforeach
 
-py.install_sources('__init__.py',
-                    pure: false,
-                    subdir: 'pandas/_libs/tslibs')
+py.install_sources(
+    '__init__.py',
+    subdir: 'pandas/_libs/tslibs'
+)

--- a/pandas/meson.build
+++ b/pandas/meson.build
@@ -40,8 +40,9 @@ subdirs_list = [
     'util'
 ]
 foreach subdir: subdirs_list
-    install_subdir(subdir, install_dir: py.get_install_dir(pure: false) / 'pandas')
+    install_subdir(subdir, install_dir: py.get_install_dir() / 'pandas')
 endforeach
+
 top_level_py_list = [
     '__init__.py',
     '_typing.py',
@@ -49,8 +50,4 @@ top_level_py_list = [
     'conftest.py',
     'testing.py'
 ]
-foreach file: top_level_py_list
-    py.install_sources(file,
-                       pure: false,
-                       subdir: 'pandas')
-endforeach
+py.install_sources(top_level_py_list, subdir: 'pandas')


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

The second commit is a bug fix: run `generate_version.py` with a shebang, not 'python'. The way this was before can result in build failures. It assumed that `python` is a working Python 3.x interpreter, and that is not always true. See for example this bug report for the exact same thing in NumPy, where `python` isn't working for Sage: https://github.com/numpy/numpy/issues/24514
    
Meson guarantees that .py scripts with a shebang on the top line will be run with a Python interpreter (if there's none on the PATH, it can use the one Meson itself is run with). Hence this is the most robust way of using `run_command` on a .py script.

The first commit is cleanups to make `meson.build` files more idiomatic:

- Use `pure: false` only in a single place. This is recommended for robustness, this way you can't forget it in a subdirectory and end up with a subtly broken package only on niche Linux distros that split purelib and platlib directories.
- Use `py.install_sources` with a list input rather than in a foreach loop.
- Remove the `werror` comment: it's never a good idea to enable `-Werror` by default in the build config of a library, that can easily break builds. This should be done in one or more CI jobs instead.

