### PR TITLE
DOC: Clarifying brackets vs. parentheses

### DIFF
--- a/doc/source/getting_started/intro_tutorials/02_read_write.rst
+++ b/doc/source/getting_started/intro_tutorials/02_read_write.rst
@@ -97,11 +97,11 @@ in this ``DataFrame`` are integers (``int64``), floats (``float64``) and
 strings (``object``).
 
 .. note::
-    When asking for the ``dtypes``, no brackets are used!
+    When asking for the ``dtypes``, no parentheses ``()`` are used!
     ``dtypes`` is an attribute of a ``DataFrame`` and ``Series``. Attributes
-    of a ``DataFrame`` or ``Series`` do not need brackets. Attributes
+    of a ``DataFrame`` or ``Series`` do not need ``()``. Attributes
     represent a characteristic of a ``DataFrame``/``Series``, whereas
-    methods (which require brackets) *do* something with the
+    methods (which require parentheses ``()``) *do* something with the
     ``DataFrame``/``Series`` as introduced in the :ref:`first tutorial <10min_tut_01_tableoriented>`.
 
 .. raw:: html

--- a/doc/source/getting_started/intro_tutorials/03_subset_data.rst
+++ b/doc/source/getting_started/intro_tutorials/03_subset_data.rst
@@ -101,7 +101,7 @@ selection brackets ``[]``.
 .. note::
     The inner square brackets define a
     :ref:`Python list <python:tut-morelists>` with column names, whereas
-    the outer brackets are used to select the data from a pandas
+    the outer square brackets are used to select the data from a pandas
     ``DataFrame`` as seen in the previous example.
 
 The returned data type is a pandas DataFrame:
@@ -354,7 +354,7 @@ See the user guide section on :ref:`different choices for indexing <indexing.cho
         <h4>REMEMBER</h4>
 
 -  When selecting subsets of data, square brackets ``[]`` are used.
--  Inside these brackets, you can use a single column/row label, a list
+-  Inside these square brackets, you can use a single column/row label, a list
    of column/row labels, a slice of labels, a conditional expression or
    a colon.
 -  Select specific rows and/or columns using ``loc`` when using the row

--- a/doc/source/getting_started/intro_tutorials/05_add_columns.rst
+++ b/doc/source/getting_started/intro_tutorials/05_add_columns.rst
@@ -51,7 +51,7 @@ hPa, the conversion factor is 1.882*)
     air_quality["london_mg_per_cubic"] = air_quality["station_london"] * 1.882
     air_quality.head()
 
-To create a new column, use the ``[]`` brackets with the new column name
+To create a new column, use the square brackets ``[]`` with the new column name
 at the left side of the assignment.
 
 .. raw:: html

--- a/doc/source/getting_started/intro_tutorials/06_calculate_statistics.rst
+++ b/doc/source/getting_started/intro_tutorials/06_calculate_statistics.rst
@@ -162,7 +162,7 @@ columns by passing ``numeric_only=True``:
 
 It does not make much sense to get the average value of the ``Pclass``.
 If we are only interested in the average age for each gender, the
-selection of columns (rectangular brackets ``[]`` as usual) is supported
+selection of columns (square brackets ``[]`` as usual) is supported
 on the grouped data as well:
 
 .. ipython:: python


### PR DESCRIPTION
- [x] closes #56972
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit). (Doc edits only)
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. (Doc edits only)
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature. (Doc edits only)

In addition to the clarification requested in #56972, I adjusted the language where square brackets were specified elsewhere in the documentation to match "square brackets ``[]``", with the exception of one file.

In the data subsetting tutorial guide (`doc/source/getting_started/intro_tutorials/03_subset_data.rst`),  square brackets are specified towards the beginning of the guide, and "selection brackets" was used elsewhere, often to specify outer vs. inner square brackets (i.e. `df[['ColA', 'ColB']]`)