### PR TITLE
CLN: use cimports for type checks

### DIFF
--- a/pandas/_libs/tslibs/util.pxd
+++ b/pandas/_libs/tslibs/util.pxd
@@ -22,6 +22,7 @@ cdef extern from "Python.h":
     object PyUnicode_DecodeLocale(const char *str, const char *errors) nogil
 
 
+cimport numpy as cnp
 from numpy cimport (
     PyArray_Check,
     float64_t,
@@ -54,7 +55,7 @@ cdef inline bint is_integer_object(object obj) noexcept:
     """
     Cython equivalent of
 
-    `isinstance(val, (int, long, np.integer)) and not isinstance(val, bool)`
+    `isinstance(val, (int, np.integer)) and not isinstance(val, (bool, np.timedelta64))`
 
     Parameters
     ----------
@@ -68,13 +69,13 @@ cdef inline bint is_integer_object(object obj) noexcept:
     -----
     This counts np.timedelta64 objects as integers.
     """
-    return (not PyBool_Check(obj) and PyArray_IsIntegerScalar(obj)
+    return (not PyBool_Check(obj) and isinstance(obj, (int, cnp.integer))
             and not is_timedelta64_object(obj))
 
 
 cdef inline bint is_float_object(object obj) noexcept nogil:
     """
-    Cython equivalent of `isinstance(val, (float, np.float64))`
+    Cython equivalent of `isinstance(val, (float, np.floating))`
 
     Parameters
     ----------
@@ -90,7 +91,7 @@ cdef inline bint is_float_object(object obj) noexcept nogil:
 
 cdef inline bint is_complex_object(object obj) noexcept nogil:
     """
-    Cython equivalent of `isinstance(val, (complex, np.complex128))`
+    Cython equivalent of `isinstance(val, (complex, np.complexfloating))`
 
     Parameters
     ----------


### PR DESCRIPTION
The generated C corresponding to the cnp.integer check in is_integer_object is `__Pyx_TypeCheck(__pyx_v_obj, __pyx_ptype_5numpy_integer)` which looks to me like it goes through python-space paths, can you comment @WillAyd ?

Despite that, perf seems neutral-to-improved:

```
import numpy as np
from pandas._libs.lib import is_integer

item1 = 2
item2 = np.int64(1)
item3 = "foo"

%timeit is_integer(item1)
63.6 ns ± 1.17 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)  # <- main
62.9 ns ± 0.992 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)  # <- PR

%timeit is_integer(item2)
70.5 ns ± 2.78 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)  # <- main
68.9 ns ± 1.37 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)  # <- PR

%timeit is_integer(item3)
64.7 ns ± 2.95 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)  # <- main
61.6 ns ± 0.469 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)  # <- PR
```

Also for @WillAyd: we could make similar simplifications in util.is_float_object and util.is_complex_object but that would require removing their `nogil`ness.  IIRC that was something you thought we should do regardless?