### PR TITLE
Fix off-by-one in aggregations

### DIFF
--- a/pandas/core/indexers/objects.py
+++ b/pandas/core/indexers/objects.py
@@ -109,7 +109,7 @@ class FixedWindowIndexer(BaseIndexer):
 
         end = np.arange(1 + offset, num_values + 1 + offset, step, dtype="int64")
         start = end - self.window_size
-        if closed in ["left", "both"]:
+        if closed in ["left", "both"] or self.window_size == 0:
             start -= 1
         if closed in ["left", "neither"]:
             end -= 1

--- a/pandas/core/indexers/objects.py
+++ b/pandas/core/indexers/objects.py
@@ -102,14 +102,14 @@ class FixedWindowIndexer(BaseIndexer):
         closed: str | None = None,
         step: int | None = None,
     ) -> tuple[np.ndarray, np.ndarray]:
-        if center:
+        if center or self.window_size == 0:
             offset = (self.window_size - 1) // 2
         else:
             offset = 0
 
         end = np.arange(1 + offset, num_values + 1 + offset, step, dtype="int64")
         start = end - self.window_size
-        if closed in ["left", "both"] or self.window_size == 0:
+        if closed in ["left", "both"]:
             start -= 1
         if closed in ["left", "neither"]:
             end -= 1


### PR DESCRIPTION
ref https://github.com/pandas-dev/pandas/issues/55713#issuecomment-1806580402

I'm not super familiar with this function so maybe there is a more intelligent way of doing this. But the segfault occurs when self.window_size == 0 because of these lines:

```python
end = np.arange(1 + offset, num_values + 1 + offset, step, dtype="int64")
start = end - self.window_size
```

In the segfaulting example, `num_values` is 20 for an array with 20 elements. `end` ends up becoming 1-20 as does start with the window_size of 0. Later code then tries to index the 20th index in array, hence the address violation