### PR TITLE
CI: Improve error message format in validate_docstrings.py

### DIFF
--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -432,7 +432,7 @@ def print_validate_one_results(func_name: str) -> None:
             if err_code == "EX02":  # Failing examples are printed at the end
                 sys.stderr.write("\tExamples do not pass tests\n")
                 continue
-            sys.stderr.write(f"{err_code}\t{err_desc}\n")
+            sys.stderr.write(f"\t{err_code}\t{err_desc}\n")
     else:
         sys.stderr.write(f'Docstring for "{func_name}" correct. :)\n')
 

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -432,7 +432,7 @@ def print_validate_one_results(func_name: str) -> None:
             if err_code == "EX02":  # Failing examples are printed at the end
                 sys.stderr.write("\tExamples do not pass tests\n")
                 continue
-            sys.stderr.write(f"\t{err_desc}\n")
+            sys.stderr.write(f"{err_code}\t{err_desc}\n")
     else:
         sys.stderr.write(f'Docstring for "{func_name}" correct. :)\n')
 

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -392,9 +392,6 @@ def print_validate_one_results(func_name: str) -> None:
     if result["errors"]:
         sys.stderr.write(f'{len(result["errors"])} Errors found for `{func_name}`:\n')
         for err_code, err_desc in result["errors"]:
-            if err_code == "EX02":  # Failing examples are printed at the end
-                sys.stderr.write("\tExamples do not pass tests\n")
-                continue
             sys.stderr.write(f"\t{err_code}\t{err_desc}\n")
     else:
         sys.stderr.write(f'Docstring for "{func_name}" correct. :)\n')


### PR DESCRIPTION
Enhance the error message generated by executing `scripts/validate_docstrings.py --format=actions --errors=EX03 method-name`. 

Additionally, there appears to be a discrepancy, as including the ``--error=EX03`` flag still results in the display of another error. The cause of this inconsistency is unclear, and it might be related to a specific configuration.

(This observation and suggestion were brought to our attention by @asishm https://github.com/pandas-dev/pandas/issues/56804#issuecomment-1885402362)

After 
<img width="631" alt="image" src="https://github.com/pandas-dev/pandas/assets/77875500/ee8e3125-617b-4b5d-8203-57e892741d23">

Before 
<img width="615" alt="image" src="https://github.com/pandas-dev/pandas/assets/77875500/7ba9b8f8-ea93-48b4-8c7d-6e9fa5128355">

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.