### PR TITLE
ENH: Add groupby(...).agg_index

### DIFF
--- a/pandas/core/groupby/base.py
+++ b/pandas/core/groupby/base.py
@@ -83,6 +83,7 @@ transformation_kernels = frozenset(
 groupby_other_methods = frozenset(
     [
         "agg",
+        "agg_index",
         "aggregate",
         "apply",
         "boxplot",

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1799,6 +1799,16 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             res.index = default_index(len(res))
         return res
 
+    @final
+    @property
+    def agg_index(self) -> Index:
+        """Index of an aggregation result.
+
+        Produces the index that will be on the result of an aggregation. Always
+        returns the index as if ``as_index=True``.
+        """
+        return self._grouper.result_index
+
     # -----------------------------------------------------------------
     # apply/agg/transform
 

--- a/pandas/tests/groupby/test_api.py
+++ b/pandas/tests/groupby/test_api.py
@@ -32,6 +32,7 @@ def test_tab_completion(multiindex_dataframe_random_data):
         "B",
         "C",
         "agg",
+        "agg_index",
         "aggregate",
         "apply",
         "boxplot",


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Ref: https://github.com/pandas-dev/pandas/pull/56521#issuecomment-1896140609

With `groupby(...).grouper` deprecated, we can expose `.agg_index` on the groupby object so users can still determine the index that will be on aggregations (when as_index is True).

If we do go forward with this, I'd like it in 2.2.1 because of the aforementioned deprecation.

cc @jorisvandenbossche @jbrockmendel @mroeschke 