### PR TITLE
PERF: Allow RangeIndex.take to return a RangeIndex when possible

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -166,6 +166,7 @@ Performance improvements
 - Performance improvement in :meth:`Index.take` when ``indices`` is a full range indexer from zero to length of index (:issue:`56806`)
 - Performance improvement in :meth:`MultiIndex.equals` for equal length indexes (:issue:`56990`)
 - Performance improvement in :meth:`RangeIndex.append` when appending the same index (:issue:`57252`)
+- Performance improvement in :meth:`RangeIndex.take` returning a :class:`RangeIndex` instead of a :class:`Index` when possible. (:issue:`?`)
 - Performance improvement in indexing operations for string dtypes (:issue:`56997`)
 -
 

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -166,7 +166,7 @@ Performance improvements
 - Performance improvement in :meth:`Index.take` when ``indices`` is a full range indexer from zero to length of index (:issue:`56806`)
 - Performance improvement in :meth:`MultiIndex.equals` for equal length indexes (:issue:`56990`)
 - Performance improvement in :meth:`RangeIndex.append` when appending the same index (:issue:`57252`)
-- Performance improvement in :meth:`RangeIndex.take` returning a :class:`RangeIndex` instead of a :class:`Index` when possible. (:issue:`?`)
+- Performance improvement in :meth:`RangeIndex.take` returning a :class:`RangeIndex` instead of a :class:`Index` when possible. (:issue:`57445`)
 - Performance improvement in indexing operations for string dtypes (:issue:`56997`)
 -
 

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -1006,11 +1006,13 @@ class RangeIndex(Index):
             # Get the stop value from "next" or alternatively
             # from the last non-empty index
             stop = non_empty_indexes[-1].stop if next_ is None else next_
-            return RangeIndex(start, stop, step).rename(name)
+            if len(non_empty_indexes) == 1:
+                step = non_empty_indexes[0].step
+            return RangeIndex(start, stop, step, name=name)
 
         # Here all "indexes" had 0 length, i.e. were empty.
         # In this case return an empty range index.
-        return RangeIndex(0, 0).rename(name)
+        return RangeIndex(_empty_range, name=name)
 
     def __len__(self) -> int:
         """
@@ -1179,7 +1181,7 @@ class RangeIndex(Index):
         self._maybe_disallow_fill(allow_fill, fill_value, indices)
 
         if len(indices) == 0:
-            return type(self)(range(0), name=self.name)
+            return type(self)(_empty_range, name=self.name)
         else:
             ind_max = indices.max()
             if ind_max >= len(self):

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -1179,7 +1179,7 @@ class RangeIndex(Index):
         self._maybe_disallow_fill(allow_fill, fill_value, indices)
 
         if len(indices) == 0:
-            return type(self)(name=self.name)
+            return type(self)(range(0), name=self.name)
         else:
             ind_max = indices.max()
             if ind_max >= len(self):

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -1179,7 +1179,7 @@ class RangeIndex(Index):
         self._maybe_disallow_fill(allow_fill, fill_value, indices)
 
         if len(indices) == 0:
-            return type(self)(range(0), name=self.name)
+            return type(self)(name=self.name)
         else:
             ind_max = indices.max()
             if ind_max >= len(self):

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -1168,7 +1168,7 @@ class RangeIndex(Index):
         allow_fill: bool = True,
         fill_value=None,
         **kwargs,
-    ) -> Index:
+    ) -> Self | Index:
         if kwargs:
             nv.validate_take((), kwargs)
         if is_scalar(indices):
@@ -1179,7 +1179,7 @@ class RangeIndex(Index):
         self._maybe_disallow_fill(allow_fill, fill_value, indices)
 
         if len(indices) == 0:
-            taken = np.array([], dtype=self.dtype)
+            return type(self)(range(0), name=self.name)
         else:
             ind_max = indices.max()
             if ind_max >= len(self):
@@ -1199,5 +1199,4 @@ class RangeIndex(Index):
             if self.start != 0:
                 taken += self.start
 
-        # _constructor so RangeIndex-> Index with an int64 dtype
-        return self._constructor._simple_new(taken, name=self.name)
+        return self._shallow_copy(taken, name=self.name)

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -611,7 +611,7 @@ class TestRangeIndex:
 def test_take_return_rangeindex():
     ri = RangeIndex(5, name="foo")
     result = ri.take([])
-    expected = RangeIndex(0, name="foo")
+    expected = RangeIndex(name="foo")
     tm.assert_index_equal(result, expected, exact=True)
 
     result = ri.take([3, 4])

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -606,3 +606,14 @@ class TestRangeIndex:
         result = 3 - RangeIndex(0, 4, 1)
         expected = RangeIndex(3, -1, -1)
         tm.assert_index_equal(result, expected)
+
+
+def test_take_return_rangeindex():
+    ri = RangeIndex(5, name="foo")
+    result = ri.take([])
+    expected = RangeIndex(0, name="foo")
+    tm.assert_index_equal(result, expected, exact=True)
+
+    result = ri.take([3, 4])
+    expected = RangeIndex(3, 5, name="foo")
+    tm.assert_index_equal(result, expected, exact=True)

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -611,9 +611,15 @@ class TestRangeIndex:
 def test_take_return_rangeindex():
     ri = RangeIndex(5, name="foo")
     result = ri.take([])
-    expected = RangeIndex(name="foo")
+    expected = RangeIndex(0, name="foo")
     tm.assert_index_equal(result, expected, exact=True)
 
     result = ri.take([3, 4])
     expected = RangeIndex(3, 5, name="foo")
+    tm.assert_index_equal(result, expected, exact=True)
+
+
+def test_append_one_nonempty_preserve_step():
+    expected = RangeIndex(0, -1, -1)
+    result = RangeIndex(0).append([expected])
     tm.assert_index_equal(result, expected, exact=True)


### PR DESCRIPTION
Discovered in https://github.com/pandas-dev/pandas/pull/57441