### PR TITLE
Less C89, most const, static funcs

### DIFF
--- a/pandas/_libs/src/vendored/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/vendored/ujson/python/objToJSON.c
@@ -146,12 +146,10 @@ typedef struct __PyObjectEncoder {
 
 enum PANDAS_FORMAT { SPLIT, RECORDS, INDEX, COLUMNS, VALUES };
 
-int PdBlock_iterNext(JSOBJ, JSONTypeContext *);
+static int PdBlock_iterNext(JSOBJ, JSONTypeContext *);
 
 static TypeContext *createTypeContext(void) {
-  TypeContext *pc;
-
-  pc = PyObject_Malloc(sizeof(TypeContext));
+  TypeContext *pc = PyObject_Malloc(sizeof(TypeContext));
   if (!pc) {
     PyErr_NoMemory();
     return NULL;
@@ -235,12 +233,10 @@ static PyObject *get_values(PyObject *obj) {
 
 static PyObject *get_sub_attr(PyObject *obj, char *attr, char *subAttr) {
   PyObject *tmp = PyObject_GetAttrString(obj, attr);
-  PyObject *ret;
-
   if (tmp == 0) {
     return 0;
   }
-  ret = PyObject_GetAttrString(tmp, subAttr);
+  PyObject *ret = PyObject_GetAttrString(tmp, subAttr);
   Py_DECREF(tmp);
 
   return ret;
@@ -248,12 +244,10 @@ static PyObject *get_sub_attr(PyObject *obj, char *attr, char *subAttr) {
 
 static Py_ssize_t get_attr_length(PyObject *obj, char *attr) {
   PyObject *tmp = PyObject_GetAttrString(obj, attr);
-  Py_ssize_t ret;
-
   if (tmp == 0) {
     return 0;
   }
-  ret = PyObject_Length(tmp);
+  Py_ssize_t ret = PyObject_Length(tmp);
   Py_DECREF(tmp);
 
   if (ret == -1) {
@@ -266,9 +260,8 @@ static Py_ssize_t get_attr_length(PyObject *obj, char *attr) {
 static npy_int64 get_long_attr(PyObject *o, const char *attr) {
   // NB we are implicitly assuming that o is a Timedelta or Timestamp, or NaT
 
-  npy_int64 long_val;
   PyObject *value = PyObject_GetAttrString(o, attr);
-  long_val =
+  const npy_int64 long_val =
       (PyLong_Check(value) ? PyLong_AsLongLong(value) : PyLong_AsLong(value));
 
   Py_DECREF(value);
@@ -293,20 +286,19 @@ static npy_int64 get_long_attr(PyObject *o, const char *attr) {
   }
 
   if (cReso == NPY_FR_us) {
-    long_val = long_val * 1000L;
+    return long_val * 1000L;
   } else if (cReso == NPY_FR_ms) {
-    long_val = long_val * 1000000L;
+    return long_val * 1000000L;
   } else if (cReso == NPY_FR_s) {
-    long_val = long_val * 1000000000L;
+    return long_val * 1000000000L;
   }
 
   return long_val;
 }
 
 static npy_float64 total_seconds(PyObject *td) {
-  npy_float64 double_val;
   PyObject *value = PyObject_CallMethod(td, "total_seconds", NULL);
-  double_val = PyFloat_AS_DOUBLE(value);
+  const npy_float64 double_val = PyFloat_AS_DOUBLE(value);
   Py_DECREF(value);
   return double_val;
 }
@@ -361,10 +353,7 @@ static char *PyDateTimeToIsoCallback(JSOBJ obj, JSONTypeContext *tc,
 
 static char *PyTimeToJSON(JSOBJ _obj, JSONTypeContext *tc, size_t *outLen) {
   PyObject *obj = (PyObject *)_obj;
-  PyObject *str;
-  PyObject *tmp;
-
-  str = PyObject_CallMethod(obj, "isoformat", NULL);
+  PyObject *str = PyObject_CallMethod(obj, "isoformat", NULL);
   if (str == NULL) {
     *outLen = 0;
     if (!PyErr_Occurred()) {
@@ -374,7 +363,7 @@ static char *PyTimeToJSON(JSOBJ _obj, JSONTypeContext *tc, size_t *outLen) {
     return NULL;
   }
   if (PyUnicode_Check(str)) {
-    tmp = str;
+    PyObject *tmp = str;
     str = PyUnicode_AsUTF8String(str);
     Py_DECREF(tmp);
   }
@@ -398,21 +387,16 @@ static void NpyArr_freeItemValue(JSOBJ Py_UNUSED(_obj), JSONTypeContext *tc) {
   }
 }
 
-int NpyArr_iterNextNone(JSOBJ Py_UNUSED(_obj), JSONTypeContext *Py_UNUSED(tc)) {
+static int NpyArr_iterNextNone(JSOBJ Py_UNUSED(_obj),
+                               JSONTypeContext *Py_UNUSED(tc)) {
   return 0;
 }
 
-void NpyArr_iterBegin(JSOBJ _obj, JSONTypeContext *tc) {
-  PyArrayObject *obj;
-  NpyArrContext *npyarr;
+static void NpyArr_iterBegin(JSOBJ _obj, JSONTypeContext *tc) {
+  PyArrayObject *obj =
+      (PyArrayObject *)(GET_TC(tc)->newObj ? GET_TC(tc)->newObj : _obj);
 
-  if (GET_TC(tc)->newObj) {
-    obj = (PyArrayObject *)GET_TC(tc)->newObj;
-  } else {
-    obj = (PyArrayObject *)_obj;
-  }
-
-  npyarr = PyObject_Malloc(sizeof(NpyArrContext));
+  NpyArrContext *npyarr = PyObject_Malloc(sizeof(NpyArrContext));
   GET_TC(tc)->npyarr = npyarr;
 
   if (!npyarr) {
@@ -446,7 +430,7 @@ void NpyArr_iterBegin(JSOBJ _obj, JSONTypeContext *tc) {
   npyarr->rowLabels = GET_TC(tc)->rowLabels;
 }
 
-void NpyArr_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
+static void NpyArr_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
   NpyArrContext *npyarr = GET_TC(tc)->npyarr;
 
   if (npyarr) {
@@ -455,10 +439,10 @@ void NpyArr_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
   }
 }
 
-void NpyArrPassThru_iterBegin(JSOBJ Py_UNUSED(obj),
-                              JSONTypeContext *Py_UNUSED(tc)) {}
+static void NpyArrPassThru_iterBegin(JSOBJ Py_UNUSED(obj),
+                                     JSONTypeContext *Py_UNUSED(tc)) {}
 
-void NpyArrPassThru_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
+static void NpyArrPassThru_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
   NpyArrContext *npyarr = GET_TC(tc)->npyarr;
   // finished this dimension, reset the data pointer
   npyarr->curdim--;
@@ -471,7 +455,7 @@ void NpyArrPassThru_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
   NpyArr_freeItemValue(obj, tc);
 }
 
-int NpyArr_iterNextItem(JSOBJ obj, JSONTypeContext *tc) {
+static int NpyArr_iterNextItem(JSOBJ obj, JSONTypeContext *tc) {
   NpyArrContext *npyarr = GET_TC(tc)->npyarr;
 
   if (PyErr_Occurred()) {
@@ -503,7 +487,7 @@ int NpyArr_iterNextItem(JSOBJ obj, JSONTypeContext *tc) {
   return 1;
 }
 
-int NpyArr_iterNext(JSOBJ _obj, JSONTypeContext *tc) {
+static int NpyArr_iterNext(JSOBJ _obj, JSONTypeContext *tc) {
   NpyArrContext *npyarr = GET_TC(tc)->npyarr;
 
   if (PyErr_Occurred()) {
@@ -531,21 +515,20 @@ int NpyArr_iterNext(JSOBJ _obj, JSONTypeContext *tc) {
   return 1;
 }
 
-JSOBJ NpyArr_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static JSOBJ NpyArr_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   return GET_TC(tc)->itemValue;
 }
 
-char *NpyArr_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
-                         size_t *outLen) {
+static char *NpyArr_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
+                                size_t *outLen) {
   NpyArrContext *npyarr = GET_TC(tc)->npyarr;
-  npy_intp idx;
   char *cStr;
 
   if (GET_TC(tc)->iterNext == NpyArr_iterNextItem) {
-    idx = npyarr->index[npyarr->stridedim] - 1;
+    const npy_intp idx = npyarr->index[npyarr->stridedim] - 1;
     cStr = npyarr->columnLabels[idx];
   } else {
-    idx = npyarr->index[npyarr->stridedim - npyarr->inc] - 1;
+    const npy_intp idx = npyarr->index[npyarr->stridedim - npyarr->inc] - 1;
     cStr = npyarr->rowLabels[idx];
   }
 
@@ -563,7 +546,7 @@ char *NpyArr_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
 // Uses a dedicated NpyArrContext for each column.
 //=============================================================================
 
-void PdBlockPassThru_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
+static void PdBlockPassThru_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
   PdBlockContext *blkCtxt = GET_TC(tc)->pdblock;
 
   if (blkCtxt->transpose) {
@@ -575,7 +558,7 @@ void PdBlockPassThru_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
   NpyArr_freeItemValue(obj, tc);
 }
 
-int PdBlock_iterNextItem(JSOBJ obj, JSONTypeContext *tc) {
+static int PdBlock_iterNextItem(JSOBJ obj, JSONTypeContext *tc) {
   PdBlockContext *blkCtxt = GET_TC(tc)->pdblock;
 
   if (blkCtxt->colIdx >= blkCtxt->ncols) {
@@ -587,20 +570,20 @@ int PdBlock_iterNextItem(JSOBJ obj, JSONTypeContext *tc) {
   return NpyArr_iterNextItem(obj, tc);
 }
 
-char *PdBlock_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
-                          size_t *outLen) {
+static char *PdBlock_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
+                                 size_t *outLen) {
   PdBlockContext *blkCtxt = GET_TC(tc)->pdblock;
   NpyArrContext *npyarr = blkCtxt->npyCtxts[0];
-  npy_intp idx;
   char *cStr;
 
   if (GET_TC(tc)->iterNext == PdBlock_iterNextItem) {
-    idx = blkCtxt->colIdx - 1;
+    const npy_intp idx = blkCtxt->colIdx - 1;
     cStr = npyarr->columnLabels[idx];
   } else {
-    idx = GET_TC(tc)->iterNext != PdBlock_iterNext
-              ? npyarr->index[npyarr->stridedim - npyarr->inc] - 1
-              : npyarr->index[npyarr->stridedim];
+    const npy_intp idx =
+        GET_TC(tc)->iterNext != PdBlock_iterNext
+            ? npyarr->index[npyarr->stridedim - npyarr->inc] - 1
+            : npyarr->index[npyarr->stridedim];
 
     cStr = npyarr->rowLabels[idx];
   }
@@ -609,18 +592,18 @@ char *PdBlock_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
   return cStr;
 }
 
-char *PdBlock_iterGetName_Transpose(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
-                                    size_t *outLen) {
+static char *PdBlock_iterGetName_Transpose(JSOBJ Py_UNUSED(obj),
+                                           JSONTypeContext *tc,
+                                           size_t *outLen) {
   PdBlockContext *blkCtxt = GET_TC(tc)->pdblock;
   NpyArrContext *npyarr = blkCtxt->npyCtxts[blkCtxt->colIdx];
-  npy_intp idx;
   char *cStr;
 
   if (GET_TC(tc)->iterNext == NpyArr_iterNextItem) {
-    idx = npyarr->index[npyarr->stridedim] - 1;
+    const npy_intp idx = npyarr->index[npyarr->stridedim] - 1;
     cStr = npyarr->columnLabels[idx];
   } else {
-    idx = blkCtxt->colIdx;
+    const npy_intp idx = blkCtxt->colIdx;
     cStr = npyarr->rowLabels[idx];
   }
 
@@ -628,9 +611,8 @@ char *PdBlock_iterGetName_Transpose(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
   return cStr;
 }
 
-int PdBlock_iterNext(JSOBJ obj, JSONTypeContext *tc) {
+static int PdBlock_iterNext(JSOBJ obj, JSONTypeContext *tc) {
   PdBlockContext *blkCtxt = GET_TC(tc)->pdblock;
-  NpyArrContext *npyarr;
 
   if (PyErr_Occurred() || ((JSONObjectEncoder *)tc->encoder)->errorMsg) {
     return 0;
@@ -641,7 +623,7 @@ int PdBlock_iterNext(JSOBJ obj, JSONTypeContext *tc) {
       return 0;
     }
   } else {
-    npyarr = blkCtxt->npyCtxts[0];
+    const NpyArrContext *npyarr = blkCtxt->npyCtxts[0];
     if (npyarr->index[npyarr->stridedim] >= npyarr->dim) {
       return 0;
     }
@@ -653,7 +635,8 @@ int PdBlock_iterNext(JSOBJ obj, JSONTypeContext *tc) {
   return 1;
 }
 
-void PdBlockPassThru_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static void PdBlockPassThru_iterBegin(JSOBJ Py_UNUSED(obj),
+                                      JSONTypeContext *tc) {
   PdBlockContext *blkCtxt = GET_TC(tc)->pdblock;
 
   if (blkCtxt->transpose) {
@@ -664,19 +647,14 @@ void PdBlockPassThru_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   }
 }
 
-void PdBlock_iterBegin(JSOBJ _obj, JSONTypeContext *tc) {
-  PyObject *obj, *values, *arrays, *array;
-  PdBlockContext *blkCtxt;
-  NpyArrContext *npyarr;
-  Py_ssize_t i;
-
-  obj = (PyObject *)_obj;
+static void PdBlock_iterBegin(JSOBJ _obj, JSONTypeContext *tc) {
+  PyObject *obj = (PyObject *)_obj;
 
   GET_TC(tc)->iterGetName = GET_TC(tc)->transpose
                                 ? PdBlock_iterGetName_Transpose
                                 : PdBlock_iterGetName;
 
-  blkCtxt = PyObject_Malloc(sizeof(PdBlockContext));
+  PdBlockContext *blkCtxt = PyObject_Malloc(sizeof(PdBlockContext));
   if (!blkCtxt) {
     PyErr_NoMemory();
     GET_TC(tc)->iterNext = NpyArr_iterNextNone;
@@ -702,21 +680,21 @@ void PdBlock_iterBegin(JSOBJ _obj, JSONTypeContext *tc) {
     return;
   }
 
-  arrays = get_sub_attr(obj, "_mgr", "column_arrays");
+  PyObject *arrays = get_sub_attr(obj, "_mgr", "column_arrays");
   if (!arrays) {
     GET_TC(tc)->iterNext = NpyArr_iterNextNone;
     return;
   }
 
-  for (i = 0; i < PyObject_Length(arrays); i++) {
-    array = PyList_GET_ITEM(arrays, i);
+  for (Py_ssize_t i = 0; i < PyObject_Length(arrays); i++) {
+    PyObject *array = PyList_GET_ITEM(arrays, i);
     if (!array) {
       GET_TC(tc)->iterNext = NpyArr_iterNextNone;
       goto ARR_RET;
     }
 
     // ensure we have a numpy array (i.e. np.asarray)
-    values = PyObject_CallMethod(array, "__array__", NULL);
+    PyObject *values = PyObject_CallMethod(array, "__array__", NULL);
     if ((!values) || (!PyArray_CheckExact(values))) {
       // Didn't get a numpy array
       ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
@@ -728,12 +706,11 @@ void PdBlock_iterBegin(JSOBJ _obj, JSONTypeContext *tc) {
 
     // init a dedicated context for this column
     NpyArr_iterBegin(obj, tc);
-    npyarr = GET_TC(tc)->npyarr;
 
     GET_TC(tc)->itemValue = NULL;
     ((PyObjectEncoder *)tc->encoder)->npyCtxtPassthru = NULL;
 
-    blkCtxt->npyCtxts[i] = npyarr;
+    blkCtxt->npyCtxts[i] = GET_TC(tc)->npyarr;
     GET_TC(tc)->newObj = NULL;
   }
   GET_TC(tc)->npyarr = blkCtxt->npyCtxts[0];
@@ -743,18 +720,13 @@ ARR_RET:
   Py_DECREF(arrays);
 }
 
-void PdBlock_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
-  PdBlockContext *blkCtxt;
-  NpyArrContext *npyarr;
-  int i;
-
+static void PdBlock_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
   GET_TC(tc)->itemValue = NULL;
-  npyarr = GET_TC(tc)->npyarr;
-
-  blkCtxt = GET_TC(tc)->pdblock;
+  NpyArrContext *npyarr = GET_TC(tc)->npyarr;
+  PdBlockContext *blkCtxt = GET_TC(tc)->pdblock;
 
   if (blkCtxt) {
-    for (i = 0; i < blkCtxt->ncols; i++) {
+    for (int i = 0; i < blkCtxt->ncols; i++) {
       npyarr = blkCtxt->npyCtxts[i];
       if (npyarr) {
         if (npyarr->array) {
@@ -780,34 +752,35 @@ void PdBlock_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
 // Tuple iteration functions
 // itemValue is borrowed reference, no ref counting
 //=============================================================================
-void Tuple_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
+static void Tuple_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
   GET_TC(tc)->index = 0;
   GET_TC(tc)->size = PyTuple_GET_SIZE((PyObject *)obj);
   GET_TC(tc)->itemValue = NULL;
 }
 
-int Tuple_iterNext(JSOBJ obj, JSONTypeContext *tc) {
-  PyObject *item;
+static int Tuple_iterNext(JSOBJ obj, JSONTypeContext *tc) {
 
   if (GET_TC(tc)->index >= GET_TC(tc)->size) {
     return 0;
   }
 
-  item = PyTuple_GET_ITEM(obj, GET_TC(tc)->index);
+  PyObject *item = PyTuple_GET_ITEM(obj, GET_TC(tc)->index);
 
   GET_TC(tc)->itemValue = item;
   GET_TC(tc)->index++;
   return 1;
 }
 
-void Tuple_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *Py_UNUSED(tc)) {}
+static void Tuple_iterEnd(JSOBJ Py_UNUSED(obj),
+                          JSONTypeContext *Py_UNUSED(tc)) {}
 
-JSOBJ Tuple_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static JSOBJ Tuple_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   return GET_TC(tc)->itemValue;
 }
 
-char *Tuple_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *Py_UNUSED(tc),
-                        size_t *Py_UNUSED(outLen)) {
+static char *Tuple_iterGetName(JSOBJ Py_UNUSED(obj),
+                               JSONTypeContext *Py_UNUSED(tc),
+                               size_t *Py_UNUSED(outLen)) {
   return NULL;
 }
 
@@ -815,20 +788,18 @@ char *Tuple_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *Py_UNUSED(tc),
 // Set iteration functions
 // itemValue is borrowed reference, no ref counting
 //=============================================================================
-void Set_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
+static void Set_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
   GET_TC(tc)->itemValue = NULL;
   GET_TC(tc)->iterator = PyObject_GetIter(obj);
 }
 
-int Set_iterNext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
-  PyObject *item;
-
+static int Set_iterNext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   if (GET_TC(tc)->itemValue) {
     Py_DECREF(GET_TC(tc)->itemValue);
     GET_TC(tc)->itemValue = NULL;
   }
 
-  item = PyIter_Next(GET_TC(tc)->iterator);
+  PyObject *item = PyIter_Next(GET_TC(tc)->iterator);
 
   if (item == NULL) {
     return 0;
@@ -838,7 +809,7 @@ int Set_iterNext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   return 1;
 }
 
-void Set_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static void Set_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   if (GET_TC(tc)->itemValue) {
     Py_DECREF(GET_TC(tc)->itemValue);
     GET_TC(tc)->itemValue = NULL;
@@ -850,12 +821,13 @@ void Set_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   }
 }
 
-JSOBJ Set_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static JSOBJ Set_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   return GET_TC(tc)->itemValue;
 }
 
-char *Set_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *Py_UNUSED(tc),
-                      size_t *Py_UNUSED(outLen)) {
+static char *Set_iterGetName(JSOBJ Py_UNUSED(obj),
+                             JSONTypeContext *Py_UNUSED(tc),
+                             size_t *Py_UNUSED(outLen)) {
   return NULL;
 }
 
@@ -864,13 +836,13 @@ char *Set_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *Py_UNUSED(tc),
 // itemName ref is borrowed from PyObject_Dir (attrList). No refcount
 // itemValue ref is from PyObject_GetAttr. Ref counted
 //=============================================================================
-void Dir_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
+static void Dir_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
   GET_TC(tc)->attrList = PyObject_Dir(obj);
   GET_TC(tc)->index = 0;
   GET_TC(tc)->size = PyList_GET_SIZE(GET_TC(tc)->attrList);
 }
 
-void Dir_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static void Dir_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   if (GET_TC(tc)->itemValue) {
     Py_DECREF(GET_TC(tc)->itemValue);
     GET_TC(tc)->itemValue = NULL;
@@ -884,13 +856,10 @@ void Dir_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   Py_DECREF((PyObject *)GET_TC(tc)->attrList);
 }
 
-int Dir_iterNext(JSOBJ _obj, JSONTypeContext *tc) {
+static int Dir_iterNext(JSOBJ _obj, JSONTypeContext *tc) {
   PyObject *obj = (PyObject *)_obj;
   PyObject *itemValue = GET_TC(tc)->itemValue;
   PyObject *itemName = GET_TC(tc)->itemName;
-  PyObject *attr;
-  PyObject *attrName;
-  char *attrStr;
 
   if (PyErr_Occurred() || ((JSONObjectEncoder *)tc->encoder)->errorMsg) {
     return 0;
@@ -907,9 +876,10 @@ int Dir_iterNext(JSOBJ _obj, JSONTypeContext *tc) {
   }
 
   for (; GET_TC(tc)->index < GET_TC(tc)->size; GET_TC(tc)->index++) {
-    attrName = PyList_GET_ITEM(GET_TC(tc)->attrList, GET_TC(tc)->index);
-    attr = PyUnicode_AsUTF8String(attrName);
-    attrStr = PyBytes_AS_STRING(attr);
+    PyObject *attrName =
+        PyList_GET_ITEM(GET_TC(tc)->attrList, GET_TC(tc)->index);
+    PyObject *attr = PyUnicode_AsUTF8String(attrName);
+    const char *attrStr = PyBytes_AS_STRING(attr);
 
     if (attrStr[0] == '_') {
       Py_DECREF(attr);
@@ -949,12 +919,12 @@ int Dir_iterNext(JSOBJ _obj, JSONTypeContext *tc) {
   return 1;
 }
 
-JSOBJ Dir_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static JSOBJ Dir_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   return GET_TC(tc)->itemValue;
 }
 
-char *Dir_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
-                      size_t *outLen) {
+static char *Dir_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
+                             size_t *outLen) {
   *outLen = PyBytes_GET_SIZE(GET_TC(tc)->itemName);
   return PyBytes_AS_STRING(GET_TC(tc)->itemName);
 }
@@ -963,12 +933,12 @@ char *Dir_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
 // List iteration functions
 // itemValue is borrowed from object (which is list). No refcounting
 //=============================================================================
-void List_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
+static void List_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
   GET_TC(tc)->index = 0;
   GET_TC(tc)->size = PyList_GET_SIZE((PyObject *)obj);
 }
 
-int List_iterNext(JSOBJ obj, JSONTypeContext *tc) {
+static int List_iterNext(JSOBJ obj, JSONTypeContext *tc) {
   if (GET_TC(tc)->index >= GET_TC(tc)->size) {
     return 0;
   }
@@ -978,21 +948,23 @@ int List_iterNext(JSOBJ obj, JSONTypeContext *tc) {
   return 1;
 }
 
-void List_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *Py_UNUSED(tc)) {}
+static void List_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *Py_UNUSED(tc)) {
+}
 
-JSOBJ List_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static JSOBJ List_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   return GET_TC(tc)->itemValue;
 }
 
-char *List_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *Py_UNUSED(tc),
-                       size_t *Py_UNUSED(outLen)) {
+static char *List_iterGetName(JSOBJ Py_UNUSED(obj),
+                              JSONTypeContext *Py_UNUSED(tc),
+                              size_t *Py_UNUSED(outLen)) {
   return NULL;
 }
 
 //=============================================================================
 // pandas Index iteration functions
 //=============================================================================
-void Index_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static void Index_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   GET_TC(tc)->index = 0;
   GET_TC(tc)->cStr = PyObject_Malloc(20 * sizeof(char));
   if (!GET_TC(tc)->cStr) {
@@ -1000,13 +972,12 @@ void Index_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   }
 }
 
-int Index_iterNext(JSOBJ obj, JSONTypeContext *tc) {
-  Py_ssize_t index;
+static int Index_iterNext(JSOBJ obj, JSONTypeContext *tc) {
   if (!GET_TC(tc)->cStr) {
     return 0;
   }
 
-  index = GET_TC(tc)->index;
+  const Py_ssize_t index = GET_TC(tc)->index;
   Py_XDECREF(GET_TC(tc)->itemValue);
   if (index == 0) {
     memcpy(GET_TC(tc)->cStr, "name", sizeof(char) * 5);
@@ -1025,14 +996,15 @@ int Index_iterNext(JSOBJ obj, JSONTypeContext *tc) {
   return 1;
 }
 
-void Index_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *Py_UNUSED(tc)) {}
+static void Index_iterEnd(JSOBJ Py_UNUSED(obj),
+                          JSONTypeContext *Py_UNUSED(tc)) {}
 
-JSOBJ Index_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static JSOBJ Index_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   return GET_TC(tc)->itemValue;
 }
 
-char *Index_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
-                        size_t *outLen) {
+static char *Index_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
+                               size_t *outLen) {
   *outLen = strlen(GET_TC(tc)->cStr);
   return GET_TC(tc)->cStr;
 }
@@ -1040,7 +1012,7 @@ char *Index_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
 //=============================================================================
 // pandas Series iteration functions
 //=============================================================================
-void Series_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static void Series_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   PyObjectEncoder *enc = (PyObjectEncoder *)tc->encoder;
   GET_TC(tc)->index = 0;
   GET_TC(tc)->cStr = PyObject_Malloc(20 * sizeof(char));
@@ -1050,13 +1022,12 @@ void Series_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   }
 }
 
-int Series_iterNext(JSOBJ obj, JSONTypeContext *tc) {
-  Py_ssize_t index;
+static int Series_iterNext(JSOBJ obj, JSONTypeContext *tc) {
   if (!GET_TC(tc)->cStr) {
     return 0;
   }
 
-  index = GET_TC(tc)->index;
+  const Py_ssize_t index = GET_TC(tc)->index;
   Py_XDECREF(GET_TC(tc)->itemValue);
   if (index == 0) {
     memcpy(GET_TC(tc)->cStr, "name", sizeof(char) * 5);
@@ -1078,17 +1049,17 @@ int Series_iterNext(JSOBJ obj, JSONTypeContext *tc) {
   return 1;
 }
 
-void Series_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static void Series_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   PyObjectEncoder *enc = (PyObjectEncoder *)tc->encoder;
   enc->outputFormat = enc->originalOutputFormat;
 }
 
-JSOBJ Series_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static JSOBJ Series_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   return GET_TC(tc)->itemValue;
 }
 
-char *Series_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
-                         size_t *outLen) {
+static char *Series_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
+                                size_t *outLen) {
   *outLen = strlen(GET_TC(tc)->cStr);
   return GET_TC(tc)->cStr;
 }
@@ -1096,7 +1067,7 @@ char *Series_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
 //=============================================================================
 // pandas DataFrame iteration functions
 //=============================================================================
-void DataFrame_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static void DataFrame_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   PyObjectEncoder *enc = (PyObjectEncoder *)tc->encoder;
   GET_TC(tc)->index = 0;
   GET_TC(tc)->cStr = PyObject_Malloc(20 * sizeof(char));
@@ -1106,13 +1077,12 @@ void DataFrame_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   }
 }
 
-int DataFrame_iterNext(JSOBJ obj, JSONTypeContext *tc) {
-  Py_ssize_t index;
+static int DataFrame_iterNext(JSOBJ obj, JSONTypeContext *tc) {
   if (!GET_TC(tc)->cStr) {
     return 0;
   }
 
-  index = GET_TC(tc)->index;
+  const Py_ssize_t index = GET_TC(tc)->index;
   Py_XDECREF(GET_TC(tc)->itemValue);
   if (index == 0) {
     memcpy(GET_TC(tc)->cStr, "columns", sizeof(char) * 8);
@@ -1132,17 +1102,17 @@ int DataFrame_iterNext(JSOBJ obj, JSONTypeContext *tc) {
   return 1;
 }
 
-void DataFrame_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static void DataFrame_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   PyObjectEncoder *enc = (PyObjectEncoder *)tc->encoder;
   enc->outputFormat = enc->originalOutputFormat;
 }
 
-JSOBJ DataFrame_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static JSOBJ DataFrame_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   return GET_TC(tc)->itemValue;
 }
 
-char *DataFrame_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
-                            size_t *outLen) {
+static char *DataFrame_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
+                                   size_t *outLen) {
   *outLen = strlen(GET_TC(tc)->cStr);
   return GET_TC(tc)->cStr;
 }
@@ -1152,13 +1122,11 @@ char *DataFrame_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
 // itemName might converted to string (Python_Str). Do refCounting
 // itemValue is borrowed from object (which is dict). No refCounting
 //=============================================================================
-void Dict_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static void Dict_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   GET_TC(tc)->index = 0;
 }
 
-int Dict_iterNext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
-  PyObject *itemNameTmp;
-
+static int Dict_iterNext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   if (GET_TC(tc)->itemName) {
     Py_DECREF(GET_TC(tc)->itemName);
     GET_TC(tc)->itemName = NULL;
@@ -1173,7 +1141,7 @@ int Dict_iterNext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     GET_TC(tc)->itemName = PyUnicode_AsUTF8String(GET_TC(tc)->itemName);
   } else if (!PyBytes_Check(GET_TC(tc)->itemName)) {
     GET_TC(tc)->itemName = PyObject_Str(GET_TC(tc)->itemName);
-    itemNameTmp = GET_TC(tc)->itemName;
+    PyObject *itemNameTmp = GET_TC(tc)->itemName;
     GET_TC(tc)->itemName = PyUnicode_AsUTF8String(GET_TC(tc)->itemName);
     Py_DECREF(itemNameTmp);
   } else {
@@ -1182,7 +1150,7 @@ int Dict_iterNext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   return 1;
 }
 
-void Dict_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static void Dict_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   if (GET_TC(tc)->itemName) {
     Py_DECREF(GET_TC(tc)->itemName);
     GET_TC(tc)->itemName = NULL;
@@ -1190,21 +1158,19 @@ void Dict_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   Py_DECREF(GET_TC(tc)->dictObj);
 }
 
-JSOBJ Dict_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static JSOBJ Dict_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   return GET_TC(tc)->itemValue;
 }
 
-char *Dict_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
-                       size_t *outLen) {
+static char *Dict_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
+                              size_t *outLen) {
   *outLen = PyBytes_GET_SIZE(GET_TC(tc)->itemName);
   return PyBytes_AS_STRING(GET_TC(tc)->itemName);
 }
 
-void NpyArr_freeLabels(char **labels, npy_intp len) {
-  npy_intp i;
-
+static void NpyArr_freeLabels(char **labels, npy_intp len) {
   if (labels) {
-    for (i = 0; i < len; i++) {
+    for (npy_intp i = 0; i < len; i++) {
       PyObject_Free(labels[i]);
     }
     PyObject_Free(labels);
@@ -1228,17 +1194,11 @@ void NpyArr_freeLabels(char **labels, npy_intp len) {
  * this has instead just stringified any input save for datetime values,
  * which may need to be represented in various formats.
  */
-char **NpyArr_encodeLabels(PyArrayObject *labels, PyObjectEncoder *enc,
-                           npy_intp num) {
+static char **NpyArr_encodeLabels(PyArrayObject *labels, PyObjectEncoder *enc,
+                                  npy_intp num) {
   // NOTE this function steals a reference to labels.
   PyObject *item = NULL;
-  size_t len;
-  npy_intp i, stride;
-  char **ret;
-  char *dataptr, *cLabel;
-  int type_num;
-  PyArray_Descr *dtype;
-  NPY_DATETIMEUNIT base = enc->datetimeUnit;
+  const NPY_DATETIMEUNIT base = enc->datetimeUnit;
 
   if (!labels) {
     return 0;
@@ -1251,23 +1211,23 @@ char **NpyArr_encodeLabels(PyArrayObject *labels, PyObjectEncoder *enc,
     return 0;
   }
 
-  ret = PyObject_Malloc(sizeof(char *) * num);
+  char **ret = PyObject_Malloc(sizeof(char *) * num);
   if (!ret) {
     PyErr_NoMemory();
     Py_DECREF(labels);
     return 0;
   }
 
-  for (i = 0; i < num; i++) {
+  for (npy_intp i = 0; i < num; i++) {
     ret[i] = NULL;
   }
 
-  stride = PyArray_STRIDE(labels, 0);
-  dataptr = PyArray_DATA(labels);
-  type_num = PyArray_TYPE(labels);
-  dtype = PyArray_DESCR(labels);
+  const npy_intp stride = PyArray_STRIDE(labels, 0);
+  char *dataptr = PyArray_DATA(labels);
+  const int type_num = PyArray_TYPE(labels);
+  PyArray_Descr *dtype = PyArray_DESCR(labels);
 
-  for (i = 0; i < num; i++) {
+  for (npy_intp i = 0; i < num; i++) {
     item = PyArray_GETITEM(labels, dataptr);
     if (!item) {
       NpyArr_freeLabels(ret, num);
@@ -1298,6 +1258,8 @@ char **NpyArr_encodeLabels(PyArrayObject *labels, PyObjectEncoder *enc,
       }
     }
 
+    size_t len;
+    char *cLabel;
     if (is_datetimelike) {
       if (i8date == get_nat()) {
         len = 4;
@@ -1370,7 +1332,7 @@ char **NpyArr_encodeLabels(PyArrayObject *labels, PyObjectEncoder *enc,
   return ret;
 }
 
-void Object_invokeDefaultHandler(PyObject *obj, PyObjectEncoder *enc) {
+static void Object_invokeDefaultHandler(PyObject *obj, PyObjectEncoder *enc) {
   PyObject *tmpObj = NULL;
   tmpObj = PyObject_CallFunctionObjArgs(enc->defaultHandler, obj, NULL);
   if (!PyErr_Occurred()) {
@@ -1384,14 +1346,7 @@ void Object_invokeDefaultHandler(PyObject *obj, PyObjectEncoder *enc) {
   return;
 }
 
-void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
-  PyObject *obj, *exc, *toDictFunc, *tmpObj, *values;
-  TypeContext *pc;
-  PyObjectEncoder *enc;
-  double val;
-  npy_int64 value;
-  int unit;
-
+static void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
   tc->prv = NULL;
 
   if (!_obj) {
@@ -1399,8 +1354,8 @@ void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
     return;
   }
 
-  obj = (PyObject *)_obj;
-  enc = (PyObjectEncoder *)tc->encoder;
+  PyObject *obj = (PyObject *)_obj;
+  PyObjectEncoder *enc = (PyObjectEncoder *)tc->encoder;
 
   if (PyBool_Check(obj)) {
     tc->type = (obj == Py_True) ? JT_TRUE : JT_FALSE;
@@ -1410,7 +1365,7 @@ void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
     return;
   }
 
-  pc = createTypeContext();
+  TypeContext *pc = createTypeContext();
   if (!pc) {
     tc->type = JT_INVALID;
     return;
@@ -1418,9 +1373,7 @@ void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
   tc->prv = pc;
 
   if (PyTypeNum_ISDATETIME(enc->npyType)) {
-    int64_t longVal;
-
-    longVal = *(npy_int64 *)enc->npyValue;
+    const int64_t longVal = *(npy_int64 *)enc->npyValue;
     if (longVal == get_nat()) {
       tc->type = JT_NULL;
     } else {
@@ -1468,7 +1421,7 @@ void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
 
     return;
   } else if (PyFloat_Check(obj)) {
-    val = PyFloat_AS_DOUBLE(obj);
+    const double val = PyFloat_AS_DOUBLE(obj);
     if (npy_isnan(val) || npy_isinf(val)) {
       tc->type = JT_NULL;
     } else {
@@ -1535,12 +1488,10 @@ void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
     }
     return;
   } else if (PyDelta_Check(obj)) {
-    if (PyObject_HasAttrString(obj, "_value")) {
-      // pd.Timedelta object or pd.NaT
-      value = get_long_attr(obj, "_value");
-    } else {
-      value = total_seconds(obj) * 1000000000LL; // nanoseconds per sec
-    }
+    npy_int64 value =
+        PyObject_HasAttrString(obj, "_value") ? get_long_attr(obj, "_value")
+                                              : // pd.Timedelta object or pd.NaT
+            total_seconds(obj) * 1000000000LL;  // nanoseconds per sec
 
     if (value == get_nat()) {
       tc->type = JT_NULL;
@@ -1549,14 +1500,12 @@ void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
       pc->PyTypeToUTF8 = NpyTimeDeltaToIsoCallback;
       tc->type = JT_UTF8;
     } else {
-      unit = ((PyObjectEncoder *)tc->encoder)->datetimeUnit;
+      const int unit = ((PyObjectEncoder *)tc->encoder)->datetimeUnit;
       if (scaleNanosecToUnit(&value, unit) != 0) {
         // TODO(username): Add some kind of error handling here
       }
 
-      exc = PyErr_Occurred();
-
-      if (exc && PyErr_ExceptionMatches(PyExc_OverflowError)) {
+      if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_OverflowError)) {
         goto INVALID;
       }
 
@@ -1569,9 +1518,7 @@ void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
     PyArray_CastScalarToCtype(obj, &(pc->longValue),
                               PyArray_DescrFromType(NPY_INT64));
 
-    exc = PyErr_Occurred();
-
-    if (exc && PyErr_ExceptionMatches(PyExc_OverflowError)) {
+    if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_OverflowError)) {
       goto INVALID;
     }
 
@@ -1640,11 +1587,11 @@ ISITERABLE:
 
     if (enc->outputFormat == INDEX || enc->outputFormat == COLUMNS) {
       tc->type = JT_OBJECT;
-      tmpObj = PyObject_GetAttrString(obj, "index");
+      PyObject *tmpObj = PyObject_GetAttrString(obj, "index");
       if (!tmpObj) {
         goto INVALID;
       }
-      values = get_values(tmpObj);
+      PyObject *values = get_values(tmpObj);
       Py_DECREF(tmpObj);
       if (!values) {
         goto INVALID;
@@ -1722,11 +1669,11 @@ ISITERABLE:
       tc->type = JT_ARRAY;
     } else if (enc->outputFormat == RECORDS) {
       tc->type = JT_ARRAY;
-      tmpObj = PyObject_GetAttrString(obj, "columns");
+      PyObject *tmpObj = PyObject_GetAttrString(obj, "columns");
       if (!tmpObj) {
         goto INVALID;
       }
-      values = get_values(tmpObj);
+      PyObject *values = get_values(tmpObj);
       if (!values) {
         Py_DECREF(tmpObj);
         goto INVALID;
@@ -1740,13 +1687,13 @@ ISITERABLE:
       }
     } else if (enc->outputFormat == INDEX || enc->outputFormat == COLUMNS) {
       tc->type = JT_OBJECT;
-      tmpObj =
+      PyObject *tmpObj =
           (enc->outputFormat == INDEX ? PyObject_GetAttrString(obj, "index")
                                       : PyObject_GetAttrString(obj, "columns"));
       if (!tmpObj) {
         goto INVALID;
       }
-      values = get_values(tmpObj);
+      PyObject *values = get_values(tmpObj);
       if (!values) {
         Py_DECREF(tmpObj);
         goto INVALID;
@@ -1824,7 +1771,7 @@ ISITERABLE:
     return;
   }
 
-  toDictFunc = PyObject_GetAttrString(obj, "toDict");
+  PyObject *toDictFunc = PyObject_GetAttrString(obj, "toDict");
 
   if (toDictFunc) {
     PyObject *tuple = PyTuple_New(0);
@@ -1876,7 +1823,7 @@ INVALID:
   return;
 }
 
-void Object_endTypeContext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static void Object_endTypeContext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   if (tc->prv) {
     Py_XDECREF(GET_TC(tc)->newObj);
     GET_TC(tc)->newObj = NULL;
@@ -1891,21 +1838,21 @@ void Object_endTypeContext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   }
 }
 
-const char *Object_getStringValue(JSOBJ obj, JSONTypeContext *tc,
-                                  size_t *_outLen) {
+static const char *Object_getStringValue(JSOBJ obj, JSONTypeContext *tc,
+                                         size_t *_outLen) {
   return GET_TC(tc)->PyTypeToUTF8(obj, tc, _outLen);
 }
 
-JSINT64 Object_getLongValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static JSINT64 Object_getLongValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   return GET_TC(tc)->longValue;
 }
 
-double Object_getDoubleValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+static double Object_getDoubleValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   return GET_TC(tc)->doubleValue;
 }
 
-const char *Object_getBigNumStringValue(JSOBJ obj, JSONTypeContext *tc,
-                                        size_t *_outLen) {
+static const char *Object_getBigNumStringValue(JSOBJ obj, JSONTypeContext *tc,
+                                               size_t *_outLen) {
   PyObject *repr = PyObject_Str(obj);
   const char *str = PyUnicode_AsUTF8AndSize(repr, (Py_ssize_t *)_outLen);
   char *bytes = PyObject_Malloc(*_outLen + 1);
@@ -1919,23 +1866,24 @@ const char *Object_getBigNumStringValue(JSOBJ obj, JSONTypeContext *tc,
 
 static void Object_releaseObject(JSOBJ _obj) { Py_DECREF((PyObject *)_obj); }
 
-void Object_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
+static void Object_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
   GET_TC(tc)->iterBegin(obj, tc);
 }
 
-int Object_iterNext(JSOBJ obj, JSONTypeContext *tc) {
+static int Object_iterNext(JSOBJ obj, JSONTypeContext *tc) {
   return GET_TC(tc)->iterNext(obj, tc);
 }
 
-void Object_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
+static void Object_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
   GET_TC(tc)->iterEnd(obj, tc);
 }
 
-JSOBJ Object_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
+static JSOBJ Object_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
   return GET_TC(tc)->iterGetValue(obj, tc);
 }
 
-char *Object_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
+static char *Object_iterGetName(JSOBJ obj, JSONTypeContext *tc,
+                                size_t *outLen) {
   return GET_TC(tc)->iterGetName(obj, tc, outLen);
 }
 
@@ -1962,9 +1910,6 @@ PyObject *objToJSON(PyObject *Py_UNUSED(self), PyObject *args,
                            "indent",
                            NULL};
 
-  char buffer[65536];
-  char *ret;
-  PyObject *newobj;
   PyObject *oinput = NULL;
   PyObject *oensureAscii = NULL;
   int idoublePrecision = 10; // default double precision setting
@@ -1994,9 +1939,9 @@ PyObject *objToJSON(PyObject *Py_UNUSED(self), PyObject *args,
       PyObject_Free,
       -1, // recursionMax
       idoublePrecision,
-      1, // forceAscii
-      0, // encodeHTMLChars
-      0, // indent
+      1,      // forceAscii
+      0,      // encodeHTMLChars
+      indent, // indent
   }};
   JSONObjectEncoder *encoder = (JSONObjectEncoder *)&pyEncoder;
 
@@ -2080,7 +2025,9 @@ PyObject *objToJSON(PyObject *Py_UNUSED(self), PyObject *args,
   encoder->indent = indent;
 
   pyEncoder.originalOutputFormat = pyEncoder.outputFormat;
-  ret = JSON_EncodeObject(oinput, encoder, buffer, sizeof(buffer));
+
+  char buffer[65536];
+  char *ret = JSON_EncodeObject(oinput, encoder, buffer, sizeof(buffer));
   if (PyErr_Occurred()) {
     return NULL;
   }
@@ -2093,7 +2040,7 @@ PyObject *objToJSON(PyObject *Py_UNUSED(self), PyObject *args,
     return NULL;
   }
 
-  newobj = PyUnicode_FromString(ret);
+  PyObject *newobj = PyUnicode_FromString(ret);
 
   if (ret != buffer) {
     encoder->free(ret);


### PR DESCRIPTION
Will have to do this in a few passes for other files, but generally we:

1.  Are removing C89 style variable declarations at the top of functions
2. Adding `const` qualifiers where we can
3. Making more functions static that aren't intended to be linked outside of their translation unit

Point 1 helps with code readability, Point 2 can help with code safety and compiler optimization. Point 3 helps with code structure and makes functions "local" to their translaction unit instead of "global"