### PR TITLE
DOC: add alternative to docstring of deprecated Series.bool() method

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1558,8 +1558,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         >>> pd.DataFrame({'col': [False]}).bool()  # doctest: +SKIP
         False
 
-        Alternative
-        --------
         This is an alternative method and will only work
         for single element objects with a boolean value:
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1526,7 +1526,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         .. deprecated:: 2.1.0
 
-           bool is deprecated and will be removed in future version of pandas
+           bool is deprecated and will be removed in future version of pandas.
+           For series use pandas.Series.item.
 
         This must be a boolean scalar value, either True or False. It will raise a
         ValueError if the Series or DataFrame does not have exactly 1 element, or that
@@ -1555,6 +1556,17 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         >>> pd.DataFrame({'col': [True]}).bool()  # doctest: +SKIP
         True
         >>> pd.DataFrame({'col': [False]}).bool()  # doctest: +SKIP
+        False
+
+
+        Alternative
+        --------
+        This is an alternative method and will only work
+        for single element objects with a boolean value:
+
+        >>> pd.Series([True]).item()  # doctest: +SKIP
+        True
+        >>> pd.Series([False]).item()  # doctest: +SKIP
         False
         """
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1527,7 +1527,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         .. deprecated:: 2.1.0
 
            bool is deprecated and will be removed in future version of pandas.
-           For series use pandas.Series.item.
+           For ``Series`` use ``pandas.Series.item``.
 
         This must be a boolean scalar value, either True or False. It will raise a
         ValueError if the Series or DataFrame does not have exactly 1 element, or that

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1558,7 +1558,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         >>> pd.DataFrame({'col': [False]}).bool()  # doctest: +SKIP
         False
 
-
         Alternative
         --------
         This is an alternative method and will only work


### PR DESCRIPTION
Fixed! Docs adapted.

https://pandas.pydata.org/docs/dev/reference/api/pandas.Series.bool.html is deprecated; it would be nice to explain a potential alternative.
