### PR TITLE
TST: Add dedicated test for plt.savefig

### DIFF
--- a/pandas/tests/plotting/common.py
+++ b/pandas/tests/plotting/common.py
@@ -535,9 +535,6 @@ def _check_plot_works(f, default_axes=False, **kwargs):
         for ret in gen_plots(f, fig, **kwargs):
             tm.assert_is_valid_plot_return_object(ret)
 
-        with tm.ensure_clean(return_filelike=True) as path:
-            plt.savefig(path)
-
     finally:
         plt.close(fig)
 

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -1645,9 +1645,6 @@ def _check_plot_works(f, freq=None, series=None, *args, **kwargs):
         ret = f(*args, **kwargs)
         assert ret is not None  # TODO: do something more intelligent
 
-        with tm.ensure_clean(return_filelike=True) as path:
-            plt.savefig(path)
-
         # GH18439, GH#24088, statsmodels#4772
         with tm.ensure_clean(return_filelike=True) as path:
             pickle.dump(fig, path)


### PR DESCRIPTION
I'm observing that testing `plt.savefig` seems to appear redundant over certain plotting types and not necessarily comprehensive over all the supported plotting types. Additionally, by isolating `plt.savefig` testing, I'm seeing a 20 second time save when testing `pandas/tests/plotting`