### PR TITLE
ENH: Add missing parameters to read_gbq for BigQuery

### DIFF
--- a/doc/source/whatsnew/v2.3.0.rst
+++ b/doc/source/whatsnew/v2.3.0.rst
@@ -169,8 +169,8 @@ MultiIndex
 
 I/O
 ^^^
--
--
+- Bug in :func:`read_gbq` that was missing parameters ``progress_bar_type``, ``dtypes``, ``auth_redirect_uri``, ``client_id``, ``columns``, which ``col_order`` is now an alias of (:issue:``)
+-  
 
 Period
 ^^^^^^

--- a/doc/source/whatsnew/v2.3.0.rst
+++ b/doc/source/whatsnew/v2.3.0.rst
@@ -110,7 +110,7 @@ Performance improvements
 Bug fixes
 ~~~~~~~~~
 - Fixed bug in :meth:`Series.diff` allowing non-integer values for the ``periods`` argument. (:issue:`56607`)
-
+-
 
 Categorical
 ^^^^^^^^^^^

--- a/doc/source/whatsnew/v2.3.0.rst
+++ b/doc/source/whatsnew/v2.3.0.rst
@@ -169,8 +169,8 @@ MultiIndex
 
 I/O
 ^^^
-- Bug in :func:`read_gbq` that was missing parameters ``progress_bar_type``, ``dtypes``, ``auth_redirect_uri``, ``client_id``, ``columns``, which ``col_order`` is now an alias of (:issue:``)
--  
+- Bug in :func:`read_gbq` that was missing parameters ``progress_bar_type``, ``dtypes``, ``auth_redirect_uri``, ``client_id``, ``columns``, which ``col_order`` is now an alias of (:issue:`#56826`)
+-
 
 Period
 ^^^^^^

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -30,10 +30,10 @@ def _try_import() -> ModuleType:
 
 
 def read_gbq(
-    query: str,
+    query_or_table: str,
     project_id: str | None = None,
     index_col: str | None = None,
-    col_order: list[str] | None = None,
+    columns: list[str] | None = None,
     reauth: bool = False,
     auth_local_webserver: bool = True,
     dialect: str | None = None,
@@ -43,6 +43,12 @@ def read_gbq(
     use_bqstorage_api: bool | None = None,
     max_results: int | None = None,
     progress_bar_type: str | None = None,
+    dtypes: dict[str, Any] | None = None,
+    auth_redirect_uri: str | None = None,
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    col_order: list[str] | None = None,
+
 ) -> DataFrame:
     """
     Load data from Google BigQuery.
@@ -60,14 +66,14 @@ def read_gbq(
 
     Parameters
     ----------
-    query : str
+    query_or_table : str
         SQL-Like Query to return data values.
     project_id : str, optional
         Google BigQuery Account project ID. Optional when available from
         the environment.
     index_col : str, optional
         Name of result column to use for index in results DataFrame.
-    col_order : list(str), optional
+    columns : list(str), optional
         List of BigQuery column names in the desired order for results
         DataFrame.
     reauth : bool, default False
@@ -162,6 +168,26 @@ def read_gbq(
         ``'tqdm_gui'``
             Use the :func:`tqdm.tqdm_gui` function to display a
             progress bar as a graphical dialog box.
+    
+    dtypes : dict, optional
+        A dictionary of column names to pandas ``dtype``. The provided
+        ``dtype`` is used when constructing the series for the column
+        specified. Otherwise, a default ``dtype`` is used.
+
+    auth_redirect_uri : str
+        Path to the authentication page for organization-specific authentication
+        workflows. Used when ``auth_local_webserver=False``.
+
+    client_id : str
+        The Client ID for the Google Cloud Project the user is attempting to
+        connect to.
+
+    client_secret : str
+        The Client Secret associated with the Client ID for the Google Cloud Project
+        the user is attempting to connect to.
+
+    col_order : list(str), optional
+        Alias for columns, retained for backwards compatibility.
 
     Returns
     -------
@@ -202,15 +228,26 @@ def read_gbq(
         kwargs["use_bqstorage_api"] = use_bqstorage_api
     if max_results is not None:
         kwargs["max_results"] = max_results
-
-    kwargs["progress_bar_type"] = progress_bar_type
+    if progress_bar_type is not None:
+        kwargs["progress_bar_type"] = progress_bar_type
+    if dtypes is not None:
+        kwargs["dtypes"] = dtypes
+    if auth_redirect_uri is not None:
+        kwargs["auth_redirect_uri"] = auth_redirect_uri
+    if client_id is not None:
+        kwargs["client_id"] = client_id
+    if client_secret is not None:
+        kwargs["client_secret"] = client_secret
+    if columns is not None:
+        kwargs["columns"] = columns
+    if col_order is not None:
+        kwargs["col_order"] = col_order
     # END: new kwargs
 
     return pandas_gbq.read_gbq(
-        query,
+        query_or_table=query_or_table,
         project_id=project_id,
         index_col=index_col,
-        col_order=col_order,
         reauth=reauth,
         auth_local_webserver=auth_local_webserver,
         dialect=dialect,

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -48,7 +48,6 @@ def read_gbq(
     client_id: str | None = None,
     client_secret: str | None = None,
     col_order: list[str] | None = None,
-
 ) -> DataFrame:
     """
     Load data from Google BigQuery.
@@ -168,7 +167,7 @@ def read_gbq(
         ``'tqdm_gui'``
             Use the :func:`tqdm.tqdm_gui` function to display a
             progress bar as a graphical dialog box.
-    
+
     dtypes : dict, optional
         A dictionary of column names to pandas ``dtype``. The provided
         ``dtype`` is used when constructing the series for the column

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -220,7 +220,7 @@ def read_gbq(
     )
     pandas_gbq = _try_import()
 
-    kwargs: dict[str, str | bool | int | None] = {}
+    kwargs: dict[str, str | bool | int | dict[str, Any] | list[str] | None] = {}
 
     # START: new kwargs.  Don't populate unless explicitly set.
     if use_bqstorage_api is not None:


### PR DESCRIPTION
There are some missing params from pandas-gbq needed to be added: progress_bar_type, dtypes, auth_redirect_uri, client_id, columns, which col_order is now an alias of

- [ ] ~closes #xxxx~
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
