### PR TITLE
DOC: Avoid requesting data from s3 buckets from our docs

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -3017,11 +3017,10 @@ Biomedical and Life Science Jorurnals:
 
 .. code-block:: python
 
-   df = pd.read_xml(
+   pd.read_xml(
        "s3://pmc-oa-opendata/oa_comm/xml/all/PMC1236943.xml",
        xpath=".//journal-meta",
    )
-   df
 
 With `lxml`_ as default ``parser``, you access the full-featured XML library
 that extends Python's ElementTree API. One powerful tool is ability to query

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -3015,8 +3015,7 @@ Read in the content of the "books.xml" as instance of ``StringIO`` or
 Even read XML from AWS S3 buckets such as NIH NCBI PMC Article Datasets providing
 Biomedical and Life Science Jorurnals:
 
-.. ipython:: python
-   :okwarning:
+.. code-block:: python
 
    df = pd.read_xml(
        "s3://pmc-oa-opendata/oa_comm/xml/all/PMC1236943.xml",

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -3021,7 +3021,7 @@ Biomedical and Life Science Jorurnals:
    ...    "s3://pmc-oa-opendata/oa_comm/xml/all/PMC1236943.xml",
    ...    xpath=".//journal-meta",
    ...)
-   >>> df.head(1)
+   >>> df
          journal-id  journal-title  issn  publisher
    0 Cardiovasc Ultrasound Cardiovascular Ultrasound 1476-7120 NaN
 

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -1704,7 +1704,7 @@ option parameter:
 
 .. code-block:: python
 
-   storage_options = {"client_kwargs": {"endpoint_url": "http://127.0.0.1:5555"}}}
+   storage_options = {"client_kwargs": {"endpoint_url": "http://127.0.0.1:5555"}}
    df = pd.read_json("s3://pandas-test/test-1", storage_options=storage_options)
 
 More sample configurations and documentation can be found at `S3Fs documentation

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -1722,7 +1722,7 @@ data by specifying an anonymous connection, such as
        "-D20130523-T080854_to_SaKe2013-D20130523-T085643.csv",
        storage_options={"anon": True},
    )
-   
+
 ``fsspec`` also allows complex URLs, for accessing data in compressed
 archives, local caching of files, and more. To locally cache the above
 example, you would modify the call to

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -1717,11 +1717,18 @@ data by specifying an anonymous connection, such as
 
 .. code-block:: python
 
-   pd.read_csv(
-       "s3://ncei-wcsd-archive/data/processed/SH1305/18kHz/SaKe2013"
-       "-D20130523-T080854_to_SaKe2013-D20130523-T085643.csv",
-       storage_options={"anon": True},
-   )
+   >>> df = pd.read_csv(
+   ...    "s3://ncei-wcsd-archive/data/processed/SH1305/18kHz/SaKe2013"
+   ...    "-D20130523-T080854_to_SaKe2013-D20130523-T085643.csv",
+   ...    storage_options={"anon": True},
+   ...)
+   >>> df.columns
+   Index(['Ping_index', ' Distance_gps', ' Distance_vl', ' Ping_date',
+         ' Ping_time', ' Ping_milliseconds', ' Latitude', ' Longitude',
+         ' Depth_start', ' Depth_stop', ' Range_start', ' Range_stop',
+         ' Sample_count'],
+         dtype='object')
+
 
 ``fsspec`` also allows complex URLs, for accessing data in compressed
 archives, local caching of files, and more. To locally cache the above
@@ -3017,10 +3024,13 @@ Biomedical and Life Science Jorurnals:
 
 .. code-block:: python
 
-   pd.read_xml(
-       "s3://pmc-oa-opendata/oa_comm/xml/all/PMC1236943.xml",
-       xpath=".//journal-meta",
-   )
+   >>> df = pd.read_xml(
+   ...    "s3://pmc-oa-opendata/oa_comm/xml/all/PMC1236943.xml",
+   ...    xpath=".//journal-meta",
+   ...)
+   >>> df.head(1)
+         journal-id  journal-title  issn  publisher
+   0 Cardiovasc Ultrasound Cardiovascular Ultrasound 1476-7120 NaN
 
 With `lxml`_ as default ``parser``, you access the full-featured XML library
 that extends Python's ElementTree API. One powerful tool is ability to query

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -1717,19 +1717,12 @@ data by specifying an anonymous connection, such as
 
 .. code-block:: python
 
-   >>> df = pd.read_csv(
-   ...    "s3://ncei-wcsd-archive/data/processed/SH1305/18kHz/SaKe2013"
-   ...    "-D20130523-T080854_to_SaKe2013-D20130523-T085643.csv",
-   ...    storage_options={"anon": True},
-   ...)
-   >>> df.columns
-   Index(['Ping_index', ' Distance_gps', ' Distance_vl', ' Ping_date',
-         ' Ping_time', ' Ping_milliseconds', ' Latitude', ' Longitude',
-         ' Depth_start', ' Depth_stop', ' Range_start', ' Range_stop',
-         ' Sample_count'],
-         dtype='object')
-
-
+   pd.read_csv(
+       "s3://ncei-wcsd-archive/data/processed/SH1305/18kHz/SaKe2013"
+       "-D20130523-T080854_to_SaKe2013-D20130523-T085643.csv",
+       storage_options={"anon": True},
+   )
+   
 ``fsspec`` also allows complex URLs, for accessing data in compressed
 archives, local caching of files, and more. To locally cache the above
 example, you would modify the call to

--- a/doc/source/whatsnew/v2.3.0.rst
+++ b/doc/source/whatsnew/v2.3.0.rst
@@ -211,8 +211,6 @@ Styler
 
 Other
 ^^^^^
-- Bug when building html documentation from ``doc\source\user_guide\io.rst`` no longer calls S3 bucket URL (:issue:`56592`)
-
 .. ***DO NOT USE THIS SECTION***
 
 -

--- a/doc/source/whatsnew/v2.3.0.rst
+++ b/doc/source/whatsnew/v2.3.0.rst
@@ -211,6 +211,7 @@ Styler
 
 Other
 ^^^^^
+
 .. ***DO NOT USE THIS SECTION***
 
 -

--- a/doc/source/whatsnew/v2.3.0.rst
+++ b/doc/source/whatsnew/v2.3.0.rst
@@ -206,6 +206,7 @@ Styler
 
 Other
 ^^^^^
+- Bug when building html documentation from ``doc\source\user_guide\io.rst`` no longer calls S3 bucket URL (:issue:`56592`)
 
 .. ***DO NOT USE THIS SECTION***
 


### PR DESCRIPTION
- [x] closes #56592
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v2.3.0.rst` file if fixing a bug or adding a new feature.

ipython code chunk would make call to S3 bucket URL. Most often harmless and therefore not easy to replicate, but some users reported error when building html documentation (see issue  #56592) when there was some access issue to the S3 bucket URL. Decision was to change to code block to avoid calls. 