### PR TITLE
DOC: complete parameter descriptions for DataFrame.insert's docstring

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4915,7 +4915,9 @@ class DataFrame(NDFrame, OpsMixin):
         column : str, number, or hashable object
             Label of the inserted column.
         value : Scalar, Series, or array-like
+            Content of the inserted column.
         allow_duplicates : bool, optional, default lib.no_default
+            Allow duplicate column labels to be created.
 
         See Also
         --------


### PR DESCRIPTION
issue: https://github.com/jorisvandenbossche/pydata-amsterdam-pandas-sprint/issues/1
- bullet point item #5: "complete the parameter descriptions"

- [x] closes https://github.com/jorisvandenbossche/pydata-amsterdam-pandas-sprint/issues/1, bullet point 5
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

@jorisvandenbossche 
