### PR TITLE
DOC: Explicit how 'cond' is updated on 'where'

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10735,8 +10735,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         element in the calling DataFrame, if ``cond`` is ``{cond}`` the
         element is used; otherwise the corresponding element from the DataFrame
         ``other`` is used. If the axis of ``other`` does not align with axis of
-        ``cond`` {klass}, the misaligned index positions will be filled with
-        {cond_rev}.
+        ``cond`` {klass}, the values of ``cond`` on misaligned index positions
+        will be filled with {cond_rev}.
 
         The signature for :func:`DataFrame.where` differs from
         :func:`numpy.where`. Roughly ``df1.where(m, df2)`` is equivalent to


### PR DESCRIPTION
This PR updates the section notes on `DataFrame.where(cond, other=nan, *, inplace=False, axis=None, level=None)` docstring.
Currently pandas isn't explicit on who is being updated when  `cond` is misaligned with `other`. Just made that explicit to avoid confusion.