### PR TITLE
CI: Have NumpyDev build only test nightly numpy

### DIFF
--- a/ci/deps/actions-311-numpydev.yaml
+++ b/ci/deps/actions-311-numpydev.yaml
@@ -29,5 +29,4 @@ dependencies:
     - "--extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
     - "--pre"
     - "numpy"
-    - "scipy"
     - "tzdata>=2022.1"


### PR DESCRIPTION
Since scipy is an optional dependency and is only use sparsely within the pandas API, I don't think it's entirely necessary to test its nightly
