### PR TITLE
TST: test for warnings using pytest.warns()

### DIFF
--- a/pandas/tests/io/xml/test_xml.py
+++ b/pandas/tests/io/xml/test_xml.py
@@ -1361,7 +1361,8 @@ def test_stylesheet_with_etree(kml_cta_rail_lines, xsl_flatten_doc):
 
 @pytest.mark.parametrize("val", ["", b""])
 def test_empty_stylesheet(val):
-    pytest.importorskip("lxml")
+    lxml_etree = pytest.importorskip("lxml.etree")
+
     msg = (
         "Passing literal xml to 'read_xml' is deprecated and "
         "will be removed in a future version. To read from a "
@@ -1369,8 +1370,9 @@ def test_empty_stylesheet(val):
     )
     kml = os.path.join("data", "xml", "cta_rail_lines.kml")
 
-    with pytest.raises(FutureWarning, match=msg):
-        read_xml(kml, stylesheet=val)
+    with pytest.raises(lxml_etree.XMLSyntaxError):
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            read_xml(kml, stylesheet=val)
 
 
 # ITERPARSE

--- a/pandas/tests/tslibs/test_to_offset.py
+++ b/pandas/tests/tslibs/test_to_offset.py
@@ -7,6 +7,7 @@ from pandas._libs.tslibs import (
     offsets,
     to_offset,
 )
+
 import pandas._testing as tm
 
 

--- a/pandas/tests/tslibs/test_to_offset.py
+++ b/pandas/tests/tslibs/test_to_offset.py
@@ -7,6 +7,7 @@ from pandas._libs.tslibs import (
     offsets,
     to_offset,
 )
+import pandas._testing as tm
 
 
 @pytest.mark.parametrize(
@@ -194,7 +195,7 @@ def test_to_offset_lowercase_frequency_deprecated(freq_depr):
     depr_msg = f"'{freq_depr[1:]}' is deprecated and will be removed in a "
     f"future version, please use '{freq_depr.upper()[1:]}' instead."
 
-    with pytest.raises(FutureWarning, match=depr_msg):
+    with tm.assert_produces_warning(FutureWarning, match=depr_msg):
         to_offset(freq_depr)
 
 
@@ -214,5 +215,5 @@ def test_to_offset_uppercase_frequency_deprecated(freq_depr):
     depr_msg = f"'{freq_depr[1:]}' is deprecated and will be removed in a "
     f"future version, please use '{freq_depr.lower()[1:]}' instead."
 
-    with pytest.raises(FutureWarning, match=depr_msg):
+    with tm.assert_produces_warning(FutureWarning, match=depr_msg):
         to_offset(freq_depr)


### PR DESCRIPTION
Fix tests that used `pytest.raises()` to check for warnings, to use `pytest.warns()` instead.  This is more correct, and it fixes running the test suite without `-Werror`.  This is how Gentoo runs it, to avoid sudden test failures due to new deprecation warnings from upgraded dependencies.

- [ ] closes #56716 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
