### PR TITLE
DOC: add section Raises to PeriodIndex docstring

### DIFF
--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -134,6 +134,12 @@ class PeriodIndex(DatetimeIndexOpsMixin):
     from_fields
     from_ordinals
 
+    Raises
+    ------
+    ValueError
+        Passing the parameter data as a list without specifying either freq or
+        dtype will raise a ValueError: "freq not specified and cannot be inferred"
+
     See Also
     --------
     Index : The base pandas Index type.


### PR DESCRIPTION
we raise a ValueError: "freq not specified and cannot be inferred" if both freq and dtype are not specified in `PeriodIndex`

```
>>> pd.PeriodIndex(["2023-01-01", "2023-02-01", "2023-03-01", "2023-04-01"], freq="M")
PeriodIndex(['2023-01', '2023-02', '2023-03', '2023-04'], dtype='period[M]')

>>> pd.PeriodIndex(["2023-01-01", "2023-02-01", "2023-03-01", "2023-04-01"], dtype ="period[M]")
PeriodIndex(['2023-01', '2023-02', '2023-03', '2023-04'], dtype='period[M]')

>>> pd.PeriodIndex(["2023-01-01", "2023-02-01", "2023-03-01", "2023-04-01"])
ValueError: freq not specified and cannot be inferred
```
I added a section "Raises" to `PeriodIndex` documentation.