### PR TITLE
Fixed BUG: Using NamedTuples with .iloc fails #48188

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1162,7 +1162,8 @@ class _LocationIndexer(NDFrameIndexerBase):
     @final
     def __getitem__(self, key):
         check_dict_or_set_indexers(key)
-        if type(key) is tuple:
+        ##if type(key) is tuple:
+        if isinstance(key, tuple):
             key = tuple(list(x) if is_iterator(x) else x for x in key)
             key = tuple(com.apply_if_callable(x, self.obj) for x in key)
             if self._is_scalar_access(key):

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -6,6 +6,10 @@ import re
 import numpy as np
 import pytest
 
+
+import pandas as pd
+from collections import namedtuple
+
 from pandas.errors import IndexingError
 
 from pandas import (
@@ -1463,3 +1467,24 @@ class TestILocSeries:
             result.loc[:, "b"] = result.loc[:, "b"].astype("Int64")
         expected = DataFrame({"a": ["test"], "b": array([NA], dtype="Int64")})
         tm.assert_frame_equal(result, expected)
+
+
+
+    def test_iloc_with_namedtuple():
+        # setup a dataFrame
+        df = pd.DataFrame(np.arange(100).reshape(10, 10))
+    
+        # define a namedtuple 
+        Indexer = namedtuple("Indexer", ["row", "col"])
+    
+        # Test .iloc with a regular tuple
+        result_with_tuple = df.iloc[(1, 2)]
+        assert result_with_tuple == df.iloc[1, 2]
+    
+        # Test .iloc with a namedtuple
+        indexer = Indexer(row=1, col=2)
+        result_with_namedtuple = df.iloc[indexer]
+        assert result_with_namedtuple == df.iloc[1, 2]
+    
+        # ensure both methods yield the same result testing the initial issue
+        assert result_with_tuple == result_with_namedtuple


### PR DESCRIPTION
- [ ] closes #48188 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
