### PR TITLE
TST: extension tests use its own fixtures

### DIFF
--- a/pandas/tests/extension/base/accumulate.py
+++ b/pandas/tests/extension/base/accumulate.py
@@ -26,6 +26,7 @@ class BaseAccumulateTests:
         expected = getattr(alt, op_name)(skipna=skipna)
         tm.assert_series_equal(result, expected, check_dtype=False)
 
+    @pytest.mark.parametrize("skipna", [True, False])
     def test_accumulate_series(self, data, all_numeric_accumulations, skipna):
         op_name = all_numeric_accumulations
         ser = pd.Series(data)

--- a/pandas/tests/extension/base/dtype.py
+++ b/pandas/tests/extension/base/dtype.py
@@ -114,6 +114,7 @@ class BaseDtypeTests:
         # only case we can test in general)
         assert dtype._get_common_dtype([dtype]) == dtype
 
+    @pytest.mark.parametrize("skipna", [True, False])
     def test_infer_dtype(self, data, data_missing, skipna):
         # only testing that this works without raising an error
         res = infer_dtype(data, skipna=skipna)

--- a/pandas/tests/extension/base/groupby.py
+++ b/pandas/tests/extension/base/groupby.py
@@ -34,6 +34,7 @@ class BaseGroupbyTests:
         tm.assert_numpy_array_equal(gr1.grouping_vector, df.A.values)
         tm.assert_extension_array_equal(gr2.grouping_vector, data_for_grouping)
 
+    @pytest.mark.parametrize("as_index", [True, False])
     def test_groupby_extension_agg(self, as_index, data_for_grouping):
         df = pd.DataFrame({"A": [1, 1, 2, 2, 3, 3, 1, 4], "B": data_for_grouping})
 

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -37,6 +37,7 @@ class BaseMethodsTests:
         kwarg = sig.parameters["dropna"]
         assert kwarg.default is True
 
+    @pytest.mark.parametrize("dropna", [True, False])
     def test_value_counts(self, all_data, dropna):
         all_data = all_data[:10]
         if dropna:
@@ -96,6 +97,7 @@ class BaseMethodsTests:
         result = pd.Series(data).apply(id)
         assert isinstance(result, pd.Series)
 
+    @pytest.mark.parametrize("na_action", [None, "ignore"])
     def test_map(self, data_missing, na_action):
         result = data_missing.map(lambda x: x, na_action=na_action)
         expected = data_missing.to_numpy()
@@ -211,6 +213,7 @@ class BaseMethodsTests:
         result = nargsort(data_missing_for_sorting, na_position=na_position)
         tm.assert_numpy_array_equal(result, expected)
 
+    @pytest.mark.parametrize("ascending", [True, False])
     def test_sort_values(self, data_for_sorting, ascending, sort_by_key):
         ser = pd.Series(data_for_sorting)
         result = ser.sort_values(ascending=ascending, key=sort_by_key)
@@ -224,6 +227,7 @@ class BaseMethodsTests:
 
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize("ascending", [True, False])
     def test_sort_values_missing(
         self, data_missing_for_sorting, ascending, sort_by_key
     ):
@@ -235,6 +239,7 @@ class BaseMethodsTests:
             expected = ser.iloc[[0, 2, 1]]
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize("ascending", [True, False])
     def test_sort_values_frame(self, data_for_sorting, ascending):
         df = pd.DataFrame({"A": [1, 2, 1], "B": data_for_sorting})
         result = df.sort_values(["A", "B"])
@@ -243,6 +248,7 @@ class BaseMethodsTests:
         )
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.parametrize("keep", ["first", "last", False])
     def test_duplicated(self, data, keep):
         arr = data.take([0, 1, 0, 1])
         result = arr.duplicated(keep=keep)

--- a/pandas/tests/extension/base/reduce.py
+++ b/pandas/tests/extension/base/reduce.py
@@ -77,6 +77,7 @@ class BaseReduceTests:
 
         tm.assert_extension_array_equal(result1, expected)
 
+    @pytest.mark.parametrize("skipna", [True, False])
     def test_reduce_series_boolean(self, data, all_boolean_reductions, skipna):
         op_name = all_boolean_reductions
         ser = pd.Series(data)
@@ -95,6 +96,7 @@ class BaseReduceTests:
             self.check_reduce(ser, op_name, skipna)
 
     @pytest.mark.filterwarnings("ignore::RuntimeWarning")
+    @pytest.mark.parametrize("skipna", [True, False])
     def test_reduce_series_numeric(self, data, all_numeric_reductions, skipna):
         op_name = all_numeric_reductions
         ser = pd.Series(data)
@@ -113,6 +115,7 @@ class BaseReduceTests:
             # min/max with empty produce numpy warnings
             self.check_reduce(ser, op_name, skipna)
 
+    @pytest.mark.parametrize("skipna", [True, False])
     def test_reduce_frame(self, data, all_numeric_reductions, skipna):
         op_name = all_numeric_reductions
         ser = pd.Series(data)

--- a/pandas/tests/extension/base/setitem.py
+++ b/pandas/tests/extension/base/setitem.py
@@ -105,9 +105,10 @@ class BaseSetitemTests:
         assert data[0] == data[2]
         assert data[1] == data[2]
 
-    def test_setitem_scalar(self, data, indexer_li):
+    @pytest.mark.parametrize("setter", ["loc", "iloc"])
+    def test_setitem_scalar(self, data, setter):
         arr = pd.Series(data)
-        setter = indexer_li(arr)
+        setter = getattr(arr, setter)
         setter[0] = data[1]
         assert arr[0] == data[1]
 

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -257,6 +257,7 @@ class TestDecimalArray(base.ExtensionTests):
         with tm.assert_produces_warning(warn, match=msg, check_stacklevel=False):
             super().test_fillna_copy_series(data_missing)
 
+    @pytest.mark.parametrize("dropna", [True, False])
     def test_value_counts(self, all_data, dropna):
         all_data = all_data[:10]
         if dropna:

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -271,6 +271,7 @@ class TestArrowArray(base.ExtensionTests):
         ser = pd.Series(data)
         self._compare_other(ser, data, comparison_op, data[0])
 
+    @pytest.mark.parametrize("na_action", [None, "ignore"])
     def test_map(self, data_missing, na_action):
         if data_missing.dtype.kind in "mM":
             result = data_missing.map(lambda x: x, na_action=na_action)
@@ -423,6 +424,7 @@ class TestArrowArray(base.ExtensionTests):
                 return False
         return True
 
+    @pytest.mark.parametrize("skipna", [True, False])
     def test_accumulate_series(self, data, all_numeric_accumulations, skipna, request):
         pa_type = data.dtype.pyarrow_dtype
         op_name = all_numeric_accumulations
@@ -524,6 +526,7 @@ class TestArrowArray(base.ExtensionTests):
             expected = getattr(alt, op_name)(skipna=skipna)
         tm.assert_almost_equal(result, expected)
 
+    @pytest.mark.parametrize("skipna", [True, False])
     def test_reduce_series_numeric(self, data, all_numeric_reductions, skipna, request):
         dtype = data.dtype
         pa_dtype = dtype.pyarrow_dtype
@@ -549,6 +552,7 @@ class TestArrowArray(base.ExtensionTests):
             request.applymarker(xfail_mark)
         super().test_reduce_series_numeric(data, all_numeric_reductions, skipna)
 
+    @pytest.mark.parametrize("skipna", [True, False])
     def test_reduce_series_boolean(
         self, data, all_boolean_reductions, skipna, na_value, request
     ):
@@ -585,6 +589,7 @@ class TestArrowArray(base.ExtensionTests):
             }[arr.dtype.kind]
         return cmp_dtype
 
+    @pytest.mark.parametrize("skipna", [True, False])
     def test_reduce_frame(self, data, all_numeric_reductions, skipna, request):
         op_name = all_numeric_reductions
         if op_name == "skew":
@@ -2325,6 +2330,7 @@ def test_str_extract_expand():
     tm.assert_series_equal(result, expected)
 
 
+@pytest.mark.parametrize("unit", ["ns", "us", "ms", "s"])
 def test_duration_from_strings_with_nat(unit):
     # GH51175
     strings = ["1000", "NaT"]
@@ -2827,6 +2833,7 @@ def test_dt_components():
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize("skipna", [True, False])
 def test_boolean_reduce_series_all_null(all_boolean_reductions, skipna):
     # GH51624
     ser = pd.Series([None], dtype="float64[pyarrow]")

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -134,6 +134,7 @@ class TestCategorical(base.ExtensionTests):
         expected = pd.Series([a + val for a in list(orig_data1)])
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize("na_action", [None, "ignore"])
     def test_map(self, data, na_action):
         result = data.map(lambda x: x, na_action=na_action)
         tm.assert_extension_array_equal(result, data)
@@ -174,6 +175,7 @@ class TestCategorical(base.ExtensionTests):
         super().test_array_repr(data, size)
 
     @pytest.mark.xfail(reason="TBD")
+    @pytest.mark.parametrize("as_index", [True, False])
     def test_groupby_extension_agg(self, as_index, data_for_grouping):
         super().test_groupby_extension_agg(as_index, data_for_grouping)
 

--- a/pandas/tests/extension/test_datetime.py
+++ b/pandas/tests/extension/test_datetime.py
@@ -100,6 +100,7 @@ class TestDatetimeArray(base.ExtensionTests):
     def _supports_reduction(self, obj, op_name: str) -> bool:
         return op_name in ["min", "max", "median", "mean", "std", "any", "all"]
 
+    @pytest.mark.parametrize("skipna", [True, False])
     def test_reduce_series_boolean(self, data, all_boolean_reductions, skipna):
         meth = all_boolean_reductions
         msg = f"'{meth}' with datetime64 dtypes is deprecated and will raise in"
@@ -113,6 +114,7 @@ class TestDatetimeArray(base.ExtensionTests):
         data = data._with_freq(None)
         super().test_series_constructor(data)
 
+    @pytest.mark.parametrize("na_action", [None, "ignore"])
     def test_map(self, data, na_action):
         result = data.map(lambda x: x, na_action=na_action)
         tm.assert_extension_array_equal(result, data)

--- a/pandas/tests/extension/test_masked.py
+++ b/pandas/tests/extension/test_masked.py
@@ -169,6 +169,7 @@ def data_for_grouping(dtype):
 
 
 class TestMaskedArrays(base.ExtensionTests):
+    @pytest.mark.parametrize("na_action", [None, "ignore"])
     def test_map(self, data_missing, na_action):
         result = data_missing.map(lambda x: x, na_action=na_action)
         if data_missing.dtype == Float32Dtype():

--- a/pandas/tests/extension/test_numpy.py
+++ b/pandas/tests/extension/test_numpy.py
@@ -313,6 +313,7 @@ class TestNumpyExtensionArray(base.ExtensionTests):
         tm.assert_almost_equal(result, expected)
 
     @pytest.mark.skip("TODO: tests not written yet")
+    @pytest.mark.parametrize("skipna", [True, False])
     def test_reduce_frame(self, data, all_numeric_reductions, skipna):
         pass
 

--- a/pandas/tests/extension/test_period.py
+++ b/pandas/tests/extension/test_period.py
@@ -109,6 +109,7 @@ class TestPeriodArray(base.ExtensionTests):
         else:
             super().test_diff(data, periods)
 
+    @pytest.mark.parametrize("na_action", [None, "ignore"])
     def test_map(self, data, na_action):
         result = data.map(lambda x: x, na_action=na_action)
         tm.assert_extension_array_equal(result, data)

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -102,6 +102,7 @@ class TestSparseArray(base.ExtensionTests):
     def _supports_reduction(self, obj, op_name: str) -> bool:
         return True
 
+    @pytest.mark.parametrize("skipna", [True, False])
     def test_reduce_series_numeric(self, data, all_numeric_reductions, skipna, request):
         if all_numeric_reductions in [
             "prod",
@@ -126,6 +127,7 @@ class TestSparseArray(base.ExtensionTests):
 
         super().test_reduce_series_numeric(data, all_numeric_reductions, skipna)
 
+    @pytest.mark.parametrize("skipna", [True, False])
     def test_reduce_frame(self, data, all_numeric_reductions, skipna, request):
         if all_numeric_reductions in [
             "prod",
@@ -366,6 +368,7 @@ class TestSparseArray(base.ExtensionTests):
         result = data.map(func, na_action=na_action)
         tm.assert_extension_array_equal(result, expected)
 
+    @pytest.mark.parametrize("na_action", [None, "ignore"])
     def test_map_raises(self, data, na_action):
         # GH52096
         msg = "fill value in the sparse values not supported"
@@ -486,6 +489,7 @@ class TestSparseArray(base.ExtensionTests):
         super().test_array_repr(data, size)
 
     @pytest.mark.xfail(reason="result does not match expected")
+    @pytest.mark.parametrize("as_index", [True, False])
     def test_groupby_extension_agg(self, as_index, data_for_grouping):
         super().test_groupby_extension_agg(as_index, data_for_grouping)
 


### PR DESCRIPTION
This reverts a small part of https://github.com/pandas-dev/pandas/pull/56583, for the changes made in the `pandas/tests/extension` directory

This is still a bit brittle, as there is currently no check inplace we don't change this back in the future -> https://github.com/pandas-dev/pandas/issues/56735. I was thinking we could run the tests for one of our own extension arrays outside of the pandas tests, will comment more on the issue.
