### PR TITLE
CI: only keep conda cache for one day

### DIFF
--- a/.github/actions/setup-conda/action.yml
+++ b/.github/actions/setup-conda/action.yml
@@ -14,3 +14,6 @@ runs:
         condarc-file: ci/.condarc
         cache-environment: true
         cache-downloads: true
+        # persist on the same day.
+        cache-environment-key: environment-${{ steps.date.outputs.date }}
+        cache-downloads-key: downloads-${{ steps.date.outputs.date }}


### PR DESCRIPTION
Our conda envs are being cached, but that also means that for the dev builds (eg numpy nightly, pyarrow nightly), you don't actually get the latest version, depending on whether some other change happened in the CI setup that would invalidate the cache.

Maybe ideally we do this _only_ for those builds that test for other dev packages? 

From https://github.com/mamba-org/setup-micromamba?tab=readme-ov-file#caching  
Related issue: https://github.com/mamba-org/setup-micromamba/issues/50