### PR TITLE
DOC: fix reference to api.typing.NaTType (from api.types.NaTType)

### DIFF
--- a/doc/source/user_guide/missing_data.rst
+++ b/doc/source/user_guide/missing_data.rst
@@ -21,7 +21,7 @@ is that the original data type will be coerced to ``np.float64`` or ``object``.
    pd.Series([True, False], dtype=np.bool_).reindex([0, 1, 2])
 
 :class:`NaT` for NumPy ``np.datetime64``, ``np.timedelta64``, and :class:`PeriodDtype`. For typing applications,
-use :class:`api.types.NaTType`.
+use :class:`api.typing.NaTType`.
 
 .. ipython:: python
 


### PR DESCRIPTION
Effectively, the `NaTType` definition lives under `api.typing` and not `api.types`
