### PR TITLE
TST: Allow test_dti_constructor_with_non_nano_now_today to be flaky

### DIFF
--- a/pandas/tests/indexes/datetimes/test_constructors.py
+++ b/pandas/tests/indexes/datetimes/test_constructors.py
@@ -1031,23 +1031,23 @@ class TestDatetimeIndex:
         result2 = DatetimeIndex(np.array(vals, dtype=object), dtype=dtype)
         tm.assert_index_equal(result2, expected)
 
-    def test_dti_constructor_with_non_nano_now_today(self):
+    def test_dti_constructor_with_non_nano_now_today(self, request):
         # GH#55756
         now = Timestamp.now()
         today = Timestamp.today()
         result = DatetimeIndex(["now", "today"], dtype="M8[s]")
         assert result.dtype == "M8[s]"
 
-        # result may not exactly match [now, today] so we'll test it up to a tolerance.
-        #  (it *may* match exactly due to rounding)
-        tolerance = pd.Timedelta(seconds=1)
-
         diff0 = result[0] - now.as_unit("s")
-        assert diff0 >= pd.Timedelta(0), f"The difference is {diff0}"
-        assert diff0 < tolerance, f"The difference is {diff0}"
-
         diff1 = result[1] - today.as_unit("s")
         assert diff1 >= pd.Timedelta(0), f"The difference is {diff0}"
+        assert diff0 >= pd.Timedelta(0), f"The difference is {diff0}"
+
+        # result may not exactly match [now, today] so we'll test it up to a tolerance.
+        #  (it *may* match exactly due to rounding)
+        request.applymarker(pytest.mark.xfail(strict=False))
+        tolerance = pd.Timedelta(seconds=1)
+        assert diff0 < tolerance, f"The difference is {diff0}"
         assert diff1 < tolerance, f"The difference is {diff0}"
 
     def test_dti_constructor_object_float_matches_float_dtype(self):

--- a/pandas/tests/indexes/datetimes/test_constructors.py
+++ b/pandas/tests/indexes/datetimes/test_constructors.py
@@ -1046,7 +1046,11 @@ class TestDatetimeIndex:
         # result may not exactly match [now, today] so we'll test it up to a tolerance.
         #  (it *may* match exactly due to rounding)
         # GH 57535
-        request.applymarker(pytest.mark.xfail(strict=False))
+        request.applymarker(
+            pytest.mark.xfail(
+                reason="result may not exactly match [now, today]", strict=False
+            )
+        )
         tolerance = pd.Timedelta(seconds=1)
         assert diff0 < tolerance, f"The difference is {diff0}"
         assert diff1 < tolerance, f"The difference is {diff0}"

--- a/pandas/tests/indexes/datetimes/test_constructors.py
+++ b/pandas/tests/indexes/datetimes/test_constructors.py
@@ -1045,6 +1045,7 @@ class TestDatetimeIndex:
 
         # result may not exactly match [now, today] so we'll test it up to a tolerance.
         #  (it *may* match exactly due to rounding)
+        # GH 57535
         request.applymarker(pytest.mark.xfail(strict=False))
         tolerance = pd.Timedelta(seconds=1)
         assert diff0 < tolerance, f"The difference is {diff0}"


### PR DESCRIPTION
I see this test occasionally fail e.g. https://github.com/pandas-dev/pandas/actions/runs/7977358781/job/21780077825?pr=57510

It's probably best in the long run if we can find a way to make now/today be deterministic