### PR TITLE
BUG: DataFrame.stack with future_stack=True failing when columns are tuples

### DIFF
--- a/doc/source/whatsnew/v2.1.1.rst
+++ b/doc/source/whatsnew/v2.1.1.rst
@@ -25,7 +25,7 @@ Fixed regressions
 
 Bug fixes
 ~~~~~~~~~
--
+- Fixed bug in :meth:`DataFrame.stack` with ``future_stack=True`` and columns a non-:class:`MultiIndex` consisting of tuples (:issue:`54948`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_211.other:

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -908,7 +908,7 @@ def stack_v3(frame: DataFrame, level: list[int]) -> Series | DataFrame:
             data = frame.copy()
         else:
             # Take the data from frame corresponding to this idx value
-            if not isinstance(idx, tuple):
+            if len(level) == 1:
                 idx = (idx,)
             gen = iter(idx)
             column_indexer = tuple(

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -2508,3 +2508,19 @@ Thu,Lunch,Yes,51.51,17"""
             index=MultiIndex.from_tuples([(1, "red"), (2, "blue")], names=[0, "y"]),
         )
         tm.assert_frame_equal(result, expected)
+
+
+def test_stack_tuple_columns(future_stack):
+    # GH#54948 - test stack when the input has a non-MultiIndex with tuples
+    df = DataFrame(
+        [[1, 2, 3], [4, 5, 6], [7, 8, 9]], columns=[("a", 1), ("a", 2), ("b", 1)]
+    )
+    result = df.stack(future_stack=future_stack)
+    expected = Series(
+        [1, 2, 3, 4, 5, 6, 7, 8, 9],
+        index=MultiIndex(
+            levels=[[0, 1, 2], [("a", 1), ("a", 2), ("b", 1)]],
+            codes=[[0, 0, 0, 1, 1, 1, 2, 2, 2], [0, 1, 2, 0, 1, 2, 0, 1, 2]],
+        ),
+    )
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #54948 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

In the previous implementation, we assumed that if `idx` is a tuple that we were stacking multiple levels and hence did not need to wrap it in a tuple. However you can have columns consist of tuples that are not a MultiIndex, and then when stacking (the only level) you still want to wrap in a tuple.