### PR TITLE
Revert "DOC: Change core paths to api.typing in URLs (#55626)"

### DIFF
--- a/doc/source/reference/groupby.rst
+++ b/doc/source/reference/groupby.rst
@@ -5,7 +5,7 @@
 =======
 GroupBy
 =======
-.. currentmodule:: pandas.api.typing
+.. currentmodule:: pandas.core.groupby
 
 :class:`pandas.api.typing.DataFrameGroupBy` and :class:`pandas.api.typing.SeriesGroupBy`
 instances are returned by groupby calls :func:`pandas.DataFrame.groupby` and
@@ -40,7 +40,7 @@ Function application helper
 
    NamedAgg
 
-.. currentmodule:: pandas.api.typing
+.. currentmodule:: pandas.core.groupby
 
 Function application
 --------------------

--- a/doc/source/reference/resampling.rst
+++ b/doc/source/reference/resampling.rst
@@ -5,7 +5,7 @@
 ==========
 Resampling
 ==========
-.. currentmodule:: pandas.api.typing
+.. currentmodule:: pandas.core.resample
 
 :class:`pandas.api.typing.Resampler` instances are returned by
 resample calls: :func:`pandas.DataFrame.resample`, :func:`pandas.Series.resample`.

--- a/doc/source/reference/window.rst
+++ b/doc/source/reference/window.rst
@@ -17,7 +17,7 @@ calls: :func:`pandas.DataFrame.ewm` and :func:`pandas.Series.ewm`.
 
 Rolling window functions
 ------------------------
-.. currentmodule:: pandas.api.typing
+.. currentmodule:: pandas.core.window.rolling
 
 .. autosummary::
    :toctree: api/
@@ -44,7 +44,7 @@ Rolling window functions
 
 Weighted window functions
 -------------------------
-.. currentmodule:: pandas.api.typing
+.. currentmodule:: pandas.core.window.rolling
 
 .. autosummary::
    :toctree: api/
@@ -58,7 +58,7 @@ Weighted window functions
 
 Expanding window functions
 --------------------------
-.. currentmodule:: pandas.api.typing
+.. currentmodule:: pandas.core.window.expanding
 
 .. autosummary::
    :toctree: api/
@@ -85,7 +85,7 @@ Expanding window functions
 
 Exponentially-weighted window functions
 ---------------------------------------
-.. currentmodule:: pandas.api.typing
+.. currentmodule:: pandas.core.window.ewm
 
 .. autosummary::
    :toctree: api/


### PR DESCRIPTION
This reverts commit 5c7d89db4583bfa8cf628235f4d566d104776278.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Reverting this as we don't want to change the URLs twice, pending #55632. 