### PR TITLE
This fix allows a DataFrame to retain key order from a dictionary 

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -437,9 +437,9 @@ Other
 - Bug in :func:`cut` incorrectly allowing cutting of timezone-aware datetimes with timezone-naive bins (:issue:`54964`)
 - Bug in :func:`infer_freq` and :meth:`DatetimeIndex.inferred_freq` with weekly frequencies and non-nanosecond resolutions (:issue:`55609`)
 - Bug in :meth:`DataFrame.apply` where passing ``raw=True`` ignored ``args`` passed to the applied function (:issue:`55009`)
+- Bug in :meth:`Dataframe.from_dict` which would always sort the rows of the created :class:`DataFrame`.  (:issue:`55683`)
 - Bug in rendering ``inf`` values inside a a :class:`DataFrame` with the ``use_inf_as_na`` option enabled (:issue:`55483`)
 - Bug in rendering a :class:`Series` with a :class:`MultiIndex` when one of the index level's names is 0 not having that name displayed (:issue:`55415`)
--
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -220,7 +220,10 @@ def union_indexes(indexes, sort: bool | None = True) -> Index:
     if len(indexes) == 1:
         result = indexes[0]
         if isinstance(result, list):
-            result = Index(sorted(result))
+            if not sort:
+                result = Index(result)
+            else:
+                result = Index(sorted(result))
         return result
 
     indexes, kind = _sanitize_and_check(indexes)

--- a/pandas/tests/frame/constructors/test_from_dict.py
+++ b/pandas/tests/frame/constructors/test_from_dict.py
@@ -200,3 +200,24 @@ class TestFromDict:
         )
         with pytest.raises(ValueError, match=msg):
             DataFrame.from_dict({"foo": 1, "baz": 3, "bar": 2}, orient="abc")
+
+    def test_from_dict_order_with_single_column(self):
+        data = {
+            "alpha": {
+                "value2": 123,
+                "value1": 532,
+                "animal": 222,
+                "plant": False,
+                "name": "test",
+            }
+        }
+        result = DataFrame.from_dict(
+            data,
+            orient="columns",
+        )
+        expected = DataFrame(
+            [[123], [532], [222], [False], ["test"]],
+            index=["value2", "value1", "animal", "plant", "name"],
+            columns=["alpha"],
+        )
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/methods/test_rename.py
+++ b/pandas/tests/frame/methods/test_rename.py
@@ -50,13 +50,12 @@ class TestRename:
         # index
         data = {"A": {"foo": 0, "bar": 1}}
 
-        # gets sorted alphabetical
         df = DataFrame(data)
         renamed = df.rename(index={"foo": "bar", "bar": "foo"})
-        tm.assert_index_equal(renamed.index, Index(["foo", "bar"]))
+        tm.assert_index_equal(renamed.index, Index(["bar", "foo"]))
 
         renamed = df.rename(index=str.upper)
-        tm.assert_index_equal(renamed.index, Index(["BAR", "FOO"]))
+        tm.assert_index_equal(renamed.index, Index(["FOO", "BAR"]))
 
         # have to pass something
         with pytest.raises(TypeError, match="must pass an index to rename"):

--- a/pandas/tests/indexing/multiindex/test_setitem.py
+++ b/pandas/tests/indexing/multiindex/test_setitem.py
@@ -175,7 +175,7 @@ class TestMultiIndexSetItem:
         )
 
         expected = df_orig.copy()
-        expected.iloc[[0, 2, 3]] *= 2
+        expected.iloc[[0, 1, 3]] *= 2
 
         idx = pd.IndexSlice
         df = df_orig.copy()


### PR DESCRIPTION
This fix allows a DataFrame to retain key order from a dictionary with only one column instead of sorting them alphabetically.

Note: I had to change the order for the rename tests in `test_rename.py` but the order there seemed trivial.  If I'm wrong in my assumption please let me know. I also had to change the index order of the control df in `indexing/multiindex/test_setitem.py` but again this seemed trivial/innocuous change in this circumstance.

- [x] closes #55683
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
