### PR TITLE
CoW: Remove todos that aren't necessary

### DIFF
--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -476,7 +476,9 @@ with cf.config_prefix("mode"):
         "copy_on_write",
         # Get the default from an environment variable, if set, otherwise defaults
         # to False. This environment variable can be set for testing.
-        "warn",
+        "warn"
+        if os.environ.get("PANDAS_COPY_ON_WRITE", "0") == "warn"
+        else os.environ.get("PANDAS_COPY_ON_WRITE", "0") == "1",
         copy_on_write_doc,
         validator=is_one_of_factory([True, False, "warn"]),
     )

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -476,9 +476,7 @@ with cf.config_prefix("mode"):
         "copy_on_write",
         # Get the default from an environment variable, if set, otherwise defaults
         # to False. This environment variable can be set for testing.
-        "warn"
-        if os.environ.get("PANDAS_COPY_ON_WRITE", "0") == "warn"
-        else os.environ.get("PANDAS_COPY_ON_WRITE", "0") == "1",
+        "warn",
         copy_on_write_doc,
         validator=is_one_of_factory([True, False, "warn"]),
     )

--- a/pandas/tests/apply/test_invalid_arg.py
+++ b/pandas/tests/apply/test_invalid_arg.py
@@ -18,6 +18,7 @@ from pandas import (
     DataFrame,
     Series,
     date_range,
+    notna,
 )
 import pandas._testing as tm
 
@@ -149,6 +150,8 @@ def test_transform_axis_1_raises():
         Series([1]).transform("sum", axis=1)
 
 
+# TODO(CoW-warn) should not need to warn
+@pytest.mark.filterwarnings("ignore:Setting a value on a view:FutureWarning")
 def test_apply_modify_traceback(warn_copy_on_write):
     data = DataFrame(
         {
@@ -201,6 +204,11 @@ def test_apply_modify_traceback(warn_copy_on_write):
 
     def transform(row):
         if row["C"].startswith("shin") and row["A"] == "foo":
+            row["D"] = 7
+        return row
+
+    def transform2(row):
+        if notna(row["C"]) and row["C"].startswith("shin") and row["A"] == "foo":
             row["D"] = 7
         return row
 

--- a/pandas/tests/apply/test_invalid_arg.py
+++ b/pandas/tests/apply/test_invalid_arg.py
@@ -18,7 +18,6 @@ from pandas import (
     DataFrame,
     Series,
     date_range,
-    notna,
 )
 import pandas._testing as tm
 
@@ -150,8 +149,6 @@ def test_transform_axis_1_raises():
         Series([1]).transform("sum", axis=1)
 
 
-# TODO(CoW-warn) should not need to warn
-@pytest.mark.filterwarnings("ignore:Setting a value on a view:FutureWarning")
 def test_apply_modify_traceback():
     data = DataFrame(
         {
@@ -204,11 +201,6 @@ def test_apply_modify_traceback():
 
     def transform(row):
         if row["C"].startswith("shin") and row["A"] == "foo":
-            row["D"] = 7
-        return row
-
-    def transform2(row):
-        if notna(row["C"]) and row["C"].startswith("shin") and row["A"] == "foo":
             row["D"] = 7
         return row
 

--- a/pandas/tests/apply/test_invalid_arg.py
+++ b/pandas/tests/apply/test_invalid_arg.py
@@ -149,7 +149,7 @@ def test_transform_axis_1_raises():
         Series([1]).transform("sum", axis=1)
 
 
-def test_apply_modify_traceback():
+def test_apply_modify_traceback(warn_copy_on_write):
     data = DataFrame(
         {
             "A": [
@@ -206,7 +206,8 @@ def test_apply_modify_traceback():
 
     msg = "'float' object has no attribute 'startswith'"
     with pytest.raises(AttributeError, match=msg):
-        data.apply(transform, axis=1)
+        with tm.assert_cow_warning(warn_copy_on_write):
+            data.apply(transform, axis=1)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/copy_view/test_constructors.py
+++ b/pandas/tests/copy_view/test_constructors.py
@@ -297,7 +297,6 @@ def test_dataframe_from_series_or_index(
     if using_copy_on_write:
         assert not df._mgr._has_no_reference(0)
 
-    # TODO(CoW-warn) should not warn for an index?
     with tm.assert_cow_warning(warn_copy_on_write):
         df.iloc[0, 0] = data[-1]
     if using_copy_on_write:

--- a/pandas/tests/copy_view/test_indexing.py
+++ b/pandas/tests/copy_view/test_indexing.py
@@ -913,7 +913,6 @@ def test_del_frame(backend, using_copy_on_write, warn_copy_on_write):
     tm.assert_frame_equal(df2, df_orig[["a", "c"]])
     df2._mgr._verify_integrity()
 
-    # TODO(CoW-warn) false positive, this should not warn?
     with tm.assert_cow_warning(warn_copy_on_write and dtype_backend == "numpy"):
         df.loc[0, "b"] = 200
     assert np.shares_memory(get_array(df, "a"), get_array(df2, "a"))


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/56019

This should warn, row is a Series and the setitem is inplace then

The Index case is a bug at the moment, creating the df is zero copy, updating the df afterwards will propagate to the index, but will be fixed with CoW

``test_del_frame`` the parent is a single block, we are viewing the same block in df2 even though we deleted column "b"