### PR TITLE
TST: Remove groupby/test_function.py

### DIFF
--- a/pandas/tests/groupby/methods/test_nth.py
+++ b/pandas/tests/groupby/methods/test_nth.py
@@ -898,3 +898,24 @@ def test_nth_after_selection(selection, dropna):
         locs = [0, 2]
     expected = df.loc[locs, selection]
     tm.assert_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        (
+            Timestamp("2011-01-15 12:50:28.502376"),
+            Timestamp("2011-01-20 12:50:28.593448"),
+        ),
+        (24650000000000001, 24650000000000002),
+    ],
+)
+def test_groupby_nth_int_like_precision(data):
+    # GH#6620, GH#9311
+    df = DataFrame({"a": [1, 1], "b": data})
+
+    grouped = df.groupby("a")
+    result = grouped.nth(0)
+    expected = DataFrame({"a": 1, "b": [data[0]]})
+
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/test_all_methods.py
+++ b/pandas/tests/groupby/test_all_methods.py
@@ -1,0 +1,58 @@
+"""
+Tests that apply to all groupby operation methods.
+
+The only tests that should appear here are those that use the `groupby_func` fixture.
+Even if it does use that fixture, prefer a more specific test file if it available
+such as:
+
+ - test_categorical
+ - test_groupby_dropna
+ - test_groupby_subclass
+ - test_raises
+"""
+
+import pytest
+
+from pandas import DataFrame
+import pandas._testing as tm
+from pandas.tests.groupby import get_groupby_method_args
+
+
+def test_multiindex_group_all_columns_when_empty(groupby_func):
+    # GH 32464
+    df = DataFrame({"a": [], "b": [], "c": []}).set_index(["a", "b", "c"])
+    gb = df.groupby(["a", "b", "c"], group_keys=False)
+    method = getattr(gb, groupby_func)
+    args = get_groupby_method_args(groupby_func, df)
+
+    warn = FutureWarning if groupby_func == "fillna" else None
+    warn_msg = "DataFrameGroupBy.fillna is deprecated"
+    with tm.assert_produces_warning(warn, match=warn_msg):
+        result = method(*args).index
+    expected = df.index
+    tm.assert_index_equal(result, expected)
+
+
+def test_duplicate_columns(request, groupby_func, as_index):
+    # GH#50806
+    if groupby_func == "corrwith":
+        msg = "GH#50845 - corrwith fails when there are duplicate columns"
+        request.applymarker(pytest.mark.xfail(reason=msg))
+    df = DataFrame([[1, 3, 6], [1, 4, 7], [2, 5, 8]], columns=list("abb"))
+    args = get_groupby_method_args(groupby_func, df)
+    gb = df.groupby("a", as_index=as_index)
+    warn = FutureWarning if groupby_func == "fillna" else None
+    warn_msg = "DataFrameGroupBy.fillna is deprecated"
+    with tm.assert_produces_warning(warn, match=warn_msg):
+        result = getattr(gb, groupby_func)(*args)
+
+    expected_df = df.set_axis(["a", "b", "c"], axis=1)
+    expected_args = get_groupby_method_args(groupby_func, expected_df)
+    expected_gb = expected_df.groupby("a", as_index=as_index)
+    warn = FutureWarning if groupby_func == "fillna" else None
+    warn_msg = "DataFrameGroupBy.fillna is deprecated"
+    with tm.assert_produces_warning(warn, match=warn_msg):
+        expected = getattr(expected_gb, groupby_func)(*expected_args)
+    if groupby_func not in ("size", "ngroup", "cumcount"):
+        expected = expected.rename(columns={"c": "b"})
+    tm.assert_equal(result, expected)

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -29,7 +29,6 @@ from pandas import (
 import pandas._testing as tm
 from pandas.core.arrays import BooleanArray
 import pandas.core.common as com
-from pandas.tests.groupby import get_groupby_method_args
 
 pytestmark = pytest.mark.filterwarnings("ignore:Mean of empty slice:RuntimeWarning")
 
@@ -2422,30 +2421,6 @@ def test_group_on_empty_multiindex(transformation_func, request):
     if transformation_func in ("diff", "shift"):
         expected = expected.astype(int)
     tm.assert_equal(result, expected)
-
-
-@pytest.mark.parametrize(
-    "idx",
-    [
-        Index(["a", "a"], name="foo"),
-        MultiIndex.from_tuples((("a", "a"), ("a", "a")), names=["foo", "bar"]),
-    ],
-)
-def test_dup_labels_output_shape(groupby_func, idx):
-    if groupby_func in {"size", "ngroup", "cumcount"}:
-        pytest.skip(f"Not applicable for {groupby_func}")
-
-    df = DataFrame([[1, 1]], columns=idx)
-    grp_by = df.groupby([0])
-
-    args = get_groupby_method_args(groupby_func, df)
-    warn = FutureWarning if groupby_func == "fillna" else None
-    warn_msg = "DataFrameGroupBy.fillna is deprecated"
-    with tm.assert_produces_warning(warn, match=warn_msg):
-        result = getattr(grp_by, groupby_func)(*args)
-
-    assert result.shape == (1, 2)
-    tm.assert_index_equal(result.columns, idx)
 
 
 def test_groupby_crash_on_nunique(axis):

--- a/pandas/tests/groupby/test_reductions.py
+++ b/pandas/tests/groupby/test_reductions.py
@@ -235,6 +235,36 @@ def test_idxmin_idxmax_returns_int_types(func, values, numeric_only):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize(
+    "data",
+    [
+        (
+            Timestamp("2011-01-15 12:50:28.502376"),
+            Timestamp("2011-01-20 12:50:28.593448"),
+        ),
+        (24650000000000001, 24650000000000002),
+    ],
+)
+@pytest.mark.parametrize("method", ["count", "min", "max", "first", "last"])
+def test_groupby_non_arithmetic_agg_int_like_precision(method, data):
+    # GH#6620, GH#9311
+    df = DataFrame({"a": [1, 1], "b": data})
+
+    grouped = df.groupby("a")
+    result = getattr(grouped, method)()
+    if method == "count":
+        expected_value = 2
+    elif method == "first":
+        expected_value = data[0]
+    elif method == "last":
+        expected_value = data[1]
+    else:
+        expected_value = getattr(df["b"], method)()
+    expected = DataFrame({"b": [expected_value]}, index=pd.Index([1], name="a"))
+
+    tm.assert_frame_equal(result, expected)
+
+
 def test_idxmin_idxmax_axis1():
     df = DataFrame(
         np.random.default_rng(2).standard_normal((10, 4)), columns=["A", "B", "C", "D"]


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This finishes up the removal of test_function.py from the groupby tests. With the exception of `test_groupby_non_arithmetic_agg_int_like_precision` (which is moved to other files here), the tests that remained fall into two (and partially overlapping) camps:

 - Tests for `numeric_only`
 - Tests that use the fixture `groupby_func`, which goes over every groupby operation

For the first, the options I considered were creating `test_numeric_only.py` or split it up into various other files such as `test_reductions.py`, `test_cumlative.py`, and some others. Similarly, for tests that use `groupby_func` that don't fit in other files, I considered creating `test_all_methods.py` (which can be renamed to something better) or split up the tests into several different files.

I'm completely on the fence here. Breaking up a parameterized test and duplicating code across multiple files seems pretty bad. While I don't love having `test_all_methods` (it's sort of a catch-all), at first it seemed to me that it is less bad than breaking up the parameterized tests. But then grepping around, it appears that there are only three tests across all of groupby that would go in `test_all_methods`. Perhaps this is something we can expand on later - but maybe since there are so few tests it's okay to break these up?

Any ideas here are very much welcome.

cc @jbrockmendel @mroeschke 