### PR TITLE
DOC: convert outdated example of NumPy's broadcasting to literal code block

### DIFF
--- a/doc/source/whatsnew/v0.17.0.rst
+++ b/doc/source/whatsnew/v0.17.0.rst
@@ -727,10 +727,10 @@ be broadcast:
 
 or it can return False if broadcasting can not be done:
 
-.. ipython:: python
-   :okwarning:
+.. code-block:: ipython
 
-   np.array([1, 2, 3]) == np.array([1, 2])
+   In [11]: np.array([1, 2, 3]) == np.array([1, 2])
+   Out[11]: False
 
 Changes to boolean comparisons vs. None
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Similar like https://github.com/pandas-dev/pandas/pull/55427, and breaking this off from https://github.com/pandas-dev/pandas/pull/55885