### PR TITLE
DOC: fix SA05 errors in docstring for pandas.DataFrame - agg, aggregate, boxplot

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -143,9 +143,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
 
     MSG='Partially validate docstrings (SA05)' ;  echo $MSG
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=SA05 --ignore_functions \
-        pandas.DataFrame.agg\
-        pandas.DataFrame.aggregate\
-        pandas.DataFrame.boxplot\
         pandas.PeriodIndex.asfreq\
         pandas.arrays.ArrowStringArray\
         pandas.arrays.StringArray\

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9752,11 +9752,11 @@ class DataFrame(NDFrame, OpsMixin):
     --------
     DataFrame.apply : Perform any type of operations.
     DataFrame.transform : Perform transformation type operations.
-    pandas.DataFrame.groupby : Perform operations over groups.
-    pandas.DataFrame.resample : Perform operations over resampled bins.
-    pandas.DataFrame.rolling : Perform operations over rolling window.
-    pandas.DataFrame.expanding : Perform operations over expanding window.
-    pandas.core.window.ewm.ExponentialMovingWindow : Perform operation over exponential
+    DataFrame.groupby : Perform operations over groups.
+    DataFrame.resample : Perform operations over resampled bins.
+    DataFrame.rolling : Perform operations over rolling window.
+    DataFrame.expanding : Perform operations over expanding window.
+    core.window.ewm.ExponentialMovingWindow : Perform operation over exponential
         weighted window.
     """
     )

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -335,7 +335,7 @@ result
 
 See Also
 --------
-pandas.Series.plot.hist: Make a histogram.
+Series.plot.hist: Make a histogram.
 matplotlib.pyplot.boxplot : Matplotlib equivalent plot.
 
 Notes


### PR DESCRIPTION
All SA05 Errors resolved in the following cases:

1. scripts/validate_docstrings.py --format=actions --errors=SA05 pandas.DataFrame.agg
2. scripts/validate_docstrings.py --format=actions --errors=SA05 pandas.DataFrame.aggregate
3. scripts/validate_docstrings.py --format=actions --errors=SA05 pandas.DataFrame.boxplot


- [x] xref https://github.com/pandas-dev/pandas/issues/57392
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
