### PR TITLE
PERF: Index.take to check for full range indices

### DIFF
--- a/doc/source/whatsnew/v2.3.0.rst
+++ b/doc/source/whatsnew/v2.3.0.rst
@@ -101,7 +101,7 @@ Deprecations
 
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
--
+- Performance improvement in :meth:`Index.take` when ``indices`` is a full range indexer from zero to length of index (:issue:`56806`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1157,7 +1157,7 @@ class Index(IndexOpsMixin, PandasObject):
         indices = ensure_platform_int(indices)
         allow_fill = self._maybe_disallow_fill(allow_fill, fill_value, indices)
 
-        if lib.is_range_indexer(indices, len(self)):
+        if indices.ndim == 1 and lib.is_range_indexer(indices, len(self)):
             return self.copy()
 
         # Note: we discard fill_value and use self._na_value, only relevant

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1157,6 +1157,9 @@ class Index(IndexOpsMixin, PandasObject):
         indices = ensure_platform_int(indices)
         allow_fill = self._maybe_disallow_fill(allow_fill, fill_value, indices)
 
+        if lib.is_range_indexer(indices, len(self)):
+            return self.copy()
+
         # Note: we discard fill_value and use self._na_value, only relevant
         #  in the case where allow_fill is True and fill_value is not None
         values = self._values

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2247,6 +2247,9 @@ class MultiIndex(Index):
         # only fill if we are passing a non-None fill_value
         allow_fill = self._maybe_disallow_fill(allow_fill, fill_value, indices)
 
+        if lib.is_range_indexer(indices, len(self)):
+            return self.copy()
+
         na_value = -1
 
         taken = [lab.take(indices) for lab in self.codes]

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2247,7 +2247,7 @@ class MultiIndex(Index):
         # only fill if we are passing a non-None fill_value
         allow_fill = self._maybe_disallow_fill(allow_fill, fill_value, indices)
 
-        if lib.is_range_indexer(indices, len(self)):
+        if indices.ndim == 1 and lib.is_range_indexer(indices, len(self)):
             return self.copy()
 
         na_value = -1


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.3.0.rst` file if fixing a bug or adding a new feature.


```
import pandas as pd
import numpy as np

N = 1_000_000
idx = pd.Index(np.arange(N))
indices = np.arange(N)

%timeit idx.take(indices)

# 11.1 ms ± 271 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)   -> main
# 1.33 ms ± 279 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  -> PR
```

Motivating use-case:

```
idx1 = pd.Index(np.tile(np.arange(1000), 1000))
idx2 = pd.Index(np.arange(100))

%timeit idx1.join(idx2, how="left")

# 132 ms ± 1.43 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)  -> main
# 110 ms ± 587 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)   -> PR
```