### PR TITLE
CI: Pinning doc previewer action to current release

### DIFF
--- a/.github/workflows/comment-commands.yml
+++ b/.github/workflows/comment-commands.yml
@@ -24,7 +24,7 @@ jobs:
     concurrency:
       group: ${{ github.actor }}-preview-docs
     steps:
-      - uses: pandas-dev/github-doc-previewer@master
+      - uses: pandas-dev/github-doc-previewer@v0.3.1
         with:
           previewer-server: "https://pandas.pydata.org/preview"
           artifact-job: "Doc Build and Upload"


### PR DESCRIPTION
I don't think we'll have any doc previewer release that won't be done for pandas, but pinning the action to avoid automatic upgrades anyway.