### PR TITLE
DOC: fix PR02 errors in docstring for pandas.io.formats.style.Styler.to_excel

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -71,7 +71,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
 
     MSG='Partially validate docstrings (PR02)' ;  echo $MSG
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=PR02 --ignore_functions \
-        pandas.io.formats.style.Styler.to_excel\
         pandas.CategoricalIndex.rename_categories\
         pandas.CategoricalIndex.reorder_categories\
         pandas.CategoricalIndex.add_categories\

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -220,6 +220,8 @@ if TYPE_CHECKING:
     from pandas.core.indexers.objects import BaseIndexer
     from pandas.core.resample import Resampler
 
+import textwrap
+
 # goal is to be able to define the docs close to function, while still being
 # able to share
 _shared_docs = {**_shared_docs}
@@ -2240,6 +2242,12 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         klass="object",
         storage_options=_shared_docs["storage_options"],
         storage_options_versionadded="1.2.0",
+        extra_parameters=textwrap.dedent(
+            """\
+        engine_kwargs : dict, optional
+            Arbitrary keyword arguments passed to excel engine.
+    """
+        ),
     )
     def to_excel(
         self,
@@ -2315,9 +2323,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         {storage_options}
 
             .. versionadded:: {storage_options_versionadded}
-        engine_kwargs : dict, optional
-            Arbitrary keyword arguments passed to excel engine.
-
+        {extra_parameters}
         See Also
         --------
         to_csv : Write DataFrame to a comma-separated values (csv) file.

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -516,6 +516,7 @@ class Styler(StylerRenderer):
         klass="Styler",
         storage_options=_shared_docs["storage_options"],
         storage_options_versionadded="1.5.0",
+        extra_parameters="",
     )
     def to_excel(
         self,


### PR DESCRIPTION
All PR02 Errors resolved in the following cases:

1. scripts/validate_docstrings.py --format=actions --errors=PR02 pandas.io.formats.style.Styler.to_excel

OUTPUT:

1. scripts/validate_docstrings.py --format=actions --errors=PR02 pandas.io.formats.style.Styler.to_excel
```
################################################################################
################################## Validation ##################################
################################################################################

1 Errors found for `pandas.io.formats.style.Styler.to_excel`:
	PR01	Parameters {'verbose', 'encoding'} not documented
```


- [x] xref https://github.com/pandas-dev/pandas/issues/57111
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
