### PR TITLE
BUG: inferred resolution with ISO8601 and tzoffset

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -468,6 +468,7 @@ Datetimelike
 - Bug in parsing datetime strings with nanosecond resolution with non-ISO8601 formats incorrectly truncating sub-microsecond components (:issue:`56051`)
 - Bug in parsing datetime strings with sub-second resolution and trailing zeros incorrectly inferring second or millisecond resolution (:issue:`55737`)
 - Bug in the results of :func:`pd.to_datetime` with an floating-dtype argument with ``unit`` not matching the pointwise results of :class:`Timestamp` (:issue:`56037`)
+- Bug in :meth:`Timestamp.unit` being inferred incorrectly from an ISO8601 format string with minute or hour resolution and a timezone offset (:issue:`??`)
 -
 
 Timedelta

--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -457,6 +457,7 @@ Datetimelike
 - Bug in :meth:`Index.view` to a datetime64 dtype with non-supported resolution incorrectly raising (:issue:`55710`)
 - Bug in :meth:`Series.dt.round` with non-nanosecond resolution and ``NaT`` entries incorrectly raising ``OverflowError`` (:issue:`56158`)
 - Bug in :meth:`Tick.delta` with very large ticks raising ``OverflowError`` instead of ``OutOfBoundsTimedelta`` (:issue:`55503`)
+- Bug in :meth:`Timestamp.unit` being inferred incorrectly from an ISO8601 format string with minute or hour resolution and a timezone offset (:issue:`56208`)
 - Bug in ``.astype`` converting from a higher-resolution ``datetime64`` dtype to a lower-resolution ``datetime64`` dtype (e.g. ``datetime64[us]->datetim64[ms]``) silently overflowing with values near the lower implementation bound (:issue:`55979`)
 - Bug in adding or subtracting a :class:`Week` offset to a ``datetime64`` :class:`Series`, :class:`Index`, or :class:`DataFrame` column with non-nanosecond resolution returning incorrect results (:issue:`55583`)
 - Bug in addition or subtraction of :class:`BusinessDay` offset with ``offset`` attribute to non-nanosecond :class:`Index`, :class:`Series`, or :class:`DataFrame` column giving incorrect results (:issue:`55608`)
@@ -468,7 +469,6 @@ Datetimelike
 - Bug in parsing datetime strings with nanosecond resolution with non-ISO8601 formats incorrectly truncating sub-microsecond components (:issue:`56051`)
 - Bug in parsing datetime strings with sub-second resolution and trailing zeros incorrectly inferring second or millisecond resolution (:issue:`55737`)
 - Bug in the results of :func:`pd.to_datetime` with an floating-dtype argument with ``unit`` not matching the pointwise results of :class:`Timestamp` (:issue:`56037`)
-- Bug in :meth:`Timestamp.unit` being inferred incorrectly from an ISO8601 format string with minute or hour resolution and a timezone offset (:issue:`??`)
 -
 
 Timedelta

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime_strings.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime_strings.c
@@ -364,6 +364,7 @@ int parse_iso_8601_datetime(const char *str, int len, int want_exc,
     goto parse_error;
   }
   out->hour = (*substr - '0');
+  bestunit = NPY_FR_h;
   ++substr;
   --sublen;
   /* Second digit optional */
@@ -425,6 +426,7 @@ int parse_iso_8601_datetime(const char *str, int len, int want_exc,
   }
   /* First digit required */
   out->min = (*substr - '0');
+  bestunit = NPY_FR_m;
   ++substr;
   --sublen;
   /* Second digit optional if there was a separator */

--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -457,7 +457,7 @@ class TestTimestampResolutionInference:
         assert ts == Timestamp("01-01-2013T00:00:00.000000002+0000")
         assert ts.unit == "ns"
 
-        # minute reso through the ISO8601 path with tz offset
+        # GH#56208 minute reso through the ISO8601 path with tz offset
         ts = Timestamp("2020-01-01 00:00+00:00")
         assert ts.unit == "s"
 

--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -457,6 +457,13 @@ class TestTimestampResolutionInference:
         assert ts == Timestamp("01-01-2013T00:00:00.000000002+0000")
         assert ts.unit == "ns"
 
+        # minute reso through the ISO8601 path with tz offset
+        ts = Timestamp("2020-01-01 00:00+00:00")
+        assert ts.unit == "s"
+
+        ts = Timestamp("2020-01-01 00+00:00")
+        assert ts.unit == "s"
+
 
 class TestTimestampConstructors:
     def test_weekday_but_no_day_raises(self):


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
