### PR TITLE
Fix rank method with nullable int

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -281,6 +281,7 @@ Bug fixes
 - Fixed bug in :meth:`DataFrame.to_string` that raised ``StopIteration`` with nested DataFrames. (:issue:`16098`)
 - Fixed bug in :meth:`DataFrame.update` bool dtype being converted to object (:issue:`55509`)
 - Fixed bug in :meth:`Series.diff` allowing non-integer values for the ``periods`` argument. (:issue:`56607`)
+- Fixed bug in :meth:`Series.rank` that doesn't preserve missing values for nullable integers when ``na_option='keep'``. (:issue:`56976`)
 
 Categorical
 ^^^^^^^^^^^

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -2206,7 +2206,7 @@ class ExtensionArray:
             raise NotImplementedError
 
         return rank(
-            self._values_for_argsort(),
+            self,
             axis=axis,
             method=method,
             na_option=na_option,

--- a/pandas/tests/series/methods/test_rank.py
+++ b/pandas/tests/series/methods/test_rank.py
@@ -234,6 +234,16 @@ class TestSeriesRank:
         tm.assert_series_equal(na_ser.rank(na_option="bottom", pct=True), exp_bot)
         tm.assert_series_equal(na_ser.rank(na_option="keep", pct=True), exp_keep)
 
+    def test_rank_nullable_integer(self):
+        # GH 56976
+        exp = Series([np.nan, 2, np.nan, 3, 3, 2, 3, 1])
+        exp = exp.astype("Int64")
+        result = exp.rank(na_option="keep")
+
+        expected = Series([np.nan, 2.5, np.nan, 5.0, 5.0, 2.5, 5.0, 1.0])
+
+        tm.assert_series_equal(result, expected)
+
     def test_rank_signature(self):
         s = Series([0, 1])
         s.rank(method="average")


### PR DESCRIPTION
We can't pass only `self._values_for_argsort()` to `rank` as the missing data info will be lost. Fortunately, passing `self` directly to `rank` seems to work just fine.

- [x] closes #56976 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
