### PR TITLE
TST: Use more explicit object names

### DIFF
--- a/pandas/tests/frame/methods/test_reindex.py
+++ b/pandas/tests/frame/methods/test_reindex.py
@@ -26,7 +26,7 @@ from pandas import (
     isna,
 )
 import pandas._testing as tm
-from pandas.api.types import CategoricalDtype as CDT
+from pandas.api.types import CategoricalDtype
 
 
 class TestReindexSetIndex:
@@ -1082,7 +1082,9 @@ class TestDataFrameSelectReindex:
             {
                 "A": np.arange(3, dtype="int64"),
             },
-            index=CategoricalIndex(list("abc"), dtype=CDT(list("cabe")), name="B"),
+            index=CategoricalIndex(
+                list("abc"), dtype=CategoricalDtype(list("cabe")), name="B"
+            ),
         )
 
         # reindexing
@@ -1111,13 +1113,13 @@ class TestDataFrameSelectReindex:
 
         result = df.reindex(Categorical(["a", "e"], categories=cats))
         expected = DataFrame(
-            {"A": [0, np.nan], "B": Series(list("ae")).astype(CDT(cats))}
+            {"A": [0, np.nan], "B": Series(list("ae")).astype(CategoricalDtype(cats))}
         ).set_index("B")
         tm.assert_frame_equal(result, expected, check_index_type=True)
 
         result = df.reindex(Categorical(["a"], categories=cats))
         expected = DataFrame(
-            {"A": [0], "B": Series(list("a")).astype(CDT(cats))}
+            {"A": [0], "B": Series(list("a")).astype(CategoricalDtype(cats))}
         ).set_index("B")
         tm.assert_frame_equal(result, expected, check_index_type=True)
 
@@ -1138,13 +1140,19 @@ class TestDataFrameSelectReindex:
         # give back the type of categorical that we received
         result = df.reindex(Categorical(["a", "e"], categories=cats, ordered=True))
         expected = DataFrame(
-            {"A": [0, np.nan], "B": Series(list("ae")).astype(CDT(cats, ordered=True))}
+            {
+                "A": [0, np.nan],
+                "B": Series(list("ae")).astype(CategoricalDtype(cats, ordered=True)),
+            }
         ).set_index("B")
         tm.assert_frame_equal(result, expected, check_index_type=True)
 
         result = df.reindex(Categorical(["a", "d"], categories=["a", "d"]))
         expected = DataFrame(
-            {"A": [0, np.nan], "B": Series(list("ad")).astype(CDT(["a", "d"]))}
+            {
+                "A": [0, np.nan],
+                "B": Series(list("ad")).astype(CategoricalDtype(["a", "d"])),
+            }
         ).set_index("B")
         tm.assert_frame_equal(result, expected, check_index_type=True)
 
@@ -1152,7 +1160,9 @@ class TestDataFrameSelectReindex:
             {
                 "A": np.arange(6, dtype="int64"),
             },
-            index=CategoricalIndex(list("aabbca"), dtype=CDT(list("cabe")), name="B"),
+            index=CategoricalIndex(
+                list("aabbca"), dtype=CategoricalDtype(list("cabe")), name="B"
+            ),
         )
         # passed duplicate indexers are not allowed
         msg = "cannot reindex on an axis with duplicate labels"

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -10,9 +10,6 @@ from pandas import (
 )
 import pandas._testing as tm
 
-# aliases to make some tests easier to read
-RI = RangeIndex
-
 
 class TestRangeIndex:
     @pytest.fixture
@@ -507,25 +504,31 @@ class TestRangeIndex:
     @pytest.mark.parametrize(
         "indices, expected",
         [
-            ([RI(1, 12, 5)], RI(1, 12, 5)),
-            ([RI(0, 6, 4)], RI(0, 6, 4)),
-            ([RI(1, 3), RI(3, 7)], RI(1, 7)),
-            ([RI(1, 5, 2), RI(5, 6)], RI(1, 6, 2)),
-            ([RI(1, 3, 2), RI(4, 7, 3)], RI(1, 7, 3)),
-            ([RI(-4, 3, 2), RI(4, 7, 2)], RI(-4, 7, 2)),
-            ([RI(-4, -8), RI(-8, -12)], RI(0, 0)),
-            ([RI(-4, -8), RI(3, -4)], RI(0, 0)),
-            ([RI(-4, -8), RI(3, 5)], RI(3, 5)),
-            ([RI(-4, -2), RI(3, 5)], Index([-4, -3, 3, 4])),
-            ([RI(-2), RI(3, 5)], RI(3, 5)),
-            ([RI(2), RI(2)], Index([0, 1, 0, 1])),
-            ([RI(2), RI(2, 5), RI(5, 8, 4)], RI(0, 6)),
-            ([RI(2), RI(3, 5), RI(5, 8, 4)], Index([0, 1, 3, 4, 5])),
-            ([RI(-2, 2), RI(2, 5), RI(5, 8, 4)], RI(-2, 6)),
-            ([RI(3), Index([-1, 3, 15])], Index([0, 1, 2, -1, 3, 15])),
-            ([RI(3), Index([-1, 3.1, 15.0])], Index([0, 1, 2, -1, 3.1, 15.0])),
-            ([RI(3), Index(["a", None, 14])], Index([0, 1, 2, "a", None, 14])),
-            ([RI(3, 1), Index(["a", None, 14])], Index(["a", None, 14])),
+            ([RangeIndex(1, 12, 5)], RangeIndex(1, 12, 5)),
+            ([RangeIndex(0, 6, 4)], RangeIndex(0, 6, 4)),
+            ([RangeIndex(1, 3), RangeIndex(3, 7)], RangeIndex(1, 7)),
+            ([RangeIndex(1, 5, 2), RangeIndex(5, 6)], RangeIndex(1, 6, 2)),
+            ([RangeIndex(1, 3, 2), RangeIndex(4, 7, 3)], RangeIndex(1, 7, 3)),
+            ([RangeIndex(-4, 3, 2), RangeIndex(4, 7, 2)], RangeIndex(-4, 7, 2)),
+            ([RangeIndex(-4, -8), RangeIndex(-8, -12)], RangeIndex(0, 0)),
+            ([RangeIndex(-4, -8), RangeIndex(3, -4)], RangeIndex(0, 0)),
+            ([RangeIndex(-4, -8), RangeIndex(3, 5)], RangeIndex(3, 5)),
+            ([RangeIndex(-4, -2), RangeIndex(3, 5)], Index([-4, -3, 3, 4])),
+            ([RangeIndex(-2), RangeIndex(3, 5)], RangeIndex(3, 5)),
+            ([RangeIndex(2), RangeIndex(2)], Index([0, 1, 0, 1])),
+            ([RangeIndex(2), RangeIndex(2, 5), RangeIndex(5, 8, 4)], RangeIndex(0, 6)),
+            (
+                [RangeIndex(2), RangeIndex(3, 5), RangeIndex(5, 8, 4)],
+                Index([0, 1, 3, 4, 5]),
+            ),
+            (
+                [RangeIndex(-2, 2), RangeIndex(2, 5), RangeIndex(5, 8, 4)],
+                RangeIndex(-2, 6),
+            ),
+            ([RangeIndex(3), Index([-1, 3, 15])], Index([0, 1, 2, -1, 3, 15])),
+            ([RangeIndex(3), Index([-1, 3.1, 15.0])], Index([0, 1, 2, -1, 3.1, 15.0])),
+            ([RangeIndex(3), Index(["a", None, 14])], Index([0, 1, 2, "a", None, 14])),
+            ([RangeIndex(3, 1), Index(["a", None, 14])], Index(["a", None, 14])),
         ],
     )
     def test_append(self, indices, expected):
@@ -567,7 +570,7 @@ class TestRangeIndex:
         assert empty_idx.format(name=True) == [""]
 
     @pytest.mark.parametrize(
-        "RI",
+        "ri",
         [
             RangeIndex(0, -1, -1),
             RangeIndex(0, 1, 1),
@@ -576,10 +579,10 @@ class TestRangeIndex:
             RangeIndex(-3, -5, -2),
         ],
     )
-    def test_append_len_one(self, RI):
+    def test_append_len_one(self, ri):
         # GH39401
-        result = RI.append([])
-        tm.assert_index_equal(result, RI, exact=True)
+        result = ri.append([])
+        tm.assert_index_equal(result, ri, exact=True)
 
     @pytest.mark.parametrize("base", [RangeIndex(0, 2), Index([0, 1])])
     def test_isin_range(self, base):

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -16,7 +16,6 @@ from pandas import (
     Timestamp,
 )
 import pandas._testing as tm
-from pandas.api.types import CategoricalDtype as CDT
 
 
 @pytest.fixture
@@ -25,7 +24,9 @@ def df():
         {
             "A": np.arange(6, dtype="int64"),
         },
-        index=CategoricalIndex(list("aabbca"), dtype=CDT(list("cab")), name="B"),
+        index=CategoricalIndex(
+            list("aabbca"), dtype=CategoricalDtype(list("cab")), name="B"
+        ),
     )
 
 
@@ -35,13 +36,15 @@ def df2():
         {
             "A": np.arange(6, dtype="int64"),
         },
-        index=CategoricalIndex(list("aabbca"), dtype=CDT(list("cabe")), name="B"),
+        index=CategoricalIndex(
+            list("aabbca"), dtype=CategoricalDtype(list("cabe")), name="B"
+        ),
     )
 
 
 class TestCategoricalIndex:
     def test_loc_scalar(self, df):
-        dtype = CDT(list("cab"))
+        dtype = CategoricalDtype(list("cab"))
         result = df.loc["a"]
         bidx = Series(list("aaa"), name="B").astype(dtype)
         assert bidx.dtype == dtype

--- a/pandas/tests/indexing/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/test_chaining_and_caching.py
@@ -1,4 +1,4 @@
-from string import ascii_letters as letters
+from string import ascii_letters
 
 import numpy as np
 import pytest
@@ -24,9 +24,9 @@ msg = "A value is trying to be set on a copy of a slice from a DataFrame"
 
 def random_text(nobs=100):
     # Construct a DataFrame where each row is a random slice from 'letters'
-    idxs = np.random.default_rng(2).integers(len(letters), size=(nobs, 2))
+    idxs = np.random.default_rng(2).integers(len(ascii_letters), size=(nobs, 2))
     idxs.sort(axis=1)
-    strings = [letters[x[0] : x[1]] for x in idxs]
+    strings = [ascii_letters[x[0] : x[1]] for x in idxs]
 
     return DataFrame(strings, columns=["letters"])
 

--- a/pandas/tests/io/formats/test_info.py
+++ b/pandas/tests/io/formats/test_info.py
@@ -1,6 +1,6 @@
 from io import StringIO
 import re
-from string import ascii_uppercase as uppercase
+from string import ascii_uppercase
 import sys
 import textwrap
 
@@ -452,9 +452,9 @@ def test_info_memory_usage_bug_on_multiindex():
         return f.memory_usage(deep=True).sum()
 
     N = 100
-    M = len(uppercase)
+    M = len(ascii_uppercase)
     index = MultiIndex.from_product(
-        [list(uppercase), date_range("20160101", periods=N)],
+        [list(ascii_uppercase), date_range("20160101", periods=N)],
         names=["id", "date"],
     )
     df = DataFrame(

--- a/pandas/tests/io/formats/test_series_info.py
+++ b/pandas/tests/io/formats/test_series_info.py
@@ -1,5 +1,5 @@
 from io import StringIO
-from string import ascii_uppercase as uppercase
+from string import ascii_uppercase
 import textwrap
 
 import numpy as np
@@ -165,9 +165,9 @@ def test_info_memory_usage_bug_on_multiindex():
     # GH 14308
     # memory usage introspection should not materialize .values
     N = 100
-    M = len(uppercase)
+    M = len(ascii_uppercase)
     index = MultiIndex.from_product(
-        [list(uppercase), date_range("20160101", periods=N)],
+        [list(ascii_uppercase), date_range("20160101", periods=N)],
         names=["id", "date"],
     )
     s = Series(np.random.default_rng(2).standard_normal(N * M), index=index)

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -26,7 +26,6 @@ from pandas import (
     TimedeltaIndex,
 )
 import pandas._testing as tm
-from pandas.api.types import CategoricalDtype as CDT
 from pandas.core.reshape.concat import concat
 from pandas.core.reshape.merge import (
     MergeError,
@@ -1842,7 +1841,7 @@ def left():
         {
             "X": Series(
                 np.random.default_rng(2).choice(["foo", "bar"], size=(10,))
-            ).astype(CDT(["foo", "bar"])),
+            ).astype(CategoricalDtype(["foo", "bar"])),
             "Y": np.random.default_rng(2).choice(["one", "two", "three"], size=(10,)),
         }
     )
@@ -1851,7 +1850,10 @@ def left():
 @pytest.fixture
 def right():
     return DataFrame(
-        {"X": Series(["foo", "bar"]).astype(CDT(["foo", "bar"])), "Z": [1, 2]}
+        {
+            "X": Series(["foo", "bar"]).astype(CategoricalDtype(["foo", "bar"])),
+            "Z": [1, 2],
+        }
     )
 
 
@@ -2002,8 +2004,8 @@ class TestMergeCategorical:
         "change",
         [
             lambda x: x,
-            lambda x: x.astype(CDT(["foo", "bar", "bah"])),
-            lambda x: x.astype(CDT(ordered=True)),
+            lambda x: x.astype(CategoricalDtype(["foo", "bar", "bah"])),
+            lambda x: x.astype(CategoricalDtype(ordered=True)),
         ],
     )
     def test_dtype_on_merged_different(self, change, join_type, left, right):
@@ -2110,11 +2112,13 @@ class TestMergeCategorical:
         # GH 17187
         # merging with a boolean/int categorical column
         df1 = DataFrame({"id": [1, 2, 3, 4], "cat": category_column})
-        df1["cat"] = df1["cat"].astype(CDT(categories, ordered=ordered))
+        df1["cat"] = df1["cat"].astype(CategoricalDtype(categories, ordered=ordered))
         df2 = DataFrame({"id": [2, 4], "num": [1, 9]})
         result = df1.merge(df2)
         expected = DataFrame({"id": [2, 4], "cat": expected_categories, "num": [1, 9]})
-        expected["cat"] = expected["cat"].astype(CDT(categories, ordered=ordered))
+        expected["cat"] = expected["cat"].astype(
+            CategoricalDtype(categories, ordered=ordered)
+        )
         tm.assert_frame_equal(expected, result)
 
     def test_merge_on_int_array(self):

--- a/pandas/tests/reshape/test_cut.py
+++ b/pandas/tests/reshape/test_cut.py
@@ -21,7 +21,7 @@ from pandas import (
     to_datetime,
 )
 import pandas._testing as tm
-from pandas.api.types import CategoricalDtype as CDT
+from pandas.api.types import CategoricalDtype
 import pandas.core.reshape.tile as tmod
 
 
@@ -359,7 +359,7 @@ def test_cut_return_intervals():
         IntervalIndex.from_breaks(exp_bins, closed="right").take(
             [0, 0, 0, 1, 1, 1, 2, 2, 2]
         )
-    ).astype(CDT(ordered=True))
+    ).astype(CategoricalDtype(ordered=True))
     tm.assert_series_equal(result, expected)
 
 
@@ -370,7 +370,7 @@ def test_series_ret_bins():
 
     expected = Series(
         IntervalIndex.from_breaks([-0.003, 1.5, 3], closed="right").repeat(2)
-    ).astype(CDT(ordered=True))
+    ).astype(CategoricalDtype(ordered=True))
     tm.assert_series_equal(result, expected)
 
 
@@ -445,7 +445,7 @@ def test_datetime_bin(conv):
                 Interval(Timestamp(bin_data[1]), Timestamp(bin_data[2])),
             ]
         )
-    ).astype(CDT(ordered=True))
+    ).astype(CategoricalDtype(ordered=True))
 
     bins = [conv(v) for v in bin_data]
     result = Series(cut(data, bins=bins))
@@ -491,7 +491,7 @@ def test_datetime_cut(data):
                 ),
             ]
         )
-    ).astype(CDT(ordered=True))
+    ).astype(CategoricalDtype(ordered=True))
     tm.assert_series_equal(Series(result), expected)
 
 
@@ -534,7 +534,7 @@ def test_datetime_tz_cut(bins, box):
                 ),
             ]
         )
-    ).astype(CDT(ordered=True))
+    ).astype(CategoricalDtype(ordered=True))
     tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -23,7 +23,7 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
-from pandas.api.types import CategoricalDtype as CDT
+from pandas.api.types import CategoricalDtype
 from pandas.core.reshape import reshape as reshape_lib
 from pandas.core.reshape.pivot import pivot_table
 
@@ -219,10 +219,12 @@ class TestPivotTable:
             }
         )
 
-        df["A"] = df["A"].astype(CDT(categories, ordered=False))
+        df["A"] = df["A"].astype(CategoricalDtype(categories, ordered=False))
         result = df.pivot_table(index="B", columns="A", values="C", dropna=dropna)
         expected_columns = Series(["a", "b", "c"], name="A")
-        expected_columns = expected_columns.astype(CDT(categories, ordered=False))
+        expected_columns = expected_columns.astype(
+            CategoricalDtype(categories, ordered=False)
+        )
         expected_index = Series([1, 2, 3], name="B")
         expected = DataFrame(
             [[0.0, 3.0, 6.0], [1.0, 4.0, 7.0], [2.0, 5.0, 8.0]],

--- a/pandas/tests/reshape/test_qcut.py
+++ b/pandas/tests/reshape/test_qcut.py
@@ -20,7 +20,7 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
-from pandas.api.types import CategoricalDtype as CDT
+from pandas.api.types import CategoricalDtype
 
 from pandas.tseries.offsets import (
     Day,
@@ -129,7 +129,9 @@ def test_qcut_return_intervals():
     exp_levels = np.array(
         [Interval(-0.001, 2.664), Interval(2.664, 5.328), Interval(5.328, 8)]
     )
-    exp = Series(exp_levels.take([0, 0, 0, 1, 1, 1, 2, 2, 2])).astype(CDT(ordered=True))
+    exp = Series(exp_levels.take([0, 0, 0, 1, 1, 1, 2, 2, 2])).astype(
+        CategoricalDtype(ordered=True)
+    )
     tm.assert_series_equal(res, exp)
 
 
@@ -199,7 +201,7 @@ def test_single_quantile(data, start, end, length, labels):
 
     if labels is None:
         intervals = IntervalIndex([Interval(start, end)] * length, closed="right")
-        expected = Series(intervals).astype(CDT(ordered=True))
+        expected = Series(intervals).astype(CategoricalDtype(ordered=True))
     else:
         expected = Series([0] * length, dtype=np.intp)
 
@@ -249,7 +251,7 @@ def test_datetime_tz_qcut(bins):
                 ),
             ]
         )
-    ).astype(CDT(ordered=True))
+    ).astype(CategoricalDtype(ordered=True))
     tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -17,7 +17,7 @@ from pandas.core.dtypes.common import (
     is_integer_dtype,
     is_object_dtype,
 )
-from pandas.core.dtypes.dtypes import CategoricalDtype as CDT
+from pandas.core.dtypes.dtypes import CategoricalDtype
 
 import pandas as pd
 from pandas import (
@@ -1182,7 +1182,7 @@ class TestValueCounts:
         with tm.assert_produces_warning(FutureWarning, match=msg):
             result = algos.value_counts(factor)
         breaks = [-1.606, -1.018, -0.431, 0.155, 0.741]
-        index = IntervalIndex.from_breaks(breaks).astype(CDT(ordered=True))
+        index = IntervalIndex.from_breaks(breaks).astype(CategoricalDtype(ordered=True))
         expected = Series([1, 0, 2, 1], index=index, name="count")
         tm.assert_series_equal(result.sort_index(), expected.sort_index())
 


### PR DESCRIPTION
When going over some tests, the `import obj as o` patterns have not been the most clear so making some of these usages more explicit