### PR TITLE
BENCH: Add decorator to parameterize benchmarks for copy on write

### DIFF
--- a/asv_bench/benchmarks/algorithms.py
+++ b/asv_bench/benchmarks/algorithms.py
@@ -5,7 +5,10 @@ import pyarrow as pa
 
 import pandas as pd
 
-from .pandas_vb_common import tm
+from .pandas_vb_common import (
+    CowDecorator,
+    tm,
+)
 
 for imp in ["pandas.util", "pandas.tools.hashing"]:
     try:
@@ -15,6 +18,7 @@ for imp in ["pandas.util", "pandas.tools.hashing"]:
         pass
 
 
+@CowDecorator()
 class Factorize:
     params = [
         [True, False],

--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -14,7 +14,10 @@ from pandas import (
     timedelta_range,
 )
 
-from .pandas_vb_common import tm
+from .pandas_vb_common import (
+    CowDecorator,
+    tm,
+)
 
 
 class AsType:
@@ -111,6 +114,7 @@ class Reindex:
         self.df2.reindex(np.random.permutation(range(1200)))
 
 
+@CowDecorator()
 class Rename:
     def setup(self):
         N = 10**3


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This is a POC for benchmarking copy on write. I wanted to get more feedback before moving forward

The idea here was to make a decorator to detect methods starting with ``time`` or ``peakmem`` and modify those methods to run with copy on write enabled or disabled.

I chose this method since it should be minimally invasive in terms of code changes - otherwise we would need to wrap every single method in a context manager by hand, and add the copy on write parameters to every single class by hand.

This would also cause problems when Copy on Write becomes the default, as we would have to do a bunch of changes to remove the copy on write option from the benchmarks at that time.

With this approach (despite its hackiness), all you have to do is put on or remove the decorator, which is much less error-prone.

Initial testing seems to show this working correctly, 
``rename`` is much faster under copy on write, which makes sense as it one of the methods where copy on write would eliminate a copy.