### PR TITLE
PERF: Improve merge performance

### DIFF
--- a/pandas/_libs/hashtable.pyx
+++ b/pandas/_libs/hashtable.pyx
@@ -111,6 +111,7 @@ cdef class ObjectFactorizer(Factorizer):
         """
         cdef:
             ndarray[intp_t] labels
+            bint seen_na
 
         if mask is not None:
             raise NotImplementedError("mask not supported for ObjectFactorizer.")
@@ -119,7 +120,7 @@ cdef class ObjectFactorizer(Factorizer):
             uniques = ObjectVector()
             uniques.extend(self.uniques.to_array())
             self.uniques = uniques
-        labels = self.table.get_labels(values, self.uniques,
-                                       self.count, na_sentinel, na_value)
+        labels, seen_na = self.table.get_labels(values, self.uniques,
+                                                self.count, na_sentinel, na_value)
         self.count = len(self.uniques)
-        return labels
+        return labels, seen_na

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -595,7 +595,8 @@ cdef class {{name}}HashTable(HashTable):
     def _unique(self, const {{dtype}}_t[:] values, {{name}}Vector uniques,
                 Py_ssize_t count_prior=0, Py_ssize_t na_sentinel=-1,
                 object na_value=None, bint ignore_na=False,
-                object mask=None, bint return_inverse=False, bint use_result_mask=False):
+                object mask=None, bint return_inverse=False, bint use_result_mask=False,
+                bint return_labels_only=False):
         """
         Calculate unique values and labels (no sorting!)
 
@@ -684,6 +685,7 @@ cdef class {{name}}HashTable(HashTable):
                 if ignore_na and use_mask:
                     if mask_values[i]:
                         labels[i] = na_sentinel
+                        seen_na = True
                         continue
                 elif ignore_na and (
                    is_nan_{{c_type}}(val) or
@@ -693,6 +695,7 @@ cdef class {{name}}HashTable(HashTable):
                     # ignore_na is True), skip the hashtable entry for them,
                     # and replace the corresponding label with na_sentinel
                     labels[i] = na_sentinel
+                    seen_na = True
                     continue
                 elif not ignore_na and use_result_mask:
                     if mask_values[i]:
@@ -749,6 +752,8 @@ cdef class {{name}}HashTable(HashTable):
                     idx = self.table.vals[k]
                     labels[i] = idx
 
+        if return_inverse and return_labels_only:
+            return labels.base, seen_na  # .base -> underlying ndarray
         if return_inverse:
             return uniques.to_array(), labels.base  # .base -> underlying ndarray
         if use_result_mask:
@@ -824,10 +829,11 @@ cdef class {{name}}HashTable(HashTable):
                    Py_ssize_t count_prior=0, Py_ssize_t na_sentinel=-1,
                    object na_value=None, object mask=None):
         # -> np.ndarray[np.intp]
-        _, labels = self._unique(values, uniques, count_prior=count_prior,
+        labels, seen_na = self._unique(values, uniques, count_prior=count_prior,
                                  na_sentinel=na_sentinel, na_value=na_value,
-                                 ignore_na=True, return_inverse=True, mask=mask)
-        return labels
+                                 ignore_na=True, return_inverse=True, mask=mask,
+                                 return_labels_only=True)
+        return labels, seen_na
 
     {{if dtype == 'int64'}}
     @cython.boundscheck(False)
@@ -904,16 +910,17 @@ cdef class {{name}}Factorizer(Factorizer):
         """
         cdef:
             ndarray[intp_t] labels
+            bint seen_na
 
         if self.uniques.external_view_exists:
             uniques = {{name}}Vector()
             uniques.extend(self.uniques.to_array())
             self.uniques = uniques
-        labels = self.table.get_labels(values, self.uniques,
+        labels, seen_na = self.table.get_labels(values, self.uniques,
                                        self.count, na_sentinel,
                                        na_value=na_value, mask=mask)
         self.count = len(self.uniques)
-        return labels
+        return labels, seen_na
 
 {{endfor}}
 
@@ -1080,7 +1087,7 @@ cdef class StringHashTable(HashTable):
     def _unique(self, ndarray[object] values, ObjectVector uniques,
                 Py_ssize_t count_prior=0, Py_ssize_t na_sentinel=-1,
                 object na_value=None, bint ignore_na=False,
-                bint return_inverse=False):
+                bint return_inverse=False, bint return_labels_only=False):
         """
         Calculate unique values and labels (no sorting!)
 
@@ -1123,7 +1130,7 @@ cdef class StringHashTable(HashTable):
             const char *v
             const char **vecs
             khiter_t k
-            bint use_na_value
+            bint use_na_value, seen_na = False
 
         if return_inverse:
             labels = np.zeros(n, dtype=np.intp)
@@ -1142,6 +1149,7 @@ cdef class StringHashTable(HashTable):
                 # ignore_na is True), we can skip the actual value, and
                 # replace the label with na_sentinel directly
                 labels[i] = na_sentinel
+                seen_na = True
             else:
                 # if ignore_na is False, we also stringify NaN/None/etc.
                 try:
@@ -1179,6 +1187,8 @@ cdef class StringHashTable(HashTable):
         for i in range(count):
             uniques.append(values[uindexer[i]])
 
+        if return_inverse and return_labels_only:
+            return labels.base, seen_na  # .base -> underlying ndarray
         if return_inverse:
             return uniques.to_array(), labels.base  # .base -> underlying ndarray
         return uniques.to_array()
@@ -1247,10 +1257,11 @@ cdef class StringHashTable(HashTable):
                    Py_ssize_t count_prior=0, Py_ssize_t na_sentinel=-1,
                    object na_value=None, object mask=None):
         # -> np.ndarray[np.intp]
-        _, labels = self._unique(values, uniques, count_prior=count_prior,
+        labels, seen_na = self._unique(values, uniques, count_prior=count_prior,
                                  na_sentinel=na_sentinel, na_value=na_value,
-                                 ignore_na=True, return_inverse=True)
-        return labels
+                                 ignore_na=True, return_inverse=True,
+                                 return_labels_only=True)
+        return labels, seen_na
 
 
 cdef class PyObjectHashTable(HashTable):
@@ -1362,7 +1373,7 @@ cdef class PyObjectHashTable(HashTable):
     def _unique(self, ndarray[object] values, ObjectVector uniques,
                 Py_ssize_t count_prior=0, Py_ssize_t na_sentinel=-1,
                 object na_value=None, bint ignore_na=False,
-                bint return_inverse=False):
+                bint return_inverse=False, bint return_labels_only=False):
         """
         Calculate unique values and labels (no sorting!)
 
@@ -1402,7 +1413,7 @@ cdef class PyObjectHashTable(HashTable):
             int ret = 0
             object val
             khiter_t k
-            bint use_na_value
+            bint use_na_value, seen_na=False
 
         if return_inverse:
             labels = np.empty(n, dtype=np.intp)
@@ -1420,6 +1431,7 @@ cdef class PyObjectHashTable(HashTable):
                 # ignore_na is True), skip the hashtable entry for them, and
                 # replace the corresponding label with na_sentinel
                 labels[i] = na_sentinel
+                seen_na = True
                 continue
 
             k = kh_get_pymap(self.table, <PyObject*>val)
@@ -1437,6 +1449,8 @@ cdef class PyObjectHashTable(HashTable):
                 idx = self.table.vals[k]
                 labels[i] = idx
 
+        if return_inverse and return_labels_only:
+            return labels.base, seen_na  # .base -> underlying ndarray
         if return_inverse:
             return uniques.to_array(), labels.base  # .base -> underlying ndarray
         return uniques.to_array()
@@ -1505,7 +1519,8 @@ cdef class PyObjectHashTable(HashTable):
                    Py_ssize_t count_prior=0, Py_ssize_t na_sentinel=-1,
                    object na_value=None, object mask=None):
         # -> np.ndarray[np.intp]
-        _, labels = self._unique(values, uniques, count_prior=count_prior,
+        labels, seen_na = self._unique(values, uniques, count_prior=count_prior,
                                  na_sentinel=na_sentinel, na_value=na_value,
-                                 ignore_na=True, return_inverse=True)
-        return labels
+                                 ignore_na=True, return_inverse=True,
+                                 return_labels_only=True)
+        return labels, seen_na

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -217,9 +217,10 @@ class TestFactorize:
         key = np.array([1, 2, 1, np.nan], dtype="O")
         rizer = ht.ObjectFactorizer(len(key))
         for na_sentinel in (-1, 20):
-            ids = rizer.factorize(key, na_sentinel=na_sentinel)
+            ids, seen_na = rizer.factorize(key, na_sentinel=na_sentinel)
             expected = np.array([0, 1, 0, na_sentinel], dtype=np.intp)
             assert len(set(key)) == len(set(expected))
+            assert seen_na
             tm.assert_numpy_array_equal(pd.isna(key), expected == na_sentinel)
             tm.assert_numpy_array_equal(ids, expected)
 
@@ -228,9 +229,10 @@ class TestFactorize:
         data = np.array([1, 2, 3, 1, 1, 0], dtype="int64")
         mask = np.array([False, False, False, False, False, True])
         rizer = ht.Int64Factorizer(len(data))
-        result = rizer.factorize(data, mask=mask)
+        result, seen_na = rizer.factorize(data, mask=mask)
         expected = np.array([0, 1, 2, 0, 0, -1], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
+        assert seen_na
         expected_uniques = np.array([1, 2, 3], dtype="int64")
         tm.assert_numpy_array_equal(rizer.uniques.to_array(), expected_uniques)
 
@@ -238,9 +240,10 @@ class TestFactorize:
         # GH#49549
         data = np.array([1, 2, 3, 1, np.nan])
         rizer = ht.ObjectFactorizer(len(data))
-        result = rizer.factorize(data.astype(object))
+        result, seen_na = rizer.factorize(data.astype(object))
         expected = np.array([0, 1, 2, 0, -1], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
+        assert seen_na
         expected_uniques = np.array([1, 2, 3], dtype=object)
         tm.assert_numpy_array_equal(rizer.uniques.to_array(), expected_uniques)
 


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

this avoids a bunch of unnecessary checks, might be worth it


```
| Change   | Before [b2b1aae3] <merge~1>   | After [aebecfe9] <merge>   |   Ratio | Benchmark (Parameter)                                                                       |
|----------|-------------------------------|----------------------------|---------|---------------------------------------------------------------------------------------------|
| -        | 46.9±3μs                      | 41.9±0.5μs                 |    0.89 | join_merge.ConcatIndexDtype.time_concat_series('string[pyarrow]', 'monotonic', 0, True)     |
| -        | 210±7ms                       | 187±5ms                    |    0.89 | join_merge.I8Merge.time_i8merge('left')                                                     |
| -        | 2.11±0.2ms                    | 1.88±0.01ms                |    0.89 | join_merge.MergeEA.time_merge('Float32', False)                                             |
| -        | 17.1±3ms                      | 15.2±0.2ms                 |    0.89 | join_merge.MergeMultiIndex.time_merge_sorted_multiindex(('int64', 'int64'), 'inner')        |
| -        | 1.06±0.04ms                   | 907±20μs                   |    0.86 | join_merge.Merge.time_merge_dataframe_integer_2key(False)                                   |
| -        | 7.99±0.9ms                    | 6.82±0.06ms                |    0.85 | join_merge.ConcatIndexDtype.time_concat_series('string[pyarrow]', 'non_monotonic', 1, True) |
| -        | 224±10ms                      | 191±6ms                    |    0.85 | join_merge.I8Merge.time_i8merge('inner')                                                    |
| -        | 513±90μs                      | 425±5μs                    |    0.83 | join_merge.ConcatIndexDtype.time_concat_series('string[python]', 'monotonic', 0, False)     |
| -        | 519±100μs                     | 421±2μs                    |    0.81 | join_merge.ConcatIndexDtype.time_concat_series('string[python]', 'non_monotonic', 0, False) |
| -        | 1.18±0.6ms                    | 751±7μs                    |    0.63 | join_merge.ConcatIndexDtype.time_concat_series('int64[pyarrow]', 'has_na', 1, False)        |

```