### PR TITLE
TYP: Add typing.overload signatures to DataFrame/Series.clip

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8630,7 +8630,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         **kwargs,
     ) -> None:
         ...
-    
+
     @overload
     def clip(
         self,
@@ -8642,7 +8642,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         **kwargs,
     ) -> Self | None:
         ...
-    
+
     @final
     def clip(
         self,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8607,6 +8607,42 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         # GH 40420
         return self.where(subset, threshold, axis=axis, inplace=inplace)
 
+    @overload
+    def clip(
+        self,
+        lower=...,
+        upper=...,
+        *,
+        axis: Axis | None = ...,
+        inplace: Literal[False] = ...,
+        **kwargs,
+    ) -> Self:
+        ...
+
+    @overload
+    def clip(
+        self,
+        lower=...,
+        upper=...,
+        *,
+        axis: Axis | None = ...,
+        inplace: Literal[True],
+        **kwargs,
+    ) -> None:
+        ...
+    
+    @overload
+    def clip(
+        self,
+        lower=...,
+        upper=...,
+        *,
+        axis: Axis | None = ...,
+        inplace: bool_t = ...,
+        **kwargs,
+    ) -> Self | None:
+        ...
+    
     @final
     def clip(
         self,


### PR DESCRIPTION
This adds overloads so that a type checker can determine whether clip returns a  Series/DataFrame or None based on the value of the inplace argument.
