### PR TITLE
BUG: df.resample('MS', closed='right') incorrectly places bins

### DIFF
--- a/doc/source/whatsnew/v2.1.1.rst
+++ b/doc/source/whatsnew/v2.1.1.rst
@@ -17,7 +17,6 @@ Fixed regressions
 - Fixed regression in :func:`merge` when merging over a PyArrow string index (:issue:`54894`)
 - Fixed regression in :func:`read_csv` when ``usecols`` is given and ``dtypes`` is a dict for ``engine="python"`` (:issue:`54868`)
 - Fixed regression in :func:`read_csv` when ``delim_whitespace`` is True (:issue:`54918`, :issue:`54931`)
-- Fixed bug in :meth:`DataFrame.resample` where bin edges were not correct for :class:`~pandas.tseries.offsets.MonthBegin` (:issue:`55271`)
 - Fixed regression in :meth:`.GroupBy.get_group` raising for ``axis=1`` (:issue:`54858`)
 - Fixed regression in :meth:`DataFrame.__setitem__` raising ``AssertionError`` when setting a :class:`Series` with a partial :class:`MultiIndex` (:issue:`54875`)
 - Fixed regression in :meth:`DataFrame.filter` not respecting the order of elements for ``filter`` (:issue:`54980`)
@@ -36,8 +35,6 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 - Fixed bug for :class:`ArrowDtype` raising ``NotImplementedError`` for fixed-size list (:issue:`55000`)
-- Fixed bug in :meth:`DataFrame.resample` not respecting ``closed`` and ``label`` arguments for :class:`~pandas.tseries.offsets.BusinessDay` (:issue:`55282`)
-- Fixed bug in :meth:`DataFrame.resample` where bin edges were not correct for :class:`~pandas.tseries.offsets.BusinessDay` (:issue:`55281`)
 - Fixed bug in :meth:`DataFrame.stack` with ``future_stack=True`` and columns a non-:class:`MultiIndex` consisting of tuples (:issue:`54948`)
 - Fixed bug in :meth:`Series.dt.tz` with :class:`ArrowDtype` where a string was returned instead of a ``tzinfo`` object (:issue:`55003`)
 - Fixed bug in :meth:`Series.pct_change` and :meth:`DataFrame.pct_change` showing unnecessary ``FutureWarning`` (:issue:`54981`)

--- a/doc/source/whatsnew/v2.1.1.rst
+++ b/doc/source/whatsnew/v2.1.1.rst
@@ -17,6 +17,7 @@ Fixed regressions
 - Fixed regression in :func:`merge` when merging over a PyArrow string index (:issue:`54894`)
 - Fixed regression in :func:`read_csv` when ``usecols`` is given and ``dtypes`` is a dict for ``engine="python"`` (:issue:`54868`)
 - Fixed regression in :func:`read_csv` when ``delim_whitespace`` is True (:issue:`54918`, :issue:`54931`)
+- Fixed bug in :meth:`DataFrame.resample` where bin edges were not correct for :class:`~pandas.tseries.offsets.MonthBegin` (:issue:`55271`)
 - Fixed regression in :meth:`.GroupBy.get_group` raising for ``axis=1`` (:issue:`54858`)
 - Fixed regression in :meth:`DataFrame.__setitem__` raising ``AssertionError`` when setting a :class:`Series` with a partial :class:`MultiIndex` (:issue:`54875`)
 - Fixed regression in :meth:`DataFrame.filter` not respecting the order of elements for ``filter`` (:issue:`54980`)
@@ -35,6 +36,8 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 - Fixed bug for :class:`ArrowDtype` raising ``NotImplementedError`` for fixed-size list (:issue:`55000`)
+- Fixed bug in :meth:`DataFrame.resample` not respecting ``closed`` and ``label`` arguments for :class:`~pandas.tseries.offsets.BusinessDay` (:issue:`55282`)
+- Fixed bug in :meth:`DataFrame.resample` where bin edges were not correct for :class:`~pandas.tseries.offsets.BusinessDay` (:issue:`55281`)
 - Fixed bug in :meth:`DataFrame.stack` with ``future_stack=True`` and columns a non-:class:`MultiIndex` consisting of tuples (:issue:`54948`)
 - Fixed bug in :meth:`Series.dt.tz` with :class:`ArrowDtype` where a string was returned instead of a ``tzinfo`` object (:issue:`55003`)
 - Fixed bug in :meth:`Series.pct_change` and :meth:`DataFrame.pct_change` showing unnecessary ``FutureWarning`` (:issue:`54981`)

--- a/doc/source/whatsnew/v2.1.2.rst
+++ b/doc/source/whatsnew/v2.1.2.rst
@@ -13,6 +13,7 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
+- Fixed bug in :meth:`DataFrame.resample` where bin edges were not correct for :class:`~pandas.tseries.offsets.MonthBegin` (:issue:`55271`)
 - Fixed bug where PDEP-6 warning about setting an item of an incompatible dtype was being shown when creating a new conditional column (:issue:`55025`)
 -
 
@@ -21,7 +22,8 @@ Fixed regressions
 
 Bug fixes
 ~~~~~~~~~
--
+- Fixed bug in :meth:`DataFrame.resample` not respecting ``closed`` and ``label`` arguments for :class:`~pandas.tseries.offsets.BusinessDay` (:issue:`55282`)
+- Fixed bug in :meth:`DataFrame.resample` where bin edges were not correct for :class:`~pandas.tseries.offsets.BusinessDay` (:issue:`55281`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -2297,7 +2297,17 @@ class TimeGrouper(Grouper):
     ) -> tuple[DatetimeIndex, npt.NDArray[np.int64]]:
         # Some hacks for > daily data, see #1471, #1458, #1483
 
-        if self.freq != "D" and is_superperiod(self.freq, "D"):
+        if self.freq.name in ("BM", "ME", "W") or self.freq.name.split("-")[0] in (
+            "BQ",
+            "BA",
+            "Q",
+            "A",
+            "W",
+        ):
+            # If the right end-point is on the last day of the month, roll forwards
+            # until the last moment of that day. Note that we only do this for offsets
+            # which correspond to the end of a super-daily period - "month start", for
+            # example, is excluded.
             if self.closed == "right":
                 # GH 21459, GH 9119: Adjust the bins relative to the wall time
                 edges_dti = binner.tz_localize(None)

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -2051,3 +2051,66 @@ def test_resample_M_deprecated():
     with tm.assert_produces_warning(UserWarning, match=depr_msg):
         result = s.resample("2M").mean()
     tm.assert_series_equal(result, expected)
+
+
+def test_resample_ms_closed_right():
+    # https://github.com/pandas-dev/pandas/issues/55271
+    dti = date_range(start="2020-01-31", freq="1min", periods=6000)
+    df = DataFrame({"ts": dti}, index=dti)
+    grouped = df.resample("MS", closed="right")
+    result = grouped.last()
+    expected = DataFrame(
+        {"ts": [datetime(2020, 2, 1), datetime(2020, 2, 4, 3, 59)]},
+        index=DatetimeIndex([datetime(2020, 1, 1), datetime(2020, 2, 1)], freq="MS"),
+    )
+    tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("freq", ["B", "C"])
+def test_resample_c_b_closed_right(freq: str):
+    # https://github.com/pandas-dev/pandas/issues/55281
+    dti = date_range(start="2020-01-31", freq="1min", periods=6000)
+    df = DataFrame({"ts": dti}, index=dti)
+    grouped = df.resample(freq, closed="right")
+    result = grouped.last()
+    expected = DataFrame(
+        {
+            "ts": [
+                datetime(2020, 1, 31),
+                datetime(2020, 2, 3),
+                datetime(2020, 2, 4),
+                datetime(2020, 2, 4, 3, 59),
+            ]
+        },
+        index=DatetimeIndex(
+            [
+                datetime(2020, 1, 30),
+                datetime(2020, 1, 31),
+                datetime(2020, 2, 3),
+                datetime(2020, 2, 4),
+            ],
+            freq=freq,
+        ),
+    )
+    tm.assert_frame_equal(result, expected)
+
+
+def test_resample_b_55282():
+    # https://github.com/pandas-dev/pandas/issues/55282
+    s = Series(
+        [1, 2, 3, 4, 5, 6], index=date_range("2023-09-26", periods=6, freq="12H")
+    )
+    result = s.resample("B", closed="right", label="right").mean()
+    expected = Series(
+        [1.0, 2.5, 4.5, 6.0],
+        index=DatetimeIndex(
+            [
+                datetime(2023, 9, 26),
+                datetime(2023, 9, 27),
+                datetime(2023, 9, 28),
+                datetime(2023, 9, 29),
+            ],
+            freq="B",
+        ),
+    )
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -660,7 +660,7 @@ def test_resample_reresample(unit):
     s = Series(np.random.default_rng(2).random(len(dti)), dti)
     bs = s.resample("B", closed="right", label="right").mean()
     result = bs.resample("8H").mean()
-    assert len(result) == 22
+    assert len(result) == 25
     assert isinstance(result.index.freq, offsets.DateOffset)
     assert result.index.freq == offsets.Hour(8)
 


### PR DESCRIPTION
- [x] closes #55271
- [x] closes #55281
- [x] closes #55282
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

~todo: extra tests for 'B' with closed ='right' (linked issue below), whatsnew~

This fixes a regression from 2.1.0 - but, it also happens to fix two older bugs as a side-effect. So, I've put this in the 2.1.2 milestone