### PR TITLE
COMPAT: bump pyarrow min version for div on duration

### DIFF
--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -30,6 +30,7 @@ from pandas.compat.pyarrow import (
     pa_version_under9p0,
     pa_version_under11p0,
     pa_version_under13p0,
+    pa_version_under14p0,
 )
 
 if TYPE_CHECKING:
@@ -186,6 +187,7 @@ __all__ = [
     "pa_version_under9p0",
     "pa_version_under11p0",
     "pa_version_under13p0",
+    "pa_version_under14p0",
     "IS64",
     "ISMUSL",
     "PY310",

--- a/pandas/compat/pyarrow.py
+++ b/pandas/compat/pyarrow.py
@@ -15,6 +15,7 @@ try:
     pa_version_under11p0 = _palv < Version("11.0.0")
     pa_version_under12p0 = _palv < Version("12.0.0")
     pa_version_under13p0 = _palv < Version("13.0.0")
+    pa_version_under14p0 = _palv < Version("14.0.0")
 except ImportError:
     pa_version_under7p0 = True
     pa_version_under8p0 = True
@@ -23,3 +24,4 @@ except ImportError:
     pa_version_under11p0 = True
     pa_version_under12p0 = True
     pa_version_under13p0 = True
+    pa_version_under14p0 = True

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -40,6 +40,7 @@ from pandas.compat import (
     pa_version_under9p0,
     pa_version_under11p0,
     pa_version_under13p0,
+    pa_version_under14p0,
 )
 
 from pandas.core.dtypes.dtypes import (
@@ -917,7 +918,7 @@ class TestArrowArray(base.ExtensionTests):
                 or (
                     opname
                     in ("__truediv__", "__rtruediv__", "__floordiv__", "__rfloordiv__")
-                    and not pa_version_under13p0
+                    and not pa_version_under14p0
                 )
             )
             and pa.types.is_duration(pa_dtype)


### PR DESCRIPTION
- [x] closes #55020
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
