### PR TITLE
DEPR: correct warning message while parsing datetimes with mixed time zones if utc=False

### DIFF
--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -668,7 +668,7 @@ cdef _array_to_datetime_object(
     if len(unique_timezones) > 1:
         warnings.warn(
             "In a future version of pandas, parsing datetimes with mixed time "
-            "zones will raise a warning unless `utc=True`. "
+            "zones will raise an error unless `utc=True`. "
             "Please specify `utc=True` to opt in to the new behaviour "
             "and silence this warning. To create a `Series` with mixed offsets and "
             "`object` dtype, please use `apply` and `datetime.datetime.strptime`",

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -356,7 +356,7 @@ def _return_parsed_timezone_results(
     if len(non_na_timezones) > 1:
         warnings.warn(
             "In a future version of pandas, parsing datetimes with mixed time "
-            "zones will raise a warning unless `utc=True`. Please specify `utc=True` "
+            "zones will raise an error unless `utc=True`. Please specify `utc=True` "
             "to opt in to the new behaviour and silence this warning. "
             "To create a `Series` with mixed offsets and `object` dtype, "
             "please use `apply` and `datetime.datetime.strptime`",
@@ -788,7 +788,7 @@ def to_datetime(
         .. warning::
 
             In a future version of pandas, parsing datetimes with mixed time
-            zones will raise a warning unless `utc=True`.
+            zones will raise an error unless `utc=True`.
             Please specify `utc=True` to opt in to the new behaviour
             and silence this warning. To create a `Series` with mixed offsets and
             `object` dtype, please use `apply` and `datetime.datetime.strptime`.
@@ -1023,7 +1023,7 @@ def to_datetime(
     >>> pd.to_datetime(['2020-10-25 02:00 +0200',
     ...                 '2020-10-25 04:00 +0100'])  # doctest: +SKIP
     FutureWarning: In a future version of pandas, parsing datetimes with mixed
-    time zones will raise a warning unless `utc=True`. Please specify `utc=True`
+    time zones will raise an error unless `utc=True`. Please specify `utc=True`
     to opt in to the new behaviour and silence this warning. To create a `Series`
     with mixed offsets and `object` dtype, please use `apply` and
     `datetime.datetime.strptime`.
@@ -1037,7 +1037,7 @@ def to_datetime(
     >>> pd.to_datetime(["2020-01-01 01:00:00-01:00",
     ...                 datetime(2020, 1, 1, 3, 0)])  # doctest: +SKIP
     FutureWarning: In a future version of pandas, parsing datetimes with mixed
-    time zones will raise a warning unless `utc=True`. Please specify `utc=True`
+    time zones will raise an error unless `utc=True`. Please specify `utc=True`
     to opt in to the new behaviour and silence this warning. To create a `Series`
     with mixed offsets and `object` dtype, please use `apply` and
     `datetime.datetime.strptime`.

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -1326,7 +1326,7 @@ class Parser:
                     warnings.filterwarnings(
                         "ignore",
                         ".*parsing datetimes with mixed time "
-                        "zones will raise a warning",
+                        "zones will raise an error",
                         category=FutureWarning,
                     )
                     new_data = to_datetime(new_data, errors="raise", unit=date_unit)

--- a/pandas/io/parsers/base_parser.py
+++ b/pandas/io/parsers/base_parser.py
@@ -1147,7 +1147,7 @@ def _make_date_converter(
             with warnings.catch_warnings():
                 warnings.filterwarnings(
                     "ignore",
-                    ".*parsing datetimes with mixed time zones will raise a warning",
+                    ".*parsing datetimes with mixed time zones will raise an error",
                     category=FutureWarning,
                 )
                 result = tools.to_datetime(
@@ -1169,7 +1169,7 @@ def _make_date_converter(
                     warnings.filterwarnings(
                         "ignore",
                         ".*parsing datetimes with mixed time zones "
-                        "will raise a warning",
+                        "will raise an error",
                         category=FutureWarning,
                     )
                     result = tools.to_datetime(
@@ -1187,7 +1187,7 @@ def _make_date_converter(
                     warnings.filterwarnings(
                         "ignore",
                         ".*parsing datetimes with mixed time zones "
-                        "will raise a warning",
+                        "will raise an error",
                         category=FutureWarning,
                     )
                     return tools.to_datetime(

--- a/pandas/tests/indexes/datetimes/test_constructors.py
+++ b/pandas/tests/indexes/datetimes/test_constructors.py
@@ -300,7 +300,7 @@ class TestDatetimeIndex:
         assert not isinstance(result, DatetimeIndex)
 
         msg = "DatetimeIndex has mixed timezones"
-        msg_depr = "parsing datetimes with mixed time zones will raise a warning"
+        msg_depr = "parsing datetimes with mixed time zones will raise an error"
         with pytest.raises(TypeError, match=msg):
             with tm.assert_produces_warning(FutureWarning, match=msg_depr):
                 DatetimeIndex(["2013-11-02 22:00-05:00", "2013-11-03 22:00-06:00"])

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -518,7 +518,7 @@ class TestTimeConversionFormats:
         self, fmt, dates, expected_dates
     ):
         # GH 13486, 50887
-        msg = "parsing datetimes with mixed time zones will raise a warning"
+        msg = "parsing datetimes with mixed time zones will raise an error"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             result = to_datetime(dates, format=fmt)
         expected = Index(expected_dates)
@@ -693,7 +693,7 @@ class TestToDatetime:
         args = ["2000-01-01 01:00:00", "2000-01-01 02:00:00+00:00"]
         ts1 = constructor(args[0])
         ts2 = args[1]
-        msg = "parsing datetimes with mixed time zones will raise a warning"
+        msg = "parsing datetimes with mixed time zones will raise an error"
 
         expected = Index(
             [
@@ -734,7 +734,7 @@ class TestToDatetime:
     )
     def test_to_datetime_mixed_offsets_with_none_tz(self, fmt, expected):
         # https://github.com/pandas-dev/pandas/issues/50071
-        msg = "parsing datetimes with mixed time zones will raise a warning"
+        msg = "parsing datetimes with mixed time zones will raise an error"
 
         with tm.assert_produces_warning(FutureWarning, match=msg):
             result = to_datetime(
@@ -1236,7 +1236,7 @@ class TestToDatetime:
         ts_string_2 = "March 1, 2018 12:00:00+0500"
         arr = [ts_string_1] * 5 + [ts_string_2] * 5
         expected = Index([parse(x) for x in arr])
-        msg = "parsing datetimes with mixed time zones will raise a warning"
+        msg = "parsing datetimes with mixed time zones will raise an error"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             result = to_datetime(arr, cache=cache)
         tm.assert_index_equal(result, expected)
@@ -1604,7 +1604,7 @@ class TestToDatetime:
             "March 1, 2018 12:00:00+0500",
             "20100240",
         ]
-        msg = "parsing datetimes with mixed time zones will raise a warning"
+        msg = "parsing datetimes with mixed time zones will raise an error"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             result = to_datetime(ts_strings, errors="coerce")
         expected = Index(
@@ -1689,7 +1689,7 @@ class TestToDatetime:
     def test_iso_8601_strings_with_different_offsets(self):
         # GH 17697, 11736, 50887
         ts_strings = ["2015-11-18 15:30:00+05:30", "2015-11-18 16:30:00+06:30", NaT]
-        msg = "parsing datetimes with mixed time zones will raise a warning"
+        msg = "parsing datetimes with mixed time zones will raise an error"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             result = to_datetime(ts_strings)
         expected = np.array(
@@ -1729,7 +1729,7 @@ class TestToDatetime:
 
         now = Timestamp("now")
         today = Timestamp("today")
-        msg = "parsing datetimes with mixed time zones will raise a warning"
+        msg = "parsing datetimes with mixed time zones will raise an error"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             mixed = to_datetime(ser)
         expected = Series(
@@ -1810,7 +1810,7 @@ class TestToDatetime:
     )
     def test_to_datetime_mixed_offsets_with_utc_false_deprecated(self, date):
         # GH 50887
-        msg = "parsing datetimes with mixed time zones will raise a warning"
+        msg = "parsing datetimes with mixed time zones will raise an error"
         with tm.assert_produces_warning(FutureWarning, match=msg):
             to_datetime(date, utc=False)
 
@@ -3680,7 +3680,7 @@ def test_to_datetime_with_empty_str_utc_false_format_mixed():
 
 def test_to_datetime_with_empty_str_utc_false_offsets_and_format_mixed():
     # GH 50887
-    msg = "parsing datetimes with mixed time zones will raise a warning"
+    msg = "parsing datetimes with mixed time zones will raise an error"
 
     with tm.assert_produces_warning(FutureWarning, match=msg):
         to_datetime(

--- a/pandas/tests/tslibs/test_array_to_datetime.py
+++ b/pandas/tests/tslibs/test_array_to_datetime.py
@@ -85,7 +85,7 @@ def test_parsing_different_timezone_offsets():
     data = ["2015-11-18 15:30:00+05:30", "2015-11-18 15:30:00+06:30"]
     data = np.array(data, dtype=object)
 
-    msg = "parsing datetimes with mixed time zones will raise a warning"
+    msg = "parsing datetimes with mixed time zones will raise an error"
     with tm.assert_produces_warning(FutureWarning, match=msg):
         result, result_tz = tslib.array_to_datetime(data)
     expected = np.array(


### PR DESCRIPTION
xref #54014

replaced "warning" with "error" in  warning message for parsing datetimes with mixed time zones if `utc=False`