### PR TITLE
MAINT: Cleanup expired ndarray methods

### DIFF
--- a/doc/source/user_guide/gotchas.rst
+++ b/doc/source/user_guide/gotchas.rst
@@ -379,7 +379,7 @@ constructors using something similar to the following:
 .. ipython:: python
 
    x = np.array(list(range(10)), ">i4")  # big endian
-   newx = x.byteswap().newbyteorder()  # force native byteorder
+   newx = x.byteswap().view(x.dtype.newbyteorder())  # force native byteorder
    s = pd.Series(newx)
 
 See `the NumPy documentation on byte order

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1773,7 +1773,7 @@ the string values returned are correct."""
             self._data_read = True
         # if necessary, swap the byte order to native here
         if self._byteorder != self._native_byteorder:
-            raw_data = raw_data.byteswap().newbyteorder()
+            raw_data = raw_data.byteswap().view(raw_data.dtype.newbyteorder())
 
         if convert_categoricals:
             self._read_value_labels()


### PR DESCRIPTION
Hi!
This PR reflects changes introduced in https://github.com/numpy/numpy/pull/24682.