### PR TITLE
DOC: fixed EX03 errors in docstrings for `pandas.Series.dt.day_name` and `pandas.Series.dt.day_name`

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -71,8 +71,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
 
     MSG='Partially validate docstrings (EX03)' ;  echo $MSG
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=EX03 --ignore_functions \
-        pandas.Series.dt.day_name \
-        pandas.Series.str.len \
         pandas.Series.cat.set_categories \
         pandas.Series.plot.bar \
         pandas.Series.plot.hist \

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1365,7 +1365,7 @@ default 'raise'
         >>> idx
         DatetimeIndex(['2018-01-01', '2018-01-02', '2018-01-03'],
                       dtype='datetime64[ns]', freq='D')
-        >>> idx.day_name(locale='pt_BR.utf8') # doctest: +SKIP
+        >>> idx.day_name(locale='pt_BR.utf8')  # doctest: +SKIP
         Index(['Segunda', 'Terça', 'Quarta'], dtype='object')
         """
         values = self._local_timestamps()

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -3055,11 +3055,11 @@ class StringMethods(NoNewAttributesMixin):
         number of entries for dictionaries, lists or tuples.
 
         >>> s = pd.Series(['dog',
-        ...                 '',
-        ...                 5,
-        ...                 {'foo' : 'bar'},
-        ...                 [2, 3, 5, 7],
-        ...                 ('one', 'two', 'three')])
+        ...                '',
+        ...                5,
+        ...                {'foo' : 'bar'},
+        ...                [2, 3, 5, 7],
+        ...                ('one', 'two', 'three')])
         >>> s
         0                  dog
         1


### PR DESCRIPTION
Modified the docstrings to resolve EX03/flake8 errors for,
- `pandas.Series.dt.day_name`
```
################################################################################
################################## Validation ##################################
################################################################################

4 Errors found for `pandas.Series.dt.day_name`:
        No extended summary found
        Parameters {'*args', '**kwargs'} not documented
        Unknown parameters {'locale'}
        See Also section not found
```
- `pandas.Series.str.len`
```
################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Series.str.len" correct. :)
```

- [x] #56804
- [ ] [Tests passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
