### PR TITLE
TST: Remove arraymanager markers

### DIFF
--- a/pandas/tests/copy_view/test_astype.py
+++ b/pandas/tests/copy_view/test_astype.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 
 from pandas.compat.pyarrow import pa_version_under12p0
-import pandas.util._test_decorators as td
 
 import pandas as pd
 from pandas import (
@@ -88,7 +87,6 @@ def test_astype_different_target_dtype(using_copy_on_write, dtype):
     tm.assert_frame_equal(df2, df_orig.astype(dtype))
 
 
-@td.skip_array_manager_invalid_test
 def test_astype_numpy_to_ea():
     ser = Series([1, 2, 3])
     with pd.option_context("mode.copy_on_write", True):

--- a/pandas/tests/copy_view/test_internals.py
+++ b/pandas/tests/copy_view/test_internals.py
@@ -1,15 +1,12 @@
 import numpy as np
 import pytest
 
-import pandas.util._test_decorators as td
-
 import pandas as pd
 from pandas import DataFrame
 import pandas._testing as tm
 from pandas.tests.copy_view.util import get_array
 
 
-@td.skip_array_manager_invalid_test
 def test_consolidate(using_copy_on_write):
     # create unconsolidated DataFrame
     df = DataFrame({"a": [1, 2, 3], "b": [0.1, 0.2, 0.3]})
@@ -46,7 +43,6 @@ def test_consolidate(using_copy_on_write):
 
 
 @pytest.mark.single_cpu
-@td.skip_array_manager_invalid_test
 def test_switch_options():
     # ensure we can switch the value of the option within one session
     # (assuming data is constructed after switching)
@@ -75,7 +71,6 @@ def test_switch_options():
         assert df.iloc[0, 0] == 0
 
 
-@td.skip_array_manager_invalid_test
 @pytest.mark.parametrize("dtype", [np.intp, np.int8])
 @pytest.mark.parametrize(
     "locs, arr",

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -15,7 +15,6 @@ from pandas.errors import (
     PerformanceWarning,
     SettingWithCopyError,
 )
-import pandas.util._test_decorators as td
 
 from pandas.core.dtypes.common import is_integer
 
@@ -574,7 +573,6 @@ class TestDataFrameIndexing:
         with pytest.raises(KeyError, match=r"^3$"):
             df2.loc[3:11] = 0
 
-    @td.skip_array_manager_invalid_test  # already covered in test_iloc_col_slice_view
     def test_fancy_getitem_slice_mixed(
         self, float_frame, float_string_frame, using_copy_on_write, warn_copy_on_write
     ):
@@ -640,7 +638,6 @@ class TestDataFrameIndexing:
             for idx in f.index[::5]:
                 assert ix[idx, col] == ts[idx]
 
-    @td.skip_array_manager_invalid_test  # TODO(ArrayManager) rewrite not using .values
     def test_setitem_fancy_scalar(self, float_frame):
         f = float_frame
         expected = float_frame.copy()
@@ -680,7 +677,6 @@ class TestDataFrameIndexing:
         expected = f.reindex(index=f.index[boolvec], columns=["C", "D"])
         tm.assert_frame_equal(result, expected)
 
-    @td.skip_array_manager_invalid_test  # TODO(ArrayManager) rewrite not using .values
     def test_setitem_fancy_boolean(self, float_frame):
         # from 2d, set with booleans
         frame = float_frame.copy()
@@ -1406,7 +1402,6 @@ class TestDataFrameIndexing:
         expected = DataFrame({"a": [np.nan, val]})
         tm.assert_frame_equal(df, expected)
 
-    @td.skip_array_manager_invalid_test
     def test_iloc_setitem_enlarge_no_warning(self, warn_copy_on_write):
         # GH#47381
         df = DataFrame(columns=["a", "b"])

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -3,8 +3,6 @@ from datetime import datetime
 import numpy as np
 import pytest
 
-import pandas.util._test_decorators as td
-
 from pandas.core.dtypes.base import _registry as ea_registry
 from pandas.core.dtypes.common import is_object_dtype
 from pandas.core.dtypes.dtypes import (
@@ -704,8 +702,6 @@ class TestDataFrameSetItem:
         expected = DataFrame({"a": [1, 2]}, dtype="Int64")
         tm.assert_frame_equal(df, expected)
 
-    # TODO(ArrayManager) set column with 2d column array, see #44788
-    @td.skip_array_manager_not_yet_implemented
     def test_setitem_npmatrix_2d(self):
         # GH#42376
         # for use-case df["x"] = sparse.random((10, 10)).mean(axis=1)
@@ -1063,7 +1059,6 @@ class TestDataFrameSetItemCallable:
 
 
 class TestDataFrameSetItemBooleanMask:
-    @td.skip_array_manager_invalid_test  # TODO(ArrayManager) rewrite not using .values
     @pytest.mark.parametrize(
         "mask_type",
         [lambda df: df > np.abs(df) / 2, lambda df: (df > np.abs(df) / 2).values],
@@ -1310,7 +1305,6 @@ class TestDataFrameSetitemCopyViewSemantics:
         df[indexer] = set_value
         tm.assert_frame_equal(view, expected)
 
-    @td.skip_array_manager_invalid_test
     def test_setitem_column_update_inplace(
         self, using_copy_on_write, warn_copy_on_write
     ):

--- a/pandas/tests/frame/methods/test_copy.py
+++ b/pandas/tests/frame/methods/test_copy.py
@@ -46,7 +46,6 @@ class TestCopy:
         copy = float_string_frame.copy()
         assert copy._mgr is not float_string_frame._mgr
 
-    @td.skip_array_manager_invalid_test
     def test_copy_consolidates(self):
         # GH#42477
         df = DataFrame(

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -3,8 +3,6 @@ import pytest
 
 from pandas._config import using_pyarrow_string_dtype
 
-import pandas.util._test_decorators as td
-
 from pandas import (
     Categorical,
     DataFrame,
@@ -49,7 +47,6 @@ class TestFillNA:
         if not using_copy_on_write:
             assert tm.shares_memory(df.iloc[:, 2], orig.iloc[:, 2])
 
-    @td.skip_array_manager_not_yet_implemented
     def test_fillna_on_column_view(self, using_copy_on_write):
         # GH#46149 avoid unnecessary copies
         arr = np.full((40, 50), np.nan)
@@ -752,7 +749,6 @@ class TestFillNA:
         df.fillna(axis=1, value=100, limit=1, inplace=True)
         tm.assert_frame_equal(df, expected)
 
-    @td.skip_array_manager_invalid_test
     @pytest.mark.parametrize("val", [-1, {"x": -1, "y": -1}])
     def test_inplace_dict_update_view(
         self, val, using_copy_on_write, warn_copy_on_write

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -474,14 +474,8 @@ class TestDataFrameInterpolate:
 
     @pytest.mark.parametrize("multiblock", [True, False])
     @pytest.mark.parametrize("method", ["ffill", "bfill", "pad"])
-    def test_interp_fillna_methods(
-        self, request, axis, multiblock, method, using_array_manager
-    ):
+    def test_interp_fillna_methods(self, axis, multiblock, method):
         # GH 12918
-        if using_array_manager and axis in (1, "columns"):
-            # TODO(ArrayManager) support axis=1
-            td.mark_array_manager_not_yet_implemented(request)
-
         df = DataFrame(
             {
                 "A": [1.0, 2.0, 3.0, 4.0, np.nan, 5.0],

--- a/pandas/tests/frame/methods/test_is_homogeneous_dtype.py
+++ b/pandas/tests/frame/methods/test_is_homogeneous_dtype.py
@@ -1,15 +1,10 @@
 import numpy as np
 import pytest
 
-import pandas.util._test_decorators as td
-
 from pandas import (
     Categorical,
     DataFrame,
 )
-
-# _is_homogeneous_type always returns True for ArrayManager
-pytestmark = td.skip_array_manager_invalid_test
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/frame/methods/test_reindex.py
+++ b/pandas/tests/frame/methods/test_reindex.py
@@ -13,7 +13,6 @@ from pandas.compat import (
     is_platform_windows,
 )
 from pandas.compat.numpy import np_version_gt2
-import pandas.util._test_decorators as td
 
 import pandas as pd
 from pandas import (
@@ -136,7 +135,6 @@ class TestDataFrameSelectReindex:
         reason="Passes int32 values to DatetimeArray in make_na_array on "
         "windows, 32bit linux builds",
     )
-    @td.skip_array_manager_not_yet_implemented
     def test_reindex_tzaware_fill_value(self):
         # GH#52586
         df = DataFrame([[1]])
@@ -198,7 +196,6 @@ class TestDataFrameSelectReindex:
         else:
             assert not np.shares_memory(result2[0].array._data, df[0].array._data)
 
-    @td.skip_array_manager_not_yet_implemented
     def test_reindex_date_fill_value(self):
         # passing date to dt64 is deprecated; enforced in 2.0 to cast to object
         arr = date_range("2016-01-01", periods=6).values.reshape(3, 2)

--- a/pandas/tests/frame/methods/test_shift.py
+++ b/pandas/tests/frame/methods/test_shift.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-import pandas.util._test_decorators as td
-
 import pandas as pd
 from pandas import (
     CategoricalIndex,
@@ -466,7 +464,6 @@ class TestDataFrameShift:
 
         tm.assert_frame_equal(result, expected)
 
-    @td.skip_array_manager_not_yet_implemented  # TODO(ArrayManager) axis=1 support
     def test_shift_axis1_multiple_blocks_with_int_fill(self):
         # GH#42719
         rng = np.random.default_rng(2)

--- a/pandas/tests/frame/methods/test_to_dict_of_blocks.py
+++ b/pandas/tests/frame/methods/test_to_dict_of_blocks.py
@@ -1,16 +1,12 @@
 import numpy as np
 import pytest
 
-import pandas.util._test_decorators as td
-
 from pandas import (
     DataFrame,
     MultiIndex,
 )
 import pandas._testing as tm
 from pandas.core.arrays import NumpyExtensionArray
-
-pytestmark = td.skip_array_manager_invalid_test
 
 
 class TestToDictOfBlocks:

--- a/pandas/tests/frame/methods/test_to_numpy.py
+++ b/pandas/tests/frame/methods/test_to_numpy.py
@@ -1,7 +1,5 @@
 import numpy as np
 
-import pandas.util._test_decorators as td
-
 from pandas import (
     DataFrame,
     Timestamp,
@@ -22,7 +20,6 @@ class TestToNumpy:
         result = df.to_numpy(dtype="int64")
         tm.assert_numpy_array_equal(result, expected)
 
-    @td.skip_array_manager_invalid_test
     def test_to_numpy_copy(self, using_copy_on_write):
         arr = np.random.default_rng(2).standard_normal((4, 3))
         df = DataFrame(arr)

--- a/pandas/tests/frame/methods/test_transpose.py
+++ b/pandas/tests/frame/methods/test_transpose.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-import pandas.util._test_decorators as td
-
 from pandas import (
     DataFrame,
     DatetimeIndex,
@@ -126,7 +124,6 @@ class TestTranspose:
         for col, s in mixed_T.items():
             assert s.dtype == np.object_
 
-    @td.skip_array_manager_invalid_test
     def test_transpose_get_view(self, float_frame, using_copy_on_write):
         dft = float_frame.T
         dft.iloc[:, 5:10] = 5
@@ -136,7 +133,6 @@ class TestTranspose:
         else:
             assert (float_frame.values[5:10] == 5).all()
 
-    @td.skip_array_manager_invalid_test
     def test_transpose_get_view_dt64tzget_view(self, using_copy_on_write):
         dti = date_range("2016-01-01", periods=6, tz="US/Pacific")
         arr = dti._data.reshape(3, 2)

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-import pandas.util._test_decorators as td
-
 import pandas as pd
 from pandas import (
     DataFrame,
@@ -175,7 +173,6 @@ class TestDataFrameUpdate:
         )
         tm.assert_frame_equal(df, expected)
 
-    @td.skip_array_manager_invalid_test
     def test_update_modify_view(
         self, using_copy_on_write, warn_copy_on_write, using_infer_string
     ):

--- a/pandas/tests/frame/methods/test_values.py
+++ b/pandas/tests/frame/methods/test_values.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-import pandas.util._test_decorators as td
-
 from pandas import (
     DataFrame,
     NaT,
@@ -15,7 +13,6 @@ import pandas._testing as tm
 
 
 class TestDataFrameValues:
-    @td.skip_array_manager_invalid_test
     def test_values(self, float_frame, using_copy_on_write):
         if using_copy_on_write:
             with pytest.raises(ValueError, match="read-only"):
@@ -231,7 +228,6 @@ class TestDataFrameValues:
 
 
 class TestPrivateValues:
-    @td.skip_array_manager_invalid_test
     def test_private_values_dt64tz(self, using_copy_on_write):
         dta = date_range("2000", periods=4, tz="US/Central")._data.reshape(-1, 1)
 
@@ -249,7 +245,6 @@ class TestPrivateValues:
         df2 = df - df
         tm.assert_equal(df2._values, tda)
 
-    @td.skip_array_manager_invalid_test
     def test_private_values_dt64tz_multicol(self, using_copy_on_write):
         dta = date_range("2000", periods=8, tz="US/Central")._data.reshape(-1, 2)
 

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -13,8 +13,6 @@ import pytest
 
 from pandas._config import using_pyarrow_string_dtype
 
-import pandas.util._test_decorators as td
-
 import pandas as pd
 from pandas import (
     DataFrame,
@@ -894,15 +892,10 @@ class TestFrameArithmetic:
         tm.assert_frame_equal(result, expected)
 
     def test_df_arith_2d_array_rowlike_broadcasts(
-        self, request, all_arithmetic_operators, using_array_manager
+        self, request, all_arithmetic_operators
     ):
         # GH#23000
         opname = all_arithmetic_operators
-
-        if using_array_manager and opname in ("__rmod__", "__rfloordiv__"):
-            # TODO(ArrayManager) decide on dtypes
-            td.mark_array_manager_not_yet_implemented(request)
-
         arr = np.arange(6).reshape(3, 2)
         df = DataFrame(arr, columns=[True, False], index=["A", "B", "C"])
 
@@ -921,15 +914,10 @@ class TestFrameArithmetic:
         tm.assert_frame_equal(result, expected)
 
     def test_df_arith_2d_array_collike_broadcasts(
-        self, request, all_arithmetic_operators, using_array_manager
+        self, request, all_arithmetic_operators
     ):
         # GH#23000
         opname = all_arithmetic_operators
-
-        if using_array_manager and opname in ("__rmod__", "__rfloordiv__"):
-            # TODO(ArrayManager) decide on dtypes
-            td.mark_array_manager_not_yet_implemented(request)
-
         arr = np.arange(6).reshape(3, 2)
         df = DataFrame(arr, columns=[True, False], index=["A", "B", "C"])
 

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -8,7 +8,6 @@ import numpy as np
 import pytest
 
 from pandas.errors import PerformanceWarning
-import pandas.util._test_decorators as td
 
 import pandas as pd
 from pandas import (
@@ -24,11 +23,6 @@ from pandas.core.internals.blocks import NumpyBlock
 
 # Segregated collection of methods that require the BlockManager internal data
 # structure
-
-
-# TODO(ArrayManager) check which of those tests need to be rewritten to test the
-# equivalent for ArrayManager
-pytestmark = td.skip_array_manager_invalid_test
 
 
 class TestDataFrameBlockInternals:

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -25,7 +25,6 @@ from pandas._config import using_pyarrow_string_dtype
 
 from pandas._libs import lib
 from pandas.errors import IntCastingNaNError
-import pandas.util._test_decorators as td
 
 from pandas.core.dtypes.common import is_integer_dtype
 from pandas.core.dtypes.dtypes import (
@@ -325,7 +324,6 @@ class TestDataFrameConstructors:
             df2 = DataFrame(df.values, dtype=df[0].dtype)
             assert df2._mgr.arrays[0].flags.c_contiguous
 
-    @td.skip_array_manager_invalid_test
     @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="conversion copies")
     def test_1d_object_array_does_not_copy(self):
         # https://github.com/pandas-dev/pandas/issues/39272
@@ -333,7 +331,6 @@ class TestDataFrameConstructors:
         df = DataFrame(arr, copy=False)
         assert np.shares_memory(df.values, arr)
 
-    @td.skip_array_manager_invalid_test
     @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="conversion copies")
     def test_2d_object_array_does_not_copy(self):
         # https://github.com/pandas-dev/pandas/issues/39272
@@ -2328,15 +2325,10 @@ class TestDataFrameConstructors:
     @pytest.mark.parametrize(
         "dtype", tm.STRING_DTYPES + tm.BYTES_DTYPES + tm.OBJECT_DTYPES
     )
-    def test_check_dtype_empty_string_column(self, request, dtype, using_array_manager):
+    def test_check_dtype_empty_string_column(self, dtype):
         # GH24386: Ensure dtypes are set correctly for an empty DataFrame.
         # Empty DataFrame is generated via dictionary data with non-overlapping columns.
         data = DataFrame({"a": [1, 2]}, columns=["b"], dtype=dtype)
-
-        if using_array_manager and dtype in tm.BYTES_DTYPES:
-            # TODO(ArrayManager) astype to bytes dtypes does not yet give object dtype
-            td.mark_array_manager_not_yet_implemented(request)
-
         assert data.b.dtype.name == "object"
 
     def test_to_frame_with_falsey_names(self):
@@ -2511,21 +2503,11 @@ class TestDataFrameConstructors:
     @pytest.mark.parametrize("copy", [False, True])
     def test_dict_nocopy(
         self,
-        request,
         copy,
         any_numeric_ea_dtype,
         any_numpy_dtype,
-        using_array_manager,
         using_copy_on_write,
     ):
-        if (
-            using_array_manager
-            and not copy
-            and any_numpy_dtype not in tm.STRING_DTYPES + tm.BYTES_DTYPES
-        ):
-            # TODO(ArrayManager) properly honor copy keyword for dict input
-            td.mark_array_manager_not_yet_implemented(request)
-
         a = np.array([1, 2], dtype=any_numpy_dtype)
         b = np.array([3, 4], dtype=any_numpy_dtype)
         if b.dtype.kind in ["S", "U"]:

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -1710,7 +1710,6 @@ class TestDataFrameReductions:
         with pytest.raises(ValueError, match=msg):
             getattr(obj, all_reductions)(skipna=None)
 
-    @td.skip_array_manager_invalid_test
     def test_reduction_timestamp_smallest_unit(self):
         # GH#52524
         df = DataFrame(
@@ -1729,7 +1728,6 @@ class TestDataFrameReductions:
         )
         tm.assert_series_equal(result, expected)
 
-    @td.skip_array_manager_not_yet_implemented
     def test_reduction_timedelta_smallest_unit(self):
         # GH#52524
         df = DataFrame(

--- a/pandas/tests/groupby/test_bin_groupby.py
+++ b/pandas/tests/groupby/test_bin_groupby.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from pandas._libs import lib
-import pandas.util._test_decorators as td
 
 import pandas as pd
 import pandas._testing as tm
@@ -22,7 +21,7 @@ def cumsum_max(x):
     "func",
     [
         cumsum_max,
-        pytest.param(assert_block_lengths, marks=td.skip_array_manager_invalid_test),
+        assert_block_lengths,
     ],
 )
 def test_mgr_locs_updated(func):

--- a/pandas/tests/indexing/multiindex/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/multiindex/test_chaining_and_caching.py
@@ -3,7 +3,6 @@ import pytest
 
 from pandas._libs import index as libindex
 from pandas.errors import SettingWithCopyError
-import pandas.util._test_decorators as td
 
 from pandas import (
     DataFrame,
@@ -43,7 +42,6 @@ def test_detect_chained_assignment(using_copy_on_write, warn_copy_on_write):
                 zed["eyes"]["right"].fillna(value=555, inplace=True)
 
 
-@td.skip_array_manager_invalid_test  # with ArrayManager df.loc[0] is not a view
 def test_cache_updating(using_copy_on_write, warn_copy_on_write):
     # 5216
     # make sure that we don't try to set a dead cache

--- a/pandas/tests/indexing/multiindex/test_partial.py
+++ b/pandas/tests/indexing/multiindex/test_partial.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-import pandas.util._test_decorators as td
-
 from pandas import (
     DataFrame,
     DatetimeIndex,
@@ -118,9 +116,6 @@ class TestMultiIndexPartial:
         with pytest.raises(KeyError, match=r"\('a', 'foo'\)"):
             df.loc[("a", "foo"), :]
 
-    # TODO(ArrayManager) rewrite test to not use .values
-    # exp.loc[2000, 4].values[:] select multiple columns -> .values is not a view
-    @td.skip_array_manager_invalid_test
     def test_partial_set(
         self,
         multiindex_year_month_day_dataframe_random_data,

--- a/pandas/tests/indexing/multiindex/test_setitem.py
+++ b/pandas/tests/indexing/multiindex/test_setitem.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from pandas.errors import SettingWithCopyError
-import pandas.util._test_decorators as td
 
 import pandas as pd
 from pandas import (
@@ -126,9 +125,6 @@ class TestMultiIndexSetItem:
             expected=copy,
         )
 
-    # TODO(ArrayManager) df.loc["bar"] *= 2 doesn't raise an error but results in
-    # all NaNs -> doesn't work in the "split" path (also for BlockManager actually)
-    @td.skip_array_manager_not_yet_implemented
     def test_multiindex_setitem(self):
         # GH 3738
         # setting with a multi-index right hand side
@@ -520,8 +516,6 @@ class TestSetitemWithExpansionMultiIndex:
         tm.assert_frame_equal(df, expected)
 
 
-@td.skip_array_manager_invalid_test  # df["foo"] select multiple columns -> .values
-# is not a view
 def test_frame_setitem_view_direct(
     multiindex_dataframe_random_data, using_copy_on_write
 ):

--- a/pandas/tests/indexing/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/test_chaining_and_caching.py
@@ -7,7 +7,6 @@ from pandas.errors import (
     SettingWithCopyError,
     SettingWithCopyWarning,
 )
-import pandas.util._test_decorators as td
 
 import pandas as pd
 from pandas import (
@@ -558,8 +557,6 @@ class TestChaining:
                 chained[2] = rhs
                 tm.assert_frame_equal(df, df_original)
 
-    # TODO(ArrayManager) fast_xs with array-like scalars is not yet working
-    @td.skip_array_manager_not_yet_implemented
     def test_chained_getitem_with_lists(self):
         # GH6394
         # Regression in chained getitem indexing with embedded list-like from

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 
 from pandas.errors import IndexingError
-import pandas.util._test_decorators as td
 
 from pandas import (
     NA,
@@ -1200,7 +1199,6 @@ class TestiLocBaseIndependent:
         expected = DataFrame({"status": ["a", "a", "c"]}, dtype=df["status"].dtype)
         tm.assert_frame_equal(df, expected)
 
-    @td.skip_array_manager_not_yet_implemented
     def test_iloc_getitem_int_single_ea_block_view(self):
         # GH#45241
         # TODO: make an extension interface test for this?

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -17,7 +17,6 @@ from pandas._config import using_pyarrow_string_dtype
 from pandas._libs import index as libindex
 from pandas.compat.numpy import np_version_gt2
 from pandas.errors import IndexingError
-import pandas.util._test_decorators as td
 
 import pandas as pd
 from pandas import (
@@ -2646,7 +2645,6 @@ class TestLocBooleanMask:
         assert expected == result
         tm.assert_frame_equal(df, df_copy)
 
-    @td.skip_array_manager_invalid_test  # TODO(ArrayManager) rewrite not using .values
     def test_loc_setitem_boolean_and_column(self, float_frame):
         expected = float_frame.copy()
         mask = float_frame["A"] > 0
@@ -3321,7 +3319,6 @@ class TestLocSeries:
 
         tm.assert_frame_equal(df, expected)
 
-    @td.skip_array_manager_invalid_test
     def test_loc_setitem_dict_timedelta_multiple_set(self):
         # GH 16309
         result = DataFrame(columns=["time", "value"])

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -10,7 +10,6 @@ import pytest
 
 from pandas._libs.internals import BlockPlacement
 from pandas.compat import IS64
-import pandas.util._test_decorators as td
 
 from pandas.core.dtypes.common import is_scalar
 
@@ -43,10 +42,6 @@ from pandas.core.internals.blocks import (
     maybe_coerce_values,
     new_block,
 )
-
-# this file contains BlockManager specific tests
-# TODO(ArrayManager) factor out interleave_dtype tests
-pytestmark = td.skip_array_manager_invalid_test
 
 
 @pytest.fixture(params=[new_block, make_block])

--- a/pandas/tests/io/pytables/test_append.py
+++ b/pandas/tests/io/pytables/test_append.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs import Timestamp
-import pandas.util._test_decorators as td
 
 import pandas as pd
 from pandas import (
@@ -733,10 +732,6 @@ def test_append_misc_empty_frame(setup_path):
         tm.assert_frame_equal(store.select("df2"), df)
 
 
-# TODO(ArrayManager) currently we rely on falling back to BlockManager, but
-# the conversion from AM->BM converts the invalid object dtype column into
-# a datetime64 column no longer raising an error
-@td.skip_array_manager_not_yet_implemented
 def test_append_raise(setup_path):
     with ensure_clean_store(setup_path) as store:
         # test append with invalid input to get good error messages

--- a/pandas/tests/io/test_fsspec.py
+++ b/pandas/tests/io/test_fsspec.py
@@ -194,7 +194,6 @@ def test_arrowparquet_options(fsspectest):
     assert fsspectest.test[0] == "parquet_read"
 
 
-@td.skip_array_manager_not_yet_implemented  # TODO(ArrayManager) fastparquet
 def test_fastparquet_options(fsspectest):
     """Regression test for writing to a not-yet-existent GCS Parquet file."""
     pytest.importorskip("fastparquet")
@@ -253,7 +252,6 @@ def test_s3_protocols(s3_public_bucket_with_data, tips_file, protocol, s3so):
 
 
 @pytest.mark.single_cpu
-@td.skip_array_manager_not_yet_implemented  # TODO(ArrayManager) fastparquet
 def test_s3_parquet(s3_public_bucket, s3so, df1):
     pytest.importorskip("fastparquet")
     pytest.importorskip("s3fs")

--- a/pandas/tests/io/test_http_headers.py
+++ b/pandas/tests/io/test_http_headers.py
@@ -100,11 +100,9 @@ def stata_responder(df):
         pytest.param(
             parquetfastparquet_responder,
             partial(pd.read_parquet, engine="fastparquet"),
-            # TODO(ArrayManager) fastparquet
             marks=[
                 td.skip_if_no("fastparquet"),
                 td.skip_if_no("fsspec"),
-                td.skip_array_manager_not_yet_implemented,
             ],
         ),
         (pickle_respnder, pd.read_pickle),

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -37,7 +37,6 @@ from pandas.compat import (
 )
 from pandas.compat._optional import import_optional_dependency
 from pandas.compat.compressors import flatten_buffer
-import pandas.util._test_decorators as td
 
 import pandas as pd
 from pandas import (
@@ -600,7 +599,6 @@ def test_pickle_strings(string_series):
     tm.assert_series_equal(unp_series, string_series)
 
 
-@td.skip_array_manager_invalid_test
 def test_pickle_preserves_block_ndim():
     # GH#37631
     ser = Series(list("abc")).astype("category").iloc[[0]]

--- a/pandas/tests/reshape/concat/test_concat.py
+++ b/pandas/tests/reshape/concat/test_concat.py
@@ -10,7 +10,6 @@ import numpy as np
 import pytest
 
 from pandas.errors import InvalidIndexError
-import pandas.util._test_decorators as td
 
 import pandas as pd
 from pandas import (
@@ -777,7 +776,6 @@ def test_concat_retain_attrs(data):
     assert df.attrs[1] == 1
 
 
-@td.skip_array_manager_invalid_test
 @pytest.mark.parametrize("df_dtype", ["float64", "int64", "datetime64[ns]"])
 @pytest.mark.parametrize("empty_dtype", [None, "float64", "object"])
 def test_concat_ignore_empty_object_float(empty_dtype, df_dtype):
@@ -803,7 +801,6 @@ def test_concat_ignore_empty_object_float(empty_dtype, df_dtype):
     tm.assert_frame_equal(result, expected)
 
 
-@td.skip_array_manager_invalid_test
 @pytest.mark.parametrize("df_dtype", ["float64", "int64", "datetime64[ns]"])
 @pytest.mark.parametrize("empty_dtype", [None, "float64", "object"])
 def test_concat_ignore_all_na_object_float(empty_dtype, df_dtype):
@@ -831,7 +828,6 @@ def test_concat_ignore_all_na_object_float(empty_dtype, df_dtype):
     tm.assert_frame_equal(result, expected)
 
 
-@td.skip_array_manager_invalid_test
 def test_concat_ignore_empty_from_reindex():
     # https://github.com/pandas-dev/pandas/pull/43507#issuecomment-920375856
     df1 = DataFrame({"a": [1], "b": [pd.Timestamp("2012-01-01")]})

--- a/pandas/tests/series/methods/test_reindex.py
+++ b/pandas/tests/series/methods/test_reindex.py
@@ -3,8 +3,6 @@ import pytest
 
 from pandas._config import using_pyarrow_string_dtype
 
-import pandas.util._test_decorators as td
-
 from pandas import (
     NA,
     Categorical,
@@ -315,7 +313,6 @@ def test_reindex_fill_value():
     tm.assert_series_equal(result, expected)
 
 
-@td.skip_array_manager_not_yet_implemented
 @pytest.mark.parametrize("dtype", ["datetime64[ns]", "timedelta64[ns]"])
 @pytest.mark.parametrize("fill_value", ["string", 0, Timedelta(0)])
 def test_reindex_fill_value_datetimelike_upcast(dtype, fill_value, using_array_manager):

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -16,7 +16,6 @@ from pandas._libs import (
 )
 from pandas.compat.numpy import np_version_gt2
 from pandas.errors import IntCastingNaNError
-import pandas.util._test_decorators as td
 
 from pandas.core.dtypes.dtypes import CategoricalDtype
 
@@ -702,7 +701,6 @@ class TestSeriesConstructors:
             assert x[0] == 2.0
             assert y[0] == 1.0
 
-    @td.skip_array_manager_invalid_test  # TODO(ArrayManager) rewrite test
     @pytest.mark.parametrize(
         "index",
         [
@@ -2195,7 +2193,6 @@ class TestSeriesConstructorInternals:
             assert isinstance(result._mgr.blocks[0], NumpyBlock)
             assert result._mgr.blocks[0].is_numeric
 
-    @td.skip_array_manager_invalid_test
     def test_from_array(self):
         result = Series(pd.array(["1h", "2h"], dtype="timedelta64[ns]"))
         assert result._mgr.blocks[0].is_extension is False
@@ -2203,7 +2200,6 @@ class TestSeriesConstructorInternals:
         result = Series(pd.array(["2015"], dtype="datetime64[ns]"))
         assert result._mgr.blocks[0].is_extension is False
 
-    @td.skip_array_manager_invalid_test
     def test_from_list_dtype(self):
         result = Series(["1h", "2h"], dtype="timedelta64[ns]")
         assert result._mgr.blocks[0].is_extension is False

--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -38,7 +38,6 @@ from pandas._config import get_option
 if TYPE_CHECKING:
     from pandas._typing import F
 
-from pandas._config.config import _get_option
 
 from pandas.compat import (
     IS64,
@@ -146,21 +145,6 @@ def parametrize_fixture_doc(*args) -> Callable[[F], F]:
 
     return documented_fixture
 
-
-def mark_array_manager_not_yet_implemented(request) -> None:
-    mark = pytest.mark.xfail(reason="Not yet implemented for ArrayManager")
-    request.applymarker(mark)
-
-
-skip_array_manager_not_yet_implemented = pytest.mark.xfail(
-    _get_option("mode.data_manager", silent=True) == "array",
-    reason="Not yet implemented for ArrayManager",
-)
-
-skip_array_manager_invalid_test = pytest.mark.skipif(
-    _get_option("mode.data_manager", silent=True) == "array",
-    reason="Test that relies on BlockManager internals or specific behaviour",
-)
 
 skip_copy_on_write_not_yet_implemented = pytest.mark.xfail(
     get_option("mode.copy_on_write") is True,


### PR DESCRIPTION
No longer really necessary since we don't test this in the CI anymore