### PR TITLE
Bug fix where df.rolling doesn't work with certain datetime64 index t…

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -248,6 +248,7 @@ Performance improvements
 Bug fixes
 ~~~~~~~~~
 - Bug in :class:`AbstractHolidayCalendar` where timezone data was not propagated when computing holiday observances (:issue:`54580`)
+- Bug in :class:`pandas.core.window.Rolling` where df.rolling does not work with 'datetime64[us]', 'datetime64[ms]', and 'datetime64[s]' index types (:issue:`55299`)
 - Bug in :class:`pandas.core.window.Rolling` where duplicate datetimelike indexes are treated as consecutive rather than equal with ``closed='left'`` and ``closed='neither'`` (:issue:`20712`)
 - Bug in :meth:`DataFrame.apply` where passing ``raw=True`` ignored ``args`` passed to the applied function (:issue:`55009`)
 - Bug in :meth:`pandas.read_excel` with a ODS file without cached formatted cell for float values (:issue:`55219`)

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -405,6 +405,8 @@ class BaseWindow(SelectionMixin):
         # TODO: why do we get here with e.g. MultiIndex?
         if needs_i8_conversion(self._on.dtype):
             idx = cast("PeriodIndex | DatetimeIndex | TimedeltaIndex", self._on)
+            if (type(idx) == DatetimeIndex) and (idx.T.unit != "ns"):
+                idx = idx.astype("datetime64[ns]")
             return idx.asi8
         return None
 

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -1950,3 +1950,30 @@ def test_numeric_only_corr_cov_series(kernel, use_arg, numeric_only, dtype):
         op2 = getattr(rolling2, kernel)
         expected = op2(*arg2, numeric_only=numeric_only)
         tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "data_type",
+    [
+        "datetime64[us]",
+        "datetime64[ms]",
+        "datetime64[s]",
+    ],
+)
+def test_rolling_sum_on_dtypes(data_type):
+    # GH 55299
+    index = [
+        "2019-01-03 05:11",
+        "2019-01-03 05:23",
+        "2019-01-03 05:28",
+        "2019-01-03 05:32",
+        "2019-01-03 05:36",
+    ]
+    arr = [True, False, False, True, True]
+
+    df_exp = DataFrame({"arr": arr}, index=to_datetime(index).astype("datetime64[ns]"))
+    df_test = DataFrame({"arr": arr}, index=to_datetime(index).astype(data_type))
+    sum_df_exp = df_exp.rolling("5min").sum()
+    sum_df_test = df_test.rolling("5min").sum()
+
+    assert list(sum_df_test.values) == list(sum_df_exp.values)


### PR DESCRIPTION
- [x] closes #55299
- [x] Tests added and passed.
- [x] All code checks passed.
- [x] Added an entry in bug fixes in the latest `doc/source/whatsnew/v2.2.0.rst` file.

This PR fixes an issue where in `df.rolling`, `rolling._win_freq_i8` is always given in nanoseconds but `rolling._index_array` is given in the unit corresponding to the dtype (e.g. s, ms, us, ns). This causes a problem when the window is calculated if the dtype is not `datetime64[ns]`. This code returns the index array in nanoseconds so it matches with `rolling._win_freq_i8`.