### PR TITLE
Fix integral truediv and floordiv for pyarrow types with large divisor and avoid floating points for floordiv

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -777,6 +777,7 @@ Numeric
 ^^^^^^^
 - Bug in :func:`read_csv` with ``engine="pyarrow"`` causing rounding errors for large integers (:issue:`52505`)
 - Bug in :meth:`Series.__floordiv__` for :class:`ArrowDtype` with integral dtypes raising for large values (:issue:`56645`)
+- Bug in :meth:`Series.__floordiv__` for :class:`ArrowDtype` with large integral results (:issue:`56676`)
 - Bug in :meth:`Series.pow` not filling missing values correctly (:issue:`55512`)
 
 Conversion

--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -776,7 +776,6 @@ Timezones
 Numeric
 ^^^^^^^
 - Bug in :func:`read_csv` with ``engine="pyarrow"`` causing rounding errors for large integers (:issue:`52505`)
-- Bug in :meth:`Series.__floordiv__` for :class:`ArrowDtype` causing rounding errors for large integral results (:issue:`56676`)
 - Bug in :meth:`Series.__floordiv__` for :class:`ArrowDtype` with integral dtypes raising for large values (:issue:`56645`)
 - Bug in :meth:`Series.pow` not filling missing values correctly (:issue:`55512`)
 

--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -776,6 +776,7 @@ Timezones
 Numeric
 ^^^^^^^
 - Bug in :func:`read_csv` with ``engine="pyarrow"`` causing rounding errors for large integers (:issue:`52505`)
+- Bug in :meth:`Series.__floordiv__` and :meth:`Series.__truediv__` for :class:`ArrowDtype` with integral dtypes raising for large divisors (:issue:`56706`)
 - Bug in :meth:`Series.__floordiv__` for :class:`ArrowDtype` with integral dtypes raising for large values (:issue:`56645`)
 - Bug in :meth:`Series.pow` not filling missing values correctly (:issue:`55512`)
 

--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -776,8 +776,8 @@ Timezones
 Numeric
 ^^^^^^^
 - Bug in :func:`read_csv` with ``engine="pyarrow"`` causing rounding errors for large integers (:issue:`52505`)
+- Bug in :meth:`Series.__floordiv__` for :class:`ArrowDtype` causing rounding errors for large integral results (:issue:`56676`)
 - Bug in :meth:`Series.__floordiv__` for :class:`ArrowDtype` with integral dtypes raising for large values (:issue:`56645`)
-- Bug in :meth:`Series.__floordiv__` for :class:`ArrowDtype` with large integral results (:issue:`56676`)
 - Bug in :meth:`Series.pow` not filling missing values correctly (:issue:`55512`)
 
 Conversion

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -136,7 +136,10 @@ if not pa_version_under10p1:
                 # which always inferred as int64, to prevent overflow
                 # in case of large uint64 values.
                 pc.and_(
-                    pc.less(divided, pa.scalar(0, type=divided.type)), has_remainder
+                    pc.less(
+                        pc.bit_wise_xor(left, right), pa.scalar(0, type=divided.type)
+                    ),
+                    has_remainder,
                 ),
                 # GH 55561: floordiv should round towards negative infinity.
                 # pv.divide for integral types rounds towards 0.

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -133,11 +133,10 @@ if not pa_version_under10p1:
             has_remainder = pc.not_equal(pc.multiply(divided, right), left)
             result = pc.if_else(
                 pc.less(divided, 0),
-                # Avoid using subtract_checked which has significantly worse perf:
-                # https://github.com/apache/arrow/issues/37678, especially since
-                # integer overflow should be impossible here. Using subtract_checked
-                # would also incorrectly raise for -9223372036854775808 // 1,
-                # if integer overflow occurs, then has_remainder is false.
+                # Avoid using subtract_checked which would incorrectly raise
+                # for -9223372036854775808 // 1, because if integer overflow
+                # occurs, then has_remainder should be false, and overflowed
+                # value is discarded.
                 pc.if_else(has_remainder, pc.subtract(divided, 1), divided),
                 divided,
             )

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -134,7 +134,7 @@ if not pa_version_under10p1:
                 pc.less(divided, 0),
                 # Avoid using subtract_checked which has significantly worse perf:
                 # https://github.com/apache/arrow/issues/37678, especially since
-                # integer overflow should be impossible here/
+                # integer overflow should be impossible here.
                 pc.if_else(has_remainder, pc.subtract(divided, 1), divided),
                 divided,
             )

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -135,7 +135,9 @@ if not pa_version_under10p1:
                 pc.less(divided, 0),
                 # Avoid using subtract_checked which has significantly worse perf:
                 # https://github.com/apache/arrow/issues/37678, especially since
-                # integer overflow should be impossible here.
+                # integer overflow should be impossible here. Using subtract_checked
+                # would also incorrectly raise for -9223372036854775808 // 1,
+                # if integer overflow occurs, then has_remainder is false.
                 pc.if_else(has_remainder, pc.subtract(divided, 1), divided),
                 divided,
             )

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -132,12 +132,12 @@ if not pa_version_under10p1:
             # GH 56676, avoid storing intermediate calculating in floating point type.
             has_remainder = pc.not_equal(pc.multiply(divided, right), left)
             result = pc.if_else(
-                pc.less(divided, 0),
+                pc.and_(pc.less(divided, 0), has_remainder),
                 # Avoid using subtract_checked which would incorrectly raise
                 # for -9223372036854775808 // 1, because if integer overflow
                 # occurs, then has_remainder should be false, and overflowed
                 # value is discarded.
-                pc.if_else(has_remainder, pc.subtract(divided, 1), divided),
+                pc.subtract(divided, 1),
                 divided,
             )
             # Ensure compatibility with older versions of pandas where

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -148,11 +148,11 @@ if not pa_version_under10p1:
                 has_remainder = pc.not_equal(pc.multiply(divided, right), left)
                 result = pc.if_else(
                     pc.and_(
+                        has_remainder,
                         pc.less(
                             pc.bit_wise_xor(left, right),
                             pa.scalar(0, type=divided.type),
                         ),
-                        has_remainder,
                     ),
                     # GH 55561: floordiv should round towards negative infinity.
                     # pc.divide_checked for integral types rounds towards 0.
@@ -167,6 +167,8 @@ if not pa_version_under10p1:
                 # For 2 unsigned integer operands, integer division is
                 # same as floor division.
                 result = divided
+            # Ensure compatibility with older versions of pandas where
+            # int8 // int64 returned int8 rather than int64.
             result = result.cast(left.type)
         else:
             # Use divide instead of divide_checked to match numpy

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -145,9 +145,6 @@ if not pa_version_under10p1:
             # int8 // int64 returned int8 rather than int64.
             result = result.cast(left.type)
         else:
-            assert pa.types.is_floating(divided.type) or pa.types.is_decimal(
-                divided.type
-            )
             result = pc.floor(divided)
         return result
 

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -129,15 +129,22 @@ if not pa_version_under10p1:
     ) -> pa.ChunkedArray:
         divided = pc.divide(left, right)
         if pa.types.is_integer(divided.type):
-            # GH 56676, avoid storing intermediate calculating in floating point type.
+            # GH 56676: avoid storing intermediate calculating in floating point type.
             has_remainder = pc.not_equal(pc.multiply(divided, right), left)
             result = pc.if_else(
-                pc.and_(pc.less(divided, 0), has_remainder),
+                # Pass a typed arrow scalar rather than stdlib int
+                # which always inferred as int64, to prevent overflow
+                # in case of large uint64 values.
+                pc.and_(
+                    pc.less(divided, pa.scalar(0, type=divided.type)), has_remainder
+                ),
+                # GH 55561: floordiv should round towards negative infinity.
+                # pv.divide for integral types rounds towards 0.
                 # Avoid using subtract_checked which would incorrectly raise
                 # for -9223372036854775808 // 1, because if integer overflow
                 # occurs, then has_remainder should be false, and overflowed
                 # value is discarded.
-                pc.subtract(divided, 1),
+                pc.subtract(divided, pa.scalar(1, type=divided.type)),
                 divided,
             )
             # Ensure compatibility with older versions of pandas where

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -129,6 +129,7 @@ if not pa_version_under10p1:
     ) -> pa.ChunkedArray:
         divided = pc.divide(left, right)
         if pa.types.is_integer(divided.type):
+            # GH 56676, avoid storing intermediate calculating in floating point type.
             has_remainder = pc.not_equal(pc.multiply(divided, right), left)
             result = pc.if_else(
                 pc.less(divided, 0),

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -146,13 +146,14 @@ if not pa_version_under10p1:
                 # GH 56676: avoid storing intermediate calculating in
                 # floating point type.
                 has_remainder = pc.not_equal(pc.multiply(divided, right), left)
+                has_one_negative_operand = pc.less(
+                    pc.bit_wise_xor(left, right),
+                    pa.scalar(0, type=divided.type),
+                )
                 result = pc.if_else(
                     pc.and_(
                         has_remainder,
-                        pc.less(
-                            pc.bit_wise_xor(left, right),
-                            pa.scalar(0, type=divided.type),
-                        ),
+                        has_one_negative_operand,
                     ),
                     # GH 55561: floordiv should round towards negative infinity.
                     # pc.divide_checked for integral types rounds towards 0.

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -132,6 +132,9 @@ if not pa_version_under10p1:
             has_remainder = pc.not_equal(pc.multiply(divided, right), left)
             result = pc.if_else(
                 pc.less(divided, 0),
+                # Avoid using subtract_checked which has significantly worse perf:
+                # https://github.com/apache/arrow/issues/37678, especially since
+                # integer overflow should be impossible here/
                 pc.if_else(has_remainder, pc.subtract(divided, 1), divided),
                 divided,
             )

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -149,15 +149,9 @@ if not pa_version_under10p1:
                 result = pc.if_else(
                     pc.and_(
                         has_remainder,
-                        pa.compute.xor(
-                            pa.compute.less(
-                                left,
-                                pa.scalar(0, type=left.type),
-                            ),
-                            pa.compute.less(
-                                right,
-                                pa.scalar(0, type=right.type),
-                            ),
+                        pc.less(
+                            pc.bit_wise_xor(left, right),
+                            pa.scalar(0, type=divided.type),
                         ),
                     ),
                     # GH 55561: floordiv should round towards negative infinity.

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -149,9 +149,15 @@ if not pa_version_under10p1:
                 result = pc.if_else(
                     pc.and_(
                         has_remainder,
-                        pc.less(
-                            pc.bit_wise_xor(left, right),
-                            pa.scalar(0, type=divided.type),
+                        pa.compute.xor(
+                            pa.compute.less(
+                                left,
+                                pa.scalar(0, type=left.type),
+                            ),
+                            pa.compute.less(
+                                right,
+                                pa.scalar(0, type=right.type),
+                            ),
                         ),
                     ),
                     # GH 55561: floordiv should round towards negative infinity.

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -144,7 +144,7 @@ if not pa_version_under10p1:
                     has_remainder,
                 ),
                 # GH 55561: floordiv should round towards negative infinity.
-                # pv.divide for integral types rounds towards 0.
+                # pc.divide_checked for integral types rounds towards 0.
                 # Avoid using subtract_checked which would incorrectly raise
                 # for -9223372036854775808 // 1, because if integer overflow
                 # occurs, then has_remainder should be false, and overflowed

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -109,7 +109,7 @@ if not pa_version_under10p1:
 
     def cast_for_truediv(
         arrow_array: pa.ChunkedArray, pa_object: pa.Array | pa.Scalar
-    ) -> pa.ChunkedArray:
+    ) -> tuple[pa.ChunkedArray, pa.Array | pa.Scalar]:
         # Ensure int / int -> float mirroring Python/Numpy behavior
         # as pc.divide_checked(int, int) -> int
         if pa.types.is_integer(arrow_array.type) and pa.types.is_integer(
@@ -120,8 +120,15 @@ if not pa_version_under10p1:
             # Intentionally not using arrow_array.cast because it could be a scalar
             # value in reflected case, and safe=False only added to
             # scalar cast in pyarrow 13.
-            return pc.cast(arrow_array, pa.float64(), safe=False)
-        return arrow_array
+            # In arrow, common type between integral and float64 is float64,
+            # but integral type is safe casted to float64, to mirror python
+            # and numpy, we want an unsafe cast, so we cast both operands to
+            # to float64 before invoking arrow.
+            return pc.cast(arrow_array, pa.float64(), safe=False), pc.cast(
+                pa_object, pa.float64(), safe=False
+            )
+
+        return arrow_array, pa_object
 
     def floordiv_compat(
         left: pa.ChunkedArray | pa.Array | pa.Scalar,
@@ -170,8 +177,8 @@ if not pa_version_under10p1:
         "rsub": lambda x, y: pc.subtract_checked(y, x),
         "mul": pc.multiply_checked,
         "rmul": lambda x, y: pc.multiply_checked(y, x),
-        "truediv": lambda x, y: pc.divide(cast_for_truediv(x, y), y),
-        "rtruediv": lambda x, y: pc.divide(y, cast_for_truediv(x, y)),
+        "truediv": lambda x, y: pc.divide(*cast_for_truediv(x, y)),
+        "rtruediv": lambda x, y: pc.divide(*cast_for_truediv(y, x)),
         "floordiv": lambda x, y: floordiv_compat(x, y),
         "rfloordiv": lambda x, y: floordiv_compat(y, x),
         "mod": NotImplemented,

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -127,8 +127,10 @@ if not pa_version_under10p1:
         left: pa.ChunkedArray | pa.Array | pa.Scalar,
         right: pa.ChunkedArray | pa.Array | pa.Scalar,
     ) -> pa.ChunkedArray:
-        divided = pc.divide(left, right)
-        if pa.types.is_integer(divided.type):
+        if pa.types.is_integer(left.type) and pa.types.is_integer(right.type):
+            # Use divide_checked to ensure cases like -9223372036854775808 // -1
+            # don't silently overflow.
+            divided = pc.divide_checked(left, right)
             # GH 56676: avoid storing intermediate calculating in floating point type.
             has_remainder = pc.not_equal(pc.multiply(divided, right), left)
             result = pc.if_else(
@@ -154,6 +156,10 @@ if not pa_version_under10p1:
             # int8 // int64 returned int8 rather than int64.
             result = result.cast(left.type)
         else:
+            # Use divide instead of divide_checked to match numpy
+            # floordiv where divide by 0 returns infinity for floating
+            # point types.
+            divided = pc.divide(left, right)
             result = pc.floor(divided)
         return result
 

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3246,60 +3246,71 @@ def test_arrow_floordiv_large_values():
     tm.assert_series_equal(result, expected)
 
 
-def test_arrow_floordiv_large_integral_result():
+@pytest.mark.parametrize("dtype", ["int64[pyarrow]", "uint64[pyarrow]"])
+def test_arrow_floordiv_large_integral_result(dtype):
     # GH 56676
-    a = pd.Series([18014398509481983, -9223372036854775808], dtype="int64[pyarrow]")
+    a = pd.Series([18014398509481983], dtype=dtype)
     result = a // 1
     tm.assert_series_equal(result, a)
 
 
-def test_arrow_floordiv_larger_divisor():
+@pytest.mark.parametrize("pa_type", tm.SIGNED_INT_PYARROW_DTYPES)
+def test_arrow_floordiv_larger_divisor(pa_type):
     # GH 56676
-    a = pd.Series([-23], dtype="int64[pyarrow]")
+    dtype = ArrowDtype(pa_type)
+    a = pd.Series([-23], dtype=dtype)
     result = a // 24
-    expected = pd.Series([-1], dtype="int64[pyarrow]")
+    expected = pd.Series([-1], dtype=dtype)
     tm.assert_series_equal(result, expected)
 
 
-def test_arrow_floordiv_integral_invalid():
+@pytest.mark.parametrize("pa_type", tm.SIGNED_INT_PYARROW_DTYPES)
+def test_arrow_floordiv_integral_invalid(pa_type):
     # GH 56676
-    a = pd.Series([-9223372036854775808], dtype="int64[pyarrow]")
-    with pytest.raises(pa.lib.ArrowInvalid, match="overflow"):
+    min_value = np.iinfo(pa_type.to_pandas_dtype()).min
+    a = pd.Series([min_value], dtype=ArrowDtype(pa_type))
+    with pytest.raises(pa.lib.ArrowInvalid, match="overflow|not in range"):
         a // -1
     with pytest.raises(pa.lib.ArrowInvalid, match="divide by zero"):
         a // 0
 
 
-def test_arrow_floordiv_floating_0_divisor():
+@pytest.mark.parametrize("dtype", tm.FLOAT_PYARROW_DTYPES_STR_REPR)
+def test_arrow_floordiv_floating_0_divisor(dtype):
     # GH 56676
-    a = pd.Series([2], dtype="double[pyarrow]")
+    a = pd.Series([2], dtype=dtype)
     result = a // 0
-    expected = pd.Series([float("inf")], dtype="double[pyarrow]")
+    expected = pd.Series([float("inf")], dtype=dtype)
     tm.assert_series_equal(result, expected)
 
 
-def test_arrow_floordiv_no_overflow():
+@pytest.mark.parametrize("pa_type", tm.ALL_INT_PYARROW_DTYPES)
+def test_arrow_integral_floordiv_large_values(pa_type):
     # GH 56676
-    a = pd.Series([9223372036854775808], dtype="uint64[pyarrow]")
-    b = pd.Series([1], dtype="uint64[pyarrow]")
+    max_value = np.iinfo(pa_type.to_pandas_dtype()).max
+    dtype = ArrowDtype(pa_type)
+    a = pd.Series([max_value], dtype=dtype)
+    b = pd.Series([1], dtype=dtype)
     result = a // b
     tm.assert_series_equal(result, a)
 
 
-def test_arrow_true_division_large_divisor():
+@pytest.mark.parametrize("dtype", ["int64[pyarrow]", "uint64[pyarrow]"])
+def test_arrow_true_division_large_divisor(dtype):
     # GH 56706
-    a = pd.Series([0], dtype="int64[pyarrow]")
-    b = pd.Series([18014398509481983], dtype="int64[pyarrow]")
+    a = pd.Series([0], dtype=dtype)
+    b = pd.Series([18014398509481983], dtype=dtype)
     expected = pd.Series([0], dtype="float64[pyarrow]")
     result = a / b
     tm.assert_series_equal(result, expected)
 
 
-def test_arrow_floor_division_large_divisor():
+@pytest.mark.parametrize("dtype", ["int64[pyarrow]", "uint64[pyarrow]"])
+def test_arrow_floor_division_large_divisor(dtype):
     # GH 56706
-    a = pd.Series([0], dtype="int64[pyarrow]")
-    b = pd.Series([18014398509481983], dtype="int64[pyarrow]")
-    expected = pd.Series([0], dtype="int64[pyarrow]")
+    a = pd.Series([0], dtype=dtype)
+    b = pd.Series([18014398509481983], dtype=dtype)
+    expected = pd.Series([0], dtype=dtype)
     result = a // b
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3261,6 +3261,23 @@ def test_arrow_floordiv_larger_divisor():
     tm.assert_series_equal(result, expected)
 
 
+def test_arrow_floordiv_integral_invalid():
+    # GH 56676
+    a = pd.Series([-9223372036854775808], dtype="int64[pyarrow]")
+    with pytest.raises(pa.lib.ArrowInvalid, match="overflow"):
+        a // -1
+    with pytest.raises(pa.lib.ArrowInvalid, match="divide by zero"):
+        a // 0
+
+
+def test_arrow_floordiv_floating_0_divisor():
+    # GH 56676
+    a = pd.Series([2], dtype="double[pyarrow]")
+    result = a // 0
+    expected = pd.Series([float("inf")], dtype="double[pyarrow]")
+    tm.assert_series_equal(result, expected)
+
+
 def test_arrow_floordiv_no_overflow():
     # GH 56676
     a = pd.Series([9223372036854775808], dtype="uint64[pyarrow]")

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3246,10 +3246,14 @@ def test_arrow_floordiv_large_values():
     tm.assert_series_equal(result, expected)
 
 
-def test_arrow_floordiv_large_integral_result():
+@pytest.mark.parametrize(
+    "value",
+    [18014398509481983, -9223372036854775808],
+)
+def test_arrow_floordiv_large_integral_result(value):
     # GH 56676
-    a = pd.Series([18014398509481983], dtype="int64[pyarrow]")
-    expected = pd.Series([18014398509481983], dtype="int64[pyarrow]")
+    a = pd.Series([value], dtype="int64[pyarrow]")
+    expected = pd.Series([value], dtype="int64[pyarrow]")
     result = a // 1
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3286,6 +3286,24 @@ def test_arrow_floordiv_no_overflow():
     tm.assert_series_equal(result, a)
 
 
+def test_arrow_true_division_large_divisor():
+    # GH 56706
+    a = pd.Series([0], dtype="int64[pyarrow]")
+    b = pd.Series([18014398509481983], dtype="int64[pyarrow]")
+    expected = pd.Series([0], dtype="float64[pyarrow]")
+    result = a / b
+    tm.assert_series_equal(result, expected)
+
+
+def test_arrow_floor_division_large_divisor():
+    # GH 56706
+    a = pd.Series([0], dtype="int64[pyarrow]")
+    b = pd.Series([18014398509481983], dtype="int64[pyarrow]")
+    expected = pd.Series([0], dtype="int64[pyarrow]")
+    result = a // b
+    tm.assert_series_equal(result, expected)
+
+
 def test_string_to_datetime_parsing_cast():
     # GH 56266
     string_dates = ["2020-01-01 04:30:00", "2020-01-02 00:00:00", "2020-01-03 00:00:00"]

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3247,7 +3247,7 @@ def test_arrow_floordiv_large_values():
 
 
 def test_arrow_floordiv_large_integral_result():
-    # GH XXXXX
+    # GH 56676
     a = pd.Series([18014398509481983], dtype="int64[pyarrow]")
     expected = pd.Series([18014398509481983], dtype="int64[pyarrow]")
     result = a // 1

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3253,6 +3253,14 @@ def test_arrow_floordiv_large_integral_result():
     tm.assert_series_equal(result, a)
 
 
+def test_arrow_floordiv_no_overflow():
+    # GH 56676
+    a = pd.Series([9223372036854775808], dtype="uint64[pyarrow]")
+    b = pd.Series([1], dtype="uint64[pyarrow]")
+    result = a // b
+    tm.assert_series_equal(result, a)
+
+
 def test_string_to_datetime_parsing_cast():
     # GH 56266
     string_dates = ["2020-01-01 04:30:00", "2020-01-02 00:00:00", "2020-01-03 00:00:00"]

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3249,11 +3249,8 @@ def test_arrow_floordiv_large_values():
 def test_arrow_floordiv_large_integral_result():
     # GH 56676
     a = pd.Series([18014398509481983, -9223372036854775808], dtype="int64[pyarrow]")
-    expected = pd.Series(
-        [18014398509481983, -9223372036854775808], dtype="int64[pyarrow]"
-    )
     result = a // 1
-    tm.assert_series_equal(result, expected)
+    tm.assert_series_equal(result, a)
 
 
 def test_string_to_datetime_parsing_cast():

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3239,21 +3239,19 @@ def test_arrow_floordiv():
 
 
 def test_arrow_floordiv_large_values():
-    # GH 55561
+    # GH 56645
     a = pd.Series([1425801600000000000], dtype="int64[pyarrow]")
     expected = pd.Series([1425801600000], dtype="int64[pyarrow]")
     result = a // 1_000_000
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    "value",
-    [18014398509481983, -9223372036854775808],
-)
-def test_arrow_floordiv_large_integral_result(value):
+def test_arrow_floordiv_large_integral_result():
     # GH 56676
-    a = pd.Series([value], dtype="int64[pyarrow]")
-    expected = pd.Series([value], dtype="int64[pyarrow]")
+    a = pd.Series([18014398509481983, -9223372036854775808], dtype="int64[pyarrow]")
+    expected = pd.Series(
+        [18014398509481983, -9223372036854775808], dtype="int64[pyarrow]"
+    )
     result = a // 1
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3253,6 +3253,14 @@ def test_arrow_floordiv_large_integral_result():
     tm.assert_series_equal(result, a)
 
 
+def test_arrow_floordiv_larger_divisor():
+    # GH 56676
+    a = pd.Series([-23], dtype="int64[pyarrow]")
+    result = a // 24
+    expected = pd.Series([-1], dtype="int64[pyarrow]")
+    tm.assert_series_equal(result, expected)
+
+
 def test_arrow_floordiv_no_overflow():
     # GH 56676
     a = pd.Series([9223372036854775808], dtype="uint64[pyarrow]")

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3246,6 +3246,14 @@ def test_arrow_floordiv_large_values():
     tm.assert_series_equal(result, expected)
 
 
+def test_arrow_floordiv_large_integral_result():
+    # GH XXXXX
+    a = pd.Series([18014398509481983], dtype="int64[pyarrow]")
+    expected = pd.Series([18014398509481983], dtype="int64[pyarrow]")
+    result = a // 1
+    tm.assert_series_equal(result, expected)
+
+
 def test_string_to_datetime_parsing_cast():
     # GH 56266
     string_dates = ["2020-01-01 04:30:00", "2020-01-02 00:00:00", "2020-01-03 00:00:00"]


### PR DESCRIPTION
- [x] closes #56676(Replace xxxx with the GitHub issue number)
- [x] closes #56706(Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
