### PR TITLE
ENH: Preserve Series index on `json_normalize`

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -31,7 +31,7 @@ Other enhancements
 - :func:`DataFrame.to_excel` now raises an ``UserWarning`` when the character count in a cell exceeds Excel's limitation of 32767 characters (:issue:`56954`)
 - :func:`read_stata` now returns ``datetime64`` resolutions better matching those natively stored in the stata format (:issue:`55642`)
 - Allow dictionaries to be passed to :meth:`pandas.Series.str.replace` via ``pat`` parameter (:issue:`51748`)
-- Support passing a ``Series`` input to :func:`normalize_json` (:issue:`51452`)
+- Support passing a :class:`Series` input to :func:`json_normalize` that retains the :class:`Series` :class:`Index` (:issue:`51452`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -31,6 +31,7 @@ Other enhancements
 - :func:`DataFrame.to_excel` now raises an ``UserWarning`` when the character count in a cell exceeds Excel's limitation of 32767 characters (:issue:`56954`)
 - :func:`read_stata` now returns ``datetime64`` resolutions better matching those natively stored in the stata format (:issue:`55642`)
 - Allow dictionaries to be passed to :meth:`pandas.Series.str.replace` via ``pat`` parameter (:issue:`51748`)
+- Support passing a ``Series`` input to :func:`normalize_json` (:issue:`51452`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/io/json/_normalize.py
+++ b/pandas/io/json/_normalize.py
@@ -283,7 +283,7 @@ def json_normalize(
 
     Parameters
     ----------
-    data : dict or list of dicts
+    data : dict, list of dicts, or Series of dicts
         Unserialized JSON objects.
     record_path : str or list of str, default None
         Path in each object to list of records. If not passed, data will be
@@ -367,6 +367,26 @@ def json_normalize(
     0  1.0   Cole Volk             130              60
     1  NaN    Mark Reg             130              60
     2  2.0  Faye Raker             130              60
+
+    >>> data = [
+    ...     {
+    ...         "id": 1,
+    ...         "name": "Cole Volk",
+    ...         "fitness": {"height": 130, "weight": 60},
+    ...     },
+    ...     {"name": "Mark Reg", "fitness": {"height": 130, "weight": 60}},
+    ...     {
+    ...         "id": 2,
+    ...         "name": "Faye Raker",
+    ...         "fitness": {"height": 130, "weight": 60},
+    ...     },
+    ... ]
+    >>> series = pd.Series(data, index=pd.Index(["a", "b", "c"]))
+    >>> pd.json_normalize(series)
+        id        name  fitness.height  fitness.weight
+    a  1.0   Cole Volk             130              60
+    b  NaN    Mark Reg             130              60
+    c  2.0  Faye Raker             130              60
 
     >>> data = [
     ...     {

--- a/pandas/io/json/_normalize.py
+++ b/pandas/io/json/_normalize.py
@@ -19,7 +19,10 @@ import numpy as np
 from pandas._libs.writers import convert_json_to_lines
 
 import pandas as pd
-from pandas import DataFrame, Series
+from pandas import (
+    DataFrame,
+    Series,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable

--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -560,6 +560,14 @@ class TestJSONNormalize:
         expected = DataFrame([[4, 10, 0]], columns=["gg", "_id_a1", "_id_l2_l3"])
 
         tm.assert_frame_equal(result, expected)
+        
+    def test_series_index(self, state_data):
+        idx = [7, 8]
+        series = Series(state_data, index=idx)
+        result = json_normalize(series)
+        assert (result.index == idx).all()
+        result = json_normalize(series, "counties")
+        assert (result.index == np.array(idx).repeat([3, 2])).all()
 
 
 class TestNestedToRecord:
@@ -893,4 +901,5 @@ class TestNestedToRecord:
                 "elements.c": [np.nan, np.nan, 3.0],
             }
         )
+        expected.index = [1, 2, 3]
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -562,12 +562,12 @@ class TestJSONNormalize:
         tm.assert_frame_equal(result, expected)
 
     def test_series_index(self, state_data):
-        idx = [7, 8]
+        idx = Index([7, 8])
         series = Series(state_data, index=idx)
         result = json_normalize(series)
-        assert (result.index == idx).all()
+        tm.assert_index_equal(result.index, idx)
         result = json_normalize(series, "counties")
-        assert (result.index == np.array(idx).repeat([3, 2])).all()
+        tm.assert_index_equal(result.index, idx.repeat([3, 2]))
 
 
 class TestNestedToRecord:

--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -899,7 +899,7 @@ class TestNestedToRecord:
                 "elements.a": [1.0, np.nan, np.nan],
                 "elements.b": [np.nan, 2.0, np.nan],
                 "elements.c": [np.nan, np.nan, 3.0],
-            }
+            },
+            index=[1, 2, 3],
         )
-        expected.index = [1, 2, 3]
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -560,7 +560,7 @@ class TestJSONNormalize:
         expected = DataFrame([[4, 10, 0]], columns=["gg", "_id_a1", "_id_l2_l3"])
 
         tm.assert_frame_equal(result, expected)
-        
+
     def test_series_index(self, state_data):
         idx = [7, 8]
         series = Series(state_data, index=idx)


### PR DESCRIPTION
- [ ] closes #51452 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Passing a Series as input to `json_normalize` was already functional before but undocumented as a feature, and had the issue linked above where it would not preserve the index of the input series.