### PR TITLE
DOC: Typo: missing space.

### DIFF
--- a/pandas/io/xml.py
+++ b/pandas/io/xml.py
@@ -88,7 +88,7 @@ class _XMLFrameParser:
         Parse only the attributes at the specified ``xpath``.
 
     names : list
-        Column names for :class:`~pandas.DataFrame`of parsed XML data.
+        Column names for :class:`~pandas.DataFrame` of parsed XML data.
 
     dtype : dict
         Data type for data or columns. E.g. {{'a': np.float64,


### PR DESCRIPTION
Without trailing space the interpreted text is not close. Even if it were we want a space in the documentation.

(Note, if one does not want a space between the closing backtick and the subsequent text one must use backslash-space.