### PR TITLE
REGR: DataFrame.update emits spurious warning about downcasting

### DIFF
--- a/doc/source/whatsnew/v2.2.1.rst
+++ b/doc/source/whatsnew/v2.2.1.rst
@@ -32,6 +32,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.to_dict` with ``orient='list'`` and datetime or timedelta types returning integers (:issue:`54824`)
 - Fixed regression in :meth:`DataFrame.to_json` converting nullable integers to floats (:issue:`57224`)
 - Fixed regression in :meth:`DataFrame.to_sql` when ``method="multi"`` is passed and the dialect type is not Oracle (:issue:`57310`)
+- Fixed regression in :meth:`DataFrame.update` emitting incorrect warnings about downcasting (:issue:`57124`)
 - Fixed regression in :meth:`DataFrameGroupBy.idxmin`, :meth:`DataFrameGroupBy.idxmax`, :meth:`SeriesGroupBy.idxmin`, :meth:`SeriesGroupBy.idxmax` ignoring the ``skipna`` argument (:issue:`57040`)
 - Fixed regression in :meth:`DataFrameGroupBy.idxmin`, :meth:`DataFrameGroupBy.idxmax`, :meth:`SeriesGroupBy.idxmin`, :meth:`SeriesGroupBy.idxmax` where values containing the minimum or maximum value for the dtype could produce incorrect results (:issue:`57040`)
 - Fixed regression in :meth:`ExtensionArray.to_numpy` raising for non-numeric masked dtypes (:issue:`56991`)

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -48,16 +48,18 @@ class TestDataFrameUpdate:
     def test_update_dtypes(self):
         # gh 3016
         df = DataFrame(
-            [[1.0, 2.0, False, True], [4.0, 5.0, True, False]],
-            columns=["A", "B", "bool1", "bool2"],
+            [[1.0, 2.0, 1, False, True], [4.0, 5.0, 2, True, False]],
+            columns=["A", "B", "int", "bool1", "bool2"],
         )
 
-        other = DataFrame([[45, 45]], index=[0], columns=["A", "B"])
+        other = DataFrame(
+            [[45, 45, 3, True]], index=[0], columns=["A", "B", "int", "bool1"]
+        )
         df.update(other)
 
         expected = DataFrame(
-            [[45.0, 45.0, False, True], [4.0, 5.0, True, False]],
-            columns=["A", "B", "bool1", "bool2"],
+            [[45.0, 45.0, 3, True, True], [4.0, 5.0, 2, True, False]],
+            columns=["A", "B", "int", "bool1", "bool2"],
         )
         tm.assert_frame_equal(df, expected)
 


### PR DESCRIPTION
- [x] closes #57124 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This is meant as a stopgap - I plan to finish up #55634 for 3.0 which will avoid any upcasting/downcasting altogether. However I do no like the idea of that PR being put in a patch version since it is an entirely new approach to `DataFrame.update`.

I think this can't go in main because the warning and downcasting behavior has already been removed there.