### PR TITLE
FIX: Solving Int64 precision loss when read_csv(StringIO(data), dtype…

### DIFF
--- a/pandas/io/parsers/arrow_parser_wrapper.py
+++ b/pandas/io/parsers/arrow_parser_wrapper.py
@@ -273,19 +273,6 @@ class ArrowParserWrapper(ParserBase):
 
         dtype_backend = self.kwds["dtype_backend"]
 
-        # Convert all pa.null() cols -> float64 (non nullable)
-        # else Int64 (nullable case, see below)
-        if dtype_backend is lib.no_default:
-            new_schema = table.schema
-            new_type = pa.float64()
-            for i, arrow_type in enumerate(table.schema.types):
-                if pa.types.is_null(arrow_type):
-                    new_schema = new_schema.set(
-                        i, new_schema.field(i).with_type(new_type)
-                    )
-
-            table = table.cast(new_schema)
-
         if dtype_backend == "pyarrow":
             frame = table.to_pandas(types_mapper=pd.ArrowDtype)
         elif dtype_backend == "numpy_nullable":
@@ -298,7 +285,7 @@ class ArrowParserWrapper(ParserBase):
             frame = table.to_pandas(types_mapper=arrow_string_types_mapper())
         else:
             if isinstance(self.kwds.get("dtype"), dict):
-                frame = table.to_pandas(types_mapper=self.kwds["dtype"].get)
+                frame = table.to_pandas(types_mapper=self.kwds["dtype"].get, integer_object_nulls=True)
             else:
                 frame = table.to_pandas()
         return self._finalize_pandas_output(frame)

--- a/pandas/io/parsers/arrow_parser_wrapper.py
+++ b/pandas/io/parsers/arrow_parser_wrapper.py
@@ -298,7 +298,7 @@ class ArrowParserWrapper(ParserBase):
             frame = table.to_pandas(types_mapper=arrow_string_types_mapper())
         else:
             if isinstance(self.kwds.get("dtype"), dict):
-                frame = table.to_pandas(types_mapper=self.kwds["dtype"].get, integer_object_nulls=True)
+                frame = table.to_pandas(types_mapper=self.kwds["dtype"].get)
             else:
                 frame = table.to_pandas()
         return self._finalize_pandas_output(frame)


### PR DESCRIPTION
…={a:Int64}, engine=pyarrow)

- [] closes #56135 and #56136
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.


Enable the integer_object_nulls option by setting it to True in the following line of code in the "arrow_parser_wrapper.py" file:
table.to_pandas(types_mapper=self.kwds["dtype"].get, integer_object_nulls=True)
This adjustment is crucial when using the "pyarrow" engine as a parameter for the 'read_csv' function. It ensures that columns containing integers (Int64) with null elements within a dataframe maintain their precision. Without this setting, numpy may treat columns with null elements by converting the entire column data to Float, leading to precision loss. Enabling 'integer_object_nulls' prevents this issue and preserves the precision of integer data.