### PR TITLE
PERF: resolution, is_normalized

### DIFF
--- a/pandas/_libs/tslibs/vectorized.pyx
+++ b/pandas/_libs/tslibs/vectorized.pyx
@@ -234,7 +234,7 @@ def get_resolution(
 
     for i in range(n):
         # Analogous to: utc_val = stamps[i]
-        utc_val = cnp.PyArray_GETITEM(stamps, cnp.PyArray_ITER_DATA(it))
+        utc_val = (<int64_t*>cnp.PyArray_ITER_DATA(it))[0]
 
         if utc_val == NPY_NAT:
             pass
@@ -331,7 +331,7 @@ def is_date_array_normalized(ndarray stamps, tzinfo tz, NPY_DATETIMEUNIT reso) -
 
     for i in range(n):
         # Analogous to: utc_val = stamps[i]
-        utc_val = cnp.PyArray_GETITEM(stamps, cnp.PyArray_ITER_DATA(it))
+        utc_val = (<int64_t*>cnp.PyArray_ITER_DATA(it))[0]
 
         local_val = info.utc_val_to_local_val(utc_val, &pos)
 


### PR DESCRIPTION
```
dti = pd.date_range("2016-01-01", periods=10_000)
dta = dti._data

In [4]: %timeit dta.is_normalized
354 µs ± 3.62 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)   # <- main
122 µs ± 2.71 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)  # <- PR

In [5]: %timeit dta.resolution
493 µs ± 4.86 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)  # <- main
258 µs ± 10.3 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)  # <- PR
```