### PR TITLE
Remove enter on begin of warnign message

### DIFF
--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -219,8 +219,7 @@ if pa_version_under10p1:
         )
 
     warnings.warn(
-        f"""
-Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),
+        f"""Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),
 (to allow more performant data types, such as the Arrow string type, and better interoperability with other libraries)
 but {pa_msg}
 If this would cause problems for you,

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -278,8 +278,7 @@ def test_pyarrow_missing_warn(module):
         capture_output=True,
         check=True,
     )
-    msg = """
-Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),
+    msg = """Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),
 (to allow more performant data types, such as the Arrow string type, and better interoperability with other libraries)
 but was not found to be installed on your system.
 If this would cause problems for you,


### PR DESCRIPTION
Closes #57082

With current code, it is not possible to filter pandas warning about PyArrow that leads to crash of test suite with the rule to treat warning as error. 

It looks like the source of the problem is that `warnigns` library compile pattern with only IgnoreCase flag.

https://github.com/python/cpython/blob/d1b031cc58516e1aba823fd613528417a996f50d/Lib/warnings.py#L160

And then is using `match` instead of `search` so it matches to initial line. 

With this change, it this warning will be possible to ignore this using:

```
"ignore:Pyarrow will become a required dependency of pandas in the next major release of pandas.*:DeprecationWarning"
```

In napari we meet it here: https://github.com/napari/napari/pull/6609

cPython issue about problem with empty line https://github.com/python/cpython/issues/114426