### PR TITLE
[Documentation] Added another example in `df.clip` documentation.

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8785,6 +8785,16 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         3     -1      6
         4      5     -4
 
+        Clips using specific lower and upper thresholds per column:
+        
+        >>> df.clip([-2, -1], [4,5])
+        col_0  col_1
+        0      4     -1
+        1     -2     -1
+        2      0      5
+        3     -1      5
+        4      4     -1
+
         Clips using specific lower and upper thresholds per column element:
 
         >>> t = pd.Series([2, -4, -1, 6, 3])

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8786,7 +8786,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         4      5     -4
 
         Clips using specific lower and upper thresholds per column:
-        
+
         >>> df.clip([-2, -1], [4,5])
             col_0  col_1
         0      4     -1

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8788,7 +8788,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         Clips using specific lower and upper thresholds per column:
         
         >>> df.clip([-2, -1], [4,5])
-        col_0  col_1
+            col_0  col_1
         0      4     -1
         1     -2     -1
         2      0      5


### PR DESCRIPTION
df.clip takes lower and upper threshholds as inputs, and both of these can be `float or array-like, default None` type. 

I am aware of an example in doc which Clips specific lower and upper thresholds per column element. 

But it would be also nice to have example clipping is happening per column with specific lower and upper threshhold. 