### PR TITLE
BUG: MultiIndex.get_indexer with method not raising for non-monotonic

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -310,7 +310,7 @@ Missing
 
 MultiIndex
 ^^^^^^^^^^
--
+- Bug in :meth:`MultiIndex.get_indexer` not raising ``ValueError`` when ``method`` provided and index is non-monotonic (:issue:`53452`)
 -
 
 I/O

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4011,8 +4011,8 @@ class Index(IndexOpsMixin, PandasObject):
         self, target: Index, method: str_t, limit: int | None = None, tolerance=None
     ) -> npt.NDArray[np.intp]:
         if self._is_multi:
-            # TODO: get_indexer_with_fill docstring says values must be _sorted_
-            #  but that doesn't appear to be enforced
+            if not (self.is_monotonic_increasing or self.is_monotonic_decreasing):
+                raise ValueError("index must be monotonic increasing or decreasing")
             # error: "IndexEngine" has no attribute "get_indexer_with_fill"
             engine = self._engine
             with warnings.catch_warnings():

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -342,6 +342,19 @@ class TestGetIndexer:
         expected = np.array([4, 6, 7], dtype=pad_indexer.dtype)
         tm.assert_almost_equal(expected, pad_indexer)
 
+    @pytest.mark.parametrize("method", ["pad", "ffill", "backfill", "bfill", "nearest"])
+    def test_get_indexer_methods_raise_for_non_monotonic(self, method):
+        # 53452
+        mi = MultiIndex.from_arrays([[0, 4, 2], [0, 4, 2]])
+        if method == "nearest":
+            err = NotImplementedError
+            msg = "not implemented yet for MultiIndex"
+        else:
+            err = ValueError
+            msg = "index must be monotonic increasing or decreasing"
+        with pytest.raises(err, match=msg):
+            mi.get_indexer([(1, 1)], method=method)
+
     def test_get_indexer_three_or_more_levels(self):
         # https://github.com/pandas-dev/pandas/issues/29896
         # tests get_indexer() on MultiIndexes with 3+ levels


### PR DESCRIPTION
- [x] closes #53452
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.2.0.rst` file if fixing a bug or adding a new feature.
