### PR TITLE
TST: Fix assert_is_sorted for eas

### DIFF
--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -440,7 +440,10 @@ def assert_is_sorted(seq) -> None:
     if isinstance(seq, (Index, Series)):
         seq = seq.values
     # sorting does not change precisions
-    assert_numpy_array_equal(seq, np.sort(np.array(seq)))
+    if isinstance(seq, np.ndarray):
+        assert_numpy_array_equal(seq, np.sort(np.array(seq)))
+    else:
+        assert_extension_array_equal(seq, seq[seq.argsort()])
 
 
 def assert_categorical_equal(

--- a/pandas/tests/util/test_util.py
+++ b/pandas/tests/util/test_util.py
@@ -2,7 +2,10 @@ import os
 
 import pytest
 
-from pandas import compat
+from pandas import (
+    array,
+    compat,
+)
 import pandas._testing as tm
 
 
@@ -44,3 +47,12 @@ def test_datapath(datapath):
 def test_external_error_raised():
     with tm.external_error_raised(TypeError):
         raise TypeError("Should not check this error message, so it will pass")
+
+
+def test_is_sorted():
+    arr = array([1, 2, 3], dtype="Int64")
+    tm.assert_is_sorted(arr)
+
+    arr = array([4, 2, 3], dtype="Int64")
+    with pytest.raises(AssertionError, match="ExtensionArray are different"):
+        tm.assert_is_sorted(arr)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
