### PR TITLE
BUG: Bad shift_forward around UTC+0 when DST

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -360,7 +360,7 @@ Timezones
 ^^^^^^^^^
 - Bug in :class:`AbstractHolidayCalendar` where timezone data was not propagated when computing holiday observances (:issue:`54580`)
 - Bug in :class:`Timestamp` construction with an ambiguous value and a ``pytz`` timezone failing to raise ``pytz.AmbiguousTimeError`` (:issue:`55657`)
--
+- Bug in :meth:`Timestamp.tz_localize` with ``nonexistent="shift_forward`` around UTC+0 during DST (:issue:`51501`)
 
 Numeric
 ^^^^^^^

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -418,9 +418,9 @@ timedelta-like}
                     delta_idx = bisect_right_i8(info.tdata, new_local, info.ntrans)
                     if (shift_forward or shift_delta > 0) and \
                        info.deltas[delta_idx-1] >= 0:
-                        delta_idx_offset = 1
-
-                    delta_idx = delta_idx - delta_idx_offset
+                        delta_idx = delta_idx - 1
+                    else:
+                        delta_idx = delta_idx - delta_idx_offset
                     result[i] = new_local - info.deltas[delta_idx]
             elif fill_nonexist:
                 result[i] = NPY_NAT

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -416,8 +416,8 @@ timedelta-like}
 
                 else:
                     delta_idx = bisect_right_i8(info.tdata, new_local, info.ntrans)
-                    # Logic similar to the precompute portion right before this for-loop
-                    # But check the current delta in case we are moving in/out of UTC+0
+                    # Logic similar to the precompute section. But check the current
+                    # delta in case we are moving between UTC+0 and non-zero timezone
                     if (shift_forward or shift_delta > 0) and \
                        info.deltas[delta_idx - 1] >= 0:
                         delta_idx = delta_idx - 1

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -237,7 +237,7 @@ timedelta-like}
         Py_ssize_t i, n = vals.shape[0]
         Py_ssize_t delta_idx_offset, delta_idx
         int64_t v, left, right, val, new_local, remaining_mins
-        int64_t delta
+        int64_t first_delta, delta
         int64_t shift_delta = 0
         ndarray[int64_t] result_a, result_b, dst_hours
         int64_t[::1] result
@@ -327,6 +327,22 @@ timedelta-like}
     if infer_dst:
         dst_hours = _get_dst_hours(vals, result_a, result_b, creso=creso)
 
+    # Pre-compute delta_idx_offset that will be used if we go down non-existent
+    #  paths.
+    # Shift the delta_idx by if the UTC offset of
+    # the target tz is greater than 0 and we're moving forward
+    # or vice versa
+    # TODO: delta_idx_offset and info.deltas are needed for zoneinfo timezones,
+    # but are not applicable for all timezones. Setting the former to 0 and
+    # length checking the latter avoids UB, but this could use a larger refactor
+    delta_idx_offset = 0
+    if len(info.deltas):
+        first_delta = info.deltas[0]
+        if (shift_forward or shift_delta > 0) and first_delta > 0:
+            delta_idx_offset = 1
+        elif (shift_backward or shift_delta < 0) and first_delta < 0:
+            delta_idx_offset = 1
+
     for i in range(n):
         val = vals[i]
         left = result_a[i]
@@ -400,21 +416,9 @@ timedelta-like}
 
                 else:
                     delta_idx = bisect_right_i8(info.tdata, new_local, info.ntrans)
-
-                    # Shift the delta_idx by if the UTC offset of
-                    # the target tz is greater than 0 and we're moving forward
-                    # or vice versa
-                    # TODO: delta_idx_offset and info.deltas are needed for zoneinfo
-                    # timezones, but are not applicable for all timezones. Setting the
-                    # former to 0 and length checking the latter avoids UB, but this
-                    # could use a larger refactor
-                    delta_idx_offset = 0
-                    if len(info.deltas):
-                        delta = info.deltas[delta_idx-1]
-                        if (shift_forward or shift_delta > 0) and delta >= 0:
-                            delta_idx_offset = 1
-                        elif (shift_backward or shift_delta < 0) and delta < 0:
-                            delta_idx_offset = 1
+                    if (shift_forward or shift_delta > 0) and \
+                       info.deltas[delta_idx-1] >= 0:
+                        delta_idx_offset = 1
 
                     delta_idx = delta_idx - delta_idx_offset
                     result[i] = new_local - info.deltas[delta_idx]

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -416,6 +416,9 @@ timedelta-like}
 
                 else:
                     delta_idx = bisect_right_i8(info.tdata, new_local, info.ntrans)
+                    if (shift_forward or shift_delta > 0) and \
+                       info.deltas[delta_idx-1] >= 0:
+                        delta_idx_offset = 1
 
                     delta_idx = delta_idx - delta_idx_offset
                     result[i] = new_local - info.deltas[delta_idx]

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -237,7 +237,7 @@ timedelta-like}
         Py_ssize_t i, n = vals.shape[0]
         Py_ssize_t delta_idx_offset, delta_idx
         int64_t v, left, right, val, new_local, remaining_mins
-        int64_t first_delta, delta
+        int64_t delta
         int64_t shift_delta = 0
         ndarray[int64_t] result_a, result_b, dst_hours
         int64_t[::1] result
@@ -327,22 +327,6 @@ timedelta-like}
     if infer_dst:
         dst_hours = _get_dst_hours(vals, result_a, result_b, creso=creso)
 
-    # Pre-compute delta_idx_offset that will be used if we go down non-existent
-    #  paths.
-    # Shift the delta_idx by if the UTC offset of
-    # the target tz is greater than 0 and we're moving forward
-    # or vice versa
-    # TODO: delta_idx_offset and info.deltas are needed for zoneinfo timezones,
-    # but are not applicable for all timezones. Setting the former to 0 and
-    # length checking the latter avoids UB, but this could use a larger refactor
-    delta_idx_offset = 0
-    if len(info.deltas):
-        first_delta = info.deltas[0]
-        if (shift_forward or shift_delta > 0) and first_delta > 0:
-            delta_idx_offset = 1
-        elif (shift_backward or shift_delta < 0) and first_delta < 0:
-            delta_idx_offset = 1
-
     for i in range(n):
         val = vals[i]
         left = result_a[i]
@@ -416,9 +400,21 @@ timedelta-like}
 
                 else:
                     delta_idx = bisect_right_i8(info.tdata, new_local, info.ntrans)
-                    if (shift_forward or shift_delta > 0) and \
-                       info.deltas[delta_idx-1] >= 0:
-                        delta_idx_offset = 1
+
+                    # Shift the delta_idx by if the UTC offset of
+                    # the target tz is greater than 0 and we're moving forward
+                    # or vice versa
+                    # TODO: delta_idx_offset and info.deltas are needed for zoneinfo
+                    # timezones, but are not applicable for all timezones. Setting the
+                    # former to 0 and length checking the latter avoids UB, but this
+                    # could use a larger refactor
+                    delta_idx_offset = 0
+                    if len(info.deltas):
+                        delta = info.deltas[delta_idx-1]
+                        if (shift_forward or shift_delta > 0) and delta >= 0:
+                            delta_idx_offset = 1
+                        elif (shift_backward or shift_delta < 0) and delta < 0:
+                            delta_idx_offset = 1
 
                     delta_idx = delta_idx - delta_idx_offset
                     result[i] = new_local - info.deltas[delta_idx]

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -416,8 +416,10 @@ timedelta-like}
 
                 else:
                     delta_idx = bisect_right_i8(info.tdata, new_local, info.ntrans)
+                    # Logic similar to the precompute portion right before this for-loop
+                    # But check the current delta in case we are moving in/out of UTC+0
                     if (shift_forward or shift_delta > 0) and \
-                       info.deltas[delta_idx-1] >= 0:
+                       info.deltas[delta_idx - 1] >= 0:
                         delta_idx = delta_idx - 1
                     else:
                         delta_idx = delta_idx - delta_idx_offset

--- a/pandas/tests/scalar/timestamp/methods/test_tz_localize.py
+++ b/pandas/tests/scalar/timestamp/methods/test_tz_localize.py
@@ -123,6 +123,44 @@ class TestTimestampTZLocalize:
             ts.tz_localize(tz, nonexistent="raise")
         assert ts.tz_localize(tz, nonexistent="NaT") is NaT
 
+    @pytest.mark.parametrize(
+        "stamp, tz, forward_expected, backward_expected",
+        [
+            (
+                "2015-03-29 02:00:00",
+                "Europe/Warsaw",
+                "2015-03-29 03:00:00",
+                "2015-03-29 01:59:59",
+            ),  # utc+1 -> utc+2
+            (
+                "2023-03-12 02:00:00",
+                "America/Los_Angeles",
+                "2023-03-12 03:00:00",
+                "2023-03-12 01:59:59",
+            ),  # utc-8 -> utc-7
+            (
+                "2023-03-26 01:00:00",
+                "Europe/London",
+                "2023-03-26 02:00:00",
+                "2023-03-26 00:59:59",
+            ),  # utc+0 -> utc+1
+            (
+                "2023-03-26 00:00:00",
+                "Atlantic/Azores",
+                "2023-03-26 01:00:00",
+                "2023-03-25 23:59:59",
+            ),  # utc-1 -> utc+0
+        ],
+    )
+    def test_tz_localize_nonexistent_shift(
+        self, stamp, tz, forward_expected, backward_expected
+    ):
+        ts = Timestamp(stamp)
+        forward_ts = ts.tz_localize(tz, nonexistent="shift_forward")
+        assert forward_ts == Timestamp(forward_expected, tz=tz)
+        backward_ts = ts.tz_localize(tz, nonexistent="shift_backward")
+        assert backward_ts == Timestamp(backward_expected, tz=tz)
+
     def test_tz_localize_ambiguous_raise(self):
         # GH#13057
         ts = Timestamp("2015-11-1 01:00")


### PR DESCRIPTION
- [ ] closes #51501 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

- The algo originates from https://github.com/pandas-dev/pandas/pull/22644. 
- A related bug fix later in https://github.com/pandas-dev/pandas/pull/23406 but failed to take care of edge cases where we move in/out of UTC+0.
  - The 3rd and 4th test case related to utc+0 all fail on main
- More tests added.
