### PR TITLE
PERF: avoid unnecessary method call in get_indexer_non_unique() on MultiIndex

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6041,12 +6041,13 @@ class Index(IndexOpsMixin, PandasObject):
 
         # Note: _maybe_downcast_for_indexing ensures we never get here
         #  with MultiIndex self and non-Multi target
-        tgt_values = target._get_engine_target()
         if self._is_multi and target._is_multi:
             engine = self._engine
             # Item "IndexEngine" of "Union[IndexEngine, ExtensionEngine]" has
             # no attribute "_extract_level_codes"
             tgt_values = engine._extract_level_codes(target)  # type: ignore[union-attr]
+        else:
+            tgt_values = target._get_engine_target()
 
         indexer, missing = self._engine.get_indexer_non_unique(tgt_values)
         return ensure_platform_int(indexer), ensure_platform_int(missing)


### PR DESCRIPTION
Hello,

There was a regression that made reindex 60x slower, in pandas v0.23 to v1.4, that was finally fixed by this PR last year
discussion https://github.com/pandas-dev/pandas/issues/23735
commit https://github.com/pandas-dev/pandas/pull/46235/files
a benchmark was added in a later commit https://github.com/pandas-dev/pandas/pull/47221/files

That resolved the issue in `get_indexer()`. 
I was going through pandas source code and I noticed there is a second code path in `get_indexer_non_unique()` with the same problem.
This PR fixes the remaining code path.

I'm not super familiar with pandas, I'm not sure what might hit the default indexer vs the non unique indexer. 
It would be great if you can think of something and add a benchmark. 
It looks like the exact same bug and nearly the same code to me, it might just be a 60x performance improvement too 😄 

@jreback 
@lukemanley 
@jbrockmendel 

Cheers.

- [X] closes #23735 (Replace xxxx with the GitHub issue number)
- [NA] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [NA] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [NA] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
