### PR TITLE
DEPR: correct class of Warning for offsets deprecated frequency ('M' to 'ME')

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -4731,7 +4731,7 @@ cpdef to_offset(freq, bint is_period=False):
                     warnings.warn(
                         f"\'{name}\' will be deprecated, please use "
                         f"\'{c_OFFSET_DEPR_FREQSTR.get(name)}\' instead.",
-                        UserWarning,
+                        FutureWarning,
                         stacklevel=find_stack_level(),
                     )
                     name = c_OFFSET_DEPR_FREQSTR[name]

--- a/pandas/tests/frame/methods/test_asfreq.py
+++ b/pandas/tests/frame/methods/test_asfreq.py
@@ -240,6 +240,6 @@ class TestAsFreq:
         index = date_range("1/1/2000", periods=4, freq="ME")
         df = DataFrame({"s": Series([0.0, 1.0, 2.0, 3.0], index=index)})
         expected = df.asfreq(freq="5ME")
-        with tm.assert_produces_warning(UserWarning, match=depr_msg):
+        with tm.assert_produces_warning(FutureWarning, match=depr_msg):
             result = df.asfreq(freq="5M")
             tm.assert_frame_equal(result, expected)

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -128,7 +128,7 @@ class TestDateRanges:
         depr_msg = "'M' will be deprecated, please use 'ME' instead."
 
         expected = date_range("1/1/2000", periods=4, freq="2ME")
-        with tm.assert_produces_warning(UserWarning, match=depr_msg):
+        with tm.assert_produces_warning(FutureWarning, match=depr_msg):
             result = date_range("1/1/2000", periods=4, freq="2M")
         tm.assert_index_equal(result, expected)
 

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -2015,7 +2015,7 @@ def test_resample_M_deprecated():
 
     s = Series(range(10), index=date_range("20130101", freq="d", periods=10))
     expected = s.resample("2ME").mean()
-    with tm.assert_produces_warning(UserWarning, match=depr_msg):
+    with tm.assert_produces_warning(FutureWarning, match=depr_msg):
         result = s.resample("2M").mean()
     tm.assert_series_equal(result, expected)
 


### PR DESCRIPTION
xref #52064, #55553

for offsets deprecated frequency ('M' to 'ME', etc.) replaced UserWarning with FutureWarning