### PR TITLE
DOCS: temporary pin pydata-sphinx-theme to 0.13

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -85,7 +85,7 @@ dependencies:
   - google-auth
   - natsort  # DataFrame.sort_values doctest
   - numpydoc
-  - pydata-sphinx-theme
+  - pydata-sphinx-theme=0.13
   - pytest-cython  # doctest
   - sphinx
   - sphinx-design

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -60,7 +60,7 @@ gitdb
 google-auth
 natsort
 numpydoc
-pydata-sphinx-theme
+pydata-sphinx-theme==0.13
 pytest-cython
 sphinx
 sphinx-design


### PR DESCRIPTION

The pydata-sphinx-theme has a new release, and that causes some issues with the top bar:

![image](https://github.com/pandas-dev/pandas/assets/1020496/c0f2a1ff-c2a4-46e8-9ed9-6ab43316c20c)

So we can maybe temporarily pin the theme until that is fixed