### PR TITLE
REGR: fix read_parquet with column of large strings (avoid overflow from concat)

### DIFF
--- a/doc/source/whatsnew/v2.1.2.rst
+++ b/doc/source/whatsnew/v2.1.2.rst
@@ -19,6 +19,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrameGroupBy.agg` and :meth:`SeriesGroupBy.agg` where if the option ``compute.use_numba`` was set to True, groupby methods not supported by the numba engine would raise a ``TypeError`` (:issue:`55520`)
 - Fixed performance regression with wide DataFrames, typically involving methods where all columns were accessed individually (:issue:`55256`, :issue:`55245`)
 - Fixed regression in :func:`merge_asof` raising ``TypeError`` for ``by`` with datetime and timedelta dtypes (:issue:`55453`)
+- Fixed regression in :func:`read_parquet` when reading a file with a string column consisting of more than 2 GB of string data and using the ``"string"`` dtype (:issue:`55606`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_212.bug_fixes:

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -230,6 +230,8 @@ class StringDtype(StorageExtensionDtype):
 
             results = []
             for arr in chunks:
+                # convert chunk by chunk to numpy and concatenate then, to avoid
+                # overflow for large string data when concatenating the pyarrow arrays
                 arr = arr.to_numpy(zero_copy_only=False)
                 arr = ensure_string_array(arr, na_value=libmissing.NA)
                 results.append(arr)

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -228,11 +228,17 @@ class StringDtype(StorageExtensionDtype):
                 # pyarrow.ChunkedArray
                 chunks = array.chunks
 
+            results = []
+            for arr in chunks:
+                arr = arr.to_numpy(zero_copy_only=False)
+                arr = ensure_string_array(arr, na_value=libmissing.NA)
+                results.append(arr)
+
         if len(chunks) == 0:
             arr = np.array([], dtype=object)
         else:
-            arr = pyarrow.concat_arrays(chunks).to_numpy(zero_copy_only=False)
-            arr = ensure_string_array(arr, na_value=libmissing.NA)
+            arr = np.concatenate(results)
+
         # Bypass validation inside StringArray constructor, see GH#47781
         new_string_array = StringArray.__new__(StringArray)
         NDArrayBacked.__init__(

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -1141,16 +1141,17 @@ class TestParquetPyArrow(Base):
         )
         tm.assert_frame_equal(result, expected)
 
-    @pytest.mark.slow
-    def test_string_column_above_2GB(self, tmp_path, pa):
-        # https://github.com/pandas-dev/pandas/issues/55606
-        # above 2GB of string data
-        v1 = b"x" * 100000000
-        v2 = b"x" * 147483646
-        df = pd.DataFrame({"strings": [v1] * 20 + [v2] + ["x"] * 20}, dtype="string")
-        df.to_parquet(tmp_path / "test.parquet")
-        result = read_parquet(tmp_path / "test.parquet")
-        assert result["strings"].dtype == "string"
+    # NOTE: this test is not run by default, because it requires a lot of memory (>5GB)
+    # @pytest.mark.slow
+    # def test_string_column_above_2GB(self, tmp_path, pa):
+    #     # https://github.com/pandas-dev/pandas/issues/55606
+    #     # above 2GB of string data
+    #     v1 = b"x" * 100000000
+    #     v2 = b"x" * 147483646
+    #     df = pd.DataFrame({"strings": [v1] * 20 + [v2] + ["x"] * 20}, dtype="string")
+    #     df.to_parquet(tmp_path / "test.parquet")
+    #     result = read_parquet(tmp_path / "test.parquet")
+    #     assert result["strings"].dtype == "string"
 
 
 class TestParquetFastParquet(Base):

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -1141,6 +1141,17 @@ class TestParquetPyArrow(Base):
         )
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.slow
+    def test_string_column_above_2GB(self, tmp_path, pa):
+        # https://github.com/pandas-dev/pandas/issues/55606
+        # above 2GB of string data
+        v1 = b"x" * 100000000
+        v2 = b"x" * 147483646
+        df = pd.DataFrame({"strings": [v1] * 20 + [v2] + ["x"] * 20}, dtype="string")
+        df.to_parquet(tmp_path / "test.parquet")
+        result = read_parquet(tmp_path / "test.parquet")
+        assert result["strings"].dtype == "string"
+
 
 class TestParquetFastParquet(Base):
     def test_basic(self, fp, df_full):


### PR DESCRIPTION
- [x] closes #55606
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
