### PR TITLE
MAINT: Partially revert `np.int_` changes

### DIFF
--- a/pandas/tests/arrays/boolean/test_reduction.py
+++ b/pandas/tests/arrays/boolean/test_reduction.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat.numpy import np_long
-
 import pandas as pd
 
 
@@ -53,7 +51,7 @@ def test_reductions_return_types(dropna, data, all_numeric_reductions):
         s = s.dropna()
 
     if op in ("sum", "prod"):
-        assert isinstance(getattr(s, op)(), np_long)
+        assert isinstance(getattr(s, op)(), np.int_)
     elif op == "count":
         # Oddly on the 32 bit build (but not Windows), this is intc (!= intp)
         assert isinstance(getattr(s, op)(), np.integer)

--- a/pandas/tests/frame/methods/test_shift.py
+++ b/pandas/tests/frame/methods/test_shift.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat.numpy import np_long
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -472,22 +471,22 @@ class TestDataFrameShift:
         df1 = DataFrame(rng.integers(1000, size=(5, 3), dtype=int))
         df2 = DataFrame(rng.integers(1000, size=(5, 2), dtype=int))
         df3 = pd.concat([df1.iloc[:4, 1:3], df2.iloc[:4, :]], axis=1)
-        result = df3.shift(2, axis=1, fill_value=np_long(0))
+        result = df3.shift(2, axis=1, fill_value=np.int_(0))
         assert len(df3._mgr.blocks) == 2
 
         expected = df3.take([-1, -1, 0, 1], axis=1)
-        expected.iloc[:, :2] = np_long(0)
+        expected.iloc[:, :2] = np.int_(0)
         expected.columns = df3.columns
 
         tm.assert_frame_equal(result, expected)
 
         # Case with periods < 0
         df3 = pd.concat([df1.iloc[:4, 1:3], df2.iloc[:4, :]], axis=1)
-        result = df3.shift(-2, axis=1, fill_value=np_long(0))
+        result = df3.shift(-2, axis=1, fill_value=np.int_(0))
         assert len(df3._mgr.blocks) == 2
 
         expected = df3.take([2, 3, -1, -1], axis=1)
-        expected.iloc[:, -2:] = np_long(0)
+        expected.iloc[:, -2:] = np.int_(0)
         expected.columns = df3.columns
 
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -10,10 +10,6 @@ from pandas.compat import (
     IS64,
     is_platform_windows,
 )
-from pandas.compat.numpy import (
-    np_long,
-    np_ulong,
-)
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -1726,11 +1722,11 @@ class TestEmptyDataFrameReductions:
         "opname, dtype, exp_value, exp_dtype",
         [
             ("sum", np.int8, 0, np.int64),
-            ("prod", np.int8, 1, np_long),
+            ("prod", np.int8, 1, np.int_),
             ("sum", np.int64, 0, np.int64),
             ("prod", np.int64, 1, np.int64),
             ("sum", np.uint8, 0, np.uint64),
-            ("prod", np.uint8, 1, np_ulong),
+            ("prod", np.uint8, 1, np.uint),
             ("sum", np.uint64, 0, np.uint64),
             ("prod", np.uint64, 1, np.uint64),
             ("sum", np.float32, 0, np.float32),

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -6,10 +6,7 @@ import numpy as np
 import pytest
 
 from pandas.compat import is_platform_linux
-from pandas.compat.numpy import (
-    np_long,
-    np_version_gte1p24,
-)
+from pandas.compat.numpy import np_version_gte1p24
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -564,7 +561,7 @@ class TestSeriesPlots:
         [
             ["scott", 20],
             [None, 20],
-            [None, np_long(20)],
+            [None, np.int_(20)],
             [0.5, np.linspace(-100, 100, 20)],
         ],
     )

--- a/pandas/tests/scalar/test_na_scalar.py
+++ b/pandas/tests/scalar/test_na_scalar.py
@@ -9,7 +9,6 @@ import numpy as np
 import pytest
 
 from pandas._libs.missing import NA
-from pandas.compat.numpy import np_long
 
 from pandas.core.dtypes.common import is_scalar
 
@@ -103,9 +102,9 @@ def test_comparison_ops(comparison_op, other):
         -0.0,
         False,
         np.bool_(False),
-        np_long(0),
+        np.int_(0),
         np.float64(0),
-        np_long(-0),
+        np.int_(-0),
         np.float64(-0),
     ],
 )
@@ -124,7 +123,7 @@ def test_pow_special(value, asarray):
 
 
 @pytest.mark.parametrize(
-    "value", [1, 1.0, True, np.bool_(True), np_long(1), np.float64(1)]
+    "value", [1, 1.0, True, np.bool_(True), np.int_(1), np.float64(1)]
 )
 @pytest.mark.parametrize("asarray", [True, False])
 def test_rpow_special(value, asarray):
@@ -134,14 +133,14 @@ def test_rpow_special(value, asarray):
 
     if asarray:
         result = result[0]
-    elif not isinstance(value, (np.float64, np.bool_, np_long)):
+    elif not isinstance(value, (np.float64, np.bool_, np.int_)):
         # this assertion isn't possible with asarray=True
         assert isinstance(result, type(value))
 
     assert result == value
 
 
-@pytest.mark.parametrize("value", [-1, -1.0, np_long(-1), np.float64(-1)])
+@pytest.mark.parametrize("value", [-1, -1.0, np.int_(-1), np.float64(-1)])
 @pytest.mark.parametrize("asarray", [True, False])
 def test_rpow_minus_one(value, asarray):
     if asarray:


### PR DESCRIPTION
Hi!

This PR reverts some changes introduced in https://github.com/pandas-dev/pandas/pull/55369 that, after discussions, are outdated (`np.long` should be used in places that specifically refer to the C type, rather than just "default integer").
