### PR TITLE
Update _core.py to show valid plot types in the Error Message for Invalid plot kind

### DIFF
--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -961,7 +961,10 @@ class PlotAccessor(PandasObject):
             return plot_backend.plot(self._parent, x=x, y=y, kind=kind, **kwargs)
 
         if kind not in self._all_kinds:
-            raise ValueError(f"{kind} is not a valid plot kind\nValid plot kinds {self._all_kinds}")
+            raise ValueError(
+                    f"{kind} is not a valid plot kind "
+                    f"Valid plot kinds: {self._all_kinds}"
+                )
 
         # The original data structured can be transformed before passed to the
         # backend. For example, for DataFrame is common to set the index as the

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -962,9 +962,9 @@ class PlotAccessor(PandasObject):
 
         if kind not in self._all_kinds:
             raise ValueError(
-                    f"{kind} is not a valid plot kind "
-                    f"Valid plot kinds: {self._all_kinds}"
-                )
+                f"{kind} is not a valid plot kind "
+                f"Valid plot kinds: {self._all_kinds}"
+            )
 
         # The original data structured can be transformed before passed to the
         # backend. For example, for DataFrame is common to set the index as the

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -961,7 +961,7 @@ class PlotAccessor(PandasObject):
             return plot_backend.plot(self._parent, x=x, y=y, kind=kind, **kwargs)
 
         if kind not in self._all_kinds:
-            raise ValueError(f"{kind} is not a valid plot kind")
+            raise ValueError(f"{kind} is not a valid plot kind\nValid plot kinds {self._all_kinds}")
 
         # The original data structured can be transformed before passed to the
         # backend. For example, for DataFrame is common to set the index as the


### PR DESCRIPTION
If an invalid plot type is passed, the error message raised is

```
raise ValueError(f"{kind} is not a valid plot kind")
```
To give more context to user, it should also show the valid plot kinds.