### PR TITLE
BUG: GroupBy.value_counts sorting order

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -444,6 +444,9 @@ Groupby/resample/rolling
 - Bug in :meth:`DataFrame.resample` not respecting ``closed`` and ``label`` arguments for :class:`~pandas.tseries.offsets.BusinessDay` (:issue:`55282`)
 - Bug in :meth:`DataFrame.resample` where bin edges were not correct for :class:`~pandas.tseries.offsets.BusinessDay` (:issue:`55281`)
 - Bug in :meth:`DataFrame.resample` where bin edges were not correct for :class:`~pandas.tseries.offsets.MonthBegin` (:issue:`55271`)
+- Bug in :meth:`DataFrameGroupBy.value_counts` and :meth:`SeriesGroupBy.value_count` could result in incorrect sorting if the columns of the DataFrame or name of the Series are integers (:issue:`56007`)
+- Bug in :meth:`DataFrameGroupBy.value_counts` and :meth:`SeriesGroupBy.value_count` would not respect ``sort=False`` in :meth:`DataFrame.groupby` and :meth:`Series.groupby` (:issue:`56007`)
+- Bug in :meth:`DataFrameGroupBy.value_counts` and :meth:`SeriesGroupBy.value_count` would sort by proportions rather than frequencies when ``sort=True`` and ``normalize=True`` (:issue:`56007`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2821,9 +2821,9 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             for grouping in groupings
         ):
             levels_list = [ping.result_index for ping in groupings]
-            multi_index, _ = MultiIndex.from_product(
+            multi_index = MultiIndex.from_product(
                 levels_list, names=[ping.name for ping in groupings]
-            ).sortlevel()
+            )
             result_series = result_series.reindex(multi_index, fill_value=0)
 
         if sort:

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2826,6 +2826,22 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             ).sortlevel()
             result_series = result_series.reindex(multi_index, fill_value=0)
 
+        if sort:
+            # Sort by the values
+            result_series = result_series.sort_values(
+                ascending=ascending, kind="stable"
+            )
+        if self.sort:
+            # Sort by the groupings
+            names = result_series.index.names
+            # GH#56007 - Temporarily replace names in case they are integers
+            result_series.index.names = range(len(names))
+            index_level = list(range(len(self.grouper.groupings)))
+            result_series = result_series.sort_index(
+                level=index_level, sort_remaining=False
+            )
+            result_series.index.names = names
+
         if normalize:
             # Normalize the results by dividing by the original group sizes.
             # We are guaranteed to have the first N levels be the
@@ -2844,13 +2860,6 @@ class GroupBy(BaseGroupBy[NDFrameT]):
 
             # Handle groups of non-observed categories
             result_series = result_series.fillna(0.0)
-
-        if sort:
-            # Sort the values and then resort by the main grouping
-            index_level = range(len(self.grouper.groupings))
-            result_series = result_series.sort_values(ascending=ascending).sort_index(
-                level=index_level, sort_remaining=False
-            )
 
         result: Series | DataFrame
         if self.as_index:

--- a/pandas/tests/groupby/methods/test_value_counts.py
+++ b/pandas/tests/groupby/methods/test_value_counts.py
@@ -1183,9 +1183,6 @@ def test_value_counts_integer_columns():
 @pytest.mark.parametrize("normalize", [True, False])
 def test_value_counts_sort(sort, vc_sort, normalize):
     # GH#55951
-    # These values give different results for all four combinations of sort options
-    # and would give a different result if we sorted by normalized values.
-    # However, value_counts only sorts by frequencies.
     df = DataFrame({"a": [2, 1, 1, 1], 0: [3, 4, 3, 3]})
     gb = df.groupby("a", sort=sort)
     result = gb.value_counts(sort=vc_sort, normalize=normalize)

--- a/pandas/tests/groupby/methods/test_value_counts.py
+++ b/pandas/tests/groupby/methods/test_value_counts.py
@@ -1184,7 +1184,7 @@ def test_value_counts_integer_columns():
 def test_value_counts_sort(sort, vc_sort, normalize):
     # GH#55951
     df = DataFrame({"a": [2, 1, 1, 1], 0: [3, 4, 3, 3]})
-    gb = df.groupby("a", sort=sort)
+    gb = df.groupby("a", sort=sort, observed=True)
     result = gb.value_counts(sort=vc_sort, normalize=normalize)
 
     if normalize:
@@ -1203,6 +1203,39 @@ def test_value_counts_sort(sort, vc_sort, normalize):
         taker = [0, 2, 1]
     else:
         taker = [2, 1, 0]
+    expected = expected.take(taker)
+
+    tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("vc_sort", [True, False])
+@pytest.mark.parametrize("normalize", [True, False])
+def test_value_counts_sort_categorical(sort, vc_sort, normalize):
+    # GH#55951
+    df = DataFrame({"a": [2, 1, 1, 1], 0: [3, 4, 3, 3]}, dtype="category")
+    gb = df.groupby("a", sort=sort, observed=True)
+    result = gb.value_counts(sort=vc_sort, normalize=normalize)
+
+    if normalize:
+        values = [2 / 3, 1 / 3, 1.0, 0.0]
+    else:
+        values = [2, 1, 1, 0]
+    name = "proportion" if normalize else "count"
+    expected = DataFrame(
+        {
+            "a": Categorical([1, 1, 2, 2]),
+            0: Categorical([3, 4, 3, 4]),
+            name: values,
+        }
+    ).set_index(["a", 0])[name]
+    if sort and vc_sort:
+        taker = [0, 1, 2, 3]
+    elif sort and not vc_sort:
+        taker = [0, 1, 2, 3]
+    elif not sort and vc_sort:
+        taker = [0, 2, 1, 3]
+    else:
+        taker = [2, 3, 0, 1]
     expected = expected.take(taker)
 
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/groupby/methods/test_value_counts.py
+++ b/pandas/tests/groupby/methods/test_value_counts.py
@@ -1184,7 +1184,7 @@ def test_value_counts_integer_columns():
 def test_value_counts_sort(sort, vc_sort, normalize):
     # GH#55951
     df = DataFrame({"a": [2, 1, 1, 1], 0: [3, 4, 3, 3]})
-    gb = df.groupby("a", sort=sort, observed=True)
+    gb = df.groupby("a", sort=sort)
     result = gb.value_counts(sort=vc_sort, normalize=normalize)
 
     if normalize:


### PR DESCRIPTION
- [x] closes #56007 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
