### PR TITLE
BLD: Bump our C standard to 11

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@ project(
     meson_version: '>=1.2.1',
     default_options: [
         'buildtype=release',
-        'c_std=c99'
+        'c_std=c11'
     ]
 )
 


### PR DESCRIPTION
We're getting Cython compilation errors with Cython < 3 and C99, on the wheel builders.

NOTE: Cython 3 seems to handle this OK.

Let's see if C11 fixes it since we can't go directly to Cython 3 yet.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
