### PR TITLE
BUG: Raise if an aggregation function other than mean is used with ewm and times

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -205,7 +205,7 @@ Plotting
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 - Bug in :meth:`.DataFrameGroupBy.quantile` when ``interpolation="nearest"`` is inconsistent with :meth:`DataFrame.quantile` (:issue:`47942`)
--
+- Bug in :meth:`DataFrame.ewm` and :meth:`Series.ewm` when passed ``times`` and aggregation functions other than mean (:issue:`51695`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -587,6 +587,8 @@ class ExponentialMovingWindow(BaseWindow):
     ):
         if not self.adjust:
             raise NotImplementedError("sum is not implemented with adjust=False")
+        if self.times is not None:
+            raise NotImplementedError("sum is not implemented with times")
         if maybe_use_numba(engine):
             if self.method == "single":
                 func = generate_numba_ewm_func
@@ -658,6 +660,8 @@ class ExponentialMovingWindow(BaseWindow):
             raise NotImplementedError(
                 f"{type(self).__name__}.std does not implement numeric_only"
             )
+        if self.times is not None:
+            raise NotImplementedError("std is not implemented with times")
         return zsqrt(self.var(bias=bias, numeric_only=numeric_only))
 
     @doc(
@@ -691,6 +695,8 @@ class ExponentialMovingWindow(BaseWindow):
         agg_method="var",
     )
     def var(self, bias: bool = False, numeric_only: bool = False):
+        if self.times is not None:
+            raise NotImplementedError("var is not implemented with times")
         window_func = window_aggregations.ewmcov
         wfunc = partial(
             window_func,
@@ -753,6 +759,9 @@ class ExponentialMovingWindow(BaseWindow):
         bias: bool = False,
         numeric_only: bool = False,
     ):
+        if self.times is not None:
+            raise NotImplementedError("cov is not implemented with times")
+
         from pandas import Series
 
         self._validate_numeric_only("cov", numeric_only)
@@ -837,6 +846,9 @@ class ExponentialMovingWindow(BaseWindow):
         pairwise: bool | None = None,
         numeric_only: bool = False,
     ):
+        if self.times is not None:
+            raise NotImplementedError("corr is not implemented with times")
+
         from pandas import Series
 
         self._validate_numeric_only("corr", numeric_only)

--- a/pandas/tests/window/test_ewm.py
+++ b/pandas/tests/window/test_ewm.py
@@ -173,6 +173,20 @@ def test_ewm_sum_adjust_false_notimplemented():
         data.sum()
 
 
+@pytest.mark.parametrize("method", ["sum", "std", "var", "cov", "corr"])
+def test_times_only_mean_implemented(
+    frame_or_series: (type[DataFrame] | type[Series]), method: str
+):
+    # GH 51695
+    halflife = "1 day"
+    times = date_range("2000", freq="D", periods=10)
+    ewm = frame_or_series(range(10)).ewm(halflife=halflife, times=times)
+    with pytest.raises(
+        NotImplementedError, match=f"{method} is not implemented with times"
+    ):
+        getattr(ewm, method)()
+
+
 @pytest.mark.parametrize(
     "expected_data, ignore",
     [[[10.0, 5.0, 2.5, 11.25], False], [[10.0, 5.0, 5.0, 12.5], True]],

--- a/pandas/tests/window/test_ewm.py
+++ b/pandas/tests/window/test_ewm.py
@@ -174,9 +174,7 @@ def test_ewm_sum_adjust_false_notimplemented():
 
 
 @pytest.mark.parametrize("method", ["sum", "std", "var", "cov", "corr"])
-def test_times_only_mean_implemented(
-    frame_or_series: (type[DataFrame] | type[Series]), method: str
-):
+def test_times_only_mean_implemented(frame_or_series, method):
     # GH 51695
     halflife = "1 day"
     times = date_range("2000", freq="D", periods=10)


### PR DESCRIPTION
Ran into this recently and found an issue was reported a while ago without any progress (#51695)

- [x] closes #51695
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
