### PR TITLE
BUG: datetime parsing fails on a leapday

### DIFF
--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -938,6 +938,8 @@ def guess_datetime_format(dt_str: str, bint dayfirst=False) -> str | None:
 
     # same default used by dateutil
     default = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    if default.month == 2 and default.day == 29:
+        default -= timedelta(days=1)
     try:
         parsed_datetime = dateutil_parse(
             dt_str,


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

No idea what would be a better fix. `dateutil_parse` will substitute parts of the `dt_str` into `default` and then check if it's a valid date.