### PR TITLE
DEV: don't install tables on MacOS ARM in dev requirements.txt (add env markers)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,7 +35,7 @@ psycopg2-binary>=2.9.3
 pyarrow>=7.0.0
 pymysql>=1.0.2
 pyreadstat>=1.1.5
-tables>=3.7.0
+tables>=3.7.0 ; sys_platform != 'darwin' and platform_machine != 'arm64'
 python-calamine>=0.1.6
 pyxlsb>=1.0.9
 s3fs>=2022.05.0

--- a/scripts/generate_pip_deps_from_conda.py
+++ b/scripts/generate_pip_deps_from_conda.py
@@ -33,6 +33,8 @@ RENAME = {
     "sqlalchemy": "SQLAlchemy",
 }
 ADD_ENV_MARKERS = {
+    # pytables has no wheels available for macOS arm, and installing from source generally fails 
+    # -> exclude from dev dependencies in this case
     "pytables": " ; sys_platform != 'darwin' and platform_machine != 'arm64'",
 }
 

--- a/scripts/generate_pip_deps_from_conda.py
+++ b/scripts/generate_pip_deps_from_conda.py
@@ -75,12 +75,14 @@ def conda_package_to_pip(package: str):
             pkg, version = package.split(compare)
             if pkg in EXCLUDE:
                 return
-            return "".join((
-                rename(pkg),
-                compare,
-                remap_version(pkg, version),
-                retrieve_env_markers(pkg),
-            ))
+            return "".join(
+                (
+                    rename(pkg),
+                    compare,
+                    remap_version(pkg, version),
+                    retrieve_env_markers(pkg),
+                )
+            )
 
     return "".join((rename(package), retrieve_env_markers(package)))
 

--- a/scripts/generate_pip_deps_from_conda.py
+++ b/scripts/generate_pip_deps_from_conda.py
@@ -129,9 +129,9 @@ def generate_pip_from_conda(
 
     header = (
         f"# This file is auto-generated from {conda_path.name}, do not modify.\
-        \n"
+\n"
         "# See that file for comments about the need/usage of each dependency.\
-        \n\n"
+\n\n"
     )
     pip_content = header + "\n".join(pip_deps) + "\n"
 

--- a/scripts/generate_pip_deps_from_conda.py
+++ b/scripts/generate_pip_deps_from_conda.py
@@ -33,7 +33,8 @@ RENAME = {
     "sqlalchemy": "SQLAlchemy",
 }
 ADD_ENV_MARKERS = {
-    # pytables has no wheels available for macOS arm, and installing from source generally fails 
+    # pytables has no wheels available for macOS arm,
+    # and installing from source generally fails
     # -> exclude from dev dependencies in this case
     "pytables": " ; sys_platform != 'darwin' and platform_machine != 'arm64'",
 }
@@ -127,8 +128,10 @@ def generate_pip_from_conda(
             raise ValueError(f"Unexpected dependency {dep}")
 
     header = (
-        f"# This file is auto-generated from {conda_path.name}, do not modify.\n"
-        "# See that file for comments about the need/usage of each dependency.\n\n"
+        f"# This file is auto-generated from {conda_path.name}, do not modify.\
+        \n"
+        "# See that file for comments about the need/usage of each dependency.\
+        \n\n"
     )
     pip_content = header + "\n".join(pip_deps) + "\n"
 


### PR DESCRIPTION
When installing dependencies via pip on Mac M1 or M2 installing tables is not trivial and throws an error (see below) because wheels of tables for this hardware is not available and building depends on hdf5.

The solution is to exclude the install of tables via environment markers in the `requirements-dev.txt`. This file is generated by `scripts/generate_pip_deps_from_conda.py`.

This commit adds the following functionality to `scripts/generate_pip_deps_from_conda.py`:
- Adding environment markers to dependencies specified in `ADD_ENV_MARKERS`.
- Allow multiple operations on the same package (add env markers, rename package and remap version).


- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.


# error installing tables
```pip install tables
Collecting tables
  Using cached tables-3.8.0.tar.gz (8.0 MB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [11 lines of output]
      <string>:19: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
      ld: library not found for -lhdf5
      clang: error: linker command failed with exit code 1 (use -v to see invocation)
      cpuinfo failed, assuming no CPU features: 'flags'
      * Using Python 3.10.10 (main, Apr 20 2023, 14:37:50) [Clang 14.0.0 (clang-1400.0.29.202)]
      * Found cython 3.0.2
      * USE_PKGCONFIG: True
      .. ERROR:: Could not find a local HDF5 installation.
         You may need to explicitly state where your local HDF5 headers and
         library can be found by setting the ``HDF5_DIR`` environment
         variable or by using the ``--hdf5`` command-line option.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.```