### PR TITLE
BUG: Keep original values when taking with a new fill value

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -349,7 +349,6 @@ Datetimelike
 - Bug in addition or subtraction of very large :class:`Tick` objects with :class:`Timestamp` or :class:`Timedelta` objects raising ``OverflowError`` instead of ``OutOfBoundsTimedelta`` (:issue:`55503`)
 - Bug in creating a :class:`Index`, :class:`Series`, or :class:`DataFrame` with a non-nanosecond :class:`DatetimeTZDtype` and inputs that would be out of bounds with nanosecond resolution incorrectly raising ``OutOfBoundsDatetime`` (:issue:`54620`)
 - Bug in creating a :class:`Index`, :class:`Series`, or :class:`DataFrame` with a non-nanosecond ``datetime64`` dtype and inputs that would be out of bounds for a ``datetime64[ns]`` incorrectly raising ``OutOfBoundsDatetime`` (:issue:`55756`)
-- Bug in taking from a :class:`SparseArray` when using a different fill value than the array's fill value. (:issue:`55181`)
 -
 
 Timedelta
@@ -446,7 +445,7 @@ Reshaping
 
 Sparse
 ^^^^^^
--
+- Bug in :meth:`SparseArray.take` when using a different fill value than the array's fill value (:issue:`55181`)
 -
 
 ExtensionArray

--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -349,6 +349,7 @@ Datetimelike
 - Bug in addition or subtraction of very large :class:`Tick` objects with :class:`Timestamp` or :class:`Timedelta` objects raising ``OverflowError`` instead of ``OutOfBoundsTimedelta`` (:issue:`55503`)
 - Bug in creating a :class:`Index`, :class:`Series`, or :class:`DataFrame` with a non-nanosecond :class:`DatetimeTZDtype` and inputs that would be out of bounds with nanosecond resolution incorrectly raising ``OutOfBoundsDatetime`` (:issue:`54620`)
 - Bug in creating a :class:`Index`, :class:`Series`, or :class:`DataFrame` with a non-nanosecond ``datetime64`` dtype and inputs that would be out of bounds for a ``datetime64[ns]`` incorrectly raising ``OutOfBoundsDatetime`` (:issue:`55756`)
+- Bug in taking from a :class:`SparseArray` when using a different fill value than the array's fill value. (:issue:`55181`)
 -
 
 Timedelta

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1086,9 +1086,10 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
             )
 
         elif self.sp_index.npoints == 0:
-            # Avoid taking from the empty self.sp_values
+            # Use the old fill_value unless we took for an index of -1
             _dtype = np.result_type(self.dtype.subtype, type(fill_value))
             taken = np.full(sp_indexer.shape, fill_value=fill_value, dtype=_dtype)
+            taken[old_fill_indices] = self.fill_value
         else:
             taken = self.sp_values.take(sp_indexer)
 

--- a/pandas/tests/arrays/sparse/test_indexing.py
+++ b/pandas/tests/arrays/sparse/test_indexing.py
@@ -166,15 +166,15 @@ class TestTake:
         tm.assert_sp_array_equal(arr.take([0, 1, 2]), exp)
 
     def test_take_all_empty(self):
-        a = pd.array([0, 0], dtype=SparseDtype("int64"))
-        result = a.take([0, 1], allow_fill=True, fill_value=np.nan)
-        tm.assert_sp_array_equal(a, result)
+        sparse = pd.array([0, 0], dtype=SparseDtype("int64"))
+        result = sparse.take([0, 1], allow_fill=True, fill_value=np.nan)
+        tm.assert_sp_array_equal(sparse, result)
 
     def test_take_different_fill_value(self):
         # Take with a different fill value shouldn't overwrite the original
-        a = pd.array([0.0], dtype=SparseDtype("float64", fill_value=0.0))
-        result = a.take([0, -1], allow_fill=True, fill_value=np.nan)
-        expected = pd.array([0, np.nan], dtype=a.dtype)
+        sparse = pd.array([0.0], dtype=SparseDtype("float64", fill_value=0.0))
+        result = sparse.take([0, -1], allow_fill=True, fill_value=np.nan)
+        expected = pd.array([0, np.nan], dtype=sparse.dtype)
         tm.assert_sp_array_equal(expected, result)
 
     def test_take_fill_value(self):

--- a/pandas/tests/arrays/sparse/test_indexing.py
+++ b/pandas/tests/arrays/sparse/test_indexing.py
@@ -170,6 +170,13 @@ class TestTake:
         result = a.take([0, 1], allow_fill=True, fill_value=np.nan)
         tm.assert_sp_array_equal(a, result)
 
+    def test_take_different_fill_value(self):
+        # Take with a different fill value shouldn't overwrite the original
+        a = pd.array([0.0], dtype=SparseDtype("float64", fill_value=0.0))
+        result = a.take([0, -1], allow_fill=True, fill_value=np.nan)
+        expected = pd.array([0, np.nan], dtype=a.dtype)
+        tm.assert_sp_array_equal(expected, result)
+
     def test_take_fill_value(self):
         data = np.array([1, np.nan, 0, 3, 0])
         sparse = SparseArray(data, fill_value=0)


### PR DESCRIPTION
- [x] closes #55181
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v2.2.0.rst` file if fixing a bug or adding a new feature.

`SparseArray`'s `take` method could mix up the two possible fill values: the array's fill value and the `fill_value` argument provided to `take`. In the case of a non-empty sparse array whose values were all its fill value, `take` would ignore the array's fill value and only use its `fill_value` argument, even for valid indices. The return value would be all `fill_value`, rather than a mix of the two fill values.
