### PR TITLE
DOC: fix ES01 for pandas.Flags

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -521,7 +521,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.DatetimeIndex.year\
         pandas.DatetimeTZDtype.tz\
         pandas.DatetimeTZDtype.unit\
-        pandas.Flags\
         pandas.HDFStore.get\
         pandas.HDFStore.info\
         pandas.HDFStore.keys\

--- a/pandas/core/flags.py
+++ b/pandas/core/flags.py
@@ -11,6 +11,10 @@ class Flags:
     """
     Flags that apply to pandas objects.
 
+    “Flags” differ from “metadata”. Flags reflect properties of the pandas
+    object (the Series or DataFrame). Metadata refer to properties of the
+    dataset, and should be stored in DataFrame.attrs.
+
     Parameters
     ----------
     obj : Series or DataFrame
@@ -29,6 +33,11 @@ class Flags:
            propagate the ``allows_duplicate_labels`` value. In future versions
            it is expected that every method taking or returning one or more
            DataFrame or Series objects will propagate ``allows_duplicate_labels``.
+
+    See Also
+    --------
+    DataFrame.attrs : Dictionary of global attributes of this dataset.
+    Series.attrs : Dictionary of global attributes of this dataset.
 
     Examples
     --------


### PR DESCRIPTION
All ES01 Errors resolved in the following cases:

1. scripts/validate_docstrings.py --format=actions --errors=ES01 pandas.Flags

- [x] xref https://github.com/pandas-dev/pandas/issues/57440
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
