### PR TITLE
TST update and simplify consortium api test

### DIFF
--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -337,11 +337,9 @@ def test_dataframe_consortium() -> None:
     expected_1 = ["a", "b"]
     assert result_1 == expected_1
 
-    ser = Series([1, 2, 3])
+    ser = Series([1, 2, 3], name="a")
     col = ser.__column_consortium_standard__()
-    result_2 = col.get_value(1)
-    expected_2 = 2
-    assert result_2 == expected_2
+    assert col.name == "a"
 
 
 def test_xarray_coerce_unit():


### PR DESCRIPTION
It's quite likely that the dataframe api will have a `Scalar` class, and that `Column.get_value` will return that

I'm suggesting to just simplify the test to make an assertion about `Column.name`, which realistically isn't going to change

---

Docs CI failure is unrelated and due to https://github.com/scipy/docs.scipy.org/issues/80