### PR TITLE
BUG: Index.difference not always returning a unique set of values

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -231,7 +231,7 @@ Interval
 
 Indexing
 ^^^^^^^^
--
+- Bug in :meth:`Index.difference` not returning a unique set of values when ``other`` is empty or ``other`` is considered non-comparable (:issue:`55113`)
 -
 
 Missing

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3598,14 +3598,14 @@ class Index(IndexOpsMixin, PandasObject):
 
         if len(other) == 0:
             # Note: we do not (yet) sort even if sort=None GH#24959
-            result = self.rename(result_name)
+            result = self.unique().rename(result_name)
             if sort is True:
                 return result.sort_values()
             return result
 
         if not self._should_compare(other):
             # Nothing matches -> difference is everything
-            result = self.rename(result_name)
+            result = self.unique().rename(result_name)
             if sort is True:
                 return result.sort_values()
             return result

--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -809,7 +809,7 @@ class TestSetOpsUnsorted:
         left = Index([1, 1])
         right = Index([True])
         result = left.difference(right)
-        expected = left.unique()
+        expected = Index([1])
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("index", ["string"], indirect=True)

--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -803,7 +803,7 @@ class TestSetOpsUnsorted:
         tm.assert_index_equal(result, expected)
 
     def test_difference_should_not_compare(self):
-        # GH #####
+        # GH 55113
         left = Index([1, 1])
         right = Index([True])
         result = left.difference(right)

--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -796,10 +796,12 @@ class TestSetOpsUnsorted:
             assert result.name == expected
 
     def test_difference_empty_arg(self, index, sort):
-        first = index[5:20]
+        first = index.copy()
+        first = first[5:20]
         first.name = "name"
         result = first.difference([], sort)
-        expected = first.unique()
+        expected = index[5:20].unique()
+        expected.name = "name"
         tm.assert_index_equal(result, expected)
 
     def test_difference_should_not_compare(self):

--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -799,8 +799,16 @@ class TestSetOpsUnsorted:
         first = index[5:20]
         first.name = "name"
         result = first.difference([], sort)
+        expected = first.unique()
+        tm.assert_index_equal(result, expected)
 
-        tm.assert_index_equal(result, first)
+    def test_difference_should_not_compare(self):
+        # GH #####
+        left = Index([1, 1])
+        right = Index([True])
+        result = left.difference(right)
+        expected = left.unique()
+        tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("index", ["string"], indirect=True)
     def test_difference_identity(self, index, sort):


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.2.0.rst` file if fixing a bug or adding a new feature.

`Index.difference` has two short-circuit paths which currently differ in behavior from the main path in that they do not return a unique set of values when duplicates exist:

```
In [1]: import pandas as pd

In [2]: idx = pd.Index([1, 1])

In [3]: idx.difference([2])
Out[3]: Index([1], dtype='int64')      <- main path: unique

In [4]: idx.difference([])
Out[4]: Index([1, 1], dtype='int64')   <- short circuit path when right is empty: non-unique

In [5]: idx.difference([True])
Out[5]: Index([1, 1], dtype='int64')   <- short circuit path when right is considered "non-comparable": non-unique
```