### PR TITLE
DOC: Fix broken link for mamba installation

### DIFF
--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -86,7 +86,7 @@ Before we begin, please:
 Option 1: using mamba (recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Install `mamba <https://mamba.readthedocs.io/en/latest/installation.html>`_
+* Install `mamba <https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html>`_
 * Make sure your mamba is up to date (``mamba update mamba``)
 
 .. code-block:: none


### PR DESCRIPTION
Prior to this change, this link:

https://pandas.pydata.org/docs/dev/development/contributing_environment.html#contributing-mamba
<img width="1051" alt="image" src="https://github.com/pandas-dev/pandas/assets/122238526/aa20e607-a764-49c2-92fc-e32a7c92fae8">

was broken:
![image](https://github.com/pandas-dev/pandas/assets/122238526/b89b4c4d-af1f-4ef0-b0d4-a7d44379bc89)



With this change it now goes here:
![image](https://github.com/pandas-dev/pandas/assets/122238526/44178aaf-5cfe-4da2-9f4f-7f8c7c82d3c3)







- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
