### PR TITLE
DOC : ambiguous takes bool as an argument, not bool-ndarray

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11596,7 +11596,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
             - 'infer' will attempt to infer fall dst-transition hours based on
               order
-            - bool where True signifies a DST time, False designates
+            - bool (or bool-ndarray) where True signifies a DST time, False designates
               a non-DST time (note that this flag is only applicable for
               ambiguous times)
             - 'NaT' will return NaT where there are ambiguous times

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11586,7 +11586,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
                 You can already get the future behavior and improvements through
                 enabling copy on write ``pd.options.mode.copy_on_write = True``
-        ambiguous : 'infer', bool, 'NaT', default 'raise'
+        ambiguous : 'infer', bool, bool-ndarray, 'NaT', default 'raise'
             When clocks moved backward due to DST, ambiguous times may arise.
             For example in Central European Time (UTC+01), when going from
             03:00 DST to 02:00 non-DST, 02:30:00 local time occurs both at

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11586,7 +11586,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
                 You can already get the future behavior and improvements through
                 enabling copy on write ``pd.options.mode.copy_on_write = True``
-        ambiguous : 'infer', bool-ndarray, 'NaT', default 'raise'
+        ambiguous : 'infer', bool, 'NaT', default 'raise'
             When clocks moved backward due to DST, ambiguous times may arise.
             For example in Central European Time (UTC+01), when going from
             03:00 DST to 02:00 non-DST, 02:30:00 local time occurs both at
@@ -11596,7 +11596,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
             - 'infer' will attempt to infer fall dst-transition hours based on
               order
-            - bool-ndarray where True signifies a DST time, False designates
+            - bool where True signifies a DST time, False designates
               a non-DST time (note that this flag is only applicable for
               ambiguous times)
             - 'NaT' will return NaT where there are ambiguous times


### PR DESCRIPTION
`ambiguous` takes bool as an argument, not bool-ndarray. `[True, False]` wouldn't make sense in this context. 

Docstring update so checklist N/A. 

