### PR TITLE
Doc: fix ES01 for pandas.CategoricalDtype

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -423,7 +423,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.Categorical.ordered\
         pandas.Categorical.remove_unused_categories\
         pandas.Categorical.rename_categories\
-        pandas.CategoricalDtype\
         pandas.CategoricalDtype.categories\
         pandas.CategoricalDtype.ordered\
         pandas.CategoricalIndex.as_ordered\

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -157,6 +157,17 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
     """
     Type for categorical data with the categories and orderedness.
 
+    A categorical's type is fully described by
+    1. categories: a sequence of unique values and no missing values
+    2. ordered: a boolean
+    This information can be stored in a CategoricalDtype. The categories argument
+    is optional, which implies that the actual categories should be inferred from
+    whatever is present in the data when the pandas.Categorical is created.
+    The categories are assumed to be unordered by default.
+
+    A CategoricalDtype can be used in any place pandas expects a dtype. For example
+    pandas.read_csv(), pandas.DataFrame.astype(), or in the Series constructor.
+
     Parameters
     ----------
     categories : sequence, optional


### PR DESCRIPTION
All ES01 Errors resolved in the following cases:

1. scripts/validate_docstrings.py --format=actions --errors=ES01 pandas.CategoricalDtype

- [x]  xref #57440
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
