### PR TITLE
TST: Don't call gc.collect for plotting tests

### DIFF
--- a/pandas/tests/io/formats/style/test_matplotlib.py
+++ b/pandas/tests/io/formats/style/test_matplotlib.py
@@ -1,5 +1,3 @@
-import gc
-
 import numpy as np
 import pytest
 
@@ -33,8 +31,6 @@ def mpl_cleanup():
     mpl_units.registry.clear()
     mpl_units.registry.update(orig_units_registry)
     plt.close("all")
-    # https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.6.0.html#garbage-collection-is-no-longer-run-on-figure-close  # noqa: E501
-    gc.collect(1)
 
 
 @pytest.fixture

--- a/pandas/tests/plotting/conftest.py
+++ b/pandas/tests/plotting/conftest.py
@@ -1,5 +1,3 @@
-import gc
-
 import numpy as np
 import pytest
 
@@ -25,8 +23,6 @@ def mpl_cleanup():
     mpl_units.registry.clear()
     mpl_units.registry.update(orig_units_registry)
     plt.close("all")
-    # https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.6.0.html#garbage-collection-is-no-longer-run-on-figure-close  # noqa: E501
-    gc.collect(1)
 
 
 @pytest.fixture

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -3,7 +3,6 @@ from datetime import (
     date,
     datetime,
 )
-import gc
 import itertools
 import re
 import string
@@ -2050,8 +2049,6 @@ class TestDataFramePlots:
 
         # have matplotlib delete all the figures
         plt.close("all")
-        # force a garbage collection
-        gc.collect()
         assert ref() is None
 
     def test_df_gridspec_patterns_vert_horiz(self):


### PR DESCRIPTION
This may be slowing down test run time while Python may be garbage collecting dead objects already