### PR TITLE
TST: fix file left behind

### DIFF
--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -303,8 +303,10 @@ def test_store_dropna(tmp_path, setup_path):
     tm.assert_frame_equal(df_without_missing, reloaded)
 
 
-def test_keyword_deprecation():
+def test_keyword_deprecation(tmp_path, setup_path):
     # GH 54229
+    path = tmp_path / setup_path
+
     msg = (
         "Starting with pandas version 3.0 all arguments of to_hdf except for the "
         "argument 'path_or_buf' will be keyword-only."
@@ -312,7 +314,7 @@ def test_keyword_deprecation():
     df = DataFrame([{"A": 1, "B": 2, "C": 3}, {"A": 1, "B": 2, "C": 3}])
 
     with tm.assert_produces_warning(FutureWarning, match=msg):
-        df.to_hdf("example", "key")
+        df.to_hdf(path, "key")
 
 
 def test_to_hdf_with_min_itemsize(tmp_path, setup_path):


### PR DESCRIPTION
ATM local test runs are leaving an "example" file behind.  This fixes that.