### PR TITLE
TST: add a test for selecting columns in DataFrame with `big-endian` dtype

### DIFF
--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -1537,6 +1537,16 @@ class TestDataFrameIndexing:
         expected = DataFrame([[1, np.nan], [2, np.nan], ["3", np.nan]], dtype=object)
         tm.assert_frame_equal(df, expected)
 
+    def test_big_endian_support_selecting_columns(self):
+        # GH#57457
+        columns = ["a"]
+        data = [np.array([1, 2], dtype=">f8")]
+        df = DataFrame(dict(zip(columns, data)))
+        result = df[df.columns]
+        dfexp = DataFrame({"a": [1, 2]}, dtype=">f8")
+        expected = dfexp[dfexp.columns]
+        tm.assert_frame_equal(result, expected)
+
 
 class TestDataFrameIndexingUInt64:
     def test_setitem(self):


### PR DESCRIPTION
- [x] closes #57457
 
added a test in to check that selecting columns in DataFrame with `big-endian` dtype is supported