### PR TITLE
DOC: fix PR02 errors in docstrings - pandas.describe_option, pandas.get_option, pandas.reset_option

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -162,9 +162,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.tseries.offsets.Milli\
         pandas.tseries.offsets.Micro\
         pandas.tseries.offsets.Nano\
-        pandas.describe_option\
-        pandas.reset_option\
-        pandas.get_option\
         pandas.set_option\
         pandas.Timestamp.max\
         pandas.Timestamp.min\

--- a/pandas/_config/config.py
+++ b/pandas/_config/config.py
@@ -54,6 +54,7 @@ from contextlib import (
     ContextDecorator,
     contextmanager,
 )
+from inspect import signature
 import re
 from typing import (
     TYPE_CHECKING,
@@ -270,6 +271,7 @@ class CallableDynamicDoc(Generic[T]):
     def __init__(self, func: Callable[..., T], doc_tmpl: str) -> None:
         self.__doc_tmpl__ = doc_tmpl
         self.__func__ = func
+        self.__signature__ = signature(func)
 
     def __call__(self, *args, **kwds) -> T:
         return self.__func__(*args, **kwds)


### PR DESCRIPTION
Test results:
Describe_option
```
$ scripts/validate_docstrings.py --format=actions --errors=PR02 pandas.describe_option
...
################################################################################
################################## Validation ##################################
################################################################################

1 Errors found for `pandas.describe_option`:
        SA01    See Also section not found
```
Get_option
```
$ scripts/validate_docstrings.py --format=actions --errors=PR02 pandas.get_option
...
################################################################################
################################## Validation ##################################
################################################################################

2 Errors found for `pandas.get_option`:
        PR01    Parameters {'silent'} not documented
        SA01    See Also section not found
```
Reset_option
```
$ scripts/validate_docstrings.py --format=actions --errors=PR02 pandas.reset_option
...
################################################################################
################################## Validation ##################################
################################################################################

2 Errors found for `pandas.reset_option`:
        PR01    Parameters {'silent'} not documented
        SA01    See Also section not found
```

- [X] Cross-ref: https://github.com/pandas-dev/pandas/issues/57111
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
