### PR TITLE
BUG: outer join on equal indexes not sorting

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4653,9 +4653,8 @@ class Index(IndexOpsMixin, PandasObject):
         elif how == "inner":
             join_index = self.intersection(other, sort=sort)
         elif how == "outer":
-            # TODO: sort=True here for backwards compat. It may
-            # be better to use the sort parameter passed into join
             join_index = self.union(other)
+            join_index = _maybe_try_sort(join_index, sort=None)
 
         if sort and how in ["left", "right"]:
             join_index = join_index.sort_values()

--- a/pandas/tests/indexes/datetimes/test_join.py
+++ b/pandas/tests/indexes/datetimes/test_join.py
@@ -32,7 +32,8 @@ class TestJoin:
             r_idx_type="i",
             c_idx_type="dt",
         )
-        cols = df.columns.join(df.index, how="outer")
+        with tm.assert_produces_warning(RuntimeWarning):
+            cols = df.columns.join(df.index, how="outer")
         joined = cols.join(df.columns)
         assert cols.dtype == np.dtype("O")
         assert cols.dtype == joined.dtype
@@ -53,8 +54,11 @@ class TestJoin:
         )
         s = df.iloc[:5, 0]
 
-        expected = df.columns.astype("O").join(s.index, how=join_type)
-        result = df.columns.join(s.index, how=join_type)
+        warning = RuntimeWarning if join_type == "outer" else None
+        with tm.assert_produces_warning(warning):
+            expected = df.columns.astype("O").join(s.index, how=join_type)
+        with tm.assert_produces_warning(warning):
+            result = df.columns.join(s.index, how=join_type)
         tm.assert_index_equal(expected, result)
 
     def test_join_object_index(self):

--- a/pandas/tests/indexes/multi/test_join.py
+++ b/pandas/tests/indexes/multi/test_join.py
@@ -51,8 +51,11 @@ def test_join_level_corner_case(idx):
 
 
 def test_join_self(idx, join_type):
-    joined = idx.join(idx, how=join_type)
-    tm.assert_index_equal(joined, idx)
+    result = idx.join(idx, how=join_type)
+    expected = idx
+    if join_type == "outer":
+        expected = expected.sort_values()
+    tm.assert_index_equal(result, expected)
 
 
 def test_join_multi():
@@ -91,8 +94,12 @@ def test_join_multi():
 
 def test_join_self_unique(idx, join_type):
     if idx.is_unique:
-        joined = idx.join(idx, how=join_type)
-        assert (idx == joined).all()
+        result = idx.join(idx, how=join_type)
+        if join_type == "outer":
+            expected = idx.sort_values()
+        else:
+            expected = idx
+        tm.assert_index_equal(result, expected)
 
 
 def test_join_multi_wrong_order():

--- a/pandas/tests/indexes/period/test_join.py
+++ b/pandas/tests/indexes/period/test_join.py
@@ -44,11 +44,12 @@ class TestJoin:
         )
         ser = df.iloc[:2, 0]
 
-        res = ser.index.join(df.columns, how="outer")
+        with tm.assert_produces_warning(RuntimeWarning):
+            result = ser.index.join(df.columns, how="outer")
         expected = Index(
             [ser.index[0], ser.index[1], df.columns[0], df.columns[1]], object
         )
-        tm.assert_index_equal(res, expected)
+        tm.assert_index_equal(result, expected)
 
     def test_join_mismatched_freq_raises(self):
         index = period_range("1/1/2000", "1/20/2000", freq="D")

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -979,8 +979,11 @@ class TestIndex:
         indirect=True,
     )
     def test_join_self(self, index, join_type):
-        joined = index.join(index, how=join_type)
-        assert index is joined
+        result = index.join(index, how=join_type)
+        expected = index
+        if join_type == "outer":
+            expected = expected.sort_values()
+        tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("method", ["strip", "rstrip", "lstrip"])
     def test_str_attribute(self, method):

--- a/pandas/tests/indexes/test_old_base.py
+++ b/pandas/tests/indexes/test_old_base.py
@@ -30,6 +30,7 @@ from pandas import (
     period_range,
 )
 import pandas._testing as tm
+import pandas.core.algorithms as algos
 from pandas.core.arrays import BaseMaskedArray
 
 
@@ -646,7 +647,10 @@ class TestBase:
         idx = simple_index
         if idx.is_unique:
             joined = idx.join(idx, how=join_type)
-            assert (idx == joined).all()
+            expected = simple_index
+            if join_type == "outer":
+                expected = algos.safe_sort(expected)
+            tm.assert_index_equal(joined, expected)
 
     def test_map(self, simple_index):
         # callable

--- a/pandas/tests/indexes/timedeltas/test_join.py
+++ b/pandas/tests/indexes/timedeltas/test_join.py
@@ -35,7 +35,8 @@ class TestJoin:
             c_idx_type="td",
         )
 
-        cols = df.columns.join(df.index, how="outer")
+        with tm.assert_produces_warning(RuntimeWarning):
+            cols = df.columns.join(df.index, how="outer")
         joined = cols.join(df.columns)
         assert cols.dtype == np.dtype("O")
         assert cols.dtype == joined.dtype

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2913,16 +2913,13 @@ def test_merge_combinations(
             expected = expected["key"].repeat(repeats.values)
             expected = expected.to_frame()
     elif how == "outer":
-        if on_index and left_unique and left["key"].equals(right["key"]):
-            expected = DataFrame({"key": left["key"]})
-        else:
-            left_counts = left["key"].value_counts()
-            right_counts = right["key"].value_counts()
-            expected_counts = left_counts.mul(right_counts, fill_value=1)
-            expected_counts = expected_counts.astype(np.intp)
-            expected = expected_counts.index.values.repeat(expected_counts.values)
-            expected = DataFrame({"key": expected})
-            expected = expected.sort_values("key")
+        left_counts = left["key"].value_counts()
+        right_counts = right["key"].value_counts()
+        expected_counts = left_counts.mul(right_counts, fill_value=1)
+        expected_counts = expected_counts.astype(np.intp)
+        expected = expected_counts.index.values.repeat(expected_counts.values)
+        expected = DataFrame({"key": expected})
+        expected = expected.sort_values("key")
 
     if on_index:
         expected = expected.set_index("key")


### PR DESCRIPTION
- [x] closes #55992
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

