### PR TITLE
DEPR: correct error message in to_offset

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -58,7 +58,7 @@ from pandas._libs.tslibs.conversion cimport localize_pydatetime
 from pandas._libs.tslibs.dtypes cimport (
     c_DEPR_ABBREVS,
     c_OFFSET_DEPR_FREQSTR,
-    c_OFFSET_TO_PERIOD_FREQSTR,
+    c_REVERSE_OFFSET_DEPR_FREQSTR,
     periods_per_day,
 )
 from pandas._libs.tslibs.nattype cimport (
@@ -4729,17 +4729,19 @@ cpdef to_offset(freq, bint is_period=False):
                         stacklevel=find_stack_level(),
                     )
                     name = c_OFFSET_DEPR_FREQSTR[name]
-                if is_period is True and name in c_OFFSET_TO_PERIOD_FREQSTR:
+                if is_period is True and name in c_REVERSE_OFFSET_DEPR_FREQSTR:
                     if name.startswith("Y"):
                         raise ValueError(
-                            f"for Period, please use "
-                            f"\'Y{c_OFFSET_TO_PERIOD_FREQSTR.get(name)[2:]}\' "
+                            f"for Period, please use \'Y{name[2:]}\' "
                             f"instead of \'{name}\'"
                         )
+                    if (name.startswith("B") or
+                            name.startswith("S") or name.startswith("C")):
+                        raise ValueError(INVALID_FREQ_ERR_MSG.format(name))
                     else:
                         raise ValueError(
                             f"for Period, please use "
-                            f"\'{c_OFFSET_TO_PERIOD_FREQSTR.get(name)}\' "
+                            f"\'{c_REVERSE_OFFSET_DEPR_FREQSTR.get(name)}\' "
                             f"instead of \'{name}\'"
                         )
                 elif is_period is True and name in c_OFFSET_DEPR_FREQSTR:

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -58,7 +58,7 @@ from pandas._libs.tslibs.conversion cimport localize_pydatetime
 from pandas._libs.tslibs.dtypes cimport (
     c_DEPR_ABBREVS,
     c_OFFSET_DEPR_FREQSTR,
-    c_REVERSE_OFFSET_DEPR_FREQSTR,
+    c_OFFSET_TO_PERIOD_FREQSTR,
     periods_per_day,
 )
 from pandas._libs.tslibs.nattype cimport (
@@ -4729,16 +4729,17 @@ cpdef to_offset(freq, bint is_period=False):
                         stacklevel=find_stack_level(),
                     )
                     name = c_OFFSET_DEPR_FREQSTR[name]
-                if is_period is True and name in c_REVERSE_OFFSET_DEPR_FREQSTR:
+                if is_period is True and name in c_OFFSET_TO_PERIOD_FREQSTR:
                     if name.startswith("Y"):
                         raise ValueError(
-                            f"for Period, please use \'Y{name[2:]}\' "
+                            f"for Period, please use "
+                            f"\'Y{c_OFFSET_TO_PERIOD_FREQSTR.get(name)[2:]}\' "
                             f"instead of \'{name}\'"
                         )
                     else:
                         raise ValueError(
                             f"for Period, please use "
-                            f"\'{c_REVERSE_OFFSET_DEPR_FREQSTR.get(name)}\' "
+                            f"\'{c_OFFSET_TO_PERIOD_FREQSTR.get(name)}\' "
                             f"instead of \'{name}\'"
                         )
                 elif is_period is True and name in c_OFFSET_DEPR_FREQSTR:

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -285,10 +285,11 @@ class TestPeriodIndex:
         "freq,freq_depr",
         [
             ("2M", "2ME"),
-            ("2SM", "2SME"),
+            ("2Q-MAR", "2QE-MAR"),
+            ("2Y-FEB", "2YE-FEB"),
         ],
     )
-    def test_period_index_frequency_ME_SME_error_message(self, freq, freq_depr):
+    def test_period_index_frequency_ME_error_message(self, freq, freq_depr):
         # GH#52064
         msg = f"for Period, please use '{freq[1:]}' instead of '{freq_depr[1:]}'"
 
@@ -316,11 +317,10 @@ class TestPeriodIndex:
         series = Series(1, index=index)
         assert isinstance(series, Series)
 
-    @pytest.mark.parametrize("freq_depr", ["2ME", "2QE", "2BQE", "2YE"])
-    def test_period_index_frequency_error_message(self, freq_depr):
+    @pytest.mark.parametrize("freq_depr", ["2SME", "2CBME", "2BYE"])
+    def test_period_index_frequency_invalid_freq(self, freq_depr):
         # GH#9586
-        msg = f"for Period, please use '{freq_depr[1:-1]}' "
-        f"instead of '{freq_depr[1:]}'"
+        msg = f"Invalid frequency: {freq_depr[1:]}"
 
         with pytest.raises(ValueError, match=msg):
             period_range("2020-01", "2020-05", freq=freq_depr)

--- a/pandas/tests/resample/test_period_index.py
+++ b/pandas/tests/resample/test_period_index.py
@@ -956,11 +956,8 @@ class TestPeriodIndex:
         ("2M", "2ME"),
         ("2Q", "2QE"),
         ("2Q-FEB", "2QE-FEB"),
-        ("2BQ", "2BQE"),
-        ("2BQ-FEB", "2BQE-FEB"),
         ("2Y", "2YE"),
         ("2Y-MAR", "2YE-MAR"),
-        ("2BA-MAR", "2BYE-MAR"),
     ],
 )
 def test_resample_frequency_ME_QE_YE_error_message(series_and_frame, freq, freq_depr):
@@ -978,3 +975,22 @@ def test_corner_cases_period(simple_period_range_series):
     # it works
     result = len0pts.resample("Y-DEC").mean()
     assert len(result) == 0
+
+
+@pytest.mark.parametrize(
+    "freq_depr",
+    [
+        "2BME",
+        "2CBME",
+        "2SME",
+        "2BQE-FEB",
+        "2BYE-MAR",
+    ],
+)
+def test_resample_frequency_invalid_freq(series_and_frame, freq_depr):
+    # GH#9586
+    msg = f"Invalid frequency: {freq_depr[1:]}"
+
+    obj = series_and_frame
+    with pytest.raises(ValueError, match=msg):
+        obj.resample(freq_depr)


### PR DESCRIPTION
xref #56050, #55978, #56092

Improved error message when constructing period index with offsets frequencies invalid for period such as “SME" or “BYE-MAR".
the reason: for some renamed offsets frequencies there are not corresponding period frequencies
