### PR TITLE
BUG: fix subclass metadata preservation in groupby column selection

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -873,6 +873,7 @@ Groupby/resample/rolling
 - Bug in :meth:`DataFrame.asfreq` and :meth:`Series.asfreq` with a :class:`DatetimeIndex` with non-nanosecond resolution incorrectly converting to nanosecond resolution (:issue:`55958`)
 - Bug in :meth:`DataFrame.ewm` when passed ``times`` with non-nanosecond ``datetime64`` or :class:`DatetimeTZDtype` dtype (:issue:`56262`)
 - Bug in :meth:`DataFrame.groupby` and :meth:`Series.groupby` where grouping by a combination of ``Decimal`` and NA values would fail when ``sort=True`` (:issue:`54847`)
+- Bug in :meth:`DataFrame.groupby` for DataFrame subclasses when selecting a subset of columns to apply the function to (:issue:`56761`)
 - Bug in :meth:`DataFrame.resample` not respecting ``closed`` and ``label`` arguments for :class:`~pandas.tseries.offsets.BusinessDay` (:issue:`55282`)
 - Bug in :meth:`DataFrame.resample` when resampling on a :class:`ArrowDtype` of ``pyarrow.timestamp`` or ``pyarrow.duration`` type (:issue:`55989`)
 - Bug in :meth:`DataFrame.resample` where bin edges were not correct for :class:`~pandas.tseries.offsets.BusinessDay` (:issue:`55281`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4016,7 +4016,9 @@ class DataFrame(NDFrame, OpsMixin):
             copy=False,
             only_slice=True,
         )
-        return self._constructor_from_mgr(new_mgr, axes=new_mgr.axes)
+        result = self._constructor_from_mgr(new_mgr, axes=new_mgr.axes)
+        result = result.__finalize__(self)
+        return result
 
     def __getitem__(self, key):
         check_dict_or_set_indexers(key)

--- a/pandas/tests/groupby/test_groupby_subclass.py
+++ b/pandas/tests/groupby/test_groupby_subclass.py
@@ -69,6 +69,7 @@ def test_groupby_preserves_metadata():
     def func(group):
         assert isinstance(group, tm.SubclassedDataFrame)
         assert hasattr(group, "testattr")
+        assert group.testattr == "hello"
         return group.testattr
 
     msg = "DataFrameGroupBy.apply operated on the grouping columns"
@@ -77,6 +78,12 @@ def test_groupby_preserves_metadata():
     ):
         result = custom_df.groupby("c").apply(func)
     expected = tm.SubclassedSeries(["hello"] * 3, index=Index([7, 8, 9], name="c"))
+    tm.assert_series_equal(result, expected)
+
+    result = custom_df.groupby("c").apply(func, include_groups=False)
+    tm.assert_series_equal(result, expected)
+
+    result = custom_df.groupby("c")[["a", "b"]].apply(func)
     tm.assert_series_equal(result, expected)
 
     def func2(group):

--- a/pandas/tests/groupby/test_groupby_subclass.py
+++ b/pandas/tests/groupby/test_groupby_subclass.py
@@ -83,6 +83,7 @@ def test_groupby_preserves_metadata():
     result = custom_df.groupby("c").apply(func, include_groups=False)
     tm.assert_series_equal(result, expected)
 
+    # https://github.com/pandas-dev/pandas/pull/56761
     result = custom_df.groupby("c")[["a", "b"]].apply(func)
     tm.assert_series_equal(result, expected)
 


### PR DESCRIPTION
This is a small regression that was introduced with https://github.com/pandas-dev/pandas/pull/51090 (in pandas 2.0): before that PR, the column subselection in the groupby code was done with a standard `__getitem__` call, while the PR introduced an optimized helper `_getitem_nocopy` to avoid the copy that a standard `__getitem__` does. However, that new helper forgot to add a `__finalize__` call after `_constructor` from a manager.

The reason we noticed this in geopandas (https://github.com/geopandas/geopandas/pull/3130) was to update our tests for the `apply` deprecation to include group columns (for which one alternative is to specifically select the non-group columns, but so that didn't work with recent pandas versions)