### PR TITLE
BUG: IntervalIndex.from_arrays with mismatched datetimelike resos

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -361,6 +361,7 @@ Interval
 - Bug in :meth:`IntervalIndex.get_indexer` with datetime or timedelta intervals incorrectly matching on integer targets (:issue:`47772`)
 - Bug in :meth:`IntervalIndex.get_indexer` with timezone-aware datetime intervals incorrectly matching on a sequence of timezone-naive targets (:issue:`47772`)
 - Bug in setting values on a :class:`Series` with an :class:`IntervalIndex` using a slice incorrectly raising (:issue:`54722`)
+- Bug in :meth:`IntervalIndex.from_arrays` when passed ``datetime64`` or ``timedelta64`` arrays with mismatched resolutions constructing an invalid ``IntervalArray`` object (:issue:`??`)
 -
 
 Indexing

--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -358,10 +358,10 @@ Strings
 Interval
 ^^^^^^^^
 - Bug in :class:`Interval` ``__repr__`` not displaying UTC offsets for :class:`Timestamp` bounds. Additionally the hour, minute and second components will now be shown. (:issue:`55015`)
+- Bug in :meth:`IntervalIndex.from_arrays` when passed ``datetime64`` or ``timedelta64`` arrays with mismatched resolutions constructing an invalid ``IntervalArray`` object (:issue:`55714`)
 - Bug in :meth:`IntervalIndex.get_indexer` with datetime or timedelta intervals incorrectly matching on integer targets (:issue:`47772`)
 - Bug in :meth:`IntervalIndex.get_indexer` with timezone-aware datetime intervals incorrectly matching on a sequence of timezone-naive targets (:issue:`47772`)
 - Bug in setting values on a :class:`Series` with an :class:`IntervalIndex` using a slice incorrectly raising (:issue:`54722`)
-- Bug in :meth:`IntervalIndex.from_arrays` when passed ``datetime64`` or ``timedelta64`` arrays with mismatched resolutions constructing an invalid ``IntervalArray`` object (:issue:`??`)
 -
 
 Indexing

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -357,6 +357,11 @@ class IntervalArray(IntervalMixin, ExtensionArray):
                 f"'{left.tz}' and '{right.tz}'"
             )
             raise ValueError(msg)
+        elif needs_i8_conversion(left.dtype) and left.unit != right.unit:
+            # e.g. m8[s] vs m8[ms], try to cast to a common dtype
+            left_arr, right_arr = left._data._ensure_matching_resos(right._data)
+            left = ensure_index(left_arr)
+            right = ensure_index(right_arr)
 
         # For dt64/td64 we want DatetimeArray/TimedeltaArray instead of ndarray
         left = ensure_wrapped_if_datetimelike(left)

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -358,7 +358,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             )
             raise ValueError(msg)
         elif needs_i8_conversion(left.dtype) and left.unit != right.unit:
-            # e.g. m8[s] vs m8[ms], try to cast to a common dtype
+            # e.g. m8[s] vs m8[ms], try to cast to a common dtype GH#55714
             left_arr, right_arr = left._data._ensure_matching_resos(right._data)
             left = ensure_index(left_arr)
             right = ensure_index(right_arr)

--- a/pandas/tests/indexes/interval/test_constructors.py
+++ b/pandas/tests/indexes/interval/test_constructors.py
@@ -256,6 +256,28 @@ class TestFromArrays(ConstructorTests):
         tm.assert_index_equal(result.right, expected_right)
         assert result.dtype.subtype == expected_subtype
 
+    @pytest.mark.parametrize("interval_cls", [IntervalArray, IntervalIndex])
+    def test_from_arrays_mismatched_datetimelike_resos(self, interval_cls):
+        left = date_range("2016-01-01", periods=3, unit="s")
+        right = date_range("2017-01-01", periods=3, unit="ms")
+        result = interval_cls.from_arrays(left, right)
+        expected = interval_cls.from_arrays(left.as_unit("ms"), right)
+        tm.assert_equal(result, expected)
+
+        # td64
+        left2 = left - left[0]
+        right2 = right - left[0]
+        result2 = interval_cls.from_arrays(left2, right2)
+        expected2 = interval_cls.from_arrays(left2.as_unit("ms"), right2)
+        tm.assert_equal(result2, expected2)
+
+        # dt64tz
+        left3 = left.tz_localize("UTC")
+        right3 = right.tz_localize("UTC")
+        result3 = interval_cls.from_arrays(left3, right3)
+        expected3 = interval_cls.from_arrays(left3.as_unit("ms"), right3)
+        tm.assert_equal(result3, expected3)
+
 
 class TestFromBreaks(ConstructorTests):
     """Tests specific to IntervalIndex.from_breaks"""

--- a/pandas/tests/indexes/interval/test_constructors.py
+++ b/pandas/tests/indexes/interval/test_constructors.py
@@ -258,6 +258,7 @@ class TestFromArrays(ConstructorTests):
 
     @pytest.mark.parametrize("interval_cls", [IntervalArray, IntervalIndex])
     def test_from_arrays_mismatched_datetimelike_resos(self, interval_cls):
+        # GH#55714
         left = date_range("2016-01-01", periods=3, unit="s")
         right = date_range("2017-01-01", periods=3, unit="ms")
         result = interval_cls.from_arrays(left, right)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Surfaced while implementing #55564