### PR TITLE
TST: add missing assert in `test_apply_datetimetz` in test_series_apply.py

### DIFF
--- a/pandas/tests/apply/test_series_apply.py
+++ b/pandas/tests/apply/test_series_apply.py
@@ -213,7 +213,7 @@ def test_apply_datetimetz(by_row):
         exp = Series(["Asia/Tokyo"] * 25, name="XX")
         tm.assert_series_equal(result, exp)
     else:
-        result == "Asia/Tokyo"
+        assert result == "Asia/Tokyo"
 
 
 def test_apply_categorical(by_row):


### PR DESCRIPTION
I think assert is missing before `result == "Asia/Tokyo"`. Came across this when checking some Pylance warnings.
https://github.com/pandas-dev/pandas/blob/fe178189e589711559a3064fcefa4d330b7f41fa/pandas/tests/apply/test_series_apply.py#L211-L216

- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

