### PR TITLE
fix SA01 error for pandas.ArrowDtype

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -2152,7 +2152,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
 
     MSG='Partially validate docstrings (SA01)' ;  echo $MSG
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=SA01 --ignore_functions \
-        pandas.ArrowDtype\
         pandas.BooleanDtype\
         pandas.Categorical.__array__\
         pandas.Categorical.as_ordered\

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -2062,7 +2062,7 @@ class ArrowDtype(StorageExtensionDtype):
     Parameters
     ----------
     pyarrow_dtype : pa.DataType
-        An instance of a `pyarrow.DataType <https://arrow.apache.org/docs/python/api/datatypes.html#factory-functions>`__.
+        An instance of a :ref:`pyarrow.DataType<datatypes.factory-functions>`.
 
     Attributes
     ----------
@@ -2075,6 +2075,10 @@ class ArrowDtype(StorageExtensionDtype):
     Returns
     -------
     ArrowDtype
+
+    See Also
+    --------
+    DataFrame.convert_dtypes : Convert columns to the best possible dtypes.
 
     Examples
     --------

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -2062,7 +2062,7 @@ class ArrowDtype(StorageExtensionDtype):
     Parameters
     ----------
     pyarrow_dtype : pa.DataType
-        An instance of a :ref:`pyarrow.DataType<datatypes.factory-functions>`.
+        An instance of a `pyarrow.DataType <https://arrow.apache.org/docs/python/api/datatypes.html#factory-functions>`__.
 
     Attributes
     ----------


### PR DESCRIPTION
All SA01 Errors resolved in the following cases:

1. scripts/validate_docstrings.py --format=actions --errors=SA01 pandas.ArrowDtype

- [x] xref https://github.com/pandas-dev/pandas/issues/57417
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
