### PR TITLE
PERF: use copy=False in constructor in unstack (CoW)

### DIFF
--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -241,7 +241,7 @@ class _Unstacker:
         index = self.new_index
 
         return self.constructor(
-            values, index=index, columns=columns, dtype=values.dtype
+            values, index=index, columns=columns, dtype=values.dtype, copy=False
         )
 
     def get_new_values(self, values, fill_value=None):


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/57431

I _think_ we are sure that the `values` from `self.get_new_values(..)`, which we pass here to the DataFrame constructor, are always new values owned by us (not shared by any other object), and so we can safely set `copy=False` in that case.

Mimicking the `time_unstack` benchmark:
```
m = 100
n = 1000

levels = np.arange(m)
index = pd.MultiIndex.from_product([levels] * 2)
columns = np.arange(n)
values = np.arange(m * m * n).reshape(m * m, n)
df = pd.DataFrame(values, index, columns)
```

```
In [2]: %timeit df.unstack()
316 ms ± 44.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)   # main
228 ms ± 25.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)   # PR
```