### PR TITLE
REGR: rountripping datetime through sqlite doesn't work

### DIFF
--- a/doc/source/whatsnew/v2.1.1.rst
+++ b/doc/source/whatsnew/v2.1.1.rst
@@ -18,6 +18,7 @@ Fixed regressions
 - Fixed regression in :func:`read_csv` when ``delim_whitespace`` is True (:issue:`54918`, :issue:`54931`)
 - Fixed regression in :meth:`.GroupBy.get_group` raising for ``axis=1`` (:issue:`54858`)
 - Fixed regression in :meth:`DataFrame.__setitem__` raising ``AssertionError`` when setting a :class:`Series` with a partial :class:`MultiIndex` (:issue:`54875`)
+- Fixed regression in :meth:`DataFrame.to_sql` not roundtripping datetime columns correctly for sqlite (:issue:`54877`)
 - Fixed regression in :meth:`MultiIndex.append` raising when appending overlapping :class:`IntervalIndex` levels (:issue:`54934`)
 - Fixed regression in :meth:`Series.drop_duplicates` for PyArrow strings (:issue:`54904`)
 - Fixed regression in :meth:`Series.value_counts` raising for numeric data if ``bins`` was specified (:issue:`54857`)

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -2091,13 +2091,11 @@ class SQLiteTable(SQLTable):
 
         adapt_date_iso = lambda val: val.isoformat()
         adapt_datetime_iso = lambda val: val.isoformat()
-        adapt_datetime_epoch = lambda val: int(val.timestamp())
 
         sqlite3.register_adapter(time, _adapt_time)
 
         sqlite3.register_adapter(date, adapt_date_iso)
         sqlite3.register_adapter(datetime, adapt_datetime_iso)
-        sqlite3.register_adapter(datetime, adapt_datetime_epoch)
 
         convert_date = lambda val: date.fromisoformat(val.decode())
         convert_datetime = lambda val: datetime.fromisoformat(val.decode())

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -2962,6 +2962,13 @@ class TestSQLiteAlchemy(_TestSQLAlchemy):
 
         tm.assert_frame_equal(result, expected)
 
+    def test_roundtripping_datetimes(self):
+        # GH#54877
+        df = DataFrame({"t": [datetime(2020, 12, 31, 12)]}, dtype="datetime64[ns]")
+        df.to_sql("test", self.conn, if_exists="replace", index=False)
+        result = pd.read_sql("select * from test", self.conn).iloc[0, 0]
+        assert result == "2020-12-31 12:00:00.000000"
+
 
 @pytest.mark.db
 class TestMySQLAlchemy(_TestSQLAlchemy):


### PR DESCRIPTION
- [ ] closes #54877 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

this wasn't one of the deprecated converters