### PR TITLE
BUG: Don't clean docs and open browser in code_checks

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -176,9 +176,8 @@ fi
 
 ### SINGLE-PAGE DOCS ###
 if [[ -z "$CHECK" || "$CHECK" == "single-docs" ]]; then
-    python doc/make.py --warnings-are-errors --single pandas.Series.value_counts
-    python doc/make.py --warnings-are-errors --single pandas.Series.str.split
-    python doc/make.py clean
+    python doc/make.py --warnings-are-errors --no-browser --single pandas.Series.value_counts
+    python doc/make.py --warnings-are-errors --no-browser --single pandas.Series.str.split
 fi
 
 exit $RET

--- a/doc/make.py
+++ b/doc/make.py
@@ -45,12 +45,14 @@ class DocBuilder:
         single_doc=None,
         verbosity=0,
         warnings_are_errors=False,
+        no_browser=False,
     ) -> None:
         self.num_jobs = num_jobs
         self.include_api = include_api
         self.whatsnew = whatsnew
         self.verbosity = verbosity
         self.warnings_are_errors = warnings_are_errors
+        self.no_browser = no_browser
 
         if single_doc:
             single_doc = self._process_single_doc(single_doc)
@@ -234,11 +236,11 @@ class DocBuilder:
             os.remove(zip_fname)
 
         if ret_code == 0:
-            if self.single_doc_html is not None:
+            if self.single_doc_html is not None and not self.no_browser:
                 self._open_browser(self.single_doc_html)
             else:
                 self._add_redirects()
-                if self.whatsnew:
+                if self.whatsnew and not self.no_browser:
                     self._open_browser(os.path.join("whatsnew", "index.html"))
 
         return ret_code
@@ -349,6 +351,9 @@ def main():
         action="store_true",
         help="fail if warnings are raised",
     )
+    argparser.add_argument(
+        "--no-browser", help="Don't open browser", action="store_true"
+    )
     args = argparser.parse_args()
 
     if args.command not in cmds:
@@ -374,6 +379,7 @@ def main():
         args.single,
         args.verbosity,
         args.warnings_are_errors,
+        args.no_browser,
     )
     return getattr(builder, args.command)()
 

--- a/doc/make.py
+++ b/doc/make.py
@@ -352,7 +352,10 @@ def main():
         help="fail if warnings are raised",
     )
     argparser.add_argument(
-        "--no-browser", help="Don't open browser", action="store_true"
+        "--no-browser",
+        help="Don't open browser",
+        default=False,
+        action="store_true",
     )
     args = argparser.parse_args()
 


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Ref: https://github.com/pandas-dev/pandas/pull/46806#issuecomment-1152922326

In regards to not cleaning the docs at the end, when I'm wrapping up a PR, I'm typically building documentation and running code_checks. Right now these are at odds with each other since the docs are cleared in code_checks. Can remove if there is opposition to this change.