### PR TITLE
REGR: DatetimeTZDtype __from_arrow__ interprets UTC values as wall time

### DIFF
--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -919,7 +919,7 @@ class DatetimeTZDtype(PandasExtensionDtype):
         else:
             np_arr = array.to_numpy()
 
-        return DatetimeArray._from_sequence(np_arr, dtype=self, copy=False)
+        return DatetimeArray._simple_new(np_arr, dtype=self)
 
     def __setstate__(self, state) -> None:
         # for pickle compat. __get_state__ is defined in the

--- a/pandas/tests/arrays/datetimes/test_constructors.py
+++ b/pandas/tests/arrays/datetimes/test_constructors.py
@@ -232,10 +232,8 @@ def test_from_arrow_with_different_units_and_timezones_with(
     dtype = DatetimeTZDtype(unit=pd_unit, tz=pd_tz)
 
     result = dtype.__from_arrow__(arr)
-    expected = (
-        DatetimeArray._from_sequence(data, dtype=f"datetime64[{pa_unit}]")
-        .tz_localize("UTC")
-        .astype(dtype, copy=False)
+    expected = DatetimeArray._from_sequence(data, dtype=f"M8[{pa_unit}, UTC]").astype(
+        dtype, copy=False
     )
     tm.assert_extension_array_equal(result, expected)
 

--- a/pandas/tests/arrays/datetimes/test_constructors.py
+++ b/pandas/tests/arrays/datetimes/test_constructors.py
@@ -233,7 +233,7 @@ def test_from_arrowtest_from_arrow_with_different_units_and_timezones_with_(
     dtype = DatetimeTZDtype(unit=pd_unit, tz=pd_tz)
 
     result = dtype.__from_arrow__(arr)
-    expected = DatetimeArray._from_sequence(
+    expected = DatetimeArray._simple_new(
         np.array(data, dtype=f"datetime64[{pa_unit}]").astype(f"datetime64[{pd_unit}]"),
         dtype=dtype,
     )

--- a/pandas/tests/arrays/datetimes/test_constructors.py
+++ b/pandas/tests/arrays/datetimes/test_constructors.py
@@ -6,6 +6,7 @@ from pandas._libs import iNaT
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
 
 import pandas as pd
+from pandas import Series
 import pandas._testing as tm
 from pandas.core.arrays import DatetimeArray
 
@@ -239,6 +240,17 @@ def test_from_arrowtest_from_arrow_with_different_units_and_timezones_with_(
     tm.assert_extension_array_equal(result, expected)
 
     result = dtype.__from_arrow__(pa.chunked_array([arr]))
+    tm.assert_extension_array_equal(result, expected)
+
+
+def test_datetimetz_from_arrow_roundtrip():
+    # GH 56775
+    pa = pytest.importorskip("pyarrow")
+
+    ser = Series(["2012-01-01", "2012-01-02"], dtype="datetime64[ns, Europe/Brussels]")
+
+    result = ser.dtype.__from_arrow__(pa.array(ser))
+    expected = DatetimeArray._from_sequence(ser)
     tm.assert_extension_array_equal(result, expected)
 
 

--- a/pandas/tests/arrays/datetimes/test_constructors.py
+++ b/pandas/tests/arrays/datetimes/test_constructors.py
@@ -6,7 +6,6 @@ from pandas._libs import iNaT
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
 
 import pandas as pd
-from pandas import Series
 import pandas._testing as tm
 from pandas.core.arrays import DatetimeArray
 
@@ -223,7 +222,7 @@ COARSE_TO_FINE_SAFE = [123, None, -123]
         ("s", "ns", "US/Central", "Asia/Kolkata", COARSE_TO_FINE_SAFE),
     ],
 )
-def test_from_arrowtest_from_arrow_with_different_units_and_timezones_with_(
+def test_from_arrow_with_different_units_and_timezones_with(
     pa_unit, pd_unit, pa_tz, pd_tz, data
 ):
     pa = pytest.importorskip("pyarrow")
@@ -233,24 +232,14 @@ def test_from_arrowtest_from_arrow_with_different_units_and_timezones_with_(
     dtype = DatetimeTZDtype(unit=pd_unit, tz=pd_tz)
 
     result = dtype.__from_arrow__(arr)
-    expected = DatetimeArray._simple_new(
-        np.array(data, dtype=f"datetime64[{pa_unit}]").astype(f"datetime64[{pd_unit}]"),
-        dtype=dtype,
+    expected = (
+        DatetimeArray._from_sequence(data, dtype=f"datetime64[{pa_unit}]")
+        .tz_localize("UTC")
+        .astype(dtype, copy=False)
     )
     tm.assert_extension_array_equal(result, expected)
 
     result = dtype.__from_arrow__(pa.chunked_array([arr]))
-    tm.assert_extension_array_equal(result, expected)
-
-
-def test_datetimetz_from_arrow_roundtrip():
-    # GH 56775
-    pa = pytest.importorskip("pyarrow")
-
-    ser = Series(["2012-01-01", "2012-01-02"], dtype="datetime64[ns, Europe/Brussels]")
-
-    result = ser.dtype.__from_arrow__(pa.array(ser))
-    expected = DatetimeArray._from_sequence(ser)
     tm.assert_extension_array_equal(result, expected)
 
 


### PR DESCRIPTION
- [ ] closes #56775  (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
