### PR TITLE
TST: Clean contexts

### DIFF
--- a/doc/source/development/contributing_codebase.rst
+++ b/doc/source/development/contributing_codebase.rst
@@ -596,14 +596,15 @@ with the specific exception subclass (i.e. never use :py:class:`Exception`) and 
 Testing involving files
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``tm.ensure_clean`` context manager creates a temporary file for testing,
-with a generated filename (or your filename if provided), that is automatically
-deleted when the context block is exited.
+The ``temp_file`` pytest fixture creates a temporary file :py:class:`Pathlib` object for testing:
 
 .. code-block:: python
 
-    with tm.ensure_clean('my_file_path') as path:
-        # do something with the path
+    def test_something(temp_file):
+        pd.DataFrame([1]).to_csv(str(temp_file))
+
+Please review `pytest documentation <https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html#the-default-base-temporary-directory>`_
+for the file retension policy.
 
 Testing involving network connectivity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/development/contributing_codebase.rst
+++ b/doc/source/development/contributing_codebase.rst
@@ -603,7 +603,7 @@ The ``temp_file`` pytest fixture creates a temporary file :py:class:`Pathlib` ob
     def test_something(temp_file):
         pd.DataFrame([1]).to_csv(str(temp_file))
 
-Please review `pytest documentation <https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html#the-default-base-temporary-directory>`_
+Please reference `pytest's documentation <https://docs.pytest.org/en/latest/how-to/tmp_path.html#the-default-base-temporary-directory>`_
 for the file retension policy.
 
 Testing involving network connectivity

--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -627,7 +627,6 @@ __all__ = [
     "to_array",
     "UNSIGNED_INT_EA_DTYPES",
     "UNSIGNED_INT_NUMPY_DTYPES",
-    "use_numexpr",
     "with_csv_dialect",
     "write_to_compressed",
 ]

--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -76,7 +76,6 @@ from pandas._testing.contexts import (
     ensure_clean,
     raises_chained_assignment_error,
     set_timezone,
-    use_numexpr,
     with_csv_dialect,
 )
 from pandas.core.arrays import (

--- a/pandas/_testing/contexts.py
+++ b/pandas/_testing/contexts.py
@@ -16,8 +16,6 @@ from pandas._config import using_copy_on_write
 from pandas.compat import PYPY
 from pandas.errors import ChainedAssignmentError
 
-from pandas import set_option
-
 from pandas.io.common import get_handle
 
 if TYPE_CHECKING:
@@ -174,24 +172,6 @@ def with_csv_dialect(name: str, **kwargs) -> Generator[None, None, None]:
         yield
     finally:
         csv.unregister_dialect(name)
-
-
-@contextmanager
-def use_numexpr(use, min_elements=None) -> Generator[None, None, None]:
-    from pandas.core.computation import expressions as expr
-
-    if min_elements is None:
-        min_elements = expr._MIN_ELEMENTS
-
-    olduse = expr.USE_NUMEXPR
-    oldmin = expr._MIN_ELEMENTS
-    set_option("compute.use_numexpr", use)
-    expr._MIN_ELEMENTS = min_elements
-    try:
-        yield
-    finally:
-        expr._MIN_ELEMENTS = oldmin
-        set_option("compute.use_numexpr", olduse)
 
 
 def raises_chained_assignment_error(warn=True, extra_warnings=(), extra_match=()):

--- a/pandas/_testing/contexts.py
+++ b/pandas/_testing/contexts.py
@@ -93,9 +93,7 @@ def set_timezone(tz: str) -> Generator[None, None, None]:
 
 
 @contextmanager
-def ensure_clean(
-    filename=None, return_filelike: bool = False, **kwargs: Any
-) -> Generator[Any, None, None]:
+def ensure_clean(filename=None) -> Generator[Any, None, None]:
     """
     Gets a temporary path and agrees to remove on close.
 
@@ -107,12 +105,6 @@ def ensure_clean(
     ----------
     filename : str (optional)
         suffix of the created file.
-    return_filelike : bool (default False)
-        if True, returns a file-like which is *always* cleaned. Necessary for
-        savefig and other functions which want to append extensions.
-    **kwargs
-        Additional keywords are passed to open().
-
     """
     folder = Path(tempfile.gettempdir())
 
@@ -123,19 +115,11 @@ def ensure_clean(
 
     path.touch()
 
-    handle_or_str: str | IO = str(path)
-    encoding = kwargs.pop("encoding", None)
-    if return_filelike:
-        kwargs.setdefault("mode", "w+b")
-        if encoding is None and "b" not in kwargs["mode"]:
-            encoding = "utf-8"
-        handle_or_str = open(path, encoding=encoding, **kwargs)
+    handle_or_str = str(path)
 
     try:
         yield handle_or_str
     finally:
-        if not isinstance(handle_or_str, str):
-            handle_or_str.close()
         if path.is_file():
             path.unlink()
 

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -35,6 +35,7 @@ from typing import (
     TYPE_CHECKING,
     Callable,
 )
+import uuid
 
 from dateutil.tz import (
     tzlocal,
@@ -2010,3 +2011,14 @@ def arrow_string_storage():
     Fixture that lists possible PyArrow values for StringDtype storage field.
     """
     return ("pyarrow", "pyarrow_numpy")
+
+
+@pytest.fixture
+def temp_file(tmp_path):
+    """
+    Generate a unique file for testing use. See link for removal policy.
+    https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html#the-default-base-temporary-directory
+    """
+    file_path = tmp_path / str(uuid.uuid4())
+    file_path.touch()
+    return file_path

--- a/pandas/tests/frame/methods/test_to_csv.py
+++ b/pandas/tests/frame/methods/test_to_csv.py
@@ -33,125 +33,125 @@ class TestDataFrameToCSV:
 
         return read_csv(path, **params)
 
-    def test_to_csv_from_csv1(self, float_frame, datetime_frame):
-        with tm.ensure_clean("__tmp_to_csv_from_csv1__") as path:
-            float_frame.iloc[:5, float_frame.columns.get_loc("A")] = np.nan
+    def test_to_csv_from_csv1(self, temp_file, float_frame, datetime_frame):
+        path = str(temp_file)
+        float_frame.iloc[:5, float_frame.columns.get_loc("A")] = np.nan
 
-            float_frame.to_csv(path)
-            float_frame.to_csv(path, columns=["A", "B"])
-            float_frame.to_csv(path, header=False)
-            float_frame.to_csv(path, index=False)
+        float_frame.to_csv(path)
+        float_frame.to_csv(path, columns=["A", "B"])
+        float_frame.to_csv(path, header=False)
+        float_frame.to_csv(path, index=False)
 
-            # test roundtrip
-            # freq does not roundtrip
-            datetime_frame.index = datetime_frame.index._with_freq(None)
-            datetime_frame.to_csv(path)
-            recons = self.read_csv(path, parse_dates=True)
-            tm.assert_frame_equal(datetime_frame, recons)
+        # test roundtrip
+        # freq does not roundtrip
+        datetime_frame.index = datetime_frame.index._with_freq(None)
+        datetime_frame.to_csv(path)
+        recons = self.read_csv(path, parse_dates=True)
+        tm.assert_frame_equal(datetime_frame, recons)
 
-            datetime_frame.to_csv(path, index_label="index")
-            recons = self.read_csv(path, index_col=None, parse_dates=True)
+        datetime_frame.to_csv(path, index_label="index")
+        recons = self.read_csv(path, index_col=None, parse_dates=True)
 
-            assert len(recons.columns) == len(datetime_frame.columns) + 1
+        assert len(recons.columns) == len(datetime_frame.columns) + 1
 
-            # no index
-            datetime_frame.to_csv(path, index=False)
-            recons = self.read_csv(path, index_col=None, parse_dates=True)
-            tm.assert_almost_equal(datetime_frame.values, recons.values)
+        # no index
+        datetime_frame.to_csv(path, index=False)
+        recons = self.read_csv(path, index_col=None, parse_dates=True)
+        tm.assert_almost_equal(datetime_frame.values, recons.values)
 
-            # corner case
-            dm = DataFrame(
-                {
-                    "s1": Series(range(3), index=np.arange(3, dtype=np.int64)),
-                    "s2": Series(range(2), index=np.arange(2, dtype=np.int64)),
-                }
-            )
-            dm.to_csv(path)
+        # corner case
+        dm = DataFrame(
+            {
+                "s1": Series(range(3), index=np.arange(3, dtype=np.int64)),
+                "s2": Series(range(2), index=np.arange(2, dtype=np.int64)),
+            }
+        )
+        dm.to_csv(path)
 
-            recons = self.read_csv(path)
-            tm.assert_frame_equal(dm, recons)
+        recons = self.read_csv(path)
+        tm.assert_frame_equal(dm, recons)
 
-    def test_to_csv_from_csv2(self, float_frame):
-        with tm.ensure_clean("__tmp_to_csv_from_csv2__") as path:
-            # duplicate index
-            df = DataFrame(
-                np.random.default_rng(2).standard_normal((3, 3)),
-                index=["a", "a", "b"],
-                columns=["x", "y", "z"],
-            )
-            df.to_csv(path)
-            result = self.read_csv(path)
-            tm.assert_frame_equal(result, df)
+    def test_to_csv_from_csv2(self, temp_file, float_frame):
+        path = str(temp_file)
+        # duplicate index
+        df = DataFrame(
+            np.random.default_rng(2).standard_normal((3, 3)),
+            index=["a", "a", "b"],
+            columns=["x", "y", "z"],
+        )
+        df.to_csv(path)
+        result = self.read_csv(path)
+        tm.assert_frame_equal(result, df)
 
-            midx = MultiIndex.from_tuples([("A", 1, 2), ("A", 1, 2), ("B", 1, 2)])
-            df = DataFrame(
-                np.random.default_rng(2).standard_normal((3, 3)),
-                index=midx,
-                columns=["x", "y", "z"],
-            )
+        midx = MultiIndex.from_tuples([("A", 1, 2), ("A", 1, 2), ("B", 1, 2)])
+        df = DataFrame(
+            np.random.default_rng(2).standard_normal((3, 3)),
+            index=midx,
+            columns=["x", "y", "z"],
+        )
 
-            df.to_csv(path)
-            result = self.read_csv(path, index_col=[0, 1, 2], parse_dates=False)
-            tm.assert_frame_equal(result, df, check_names=False)
+        df.to_csv(path)
+        result = self.read_csv(path, index_col=[0, 1, 2], parse_dates=False)
+        tm.assert_frame_equal(result, df, check_names=False)
 
-            # column aliases
-            col_aliases = Index(["AA", "X", "Y", "Z"])
-            float_frame.to_csv(path, header=col_aliases)
+        # column aliases
+        col_aliases = Index(["AA", "X", "Y", "Z"])
+        float_frame.to_csv(path, header=col_aliases)
 
-            rs = self.read_csv(path)
-            xp = float_frame.copy()
-            xp.columns = col_aliases
-            tm.assert_frame_equal(xp, rs)
+        rs = self.read_csv(path)
+        xp = float_frame.copy()
+        xp.columns = col_aliases
+        tm.assert_frame_equal(xp, rs)
 
-            msg = "Writing 4 cols but got 2 aliases"
-            with pytest.raises(ValueError, match=msg):
-                float_frame.to_csv(path, header=["AA", "X"])
+        msg = "Writing 4 cols but got 2 aliases"
+        with pytest.raises(ValueError, match=msg):
+            float_frame.to_csv(path, header=["AA", "X"])
 
-    def test_to_csv_from_csv3(self):
-        with tm.ensure_clean("__tmp_to_csv_from_csv3__") as path:
-            df1 = DataFrame(np.random.default_rng(2).standard_normal((3, 1)))
-            df2 = DataFrame(np.random.default_rng(2).standard_normal((3, 1)))
+    def test_to_csv_from_csv3(self, temp_file):
+        path = str(temp_file)
+        df1 = DataFrame(np.random.default_rng(2).standard_normal((3, 1)))
+        df2 = DataFrame(np.random.default_rng(2).standard_normal((3, 1)))
 
-            df1.to_csv(path)
-            df2.to_csv(path, mode="a", header=False)
-            xp = pd.concat([df1, df2])
-            rs = read_csv(path, index_col=0)
-            rs.columns = [int(label) for label in rs.columns]
-            xp.columns = [int(label) for label in xp.columns]
-            tm.assert_frame_equal(xp, rs)
+        df1.to_csv(path)
+        df2.to_csv(path, mode="a", header=False)
+        xp = pd.concat([df1, df2])
+        rs = read_csv(path, index_col=0)
+        rs.columns = [int(label) for label in rs.columns]
+        xp.columns = [int(label) for label in xp.columns]
+        tm.assert_frame_equal(xp, rs)
 
-    def test_to_csv_from_csv4(self):
-        with tm.ensure_clean("__tmp_to_csv_from_csv4__") as path:
-            # GH 10833 (TimedeltaIndex formatting)
-            dt = pd.Timedelta(seconds=1)
-            df = DataFrame(
-                {"dt_data": [i * dt for i in range(3)]},
-                index=Index([i * dt for i in range(3)], name="dt_index"),
-            )
-            df.to_csv(path)
+    def test_to_csv_from_csv4(self, temp_file):
+        path = str(temp_file)
+        # GH 10833 (TimedeltaIndex formatting)
+        dt = pd.Timedelta(seconds=1)
+        df = DataFrame(
+            {"dt_data": [i * dt for i in range(3)]},
+            index=Index([i * dt for i in range(3)], name="dt_index"),
+        )
+        df.to_csv(path)
 
-            result = read_csv(path, index_col="dt_index")
-            result.index = pd.to_timedelta(result.index)
-            result["dt_data"] = pd.to_timedelta(result["dt_data"])
+        result = read_csv(path, index_col="dt_index")
+        result.index = pd.to_timedelta(result.index)
+        result["dt_data"] = pd.to_timedelta(result["dt_data"])
 
-            tm.assert_frame_equal(df, result, check_index_type=True)
+        tm.assert_frame_equal(df, result, check_index_type=True)
 
-    def test_to_csv_from_csv5(self, timezone_frame):
+    def test_to_csv_from_csv5(self, temp_file, timezone_frame):
         # tz, 8260
-        with tm.ensure_clean("__tmp_to_csv_from_csv5__") as path:
-            timezone_frame.to_csv(path)
-            result = read_csv(path, index_col=0, parse_dates=["A"])
+        path = str(temp_file)
+        timezone_frame.to_csv(path)
+        result = read_csv(path, index_col=0, parse_dates=["A"])
 
-            converter = (
-                lambda c: to_datetime(result[c])
-                .dt.tz_convert("UTC")
-                .dt.tz_convert(timezone_frame[c].dt.tz)
-            )
-            result["B"] = converter("B")
-            result["C"] = converter("C")
-            tm.assert_frame_equal(result, timezone_frame)
+        converter = (
+            lambda c: to_datetime(result[c])
+            .dt.tz_convert("UTC")
+            .dt.tz_convert(timezone_frame[c].dt.tz)
+        )
+        result["B"] = converter("B")
+        result["C"] = converter("C")
+        tm.assert_frame_equal(result, timezone_frame)
 
-    def test_to_csv_cols_reordering(self):
+    def test_to_csv_cols_reordering(self, temp_file):
         # GH3454
         chunksize = 5
         N = int(chunksize * 2.5)
@@ -164,14 +164,14 @@ class TestDataFrameToCSV:
         cs = df.columns
         cols = [cs[2], cs[0]]
 
-        with tm.ensure_clean() as path:
-            df.to_csv(path, columns=cols, chunksize=chunksize)
-            rs_c = read_csv(path, index_col=0)
+        path = str(temp_file)
+        df.to_csv(path, columns=cols, chunksize=chunksize)
+        rs_c = read_csv(path, index_col=0)
 
         tm.assert_frame_equal(df[cols], rs_c, check_names=False)
 
     @pytest.mark.parametrize("cols", [None, ["b", "a"]])
-    def test_to_csv_new_dupe_cols(self, cols):
+    def test_to_csv_new_dupe_cols(self, temp_file, cols):
         chunksize = 5
         N = int(chunksize * 2.5)
 
@@ -181,34 +181,34 @@ class TestDataFrameToCSV:
             index=Index([f"i-{i}" for i in range(N)], name="a"),
             columns=["a", "a", "b"],
         )
-        with tm.ensure_clean() as path:
-            df.to_csv(path, columns=cols, chunksize=chunksize)
-            rs_c = read_csv(path, index_col=0)
+        path = str(temp_file)
+        df.to_csv(path, columns=cols, chunksize=chunksize)
+        rs_c = read_csv(path, index_col=0)
 
-            # we wrote them in a different order
-            # so compare them in that order
-            if cols is not None:
-                if df.columns.is_unique:
-                    rs_c.columns = cols
-                else:
-                    indexer, missing = df.columns.get_indexer_non_unique(cols)
-                    rs_c.columns = df.columns.take(indexer)
-
-                for c in cols:
-                    obj_df = df[c]
-                    obj_rs = rs_c[c]
-                    if isinstance(obj_df, Series):
-                        tm.assert_series_equal(obj_df, obj_rs)
-                    else:
-                        tm.assert_frame_equal(obj_df, obj_rs, check_names=False)
-
-            # wrote in the same order
+        # we wrote them in a different order
+        # so compare them in that order
+        if cols is not None:
+            if df.columns.is_unique:
+                rs_c.columns = cols
             else:
-                rs_c.columns = df.columns
-                tm.assert_frame_equal(df, rs_c, check_names=False)
+                indexer, missing = df.columns.get_indexer_non_unique(cols)
+                rs_c.columns = df.columns.take(indexer)
+
+            for c in cols:
+                obj_df = df[c]
+                obj_rs = rs_c[c]
+                if isinstance(obj_df, Series):
+                    tm.assert_series_equal(obj_df, obj_rs)
+                else:
+                    tm.assert_frame_equal(obj_df, obj_rs, check_names=False)
+
+        # wrote in the same order
+        else:
+            rs_c.columns = df.columns
+            tm.assert_frame_equal(df, rs_c, check_names=False)
 
     @pytest.mark.slow
-    def test_to_csv_dtnat(self):
+    def test_to_csv_dtnat(self, temp_file):
         # GH3437
         def make_dtnat_arr(n, nnat=None):
             if nnat is None:
@@ -226,12 +226,12 @@ class TestDataFrameToCSV:
         s1 = make_dtnat_arr(chunksize + 5)
         s2 = make_dtnat_arr(chunksize + 5, 0)
 
-        with tm.ensure_clean("1.csv") as pth:
-            df = DataFrame({"a": s1, "b": s2})
-            df.to_csv(pth, chunksize=chunksize)
+        path = str(temp_file)
+        df = DataFrame({"a": s1, "b": s2})
+        df.to_csv(path, chunksize=chunksize)
 
-            recons = self.read_csv(pth).apply(to_datetime)
-            tm.assert_frame_equal(df, recons, check_names=False)
+        recons = self.read_csv(path).apply(to_datetime)
+        tm.assert_frame_equal(df, recons, check_names=False)
 
     def _return_result_expected(
         self,
@@ -465,42 +465,42 @@ class TestDataFrameToCSV:
         result, expected = self._return_result_expected(df, 1000, **func_params)
         tm.assert_frame_equal(result, expected, check_names=False)
 
-    def test_to_csv_from_csv_w_some_infs(self, float_frame):
+    def test_to_csv_from_csv_w_some_infs(self, temp_file, float_frame):
         # test roundtrip with inf, -inf, nan, as full columns and mix
         float_frame["G"] = np.nan
         f = lambda x: [np.inf, np.nan][np.random.default_rng(2).random() < 0.5]
         float_frame["h"] = float_frame.index.map(f)
 
-        with tm.ensure_clean() as path:
-            float_frame.to_csv(path)
-            recons = self.read_csv(path)
+        path = str(temp_file)
+        float_frame.to_csv(path)
+        recons = self.read_csv(path)
 
-            tm.assert_frame_equal(float_frame, recons)
-            tm.assert_frame_equal(np.isinf(float_frame), np.isinf(recons))
+        tm.assert_frame_equal(float_frame, recons)
+        tm.assert_frame_equal(np.isinf(float_frame), np.isinf(recons))
 
-    def test_to_csv_from_csv_w_all_infs(self, float_frame):
+    def test_to_csv_from_csv_w_all_infs(self, temp_file, float_frame):
         # test roundtrip with inf, -inf, nan, as full columns and mix
         float_frame["E"] = np.inf
         float_frame["F"] = -np.inf
 
-        with tm.ensure_clean() as path:
-            float_frame.to_csv(path)
-            recons = self.read_csv(path)
+        path = str(temp_file)
+        float_frame.to_csv(path)
+        recons = self.read_csv(path)
 
-            tm.assert_frame_equal(float_frame, recons)
-            tm.assert_frame_equal(np.isinf(float_frame), np.isinf(recons))
+        tm.assert_frame_equal(float_frame, recons)
+        tm.assert_frame_equal(np.isinf(float_frame), np.isinf(recons))
 
-    def test_to_csv_no_index(self):
+    def test_to_csv_no_index(self, temp_file):
         # GH 3624, after appending columns, to_csv fails
-        with tm.ensure_clean("__tmp_to_csv_no_index__") as path:
-            df = DataFrame({"c1": [1, 2, 3], "c2": [4, 5, 6]})
-            df.to_csv(path, index=False)
-            result = read_csv(path)
-            tm.assert_frame_equal(df, result)
-            df["c3"] = Series([7, 8, 9], dtype="int64")
-            df.to_csv(path, index=False)
-            result = read_csv(path)
-            tm.assert_frame_equal(df, result)
+        path = str(temp_file)
+        df = DataFrame({"c1": [1, 2, 3], "c2": [4, 5, 6]})
+        df.to_csv(path, index=False)
+        result = read_csv(path)
+        tm.assert_frame_equal(df, result)
+        df["c3"] = Series([7, 8, 9], dtype="int64")
+        df.to_csv(path, index=False)
+        result = read_csv(path)
+        tm.assert_frame_equal(df, result)
 
     def test_to_csv_with_mix_columns(self):
         # gh-11637: incorrect output when a mix of integer and string column
@@ -510,74 +510,72 @@ class TestDataFrameToCSV:
         df["test"] = "txt"
         assert df.to_csv() == df.to_csv(columns=[0, 1, "test"])
 
-    def test_to_csv_headers(self):
+    def test_to_csv_headers(self, temp_file):
         # GH6186, the presence or absence of `index` incorrectly
         # causes to_csv to have different header semantics.
         from_df = DataFrame([[1, 2], [3, 4]], columns=["A", "B"])
         to_df = DataFrame([[1, 2], [3, 4]], columns=["X", "Y"])
-        with tm.ensure_clean("__tmp_to_csv_headers__") as path:
-            from_df.to_csv(path, header=["X", "Y"])
-            recons = self.read_csv(path)
+        path = str(temp_file)
+        from_df.to_csv(path, header=["X", "Y"])
+        recons = self.read_csv(path)
 
-            tm.assert_frame_equal(to_df, recons)
+        tm.assert_frame_equal(to_df, recons)
 
-            from_df.to_csv(path, index=False, header=["X", "Y"])
-            recons = self.read_csv(path)
+        from_df.to_csv(path, index=False, header=["X", "Y"])
+        recons = self.read_csv(path)
 
-            return_value = recons.reset_index(inplace=True)
-            assert return_value is None
-            tm.assert_frame_equal(to_df, recons)
+        return_value = recons.reset_index(inplace=True)
+        assert return_value is None
+        tm.assert_frame_equal(to_df, recons)
 
-    def test_to_csv_multiindex(self, float_frame, datetime_frame):
+    def test_to_csv_multiindex(self, temp_file, float_frame, datetime_frame):
         frame = float_frame
         old_index = frame.index
         arrays = np.arange(len(old_index) * 2, dtype=np.int64).reshape(2, -1)
         new_index = MultiIndex.from_arrays(arrays, names=["first", "second"])
         frame.index = new_index
 
-        with tm.ensure_clean("__tmp_to_csv_multiindex__") as path:
-            frame.to_csv(path, header=False)
-            frame.to_csv(path, columns=["A", "B"])
+        path = str(temp_file)
+        frame.to_csv(path, header=False)
+        frame.to_csv(path, columns=["A", "B"])
 
-            # round trip
-            frame.to_csv(path)
+        # round trip
+        frame.to_csv(path)
 
-            df = self.read_csv(path, index_col=[0, 1], parse_dates=False)
+        df = self.read_csv(path, index_col=[0, 1], parse_dates=False)
 
-            # TODO to_csv drops column name
-            tm.assert_frame_equal(frame, df, check_names=False)
-            assert frame.index.names == df.index.names
+        # TODO to_csv drops column name
+        tm.assert_frame_equal(frame, df, check_names=False)
+        assert frame.index.names == df.index.names
 
-            # needed if setUp becomes a class method
-            float_frame.index = old_index
+        # needed if setUp becomes a class method
+        float_frame.index = old_index
 
-            # try multiindex with dates
-            tsframe = datetime_frame
-            old_index = tsframe.index
-            new_index = [old_index, np.arange(len(old_index), dtype=np.int64)]
-            tsframe.index = MultiIndex.from_arrays(new_index)
+        # try multiindex with dates
+        tsframe = datetime_frame
+        old_index = tsframe.index
+        new_index = [old_index, np.arange(len(old_index), dtype=np.int64)]
+        tsframe.index = MultiIndex.from_arrays(new_index)
 
-            tsframe.to_csv(path, index_label=["time", "foo"])
-            with tm.assert_produces_warning(
-                UserWarning, match="Could not infer format"
-            ):
-                recons = self.read_csv(path, index_col=[0, 1], parse_dates=True)
+        tsframe.to_csv(path, index_label=["time", "foo"])
+        with tm.assert_produces_warning(UserWarning, match="Could not infer format"):
+            recons = self.read_csv(path, index_col=[0, 1], parse_dates=True)
 
-            # TODO to_csv drops column name
-            tm.assert_frame_equal(tsframe, recons, check_names=False)
+        # TODO to_csv drops column name
+        tm.assert_frame_equal(tsframe, recons, check_names=False)
 
-            # do not load index
-            tsframe.to_csv(path)
-            recons = self.read_csv(path, index_col=None)
-            assert len(recons.columns) == len(tsframe.columns) + 2
+        # do not load index
+        tsframe.to_csv(path)
+        recons = self.read_csv(path, index_col=None)
+        assert len(recons.columns) == len(tsframe.columns) + 2
 
-            # no index
-            tsframe.to_csv(path, index=False)
-            recons = self.read_csv(path, index_col=None)
-            tm.assert_almost_equal(recons.values, datetime_frame.values)
+        # no index
+        tsframe.to_csv(path, index=False)
+        recons = self.read_csv(path, index_col=None)
+        tm.assert_almost_equal(recons.values, datetime_frame.values)
 
-            # needed if setUp becomes class method
-            datetime_frame.index = old_index
+        # needed if setUp becomes class method
+        datetime_frame.index = old_index
 
         with tm.ensure_clean("__tmp_to_csv_multiindex__") as path:
             # GH3571, GH1651, GH3141
@@ -682,46 +680,46 @@ class TestDataFrameToCSV:
             tm.assert_index_equal(recons.columns, exp.columns)
             assert len(recons) == 0
 
-    def test_to_csv_interval_index(self, using_infer_string):
+    def test_to_csv_interval_index(self, temp_file, using_infer_string):
         # GH 28210
         df = DataFrame({"A": list("abc"), "B": range(3)}, index=pd.interval_range(0, 3))
 
-        with tm.ensure_clean("__tmp_to_csv_interval_index__.csv") as path:
-            df.to_csv(path)
-            result = self.read_csv(path, index_col=0)
+        path = str(temp_file)
+        df.to_csv(path)
+        result = self.read_csv(path, index_col=0)
 
-            # can't roundtrip intervalindex via read_csv so check string repr (GH 23595)
-            expected = df.copy()
-            if using_infer_string:
-                expected.index = expected.index.astype("string[pyarrow_numpy]")
-            else:
-                expected.index = expected.index.astype(str)
+        # can't roundtrip intervalindex via read_csv so check string repr (GH 23595)
+        expected = df.copy()
+        if using_infer_string:
+            expected.index = expected.index.astype("string[pyarrow_numpy]")
+        else:
+            expected.index = expected.index.astype(str)
 
-            tm.assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
-    def test_to_csv_float32_nanrep(self):
+    def test_to_csv_float32_nanrep(self, temp_file):
         df = DataFrame(
             np.random.default_rng(2).standard_normal((1, 4)).astype(np.float32)
         )
         df[1] = np.nan
 
-        with tm.ensure_clean("__tmp_to_csv_float32_nanrep__.csv") as path:
-            df.to_csv(path, na_rep=999)
+        path = str(temp_file)
+        df.to_csv(path, na_rep=999)
 
-            with open(path, encoding="utf-8") as f:
-                lines = f.readlines()
-                assert lines[1].split(",")[2] == "999"
+        with open(path, encoding="utf-8") as f:
+            lines = f.readlines()
+            assert lines[1].split(",")[2] == "999"
 
-    def test_to_csv_withcommas(self):
+    def test_to_csv_withcommas(self, temp_file):
         # Commas inside fields should be correctly escaped when saving as CSV.
         df = DataFrame({"A": [1, 2, 3], "B": ["5,6", "7,8", "9,0"]})
 
-        with tm.ensure_clean("__tmp_to_csv_withcommas__.csv") as path:
-            df.to_csv(path)
-            df2 = self.read_csv(path)
-            tm.assert_frame_equal(df2, df)
+        path = str(temp_file)
+        df.to_csv(path)
+        df2 = self.read_csv(path)
+        tm.assert_frame_equal(df2, df)
 
-    def test_to_csv_mixed(self):
+    def test_to_csv_mixed(self, temp_file):
         def create_cols(name):
             return [f"{name}{i:03d}" for i in range(5)]
 
@@ -762,25 +760,23 @@ class TestDataFrameToCSV:
             for c in create_cols(n):
                 dtypes[c] = dtype
 
-        with tm.ensure_clean() as filename:
-            df.to_csv(filename)
-            rs = read_csv(
-                filename, index_col=0, dtype=dtypes, parse_dates=create_cols("date")
-            )
-            tm.assert_frame_equal(rs, df)
+        path = str(temp_file)
+        df.to_csv(path)
+        rs = read_csv(path, index_col=0, dtype=dtypes, parse_dates=create_cols("date"))
+        tm.assert_frame_equal(rs, df)
 
-    def test_to_csv_dups_cols(self):
+    def test_to_csv_dups_cols(self, temp_file):
         df = DataFrame(
             np.random.default_rng(2).standard_normal((1000, 30)),
             columns=list(range(15)) + list(range(15)),
             dtype="float64",
         )
 
-        with tm.ensure_clean() as filename:
-            df.to_csv(filename)  # single dtype, fine
-            result = read_csv(filename, index_col=0)
-            result.columns = df.columns
-            tm.assert_frame_equal(result, df)
+        path = str(temp_file)
+        df.to_csv(path)  # single dtype, fine
+        result = read_csv(path, index_col=0)
+        result.columns = df.columns
+        tm.assert_frame_equal(result, df)
 
         df_float = DataFrame(
             np.random.default_rng(2).standard_normal((1000, 3)), dtype="float64"
@@ -810,7 +806,7 @@ class TestDataFrameToCSV:
             result.columns = df.columns
             tm.assert_frame_equal(result, df)
 
-    def test_to_csv_dups_cols2(self):
+    def test_to_csv_dups_cols2(self, temp_file):
         # GH3457
         df = DataFrame(
             np.ones((5, 3)),
@@ -818,28 +814,28 @@ class TestDataFrameToCSV:
             columns=Index(["a", "a", "b"], dtype=object),
         )
 
-        with tm.ensure_clean() as filename:
-            df.to_csv(filename)
+        path = str(temp_file)
+        df.to_csv(path)
 
-            # read_csv will rename the dups columns
-            result = read_csv(filename, index_col=0)
-            result = result.rename(columns={"a.1": "a"})
-            tm.assert_frame_equal(result, df)
+        # read_csv will rename the dups columns
+        result = read_csv(path, index_col=0)
+        result = result.rename(columns={"a.1": "a"})
+        tm.assert_frame_equal(result, df)
 
     @pytest.mark.parametrize("chunksize", [10000, 50000, 100000])
-    def test_to_csv_chunking(self, chunksize):
+    def test_to_csv_chunking(self, chunksize, temp_file):
         aa = DataFrame({"A": range(100000)})
         aa["B"] = aa.A + 1.0
         aa["C"] = aa.A + 2.0
         aa["D"] = aa.A + 3.0
 
-        with tm.ensure_clean() as filename:
-            aa.to_csv(filename, chunksize=chunksize)
-            rs = read_csv(filename, index_col=0)
-            tm.assert_frame_equal(rs, aa)
+        path = str(temp_file)
+        aa.to_csv(path, chunksize=chunksize)
+        rs = read_csv(path, index_col=0)
+        tm.assert_frame_equal(rs, aa)
 
     @pytest.mark.slow
-    def test_to_csv_wide_frame_formatting(self, monkeypatch):
+    def test_to_csv_wide_frame_formatting(self, temp_file, monkeypatch):
         # Issue #8621
         chunksize = 100
         df = DataFrame(
@@ -847,35 +843,35 @@ class TestDataFrameToCSV:
             columns=None,
             index=None,
         )
-        with tm.ensure_clean() as filename:
-            with monkeypatch.context() as m:
-                m.setattr("pandas.io.formats.csvs._DEFAULT_CHUNKSIZE_CELLS", chunksize)
-                df.to_csv(filename, header=False, index=False)
-            rs = read_csv(filename, header=None)
+        path = str(temp_file)
+        with monkeypatch.context() as m:
+            m.setattr("pandas.io.formats.csvs._DEFAULT_CHUNKSIZE_CELLS", chunksize)
+            df.to_csv(path, header=False, index=False)
+        rs = read_csv(path, header=None)
         tm.assert_frame_equal(rs, df)
 
-    def test_to_csv_bug(self):
+    def test_to_csv_bug(self, temp_file):
         f1 = StringIO("a,1.0\nb,2.0")
         df = self.read_csv(f1, header=None)
         newdf = DataFrame({"t": df[df.columns[0]]})
 
-        with tm.ensure_clean() as path:
-            newdf.to_csv(path)
+        path = str(temp_file)
+        newdf.to_csv(path)
 
-            recons = read_csv(path, index_col=0)
-            # don't check_names as t != 1
-            tm.assert_frame_equal(recons, newdf, check_names=False)
+        recons = read_csv(path, index_col=0)
+        # don't check_names as t != 1
+        tm.assert_frame_equal(recons, newdf, check_names=False)
 
-    def test_to_csv_unicode(self):
+    def test_to_csv_unicode(self, temp_file):
         df = DataFrame({"c/\u03c3": [1, 2, 3]})
-        with tm.ensure_clean() as path:
-            df.to_csv(path, encoding="UTF-8")
-            df2 = read_csv(path, index_col=0, encoding="UTF-8")
-            tm.assert_frame_equal(df, df2)
+        path = str(temp_file)
+        df.to_csv(path, encoding="UTF-8")
+        df2 = read_csv(path, index_col=0, encoding="UTF-8")
+        tm.assert_frame_equal(df, df2)
 
-            df.to_csv(path, encoding="UTF-8", index=False)
-            df2 = read_csv(path, index_col=None, encoding="UTF-8")
-            tm.assert_frame_equal(df, df2)
+        df.to_csv(path, encoding="UTF-8", index=False)
+        df2 = read_csv(path, index_col=None, encoding="UTF-8")
+        tm.assert_frame_equal(df, df2)
 
     def test_to_csv_unicode_index_col(self):
         buf = StringIO("")
@@ -898,23 +894,23 @@ class TestDataFrameToCSV:
         recons = read_csv(buf, index_col=0)
         tm.assert_frame_equal(recons, float_frame)
 
-    def test_to_csv_float_format(self):
+    def test_to_csv_float_format(self, temp_file):
         df = DataFrame(
             [[0.123456, 0.234567, 0.567567], [12.32112, 123123.2, 321321.2]],
             index=["A", "B"],
             columns=["X", "Y", "Z"],
         )
 
-        with tm.ensure_clean() as filename:
-            df.to_csv(filename, float_format="%.2f")
+        path = str(temp_file)
+        df.to_csv(path, float_format="%.2f")
 
-            rs = read_csv(filename, index_col=0)
-            xp = DataFrame(
-                [[0.12, 0.23, 0.57], [12.32, 123123.20, 321321.20]],
-                index=["A", "B"],
-                columns=["X", "Y", "Z"],
-            )
-            tm.assert_frame_equal(rs, xp)
+        rs = read_csv(path, index_col=0)
+        xp = DataFrame(
+            [[0.12, 0.23, 0.57], [12.32, 123123.20, 321321.20]],
+            index=["A", "B"],
+            columns=["X", "Y", "Z"],
+        )
+        tm.assert_frame_equal(rs, xp)
 
     def test_to_csv_float_format_over_decimal(self):
         # GH#47436
@@ -961,43 +957,50 @@ class TestDataFrameToCSV:
         expected = tm.convert_rows_list_to_csv_str(expected_rows)
         assert buf.getvalue() == expected
 
-    def test_to_csv_lineterminators(self):
+    def test_to_csv_lineterminators(self, temp_file):
         # see gh-20353
         df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]}, index=["one", "two", "three"])
 
-        with tm.ensure_clean() as path:
-            # case 1: CRLF as line terminator
-            df.to_csv(path, lineterminator="\r\n")
-            expected = b",A,B\r\none,1,4\r\ntwo,2,5\r\nthree,3,6\r\n"
+        path = str(temp_file)
+        # case 1: CRLF as line terminator
+        df.to_csv(path, lineterminator="\r\n")
+        expected = b",A,B\r\none,1,4\r\ntwo,2,5\r\nthree,3,6\r\n"
 
-            with open(path, mode="rb") as f:
-                assert f.read() == expected
+        with open(path, mode="rb") as f:
+            assert f.read() == expected
 
-        with tm.ensure_clean() as path:
-            # case 2: LF as line terminator
-            df.to_csv(path, lineterminator="\n")
-            expected = b",A,B\none,1,4\ntwo,2,5\nthree,3,6\n"
+    def test_to_csv_lineterminators2(self, temp_file):
+        # see gh-20353
+        df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]}, index=["one", "two", "three"])
 
-            with open(path, mode="rb") as f:
-                assert f.read() == expected
+        path = str(temp_file)
+        # case 2: LF as line terminator
+        df.to_csv(path, lineterminator="\n")
+        expected = b",A,B\none,1,4\ntwo,2,5\nthree,3,6\n"
 
-        with tm.ensure_clean() as path:
-            # case 3: The default line terminator(=os.linesep)(gh-21406)
-            df.to_csv(path)
-            os_linesep = os.linesep.encode("utf-8")
-            expected = (
-                b",A,B"
-                + os_linesep
-                + b"one,1,4"
-                + os_linesep
-                + b"two,2,5"
-                + os_linesep
-                + b"three,3,6"
-                + os_linesep
-            )
+        with open(path, mode="rb") as f:
+            assert f.read() == expected
 
-            with open(path, mode="rb") as f:
-                assert f.read() == expected
+    def test_to_csv_lineterminators3(self, temp_file):
+        # see gh-20353
+        df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]}, index=["one", "two", "three"])
+        path = str(temp_file)
+        # case 3: The default line terminator(=os.linesep)(gh-21406)
+        df.to_csv(path)
+        os_linesep = os.linesep.encode("utf-8")
+        expected = (
+            b",A,B"
+            + os_linesep
+            + b"one,1,4"
+            + os_linesep
+            + b"two,2,5"
+            + os_linesep
+            + b"three,3,6"
+            + os_linesep
+        )
+
+        with open(path, mode="rb") as f:
+            assert f.read() == expected
 
     def test_to_csv_from_csv_categorical(self):
         # CSV with categoricals should result in the same output
@@ -1055,120 +1058,116 @@ class TestDataFrameToCSV:
             ),
         ],
     )
-    def test_to_csv_compression(self, df, encoding, compression):
-        with tm.ensure_clean() as filename:
-            df.to_csv(filename, compression=compression, encoding=encoding)
-            # test the round trip - to_csv -> read_csv
-            result = read_csv(
-                filename, compression=compression, index_col=0, encoding=encoding
-            )
-            tm.assert_frame_equal(df, result)
+    def test_to_csv_compression(self, temp_file, df, encoding, compression):
+        path = str(temp_file)
+        df.to_csv(path, compression=compression, encoding=encoding)
+        # test the round trip - to_csv -> read_csv
+        result = read_csv(path, compression=compression, index_col=0, encoding=encoding)
+        tm.assert_frame_equal(df, result)
 
-            # test the round trip using file handle - to_csv -> read_csv
-            with get_handle(
-                filename, "w", compression=compression, encoding=encoding
-            ) as handles:
-                df.to_csv(handles.handle, encoding=encoding)
-                assert not handles.handle.closed
+        # test the round trip using file handle - to_csv -> read_csv
+        with get_handle(
+            path, "w", compression=compression, encoding=encoding
+        ) as handles:
+            df.to_csv(handles.handle, encoding=encoding)
+            assert not handles.handle.closed
 
-            result = read_csv(
-                filename,
-                compression=compression,
-                encoding=encoding,
-                index_col=0,
-            ).squeeze("columns")
-            tm.assert_frame_equal(df, result)
+        result = read_csv(
+            path,
+            compression=compression,
+            encoding=encoding,
+            index_col=0,
+        ).squeeze("columns")
+        tm.assert_frame_equal(df, result)
 
-            # explicitly make sure file is compressed
-            with tm.decompress_file(filename, compression) as fh:
-                text = fh.read().decode(encoding or "utf8")
-                for col in df.columns:
-                    assert col in text
+        # explicitly make sure file is compressed
+        with tm.decompress_file(path, compression) as fh:
+            text = fh.read().decode(encoding or "utf8")
+            for col in df.columns:
+                assert col in text
 
-            with tm.decompress_file(filename, compression) as fh:
-                tm.assert_frame_equal(df, read_csv(fh, index_col=0, encoding=encoding))
+        with tm.decompress_file(path, compression) as fh:
+            tm.assert_frame_equal(df, read_csv(fh, index_col=0, encoding=encoding))
 
-    def test_to_csv_date_format(self, datetime_frame):
-        with tm.ensure_clean("__tmp_to_csv_date_format__") as path:
-            dt_index = datetime_frame.index
-            datetime_frame = DataFrame(
-                {"A": dt_index, "B": dt_index.shift(1)}, index=dt_index
-            )
-            datetime_frame.to_csv(path, date_format="%Y%m%d")
+    def test_to_csv_date_format(self, temp_file, datetime_frame):
+        path = str(temp_file)
+        dt_index = datetime_frame.index
+        datetime_frame = DataFrame(
+            {"A": dt_index, "B": dt_index.shift(1)}, index=dt_index
+        )
+        datetime_frame.to_csv(path, date_format="%Y%m%d")
 
-            # Check that the data was put in the specified format
-            test = read_csv(path, index_col=0)
+        # Check that the data was put in the specified format
+        test = read_csv(path, index_col=0)
 
-            datetime_frame_int = datetime_frame.map(lambda x: int(x.strftime("%Y%m%d")))
-            datetime_frame_int.index = datetime_frame_int.index.map(
-                lambda x: int(x.strftime("%Y%m%d"))
-            )
+        datetime_frame_int = datetime_frame.map(lambda x: int(x.strftime("%Y%m%d")))
+        datetime_frame_int.index = datetime_frame_int.index.map(
+            lambda x: int(x.strftime("%Y%m%d"))
+        )
 
-            tm.assert_frame_equal(test, datetime_frame_int)
+        tm.assert_frame_equal(test, datetime_frame_int)
 
-            datetime_frame.to_csv(path, date_format="%Y-%m-%d")
+        datetime_frame.to_csv(path, date_format="%Y-%m-%d")
 
-            # Check that the data was put in the specified format
-            test = read_csv(path, index_col=0)
-            datetime_frame_str = datetime_frame.map(lambda x: x.strftime("%Y-%m-%d"))
-            datetime_frame_str.index = datetime_frame_str.index.map(
-                lambda x: x.strftime("%Y-%m-%d")
-            )
+        # Check that the data was put in the specified format
+        test = read_csv(path, index_col=0)
+        datetime_frame_str = datetime_frame.map(lambda x: x.strftime("%Y-%m-%d"))
+        datetime_frame_str.index = datetime_frame_str.index.map(
+            lambda x: x.strftime("%Y-%m-%d")
+        )
 
-            tm.assert_frame_equal(test, datetime_frame_str)
+        tm.assert_frame_equal(test, datetime_frame_str)
 
-            # Check that columns get converted
-            datetime_frame_columns = datetime_frame.T
-            datetime_frame_columns.to_csv(path, date_format="%Y%m%d")
+        # Check that columns get converted
+        datetime_frame_columns = datetime_frame.T
+        datetime_frame_columns.to_csv(path, date_format="%Y%m%d")
 
-            test = read_csv(path, index_col=0)
+        test = read_csv(path, index_col=0)
 
-            datetime_frame_columns = datetime_frame_columns.map(
-                lambda x: int(x.strftime("%Y%m%d"))
-            )
-            # Columns don't get converted to ints by read_csv
-            datetime_frame_columns.columns = datetime_frame_columns.columns.map(
-                lambda x: x.strftime("%Y%m%d")
-            )
+        datetime_frame_columns = datetime_frame_columns.map(
+            lambda x: int(x.strftime("%Y%m%d"))
+        )
+        # Columns don't get converted to ints by read_csv
+        datetime_frame_columns.columns = datetime_frame_columns.columns.map(
+            lambda x: x.strftime("%Y%m%d")
+        )
 
-            tm.assert_frame_equal(test, datetime_frame_columns)
+        tm.assert_frame_equal(test, datetime_frame_columns)
 
-            # test NaTs
-            nat_index = to_datetime(
-                ["NaT"] * 10 + ["2000-01-01", "2000-01-01", "2000-01-01"]
-            )
-            nat_frame = DataFrame({"A": nat_index}, index=nat_index)
-            nat_frame.to_csv(path, date_format="%Y-%m-%d")
+        # test NaTs
+        nat_index = to_datetime(
+            ["NaT"] * 10 + ["2000-01-01", "2000-01-01", "2000-01-01"]
+        )
+        nat_frame = DataFrame({"A": nat_index}, index=nat_index)
+        nat_frame.to_csv(path, date_format="%Y-%m-%d")
 
-            test = read_csv(path, parse_dates=[0, 1], index_col=0)
+        test = read_csv(path, parse_dates=[0, 1], index_col=0)
 
-            tm.assert_frame_equal(test, nat_frame)
+        tm.assert_frame_equal(test, nat_frame)
 
     @pytest.mark.parametrize("td", [pd.Timedelta(0), pd.Timedelta("10s")])
-    def test_to_csv_with_dst_transitions(self, td):
-        with tm.ensure_clean("csv_date_format_with_dst") as path:
-            # make sure we are not failing on transitions
-            times = date_range(
-                "2013-10-26 23:00",
-                "2013-10-27 01:00",
-                tz="Europe/London",
-                freq="h",
-                ambiguous="infer",
-            )
-            i = times + td
-            i = i._with_freq(None)  # freq is not preserved by read_csv
-            time_range = np.array(range(len(i)), dtype="int64")
-            df = DataFrame({"A": time_range}, index=i)
-            df.to_csv(path, index=True)
-            # we have to reconvert the index as we
-            # don't parse the tz's
-            result = read_csv(path, index_col=0)
-            result.index = to_datetime(result.index, utc=True).tz_convert(
-                "Europe/London"
-            )
-            tm.assert_frame_equal(result, df)
+    def test_to_csv_with_dst_transitions(self, td, temp_file):
+        path = str(temp_file)
+        # make sure we are not failing on transitions
+        times = date_range(
+            "2013-10-26 23:00",
+            "2013-10-27 01:00",
+            tz="Europe/London",
+            freq="h",
+            ambiguous="infer",
+        )
+        i = times + td
+        i = i._with_freq(None)  # freq is not preserved by read_csv
+        time_range = np.array(range(len(i)), dtype="int64")
+        df = DataFrame({"A": time_range}, index=i)
+        df.to_csv(path, index=True)
+        # we have to reconvert the index as we
+        # don't parse the tz's
+        result = read_csv(path, index_col=0)
+        result.index = to_datetime(result.index, utc=True).tz_convert("Europe/London")
+        tm.assert_frame_equal(result, df)
 
-    def test_to_csv_with_dst_transitions_with_pickle(self):
+    def test_to_csv_with_dst_transitions_with_pickle(self, temp_file):
         # GH11619
         idx = date_range("2015-01-01", "2015-12-31", freq="h", tz="Europe/Paris")
         idx = idx._with_freq(None)  # freq does not round-trip
@@ -1188,10 +1187,10 @@ class TestDataFrameToCSV:
         # assert working
         df.astype(str)
 
-        with tm.ensure_clean("csv_date_format_with_dst") as path:
-            df.to_pickle(path)
-            result = pd.read_pickle(path)
-            tm.assert_frame_equal(result, df)
+        path = str(temp_file)
+        df.to_pickle(path)
+        result = pd.read_pickle(path)
+        tm.assert_frame_equal(result, df)
 
     def test_to_csv_quoting(self):
         df = DataFrame(
@@ -1344,15 +1343,17 @@ class TestDataFrameToCSV:
         result = df.to_csv(lineterminator="\n")
         tm.assert_almost_equal(result, expected)
 
-    def test_gz_lineend(self):
+    def test_gz_lineend(self, tmp_path):
         # GH 25311
         df = DataFrame({"a": [1, 2]})
         expected_rows = ["a", "1", "2"]
         expected = tm.convert_rows_list_to_csv_str(expected_rows)
-        with tm.ensure_clean("__test_gz_lineend.csv.gz") as path:
-            df.to_csv(path, index=False)
-            with tm.decompress_file(path, compression="gzip") as f:
-                result = f.read().decode("utf-8")
+        file_path = tmp_path / "__test_gz_lineend.csv.gz"
+        file_path.touch()
+        path = str(file_path)
+        df.to_csv(path, index=False)
+        with tm.decompress_file(path, compression="gzip") as f:
+            result = f.read().decode("utf-8")
 
         assert result == expected
 

--- a/pandas/tests/indexing/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/test_chaining_and_caching.py
@@ -221,15 +221,15 @@ class TestChaining:
         tm.assert_frame_equal(df, df_original)
 
     @pytest.mark.arm_slow
-    def test_detect_chained_assignment_is_copy_pickle(self):
+    def test_detect_chained_assignment_is_copy_pickle(self, temp_file):
         # gh-5475: Make sure that is_copy is picked up reconstruction
         df = DataFrame({"A": [1, 2]})
 
-        with tm.ensure_clean("__tmp__pickle") as path:
-            df.to_pickle(path)
-            df2 = pd.read_pickle(path)
-            df2["B"] = df2["A"]
-            df2["B"] = df2["A"]
+        path = str(temp_file)
+        df.to_pickle(path)
+        df2 = pd.read_pickle(path)
+        df2["B"] = df2["A"]
+        df2["B"] = df2["A"]
 
     @pytest.mark.arm_slow
     def test_detect_chained_assignment_str(self):

--- a/pandas/tests/io/parser/common/test_file_buffer_url.py
+++ b/pandas/tests/io/parser/common/test_file_buffer_url.py
@@ -233,12 +233,12 @@ def test_eof_states(all_parsers, data, kwargs, expected, msg, request):
         tm.assert_frame_equal(result, expected)
 
 
-def test_temporary_file(all_parsers):
+def test_temporary_file(all_parsers, temp_file):
     # see gh-13398
     parser = all_parsers
     data = "0 0"
 
-    with tm.ensure_clean(mode="w+", return_filelike=True) as new_file:
+    with temp_file.open(mode="w+", encoding="utf-8") as new_file:
         new_file.write(data)
         new_file.flush()
         new_file.seek(0)

--- a/pandas/tests/io/parser/test_encoding.py
+++ b/pandas/tests/io/parser/test_encoding.py
@@ -180,7 +180,9 @@ def test_binary_mode_file_buffers(all_parsers, file_path, encoding, datapath):
 
 
 @pytest.mark.parametrize("pass_encoding", [True, False])
-def test_encoding_temp_file(all_parsers, utf_value, encoding_fmt, pass_encoding):
+def test_encoding_temp_file(
+    all_parsers, utf_value, encoding_fmt, pass_encoding, temp_file
+):
     # see gh-24130
     parser = all_parsers
     encoding = encoding_fmt.format(utf_value)
@@ -191,7 +193,7 @@ def test_encoding_temp_file(all_parsers, utf_value, encoding_fmt, pass_encoding)
 
     expected = DataFrame({"foo": ["bar"]})
 
-    with tm.ensure_clean(mode="w+", encoding=encoding, return_filelike=True) as f:
+    with temp_file.open(mode="w+", encoding=encoding) as f:
         f.write("foo\nbar")
         f.seek(0)
 

--- a/pandas/tests/plotting/frame/test_frame_subplots.py
+++ b/pandas/tests/plotting/frame/test_frame_subplots.py
@@ -554,7 +554,7 @@ class TestDataFramePlotsSubplots:
         _, axes = mpl.pyplot.subplots(2, **kwargs)
         with tm.assert_produces_warning(None):
             df.plot(ax=axes[0])
-            with temp_file.open(mode="w+b", encoding="utf-8") as path:
+            with temp_file.open(mode="wb") as path:
                 mpl.pyplot.savefig(path)
 
     @pytest.mark.parametrize(

--- a/pandas/tests/plotting/frame/test_frame_subplots.py
+++ b/pandas/tests/plotting/frame/test_frame_subplots.py
@@ -544,7 +544,7 @@ class TestDataFramePlotsSubplots:
         tm.assert_numpy_array_equal(axs[0].get_xticks(), expected_ax1)
         tm.assert_numpy_array_equal(axs[1].get_xticks(), expected_ax2)
 
-    def test_subplots_constrained_layout(self):
+    def test_subplots_constrained_layout(self, temp_file):
         # GH 25261
         idx = date_range(start="now", periods=10)
         df = DataFrame(np.random.default_rng(2).random((10, 3)), index=idx)
@@ -554,7 +554,7 @@ class TestDataFramePlotsSubplots:
         _, axes = mpl.pyplot.subplots(2, **kwargs)
         with tm.assert_produces_warning(None):
             df.plot(ax=axes[0])
-            with tm.ensure_clean(return_filelike=True) as path:
+            with temp_file.open(mode="w+b", encoding="utf-8") as path:
                 mpl.pyplot.savefig(path)
 
     @pytest.mark.parametrize(

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -42,6 +42,7 @@ from pandas.tests.plotting.common import _check_ticks_props
 from pandas.tseries.offsets import WeekOfMonth
 
 mpl = pytest.importorskip("matplotlib")
+plt = pytest.importorskip("matplotlib.pyplot")
 
 
 class TestTSPlot:
@@ -1714,6 +1715,25 @@ class TestTSPlot:
         axes = df.plot(x="x", y="y", subplots=True, sharex=False)
         _check_ticks_props(axes, xrot=0)
 
+    @pytest.mark.parametrize(
+        "idx",
+        [
+            date_range("2020-01-01", periods=5),
+            date_range("2020-01-01", periods=5, tz="UTC"),
+            timedelta_range("1 day", periods=5, freq="D"),
+            period_range("2020-01-01", periods=5, freq="D"),
+            Index([date(2000, 1, i) for i in [1, 3, 6, 20, 22]], dtype=object),
+            range(5),
+        ],
+    )
+    def test_pickle_fig(self, temp_file, frame_or_series, idx):
+        # GH18439, GH#24088, statsmodels#4772
+        df = frame_or_series(range(5), index=idx)
+        fig, ax = plt.subplots(1, 1)
+        df.plot(ax=ax)
+        with temp_file.open(mode="wb") as path:
+            pickle.dump(fig, path)
+
 
 def _check_plot_works(f, freq=None, series=None, *args, **kwargs):
     import matplotlib.pyplot as plt
@@ -1746,9 +1766,5 @@ def _check_plot_works(f, freq=None, series=None, *args, **kwargs):
         kwargs["ax"] = ax
         ret = f(*args, **kwargs)
         assert ret is not None  # TODO: do something more intelligent
-
-        # GH18439, GH#24088, statsmodels#4772
-        with tm.ensure_clean(return_filelike=True) as path:
-            pickle.dump(fig, path)
     finally:
         plt.close(fig)

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -320,7 +320,7 @@ class TestExpressions:
     @pytest.mark.parametrize(
         "op_str,opname", [("+", "add"), ("*", "mul"), ("-", "sub")]
     )
-    def test_bool_ops_warn_on_arithmetic(self, op_str, opname):
+    def test_bool_ops_warn_on_arithmetic(self, op_str, opname, monkeypatch):
         n = 10
         df = DataFrame(
             {
@@ -339,36 +339,38 @@ class TestExpressions:
             # raises TypeError
             return
 
-        with tm.use_numexpr(True, min_elements=5):
-            with tm.assert_produces_warning():
-                r = f(df, df)
-                e = fe(df, df)
-                tm.assert_frame_equal(r, e)
+        with monkeypatch.context() as m:
+            m.setattr(expr, "_MIN_ELEMENTS", 5)
+            with option_context("compute.use_numexpr", True):
+                with tm.assert_produces_warning():
+                    r = f(df, df)
+                    e = fe(df, df)
+                    tm.assert_frame_equal(r, e)
 
-            with tm.assert_produces_warning():
-                r = f(df.a, df.b)
-                e = fe(df.a, df.b)
-                tm.assert_series_equal(r, e)
+                with tm.assert_produces_warning():
+                    r = f(df.a, df.b)
+                    e = fe(df.a, df.b)
+                    tm.assert_series_equal(r, e)
 
-            with tm.assert_produces_warning():
-                r = f(df.a, True)
-                e = fe(df.a, True)
-                tm.assert_series_equal(r, e)
+                with tm.assert_produces_warning():
+                    r = f(df.a, True)
+                    e = fe(df.a, True)
+                    tm.assert_series_equal(r, e)
 
-            with tm.assert_produces_warning():
-                r = f(False, df.a)
-                e = fe(False, df.a)
-                tm.assert_series_equal(r, e)
+                with tm.assert_produces_warning():
+                    r = f(False, df.a)
+                    e = fe(False, df.a)
+                    tm.assert_series_equal(r, e)
 
-            with tm.assert_produces_warning():
-                r = f(False, df)
-                e = fe(False, df)
-                tm.assert_frame_equal(r, e)
+                with tm.assert_produces_warning():
+                    r = f(False, df)
+                    e = fe(False, df)
+                    tm.assert_frame_equal(r, e)
 
-            with tm.assert_produces_warning():
-                r = f(df, True)
-                e = fe(df, True)
-                tm.assert_frame_equal(r, e)
+                with tm.assert_produces_warning():
+                    r = f(df, True)
+                    e = fe(df, True)
+                    tm.assert_frame_equal(r, e)
 
     @pytest.mark.parametrize(
         "test_input,expected",


### PR DESCRIPTION
* Replaced only use of `use_numexpr`
* Created pytest native `temp_file` fixture for use over `tm.ensure_clean`
