### PR TITLE
Cython 3.0 faster maybe_convert_objects

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2520,6 +2520,7 @@ def maybe_convert_objects(ndarray[object] objects,
         ndarray[int64_t] ints
         ndarray[uint64_t] uints
         ndarray[uint8_t] bools
+        ndarray[uint8_t] mask
         Seen seen = Seen()
         object val
         _TSObject tsobj


### PR DESCRIPTION
Since mask is a PyObject Cython 3.0 tries to do setting using the mapping protocol, which causes some slowdowns in tight loops.

This probably should have been cdef'ed to begin with anyway though