### PR TITLE
TST: de-xfail pyarrow dialect tests

### DIFF
--- a/pandas/tests/io/parser/test_dialect.py
+++ b/pandas/tests/io/parser/test_dialect.py
@@ -16,7 +16,6 @@ import pandas._testing as tm
 pytestmark = pytest.mark.filterwarnings(
     "ignore:Passing a BlockManager to DataFrame:DeprecationWarning"
 )
-xfail_pyarrow = pytest.mark.usefixtures("pyarrow_xfail")
 
 
 @pytest.fixture
@@ -33,7 +32,6 @@ def custom_dialect():
     return dialect_name, dialect_kwargs
 
 
-@xfail_pyarrow  # ValueError: The 'dialect' option is not supported
 def test_dialect(all_parsers):
     parser = all_parsers
     data = """\
@@ -44,6 +42,13 @@ index2,b,d,f
 
     dia = csv.excel()
     dia.quoting = csv.QUOTE_NONE
+
+    if parser.engine == "pyarrow":
+        msg = "The 'dialect' option is not supported with the 'pyarrow' engine"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), dialect=dia)
+        return
+
     df = parser.read_csv(StringIO(data), dialect=dia)
 
     data = """\
@@ -56,7 +61,6 @@ index2,b,d,f
     tm.assert_frame_equal(df, exp)
 
 
-@xfail_pyarrow  # ValueError: The 'dialect' option is not supported
 def test_dialect_str(all_parsers):
     dialect_name = "mydialect"
     parser = all_parsers
@@ -68,6 +72,12 @@ pear:tomato
     exp = DataFrame({"fruit": ["apple", "pear"], "vegetable": ["broccoli", "tomato"]})
 
     with tm.with_csv_dialect(dialect_name, delimiter=":"):
+        if parser.engine == "pyarrow":
+            msg = "The 'dialect' option is not supported with the 'pyarrow' engine"
+            with pytest.raises(ValueError, match=msg):
+                parser.read_csv(StringIO(data), dialect=dialect_name)
+            return
+
         df = parser.read_csv(StringIO(data), dialect=dialect_name)
         tm.assert_frame_equal(df, exp)
 
@@ -84,7 +94,6 @@ def test_invalid_dialect(all_parsers):
         parser.read_csv(StringIO(data), dialect=InvalidDialect)
 
 
-@xfail_pyarrow  # ValueError: The 'dialect' option is not supported
 @pytest.mark.parametrize(
     "arg",
     [None, "doublequote", "escapechar", "skipinitialspace", "quotechar", "quoting"],
@@ -114,6 +123,18 @@ def test_dialect_conflict_except_delimiter(all_parsers, custom_dialect, arg, val
             kwds[arg] = "blah"
 
     with tm.with_csv_dialect(dialect_name, **dialect_kwargs):
+        if parser.engine == "pyarrow":
+            msg = "The 'dialect' option is not supported with the 'pyarrow' engine"
+            with pytest.raises(ValueError, match=msg):
+                parser.read_csv_check_warnings(
+                    # No warning bc we raise
+                    None,
+                    "Conflicting values for",
+                    StringIO(data),
+                    dialect=dialect_name,
+                    **kwds,
+                )
+            return
         result = parser.read_csv_check_warnings(
             warning_klass,
             "Conflicting values for",
@@ -124,7 +145,6 @@ def test_dialect_conflict_except_delimiter(all_parsers, custom_dialect, arg, val
         tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # ValueError: The 'dialect' option is not supported
 @pytest.mark.parametrize(
     "kwargs,warning_klass",
     [
@@ -153,6 +173,18 @@ def test_dialect_conflict_delimiter(all_parsers, custom_dialect, kwargs, warning
     data = "a:b\n1:2"
 
     with tm.with_csv_dialect(dialect_name, **dialect_kwargs):
+        if parser.engine == "pyarrow":
+            msg = "The 'dialect' option is not supported with the 'pyarrow' engine"
+            with pytest.raises(ValueError, match=msg):
+                parser.read_csv_check_warnings(
+                    # no warning bc we raise
+                    None,
+                    "Conflicting values for 'delimiter'",
+                    StringIO(data),
+                    dialect=dialect_name,
+                    **kwargs,
+                )
+            return
         result = parser.read_csv_check_warnings(
             warning_klass,
             "Conflicting values for 'delimiter'",


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
