### PR TITLE
DOC: fix EX03 errors in docstrings - pandas.io.formats.style.Styler: format_index, relabel_index, hide, set_td_classes

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -109,10 +109,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.io.formats.style.Styler.apply_index \
         pandas.io.formats.style.Styler.map_index \
         pandas.io.formats.style.Styler.format \
-        pandas.io.formats.style.Styler.format_index \
-        pandas.io.formats.style.Styler.relabel_index \
-        pandas.io.formats.style.Styler.hide \
-        pandas.io.formats.style.Styler.set_td_classes \
         pandas.io.formats.style.Styler.set_tooltips \
         pandas.io.formats.style.Styler.set_uuid \
         pandas.io.formats.style.Styler.pipe \
@@ -122,9 +118,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.io.formats.style.Styler.text_gradient \
         pandas.DataFrame.values \
         pandas.DataFrame.groupby \
-        pandas.DataFrame.idxmax \
-        pandas.DataFrame.idxmin \
-        pandas.DataFrame.pivot \
         pandas.DataFrame.sort_values \
         pandas.DataFrame.plot.hexbin \
         pandas.DataFrame.plot.line \

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -1496,10 +1496,10 @@ class Styler(StylerRenderer):
         Using `MultiIndex` columns and a `classes` `DataFrame` as a subset of the
         underlying,
 
-        >>> df = pd.DataFrame([[1,2],[3,4]], index=["a", "b"],
-        ...     columns=[["level0", "level0"], ["level1a", "level1b"]])
+        >>> df = pd.DataFrame([[1, 2], [3, 4]], index=["a", "b"],
+        ...                   columns=[["level0", "level0"], ["level1a", "level1b"]])
         >>> classes = pd.DataFrame(["min-val"], index=["a"],
-        ...     columns=[["level0"],["level1a"]])
+        ...                        columns=[["level0"], ["level1a"]])
         >>> df.style.set_td_classes(classes)  # doctest: +SKIP
 
         Form of the output with new additional css classes,
@@ -2717,7 +2717,7 @@ class Styler(StylerRenderer):
         --------
         Simple application hiding specific rows:
 
-        >>> df = pd.DataFrame([[1,2], [3,4], [5,6]], index=["a", "b", "c"])
+        >>> df = pd.DataFrame([[1, 2], [3, 4], [5, 6]], index=["a", "b", "c"])
         >>> df.style.hide(["a", "b"])  # doctest: +SKIP
              0    1
         c    5    6
@@ -2725,7 +2725,7 @@ class Styler(StylerRenderer):
         Hide the index and retain the data values:
 
         >>> midx = pd.MultiIndex.from_product([["x", "y"], ["a", "b", "c"]])
-        >>> df = pd.DataFrame(np.random.randn(6,6), index=midx, columns=midx)
+        >>> df = pd.DataFrame(np.random.randn(6, 6), index=midx, columns=midx)
         >>> df.style.format("{:.1f}").hide()  # doctest: +SKIP
                          x                    y
            a      b      c      a      b      c
@@ -2739,7 +2739,7 @@ class Styler(StylerRenderer):
         Hide specific rows in a MultiIndex but retain the index:
 
         >>> df.style.format("{:.1f}").hide(subset=(slice(None), ["a", "c"]))
-        ...   # doctest: +SKIP
+        ... # doctest: +SKIP
                                  x                    y
                    a      b      c      a      b      c
         x   b    0.7    1.0    1.3    1.5   -0.0   -0.2
@@ -2748,7 +2748,7 @@ class Styler(StylerRenderer):
         Hide specific rows and the index through chaining:
 
         >>> df.style.format("{:.1f}").hide(subset=(slice(None), ["a", "c"])).hide()
-        ...   # doctest: +SKIP
+        ... # doctest: +SKIP
                          x                    y
            a      b      c      a      b      c
          0.7    1.0    1.3    1.5   -0.0   -0.2

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -1318,9 +1318,10 @@ class StylerRenderer:
         Using the default ``formatter`` for unspecified levels
 
         >>> df = pd.DataFrame([[1, 2, 3]],
-        ...     columns=pd.MultiIndex.from_arrays([["a", "a", "b"],[2, np.nan, 4]]))
+        ...                   columns=pd.MultiIndex.from_arrays(
+        ...                   [["a", "a", "b"], [2, np.nan, 4]]))
         >>> df.style.format_index({0: lambda v: v.upper()}, axis=1, precision=1)
-        ...  # doctest: +SKIP
+        ... # doctest: +SKIP
                        A       B
               2.0    nan     4.0
         0       1      2       3
@@ -1329,7 +1330,7 @@ class StylerRenderer:
 
         >>> func = lambda s: 'STRING' if isinstance(s, str) else 'FLOAT'
         >>> df.style.format_index(func, axis=1, na_rep='MISS')
-        ...  # doctest: +SKIP
+        ... # doctest: +SKIP
                   STRING  STRING
             FLOAT   MISS   FLOAT
         0       1      2       3
@@ -1338,7 +1339,7 @@ class StylerRenderer:
 
         >>> df = pd.DataFrame([[1, 2, 3]], columns=['"A"', 'A&B', None])
         >>> s = df.style.format_index('$ {0}', axis=1, escape="html", na_rep="NA")
-        ...  # doctest: +SKIP
+        ... # doctest: +SKIP
         <th .. >$ &#34;A&#34;</th>
         <th .. >$ A&amp;B</th>
         <th .. >NA</td>
@@ -1348,7 +1349,7 @@ class StylerRenderer:
 
         >>> df = pd.DataFrame([[1, 2, 3]], columns=["123", "~", "$%#"])
         >>> df.style.format_index("\\textbf{{{}}}", escape="latex", axis=1).to_latex()
-        ...  # doctest: +SKIP
+        ... # doctest: +SKIP
         \begin{tabular}{lrrr}
         {} & {\textbf{123}} & {\textbf{\textasciitilde }} & {\textbf{\$\%\#}} \\
         0 & 1 & 2 & 3 \\
@@ -1475,7 +1476,7 @@ class StylerRenderer:
 
         Chaining with pre-hidden elements
 
-        >>> df.style.hide([0,1]).relabel_index(["C"])  # doctest: +SKIP
+        >>> df.style.hide([0, 1]).relabel_index(["C"])  # doctest: +SKIP
              col
         C      c
 
@@ -1493,9 +1494,10 @@ class StylerRenderer:
               1     5
            1  0     6
               1     7
-        >>> styler.hide((midx.get_level_values(0)==0)|(midx.get_level_values(1)==0))
-        ...  # doctest: +SKIP
-        >>> styler.hide(level=[0,1])  # doctest: +SKIP
+        >>> styler.hide((midx.get_level_values(0) == 0) |
+        ...             (midx.get_level_values(1) == 0))
+        ... # doctest: +SKIP
+        >>> styler.hide(level=[0, 1])  # doctest: +SKIP
         >>> styler.relabel_index(["binary6", "binary7"])  # doctest: +SKIP
                   col
         binary6     6
@@ -1503,9 +1505,9 @@ class StylerRenderer:
 
         We can also achieve the above by indexing first and then re-labeling
 
-        >>> styler = df.loc[[(1,1,0), (1,1,1)]].style
-        >>> styler.hide(level=[0,1]).relabel_index(["binary6", "binary7"])
-        ...  # doctest: +SKIP
+        >>> styler = df.loc[[(1, 1, 0), (1, 1, 1)]].style
+        >>> styler.hide(level=[0, 1]).relabel_index(["binary6", "binary7"])
+        ... # doctest: +SKIP
                   col
         binary6     6
         binary7     7
@@ -1516,9 +1518,9 @@ class StylerRenderer:
         brackets if the string if pre-formatted),
 
         >>> df = pd.DataFrame({"samples": np.random.rand(10)})
-        >>> styler = df.loc[np.random.randint(0,10,3)].style
+        >>> styler = df.loc[np.random.randint(0, 10, 3)].style
         >>> styler.relabel_index([f"sample{i+1} ({{}})" for i in range(3)])
-        ...  # doctest: +SKIP
+        ... # doctest: +SKIP
                          samples
         sample1 (5)     0.315811
         sample2 (0)     0.495941


### PR DESCRIPTION
All EX03 Errors resolved in the following cases:

1. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.io.formats.style.Styler.format_index
2. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.io.formats.style.Styler.relabel_index
3. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.io.formats.style.Styler.hide
4. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.io.formats.style.Styler.set_td_classes
5. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.DataFrame.idxmax
6. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.DataFrame.idxmin
7. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.DataFrame.pivot

OUTPUT:

1. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.io.formats.style.Styler.format_index
```
################################################################################
################################## Validation ##################################
################################################################################

1 Errors found for `pandas.io.formats.style.Styler.format_index`:
	Return value has no description
```

2. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.io.formats.style.Styler.relabel_index
```
################################################################################
################################## Validation ##################################
################################################################################

1 Errors found for `pandas.io.formats.style.Styler.relabel_index`:
	Return value has no description
```

3. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.io.formats.style.Styler.hide
```
################################################################################
################################## Validation ##################################
################################################################################

2 Errors found for `pandas.io.formats.style.Styler.hide`:
	Return value has no description
	See Also section not found
```

4. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.io.formats.style.Styler.set_td_classes
```
################################################################################
################################## Validation ##################################
################################################################################

2 Errors found for `pandas.io.formats.style.Styler.set_td_classes`:
	No extended summary found
	Return value has no description
```

5. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.DataFrame.idxmax
```
################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DataFrame.idxmax" correct. :)
```

6. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.DataFrame.idxmin
```
################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DataFrame.idxmin" correct. :)
```

7. scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.DataFrame.pivot
```
################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DataFrame.pivot" correct. :)
```



- [ ] xref https://github.com/pandas-dev/pandas/issues/56804
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
