### PR TITLE
CLN: remove from PeriodIndex.asfreq unnecessary raising ValueError for invalid period freq

### DIFF
--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -2773,11 +2773,6 @@ def asfreq(
         if isinstance(freq, BaseOffset):
             if hasattr(freq, "_period_dtype_code"):
                 freq = freq_to_period_freqstr(freq.n, freq.name)
-            else:
-                raise ValueError(
-                    f"Invalid offset: '{freq.base}' for converting time series "
-                    f"with PeriodIndex."
-                )
 
         new_obj = obj.copy()
         new_obj.index = obj.index.asfreq(freq, how=how)

--- a/pandas/tests/indexes/period/methods/test_asfreq.py
+++ b/pandas/tests/indexes/period/methods/test_asfreq.py
@@ -142,16 +142,21 @@ class TestPeriodIndex:
         tm.assert_series_equal(result, excepted)
 
     @pytest.mark.parametrize(
-        "freq",
+        "freq, is_str",
         [
-            "2BMS",
-            "2YS-MAR",
-            "2bh",
+            ("2BMS", True),
+            ("2YS-MAR", True),
+            ("2bh", True),
+            (offsets.MonthBegin(2), False),
+            (offsets.BusinessMonthEnd(2), False),
         ],
     )
-    def test_pi_asfreq_not_supported_frequency(self, freq):
-        # GH#55785
-        msg = f"{freq[1:]} is not supported as period frequency"
+    def test_pi_asfreq_not_supported_frequency(self, freq, is_str):
+        # GH#55785, GH#56945
+        if is_str:
+            msg = f"{freq[1:]} is not supported as period frequency"
+        else:
+            msg = re.escape(f"{freq} is not supported as period frequency")
 
         pi = PeriodIndex(["2020-01-01", "2021-01-01"], freq="M")
         with pytest.raises(ValueError, match=msg):
@@ -168,21 +173,6 @@ class TestPeriodIndex:
     def test_pi_asfreq_invalid_frequency(self, freq):
         # GH#55785
         msg = f"Invalid frequency: {freq}"
-
-        pi = PeriodIndex(["2020-01-01", "2021-01-01"], freq="M")
-        with pytest.raises(ValueError, match=msg):
-            pi.asfreq(freq=freq)
-
-    @pytest.mark.parametrize(
-        "freq",
-        [
-            offsets.MonthBegin(2),
-            offsets.BusinessMonthEnd(2),
-        ],
-    )
-    def test_pi_asfreq_invalid_baseoffset(self, freq):
-        # GH#56945
-        msg = re.escape(f"{freq} is not supported as period frequency")
 
         pi = PeriodIndex(["2020-01-01", "2021-01-01"], freq="M")
         with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/resample/test_period_index.py
+++ b/pandas/tests/resample/test_period_index.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import re
 import warnings
 
 import dateutil
@@ -1034,7 +1035,7 @@ class TestPeriodIndex:
     )
     def test_asfreq_invalid_period_offset(self, offset, frame_or_series):
         # GH#55785
-        msg = f"Invalid offset: '{offset.base}' for converting time series "
+        msg = re.escape(f"{offset} is not supported as period frequency")
 
         obj = frame_or_series(range(5), index=period_range("2020-01-01", periods=5))
         with pytest.raises(ValueError, match=msg):


### PR DESCRIPTION
xref #56945

removed from `PeriodIndex.asfreq` unnecessary raising ValueError for invalid period freq. Now we raise this ValueError for invalid period freq in `to_offset`.