### PR TITLE
BUG: Rolling pd.date_range incorrect for unit='s' #55026

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -172,7 +172,9 @@ copyright = f"{datetime.now().year}"
 import pandas  # isort:skip
 
 # version = '%s r%s' % (pandas.__version__, svn_version())
-version = str(pandas.__version__)
+# version = str(pandas.__version__)
+
+version = str(pandas.__version__).split("+")[0]
 
 # The full version, including alpha/beta/rc tags.
 release = version

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -172,9 +172,7 @@ copyright = f"{datetime.now().year}"
 import pandas  # isort:skip
 
 # version = '%s r%s' % (pandas.__version__, svn_version())
-# version = str(pandas.__version__)
-
-version = str(pandas.__version__).split("+")[0]
+version = str(pandas.__version__)
 
 # The full version, including alpha/beta/rc tags.
 release = version

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1884,6 +1884,13 @@ class Rolling(RollingAndExpandingMixin):
             else:
                 self._win_freq_i8 = freq.nanos
 
+            if self._on.dtype == "M8[us]":
+                self._win_freq_i8 /= 1e3
+            elif self._on.dtype == "M8[ms]":
+                self._win_freq_i8 /= 1e6
+            elif self._on.dtype == "M8[s]":
+                self._win_freq_i8 /= 1e9
+
             # min_periods must be an integer
             if self.min_periods is None:
                 self.min_periods = 1

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1884,9 +1884,6 @@ class Rolling(RollingAndExpandingMixin):
             else:
                 self._win_freq_i8 = freq.nanos
 
-            if self._on.dtype == "M8[us]":
-                self._win_freq_i8 /= 1000
-
             # min_periods must be an integer
             if self.min_periods is None:
                 self.min_periods = 1

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1884,6 +1884,9 @@ class Rolling(RollingAndExpandingMixin):
             else:
                 self._win_freq_i8 = freq.nanos
 
+            if self._on.dtype == "M8[us]":
+                self._win_freq_i8 /= 1000
+
             # min_periods must be an integer
             if self.min_periods is None:
                 self.min_periods = 1

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -1950,24 +1950,3 @@ def test_numeric_only_corr_cov_series(kernel, use_arg, numeric_only, dtype):
         op2 = getattr(rolling2, kernel)
         expected = op2(*arg2, numeric_only=numeric_only)
         tm.assert_series_equal(result, expected)
-
-
-def test_rolling_rolling_sum_window_microseconds_confilict_timestamp():
-    # GH#55106
-    df_time = DataFrame(
-        {"B": [0, 1, 2, 4, 5, 6]},
-        index=[
-            Timestamp("20130101 09:00:00"),
-            Timestamp("20130101 09:00:02"),
-            Timestamp("20130101 09:00:03"),
-            Timestamp("20130101 09:00:06"),
-            Timestamp("20130101 09:00:07"),
-            Timestamp("20130101 09:00:08"),
-        ],
-    )
-    sum_in_nanosecs = df_time.rolling("1s").sum()
-    # micro seconds / milliseconds should not breaks the correct rolling
-    df_time.index = df_time.index.as_unit("us")
-    sum_in_microsecs = df_time.rolling("1s").sum()
-    sum_in_microsecs.index = sum_in_microsecs.index.as_unit("ns")
-    tm.assert_frame_equal(sum_in_nanosecs, sum_in_microsecs)

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -1950,3 +1950,25 @@ def test_numeric_only_corr_cov_series(kernel, use_arg, numeric_only, dtype):
         op2 = getattr(rolling2, kernel)
         expected = op2(*arg2, numeric_only=numeric_only)
         tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("unit", ["s", "ms", "us", "ns"])
+def test_rolling_rolling_max_window_nanoseconds_confilict_timestamp(unit):
+    # GH#55026
+    window = Timedelta(days=4)
+
+    ref_dates = date_range("2023-01-01", "2023-01-10", unit="ns")
+    ref_series = Series(0, index=ref_dates)
+    ref_series.iloc[0] = 1
+    ref_max_series = ref_series.rolling(window).max()
+
+    dates = date_range("2023-01-01", "2023-01-10", unit=unit)
+    series = Series(0, index=dates)
+    series.iloc[0] = 1
+    max_series = series.rolling(window).max()
+
+    ref_df = DataFrame(ref_max_series)
+    df = DataFrame(max_series)
+    df.index = df.index.as_unit("ns")
+
+    tm.assert_frame_equal(ref_df, df)

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -1950,3 +1950,24 @@ def test_numeric_only_corr_cov_series(kernel, use_arg, numeric_only, dtype):
         op2 = getattr(rolling2, kernel)
         expected = op2(*arg2, numeric_only=numeric_only)
         tm.assert_series_equal(result, expected)
+
+
+def test_rolling_rolling_sum_window_microseconds_confilict_timestamp():
+    # GH#55106
+    df_time = DataFrame(
+        {"B": [0, 1, 2, 4, 5, 6]},
+        index=[
+            Timestamp("20130101 09:00:00"),
+            Timestamp("20130101 09:00:02"),
+            Timestamp("20130101 09:00:03"),
+            Timestamp("20130101 09:00:06"),
+            Timestamp("20130101 09:00:07"),
+            Timestamp("20130101 09:00:08"),
+        ],
+    )
+    sum_in_nanosecs = df_time.rolling("1s").sum()
+    # micro seconds / milliseconds should not breaks the correct rolling
+    df_time.index = df_time.index.as_unit("us")
+    sum_in_microsecs = df_time.rolling("1s").sum()
+    sum_in_microsecs.index = sum_in_microsecs.index.as_unit("ns")
+    tm.assert_frame_equal(sum_in_nanosecs, sum_in_microsecs)


### PR DESCRIPTION
- [X] closes #55026
- [X] [Tests added and passed]

This follows the #55173 and will be fixed by the same approach. The custom tests were added for the `max` function itself.