### PR TITLE
BUG: round with non-nanosecond raising OverflowError

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -464,6 +464,7 @@ Datetimelike
 - Bug in parsing datetime strings with nanosecond resolution with non-ISO8601 formats incorrectly truncating sub-microsecond components (:issue:`56051`)
 - Bug in parsing datetime strings with sub-second resolution and trailing zeros incorrectly inferring second or millisecond resolution (:issue:`55737`)
 - Bug in the results of :func:`pd.to_datetime` with an floating-dtype argument with ``unit`` not matching the pointwise results of :class:`Timestamp` (:issue:`56037`)
+- Bug in :meth:`Series.dt.round` with non-nanosecond resolution and ``NaT`` entries incorrectly raising ``OverflowError`` (:issue:`??`)
 -
 
 Timedelta

--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -452,6 +452,7 @@ Datetimelike
 - Bug in :meth:`DatetimeIndex.union` returning object dtype for tz-aware indexes with the same timezone but different units (:issue:`55238`)
 - Bug in :meth:`Index.is_monotonic_increasing` and :meth:`Index.is_monotonic_decreasing` always caching :meth:`Index.is_unique` as ``True`` when first value in index is ``NaT`` (:issue:`55755`)
 - Bug in :meth:`Index.view` to a datetime64 dtype with non-supported resolution incorrectly raising (:issue:`55710`)
+- Bug in :meth:`Series.dt.round` with non-nanosecond resolution and ``NaT`` entries incorrectly raising ``OverflowError`` (:issue:`56158`)
 - Bug in :meth:`Tick.delta` with very large ticks raising ``OverflowError`` instead of ``OutOfBoundsTimedelta`` (:issue:`55503`)
 - Bug in ``.astype`` converting from a higher-resolution ``datetime64`` dtype to a lower-resolution ``datetime64`` dtype (e.g. ``datetime64[us]->datetim64[ms]``) silently overflowing with values near the lower implementation bound (:issue:`55979`)
 - Bug in adding or subtracting a :class:`Week` offset to a ``datetime64`` :class:`Series`, :class:`Index`, or :class:`DataFrame` column with non-nanosecond resolution returning incorrect results (:issue:`55583`)
@@ -464,7 +465,6 @@ Datetimelike
 - Bug in parsing datetime strings with nanosecond resolution with non-ISO8601 formats incorrectly truncating sub-microsecond components (:issue:`56051`)
 - Bug in parsing datetime strings with sub-second resolution and trailing zeros incorrectly inferring second or millisecond resolution (:issue:`55737`)
 - Bug in the results of :func:`pd.to_datetime` with an floating-dtype argument with ``unit`` not matching the pointwise results of :class:`Timestamp` (:issue:`56037`)
-- Bug in :meth:`Series.dt.round` with non-nanosecond resolution and ``NaT`` entries incorrectly raising ``OverflowError`` (:issue:`??`)
 -
 
 Timedelta

--- a/pandas/_libs/tslibs/fields.pyx
+++ b/pandas/_libs/tslibs/fields.pyx
@@ -749,7 +749,7 @@ cdef ndarray[int64_t] _rounddown_int64(values, int64_t unit):
     cdef:
         Py_ssize_t i, n = len(values)
         ndarray[int64_t] result = np.empty(n, dtype="i8")
-        int64_t res, value, half, remainder, quotient
+        int64_t res, value, remainder, half
 
     half = unit // 2
 
@@ -761,18 +761,15 @@ cdef ndarray[int64_t] _rounddown_int64(values, int64_t unit):
                 res = NPY_NAT
             else:
                 # This adjustment is the only difference between rounddown_int64
-                #  and _round_nearest_int64
-                value = value - unit // 2
-                quotient, remainder = divmod(value, unit)
-                if remainder > half:
-                    res = value + (unit - remainder)
-                elif remainder == half and quotient % 2:
-                    res = value + (unit - remainder)
+                #  and _ceil_int64
+                value = value - half
+                remainder = value % unit
+                if remainder == 0:
+                    res = value
                 else:
-                    res = value - remainder
+                    res = value + (unit - remainder)
 
             result[i] = res
-
     return result
 
 

--- a/pandas/_libs/tslibs/fields.pyx
+++ b/pandas/_libs/tslibs/fields.pyx
@@ -746,7 +746,34 @@ cdef ndarray[int64_t] _ceil_int64(const int64_t[:] values, int64_t unit):
 
 
 cdef ndarray[int64_t] _rounddown_int64(values, int64_t unit):
-    return _ceil_int64(values - unit // 2, unit)
+    cdef:
+        Py_ssize_t i, n = len(values)
+        ndarray[int64_t] result = np.empty(n, dtype="i8")
+        int64_t res, value, half, remainder, quotient
+
+    half = unit // 2
+
+    with cython.overflowcheck(True):
+        for i in range(n):
+            value = values[i]
+
+            if value == NPY_NAT:
+                res = NPY_NAT
+            else:
+                # This adjustment is the only difference between rounddown_int64
+                #  and _round_nearest_int64
+                value = value - unit // 2
+                quotient, remainder = divmod(value, unit)
+                if remainder > half:
+                    res = value + (unit - remainder)
+                elif remainder == half and quotient % 2:
+                    res = value + (unit - remainder)
+                else:
+                    res = value - remainder
+
+            result[i] = res
+
+    return result
 
 
 cdef ndarray[int64_t] _roundup_int64(values, int64_t unit):

--- a/pandas/tests/series/methods/test_round.py
+++ b/pandas/tests/series/methods/test_round.py
@@ -56,9 +56,10 @@ class TestSeriesRound:
 
     @pytest.mark.parametrize("method", ["round", "floor", "ceil"])
     @pytest.mark.parametrize("freq", ["s", "5s", "min", "5min", "h", "5h"])
-    def test_round_nat(self, method, freq):
+    def test_round_nat(self, method, freq, unit):
         # GH14940
-        ser = Series([pd.NaT])
-        expected = Series(pd.NaT)
+        ser = Series([pd.NaT], dtype=f"M8[{unit}]")
+        expected = Series(pd.NaT, dtype=f"M8[{unit}]")
         round_method = getattr(ser.dt, method)
-        tm.assert_series_equal(round_method(freq), expected)
+        result = round_method(freq)
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/methods/test_round.py
+++ b/pandas/tests/series/methods/test_round.py
@@ -57,7 +57,7 @@ class TestSeriesRound:
     @pytest.mark.parametrize("method", ["round", "floor", "ceil"])
     @pytest.mark.parametrize("freq", ["s", "5s", "min", "5min", "h", "5h"])
     def test_round_nat(self, method, freq, unit):
-        # GH14940
+        # GH14940, GH#56158
         ser = Series([pd.NaT], dtype=f"M8[{unit}]")
         expected = Series(pd.NaT, dtype=f"M8[{unit}]")
         round_method = getattr(ser.dt, method)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
