### PR TITLE
CLN: groupby.first/last unused compat

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -3250,27 +3250,10 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         1  5.0  1
         3  6.0  3
         """
-
-        def first_compat(obj: NDFrameT):
-            def first(x: Series):
-                """Helper function for first item that isn't NA."""
-                arr = x.array[notna(x.array)]
-                if not len(arr):
-                    return x.array.dtype.na_value
-                return arr[0]
-
-            if isinstance(obj, DataFrame):
-                return obj.apply(first)
-            elif isinstance(obj, Series):
-                return first(obj)
-            else:  # pragma: no cover
-                raise TypeError(type(obj))
-
         return self._agg_general(
             numeric_only=numeric_only,
             min_count=min_count,
             alias="first",
-            npfunc=first_compat,
             skipna=skipna,
         )
 
@@ -3319,27 +3302,10 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         1  5.0  2
         3  6.0  3
         """
-
-        def last_compat(obj: NDFrameT):
-            def last(x: Series):
-                """Helper function for last item that isn't NA."""
-                arr = x.array[notna(x.array)]
-                if not len(arr):
-                    return x.array.dtype.na_value
-                return arr[-1]
-
-            if isinstance(obj, DataFrame):
-                return obj.apply(last)
-            elif isinstance(obj, Series):
-                return last(obj)
-            else:  # pragma: no cover
-                raise TypeError(type(obj))
-
         return self._agg_general(
             numeric_only=numeric_only,
             min_count=min_count,
             alias="last",
-            npfunc=last_compat,
             skipna=skipna,
         )
 


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

It used to be that any op winding up in `_cython_agg_general` needed a fallback. This is no longer the case since `first` and `last` now handle `object` dtype in the Cython code and `axis=1` has been removed.

