### PR TITLE
ENH: infer resolution in array_to_datetime_with_tz

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2241,14 +2241,14 @@ def _sequence_to_dt64(
             data = data.astype(np.int64)
         elif tz is not None and ambiguous == "raise":
             obj_data = np.asarray(data, dtype=object)
-            i8data = tslib.array_to_datetime_with_tz(
+            result = tslib.array_to_datetime_with_tz(
                 obj_data,
                 tz=tz,
                 dayfirst=dayfirst,
                 yearfirst=yearfirst,
                 creso=abbrev_to_npy_unit(out_unit),
             )
-            return i8data.view(out_dtype), tz, None
+            return result, tz, None
         else:
             # data comes back here as either i8 to denote UTC timestamps
             #  or M8[ns] to denote wall times

--- a/pandas/tests/tslibs/test_array_to_datetime.py
+++ b/pandas/tests/tslibs/test_array_to_datetime.py
@@ -10,12 +10,42 @@ import numpy as np
 import pytest
 
 from pandas._libs import (
+    NaT,
     iNaT,
     tslib,
 )
+from pandas._libs.tslibs.dtypes import NpyDatetimeUnit
 
 from pandas import Timestamp
 import pandas._testing as tm
+
+creso_infer = NpyDatetimeUnit.NPY_FR_GENERIC.value
+
+
+class TestArrayToDatetimeWithTZResolutionInference:
+    def test_array_to_datetime_with_tz_resolution(self):
+        tz = tzoffset("custom", 3600)
+        vals = np.array(["2016-01-01 02:03:04.567", NaT], dtype=object)
+        res = tslib.array_to_datetime_with_tz(vals, tz, False, False, creso_infer)
+        assert res.dtype == "M8[ms]"
+
+        vals2 = np.array([datetime(2016, 1, 1, 2, 3, 4), NaT], dtype=object)
+        res2 = tslib.array_to_datetime_with_tz(vals2, tz, False, False, creso_infer)
+        assert res2.dtype == "M8[us]"
+
+        vals3 = np.array([NaT, np.datetime64(12345, "s")], dtype=object)
+        res3 = tslib.array_to_datetime_with_tz(vals3, tz, False, False, creso_infer)
+        assert res3.dtype == "M8[s]"
+
+    def test_array_to_datetime_with_tz_resolution_all_nat(self):
+        tz = tzoffset("custom", 3600)
+        vals = np.array(["NaT"], dtype=object)
+        res = tslib.array_to_datetime_with_tz(vals, tz, False, False, creso_infer)
+        assert res.dtype == "M8[ns]"
+
+        vals2 = np.array([NaT, NaT], dtype=object)
+        res2 = tslib.array_to_datetime_with_tz(vals2, tz, False, False, creso_infer)
+        assert res2.dtype == "M8[ns]"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

towards #55564