### PR TITLE
BUG: Ensure consistent kwarg only restriction on df.any and df.all

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -948,7 +948,7 @@ To select a row where each column meets its own criterion:
 
   values = {'ids': ['a', 'b'], 'ids2': ['a', 'c'], 'vals': [1, 3]}
 
-  row_mask = df.isin(values).all(1)
+  row_mask = df.isin(values).all(axis=1)
 
   df[row_mask]
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -11331,6 +11331,7 @@ class DataFrame(NDFrame, OpsMixin):
     @doc(make_doc("all", ndim=2))
     def all(
         self,
+        *,
         axis: Axis | None = 0,
         bool_only: bool = False,
         skipna: bool = True,

--- a/pandas/tests/frame/methods/test_asof.py
+++ b/pandas/tests/frame/methods/test_asof.py
@@ -36,18 +36,18 @@ class TestFrameAsof:
         dates = date_range("1/1/1990", periods=N * 3, freq="25s")
 
         result = df.asof(dates)
-        assert result.notna().all(1).all()
+        assert result.notna().all(axis=1).all()
         lb = df.index[14]
         ub = df.index[30]
 
         dates = list(dates)
 
         result = df.asof(dates)
-        assert result.notna().all(1).all()
+        assert result.notna().all(axis=1).all()
 
         mask = (result.index >= lb) & (result.index < ub)
         rs = result[mask]
-        assert (rs == 14).all(1).all()
+        assert (rs == 14).all(axis=1).all()
 
     def test_subset(self, date_range_frame):
         N = 10

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -1506,38 +1506,26 @@ class TestDataFrameAnalytics:
         result = np.any(DataFrame(columns=["a", "b"])).item()
         assert result is False
 
-    def test_any_all_take_kwargs_only(self):
+    @pytest.mark.parametrize("method", ["all", "any"])
+    def test_any_all_take_kwargs_only(self, method):
         # GH 57087
         df = DataFrame({"x": [1, 2, 3], "y": [1, 2, 3]})
         msg = "takes 1 positional argument but"
 
         with pytest.raises(TypeError, match=msg):
-            df.all(0)
+            getattr(df, method)(0)
 
         with pytest.raises(TypeError, match=msg):
-            df.all(0, bool_only=True, skipna=False)
+            getattr(df, method)(0, bool_only=True, skipna=False)
 
         with pytest.raises(TypeError, match=msg):
-            df.all(0, True, False)
+            getattr(df, method)(0, True, False)
 
         with pytest.raises(TypeError, match=msg):
-            df.all(0, bool_only=True)
-
-        with pytest.raises(TypeError, match=msg):
-            df.any(0)
-
-        with pytest.raises(TypeError, match=msg):
-            df.any(0, bool_only=True, skipna=False)
-
-        with pytest.raises(TypeError, match=msg):
-            df.any(0, True, False)
-
-        with pytest.raises(TypeError, match=msg):
-            df.any(0, bool_only=True)
+            getattr(df, method)(0, bool_only=True)
 
         # Ensure that it works with only keyword arguments
-        df.all(axis=0, bool_only=True, skipna=False)
-        df.any(axis=0, bool_only=True, skipna=False)
+        getattr(df, method)(axis=0, bool_only=True, skipna=False)
 
     def test_any_all_object_bool_only(self):
         df = DataFrame({"A": ["foo", 2], "B": [True, False]}).astype(object)

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -1329,11 +1329,11 @@ class TestDataFrameAnalytics:
         result = df[["A", "B"]].any(axis=1, bool_only=True)
         tm.assert_series_equal(result, expected)
 
-        result = df.all(1)
+        result = df.all(axis=1)
         expected = Series([True, False, False], index=["a", "b", "c"])
         tm.assert_series_equal(result, expected)
 
-        result = df.all(1, bool_only=True)
+        result = df.all(axis=1, bool_only=True)
         tm.assert_series_equal(result, expected)
 
         # Axis is None

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -1506,6 +1506,39 @@ class TestDataFrameAnalytics:
         result = np.any(DataFrame(columns=["a", "b"])).item()
         assert result is False
 
+    def test_any_all_take_kwargs_only(self):
+        # GH 57087
+        df = DataFrame({"x": [1, 2, 3], "y": [1, 2, 3]})
+        msg = "takes 1 positional argument but"
+
+        with pytest.raises(TypeError, match=msg):
+            df.all(0)
+
+        with pytest.raises(TypeError, match=msg):
+            df.all(0, bool_only=True, skipna=False)
+
+        with pytest.raises(TypeError, match=msg):
+            df.all(0, True, False)
+
+        with pytest.raises(TypeError, match=msg):
+            df.all(0, bool_only=True)
+
+        with pytest.raises(TypeError, match=msg):
+            df.any(0)
+
+        with pytest.raises(TypeError, match=msg):
+            df.any(0, bool_only=True, skipna=False)
+
+        with pytest.raises(TypeError, match=msg):
+            df.any(0, True, False)
+
+        with pytest.raises(TypeError, match=msg):
+            df.any(0, bool_only=True)
+
+        # Ensure that it works with only keyword arguments
+        df.all(axis=0, bool_only=True, skipna=False)
+        df.any(axis=0, bool_only=True, skipna=False)
+
     def test_any_all_object_bool_only(self):
         df = DataFrame({"A": ["foo", 2], "B": [True, False]}).astype(object)
         df._consolidate_inplace()


### PR DESCRIPTION
- [x] closes #57087 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
