### PR TITLE
TYP: Add typing.overload signatures to DataFrame/Series.interpolate

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7938,6 +7938,51 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         else:
             return result.__finalize__(self, method="replace")
 
+    @overload
+    def interpolate(
+        self,
+        method: InterpolateOptions = ...,
+        *,
+        axis: Axis = ...,
+        limit: int | None = ...,
+        inplace: Literal[False] = ...,
+        limit_direction: Literal["forward", "backward", "both"] | None = ...,
+        limit_area: Literal["inside", "outside"] | None = ...,
+        downcast: Literal["infer"] | None | lib.NoDefault = ...,
+        **kwargs,
+    ) -> Self:
+        ...
+        
+    @overload
+    def interpolate(
+        self,
+        method: InterpolateOptions = ...,
+        *,
+        axis: Axis = ...,
+        limit: int | None = ...,
+        inplace: Literal[True],
+        limit_direction: Literal["forward", "backward", "both"] | None = ...,
+        limit_area: Literal["inside", "outside"] | None = ...,
+        downcast: Literal["infer"] | None | lib.NoDefault = ...,
+        **kwargs,
+    ) -> None:
+        ...
+    
+    @overload
+    def interpolate(
+        self,
+        method: InterpolateOptions = ...,
+        *,
+        axis: Axis = ...,
+        limit: int | None = ...,
+        inplace: bool_t = ...,
+        limit_direction: Literal["forward", "backward", "both"] | None = ...,
+        limit_area: Literal["inside", "outside"] | None = ...,
+        downcast: Literal["infer"] | None | lib.NoDefault = ...,
+        **kwargs,
+    ) -> Self | None:
+        ...    
+    
     @final
     def interpolate(
         self,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7952,7 +7952,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         **kwargs,
     ) -> Self:
         ...
-        
+
     @overload
     def interpolate(
         self,
@@ -7967,7 +7967,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         **kwargs,
     ) -> None:
         ...
-    
+
     @overload
     def interpolate(
         self,
@@ -7981,8 +7981,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         downcast: Literal["infer"] | None | lib.NoDefault = ...,
         **kwargs,
     ) -> Self | None:
-        ...    
-    
+        ...
+
     @final
     def interpolate(
         self,


### PR DESCRIPTION
This adds overloads so that a type checker can determine whether interpolate returns DataFrame/Series or None based on the value of the inplace argument.

This is more of the same thing that was done in [this pull](https://github.com/pandas-dev/pandas/pull/54281).