### PR TITLE
Added a test that breaks over Series.rank with nullable ints

### DIFF
--- a/pandas/tests/series/methods/test_rank.py
+++ b/pandas/tests/series/methods/test_rank.py
@@ -248,6 +248,23 @@ class TestSeriesRank:
         result = ser.rank(method=method)
         tm.assert_series_equal(result, Series(exp))
 
+    @pytest.mark.parametrize('dtype', ['Int64', 'UInt64'])   #Full set of dtypes not necessary
+    def test_rank_with_nullable_int(self, dtype, ser, results):
+        if dtype == 'int64': pytest.skip("Irrelevant dtype for this test.")
+        method, exp = results
+        ser = ser.astype(dtype)
+        result = ser.rank(method=method)
+        # cast dtype, because pyarrow input leads to different output type
+        if 'pyarrow' in dtype:
+            if method == 'average':
+                exp = Series(exp, dtype='double[pyarrow]')
+            else:
+                exp = Series(exp, dtype='uint64[pyarrow]')
+
+        else:
+            exp = Series(exp)
+        tm.assert_series_equal(result, exp)
+
     @pytest.mark.parametrize("na_option", ["top", "bottom", "keep"])
     @pytest.mark.parametrize(
         "dtype, na_value, pos_inf, neg_inf",


### PR DESCRIPTION


- [ ] will eventually close #56976
- [ ] [Tests added and passed] Added a test for `pandas.Series.rank`

I'll have to check the rest as soon as the Issue is closed
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
