### PR TITLE
DOC: fix a typo in Resampler.interpolate

### DIFF
--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -937,7 +937,7 @@ class Resampler(BaseGroupBy, PandasObject):
 
         The original index is first reindexed to target timestamps
         (see :meth:`core.resample.Resampler.asfreq`),
-        then the interpolation of ``NaN`` values via :meth`DataFrame.interpolate`
+        then the interpolation of ``NaN`` values via :meth:`DataFrame.interpolate`
         happens.
 
         Parameters


### PR DESCRIPTION
A colon is missing, which makes the [doc](https://pandas.pydata.org/docs/dev/reference/api/pandas.api.typing.Resampler.interpolate.html) not rendered correctly.
