### PR TITLE
DEPS: update numexpr to use not buggy numexpr 2.8.x anymore (update to 2.9.0) - fix critical CVE-2023-39631⁠

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ matplotlib = "pandas:plotting._matplotlib"
 [project.optional-dependencies]
 test = ['hypothesis>=6.46.1', 'pytest>=7.3.2', 'pytest-xdist>=2.2.0']
 pyarrow = ['pyarrow>=10.0.1']
-performance = ['bottleneck>=1.3.6', 'numba>=0.56.4', 'numexpr>=2.8.4']
+performance = ['bottleneck>=1.3.6', 'numba>=0.56.4', 'numexpr>=2.9.0']
 computation = ['scipy>=1.10.0', 'xarray>=2022.12.0']
 fss = ['fsspec>=2022.11.0']
 aws = ['s3fs>=2022.11.0']
@@ -100,7 +100,7 @@ all = ['adbc-driver-postgresql>=0.8.0',
        'lxml>=4.9.2',
        'matplotlib>=3.6.3',
        'numba>=0.56.4',
-       'numexpr>=2.8.4',
+       'numexpr>=2.9.0',
        'odfpy>=1.4.1',
        'openpyxl>=3.1.0',
        'psycopg2>=2.9.6',


### PR DESCRIPTION
update numexpr to 2.9.0 to fix CVE-2023-39631⁠ findings

HINT: come from other project (apache-superset) where panda is injecting this faulty numexpr inside the project as sub-dependency

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
