### PR TITLE
Remove support for errors="ignore" in to_datetime, to_timedelta and to_numeric

### DIFF
--- a/asv_bench/benchmarks/inference.py
+++ b/asv_bench/benchmarks/inference.py
@@ -184,7 +184,7 @@ class ToDatetimeISO8601:
 
     def time_iso8601_infer_zero_tz_fromat(self):
         # GH 41047
-        to_datetime(self.strings_zero_tz, infer_datetime_format=True)
+        to_datetime(self.strings_zero_tz)
 
 
 class ToDatetimeNONISO8601:
@@ -266,16 +266,6 @@ class ToDatetimeCache:
 
     def time_dup_string_tzoffset_dates(self, cache):
         to_datetime(self.dup_string_with_tz, cache=cache)
-
-
-# GH 43901
-class ToDatetimeInferDatetimeFormat:
-    def setup(self):
-        rng = date_range(start="1/1/2000", periods=100000, freq="h")
-        self.strings = rng.strftime("%Y-%m-%d %H:%M:%S").tolist()
-
-    def time_infer_datetime_format(self):
-        to_datetime(self.strings, infer_datetime_format=True)
 
 
 class ToTimedelta:

--- a/asv_bench/benchmarks/inference.py
+++ b/asv_bench/benchmarks/inference.py
@@ -22,17 +22,14 @@ from .pandas_vb_common import lib
 
 
 class ToNumeric:
-    params = ["ignore", "coerce"]
-    param_names = ["errors"]
-
-    def setup(self, errors):
+    def setup(self):
         N = 10000
         self.float = Series(np.random.randn(N))
         self.numstr = self.float.astype("str")
         self.str = Series(Index([f"i-{i}" for i in range(N)], dtype=object))
 
-    def time_from_float(self, errors):
-        to_numeric(self.float, errors=errors)
+    def time_from_float(self):
+        to_numeric(self.float, errors="coerce")
 
     def time_from_numeric_str(self, errors):
         to_numeric(self.numstr, errors=errors)
@@ -301,16 +298,13 @@ class ToTimedelta:
 
 
 class ToTimedeltaErrors:
-    params = ["coerce", "ignore"]
-    param_names = ["errors"]
-
-    def setup(self, errors):
+    def setup(self):
         ints = np.random.randint(0, 60, size=10000)
         self.arr = [f"{i} days" for i in ints]
         self.arr[-1] = "apple"
 
-    def time_convert(self, errors):
-        to_timedelta(self.arr, errors=errors)
+    def time_convert(self):
+        to_timedelta(self.arr, errors="coerce")
 
 
 from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/inference.py
+++ b/asv_bench/benchmarks/inference.py
@@ -31,11 +31,11 @@ class ToNumeric:
     def time_from_float(self):
         to_numeric(self.float, errors="coerce")
 
-    def time_from_numeric_str(self, errors):
-        to_numeric(self.numstr, errors=errors)
+    def time_from_numeric_str(self):
+        to_numeric(self.numstr, errors="coerce")
 
-    def time_from_str(self, errors):
-        to_numeric(self.str, errors=errors)
+    def time_from_str(self):
+        to_numeric(self.str, errors="coerce")
 
 
 class ToNumericDowncast:

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -123,6 +123,7 @@ Removal of prior version deprecations/changes
 - Removed ``read_gbq`` and ``DataFrame.to_gbq``. Use ``pandas_gbq.read_gbq`` and ``pandas_gbq.to_gbq`` instead https://pandas-gbq.readthedocs.io/en/latest/api.html (:issue:`55525`)
 - Removed deprecated argument ``obj`` in :meth:`.DataFrameGroupBy.get_group` and :meth:`.SeriesGroupBy.get_group` (:issue:`53545`)
 - Removed deprecated behavior of :meth:`Series.agg` using :meth:`Series.apply` (:issue:`53325`)
+- Removed support for ``errors="ignore"`` in :func:`to_datetime`, :func:`to_timedelta` and :func:`to_numeric` (:issue:`55734`)
 - Removed the ``ArrayManager`` (:issue:`55043`)
 - Removed the ``fastpath`` argument from the :class:`Series` constructor (:issue:`55466`)
 - Removed the ``is_boolean``, ``is_integer``, ``is_floating``, ``holds_integer``, ``is_numeric``, ``is_categorical``, ``is_object``, and ``is_interval`` attributes of :class:`Index` (:issue:`50042`)

--- a/pandas/_libs/src/vendored/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/vendored/ujson/python/objToJSON.c
@@ -95,11 +95,11 @@ typedef struct __TypeContext {
   JSPFN_ITERGETNAME iterGetName;
   JSPFN_ITERGETVALUE iterGetValue;
   PFN_PyTypeToUTF8 PyTypeToUTF8;
-  PyArrayObject *newObj;
+  PyObject *newObj;
   PyObject *dictObj;
   Py_ssize_t index;
   Py_ssize_t size;
-  PyArrayObject *itemValue;
+  PyObject *itemValue;
   PyObject *itemName;
   PyObject *attrList;
   PyObject *iterator;
@@ -174,8 +174,8 @@ static TypeContext *createTypeContext(void) {
   return pc;
 }
 
-static PyArrayObject *get_values(PyObject *obj) {
-  PyArrayObject *values = NULL;
+static PyObject *get_values(PyObject *obj) {
+  PyObject *values = NULL;
 
   if (object_is_index_type(obj) || object_is_series_type(obj)) {
     // The special cases to worry about are dt64tz and category[dt64tz].
@@ -404,7 +404,7 @@ static void NpyArr_iterBegin(JSOBJ _obj, JSONTypeContext *tc) {
     return;
   }
 
-  npyarr->array = (PyArrayObject *)obj;
+  npyarr->array = (PyObject *)obj;
   npyarr->getitem = (PyArray_GetItemFunc *)PyArray_DESCR(obj)->f->getitem;
   npyarr->dataptr = PyArray_DATA(obj);
   npyarr->ndim = PyArray_NDIM(obj) - 1;
@@ -1605,7 +1605,7 @@ ISITERABLE:
       if (!tmpObj) {
         goto INVALID;
       }
-      PyArrayObject *values = get_values(tmpObj);
+      PyObject *values = get_values(tmpObj);
       Py_DECREF(tmpObj);
       if (!values) {
         goto INVALID;
@@ -1687,7 +1687,7 @@ ISITERABLE:
       if (!tmpObj) {
         goto INVALID;
       }
-      PyArrayObject *values = get_values(tmpObj);
+      PyObject *values = get_values(tmpObj);
       if (!values) {
         Py_DECREF(tmpObj);
         goto INVALID;
@@ -1707,7 +1707,7 @@ ISITERABLE:
       if (!tmpObj) {
         goto INVALID;
       }
-      PyArrayObject *values = get_values(tmpObj);
+      PyObject *values = get_values(tmpObj);
       if (!values) {
         Py_DECREF(tmpObj);
         goto INVALID;

--- a/pandas/_libs/src/vendored/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/vendored/ujson/python/objToJSON.c
@@ -95,11 +95,11 @@ typedef struct __TypeContext {
   JSPFN_ITERGETNAME iterGetName;
   JSPFN_ITERGETVALUE iterGetValue;
   PFN_PyTypeToUTF8 PyTypeToUTF8;
-  PyObject *newObj;
+  PyArrayObject *newObj;
   PyObject *dictObj;
   Py_ssize_t index;
   Py_ssize_t size;
-  PyObject *itemValue;
+  PyArrayObject *itemValue;
   PyObject *itemName;
   PyObject *attrList;
   PyObject *iterator;
@@ -174,8 +174,8 @@ static TypeContext *createTypeContext(void) {
   return pc;
 }
 
-static PyObject *get_values(PyObject *obj) {
-  PyObject *values = NULL;
+static PyArrayObject *get_values(PyObject *obj) {
+  PyArrayObject *values = NULL;
 
   if (object_is_index_type(obj) || object_is_series_type(obj)) {
     // The special cases to worry about are dt64tz and category[dt64tz].
@@ -404,7 +404,7 @@ static void NpyArr_iterBegin(JSOBJ _obj, JSONTypeContext *tc) {
     return;
   }
 
-  npyarr->array = (PyObject *)obj;
+  npyarr->array = (PyArrayObject *)obj;
   npyarr->getitem = (PyArray_GetItemFunc *)PyArray_DESCR(obj)->f->getitem;
   npyarr->dataptr = PyArray_DATA(obj);
   npyarr->ndim = PyArray_NDIM(obj) - 1;
@@ -1605,7 +1605,7 @@ ISITERABLE:
       if (!tmpObj) {
         goto INVALID;
       }
-      PyObject *values = get_values(tmpObj);
+      PyArrayObject *values = get_values(tmpObj);
       Py_DECREF(tmpObj);
       if (!values) {
         goto INVALID;
@@ -1687,7 +1687,7 @@ ISITERABLE:
       if (!tmpObj) {
         goto INVALID;
       }
-      PyObject *values = get_values(tmpObj);
+      PyArrayObject *values = get_values(tmpObj);
       if (!values) {
         Py_DECREF(tmpObj);
         goto INVALID;
@@ -1707,7 +1707,7 @@ ISITERABLE:
       if (!tmpObj) {
         goto INVALID;
       }
-      PyObject *values = get_values(tmpObj);
+      PyArrayObject *values = get_values(tmpObj);
       if (!values) {
         Py_DECREF(tmpObj);
         goto INVALID;

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -272,14 +272,13 @@ def array_with_unit_to_datetime(
     """
     cdef:
         Py_ssize_t i, n=len(values)
-        bint is_ignore = errors == "ignore"
         bint is_coerce = errors == "coerce"
         bint is_raise = errors == "raise"
         ndarray[int64_t] iresult
         tzinfo tz = None
         float fval
 
-    assert is_ignore or is_coerce or is_raise
+    assert is_coerce or is_raise
 
     if unit == "ns":
         result, tz = array_to_datetime(
@@ -342,11 +341,6 @@ def array_with_unit_to_datetime(
             if is_raise:
                 err.args = (f"{err}, at position {i}",)
                 raise
-            elif is_ignore:
-                # we have hit an exception
-                # and are in ignore mode
-                # redo as object
-                return _array_with_unit_to_datetime_object_fallback(values, unit)
             else:
                 # is_coerce
                 iresult[i] = NPY_NAT
@@ -461,7 +455,6 @@ cpdef array_to_datetime(
         bint utc_convert = bool(utc)
         bint seen_datetime_offset = False
         bint is_raise = errors == "raise"
-        bint is_ignore = errors == "ignore"
         bint is_coerce = errors == "coerce"
         bint is_same_offsets
         _TSObject tsobj
@@ -475,7 +468,7 @@ cpdef array_to_datetime(
         str abbrev
 
     # specify error conditions
-    assert is_raise or is_ignore or is_coerce
+    assert is_raise or is_coerce
 
     if infer_reso:
         abbrev = "ns"
@@ -687,7 +680,6 @@ cdef _array_to_datetime_object(
     cdef:
         Py_ssize_t i, n = values.size
         object val
-        bint is_ignore = errors == "ignore"
         bint is_coerce = errors == "coerce"
         bint is_raise = errors == "raise"
         ndarray oresult_nd
@@ -696,7 +688,7 @@ cdef _array_to_datetime_object(
         cnp.broadcast mi
         _TSObject tsobj
 
-    assert is_raise or is_ignore or is_coerce
+    assert is_raise or is_coerce
 
     oresult_nd = cnp.PyArray_EMPTY(values.ndim, values.shape, cnp.NPY_OBJECT, 0)
     mi = cnp.PyArray_MultiIterNew2(oresult_nd, values)

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -310,7 +310,7 @@ def array_strptime(
     values : ndarray of string-like objects
     fmt : string-like regex
     exact : matches must be exact if True, search if False
-    errors : string specifying error handling, {'raise', 'ignore', 'coerce'}
+    errors : string specifying error handling, {'raise', 'coerce'}
     creso : NPY_DATETIMEUNIT, default NPY_FR_ns
         Set to NPY_FR_GENERIC to infer a resolution.
     """
@@ -322,7 +322,6 @@ def array_strptime(
         object val
         bint seen_datetime_offset = False
         bint is_raise = errors=="raise"
-        bint is_ignore = errors=="ignore"
         bint is_coerce = errors=="coerce"
         bint is_same_offsets
         set out_tzoffset_vals = set()
@@ -334,7 +333,7 @@ def array_strptime(
         bint infer_reso = creso == NPY_DATETIMEUNIT.NPY_FR_GENERIC
         DatetimeParseState state = DatetimeParseState(creso)
 
-    assert is_raise or is_ignore or is_coerce
+    assert is_raise or is_coerce
 
     _validate_fmt(fmt)
     format_regex, locale_time = _get_format_regex(fmt)
@@ -806,14 +805,13 @@ def _array_strptime_object_fallback(
         object val
         tzinfo tz
         bint is_raise = errors=="raise"
-        bint is_ignore = errors=="ignore"
         bint is_coerce = errors=="coerce"
         bint iso_format = format_is_iso(fmt)
         NPY_DATETIMEUNIT creso, out_bestunit, item_reso
         int out_local = 0, out_tzoffset = 0
         bint string_to_dts_succeeded = 0
 
-    assert is_raise or is_ignore or is_coerce
+    assert is_raise or is_coerce
 
     item_reso = NPY_DATETIMEUNIT.NPY_FR_GENERIC
     format_regex, locale_time = _get_format_regex(fmt)
@@ -922,9 +920,8 @@ def _array_strptime_object_fallback(
             if is_coerce:
                 result[i] = NaT
                 continue
-            elif is_raise:
+            else:
                 raise
-            return values
 
     import warnings
 

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -434,7 +434,7 @@ IntervalClosedType = Union[IntervalLeftRight, Literal["both", "neither"]]
 
 # datetime and NaTType
 DatetimeNaTType = Union[datetime, "NaTType"]
-DateTimeErrorChoices = Union[Literal["raise", "coerce"]]
+DateTimeErrorChoices = Literal["raise", "coerce"]
 
 # sort_index
 SortKind = Literal["quicksort", "mergesort", "heapsort", "stable"]

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -434,7 +434,7 @@ IntervalClosedType = Union[IntervalLeftRight, Literal["both", "neither"]]
 
 # datetime and NaTType
 DatetimeNaTType = Union[datetime, "NaTType"]
-DateTimeErrorChoices = Union[IgnoreRaise, Literal["coerce"]]
+DateTimeErrorChoices = Union[Literal["raise", "coerce"]]
 
 # sort_index
 SortKind = Literal["quicksort", "mergesort", "heapsort", "stable"]

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2394,7 +2394,7 @@ def objects_to_datetime64(
     yearfirst : bool
     utc : bool, default False
         Whether to convert/localize timestamps to UTC.
-    errors : {'raise', 'ignore', 'coerce'}
+    errors : {'raise', 'coerce'}
     allow_object : bool
         Whether to return an object-dtype ndarray instead of raising if the
         data contains more than one timezone.
@@ -2414,7 +2414,7 @@ def objects_to_datetime64(
     ValueError : if data cannot be converted to datetimes
     TypeError  : When a type cannot be converted to datetime
     """
-    assert errors in ["raise", "ignore", "coerce"]
+    assert errors in ["raise", "coerce"]
 
     # if str-dtype, convert
     data = np.array(data, copy=False, dtype=np.object_)

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -4,12 +4,10 @@ from typing import (
     TYPE_CHECKING,
     Literal,
 )
-import warnings
 
 import numpy as np
 
 from pandas._libs import lib
-from pandas.util._exceptions import find_stack_level
 from pandas.util._validators import check_dtype_backend
 
 from pandas.core.dtypes.cast import maybe_downcast_numeric
@@ -66,14 +64,9 @@ def to_numeric(
     ----------
     arg : scalar, list, tuple, 1-d array, or Series
         Argument to be converted.
-    errors : {'ignore', 'raise', 'coerce'}, default 'raise'
+    errors : {'raise', 'coerce'}, default 'raise'
         - If 'raise', then invalid parsing will raise an exception.
         - If 'coerce', then invalid parsing will be set as NaN.
-        - If 'ignore', then invalid parsing will return the input.
-
-        .. versionchanged:: 2.2
-
-        "ignore" is deprecated. Catch exceptions explicitly instead.
 
     downcast : str, default None
         Can be 'integer', 'signed', 'unsigned', or 'float'.
@@ -166,17 +159,8 @@ def to_numeric(
     if downcast not in (None, "integer", "signed", "unsigned", "float"):
         raise ValueError("invalid downcasting method provided")
 
-    if errors not in ("ignore", "raise", "coerce"):
+    if errors not in ("raise", "coerce"):
         raise ValueError("invalid error value specified")
-    if errors == "ignore":
-        # GH#54467
-        warnings.warn(
-            "errors='ignore' is deprecated and will raise in a future version. "
-            "Use to_numeric without passing `errors` and catch exceptions "
-            "explicitly instead",
-            FutureWarning,
-            stacklevel=find_stack_level(),
-        )
 
     check_dtype_backend(dtype_backend)
 
@@ -207,8 +191,6 @@ def to_numeric(
     else:
         values = arg
 
-    orig_values = values
-
     # GH33013: for IntegerArray & FloatingArray extract non-null values for casting
     # save mask to reconstruct the full array after casting
     mask: npt.NDArray[np.bool_] | None = None
@@ -227,20 +209,15 @@ def to_numeric(
         values = values.view(np.int64)
     else:
         values = ensure_object(values)
-        coerce_numeric = errors not in ("ignore", "raise")
-        try:
-            values, new_mask = lib.maybe_convert_numeric(  # type: ignore[call-overload]
-                values,
-                set(),
-                coerce_numeric=coerce_numeric,
-                convert_to_masked_nullable=dtype_backend is not lib.no_default
-                or isinstance(values_dtype, StringDtype)
-                and not values_dtype.storage == "pyarrow_numpy",
-            )
-        except (ValueError, TypeError):
-            if errors == "raise":
-                raise
-            values = orig_values
+        coerce_numeric = errors != "raise"
+        values, new_mask = lib.maybe_convert_numeric(  # type: ignore[call-overload]
+            values,
+            set(),
+            coerce_numeric=coerce_numeric,
+            convert_to_masked_nullable=dtype_backend is not lib.no_default
+            or isinstance(values_dtype, StringDtype)
+            and not values_dtype.storage == "pyarrow_numpy",
+        )
 
     if new_mask is not None:
         # Remove unnecessary values, is expected later anyway and enables

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 
 from typing import (
     TYPE_CHECKING,
-    Any,
     overload,
 )
-import warnings
 
 import numpy as np
 
@@ -22,7 +20,6 @@ from pandas._libs.tslibs.timedeltas import (
     disallow_ambiguous_unit,
     parse_timedelta_unit,
 )
-from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.common import is_list_like
 from pandas.core.dtypes.dtypes import ArrowDtype
@@ -90,8 +87,7 @@ def to_timedelta(
     | Series,
     unit: UnitChoices | None = None,
     errors: DateTimeErrorChoices = "raise",
-    # returning Any for errors="ignore"
-) -> Timedelta | TimedeltaIndex | Series | NaTType | Any:
+) -> Timedelta | TimedeltaIndex | Series | NaTType:
     """
     Convert argument to timedelta.
 
@@ -130,10 +126,9 @@ def to_timedelta(
             in a future version. Please use 'h', 'min', 's', 'ms', 'us', and 'ns'
             instead of 'H', 'T', 'S', 'L', 'U' and 'N'.
 
-    errors : {'ignore', 'raise', 'coerce'}, default 'raise'
+    errors : {'raise', 'coerce'}, default 'raise'
         - If 'raise', then invalid parsing will raise an exception.
         - If 'coerce', then invalid parsing will be set as NaT.
-        - If 'ignore', then invalid parsing will return the input.
 
     Returns
     -------
@@ -185,17 +180,8 @@ def to_timedelta(
         unit = parse_timedelta_unit(unit)
         disallow_ambiguous_unit(unit)
 
-    if errors not in ("ignore", "raise", "coerce"):
-        raise ValueError("errors must be one of 'ignore', 'raise', or 'coerce'.")
-    if errors == "ignore":
-        # GH#54467
-        warnings.warn(
-            "errors='ignore' is deprecated and will raise in a future version. "
-            "Use to_timedelta without passing `errors` and catch exceptions "
-            "explicitly instead",
-            FutureWarning,
-            stacklevel=find_stack_level(),
-        )
+    if errors not in ("raise", "coerce"):
+        raise ValueError("errors must be one of 'raise', or 'coerce'.")
 
     if arg is None:
         return arg
@@ -236,9 +222,6 @@ def _coerce_scalar_to_timedelta_type(
     except ValueError:
         if errors == "raise":
             raise
-        if errors == "ignore":
-            return r
-
         # coerce
         result = NaT
 
@@ -254,12 +237,6 @@ def _convert_listlike(
     """Convert a list of objects to a timedelta index object."""
     arg_dtype = getattr(arg, "dtype", None)
     if isinstance(arg, (list, tuple)) or arg_dtype is None:
-        # This is needed only to ensure that in the case where we end up
-        #  returning arg (errors == "ignore"), and where the input is a
-        #  generator, we return a useful list-like instead of a
-        #  used-up generator
-        if not hasattr(arg, "__array__"):
-            arg = list(arg)
         arg = np.array(arg, dtype=object)
     elif isinstance(arg_dtype, ArrowDtype) and arg_dtype.kind == "m":
         return arg
@@ -267,17 +244,13 @@ def _convert_listlike(
     try:
         td64arr = sequence_to_td64ns(arg, unit=unit, errors=errors, copy=False)[0]
     except ValueError:
-        if errors == "ignore":
-            return arg
-        else:
-            # This else-block accounts for the cases when errors='raise'
-            # and errors='coerce'. If errors == 'raise', these errors
-            # should be raised. If errors == 'coerce', we shouldn't
-            # expect any errors to be raised, since all parsing errors
-            # cause coercion to pd.NaT. However, if an error / bug is
-            # introduced that causes an Exception to be raised, we would
-            # like to surface it.
-            raise
+        # If errors == 'raise', these errors
+        # should be raised. If errors == 'coerce', we shouldn't
+        # expect any errors to be raised, since all parsing errors
+        # cause coercion to pd.NaT. However, if an error / bug is
+        # introduced that causes an Exception to be raised, we would
+        # like to surface it.
+        raise
 
     from pandas import TimedeltaIndex
 

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -241,16 +241,7 @@ def _convert_listlike(
     elif isinstance(arg_dtype, ArrowDtype) and arg_dtype.kind == "m":
         return arg
 
-    try:
-        td64arr = sequence_to_td64ns(arg, unit=unit, errors=errors, copy=False)[0]
-    except ValueError:
-        # If errors == 'raise', these errors
-        # should be raised. If errors == 'coerce', we shouldn't
-        # expect any errors to be raised, since all parsing errors
-        # cause coercion to pd.NaT. However, if an error / bug is
-        # introduced that causes an Exception to be raised, we would
-        # like to surface it.
-        raise
+    td64arr = sequence_to_td64ns(arg, unit=unit, errors=errors, copy=False)[0]
 
     from pandas import TimedeltaIndex
 

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from typing import (
     TYPE_CHECKING,
+    Any,
     overload,
 )
 
@@ -87,7 +88,7 @@ def to_timedelta(
     | Series,
     unit: UnitChoices | None = None,
     errors: DateTimeErrorChoices = "raise",
-) -> Timedelta | TimedeltaIndex | Series | NaTType:
+) -> Timedelta | TimedeltaIndex | Series | NaTType | Any:
     """
     Convert argument to timedelta.
 

--- a/pandas/core/tools/times.py
+++ b/pandas/core/tools/times.py
@@ -5,12 +5,10 @@ from datetime import (
     time,
 )
 from typing import TYPE_CHECKING
-import warnings
 
 import numpy as np
 
 from pandas._libs.lib import is_list_like
-from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.generic import (
     ABCIndex,
@@ -45,24 +43,16 @@ def to_time(
     infer_time_format: bool, default False
         Infer the time format based on the first non-NaN element.  If all
         strings are in the same format, this will speed up conversion.
-    errors : {'ignore', 'raise', 'coerce'}, default 'raise'
+    errors : {'raise', 'coerce'}, default 'raise'
         - If 'raise', then invalid parsing will raise an exception
         - If 'coerce', then invalid parsing will be set as None
-        - If 'ignore', then invalid parsing will return the input
 
     Returns
     -------
     datetime.time
     """
-    if errors == "ignore":
-        # GH#54467
-        warnings.warn(
-            "errors='ignore' is deprecated and will raise in a future version. "
-            "Use to_time without passing `errors` and catch exceptions "
-            "explicitly instead",
-            FutureWarning,
-            stacklevel=find_stack_level(),
-        )
+    if errors not in ("raise", "coerce"):
+        raise ValueError("errors must be one of 'raise', or 'coerce'.")
 
     def _convert_listlike(arg, format):
         if isinstance(arg, (list, tuple)):
@@ -90,10 +80,7 @@ def to_time(
                             f"format {format}"
                         )
                         raise ValueError(msg) from err
-                    if errors == "ignore":
-                        return arg
-                    else:
-                        times.append(None)
+                    times.append(None)
         else:
             formats = _time_formats[:]
             format_found = False
@@ -118,8 +105,6 @@ def to_time(
                     times.append(time_object)
                 elif errors == "raise":
                     raise ValueError(f"Cannot convert arg {arg} to a time")
-                elif errors == "ignore":
-                    return arg
                 else:
                     times.append(None)
 

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -79,7 +79,6 @@ if TYPE_CHECKING:
     )
 
     from pandas._typing import (
-        DateTimeErrorChoices,
         DtypeArg,
         DtypeBackend,
         IndexLabel,
@@ -111,8 +110,7 @@ def _handle_date_column(
         # read_sql like functions.
         # Format can take on custom to_datetime argument values such as
         # {"errors": "coerce"} or {"dayfirst": True}
-        error: DateTimeErrorChoices = format.pop("errors", None) or "raise"
-        return to_datetime(col, errors=error, **format)
+        return to_datetime(col, **format)
     else:
         # Allow passing of formatting string for integers
         # GH17855

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -111,13 +111,7 @@ def _handle_date_column(
         # read_sql like functions.
         # Format can take on custom to_datetime argument values such as
         # {"errors": "coerce"} or {"dayfirst": True}
-        error: DateTimeErrorChoices = format.pop("errors", None) or "ignore"
-        if error == "ignore":
-            try:
-                return to_datetime(col, **format)
-            except (TypeError, ValueError):
-                # TODO: not reached 2023-10-27; needed?
-                return col
+        error: DateTimeErrorChoices = format.pop("errors", None) or "raise"
         return to_datetime(col, errors=error, **format)
     else:
         # Allow passing of formatting string for integers

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1776,7 +1776,7 @@ def test_api_date_parsing(conn, request):
 
 
 @pytest.mark.parametrize("conn", all_connectable_types)
-@pytest.mark.parametrize("error", ["ignore", "raise", "coerce"])
+@pytest.mark.parametrize("error", ["raise", "coerce"])
 @pytest.mark.parametrize(
     "read_sql, text, mode",
     [

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -18,7 +18,7 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.fixture(params=[None, "ignore", "raise", "coerce"])
+@pytest.fixture(params=[None, "raise", "coerce"])
 def errors(request):
     return request.param
 
@@ -116,15 +116,11 @@ def test_error(data, msg):
         to_numeric(ser, errors="raise")
 
 
-@pytest.mark.parametrize(
-    "errors,exp_data", [("ignore", [1, -3.14, "apple"]), ("coerce", [1, -3.14, np.nan])]
-)
-@pytest.mark.filterwarnings("ignore:errors='ignore' is deprecated:FutureWarning")
-def test_ignore_error(errors, exp_data):
+def test_ignore_error():
     ser = Series([1, -3.14, "apple"])
-    result = to_numeric(ser, errors=errors)
+    result = to_numeric(ser, errors="coerce")
 
-    expected = Series(exp_data)
+    expected = Series([1, -3.14, np.nan])
     tm.assert_series_equal(result, expected)
 
 
@@ -132,12 +128,10 @@ def test_ignore_error(errors, exp_data):
     "errors,exp",
     [
         ("raise", 'Unable to parse string "apple" at position 2'),
-        ("ignore", [True, False, "apple"]),
         # Coerces to float.
         ("coerce", [1.0, 0.0, np.nan]),
     ],
 )
-@pytest.mark.filterwarnings("ignore:errors='ignore' is deprecated:FutureWarning")
 def test_bool_handling(errors, exp):
     ser = Series([True, False, "apple"])
 
@@ -236,7 +230,6 @@ def test_all_nan():
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.filterwarnings("ignore:errors='ignore' is deprecated:FutureWarning")
 def test_type_check(errors):
     # see gh-11776
     df = DataFrame({"a": [1, -3.14, 7], "b": ["4", "5", "6"]})
@@ -251,7 +244,6 @@ def test_scalar(val, signed, transform):
     assert to_numeric(transform(val)) == float(val)
 
 
-@pytest.mark.filterwarnings("ignore:errors='ignore' is deprecated:FutureWarning")
 def test_really_large_scalar(large_val, signed, transform, errors):
     # see gh-24910
     kwargs = {"errors": errors} if errors is not None else {}
@@ -269,7 +261,6 @@ def test_really_large_scalar(large_val, signed, transform, errors):
         tm.assert_almost_equal(to_numeric(val, **kwargs), expected)
 
 
-@pytest.mark.filterwarnings("ignore:errors='ignore' is deprecated:FutureWarning")
 def test_really_large_in_arr(large_val, signed, transform, multiple_elts, errors):
     # see gh-24910
     kwargs = {"errors": errors} if errors is not None else {}
@@ -309,7 +300,6 @@ def test_really_large_in_arr(large_val, signed, transform, multiple_elts, errors
         tm.assert_almost_equal(result, np.array(expected, dtype=exp_dtype))
 
 
-@pytest.mark.filterwarnings("ignore:errors='ignore' is deprecated:FutureWarning")
 def test_really_large_in_arr_consistent(large_val, signed, multiple_elts, errors):
     # see gh-24910
     #
@@ -329,13 +319,8 @@ def test_really_large_in_arr_consistent(large_val, signed, multiple_elts, errors
             to_numeric(arr, **kwargs)
     else:
         result = to_numeric(arr, **kwargs)
-
-        if errors == "coerce":
-            expected = [float(i) for i in arr]
-            exp_dtype = float
-        else:
-            expected = arr
-            exp_dtype = object
+        expected = [float(i) for i in arr]
+        exp_dtype = float
 
         tm.assert_almost_equal(result, np.array(expected, dtype=exp_dtype))
 
@@ -344,11 +329,9 @@ def test_really_large_in_arr_consistent(large_val, signed, multiple_elts, errors
     "errors,checker",
     [
         ("raise", 'Unable to parse string "fail" at position 0'),
-        ("ignore", lambda x: x == "fail"),
         ("coerce", lambda x: np.isnan(x)),
     ],
 )
-@pytest.mark.filterwarnings("ignore:errors='ignore' is deprecated:FutureWarning")
 def test_scalar_fail(errors, checker):
     scalar = "fail"
 
@@ -420,11 +403,9 @@ def test_period(request, transform_assert_equal):
     "errors,expected",
     [
         ("raise", "Invalid object type at position 0"),
-        ("ignore", Series([[10.0, 2], 1.0, "apple"])),
         ("coerce", Series([np.nan, 1.0, np.nan])),
     ],
 )
-@pytest.mark.filterwarnings("ignore:errors='ignore' is deprecated:FutureWarning")
 def test_non_hashable(errors, expected):
     # see gh-13324
     ser = Series([[10.0, 2], 1.0, "apple"])
@@ -502,19 +483,6 @@ def test_signed_downcast(data, signed_downcast):
     tm.assert_numpy_array_equal(res, expected)
 
 
-def test_ignore_downcast_invalid_data():
-    # If we can't successfully cast the given
-    # data to a numeric dtype, do not bother
-    # with the downcast parameter.
-    data = ["foo", 2, 3]
-    expected = np.array(data, dtype=object)
-
-    msg = "errors='ignore' is deprecated"
-    with tm.assert_produces_warning(FutureWarning, match=msg):
-        res = to_numeric(data, errors="ignore", downcast="unsigned")
-    tm.assert_numpy_array_equal(res, expected)
-
-
 def test_ignore_downcast_neg_to_unsigned():
     # Cannot cast to an unsigned integer
     # because we have a negative number.
@@ -526,7 +494,6 @@ def test_ignore_downcast_neg_to_unsigned():
 
 
 # Warning in 32 bit platforms
-@pytest.mark.filterwarnings("ignore:invalid value encountered in cast:RuntimeWarning")
 @pytest.mark.parametrize("downcast", ["integer", "signed", "unsigned"])
 @pytest.mark.parametrize(
     "data,expected",
@@ -628,26 +595,14 @@ def test_coerce_uint64_conflict(data, exp_data):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    "errors,exp",
-    [
-        ("ignore", Series(["12345678901234567890", "1234567890", "ITEM"])),
-        ("raise", "Unable to parse string"),
-    ],
-)
-@pytest.mark.filterwarnings("ignore:errors='ignore' is deprecated:FutureWarning")
-def test_non_coerce_uint64_conflict(errors, exp):
+def test_non_coerce_uint64_conflict():
     # see gh-17007 and gh-17125
     #
     # For completeness.
     ser = Series(["12345678901234567890", "1234567890", "ITEM"])
 
-    if isinstance(exp, str):
-        with pytest.raises(ValueError, match=exp):
-            to_numeric(ser, errors=errors)
-    else:
-        result = to_numeric(ser, errors=errors)
-        tm.assert_series_equal(result, ser)
+    with pytest.raises(ValueError, match="Unable to parse string"):
+        to_numeric(ser, errors="raise")
 
 
 @pytest.mark.parametrize("dc1", ["integer", "float", "unsigned"])
@@ -754,17 +709,6 @@ def test_to_numeric_from_nullable_string_coerce(nullable_string_dtype):
     ser = Series(values, dtype=nullable_string_dtype)
     result = to_numeric(ser, errors="coerce")
     expected = Series([pd.NA, 1], dtype="Int64")
-    tm.assert_series_equal(result, expected)
-
-
-def test_to_numeric_from_nullable_string_ignore(nullable_string_dtype):
-    # GH#52146
-    values = ["a", "1"]
-    ser = Series(values, dtype=nullable_string_dtype)
-    expected = ser.copy()
-    msg = "errors='ignore' is deprecated"
-    with tm.assert_produces_warning(FutureWarning, match=msg):
-        result = to_numeric(ser, errors="ignore")
     tm.assert_series_equal(result, expected)
 
 
@@ -933,11 +877,6 @@ def test_to_numeric_dtype_backend_error(dtype_backend):
     expected = ser.copy()
     with pytest.raises(ValueError, match="Unable to parse string"):
         to_numeric(ser, dtype_backend=dtype_backend)
-
-    msg = "errors='ignore' is deprecated"
-    with tm.assert_produces_warning(FutureWarning, match=msg):
-        result = to_numeric(ser, dtype_backend=dtype_backend, errors="ignore")
-    tm.assert_series_equal(result, expected)
 
     result = to_numeric(ser, dtype_backend=dtype_backend, errors="coerce")
     if dtype_backend == "pyarrow":

--- a/pandas/tests/tools/test_to_time.py
+++ b/pandas/tests/tools/test_to_time.py
@@ -54,10 +54,8 @@ class TestToTime:
         assert to_time(arg, infer_time_format=True) == expected_arr
         assert to_time(arg, format="%I:%M%p", errors="coerce") == [None, None]
 
-        msg = "errors='ignore' is deprecated"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
-            res = to_time(arg, format="%I:%M%p", errors="ignore")
-        tm.assert_numpy_array_equal(res, np.array(arg, dtype=np.object_))
+        with pytest.raises(ValueError, match="errors must be"):
+            to_time(arg, format="%I:%M%p", errors="ignore")
 
         msg = "Cannot convert.+to a time with given format"
         with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -99,8 +99,7 @@ class TestTimedeltas:
             TimedeltaArray._from_sequence(arr, dtype="m8[s]")
 
     @pytest.mark.parametrize("box", [lambda x: x, pd.DataFrame])
-    @pytest.mark.parametrize("errors", ["ignore", "raise", "coerce"])
-    @pytest.mark.filterwarnings("ignore:errors='ignore' is deprecated:FutureWarning")
+    @pytest.mark.parametrize("errors", ["raise", "coerce"])
     def test_to_timedelta_dataframe(self, box, errors):
         # GH 11776
         arg = box(np.arange(10).reshape(2, 5))
@@ -144,32 +143,6 @@ class TestTimedeltas:
             TimedeltaIndex(["1 day", pd.NaT, "1 min"]),
             to_timedelta(["1 day", "bar", "1 min"], errors="coerce"),
         )
-
-    def test_to_timedelta_invalid_errors_ignore(self):
-        # gh-13613: these should not error because errors='ignore'
-        msg = "errors='ignore' is deprecated"
-        invalid_data = "apple"
-
-        with tm.assert_produces_warning(FutureWarning, match=msg):
-            result = to_timedelta(invalid_data, errors="ignore")
-        assert invalid_data == result
-
-        invalid_data = ["apple", "1 days"]
-        expected = np.array(invalid_data, dtype=object)
-
-        with tm.assert_produces_warning(FutureWarning, match=msg):
-            result = to_timedelta(invalid_data, errors="ignore")
-        tm.assert_numpy_array_equal(expected, result)
-
-        invalid_data = pd.Index(["apple", "1 days"])
-        with tm.assert_produces_warning(FutureWarning, match=msg):
-            result = to_timedelta(invalid_data, errors="ignore")
-        tm.assert_index_equal(invalid_data, result)
-
-        invalid_data = Series(["apple", "1 days"])
-        with tm.assert_produces_warning(FutureWarning, match=msg):
-            result = to_timedelta(invalid_data, errors="ignore")
-        tm.assert_series_equal(invalid_data, result)
 
     @pytest.mark.parametrize(
         "val, errors",
@@ -254,13 +227,6 @@ class TestTimedeltas:
         result = to_timedelta(arr, unit="ns", errors="coerce")
         expected = to_timedelta([1, 2, pd.NaT], unit="ns")
         tm.assert_index_equal(result, expected)
-
-    def test_to_timedelta_ignore_strings_unit(self):
-        arr = np.array([1, 2, "error"], dtype=object)
-        msg = "errors='ignore' is deprecated"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
-            result = to_timedelta(arr, unit="ns", errors="ignore")
-        tm.assert_numpy_array_equal(result, arr)
 
     @pytest.mark.parametrize(
         "expected_val, result_val", [[timedelta(days=2), 2], [None, None]]

--- a/pandas/tests/tslibs/test_array_to_datetime.py
+++ b/pandas/tests/tslibs/test_array_to_datetime.py
@@ -216,20 +216,6 @@ def test_parsing_different_timezone_offsets():
 
 
 @pytest.mark.parametrize(
-    "data", [["-352.737091", "183.575577"], ["1", "2", "3", "4", "5"]]
-)
-def test_number_looking_strings_not_into_datetime(data):
-    # see gh-4601
-    #
-    # These strings don't look like datetimes, so
-    # they shouldn't be attempted to be converted.
-    arr = np.array(data, dtype=object)
-    result, _ = tslib.array_to_datetime(arr, errors="ignore")
-
-    tm.assert_numpy_array_equal(result, arr)
-
-
-@pytest.mark.parametrize(
     "invalid_date",
     [
         date(1000, 1, 1),
@@ -266,22 +252,12 @@ def test_coerce_outside_ns_bounds_one_valid():
     tm.assert_numpy_array_equal(result, expected)
 
 
-@pytest.mark.parametrize("errors", ["ignore", "coerce"])
-def test_coerce_of_invalid_datetimes(errors):
+def test_coerce_of_invalid_datetimes():
     arr = np.array(["01-01-2013", "not_a_date", "1"], dtype=object)
-    kwargs = {"values": arr, "errors": errors}
-
-    if errors == "ignore":
-        # Without coercing, the presence of any invalid
-        # dates prevents any values from being converted.
-        result, _ = tslib.array_to_datetime(**kwargs)
-        tm.assert_numpy_array_equal(result, arr)
-    else:  # coerce.
-        # With coercing, the invalid dates becomes iNaT
-        result, _ = tslib.array_to_datetime(arr, errors="coerce")
-        expected = ["2013-01-01T00:00:00.000000000", iNaT, iNaT]
-
-        tm.assert_numpy_array_equal(result, np.array(expected, dtype="M8[ns]"))
+    # With coercing, the invalid dates becomes iNaT
+    result, _ = tslib.array_to_datetime(arr, errors="coerce")
+    expected = ["2013-01-01T00:00:00.000000000", iNaT, iNaT]
+    tm.assert_numpy_array_equal(result, np.array(expected, dtype="M8[ns]"))
 
 
 def test_to_datetime_barely_out_of_bounds():


### PR DESCRIPTION

- [ ] closes #55734 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
