### PR TITLE
DOC: Add example using ``dtype_backend="numpy_nullable"`` to ``read_json``

### DIFF
--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -763,6 +763,20 @@ def read_json(
 {{"index":"row 2","col 1":"c","col 2":"d"}}]\
 }}\
 '
+
+    The following example uses ``dtype_backend="numpy_nullable"``
+
+    >>> data = '''{{"index": {{"0": 0, "1": 1}},
+    ...        "a": {{"0": 1, "1": null}},
+    ...        "b": {{"0": 2.5, "1": 4.5}},
+    ...        "c": {{"0": true, "1": false}},
+    ...        "d": {{"0": "a", "1": "b"}},
+    ...        "e": {{"0": 1577.2, "1": 1577.1}}}}'''
+    >>> df = pd.read_json(StringIO(data), dtype_backend="numpy_nullable")
+    >>> print(df)
+       index     a    b      c  d       e
+    0      0     1  2.5   True  a  1577.2
+    1      1  <NA>  4.5  False  b  1577.1
     """
     if orient == "table" and dtype:
         raise ValueError("cannot pass both dtype and orient='table'")

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -772,8 +772,7 @@ def read_json(
     ...        "c": {{"0": true, "1": false}},
     ...        "d": {{"0": "a", "1": "b"}},
     ...        "e": {{"0": 1577.2, "1": 1577.1}}}}'''
-    >>> df = pd.read_json(StringIO(data), dtype_backend="numpy_nullable")
-    >>> print(df)
+    >>> pd.read_json(StringIO(data), dtype_backend="numpy_nullable")
        index     a    b      c  d       e
     0      0     1  2.5   True  a  1577.2
     1      1  <NA>  4.5  False  b  1577.1


### PR DESCRIPTION
- [x] [closes](https://github.com/noatamir/pyladies-berlin-sprints/issues/4)