### PR TITLE
DOC: fixing GL08 errors for pandas.DatetimeIndex.as_unit and pandas.DatetimeIndex.freq

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -71,6 +71,7 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
 
     MSG='Partially validate docstrings (PR02)' ;  echo $MSG
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=PR02 --ignore_functions \
+        pandas.Series.dt.as_unit\
         pandas.Series.dt.to_period\
         pandas.Series.dt.tz_localize\
         pandas.Series.dt.tz_convert\
@@ -1494,6 +1495,7 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.Series.cat.rename_categories\
         pandas.Series.cat.reorder_categories\
         pandas.Series.cat.set_categories\
+        pandas.Series.dt.as_unit\
         pandas.Series.dt.ceil\
         pandas.Series.dt.day_name\
         pandas.Series.dt.floor\

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -143,8 +143,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
 
     MSG='Partially validate docstrings (GL08)' ;  echo $MSG
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=GL08 --ignore_functions \
-        pandas.DatetimeIndex.as_unit\
-        pandas.DatetimeIndex.freq\
         pandas.ExcelFile.book\
         pandas.ExcelFile.sheet_names\
         pandas.Index.empty\

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -2039,8 +2039,8 @@ class TimelikeOps(DatetimeLikeArrayMixin):
         """
         Return the frequency object if it is set, otherwise None.
 
-        To learn more about the frequency strings, please see `this link
-        <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases>`__.
+        To learn more about the frequency strings, please see
+        :ref:`this link<timeseries.offset_aliases>`
 
         See Also
         --------
@@ -2061,7 +2061,7 @@ class TimelikeOps(DatetimeLikeArrayMixin):
                       dtype='datetime64[ns, America/Chicago]', freq='h')
         >>> datetimeindex.freq
         <Hour>
-        """  # (http link too long)
+        """
         return self._freq
 
     @freq.setter

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -2180,6 +2180,9 @@ class TimelikeOps(DatetimeLikeArrayMixin):
         """
         Convert to a dtype with the given unit resolution.
 
+        The limits of timestamp representation depend on the chosen resolution.
+        Different resolutions can be converted to each other through as_unit.
+
         Parameters
         ----------
         unit : {'s', 'ms', 'us', 'ns'}
@@ -2189,6 +2192,7 @@ class TimelikeOps(DatetimeLikeArrayMixin):
         Returns
         -------
         same type as self
+            Converted to the specified unit.
 
         See Also
         --------

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -2151,6 +2151,37 @@ class TimelikeOps(DatetimeLikeArrayMixin):
         return dtype_to_unit(self.dtype)  # type: ignore[arg-type]
 
     def as_unit(self, unit: str, round_ok: bool = True) -> Self:
+        """
+        Convert to a dtype with the given unit resolution.
+
+        Parameters
+        ----------
+        unit : {'s', 'ms', 'us', 'ns'}
+
+        Returns
+        -------
+        same type as self
+
+        Examples
+        --------
+        For :class:`pandas.DatetimeIndex`:
+
+        >>> idx = pd.DatetimeIndex(["2020-01-02 01:02:03.004005006"])
+        >>> idx
+        DatetimeIndex(['2020-01-02 01:02:03.004005006'],
+                      dtype='datetime64[ns]', freq=None)
+        >>> idx.as_unit("s")
+        DatetimeIndex(['2020-01-02 01:02:03'], dtype='datetime64[s]', freq=None)
+
+        For :class:`pandas.TimedeltaIndex`:
+
+        >>> tdelta_idx = pd.to_timedelta(["1 day 3 min 2 us 42 ns"])
+        >>> tdelta_idx
+        TimedeltaIndex(['1 days 00:03:00.000002042'],
+                        dtype='timedelta64[ns]', freq=None)
+        >>> tdelta_idx.as_unit("s")
+        TimedeltaIndex(['1 days 00:03:00'], dtype='timedelta64[s]', freq=None)
+        """
         if unit not in ["s", "ms", "us", "ns"]:
             raise ValueError("Supported units are 's', 'ms', 'us', 'ns'")
 

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -2181,7 +2181,7 @@ class TimelikeOps(DatetimeLikeArrayMixin):
         ----------
         unit : {'s', 'ms', 'us', 'ns'}
         round_ok : bool, default True
-            If False and the conversion requires rounding, raise.
+            If False and the conversion requires rounding, raise ValueError.
 
         Returns
         -------

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -2040,7 +2040,7 @@ class TimelikeOps(DatetimeLikeArrayMixin):
         Return the frequency object if it is set, otherwise None.
 
         To learn more about the frequency strings, please see
-        :ref:`this link<timeseries.offset_aliases>`
+        :ref:`this link<timeseries.offset_aliases>`.
 
         See Also
         --------

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -2180,11 +2180,16 @@ class TimelikeOps(DatetimeLikeArrayMixin):
         Parameters
         ----------
         unit : {'s', 'ms', 'us', 'ns'}
-        round_ok : bool (default True)
+        round_ok : bool, default True
+            If False and the conversion requires rounding, raise.
 
         Returns
         -------
         same type as self
+
+        See Also
+        --------
+        Timestamp.as_unit : Convert to the given unit.
 
         Examples
         --------

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -2038,7 +2038,30 @@ class TimelikeOps(DatetimeLikeArrayMixin):
     def freq(self):
         """
         Return the frequency object if it is set, otherwise None.
-        """
+
+        To learn more about the frequency strings, please see `this link
+        <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases>`__.
+
+        See Also
+        --------
+        DatetimeIndex.freq : Return the frequency object if it is set, otherwise None.
+        PeriodIndex.freq : Return the frequency object if it is set, otherwise None.
+
+        Examples
+        --------
+        >>> datetimeindex = pd.date_range(
+        ...     "2022-02-22 02:22:22", periods=10, tz="America/Chicago", freq="h"
+        ... )
+        >>> datetimeindex
+        DatetimeIndex(['2022-02-22 02:22:22-06:00', '2022-02-22 03:22:22-06:00',
+                       '2022-02-22 04:22:22-06:00', '2022-02-22 05:22:22-06:00',
+                       '2022-02-22 06:22:22-06:00', '2022-02-22 07:22:22-06:00',
+                       '2022-02-22 08:22:22-06:00', '2022-02-22 09:22:22-06:00',
+                       '2022-02-22 10:22:22-06:00', '2022-02-22 11:22:22-06:00'],
+                      dtype='datetime64[ns, America/Chicago]', freq='h')
+        >>> datetimeindex.freq
+        <Hour>
+        """  # (http link too long)
         return self._freq
 
     @freq.setter
@@ -2157,6 +2180,7 @@ class TimelikeOps(DatetimeLikeArrayMixin):
         Parameters
         ----------
         unit : {'s', 'ms', 'us', 'ns'}
+        round_ok : bool (default True)
 
         Returns
         -------

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -96,7 +96,30 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
     def freq(self) -> BaseOffset | None:
         """
         Return the frequency object if it is set, otherwise None.
-        """
+
+        To learn more about the frequency strings, please see `this link
+        <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases>`__.
+
+        See Also
+        --------
+        DatetimeIndex.freq : Return the frequency object if it is set, otherwise None.
+        PeriodIndex.freq : Return the frequency object if it is set, otherwise None.
+
+        Examples
+        --------
+        >>> datetimeindex = pd.date_range(
+        ...     "2022-02-22 02:22:22", periods=10, tz="America/Chicago", freq="h"
+        ... )
+        >>> datetimeindex
+        DatetimeIndex(['2022-02-22 02:22:22-06:00', '2022-02-22 03:22:22-06:00',
+                       '2022-02-22 04:22:22-06:00', '2022-02-22 05:22:22-06:00',
+                       '2022-02-22 06:22:22-06:00', '2022-02-22 07:22:22-06:00',
+                       '2022-02-22 08:22:22-06:00', '2022-02-22 09:22:22-06:00',
+                       '2022-02-22 10:22:22-06:00', '2022-02-22 11:22:22-06:00'],
+                      dtype='datetime64[ns, America/Chicago]', freq='h')
+        >>> datetimeindex.freq
+        <Hour>
+        """  # (http link too long)
         return self._data.freq
 
     @freq.setter

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -94,6 +94,9 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
 
     @property
     def freq(self) -> BaseOffset | None:
+        """
+        Return the frequency object if it is set, otherwise None.
+        """
         return self._data.freq
 
     @freq.setter

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -98,7 +98,7 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
         Return the frequency object if it is set, otherwise None.
 
         To learn more about the frequency strings, please see
-        :ref:`this link<timeseries.offset_aliases>`
+        :ref:`this link<timeseries.offset_aliases>`.
 
         See Also
         --------

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -97,8 +97,8 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
         """
         Return the frequency object if it is set, otherwise None.
 
-        To learn more about the frequency strings, please see `this link
-        <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases>`__.
+        To learn more about the frequency strings, please see
+        :ref:`this link<timeseries.offset_aliases>`
 
         See Also
         --------
@@ -119,7 +119,7 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
                       dtype='datetime64[ns, America/Chicago]', freq='h')
         >>> datetimeindex.freq
         <Hour>
-        """  # (http link too long)
+        """
         return self._data.freq
 
     @freq.setter


### PR DESCRIPTION
All GL08 Errors resolved in the following cases:

1. scripts/validate_docstrings.py --format=actions --errors=GL08 pandas.DatetimeIndex.as_unit
2. scripts/validate_docstrings.py --format=actions --errors=GL08 pandas.DatetimeIndex.freq

_Note: [6232a2e](https://github.com/pandas-dev/pandas/pull/57562/commits/6232a2ed2590fb8d8b43658adc009688cb30dce2) commit message was a typo, this commit is for GL08 errors_

- [x] xref https://github.com/pandas-dev/pandas/issues/57443
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
