### PR TITLE
Fix Cython 3.0 regression with time_loc_dups

### DIFF
--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -1,4 +1,5 @@
 cimport cython
+from cpython.sequence cimport PySequence_GetItem
 
 import numpy as np
 
@@ -437,7 +438,7 @@ cdef class IndexEngine:
                     d[val].append(i)
 
         for i in range(n_t):
-            val = targets[i]
+            val = PySequence_GetItem(targets, i)
 
             # ensure there are nas in values before looking for a matching na
             if check_na_values and checknull(val):
@@ -996,7 +997,7 @@ cdef class SharedEngine:
 
         # See also IntervalIndex.get_indexer_pointwise
         for i in range(N):
-            val = targets[i]
+            val = PySequence_GetItem(targets, i)
 
             try:
                 locs = self.get_loc(val)


### PR DESCRIPTION
re https://github.com/pandas-dev/pandas/pull/55179

From discussion in https://github.com/cython/cython/issues/1807#issuecomment-1802656280 it looks like Cython  prior to 3.0 would always use the sequence protocol for indexing with an integral value. However, Python prefers the object protocol first if available, and Cython switched to match that logic with 3.0

NumPy arrays implement both the sequence and the mapping protocol. In cases where we have untyped arrays that fall back to Python calls we will see a performance regression since this will now route through the mapping space

The changes in this PR are not meant to be an exhaustive review of the codebase, rather just a quick POC to reset the time_loc_dups benchmark
