### PR TITLE
PERF: Switch conditions in RangeIndex._shallow_copy

### DIFF
--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -474,8 +474,9 @@ class RangeIndex(Index):
             diff = values[1] - values[0]
             if diff != 0:
                 maybe_range_indexer, remainder = np.divmod(values - values[0], diff)
-                if not remainder.any() and lib.is_range_indexer(
-                    maybe_range_indexer, len(maybe_range_indexer)
+                if (
+                    lib.is_range_indexer(maybe_range_indexer, len(maybe_range_indexer))
+                    and not remainder.any()
                 ):
                     new_range = range(values[0], values[-1] + diff, diff)
                     return type(self)._simple_new(new_range, name=name)


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/57534#issuecomment-1957832841

`is_range_indexer` lets us short circuit unlike checking the remainder

```python
In [1]: from pandas import *; import numpy as np
   ...: np.random.seed(123)
   ...: size = 1_000_000
   ...: ngroups = 1000
   ...: data = Series(np.random.randint(0, ngroups, size=size))
+ /opt/miniconda3/envs/pandas-dev/bin/ninja
[1/1] Generating write_version_file with a custom command

In [2]: %timeit data.groupby(data).groups
16.8 ms ± 183 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  # PR

In [3]: %timeit data.groupby(data).groups
17.6 ms ± 114 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  # main
```