### PR TITLE
CLN: The smallest typo correction, "engine" lacked an "n".

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -332,7 +332,7 @@ class ReadCsvBuffer(ReadBuffer[AnyStr_co], Protocol):
 
     @property
     def closed(self) -> bool:
-        # for enine=pyarrow
+        # for engine=pyarrow
         ...
 
 


### PR DESCRIPTION
The title is pretty descriptive, was checking some pyarrow stuff and stumbled onto this. I apologize if a PR was not needed. Have a good one!
