### PR TITLE
TST: Test patching over fake instead of real method in accessor test

### DIFF
--- a/pandas/tests/test_register_accessor.py
+++ b/pandas/tests/test_register_accessor.py
@@ -82,19 +82,13 @@ def test_accessor_works():
 
 
 def test_overwrite_warns():
-    # Need to restore mean
-    mean = pd.Series.mean
-    try:
-        with tm.assert_produces_warning(UserWarning) as w:
-            pd.api.extensions.register_series_accessor("mean")(MyAccessor)
+    match = r".*MyAccessor.*fake.*Series.*"
+    with tm.assert_produces_warning(UserWarning, match=match):
+        with ensure_removed(pd.Series, "fake"):
+            setattr(pd.Series, "fake", 123)
+            pd.api.extensions.register_series_accessor("fake")(MyAccessor)
             s = pd.Series([1, 2])
-            assert s.mean.prop == "item"
-        msg = str(w[0].message)
-        assert "mean" in msg
-        assert "MyAccessor" in msg
-        assert "Series" in msg
-    finally:
-        pd.Series.mean = mean
+            assert s.fake.prop == "item"
 
 
 def test_raises_attribute_error():


### PR DESCRIPTION
Ran into a scenario where `Series.mean` was patched while running tests in parallel and `Series.mean` therefore was not behaving correctly