### PR TITLE
Update on_bad_lines logic in python_parser.py

### DIFF
--- a/pandas/io/parsers/python_parser.py
+++ b/pandas/io/parsers/python_parser.py
@@ -1030,7 +1030,7 @@ class PythonParser(ParserBase):
             for i, _content in iter_content:
                 actual_len = len(_content)
 
-                if actual_len > col_len:
+                if actual_len != col_len:
                     if callable(self.on_bad_lines):
                         new_l = self.on_bad_lines(_content)
                         if new_l is not None:


### PR DESCRIPTION
On_bad_lines only considers a bad line as "a line with too many fields" and silently pads NaNs for rows with missing fields.  Either consider all rows with inconsistent fields as a bad line, as I am proposing here (tested only with our framework, and we log those error details as part of file validation), or also have a param like "allow_jagged_rows = true/false" so users can decide whether to pad or use this logic proposed.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
