### PR TITLE
BUG: Line plots aligned from start #57594

### DIFF
--- a/pandas/plotting/_matplotlib/timeseries.py
+++ b/pandas/plotting/_matplotlib/timeseries.py
@@ -310,7 +310,7 @@ def maybe_convert_index(ax: Axes, data: NDFrameT) -> NDFrameT:
             if isinstance(data.index, ABCDatetimeIndex):
                 data = data.tz_localize(None).to_period(freq=freq_str)
             elif isinstance(data.index, ABCPeriodIndex):
-                data.index = data.index.asfreq(freq=freq_str)
+                data.index = data.index.asfreq(freq=freq_str, how = "S")
     return data
 
 

--- a/pandas/plotting/_matplotlib/timeseries.py
+++ b/pandas/plotting/_matplotlib/timeseries.py
@@ -310,7 +310,7 @@ def maybe_convert_index(ax: Axes, data: NDFrameT) -> NDFrameT:
             if isinstance(data.index, ABCDatetimeIndex):
                 data = data.tz_localize(None).to_period(freq=freq_str)
             elif isinstance(data.index, ABCPeriodIndex):
-                data.index = data.index.asfreq(freq=freq_str, how = "S")
+                data.index = data.index.asfreq(freq=freq_str, how = "S") #Lineplot alignes to the start of period  
     return data
 
 

--- a/pandas/tests/indexes/period/test_period_range.py
+++ b/pandas/tests/indexes/period/test_period_range.py
@@ -79,10 +79,16 @@ class TestPeriodRange:
     @pytest.mark.parametrize(
         "freq_offset, freq_period",
         [
+            ("h", "h"),
+            ("7h", "7h"),
             ("D", "D"),
-            ("W", "W"),
-            ("QE", "Q"),
+            ("15D", "15D"),
+            ("ME", "M"),
+            ("3ME", "3M"),
             ("YE", "Y"),
+            ("8YE", "8Y"),
+            ("20s", "20s"),
+            ("2QE", "2Q"),
         ],
     )
     def test_construction_from_string(self, freq_offset, freq_period):
@@ -111,34 +117,6 @@ class TestPeriodRange:
         tm.assert_index_equal(result, expected)
 
         result = period_range(start=end, end=start, freq=freq_period, name="foo")
-        tm.assert_index_equal(result, expected)
-
-    def test_construction_from_string_monthly(self):
-        # non-empty
-        expected = date_range(
-            start="2017-01-01", periods=5, freq="ME", name="foo"
-        ).to_period()
-        start, end = str(expected[0]), str(expected[-1])
-
-        result = period_range(start=start, end=end, freq="M", name="foo")
-        tm.assert_index_equal(result, expected)
-
-        result = period_range(start=start, periods=5, freq="M", name="foo")
-        tm.assert_index_equal(result, expected)
-
-        result = period_range(end=end, periods=5, freq="M", name="foo")
-        tm.assert_index_equal(result, expected)
-
-        # empty
-        expected = PeriodIndex([], freq="M", name="foo")
-
-        result = period_range(start=start, periods=0, freq="M", name="foo")
-        tm.assert_index_equal(result, expected)
-
-        result = period_range(end=end, periods=0, freq="M", name="foo")
-        tm.assert_index_equal(result, expected)
-
-        result = period_range(start=end, end=start, freq="M", name="foo")
         tm.assert_index_equal(result, expected)
 
     def test_construction_from_period(self):

--- a/pandas/tests/plotting/common.py
+++ b/pandas/tests/plotting/common.py
@@ -548,13 +548,13 @@ def _check_inputdata_equals_outputdata(idx, ax):
     )
 
     """
-    Check that the input data is equal to the output data
+    Check that the input dates is equal to the plotted dates
     Parameters
     ----------
-    idx : PeriodIndex
+    idx : PeriodIndex , DatetimeIndex
         The input data based on freq
     ax : matplotlib Axes object
-        The input data after plotting
+        The plotted data
     """
 
     #Convert to periodIndex to use same formatting as the output

--- a/pandas/tests/plotting/common.py
+++ b/pandas/tests/plotting/common.py
@@ -541,6 +541,30 @@ def _check_plot_works(f, default_axes=False, **kwargs):
         plt.close(fig)
 
     return ret
+    
+def _check_inputdata_equals_outputdata(idx, ax):
+    from pandas.core.indexes.datetimes import (
+        DatetimeIndex,
+    )
+
+    """
+    Check that the input data is equal to the output data
+    Parameters
+    ----------
+    idx : PeriodIndex
+        The input data based on freq
+    ax : matplotlib Axes object
+        The input data after plotting
+    """
+
+    #Convert to periodIndex to use same formatting as the output
+    if isinstance(idx, DatetimeIndex):
+        idx = idx.to_period()
+    input = [str(period) for period in idx]
+    output_unformatted = ax.get_lines()[0].get_xdata()
+    output = [str(period) for period in output_unformatted]
+    # Convert idx and lines to lists of strings representing dates
+    assert input == output
 
 
 def _gen_default_plot(f, fig, **kwargs):

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -1,4 +1,5 @@
 """ Test cases for time series specific (freq conversion, etc) """
+
 from datetime import (
     date,
     datetime,
@@ -38,6 +39,7 @@ from pandas.core.indexes.period import (
 )
 from pandas.core.indexes.timedeltas import timedelta_range
 from pandas.tests.plotting.common import _check_ticks_props
+from pandas.tests.plotting.common import _check_inputdata_equals_outputdata
 
 from pandas.tseries.offsets import WeekOfMonth
 
@@ -69,11 +71,10 @@ class TestTSPlot:
         for label in ax.get_xticklabels() + ax.get_yticklabels():
             assert label.get_fontsize() == 2
 
-
-     #TODO: Add more tests for different frequencies
-    @pytest.mark.parametrize("freq", ["1Y", "Y", "3Y", "10Y"])
+    # TODO: Add more tests for different frequencies
+    @pytest.mark.parametrize("freq", ["20s","3s","60min","5min","7h","4D","8W","11M","2Q","Y", "3Y", "10Y"])
     def test_period_range_content(self, freq):
-    # Setup your DataFrame as in your scenario
+        # Setup your DataFrame as in your scenario
         idx = period_range("2000-01-01", freq=freq, periods=4)
         df = DataFrame(
             np.array([0, 1, 0, 1]),
@@ -82,18 +83,12 @@ class TestTSPlot:
         )
 
         ax = df.plot()
-        lines = ax.get_lines()[0].get_xdata()
-        
-        # Convert idx and lines to lists of strings representing dates
-        idx_dates = [str(period) for period in idx]
-        lines_dates = [str(period) for period in lines]
+        _check_inputdata_equals_outputdata(idx=idx, ax=ax)
 
-        assert idx_dates == lines_dates
-
-    #TODO: Add more tests for different frequency formats
-    @pytest.mark.parametrize("freq", ["1YE", "YE", "3YE", "10YE"])
+    # TODO: Add more tests for different frequency formats
+    @pytest.mark.parametrize("freq", ["20s","3s","60min","5min","7h","4D","8W","11ME","2QE","YE", "3YE", "10YE"])
     def test_date_range_content(self, freq):
-    # Setup your DataFrame as in your scenario
+        # Setup your DataFrame as in your scenario
         idx = date_range("2000/01/01", freq=freq, periods=4)
         df = DataFrame(
             np.array([0, 1, 0, 1]),
@@ -101,13 +96,7 @@ class TestTSPlot:
             columns=["A"],
         )
         ax = df.plot()
-        lines = ax.get_lines()[0].get_xdata()
-        # Convert idx and lines to lists of strings representing dates
-        idx_dates = [str(period).split("-")[0] for period in idx]
-        lines_dates = [str(period) for period in lines]
-        assert idx_dates == lines_dates
-
-
+        _check_inputdata_equals_outputdata(idx=idx, ax=ax)
 
     def test_frame_inferred(self):
         # inferred freq

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -71,7 +71,7 @@ class TestTSPlot:
 
 
      #TODO: Add more tests for different frequencies
-    @pytest.mark.parametrize("freq", ["1Y", "Y", "3Y", "10Y", "100Y"])
+    @pytest.mark.parametrize("freq", ["1Y", "Y", "3Y", "10Y"])
     def test_period_range_content(self, freq):
     # Setup your DataFrame as in your scenario
         idx = period_range("2000-01-01", freq=freq, periods=4)
@@ -91,7 +91,7 @@ class TestTSPlot:
         assert idx_dates == lines_dates
 
     #TODO: Add more tests for different frequency formats
-    @pytest.mark.parametrize("freq", ["1Y", "Y", "3Y", "10Y", "100Y"])
+    @pytest.mark.parametrize("freq", ["1YE", "YE", "3YE", "10YE"])
     def test_date_range_content(self, freq):
     # Setup your DataFrame as in your scenario
         idx = date_range("2000/01/01", freq=freq, periods=4)

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -69,6 +69,46 @@ class TestTSPlot:
         for label in ax.get_xticklabels() + ax.get_yticklabels():
             assert label.get_fontsize() == 2
 
+
+     #TODO: Add more tests for different frequencies
+    @pytest.mark.parametrize("freq", ["1Y", "Y", "3Y", "10Y", "100Y"])
+    def test_period_range_content(self, freq):
+    # Setup your DataFrame as in your scenario
+        idx = period_range("2000-01-01", freq=freq, periods=4)
+        df = DataFrame(
+            np.array([0, 1, 0, 1]),
+            index=idx,
+            columns=["A"],
+        )
+
+        ax = df.plot()
+        lines = ax.get_lines()[0].get_xdata()
+        
+        # Convert idx and lines to lists of strings representing dates
+        idx_dates = [str(period) for period in idx]
+        lines_dates = [str(period) for period in lines]
+
+        assert idx_dates == lines_dates
+
+    #TODO: Add more tests for different frequency formats
+    @pytest.mark.parametrize("freq", ["1Y", "Y", "3Y", "10Y", "100Y"])
+    def test_date_range_content(self, freq):
+    # Setup your DataFrame as in your scenario
+        idx = date_range("2000/01/01", freq=freq, periods=4)
+        df = DataFrame(
+            np.array([0, 1, 0, 1]),
+            index=idx,
+            columns=["A"],
+        )
+        ax = df.plot()
+        lines = ax.get_lines()[0].get_xdata()
+        # Convert idx and lines to lists of strings representing dates
+        idx_dates = [str(period).split("-")[0] for period in idx]
+        lines_dates = [str(period) for period in lines]
+        assert idx_dates == lines_dates
+
+
+
     def test_frame_inferred(self):
         # inferred freq
         idx = date_range("1/1/1987", freq="MS", periods=100)

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -1,5 +1,4 @@
 """ Test cases for time series specific (freq conversion, etc) """
-
 from datetime import (
     date,
     datetime,
@@ -71,7 +70,6 @@ class TestTSPlot:
         for label in ax.get_xticklabels() + ax.get_yticklabels():
             assert label.get_fontsize() == 2
 
-    # TODO: Add more tests for different frequencies
     @pytest.mark.parametrize("freq", ["20s","3s","60min","5min","7h","4D","8W","11M","2Q","Y", "3Y", "10Y"])
     def test_period_range_content(self, freq):
         # Setup your DataFrame as in your scenario
@@ -85,7 +83,6 @@ class TestTSPlot:
         ax = df.plot()
         _check_inputdata_equals_outputdata(idx=idx, ax=ax)
 
-    # TODO: Add more tests for different frequency formats
     @pytest.mark.parametrize("freq", ["20s","3s","60min","5min","7h","4D","8W","11ME","2QE","YE", "3YE", "10YE"])
     def test_date_range_content(self, freq):
         # Setup your DataFrame as in your scenario


### PR DESCRIPTION
#57594 BUG: df.plot makes a shift to the right if frequency multiplies to n > 1

The cause of this bug is that by default all elements are generated to align to the end of
a period instead of at the start and the period technically does not end at the start of
the last period but rather just before the period subsequent to the last period. To fix this
problem we therefore passed a parameter stating that the elements should be aligned to
the start of the period instead of the end. Parameter "how=S" was added in pandas/plotting/_matplotlib/timeseries.py::maybe_convert_index(), 
on the function call data.index.asfreq(freq=freq_str, how = "S").  

Additional tests were added to test whether input data match data in plot and one test was merged into one the added test to reduce code duplication. 