### PR TITLE
BUG: Updated _pprint_seq to use enumerate instead of next

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -137,8 +137,8 @@ Performance improvements
 Bug fixes
 ~~~~~~~~~
 - Fixed bug in :meth:`DataFrame.join` inconsistently setting result index name (:issue:`55815`)
+- Fixed bug in :meth:`DataFrame.to_string` that raised ``StopIteration`` with nested DataFrames. (:issue:`16098`)
 - Fixed bug in :meth:`Series.diff` allowing non-integer values for the ``periods`` argument. (:issue:`56607`)
-- Fixed bug in :meth:`DataFrame.to_string` that raised ``StopIteration`` with nested DataFrames.
 
 Categorical
 ^^^^^^^^^^^

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -138,6 +138,7 @@ Bug fixes
 ~~~~~~~~~
 - Fixed bug in :meth:`DataFrame.join` inconsistently setting result index name (:issue:`55815`)
 - Fixed bug in :meth:`Series.diff` allowing non-integer values for the ``periods`` argument. (:issue:`56607`)
+- Fixed bug in :meth:`DataFrame.to_string` that raised ``StopIteration`` with nested DataFrames.
 
 Categorical
 ^^^^^^^^^^^

--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -111,22 +111,22 @@ def _pprint_seq(
         fmt = "[{body}]" if hasattr(seq, "__setitem__") else "({body})"
 
     if max_seq_items is False:
-        nitems = len(seq)
+        max_items = None
     else:
-        nitems = max_seq_items or get_option("max_seq_items") or len(seq)
+        max_items = max_seq_items or get_option("max_seq_items") or len(seq)
 
     s = iter(seq)
     # handle sets, no slicing
     r = []
-    max_item_limit = False
+    max_items_reached = False
     for i, item in enumerate(s):
-        if i >= nitems:
-            max_item_limit = True
+        if (max_items is not None) and (i >= max_items):
+            max_items_reached = True
             break
         r.append(pprint_thing(item, _nest_lvl + 1, max_seq_items=max_seq_items, **kwds))
     body = ", ".join(r)
 
-    if max_item_limit:
+    if max_items_reached:
         body += ", ..."
     elif isinstance(seq, tuple) and len(seq) == 1:
         body += ","

--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -117,13 +117,16 @@ def _pprint_seq(
 
     s = iter(seq)
     # handle sets, no slicing
-    r = [
-        pprint_thing(next(s), _nest_lvl + 1, max_seq_items=max_seq_items, **kwds)
-        for i in range(min(nitems, len(seq)))
-    ]
+    r = []
+    max_item_limit = False
+    for i, item in enumerate(s):
+        if i >= nitems:
+            max_item_limit = True
+            break
+        r.append(pprint_thing(item, _nest_lvl + 1, max_seq_items=max_seq_items, **kwds))
     body = ", ".join(r)
 
-    if nitems < len(seq):
+    if max_item_limit:
         body += ", ..."
     elif isinstance(seq, tuple) and len(seq) == 1:
         body += ","

--- a/pandas/tests/io/formats/test_to_string.py
+++ b/pandas/tests/io/formats/test_to_string.py
@@ -948,7 +948,9 @@ class TestDataFrameToString:
     def test_nested_dataframe(self):
         df1 = DataFrame({"level1": [["row1"], ["row2"]]})
         df2 = DataFrame({"level3": [{"level2": df1}]})
-        df2.to_string()
+        result = df2.to_string()
+        expected = "                   level3\n0  {'level2': ['level1']}"
+        assert result == expected
 
 
 class TestSeriesToString:

--- a/pandas/tests/io/formats/test_to_string.py
+++ b/pandas/tests/io/formats/test_to_string.py
@@ -945,6 +945,11 @@ class TestDataFrameToString:
         finally:
             sys.stdin = _stdin
 
+    def test_nested_dataframe(self):
+        df1 = DataFrame({"level1": [["row1"], ["row2"]]})
+        df2 = DataFrame({"level3": [{"level2": df1}]})
+        df2.to_string()
+
 
 class TestSeriesToString:
     def test_to_string_without_index(self):


### PR DESCRIPTION
This PR closes an edge-case [bug](https://github.com/pandas-dev/pandas/issues/16098) that has been around for almost 7 years.

To print a DataFrame, the function `_pprint_seq()` constructs a string representation of an iterable object (called `seq`) by creating an iterator over it, and truncating it if `len(seq) > max_seq_items`.

However, a pandas `DataFrame` is an example of an object where `len(seq)` is _not_ a valid way of checking the length of the iterator. Specifically, `len(df)` returns the number of rows, while `iter(df)` iterates over the columns. When trying to print a DataFrame with more rows than columns, this raises a `StopIterator` exception.

This PR fixes this bug by explicitly iterating over the object, rather than assuming that `len(seq)` is equal to the number of items in the object. The new test `test_nested_dataframe()` raises an exception on `main`, but passes on this branch.

- [x] closes #16098
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests).
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) (no new arguments/methods/functions).
- [x] Added an entry in `doc/source/whatsnew/v3.0.0.rst`.
