### PR TITLE
DOC: Remove old versions from doc dropdown

### DIFF
--- a/web/pandas/versions.json
+++ b/web/pandas/versions.json
@@ -24,30 +24,5 @@
         "name": "1.5",
         "version": "1.5",
         "url": "https://pandas.pydata.org/pandas-docs/version/1.5/"
-    },
-    {
-        "name": "1.4",
-        "version": "1.4",
-        "url": "https://pandas.pydata.org/pandas-docs/version/1.4/"
-    },
-    {
-        "name": "1.3",
-        "version": "1.3",
-        "url": "https://pandas.pydata.org/pandas-docs/version/1.3/"
-    },
-    {
-        "name": "1.2",
-        "version": "1.2",
-        "url": "https://pandas.pydata.org/pandas-docs/version/1.2/"
-    },
-    {
-        "name": "1.1",
-        "version": "1.1",
-        "url": "https://pandas.pydata.org/pandas-docs/version/1.1/"
-    },
-    {
-        "name": "1.0",
-        "version": "1.0",
-        "url": "https://pandas.pydata.org/pandas-docs/version/1.0/"
     }
 ]


### PR DESCRIPTION
- [X] closes #53286

The version switcher in the docs is currently missing for <= v1.3 and broken for 1.4. I had a look at the views for the older versions, and I don't think it's worth to keep the old versions in the dropdown:

![version_switcher_views](https://github.com/pandas-dev/pandas/assets/10058240/c47fbd17-a0ec-4bf4-a1d3-6180f22c9c09)

Note that this only affects the dropdown for the documentation of pandas 1.5+. The documentation of the old versions will continue to exist, and accessible from links on the internet, bookmarks or typing the url. And the dropdown in these old versions will continue to be broken. But from the main documentation it won't the possible to select 1.4 in the dropdown, and then get an error when trying to go back to the stable documentation.

The data in the screenshot is from Google analytics, from the first half of last year. @jorisvandenbossche can you add the url and credentials of Plausible to our credentials, so anyone can access the latest stats?

CC: @lithomas1 