### PR TITLE
DOC: fixed Ex03 errors in docstrings: pandas.io.formats.style.Styler.to_latex and pandas.read_parquet

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -77,8 +77,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.errors.SpecificationError \
         pandas.errors.UndefinedVariableError \
         pandas.read_json \
-        pandas.io.formats.style.Styler.to_latex \
-        pandas.read_parquet \
         pandas.DataFrame.to_sql \
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -987,11 +987,11 @@ class Styler(StylerRenderer):
         hide the repeated level-0 of the index:
 
         >>> (styler.format(subset="Equity", precision=2)
-        ...       .format(subset="Stats", precision=1, thousands=",")
-        ...       .format(subset="Rating", formatter=str.upper)
-        ...       .format_index(escape="latex", axis=1)
-        ...       .format_index(escape="latex", axis=0)
-        ...       .hide(level=0, axis=0))  # doctest: +SKIP
+        ...     .format(subset="Stats", precision=1, thousands=",")
+        ...     .format(subset="Rating", formatter=str.upper)
+        ...     .format_index(escape="latex", axis=1)
+        ...     .format_index(escape="latex", axis=0)
+        ...     .hide(level=0, axis=0))  # doctest: +SKIP
 
         Note that one of the string entries of the index and column headers is "H&M".
         Without applying the `escape="latex"` option to the `format_index` method the
@@ -1003,12 +1003,15 @@ class Styler(StylerRenderer):
         recommendation:
 
         >>> def rating_color(v):
-        ...     if v == "Buy": color = "#33ff85"
-        ...     elif v == "Sell": color = "#ff5933"
-        ...     else: color = "#ffdd33"
+        ...     if v == "Buy":
+        ...         color = "#33ff85"
+        ...     elif v == "Sell":
+        ...         color = "#ff5933"
+        ...     else:
+        ...         color = "#ffdd33"
         ...     return f"color: {color}; font-weight: bold;"
         >>> (styler.background_gradient(cmap="inferno", subset="Equity", vmin=0, vmax=1)
-        ...       .map(rating_color, subset="Rating"))  # doctest: +SKIP
+        ...     .map(rating_color, subset="Rating"))  # doctest: +SKIP
 
         All the above styles will work with HTML (see below) and LaTeX upon conversion:
 

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -510,6 +510,9 @@ def read_parquet(
     """
     Load a parquet object from the file path, returning a DataFrame.
 
+    The function automatically handles reading the data from a parquet file
+    and creates a DataFrame with the appropriate structure.
+
     Parameters
     ----------
     path : str, path object or file-like object
@@ -591,6 +594,7 @@ def read_parquet(
     Returns
     -------
     DataFrame
+        DataFrame based on parquet file.
 
     See Also
     --------
@@ -600,7 +604,7 @@ def read_parquet(
     --------
     >>> original_df = pd.DataFrame(
     ...     {{"foo": range(5), "bar": range(5, 10)}}
-    ...    )
+    ... )
     >>> original_df
        foo  bar
     0    0    5


### PR DESCRIPTION
**PR SUMMARY**

Checked if validation docstrings passes for:

- [x] pandas.io.formats.style.Styler.to_latex
- [x] pandas.read_parquet

OUTPUT:
1. python scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.io.formats.style.Styler.to_latex
```
################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.io.formats.style.Styler.to_latex" correct. :)
```

2. python scripts/validate_docstrings.py --format=actions --errors=EX03 pandas.read_parquet
```
################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.read_parquet" correct. :)
```

**PR CHECKLIST**

- [ ] xref #56804 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
