### PR TITLE
Ensure HDFStore read gives column-major data with CoW

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -30,6 +30,7 @@ import numpy as np
 from pandas._config import (
     config,
     get_option,
+    using_copy_on_write,
     using_pyarrow_string_dtype,
 )
 
@@ -3297,6 +3298,10 @@ class BlockManagerFixed(GenericFixed):
 
         if len(dfs) > 0:
             out = concat(dfs, axis=1, copy=True)
+            if using_copy_on_write():
+                # with CoW, concat ignores the copy keyword. Here, we still want
+                # to copy to enforce optimized column-major layout
+                out = out.copy()
             out = out.reindex(columns=items, copy=False)
             return out
 


### PR DESCRIPTION
Fixing a failing test that turned up in https://github.com/pandas-dev/pandas/pull/55732. 
This PR specifically fixes `pandas/tests/io/pytables/test_store.py::test_hdfstore_strides`, which tests that the data coming back from HDF are column-major (the "idea" of the test was to ensure the layout is _preserved_, i.e. when starting with a DataFrame that is column-major, you should get back one with the same layout. But in practice we don't do that, we just simply always return column-major data because of `concat` making a copy by default (see https://github.com/pandas-dev/pandas/issues/22073#issuecomment-1383843005), and we only test the column-major case in the test)

We have ran into this issue before: in pandas/tests/io/pytables/test_store.py::test_hdfstore_strides, @phofl initially just skipped the test for CoW. But then in the final version of that PR, we removed that skip in favor of adding a `copy=True` inside the `concat` call in HDFStore.read. 
However, later, we then changed `concat` to ignore the `copy` keyword alltogether when CoW is enabled, even when specifically passing `copy=True` (done in https://github.com/pandas-dev/pandas/pull/51464). Because of that, this test is failing again (the reason this wasn't caught in our CI, s because the specific test was in the meantime moved to "single_cpu", which we don't run on the CoW CI builds)

This PR implements the option to manually copy inside HDFStore.read when CoW is enabled to achieve the same end result, but two other options would be:

1) Copy manually in HDFStore.read to ensure column-major data (i.e. current version of this PR)
2) Don't copy, and live with HDFStore returning row-major data (and update the test to reflect that for CoW). This gives a faster read, but lower performance afterwards (probably not the best option)
3) Change `pd.concat(..)` again to _do_ honor the `copy=True` option, even in the case of CoW

