### PR TITLE
BUG: Silence `Period[B]` warnings in plotting code

### DIFF
--- a/doc/source/whatsnew/v2.1.2.rst
+++ b/doc/source/whatsnew/v2.1.2.rst
@@ -24,6 +24,7 @@ Bug fixes
 ~~~~~~~~~
 - Fixed bug in :meth:`DataFrame.resample` not respecting ``closed`` and ``label`` arguments for :class:`~pandas.tseries.offsets.BusinessDay` (:issue:`55282`)
 - Fixed bug in :meth:`DataFrame.resample` where bin edges were not correct for :class:`~pandas.tseries.offsets.BusinessDay` (:issue:`55281`)
+- Silence ``Period[B]`` warnings introduced by :issue:`53446` during normal plotting activity (:issue:`55138`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -2487,6 +2487,13 @@ class TestDataFramePlots:
                 assert ax.get_ylim() == (0, 100)
                 assert ax.get_yticks()[0] == 99
 
+    @pytest.mark.slow
+    def test_plot_no_warning(self):
+        df = tm.makeTimeDataFrame()
+        with tm.assert_produces_warning(False):
+            _ = df.plot()
+            _ = df.T.plot()
+
 
 def _generate_4_axes_via_gridspec():
     import matplotlib.pyplot as plt

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -2489,6 +2489,8 @@ class TestDataFramePlots:
 
     @pytest.mark.slow
     def test_plot_no_warning(self):
+        # GH 55138
+        # TODO(3.0): this can be removed once Period[B] deprecation is enforced
         df = tm.makeTimeDataFrame()
         with tm.assert_produces_warning(False):
             _ = df.plot()

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -973,3 +973,8 @@ class TestSeriesPlots:
         ax = series.plot(color=None)
         expected = _unpack_cycler(mpl.pyplot.rcParams)[:1]
         _check_colors(ax.get_lines(), linecolors=expected)
+
+    @pytest.mark.slow
+    def test_plot_no_warning(self, ts):
+        with tm.assert_produces_warning(False):
+            _ = ts.plot()

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -976,5 +976,7 @@ class TestSeriesPlots:
 
     @pytest.mark.slow
     def test_plot_no_warning(self, ts):
+        # GH 55138
+        # TODO(3.0): this can be removed once Period[B] deprecation is enforced
         with tm.assert_produces_warning(False):
             _ = ts.plot()


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This silences warnings introduced by https://github.com/pandas-dev/pandas/issues/53446 that would happen during normal plotting activity.
