### PR TITLE
DOC: fix EX03 in `pandas.errors`

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -77,13 +77,9 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.errors.DatabaseError \
         pandas.errors.IndexingError \
         pandas.errors.InvalidColumnName \
-        pandas.errors.PossibleDataLossError \
-        pandas.errors.PossiblePrecisionLoss \
-        pandas.errors.SettingWithCopyError \
         pandas.errors.SettingWithCopyWarning \
         pandas.errors.SpecificationError \
         pandas.errors.UndefinedVariableError \
-        pandas.errors.ValueLabelTypeMismatch \
         pandas.Timestamp.ceil \
         pandas.Timestamp.floor \
         pandas.Timestamp.round \

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -425,7 +425,7 @@ class SettingWithCopyError(ValueError):
     --------
     >>> pd.options.mode.chained_assignment = 'raise'
     >>> df = pd.DataFrame({'A': [1, 1, 1, 2, 2]}, columns=['A'])
-    >>> df.loc[0:3]['A'] = 'a' # doctest: +SKIP
+    >>> df.loc[0:3]['A'] = 'a'  # doctest: +SKIP
     ... # SettingWithCopyError: A value is trying to be set on a copy of a...
     """
 
@@ -665,8 +665,8 @@ class PossibleDataLossError(Exception):
 
     Examples
     --------
-    >>> store = pd.HDFStore('my-store', 'a') # doctest: +SKIP
-    >>> store.open("w") # doctest: +SKIP
+    >>> store = pd.HDFStore('my-store', 'a')  # doctest: +SKIP
+    >>> store.open("w")  # doctest: +SKIP
     ... # PossibleDataLossError: Re-opening the file [my-store] with mode [a]...
     """
 
@@ -734,7 +734,7 @@ class PossiblePrecisionLoss(Warning):
     Examples
     --------
     >>> df = pd.DataFrame({"s": pd.Series([1, 2**53], dtype=np.int64)})
-    >>> df.to_stata('test') # doctest: +SKIP
+    >>> df.to_stata('test')  # doctest: +SKIP
     ... # PossiblePrecisionLoss: Column converted from int64 to float64...
     """
 
@@ -746,7 +746,7 @@ class ValueLabelTypeMismatch(Warning):
     Examples
     --------
     >>> df = pd.DataFrame({"categories": pd.Series(["a", 2], dtype="category")})
-    >>> df.to_stata('test') # doctest: +SKIP
+    >>> df.to_stata('test')  # doctest: +SKIP
     ... # ValueLabelTypeMismatch: Stata value labels (pandas categories) must be str...
     """
 


### PR DESCRIPTION
Fix flake8 errors of some exceptions in `pandas.errors`.

- [ ] xref #56804 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
