### PR TITLE
PERF: assert_produces_warning

### DIFF
--- a/pandas/_testing/_warnings.py
+++ b/pandas/_testing/_warnings.py
@@ -210,8 +210,8 @@ def _assert_raised_with_correct_stacklevel(
     # https://stackoverflow.com/questions/17407119/python-inspect-stack-is-slow
     frame = inspect.currentframe()
     for _ in range(4):
-        frame = frame.f_back
-    caller_filename = inspect.getfile(frame)
+        frame = frame.f_back  # type: ignore[union-attr]
+    caller_filename = inspect.getfile(frame)  # type: ignore[arg-type]
     msg = (
         "Warning not set with correct stacklevel. "
         f"File where warning is raised: {actual_warning.filename} != "

--- a/pandas/_testing/_warnings.py
+++ b/pandas/_testing/_warnings.py
@@ -4,6 +4,7 @@ from contextlib import (
     contextmanager,
     nullcontext,
 )
+import inspect
 import re
 import sys
 from typing import (
@@ -206,15 +207,14 @@ def _is_unexpected_warning(
 def _assert_raised_with_correct_stacklevel(
     actual_warning: warnings.WarningMessage,
 ) -> None:
-    from inspect import (
-        getframeinfo,
-        stack,
-    )
-
-    caller = getframeinfo(stack()[4][0])
+    # https://stackoverflow.com/questions/17407119/python-inspect-stack-is-slow
+    frame = inspect.currentframe()
+    for _ in range(4):
+        frame = frame.f_back
+    caller_filename = inspect.getfile(frame)
     msg = (
         "Warning not set with correct stacklevel. "
         f"File where warning is raised: {actual_warning.filename} != "
-        f"{caller.filename}. Warning message: {actual_warning.message}"
+        f"{caller_filename}. Warning message: {actual_warning.message}"
     )
-    assert actual_warning.filename == caller.filename, msg
+    assert actual_warning.filename == caller_filename, msg


### PR DESCRIPTION
Similar to the implementation in `pandas.util._exceptions.find_stack_level`. 

Seems like it may save a little testing time:

```
> pytest pandas/tests/series/

160.85s  <- main
135.46s  <- PR
```

```
> pytest pandas/tests/arithmetic/

309.48s  <- main
276.90s  <- PR
```
