### PR TITLE
Update Styler documentation for escaping HTML

### DIFF
--- a/doc/source/user_guide/style.ipynb
+++ b/doc/source/user_guide/style.ipynb
@@ -1621,7 +1621,9 @@
    "source": [
     "### HTML Escaping\n",
     "\n",
-    "Suppose you have to display HTML within HTML, that can be a bit of pain when the renderer can't distinguish. You can use the `escape` formatting option to handle this, and even use it within a formatter that contains HTML itself."
+    "Suppose you have to display HTML within HTML, that can be a bit of pain when the renderer can't distinguish. You can use the `escape` formatting option to handle this, and even use it within a formatter that contains HTML itself.\n",
+    "\n",
+    "Note that if you're using `Styler` on untrusted, user-provided input to serve HTML then you should escape the input to prevent security vulnerabilities. See the Jinja2 documentation for more."
    ]
   },
   {

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -179,13 +179,6 @@ class Styler(StylerRenderer):
         Use 'html' to replace the characters ``&``, ``<``, ``>``, ``'``, and ``"``
         in cell display string with HTML-safe sequences.
 
-        .. warning::
-
-           ``Styler`` is primarily intended for use on safe input that you control.
-           When using ``Styler`` on untrusted, user-provided input to serve HTML,
-           you should set ``escape=true`` to prevent security vulnerabilities.
-           See the Jinja2 documentation on HTML escaping for more.
-
         Use 'latex' to replace the characters ``&``, ``%``, ``$``, ``#``, ``_``,
         ``{``, ``}``, ``~``, ``^``, and ``\`` in the cell display string with
         LaTeX-safe sequences. Use 'latex-math' to replace the characters
@@ -217,6 +210,13 @@ class Styler(StylerRenderer):
 
     Notes
     -----
+    .. warning::
+
+       ``Styler`` is primarily intended for use on safe input that you control.
+       When using ``Styler`` on untrusted, user-provided input to serve HTML,
+       you should set ``escape="html"`` to prevent security vulnerabilities.
+       See the Jinja2 documentation on escaping HTML for more.
+
     Most styling will be done by passing style functions into
     ``Styler.apply`` or ``Styler.map``. Style functions should
     return values with strings containing CSS ``'attr: value'`` that will

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -178,6 +178,14 @@ class Styler(StylerRenderer):
     escape : str, optional
         Use 'html' to replace the characters ``&``, ``<``, ``>``, ``'``, and ``"``
         in cell display string with HTML-safe sequences.
+
+        .. warning::
+
+           ``Styler`` is primarily intended for use on safe input that you control.
+           When using ``Styler`` on untrusted, user-provided input to serve HTML,
+           you should set ``escape=true`` to prevent security vulnerabilities.
+           See the Jinja2 documentation on HTML escaping for more.
+
         Use 'latex' to replace the characters ``&``, ``%``, ``$``, ``#``, ``_``,
         ``{``, ``}``, ``~``, ``^``, and ``\`` in the cell display string with
         LaTeX-safe sequences. Use 'latex-math' to replace the characters


### PR DESCRIPTION
Adds a note to the docs about `Styler` and `escape` on untrusted HTML input.