### PR TITLE
BUG: eq not implemented for categorical and arrow backed strings

### DIFF
--- a/doc/source/whatsnew/v2.1.2.rst
+++ b/doc/source/whatsnew/v2.1.2.rst
@@ -24,7 +24,7 @@ Bug fixes
 ~~~~~~~~~
 - Fixed bug in :meth:`DataFrame.resample` not respecting ``closed`` and ``label`` arguments for :class:`~pandas.tseries.offsets.BusinessDay` (:issue:`55282`)
 - Fixed bug in :meth:`DataFrame.resample` where bin edges were not correct for :class:`~pandas.tseries.offsets.BusinessDay` (:issue:`55281`)
--
+- Fixed bug in :meth:`Categorical.equals` if other has arrow backed string dtype (:issue:`TODO`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_212.other:

--- a/doc/source/whatsnew/v2.1.2.rst
+++ b/doc/source/whatsnew/v2.1.2.rst
@@ -24,7 +24,7 @@ Bug fixes
 ~~~~~~~~~
 - Fixed bug in :meth:`DataFrame.resample` not respecting ``closed`` and ``label`` arguments for :class:`~pandas.tseries.offsets.BusinessDay` (:issue:`55282`)
 - Fixed bug in :meth:`DataFrame.resample` where bin edges were not correct for :class:`~pandas.tseries.offsets.BusinessDay` (:issue:`55281`)
-- Fixed bug in :meth:`Categorical.equals` if other has arrow backed string dtype (:issue:`TODO`)
+- Fixed bug in :meth:`Categorical.equals` if other has arrow backed string dtype (:issue:`55364`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_212.other:

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -32,6 +32,7 @@ from pandas.util._validators import validate_fillna_kwargs
 
 from pandas.core.dtypes.cast import can_hold_element
 from pandas.core.dtypes.common import (
+    CategoricalDtype,
     is_array_like,
     is_bool_dtype,
     is_integer,
@@ -627,7 +628,9 @@ class ArrowExtensionArray(
 
     def _cmp_method(self, other, op):
         pc_func = ARROW_CMP_FUNCS[op.__name__]
-        if isinstance(other, (ArrowExtensionArray, np.ndarray, list, BaseMaskedArray)):
+        if isinstance(
+            other, (ArrowExtensionArray, np.ndarray, list, BaseMaskedArray)
+        ) or isinstance(getattr(other, "dtype", None), CategoricalDtype):
             result = pc_func(self._pa_array, self._box_pa(other))
         elif is_scalar(other):
             try:

--- a/pandas/tests/indexes/categorical/test_equals.py
+++ b/pandas/tests/indexes/categorical/test_equals.py
@@ -88,3 +88,9 @@ class TestEquals:
         ci = mi.to_flat_index().astype("category")
 
         assert not ci.equals(mi)
+
+    def test_equals_string_dtype(self, any_string_dtype):
+        # GH#
+        idx = CategoricalIndex(list("abc"), name="B")
+        other = Index(["a", "b", "c"], name="B", dtype=any_string_dtype)
+        assert idx.equals(other)

--- a/pandas/tests/indexes/categorical/test_equals.py
+++ b/pandas/tests/indexes/categorical/test_equals.py
@@ -90,7 +90,7 @@ class TestEquals:
         assert not ci.equals(mi)
 
     def test_equals_string_dtype(self, any_string_dtype):
-        # GH#
+        # GH#55364
         idx = CategoricalIndex(list("abc"), name="B")
         other = Index(["a", "b", "c"], name="B", dtype=any_string_dtype)
         assert idx.equals(other)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
