### PR TITLE
Add remove_from_default_na options to read_csv, read_excel...

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -1741,7 +1741,9 @@ class TextFileReader(abc.Iterator):
         # Converting values to NA
         keep_default_na = options["keep_default_na"]
         remove_from_default_na = options["remove_from_default_na"]
-        na_values, na_fvalues = _clean_na_values(na_values, remove_from_default_na, keep_default_na)
+        na_values, na_fvalues = _clean_na_values(
+            na_values, remove_from_default_na, keep_default_na
+        )
 
         # handle skiprows; this is internally handled by the
         # c-engine, so only need for python and pyarrow parsers

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -211,6 +211,9 @@ na_values : Hashable, Iterable of Hashable or dict of {{Hashable : Iterable}}, o
     + fill('", "'.join(sorted(STR_NA_VALUES)), 70, subsequent_indent="    ")
     + """ ".
 
+remove_from_default_na : : Hashable, Iterable of Hashable or dict of {{Hashable : Iterable}}, optional
+    Remvoe values from the default ``NaN`` values when parsing the data.
+
 keep_default_na : bool, default True
     Whether or not to include the default ``NaN`` values when parsing the data.
     Depending on whether ``na_values`` is passed in, the behavior is as follows:
@@ -718,6 +721,10 @@ def read_csv(
     | Iterable[Hashable]
     | Mapping[Hashable, Iterable[Hashable]]
     | None = ...,
+    remove_from_default_na: Hashable
+    | Iterable[Hashable]
+    | Mapping[Hashable, Iterable[Hashable]]
+    | None = ...,
     keep_default_na: bool = ...,
     na_filter: bool = ...,
     verbose: bool = ...,
@@ -781,6 +788,10 @@ def read_csv(
     | Iterable[Hashable]
     | Mapping[Hashable, Iterable[Hashable]]
     | None = ...,
+    remove_from_default_na: Hashable
+    | Iterable[Hashable]
+    | Mapping[Hashable, Iterable[Hashable]]
+    | None = ...,
     keep_default_na: bool = ...,
     na_filter: bool = ...,
     verbose: bool = ...,
@@ -841,6 +852,10 @@ def read_csv(
     skipfooter: int = ...,
     nrows: int | None = ...,
     na_values: Hashable
+    | Iterable[Hashable]
+    | Mapping[Hashable, Iterable[Hashable]]
+    | None = ...,
+    remove_from_default_na: Hashable
     | Iterable[Hashable]
     | Mapping[Hashable, Iterable[Hashable]]
     | None = ...,
@@ -920,6 +935,10 @@ def read_csv(
     | Iterable[Hashable]
     | Mapping[Hashable, Iterable[Hashable]]
     | None = None,
+    remove_from_default_na: Hashable
+    | Iterable[Hashable]
+    | Mapping[Hashable, Iterable[Hashable]]
+    | None = ...,
     keep_default_na: bool = True,
     na_filter: bool = True,
     verbose: bool = False,
@@ -1013,6 +1032,7 @@ def read_table(
     skipfooter: int = ...,
     nrows: int | None = ...,
     na_values: Sequence[str] | Mapping[str, Sequence[str]] | None = ...,
+    remove_from_default_na: Sequence[str] | Mapping[str, Sequence[str]] | None = ...,
     keep_default_na: bool = ...,
     na_filter: bool = ...,
     verbose: bool = ...,
@@ -1073,6 +1093,7 @@ def read_table(
     skipfooter: int = ...,
     nrows: int | None = ...,
     na_values: Sequence[str] | Mapping[str, Sequence[str]] | None = ...,
+    remove_from_default_na: Sequence[str] | Mapping[str, Sequence[str]] | None = ...,
     keep_default_na: bool = ...,
     na_filter: bool = ...,
     verbose: bool = ...,
@@ -1133,6 +1154,7 @@ def read_table(
     skipfooter: int = ...,
     nrows: int | None = ...,
     na_values: Sequence[str] | Mapping[str, Sequence[str]] | None = ...,
+    remove_from_default_na: Sequence[str] | Mapping[str, Sequence[str]] | None = ...,
     keep_default_na: bool = ...,
     na_filter: bool = ...,
     verbose: bool = ...,
@@ -1193,6 +1215,7 @@ def read_table(
     skipfooter: int = ...,
     nrows: int | None = ...,
     na_values: Sequence[str] | Mapping[str, Sequence[str]] | None = ...,
+    remove_from_default_na: Sequence[str] | Mapping[str, Sequence[str]] | None = ...,
     keep_default_na: bool = ...,
     na_filter: bool = ...,
     verbose: bool = ...,
@@ -1268,6 +1291,7 @@ def read_table(
     nrows: int | None = None,
     # NA and Missing Data Handling
     na_values: Sequence[str] | Mapping[str, Sequence[str]] | None = None,
+    remove_from_default_na: Sequence[str] | Mapping[str, Sequence[str]] | None = ...,
     keep_default_na: bool = True,
     na_filter: bool = True,
     verbose: bool = False,
@@ -1919,6 +1943,8 @@ def TextParser(*args, **kwds) -> TextFileReader:
         not in the header.
     na_values : scalar, str, list-like, or dict, optional
         Additional strings to recognize as NA/NaN.
+    remove_from_default_na : scalar, str, list-like, or dict, optional
+        Strings not to recognize as NA/NaN.
     keep_default_na : bool, default True
     thousands : str, optional
         Thousands separator

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -211,7 +211,7 @@ na_values : Hashable, Iterable of Hashable or dict of {{Hashable : Iterable}}, o
     + fill('", "'.join(sorted(STR_NA_VALUES)), 70, subsequent_indent="    ")
     + """ ".
 
-remove_from_default_na : : Hashable, Iterable of Hashable or dict of {{Hashable : Iterable}}, optional
+remove_from_default_na : Hashable or Iterable of Hashable, optional
     Remvoe values from the default ``NaN`` values when parsing the data.
 
 keep_default_na : bool, default True
@@ -723,7 +723,6 @@ def read_csv(
     | None = ...,
     remove_from_default_na: Hashable
     | Iterable[Hashable]
-    | Mapping[Hashable, Iterable[Hashable]]
     | None = ...,
     keep_default_na: bool = ...,
     na_filter: bool = ...,
@@ -790,7 +789,6 @@ def read_csv(
     | None = ...,
     remove_from_default_na: Hashable
     | Iterable[Hashable]
-    | Mapping[Hashable, Iterable[Hashable]]
     | None = ...,
     keep_default_na: bool = ...,
     na_filter: bool = ...,
@@ -857,7 +855,6 @@ def read_csv(
     | None = ...,
     remove_from_default_na: Hashable
     | Iterable[Hashable]
-    | Mapping[Hashable, Iterable[Hashable]]
     | None = ...,
     keep_default_na: bool = ...,
     na_filter: bool = ...,
@@ -937,7 +934,6 @@ def read_csv(
     | None = None,
     remove_from_default_na: Hashable
     | Iterable[Hashable]
-    | Mapping[Hashable, Iterable[Hashable]]
     | None = ...,
     keep_default_na: bool = True,
     na_filter: bool = True,
@@ -1032,7 +1028,7 @@ def read_table(
     skipfooter: int = ...,
     nrows: int | None = ...,
     na_values: Sequence[str] | Mapping[str, Sequence[str]] | None = ...,
-    remove_from_default_na: Sequence[str] | Mapping[str, Sequence[str]] | None = ...,
+    remove_from_default_na: Sequence[str] | None = ...,
     keep_default_na: bool = ...,
     na_filter: bool = ...,
     verbose: bool = ...,
@@ -1093,7 +1089,7 @@ def read_table(
     skipfooter: int = ...,
     nrows: int | None = ...,
     na_values: Sequence[str] | Mapping[str, Sequence[str]] | None = ...,
-    remove_from_default_na: Sequence[str] | Mapping[str, Sequence[str]] | None = ...,
+    remove_from_default_na: Sequence[str] | None = ...,
     keep_default_na: bool = ...,
     na_filter: bool = ...,
     verbose: bool = ...,
@@ -1154,7 +1150,7 @@ def read_table(
     skipfooter: int = ...,
     nrows: int | None = ...,
     na_values: Sequence[str] | Mapping[str, Sequence[str]] | None = ...,
-    remove_from_default_na: Sequence[str] | Mapping[str, Sequence[str]] | None = ...,
+    remove_from_default_na: Sequence[str] | None = ...,
     keep_default_na: bool = ...,
     na_filter: bool = ...,
     verbose: bool = ...,
@@ -1215,7 +1211,7 @@ def read_table(
     skipfooter: int = ...,
     nrows: int | None = ...,
     na_values: Sequence[str] | Mapping[str, Sequence[str]] | None = ...,
-    remove_from_default_na: Sequence[str] | Mapping[str, Sequence[str]] | None = ...,
+    remove_from_default_na: Sequence[str] | None = ...,
     keep_default_na: bool = ...,
     na_filter: bool = ...,
     verbose: bool = ...,
@@ -1291,7 +1287,7 @@ def read_table(
     nrows: int | None = None,
     # NA and Missing Data Handling
     na_values: Sequence[str] | Mapping[str, Sequence[str]] | None = None,
-    remove_from_default_na: Sequence[str] | Mapping[str, Sequence[str]] | None = ...,
+    remove_from_default_na: Sequence[str] | None = ...,
     keep_default_na: bool = True,
     na_filter: bool = True,
     verbose: bool = False,

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -277,6 +277,26 @@ a,b,c,d
                 }
             ),
         ),
+        (
+            {"remove_from_default_na": ["nan"]},
+            DataFrame(
+                {
+                    "A": ["a", "b", np.nan, "d", "e", "nan", "g"],
+                    "B": [1, 2, 3, 4, 5, 6, 7],
+                    "C": ["one", "two", "three", "nan", "five", np.nan, "seven"],
+                }
+            ),
+        ),
+        (
+            {"na_values" ["nan"], "remove_from_default_na": ["nan"]},
+            DataFrame(
+                {
+                    "A": ["a", "b", np.nan, "d", "e", np.nan, "g"],
+                    "B": [1, 2, 3, 4, 5, 6, 7],
+                    "C": ["one", "two", "three", np.nan, "five", np.nan, "seven"],
+                }
+            ),
+        ),
     ],
 )
 def test_na_values_keep_default(all_parsers, kwargs, expected):

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -288,7 +288,7 @@ a,b,c,d
             ),
         ),
         (
-            {"na_values" ["nan"], "remove_from_default_na": ["nan"]},
+            {"na_values": ["nan"], "remove_from_default_na": ["nan"]},
             DataFrame(
                 {
                     "A": ["a", "b", np.nan, "d", "e", np.nan, "g"],


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

https://github.com/pandas-dev/pandas/issues/52493
As already known, pd.read_csv(io.StringIO("a\nNone")).a[0] is 'None' on pandas 1 but NaN on pandas 2.

Pandas uses NaN to represent missing values, but "None" often means 'No options satisfy the condition' in real data.
Even though this is an unintentional breaking change, this bug is considered to be too late to be fixed now.

I was trying to update libraries we use and bumped into this problem.
So, I suggest to add a parameter 'remove_from_default_na' 

`read_excel(path, remove_from_default_na="None")
`

which is also a straightforward solution to the issue below.
https://github.com/pandas-dev/pandas/issues/19156

Without this parameter, the workaround would be something like

> from pandas._libs.parsers import STR_NA_VALUES
> read_excel(path, na_values=STR_NA_VALUES-set(["None"]), keep_default_na=False)

Thank you for the great library.