### PR TITLE
CI: Disable linkecheck

### DIFF
--- a/.github/workflows/broken-linkcheck.yml
+++ b/.github/workflows/broken-linkcheck.yml
@@ -9,6 +9,7 @@ on:
       - "doc/make.py"
 jobs:
   linkcheck:
+    if: false
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Since this job is not fully ready yet, going to disable as it can "fail" if the right files were modified