### PR TITLE
BUG fix for datetime null (closes #56853)

### DIFF
--- a/doc/source/whatsnew/v2.3.0.rst
+++ b/doc/source/whatsnew/v2.3.0.rst
@@ -112,6 +112,7 @@ Performance improvements
 Bug fixes
 ~~~~~~~~~
 - Fixed bug in :meth:`Series.diff` allowing non-integer values for the ``periods`` argument. (:issue:`56607`)
+- Fixed bug causing null values when using datetimes in multi-index. (:issue:`56853`)
 
 
 Categorical
@@ -122,7 +123,6 @@ Categorical
 Datetimelike
 ^^^^^^^^^^^^
 - Bug in :func:`date_range` where the last valid timestamp would sometimes not be produced (:issue:`56134`)
--
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v2.3.0.rst
+++ b/doc/source/whatsnew/v2.3.0.rst
@@ -111,8 +111,8 @@ Performance improvements
 
 Bug fixes
 ~~~~~~~~~
-- Fixed bug in :meth:`Series.diff` allowing non-integer values for the ``periods`` argument. (:issue:`56607`)
 - Fixed bug causing null values when using datetimes in multi-index. (:issue:`56853`)
+- Fixed bug in :meth:`Series.diff` allowing non-integer values for the ``periods`` argument. (:issue:`56607`)
 
 
 Categorical

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -585,7 +585,7 @@ class DatetimeLikeArrayMixin(  # type: ignore[misc]
         elif isinstance(value, str):
             # NB: Careful about tzawareness
             try:
-                value = self._scalar_from_string(value) if value != '' else value
+                value = self._scalar_from_string(value)
             except ValueError as err:
                 msg = self._validation_error_message(value, allow_listlike)
                 raise TypeError(msg) from err

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -585,7 +585,7 @@ class DatetimeLikeArrayMixin(  # type: ignore[misc]
         elif isinstance(value, str):
             # NB: Careful about tzawareness
             try:
-                value = self._scalar_from_string(value)
+                value = self._scalar_from_string(value) if value != '' else value
             except ValueError as err:
                 msg = self._validation_error_message(value, allow_listlike)
                 raise TypeError(msg) from err

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3965,8 +3965,8 @@ class MultiIndex(Index):
                 lev_loc = level.get_loc(k)
             
             if any(isna(item) for item in level):
-                # check to make sure no null values are in the level, 
-                # replace with empty strings. if this is removed, 
+                # check to make sure no null values are in the level,
+                # replace with empty strings. if this is removed,
                 # it's possible a null value will end up in indexes with
                 # datetime values.
                 level = Index(['' if isna(item) else item for item in level], dtype=object)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3963,13 +3963,15 @@ class MultiIndex(Index):
                 level = level.insert(lev_loc, k)
             else:
                 lev_loc = level.get_loc(k)
-            
+
             if any(isna(item) for item in level):
                 # check to make sure no null values are in the level,
                 # replace with empty strings. if this is removed,
                 # it's possible a null value will end up in indexes with
                 # datetime values.
-                level = Index(['' if isna(item) else item for item in level], dtype=object)
+                level = Index(
+                    ["" if isna(item) else item for item in level], dtype=object
+                )
 
             new_levels.append(level)
             new_codes.append(np.insert(ensure_int64(level_codes), loc, lev_loc))

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3963,6 +3963,13 @@ class MultiIndex(Index):
                 level = level.insert(lev_loc, k)
             else:
                 lev_loc = level.get_loc(k)
+            
+            if any(isna(item) for item in level):
+                # check to make sure no null values are in the level, 
+                # replace with empty strings. if this is removed, 
+                # it's possible a null value will end up in indexes with
+                # datetime values.
+                level = Index(['' if isna(item) else item for item in level], dtype=object)
 
             new_levels.append(level)
             new_codes.append(np.insert(ensure_int64(level_codes), loc, lev_loc))

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3965,11 +3965,14 @@ class MultiIndex(Index):
                 lev_loc = level.get_loc(k)
             
             if any(isna(item) for item in level):
-                # check to make sure no null values are in the level,
-                # replace with empty strings. if this is removed,
-                # it's possible a null value will end up in indexes with
-                # datetime values.
-                level = Index(['' if isna(item) else item for item in level], dtype=object)
+                # check to make sure no null values are in
+                # the level, if they are replace with
+                # empty strings. if this is removed,
+                # it's possible a null value will end up in
+                # indexes with datetime values.
+                level = Index(
+                              ['' if isna(item) else item for item in level],
+                              dtype=object)
 
             new_levels.append(level)
             new_codes.append(np.insert(ensure_int64(level_codes), loc, lev_loc))

--- a/pandas/tests/indexes/datetimelike_/test_indexing.py
+++ b/pandas/tests/indexes/datetimelike_/test_indexing.py
@@ -44,9 +44,10 @@ def test_get_indexer_non_unique_wrong_dtype(ldtype, rdtype):
         tm.assert_numpy_array_equal(result[0], no_matches)
         tm.assert_numpy_array_equal(result[1], missing)
 
+
 def test_multiindex_datetime_creation_null_value():
-    df = pd.DataFrame({('A', pd.Timestamp('2024-01-01')): [0]})
-    df.insert(1, 'B', [1])
-    df['B']
-    df['B', '']
-    del df['B']
+    df = pd.DataFrame({("A", pd.Timestamp("2024-01-01")): [0]})
+    df.insert(1, "B", [1])
+    df["B"]
+    df["B", ""]
+    del df["B"]

--- a/pandas/tests/indexes/datetimelike_/test_indexing.py
+++ b/pandas/tests/indexes/datetimelike_/test_indexing.py
@@ -43,3 +43,10 @@ def test_get_indexer_non_unique_wrong_dtype(ldtype, rdtype):
         missing = np.arange(6, dtype=np.intp)
         tm.assert_numpy_array_equal(result[0], no_matches)
         tm.assert_numpy_array_equal(result[1], missing)
+
+def test_multiindex_datetime_creation_null_value():
+    df = pd.DataFrame({('A', pd.Timestamp('2024-01-01')): [0]})
+    df.insert(1, 'B', [1])
+    df['B']
+    df['B', '']
+    del df['B']


### PR DESCRIPTION
Closes #56853

This is my first time contributing to this repo and I'm not super experienced with open source, sorry if the style isn't right or if there's some better way of doing it.

From what I can tell, the issue was caused by recurring calls to `get_loc` functions caused by the fact that when you pass in a datetime, it automatically converts subsequent insertions in the same level to datetime. If you don't supply one, it converts it to `NaT`, which causes an indexing error due to having a null value as an index, which gets you caught in endless recursion from `try`/`except` blocks. If you switch the datetime out for a float (or any other common type), the problem is avoided because the unfilled indexes are filled in will empty strings rather that null values. As far as I can tell, this problem only exists with datetime types.

It's kind of a hacky fix, but I figured it would just be easiest to check for null values in the indexes at the end of an insertion and replace them with empty strings. I tried fiddling around with the datetime stuff itself, but it just ended up messing other things up. Let me know if there's some other solution. I also added this as a test case, just to see whether it breaks.

- [x] xref #56853
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions (no new arguments/methods/functions).
- [x] Added an entry in the latest doc/source/whatsnew/vX.X.X.rst file if fixing a bug or adding a new feature.