### PR TITLE
rank function returns int64 when float64 isn't necessary

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9874,7 +9874,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             data = self._get_numeric_data()
         else:
             data = self
-
+        if method != "average" and not pct:
+            temp = ranker(data)
+            temp = temp.convert_dtypes()
+            return temp
         return ranker(data)
 
     @doc(_shared_docs["compare"], klass=_shared_doc_kwargs["klass"])

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -4767,8 +4767,20 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             result = self._python_apply_general(
                 f, self._selected_obj, is_transform=True
             )
+            if method != "average" and not pct:
+                temp = result
+                temp = temp.convert_dtypes()
+                return temp
             return result
-
+        if method != "average" and not pct:
+            temp = self._cython_transform(
+                "rank",
+                numeric_only=False,
+                axis=axis,
+                **kwargs,
+            )
+            temp = temp.convert_dtypes()
+            return temp
         return self._cython_transform(
             "rank",
             numeric_only=False,


### PR DESCRIPTION
- [ ] closes #55598
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Made a few small changes, makes it so when the parameter "method" is anything other than "average" and pct is false, the ranks returned are int64 instead of float64.

122 out of 564 tests failed due to this change, with the majority of cases the issue being:
E       Attribute "dtype" are different
E       [left]:  Int64
E       [right]: float64

That is expected due to the changes, and if this commit is in line with what was expected in the issue #55598 I can change those tests so that they pass.