### PR TITLE
BLD: Allow building with NumPy nightlies and use it for nightlies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,12 @@ jobs:
           no_output_timeout: 30m # Sometimes the tests won't generate any output, make sure the job doesn't get killed by that
           command: |
             pip3 install cibuildwheel==2.15.0
+            # When this is a nightly wheel build, allow picking up NumPy 2.0 dev wheels:
+            if [[ "$IS_SCHEDULE_DISPATCH" == "true" || "$IS_PUSH" != 'true' ]]; then
+                export CIBW_ENVIRONMENT="PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
+            fi
             cibuildwheel --prerelease-pythons --output-dir wheelhouse
+
           environment:
             CIBW_BUILD: << parameters.cibw-build >>
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -137,11 +137,24 @@ jobs:
         shell: bash -el {0}
         run: echo "sdist_name=$(cd ./dist && ls -d */)" >> "$GITHUB_ENV"
 
-      - name: Build wheels
+      - name: Build normal wheels
+        if: ${{ (env.IS_SCHEDULE_DISPATCH != 'true' || env.IS_PUSH == 'true') }}
         uses: pypa/cibuildwheel@v2.16.2
         with:
          package-dir: ./dist/${{ matrix.buildplat[1] == 'macosx_*' && env.sdist_name || needs.build_sdist.outputs.sdist_file }}
         env:
+          CIBW_PRERELEASE_PYTHONS: True
+          CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
+
+      - name: Build nightly wheels (with NumPy pre-release)
+        if: ${{ (env.IS_SCHEDULE_DISPATCH == 'true' && env.IS_PUSH != 'true') }}
+        uses: pypa/cibuildwheel@v2.16.2
+        with:
+         package-dir: ./dist/${{ matrix.buildplat[1] == 'macosx_*' && env.sdist_name || needs.build_sdist.outputs.sdist_file }}
+        env:
+          # The nightly wheels should be build witht he NumPy 2.0 pre-releases
+          # which requires the additional URL.
+          CIBW_ENVIRONMENT: PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,12 @@ requires = [
     "meson==1.2.1",
     "wheel",
     "Cython>=0.29.33,<3",  # Note: sync with setup.py, environment.yml and asv.conf.json
-    # Note: numpy 1.25 has a backwards compatible C API by default
-    # we don't want to force users to compile with 1.25 though
-    # (Ideally, in the future, though, oldest-supported-numpy can be dropped when our min numpy is 1.25.x)
-    "oldest-supported-numpy>=2022.8.16; python_version<'3.12'",
-    "numpy>=1.26.0,<2; python_version>='3.12'",
+    # Any NumPy version should be fine for compiling.  Users are unlikely
+    # to get a NumPy<1.25 so the result will be compatible with all relevant
+    # NumPy versions (if not it is presumably compatible with their version).
+    # Pin <2.0 for releases until tested against an RC.  But explicitly allow
+    # testing the `.dev0` nightlies (which require the extra index).
+    "numpy>1.22.4,<=2.0.0.dev0",
     "versioneer[toml]"
 ]
 


### PR DESCRIPTION
I am not sure that this is uncontested that this is a good version pin change.  I also took the liberty of removing the current use of oldest-support-numpy, since Python 3.9 means that you should normally always get 1.25 anyway and that should work for any NumPy version.

The `<=2.0.0.dev0` is a way to explicitly allow NumPy nightly wheels, although of course you need the additional URL to use it. In a release version, it might be nicer to not have it, but it also should not really hurt since the you are unlikely to have the NumPy dev wheels available unless you really want them.

(Not sure how to best test that the changes work as is.)

---

@lithomas1 I suppose you are the one to discuss this?  I am not sure that others will agree that changing the version pin as I did is a viable approach, yet.
Maybe there is some reason why removing oldest-support-numpy seems terrible also?!  To me it seems like it should be safe, assuming it works.