### PR TITLE
updated sphinx-lint version to 0.9.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,7 +111,7 @@ repos:
         types: [text]  # overwrite types: [rst]
         types_or: [python, rst]
 -   repo: https://github.com/sphinx-contrib/sphinx-lint
-    rev: v0.9.0
+    rev: v0.9.1
     hooks:
     - id: sphinx-lint
 -   repo: https://github.com/pre-commit/mirrors-clang-format


### PR DESCRIPTION
When installing pre-commit an error occured:


<details>

[INFO] Initializing environment for https://github.com/hauntsaninja/black-pre-commit-mirror.
[INFO] Initializing environment for https://github.com/astral-sh/ruff-pre-commit.
[INFO] Initializing environment for https://github.com/jendrikseipp/vulture.
[INFO] Initializing environment for https://github.com/codespell-project/codespell.
[INFO] Initializing environment for https://github.com/codespell-project/codespell:tomli.
[INFO] Initializing environment for https://github.com/MarcoGorelli/cython-lint.
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Initializing environment for https://github.com/pylint-dev/pylint.
[INFO] Initializing environment for https://github.com/PyCQA/isort.
[INFO] Initializing environment for https://github.com/asottile/pyupgrade.
[INFO] Initializing environment for https://github.com/pre-commit/pygrep-hooks.
[INFO] Initializing environment for https://github.com/sphinx-contrib/sphinx-lint.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-clang-format.
[INFO] Initializing environment for local:pyright@1.1.318.
[INFO] Initializing environment for local.
[INFO] Initializing environment for local:tomli,pyyaml.
[INFO] Installing environment for https://github.com/hauntsaninja/black-pre-commit-mirror.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/astral-sh/ruff-pre-commit.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/jendrikseipp/vulture.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/codespell-project/codespell.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/MarcoGorelli/cython-lint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/pyupgrade.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/sphinx-contrib/sphinx-lint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/home/rscholz/.cache/pre-commit/repowxkp5dtr/py_env-python3.11/bin/python', '-mpip', 'install', '.')
return code: 1
stdout:
    Processing /home/rscholz/.cache/pre-commit/repowxkp5dtr
      Installing build dependencies: started
      Installing build dependencies: finished with status 'done'
      Getting requirements to build wheel: started
      Getting requirements to build wheel: finished with status 'done'
      Preparing metadata (pyproject.toml): started
      Preparing metadata (pyproject.toml): finished with status 'error'
stderr:
      error: subprocess-exited-with-error
      
      × Preparing metadata (pyproject.toml) did not run successfully.
      │ exit code: 1
      ╰─> [43 lines of output]
          /tmp/pip-build-env-dwi5iwha/overlay/lib/python3.11/site-packages/setuptools_scm/git.py:163: UserWarning: "/home/rscholz/.cache/pre-commit/repowxkp5dtr" is shallow and may cause errors
            warnings.warn(f'"{wd.path}" is shallow and may cause errors')
          Traceback (most recent call last):
            File "/home/rscholz/.cache/pre-commit/repowxkp5dtr/py_env-python3.11/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
              main()
            File "/home/rscholz/.cache/pre-commit/repowxkp5dtr/py_env-python3.11/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
              json_out['return_val'] = hook(**hook_input['kwargs'])
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/home/rscholz/.cache/pre-commit/repowxkp5dtr/py_env-python3.11/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 152, in prepare_metadata_for_build_wheel
              whl_basename = backend.build_wheel(metadata_directory, config_settings)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/tmp/pip-build-env-dwi5iwha/overlay/lib/python3.11/site-packages/hatchling/build.py", line 58, in build_wheel
              return os.path.basename(next(builder.build(directory=wheel_directory, versions=['standard'])))
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/tmp/pip-build-env-dwi5iwha/overlay/lib/python3.11/site-packages/hatchling/builders/plugin/interface.py", line 155, in build
              artifact = version_api[version](directory, **build_data)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/tmp/pip-build-env-dwi5iwha/overlay/lib/python3.11/site-packages/hatchling/builders/wheel.py", line 412, in build_standard
              for included_file in self.recurse_included_files():
            File "/tmp/pip-build-env-dwi5iwha/overlay/lib/python3.11/site-packages/hatchling/builders/plugin/interface.py", line 176, in recurse_included_files
              yield from self.recurse_selected_project_files()
            File "/tmp/pip-build-env-dwi5iwha/overlay/lib/python3.11/site-packages/hatchling/builders/plugin/interface.py", line 180, in recurse_selected_project_files
              if self.config.only_include:
                 ^^^^^^^^^^^^^^^^^^^^^^^^
            File "/tmp/pip-build-env-dwi5iwha/overlay/lib/python3.11/site-packages/hatchling/builders/config.py", line 781, in only_include
              only_include = only_include_config.get('only-include', self.default_only_include()) or self.packages
                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/tmp/pip-build-env-dwi5iwha/overlay/lib/python3.11/site-packages/hatchling/builders/wheel.py", line 231, in default_only_include
              return self.default_file_selection_options.only_include
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/home/rscholz/.pyenv/versions/3.11.6/lib/python3.11/functools.py", line 1001, in __get__
              val = self.func(instance)
                    ^^^^^^^^^^^^^^^^^^^
            File "/tmp/pip-build-env-dwi5iwha/overlay/lib/python3.11/site-packages/hatchling/builders/wheel.py", line 219, in default_file_selection_options
              raise ValueError(message)
          ValueError: Unable to determine which files to ship inside the wheel using the following heuristics: https://hatch.pypa.io/latest/plugins/builder/wheel/#default-file-selection
          
          At least one file selection option must be defined in the `tool.hatch.build.targets.wheel` table, see: https://hatch.pypa.io/latest/config/build/
          
          As an example, if you intend to ship a directory named `foo` that resides within a `src` directory located at the root of your project, you can define the following:
          
          [tool.hatch.build.targets.wheel]
          packages = ["src/foo"]
          [end of output]
      
      note: This error originates from a subprocess, and is likely not a problem with pip.
    error: metadata-generation-failed
    
    × Encountered error while generating package metadata.
    ╰─> See above for output.
    
    note: This is an issue with the package mentioned above, not pip.
    hint: See above for details.
Check the log at /home/rscholz/.cache/pre-commit/pre-commit.log


</details>

This was fixed in sphinx-lint 0.9.1: https://github.com/sphinx-contrib/sphinx-lint/releases/tag/v0.9.1
