### PR TITLE
BUG: fix online ewma with CoW

### DIFF
--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -1068,7 +1068,7 @@ class OnlineExponentialMovingWindow(ExponentialMovingWindow):
                 result_kwargs["columns"] = self._selected_obj.columns
             else:
                 result_kwargs["name"] = self._selected_obj.name
-            np_array = self._selected_obj.astype(np.float64).to_numpy()
+            np_array = self._selected_obj.astype(np.float64, copy=False).to_numpy()
         ewma_func = generate_online_numba_ewma_func(
             **get_jit_arguments(self.engine_kwargs)
         )

--- a/pandas/core/window/online.py
+++ b/pandas/core/window/online.py
@@ -52,7 +52,7 @@ def generate_online_numba_ewma_func(
         exponentially weighted mean accounting minimum periods.
         """
         result = np.empty(values.shape)
-        weighted_avg = values[0]
+        weighted_avg = values[0].copy()
         nobs = (~np.isnan(weighted_avg)).astype(np.int64)
         result[0] = np.where(nobs >= minimum_periods, weighted_avg, np.nan)
 


### PR DESCRIPTION
Fixing some failing tests that turned up in https://github.com/pandas-dev/pandas/pull/55732. This PR specifically fixes `pandas/tests/window/test_online.py::TestEWM::test_online_vs_non_online_mean` for Copy-on-Write enabled.

The numba function takes the underlying frame's array of values, and then writes into those values:

https://github.com/pandas-dev/pandas/blob/c36e302c7b30bc7945119a77f255d0302307847e/pandas/core/window/online.py#L80

(this `weighted_avg` is a view in the passed values, from `weighted_avg = values[0]`)

That currently doesn't cause a bug, because before getting the values from the frame and passing it to the numba func, we cast to float64:

https://github.com/pandas-dev/pandas/blob/c36e302c7b30bc7945119a77f255d0302307847e/pandas/core/window/ewm.py#L1071

This `astype()` call currently always returns a copy by default (even if you already have all float64 columns), but with CoW enabled, this avoids making a copy. Currently, with CoW enabled, the numba func fails because of the numpy array being marked as read-only. But if we wouldn't manually copy the data and just ignore this read-only flag, we would be mutating the calling dataframe (so marking as read-only prevented a new bug here!).