### PR TITLE
ExtensionArray.interpolate() method and tests

### DIFF
--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -890,7 +890,6 @@ class ExtensionArray:
         limit,
         limit_direction,
         limit_area,
-        fill_value,
         copy: bool,
         **kwargs,
     ) -> Self:
@@ -904,7 +903,6 @@ class ExtensionArray:
         ...                 limit=3,
         ...                 limit_direction="forward",
         ...                 index=pd.Index([1, 2, 3, 4]),
-        ...                 fill_value=1,
         ...                 copy=False,
         ...                 axis=0,
         ...                 limit_area="inside"

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -912,9 +912,24 @@ class ExtensionArray:
         Length: 4, dtype: float64
         """
         # NB: we return type(self) even if copy=False
-        raise NotImplementedError(
-            f"{type(self).__name__} does not implement interpolate"
+        
+        if not self.dtype._is_numeric or self.dtype._is_boolean:
+            raise TypeError(
+                f"Cannot interpolate {type(self)} dtype as it is non-numeric or boolean"
+            )
+        data = self.to_numpy('float64', copy=copy)
+        missing.interpolate_2d_inplace(
+            data = data, 
+            axis = axis,
+            index = index,
+            method = method,
+            limit = limit,
+            limit_direction = limit_direction,
+            limit_area = limit_area,
+            **kwargs,
         )
+        return self._from_sequence(data, dtype=self.dtype)
+
 
     def _pad_or_backfill(
         self, *, method: FillnaOptions, limit: int | None = None, copy: bool = True

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -704,3 +704,23 @@ class BaseMethodsTests:
     def test_equals_same_data_different_object(self, data):
         # https://github.com/pandas-dev/pandas/issues/34660
         assert pd.Series(data).equals(pd.Series(data))
+
+    @pytest.mark.parametrize("method", ['linear'])
+    def test_interpolate(self, data_for_sorting, method):
+        data = data_for_sorting
+        if not data.dtype._is_numeric or data.dtype._is_boolean:
+            pytest.skip("Interpolate is only valid for numeric non-boolean dtypes")
+
+        ser = pd.Series(data)
+        result = ser.interpolate(method)
+        
+        values = np.array(data, dtype=np.float64)
+        pd.core.missing.interpolate_2d_inplace(
+            data = np.array(values), 
+            axis = 0,
+            index = ser.index,
+            method = method
+        )
+        expected = pd.Series(values, dtype=data.dtype)
+
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/extension/decimal/array.py
+++ b/pandas/tests/extension/decimal/array.py
@@ -70,6 +70,8 @@ class DecimalArray(OpsMixin, ExtensionScalarOpsMixin, ExtensionArray):
     __array_priority__ = 1000
 
     def __init__(self, values, dtype=None, copy=False, context=None) -> None:
+        # Cast float np arrays to obj before converting to Decimal
+        values = np.asarray(values, dtype=object)
         for i, val in enumerate(values):
             if is_float(val) or is_integer(val):
                 if np.isnan(val):
@@ -81,7 +83,6 @@ class DecimalArray(OpsMixin, ExtensionScalarOpsMixin, ExtensionArray):
                     values[i] = DecimalDtype.type(val)  # type: ignore[arg-type]
             elif not isinstance(val, decimal.Decimal):
                 raise TypeError("All values must be of type " + str(decimal.Decimal))
-        values = np.asarray(values, dtype=object)
 
         self._data = values
         # Some aliases for common attribute names to ensure pandas supports


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Adds a default interpolate method for numeric EAs.

Partially fixes #40252 by removing fill_value from interpolate signiture. This doesn't fully close as I haven't implemented interpolate for integers - should interpolating an IntegerArray return a IntegerArray or FloatArray? 

Is this the right way to go about testing interpolate? I couldn't think of a simpler way to go about it.

This works for Series(EA).interpolate(), but falls over for DataFrame(EA).interpolate() as axis=1 is passed. 