### PR TITLE
DOC: Modified docstring of DataFrame.to_dict() to make the usage of orient='records' more clear

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2066,8 +2066,8 @@ class DataFrame(NDFrame, OpsMixin):
         index : bool, default True
             Whether to include the index item (and index_names item if `orient`
             is 'tight') in the returned dictionary. Can only be ``False``
-            when `orient` is 'split' or 'tight'. Note that when `orient` is 
-            'records', this parameter does not take effect (index item always 
+            when `orient` is 'split' or 'tight'. Note that when `orient` is
+            'records', this parameter does not take effect (index item always
             not included).
 
             .. versionadded:: 2.0.0

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2066,7 +2066,9 @@ class DataFrame(NDFrame, OpsMixin):
         index : bool, default True
             Whether to include the index item (and index_names item if `orient`
             is 'tight') in the returned dictionary. Can only be ``False``
-            when `orient` is 'split' or 'tight'.
+            when `orient` is 'split' or 'tight'. Note that when `orient` is 
+            'records', this parameter does not take effect (index item always 
+            not included).
 
             .. versionadded:: 2.0.0
 


### PR DESCRIPTION
Modified documentation for parameter `index` as is mentioned in #56483.
However, I don't think this should be the final solution to this issue. The current behavior remains counter-intuitive and will confuse users who haven't checked the doc.

closes #56483