### PR TITLE
Typo: 'whenlines' -> 'when lines'

### DIFF
--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -175,7 +175,7 @@ def to_json(
 
     if mode == "a" and (not lines or orient != "records"):
         msg = (
-            "mode='a' (append) is only supported when"
+            "mode='a' (append) is only supported when "
             "lines is True and orient is 'records'"
         )
         raise ValueError(msg)

--- a/pandas/tests/io/json/test_readlines.py
+++ b/pandas/tests/io/json/test_readlines.py
@@ -399,7 +399,7 @@ def test_to_json_append_orient(orient_):
     # Test ValueError when orient is not 'records'
     df = DataFrame({"col1": [1, 2], "col2": ["a", "b"]})
     msg = (
-        r"mode='a' \(append\) is only supported when"
+        r"mode='a' \(append\) is only supported when "
         "lines is True and orient is 'records'"
     )
     with pytest.raises(ValueError, match=msg):
@@ -411,7 +411,7 @@ def test_to_json_append_lines():
     # Test ValueError when lines is not True
     df = DataFrame({"col1": [1, 2], "col2": ["a", "b"]})
     msg = (
-        r"mode='a' \(append\) is only supported when"
+        r"mode='a' \(append\) is only supported when "
         "lines is True and orient is 'records'"
     )
     with pytest.raises(ValueError, match=msg):


### PR DESCRIPTION
I noticed that the text gets joined together when this particular error message gets printed. It looks like `whenlines` instead of `when lines`.