### PR TITLE
fix unsigned // negative integral value for pyarrow types

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -150,7 +150,6 @@ if not pa_version_under10p1:
                 )
             else:
                 result = divided
-            result = result.cast(left.type)
         else:
             divided = pc.divide(left, right)
             result = pc.floor(divided)


### PR DESCRIPTION
>>> a = pd.Series([7], dtype="uint8[pyarrow]")
>>> b = pd.Series([-4], dtype="int8[pyarrow]")
>>> a // b
pyarrow.lib.ArrowInvalid: Integer value -2 not in range: 0 to 255
>>>

But it works with numpy types:

>>> a = pd.Series([7], dtype="uint8")
>>> b = pd.Series([-4], dtype="int8")
>>> a // b
0   -2
dtype: int16