### PR TITLE
MAINT: Add warning filter for `np.long`

### DIFF
--- a/pandas/compat/numpy/__init__.py
+++ b/pandas/compat/numpy/__init__.py
@@ -1,4 +1,6 @@
 """ support numpy compatibility across versions """
+import warnings
+
 import numpy as np
 
 from pandas.util.version import Version
@@ -26,8 +28,14 @@ np_ulong: type
 
 if _nlv >= Version("2.0.0.dev0"):
     try:
-        np_long = np.long  # type: ignore[attr-defined]
-        np_ulong = np.ulong  # type: ignore[attr-defined]
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                r".*In the future `np\.long` will be defined as.*",
+                FutureWarning,
+            )
+            np_long = np.long  # type: ignore[attr-defined]
+            np_ulong = np.ulong  # type: ignore[attr-defined]
     except AttributeError:
         np_long = np.int_
         np_ulong = np.uint


### PR DESCRIPTION
Hi!
This is a one-line follow-up PR after https://github.com/pandas-dev/pandas/pull/55369.
Downstream libs that use nightly pandas and numpy will see a warning without it (there was a similar fix for scipy: https://github.com/scipy/scipy/pull/19341). 