### PR TITLE
CLN: unify error message when parsing datetimes with mixed time zones with utc=False

### DIFF
--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -598,7 +598,8 @@ cpdef array_to_datetime(
         is_same_offsets = len(out_tzoffset_vals) == 1
         if not is_same_offsets:
             raise ValueError(
-                "cannot parse datetimes with mixed time zones unless `utc=True`"
+                "Mixed timezones detected. pass utc=True in to_datetime "
+                "or tz='UTC' in DatetimeIndex to convert to a common timezone."
             )
         elif state.found_naive or state.found_other:
             # e.g. test_to_datetime_mixed_awareness_mixed_types

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -598,7 +598,7 @@ cpdef array_to_datetime(
         is_same_offsets = len(out_tzoffset_vals) == 1
         if not is_same_offsets:
             raise ValueError(
-                "Mixed timezones detected. pass utc=True in to_datetime "
+                "Mixed timezones detected. Pass utc=True in to_datetime "
                 "or tz='UTC' in DatetimeIndex to convert to a common timezone."
             )
         elif state.found_naive or state.found_other:
@@ -611,7 +611,7 @@ cpdef array_to_datetime(
             if not tz_compare(tz_out, tz_out2):
                 # e.g. test_to_datetime_mixed_tzs_mixed_types
                 raise ValueError(
-                    "Mixed timezones detected. pass utc=True in to_datetime "
+                    "Mixed timezones detected. Pass utc=True in to_datetime "
                     "or tz='UTC' in DatetimeIndex to convert to a common timezone."
                 )
             # e.g. test_to_datetime_mixed_types_matching_tzs

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -503,7 +503,8 @@ def array_strptime(
         is_same_offsets = len(out_tzoffset_vals) == 1
         if not is_same_offsets or (state.found_naive or state.found_other):
             raise ValueError(
-                "cannot parse datetimes with mixed time zones unless `utc=True`"
+                "Mixed timezones detected. pass utc=True in to_datetime "
+                "or tz='UTC' in DatetimeIndex to convert to a common timezone."
             )
         elif tz_out is not None:
             # GH#55693
@@ -512,7 +513,8 @@ def array_strptime(
             if not tz_compare(tz_out, tz_out2):
                 # e.g. test_to_datetime_mixed_offsets_with_utc_false_removed
                 raise ValueError(
-                    "cannot parse datetimes with mixed time zones unless `utc=True`"
+                    "Mixed timezones detected. pass utc=True in to_datetime "
+                    "or tz='UTC' in DatetimeIndex to convert to a common timezone."
                 )
             # e.g. test_guess_datetime_format_with_parseable_formats
         else:
@@ -523,7 +525,8 @@ def array_strptime(
         if tz_out and (state.found_other or state.found_naive_str):
             # found_other indicates a tz-naive int, float, dt64, or date
             raise ValueError(
-                "cannot parse datetimes with mixed time zones unless `utc=True`"
+                "Mixed timezones detected. pass utc=True in to_datetime "
+                "or tz='UTC' in DatetimeIndex to convert to a common timezone."
             )
 
     if infer_reso:

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -503,7 +503,7 @@ def array_strptime(
         is_same_offsets = len(out_tzoffset_vals) == 1
         if not is_same_offsets or (state.found_naive or state.found_other):
             raise ValueError(
-                "Mixed timezones detected. pass utc=True in to_datetime "
+                "Mixed timezones detected. Pass utc=True in to_datetime "
                 "or tz='UTC' in DatetimeIndex to convert to a common timezone."
             )
         elif tz_out is not None:
@@ -513,7 +513,7 @@ def array_strptime(
             if not tz_compare(tz_out, tz_out2):
                 # e.g. test_to_datetime_mixed_offsets_with_utc_false_removed
                 raise ValueError(
-                    "Mixed timezones detected. pass utc=True in to_datetime "
+                    "Mixed timezones detected. Pass utc=True in to_datetime "
                     "or tz='UTC' in DatetimeIndex to convert to a common timezone."
                 )
             # e.g. test_guess_datetime_format_with_parseable_formats
@@ -525,7 +525,7 @@ def array_strptime(
         if tz_out and (state.found_other or state.found_naive_str):
             # found_other indicates a tz-naive int, float, dt64, or date
             raise ValueError(
-                "Mixed timezones detected. pass utc=True in to_datetime "
+                "Mixed timezones detected. Pass utc=True in to_datetime "
                 "or tz='UTC' in DatetimeIndex to convert to a common timezone."
             )
 

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -932,7 +932,8 @@ def to_datetime(
     >>> pd.to_datetime(
     ...     ["2020-10-25 02:00 +0200", "2020-10-25 04:00 +0100"]
     ... )  # doctest: +SKIP
-    ValueError: cannot parse datetimes with mixed time zones unless `utc=True`
+    ValueError: Mixed timezones detected. pass utc=True in to_datetime
+    or tz='UTC' in DatetimeIndex to convert to a common timezone.
 
     - To create a :class:`Series` with mixed offsets and ``object`` dtype, please use
       :meth:`Series.apply` and :func:`datetime.datetime.strptime`:
@@ -951,7 +952,8 @@ def to_datetime(
     >>> pd.to_datetime(
     ...     ["2020-01-01 01:00:00-01:00", datetime(2020, 1, 1, 3, 0)]
     ... )  # doctest: +SKIP
-    ValueError: cannot parse datetimes with mixed time zones unless `utc=True`
+    ValueError: Mixed timezones detected. pass utc=True in to_datetime
+    or tz='UTC' in DatetimeIndex to convert to a common timezone.
 
     |
 

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -932,7 +932,7 @@ def to_datetime(
     >>> pd.to_datetime(
     ...     ["2020-10-25 02:00 +0200", "2020-10-25 04:00 +0100"]
     ... )  # doctest: +SKIP
-    ValueError: Mixed timezones detected. pass utc=True in to_datetime
+    ValueError: Mixed timezones detected. Pass utc=True in to_datetime
     or tz='UTC' in DatetimeIndex to convert to a common timezone.
 
     - To create a :class:`Series` with mixed offsets and ``object`` dtype, please use
@@ -952,7 +952,7 @@ def to_datetime(
     >>> pd.to_datetime(
     ...     ["2020-01-01 01:00:00-01:00", datetime(2020, 1, 1, 3, 0)]
     ... )  # doctest: +SKIP
-    ValueError: Mixed timezones detected. pass utc=True in to_datetime
+    ValueError: Mixed timezones detected. Pass utc=True in to_datetime
     or tz='UTC' in DatetimeIndex to convert to a common timezone.
 
     |

--- a/pandas/tests/indexes/datetimes/test_constructors.py
+++ b/pandas/tests/indexes/datetimes/test_constructors.py
@@ -296,7 +296,7 @@ class TestDatetimeIndex:
         tm.assert_index_equal(result, exp, exact=True)
         assert not isinstance(result, DatetimeIndex)
 
-        msg = "Mixed timezones detected. pass utc=True in to_datetime"
+        msg = "Mixed timezones detected. Pass utc=True in to_datetime"
         with pytest.raises(ValueError, match=msg):
             DatetimeIndex(["2013-11-02 22:00-05:00", "2013-11-03 22:00-06:00"])
 

--- a/pandas/tests/indexes/datetimes/test_constructors.py
+++ b/pandas/tests/indexes/datetimes/test_constructors.py
@@ -296,7 +296,7 @@ class TestDatetimeIndex:
         tm.assert_index_equal(result, exp, exact=True)
         assert not isinstance(result, DatetimeIndex)
 
-        msg = "cannot parse datetimes with mixed time zones unless `utc=True`"
+        msg = "Mixed timezones detected. pass utc=True in to_datetime"
         with pytest.raises(ValueError, match=msg):
             DatetimeIndex(["2013-11-02 22:00-05:00", "2013-11-03 22:00-06:00"])
 

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -463,7 +463,7 @@ class TestTimeConversionFormats:
         self, fmt, dates, expected_dates
     ):
         # GH#13486, GH#50887, GH#57275
-        msg = "Mixed timezones detected. pass utc=True in to_datetime"
+        msg = "Mixed timezones detected. Pass utc=True in to_datetime"
         with pytest.raises(ValueError, match=msg):
             to_datetime(dates, format=fmt)
 
@@ -646,7 +646,7 @@ class TestToDatetime:
         args = ["2000-01-01 01:00:00", "2000-01-01 02:00:00+00:00"]
         ts1 = constructor(args[0])
         ts2 = args[1]
-        msg = "Mixed timezones detected. pass utc=True in to_datetime"
+        msg = "Mixed timezones detected. Pass utc=True in to_datetime"
 
         with pytest.raises(ValueError, match=msg):
             to_datetime([ts1, ts2], format=fmt, utc=False)
@@ -679,7 +679,7 @@ class TestToDatetime:
     ):
         # https://github.com/pandas-dev/pandas/issues/50071
         # GH#57275
-        msg = "Mixed timezones detected. pass utc=True in to_datetime"
+        msg = "Mixed timezones detected. Pass utc=True in to_datetime"
 
         with pytest.raises(ValueError, match=msg):
             to_datetime(
@@ -1152,7 +1152,7 @@ class TestToDatetime:
         ts_string_1 = "March 1, 2018 12:00:00+0400"
         ts_string_2 = "March 1, 2018 12:00:00+0500"
         arr = [ts_string_1] * 5 + [ts_string_2] * 5
-        msg = "Mixed timezones detected. pass utc=True in to_datetime"
+        msg = "Mixed timezones detected. Pass utc=True in to_datetime"
         with pytest.raises(ValueError, match=msg):
             to_datetime(arr, cache=cache)
 
@@ -1509,7 +1509,7 @@ class TestToDatetime:
             "March 1, 2018 12:00:00+0500",
             "20100240",
         ]
-        msg = "Mixed timezones detected. pass utc=True in to_datetime"
+        msg = "Mixed timezones detected. Pass utc=True in to_datetime"
         with pytest.raises(ValueError, match=msg):
             to_datetime(ts_strings, errors="coerce")
 
@@ -1581,7 +1581,7 @@ class TestToDatetime:
     def test_iso_8601_strings_with_different_offsets_removed(self):
         # GH#17697, GH#11736, GH#50887, GH#57275
         ts_strings = ["2015-11-18 15:30:00+05:30", "2015-11-18 16:30:00+06:30", NaT]
-        msg = "Mixed timezones detected. pass utc=True in to_datetime"
+        msg = "Mixed timezones detected. Pass utc=True in to_datetime"
         with pytest.raises(ValueError, match=msg):
             to_datetime(ts_strings)
 
@@ -1608,7 +1608,7 @@ class TestToDatetime:
         ser = Series(vals)
         assert all(ser[i] is vals[i] for i in range(len(vals)))  # GH#40111
 
-        msg = "Mixed timezones detected. pass utc=True in to_datetime"
+        msg = "Mixed timezones detected. Pass utc=True in to_datetime"
         with pytest.raises(ValueError, match=msg):
             to_datetime(ser)
 
@@ -1673,7 +1673,7 @@ class TestToDatetime:
     )
     def test_to_datetime_mixed_offsets_with_utc_false_removed(self, date):
         # GH#50887, GH#57275
-        msg = "Mixed timezones detected. pass utc=True in to_datetime"
+        msg = "Mixed timezones detected. Pass utc=True in to_datetime"
         with pytest.raises(ValueError, match=msg):
             to_datetime(date, utc=False)
 
@@ -3463,7 +3463,7 @@ def test_to_datetime_with_empty_str_utc_false_format_mixed():
 
 def test_to_datetime_with_empty_str_utc_false_offsets_and_format_mixed():
     # GH#50887, GH#57275
-    msg = "Mixed timezones detected. pass utc=True in to_datetime"
+    msg = "Mixed timezones detected. Pass utc=True in to_datetime"
 
     with pytest.raises(ValueError, match=msg):
         to_datetime(
@@ -3479,7 +3479,7 @@ def test_to_datetime_mixed_tzs_mixed_types():
     arr = [ts, dtstr]
 
     msg = (
-        "Mixed timezones detected. pass utc=True in to_datetime or tz='UTC' "
+        "Mixed timezones detected. Pass utc=True in to_datetime or tz='UTC' "
         "in DatetimeIndex to convert to a common timezone"
     )
     with pytest.raises(ValueError, match=msg):
@@ -3578,7 +3578,7 @@ def test_to_datetime_mixed_awareness_mixed_types(aware_val, naive_val, naive_fir
             to_datetime(vec, utc=True)
 
     else:
-        msg = "Mixed timezones detected. pass utc=True in to_datetime"
+        msg = "Mixed timezones detected. Pass utc=True in to_datetime"
         with pytest.raises(ValueError, match=msg):
             to_datetime(vec)
 
@@ -3586,7 +3586,7 @@ def test_to_datetime_mixed_awareness_mixed_types(aware_val, naive_val, naive_fir
         to_datetime(vec, utc=True)
 
     if both_strs:
-        msg = "Mixed timezones detected. pass utc=True in to_datetime"
+        msg = "Mixed timezones detected. Pass utc=True in to_datetime"
         with pytest.raises(ValueError, match=msg):
             to_datetime(vec, format="mixed")
         with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -463,7 +463,7 @@ class TestTimeConversionFormats:
         self, fmt, dates, expected_dates
     ):
         # GH#13486, GH#50887, GH#57275
-        msg = "cannot parse datetimes with mixed time zones unless `utc=True`"
+        msg = "Mixed timezones detected. pass utc=True in to_datetime"
         with pytest.raises(ValueError, match=msg):
             to_datetime(dates, format=fmt)
 
@@ -646,7 +646,7 @@ class TestToDatetime:
         args = ["2000-01-01 01:00:00", "2000-01-01 02:00:00+00:00"]
         ts1 = constructor(args[0])
         ts2 = args[1]
-        msg = "cannot parse datetimes with mixed time zones unless `utc=True`"
+        msg = "Mixed timezones detected. pass utc=True in to_datetime"
 
         with pytest.raises(ValueError, match=msg):
             to_datetime([ts1, ts2], format=fmt, utc=False)
@@ -679,7 +679,7 @@ class TestToDatetime:
     ):
         # https://github.com/pandas-dev/pandas/issues/50071
         # GH#57275
-        msg = "cannot parse datetimes with mixed time zones unless `utc=True`"
+        msg = "Mixed timezones detected. pass utc=True in to_datetime"
 
         with pytest.raises(ValueError, match=msg):
             to_datetime(
@@ -1152,7 +1152,7 @@ class TestToDatetime:
         ts_string_1 = "March 1, 2018 12:00:00+0400"
         ts_string_2 = "March 1, 2018 12:00:00+0500"
         arr = [ts_string_1] * 5 + [ts_string_2] * 5
-        msg = "cannot parse datetimes with mixed time zones unless `utc=True`"
+        msg = "Mixed timezones detected. pass utc=True in to_datetime"
         with pytest.raises(ValueError, match=msg):
             to_datetime(arr, cache=cache)
 
@@ -1509,7 +1509,7 @@ class TestToDatetime:
             "March 1, 2018 12:00:00+0500",
             "20100240",
         ]
-        msg = "cannot parse datetimes with mixed time zones unless `utc=True`"
+        msg = "Mixed timezones detected. pass utc=True in to_datetime"
         with pytest.raises(ValueError, match=msg):
             to_datetime(ts_strings, errors="coerce")
 
@@ -1581,7 +1581,7 @@ class TestToDatetime:
     def test_iso_8601_strings_with_different_offsets_removed(self):
         # GH#17697, GH#11736, GH#50887, GH#57275
         ts_strings = ["2015-11-18 15:30:00+05:30", "2015-11-18 16:30:00+06:30", NaT]
-        msg = "cannot parse datetimes with mixed time zones unless `utc=True`"
+        msg = "Mixed timezones detected. pass utc=True in to_datetime"
         with pytest.raises(ValueError, match=msg):
             to_datetime(ts_strings)
 
@@ -1608,7 +1608,7 @@ class TestToDatetime:
         ser = Series(vals)
         assert all(ser[i] is vals[i] for i in range(len(vals)))  # GH#40111
 
-        msg = "cannot parse datetimes with mixed time zones unless `utc=True`"
+        msg = "Mixed timezones detected. pass utc=True in to_datetime"
         with pytest.raises(ValueError, match=msg):
             to_datetime(ser)
 
@@ -1673,7 +1673,7 @@ class TestToDatetime:
     )
     def test_to_datetime_mixed_offsets_with_utc_false_removed(self, date):
         # GH#50887, GH#57275
-        msg = "cannot parse datetimes with mixed time zones unless `utc=True`"
+        msg = "Mixed timezones detected. pass utc=True in to_datetime"
         with pytest.raises(ValueError, match=msg):
             to_datetime(date, utc=False)
 
@@ -3463,7 +3463,7 @@ def test_to_datetime_with_empty_str_utc_false_format_mixed():
 
 def test_to_datetime_with_empty_str_utc_false_offsets_and_format_mixed():
     # GH#50887, GH#57275
-    msg = "cannot parse datetimes with mixed time zones unless `utc=True`"
+    msg = "Mixed timezones detected. pass utc=True in to_datetime"
 
     with pytest.raises(ValueError, match=msg):
         to_datetime(
@@ -3578,7 +3578,7 @@ def test_to_datetime_mixed_awareness_mixed_types(aware_val, naive_val, naive_fir
             to_datetime(vec, utc=True)
 
     else:
-        msg = "cannot parse datetimes with mixed time zones unless `utc=True`"
+        msg = "Mixed timezones detected. pass utc=True in to_datetime"
         with pytest.raises(ValueError, match=msg):
             to_datetime(vec)
 
@@ -3586,7 +3586,7 @@ def test_to_datetime_mixed_awareness_mixed_types(aware_val, naive_val, naive_fir
         to_datetime(vec, utc=True)
 
     if both_strs:
-        msg = "cannot parse datetimes with mixed time zones unless `utc=True`"
+        msg = "Mixed timezones detected. pass utc=True in to_datetime"
         with pytest.raises(ValueError, match=msg):
             to_datetime(vec, format="mixed")
         with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/tslibs/test_array_to_datetime.py
+++ b/pandas/tests/tslibs/test_array_to_datetime.py
@@ -200,7 +200,7 @@ def test_parsing_different_timezone_offsets():
     data = ["2015-11-18 15:30:00+05:30", "2015-11-18 15:30:00+06:30"]
     data = np.array(data, dtype=object)
 
-    msg = "cannot parse datetimes with mixed time zones unless `utc=True`"
+    msg = "Mixed timezones detected. pass utc=True in to_datetime"
     with pytest.raises(ValueError, match=msg):
         tslib.array_to_datetime(data)
 

--- a/pandas/tests/tslibs/test_array_to_datetime.py
+++ b/pandas/tests/tslibs/test_array_to_datetime.py
@@ -200,7 +200,7 @@ def test_parsing_different_timezone_offsets():
     data = ["2015-11-18 15:30:00+05:30", "2015-11-18 15:30:00+06:30"]
     data = np.array(data, dtype=object)
 
-    msg = "Mixed timezones detected. pass utc=True in to_datetime"
+    msg = "Mixed timezones detected. Pass utc=True in to_datetime"
     with pytest.raises(ValueError, match=msg):
         tslib.array_to_datetime(data)
 


### PR DESCRIPTION
xref #57275, #55793

unified ValueError message when parsing datetimes with mixed time zones with utc=False
so far we get two different ValueError messages:
```
import pandas as pd
from datetime import datetime
import pytz

str_my ="2020-10-26 00:00:00+06:00"
ts = pd.Timestamp("2018-01-01", tz="US/Pacific")
dt = datetime(2020, 1, 1, 18, tzinfo=pytz.timezone("Australia/Melbourne"))

dt1 = pd.to_datetime([ts, str_my])
# ValueError: Mixed timezones detected. pass utc=True in to_datetime or tz='UTC' in DatetimeIndex to convert to a common timezone.
dt2 = pd.to_datetime([str_my, ts])
# ValueError: cannot parse datetimes with mixed time zones unless `utc=True`

dt1 = pd.to_datetime([dt, str_my], utc=False)
# ValueError: Mixed timezones detected. pass utc=True in to_datetime or tz='UTC' in DatetimeIndex to convert to a common timezone.
dt2 = pd.to_datetime([str_my, dt], utc=False)
# ValueError: cannot parse datetimes with mixed time zones unless `utc=True`
```