### PR TITLE
BUG: `concat` should keep series names unless `ignore_index=True`

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -636,6 +636,7 @@ Groupby/resample/rolling
 Reshaping
 ^^^^^^^^^
 - Bug in :func:`concat` ignoring ``sort`` parameter when passed :class:`DatetimeIndex` indexes (:issue:`54769`)
+- Bug in :func:`concat` renaming :class:`Series` when ``ignore_index=False`` (:issue:`15047`)
 - Bug in :func:`merge_asof` raising ``TypeError`` when ``by`` dtype is not ``object``, ``int64``, or ``uint64`` (:issue:`22794`)
 - Bug in :func:`merge` returning columns in incorrect order when left and/or right is empty (:issue:`51929`)
 - Bug in :meth:`DataFrame.melt` where an exception was raised if ``var_name`` was not a string (:issue:`55948`)

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -464,7 +464,7 @@ class _Concatenator:
         # if we have mixed ndims, then convert to highest ndim
         # creating column numbers as needed
         if len(ndims) > 1:
-            objs, sample = self._sanitize_mixed_ndim(objs, sample, ignore_index, axis)
+            objs = self._sanitize_mixed_ndim(objs, sample, ignore_index, axis)
 
         self.objs = objs
 
@@ -580,7 +580,7 @@ class _Concatenator:
         sample: Series | DataFrame,
         ignore_index: bool,
         axis: AxisInt,
-    ) -> tuple[list[Series | DataFrame], Series | DataFrame]:
+    ) -> list[Series | DataFrame]:
         # if we have mixed ndims, then convert to highest ndim
         # creating column numbers as needed
 
@@ -601,19 +601,21 @@ class _Concatenator:
             else:
                 name = getattr(obj, "name", None)
                 if ignore_index or name is None:
-                    name = current_column
-                    current_column += 1
-
-                # doing a row-wise concatenation so need everything
-                # to line up
-                if self._is_frame and axis == 1:
-                    name = 0
+                    if axis == 1:
+                        # doing a row-wise concatenation so need everything
+                        # to line up
+                        name = 0
+                    else:
+                        # doing a column-wise concatenation so need series
+                        # to have unique names
+                        name = current_column
+                        current_column += 1
 
                 obj = sample._constructor({name: obj}, copy=False)
 
             new_objs.append(obj)
 
-        return new_objs, sample
+        return new_objs
 
     def get_result(self):
         cons: Callable[..., DataFrame | Series]

--- a/pandas/tests/reshape/concat/test_concat.py
+++ b/pandas/tests/reshape/concat/test_concat.py
@@ -326,9 +326,17 @@ class TestConcatenate:
 
         # axis 0
         expected = DataFrame(
-            np.tile(arr, 3).reshape(-1, 1), index=index.tolist() * 3, columns=[0]
+            np.kron(np.where(np.identity(3) == 1, 1, np.nan), arr).T,
+            index=index.to_list() * 3,
+            columns=["foo", 0, "bar"],
         )
         result = concat([s1, df, s2])
+        tm.assert_frame_equal(result, expected)
+
+        expected = DataFrame(
+            np.tile(arr, 3).reshape(-1, 1), index=index.to_list() * 3, columns=[0]
+        )
+        result = concat([s1.rename(0), df, s2.rename(0)])
         tm.assert_frame_equal(result, expected)
 
         expected = DataFrame(np.tile(arr, 3).reshape(-1, 1), columns=[0])

--- a/pandas/tests/reshape/concat/test_concat.py
+++ b/pandas/tests/reshape/concat/test_concat.py
@@ -324,7 +324,7 @@ class TestConcatenate:
         tm.assert_frame_equal(result, expected)
 
     def test_concat_mixed_objs_index(self):
-        # Test row-wise concat for mixed series/frames (axis=0)
+        # Test row-wise concat for mixed series/frames with a common name
         # GH2385, GH15047
 
         index = date_range("01-Jan-2013", periods=10, freq="h")
@@ -333,25 +333,33 @@ class TestConcatenate:
         s2 = Series(arr, index=index)
         df = DataFrame(arr.reshape(-1, 1), index=index)
 
-        # Align series names to column names
         expected = DataFrame(
             np.tile(arr, 3).reshape(-1, 1), index=index.tolist() * 3, columns=[0]
         )
         result = concat([s1, df, s2])
         tm.assert_frame_equal(result, expected)
 
-        # Separate columns for series not appearing as column names
+    def test_concat_mixed_objs_index_names(self):
+        # Test row-wise concat for mixed series/frames with distinct names
+        # GH2385, GH15047
+
+        index = date_range("01-Jan-2013", periods=10, freq="h")
+        arr = np.arange(10, dtype="int64")
+        s1 = Series(arr, index=index, name="foo")
+        s2 = Series(arr, index=index, name="bar")
+        df = DataFrame(arr.reshape(-1, 1), index=index)
+
         expected = DataFrame(
             np.kron(np.where(np.identity(3) == 1, 1, np.nan), arr).T,
             index=index.tolist() * 3,
             columns=["foo", 0, "bar"],
         )
-        result = concat([s1.rename("foo"), df, s2.rename("bar")])
+        result = concat([s1, df, s2])
         tm.assert_frame_equal(result, expected)
 
         # Rename all series to 0 when ignore_index=True
         expected = DataFrame(np.tile(arr, 3).reshape(-1, 1), columns=[0])
-        result = concat([s1.rename("foo"), df, s2.rename("bar")], ignore_index=True)
+        result = concat([s1, df, s2], ignore_index=True)
         tm.assert_frame_equal(result, expected)
 
     def test_dtype_coercion(self):

--- a/pandas/tests/reshape/concat/test_concat.py
+++ b/pandas/tests/reshape/concat/test_concat.py
@@ -335,7 +335,7 @@ class TestConcatenate:
 
         # Align series names to column names
         expected = DataFrame(
-            np.tile(arr, 3).reshape(-1, 1), index=index.to_list() * 3, columns=[0]
+            np.tile(arr, 3).reshape(-1, 1), index=index.tolist() * 3, columns=[0]
         )
         result = concat([s1, df, s2])
         tm.assert_frame_equal(result, expected)
@@ -343,7 +343,7 @@ class TestConcatenate:
         # Separate columns for series not appearing as column names
         expected = DataFrame(
             np.kron(np.where(np.identity(3) == 1, 1, np.nan), arr).T,
-            index=index.to_list() * 3,
+            index=index.tolist() * 3,
             columns=["foo", 0, "bar"],
         )
         result = concat([s1.rename("foo"), df, s2.rename("bar")])


### PR DESCRIPTION
- [x] closes #15047
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v2.2.0.rst` file if fixing a bug or adding a new feature.
