### PR TITLE
PERF: MultiIndex.equals for equal length indexes

### DIFF
--- a/asv_bench/benchmarks/multiindex_object.py
+++ b/asv_bench/benchmarks/multiindex_object.py
@@ -223,14 +223,20 @@ class CategoricalLevel:
 
 class Equals:
     def setup(self):
-        idx_large_fast = RangeIndex(100000)
-        idx_small_slow = date_range(start="1/1/2012", periods=1)
-        self.mi_large_slow = MultiIndex.from_product([idx_large_fast, idx_small_slow])
-
+        self.mi = MultiIndex.from_product(
+            [
+                date_range("2000-01-01", periods=1000),
+                RangeIndex(1000),
+            ]
+        )
+        self.mi_deepcopy = self.mi.copy(deep=True)
         self.idx_non_object = RangeIndex(1)
 
+    def time_equals_deepcopy(self):
+        self.mi.equals(self.mi_deepcopy)
+
     def time_equals_non_object_index(self):
-        self.mi_large_slow.equals(self.idx_non_object)
+        self.mi.equals(self.idx_non_object)
 
 
 class SetOperations:

--- a/doc/source/whatsnew/v2.3.0.rst
+++ b/doc/source/whatsnew/v2.3.0.rst
@@ -106,6 +106,7 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.join` with ``how="left"`` or ``how="right"`` and ``sort=True`` (:issue:`56919`)
 - Performance improvement in :meth:`DataFrameGroupBy.ffill`, :meth:`DataFrameGroupBy.bfill`, :meth:`SeriesGroupBy.ffill`, and :meth:`SeriesGroupBy.bfill` (:issue:`56902`)
 - Performance improvement in :meth:`Index.take` when ``indices`` is a full range indexer from zero to length of index (:issue:`56806`)
+- Performance improvement in :meth:`MultiIndex.equals` for equal length indexes (:issue:`56990`)
 -
 
 .. ---------------------------------------------------------------------------


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.3.0.rst` file if fixing a bug or adding a new feature.

Avoids densifying the levels of the multiindex to check for equality.

```
from asv_bench.benchmarks.multiindex_object import Equals

b = Equals()
b.setup()
%timeit b.time_equals_deepcopy()

# 56.4 ms ± 1.03 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)   -> main
# 3.77 ms ± 58.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  -> PR
```