### PR TITLE
DOC: add simple example to DataFrame.to_csv()

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3950,13 +3950,13 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         Examples
         --------
-        Create 'out.csv' containing 'df' without indices
+        Create 'out.csv' containing 'df' without indices # doctest: +SKIP
         >>> df = pd.DataFrame({{'name': ['Raphael', 'Donatello'],
         ...                    'mask': ['red', 'purple'],
         ...                    'weapon': ['sai', 'bo staff']}})
         >>> df.to_csv('out.csv', index=False)
 
-        Create 'out.zip' containing 'out.csv'
+        Create 'out.zip' containing 'out.csv' # doctest: +SKIP
         >>> df.to_csv(index=False)
         'name,mask,weapon\nRaphael,red,sai\nDonatello,purple,bo staff\n'
         >>> compression_opts = dict(method='zip',

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3955,9 +3955,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         >>> df = pd.DataFrame({{'name': ['Raphael', 'Donatello'],
         ...                    'mask': ['red', 'purple'],
         ...                    'weapon': ['sai', 'bo staff']}})
-        >>> df.to_csv('out.csv', index=False)
+        >>> df.to_csv('out.csv', index=False) # doctest: +SKIP
 
-        Create 'out.zip' containing 'out.csv' # doctest: +SKIP
+        Create 'out.zip' containing 'out.csv'
+
         >>> df.to_csv(index=False)
         'name,mask,weapon\nRaphael,red,sai\nDonatello,purple,bo staff\n'
         >>> compression_opts = dict(method='zip',

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3950,7 +3950,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         Examples
         --------
-        Create 'out.csv' containing 'df' without indices # doctest: +SKIP
+        Create 'out.csv' containing 'df' without indices
+
         >>> df = pd.DataFrame({{'name': ['Raphael', 'Donatello'],
         ...                    'mask': ['red', 'purple'],
         ...                    'weapon': ['sai', 'bo staff']}})

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3958,6 +3958,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         Create 'out.zip' containing 'out.csv'
         >>> df.to_csv(index=False)
+        'name,mask,weapon\nRaphael,red,sai\nDonatello,purple,bo staff\n'
         >>> compression_opts = dict(method='zip',
         ...                         archive_name='out.csv')  # doctest: +SKIP
         >>> df.to_csv('out.zip', index=False,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3950,14 +3950,14 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         Examples
         --------
+        Create 'out.csv' containing 'df' without indices
         >>> df = pd.DataFrame({{'name': ['Raphael', 'Donatello'],
         ...                    'mask': ['red', 'purple'],
         ...                    'weapon': ['sai', 'bo staff']}})
-        >>> df.to_csv(index=False)
-        'name,mask,weapon\nRaphael,red,sai\nDonatello,purple,bo staff\n'
+        >>> df.to_csv('out.csv', index=False)
 
         Create 'out.zip' containing 'out.csv'
-
+        >>> df.to_csv(index=False)
         >>> compression_opts = dict(method='zip',
         ...                         archive_name='out.csv')  # doctest: +SKIP
         >>> df.to_csv('out.zip', index=False,


### PR DESCRIPTION
- [x] This closes #56256. Adding a simple example without compression should improve usability for new users.
