### PR TITLE
CI: Remove redundant check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,8 +101,6 @@ repos:
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
-      - id: python-check-blanket-noqa
-      - id: python-check-blanket-type-ignore
       - id: rst-backticks
       - id: rst-directive-colons
         types: [text]  # overwrite types: [rst]


### PR DESCRIPTION
I removed 2 checks that's already covered in `ruff`'s [`PGH003`](https://docs.astral.sh/ruff/rules/blanket-type-ignore/) and [`PGH004`](https://docs.astral.sh/ruff/rules/blanket-noqa/)

The second commit is just an example that the check works. Will revert before merging if approved.

```bash
ruff....................................................................................................Failed
- hook id: ruff
- exit code: 1

pandas/compat/numpy/function.py:209:18: PGH003 Use specific rule codes when ignoring type issues
pandas/tests/computation/test_compat.py:30:18: PGH004 Use specific rule codes when using `noqa`
Found 2 errors.

```

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
