### PR TITLE
DOC: fix RT03 error for pandas.DataFrame.hist

### DIFF
--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -228,6 +228,8 @@ def hist_frame(
     Returns
     -------
     matplotlib.AxesSubplot or numpy.ndarray of them
+        An ndarray is returned with one :class:`matplotlib.AxesSubplot`
+        per column.
 
     See Also
     --------


### PR DESCRIPTION
- [ ] ~~closes https://github.com/pandas-dev/pandas/issues/56804~~ (Not relevant, it is a RT03 error )
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

~~Detected EX03 error for `pandas.DataFrame.hist`:~~
```
python scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.DataFrame.hist
```
Output:
```
################################################################################
################################## Validation ##################################
################################################################################

1 Errors found for `pandas.DataFrame.hist`:
        Return value has no description
```

The output after this changes:
```
################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DataFrame.hist" correct. :)
```