### PR TITLE
DOC: fix PR02 errors in docstrings - pandas.core.window.rolling.Rolling.quantile, pandas.core.window.expanding.Expanding.quantile

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -178,9 +178,7 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.core.groupby.DataFrameGroupBy.hist\
         pandas.core.groupby.DataFrameGroupBy.plot\
         pandas.core.groupby.DataFrameGroupBy.corrwith\
-        pandas.core.groupby.SeriesGroupBy.plot\
-        pandas.core.window.rolling.Rolling.quantile\
-        pandas.core.window.expanding.Expanding.quantile # There should be no backslash in the final line, please keep this comment in the last ignored function
+        pandas.core.groupby.SeriesGroupBy.plot # There should be no backslash in the final line, please keep this comment in the last ignored function
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
 fi

--- a/pandas/core/window/expanding.py
+++ b/pandas/core/window/expanding.py
@@ -664,11 +664,11 @@ class Expanding(RollingAndExpandingMixin):
         create_section_header("Parameters"),
         dedent(
             """
-        quantile : float
+        q : float
             Quantile to compute. 0 <= quantile <= 1.
 
             .. deprecated:: 2.1.0
-                This will be renamed to 'q' in a future version.
+                This was renamed from 'quantile' to 'q' in version 2.1.0.
         interpolation : {{'linear', 'lower', 'higher', 'midpoint', 'nearest'}}
             This optional parameter specifies the interpolation method to use,
             when the desired quantile lies between two data points `i` and `j`:

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -2502,11 +2502,11 @@ class Rolling(RollingAndExpandingMixin):
         create_section_header("Parameters"),
         dedent(
             """
-        quantile : float
+        q : float
             Quantile to compute. 0 <= quantile <= 1.
 
             .. deprecated:: 2.1.0
-                This will be renamed to 'q' in a future version.
+                This was renamed from 'quantile' to 'q' in version 2.1.0.
         interpolation : {{'linear', 'lower', 'higher', 'midpoint', 'nearest'}}
             This optional parameter specifies the interpolation method to use,
             when the desired quantile lies between two data points `i` and `j`:


### PR DESCRIPTION
All PR02 Errors resolved in the following cases:

1. scripts/validate_docstrings.py --format=actions --errors=PR02 pandas.core.window.rolling.Rolling.quantile
2. scripts/validate_docstrings.py --format=actions --errors=PR02 pandas.core.window.expanding.Expanding.quantile

OUTPUT:

1. scripts/validate_docstrings.py --format=actions --errors=PR02 pandas.core.window.rolling.Rolling.quantile
```
################################################################################
################################## Validation ##################################
################################################################################

5 Errors found for `pandas.core.window.rolling.Rolling.quantile`:
	ES01	No extended summary found
	SA05	pandas.Series.rolling in `See Also` section does not need `pandas` prefix, use Series.rolling instead.
	SA05	pandas.DataFrame.rolling in `See Also` section does not need `pandas` prefix, use DataFrame.rolling instead.
	SA05	pandas.Series.quantile in `See Also` section does not need `pandas` prefix, use Series.quantile instead.
	SA05	pandas.DataFrame.quantile in `See Also` section does not need `pandas` prefix, use DataFrame.quantile instead.
```

2. scripts/validate_docstrings.py --format=actions --errors=PR02 pandas.core.window.expanding.Expanding.quantile
```
################################################################################
################################## Validation ##################################
################################################################################

5 Errors found for `pandas.core.window.expanding.Expanding.quantile`:
	ES01	No extended summary found
	SA05	pandas.Series.expanding in `See Also` section does not need `pandas` prefix, use Series.expanding instead.
	SA05	pandas.DataFrame.expanding in `See Also` section does not need `pandas` prefix, use DataFrame.expanding instead.
	SA05	pandas.Series.quantile in `See Also` section does not need `pandas` prefix, use Series.quantile instead.
	SA05	pandas.DataFrame.quantile in `See Also` section does not need `pandas` prefix, use DataFrame.quantile instead.
```

- [x] xref https://github.com/pandas-dev/pandas/issues/57111
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
