### PR TITLE
DEPR: Change FutureWarning for observed=False to DeprecationWarning

### DIFF
--- a/doc/source/whatsnew/v2.1.1.rst
+++ b/doc/source/whatsnew/v2.1.1.rst
@@ -44,6 +44,7 @@ Bug fixes
 
 Other
 ~~~~~
+- Changed the ``FutureWarning`` raised when ``observed=False`` in :meth:`DataFrame.groupby` and :meth:`Series.groupby` to a ``DeprecationWarning`` (:issue:`54970`)
 - Reverted the deprecation that disallowed :meth:`Series.apply` returning a :class:`DataFrame` when the passed-in callable returns a :class:`Series` object (:issue:`52116`)
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v2.1.1.rst
+++ b/doc/source/whatsnew/v2.1.1.rst
@@ -45,7 +45,6 @@ Bug fixes
 Other
 ~~~~~
 - Changed the ``FutureWarning`` raised when ``observed=False`` in :meth:`DataFrame.groupby` and :meth:`Series.groupby` to a ``DeprecationWarning`` (:issue:`54970`)
-- Reverted the deprecation that disallowed :meth:`Series.apply` returning a :class:`DataFrame` when the passed-in callable returns a :class:`Series` object (:issue:`52116`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_211.contributors:

--- a/doc/source/whatsnew/v2.1.1.rst
+++ b/doc/source/whatsnew/v2.1.1.rst
@@ -44,7 +44,7 @@ Bug fixes
 
 Other
 ~~~~~
-- Changed the ``FutureWarning`` raised when ``observed=False`` in :meth:`DataFrame.groupby` and :meth:`Series.groupby` to a ``DeprecationWarning`` (:issue:`54970`)
+- Reverted the deprecation that disallowed :meth:`Series.apply` returning a :class:`DataFrame` when the passed-in callable returns a :class:`Series` object (:issue:`52116`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_211.contributors:

--- a/doc/source/whatsnew/v2.1.2.rst
+++ b/doc/source/whatsnew/v2.1.2.rst
@@ -29,7 +29,7 @@ Bug fixes
 
 Other
 ~~~~~
-- Reverted the deprecation that disallowed :meth:`Series.apply` returning a :class:`DataFrame` when the passed-in callable returns a :class:`Series` object (:issue:`52116`)
+- Changed the ``FutureWarning`` raised when ``observed=False`` in :meth:`DataFrame.groupby` and :meth:`Series.groupby` to a ``DeprecationWarning`` (:issue:`54970`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v2.1.2.rst
+++ b/doc/source/whatsnew/v2.1.2.rst
@@ -29,7 +29,7 @@ Bug fixes
 
 Other
 ~~~~~
--
+- Reverted the deprecation that disallowed :meth:`Series.apply` returning a :class:`DataFrame` when the passed-in callable returns a :class:`Series` object (:issue:`52116`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1322,7 +1322,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                     "to True in a future version of pandas. Pass observed=False to "
                     "retain current behavior or observed=True to adopt the future "
                     "default and silence this warning.",
-                    FutureWarning,
+                    DeprecationWarning,
                     stacklevel=find_stack_level(),
                 )
             observed = False

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -2080,7 +2080,7 @@ def test_groupby_default_depr(cat_columns, keys):
     df = DataFrame({"a": [1, 1, 2, 3], "b": [4, 5, 6, 7]})
     df[cat_columns] = df[cat_columns].astype("category")
     msg = "The default of observed=False is deprecated"
-    klass = FutureWarning if set(cat_columns) & set(keys) else None
+    klass = DeprecationWarning if set(cat_columns) & set(keys) else None
     with tm.assert_produces_warning(klass, match=msg):
         df.groupby(keys)
 


### PR DESCRIPTION
- [ ] closes #54970 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
