### PR TITLE
Better support for UserDict on constructor

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -29,7 +29,7 @@ enhancement2
 Other enhancements
 ^^^^^^^^^^^^^^^^^^
 - DataFrame.apply now allows the usage of numba (via ``engine="numba"``) to JIT compile the passed function, allowing for potential speedups (:issue:`54666`)
-- It is now possible to pass an instance of a ``collections.UserDict`` subclass to initialize a DataFrame. The expected behaviour is the same as if you pass a `dict` (:issue:`55109`)
+- It is now possible to pass an instance of a ``collections.UserDict`` subclass to initialize a DataFrame. The expected behaviour is the same as if you pass a ``dict`` (:issue:`55109`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_220.notable_bug_fixes:

--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -29,7 +29,7 @@ enhancement2
 Other enhancements
 ^^^^^^^^^^^^^^^^^^
 - DataFrame.apply now allows the usage of numba (via ``engine="numba"``) to JIT compile the passed function, allowing for potential speedups (:issue:`54666`)
-- It is now possible to pass an instance of a `collections.UserDict` subclass to initialize a DataFrame. The expected behaviour is the same as if you pass a `dict` (:issue:`55109`)
+- It is now possible to pass an instance of a ``collections.UserDict`` subclass to initialize a DataFrame. The expected behaviour is the same as if you pass a `dict` (:issue:`55109`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_220.notable_bug_fixes:

--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -29,7 +29,7 @@ enhancement2
 Other enhancements
 ^^^^^^^^^^^^^^^^^^
 - DataFrame.apply now allows the usage of numba (via ``engine="numba"``) to JIT compile the passed function, allowing for potential speedups (:issue:`54666`)
--
+- It is now possible to pass an instance of a `collections.UserDict` subclass to initialize a DataFrame. The expected behaviour is the same as if you pass a `dict` (:issue:`55109`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_220.notable_bug_fixes:

--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -29,7 +29,7 @@ enhancement2
 Other enhancements
 ^^^^^^^^^^^^^^^^^^
 - DataFrame.apply now allows the usage of numba (via ``engine="numba"``) to JIT compile the passed function, allowing for potential speedups (:issue:`54666`)
-- It is now possible to pass an instance of a ``collections.UserDict`` subclass to initialize a DataFrame. The expected behaviour is the same as if you pass a ``dict`` (:issue:`55109`)
+- It is now possible to pass an object that either directly inherits from ``abc.Mapping`` or has it in its inheritance chain to initialize a DataFrame. The expected behaviour is the same as if you pass a ``dict`` object. (:issue:`55109`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_220.notable_bug_fixes:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -703,7 +703,7 @@ class DataFrame(NDFrame, OpsMixin):
             raise ValueError("columns cannot be a set")
 
         if copy is None:
-            if isinstance(data, dict):
+            if isinstance(data, abc.MutableMapping):
                 # retain pre-GH#38939 default behavior
                 copy = True
             elif (
@@ -732,7 +732,7 @@ class DataFrame(NDFrame, OpsMixin):
                 data, axes={"index": index, "columns": columns}, dtype=dtype, copy=copy
             )
 
-        elif isinstance(data, dict):
+        elif isinstance(data, abc.MutableMapping):
             # GH#38939 de facto copy defaults to False only in non-dict cases
             mgr = dict_to_mgr(data, index, columns, dtype=dtype, copy=copy, typ=manager)
         elif isinstance(data, ma.MaskedArray):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -703,7 +703,7 @@ class DataFrame(NDFrame, OpsMixin):
             raise ValueError("columns cannot be a set")
 
         if copy is None:
-            if isinstance(data, abc.MutableMapping):
+            if isinstance(data, abc.Mapping):
                 # retain pre-GH#38939 default behavior
                 copy = True
             elif (
@@ -732,7 +732,7 @@ class DataFrame(NDFrame, OpsMixin):
                 data, axes={"index": index, "columns": columns}, dtype=dtype, copy=copy
             )
 
-        elif isinstance(data, abc.MutableMapping):
+        elif isinstance(data, abc.Mapping):
             # GH#38939 de facto copy defaults to False only in non-dict cases
             mgr = dict_to_mgr(data, index, columns, dtype=dtype, copy=copy, typ=manager)
         elif isinstance(data, ma.MaskedArray):

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -421,7 +421,7 @@ def _check_values_indices_shape_match(
 
 
 def dict_to_mgr(
-    data: dict,
+    data: abc.MutableMapping,
     index,
     columns,
     *,

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -421,7 +421,7 @@ def _check_values_indices_shape_match(
 
 
 def dict_to_mgr(
-    data: abc.MutableMapping,
+    data: abc.Mapping,
     index,
     columns,
     *,

--- a/pandas/tests/frame/constructors/test_from_dict.py
+++ b/pandas/tests/frame/constructors/test_from_dict.py
@@ -209,9 +209,9 @@ class TestFromDict:
             pass
 
         d_1 = CustomUserDict(foo=1, bar=2)
-        df_1 = DataFrame(d_1, index=['a'])
+        df_1 = DataFrame(d_1, index=["a"])
 
-        d_2 = {'foo': 1, 'bar': 2}
-        df_2 = DataFrame(d_2, index=['a'])
+        d_2 = {"foo": 1, "bar": 2}
+        df_2 = DataFrame(d_2, index=["a"])
 
         tm.assert_frame_equal(df_1, df_2)

--- a/pandas/tests/frame/constructors/test_from_dict.py
+++ b/pandas/tests/frame/constructors/test_from_dict.py
@@ -1,6 +1,6 @@
 from collections import (
     OrderedDict,
-    UserDict
+    UserDict,
 )
 
 import numpy as np

--- a/pandas/tests/frame/constructors/test_from_dict.py
+++ b/pandas/tests/frame/constructors/test_from_dict.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+from collections import OrderedDict, UserDict
 
 import numpy as np
 import pytest
@@ -200,3 +200,15 @@ class TestFromDict:
         )
         with pytest.raises(ValueError, match=msg):
             DataFrame.from_dict({"foo": 1, "baz": 3, "bar": 2}, orient="abc")
+
+    def test_constructor_user_dict(self):
+        class CustomUserDict(UserDict):
+            pass
+
+        d_1 = CustomUserDict(foo=1, bar=2)
+        df_1 = DataFrame(d_1, index=['a'])
+
+        d_2 = {'foo': 1, 'bar': 2}
+        df_2 = DataFrame(d_2, index=['a'])
+
+        tm.assert_frame_equal(df_1, df_2)

--- a/pandas/tests/frame/constructors/test_from_dict.py
+++ b/pandas/tests/frame/constructors/test_from_dict.py
@@ -1,4 +1,7 @@
-from collections import OrderedDict, UserDict
+from collections import (
+    OrderedDict,
+    UserDict
+)
 
 import numpy as np
 import pytest


### PR DESCRIPTION
I noticed that if I create my DataFrame passing a dictionary which is a custom one of a subclass of `collections.UserDict` then we have incompatible behaviour with the one if I pass a builtin `dict`.

The idea is that the `UserDict` should have the same type interface as the `dict` and used for custom behaviour, instead of subclassing direct from `dict`. 

This PR attempts to fix that incompatibility issue.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
