### PR TITLE
TST: Fix IntervalIndex constructor tests on big-endian systems

### DIFF
--- a/pandas/tests/indexes/interval/test_constructors.py
+++ b/pandas/tests/indexes/interval/test_constructors.py
@@ -40,12 +40,12 @@ class ConstructorTests:
             (Index(np.arange(-10, 11, dtype=np.int64)), np.int64),
             (Index(np.arange(10, 31, dtype=np.uint64)), np.uint64),
             (Index(np.arange(20, 30, 0.5), dtype=np.float64), np.float64),
-            (date_range("20180101", periods=10), "<M8[ns]"),
+            (date_range("20180101", periods=10), "M8[ns]"),
             (
                 date_range("20180101", periods=10, tz="US/Eastern"),
                 "datetime64[ns, US/Eastern]",
             ),
-            (timedelta_range("1 day", periods=10), "<m8[ns]"),
+            (timedelta_range("1 day", periods=10), "m8[ns]"),
         ],
     )
     @pytest.mark.parametrize("name", [None, "foo"])


### PR DESCRIPTION
Two tests cases specify the expected data to be little-endian. However, none of the other cases do so, and the test creates native endian data, causing these tests to fail only in these specific cases.

- [n/a] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [n/a] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [n/a] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
