### PR TITLE
BUG: merge_asof(tolerance=Timedelta) with ArrowDtype

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -666,6 +666,7 @@ Reshaping
 - Bug in :func:`concat` renaming :class:`Series` when ``ignore_index=False`` (:issue:`15047`)
 - Bug in :func:`merge_asof` raising ``TypeError`` when ``by`` dtype is not ``object``, ``int64``, or ``uint64`` (:issue:`22794`)
 - Bug in :func:`merge_asof` raising incorrect error for string dtype (:issue:`56444`)
+- Bug in :func:`merge_asof` when using a :class:`Timedelta` tolerance on a :class:`ArrowDtype` column (:issue:`56486`)
 - Bug in :func:`merge` returning columns in incorrect order when left and/or right is empty (:issue:`51929`)
 - Bug in :meth:`DataFrame.melt` where an exception was raised if ``var_name`` was not a string (:issue:`55948`)
 - Bug in :meth:`DataFrame.melt` where it would not preserve the datetime (:issue:`55254`)

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -3577,6 +3577,29 @@ def test_merge_asof_extension_dtype(dtype):
     tm.assert_frame_equal(result, expected)
 
 
+@td.skip_if_no("pyarrow")
+def test_merge_asof_pyarrow_td_tolerance():
+    # GH 56486
+    ser = pd.Series(
+        [datetime.datetime(2023, 1, 1)], dtype="timestamp[us, UTC][pyarrow]"
+    )
+    df = pd.DataFrame(
+        {
+            "timestamp": ser,
+            "value": [1],
+        }
+    )
+    result = merge_asof(df, df, on="timestamp", tolerance=Timedelta("1s"))
+    expected = pd.DataFrame(
+        {
+            "timestamp": ser,
+            "value_x": [1],
+            "value_y": [1],
+        }
+    )
+    tm.assert_frame_equal(result, expected)
+
+
 def test_merge_asof_read_only_ndarray():
     # GH 53513
     left = pd.Series([2], index=[2], name="left")


### PR DESCRIPTION
- [ ] closes #56486 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
