### PR TITLE
REF: Move compute to BinGrouper.result_index_and_ids

### DIFF
--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -1113,23 +1113,7 @@ class BinGrouper(BaseGrouper):
 
     @cache_readonly
     def group_info(self) -> tuple[npt.NDArray[np.intp], int]:
-        ngroups = self.ngroups
-        rep = np.diff(np.r_[0, self.bins])
-
-        rep = ensure_platform_int(rep)
-        if ngroups == len(self.bins):
-            comp_ids = np.repeat(np.arange(ngroups), rep)
-        else:
-            comp_ids = np.repeat(np.r_[-1, np.arange(ngroups)], rep)
-
-        return (ensure_platform_int(comp_ids), ngroups)
-
-    @cache_readonly
-    def result_index(self) -> Index:
-        if len(self.binlabels) != 0 and isna(self.binlabels[0]):
-            return self.binlabels[1:]
-
-        return self.binlabels
+        return self.ids, self.ngroups
 
     @cache_readonly
     def codes(self) -> list[npt.NDArray[np.intp]]:
@@ -1137,7 +1121,21 @@ class BinGrouper(BaseGrouper):
 
     @cache_readonly
     def result_index_and_ids(self):
-        return self.result_index, self.group_info[0]
+        result_index = self.binlabels
+        if len(self.binlabels) != 0 and isna(self.binlabels[0]):
+            result_index = result_index[1:]
+
+        ngroups = len(result_index)
+        rep = np.diff(np.r_[0, self.bins])
+
+        rep = ensure_platform_int(rep)
+        if ngroups == len(self.bins):
+            ids = np.repeat(np.arange(ngroups), rep)
+        else:
+            ids = np.repeat(np.r_[-1, np.arange(ngroups)], rep)
+        ids = ensure_platform_int(ids)
+
+        return result_index, ids
 
     @property
     def levels(self) -> list[Index]:


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

BaseGrouper does the compute in `result_index_and_ids` and other methods utilize this result. This refactors so BinGrouper behaves the same.