### PR TITLE
DOC: fixing GL08 errors for pandas.IntervalIndex.right and pandas.Series.dt

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -155,7 +155,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.Period.ordinal\
         pandas.PeriodIndex.freq\
         pandas.PeriodIndex.qyear\
-        pandas.Series.dt\
         pandas.Series.dt.as_unit\
         pandas.Series.dt.freq\
         pandas.Series.dt.qyear\

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -151,7 +151,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.IntervalIndex.left\
         pandas.IntervalIndex.length\
         pandas.IntervalIndex.mid\
-        pandas.IntervalIndex.right\
         pandas.Period.freq\
         pandas.Period.ordinal\
         pandas.PeriodIndex.freq\

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -589,8 +589,11 @@ class CombinedDatetimelikeProperties(
     -------
     Instance of the appropriate subclass (ArrowTemporalProperties, DatetimeProperties,
     TimedeltaProperties, or PeriodProperties)
+    See Also
+    --------
+    pandas.Series.dt : Accessor object for datetimelike properties of the Series values
     Examples
-    -------
+    --------
     >>> dates = pd.Series(['2024-01-01', '2024-01-15', '2024-02-5']).astype('datetime64[ns]')
     >>> dates.dt.day
     0     1

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -594,8 +594,9 @@ class CombinedDatetimelikeProperties(
 
     Examples
     --------
-    >>> dates = pd.Series(['2024-01-01', '2024-01-15', '2024-02-5'],
-    ...         dtype='datetime64[ns]')
+    >>> dates = pd.Series(
+    ...     ["2024-01-01", "2024-01-15", "2024-02-5"], dtype="datetime64[ns]"
+    ... )
     >>> dates.dt.day
     0     1
     1    15
@@ -607,6 +608,7 @@ class CombinedDatetimelikeProperties(
     2    2
     dtype: int32
     """
+
     def __new__(cls, data: Series):  # pyright: ignore[reportInconsistentConstructor]
         # CombinedDatetimelikeProperties isn't really instantiated. Instead
         # we need to choose which parent (datetime or timedelta) is

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -574,21 +574,17 @@ class CombinedDatetimelikeProperties(
     """
     Combined datetime-like properties for a pandas Series.
 
-    Not meant to be instantiated directly. Instead, used
-    to determine the appropriate parent class (ArrowTemporalProperties, DatetimeProperties,
-    TimedeltaProperties, or PeriodProperties) based on the dtype of the provided pandas Series.
-    Parameters
-    ----------
-    data : pandas.Series
-        Series containing datetime-like data.
+    Not meant to be instantiated directly. Instead, used to determine the appropriate
+    parent class (ArrowTemporalProperties, DatetimeProperties,TimedeltaProperties,
+    or PeriodProperties) based on the dtype of the provided pandas Series.
     Raises
     ------
     TypeError
         If object is not a pandas Series.
     Returns
     -------
-    Instance of the appropriate subclass (ArrowTemporalProperties, DatetimeProperties,
-    TimedeltaProperties, or PeriodProperties)
+    Instance of the appropriate subclass (ArrowTemporalProperties,
+    DatetimeProperties, TimedeltaProperties, or PeriodProperties)
     See Also
     --------
     pandas.Series.dt : Accessor object for datetimelike properties of the Series values

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -587,10 +587,11 @@ class CombinedDatetimelikeProperties(
     DatetimeProperties, TimedeltaProperties, or PeriodProperties)
     See Also
     --------
-    pandas.Series.dt : Accessor object for datetimelike properties of the Series values
+    pandas.Series.dt : Accessor object for datetimelike properties of the Series values.
     Examples
     --------
-    >>> dates = pd.Series(['2024-01-01', '2024-01-15', '2024-02-5']).astype('datetime64[ns]')
+    >>> dates = pd.Series(['2024-01-01', '2024-01-15', '2024-02-5'],
+    ...         dtype='datetime64[ns]')
     >>> dates.dt.day
     0     1
     1    15

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -577,17 +577,21 @@ class CombinedDatetimelikeProperties(
     Not meant to be instantiated directly. Instead, used to determine the appropriate
     parent class (ArrowTemporalProperties, DatetimeProperties,TimedeltaProperties,
     or PeriodProperties) based on the dtype of the provided pandas Series.
+
     Raises
     ------
     TypeError
         If object is not a pandas Series.
+
     Returns
     -------
     Instance of the appropriate subclass (ArrowTemporalProperties,
     DatetimeProperties, TimedeltaProperties, or PeriodProperties)
+
     See Also
     --------
     pandas.Series.dt : Accessor object for datetimelike properties of the Series values.
+
     Examples
     --------
     >>> dates = pd.Series(['2024-01-01', '2024-01-15', '2024-02-5'],

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -571,6 +571,38 @@ class PeriodProperties(Properties):
 class CombinedDatetimelikeProperties(
     DatetimeProperties, TimedeltaProperties, PeriodProperties
 ):
+    """
+    Combined datetime-like properties for a pandas Series.
+
+    Not meant to be instantiated directly. Instead, used
+    to determine the appropriate parent class (ArrowTemporalProperties, DatetimeProperties,
+    TimedeltaProperties, or PeriodProperties) based on the dtype of the provided pandas Series.
+    Parameters
+    ----------
+    data : pandas.Series
+        Series containing datetime-like data.
+    Raises
+    ------
+    TypeError
+        If object is not a pandas Series.
+    Returns
+    -------
+    Instance of the appropriate subclass (ArrowTemporalProperties, DatetimeProperties,
+    TimedeltaProperties, or PeriodProperties)
+    Examples
+    -------
+    >>> dates = pd.Series(['2024-01-01', '2024-01-15', '2024-02-5']).astype('datetime64[ns]')
+    >>> dates.dt.day
+    0     1
+    1    15
+    2     5
+    dtype: int32
+    >>> dates.dt.month
+    0    1
+    1    1
+    2    2
+    dtype: int32
+    """
     def __new__(cls, data: Series):  # pyright: ignore[reportInconsistentConstructor]
         # CombinedDatetimelikeProperties isn't really instantiated. Instead
         # we need to choose which parent (datetime or timedelta) is

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -837,9 +837,11 @@ class IntervalIndex(ExtensionIndex):
         Returns
         -------
         Index
+
         See Also
         --------
         IntervalIndex : The structure of IntervalIndex.
+
         Examples
         --------
         >>> pd.interval_range(start=0, end=5)

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -831,6 +831,22 @@ class IntervalIndex(ExtensionIndex):
 
     @cache_readonly
     def right(self) -> Index:
+        """
+        Return intervals' right value.
+        Returns
+        -------
+        Index
+        See Also
+        --------
+        IntervalIndex : The structure of IntervalIndex.
+        Examples
+        --------
+        >>> pd.interval_range(start=0, end=5)
+        IntervalIndex([(0, 1], (1, 2], (2, 3], (3, 4], (4, 5]],
+                        dtype='interval[int64, right]')
+        >>> pd.interval_range(start=0, end=5).right
+        Index([1, 2, 3, 4, 5], dtype='int64')
+        """
         return Index(self._data.right, copy=False)
 
     @cache_readonly

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -833,6 +833,7 @@ class IntervalIndex(ExtensionIndex):
     def right(self) -> Index:
         """
         Return intervals' right value.
+
         Returns
         -------
         Index


### PR DESCRIPTION
Resolved GL08 errors for the following:
1. `scripts/validate_docstrings.py --format=actions --errors=GL08 pandas.IntervalIndex.right`
2. `scripts/validate_docstrings.py --format=actions --errors=GL08 pandas.Series.dt`

xref: #57443 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
