### PR TITLE
DOC: indicate that origin argument can be a string that is timestamp …

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9454,7 +9454,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         origin : Timestamp or str, default 'start_day'
             The timestamp on which to adjust the grouping. The timezone of origin
             must match the timezone of the index.
-            If string, must be one of the following:
+            If string, must be Timestamp convertible or one of the following:
 
             - 'epoch': `origin` is 1970-01-01
             - 'start': `origin` is the first value of the timeseries


### PR DESCRIPTION
resolved #56877 in file `pandas/core/generic.py`

closes #56877