### PR TITLE
REF: avoid altering self.data in get_xticks

### DIFF
--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -1362,6 +1362,7 @@ class TestDataFramePlots:
         assert result[expected][0].get_color() == "C1"
 
     def test_unordered_ts(self):
+        # GH#2609, GH#55906
         index = [date(2012, 10, 1), date(2012, 9, 1), date(2012, 8, 1)]
         values = [3.0, 2.0, 1.0]
         df = DataFrame(

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -1362,16 +1362,26 @@ class TestDataFramePlots:
         assert result[expected][0].get_color() == "C1"
 
     def test_unordered_ts(self):
+        index = [date(2012, 10, 1), date(2012, 9, 1), date(2012, 8, 1)]
+        values = [3.0, 2.0, 1.0]
         df = DataFrame(
-            np.array([3.0, 2.0, 1.0]),
-            index=[date(2012, 10, 1), date(2012, 9, 1), date(2012, 8, 1)],
+            np.array(values),
+            index=index,
             columns=["test"],
         )
         ax = df.plot()
         xticks = ax.lines[0].get_xdata()
-        assert xticks[0] < xticks[1]
+        tm.assert_numpy_array_equal(xticks, np.array(index, dtype=object))
         ydata = ax.lines[0].get_ydata()
-        tm.assert_numpy_array_equal(ydata, np.array([1.0, 2.0, 3.0]))
+        tm.assert_numpy_array_equal(ydata, np.array(values))
+
+        # even though we don't sort the data before passing it to matplotlib,
+        # the ticks are sorted
+        xticks = ax.xaxis.get_ticklabels()
+        xlocs = [x.get_position()[0] for x in xticks]
+        assert pd.Index(xlocs).is_monotonic_increasing
+        xlabels = [x.get_text() for x in xticks]
+        assert pd.to_datetime(xlabels, format="%Y-%m-%d").is_monotonic_increasing
 
     @pytest.mark.parametrize("kind", plotting.PlotAccessor._common_kinds)
     def test_kind_both_ways(self, kind):


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
