### PR TITLE
CLN: Enforce deprecation of DataFrameGroupBy.dtypes and Grouper attrs

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -243,6 +243,8 @@ Removal of prior version deprecations/changes
 - Removed the ``ordinal`` keyword in :class:`PeriodIndex`, use :meth:`PeriodIndex.from_ordinals` instead (:issue:`55960`)
 - Removed unused arguments ``*args`` and ``**kwargs`` in :class:`Resampler` methods (:issue:`50977`)
 - Unrecognized timezones when parsing strings to datetimes now raises a ``ValueError`` (:issue:`51477`)
+- Removed the :class:`Grouper` attributes ``ax``, ``groups``, ``indexer``, and ``obj`` (:issue:`51206`, :issue:`51182`)
+- Removed the attribute ``dtypes`` from :class:`.DataFrameGroupBy` (:issue:`51997`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.performance:

--- a/pandas/core/groupby/base.py
+++ b/pandas/core/groupby/base.py
@@ -90,7 +90,6 @@ groupby_other_methods = frozenset(
         "corr",
         "cov",
         "describe",
-        "dtypes",
         "expanding",
         "ewm",
         "filter",

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -2720,22 +2720,6 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         )
         return result
 
-    @property
-    @doc(DataFrame.dtypes.__doc__)
-    def dtypes(self) -> Series:
-        # GH#51045
-        warnings.warn(
-            f"{type(self).__name__}.dtypes is deprecated and will be removed in "
-            "a future version. Check the dtypes on the base object instead",
-            FutureWarning,
-            stacklevel=find_stack_level(),
-        )
-
-        # error: Incompatible return value type (got "DataFrame", expected "Series")
-        return self._python_apply_general(  # type: ignore[return-value]
-            lambda df: df.dtypes, self._selected_obj
-        )
-
     def corrwith(
         self,
         other: DataFrame | Series,

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -8,14 +8,12 @@ from typing import (
     TYPE_CHECKING,
     final,
 )
-import warnings
 
 import numpy as np
 
 from pandas._libs.tslibs import OutOfBoundsDatetime
 from pandas.errors import InvalidIndexError
 from pandas.util._decorators import cache_readonly
-from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.common import (
     is_list_like,
@@ -386,56 +384,6 @@ class Grouper:
         self._obj_deprecated = obj  # type: ignore[assignment]
         self._gpr_index = ax
         return obj, ax, indexer
-
-    @final
-    @property
-    def ax(self) -> Index:
-        warnings.warn(
-            f"{type(self).__name__}.ax is deprecated and will be removed in a "
-            "future version. Use Resampler.ax instead",
-            FutureWarning,
-            stacklevel=find_stack_level(),
-        )
-        index = self._gpr_index
-        if index is None:
-            raise ValueError("_set_grouper must be called before ax is accessed")
-        return index
-
-    @final
-    @property
-    def indexer(self):
-        warnings.warn(
-            f"{type(self).__name__}.indexer is deprecated and will be removed "
-            "in a future version. Use Resampler.indexer instead.",
-            FutureWarning,
-            stacklevel=find_stack_level(),
-        )
-        return self._indexer_deprecated
-
-    @final
-    @property
-    def obj(self):
-        # TODO(3.0): enforcing these deprecations on Grouper should close
-        #  GH#25564, GH#41930
-        warnings.warn(
-            f"{type(self).__name__}.obj is deprecated and will be removed "
-            "in a future version. Use GroupBy.indexer instead.",
-            FutureWarning,
-            stacklevel=find_stack_level(),
-        )
-        return self._obj_deprecated
-
-    @final
-    @property
-    def groups(self):
-        warnings.warn(
-            f"{type(self).__name__}.groups is deprecated and will be removed "
-            "in a future version. Use GroupBy.groups instead.",
-            FutureWarning,
-            stacklevel=find_stack_level(),
-        )
-        # error: "None" has no attribute "groups"
-        return self._grouper_deprecated.groups  # type: ignore[attr-defined]
 
     @final
     def __repr__(self) -> str:

--- a/pandas/tests/groupby/test_api.py
+++ b/pandas/tests/groupby/test_api.py
@@ -80,7 +80,6 @@ def test_tab_completion(multiindex_dataframe_random_data):
         "corr",
         "corrwith",
         "cov",
-        "dtypes",
         "ndim",
         "diff",
         "idxmax",

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2828,9 +2828,6 @@ def test_groupby_selection_other_methods(df):
     g_exp = df[["C"]].groupby(df["A"])
 
     # methods which aren't just .foo()
-    msg = "DataFrameGroupBy.dtypes is deprecated"
-    with tm.assert_produces_warning(FutureWarning, match=msg):
-        tm.assert_frame_equal(g.dtypes, g_exp.dtypes)
     tm.assert_frame_equal(g.apply(lambda x: x.sum()), g_exp.apply(lambda x: x.sum()))
 
     tm.assert_frame_equal(g.resample("D").mean(), g_exp.resample("D").mean())

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -1128,28 +1128,3 @@ def test_grouping_by_key_is_in_axis():
     result = gb.sum()
     expected = DataFrame({"a": [1, 2], "b": [1, 2], "c": [7, 5]})
     tm.assert_frame_equal(result, expected)
-
-
-def test_grouper_groups():
-    # GH#51182 check Grouper.groups does not raise AttributeError
-    df = DataFrame({"a": [1, 2, 3], "b": 1})
-    grper = Grouper(key="a")
-    gb = df.groupby(grper)
-
-    msg = "Use GroupBy.groups instead"
-    with tm.assert_produces_warning(FutureWarning, match=msg):
-        res = grper.groups
-    assert res is gb.groups
-
-    msg = "Grouper.obj is deprecated and will be removed"
-    with tm.assert_produces_warning(FutureWarning, match=msg):
-        res = grper.obj
-    assert res is gb.obj
-
-    msg = "Use Resampler.ax instead"
-    with tm.assert_produces_warning(FutureWarning, match=msg):
-        grper.ax
-
-    msg = "Grouper.indexer is deprecated"
-    with tm.assert_produces_warning(FutureWarning, match=msg):
-        grper.indexer


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Ref: #51206, #51182, and #51997