### PR TITLE
CoW warning mode: setting values into single column of DataFrame

### DIFF
--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -389,6 +389,9 @@ def eval(
             # to use a non-numeric indexer
             try:
                 with warnings.catch_warnings(record=True):
+                    warnings.filterwarnings(
+                        "always", "Setting a value on a view", FutureWarning
+                    )
                     # TODO: Filter the warnings we actually care about here.
                     if inplace and isinstance(target, NDFrame):
                         target.loc[:, assigner] = ret

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4857,6 +4857,7 @@ class DataFrame(NDFrame, OpsMixin):
 
         inplace = validate_bool_kwarg(inplace, "inplace")
         kwargs["level"] = kwargs.pop("level", 0) + 1
+        # TODO(CoW) those index/column resolvers create unnecessary refs to `self`
         index_resolvers = self._get_index_resolvers()
         column_resolvers = self._get_cleaned_column_resolvers()
         resolvers = column_resolvers, index_resolvers

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1737,13 +1737,14 @@ class Block(PandasObject, libinternals.Block):
         # has no attribute "round"
         values = self.values.round(decimals)  # type: ignore[union-attr]
         if values is self.values:
-            refs = self.refs
             if not using_cow:
                 # Normally would need to do this before, but
                 # numpy only returns same array when round operation
                 # is no-op
                 # https://github.com/numpy/numpy/blob/486878b37fc7439a3b2b87747f50db9b62fea8eb/numpy/core/src/multiarray/calculation.c#L625-L636
                 values = values.copy()
+            else:
+                refs = self.refs
         return self.make_block_same_class(values, refs=refs)
 
     # ---------------------------------------------------------------------

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1332,7 +1332,13 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         This is a method on the BlockManager level, to avoid creating an
         intermediate Series at the DataFrame level (`s = df[loc]; s[idx] = value`)
         """
-        if using_copy_on_write() and not self._has_no_reference(loc):
+        if warn_copy_on_write() and not self._has_no_reference(loc):
+            warnings.warn(
+                COW_WARNING_GENERAL_MSG,
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
+        elif using_copy_on_write() and not self._has_no_reference(loc):
             blkno = self.blknos[loc]
             # Split blocks to only copy the column we want to modify
             blk_loc = self.blklocs[loc]

--- a/pandas/tests/copy_view/test_constructors.py
+++ b/pandas/tests/copy_view/test_constructors.py
@@ -242,8 +242,8 @@ def test_dataframe_from_dict_of_series(
     assert np.shares_memory(get_array(result, "a"), get_array(s1))
 
     # mutating the new dataframe doesn't mutate original
-    # TODO(CoW-warn) this should also warn
-    result.iloc[0, 0] = 10
+    with tm.assert_cow_warning(warn_copy_on_write):
+        result.iloc[0, 0] = 10
     if using_copy_on_write:
         assert not np.shares_memory(get_array(result, "a"), get_array(s1))
         tm.assert_series_equal(s1, s1_orig)

--- a/pandas/tests/copy_view/test_core_functionalities.py
+++ b/pandas/tests/copy_view/test_core_functionalities.py
@@ -28,27 +28,32 @@ def test_setitem_dont_track_unnecessary_references(using_copy_on_write):
     assert np.shares_memory(arr, get_array(df, "a"))
 
 
-def test_setitem_with_view_copies(using_copy_on_write):
+def test_setitem_with_view_copies(using_copy_on_write, warn_copy_on_write):
     df = DataFrame({"a": [1, 2, 3], "b": 1, "c": 1})
     view = df[:]
     expected = df.copy()
 
     df["b"] = 100
     arr = get_array(df, "a")
-    df.iloc[0, 0] = 100  # Check that we correctly track reference
+    with tm.assert_cow_warning(warn_copy_on_write):
+        df.iloc[0, 0] = 100  # Check that we correctly track reference
     if using_copy_on_write:
         assert not np.shares_memory(arr, get_array(df, "a"))
         tm.assert_frame_equal(view, expected)
 
 
-def test_setitem_with_view_invalidated_does_not_copy(using_copy_on_write, request):
+def test_setitem_with_view_invalidated_does_not_copy(
+    using_copy_on_write, warn_copy_on_write, request
+):
     df = DataFrame({"a": [1, 2, 3], "b": 1, "c": 1})
     view = df[:]
 
     df["b"] = 100
     arr = get_array(df, "a")
     view = None  # noqa: F841
-    df.iloc[0, 0] = 100
+    # TODO(CoW-warn) false positive?
+    with tm.assert_cow_warning(warn_copy_on_write):
+        df.iloc[0, 0] = 100
     if using_copy_on_write:
         # Setitem split the block. Since the old block shared data with view
         # all the new blocks are referencing view and each other. When view

--- a/pandas/tests/copy_view/test_interp_fillna.py
+++ b/pandas/tests/copy_view/test_interp_fillna.py
@@ -324,11 +324,12 @@ def test_fillna_ea_noop_shares_memory(
 
 
 def test_fillna_inplace_ea_noop_shares_memory(
-    using_copy_on_write, any_numeric_ea_and_arrow_dtype
+    using_copy_on_write, warn_copy_on_write, any_numeric_ea_and_arrow_dtype
 ):
     df = DataFrame({"a": [1, NA, 3], "b": 1}, dtype=any_numeric_ea_and_arrow_dtype)
     df_orig = df.copy()
     view = df[:]
+    # TODO(CoW-warn)
     df.fillna(100, inplace=True)
 
     if isinstance(df["a"].dtype, ArrowDtype) or using_copy_on_write:
@@ -342,7 +343,9 @@ def test_fillna_inplace_ea_noop_shares_memory(
         assert not df._mgr._has_no_reference(1)
         assert not view._mgr._has_no_reference(1)
 
-    df.iloc[0, 1] = 100
+    # TODO(CoW-warn) should this warn for ArrowDtype?
+    with tm.assert_cow_warning(warn_copy_on_write):
+        df.iloc[0, 1] = 100
     if isinstance(df["a"].dtype, ArrowDtype) or using_copy_on_write:
         tm.assert_frame_equal(df_orig, view)
     else:

--- a/pandas/tests/extension/base/setitem.py
+++ b/pandas/tests/extension/base/setitem.py
@@ -402,7 +402,7 @@ class BaseSetitemTests:
 
         orig = df.copy()
 
-        df.iloc[:] = df
+        df.iloc[:] = df.copy()
         tm.assert_frame_equal(df, orig)
 
         df.iloc[:-1] = df.iloc[:-1].copy()

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -561,7 +561,7 @@ class TestDataFrameIndexing:
 
     @td.skip_array_manager_invalid_test  # already covered in test_iloc_col_slice_view
     def test_fancy_getitem_slice_mixed(
-        self, float_frame, float_string_frame, using_copy_on_write
+        self, float_frame, float_string_frame, using_copy_on_write, warn_copy_on_write
     ):
         sliced = float_string_frame.iloc[:, -3:]
         assert sliced["D"].dtype == np.float64
@@ -573,7 +573,8 @@ class TestDataFrameIndexing:
 
         assert np.shares_memory(sliced["C"]._values, float_frame["C"]._values)
 
-        sliced.loc[:, "C"] = 4.0
+        with tm.assert_cow_warning(warn_copy_on_write):
+            sliced.loc[:, "C"] = 4.0
         if not using_copy_on_write:
             assert (float_frame["C"] == 4).all()
 
@@ -1049,7 +1050,7 @@ class TestDataFrameIndexing:
         expected = df.reindex(df.index[[1, 2, 4, 6]])
         tm.assert_frame_equal(result, expected)
 
-    def test_iloc_row_slice_view(self, using_copy_on_write, request):
+    def test_iloc_row_slice_view(self, using_copy_on_write, warn_copy_on_write):
         df = DataFrame(
             np.random.default_rng(2).standard_normal((10, 4)), index=range(0, 20, 2)
         )
@@ -1062,9 +1063,9 @@ class TestDataFrameIndexing:
         assert np.shares_memory(df[2], subset[2])
 
         exp_col = original[2].copy()
-        subset.loc[:, 2] = 0.0
-        if not using_copy_on_write:
+        with tm.assert_cow_warning(warn_copy_on_write):
             subset.loc[:, 2] = 0.0
+        if not using_copy_on_write:
             exp_col._values[4:8] = 0.0
 
             # With the enforcement of GH#45333 in 2.0, this remains a view
@@ -1094,7 +1095,9 @@ class TestDataFrameIndexing:
         expected = df.reindex(columns=df.columns[[1, 2, 4, 6]])
         tm.assert_frame_equal(result, expected)
 
-    def test_iloc_col_slice_view(self, using_array_manager, using_copy_on_write):
+    def test_iloc_col_slice_view(
+        self, using_array_manager, using_copy_on_write, warn_copy_on_write
+    ):
         df = DataFrame(
             np.random.default_rng(2).standard_normal((4, 10)), columns=range(0, 20, 2)
         )
@@ -1105,7 +1108,8 @@ class TestDataFrameIndexing:
             # verify slice is view
             assert np.shares_memory(df[8]._values, subset[8]._values)
 
-            subset.loc[:, 8] = 0.0
+            with tm.assert_cow_warning(warn_copy_on_write):
+                subset.loc[:, 8] = 0.0
 
             assert (df[8] == 0).all()
 
@@ -1388,12 +1392,13 @@ class TestDataFrameIndexing:
         tm.assert_frame_equal(df, expected)
 
     @td.skip_array_manager_invalid_test
-    def test_iloc_setitem_enlarge_no_warning(self):
+    def test_iloc_setitem_enlarge_no_warning(self, warn_copy_on_write):
         # GH#47381
         df = DataFrame(columns=["a", "b"])
         expected = df.copy()
         view = df[:]
-        with tm.assert_produces_warning(None):
+        # TODO(CoW-warn) false positive: shouldn't warn in case of enlargement?
+        with tm.assert_produces_warning(FutureWarning if warn_copy_on_write else None):
             df.iloc[:, 0] = np.array([1, 2], dtype=np.float64)
         tm.assert_frame_equal(view, expected)
 

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -816,7 +816,7 @@ class TestSetitemTZAwareValues:
 
 
 class TestDataFrameSetItemWithExpansion:
-    def test_setitem_listlike_views(self, using_copy_on_write):
+    def test_setitem_listlike_views(self, using_copy_on_write, warn_copy_on_write):
         # GH#38148
         df = DataFrame({"a": [1, 2, 3], "b": [4, 4, 6]})
 
@@ -827,7 +827,8 @@ class TestDataFrameSetItemWithExpansion:
         df[["c", "d"]] = np.array([[0.1, 0.2], [0.3, 0.4], [0.4, 0.5]])
 
         # edit in place the first column to check view semantics
-        df.iloc[0, 0] = 100
+        with tm.assert_cow_warning(warn_copy_on_write):
+            df.iloc[0, 0] = 100
 
         if using_copy_on_write:
             expected = Series([1, 2, 3], name="a")

--- a/pandas/tests/frame/methods/test_diff.py
+++ b/pandas/tests/frame/methods/test_diff.py
@@ -89,7 +89,7 @@ class TestDataFrameDiff:
         # diff on NaT values should give NaT, not timedelta64(0)
         dti = date_range("2016-01-01", periods=4, tz=tz)
         ser = Series(dti)
-        df = ser.to_frame()
+        df = ser.to_frame().copy()
 
         df[1] = ser.copy()
 

--- a/pandas/tests/frame/methods/test_rename.py
+++ b/pandas/tests/frame/methods/test_rename.py
@@ -164,12 +164,13 @@ class TestRename:
         renamed = df.rename(index={"foo1": "foo3", "bar2": "bar3"}, level=0)
         tm.assert_index_equal(renamed.index, new_index)
 
-    def test_rename_nocopy(self, float_frame, using_copy_on_write):
+    def test_rename_nocopy(self, float_frame, using_copy_on_write, warn_copy_on_write):
         renamed = float_frame.rename(columns={"C": "foo"}, copy=False)
 
         assert np.shares_memory(renamed["foo"]._values, float_frame["C"]._values)
 
-        renamed.loc[:, "foo"] = 1.0
+        with tm.assert_cow_warning(warn_copy_on_write):
+            renamed.loc[:, "foo"] = 1.0
         if using_copy_on_write:
             assert not (float_frame["C"] == 1.0).all()
         else:

--- a/pandas/tests/frame/methods/test_to_dict_of_blocks.py
+++ b/pandas/tests/frame/methods/test_to_dict_of_blocks.py
@@ -30,6 +30,7 @@ class TestToDictOfBlocks:
         # make sure we did not change the original DataFrame
         assert _last_df is not None and not _last_df[column].equals(df[column])
 
+    @pytest.mark.filterwarnings("ignore:Setting a value on a view:FutureWarning")
     def test_no_copy_blocks(self, float_frame, using_copy_on_write):
         # GH#9607
         df = DataFrame(float_frame, copy=True)

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -154,13 +154,15 @@ class TestDataFrameUpdate:
         tm.assert_frame_equal(df, expected)
 
     @td.skip_array_manager_invalid_test
-    def test_update_modify_view(self, using_copy_on_write):
+    def test_update_modify_view(self, using_copy_on_write, warn_copy_on_write):
         # GH#47188
         df = DataFrame({"A": ["1", np.nan], "B": ["100", np.nan]})
         df2 = DataFrame({"A": ["a", "x"], "B": ["100", "200"]})
         df2_orig = df2.copy()
         result_view = df2[:]
-        df2.update(df)
+        # TODO(CoW-warn) better warning message
+        with tm.assert_cow_warning(warn_copy_on_write):
+            df2.update(df)
         expected = DataFrame({"A": ["1", "x"], "B": ["100", "200"]})
         tm.assert_frame_equal(df2, expected)
         if using_copy_on_write:

--- a/pandas/tests/groupby/methods/test_nth.py
+++ b/pandas/tests/groupby/methods/test_nth.py
@@ -44,7 +44,9 @@ def test_first_last_nth(df):
     grouped["B"].last()
     grouped["B"].nth(0)
 
+    df = df.copy()
     df.loc[df["A"] == "foo", "B"] = np.nan
+    grouped = df.groupby("A")
     assert isna(grouped["B"].first()["foo"])
     assert isna(grouped["B"].last()["foo"])
     assert isna(grouped["B"].nth(0).iloc[0])

--- a/pandas/tests/groupby/methods/test_quantile.py
+++ b/pandas/tests/groupby/methods/test_quantile.py
@@ -447,8 +447,7 @@ def test_timestamp_groupby_quantile(unit):
 def test_groupby_quantile_dt64tz_period():
     # GH#51373
     dti = pd.date_range("2016-01-01", periods=1000)
-    ser = pd.Series(dti)
-    df = ser.to_frame()
+    df = pd.Series(dti).to_frame().copy()
     df[1] = dti.tz_localize("US/Pacific")
     df[2] = dti.to_period("D")
     df[3] = dti - dti[0]

--- a/pandas/tests/indexing/test_iat.py
+++ b/pandas/tests/indexing/test_iat.py
@@ -41,11 +41,10 @@ def test_iat_setitem_item_cache_cleared(
 
     # previously this iat setting would split the block and fail to clear
     #  the item_cache.
-    with tm.assert_cow_warning(warn_copy_on_write and indexer_ial is tm.iloc):
+    with tm.assert_cow_warning(warn_copy_on_write):
         indexer_ial(df)[7, 0] = 9999
 
-    # TODO(CoW-warn) should also warn for iat?
-    with tm.assert_cow_warning(warn_copy_on_write and indexer_ial is tm.iloc):
+    with tm.assert_cow_warning(warn_copy_on_write):
         indexer_ial(df)[7, 1] = 1234
 
     assert df.iat[7, 1] == 1234

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -850,9 +850,8 @@ class TestiLocBaseIndependent:
 
         # Setting using .loc[:, "a"] sets inplace so alters both sliced and orig
         # depending on CoW
-        # TODO(CoW-warn) this should warn
-        # with tm.assert_cow_warning(warn_copy_on_write):
-        original_df.loc[:, "a"] = [4, 4, 4]
+        with tm.assert_cow_warning(warn_copy_on_write):
+            original_df.loc[:, "a"] = [4, 4, 4]
         if using_copy_on_write:
             assert (sliced_df["a"] == [1, 2, 3]).all()
         else:
@@ -1142,7 +1141,7 @@ class TestiLocBaseIndependent:
         expected = df.take([0], axis=1)
         tm.assert_frame_equal(result, expected)
 
-    def test_iloc_interval(self):
+    def test_iloc_interval(self, warn_copy_on_write):
         # GH#17130
         df = DataFrame({Interval(1, 2): [1, 2]})
 
@@ -1155,7 +1154,9 @@ class TestiLocBaseIndependent:
         tm.assert_series_equal(result, expected)
 
         result = df.copy()
-        result.iloc[:, 0] += 1
+        # TODO(CoW-warn) false positive
+        with tm.assert_cow_warning(warn_copy_on_write):
+            result.iloc[:, 0] += 1
         expected = DataFrame({Interval(1, 2): [2, 3]})
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -828,7 +828,8 @@ class TestLocBaseIndependent:
         df.loc[0, [1, 2]] = [5, 6]
         tm.assert_frame_equal(df, expected)
 
-    def test_loc_setitem_frame_multiples(self):
+    @pytest.mark.filterwarnings("ignore:Setting a value on a view:FutureWarning")
+    def test_loc_setitem_frame_multiples(self, warn_copy_on_write):
         # multiple setting
         df = DataFrame(
             {"A": ["foo", "bar", "baz"], "B": Series(range(3), dtype=np.int64)}
@@ -1097,9 +1098,8 @@ class TestLocBaseIndependent:
 
         # Setting using .loc[:, "a"] sets inplace so alters both sliced and orig
         # depending on CoW
-        # TODO(CoW-warn) should warn
-        # with tm.assert_cow_warning(warn_copy_on_write):
-        original_df.loc[:, "a"] = [4, 4, 4]
+        with tm.assert_cow_warning(warn_copy_on_write):
+            original_df.loc[:, "a"] = [4, 4, 4]
         if using_copy_on_write:
             assert (sliced_df["a"] == [1, 2, 3]).all()
         else:

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -288,6 +288,8 @@ Look,a snake,🐍"""
         ):
             reader(path)
 
+    # TODO(CoW-warn) avoid warnings in the stata reader code
+    @pytest.mark.filterwarnings("ignore:Setting a value on a view:FutureWarning")
     @pytest.mark.parametrize(
         "reader, module, path",
         [

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -721,21 +721,15 @@ class TestParquetPyArrow(Base):
 
     def test_to_bytes_without_path_or_buf_provided(self, pa, df_full):
         # GH 37105
-        msg = "Mismatched null-like values nan and None found"
-        warn = None
-        if using_copy_on_write():
-            warn = FutureWarning
-
         buf_bytes = df_full.to_parquet(engine=pa)
         assert isinstance(buf_bytes, bytes)
 
         buf_stream = BytesIO(buf_bytes)
         res = read_parquet(buf_stream)
 
-        expected = df_full.copy(deep=False)
+        expected = df_full.copy()
         expected.loc[1, "string_with_nan"] = None
-        with tm.assert_produces_warning(warn, match=msg):
-            tm.assert_frame_equal(df_full, res)
+        tm.assert_frame_equal(res, expected)
 
     def test_duplicate_columns(self, pa):
         # not currently able to handle duplicate columns

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -32,6 +32,11 @@ from pandas.io.stata import (
     read_stata,
 )
 
+# TODO(CoW-warn) avoid warnings in the stata reader code
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Setting a value on a view:FutureWarning"
+)
+
 
 @pytest.fixture
 def mixed_frame():
@@ -178,11 +183,13 @@ class TestStata:
         path2 = datapath("io", "data", "stata", "stata2_115.dta")
         path3 = datapath("io", "data", "stata", "stata2_117.dta")
 
-        with tm.assert_produces_warning(UserWarning):
+        # TODO(CoW-warn) avoid warnings in the stata reader code
+        # once fixed -> remove `raise_on_extra_warnings=False` again
+        with tm.assert_produces_warning(UserWarning, raise_on_extra_warnings=False):
             parsed_114 = self.read_dta(path1)
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, raise_on_extra_warnings=False):
             parsed_115 = self.read_dta(path2)
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, raise_on_extra_warnings=False):
             parsed_117 = self.read_dta(path3)
             # FIXME: don't leave commented-out
             # 113 is buggy due to limits of date format support in Stata


### PR DESCRIPTION
Next subtask of https://github.com/pandas-dev/pandas/issues/56019. 

This tackles `mgr.column_setitem`, which is used to set values into a single column (but not setting the full column, so like `df.loc[idx, "col"] = ..`)