### PR TITLE
DOC: Extended the documentation for `DataFrame.sort_values()`

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6928,8 +6928,7 @@ class DataFrame(NDFrame, OpsMixin):
         If sorted indices are not needed, you may simplify the procedure as follows:
 
         >>> from natsort import natsort_keygen
-        ...
-        ... df.sort_values(
+        >>> df.sort_values(
         ...     by="time",
         ...     key=natsort_keygen(),
         ... )

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6896,7 +6896,35 @@ class DataFrame(NDFrame, OpsMixin):
         `natural sorting <https://en.wikipedia.org/wiki/Natural_sort_order>`__.
         This can be done using
         ``natsort`` `package <https://github.com/SethMMorton/natsort>`__,
-        which sorts according to natural order of elements.
+        which provides sorted indices according
+        to their natural order, as shown below:
+
+        >>> df = pd.DataFrame(
+        ...     {
+        ...         "time": ["0hr", "128hr", "72hr", "48hr", "96hr"],
+        ...         "value": [10, 20, 30, 40, 50],
+        ...     }
+        ... )
+        >>> df
+            time  value
+        0    0hr     10
+        1  128hr     20
+        2   72hr     30
+        3   48hr     40
+        4   96hr     50
+        >>> from natsort import index_natsorted
+        >>> index_natsorted(df["time"])
+        [0, 3, 2, 4, 1]
+        >>> df.sort_values(
+        ...     by="time",
+        ...     key=lambda x: np.argsort(index_natsorted(x)),
+        ... )
+            time  value
+        0    0hr     10
+        3   48hr     40
+        2   72hr     30
+        4   96hr     50
+        1  128hr     20
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         axis = self._get_axis_number(axis)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6821,7 +6821,7 @@ class DataFrame(NDFrame, OpsMixin):
 
         **Sort by a single column**
 
-        In this case, we are soring the rows according to values in ``col1``:
+        In this case, we are sorting the rows according to values in ``col1``:
 
         >>> df.sort_values(by=["col1"])
           col1  col2  col3 col4
@@ -6834,8 +6834,9 @@ class DataFrame(NDFrame, OpsMixin):
 
         **Sort by multiple columns**
 
-        You can also provide multiple columns to ``by`` argument, as shown below. In this example, the rows are 
-        first sorted according to ``col1``, and then the rows that have an identical value in ``col1`` are sorted according
+        You can also provide multiple columns to ``by`` argument, as shown below.
+        In this example, the rows are first sorted according to ``col1``, and then
+        the rows that have an identical value in ``col1`` are sorted according
         to ``col2``.
 
         >>> df.sort_values(by=["col1", "col2"])
@@ -6862,8 +6863,9 @@ class DataFrame(NDFrame, OpsMixin):
 
         **Placing any** ``NA`` **first**
 
-        Note that in the above example, the rows that contain an ``NA`` value in their ``col1`` are placed
-        at the end of the dataframe. This behavior can be modified via ``na_position`` argument, as shown below:
+        Note that in the above example, the rows that contain an ``NA`` value in their
+        ``col1`` are placed at the end of the dataframe. This behavior can be modified
+        via ``na_position`` argument, as shown below:
 
         >>> df.sort_values(by="col1", ascending=False, na_position="first")
           col1  col2  col3 col4
@@ -6876,8 +6878,10 @@ class DataFrame(NDFrame, OpsMixin):
 
         **Customized sort order**
 
-        The ``key`` argument allows for a further customization of sorting behaviour. For example, you may want 
-        to ignore the `letter's case <https://en.wikipedia.org/wiki/Letter_case>`__ when sorting strings:
+        The ``key`` argument allows for a further customization of sorting behaviour.
+        For example, you may want
+        to ignore the `letter's case <https://en.wikipedia.org/wiki/Letter_case>`__
+        when sorting strings:
 
         >>> df.sort_values(by="col4", key=lambda col: col.str.lower())
            col1  col2  col3 col4
@@ -6888,9 +6892,11 @@ class DataFrame(NDFrame, OpsMixin):
         4    D     7     2    e
         5    C     4     3    F
 
-        Another typical example is `natural sorting <https://en.wikipedia.org/wiki/Natural_sort_order>`__. 
+        Another typical example is
+        `natural sorting <https://en.wikipedia.org/wiki/Natural_sort_order>`__.
         This can be done using
-        ``natsort`` `package <https://github.com/SethMMorton/natsort>`__, which provides sorted indices according
+        ``natsort`` `package <https://github.com/SethMMorton/natsort>`__,
+        which provides sorted indices according
         to their natural order, as shown below:
 
         >>> df = pd.DataFrame(
@@ -6922,9 +6928,10 @@ class DataFrame(NDFrame, OpsMixin):
         If sorted indices are not needed, you may simplify the procedure as follows:
 
         >>> from natsort import natsort_keygen
+        ...
         ... df.sort_values(
-        ...    by="time",
-        ...    key=natsort_keygen(),
+        ...     by="time",
+        ...     key=natsort_keygen(),
         ... )
             time  value
         0    0hr     10

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6939,6 +6939,13 @@ class DataFrame(NDFrame, OpsMixin):
         2   72hr     30
         4   96hr     50
         1  128hr     20
+
+        .. warning::
+           At the time of writing (1st March, 2024), ``natsort`` (v8.4.0) may fail
+           without error or warning in the case of multi-column sorting of
+           indices (e.g., ``DataFrame.sort_index()``, see
+           `here <https://github.com/SethMMorton/natsort/issues/172>`__ for further
+           details).
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         axis = self._get_axis_number(axis)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6896,56 +6896,7 @@ class DataFrame(NDFrame, OpsMixin):
         `natural sorting <https://en.wikipedia.org/wiki/Natural_sort_order>`__.
         This can be done using
         ``natsort`` `package <https://github.com/SethMMorton/natsort>`__,
-        which provides sorted indices according
-        to their natural order, as shown below:
-
-        >>> df = pd.DataFrame(
-        ...     {
-        ...         "time": ["0hr", "128hr", "72hr", "48hr", "96hr"],
-        ...         "value": [10, 20, 30, 40, 50],
-        ...     }
-        ... )
-        >>> df
-            time  value
-        0    0hr     10
-        1  128hr     20
-        2   72hr     30
-        3   48hr     40
-        4   96hr     50
-        >>> from natsort import index_natsorted
-        >>> index_natsorted(df["time"])
-        [0, 3, 2, 4, 1]
-        >>> df.sort_values(
-        ...     by="time",
-        ...     key=lambda x: np.argsort(index_natsorted(x)),
-        ... )
-            time  value
-        0    0hr     10
-        3   48hr     40
-        2   72hr     30
-        4   96hr     50
-        1  128hr     20
-
-        If sorted indices are not needed, you may simplify the procedure as follows:
-
-        >>> from natsort import natsort_keygen
-        >>> df.sort_values(
-        ...     by="time",
-        ...     key=natsort_keygen(),
-        ... )
-            time  value
-        0    0hr     10
-        3   48hr     40
-        2   72hr     30
-        4   96hr     50
-        1  128hr     20
-
-        .. warning::
-           At the time of writing (1st March, 2024), ``natsort`` (v8.4.0) may fail
-           without error or warning in the case of multi-column sorting of
-           indices (e.g., ``DataFrame.sort_index()``, see
-           `here <https://github.com/SethMMorton/natsort/issues/172>`__ for further
-           details).
+        which sorts according to natural order of elements.
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         axis = self._get_axis_number(axis)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6819,7 +6819,9 @@ class DataFrame(NDFrame, OpsMixin):
         4    D     7     2    e
         5    C     4     3    F
 
-        Sort by col1
+        **Sort by a single column**
+
+        In this case, we are soring the rows according to values in ``col1``:
 
         >>> df.sort_values(by=["col1"])
           col1  col2  col3 col4
@@ -6830,7 +6832,11 @@ class DataFrame(NDFrame, OpsMixin):
         4    D     7     2    e
         3  NaN     8     4    D
 
-        Sort by multiple columns
+        **Sort by multiple columns**
+
+        You can also provide multiple columns to ``by`` argument, as shown below. In this example, the rows are 
+        first sorted according to ``col1``, and then the rows that have an identical value in ``col1`` are sorted according
+        to ``col2``.
 
         >>> df.sort_values(by=["col1", "col2"])
           col1  col2  col3 col4
@@ -6841,7 +6847,9 @@ class DataFrame(NDFrame, OpsMixin):
         4    D     7     2    e
         3  NaN     8     4    D
 
-        Sort Descending
+        **Sort in a descending order**
+
+        The sort order can be reversed using ``ascending`` argument, as shown below:
 
         >>> df.sort_values(by="col1", ascending=False)
           col1  col2  col3 col4
@@ -6852,7 +6860,10 @@ class DataFrame(NDFrame, OpsMixin):
         1    A     1     1    B
         3  NaN     8     4    D
 
-        Putting NAs first
+        **Placing any** ``NA`` **first**
+
+        Note that in the above example, the rows that contain an ``NA`` value in their ``col1`` are placed
+        at the end of the dataframe. This behavior can be modified via ``na_position`` argument, as shown below:
 
         >>> df.sort_values(by="col1", ascending=False, na_position="first")
           col1  col2  col3 col4
@@ -6863,7 +6874,10 @@ class DataFrame(NDFrame, OpsMixin):
         0    A     2     0    a
         1    A     1     1    B
 
-        Sorting with a key function
+        **Customized sort order**
+
+        The ``key`` argument allows for a further customization of sorting behaviour. For example, you may want 
+        to ignore the `letter's case <https://en.wikipedia.org/wiki/Letter_case>`__ when sorting strings:
 
         >>> df.sort_values(by="col4", key=lambda col: col.str.lower())
            col1  col2  col3 col4
@@ -6874,8 +6888,10 @@ class DataFrame(NDFrame, OpsMixin):
         4    D     7     2    e
         5    C     4     3    F
 
-        Natural sort with the key argument,
-        using the `natsort <https://github.com/SethMMorton/natsort>` package.
+        Another typical example is `natural sorting <https://en.wikipedia.org/wiki/Natural_sort_order>`__. 
+        This can be done using
+        ``natsort`` `package <https://github.com/SethMMorton/natsort>`__, which provides sorted indices according
+        to their natural order, as shown below:
 
         >>> df = pd.DataFrame(
         ...     {
@@ -6891,8 +6907,24 @@ class DataFrame(NDFrame, OpsMixin):
         3   48hr     40
         4   96hr     50
         >>> from natsort import index_natsorted
+        >>> index_natsorted(df["time"])
+        [0, 3, 2, 4, 1]
         >>> df.sort_values(
         ...     by="time", key=lambda x: np.argsort(index_natsorted(df["time"]))
+        ... )
+            time  value
+        0    0hr     10
+        3   48hr     40
+        2   72hr     30
+        4   96hr     50
+        1  128hr     20
+
+        If sorted indices are not needed, you may simplify the procedure as follows:
+
+        >>> from natsort import natsort_keygen
+        ... df.sort_values(
+        ...    by="time",
+        ...    key=natsort_keygen(),
         ... )
             time  value
         0    0hr     10

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6916,7 +6916,8 @@ class DataFrame(NDFrame, OpsMixin):
         >>> index_natsorted(df["time"])
         [0, 3, 2, 4, 1]
         >>> df.sort_values(
-        ...     by="time", key=lambda x: np.argsort(index_natsorted(df["time"]))
+        ...     by="time",
+        ...     key=lambda x: np.argsort(index_natsorted(x)),
         ... )
             time  value
         0    0hr     10


### PR DESCRIPTION
The current docstring for [`DataFrame.sort_values()`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.sort_values.html) is lacking clarity, and also contains links that are not converted to hyperlinks. I extended and rephrased part of the documentation for this method. In particular:

- Added further explanation to compare the single-column vs. multi-column sorting,
- Extended explanation for customized sorting via `key` argument,
- Provided a simplified version of `natsort` example, with added explanation.