### PR TITLE
REGR: Fix astype conversion of ea int to td/dt with missing values

### DIFF
--- a/pandas/core/arrays/_utils.py
+++ b/pandas/core/arrays/_utils.py
@@ -46,11 +46,11 @@ def to_numpy_dtype_inference(
     if na_value is lib.no_default:
         if dtype is None or not hasna:
             na_value = arr.dtype.na_value
-        elif dtype.kind == "f":
+        elif dtype.kind == "f":  # type: ignore[union-attr]
             na_value = np.nan
-        elif dtype.kind == "M":
+        elif dtype.kind == "M":  # type: ignore[union-attr]
             na_value = np.datetime64("nat")
-        elif dtype.kind == "m":
+        elif dtype.kind == "m":  # type: ignore[union-attr]
             na_value = np.timedelta64("nat")
         else:
             na_value = arr.dtype.na_value

--- a/pandas/core/arrays/_utils.py
+++ b/pandas/core/arrays/_utils.py
@@ -39,14 +39,21 @@ def to_numpy_dtype_inference(
             dtype = arr.dtype.numpy_dtype  # type: ignore[union-attr]
     elif dtype is not None:
         dtype = np.dtype(dtype)
-        if na_value is lib.no_default and hasna and dtype.kind == "f":
-            na_value = np.nan
         dtype_given = True
     else:
         dtype_given = True
 
     if na_value is lib.no_default:
-        na_value = arr.dtype.na_value
+        if dtype is None or not hasna:
+            na_value = arr.dtype.na_value
+        elif dtype.kind == "f":
+            na_value = np.nan
+        elif dtype.kind == "M":
+            na_value = np.datetime64("nat")
+        elif dtype.kind == "m":
+            na_value = np.timedelta64("nat")
+        else:
+            na_value = arr.dtype.na_value
 
     if not dtype_given and hasna:
         try:

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3395,6 +3395,15 @@ def test_arrow_floordiv_floating_0_divisor(dtype):
     tm.assert_series_equal(result, expected)
 
 
+@pytest.mark.parametrize("dtype", ["float64", "datetime64[ns]", "timedelta64[ns]"])
+def test_astype_int_with_null_to_numpy_dtype(dtype):
+    # GH 57093
+    ser = pd.Series([1, None], dtype="int64[pyarrow]")
+    result = ser.astype(dtype)
+    expected = pd.Series([1, None], dtype=dtype)
+    tm.assert_series_equal(result, expected)
+
+
 @pytest.mark.parametrize("pa_type", tm.ALL_INT_PYARROW_DTYPES)
 def test_arrow_integral_floordiv_large_values(pa_type):
     # GH 56676

--- a/pandas/tests/series/methods/test_to_numpy.py
+++ b/pandas/tests/series/methods/test_to_numpy.py
@@ -6,6 +6,7 @@ import pandas.util._test_decorators as td
 from pandas import (
     NA,
     Series,
+    Timedelta,
 )
 import pandas._testing as tm
 
@@ -34,3 +35,15 @@ def test_to_numpy_arrow_dtype_given():
     result = ser.to_numpy(dtype="float64")
     expected = np.array([1.0, np.nan])
     tm.assert_numpy_array_equal(result, expected)
+
+
+def test_astype_ea_int_to_td_ts():
+    # GH#57093
+    ser = Series([1, None], dtype="Int64")
+    result = ser.astype("m8[ns]")
+    expected = Series([1, Timedelta("nat")], dtype="m8[ns]")
+    tm.assert_series_equal(result, expected)
+
+    result = ser.astype("M8[ns]")
+    expected = Series([1, Timedelta("nat")], dtype="M8[ns]")
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

cc @lukemanley 

it should be covered by the other whatsnew