### PR TITLE
DOC: fix RT03 for pandas.Index.to_numpy and pandas.Categorial.set_categories 

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -1882,8 +1882,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
 
     MSG='Partially validate docstrings (RT03)' ;  echo $MSG
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=RT03 --ignore_functions \
-        pandas.Index.to_numpy\
-        pandas.Categorical.set_categories\
         pandas.CategoricalIndex.set_categories\
         pandas.DataFrame.astype\
         pandas.DataFrame.at_time\

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1071,7 +1071,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         ----------
         new_categories : Index-like
            The categories in new order.
-        ordered : bool, default False
+        ordered : bool, default None
            Whether or not the categorical is treated as a ordered categorical.
            If not given, do not change the ordered information.
         rename : bool, default False
@@ -1080,7 +1080,8 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
         Returns
         -------
-        Categorical with reordered categories.
+        Categorical
+            
 
         Raises
         ------

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1064,7 +1064,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         On the other hand this methods does not do checks (e.g., whether the
         old categories are included in the new categories on a reorder), which
         can result in surprising changes, for example when using special string
-        dtypes, which does not considers a S1 string equal to a single char
+        dtypes, which do not consider a S1 string equal to a single char
         python string.
 
         Parameters
@@ -1081,7 +1081,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         Returns
         -------
         Categorical
-            
+            New categories to be used, with optional ordering changes.
 
         Raises
         ------

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -566,6 +566,8 @@ class IndexOpsMixin(OpsMixin):
         Returns
         -------
         numpy.ndarray
+            The NumPy ndarray holding the values from this Series or Index.
+            The dtype of the array may differ. See Notes.
 
         See Also
         --------


### PR DESCRIPTION
Resolve all errors for the following cases:

1. scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.Index.to_numpy
2. scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.Categorical.set_categories

Also fixes typos and wrong default value in docstring of pandas.Categorical.set_categories.

- [ ] xref #57416 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
