### PR TITLE
CLN: Use group_info less

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -813,7 +813,7 @@ class SeriesGroupBy(GroupBy[Series]):
         from pandas.core.reshape.merge import get_join_indexers
         from pandas.core.reshape.tile import cut
 
-        ids, _ = self._grouper.group_info
+        ids = self._grouper.ids
         val = self.obj._values
 
         index_names = self._grouper.names + [self.obj.name]

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1228,7 +1228,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
 
             ax = self._selected_obj.index
             if self.dropna:
-                labels = self._grouper.group_info[0]
+                labels = self._grouper.ids
                 mask = labels != -1
                 ax = ax[mask]
 
@@ -1423,7 +1423,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         )
         # Pass group ids to kernel directly if it can handle it
         # (This is faster since it doesn't require a sort)
-        ids, _ = self._grouper.group_info
+        ids = self._grouper.ids
         ngroups = self._grouper.ngroups
 
         res_mgr = df._mgr.apply(
@@ -4163,7 +4163,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         if not dropna:
             mask = self._make_mask_from_positional_indexer(n)
 
-            ids, _ = self._grouper.group_info
+            ids = self._grouper.ids
 
             # Drop NA values in grouping
             mask = mask & (ids != -1)
@@ -4503,7 +4503,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         """
         obj = self._obj_with_exclusions
         index = obj.index
-        comp_ids = self._grouper.group_info[0]
+        comp_ids = self._grouper.ids
 
         dtype: type
         if self._grouper.has_dropped_na:
@@ -5382,7 +5382,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         Series or DataFrame
             Filtered _selected_obj.
         """
-        ids = self._grouper.group_info[0]
+        ids = self._grouper.ids
         mask = mask & (ids != -1)
         return self._selected_obj[mask]
 

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -716,7 +716,7 @@ class BaseGrouper:
     @cache_readonly
     def is_monotonic(self) -> bool:
         # return if my group orderings are monotonic
-        return Index(self.group_info[0]).is_monotonic_increasing
+        return Index(self.ids).is_monotonic_increasing
 
     @final
     @cache_readonly
@@ -735,8 +735,7 @@ class BaseGrouper:
     @cache_readonly
     def codes_info(self) -> npt.NDArray[np.intp]:
         # return the codes of items in original grouped axis
-        ids, _ = self.group_info
-        return ids
+        return self.ids
 
     @final
     @cache_readonly
@@ -933,9 +932,7 @@ class BaseGrouper:
     def _aggregate_series_pure_python(
         self, obj: Series, func: Callable
     ) -> npt.NDArray[np.object_]:
-        _, ngroups = self.group_info
-
-        result = np.empty(ngroups, dtype="O")
+        result = np.empty(self.ngroups, dtype="O")
         initialized = False
 
         splitter = self._get_splitter(obj)
@@ -1073,7 +1070,7 @@ class BinGrouper(BaseGrouper):
     @cache_readonly
     def codes_info(self) -> npt.NDArray[np.intp]:
         # return the codes of items in original grouped axis
-        ids, _ = self.group_info
+        ids = self.ids
         if self.indexer is not None:
             sorter = np.lexsort((ids, self.indexer))
             ids = ids[sorter]
@@ -1133,7 +1130,7 @@ class BinGrouper(BaseGrouper):
 
     @cache_readonly
     def codes(self) -> list[npt.NDArray[np.intp]]:
-        return [self.group_info[0]]
+        return [self.ids]
 
     @cache_readonly
     def result_index_and_ids(self):
@@ -1150,7 +1147,7 @@ class BinGrouper(BaseGrouper):
     @property
     def groupings(self) -> list[grouper.Grouping]:
         lev = self.binlabels
-        codes = self.group_info[0]
+        codes = self.ids
         labels = lev.take(codes)
         ping = grouper.Grouping(
             labels, labels, in_axis=False, level=None, uniques=lev._values

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -776,10 +776,10 @@ class TestGrouping:
         # check group properties
         assert len(gr._grouper.groupings) == 1
         tm.assert_numpy_array_equal(
-            gr._grouper.group_info[0], np.array([], dtype=np.dtype(np.intp))
+            gr._grouper.ids, np.array([], dtype=np.dtype(np.intp))
         )
 
-        assert gr._grouper.group_info[1] == 0
+        assert gr._grouper.ngroups == 0
 
         # check name
         gb = s.groupby(s)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

My goal is to remove redundant methods in BaseGrouper / Grouping - group_info seems like a good candidate.