### PR TITLE
CoW: Set a bunch of Series copy statements to False

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1160,7 +1160,10 @@ class FrameRowApply(FrameApply):
             for j in range(values.shape[1]):
                 # Create the series
                 ser = Series(
-                    values[:, j], index=df_index, name=maybe_cast_str(col_names[j])
+                    values[:, j],
+                    index=df_index,
+                    name=maybe_cast_str(col_names[j]),
+                    copy=False,
                 )
                 results[j] = jitted_udf(ser)
             return results

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1160,10 +1160,7 @@ class FrameRowApply(FrameApply):
             for j in range(values.shape[1]):
                 # Create the series
                 ser = Series(
-                    values[:, j],
-                    index=df_index,
-                    name=maybe_cast_str(col_names[j]),
-                    copy=False,
+                    values[:, j], index=df_index, name=maybe_cast_str(col_names[j])
                 )
                 results[j] = jitted_udf(ser)
             return results

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2188,7 +2188,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         """
         return self._cython_agg_general(
             "any",
-            alt=lambda x: Series(x).any(skipna=skipna),
+            alt=lambda x: Series(x, copy=False).any(skipna=skipna),
             skipna=skipna,
         )
 
@@ -2245,7 +2245,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         """
         return self._cython_agg_general(
             "all",
-            alt=lambda x: Series(x).all(skipna=skipna),
+            alt=lambda x: Series(x, copy=False).all(skipna=skipna),
             skipna=skipna,
         )
 
@@ -2438,7 +2438,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         else:
             result = self._cython_agg_general(
                 "mean",
-                alt=lambda x: Series(x).mean(numeric_only=numeric_only),
+                alt=lambda x: Series(x, copy=False).mean(numeric_only=numeric_only),
                 numeric_only=numeric_only,
             )
             return result.__finalize__(self.obj, method="groupby")
@@ -2518,7 +2518,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         """
         result = self._cython_agg_general(
             "median",
-            alt=lambda x: Series(x).median(numeric_only=numeric_only),
+            alt=lambda x: Series(x, copy=False).median(numeric_only=numeric_only),
             numeric_only=numeric_only,
         )
         return result.__finalize__(self.obj, method="groupby")
@@ -2627,7 +2627,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         else:
             return self._cython_agg_general(
                 "std",
-                alt=lambda x: Series(x).std(ddof=ddof),
+                alt=lambda x: Series(x, copy=False).std(ddof=ddof),
                 numeric_only=numeric_only,
                 ddof=ddof,
             )
@@ -2734,7 +2734,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         else:
             return self._cython_agg_general(
                 "var",
-                alt=lambda x: Series(x).var(ddof=ddof),
+                alt=lambda x: Series(x, copy=False).var(ddof=ddof),
                 numeric_only=numeric_only,
                 ddof=ddof,
             )
@@ -2964,7 +2964,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             )
         return self._cython_agg_general(
             "sem",
-            alt=lambda x: Series(x).sem(ddof=ddof),
+            alt=lambda x: Series(x, copy=False).sem(ddof=ddof),
             numeric_only=numeric_only,
             ddof=ddof,
         )

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -720,7 +720,7 @@ class BaseGrouper:
             out = np.bincount(ids[ids != -1], minlength=ngroups)
         else:
             out = []
-        return Series(out, index=self.result_index, dtype="int64")
+        return Series(out, index=self.result_index, dtype="int64", copy=False)
 
     @cache_readonly
     def groups(self) -> dict[Hashable, np.ndarray]:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -722,7 +722,7 @@ class Index(IndexOpsMixin, PandasObject):
         assert len(duplicates)
 
         out = (
-            Series(np.arange(len(self)))
+            Series(np.arange(len(self)), copy=False)
             .groupby(self, observed=False)
             .agg(list)[duplicates]
         )

--- a/pandas/io/sas/sas7bdat.py
+++ b/pandas/io/sas/sas7bdat.py
@@ -100,10 +100,10 @@ def _convert_datetimes(sas_datetimes: pd.Series, unit: str) -> pd.Series:
             sas_datetimes._values, unit="s", out_unit="ms"
         )
         dt64ms = millis.view("M8[ms]") + td
-        return pd.Series(dt64ms, index=sas_datetimes.index)
+        return pd.Series(dt64ms, index=sas_datetimes.index, copy=False)
     else:
         vals = np.array(sas_datetimes, dtype="M8[D]") + td
-        return pd.Series(vals, dtype="M8[s]", index=sas_datetimes.index)
+        return pd.Series(vals, dtype="M8[s]", index=sas_datetimes.index, copy=False)
 
 
 class _Column:
@@ -727,7 +727,7 @@ class SAS7BDATReader(ReaderBase, abc.Iterator):
 
             if self._column_types[j] == b"d":
                 col_arr = self._byte_chunk[jb, :].view(dtype=self.byte_order + "d")
-                rslt[name] = pd.Series(col_arr, dtype=np.float64, index=ix)
+                rslt[name] = pd.Series(col_arr, dtype=np.float64, index=ix, copy=False)
                 if self.convert_dates:
                     if self.column_formats[j] in const.sas_date_formats:
                         rslt[name] = _convert_datetimes(rslt[name], "d")
@@ -735,7 +735,7 @@ class SAS7BDATReader(ReaderBase, abc.Iterator):
                         rslt[name] = _convert_datetimes(rslt[name], "s")
                 jb += 1
             elif self._column_types[j] == b"s":
-                rslt[name] = pd.Series(self._string_chunk[js, :], index=ix)
+                rslt[name] = pd.Series(self._string_chunk[js, :], index=ix, copy=False)
                 if self.convert_text and (self.encoding is not None):
                     rslt[name] = self._decode_string(rslt[name].str)
                 js += 1

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -494,11 +494,11 @@ def _datetime_to_stata_elapsed_vec(dates: Series, fmt: str) -> Series:
     else:
         raise ValueError(f"Format {fmt} is not a known Stata date format")
 
-    conv_dates = Series(conv_dates, dtype=np.float64)
+    conv_dates = Series(conv_dates, dtype=np.float64, copy=False)
     missing_value = struct.unpack("<d", b"\x00\x00\x00\x00\x00\x00\xe0\x7f")[0]
     conv_dates[bad_loc] = missing_value
 
-    return Series(conv_dates, index=index)
+    return Series(conv_dates, index=index, copy=False)
 
 
 excessive_string_length_error: Final = """


### PR DESCRIPTION
Because the default is now `copy=True` for numpy array input when CoW is enabled, we can explicitly disable copying when we know the data is newly generated.