### PR TITLE
REF: initialize Series._name in _from_mgr to return valid Series object

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -658,7 +658,6 @@ class DataFrame(NDFrame, OpsMixin):
 
     def _constructor_sliced_from_mgr(self, mgr, axes):
         ser = self._sliced_from_mgr(mgr, axes=axes)
-        ser._name = None  # caller is responsible for setting real name
         if type(self) is DataFrame:
             # fastpath avoiding constructor call
             return ser

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -346,7 +346,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
     _typ = "series"
     _HANDLED_TYPES = (Index, ExtensionArray, np.ndarray)
 
-    _name: Hashable
+    _name: Hashable = None
     _metadata: list[str] = ["_name"]
     _internal_names_set = {"index", "name"} | NDFrame._internal_names_set
     _accessors = {"dt", "cat", "str", "sparse"}
@@ -633,7 +633,6 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
     def _constructor_from_mgr(self, mgr, axes):
         ser = self._from_mgr(mgr, axes=axes)
-        ser._name = None  # caller is responsible for setting real name
         if type(self) is Series:
             # fastpath avoiding constructor call
             return ser

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -172,6 +172,7 @@ if TYPE_CHECKING:
         IndexKeyFunc,
         IndexLabel,
         Level,
+        Manager,
         MutableMappingT,
         NaPosition,
         NumpySorter,
@@ -346,7 +347,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
     _typ = "series"
     _HANDLED_TYPES = (Index, ExtensionArray, np.ndarray)
 
-    _name: Hashable = None
+    _name: Hashable
     _metadata: list[str] = ["_name"]
     _internal_names_set = {"index", "name"} | NDFrame._internal_names_set
     _accessors = {"dt", "cat", "str", "sparse"}
@@ -573,6 +574,27 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         NDFrame.__init__(self, data)
         self.name = name
         self._set_axis(0, index)
+
+    @classmethod
+    def _from_mgr(cls, mgr: Manager, axes: list[Index]) -> Self:
+        """
+        Construct a new Series from a Manager object and axes.
+
+        Parameters
+        ----------
+        mgr : Manager
+            Must have the same ndim as cls.
+        axes : list[Index]
+
+        Notes
+        -----
+        The axes must match mgr.axes, but are required for future-proofing
+        in the event that axes are refactored out of the Manager objects.
+        """
+        obj = cls.__new__(cls)
+        NDFrame.__init__(obj, mgr)
+        object.__setattr__(obj, "_name", None)
+        return obj
 
     def _init_dict(
         self, data, index: Index | None = None, dtype: DtypeObj | None = None


### PR DESCRIPTION
Currently `Series._from_mgr` doesn't return a fully initialized Series object, because it misses the `_name` attribute (without this, several kinds of operations fail on the object). 
While `_from_mgr` is not a user-facing method, I think also from a developer perspective, it's nicer if it returns a proper Series, for example for during debugging, and for not having to think about setting `_name` after using it (as we are currently doing).