### PR TITLE
DOC: fixing PR01 errors for pandas.Categorical and pandas.Categorical.__array__

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -1459,8 +1459,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
 
     MSG='Partially validate docstrings (PR01)' ;  echo $MSG
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=PR01 --ignore_functions \
-        pandas.Categorical\
-        pandas.Categorical.__array__\
         pandas.CategoricalIndex.equals\
         pandas.CategoricalIndex.map\
         pandas.DataFrame.at_time\

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1664,7 +1664,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
         Parameters
         ----------
-        dtype : NpDtype or None
+        dtype : np.dtype or None
             Specifies the the dtype for the array.
 
         Returns

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -276,6 +276,11 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         provided).
     dtype : CategoricalDtype
         An instance of ``CategoricalDtype`` to use for this categorical.
+    fastpath : bool
+        The 'fastpath' keyword in Categorical is deprecated and will be
+        removed in a future version. Use Categorical.from_codes instead.
+    copy : bool, default True
+        Whether to copy if the codes are unchanged.
 
     Attributes
     ----------
@@ -1656,6 +1661,11 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
     def __array__(self, dtype: NpDtype | None = None) -> np.ndarray:
         """
         The numpy array interface.
+
+        Parameters
+        ----------
+        dtype : NpDtype or None
+            Specifies the the dtype for the array.
 
         Returns
         -------


### PR DESCRIPTION
All PR01 Errors resolved in the following cases:

1. scripts/validate_docstrings.py --format=actions --errors=PR01 pandas.Categorical
2. scripts/validate_docstrings.py --format=actions --errors=PR01 pandas.Categorical.__array__

- [x] xref https://github.com/pandas-dev/pandas/issues/57438
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
