### PR TITLE
CI: locking `pytest` version = `8.1.0`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - meson-python=0.13.1
 
   # test dependencies
-  - pytest>=7.3.2
+  - pytest>=7.3.2,<8.1.0
   - pytest-cov
   - pytest-xdist>=2.2.0
   - pytest-qt>=4.2.0


### PR DESCRIPTION
- [x] closes #57718

locked `pytest` to version more then `8.1.0`, as a temporary solution.

the reason: with the latest `pytest` version `8.1.0` we get an error when runninig pytest
``` 
File "/home/panda/miniforge3/envs/pandas-dev/lib/python3.10/site-packages/pluggy/_manager.py", line 342, in _verify_hook
    raise PluginValidationError(
pluggy._manager.PluginValidationError: Plugin 'pytest_cython' for hook 'pytest_collect_file'
hookimpl definition: pytest_collect_file(path, parent)
Argument(s) {'path'} are declared in the hookimpl but can not be found in the hookspec
```
I think, it’s a bug in the last version of `pytest-cython-0.2.1` (see [link](https://github.com/lgpage/pytest-cython/issues/59))
which is related to enforcing deprecation of `path` parameter in the last version of `pytest 8.1.0` (see [link](https://github.com/pytest-dev/pytest/issues/11779))