### PR TITLE
TST: Ensure Matplotlib is always cleaned up

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -28,6 +28,7 @@ from datetime import (
     timezone,
 )
 from decimal import Decimal
+import gc
 import operator
 import os
 from typing import (
@@ -1861,6 +1862,39 @@ def ip():
     c.HistoryManager.hist_file = ":memory:"
 
     return InteractiveShell(config=c)
+
+
+@pytest.fixture
+def mpl_cleanup():
+    """
+    Ensure Matplotlib is cleaned up around a test.
+
+    Before a test is run:
+
+    1) Set the backend to "template" to avoid requiring a GUI.
+
+    After a test is run:
+
+    1) Reset units registry
+    2) Reset rc_context
+    3) Close all figures
+
+    See matplotlib/testing/decorators.py#L24.
+    """
+    mpl = pytest.importorskip("matplotlib")
+    mpl_units = pytest.importorskip("matplotlib.units")
+    plt = pytest.importorskip("matplotlib.pyplot")
+    orig_units_registry = mpl_units.registry.copy()
+    try:
+        with mpl.rc_context():
+            mpl.use("template")
+            yield
+    finally:
+        mpl_units.registry.clear()
+        mpl_units.registry.update(orig_units_registry)
+        plt.close("all")
+        # https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.6.0.html#garbage-collection-is-no-longer-run-on-figure-close  # noqa: E501
+        gc.collect(1)
 
 
 @pytest.fixture(

--- a/pandas/tests/io/formats/style/test_matplotlib.py
+++ b/pandas/tests/io/formats/style/test_matplotlib.py
@@ -1,5 +1,3 @@
-import gc
-
 import numpy as np
 import pytest
 
@@ -16,25 +14,7 @@ import matplotlib as mpl
 
 from pandas.io.formats.style import Styler
 
-
-@pytest.fixture(autouse=True)
-def mpl_cleanup():
-    # matplotlib/testing/decorators.py#L24
-    # 1) Resets units registry
-    # 2) Resets rc_context
-    # 3) Closes all figures
-    mpl = pytest.importorskip("matplotlib")
-    mpl_units = pytest.importorskip("matplotlib.units")
-    plt = pytest.importorskip("matplotlib.pyplot")
-    orig_units_registry = mpl_units.registry.copy()
-    with mpl.rc_context():
-        mpl.use("template")
-        yield
-    mpl_units.registry.clear()
-    mpl_units.registry.update(orig_units_registry)
-    plt.close("all")
-    # https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.6.0.html#garbage-collection-is-no-longer-run-on-figure-close  # noqa: E501
-    gc.collect(1)
+pytestmark = pytest.mark.usefixtures("mpl_cleanup")
 
 
 @pytest.fixture

--- a/pandas/tests/plotting/conftest.py
+++ b/pandas/tests/plotting/conftest.py
@@ -1,5 +1,3 @@
-import gc
-
 import numpy as np
 import pytest
 
@@ -10,23 +8,8 @@ from pandas import (
 
 
 @pytest.fixture(autouse=True)
-def mpl_cleanup():
-    # matplotlib/testing/decorators.py#L24
-    # 1) Resets units registry
-    # 2) Resets rc_context
-    # 3) Closes all figures
-    mpl = pytest.importorskip("matplotlib")
-    mpl_units = pytest.importorskip("matplotlib.units")
-    plt = pytest.importorskip("matplotlib.pyplot")
-    orig_units_registry = mpl_units.registry.copy()
-    with mpl.rc_context():
-        mpl.use("template")
-        yield
-    mpl_units.registry.clear()
-    mpl_units.registry.update(orig_units_registry)
-    plt.close("all")
-    # https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.6.0.html#garbage-collection-is-no-longer-run-on-figure-close  # noqa: E501
-    gc.collect(1)
+def autouse_mpl_cleanup(mpl_cleanup):
+    pass
 
 
 @pytest.fixture

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -155,7 +155,7 @@ def test_scikit_learn():
     clf.predict(digits.data[-1:])
 
 
-def test_seaborn():
+def test_seaborn(mpl_cleanup):
     seaborn = pytest.importorskip("seaborn")
     tips = DataFrame(
         {"day": pd.date_range("2023", freq="D", periods=5), "total_bill": range(5)}


### PR DESCRIPTION
The seaborn test also uses Matplotlib but was not wrapped in the cleanup fixture, As there are now 3 files that need this fixture, refactor to reduce code duplication.

The leftover figure from `test_seaborn` would cause a DeprecationWarning from Matplotlib 3.8 for closing the figures on the backend change (from the `mpl.use("template")` in the fixture), but this probably depends on if pytest chose to run it before the other tests or not.

- [n/a] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [n/a] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
