### PR TITLE
REGR: Behavior differs when adding Series to frame between matching and non matching index

### DIFF
--- a/doc/source/whatsnew/v2.2.1.rst
+++ b/doc/source/whatsnew/v2.2.1.rst
@@ -37,6 +37,7 @@ Fixed regressions
 - Fixed regression in :meth:`Index.join` raising ``TypeError`` when joining an empty index to a non-empty index containing mixed dtype values (:issue:`57048`)
 - Fixed regression in :meth:`Series.pct_change` raising a ``ValueError`` for an empty :class:`Series` (:issue:`57056`)
 - Fixed regression in :meth:`Series.to_numpy` when dtype is given as float and the data contains NaNs (:issue:`57121`)
+- Fixed regression in arithmetic methods not sorting columns when indexes are equal (:issue:`57462`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_221.bug_fixes:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9645,7 +9645,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             fdata = self._mgr
             join_index = self.axes[1]
             lidx, ridx = None, None
-            if not join_index.equals(other.index):
+            if not join_index.equals(other.index) or join == "outer":
                 join_index, lidx, ridx = join_index.join(
                     other.index, how=join, level=level, return_indexers=True
                 )

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -2108,3 +2108,15 @@ def test_mixed_col_index_dtype():
     result = df1 + df2
     expected = DataFrame(columns=list("abc"), data=1.0, index=[0])
     tm.assert_frame_equal(result, expected)
+
+
+def test_arithmetic_alignment():
+    df = DataFrame({"x": [], "a": []})
+    other = Series(dtype=float)
+    expected = DataFrame({"a": [], "x": []})
+    tm.assert_frame_equal(df + other, expected)
+
+    df = DataFrame({"x": [1], "a": [2]})
+    other = Series([3, 4], index=["x", "a"])
+    expected = DataFrame({"a": [6], "x": [4]})
+    tm.assert_frame_equal(df + other, expected)


### PR DESCRIPTION
follow up to #56426

this was inconsistent now for matching vs non-matching

cc @lukemanley 