### PR TITLE
Use pandasSQL transactions in sql test suite to avoid engine deadlocks

### DIFF
--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1141,18 +1141,21 @@ class PandasSQLTest:
     def _read_sql_iris_parameter(self, sql_strings):
         query = sql_strings["read_parameters"][self.flavor]
         params = ("Iris-setosa", 5.1)
-        iris_frame = self.pandasSQL.read_query(query, params=params)
+        with self.pandasSQL.run_transaction():
+            iris_frame = self.pandasSQL.read_query(query, params=params)
         check_iris_frame(iris_frame)
 
     def _read_sql_iris_named_parameter(self, sql_strings):
         query = sql_strings["read_named_parameters"][self.flavor]
         params = {"name": "Iris-setosa", "length": 5.1}
-        iris_frame = self.pandasSQL.read_query(query, params=params)
+        with self.pandasSQL.run_transaction():
+            iris_frame = self.pandasSQL.read_query(query, params=params)
         check_iris_frame(iris_frame)
 
     def _read_sql_iris_no_parameter_with_percent(self, sql_strings):
         query = sql_strings["read_no_parameters_with_percent"][self.flavor]
-        iris_frame = self.pandasSQL.read_query(query, params=None)
+        with self.pandasSQL.run_transaction():
+            iris_frame = self.pandasSQL.read_query(query, params=None)
         check_iris_frame(iris_frame)
 
     def _to_sql_empty(self, test_frame1):
@@ -1182,7 +1185,8 @@ class PandasSQLTest:
     def _roundtrip(self, test_frame1):
         self.drop_table("test_frame_roundtrip", self.conn)
         assert self.pandasSQL.to_sql(test_frame1, "test_frame_roundtrip") == 4
-        result = self.pandasSQL.read_query("SELECT * FROM test_frame_roundtrip")
+        with self.pandasSQL.run_transaction():
+            result = self.pandasSQL.read_query("SELECT * FROM test_frame_roundtrip")
 
         result.set_index("level_0", inplace=True)
         # result.index.astype(int)
@@ -1232,13 +1236,14 @@ class PandasSQLTest:
         except DummyException:
             # ignore raised exception
             pass
-        res = self.pandasSQL.read_query("SELECT * FROM test_trans")
+        with self.pandasSQL.run_transaction():
+            res = self.pandasSQL.read_query("SELECT * FROM test_trans")
         assert len(res) == 0
 
         # Make sure when transaction is committed, rows do get inserted
         with self.pandasSQL.run_transaction() as trans:
             trans.execute(ins_sql)
-        res2 = self.pandasSQL.read_query("SELECT * FROM test_trans")
+            res2 = self.pandasSQL.read_query("SELECT * FROM test_trans")
         assert len(res2) == 1
 
 


### PR DESCRIPTION
When trying to integrate the engine fixtures into these tests I have been running into a lot of deadlocking issues. From some [research](https://github.com/sqlalchemy/sqlalchemy/issues/5405#issuecomment-646607306) it looks like SQLAlchemy strongly discourages running doing [Connectionless Execution](https://docs.sqlalchemy.org/en/13/core/connections.html#connectionless-execution-implicit-execution) 

Note the comment:

> Modern SQLAlchemy usage, especially the ORM, places a heavy stress on working within the context of a transaction at all times; the “implicit execution” concept makes the job of associating statement execution with a particular transaction much more difficult.

We probably need an overhaul of the sql module to more natively account for this, but I think it makes sense to unlock our test suite first so that getting better coverage via fixtures in https://github.com/pandas-dev/pandas/pull/55074 would help us more confidently refactor

Here's an MRE to reproduce this deadlock locally:

```python
import sqlalchemy as sa

from pandas.io.sql import pandasSQL_builder

engine = sa.create_engine("mysql+pymysql://root@localhost:3306/pandas")

pandasSQL = pandasSQL_builder(engine)
with pandasSQL.run_transaction() as trans:
    stmt = sa.text("CREATE TABLE test_trans (A INT, B TEXT)")
    trans.execute(stmt)

with pandasSQL.run_transaction() as trans:
    stmt = sa.text("INSERT INTO test_trans (A,B) VALUES (1, 'blah')")
    trans.execute(stmt)

result = pandasSQL.read_query("SELECT * FROM test_trans")

# Assume fixture tries to clean up all tables after function exit
with engine.begin() as conn:
    stmt = sa.text("DROP TABLE test_trans")
    conn.execute(stmt)
```

If you wrap the read_query call in a transaction there is no deadlock

(tip: if you ran the above locally you will probably want to kill the thread so it doesn't lock up your database. run `show engine innodb status;` inside the db, look for the hanging thread id and run `KILL <thread_id>`)
