### PR TITLE
BUG: DataFrame.update not operating in-place for datetime64[ns, UTC] dtype

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -520,7 +520,7 @@ Indexing
 
 Missing
 ^^^^^^^
--
+- Bug in :meth:`DataFrame.update` wasn't updating in-place for datetime64 dtypes (:issue:`56227`)
 -
 
 MultiIndex

--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -520,7 +520,7 @@ Indexing
 
 Missing
 ^^^^^^^
-- Bug in :meth:`DataFrame.update` wasn't updating in-place for datetime64 dtypes (:issue:`56227`)
+- Bug in :meth:`DataFrame.update` wasn't updating in-place for tz-aware datetime64 dtypes (:issue:`56227`)
 -
 
 MultiIndex

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8838,14 +8838,14 @@ class DataFrame(NDFrame, OpsMixin):
         in the original dataframe.
 
         >>> df = pd.DataFrame({'A': [1, 2, 3],
-        ...                    'B': [400, 500, 600]})
+        ...                    'B': [400., 500., 600.]})
         >>> new_df = pd.DataFrame({'B': [4, np.nan, 6]})
         >>> df.update(new_df)
         >>> df
-           A    B
-        0  1    4
-        1  2  500
-        2  3    6
+           A      B
+        0  1    4.0
+        1  2  500.0
+        2  3    6.0
         """
         if not PYPY and using_copy_on_write():
             if sys.getrefcount(self) <= REF_COUNT:
@@ -8862,8 +8862,6 @@ class DataFrame(NDFrame, OpsMixin):
                     stacklevel=2,
                 )
 
-        from pandas.core.computation import expressions
-
         # TODO: Support other joins
         if join != "left":  # pragma: no cover
             raise NotImplementedError("Only left join is supported")
@@ -8876,8 +8874,8 @@ class DataFrame(NDFrame, OpsMixin):
         other = other.reindex(self.index)
 
         for col in self.columns.intersection(other.columns):
-            this = self[col]._values
-            that = other[col]._values
+            this = self[col]
+            that = other[col]
 
             if filter_func is not None:
                 mask = ~filter_func(this) | isna(that)
@@ -8897,7 +8895,7 @@ class DataFrame(NDFrame, OpsMixin):
             if mask.all():
                 continue
 
-            self.loc[:, col] = expressions.where(mask, this, that)
+            self.loc[:, col] = this.where(mask, that)
 
     # ----------------------------------------------------------------------
     # Data reshaping

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8874,8 +8874,8 @@ class DataFrame(NDFrame, OpsMixin):
         other = other.reindex(self.index)
 
         for col in self.columns.intersection(other.columns):
-            this = self[col]
-            that = other[col]
+            this = self[col]._values
+            that = other[col]._values
 
             if filter_func is not None:
                 mask = ~filter_func(this) | isna(that)
@@ -8895,7 +8895,7 @@ class DataFrame(NDFrame, OpsMixin):
             if mask.all():
                 continue
 
-            self.loc[:, col] = this.where(mask, that)
+            self.loc[:, col] = self[col].where(mask, that)
 
     # ----------------------------------------------------------------------
     # Data reshaping

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -140,12 +140,15 @@ class TestDataFrameUpdate:
         expected = DataFrame([pd.Timestamp("2019", tz="UTC")])
         tm.assert_frame_equal(result, expected)
 
-    def test_update_datetime_tz_in_place(self, using_copy_on_write):
+    def test_update_datetime_tz_in_place(self, using_copy_on_write, warn_copy_on_write):
         # https://github.com/pandas-dev/pandas/issues/56227
         result = DataFrame([pd.Timestamp("2019", tz="UTC")])
         orig = result.copy()
         view = result[:]
-        result.update(result + pd.Timedelta(days=1))
+        with tm.assert_produces_warning(
+            FutureWarning if warn_copy_on_write else None, match="Setting a value"
+        ):
+            result.update(result + pd.Timedelta(days=1))
         expected = DataFrame([pd.Timestamp("2019-01-02", tz="UTC")])
         tm.assert_frame_equal(result, expected)
         if not using_copy_on_write:

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -140,6 +140,19 @@ class TestDataFrameUpdate:
         expected = DataFrame([pd.Timestamp("2019", tz="UTC")])
         tm.assert_frame_equal(result, expected)
 
+    def test_update_datetime_tz_in_place(self, using_copy_on_write):
+        # https://github.com/pandas-dev/pandas/issues/56227
+        result = DataFrame([pd.Timestamp("2019", tz="UTC")])
+        orig = result.copy()
+        view = result[:]
+        result.update(result + pd.Timedelta(days=1))
+        expected = DataFrame([pd.Timestamp("2019-01-02", tz="UTC")])
+        tm.assert_frame_equal(result, expected)
+        if not using_copy_on_write:
+            tm.assert_frame_equal(view, expected)
+        else:
+            tm.assert_frame_equal(view, orig)
+
     def test_update_with_different_dtype(self, using_copy_on_write):
         # GH#3217
         df = DataFrame({"a": [1, 3], "b": [np.nan, 2]})


### PR DESCRIPTION
- [ ] closes #56227 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
