### PR TITLE
DOC: fix RT03 for CategoricalIndex.set_categories, DataFrame.astype, DataFrame.at_time and DataFrame.ewm

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -1882,10 +1882,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
 
     MSG='Partially validate docstrings (RT03)' ;  echo $MSG
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=RT03 --ignore_functions \
-        pandas.CategoricalIndex.set_categories\
-        pandas.DataFrame.astype\
-        pandas.DataFrame.at_time\
-        pandas.DataFrame.ewm\
         pandas.DataFrame.expanding\
         pandas.DataFrame.filter\
         pandas.DataFrame.first_valid_index\

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6197,6 +6197,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         Returns
         -------
         same type as caller
+            The pandas object casted to the specified ``dtype``.
 
         See Also
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8676,6 +8676,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         Returns
         -------
         Series or DataFrame
+            The values with the specified time.
 
         Raises
         ------

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -226,7 +226,8 @@ class ExponentialMovingWindow(BaseWindow):
     Returns
     -------
     pandas.api.typing.ExponentialMovingWindow
-        An instance of ExponentialMovingWindow for further exponentially weighted (EW) calculations, e.g. using the ``mean`` method.
+        An instance of ExponentialMovingWindow for further exponentially weighted (EW)
+        calculations, e.g. using the ``mean`` method.
 
     See Also
     --------

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -226,6 +226,7 @@ class ExponentialMovingWindow(BaseWindow):
     Returns
     -------
     pandas.api.typing.ExponentialMovingWindow
+        An instance of ExponentialMovingWindow for further exponentially weighted (EW) calculations, e.g. using the ``mean`` method.
 
     See Also
     --------


### PR DESCRIPTION
Resolve all RT03 errors for the following cases:

1. scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.CategoricalIndex.set_categories (already valid)
2. scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.DataFrame.astype
3. scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.DataFrame.at_time
4. scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.DataFrame.ewm

- [ ] xref #57416 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
