### PR TITLE
Remove pandas.core.groupby.DataFrameGroupBy for describe, idxmax, idxmin, value_counts from ci/code_checks.sh

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -128,10 +128,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.core.groupby.SeriesGroupBy.transform \
         pandas.core.groupby.SeriesGroupBy.pipe \
         pandas.core.groupby.DataFrameGroupBy.pipe \
-        pandas.core.groupby.DataFrameGroupBy.describe \
-        pandas.core.groupby.DataFrameGroupBy.idxmax \
-        pandas.core.groupby.DataFrameGroupBy.idxmin \
-        pandas.core.groupby.DataFrameGroupBy.value_counts \
         pandas.core.groupby.SeriesGroupBy.describe \
         pandas.core.groupby.DataFrameGroupBy.boxplot \
         pandas.core.groupby.DataFrameGroupBy.hist \


### PR DESCRIPTION
Checked if validation docstrings passes for :

1. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.core.groupby.DataFrameGroupBy.describe
2. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.core.groupby.DataFrameGroupBy.idxmax
3. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.core.groupby.DataFrameGroupBy.idxmin
4. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.core.groupby.DataFrameGroupBy.value_counts

OUTPUT: 

1. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.core.groupby.DataFrameGroupBy.describe
```
################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.core.groupby.DataFrameGroupBy.describe" correct. :)
```

2. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.core.groupby.DataFrameGroupBy.idxmax
```
################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.core.groupby.DataFrameGroupBy.idxmax" correct. :)
```

3. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.core.groupby.DataFrameGroupBy.idxmin
```
################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.core.groupby.DataFrameGroupBy.idxmin" correct. :)
```

4. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.core.groupby.DataFrameGroupBy.value_counts
```
################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.core.groupby.DataFrameGroupBy.value_counts" correct. :)
```

- [ ] xref https://github.com/pandas-dev/pandas/issues/56804
- [x] [Tests passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
