### PR TITLE
BUG: df.to_csv() fails to a not-yet-created file when the path is fsspec-based (#55828)

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -572,8 +572,8 @@ I/O
 - Bug in :meth:`DataFrame.to_hdf` and :func:`read_hdf` with ``datetime64`` dtypes with non-nanosecond resolution failing to round-trip correctly (:issue:`55622`)
 - Bug in :meth:`pandas.read_excel` with ``engine="odf"`` (``ods`` files) when string contains annotation (:issue:`55200`)
 - Bug in :meth:`pandas.read_excel` with an ODS file without cached formatted cell for float values (:issue:`55219`)
+- Bug where :meth:`DataFrame.to_csv` would raise a ``URLError`` when specifying local file scheme paths to not-yet-created files (:issue:`55828`)
 - Bug where :meth:`DataFrame.to_json` would raise an ``OverflowError`` instead of a ``TypeError`` with unsupported NumPy types (:issue:`55403`)
-
 Period
 ^^^^^^
 - Bug in :class:`PeriodIndex` construction when more than one of ``data``, ``ordinal`` and ``**fields`` are passed failing to raise ``ValueError`` (:issue:`55961`)

--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -574,6 +574,7 @@ I/O
 - Bug in :meth:`pandas.read_excel` with an ODS file without cached formatted cell for float values (:issue:`55219`)
 - Bug where :meth:`DataFrame.to_csv` would raise a ``URLError`` when specifying local file scheme paths to not-yet-created files (:issue:`55828`)
 - Bug where :meth:`DataFrame.to_json` would raise an ``OverflowError`` instead of a ``TypeError`` with unsupported NumPy types (:issue:`55403`)
+
 Period
 ^^^^^^
 - Bug in :class:`PeriodIndex` construction when more than one of ``data``, ``ordinal`` and ``**fields`` are passed failing to raise ``ValueError`` (:issue:`55961`)

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -384,9 +384,9 @@ def _get_filepath_or_buffer(
 
         # Fix for GH #55828
         parsed_url = parse_url(filepath_or_buffer)
-        if parse_url(filepath_or_buffer).scheme == "file":
+        if parsed_url.scheme == "file":
             file_path = urllib.request.url2pathname(parsed_url.path)
-            file_path = os.path.normpath(parsed_url.path)
+            file_path = os.path.normpath(file_path)
             return IOArgs(
                 filepath_or_buffer=open(file_path, "rb"),
                 encoding=encoding,

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -378,9 +378,14 @@ def _get_filepath_or_buffer(
         # server responded with gzipped data
         storage_options = storage_options or {}
 
+        # waiting until now for importing to match intended lazy logic of
+        # urlopen function defined elsewhere in this module
+        import urllib.request
+
         # Fix for GH #55828
         parsed_url = parse_url(filepath_or_buffer)
         if parse_url(filepath_or_buffer).scheme == "file":
+            file_path = urllib.request.url2pathname(parsed_url.path)
             file_path = os.path.normpath(parsed_url.path)
             return IOArgs(
                 filepath_or_buffer=open(file_path, "rb"),
@@ -389,10 +394,6 @@ def _get_filepath_or_buffer(
                 should_close=True,
                 mode=fsspec_mode,
             )
-
-        # waiting until now for importing to match intended lazy logic of
-        # urlopen function defined elsewhere in this module
-        import urllib.request
 
         # assuming storage_options is to be interpreted as headers
         req_info = urllib.request.Request(filepath_or_buffer, headers=storage_options)

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -378,6 +378,18 @@ def _get_filepath_or_buffer(
         # server responded with gzipped data
         storage_options = storage_options or {}
 
+        # Fix for GH #55828
+        parsed_url = parse_url(filepath_or_buffer)
+        if parse_url(filepath_or_buffer).scheme == "file":
+            file_path = os.path.normpath(parsed_url.path)
+            return IOArgs(
+                filepath_or_buffer=open(file_path, "rb"),
+                encoding=encoding,
+                compression=compression,
+                should_close=True,
+                mode=fsspec_mode,
+            )
+
         # waiting until now for importing to match intended lazy logic of
         # urlopen function defined elsewhere in this module
         import urllib.request


### PR DESCRIPTION
When specifying local to_csv file paths with the file scheme, Pandas will now create the file instead of raising an exception

- [✅ ] closes #55828 (Replace xxxx with the GitHub issue number)
- [✅ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ✅] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [✅ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [✅ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
