### PR TITLE
PERF: join on unordered CategoricalIndex

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -479,6 +479,7 @@ Performance improvements
 - Performance improvement in :func:`merge_asof` when ``by`` is not ``None`` (:issue:`55580`, :issue:`55678`)
 - Performance improvement in :func:`read_stata` for files with many variables (:issue:`55515`)
 - Performance improvement in :meth:`DataFrame.groupby` when aggregating pyarrow timestamp and duration dtypes (:issue:`55031`)
+- Performance improvement in :meth:`DataFrame.join` when joining on unordered categorical indexes (:issue:`56345`)
 - Performance improvement in :meth:`DataFrame.loc` and :meth:`Series.loc` when indexing with a :class:`MultiIndex` (:issue:`56062`)
 - Performance improvement in :meth:`DataFrame.sort_index` and :meth:`Series.sort_index` when indexed by a :class:`MultiIndex` (:issue:`54835`)
 - Performance improvement in :meth:`DataFrame.to_dict` on converting DataFrame to dictionary (:issue:`50990`)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4633,7 +4633,11 @@ class Index(IndexOpsMixin, PandasObject):
             and other._can_use_libjoin
             and (self.is_unique or other.is_unique)
         ):
-            return self._join_monotonic(other, how=how)
+            try:
+                return self._join_monotonic(other, how=how)
+            except TypeError:
+                # object dtype; non-comparable objects
+                pass
         elif not self.is_unique or not other.is_unique:
             return self._join_non_unique(other, how=how, sort=sort)
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4936,18 +4936,6 @@ class Index(IndexOpsMixin, PandasObject):
         )
         return join_index, left_indexer, right_indexer
 
-    def _can_join_monotonic(self, other):
-        if (
-            # not isinstance(self.dtype, CategoricalDtype)
-            self.is_monotonic_increasing
-            and other.is_monotonic_increasing
-            and self._can_use_libjoin
-            and other._can_use_libjoin
-            and (self.is_unique or other.is_unique)
-        ):
-            return True
-        return False
-
     @final
     def _join_monotonic(
         self, other: Index, how: JoinHow = "left"


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.2.0.rst` file if fixing a bug or adding a new feature.

existing test: `test_join_with_categorical_index`


```
import pandas as pd
import numpy as np

categories = [f"cat_{i:03}" for i in range(1000)]

idx1 = pd.CategoricalIndex(np.repeat(categories, 1000), categories=categories)
idx2 = pd.CategoricalIndex(categories[100:200], categories=reversed(categories))

df1 = pd.DataFrame({"val1": 1}, index=idx1)
df2 = pd.DataFrame({"val2": 2}, index=idx2)

%timeit df1.join(df2)

# 129 ms ± 7.93 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)   -> main
# 28.4 ms ± 1.18 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)  -> PR
```