### PR TITLE
DEPR: removed deprecated argument `obj` from GroupBy `get_group`

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -97,6 +97,13 @@ Deprecations
 -
 
 .. ---------------------------------------------------------------------------
+.. _whatsnew_300.prior_deprecations:
+
+Removal of prior version deprecations/changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- Removed deprecated argument ``obj`` in :meth:`GroupBy.get_group` (:issue:`53545`)
+
+.. ---------------------------------------------------------------------------
 .. _whatsnew_300.performance:
 
 Performance improvements

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -101,7 +101,7 @@ Deprecations
 
 Removal of prior version deprecations/changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- Removed deprecated argument ``obj`` in :meth:`GroupBy.get_group` (:issue:`53545`)
+- Removed deprecated argument ``obj`` in :meth:`.DataFrameGroupBy.get_group` and :meth:`.SeriesGroupBy.get_group` (:issue:`53545`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.performance:

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1049,7 +1049,7 @@ class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
         return com.pipe(self, func, *args, **kwargs)
 
     @final
-    def get_group(self, name, obj=None) -> DataFrame | Series:
+    def get_group(self, name) -> DataFrame | Series:
         """
         Construct DataFrame from group with provided name.
 
@@ -1057,18 +1057,10 @@ class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
         ----------
         name : object
             The name of the group to get as a DataFrame.
-        obj : DataFrame, default None
-            The DataFrame to take the DataFrame out of.  If
-            it is None, the object groupby was called on will
-            be used.
 
         Returns
         -------
-        same type as obj
-
-        Raises
-        ------
-        ValueError : The passed argument obj is not None.
+        DataFrame or Series
 
         Examples
         --------
@@ -1141,11 +1133,8 @@ class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
         if not len(inds):
             raise KeyError(name)
 
-        if obj is None:
-            indexer = inds if self.axis == 0 else (slice(None), inds)
-            return self._selected_obj.iloc[indexer]
-        else:
-            raise ValueError("cannot pass argument obj to get_group")
+        indexer = inds if self.axis == 0 else (slice(None), inds)
+        return self._selected_obj.iloc[indexer]
 
     @final
     def __iter__(self) -> Iterator[tuple[Hashable, NDFrameT]]:

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1062,14 +1062,13 @@ class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
             it is None, the object groupby was called on will
             be used.
 
-            .. deprecated:: 2.1.0
-                The obj is deprecated and will be removed in a future version.
-                Do ``df.iloc[gb.indices.get(name)]``
-                instead of ``gb.get_group(name, obj=df)``.
-
         Returns
         -------
         same type as obj
+
+        Raises
+        ------
+        ValueError : The passed argument obj is not None.
 
         Examples
         --------
@@ -1146,14 +1145,7 @@ class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
             indexer = inds if self.axis == 0 else (slice(None), inds)
             return self._selected_obj.iloc[indexer]
         else:
-            warnings.warn(
-                "obj is deprecated and will be removed in a future version. "
-                "Do ``df.iloc[gb.indices.get(name)]`` "
-                "instead of ``gb.get_group(name, obj=df)``.",
-                FutureWarning,
-                stacklevel=find_stack_level(),
-            )
-            return obj._take_with_is_copy(inds, axis=self.axis)
+            raise ValueError("cannot pass argument obj to get_group")
 
     @final
     def __iter__(self) -> Iterator[tuple[Hashable, NDFrameT]]:

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -526,14 +526,6 @@ def test_as_index_select_column():
     tm.assert_series_equal(result, expected)
 
 
-def test_obj_arg_get_group_deprecated():
-    msg = "cannot pass argument obj to get_group"
-
-    df = DataFrame({"a": [1, 1, 2], "b": [3, 4, 5]})
-    with pytest.raises(ValueError, match=msg):
-        df.groupby("b").get_group(4, obj=df)
-
-
 def test_groupby_as_index_select_column_sum_empty_df():
     # GH 35246
     df = DataFrame(columns=Index(["A", "B", "C"], name="alpha"))

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -527,7 +527,7 @@ def test_as_index_select_column():
 
 
 def test_obj_arg_get_group_deprecated():
-    msg = "cannot pass parameter obj to get_group"
+    msg = "cannot pass argument obj to get_group"
 
     df = DataFrame({"a": [1, 1, 2], "b": [3, 4, 5]})
     with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -527,13 +527,11 @@ def test_as_index_select_column():
 
 
 def test_obj_arg_get_group_deprecated():
-    depr_msg = "obj is deprecated"
+    msg = "cannot pass parameter obj to get_group"
 
     df = DataFrame({"a": [1, 1, 2], "b": [3, 4, 5]})
-    expected = df.iloc[df.groupby("b").indices.get(4)]
-    with tm.assert_produces_warning(FutureWarning, match=depr_msg):
-        result = df.groupby("b").get_group(4, obj=df)
-        tm.assert_frame_equal(result, expected)
+    with pytest.raises(ValueError, match=msg):
+        df.groupby("b").get_group(4, obj=df)
 
 
 def test_groupby_as_index_select_column_sum_empty_df():


### PR DESCRIPTION
- xref #53571
- removed deprecated argument `obj` from GroupBy `get_group`
- added an entry in the doc/source/whatsnew/v3.0.0.rst

