### PR TITLE
MNT: use int instead of long in cython code

### DIFF
--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -639,7 +639,7 @@ cdef tzinfo _parse_with_format(
                 item_reso[0] = NPY_DATETIMEUNIT.NPY_FR_ns
             # Pad to always return nanoseconds
             s += "0" * (9 - len(s))
-            us = long(s)
+            us = int(s)
             ns = us % 1000
             us = us // 1000
         elif parse_code == 11:


### PR DESCRIPTION
https://github.com/cython/cython/pull/5830 /
d7e95912b6ed7d20e190fbf1aecb9f2a997d479 in cython removed long as a valid type in favor of int.

Without this change pandas fails to cythonize under the default branch of cython.


- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
