### PR TITLE
ASV: DataFrame.__setitem__ performance with object dtype

### DIFF
--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -515,6 +515,17 @@ class Setitem:
         self.df[[100, 200, 300]] = 100
 
 
+class SetitemObjectDtype:
+    def setup(self):
+        N = 1000
+        cols = 500
+        self.df = DataFrame(index=range(N), columns=range(cols), dtype=object)
+        self.df = DataFrame(np.random.rand(N, cols))
+
+    def time_setitem_object_dtype(self):
+        self.df.loc[0, 1] = 1.0
+
+
 class ChainIndexing:
     params = [None, "warn"]
     param_names = ["mode"]

--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -522,7 +522,6 @@ class SetitemObjectDtype:
         N = 1000
         cols = 500
         self.df = DataFrame(index=range(N), columns=range(cols), dtype=object)
-        self.df = DataFrame(np.random.rand(N, cols))
 
     def time_setitem_object_dtype(self):
         self.df.loc[0, 1] = 1.0

--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -516,6 +516,8 @@ class Setitem:
 
 
 class SetitemObjectDtype:
+    # GH#19299
+
     def setup(self):
         N = 1000
         cols = 500


### PR DESCRIPTION
- [ ] closes #19299 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x]  Added new benchmark SetitemObjectDtype