### PR TITLE
Backport PR #56160 on branch 2.1.x (BUG: reset_index not preserving object dtype for string option)

### DIFF
--- a/doc/source/whatsnew/v2.1.4.rst
+++ b/doc/source/whatsnew/v2.1.4.rst
@@ -31,6 +31,8 @@ Bug fixes
 - Fixed bug in :meth:`DataFrame.to_hdf` raising when columns have ``StringDtype`` (:issue:`55088`)
 - Fixed bug in :meth:`Index.insert` casting object-dtype to PyArrow backed strings when ``infer_string`` option is set (:issue:`55638`)
 - Fixed bug in :meth:`Series.__ne__` resulting in False for comparison between ``NA`` and string value for ``dtype="string[pyarrow_numpy]"`` (:issue:`56122`)
+- Fixed bug in :meth:`Series.mode` not keeping object dtype when ``infer_string`` is set (:issue:`56183`)
+- Fixed bug in :meth:`Series.reset_index` not preserving object dtype when ``infer_string`` is set (:issue:`56160`)
 - Fixed bug in :meth:`Series.str.split` and :meth:`Series.str.rsplit` when ``pat=None`` for :class:`ArrowDtype` with ``pyarrow.string`` (:issue:`56271`)
 - Fixed bug in :meth:`Series.str.translate` losing object dtype when string option is set (:issue:`56152`)
 -

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1652,7 +1652,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
                 return new_ser.__finalize__(self, method="reset_index")
             else:
                 return self._constructor(
-                    self._values.copy(), index=new_index, copy=False
+                    self._values.copy(), index=new_index, copy=False, dtype=self.dtype
                 ).__finalize__(self, method="reset_index")
         elif inplace:
             raise TypeError(

--- a/pandas/tests/series/methods/test_reset_index.py
+++ b/pandas/tests/series/methods/test_reset_index.py
@@ -11,6 +11,7 @@ from pandas import (
     RangeIndex,
     Series,
     date_range,
+    option_context,
 )
 import pandas._testing as tm
 
@@ -154,6 +155,14 @@ class TestResetIndex:
         ser.reset_index(name="new", drop=True, inplace=True)
         expected = Series(range(2), name="old")
         tm.assert_series_equal(ser, expected)
+
+    def test_reset_index_drop_infer_string(self):
+        # GH#56160
+        pytest.importorskip("pyarrow")
+        ser = Series(["a", "b", "c"], dtype=object)
+        with option_context("future.infer_string", True):
+            result = ser.reset_index(drop=True)
+        tm.assert_series_equal(result, ser)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#56160