### PR TITLE
BUG: Fix reading of multi_index dataframe with NaN

### DIFF
--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -746,7 +746,8 @@ cdef class TextReader:
                               is not None else 0)
 
                         # if wrong number of blanks or no index, not our format
-                        if (lc != unnamed_count and lc - ic >= unnamed_count) or ic == 0:
+                        if ((lc != unnamed_count and lc - ic >= unnamed_count) or
+                                ic == 0):
                             hr -= 1
                             self.parser_start -= 1
                             this_header = [None] * lc

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -746,7 +746,7 @@ cdef class TextReader:
                               is not None else 0)
 
                         # if wrong number of blanks or no index, not our format
-                        if (lc != unnamed_count and lc - ic > unnamed_count) or ic == 0:
+                        if (lc != unnamed_count and lc - ic >= unnamed_count) or ic == 0:
                             hr -= 1
                             self.parser_start -= 1
                             this_header = [None] * lc

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -332,6 +332,22 @@ $1$,$2$
         )
         assert result == expected
 
+    def test_to_csv_multi_index_nan(self):
+        # Create a MultiIndex DataFrame
+        columns = pd.MultiIndex.from_tuples([('Level 1', 'Level 2')], names=['level1', 'level2'])
+        data = [[np.nan], [0.1], [0.4]]
+        df_complex = pd.DataFrame(data, columns=columns)
+
+        # Expected DataFrame
+        expected_df = pd.DataFrame(data, columns=columns, index=range(3))
+
+        # Save and load the DataFrame as a CSV
+        with tm.ensure_clean("complex_data.csv") as path:
+            df_complex.to_csv(path)
+            loaded_df_complex = pd.read_csv(path, header=[0, 1], index_col=0)
+
+        tm.assert_frame_equal(loaded_df_complex, expected_df)
+
     def test_to_csv_multi_index(self):
         # see gh-6618
         df = DataFrame([1], columns=pd.MultiIndex.from_arrays([[1], [2]]))

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -334,12 +334,14 @@ $1$,$2$
 
     def test_to_csv_multi_index_nan(self):
         # Create a MultiIndex DataFrame
-        columns = pd.MultiIndex.from_tuples([('Level 1', 'Level 2')], names=['level1', 'level2'])
+        columns = pd.MultiIndex.from_tuples(
+            [("Level 1", "Level 2")], names=["level1", "level2"]
+        )
         data = [[np.nan], [0.1], [0.4]]
-        df_complex = pd.DataFrame(data, columns=columns)
+        df_complex = DataFrame(data, columns=columns)
 
         # Expected DataFrame
-        expected_df = pd.DataFrame(data, columns=columns, index=range(3))
+        expected_df = DataFrame(data, columns=columns, index=range(3))
 
         # Save and load the DataFrame as a CSV
         with tm.ensure_clean("complex_data.csv") as path:


### PR DESCRIPTION
- [x] closes #56929 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

See #56929 for some of the discussion around this bug. Instead of removing the additional header row as suggested in the issue, I fixed the bug _after_ reading all three rows as a header. The code that errors will have these headers: _header_: ['0', 'Unnamed: 1_level_2'], the code where we explicitly set empty values to NaN before writing has these: _header_: ['0', 'NaN'].  The problem with the empty value stems from this line: https://github.com/pandas-dev/pandas/blob/736868671044605b0f2c2cc23ab5ea09fbc9a2ac/pandas/_libs/parsers.pyx#L694-L698 which checks for an empty string and then assigns Unnamed level to it (this is where the paths for the csv with explicit NaN values diverges as its not assigned the unnamed level)

I think there are several ways of fixing this. In this PR I tried to make sure that the first header is treated like the second by simply changing the comparison in this line: https://github.com/pandas-dev/pandas/blob/736868671044605b0f2c2cc23ab5ea09fbc9a2ac/pandas/_libs/parsers.pyx#L749 
No other tests are failing after recompiling the code, therefore I am fairly confident that this fixes the issue and does not introduce others. However, it would still be good if someone else with more parsing experience looks over it. 

Edit: It seems some tests are breaking due to this, will check it out now. 