### PR TITLE
added validation for series datatypes

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -73,6 +73,7 @@ from pandas.core.dtypes.cast import (
 from pandas.core.dtypes.common import (
     is_dict_like,
     is_integer,
+    is_float,
     is_iterator,
     is_list_like,
     is_object_dtype,
@@ -3102,6 +3103,10 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         --------
         {examples}
         """
+        if not lib.is_integer(periods):
+            if not (is_float(periods) and periods.is_integer()):
+                raise ValueError("periods must be an integer")
+            periods = int(periods)
         result = algorithms.diff(self._values, periods)
         return self._constructor(result, index=self.index, copy=False).__finalize__(
             self, method="diff"


### PR DESCRIPTION
closes #56607 
This fix makes sure Series.diff validates and throws an exception based on the datatype.
Changes made:

- import "is_float" from pandas
- Checking if the input periods are integers/float or not before calling "algorithms.diff"

Behaviour after the changes:
<img width="480" alt="image" src="https://github.com/pandas-dev/pandas/assets/26180886/4f52a26e-11c3-4c24-b07b-168381ee171e">
