### PR TITLE
BUG: Fix empty MultiIndex DataFrame xlsx export

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -324,7 +324,7 @@ MultiIndex
 
 I/O
 ^^^
-- Bug in :class:`io.formats.excel.ExcelFormatter` when writing empty :class:`DataFrame` with :class:`MultiIndex` on both axes (:issue:`57696`)
+- Bug in :meth:`DataFrame.to_excel` when writing empty :class:`DataFrame` with :class:`MultiIndex` on both axes (:issue:`57696`)
 -
 -
 

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -324,6 +324,7 @@ MultiIndex
 
 I/O
 ^^^
+- Bug in :class:`io.formats.excel.ExcelFormatter` when writing empty :class:`DataFrame` with :class:`MultiIndex` on both axes (:issue:`57696`)
 -
 -
 

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -620,7 +620,7 @@ class ExcelFormatter:
         lnum = 0
 
         if self.index and isinstance(self.df.index, MultiIndex):
-            coloffset = len(self.df.index[0]) - 1
+            coloffset = self.df.index.nlevels - 1
 
         if self.merge_cells:
             # Format multi-index as a merged cells.

--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -944,8 +944,8 @@ class TestExcelWriter:
             columns=MultiIndex.from_tuples([("A", "B")]),
         )
         df.to_excel(tmp_excel)
-        result = pd.read_excel(tmp_excel, header=None)
-        assert result.iloc[:2, -1].to_list() == ["A", "B"]
+        result = pd.read_excel(tmp_excel, header=[0, 1], index_col=[0, 1])
+        tm.assert_frame_equal(result, df)
 
     def test_to_excel_float_format(self, tmp_excel):
         df = DataFrame(

--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -936,6 +936,17 @@ class TestExcelWriter:
             result, expected, check_index_type=False, check_dtype=False
         )
 
+    def test_to_excel_empty_multiindex_both_axes(self, tmp_excel):
+        # GH 57696
+        df = DataFrame(
+            [],
+            index=MultiIndex.from_tuples([], names=[0, 1]),
+            columns=MultiIndex.from_tuples([("A", "B")]),
+        )
+        df.to_excel(tmp_excel)
+        result = pd.read_excel(tmp_excel, header=None)
+        assert result.iloc[:2, -1].to_list() == ["A", "B"]
+
     def test_to_excel_float_format(self, tmp_excel):
         df = DataFrame(
             [[0.123456, 0.234567, 0.567567], [12.32112, 123123.2, 321321.2]],


### PR DESCRIPTION
Fix Excel xlsx export of empty (zero rows) DataFrame with MultiIndex on both axes.

- [x] closes #57696
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
