### PR TITLE
BUG: fix `Series.value_counts` with `sort=False` returns result sorted on values for Series with string dtype

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -152,7 +152,7 @@ Conversion
 
 Strings
 ^^^^^^^
--
+- Bug in :meth:`Series.value_counts` would not respect ``sort=False`` for series having ``string`` dtype (:issue:`55224`)
 -
 
 Interval

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -908,13 +908,8 @@ def value_counts_internal(
 
     else:
         if is_extension_array_dtype(values):
-            if values.dtype == "string[python]":
-                result = Series(values, copy=False)._values.value_counts(
-                    sort=sort, dropna=dropna
-                )
-            else:
-                # handle Categorical and sparse,
-                result = Series(values, copy=False)._values.value_counts(dropna=dropna)
+            # handle Categorical and sparse,
+            result = Series(values, copy=False)._values.value_counts(dropna=dropna)
             result.name = name
             result.index.name = index_name
             counts = result._values

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -908,8 +908,13 @@ def value_counts_internal(
 
     else:
         if is_extension_array_dtype(values):
-            # handle Categorical and sparse,
-            result = Series(values, copy=False)._values.value_counts(dropna=dropna)
+            if values.dtype == "string[python]":
+                result = Series(values, copy=False)._values.value_counts(
+                    sort=sort, dropna=dropna
+                )
+            else:
+                # handle Categorical and sparse,
+                result = Series(values, copy=False)._values.value_counts(dropna=dropna)
             result.name = name
             result.index.name = index_name
             counts = result._values

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -539,10 +539,10 @@ class StringArray(BaseStringArray, NumpyExtensionArray):  # type: ignore[misc]
         )
         return self._wrap_reduction_result(axis, result)
 
-    def value_counts(self, dropna: bool = True) -> Series:
+    def value_counts(self, sort: bool = True, dropna: bool = True) -> Series:
         from pandas.core.algorithms import value_counts_internal as value_counts
 
-        result = value_counts(self._ndarray, dropna=dropna).astype("Int64")
+        result = value_counts(self._ndarray, sort=sort, dropna=dropna).astype("Int64")
         result.index = result.index.astype(self.dtype)
         return result
 

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -539,10 +539,10 @@ class StringArray(BaseStringArray, NumpyExtensionArray):  # type: ignore[misc]
         )
         return self._wrap_reduction_result(axis, result)
 
-    def value_counts(self, sort: bool = True, dropna: bool = True) -> Series:
+    def value_counts(self, dropna: bool = True) -> Series:
         from pandas.core.algorithms import value_counts_internal as value_counts
 
-        result = value_counts(self._ndarray, sort=sort, dropna=dropna).astype("Int64")
+        result = value_counts(self._ndarray, sort=False, dropna=dropna).astype("Int64")
         result.index = result.index.astype(self.dtype)
         return result
 

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -584,6 +584,19 @@ def test_value_counts_with_normalize(dtype):
     tm.assert_series_equal(result, expected)
 
 
+def test_value_counts_sort_false(dtype):
+    if getattr(dtype, "storage", "") == "pyarrow":
+        exp_dtype = "int64[pyarrow]"
+    elif getattr(dtype, "storage", "") == "pyarrow_numpy":
+        exp_dtype = "int64"
+    else:
+        exp_dtype = "Int64"
+    ser = pd.Series(["a", "b", "c", "b"], dtype=dtype)
+    result = ser.value_counts(sort=False)
+    expected = pd.Series([1, 2, 1], index=ser[:3], dtype=exp_dtype, name="count")
+    tm.assert_series_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     "values, expected",
     [


### PR DESCRIPTION

- [x] closes #55224 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
