### PR TITLE
Doc: add DataFrame.index.levels

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -1725,7 +1725,7 @@ When a large data frame has a multiIndex on its row, you can use the ``index.get
 
 The level does not change after slicing because the slicing method only updates the code at slicing time, not the level.
 
-.. ipython:: python
+   .. code-block:: python
    
    Index([u'John', u'Josh'], dtype='object')
    Index([u'Alex', u'John', u'Josh'], dtype='object')

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -1725,7 +1725,7 @@ When a large data frame has a multiIndex on its row, you can use the ``index.get
 
 The level does not change after slicing because the slicing method only updates the code at slicing time, not the level.
 
-   .. code-block:: python
+.. code-block:: python
    
    Index([u'John', u'Josh'], dtype='object')
    Index([u'Alex', u'John', u'Josh'], dtype='object')

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -1719,14 +1719,13 @@ When a large data frame has a multiIndex on its row, you can use the ``index.get
                         index=idx,
                         columns=['one', 'two'])
    small = large.loc[['Jo'==d[0:2] for d in large.index.get_level_values('Person')]]
-
    small.index.levels[0]
    large.index.levels[0]
 
 The level does not change after slicing because the slicing method only updates the code at slicing time, not the level.
 
 .. code-block:: python
-   
+
    Index([u'John', u'Josh'], dtype='object')
    Index([u'Alex', u'John', u'Josh'], dtype='object')
 

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -1704,6 +1704,32 @@ You can assign a custom index to the ``index`` attribute:
    df_idx.index = pd.Index([10, 20, 30, 40], name="a")
    df_idx
 
+.. _index-sliced-dataframe:
+
+Index of the sliced data frame
+------------------------------
+
+When a large data frame has a multiIndex on its row, you can use the ``index.get_level_values()`` operation to reduce the data frame.
+
+.. ipython:: python
+
+   idx = pd.MultiIndex.from_product([['John', 'Josh', 'Alex'], list('abcde')],
+                                    names=['Person', 'Letter'])
+   large = pd.DataFrame(data=np.random.randn(15, 2),
+                        index=idx,
+                        columns=['one', 'two'])
+   small = large.loc[['Jo'==d[0:2] for d in large.index.get_level_values('Person')]]
+
+   small.index.levels[0]
+   large.index.levels[0]
+
+The level does not change after slicing because the slicing method only updates the code at slicing time, not the level.
+
+.. ipython:: python
+   
+   Index([u'John', u'Josh'], dtype='object')
+   Index([u'Alex', u'John', u'Josh'], dtype='object')
+
 .. _indexing.view_versus_copy:
 
 Returning a view versus a copy


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc\source\user_guide\indexing.rst` file  adding a new feature.

> solved problem

BUG: MultiIndex.levels[x] of sliced DataFrame returns values from the non-sliced index #55148
[https://github.com/pandas-dev/pandas/issues/55148](url)

> Description:

Adding DataFrame.index.levels to doc will show the original value after reducing the data frame reason: pandas only updates the code at slicing time, not the level.

> Add content details

![屏幕截图 2023-10-07 125621(1)](https://github.com/pandas-dev/pandas/assets/143710553/6088db73-5573-4e38-b44f-d69273d61142)
