### PR TITLE
DOC: Fix PR01 errors in multiple files (#57438)

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -1477,7 +1477,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.DatetimeIndex.std\
         pandas.ExcelFile\
         pandas.ExcelFile.parse\
-        pandas.Grouper\
         pandas.HDFStore.append\
         pandas.HDFStore.put\
         pandas.Index.get_indexer_for\
@@ -1538,21 +1537,7 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.api.types.is_float\
         pandas.api.types.is_hashable\
         pandas.api.types.is_integer\
-        pandas.core.groupby.DataFrameGroupBy.cummax\
-        pandas.core.groupby.DataFrameGroupBy.cummin\
-        pandas.core.groupby.DataFrameGroupBy.cumprod\
-        pandas.core.groupby.DataFrameGroupBy.cumsum\
-        pandas.core.groupby.DataFrameGroupBy.filter\
-        pandas.core.groupby.DataFrameGroupBy.pct_change\
-        pandas.core.groupby.DataFrameGroupBy.rolling\
-        pandas.core.groupby.SeriesGroupBy.cummax\
-        pandas.core.groupby.SeriesGroupBy.cummin\
-        pandas.core.groupby.SeriesGroupBy.cumprod\
-        pandas.core.groupby.SeriesGroupBy.cumsum\
         pandas.core.groupby.SeriesGroupBy.filter\
-        pandas.core.groupby.SeriesGroupBy.nunique\
-        pandas.core.groupby.SeriesGroupBy.pct_change\
-        pandas.core.groupby.SeriesGroupBy.rolling\
         pandas.core.resample.Resampler.max\
         pandas.core.resample.Resampler.min\
         pandas.core.resample.Resampler.quantile\

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -719,29 +719,26 @@ class SeriesGroupBy(GroupBy[Series]):
         filtered = self._apply_filter(indices, dropna)
         return filtered
 
-    _nunique_extra_params = dedent(
+    def nunique(self, dropna: bool = True) -> Series | DataFrame:
         """
+        Return number of unique elements in the group.
+
         Parameters
         ----------
         dropna : bool, default True
             Don't include NaN in the counts.
-        """
-    )
 
-    @doc(extra_params=_nunique_extra_params)
-    def nunique(self, dropna: bool = True) -> Series | DataFrame:
-        """
-        Return number of unique elements in the group.
-        {extra_params}
         Returns
         -------
         Series
             Number of unique values within each group.
 
+        See Also
+        --------
+        core.resample.Resampler.nunique : Method nunique for Resampler.
+
         Examples
         --------
-        For SeriesGroupby:
-
         >>> lst = ["a", "a", "b", "b"]
         >>> ser = pd.Series([1, 2, 3, 3], index=lst)
         >>> ser
@@ -754,25 +751,6 @@ class SeriesGroupBy(GroupBy[Series]):
         a    2
         b    1
         dtype: int64
-
-        For Resampler:
-
-        >>> ser = pd.Series(
-        ...     [1, 2, 3, 3],
-        ...     index=pd.DatetimeIndex(
-        ...         ["2023-01-01", "2023-01-15", "2023-02-01", "2023-02-15"]
-        ...     ),
-        ... )
-        >>> ser
-        2023-01-01    1
-        2023-01-15    2
-        2023-02-01    3
-        2023-02-15    3
-        dtype: int64
-        >>> ser.resample("MS").nunique()
-        2023-01-01    2
-        2023-02-01    1
-        Freq: MS, dtype: int64
         """
         ids, ngroups = self._grouper.group_info
         val = self.obj._values

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -723,6 +723,11 @@ class SeriesGroupBy(GroupBy[Series]):
         """
         Return number of unique elements in the group.
 
+        Parameters
+        ----------
+        dropna : bool, default True
+            Don't include NaN in the counts.
+
         Returns
         -------
         Series
@@ -1942,6 +1947,10 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         dropna : bool
             Drop groups that do not pass the filter. True by default; if False,
             groups that evaluate False are filled with NaNs.
+        *args
+            Additional positional arguments to pass to `func`.
+        **kwargs
+            Additional keyword arguments to pass to `func`.
 
         Returns
         -------

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -719,15 +719,20 @@ class SeriesGroupBy(GroupBy[Series]):
         filtered = self._apply_filter(indices, dropna)
         return filtered
 
-    def nunique(self, dropna: bool = True) -> Series | DataFrame:
+    _nunique_extra_params = dedent(
         """
-        Return number of unique elements in the group.
-
         Parameters
         ----------
         dropna : bool, default True
             Don't include NaN in the counts.
+        """
+    )
 
+    @doc(extra_params=_nunique_extra_params)
+    def nunique(self, dropna: bool = True) -> Series | DataFrame:
+        """
+        Return number of unique elements in the group.
+        {extra_params}
         Returns
         -------
         Series

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -4867,8 +4867,8 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         numeric_only : bool, default False
             Include only `float`, `int` or `boolean` data.
         **kwargs : dict, optional
-            Additional keyword arguments to be passed to the function, such as `skipna`, to control whether
-            NA/null values are ignored.
+            Additional keyword arguments to be passed to the function, such as `skipna`,
+            to control whether NA/null values are ignored.
 
         Returns
         -------

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -4672,6 +4672,13 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         """
         Cumulative product for each group.
 
+        Parameters
+        ----------
+        *args : tuple
+            Positional arguments to be passed to `func`.
+        **kwargs : dict
+            Additional/specific keyword arguments to be passed to the function, such as `numeric_only` and `skipna`.
+
         Returns
         -------
         Series or DataFrame
@@ -4721,6 +4728,13 @@ class GroupBy(BaseGroupBy[NDFrameT]):
     def cumsum(self, *args, **kwargs) -> NDFrameT:
         """
         Cumulative sum for each group.
+        
+        Parameters
+        ----------
+        *args : tuple
+            Positional arguments to be passed to `func`.
+        **kwargs : dict
+            Additional/specific keyword arguments to be passed to the function, such as `numeric_only` and `skipna`.
 
         Returns
         -------
@@ -4775,6 +4789,14 @@ class GroupBy(BaseGroupBy[NDFrameT]):
     ) -> NDFrameT:
         """
         Cumulative min for each group.
+
+        Parameters
+        ----------
+        numeric_only : bool, default False
+            Include only `float`, `int` or `boolean` data.
+        **kwargs : dict, optional
+            Additional keyword arguments to be passed to the function, such as `skipna`, to control whether
+            NA/null values are ignored.
 
         Returns
         -------
@@ -4837,6 +4859,14 @@ class GroupBy(BaseGroupBy[NDFrameT]):
     ) -> NDFrameT:
         """
         Cumulative max for each group.
+
+        Parameters
+        ----------
+        numeric_only : bool, default False
+            Include only `float`, `int` or `boolean` data.
+        **kwargs : dict, optional
+            Additional keyword arguments to be passed to the function, such as `skipna`, to control whether
+            NA/null values are ignored.
 
         Returns
         -------
@@ -5133,6 +5163,32 @@ class GroupBy(BaseGroupBy[NDFrameT]):
     ):
         """
         Calculate pct_change of each value to previous entry in group.
+
+        Parameters
+        ----------
+        periods : int, default 1
+            Periods to shift for calculating percentage change. (E.g., 1
+            compares adjacent elements, while a period of 2 compares every other element).
+
+        fill_method : FillnaOptions or None, default None
+            This parameter specifies how to handle missing values after the initial shift operation
+            that is necessary for calculating the percentage change. In future versions, users will be
+            encouraged to manually handle missing values prior to using `pct_change`. Options for fill methods
+            (when explicitly specified) are as follows:
+            
+            - A FillnaOptions value (e.g., 'ffill', 'bfill') to specify forward or backward filling.
+            - None to indicate that no filling should be performed.
+
+            Note: Direct use of this parameter is discouraged due to the impending deprecation.
+
+        limit : int or None, default None
+            The maximum number of consecutive NA values to forward or backward fill, depending on the
+            `fill_method` chosen. This parameter's functionality is also subject to deprecation, and it is 
+            recommended that NaN values be addressed prior to calling `pct_change`.
+
+        freq : str, pandas offset object or None, default None
+            Increment to use from time series API (e.g., 'M' for month-end frequency). This parameter is
+            only relevant if the data is time series. If None, the frequency inferred from the index will be used.
 
         Returns
         -------

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -4677,7 +4677,8 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         *args : tuple
             Positional arguments to be passed to `func`.
         **kwargs : dict
-            Additional/specific keyword arguments to be passed to the function, such as `numeric_only` and `skipna`.
+            Additional/specific keyword arguments to be passed to the function,
+            such as `numeric_only` and `skipna`.
 
         Returns
         -------
@@ -4734,7 +4735,8 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         *args : tuple
             Positional arguments to be passed to `func`.
         **kwargs : dict
-            Additional/specific keyword arguments to be passed to the function, such as `numeric_only` and `skipna`.
+            Additional/specific keyword arguments to be passed to the function,
+            such as `numeric_only` and `skipna`.
 
         Returns
         -------
@@ -4795,8 +4797,8 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         numeric_only : bool, default False
             Include only `float`, `int` or `boolean` data.
         **kwargs : dict, optional
-            Additional keyword arguments to be passed to the function, such as `skipna`, to control whether
-            NA/null values are ignored.
+            Additional keyword arguments to be passed to the function, such as `skipna`,
+            to control whether NA/null values are ignored.
 
         Returns
         -------
@@ -5167,28 +5169,28 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         Parameters
         ----------
         periods : int, default 1
-            Periods to shift for calculating percentage change. (E.g., 1
-            compares adjacent elements, while a period of 2 compares every other element).
+            Periods to shift for calculating percentage change. Comparing with 
+            a period of 1 means adjacent elements are compared, whereas a period 
+            of 2 compares every other element.
 
         fill_method : FillnaOptions or None, default None
-            This parameter specifies how to handle missing values after the initial shift operation
-            that is necessary for calculating the percentage change. In future versions, users will be
-            encouraged to manually handle missing values prior to using `pct_change`. Options for fill methods
-            (when explicitly specified) are as follows:
-            
-            - A FillnaOptions value (e.g., 'ffill', 'bfill') to specify forward or backward filling.
-            - None to indicate that no filling should be performed.
-
-            Note: Direct use of this parameter is discouraged due to the impending deprecation.
+            Specifies how to handle missing values after the initial shift 
+            operation necessary for percentage change calculation. Users are 
+            encouraged to handle missing values manually in future versions. 
+            Valid options are:
+            - A FillnaOptions value ('ffill', 'bfill') for forward or backward filling.
+            - None to avoid filling.
+            Note: Usage is discouraged due to impending deprecation.
 
         limit : int or None, default None
-            The maximum number of consecutive NA values to forward or backward fill, depending on the
-            `fill_method` chosen. This parameter's functionality is also subject to deprecation, and it is 
-            recommended that NaN values be addressed prior to calling `pct_change`.
+            The maximum number of consecutive NA values to fill, based on the chosen 
+            `fill_method`. Address NaN values prior to using `pct_change` as this 
+            parameter is nearing deprecation.
 
-        freq : str, pandas offset object or None, default None
-            Increment to use from time series API (e.g., 'M' for month-end frequency). This parameter is
-            only relevant if the data is time series. If None, the frequency inferred from the index will be used.
+        freq : str, pandas offset object, or None, default None
+            The frequency increment for time series data (e.g., 'M' for month-end). 
+            If None, the frequency is inferred from the index. Relevant for time 
+            series data only.
 
         Returns
         -------

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -4729,7 +4729,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
     def cumsum(self, *args, **kwargs) -> NDFrameT:
         """
         Cumulative sum for each group.
-        
+
         Parameters
         ----------
         *args : tuple
@@ -5169,27 +5169,27 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         Parameters
         ----------
         periods : int, default 1
-            Periods to shift for calculating percentage change. Comparing with 
-            a period of 1 means adjacent elements are compared, whereas a period 
+            Periods to shift for calculating percentage change. Comparing with
+            a period of 1 means adjacent elements are compared, whereas a period
             of 2 compares every other element.
 
         fill_method : FillnaOptions or None, default None
-            Specifies how to handle missing values after the initial shift 
-            operation necessary for percentage change calculation. Users are 
-            encouraged to handle missing values manually in future versions. 
+            Specifies how to handle missing values after the initial shift
+            operation necessary for percentage change calculation. Users are
+            encouraged to handle missing values manually in future versions.
             Valid options are:
             - A FillnaOptions value ('ffill', 'bfill') for forward or backward filling.
             - None to avoid filling.
             Note: Usage is discouraged due to impending deprecation.
 
         limit : int or None, default None
-            The maximum number of consecutive NA values to fill, based on the chosen 
-            `fill_method`. Address NaN values prior to using `pct_change` as this 
+            The maximum number of consecutive NA values to fill, based on the chosen
+            `fill_method`. Address NaN values prior to using `pct_change` as this
             parameter is nearing deprecation.
 
         freq : str, pandas offset object, or None, default None
-            The frequency increment for time series data (e.g., 'M' for month-end). 
-            If None, the frequency is inferred from the index. Relevant for time 
+            The frequency increment for time series data (e.g., 'M' for month-end).
+            If None, the frequency is inferred from the index. Relevant for time
             series data only.
 
         Returns

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -68,6 +68,10 @@ class Grouper:
 
     Parameters
     ----------
+    *args
+        Currently unused, reserved for future use.
+    **kwargs
+        Dictionary of the keyword arguments to pass to Grouper.
     key : str, defaults to None
         Groupby key, which selects the grouping column of the target.
     level : name/number, defaults to None

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -59,7 +59,6 @@ from pandas.core.generic import (
     NDFrame,
     _shared_docs,
 )
-from pandas.core.groupby.generic import SeriesGroupBy
 from pandas.core.groupby.groupby import (
     BaseGroupBy,
     GroupBy,
@@ -1358,8 +1357,38 @@ class Resampler(BaseGroupBy, PandasObject):
         return self._downsample("ohlc")
 
     @final
-    @doc(SeriesGroupBy.nunique, extra_params="")
     def nunique(self):
+        """
+        Return number of unique elements in the group.
+
+        Returns
+        -------
+        Series
+            Number of unique values within each group.
+
+        See Also
+        --------
+        core.groupby.SeriesGroupBy.nunique : Method nunique for SeriesGroupBy.
+
+        Examples
+        --------
+        >>> ser = pd.Series(
+        ...     [1, 2, 3, 3],
+        ...     index=pd.DatetimeIndex(
+        ...         ["2023-01-01", "2023-01-15", "2023-02-01", "2023-02-15"]
+        ...     ),
+        ... )
+        >>> ser
+        2023-01-01    1
+        2023-01-15    2
+        2023-02-01    3
+        2023-02-15    3
+        dtype: int64
+        >>> ser.resample("MS").nunique()
+        2023-01-01    2
+        2023-02-01    1
+        Freq: MS, dtype: int64
+        """
         return self._downsample("nunique")
 
     @final

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -59,7 +59,6 @@ from pandas.core.generic import (
     NDFrame,
     _shared_docs,
 )
-from pandas.core.groupby.generic import SeriesGroupBy
 from pandas.core.groupby.groupby import (
     BaseGroupBy,
     GroupBy,

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -59,6 +59,7 @@ from pandas.core.generic import (
     NDFrame,
     _shared_docs,
 )
+from pandas.core.groupby.generic import SeriesGroupBy
 from pandas.core.groupby.groupby import (
     BaseGroupBy,
     GroupBy,

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1358,7 +1358,7 @@ class Resampler(BaseGroupBy, PandasObject):
         return self._downsample("ohlc")
 
     @final
-    @doc(SeriesGroupBy.nunique)
+    @doc(SeriesGroupBy.nunique, extra_params="")
     def nunique(self):
         return self._downsample("nunique")
 


### PR DESCRIPTION
Fixed PR01 errors (#57438) and added parameter descriptions for:
- `pandas.Grouper`
- `pandas.core.groupby.DataFrameGroupBy.cummax`
- `pandas.core.groupby.DataFrameGroupBy.cummin`
- `pandas.core.groupby.DataFrameGroupBy.cumprod`
- `pandas.core.groupby.DataFrameGroupBy.cumsum`
- `pandas.core.groupby.DataFrameGroupBy.filter`
- `pandas.core.groupby.DataFrameGroupBy.pct_change`
- `pandas.core.groupby.DataFrameGroupBy.rolling`
- `pandas.core.groupby.SeriesGroupBy.nunique`
- `pandas.core.groupby.SeriesGroupBy.cummax`
- `pandas.core.groupby.SeriesGroupBy.cummin`
- `pandas.core.groupby.SeriesGroupBy.cumprod`
- `pandas.core.groupby.SeriesGroupBy.cumsum`
- `pandas.core.groupby.SeriesGroupBy.cumprod`

Fixed functions also removed from code_checks.sh
