### PR TITLE
DOC: fix typos newly found by codespell

### DIFF
--- a/doc/source/development/debugging_extensions.rst
+++ b/doc/source/development/debugging_extensions.rst
@@ -23,7 +23,7 @@ By default building pandas from source will generate a release build. To generat
 
 .. note::
 
-   conda environements update CFLAGS/CPPFLAGS with flags that are geared towards generating releases. If using conda, you may need to set ``CFLAGS="$CFLAGS -O0"`` and ``CPPFLAGS="$CPPFLAGS -O0"`` to ensure optimizations are turned off for debugging
+   conda environments update CFLAGS/CPPFLAGS with flags that are geared towards generating releases. If using conda, you may need to set ``CFLAGS="$CFLAGS -O0"`` and ``CPPFLAGS="$CPPFLAGS -O0"`` to ensure optimizations are turned off for debugging
 
 By specifying ``builddir="debug"`` all of the targets will be built and placed in the debug directory relative to the project root. This helps to keep your debug and release artifacts separate; you are of course able to choose a different directory name or omit altogether if you do not care to separate build types.
 

--- a/doc/source/user_guide/merging.rst
+++ b/doc/source/user_guide/merging.rst
@@ -525,7 +525,7 @@ Performing an outer join with duplicate join keys in :class:`DataFrame`
 
 .. warning::
 
-  Merging on duplicate keys sigificantly increase the dimensions of the result
+  Merging on duplicate keys significantly increases the dimensions of the result
   and can cause a memory overflow.
 
 .. _merging.validation:

--- a/doc/source/user_guide/reshaping.rst
+++ b/doc/source/user_guide/reshaping.rst
@@ -480,7 +480,7 @@ The values can be cast to a different type using the ``dtype`` argument.
 
 .. versionadded:: 1.5.0
 
-:func:`~pandas.from_dummies` coverts the output of :func:`~pandas.get_dummies` back into
+:func:`~pandas.from_dummies` converts the output of :func:`~pandas.get_dummies` back into
 a :class:`Series` of categorical values from indicator values.
 
 .. ipython:: python

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -950,7 +950,7 @@ def guess_datetime_format(dt_str: str, bint dayfirst=False) -> str | None:
             # the offset is separated into two tokens, ex. ['+', '0900’].
             # This separation will prevent subsequent processing
             # from correctly parsing the time zone format.
-            # So in addition to the format nomalization, we rejoin them here.
+            # So in addition to the format normalization, we rejoin them here.
             try:
                 tokens[offset_index] = parsed_datetime.strftime("%z")
             except ValueError:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -985,7 +985,7 @@ class _LocationIndexer(NDFrameIndexerBase):
         This is only called after a failed call to _getitem_lowerdim.
         """
         retval = self.obj
-        # Selecting columns before rows is signficiantly faster
+        # Selecting columns before rows is significantly faster
         start_val = (self.ndim - len(tup)) + 1
         for i, key in enumerate(reversed(tup)):
             i = self.ndim - i - start_val

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -2722,7 +2722,7 @@ class Styler(StylerRenderer):
              - Boolean
              - ValueError: cannot supply ``subset`` and ``level`` simultaneously.
 
-        Note this method only hides the identifed elements so can be chained to hide
+        Note this method only hides the identified elements so can be chained to hide
         multiple elements in sequence.
 
         Examples

--- a/pandas/tests/frame/constructors/test_from_records.py
+++ b/pandas/tests/frame/constructors/test_from_records.py
@@ -110,7 +110,7 @@ class TestFromRecords:
             columns=df.columns
         )
 
-        # list of tupels (no dtype info)
+        # list of tuples (no dtype info)
         result4 = DataFrame.from_records(lists, columns=columns).reindex(
             columns=df.columns
         )

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -91,7 +91,7 @@ class TestCategoricalIndex:
         )
         tm.assert_frame_equal(df3, expected3)
 
-        # Settig a new row _and_ new column
+        # Setting a new row _and_ new column
         df4 = df.copy()
         df4.loc["d", "C"] = 10
         expected3 = DataFrame(

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -1445,7 +1445,7 @@ def test_make_block_no_pandas_array(block_maker):
         assert result.dtype.kind in ["i", "u"]
         assert result.is_extension is False
 
-        # new_block no longer taked dtype keyword
+        # new_block no longer takes dtype keyword
         # ndarray, NumpyEADtype
         result = block_maker(
             arr.to_numpy(), slice(len(arr)), dtype=arr.dtype, ndim=arr.ndim

--- a/pandas/tests/reshape/concat/test_categorical.py
+++ b/pandas/tests/reshape/concat/test_categorical.py
@@ -220,7 +220,7 @@ class TestCategoricalConcat:
 
     def test_categorical_index_upcast(self):
         # GH 17629
-        # test upcasting to object when concatinating on categorical indexes
+        # test upcasting to object when concatenating on categorical indexes
         # with non-identical categories
 
         a = DataFrame({"foo": [1, 2]}, index=Categorical(["foo", "bar"]))

--- a/pandas/tests/series/methods/test_infer_objects.py
+++ b/pandas/tests/series/methods/test_infer_objects.py
@@ -31,7 +31,7 @@ class TestInferObjects:
         expected = index_or_series([1.0, 2.0, 3.0, np.nan])
         tm.assert_equal(actual, expected)
 
-        # only soft conversions, unconvertable pass thru unchanged
+        # only soft conversions, unconvertible pass thru unchanged
 
         obj = index_or_series(np.array([1, 2, 3, None, "a"], dtype="O"))
         actual = obj.infer_objects()


### PR DESCRIPTION
Mostly in code comments and some in docs.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
