### PR TITLE
DOC: ES01 fix for to_csv method

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -476,7 +476,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.DataFrame.sparse.from_spmatrix\
         pandas.DataFrame.sparse.to_coo\
         pandas.DataFrame.sparse.to_dense\
-        pandas.DataFrame.to_csv\
         pandas.DataFrame.to_feather\
         pandas.DataFrame.to_html\
         pandas.DataFrame.to_markdown\

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3672,14 +3672,13 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         r"""
         Write object to a comma-separated values (csv) file.
 
-        This method enables users to export DataFrame data to a CSV file
+        This method enables users to write object to comma-separated values (csv) file
         with customizable options. These options include specifying the delimiter,
-        handling missing data, formatting numbers,selecting columns, including headers
-        and row names, defining file opening modes, setting encoding and
-        compression options, controlling quoting and escaping characters,
-        specifying newline characters, managing chunk sizes, formatting
-        datetime objects, handling errors during encoding/decoding,
-        and providing storage connection options.
+        handling missing data, formatting numbers, selecting columns, including
+        headers and row names, defining file opening modes, setting encoding and
+        compression options, controlling quoting and escaping characters, specifying
+        newline characters, managing chunk sizes, formatting datetime objects, handling
+        errors during encoding/decoding, and providing storage connection options.
 
         The method returns None if path_or_buf is not specified;
         otherwise, it returns the resulting CSV format as a string.

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3672,6 +3672,18 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         r"""
         Write object to a comma-separated values (csv) file.
 
+        This method enables users to export DataFrame data to a CSV file
+        with customizable options. These options include specifying the delimiter,
+        handling missing data, formatting numbers,selecting columns, including headers
+        and row names, defining file opening modes, setting encoding and
+        compression options, controlling quoting and escaping characters,
+        specifying newline characters, managing chunk sizes, formatting
+        datetime objects, handling errors during encoding/decoding,
+        and providing storage connection options.
+
+        The method returns None if path_or_buf is not specified;
+        otherwise, it returns the resulting CSV format as a string.
+
         Parameters
         ----------
         path_or_buf : str, path object, file-like object, or None, default None

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3670,9 +3670,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         storage_options: StorageOptions | None = None,
     ) -> str | None:
         r"""
-        Write object to a comma-separated values (csv) file.
+        Write object to a comma-separated values (CSV) file.
 
-        This method enables users to write object to comma-separated values (csv) file
+        This method enables users to write object to comma-separated values (CSV) file
         with customizable options. These options include specifying the delimiter,
         handling missing data, formatting numbers, selecting columns, including
         headers and row names, defining file opening modes, setting encoding and
@@ -3680,7 +3680,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         newline characters, managing chunk sizes, formatting datetime objects, handling
         errors during encoding/decoding, and providing storage connection options.
 
-        The method returns None if path_or_buf is not specified;
+        The method returns None if `path_or_buf` is not specified;
         otherwise, it returns the resulting CSV format as a string.
 
         Parameters

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3680,7 +3680,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         newline characters, managing chunk sizes, formatting datetime objects, handling
         errors during encoding/decoding, and providing storage connection options.
 
-        The method returns None if `path_or_buf` is not specified;
+        The method returns None if ``path_or_buf`` is not specified;
         otherwise, it returns the resulting CSV format as a string.
 
         Parameters


### PR DESCRIPTION
All ES01 Errors resolved in the following cases:

scripts/validate_docstrings.py --format=actions --errors=ES01 pandas.DataFrame.to_csv 

- [x] xref #57440 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
