### PR TITLE
DEPR: by_row="compat" in DataFrame.apply and Series.apply

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -675,6 +675,7 @@ Other Deprecations
 - Deprecated including the groups in computations when using :meth:`.DataFrameGroupBy.apply` and :meth:`.DataFrameGroupBy.resample`; pass ``include_groups=False`` to exclude the groups (:issue:`7155`)
 - Deprecated indexing an :class:`Index`  with a boolean indexer of length zero (:issue:`55820`)
 - Deprecated not passing a tuple to :class:`.DataFrameGroupBy.get_group` or :class:`.SeriesGroupBy.get_group` when grouping by a length-1 list-like (:issue:`25971`)
+- Deprecated specifying ``by_row="compat"`` in :meth:`DataFrame.apply` and :meth:`Series.apply` (:issue:`53400`)
 - Deprecated string ``AS`` denoting frequency in :class:`YearBegin` and strings ``AS-DEC``, ``AS-JAN``, etc. denoting annual frequencies with various fiscal year starts (:issue:`54275`)
 - Deprecated string ``A`` denoting frequency in :class:`YearEnd` and strings ``A-DEC``, ``A-JAN``, etc. denoting annual frequencies with various fiscal year ends (:issue:`54275`)
 - Deprecated string ``BAS`` denoting frequency in :class:`BYearBegin` and strings ``BAS-DEC``, ``BAS-JAN``, etc. denoting annual frequencies with various fiscal year starts (:issue:`54275`)

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1475,6 +1475,15 @@ class SeriesApply(NDFrameApply):
 
         try:
             result = obj.apply(func, by_row="compat")
+            warnings.warn(
+                "apply operated row-by-row. This behavior is "
+                "deprecated and will be removed in a future version of pandas. To keep "
+                "the current behavior of operating row-by-row, use "
+                "map. To have apply operate on the entire Series, "
+                "pass by_row=False.",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
         except (ValueError, AttributeError, TypeError):
             result = obj.apply(func, by_row=False)
         return result

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10182,6 +10182,11 @@ class DataFrame(NDFrame, OpsMixin):
 
             .. versionadded:: 2.1.0
 
+            .. versionchange:: 2.2.0
+
+                Specifying ``by_row="compat"`` is deprecated and will be removed in
+                a future version of pandas. To operate row-by-row, use DataFrame.map.
+
         engine : {'python', 'numba'}, default 'python'
             Choose between the python (default) engine or the numba engine in apply.
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10182,7 +10182,7 @@ class DataFrame(NDFrame, OpsMixin):
 
             .. versionadded:: 2.1.0
 
-            .. versionchange:: 2.2.0
+            .. versionchanged:: 2.2.0
 
                 Specifying ``by_row="compat"`` is deprecated and will be removed in
                 a future version of pandas. To operate row-by-row, use DataFrame.map.

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4804,7 +4804,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
             .. versionadded:: 2.1.0
 
-            .. versionchange:: 2.2.0
+            .. versionchanged:: 2.2.0
 
                 Specifying ``by_row="compat"`` is deprecated and will be removed in
                 a future version of pandas. To operate row-by-row, use Series.map.

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4803,6 +4803,12 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             ``by_row`` has no effect when ``func`` is a string.
 
             .. versionadded:: 2.1.0
+
+            .. versionchange:: 2.2.0
+
+                Specifying ``by_row="compat"`` is deprecated and will be removed in
+                a future version of pandas. To operate row-by-row, use Series.map.
+
         **kwargs
             Additional keyword arguments passed to func.
 


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Followup to #53400. Fell off my radar that this needed to be deprecated. Will only be able to specify `by_row=False` in 3.0, and then the argument will be removed in 4.0.

cc @topper-123 