### PR TITLE
DOCS: DataFrame.any() and DataFrame.all() documentation specifies the…

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -13081,8 +13081,8 @@ skipna : bool, default True
 Returns
 -------
 {name1} or {name2}
-    If level is specified, then, {name2} is returned; otherwise, {name1}
-    is returned.
+    If axis=None, then a {name2} boolean is returned. Otherwise a Series is 
+    returned with index matching the index argument.
 
 {see_also}
 {examples}"""
@@ -13643,12 +13643,16 @@ def make_doc(name: str, ndim: int) -> str:
         axis_descr = "{index (0), columns (1)}"
 
     if name == "any":
+        name1 = "DataFrame"
+        name2 = "scalar"
         base_doc = _bool_doc
         desc = _any_desc
         see_also = _any_see_also
         examples = _any_examples
         kwargs = {"empty_value": "False"}
     elif name == "all":
+        name1 = "DataFrame"
+        name2 = "scalar"
         base_doc = _bool_doc
         desc = _all_desc
         see_also = _all_see_also

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -13081,7 +13081,7 @@ skipna : bool, default True
 Returns
 -------
 {name1} or {name2}
-    If axis=None, then a {name2} boolean is returned. Otherwise a Series is 
+    If axis=None, then a {name2} boolean is returned. Otherwise a Series is
     returned with index matching the index argument.
 
 {see_also}


### PR DESCRIPTION
… wrong return types

- [x] closes #57088  
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
