### PR TITLE
Nanosecond fixed precision of DatetimeIndex with time zone information, Fix #53473

### DIFF
--- a/pandas/_libs/src/datetime/pd_datetime.c
+++ b/pandas/_libs/src/datetime/pd_datetime.c
@@ -71,7 +71,7 @@ static int convert_pydatetime_to_datetimestruct(PyObject *dtobj,
   out->min = PyLong_AsLong(PyObject_GetAttrString(obj, "minute"));
   out->sec = PyLong_AsLong(PyObject_GetAttrString(obj, "second"));
   out->us = PyLong_AsLong(PyObject_GetAttrString(obj, "microsecond"));
-
+  out->ps = 1000 * PyLong_AsLong(PyObject_GetAttrString(obj, "nanosecond"));
   if (PyObject_HasAttrString(obj, "tzinfo")) {
     PyObject *offset = extract_utc_offset(obj);
     /* Apply the time zone offset if datetime obj is tz-aware */

--- a/pandas/_libs/src/datetime/pd_datetime.c
+++ b/pandas/_libs/src/datetime/pd_datetime.c
@@ -71,7 +71,9 @@ static int convert_pydatetime_to_datetimestruct(PyObject *dtobj,
   out->min = PyLong_AsLong(PyObject_GetAttrString(obj, "minute"));
   out->sec = PyLong_AsLong(PyObject_GetAttrString(obj, "second"));
   out->us = PyLong_AsLong(PyObject_GetAttrString(obj, "microsecond"));
-  out->ps = 1000 * PyLong_AsLong(PyObject_GetAttrString(obj, "nanosecond"));
+  if (PyObject_HasAttrString(obj, "nanosecond")) {
+    out->ps = 1000 * PyLong_AsLong(PyObject_GetAttrString(obj, "nanosecond"));
+  }
   if (PyObject_HasAttrString(obj, "tzinfo")) {
     PyObject *offset = extract_utc_offset(obj);
     /* Apply the time zone offset if datetime obj is tz-aware */

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1216,6 +1216,26 @@ class TestPandasContainer:
         s_naive = Series(tz_naive)
         assert stz.to_json() == s_naive.to_json()
 
+    def test_tz_nano_datetimes(self):
+        df = DataFrame(
+            {
+                "date": Series(
+                    [
+                        datetime.datetime(
+                            2024, 1, 1, 0, 0, 0, 000000, tzinfo=datetime.timezone.utc
+                        )
+                    ]
+                )
+            }
+        )
+        df.date = df.date + np.timedelta64(1, "ns")
+        buf = StringIO()
+        df.to_json(buf, date_unit="ns", orient="columns", date_format="iso")
+        buf.seek(0)
+        tm.assert_frame_equal(
+            read_json(buf), df, check_index_type=False, check_dtype=False
+        )
+
     def test_sparse(self):
         # GH4377 df.to_json segfaults with non-ndarray blocks
         df = DataFrame(np.random.default_rng(2).standard_normal((10, 4)))


### PR DESCRIPTION
The expected behaviour is now correct from issue #53473 The out->picoseond value wasn't set which ended with a Json error regarding the ns calculations.

- [x] closes #53473
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
