### PR TITLE
DOC: fix SA05 errors in docstrings for `pandas.plotting.bootstrap_plot` and `pandas.plotting.radviz`

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -1871,9 +1871,7 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.core.groupby.SeriesGroupBy.first\
         pandas.core.groupby.SeriesGroupBy.last\
         pandas.core.window.expanding.Expanding.aggregate\
-        pandas.core.window.rolling.Rolling.aggregate\
-        pandas.plotting.bootstrap_plot\
-        pandas.plotting.radviz # There should be no backslash in the final line, please keep this comment in the last ignored function
+        pandas.core.window.rolling.Rolling.aggregate # There should be no backslash in the final line, please keep this comment in the last ignored function
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
 fi

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -278,10 +278,11 @@ def radviz(
     Returns
     -------
     :class:`matplotlib.axes.Axes`
+        The Axes object from Matplotlib.
 
     See Also
     --------
-    pandas.plotting.andrews_curves : Plot clustering visualization.
+    plotting.andrews_curves : Plot clustering visualization.
 
     Examples
     --------
@@ -431,8 +432,8 @@ def bootstrap_plot(
 
     See Also
     --------
-    pandas.DataFrame.plot : Basic plotting for DataFrame objects.
-    pandas.Series.plot : Basic plotting for Series objects.
+    DataFrame.plot : Basic plotting for DataFrame objects.
+    Series.plot : Basic plotting for Series objects.
 
     Examples
     --------


### PR DESCRIPTION
All SA05 Errors resolved in the following cases:

1. scripts/validate_docstrings.py --format=actions --errors=SA05 pandas.plotting.bootstrap_plot
2. scripts/validate_docstrings.py --format=actions --errors=SA05 pandas.plotting.radviz
3. try to fix a `RT03    Return value has no description` in pandas.plotting.radviz



- [x]  xref [DOC: fix SA05 errors in docstrings  #57392](https://github.com/pandas-dev/pandas/issues/57392)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
