### PR TITLE
PERF: Return RangeIndex from RangeIndex.join when possible

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -165,7 +165,7 @@ Removal of prior version deprecations/changes
 
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
-- :meth:`RangeIndex.join` returns a :class:`RangeIndex` instead of a :class:`Index` when appending values that could continue the :class:`RangeIndex` (:issue:`57467`)
+- :meth:`RangeIndex.join` returns a :class:`RangeIndex` instead of a :class:`Index` when appending values that could continue the :class:`RangeIndex` (:issue:`57543`)
 - Performance improvement in :meth:`DataFrame.join` for sorted but non-unique indexes (:issue:`56941`)
 - Performance improvement in :meth:`DataFrame.join` when left and/or right are non-unique and ``how`` is ``"left"``, ``"right"``, or ``"inner"`` (:issue:`56817`)
 - Performance improvement in :meth:`DataFrame.join` with ``how="left"`` or ``how="right"`` and ``sort=True`` (:issue:`56919`)

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -165,6 +165,7 @@ Removal of prior version deprecations/changes
 
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
+- :meth:`RangeIndex.join` returns a :class:`RangeIndex` instead of a :class:`Index` when appending values that could continue the :class:`RangeIndex` (:issue:`57467`)
 - Performance improvement in :meth:`DataFrame.join` for sorted but non-unique indexes (:issue:`56941`)
 - Performance improvement in :meth:`DataFrame.join` when left and/or right are non-unique and ``how`` is ``"left"``, ``"right"``, or ``"inner"`` (:issue:`56817`)
 - Performance improvement in :meth:`DataFrame.join` with ``how="left"`` or ``how="right"`` and ``sort=True`` (:issue:`56919`)

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
     from pandas._typing import (
         Axis,
         Dtype,
+        JoinHow,
         NaPosition,
         Self,
         npt,
@@ -1015,6 +1016,22 @@ class RangeIndex(Index):
         # Here all "indexes" had 0 length, i.e. were empty.
         # In this case return an empty range index.
         return RangeIndex(_empty_range, name=name)
+
+    def _wrap_join_result(
+        self,
+        joined,
+        other,
+        lidx: npt.NDArray[np.intp] | None,
+        ridx: npt.NDArray[np.intp] | None,
+        how: JoinHow,
+    ) -> tuple[Self, npt.NDArray[np.intp] | None, npt.NDArray[np.intp] | None]:
+        join_index, lidx, ridx = super()._wrap_join_result(
+            joined, other, lidx, ridx, how
+        )
+        maybe_ri = self._shallow_copy(join_index._values)
+        if isinstance(maybe_ri, type(self)):
+            return maybe_ri, lidx, ridx
+        return join_index, lidx, ridx
 
     def __len__(self) -> int:
         """

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -397,7 +397,7 @@ class BaseMethodsTests:
         b = pd.Series(data[2:5], index=[2, 3, 4])
         result = a.combine_first(b)
         expected = pd.Series(data[:5])
-        tm.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected, check_index_type=True)
 
     @pytest.mark.parametrize("frame", [True, False])
     @pytest.mark.parametrize(

--- a/pandas/tests/indexes/ranges/test_join.py
+++ b/pandas/tests/indexes/ranges/test_join.py
@@ -175,3 +175,9 @@ class TestJoin:
         index = RangeIndex(start=0, stop=20, step=2)
         joined = index.join(index, how=join_type)
         assert index is joined
+
+
+def test_join_overlap_returns_rangeindex():
+    result = RangeIndex(3).join(RangeIndex(2, 5), how="outer")
+    expected = RangeIndex(5)
+    tm.assert_index_equal(result, expected, exact=True)


### PR DESCRIPTION
Discovered in https://github.com/pandas-dev/pandas/pull/57441