### PR TITLE
Address violation fix

### DIFF
--- a/pandas/core/methods/selectn.py
+++ b/pandas/core/methods/selectn.py
@@ -140,7 +140,10 @@ class SelectNSeries(SelectN):
         # arr passed into kth_smallest must be contiguous. We copy
         # here because kth_smallest will modify its input
         # avoid OOB access with kth_smallest_c when n <= 0
-        kth_val = libalgos.kth_smallest(arr.copy(order="C"), max(n - 1, 0))
+        if len(arr) > 0:
+            kth_val = libalgos.kth_smallest(arr.copy(order="C"), n - 1)
+        else:
+            kth_val = np.nan
         (ns,) = np.nonzero(arr <= kth_val)
         inds = ns[arr[ns].argsort(kind="mergesort")]
 


### PR DESCRIPTION
Follow up to https://github.com/pandas-dev/pandas/pull/56000 looks like this still is an address violation when the array is empty, since `arr[0]` on an empty array is out of bounds