### PR TITLE
Update get_utc declarations

### DIFF
--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -466,7 +466,7 @@ cdef str _render_tstamp(int64_t val, NPY_DATETIMEUNIT creso):
 
 
 cdef _get_utc_bounds(
-    const int64_t[:] vals,
+    ndarray[int64_t] vals,
     const int64_t* tdata,
     Py_ssize_t ntrans,
     const int64_t[::1] deltas,

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -425,7 +425,11 @@ timedelta-like}
     return result.base  # .base to get underlying ndarray
 
 
-cdef Py_ssize_t bisect_right_i8(int64_t *data, int64_t val, Py_ssize_t n):
+cdef Py_ssize_t bisect_right_i8(
+    const int64_t *data,
+    int64_t val,
+    Py_ssize_t n
+) noexcept:
     # Caller is responsible for checking n > 0
     # This looks very similar to local_search_right in the ndarray.searchsorted
     #  implementation.
@@ -462,8 +466,8 @@ cdef str _render_tstamp(int64_t val, NPY_DATETIMEUNIT creso):
 
 
 cdef _get_utc_bounds(
-    ndarray[int64_t] vals,
-    int64_t* tdata,
+    const int64_t[:] vals,
+    const int64_t* tdata,
     Py_ssize_t ntrans,
     const int64_t[::1] deltas,
     NPY_DATETIMEUNIT creso,


### PR DESCRIPTION
This helps a bit with the Cython 3.0 performance; the regression here is that without noexcept Cython checks for an error each invocation of bisect_right_i8

The const qualifiers are not necessarily required, but are a nice safety add-on and only give the compiler a better chance to optimize
