### PR TITLE
Fixed GIL regressions with Cython 3

### DIFF
--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -228,7 +228,7 @@ cdef extern from "pandas/parser/tokenizer.h":
         # pick one, depending on whether the converter requires GIL
         double (*double_converter)(const char *, char **,
                                    char, char, char,
-                                   int, int *, int *) nogil
+                                   int, int *, int *) noexcept nogil
 
         #  error handling
         char *warn_msg
@@ -1605,7 +1605,7 @@ cdef _categorical_convert(parser_t *parser, int64_t col,
 
 # -> ndarray[f'|S{width}']
 cdef _to_fw_string(parser_t *parser, int64_t col, int64_t line_start,
-                   int64_t line_end, int64_t width):
+                   int64_t line_end, int64_t width) noexcept:
     cdef:
         char *data
         ndarray result
@@ -1621,7 +1621,7 @@ cdef _to_fw_string(parser_t *parser, int64_t col, int64_t line_start,
 
 cdef void _to_fw_string_nogil(parser_t *parser, int64_t col,
                               int64_t line_start, int64_t line_end,
-                              size_t width, char *data) nogil:
+                              size_t width, char *data) noexcept nogil:
     cdef:
         int64_t i
         coliter_t it
@@ -1677,7 +1677,7 @@ cdef _try_double(parser_t *parser, int64_t col,
 cdef int _try_double_nogil(parser_t *parser,
                            float64_t (*double_converter)(
                                const char *, char **, char,
-                               char, char, int, int *, int *) nogil,
+                               char, char, int, int *, int *) noexcept nogil,
                            int64_t col, int64_t line_start, int64_t line_end,
                            bint na_filter, kh_str_starts_t *na_hashset,
                            bint use_na_flist,


### PR DESCRIPTION
ref https://github.com/pandas-dev/pandas/pull/55179

The main issue was that the functions returning `double` were not marked `noexcept`, so in Cython 3.0 these now explicitly check the global Python error indicator, which requires a reacquisition of the GIL

The changes to `to_fw_string` were to fix warnings generated by Cython that subsequently appeared:

```
 [2/4] Compiling Cython source /home/willayd/clones/pandas/pandas/_libs/parsers.pyx
  performance hint: /home/willayd/clones/pandas/pandas/_libs/parsers.pyx:1622:5: Exception check on '_to_fw_string_nogil' will always require the GIL to be acquired.
  Possible solutions:
        1. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
        2. Use an 'int' return type on the function to allow an error code to be returned.
  performance hint: /home/willayd/clones/pandas/pandas/_libs/parsers.pyx:1617:27: Exception check will always require the GIL to be acquired.
  Possible solutions:
        1. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
        2. Use an 'int' return type on the function to allow an error code to be returned.
  performance hint: /home/willayd/clones/pandas/pandas/_libs/parsers.pyx:1707:42: Exception check will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
  performance hint: /home/willayd/clones/pandas/pandas/_libs/parsers.pyx:1731:38: Exception check will always require the GIL to be acquired. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
```

We maybe shouldn't just be swallowing errors like this, but that is a different problem for a different day...for now this should get us back to 0.29 performance
