### PR TITLE
DOC: fix PR02 errors in docstrings of Index subclasses

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -71,26 +71,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
 
     MSG='Partially validate docstrings (PR02)' ;  echo $MSG
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=PR02 --ignore_functions \
-        pandas.CategoricalIndex.rename_categories\
-        pandas.CategoricalIndex.reorder_categories\
-        pandas.CategoricalIndex.add_categories\
-        pandas.CategoricalIndex.remove_categories\
-        pandas.CategoricalIndex.set_categories\
-        pandas.IntervalIndex.set_closed\
-        pandas.IntervalIndex.contains\
-        pandas.IntervalIndex.overlaps\
-        pandas.IntervalIndex.to_tuples\
-        pandas.DatetimeIndex.round\
-        pandas.DatetimeIndex.floor\
-        pandas.DatetimeIndex.ceil\
-        pandas.DatetimeIndex.month_name\
-        pandas.DatetimeIndex.day_name\
-        pandas.DatetimeIndex.to_period\
-        pandas.DatetimeIndex.std\
-        pandas.TimedeltaIndex.round\
-        pandas.TimedeltaIndex.floor\
-        pandas.TimedeltaIndex.ceil\
-        pandas.PeriodIndex.strftime\
         pandas.Series.dt.to_period\
         pandas.Series.dt.tz_localize\
         pandas.Series.dt.tz_convert\

--- a/pandas/core/indexes/extension.py
+++ b/pandas/core/indexes/extension.py
@@ -105,7 +105,7 @@ def _inherit_from_data(
         # error: "property" has no attribute "__name__"
         method.__name__ = name  # type: ignore[attr-defined]
         method.__doc__ = attr.__doc__
-        method.__signature__ = signature(attr)
+        method.__signature__ = signature(attr)  # type: ignore[attr-defined]
     return method
 
 

--- a/pandas/core/indexes/extension.py
+++ b/pandas/core/indexes/extension.py
@@ -3,6 +3,7 @@ Shared methods for Index subclasses backed by ExtensionArray.
 """
 from __future__ import annotations
 
+from inspect import signature
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -104,6 +105,7 @@ def _inherit_from_data(
         # error: "property" has no attribute "__name__"
         method.__name__ = name  # type: ignore[attr-defined]
         method.__doc__ = attr.__doc__
+        method.__signature__ = signature(attr)
     return method
 
 


### PR DESCRIPTION
To fix PR02 errors, this PR adds `__signature__` to the methods, so that the docs show the correct signature instead of `*args, **kwargs`.

- [x] xref #57111(Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
