### PR TITLE
TST: Make test_hash_equality_invariance xfail more generic

### DIFF
--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -927,7 +927,6 @@ class TestTimedeltas:
 
     @pytest.mark.xfail(
         reason="pd.Timedelta violates the Python hash invariant (GH#44504).",
-        raises=AssertionError,
     )
     @given(
         st.integers(


### PR DESCRIPTION
The `raises` isn't too novel compared to raising a more specific behavior exception like a `ValueError`

Additionally, seems like hypothesis raises an ExceptionGroup here now which is PY311 specific (or using a backport package).