### PR TITLE
DEPS: Add warning if pyarrow is not installed

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -92,7 +92,10 @@ jobs:
           - name: "Numpy Dev"
             env_file: actions-311-numpydev.yaml
             pattern: "not slow and not network and not single_cpu"
-            test_args: "-W error::DeprecationWarning -W error::FutureWarning"
+            # Currently restricted the warnings that error to Deprecation Warnings from numpy
+            #
+            # TODO:
+            test_args: "-W error::DeprecationWarning:numpy -W error::FutureWarning:numpy"
           - name: "Pyarrow Nightly"
             env_file: actions-311-pyarrownightly.yaml
             pattern: "not slow and not network and not single_cpu"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -93,8 +93,8 @@ jobs:
             env_file: actions-311-numpydev.yaml
             pattern: "not slow and not network and not single_cpu"
             # Currently restricted the warnings that error to Deprecation Warnings from numpy
-            #
-            # TODO:
+            # done since pyarrow isn't compatible with numpydev always
+            # TODO: work with pyarrow to revert this?
             test_args: "-W error::DeprecationWarning:numpy -W error::FutureWarning:numpy"
           - name: "Pyarrow Nightly"
             env_file: actions-311-pyarrownightly.yaml

--- a/ci/deps/actions-311-numpydev.yaml
+++ b/ci/deps/actions-311-numpydev.yaml
@@ -20,6 +20,7 @@ dependencies:
   - hypothesis>=6.46.1
 
   # pandas dependencies
+  - pyarrow>=10.0.1
   - python-dateutil
   - pytz
   - pip

--- a/ci/deps/actions-311-numpydev.yaml
+++ b/ci/deps/actions-311-numpydev.yaml
@@ -20,7 +20,6 @@ dependencies:
   - hypothesis>=6.46.1
 
   # pandas dependencies
-  - pyarrow>=10.0.1
   - python-dateutil
   - pytz
   - pip

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -216,7 +216,7 @@ if pa_version_under10p1:
         f"""
 Pyarrow will become a future required dependency of pandas,
 but was not found to be installed on your system.
-(or was too old-pyarrow {VERSIONS['pyarrow']}
+(or was too old - pyarrow {VERSIONS['pyarrow']}
 is the current minimum supported version as of this release)
 If this would cause problems for you,
 please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -208,17 +208,19 @@ del os, warnings
 # DeprecationWarning for missing pyarrow
 from pandas.compat.pyarrow import pa_version_under10p1
 
-if not pa_version_under10p1:
+if pa_version_under10p1:
     import warnings
     from pandas.compat._optional import VERSIONS
 
     warnings.warn(
-        "Pyarrow will become a future required dependency of pandas,"
-        "but was not found to be installed on your system."
-        f"(or was too old - pyarrow {VERSIONS['pyarrow']} is the current"
-        f"minimum supported version as of this release)"
-        "If this would cause problems for you, "
-        "please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466",
+        f"""
+Pyarrow will become a future required dependency of pandas,
+but was not found to be installed on your system.
+(or was too old-pyarrow {VERSIONS['pyarrow']}
+is the current minimum supported version as of this release)
+If this would cause problems for you,
+please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466
+        """,
         DeprecationWarning,
         stacklevel=2,
     )

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -202,8 +202,8 @@ if "PANDAS_DATA_MANAGER" in os.environ:
         FutureWarning,
         stacklevel=2,
     )
-# Don't allow users to use pandas.os or pandas.warnings
-del os, warnings
+# Don't allow users to use pandas.os
+del os
 
 # DeprecationWarning for missing pyarrow
 from pandas.compat.pyarrow import pa_version_under10p1
@@ -224,7 +224,7 @@ please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466
         DeprecationWarning,
         stacklevel=2,
     )
-del pa_version_under10p1
+del pa_version_under10p1, warnings
 
 # module level doc-string
 __doc__ = """

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -202,8 +202,6 @@ if "PANDAS_DATA_MANAGER" in os.environ:
         FutureWarning,
         stacklevel=2,
     )
-# Don't allow users to use pandas.os
-del os
 
 # DeprecationWarning for missing pyarrow
 from pandas.compat.pyarrow import pa_version_under10p1
@@ -213,12 +211,13 @@ if pa_version_under10p1:
     from pandas.compat._optional import VERSIONS
 
     try:
-        import pyarrow  # noqa: F401
+        import pyarrow
 
         pa_msg = (
             f"was too old on your system - pyarrow {VERSIONS['pyarrow']} "
             "is the current minimum supported version as of this release."
         )
+        del pyarrow
     except ImportError:
         pa_msg = "was not found to be installed on your system."
 
@@ -234,7 +233,9 @@ please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466
         stacklevel=2,
     )
     del VERSIONS
-del pa_version_under10p1, warnings
+
+# Delete all unnecessary imported modules
+del pa_version_under10p1, warnings, os
 
 # module level doc-string
 __doc__ = """

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -204,38 +204,35 @@ if "PANDAS_DATA_MANAGER" in os.environ:
     )
 
 # DeprecationWarning for missing pyarrow
-from pandas.compat.pyarrow import pa_version_under10p1
+from pandas.compat.pyarrow import pa_version_under10p1, pa_not_found
 
 if pa_version_under10p1:
-    # Check if old pyarrow is installed
+    # pyarrow is either too old or nonexistent, warn
     from pandas.compat._optional import VERSIONS
 
-    try:
-        import pyarrow
-
+    if pa_not_found:
+        pa_msg = "was not found to be installed on your system."
+    else:
         pa_msg = (
             f"was too old on your system - pyarrow {VERSIONS['pyarrow']} "
             "is the current minimum supported version as of this release."
         )
-        del pyarrow
-    except ImportError:
-        pa_msg = "was not found to be installed on your system."
 
     warnings.warn(
         f"""
-Pyarrow will become a required dependency of pandas in the next major release of pandas,
-(to allow more performant data types and better interoperability with other libraries)
+Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),
+(to allow more performant data types, such as the Arrow string type, and better interoperability with other libraries)
 but {pa_msg}
 If this would cause problems for you,
 please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466
-        """,
+        """,  # noqa: E501
         DeprecationWarning,
         stacklevel=2,
     )
     del VERSIONS
 
 # Delete all unnecessary imported modules
-del pa_version_under10p1, warnings, os
+del pa_version_under10p1, pa_not_found, warnings, os
 
 # module level doc-string
 __doc__ = """

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -229,7 +229,7 @@ please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466
         DeprecationWarning,
         stacklevel=2,
     )
-    del VERSIONS
+    del VERSIONS, pa_msg
 
 # Delete all unnecessary imported modules
 del pa_version_under10p1, pa_not_found, warnings, os

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -209,21 +209,31 @@ del os
 from pandas.compat.pyarrow import pa_version_under10p1
 
 if pa_version_under10p1:
-    import warnings
+    # Check if old pyarrow is installed
     from pandas.compat._optional import VERSIONS
+
+    try:
+        import pyarrow  # noqa: F401
+
+        pa_msg = (
+            f"was too old on your system - pyarrow {VERSIONS['pyarrow']} "
+            "is the current minimum supported version as of this release."
+        )
+    except ImportError:
+        pa_msg = "was not found to be installed on your system."
 
     warnings.warn(
         f"""
 Pyarrow will become a future required dependency of pandas,
-but was not found to be installed on your system.
-(or was too old - pyarrow {VERSIONS['pyarrow']}
-is the current minimum supported version as of this release)
+(to allow more performant data types and better interoperability with other libraries)
+but {pa_msg}
 If this would cause problems for you,
 please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466
         """,
         DeprecationWarning,
         stacklevel=2,
     )
+    del VERSIONS
 del pa_version_under10p1, warnings
 
 # module level doc-string

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -224,7 +224,7 @@ if pa_version_under10p1:
 
     warnings.warn(
         f"""
-Pyarrow will become a future required dependency of pandas,
+Pyarrow will become a required dependency of pandas in the next major release of pandas,
 (to allow more performant data types and better interoperability with other libraries)
 but {pa_msg}
 If this would cause problems for you,

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -205,6 +205,25 @@ if "PANDAS_DATA_MANAGER" in os.environ:
 # Don't allow users to use pandas.os or pandas.warnings
 del os, warnings
 
+# DeprecationWarning for missing pyarrow
+from pandas.compat.pyarrow import pa_version_under10p1
+
+if not pa_version_under10p1:
+    import warnings
+    from pandas.compat._optional import VERSIONS
+
+    warnings.warn(
+        "Pyarrow will become a future required dependency of pandas,"
+        "but was not found to be installed on your system."
+        f"(or was too old - pyarrow {VERSIONS['pyarrow']} is the current"
+        f"minimum supported version as of this release)"
+        "If this would cause problems for you, "
+        "please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+del pa_version_under10p1
+
 # module level doc-string
 __doc__ = """
 pandas - a powerful data analysis and manipulation library for Python

--- a/pandas/compat/pyarrow.py
+++ b/pandas/compat/pyarrow.py
@@ -8,6 +8,7 @@ try:
     import pyarrow as pa
 
     _palv = Version(Version(pa.__version__).base_version)
+    pa_not_found = False
     pa_version_under10p1 = _palv < Version("10.0.1")
     pa_version_under11p0 = _palv < Version("11.0.0")
     pa_version_under12p0 = _palv < Version("12.0.0")
@@ -16,6 +17,7 @@ try:
     pa_version_under14p1 = _palv < Version("14.0.1")
     pa_version_under15p0 = _palv < Version("15.0.0")
 except ImportError:
+    pa_not_found = True
     pa_version_under10p1 = True
     pa_version_under11p0 = True
     pa_version_under12p0 = True

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -265,3 +265,26 @@ def test_bz2_missing_import():
     code = textwrap.dedent(code)
     call = [sys.executable, "-c", code]
     subprocess.check_output(call)
+
+
+import pandas.util._test_decorators as td
+
+
+@td.skip_if_installed("pyarrow")
+@pytest.mark.parametrize("module", ["pandas", "pandas.arrays"])
+def test_pyarrow_missing_warn(module):
+    # GH56896
+    response = subprocess.run(
+        [sys.executable, "-c", f"import {module}"],
+        capture_output=True,
+        check=True,
+    )
+    msg = """
+Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),
+(to allow more performant data types, such as the Arrow string type, and better interoperability with other libraries)
+but was not found to be installed on your system.
+If this would cause problems for you,
+please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466
+"""  # noqa: E501
+    stderr_msg = response.stderr.decode("utf-8")
+    assert msg in stderr_msg, stderr_msg

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -8,6 +8,8 @@ import textwrap
 import numpy as np
 import pytest
 
+import pandas.util._test_decorators as td
+
 import pandas as pd
 from pandas import Series
 import pandas._testing as tm
@@ -265,9 +267,6 @@ def test_bz2_missing_import():
     code = textwrap.dedent(code)
     call = [sys.executable, "-c", code]
     subprocess.check_output(call)
-
-
-import pandas.util._test_decorators as td
 
 
 @td.skip_if_installed("pyarrow")


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

~~Not sure how to add a test for this - importing our warning asserters would cause the warning the be raised! 🤣 ~~

EDIT: Nvm, figured it out.

(I've checked by hand that the warning is both raised when you import pandas directly and import a submodule of pandas e.g. ``pandas.arrays``.
I also double checked that the warning only occurs once and not on every import.)