### PR TITLE
[NOT FOR MERGE] Test enabling Copy-on-Write by default

### DIFF
--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -476,9 +476,7 @@ with cf.config_prefix("mode"):
         "copy_on_write",
         # Get the default from an environment variable, if set, otherwise defaults
         # to False. This environment variable can be set for testing.
-        "warn"
-        if os.environ.get("PANDAS_COPY_ON_WRITE", "0") == "warn"
-        else os.environ.get("PANDAS_COPY_ON_WRITE", "0") == "1",
+        True,
         copy_on_write_doc,
         validator=is_one_of_factory([True, False, "warn"]),
     )


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/48998

We already test with CoW enabled in a few CI builds, but let's see what this gives when enabling it by default for the full test matrix.