### PR TITLE
CLN: enforce deprecation of the `method` keyword on `df.fillna`

### DIFF
--- a/doc/source/whatsnew/v0.10.0.rst
+++ b/doc/source/whatsnew/v0.10.0.rst
@@ -242,18 +242,42 @@ labeled the aggregated group with the end of the interval: the next day).
 - Calling ``fillna`` on Series or DataFrame with no arguments is no longer
   valid code. You must either specify a fill value or an interpolation method:
 
-.. ipython:: python
-   :okwarning:
+.. code-block:: ipython
 
-   s = pd.Series([np.nan, 1.0, 2.0, np.nan, 4])
-   s
-   s.fillna(0)
-   s.fillna(method="pad")
+    In [6]: s = pd.Series([np.nan, 1.0, 2.0, np.nan, 4])
+
+    In [7]: s
+    Out[7]:
+    0      NaN
+    1      1.0
+    2      2.0
+    3      NaN
+    4      4.0
+    dtype: float64
+
+    In [8]: s.fillna(0)
+    Out[8]:
+    0      0.0
+    1      1.0
+    2      2.0
+    3      0.0
+    4      4.0
+    dtype: float64
+
+    In [9]: s.fillna(method="pad")
+    Out[9]:
+    0      NaN
+    1      1.0
+    2      2.0
+    3      2.0
+    4      4.0
+    dtype: float64
 
 Convenience methods ``ffill`` and  ``bfill`` have been added:
 
 .. ipython:: python
 
+   s = pd.Series([np.nan, 1.0, 2.0, np.nan, 4])
    s.ffill()
 
 

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -229,6 +229,7 @@ Removal of prior version deprecations/changes
 - Removed ``year``, ``month``, ``quarter``, ``day``, ``hour``, ``minute``, and ``second`` keywords in the :class:`PeriodIndex` constructor, use :meth:`PeriodIndex.from_fields` instead (:issue:`55960`)
 - Removed deprecated argument ``obj`` in :meth:`.DataFrameGroupBy.get_group` and :meth:`.SeriesGroupBy.get_group` (:issue:`53545`)
 - Removed deprecated behavior of :meth:`Series.agg` using :meth:`Series.apply` (:issue:`53325`)
+- Removed deprecated keyword ``method`` on :meth:`Series.fillna`, :meth:`DataFrame.fillna` (:issue:`57760`)
 - Removed option ``mode.use_inf_as_na``, convert inf entries to ``NaN`` before instead (:issue:`51684`)
 - Removed support for :class:`DataFrame` in :meth:`DataFrame.from_records`(:issue:`51697`)
 - Removed support for ``errors="ignore"`` in :func:`to_datetime`, :func:`to_timedelta` and :func:`to_numeric` (:issue:`55734`)

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -172,10 +172,6 @@ def pytest_collection_modifyitems(items, config) -> None:
             "DataFrameGroupBy.fillna",
             "DataFrameGroupBy.fillna with 'method' is deprecated",
         ),
-        (
-            "DataFrameGroupBy.fillna",
-            "DataFrame.fillna with 'method' is deprecated",
-        ),
         ("read_parquet", "Passing a BlockManager to DataFrame is deprecated"),
     ]
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6769,7 +6769,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         self,
         value: Hashable | Mapping | Series | DataFrame = ...,
         *,
-        method: FillnaOptions | None = ...,
         axis: Axis | None = ...,
         inplace: Literal[False] = ...,
         limit: int | None = ...,
@@ -6781,7 +6780,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         self,
         value: Hashable | Mapping | Series | DataFrame = ...,
         *,
-        method: FillnaOptions | None = ...,
         axis: Axis | None = ...,
         inplace: Literal[True],
         limit: int | None = ...,
@@ -6793,7 +6791,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         self,
         value: Hashable | Mapping | Series | DataFrame = ...,
         *,
-        method: FillnaOptions | None = ...,
         axis: Axis | None = ...,
         inplace: bool = ...,
         limit: int | None = ...,
@@ -6809,7 +6806,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         self,
         value: Hashable | Mapping | Series | DataFrame | None = None,
         *,
-        method: FillnaOptions | None = None,
         axis: Axis | None = None,
         inplace: bool = False,
         limit: int | None = None,
@@ -6825,15 +6821,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             each index (for a Series) or column (for a DataFrame).  Values not
             in the dict/Series/DataFrame will not be filled. This value cannot
             be a list.
-        method : {{'backfill', 'bfill', 'ffill', None}}, default None
-            Method to use for filling holes in reindexed Series:
-
-            * ffill: propagate last valid observation forward to next valid.
-            * backfill / bfill: use next valid observation to fill gap.
-
-            .. deprecated:: 2.1.0
-                Use ffill or bfill instead.
-
         axis : {axes_single_arg}
             Axis along which to fill missing values. For `Series`
             this parameter is unused and defaults to 0.
@@ -6932,15 +6919,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                         stacklevel=2,
                     )
 
-        value, method = validate_fillna_kwargs(value, method)
-        if method is not None:
-            warnings.warn(
-                f"{type(self).__name__}.fillna with 'method' is deprecated and "
-                "will raise in a future version. Use obj.ffill() or obj.bfill() "
-                "instead.",
-                FutureWarning,
-                stacklevel=find_stack_level(),
-            )
+        value, _ = validate_fillna_kwargs(value, None)
 
         # set the default here, so functions examining the signaure
         # can detect if something was set (e.g. in groupby) (GH9221)
@@ -6953,7 +6932,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 # error: Argument 1 to "_pad_or_backfill" of "NDFrame" has
                 # incompatible type "Optional[Literal['backfill', 'bfill', 'ffill',
                 # 'pad']]"; expected "Literal['ffill', 'bfill', 'pad', 'backfill']"
-                method,  # type: ignore[arg-type]
+                method=None,  # type: ignore[arg-type]
                 axis=axis,
                 limit=limit,
                 inplace=inplace,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6811,7 +6811,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         limit: int | None = None,
     ) -> Self | None:
         """
-        Fill NA/NaN values using the specified method.
+        Fill NA/NaN values with `value`.
 
         Parameters
         ----------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6919,7 +6919,11 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                         stacklevel=2,
                     )
 
-        value, _ = validate_fillna_kwargs(value, None)
+        if isinstance(value, (list, tuple)):
+            raise TypeError(
+                '"value" parameter must be a scalar or dict, but '
+                f'you passed a "{type(value).__name__}"'
+            )
 
         # set the default here, so functions examining the signaure
         # can detect if something was set (e.g. in groupby) (GH9221)
@@ -6928,15 +6932,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         axis = self._get_axis_number(axis)
 
         if value is None:
-            return self._pad_or_backfill(
-                # error: Argument 1 to "_pad_or_backfill" of "NDFrame" has
-                # incompatible type "Optional[Literal['backfill', 'bfill', 'ffill',
-                # 'pad']]"; expected "Literal['ffill', 'bfill', 'pad', 'backfill']"
-                method=None,  # type: ignore[arg-type]
-                axis=axis,
-                limit=limit,
-                inplace=inplace,
-            )
+            raise ValueError("Must specify a fill 'value'.")
         else:
             if self.ndim == 1:
                 if isinstance(value, (dict, ABCSeries)):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6829,12 +6829,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             other views on this object (e.g., a no-copy slice for a column in a
             DataFrame).
         limit : int, default None
-            If method is specified, this is the maximum number of consecutive
-            NaN values to forward/backward fill. In other words, if there is
-            a gap with more than this number of consecutive NaNs, it will only
-            be partially filled. If method is not specified, this is the
-            maximum number of entries along the entire axis where NaNs will be
-            filled. Must be greater than 0 if not None.
+            This is the maximum number of entries along the entire axis
+            where NaNs will be filled. Must be greater than 0 if not None.
 
         Returns
         -------

--- a/pandas/tests/extension/base/missing.py
+++ b/pandas/tests/extension/base/missing.py
@@ -68,9 +68,6 @@ class BaseMissingTests:
         expected = data_missing.fillna(valid)
         tm.assert_extension_array_equal(result, expected)
 
-    @pytest.mark.filterwarnings(
-        "ignore:Series.fillna with 'method' is deprecated:FutureWarning"
-    )
     def test_fillna_limit_pad(self, data_missing):
         arr = data_missing.take([1, 0, 0, 0, 1])
         result = pd.Series(arr).ffill(limit=2)
@@ -99,12 +96,9 @@ class BaseMissingTests:
         expected = pd.Series(data_missing.take(expected_ilocs))
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.filterwarnings(
-        "ignore:Series.fillna with 'method' is deprecated:FutureWarning"
-    )
     def test_fillna_limit_backfill(self, data_missing):
         arr = data_missing.take([1, 0, 0, 0, 1])
-        result = pd.Series(arr).fillna(method="backfill", limit=2)
+        result = pd.Series(arr).bfill(limit=2)
         expected = pd.Series(data_missing.take([1, 0, 1, 1, 1]))
         tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -187,15 +187,6 @@ class TestDecimalArray(base.ExtensionTests):
                 )
 
     def test_fillna_limit_backfill(self, data_missing):
-        msg = "Series.fillna with 'method' is deprecated"
-        with tm.assert_produces_warning(
-            FutureWarning,
-            match=msg,
-            check_stacklevel=False,
-            raise_on_extra_warnings=False,
-        ):
-            super().test_fillna_limit_backfill(data_missing)
-
         msg = "ExtensionArray.fillna 'method' keyword is deprecated"
         with tm.assert_produces_warning(
             DeprecationWarning,

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -234,9 +234,6 @@ class TestSparseArray(base.ExtensionTests):
         expected = SparseArray([False, False], fill_value=False, dtype=expected_dtype)
         tm.assert_equal(sarr.isna(), expected)
 
-    def test_fillna_limit_backfill(self, data_missing):
-        super().test_fillna_limit_backfill(data_missing)
-
     def test_fillna_no_op_returns_copy(self, data, request):
         if np.isnan(data.fill_value):
             request.applymarker(

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -235,9 +235,7 @@ class TestSparseArray(base.ExtensionTests):
         tm.assert_equal(sarr.isna(), expected)
 
     def test_fillna_limit_backfill(self, data_missing):
-        warns = FutureWarning
-        with tm.assert_produces_warning(warns, check_stacklevel=False):
-            super().test_fillna_limit_backfill(data_missing)
+        super().test_fillna_limit_backfill(data_missing)
 
     def test_fillna_no_op_returns_copy(self, data, request):
         if np.isnan(data.fill_value):

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -757,11 +757,9 @@ class TestDataFrameReplace:
         tsframe.loc[tsframe.index[:5], "A"] = np.nan
         tsframe.loc[tsframe.index[-5:], "A"] = np.nan
         tsframe.loc[tsframe.index[:5], "B"] = np.nan
-        msg = "DataFrame.fillna with 'method' is deprecated"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
-            # TODO: what is this even testing?
-            result = tsframe.fillna(method="bfill")
-            tm.assert_frame_equal(result, tsframe.fillna(method="bfill"))
+        # TODO: what is this even testing?
+        result = tsframe.bfill()
+        tm.assert_frame_equal(result, tsframe.bfill())
 
     @pytest.mark.parametrize(
         "frame, to_replace, value, expected",

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -757,9 +757,6 @@ class TestDataFrameReplace:
         tsframe.loc[tsframe.index[:5], "A"] = np.nan
         tsframe.loc[tsframe.index[-5:], "A"] = np.nan
         tsframe.loc[tsframe.index[:5], "B"] = np.nan
-        # TODO: what is this even testing?
-        result = tsframe.bfill()
-        tm.assert_frame_equal(result, tsframe.bfill())
 
     @pytest.mark.parametrize(
         "frame, to_replace, value, expected",

--- a/pandas/tests/generic/test_finalize.py
+++ b/pandas/tests/generic/test_finalize.py
@@ -89,7 +89,6 @@ _all_methods = [
     (pd.DataFrame, frame_data, operator.methodcaller("rename", columns={"A": "a"})),
     (pd.DataFrame, frame_data, operator.methodcaller("rename", index=lambda x: x)),
     (pd.DataFrame, frame_data, operator.methodcaller("fillna", "A")),
-    (pd.DataFrame, frame_data, operator.methodcaller("fillna", method="ffill")),
     (pd.DataFrame, frame_data, operator.methodcaller("set_index", "A")),
     (pd.DataFrame, frame_data, operator.methodcaller("reset_index")),
     (pd.DataFrame, frame_data, operator.methodcaller("isna")),
@@ -375,9 +374,6 @@ def idfn(x):
         return str(x)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:DataFrame.fillna with 'method' is deprecated:FutureWarning",
-)
 @pytest.mark.parametrize("ndframe_method", _all_methods, ids=lambda x: idfn(x[-1]))
 def test_finalize_called(ndframe_method):
     cls, init_args, method = ndframe_method

--- a/pandas/tests/series/methods/test_fillna.py
+++ b/pandas/tests/series/methods/test_fillna.py
@@ -795,12 +795,6 @@ class TestSeriesFillNA:
     # ---------------------------------------------------------------
     # Invalid Usages
 
-    def test_fillna_invalid_method(self, datetime_series):
-        try:
-            datetime_series.ffill()
-        except ValueError as inst:
-            assert "ffil" in str(inst)
-
     def test_fillna_listlike_invalid(self):
         ser = Series(np.random.default_rng(2).integers(-100, 100, 50))
         msg = '"value" parameter must be a scalar or dict, but you passed a "list"'
@@ -875,25 +869,11 @@ class TestFillnaPad:
         expected = Series([1.0, 1.0, 3.0, 3.0, np.nan], ser.index)
         tm.assert_series_equal(filled, expected)
 
-    def test_ffill(self):
-        ts = Series(
-            [0.0, 1.0, 2.0, 3.0, 4.0], index=date_range("2020-01-01", periods=5)
-        )
-        ts.iloc[2] = np.nan
-        tm.assert_series_equal(ts.ffill(), ts.ffill())
-
     def test_ffill_mixed_dtypes_without_missing_data(self):
         # GH#14956
         series = Series([datetime(2015, 1, 1, tzinfo=pytz.utc), 1])
         result = series.ffill()
         tm.assert_series_equal(series, result)
-
-    def test_bfill(self):
-        ts = Series(
-            [0.0, 1.0, 2.0, 3.0, 4.0], index=date_range("2020-01-01", periods=5)
-        )
-        ts.iloc[2] = np.nan
-        tm.assert_series_equal(ts.bfill(), ts.bfill())
 
     def test_pad_nan(self):
         x = Series(

--- a/pandas/tests/series/methods/test_fillna.py
+++ b/pandas/tests/series/methods/test_fillna.py
@@ -25,14 +25,11 @@ import pandas._testing as tm
 from pandas.core.arrays import period_array
 
 
-@pytest.mark.filterwarnings(
-    "ignore:(Series|DataFrame).fillna with 'method' is deprecated:FutureWarning"
-)
 class TestSeriesFillNA:
     def test_fillna_nat(self):
         series = Series([0, 1, 2, NaT._value], dtype="M8[ns]")
 
-        filled = series.fillna(method="pad")
+        filled = series.ffill()
         filled2 = series.fillna(value=series.values[2])
 
         expected = series.copy()
@@ -42,7 +39,7 @@ class TestSeriesFillNA:
         tm.assert_series_equal(filled2, expected)
 
         df = DataFrame({"A": series})
-        filled = df.fillna(method="pad")
+        filled = df.ffill()
         filled2 = df.fillna(value=series.values[2])
         expected = DataFrame({"A": expected})
         tm.assert_frame_equal(filled, expected)
@@ -50,7 +47,7 @@ class TestSeriesFillNA:
 
         series = Series([NaT._value, 0, 1, 2], dtype="M8[ns]")
 
-        filled = series.fillna(method="bfill")
+        filled = series.bfill()
         filled2 = series.fillna(value=series[1])
 
         expected = series.copy()
@@ -60,38 +57,29 @@ class TestSeriesFillNA:
         tm.assert_series_equal(filled2, expected)
 
         df = DataFrame({"A": series})
-        filled = df.fillna(method="bfill")
+        filled = df.bfill()
         filled2 = df.fillna(value=series[1])
         expected = DataFrame({"A": expected})
         tm.assert_frame_equal(filled, expected)
         tm.assert_frame_equal(filled2, expected)
-
-    def test_fillna_value_or_method(self, datetime_series):
-        msg = "Cannot specify both 'value' and 'method'"
-        with pytest.raises(ValueError, match=msg):
-            datetime_series.fillna(value=0, method="ffill")
 
     def test_fillna(self):
         ts = Series(
             [0.0, 1.0, 2.0, 3.0, 4.0], index=date_range("2020-01-01", periods=5)
         )
 
-        tm.assert_series_equal(ts, ts.fillna(method="ffill"))
+        tm.assert_series_equal(ts, ts.ffill())
 
         ts.iloc[2] = np.nan
 
         exp = Series([0.0, 1.0, 1.0, 3.0, 4.0], index=ts.index)
-        tm.assert_series_equal(ts.fillna(method="ffill"), exp)
+        tm.assert_series_equal(ts.ffill(), exp)
 
         exp = Series([0.0, 1.0, 3.0, 3.0, 4.0], index=ts.index)
-        tm.assert_series_equal(ts.fillna(method="backfill"), exp)
+        tm.assert_series_equal(ts.bfill(), exp)
 
         exp = Series([0.0, 1.0, 5.0, 3.0, 4.0], index=ts.index)
         tm.assert_series_equal(ts.fillna(value=5), exp)
-
-        msg = "Must specify a fill 'value' or 'method'"
-        with pytest.raises(ValueError, match=msg):
-            ts.fillna()
 
     def test_fillna_nonscalar(self):
         # GH#5703
@@ -395,7 +383,7 @@ class TestSeriesFillNA:
             ],
             dtype="M8[ns]",
         )
-        result = ser.fillna(method="backfill")
+        result = ser.bfill()
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("tz", ["US/Eastern", "Asia/Tokyo"])
@@ -615,7 +603,7 @@ class TestSeriesFillNA:
                 Timestamp("2012-11-11 00:00:00+01:00"),
             ]
         )
-        tm.assert_series_equal(ser.fillna(method="pad"), exp)
+        tm.assert_series_equal(ser.ffill(), exp)
 
         ser = Series([NaT, Timestamp("2012-11-11 00:00:00+01:00")])
         exp = Series(
@@ -624,7 +612,7 @@ class TestSeriesFillNA:
                 Timestamp("2012-11-11 00:00:00+01:00"),
             ]
         )
-        tm.assert_series_equal(ser.fillna(method="bfill"), exp)
+        tm.assert_series_equal(ser.bfill(), exp)
 
     def test_fillna_pytimedelta(self):
         # GH#8209
@@ -809,7 +797,7 @@ class TestSeriesFillNA:
 
     def test_fillna_invalid_method(self, datetime_series):
         try:
-            datetime_series.fillna(method="ffil")
+            datetime_series.ffill()
         except ValueError as inst:
             assert "ffil" in str(inst)
 
@@ -877,17 +865,14 @@ class TestSeriesFillNA:
         tm.assert_categorical_equal(result, expected)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:Series.fillna with 'method' is deprecated:FutureWarning"
-)
 class TestFillnaPad:
     def test_fillna_bug(self):
         ser = Series([np.nan, 1.0, np.nan, 3.0, np.nan], ["z", "a", "b", "c", "d"])
-        filled = ser.fillna(method="ffill")
+        filled = ser.ffill()
         expected = Series([np.nan, 1.0, 1.0, 3.0, 3.0], ser.index)
         tm.assert_series_equal(filled, expected)
 
-        filled = ser.fillna(method="bfill")
+        filled = ser.bfill()
         expected = Series([1.0, 1.0, 3.0, 3.0, np.nan], ser.index)
         tm.assert_series_equal(filled, expected)
 
@@ -896,7 +881,7 @@ class TestFillnaPad:
             [0.0, 1.0, 2.0, 3.0, 4.0], index=date_range("2020-01-01", periods=5)
         )
         ts.iloc[2] = np.nan
-        tm.assert_series_equal(ts.ffill(), ts.fillna(method="ffill"))
+        tm.assert_series_equal(ts.ffill(), ts.ffill())
 
     def test_ffill_mixed_dtypes_without_missing_data(self):
         # GH#14956
@@ -909,14 +894,14 @@ class TestFillnaPad:
             [0.0, 1.0, 2.0, 3.0, 4.0], index=date_range("2020-01-01", periods=5)
         )
         ts.iloc[2] = np.nan
-        tm.assert_series_equal(ts.bfill(), ts.fillna(method="bfill"))
+        tm.assert_series_equal(ts.bfill(), ts.bfill())
 
     def test_pad_nan(self):
         x = Series(
             [np.nan, 1.0, np.nan, 3.0, np.nan], ["z", "a", "b", "c", "d"], dtype=float
         )
 
-        return_value = x.fillna(method="pad", inplace=True)
+        return_value = x.ffill(inplace=True)
         assert return_value is None
 
         expected = Series(
@@ -930,16 +915,16 @@ class TestFillnaPad:
         s = Series(np.random.default_rng(2).standard_normal(10), index=index)
 
         result = s[:2].reindex(index)
-        result = result.fillna(method="pad", limit=5)
+        result = result.ffill(limit=5)
 
-        expected = s[:2].reindex(index).fillna(method="pad")
+        expected = s[:2].reindex(index).ffill()
         expected[-3:] = np.nan
         tm.assert_series_equal(result, expected)
 
         result = s[-2:].reindex(index)
-        result = result.fillna(method="bfill", limit=5)
+        result = result.bfill(limit=5)
 
-        expected = s[-2:].reindex(index).fillna(method="backfill")
+        expected = s[-2:].reindex(index).bfill()
         expected[:3] = np.nan
         tm.assert_series_equal(result, expected)
 
@@ -949,21 +934,21 @@ class TestFillnaPad:
 
         result = s[:2].reindex(index, method="pad", limit=5)
 
-        expected = s[:2].reindex(index).fillna(method="pad")
+        expected = s[:2].reindex(index).ffill()
         expected[-3:] = np.nan
         tm.assert_series_equal(result, expected)
 
         result = s[-2:].reindex(index, method="backfill", limit=5)
 
-        expected = s[-2:].reindex(index).fillna(method="backfill")
+        expected = s[-2:].reindex(index).bfill()
         expected[:3] = np.nan
         tm.assert_series_equal(result, expected)
 
     def test_fillna_int(self):
         ser = Series(np.random.default_rng(2).integers(-100, 100, 50))
-        return_value = ser.fillna(method="ffill", inplace=True)
+        return_value = ser.ffill(inplace=True)
         assert return_value is None
-        tm.assert_series_equal(ser.fillna(method="ffill", inplace=False), ser)
+        tm.assert_series_equal(ser.ffill(inplace=False), ser)
 
     def test_datetime64tz_fillna_round_issue(self):
         # GH#14872

--- a/pandas/tests/series/methods/test_fillna.py
+++ b/pandas/tests/series/methods/test_fillna.py
@@ -822,9 +822,8 @@ class TestSeriesFillNA:
             ]
         )
         for limit in [-1, 0, 1.0, 2.0]:
-            for method in ["backfill", "bfill", "pad", "ffill", None]:
-                with pytest.raises(ValueError, match=msg):
-                    ser.fillna(1, limit=limit, method=method)
+            with pytest.raises(ValueError, match=msg):
+                ser.fillna(1, limit=limit)
 
     def test_fillna_datetime64_with_timezone_tzinfo(self):
         # https://github.com/pandas-dev/pandas/issues/38851


### PR DESCRIPTION
xref #53496

enforced deprecation of the `method` keyword on `df.fillna/ser.fillna`