### PR TITLE
BUG: Change output returned by _LocIndexer._convert_to_indexer to return key with greater resolution value

### DIFF
--- a/doc/source/whatsnew/v2.2.1.rst
+++ b/doc/source/whatsnew/v2.2.1.rst
@@ -62,6 +62,7 @@ Bug fixes
 - Fixed bug in :func:`pandas.api.interchange.from_dataframe` which wasn't converting columns names to strings (:issue:`55069`)
 - Fixed bug in :meth:`DataFrame.__getitem__` for empty :class:`DataFrame` with Copy-on-Write enabled (:issue:`57130`)
 - Fixed bug in :meth:`PeriodIndex.asfreq` which was silently converting frequencies which are not supported as period frequencies instead of raising an error (:issue:`56945`)
+- Fixed bug in :meth:`_LocIndexer._convert_to_indexer` which doesn't properly insert timestamps into Series (:issue:`57596`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_221.other:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1490,7 +1490,10 @@ class _LocIndexer(_LocationIndexer):
 
             # if we are a label return me
             try:
-                return labels.get_loc(key)
+                label = labels.get_loc(key)
+                if label:
+                    return label
+                return {"key": key} 
             except LookupError:
                 if isinstance(key, tuple) and isinstance(labels, MultiIndex):
                     if len(key) == labels.nlevels:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1493,7 +1493,7 @@ class _LocIndexer(_LocationIndexer):
                 label = labels.get_loc(key)
                 if label:
                     return label
-                return {"key": key} 
+                return {"key": key}
             except LookupError:
                 if isinstance(key, tuple) and isinstance(labels, MultiIndex):
                     if len(key) == labels.nlevels:


### PR DESCRIPTION
Resolution info:

**Resolution.RESO_SEC - 3 for seconds**
**Resolution.RESO_MIN - 4 for minute**

Observation:
With the previous code, when the current entry (**resolution: 4, entry: '2024-02-24 10:08'**) has a greater resolution value than the smallest amongst previous entries (in this case **resolution: 3, entry: '2024-02-24 10:2:30'**), it is shown that the key is said to exist within the list of keys within the Series even though it shouldn't. This does not happen when a smaller or equal resolution value entry is inserted into the Series.

![Screenshot from 2024-02-26 13-14-10](https://github.com/pandas-dev/pandas/assets/122815453/0ec3fc4d-4831-47ac-9c19-c8b8fdbbaea9)

Thought process:
With the previous code, if the current entry's resolution value is greater than the smallest resolution value amongst the previous entries, the *_LocIndexer._convert_to_indexer* method will only return an empty list (output of the method *labels.get_loc(key)*), which might be causing entries with larger resolution values not being inserted into the *Series* correctly.

Potential solution:
I have changed the method *_LocIndexer._convert_to_indexer* to return the key ('2024-02-24 10:08') instead of an empty list when the resolution value is greater than the smallest resolution value.


- [x] closes #57596 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v2.2.1.rst` file if fixing a bug or adding a new feature.
