### PR TITLE
DOC: Add clarifications to docs for setting up a development environment

### DIFF
--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -87,9 +87,7 @@ Before we begin, please:
 Option 1: using mamba (recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Install `mamba <https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html>`_
-  (the instructions may direct you to install `miniforge <https://github.com/conda-forge/miniforge>`_,
-  which is OK - it includes mamba)
+* Install miniforge to get `mamba <https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html>`_
 * Make sure your mamba is up to date (``mamba update mamba``)
 * Create and activate the ``pandas-dev`` mamba environment using the following commands:
 

--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -96,14 +96,6 @@ Option 1: using mamba (recommended)
    mamba env create --file environment.yml
    mamba activate pandas-dev
 
-* Ensure any python packages without a version specified in the ``environment.yml`` file
-  in the root directory are the most recent version:
-
-.. code-block:: none
-
-    mamba activate pandas-dev
-    mamba update --all
-
 .. _contributing.pip:
 
 Option 2: using pip

--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -98,8 +98,8 @@ Option 1: using mamba (recommended)
    mamba env create --file environment.yml
    mamba activate pandas-dev
 
-* Ensure any python packages that do not have a version specified in the `environment.yml` file are
-  as up-to-date as possible:
+* Ensure any python packages without a version specified in the ``environment.yml`` file
+  in the root directory are the most recent version:
 
 .. code-block:: none
 

--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -98,6 +98,14 @@ Option 1: using mamba (recommended)
    mamba env create --file environment.yml
    mamba activate pandas-dev
 
+* Ensure any python packages that do not have a version specified in the `environment.yml` file are
+  as up-to-date as possible:
+
+.. code-block:: none
+
+    mamba activate pandas-dev
+    mamba update --all
+
 .. _contributing.pip:
 
 Option 2: using pip

--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -44,8 +44,9 @@ and consult the ``Linux`` instructions below.
 **macOS**
 
 To use the :ref:`mamba <contributing.mamba>`-based compilers, you will need to install the
-Developer Tools using ``xcode-select --install``. Otherwise
-information about compiler installation can be found here:
+Developer Tools using ``xcode-select --install``.
+
+If you prefer to use a different compiler, general information can be found here:
 https://devguide.python.org/setup/#macos
 
 **Linux**
@@ -87,11 +88,13 @@ Option 1: using mamba (recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Install `mamba <https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html>`_
+  (the instructions may direct you to install `miniforge <https://github.com/conda-forge/miniforge>`_,
+  which is OK - it includes mamba)
 * Make sure your mamba is up to date (``mamba update mamba``)
+* Create and activate the ``pandas-dev`` mamba environment using the following commands:
 
 .. code-block:: none
 
-   # Create and activate the build environment
    mamba env create --file environment.yml
    mamba activate pandas-dev
 
@@ -273,12 +276,20 @@ uses to import the extension from the build folder, which may cause errors such 
    You will need to repeat this step each time the C extensions change, for example
    if you modified any file in ``pandas/_libs`` or if you did a fetch and merge from ``upstream/main``.
 
+**Checking the build**
+
 At this point you should be able to import pandas from your locally built version::
 
    $ python
    >>> import pandas
    >>> print(pandas.__version__)  # note: the exact output may differ
    2.0.0.dev0+880.g2b9e661fbb.dirty
+
+
+At this point you may want to try
+`running the test suite <https://pandas.pydata.org/docs/dev/development/contributing_codebase.html#running-the-test-suite>`_.
+
+**Keeping up to date with the latest build**
 
 When building pandas with meson, importing pandas will automatically trigger a rebuild, even when C/Cython files are modified.
 By default, no output will be produced by this rebuild (the import will just take longer). If you would like to see meson's


### PR DESCRIPTION
Hi all - having just been through the setup process (Mac, mamba) and as a non-expert I thought I'd feed back some things that would have made my experience faster and smoother.

---
**Change 1**
- It wasn't 100% clear to me that I did **_not_** need to use any information from the link `https://devguide.python.org/setup/#macos`  (it is clear with hindsight, but it's the initial impression that I'm trying to improve here):

Before this change:
<kbd><img width="750" alt="image" src="https://github.com/pandas-dev/pandas/assets/122238526/c72c8c93-4b70-4918-bdfe-557c859d40a7"></kbd>

After:
<kbd><img width="683" alt="image" src="https://github.com/pandas-dev/pandas/assets/122238526/8025886f-4d85-4987-b29b-398897662035"></kbd>

---
**Change 2**
- I got confused by `mamba` vs `conda`, and that you actually need to install is called `miniforge` - I had a moment of doubt here that I was on the wrong track.

Before this change:
<kbd><img width="617" alt="image" src="https://github.com/pandas-dev/pandas/assets/122238526/bd87599c-30a0-4f88-8a11-087cb8824dbf"></kbd>

<kbd><img width="729" alt="image" src="https://github.com/pandas-dev/pandas/assets/122238526/123675ee-e30e-4385-99b3-5c085613de99"></kbd>

---
**Change 3**
- I found that I had some old packages that were used in my mamba environment (probably from a previous install of mamba - last I played with this was about a year ago). Looking into them, they were packages like `sphinx` that did not have a version pinned in `environment.yml`. This feels like it could be a source of errors for people getting set up.

After:
<kbd><img width="769" alt="image" src="https://github.com/pandas-dev/pandas/assets/122238526/395165e2-3b39-4a5a-9f7f-d377319a2453"></kbd>

---
**Change 4**
- Sounds strange, but I wasn't sure when I was actually 'done' with getting set up.
- I tend to like to run unit tests when I get set up with a new repo.
- I didn't realize that with this setup some of the unit tests (the ones with external dependencies) were expected to fail, as helpfully documented [here](https://pandas.pydata.org/docs/dev/development/contributing_codebase.html#running-the-test-suite).  I feel this is really important - I lost a lot of time because I assumed there must be something wrong with my install because unit tests were failing. By adding the link here hopefully others see this information sooner.

Before this change:
<kbd><img width="776" alt="image" src="https://github.com/pandas-dev/pandas/assets/122238526/7e689a9d-86db-4a28-96f5-46322f33c417"></kbd>


After:
<kbd><img width="791" alt="image" src="https://github.com/pandas-dev/pandas/assets/122238526/079ce0c7-bc8b-4359-a03e-fa4e0f35c71e"></kbd>


---

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
