### PR TITLE
DOC: Remove outdated docs about NumPy's broadcasting

### DIFF
--- a/doc/source/user_guide/basics.rst
+++ b/doc/source/user_guide/basics.rst
@@ -408,20 +408,6 @@ raise a ValueError:
 
     pd.Series(['foo', 'bar', 'baz']) == pd.Series(['foo'])
 
-Note that this is different from the NumPy behavior where a comparison can
-be broadcast:
-
-.. ipython:: python
-
-    np.array([1, 2, 3]) == np.array([2])
-
-or it can return False if broadcasting can not be done:
-
-.. ipython:: python
-   :okwarning:
-
-    np.array([1, 2, 3]) == np.array([1, 2])
-
 Combining overlapping data sets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
NumPy v1.25.0 removes the previosuly deprecated behavior of returning `False` when an array could not be broadcast. It now raises a `ValueError`, same as Pandas. https://github.com/numpy/numpy/pull/22707
The Pandas documentation previously highlighted this discrepancy. However, since it now throws an error, it is causing building the documentation to fail.

I removed the mention of NumPy in this section since the behavior is mostly the same (NumPy still treats an array of one item as a scalar, while Pandas doesn't). Would it be preferable to mention that they act the same now?