### PR TITLE
PERF: concat(axis=1) with unaligned indexes

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -158,9 +158,11 @@ Deprecations
 
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
+- Performance improvement in :func:`concat` with ``axis=1`` and objects with unaligned indexes (:issue:`55084`)
 - Performance improvement in :func:`to_dict` on converting DataFrame to dictionary (:issue:`50990`)
 - Performance improvement in :meth:`DataFrame.sort_index` and :meth:`Series.sort_index` when indexed by a :class:`MultiIndex` (:issue:`54835`)
 - Performance improvement when indexing with more than 4 keys (:issue:`54550`)
+-
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_220.bug_fixes:

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -239,8 +239,12 @@ def union_indexes(indexes, sort: bool | None = True) -> Index:
         Index
         """
         if all(isinstance(ind, Index) for ind in inds):
-            result = inds[0].append(inds[1:]).unique()
-            result = result.astype(dtype, copy=False)
+            inds = [ind.astype(dtype, copy=False) for ind in inds]
+            result = inds[0].unique()
+            other = inds[1].append(inds[2:])
+            diff = other[result.get_indexer_for(other) == -1]
+            if len(diff):
+                result = result.append(diff.unique())
             if sort:
                 result = result.sort_values()
             return result


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.2.0.rst` file if fixing a bug or adding a new feature.



```
       before           after         ratio
-      23.4±0.7ms         19.3±1ms     0.82  join_merge.ConcatIndexDtype.time_concat_series('string[python]', 'monotonic', 1, False)
-        54.7±6ms       42.6±0.3ms     0.78  join_merge.ConcatIndexDtype.time_concat_series('string[pyarrow]', 'has_na', 1, True)
-        19.4±2ms         14.4±1ms     0.75  join_merge.ConcatIndexDtype.time_concat_series('string[python]', 'has_na', 1, False)
-        40.2±3ms         29.8±1ms     0.74  join_merge.ConcatIndexDtype.time_concat_series('string[pyarrow]', 'monotonic', 1, False)
-        52.3±1ms       37.9±0.9ms     0.73  join_merge.ConcatIndexDtype.time_concat_series('string[pyarrow]', 'non_monotonic', 1, True)
-        37.6±3ms         24.5±1ms     0.65  join_merge.ConcatIndexDtype.time_concat_series('string[python]', 'has_na', 1, True)
-        6.81±1ms       4.35±0.4ms     0.64  join_merge.ConcatIndexDtype.time_concat_series('int64[pyarrow]', 'monotonic', 1, True)
-        7.56±1ms       4.81±0.3ms     0.64  join_merge.ConcatIndexDtype.time_concat_series('int64[pyarrow]', 'non_monotonic', 1, False)
-      39.1±0.8ms       24.6±0.2ms     0.63  join_merge.ConcatIndexDtype.time_concat_series('string[python]', 'non_monotonic', 1, True)
-       20.8±10ms       12.5±0.6ms     0.60  join_merge.ConcatIndexDtype.time_concat_series('string[python]', 'non_monotonic', 1, False)
-        9.35±2ms       5.56±0.6ms     0.59  join_merge.ConcatIndexDtype.time_concat_series('int64[pyarrow]', 'has_na', 1, False)
-        12.2±2ms       7.16±0.6ms     0.59  join_merge.ConcatIndexDtype.time_concat_series('int64[pyarrow]', 'has_na', 1, True)
-      7.09±0.8ms       4.00±0.9ms     0.56  join_merge.ConcatIndexDtype.time_concat_series('int64', 'non_monotonic', 1, False)
-        10.3±1ms       5.66±0.2ms     0.55  join_merge.ConcatIndexDtype.time_concat_series('int64[pyarrow]', 'non_monotonic', 1, True)
-        8.09±1ms       4.17±0.2ms     0.52  join_merge.ConcatIndexDtype.time_concat_series('int64[pyarrow]', 'monotonic', 1, False)
-        7.47±1ms       3.74±0.2ms     0.50  join_merge.ConcatIndexDtype.time_concat_series('Int64', 'has_na', 1, False)
-        9.98±1ms      4.99±0.08ms     0.50  join_merge.ConcatIndexDtype.time_concat_series('Int64', 'non_monotonic', 1, True)
-       59.3±20ms       29.0±0.4ms     0.49  join_merge.ConcatIndexDtype.time_concat_series('string[pyarrow]', 'non_monotonic', 1, False)
-        27.9±3ms       13.4±0.9ms     0.48  join_merge.ConcatIndexDtype.time_concat_series('string[python]', 'monotonic', 1, True)
-        7.96±1ms       3.72±0.2ms     0.47  join_merge.ConcatIndexDtype.time_concat_series('Int64', 'monotonic', 1, False)
-        8.59±2ms      3.93±0.08ms     0.46  join_merge.ConcatIndexDtype.time_concat_series('Int64', 'non_monotonic', 1, False)
-        7.88±1ms       3.60±0.2ms     0.46  join_merge.ConcatIndexDtype.time_concat_series('Int64', 'monotonic', 1, True)
-        7.19±1ms      2.97±0.06ms     0.41  join_merge.ConcatIndexDtype.time_concat_series('int64', 'monotonic', 1, True)
-        7.46±2ms       3.06±0.2ms     0.41  join_merge.ConcatIndexDtype.time_concat_series('int64', 'monotonic', 1, False)
-        11.3±3ms       4.54±0.3ms     0.40  join_merge.ConcatIndexDtype.time_concat_series('Int64', 'has_na', 1, True)
-        10.8±2ms       3.81±0.1ms     0.35  join_merge.ConcatIndexDtype.time_concat_series('int64', 'non_monotonic', 1, True)
```