### PR TITLE
DOC: Replace pandas logo with a conditional image for light and dark …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-<div align="center">
-  <img src="https://pandas.pydata.org/static/img/pandas.svg"><br>
-</div>
+<picture align="center">
+  <source media="(prefers-color-scheme: dark)" srcset="https://pandas.pydata.org/static/img/pandas_white.svg">
+  <img alt="Pandas Logo" src="https://pandas.pydata.org/static/img/pandas.svg">
+</picture>
 
 -----------------
 


### PR DESCRIPTION
...themes

Replaced the static pandas logo with a `picture` tag that displays a different logo based on the color scheme. In light mode, the original logo is shown, while in dark mode, a white version of the logo is displayed for better visibility.

In GitHub Dark Theme
![image](https://github.com/pandas-dev/pandas/assets/61258323/a820a065-29d9-489a-b6f8-1e9d68bb5e57)

In GitHub Light Theme
![image](https://github.com/pandas-dev/pandas/assets/61258323/66ff39ee-8f6f-4271-9cf6-16d7ba229717)
