### PR TITLE
Fix typo in missing_data.rst

### DIFF
--- a/doc/source/user_guide/missing_data.rst
+++ b/doc/source/user_guide/missing_data.rst
@@ -30,7 +30,7 @@ use :class:`api.types.NaTType`.
    pd.Series(["2020", "2020"], dtype=pd.PeriodDtype("D")).reindex([0, 1, 2])
 
 :class:`NA` for :class:`StringDtype`, :class:`Int64Dtype` (and other bit widths),
-:class:`Float64Dtype`(and other bit widths), :class:`BooleanDtype` and :class:`ArrowDtype`.
+:class:`Float64Dtype` (and other bit widths), :class:`BooleanDtype` and :class:`ArrowDtype`.
 These types will maintain the original data type of the data.
 For typing applications, use :class:`api.types.NAType`.
 


### PR DESCRIPTION
<img width="736" alt="Screen Shot 2024-01-29 at 10 58 11 AM" src="https://github.com/pandas-dev/pandas/assets/48232/1c2b9c87-9acc-43a6-8fe2-19a3a131c9c1">
