### PR TITLE
MAINT: Remove `np.int_` and `np.uint`

### DIFF
--- a/doc/source/user_guide/enhancingperf.rst
+++ b/doc/source/user_guide/enhancingperf.rst
@@ -184,7 +184,7 @@ can be improved by passing an ``np.ndarray``.
       ...: cpdef np.ndarray[double] apply_integrate_f(np.ndarray col_a, np.ndarray col_b,
       ...:                                            np.ndarray col_N):
       ...:     assert (col_a.dtype == np.float64
-      ...:             and col_b.dtype == np.float64 and col_N.dtype == np.int_)
+      ...:             and col_b.dtype == np.float64 and col_N.dtype == np.dtype(int))
       ...:     cdef Py_ssize_t i, n = len(col_N)
       ...:     assert (len(col_a) == len(col_b) == n)
       ...:     cdef np.ndarray[double] res = np.empty(n)

--- a/pandas/compat/numpy/__init__.py
+++ b/pandas/compat/numpy/__init__.py
@@ -21,6 +21,21 @@ if _nlv < Version(_min_numpy_ver):
     )
 
 
+np_long: type
+np_ulong: type
+
+if _nlv >= Version("2.0.0.dev0"):
+    try:
+        np_long = np.long  # type: ignore[attr-defined]
+        np_ulong = np.ulong  # type: ignore[attr-defined]
+    except AttributeError:
+        np_long = np.int_
+        np_ulong = np.uint
+else:
+    np_long = np.int_
+    np_ulong = np.uint
+
+
 __all__ = [
     "np",
     "_np_version",

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1641,7 +1641,7 @@ def safe_sort(
         else:
             mask = None
     else:
-        reverse_indexer = np.empty(len(sorter), dtype=np.int_)
+        reverse_indexer = np.empty(len(sorter), dtype=int)
         reverse_indexer.put(sorter, np.arange(len(sorter)))
         # Out of bound indices will be masked with `-1` next, so we
         # may deal with them here without performance loss using `mode='wrap'`

--- a/pandas/tests/arrays/boolean/test_reduction.py
+++ b/pandas/tests/arrays/boolean/test_reduction.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from pandas.compat.numpy import np_long
+
 import pandas as pd
 
 
@@ -51,7 +53,7 @@ def test_reductions_return_types(dropna, data, all_numeric_reductions):
         s = s.dropna()
 
     if op in ("sum", "prod"):
-        assert isinstance(getattr(s, op)(), np.int_)
+        assert isinstance(getattr(s, op)(), np_long)
     elif op == "count":
         # Oddly on the 32 bit build (but not Windows), this is intc (!= intp)
         assert isinstance(getattr(s, op)(), np.integer)

--- a/pandas/tests/dtypes/cast/test_infer_dtype.py
+++ b/pandas/tests/dtypes/cast/test_infer_dtype.py
@@ -170,7 +170,7 @@ def test_infer_dtype_from_scalar(value, expected):
 @pytest.mark.parametrize(
     "arr, expected",
     [
-        ([1], np.int_),
+        ([1], np.dtype(int)),
         (np.array([1], dtype=np.int64), np.int64),
         ([np.nan, 1, ""], np.object_),
         (np.array([[1.0, 2.0]]), np.float64),

--- a/pandas/tests/extension/base/dim2.py
+++ b/pandas/tests/extension/base/dim2.py
@@ -248,7 +248,7 @@ class Dim2CompatTests:
                 return NUMPY_INT_TO_DTYPE[np.dtype(int)]
             else:
                 # i.e. dtype.kind == "u"
-                return NUMPY_INT_TO_DTYPE[np.dtype(np.uint)]
+                return NUMPY_INT_TO_DTYPE[np.dtype("uint")]
 
         if method in ["sum", "prod"]:
             # std and var are not dtype-preserving

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -108,11 +108,11 @@ class TestDataFrameIndexing:
             data["A"] = newcolumndata
 
     def test_setitem_list2(self):
-        df = DataFrame(0, index=range(3), columns=["tt1", "tt2"], dtype=np.int_)
+        df = DataFrame(0, index=range(3), columns=["tt1", "tt2"], dtype=int)
         df.loc[1, ["tt1", "tt2"]] = [1, 2]
 
         result = df.loc[df.index[1], ["tt1", "tt2"]]
-        expected = Series([1, 2], df.columns, dtype=np.int_, name=1)
+        expected = Series([1, 2], df.columns, dtype=int, name=1)
         tm.assert_series_equal(result, expected)
 
         df["tt1"] = df["tt2"] = "0"

--- a/pandas/tests/frame/methods/test_shift.py
+++ b/pandas/tests/frame/methods/test_shift.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from pandas.compat.numpy import np_long
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -471,22 +472,22 @@ class TestDataFrameShift:
         df1 = DataFrame(rng.integers(1000, size=(5, 3), dtype=int))
         df2 = DataFrame(rng.integers(1000, size=(5, 2), dtype=int))
         df3 = pd.concat([df1.iloc[:4, 1:3], df2.iloc[:4, :]], axis=1)
-        result = df3.shift(2, axis=1, fill_value=np.int_(0))
+        result = df3.shift(2, axis=1, fill_value=np_long(0))
         assert len(df3._mgr.blocks) == 2
 
         expected = df3.take([-1, -1, 0, 1], axis=1)
-        expected.iloc[:, :2] = np.int_(0)
+        expected.iloc[:, :2] = np_long(0)
         expected.columns = df3.columns
 
         tm.assert_frame_equal(result, expected)
 
         # Case with periods < 0
         df3 = pd.concat([df1.iloc[:4, 1:3], df2.iloc[:4, :]], axis=1)
-        result = df3.shift(-2, axis=1, fill_value=np.int_(0))
+        result = df3.shift(-2, axis=1, fill_value=np_long(0))
         assert len(df3._mgr.blocks) == 2
 
         expected = df3.take([2, 3, -1, -1], axis=1)
-        expected.iloc[:, -2:] = np.int_(0)
+        expected.iloc[:, -2:] = np_long(0)
         expected.columns = df3.columns
 
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1823,7 +1823,7 @@ class TestDataFrameConstructors:
             DataFrame("a", [1, 2], ["a", "c"], float)
 
     def test_constructor_with_datetimes(self):
-        intname = np.dtype(np.int_).name
+        intname = np.dtype(int).name
         floatname = np.dtype(np.float64).name
         objectname = np.dtype(np.object_).name
 

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -10,6 +10,10 @@ from pandas.compat import (
     IS64,
     is_platform_windows,
 )
+from pandas.compat.numpy import (
+    np_long,
+    np_ulong,
+)
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -1700,11 +1704,11 @@ class TestEmptyDataFrameReductions:
         "opname, dtype, exp_value, exp_dtype",
         [
             ("sum", np.int8, 0, np.int64),
-            ("prod", np.int8, 1, np.int_),
+            ("prod", np.int8, 1, np_long),
             ("sum", np.int64, 0, np.int64),
             ("prod", np.int64, 1, np.int64),
             ("sum", np.uint8, 0, np.uint64),
-            ("prod", np.uint8, 1, np.uint),
+            ("prod", np.uint8, 1, np_ulong),
             ("sum", np.uint64, 0, np.uint64),
             ("prod", np.uint64, 1, np.uint64),
             ("sum", np.float32, 0, np.float32),

--- a/pandas/tests/groupby/aggregate/test_cython.py
+++ b/pandas/tests/groupby/aggregate/test_cython.py
@@ -229,7 +229,7 @@ def test_cython_agg_empty_buckets_nanops(observed):
     # GH-18869 can't call nanops on empty groups, so hardcode expected
     # for these
     df = DataFrame([11, 12, 13], columns=["a"])
-    grps = np.arange(0, 25, 5, dtype=np.int_)
+    grps = np.arange(0, 25, 5, dtype=int)
     # add / sum
     result = df.groupby(pd.cut(df["a"], grps), observed=observed)._cython_agg_general(
         "sum", alt=None, numeric_only=True

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -824,7 +824,7 @@ def test_nlargest_and_smallest_noop(data, groups, dtype, method):
         data = list(reversed(data))
     ser = Series(data, name="a")
     result = getattr(ser.groupby(groups), method)(n=2)
-    expidx = np.array(groups, dtype=np.int_) if isinstance(groups, list) else groups
+    expidx = np.array(groups, dtype=int) if isinstance(groups, list) else groups
     expected = Series(data, index=MultiIndex.from_arrays([expidx, ser.index]), name="a")
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -3004,12 +3004,12 @@ def test_groupby_reduce_period():
 
     res = gb.max()
     expected = ser[-10:]
-    expected.index = Index(range(10), dtype=np.int_)
+    expected.index = Index(range(10), dtype=int)
     tm.assert_series_equal(res, expected)
 
     res = gb.min()
     expected = ser[:10]
-    expected.index = Index(range(10), dtype=np.int_)
+    expected.index = Index(range(10), dtype=int)
     tm.assert_series_equal(res, expected)
 
 

--- a/pandas/tests/groupby/test_min_max.py
+++ b/pandas/tests/groupby/test_min_max.py
@@ -108,7 +108,7 @@ def test_max_inat_not_all_na():
 
     # Note: in converting to float64, the iNaT + 1 maps to iNaT, i.e. is lossy
     expected = Series({1: np.nan, 2: np.nan, 3: iNaT + 1})
-    expected.index = expected.index.astype(np.int_)
+    expected.index = expected.index.astype(int)
     tm.assert_series_equal(result, expected, check_exact=True)
 
 

--- a/pandas/tests/groupby/test_quantile.py
+++ b/pandas/tests/groupby/test_quantile.py
@@ -468,7 +468,7 @@ def test_groupby_quantile_dt64tz_period():
     # Check that we match the group-by-group result
     exp = {i: df.iloc[i::5].quantile(0.5) for i in range(5)}
     expected = DataFrame(exp).T.infer_objects()
-    expected.index = expected.index.astype(np.int_)
+    expected.index = expected.index.astype(int)
 
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/groupby/test_size.py
+++ b/pandas/tests/groupby/test_size.py
@@ -39,7 +39,7 @@ def test_size_axis_1(df, axis_1, by, sort, dropna):
     if sort:
         expected = expected.sort_index()
     if is_integer_dtype(expected.index.dtype) and not any(x is None for x in by):
-        expected.index = expected.index.astype(np.int_)
+        expected.index = expected.index.astype(int)
 
     msg = "DataFrame.groupby with axis=1 is deprecated"
     with tm.assert_produces_warning(FutureWarning, match=msg):

--- a/pandas/tests/groupby/test_value_counts.py
+++ b/pandas/tests/groupby/test_value_counts.py
@@ -996,7 +996,7 @@ def test_mixed_groupings(normalize, expected_label, expected_values):
     result = gp.value_counts(sort=True, normalize=normalize)
     expected = DataFrame(
         {
-            "level_0": np.array([4, 4, 5], dtype=np.int_),
+            "level_0": np.array([4, 4, 5], dtype=int),
             "A": [1, 1, 2],
             "level_2": [8, 8, 7],
             "B": [1, 3, 2],

--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -4,6 +4,8 @@ import dateutil
 import numpy as np
 import pytest
 
+from pandas.compat.numpy import np_long
+
 import pandas as pd
 from pandas import (
     DataFrame,
@@ -54,7 +56,7 @@ class TestDatetimeIndex:
         # (which has value 1e9) and since the max value for np.int32 is ~2e9,
         # and since those machines won't promote np.int32 to np.int64, we get
         # overflow.
-        periods = np.int_(1000)
+        periods = np_long(1000)
 
         idx1 = date_range(start="2000", periods=periods, freq="s")
         assert len(idx1) == periods

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -8,6 +8,8 @@ from datetime import (
 import numpy as np
 import pytest
 
+from pandas.compat.numpy import np_long
+
 import pandas as pd
 from pandas import (
     DatetimeIndex,
@@ -91,7 +93,7 @@ class TestGetItem:
         assert fancy_indexed.freq is None
 
         # 32-bit vs. 64-bit platforms
-        assert rng[4] == rng[np.int_(4)]
+        assert rng[4] == rng[np_long(4)]
 
     @pytest.mark.parametrize("freq", ["B", "C"])
     def test_dti_business_getitem_matplotlib_hackaround(self, freq):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -457,7 +457,7 @@ class TestIndex:
         ["string", "int64", "int32", "uint64", "uint32", "float64", "float32"],
         indirect=True,
     )
-    @pytest.mark.parametrize("dtype", [np.int_, np.bool_])
+    @pytest.mark.parametrize("dtype", [int, np.bool_])
     def test_empty_fancy(self, index, dtype):
         empty_arr = np.array([], dtype=dtype)
         empty_index = type(index)([], dtype=index.dtype)

--- a/pandas/tests/indexing/multiindex/test_partial.py
+++ b/pandas/tests/indexing/multiindex/test_partial.py
@@ -166,7 +166,7 @@ class TestMultiIndexPartial:
         mi = ser.index
         assert isinstance(mi, MultiIndex)
         if dtype is int:
-            assert mi.levels[0].dtype == np.int_
+            assert mi.levels[0].dtype == np.dtype(int)
         else:
             assert mi.levels[0].dtype == np.float64
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -442,7 +442,7 @@ class TestLocBaseIndependent:
         )
 
         msg = (
-            rf"\"None of \[Index\(\[1, 2\], dtype='{np.int_().dtype}'\)\] are "
+            rf"\"None of \[Index\(\[1, 2\], dtype='{np.dtype(int)}'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -460,7 +460,7 @@ class TestLocBaseIndependent:
             s.loc[-1]
 
         msg = (
-            rf"\"None of \[Index\(\[-1, -2\], dtype='{np.int_().dtype}'\)\] are "
+            rf"\"None of \[Index\(\[-1, -2\], dtype='{np.dtype(int)}'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -476,7 +476,7 @@ class TestLocBaseIndependent:
 
         s["a"] = 2
         msg = (
-            rf"\"None of \[Index\(\[-2\], dtype='{np.int_().dtype}'\)\] are "
+            rf"\"None of \[Index\(\[-2\], dtype='{np.dtype(int)}'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -493,7 +493,7 @@ class TestLocBaseIndependent:
         df = DataFrame([["a"], ["b"]], index=[1, 2], columns=["value"])
 
         msg = (
-            rf"\"None of \[Index\(\[3\], dtype='{np.int_().dtype}'\)\] are "
+            rf"\"None of \[Index\(\[3\], dtype='{np.dtype(int)}'\)\] are "
             r"in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -510,7 +510,7 @@ class TestLocBaseIndependent:
 
         s.loc[[2]]
 
-        msg = f"\"None of [Index([3], dtype='{np.int_().dtype}')] are in the [index]"
+        msg = f"\"None of [Index([3], dtype='{np.dtype(int)}')] are in the [index]"
         with pytest.raises(KeyError, match=re.escape(msg)):
             s.loc[[3]]
 
@@ -1209,7 +1209,7 @@ class TestLocBaseIndependent:
         df = DataFrame(columns=["x", "y"])
         df.index = df.index.astype(np.int64)
         msg = (
-            rf"None of \[Index\(\[0, 1\], dtype='{np.int_().dtype}'\)\] "
+            rf"None of \[Index\(\[0, 1\], dtype='{np.dtype(int)}'\)\] "
             r"are in the \[index\]"
         )
         with pytest.raises(KeyError, match=msg):

--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -402,7 +402,7 @@ class TestPartialSetting:
 
         # raises as nothing is in the index
         msg = (
-            rf"\"None of \[Index\(\[3, 3, 3\], dtype='{np.int_().dtype}'\)\] "
+            rf"\"None of \[Index\(\[3, 3, 3\], dtype='{np.dtype(int)}'\)\] "
             r"are in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):
@@ -483,7 +483,7 @@ class TestPartialSetting:
 
         # raises as nothing is in the index
         msg = (
-            rf"\"None of \[Index\(\[3, 3, 3\], dtype='{np.int_().dtype}', "
+            rf"\"None of \[Index\(\[3, 3, 3\], dtype='{np.dtype(int)}', "
             r"name='idx'\)\] are in the \[index\]\""
         )
         with pytest.raises(KeyError, match=msg):

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -468,7 +468,7 @@ class TestBlockManager:
             np.random.default_rng(2).standard_normal(N).astype(int),
         )
         idx = mgr2.items.get_loc("quux")
-        assert mgr2.iget(idx).dtype == np.int_
+        assert mgr2.iget(idx).dtype == np.dtype(int)
 
         mgr2.iset(
             mgr2.items.get_loc("quux"), np.random.default_rng(2).standard_normal(N)

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -47,7 +47,7 @@ def test_read_csv_with_custom_date_parser(all_parsers):
     # GH36111
     def __custom_date_parser(time):
         time = time.astype(np.float64)
-        time = time.astype(np.int_)  # convert float seconds to int type
+        time = time.astype(int)  # convert float seconds to int type
         return pd.to_timedelta(time, unit="s")
 
     testdata = StringIO(
@@ -87,7 +87,7 @@ def test_read_csv_with_custom_date_parser_parse_dates_false(all_parsers):
     # GH44366
     def __custom_date_parser(time):
         time = time.astype(np.float64)
-        time = time.astype(np.int_)  # convert float seconds to int type
+        time = time.astype(int)  # convert float seconds to int type
         return pd.to_timedelta(time, unit="s")
 
     testdata = StringIO(

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -6,7 +6,10 @@ import numpy as np
 import pytest
 
 from pandas.compat import is_platform_linux
-from pandas.compat.numpy import np_version_gte1p24
+from pandas.compat.numpy import (
+    np_long,
+    np_version_gte1p24,
+)
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -561,7 +564,7 @@ class TestSeriesPlots:
         [
             ["scott", 20],
             [None, 20],
-            [None, np.int_(20)],
+            [None, np_long(20)],
             [0.5, np.linspace(-100, 100, 20)],
         ],
     )

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -365,7 +365,7 @@ class TestMerge:
         lkey = np.array([1])
         rkey = np.array([2])
         df = merge(df1, df2, left_on=lkey, right_on=rkey, how="outer")
-        assert df["key_0"].dtype == np.int_
+        assert df["key_0"].dtype == np.dtype(int)
 
     def test_handle_join_key_pass_array(self):
         left = DataFrame(
@@ -389,7 +389,7 @@ class TestMerge:
         rkey = np.array([1, 1, 2, 3, 4, 5])
 
         merged = merge(left, right, left_on=lkey, right_on=rkey, how="outer")
-        expected = Series([1, 1, 1, 1, 2, 2, 3, 4, 5], dtype=np.int_, name="key_0")
+        expected = Series([1, 1, 1, 1, 2, 2, 3, 4, 5], dtype=int, name="key_0")
         tm.assert_series_equal(merged["key_0"], expected)
 
         left = DataFrame({"value": np.arange(3)})

--- a/pandas/tests/scalar/test_na_scalar.py
+++ b/pandas/tests/scalar/test_na_scalar.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.missing import NA
+from pandas.compat.numpy import np_long
 
 from pandas.core.dtypes.common import is_scalar
 
@@ -102,9 +103,9 @@ def test_comparison_ops(comparison_op, other):
         -0.0,
         False,
         np.bool_(False),
-        np.int_(0),
+        np_long(0),
         np.float64(0),
-        np.int_(-0),
+        np_long(-0),
         np.float64(-0),
     ],
 )
@@ -123,7 +124,7 @@ def test_pow_special(value, asarray):
 
 
 @pytest.mark.parametrize(
-    "value", [1, 1.0, True, np.bool_(True), np.int_(1), np.float64(1)]
+    "value", [1, 1.0, True, np.bool_(True), np_long(1), np.float64(1)]
 )
 @pytest.mark.parametrize("asarray", [True, False])
 def test_rpow_special(value, asarray):
@@ -133,14 +134,14 @@ def test_rpow_special(value, asarray):
 
     if asarray:
         result = result[0]
-    elif not isinstance(value, (np.float64, np.bool_, np.int_)):
+    elif not isinstance(value, (np.float64, np.bool_, np_long)):
         # this assertion isn't possible with asarray=True
         assert isinstance(result, type(value))
 
     assert result == value
 
 
-@pytest.mark.parametrize("value", [-1, -1.0, np.int_(-1), np.float64(-1)])
+@pytest.mark.parametrize("value", [-1, -1.0, np_long(-1), np.float64(-1)])
 @pytest.mark.parametrize("asarray", [True, False])
 def test_rpow_minus_one(value, asarray):
     if asarray:

--- a/pandas/tests/series/methods/test_reindex.py
+++ b/pandas/tests/series/methods/test_reindex.py
@@ -197,7 +197,7 @@ def test_reindex_int(datetime_series):
 
     # NO NaNs introduced
     reindexed_int = int_ts.reindex(int_ts.index[::2])
-    assert reindexed_int.dtype == np.int_
+    assert reindexed_int.dtype == np.dtype(int)
 
 
 def test_reindex_bool(datetime_series):

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -348,7 +348,7 @@ Categories (3, int64): [1, 2, 3]"""
 8    8
 9    9
 dtype: category
-Categories (10, {np.int_().dtype}): [0, 1, 2, 3, ..., 6, 7, 8, 9]"""
+Categories (10, {np.dtype(int)}): [0, 1, 2, 3, ..., 6, 7, 8, 9]"""
 
         assert repr(s) == exp
 
@@ -374,7 +374,7 @@ Categories (3, int64): [1 < 2 < 3]"""
 8    8
 9    9
 dtype: category
-Categories (10, {np.int_().dtype}): [0 < 1 < 2 < 3 ... 6 < 7 < 8 < 9]"""
+Categories (10, {np.dtype(int)}): [0 < 1 < 2 < 3 ... 6 < 7 < 8 < 9]"""
 
         assert repr(s) == exp
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -505,6 +505,8 @@ filterwarnings = [
   "ignore:distutils Version classes are deprecated:DeprecationWarning:numexpr",
   "ignore:distutils Version classes are deprecated:DeprecationWarning:fastparquet",
   "ignore:distutils Version classes are deprecated:DeprecationWarning:fsspec",
+  # Can be removed once https://github.com/numpy/numpy/pull/24794 is merged
+  "ignore:.*In the future `np.long` will be defined as.*:FutureWarning",
 ]
 junit_family = "xunit2"
 markers = [


### PR DESCRIPTION
Hi!
This PR addresses changes that will be shipped in https://github.com/numpy/numpy/pull/24794 - deprecation of `np.int_` and `np.uint`. An explanation of changes:

- In places where `np.int_(value)` was used I replaced it with backward compatible `np_long(value)`.
- If dtypes were directly compared I replaced `np.int_` with `np.dtype(int)` (they are equivalent).
- For `dtype=` arguments I used `int` for conciseness.
