### PR TITLE
DOC: Clarify DataFrame.dropna lib.no_default kwarg behavior

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6428,7 +6428,7 @@ class DataFrame(NDFrame, OpsMixin):
         inplace: bool = False,
         ignore_index: bool = False,
     ) -> DataFrame | None:
-        """
+        """dropna(self, *, axis = 0, how = 'any', thresh = no_default, subset  = None, inplace = False, ignore_index = False)
         Remove missing values.
 
         See the :ref:`User Guide <missing_data>` for more on which values are


### PR DESCRIPTION
- [x] closes #55848

Changes
<img width="745" alt="Screenshot 2023-11-11 at 9 42 37 PM" src="https://github.com/pandas-dev/pandas/assets/25352646/44286bca-31d8-45dd-a47f-a4697e53098f">

To
<img width="917" alt="Screenshot 2023-11-11 at 9 42 12 PM" src="https://github.com/pandas-dev/pandas/assets/25352646/e53c7b6a-e9a6-48e7-8a3a-dfb518d39990">

by adding one-line function declaration to doc-string per sphinx default autodoc_docstring_signature behavior.