### PR TITLE
[Docstring] Update a link to SQLAlchemy documentation to be compatible with 2.0 

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -564,7 +564,7 @@ def read_sql(
         library. If a DBAPI2 object, only sqlite3 is supported. The user is responsible
         for engine disposal and connection closure for the SQLAlchemy connectable; str
         connections are closed automatically. See
-        `here <https://docs.sqlalchemy.org/en/13/core/connections.html>`_.
+        `here <https://docs.sqlalchemy.org/en/20/core/connections.html>`_.
     index_col : str or list of str, optional, default: None
         Column(s) to set as index(MultiIndex).
     coerce_float : bool, default True


### PR DESCRIPTION
While reading that docstring I found that the link to SQLAlchemy documentation was outdated. I propose to change it to link to a documentation of SQLAlchemy version that is actually supported (>=2.0).

Quick search in repo for string `https://docs.sqlalchemy.org/en/13` yields just that single string to be outdated.

Cheers,
Damian