### PR TITLE
ENH: Raise TypeError when converting DatetimeIndex to PeriodIndex with invalid period frequency

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -195,6 +195,7 @@ Other enhancements
 - Allow passing ``read_only``, ``data_only`` and ``keep_links`` arguments to openpyxl using ``engine_kwargs`` of :func:`read_excel` (:issue:`55027`)
 - DataFrame.apply now allows the usage of numba (via ``engine="numba"``) to JIT compile the passed function, allowing for potential speedups (:issue:`54666`)
 - Implement masked algorithms for :meth:`Series.value_counts` (:issue:`54984`)
+- Improved error message that appears in :meth:`DatetimeIndex.to_period` with frequencies which are not supported as period frequencies, such as "BMS" (:issue:`56243`)
 - Improved error message when constructing :class:`Period` with invalid offsets such as "QS" (:issue:`55785`)
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -1179,9 +1179,7 @@ def dt64arr_to_periodarr(
     except (AttributeError, TypeError):
         # AttributeError: _period_dtype_code might not exist
         # TypeError: _period_dtype_code might intentionally raise
-        raise TypeError(
-            f"{(type(freq).__name__)} is not supported as period frequency"
-        )
+        raise TypeError(f"{(type(freq).__name__)} is not supported as period frequency")
     return c_dt64arr_to_periodarr(data.view("i8"), base, tz, reso=reso), freq
 
 

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -1179,7 +1179,7 @@ def dt64arr_to_periodarr(
     except (AttributeError, TypeError):
         # AttributeError: _period_dtype_code might not exist
         # TypeError: _period_dtype_code might intentionally raise
-        raise TypeError(f"{(type(freq).__name__)} is not supported as period frequency")
+        raise TypeError(f"{freq.name} is not supported as period frequency")
     return c_dt64arr_to_periodarr(data.view("i8"), base, tz, reso=reso), freq
 
 

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -1174,7 +1174,14 @@ def dt64arr_to_periodarr(
 
     reso = get_unit_from_dtype(data.dtype)
     freq = Period._maybe_convert_freq(freq)
-    base = freq._period_dtype_code
+    try:
+        base = freq._period_dtype_code
+    except (AttributeError, TypeError):
+        # AttributeError: _period_dtype_code might not exist
+        # TypeError: _period_dtype_code might intentionally raise
+        raise TypeError(
+            f"{(type(freq).__name__)} is not supported as period frequency"
+        )
     return c_dt64arr_to_periodarr(data.view("i8"), base, tz, reso=reso), freq
 
 

--- a/pandas/tests/indexes/datetimes/methods/test_to_period.py
+++ b/pandas/tests/indexes/datetimes/methods/test_to_period.py
@@ -230,3 +230,11 @@ class TestToPeriod:
         idx = DatetimeIndex(["2000-01-01", "2000-01-02", "2000-01-03"])
         assert idx.freqstr is None
         tm.assert_index_equal(idx.to_period(), expected)
+
+    @pytest.mark.parametrize("freq", ["2BMS", "1SME-15"])
+    def test_to_period_offsets_not_supported(self, freq):
+        # GH#56243
+        msg = f"{freq[1:]} is not supported as period frequency"
+        ts = date_range("1/1/2012", periods=4, freq=freq)
+        with pytest.raises(TypeError, match=msg):
+            ts.to_period()


### PR DESCRIPTION
xref #55844

Added to `dt64arr_to_periodarr` check if frequency is supported as period frequency, if not a TypeError is raised.

The reason: so far in the example below
```
>>> ts = pd.date_range('1/1/2012', periods=4, freq="BMS")
>>> ts.to_period()
```
we get
`AttributeError: 'pandas._libs.tslibs.offsets.BusinessMonthBegin' object has no attribute '_period_dtype_code'`
