### PR TITLE
CI: Add CoW warning builds

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -73,6 +73,14 @@ jobs:
             env_file: actions-311.yaml
             pattern: "not slow and not network and not single_cpu"
             pandas_copy_on_write: "warn"
+          - name: "Copy-on-Write 3.10 (warnings)"
+            env_file: actions-310.yaml
+            pattern: "not slow and not network and not single_cpu"
+            pandas_copy_on_write: "warn"
+          - name: "Copy-on-Write 3.9 (warnings)"
+            env_file: actions-39.yaml
+            pattern: "not slow and not network and not single_cpu"
+            pandas_copy_on_write: "warn"
           - name: "Pypy"
             env_file: actions-pypy-39.yaml
             pattern: "not slow and not network and not single_cpu"

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -12450,7 +12450,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         """
         warn = True
         if not PYPY and warn_copy_on_write():
-            if sys.getrefcount(self) <= 4:
+            if sys.getrefcount(self) <= REF_COUNT * 2:
                 # we are probably in an inplace setitem context (e.g. df['a'] += 1)
                 warn = False
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -12450,7 +12450,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         """
         warn = True
         if not PYPY and warn_copy_on_write():
-            if sys.getrefcount(self) <= REF_COUNT * 2:
+            if sys.getrefcount(self) <= 4:
                 # we are probably in an inplace setitem context (e.g. df['a'] += 1)
                 warn = False
 


### PR DESCRIPTION
I am on 3.10 and getting a bunch of failures locally, since we have this reference tracking issues between different python versions I would rather test those in ci