### PR TITLE
#48188 FIX: iloc works with namedtuple

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1734,12 +1734,12 @@ class _iLocIndexer(_LocationIndexer):
         if isinstance(key, list):
             key = np.asarray(key)
 
+        if type(key) is tuple or (hasattr(key, "_fields") and isinstance(key, type(key))):
+            return self.__getitem__(tuple(key))
+
         if com.is_bool_indexer(key):
             self._validate_key(key, axis)
             return self._getbool_axis(key, axis=axis)
-
-        if type(key) is tuple or (hasattr(key, "_fields") and isinstance(key, type(key))):
-            return self.__getitem__(tuple(key))
 
         # a list of integers
         elif is_list_like_indexer(key):

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1738,6 +1738,9 @@ class _iLocIndexer(_LocationIndexer):
             self._validate_key(key, axis)
             return self._getbool_axis(key, axis=axis)
 
+        if type(key) is tuple or (hasattr(key, "_fields") and isinstance(key, type(key))):
+            return self.__getitem__(tuple(key))
+
         # a list of integers
         elif is_list_like_indexer(key):
             return self._get_list_axis(key, axis=axis)

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -1449,3 +1449,20 @@ class TestILocSeries:
             result.loc[:, "b"] = result.loc[:, "b"].astype("Int64")
         expected = DataFrame({"a": ["test"], "b": array([NA], dtype="Int64")})
         tm.assert_frame_equal(result, expected)
+
+    def test_iloc_with_namedtuple(self):
+        df = DataFrame(np.arange(120).reshape(6, -1))
+
+        output1 = df.iloc[1, 2]
+        output2 = df.iloc[(1, 2)]
+
+        from collections import namedtuple
+
+        indexer_tuple = namedtuple("Indexer", ["x", "y"])
+
+        output3 = df.iloc[tuple(indexer_tuple(x=1, y=2))]
+        output4 = df.iloc[indexer_tuple(x=1, y=2)]
+        tm.assert_equal(output1, output2)
+        tm.assert_equal(output3, output4)
+        tm.assert_equal(output1, output3)
+


### PR DESCRIPTION
- unit test for added for test_iloc.py that verifies that all four uses of iloc given in the reproducible example now works

- [x] closes #48188
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature