### PR TITLE
ENH: Report how far off the formatting is

### DIFF
--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -1327,7 +1327,8 @@ class ExcelWriter(Generic[_WorkbookT]):
             # xref https://support.microsoft.com/en-au/office/excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3
             if len(val) > 32767:
                 warnings.warn(
-                    "Cell contents too long, truncated to 32767 characters",
+                    f"Cell contents too long ({len(val)}), "
+                    "truncated to 32767 characters",
                     UserWarning,
                     stacklevel=find_stack_level(),
                 )

--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -1390,7 +1390,7 @@ class TestExcelWriter:
     def test_to_excel_raising_warning_when_cell_character_exceed_limit(self):
         # GH#56954
         df = DataFrame({"A": ["a" * 32768]})
-        msg = "Cell contents too long, truncated to 32767 characters"
+        msg = r"Cell contents too long \(32768\), truncated to 32767 characters"
         with tm.assert_produces_warning(
             UserWarning, match=msg, raise_on_extra_warnings=False
         ):


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Not sure this warrants a ~~test change or~~ `whatsnew` entry but I can add it if requested -- just takes the error message and makes it more informative:
```
E   UserWarning: Cell contents too long (54416), truncated to 32767 characters
```