### PR TITLE
PERF: assert_frame_equal and assert_series_equal for frames/series with a MultiIndex

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -304,6 +304,7 @@ Other Deprecations
 
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
+- Performance improvement in :func:`.testing.assert_frame_equal` and :func:`.testing.assert_series_equal` for objects indexed by a :class:`MultiIndex` (:issue:`55949`)
 - Performance improvement in :func:`concat` with ``axis=1`` and objects with unaligned indexes (:issue:`55084`)
 - Performance improvement in :func:`merge_asof` when ``by`` is not ``None`` (:issue:`55580`, :issue:`55678`)
 - Performance improvement in :func:`read_stata` for files with many variables (:issue:`55515`)

--- a/pandas/_libs/testing.pyx
+++ b/pandas/_libs/testing.pyx
@@ -78,7 +78,7 @@ cpdef assert_almost_equal(a, b,
     robj : str, default None
         Specify right object name being compared, internally used to show
         appropriate assertion message.
-    index_values : ndarray, default None
+    index_values : Index | ndarray, default None
         Specify shared index values of objects being compared, internally used
         to show appropriate assertion message.
 

--- a/pandas/tests/frame/methods/test_value_counts.py
+++ b/pandas/tests/frame/methods/test_value_counts.py
@@ -147,7 +147,7 @@ def test_data_frame_value_counts_dropna_false(nulls_fixture):
         index=pd.MultiIndex(
             levels=[
                 pd.Index(["Anne", "Beth", "John"]),
-                pd.Index(["Louise", "Smith", nulls_fixture]),
+                pd.Index(["Louise", "Smith", np.nan]),
             ],
             codes=[[0, 1, 2, 2], [2, 0, 1, 2]],
             names=["first_name", "middle_name"],


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.2.0.rst` file if fixing a bug or adding a new feature.


```
import pandas as pd

N = 500

dates = pd.date_range("2000-01-01", periods=N)
strings = pd._testing.makeStringIndex(N)

mi = pd.MultiIndex.from_product([dates, strings])

df1 = pd.DataFrame({"a": 1}, index=mi)
df2 = df1.copy(deep=True)

%timeit pd.testing.assert_frame_equal(df1, df2)

# 4.27 s ± 245 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)    -> main
# 10 ms ± 415 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  -> PR
```