### PR TITLE
BUG: PeriodIndex.asfreq silently converts offset to period

### DIFF
--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -17,7 +17,10 @@ from pandas._libs.tslibs import (
     Resolution,
     Tick,
 )
-from pandas._libs.tslibs.dtypes import OFFSET_TO_PERIOD_FREQSTR
+from pandas._libs.tslibs.dtypes import (
+    OFFSET_TO_PERIOD_FREQSTR,
+    freq_to_period_freqstr,
+)
 from pandas.util._decorators import (
     cache_readonly,
     doc,
@@ -205,6 +208,15 @@ class PeriodIndex(DatetimeIndexOpsMixin):
         **_shared_doc_kwargs,
     )
     def asfreq(self, freq=None, how: str = "E") -> Self:
+        if isinstance(freq, BaseOffset):
+            if hasattr(freq, "_period_dtype_code"):
+                freq = freq_to_period_freqstr(freq.n, freq.name)
+            else:
+                raise ValueError(
+                    f"Invalid offset: '{freq.base}' for converting time series "
+                    f"with PeriodIndex."
+                )
+
         arr = self._data.asfreq(freq, how)
         return type(self)._simple_new(arr, name=self.name)
 

--- a/pandas/tests/indexes/period/methods/test_asfreq.py
+++ b/pandas/tests/indexes/period/methods/test_asfreq.py
@@ -7,6 +7,8 @@ from pandas import (
 )
 import pandas._testing as tm
 
+from pandas.tseries import offsets
+
 
 class TestPeriodIndex:
     def test_asfreq(self):
@@ -136,3 +138,18 @@ class TestPeriodIndex:
 
         excepted = Series([1, 2], index=PeriodIndex(["2020-02", "2020-04"], freq="M"))
         tm.assert_series_equal(result, excepted)
+
+    @pytest.mark.parametrize(
+        "freq",
+        [
+            offsets.MonthBegin(2),
+            offsets.BusinessMonthEnd(2),
+        ],
+    )
+    def test_pi_asfreq_invalid_baseoffset(self, freq):
+        # GH#55785
+        msg = f"Invalid offset: '{freq.base}' for converting time series "
+
+        pi = PeriodIndex(["2020-01-01", "2021-01-01"], freq="M")
+        with pytest.raises(ValueError, match=msg):
+            pi.asfreq(freq=freq)


### PR DESCRIPTION
xref #52064

`PeriodIndex.asfreq` silently converts for offsets such as `offsets.MonthBegin()`, `offsets.BusinessMonthEnd()`, etc. (with no attribute `'_period_dtype_code'`) frequency to period frequency (in this case `'M'`).

Reproducible Example:
```
>>> import pandas as pd
>>> from pandas.tseries import offsets
>>>
>>> index = pd.PeriodIndex(["2020-01-01", "2021-01-01"], freq="Q")
>>> index.asfreq(freq=offsets.MonthBegin(1))
PeriodIndex(['2020-03', '2021-03'], dtype='period[M]')
>>>
>>> index.asfreq(freq=offsets.BusinessMonthEnd(1)) 
PeriodIndex(['2020-03', '2021-03'], dtype='period[M]')
```
the correct behaviour would be raising an Error:
```
>>> index.asfreq(freq=offsets.MonthBegin(1))
ValueError: <MonthBegin> is not supported as period frequency
>>>
>>> index.asfreq(freq=offsets.BusinessMonthEnd(1))
ValueError: <BusinessMonthEnd> is not supported as period frequency
```

corrected the definition of `PeriodIndex.asfreq`and added tests.