### PR TITLE
BUG: `assert_extension_array_equal` using the wrong dtype

### DIFF
--- a/doc/source/whatsnew/v2.1.3.rst
+++ b/doc/source/whatsnew/v2.1.3.rst
@@ -22,7 +22,7 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 - Bug in :meth:`DatetimeIndex.diff` raising ``TypeError`` (:issue:`55080`)
--
+- Bug in :func:`testing.assert_extension_array_equal` that could use the wrong datatype when calculating time units (:issue:`55730`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_213.other:

--- a/doc/source/whatsnew/v2.1.3.rst
+++ b/doc/source/whatsnew/v2.1.3.rst
@@ -22,7 +22,7 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 - Bug in :meth:`DatetimeIndex.diff` raising ``TypeError`` (:issue:`55080`)
-- Bug in :func:`testing.assert_extension_array_equal` that could use the wrong datatype when calculating time units (:issue:`55730`)
+-
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_213.other:

--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -345,6 +345,7 @@ Datetimelike
 ^^^^^^^^^^^^
 - Bug in :class:`DatetimeIndex` when passing an object-dtype ndarray of float objects and a ``tz`` incorrectly localizing the result (:issue:`55780`)
 - Bug in :func:`concat` raising ``AttributeError`` when concatenating all-NA DataFrame with :class:`DatetimeTZDtype` dtype DataFrame. (:issue:`52093`)
+- Bug in :func:`testing.assert_extension_array_equal` that could use the wrong unit when comparing resolutions (:issue:`55730`)
 - Bug in :func:`to_datetime` and :class:`DatetimeIndex` when passing a list of mixed-string-and-numeric types incorrectly raising (:issue:`55780`)
 - Bug in :meth:`DatetimeIndex.union` returning object dtype for tz-aware indexes with the same timezone but different units (:issue:`55238`)
 - Bug in :meth:`Index.is_monotonic_increasing` and :meth:`Index.is_monotonic_decreasing` always caching :meth:`Index.is_unique` as ``True`` when first value in index is ``NaT`` (:issue:`55755`)

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -745,7 +745,7 @@ def assert_extension_array_equal(
             else:
                 l_unit = np.datetime_data(left.dtype)[0]
             if not isinstance(right.dtype, np.dtype):
-                r_unit = cast(DatetimeTZDtype, left.dtype).unit
+                r_unit = cast(DatetimeTZDtype, right.dtype).unit
             else:
                 r_unit = np.datetime_data(right.dtype)[0]
             if (

--- a/pandas/tests/util/test_assert_extension_array_equal.py
+++ b/pandas/tests/util/test_assert_extension_array_equal.py
@@ -1,7 +1,10 @@
 import numpy as np
 import pytest
 
-from pandas import array, Timestamp
+from pandas import (
+    Timestamp,
+    array,
+)
 import pandas._testing as tm
 from pandas.core.arrays.sparse import SparseArray
 

--- a/pandas/tests/util/test_assert_extension_array_equal.py
+++ b/pandas/tests/util/test_assert_extension_array_equal.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas import array
+from pandas import array, Timestamp
 import pandas._testing as tm
 from pandas.core.arrays.sparse import SparseArray
 
@@ -111,3 +111,13 @@ def test_assert_extension_array_equal_ignore_dtype_mismatch(right_dtype):
     left = array([1, 2, 3], dtype="Int64")
     right = array([1, 2, 3], dtype=right_dtype)
     tm.assert_extension_array_equal(left, right, check_dtype=False)
+
+
+def test_assert_extension_array_equal_time_units():
+    # https://github.com/pandas-dev/pandas/issues/55730
+    timestamp = Timestamp("2023-11-04T12")
+    naive = array([timestamp], dtype="datetime64[ns]")
+    utc = array([timestamp], dtype="datetime64[ns, UTC]")
+
+    tm.assert_extension_array_equal(naive, utc, check_dtype=False)
+    tm.assert_extension_array_equal(utc, naive, check_dtype=False)


### PR DESCRIPTION
- [x] closes #55730 
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v2.1.3.rst` file if fixing a bug or adding a new feature.
