### PR TITLE
Translate more banned import config to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -208,16 +208,9 @@ repos:
         language: pygrep
         entry: |
             (?x)
-            # pytest.xfail instead of pytest.mark.xfail
-            pytest\.xfail
-
             # imports from pandas._testing instead of `import pandas._testing as tm`
-            |from\ pandas\._testing\ import
+            from\ pandas\._testing\ import
             |from\ pandas\ import\ _testing\ as\ tm
-
-            # No direct imports from conftest
-            |conftest\ import
-            |import\ conftest
 
             # pandas.testing instead of tm
             |pd\.testing\.
@@ -225,21 +218,11 @@ repos:
             # pd.api.types instead of from pandas.api.types import ...
             |(pd|pandas)\.api\.types\.
 
-            # np.testing, np.array_equal
-            |(numpy|np)(\.testing|\.array_equal)
-
-            # unittest.mock (use pytest builtin monkeypatch fixture instead)
-            |(unittest(\.| import )mock|mock\.Mock\(\)|mock\.patch)
+            # np.array_equal
+            |(numpy|np)\.array_equal
 
             # pytest raises without context
             |\s\ pytest.raises
-
-            # TODO
-            # pytest.warns (use tm.assert_produces_warning instead)
-            # |pytest\.warns
-
-            # os.remove
-            |os\.remove
 
             # Unseeded numpy default_rng
             |default_rng\(\)

--- a/doc/make.py
+++ b/doc/make.py
@@ -233,7 +233,7 @@ class DocBuilder:
         ret_code = self._sphinx_build("html")
         zip_fname = os.path.join(BUILD_PATH, "html", "pandas.zip")
         if os.path.exists(zip_fname):
-            os.remove(zip_fname)
+            os.remove(zip_fname)  # noqa: TID251
 
         if ret_code == 0:
             if self.single_doc_html is not None:
@@ -285,7 +285,7 @@ class DocBuilder:
         """
         zip_fname = os.path.join(BUILD_PATH, "html", "pandas.zip")
         if os.path.exists(zip_fname):
-            os.remove(zip_fname)
+            os.remove(zip_fname)  # noqa: TID251
         dirname = os.path.join(BUILD_PATH, "html")
         fnames = os.listdir(dirname)
         os.chdir(dirname)

--- a/pandas/tests/copy_view/test_chained_assignment_deprecation.py
+++ b/pandas/tests/copy_view/test_chained_assignment_deprecation.py
@@ -18,7 +18,7 @@ def test_series_setitem(indexer):
 
     # using custom check instead of tm.assert_produces_warning because that doesn't
     # fail if multiple warnings are raised
-    with pytest.warns() as record:
+    with pytest.warns() as record:  # noqa: TID251
         df["a"][indexer] = 0
     assert len(record) == 1
     assert record[0].category == ChainedAssignmentError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -331,6 +331,17 @@ exclude = [
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "urllib.request.urlopen".msg = "Use pandas.io.common.urlopen instead of urllib.request.urlopen"
+# numpy.random is banned but np.random is not. Is this intentional?
+# "numpy.random".msg = "Do not use numpy.random"
+"pytest.warns".msg = "Use tm.assert_produces_warning instead of pytest.warns"
+"pytest.xfail".msg = "Use pytest.mark.xfail instead of pytest.xfail"
+"conftest".msg = "No direct imports from conftest"
+"numpy.testing".msg = "Do not use numpy.testing"
+# "numpy.array_equal".msg = "Do not use numpy.array_equal" # Used in pandas/core
+"unittest.mock".msg = "use pytest builtin monkeypatch fixture instead"
+"os.remove".msg = "Do not use os.remove"
+
+
 
 [tool.ruff.per-file-ignores]
 # relative imports allowed for asv_bench

--- a/web/tests/test_pandas_web.py
+++ b/web/tests/test_pandas_web.py
@@ -1,4 +1,4 @@
-from unittest.mock import (
+from unittest.mock import (  # noqa: TID251
     mock_open,
     patch,
 )


### PR DESCRIPTION
Translate some config in `unwanted-patterns-in-tests` to `ruff`. I think the main selling point of `ruff` here is just the ease of implementing new rules, like the currently unenabled `pytest.warns` one.

The major difference is that `unwanted-patterns-in-tests` is currently only enabled in `pandas/tests` while with this implementation, `TID251` will be enabled globally. 

There are several approaches we can explore to reconcile the 2 behaviors. 
- Keep it globally enabled for rule where the number of errors is low (and keep using `pygrep`) for the rest
- Use [hierarchical configuration](https://docs.astral.sh/ruff/configuration/#pyprojecttoml-discovery) (I think `pandas` doesn't use it at the moment, so this will be a fairly big change)

There's an open issue to track the progress of [flat configuration](https://github.com/astral-sh/ruff/issues/7696), which allows us to keep all rules within 1 config file, but there's not much progress lately.